### PR TITLE
refactor: switch from thread-local globals to context vars

### DIFF
--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -190,7 +190,7 @@ class ConversationSession:
 
     # Capture context at session creation
     # TODO: use a fresh context for each session?
-    context: Context = field(default_factory=copy_context)
+    context: Context = field(default_factory=Context)
 
 
 class SessionManager:


### PR DESCRIPTION
Follow-up on #502 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor code to use context variables instead of thread-local storage for configuration and tool state management, enhancing context isolation in server environments.
> 
>   - **Behavior**:
>     - Switch from thread-local to context-local storage for configuration in `config.py` using `ContextVar`.
>     - Replace thread-local tool state with context-local storage in `tools/__init__.py`.
>     - Update session management in `api_v2.py` to use context variables for tool initialization.
>   - **Functions**:
>     - Rename `start_tool_execution()` to `_start_tool_execution()` in `api_v2.py` for internal use.
>     - Use `session.context.run()` to execute threads with session-specific context in `api_v2.py`.
>   - **Misc**:
>     - Add comments and TODOs in `api_v2.py` for future improvements in tool initialization and context management.
>     - Minor refactoring and logging improvements in `api_v2.py` and `tools/__init__.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 3cf2b76fd6cb96caaed68d5abbc6c77c33f3169d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->