### PR TITLE
feat(tauri): surface provider_configured in /api/v2 + SetupWizard onboarding step

### DIFF
--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -111,11 +111,14 @@ def api_root():
     if provider is not None:
         capabilities.update(provider.capabilities)
 
+    provider_configured = get_default_model() is not None
+
     return flask.jsonify(
         {
             "message": "gptme v2 API",
             "documentation": "https://gptme.org/docs/server.html",
             "capabilities": capabilities,
+            "provider_configured": provider_configured,
         }
     )
 

--- a/gptme/server/openapi_docs.py
+++ b/gptme/server/openapi_docs.py
@@ -150,6 +150,10 @@ class ApiRootResponse(BaseModel):
     capabilities: ApiCapabilities = Field(
         ..., description="Advertised optional server capabilities"
     )
+    provider_configured: bool = Field(
+        True,
+        description="Whether an LLM provider is configured. False means the server started in degraded mode with no API keys or cloud auth. Clients should surface onboarding UI when false.",
+    )
 
 
 class ExternalSessionListItem(BaseModel):

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -76,6 +76,34 @@ def test_v2_api_root(client: FlaskClient, monkeypatch):
         "external_session_catalog": False,
         "external_session_transcript": False,
     }
+    assert "provider_configured" in data
+
+
+def test_v2_api_root_provider_configured(client: FlaskClient, monkeypatch):
+    """provider_configured reflects whether get_default_model() returns a model."""
+    from gptme.llm.models.types import ModelMeta
+
+    monkeypatch.setattr(
+        "gptme.server.api_v2.get_external_session_provider", lambda: None
+    )
+
+    # No model configured → provider_configured should be False
+    monkeypatch.setattr("gptme.server.api_v2.get_default_model", lambda: None)
+    response = client.get("/api/v2")
+    data = response.get_json()
+    assert data["provider_configured"] is False
+
+    # Model configured → provider_configured should be True
+    fake_model = ModelMeta(
+        model="test-model",
+        provider="anthropic",
+        context=10000,
+        max_output=1000,
+    )
+    monkeypatch.setattr("gptme.server.api_v2.get_default_model", lambda: fake_model)
+    response = client.get("/api/v2")
+    data = response.get_json()
+    assert data["provider_configured"] is True
 
 
 class _FakeExternalSessionItem:

--- a/webui/src/components/SetupWizard.tsx
+++ b/webui/src/components/SetupWizard.tsx
@@ -14,7 +14,7 @@ import { isTauriEnvironment } from '@/utils/tauri';
 import { use$ } from '@legendapp/state/react';
 import { Monitor, Cloud, ArrowRight, Check, Terminal, ExternalLink } from 'lucide-react';
 
-type SetupStep = 'welcome' | 'mode' | 'local' | 'cloud' | 'api-key' | 'complete';
+type SetupStep = 'welcome' | 'mode' | 'local' | 'cloud' | 'provider' | 'complete';
 
 // The gptme cloud service is hosted on fleet.gptme.ai (the cloud.gptme.ai domain
 // is a planned alias). Use a small runtime helper so Jest doesn't choke on import.meta.
@@ -62,7 +62,7 @@ export function SetupWizard() {
       const resp = await fetch(`${connectionConfig.baseUrl}/api/v2`);
       const data = (await resp.json()) as { provider_configured?: boolean };
       if (data.provider_configured === false) {
-        setStep('api-key');
+        setStep('provider');
         return;
       }
     } catch {
@@ -73,7 +73,7 @@ export function SetupWizard() {
   }, [connectionConfig.baseUrl, completeSetup]);
 
   useEffect(() => {
-    if (!isOpen || !isConnected || step === 'complete' || step === 'api-key') return;
+    if (!isOpen || !isConnected || step === 'complete' || step === 'provider') return;
     setCloudLoginStarted(false);
     void checkProviderAndAdvance();
   }, [checkProviderAndAdvance, isConnected, isOpen, step]);
@@ -304,24 +304,38 @@ export function SetupWizard() {
           </>
         )}
 
-        {step === 'api-key' && (
+        {step === 'provider' && (
           <>
             <DialogHeader>
               <DialogTitle>Configure a provider</DialogTitle>
               <DialogDescription>
-                No LLM provider is configured. Set an API key so gptme can process your requests.
+                The server is running, but it does not have an LLM provider yet.
               </DialogDescription>
             </DialogHeader>
             <div className="flex flex-col gap-4 py-4">
               <p className="text-sm text-muted-foreground">
-                Set one of these environment variables before launching gptme-server:
+                Choose one of these paths to finish setup:
               </p>
-              <code className="rounded bg-muted px-3 py-2 font-mono text-sm">
-                ANTHROPIC_API_KEY=sk-ant-...
-              </code>
-              <code className="rounded bg-muted px-3 py-2 font-mono text-sm">
-                OPENAI_API_KEY=sk-...
-              </code>
+              <div className="rounded-lg border bg-muted/40 p-4 text-sm">
+                <p className="font-medium">Use gptme.ai</p>
+                <p className="mt-1 text-muted-foreground">
+                  Sign in with a cloud account for a managed setup with no local API keys.
+                </p>
+              </div>
+              <div className="rounded-lg border bg-muted/40 p-4 text-sm">
+                <p className="font-medium">Bring your own API key</p>
+                <p className="mt-1 text-muted-foreground">
+                  Set one of these environment variables before launching gptme-server:
+                </p>
+                <div className="mt-3 flex flex-col gap-2">
+                  <code className="rounded bg-muted px-3 py-2 font-mono text-sm">
+                    ANTHROPIC_API_KEY=sk-ant-...
+                  </code>
+                  <code className="rounded bg-muted px-3 py-2 font-mono text-sm">
+                    OPENAI_API_KEY=sk-...
+                  </code>
+                </div>
+              </div>
               <p className="text-xs text-muted-foreground">
                 Get a key from{' '}
                 <a
@@ -341,10 +355,16 @@ export function SetupWizard() {
                 >
                   OpenAI Platform
                 </a>
-                . Then restart the server.
+                . Then {isTauri ? 'restart the app' : 'restart the server'} and check again.
               </p>
             </div>
-            <DialogFooter>
+            <DialogFooter className="gap-2 sm:gap-0">
+              <Button variant="outline" onClick={() => setStep('cloud')}>
+                Use gptme.ai instead
+              </Button>
+              <Button variant="outline" onClick={() => void checkProviderAndAdvance()}>
+                I configured a provider
+              </Button>
               <Button variant="ghost" onClick={closeWizard}>
                 Skip for now
               </Button>

--- a/webui/src/components/SetupWizard.tsx
+++ b/webui/src/components/SetupWizard.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import {
   Dialog,
@@ -50,13 +50,14 @@ export function SetupWizard() {
   const [isConnecting, setIsConnecting] = useState(false);
   const [connectError, setConnectError] = useState<string | null>(null);
   const [cloudLoginStarted, setCloudLoginStarted] = useState(false);
+  const lastAutoAdvanceBaseUrlRef = useRef<string | null>(null);
   const isTauri = isTauriEnvironment();
 
   const completeSetup = useCallback(() => {
     updateSettings({ hasCompletedSetup: true });
   }, [updateSettings]);
 
-  // Fetch /api/v2, check provider_configured, then advance to 'api-key' or 'complete'.
+  // Fetch /api/v2, check provider_configured, then advance to 'provider' or 'complete'.
   const checkProviderAndAdvance = useCallback(async () => {
     try {
       const resp = await fetch(`${connectionConfig.baseUrl}/api/v2`);
@@ -73,10 +74,18 @@ export function SetupWizard() {
   }, [connectionConfig.baseUrl, completeSetup]);
 
   useEffect(() => {
-    if (!isOpen || !isConnected || step === 'complete' || step === 'provider') return;
+    if (!isConnected) {
+      lastAutoAdvanceBaseUrlRef.current = null;
+      return;
+    }
+    if (!isOpen || step === 'complete' || step === 'provider') return;
+
+    if (lastAutoAdvanceBaseUrlRef.current === connectionConfig.baseUrl) return;
+    lastAutoAdvanceBaseUrlRef.current = connectionConfig.baseUrl;
+
     setCloudLoginStarted(false);
     void checkProviderAndAdvance();
-  }, [checkProviderAndAdvance, isConnected, isOpen, step]);
+  }, [checkProviderAndAdvance, connectionConfig.baseUrl, isConnected, isOpen, step]);
 
   // Close the dialog. Also calls completeSetup() so that skipping or finishing always persists.
   const closeWizard = () => {

--- a/webui/src/components/SetupWizard.tsx
+++ b/webui/src/components/SetupWizard.tsx
@@ -14,7 +14,7 @@ import { isTauriEnvironment } from '@/utils/tauri';
 import { use$ } from '@legendapp/state/react';
 import { Monitor, Cloud, ArrowRight, Check, Terminal, ExternalLink } from 'lucide-react';
 
-type SetupStep = 'welcome' | 'mode' | 'local' | 'cloud' | 'complete';
+type SetupStep = 'welcome' | 'mode' | 'local' | 'cloud' | 'api-key' | 'complete';
 
 // The gptme cloud service is hosted on fleet.gptme.ai (the cloud.gptme.ai domain
 // is a planned alias). Use a small runtime helper so Jest doesn't choke on import.meta.
@@ -36,7 +36,7 @@ const CLOUD_AUTH_URL = getCloudAuthUrl();
 
 export function SetupWizard() {
   const { settings, updateSettings } = useSettings();
-  const { isConnected$, connect } = useApi();
+  const { isConnected$, connect, connectionConfig } = useApi();
   const isConnected = use$(isConnected$);
   const [step, setStep] = useState<SetupStep>('welcome');
   // isOpen is a one-time snapshot of hasCompletedSetup taken at mount. It is intentionally
@@ -56,12 +56,27 @@ export function SetupWizard() {
     updateSettings({ hasCompletedSetup: true });
   }, [updateSettings]);
 
-  useEffect(() => {
-    if (!isOpen || !isConnected || step === 'complete') return;
+  // Fetch /api/v2, check provider_configured, then advance to 'api-key' or 'complete'.
+  const checkProviderAndAdvance = useCallback(async () => {
+    try {
+      const resp = await fetch(`${connectionConfig.baseUrl}/api/v2`);
+      const data = (await resp.json()) as { provider_configured?: boolean };
+      if (data.provider_configured === false) {
+        setStep('api-key');
+        return;
+      }
+    } catch {
+      // On error, don't block the user — assume provider is configured.
+    }
     completeSetup();
-    setCloudLoginStarted(false);
     setStep('complete');
-  }, [completeSetup, isConnected, isOpen, step]);
+  }, [connectionConfig.baseUrl, completeSetup]);
+
+  useEffect(() => {
+    if (!isOpen || !isConnected || step === 'complete' || step === 'api-key') return;
+    setCloudLoginStarted(false);
+    void checkProviderAndAdvance();
+  }, [checkProviderAndAdvance, isConnected, isOpen, step]);
 
   // Close the dialog. Also calls completeSetup() so that skipping or finishing always persists.
   const closeWizard = () => {
@@ -71,18 +86,15 @@ export function SetupWizard() {
 
   const handleLocalSetup = async () => {
     if (isConnected) {
-      // Persist immediately so a refresh before clicking "Start using gptme" won't re-show wizard.
-      completeSetup();
-      setStep('complete');
+      // Already connected — check provider config and advance.
+      void checkProviderAndAdvance();
       return;
     }
     setIsConnecting(true);
     setConnectError(null);
     try {
       await connect();
-      // Persist immediately — isOpen remains true so the complete step renders.
-      completeSetup();
-      setStep('complete');
+      // The isConnected useEffect will fire and call checkProviderAndAdvance.
     } catch (err) {
       setConnectError(
         err instanceof Error ? err.message : 'Could not connect to server. Is it running?'
@@ -287,6 +299,54 @@ export function SetupWizard() {
               <Button onClick={handleCloudLogin} className="gap-2">
                 Sign in to gptme.ai
                 <ExternalLink className="h-4 w-4" />
+              </Button>
+            </DialogFooter>
+          </>
+        )}
+
+        {step === 'api-key' && (
+          <>
+            <DialogHeader>
+              <DialogTitle>Configure a provider</DialogTitle>
+              <DialogDescription>
+                No LLM provider is configured. Set an API key so gptme can process your requests.
+              </DialogDescription>
+            </DialogHeader>
+            <div className="flex flex-col gap-4 py-4">
+              <p className="text-sm text-muted-foreground">
+                Set one of these environment variables before launching gptme-server:
+              </p>
+              <code className="rounded bg-muted px-3 py-2 font-mono text-sm">
+                ANTHROPIC_API_KEY=sk-ant-...
+              </code>
+              <code className="rounded bg-muted px-3 py-2 font-mono text-sm">
+                OPENAI_API_KEY=sk-...
+              </code>
+              <p className="text-xs text-muted-foreground">
+                Get a key from{' '}
+                <a
+                  href="https://console.anthropic.com"
+                  target="_blank"
+                  rel="noreferrer"
+                  className="underline underline-offset-2"
+                >
+                  Anthropic Console
+                </a>{' '}
+                or{' '}
+                <a
+                  href="https://platform.openai.com"
+                  target="_blank"
+                  rel="noreferrer"
+                  className="underline underline-offset-2"
+                >
+                  OpenAI Platform
+                </a>
+                . Then restart the server.
+              </p>
+            </div>
+            <DialogFooter>
+              <Button variant="ghost" onClick={closeWizard}>
+                Skip for now
               </Button>
             </DialogFooter>
           </>

--- a/webui/src/components/__tests__/SetupWizard.test.tsx
+++ b/webui/src/components/__tests__/SetupWizard.test.tsx
@@ -6,12 +6,14 @@ import { SettingsProvider } from '@/contexts/SettingsContext';
 
 const mockConnect = jest.fn();
 const mockOpen = jest.fn();
+const mockFetch = jest.fn();
 const isConnected$ = observable(false);
 
 jest.mock('@/contexts/ApiContext', () => ({
   useApi: () => ({
     isConnected$,
     connect: mockConnect,
+    connectionConfig: { baseUrl: 'http://localhost:5700' },
   }),
 }));
 
@@ -54,6 +56,14 @@ describe('SetupWizard', () => {
     isConnected$.set(false);
     mockConnect.mockReset();
     mockOpen.mockReset();
+    mockFetch.mockReset();
+    mockFetch.mockResolvedValue({
+      json: async () => ({ provider_configured: true }),
+    });
+    Object.defineProperty(window, 'fetch', {
+      writable: true,
+      value: mockFetch,
+    });
     Object.defineProperty(window, 'open', {
       writable: true,
       value: mockOpen,
@@ -88,7 +98,9 @@ describe('SetupWizard', () => {
   });
 
   it('marks setup complete after local connect succeeds', async () => {
-    mockConnect.mockResolvedValue(undefined);
+    mockConnect.mockImplementation(async () => {
+      isConnected$.set(true);
+    });
 
     render(
       <SettingsProvider>
@@ -104,9 +116,44 @@ describe('SetupWizard', () => {
       expect(mockConnect).toHaveBeenCalled();
     });
 
-    expect(JSON.parse(localStorage.getItem('gptme-settings') || '{}')).toMatchObject({
-      hasCompletedSetup: true,
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith('http://localhost:5700/api/v2');
+    });
+
+    await waitFor(() => {
+      expect(JSON.parse(localStorage.getItem('gptme-settings') || '{}')).toMatchObject({
+        hasCompletedSetup: true,
+      });
     });
     expect(screen.getByRole('heading', { name: /you're all set/i })).toBeInTheDocument();
+  });
+
+  it('shows provider setup guidance when connected server is in degraded mode', async () => {
+    mockFetch.mockResolvedValue({
+      json: async () => ({ provider_configured: false }),
+    });
+    mockConnect.mockImplementation(async () => {
+      isConnected$.set(true);
+    });
+
+    render(
+      <SettingsProvider>
+        <SetupWizard />
+      </SettingsProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /get started/i }));
+    fireEvent.click(screen.getByRole('button', { name: /monitor local/i }));
+    fireEvent.click(screen.getByRole('button', { name: /connect/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: /configure a provider/i })).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole('button', { name: /use gptme.ai instead/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /i configured a provider/i })).toBeInTheDocument();
+    expect(JSON.parse(localStorage.getItem('gptme-settings') || '{}')).not.toMatchObject({
+      hasCompletedSetup: true,
+    });
   });
 });

--- a/webui/src/components/__tests__/SetupWizard.test.tsx
+++ b/webui/src/components/__tests__/SetupWizard.test.tsx
@@ -156,4 +156,39 @@ describe('SetupWizard', () => {
       hasCompletedSetup: true,
     });
   });
+
+  it('keeps the cloud step visible when switching from provider fallback', async () => {
+    mockFetch.mockResolvedValue({
+      json: async () => ({ provider_configured: false }),
+    });
+    mockConnect.mockImplementation(async () => {
+      isConnected$.set(true);
+    });
+
+    render(
+      <SettingsProvider>
+        <SetupWizard />
+      </SettingsProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /get started/i }));
+    fireEvent.click(screen.getByRole('button', { name: /monitor local/i }));
+    fireEvent.click(screen.getByRole('button', { name: /connect/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: /configure a provider/i })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /use gptme.ai instead/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: /cloud setup/i })).toBeInTheDocument();
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(
+      screen.queryByRole('heading', { name: /configure a provider/i })
+    ).not.toBeInTheDocument();
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
## Summary

When `gptme-server` starts in degraded mode (no API keys configured), users currently get no guidance. This PR makes the problem visible and actionable in the desktop app.

- **Server** (`api_v2.py`, `openapi_docs.py`): add `provider_configured: bool` to the `/api/v2` root response — `false` when `get_default_model()` returns `None` (server in degraded mode), `true` otherwise. Defaults to `true` for backward compat.
- **WebUI** (`SetupWizard.tsx`): after establishing a connection, `checkProviderAndAdvance()` fetches `/api/v2` and routes to a new `'provider'` step instead of completing silently when `provider_configured` is `false`. The step shows `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` env var instructions with links to provider consoles.
- **Tests**: assert `provider_configured` field is present; two-state test monkeypatching `get_default_model()` to verify `false`/`true` cases; updated SetupWizard test stubs for `connectionConfig` and `fetch`.

## Test plan

- [ ] Start `gptme-server` with no API keys set → connect in webui → wizard shows "Configure a provider" step
- [ ] Start `gptme-server` with `ANTHROPIC_API_KEY` set → connect in webui → wizard goes directly to "You're all set!" step
- [ ] `curl http://localhost:5700/api/v2 | jq .provider_configured` returns `false`/`true` accordingly
- [ ] `pytest tests/test_server_v2.py::test_v2_api_root tests/test_server_v2.py::test_v2_api_root_provider_configured` passes
- [ ] Existing wizard flow (local/cloud mode, skip) unchanged

Related: #2193 (user-testing tracking), ErikBjare/bob#661 (software factory prototype run #1)