### PR TITLE
feat(lessons): support holdout exclusions in auto-include hook

### DIFF
--- a/gptme/tools/lessons.py
+++ b/gptme/tools/lessons.py
@@ -22,7 +22,7 @@ from typing import TYPE_CHECKING
 from ..commands import CommandContext
 from ..config import get_config
 from ..hooks import HookType, StopPropagation
-from ..lessons import LessonIndex, LessonMatcher, MatchContext
+from ..lessons import Lesson, LessonIndex, LessonMatcher, MatchContext
 from ..lessons.commands import lesson
 from ..message import Message
 from .base import ToolSpec
@@ -44,7 +44,7 @@ def _parse_holdout_lessons(raw: str | None) -> set[str]:
     }
 
 
-def _is_holdout_lesson(lesson, holdout_lessons: set[str]) -> bool:
+def _is_holdout_lesson(lesson: "Lesson", holdout_lessons: set[str]) -> bool:
     """Return True if the lesson matches a configured holdout identifier."""
     if not holdout_lessons:
         return False
@@ -54,7 +54,7 @@ def _is_holdout_lesson(lesson, holdout_lessons: set[str]) -> bool:
     identifiers = {
         path_str,
         path.name.lower(),
-        (path.parent.name if path.name == "SKILL.md" else path.stem).lower(),
+        (path.parent.name if path.name.upper() == "SKILL.MD" else path.stem).lower(),
     }
 
     lesson_id = getattr(lesson.metadata, "id", None)
@@ -242,7 +242,7 @@ def auto_include_lessons_hook(
     # Get configuration
     config = get_config()
     auto_include = config.get_env_bool("GPTME_LESSONS_AUTO_INCLUDE", True)
-    holdout_lessons = _parse_holdout_lessons(config.get_env("HOLDOUT_LESSONS"))
+    holdout_lessons = _parse_holdout_lessons(config.get_env("GPTME_LESSONS_HOLDOUT"))
 
     if not auto_include:
         logger.debug("Auto-inclusion disabled")

--- a/gptme/tools/lessons.py
+++ b/gptme/tools/lessons.py
@@ -33,6 +33,45 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _parse_holdout_lessons(raw: str | None) -> set[str]:
+    """Parse comma-separated lesson identifiers from HOLDOUT_LESSONS."""
+    if not raw:
+        return set()
+    return {
+        token.strip().lower().replace("\\", "/")
+        for token in raw.split(",")
+        if token.strip()
+    }
+
+
+def _is_holdout_lesson(lesson, holdout_lessons: set[str]) -> bool:
+    """Return True if the lesson matches a configured holdout identifier."""
+    if not holdout_lessons:
+        return False
+
+    path = lesson.path
+    path_str = str(path).lower().replace("\\", "/")
+    identifiers = {
+        path_str,
+        path.name.lower(),
+        (path.parent.name if path.name == "SKILL.md" else path.stem).lower(),
+    }
+
+    lesson_id = getattr(lesson.metadata, "id", None)
+    if lesson_id:
+        identifiers.add(str(lesson_id).strip().lower())
+
+    for token in holdout_lessons:
+        if token in identifiers:
+            return True
+        if "/" in token or token.endswith(".md"):
+            normalized = token.lstrip("./")
+            if path_str == normalized or path_str.endswith(f"/{normalized}"):
+                return True
+
+    return False
+
+
 def _get_ace_components() -> tuple[type | None, type | None]:
     """Lazily import ACE components when needed.
 
@@ -203,6 +242,7 @@ def auto_include_lessons_hook(
     # Get configuration
     config = get_config()
     auto_include = config.get_env_bool("GPTME_LESSONS_AUTO_INCLUDE", True)
+    holdout_lessons = _parse_holdout_lessons(config.get_env("HOLDOUT_LESSONS"))
 
     if not auto_include:
         logger.debug("Auto-inclusion disabled")
@@ -321,7 +361,8 @@ def auto_include_lessons_hook(
         new_matches = [
             match
             for match in match_results
-            if str(match.lesson.path) not in included_lessons
+            if not _is_holdout_lesson(match.lesson, holdout_lessons)
+            and str(match.lesson.path) not in included_lessons
             and str(match.lesson.path) not in stats.unique_lessons
         ]
 

--- a/tests/test_tools_lessons.py
+++ b/tests/test_tools_lessons.py
@@ -416,6 +416,58 @@ class TestAutoIncludeLessonsHook:
 
     @patch("gptme.tools.lessons._get_lesson_index")
     @patch("gptme.tools.lessons.get_config")
+    def test_skips_holdout_lessons(self, mock_config, mock_index):
+        """Lessons named in HOLDOUT_LESSONS are not auto-included."""
+        config = MagicMock()
+        config.get_env_bool.side_effect = lambda key, default: default
+        config.get_env.side_effect = lambda key: (
+            "strict-time-boxing"
+            if key == "HOLDOUT_LESSONS"
+            else "20"
+            if key == "GPTME_LESSONS_MAX_SESSION"
+            else None
+        )
+        mock_config.return_value = config
+
+        holdout = Lesson(
+            path=Path("/lessons/workflow/strict-time-boxing.md"),
+            metadata=LessonMetadata(keywords=["time boxing"]),
+            title="Strict Time Boxing",
+            description="Holdout lesson",
+            category="workflow",
+            body="Stop after 10 minutes.",
+        )
+        control = Lesson(
+            path=Path("/lessons/workflow/progress-despite-blockers.md"),
+            metadata=LessonMetadata(keywords=["blocked"]),
+            title="Progress Despite Blockers",
+            description="Control lesson",
+            category="workflow",
+            body="Keep moving.",
+        )
+        mock_idx = MagicMock()
+        mock_idx.lessons = [holdout, control]
+        mock_index.return_value = mock_idx
+
+        manager = self._make_manager([_msg("user", "I am blocked and need to move on")])
+
+        with patch("gptme.tools.lessons.LessonMatcher") as MockMatcher:
+            mock_matcher = MagicMock()
+            mock_matcher.match.return_value = [
+                _match_result(holdout, matched_by=["keyword:time boxing"]),
+                _match_result(control, matched_by=["keyword:blocked"]),
+            ]
+            MockMatcher.return_value = mock_matcher
+
+            results = list(auto_include_lessons_hook(manager))
+
+        assert len(results) == 1
+        assert isinstance(results[0], Message)
+        assert "Progress Despite Blockers" in results[0].content
+        assert "Strict Time Boxing" not in results[0].content
+
+    @patch("gptme.tools.lessons._get_lesson_index")
+    @patch("gptme.tools.lessons.get_config")
     def test_respects_session_limit(self, mock_config, mock_index):
         """Session lesson limit prevents including too many."""
         config = MagicMock()

--- a/tests/test_tools_lessons.py
+++ b/tests/test_tools_lessons.py
@@ -417,12 +417,12 @@ class TestAutoIncludeLessonsHook:
     @patch("gptme.tools.lessons._get_lesson_index")
     @patch("gptme.tools.lessons.get_config")
     def test_skips_holdout_lessons(self, mock_config, mock_index):
-        """Lessons named in HOLDOUT_LESSONS are not auto-included."""
+        """Lessons named in GPTME_LESSONS_HOLDOUT are not auto-included."""
         config = MagicMock()
         config.get_env_bool.side_effect = lambda key, default: default
         config.get_env.side_effect = lambda key: (
             "strict-time-boxing"
-            if key == "HOLDOUT_LESSONS"
+            if key == "GPTME_LESSONS_HOLDOUT"
             else "20"
             if key == "GPTME_LESSONS_MAX_SESSION"
             else None


### PR DESCRIPTION
## Summary
- respect `GPTME_LESSONS_HOLDOUT` in the native lesson auto-include hook
- match holdouts by stable id, stem, filename, or path suffix
- add coverage proving held-out lessons are skipped while other matches still inject

## Testing
- uv run pytest tests/test_tools_lessons.py -q
- uv run mypy --ignore-missing-imports gptme/tools/lessons.py tests/test_tools_lessons.py
- uv run ruff check gptme/tools/lessons.py tests/test_tools_lessons.py