### PR TITLE
feat(webui): wire ServerDefaultModelSettings to GET /api/v2/user/settings

### DIFF
--- a/webui/src/components/settings/ServerDefaultModelSettings.tsx
+++ b/webui/src/components/settings/ServerDefaultModelSettings.tsx
@@ -22,6 +22,7 @@ export function ServerDefaultModelSettings() {
     refetch: refetchSettings,
   } = useUserSettings();
   const [selectedModel, setSelectedModel] = useState<string>('');
+  const [userSelected, setUserSelected] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
 
   const isLoading = modelsLoading || settingsLoading;
@@ -40,15 +41,20 @@ export function ServerDefaultModelSettings() {
     );
   }, [models, recommendedModels]);
 
+  // Server default wins over the fallback as long as the user hasn't explicitly picked.
+  // Without this, useModels resolves first → sets fallback → useUserSettings resolves later
+  // → the (current => current || serverDefault) guard is a no-op, silently diverging picker
+  // from the "Current default" label.
   useEffect(() => {
+    if (userSelected) return;
     if (serverDefaultModel) {
-      setSelectedModel((current) => current || serverDefaultModel);
+      setSelectedModel(serverDefaultModel);
       return;
     }
-    if (!selectedModel && fallbackModel) {
+    if (fallbackModel) {
       setSelectedModel(fallbackModel);
     }
-  }, [serverDefaultModel, fallbackModel, selectedModel]);
+  }, [serverDefaultModel, fallbackModel, userSelected]);
 
   const handleSave = async () => {
     if (!selectedModel) {
@@ -77,7 +83,9 @@ export function ServerDefaultModelSettings() {
       }
 
       const result = data as SaveDefaultModelResponse;
-      // Refetch from server to reflect the saved state authoritatively
+      // Refetch from server to reflect the saved state authoritatively.
+      // Reset userSelected so the refetch can update the picker to the confirmed model.
+      setUserSelected(false);
       refetchSettings();
       toast.success(
         result.restart_required
@@ -126,7 +134,10 @@ export function ServerDefaultModelSettings() {
       ) : (
         <ModelPickerButton
           value={selectedModel}
-          onSelect={setSelectedModel}
+          onSelect={(model) => {
+            setSelectedModel(model);
+            setUserSelected(true);
+          }}
           disabled={isLoading || isSaving || models.length === 0}
           placeholder={isLoading ? 'Loading models…' : 'Select model'}
         />

--- a/webui/src/components/settings/ServerDefaultModelSettings.tsx
+++ b/webui/src/components/settings/ServerDefaultModelSettings.tsx
@@ -3,6 +3,7 @@ import { Button } from '@/components/ui/button';
 import { ModelPickerButton } from '@/components/ModelPicker';
 import { useApi } from '@/contexts/ApiContext';
 import { useModels } from '@/hooks/useModels';
+import { useUserSettings } from '@/hooks/useUserSettings';
 import { toast } from 'sonner';
 
 type SaveDefaultModelResponse = {
@@ -13,12 +14,22 @@ type SaveDefaultModelResponse = {
 
 export function ServerDefaultModelSettings() {
   const { api } = useApi();
-  const { models, defaultModel, recommendedModels, isLoading, error } = useModels();
+  const { models, recommendedModels, isLoading: modelsLoading, error: modelsError } = useModels();
+  const {
+    settings,
+    isLoading: settingsLoading,
+    error: settingsError,
+    refetch: refetchSettings,
+  } = useUserSettings();
   const [selectedModel, setSelectedModel] = useState<string>('');
-  const [savedModel, setSavedModel] = useState<string | null>(null);
   const [isSaving, setIsSaving] = useState(false);
 
-  const effectiveDefaultModel = savedModel || defaultModel;
+  const isLoading = modelsLoading || settingsLoading;
+  const error = modelsError || settingsError;
+
+  // Server-authoritative default model from /api/v2/user/settings
+  const serverDefaultModel = settings?.default_model ?? null;
+
   const fallbackModel = useMemo(() => {
     if (models.length === 0) {
       return '';
@@ -30,18 +41,14 @@ export function ServerDefaultModelSettings() {
   }, [models, recommendedModels]);
 
   useEffect(() => {
-    if (savedModel) {
-      setSelectedModel(savedModel);
-      return;
-    }
-    if (defaultModel) {
-      setSelectedModel((current) => current || defaultModel);
+    if (serverDefaultModel) {
+      setSelectedModel((current) => current || serverDefaultModel);
       return;
     }
     if (!selectedModel && fallbackModel) {
       setSelectedModel(fallbackModel);
     }
-  }, [defaultModel, fallbackModel, savedModel, selectedModel]);
+  }, [serverDefaultModel, fallbackModel, selectedModel]);
 
   const handleSave = async () => {
     if (!selectedModel) {
@@ -70,7 +77,8 @@ export function ServerDefaultModelSettings() {
       }
 
       const result = data as SaveDefaultModelResponse;
-      setSavedModel(result.model);
+      // Refetch from server to reflect the saved state authoritatively
+      refetchSettings();
       toast.success(
         result.restart_required
           ? 'Default model saved. Restart the server to apply it.'
@@ -83,6 +91,8 @@ export function ServerDefaultModelSettings() {
     }
   };
 
+  const configuredProviders = settings?.providers_configured ?? [];
+
   return (
     <div className="space-y-3 rounded-lg border p-4">
       <div>
@@ -92,9 +102,22 @@ export function ServerDefaultModelSettings() {
         </p>
       </div>
 
-      {effectiveDefaultModel && (
+      {configuredProviders.length > 0 && (
+        <div className="flex flex-wrap gap-1">
+          {configuredProviders.map((provider) => (
+            <span
+              key={provider}
+              className="rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground"
+            >
+              {provider}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {serverDefaultModel && (
         <p className="text-xs text-muted-foreground">
-          Current default: <code>{effectiveDefaultModel}</code>
+          Current default: <code>{serverDefaultModel}</code>
         </p>
       )}
 

--- a/webui/src/components/settings/__tests__/ServerDefaultModelSettings.test.tsx
+++ b/webui/src/components/settings/__tests__/ServerDefaultModelSettings.test.tsx
@@ -6,6 +6,7 @@ const mockSuccess = jest.fn();
 const mockError = jest.fn();
 const mockFetch = jest.fn();
 const mockOnSelect = jest.fn();
+const mockRefetch = jest.fn();
 
 jest.mock('@/contexts/ApiContext', () => ({
   useApi: () => ({
@@ -34,6 +35,18 @@ jest.mock('@/hooks/useModels', () => ({
     recommendedModels: ['anthropic/claude-sonnet-4-7'],
     isLoading: false,
     error: null,
+  }),
+}));
+
+jest.mock('@/hooks/useUserSettings', () => ({
+  useUserSettings: () => ({
+    settings: {
+      providers_configured: ['anthropic', 'openai'],
+      default_model: 'anthropic/claude-sonnet-4-7',
+    },
+    isLoading: false,
+    error: null,
+    refetch: mockRefetch,
   }),
 }));
 
@@ -79,6 +92,7 @@ describe('ServerDefaultModelSettings', () => {
     mockSuccess.mockReset();
     mockError.mockReset();
     mockOnSelect.mockReset();
+    mockRefetch.mockReset();
     Object.defineProperty(window, 'fetch', {
       writable: true,
       value: mockFetch,
@@ -113,5 +127,21 @@ describe('ServerDefaultModelSettings', () => {
 
     expect(mockOnSelect).toHaveBeenCalled();
     expect(mockSuccess).toHaveBeenCalledWith('Default model updated.');
+    expect(mockRefetch).toHaveBeenCalled();
+  });
+
+  it('shows configured providers from user settings', () => {
+    render(<ServerDefaultModelSettings />);
+
+    expect(screen.getByText('anthropic')).toBeInTheDocument();
+    expect(screen.getByText('openai')).toBeInTheDocument();
+  });
+
+  it('shows server-authoritative default model', () => {
+    render(<ServerDefaultModelSettings />);
+
+    expect(screen.getByText(/current default:/i).closest('p')).toHaveTextContent(
+      'anthropic/claude-sonnet-4-7'
+    );
   });
 });

--- a/webui/src/hooks/useUserSettings.ts
+++ b/webui/src/hooks/useUserSettings.ts
@@ -14,6 +14,8 @@ export function useUserSettings() {
   const [refetchKey, setRefetchKey] = useState(0);
 
   useEffect(() => {
+    const controller = new AbortController();
+
     const fetchSettings = async () => {
       setIsLoading(true);
       setError(null);
@@ -22,13 +24,17 @@ export function useUserSettings() {
         if (api.authHeader) {
           headers.Authorization = api.authHeader;
         }
-        const response = await fetch(`${api.baseUrl}/api/v2/user/settings`, { headers });
+        const response = await fetch(`${api.baseUrl}/api/v2/user/settings`, {
+          headers,
+          signal: controller.signal,
+        });
         if (!response.ok) {
           throw new Error(`Failed to fetch user settings: ${response.statusText}`);
         }
         const data = (await response.json()) as UserSettings;
         setSettings(data);
       } catch (err) {
+        if (err instanceof Error && err.name === 'AbortError') return;
         setError(err instanceof Error ? err.message : 'Failed to fetch user settings');
         setSettings(null);
       } finally {
@@ -37,6 +43,7 @@ export function useUserSettings() {
     };
 
     void fetchSettings();
+    return () => controller.abort();
   }, [api.baseUrl, api.authHeader, refetchKey]);
 
   const refetch = useCallback(() => setRefetchKey((k) => k + 1), []);

--- a/webui/src/hooks/useUserSettings.ts
+++ b/webui/src/hooks/useUserSettings.ts
@@ -1,0 +1,45 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useApi } from '@/contexts/ApiContext';
+
+export interface UserSettings {
+  providers_configured: string[];
+  default_model: string | null;
+}
+
+export function useUserSettings() {
+  const { api } = useApi();
+  const [settings, setSettings] = useState<UserSettings | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [refetchKey, setRefetchKey] = useState(0);
+
+  useEffect(() => {
+    const fetchSettings = async () => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const headers: Record<string, string> = {};
+        if (api.authHeader) {
+          headers.Authorization = api.authHeader;
+        }
+        const response = await fetch(`${api.baseUrl}/api/v2/user/settings`, { headers });
+        if (!response.ok) {
+          throw new Error(`Failed to fetch user settings: ${response.statusText}`);
+        }
+        const data = (await response.json()) as UserSettings;
+        setSettings(data);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to fetch user settings');
+        setSettings(null);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    void fetchSettings();
+  }, [api.baseUrl, api.authHeader, refetchKey]);
+
+  const refetch = useCallback(() => setRefetchKey((k) => k + 1), []);
+
+  return { settings, isLoading, error, refetch };
+}

--- a/webui/src/hooks/useUserSettings.ts
+++ b/webui/src/hooks/useUserSettings.ts
@@ -33,11 +33,11 @@ export function useUserSettings() {
         }
         const data = (await response.json()) as UserSettings;
         setSettings(data);
+        setIsLoading(false);
       } catch (err) {
         if (err instanceof Error && err.name === 'AbortError') return;
         setError(err instanceof Error ? err.message : 'Failed to fetch user settings');
         setSettings(null);
-      } finally {
         setIsLoading(false);
       }
     };


### PR DESCRIPTION
## Summary

- Adds `useUserSettings()` hook that fetches from `/api/v2/user/settings` (added in #2203)
- Wires `ServerDefaultModelSettings` to read from it:
  - **Replaces `savedModel` local state** with a server-authoritative `refetch()` after save — the default model now reflects ground truth after reload instead of evaporating with the React state tree
  - **Shows `providers_configured` as badges** above the model picker, giving users a clear view of which providers have API keys configured
- New tests verify badge rendering and server-default model display (3 tests, 168 total passing)

## Test plan

- [x] `npm test` — 168/168 pass
- [x] `npm run typecheck` — clean
- [x] ESLint auto-fix ran cleanly via prek