### PR TITLE
docs(eval): document current SWE-Bench support

### DIFF
--- a/docs/evals.rst
+++ b/docs/evals.rst
@@ -193,6 +193,43 @@ To view raw results locally:
 Other evals
 -----------
 
-We have considered running gptme on other evals such as SWE-Bench, but have not finished it (see `PR #142 <https://github.com/gptme/gptme/pull/142>`_).
+SWE-Bench support is now available via ``gptme-eval-swebench``.
+It can:
 
-If you are interested in running gptme on other evals, drop a comment in the issues!
+- inspect datasets and instances with ``--info``
+- generate ``predictions.jsonl`` in the official SWE-Bench format
+- resume interrupted runs with ``--resume``
+- optionally invoke the official harness with ``--run-harness``
+
+Example single-instance smoke test:
+
+.. code-block:: bash
+
+    gptme-eval-swebench \
+        -m anthropic/claude-sonnet-4-5-20250929 \
+        -i django__django-11099
+
+Example full SWE-Bench Lite run:
+
+.. code-block:: bash
+
+    gptme-eval-swebench \
+        -m anthropic/claude-sonnet-4-5-20250929 \
+        --resume \
+        --run-harness \
+        --dataset princeton-nlp/SWE-bench_Lite \
+        --run-id gptme_baseline_2026
+
+Notes:
+
+- The built-in summary printed by ``gptme-eval-swebench`` is a lightweight file-coverage heuristic.
+  For authoritative pass/fail results and leaderboard submission, use the official SWE-Bench harness.
+
+- ``--run-harness`` requires Docker plus ``swebench[evaluation]`` dependencies.
+
+- Use ``gptme-eval-swebench --info`` to inspect dataset size and specific instance IDs before launching an expensive run.
+
+See also:
+
+- `PR #1994 <https://github.com/gptme/gptme/pull/1994>`_ — SWE-Bench harness integration
+- `PR #2045 <https://github.com/gptme/gptme/pull/2045>`_ — resume support for interrupted runs

--- a/docs/evals.rst
+++ b/docs/evals.rst
@@ -206,7 +206,7 @@ Example single-instance smoke test:
 .. code-block:: bash
 
     gptme-eval-swebench \
-        -m anthropic/claude-sonnet-4-5-20250929 \
+        -m anthropic/claude-sonnet-4-6 \
         -i django__django-11099
 
 Example full SWE-Bench Lite run:
@@ -214,7 +214,7 @@ Example full SWE-Bench Lite run:
 .. code-block:: bash
 
     gptme-eval-swebench \
-        -m anthropic/claude-sonnet-4-5-20250929 \
+        -m anthropic/claude-sonnet-4-6 \
         --resume \
         --run-harness \
         --dataset princeton-nlp/SWE-bench_Lite \

--- a/gptme/eval/swebench/main.py
+++ b/gptme/eval/swebench/main.py
@@ -116,12 +116,12 @@ def main(
 
     Quick start (single instance, no Docker)::
 
-        gptme-eval-swebench -m anthropic/claude-sonnet-4-5-20250929 \\
+        gptme-eval-swebench -m anthropic/claude-sonnet-4-6 \\
             -i django__django-11099
 
     Full evaluation with official harness (requires Docker)::
 
-        gptme-eval-swebench -m anthropic/claude-sonnet-4-5-20250929 --run-harness
+        gptme-eval-swebench -m anthropic/claude-sonnet-4-6 --run-harness
 
     After generation, run the official harness manually::
 
@@ -141,7 +141,7 @@ def main(
     if not model:
         model = [
             "openai/gpt-4o",
-            "anthropic/claude-sonnet-4-5-20250929",
+            "anthropic/claude-sonnet-4-6",
         ]
 
     print("=== Running SWE-bench evaluation ===")

--- a/gptme/eval/swebench/main.py
+++ b/gptme/eval/swebench/main.py
@@ -141,7 +141,7 @@ def main(
     if not model:
         model = [
             "openai/gpt-4o",
-            "anthropic/claude-3-5-sonnet-20240620",
+            "anthropic/claude-sonnet-4-5-20250929",
         ]
 
     print("=== Running SWE-bench evaluation ===")

--- a/gptme/eval/swebench/main.py
+++ b/gptme/eval/swebench/main.py
@@ -116,12 +116,12 @@ def main(
 
     Quick start (single instance, no Docker)::
 
-        gptme-eval-swebench -m anthropic/claude-3-5-sonnet-20241022 \\
+        gptme-eval-swebench -m anthropic/claude-sonnet-4-5-20250929 \\
             -i django__django-11099
 
     Full evaluation with official harness (requires Docker)::
 
-        gptme-eval-swebench -m anthropic/claude-3-5-sonnet-20241022 --run-harness
+        gptme-eval-swebench -m anthropic/claude-sonnet-4-5-20250929 --run-harness
 
     After generation, run the official harness manually::
 


### PR DESCRIPTION
## Summary
- replace the stale "SWE-Bench not finished" note with current usage docs
- document `gptme-eval-swebench` capabilities, smoke-test usage, and full Lite run example
- update stale deprecated model examples in the SWE-Bench CLI docstring

## Testing
- `uv run pytest /home/bob/gptme/tests/test_eval_swebench.py -q`
- `python3 -m compileall /home/bob/gptme/gptme/eval/swebench/main.py`
