### PR TITLE
fix(eval): close remaining practical16 review gaps

### DIFF
--- a/gptme/eval/suites/practical16.py
+++ b/gptme/eval/suites/practical16.py
@@ -70,17 +70,31 @@ def check_queue_all_producers_mentioned(ctx):
     out = ctx.stdout.lower()
     # Accept producer IDs 0-2 or 1-3
     has_three = (
-        ("producer 0" in out or "producer-0" in out or "p0" in out or "prod 0" in out)
-        and (
-            "producer 1" in out or "producer-1" in out or "p1" in out or "prod 1" in out
+        (
+            "producer 0" in out
+            or "producer-0" in out
+            or "producer=0" in out
+            or "p0" in out
+            or "prod 0" in out
         )
         and (
-            "producer 2" in out or "producer-2" in out or "p2" in out or "prod 2" in out
+            "producer 1" in out
+            or "producer-1" in out
+            or "producer=1" in out
+            or "p1" in out
+            or "prod 1" in out
+        )
+        and (
+            "producer 2" in out
+            or "producer-2" in out
+            or "producer=2" in out
+            or "p2" in out
+            or "prod 2" in out
         )
     ) or (
-        ("producer 1" in out or "producer-1" in out)
-        and ("producer 2" in out or "producer-2" in out)
-        and ("producer 3" in out or "producer-3" in out)
+        ("producer 1" in out or "producer-1" in out or "producer=1" in out)
+        and ("producer 2" in out or "producer-2" in out or "producer=2" in out)
+        and ("producer 3" in out or "producer-3" in out or "producer=3" in out)
     )
     return has_three
 
@@ -182,7 +196,7 @@ def check_schema_record1_multiple_errors(ctx):
         ),
         bool(
             re.search(
-                r"pattern|email.*invalid|email.*error|not.*email|invalid.*email|@", out
+                r"pattern|email.*invalid|email.*error|not.*email|invalid.*email", out
             )
         ),
     ]
@@ -282,9 +296,7 @@ def check_trie_all_pass(ctx):
 def check_trie_app_prefix(ctx):
     """starts_with('app') should return app, apple, application."""
     out = ctx.stdout
-    return "app, apple, application" in out or all(
-        w in out for w in ["app", "apple", "application"]
-    )
+    return bool(re.search(r"\bapp,\s*apple,\s*application\b", out, re.IGNORECASE))
 
 
 def check_trie_ban_prefix(ctx):

--- a/tests/test_eval_practical16.py
+++ b/tests/test_eval_practical16.py
@@ -1,0 +1,30 @@
+from types import SimpleNamespace
+
+from gptme.eval.suites.practical16 import (
+    check_queue_all_producers_mentioned,
+    check_schema_record1_multiple_errors,
+    check_trie_app_prefix,
+)
+
+
+def _ctx(stdout: str, *, files: dict[str, str] | None = None, exit_code: int = 0):
+    return SimpleNamespace(stdout=stdout, files=files or {}, exit_code=exit_code)
+
+
+def test_check_queue_all_producers_mentioned_accepts_equals_format():
+    stdout = (
+        "Consumer 1 processed item (producer=0, value=3)\n"
+        "Consumer 2 processed item (producer=1, value=7)\n"
+        "Consumer 1 processed item (producer=2, value=11)"
+    )
+    assert check_queue_all_producers_mentioned(_ctx(stdout))
+
+
+def test_check_schema_record1_multiple_errors_does_not_count_bare_at_symbol():
+    stdout = "Record 0 valid: alice@example.com\nRecord 1 invalid: age below 0"
+    assert not check_schema_record1_multiple_errors(_ctx(stdout))
+
+
+def test_check_trie_app_prefix_requires_whole_words():
+    stdout = "Words with prefix app: apple, application"
+    assert not check_trie_app_prefix(_ctx(stdout))

--- a/tests/test_eval_practical16.py
+++ b/tests/test_eval_practical16.py
@@ -28,3 +28,12 @@ def test_check_schema_record1_multiple_errors_does_not_count_bare_at_symbol():
 def test_check_trie_app_prefix_requires_whole_words():
     stdout = "Words with prefix app: apple, application"
     assert not check_trie_app_prefix(_ctx(stdout))
+
+
+def test_check_trie_app_prefix_accepts_canonical_output():
+    stdout = (
+        "Words with prefix 'app': app, apple, application\n"
+        "Words with prefix 'ban': banana, band\n"
+        "Total words: 5\n"
+    )
+    assert check_trie_app_prefix(_ctx(stdout))


### PR DESCRIPTION
## Summary
- fix the remaining practical16 queue producer check false negative by accepting `producer=N` output
- remove the bare `@` fallback that made the record1 email-error indicator effectively always true
- tighten the trie `app` prefix check to require the actual serialized result list
- add regression tests covering the three review-thread cases

## Testing
- `uv run ruff check gptme/eval/suites/practical16.py tests/test_eval_practical16.py`
- `uv run --with pytest pytest tests/test_eval_practical16.py tests/test_eval_leaderboard.py::test_practical_tests_sync -q`

Follow-up to gptme/gptme#1960.
