### PR TITLE
feat(telemetry): add hostname to resource attributes

### DIFF
--- a/gptme/util/_telemetry.py
+++ b/gptme/util/_telemetry.py
@@ -117,6 +117,16 @@ def init_telemetry(
         # Initialize tracing with proper service name and additional metadata
         resource_attrs = {"service.name": service_name}
 
+        # Add hostname (standard OpenTelemetry attribute)
+        import socket
+
+        try:
+            hostname = socket.gethostname()
+            resource_attrs["host.name"] = hostname
+            logger.debug(f"Adding host.name to resource: {hostname}")
+        except Exception as e:
+            logger.warning(f"Failed to get hostname: {e}")
+
         # Add agent name if provided
         if agent_name:
             resource_attrs["agent.name"] = agent_name


### PR DESCRIPTION
## Summary

Adds hostname to telemetry resource attributes to identify which machine/VM metrics are coming from.

## Changes

- Collect hostname using `socket.gethostname()`
- Add as `host.name` (standard OpenTelemetry semantic convention)
- Gracefully handle hostname collection failures

## Benefits

- Identify metrics by machine/VM (e.g., bob-vm, server3, localhost)
- Essential for multi-host deployments
- Useful for agent VMs and distributed systems
- Follows OpenTelemetry standard conventions

## Context

This builds on PR #675 which added agent name and interactive mode metadata. Hostname completes the resource identification trinity:
- `agent.name`: Which agent (Bob, Alice, etc.)
- `agent.interactive`: Operation mode (interactive/autonomous/server)
- `host.name`: Which machine (bob-vm, erik-laptop, etc.)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds hostname to telemetry resource attributes in `_telemetry.py` for machine identification, following OpenTelemetry conventions.
> 
>   - **Behavior**:
>     - Adds hostname to telemetry resource attributes in `init_telemetry()` in `_telemetry.py` using `socket.gethostname()`.
>     - Adds `host.name` to resource attributes following OpenTelemetry semantic conventions.
>     - Handles hostname collection failures gracefully with logging.
>   - **Context**:
>     - Completes resource identification with `agent.name` and `agent.interactive` attributes.
>     - Essential for multi-host deployments and distributed systems.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 8dcfb56db5893fe9d8db4f1936646a7518deb2fc. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->