### PR TITLE
fix: pass provider prefix when using LLM proxy

### DIFF
--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -61,8 +61,8 @@ RUN pipx ensurepath
 # we need to manually add the pipx bin directory to PATH.
 ENV PATH="/home/appuser/.local/bin:${PATH}"
 
-git config --global user.name "gptme.ai"
-git config --global user.email "noreply@gptme.ai"
+RUN git config --global user.name "gptme.ai"
+RUN git config --global user.email "noreply@gptme.ai"
 
 WORKDIR /workspace
 

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -34,6 +34,7 @@ RUN apt-get update && apt-get install -y \
     pandoc \
     gpg \
     pipx \
+    tree \
     && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
     && chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -60,6 +60,9 @@ RUN pipx ensurepath
 # we need to manually add the pipx bin directory to PATH.
 ENV PATH="/home/appuser/.local/bin:${PATH}"
 
+git config --global user.name "gptme.ai"
+git config --global user.email "noreply@gptme.ai"
+
 WORKDIR /workspace
 
 ENTRYPOINT ["gptme"]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Pass provider prefix in model name when using LLM proxy in `llm_anthropic.py` and `llm_openai.py`, and update Dockerfile with `tree` package and Git configurations.
> 
>   - **Behavior**:
>     - Pass provider prefix in model name when using LLM proxy in `chat()` and `stream()` functions in `llm_anthropic.py` and `llm_openai.py`.
>     - Determine if using proxy via `_is_proxy` in `llm_openai.py` and `llm_anthropic.py`.
>   - **Dockerfile**:
>     - Add `tree` package installation.
>     - Set global Git user name and email.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 2a087436ef3c59c32c46cd4c9b3d7508d9f6c0d7. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->