### PR TITLE
fix: better support for reasoning via openrouter

### DIFF
--- a/gptme/llm/llm_openai_models.py
+++ b/gptme/llm/llm_openai_models.py
@@ -45,22 +45,26 @@ OPENAI_MODELS: dict[str, "_ModelDictMeta"] = {
         "context": 128_000,
         "price_input": 15,
         "price_output": 60,
+        "supports_reasoning": True,
     },
     "o1-preview-2024-09-12": {
         "context": 128_000,
         "price_input": 15,
         "price_output": 60,
+        "supports_reasoning": True,
     },
     # OpenAI o1-mini
     "o1-mini": {
         "context": 128_000,
         "price_input": 3,
         "price_output": 12,
+        "supports_reasoning": True,
     },
     "o1-mini-2024-09-12": {
         "context": 128_000,
         "price_input": 3,
         "price_output": 12,
+        "supports_reasoning": True,
     },
     # GPT-4 Turbo
     "gpt-4-turbo": {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Improved reasoning support for OpenRouter and DeepSeek models by updating `chat` and `stream` functions and adding `supports_reasoning` to specific models.
> 
>   - **Behavior**:
>     - Introduced `_is_reasoner()` in `llm_openai.py` to check if a model supports reasoning.
>     - Updated `chat()` and `stream()` in `llm_openai.py` to handle reasoning content using `reasoning_content` or `reasoning` attributes.
>     - Added reasoning block markers `<think>` and `</think>` in `stream()` for reasoning content.
>   - **Models**:
>     - Added `supports_reasoning` attribute to `o1-preview`, `o1-preview-2024-09-12`, `o1-mini`, and `o1-mini-2024-09-12` in `llm_openai_models.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 9c20bbae8219d0551522edd2339656b4578740f5. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->