### PR TITLE
feat(util): added `gptme-util prompts workspace/git/journal` helper commands

### DIFF
--- a/gptme/cli/util.py
+++ b/gptme/cli/util.py
@@ -421,31 +421,14 @@ def _walk_directory(
 
 
 @context.command("git")
-@click.option("--max-files", type=int, default=10, help="Max files to list per section")
-@click.option(
-    "--show-diff/--no-diff", default=True, help="Include staged/unstaged diffs"
-)
-def context_git(max_files: int, show_diff: bool):
+def context_git():
     """Summarise the current git repo: branch, recent commits, staged/unstaged changes."""
     output, success = _git_run(["rev-parse", "--git-dir"])
     if not success:
         click.echo("Not a git repository", err=True)
         raise SystemExit(1)
 
-    sections: list[str] = ["## Git"]
-
-    remote, ok = _git_run(["config", "--get", "remote.origin.url"])
-    if ok and remote:
-        sections.append(f"Repository: {remote}")
-
-    branch, ok = _git_run(["rev-parse", "--abbrev-ref", "HEAD"])
-    if ok:
-        if branch == "HEAD":
-            sha, _ = _git_run(["rev-parse", "--short", "HEAD"])
-            sections.append(f"HEAD is detached at {sha}")
-            branch = ""
-        else:
-            sections.append(f"Current branch: {branch}")
+    print("## Git\n")
 
     log_out, ok = _git_run(
         [
@@ -454,37 +437,17 @@ def context_git(max_files: int, show_diff: bool):
             "--date=format:%Y-%m-%d %H:%M",
             "-n",
             "5",
-            branch or "HEAD",
         ]
     )
     if ok and log_out:
-        sections.append("\n### Recent commits")
-        sections.extend(f"- {line}" for line in log_out.split("\n"))
+        print("### Recent commits")
+        for line in log_out.split("\n"):
+            print(f"- {line}")
+        print()
 
-    for title, git_args in [
-        ("Staged files", ["diff", "--name-only", "--cached"]),
-        ("Changed files (unstaged)", ["diff", "--name-only"]),
-        ("Untracked files", ["ls-files", "--others", "--exclude-standard"]),
-    ]:
-        out, ok = _git_run(git_args)
-        if ok and out:
-            files = [fp for fp in out.split("\n") if fp]
-            sections.append(f"\n### {title}")
-            sections.extend(f"- {fp}" for fp in files[:max_files])
-            if len(files) > max_files:
-                sections.append(f"... and {len(files) - max_files} more")
-
-    if show_diff:
-        for title, git_args in [
-            ("Staged changes", ["diff", "--cached"]),
-            ("Unstaged changes", ["diff"]),
-        ]:
-            diff, ok = _git_run(git_args)
-            if ok and diff:
-                sections.append(f"\n### {title}")
-                sections.append(_codeblock("diff", diff))
-
-    print("\n".join(sections))
+    status_out, ok = _git_run(["status", "-vv"])
+    if ok and status_out:
+        print(_codeblock("", status_out))
 
 
 @context.command("tree")

--- a/gptme/cli/util.py
+++ b/gptme/cli/util.py
@@ -579,10 +579,8 @@ def context_journal(days: int, path: str | None):
         click.echo("No journal directory found. Use --path to specify one.", err=True)
         raise SystemExit(1)
 
-    dates = [
-        (datetime.now(tz=timezone.utc) - timedelta(days=i)).strftime("%Y-%m-%d")
-        for i in range(days)
-    ]
+    today = datetime.now(tz=timezone.utc).astimezone().date()
+    dates = [(today - timedelta(days=i)).strftime("%Y-%m-%d") for i in range(days)]
     entries: list[str] = []
     for date in dates:
         # Support both flat (YYYY-MM-DD-topic.md) and subdirectory (YYYY-MM-DD/topic.md) layouts

--- a/gptme/cli/util.py
+++ b/gptme/cli/util.py
@@ -351,6 +351,8 @@ def _git_run(cmd: list[str], check: bool = True, timeout: int = 10) -> tuple[str
             env=env,
             timeout=timeout,
         )
+        if result.returncode != 0:
+            return (result.stderr or result.stdout).strip(), False
         return result.stdout.strip(), True
     except subprocess.TimeoutExpired:
         return "", False
@@ -492,16 +494,18 @@ def context_git(max_files: int, show_diff: bool):
 @click.option("--max-depth", type=int, default=1, help="Tree depth")
 def context_tree(path: str, max_depth: int):
     """Print workspace directory tree (respects .gitignore)."""
-    from rich import print as rich_print
+    from rich.console import Console
     from rich.tree import Tree
 
     excludes = _read_gitignore(path) + [".git"]
     abs_path = os.path.abspath(path)
     tree = Tree(abs_path, guide_style="bold bright_blue")
     _walk_directory(Path(path), tree, excludes, max_depth)
-    print("## Workspace structure\n\n```tree")
-    rich_print(tree)
-    print("```")
+    buffer = io.StringIO()
+    console = Console(file=buffer, force_terminal=False, color_system=None)
+    console.print(tree)
+    print("## Workspace structure")
+    print(_codeblock("tree", buffer.getvalue().rstrip()))
 
 
 @context.command("files")
@@ -517,7 +521,10 @@ def context_files(config: str | None):
     Replaces ad-hoc context scripts in non-gptme harnesses (autonomous runs,
     project-monitoring) that manually concatenate gptme.toml prompt files.
     """
-    import tomllib
+    try:
+        import tomllib
+    except ModuleNotFoundError:
+        import tomli as tomllib  # type: ignore[no-redef]
 
     # Discover gptme.toml from cwd → git root
     toml_path: Path | None
@@ -555,7 +562,11 @@ def context_files(config: str | None):
 
 @context.command("journal")
 @click.option("--days", type=int, default=7, help="Days to look back")
-@click.option("--path", type=click.Path(exists=True), help="Journal directory")
+@click.option(
+    "--path",
+    type=click.Path(exists=True, file_okay=False),
+    help="Journal directory",
+)
 def context_journal(days: int, path: str | None):
     """Print journal entries from the last N days."""
     # Discover journal dir: prefer workspace-relative path first

--- a/gptme/cli/util.py
+++ b/gptme/cli/util.py
@@ -7,6 +7,9 @@ Command groups are split into separate modules for maintainability:
 - cmd_hooks.py: Claude Code hook installation and execution
 - cmd_mcp.py: MCP server management (list, test, info, search)
 - cmd_skills.py: Skills and lessons (list, show, search, install, validate, etc.)
+
+Inline command groups (smaller, live in this file):
+- context: RAG index/retrieve plus workspace/git/journal context generation
 """
 
 # Filter requests' overly-strict version-compatibility warning before any
@@ -19,17 +22,24 @@ warnings.filterwarnings(
     message=r".*urllib3.*chardet.*charset_normalizer.*",
 )
 
+import glob
 import importlib
 import io
 import json
 import logging
 import os
+import subprocess
 import sys
 import time
 from contextlib import redirect_stderr, redirect_stdout
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import click
+
+if TYPE_CHECKING:
+    from rich.tree import Tree as RichTree
 
 _LAZY_COMMANDS: dict[str, tuple[str, str]] = {
     "agents": (".cmd_agents", "agents"),
@@ -326,6 +336,267 @@ def context_retrieve(query: str, full: bool):
     # Search for the query
     results = rag_search(query, return_full=full)
     print(results)
+
+
+def _git_run(cmd: list[str], check: bool = True, timeout: int = 10) -> tuple[str, bool]:
+    """Run a git command and return (stdout, success)."""
+    try:
+        env = os.environ.copy()
+        env.update({"PAGER": "cat", "GIT_PAGER": "cat", "GIT_TERMINAL_PROMPT": "0"})
+        result = subprocess.run(
+            ["git"] + cmd,
+            capture_output=True,
+            text=True,
+            check=check,
+            env=env,
+            timeout=timeout,
+        )
+        return result.stdout.strip(), True
+    except subprocess.TimeoutExpired:
+        return "", False
+    except subprocess.CalledProcessError as e:
+        return e.stderr.strip(), False
+
+
+def _codeblock(langtag: str, content: str) -> str:
+    return f"```{langtag}\n{content}\n```"
+
+
+def _read_gitignore(path: str) -> list[str]:
+    ignores: list[str] = []
+    for fp in [
+        os.path.join(path, ".gitignore"),
+        os.path.expanduser("~/.config/git/ignore"),
+    ]:
+        if os.path.exists(fp):
+            with open(fp) as f:
+                ignores += [
+                    line.strip()
+                    for line in f
+                    if line.strip() and not line.startswith("#")
+                ]
+    return ignores
+
+
+def _walk_directory(
+    directory: Path,
+    tree: "RichTree",
+    excludes: list[str],
+    max_depth: int | None,
+    depth: int = 1,
+) -> None:  # type: ignore[name-defined]
+    from rich.filesize import decimal
+    from rich.markup import escape
+    from rich.text import Text
+
+    if max_depth is not None and depth > max_depth:
+        return
+    try:
+        for path in sorted(
+            Path(directory).iterdir(), key=lambda p: (p.is_file(), p.name.lower())
+        ):
+            if any(path.match(e) for e in excludes):
+                continue
+            try:
+                if path.is_dir():
+                    style = "dim" if path.name.startswith("__") else ""
+                    branch = tree.add(
+                        f"[bold magenta][link file://{path}]{escape(path.name)}/",
+                        style=style,
+                        guide_style=style,
+                    )
+                    _walk_directory(path, branch, excludes, max_depth, depth + 1)
+                else:
+                    text = Text(path.name, "green")
+                    text.highlight_regex(r"\..*$", "bold red")
+                    text.stylize(f"link file://{path}")
+                    text.append(f" ({decimal(path.stat().st_size)})", "blue")
+                    tree.add(text)
+            except OSError as e:
+                tree.add(f"[red]{path.name} [Error: {e}]")
+    except (PermissionError, OSError) as e:
+        tree.add(f"[red][Error: {e}]")
+
+
+@context.command("git")
+@click.option("--max-files", type=int, default=10, help="Max files to list per section")
+@click.option(
+    "--show-diff/--no-diff", default=True, help="Include staged/unstaged diffs"
+)
+def context_git(max_files: int, show_diff: bool):
+    """Summarise the current git repo: branch, recent commits, staged/unstaged changes."""
+    output, success = _git_run(["rev-parse", "--git-dir"])
+    if not success:
+        click.echo("Not a git repository", err=True)
+        raise SystemExit(1)
+
+    sections: list[str] = ["## Git"]
+
+    remote, ok = _git_run(["config", "--get", "remote.origin.url"])
+    if ok and remote:
+        sections.append(f"Repository: {remote}")
+
+    branch, ok = _git_run(["rev-parse", "--abbrev-ref", "HEAD"])
+    if ok:
+        if branch == "HEAD":
+            sha, _ = _git_run(["rev-parse", "--short", "HEAD"])
+            sections.append(f"HEAD is detached at {sha}")
+            branch = ""
+        else:
+            sections.append(f"Current branch: {branch}")
+
+    log_out, ok = _git_run(
+        [
+            "log",
+            "--pretty=format:%h (%ad) %s",
+            "--date=format:%Y-%m-%d %H:%M",
+            "-n",
+            "5",
+            branch or "HEAD",
+        ]
+    )
+    if ok and log_out:
+        sections.append("\n### Recent commits")
+        sections.extend(f"- {line}" for line in log_out.split("\n"))
+
+    for title, git_args in [
+        ("Staged files", ["diff", "--name-only", "--cached"]),
+        ("Changed files (unstaged)", ["diff", "--name-only"]),
+        ("Untracked files", ["ls-files", "--others", "--exclude-standard"]),
+    ]:
+        out, ok = _git_run(git_args)
+        if ok and out:
+            files = [fp for fp in out.split("\n") if fp]
+            sections.append(f"\n### {title}")
+            sections.extend(f"- {fp}" for fp in files[:max_files])
+            if len(files) > max_files:
+                sections.append(f"... and {len(files) - max_files} more")
+
+    if show_diff:
+        for title, git_args in [
+            ("Staged changes", ["diff", "--cached"]),
+            ("Unstaged changes", ["diff"]),
+        ]:
+            diff, ok = _git_run(git_args)
+            if ok and diff:
+                sections.append(f"\n### {title}")
+                sections.append(_codeblock("diff", diff))
+
+    print("\n".join(sections))
+
+
+@context.command("tree")
+@click.option(
+    "--path", type=click.Path(exists=True), default=".", help="Workspace root"
+)
+@click.option("--max-depth", type=int, default=1, help="Tree depth")
+def context_tree(path: str, max_depth: int):
+    """Print workspace directory tree (respects .gitignore)."""
+    from rich import print as rich_print
+    from rich.tree import Tree
+
+    excludes = _read_gitignore(path) + [".git"]
+    abs_path = os.path.abspath(path)
+    tree = Tree(abs_path, guide_style="bold bright_blue")
+    _walk_directory(Path(path), tree, excludes, max_depth)
+    print("## Workspace structure\n\n```tree")
+    rich_print(tree)
+    print("```")
+
+
+@context.command("files")
+@click.option(
+    "--config",
+    type=click.Path(exists=True),
+    default=None,
+    help="Path to gptme.toml (default: auto-discover from git root or cwd)",
+)
+def context_files(config: str | None):
+    """Print the contents of all files listed in gptme.toml [prompt] files.
+
+    Replaces ad-hoc context scripts in non-gptme harnesses (autonomous runs,
+    project-monitoring) that manually concatenate gptme.toml prompt files.
+    """
+    import tomllib
+
+    # Discover gptme.toml from cwd → git root
+    toml_path: Path | None
+    if config:
+        toml_path = Path(config)
+    else:
+        candidates = [Path.cwd() / "gptme.toml"]
+        root, ok = _git_run(["rev-parse", "--show-toplevel"])
+        if ok and root:
+            candidates.append(Path(root) / "gptme.toml")
+        toml_path = next((p for p in candidates if p.exists()), None)  # type: ignore[arg-type]
+
+    if not toml_path or not toml_path.exists():
+        click.echo("No gptme.toml found. Use --config to specify path.", err=True)
+        raise SystemExit(1)
+
+    with open(toml_path, "rb") as f:
+        cfg = tomllib.load(f)
+
+    files = cfg.get("prompt", {}).get("files", [])
+    if not files:
+        click.echo("No [prompt] files configured in gptme.toml.", err=True)
+        raise SystemExit(1)
+
+    workspace = toml_path.parent
+    for rel in files:
+        fpath = workspace / rel
+        if not fpath.exists():
+            click.echo(f"# FILE: {rel} (not found)\n", err=True)
+            continue
+        print(f"## FILE: {rel}\n")
+        print(fpath.read_text())
+        print("---\n")
+
+
+@context.command("journal")
+@click.option("--days", type=int, default=7, help="Days to look back")
+@click.option("--path", type=click.Path(exists=True), help="Journal directory")
+def context_journal(days: int, path: str | None):
+    """Print journal entries from the last N days."""
+    # Discover journal dir: prefer workspace-relative path first
+    candidates: list[str | None] = [path]
+    repo_root, ok = _git_run(["rev-parse", "--show-toplevel"])
+    if ok and repo_root:
+        candidates.append(os.path.join(repo_root, "journal"))
+    candidates += [
+        os.path.expanduser("~/journal"),
+        os.path.expanduser("~/Documents/journal"),
+        os.path.expanduser("~/notes"),
+    ]
+
+    journal_dir: str | None = None
+    for loc in candidates:
+        if loc and os.path.isdir(loc):
+            journal_dir = loc
+            break
+
+    if not journal_dir:
+        click.echo("No journal directory found. Use --path to specify one.", err=True)
+        raise SystemExit(1)
+
+    dates = [
+        (datetime.now(tz=timezone.utc) - timedelta(days=i)).strftime("%Y-%m-%d")
+        for i in range(days)
+    ]
+    entries: list[str] = []
+    for date in dates:
+        # Support both flat (YYYY-MM-DD-topic.md) and subdirectory (YYYY-MM-DD/topic.md) layouts
+        flat_files = glob.glob(os.path.join(journal_dir, f"*{date}*.md"))
+        subdir_files = glob.glob(os.path.join(journal_dir, date, "*.md"))
+        for file in flat_files + subdir_files:
+            with open(file) as f:
+                entries.append(f"\n# {date} — {os.path.basename(file)}\n{f.read()}")
+
+    if entries:
+        print(f"Journal entries from the last {days} days:\n")
+        print("\n".join(entries))
+    else:
+        print(f"No journal entries found for the last {days} days")
 
 
 @main.group()

--- a/gptme/cli/util.py
+++ b/gptme/cli/util.py
@@ -521,9 +521,9 @@ def context_files(config: str | None):
     Replaces ad-hoc context scripts in non-gptme harnesses (autonomous runs,
     project-monitoring) that manually concatenate gptme.toml prompt files.
     """
-    try:
+    if sys.version_info >= (3, 11):
         import tomllib
-    except ModuleNotFoundError:
+    else:
         import tomli as tomllib  # type: ignore[no-redef]
 
     # Discover gptme.toml from cwd → git root

--- a/tests/test_util_cli.py
+++ b/tests/test_util_cli.py
@@ -938,6 +938,7 @@ def test_context_tree(tmp_path):
     result = runner.invoke(main, ["context", "tree", "--path", str(tmp_path)])
     assert result.exit_code == 0, result.output
     assert "Workspace structure" in result.output
+    assert "\x1b[" not in result.output
 
 
 def test_context_files(tmp_path):
@@ -1033,3 +1034,13 @@ def test_context_journal_no_entries(tmp_path):
     )
     assert result.exit_code == 0, result.output
     assert "No journal entries" in result.output
+
+
+def test_context_journal_rejects_file_path(tmp_path):
+    """context journal should reject a file passed to --path."""
+    runner = CliRunner()
+    journal_file = tmp_path / "journal.md"
+    journal_file.write_text("# Not a directory\n")
+    result = runner.invoke(main, ["context", "journal", "--path", str(journal_file)])
+    assert result.exit_code != 0
+    assert "Directory" in result.output

--- a/tests/test_util_cli.py
+++ b/tests/test_util_cli.py
@@ -967,7 +967,7 @@ def test_context_journal(tmp_path):
     from datetime import datetime, timezone
 
     runner = CliRunner()
-    today = datetime.now(tz=timezone.utc).strftime("%Y-%m-%d")
+    today = datetime.now(tz=timezone.utc).astimezone().strftime("%Y-%m-%d")
     journal_dir = tmp_path / "journal"
     journal_dir.mkdir()
     # flat layout: YYYY-MM-DD-topic.md
@@ -984,7 +984,7 @@ def test_context_journal_subdirectory_layout(tmp_path):
     from datetime import datetime, timezone
 
     runner = CliRunner()
-    today = datetime.now(tz=timezone.utc).strftime("%Y-%m-%d")
+    today = datetime.now(tz=timezone.utc).astimezone().strftime("%Y-%m-%d")
     journal_dir = tmp_path / "journal"
     day_dir = journal_dir / today
     day_dir.mkdir(parents=True)

--- a/tests/test_util_cli.py
+++ b/tests/test_util_cli.py
@@ -995,6 +995,34 @@ def test_context_journal_subdirectory_layout(tmp_path):
     assert "subdir notes" in result.output
 
 
+def test_context_journal_uses_local_date_not_utc(tmp_path, monkeypatch):
+    """context journal should use the local calendar date when choosing entries."""
+    from datetime import datetime, timedelta, timezone
+
+    class FakeDateTime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return cls(2026, 1, 1, 23, 0, tzinfo=tz)
+
+        def astimezone(self, tz=None):
+            return type(self)(2026, 1, 2, 8, 0, tzinfo=timezone(timedelta(hours=9)))
+
+    monkeypatch.setattr("gptme.cli.util.datetime", FakeDateTime)
+
+    runner = CliRunner()
+    journal_dir = tmp_path / "journal"
+    journal_dir.mkdir()
+    (journal_dir / "2026-01-02-local.md").write_text(
+        "# Local day\nfound via local date"
+    )
+
+    result = runner.invoke(
+        main, ["context", "journal", "--path", str(journal_dir), "--days", "1"]
+    )
+    assert result.exit_code == 0, result.output
+    assert "found via local date" in result.output
+
+
 def test_context_journal_no_entries(tmp_path):
     """context journal reports nothing found gracefully."""
     runner = CliRunner()

--- a/tests/test_util_cli.py
+++ b/tests/test_util_cli.py
@@ -870,3 +870,138 @@ def test_llm_generate_prepends_system_message_stream(monkeypatch):
     assert captured[0].role == "system", (
         f"First message must be system, got {captured[0].role!r}"
     )
+
+
+def test_context_git_in_repo(tmp_path):
+    """context git outputs branch/commit info inside a git repo."""
+    import subprocess
+
+    runner = CliRunner()
+    # Minimal git env so global hooks/signing/gpg don't interfere
+    git_env = {
+        "HOME": str(tmp_path),
+        "GIT_CONFIG_NOSYSTEM": "1",
+        "GIT_AUTHOR_NAME": "Test",
+        "GIT_AUTHOR_EMAIL": "test@test.com",
+        "GIT_COMMITTER_NAME": "Test",
+        "GIT_COMMITTER_EMAIL": "test@test.com",
+        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+    }
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        subprocess.run(["git", "init"], check=True, capture_output=True, env=git_env)
+        subprocess.run(
+            ["git", "config", "user.email", "test@test.com"],
+            check=True,
+            capture_output=True,
+            env=git_env,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "Test"],
+            check=True,
+            capture_output=True,
+            env=git_env,
+        )
+        subprocess.run(
+            ["git", "config", "commit.gpgsign", "false"],
+            check=True,
+            capture_output=True,
+            env=git_env,
+        )
+        Path("readme.txt").write_text("hello")
+        subprocess.run(
+            ["git", "add", "."], check=True, capture_output=True, env=git_env
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "initial commit", "--no-verify"],
+            check=True,
+            capture_output=True,
+            env=git_env,
+        )
+        result = runner.invoke(main, ["context", "git"])
+    assert result.exit_code == 0, result.output
+    assert "## Git" in result.output
+
+
+def test_context_git_not_in_repo(tmp_path):
+    """context git exits nonzero outside a git repo."""
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        result = runner.invoke(main, ["context", "git"])
+    assert result.exit_code != 0
+
+
+def test_context_tree(tmp_path):
+    """context tree prints a workspace tree."""
+    runner = CliRunner()
+    (tmp_path / "file.txt").write_text("content")
+    (tmp_path / "subdir").mkdir()
+    result = runner.invoke(main, ["context", "tree", "--path", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+    assert "Workspace structure" in result.output
+
+
+def test_context_files(tmp_path):
+    """context files reads gptme.toml [prompt] files and prints them."""
+    runner = CliRunner()
+    prompt_file = tmp_path / "notes.md"
+    prompt_file.write_text("hello notes")
+    toml = tmp_path / "gptme.toml"
+    toml.write_text('[prompt]\nfiles = ["notes.md"]\n')
+    result = runner.invoke(main, ["context", "files", "--config", str(toml)])
+    assert result.exit_code == 0, result.output
+    assert "notes.md" in result.output
+    assert "hello notes" in result.output
+
+
+def test_context_files_missing_toml(tmp_path):
+    """context files exits nonzero when no gptme.toml is found."""
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        result = runner.invoke(main, ["context", "files"])
+    assert result.exit_code != 0
+
+
+def test_context_journal(tmp_path):
+    """context journal finds and prints journal entries."""
+    from datetime import datetime, timezone
+
+    runner = CliRunner()
+    today = datetime.now(tz=timezone.utc).strftime("%Y-%m-%d")
+    journal_dir = tmp_path / "journal"
+    journal_dir.mkdir()
+    # flat layout: YYYY-MM-DD-topic.md
+    (journal_dir / f"{today}-test.md").write_text("# Today\nsome notes")
+    result = runner.invoke(
+        main, ["context", "journal", "--path", str(journal_dir), "--days", "1"]
+    )
+    assert result.exit_code == 0, result.output
+    assert "some notes" in result.output
+
+
+def test_context_journal_subdirectory_layout(tmp_path):
+    """context journal handles subdirectory-per-day journal layout."""
+    from datetime import datetime, timezone
+
+    runner = CliRunner()
+    today = datetime.now(tz=timezone.utc).strftime("%Y-%m-%d")
+    journal_dir = tmp_path / "journal"
+    day_dir = journal_dir / today
+    day_dir.mkdir(parents=True)
+    (day_dir / "session.md").write_text("# Session\nsubdir notes")
+    result = runner.invoke(
+        main, ["context", "journal", "--path", str(journal_dir), "--days", "1"]
+    )
+    assert result.exit_code == 0, result.output
+    assert "subdir notes" in result.output
+
+
+def test_context_journal_no_entries(tmp_path):
+    """context journal reports nothing found gracefully."""
+    runner = CliRunner()
+    journal_dir = tmp_path / "journal"
+    journal_dir.mkdir()
+    result = runner.invoke(
+        main, ["context", "journal", "--path", str(journal_dir), "--days", "1"]
+    )
+    assert result.exit_code == 0, result.output
+    assert "No journal entries" in result.output


### PR DESCRIPTION
The idea is to move the helper scripts for prompt generation in gptme-bob into gptme.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds new CLI commands to `gptme` for generating git, workspace, and journal prompts, enhancing context generation capabilities.
> 
>   - **New CLI Commands**:
>     - Adds `prompts git` command in `gptme/util/cli.py` for generating git repository summaries with options like `--branch`, `--since`, `--max-files`, and `--show-diff`.
>     - Adds `prompts workspace` command in `gptme/util/cli_context.py` to display directory structure as a tree, respecting `.gitignore`.
>     - Adds `prompts journal` command in `gptme/util/cli_context.py` to generate prompts from journal entries.
>   - **Functionality**:
>     - `context_git()` in `cli_context.py` gathers git status, diffs, and recent commits.
>     - `context_workspace()` in `cli_context.py` shows directory structure and file statistics.
>     - `context_journal()` in `cli_context.py` retrieves journal entries from specified directories.
>   - **Integration**:
>     - Updates `get_workspace_prompt()` in `gptme/prompts.py` to include references to `prompts_git` and `prompts_workspace`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ErikBjare%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 21b39820b0a514ceb44c17b402e33086a1a68bf7. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->