### PR TITLE
fix(server): don't store chat config obj in session, load mcp server from user/project config

### DIFF
--- a/gptme/config.py
+++ b/gptme/config.py
@@ -75,7 +75,7 @@ class UserConfig:
     prompt: UserPromptConfig = field(default_factory=UserPromptConfig)
 
     env: dict[str, str] = field(default_factory=dict)
-    mcp: MCPConfig = field(default_factory=MCPConfig)
+    mcp: MCPConfig | None = None
 
 
 @dataclass
@@ -216,7 +216,8 @@ def get_project_config(workspace: Path | None) -> ProjectConfig | None:
         files = config_data.pop("files", [])
         context_cmd = config_data.pop("context_cmd", None)
         rag = RagConfig(**config_data.pop("rag", {}))
-        mcp = MCPConfig.from_dict(config_data.pop("mcp", {}))
+        if mcp := config_data.pop("mcp", None):
+            mcp = MCPConfig.from_dict(mcp)
 
         # Check for unknown keys
         if config_data:
@@ -399,13 +400,13 @@ class Config:
     @property
     def mcp(self) -> MCPConfig:
         """Get the MCP configuration, merging user and project configurations."""
-        mcp = self.user.mcp
-
         # Override MCP config from project config and chat config if present, merging mcp servers
         servers: list[MCPServerConfig] = []
-        enabled = self.user.mcp.enabled
-        auto_start = self.user.mcp.auto_start
 
+        enabled = False
+        auto_start = False
+
+        # merge mcp servers
         if self.chat and self.chat.mcp:
             for server in self.chat.mcp.servers:
                 if server.name not in [s.name for s in servers]:
@@ -416,9 +417,15 @@ class Config:
                 if server.name not in [s.name for s in servers]:
                     servers.append(server)
 
-        for server in self.user.mcp.servers:
-            if server.name not in [s.name for s in servers]:
-                servers.append(server)
+        if self.user and self.user.mcp:
+            for server in self.user.mcp.servers:
+                if server.name not in [s.name for s in servers]:
+                    servers.append(server)
+
+        # merge mcp config
+        if self.user and self.user.mcp:
+            enabled = self.user.mcp.enabled
+            auto_start = self.user.mcp.auto_start
 
         if self.project and self.project.mcp:
             enabled = self.project.mcp.enabled

--- a/gptme/config.py
+++ b/gptme/config.py
@@ -155,7 +155,9 @@ def _load_config_doc(path: str | None = None) -> tomlkit.TOMLDocument:
     if not os.path.exists(path):
         # If not, create it and write some default settings
         os.makedirs(os.path.dirname(path), exist_ok=True)
-        toml = tomlkit.dumps(asdict(default_config))
+        toml = tomlkit.dumps(
+            {k: v for k, v in asdict(default_config).items() if v is not None}
+        )
         with open(path, "w") as config_file:
             config_file.write(toml)
         console.log(f"Created config file at {path}")

--- a/gptme/mcp/client.py
+++ b/gptme/mcp/client.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 from contextlib import AsyncExitStack
+import os
 
 from gptme.config import Config, get_config
 
@@ -91,8 +92,13 @@ class MCPClient:
         if not server:
             raise ValueError(f"No MCP server config found for '{server_name}'")
 
+        env = server.env or {}
+
+        # Add env vars to the environment
+        env.update(os.environ)
+
         params = StdioServerParameters(
-            command=server.command, args=server.args, env=server.env
+            command=server.command, args=server.args, env=env
         )
 
         tools, session = self._run_async(self._setup_connection(params))

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -21,6 +21,7 @@ from itertools import islice
 from pathlib import Path
 from typing import Literal, TypedDict
 
+from dotenv import load_dotenv
 import flask
 from flask import request
 
@@ -316,6 +317,9 @@ def step(
     # Initialize tools in this thread
     init_tools(chat_config.tools)
 
+    # Load .env file if present
+    load_dotenv(dotenv_path=workspace / ".env")
+
     # Load conversation
     manager = LogManager.load(
         conversation_id,
@@ -528,6 +532,9 @@ def api_conversation_put(conversation_id: str):
     # Load or create the chat config, overriding values from request config if provided
     request_config = ChatConfig.from_dict(req_json.get("config", {}))
     chat_config = ChatConfig.load_or_create(logdir, request_config)
+
+    # Load .env file if present
+    load_dotenv(dotenv_path=chat_config.workspace / ".env")
 
     # Set tool allowlist to available tools if not provided
     if not chat_config.tools:
@@ -922,6 +929,9 @@ def start_tool_execution(
 
         # Initialize tools in this thread
         init_tools(None)
+
+        # Load .env file if present
+        load_dotenv(dotenv_path=chat_config.workspace / ".env")
 
         # Load the conversation
         manager = LogManager.load(conversation_id, lock=False)

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -511,7 +511,12 @@ def api_conversation_put(conversation_id: str):
 
     # Set tool allowlist to available tools if not provided
     if not chat_config.tools:
-        chat_config.tools = [t.name for t in get_toolchain(None)]
+        chat_config.tools = [t.name for t in get_toolchain(None) if not t.is_mcp]
+
+    if not chat_config.mcp:
+        # load from user or project config
+        config = Config.from_workspace(chat_config.workspace)
+        chat_config.mcp = config.mcp
 
     # Save the chat config
     chat_config.save()

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -7,7 +7,7 @@ from typing import cast, Any
 import pytest
 from flask.testing import FlaskClient
 import tomlkit  # noqa
-from gptme.config import ChatConfig
+from gptme.config import ChatConfig, MCPConfig
 from gptme.llm.models import ModelMeta, get_default_model
 from gptme.tools import get_toolchain
 
@@ -200,7 +200,8 @@ def test_v2_interrupt(v2_conv, client: FlaskClient):
 def test_v2_chat_config_saved_on_conversation_create(client: FlaskClient):
     """Test that the chat config is saved on conversation create."""
     input_config = ChatConfig(model="gpt-4o")
-    input_config.tools = [t.name for t in get_toolchain(None)]
+    input_config.tools = [t.name for t in get_toolchain(None) if not t.is_mcp]
+    input_config.mcp = MCPConfig()
     conversation_id = create_conversation(client, input_config)["conversation_id"]
 
     response = client.get(f"/api/v2/conversations/{conversation_id}")
@@ -226,11 +227,13 @@ def test_v2_chat_config_saved_on_conversation_create(client: FlaskClient):
 def test_v2_chat_config_saved_separately_for_each_conversation(client: FlaskClient):
     """Test that the chat config is saved separately for each conversation."""
     input_config_1 = ChatConfig(model="gpt-4o")
-    input_config_1.tools = [t.name for t in get_toolchain(None)]
+    input_config_1.tools = [t.name for t in get_toolchain(None) if not t.is_mcp]
+    input_config_1.mcp = MCPConfig()
     conversation_id_1 = create_conversation(client, input_config_1)["conversation_id"]
 
     input_config_2 = ChatConfig(model="gpt-4o-mini")
-    input_config_2.tools = [t.name for t in get_toolchain(None)]
+    input_config_2.tools = [t.name for t in get_toolchain(None) if not t.is_mcp]
+    input_config_2.mcp = MCPConfig()
     conversation_id_2 = create_conversation(client, input_config_2)["conversation_id"]
 
     response_1 = client.get(f"/api/v2/conversations/{conversation_id_1}")
@@ -247,18 +250,22 @@ def test_v2_chat_config_saved_separately_for_each_conversation(client: FlaskClie
 def test_v2_chat_config_get_works(client: FlaskClient):
     """Test that the chat config get endpoint works."""
     input_config = ChatConfig(model="gpt-4o")
-    input_config.tools = [t.name for t in get_toolchain(None)]
+    input_config.tools = [t.name for t in get_toolchain(None) if not t.is_mcp]
+    input_config.mcp = MCPConfig()
     conversation_id = create_conversation(client, input_config)["conversation_id"]
 
     response = client.get(f"/api/v2/conversations/{conversation_id}/config")
     config = ChatConfig.from_dict(response.get_json())
+    print("config", config.to_dict())
+    print("input_config", input_config.to_dict())
     assert config.to_dict() == input_config.to_dict()
 
 
 def test_v2_chat_config_update_works(client: FlaskClient):
     """Test that the chat config update endpoint works."""
     input_config = ChatConfig(model="gpt-4o")
-    input_config.tools = [t.name for t in get_toolchain(None)]
+    input_config.tools = [t.name for t in get_toolchain(None) if not t.is_mcp]
+    input_config.mcp = MCPConfig()
     conversation_id = create_conversation(client, input_config)["conversation_id"]
 
     response = client.get(f"/api/v2/conversations/{conversation_id}/config")


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Refactor chat and MCP server configuration handling by removing chat config from session storage and loading MCP server configurations from user or project configurations.
> 
>   - **Behavior**:
>     - Removed `chat_config` from `ConversationSession` in `api_v2.py`.
>     - Load `MCPConfig` from user or project config in `get_project_config()` in `config.py`.
>     - Updated `connect()` in `client.py` to merge server environment variables with OS environment.
>   - **Configuration**:
>     - Changed `UserConfig` and `ProjectConfig` to allow `MCPConfig` to be `None` in `config.py`.
>     - Updated `_load_config_doc()` in `config.py` to exclude `None` values when creating default config.
>   - **Tests**:
>     - Updated tests in `test_config.py` and `test_server_v2.py` to reflect changes in configuration handling.
>     - Added checks for MCP server merging logic in `test_config.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 93725e7dd3d241e64daa672668f91b466fa8a249. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->