### PR TITLE
fix(ci): fall back to unsigned tauri release when Apple secrets are missing

### DIFF
--- a/.github/workflows/tauri.yml
+++ b/.github/workflows/tauri.yml
@@ -281,6 +281,8 @@ jobs:
       needs.build.result == 'success' &&
       (startsWith(github.ref, 'refs/tags/v') || inputs.tag != '')
     needs: [lint, test, build, build-sidecar]
+    env:
+      HAS_APPLE_SIGNING: ${{ secrets.APPLE_CERTIFICATE != '' && secrets.APPLE_CERTIFICATE_PASSWORD != '' && secrets.KEYCHAIN_PASSWORD != '' && secrets.APPLE_ID != '' && secrets.APPLE_ID_PASSWORD != '' && secrets.APPLE_TEAM_ID != '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -452,7 +454,8 @@ jobs:
           print(f"Tauri semver version: {semver_version}")
           PY
 
-      - name: Build and publish release
+      - name: Build and publish release (signed macOS)
+        if: matrix.platform == 'macos-latest' && env.HAS_APPLE_SIGNING == 'true'
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -462,6 +465,20 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        with:
+          projectPath: tauri
+          tagName: ${{ inputs.tag || github.ref_name }}
+          releaseName: 'gptme ${{ inputs.tag || github.ref_name }}'
+          releaseBody: 'Desktop app release. See the assets to download and install.'
+          releaseDraft: ${{ inputs.tag == '' }}
+          prerelease: ${{ contains(inputs.tag || github.ref_name, '.dev') || contains(inputs.tag || github.ref_name, '.a') || contains(inputs.tag || github.ref_name, '.b') || contains(inputs.tag || github.ref_name, '.rc') }}
+          args: ${{ matrix.args }}
+
+      - name: Build and publish release (unsigned/fallback)
+        if: matrix.platform != 'macos-latest' || env.HAS_APPLE_SIGNING != 'true'
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           projectPath: tauri
           tagName: ${{ inputs.tag || github.ref_name }}


### PR DESCRIPTION
Fixes #2118.

## Summary
- compute a single `HAS_APPLE_SIGNING` flag for the release job
- only run the signed macOS Tauri release step when the full Apple signing/notarization secret set is present
- add an unsigned fallback release step so missing Apple secrets no longer make the macOS release fail

## Why
The current release workflow always invokes `tauri-action` with Apple signing env vars, even when the secrets are empty. That makes the macOS release path fail with `failed to import keychain certificate` instead of degrading cleanly to an unsigned build.

We already warn and skip certificate import earlier in the job, so the final release step should match that behavior.

## Verification
- inspected failing run `24192794939` and confirmed the failure mode was `failed to import keychain certificate` after the workflow had already printed `Warning: Apple signing certificates not available. Building without code signing.`
- parsed the updated workflow with `yaml.safe_load(...)`
- verified the release job now contains separate signed and unsigned/fallback steps with mutually exclusive conditions
