### PR TITLE
docs: add guardrails framing for autonomous agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ One of the first agent CLIs created (Spring 2023) — and still in very active d
   - [🔌 Extensibility: Plugins, Skills & Lessons](#-extensibility-plugins-skills--lessons)
   - [🔗 Integrations: MCP & ACP](#-integrations-mcp--acp)
   - [🤖 Autonomous Agents](#-autonomous-agents)
+  - [🛡 Guardrails](#-guardrails)
   - [🛠 Use Cases](#-use-cases)
   - [🛠 Developer Perks](#-developer-perks)
   - [🚧 In Progress](#-in-progress)
@@ -349,6 +350,16 @@ gptme-agent status    # check on it
 Multiple specialized agents can run in parallel — e.g. Bob (engineering) and [Alice](https://github.com/TimeToLearnAlice) (personal assistant & orchestration) — coordinating through shared infrastructure.
 
 See the [Autonomous Agents docs](https://gptme.org/docs/agents.html) for the full guide.
+
+### 🛡 Guardrails
+
+Persistent agents need guardrails around the full loop, not just tool permissions:
+
+- **Input guardrails** — structured task selectors in the agent workspace keep work focused and reduce thrashing on notifications or ambiguous work. Bob uses a CASCADE-style selector for this layer.
+- **Pre-action guardrails** — [lessons][docs-lessons] inject situational guidance before the agent acts.
+- **Output guardrails** — [hooks][docs-hooks] and [pre-commit checks](https://gptme.org/docs/usage.html#pre-commit-integration) validate file changes before control returns to the user.
+
+This stack is simple and composable: selectors improve work choice, lessons steer behavior, and checks verify the result. You can add evals on top later, but the baseline guardrail loop already exists.
 
 ### 🛠 Use Cases
 

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -229,6 +229,17 @@ The `gptme-agent-template <https://github.com/gptme/gptme-agent-template>`_ prov
 
 Bob is not a demo — he's a production agent that runs on a schedule, handles real work, and has been iterating on his own architecture for over a year. He serves as a living example of the agent pattern.
 
+🛡 Guardrails
+^^^^^^^^^^^^
+
+Persistent agents need guardrails around the full loop, not just tool permissions:
+
+- **Input guardrails** — structured task selectors in the agent workspace keep work focused and reduce thrashing on notifications or ambiguous work. Bob uses a CASCADE-style selector for this layer.
+- **Pre-action guardrails** — :doc:`lessons` inject situational guidance before the agent acts.
+- **Output guardrails** — :doc:`hooks` and :ref:`pre-commit` checks validate file changes before control returns to the user.
+
+This stack is simple and composable: selectors improve work choice, lessons steer behavior, and checks verify the result. You can add evals on top later, but the baseline guardrail loop already exists.
+
 🌐 Multi-Agent Ecosystem
 ^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
## Summary
- add a Guardrails subsection to the README autonomous-agent story
- mirror the same framing in docs/features.rst so the hosted docs match GitHub
- connect the three layers explicitly: task selection, lessons, and pre-commit/hooks

## Verification
- `poetry run python scripts/check_rst_formatting.py docs/features.rst`
- `poetry run sphinx-build -b dummy docs docs/_build/dummy -W --keep-going` *(hits existing repo-global warnings: missing `flask` for `gptme.server` autodoc and an existing `server.rst` undefined-label warning; no new warnings from `docs/features.rst`)*
- README TOC + Guardrails section presence checked via `python3`
