### PR TITLE
test(computer): assert screenshot resize dimensions

### DIFF
--- a/tests/test_tools_computer.py
+++ b/tests/test_tools_computer.py
@@ -591,7 +591,11 @@ def test_computer_screenshot_success(
         args=[], returncode=0
     )
 
-    result = computer("screenshot")
+    # Unset WIDTH/HEIGHT so env vars don't override the mocked display resolution.
+    with mock.patch.dict("os.environ", {}, clear=False) as env:
+        env.pop("WIDTH", None)
+        env.pop("HEIGHT", None)
+        result = computer("screenshot")
     mock_screenshot.assert_called_once()
     mock_view_image.assert_called_once_with(mock_path)
     assert result == "image_message"

--- a/tests/test_tools_computer.py
+++ b/tests/test_tools_computer.py
@@ -595,6 +595,12 @@ def test_computer_screenshot_success(
     mock_screenshot.assert_called_once()
     mock_view_image.assert_called_once_with(mock_path)
     assert result == "image_message"
+    # Verify resize uses correct API dimensions, not squared coordinates.
+    cmd = mock_subprocess_run.call_args[0][0]
+    assert "-resize" in cmd
+    resize_dim = cmd[cmd.index("-resize") + 1]
+    # With physical 1920x1080 (16:9), FWXGA (1366x768) is the closest API target.
+    assert resize_dim == "1366x768!"
 
 
 @mock.patch("gptme.tools.computer.IS_MACOS", False)


### PR DESCRIPTION
## Summary

- add a regression assertion in test_computer_screenshot_success
- verify the screenshot resize command uses the API dimensions directly
- close the Greptile P2 follow-up from #1949, where the branch-only commit fc74498 never landed on master

## Test plan

- [x] poetry run pytest tests/test_tools_computer.py -q
