### PR TITLE
feat: add automatic inclusion of default project files

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -79,11 +79,26 @@ Example ``gptme.toml``:
 
 This file currently supports a few options:
 
-- ``files``, a list of paths that gptme will always include in the context.
+- ``files``, a list of paths that gptme will always include in the context. If no ``gptme.toml`` is present or if the ``files`` list is empty, gptme will automatically include a default set of common project files such as ``README.md``, ``pyproject.toml``, ``package.json``, ``Cargo.toml``, ``Makefile``, and documentation files like ``CLAUDE.md`` or ``GEMINI.md``.
 - ``prompt``, a string that will be included in the system prompt with a ``# Current Project`` header.
 - ``base_prompt``, a string that will be used as the base prompt for the project. This will override the global base prompt ("You are gptme v{__version__}, a general-purpose AI assistant powered by LLMs. [...]"). It can be useful to change the identity of the assistant and override some default behaviors.
 - ``context_cmd``, a command used to generate context to include when constructing the system prompt. The command will be run in the workspace root and should output a string that will be included in the system prompt. Examples can be ``git status -v`` or ``scripts/context.sh``.
 - ``rag``, a dictionary to configure the RAG tool. See :ref:`rag` for more information.
+
+.. note::
+
+    **Default Context Files**: When no project configuration file is found or when the ``files`` list is empty, gptme automatically includes these common project files for context:
+
+    - ``README.md``, ``README.rst``, ``README.txt``
+    - ``CLAUDE.md``, ``GEMINI.md``
+    - ``.cursor/**/*.md``
+    - ``pyproject.toml``
+    - ``package.json``
+    - ``Cargo.toml``
+    - ``Makefile``
+    - ``docker-compose.yml``, ``docker-compose.yaml``
+
+    This ensures that gptme has relevant project context even when no explicit configuration is provided.
 
 See :class:`gptme.config.ProjectConfig` for the API reference.
 

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -79,26 +79,11 @@ Example ``gptme.toml``:
 
 This file currently supports a few options:
 
-- ``files``, a list of paths that gptme will always include in the context. If no ``gptme.toml`` is present or if the ``files`` list is empty, gptme will automatically include a default set of common project files such as ``README.md``, ``pyproject.toml``, ``package.json``, ``Cargo.toml``, ``Makefile``, and documentation files like ``CLAUDE.md`` or ``GEMINI.md``.
+- ``files``, a list of paths that gptme will always include in the context. If no ``gptme.toml`` is present or if the ``files`` option is unset, gptme will automatically look for common project files, such as: ``README.md``, ``pyproject.toml``, ``package.json``, ``Cargo.toml``, ``Makefile``, ``.cursor/rules/**.mdc``, ``CLAUDE.md``, ``GEMINI.md``.
 - ``prompt``, a string that will be included in the system prompt with a ``# Current Project`` header.
 - ``base_prompt``, a string that will be used as the base prompt for the project. This will override the global base prompt ("You are gptme v{__version__}, a general-purpose AI assistant powered by LLMs. [...]"). It can be useful to change the identity of the assistant and override some default behaviors.
 - ``context_cmd``, a command used to generate context to include when constructing the system prompt. The command will be run in the workspace root and should output a string that will be included in the system prompt. Examples can be ``git status -v`` or ``scripts/context.sh``.
 - ``rag``, a dictionary to configure the RAG tool. See :ref:`rag` for more information.
-
-.. note::
-
-    **Default Context Files**: When no project configuration file is found or when the ``files`` list is empty, gptme automatically includes these common project files for context:
-
-    - ``README.md``, ``README.rst``, ``README.txt``
-    - ``CLAUDE.md``, ``GEMINI.md``
-    - ``.cursor/**/*.md``
-    - ``pyproject.toml``
-    - ``package.json``
-    - ``Cargo.toml``
-    - ``Makefile``
-    - ``docker-compose.yml``, ``docker-compose.yaml``
-
-    This ensures that gptme has relevant project context even when no explicit configuration is provided.
 
 See :class:`gptme.config.ProjectConfig` for the API reference.
 

--- a/gptme/config.py
+++ b/gptme/config.py
@@ -103,7 +103,7 @@ class ProjectConfig:
 
     base_prompt: str | None = None
     prompt: str | None = None
-    files: list[str] = field(default_factory=list)
+    files: list[str] | None = None
     context_cmd: str | None = None
     rag: RagConfig = field(default_factory=RagConfig)
 
@@ -215,7 +215,7 @@ def get_project_config(workspace: Path | None) -> ProjectConfig | None:
             config_data = tomlkit.load(f).unwrap()
 
         prompt = config_data.pop("prompt", "")
-        files = config_data.pop("files", [])
+        files = config_data.pop("files", None)
         context_cmd = config_data.pop("context_cmd", None)
         rag = RagConfig(**config_data.pop("rag", {}))
         if mcp := config_data.pop("mcp", None):

--- a/gptme/prompts.py
+++ b/gptme/prompts.py
@@ -24,6 +24,19 @@ from .tools import ToolFormat, ToolSpec, get_available_tools
 from .util import document_prompt_function
 from .util.context import md_codeblock
 
+# Default files to include in context when no gptme.toml is present or files list is empty
+DEFAULT_CONTEXT_FILES = [
+    "README*",
+    "CLAUDE.md",
+    "GEMINI.md",
+    ".cursor/**/*.md",
+    "pyproject.toml",
+    "package.json",
+    "Cargo.toml",
+    "Makefile",
+    "docker-compose.y*ml",
+]
+
 PromptType = Literal["full", "short"]
 
 logger = logging.getLogger(__name__)
@@ -352,34 +365,60 @@ def prompt_workspace(workspace: Path | None = None) -> Generator[Message, None, 
     if workspace is None:
         return
 
-    if project := get_project_config(workspace):
-        # files
-        files: list[Path] = []
-        for fileglob in project.files:
-            # expand user
-            fileglob = str(Path(fileglob).expanduser())
-            # expand with glob
-            if new_files := workspace.glob(fileglob):
-                files.extend(new_files)
-            else:
+    project = get_project_config(workspace)
+
+    # Determine which file patterns to use
+    if project is None or project.files is None:
+        # No project config or no files specified in config
+        file_patterns = DEFAULT_CONTEXT_FILES
+        if project is None:
+            logger.debug("No project config found, using default context files")
+        else:
+            logger.debug(
+                "Project config has no files specified, using default context files"
+            )
+    else:
+        # Project config exists with files explicitly set (could be empty list)
+        file_patterns = project.files
+        if not project.files:
+            logger.debug(
+                "Project config has files explicitly set to empty, not including any files"
+            )
+
+    # Process file patterns
+    files: list[Path] = []
+    for fileglob in file_patterns:
+        # expand user
+        fileglob = str(Path(fileglob).expanduser())
+        # expand with glob
+        if new_files := workspace.glob(fileglob):
+            files.extend(new_files)
+        else:
+            # Only warn for explicitly configured files, not defaults
+            if project and project.files is not None:
                 logger.warning(
                     f"File glob '{fileglob}' specified in project config does not match any files."
                 )
-        files_str = []
-        for file in files:
-            if file.exists():
-                files_str.append(md_codeblock(file, file.read_text()))
-        if files_str:
-            sections.append(
-                "## Selected project files\n\nRead more with `cat`.\n\n"
-                + "\n\n".join(files_str)
-            )
 
-        # context_cmd
-        if project.context_cmd and (
+    files_str = []
+    for file in files:
+        if file.exists():
+            files_str.append(md_codeblock(file, file.read_text()))
+    if files_str:
+        sections.append(
+            "## Selected project files\n\nRead more with `cat`.\n\n"
+            + "\n\n".join(files_str)
+        )
+
+    # context_cmd
+    if (
+        project
+        and project.context_cmd
+        and (
             cmd_output := get_project_context_cmd_output(project.context_cmd, workspace)
-        ):
-            sections.append("## Computed context\n\n" + cmd_output)
+        )
+    ):
+        sections.append("## Computed context\n\n" + cmd_output)
 
     # Get tree output if enabled
     if tree_output := get_tree_output(workspace):

--- a/gptme/prompts.py
+++ b/gptme/prompts.py
@@ -29,7 +29,7 @@ DEFAULT_CONTEXT_FILES = [
     "README*",
     "CLAUDE.md",
     "GEMINI.md",
-    ".cursor/**/*.md",
+    ".cursor/rules/*.mdc",
     "pyproject.toml",
     "package.json",
     "Cargo.toml",


### PR DESCRIPTION
- Include common project files (README, pyproject.toml, package.json, etc.) when no gptme.toml is present or files list is empty
- Update config to support files: null to distinguish from files: []
- Update documentation to explain default behavior
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Automatically include default project files when `gptme.toml` is absent or `files` list is empty, with updated documentation.
> 
>   - **Behavior**:
>     - Automatically includes default project files (`README.md`, `pyproject.toml`, `package.json`, etc.) when `gptme.toml` is absent or `files` list is empty in `prompts.py`.
>     - Supports `files: null` in `config.py` to distinguish from `files: []`.
>   - **Documentation**:
>     - Updated `config.rst` to explain default file inclusion behavior when `gptme.toml` is missing or `files` is unset.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 8044ac5a3c47f6e5cb326c9775008bb98e600bcc. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->