### PR TITLE
docs: added sitemap.xml

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -91,8 +91,15 @@ extensions = [
     "sphinx_click",
     "sphinxcontrib.programoutput",
     "sphinxcontrib.asciinema",
+    "sphinx_sitemap",
 ]
 
+html_baseurl = "https://gptme.org/docs/"  # used to build sitemap
+sitemap_url_scheme = "{link}"
+sitemap_excludes = [
+    "search.html",
+    "genindex.html",
+]
 
 templates_path = ["_templates"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]

--- a/poetry.lock
+++ b/poetry.lock
@@ -3359,6 +3359,25 @@ docutils = "*"
 sphinx = ">=4.0"
 
 [[package]]
+name = "sphinx-sitemap"
+version = "2.6.0"
+description = "Sitemap generator for Sphinx"
+optional = false
+python-versions = "*"
+groups = ["dev"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
+files = [
+    {file = "sphinx_sitemap-2.6.0-py3-none-any.whl", hash = "sha256:7478e417d141f99c9af27ccd635f44c03a471a08b20e778a0f9daef7ace1d30b"},
+    {file = "sphinx_sitemap-2.6.0.tar.gz", hash = "sha256:5e0c66b9f2e371ede80c659866a9eaad337d46ab02802f9c7e5f7bc5893c28d2"},
+]
+
+[package.dependencies]
+sphinx = ">=1.2"
+
+[package.extras]
+dev = ["build", "flake8", "pre-commit", "pytest", "sphinx", "tox"]
+
+[[package]]
 name = "sphinxcontrib-applehelp"
 version = "2.0.0"
 description = "sphinxcontrib-applehelp is a Sphinx extension which outputs Apple help books"
@@ -3896,4 +3915,4 @@ youtube = ["youtube_transcript_api"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "d1d095e917f85fa33933036eedb507939f197f20c2783a9b5e9e5b89dc5a15e9"
+content-hash = "729f9b2cbfce2b12afa59b5cab5e466fb9def25084ab24585beb4a1af670618c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,7 @@ greenlet = "*"  # dependency of playwright, but needed for coverage
 sphinx = "^8.0"
 sphinx-click = "^6.0"
 sphinx-book-theme = "^1.0.1"
+sphinx-sitemap = "^2.6.0"
 sphinxcontrib-programoutput = "*"
 sphinxcontrib-asciinema = "*"
 myst-parser = "*"


### PR DESCRIPTION
Added this while experimenting with `uvx --from llms-txt-action llms-txt --docs-dir docs/_build/html/` to build `llms.txt` and `llms-full.txt` from the gptme docs.


<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add sitemap.xml generation to documentation using `sphinx_sitemap` extension.
> 
>   - **Sitemap Generation**:
>     - Added `sphinx_sitemap` to `extensions` in `docs/conf.py` for sitemap generation.
>     - Configured `html_baseurl`, `sitemap_url_scheme`, and `sitemap_excludes` in `docs/conf.py`.
>   - **Dependencies**:
>     - Added `sphinx-sitemap` version `^2.6.0` to `pyproject.toml` under documentation dependencies.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for bb60e7ca54b9853c4f83430f847d5c899228eda4. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->