### PR TITLE
fix(server): start without a default model when no API keys configured

### DIFF
--- a/gptme/init.py
+++ b/gptme/init.py
@@ -34,6 +34,7 @@ def init(
     tool_format: ToolFormat,
     no_confirm: bool = False,
     server: bool = False,
+    require_llm: bool = True,
 ):
     """Initialize gptme.
 
@@ -44,6 +45,9 @@ def init(
         tool_format: Format for tool output
         no_confirm: Whether to skip tool confirmations
         server: Whether running in server mode (API/WebUI)
+        require_llm: If True (default), raise when LLM initialization fails.
+            If False, log a warning and continue without a default model —
+            callers (e.g. the server) can still accept per-request models.
     """
     global _init_done
     if _init_done:
@@ -52,16 +56,30 @@ def init(
         # between conversations in the same process (e.g. test suite)
         set_tool_format(tool_format)
         return
-    _init_done = True
 
     load_dotenv()
     _init_plugins()
-    init_model(model, interactive)
+    try:
+        init_model(model, interactive)
+    except (ValueError, KeyError) as e:
+        if require_llm:
+            raise
+        # Server/degraded mode: keep starting up so the app is reachable
+        # and the user can configure a provider via env/config/UI.
+        first_line = str(e).split("\n", 1)[0]
+        logger.warning(
+            "Continuing without a default model (%s). "
+            "Clients must supply a model per-request, or set an API key and restart.",
+            first_line,
+        )
     init_tools(tool_allowlist)
     init_hooks(interactive=interactive, no_confirm=no_confirm, server=server)
     init_commands()
 
     set_tool_format(tool_format)
+    # Mark initialization done at the end so callers can retry init()
+    # after a failure earlier in this function.
+    _init_done = True
 
 
 def _init_plugins():

--- a/gptme/server/cli.py
+++ b/gptme/server/cli.py
@@ -103,12 +103,16 @@ def serve(
             f"No default model configured. Using fallback: {fallback_model}. "
             "Set MODEL environment variable or use --model flag for explicit configuration."
         )
+        # require_llm=False: if the fallback provider also has no API key
+        # (e.g. first-run Tauri with no keys configured), start the server
+        # in degraded mode so the user can configure a provider via the UI.
         init(
             fallback_model,
             interactive=False,
             tool_allowlist=None if tools is None else tools.split(","),
             tool_format="markdown",
             server=True,
+            require_llm=False,
         )
 
     # Initialize telemetry (server is API/WebUI driven, not CLI interactive)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -232,6 +232,153 @@ class TestInit:
 
         assert mock_set_fmt.call_args_list[-1] == call("tool")
 
+    @patch("gptme.init.init_commands")
+    @patch("gptme.init.init_hooks")
+    @patch("gptme.init.init_tools")
+    @patch("gptme.init.init_model", side_effect=ValueError("No API key found"))
+    @patch("gptme.init.set_tool_format")
+    @patch("gptme.init.load_dotenv")
+    def test_init_require_llm_true_propagates_error(
+        self,
+        mock_dotenv,
+        mock_set_fmt,
+        mock_init_model,
+        mock_init_tools,
+        mock_init_hooks,
+        mock_init_commands,
+    ):
+        """require_llm=True (default) should re-raise init_model failures."""
+        from gptme.init import init
+
+        with pytest.raises(ValueError, match="No API key found"):
+            init(
+                model=None,
+                interactive=False,
+                tool_allowlist=None,
+                tool_format="markdown",
+            )
+        # Subsystems that come after init_model must not have been called
+        mock_init_tools.assert_not_called()
+        mock_init_hooks.assert_not_called()
+        mock_init_commands.assert_not_called()
+
+    @patch("gptme.init.init_commands")
+    @patch("gptme.init.init_hooks")
+    @patch("gptme.init.init_tools")
+    @patch("gptme.init.init_model", side_effect=ValueError("No API key found"))
+    @patch("gptme.init.set_tool_format")
+    @patch("gptme.init.load_dotenv")
+    def test_init_require_llm_false_continues_on_error(
+        self,
+        mock_dotenv,
+        mock_set_fmt,
+        mock_init_model,
+        mock_init_tools,
+        mock_init_hooks,
+        mock_init_commands,
+        caplog,
+    ):
+        """require_llm=False should swallow config errors and init the rest."""
+        from gptme.init import init
+
+        with caplog.at_level(logging.WARNING, logger="gptme.init"):
+            init(
+                model=None,
+                interactive=False,
+                tool_allowlist=None,
+                tool_format="markdown",
+                server=True,
+                require_llm=False,
+            )
+
+        mock_init_tools.assert_called_once()
+        mock_init_hooks.assert_called_once()
+        mock_init_commands.assert_called_once()
+        mock_set_fmt.assert_called_once_with("markdown")
+        assert any(
+            "Continuing without a default model" in rec.message
+            for rec in caplog.records
+        )
+
+    @patch("gptme.init.init_commands")
+    @patch("gptme.init.init_hooks")
+    @patch("gptme.init.init_tools")
+    @patch(
+        "gptme.init.init_model",
+        side_effect=KeyError("ANTHROPIC_API_KEY not set in env or config"),
+    )
+    @patch("gptme.init.set_tool_format")
+    @patch("gptme.init.load_dotenv")
+    def test_init_require_llm_false_handles_keyerror(
+        self,
+        mock_dotenv,
+        mock_set_fmt,
+        mock_init_model,
+        mock_init_tools,
+        mock_init_hooks,
+        mock_init_commands,
+    ):
+        """require_llm=False should also swallow KeyError from missing API keys."""
+        from gptme.init import init
+
+        init(
+            model="anthropic/claude-sonnet-4-6",
+            interactive=False,
+            tool_allowlist=None,
+            tool_format="markdown",
+            server=True,
+            require_llm=False,
+        )
+        mock_init_tools.assert_called_once()
+        mock_init_hooks.assert_called_once()
+        mock_init_commands.assert_called_once()
+
+    @patch("gptme.init.init_commands")
+    @patch("gptme.init.init_hooks")
+    @patch("gptme.init.init_tools")
+    @patch("gptme.init.init_model")
+    @patch("gptme.init.set_tool_format")
+    @patch("gptme.init.load_dotenv")
+    def test_init_can_be_retried_after_failure(
+        self,
+        mock_dotenv,
+        mock_set_fmt,
+        mock_init_model,
+        mock_init_tools,
+        mock_init_hooks,
+        mock_init_commands,
+    ):
+        """If init_model fails, subsequent init() calls should actually run
+        (not be short-circuited by the _init_done guard)."""
+        from gptme.init import init
+
+        mock_init_model.side_effect = [ValueError("No API key found"), None]
+
+        # First call raises
+        with pytest.raises(ValueError, match="No API key found"):
+            init(
+                model=None,
+                interactive=False,
+                tool_allowlist=None,
+                tool_format="markdown",
+            )
+
+        # Second call succeeds — tools/hooks/commands must run this time
+        mock_init_tools.reset_mock()
+        mock_init_hooks.reset_mock()
+        mock_init_commands.reset_mock()
+
+        init(
+            model="anthropic/claude-sonnet-4-6",
+            interactive=False,
+            tool_allowlist=None,
+            tool_format="markdown",
+        )
+
+        mock_init_tools.assert_called_once()
+        mock_init_hooks.assert_called_once()
+        mock_init_commands.assert_called_once()
+
 
 # ===========================================================================
 # init_model() — provider/model parsing


### PR DESCRIPTION
## Summary

Fixes #2173 — gptme-server (and tauri AppImage first-run) fails to start with `No API key found, couldn't auto-detect provider` when no API keys are configured.

## Problem

The existing fallback path in `server/cli.py` (added in #2177) tries to pick a provider-matching fallback model, but two bugs keep it from actually rescuing a keyless first-run:

1. **`_init_done` set too early** — `init()` sets `_init_done = True` *before* calling `init_model()`. When `init_model()` raises, the CLI's `except` block calls `init(fallback_model, ...)` — but that second call short-circuits immediately because `_init_done` is already `True`.
2. **Fallback provider can also be keyless** — on a fresh tauri install nothing is configured. `_pick_fallback_model()` falls back to `DEFAULT_FALLBACK_MODEL` (anthropic), and the retry raises `KeyError: Environment variable ANTHROPIC_API_KEY not set in env or config`.

Net result: server exits hard, tauri AppImage shows startup failure, user has no way into the UI to configure a provider.

## Fix

1. **Move `_init_done = True` to the end of `init()`** so callers can retry after a first-attempt failure.
2. **Add `require_llm: bool = True` to `init()`**. When `False`, the LLM-init `ValueError`/`KeyError` is logged as a warning and init continues (tools/hooks/commands still run). Default is `True`, so no existing caller changes behavior.
3. **Pass `require_llm=False` from `server/cli.py`'s fallback init call**, so the server can start in degraded mode.

Clients (webui/tauri) can then supply a model per-request — `api_v2_sessions.py` already handles the no-default-model case with a helpful 400 listing `example_models`.

## Tests

4 new tests in `tests/test_init.py`:
- `test_init_require_llm_true_propagates_error` — default behavior unchanged.
- `test_init_require_llm_false_continues_on_error` — ValueError swallowed, tools/hooks/commands still called.
- `test_init_require_llm_false_handles_keyerror` — KeyError also swallowed.
- `test_init_can_be_retried_after_failure` — `_init_done` at end allows retry after failure.

Full `tests/test_init.py` (74) + `tests/test_server_cli_fallback.py` (existing 5) pass. Broader `tests/test_server.py + test_cli.py` also pass.

## Test plan

- [x] New tests pass
- [x] `tests/test_server.py` + `tests/test_cli.py` pass (22 passed, 9 skipped)
- [x] Pre-commit hooks green
- [ ] Manual: start `gptme-server` with no API keys — should log warning + start up, not crash.