### PR TITLE
feat(onboarding): add shared default-model selection flow

### DIFF
--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -32,7 +32,9 @@ from gptme.llm.models import (
     _apply_model_filters,
     _get_models_for_provider,
     get_default_model,
+    get_model,
     get_recommended_model,
+    set_default_model,
 )
 from gptme.prompts import get_prompt
 
@@ -68,6 +70,8 @@ from .openapi_docs import (
     StatusResponse,
     UserApiKeySaveRequest,
     UserApiKeySaveResponse,
+    UserDefaultModelSaveRequest,
+    UserDefaultModelSaveResponse,
     api_doc,
     api_doc_simple,
 )
@@ -97,6 +101,50 @@ def _is_valid_image_content(path: "Path") -> bool:
     except Exception:
         logger.warning("Unexpected error validating image %s", path, exc_info=True)
         return False
+
+
+def _validate_model_input(model: str, expected_provider: str | None = None) -> str:
+    """Validate a fully qualified provider/model identifier."""
+    trimmed_model = model.strip()
+    if not trimmed_model:
+        raise ValueError("model must not be empty")
+    if "/" not in trimmed_model:
+        raise ValueError("model must be fully qualified as provider/model")
+
+    provider, model_name = trimmed_model.split("/", 1)
+    if provider not in PROVIDERS:
+        raise ValueError(f"Unknown provider: {provider}")
+    if not model_name.strip():
+        raise ValueError("model must include a model name after the provider prefix")
+    if expected_provider and provider != expected_provider:
+        raise ValueError(
+            f"Model {trimmed_model} does not match provider {expected_provider}"
+        )
+    return trimmed_model
+
+
+def _persist_default_model(model: str) -> bool:
+    """Persist env.MODEL and try to apply it in-process.
+
+    Returns True if a restart is still required to guarantee the change takes effect.
+    """
+    set_config_value("env.MODEL", model, reload=False)
+
+    model_meta = get_model(model)
+    try:
+        from gptme.llm import init_llm
+
+        init_llm(cast(Provider, model_meta.provider))
+        set_default_model(model_meta)
+        flask.current_app.config["SERVER_DEFAULT_MODEL"] = model_meta
+        return False
+    except Exception:
+        logger.warning(
+            "Persisted default model %s but could not apply it in-process; restart required",
+            model,
+            exc_info=True,
+        )
+        return True
 
 
 def _validate_api_key_input(api_key: str) -> str:
@@ -1328,20 +1376,30 @@ def api_user_api_key():
 
     provider = req_json.get("provider")
     api_key = req_json.get("api_key")
+    model = req_json.get("model")
     if not isinstance(provider, str):
         return flask.jsonify({"error": "provider must be a string"}), 400
     if not isinstance(api_key, str):
         return flask.jsonify({"error": "api_key must be a string"}), 400
+    if model is not None and not isinstance(model, str):
+        return flask.jsonify({"error": "model must be a string"}), 400
     if provider not in PROVIDER_API_KEYS:
         return flask.jsonify({"error": f"Unknown provider: {provider}"}), 400
 
     try:
         trimmed_api_key = _validate_api_key_input(api_key)
+        trimmed_model = (
+            _validate_model_input(model, expected_provider=provider)
+            if model is not None
+            else None
+        )
     except ValueError as exc:
         return flask.jsonify({"error": str(exc)}), 400
 
     env_var = PROVIDER_API_KEYS[provider]
     set_config_value(f"env.{env_var}", trimmed_api_key, reload=False)
+    if trimmed_model is not None:
+        set_config_value("env.MODEL", trimmed_model, reload=False)
     logger.info("Saved %s to user config via /api/v2/user/api-key", env_var)
     return flask.jsonify(
         {
@@ -1349,6 +1407,44 @@ def api_user_api_key():
             "provider": provider,
             "env_var": env_var,
             "restart_required": True,
+        }
+    )
+
+
+@v2_api.route("/api/v2/user/default-model", methods=["POST"])
+@require_auth
+@api_doc(
+    summary="Save default model",
+    description=(
+        "Persist the default model into the user's global gptme config and apply "
+        "it to the running server when possible."
+    ),
+    request_body=UserDefaultModelSaveRequest,
+    responses={200: UserDefaultModelSaveResponse, 400: ErrorResponse},
+    tags=["user"],
+)
+def api_user_default_model():
+    """Persist the default model into user config."""
+    req_json = flask.request.json
+    if not req_json:
+        return flask.jsonify({"error": "No JSON data provided"}), 400
+
+    model = req_json.get("model")
+    if not isinstance(model, str):
+        return flask.jsonify({"error": "model must be a string"}), 400
+
+    try:
+        trimmed_model = _validate_model_input(model)
+    except ValueError as exc:
+        return flask.jsonify({"error": str(exc)}), 400
+
+    restart_required = _persist_default_model(trimmed_model)
+    logger.info("Saved MODEL=%s via /api/v2/user/default-model", trimmed_model)
+    return flask.jsonify(
+        {
+            "status": "ok",
+            "model": trimmed_model,
+            "restart_required": restart_required,
         }
     )
 

--- a/gptme/server/openapi_docs.py
+++ b/gptme/server/openapi_docs.py
@@ -161,6 +161,10 @@ class UserApiKeySaveRequest(BaseModel):
 
     provider: str = Field(..., description="Provider slug, e.g. anthropic or openai")
     api_key: str = Field(..., description="Provider API key to persist in [env]")
+    model: str | None = Field(
+        None,
+        description="Optional fully qualified default model to persist in [env.MODEL]",
+    )
 
 
 class UserApiKeySaveResponse(BaseModel):
@@ -172,6 +176,26 @@ class UserApiKeySaveResponse(BaseModel):
     restart_required: bool = Field(
         True,
         description="Whether the running server must be restarted before the new key is guaranteed to take effect",
+    )
+
+
+class UserDefaultModelSaveRequest(BaseModel):
+    """Request to save a default model into user config."""
+
+    model: str = Field(
+        ...,
+        description="Fully qualified default model to persist in [env.MODEL]",
+    )
+
+
+class UserDefaultModelSaveResponse(BaseModel):
+    """Response after persisting a default model."""
+
+    status: str = Field(..., description="Operation status")
+    model: str = Field(..., description="Fully qualified default model that was saved")
+    restart_required: bool = Field(
+        False,
+        description="Whether the running server must be restarted before the new model is guaranteed to take effect",
     )
 
 

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -133,6 +133,46 @@ def test_v2_user_api_key_persists_env_entry(client: FlaskClient, tmp_path, monke
     assert saved["env"]["ANTHROPIC_API_KEY"] == "sk-ant-test-key"
 
 
+def test_v2_user_api_key_persists_default_model(
+    client: FlaskClient, tmp_path, monkeypatch
+):
+    """Saving an API key may also persist the selected default model."""
+    import gptme.config.user as user_mod
+
+    config_file = tmp_path / "config.toml"
+    monkeypatch.setattr(user_mod, "config_path", str(config_file))
+    monkeypatch.setattr("gptme.config.core.reload_config", lambda: None)
+
+    response = client.post(
+        "/api/v2/user/api-key",
+        json={
+            "provider": "anthropic",
+            "api_key": "sk-ant-test-key",
+            "model": "anthropic/claude-sonnet-4-7",
+        },
+    )
+
+    assert response.status_code == 200
+    saved = tomlkit.loads(config_file.read_text()).unwrap()
+    assert saved["env"]["ANTHROPIC_API_KEY"] == "sk-ant-test-key"
+    assert saved["env"]["MODEL"] == "anthropic/claude-sonnet-4-7"
+
+
+def test_v2_user_api_key_rejects_model_provider_mismatch(client: FlaskClient):
+    response = client.post(
+        "/api/v2/user/api-key",
+        json={
+            "provider": "anthropic",
+            "api_key": "sk-ant-test-key",
+            "model": "openai/gpt-4.1",
+        },
+    )
+
+    assert response.status_code == 400
+    data = response.get_json()
+    assert data == {"error": "Model openai/gpt-4.1 does not match provider anthropic"}
+
+
 def test_v2_user_api_key_rejects_unknown_provider(client: FlaskClient):
     response = client.post(
         "/api/v2/user/api-key",
@@ -142,6 +182,51 @@ def test_v2_user_api_key_rejects_unknown_provider(client: FlaskClient):
     assert response.status_code == 400
     data = response.get_json()
     assert data == {"error": "Unknown provider: bogus"}
+
+
+def test_v2_user_default_model_persists_and_applies(
+    client: FlaskClient, tmp_path, monkeypatch
+):
+    """Saving a default model should write env.MODEL and update runtime state."""
+    import gptme.config.user as user_mod
+
+    config_file = tmp_path / "config.toml"
+    applied: dict[str, ModelMeta] = {}
+    monkeypatch.setattr(user_mod, "config_path", str(config_file))
+    monkeypatch.setattr("gptme.config.core.reload_config", lambda: None)
+    monkeypatch.setattr("gptme.llm.init_llm", lambda provider: None)
+    monkeypatch.setattr(
+        "gptme.server.api_v2.set_default_model",
+        lambda model: applied.setdefault("model", model),
+    )
+
+    response = client.post(
+        "/api/v2/user/default-model",
+        json={"model": "anthropic/claude-sonnet-4-7"},
+    )
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data == {
+        "status": "ok",
+        "model": "anthropic/claude-sonnet-4-7",
+        "restart_required": False,
+    }
+
+    saved = tomlkit.loads(config_file.read_text()).unwrap()
+    assert saved["env"]["MODEL"] == "anthropic/claude-sonnet-4-7"
+    assert applied["model"].full == "anthropic/claude-sonnet-4-7"
+
+
+def test_v2_user_default_model_rejects_unqualified_model(client: FlaskClient):
+    response = client.post(
+        "/api/v2/user/default-model",
+        json={"model": "anthropic"},
+    )
+
+    assert response.status_code == 400
+    data = response.get_json()
+    assert data == {"error": "model must be fully qualified as provider/model"}
 
 
 class _FakeExternalSessionItem:

--- a/webui/src/components/ModelPicker.tsx
+++ b/webui/src/components/ModelPicker.tsx
@@ -163,6 +163,56 @@ export const ModelPicker: FC<{
   onSelect: (modelId: string) => void;
 }> = ({ value, onSelect }) => <ModelCommandList value={value} onSelect={onSelect} />;
 
+/** Model picker as a popover button without form bindings. */
+export function ModelPickerButton({
+  value,
+  onSelect,
+  disabled = false,
+  placeholder = 'Select model',
+}: {
+  value?: string;
+  onSelect: (modelId: string) => void;
+  disabled?: boolean;
+  placeholder?: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const { models } = useModels();
+  const modelInfo = models.find((m) => m.id === value);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          disabled={disabled}
+          className="w-full justify-between font-normal"
+        >
+          {value ? (
+            <span className="flex items-center gap-2 truncate">
+              {modelInfo?.provider && <ProviderIcon provider={modelInfo.provider} />}
+              {modelInfo?.model || value}
+            </span>
+          ) : (
+            <span className="text-muted-foreground">{placeholder}</span>
+          )}
+          <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-[--radix-popover-trigger-width] p-0" align="start">
+        <ModelCommandList
+          value={value}
+          onSelect={(id) => {
+            onSelect(id);
+            setOpen(false);
+          }}
+        />
+      </PopoverContent>
+    </Popover>
+  );
+}
+
 /** Model picker as a form field with popover trigger (for use in settings forms) */
 export function ModelPickerField<T extends FieldValues = FieldValues>({
   control,

--- a/webui/src/components/SetupWizard.tsx
+++ b/webui/src/components/SetupWizard.tsx
@@ -19,6 +19,15 @@ import { Monitor, Cloud, ArrowRight, Check, Terminal, ExternalLink } from 'lucid
 
 type SetupStep = 'welcome' | 'mode' | 'local' | 'cloud' | 'provider' | 'complete';
 type SetupProvider = 'anthropic' | 'openai' | 'openrouter' | 'gemini' | 'groq' | 'xai' | 'deepseek';
+type SetupModelInfo = {
+  id: string;
+  provider: string;
+  model: string;
+};
+type SetupModelsResponse = {
+  models: SetupModelInfo[];
+  recommended: string[];
+};
 
 // The gptme cloud service is hosted on fleet.gptme.ai (the cloud.gptme.ai domain
 // is a planned alias). Use a small runtime helper so Jest doesn't choke on import.meta.
@@ -64,9 +73,16 @@ function sleep(ms: number): Promise<void> {
   });
 }
 
+function withAuthHeaders(
+  authHeader: string | null,
+  headers: Record<string, string> = {}
+): Record<string, string> {
+  return authHeader ? { ...headers, Authorization: authHeader } : headers;
+}
+
 export function SetupWizard() {
   const { settings, updateSettings } = useSettings();
-  const { isConnected$, connect, connectionConfig } = useApi();
+  const { api, isConnected$, connect, connectionConfig } = useApi();
   const isConnected = use$(isConnected$);
   const [step, setStep] = useState<SetupStep>('welcome');
   // isOpen is a one-time snapshot of hasCompletedSetup taken at mount. It is intentionally
@@ -92,32 +108,40 @@ export function SetupWizard() {
   const [remoteAuthToken, setRemoteAuthToken] = useState(connectionConfig.authToken || '');
   const [apiKeyProvider, setApiKeyProvider] = useState<SetupProvider>('anthropic');
   const [apiKey, setApiKey] = useState('');
+  const [apiKeyModel, setApiKeyModel] = useState('');
   const [apiKeySaving, setApiKeySaving] = useState(false);
   const [apiKeyError, setApiKeyError] = useState<string | null>(null);
+  const [availableModels, setAvailableModels] = useState<SetupModelInfo[]>([]);
+  const [recommendedModels, setRecommendedModels] = useState<string[]>([]);
+  const [modelsLoading, setModelsLoading] = useState(false);
+  const [modelsError, setModelsError] = useState<string | null>(null);
 
   const completeSetup = useCallback(() => {
     updateSettings({ hasCompletedSetup: true });
   }, [updateSettings]);
 
   const fetchProviderConfigured = useCallback(async () => {
-    const resp = await fetch(`${connectionConfig.baseUrl}/api/v2`);
+    const resp = await fetch(`${connectionConfig.baseUrl}/api/v2`, {
+      headers: withAuthHeaders(api.authHeader),
+    });
     if (!resp.ok) {
       throw new Error(`Failed to verify provider status (${resp.status})`);
     }
     const data = (await resp.json()) as { provider_configured?: boolean };
     return data.provider_configured !== false;
-  }, [connectionConfig.baseUrl]);
+  }, [api.authHeader, connectionConfig.baseUrl]);
 
   const saveApiKeyToServer = useCallback(
-    async (provider: SetupProvider, apiKeyValue: string) => {
+    async (provider: SetupProvider, apiKeyValue: string, model?: string) => {
       const resp = await fetch(`${connectionConfig.baseUrl}/api/v2/user/api-key`, {
         method: 'POST',
-        headers: {
+        headers: withAuthHeaders(api.authHeader, {
           'Content-Type': 'application/json',
-        },
+        }),
         body: JSON.stringify({
           provider,
           api_key: apiKeyValue,
+          ...(model ? { model } : {}),
         }),
       });
 
@@ -136,8 +160,56 @@ export function SetupWizard() {
       }
       throw new Error(message);
     },
-    [connectionConfig.baseUrl]
+    [api.authHeader, connectionConfig.baseUrl]
   );
+
+  const fetchAvailableModels = useCallback(async () => {
+    setModelsLoading(true);
+    setModelsError(null);
+    try {
+      const resp = await fetch(`${connectionConfig.baseUrl}/api/v2/models`, {
+        headers: withAuthHeaders(api.authHeader),
+      });
+      if (!resp.ok) {
+        throw new Error(`Failed to load models (${resp.status})`);
+      }
+
+      const data = (await resp.json()) as SetupModelsResponse;
+      setAvailableModels(data.models || []);
+      setRecommendedModels(data.recommended || []);
+    } catch (error) {
+      setAvailableModels([]);
+      setRecommendedModels([]);
+      setModelsError(error instanceof Error ? error.message : 'Failed to load available models.');
+    } finally {
+      setModelsLoading(false);
+    }
+  }, [api.authHeader, connectionConfig.baseUrl]);
+
+  const providerModels = availableModels.filter((model) => model.provider === apiKeyProvider);
+
+  useEffect(() => {
+    if (step !== 'provider' || !canManageApiKeyInApp) {
+      return;
+    }
+    void fetchAvailableModels();
+  }, [canManageApiKeyInApp, fetchAvailableModels, step]);
+
+  useEffect(() => {
+    if (step !== 'provider' || !canManageApiKeyInApp) {
+      return;
+    }
+    if (providerModels.length === 0) {
+      setApiKeyModel('');
+      return;
+    }
+    if (providerModels.some((model) => model.id === apiKeyModel)) {
+      return;
+    }
+    const preferredModel =
+      providerModels.find((model) => recommendedModels.includes(model.id)) || providerModels[0];
+    setApiKeyModel(preferredModel.id);
+  }, [apiKeyModel, canManageApiKeyInApp, providerModels, recommendedModels, step]);
 
   // Fetch /api/v2, check provider_configured, then advance to 'provider' or 'complete'.
   const checkProviderAndAdvance = useCallback(
@@ -253,10 +325,14 @@ export function SetupWizard() {
       setApiKeyError('Enter an API key before saving.');
       return;
     }
+    if (!modelsLoading && providerModels.length > 0 && !apiKeyModel) {
+      setApiKeyError('Choose a default model before saving.');
+      return;
+    }
     setApiKeySaving(true);
     setApiKeyError(null);
     try {
-      await saveApiKeyToServer(apiKeyProvider, trimmed);
+      await saveApiKeyToServer(apiKeyProvider, trimmed, apiKeyModel || undefined);
       try {
         await invokeTauri('stop_server');
       } catch {
@@ -617,6 +693,37 @@ export function SetupWizard() {
                           </option>
                         ))}
                       </select>
+                    </div>
+                    <div className="flex flex-col gap-2">
+                      <Label htmlFor="setup-api-key-model">Default model</Label>
+                      <select
+                        id="setup-api-key-model"
+                        className="h-9 rounded-md border bg-background px-3 text-sm"
+                        value={apiKeyModel}
+                        onChange={(e) => setApiKeyModel(e.target.value)}
+                        disabled={apiKeySaving || modelsLoading || providerModels.length === 0}
+                      >
+                        {providerModels.length === 0 ? (
+                          <option value="">
+                            {modelsLoading ? 'Loading models…' : 'No models available'}
+                          </option>
+                        ) : (
+                          providerModels.map((model) => (
+                            <option key={model.id} value={model.id}>
+                              {model.model}
+                            </option>
+                          ))
+                        )}
+                      </select>
+                      <p className="text-xs text-muted-foreground">
+                        Pick the model gptme should use after restart.
+                      </p>
+                      {modelsError && (
+                        <p className="text-xs text-destructive">
+                          {modelsError} If this keeps failing, save without a model and gptme will
+                          fall back to the provider default.
+                        </p>
+                      )}
                     </div>
                     <div className="flex flex-col gap-2">
                       <Label htmlFor="setup-api-key-input">API key</Label>

--- a/webui/src/components/__tests__/SetupWizard.test.tsx
+++ b/webui/src/components/__tests__/SetupWizard.test.tsx
@@ -34,6 +34,10 @@ const mockUseTauriServerStatus = jest.fn(
 
 jest.mock('@/contexts/ApiContext', () => ({
   useApi: () => ({
+    api: {
+      baseUrl: 'http://127.0.0.1:5700',
+      authHeader: null,
+    },
     isConnected$,
     connect: mockConnect,
     connectionConfig: {
@@ -171,7 +175,9 @@ describe('SetupWizard', () => {
     });
 
     await waitFor(() => {
-      expect(mockFetch).toHaveBeenCalledWith('http://127.0.0.1:5700/api/v2');
+      expect(mockFetch).toHaveBeenCalledWith('http://127.0.0.1:5700/api/v2', {
+        headers: {},
+      });
     });
 
     await waitFor(() => {
@@ -343,6 +349,20 @@ describe('SetupWizard', () => {
       .mockResolvedValueOnce({
         ok: true,
         status: 200,
+        json: async () => ({
+          models: [
+            {
+              id: 'anthropic/claude-sonnet-4-7',
+              provider: 'anthropic',
+              model: 'claude-sonnet-4-7',
+            },
+          ],
+          recommended: ['anthropic/claude-sonnet-4-7'],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
         json: async () => ({ status: 'ok', env_var: 'ANTHROPIC_API_KEY' }),
       })
       .mockRejectedValueOnce(new Error('connection refused'))
@@ -387,6 +407,7 @@ describe('SetupWizard', () => {
         body: JSON.stringify({
           provider: 'anthropic',
           api_key: 'sk-ant-test-key',
+          model: 'anthropic/claude-sonnet-4-7',
         }),
       });
     });
@@ -415,6 +436,20 @@ describe('SetupWizard', () => {
         ok: true,
         status: 200,
         json: async () => ({ provider_configured: false }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          models: [
+            {
+              id: 'anthropic/claude-sonnet-4-7',
+              provider: 'anthropic',
+              model: 'claude-sonnet-4-7',
+            },
+          ],
+          recommended: ['anthropic/claude-sonnet-4-7'],
+        }),
       })
       .mockResolvedValueOnce({
         ok: true,
@@ -471,6 +506,20 @@ describe('SetupWizard', () => {
         ok: true,
         status: 200,
         json: async () => ({ provider_configured: false }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          models: [
+            {
+              id: 'anthropic/claude-sonnet-4-7',
+              provider: 'anthropic',
+              model: 'claude-sonnet-4-7',
+            },
+          ],
+          recommended: ['anthropic/claude-sonnet-4-7'],
+        }),
       })
       .mockResolvedValueOnce({
         ok: false,

--- a/webui/src/components/settings/ServerConfiguration.tsx
+++ b/webui/src/components/settings/ServerConfiguration.tsx
@@ -27,6 +27,7 @@ import { getClientForServer } from '@/stores/serverClients';
 import type { ServerConfig } from '@/types/servers';
 import { toast } from 'sonner';
 import { cn } from '@/lib/utils';
+import { ServerDefaultModelSettings } from './ServerDefaultModelSettings';
 
 interface ServerFormState {
   name: string;
@@ -345,6 +346,8 @@ export const ServerConfiguration: FC = () => {
           );
         })}
       </div>
+
+      <ServerDefaultModelSettings />
 
       <Button variant="outline" onClick={handleOpenAdd}>
         <Plus className="mr-2 h-4 w-4" />

--- a/webui/src/components/settings/ServerDefaultModelSettings.tsx
+++ b/webui/src/components/settings/ServerDefaultModelSettings.tsx
@@ -1,0 +1,122 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { ModelPickerButton } from '@/components/ModelPicker';
+import { useApi } from '@/contexts/ApiContext';
+import { useModels } from '@/hooks/useModels';
+import { toast } from 'sonner';
+
+type SaveDefaultModelResponse = {
+  status: string;
+  model: string;
+  restart_required: boolean;
+};
+
+export function ServerDefaultModelSettings() {
+  const { api } = useApi();
+  const { models, defaultModel, recommendedModels, isLoading, error } = useModels();
+  const [selectedModel, setSelectedModel] = useState<string>('');
+  const [savedModel, setSavedModel] = useState<string | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const effectiveDefaultModel = savedModel || defaultModel;
+  const fallbackModel = useMemo(() => {
+    if (models.length === 0) {
+      return '';
+    }
+    return (
+      recommendedModels.find((modelId) => models.some((model) => model.id === modelId)) ||
+      models[0].id
+    );
+  }, [models, recommendedModels]);
+
+  useEffect(() => {
+    if (savedModel) {
+      setSelectedModel(savedModel);
+      return;
+    }
+    if (defaultModel) {
+      setSelectedModel((current) => current || defaultModel);
+      return;
+    }
+    if (!selectedModel && fallbackModel) {
+      setSelectedModel(fallbackModel);
+    }
+  }, [defaultModel, fallbackModel, savedModel, selectedModel]);
+
+  const handleSave = async () => {
+    if (!selectedModel) {
+      toast.error('Select a model first.');
+      return;
+    }
+
+    setIsSaving(true);
+    try {
+      const headers: Record<string, string> = {
+        'Content-Type': 'application/json',
+      };
+      if (api.authHeader) {
+        headers.Authorization = api.authHeader;
+      }
+
+      const response = await fetch(`${api.baseUrl}/api/v2/user/default-model`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ model: selectedModel }),
+      });
+
+      const data = (await response.json()) as SaveDefaultModelResponse | { error?: string };
+      if (!response.ok) {
+        throw new Error('error' in data && data.error ? data.error : 'Failed to save model');
+      }
+
+      const result = data as SaveDefaultModelResponse;
+      setSavedModel(result.model);
+      toast.success(
+        result.restart_required
+          ? 'Default model saved. Restart the server to apply it.'
+          : 'Default model updated.'
+      );
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to save model');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <div className="space-y-3 rounded-lg border p-4">
+      <div>
+        <h4 className="text-sm font-medium">Default model</h4>
+        <p className="text-sm text-muted-foreground">
+          Choose which model new server-backed chats should use by default.
+        </p>
+      </div>
+
+      {effectiveDefaultModel && (
+        <p className="text-xs text-muted-foreground">
+          Current default: <code>{effectiveDefaultModel}</code>
+        </p>
+      )}
+
+      {error ? (
+        <p className="text-sm text-destructive">{error}</p>
+      ) : (
+        <ModelPickerButton
+          value={selectedModel}
+          onSelect={setSelectedModel}
+          disabled={isLoading || isSaving || models.length === 0}
+          placeholder={isLoading ? 'Loading models…' : 'Select model'}
+        />
+      )}
+
+      <Button
+        type="button"
+        variant="outline"
+        onClick={() => void handleSave()}
+        disabled={isSaving || isLoading || !selectedModel}
+      >
+        {isSaving ? 'Saving…' : 'Save default model'}
+      </Button>
+    </div>
+  );
+}

--- a/webui/src/components/settings/__tests__/ServerDefaultModelSettings.test.tsx
+++ b/webui/src/components/settings/__tests__/ServerDefaultModelSettings.test.tsx
@@ -1,0 +1,117 @@
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { ServerDefaultModelSettings } from '../ServerDefaultModelSettings';
+
+const mockSuccess = jest.fn();
+const mockError = jest.fn();
+const mockFetch = jest.fn();
+const mockOnSelect = jest.fn();
+
+jest.mock('@/contexts/ApiContext', () => ({
+  useApi: () => ({
+    api: {
+      baseUrl: 'http://127.0.0.1:5700',
+      authHeader: 'Bearer test-token',
+    },
+  }),
+}));
+
+jest.mock('@/hooks/useModels', () => ({
+  useModels: () => ({
+    models: [
+      {
+        id: 'anthropic/claude-sonnet-4-7',
+        provider: 'anthropic',
+        model: 'claude-sonnet-4-7',
+      },
+      {
+        id: 'openai/gpt-4.1',
+        provider: 'openai',
+        model: 'gpt-4.1',
+      },
+    ],
+    defaultModel: 'anthropic/claude-sonnet-4-7',
+    recommendedModels: ['anthropic/claude-sonnet-4-7'],
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+jest.mock('@/components/ModelPicker', () => ({
+  ModelPickerButton: ({
+    value,
+    onSelect,
+    disabled,
+  }: {
+    value?: string;
+    onSelect: (value: string) => void;
+    disabled?: boolean;
+  }) => (
+    <button
+      type="button"
+      disabled={disabled}
+      onClick={() => {
+        mockOnSelect();
+        onSelect('openai/gpt-4.1');
+      }}
+    >
+      {value || 'Select model'}
+    </button>
+  ),
+}));
+
+jest.mock('@/components/ui/button', () => ({
+  Button: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button {...props}>{children}</button>
+  ),
+}));
+
+jest.mock('sonner', () => ({
+  toast: {
+    success: (...args: unknown[]) => mockSuccess(...args),
+    error: (...args: unknown[]) => mockError(...args),
+  },
+}));
+
+describe('ServerDefaultModelSettings', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    mockSuccess.mockReset();
+    mockError.mockReset();
+    mockOnSelect.mockReset();
+    Object.defineProperty(window, 'fetch', {
+      writable: true,
+      value: mockFetch,
+    });
+  });
+
+  it('saves the selected default model through the server API', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        status: 'ok',
+        model: 'openai/gpt-4.1',
+        restart_required: false,
+      }),
+    });
+
+    render(<ServerDefaultModelSettings />);
+
+    fireEvent.click(screen.getByRole('button', { name: /anthropic\/claude-sonnet-4-7/i }));
+    fireEvent.click(screen.getByRole('button', { name: /save default model/i }));
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith('http://127.0.0.1:5700/api/v2/user/default-model', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer test-token',
+        },
+        body: JSON.stringify({ model: 'openai/gpt-4.1' }),
+      });
+    });
+
+    expect(mockOnSelect).toHaveBeenCalled();
+    expect(mockSuccess).toHaveBeenCalledWith('Default model updated.');
+  });
+});


### PR DESCRIPTION
## Summary
- extend the shared server onboarding surface so API key setup can also persist `env.MODEL`
- add a dedicated `/api/v2/user/default-model` endpoint and wire server settings to it
- add onboarding + settings UI coverage plus server tests for model persistence/validation

## Verification
- `uv run python3 -m pytest tests/test_server_v2.py -q -k "test_v2_user_api_key_persists_env_entry or test_v2_user_api_key_persists_default_model or test_v2_user_api_key_rejects_model_provider_mismatch or test_v2_user_api_key_rejects_unknown_provider or test_v2_user_default_model_persists_and_applies or test_v2_user_default_model_rejects_unqualified_model"`
- `npm test -- --runInBand src/components/__tests__/SetupWizard.test.tsx src/components/settings/__tests__/ServerDefaultModelSettings.test.tsx`
- `npm run typecheck`
- `npx eslint src/components/ModelPicker.tsx src/components/SetupWizard.tsx src/components/__tests__/SetupWizard.test.tsx src/components/settings/ServerConfiguration.tsx src/components/settings/ServerDefaultModelSettings.tsx src/components/settings/__tests__/ServerDefaultModelSettings.test.tsx`
- `python3 -m py_compile gptme/server/api_v2.py gptme/server/openapi_docs.py tests/test_server_v2.py`