### PR TITLE
fix(anthropic): keep static bootstrap in top-level system prompt

### DIFF
--- a/gptme/llm/llm_anthropic.py
+++ b/gptme/llm/llm_anthropic.py
@@ -952,26 +952,42 @@ def _transform_system_messages(
     """Transform system messages into Anthropic's expected format.
 
     This function:
-    1. Extracts the first system message as the main system prompt
+    1. Extracts the leading static system prompt messages as the main system prompt
     2. Transforms subsequent system messages into <system> tags in user messages
     3. Merges consecutive user messages
     4. Applies cache control to optimize performance
 
     Note: Anthropic allows up to 4 cache breakpoints in a conversation.
     We use this to cache:
-    1. The system prompt (if long enough)
+    1. The static bootstrap prompt (if long enough)
     2. Earlier messages in multi-turn conversations
 
     Returns:
         tuple[list[Message], list[TextBlockParam]]: Transformed messages and system messages
     """
+    from ..prompts import SYSTEM_PROMPT_CACHE_BOUNDARY
+
     if not messages or messages[0].role != "system":
         raise ValueError(
             f"First message must be a system message, got {messages[0].role if messages else 'empty list'}"
         )
-    system_prompt = messages[0].content
+
     messages = messages.copy()
-    messages.pop(0)
+    system_prompt_parts = [messages.pop(0).content]
+
+    # Anthropic only allows a single top-level system prompt. Fold the static
+    # bootstrap prefix into that block so project/agent prompt files remain in
+    # the cacheable prefix instead of being downgraded into a synthetic user
+    # message that changes whenever context_cmd output changes.
+    while (
+        messages
+        and messages[0].role == "system"
+        and messages[0].call_id is None
+        and messages[0].content != SYSTEM_PROMPT_CACHE_BOUNDARY
+    ):
+        system_prompt_parts.append(messages.pop(0).content)
+
+    system_prompt = "\n\n".join(system_prompt_parts)
 
     # Convert subsequent system messages into <system> messages,
     # unless a `call_id` is present, indicating the tool_format is 'tool'.

--- a/tests/test_llm_anthropic.py
+++ b/tests/test_llm_anthropic.py
@@ -11,6 +11,7 @@ from gptme.llm.llm_anthropic import (
     _resolve_thinking_budget,
 )
 from gptme.message import Message
+from gptme.prompts import SYSTEM_PROMPT_CACHE_BOUNDARY
 from gptme.tools import get_tool, init_tools
 
 
@@ -28,7 +29,7 @@ def test_message_conversion():
     assert system_messages == [
         {
             "type": "text",
-            "text": "Initial Message",
+            "text": "Initial Message\n\nProject prompt",
             "cache_control": {"type": "ephemeral"},
         }
     ]
@@ -39,7 +40,7 @@ def test_message_conversion():
             "content": [
                 {
                     "type": "text",
-                    "text": "<system>Project prompt</system>\n\nFirst user prompt",
+                    "text": "First user prompt",
                     "cache_control": {"type": "ephemeral"},
                 }
             ],
@@ -69,7 +70,7 @@ def test_message_conversion_without_tools():
             "content": [
                 {
                     "type": "text",
-                    "text": "<system>Project prompt</system>\n\nFirst user prompt",
+                    "text": "First user prompt",
                     "cache_control": {"type": "ephemeral"},
                 }
             ],
@@ -146,7 +147,7 @@ def test_message_conversion_with_tools():
             "content": [
                 {
                     "type": "text",
-                    "text": "<system>Project prompt</system>\n\nFirst user prompt",
+                    "text": "First user prompt",
                     "cache_control": {"type": "ephemeral"},
                 }
             ],
@@ -219,10 +220,6 @@ def test_message_conversion_with_tool_and_non_tool():
 
     assert messages_dicts == [
         {
-            "role": "user",
-            "content": [{"type": "text", "text": "<system>Project prompt</system>"}],
-        },
-        {
             "role": "assistant",
             "content": [
                 {
@@ -263,6 +260,41 @@ def test_message_conversion_with_tool_and_non_tool():
                 }
             ],
         },
+    ]
+
+
+def test_boundary_keeps_dynamic_context_out_of_static_system_prompt():
+    messages = [
+        Message(role="system", content="Core prompt"),
+        Message(role="system", content="Static workspace prompt"),
+        Message(role="system", content=SYSTEM_PROMPT_CACHE_BOUNDARY),
+        Message(role="system", content="Dynamic context"),
+        Message(role="user", content="Actual user prompt"),
+    ]
+
+    messages_dicts, system_messages, _ = _prepare_messages_for_api(messages, None)
+
+    assert system_messages == [
+        {
+            "type": "text",
+            "text": "Core prompt\n\nStatic workspace prompt",
+            "cache_control": {"type": "ephemeral"},
+        }
+    ]
+
+    assert messages_dicts == [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "<system>"
+                    + SYSTEM_PROMPT_CACHE_BOUNDARY
+                    + "</system>\n\n<system>Dynamic context</system>\n\nActual user prompt",
+                    "cache_control": {"type": "ephemeral"},
+                }
+            ],
+        }
     ]
 
 


### PR DESCRIPTION
## Summary
- fold leading static system prompt messages into Anthropic's top-level system prompt
- stop downgrading project/agent bootstrap context into a synthetic pre-user message
- add regression coverage for the cache-boundary split between static bootstrap and dynamic context

## Why
Anthropic only gets one real top-level system prompt. Before this patch, only the first system message stayed there; later bootstrap messages were rewritten into a user message, so the new cache boundary marker was largely cosmetic for Anthropic. This keeps the static bootstrap prefix in the actual cacheable system block.

## Testing
- uv run pytest tests/test_llm_anthropic.py tests/test_prompts.py tests/test_prompt_templates.py -q