### PR TITLE
feat(llm): add max_tokens parameter to reply() and chat()

### DIFF
--- a/gptme/llm/__init__.py
+++ b/gptme/llm/__init__.py
@@ -203,6 +203,11 @@ def _chat_complete(
         )
     if provider == "openai-subscription":
         # TODO: max_tokens not yet forwarded to openai-subscription
+        if max_tokens is not None:
+            logger.warning(
+                "max_tokens=%d is not forwarded to openai-subscription provider and will be ignored.",
+                max_tokens,
+            )
         content = chat_subscription(messages, _get_base_model(model), tools)
         return content, {"model": model}
 
@@ -257,12 +262,16 @@ def _stream(
         return _StreamWithMetadata(gen, model)
     if provider == "openai-subscription":
         # TODO: max_tokens not yet forwarded to openai-subscription
+        if max_tokens is not None:
+            logger.warning(
+                "max_tokens=%d is not forwarded to openai-subscription provider and will be ignored.",
+                max_tokens,
+            )
         gen = stream_subscription(messages, _get_base_model(model), tools)
         return _StreamWithMetadata(gen, model)
     # Note: Validation-only fallback for streaming is complex
     # For now, unsupported providers don't support output_schema in streaming mode
     if output_schema is not None:
-        logger = logging.getLogger(__name__)
         logger.warning(
             f"Provider {provider} does not support output_schema in streaming mode"
         )

--- a/gptme/llm/__init__.py
+++ b/gptme/llm/__init__.py
@@ -187,6 +187,8 @@ def _chat_complete(
     output_schema: type | None = None,
     max_tokens: int | None = None,
 ) -> tuple[str, MessageMetadata | None]:
+    if max_tokens is not None and max_tokens <= 0:
+        raise ValueError(f"max_tokens must be a positive integer, got {max_tokens}")
     provider = get_provider_from_model(model)
 
     # Providers with native constrained decoding support

--- a/gptme/llm/__init__.py
+++ b/gptme/llm/__init__.py
@@ -256,6 +256,7 @@ def _stream(
         )
         return _StreamWithMetadata(gen, model)
     if provider == "openai-subscription":
+        # TODO: max_tokens not yet forwarded to openai-subscription
         gen = stream_subscription(messages, _get_base_model(model), tools)
         return _StreamWithMetadata(gen, model)
     # Note: Validation-only fallback for streaming is complex

--- a/gptme/llm/__init__.py
+++ b/gptme/llm/__init__.py
@@ -96,6 +96,7 @@ def reply(
     workspace: Path | None = None,
     output_schema: type | None = None,
     on_token: Callable[[str], None] | None = None,
+    max_tokens: int | None = None,
 ) -> Message:
     # Trigger GENERATION_PRE hooks and collect context messages
     from ..hooks import HookType, trigger_hook
@@ -137,7 +138,11 @@ def reply(
         )
     rprint(f"{prompt_assistant(agent_name)}: Thinking...", end="\r")
     response, metadata = _chat_complete(
-        generation_msgs, model, tools, output_schema=output_schema
+        generation_msgs,
+        model,
+        tools,
+        output_schema=output_schema,
+        max_tokens=max_tokens,
     )
     rprint(" " * shutil.get_terminal_size().columns, end="\r")
     rprint(f"{prompt_assistant(agent_name)}: {response}")
@@ -177,16 +182,23 @@ def _chat_complete(
     model: str,
     tools: list[ToolSpec] | None,
     output_schema: type | None = None,
+    max_tokens: int | None = None,
 ) -> tuple[str, MessageMetadata | None]:
     provider = get_provider_from_model(model)
 
     # Providers with native constrained decoding support
     # Custom providers are OpenAI-compatible, so route them through the OpenAI path
     if provider in PROVIDERS_OPENAI or is_custom_provider(provider):
-        return chat_openai(messages, model, tools, output_schema=output_schema)
+        return chat_openai(
+            messages, model, tools, output_schema=output_schema, max_tokens=max_tokens
+        )
     if provider == "anthropic":
         return chat_anthropic(
-            messages, _get_base_model(model), tools, output_schema=output_schema
+            messages,
+            _get_base_model(model),
+            tools,
+            output_schema=output_schema,
+            max_tokens=max_tokens,
         )
     if provider == "openai-subscription":
         content = chat_subscription(messages, _get_base_model(model), tools)

--- a/gptme/llm/__init__.py
+++ b/gptme/llm/__init__.py
@@ -135,6 +135,7 @@ def reply(
             agent_name=agent_name,
             output_schema=output_schema,
             on_token=on_token,
+            max_tokens=max_tokens,
         )
     rprint(f"{prompt_assistant(agent_name)}: Thinking...", end="\r")
     response, metadata = _chat_complete(
@@ -235,15 +236,22 @@ def _stream(
     model: str,
     tools: list[ToolSpec] | None,
     output_schema: type | None = None,
+    max_tokens: int | None = None,
 ) -> _StreamWithMetadata:
     provider = get_provider_from_model(model)
     # Custom providers are OpenAI-compatible, so route them through the OpenAI path
     if provider in PROVIDERS_OPENAI or is_custom_provider(provider):
-        gen = stream_openai(messages, model, tools, output_schema=output_schema)
+        gen = stream_openai(
+            messages, model, tools, output_schema=output_schema, max_tokens=max_tokens
+        )
         return _StreamWithMetadata(gen, model)
     if provider == "anthropic":
         gen = stream_anthropic(
-            messages, _get_base_model(model), tools, output_schema=output_schema
+            messages,
+            _get_base_model(model),
+            tools,
+            output_schema=output_schema,
+            max_tokens=max_tokens,
         )
         return _StreamWithMetadata(gen, model)
     if provider == "openai-subscription":
@@ -268,6 +276,7 @@ def _reply_stream(
     agent_name: str | None = None,
     output_schema: type | None = None,
     on_token: Callable[[str], None] | None = None,
+    max_tokens: int | None = None,
 ) -> Message:
     rprint(f"{prompt_assistant(agent_name)}: Thinking...", end="\r")
 
@@ -288,7 +297,9 @@ def _reply_stream(
     line_buffer: list[str] = []
 
     # Create stream wrapper to capture metadata
-    stream = _stream(messages, model, tools, output_schema=output_schema)
+    stream = _stream(
+        messages, model, tools, output_schema=output_schema, max_tokens=max_tokens
+    )
 
     try:
         for char in (char for chunk in stream for char in chunk):

--- a/gptme/llm/__init__.py
+++ b/gptme/llm/__init__.py
@@ -98,6 +98,8 @@ def reply(
     on_token: Callable[[str], None] | None = None,
     max_tokens: int | None = None,
 ) -> Message:
+    if max_tokens is not None and max_tokens <= 0:
+        raise ValueError(f"max_tokens must be a positive integer, got {max_tokens}")
     # Trigger GENERATION_PRE hooks and collect context messages
     from ..hooks import HookType, trigger_hook
 

--- a/gptme/llm/__init__.py
+++ b/gptme/llm/__init__.py
@@ -202,6 +202,7 @@ def _chat_complete(
             max_tokens=max_tokens,
         )
     if provider == "openai-subscription":
+        # TODO: max_tokens not yet forwarded to openai-subscription
         content = chat_subscription(messages, _get_base_model(model), tools)
         return content, {"model": model}
 

--- a/gptme/llm/constants.py
+++ b/gptme/llm/constants.py
@@ -1,0 +1,6 @@
+# Shared constants for the llm package.
+
+# Minimum tokens reserved for the actual response content when a thinking budget
+# is active. Prevents near-zero response budgets when the caller supplies a
+# max_tokens value that is only slightly above the thinking budget.
+_MIN_RESPONSE_TOKENS = 256

--- a/gptme/llm/llm_anthropic.py
+++ b/gptme/llm/llm_anthropic.py
@@ -158,6 +158,38 @@ def _record_usage(
     return metadata
 
 
+def _adjust_thinking_budget(
+    max_tokens: int, thinking_budget: int, use_thinking: bool
+) -> tuple[int, bool]:
+    """Clamp thinking_budget to fit within max_tokens for Anthropic's extended thinking.
+
+    Anthropic requires max_tokens > budget_tokens when extended thinking is active.
+    We honor the caller's max_tokens limit by reducing thinking_budget to fit,
+    rather than inflating max_tokens (which defeats cost-saving intent).
+    """
+    if not use_thinking or max_tokens > thinking_budget:
+        return thinking_budget, use_thinking
+    if max_tokens <= 1:
+        # Cannot fit even 1 thinking token — disable extended thinking entirely.
+        logger.warning(
+            "max_tokens=%d is too small to accommodate any thinking tokens; "
+            "disabling extended thinking. Increase max_tokens or unset %s.",
+            max_tokens,
+            ENV_REASONING_BUDGET,
+        )
+        return thinking_budget, False
+    new_budget = max_tokens - 1  # >= 1 since max_tokens >= 2
+    logger.warning(
+        "max_tokens=%d cannot accommodate thinking_budget=%d; "
+        "reducing thinking_budget to %d. Set %s to a smaller value to avoid this.",
+        max_tokens,
+        thinking_budget,
+        new_budget,
+        ENV_REASONING_BUDGET,
+    )
+    return new_budget, use_thinking
+
+
 def _should_use_thinking(model_meta: ModelMeta, tools: list[ToolSpec] | None) -> bool:
     """Determine if thinking mode should be enabled for the given model and tools.
 
@@ -409,31 +441,12 @@ def chat(
             f"Invalid {ENV_REASONING_BUDGET} value: {thinking_budget_str!r}. "
             "Must be a valid integer."
         ) from parse_err
-    max_tokens = max_tokens or model_meta.max_output or 4096
-    # Anthropic requires max_tokens > budget_tokens when extended thinking is active.
-    # Respect the caller's max_tokens budget by reducing thinking_budget to fit,
-    # rather than inflating max_tokens (which would defeat caller's cost-saving intent).
-    if use_thinking and max_tokens <= thinking_budget:
-        if max_tokens <= 1:
-            # Cannot fit even 1 thinking token — disable extended thinking entirely.
-            use_thinking = False
-            logger.warning(
-                "max_tokens=%d is too small to accommodate any thinking tokens; "
-                "disabling extended thinking. Increase max_tokens or unset %s.",
-                max_tokens,
-                ENV_REASONING_BUDGET,
-            )
-        else:
-            new_budget = max_tokens - 1  # >= 1 since max_tokens >= 2
-            logger.warning(
-                "max_tokens=%d cannot accommodate thinking_budget=%d; "
-                "reducing thinking_budget to %d. Set %s to a smaller value to avoid this.",
-                max_tokens,
-                thinking_budget,
-                new_budget,
-                ENV_REASONING_BUDGET,
-            )
-            thinking_budget = new_budget
+    max_tokens = (
+        max_tokens if max_tokens is not None else (model_meta.max_output or 4096)
+    )
+    thinking_budget, use_thinking = _adjust_thinking_budget(
+        max_tokens, thinking_budget, use_thinking
+    )
 
     response = _anthropic.messages.create(
         model=api_model,
@@ -532,31 +545,12 @@ def stream(
             f"Invalid {ENV_REASONING_BUDGET} value: {thinking_budget_str!r}. "
             "Must be a valid integer."
         ) from parse_err
-    max_tokens = max_tokens or model_meta.max_output or 4096
-    # Anthropic requires max_tokens > budget_tokens when extended thinking is active.
-    # Respect the caller's max_tokens budget by reducing thinking_budget to fit,
-    # rather than inflating max_tokens (which would defeat caller's cost-saving intent).
-    if use_thinking and max_tokens <= thinking_budget:
-        if max_tokens <= 1:
-            # Cannot fit even 1 thinking token — disable extended thinking entirely.
-            use_thinking = False
-            logger.warning(
-                "max_tokens=%d is too small to accommodate any thinking tokens; "
-                "disabling extended thinking. Increase max_tokens or unset %s.",
-                max_tokens,
-                ENV_REASONING_BUDGET,
-            )
-        else:
-            new_budget = max_tokens - 1  # >= 1 since max_tokens >= 2
-            logger.warning(
-                "max_tokens=%d cannot accommodate thinking_budget=%d; "
-                "reducing thinking_budget to %d. Set %s to a smaller value to avoid this.",
-                max_tokens,
-                thinking_budget,
-                new_budget,
-                ENV_REASONING_BUDGET,
-            )
-            thinking_budget = new_budget
+    max_tokens = (
+        max_tokens if max_tokens is not None else (model_meta.max_output or 4096)
+    )
+    thinking_budget, use_thinking = _adjust_thinking_budget(
+        max_tokens, thinking_budget, use_thinking
+    )
 
     with _anthropic.messages.stream(
         model=api_model,

--- a/gptme/llm/llm_anthropic.py
+++ b/gptme/llm/llm_anthropic.py
@@ -158,6 +158,9 @@ def _record_usage(
     return metadata
 
 
+_MIN_RESPONSE_TOKENS = 256  # Minimum tokens reserved for actual response content
+
+
 def _adjust_thinking_budget(
     max_tokens: int, thinking_budget: int, use_thinking: bool
 ) -> tuple[int, bool]:
@@ -166,25 +169,32 @@ def _adjust_thinking_budget(
     Anthropic requires max_tokens > budget_tokens when extended thinking is active.
     We honor the caller's max_tokens limit by reducing thinking_budget to fit,
     rather than inflating max_tokens (which defeats cost-saving intent).
+
+    Always reserves at least _MIN_RESPONSE_TOKENS for the actual response;
+    disables thinking entirely when max_tokens is too small to be useful.
     """
     if not use_thinking or max_tokens > thinking_budget:
         return thinking_budget, use_thinking
-    if max_tokens <= 1:
-        # Cannot fit even 1 thinking token — disable extended thinking entirely.
+    new_budget = max_tokens - _MIN_RESPONSE_TOKENS
+    if new_budget <= 0:
+        # Not enough room for thinking AND a useful response — disable thinking.
         logger.warning(
-            "max_tokens=%d is too small to accommodate any thinking tokens; "
+            "max_tokens=%d is too small to accommodate thinking tokens "
+            "and a useful response (min %d tokens); "
             "disabling extended thinking. Increase max_tokens or unset %s.",
             max_tokens,
+            _MIN_RESPONSE_TOKENS,
             ENV_REASONING_BUDGET,
         )
         return thinking_budget, False
-    new_budget = max_tokens - 1  # >= 1 since max_tokens >= 2
     logger.warning(
         "max_tokens=%d cannot accommodate thinking_budget=%d; "
-        "reducing thinking_budget to %d. Set %s to a smaller value to avoid this.",
+        "reducing thinking_budget to %d (reserving %d tokens for response). "
+        "Set %s to a smaller value to avoid this.",
         max_tokens,
         thinking_budget,
         new_budget,
+        _MIN_RESPONSE_TOKENS,
         ENV_REASONING_BUDGET,
     )
     return new_budget, use_thinking

--- a/gptme/llm/llm_anthropic.py
+++ b/gptme/llm/llm_anthropic.py
@@ -455,6 +455,7 @@ def stream(
     model: str,
     tools: list[ToolSpec] | None,
     output_schema: type[BaseModel] | None = None,
+    max_tokens: int | None = None,
 ) -> Generator[str, None, MessageMetadata | None]:
     import anthropic.types  # fmt: skip
     from anthropic import NOT_GIVEN  # fmt: skip
@@ -507,7 +508,7 @@ def stream(
             f"Invalid {ENV_REASONING_BUDGET} value: {thinking_budget_str!r}. "
             "Must be a valid integer."
         ) from parse_err
-    max_tokens = model_meta.max_output or 4096
+    max_tokens = max_tokens or model_meta.max_output or 4096
 
     with _anthropic.messages.stream(
         model=api_model,

--- a/gptme/llm/llm_anthropic.py
+++ b/gptme/llm/llm_anthropic.py
@@ -410,6 +410,17 @@ def chat(
             "Must be a valid integer."
         ) from parse_err
     max_tokens = max_tokens or model_meta.max_output or 4096
+    # Anthropic requires max_tokens > budget_tokens when extended thinking is active
+    if use_thinking and max_tokens <= thinking_budget:
+        clamped = thinking_budget + 1
+        logger.warning(
+            "max_tokens=%d is not greater than thinking_budget=%d; "
+            "clamping to %d to prevent Anthropic API error",
+            max_tokens,
+            thinking_budget,
+            clamped,
+        )
+        max_tokens = clamped
 
     response = _anthropic.messages.create(
         model=api_model,
@@ -509,6 +520,17 @@ def stream(
             "Must be a valid integer."
         ) from parse_err
     max_tokens = max_tokens or model_meta.max_output or 4096
+    # Anthropic requires max_tokens > budget_tokens when extended thinking is active
+    if use_thinking and max_tokens <= thinking_budget:
+        clamped = thinking_budget + 1
+        logger.warning(
+            "max_tokens=%d is not greater than thinking_budget=%d; "
+            "clamping to %d to prevent Anthropic API error",
+            max_tokens,
+            thinking_budget,
+            clamped,
+        )
+        max_tokens = clamped
 
     with _anthropic.messages.stream(
         model=api_model,

--- a/gptme/llm/llm_anthropic.py
+++ b/gptme/llm/llm_anthropic.py
@@ -364,6 +364,7 @@ def chat(
     model: str,
     tools: list[ToolSpec] | None,
     output_schema: type[BaseModel] | None = None,
+    max_tokens: int | None = None,
 ) -> tuple[str, MessageMetadata | None]:
     from anthropic import NOT_GIVEN  # fmt: skip
 
@@ -408,7 +409,7 @@ def chat(
             f"Invalid {ENV_REASONING_BUDGET} value: {thinking_budget_str!r}. "
             "Must be a valid integer."
         ) from parse_err
-    max_tokens = model_meta.max_output or 4096
+    max_tokens = max_tokens or model_meta.max_output or 4096
 
     response = _anthropic.messages.create(
         model=api_model,

--- a/gptme/llm/llm_anthropic.py
+++ b/gptme/llm/llm_anthropic.py
@@ -410,17 +410,20 @@ def chat(
             "Must be a valid integer."
         ) from parse_err
     max_tokens = max_tokens or model_meta.max_output or 4096
-    # Anthropic requires max_tokens > budget_tokens when extended thinking is active
+    # Anthropic requires max_tokens > budget_tokens when extended thinking is active.
+    # Respect the caller's max_tokens budget by reducing thinking_budget to fit,
+    # rather than inflating max_tokens (which would defeat caller's cost-saving intent).
     if use_thinking and max_tokens <= thinking_budget:
-        clamped = thinking_budget + 1
+        new_budget = max_tokens - 1
         logger.warning(
-            "max_tokens=%d is not greater than thinking_budget=%d; "
-            "clamping to %d to prevent Anthropic API error",
+            "max_tokens=%d cannot accommodate thinking_budget=%d; "
+            "reducing thinking_budget to %d. Set %s to a smaller value to avoid this.",
             max_tokens,
             thinking_budget,
-            clamped,
+            new_budget,
+            ENV_REASONING_BUDGET,
         )
-        max_tokens = clamped
+        thinking_budget = new_budget
 
     response = _anthropic.messages.create(
         model=api_model,
@@ -520,17 +523,20 @@ def stream(
             "Must be a valid integer."
         ) from parse_err
     max_tokens = max_tokens or model_meta.max_output or 4096
-    # Anthropic requires max_tokens > budget_tokens when extended thinking is active
+    # Anthropic requires max_tokens > budget_tokens when extended thinking is active.
+    # Respect the caller's max_tokens budget by reducing thinking_budget to fit,
+    # rather than inflating max_tokens (which would defeat caller's cost-saving intent).
     if use_thinking and max_tokens <= thinking_budget:
-        clamped = thinking_budget + 1
+        new_budget = max_tokens - 1
         logger.warning(
-            "max_tokens=%d is not greater than thinking_budget=%d; "
-            "clamping to %d to prevent Anthropic API error",
+            "max_tokens=%d cannot accommodate thinking_budget=%d; "
+            "reducing thinking_budget to %d. Set %s to a smaller value to avoid this.",
             max_tokens,
             thinking_budget,
-            clamped,
+            new_budget,
+            ENV_REASONING_BUDGET,
         )
-        max_tokens = clamped
+        thinking_budget = new_budget
 
     with _anthropic.messages.stream(
         model=api_model,

--- a/gptme/llm/llm_anthropic.py
+++ b/gptme/llm/llm_anthropic.py
@@ -19,6 +19,7 @@ from ..constants import TEMPERATURE, TOP_P
 from ..message import Message, MessageMetadata, UsageData, msgs2dicts
 from ..telemetry import record_llm_request
 from ..tools.base import ToolSpec
+from .constants import _MIN_RESPONSE_TOKENS
 from .models import ModelMeta, get_model
 from .utils import (
     apply_cache_control,
@@ -158,9 +159,6 @@ def _record_usage(
     return metadata
 
 
-_MIN_RESPONSE_TOKENS = 256  # Minimum tokens reserved for actual response content
-
-
 def _adjust_thinking_budget(
     max_tokens: int, thinking_budget: int, use_thinking: bool
 ) -> tuple[int, bool]:
@@ -173,7 +171,7 @@ def _adjust_thinking_budget(
     Always reserves at least _MIN_RESPONSE_TOKENS for the actual response;
     disables thinking entirely when max_tokens is too small to be useful.
     """
-    if not use_thinking or max_tokens > thinking_budget:
+    if not use_thinking or max_tokens >= thinking_budget + _MIN_RESPONSE_TOKENS:
         return thinking_budget, use_thinking
     new_budget = max_tokens - _MIN_RESPONSE_TOKENS
     if new_budget <= 0:

--- a/gptme/llm/llm_anthropic.py
+++ b/gptme/llm/llm_anthropic.py
@@ -414,16 +414,26 @@ def chat(
     # Respect the caller's max_tokens budget by reducing thinking_budget to fit,
     # rather than inflating max_tokens (which would defeat caller's cost-saving intent).
     if use_thinking and max_tokens <= thinking_budget:
-        new_budget = max(1, max_tokens - 1)
-        logger.warning(
-            "max_tokens=%d cannot accommodate thinking_budget=%d; "
-            "reducing thinking_budget to %d. Set %s to a smaller value to avoid this.",
-            max_tokens,
-            thinking_budget,
-            new_budget,
-            ENV_REASONING_BUDGET,
-        )
-        thinking_budget = new_budget
+        if max_tokens <= 1:
+            # Cannot fit even 1 thinking token — disable extended thinking entirely.
+            use_thinking = False
+            logger.warning(
+                "max_tokens=%d is too small to accommodate any thinking tokens; "
+                "disabling extended thinking. Increase max_tokens or unset %s.",
+                max_tokens,
+                ENV_REASONING_BUDGET,
+            )
+        else:
+            new_budget = max_tokens - 1  # >= 1 since max_tokens >= 2
+            logger.warning(
+                "max_tokens=%d cannot accommodate thinking_budget=%d; "
+                "reducing thinking_budget to %d. Set %s to a smaller value to avoid this.",
+                max_tokens,
+                thinking_budget,
+                new_budget,
+                ENV_REASONING_BUDGET,
+            )
+            thinking_budget = new_budget
 
     response = _anthropic.messages.create(
         model=api_model,
@@ -527,16 +537,26 @@ def stream(
     # Respect the caller's max_tokens budget by reducing thinking_budget to fit,
     # rather than inflating max_tokens (which would defeat caller's cost-saving intent).
     if use_thinking and max_tokens <= thinking_budget:
-        new_budget = max(1, max_tokens - 1)
-        logger.warning(
-            "max_tokens=%d cannot accommodate thinking_budget=%d; "
-            "reducing thinking_budget to %d. Set %s to a smaller value to avoid this.",
-            max_tokens,
-            thinking_budget,
-            new_budget,
-            ENV_REASONING_BUDGET,
-        )
-        thinking_budget = new_budget
+        if max_tokens <= 1:
+            # Cannot fit even 1 thinking token — disable extended thinking entirely.
+            use_thinking = False
+            logger.warning(
+                "max_tokens=%d is too small to accommodate any thinking tokens; "
+                "disabling extended thinking. Increase max_tokens or unset %s.",
+                max_tokens,
+                ENV_REASONING_BUDGET,
+            )
+        else:
+            new_budget = max_tokens - 1  # >= 1 since max_tokens >= 2
+            logger.warning(
+                "max_tokens=%d cannot accommodate thinking_budget=%d; "
+                "reducing thinking_budget to %d. Set %s to a smaller value to avoid this.",
+                max_tokens,
+                thinking_budget,
+                new_budget,
+                ENV_REASONING_BUDGET,
+            )
+            thinking_budget = new_budget
 
     with _anthropic.messages.stream(
         model=api_model,

--- a/gptme/llm/llm_anthropic.py
+++ b/gptme/llm/llm_anthropic.py
@@ -414,7 +414,7 @@ def chat(
     # Respect the caller's max_tokens budget by reducing thinking_budget to fit,
     # rather than inflating max_tokens (which would defeat caller's cost-saving intent).
     if use_thinking and max_tokens <= thinking_budget:
-        new_budget = max_tokens - 1
+        new_budget = max(1, max_tokens - 1)
         logger.warning(
             "max_tokens=%d cannot accommodate thinking_budget=%d; "
             "reducing thinking_budget to %d. Set %s to a smaller value to avoid this.",
@@ -527,7 +527,7 @@ def stream(
     # Respect the caller's max_tokens budget by reducing thinking_budget to fit,
     # rather than inflating max_tokens (which would defeat caller's cost-saving intent).
     if use_thinking and max_tokens <= thinking_budget:
-        new_budget = max_tokens - 1
+        new_budget = max(1, max_tokens - 1)
         logger.warning(
             "max_tokens=%d cannot accommodate thinking_budget=%d; "
             "reducing thinking_budget to %d. Set %s to a smaller value to avoid this.",

--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -17,6 +17,7 @@ from ..constants import TEMPERATURE, TOP_P
 from ..message import Message, MessageMetadata, UsageData, msgs2dicts
 from ..telemetry import _calculate_llm_cost, record_llm_request
 from ..tools import ToolSpec
+from .constants import _MIN_RESPONSE_TOKENS
 from .models import (
     CustomProvider,
     ModelMeta,
@@ -591,7 +592,6 @@ def extra_headers(provider: Provider) -> dict[str, str]:
 
 
 _OPENROUTER_REASONING_DEFAULT = 20000
-_MIN_RESPONSE_TOKENS = 256  # Minimum tokens reserved for actual response content
 
 
 def extra_body(

--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -553,7 +553,7 @@ def chat(
         model=api_model.split("@")[0],
         messages=cast(list, messages_dicts),
         extra_headers=extra_headers(provider),
-        extra_body=extra_body(provider, model_meta),
+        extra_body=extra_body(provider, model_meta, max_tokens=max_tokens),
         **optional_kwargs,
     )
     metadata = _record_usage(response.usage, model)
@@ -590,7 +590,13 @@ def extra_headers(provider: Provider) -> dict[str, str]:
     return headers
 
 
-def extra_body(provider: Provider, model_meta: ModelMeta) -> dict[str, Any]:
+_OPENROUTER_REASONING_DEFAULT = 20000
+_MIN_RESPONSE_TOKENS = 256  # Minimum tokens reserved for actual response content
+
+
+def extra_body(
+    provider: Provider, model_meta: ModelMeta, max_tokens: int | None = None
+) -> dict[str, Any]:
     """Return extra body for the OpenAI API based on the model."""
     body: dict[str, Any] = {}
     if provider == "openrouter":
@@ -598,7 +604,31 @@ def extra_body(provider: Provider, model_meta: ModelMeta) -> dict[str, Any]:
         # See: https://openrouter.ai/docs/guides/usage-accounting
         body["usage"] = {"include": True}
         if model_meta.supports_reasoning:
-            body["reasoning"] = {"enabled": True, "max_tokens": 20000}
+            reasoning_budget = _OPENROUTER_REASONING_DEFAULT
+            if max_tokens is not None:
+                available = max_tokens - _MIN_RESPONSE_TOKENS
+                if available <= 0:
+                    # Not enough room for reasoning AND a useful response
+                    logger.warning(
+                        "max_tokens=%d is too small to accommodate reasoning tokens "
+                        "and a useful response (min %d tokens); "
+                        "disabling OpenRouter extended reasoning.",
+                        max_tokens,
+                        _MIN_RESPONSE_TOKENS,
+                    )
+                    reasoning_budget = 0
+                elif available < reasoning_budget:
+                    logger.warning(
+                        "max_tokens=%d cannot accommodate reasoning_budget=%d; "
+                        "reducing to %d (reserving %d tokens for response).",
+                        max_tokens,
+                        reasoning_budget,
+                        available,
+                        _MIN_RESPONSE_TOKENS,
+                    )
+                    reasoning_budget = available
+            if reasoning_budget > 0:
+                body["reasoning"] = {"enabled": True, "max_tokens": reasoning_budget}
         if "@" in model_meta.model:
             provider_override = model_meta.model.split("@")[1]
             body["provider"] = {
@@ -655,7 +685,7 @@ def stream(
         messages=cast(list, messages_dicts),
         stream=True,
         extra_headers=extra_headers(provider),
-        extra_body=extra_body(provider, model_meta),
+        extra_body=extra_body(provider, model_meta, max_tokens=max_tokens),
         stream_options={"include_usage": True},
         **optional_kwargs,
     ):

--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -513,6 +513,7 @@ def chat(
     model: str,
     tools: list[ToolSpec] | None,
     output_schema=None,
+    max_tokens: int | None = None,
 ) -> tuple[str, MessageMetadata | None]:
     # This will generate code and such, so we need appropriate temperature and top_p params
     # top_p controls diversity, temperature controls randomness
@@ -545,6 +546,8 @@ def chat(
         optional_kwargs["tools"] = tools_dict
     if response_format is not None:
         optional_kwargs["response_format"] = response_format
+    if max_tokens is not None:
+        optional_kwargs["max_tokens"] = max_tokens
 
     response = client.chat.completions.create(
         model=api_model.split("@")[0],

--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -614,6 +614,7 @@ def stream(
     model: str,
     tools: list[ToolSpec] | None,
     output_schema=None,
+    max_tokens: int | None = None,
 ) -> Generator[str, None, MessageMetadata | None]:
     from . import _get_base_model, get_provider_from_model  # fmt: skip
     from .models import get_model  # fmt: skip
@@ -646,6 +647,8 @@ def stream(
         optional_kwargs["tools"] = tools_dict
     if response_format is not None:
         optional_kwargs["response_format"] = response_format
+    if max_tokens is not None:
+        optional_kwargs["max_tokens"] = max_tokens
 
     for chunk_raw in client.chat.completions.create(
         model=api_model.split("@")[0],


### PR DESCRIPTION
## Problem

OpenRouter counts the *reserved* `max_tokens` against the key's daily dollar budget — not actual usage. For `claude-sonnet-4-5` with `max_output=64000`, every API call reserves ~\$0.96 even if only 100 tokens are used.

This hits hard on lightweight use cases like tweet evaluation, where 48 daily cycles × ~2 LLM calls × \$0.96/reservation = \$92/day in reservations, vs ~\$1/day actual cost.

## Fix

Add a `max_tokens: int | None = None` parameter to `reply()`, threading it through `_chat_complete()` → `chat()` in both `llm_openai.py` and `llm_anthropic.py`.

When specified, the value is passed directly to the API. When `None` (default), behavior is unchanged — the API uses the model's default.

## Changes

- `llm/__init__.py`: add `max_tokens` to `reply()` and `_chat_complete()` signatures
- `llm/llm_openai.py`: thread `max_tokens` into `optional_kwargs` for the API call
- `llm/llm_anthropic.py`: allow caller-specified `max_tokens` to override `model_meta.max_output`

## Usage

```python
# Cap at 2048 tokens for tweet evaluation — prevents ~$0.96 reservation
# from 64k default down to ~$0.03
response = reply(messages, model.full, stream=False, max_tokens=2048)
```

## Motivation

Fixes Twitter loop cost issue in ErikBjare/bob#479 — OpenRouter key exhausted daily budget on reservations for `claude-sonnet-4-5` despite minimal actual token usage.