### PR TITLE
feat(prompts): inject tool-use enforcement for GPT/Gemini/Grok families

### DIFF
--- a/gptme/prompts/templates.py
+++ b/gptme/prompts/templates.py
@@ -22,7 +22,7 @@ _TOOL_ENFORCEMENT_PROVIDERS = frozenset(
 )
 # Model name substrings that need enforcement when running under generic providers
 # (openrouter, groq, deepseek, nvidia, local).
-_TOOL_ENFORCEMENT_MODEL_FAMILIES = ("gpt", "codex", "gemini", "gemma", "grok")
+_TOOL_ENFORCEMENT_MODEL_FAMILIES = ("gpt-", "codex", "gemini", "gemma", "grok")
 
 _TOOL_USE_ENFORCEMENT_PROMPT = (
     "\n\nWhen a tool is available for a task, call it immediately — do not describe "

--- a/gptme/prompts/templates.py
+++ b/gptme/prompts/templates.py
@@ -15,6 +15,33 @@ from .skills import prompt_skills_summary
 
 logger = logging.getLogger(__name__)
 
+# Providers whose models tend to narrate tool use instead of emitting actual calls.
+# Inspired by Hermes/OpenClaw research on "describe without doing" drift.
+_TOOL_ENFORCEMENT_PROVIDERS = frozenset(
+    ["openai", "openai-subscription", "azure", "gemini", "xai"]
+)
+# Model name substrings that need enforcement when running under generic providers
+# (openrouter, groq, deepseek, nvidia, local).
+_TOOL_ENFORCEMENT_MODEL_FAMILIES = ("gpt", "codex", "gemini", "gemma", "grok")
+
+_TOOL_USE_ENFORCEMENT_PROMPT = (
+    "\n\nWhen a tool is available for a task, call it immediately — do not describe "
+    "what you would do or which tool you would use. Every decision to use a tool "
+    "must produce an actual tool call in the same message."
+)
+
+
+def _needs_tool_use_enforcement(model_meta) -> bool:
+    """Return True for model families that tend to narrate instead of calling tools."""
+    if model_meta is None:
+        return False
+    provider = str(model_meta.provider)
+    if provider in _TOOL_ENFORCEMENT_PROVIDERS:
+        return True
+    # For pass-through providers, check the model name for known families.
+    model_name = model_meta.model.lower()
+    return any(family in model_name for family in _TOOL_ENFORCEMENT_MODEL_FAMILIES)
+
 
 def prompt_full(
     interactive: bool,
@@ -152,6 +179,8 @@ Proceed directly with the most appropriate actions to complete the task.
         + "\n\n"
         + (interactive_prompt if interactive else non_interactive_prompt)
     )
+    if _needs_tool_use_enforcement(model_meta):
+        full_prompt += _TOOL_USE_ENFORCEMENT_PROMPT
     if tool_format == "xml":
         full_prompt = _xml_section("role", xml_escape(full_prompt))
     yield Message("system", full_prompt)

--- a/tests/test_prompt_templates.py
+++ b/tests/test_prompt_templates.py
@@ -377,6 +377,22 @@ class TestPromptGptme:
         msgs = list(prompt_gptme(interactive=True, model=None))
         assert "call it immediately" not in msgs[0].content
 
+    def test_no_tool_use_enforcement_for_gptq_models(self):
+        """GPTQ-quantized models (e.g. Llama-2-7B-GPTQ) must NOT get enforcement."""
+        from gptme.prompts import prompt_gptme
+
+        mock_model = MagicMock()
+        mock_model.supports_reasoning = False
+        mock_model.full = "openrouter/Llama-2-7B-GPTQ"
+        mock_model.provider = "openrouter"
+        mock_model.model = "llama-2-7b-gptq"
+
+        with patch("gptme.prompts.templates.get_model", return_value=mock_model):
+            msgs = list(
+                prompt_gptme(interactive=True, model="openrouter/Llama-2-7B-GPTQ")
+            )
+        assert "call it immediately" not in msgs[0].content
+
 
 # ---------------------------------------------------------------------------
 # prompt_full / prompt_short composition

--- a/tests/test_prompt_templates.py
+++ b/tests/test_prompt_templates.py
@@ -325,6 +325,58 @@ class TestPromptGptme:
         assert content.startswith("<role>")
         assert content.endswith("</role>")
 
+    def test_tool_use_enforcement_for_openai(self):
+        """GPT-family models get explicit tool-use enforcement guidance."""
+        from gptme.prompts import prompt_gptme
+
+        mock_model = MagicMock()
+        mock_model.supports_reasoning = False
+        mock_model.full = "openai/gpt-5"
+        mock_model.provider = "openai"
+        mock_model.model = "gpt-5"
+
+        with patch("gptme.prompts.templates.get_model", return_value=mock_model):
+            msgs = list(prompt_gptme(interactive=True, model="openai/gpt-5"))
+        content = msgs[0].content
+        assert "call it immediately" in content
+
+    def test_tool_use_enforcement_for_xai(self):
+        """Grok-family models get explicit tool-use enforcement guidance."""
+        from gptme.prompts import prompt_gptme
+
+        mock_model = MagicMock()
+        mock_model.supports_reasoning = False
+        mock_model.full = "xai/grok-4"
+        mock_model.provider = "xai"
+        mock_model.model = "grok-4"
+
+        with patch("gptme.prompts.templates.get_model", return_value=mock_model):
+            msgs = list(prompt_gptme(interactive=True, model="xai/grok-4"))
+        assert "call it immediately" in msgs[0].content
+
+    def test_no_tool_use_enforcement_for_anthropic(self):
+        """Anthropic/Claude models do NOT get tool-use enforcement guidance."""
+        from gptme.prompts import prompt_gptme
+
+        mock_model = MagicMock()
+        mock_model.supports_reasoning = False
+        mock_model.full = "anthropic/claude-sonnet-4-6"
+        mock_model.provider = "anthropic"
+        mock_model.model = "claude-sonnet-4-6"
+
+        with patch("gptme.prompts.templates.get_model", return_value=mock_model):
+            msgs = list(
+                prompt_gptme(interactive=True, model="anthropic/claude-sonnet-4-6")
+            )
+        assert "call it immediately" not in msgs[0].content
+
+    def test_no_tool_use_enforcement_without_model(self):
+        """When no model is specified, enforcement guidance is not injected."""
+        from gptme.prompts import prompt_gptme
+
+        msgs = list(prompt_gptme(interactive=True, model=None))
+        assert "call it immediately" not in msgs[0].content
+
 
 # ---------------------------------------------------------------------------
 # prompt_full / prompt_short composition


### PR DESCRIPTION
## Summary

- Adds `_needs_tool_use_enforcement()` helper in `gptme/prompts/templates.py` that returns `True` for OpenAI, Gemini, and xAI providers (and model names containing gpt/codex/gemini/gemma/grok under pass-through providers)
- When triggered, appends a one-sentence tool-use enforcement note to the assembled system prompt: *"When a tool is available for a task, call it immediately — do not describe what you would do or which tool you would use."*
- Anthropic/Claude models and unknown/no-model sessions are **not** affected
- Adds 4 targeted tests to `tests/test_prompt_templates.py`

## Motivation

Models from OpenAI (GPT family), Google (Gemini/Gemma), and xAI (Grok) tend to **narrate tool use** rather than emit actual tool calls — the "describe without doing" drift identified in Hermes/OpenClaw research on agent behavior. Claude models don't have this issue. The fix is a targeted one-sentence enforcement injected only where needed.

## Test plan

- [ ] `tests/test_prompt_templates.py::TestPromptGptme::test_tool_use_enforcement_for_openai` — GPT model gets enforcement note
- [ ] `tests/test_prompt_templates.py::TestPromptGptme::test_tool_use_enforcement_for_xai` — Grok model gets enforcement note
- [ ] `tests/test_prompt_templates.py::TestPromptGptme::test_no_tool_use_enforcement_for_anthropic` — Claude model does NOT get it
- [ ] `tests/test_prompt_templates.py::TestPromptGptme::test_no_tool_use_enforcement_without_model` — No model → no enforcement
- [ ] All 70 existing `test_prompt_templates.py` tests pass