### PR TITLE
fix: improve support for nested markdown codeblocks in markdown tool format

### DIFF
--- a/gptme/codeblock.py
+++ b/gptme/codeblock.py
@@ -80,6 +80,7 @@ def _extract_codeblocks(markdown: str) -> Generator[Codeblock, None, None]:
 
         # Look for code block start
         if line.startswith("```"):
+            start_line = i  # Track the starting line number
             lang = line[3:].strip()
             content_lines: list[str] = []
             i += 1
@@ -108,7 +109,7 @@ def _extract_codeblocks(markdown: str) -> Generator[Codeblock, None, None]:
                             nesting_depth -= 1
                             if nesting_depth == 0:
                                 # This closes our top-level block
-                                yield Codeblock(lang, "\n".join(content_lines))
+                                yield Codeblock(lang, "\n".join(content_lines), start=start_line)
                                 break
                             else:
                                 # This closes a nested block, add to content

--- a/gptme/codeblock.py
+++ b/gptme/codeblock.py
@@ -110,6 +110,7 @@ def _extract_codeblocks(markdown: str) -> Generator[Codeblock, None, None]:
                             if nesting_depth == 0:
                                 # This closes our top-level block
                                 yield Codeblock(lang, "\n".join(content_lines), start=start_line)
+                                i += 1  # Move past the closing ```
                                 break
                             else:
                                 # This closes a nested block, add to content
@@ -125,5 +126,5 @@ def _extract_codeblocks(markdown: str) -> Generator[Codeblock, None, None]:
 
             # If we reached the end without completing the block, don't yield it
             # (this handles the unfinished nested test case)
-
-        i += 1
+        else:
+            i += 1

--- a/gptme/codeblock.py
+++ b/gptme/codeblock.py
@@ -50,38 +50,79 @@ class Codeblock:
         return list(_extract_codeblocks(markdown))
 
 
+import re
+
+# valid start/end of markdown code blocks
+re_triple_tick_start = re.compile(r"^```.*\n")
+re_triple_tick_end = re.compile(r"^```$")
+
+
 def _extract_codeblocks(markdown: str) -> Generator[Codeblock, None, None]:
+    """
+    Extracts code blocks from a markdown string using context-aware pattern matching.
+
+    Tricks used:
+    - Opening ``` must be at start of line, optionally preceded by blank lines
+    - Closing ``` must be alone on line, optionally followed by blank lines or EOF
+    - ``` with content immediately before/after is treated as literal text, not delimiter
+
+    This handles nested cases where ``` appears inside string literals or other content.
+    """
     # speed check (early exit): check if message contains a code block
-    backtick_count = markdown.count("```")
-    if backtick_count < 2:
+    if "```" not in markdown:
         return
 
     lines = markdown.split("\n")
-    stack: list[str] = []
-    current_block = []
-    current_lang = ""
+    i = 0
 
-    for idx, line in enumerate(lines):
-        # not actually the starting index, but close enough
-        # TODO: fix to actually be correct
-        start_idx = sum(len(line) + 1 for line in lines[:idx])
-        stripped_line = line.strip()
-        if stripped_line.startswith("```"):
-            if not stack:  # Start of a new block
-                stack.append(stripped_line[3:])
-                current_lang = stripped_line[3:]
-            elif stripped_line[3:] and stack[-1] != stripped_line[3:]:  # Nested start
-                current_block.append(line)
-                stack.append(stripped_line[3:])
-            else:  # End of a block
-                if len(stack) == 1:  # Outermost block
-                    yield Codeblock(
-                        current_lang, "\n".join(current_block), start=start_idx
-                    )
-                    current_block = []
-                    current_lang = ""
-                else:  # Nested end
-                    current_block.append(line)
-                stack.pop()
-        elif stack:
-            current_block.append(line)
+    while i < len(lines):
+        line = lines[i]
+
+        # Look for code block start
+        if line.startswith("```"):
+            lang = line[3:].strip()
+            content_lines: list[str] = []
+            i += 1
+
+            # Track nesting depth to handle nested code blocks
+            nesting_depth = 1
+
+            # Collect content until we find the matching closing ```
+            while i < len(lines):
+                line = lines[i]
+
+                # Check if this line starts with ``` (potential opening or closing)
+                if line.startswith("```"):
+                    if line.strip() == "```":
+                        # Bare ``` - check if it's opening or closing based on next line
+                        if (
+                            i + 1 < len(lines)
+                            and lines[i + 1].strip() != ""
+                            and not lines[i + 1].startswith("```")
+                        ):
+                            # Next line has content, this is an opening tag
+                            nesting_depth += 1
+                            content_lines.append(line)
+                        else:
+                            # Next line is empty/EOF or starts with ```, this is closing tag
+                            nesting_depth -= 1
+                            if nesting_depth == 0:
+                                # This closes our top-level block
+                                yield Codeblock(lang, "\n".join(content_lines))
+                                break
+                            else:
+                                # This closes a nested block, add to content
+                                content_lines.append(line)
+                    else:
+                        # This starts a nested block (has language or content after ```)
+                        nesting_depth += 1
+                        content_lines.append(line)
+                else:
+                    content_lines.append(line)
+
+                i += 1
+
+            # If we reached the end without completing the block, don't yield it
+            # (this handles the unfinished nested test case)
+
+        i += 1

--- a/tests/test_codeblock.py
+++ b/tests/test_codeblock.py
@@ -1,4 +1,4 @@
-from gptme.codeblock import Codeblock
+from gptme.codeblock import Codeblock, _extract_codeblocks
 
 
 def test_extract_codeblocks_basic():
@@ -134,3 +134,21 @@ Done!
     assert "npm install" in content
     assert "node app.js" in content
     assert "Done!" in content
+
+
+def test_extract_codeblocks_consecutive():
+    """Test that consecutive codeblocks are both extracted."""
+    markdown = """```python
+print("first")
+```
+```bash
+echo "second"
+```"""
+    codeblocks = list(_extract_codeblocks(markdown))
+    assert len(codeblocks) == 2
+    assert codeblocks[0].lang == "python"
+    assert codeblocks[0].content == 'print("first")'
+    assert codeblocks[0].start == 0
+    assert codeblocks[1].lang == "bash"
+    assert codeblocks[1].content == 'echo "second"'
+    assert codeblocks[1].start == 3

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -50,12 +50,15 @@ def test():
     msg = Message(
         "system",
         """Hello world!
+
 ```bash
 echo "Hello world!"
 ```
+
 ```ipython
 print("Hello world!")
 ```
+
 That's all folks!
 """,
     )

--- a/tests/test_tools_patch.py
+++ b/tests/test_tools_patch.py
@@ -201,3 +201,41 @@ def test_apply_with_extra_divider_fails():
     except ValueError as e:
         assert "extra ======= marker found" in str(e)
         assert "Use only one =======" in str(e)
+
+
+# TODO: write a test for this
+example_patch_with_nested_codeblock = '''
+<<<<<<< ORIGINAL
+        return_prompt = """Thank you for doing the task, please reply with a JSON codeblock on the format:
+
+```json
+{
+    result: 'A description of the task result/outcome',
+    status: 'success' | 'failure',
+}
+```"""
+=======
+        return_prompt = """Thank you for doing the task, please reply with a JSON codeblock on the format:
+
+```json
+{
+    "result": "A description of the task result/outcome",
+    "status": "success"
+}
+```"""
+>>>>>>> UPDATED
+```
+'''
+
+
+def test_apply_with_nested_codeblock():
+    """Test that patches containing nested codeblocks (like ```json) work correctly."""
+    # Parse the example patch to extract original and expected content
+    patches = list(Patch.from_codeblock(example_patch_with_nested_codeblock.strip()))
+    patch = patches[0]
+
+    content = patch.original
+    expected = patch.updated
+
+    result = apply(example_patch_with_nested_codeblock.strip(), content)
+    assert result == expected

--- a/tests/test_tools_patch.py
+++ b/tests/test_tools_patch.py
@@ -203,7 +203,6 @@ def test_apply_with_extra_divider_fails():
         assert "Use only one =======" in str(e)
 
 
-# TODO: write a test for this
 example_patch_with_nested_codeblock = '''
 <<<<<<< ORIGINAL
         return_prompt = """Thank you for doing the task, please reply with a JSON codeblock on the format:


### PR DESCRIPTION
Attempt at fixing early closes of codeblocks that can happen when codeblock contents have nested codeblocks by using tricks like needing codeblock starts to have leading line (or start of string) and their ends to have leading line (or EOF).

This should help situations where we have nested codeblocks where their start tags dont have a langtag set. gptme likes to output these sometimes, causing issues, especially in situations where it'd use a "text" langtag if asked to include a langtag (langtag otherwise often redundant for such plaintext codeblocks).

I thought this approach would be an easy fix/improvement, but turns out it's a bit of a thorny issue (12 failing tests in CI). Maybe I'm missing something here about the limitations posed. It all works fairly well with the XML tool format.

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Improved handling of nested markdown codeblocks in `gptme/codeblock.py` to prevent early closure and added tests for better parsing accuracy.
> 
>   - **Behavior**:
>     - Improved `_extract_codeblocks()` in `gptme/codeblock.py` to handle nested markdown codeblocks without language tags.
>     - Codeblocks must start at the beginning of a line and end alone on a line, handling nested cases.
>     - Handles consecutive codeblocks correctly.
>   - **Tests**:
>     - Updated `test_extract_codeblocks_basic`, `test_extract_codeblocks_multiple`, `test_extract_codeblocks_nested`, and `test_extract_codeblocks_unfinished_nested` in `tests/test_codeblock.py`.
>     - Added `test_extract_codeblocks_markdown_with_nested_no_langtag` and `test_extract_codeblocks_consecutive` in `tests/test_codeblock.py`.
>     - Added `test_apply_with_nested_codeblock` in `tests/test_tools_patch.py` to test patch application with nested codeblocks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 56a6740d4c163299648ef6345bc40c34df0bd90d. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->