### PR TITLE
feat(webui): refresh new chat view

### DIFF
--- a/webui/src/components/WelcomeView.tsx
+++ b/webui/src/components/WelcomeView.tsx
@@ -7,9 +7,10 @@ import { toast } from 'sonner';
 import { use$ } from '@legendapp/state/react';
 import { observable } from '@legendapp/state';
 import { ChatInput, type ChatOptions } from '@/components/ChatInput';
-import { History, Server } from 'lucide-react';
+import { History, Server, Sparkles } from 'lucide-react';
 import { ExamplesSection } from '@/components/ExamplesSection';
 import { serverRegistry$, getConnectedServers } from '@/stores/servers';
+import { getExamples } from '@/utils/examples';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -28,6 +29,7 @@ export const WelcomeView = () => {
   const connectedServers = getConnectedServers();
   const activeServer = registry.servers.find((s) => s.id === registry.activeServerId);
   const showServerPicker = connectedServers.length > 1;
+  const quickSuggestions = getExamples('welcome-suggestions', 'mixed', 4);
 
   // Create observables that ChatInput expects
   const autoFocus$ = observable(true);
@@ -74,55 +76,101 @@ export const WelcomeView = () => {
   };
 
   return (
-    <div className="mx-auto flex h-full w-full flex-col items-center justify-center">
-      <div className="text-center">
-        <h1 className="text-4xl font-bold">How can I help you today?</h1>
-        <p className="mt-2 text-muted-foreground">
-          I can help you write code, debug issues, and learn new concepts.
-        </p>
-      </div>
+    <div className="relative mx-auto flex h-full w-full flex-col overflow-hidden">
+      <div className="pointer-events-none absolute inset-x-0 top-0 h-40 bg-gradient-to-b from-primary/10 via-primary/5 to-transparent" />
+      <div className="pointer-events-none absolute left-1/2 top-1/3 h-72 w-72 -translate-x-1/2 rounded-full bg-primary/10 blur-3xl" />
 
-      <div className="my-4 w-full max-w-xl px-4">
-        <ChatInput
-          onSend={handleSend}
-          autoFocus$={autoFocus$}
-          value={inputValue}
-          onChange={setInputValue}
-        />
-      </div>
+      <div className="relative mx-auto flex h-full w-full max-w-5xl flex-col items-center justify-center px-4 py-10 sm:px-6">
+        <div className="w-full max-w-4xl rounded-[28px] border border-border/70 bg-background/90 p-6 shadow-[0_30px_120px_-48px_rgba(15,23,42,0.45)] backdrop-blur sm:p-8">
+          <div className="flex flex-col gap-8">
+            <div className="space-y-4 text-center">
+              <div className="inline-flex items-center gap-2 rounded-full border border-border/70 bg-background/80 px-3 py-1 text-xs font-medium uppercase tracking-[0.24em] text-muted-foreground">
+                <Sparkles className="h-3.5 w-3.5" />
+                New chat
+              </div>
+              <div className="space-y-3">
+                <h1 className="text-3xl font-semibold tracking-tight text-foreground/90 sm:text-5xl">
+                  What are you working on?
+                </h1>
+                <p className="mx-auto max-w-2xl text-sm leading-6 text-muted-foreground sm:text-base">
+                  Start with a real task, question, or rough idea. gptme is best when you give it
+                  something concrete to work on.
+                </p>
+              </div>
+            </div>
 
-      <div>
-        <div className="flex justify-center space-x-4">
-          {showServerPicker && (
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button variant="ghost" size="sm" className="text-muted-foreground">
-                  <Server className="mr-2 h-4 w-4" />
-                  {activeServer?.name || 'Server'}
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent>
-                {connectedServers.map((server) => (
-                  <DropdownMenuItem key={server.id} onClick={() => handleServerSwitch(server.id)}>
-                    <span className={server.id === registry.activeServerId ? 'font-medium' : ''}>
-                      {server.name}
-                    </span>
-                  </DropdownMenuItem>
+            <div className="mx-auto w-full max-w-2xl rounded-[24px] border border-border/70 bg-card/80 shadow-[0_20px_50px_-36px_rgba(15,23,42,0.45)]">
+              <ChatInput
+                onSend={handleSend}
+                autoFocus$={autoFocus$}
+                value={inputValue}
+                onChange={setInputValue}
+              />
+            </div>
+
+            <div className="space-y-3">
+              <p className="text-center text-xs font-medium uppercase tracking-[0.2em] text-muted-foreground">
+                Try one of these
+              </p>
+              <div className="flex flex-wrap justify-center gap-2">
+                {quickSuggestions.map((suggestion) => (
+                  <Button
+                    key={suggestion}
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className="rounded-full border-border/70 bg-background/70 text-xs text-muted-foreground hover:bg-background hover:text-foreground"
+                    onClick={() => setInputValue(suggestion)}
+                    disabled={isSubmitting}
+                  >
+                    {suggestion}
+                  </Button>
                 ))}
-              </DropdownMenuContent>
-            </DropdownMenu>
-          )}
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            onClick={() => navigate('/history')}
-            className="text-muted-foreground"
-          >
-            <History className="mr-2 h-4 w-4" />
-            Show history
-          </Button>
-          <ExamplesSection onExampleSelect={setInputValue} disabled={isSubmitting} />
+              </div>
+            </div>
+
+            <div className="flex flex-wrap items-center justify-center gap-3">
+              {showServerPicker && (
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="rounded-full border border-transparent text-muted-foreground hover:border-border/70 hover:bg-background/70"
+                    >
+                      <Server className="mr-2 h-4 w-4" />
+                      {activeServer?.name || 'Server'}
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent>
+                    {connectedServers.map((server) => (
+                      <DropdownMenuItem
+                        key={server.id}
+                        onClick={() => handleServerSwitch(server.id)}
+                      >
+                        <span
+                          className={server.id === registry.activeServerId ? 'font-medium' : ''}
+                        >
+                          {server.name}
+                        </span>
+                      </DropdownMenuItem>
+                    ))}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              )}
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={() => navigate('/history')}
+                className="rounded-full border border-transparent text-muted-foreground hover:border-border/70 hover:bg-background/70"
+              >
+                <History className="mr-2 h-4 w-4" />
+                Show history
+              </Button>
+              <ExamplesSection onExampleSelect={setInputValue} disabled={isSubmitting} />
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/webui/src/components/__tests__/WelcomeView.test.tsx
+++ b/webui/src/components/__tests__/WelcomeView.test.tsx
@@ -1,0 +1,74 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { WelcomeView } from '../WelcomeView';
+
+const mockNavigate = jest.fn();
+const mockInvalidateQueries = jest.fn();
+
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+jest.mock('@/contexts/ApiContext', () => {
+  const { observable } = jest.requireActual('@legendapp/state');
+  return {
+    useApi: () => ({
+      api: {
+        createConversationWithPlaceholder: jest.fn(),
+      },
+      isConnected$: observable(true),
+      connectionConfig: { baseUrl: 'http://localhost:5700' },
+      switchServer: jest.fn(),
+    }),
+  };
+});
+
+jest.mock('@tanstack/react-query', () => ({
+  useQueryClient: () => ({
+    invalidateQueries: mockInvalidateQueries,
+  }),
+}));
+
+jest.mock('@/stores/servers', () => {
+  const { observable } = jest.requireActual('@legendapp/state');
+  return {
+    serverRegistry$: observable({
+      servers: [{ id: 'default', name: 'Default' }],
+      activeServerId: 'default',
+    }),
+    getConnectedServers: () => [{ id: 'default', name: 'Default' }],
+  };
+});
+
+jest.mock('../ChatInput', () => ({
+  ChatInput: () => <div data-testid="chat-input" />,
+}));
+
+jest.mock('../ExamplesSection', () => ({
+  ExamplesSection: () => <div data-testid="examples-section" />,
+}));
+
+describe('WelcomeView', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+    mockInvalidateQueries.mockClear();
+  });
+
+  it('renders the refreshed new chat copy and quick suggestions', () => {
+    render(<WelcomeView />);
+
+    expect(screen.getByText('New chat')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'What are you working on?' })).toBeInTheDocument();
+    expect(
+      screen.getByText(/Start with a real task, question, or rough idea\./)
+    ).toBeInTheDocument();
+    expect(screen.getByText('Try one of these')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Write a Python script' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Show history' })).toBeInTheDocument();
+    expect(screen.queryByText('How can I help you today?')).not.toBeInTheDocument();
+  });
+});

--- a/webui/src/components/ui/input.tsx
+++ b/webui/src/components/ui/input.tsx
@@ -10,7 +10,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cn(
-          'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+          'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm transition-[border-color,box-shadow] file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-foreground/15 focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-primary/10 disabled:cursor-not-allowed disabled:opacity-50',
           className
         )}
         ref={ref}

--- a/webui/src/components/ui/select.tsx
+++ b/webui/src/components/ui/select.tsx
@@ -17,7 +17,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      'flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1',
+      'flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm transition-[border-color,box-shadow] placeholder:text-muted-foreground focus:border-foreground/15 focus:outline-none focus:ring-4 focus:ring-primary/10 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1',
       className
     )}
     {...props}

--- a/webui/src/components/ui/textarea.tsx
+++ b/webui/src/components/ui/textarea.tsx
@@ -9,7 +9,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
     return (
       <textarea
         className={cn(
-          'flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+          'flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm transition-[border-color,box-shadow] placeholder:text-muted-foreground focus-visible:border-foreground/15 focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-primary/10 disabled:cursor-not-allowed disabled:opacity-50',
           className
         )}
         ref={ref}


### PR DESCRIPTION
## Summary
- replace the generic new-chat empty state with a cleaner hero, calmer copy, and quick suggestion chips
- soften focus styling for shared input/select/textarea controls so the chat input no longer gets the loud bright-green treatment
- add a WelcomeView regression test for the refreshed copy

## Testing
- cd /tmp/worktrees/gptme-issue-1923/webui && npm test -- --runInBand src/components/__tests__/WelcomeView.test.tsx src/components/__tests__/ChatInput.test.tsx
- cd /tmp/worktrees/gptme-issue-1923/webui && npm run build

Closes #1923.