### PR TITLE
fix(doctor): check for pandoc, pdftoppm, convert, and shellcheck

### DIFF
--- a/gptme/cli/doctor.py
+++ b/gptme/cli/doctor.py
@@ -220,8 +220,13 @@ def _check_tools(verbose: bool = False) -> list[CheckResult]:
         ),
         (
             "convert",
-            "ImageMagick - image conversion for browser tool",
+            "ImageMagick - image conversion for browser and computer tools",
             "Install ImageMagick from https://imagemagick.org",
+        ),
+        (
+            "vips",
+            "libvips - fast image processing, PDF rasterization fallback for browser tool",
+            "Install with: sudo apt install libvips-tools  or  brew install vips",
         ),
         ("rg", "ripgrep - fast file searching", None),
         ("ast-grep", "AST-based code search", None),

--- a/gptme/cli/doctor.py
+++ b/gptme/cli/doctor.py
@@ -208,8 +208,28 @@ def _check_tools(verbose: bool = False) -> list[CheckResult]:
         ),
         ("lynx", "Text browser - fallback for web browsing", None),
         ("pdftotext", "PDF extraction - enables PDF reading", None),
+        (
+            "pdftoppm",
+            "PDF page rasterizer - enables PDF preview in browser tool",
+            "Usually provided by the poppler-utils package",
+        ),
+        (
+            "pandoc",
+            "Document converter - enables HTML→Markdown for browser tool",
+            "Install from https://pandoc.org/installing.html or your package manager",
+        ),
+        (
+            "convert",
+            "ImageMagick - image conversion for browser tool",
+            "Install ImageMagick from https://imagemagick.org",
+        ),
         ("rg", "ripgrep - fast file searching", None),
         ("ast-grep", "AST-based code search", None),
+        (
+            "shellcheck",
+            "Shell script linter - enables shell command validation",
+            "Install from https://www.shellcheck.net",
+        ),
     ]
 
     # Check required tools


### PR DESCRIPTION
## Summary

Adds four commonly-used optional tools to `gptme-doctor`'s tool check. These are referenced by gptme's own code but were missing from the diagnostic:

- **pandoc** — used by the browser tool for HTML→Markdown conversion (`gptme/tools/_browser_playwright.py:717`)
- **pdftoppm** — used by the browser tool for PDF page rasterization (`gptme/tools/browser.py:114`)
- **convert** (ImageMagick) — used by the browser tool for image conversion (`gptme/tools/browser.py:109`)
- **shellcheck** — used by the shell command validation layer (`gptme/tools/shell_validation.py:395`)

Mirrors the pattern from #2171 (which added `node`, `npx`, `docker`) and uses explicit `fix_hint` messages so users get install guidance.

Missing-tool output becomes:
```
warning    Tool: pdftoppm            Not found - PDF page rasterizer - enables PDF preview in browser tool
           → Usually provided by the poppler-utils package
```

## Test plan
- [x] `pytest tests/test_doctor.py` — 57 tests pass, no regressions
- [x] Ran `_check_tools()` directly to verify new entries render correctly
- [x] All 4 new tools reported as `ok` when installed, `warning` with install hint when missing