### PR TITLE
docs: update gptme-webui links to merged location

### DIFF
--- a/README.md
+++ b/README.md
@@ -605,7 +605,7 @@ Contributions welcome! See the [contributing guide](https://gptme.org/docs/contr
 [discord]: https://discord.gg/NMaCmmkxWv
 [github]: https://github.com/gptme/gptme
 [gptme.vim]: https://github.com/gptme/gptme.vim
-[gptme-webui]: https://github.com/gptme/gptme-webui
+[gptme-webui]: https://github.com/gptme/gptme/tree/master/webui
 [gptme-rag]: https://github.com/gptme/gptme-rag
 [gptme-contrib]: https://github.com/gptme/gptme-contrib
 [gptme-tauri]: https://github.com/gptme/gptme-tauri

--- a/docs/projects.rst
+++ b/docs/projects.rst
@@ -18,8 +18,8 @@ Official Projects
 * `gptme-rag <https://github.com/gptme/gptme-rag>`_
     RAG (Retrieval-Augmented Generation) implementation for gptme context management.
 
-* `gptme-webui <https://github.com/gptme/gptme-webui>`_
-    Fancy web-based user interface for gptme, built with the help of `Lovable <https://lovable.dev/>`_.
+* `gptme-webui <https://github.com/gptme/gptme/tree/master/webui>`_
+    Modern React-based web interface for gptme, available at `chat.gptme.org <https://chat.gptme.org>`_. Originally a `standalone repo <https://github.com/gptme/gptme-webui>`_, now merged into the main gptme repository.
 
 * `gptme.vim <https://github.com/gptme/gptme.vim>`_
     Vim plugin for gptme integration.

--- a/docs/server.rst
+++ b/docs/server.rst
@@ -26,7 +26,7 @@ For more CLI options, see the :ref:`CLI reference <cli:gptme-server>`.
 gptme-webui: Modern Web Interface
 ---------------------------------
 
-The primary web interface is `gptme-webui <https://github.com/gptme/gptme-webui>`_: a modern, feature-rich application that provides a complete gptme experience in your browser.
+The primary web interface is `gptme-webui <https://github.com/gptme/gptme/tree/master/webui>`_: a modern, feature-rich application that provides a complete gptme experience in your browser. (Originally a `standalone repo <https://github.com/gptme/gptme-webui>`_, now merged into the main gptme repository.)
 
 **Try it now:**
 
@@ -44,7 +44,7 @@ The primary web interface is `gptme-webui <https://github.com/gptme/gptme-webui>
 - Create your own persistent `agents`
 
 **Local Installation:**
-For self-hosting and local development, see the `gptme-webui README <https://github.com/gptme/gptme-webui>`_.
+For self-hosting and local development, see the `gptme-webui README <https://github.com/gptme/gptme/tree/master/webui>`_.
 
 To use the server with a locally hosted gptme-webui, configure the CORS origin when starting the server:
 

--- a/docs/timeline.rst
+++ b/docs/timeline.rst
@@ -18,11 +18,11 @@ The idea is to later make this into a timeline similar to the one for `ActivityW
     - `gptme-agent-template <https://github.com/gptme/gptme-agent-template>`_
     - `gptme-rag <https://github.com/gptme/gptme-rag>`_
     - `gptme.vim <https://github.com/gptme/gptme.vim>`_
-    - `gptme-webui <https://github.com/gptme/gptme-webui>`_
+    - `gptme-webui <https://github.com/gptme/gptme-webui>`_ (archived; merged into main gptme repo)
 
     For repositories with formal releases, we track significant version releases.
-    For repositories without formal releases (like gptme.vim and gptme-webui),
-    we track initial releases and major feature additions based on commit history.
+    For repositories without formal releases (like gptme.vim), we track initial
+    releases and major feature additions based on commit history.
 
     This file can be automatically updated by gptme with the help of `gh release list` and `gh release view` commands.
 

--- a/webui/src/components/SettingsModal.tsx
+++ b/webui/src/components/SettingsModal.tsx
@@ -290,7 +290,7 @@ export const SettingsModal = forwardRef<HTMLButtonElement, SettingsModalProps>(
                       gptme - AI agent framework
                     </a>
                     <a
-                      href="https://github.com/gptme/gptme-webui"
+                      href="https://github.com/gptme/gptme/tree/master/webui"
                       target="_blank"
                       rel="noopener noreferrer"
                       className="flex items-center text-sm text-muted-foreground transition-colors hover:text-foreground"


### PR DESCRIPTION
## Summary

The `gptme/gptme-webui` repo was archived after being merged into the main `gptme/gptme` repo at `webui/`. This PR updates the **active** links across docs, README, and the SettingsModal UI to point to the new location at `gptme/gptme/tree/master/webui`.

## Changes

- **`docs/server.rst`**: "primary web interface" link + "Local Installation" README link now point to merged location, with a parenthetical noting the historical standalone repo
- **`docs/projects.rst`**: "Official Projects" entry updated; description now mentions chat.gptme.org and the merge history
- **`docs/timeline.rst`**: ecosystem-tracking note marks the standalone repo as archived; removed gptme-webui from the "no formal releases" list (it's tracked via gptme commits now)
- **`README.md`**: `[gptme-webui]` link reference (used in the ecosystem table at line 561 and the "modern web interface" mention at line 251) now resolves to the merged location
- **`webui/src/components/SettingsModal.tsx`**: UI external link in the Settings modal updated to merged location

## What was preserved

Historical mentions are kept as-is — they correctly reference the standalone repo at the time it existed:
- README.md line 98: "**2024-11** - Ecosystem expansion: [gptme-webui](https://github.com/gptme/gptme-webui), ..."
- The standalone-repo URL still appears in `docs/timeline.rst` as a historical anchor (with an "archived; merged" annotation added).

## What was skipped

- **`webui/src/democonversations.ts`** (lines 124, 135): demo conversation prose mentioning the old repo URL — text content, not user-facing links
- **`scripts/gh-pr-view-with-pr-comments.sh`** (line 60): a single PR URL example in a shell comment

## Test plan

- [x] `git diff --stat` shows only the 5 expected files
- [x] Pre-commit (typecheck, ruff, RST formatting) passed
- [ ] CI green