### PR TITLE
fix: remove default BASE ARG from Dockerfile.server to remove the need for skaffold workarounds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -160,6 +160,8 @@ jobs:
           ghcr.io/${{ env.OWNER_LC }}/gptme-server:${{ env.SANITIZED_REF_NAME }}
         file: ./scripts/Dockerfile.server
         context: .
+        build-args: |
+          BASE=gptme:latest
         push: ${{ env.SHOULD_PUSH }}
 
     # Build and push eval image

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ build:
 
 build-docker:
 	docker build . -t gptme:latest -f scripts/Dockerfile
-	docker build . -t gptme-server:latest -f scripts/Dockerfile.server
+	docker build . -t gptme-server:latest -f scripts/Dockerfile.server --build-arg BASE=gptme:latest
 	docker build . -t gptme-eval:latest -f scripts/Dockerfile.eval
 	# docker build . -t gptme-eval:latest -f scripts/Dockerfile.eval --build-arg RUST=yes --build-arg BROWSER=yes
 

--- a/scripts/Dockerfile.server
+++ b/scripts/Dockerfile.server
@@ -1,6 +1,7 @@
 # Use the main Dockerfile as the base image
-ARG BASE=gptme:latest
-FROM $BASE as build
+# We don't set a default here due to skaffold not supporting defaults for the BASE ARG
+ARG BASE
+FROM $BASE
 
 # Install server dependencies
 USER root


### PR DESCRIPTION
To simplify gptme.ai infra setup
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Remove default `BASE` argument from `Dockerfile.server` and update build scripts to set it explicitly.
> 
>   - **Dockerfile Changes**:
>     - Remove default `BASE` argument from `Dockerfile.server`.
>   - **Build Process**:
>     - Update `.github/workflows/build.yml` to set `BASE=gptme:latest` during server image build.
>     - Update `Makefile` to set `BASE=gptme:latest` during server image build.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 67f975b807cb8ee254d3142883166ecfa855f09a. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->