### PR TITLE
fix(cli): reduce agents scan latency

### DIFF
--- a/gptme/cli/util.py
+++ b/gptme/cli/util.py
@@ -61,6 +61,13 @@ def model_to_dict(model):
     return _model_to_dict(model)
 
 
+def get_config(*args, **kwargs):
+    """Lazy proxy so tests can still patch ``gptme.cli.util.get_config``."""
+    from ..config import get_config as _get_config  # fmt: skip
+
+    return _get_config(*args, **kwargs)
+
+
 class LazyGroup(click.Group):
     """Click group that imports heavyweight subcommands on demand."""
 
@@ -732,7 +739,6 @@ def models_test(model_name: str | None, as_json: bool):
         gptme-util models test anthropic/claude-opus-4-7  # specific model
         gptme-util models test --json anthropic   # machine-readable output
     """
-    from ..config import get_config
     from ..llm import (
         PROVIDER_API_KEYS,
         get_provider_from_model,

--- a/gptme/cli/util.py
+++ b/gptme/cli/util.py
@@ -19,6 +19,7 @@ warnings.filterwarnings(
     message=r".*urllib3.*chardet.*charset_normalizer.*",
 )
 
+import importlib
 import io
 import json
 import logging
@@ -30,33 +31,67 @@ from pathlib import Path
 
 import click
 
-from ..config import get_config
-from ..llm import PROVIDER_DEFAULT_MODELS as _PROVIDER_DEFAULT_MODELS
-from ..llm.models import get_model_list, list_models, model_to_dict
-from ..message import Message
-from ..util.context import include_paths
-from .cmd_agents import agents
-from .cmd_chats import chats
-from .cmd_hooks import hooks
-from .cmd_mcp import mcp
-from .cmd_skills import skills
+_LAZY_COMMANDS: dict[str, tuple[str, str]] = {
+    "agents": (".cmd_agents", "agents"),
+    "chats": (".cmd_chats", "chats"),
+    "hooks": (".cmd_hooks", "hooks"),
+    "mcp": (".cmd_mcp", "mcp"),
+    "skills": (".cmd_skills", "skills"),
+}
 
 
-@click.group()
+def get_model_list(*args, **kwargs):
+    """Lazy proxy so tests can still patch ``gptme.cli.util.get_model_list``."""
+    from ..llm.models import get_model_list as _get_model_list  # fmt: skip
+
+    return _get_model_list(*args, **kwargs)
+
+
+def list_models(*args, **kwargs):
+    """Lazy proxy so util commands don't import model code at module import time."""
+    from ..llm.models import list_models as _list_models  # fmt: skip
+
+    return _list_models(*args, **kwargs)
+
+
+def model_to_dict(model):
+    """Lazy proxy used by JSON model output."""
+    from ..llm.models import model_to_dict as _model_to_dict  # fmt: skip
+
+    return _model_to_dict(model)
+
+
+class LazyGroup(click.Group):
+    """Click group that imports heavyweight subcommands on demand."""
+
+    def list_commands(self, ctx: click.Context) -> list[str]:
+        commands = set(super().list_commands(ctx))
+        commands.update(_LAZY_COMMANDS)
+        return sorted(commands)
+
+    def get_command(self, ctx: click.Context, cmd_name: str) -> click.Command | None:
+        command = super().get_command(ctx, cmd_name)
+        if command is not None:
+            return command
+
+        target = _LAZY_COMMANDS.get(cmd_name)
+        if target is None:
+            return None
+
+        module_name, attr_name = target
+        module = importlib.import_module(module_name, package=__package__)
+        command = getattr(module, attr_name)
+        self.add_command(command, cmd_name)
+        return command
+
+
+@click.group(cls=LazyGroup)
 @click.option("-v", "--verbose", is_flag=True, help="Enable verbose output.")
 def main(verbose: bool = False):
     """Utility commands for gptme."""
 
     if verbose:
         logging.getLogger().setLevel(logging.DEBUG)
-
-
-# Register command groups from submodules
-main.add_command(agents)
-main.add_command(chats)
-main.add_command(hooks)
-main.add_command(mcp)
-main.add_command(skills)
 
 
 @main.group()
@@ -67,6 +102,7 @@ def providers():
 @providers.command("list")
 def providers_list():
     """List configured custom OpenAI-compatible providers."""
+    from ..config import get_config  # fmt: skip
 
     config = get_config()
 
@@ -112,6 +148,8 @@ def providers_test(provider_name: str):
 
     Connects to the provider's API and lists available models.
     """
+    from ..config import get_config  # fmt: skip
+
     config = get_config()
 
     # Find the provider config
@@ -553,6 +591,9 @@ def prompts_expand(prompt: tuple[str, ...]):
     full_prompt = "\n\n".join(prompt)
 
     # Use the existing include_paths function to expand the prompt
+    from ..message import Message  # fmt: skip
+    from ..util.context import include_paths  # fmt: skip
+
     original_msg = Message("user", full_prompt)
     expanded_msg = include_paths(original_msg, workspace=Path.cwd())
 
@@ -691,11 +732,16 @@ def models_test(model_name: str | None, as_json: bool):
         gptme-util models test anthropic/claude-opus-4-7  # specific model
         gptme-util models test --json anthropic   # machine-readable output
     """
-    from ..llm import (  # fmt: skip
+    from ..config import get_config
+    from ..llm import (
         PROVIDER_API_KEYS,
         get_provider_from_model,
         init_llm,
     )
+    from ..llm import (
+        PROVIDER_DEFAULT_MODELS as _PROVIDER_DEFAULT_MODELS,
+    )
+    from ..message import Message
 
     # Resolve model name
     if model_name is None:

--- a/gptme/cli/util.py
+++ b/gptme/cli/util.py
@@ -109,8 +109,6 @@ def providers():
 @providers.command("list")
 def providers_list():
     """List configured custom OpenAI-compatible providers."""
-    from ..config import get_config  # fmt: skip
-
     config = get_config()
 
     if not config.user.providers:
@@ -155,8 +153,6 @@ def providers_test(provider_name: str):
 
     Connects to the provider's API and lists available models.
     """
-    from ..config import get_config  # fmt: skip
-
     config = get_config()
 
     # Find the provider config

--- a/gptme/hooks/tests/test_workspace_agents.py
+++ b/gptme/hooks/tests/test_workspace_agents.py
@@ -597,6 +597,96 @@ class TestScanAgents:
 
         assert resolved == "ls"
 
+    def test_claude_session_lookup_caps_recent_file_scan(self, tmp_path: Path) -> None:
+        import gptme.hooks.workspace_agents as mod
+
+        fixed_now = 1_760_000_000.0
+        project_dir = tmp_path / ".claude" / "projects" / "-workspace"
+        project_dir.mkdir(parents=True)
+
+        for i in range(6):
+            session_id = f"session-{i}"
+            prompt = f"recent prompt {i} for bounded scan"
+            timestamp = fixed_now - (300 - i)
+            self._write_claude_session(project_dir, session_id, timestamp, prompt)
+            session_path = project_dir / f"{session_id}.jsonl"
+            os.utime(session_path, (timestamp, timestamp))
+
+        read_count = 0
+        original = mod._read_claude_session_metadata
+
+        def counting_reader(session_file: Path) -> tuple[float | None, str | None]:
+            nonlocal read_count
+            read_count += 1
+            return original(session_file)
+
+        mod._CLAUDE_SESSION_INDEX.clear()
+        with (
+            patch("gptme.hooks.workspace_agents._CLAUDE_SESSION_SCAN_LIMIT", 3),
+            patch(
+                "gptme.hooks.workspace_agents._read_claude_session_metadata",
+                side_effect=counting_reader,
+            ),
+            patch("gptme.hooks.workspace_agents.time.time", return_value=fixed_now),
+        ):
+            resolved = mod._resolve_claude_conversation_id(
+                project_dir,
+                "recent prompt 5 for bounded scan",
+                295,
+            )
+
+        assert resolved == "session-5"
+        assert read_count == 3
+
+    def test_skips_claude_session_lookup_for_stale_process(
+        self, tmp_path: Path
+    ) -> None:
+        fake_pid = 99993
+        workspace = "/workspace"
+        project_dir = tmp_path / ".claude" / "projects" / "-workspace"
+        project_dir.mkdir(parents=True)
+
+        self._write_claude_session(
+            project_dir,
+            "stale-session",
+            1_760_000_000.0 - 600,
+            "stale session should not trigger lookup",
+        )
+
+        with (
+            patch(
+                "gptme.hooks.workspace_agents._get_all_pids", return_value=[fake_pid]
+            ),
+            patch(
+                "gptme.hooks.workspace_agents._get_process_cmdline",
+                return_value=["claude", "-p", "hello"],
+            ),
+            patch(
+                "gptme.hooks.workspace_agents._get_process_cwd",
+                return_value=workspace,
+            ),
+            patch("gptme.hooks.workspace_agents._get_git_branch", return_value="main"),
+            patch(
+                "gptme.hooks.workspace_agents._get_process_timing",
+                return_value=(400_000, 700.0, "S"),
+            ),
+            patch(
+                "gptme.hooks.workspace_agents._get_process_memory_mb",
+                return_value=None,
+            ),
+            patch("gptme.hooks.workspace_agents.Path.home", return_value=tmp_path),
+            patch(
+                "gptme.hooks.workspace_agents._resolve_claude_conversation_id"
+            ) as mock_resolve,
+            patch("os.path.realpath", side_effect=lambda p: p),
+        ):
+            agents = scan_agents(workspace=workspace)
+
+        assert len(agents) == 1
+        assert agents[0].stale is True
+        assert agents[0].conversation_id is None
+        mock_resolve.assert_not_called()
+
     def test_keeps_codex_interactive_and_autonomous_rows_separate(self) -> None:
         pids = [99991, 99992]
 

--- a/gptme/hooks/workspace_agents.py
+++ b/gptme/hooks/workspace_agents.py
@@ -97,6 +97,7 @@ _CLAUDE_SESSION_INDEX: dict[
 ] = {}
 _CLAUDE_SESSION_MAX_DELTA_SECONDS = 15 * 60
 _CLAUDE_SESSION_MIN_UNIQUENESS_SECONDS = 15
+_CLAUDE_SESSION_SCAN_LIMIT = 256
 
 
 # ---------------------------------------------------------------------------
@@ -521,18 +522,41 @@ def _read_claude_session_metadata(
     return session_start, initial_prompt
 
 
+def _claude_session_mtime_ns(session_file: Path) -> int:
+    """Best-effort mtime lookup for transcript ordering."""
+    try:
+        return session_file.stat().st_mtime_ns
+    except OSError:
+        return -1
+
+
 def _get_claude_project_sessions(
     project_dir: Path,
 ) -> list[tuple[float, str, str | None]]:
-    """Index Claude sessions for a workspace project dir, caching by dir mtime."""
+    """Index recent Claude sessions for a workspace project dir.
+
+    Large workspaces can accumulate tens of thousands of Claude transcripts.
+    Scanning every file on every agent scan makes ``gptme-util agents scan``
+    unusably slow, so only the most recently touched transcripts are indexed.
+    Older sessions simply resolve to ``None`` when they fall outside the
+    bounded recent window.
+    """
     try:
         session_files = list(project_dir.glob("*.jsonl"))
         dir_mtime_ns = project_dir.stat().st_mtime_ns
     except OSError:
         return []
 
+    total_sessions = len(session_files)
+    if total_sessions > _CLAUDE_SESSION_SCAN_LIMIT:
+        session_files = sorted(
+            session_files,
+            key=_claude_session_mtime_ns,
+            reverse=True,
+        )[:_CLAUDE_SESSION_SCAN_LIMIT]
+
     cache_key = str(project_dir)
-    cache_signature = (dir_mtime_ns, len(session_files))
+    cache_signature = (dir_mtime_ns, total_sessions)
     cached = _CLAUDE_SESSION_INDEX.get(cache_key)
     if cached and cached[:2] == cache_signature:
         return cached[2]
@@ -954,14 +978,13 @@ def scan_agents(workspace: str | None = None) -> list[AgentInfo]:
         info.cpu_seconds = timing_cpu
         info.process_state = timing_state
         info.memory_mb = _get_process_memory_mb(pid)
-        if info.runtime == "claude-code" and info.log_dir:
+        assess_staleness(info)
+        if info.runtime == "claude-code" and info.log_dir and not info.stale:
             info.conversation_id = _resolve_claude_conversation_id(
                 Path(info.log_dir),
                 info.cmdline_summary,
                 timing_uptime,
             )
-
-        assess_staleness(info)
         agents.append(info)
 
     # Deduplicate: for same runtime+cwd, keep distinct modes; within same mode keep highest PID


### PR DESCRIPTION
## Summary
Reduce `gptme-util agents scan` latency on hosts with large Claude transcript histories.

This fixes the worst offender I found on Bob's VM:
- a stale 4-day Claude Code process under `/home/bob/bob`
- `~/.claude/projects/-home-bob-bob/` containing about 18,978 transcript files
- `_resolve_claude_conversation_id()` dominating scan time by indexing that history even though the stale process is hidden by default

## Changes
- skip Claude conversation-id resolution for processes already classified as stale
- cap Claude transcript indexing to the most recently touched files instead of whole-history scans
- lazy-load heavyweight `gptme-util` subcommands/model helpers so `agents scan` does not import MCP/model code it never uses

## Verification
- `python -m pytest gptme/hooks/tests/test_workspace_agents.py tests/test_util_cli.py -q`
- `ruff check gptme/cli/util.py gptme/hooks/workspace_agents.py gptme/hooks/tests/test_workspace_agents.py`

## Measurements
On Bob's host:
- before: `uv run gptme-util agents scan` about `11.96s` real
- after: `uv run gptme-util agents scan` about `6.47s` real
- after: `scan_agents()` itself about `0.126s`

Under instrumentation before the fix, `_resolve_claude_conversation_id()` accounted for `17.97s` of `18.56s` inside the scanner, so this was not a PID-count problem.
