### PR TITLE
feat: implement auto-commit

### DIFF
--- a/gptme/__init__.py
+++ b/gptme/__init__.py
@@ -1,3 +1,4 @@
+# Testing autocommit functionality - second test
 from .__version__ import __version__
 from .cli import chat, main
 from .codeblock import Codeblock

--- a/gptme/chat.py
+++ b/gptme/chat.py
@@ -6,6 +6,7 @@ from collections.abc import Generator
 from pathlib import Path
 
 from .commands import execute_cmd
+from .config import get_config
 from .constants import INTERRUPT_CONTENT, PROMPT_USER
 from .init import init
 from .llm import reply
@@ -29,7 +30,11 @@ from .tools.tts import (
 )
 from .util import console, path_with_tilde, print_bell
 from .util.ask_execute import ask_execute
-from .util.context import include_paths, run_precommit_checks
+from .util.context import (
+    autocommit,
+    include_paths,
+    run_precommit_checks,
+)
 from .util.cost import log_costs
 from .util.interrupt import clear_interruptible, set_interruptible
 from .util.prompt import add_history, get_input
@@ -228,9 +233,13 @@ def step(
         )
     ):
         # Only check for modifications if the last assistant message has no runnable tools
-        if check_for_modifications(log) and (failed_check_message := check_changes()):
-            yield Message("system", failed_check_message, quiet=False)
-            return
+        if check_for_modifications(log):
+            if failed_check_message := check_changes():
+                yield Message("system", failed_check_message, quiet=False)
+                return
+            if get_config().get_env("GPTME_AUTOCOMMIT") in ["true", "1"]:
+                yield autocommit()
+                return
 
     # If last message was a response, ask for input.
     # If last message was from the user (such as from crash/edited log),

--- a/gptme/codeblock.py
+++ b/gptme/codeblock.py
@@ -109,7 +109,9 @@ def _extract_codeblocks(markdown: str) -> Generator[Codeblock, None, None]:
                             nesting_depth -= 1
                             if nesting_depth == 0:
                                 # This closes our top-level block
-                                yield Codeblock(lang, "\n".join(content_lines), start=start_line)
+                                yield Codeblock(
+                                    lang, "\n".join(content_lines), start=start_line
+                                )
                                 i += 1  # Move past the closing ```
                                 break
                             else:

--- a/gptme/commands.py
+++ b/gptme/commands.py
@@ -43,6 +43,7 @@ Actions = Literal[
     "summarize",
     "tokens",
     "export",
+    "commit",
     "help",
     "exit",
 ]
@@ -60,6 +61,7 @@ action_descriptions: dict[Actions, str] = {
     "impersonate": "Impersonate the assistant",
     "tokens": "Show the number of tokens used",
     "export": "Export conversation as HTML",
+    "commit": "Commit staged changes to git",
     "help": "Show this help message",
     "exit": "Exit the program",
 }
@@ -182,6 +184,11 @@ def handle_cmd(
             # Export the chat
             export_chat_to_html(manager.name, manager.log, output_path)
             print(f"Exported conversation to {output_path}")
+        case "commit":
+            manager.undo(1, quiet=True)
+            from .util.context import autocommit
+
+            yield autocommit()
         case _:
             # the case for python, shell, and other block_types supported by tools
             tooluse = ToolUse(name, [], full_args)

--- a/gptme/util/context.py
+++ b/gptme/util/context.py
@@ -394,10 +394,16 @@ The following changes have been made:
 Please review these changes and create an appropriate commit:
 
 1. Stage the relevant files using `git add`
-2. Generate a descriptive commit message following Conventional Commits format (feat:, fix:, docs:, chore:, etc.)
-3. Create the commit using `git commit -m "message"`
+2. Create the commit using the HEREDOC format to avoid escaping issues:
 
-Focus on the actual changes made and their purpose rather than just listing modified files."""
+```shell
+git add example.txt
+git commit -m "$(cat <<'EOF'
+Your commit message here
+EOF
+)"
+```
+"""
 
         return Message("user", commit_prompt)
 


### PR DESCRIPTION
Since the experiment with integrating pre-commit checks wen't well, I figured I should attempt to add an autocommit feature as well. Would speed up many of my workflows, especially with @TimeToBuildBob.


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Introduces an auto-commit feature in `gptme` to automate git commits post pre-commit checks, with manual trigger support via a new command.
> 
>   - **Behavior**:
>     - Adds `autocommit()` function in `context.py` to automate git commits after changes.
>     - Modifies `step()` in `chat.py` to call `autocommit()` if `GPTME_AUTOCOMMIT` is enabled and pre-commit checks pass.
>     - Adds `/commit` command in `commands.py` to manually trigger `autocommit()`.
>   - **Commands**:
>     - Updates `COMMANDS` and `action_descriptions` in `commands.py` to include `commit`.
>   - **Misc**:
>     - Minor formatting changes in `codeblock.py` and `__init__.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 7abce1a7065b096cc9f82b9ac2f37cc31ee3e233. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->