### PR TITLE
feat(prompts): propagate model to prompt_short for tool-use enforcement

### DIFF
--- a/gptme/prompts/__init__.py
+++ b/gptme/prompts/__init__.py
@@ -225,7 +225,13 @@ def get_prompt(
     elif prompt == "short":
         if include_tools:
             core_msgs = list(
-                prompt_short(interactive, tools, tool_format, agent_name=agent_name)
+                prompt_short(
+                    interactive,
+                    tools,
+                    tool_format,
+                    model=model,
+                    agent_name=agent_name,
+                )
             )
         else:
             core_msgs = list(

--- a/gptme/prompts/templates.py
+++ b/gptme/prompts/templates.py
@@ -66,11 +66,16 @@ def prompt_short(
     interactive: bool,
     tools: list[ToolSpec],
     tool_format: ToolFormat,
+    model: str | None = None,
     agent_name: str | None = None,
 ) -> Generator[Message, None, None]:
     """Short prompt to start the conversation."""
-    yield from prompt_gptme(interactive, agent_name=agent_name, tool_format=tool_format)
-    yield from prompt_tools(examples=False, tools=tools, tool_format=tool_format)
+    yield from prompt_gptme(
+        interactive, model, agent_name=agent_name, tool_format=tool_format
+    )
+    yield from prompt_tools(
+        examples=False, tools=tools, tool_format=tool_format, model=model
+    )
     if interactive:
         yield from prompt_user(tool_format=tool_format)
     yield from prompt_project(tool_format=tool_format)

--- a/tests/test_prompt_templates.py
+++ b/tests/test_prompt_templates.py
@@ -527,6 +527,50 @@ class TestPromptComposition:
         assert "### Examples" not in combined
         assert "example usage" not in combined
 
+    def test_prompt_short_passes_model_for_tool_enforcement(self):
+        """prompt_short propagates `model` so GPT/Gemini/Grok get enforcement guidance."""
+        from gptme.prompts.templates import prompt_short
+
+        mock_model = MagicMock()
+        mock_model.supports_reasoning = False
+        mock_model.full = "openai/gpt-5"
+        mock_model.provider = "openai"
+        mock_model.model = "gpt-5"
+
+        with patch("gptme.prompts.templates.get_model", return_value=mock_model):
+            msgs = list(
+                prompt_short(
+                    interactive=True,
+                    tools=[self._make_tool()],
+                    tool_format="markdown",
+                    model="openai/gpt-5",
+                )
+            )
+        combined = "\n".join(m.content for m in msgs)
+        assert "call it immediately" in combined
+
+    def test_prompt_short_no_enforcement_for_anthropic(self):
+        """prompt_short with Claude model must NOT include enforcement guidance."""
+        from gptme.prompts.templates import prompt_short
+
+        mock_model = MagicMock()
+        mock_model.supports_reasoning = False
+        mock_model.full = "anthropic/claude-sonnet-4-6"
+        mock_model.provider = "anthropic"
+        mock_model.model = "claude-sonnet-4-6"
+
+        with patch("gptme.prompts.templates.get_model", return_value=mock_model):
+            msgs = list(
+                prompt_short(
+                    interactive=True,
+                    tools=[self._make_tool()],
+                    tool_format="markdown",
+                    model="anthropic/claude-sonnet-4-6",
+                )
+            )
+        combined = "\n".join(m.content for m in msgs)
+        assert "call it immediately" not in combined
+
 
 # ---------------------------------------------------------------------------
 # prompt_user


### PR DESCRIPTION
## Summary

Follow-up to #2180 addressing the P2 coverage gap I noted in that PR.

`prompt_short()` didn't accept a `model` parameter, so `prompt_gptme()` always saw `model=None` in the short-prompt path and the `_needs_tool_use_enforcement()` check never fired for GPT / Gemini / Grok models when the user (or caller) selected `prompt=\"short\"`.

This PR:

- Adds `model: str | None = None` to `prompt_short()` and threads it through to `prompt_gptme()` (so the enforcement note actually fires) and `prompt_tools()` (so tool-format gating stays consistent with `prompt_full()`).
- Updates the call site in `gptme/prompts/__init__.py` (the `prompt == \"short\"` branch) to pass the in-scope `model`.
- Adds two tests: GPT-family model triggers enforcement via `prompt_short`, Anthropic does not.

## Test plan

- [x] `poetry run pytest tests/test_prompt_templates.py` — 73 passed (incl. 2 new)
- [x] `poetry run pytest tests/test_prompts.py` — 13 passed
- [x] `poetry run mypy gptme/prompts/templates.py gptme/prompts/__init__.py` — clean

Related: #2180