### PR TITLE
feat(user-confirm): capture user feedback when command execution is declined

### DIFF
--- a/gptme/util/ask_execute.py
+++ b/gptme/util/ask_execute.py
@@ -249,9 +249,17 @@ def execute_with_confirmation(
         try:
             # Get confirmation
             if not confirm_fn(confirm_msg or f"Execute on {path}?"):
-                yield Message(
-                    "system", "Operation aborted: user chose not to run the operation."
+                # Obtaining reasons and recommendations for users' refusal to implement
+                session = get_prompt_session()
+                feedback = session.prompt(
+                    [
+                        (
+                            "bold fg:ansiyellow",
+                            "Why did you decline? What would you like me to do instead? ",
+                        )
+                    ]
                 )
+                yield Message("user", f"I declined to execute because: {feedback}")
                 return
 
             # Get potentially edited content


### PR DESCRIPTION
# Improved User Feedback When Declining Command Execution

This PR enhances the user experience when a user declines to execute a command by:

- Prompting the user to explain why they declined execution
- Asking for suggestions on what they'd like to do instead
- Sending this feedback as a user message rather than a system message

This change helps the LLM understand the user's concerns and expectations better, enabling it to provide more relevant alternatives or explanations in its next response. It transforms a dead-end rejection into a conversational opportunity, maintaining dialogue flow and improving the collaborative experience.