### PR TITLE
fix: change default gptme-server port to 5700

### DIFF
--- a/docs/server.rst
+++ b/docs/server.rst
@@ -27,7 +27,7 @@ Web UI
 
 A tiny chat interface with minimal dependencies that is bundled with the server.
 
-Simply start the server to access the interface at http://localhost:5000
+Simply start the server to access the interface at http://localhost:5700
 
 Fancy Web UI
 ------------

--- a/gptme/server/cli.py
+++ b/gptme/server/cli.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 )
 @click.option(
     "--port",
-    default="5000",
+    default="5700",
     help="Port to run the server on.",
 )
 @click.option("--tools", default=None, help="Tools to enable, comma separated.")

--- a/scripts/Dockerfile.server
+++ b/scripts/Dockerfile.server
@@ -14,11 +14,11 @@ USER appuser
 WORKDIR /workspace
 
 # Expose the server port
-EXPOSE 5000
+EXPOSE 5700
 
 # Add healthcheck
 HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 \
-    CMD curl -f http://localhost:5000/ || exit 1
+    CMD curl -f http://localhost:5700/ || exit 1
 
 # Set the entrypoint to run the server
-ENTRYPOINT ["python", "-m", "gptme.server", "--host", "0.0.0.0"]
+ENTRYPOINT ["python", "-m", "gptme.server", "--host", "0.0.0.0", "--port", "5700"]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change default gptme-server port from 5000 to 5700 in code, Dockerfile, and documentation.
> 
>   - **Behavior**:
>     - Change default server port from 5000 to 5700 in `gptme/server/cli.py`.
>     - Update `Dockerfile.server` to expose and use port 5700.
>     - Modify healthcheck in `Dockerfile.server` to check port 5700.
>   - **Documentation**:
>     - Update `docs/server.rst` to reflect new default port 5700 for web UI access.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 95c96fc18bdba7b8ff6e73be9439eea4feb1e97b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->