### PR TITLE
fix(doctor): add node, npx, and docker to optional tool checks

### DIFF
--- a/gptme/cli/doctor.py
+++ b/gptme/cli/doctor.py
@@ -187,14 +187,29 @@ def _check_tools(verbose: bool = False) -> list[CheckResult]:
         ("git", "Version control"),
     ]
 
-    # Optional tools with their purpose
-    optional_tools = [
-        ("gh", "GitHub CLI - enables GitHub integration"),
-        ("tmux", "Terminal multiplexer - enables background tasks"),
-        ("lynx", "Text browser - fallback for web browsing"),
-        ("pdftotext", "PDF extraction - enables PDF reading"),
-        ("rg", "ripgrep - fast file searching"),
-        ("ast-grep", "AST-based code search"),
+    # Optional tools: (name, description, fix_hint or None for generic)
+    optional_tools: list[tuple[str, str, str | None]] = [
+        ("gh", "GitHub CLI - enables GitHub integration", None),
+        ("tmux", "Terminal multiplexer - enables background tasks", None),
+        (
+            "node",
+            "Node.js - required for npx-based MCP servers",
+            "Install from https://nodejs.org or via your package manager",
+        ),
+        (
+            "npx",
+            "npm package runner - runs MCP servers without install",
+            "Included with Node.js — install Node.js first",
+        ),
+        (
+            "docker",
+            "Docker - enables eval sandbox and containerized tasks",
+            "Install from https://docs.docker.com/get-docker/",
+        ),
+        ("lynx", "Text browser - fallback for web browsing", None),
+        ("pdftotext", "PDF extraction - enables PDF reading", None),
+        ("rg", "ripgrep - fast file searching", None),
+        ("ast-grep", "AST-based code search", None),
     ]
 
     # Check required tools
@@ -220,7 +235,7 @@ def _check_tools(verbose: bool = False) -> list[CheckResult]:
             )
 
     # Check optional tools
-    for tool, desc in optional_tools:
+    for tool, desc, fix_hint in optional_tools:
         path = shutil.which(tool)
         if path:
             results.append(
@@ -237,7 +252,7 @@ def _check_tools(verbose: bool = False) -> list[CheckResult]:
                     name=f"Tool: {tool}",
                     status=CheckStatus.WARNING,
                     message=f"Not found - {desc}",
-                    fix_hint=f"Install {tool} for additional features",
+                    fix_hint=fix_hint or f"Install {tool} for additional features",
                 )
             )
 

--- a/gptme/cli/doctor.py
+++ b/gptme/cli/doctor.py
@@ -199,7 +199,7 @@ def _check_tools(verbose: bool = False) -> list[CheckResult]:
         (
             "npx",
             "npm package runner - runs MCP servers without install",
-            "Included with Node.js — install Node.js first",
+            "Usually bundled with Node.js; on Debian/Ubuntu install `npm` separately",
         ),
         (
             "docker",
@@ -792,7 +792,7 @@ def print_results(results: list[CheckResult], summary: dict, verbose: bool = Fal
                 CheckStatus.ERROR,
                 CheckStatus.WARNING,
             ):
-                if verbose or result.status == CheckStatus.ERROR:
+                if verbose or result.status in (CheckStatus.ERROR, CheckStatus.WARNING):
                     table.add_row("", "", f"  [dim]→ {result.fix_hint}[/dim]")
 
         console.print(table)


### PR DESCRIPTION
## Summary

- Adds `node`, `npx`, and `docker` to the optional tool checks in `gptme-doctor`
- Node.js and npx are needed to run MCP servers (most popular MCP servers use `npx -y <server>`)
- Docker is needed for the eval sandbox functionality
- Adds specific install hints for each new tool (instead of the generic "install X for additional features")
- Refactors `optional_tools` from 2-tuples to 3-tuples `(name, desc, fix_hint)` to support per-tool hints

## Before

Running `gptme-doctor` wouldn't surface missing Node.js/Docker even when users are trying to use MCP or eval features.

## After

```
⚠️  node      Not found - Node.js - required for npx-based MCP servers
              → Install from https://nodejs.org or via your package manager
⚠️  npx       Not found - npm package runner - runs MCP servers without install
              → Included with Node.js — install Node.js first
⚠️  docker    Not found - Docker - enables eval sandbox and containerized tasks
              → Install from https://docs.docker.com/get-docker/
```

## Test plan

- [x] All 53 existing `test_doctor.py` tests still pass
- [x] `ruff` + `mypy` clean (pre-commit hooks passed)