### PR TITLE
feat: added alternate patch tool using morph fast apply v2 via openro…

### DIFF
--- a/gptme/llm/__init__.py
+++ b/gptme/llm/__init__.py
@@ -306,25 +306,43 @@ def _summarize_helper(s: str, tok_max_start=400, tok_max_end=400) -> str:
     return summary
 
 
+def list_available_providers() -> list[tuple[Provider, str]]:
+    """
+    List all available providers based on configured API keys.
+
+    Returns:
+        List of tuples (provider, api_key_env_var) for configured providers
+    """
+    config = get_config()
+    available = []
+
+    provider_checks = [
+        ("openai", "OPENAI_API_KEY"),
+        ("anthropic", "ANTHROPIC_API_KEY"),
+        ("openrouter", "OPENROUTER_API_KEY"),
+        ("gemini", "GEMINI_API_KEY"),
+        ("groq", "GROQ_API_KEY"),
+        ("xai", "XAI_API_KEY"),
+        ("deepseek", "DEEPSEEK_API_KEY"),
+        ("openai-azure", "AZURE_OPENAI_API_KEY"),
+    ]
+
+    for provider, env_var in provider_checks:
+        if config.get_env(env_var):
+            available.append((cast(Provider, provider), env_var))
+
+    return available
+
+
 def guess_provider_from_config() -> Provider | None:
     """
     Guess the provider to use from the configuration.
     """
-    config = get_config()
-
-    if config.get_env("OPENAI_API_KEY"):
-        console.log("Found OpenAI API key, using OpenAI provider")
-        return "openai"
-    elif config.get_env("ANTHROPIC_API_KEY"):
-        console.log("Found Anthropic API key, using Anthropic provider")
-        return "anthropic"
-    elif config.get_env("OPENROUTER_API_KEY"):
-        console.log("Found OpenRouter API key, using OpenRouter provider")
-        return "openrouter"
-    elif config.get_env("GEMINI_API_KEY"):
-        console.log("Found Gemini API key, using Gemini provider")
-        return "gemini"
-
+    available = list_available_providers()
+    if available:
+        provider, _ = available[0]  # Return first available provider
+        console.log(f"Found {provider} API key, using {provider} provider")
+        return provider
     return None
 
 

--- a/gptme/tools/morph.py
+++ b/gptme/tools/morph.py
@@ -54,17 +54,9 @@ If you plan on deleting a section, you must provide surrounding context to indic
 DO NOT omit spans of pre-existing code without using the // ... existing code ... comment to indicate its absence.
 """
 
-instructions_format = {
-    "markdown": f"""
-The $PATH parameter MUST be on the same line as the code block start, not on the line after.
-
-{ToolUse("morph", ["$PATH"], "$EDIT_INSTRUCTIONS").to_output("markdown")}
-""",
-    "tool": "The `edit` parameter must contain your edit instructions as a string.",
-}
-
-examples = """
-```morph example.py
+examples = f"""
+{ToolUse("morph", ["example.py"],
+'''
 // ... existing code ...
 FIRST_EDIT
 // ... existing code ...
@@ -72,7 +64,7 @@ SECOND_EDIT
 // ... existing code ...
 THIRD_EDIT
 // ... existing code ...
-```
+'''.strip()).to_output("markdown")}
 """
 
 

--- a/gptme/tools/morph.py
+++ b/gptme/tools/morph.py
@@ -1,0 +1,223 @@
+"""
+Gives the LLM agent the ability to edit files using Morph Fast Apply v2.
+
+Morph is a specialized code-patching LLM that applies edits at 4000+ tokens per second.
+It uses a different format than the patch tool: <code>original</code><update>changes</update>
+
+Environment Variables:
+    OPENROUTER_API_KEY: Required for accessing Morph via OpenRouter
+"""
+
+import difflib
+from collections.abc import Generator
+from pathlib import Path
+
+from ..llm import reply as llm_reply
+from ..message import Message
+from ..util.ask_execute import execute_with_confirmation
+from .base import (
+    ConfirmFunc,
+    Parameter,
+    ToolSpec,
+    ToolUse,
+    get_path,
+)
+
+instructions = """
+Use this tool to propose an edit to an existing file.
+
+This will be read by a less intelligent model, which will quickly apply the edit. You should make it clear what the edit is, while also minimizing the unchanged code you write.
+
+When writing the edit, you should specify each edit in sequence, with the special comment // ... existing code ... to represent unchanged code in between edited lines.
+
+For example:
+
+```morph example.py
+// ... existing code ...
+FIRST_EDIT
+// ... existing code ...
+SECOND_EDIT
+// ... existing code ...
+THIRD_EDIT
+// ... existing code ...
+```
+
+This will be read by a less intelligent model, which will quickly apply the edit. You should make it clear what the edit is, while also minimizing the unchanged code you write.
+When writing the edit, you should specify each edit in sequence, with the special comment // ... existing code ... to represent unchanged code in between edited lines.
+
+You should bias towards repeating as few lines of the original file as possible to convey the change.
+NEVER show unmodified code in the edit, unless sufficient context of unchanged lines around the code you're editing is needed to resolve ambiguity.
+If you plan on deleting a section, you must provide surrounding context to indicate the deletion.
+DO NOT omit spans of pre-existing code without using the // ... existing code ... comment to indicate its absence.
+"""
+
+# gptme-generated prompt
+instructions_gptme = """
+To edit files using Morph Fast Apply, provide the target file path and edit instructions.
+
+Morph will intelligently apply your changes by understanding the intent and making minimal, precise edits.
+You can describe what you want to change in natural language or provide specific code snippets.
+
+Use truncation markers like "// ... existing code ..." to indicate unchanged parts when providing specific edits.
+This tool is particularly effective for:
+- Adding new functions or methods
+- Modifying existing logic
+- Refactoring code
+- Bug fixes
+
+The tool reads the original file, sends it to Morph with your edit instructions, and applies the result.
+""".strip()
+
+instructions_format = {
+    "markdown": f"""
+The $PATH parameter MUST be on the same line as the code block start, not on the line after.
+
+{ToolUse("morph", ["$PATH"], "$EDIT_INSTRUCTIONS").to_output("markdown")}
+""",
+    "tool": "The `edit` parameter must contain your edit instructions as a string.",
+}
+
+examples = """
+```morph example.py
+// ... existing code ...
+FIRST_EDIT
+// ... existing code ...
+SECOND_EDIT
+// ... existing code ...
+THIRD_EDIT
+// ... existing code ...
+```
+"""
+
+
+def preview_morph(content: str, path: Path | None) -> str | None:
+    """Prepare preview content for morph operation."""
+    if not path or not path.exists():
+        return "File does not exist"
+
+    try:
+        # Read original content
+        with open(path) as f:
+            original_content = f.read()
+
+        # Generate a diff between original and edited content
+        diff_lines = list(
+            difflib.unified_diff(
+                original_content.splitlines(),
+                content.splitlines(),
+                fromfile=str(path),
+                tofile=str(path),
+                lineterm="",
+            )
+        )
+
+        if not diff_lines:
+            return "No changes would be made"
+
+        return "\n".join(diff_lines)
+
+    except Exception as e:
+        return f"Preview failed: {str(e)}"
+
+
+def execute_morph_impl(
+    content: str, path: Path | None, confirm: ConfirmFunc
+) -> Generator[Message, None, None]:
+    """Actual morph implementation - writes the edited content to file."""
+    if not path:
+        raise ValueError("No file path provided")
+
+    try:
+        # Write the edited content back to file
+        with open(path, "w") as f:
+            f.write(content)
+
+        yield Message("system", f"File successfully edited using Morph: {path}")
+
+    except Exception as e:
+        raise ValueError(f"Failed to write file: {str(e)}") from e
+
+
+def execute_morph(
+    code: str | None,
+    args: list[str] | None,
+    kwargs: dict[str, str] | None,
+    confirm: ConfirmFunc = lambda _: True,
+) -> Generator[Message, None, None]:
+    """Applies the morph edit."""
+    if code is None and kwargs is not None:
+        code = kwargs.get("edit", code)
+
+    if not code:
+        yield Message("system", "Error: No edit instructions provided")
+        return
+
+    # Get the file path
+    file_path = get_path(code, args, kwargs)
+    if not file_path:
+        yield Message("system", "Error: No file path provided")
+        return
+
+    try:
+        # Read the original file
+        with open(file_path) as f:
+            original_content = f.read()
+    except FileNotFoundError:
+        yield Message("system", f"Error: File not found: {file_path}")
+        return
+
+    # Format the prompt for Morph
+    morph_prompt = f"<code>{original_content}</code><update>{code}</update>"
+
+    # Create message for Morph
+    messages = [Message("user", morph_prompt)]
+
+    # Call Morph via OpenRouter
+    try:
+        # Use the openrouter/morph/morph-v2 model
+        response = llm_reply(
+            messages, "openrouter/morph/morph-v2", stream=False, tools=None
+        )
+        edited_content = response.content.strip()
+
+        # Use execute_with_confirmation with the edited content
+        yield from execute_with_confirmation(
+            edited_content,
+            args,
+            kwargs,
+            confirm,
+            execute_fn=execute_morph_impl,
+            get_path_fn=lambda *_: file_path,
+            preview_fn=preview_morph,
+            preview_lang="diff",
+            confirm_msg=f"Apply Morph edit to {file_path}?",
+            allow_edit=False,  # Don't allow editing the computed result
+        )
+
+    except Exception as e:
+        yield Message("system", f"Morph API call failed: {str(e)}")
+
+
+tool = ToolSpec(
+    name="morph",
+    desc="Edit files using Morph Fast Apply v2 - an AI specialized for fast, precise code edits",
+    instructions=instructions,
+    examples=examples,
+    execute=execute_morph,
+    block_types=["morph"],
+    parameters=[
+        Parameter(
+            name="path",
+            type="string",
+            description="The path of the file to edit.",
+            required=True,
+        ),
+        Parameter(
+            name="edit",
+            type="string",
+            description="Updated content, using '// ... existing code ...' markers.",
+            required=True,
+        ),
+    ],
+)
+__doc__ = tool.get_doc(__doc__)


### PR DESCRIPTION
Saw this just dropped on OpenRouter: https://openrouter.ai/morph/morph-v2

Just had to add a tool for it! So far I've had great results.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds a new tool for file editing using Morph Fast Apply v2 via OpenRouter, with provider management updates in `gptme/llm/__init__.py`.
> 
>   - **New Tool**:
>     - Adds `morph.py` to `gptme/tools/` for editing files using Morph Fast Apply v2 via OpenRouter.
>     - Implements `execute_morph`, `execute_morph_impl`, and `preview_morph` for handling file edits.
>     - Includes `is_openrouter_available` to check provider availability.
>   - **Provider Management**:
>     - Adds `list_available_providers` in `gptme/llm/__init__.py` to list providers based on API keys.
>     - Updates `guess_provider_from_config` to use `list_available_providers`.
>   - **Misc**:
>     - Updates `tool` definition in `morph.py` with parameters and instructions for Morph Fast Apply v2.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for a50b49754d72caad8b6691835686d7ea2564014c. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->