### PR TITLE
perf(lessons): defer sentence_transformers import (~33s CLI startup savings)

### DIFF
--- a/gptme/lessons/hybrid_matcher.py
+++ b/gptme/lessons/hybrid_matcher.py
@@ -1,5 +1,6 @@
 """Hybrid lesson matching using semantic similarity + effectiveness."""
 
+import importlib.util
 import json
 import logging
 import os
@@ -12,16 +13,14 @@ from .parser import Lesson
 
 logger = logging.getLogger(__name__)
 
-# Optional embedding support
-try:
-    import numpy as np
-    from sentence_transformers import (
-        SentenceTransformer,
-    )
-
-    EMBEDDINGS_AVAILABLE = True
-except ImportError:
-    EMBEDDINGS_AVAILABLE = False
+# Optional embedding support — availability checked lazily to avoid a 10+ second
+# cumulative import of sentence_transformers/transformers/sklearn at CLI startup.
+# The heavy modules are imported on first use inside HybridLessonMatcher.
+EMBEDDINGS_AVAILABLE = (
+    importlib.util.find_spec("sentence_transformers") is not None
+    and importlib.util.find_spec("numpy") is not None
+)
+if not EMBEDDINGS_AVAILABLE:
     logger.info("Embeddings not available, falling back to keyword-only matching")
 
 
@@ -197,10 +196,14 @@ class HybridLessonMatcher(LessonMatcher):
         super().__init__()
         self.config = config or HybridConfig()
 
-        # Initialize embedder if available and enabled
+        # Initialize embedder if available and enabled.
+        # sentence_transformers is imported lazily here (rather than at module top)
+        # because it pulls in transformers + sklearn (~10s cumulative import time).
         self.embedder = None
         if EMBEDDINGS_AVAILABLE and self.config.enable_semantic:
             try:
+                from sentence_transformers import SentenceTransformer
+
                 self.embedder = SentenceTransformer("all-MiniLM-L6-v2")
                 logger.info("Initialized sentence embedder for semantic matching")
             except Exception as e:
@@ -353,6 +356,8 @@ class HybridLessonMatcher(LessonMatcher):
         """Cosine similarity between query and lesson (0.0-1.0)."""
         if not self.embedder:
             return 0.0
+
+        import numpy as np
 
         # Generate lesson embedding from title and body
         lesson_text = f"{lesson.title}\n{lesson.body[:500]}"  # Limit to first 500 chars

--- a/tests/test_hybrid_lessons.py
+++ b/tests/test_hybrid_lessons.py
@@ -395,3 +395,37 @@ def test_semantic_score_zero_norm_returns_zero():
     assert score == 0.0
     assert not np.isnan(score)
     assert not np.isinf(score)
+
+
+def test_hybrid_matcher_does_not_eagerly_import_sentence_transformers():
+    """Importing hybrid_matcher must not trigger a sentence_transformers import.
+
+    sentence_transformers pulls in transformers + sklearn (~10s cumulative).
+    The module-level import was moved inside HybridLessonMatcher.__init__ so the
+    CLI doesn't pay that cost unless hybrid matching is actually used.
+    Regression guard for the perf/lazy-sentence-transformers fix.
+    """
+    import subprocess
+    import sys
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import sys; import gptme.lessons.hybrid_matcher as hm;"
+                " blocked = {'sentence_transformers', 'transformers', 'sklearn'};"
+                " loaded = blocked & set(sys.modules);"
+                " print('LOADED:' + ','.join(sorted(loaded)) if loaded else 'OK');"
+                " sys.exit(1 if loaded else 0)"
+            ),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        f"Heavy deps eagerly imported from gptme.lessons.hybrid_matcher: "
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )

--- a/tests/test_hybrid_lessons.py
+++ b/tests/test_hybrid_lessons.py
@@ -397,6 +397,7 @@ def test_semantic_score_zero_norm_returns_zero():
     assert not np.isinf(score)
 
 
+@pytest.mark.timeout(30)
 def test_hybrid_matcher_does_not_eagerly_import_sentence_transformers():
     """Importing hybrid_matcher must not trigger a sentence_transformers import.
 
@@ -404,6 +405,9 @@ def test_hybrid_matcher_does_not_eagerly_import_sentence_transformers():
     The module-level import was moved inside HybridLessonMatcher.__init__ so the
     CLI doesn't pay that cost unless hybrid matching is actually used.
     Regression guard for the perf/lazy-sentence-transformers fix.
+
+    Timeout override: the default 10s can be too tight on cold CI runners
+    that need to import the gptme package tree in a fresh subprocess.
     """
     import subprocess
     import sys


### PR DESCRIPTION
## Summary

Follow-up to #2207. `gptme/lessons/hybrid_matcher.py` had a module-level `from sentence_transformers import SentenceTransformer` that fired whenever anyone imported `gptme.lessons` (which `gptme.cli.main` does on every startup). For users with the `dspy`, `eval`, or `all` optional extras installed, that single import pulled in `transformers` + `sklearn` and cost ~33s of cumulative import time at CLI startup.

## Measurement

`python -X importtime -c "import gptme.cli.main"` (with `sentence_transformers` available):

| | cumulative import time | `sentence_transformers` loaded? |
|-|-:|:-|
| Before | **54.2s** | yes (33.5s) |
| After | **3.3s** | no |

Wall-clock `gptme --version` is less dramatic (OS file cache hides much of it on repeat runs), but **first-run startup** for users with the optional embedding extras drops by tens of seconds.

For users without the optional extra, behavior is unchanged — the old module-level `try/except ImportError` was already a no-op in that case, and the new `importlib.util.find_spec(...)` check returns `EMBEDDINGS_AVAILABLE = False` without importing anything heavy.

## Changes

- Replace module-level `from sentence_transformers import SentenceTransformer` with `importlib.util.find_spec(...)` availability probe (cheap, no real import).
- Move `from sentence_transformers import SentenceTransformer` inside `HybridLessonMatcher.__init__` so it only runs when `enable_semantic=True` and embeddings are actually requested.
- Move `import numpy as np` inside `_semantic_score` for the same reason (numpy is pulled in by sentence_transformers anyway, but keeps the lazy contract explicit when `sentence_transformers` is absent).
- Add `test_hybrid_matcher_does_not_eagerly_import_sentence_transformers` — runs in a subprocess, imports `gptme.lessons.hybrid_matcher`, asserts `sentence_transformers`/`transformers`/`sklearn` are absent from `sys.modules`. Locks in the lazy-import contract.

## Test plan

- [x] `pytest tests/test_hybrid_lessons.py` — 22/22 pass (with `dspy` extra installed)
- [x] `pytest tests/test_hybrid_lessons.py tests/test_lessons.py tests/test_lessons_matcher.py` — 138/138 pass (without extras)
- [x] `ruff check` clean on touched files
- [x] Regression test confirms heavy deps not loaded after importing `hybrid_matcher`