### PR TITLE
fix(server): persist visible generation errors

### DIFF
--- a/gptme/server/session_step.py
+++ b/gptme/server/session_step.py
@@ -226,6 +226,16 @@ def _append_and_notify(manager: LogManager, session: ConversationSession, msg: M
     )
 
 
+def _persist_generation_error(
+    manager: LogManager,
+    session: ConversationSession,
+    error_message: str,
+) -> None:
+    """Persist a visible generation error message and notify SSE clients."""
+    _append_and_notify(manager, session, Message("system", f"Error: {error_message}"))
+    manager.write()
+
+
 def _try_auto_name_and_notify(
     config: ChatConfig,
     messages: list[Message],
@@ -586,6 +596,7 @@ def step(
     # Prepare messages for the model
     msgs = prepare_messages(manager.log.messages)
     if not msgs:
+        _persist_generation_error(manager, session, "No messages to process")
         error_event: ErrorEvent = {
             "type": "error",
             "error": "No messages to process",
@@ -714,7 +725,14 @@ def step(
 
     except Exception as e:
         logger.exception(f"Error during step execution: {e}")
-        SessionManager.add_event(conversation_id, {"type": "error", "error": str(e)})
+        error_message = str(e) or "Generation failed"
+        try:
+            _persist_generation_error(manager, session, error_message)
+        except Exception:
+            logger.exception("Failed to persist generation error message")
+        SessionManager.add_event(
+            conversation_id, {"type": "error", "error": error_message}
+        )
         session.generating = False
 
 

--- a/tests/test_llm_models_resolution.py
+++ b/tests/test_llm_models_resolution.py
@@ -44,11 +44,13 @@ def _restore_default_model():
 
 @pytest.fixture(autouse=True)
 def _restore_model_list_cache():
-    """Save and restore the model list cache between tests."""
+    """Run each test with a clean model list cache and restore prior state after."""
     import gptme.llm.models.listing as listing_mod
 
     old_cache = listing_mod._model_list_cache
     old_time = listing_mod._model_list_cache_time
+    listing_mod._model_list_cache = None
+    listing_mod._model_list_cache_time = 0
     yield
     listing_mod._model_list_cache = old_cache
     listing_mod._model_list_cache_time = old_time

--- a/tests/test_server_v2_auto_stepping.py
+++ b/tests/test_server_v2_auto_stepping.py
@@ -127,3 +127,42 @@ def test_auto_stepping(
         assert messages[6]["role"] == "assistant"
         assert messages[7]["role"] == "system"
         assert messages[8]["role"] == "assistant"
+
+
+@pytest.mark.timeout(30)
+def test_generation_error_persists_system_message(
+    setup_conversation, event_listener, wait_for_event
+):
+    """Generation failures should be visible in the conversation log, not SSE-only."""
+    port, conversation_id, session_id = setup_conversation
+
+    requests.post(
+        f"http://localhost:{port}/api/v2/conversations/{conversation_id}",
+        json={"role": "user", "content": "Say hello"},
+    )
+
+    with unittest.mock.patch(
+        "gptme.server.session_step._stream",
+        side_effect=RuntimeError("provider quota exceeded"),
+    ):
+        response = requests.post(
+            f"http://localhost:{port}/api/v2/conversations/{conversation_id}/step",
+            json={
+                "session_id": session_id,
+                "model": "openai/mock-model",
+            },
+        )
+
+        assert response.status_code == 200
+        assert wait_for_event(event_listener, "generation_started")
+        assert wait_for_event(event_listener, "message_added")
+        assert wait_for_event(event_listener, "error")
+
+    resp = requests.get(
+        f"http://localhost:{port}/api/v2/conversations/{conversation_id}",
+    )
+    assert resp.status_code == 200
+
+    messages = resp.json()["log"]
+    assert messages[-1]["role"] == "system"
+    assert messages[-1]["content"] == "Error: provider quota exceeded"

--- a/tests/test_server_v2_auto_stepping.py
+++ b/tests/test_server_v2_auto_stepping.py
@@ -164,5 +164,8 @@ def test_generation_error_persists_system_message(
     assert resp.status_code == 200
 
     messages = resp.json()["log"]
+    assert not any(
+        m["role"] == "assistant" and m.get("content", "") == "" for m in messages
+    ), "Lingering empty assistant placeholder found in log after error"
     assert messages[-1]["role"] == "system"
     assert messages[-1]["content"] == "Error: provider quota exceeded"

--- a/webui/src/hooks/useConversation.ts
+++ b/webui/src/hooks/useConversation.ts
@@ -284,6 +284,25 @@ export function useConversation(conversationId: string, serverId?: string) {
             },
             onError: (error) => {
               console.error('[useConversation] Error:', error);
+              setGenerating(conversationId, false);
+              setPendingTool(conversationId, null, null);
+              setExecutingTool(conversationId, null, null);
+              messageJustCompleted.current = false;
+
+              const messages$ = conversation$?.data.log;
+              const lastMessage$ = messages$?.[messages$.length - 1];
+              if (lastMessage$?.role.get() === 'assistant') {
+                const content = lastMessage$.content.get();
+                if (content === '') {
+                  const timestamp = lastMessage$.timestamp?.get();
+                  if (timestamp) {
+                    removeMessage(conversationId, timestamp);
+                  }
+                } else if ('isComplete' in lastMessage$) {
+                  lastMessage$.isComplete.set(true);
+                }
+              }
+
               toast({
                 variant: 'destructive',
                 title: 'Error',

--- a/webui/src/hooks/useConversation.ts
+++ b/webui/src/hooks/useConversation.ts
@@ -24,6 +24,7 @@ import {
   setNeedsInitialStep,
 } from '@/stores/conversations';
 import { playChime } from '@/utils/audio';
+import { findLatestAssistantIndexForError } from '@/utils/conversationErrorHandling';
 import { notifyGenerationComplete, notifyToolConfirmation } from '@/utils/notifications';
 import { ApiClientError } from '@/utils/api';
 
@@ -290,16 +291,22 @@ export function useConversation(conversationId: string, serverId?: string) {
               messageJustCompleted.current = false;
 
               const messages$ = conversation$?.data.log;
-              const lastMessage$ = messages$?.[messages$.length - 1];
-              if (lastMessage$?.role.get() === 'assistant') {
-                const content = lastMessage$.content.get();
+              const assistantIndex = findLatestAssistantIndexForError(messages$?.peek());
+              const assistantMessage$ =
+                assistantIndex >= 0 ? messages$?.[assistantIndex] : undefined;
+              const streamingAssistantMessage$ = assistantMessage$ as
+                | (typeof assistantMessage$ & { isComplete?: { set: (value: boolean) => void } })
+                | undefined;
+
+              if (assistantMessage$?.role.get() === 'assistant') {
+                const content = assistantMessage$.content.get();
                 if (content === '') {
-                  const timestamp = lastMessage$.timestamp?.get();
+                  const timestamp = assistantMessage$.timestamp?.get();
                   if (timestamp) {
                     removeMessage(conversationId, timestamp);
                   }
-                } else if ('isComplete' in lastMessage$) {
-                  lastMessage$.isComplete.set(true);
+                } else if (streamingAssistantMessage$?.isComplete) {
+                  streamingAssistantMessage$.isComplete.set(true);
                 }
               }
 

--- a/webui/src/utils/__tests__/conversationErrorHandling.test.ts
+++ b/webui/src/utils/__tests__/conversationErrorHandling.test.ts
@@ -1,0 +1,21 @@
+import { findLatestAssistantIndexForError } from '../conversationErrorHandling';
+
+describe('findLatestAssistantIndexForError', () => {
+  it('returns the last message when it is an assistant message', () => {
+    expect(findLatestAssistantIndexForError([{ role: 'user' }, { role: 'assistant' }])).toBe(1);
+  });
+
+  it('returns the second-to-last assistant when a system error was appended after it', () => {
+    expect(
+      findLatestAssistantIndexForError([
+        { role: 'user' },
+        { role: 'assistant' },
+        { role: 'system' },
+      ])
+    ).toBe(1);
+  });
+
+  it('returns -1 when there is no assistant message to clean up', () => {
+    expect(findLatestAssistantIndexForError([{ role: 'user' }, { role: 'system' }])).toBe(-1);
+  });
+});

--- a/webui/src/utils/conversationErrorHandling.ts
+++ b/webui/src/utils/conversationErrorHandling.ts
@@ -1,0 +1,18 @@
+import type { Message } from '@/types/conversation';
+
+export function findLatestAssistantIndexForError(log?: Pick<Message, 'role'>[]): number {
+  if (!log?.length) {
+    return -1;
+  }
+
+  const lastIndex = log.length - 1;
+  if (log[lastIndex]?.role === 'assistant') {
+    return lastIndex;
+  }
+
+  if (log[lastIndex]?.role === 'system' && log[lastIndex - 1]?.role === 'assistant') {
+    return lastIndex - 1;
+  }
+
+  return -1;
+}


### PR DESCRIPTION
## Summary

- persist generation failures as visible `system` messages in the conversation log instead of SSE-only errors
- keep emitting the SSE `error` event, but clean up webui generation/tool state when it arrives
- remove empty assistant placeholders on failure so the UI does not look like a hung infinite spinner
- add a regression test covering provider failure during `/step`

## Why

Today `/api/v2/conversations/:id/step` returns `200 {"status":"ok"}` once the background step starts. If the model call then fails, the failure only appears on SSE. That is a bad default for cloud/web users: the conversation can appear stalled with no durable explanation.

This change makes the failure visible in the conversation itself and ensures the frontend exits the generating state cleanly.

Refs gptme/gptme-cloud#172

## Test plan

- [x] `uv run pytest /home/bob/gptme/tests/test_server_v2_auto_stepping.py -q`
- [x] `npm --prefix /home/bob/gptme/webui run typecheck`