### PR TITLE
fix: include conversation workspace metadata in api

### DIFF
--- a/gptme/logmanager.py
+++ b/gptme/logmanager.py
@@ -388,6 +388,7 @@ class ConversationMeta:
     modified: float
     messages: int
     branches: int
+    workspace: str
 
     def format(self, metadata=False) -> str:
         """Format conversation metadata for display."""
@@ -423,6 +424,7 @@ def get_conversations() -> Generator[ConversationMeta, None, None]:
             modified=modified,
             messages=len_msgs,
             branches=1 + len(list(conv_fn.parent.glob("branches/*.jsonl"))),
+            workspace=str(chat_config.workspace),
         )
 
 

--- a/gptme/server/api.py
+++ b/gptme/server/api.py
@@ -59,6 +59,8 @@ def api_conversation(logfile: str):
     init_tools(None)  # FIXME: this is not thread-safe
     log = LogManager.load(logfile, lock=False)
     log_dict = log.to_dict(branches=True)
+    # add workspace to response
+    log_dict["workspace"] = str(log.workspace)
     # make all paths absolute or relative to workspace (no "../")
     for msg in log_dict["log"]:
         if files := msg.get("files"):

--- a/tests/test_util_cli.py
+++ b/tests/test_util_cli.py
@@ -75,6 +75,7 @@ def test_chats_list(tmp_path, mocker):
         modified=time.time(),
         messages=1,
         branches=1,
+        workspace=".",
     )
     conv2 = ConversationMeta(
         id="2024-01-01-chat-two",
@@ -84,6 +85,7 @@ def test_chats_list(tmp_path, mocker):
         modified=time.time(),
         messages=2,
         branches=1,
+        workspace=".",
     )
 
     # Update the mock to return our test conversations


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add workspace metadata to conversation functionalities and update related tests.
> 
>   - **Behavior**:
>     - Include `workspace` metadata in `ConversationMeta` in `logmanager.py`.
>     - Add `workspace` to API response in `api_conversation()` in `api.py`.
>   - **Tests**:
>     - Update `test_chats_list()` in `test_util_cli.py` to include `workspace` in `ConversationMeta` objects.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 16b21ac9017a431e5de14b73fd2531a483f16c8c. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->