### PR TITLE
feat(cli): add gptme-util agents scan command

### DIFF
--- a/gptme/cli/cmd_agents.py
+++ b/gptme/cli/cmd_agents.py
@@ -87,9 +87,7 @@ def scan(
             scope = f" in {workspace}" if workspace else " on this host"
             click.echo(f"Live agents{scope}:")
             for a in shown:
-                line = _format_agent_line(a)
-                stale_tag = "  [STALE]" if a.stale else ""
-                click.echo(f"  {line}{stale_tag}")
+                click.echo(f"  {_format_agent_line(a)}")
 
         if not show_all and stale:
             n = len(stale)

--- a/gptme/cli/cmd_agents.py
+++ b/gptme/cli/cmd_agents.py
@@ -1,0 +1,108 @@
+"""CLI commands for live agent scanning.
+
+Provides ``gptme-util agents`` subcommands for inspecting other agent processes
+running on the same host.
+
+Subcommands:
+- ``scan``: List live agent processes (all runtimes, any workspace)
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import asdict
+from pathlib import Path
+
+import click
+
+
+@click.group()
+def agents() -> None:
+    """Inspect live agent processes on this host."""
+
+
+@agents.command("scan")
+@click.option(
+    "--workspace",
+    "-w",
+    default=None,
+    type=click.Path(file_okay=False, path_type=Path),
+    help="Only show agents whose CWD is under this path. "
+    "By default all agents on the host are shown.",
+)
+@click.option(
+    "--all",
+    "show_all",
+    is_flag=True,
+    default=False,
+    help="Include stale/stuck agents (excluded by default).",
+)
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    default=False,
+    help="Output as JSON.",
+)
+def scan(
+    workspace: Path | None,
+    show_all: bool,
+    as_json: bool,
+) -> None:
+    """List live agent processes (gptme, claude-code, codex, aider, …).
+
+    By default shows all active (non-stale) agents on the host.
+    Use --workspace to filter by repo root.
+    Use --all to also include stale/stuck processes.
+
+    Exit code: 0 if at least one active agent found, 1 if none.
+    """
+    from ..hooks.workspace_agents import (
+        _format_agent_line,
+        _format_duration,
+        scan_agents,
+    )
+
+    results = scan_agents(workspace=str(workspace) if workspace else None)
+
+    active = [a for a in results if not a.stale]
+    stale = [a for a in results if a.stale]
+
+    shown = results if show_all else active
+
+    if as_json:
+        output = []
+        for a in shown:
+            d = asdict(a)
+            output.append(d)
+        json.dump(output, sys.stdout, indent=2)
+        print()
+    else:
+        if not shown:
+            label = "agents" if show_all else "active agents"
+            scope = f" in {workspace}" if workspace else ""
+            click.echo(f"No {label} found{scope}.")
+        else:
+            scope = f" in {workspace}" if workspace else " on this host"
+            click.echo(f"Live agents{scope}:")
+            for a in shown:
+                line = _format_agent_line(a)
+                stale_tag = "  [STALE]" if a.stale else ""
+                click.echo(f"  {line}{stale_tag}")
+
+        if not show_all and stale:
+            n = len(stale)
+            ages = ", ".join(
+                _format_duration(a.uptime_seconds)
+                for a in stale
+                if a.uptime_seconds is not None
+            )
+            click.echo(
+                f"  ({n} stale process{'es' if n != 1 else ''} hidden"
+                + (f"; ages: {ages}" if ages else "")
+                + "; use --all to show)",
+                err=False,
+            )
+
+    sys.exit(0 if active else 1)

--- a/gptme/cli/util.py
+++ b/gptme/cli/util.py
@@ -2,6 +2,7 @@
 CLI for gptme utility commands.
 
 Command groups are split into separate modules for maintainability:
+- cmd_agents.py: Live agent scanning (scan for gptme/claude/codex/… processes)
 - cmd_chats.py: Chat/conversation management (list, search, export, clean, stats)
 - cmd_hooks.py: Claude Code hook installation and execution
 - cmd_mcp.py: MCP server management (list, test, info, search)
@@ -34,6 +35,7 @@ from ..llm import PROVIDER_DEFAULT_MODELS as _PROVIDER_DEFAULT_MODELS
 from ..llm.models import get_model_list, list_models, model_to_dict
 from ..message import Message
 from ..util.context import include_paths
+from .cmd_agents import agents
 from .cmd_chats import chats
 from .cmd_hooks import hooks
 from .cmd_mcp import mcp
@@ -50,6 +52,7 @@ def main(verbose: bool = False):
 
 
 # Register command groups from submodules
+main.add_command(agents)
 main.add_command(chats)
 main.add_command(hooks)
 main.add_command(mcp)

--- a/tests/test_util_cli.py
+++ b/tests/test_util_cli.py
@@ -563,6 +563,7 @@ def test_agents_scan_hides_stale_by_default(mocker):
     assert result.exit_code == 0
     assert "100" in result.output
     assert "200" in result.output
+    assert result.output.count("[STALE]") == 1
 
 
 def test_agents_scan_workspace_passes_through(mocker, tmp_path):

--- a/tests/test_util_cli.py
+++ b/tests/test_util_cli.py
@@ -470,3 +470,106 @@ def test_profile_show_shows_empty_tools_as_empty_not_all_tools(monkeypatch):
     assert "no-tools" in result.output
     assert "Tools:" in result.output
     assert "all tools" not in result.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# agents scan tests
+# ---------------------------------------------------------------------------
+
+
+def _make_agent(
+    pid=1234,
+    runtime="claude-code",
+    cwd="/home/user/project",
+    model="opus",
+    mode="autonomous",
+    branch="master",
+    uptime_seconds=300,
+    stale=False,
+    stale_reason=None,
+):
+    from gptme.hooks.workspace_agents import AgentInfo
+
+    return AgentInfo(
+        pid=pid,
+        runtime=runtime,
+        cwd=cwd,
+        model=model,
+        mode=mode,
+        branch=branch,
+        uptime_seconds=uptime_seconds,
+        stale=stale,
+        stale_reason=stale_reason,
+    )
+
+
+def test_agents_scan_empty(mocker):
+    """agents scan returns exit 1 and a clear message when no agents run."""
+    mocker.patch("gptme.hooks.workspace_agents.scan_agents", return_value=[])
+    runner = CliRunner()
+    result = runner.invoke(main, ["agents", "scan"])
+    assert result.exit_code == 1
+    assert "No active agents" in result.output
+
+
+def test_agents_scan_active(mocker):
+    """agents scan shows active agents and exits 0."""
+    agent = _make_agent()
+    mocker.patch("gptme.hooks.workspace_agents.scan_agents", return_value=[agent])
+    runner = CliRunner()
+    result = runner.invoke(main, ["agents", "scan"])
+    assert result.exit_code == 0
+    assert "claude-code" in result.output
+    assert "1234" in result.output  # PID shown
+
+
+def test_agents_scan_json(mocker):
+    """agents scan --json returns valid JSON with expected fields."""
+    import json
+
+    agent = _make_agent()
+    mocker.patch("gptme.hooks.workspace_agents.scan_agents", return_value=[agent])
+    runner = CliRunner()
+    result = runner.invoke(main, ["agents", "scan", "--json"])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert isinstance(data, list)
+    assert len(data) == 1
+    assert data[0]["runtime"] == "claude-code"
+    assert data[0]["pid"] == 1234
+    assert data[0]["mode"] == "autonomous"
+
+
+def test_agents_scan_hides_stale_by_default(mocker):
+    """Stale agents are hidden unless --all is passed."""
+    active = _make_agent(pid=100, stale=False)
+    stale = _make_agent(
+        pid=200, stale=True, stale_reason="too old", uptime_seconds=10000
+    )
+    mocker.patch(
+        "gptme.hooks.workspace_agents.scan_agents", return_value=[active, stale]
+    )
+    runner = CliRunner()
+
+    # Default: stale hidden
+    result = runner.invoke(main, ["agents", "scan"])
+    assert result.exit_code == 0
+    assert "100" in result.output
+    assert "200" not in result.output
+    assert "stale" in result.output  # hint shown
+
+    # --all: both shown
+    result = runner.invoke(main, ["agents", "scan", "--all"])
+    assert result.exit_code == 0
+    assert "100" in result.output
+    assert "200" in result.output
+
+
+def test_agents_scan_workspace_passes_through(mocker, tmp_path):
+    """--workspace argument is forwarded to scan_agents."""
+    mock_scan = mocker.patch(
+        "gptme.hooks.workspace_agents.scan_agents", return_value=[]
+    )
+    runner = CliRunner()
+    runner.invoke(main, ["agents", "scan", "--workspace", str(tmp_path)])
+    mock_scan.assert_called_once_with(workspace=str(tmp_path))


### PR DESCRIPTION
## Summary

- Adds `gptme-util agents scan` — a thin CLI wrapper around the existing `scan_agents()` from `gptme.hooks.workspace_agents`
- Gives users a direct way to list live agent processes from the command line without writing Python
- Follow-up to #2196 (Codex mode detection), upstreaming the `--once` snapshot functionality that currently lives only in agent-specific monitoring scripts

## Usage

```
$ gptme-util agents scan
Live agents on this host:
  PID 2299286: gptme (interactive, branch=master) up 19h
  PID 4140844: claude-code (model=opus, autonomous, branch=master) up 5m
  (1 stale process hidden; use --all to show)

$ gptme-util agents scan --workspace /path/to/project  # filter by workspace
$ gptme-util agents scan --json                         # machine-readable
$ gptme-util agents scan --all                          # include stale/stuck
```

Exit code: 0 if active agents found, 1 if none (scriptable in CI/hooks).

## What changed

- `gptme/cli/cmd_agents.py` — new `agents` click group with `scan` subcommand
- `gptme/cli/util.py` — register `agents` in `gptme-util`
- `tests/test_util_cli.py` — 5 new tests (empty, active, JSON, stale filtering, workspace passthrough)

## Test plan

- [x] `gptme-util agents scan` shows live agents in human-readable format
- [x] `gptme-util agents scan --json` produces valid JSON with all `AgentInfo` fields
- [x] `gptme-util agents scan --workspace PATH` passes workspace filter to `scan_agents()`
- [x] Stale agents hidden by default, shown with `--all`
- [x] Exit code 0 when active agents found, 1 when none
- [x] 157 existing tests still pass (workspace_agents + test_util_cli)