### PR TITLE
fix: fixes auto-stepping in server

### DIFF
--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -366,7 +366,7 @@ def step(
             },
         )
 
-        if len(tooluses) != 1:
+        if len(tooluses) > 1:
             logger.warning(
                 "Multiple tools per message not yet supported, expect issues"
             )

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -366,6 +366,11 @@ def step(
             },
         )
 
+        if len(tooluses) != 1:
+            logger.warning(
+                "Multiple tools per message not yet supported, expect issues"
+            )
+
         # Handle tool use
         for tooluse in tooluses:
             # Create a tool execution record
@@ -397,7 +402,7 @@ def step(
             if tool_exec.auto_confirm:
                 if session.auto_confirm_count > 0:
                     session.auto_confirm_count -= 1
-                await_tool_execution(conversation_id, session, tool_id, tooluse)
+                start_tool_execution(conversation_id, session, tool_id, tooluse)
 
         # Mark session as not generating
         session.generating = False
@@ -674,7 +679,7 @@ def api_conversation_tool_confirm(conversation_id: str):
         tooluse = tool_exec.tooluse
 
         logger.info(f"Executing runnable tooluse: {tooluse}")
-        await_tool_execution(conversation_id, session, tool_id, tooluse)
+        start_tool_execution(conversation_id, session, tool_id, tooluse)
         return flask.jsonify({"status": "ok", "message": "Tool confirmed"})
 
     elif action == "edit":
@@ -684,7 +689,7 @@ def api_conversation_tool_confirm(conversation_id: str):
             return flask.jsonify({"error": "content is required for edit action"}), 400
 
         # Execute with edited content
-        await_tool_execution(
+        start_tool_execution(
             conversation_id,
             session,
             tool_id,
@@ -711,7 +716,7 @@ def api_conversation_tool_confirm(conversation_id: str):
         session.auto_confirm_count = count
 
         # Also confirm this tool
-        await_tool_execution(conversation_id, session, tool_id, tool_exec.tooluse)
+        start_tool_execution(conversation_id, session, tool_id, tool_exec.tooluse)
     else:
         return flask.jsonify({"error": f"Unknown action: {action}"}), 400
 
@@ -757,12 +762,12 @@ def api_conversation_interrupt(conversation_id: str):
 # ---------------
 
 
-def await_tool_execution(
+def start_tool_execution(
     conversation_id: str,
     session: ConversationSession,
     tool_id: str,
     edited_tooluse: ToolUse | None,
-):
+) -> threading.Thread:
     """Execute a tool and handle its output."""
     # TODO: Use the model from the conversation
     model = m.full if (m := get_default_model()) else "anthropic"
@@ -805,15 +810,14 @@ def await_tool_execution(
             msg = Message("system", f"Error: {str(e)}")
             _append_and_notify(manager, session, msg)
 
-        # Automatically resume generation if auto-confirm is enabled
         # This implements auto-stepping similar to the CLI behavior
-        if session.auto_confirm_count > 0:
-            _start_step_thread(conversation_id, session, model)
+        _start_step_thread(conversation_id, session, model)
 
     # Start execution in a thread
     thread = threading.Thread(target=execute_tool_thread)
     thread.daemon = True
     thread.start()
+    return thread
 
 
 def _start_step_thread(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -264,10 +264,9 @@ def wait_for_event():
         while time.time() - start_time < timeout:
             if event_type in seq[already_awaited:]:
                 events_passed = seq[already_awaited:].index(event_type) + 1
-                print(seq[already_awaited : already_awaited + events_passed])
+                # print(seq[already_awaited : already_awaited + events_passed])
                 already_awaited += events_passed
-                print(already_awaited)
-                print(seq[already_awaited])
+                # print(already_awaited)
                 return True
             time.sleep(0.1)
         return False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -110,7 +110,7 @@ def init_():
 @pytest.fixture
 def server_thread():
     """Start a server in a thread for testing."""
-    from gptme.server.api import create_app  # noqa
+    from gptme.server.api import create_app  # fmt: skip
 
     app = create_app()
 
@@ -141,7 +141,7 @@ def server_thread():
 
 @pytest.fixture
 def client():
-    from gptme.server.api import create_app  # noqa
+    from gptme.server.api import create_app  # fmt: skip
 
     app = create_app()
     with app.test_client() as client:
@@ -230,10 +230,16 @@ def event_listener(setup_conversation):
 def mock_generation():
     """Create a mock generation with customizable output."""
 
-    def create(content):
+    def create(responses: list[str]):
+        response_iter = iter(responses)
+
         def mock_stream(messages, model, tools=None, max_tokens=None):
-            # Yield the content as a single chunk that will be iterated over char by char
-            yield [content]  # Wrap in list so it's only iterated once
+            try:
+                content = next(response_iter)
+                # Yield the content as a single chunk that will be iterated over char by char
+                yield [content]  # Wrap in list so it's only iterated once
+            except StopIteration:
+                yield ["No more responses"]
 
         return mock_stream
 
@@ -258,8 +264,10 @@ def wait_for_event():
         while time.time() - start_time < timeout:
             if event_type in seq[already_awaited:]:
                 events_passed = seq[already_awaited:].index(event_type) + 1
+                print(seq[already_awaited : already_awaited + events_passed])
                 already_awaited += events_passed
-                # print(already_awaited)
+                print(already_awaited)
+                print(seq[already_awaited])
                 return True
             time.sleep(0.1)
         return False

--- a/tests/test_server_v2_auto_stepping.py
+++ b/tests/test_server_v2_auto_stepping.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 def test_auto_stepping(
     init_, setup_conversation, event_listener, mock_generation, wait_for_event
 ):
-    """Test auto-stepping functionality with multiple tools in sequence."""
+    """Test auto-stepping and auto-confirm functionality with multiple tools in sequence."""
     port, conversation_id, session_id = setup_conversation
 
     # Add a user message requesting multiple commands
@@ -37,21 +37,16 @@ def test_auto_stepping(
     )
 
     # Create a mock that returns different responses for each call
-    responses = [
-        (
-            "I'll help you create a directory and list its contents.\n\nFirst, let's create a directory:\n\n"
-            + tool1.to_output("markdown")
-        ),
-        ("Now, let's list its contents:\n\n" + tool2.to_output("markdown")),
-    ]
-    response_iter = iter(responses)
-
-    def mock_stream(messages, model, tools=None, max_tokens=None):
-        try:
-            content = next(response_iter)
-            yield [content]
-        except StopIteration:
-            yield ["No more responses"]
+    mock_stream = mock_generation(
+        [
+            (
+                "I'll help you create a directory and list its contents.\n\nFirst, let's create a directory:\n\n"
+                + tool1.to_output("markdown")
+            ),
+            ("Now, let's list its contents:\n\n" + tool2.to_output("markdown")),
+            ("The directory has been created and listed successfully."),
+        ]
+    )
 
     # Start generation with auto-confirm and the sequential mock
     with unittest.mock.patch("gptme.server.api_v2._stream", mock_stream):
@@ -60,7 +55,7 @@ def test_auto_stepping(
             json={
                 "session_id": session_id,
                 "model": "openai/mock-model",
-                "auto_confirm": True,
+                "auto_confirm": 2,
             },
         )
 
@@ -71,14 +66,14 @@ def test_auto_stepping(
         assert wait_for_event(event_listener, "tool_executing")
         assert wait_for_event(event_listener, "message_added")
 
-        requests.post(
-            f"http://localhost:{port}/api/v2/conversations/{conversation_id}/step",
-            json={
-                "session_id": session_id,
-                "model": "openai/mock-model",
-                "auto_confirm": True,
-            },
-        )
+        # requests.post(
+        #     f"http://localhost:{port}/api/v2/conversations/{conversation_id}/step",
+        #     json={
+        #         "session_id": session_id,
+        #         "model": "openai/mock-model",
+        #         "auto_confirm": True,
+        #     },
+        # )
 
         # Wait for second tool execution
         assert wait_for_event(event_listener, "generation_started")
@@ -98,8 +93,8 @@ def test_auto_stepping(
     # We should have 6 messages:
     # 1. System, 2. User, 3. Assistant (mkdir), 4. System output,
     # 5. Assistant (ls), 6. System output
-    assert len(messages) == 6, (
-        f"Expected 6 messages, got {len(messages)}" + "\n" + str(messages)
+    assert len(messages) == 7, (
+        f"Expected 7 messages, got {len(messages)}" + "\n" + str(messages)
     )
 
     # Check for specific content

--- a/tests/test_server_v2_auto_stepping.py
+++ b/tests/test_server_v2_auto_stepping.py
@@ -66,15 +66,6 @@ def test_auto_stepping(
         assert wait_for_event(event_listener, "tool_executing")
         assert wait_for_event(event_listener, "message_added")
 
-        # requests.post(
-        #     f"http://localhost:{port}/api/v2/conversations/{conversation_id}/step",
-        #     json={
-        #         "session_id": session_id,
-        #         "model": "openai/mock-model",
-        #         "auto_confirm": True,
-        #     },
-        # )
-
         # Wait for second tool execution
         assert wait_for_event(event_listener, "generation_started")
         assert wait_for_event(event_listener, "generation_complete")
@@ -90,9 +81,9 @@ def test_auto_stepping(
     conversation_data = resp.json()
     messages = conversation_data["log"]
 
-    # We should have 6 messages:
+    # We should have 7 messages:
     # 1. System, 2. User, 3. Assistant (mkdir), 4. System output,
-    # 5. Assistant (ls), 6. System output
+    # 5. Assistant (ls), 6. System output, 7. Assistant (final message)
     assert len(messages) == 7, (
         f"Expected 7 messages, got {len(messages)}" + "\n" + str(messages)
     )

--- a/tests/test_server_v2_tool_confirmation.py
+++ b/tests/test_server_v2_tool_confirmation.py
@@ -32,8 +32,11 @@ def test_tool_confirmation_flow(
 
     # Create mock response with the tool
     mock_stream = mock_generation(
-        "I'll help you list the files. Let me run the command:\n\n"
-        + tool.to_output("markdown")
+        [
+            "I'll help you list the files. Let me run the command:\n\n"
+            + tool.to_output("markdown"),
+            "Done, let me know if you need anything else.",
+        ]
     )
 
     # Start generation with mocked response
@@ -69,7 +72,7 @@ def test_tool_confirmation_flow(
 
     # Check message sequence
     messages = resp.json()["log"]
-    assert len(messages) == 4, f"Expected 4 messages, got {len(messages)}"
+    assert len(messages) == 5, f"Expected 5 messages, got {len(messages)}"
 
     # Verify message content
     assert messages[0]["role"] == "system" and "testing" in messages[0]["content"]


### PR DESCRIPTION
Fixes https://github.com/gptme/gptme-webui/issues/9
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes auto-stepping in server by renaming function, handling multiple tools, and updating tests for auto-stepping and tool confirmation.
> 
>   - **Behavior**:
>     - Fixes auto-stepping by renaming `await_tool_execution()` to `start_tool_execution()` in `api_v2.py`.
>     - Adds warning for multiple tools per message in `step()` in `api_v2.py`.
>     - Updates `api_conversation_step()` to handle `auto_confirm` as int or bool, setting `auto_confirm_count` accordingly.
>   - **Tests**:
>     - Updates `test_server_v2_auto_stepping.py` to test auto-stepping with multiple tools and verify message sequence.
>     - Updates `test_server_v2_tool_confirmation.py` to test tool confirmation flow and verify message content.
>   - **Misc**:
>     - Changes import statement in `conftest.py` to use `# fmt: skip` instead of `# noqa`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for bfac1ddb9825f6b4df2a67f2c9562d1ced3a51cd. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->