### PR TITLE
fix(release): use creatordate sorting for previous tag detection

### DIFF
--- a/scripts/bump_version.sh
+++ b/scripts/bump_version.sh
@@ -47,11 +47,12 @@ cd "$REPO_ROOT"
 # --- Shared: find last stable and last tag ---
 
 LAST_STABLE=$(git tag --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1 || true)
-# Use --sort to find the most recent tag by version, including dev tags that may not be
-# reachable from the current branch (dev release commits are not pushed to master).
-# `git describe --tags --abbrev=0` only finds tags reachable from HEAD, which misses
-# dev tags whose version-bump commits are floating off master.
-LAST_TAG=$(git tag --sort=-version:refname | head -1 || echo "")
+# Use creatordate sort to find the most recent tag chronologically.
+# We can't use version:refname because collision-suffixed dev tags like
+# v0.31.1.dev202603103 sort higher than later dates like v0.31.1.dev20260423.
+# We can't use `git describe --tags --abbrev=0` because it only finds tags
+# reachable from HEAD, missing dev tags whose commits float off master.
+LAST_TAG=$(git tag --sort=-creatordate | head -1 || echo "")
 
 if [ -z "$LAST_STABLE" ]; then
     echo "Error: No stable release tag found (vX.Y.Z). Create an initial release manually first." >&2

--- a/scripts/publish_release.sh
+++ b/scripts/publish_release.sh
@@ -42,8 +42,10 @@ if ! git tag --points-at HEAD | grep -q "^${TAG}$"; then
     exit 1
 fi
 
-# Find previous tag of any kind (excluding the one we just created)
-PREV_TAG=$(git tag --sort=-version:refname | grep -v "^${TAG}$" | head -1 || true)
+# Find previous tag of any kind (excluding the one we just created).
+# Use creatordate sort instead of version:refname because collision-suffixed
+# dev tags (e.g. v0.31.1.dev202603103) sort higher than later dates.
+PREV_TAG=$(git tag --sort=-creatordate | grep -v "^${TAG}$" | head -1 || true)
 
 # Find previous stable tag (excluding the one we just created)
 PREV_STABLE=$(git tag --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | grep -v "^${TAG}$" | head -1 || true)


### PR DESCRIPTION
## Summary

- Dev release notes have been showing changes since `v0.31.1.dev202603103` (March 10) instead of the actual previous release, because collision-suffixed tags sort higher numerically (`202603103 > 20260423`)
- Switches `git tag --sort` from `-version:refname` to `-creatordate` for finding the previous tag in both `bump_version.sh` and `publish_release.sh`
- Stable tag lookups (`LAST_STABLE`/`PREV_STABLE`) are unchanged since they filter to `vX.Y.Z` which doesn't have this issue

## Test plan

- [ ] Verify next scheduled dev release shows only incremental changes since the previous release, not since March 10