### PR TITLE
feat: Add AI/ML API provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ You can find more [Demos][docs-demos] and [Examples][docs-examples] in the [docu
 - 🔄 Self-correcting
   - Output is fed back to the assistant, allowing it to respond and self-correct.
 - 🤖 Support for several LLM [providers][docs-providers]
-  - Use OpenAI, Anthropic, OpenRouter, or serve locally with `llama.cpp`
+  - Use OpenAI, Anthropic, OpenRouter, AI/ML API, or serve locally with `llama.cpp`
 - 🌐 Web UI and REST API
   - Modern web interface at [chat.gptme.org](https://chat.gptme.org) ([gptme-webui])
   - Simple built-in web UI included in the Python package

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -35,6 +35,7 @@ Here is an example:
     OPENAI_API_KEY = ""
     ANTHROPIC_API_KEY = ""
     OPENROUTER_API_KEY = ""
+    AIML_API_KEY = ""
     XAI_API_KEY = ""
     GEMINI_API_KEY = ""
     GROQ_API_KEY = ""

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -1,7 +1,7 @@
 Providers
 =========
 
-We support LLMs from several providers, including OpenAI, Anthropic, OpenRouter, Deepseek, Azure, and any OpenAI-compatible server (e.g. ``ollama``, ``llama-cpp-python``).
+We support LLMs from several providers, including OpenAI, Anthropic, OpenRouter, AI/ML API, Deepseek, Azure, and any OpenAI-compatible server (e.g. ``ollama``, ``llama-cpp-python``).
 
 You can find our model recommendations on the :doc:`evals` page.
 
@@ -12,6 +12,7 @@ To select a provider and model, run ``gptme`` with the ``-m``/``--model`` flag s
     gptme "hello" -m openai/gpt-5
     gptme "hello" -m anthropic  # will use provider default
     gptme "hello" -m openrouter/x-ai/grok-4
+    gptme "hello" -m aimlapi/openai/gpt-4o-mini
     gptme "hello" -m deepseek/deepseek-reasoner
     gptme "hello" -m gemini/gemini-2.5-flash
     gptme "hello" -m groq/llama-3.3-70b-versatile
@@ -27,6 +28,7 @@ Use the ``[env]`` section in the :ref:`global-config` file to store API keys usi
 - ``OPENAI_API_KEY="your-api-key"``
 - ``ANTHROPIC_API_KEY="your-api-key"``
 - ``OPENROUTER_API_KEY="your-api-key"``
+- ``AIML_API_KEY="your-api-key"``
 - ``GEMINI_API_KEY="your-api-key"``
 - ``XAI_API_KEY="your-api-key"``
 - ``GROQ_API_KEY="your-api-key"``

--- a/gptme/llm/__init__.py
+++ b/gptme/llm/__init__.py
@@ -1,4 +1,5 @@
 import logging
+import re
 import shutil
 import sys
 import time
@@ -289,6 +290,7 @@ def list_available_providers() -> list[tuple[Provider, str]]:
         ("openai", "OPENAI_API_KEY"),
         ("anthropic", "ANTHROPIC_API_KEY"),
         ("openrouter", "OPENROUTER_API_KEY"),
+        ("aimlapi", "AIML_API_KEY"),
         ("gemini", "GEMINI_API_KEY"),
         ("groq", "GROQ_API_KEY"),
         ("xai", "XAI_API_KEY"),
@@ -324,6 +326,8 @@ def get_model_from_api_key(api_key: str) -> tuple[str, Provider, str] | None:
         return api_key, "anthropic", "ANTHROPIC_API_KEY"
     elif api_key.startswith("sk-or-"):
         return api_key, "openrouter", "OPENROUTER_API_KEY"
+    elif api_key.startswith("sk-aiml-") or re.fullmatch(r"[0-9a-fA-F]{32}", api_key):
+        return api_key, "aimlapi", "AIML_API_KEY"
     elif api_key.startswith("sk-"):
         return api_key, "openai", "OPENAI_API_KEY"
 

--- a/gptme/llm/models.py
+++ b/gptme/llm/models.py
@@ -20,6 +20,7 @@ Provider = Literal[
     "anthropic",
     "azure",
     "openrouter",
+    "aimlapi",
     "gemini",
     "groq",
     "xai",
@@ -33,6 +34,7 @@ PROVIDERS_OPENAI = [
     "openai",
     "azure",
     "openrouter",
+    "aimlapi",
     "gemini",
     "xai",
     "groq",
@@ -307,6 +309,7 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
             "supports_vision": True,
         },
     },
+    "aimlapi": {},
     "nvidia": {},
     "azure": {},
     "local": {},
@@ -376,6 +379,8 @@ def get_recommended_model(provider: Provider) -> str:  # pragma: no cover
         return "gpt-5"
     elif provider == "openrouter":
         return "meta-llama/llama-3.1-405b-instruct"
+    elif provider == "aimlapi":
+        return "openai/gpt-4o-mini"
     elif provider == "gemini":
         return "gemini-2.5-pro"
     elif provider == "anthropic":
@@ -389,6 +394,8 @@ def get_summary_model(provider: Provider) -> str:  # pragma: no cover
         return "gpt-5-mini"
     elif provider == "openrouter":
         return "meta-llama/llama-3.1-8b-instruct"
+    elif provider == "aimlapi":
+        return "openai/gpt-4o-mini"
     elif provider == "gemini":
         return "gemini-2.5-flash"
     elif provider == "anthropic":
@@ -408,7 +415,7 @@ def _get_models_for_provider(
     models_to_show = []
 
     # Try dynamic fetching first for supported providers
-    if dynamic_fetch and provider == "openrouter":
+    if dynamic_fetch and provider in ["openrouter", "aimlapi"]:
         try:
             dynamic_models = get_available_models(provider)
             models_to_show = dynamic_models

--- a/gptme/setup.py
+++ b/gptme/setup.py
@@ -604,6 +604,7 @@ def ask_for_api_key():  # pragma: no cover
     providers_table.add_row("Anthropic", "https://console.anthropic.com/settings/keys")
     providers_table.add_row("OpenRouter", "https://openrouter.ai/settings/keys")
     providers_table.add_row("Gemini", "https://aistudio.google.com/app/apikey")
+    providers_table.add_row("AI/ML API", "https://aimlapi.com/")
 
     console.print()
     console.print(providers_table)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,7 @@ def has_api_key() -> bool:
         config.get_env("OPENAI_API_KEY", "")
         or config.get_env("ANTHROPIC_API_KEY", "")
         or config.get_env("OPENROUTER_API_KEY", "")
+        or config.get_env("AIML_API_KEY", "")
         or config.get_env("DEEPSEEK_API_KEY", "")
     )
 

--- a/tests/test_llm_aimlapi.py
+++ b/tests/test_llm_aimlapi.py
@@ -1,0 +1,27 @@
+from gptme.llm import get_model_from_api_key, list_available_providers
+from gptme.llm.llm_openai import extra_headers
+
+
+def test_get_model_from_api_key_detects_aimlapi():
+    sample_key = "3aaa9c515e894402a47c136ee3dd8f5a"
+    api_key, provider, env_var = get_model_from_api_key(sample_key)
+    assert api_key == sample_key
+    assert provider == "aimlapi"
+    assert env_var == "AIML_API_KEY"
+
+
+def test_list_available_providers_includes_aimlapi(monkeypatch):
+    monkeypatch.setenv("AIML_API_KEY", "test-key")
+    providers = list_available_providers()
+    assert ("aimlapi", "AIML_API_KEY") in providers
+    # ensure no side-effect persists
+    monkeypatch.delenv("AIML_API_KEY", raising=False)
+
+
+def test_extra_headers_includes_defaults():
+    expected = {
+        "HTTP-Referer": "https://github.com/gptme/gptme",
+        "X-Title": "gptme",
+    }
+    assert extra_headers("aimlapi") == expected
+    assert extra_headers("openrouter") == expected


### PR DESCRIPTION
from: https://github.com/gptme/gptme/issues/548

Adds **AI/ML API** as a new provider (`aimlapi`) with:

* Provider detection via `AIML_API_KEY`
* OpenAI-compatible client (`https://api.aimlapi.com/v1`)
* Dynamic model listing from `/v1/models`
* Extra headers (`HTTP-Referer`, `X-Title`)
* Docs update (config + providers)
* Tests for detection, headers, and provider listing

---

### How to test

```bash
export AIML_API_KEY=<xxxxxx>

gptme "hello" -m aimlapi/openai/gpt-4o-mini
pytest -k aimlapi
```

---

### Notes

* **No breaking changes to other providers**
  * OpenRouter logic is unchanged.
  * Extra headers are now applied to both OpenRouter and AI/ML API.
  * Dynamic model listing, previously only for OpenRouter, now also supports AI/ML API.