### PR TITLE
fix: output cwd changes in shell responses, error on extra ======= for patch

### DIFF
--- a/gptme/tools/patch.py
+++ b/gptme/tools/patch.py
@@ -165,6 +165,14 @@ class Patch:
                 if UPDATED not in after_divider:  # pragma: no cover
                     raise ValueError("invalid patch format: missing >>>>>>> UPDATED")
                 modified, _ = re.split(re.escape(UPDATED), after_divider, maxsplit=1)
+
+                # Check for extra ======= markers in the updated content
+                if "\n=======" in modified:
+                    raise ValueError(
+                        "invalid patch format: extra ======= marker found in updated content. "
+                        "Use only one ======= between original and updated content."
+                    )
+
             yield Patch(original, modified)
 
     @classmethod

--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -282,10 +282,17 @@ def execute_shell_impl(
     shell = get_shell()
     allowlisted = is_allowlisted(cmd)
 
+    # Track current working directory before command execution
+    prev_cwd = os.getcwd()
+
     try:
         returncode, stdout, stderr = shell.run(cmd)
     except Exception as e:
         raise ValueError(f"Shell error: {e}") from None
+
+    # Check if working directory changed
+    current_cwd = os.getcwd()
+    pwd_changed = prev_cwd != current_cwd
 
     stdout = _shorten_stdout(stdout.strip(), pre_tokens=2000, post_tokens=8000)
     stderr = _shorten_stdout(stderr.strip(), pre_tokens=2000, post_tokens=2000)
@@ -303,7 +310,9 @@ def execute_shell_impl(
     if not stdout and not stderr:
         msg += "No output\n"
     if returncode:
-        msg += f"Return code: {returncode}"
+        msg += f"Return code: {returncode}\n"
+    if pwd_changed:
+        msg += f"Working directory changed to: {current_cwd}"
 
     yield Message("system", msg)
 

--- a/tests/test_tools_patch.py
+++ b/tests/test_tools_patch.py
@@ -179,3 +179,25 @@ def test_patch_minimal():
  3"""
     )
     assert p.diff_minimal(strip_context=True) == "-2\n+0"
+
+
+def test_apply_with_extra_divider_fails():
+    """Test that extra ======= markers before >>>>>>> UPDATED cause a clear error."""
+    # This is the problematic case where Claude adds an extra =======
+    codeblock = """
+<<<<<<< ORIGINAL
+    print("Hello world")
+=======
+    name = input("What is your name? ")
+    print(f"Hello {name}")
+=======
+>>>>>>> UPDATED
+"""
+
+    # Should raise a clear error about the extra divider
+    try:
+        list(Patch.from_codeblock(codeblock.strip()))
+        raise AssertionError("Expected ValueError for extra ======= marker")
+    except ValueError as e:
+        assert "extra ======= marker found" in str(e)
+        assert "Use only one =======" in str(e)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes handling of extra '=======' markers in patch files and logs working directory changes in shell command execution.
> 
>   - **Patch Tool**:
>     - In `gptme/tools/patch.py`, `_from_codeblock()` now raises `ValueError` for extra '=======' markers in updated content.
>     - Added test `test_apply_with_extra_divider_fails()` in `tests/test_tools_patch.py` to verify error handling for extra '=======' markers.
>   - **Shell Tool**:
>     - In `gptme/tools/shell.py`, `execute_shell_impl()` now tracks and logs changes in the working directory after command execution.
>     - If the working directory changes, it appends a message to the output indicating the new directory.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 875690ae181c3b6c2f3885a1ecceb9256d75d993. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->