### PR TITLE
feat(wip): added mcp client tool

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,12 +11,14 @@ repos:
   - id: ruff
     args: [ --fix ]
   - id: ruff-format
-- repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.12.0
+- repo: local
   hooks:
   - id: mypy
-    additional_dependencies: [types-tabulate, types-docutils]
-    args: [--ignore-missing-imports, --check-untyped-defs]
+    name: mypy
+    entry: make typecheck
+    language: system
+    pass_filenames: false
+    always_run: true
 #- repo: local
 #  hooks:
 #  - id: pytest

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ SRCDIRS = gptme tests scripts
 SRCFILES_RAW = $(shell find gptme tests -name '*.py' && find scripts -name '*.py' -not -path "scripts/Kokoro-82M/*" -not -path "*/Kokoro-82M/*")
 
 # exclude files
-EXCLUDES = tests/output scripts/build_changelog.py scripts/tts_server.py
+EXCLUDES = tests/output scripts/build_changelog.py scripts/tts_server.py scripts/Kokoro-82M
 SRCFILES = $(shell echo "${SRCFILES_RAW}" | tr ' ' '\n' | grep -v -f <(echo "${EXCLUDES}" | tr ' ' '\n') | tr '\n' ' ')
 
 # radon args

--- a/gptme.toml
+++ b/gptme.toml
@@ -1,5 +1,5 @@
 prompt = "This is gptme"
-files = ["README.md", "Makefile"]
+files = ["README.md", "Makefile", "pyproject.toml", "docs/index.rst"]
 #files = ["README.md", "Makefile", "gptme/cli.py", "docs/*.rst", "docs/*.md"]
 
 #[rag]

--- a/gptme/tools/mcp.py
+++ b/gptme/tools/mcp.py
@@ -1,0 +1,544 @@
+"""MCP client tool for gptme."""
+
+import ast
+import json
+import logging
+import asyncio
+from collections.abc import Callable, Generator
+from contextlib import AsyncExitStack
+from typing import Any, TypeAlias
+
+import anyio
+
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import get_default_environment, stdio_client
+
+from ..message import Message
+from .base import ConfirmFunc, Parameter, ToolSpec
+
+# Type alias for parameter arguments
+ParameterArgs: TypeAlias = dict[str, str | bool | None]
+
+
+logger = logging.getLogger(__name__)
+
+
+def parse_args(args_str: str) -> dict[str, Any]:
+    """Safely parse arguments from string."""
+    try:
+        # First try as JSON
+        return json.loads(args_str)
+    except json.JSONDecodeError:
+        try:
+            # Then try as Python literal
+            return ast.literal_eval(args_str)
+        except (SyntaxError, ValueError) as e:
+            raise ValueError(
+                "Arguments must be valid JSON or Python literal dictionary"
+            ) from e
+
+
+class MCPTool:
+    """Tool for interacting with MCP servers."""
+
+    def __init__(self):
+        self._servers: dict[str, anyio.Event] = {}  # server_name -> stop_event
+        self._sessions: dict[str, tuple[ClientSession, AsyncExitStack]] = {}
+        self._lock = anyio.Lock()
+
+    async def _server_loop(
+        self,
+        server_name: str,
+        server_params: StdioServerParameters,
+        stop_event: anyio.Event,
+        connection_ready: anyio.Event,
+    ):
+        """Run the server event loop."""
+        logger.info(
+            "Starting server loop for %s with params: %s", server_name, server_params
+        )
+        try:
+            async with AsyncExitStack() as stack:
+                logger.info(
+                    "Creating stdio transport with command: %s %s",
+                    server_params.command,
+                    " ".join(server_params.args),
+                )
+                try:
+                    stdio_transport = await stack.enter_async_context(
+                        stdio_client(server_params)
+                    )
+                    logger.info("Stdio transport created successfully")
+                except Exception as e:
+                    logger.error("Failed to create stdio transport: %s", e)
+                    raise
+                read_stream, write_stream = stdio_transport
+                logger.info("Creating client session...")
+                session = await stack.enter_async_context(
+                    ClientSession(read_stream, write_stream)
+                )
+                logger.info("Initializing session...")
+                await session.initialize()
+
+                logger.info("Session initialized, storing in sessions dict...")
+                self._sessions[server_name] = (session, stack)
+
+                # Signal that connection is ready
+                connection_ready.set()
+                logger.info("Connection ready event set, waiting for stop event...")
+
+                # Keep the server running until stopped
+                await stop_event.wait()
+                logger.info("Stop event received, server loop completing")
+        finally:
+            if server_name in self._sessions:
+                del self._sessions[server_name]
+
+    async def connect_server(self, server_path: str, name: str | None = None) -> str:
+        """Connect to an MCP server."""
+        async with self._lock:
+            # Validate server name
+            server_name = name or f"mcp_server_{len(self._sessions)}"
+            if server_name in self._servers:
+                raise ValueError(f"Server name '{server_name}' already in use")
+
+            # Create server parameters with safe environment and uv
+            server_params = StdioServerParameters(
+                command="uv",
+                args=["run", "--with", "mcp", server_path],
+                env=get_default_environment(),
+            )
+
+            try:
+                # Create stop event and start server loop
+                stop_event = anyio.Event()
+                self._servers[server_name] = stop_event
+
+                logger.info("Starting server loop for %s", server_name)
+
+                # Create a nursery for concurrent tasks
+                async def connection_monitor():
+                    logger.info("Starting connection monitor...")
+                    for i in range(50):  # 5 second timeout
+                        if server_name in self._sessions:
+                            logger.info("Session established after %d attempts", i)
+                            return True
+                        logger.debug("Waiting... attempt %d", i)
+                        await anyio.sleep(0.1)
+                    logger.error("Session establishment timed out")
+                    return False
+
+                async def setup_connection():
+                    logger.info("Setting up connection...")
+                    success = False
+
+                    connection_ready = anyio.Event()
+
+                    async def run_server():
+                        nonlocal success
+                        try:
+                            logger.info("Starting server loop task")
+                            await self._server_loop(
+                                server_name, server_params, stop_event, connection_ready
+                            )
+                            logger.info("Server loop task completed normally")
+                        except Exception as e:
+                            logger.error("Server loop failed: %s", e)
+                            success = False
+                            raise
+
+                    async def monitor():
+                        nonlocal success
+                        logger.info("Starting monitor task")
+                        success = await connection_monitor()
+                        if not success:
+                            logger.error("Connection monitor failed")
+                            # Cancel the server loop if monitor fails
+                            stop_event.set()
+                        logger.info("Monitor task completed")
+
+                    logger.info("Creating task group")
+                    async with anyio.create_task_group() as tg:
+                        # Start server first
+                        tg.start_soon(run_server)
+                        # Then start monitor
+                        tg.start_soon(monitor)
+                        # Wait for either success or failure
+                        await connection_ready.wait()
+                    logger.info("Task group completed")
+
+                    logger.info("Connection setup completed with success=%s", success)
+                    if not success:
+                        raise TimeoutError("Server connection timed out")
+                    return success
+
+                success = await setup_connection()
+                if success:
+                    logger.info("Server %s connected successfully", server_name)
+                    return server_name
+                else:
+                    raise ValueError("Failed to connect to server")
+
+            except Exception as e:
+                logger.exception("Failed to connect to MCP server")
+                if server_name in self._servers:
+                    del self._servers[server_name]
+                raise ValueError(f"Failed to connect to MCP server: {str(e)}") from e
+
+    def _get_session(self, server_name: str) -> tuple[ClientSession, AsyncExitStack]:
+        """Get a session by name, with error handling."""
+        if server_name not in self._sessions:
+            raise ValueError(f"Unknown server: {server_name}")
+        return self._sessions[server_name]
+
+    async def cleanup(self, server_name: str | None = None) -> None:
+        """Clean up server connections."""
+        async with self._lock:
+            if server_name:
+                if server_name in self._servers:
+                    # Signal server loop to stop
+                    stop_event = self._servers[server_name]
+                    stop_event.set()
+                    del self._servers[server_name]
+            else:
+                # Stop all servers
+                for stop_event in self._servers.values():
+                    stop_event.set()
+                self._servers.clear()
+
+    async def list_tools(self, server_name: str) -> list[dict[str, Any]]:
+        """List available tools from an MCP server."""
+
+        async def _list_tools(session: ClientSession):
+            response = await session.list_tools()
+            return [
+                {
+                    "name": tool.name,
+                    "description": tool.description,
+                    "arguments": [
+                        Parameter(
+                            name=arg.name,
+                            description=arg.description or "",
+                            required=arg.required or False,
+                            type="string",  # Default to string type
+                        )
+                        for arg in (tool.arguments or [])
+                    ],
+                }
+                for tool in response.tools
+            ]
+
+        return await self._run_shielded(server_name, "list tools", _list_tools)
+
+    async def list_resources(self, server_name: str) -> list[dict[str, Any]]:
+        """List available resources from an MCP server."""
+
+        async def _list_resources(session: ClientSession):
+            response = await session.list_resources()
+            return [
+                {
+                    "uri_template": resource.uriTemplate,
+                    "description": resource.description,
+                }
+                for resource in response.resources
+            ]
+
+        return await self._run_shielded(server_name, "list resources", _list_resources)
+
+    async def call_tool(
+        self, server_name: str, tool_name: str, arguments: dict[str, Any]
+    ) -> str:
+        """Call a tool on an MCP server."""
+        result = await self._run_shielded(
+            server_name,
+            "call tool",
+            lambda session: session.call_tool(tool_name, arguments),
+        )
+        return result.content
+
+    async def _run_shielded(
+        self, server_name: str, operation: str, func: Callable[[ClientSession], Any]
+    ) -> Any:
+        """Run an operation with task group shielding."""
+        session, _ = self._get_session(server_name)
+        async with self._lock:
+            try:
+                with anyio.CancelScope(shield=True):
+                    return await func(session)
+            except Exception as e:
+                logger.exception(f"Failed to {operation}")
+                raise ValueError(f"Failed to {operation}: {str(e)}") from e
+
+    async def read_resource(
+        self, server_name: str, resource_uri: str
+    ) -> tuple[str, str]:
+        """Read a resource from an MCP server."""
+        return await self._run_shielded(
+            server_name,
+            "read resource",
+            lambda session: session.read_resource(resource_uri),
+        )
+
+    async def list_prompts(self, server_name: str) -> list[dict[str, Any]]:
+        """List available prompts from an MCP server."""
+
+        async def _list_prompts(session: ClientSession):
+            response = await session.list_prompts()
+            return [
+                {
+                    "name": prompt.name,
+                    "description": prompt.description,
+                    "arguments": [
+                        Parameter(
+                            name=arg.name,
+                            description=arg.description or "",
+                            required=arg.required or False,
+                            type="string",  # Default to string type
+                        )
+                        for arg in (prompt.arguments or [])
+                    ],
+                }
+                for prompt in response.prompts
+            ]
+
+        return await self._run_shielded(server_name, "list prompts", _list_prompts)
+
+    async def get_prompt(
+        self, server_name: str, prompt_name: str, arguments: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        """Get a prompt from an MCP server."""
+
+        async def _get_prompt(session: ClientSession):
+            result = await session.get_prompt(prompt_name, arguments)
+            return [
+                {"role": msg.role, "content": msg.content.text}
+                for msg in result.messages
+            ]
+
+        return await self._run_shielded(server_name, "get prompt", _get_prompt)
+
+    def execute(
+        self,
+        code: str | None,
+        args: list[str] | None,
+        kwargs: dict[str, str] | None,
+        confirm: ConfirmFunc,
+    ) -> Generator[Message, None, None]:
+        """Execute an MCP command."""
+        if not code:
+            yield Message("assistant", "No command provided")
+            return
+
+        # Create an async queue for results
+        result_queue = anyio.create_memory_object_stream[Message](max_buffer_size=10)
+        send_stream, receive_stream = result_queue
+
+        async def async_execute(command: str) -> None:
+            logger.info("Executing command: %s", command)
+            try:
+                cmd = command.split(maxsplit=3)  # Split into max 4 parts
+                if not cmd:
+                    await send_stream.send(
+                        Message("assistant", "Please specify an MCP command")
+                    )
+                    return
+
+                logger.info("Processing command: %s", cmd[0])
+                match cmd[0]:
+                    case "disconnect":
+                        if len(cmd) < 2:
+                            result_queue.put(
+                                Message("assistant", "Please specify server name")
+                            )
+                            return
+                        server_name = cmd[1]
+                        await self.cleanup(server_name)
+                        result_queue.put(
+                            Message(
+                                "assistant",
+                                f"Disconnected from MCP server: {server_name}",
+                            )
+                        )
+
+                    case "connect":
+                        if len(cmd) < 2:
+                            result_queue.put(
+                                Message("assistant", "Please specify server path")
+                            )
+                            return
+                        try:
+                            name = cmd[2] if len(cmd) > 2 else None
+                            server_name = await self.connect_server(cmd[1], name)
+                            result_queue.put(
+                                Message(
+                                    "assistant",
+                                    f"Connected to MCP server: {server_name}",
+                                )
+                            )
+                        except Exception as e:
+                            result_queue.put(
+                                Message(
+                                    "assistant",
+                                    f"Failed to connect to server: {str(e)}",
+                                )
+                            )
+
+                    case "tools" | "resources" | "prompts" as list_cmd:
+                        if len(cmd) < 2:
+                            result_queue.put(
+                                Message(
+                                    "assistant",
+                                    f"Please specify server name for {list_cmd}",
+                                )
+                            )
+                            return
+
+                        items = await getattr(self, f"list_{list_cmd}")(cmd[1])
+                        if not items:
+                            result_queue.put(
+                                Message("assistant", f"No {list_cmd} available")
+                            )
+                            return
+
+                        # Format output based on type
+                        if list_cmd == "tools":
+                            items_str = "Available tools:\n" + "\n".join(
+                                f"- {t['name']}: {t['description']}\n  Arguments: {t['arguments']}"
+                                for t in items
+                            )
+                        elif list_cmd == "resources":
+                            items_str = "Available resources:\n" + "\n".join(
+                                f"- {r['uri_template']}: {r['description']}"
+                                for r in items
+                            )
+                        else:  # prompts
+                            items_str = "Available prompts:\n" + "\n".join(
+                                f"- {p['name']}: {p['description']}\n  Arguments: {p['arguments']}"
+                                for p in items
+                            )
+
+                        result_queue.put(Message("assistant", items_str))
+
+                    case "call":
+                        if len(cmd) < 4:
+                            result_queue.put(
+                                Message(
+                                    "assistant",
+                                    "Usage: call <server> <tool> <args>",
+                                )
+                            )
+                            return
+                        server_name, tool_name = cmd[1:3]
+                        args = parse_args(cmd[3])
+                        result = await self.call_tool(server_name, tool_name, args)
+                        result_queue.put(Message("assistant", f"Tool result: {result}"))
+
+                    case "read":
+                        if len(cmd) < 3:
+                            result_queue.put(
+                                Message(
+                                    "assistant",
+                                    "Usage: read <server> <resource_uri>",
+                                )
+                            )
+                            return
+                        content, mime_type = await self.read_resource(cmd[1], cmd[2])
+                        result_queue.put(
+                            Message(
+                                "assistant",
+                                f"Resource content ({mime_type}):\n{content}",
+                            )
+                        )
+
+                    case "prompt":
+                        if len(cmd) < 4:
+                            result_queue.put(
+                                Message(
+                                    "assistant",
+                                    "Usage: prompt <server> <name> <args>",
+                                )
+                            )
+                            return
+                        server_name, prompt_name = cmd[1:3]
+                        args = parse_args(cmd[3])
+                        messages = await self.get_prompt(server_name, prompt_name, args)
+                        result_queue.put(
+                            Message(
+                                "assistant",
+                                "Prompt messages:\n"
+                                + "\n".join(
+                                    f"{m['role']}: {m['content']}" for m in messages
+                                ),
+                            )
+                        )
+
+                    case _:
+                        result_queue.put(
+                            Message("assistant", f"Unknown MCP command: {cmd[0]}")
+                        )
+
+            except Exception as e:
+                logger.exception("Error executing MCP command")
+                result_queue.put(
+                    Message("assistant", f"Error executing MCP command: {str(e)}")
+                )
+
+        async def run_with_session():
+            try:
+                await async_execute(code)
+            except Exception as e:
+                logger.exception("Error in async execution")
+                result_queue.put(Message("assistant", f"Error: {str(e)}"))
+
+        try:
+            logger.info("Starting async execution...")
+            # Create a new event loop for async execution
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+
+            # Run the async code and wait for it to complete
+            loop.run_until_complete(run_with_session())
+            loop.close()
+
+            logger.info("Async execution completed")
+
+            # Yield all messages from the queue
+            logger.info("Processing result queue...")
+            while not result_queue.empty():
+                msg = result_queue.get_nowait()
+                logger.info("Yielding message: %s", msg)
+                yield msg
+            logger.info("Queue processing complete")
+
+            # Only cleanup on explicit disconnect
+            if code and code.startswith("disconnect "):
+                cmd = code.split(maxsplit=2)
+                if len(cmd) >= 2:
+                    server_name = cmd[1]
+                    try:
+                        loop = asyncio.new_event_loop()
+                        asyncio.set_event_loop(loop)
+                        loop.run_until_complete(self.cleanup(server_name))
+                        loop.close()
+                    except Exception as e:
+                        logger.warning("Error during cleanup: %s", e)
+        except Exception as e:
+            logger.exception("Error in execution")
+            yield Message("assistant", f"Error: {str(e)}")
+
+
+# Create and expose the tool instance
+tool = ToolSpec(
+    name="mcp",
+    desc="Model Context Protocol client for interacting with MCP servers",
+    block_types=["mcp"],
+    parameters=[
+        Parameter(
+            "command",
+            type="string",
+            description="MCP command to execute",
+            required=True,
+        ),
+    ],
+    execute=MCPTool().execute,
+)

--- a/poetry.lock
+++ b/poetry.lock
@@ -1044,6 +1044,19 @@ socks = ["socksio (==1.*)"]
 zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
+name = "httpx-sse"
+version = "0.4.0"
+description = "Consume Server-Sent Event (SSE) messages with HTTPX."
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
+files = [
+    {file = "httpx-sse-0.4.0.tar.gz", hash = "sha256:1e81a3a3070ce322add1d3529ed42eb5f70817f45ed6ec915ab753f961139721"},
+    {file = "httpx_sse-0.4.0-py3-none-any.whl", hash = "sha256:f329af6eae57eaa2bdfd962b42524764af68075ea87370a2de920af5341e318f"},
+]
+
+[[package]]
 name = "identify"
 version = "2.6.3"
 description = "File identification library for Python"
@@ -1795,6 +1808,33 @@ files = [
     {file = "mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"},
     {file = "mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325"},
 ]
+
+[[package]]
+name = "mcp"
+version = "1.2.1"
+description = "Model Context Protocol SDK"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
+files = [
+    {file = "mcp-1.2.1-py3-none-any.whl", hash = "sha256:579bf9c9157850ebb1344f3ca6f7a3021b0123c44c9f089ef577a7062522f0fd"},
+    {file = "mcp-1.2.1.tar.gz", hash = "sha256:c9d43dbfe943aa1530e2be8f54b73af3ebfb071243827b4483d421684806cb45"},
+]
+
+[package.dependencies]
+anyio = ">=4.5"
+httpx = ">=0.27"
+httpx-sse = ">=0.4"
+pydantic = ">=2.10.1,<3.0.0"
+pydantic-settings = ">=2.6.1"
+sse-starlette = ">=1.6.1"
+starlette = ">=0.27"
+uvicorn = ">=0.30"
+
+[package.extras]
+cli = ["python-dotenv (>=1.0.0)", "typer (>=0.12.4)"]
+rich = ["rich (>=13.9.4)"]
 
 [[package]]
 name = "mdit-py-plugins"
@@ -2558,6 +2598,28 @@ files = [
 
 [package.dependencies]
 typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
+
+[[package]]
+name = "pydantic-settings"
+version = "2.7.1"
+description = "Settings management using Pydantic"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
+files = [
+    {file = "pydantic_settings-2.7.1-py3-none-any.whl", hash = "sha256:590be9e6e24d06db33a4262829edef682500ef008565a969c73d39d5f8bfb3fd"},
+    {file = "pydantic_settings-2.7.1.tar.gz", hash = "sha256:10c9caad35e64bfb3c2fbf70a078c0e25cc92499782e5200747f942a065dec93"},
+]
+
+[package.dependencies]
+pydantic = ">=2.7.0"
+python-dotenv = ">=0.21.0"
+
+[package.extras]
+azure-key-vault = ["azure-identity (>=1.16.0)", "azure-keyvault-secrets (>=4.8.0)"]
+toml = ["tomli (>=2.0.1)"]
+yaml = ["pyyaml (>=6.0.1)"]
 
 [[package]]
 name = "pydata-sphinx-theme"
@@ -3499,6 +3561,27 @@ standalone = ["Sphinx (>=5)"]
 test = ["pytest"]
 
 [[package]]
+name = "sse-starlette"
+version = "2.2.1"
+description = "SSE plugin for Starlette"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
+files = [
+    {file = "sse_starlette-2.2.1-py3-none-any.whl", hash = "sha256:6410a3d3ba0c89e7675d4c273a301d64649c03a5ef1ca101f10b47f895fd0e99"},
+    {file = "sse_starlette-2.2.1.tar.gz", hash = "sha256:54470d5f19274aeed6b2d473430b08b4b379ea851d953b11d7f1c4a2c118b419"},
+]
+
+[package.dependencies]
+anyio = ">=4.7.0"
+starlette = ">=0.41.3"
+
+[package.extras]
+examples = ["fastapi"]
+uvicorn = ["uvicorn (>=0.34.0)"]
+
+[[package]]
 name = "stack-data"
 version = "0.6.3"
 description = "Extract data from python stack frames and tracebacks for informative displays"
@@ -3518,6 +3601,25 @@ pure-eval = "*"
 
 [package.extras]
 tests = ["cython", "littleutils", "pygments", "pytest", "typeguard"]
+
+[[package]]
+name = "starlette"
+version = "0.45.3"
+description = "The little ASGI library that shines."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
+files = [
+    {file = "starlette-0.45.3-py3-none-any.whl", hash = "sha256:dfb6d332576f136ec740296c7e8bb8c8a7125044e7c6da30744718880cdd059d"},
+    {file = "starlette-0.45.3.tar.gz", hash = "sha256:2cbcba2a75806f8a41c722141486f37c28e30a0921c5f6fe4346cb0dcee1302f"},
+]
+
+[package.dependencies]
+anyio = ">=3.6.2,<5"
+
+[package.extras]
+full = ["httpx (>=0.27.0,<0.29.0)", "itsdangerous", "jinja2", "python-multipart (>=0.0.18)", "pyyaml"]
 
 [[package]]
 name = "tabulate"
@@ -3790,6 +3892,27 @@ socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
 zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
+name = "uvicorn"
+version = "0.34.0"
+description = "The lightning-fast ASGI server."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
+files = [
+    {file = "uvicorn-0.34.0-py3-none-any.whl", hash = "sha256:023dc038422502fa28a09c7a30bf2b6991512da7dcdb8fd35fe57cfc154126f4"},
+    {file = "uvicorn-0.34.0.tar.gz", hash = "sha256:404051050cd7e905de2c9a7e61790943440b3416f49cb409f965d9dcd0fa73e9"},
+]
+
+[package.dependencies]
+click = ">=7.0"
+h11 = ">=0.8"
+typing-extensions = {version = ">=4.0", markers = "python_version < \"3.11\""}
+
+[package.extras]
+standard = ["colorama (>=0.4)", "httptools (>=0.6.3)", "python-dotenv (>=0.13)", "pyyaml (>=5.1)", "uvloop (>=0.14.0,!=0.15.0,!=0.15.1)", "watchfiles (>=0.13)", "websockets (>=10.4)"]
+
+[[package]]
 name = "virtualenv"
 version = "20.28.0"
 description = "Virtual Python Environment builder"
@@ -3896,4 +4019,4 @@ youtube = ["youtube_transcript_api"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "a4ba8081b217b149d560b6a2a49338a8bc148c4c16d69fd134d21e052a232992"
+content-hash = "7d405762d2f01e890b786191dd74559368751f248ba9e186518785441eb58518"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ typing-extensions = "*"
 platformdirs = "^4.3"
 lxml = "*"
 json-repair = "^0.32.0"
+mcp = "^1.2.1"  # Model Context Protocol SDK
 
 # providers
 openai = "^1.0"

--- a/test_mcp_server.py
+++ b/test_mcp_server.py
@@ -1,0 +1,19 @@
+import logging
+from mcp.server.fastmcp import FastMCP
+
+# Create an MCP server
+mcp = FastMCP("Test")
+
+logger = logging.getLogger("mcp")
+
+
+# Add a simple tool
+@mcp.tool()
+def hello(name: str) -> str:
+    """Say hello to someone"""
+    return f"Hello, {name}!"
+
+
+if __name__ == "__main__":
+    logger.warning("Starting MCP server")
+    mcp.run()

--- a/test_mcp_tool.py
+++ b/test_mcp_tool.py
@@ -1,0 +1,87 @@
+import logging
+from collections.abc import Generator
+
+import gptme.tools as tools
+from gptme.message import Message
+from gptme.tools.base import ToolSpec
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+# Make sure tools are initialized
+tools.clear_tools()
+tools.init_tools()
+
+# Get and verify MCP tool
+mcp_tool: ToolSpec | None = tools.get_tool("mcp")
+print("Available tools:", [t.name for t in tools.get_tools()])
+
+if not mcp_tool:
+    print("ERROR: MCP tool not loaded")
+    exit(1)
+
+print("Tool loaded:", mcp_tool.name)
+
+
+def confirm_callback(msg: str) -> bool:
+    """Callback for confirming actions."""
+    return True
+
+
+def run_command(cmd: str) -> bool:
+    print(f"\nTesting: {cmd}")
+    success = True
+    got_response = False
+    try:
+        # We know mcp_tool is not None here
+        assert mcp_tool
+        assert mcp_tool.execute
+        # Explicitly type the generator
+        messages: Generator[Message, None, None] | Message = mcp_tool.execute(
+            cmd, None, None, confirm_callback
+        )
+        assert isinstance(messages, Generator)
+        # Iterate through the generator
+        for msg in messages:
+            got_response = True
+            print(f"Response: {msg.content}")
+            if "Error" in msg.content or "Failed" in msg.content:
+                logger.error(f"Command failed: {msg.content}")
+                success = False
+        if not got_response:
+            logger.error("No response received from command")
+            success = False
+        return success
+    except Exception as e:
+        logger.error(f"Command failed with exception: {e}")
+        return False
+
+
+success = True
+try:
+    # Test server connection and operations
+    logger.info("Connecting to server...")
+    if not run_command("connect test_mcp_server.py"):
+        raise Exception("Failed to connect to server")
+
+    logger.info("Listing tools...")
+    if not run_command("tools mcp_server_0"):
+        raise Exception("Failed to list tools")
+
+    logger.info("Testing hello tool...")
+    if not run_command('call mcp_server_0 hello {"name": "World"}'):
+        raise Exception("Failed to call hello tool")
+
+except Exception as e:
+    logger.error(f"Test failed: {e}")
+    success = False
+finally:
+    # Cleanup
+    logger.info("Cleaning up...")
+    run_command("disconnect mcp_server_0")
+
+if success:
+    print("\nAll tests passed!")
+else:
+    print("\nTests failed!")
+    exit(1)


### PR DESCRIPTION
Attempting to make a MCP client tool, as a first step to proper MCP integration/support.

Having lots of trouble with the async interface of the MCP SDK.


TODO:
 - [ ] Wrap the async MCP SDK interface to work well from non-async code
 - [ ] Make the MCP interface itself less of a tool in gptme and more of a "tool loader" which creates ToolSpec's from MCP servers. So that we can load tools from MCP, instead of loading a MCP tool.
 - [ ] When done, make PR to get added to the MCP docs of supported clients

Related:
 - #286 
 - #287 (gptme as MCP server)
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Introduces MCP client tool for server interaction with command handling and testing support.
> 
>   - **New Feature**:
>     - Added `MCPTool` and `MCPCommandHandler` in `gptme/tools/mcp.py` for interacting with MCP servers.
>     - Supports commands: `connect`, `disconnect`, `tools`, `resources`, `prompts`, `call`, `read`, `prompt`.
>   - **Configuration**:
>     - Updated `.pre-commit-config.yaml` to use a local `mypy` hook.
>     - Updated `Makefile` to exclude `scripts/Kokoro-82M` from source files.
>     - Updated `gptme.toml` to include `pyproject.toml` and `docs/index.rst`.
>     - Added `mcp` dependency in `pyproject.toml`.
>   - **Testing**:
>     - Added `test_mcp_server.py` to create a test MCP server with a simple `hello` tool.
>     - Added `test_mcp_tool.py` to test MCP tool commands and server interactions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ErikBjare%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 76c62d2d675f4ce0380d9f1a1adb9945c6694fe5. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->