### PR TITLE
fix(server): improve external session provider detection for uv tool installs

### DIFF
--- a/gptme/server/external_sessions.py
+++ b/gptme/server/external_sessions.py
@@ -151,4 +151,26 @@ def get_external_session_provider() -> ExternalSessionProvider | None:
     try:
         return ExternalSessionProvider()
     except ImportError:
+        _warn_if_cli_only()
         return None
+
+
+def _warn_if_cli_only() -> None:
+    """Log a helpful warning when gptme-sessions CLI is in PATH but not importable.
+
+    This happens when gptme-sessions is installed via ``uv tool install`` (isolated
+    venv) rather than into gptme's own Python environment.
+    """
+    import shutil
+
+    if shutil.which("gptme-sessions"):
+        logger.warning(
+            "gptme-sessions CLI found in PATH but the gptme_sessions Python package is "
+            "not importable from gptme's environment. "
+            "The external session catalog feature requires gptme_sessions to be installed "
+            "in the same Python environment as gptme-server. "
+            "If you installed via 'uv tool install gptme-sessions', that creates an isolated "
+            "venv — the module is not visible to gptme. "
+            "Instead, install it into gptme's venv: "
+            "pip install gptme-sessions  (or add it to gptme's dependencies)."
+        )

--- a/gptme/server/external_sessions.py
+++ b/gptme/server/external_sessions.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import functools
 import hashlib
 import logging
 from dataclasses import dataclass
@@ -146,8 +147,12 @@ class ExternalSessionProvider:
         return None
 
 
+@functools.lru_cache(maxsize=1)
 def get_external_session_provider() -> ExternalSessionProvider | None:
-    """Return the optional external session provider if dependencies are available."""
+    """Return the optional external session provider if dependencies are available.
+
+    Cached so the import attempt and CLI-only warning happen at most once per process.
+    """
     try:
         return ExternalSessionProvider()
     except ImportError:

--- a/webui/src/components/ExternalSessionsView.tsx
+++ b/webui/src/components/ExternalSessionsView.tsx
@@ -193,8 +193,10 @@ export const ExternalSessionsView: FC = () => {
           <h2 className="text-lg font-medium">External sessions unavailable</h2>
           <p className="mt-1 text-sm text-muted-foreground">
             The server does not have an external session provider configured. Install{' '}
-            <code className="rounded bg-muted px-1 text-xs">gptme-sessions</code> and restart the
-            server to enable this feature.
+            <code className="rounded bg-muted px-1 text-xs">gptme-sessions</code> into{' '}
+            <strong>gptme&apos;s Python environment</strong> (not via{' '}
+            <code className="rounded bg-muted px-1 text-xs">uv tool install</code>, which creates an
+            isolated venv) and restart the server to enable this feature.
           </p>
         </div>
       </div>


### PR DESCRIPTION
## Problem

When `gptme-sessions` is installed via `uv tool install gptme-sessions`, it goes into an isolated venv at `~/.local/share/uv/tools/gptme-sessions/`. The `gptme_sessions` Python module is **not importable** from gptme's own Python environment.

The current `get_external_session_provider()` silently catches the `ImportError` and returns `None`, which causes the server to return a 503. The webui then shows:

> "The server does not have an external session provider configured. Install `gptme-sessions` and restart the server to enable this feature."

This message is misleading — `gptme-sessions` IS installed, just in the wrong way.

Reported in: gptme/gptme#1922 (comment by @ErikBjare)

## Fix

1. **Server-side**: Add `_warn_if_cli_only()` — when the import fails, check if the `gptme-sessions` CLI is in PATH. If it is, log an actionable warning explaining the correct install method.

2. **Webui**: Update the 503 error message to clarify that `uv tool install` creates an isolated venv, and the package must be installed in gptme's Python environment.

## How to correctly install gptme-sessions

```bash
# Into gptme's venv (after activating it):
pip install gptme-sessions

# Or with uv, in gptme's project dir:
uv add gptme-sessions

# NOT this (creates isolated venv):
uv tool install gptme-sessions  # ❌
```