### PR TITLE
feat(server): add GET /api/v2/user/settings for provider+model introspection

### DIFF
--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -25,7 +25,7 @@ from gptme.config import (
     set_config,
     set_config_value,
 )
-from gptme.llm import PROVIDER_API_KEYS
+from gptme.llm import PROVIDER_API_KEYS, list_available_providers
 from gptme.llm.models import (
     PROVIDERS,
     Provider,
@@ -72,6 +72,7 @@ from .openapi_docs import (
     UserApiKeySaveResponse,
     UserDefaultModelSaveRequest,
     UserDefaultModelSaveResponse,
+    UserSettingsResponse,
     api_doc,
     api_doc_simple,
 )
@@ -1487,3 +1488,29 @@ def api_user_avatar():
         return flask.jsonify({"error": "Avatar must be a valid image file"}), 400
 
     return flask.send_file(full_path)
+
+
+@v2_api.route("/api/v2/user/settings", methods=["GET"])
+@require_auth
+@api_doc(
+    summary="Get current user settings",
+    description=(
+        "Return a read-only snapshot of the current user settings: which providers "
+        "have API keys or OAuth tokens configured, and the active default model. "
+        "Useful for settings UI and onboarding flows that need to reflect server-side "
+        "state without keeping a local copy."
+    ),
+    responses={200: UserSettingsResponse},
+    tags=["user"],
+)
+def api_user_settings():
+    """Return the current user settings state."""
+    available = list_available_providers()
+    providers = [str(provider) for provider, _ in available]
+    default_model = get_default_model()
+    return flask.jsonify(
+        {
+            "providers_configured": providers,
+            "default_model": default_model.full if default_model else None,
+        }
+    )

--- a/gptme/server/openapi_docs.py
+++ b/gptme/server/openapi_docs.py
@@ -199,6 +199,19 @@ class UserDefaultModelSaveResponse(BaseModel):
     )
 
 
+class UserSettingsResponse(BaseModel):
+    """Current user settings state (read-only snapshot)."""
+
+    providers_configured: list[str] = Field(
+        ...,
+        description="Provider slugs that have an API key or OAuth token configured",
+    )
+    default_model: str | None = Field(
+        None,
+        description="Fully qualified default model from config, or null if unset",
+    )
+
+
 class ExternalSessionListItem(BaseModel):
     """A read-only external session catalog item."""
 

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -1553,3 +1553,41 @@ def test_v2_tasks_put_rejects_non_object_json(client: FlaskClient, body: object)
     )
     assert response.status_code == 400
     assert "object" in response.get_json()["error"].lower()
+
+
+def test_v2_user_settings_returns_providers_and_model(client: FlaskClient, monkeypatch):
+    """GET /api/v2/user/settings should reflect configured providers and default model."""
+    from gptme.llm.models import ModelMeta
+
+    fake_model = ModelMeta(
+        model="claude-sonnet-4-5",
+        provider="anthropic",
+        context=10000,
+        max_output=1000,
+    )
+    monkeypatch.setattr("gptme.server.api_v2.get_default_model", lambda: fake_model)
+    monkeypatch.setattr(
+        "gptme.server.api_v2.list_available_providers",
+        lambda: [("anthropic", "ANTHROPIC_API_KEY")],
+    )
+
+    response = client.get("/api/v2/user/settings")
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["providers_configured"] == ["anthropic"]
+    assert data["default_model"] == "anthropic/claude-sonnet-4-5"
+
+
+def test_v2_user_settings_no_providers_no_model(client: FlaskClient, monkeypatch):
+    """GET /api/v2/user/settings with no config returns empty lists and null model."""
+    monkeypatch.setattr(
+        "gptme.server.api_v2.list_available_providers",
+        lambda: [],
+    )
+    monkeypatch.setattr("gptme.server.api_v2.get_default_model", lambda: None)
+
+    response = client.get("/api/v2/user/settings")
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["providers_configured"] == []
+    assert data["default_model"] is None


### PR DESCRIPTION
## Summary

- Adds `GET /api/v2/user/settings` — a read-only snapshot of current user settings
- Returns `providers_configured` (list of slugs with API keys or OAuth tokens) and `default_model` (fully qualified or null)
- Uses `list_available_providers()` from `gptme.llm` to detect configured providers, including OAuth-based (`openai-subscription`) and plugin providers — not just `PROVIDER_API_KEYS` env vars

## Motivation

Runs 2 and 3 of the software factory added write endpoints (`POST /api/v2/user/api-key` and `POST /api/v2/user/default-model`). This run adds the corresponding read endpoint, completing the read/write contract for the settings surface.

Settings UIs (SetupWizard, ServerDefaultModelSettings) can now reflect server-side state without keeping a local React copy that may drift after page reload or across tabs.

## Changes

| File | What changed |
|------|-------------|
| `gptme/server/api_v2.py` | Import `list_available_providers`; add `api_user_settings` endpoint |
| `gptme/server/openapi_docs.py` | Add `UserSettingsResponse` dataclass |
| `tests/test_server_v2.py` | 2 new tests: populated config path and empty-config path |

## Test plan

- [x] `test_v2_user_settings_returns_providers_and_model` — verifies populated providers list and model string
- [x] `test_v2_user_settings_no_providers_no_model` — verifies empty list and `null` model
- [x] All 8 existing user endpoint tests still pass
- [x] mypy clean on changed files
- [x] ruff format clean (auto-fixed by pre-commit)

## Desktop-specific LOC: 0

No Tauri or packaging changes. Shared-surface discipline maintained.