### PR TITLE
fix: validate auto_confirm type in PUT conversation endpoint (CWE-20)

### DIFF
--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -219,6 +219,20 @@ def api_conversation_put(conversation_id: str):
 
     req_json = flask.request.json or {}
 
+    # Validate auto_confirm type early, before any side effects (disk I/O).
+    # Reject strings/floats/etc. to avoid truthy coercion (e.g. "false" → 999).
+    auto_confirm = req_json.get("auto_confirm", False)
+    if type(auto_confirm) not in (bool, int):
+        return (
+            flask.jsonify(
+                {
+                    "error": "Invalid 'auto_confirm' value",
+                    "message": "'auto_confirm' must be a boolean or integer",
+                }
+            ),
+            400,
+        )
+
     # Create the log directory
     logdir.mkdir(parents=True)
 
@@ -276,24 +290,13 @@ def api_conversation_put(conversation_id: str):
     # Create a session for this conversation
     session = SessionManager.create_session(conversation_id)
 
-    # Validate auto_confirm type explicitly (bool OR int).
-    # Reject strings/floats/etc. to avoid truthy coercion (e.g. "false" → 999).
-    auto_confirm = req_json.get("auto_confirm", False)
-    if type(auto_confirm) not in (bool, int):
-        return (
-            flask.jsonify(
-                {
-                    "error": "Invalid 'auto_confirm' value",
-                    "message": "'auto_confirm' must be a boolean or integer",
-                }
-            ),
-            400,
-        )
+    # Apply auto_confirm setting (already type-validated above)
     if type(auto_confirm) is bool:
         if auto_confirm:
             session.auto_confirm_count = 999  # Essentially unlimited
     elif auto_confirm > 0:
         session.auto_confirm_count = auto_confirm
+    # int <= 0 is treated the same as omitting the field (no auto-confirm)
 
     return flask.jsonify(
         {"status": "ok", "conversation_id": conversation_id, "session_id": session.id}

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -276,9 +276,24 @@ def api_conversation_put(conversation_id: str):
     # Create a session for this conversation
     session = SessionManager.create_session(conversation_id)
 
-    # Check for auto_confirm parameter and set auto_confirm_count
-    if req_json and req_json.get("auto_confirm"):
-        session.auto_confirm_count = 999  # High number to essentially make it unlimited
+    # Validate auto_confirm type explicitly (bool OR int).
+    # Reject strings/floats/etc. to avoid truthy coercion (e.g. "false" → 999).
+    auto_confirm = req_json.get("auto_confirm", False)
+    if type(auto_confirm) not in (bool, int):
+        return (
+            flask.jsonify(
+                {
+                    "error": "Invalid 'auto_confirm' value",
+                    "message": "'auto_confirm' must be a boolean or integer",
+                }
+            ),
+            400,
+        )
+    if type(auto_confirm) is bool:
+        if auto_confirm:
+            session.auto_confirm_count = 999  # Essentially unlimited
+    elif auto_confirm > 0:
+        session.auto_confirm_count = auto_confirm
 
     return flask.jsonify(
         {"status": "ok", "conversation_id": conversation_id, "session_id": session.id}

--- a/tests/test_cwe20_auto_confirm_validation.py
+++ b/tests/test_cwe20_auto_confirm_validation.py
@@ -1,0 +1,90 @@
+"""Test for CWE-20: Improper input validation on auto_confirm parameter.
+
+The PUT /api/v2/conversations/<id> endpoint uses truthy coercion on the
+``auto_confirm`` JSON field: any truthy value (including the string "false")
+sets ``auto_confirm_count = 999``, enabling unlimited automatic tool execution
+without human review.
+
+The step endpoint (POST /api/v2/conversations/<id>/step) already has strict
+type validation (``type(auto_confirm) in (bool, int)``), but the PUT endpoint
+and the tool-confirm "auto" action lack equivalent checks.
+
+This test verifies that:
+1. String values like "false" are rejected (not coerced to truthy).
+2. Only bool and int types are accepted for auto_confirm.
+3. The tool-confirm "auto" count is type-validated as int.
+"""
+
+import random
+
+import pytest
+
+pytest.importorskip(
+    "flask", reason="flask not installed, install server extras (-E server)"
+)
+
+from flask.testing import FlaskClient  # fmt: skip
+
+pytestmark = [pytest.mark.timeout(10)]
+
+
+def _create_conversation(client: FlaskClient, auto_confirm=None):
+    """Create a V2 conversation, optionally passing auto_confirm."""
+    convname = f"test-cwe20-{random.randint(0, 10_000_000)}"
+    payload: dict = {"prompt": "You are an AI assistant for testing."}
+    if auto_confirm is not None:
+        payload["auto_confirm"] = auto_confirm
+    response = client.put(f"/api/v2/conversations/{convname}", json=payload)
+    return response, convname
+
+
+class TestAutoConfirmPutValidation:
+    """PUT /api/v2/conversations/<id> auto_confirm type validation."""
+
+    def test_string_false_rejected(self, client: FlaskClient):
+        """The string 'false' must NOT enable auto-confirm (truthy coercion bug)."""
+        resp, _ = _create_conversation(client, auto_confirm="false")
+        assert resp.status_code == 400, (
+            f"Expected 400 for auto_confirm='false', got {resp.status_code}. "
+            f"Truthy coercion would incorrectly set auto_confirm_count=999."
+        )
+
+    def test_string_true_rejected(self, client: FlaskClient):
+        """Strings should not be accepted for auto_confirm."""
+        resp, _ = _create_conversation(client, auto_confirm="true")
+        assert resp.status_code == 400
+
+    def test_dict_rejected(self, client: FlaskClient):
+        """Non-primitive types must be rejected."""
+        resp, _ = _create_conversation(client, auto_confirm={"nested": True})
+        assert resp.status_code == 400
+
+    def test_list_rejected(self, client: FlaskClient):
+        """List values must be rejected."""
+        resp, _ = _create_conversation(client, auto_confirm=[1, 2])
+        assert resp.status_code == 400
+
+    def test_float_rejected(self, client: FlaskClient):
+        """Floats must be rejected (only bool/int allowed)."""
+        resp, _ = _create_conversation(client, auto_confirm=1.5)
+        assert resp.status_code == 400
+
+    def test_bool_true_accepted(self, client: FlaskClient):
+        """Boolean True should be accepted."""
+        resp, _ = _create_conversation(client, auto_confirm=True)
+        assert resp.status_code == 200
+
+    def test_bool_false_accepted(self, client: FlaskClient):
+        """Boolean False should be accepted (no auto-confirm)."""
+        resp, _ = _create_conversation(client, auto_confirm=False)
+        assert resp.status_code == 200
+
+    def test_int_accepted(self, client: FlaskClient):
+        """Integer values should be accepted as auto_confirm_count."""
+        resp, _ = _create_conversation(client, auto_confirm=5)
+        assert resp.status_code == 200
+
+    def test_none_accepted(self, client: FlaskClient):
+        """Omitting auto_confirm should work (default: no auto-confirm)."""
+        resp, _ = _create_conversation(client)
+        assert resp.status_code == 200

--- a/tests/test_cwe20_auto_confirm_validation.py
+++ b/tests/test_cwe20_auto_confirm_validation.py
@@ -12,7 +12,6 @@ and the tool-confirm "auto" action lack equivalent checks.
 This test verifies that:
 1. String values like "false" are rejected (not coerced to truthy).
 2. Only bool and int types are accepted for auto_confirm.
-3. The tool-confirm "auto" count is type-validated as int.
 """
 
 import random


### PR DESCRIPTION
## Vulnerability Summary

**CWE-20 (Improper Input Validation)** — Medium severity

### Data Flow

```
HTTP PUT /api/v2/conversations/<id> request body
  → req_json.get("auto_confirm")
  → Python truthy coercion: if req_json.get("auto_confirm"):
  → session.auto_confirm_count = 999
  → unlimited automatic tool execution (including shell) without human review
```

### Problem

In `gptme/server/api_v2.py` line 280, the PUT conversation endpoint used Python truthy coercion to evaluate the `auto_confirm` field:

```python
if req_json and req_json.get("auto_confirm"):
    session.auto_confirm_count = 999
```

Any truthy JSON value — including the string `"false"`, dicts like `{"nested": true}`, lists like `[1]`, or floats — would silently enable 999 automatic tool executions without human review.

This is inconsistent with the **step endpoint** (`POST /step` in `api_v2_sessions.py:239-251`) which already has strict `type(auto_confirm) in (bool, int)` validation and correctly returns HTTP 400 for invalid types.

### Impact

An API caller sending `"auto_confirm": "false"` (string, not boolean) would **unintentionally enable** 999 automatic tool executions — the opposite of the intended behavior. In server mode, tool execution includes shell commands. While endpoints are behind `@require_auth`, authentication is disabled in localhost mode (`is_local_host()`), the default development configuration.

---

## Fix Description

Applied the same strict type validation pattern already used in the step endpoint:

1. **Reject** any `auto_confirm` value that is not `bool` or `int` with HTTP 400 and a descriptive error message
2. **`bool(True)`**: set `auto_confirm_count = 999` (preserving existing unlimited semantics)
3. **`int > 0`**: set `auto_confirm_count` to the exact value (allows callers to specify a cap)
4. **`bool(False)`, `int <= 0`, or omitted**: no auto-confirm (default behavior)

### Rationale

- Matches the existing validated pattern in `api_v2_sessions.py:239-251`
- Eliminates the entire class of truthy coercion bugs for this parameter
- Minimal change: 3 lines removed, 18 lines added in the source file

### Diff Summary

```
 gptme/server/api_v2.py                      | 21 ++++++-
 tests/test_cwe20_auto_confirm_validation.py  | 90 +++++++++++++++++++
 2 files changed, 108 insertions(+), 3 deletions(-)
```

---

## Test Results

9 test cases in `tests/test_cwe20_auto_confirm_validation.py`:

| Test | Input | Expected | Status |
|------|-------|----------|--------|
| `test_string_false_rejected` | `"false"` | 400 | ✅ Pass |
| `test_string_true_rejected` | `"true"` | 400 | ✅ Pass |
| `test_dict_rejected` | `{"nested": true}` | 400 | ✅ Pass |
| `test_list_rejected` | `[1, 2]` | 400 | ✅ Pass |
| `test_float_rejected` | `1.5` | 400 | ✅ Pass |
| `test_bool_true_accepted` | `true` | 200 | ✅ Pass |
| `test_bool_false_accepted` | `false` | 200 | ✅ Pass |
| `test_int_accepted` | `5` | 200 | ✅ Pass |
| `test_none_accepted` | *(omitted)* | 200 | ✅ Pass |

All 9 tests pass. No regressions in existing test suites.

---

## Disprove Analysis

We attempted to challenge the validity of this finding:

### Preconditions & Practical Severity

- **Auth layer**: Endpoints are behind `@require_auth`, but auth is disabled in the default localhost development mode (`is_local_host()`)
- **Caller context**: The API is used by the gptme web frontend and potentially third-party integrations
- **Real-world likelihood**: A frontend or script sending `"auto_confirm": "false"` (string instead of boolean) is a realistic misconfiguration — JSON libraries in some languages serialize differently

### Missed Instances

The step endpoint (`api_v2_sessions.py:239-251`) already has correct validation — this fix brings the PUT endpoint into alignment. The tool-confirm "auto" action (`POST /tool/confirm`) uses `count = req_json.get("count", 1)` with a `count <= 0` check but no type validation; a string would crash with TypeError (500). This is a separate, lower-priority issue.

### Verdict: **LIKELY_VALID**

The vulnerability is technically real and the fix is consistent with the project's own established validation pattern. The practical severity depends on deployment context — localhost mode has lower risk, but the inconsistency between endpoints is a clear bug regardless.

### Mitigations Already Present

- `@require_auth` decorator on all endpoints
- Step endpoint already validates correctly (this fix closes the gap)
- Default `auto_confirm` is `False` when omitted

---

*This fix was prepared through a 4-stage review process including research, code review, testing, and adversarial disprove analysis. Happy to discuss or adjust anything.*