### PR TITLE
fix(config): ignore unknown keys in [prompt] and [user] instead of crashing

### DIFF
--- a/gptme/config/user.py
+++ b/gptme/config/user.py
@@ -7,9 +7,9 @@ from ~/.config/gptme/config.toml and config.local.toml.
 import copy
 import logging
 import os
-from dataclasses import asdict
+from dataclasses import asdict, fields
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import tomlkit
 from tomlkit import TOMLDocument
@@ -32,6 +32,23 @@ logger = logging.getLogger(__name__)
 
 # Define the path to the config file
 config_path = os.path.expanduser("~/.config/gptme/config.toml")
+
+
+def _filter_known_fields(
+    cls: type, data: dict[str, Any], section: str
+) -> dict[str, Any]:
+    """Filter a dict down to fields known to a dataclass, warning about unknown keys.
+
+    This keeps older gptme versions forward-compatible with newer config schemas:
+    unknown keys are dropped with a warning instead of raising TypeError.
+    """
+    known = {f.name for f in fields(cls)}
+    unknown = set(data) - known
+    if unknown:
+        logger.warning(
+            f"Unknown keys in [{section}] config: {sorted(unknown)} (ignored)"
+        )
+    return {k: v for k, v in data.items() if k in known}
 
 
 ABOUT_ACTIVITYWATCH = """ActivityWatch is a free and open-source automated time-tracker that helps you track how you spend your time on your devices."""
@@ -93,14 +110,19 @@ def load_user_config(path: str | None = None) -> UserConfig:
 
     # Note: prompt and env are optional - defaults are used if missing
 
-    prompt = UserPromptConfig(**config.pop("prompt", {}))
+    prompt_data = config.pop("prompt", {})
+    prompt = UserPromptConfig(
+        **_filter_known_fields(UserPromptConfig, prompt_data, "prompt")
+    )
 
     # Parse [user] section (validate it's a dict in case of e.g. user = "Erik")
     user_data = config.pop("user", {})
     if not isinstance(user_data, dict):
         logger.warning(f"[user] should be a table, got {type(user_data).__name__}")
         user_data = {}
-    user_identity = UserIdentityConfig(**user_data)
+    user_identity = UserIdentityConfig(
+        **_filter_known_fields(UserIdentityConfig, user_data, "user")
+    )
 
     # Backward compat: if about/response_preference not set in [user],
     # fall back to [prompt].about_user / [prompt].response_preference

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -847,6 +847,35 @@ def test_user_identity_config_defaults():
     assert identity.response_preference is None
 
 
+def test_user_config_ignores_unknown_keys_in_prompt_and_user():
+    """Forward-compat: unknown keys in [prompt] or [user] should warn, not crash.
+
+    Reproduces gptme#2173: older gptme bundled in archived gptme-tauri v0.1.1
+    crashed with `TypeError: UserPromptConfig.__init__() got an unexpected keyword
+    argument 'files'` when reading a config written by a newer gptme.
+    """
+    config_toml = """
+[prompt]
+about_user = "Hi"
+future_field_added_by_newer_gptme = "should be ignored"
+
+[user]
+name = "Erik"
+some_future_user_key = 42
+
+[env]
+"""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".toml", delete=False) as f:
+        f.write(config_toml)
+        f.flush()
+        try:
+            config = load_user_config(f.name)
+            assert config.user.name == "Erik"
+            assert config.user.about == "Hi"
+        finally:
+            os.remove(f.name)
+
+
 def test_user_identity_config_partial_fallback():
     """Test that fallback works per-field."""
     config_toml = """


### PR DESCRIPTION
## Summary
Older gptme versions crash when reading configs that contain keys added in newer versions:

```txt
TypeError: UserPromptConfig.__init__() got an unexpected keyword argument 'files'
```

This makes the loader **forward-compatible**: unknown keys in `[prompt]` and `[user]` are dropped with a `logger.warning(...)` instead of crashing `load_user_config()`.

## Context
Reported in #2173 — the archived `gptme-tauri` v0.1.1 AppImage bundles an older `gptme-server` that chokes on current Bob workspace configs (which use `[prompt].files`). The same class of breakage will happen any time the bundled/frozen gptme lags the config schema.

Pattern mirrors how `MCPConfig.from_dict` already logs unknown keys rather than raising.

## Changes
- `gptme/config/user.py`: new `_filter_known_fields(cls, data, section)` helper that filters to known dataclass fields, warning on unknowns. Used at both `UserPromptConfig` and `UserIdentityConfig` construction sites.
- `tests/test_config.py`: new `test_user_config_ignores_unknown_keys_in_prompt_and_user` that writes a config with future-schema keys in both sections and asserts `load_user_config` succeeds.

## Test plan
- [x] New test passes: `uv run pytest tests/test_config.py::test_user_config_ignores_unknown_keys_in_prompt_and_user`
- [x] Full `tests/test_config.py` sweep: 32 passed
- [ ] CI green

## Notes
- Does NOT fix the secondary "No API key found, couldn't auto-detect provider" failure from #2173 — that's a separate first-run-setup issue and belongs in a distinct PR / in the desktop app.
- Only the two loader sites in `load_user_config` are touched; runtime model code is unchanged.