### PR TITLE
feat(telemetry): add agent name and interactive mode metadata

### DIFF
--- a/gptme/cli.py
+++ b/gptme/cli.py
@@ -175,9 +175,6 @@ def main(
     # init logging
     init_logging(verbose)
 
-    # init telemetry
-    init_telemetry(service_name="gptme-cli")
-
     if not interactive:
         no_confirm = True
 
@@ -266,6 +263,15 @@ def main(
         agent_path=Path(agent_path) if agent_path else None,
     )
     assert config.chat and config.chat.tool_format
+
+    # init telemetry with agent name and interactive mode
+    agent_config = config.chat.agent_config
+    agent_name = agent_config.name if agent_config else None
+    init_telemetry(
+        service_name="gptme-cli",
+        agent_name=agent_name,
+        interactive=interactive,
+    )
 
     # early init tools to generate system prompt
     # We pass the tool_allowlist CLI argument. If it's not provided, init_tools

--- a/gptme/server/cli.py
+++ b/gptme/server/cli.py
@@ -73,8 +73,12 @@ def serve(
         tool_allowlist=None if tools is None else tools.split(","),
     )
 
-    # Initialize telemetry
-    init_telemetry(service_name="gptme-server", enable_flask_instrumentation=True)
+    # Initialize telemetry (server is API/WebUI driven, not CLI interactive)
+    init_telemetry(
+        service_name="gptme-server",
+        enable_flask_instrumentation=True,
+        interactive=None,
+    )
 
     click.echo("Initialization complete, starting server")
 

--- a/gptme/telemetry.py
+++ b/gptme/telemetry.py
@@ -39,8 +39,20 @@ def init_telemetry(
     enable_requests_instrumentation: bool = True,
     enable_openai_instrumentation: bool = True,
     enable_anthropic_instrumentation: bool = True,
+    agent_name: str | None = None,
+    interactive: bool | None = None,
 ) -> None:
-    """Initialize OpenTelemetry tracing and metrics."""
+    """Initialize OpenTelemetry tracing and metrics.
+
+    Args:
+        service_name: Name of the service for telemetry
+        enable_flask_instrumentation: Whether to auto-instrument Flask
+        enable_requests_instrumentation: Whether to auto-instrument requests library
+        enable_openai_instrumentation: Whether to auto-instrument OpenAI
+        enable_anthropic_instrumentation: Whether to auto-instrument Anthropic
+        agent_name: Name of the agent (from gptme.toml [agent].name)
+        interactive: Whether running in interactive mode (None = unknown, False = autonomous)
+    """
     try:
         _init(
             service_name=service_name,
@@ -48,6 +60,8 @@ def init_telemetry(
             enable_requests_instrumentation=enable_requests_instrumentation,
             enable_openai_instrumentation=enable_openai_instrumentation,
             enable_anthropic_instrumentation=enable_anthropic_instrumentation,
+            agent_name=agent_name,
+            interactive=interactive,
         )
     except ImportError:
         logger.warning(


### PR DESCRIPTION
## Summary

Adds configurable metadata to the telemetry system to track:
- **Agent name**: From `gptme.toml` `[agent].name` config
- **Interactive mode**: CLI operation mode (True/False/None)

## Changes

- Add `agent_name` and `interactive` parameters to `init_telemetry()`
- Update OpenTelemetry Resource attributes to include:
  - `agent.name`: Which agent (Bob, Alice, etc.) generated metrics
  - `agent.interactive`: Operation mode
    - `true`: Interactive CLI session
    - `false`: Non-interactive/autonomous operation  
    - Not set: Server/API mode or unknown
- Move CLI telemetry init after config load to access agent name
- Server passes `interactive=None` (API/WebUI driven, not CLI)

## Benefits

These metadata tags enable:
- Filtering metrics by agent (e.g., Bob vs Alice)
- Distinguishing interactive vs autonomous operation
- Separating CLI vs server telemetry
- Better understanding of agent behavior patterns

## Testing

- [x] Pre-commit checks pass (except pre-existing mypy errors in unrelated files)
- [x] Merge conflicts resolved with upstream changes
- [x] Code changes verified for correctness