### PR TITLE
feat: add LiteLLM as AI gateway provider

### DIFF
--- a/gptme/llm/litellm.py
+++ b/gptme/llm/litellm.py
@@ -1,0 +1,51 @@
+"""LiteLLM-backed OpenAI-compatible client.
+
+Provides ``LiteLLMClient``, a duck-typed object that exposes ``chat.completions.create``
+(and a minimal subset of the OpenAI client surface) but dispatches every call to
+``litellm.completion()``. Installed into ``llm_openai.clients`` when the user selects
+the ``litellm`` provider, which lets the existing OpenAI-shaped chat/stream code in
+``llm_openai.py`` route to any of LiteLLM's 100+ providers without modification.
+
+Authentication: LiteLLM resolves provider-specific API keys from the environment
+(``ANTHROPIC_API_KEY``, ``GEMINI_API_KEY``, ``AWS_*``, ``GROQ_API_KEY``, etc.). Users
+pass the fully-prefixed model name via ``gptme -m litellm/<provider>/<model>``. The
+``litellm/`` prefix is stripped upstream by ``_get_base_model`` before the model name
+reaches this shim, so ``litellm.completion`` receives the provider-prefixed name
+(e.g. ``anthropic/claude-3-5-sonnet-20241022``) that it knows how to route.
+
+See https://docs.litellm.ai/docs/providers for supported model prefixes.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class _LiteLLMChatCompletions:
+    """Dispatches ``.create(**kwargs)`` to ``litellm.completion(**kwargs)``."""
+
+    def create(self, **kwargs: Any) -> Any:
+        import litellm  # lazy import — ``litellm`` is an optional extra
+
+        return litellm.completion(**kwargs)
+
+
+class _LiteLLMChat:
+    def __init__(self) -> None:
+        self.completions = _LiteLLMChatCompletions()
+
+
+class LiteLLMClient:
+    """Duck-typed OpenAI-compatible client backed by ``litellm.completion``.
+
+    Only the subset of the OpenAI v1 client surface actually exercised by gptme's
+    ``llm_openai`` code path is implemented. Attributes present purely so that
+    helper checks (e.g. ``_is_proxy``) don't raise.
+    """
+
+    # Exposed for ``_is_proxy`` in llm_openai.py. LiteLLM is in-process; no base_url.
+    base_url: str | None = None
+    api_key: str | None = None
+
+    def __init__(self) -> None:
+        self.chat = _LiteLLMChat()

--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -296,6 +296,11 @@ def init(provider: Provider, config: Config):
             raise KeyError("Missing environment variable OPENAI_BASE_URL")
         api_key = config.get_env("OPENAI_API_KEY") or "ollama"
         clients[provider] = OpenAI(api_key=api_key, base_url=api_base, timeout=timeout)
+    elif provider == "litellm":
+        # LiteLLM is an in-process router; API keys resolve from per-provider env vars.
+        from .litellm import LiteLLMClient  # fmt: skip
+
+        clients[provider] = LiteLLMClient()  # type: ignore[assignment]
     else:
         # Check if this is a custom provider (config-file based)
         custom_provider = next(

--- a/gptme/llm/models/data.py
+++ b/gptme/llm/models/data.py
@@ -391,6 +391,10 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
     # Empty dict = models fetched dynamically or specified by user
     "gptme": {},
     "local": {},
+    # LiteLLM AI gateway — routes to 100+ providers via model prefix
+    # (e.g. "litellm/anthropic/claude-3-5-sonnet-20241022"). Kept empty because
+    # the model metadata is owned by LiteLLM and resolved dynamically at call time.
+    "litellm": {},
 }
 
 # check that all providers have a MODELS entry

--- a/gptme/llm/models/resolution.py
+++ b/gptme/llm/models/resolution.py
@@ -339,6 +339,11 @@ def get_recommended_model(provider: Provider) -> str:  # pragma: no cover
         return "deepseek-chat"
     if provider == "groq":
         return "llama-3.3-70b-versatile"
+    if provider == "litellm":
+        raise ValueError(
+            "LiteLLM requires an explicit model name, "
+            "e.g. gptme -m litellm/anthropic/claude-3-5-sonnet-20241022"
+        )
     raise ValueError(
         f"Provider '{provider}' requires specifying a model, "
         f"e.g. gptme -m {provider}/your-model-name"

--- a/gptme/llm/models/types.py
+++ b/gptme/llm/models/types.py
@@ -51,6 +51,7 @@ BuiltinProvider = Literal[
     "deepseek",
     "nvidia",
     "local",
+    "litellm",
 ]
 PROVIDERS: list[BuiltinProvider] = cast(
     list[BuiltinProvider], get_args(BuiltinProvider)
@@ -88,6 +89,7 @@ PROVIDERS_OPENAI = [
     "deepseek",
     "nvidia",
     "local",
+    "litellm",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,9 @@ pyinstaller = {version="^6.15", python=">=3.10,<3.15", optional=true}  # not yet
 # acp (Agent Client Protocol)
 agent-client-protocol = {version = ">=0.7", optional=true, python=">=3.10,<3.15"}
 
+# litellm (AI gateway — routes to 100+ providers via litellm.completion)
+litellm = {version = ">=1.50", optional=true}
+
 [tool.poetry.group.dev.dependencies]
 # lint
 mypy = "*"
@@ -159,6 +162,7 @@ sounds = ["sounddevice", "scipy"]
 computer = []  # pillow (non-opt)
 pyinstaller = ["pyinstaller"]
 acp = ["agent-client-protocol"]
+litellm = ["litellm"]
 telemetry = [
     "opentelemetry-api", "opentelemetry-sdk",
     "opentelemetry-exporter-otlp", "opentelemetry-exporter-prometheus",

--- a/tests/test_litellm.py
+++ b/tests/test_litellm.py
@@ -1,0 +1,81 @@
+"""Unit tests for the LiteLLM provider shim."""
+
+from __future__ import annotations
+
+import sys
+import types
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+from gptme.llm.litellm import LiteLLMClient
+from gptme.llm.models import PROVIDERS, PROVIDERS_OPENAI, get_model
+
+
+def _install_litellm_stub() -> mock.MagicMock:
+    """Register a fake ``litellm`` module so ``import litellm`` resolves in tests."""
+    fake = types.ModuleType("litellm")
+    fake.completion = mock.MagicMock(name="litellm.completion")
+    sys.modules["litellm"] = fake
+    return fake.completion
+
+
+def _fake_chat_completion(content: str = "hi") -> SimpleNamespace:
+    message = SimpleNamespace(content=content, role="assistant", tool_calls=None)
+    choice = SimpleNamespace(message=message, finish_reason="stop", index=0)
+    usage = SimpleNamespace(prompt_tokens=3, completion_tokens=5, total_tokens=8)
+    return SimpleNamespace(choices=[choice], usage=usage, model="test")
+
+
+def test_litellm_client_exposes_openai_surface():
+    client = LiteLLMClient()
+    assert hasattr(client.chat.completions, "create")
+    # `_is_proxy` in llm_openai.py reads these attributes; both should exist.
+    assert client.base_url is None
+    assert client.api_key is None
+
+
+def test_litellm_client_forwards_to_litellm_completion():
+    completion = _install_litellm_stub()
+    completion.return_value = _fake_chat_completion("pong")
+
+    client = LiteLLMClient()
+    resp = client.chat.completions.create(
+        model="anthropic/claude-3-5-sonnet-20241022",
+        messages=[{"role": "user", "content": "ping"}],
+    )
+
+    assert resp.choices[0].message.content == "pong"
+    completion.assert_called_once()
+    kwargs = completion.call_args.kwargs
+    assert kwargs["model"] == "anthropic/claude-3-5-sonnet-20241022"
+    assert kwargs["messages"] == [{"role": "user", "content": "ping"}]
+
+
+def test_litellm_registered_as_builtin_provider():
+    assert "litellm" in PROVIDERS
+
+
+def test_litellm_routes_through_openai_path():
+    """Providers in PROVIDERS_OPENAI are dispatched via the OpenAI-compatible code
+    path in llm_openai.py; litellm relies on that dispatch to reach the shim."""
+    assert "litellm" in PROVIDERS_OPENAI
+
+
+def test_get_model_accepts_litellm_prefix():
+    """``get_model('litellm/<prov>/<model>')`` must not raise; it should return a
+    ModelMeta so the CLI can accept the model arg even without an entry in the
+    static MODELS dict."""
+    meta = get_model("litellm/anthropic/claude-3-5-sonnet-20241022")
+    assert meta.model == "anthropic/claude-3-5-sonnet-20241022"
+    # Generic 128k fallback is fine for LiteLLM routing — provider-specific context
+    # limits are enforced by the downstream provider (LiteLLM raises on exceed).
+    assert meta.context > 0
+
+
+def test_get_recommended_model_errors_for_litellm():
+    from gptme.llm.models.resolution import get_recommended_model
+
+    with pytest.raises(ValueError, match="LiteLLM requires an explicit model name"):
+        get_recommended_model("litellm")


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                                                                          
  - Add litellm as a new BuiltinProvider that routes chat completions through litellm.completion() to 100+ providers (OpenAI, Anthropic, Bedrock, Vertex, Gemini, Ollama, OpenRouter, Groq, DeepSeek, etc.) using provider-native API keys.                                                                                                                               
  - Implemented as a duck-typed OpenAI-client shim (LiteLLMClient) installed into llm_openai.clients, so the existing OpenAI-compatible chat() / stream() logic (tool use, reasoning content, retry, response parsing) is reused unchanged.                                                                                                                                                                                                                                                                                                                                                                
  
  ## Changes                                                                                                                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                                                                          
  - gptme/llm/litellm.py: new LiteLLMClient duck-typed shim (chat.completions.create → litellm.completion, lazy import).                                                                                                                                                                                                                                                  
  - gptme/llm/models/types.py: "litellm" added to BuiltinProvider and PROVIDERS_OPENAI.                                                                                                                                                                                                                                                                                   
  - gptme/llm/models/data.py: empty "litellm": {} entry so get_provider_from_model("litellm/...") resolves.                                                                                                                                                                                                                                                               
  - gptme/llm/models/resolution.py: explicit error from get_recommended_model("litellm") asking for a full model path.                                                                                                                                                                                                                                                    
  - gptme/llm/llm_openai.py: init() branch that installs LiteLLMClient as the client.                                                                                                                                                                                                                                                                                     
  - tests/test_litellm.py: 6 mocked tests.                                                                                                                                                                                                                                                                                                                                
  - pyproject.toml: new litellm optional extra (pip install 'gptme[litellm]').                                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                                                                          
  ## Testing                                                                                                                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                                                                          
  pytest tests/test_litellm.py -v              → 6/6 pass                                                                                                                                                                                                                                                                                                                 
  pytest tests/test_llm_openai.py tests/test_llm_models.py -v → 102/102 pass (no regression)                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                                             
  
  ## Example usage                                                                                                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                                                                          

  export ANTHROPIC_API_KEY=sk-ant-...                                                                                                                                                                                                                                                                                                                                     
  gptme -m litellm/anthropic/claude-3-5-sonnet-20241022
                                                                                                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                             
  gptme -m litellm/bedrock/anthropic.claude-3-sonnet-20240229-v1:0
  gptme -m litellm/gemini/gemini-1.5-pro                                                                                                                                                                                                                                                                                                                                  
  gptme -m litellm/ollama/llama3                                                                                                                                                                                                                                                                                                                                          
  gptme -m litellm/openrouter/meta-llama/llama-3.1-70b-instruct
