### PR TITLE
feat(webui): add scroll-to-bottom floating button in conversations

### DIFF
--- a/webui/src/components/ConversationContent.tsx
+++ b/webui/src/components/ConversationContent.tsx
@@ -11,6 +11,7 @@ import { getObservableIndex } from '@legendapp/state';
 import { useApi } from '@/contexts/ApiContext';
 import { useSettings } from '@/contexts/SettingsContext';
 import { useModels } from '@/hooks/useModels';
+import { ArrowDown } from 'lucide-react';
 
 interface Props {
   conversationId: string;
@@ -115,6 +116,10 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
   // Observable for if the user scrolled during generation
   const autoScrollAborted$ = useObservable(false);
 
+  // Observable for if the user is scrolled away from the bottom
+  // (used to show the scroll-to-bottom button)
+  const isScrolledUp$ = useObservable(false);
+
   // Reset the autoScrollAborted flag when generation is complete or starts again
   useObserveEffect(conversation$?.isGenerating, () => {
     autoScrollAborted$.set(false);
@@ -165,6 +170,16 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
     await confirmTool('auto', { count });
   };
 
+  const handleScrollToBottom = () => {
+    if (scrollContainerRef.current) {
+      scrollContainerRef.current.scrollTo({
+        top: scrollContainerRef.current.scrollHeight,
+        behavior: 'smooth',
+      });
+    }
+    autoScrollAborted$.set(false);
+  };
+
   if (!conversation$) {
     return (
       <div className="flex h-full items-center justify-center">
@@ -187,8 +202,10 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
             ) <= 1;
           if (isBottom) {
             autoScrollAborted$.set(false);
+            isScrolledUp$.set(false);
           } else {
             autoScrollAborted$.set(true);
+            isScrolledUp$.set(true);
           }
         }}
       >
@@ -271,6 +288,17 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
         {/* Add padding at the bottom to account for the floating input */}
         <div className="mb-40" />
       </div>
+
+      {/* Scroll-to-bottom button — appears when user scrolls up from bottom */}
+      {isScrolledUp$.get() && (
+        <button
+          onClick={handleScrollToBottom}
+          className="absolute bottom-44 right-6 z-10 flex h-8 w-8 items-center justify-center rounded-full border border-border/50 bg-background/90 text-muted-foreground shadow-md transition-colors hover:bg-accent hover:text-accent-foreground"
+          aria-label="Scroll to bottom"
+        >
+          <ArrowDown className="h-4 w-4" />
+        </button>
+      )}
 
       <div className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-background via-background/80 to-transparent">
         <div className=" mx-auto max-w-2xl">


### PR DESCRIPTION
## Summary

Adds a floating **scroll-to-bottom** button that appears when a user scrolls up to read message history during a conversation.

## Behavior

- **Button appears** when the user scrolls away from the bottom of the conversation
- **Clicking** smoothly scrolls to the latest message and resumes auto-scroll behavior
- **Button hides** automatically when the user is already at the bottom
- Positioned above the floating ChatInput (bottom-right corner)

## Implementation

- Reuses the existing `autoScrollAborted$` observable from the scroll handler
- Adds a new `isScrolledUp$` observable to track button visibility
- `handleScrollToBottom` uses `scrollTo({ behavior: 'smooth' })` for a smooth scroll and resets auto-scroll state
- Uses `ArrowDown` icon from lucide-react (already a project dependency)

## Screenshots

*(Visual: small circular button with down-arrow icon, appears above the chat input when scrolled up)*

**Test plan**: 
- [ ] Open a conversation with enough messages to scroll
- [ ] Scroll up — button should appear
- [ ] Click button — should smooth-scroll to bottom
- [ ] Button should disappear once at bottom