### PR TITLE
feat(docs): wire eval leaderboard into docs build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           # Fetch eval results from the dedicated eval-results branch
           # so the docs build can generate the model leaderboard table
-          git fetch origin eval-results --depth=1
+          git fetch origin eval-results --depth=1 || true
           git checkout origin/eval-results -- eval_results/ || echo "No eval results available"
 
       - name: Build docs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,6 +42,13 @@ jobs:
         run: |
           poetry install -E browser -E server
 
+      - name: Fetch eval results for leaderboard
+        run: |
+          # Fetch eval results from the dedicated eval-results branch
+          # so the docs build can generate the model leaderboard table
+          git fetch origin eval-results --depth=1
+          git checkout origin/eval-results -- eval_results/ || echo "No eval results available"
+
       - name: Build docs
         run: make docs
 

--- a/docs/evals.rst
+++ b/docs/evals.rst
@@ -44,7 +44,7 @@ Model Leaderboard
 
 The table below shows pass rates across our eval suites for each model (best tool format per model). Models are ranked by overall pass rate, with breakdowns by suite type.
 
-.. command-output:: python scripts/eval_leaderboard.py --format rst --min-tests 4
+.. command-output:: python -m gptme.eval.leaderboard --results-dir eval_results --format rst --min-tests 4
    :cwd: ..
    :shell:
 
@@ -60,9 +60,10 @@ To generate this table locally:
 
 .. code-block:: bash
 
-    python scripts/eval_leaderboard.py --format rst
-    python scripts/eval_leaderboard.py --format csv    # for data analysis
-    python scripts/eval_leaderboard.py --format markdown  # for GitHub/blog
+    gptme eval --leaderboard --leaderboard-format rst
+    gptme eval --leaderboard --leaderboard-format csv       # for data analysis
+    gptme eval --leaderboard --leaderboard-format markdown   # for GitHub/blog
+    gptme eval --leaderboard --leaderboard-format html       # self-contained HTML page
 
 
 Usage
@@ -147,11 +148,21 @@ Run all practical suites at once (useful for benchmarking):
 Raw Results
 -----------
 
-Full per-test results from all eval runs:
+Full per-test results from all eval runs are stored as CSV files in ``eval_results/`` subdirectories.
+Results are published to the ``eval-results`` branch of the repository.
 
-.. command-output:: gptme-eval eval_results/*/eval_results.csv
-   :cwd: ..
-   :shell:
+To view raw results locally:
+
+.. code-block:: bash
+
+    # View latest results
+    cat eval_results/*/eval_results.csv | head -50
+
+    # Export leaderboard as CSV for analysis
+    gptme eval --leaderboard --leaderboard-format csv
+
+    # Export as JSON for programmatic use
+    gptme eval --leaderboard --leaderboard-format json
 
 
 Other evals

--- a/gptme/eval/leaderboard.py
+++ b/gptme/eval/leaderboard.py
@@ -112,6 +112,10 @@ def normalize_model(model: str) -> str:
         "openrouter/x-ai/grok-4-fast:free": "Grok 4 Fast",
         "openrouter/x-ai/grok-code-fast-1": "Grok Code Fast",
         "openrouter/z-ai/glm-5": "GLM-5",
+        # OpenRouter-proxied versions of direct-API models
+        "openrouter/openai/gpt-4o-mini": "GPT-4o Mini (OR)",
+        # Model IDs without date suffix
+        "anthropic/claude-sonnet-4-5": "Claude Sonnet 4.5",
     }
     return replacements.get(model, model)
 
@@ -564,8 +568,18 @@ def main():
             min_tests=args.min_tests,
         )
     except (FileNotFoundError, ValueError) as e:
-        print(str(e), file=sys.stderr)
-        sys.exit(1)
+        # Print a placeholder instead of failing — allows docs builds to succeed
+        # even when eval results are not available
+        print(f"*No leaderboard data available ({e})*", file=sys.stderr)
+        if args.format == "rst":
+            print("*No eval results available. Run evals to populate the leaderboard.*")
+        elif args.format == "html":
+            print("<p><em>No eval results available.</em></p>")
+        elif args.format == "json":
+            print('{"models": [], "error": "' + str(e).replace('"', '\\"') + '"}')
+        else:
+            print("*No eval results available.*")
+        return
     if args.format == "csv":
         print(output, end="")
     else:

--- a/tests/test_eval_leaderboard.py
+++ b/tests/test_eval_leaderboard.py
@@ -15,6 +15,7 @@ from gptme.eval.leaderboard import (
     format_rst_table,
     generate_leaderboard,
     load_results,
+    main,
     normalize_model,
     parse_model_format,
 )
@@ -45,6 +46,8 @@ def test_normalize_model():
     """Known models get human-readable names."""
     assert normalize_model("openai/gpt-4o") == "GPT-4o"
     assert normalize_model("anthropic/claude-sonnet-4-20250514") == "Claude Sonnet 4"
+    assert normalize_model("anthropic/claude-sonnet-4-5") == "Claude Sonnet 4.5"
+    assert normalize_model("openrouter/openai/gpt-4o-mini") == "GPT-4o Mini (OR)"
     # Unknown models pass through unchanged
     assert normalize_model("some/unknown-model") == "some/unknown-model"
 
@@ -579,6 +582,24 @@ def test_format_html_escapes_model_names(tmp_path):
     html = format_html_page(ranked)
     assert "<script>" not in html
     assert "&lt;script&gt;" in html
+
+
+def test_main_graceful_on_missing_results(tmp_path, capsys, monkeypatch):
+    """CLI main() prints placeholder instead of crashing when no results exist."""
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "leaderboard",
+            "--results-dir",
+            str(tmp_path / "nonexistent"),
+            "--format",
+            "rst",
+        ],
+    )
+    # main() should not raise or sys.exit
+    main()
+    captured = capsys.readouterr()
+    assert "No eval results available" in captured.out
 
 
 def test_generate_leaderboard_html(tmp_path):


### PR DESCRIPTION
## Summary

The eval leaderboard table was never rendering on [gptme.org/docs/evals.html](https://gptme.org/docs/evals.html) because the docs build had no access to `eval_results/` (gitignored, data lives on the `eval-results` branch).

- **CI step**: Fetches eval results from the `eval-results` branch during docs build, so the leaderboard table actually renders with real data (39 models currently)
- **Updated docs references**: Uses `python -m gptme.eval.leaderboard` and documents the new `gptme eval --leaderboard` CLI
- **Graceful fallback**: `main()` now prints a placeholder instead of `sys.exit(1)` when no results are available, preventing docs build failures
- **Fixed raw results section**: Replaced broken `command-output` directive (was running `gptme-eval` on CSV paths) with static docs explaining where to find results
- **Model normalizations**: Added `anthropic/claude-sonnet-4-5` → "Claude Sonnet 4.5" and `openrouter/openai/gpt-4o-mini` → "GPT-4o Mini (OR)"

## Test plan

- [x] All 26 leaderboard tests pass (including new graceful fallback test)
- [x] Verified leaderboard generates correctly with real eval data from `eval-results` branch (39 models)
- [ ] Verify docs build succeeds in CI with the new fetch step
- [ ] Verify leaderboard table appears on the built docs page
