### PR TITLE
docs: add a copiable markdown for powered by gptme badge

### DIFF
--- a/docs/projects.rst
+++ b/docs/projects.rst
@@ -38,11 +38,15 @@ Community Projects
 
 If you've built something using gptme, we'd love to feature it here!
 
-1. Add the "Built with gptme" badge to your README:
+1. Add the "Built with gptme" or "Powered by gptme" badge to your README:
 
    .. code-block:: markdown
 
       [![built using gptme](https://img.shields.io/badge/built%20using-gptme%20%F0%9F%A4%96-5151f5?style=flat)](https://github.com/gptme/gptme)
+      
+    .. code-block:: markdown
+      
+      [![Powered by gptme](https://img.shields.io/badge/powered%20by-gptme%20%F0%9F%A4%96-5151f5?style=flat)](https://github.com/gptme/gptme)
 
 2. Create a PR adding your project to this list:
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a copiable markdown for "Powered by gptme" badge in `projects.rst`.
> 
>   - **Documentation**:
>     - Adds a copiable markdown for "Powered by gptme" badge in `projects.rst`.
>     - Provides two badge options: "Built with gptme" and "Powered by gptme" for README integration.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 740c17ed8950fcbbe2ee88ac6d464ed42ce910a6. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->