### PR TITLE
feat(hooks): track memory_mb for detected agents in workspace_agents

### DIFF
--- a/gptme/hooks/tests/test_workspace_agents.py
+++ b/gptme/hooks/tests/test_workspace_agents.py
@@ -13,7 +13,9 @@ from gptme.hooks.workspace_agents import (
     AGENT_BINARIES,
     AgentInfo,
     _extract_flag,
+    _format_agent_line,
     _format_duration,
+    _get_process_memory_mb,
     _has_flag,
     _init_tracking,
     _parse_etime,
@@ -182,6 +184,48 @@ class TestParseEtime:
 
     def test_invalid(self) -> None:
         assert _parse_etime("abc") is None
+
+
+class TestGetProcessMemoryMb:
+    """Tests for _get_process_memory_mb — resident memory lookup."""
+
+    def test_current_process(self) -> None:
+        # Our own process has a real VmRSS; value should be a positive float.
+        mem = _get_process_memory_mb(os.getpid())
+        assert mem is not None
+        assert mem > 0.0
+
+    def test_missing_pid_returns_none(self) -> None:
+        # PID 2**31 - 1 is effectively guaranteed not to exist.
+        assert _get_process_memory_mb(2**31 - 1) is None
+
+
+class TestFormatAgentLineMemory:
+    """Tests for memory formatting in _format_agent_line."""
+
+    def test_memory_rendered_when_present(self) -> None:
+        agent = AgentInfo(
+            pid=123,
+            runtime="gptme",
+            cwd="/tmp",
+            mode="interactive",
+            uptime_seconds=60,
+            memory_mb=42.0,
+        )
+        line = _format_agent_line(agent)
+        assert "mem=42MB" in line
+
+    def test_memory_omitted_when_missing(self) -> None:
+        agent = AgentInfo(
+            pid=123,
+            runtime="gptme",
+            cwd="/tmp",
+            mode="interactive",
+            uptime_seconds=60,
+            memory_mb=None,
+        )
+        line = _format_agent_line(agent)
+        assert "mem=" not in line
 
 
 class TestFormatDuration:

--- a/gptme/hooks/tests/test_workspace_agents.py
+++ b/gptme/hooks/tests/test_workspace_agents.py
@@ -384,6 +384,10 @@ class TestScanAgents:
                 "gptme.hooks.workspace_agents._get_process_timing",
                 return_value=(120, 5.0, "S"),
             ),
+            patch(
+                "gptme.hooks.workspace_agents._get_process_memory_mb",
+                return_value=None,
+            ),
             patch("os.path.realpath", side_effect=lambda p: p),
         ):
             agents = scan_agents(workspace=workspace)
@@ -435,6 +439,10 @@ class TestScanAgents:
             patch(
                 "gptme.hooks.workspace_agents._get_process_timing",
                 return_value=(120, 5.0, "S"),
+            ),
+            patch(
+                "gptme.hooks.workspace_agents._get_process_memory_mb",
+                return_value=None,
             ),
             patch("os.path.realpath", side_effect=lambda p: p),
         ):

--- a/gptme/hooks/workspace_agents.py
+++ b/gptme/hooks/workspace_agents.py
@@ -111,6 +111,7 @@ class AgentInfo:
     uptime_seconds: int | None = None
     cpu_seconds: float | None = None
     process_state: str | None = None  # S=sleeping, R=running, T=stopped, Z=zombie
+    memory_mb: float | None = None  # resident set size in MB
     stale: bool = False
     stale_reason: str | None = None
     extra: dict[str, Any] = field(default_factory=dict)
@@ -261,6 +262,47 @@ def _get_process_timing(pid: int) -> tuple[int | None, float | None, str | None]
         ):
             return None, None, None
     return None, None, None
+
+
+def _get_process_memory_mb(pid: int) -> float | None:
+    """Get process resident memory in MB, cross-platform.
+
+    Linux reads ``/proc/<pid>/status`` (``VmRSS``); macOS falls back to
+    ``ps -o rss=``. Returns ``None`` if the value can't be determined (e.g.
+    the process exited, or the kernel doesn't expose VmRSS for it).
+    """
+    system = platform.system()
+    if system == "Linux":
+        try:
+            for line in Path(f"/proc/{pid}/status").read_text().splitlines():
+                if line.startswith("VmRSS:"):
+                    parts = line.split()
+                    # Format: "VmRSS:\t  12345 kB"
+                    if len(parts) >= 2:
+                        return int(parts[1]) / 1024.0
+            return None
+        except (OSError, ValueError):
+            return None
+    elif system == "Darwin":
+        try:
+            out = subprocess.check_output(
+                ["ps", "-p", str(pid), "-o", "rss="],
+                stderr=subprocess.DEVNULL,
+                text=True,
+                timeout=10,
+            ).strip()
+            if not out:
+                return None
+            return int(out) / 1024.0
+        except (
+            subprocess.CalledProcessError,
+            subprocess.TimeoutExpired,
+            FileNotFoundError,
+            ValueError,
+        ):
+            return None
+    # TODO: Windows
+    return None
 
 
 def _parse_etime(s: str) -> int | None:
@@ -772,6 +814,7 @@ def scan_agents(workspace: str | None = None) -> list[AgentInfo]:
         info.uptime_seconds = timing_uptime
         info.cpu_seconds = timing_cpu
         info.process_state = timing_state
+        info.memory_mb = _get_process_memory_mb(pid)
 
         assess_staleness(info)
         agents.append(info)
@@ -816,6 +859,9 @@ def _format_agent_line(agent: AgentInfo) -> str:
         parts.append("[STALE]")
     elif agent.uptime_seconds is not None:
         parts.append(f"up {_format_duration(agent.uptime_seconds)}")
+
+    if agent.memory_mb is not None:
+        parts.append(f"mem={agent.memory_mb:.0f}MB")
 
     return " ".join(parts)
 


### PR DESCRIPTION
## Summary

Adds resident-memory tracking to the `workspace_agents` hook so the agent-awareness block can show how much memory each detected agent is using — not just runtime, PID, and uptime.

Continuation of the upstream-from-live-agent-monitor effort (follows #2196 for codex mode detection). Direct response to Erik's reopen of ErikBjare/bob#662: "Reopening until more improvements have been upstreamed."

## What it does

- `AgentInfo` gets a new `memory_mb: float | None` field
- New `_get_process_memory_mb(pid)` helper: reads `/proc/<pid>/status` VmRSS on Linux, falls back to `ps -o rss=` on macOS. Returns `None` when unavailable (process exited, kernel doesn't expose it, etc.)
- `scan_agents()` populates `memory_mb` right before staleness assessment
- `_format_agent_line()` appends `mem=<N>MB` when present, omits the token otherwise

Stays psutil-free per the hook's existing design constraint — uses the same `/proc` + `ps` cross-platform pattern already used elsewhere in the file.

## Example output

Before:
```
- claude-code pid=1932049 mode=claude-code-interactive /home/bob/bob up 1h2m
- gptme pid=3896769 mode=non-interactive /home/bob/bob up 0s
```

After:
```
- claude-code pid=1932049 mode=claude-code-interactive /home/bob/bob up 1h2m mem=353MB
- gptme pid=3896769 mode=non-interactive /home/bob/bob up 0s mem=34MB
```

## Test plan

- [x] Added `TestGetProcessMemoryMb` covering current-pid and bogus-pid cases
- [x] Added `TestFormatAgentLineMemory` for the render path (present + missing)
- [x] `poetry run pytest gptme/hooks/tests/test_workspace_agents.py` — 61/61 pass
- [x] `poetry run pytest gptme/hooks/tests/` — 83/83 pass
- [x] `poetry run mypy gptme/hooks/workspace_agents.py` — clean
- [x] Live smoke: output verified on Bob's VM with real running agents (values above)

## Related

- ErikBjare/bob#662 — Erik's reopen comment requesting more upstreaming from live-agent-monitor
- #2196 — previous upstream slice (codex mode detection)
- `scripts/live-agent-monitor.py` in Bob's workspace — source of the pattern; can drop its local memory tracking once this lands