### PR TITLE
fix(chats): use 1-indexed labels in read to match --start parameter

### DIFF
--- a/gptme/tools/chats.py
+++ b/gptme/tools/chats.py
@@ -230,7 +230,7 @@ def read_chat(
                 start_idx = max(0, start_message - 1 - context_messages)
                 messages = messages[start_idx:]
             for i, msg in enumerate(messages[:max_results]):
-                print(f"{start_idx + i}. {msg.format(max_length=100)}")
+                print(f"{start_idx + i + 1}. {msg.format(max_length=100)}")
             break
     else:
         print(f"Conversation '{id}' not found.")


### PR DESCRIPTION
Follow-up to #2155. Greptile flagged this P2 UX issue: message labels in `gptme-util chats read` were 0-indexed while `--start` is 1-indexed, creating a confusing off-by-one for users.

## Before
```
0. user: How do I...
1. assistant: Here is...
2. user: Follow-up...
```
To start at label 2: `--start 3` (non-obvious)

## After
```
1. user: How do I...
2. assistant: Here is...
3. user: Follow-up...
```
To start at label 3: `--start 3` ✓

This also makes `read_chat` consistent with `list_chats` and `search_chats`, which already use `enumerate(..., 1)` (1-indexed).