### PR TITLE
feat: set enable_suspend (Ctrl+Z) and enable_open_in_editor (Ctrl+X Ctrl+E) for prompt (fixes #525)

### DIFF
--- a/gptme/util/prompt.py
+++ b/gptme/util/prompt.py
@@ -306,7 +306,7 @@ class GptmeCompleter(Completer):
             for option in completions:
                 if option.startswith(text):
                     # make the already typed part bold and underlined
-                    html = f"<teal><u><b>{text}</b></u>{option[len(text):]}</teal>"
+                    html = f"<teal><u><b>{text}</b></u>{option[len(text) :]}</teal>"
                     yield Completion(
                         option,
                         start_position=-len(text),
@@ -435,6 +435,8 @@ def get_input(prompt: str) -> str:
                     }
                 ),
                 include_default_pygments_style=False,
+                enable_suspend=True,
+                enable_open_in_editor=True,
             )
         return result
     except (EOFError, KeyboardInterrupt) as e:


### PR DESCRIPTION
Fixes https://github.com/gptme/gptme/issues/525

The conversation selector behaves a bit strange on resume (re-showing its output), not exactly sure what that is about.

The `Ctrl+X Ctrl+E` feature that I found in `prompt_toolkit` was a nice surprise!

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enable Ctrl+Z and Ctrl-X Ctrl-E key bindings in `get_input()` in `prompt.py`.
> 
>   - **Behavior**:
>     - Enable `enable_suspend` (Ctrl+Z) and `enable_open_in_editor` (Ctrl-X Ctrl-E) in `get_input()` in `prompt.py`.
>   - **Misc**:
>     - Minor formatting change in `get_completions()` in `GptmeCompleter` class.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 67ec7422a28633c3f927b774be513ed62b1079ba. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->