### PR TITLE
Support entering newlines with Ctrl+J

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,9 @@ Usage: gptme [OPTIONS] [PROMPTS]...
     /help         Show this help message
     /exit         Exit the program
 
+  Keyboard shortcuts:
+    Ctrl+J        Insert a new line without executing the prompt
+
 Options:
   -n, --name TEXT        Name of conversation. Defaults to generating a random
                          name.

--- a/gptme/commands.py
+++ b/gptme/commands.py
@@ -245,6 +245,11 @@ def _gen_help(incl_langtags: bool = True) -> Generator[str, None, None]:
     for cmd, desc in action_descriptions.items():
         yield f"  /{cmd.ljust(max_cmdlen)}  {desc}"
 
+    yield ""
+    yield "Keyboard shortcuts:"
+    yield ""
+    yield "  Ctrl+J        Insert a new line without executing the prompt"
+
     if incl_langtags:
         yield ""
         yield "To execute code with supported tools, use the following syntax:"

--- a/gptme/tools/screenshot.py
+++ b/gptme/tools/screenshot.py
@@ -19,10 +19,12 @@ def _screenshot(path: Path) -> Path:
             subprocess.run(["screencapture", str(path)], check=True)
         else:  # Linux
             # TODO: add support for specifying window/fullscreen?
-            if os.environ.get("XDG_SESSION_TYPE") == 'wayland':
+            if os.environ.get("XDG_SESSION_TYPE") == "wayland":
                 subprocess.run(["gnome-screenshot", "-f", str(path)], check=True)
             else:
-                subprocess.run(["scrot", "--overwrite", str(path)], check=True)  # --focused
+                subprocess.run(
+                    ["scrot", "--overwrite", str(path)], check=True
+                )  # --focused
     else:
         raise NotImplementedError(
             "Screenshot functionality is only available on macOS and Linux."

--- a/gptme/util/prompt.py
+++ b/gptme/util/prompt.py
@@ -393,7 +393,7 @@ def get_prompt_session() -> PromptSession:
 
         kb = KeyBindings()
 
-        @kb.add("c-j")  # Support both Ctrl+J
+        @kb.add("c-j")  # Add Ctrl+J support for newline
         def _(event):
             """Insert newline on Ctrl+J"""
             event.current_buffer.insert_text("\n")

--- a/gptme/util/prompt.py
+++ b/gptme/util/prompt.py
@@ -11,6 +11,7 @@ from typing import Any
 
 from gptme.llm.models import get_default_model
 from prompt_toolkit import PromptSession
+from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
 from prompt_toolkit.completion import Completer, Completion, PathCompleter
 from prompt_toolkit.document import Document
@@ -390,6 +391,18 @@ def get_prompt_session() -> PromptSession:
         history = FileHistory(str(history_path))
         completer = GptmeCompleter()
 
+        kb = KeyBindings()
+
+        @kb.add("c-j")  # Support both Ctrl+J
+        def _(event):
+            """Insert newline on Ctrl+J"""
+            event.current_buffer.insert_text("\n")
+
+        @kb.add("enter")
+        def _(event):
+            """Submit on Enter."""
+            event.current_buffer.validate_and_handle()
+
         _prompt_session = PromptSession(
             history=history,
             completer=completer,
@@ -397,6 +410,8 @@ def get_prompt_session() -> PromptSession:
             auto_suggest=AutoSuggestFromHistory(),
             enable_history_search=True,
             complete_style=CompleteStyle.READLINE_LIKE,
+            multiline=True,
+            key_bindings=kb,
         )
     return _prompt_session
 


### PR DESCRIPTION
adding new new line in the client with ctrl-j
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds Ctrl+J shortcut to insert a newline without executing the prompt and updates documentation.
> 
>   - **Behavior**:
>     - Adds Ctrl+J keyboard shortcut to insert a newline without executing the prompt in `get_prompt_session()` in `prompt.py`.
>     - Updates `README.md` to document the new Ctrl+J shortcut.
>   - **Misc**:
>     - Minor formatting change in `screenshot.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ErikBjare%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 072ea5203c99260684cc38da95fb5e149a316fa0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->