### PR TITLE
fix(reduce): skip unfindable codeblocks instead of asserting

### DIFF
--- a/gptme/util/reduce.py
+++ b/gptme/util/reduce.py
@@ -79,9 +79,19 @@ def truncate_msg(msg: Message, lines_pre=10, lines_post=10) -> Message | None:
 
     # Truncate long codeblocks
     for codeblock in msg.get_codeblocks():
-        # check that the reformatted codeblock is in the content
+        # Reformatted codeblock must be present in content for .replace() to work.
+        # Round-trip parsing may produce a slightly different rendering than the
+        # original (e.g. mixed fence styles, nested fences). Skip rather than crash
+        # the whole reduction pass — other codeblocks may still be truncatable.
         full_block = codeblock.to_markdown()
-        assert full_block in content_staged, f"{full_block} not in {content_staged}"
+        if full_block not in content_staged:
+            logger.warning(
+                "truncate_msg: reformatted codeblock not found in content; "
+                "skipping. lang=%s lines=%d",
+                codeblock.lang,
+                codeblock.content.count("\n") + 1,
+            )
+            continue
 
         # truncate the middle part of the codeblock, keeping the first and last n lines
         lines = codeblock.content.split("\n")

--- a/tests/test_reduce.py
+++ b/tests/test_reduce.py
@@ -145,6 +145,51 @@ def test_reduce_log_all_pinned():
     assert reduced == msgs
 
 
+def test_truncate_msg_skips_unfindable_codeblock(monkeypatch):
+    """If a codeblock's reformatted markdown is not in the content, skip it.
+
+    Regression: before this fix, truncate_msg asserted
+    ``full_block in content_staged`` and crashed the entire reduction pass
+    when the round-trip reconstruction diverged from the original. The
+    session-level symptom was an unhandled AssertionError and exit code 1
+    in long-context autonomous runs (Bob 2026-04-24, minimax-m2.7 session).
+    """
+    real_block_lines = "\n".join(f"real_{i}" for i in range(50))
+    truncatable_lines = "\n".join(f"trunc_{i}" for i in range(50))
+    # Original content has a codeblock with content `real_*`, and a fully
+    # well-formed codeblock with content `trunc_*` that should still be
+    # truncated even if the first one cannot be round-tripped.
+    content = (
+        f"```python\n{real_block_lines}\n```\n\n```python\n{truncatable_lines}\n```"
+    )
+    msg = Message("assistant", content=content)
+
+    # Fake extra codeblock whose to_markdown() output is not present in content.
+    class FakeCodeblock:
+        lang = "python"
+        content = "x = 1"
+        fence = "```"
+
+        def to_markdown(self) -> str:
+            return "```python\ndoes-not-appear-in-content\n```"
+
+    real_get_codeblocks = Message.get_codeblocks
+
+    def patched_get_codeblocks(self):
+        blocks = real_get_codeblocks(self)
+        # Prepend the fake one so the skip path runs before a real truncation.
+        return [FakeCodeblock(), *blocks]
+
+    monkeypatch.setattr(Message, "get_codeblocks", patched_get_codeblocks)
+
+    truncated = truncate_msg(msg)
+    # Truncation still succeeds via the real codeblock.
+    assert truncated is not None
+    assert "[...]" in truncated.content
+    assert "trunc_0" in truncated.content
+    assert "trunc_49" in truncated.content
+
+
 def test_truncate_msg_quad_fence():
     """Quadruple-backtick codeblocks (e.g. from md_codeblock) must survive truncation.
 


### PR DESCRIPTION
## Summary

`truncate_msg` asserted that every codeblock's reformatted markdown (`codeblock.to_markdown()`) must appear verbatim in the message content. When the round-trip parse + reconstruction diverges from the original — mixed fence styles, nested fences, exotic lang tags — the assertion crashes the entire reduction pass, producing an unhandled `AssertionError` and exiting mid-session.

Behavior change: when a codeblock can't be found after round-trip, log a warning and continue to the next codeblock. The outer reducer (`reduce_log`) already handles the no-progress case, so skipping is safe — other codeblocks in the same message may still be truncated, and `reduce_log` decides what to do next based on the resulting token count.

## Context

Observed in a long-context autonomous run on 2026-04-24: a gptme session running on `minimax-m2.7` hit the context limit at ~708k tokens, `truncate_msg` tried to reduce it, and the process exited with code 1. Log excerpt:

```
[00:37:42] INFO     Log exceeded limit of 176947.2, was 177023, reducing   reduce.py:39
           ERROR    Fatal error occurred                                   main.py:701
           ERROR    [dumps large codeblock content]                        main.py:705
           ERROR    at /home/bob/bob/.venv/lib/python3.12/site-packages
                    /gptme/util/reduce.py:84 in truncate_msg               main.py:720
Session exited with code 1
```

Related prior fix: #1947 addressed fence-length preservation for quad-backtick blocks. This PR closes the remaining robustness gap by removing the crash path entirely — any round-trip mismatch now logs and continues instead of aborting.

## Test plan

- [x] Added `test_truncate_msg_skips_unfindable_codeblock` — monkeypatches `Message.get_codeblocks` to inject a codeblock whose `to_markdown()` output is absent from content, and verifies truncation still succeeds on the neighbouring real codeblock.
- [x] All 11 tests in `tests/test_reduce.py` pass locally (including the existing `test_truncate_msg_quad_fence` regression from #1947).

```
tests/test_reduce.py::test_truncate_msg PASSED
tests/test_reduce.py::test_truncate_details_block PASSED
tests/test_reduce.py::test_truncate_details_short PASSED
tests/test_reduce.py::test_truncate_details_no_summary PASSED
tests/test_reduce.py::test_truncate_details_and_codeblocks PASSED
tests/test_reduce.py::test_truncate_details_helper PASSED
tests/test_reduce.py::test_truncate_details_nested PASSED
tests/test_reduce.py::test_reduce_log_all_pinned PASSED
tests/test_reduce.py::test_truncate_msg_skips_unfindable_codeblock PASSED
tests/test_reduce.py::test_truncate_msg_quad_fence PASSED
tests/test_reduce.py::test_reduce_log PASSED
============================== 11 passed in 2.86s ==============================
```