### PR TITLE
feat(agent): add gptme-agent scan alias

### DIFF
--- a/gptme/agent/cli.py
+++ b/gptme/agent/cli.py
@@ -2,6 +2,7 @@
 CLI commands for gptme agent management.
 
 Usage:
+    gptme-agent scan                # Show live agent processes across runtimes
     gptme-agent status              # Show all agent statuses
     gptme-agent create <path>       # Create a new agent workspace
     gptme-agent install [--timer]   # Install systemd/launchd services
@@ -19,6 +20,7 @@ from pathlib import Path
 
 import click
 
+from ..cli.cmd_agents import run_scan
 from .doctor import run_doctor
 from .service import ServiceStatus, detect_service_manager, get_service_manager
 from .workspace import (
@@ -83,12 +85,41 @@ def main(verbose: bool = False):
 
     \b
     Common workflows:
+      gptme-agent scan                # See active local agents across runtimes
       gptme-agent logs --follow       # Monitor agent activity
       gptme-agent run                 # Trigger an immediate run
       gptme-agent stop                # Pause scheduled runs
     """
     if verbose:
         logging.basicConfig(level=logging.DEBUG)
+
+
+@main.command("scan")
+@click.option(
+    "--workspace",
+    "-w",
+    default=None,
+    type=click.Path(file_okay=False, path_type=Path),
+    help="Only show agents whose CWD is under this path. "
+    "By default all agents on the host are shown.",
+)
+@click.option(
+    "--all",
+    "show_all",
+    is_flag=True,
+    default=False,
+    help="Include stale/stuck agents (excluded by default).",
+)
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    default=False,
+    help="Output as JSON.",
+)
+def scan_cmd(workspace: Path | None, show_all: bool, as_json: bool):
+    """List live agent processes (gptme, claude-code, codex, aider, …)."""
+    sys.exit(run_scan(workspace=workspace, show_all=show_all, as_json=as_json))
 
 
 @main.command("status")

--- a/gptme/cli/cmd_agents.py
+++ b/gptme/cli/cmd_agents.py
@@ -22,6 +22,57 @@ def agents() -> None:
     """Inspect live agent processes on this host."""
 
 
+def run_scan(
+    workspace: Path | None,
+    show_all: bool,
+    as_json: bool,
+) -> int:
+    """Render live agent scan results and return the command exit code."""
+    from ..hooks.workspace_agents import (
+        _format_agent_line,
+        _format_duration,
+        scan_agents,
+    )
+
+    results = scan_agents(workspace=str(workspace) if workspace else None)
+
+    active = [a for a in results if not a.stale]
+    stale = [a for a in results if a.stale]
+
+    shown = results if show_all else active
+
+    if as_json:
+        output = [asdict(a) for a in shown]
+        json.dump(output, sys.stdout, indent=2)
+        print()
+    else:
+        if not shown:
+            label = "agents" if show_all else "active agents"
+            scope = f" in {workspace}" if workspace else ""
+            click.echo(f"No {label} found{scope}.")
+        else:
+            scope = f" in {workspace}" if workspace else " on this host"
+            click.echo(f"Live agents{scope}:")
+            for a in shown:
+                click.echo(f"  {_format_agent_line(a)}")
+
+        if not show_all and stale:
+            n = len(stale)
+            ages = ", ".join(
+                _format_duration(a.uptime_seconds)
+                for a in stale
+                if a.uptime_seconds is not None
+            )
+            click.echo(
+                f"  ({n} stale process{'es' if n != 1 else ''} hidden"
+                + (f"; ages: {ages}" if ages else "")
+                + "; use --all to show)",
+                err=False,
+            )
+
+    return 0 if active else 1
+
+
 @agents.command("scan")
 @click.option(
     "--workspace",
@@ -58,49 +109,4 @@ def scan(
 
     Exit code: 0 if at least one active agent found, 1 if none.
     """
-    from ..hooks.workspace_agents import (
-        _format_agent_line,
-        _format_duration,
-        scan_agents,
-    )
-
-    results = scan_agents(workspace=str(workspace) if workspace else None)
-
-    active = [a for a in results if not a.stale]
-    stale = [a for a in results if a.stale]
-
-    shown = results if show_all else active
-
-    if as_json:
-        output = []
-        for a in shown:
-            d = asdict(a)
-            output.append(d)
-        json.dump(output, sys.stdout, indent=2)
-        print()
-    else:
-        if not shown:
-            label = "agents" if show_all else "active agents"
-            scope = f" in {workspace}" if workspace else ""
-            click.echo(f"No {label} found{scope}.")
-        else:
-            scope = f" in {workspace}" if workspace else " on this host"
-            click.echo(f"Live agents{scope}:")
-            for a in shown:
-                click.echo(f"  {_format_agent_line(a)}")
-
-        if not show_all and stale:
-            n = len(stale)
-            ages = ", ".join(
-                _format_duration(a.uptime_seconds)
-                for a in stale
-                if a.uptime_seconds is not None
-            )
-            click.echo(
-                f"  ({n} stale process{'es' if n != 1 else ''} hidden"
-                + (f"; ages: {ages}" if ages else "")
-                + "; use --all to show)",
-                err=False,
-            )
-
-    sys.exit(0 if active else 1)
+    sys.exit(run_scan(workspace=workspace, show_all=show_all, as_json=as_json))

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -23,6 +23,31 @@ from gptme.agent.workspace import (
     get_workspace_name,
     is_agent_workspace,
 )
+from gptme.hooks.workspace_agents import AgentInfo
+
+
+def _make_scanned_agent(
+    pid: int = 1234,
+    runtime: str = "claude-code",
+    cwd: str = "/home/user/project",
+    model: str = "opus",
+    mode: str = "autonomous",
+    branch: str = "master",
+    uptime_seconds: int = 300,
+    stale: bool = False,
+    stale_reason: str | None = None,
+) -> AgentInfo:
+    return AgentInfo(
+        pid=pid,
+        runtime=runtime,
+        cwd=cwd,
+        model=model,
+        mode=mode,
+        branch=branch,
+        uptime_seconds=uptime_seconds,
+        stale=stale,
+        stale_reason=stale_reason,
+    )
 
 
 class TestDetectServiceManager:
@@ -593,6 +618,12 @@ class TestCLI:
         assert result.exit_code == 0
         assert "Show status of agent(s)" in result.output
 
+    def test_scan_help(self, runner):
+        """Test scan command help."""
+        result = runner.invoke(main, ["scan", "--help"])
+        assert result.exit_code == 0
+        assert "List live agent processes" in result.output
+
     def test_create_help(self, runner):
         """Test create command help."""
         result = runner.invoke(main, ["create", "--help"])
@@ -708,6 +739,17 @@ class TestCLI:
             result = runner.invoke(main, ["list"])
             assert result.exit_code == 0
             assert "No agents installed" in result.output
+
+    def test_scan_shows_active_agents(self, runner, mocker):
+        """Test scan command exposes the shared live-agent scanner."""
+        agent = _make_scanned_agent()
+        mocker.patch("gptme.hooks.workspace_agents.scan_agents", return_value=[agent])
+
+        result = runner.invoke(main, ["scan"])
+
+        assert result.exit_code == 0
+        assert "claude-code" in result.output
+        assert "1234" in result.output
 
     def test_uninstall_help(self, runner):
         """Test uninstall command help."""


### PR DESCRIPTION
## Summary
- expose the live agent scanner as `gptme-agent scan`
- reuse the existing `gptme-util agents scan` implementation via a shared helper
- add agent CLI coverage for the new alias

## Why
`gptme-util agents scan` exists on `main` but is easy to miss, and the installed `v0.31.0` tool does not include it yet. Adding `gptme-agent scan` makes the feature more discoverable once released.