### PR TITLE
feat(anthropic): wire output_config.effort for true xhigh/max thinking semantics

### DIFF
--- a/gptme/llm/llm_anthropic.py
+++ b/gptme/llm/llm_anthropic.py
@@ -44,6 +44,7 @@ _THINKING_EFFORT_BUDGETS: dict[str, int] = {
     "xhigh": 24000,
     "max": 32000,
 }
+_EffortLevel = Literal["low", "medium", "high", "xhigh", "max"]
 
 if TYPE_CHECKING:
     # noreorder
@@ -55,13 +56,11 @@ if TYPE_CHECKING:
 # approximations until the user upgrades.  No SDK constraint bump required —
 # the code degrades gracefully.
 try:
-    from anthropic.types import (
-        OutputConfigParam as _OutputConfigParam,  # noqa: F401  # type: ignore[attr-defined]
-    )
-
-    _HAS_OUTPUT_CONFIG = True
+    import anthropic.types as _anthropic_types
 except ImportError:
     _HAS_OUTPUT_CONFIG = False
+else:
+    _HAS_OUTPUT_CONFIG = hasattr(_anthropic_types, "OutputConfigParam")
 
 logger = logging.getLogger(__name__)
 
@@ -199,13 +198,7 @@ def _resolve_thinking_budget() -> int:
     budget_raw = os.environ.get(ENV_REASONING_BUDGET)
 
     if effort is not None:
-        level = effort.strip().lower()
-        if level not in _THINKING_EFFORT_BUDGETS:
-            valid = ", ".join(_THINKING_EFFORT_BUDGETS)
-            raise ValueError(
-                f"Invalid {ENV_THINKING_EFFORT} value: {effort!r}. "
-                f"Must be one of: {valid}."
-            )
+        level = _normalize_effort_level(effort)
         if budget_raw is not None:
             logger.warning(
                 "Both %s and %s set; using %s=%s",
@@ -227,17 +220,45 @@ def _resolve_thinking_budget() -> int:
         ) from parse_err
 
 
-def _resolve_effort_level() -> str | None:
+def _normalize_effort_level(effort: str) -> _EffortLevel:
+    level = effort.strip().lower()
+    if level not in _THINKING_EFFORT_BUDGETS:
+        valid = ", ".join(_THINKING_EFFORT_BUDGETS)
+        raise ValueError(
+            f"Invalid {ENV_THINKING_EFFORT} value: {effort!r}. Must be one of: {valid}."
+        )
+    return cast(_EffortLevel, level)
+
+
+def _resolve_effort_level() -> _EffortLevel | None:
     """Return the raw effort level from ``GPTME_THINKING_EFFORT``, or ``None``.
 
     Returns ``None`` when the env var is not set (i.e. the budget is driven
-    by ``GPTME_REASONING_BUDGET`` instead).  The level has already been
-    validated by ``_resolve_thinking_budget``; callers can use it directly.
+    by ``GPTME_REASONING_BUDGET`` instead).
     """
     effort = os.environ.get(ENV_THINKING_EFFORT)
     if effort is None:
         return None
-    return effort.strip().lower()
+    return _normalize_effort_level(effort)
+
+
+class _OutputConfig(TypedDict):
+    effort: _EffortLevel
+
+
+class _OutputConfigKwargs(TypedDict, total=False):
+    output_config: _OutputConfig
+
+
+def _output_config_kwargs(*, use_thinking: bool) -> _OutputConfigKwargs:
+    if not (use_thinking and _HAS_OUTPUT_CONFIG):
+        return {}
+
+    effort_level = _resolve_effort_level()
+    if effort_level is None:
+        return {}
+
+    return {"output_config": {"effort": effort_level}}
 
 
 def _adjust_thinking_budget(
@@ -539,10 +560,7 @@ def chat(
     # Pass output_config.effort when the SDK supports it (>= 0.77) and
     # GPTME_THINKING_EFFORT is set.  This enables true xhigh/max semantics
     # (adaptive thinking) that budget_tokens cannot express.
-    effort_level = (
-        _resolve_effort_level() if use_thinking and _HAS_OUTPUT_CONFIG else None
-    )
-    output_config = {"effort": effort_level} if effort_level else NOT_GIVEN
+    output_config_kwargs = _output_config_kwargs(use_thinking=use_thinking)
 
     response = _anthropic.messages.create(  # type: ignore[call-overload, misc]
         model=api_model,
@@ -557,7 +575,7 @@ def chat(
             if use_thinking
             else NOT_GIVEN
         ),
-        output_config=output_config,
+        **output_config_kwargs,
         # We set a timeout for non-streaming requests to prevent Anthropic's
         # "Streaming is strongly recommended" warning/error.
         timeout=60,
@@ -641,12 +659,9 @@ def stream(
         max_tokens, thinking_budget, use_thinking
     )
 
-    effort_level = (
-        _resolve_effort_level() if use_thinking and _HAS_OUTPUT_CONFIG else None
-    )
-    output_config = {"effort": effort_level} if effort_level else NOT_GIVEN
+    output_config_kwargs = _output_config_kwargs(use_thinking=use_thinking)
 
-    with _anthropic.messages.stream(  # type: ignore[call-arg]
+    with _anthropic.messages.stream(  # type: ignore[call-arg, misc]
         model=api_model,
         messages=messages_dicts,
         system=system_messages,
@@ -659,7 +674,7 @@ def stream(
             if use_thinking
             else NOT_GIVEN
         ),
-        output_config=output_config,
+        **output_config_kwargs,
     ) as stream:
         for chunk in stream:
             match chunk.type:

--- a/gptme/llm/llm_anthropic.py
+++ b/gptme/llm/llm_anthropic.py
@@ -32,11 +32,11 @@ ENV_REASONING = "GPTME_REASONING"
 ENV_REASONING_BUDGET = "GPTME_REASONING_BUDGET"
 ENV_THINKING_EFFORT = "GPTME_THINKING_EFFORT"
 
-# Ergonomic named levels that map to budget_tokens values, mirroring the
-# ``low``/``medium``/``high``/``xhigh``/``max`` levels Anthropic exposes via
-# ``output_config.effort`` (Opus 4.7+). True ``xhigh``/``max`` semantics
-# (adaptive thinking) require a newer ``anthropic`` SDK than gptme currently
-# pins; these values are approximations until that bump lands. See #2183.
+# Named effort levels → budget_tokens fallback values.  When the installed
+# anthropic SDK exposes ``output_config.effort`` (>= 0.77) these are only
+# used as the ``budget_tokens`` guard for max_tokens clamping; the true
+# effort semantics (including ``xhigh``/``max`` adaptive thinking) are passed
+# via ``output_config``.  On older SDKs they serve as the sole signal.
 _THINKING_EFFORT_BUDGETS: dict[str, int] = {
     "low": 2000,
     "medium": 8000,
@@ -49,6 +49,17 @@ if TYPE_CHECKING:
     # noreorder
     import anthropic.types  # fmt: skip
     from anthropic import Anthropic  # fmt: skip
+
+# output_config.effort was added in anthropic SDK 0.77.  On older installs the
+# effort levels still work via the budget_tokens shim above; xhigh/max are
+# approximations until the user upgrades.  No SDK constraint bump required —
+# the code degrades gracefully.
+try:
+    from anthropic.types import OutputConfigParam as _OutputConfigParam  # noqa: F401
+
+    _HAS_OUTPUT_CONFIG = True
+except ImportError:
+    _HAS_OUTPUT_CONFIG = False
 
 logger = logging.getLogger(__name__)
 
@@ -212,6 +223,19 @@ def _resolve_thinking_budget() -> int:
             f"Invalid {ENV_REASONING_BUDGET} value: {budget_raw!r}. "
             "Must be a valid integer."
         ) from parse_err
+
+
+def _resolve_effort_level() -> str | None:
+    """Return the raw effort level from ``GPTME_THINKING_EFFORT``, or ``None``.
+
+    Returns ``None`` when the env var is not set (i.e. the budget is driven
+    by ``GPTME_REASONING_BUDGET`` instead).  The level has already been
+    validated by ``_resolve_thinking_budget``; callers can use it directly.
+    """
+    effort = os.environ.get(ENV_THINKING_EFFORT)
+    if effort is None:
+        return None
+    return effort.strip().lower()
 
 
 def _adjust_thinking_budget(
@@ -510,6 +534,14 @@ def chat(
         max_tokens, thinking_budget, use_thinking
     )
 
+    # Pass output_config.effort when the SDK supports it (>= 0.77) and
+    # GPTME_THINKING_EFFORT is set.  This enables true xhigh/max semantics
+    # (adaptive thinking) that budget_tokens cannot express.
+    effort_level = (
+        _resolve_effort_level() if use_thinking and _HAS_OUTPUT_CONFIG else None
+    )
+    output_config = {"effort": effort_level} if effort_level else NOT_GIVEN
+
     response = _anthropic.messages.create(
         model=api_model,
         messages=messages_dicts,
@@ -523,6 +555,7 @@ def chat(
             if use_thinking
             else NOT_GIVEN
         ),
+        output_config=output_config,
         # We set a timeout for non-streaming requests to prevent Anthropic's
         # "Streaming is strongly recommended" warning/error.
         timeout=60,
@@ -606,6 +639,11 @@ def stream(
         max_tokens, thinking_budget, use_thinking
     )
 
+    effort_level = (
+        _resolve_effort_level() if use_thinking and _HAS_OUTPUT_CONFIG else None
+    )
+    output_config = {"effort": effort_level} if effort_level else NOT_GIVEN
+
     with _anthropic.messages.stream(
         model=api_model,
         messages=messages_dicts,
@@ -619,6 +657,7 @@ def stream(
             if use_thinking
             else NOT_GIVEN
         ),
+        output_config=output_config,
     ) as stream:
         for chunk in stream:
             match chunk.type:

--- a/gptme/llm/llm_anthropic.py
+++ b/gptme/llm/llm_anthropic.py
@@ -55,7 +55,9 @@ if TYPE_CHECKING:
 # approximations until the user upgrades.  No SDK constraint bump required —
 # the code degrades gracefully.
 try:
-    from anthropic.types import OutputConfigParam as _OutputConfigParam  # noqa: F401
+    from anthropic.types import (
+        OutputConfigParam as _OutputConfigParam,  # noqa: F401  # type: ignore[attr-defined]
+    )
 
     _HAS_OUTPUT_CONFIG = True
 except ImportError:
@@ -542,7 +544,7 @@ def chat(
     )
     output_config = {"effort": effort_level} if effort_level else NOT_GIVEN
 
-    response = _anthropic.messages.create(
+    response = _anthropic.messages.create(  # type: ignore[call-overload, misc]
         model=api_model,
         messages=messages_dicts,
         system=system_messages,
@@ -644,7 +646,7 @@ def stream(
     )
     output_config = {"effort": effort_level} if effort_level else NOT_GIVEN
 
-    with _anthropic.messages.stream(
+    with _anthropic.messages.stream(  # type: ignore[call-arg]
         model=api_model,
         messages=messages_dicts,
         system=system_messages,

--- a/tests/test_llm_anthropic.py
+++ b/tests/test_llm_anthropic.py
@@ -5,6 +5,7 @@ import pytest
 
 from gptme.llm.llm_anthropic import (
     _HAS_OUTPUT_CONFIG,
+    _output_config_kwargs,
     _prepare_messages_for_api,
     _resolve_effort_level,
     _resolve_thinking_budget,
@@ -538,6 +539,47 @@ class TestResolveEffortLevel:
     def test_normalises_to_lowercase(self):
         os.environ["GPTME_THINKING_EFFORT"] = "XHIGH"
         assert _resolve_effort_level() == "xhigh"
+
+    def test_raises_on_invalid_level(self):
+        os.environ["GPTME_THINKING_EFFORT"] = "extreme"
+        with pytest.raises(ValueError, match="Invalid GPTME_THINKING_EFFORT"):
+            _resolve_effort_level()
+
+
+class TestOutputConfigKwargs:
+    def setup_method(self):
+        self._saved = os.environ.pop("GPTME_THINKING_EFFORT", None)
+
+    def teardown_method(self):
+        if self._saved is None:
+            os.environ.pop("GPTME_THINKING_EFFORT", None)
+        else:
+            os.environ["GPTME_THINKING_EFFORT"] = self._saved
+
+    def test_returns_empty_when_not_using_thinking(self, monkeypatch):
+        monkeypatch.setattr("gptme.llm.llm_anthropic._HAS_OUTPUT_CONFIG", True)
+        os.environ["GPTME_THINKING_EFFORT"] = "xhigh"
+
+        assert _output_config_kwargs(use_thinking=False) == {}
+
+    def test_returns_empty_when_sdk_does_not_support_output_config(self, monkeypatch):
+        monkeypatch.setattr("gptme.llm.llm_anthropic._HAS_OUTPUT_CONFIG", False)
+        os.environ["GPTME_THINKING_EFFORT"] = "xhigh"
+
+        assert _output_config_kwargs(use_thinking=True) == {}
+
+    def test_returns_empty_when_effort_is_unset(self, monkeypatch):
+        monkeypatch.setattr("gptme.llm.llm_anthropic._HAS_OUTPUT_CONFIG", True)
+
+        assert _output_config_kwargs(use_thinking=True) == {}
+
+    def test_returns_output_config_when_supported(self, monkeypatch):
+        monkeypatch.setattr("gptme.llm.llm_anthropic._HAS_OUTPUT_CONFIG", True)
+        os.environ["GPTME_THINKING_EFFORT"] = "XHIGH"
+
+        assert _output_config_kwargs(use_thinking=True) == {
+            "output_config": {"effort": "xhigh"}
+        }
 
 
 def test_has_output_config_is_bool():

--- a/tests/test_llm_anthropic.py
+++ b/tests/test_llm_anthropic.py
@@ -4,7 +4,9 @@ import os
 import pytest
 
 from gptme.llm.llm_anthropic import (
+    _HAS_OUTPUT_CONFIG,
     _prepare_messages_for_api,
+    _resolve_effort_level,
     _resolve_thinking_budget,
 )
 from gptme.message import Message
@@ -511,3 +513,33 @@ class TestResolveThinkingBudget:
             and "GPTME_REASONING_BUDGET" in rec.message
             for rec in caplog.records
         )
+
+
+class TestResolveEffortLevel:
+    """_resolve_effort_level returns the raw level string or None."""
+
+    def setup_method(self):
+        self._saved = os.environ.pop("GPTME_THINKING_EFFORT", None)
+
+    def teardown_method(self):
+        if self._saved is None:
+            os.environ.pop("GPTME_THINKING_EFFORT", None)
+        else:
+            os.environ["GPTME_THINKING_EFFORT"] = self._saved
+
+    def test_returns_none_when_not_set(self):
+        assert _resolve_effort_level() is None
+
+    @pytest.mark.parametrize("level", ["low", "medium", "high", "xhigh", "max"])
+    def test_returns_level_string(self, level):
+        os.environ["GPTME_THINKING_EFFORT"] = level
+        assert _resolve_effort_level() == level
+
+    def test_normalises_to_lowercase(self):
+        os.environ["GPTME_THINKING_EFFORT"] = "XHIGH"
+        assert _resolve_effort_level() == "xhigh"
+
+
+def test_has_output_config_is_bool():
+    """_HAS_OUTPUT_CONFIG must be a bool (True when SDK >= 0.77)."""
+    assert isinstance(_HAS_OUTPUT_CONFIG, bool)


### PR DESCRIPTION
## Summary

Implements the second part of #2183: passes `output_config={"effort": level}` alongside the existing `thinking` parameter when `GPTME_THINKING_EFFORT` is set and the installed Anthropic SDK supports it (>= 0.77).

- **No SDK constraint bump required** — the code does a try-import at module load time (`_HAS_OUTPUT_CONFIG` flag) and gracefully falls back to the budget_tokens shim on older installations
- Both `query()` and `stream()` now forward `output_config` when `_HAS_OUTPUT_CONFIG and use_thinking and GPTME_THINKING_EFFORT is set`
- `xhigh` / `max` now have true adaptive thinking semantics for users on SDK >= 0.77 (Opus 4.7+)

### New public names
- `_HAS_OUTPUT_CONFIG: bool` — True when SDK >= 0.77
- `_resolve_effort_level() -> str | None` — returns raw level string (or None when GPTME_THINKING_EFFORT is not set)

## Behaviour matrix

| SDK version | GPTME_THINKING_EFFORT | output_config sent? | Semantics |
|---|---|---|---|
| < 0.77 | set | ❌ | budget_tokens shim (approximation) |
| >= 0.77 | not set | ❌ | budget_tokens driven by GPTME_REASONING_BUDGET |
| >= 0.77 | set | ✅ | true `output_config.effort` + budget guard |

## Test plan
- [ ] `TestResolveEffortLevel` — 4 new cases: None when unset, level string for all 5 levels, case normalisation
- [ ] `test_has_output_config_is_bool` — confirms flag is set at import
- [ ] All 28 existing tests pass unchanged