### PR TITLE
fix: fixed prompt not showing when prompt text overflows

### DIFF
--- a/gptme/util/ask_execute.py
+++ b/gptme/util/ask_execute.py
@@ -7,9 +7,11 @@ import sys
 import termios
 from collections.abc import Callable, Generator
 from pathlib import Path
+from textwrap import wrap
 
 from rich import print
 from rich.console import Console
+from rich.style import Style
 from rich.syntax import Syntax
 
 from ..message import Message
@@ -115,19 +117,16 @@ def ask_execute(question="Execute code?", default=True) -> bool:
     with terminal_state_title("❓ waiting for confirmation"):
         session = get_prompt_session()
 
-        print(console.width)
-        question += " asd" * 100
         prompt = f"{question} {choicestr}"
-        from textwrap import wrap
-
-        from rich.style import Style
 
         style_rich = "bold yellow on red"
         style_prompt_toolkit = "bold fg:ansiyellow bg:ansired"
 
-        lines = wrap(prompt, width=console.width - 40)
+        lines = wrap(prompt, width=console.width - 2)
+
+        # print pre-prompt lines
+        # we do this because of https://github.com/gptme/gptme/issues/498
         if len(lines) > 1:
-            # print pre-prompt lines
             for line in lines[:-1]:
                 console.print(" " + line.strip() + " ", style=Style.parse(style_rich))
 

--- a/gptme/util/ask_execute.py
+++ b/gptme/util/ask_execute.py
@@ -114,9 +114,29 @@ def ask_execute(question="Execute code?", default=True) -> bool:
 
     with terminal_state_title("❓ waiting for confirmation"):
         session = get_prompt_session()
+
+        print(console.width)
+        question += " asd" * 100
+        prompt = f"{question} {choicestr}"
+        from textwrap import wrap
+
+        from rich.style import Style
+
+        style_rich = "bold yellow on red"
+        style_prompt_toolkit = "bold fg:ansiyellow bg:ansired"
+
+        lines = wrap(prompt, width=console.width - 40)
+        if len(lines) > 1:
+            # print pre-prompt lines
+            for line in lines[:-1]:
+                console.print(" " + line.strip() + " ", style=Style.parse(style_rich))
+
         answer = (
             session.prompt(
-                [("bold fg:ansiyellow bg:red", f" {question} {choicestr} "), ("", " ")],
+                [
+                    (style_prompt_toolkit, " " + lines[-1].strip() + " "),
+                    ("", " "),
+                ]
             )
             .lower()
             .strip()


### PR DESCRIPTION
Fixes https://github.com/gptme/gptme/issues/498

It resolves the issue, but not happy with the workaround used since it kind of overrides some prompt_toolkit features (like graying out the prompt after cancelled).

We should maybe be using `get_input` in `gptme/util/prompt.py` and keep the logic there.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes prompt text overflow in `ask_execute()` by wrapping and printing lines before the prompt session, overriding some `prompt_toolkit` features.
> 
>   - **Behavior**:
>     - Fixes prompt text overflow issue in `ask_execute()` in `ask_execute.py` by wrapping and printing lines before the prompt session.
>     - Overrides some `prompt_toolkit` features, such as graying out the prompt after cancellation.
>   - **Misc**:
>     - Suggests using `get_input` in `prompt.py` for better logic handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 6ccf836189d16f3f9d3822f92699e24b6f82c428. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->