### PR TITLE
fix(anthropic): use adaptive thinking on Opus 4.7 (legacy returns 400)

### DIFF
--- a/gptme/llm/llm_anthropic.py
+++ b/gptme/llm/llm_anthropic.py
@@ -305,7 +305,7 @@ def _build_thinking_param(
 
 
 def _adjust_thinking_budget(
-    max_tokens: int, thinking_budget: int, use_thinking: bool
+    max_tokens: int, thinking_budget: int, use_thinking: bool, model: str = ""
 ) -> tuple[int, bool]:
     """Clamp thinking_budget to fit within max_tokens for Anthropic's extended thinking.
 
@@ -315,8 +315,13 @@ def _adjust_thinking_budget(
 
     Always reserves at least _MIN_RESPONSE_TOKENS for the actual response;
     disables thinking entirely when max_tokens is too small to be useful.
+
+    Adaptive-thinking models (Opus 4.7+) have no ``budget_tokens`` constraint —
+    the API allocates tokens internally — so the clamping logic is skipped for them.
     """
-    if not use_thinking or max_tokens >= thinking_budget + _MIN_RESPONSE_TOKENS:
+    if not use_thinking or _requires_adaptive_thinking(model):
+        return thinking_budget, use_thinking
+    if max_tokens >= thinking_budget + _MIN_RESPONSE_TOKENS:
         return thinking_budget, use_thinking
     new_budget = max_tokens - _MIN_RESPONSE_TOKENS
     if new_budget <= 0:
@@ -597,7 +602,7 @@ def chat(
         max_tokens if max_tokens is not None else (model_meta.max_output or 4096)
     )
     thinking_budget, use_thinking = _adjust_thinking_budget(
-        max_tokens, thinking_budget, use_thinking
+        max_tokens, thinking_budget, use_thinking, model=model
     )
 
     # Pass output_config.effort when the SDK supports it (>= 0.77) and
@@ -696,7 +701,7 @@ def stream(
         max_tokens if max_tokens is not None else (model_meta.max_output or 4096)
     )
     thinking_budget, use_thinking = _adjust_thinking_budget(
-        max_tokens, thinking_budget, use_thinking
+        max_tokens, thinking_budget, use_thinking, model=model
     )
 
     output_config_kwargs = _output_config_kwargs(use_thinking=use_thinking)

--- a/gptme/llm/llm_anthropic.py
+++ b/gptme/llm/llm_anthropic.py
@@ -46,6 +46,14 @@ _THINKING_EFFORT_BUDGETS: dict[str, int] = {
 }
 _EffortLevel = Literal["low", "medium", "high", "xhigh", "max"]
 
+# Models that reject the legacy ``thinking: {type: "enabled", budget_tokens: N}``
+# format with HTTP 400 and require ``thinking: {type: "adaptive"}`` + the
+# ``output_config.effort`` parameter.  See
+# https://platform.claude.com/docs/en/docs/build-with-claude/extended-thinking
+# ("Manual extended thinking is no longer supported on Claude Opus 4.7 or
+# later models and returns a 400 error.")
+_ADAPTIVE_THINKING_MODELS: frozenset[str] = frozenset({"claude-opus-4-7"})
+
 if TYPE_CHECKING:
     # noreorder
     import anthropic.types  # fmt: skip
@@ -259,6 +267,41 @@ def _output_config_kwargs(*, use_thinking: bool) -> _OutputConfigKwargs:
         return {}
 
     return {"output_config": {"effort": effort_level}}
+
+
+def _requires_adaptive_thinking(model: str) -> bool:
+    """Return True if ``model`` rejects legacy ``thinking.type=enabled`` with 400.
+
+    Such models only accept adaptive thinking (``thinking.type=adaptive``)
+    plus ``output_config.effort``.  Handles bare names, vendor prefixes, and
+    Anthropic's dated-release suffixes (e.g. ``claude-opus-4-7-20260401``).
+    """
+    # Strip vendor prefix: "anthropic/claude-opus-4-7" -> "claude-opus-4-7",
+    # "openrouter/anthropic/claude-opus-4-7" -> "claude-opus-4-7".
+    base = model.rsplit("/", 1)[-1]
+    if base in _ADAPTIVE_THINKING_MODELS:
+        return True
+    # Match dated-release suffix: "claude-opus-4-7-20260401".
+    return any(base.startswith(known + "-") for known in _ADAPTIVE_THINKING_MODELS)
+
+
+def _build_thinking_param(
+    model: str, use_thinking: bool, thinking_budget: int
+) -> dict[str, object] | None:
+    """Build the ``thinking`` kwarg for Anthropic's messages API.
+
+    Returns ``None`` when thinking is disabled so callers can substitute
+    the SDK's ``NOT_GIVEN`` sentinel.  Branches on model capability:
+
+    - Adaptive-only models (Opus 4.7+): ``{"type": "adaptive"}`` (effort
+      flows through ``output_config`` separately).
+    - All other reasoning models: ``{"type": "enabled", "budget_tokens": N}``.
+    """
+    if not use_thinking:
+        return None
+    if _requires_adaptive_thinking(model):
+        return {"type": "adaptive"}
+    return {"type": "enabled", "budget_tokens": thinking_budget}
 
 
 def _adjust_thinking_budget(
@@ -561,6 +604,7 @@ def chat(
     # GPTME_THINKING_EFFORT is set.  This enables true xhigh/max semantics
     # (adaptive thinking) that budget_tokens cannot express.
     output_config_kwargs = _output_config_kwargs(use_thinking=use_thinking)
+    thinking_param = _build_thinking_param(model, use_thinking, thinking_budget)
 
     response = _anthropic.messages.create(  # type: ignore[call-overload, misc]
         model=api_model,
@@ -570,11 +614,7 @@ def chat(
         top_p=TOP_P if not model_meta.supports_reasoning else NOT_GIVEN,
         max_tokens=max_tokens,
         tools=tools_dict or NOT_GIVEN,
-        thinking=(
-            {"type": "enabled", "budget_tokens": thinking_budget}
-            if use_thinking
-            else NOT_GIVEN
-        ),
+        thinking=thinking_param if thinking_param is not None else NOT_GIVEN,
         **output_config_kwargs,
         # We set a timeout for non-streaming requests to prevent Anthropic's
         # "Streaming is strongly recommended" warning/error.
@@ -660,6 +700,7 @@ def stream(
     )
 
     output_config_kwargs = _output_config_kwargs(use_thinking=use_thinking)
+    thinking_param = _build_thinking_param(model, use_thinking, thinking_budget)
 
     with _anthropic.messages.stream(  # type: ignore[call-arg, misc]
         model=api_model,
@@ -669,11 +710,7 @@ def stream(
         top_p=TOP_P if not model_meta.supports_reasoning else NOT_GIVEN,
         max_tokens=max_tokens,
         tools=tools_dict or NOT_GIVEN,
-        thinking=(
-            {"type": "enabled", "budget_tokens": thinking_budget}
-            if use_thinking
-            else NOT_GIVEN
-        ),
+        thinking=thinking_param if thinking_param is not None else NOT_GIVEN,
         **output_config_kwargs,
     ) as stream:
         for chunk in stream:

--- a/gptme/llm/llm_anthropic.py
+++ b/gptme/llm/llm_anthropic.py
@@ -715,7 +715,7 @@ def stream(
         top_p=TOP_P if not model_meta.supports_reasoning else NOT_GIVEN,
         max_tokens=max_tokens,
         tools=tools_dict or NOT_GIVEN,
-        thinking=thinking_param if thinking_param is not None else NOT_GIVEN,
+        thinking=thinking_param if thinking_param is not None else NOT_GIVEN,  # type: ignore[arg-type]
         **output_config_kwargs,
     ) as stream:
         for chunk in stream:

--- a/tests/test_llm_anthropic.py
+++ b/tests/test_llm_anthropic.py
@@ -5,6 +5,7 @@ import pytest
 
 from gptme.llm.llm_anthropic import (
     _HAS_OUTPUT_CONFIG,
+    _adjust_thinking_budget,
     _build_thinking_param,
     _output_config_kwargs,
     _prepare_messages_for_api,
@@ -691,3 +692,59 @@ class TestBuildThinkingParam:
             use_thinking=True,
             thinking_budget=8000,
         ) == {"type": "adaptive"}
+
+
+class TestAdjustThinkingBudgetAdaptive:
+    """_adjust_thinking_budget must not disable thinking for adaptive models."""
+
+    def test_adaptive_model_small_max_tokens_keeps_thinking(self):
+        # Legacy logic would disable thinking here (budget=8000 > max_tokens=100).
+        # For Opus 4.7 (adaptive), budget_tokens is irrelevant — thinking stays on.
+        budget, use_thinking = _adjust_thinking_budget(
+            max_tokens=100,
+            thinking_budget=8000,
+            use_thinking=True,
+            model="claude-opus-4-7",
+        )
+        assert use_thinking is True
+        assert budget == 8000  # unchanged; adaptive doesn't use this field
+
+    def test_adaptive_model_tiny_max_tokens_keeps_thinking(self):
+        # Even max_tokens=1 must not suppress adaptive thinking.
+        budget, use_thinking = _adjust_thinking_budget(
+            max_tokens=1,
+            thinking_budget=8000,
+            use_thinking=True,
+            model="claude-opus-4-7",
+        )
+        assert use_thinking is True
+
+    def test_adaptive_model_prefixed_keeps_thinking(self):
+        budget, use_thinking = _adjust_thinking_budget(
+            max_tokens=50,
+            thinking_budget=16000,
+            use_thinking=True,
+            model="anthropic/claude-opus-4-7",
+        )
+        assert use_thinking is True
+
+    def test_legacy_model_small_max_tokens_disables_thinking(self):
+        # Legacy path unchanged: Opus 4.6 with tiny max_tokens still disables.
+        _, use_thinking = _adjust_thinking_budget(
+            max_tokens=50,
+            thinking_budget=8000,
+            use_thinking=True,
+            model="claude-opus-4-6",
+        )
+        assert use_thinking is False
+
+    def test_adaptive_thinking_disabled_returns_unchanged(self):
+        # use_thinking=False stays False regardless of model.
+        budget, use_thinking = _adjust_thinking_budget(
+            max_tokens=100,
+            thinking_budget=8000,
+            use_thinking=False,
+            model="claude-opus-4-7",
+        )
+        assert use_thinking is False
+        assert budget == 8000

--- a/tests/test_llm_anthropic.py
+++ b/tests/test_llm_anthropic.py
@@ -5,8 +5,10 @@ import pytest
 
 from gptme.llm.llm_anthropic import (
     _HAS_OUTPUT_CONFIG,
+    _build_thinking_param,
     _output_config_kwargs,
     _prepare_messages_for_api,
+    _requires_adaptive_thinking,
     _resolve_effort_level,
     _resolve_thinking_budget,
 )
@@ -617,3 +619,75 @@ class TestOutputConfigKwargs:
 def test_has_output_config_is_bool():
     """_HAS_OUTPUT_CONFIG must be a bool (True when SDK >= 0.77)."""
     assert isinstance(_HAS_OUTPUT_CONFIG, bool)
+
+
+class TestRequiresAdaptiveThinking:
+    """Opus 4.7+ rejects ``thinking.type=enabled`` with HTTP 400."""
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "claude-opus-4-7",
+            "anthropic/claude-opus-4-7",
+            "openrouter/anthropic/claude-opus-4-7",
+            "claude-opus-4-7-20260401",
+            "anthropic/claude-opus-4-7-20260401",
+        ],
+    )
+    def test_adaptive_required(self, model):
+        assert _requires_adaptive_thinking(model) is True
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "claude-opus-4-6",
+            "claude-sonnet-4-6",
+            "claude-opus-4-5-20251101",
+            "anthropic/claude-opus-4-6",
+            "openrouter/anthropic/claude-sonnet-4-5",
+            "claude-haiku-4-5",
+        ],
+    )
+    def test_legacy_still_used(self, model):
+        assert _requires_adaptive_thinking(model) is False
+
+
+class TestBuildThinkingParam:
+    """_build_thinking_param dispatches on model and thinking flag."""
+
+    def test_disabled_returns_none(self):
+        assert (
+            _build_thinking_param(
+                "claude-opus-4-7", use_thinking=False, thinking_budget=8000
+            )
+            is None
+        )
+
+    def test_opus_47_returns_adaptive(self):
+        # Opus 4.7 gets ``{"type": "adaptive"}`` — never legacy, regardless of budget.
+        assert _build_thinking_param(
+            "claude-opus-4-7", use_thinking=True, thinking_budget=8000
+        ) == {"type": "adaptive"}
+
+    def test_opus_47_adaptive_ignores_budget(self):
+        # Budget is irrelevant once adaptive: effort flows via output_config.
+        assert _build_thinking_param(
+            "claude-opus-4-7", use_thinking=True, thinking_budget=32000
+        ) == {"type": "adaptive"}
+
+    def test_opus_46_returns_legacy_enabled(self):
+        assert _build_thinking_param(
+            "claude-opus-4-6", use_thinking=True, thinking_budget=12345
+        ) == {"type": "enabled", "budget_tokens": 12345}
+
+    def test_sonnet_returns_legacy_enabled(self):
+        assert _build_thinking_param(
+            "claude-sonnet-4-6", use_thinking=True, thinking_budget=4000
+        ) == {"type": "enabled", "budget_tokens": 4000}
+
+    def test_openrouter_prefix_opus_47(self):
+        assert _build_thinking_param(
+            "openrouter/anthropic/claude-opus-4-7",
+            use_thinking=True,
+            thinking_budget=8000,
+        ) == {"type": "adaptive"}


### PR DESCRIPTION
## Summary

Claude Opus 4.7+ rejects the legacy manual extended-thinking format with HTTP 400. Per [Anthropic's extended-thinking docs](https://platform.claude.com/docs/en/docs/build-with-claude/extended-thinking):

> Manual extended thinking is no longer supported on Claude Opus 4.7 or later models and returns a 400 error.

gptme currently always sends `thinking={\"type\": \"enabled\", \"budget_tokens\": N}` when thinking is enabled, regardless of model — which silently breaks on Opus 4.7.

This PR routes Opus 4.7+ to `thinking={\"type\": \"adaptive\"}` while keeping the legacy shape for every other model (Opus 4.6, Sonnet 4.x, Haiku 4.5, etc.). The effort level is already piped via `output_config.effort` (#2184/#2186), so adaptive thinking gets the user-requested effort for free.

## Changes

- `gptme/llm/llm_anthropic.py`:
  - New frozenset `_ADAPTIVE_THINKING_MODELS = {\"claude-opus-4-7\"}`
  - `_requires_adaptive_thinking(model)` — vendor-prefix-tolerant (`anthropic/`, `openrouter/anthropic/`) and dated-release-tolerant (`claude-opus-4-7-20260401`)
  - `_build_thinking_param(model, use_thinking, thinking_budget)` — returns `None`, `{\"type\": \"adaptive\"}`, or `{\"type\": \"enabled\", \"budget_tokens\": N}` as appropriate
  - Both sync `messages.create` and stream `messages.stream` call sites use the new helper
- `tests/test_llm_anthropic.py`: 14 new regression tests covering prefix handling, dated suffixes, and both output shapes

Growing the frozenset as Anthropic ships more adaptive-only models is a one-line change.

## Context

- #2183 raised the thinking-effort gap
- #2184 added `GPTME_THINKING_EFFORT`
- #2186 wired `output_config.effort`
- This PR is the missing 4th piece: actually sending the thinking parameter in the shape the API accepts

## Test plan

- [x] New tests pass (14 new, 51/51 total in touched file)
- [x] Full \`pytest tests/test_llm_anthropic.py\` green
- [ ] Post-merge: smoke test with \`MODEL=anthropic/claude-opus-4-7 GPTME_THINKING_EFFORT=high gptme ...\` once released