### PR TITLE
feat(tauri): desktop/mobile split — gate sidecar behind cfg(desktop)

### DIFF
--- a/tauri/src-tauri/Cargo.toml
+++ b/tauri/src-tauri/Cargo.toml
@@ -29,8 +29,8 @@ log = "0.4"
 tauri-plugin-log = "2"
 
 [target.'cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))'.dependencies]
-tauri-plugin-single-instance = { version = "2", features = ["deep-link"] }
 tauri-plugin-shell = "2"
+tauri-plugin-single-instance = { version = "2", features = ["deep-link"] }
 
 [dev-dependencies]
 tauri = { version = "2", features = ["test"] }

--- a/tauri/src-tauri/Cargo.toml
+++ b/tauri/src-tauri/Cargo.toml
@@ -23,7 +23,6 @@ tauri-plugin-opener = "2"
 tauri-plugin-dialog = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tauri-plugin-shell = "2"
 tauri-plugin-deep-link = "2"
 url = "2"
 log = "0.4"
@@ -31,6 +30,7 @@ tauri-plugin-log = "2"
 
 [target.'cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))'.dependencies]
 tauri-plugin-single-instance = { version = "2", features = ["deep-link"] }
+tauri-plugin-shell = "2"
 
 [dev-dependencies]
 tauri = { version = "2", features = ["test"] }

--- a/tauri/src-tauri/capabilities/default.json
+++ b/tauri/src-tauri/capabilities/default.json
@@ -1,28 +1,11 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
-  "description": "Capability for the main window",
+  "description": "Capability for the main window (all platforms)",
   "windows": ["main"],
   "permissions": [
     "core:default",
     "opener:default",
-    "shell:default",
-    {
-      "identifier": "shell:allow-execute",
-      "allow": [
-        {
-          "name": "../bins/gptme-server",
-          "sidecar": true,
-          "args": [
-            "--cors-origin",
-            {
-              "validator": "\\S+"
-            }
-          ]
-        }
-      ]
-    },
-    "shell:allow-open",
     "log:default",
     "deep-link:default"
   ]

--- a/tauri/src-tauri/capabilities/default.json
+++ b/tauri/src-tauri/capabilities/default.json
@@ -3,6 +3,7 @@
   "identifier": "default",
   "description": "Capability for the main window (all platforms)",
   "windows": ["main"],
+  "platforms": ["linux", "macOS", "windows"],
   "permissions": [
     "core:default",
     "opener:default",

--- a/tauri/src-tauri/capabilities/desktop.json
+++ b/tauri/src-tauri/capabilities/desktop.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "desktop",
+  "description": "Desktop-only capability: shell plugin and gptme-server sidecar execution",
+  "platforms": ["linux", "macos", "windows"],
+  "windows": ["main"],
+  "permissions": [
+    "shell:default",
+    {
+      "identifier": "shell:allow-execute",
+      "allow": [
+        {
+          "name": "../bins/gptme-server",
+          "sidecar": true,
+          "args": [
+            "--cors-origin",
+            {
+              "validator": "\\S+"
+            }
+          ]
+        }
+      ]
+    },
+    "shell:allow-open"
+  ]
+}

--- a/tauri/src-tauri/capabilities/desktop.json
+++ b/tauri/src-tauri/capabilities/desktop.json
@@ -2,7 +2,7 @@
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "desktop",
   "description": "Desktop-only capability: shell plugin and gptme-server sidecar execution",
-  "platforms": ["linux", "macos", "windows"],
+  "platforms": ["linux", "macOS", "windows"],
   "windows": ["main"],
   "permissions": [
     "shell:default",

--- a/tauri/src-tauri/capabilities/mobile.json
+++ b/tauri/src-tauri/capabilities/mobile.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "../gen/schemas/mobile-schema.json",
+  "identifier": "mobile-capability",
+  "description": "Capability for the main window on mobile",
+  "windows": ["main"],
+  "platforms": ["android", "iOS"],
+  "permissions": ["core:default", "opener:default", "log:default", "deep-link:default"]
+}

--- a/tauri/src-tauri/src/lib.rs
+++ b/tauri/src-tauri/src/lib.rs
@@ -16,6 +16,7 @@ use tauri_plugin_shell::process::CommandChild;
 use tauri_plugin_shell::ShellExt;
 
 const GPTME_SERVER_PORT: u16 = 5700;
+#[cfg(not(desktop))]
 const LOCAL_SERVER_UNSUPPORTED: &str =
     "Local gptme-server management is desktop-only. Connect to a remote gptme instance instead.";
 
@@ -372,6 +373,7 @@ mod tests {
     use super::*;
 
     #[test]
+    #[cfg(desktop)]
     fn test_is_port_available_on_unused_port() {
         let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
         let port = listener.local_addr().unwrap().port();
@@ -380,6 +382,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(desktop)]
     fn test_is_port_available_on_occupied_port() {
         let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
         let port = listener.local_addr().unwrap().port();
@@ -442,6 +445,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(desktop)]
     fn test_server_process_initial_state() {
         let handle: Arc<Mutex<Option<tauri_plugin_shell::process::CommandChild>>> =
             Arc::new(Mutex::new(None));
@@ -450,6 +454,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(desktop)]
     fn test_server_process_state_is_send_sync() {
         fn assert_send_sync<T: Send + Sync>() {}
         assert_send_sync::<ServerProcess>();

--- a/tauri/src-tauri/src/lib.rs
+++ b/tauri/src-tauri/src/lib.rs
@@ -1,24 +1,35 @@
-use std::net::TcpListener;
-use std::sync::{Arc, Mutex};
 use tauri::Manager;
 use tauri_plugin_deep_link::DeepLinkExt;
+use tauri_plugin_log::{Target, TargetKind};
+
+// Desktop-only: sidecar server management
+#[cfg(desktop)]
+use std::net::TcpListener;
+#[cfg(desktop)]
+use std::sync::{Arc, Mutex};
+#[cfg(desktop)]
 use tauri_plugin_dialog::{
     DialogExt, MessageDialogBuilder, MessageDialogButtons, MessageDialogKind,
 };
-use tauri_plugin_log::{Target, TargetKind};
+#[cfg(desktop)]
 use tauri_plugin_shell::process::CommandChild;
+#[cfg(desktop)]
 use tauri_plugin_shell::ShellExt;
 
+#[cfg(desktop)]
 const GPTME_SERVER_PORT: u16 = 5700;
 
 /// Check if a port is available
+#[cfg(desktop)]
 fn is_port_available(port: u16) -> bool {
     TcpListener::bind(format!("127.0.0.1:{}", port)).is_ok()
 }
 
 /// Managed state holding the gptme-server child process for cleanup on exit.
+#[cfg(desktop)]
 struct ServerProcess(Arc<Mutex<Option<CommandChild>>>);
 
+#[cfg(desktop)]
 #[derive(serde::Serialize)]
 struct ServerStatus {
     running: bool,
@@ -27,6 +38,7 @@ struct ServerStatus {
 }
 
 /// Get the current status of the local gptme-server.
+#[cfg(desktop)]
 #[tauri::command]
 fn get_server_status(state: tauri::State<'_, ServerProcess>) -> ServerStatus {
     let running = state.0.lock().map(|guard| guard.is_some()).unwrap_or(false);
@@ -38,6 +50,7 @@ fn get_server_status(state: tauri::State<'_, ServerProcess>) -> ServerStatus {
 }
 
 /// Stop the local gptme-server process.
+#[cfg(desktop)]
 #[tauri::command]
 fn stop_server(state: tauri::State<'_, ServerProcess>) -> Result<(), String> {
     let mut guard = state.0.lock().map_err(|e| format!("Lock error: {}", e))?;
@@ -52,6 +65,7 @@ fn stop_server(state: tauri::State<'_, ServerProcess>) -> Result<(), String> {
 }
 
 /// Start the local gptme-server process (if not already running).
+#[cfg(desktop)]
 #[tauri::command]
 async fn start_server(
     app: tauri::AppHandle,
@@ -224,6 +238,8 @@ pub fn run() {
                 let _ = window.set_focus();
             }
         }));
+
+        builder = builder.plugin(tauri_plugin_shell::init());
     }
 
     builder
@@ -238,15 +254,19 @@ pub fn run() {
                 .level(log::LevelFilter::Info)
                 .build(),
         )
-        .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_deep_link::init())
-        .invoke_handler(tauri::generate_handler![
-            get_server_status,
-            start_server,
-            stop_server,
-        ])
+        .invoke_handler({
+            #[cfg(desktop)]
+            {
+                tauri::generate_handler![get_server_status, start_server, stop_server]
+            }
+            #[cfg(not(desktop))]
+            {
+                tauri::generate_handler![]
+            }
+        })
         .setup(|app| {
             log::info!("Starting gptme-tauri application");
 
@@ -274,161 +294,180 @@ pub fn run() {
                 handle_deep_link_urls(&handle, urls);
             });
 
-            let app_handle = app.handle().clone();
+            // Desktop only: spawn the bundled gptme-server sidecar
+            #[cfg(desktop)]
+            {
+                let app_handle = app.handle().clone();
 
-            // Shared handle to the child process — written by the spawn task,
-            // read by the window-close handler for cleanup.
-            let child_handle: Arc<Mutex<Option<CommandChild>>> = Arc::new(Mutex::new(None));
-            let child_for_spawn = child_handle.clone();
+                // Shared handle to the child process — written by the spawn task,
+                // read by the window-close handler for cleanup.
+                let child_handle: Arc<Mutex<Option<CommandChild>>> = Arc::new(Mutex::new(None));
+                let child_for_spawn = child_handle.clone();
 
-            // Register state so the window-close handler can access it.
-            app.manage(ServerProcess(child_handle));
+                // Register state so the window-close handler can access it.
+                app.manage(ServerProcess(child_handle));
 
-            // Spawn gptme-server with output capture
-            tauri::async_runtime::spawn(async move {
-                // Check if port is available before starting
-                if !is_port_available(GPTME_SERVER_PORT) {
-                    log::error!(
-                        "Port {} is already in use. Another gptme-server instance may be running.",
-                        GPTME_SERVER_PORT
-                    );
-
-                    let message = format!(
-                        "Cannot start gptme-server because port {} is already in use.\n\n\
-                        This usually means another gptme-server instance is already running.\n\n\
-                        Please stop the existing gptme-server process and restart this application.",
-                        GPTME_SERVER_PORT
-                    );
-
-                    MessageDialogBuilder::new(
-                        app_handle.dialog().clone(),
-                        "Port Conflict",
-                        message,
-                    )
-                    .kind(MessageDialogKind::Error)
-                    .buttons(MessageDialogButtons::Ok)
-                    .show(|_result| {});
-
-                    return;
-                }
-
-                // Determine CORS origin based on build mode and platform.
-                // Tauri v2 uses different URL schemes per platform:
-                // - macOS: tauri://localhost (custom Tauri protocol)
-                // - Linux/Windows: http://tauri.localhost
-                let cors_origin = if cfg!(debug_assertions) {
-                    "http://localhost:5701" // Dev mode
-                } else if cfg!(target_os = "macos") {
-                    "tauri://localhost" // macOS production
-                } else {
-                    "http://tauri.localhost" // Linux/Windows production
-                };
-
-                log::info!(
-                    "Port {} is available, starting gptme-server with CORS origin: {}",
-                    GPTME_SERVER_PORT,
-                    cors_origin
-                );
-
-                let sidecar_command = match app_handle
-                    .shell()
-                    .sidecar("gptme-server")
-                {
-                    Ok(s) => s.args(["--cors-origin", cors_origin]),
-                    Err(e) => {
-                        log::error!("Failed to find gptme-server sidecar: {}", e);
-                        return;
-                    }
-                };
-
-                match sidecar_command.spawn() {
-                    Ok((mut rx, child)) => {
-                        log::info!(
-                            "gptme-server started successfully with PID: {}",
-                            child.pid()
+                // Spawn gptme-server with output capture
+                tauri::async_runtime::spawn(async move {
+                    // Check if port is available before starting
+                    if !is_port_available(GPTME_SERVER_PORT) {
+                        log::error!(
+                            "Port {} is already in use. Another gptme-server instance may be running.",
+                            GPTME_SERVER_PORT
                         );
 
-                        // Store child process for later cleanup
-                        if let Ok(mut guard) = child_for_spawn.lock() {
-                            *guard = Some(child);
+                        let message = format!(
+                            "Cannot start gptme-server because port {} is already in use.\n\n\
+                            This usually means another gptme-server instance is already running.\n\n\
+                            Please stop the existing gptme-server process and restart this application.",
+                            GPTME_SERVER_PORT
+                        );
+
+                        MessageDialogBuilder::new(
+                            app_handle.dialog().clone(),
+                            "Port Conflict",
+                            message,
+                        )
+                        .kind(MessageDialogKind::Error)
+                        .buttons(MessageDialogButtons::Ok)
+                        .show(|_result| {});
+
+                        return;
+                    }
+
+                    // Determine CORS origin based on build mode and platform.
+                    // Tauri v2 uses different URL schemes per platform:
+                    // - macOS: tauri://localhost (custom Tauri protocol)
+                    // - Linux/Windows: http://tauri.localhost
+                    let cors_origin = if cfg!(debug_assertions) {
+                        "http://localhost:5701" // Dev mode
+                    } else if cfg!(target_os = "macos") {
+                        "tauri://localhost" // macOS production
+                    } else {
+                        "http://tauri.localhost" // Linux/Windows production
+                    };
+
+                    log::info!(
+                        "Port {} is available, starting gptme-server with CORS origin: {}",
+                        GPTME_SERVER_PORT,
+                        cors_origin
+                    );
+
+                    let sidecar_command = match app_handle.shell().sidecar("gptme-server") {
+                        Ok(s) => s.args(["--cors-origin", cors_origin]),
+                        Err(e) => {
+                            log::error!("Failed to find gptme-server sidecar: {}", e);
+                            return;
                         }
+                    };
 
-                        // Clone the Arc so the async task can clear state when server terminates
-                        let child_for_output = child_for_spawn.clone();
+                    match sidecar_command.spawn() {
+                        Ok((mut rx, child)) => {
+                            log::info!(
+                                "gptme-server started successfully with PID: {}",
+                                child.pid()
+                            );
 
-                        // Handle server output
-                        tauri::async_runtime::spawn(async move {
-                            while let Some(event) = rx.recv().await {
-                                match event {
-                                    tauri_plugin_shell::process::CommandEvent::Stdout(data) => {
-                                        let output = String::from_utf8_lossy(&data);
-                                        for line in output.lines() {
-                                            if !line.trim().is_empty() {
-                                                log::info!("[gptme-server] {}", line.trim());
-                                            }
-                                        }
-                                    }
-                                    tauri_plugin_shell::process::CommandEvent::Stderr(data) => {
-                                        let output = String::from_utf8_lossy(&data);
-                                        for line in output.lines() {
-                                            if !line.trim().is_empty() {
-                                                log::warn!("[gptme-server] {}", line.trim());
-                                            }
-                                        }
-                                    }
-                                    tauri_plugin_shell::process::CommandEvent::Error(error) => {
-                                        log::error!("[gptme-server] Process error: {}", error);
-                                    }
-                                    tauri_plugin_shell::process::CommandEvent::Terminated(
-                                        payload,
-                                    ) => {
-                                        log::warn!(
-                                            "[gptme-server] Process terminated with code: {:?}",
-                                            payload.code
-                                        );
-                                        // Clear state so get_server_status correctly reports not running
-                                        if let Ok(mut guard) = child_for_output.lock() {
-                                            *guard = None;
-                                        }
-                                        break;
-                                    }
-                                    _ => {}
-                                }
+                            // Store child process for later cleanup
+                            if let Ok(mut guard) = child_for_spawn.lock() {
+                                *guard = Some(child);
                             }
-                        });
+
+                            // Clone the Arc so the async task can clear state when server terminates
+                            let child_for_output = child_for_spawn.clone();
+
+                            // Handle server output
+                            tauri::async_runtime::spawn(async move {
+                                while let Some(event) = rx.recv().await {
+                                    match event {
+                                        tauri_plugin_shell::process::CommandEvent::Stdout(
+                                            data,
+                                        ) => {
+                                            let output = String::from_utf8_lossy(&data);
+                                            for line in output.lines() {
+                                                if !line.trim().is_empty() {
+                                                    log::info!(
+                                                        "[gptme-server] {}",
+                                                        line.trim()
+                                                    );
+                                                }
+                                            }
+                                        }
+                                        tauri_plugin_shell::process::CommandEvent::Stderr(
+                                            data,
+                                        ) => {
+                                            let output = String::from_utf8_lossy(&data);
+                                            for line in output.lines() {
+                                                if !line.trim().is_empty() {
+                                                    log::warn!(
+                                                        "[gptme-server] {}",
+                                                        line.trim()
+                                                    );
+                                                }
+                                            }
+                                        }
+                                        tauri_plugin_shell::process::CommandEvent::Error(
+                                            error,
+                                        ) => {
+                                            log::error!(
+                                                "[gptme-server] Process error: {}",
+                                                error
+                                            );
+                                        }
+                                        tauri_plugin_shell::process::CommandEvent::Terminated(
+                                            payload,
+                                        ) => {
+                                            log::warn!(
+                                                "[gptme-server] Process terminated with code: {:?}",
+                                                payload.code
+                                            );
+                                            // Clear state so get_server_status correctly reports not running
+                                            if let Ok(mut guard) = child_for_output.lock() {
+                                                *guard = None;
+                                            }
+                                            break;
+                                        }
+                                        _ => {}
+                                    }
+                                }
+                            });
+                        }
+                        Err(e) => {
+                            log::error!("Failed to start gptme-server: {}", e);
+                        }
                     }
-                    Err(e) => {
-                        log::error!("Failed to start gptme-server: {}", e);
-                    }
-                }
-            });
+                });
+            }
 
             Ok(())
         })
         .on_window_event(|window, event| {
             if let tauri::WindowEvent::CloseRequested { .. } = event {
-                log::info!("Window close requested, cleaning up gptme-server...");
+                log::info!("Window close requested, cleaning up...");
 
-                let arc = window.state::<ServerProcess>().0.clone();
-                let mut guard = match arc.lock() {
-                    Ok(g) => g,
-                    Err(_) => {
-                        log::error!("Failed to acquire lock on server process");
-                        return;
-                    }
-                };
-                if let Some(child) = guard.take() {
-                    log::info!("Terminating gptme-server process...");
-                    match child.kill() {
-                        Ok(_) => {
-                            log::info!("gptme-server process terminated successfully");
+                #[cfg(desktop)]
+                {
+                    let arc = window.state::<ServerProcess>().0.clone();
+                    let mut guard = match arc.lock() {
+                        Ok(g) => g,
+                        Err(_) => {
+                            log::error!("Failed to acquire lock on server process");
+                            return;
                         }
-                        Err(e) => {
-                            log::error!("Failed to terminate gptme-server: {}", e);
+                    };
+                    if let Some(child) = guard.take() {
+                        log::info!("Terminating gptme-server process...");
+                        match child.kill() {
+                            Ok(_) => {
+                                log::info!("gptme-server process terminated successfully");
+                            }
+                            Err(e) => {
+                                log::error!("Failed to terminate gptme-server: {}", e);
+                            }
                         }
+                    } else {
+                        log::warn!("No gptme-server process found to terminate");
                     }
-                } else {
-                    log::warn!("No gptme-server process found to terminate");
                 }
             }
         })
@@ -442,6 +481,7 @@ mod tests {
 
     // ── Port availability ──────────────────────────────────────────
 
+    #[cfg(desktop)]
     #[test]
     fn test_is_port_available_on_unused_port() {
         // Bind to port 0 to get an OS-assigned free port, then release it
@@ -452,6 +492,7 @@ mod tests {
         assert!(is_port_available(port));
     }
 
+    #[cfg(desktop)]
     #[test]
     fn test_is_port_available_on_occupied_port() {
         // Bind a port so it's occupied, then verify is_port_available returns false.
@@ -506,6 +547,7 @@ mod tests {
 
     // ── ServerStatus serialization ─────────────────────────────────
 
+    #[cfg(desktop)]
     #[test]
     fn test_server_status_serialization() {
         let status = ServerStatus {
@@ -521,6 +563,7 @@ mod tests {
 
     // ── ServerProcess state logic ─────────────────────────────────
 
+    #[cfg(desktop)]
     #[test]
     fn test_server_process_initial_state() {
         // With no server process, the guard should be None.
@@ -530,6 +573,7 @@ mod tests {
         assert!(!running);
     }
 
+    #[cfg(desktop)]
     #[test]
     fn test_server_process_state_is_send_sync() {
         // ServerProcess must be Send + Sync for Tauri's managed state.
@@ -537,6 +581,7 @@ mod tests {
         assert_send_sync::<ServerProcess>();
     }
 
+    #[cfg(desktop)]
     #[test]
     fn test_gptme_server_port_constant() {
         assert_eq!(GPTME_SERVER_PORT, 5700);

--- a/tauri/src-tauri/src/lib.rs
+++ b/tauri/src-tauri/src/lib.rs
@@ -1,43 +1,40 @@
-use tauri::Manager;
-use tauri_plugin_deep_link::DeepLinkExt;
-use tauri_plugin_log::{Target, TargetKind};
-
-// Desktop-only: sidecar server management
 #[cfg(desktop)]
 use std::net::TcpListener;
 #[cfg(desktop)]
 use std::sync::{Arc, Mutex};
+
+use tauri::Manager;
+use tauri_plugin_deep_link::DeepLinkExt;
 #[cfg(desktop)]
 use tauri_plugin_dialog::{
     DialogExt, MessageDialogBuilder, MessageDialogButtons, MessageDialogKind,
 };
+use tauri_plugin_log::{Target, TargetKind};
 #[cfg(desktop)]
 use tauri_plugin_shell::process::CommandChild;
 #[cfg(desktop)]
 use tauri_plugin_shell::ShellExt;
 
-#[cfg(desktop)]
 const GPTME_SERVER_PORT: u16 = 5700;
+const LOCAL_SERVER_UNSUPPORTED: &str =
+    "Local gptme-server management is desktop-only. Connect to a remote gptme instance instead.";
 
-/// Check if a port is available
 #[cfg(desktop)]
 fn is_port_available(port: u16) -> bool {
     TcpListener::bind(format!("127.0.0.1:{}", port)).is_ok()
 }
 
-/// Managed state holding the gptme-server child process for cleanup on exit.
 #[cfg(desktop)]
 struct ServerProcess(Arc<Mutex<Option<CommandChild>>>);
 
-#[cfg(desktop)]
 #[derive(serde::Serialize)]
 struct ServerStatus {
     running: bool,
     port: u16,
     port_available: bool,
+    manages_local_server: bool,
 }
 
-/// Get the current status of the local gptme-server.
 #[cfg(desktop)]
 #[tauri::command]
 fn get_server_status(state: tauri::State<'_, ServerProcess>) -> ServerStatus {
@@ -46,10 +43,21 @@ fn get_server_status(state: tauri::State<'_, ServerProcess>) -> ServerStatus {
         running,
         port: GPTME_SERVER_PORT,
         port_available: is_port_available(GPTME_SERVER_PORT),
+        manages_local_server: true,
     }
 }
 
-/// Stop the local gptme-server process.
+#[cfg(not(desktop))]
+#[tauri::command]
+fn get_server_status() -> ServerStatus {
+    ServerStatus {
+        running: false,
+        port: GPTME_SERVER_PORT,
+        port_available: false,
+        manages_local_server: false,
+    }
+}
+
 #[cfg(desktop)]
 #[tauri::command]
 fn stop_server(state: tauri::State<'_, ServerProcess>) -> Result<(), String> {
@@ -64,14 +72,18 @@ fn stop_server(state: tauri::State<'_, ServerProcess>) -> Result<(), String> {
     }
 }
 
-/// Start the local gptme-server process (if not already running).
+#[cfg(not(desktop))]
+#[tauri::command]
+fn stop_server() -> Result<(), String> {
+    Err(LOCAL_SERVER_UNSUPPORTED.to_string())
+}
+
 #[cfg(desktop)]
 #[tauri::command]
 async fn start_server(
     app: tauri::AppHandle,
     state: tauri::State<'_, ServerProcess>,
 ) -> Result<u16, String> {
-    // Check if already running
     {
         let guard = state.0.lock().map_err(|e| format!("Lock error: {}", e))?;
         if guard.is_some() {
@@ -79,19 +91,37 @@ async fn start_server(
         }
     }
 
-    if !is_port_available(GPTME_SERVER_PORT) {
-        return Err(format!("Port {} is already in use", GPTME_SERVER_PORT));
-    }
+    spawn_server_sidecar(&app, state.0.clone())?;
+    Ok(GPTME_SERVER_PORT)
+}
 
-    let cors_origin = if cfg!(debug_assertions) {
+#[cfg(not(desktop))]
+#[tauri::command]
+async fn start_server() -> Result<u16, String> {
+    Err(LOCAL_SERVER_UNSUPPORTED.to_string())
+}
+
+#[cfg(desktop)]
+fn desktop_cors_origin() -> &'static str {
+    if cfg!(debug_assertions) {
         "http://localhost:5701"
     } else if cfg!(target_os = "macos") {
         "tauri://localhost"
     } else {
-        // Linux and Windows use http://tauri.localhost in Tauri v2
         "http://tauri.localhost"
-    };
+    }
+}
 
+#[cfg(desktop)]
+fn spawn_server_sidecar(
+    app: &tauri::AppHandle,
+    state_arc: Arc<Mutex<Option<CommandChild>>>,
+) -> Result<(), String> {
+    if !is_port_available(GPTME_SERVER_PORT) {
+        return Err(format!("Port {} is already in use", GPTME_SERVER_PORT));
+    }
+
+    let cors_origin = desktop_cors_origin();
     log::info!(
         "Starting gptme-server on port {} with CORS origin: {}",
         GPTME_SERVER_PORT,
@@ -113,16 +143,12 @@ async fn start_server(
         child.pid()
     );
 
-    // Store child process
     {
-        let mut guard = state.0.lock().map_err(|e| format!("Lock error: {}", e))?;
+        let mut guard = state_arc.lock().map_err(|e| format!("Lock error: {}", e))?;
         *guard = Some(child);
     }
 
-    // Clone the Arc so the async task can clear state when server terminates
-    let state_arc = state.0.clone();
-
-    // Handle server output in background
+    let state_for_output = state_arc.clone();
     tauri::async_runtime::spawn(async move {
         while let Some(event) = rx.recv().await {
             match event {
@@ -150,8 +176,7 @@ async fn start_server(
                         "[gptme-server] Process terminated with code: {:?}",
                         payload.code
                     );
-                    // Clear state so get_server_status correctly reports not running
-                    if let Ok(mut guard) = state_arc.lock() {
+                    if let Ok(mut guard) = state_for_output.lock() {
                         *guard = None;
                     }
                     break;
@@ -161,20 +186,15 @@ async fn start_server(
         }
     });
 
-    Ok(GPTME_SERVER_PORT)
+    Ok(())
 }
 
-/// Extract and sanitize an auth code from a deep-link URL.
-///
-/// Parses `gptme://pairing-complete?code=<hex>` or `gptme://callback?code=<hex>`
-/// and returns the sanitized (alphanumeric-only) code, or `None`.
 fn extract_auth_code(url: &url::Url) -> Option<String> {
     let code = url
         .query_pairs()
         .find(|(key, _)| key == "code")
         .map(|(_, value)| value.to_string())?;
 
-    // Sanitize: only allow alphanumeric characters (codes should be hex)
     let safe_code: String = code.chars().filter(|c| c.is_ascii_alphanumeric()).collect();
     if safe_code.is_empty() {
         log::warn!("Auth code was empty after sanitization");
@@ -183,10 +203,6 @@ fn extract_auth_code(url: &url::Url) -> Option<String> {
     Some(safe_code)
 }
 
-/// Extract auth code from a gptme:// deep-link URL and inject it into the webview.
-///
-/// Sets the URL hash to `#code=<hex>` and reloads the page, which triggers
-/// the webui's existing auth code exchange flow in ApiContext.
 fn handle_deep_link_urls(app: &tauri::AppHandle, urls: Vec<url::Url>) {
     for url in &urls {
         log::info!("Deep link received: {}", url);
@@ -195,9 +211,6 @@ fn handle_deep_link_urls(app: &tauri::AppHandle, urls: Vec<url::Url>) {
             log::info!("Auth code extracted from deep link, injecting into webview");
 
             if let Some(window) = app.get_webview_window("main") {
-                // Set URL hash with the auth code and reload the page.
-                // The webui's ApiContext checks window.location.hash on mount
-                // and automatically exchanges the code for a token via fleet.gptme.ai.
                 let js = format!(
                     "window.location.hash = '#code={}'; window.location.reload();",
                     safe_code
@@ -210,19 +223,30 @@ fn handle_deep_link_urls(app: &tauri::AppHandle, urls: Vec<url::Url>) {
     }
 }
 
+#[cfg(desktop)]
+fn show_port_conflict_dialog(app: &tauri::AppHandle) {
+    let message = format!(
+        "Cannot start gptme-server because port {} is already in use.\n\n\
+         This usually means another gptme-server instance is already running.\n\n\
+         Please stop the existing gptme-server process and restart this application.",
+        GPTME_SERVER_PORT
+    );
+
+    MessageDialogBuilder::new(app.dialog().clone(), "Port Conflict", message)
+        .kind(MessageDialogKind::Error)
+        .buttons(MessageDialogButtons::Ok)
+        .show(|_result| {});
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     let mut builder = tauri::Builder::default();
 
-    // On desktop (Linux/Windows), deep links spawn a new process instance.
-    // The single-instance plugin with deep-link feature catches these and
-    // forwards the URL to the already-running instance instead.
     #[cfg(desktop)]
     {
         builder = builder.plugin(tauri_plugin_single_instance::init(|app, argv, _cwd| {
             log::info!("Single-instance callback: argv={:?}", argv);
 
-            // On Linux/Windows, deep-link URLs arrive as CLI arguments
             let urls: Vec<url::Url> = argv
                 .iter()
                 .filter_map(|arg| url::Url::parse(arg).ok())
@@ -233,16 +257,13 @@ pub fn run() {
                 handle_deep_link_urls(app, urls);
             }
 
-            // Focus the main window when another instance tries to open
             if let Some(window) = app.get_webview_window("main") {
                 let _ = window.set_focus();
             }
         }));
-
-        builder = builder.plugin(tauri_plugin_shell::init());
     }
 
-    builder
+    builder = builder
         .plugin(
             tauri_plugin_log::Builder::new()
                 .targets([
@@ -256,21 +277,22 @@ pub fn run() {
         )
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())
-        .plugin(tauri_plugin_deep_link::init())
-        .invoke_handler({
-            #[cfg(desktop)]
-            {
-                tauri::generate_handler![get_server_status, start_server, stop_server]
-            }
-            #[cfg(not(desktop))]
-            {
-                tauri::generate_handler![]
-            }
-        })
+        .plugin(tauri_plugin_deep_link::init());
+
+    #[cfg(desktop)]
+    {
+        builder = builder.plugin(tauri_plugin_shell::init());
+    }
+
+    builder
+        .invoke_handler(tauri::generate_handler![
+            get_server_status,
+            start_server,
+            stop_server,
+        ])
         .setup(|app| {
             log::info!("Starting gptme-tauri application");
 
-            // Register deep-link schemes at runtime (needed for dev on Linux/Windows)
             #[cfg(desktop)]
             if cfg!(debug_assertions) {
                 if let Err(e) = app.deep_link().register_all() {
@@ -280,13 +302,11 @@ pub fn run() {
                 }
             }
 
-            // Check if the app was launched via a deep link
             if let Ok(Some(urls)) = app.deep_link().get_current() {
                 log::info!("App launched with deep link URLs: {:?}", urls);
                 handle_deep_link_urls(app.handle(), urls);
             }
 
-            // Listen for deep-link events (macOS sends these to the running app)
             let handle = app.handle().clone();
             app.deep_link().on_open_url(move |event| {
                 let urls = event.urls();
@@ -294,146 +314,17 @@ pub fn run() {
                 handle_deep_link_urls(&handle, urls);
             });
 
-            // Desktop only: spawn the bundled gptme-server sidecar
             #[cfg(desktop)]
             {
-                let app_handle = app.handle().clone();
-
-                // Shared handle to the child process — written by the spawn task,
-                // read by the window-close handler for cleanup.
                 let child_handle: Arc<Mutex<Option<CommandChild>>> = Arc::new(Mutex::new(None));
-                let child_for_spawn = child_handle.clone();
+                app.manage(ServerProcess(child_handle.clone()));
 
-                // Register state so the window-close handler can access it.
-                app.manage(ServerProcess(child_handle));
-
-                // Spawn gptme-server with output capture
+                let app_handle = app.handle().clone();
                 tauri::async_runtime::spawn(async move {
-                    // Check if port is available before starting
-                    if !is_port_available(GPTME_SERVER_PORT) {
-                        log::error!(
-                            "Port {} is already in use. Another gptme-server instance may be running.",
-                            GPTME_SERVER_PORT
-                        );
-
-                        let message = format!(
-                            "Cannot start gptme-server because port {} is already in use.\n\n\
-                            This usually means another gptme-server instance is already running.\n\n\
-                            Please stop the existing gptme-server process and restart this application.",
-                            GPTME_SERVER_PORT
-                        );
-
-                        MessageDialogBuilder::new(
-                            app_handle.dialog().clone(),
-                            "Port Conflict",
-                            message,
-                        )
-                        .kind(MessageDialogKind::Error)
-                        .buttons(MessageDialogButtons::Ok)
-                        .show(|_result| {});
-
-                        return;
-                    }
-
-                    // Determine CORS origin based on build mode and platform.
-                    // Tauri v2 uses different URL schemes per platform:
-                    // - macOS: tauri://localhost (custom Tauri protocol)
-                    // - Linux/Windows: http://tauri.localhost
-                    let cors_origin = if cfg!(debug_assertions) {
-                        "http://localhost:5701" // Dev mode
-                    } else if cfg!(target_os = "macos") {
-                        "tauri://localhost" // macOS production
-                    } else {
-                        "http://tauri.localhost" // Linux/Windows production
-                    };
-
-                    log::info!(
-                        "Port {} is available, starting gptme-server with CORS origin: {}",
-                        GPTME_SERVER_PORT,
-                        cors_origin
-                    );
-
-                    let sidecar_command = match app_handle.shell().sidecar("gptme-server") {
-                        Ok(s) => s.args(["--cors-origin", cors_origin]),
-                        Err(e) => {
-                            log::error!("Failed to find gptme-server sidecar: {}", e);
-                            return;
-                        }
-                    };
-
-                    match sidecar_command.spawn() {
-                        Ok((mut rx, child)) => {
-                            log::info!(
-                                "gptme-server started successfully with PID: {}",
-                                child.pid()
-                            );
-
-                            // Store child process for later cleanup
-                            if let Ok(mut guard) = child_for_spawn.lock() {
-                                *guard = Some(child);
-                            }
-
-                            // Clone the Arc so the async task can clear state when server terminates
-                            let child_for_output = child_for_spawn.clone();
-
-                            // Handle server output
-                            tauri::async_runtime::spawn(async move {
-                                while let Some(event) = rx.recv().await {
-                                    match event {
-                                        tauri_plugin_shell::process::CommandEvent::Stdout(
-                                            data,
-                                        ) => {
-                                            let output = String::from_utf8_lossy(&data);
-                                            for line in output.lines() {
-                                                if !line.trim().is_empty() {
-                                                    log::info!(
-                                                        "[gptme-server] {}",
-                                                        line.trim()
-                                                    );
-                                                }
-                                            }
-                                        }
-                                        tauri_plugin_shell::process::CommandEvent::Stderr(
-                                            data,
-                                        ) => {
-                                            let output = String::from_utf8_lossy(&data);
-                                            for line in output.lines() {
-                                                if !line.trim().is_empty() {
-                                                    log::warn!(
-                                                        "[gptme-server] {}",
-                                                        line.trim()
-                                                    );
-                                                }
-                                            }
-                                        }
-                                        tauri_plugin_shell::process::CommandEvent::Error(
-                                            error,
-                                        ) => {
-                                            log::error!(
-                                                "[gptme-server] Process error: {}",
-                                                error
-                                            );
-                                        }
-                                        tauri_plugin_shell::process::CommandEvent::Terminated(
-                                            payload,
-                                        ) => {
-                                            log::warn!(
-                                                "[gptme-server] Process terminated with code: {:?}",
-                                                payload.code
-                                            );
-                                            // Clear state so get_server_status correctly reports not running
-                                            if let Ok(mut guard) = child_for_output.lock() {
-                                                *guard = None;
-                                            }
-                                            break;
-                                        }
-                                        _ => {}
-                                    }
-                                }
-                            });
-                        }
-                        Err(e) => {
-                            log::error!("Failed to start gptme-server: {}", e);
+                    if let Err(err) = spawn_server_sidecar(&app_handle, child_handle) {
+                        log::error!("Failed to start gptme-server: {}", err);
+                        if err.contains("already in use") {
+                            show_port_conflict_dialog(&app_handle);
                         }
                     }
                 });
@@ -442,34 +333,35 @@ pub fn run() {
             Ok(())
         })
         .on_window_event(|window, event| {
+            #[cfg(desktop)]
             if let tauri::WindowEvent::CloseRequested { .. } = event {
-                log::info!("Window close requested, cleaning up...");
+                log::info!("Window close requested, cleaning up gptme-server...");
 
-                #[cfg(desktop)]
-                {
-                    let arc = window.state::<ServerProcess>().0.clone();
-                    let mut guard = match arc.lock() {
-                        Ok(g) => g,
-                        Err(_) => {
-                            log::error!("Failed to acquire lock on server process");
-                            return;
-                        }
-                    };
-                    if let Some(child) = guard.take() {
-                        log::info!("Terminating gptme-server process...");
-                        match child.kill() {
-                            Ok(_) => {
-                                log::info!("gptme-server process terminated successfully");
-                            }
-                            Err(e) => {
-                                log::error!("Failed to terminate gptme-server: {}", e);
-                            }
-                        }
-                    } else {
-                        log::warn!("No gptme-server process found to terminate");
+                let arc = window.state::<ServerProcess>().0.clone();
+                let mut guard = match arc.lock() {
+                    Ok(g) => g,
+                    Err(_) => {
+                        log::error!("Failed to acquire lock on server process");
+                        return;
                     }
+                };
+                if let Some(child) = guard.take() {
+                    log::info!("Terminating gptme-server process...");
+                    match child.kill() {
+                        Ok(_) => {
+                            log::info!("gptme-server process terminated successfully");
+                        }
+                        Err(e) => {
+                            log::error!("Failed to terminate gptme-server: {}", e);
+                        }
+                    }
+                } else {
+                    log::warn!("No gptme-server process found to terminate");
                 }
             }
+
+            #[cfg(not(desktop))]
+            let _ = (window, event);
         })
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
@@ -479,32 +371,22 @@ pub fn run() {
 mod tests {
     use super::*;
 
-    // ── Port availability ──────────────────────────────────────────
-
-    #[cfg(desktop)]
     #[test]
     fn test_is_port_available_on_unused_port() {
-        // Bind to port 0 to get an OS-assigned free port, then release it
-        // and verify is_port_available returns true for that port.
         let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
         let port = listener.local_addr().unwrap().port();
         drop(listener);
         assert!(is_port_available(port));
     }
 
-    #[cfg(desktop)]
     #[test]
     fn test_is_port_available_on_occupied_port() {
-        // Bind a port so it's occupied, then verify is_port_available returns false.
         let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
         let port = listener.local_addr().unwrap().port();
         assert!(!is_port_available(port));
         drop(listener);
-        // After dropping the listener, the port should be available again.
         assert!(is_port_available(port));
     }
-
-    // ── Deep-link auth code extraction ─────────────────────────────
 
     #[test]
     fn test_extract_auth_code_valid() {
@@ -520,7 +402,6 @@ mod tests {
 
     #[test]
     fn test_extract_auth_code_strips_special_chars() {
-        // XSS attempt: special characters should be stripped
         let url =
             url::Url::parse("gptme://callback?code=abc%3Cscript%3Ealert(1)%3C/script%3E").unwrap();
         let code = extract_auth_code(&url).unwrap();
@@ -545,43 +426,35 @@ mod tests {
         assert_eq!(extract_auth_code(&url), None);
     }
 
-    // ── ServerStatus serialization ─────────────────────────────────
-
-    #[cfg(desktop)]
     #[test]
     fn test_server_status_serialization() {
         let status = ServerStatus {
             running: false,
             port: 5700,
             port_available: true,
+            manages_local_server: true,
         };
         let json = serde_json::to_string(&status).unwrap();
         assert!(json.contains("\"running\":false"));
         assert!(json.contains("\"port\":5700"));
         assert!(json.contains("\"port_available\":true"));
+        assert!(json.contains("\"manages_local_server\":true"));
     }
 
-    // ── ServerProcess state logic ─────────────────────────────────
-
-    #[cfg(desktop)]
     #[test]
     fn test_server_process_initial_state() {
-        // With no server process, the guard should be None.
         let handle: Arc<Mutex<Option<tauri_plugin_shell::process::CommandChild>>> =
             Arc::new(Mutex::new(None));
         let running = handle.lock().map(|guard| guard.is_some()).unwrap_or(false);
         assert!(!running);
     }
 
-    #[cfg(desktop)]
     #[test]
     fn test_server_process_state_is_send_sync() {
-        // ServerProcess must be Send + Sync for Tauri's managed state.
         fn assert_send_sync<T: Send + Sync>() {}
         assert_send_sync::<ServerProcess>();
     }
 
-    #[cfg(desktop)]
     #[test]
     fn test_gptme_server_port_constant() {
         assert_eq!(GPTME_SERVER_PORT, 5700);

--- a/tauri/src-tauri/tauri.android.conf.json
+++ b/tauri/src-tauri/tauri.android.conf.json
@@ -1,0 +1,5 @@
+{
+  "bundle": {
+    "externalBin": []
+  }
+}

--- a/tauri/src-tauri/tauri.conf.json
+++ b/tauri/src-tauri/tauri.conf.json
@@ -18,7 +18,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; connect-src 'self' http://localhost:* ws://localhost:* https://fleet.gptme.ai; img-src 'self' data: blob:; style-src 'self' 'unsafe-inline'; font-src 'self' data:"
+      "csp": "default-src 'self'; connect-src 'self' http://localhost:* ws://localhost:* https: wss:; img-src 'self' data: blob:; style-src 'self' 'unsafe-inline'; font-src 'self' data:"
     }
   },
   "bundle": {

--- a/tauri/src-tauri/tauri.conf.json
+++ b/tauri/src-tauri/tauri.conf.json
@@ -18,7 +18,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; connect-src 'self' http://localhost:* ws://localhost:* https: wss:; img-src 'self' data: blob:; style-src 'self' 'unsafe-inline'; font-src 'self' data:"
+      "csp": "default-src 'self'; connect-src 'self' http: https: ws: wss:; img-src 'self' data: blob:; style-src 'self' 'unsafe-inline'; font-src 'self' data:"
     }
   },
   "bundle": {

--- a/tauri/src-tauri/tauri.ios.conf.json
+++ b/tauri/src-tauri/tauri.ios.conf.json
@@ -1,0 +1,5 @@
+{
+  "bundle": {
+    "externalBin": []
+  }
+}

--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -39,6 +39,7 @@
         "@radix-ui/react-toggle-group": "^1.1.0",
         "@radix-ui/react-tooltip": "^1.1.2",
         "@tanstack/react-query": "^5.56.2",
+        "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-log": "^2.4.0",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",

--- a/webui/package.json
+++ b/webui/package.json
@@ -52,6 +52,7 @@
     "@radix-ui/react-toggle-group": "^1.1.0",
     "@radix-ui/react-tooltip": "^1.1.2",
     "@tanstack/react-query": "^5.56.2",
+    "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-log": "^2.4.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",

--- a/webui/src/components/SetupWizard.tsx
+++ b/webui/src/components/SetupWizard.tsx
@@ -11,11 +11,8 @@ import {
 } from '@/components/ui/dialog';
 import { useSettings } from '@/contexts/SettingsContext';
 import { useApi } from '@/contexts/ApiContext';
-import {
-  isTauriEnvironment,
-  isTauriMobileEnvironment,
-  tauriManagesLocalServer,
-} from '@/utils/tauri';
+import { isTauriEnvironment } from '@/utils/tauri';
+import { useTauriServerStatus } from '@/hooks/useTauriServerStatus';
 import { use$ } from '@legendapp/state/react';
 import { Monitor, Cloud, ArrowRight, Check, Terminal, ExternalLink } from 'lucide-react';
 
@@ -57,8 +54,9 @@ export function SetupWizard() {
   const [cloudLoginStarted, setCloudLoginStarted] = useState(false);
   const lastAutoAdvanceBaseUrlRef = useRef<string | null>(null);
   const isTauri = isTauriEnvironment();
-  const isTauriMobile = isTauriMobileEnvironment();
-  const managesLocalServer = tauriManagesLocalServer();
+  const { isLoading: isLoadingTauriStatus, managesLocalServer } = useTauriServerStatus();
+  const isRemoteOnlyTauri = isTauri && managesLocalServer === false;
+  const isDeterminingTauriMode = isTauri && isLoadingTauriStatus;
   const [remoteBaseUrl, setRemoteBaseUrl] = useState(
     connectionConfig.baseUrl === 'http://127.0.0.1:5700' ? '' : connectionConfig.baseUrl
   );
@@ -215,17 +213,26 @@ export function SetupWizard() {
             <div className="flex flex-col gap-3 py-4">
               <button
                 onClick={() => setStep('local')}
+                disabled={isDeterminingTauriMode}
                 className="flex items-start gap-4 rounded-lg border p-4 text-left transition-colors hover:bg-accent"
               >
                 <Monitor className="mt-0.5 h-6 w-6 shrink-0" />
                 <div>
-                  <div className="font-medium">{isTauriMobile ? 'Remote server' : 'Local'}</div>
+                  <div className="font-medium">
+                    {isDeterminingTauriMode
+                      ? 'Checking environment'
+                      : isRemoteOnlyTauri
+                        ? 'Remote server'
+                        : 'Local'}
+                  </div>
                   <div className="text-sm text-muted-foreground">
-                    {isTauriMobile
-                      ? 'Connect to Bob or another self-hosted gptme instance by URL. No on-device server.'
-                      : managesLocalServer
-                        ? 'Run gptme on your machine. The server starts automatically.'
-                        : 'Run gptme-server on your machine. Bring your own API keys.'}
+                    {isDeterminingTauriMode
+                      ? 'Checking whether this build manages a local gptme server.'
+                      : isRemoteOnlyTauri
+                        ? 'Connect to Bob or another self-hosted gptme instance by URL. No on-device server.'
+                        : managesLocalServer
+                          ? 'Run gptme on your machine. The server starts automatically.'
+                          : 'Run gptme-server on your machine. Bring your own API keys.'}
                   </div>
                 </div>
               </button>
@@ -253,17 +260,23 @@ export function SetupWizard() {
         {step === 'local' && (
           <>
             <DialogHeader>
-              <DialogTitle>{isTauriMobile ? 'Remote server setup' : 'Local setup'}</DialogTitle>
+              <DialogTitle>{isRemoteOnlyTauri ? 'Remote server setup' : 'Local setup'}</DialogTitle>
               <DialogDescription>
-                {isTauriMobile
-                  ? 'Connect this app to Bob, gptme.ai, or another remote gptme server.'
-                  : managesLocalServer
-                    ? 'The gptme server is managed automatically by the desktop app.'
-                    : 'Start the gptme server to get going.'}
+                {isDeterminingTauriMode
+                  ? 'Checking whether this build manages a local gptme server.'
+                  : isRemoteOnlyTauri
+                    ? 'Connect this app to Bob, gptme.ai, or another remote gptme server.'
+                    : managesLocalServer
+                      ? 'The gptme server is managed automatically by the desktop app.'
+                      : 'Start the gptme server to get going.'}
               </DialogDescription>
             </DialogHeader>
             <div className="flex flex-col gap-4 py-4">
-              {isTauriMobile ? (
+              {isDeterminingTauriMode ? (
+                <p className="text-sm text-muted-foreground">
+                  Checking whether this build manages a local gptme server...
+                </p>
+              ) : isRemoteOnlyTauri ? (
                 <div className="flex flex-col gap-3">
                   <p className="text-sm text-muted-foreground">
                     Enter the URL for a remote gptme server. Use Cloud instead if you want the
@@ -334,10 +347,16 @@ export function SetupWizard() {
                 Back
               </Button>
               <Button
-                onClick={isTauriMobile ? handleRemoteSetup : handleLocalSetup}
-                disabled={isConnecting}
+                onClick={isRemoteOnlyTauri ? handleRemoteSetup : handleLocalSetup}
+                disabled={isConnecting || isDeterminingTauriMode}
               >
-                {isConnecting ? 'Connecting...' : isConnected ? 'Continue' : 'Connect'}
+                {isDeterminingTauriMode
+                  ? 'Checking...'
+                  : isConnecting
+                    ? 'Connecting...'
+                    : isConnected
+                      ? 'Continue'
+                      : 'Connect'}
               </Button>
             </DialogFooter>
           </>

--- a/webui/src/components/SetupWizard.tsx
+++ b/webui/src/components/SetupWizard.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
 import {
   Dialog,
   DialogContent,
@@ -10,7 +11,11 @@ import {
 } from '@/components/ui/dialog';
 import { useSettings } from '@/contexts/SettingsContext';
 import { useApi } from '@/contexts/ApiContext';
-import { isTauriEnvironment } from '@/utils/tauri';
+import {
+  isTauriEnvironment,
+  isTauriMobileEnvironment,
+  tauriManagesLocalServer,
+} from '@/utils/tauri';
 import { use$ } from '@legendapp/state/react';
 import { Monitor, Cloud, ArrowRight, Check, Terminal, ExternalLink } from 'lucide-react';
 
@@ -52,6 +57,12 @@ export function SetupWizard() {
   const [cloudLoginStarted, setCloudLoginStarted] = useState(false);
   const lastAutoAdvanceBaseUrlRef = useRef<string | null>(null);
   const isTauri = isTauriEnvironment();
+  const isTauriMobile = isTauriMobileEnvironment();
+  const managesLocalServer = tauriManagesLocalServer();
+  const [remoteBaseUrl, setRemoteBaseUrl] = useState(
+    connectionConfig.baseUrl === 'http://127.0.0.1:5700' ? '' : connectionConfig.baseUrl
+  );
+  const [remoteAuthToken, setRemoteAuthToken] = useState(connectionConfig.authToken || '');
 
   const completeSetup = useCallback(() => {
     updateSettings({ hasCompletedSetup: true });
@@ -121,6 +132,46 @@ export function SetupWizard() {
     setCloudLoginStarted(true);
   };
 
+  const handleRemoteSetup = async () => {
+    const trimmedBaseUrl = remoteBaseUrl.trim();
+    const trimmedAuthToken = remoteAuthToken.trim();
+
+    if (!trimmedBaseUrl) {
+      setConnectError('Enter the URL of the gptme server you want to use.');
+      return;
+    }
+
+    let normalizedBaseUrl: string;
+    try {
+      const parsedUrl = new URL(trimmedBaseUrl);
+      if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
+        throw new Error('Remote server URLs must use http:// or https://');
+      }
+      normalizedBaseUrl = parsedUrl.toString().replace(/\/+$/, '');
+    } catch (error) {
+      setConnectError(error instanceof Error ? error.message : 'Enter a valid server URL.');
+      return;
+    }
+
+    setIsConnecting(true);
+    setConnectError(null);
+    try {
+      await connect({
+        baseUrl: normalizedBaseUrl,
+        authToken: trimmedAuthToken || null,
+        useAuthToken: Boolean(trimmedAuthToken),
+      });
+      completeSetup();
+      setStep('complete');
+    } catch (err) {
+      setConnectError(
+        err instanceof Error ? err.message : 'Could not connect to the remote gptme server.'
+      );
+    } finally {
+      setIsConnecting(false);
+    }
+  };
+
   return (
     <Dialog open={isOpen} onOpenChange={() => {}}>
       <DialogContent
@@ -168,11 +219,13 @@ export function SetupWizard() {
               >
                 <Monitor className="mt-0.5 h-6 w-6 shrink-0" />
                 <div>
-                  <div className="font-medium">Local</div>
+                  <div className="font-medium">{isTauriMobile ? 'Remote server' : 'Local'}</div>
                   <div className="text-sm text-muted-foreground">
-                    {isTauri
-                      ? 'Run gptme on your machine. The server starts automatically.'
-                      : 'Run gptme-server on your machine. Bring your own API keys.'}
+                    {isTauriMobile
+                      ? 'Connect to Bob or another self-hosted gptme instance by URL. No on-device server.'
+                      : managesLocalServer
+                        ? 'Run gptme on your machine. The server starts automatically.'
+                        : 'Run gptme-server on your machine. Bring your own API keys.'}
                   </div>
                 </div>
               </button>
@@ -200,15 +253,40 @@ export function SetupWizard() {
         {step === 'local' && (
           <>
             <DialogHeader>
-              <DialogTitle>Local setup</DialogTitle>
+              <DialogTitle>{isTauriMobile ? 'Remote server setup' : 'Local setup'}</DialogTitle>
               <DialogDescription>
-                {isTauri
-                  ? 'The gptme server is managed automatically by the desktop app.'
-                  : 'Start the gptme server to get going.'}
+                {isTauriMobile
+                  ? 'Connect this app to Bob, gptme.ai, or another remote gptme server.'
+                  : managesLocalServer
+                    ? 'The gptme server is managed automatically by the desktop app.'
+                    : 'Start the gptme server to get going.'}
               </DialogDescription>
             </DialogHeader>
             <div className="flex flex-col gap-4 py-4">
-              {isTauri ? (
+              {isTauriMobile ? (
+                <div className="flex flex-col gap-3">
+                  <p className="text-sm text-muted-foreground">
+                    Enter the URL for a remote gptme server. Use Cloud instead if you want the
+                    managed <code>gptme.ai</code> sign-in flow.
+                  </p>
+                  <Input
+                    autoComplete="url"
+                    placeholder="https://bob.example.com"
+                    value={remoteBaseUrl}
+                    onChange={(event) => setRemoteBaseUrl(event.target.value)}
+                  />
+                  <Input
+                    autoComplete="off"
+                    placeholder="Optional API token"
+                    type="password"
+                    value={remoteAuthToken}
+                    onChange={(event) => setRemoteAuthToken(event.target.value)}
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    For Bob or other self-hosted servers, paste the base URL and token here.
+                  </p>
+                </div>
+              ) : managesLocalServer ? (
                 <div className="flex items-start gap-3 rounded-lg bg-muted p-4">
                   <Check className="mt-0.5 h-5 w-5 shrink-0 text-green-500" />
                   <div className="text-sm">
@@ -255,7 +333,10 @@ export function SetupWizard() {
               >
                 Back
               </Button>
-              <Button onClick={handleLocalSetup} disabled={isConnecting}>
+              <Button
+                onClick={isTauriMobile ? handleRemoteSetup : handleLocalSetup}
+                disabled={isConnecting}
+              >
                 {isConnecting ? 'Connecting...' : isConnected ? 'Continue' : 'Connect'}
               </Button>
             </DialogFooter>

--- a/webui/src/components/__tests__/SetupWizard.test.tsx
+++ b/webui/src/components/__tests__/SetupWizard.test.tsx
@@ -9,7 +9,27 @@ const mockOpen = jest.fn();
 const mockFetch = jest.fn();
 const isConnected$ = observable(false);
 const mockIsTauriEnvironment = jest.fn(() => false);
-const mockIsTauriMobileEnvironment = jest.fn(() => false);
+
+type MockTauriServerStatus = {
+  running: boolean;
+  port: number;
+  port_available: boolean;
+  manages_local_server: boolean;
+};
+
+type MockUseTauriServerStatusResult = {
+  isLoading: boolean;
+  managesLocalServer: boolean | null;
+  serverStatus: MockTauriServerStatus | null;
+};
+
+const mockUseTauriServerStatus = jest.fn(
+  (): MockUseTauriServerStatusResult => ({
+    isLoading: false,
+    managesLocalServer: false,
+    serverStatus: null,
+  })
+);
 
 jest.mock('@/contexts/ApiContext', () => ({
   useApi: () => ({
@@ -25,8 +45,10 @@ jest.mock('@/contexts/ApiContext', () => ({
 
 jest.mock('@/utils/tauri', () => ({
   isTauriEnvironment: () => mockIsTauriEnvironment(),
-  isTauriMobileEnvironment: () => mockIsTauriMobileEnvironment(),
-  tauriManagesLocalServer: () => mockIsTauriEnvironment() && !mockIsTauriMobileEnvironment(),
+}));
+
+jest.mock('@/hooks/useTauriServerStatus', () => ({
+  useTauriServerStatus: () => mockUseTauriServerStatus(),
 }));
 
 jest.mock('@legendapp/state/react', () => ({
@@ -77,7 +99,11 @@ describe('SetupWizard', () => {
       value: mockFetch,
     });
     mockIsTauriEnvironment.mockReturnValue(false);
-    mockIsTauriMobileEnvironment.mockReturnValue(false);
+    mockUseTauriServerStatus.mockReturnValue({
+      isLoading: false,
+      managesLocalServer: false,
+      serverStatus: null,
+    });
     Object.defineProperty(window, 'open', {
       writable: true,
       value: mockOpen,
@@ -208,7 +234,16 @@ describe('SetupWizard', () => {
 
   it('connects to a remote server during tauri mobile setup', async () => {
     mockIsTauriEnvironment.mockReturnValue(true);
-    mockIsTauriMobileEnvironment.mockReturnValue(true);
+    mockUseTauriServerStatus.mockReturnValue({
+      isLoading: false,
+      managesLocalServer: false,
+      serverStatus: {
+        running: false,
+        port: 5700,
+        port_available: false,
+        manages_local_server: false,
+      },
+    });
     mockConnect.mockResolvedValue(undefined);
 
     render(
@@ -234,5 +269,24 @@ describe('SetupWizard', () => {
         useAuthToken: true,
       });
     });
+  });
+
+  it('waits for tauri status before enabling the server mode choice', () => {
+    mockIsTauriEnvironment.mockReturnValue(true);
+    mockUseTauriServerStatus.mockReturnValue({
+      isLoading: true,
+      managesLocalServer: null,
+      serverStatus: null,
+    });
+
+    render(
+      <SettingsProvider>
+        <SetupWizard />
+      </SettingsProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /get started/i }));
+
+    expect(screen.getByRole('button', { name: /monitor checking environment/i })).toBeDisabled();
   });
 });

--- a/webui/src/components/__tests__/SetupWizard.test.tsx
+++ b/webui/src/components/__tests__/SetupWizard.test.tsx
@@ -8,17 +8,25 @@ const mockConnect = jest.fn();
 const mockOpen = jest.fn();
 const mockFetch = jest.fn();
 const isConnected$ = observable(false);
+const mockIsTauriEnvironment = jest.fn(() => false);
+const mockIsTauriMobileEnvironment = jest.fn(() => false);
 
 jest.mock('@/contexts/ApiContext', () => ({
   useApi: () => ({
     isConnected$,
     connect: mockConnect,
-    connectionConfig: { baseUrl: 'http://localhost:5700' },
+    connectionConfig: {
+      baseUrl: 'http://127.0.0.1:5700',
+      authToken: null,
+      useAuthToken: false,
+    },
   }),
 }));
 
 jest.mock('@/utils/tauri', () => ({
-  isTauriEnvironment: () => false,
+  isTauriEnvironment: () => mockIsTauriEnvironment(),
+  isTauriMobileEnvironment: () => mockIsTauriMobileEnvironment(),
+  tauriManagesLocalServer: () => mockIsTauriEnvironment() && !mockIsTauriMobileEnvironment(),
 }));
 
 jest.mock('@legendapp/state/react', () => ({
@@ -39,6 +47,10 @@ jest.mock('@/components/ui/button', () => ({
   Button: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
     <button {...props}>{children}</button>
   ),
+}));
+
+jest.mock('@/components/ui/input', () => ({
+  Input: (props: React.InputHTMLAttributes<HTMLInputElement>) => <input {...props} />,
 }));
 
 jest.mock('lucide-react', () => ({
@@ -64,6 +76,8 @@ describe('SetupWizard', () => {
       writable: true,
       value: mockFetch,
     });
+    mockIsTauriEnvironment.mockReturnValue(false);
+    mockIsTauriMobileEnvironment.mockReturnValue(false);
     Object.defineProperty(window, 'open', {
       writable: true,
       value: mockOpen,
@@ -117,7 +131,7 @@ describe('SetupWizard', () => {
     });
 
     await waitFor(() => {
-      expect(mockFetch).toHaveBeenCalledWith('http://localhost:5700/api/v2');
+      expect(mockFetch).toHaveBeenCalledWith('http://127.0.0.1:5700/api/v2');
     });
 
     await waitFor(() => {
@@ -190,5 +204,35 @@ describe('SetupWizard', () => {
       screen.queryByRole('heading', { name: /configure a provider/i })
     ).not.toBeInTheDocument();
     expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('connects to a remote server during tauri mobile setup', async () => {
+    mockIsTauriEnvironment.mockReturnValue(true);
+    mockIsTauriMobileEnvironment.mockReturnValue(true);
+    mockConnect.mockResolvedValue(undefined);
+
+    render(
+      <SettingsProvider>
+        <SetupWizard />
+      </SettingsProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /get started/i }));
+    fireEvent.click(screen.getByRole('button', { name: /remote server/i }));
+    fireEvent.change(screen.getByPlaceholderText('https://bob.example.com'), {
+      target: { value: 'https://bob.example.com/' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('Optional API token'), {
+      target: { value: 'secret-token' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /connect/i }));
+
+    await waitFor(() => {
+      expect(mockConnect).toHaveBeenCalledWith({
+        baseUrl: 'https://bob.example.com',
+        authToken: 'secret-token',
+        useAuthToken: true,
+      });
+    });
   });
 });

--- a/webui/src/contexts/ApiContext.tsx
+++ b/webui/src/contexts/ApiContext.tsx
@@ -13,6 +13,7 @@ import {
 } from '@/stores/servers';
 import { getClientForServer, getPrimaryClient } from '@/stores/serverClients';
 import type { ServerConfig } from '@/types/servers';
+import { isTauriMobileEnvironment } from '@/utils/tauri';
 import { type Observable, observable } from '@legendapp/state';
 import { use$ } from '@legendapp/state/react';
 import type { QueryClient } from '@tanstack/react-query';
@@ -302,6 +303,7 @@ export function ApiProvider({
   useEffect(() => {
     const currentHash = window.location.hash.substring(1);
     if (hasAuthCodeInHash(currentHash)) return;
+    if (isTauriMobileEnvironment()) return;
 
     void (async () => {
       console.log('[ApiContext] Attempting initial connection');

--- a/webui/src/contexts/ApiContext.tsx
+++ b/webui/src/contexts/ApiContext.tsx
@@ -13,7 +13,8 @@ import {
 } from '@/stores/servers';
 import { getClientForServer, getPrimaryClient } from '@/stores/serverClients';
 import type { ServerConfig } from '@/types/servers';
-import { isTauriMobileEnvironment } from '@/utils/tauri';
+import { useTauriServerStatus } from '@/hooks/useTauriServerStatus';
+import { isTauriEnvironment } from '@/utils/tauri';
 import { type Observable, observable } from '@legendapp/state';
 import { use$ } from '@legendapp/state/react';
 import type { QueryClient } from '@tanstack/react-query';
@@ -93,6 +94,8 @@ export function ApiProvider({
   queryClient: QueryClient;
 }) {
   const [isExchangingAuthCode, setIsExchangingAuthCode] = useState(needsAuthCodeExchange);
+  const isTauri = isTauriEnvironment();
+  const { isLoading: isLoadingTauriStatus, managesLocalServer } = useTauriServerStatus();
 
   // Get client for any server from the shared pool
   const getClient = useCallback((serverId?: string): ApiClient => {
@@ -303,13 +306,14 @@ export function ApiProvider({
   useEffect(() => {
     const currentHash = window.location.hash.substring(1);
     if (hasAuthCodeInHash(currentHash)) return;
-    if (isTauriMobileEnvironment()) return;
+    if (isTauri && isLoadingTauriStatus) return;
+    if (isTauri && managesLocalServer === false) return;
 
     void (async () => {
       console.log('[ApiContext] Attempting initial connection');
       await autoConnect(true);
     })();
-  }, [autoConnect]);
+  }, [autoConnect, isLoadingTauriStatus, isTauri, managesLocalServer]);
 
   // Cleanup on unmount
   useEffect(() => {

--- a/webui/src/contexts/ApiContext.tsx
+++ b/webui/src/contexts/ApiContext.tsx
@@ -61,6 +61,11 @@ let autoConnectTimer: ReturnType<typeof setTimeout> | null = null;
 let autoConnectAttempts = 0;
 const MAX_AUTO_CONNECT_ATTEMPTS = 10;
 const INITIAL_RETRY_DELAY = 1000;
+const DEFAULT_LOCAL_SERVER_URL = 'http://127.0.0.1:5700';
+
+function isInitialMobileLocalTarget(baseUrl: string): boolean {
+  return ['http://127.0.0.1:5700', 'http://localhost:5700'].includes(baseUrl.replace(/\/+$/, ''));
+}
 
 const stopAutoConnect = () => {
   if (autoConnectTimer) {
@@ -302,19 +307,6 @@ export function ApiProvider({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Attempt initial connection (skip if auth code exchange is happening)
-  useEffect(() => {
-    const currentHash = window.location.hash.substring(1);
-    if (hasAuthCodeInHash(currentHash)) return;
-    if (isTauri && isLoadingTauriStatus) return;
-    if (isTauri && managesLocalServer === false) return;
-
-    void (async () => {
-      console.log('[ApiContext] Attempting initial connection');
-      await autoConnect(true);
-    })();
-  }, [autoConnect, isLoadingTauriStatus, isTauri, managesLocalServer]);
-
   // Cleanup on unmount
   useEffect(() => {
     return () => {
@@ -331,10 +323,32 @@ export function ApiProvider({
         authToken: activeServer.authToken,
         useAuthToken: activeServer.useAuthToken,
       }
-    : { baseUrl: 'http://127.0.0.1:5700', authToken: null, useAuthToken: false };
+    : { baseUrl: DEFAULT_LOCAL_SERVER_URL, authToken: null, useAuthToken: false };
+
+  const shouldSkipInitialMobileAutoConnect =
+    isTauri && managesLocalServer === false && isInitialMobileLocalTarget(connectionConfig.baseUrl);
 
   // Primary client from pool (re-resolved each render to pick up changes)
   const api = getPrimaryClient();
+
+  // Attempt initial connection (skip if auth code exchange is happening)
+  useEffect(() => {
+    const currentHash = window.location.hash.substring(1);
+    if (hasAuthCodeInHash(currentHash)) return;
+    if (isTauri && isLoadingTauriStatus) return;
+    if (shouldSkipInitialMobileAutoConnect) return;
+
+    void (async () => {
+      console.log('[ApiContext] Attempting initial connection');
+      await autoConnect(true);
+    })();
+  }, [
+    autoConnect,
+    connectionConfig.baseUrl,
+    isLoadingTauriStatus,
+    isTauri,
+    shouldSkipInitialMobileAutoConnect,
+  ]);
 
   return (
     <ApiContext.Provider

--- a/webui/src/contexts/__tests__/ApiContext.test.tsx
+++ b/webui/src/contexts/__tests__/ApiContext.test.tsx
@@ -1,0 +1,183 @@
+import '@testing-library/jest-dom';
+import { render, waitFor } from '@testing-library/react';
+import { observable } from '@legendapp/state';
+import { QueryClient } from '@tanstack/react-query';
+import { ApiProvider } from '../ApiContext';
+
+const mockCheckConnection = jest.fn();
+const mockSetConnected = jest.fn();
+const mockGetConnectionConfigFromSources = jest.fn();
+const mockProcessConnectionFromHash = jest.fn();
+const mockGetClientForServer = jest.fn();
+const mockGetPrimaryClient = jest.fn();
+const mockGetActiveServer = jest.fn();
+const mockUpdateServer = jest.fn();
+const mockSetActiveServer = jest.fn();
+const mockConnectServer = jest.fn();
+const mockUseTauriServerStatus = jest.fn();
+const mockIsTauriEnvironment = jest.fn();
+const mockToastSuccess = jest.fn();
+const mockToastError = jest.fn();
+
+const isConnected$ = observable(false);
+
+const mockClient = {
+  isConnected$,
+  checkConnection: (...args: unknown[]) => mockCheckConnection(...args),
+  setConnected: (...args: [boolean]) => mockSetConnected(...args),
+};
+
+jest.mock('@/utils/connectionConfig', () => ({
+  getConnectionConfigFromSources: (...args: unknown[]) =>
+    mockGetConnectionConfigFromSources(...args),
+  processConnectionFromHash: (...args: unknown[]) => mockProcessConnectionFromHash(...args),
+}));
+
+jest.mock('@/stores/servers', () => ({
+  serverRegistry$: jest.requireActual('@legendapp/state').observable({
+    activeServerId: 'server-1',
+    connectedServerIds: [],
+    servers: [
+      {
+        id: 'server-1',
+        name: 'Local',
+        baseUrl: 'http://127.0.0.1:5700',
+        authToken: null,
+        useAuthToken: false,
+        createdAt: 0,
+        lastUsedAt: 0,
+      },
+    ],
+  }),
+  getActiveServer: () => mockGetActiveServer(),
+  updateServer: (...args: unknown[]) => mockUpdateServer(...args),
+  setActiveServer: (...args: unknown[]) => mockSetActiveServer(...args),
+  connectServer: (...args: unknown[]) => mockConnectServer(...args),
+}));
+
+jest.mock('@/stores/serverClients', () => ({
+  getClientForServer: (...args: unknown[]) => mockGetClientForServer(...args),
+  getPrimaryClient: () => mockGetPrimaryClient(),
+}));
+
+jest.mock('@/hooks/useTauriServerStatus', () => ({
+  useTauriServerStatus: () => mockUseTauriServerStatus(),
+}));
+
+jest.mock('@/utils/tauri', () => ({
+  isTauriEnvironment: () => mockIsTauriEnvironment(),
+}));
+
+jest.mock('@legendapp/state/react', () => ({
+  use$: (obs: { get: () => unknown }) => obs.get(),
+}));
+
+jest.mock('sonner', () => ({
+  toast: {
+    success: (...args: unknown[]) => mockToastSuccess(...args),
+    error: (...args: unknown[]) => mockToastError(...args),
+  },
+}));
+
+function setActiveServerBaseUrl(baseUrl: string) {
+  const { serverRegistry$ } = jest.requireMock('@/stores/servers') as {
+    serverRegistry$: { set: (value: unknown) => void };
+  };
+
+  serverRegistry$.set({
+    activeServerId: 'server-1',
+    connectedServerIds: [],
+    servers: [
+      {
+        id: 'server-1',
+        name: 'Server',
+        baseUrl,
+        authToken: null,
+        useAuthToken: false,
+        createdAt: 0,
+        lastUsedAt: 0,
+      },
+    ],
+  });
+}
+
+function getActiveServerBaseUrl() {
+  const { serverRegistry$ } = jest.requireMock('@/stores/servers') as {
+    serverRegistry$: { get: () => { servers: Array<{ baseUrl: string }> } };
+  };
+
+  return serverRegistry$.get().servers[0].baseUrl;
+}
+
+function renderProvider() {
+  const queryClient = new QueryClient();
+  return render(
+    <ApiProvider queryClient={queryClient}>
+      <div>child</div>
+    </ApiProvider>
+  );
+}
+
+describe('ApiProvider mobile auto-connect', () => {
+  beforeEach(() => {
+    window.history.replaceState(null, '', '/');
+    jest.clearAllMocks();
+    isConnected$.set(false);
+    setActiveServerBaseUrl('http://127.0.0.1:5700');
+
+    mockSetConnected.mockImplementation((connected: boolean) => {
+      isConnected$.set(connected);
+    });
+    mockCheckConnection.mockResolvedValue(true);
+    mockGetPrimaryClient.mockReturnValue(mockClient);
+    mockGetClientForServer.mockReturnValue(mockClient);
+    mockGetActiveServer.mockImplementation(() => {
+      const { serverRegistry$ } = jest.requireMock('@/stores/servers') as {
+        serverRegistry$: { get: () => { servers: unknown[] } };
+      };
+
+      return serverRegistry$.get().servers[0] ?? null;
+    });
+    mockGetConnectionConfigFromSources.mockImplementation(() => ({
+      baseUrl: getActiveServerBaseUrl(),
+      authToken: null,
+      useAuthToken: false,
+    }));
+    mockProcessConnectionFromHash.mockResolvedValue({
+      baseUrl: getActiveServerBaseUrl(),
+      authToken: null,
+      useAuthToken: false,
+    });
+    mockUseTauriServerStatus.mockReturnValue({
+      isLoading: false,
+      managesLocalServer: false,
+      serverStatus: {
+        running: false,
+        port: 5700,
+        port_available: false,
+        manages_local_server: false,
+      },
+    });
+    mockIsTauriEnvironment.mockReturnValue(true);
+  });
+
+  it('auto-connects when a mobile client already has a remote server configured', async () => {
+    setActiveServerBaseUrl('https://bob.example.com');
+
+    renderProvider();
+
+    await waitFor(() => {
+      expect(mockCheckConnection).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('skips the initial auto-connect when mobile is still pointed at the default local URL', async () => {
+    renderProvider();
+
+    await waitFor(() => {
+      expect(mockGetPrimaryClient).toHaveBeenCalled();
+    });
+
+    expect(mockCheckConnection).not.toHaveBeenCalled();
+  });
+});

--- a/webui/src/hooks/useTauriServerStatus.ts
+++ b/webui/src/hooks/useTauriServerStatus.ts
@@ -1,0 +1,88 @@
+import { invoke } from '@tauri-apps/api/core';
+import { useEffect, useState } from 'react';
+import { isTauriEnvironment } from '@/utils/tauri';
+
+interface TauriServerStatus {
+  running: boolean;
+  port: number;
+  port_available: boolean;
+  manages_local_server: boolean;
+}
+
+let cachedServerStatus: TauriServerStatus | null = null;
+let inflightServerStatus: Promise<TauriServerStatus> | null = null;
+
+async function fetchTauriServerStatus(): Promise<TauriServerStatus> {
+  if (cachedServerStatus) {
+    return cachedServerStatus;
+  }
+
+  if (!inflightServerStatus) {
+    inflightServerStatus = invoke<TauriServerStatus>('get_server_status')
+      .then((status) => {
+        cachedServerStatus = status;
+        return status;
+      })
+      .finally(() => {
+        inflightServerStatus = null;
+      });
+  }
+
+  return inflightServerStatus;
+}
+
+export function useTauriServerStatus() {
+  const isTauri = isTauriEnvironment();
+  const [serverStatus, setServerStatus] = useState<TauriServerStatus | null>(
+    isTauri ? cachedServerStatus : null
+  );
+  const [isLoading, setIsLoading] = useState(isTauri && cachedServerStatus === null);
+
+  useEffect(() => {
+    if (!isTauri) {
+      setServerStatus(null);
+      setIsLoading(false);
+      return;
+    }
+
+    if (cachedServerStatus) {
+      setServerStatus(cachedServerStatus);
+      setIsLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    setIsLoading(true);
+
+    void fetchTauriServerStatus()
+      .then((status) => {
+        if (cancelled) return;
+        setServerStatus(status);
+      })
+      .catch((error) => {
+        if (cancelled) return;
+        console.error('Failed to query Tauri server status:', error);
+        setServerStatus({
+          running: false,
+          port: 5700,
+          port_available: false,
+          manages_local_server: false,
+        });
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isTauri]);
+
+  return {
+    isLoading,
+    managesLocalServer: isTauri ? (serverStatus?.manages_local_server ?? null) : false,
+    serverStatus,
+  };
+}

--- a/webui/src/utils/tauri.ts
+++ b/webui/src/utils/tauri.ts
@@ -3,4 +3,14 @@ export const isTauriEnvironment = () => {
   return typeof window !== 'undefined' && window.__TAURI__ !== undefined;
 };
 
-// Other Tauri-related utilities can be added here in the future
+export const isTauriMobileEnvironment = () => {
+  return (
+    isTauriEnvironment() &&
+    typeof navigator !== 'undefined' &&
+    /Android|iPhone|iPad|iPod/i.test(navigator.userAgent)
+  );
+};
+
+export const tauriManagesLocalServer = () => {
+  return isTauriEnvironment() && !isTauriMobileEnvironment();
+};

--- a/webui/src/utils/tauri.ts
+++ b/webui/src/utils/tauri.ts
@@ -2,15 +2,3 @@
 export const isTauriEnvironment = () => {
   return typeof window !== 'undefined' && window.__TAURI__ !== undefined;
 };
-
-export const isTauriMobileEnvironment = () => {
-  return (
-    isTauriEnvironment() &&
-    typeof navigator !== 'undefined' &&
-    /Android|iPhone|iPad|iPod/i.test(navigator.userAgent)
-  );
-};
-
-export const tauriManagesLocalServer = () => {
-  return isTauriEnvironment() && !isTauriMobileEnvironment();
-};


### PR DESCRIPTION
## Summary

Preparation for Android support (ErikBjare/bob#660). Removes the assumptions that Tauri always means "local server auto-starts" so the app can build and run as a remote-only mobile client.

**What changed:**
- `Cargo.toml`: move `tauri-plugin-shell` to desktop-only `cfg(any(linux,macos,windows))` target
- `lib.rs`: gate `ServerProcess`, `start/stop/get_server_status`, sidecar spawn, and window-close cleanup behind `#[cfg(desktop)]`, with explicit mobile stubs that report local server management is unsupported
- `capabilities/default.json`: keep shared core/opener/log/deep-link permissions cross-platform
- `capabilities/desktop.json`: shell + sidecar permissions restricted to `platforms: [linux, macOS, windows]`
- `capabilities/mobile.json`: mobile-specific capability set without shell access
- `tauri.conf.json`: expand `connect-src` so arbitrary remote gptme servers are allowed
- `tauri.android.conf.json` + `tauri.ios.conf.json`: override `externalBin` so mobile builds do not try to bundle the desktop-only sidecar
- `webui/src/utils/tauri.ts` + `ApiContext.tsx`: stop the Tauri mobile runtime from auto-connecting to localhost
- `webui/src/components/SetupWizard.tsx`: treat Tauri mobile as remote-only, with remote URL + optional token onboarding plus the existing cloud flow
- `SetupWizard` tests: cover the new remote mobile path

**Desktop behavior stays the same.** Mobile builds stop inheriting the sidecar/runtime assumptions, and first-run mobile setup now matches the remote-only architecture instead of pretending localhost exists.

## What this unblocks

After this lands, the next step is running `tauri android init` on a machine with Java + Android SDK to generate the Android project scaffolding. See [the implementation plan](https://github.com/ErikBjare/bob/blob/master/knowledge/technical-designs/gptme-tauri-android-remote-only-plan.md) for the full execution order.

## Verification

- [x] `cargo fmt --manifest-path tauri/src-tauri/Cargo.toml`
- [x] `git diff --check`
- [x] `cd webui && npm run typecheck`
- [x] `cd webui && npm test -- --runInBand src/components/__tests__/SetupWizard.test.tsx`
- [x] `cd webui && npx eslint src/components/SetupWizard.tsx src/components/__tests__/SetupWizard.test.tsx src/contexts/ApiContext.tsx src/utils/tauri.ts`
- [ ] `cargo test --manifest-path tauri/src-tauri/Cargo.toml` on a host with `gdk-3.0` development headers installed
- [ ] `cargo clippy --manifest-path tauri/src-tauri/Cargo.toml -- -D warnings` on a host with `gdk-3.0` development headers installed
- [ ] `tauri android init --ci` on a host with Java + Android SDK
