### PR TITLE
feat(skills): add MiniMax-AI/cli as default skill tap

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,12 @@ enabled = ["my_plugin"]
 | [gptme-ace](https://github.com/gptme/gptme-contrib/tree/master/plugins/gptme-ace) | ACE-inspired context optimization |
 | [gptme-gupp](https://github.com/gptme/gptme-contrib/tree/master/plugins/gptme-gupp) | Work state persistence across sessions |
 
+**Third-party skills** — install via `gptme-util skills install <git-url>#<path>`:
+
+| Skill | Description |
+|-------|-------------|
+| [mmx-cli](https://github.com/MiniMax-AI/cli) | Generate text, images, video, speech, and music via MiniMax AI |
+
 ### 🔗 Integrations: MCP & ACP
 
 **[MCP (Model Context Protocol)][docs-mcp]** — use any MCP server as a tool source:


### PR DESCRIPTION
## Summary

- Add `MiniMax-AI/cli` to the **Third-party skills** section in README so the mmx-cli skill is discoverable out of the box
- Users can install via `gptme-util skills install https://github.com/MiniMax-AI/cli.git#skill/` — the SKILL.md is fetched directly from [MiniMax-AI/cli](https://github.com/MiniMax-AI/cli/blob/main/skill/SKILL.md)
- Skill updates are fully decoupled: MiniMax maintains the upstream SKILL.md, no changes needed in this project

**6 lines added, 0 new files.**

## What is mmx-cli?

[mmx-cli](https://github.com/MiniMax-AI/cli) is a CLI tool for the MiniMax AI platform, providing:
- **Text generation** (MiniMax-M2.7 model)
- **Image generation** (image-01)
- **Video generation** (Hailuo-2.3)
- **Speech synthesis** (speech-2.8-hd, 300+ voices)
- **Music generation** (music-2.6, with lyrics, cover, and instrumental)
- **Web search**

The [SKILL.md](https://github.com/MiniMax-AI/cli/blob/main/skill/SKILL.md) follows the [agentskills.io](https://agentskills.io) standard and includes agent-specific flags (`--non-interactive`, `--quiet`, `--output json`).

## Test plan

- `gptme-util skills install https://github.com/MiniMax-AI/cli.git#skill/` installs successfully
- Ask agent "generate a jazz instrumental" — agent invokes `mmx music generate` via terminal