### PR TITLE
fix(config): drop unknown project-config keys instead of crashing

### DIFF
--- a/gptme/config/models.py
+++ b/gptme/config/models.py
@@ -264,9 +264,12 @@ class ProjectConfig:
             if isinstance(plugin_data, dict):
                 plugin_config = plugin_data
 
-        # Check for unknown keys
+        # Warn about unknown keys and drop them instead of passing them through
+        # as kwargs (which would crash with "unexpected keyword argument").
         if config_data:
-            logger.warning(f"Unknown keys in project config: {config_data.keys()}")
+            logger.warning(
+                f"Unknown keys in project config: {list(config_data.keys())} (ignored)"
+            )
 
         return cls(
             _workspace=workspace,
@@ -282,7 +285,6 @@ class ProjectConfig:
             plugin=plugin_config,
             env=env,
             mcp=mcp,
-            **config_data,
         )
 
     def merge(self, other: Self) -> Self:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -637,6 +637,28 @@ def test_project_config_to_toml():
     assert config_new == config
 
 
+def test_project_config_ignores_unknown_top_level_keys():
+    """Forward-compat: unknown top-level keys should warn, not crash.
+
+    Before this fix, any unrecognized top-level section in gptme.toml
+    (e.g. [user] placed in a project config, or a future section) would
+    be passed via **config_data to the dataclass constructor and raise
+    TypeError: unexpected keyword argument.
+    """
+    config_toml = """
+[prompt]
+files = ["README.md"]
+
+[user]
+name = "placed-in-project-config-by-mistake"
+
+[future_section_added_later]
+key = "value"
+"""
+    config = ProjectConfig.from_dict(tomlkit.loads(config_toml).unwrap())
+    assert config.files == ["README.md"]
+
+
 def test_resume_config_precedence():
     """Test that resume configuration respects saved config unless CLI overrides provided."""
     with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary

Complements #2176 (which covered the user-config path) with the matching
fix for project config (`gptme.toml`).

`ProjectConfig.from_dict()` already warned about unknown top-level keys,
but then spread them into the dataclass constructor via `**config_data`,
so older clients still crashed with:

```
TypeError: ProjectConfig.__init__() got an unexpected keyword argument 'user'
```

…whenever a `gptme.toml` had any section the running version didn't
recognize. That's any forward-compatibility case: a future section name
added upstream, a typo, or e.g. a stray `[user]` block placed in a
project config by mistake.

Dropping the unknown keys after warning matches the existing behavior
for `UserConfig` in #2176 and keeps older gptme binaries usable against
newer `gptme.toml` files.

## What changed

- `gptme/config/models.py`: remove `**config_data` spread; keep the
  warning, and clarify it says `(ignored)`.
- `tests/test_config.py`: add regression test
  `test_project_config_ignores_unknown_top_level_keys` with a
  forward-compat TOML containing a stray `[user]`, a `[future_section_added_later]`,
  and a valid `[prompt]` block to confirm the known keys still parse.

## Test plan
- [x] `pytest tests/test_config.py -q` — 33 passed (6 of them hit ProjectConfig/UserConfig parsing)
- [x] Manually verified: `HOME=/tmp/fresh XDG_CONFIG_HOME=... gptme-server` now starts cleanly
- [x] No behavior change for valid configs