### PR TITLE
fix(eval): clean up auto-created host_dir in DockerExecutionEnv

### DIFF
--- a/gptme/eval/execenv.py
+++ b/gptme/eval/execenv.py
@@ -126,6 +126,7 @@ class DockerExecutionEnv(ExecutionEnv):
     ):
         self.image = image
         self.working_dir = working_dir
+        self._owns_host_dir = host_dir is None
         self.host_dir = host_dir or Path(tempfile.mkdtemp(prefix="gptme-docker-"))
         self.host_dir.mkdir(parents=True, exist_ok=True)
         self.container_id: str | None = None
@@ -259,7 +260,7 @@ class DockerExecutionEnv(ExecutionEnv):
         return files
 
     def cleanup(self) -> None:
-        """Stop and remove Docker container."""
+        """Stop and remove Docker container, then clean up auto-created host_dir."""
         if self.container_id:
             try:
                 subprocess.run(
@@ -281,6 +282,9 @@ class DockerExecutionEnv(ExecutionEnv):
                 )
             except subprocess.TimeoutExpired:
                 pass  # best-effort cleanup
+            self.container_id = None
+        if self._owns_host_dir and self.host_dir.exists():
+            shutil.rmtree(self.host_dir, ignore_errors=True)
 
     def __del__(self) -> None:
         """Cleanup container on object destruction."""

--- a/tests/test_execenv.py
+++ b/tests/test_execenv.py
@@ -84,6 +84,37 @@ class TestDockerExecutionEnv:
             assert "output.txt" in files
             assert files["output.txt"] == "output content"
 
+    def test_cleanup_removes_auto_created_host_dir(self):
+        """Auto-created host_dir (default None) must be removed by cleanup()."""
+        env = DockerExecutionEnv()
+        assert env._owns_host_dir is True
+        host_dir = env.host_dir
+        assert host_dir.exists()
+        assert host_dir.name.startswith("gptme-docker-")
+
+        env.cleanup()
+        assert not host_dir.exists()
+
+    def test_cleanup_preserves_user_provided_host_dir(self):
+        """User-provided host_dir must NOT be removed by cleanup()."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            host_dir = Path(tmpdir) / "mine"
+            host_dir.mkdir()
+            (host_dir / "keep.txt").write_text("data")
+
+            env = DockerExecutionEnv(host_dir=host_dir)
+            assert env._owns_host_dir is False
+
+            env.cleanup()
+            assert host_dir.exists()
+            assert (host_dir / "keep.txt").read_text() == "data"
+
+    def test_cleanup_is_idempotent(self):
+        """cleanup() called twice should not raise even if host_dir is gone."""
+        env = DockerExecutionEnv()
+        env.cleanup()
+        env.cleanup()  # must not raise
+
 
 class TestDockerGPTMeEnv:
     """Tests for DockerGPTMeEnv - Docker-isolated gptme execution."""


### PR DESCRIPTION
## Summary

`DockerExecutionEnv.cleanup()` stops/removes the container but leaks the
tempdir created by the default `host_dir`. Over time this piles up.

Concrete evidence from Bob's VM right now:

```
$ ls -d /tmp/gptme-docker-* | wc -l
5483
$ du -sch /tmp/gptme-docker-* | tail -1
39M	total
```

Oldest leaked dirs go back to Feb 18. Each one holds just an empty
`logs/` subdir — nothing worth preserving — but the count keeps
growing with every eval run.

## Fix

- Track ownership with `_owns_host_dir` in `__init__`: `True` when we
  `mkdtemp`'d it ourselves, `False` when the caller supplied one.
- `cleanup()` now `shutil.rmtree`s `host_dir` only when we own it. User-
  supplied host_dirs (e.g. `DockerGPTMeEnv(host_dir=workspace_dir, ...)`
  in `agents/__init__.py`) are preserved, so external eval harness code
  is unaffected.
- Clear `self.container_id = None` after `docker rm` so a repeat
  `cleanup()` call (via `__del__` after an explicit `cleanup()`, or
  defensive double-invocation) doesn't re-issue commands against a
  dead id.

## Test plan

- [x] New test: auto-created `host_dir` is removed by `cleanup()`
- [x] New test: user-provided `host_dir` is preserved by `cleanup()`
- [x] New test: `cleanup()` is idempotent (second call doesn't raise)
- [x] `uv run pytest tests/test_execenv.py` — 28 passed
- [x] `uv run ruff check gptme/eval/execenv.py tests/test_execenv.py` — clean
- [ ] After merge: prune existing `/tmp/gptme-docker-*` on affected hosts (one-time cleanup)