### PR TITLE
fix(server): include exception detail in tasks API error responses

### DIFF
--- a/gptme/server/tasks_api.py
+++ b/gptme/server/tasks_api.py
@@ -318,13 +318,13 @@ def get_task_info(task: Task) -> dict[str, Any]:
 
                 except Exception as e:
                     logger.error(f"Error getting git status for {task.id}: {e}")
-                    result["git"] = {"error": "Could not get git status"}
+                    result["git"] = {"error": f"Could not get git status: {e}"}
             else:
                 result["git"] = {"error": "Workspace does not exist"}
 
         except Exception as e:
             logger.error(f"Error getting task info for {task.id}: {e}")
-            result["error"] = "Error getting task info"
+            result["error"] = f"Error getting task info: {e}"
 
     return result
 
@@ -574,7 +574,7 @@ def get_git_status(workspace_path: Path) -> dict[str, Any]:
 
     except Exception as e:
         logger.error(f"Error getting git status for {workspace_path}: {e}")
-        return {"error": "Could not get git status"}
+        return {"error": f"Could not get git status: {e}"}
 
 
 def create_task_conversation(task: Task) -> str:
@@ -698,7 +698,7 @@ def api_tasks_list():
 
     except Exception as e:
         logger.error(f"Error listing tasks: {e}")
-        return flask.jsonify({"error": "Error listing tasks"}), 500
+        return flask.jsonify({"error": f"Error listing tasks: {e}"}), 500
 
 
 @tasks_api.route("/api/v2/tasks", methods=["POST"])
@@ -772,7 +772,7 @@ def api_tasks_create():
 
     except Exception as e:
         logger.error(f"Error creating task: {e}")
-        return flask.jsonify({"error": "Error creating task"}), 500
+        return flask.jsonify({"error": f"Error creating task: {e}"}), 500
 
 
 @tasks_api.route("/api/v2/tasks/<string:task_id>")
@@ -805,7 +805,7 @@ def api_tasks_get(task_id: str):
         return flask.jsonify(task_info)
     except Exception as e:
         logger.error(f"Error getting task {task_id}: {e}")
-        return flask.jsonify({"error": "Error getting task"}), 500
+        return flask.jsonify({"error": f"Error getting task: {e}"}), 500
 
 
 @tasks_api.route("/api/v2/tasks/<string:task_id>", methods=["PUT"])
@@ -871,7 +871,7 @@ def api_tasks_update(task_id: str):
 
     except Exception as e:
         logger.error(f"Error updating task {task_id}: {e}")
-        return flask.jsonify({"error": "Error updating task"}), 500
+        return flask.jsonify({"error": f"Error updating task: {e}"}), 500
 
 
 @tasks_api.route("/api/v2/tasks/<string:task_id>/archive", methods=["POST"])
@@ -907,7 +907,7 @@ def api_tasks_archive(task_id: str):
 
     except Exception as e:
         logger.error(f"Error archiving task {task_id}: {e}")
-        return flask.jsonify({"error": "Error archiving task"}), 500
+        return flask.jsonify({"error": f"Error archiving task: {e}"}), 500
 
 
 @tasks_api.route("/api/v2/tasks/<string:task_id>/unarchive", methods=["POST"])
@@ -943,4 +943,4 @@ def api_tasks_unarchive(task_id: str):
 
     except Exception as e:
         logger.error(f"Error unarchiving task {task_id}: {e}")
-        return flask.jsonify({"error": "Error unarchiving task"}), 500
+        return flask.jsonify({"error": f"Error unarchiving task: {e}"}), 500


### PR DESCRIPTION
Follow-up to #2151 (actionable error messages). The tasks API returned generic strings like `"Error listing tasks"` or `"Could not get git status"` in error responses, hiding the actual exception from clients.

## Changes

9 instances in `tasks_api.py` now include `str(e)` in the error response:

- `"Error listing tasks"` → `f"Error listing tasks: {e}"`
- `"Error creating task"` → `f"Error creating task: {e}"`
- `"Error getting task"` → `f"Error getting task: {e}"`
- `"Error updating task"` → `f"Error updating task: {e}"`
- `"Error archiving task"` → `f"Error archiving task: {e}"`
- `"Error unarchiving task"` → `f"Error unarchiving task: {e}"`
- `"Error getting task info"` (internal dict) → `f"Error getting task info: {e}"`
- `"Could not get git status"` (×2) → `f"Could not get git status: {e}"`

The logger already received the full exception; this just surfaces it to clients too, making debugging much easier without changing behavior.