### PR TITLE
feat: implement get_model TODO and fix critical telemetry bug

### DIFF
--- a/gptme/llm/models.py
+++ b/gptme/llm/models.py
@@ -306,6 +306,20 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
             "price_output": 0.3,
             "supports_vision": True,
         },
+        "moonshotai/kimi-k2": {
+            "context": 262_144,
+            "max_output": 262_144,
+            "price_input": 0.38,
+            "price_output": 1.52,
+            "supports_vision": True,
+        },
+        "moonshotai/kimi-k2-0905": {
+            "context": 262_144,
+            "max_output": 262_144,
+            "price_input": 0.38,
+            "price_output": 1.52,
+            "supports_vision": True,
+        },
     },
     "nvidia": {},
     "azure": {},
@@ -351,24 +365,58 @@ def get_model(model: str) -> ModelMeta:
         model = get_recommended_model(provider)
         return get_model(f"{provider}/{model}")
 
+    # Check if model has provider/model format
     if any(f"{provider}/" in model for provider in PROVIDERS):
-        provider, model = cast(tuple[Provider, str], model.split("/", 1))
-        if provider not in MODELS or model not in MODELS[provider]:
+        provider_str, model_name = model.split("/", 1)
+
+        # Check if provider is known
+        if provider_str in PROVIDERS:
+            provider = cast(Provider, provider_str)
+
+            # First try static MODELS dict for performance
+            if provider in MODELS and model_name in MODELS[provider]:
+                return ModelMeta(provider, model_name, **MODELS[provider][model_name])
+
+            # For providers that support dynamic fetching, use _get_models_for_provider
+            if provider == "openrouter":
+                try:
+                    models = _get_models_for_provider(provider, dynamic_fetch=True)
+                    for model_meta in models:
+                        if model_meta.model == model_name:
+                            return model_meta
+                except Exception:
+                    # Fall back to unknown model metadata
+                    pass
+
+            # Unknown model, use fallback metadata
             if provider not in ["openrouter", "local"]:
                 log_warn_once(
-                    f"Unknown model: using fallback metadata for {provider}/{model}"
+                    f"Unknown model: using fallback metadata for {provider}/{model_name}"
                 )
-            return ModelMeta(provider, model, context=128_000)
-    else:
-        # try to find model in all providers
-        for provider in MODELS:
-            if model in MODELS[provider]:
-                break
+            return ModelMeta(provider, model_name, context=128_000)
         else:
+            # Unknown provider
             logger.warning(f"Unknown model {model}, using fallback metadata")
             return ModelMeta(provider="unknown", model=model, context=128_000)
+    else:
+        # try to find model in all providers, starting with static models
+        for provider in cast(list[Provider], MODELS.keys()):
+            if model in MODELS[provider]:
+                return ModelMeta(provider, model, **MODELS[provider][model])
 
-    return ModelMeta(provider, model, **MODELS[provider][model])
+        # For model name without provider, also try dynamic fetching for openrouter
+        try:
+            openrouter_models = _get_models_for_provider(
+                "openrouter", dynamic_fetch=True
+            )
+            for model_meta in openrouter_models:
+                if model_meta.model == model:
+                    return model_meta
+        except Exception:
+            pass
+
+        logger.warning(f"Unknown model {model}, using fallback metadata")
+        return ModelMeta(provider="unknown", model=model, context=128_000)
 
 
 def get_recommended_model(provider: Provider) -> str:  # pragma: no cover

--- a/tests/test_llm_models.py
+++ b/tests/test_llm_models.py
@@ -1,0 +1,116 @@
+from unittest.mock import patch
+
+from gptme.llm.models import (
+    get_model,
+    _get_models_for_provider,
+    ModelMeta,
+)
+
+
+def test_get_static_model():
+    """Test getting a model that exists in static MODELS dict."""
+    model = get_model("openai/gpt-4o")
+    assert model.provider == "openai"
+    assert model.model == "gpt-4o"
+    assert model.context > 0
+
+
+def test_get_model_provider_only():
+    """Test getting recommended model when only provider is given."""
+    model = get_model("openai")
+    assert model.provider == "openai"
+    assert model.model == "gpt-5"  # current recommended model
+
+
+def test_get_model_unknown_provider_model():
+    """Test fallback for unknown provider/model combination."""
+    model = get_model("unknown-provider/unknown-model")
+    assert model.provider == "unknown"
+    assert model.model == "unknown-provider/unknown-model"
+    assert model.context == 128_000  # fallback context
+
+
+def test_get_model_by_name_only():
+    """Test getting model by name only (searches all providers)."""
+    model = get_model("gpt-4o")
+    assert model.provider == "openai"
+    assert model.model == "gpt-4o"
+
+
+def test_get_model_unknown_name_only():
+    """Test fallback for unknown model name without provider."""
+    model = get_model("completely-unknown-model")
+    assert model.provider == "unknown"
+    assert model.model == "completely-unknown-model"
+    assert model.context == 128_000
+
+
+@patch("gptme.llm.models._get_models_for_provider")
+def test_get_model_dynamic_fetch_success(mock_get_models):
+    """Test successful dynamic model fetching for OpenRouter."""
+    # Mock a dynamic model
+    dynamic_model = ModelMeta(
+        provider="openrouter",
+        model="test-dynamic-model",
+        context=100_000,
+        price_input=1.0,
+        price_output=2.0,
+    )
+    mock_get_models.return_value = [dynamic_model]
+
+    model = get_model("openrouter/test-dynamic-model")
+    assert model.provider == "openrouter"
+    assert model.model == "test-dynamic-model"
+    assert model.context == 100_000
+    assert model.price_input == 1.0
+
+    mock_get_models.assert_called_once_with("openrouter", dynamic_fetch=True)
+
+
+@patch("gptme.llm.models._get_models_for_provider")
+def test_get_model_dynamic_fetch_failure(mock_get_models):
+    """Test fallback when dynamic model fetching fails."""
+    mock_get_models.side_effect = Exception("API error")
+
+    model = get_model("openrouter/test-dynamic-model")
+    assert model.provider == "openrouter"
+    assert model.model == "test-dynamic-model"
+    assert model.context == 128_000  # fallback
+
+
+@patch("gptme.llm.models._get_models_for_provider")
+def test_get_model_dynamic_fetch_model_not_found(mock_get_models):
+    """Test fallback when dynamic model is not found in results."""
+    other_model = ModelMeta(provider="openrouter", model="other-model", context=100_000)
+    mock_get_models.return_value = [other_model]
+
+    model = get_model("openrouter/test-dynamic-model")
+    assert model.provider == "openrouter"
+    assert model.model == "test-dynamic-model"
+    assert model.context == 128_000  # fallback
+
+
+def test_get_models_for_provider():
+    """Test getting models for a specific provider."""
+    # Test with static models only
+    openai_models = _get_models_for_provider("openai", dynamic_fetch=False)
+    assert len(openai_models) > 0
+    assert all(m.provider == "openai" for m in openai_models)
+
+
+@patch("gptme.llm.models._get_models_for_provider")
+def test_get_model_name_only_with_dynamic_fetch(mock_get_models):
+    """Test model lookup by name only with dynamic fetching from OpenRouter."""
+    # Mock OpenRouter dynamic model
+    dynamic_model = ModelMeta(
+        provider="openrouter", model="test-model", context=100_000
+    )
+    mock_get_models.return_value = [dynamic_model]
+
+    model = get_model("test-model")
+    assert model.provider == "openrouter"
+    assert model.model == "test-model"
+    assert model.context == 100_000
+
+    # Should have tried OpenRouter dynamic fetch
+    mock_get_models.assert_called_with("openrouter", dynamic_fetch=True)


### PR DESCRIPTION
- Enhanced get_model() to use _get_models_for_provider for dynamic model discovery
  - Integrated with existing dynamic fetching infrastructure
  - Added proper fallback handling for unknown providers/models
  - Improved parsing logic to handle provider/model formats correctly

- Fixed critical telemetry bug in OpenAI LLM where stripped model names caused warnings
  - Changed _record_usage calls to pass full model name instead of base_model
  - Resolves "Unknown model x-ai/grok-4-fast:free" warnings during evals
  - Makes OpenAI implementation consistent with Anthropic

- Improved reasoning model detection using metadata instead of hardcoded checks
  - Replaced _is_reasoner() function with model_meta.supports_reasoning
  - Updated extra_body() to use ModelMeta parameter for better reasoning support
  - Enhanced message preparation logic for reasoning models

- Added comprehensive test suite with 10 focused tests
  - Tests static/dynamic model lookup, provider-only requests
  - Validates error handling and fallback scenarios
  - Covers new dynamic model fetching integration

All changes maintain backwards compatibility while significantly enhancing model discovery capabilities and fixing evaluation warnings.