### PR TITLE
feat(webui): expose provider API key settings

### DIFF
--- a/webui/src/components/settings/ServerApiKeySettings.tsx
+++ b/webui/src/components/settings/ServerApiKeySettings.tsx
@@ -61,13 +61,12 @@ export function ServerApiKeySettings() {
       setSelectedModel('');
       return;
     }
-    if (providerModels.some((model) => model.id === selectedModel)) {
-      return;
-    }
     const preferredModel =
       providerModels.find((model) => recommendedModels.includes(model.id)) || providerModels[0];
-    setSelectedModel(preferredModel.id);
-  }, [providerModels, recommendedModels, selectedModel]);
+    setSelectedModel((current) =>
+      providerModels.some((model) => model.id === current) ? current : preferredModel.id
+    );
+  }, [providerModels, recommendedModels]);
 
   const handleSave = async () => {
     const trimmedApiKey = apiKey.trim();
@@ -95,14 +94,26 @@ export function ServerApiKeySettings() {
         }),
       });
 
-      const data = (await response.json()) as SaveApiKeyResponse | { error?: string };
+      let data: SaveApiKeyResponse | { error?: string } | null = null;
+      try {
+        data = (await response.json()) as SaveApiKeyResponse | { error?: string };
+      } catch {
+        data = null;
+      }
       if (!response.ok) {
-        throw new Error('error' in data && data.error ? data.error : 'Failed to save API key');
+        throw new Error(
+          data && 'error' in data && data.error ? data.error : 'Failed to save API key'
+        );
       }
 
+      const result = data as SaveApiKeyResponse | null;
       setApiKey('');
       refetchSettings();
-      toast.success('API key saved. Restart the server to apply it.');
+      toast.success(
+        result?.restart_required === false
+          ? 'API key saved.'
+          : 'API key saved. Restart the server to apply it.'
+      );
     } catch (error) {
       toast.error(error instanceof Error ? error.message : 'Failed to save API key');
     } finally {

--- a/webui/src/components/settings/ServerApiKeySettings.tsx
+++ b/webui/src/components/settings/ServerApiKeySettings.tsx
@@ -1,0 +1,201 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { useApi } from '@/contexts/ApiContext';
+import { useModels } from '@/hooks/useModels';
+import { useUserSettings } from '@/hooks/useUserSettings';
+import { toast } from 'sonner';
+
+type ApiKeyProvider =
+  | 'anthropic'
+  | 'openai'
+  | 'openrouter'
+  | 'gemini'
+  | 'groq'
+  | 'xai'
+  | 'deepseek';
+
+type SaveApiKeyResponse = {
+  status: string;
+  provider: string;
+  env_var: string;
+  restart_required: boolean;
+};
+
+const PROVIDER_OPTIONS: Array<{
+  value: ApiKeyProvider;
+  label: string;
+  placeholder: string;
+}> = [
+  { value: 'anthropic', label: 'Anthropic', placeholder: 'sk-ant-...' },
+  { value: 'openai', label: 'OpenAI', placeholder: 'sk-...' },
+  { value: 'openrouter', label: 'OpenRouter', placeholder: 'sk-or-...' },
+  { value: 'gemini', label: 'Gemini', placeholder: 'AIza...' },
+  { value: 'groq', label: 'Groq', placeholder: 'gsk_...' },
+  { value: 'xai', label: 'xAI', placeholder: 'xai-...' },
+  { value: 'deepseek', label: 'DeepSeek', placeholder: 'sk-...' },
+];
+
+const PROVIDER_METADATA = Object.fromEntries(
+  PROVIDER_OPTIONS.map((provider) => [provider.value, provider])
+) as Record<ApiKeyProvider, (typeof PROVIDER_OPTIONS)[number]>;
+
+export function ServerApiKeySettings() {
+  const { api } = useApi();
+  const { models, recommendedModels, isLoading: modelsLoading, error: modelsError } = useModels();
+  const { settings, refetch: refetchSettings } = useUserSettings();
+  const [provider, setProvider] = useState<ApiKeyProvider>('anthropic');
+  const [selectedModel, setSelectedModel] = useState('');
+  const [apiKey, setApiKey] = useState('');
+  const [isSaving, setIsSaving] = useState(false);
+
+  const providerModels = useMemo(
+    () => models.filter((model) => model.provider === provider),
+    [models, provider]
+  );
+  const configuredProviders = settings?.providers_configured ?? [];
+
+  useEffect(() => {
+    if (providerModels.length === 0) {
+      setSelectedModel('');
+      return;
+    }
+    if (providerModels.some((model) => model.id === selectedModel)) {
+      return;
+    }
+    const preferredModel =
+      providerModels.find((model) => recommendedModels.includes(model.id)) || providerModels[0];
+    setSelectedModel(preferredModel.id);
+  }, [providerModels, recommendedModels, selectedModel]);
+
+  const handleSave = async () => {
+    const trimmedApiKey = apiKey.trim();
+    if (!trimmedApiKey) {
+      toast.error('Enter an API key before saving.');
+      return;
+    }
+
+    setIsSaving(true);
+    try {
+      const headers: Record<string, string> = {
+        'Content-Type': 'application/json',
+      };
+      if (api.authHeader) {
+        headers.Authorization = api.authHeader;
+      }
+
+      const response = await fetch(`${api.baseUrl}/api/v2/user/api-key`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          provider,
+          api_key: trimmedApiKey,
+          ...(selectedModel ? { model: selectedModel } : {}),
+        }),
+      });
+
+      const data = (await response.json()) as SaveApiKeyResponse | { error?: string };
+      if (!response.ok) {
+        throw new Error('error' in data && data.error ? data.error : 'Failed to save API key');
+      }
+
+      setApiKey('');
+      refetchSettings();
+      toast.success('API key saved. Restart the server to apply it.');
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to save API key');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <div className="space-y-3 rounded-lg border p-4">
+      <div>
+        <h4 className="text-sm font-medium">Provider API key</h4>
+        <p className="text-sm text-muted-foreground">
+          Save a provider key into the server config without editing files by hand.
+        </p>
+      </div>
+
+      {configuredProviders.length > 0 && (
+        <div className="flex flex-wrap gap-1">
+          {configuredProviders.map((configuredProvider) => (
+            <span
+              key={configuredProvider}
+              className="rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground"
+            >
+              {configuredProvider}
+            </span>
+          ))}
+        </div>
+      )}
+
+      <div className="flex flex-col gap-2">
+        <Label htmlFor="settings-api-key-provider">Provider</Label>
+        <select
+          id="settings-api-key-provider"
+          className="h-9 rounded-md border bg-background px-3 text-sm"
+          value={provider}
+          onChange={(event) => setProvider(event.target.value as ApiKeyProvider)}
+          disabled={isSaving}
+        >
+          {PROVIDER_OPTIONS.map((providerOption) => (
+            <option key={providerOption.value} value={providerOption.value}>
+              {providerOption.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <Label htmlFor="settings-api-key-model">Default model</Label>
+        <select
+          id="settings-api-key-model"
+          className="h-9 rounded-md border bg-background px-3 text-sm"
+          value={selectedModel}
+          onChange={(event) => setSelectedModel(event.target.value)}
+          disabled={isSaving || modelsLoading || providerModels.length === 0}
+        >
+          {providerModels.length === 0 ? (
+            <option value="">{modelsLoading ? 'Loading models…' : 'No models available'}</option>
+          ) : (
+            providerModels.map((model) => (
+              <option key={model.id} value={model.id}>
+                {model.model}
+              </option>
+            ))
+          )}
+        </select>
+        <p className="text-xs text-muted-foreground">
+          Optional. Saving a model also updates the server default.
+        </p>
+        {modelsError && <p className="text-xs text-destructive">{modelsError}</p>}
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <Label htmlFor="settings-api-key-input">API key</Label>
+        <Input
+          id="settings-api-key-input"
+          type="password"
+          autoComplete="off"
+          spellCheck={false}
+          placeholder={PROVIDER_METADATA[provider].placeholder}
+          value={apiKey}
+          onChange={(event) => setApiKey(event.target.value)}
+          disabled={isSaving}
+        />
+      </div>
+
+      <Button
+        type="button"
+        variant="outline"
+        onClick={() => void handleSave()}
+        disabled={isSaving || apiKey.trim().length === 0}
+      >
+        {isSaving ? 'Saving…' : 'Save API key'}
+      </Button>
+    </div>
+  );
+}

--- a/webui/src/components/settings/ServerConfiguration.tsx
+++ b/webui/src/components/settings/ServerConfiguration.tsx
@@ -28,6 +28,7 @@ import type { ServerConfig } from '@/types/servers';
 import { toast } from 'sonner';
 import { cn } from '@/lib/utils';
 import { ServerDefaultModelSettings } from './ServerDefaultModelSettings';
+import { ServerApiKeySettings } from './ServerApiKeySettings';
 
 interface ServerFormState {
   name: string;
@@ -347,6 +348,7 @@ export const ServerConfiguration: FC = () => {
         })}
       </div>
 
+      <ServerApiKeySettings />
       <ServerDefaultModelSettings />
 
       <Button variant="outline" onClick={handleOpenAdd}>

--- a/webui/src/components/settings/__tests__/ServerApiKeySettings.test.tsx
+++ b/webui/src/components/settings/__tests__/ServerApiKeySettings.test.tsx
@@ -1,0 +1,125 @@
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { ServerApiKeySettings } from '../ServerApiKeySettings';
+
+const mockSuccess = jest.fn();
+const mockError = jest.fn();
+const mockFetch = jest.fn();
+const mockRefetch = jest.fn();
+
+jest.mock('@/contexts/ApiContext', () => ({
+  useApi: () => ({
+    api: {
+      baseUrl: 'http://127.0.0.1:5700',
+      authHeader: 'Bearer test-token',
+    },
+  }),
+}));
+
+jest.mock('@/hooks/useModels', () => ({
+  useModels: () => ({
+    models: [
+      {
+        id: 'anthropic/claude-sonnet-4-7',
+        provider: 'anthropic',
+        model: 'claude-sonnet-4-7',
+      },
+      {
+        id: 'openai/gpt-4.1',
+        provider: 'openai',
+        model: 'gpt-4.1',
+      },
+    ],
+    recommendedModels: ['anthropic/claude-sonnet-4-7'],
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+jest.mock('@/hooks/useUserSettings', () => ({
+  useUserSettings: () => ({
+    settings: {
+      providers_configured: ['anthropic'],
+      default_model: 'anthropic/claude-sonnet-4-7',
+    },
+    isLoading: false,
+    error: null,
+    refetch: mockRefetch,
+  }),
+}));
+
+jest.mock('@/components/ui/button', () => ({
+  Button: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button {...props}>{children}</button>
+  ),
+}));
+
+jest.mock('@/components/ui/input', () => ({
+  Input: (props: React.InputHTMLAttributes<HTMLInputElement>) => <input {...props} />,
+}));
+
+jest.mock('@/components/ui/label', () => ({
+  Label: ({
+    children,
+    ...props
+  }: React.LabelHTMLAttributes<HTMLLabelElement> & { children: React.ReactNode }) => (
+    <label {...props}>{children}</label>
+  ),
+}));
+
+jest.mock('sonner', () => ({
+  toast: {
+    success: (...args: unknown[]) => mockSuccess(...args),
+    error: (...args: unknown[]) => mockError(...args),
+  },
+}));
+
+describe('ServerApiKeySettings', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    mockSuccess.mockReset();
+    mockError.mockReset();
+    mockRefetch.mockReset();
+    Object.defineProperty(window, 'fetch', {
+      writable: true,
+      value: mockFetch,
+    });
+  });
+
+  it('saves provider API keys through the server API', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        status: 'ok',
+        provider: 'anthropic',
+        env_var: 'ANTHROPIC_API_KEY',
+        restart_required: true,
+      }),
+    });
+
+    render(<ServerApiKeySettings />);
+
+    fireEvent.change(screen.getByLabelText(/api key/i), {
+      target: { value: '  sk-ant-test-key  ' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /save api key/i }));
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith('http://127.0.0.1:5700/api/v2/user/api-key', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer test-token',
+        },
+        body: JSON.stringify({
+          provider: 'anthropic',
+          api_key: 'sk-ant-test-key',
+          model: 'anthropic/claude-sonnet-4-7',
+        }),
+      });
+    });
+
+    expect(mockSuccess).toHaveBeenCalledWith('API key saved. Restart the server to apply it.');
+    expect(mockRefetch).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add a Servers settings card for saving provider API keys through `/api/v2/user/api-key`
- let users choose provider + default model from the webui settings panel
- wire the card into the existing Servers tab and add a focused Jest test

Refs #2193.

## Tests
- npm test -- --runTestsByPath src/components/settings/__tests__/ServerApiKeySettings.test.tsx --runInBand
- npm run typecheck
- npx eslint src/components/settings/ServerApiKeySettings.tsx src/components/settings/__tests__/ServerApiKeySettings.test.tsx src/components/settings/ServerConfiguration.tsx