### PR TITLE
fix(hooks): detect Codex mode in workspace_agents

### DIFF
--- a/gptme/hooks/tests/test_workspace_agents.py
+++ b/gptme/hooks/tests/test_workspace_agents.py
@@ -112,6 +112,54 @@ class TestHasFlag:
 
 
 # ---------------------------------------------------------------------------
+#  Runtime parsers
+# ---------------------------------------------------------------------------
+
+
+class TestRuntimeParsers:
+    def test_codex_exec_is_autonomous(self) -> None:
+        from gptme.hooks.workspace_agents import _parse_codex
+
+        info = _parse_codex(
+            100,
+            ["codex", "exec", "--model", "gpt-5", "Fix flaky tests"],
+            "/workspace",
+        )
+        assert info.runtime == "codex"
+        assert info.mode == "autonomous"
+        assert info.model == "gpt-5"
+        assert info.cmdline_summary == "Fix flaky tests"
+
+    def test_codex_wrapped_exec_is_autonomous(self) -> None:
+        from gptme.hooks.workspace_agents import _parse_codex
+
+        info = _parse_codex(
+            100,
+            ["node", "/usr/bin/codex", "exec", "--model", "gpt-5", "Run tests"],
+            "/workspace",
+        )
+        assert info.mode == "autonomous"
+        assert info.cmdline_summary == "Run tests"
+
+    def test_codex_prompt_defaults_to_interactive(self) -> None:
+        from gptme.hooks.workspace_agents import _parse_codex
+
+        info = _parse_codex(
+            100,
+            ["codex", "--model", "gpt-5", "Investigate flaky tests"],
+            "/workspace",
+        )
+        assert info.mode == "interactive"
+        assert info.cmdline_summary == "Investigate flaky tests"
+
+    def test_codex_server_modes(self) -> None:
+        from gptme.hooks.workspace_agents import _parse_codex
+
+        info = _parse_codex(100, ["codex", "mcp-server"], "/workspace")
+        assert info.mode == "server"
+
+
+# ---------------------------------------------------------------------------
 #  Time parsing & formatting
 # ---------------------------------------------------------------------------
 
@@ -320,6 +368,35 @@ class TestScanAgents:
         ):
             agents = scan_agents(workspace="/home/bob/project")
             assert len(agents) == 0
+
+    def test_keeps_codex_interactive_and_autonomous_rows_separate(self) -> None:
+        pids = [99991, 99992]
+
+        cmdlines = {
+            99991: ["codex", "--model", "gpt-5", "Inspect status"],
+            99992: ["codex", "exec", "--model", "gpt-5", "Run tests"],
+        }
+
+        with (
+            patch("gptme.hooks.workspace_agents._get_all_pids", return_value=pids),
+            patch(
+                "gptme.hooks.workspace_agents._get_process_cmdline",
+                side_effect=lambda pid: cmdlines[pid],
+            ),
+            patch(
+                "gptme.hooks.workspace_agents._get_process_cwd",
+                return_value="/home/bob/project",
+            ),
+            patch("gptme.hooks.workspace_agents._get_git_branch", return_value="main"),
+            patch(
+                "gptme.hooks.workspace_agents._get_process_timing",
+                return_value=(120, 5.0, "S"),
+            ),
+            patch("os.path.realpath", side_effect=lambda p: p),
+        ):
+            agents = scan_agents(workspace="/home/bob/project")
+
+        assert [agent.mode for agent in agents] == ["interactive", "autonomous"]
 
 
 # ---------------------------------------------------------------------------

--- a/gptme/hooks/workspace_agents.py
+++ b/gptme/hooks/workspace_agents.py
@@ -371,6 +371,37 @@ def _has_flag(cmdline: list[str], *flags: str) -> bool:
     return any(arg in flags for arg in cmdline)
 
 
+def _positionals_after_flags(cmdline: list[str], *, value_flags: set[str]) -> list[str]:
+    """Return positional args, skipping values consumed by known flags."""
+    positionals: list[str] = []
+    skip_next = False
+
+    for arg in cmdline[1:]:
+        if skip_next:
+            skip_next = False
+            continue
+        if arg == "--":
+            break
+        if arg.startswith("-"):
+            if "=" in arg:
+                continue
+            if arg in value_flags:
+                skip_next = True
+            continue
+        positionals.append(arg)
+
+    return positionals
+
+
+def _runtime_cmdline(cmdline: list[str], *runtime_binaries: str) -> list[str]:
+    """Trim interpreter prefixes so parsers start at the actual runtime binary."""
+    for idx, arg in enumerate(cmdline[:3]):
+        basename = re.sub(r"\.exe$", "", os.path.basename(arg))
+        if basename in runtime_binaries:
+            return cmdline[idx:]
+    return cmdline
+
+
 # ---------------------------------------------------------------------------
 #  Per-runtime metadata parsers
 # ---------------------------------------------------------------------------
@@ -496,14 +527,78 @@ def _parse_gptme(pid: int, cmdline: list[str], cwd: str) -> AgentInfo:
 
 def _parse_codex(pid: int, cmdline: list[str], cwd: str) -> AgentInfo:
     """Extract metadata from a Codex process."""
-    model = _extract_flag(cmdline, "--model", "-m")
+    runtime_cmdline = _runtime_cmdline(cmdline, "codex")
+    model = _extract_flag(runtime_cmdline, "--model", "-m")
+    autonomous_commands = {"exec", "e", "review"}
+    server_commands = {"mcp-server", "app-server"}
+    interactive_commands = {"resume", "fork", "cloud"}
+    known_commands = (
+        autonomous_commands
+        | server_commands
+        | interactive_commands
+        | {
+            "login",
+            "logout",
+            "mcp",
+            "completion",
+            "sandbox",
+            "debug",
+            "apply",
+            "a",
+            "features",
+            "help",
+        }
+    )
+    positionals = _positionals_after_flags(
+        runtime_cmdline,
+        value_flags={
+            "-a",
+            "-c",
+            "-C",
+            "-i",
+            "-m",
+            "-p",
+            "-s",
+            "--add-dir",
+            "--ask-for-approval",
+            "--cd",
+            "--config",
+            "--disable",
+            "--enable",
+            "--image",
+            "--local-provider",
+            "--model",
+            "--profile",
+            "--sandbox",
+        },
+    )
+    subcommand = positionals[0] if positionals else None
+
+    if subcommand in autonomous_commands:
+        mode = "autonomous"
+        summary_parts = positionals[1:]
+    elif subcommand in server_commands:
+        mode = "server"
+        summary_parts = positionals[1:]
+    elif subcommand is None or subcommand not in known_commands:
+        mode = "interactive"
+        summary_parts = positionals
+    elif subcommand in interactive_commands:
+        mode = "interactive"
+        summary_parts = positionals[1:]
+    else:
+        mode = "unknown"
+        summary_parts = positionals[1:]
+
+    summary = " ".join(summary_parts[:6]).strip()
+
     return AgentInfo(
         pid=pid,
         runtime="codex",
         cwd=cwd,
         model=model,
-        mode="unknown",
-        cmdline_summary=" ".join(cmdline[:5]),
+        mode=mode,
+        cmdline_summary=summary or " ".join(runtime_cmdline[:5]),
     )
 
 

--- a/tests/test_workspace_agents.py
+++ b/tests/test_workspace_agents.py
@@ -395,6 +395,47 @@ class TestFormatAgentLine:
 class TestNewRuntimeParsers:
     """Tests for the new runtime metadata parsers."""
 
+    def test_codex_parser_interactive_default(self):
+        from gptme.hooks.workspace_agents import _parse_codex
+
+        info = _parse_codex(
+            100,
+            ["codex", "--model", "gpt-5", "Investigate flaky tests"],
+            "/workspace",
+        )
+        assert info.runtime == "codex"
+        assert info.mode == "interactive"
+        assert info.model == "gpt-5"
+        assert info.cmdline_summary == "Investigate flaky tests"
+
+    def test_codex_parser_exec_is_autonomous(self):
+        from gptme.hooks.workspace_agents import _parse_codex
+
+        info = _parse_codex(
+            100,
+            ["codex", "exec", "--model", "gpt-5", "Fix flaky tests"],
+            "/workspace",
+        )
+        assert info.mode == "autonomous"
+        assert info.cmdline_summary == "Fix flaky tests"
+
+    def test_codex_parser_wrapped_exec_is_autonomous(self):
+        from gptme.hooks.workspace_agents import _parse_codex
+
+        info = _parse_codex(
+            100,
+            ["node", "/usr/bin/codex", "exec", "--model", "gpt-5", "Run tests"],
+            "/workspace",
+        )
+        assert info.mode == "autonomous"
+        assert info.cmdline_summary == "Run tests"
+
+    def test_codex_parser_server_modes(self):
+        from gptme.hooks.workspace_agents import _parse_codex
+
+        info = _parse_codex(100, ["codex", "mcp-server"], "/workspace")
+        assert info.mode == "server"
+
     def test_goose_parser_basic(self):
         from gptme.hooks.workspace_agents import _parse_goose
 


### PR DESCRIPTION
## Summary
- normalize interpreter-wrapped Codex cmdlines before parsing workspace-agent metadata
- classify `codex exec`/`review` as `autonomous`, `mcp-server`/`app-server` as `server`, and prompt-first Codex sessions as `interactive`
- add regression tests for direct and wrapped Codex invocations plus `scan_agents()` mode separation

This came out of the abtop/live-monitor work in `ErikBjare/bob#662`: Bob's local monitor was already reusing `workspace_agents`, but Codex still landed in `mode="unknown"`, which weakened both the shared hook output and Bob's live session view.

## Testing
- `./.venv/bin/pytest gptme/hooks/tests/test_workspace_agents.py tests/test_workspace_agents.py -q`
- `./.venv/bin/python - <<'PY' ... scan_agents(workspace='/home/bob/bob') ... PY` to confirm the live Codex process now reports `mode='autonomous'`
