### PR TITLE
feat(prompts): add cache boundary marker and stable file order

### DIFF
--- a/gptme/prompts/__init__.py
+++ b/gptme/prompts/__init__.py
@@ -362,6 +362,7 @@ __all__ = [
     "AGENT_FILES",
     "ALWAYS_LOAD_FILES",
     "CONTEXT_CMD_MAX_CHARS",
+    "SYSTEM_PROMPT_CACHE_BOUNDARY",
     "ContextMode",
     "DEFAULT_CONTEXT_FILES",
     "PromptType",

--- a/gptme/prompts/__init__.py
+++ b/gptme/prompts/__init__.py
@@ -55,6 +55,12 @@ PromptType = Literal["full", "short"]
 
 logger = logging.getLogger(__name__)
 
+SYSTEM_PROMPT_CACHE_BOUNDARY = """# System Prompt Cache Boundary
+
+Static bootstrap content ends above. Session-volatile context starts below.
+
+---"""
+
 
 ContextMode = Literal["full", "selective"]
 
@@ -316,6 +322,12 @@ def get_prompt(
     # Add workspace messages separately (if included)
     if include_workspace:
         result.extend(workspace_msgs)
+
+    # Insert an explicit static/dynamic boundary before context_cmd output.
+    # This keeps the prompt structure stable and makes the cacheable prefix
+    # visible to both humans and providers with block-level prompt caching.
+    if dynamic_context_msgs and result:
+        result.append(Message("system", SYSTEM_PROMPT_CACHE_BOUNDARY))
 
     # Dynamic context last (changes every session, least cacheable)
     result.extend(dynamic_context_msgs)

--- a/gptme/prompts/workspace.py
+++ b/gptme/prompts/workspace.py
@@ -43,6 +43,9 @@ def _context_file_sort_key(path: Path) -> tuple[int, str]:
     order. Known high-signal files get fixed priority, then we fall back to the
     path for lexical stability.
     """
+    # tail is "parent/filename" — reserved for future path-qualified keys in
+    # CONTEXT_FILE_ORDER (e.g. ".cursor/rules.md"). With current bare-filename
+    # keys this lookup is always a miss; the fallback to `name` is what fires.
     tail = "/".join(path.parts[-2:])
     name = path.name
     priority = CONTEXT_FILE_ORDER.get(tail, CONTEXT_FILE_ORDER.get(name, 1000))

--- a/gptme/prompts/workspace.py
+++ b/gptme/prompts/workspace.py
@@ -16,6 +16,43 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+CONTEXT_FILE_ORDER: dict[str, int] = {
+    "README.md": 10,
+    "README.rst": 11,
+    "README.txt": 12,
+    "README": 13,
+    "gptme.toml": 20,
+    "AGENTS.md": 30,
+    "CLAUDE.md": 31,
+    "COPILOT.md": 32,
+    "GEMINI.md": 33,
+    "pyproject.toml": 40,
+    "package.json": 50,
+    "Cargo.toml": 60,
+    "Makefile": 70,
+    "docker-compose.yml": 80,
+    "docker-compose.yaml": 81,
+}
+
+
+def _context_file_sort_key(path: Path) -> tuple[int, str]:
+    """Sort key for stable prompt-file ordering.
+
+    We keep pattern order from gptme.toml/defaults, but sort each glob's matches
+    deterministically so prompt assembly does not depend on filesystem traversal
+    order. Known high-signal files get fixed priority, then we fall back to the
+    path for lexical stability.
+    """
+    tail = "/".join(path.parts[-2:])
+    name = path.name
+    priority = CONTEXT_FILE_ORDER.get(tail, CONTEXT_FILE_ORDER.get(name, 1000))
+    return priority, path.as_posix()
+
+
+def _sorted_workspace_matches(workspace: Path, fileglob: str) -> list[Path]:
+    """Return glob matches in a deterministic order."""
+    return sorted(workspace.glob(fileglob), key=_context_file_sort_key)
+
 
 def _get_git_status(workspace: Path) -> str | None:
     """Get git branch and working tree status for the workspace.
@@ -218,7 +255,8 @@ def prompt_workspace(
         # expand user
         fileglob = str(Path(fileglob).expanduser())
         # expand with glob
-        if new_files := workspace.glob(fileglob):
+        new_files = _sorted_workspace_matches(workspace, fileglob)
+        if new_files:
             for f in new_files:
                 # Validate file is within workspace (prevent path traversal)
                 try:

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -132,7 +133,7 @@ files = ["../outside/secret.txt", "README.md"]
     )
 
     # Get workspace content
-    msgs = list(prompt_workspace(workspace))
+    msgs = list(prompt_workspace(workspace, include_user_context=False))
     content = "\n".join(msg.content for msg in msgs)
 
     # Collect attached files from all messages
@@ -241,6 +242,73 @@ def test_dynamic_context_after_static(tmp_path):
         f"Dynamic context (msg {dynamic_idx}) should come after "
         f"static workspace files (msg {file_idx})"
     )
+
+
+def test_dynamic_context_has_explicit_cache_boundary(tmp_path):
+    """Dynamic context should be separated by a stable cache-boundary marker."""
+    from gptme.prompts import SYSTEM_PROMPT_CACHE_BOUNDARY, get_prompt
+
+    workspace = tmp_path / "project"
+    workspace.mkdir()
+    (workspace / "README.md").write_text("# Test Project")
+    (workspace / "gptme.toml").write_text(
+        '[prompt]\nfiles = ["README.md"]\ncontext_cmd = "echo DYNAMIC_MARKER_456"\n'
+    )
+
+    msgs = get_prompt(
+        get_tools(),
+        prompt="full",
+        workspace=workspace,
+    )
+
+    file_idx = None
+    boundary_idx = None
+    dynamic_idx = None
+    for i, msg in enumerate(msgs):
+        if "README.md" in msg.content:
+            file_idx = i
+        if SYSTEM_PROMPT_CACHE_BOUNDARY in msg.content:
+            boundary_idx = i
+        if "DYNAMIC_MARKER_456" in msg.content:
+            dynamic_idx = i
+
+    assert file_idx is not None, "Should include workspace files"
+    assert boundary_idx is not None, "Should include cache-boundary marker"
+    assert dynamic_idx is not None, "Should include context_cmd output"
+    assert file_idx < boundary_idx < dynamic_idx
+
+
+def test_prompt_workspace_sorts_glob_matches_deterministically(tmp_path, monkeypatch):
+    """Glob matches should not depend on filesystem traversal order."""
+    from gptme.prompts import prompt_workspace
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "z-last.md").write_text("z")
+    (workspace / "README.md").write_text("# Readme")
+    (workspace / "a-first.md").write_text("a")
+    (workspace / "gptme.toml").write_text('[prompt]\nfiles = ["*.md"]\n')
+
+    real_glob = Path.glob
+
+    def fake_glob(self, pattern):
+        if self == workspace and pattern == "*.md":
+            return iter(
+                [
+                    workspace / "z-last.md",
+                    workspace / "a-first.md",
+                    workspace / "README.md",
+                ]
+            )
+        return real_glob(self, pattern)
+
+    monkeypatch.setattr(Path, "glob", fake_glob)
+
+    msgs = list(prompt_workspace(workspace, include_user_context=False))
+    selected_files = [str(f) for msg in msgs for f in msg.files]
+    selected_names = [Path(f).name for f in selected_files]
+
+    assert selected_names == ["README.md", "a-first.md", "z-last.md"]
 
 
 def test_workspace_git_status_not_git_repo(tmp_path):


### PR DESCRIPTION
## Summary
- add an explicit system-prompt cache boundary marker before `context_cmd` output
- sort glob-matched prompt files deterministically with a fixed high-signal file order
- cover the boundary marker and deterministic ordering with prompt tests

## Testing
- uv run --with pytest pytest tests/test_prompts.py -q
- uv run --with pytest pytest tests/test_prompt_templates.py -q
- uv run --with pytest pytest tests/test_llm_anthropic.py -q
- uv run --with ruff ruff check gptme/prompts/__init__.py gptme/prompts/workspace.py tests/test_prompts.py
- uv run --with ruff ruff format --check gptme/prompts/__init__.py gptme/prompts/workspace.py tests/test_prompts.py