### PR TITLE
fix: resolve audio blocking and ALSA/PulseAudio timeout issues

### DIFF
--- a/gptme/util/_sound_cmd.py
+++ b/gptme/util/_sound_cmd.py
@@ -1,0 +1,103 @@
+"""
+Command-based audio playback using system audio players like paplay and ffplay.
+"""
+
+import logging
+import shutil
+import subprocess
+from pathlib import Path
+from typing import TypedDict
+
+log = logging.getLogger(__name__)
+
+
+class AudioPlayer(TypedDict):
+    cmd: str
+    args: list[str]
+
+
+# Available system audio players (in order of preference)
+AUDIO_PLAYERS: list[AudioPlayer] = [
+    {"cmd": "paplay", "args": []},  # PulseAudio player
+    {
+        "cmd": "ffplay",
+        "args": ["-nodisp", "-autoexit", "-loglevel", "quiet"],
+    },  # FFmpeg player
+]
+
+
+def is_cmd_audio_available() -> bool:
+    """Check if audio playback is available via system command-line tools."""
+    for player in AUDIO_PLAYERS:
+        if shutil.which(player["cmd"]):
+            return True
+    return False
+
+
+def play_with_system_command_blocking(file_path: Path, volume: float = 1.0) -> bool:
+    """Play audio file using system commands (blocking call for background thread).
+
+    Args:
+        file_path: Path to the audio file
+        volume: Volume level (0.0 to 1.0)
+
+    Returns:
+        True if successfully played, False if all system players failed
+    """
+    for player in AUDIO_PLAYERS:
+        if not shutil.which(player["cmd"]):
+            continue
+
+        try:
+            cmd = [player["cmd"]] + player["args"]
+
+            # Add volume control if supported
+            if player["cmd"] == "paplay" and volume != 1.0:
+                # paplay uses --volume (0-65536, where 65536 = 100%)
+                vol_arg = str(int(volume * 65536))
+                cmd.extend(["--volume", vol_arg])
+            elif player["cmd"] == "ffplay" and volume != 1.0:
+                # ffplay uses -volume (0-100)
+                vol_arg = str(int(volume * 100))
+                cmd.extend(["-volume", vol_arg])
+
+            cmd.append(str(file_path))
+
+            log.debug(f"Playing audio with {player['cmd']}: {' '.join(cmd)}")
+
+            # Run the command with timeout (blocking in background thread)
+            result = subprocess.run(
+                cmd,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.PIPE,
+                timeout=10,  # 10 second timeout
+                check=False,
+            )
+
+            if result.returncode == 0:
+                log.debug(f"Successfully played audio with {player['cmd']}")
+                return True
+            else:
+                log.debug(
+                    f"{player['cmd']} failed with return code {result.returncode}"
+                )
+                if result.stderr:
+                    stderr = result.stderr.decode().strip()
+                    if stderr:
+                        log.debug(f"{player['cmd']} stderr: {stderr}")
+
+        except subprocess.TimeoutExpired:
+            log.warning(f"Audio playback with {player['cmd']} timed out")
+        except Exception as e:
+            log.debug(f"Failed to play audio with {player['cmd']}: {e}")
+
+    return False
+
+
+def stop_system_audio():
+    """Stop any running subprocess audio players."""
+    try:
+        subprocess.run(["pkill", "-f", "paplay"], capture_output=True, timeout=2)
+        subprocess.run(["pkill", "-f", "ffplay"], capture_output=True, timeout=2)
+    except Exception:
+        pass

--- a/gptme/util/_sound_cmd.py
+++ b/gptme/util/_sound_cmd.py
@@ -70,7 +70,7 @@ def play_with_system_command_blocking(file_path: Path, volume: float = 1.0) -> b
                 cmd,
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.PIPE,
-                timeout=10,  # 10 second timeout
+                timeout=60,  # 60 second timeout, to account for long TTS outputs
                 check=False,
             )
 

--- a/gptme/util/_sound_sounddevice.py
+++ b/gptme/util/_sound_sounddevice.py
@@ -1,0 +1,312 @@
+"""
+Sounddevice-based audio playback using Python audio libraries.
+"""
+
+import logging
+import os
+import platform as platform_module
+import time
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+# Check for audio dependencies
+has_audio_imports = False
+try:
+    import numpy as np  # fmt: skip
+    import scipy.io.wavfile as wavfile  # fmt: skip
+    import scipy.signal as signal  # fmt: skip
+    import sounddevice as sd  # fmt: skip
+
+    has_audio_imports = True
+except (ImportError, OSError):
+    # sounddevice may throw OSError("PortAudio library not found")
+    has_audio_imports = False
+
+
+def is_sounddevice_available() -> bool:
+    """Check if sounddevice audio playback is available."""
+    return has_audio_imports
+
+
+def _check_device_override(devices) -> tuple[int, int] | None:
+    """Check for environment variable device override."""
+    if device_override := os.getenv("GPTME_AUDIO_DEVICE"):
+        try:
+            device_index = int(device_override)
+            if 0 <= device_index < len(devices):
+                device_info = sd.query_devices(device_index)
+                if device_info["max_output_channels"] > 0:
+                    log.debug(f"Using device override: {device_info['name']}")
+                    return device_index, int(device_info["default_samplerate"])
+                else:
+                    log.warning(
+                        f"Override device {device_index} has no output channels"
+                    )
+            else:
+                log.warning(f"Override device index {device_index} out of range")
+        except ValueError:
+            log.warning(f"Invalid device override value: {device_override}")
+    return None
+
+
+def _get_output_device_macos(devices) -> tuple[int, int]:
+    """Get the best output device for macOS."""
+    # Try system default first
+    try:
+        default_output = sd.default.device[1]
+        if default_output is not None:
+            device_info = sd.query_devices(default_output)
+            if device_info["max_output_channels"] > 0:
+                log.debug(f"Using system default output device: {device_info['name']}")
+                return default_output, int(device_info["default_samplerate"])
+    except Exception as e:
+        log.debug(f"Could not use default device: {e}")
+
+    # Prefer CoreAudio devices
+    coreaudio_device = next(
+        (
+            i
+            for i, d in enumerate(devices)
+            if d["max_output_channels"] > 0 and d["hostapi"] == 2
+        ),
+        None,
+    )
+    if coreaudio_device is not None:
+        device_info = sd.query_devices(coreaudio_device)
+        log.debug(f"Using CoreAudio device: {device_info['name']}")
+        return coreaudio_device, int(device_info["default_samplerate"])
+
+    # Fallback to any output device
+    output_device = next(
+        (i for i, d in enumerate(devices) if d["max_output_channels"] > 0),
+        None,
+    )
+    if output_device is None:
+        raise RuntimeError("No suitable audio output device found on macOS")
+
+    device_info = sd.query_devices(output_device)
+    log.debug(f"Fallback to device: {device_info['name']}")
+    return output_device, int(device_info["default_samplerate"])
+
+
+def _get_output_device_linux(devices) -> tuple[int, int]:
+    """Get the best output device for Linux."""
+    # Try system default first
+    try:
+        default_output = sd.default.device[1]
+        if default_output is not None:
+            device_info = sd.query_devices(default_output)
+            if device_info["max_output_channels"] > 0:
+                log.debug(f"Using system default output device: {device_info['name']}")
+                return default_output, int(device_info["default_samplerate"])
+    except Exception as e:
+        log.debug(f"Could not use default device: {e}")
+
+    # Try ALSA devices (more reliable than PulseAudio for sounddevice)
+    alsa_device = next(
+        (
+            i
+            for i, d in enumerate(devices)
+            if ("alsa" in d["name"].lower() or "hw:" in d["name"].lower())
+            and d["max_output_channels"] > 0
+        ),
+        None,
+    )
+    if alsa_device is not None:
+        device_info = sd.query_devices(alsa_device)
+        log.debug(f"Using ALSA device: {device_info['name']}")
+        return alsa_device, int(device_info["default_samplerate"])
+
+    # Fallback to PulseAudio if ALSA not found
+    pulse_device = next(
+        (
+            i
+            for i, d in enumerate(devices)
+            if "pulse" in d["name"].lower() and d["max_output_channels"] > 0
+        ),
+        None,
+    )
+    if pulse_device is not None:
+        device_info = sd.query_devices(pulse_device)
+        log.debug(f"Using PulseAudio device: {device_info['name']}")
+        return pulse_device, int(device_info["default_samplerate"])
+
+    # Last resort: any working output device
+    output_device = next(
+        (i for i, d in enumerate(devices) if d["max_output_channels"] > 0),
+        None,
+    )
+    if output_device is None:
+        raise RuntimeError("No suitable audio output device found on Linux")
+
+    device_info = sd.query_devices(output_device)
+    log.debug(f"Fallback to device: {device_info['name']}")
+    return output_device, int(device_info["default_samplerate"])
+
+
+def get_output_device() -> tuple[int, int]:
+    """Get the best available output device and its sample rate."""
+    if not has_audio_imports:
+        raise RuntimeError("Audio imports not available")
+
+    devices = sd.query_devices()
+    log.debug("Available audio devices:")
+    for i, dev in enumerate(devices):
+        log.debug(
+            f"  [{i}] {dev['name']} (in: {dev['max_input_channels']}, "
+            f"out: {dev['max_output_channels']}, hostapi: {dev['hostapi']})"
+        )
+
+    # Check for environment variable override first
+    if override_result := _check_device_override(devices):
+        return override_result
+
+    # Use platform-specific logic
+    system = platform_module.system()
+
+    if system == "Darwin":  # macOS
+        return _get_output_device_macos(devices)
+    elif system == "Linux":
+        return _get_output_device_linux(devices)
+    else:
+        # Windows or other platforms - use simple default logic
+        try:
+            default_output = sd.default.device[1]
+            if default_output is not None:
+                device_info = sd.query_devices(default_output)
+                if device_info["max_output_channels"] > 0:
+                    log.debug(f"Using system default: {device_info['name']}")
+                    return default_output, int(device_info["default_samplerate"])
+        except Exception:
+            pass
+
+        # Fallback for other platforms
+        output_device = next(
+            (i for i, d in enumerate(devices) if d["max_output_channels"] > 0),
+            None,
+        )
+        if output_device is None:
+            raise RuntimeError(f"No suitable audio output device found on {system}")
+
+        device_info = sd.query_devices(output_device)
+        return output_device, int(device_info["default_samplerate"])
+
+
+def resample_audio(data, orig_sr, target_sr):
+    """Resample audio data to target sample rate."""
+    if not has_audio_imports:
+        raise RuntimeError("Audio libraries not available for resampling")
+
+    if orig_sr == target_sr:
+        return data
+
+    duration = len(data) / orig_sr
+    num_samples = int(duration * target_sr)
+    return signal.resample(data, num_samples)
+
+
+def convert_audio_to_float32(data: Any) -> Any:
+    """Convert audio data to float32 format for consistent processing.
+
+    Args:
+        data: Audio data as numpy array
+
+    Returns:
+        Audio data converted to float32 format
+    """
+    if not has_audio_imports:
+        return data
+
+    # Convert to float32 for consistent processing
+    if data.dtype != np.float32:
+        if data.dtype.kind == "i":  # integer
+            data = data.astype(np.float32) / np.iinfo(data.dtype).max
+        elif data.dtype.kind == "f":  # floating point
+            # Normalize to [-1, 1] if needed
+            if np.max(np.abs(data)) > 1.0:
+                data = data / np.max(np.abs(data))
+            data = data.astype(np.float32)
+
+    return data
+
+
+def play_with_sounddevice(data: Any, sample_rate: int, volume: float = 1.0):
+    """Play audio data using sounddevice.
+
+    Args:
+        data: Audio data as numpy array
+        sample_rate: Sample rate of the audio
+        volume: Volume level (0.0 to 1.0)
+    """
+    if not has_audio_imports:
+        raise RuntimeError("sounddevice not available")
+
+    try:
+        # Convert to float32 and apply volume
+        data = convert_audio_to_float32(data)
+        data = data * volume
+
+        # Get output device with timeout
+        try:
+            output_device, device_sr = get_output_device()
+            # Resample if needed
+            if sample_rate != device_sr:
+                data = resample_audio(data, sample_rate, device_sr)
+                sample_rate = device_sr
+        except RuntimeError as e:
+            log.error(f"Device error: {e}")
+            raise
+
+        if output_device is not None:
+            log.debug(f"Playing on device: {output_device}")
+        else:
+            log.debug("Playing on system default device")
+
+        # Play with timeout protection
+        sd.play(data, sample_rate, device=output_device)
+
+        # Wait with timeout
+        start_time = time.time()
+        timeout = 10.0  # 10 second timeout
+        while sd.get_stream().active:
+            if time.time() - start_time > timeout:
+                log.warning("Audio playback timed out, stopping")
+                sd.stop()
+                break
+            time.sleep(0.1)
+
+        log.debug("Finished playing audio chunk")
+    except Exception as e:
+        log.error(f"sounddevice playback error: {e}")
+        try:
+            sd.stop()
+        except Exception:
+            pass
+        raise
+
+
+def stop_sounddevice_audio():
+    """Stop sounddevice audio playback."""
+    if has_audio_imports:
+        try:
+            sd.stop()
+        except Exception:
+            pass
+
+
+def load_wav_file(file_path):
+    """Load a WAV file using scipy.
+
+    Returns:
+        tuple: (sample_rate, data) or None if loading failed
+    """
+    if not has_audio_imports:
+        return None
+
+    try:
+        sample_rate, data = wavfile.read(file_path)
+        return sample_rate, data
+    except Exception as e:
+        log.error(f"Failed to load WAV file {file_path}: {e}")
+        return None

--- a/gptme/util/sound.py
+++ b/gptme/util/sound.py
@@ -5,39 +5,30 @@ Extracts core audio playback functionality for reuse across TTS and UI sounds.
 """
 
 import logging
-import os
-import platform as platform_module
 import queue
-import shutil
-import subprocess
-import sys
+import tempfile
 import threading
 import time
 from pathlib import Path
-from typing import Any, TypedDict
+from typing import Any
 
 from ..config import get_config
-
-
-class AudioPlayer(TypedDict):
-    cmd: str
-    args: list[str]
-
+from ._sound_cmd import (
+    is_cmd_audio_available,
+    play_with_system_command_blocking,
+    stop_system_audio,
+)
+from ._sound_sounddevice import (
+    convert_audio_to_float32,
+    get_output_device,
+    is_sounddevice_available,
+    load_wav_file,
+    play_with_sounddevice,
+    resample_audio,
+    stop_sounddevice_audio,
+)
 
 log = logging.getLogger(__name__)
-
-# Check for audio dependencies
-has_audio_imports = False
-try:
-    import numpy as np  # fmt: skip
-    import scipy.io.wavfile as wavfile  # fmt: skip
-    import scipy.signal as signal  # fmt: skip
-    import sounddevice as sd  # fmt: skip
-
-    has_audio_imports = True
-except (ImportError, OSError):
-    # sounddevice may throw OSError("PortAudio library not found")
-    has_audio_imports = False
 
 # Audio playback state
 audio_queue: queue.Queue[tuple[Any, int] | None] = queue.Queue()
@@ -46,199 +37,10 @@ current_volume = 0.7
 
 media_path = Path(__file__).parent.parent.parent / "media"
 
-# Available system audio players (in order of preference)
-AUDIO_PLAYERS: list[AudioPlayer] = [
-    {"cmd": "paplay", "args": []},  # PulseAudio player
-    {
-        "cmd": "ffplay",
-        "args": ["-nodisp", "-autoexit", "-loglevel", "quiet"],
-    },  # FFmpeg player
-]
-
 
 def is_audio_available() -> bool:
     """Check if audio playback is available via system tools or sounddevice."""
-    # Check if any system audio player is available
-    for player in AUDIO_PLAYERS:
-        if shutil.which(player["cmd"]):
-            return True
-
-    # Fall back to checking sounddevice
-    return has_audio_imports
-
-
-def _check_device_override(devices) -> tuple[int, int] | None:
-    """Check for environment variable device override."""
-    if device_override := os.getenv("GPTME_AUDIO_DEVICE"):
-        try:
-            device_index = int(device_override)
-            if 0 <= device_index < len(devices):
-                device_info = sd.query_devices(device_index)
-                if device_info["max_output_channels"] > 0:
-                    log.debug(f"Using device override: {device_info['name']}")
-                    return device_index, int(device_info["default_samplerate"])
-                else:
-                    log.warning(
-                        f"Override device {device_index} has no output channels"
-                    )
-            else:
-                log.warning(f"Override device index {device_index} out of range")
-        except ValueError:
-            log.warning(f"Invalid device override value: {device_override}")
-    return None
-
-
-def _get_output_device_macos(devices) -> tuple[int, int]:
-    """Get the best output device for macOS."""
-    # Try system default first
-    try:
-        default_output = sd.default.device[1]
-        if default_output is not None:
-            device_info = sd.query_devices(default_output)
-            if device_info["max_output_channels"] > 0:
-                log.debug(f"Using system default output device: {device_info['name']}")
-                return default_output, int(device_info["default_samplerate"])
-    except Exception as e:
-        log.debug(f"Could not use default device: {e}")
-
-    # Prefer CoreAudio devices
-    coreaudio_device = next(
-        (
-            i
-            for i, d in enumerate(devices)
-            if d["max_output_channels"] > 0 and d["hostapi"] == 2
-        ),
-        None,
-    )
-    if coreaudio_device is not None:
-        device_info = sd.query_devices(coreaudio_device)
-        log.debug(f"Using CoreAudio device: {device_info['name']}")
-        return coreaudio_device, int(device_info["default_samplerate"])
-
-    # Fallback to any output device
-    output_device = next(
-        (i for i, d in enumerate(devices) if d["max_output_channels"] > 0),
-        None,
-    )
-    if output_device is None:
-        raise RuntimeError("No suitable audio output device found on macOS")
-
-    device_info = sd.query_devices(output_device)
-    log.debug(f"Fallback to device: {device_info['name']}")
-    return output_device, int(device_info["default_samplerate"])
-
-
-def _get_output_device_linux(devices) -> tuple[int, int]:
-    """Get the best output device for Linux."""
-    # Try system default first
-    try:
-        default_output = sd.default.device[1]
-        if default_output is not None:
-            device_info = sd.query_devices(default_output)
-            if device_info["max_output_channels"] > 0:
-                log.debug(f"Using system default output device: {device_info['name']}")
-                return default_output, int(device_info["default_samplerate"])
-    except Exception as e:
-        log.debug(f"Could not use default device: {e}")
-
-    # Try ALSA devices (more reliable than PulseAudio for sounddevice)
-    alsa_device = next(
-        (
-            i
-            for i, d in enumerate(devices)
-            if ("alsa" in d["name"].lower() or "hw:" in d["name"].lower())
-            and d["max_output_channels"] > 0
-        ),
-        None,
-    )
-    if alsa_device is not None:
-        device_info = sd.query_devices(alsa_device)
-        log.debug(f"Using ALSA device: {device_info['name']}")
-        return alsa_device, int(device_info["default_samplerate"])
-
-    # Fallback to PulseAudio if ALSA not found
-    pulse_device = next(
-        (
-            i
-            for i, d in enumerate(devices)
-            if "pulse" in d["name"].lower() and d["max_output_channels"] > 0
-        ),
-        None,
-    )
-    if pulse_device is not None:
-        device_info = sd.query_devices(pulse_device)
-        log.debug(f"Using PulseAudio device: {device_info['name']}")
-        return pulse_device, int(device_info["default_samplerate"])
-
-    # Last resort: any working output device
-    output_device = next(
-        (i for i, d in enumerate(devices) if d["max_output_channels"] > 0),
-        None,
-    )
-    if output_device is None:
-        raise RuntimeError("No suitable audio output device found on Linux")
-
-    device_info = sd.query_devices(output_device)
-    log.debug(f"Fallback to device: {device_info['name']}")
-    return output_device, int(device_info["default_samplerate"])
-
-
-def get_output_device() -> tuple[int, int]:
-    """Get the best available output device and its sample rate."""
-    if not has_audio_imports:
-        raise RuntimeError("Audio imports not available")
-
-    devices = sd.query_devices()
-    log.debug("Available audio devices:")
-    for i, dev in enumerate(devices):
-        log.debug(
-            f"  [{i}] {dev['name']} (in: {dev['max_input_channels']}, "
-            f"out: {dev['max_output_channels']}, hostapi: {dev['hostapi']})"
-        )
-
-    # Check for environment variable override first
-    if override_result := _check_device_override(devices):
-        return override_result
-
-    # Use platform-specific logic
-    system = platform_module.system()
-
-    if system == "Darwin":  # macOS
-        return _get_output_device_macos(devices)
-    elif system == "Linux":
-        return _get_output_device_linux(devices)
-    else:
-        # Windows or other platforms - use simple default logic
-        try:
-            default_output = sd.default.device[1]
-            if default_output is not None:
-                device_info = sd.query_devices(default_output)
-                if device_info["max_output_channels"] > 0:
-                    log.debug(f"Using system default: {device_info['name']}")
-                    return default_output, int(device_info["default_samplerate"])
-        except Exception:
-            pass
-
-        # Fallback for other platforms
-        output_device = next(
-            (i for i, d in enumerate(devices) if d["max_output_channels"] > 0),
-            None,
-        )
-        if output_device is None:
-            raise RuntimeError(f"No suitable audio output device found on {system}")
-
-        device_info = sd.query_devices(output_device)
-        return output_device, int(device_info["default_samplerate"])
-
-
-def _resample_audio(data, orig_sr, target_sr):
-    """Resample audio data to target sample rate."""
-    if orig_sr == target_sr:
-        return data
-
-    duration = len(data) / orig_sr
-    num_samples = int(duration * target_sr)
-    return signal.resample(data, num_samples)
+    return is_cmd_audio_available() or is_sounddevice_available()
 
 
 def _audio_player_thread_fn() -> None:
@@ -263,133 +65,55 @@ def _audio_player_thread_fn() -> None:
 
             # First try to save as temp file and play with system commands
             success = False
-            try:
-                import tempfile
+            if is_cmd_audio_available():
+                try:
+                    with tempfile.NamedTemporaryFile(
+                        suffix=".wav", delete=False
+                    ) as tmp_file:
+                        tmp_path = Path(tmp_file.name)
 
-                with tempfile.NamedTemporaryFile(
-                    suffix=".wav", delete=False
-                ) as tmp_file:
-                    tmp_path = Path(tmp_file.name)
+                        # Convert and save to temp WAV file
+                        if is_sounddevice_available():
+                            data_converted = convert_audio_to_float32(data)
+                            data_int16 = (data_converted * 32767).astype("int16")
+                        else:
+                            # Fallback conversion without numpy
+                            data_int16 = data
 
-                    # Convert and save to temp WAV file
-                    data_int16 = (data * 32767).astype("int16")
-                    wavfile.write(tmp_path, sample_rate, data_int16)
+                        # Save WAV file (requires scipy)
+                        if is_sounddevice_available():
+                            import scipy.io.wavfile as wavfile
 
-                    # Try to play with system commands
-                    if _play_with_system_command_blocking(tmp_path, current_volume):
-                        success = True
+                            wavfile.write(tmp_path, sample_rate, data_int16)
 
-                    # Clean up temp file
-                    try:
-                        tmp_path.unlink()
-                    except OSError:
-                        pass
+                            # Try to play with system commands
+                            if play_with_system_command_blocking(
+                                tmp_path, current_volume
+                            ):
+                                success = True
 
-            except Exception as e:
-                log.debug(f"System command playback failed: {e}")
+                        # Clean up temp file
+                        try:
+                            tmp_path.unlink()
+                        except OSError:
+                            pass
+
+                except Exception as e:
+                    log.debug(f"System command playback failed: {e}")
 
             # Fall back to sounddevice if system commands failed
-            if not success:
+            if not success and is_sounddevice_available():
                 log.debug("System audio players failed, falling back to sounddevice")
                 try:
-                    # Get output device with timeout
-                    try:
-                        output_device, _ = get_output_device()
-                        if output_device is not None:
-                            log.debug(f"Playing on device: {output_device}")
-                        else:
-                            log.debug("Playing on system default device")
-                    except RuntimeError as e:
-                        log.error(f"Device error: {e}")
-                        audio_queue.task_done()
-                        continue
-
-                    # Play with timeout protection
-                    sd.play(data, sample_rate, device=output_device)
-
-                    # Wait with timeout
-                    start_time = time.time()
-                    timeout = 10.0  # 10 second timeout
-                    while sd.get_stream().active:
-                        if time.time() - start_time > timeout:
-                            log.warning("Audio playback timed out, stopping")
-                            sd.stop()
-                            break
-                        time.sleep(0.1)
-
-                    log.debug("Finished playing audio chunk")
+                    play_with_sounddevice(data, sample_rate, current_volume)
                 except Exception as e:
                     log.error(f"sounddevice playback error: {e}")
-                    try:
-                        sd.stop()
-                    except Exception:
-                        pass
 
             audio_queue.task_done()
         except Exception as e:
             log.error(f"Error in audio playback thread: {e}")
             if not audio_queue.empty():
                 audio_queue.task_done()
-
-
-def _play_with_system_command_blocking(file_path: Path, volume: float = 1.0) -> bool:
-    """Play audio file using system commands (blocking call for background thread).
-
-    Args:
-        file_path: Path to the audio file
-        volume: Volume level (0.0 to 1.0)
-
-    Returns:
-        True if successfully played, False if all system players failed
-    """
-    for player in AUDIO_PLAYERS:
-        if not shutil.which(player["cmd"]):
-            continue
-
-        try:
-            cmd = [player["cmd"]] + player["args"]
-
-            # Add volume control if supported
-            if player["cmd"] == "paplay" and volume != 1.0:
-                # paplay uses --volume (0-65536, where 65536 = 100%)
-                vol_arg = str(int(volume * 65536))
-                cmd.extend(["--volume", vol_arg])
-            elif player["cmd"] == "ffplay" and volume != 1.0:
-                # ffplay uses -volume (0-100)
-                vol_arg = str(int(volume * 100))
-                cmd.extend(["-volume", vol_arg])
-
-            cmd.append(str(file_path))
-
-            log.debug(f"Playing audio with {player['cmd']}: {' '.join(cmd)}")
-
-            # Run the command with timeout (blocking in background thread)
-            result = subprocess.run(
-                cmd,
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.PIPE,
-                timeout=10,  # 10 second timeout
-                check=False,
-            )
-
-            if result.returncode == 0:
-                log.debug(f"Successfully played audio with {player['cmd']}")
-                return True
-            else:
-                log.debug(
-                    f"{player['cmd']} failed with return code {result.returncode}"
-                )
-                if result.stderr:
-                    stderr = result.stderr.decode().strip()
-                    if stderr:
-                        log.debug(f"{player['cmd']} stderr: {stderr}")
-
-        except subprocess.TimeoutExpired:
-            log.warning(f"Audio playback with {player['cmd']} timed out")
-        except Exception as e:
-            log.debug(f"Failed to play audio with {player['cmd']}: {e}")
-
-    return False
 
 
 def ensure_playback_thread():
@@ -411,18 +135,10 @@ def set_volume(volume: float):
 def stop_audio():
     """Stop audio playback and clear queue."""
     # Stop any running subprocess audio players
-    try:
-        subprocess.run(["pkill", "-f", "paplay"], capture_output=True, timeout=2)
-        subprocess.run(["pkill", "-f", "ffplay"], capture_output=True, timeout=2)
-    except Exception:
-        pass
+    stop_system_audio()
 
     # Stop sounddevice if available
-    if has_audio_imports:
-        try:
-            sd.stop()
-        except Exception:
-            pass
+    stop_sounddevice_audio()
 
     # Clear queue
     while not audio_queue.empty():
@@ -433,31 +149,6 @@ def stop_audio():
             break
 
 
-def convert_audio_to_float32(data: Any) -> Any:
-    """Convert audio data to float32 format for consistent processing.
-
-    Args:
-        data: Audio data as numpy array
-
-    Returns:
-        Audio data converted to float32 format
-    """
-    if not has_audio_imports:
-        return data
-
-    # Convert to float32 for consistent processing
-    if data.dtype != np.float32:
-        if data.dtype.kind == "i":  # integer
-            data = data.astype(np.float32) / np.iinfo(data.dtype).max
-        elif data.dtype.kind == "f":  # floating point
-            # Normalize to [-1, 1] if needed
-            if np.max(np.abs(data)) > 1.0:
-                data = data / np.max(np.abs(data))
-            data = data.astype(np.float32)
-
-    return data
-
-
 def play_audio_data(data: Any, sample_rate: int, block: bool = False):
     """Play audio data directly (uses sounddevice as fallback).
 
@@ -466,24 +157,25 @@ def play_audio_data(data: Any, sample_rate: int, block: bool = False):
         sample_rate: Sample rate of the audio
         block: If True, wait for audio to finish playing
     """
-    if not has_audio_imports:
+    if not is_audio_available():
         log.debug("Audio not available, skipping playback")
         return
 
     try:
         # Convert to float32 for consistent processing
-        data = convert_audio_to_float32(data)
+        if is_sounddevice_available():
+            data = convert_audio_to_float32(data)
 
-        # Get output device for sample rate
-        try:
-            _, device_sr = get_output_device()
-            # Resample if needed
-            if sample_rate != device_sr:
-                data = _resample_audio(data, sample_rate, device_sr)
-                sample_rate = device_sr
-        except RuntimeError as e:
-            log.error(f"Device error: {e}")
-            return
+            # Get output device for sample rate
+            try:
+                _, device_sr = get_output_device()
+                # Resample if needed
+                if sample_rate != device_sr:
+                    data = resample_audio(data, sample_rate, device_sr)
+                    sample_rate = device_sr
+            except RuntimeError as e:
+                log.error(f"Device error: {e}")
+                return
 
         # Ensure playback thread is running
         ensure_playback_thread()
@@ -510,15 +202,22 @@ def play_sound_file(file_path: Path, block: bool = False):
         return
 
     # Always use the background thread system for consistent non-blocking behavior
-    if not has_audio_imports:
+    if not is_audio_available():
         log.warning("No audio playback methods available")
         return
 
     try:
         # Load the audio file and queue it for background playback
         if file_path.suffix.lower() == ".wav":
-            sample_rate, data = wavfile.read(file_path)
-            play_audio_data(data, sample_rate, block)
+            if is_sounddevice_available():
+                wav_data = load_wav_file(file_path)
+                if wav_data:
+                    sample_rate, data = wav_data
+                    play_audio_data(data, sample_rate, block)
+                else:
+                    log.error(f"Failed to load WAV file: {file_path}")
+            else:
+                log.warning("WAV file playback requires sounddevice libraries")
         elif file_path.suffix.lower() == ".mp3":
             # For MP3 files, we'd need additional libraries like pydub
             log.warning("MP3 files not directly supported, need to convert to WAV")
@@ -613,7 +312,7 @@ def wait_for_audio():
     time.sleep(0.1)
 
     # For sounddevice fallback
-    if has_audio_imports and playback_thread and playback_thread.is_alive():
+    if is_sounddevice_available() and playback_thread and playback_thread.is_alive():
         try:
             audio_queue.join()
         except Exception as e:
@@ -622,6 +321,8 @@ def wait_for_audio():
 
 def print_bell():
     """Ring the terminal bell or play ding sound if available."""
+    import sys
+
     # Terminal bell
     sys.stdout.write("\a")
     sys.stdout.flush()

--- a/gptme/util/sound.py
+++ b/gptme/util/sound.py
@@ -8,6 +8,7 @@ import logging
 import os
 import platform as platform_module
 import queue
+import shutil
 import subprocess
 import sys
 import threading
@@ -59,24 +60,11 @@ def is_audio_available() -> bool:
     """Check if audio playback is available via system tools or sounddevice."""
     # Check if any system audio player is available
     for player in AUDIO_PLAYERS:
-        if _check_command_available(player["cmd"]):
+        if shutil.which(player["cmd"]):
             return True
 
     # Fall back to checking sounddevice
     return has_audio_imports
-
-
-def _check_command_available(cmd: str) -> bool:
-    """Check if a command is available in the system PATH."""
-    try:
-        subprocess.run([cmd, "--help"], capture_output=True, timeout=2, check=False)
-        return True
-    except (
-        subprocess.TimeoutExpired,
-        subprocess.CalledProcessError,
-        FileNotFoundError,
-    ):
-        return False
 
 
 def _check_device_override(devices) -> tuple[int, int] | None:
@@ -355,7 +343,7 @@ def _play_with_system_command_blocking(file_path: Path, volume: float = 1.0) -> 
         True if successfully played, False if all system players failed
     """
     for player in AUDIO_PLAYERS:
-        if not _check_command_available(player["cmd"]):
+        if not shutil.which(player["cmd"]):
             continue
 
         try:


### PR DESCRIPTION
- Replace blocking system command calls with background thread processing
- Use paplay/ffplay system commands to avoid PortAudio reliability issues
- Maintain TTS interruption and queue functionality
- Add proper fallback from system commands to sounddevice
- Fix UI blocking on ding sound (1.5s → 0.001s)
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> This PR resolves audio blocking and timeout issues by using system commands for playback and improving sounddevice handling, ensuring non-blocking UI and maintaining TTS functionality.
> 
>   - **Behavior**:
>     - Replaces blocking system command calls with background thread processing in `sound.py`.
>     - Uses `paplay` and `ffplay` system commands in `_sound_cmd.py` to avoid PortAudio issues.
>     - Maintains TTS interruption and queue functionality in `sound.py`.
>     - Adds fallback from system commands to `sounddevice` in `sound.py`.
>     - Fixes UI blocking on ding sound from 1.5s to 0.001s in `sound.py`.
>   - **Functions**:
>     - Adds `is_cmd_audio_available()`, `play_with_system_command_blocking()`, and `stop_system_audio()` in `_sound_cmd.py`.
>     - Adds `is_sounddevice_available()`, `play_with_sounddevice()`, and `stop_sounddevice_audio()` in `_sound_sounddevice.py`.
>   - **Misc**:
>     - Refactors audio playback logic into `_sound_cmd.py` and `_sound_sounddevice.py` for modularity.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for c8f5374dfc0f190395fc20eb6bcf9511c7ac48f1. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->