### PR TITLE
feat(anthropic): add GPTME_THINKING_EFFORT env var with named levels

### DIFF
--- a/gptme/llm/llm_anthropic.py
+++ b/gptme/llm/llm_anthropic.py
@@ -30,6 +30,20 @@ from .utils import (
 
 ENV_REASONING = "GPTME_REASONING"
 ENV_REASONING_BUDGET = "GPTME_REASONING_BUDGET"
+ENV_THINKING_EFFORT = "GPTME_THINKING_EFFORT"
+
+# Ergonomic named levels that map to budget_tokens values, mirroring the
+# ``low``/``medium``/``high``/``xhigh``/``max`` levels Anthropic exposes via
+# ``output_config.effort`` (Opus 4.7+). True ``xhigh``/``max`` semantics
+# (adaptive thinking) require a newer ``anthropic`` SDK than gptme currently
+# pins; these values are approximations until that bump lands. See #2183.
+_THINKING_EFFORT_BUDGETS: dict[str, int] = {
+    "low": 2000,
+    "medium": 8000,
+    "high": 16000,
+    "xhigh": 24000,
+    "max": 32000,
+}
 
 if TYPE_CHECKING:
     # noreorder
@@ -157,6 +171,47 @@ def _record_usage(
     if cost > 0:
         metadata["cost"] = cost
     return metadata
+
+
+def _resolve_thinking_budget() -> int:
+    """Resolve thinking budget from ``GPTME_THINKING_EFFORT`` or ``GPTME_REASONING_BUDGET``.
+
+    Precedence: if ``GPTME_THINKING_EFFORT`` is set, its level maps to a
+    budget via ``_THINKING_EFFORT_BUDGETS``. Otherwise,
+    ``GPTME_REASONING_BUDGET`` is parsed as an integer (default 16000).
+
+    If both are set, ``GPTME_THINKING_EFFORT`` wins and a warning is logged.
+    """
+    effort = os.environ.get(ENV_THINKING_EFFORT)
+    budget_raw = os.environ.get(ENV_REASONING_BUDGET)
+
+    if effort is not None:
+        level = effort.strip().lower()
+        if level not in _THINKING_EFFORT_BUDGETS:
+            valid = ", ".join(_THINKING_EFFORT_BUDGETS)
+            raise ValueError(
+                f"Invalid {ENV_THINKING_EFFORT} value: {effort!r}. "
+                f"Must be one of: {valid}."
+            )
+        if budget_raw is not None:
+            logger.warning(
+                "Both %s and %s set; using %s=%s",
+                ENV_THINKING_EFFORT,
+                ENV_REASONING_BUDGET,
+                ENV_THINKING_EFFORT,
+                level,
+            )
+        return _THINKING_EFFORT_BUDGETS[level]
+
+    if budget_raw is None:
+        return _THINKING_EFFORT_BUDGETS["high"]
+    try:
+        return int(budget_raw)
+    except ValueError as parse_err:
+        raise ValueError(
+            f"Invalid {ENV_REASONING_BUDGET} value: {budget_raw!r}. "
+            "Must be a valid integer."
+        ) from parse_err
 
 
 def _adjust_thinking_budget(
@@ -447,14 +502,7 @@ def chat(
 
     model_meta = get_model(f"anthropic/{model}")
     use_thinking = _should_use_thinking(model_meta, tools)
-    thinking_budget_str = os.environ.get(ENV_REASONING_BUDGET, "16000")
-    try:
-        thinking_budget = int(thinking_budget_str)
-    except ValueError as parse_err:
-        raise ValueError(
-            f"Invalid {ENV_REASONING_BUDGET} value: {thinking_budget_str!r}. "
-            "Must be a valid integer."
-        ) from parse_err
+    thinking_budget = _resolve_thinking_budget()
     max_tokens = (
         max_tokens if max_tokens is not None else (model_meta.max_output or 4096)
     )
@@ -550,15 +598,7 @@ def stream(
 
     model_meta = get_model(f"anthropic/{model}")
     use_thinking = _should_use_thinking(model_meta, tools)
-    # Use the same configurable thinking budget as chat()
-    thinking_budget_str = os.environ.get(ENV_REASONING_BUDGET, "16000")
-    try:
-        thinking_budget = int(thinking_budget_str)
-    except ValueError as parse_err:
-        raise ValueError(
-            f"Invalid {ENV_REASONING_BUDGET} value: {thinking_budget_str!r}. "
-            "Must be a valid integer."
-        ) from parse_err
+    thinking_budget = _resolve_thinking_budget()
     max_tokens = (
         max_tokens if max_tokens is not None else (model_meta.max_output or 4096)
     )

--- a/tests/test_llm_anthropic.py
+++ b/tests/test_llm_anthropic.py
@@ -1,6 +1,12 @@
+import logging
 import os
 
-from gptme.llm.llm_anthropic import _prepare_messages_for_api
+import pytest
+
+from gptme.llm.llm_anthropic import (
+    _prepare_messages_for_api,
+    _resolve_thinking_budget,
+)
 from gptme.message import Message
 from gptme.tools import get_tool, init_tools
 
@@ -442,3 +448,66 @@ def test_web_search_tool_with_other_tools():
         assert web_search_tool["max_uses"] == 5  # type: ignore[typeddict-item]  # Default value
     finally:
         os.environ.pop("GPTME_ANTHROPIC_WEB_SEARCH", None)
+
+
+class TestResolveThinkingBudget:
+    """_resolve_thinking_budget handles GPTME_THINKING_EFFORT and GPTME_REASONING_BUDGET."""
+
+    def setup_method(self):
+        # Isolate tests from ambient env
+        self._saved = {}
+        for key in ("GPTME_THINKING_EFFORT", "GPTME_REASONING_BUDGET"):
+            self._saved[key] = os.environ.pop(key, None)
+
+    def teardown_method(self):
+        for key, val in self._saved.items():
+            if val is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = val
+
+    def test_default_is_high(self):
+        assert _resolve_thinking_budget() == 16000
+
+    def test_reasoning_budget_integer(self):
+        os.environ["GPTME_REASONING_BUDGET"] = "12345"
+        assert _resolve_thinking_budget() == 12345
+
+    def test_reasoning_budget_invalid_raises(self):
+        os.environ["GPTME_REASONING_BUDGET"] = "not-a-number"
+        with pytest.raises(ValueError, match="GPTME_REASONING_BUDGET"):
+            _resolve_thinking_budget()
+
+    @pytest.mark.parametrize(
+        ("effort", "expected"),
+        [
+            ("low", 2000),
+            ("medium", 8000),
+            ("high", 16000),
+            ("xhigh", 24000),
+            ("max", 32000),
+        ],
+    )
+    def test_effort_levels(self, effort, expected):
+        os.environ["GPTME_THINKING_EFFORT"] = effort
+        assert _resolve_thinking_budget() == expected
+
+    def test_effort_case_insensitive(self):
+        os.environ["GPTME_THINKING_EFFORT"] = "XHIGH"
+        assert _resolve_thinking_budget() == 24000
+
+    def test_effort_invalid_raises(self):
+        os.environ["GPTME_THINKING_EFFORT"] = "extreme"
+        with pytest.raises(ValueError, match="GPTME_THINKING_EFFORT"):
+            _resolve_thinking_budget()
+
+    def test_effort_wins_when_both_set(self, caplog):
+        os.environ["GPTME_THINKING_EFFORT"] = "low"
+        os.environ["GPTME_REASONING_BUDGET"] = "99999"
+        with caplog.at_level(logging.WARNING, logger="gptme.llm.llm_anthropic"):
+            assert _resolve_thinking_budget() == 2000
+        assert any(
+            "GPTME_THINKING_EFFORT" in rec.message
+            and "GPTME_REASONING_BUDGET" in rec.message
+            for rec in caplog.records
+        )


### PR DESCRIPTION
## Summary

Adds a `GPTME_THINKING_EFFORT` env var with named levels (`low` / `medium` / `high` / `xhigh` / `max`) that maps to `budget_tokens` for Anthropic's extended thinking. This is the shim (option B) from #2183 — no SDK bump required, ships the ergonomic knob today.

**Mapping** (approximations; real `xhigh`/`max` adaptive semantics require the SDK bump):

| Effort | Budget |
|--------|--------|
| `low` | 2000 |
| `medium` | 8000 |
| `high` | 16000 (existing default) |
| `xhigh` | 24000 |
| `max` | 32000 |

Precedence: `GPTME_THINKING_EFFORT` wins over `GPTME_REASONING_BUDGET` when both are set, with a warning logged. `GPTME_REASONING_BUDGET` continues to work unchanged for callers that want raw token counts.

## Why

`llm-anthropic 0.25` (released 2026-04-16) already wires `output_config.effort` for users of Simon Willison's `llm` CLI, with `xhigh` being Claude Opus 4.7-specific. gptme users currently have to guess a raw token count. Named levels are more ergonomic and closer to the API shape.

## What this doesn't do (follow-up)

True `xhigh` / `max` semantics (Anthropic's `output_config.effort`) require bumping the pinned `anthropic = "^0.47"` constraint — this is option A in #2183 and can be a separate PR. Once that lands, `_resolve_thinking_budget` becomes the single place to wire in the real SDK parameter (likely returning `{"effort": level}` alongside or instead of `{"budget_tokens": N}`).

## Also in this PR

Deduplicates the identical 8-line env-parsing block that existed in both `chat()` and `stream()` — now a single `_resolve_thinking_budget()` helper.

## Test plan

- [x] 11 new unit tests covering all effort levels, the invalid-value path, the invalid-budget path, case-insensitive parsing, and effort-wins-over-budget precedence
- [x] `pytest tests/test_llm_anthropic.py` — 20 passed
- [x] `mypy gptme/llm/llm_anthropic.py` — clean
- [x] Pre-commit (ruff, format, mypy) — clean

Refs #2183