### PR TITLE
fix: prevent premature code block closure during streaming with nested blocks

### DIFF
--- a/gptme/llm/__init__.py
+++ b/gptme/llm/__init__.py
@@ -184,9 +184,10 @@ def _reply_stream(
             if break_on_tooluse and char == "\n":
                 # TODO: make this more robust/general, maybe with a callback that runs on each char/chunk
                 # pause inference on finished code-block, letting user run the command before continuing
+                # Use streaming=True to require blank line after code blocks during streaming
                 tooluses = [
                     tooluse
-                    for tooluse in ToolUse.iter_from_content(output)
+                    for tooluse in ToolUse.iter_from_content(output, streaming=True)
                     if tooluse.is_runnable
                 ]
                 if tooluses:

--- a/tests/data/example-interrupted.txt
+++ b/tests/data/example-interrupted.txt
@@ -1,0 +1,32 @@
+<think>
+Perfect! The commit was successful. Now let me write a journal entry about what we accomplished today.
+</think>
+
+Excellent! The commit was successful. Let me create a journal entry about this work:
+
+```append journal/2025-10-01.md
+# Journal Entry: 2025-10-01
+
+## Roam Tasks Script - Context from Personal Notes
+
+Today I created a powerful new tool to help understand the user's current TODO items and priorities from their Roam Research backup.
+
+### Technical Implementation
+
+**Created `scripts/roam-tasks.py`:**
+- Parses Roam JSON export with full block structure and UIDs (23,300 blocks indexed)
+- Extracts TODO items with complete context hierarchy
+- Resolves block references recursively (up to depth 2)
+- Multiple filtering options (by content, by page)
+- Flexible sorting (by edited time, creation date, or page)
+- Clean, LLM-consumable output format
+
+**Key Features:**
+- **Parent Context**: Shows up to 5 levels of parent blocks to understand where TODO sits
+- **Child Blocks**: Includes all sub-tasks and notes under the TODO
+- **Block References**: Automatically resolves `((uid))` references and shows their content
+- **Timestamps**: Shows creation and last edit time for priority assessment
+- **Smart Filtering**: Regex-based content and page filtering
+
+**Output Format:**
+```

--- a/tests/test_codeblock.py
+++ b/tests/test_codeblock.py
@@ -152,3 +152,96 @@ echo "second"
     assert codeblocks[1].lang == "bash"
     assert codeblocks[1].content == 'echo "second"'
     assert codeblocks[1].start == 3
+
+
+def test_extract_codeblocks_streaming_interrupted():
+    """
+    Test case based on real interruption during streaming.
+
+    Reproduces issue where bare ``` after descriptive text was incorrectly
+    treated as closing delimiter instead of opening a nested code block.
+    """
+    # Read the actual interrupted example
+    with open("example-interrupted.txt") as f:
+        content = f.read()
+
+    # Extract just the markdown part (after "create a journal entry")
+    # This should parse as a single append block with nested code blocks inside
+    start_marker = "```append journal/2025-10-01.md"
+    start_idx = content.find(start_marker)
+    assert start_idx != -1, "Could not find append block in example"
+
+    markdown = content[start_idx:]
+
+    # Should extract one append block
+    blocks = list(_extract_codeblocks(markdown))
+    assert len(blocks) == 1, f"Expected 1 block, got {len(blocks)}"
+    assert blocks[0].lang == "append journal/2025-10-01.md"
+
+    # The content should include all the nested parts
+    content_text = blocks[0].content
+    assert "**Output Format:**" in content_text
+    assert "Journal Entry" in content_text
+
+
+def test_extract_codeblocks_nested_without_lang():
+    """
+    Test that nested code blocks without language tags are handled correctly.
+
+    This reproduces the streaming interruption issue where ``` after descriptive
+    text should open a nested block, not close the outer block.
+    """
+    # Build the test case programmatically to avoid triggering the bug
+    fence = "```"
+
+    # This is what should be parsed correctly:
+    # An append block containing text followed by a nested code block example
+    markdown = f"""{fence}append journal/entry.md
+# Journal Entry
+
+**Output Format:**
+{fence}
+key: value
+{fence}
+
+Done!
+{fence}"""
+
+    blocks = list(_extract_codeblocks(markdown))
+
+    # Should extract one append block
+    assert len(blocks) == 1, f"Expected 1 block, got {len(blocks)}"
+    assert blocks[0].lang == "append journal/entry.md"
+
+    # The content should include ALL parts including the nested block and "Done!"
+    content = blocks[0].content
+    assert "**Output Format:**" in content
+    assert "key: value" in content
+    assert (
+        "Done!" in content
+    ), "Content was cut off prematurely - nested block was treated as closing delimiter"
+
+
+def test_extract_codeblocks_incomplete_streaming():
+    """
+    Test parsing incomplete content as would happen during streaming.
+
+    When content ends with ``` after descriptive text, but more content
+    is expected, the parser should not extract an incomplete block.
+    """
+    fence = "```"
+
+    # Simulate streaming: content stops mid-block after a bare ```
+    incomplete_markdown = f"""{fence}append journal/entry.md
+# Journal Entry
+
+**Output Format:**
+{fence}"""
+
+    # During streaming, this appears incomplete - we shouldn't extract it yet
+    # The ``` after "**Output Format:**" should be treated as opening a nested block,
+    # not closing the outer block, because the prev line suggests an example follows
+    blocks = list(_extract_codeblocks(incomplete_markdown))
+
+    # Should not extract incomplete blocks
+    assert len(blocks) == 0, "Should not extract incomplete block during streaming"

--- a/tests/test_codeblock.py
+++ b/tests/test_codeblock.py
@@ -239,9 +239,12 @@ def test_extract_codeblocks_incomplete_streaming():
 {fence}"""
 
     # During streaming, this appears incomplete - we shouldn't extract it yet
-    # The ``` after "**Output Format:**" should be treated as opening a nested block,
-    # not closing the outer block, because the prev line suggests an example follows
-    blocks = list(_extract_codeblocks(incomplete_markdown))
+    # With streaming=True, requires blank line after ``` to confirm closure
+    blocks = list(_extract_codeblocks(incomplete_markdown, streaming=True))
 
-    # Should not extract incomplete blocks
+    # Should not extract incomplete blocks during streaming
     assert len(blocks) == 0, "Should not extract incomplete block during streaming"
+
+    # But without streaming flag (completed message), should extract
+    blocks_complete = list(_extract_codeblocks(incomplete_markdown, streaming=False))
+    assert len(blocks_complete) == 1, "Should extract when message is complete"

--- a/tests/test_codeblock.py
+++ b/tests/test_codeblock.py
@@ -161,8 +161,9 @@ def test_extract_codeblocks_streaming_interrupted():
     Reproduces issue where bare ``` after descriptive text was incorrectly
     treated as closing delimiter instead of opening a nested code block.
     """
-    # Read the actual interrupted example
-    with open("example-interrupted.txt") as f:
+    # Read the actual interrupted example relative to this test file
+    script_dir = __file__.rsplit("/", 1)[0]
+    with open(f"{script_dir}/data/example-interrupted.txt") as f:
         content = f.read()
 
     # Extract just the markdown part (after "create a journal entry")


### PR DESCRIPTION
## Problem

When streaming content that contains nested code blocks without language tags, the parser incorrectly treats bare ``` after descriptive text as a closing delimiter instead of recognizing it as opening a nested block. This causes the streaming output to be interrupted prematurely.

## Solution

Adds context-aware heuristics to the code block parser:
- Primary check: if next line has content and is not a fence, treat ``` as opening
- Secondary check: if no next line (streaming) but previous line suggests example (ends with colon, has bold markdown, etc.), treat as opening to avoid premature closure
- Otherwise: treat as closing (normal case)

## Changes

- Enhanced `_extract_codeblocks()` in `gptme/codeblock.py` with better opening/closing detection
- Added comprehensive tests for nested blocks, streaming scenarios, and edge cases
- All existing tests still pass

## Testing

Added tests that reproduce the streaming interruption issue and verify the fix works correctly for:
- Nested code blocks without language tags
- Incomplete streaming content
- Complete content with nested blocks
- Example from real interrupted output

Fixes the issue described in the example-interrupted.txt case.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes premature code block closure during streaming by adding context-aware heuristics to `_extract_codeblocks()` in `codeblock.py`, with comprehensive tests added.
> 
>   - **Behavior**:
>     - Fixes premature closure of code blocks during streaming when encountering nested blocks without language tags.
>     - Adds context-aware heuristics in `_extract_codeblocks()` in `codeblock.py` to determine if ` ``` ` is opening or closing.
>     - Uses streaming flag to require blank line after ` ``` ` for block closure during streaming.
>   - **Functions**:
>     - Updates `iter_from_markdown()` in `codeblock.py` and `base.py` to support streaming flag.
>     - Updates `iter_from_content()` in `base.py` to handle streaming flag.
>   - **Testing**:
>     - Adds tests in `test_codeblock.py` for nested blocks, streaming scenarios, and edge cases.
>     - Includes real-world example in `example-interrupted.txt` to verify fix.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for c7026fe97997dad281ad04526a47ad174d7236ae. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->