### PR TITLE
fix: fixed --workspace=@log behavior after config refactor

### DIFF
--- a/gptme/config.py
+++ b/gptme/config.py
@@ -325,8 +325,22 @@ class ChatConfig:
 
         # Set the workspace symlink in the logdir
         workspace_path = self._logdir / "workspace"
-        workspace_path.unlink(missing_ok=True)
-        workspace_path.symlink_to(self.workspace)
+
+        # Only create symlink if workspace is different from the log workspace
+        if self.workspace != workspace_path:
+            if workspace_path.exists():
+                if workspace_path.is_dir() and not workspace_path.is_symlink():
+                    # It's a directory with potential user content, don't delete it
+                    raise ValueError(
+                        f"Workspace directory '{workspace_path}' already exists and contains data. "
+                        "Cannot change workspace when directory is in use. "
+                        "Please move or rename the existing directory first."
+                    )
+                else:
+                    # It's a file or symlink, safe to remove
+                    workspace_path.unlink()
+            workspace_path.symlink_to(self.workspace)
+        # If workspace IS the log workspace, no symlink needed - directory already exists
 
         return self
 


### PR DESCRIPTION
Fixes https://github.com/gptme/gptme/issues/531
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes symlink creation logic in `ChatConfig.save()` to handle existing directories and prevent unnecessary symlinks.
> 
>   - **Behavior**:
>     - Fixes symlink creation in `ChatConfig.save()` to only create a symlink if `workspace` differs from `workspace_path`.
>     - Raises `ValueError` if `workspace_path` is a directory with user content, preventing deletion.
>     - Removes existing file or symlink at `workspace_path` if safe.
>   - **Misc**:
>     - Addresses issue #531.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 84ed0bb0f856c5a4f85c674397c997b38561b967. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->