### PR TITLE
feat: add support for a GPTME_REASONING flag to explicitly enable/disable reasoning

### DIFF
--- a/gptme/llm/llm_anthropic.py
+++ b/gptme/llm/llm_anthropic.py
@@ -1,5 +1,6 @@
 import base64
 import logging
+import os
 import time
 from collections.abc import Generator, Iterable
 from functools import wraps
@@ -28,6 +29,13 @@ _anthropic: "Anthropic | None" = None
 
 
 def _should_use_thinking(model_meta: ModelMeta, tools: list[ToolSpec] | None) -> bool:
+    # Support environment variable to override reasoning behavior
+    env_reasoning = os.environ.get("GPTME_REASONING")
+    if env_reasoning and env_reasoning.lower() in ("1", "true", "yes"):
+        return True
+    elif env_reasoning and env_reasoning.lower() in ("0", "false", "no"):
+        return False
+
     # Only enable thinking for supported models and when not using `tool` format
     if not model_meta.supports_reasoning:
         return False


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `GPTME_REASONING` environment variable support in `llm_anthropic.py` to control reasoning behavior.
> 
>   - **Behavior**:
>     - Adds support for `GPTME_REASONING` environment variable in `_should_use_thinking()` in `llm_anthropic.py` to explicitly enable or disable reasoning.
>     - Recognizes "1", "true", "yes" as enabling and "0", "false", "no" as disabling reasoning.
>   - **Imports**:
>     - Adds `import os` to `llm_anthropic.py` for environment variable access.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 60fbcc096a8f56e3068c16c26c5053bf69a3394c. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->