### PR TITLE
feat(context): show truncation savings in /context

### DIFF
--- a/gptme/commands/llm.py
+++ b/gptme/commands/llm.py
@@ -279,7 +279,9 @@ def cmd_context(ctx: CommandContext) -> None:
             f"{savings.entries} truncated tool output(s)"
         )
         for source, saved_tokens in sorted(
-            savings.saved_tokens_by_source.items(), key=lambda item: item[0]
+            savings.saved_tokens_by_source.items(),
+            key=lambda item: item[1],
+            reverse=True,
         ):
             calls = savings.calls_by_source[source]
             console.log(

--- a/gptme/commands/llm.py
+++ b/gptme/commands/llm.py
@@ -214,6 +214,7 @@ def cmd_context(ctx: CommandContext) -> None:
     from ..llm.models import get_default_model  # fmt: skip
     from ..tools import ToolUse  # fmt: skip
     from ..util import console  # fmt: skip
+    from ..util.context_savings import summarize_context_savings  # fmt: skip
     from ..util.tokens import len_tokens  # fmt: skip
 
     # Try to use the current model's tokenizer, fallback to gpt-4
@@ -268,6 +269,25 @@ def cmd_context(ctx: CommandContext) -> None:
         console.log(f"  {type_name:10s}: {tokens:6,} ({pct:5.1f}%)")
 
     console.log(f"\n[bold]Total Context:[/bold] {total_tokens:,} tokens")
+
+    savings = summarize_context_savings(ctx.manager.logdir)
+    if savings.entries:
+        console.log("\n[bold]Context Savings:[/bold]")
+        console.log(
+            "  "
+            f"{savings.total_saved_tokens:,} tokens saved across "
+            f"{savings.entries} truncated tool output(s)"
+        )
+        for source, saved_tokens in sorted(
+            savings.saved_tokens_by_source.items(), key=lambda item: item[0]
+        ):
+            calls = savings.calls_by_source[source]
+            console.log(
+                f"  {source:10s}: {saved_tokens:6,} tokens across {calls} call(s)"
+            )
+        console.log(
+            f"[dim]  largest single save: {savings.max_saved_tokens:,} tokens[/dim]"
+        )
 
     # Show context window utilization if model info is available
     if current_model and current_model.context > 0:

--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -1365,11 +1365,14 @@ def _shorten_stdout(
     will_truncate_by_tokens = False
     tokenizer = None
     tokens: list[int] = []
+    # Resolved lazily on first use, reused by tokenizer + savings-recording paths.
+    model_name: str | None = None
     if pre_tokens is not None and post_tokens is not None:
         from ..llm.models import get_default_model  # fmt: skip
 
         model = get_default_model()
-        tokenizer = get_tokenizer(model.model if model else "gpt-4")
+        model_name = model.model if model else "gpt-4"
+        tokenizer = get_tokenizer(model_name)
         if tokenizer is not None:
             tokens = tokenizer.encode(stdout)
             will_truncate_by_tokens = len(tokens) > pre_tokens + post_tokens
@@ -1459,10 +1462,11 @@ def _shorten_stdout(
     result = "\n".join(lines)
 
     if saved_path and logdir:
-        from ..llm.models import get_default_model  # fmt: skip
+        if model_name is None:
+            from ..llm.models import get_default_model  # fmt: skip
 
-        model = get_default_model()
-        model_name = model.model if model else "gpt-4"
+            model = get_default_model()
+            model_name = model.model if model else "gpt-4"
         record_context_savings(
             logdir=logdir,
             source="shell",

--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -1432,7 +1432,9 @@ def _shorten_stdout(
     # check that if pre_tokens is set, so is post_tokens, and vice versa
     assert (pre_tokens is None) == (post_tokens is None)
     if pre_tokens is not None and post_tokens is not None:
-        if not will_truncate_by_tokens:
+        if not will_truncate_by_tokens and tokenizer is None:
+            # tokenizer may still be unavailable (char-based estimate used above);
+            # try once more for a precise check before deciding not to truncate.
             from ..llm.models import get_default_model  # fmt: skip
 
             model = get_default_model()

--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -31,8 +31,9 @@ from ..message import Message
 from ..util import get_installed_programs
 from ..util.ask_execute import execute_with_confirmation
 from ..util.context import md_codeblock
+from ..util.context_savings import record_context_savings
 from ..util.output_storage import save_large_output
-from ..util.tokens import get_tokenizer
+from ..util.tokens import get_tokenizer, len_tokens
 from .base import (
     Parameter,
     ToolSpec,
@@ -1455,7 +1456,23 @@ def _shorten_stdout(
             truncation_msg += ") ..."
             lines = [stdout[:pre_chars]] + [truncation_msg] + [stdout[-post_chars:]]
 
-    return "\n".join(lines)
+    result = "\n".join(lines)
+
+    if saved_path and logdir:
+        from ..llm.models import get_default_model  # fmt: skip
+
+        model = get_default_model()
+        model_name = model.model if model else "gpt-4"
+        record_context_savings(
+            logdir=logdir,
+            source="shell",
+            original_tokens=len_tokens(stdout, model_name),
+            kept_tokens=len_tokens(result, model_name),
+            command_info=cmd,
+            saved_path=saved_path,
+        )
+
+    return result
 
 
 def _find_max_heredoc_pos(node, current_max: int = 0) -> int:

--- a/gptme/util/context_savings.py
+++ b/gptme/util/context_savings.py
@@ -1,0 +1,100 @@
+"""Per-conversation telemetry for context saved by truncating large tool outputs."""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections import defaultdict
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+CONTEXT_SAVINGS_FILENAME = "context-savings.jsonl"
+
+
+@dataclass(frozen=True)
+class ContextSavingsSummary:
+    entries: int = 0
+    total_saved_tokens: int = 0
+    max_saved_tokens: int = 0
+    saved_tokens_by_source: dict[str, int] = field(default_factory=dict)
+    calls_by_source: dict[str, int] = field(default_factory=dict)
+
+
+def _ledger_path(logdir: Path) -> Path:
+    return logdir / CONTEXT_SAVINGS_FILENAME
+
+
+def record_context_savings(
+    logdir: Path,
+    source: str,
+    original_tokens: int,
+    kept_tokens: int,
+    command_info: str | None = None,
+    saved_path: Path | None = None,
+) -> None:
+    """Append one truncation-savings record for the current conversation."""
+    saved_tokens = original_tokens - kept_tokens
+    if saved_tokens <= 0:
+        return
+
+    ledger_path = _ledger_path(logdir)
+    ledger_path.parent.mkdir(parents=True, exist_ok=True)
+
+    payload = {
+        "ts": datetime.now(timezone.utc).isoformat(),
+        "source": source,
+        "original_tokens": original_tokens,
+        "kept_tokens": kept_tokens,
+        "saved_tokens": saved_tokens,
+    }
+    if command_info:
+        payload["command_info"] = command_info
+    if saved_path:
+        payload["saved_path"] = str(saved_path)
+
+    with ledger_path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(payload) + "\n")
+
+
+def summarize_context_savings(logdir: Path) -> ContextSavingsSummary:
+    """Aggregate truncation-savings records for a conversation."""
+    ledger_path = _ledger_path(logdir)
+    if not ledger_path.exists():
+        return ContextSavingsSummary()
+
+    saved_tokens_by_source: defaultdict[str, int] = defaultdict(int)
+    calls_by_source: defaultdict[str, int] = defaultdict(int)
+    entries = 0
+    total_saved_tokens = 0
+    max_saved_tokens = 0
+
+    for line in ledger_path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError:
+            logger.warning("Skipping malformed context-savings row: %r", line[:200])
+            continue
+
+        saved_tokens = int(row.get("saved_tokens") or 0)
+        source = str(row.get("source") or "unknown")
+        entries += 1
+        total_saved_tokens += saved_tokens
+        max_saved_tokens = max(max_saved_tokens, saved_tokens)
+        saved_tokens_by_source[source] += saved_tokens
+        calls_by_source[source] += 1
+
+    return ContextSavingsSummary(
+        entries=entries,
+        total_saved_tokens=total_saved_tokens,
+        max_saved_tokens=max_saved_tokens,
+        saved_tokens_by_source=dict(saved_tokens_by_source),
+        calls_by_source=dict(calls_by_source),
+    )

--- a/gptme/util/context_savings.py
+++ b/gptme/util/context_savings.py
@@ -17,8 +17,11 @@ logger = logging.getLogger(__name__)
 CONTEXT_SAVINGS_FILENAME = "context-savings.jsonl"
 
 
-@dataclass(frozen=True)
+@dataclass
 class ContextSavingsSummary:
+    # Not frozen: the dict fields would still be mutable under frozen=True,
+    # which makes the annotation misleading. Callers should treat instances as
+    # read-only by convention.
     entries: int = 0
     total_saved_tokens: int = 0
     max_saved_tokens: int = 0

--- a/tests/test_commands_llm.py
+++ b/tests/test_commands_llm.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from gptme.commands.base import CommandContext
+from gptme.commands.llm import cmd_context
+from gptme.message import Message
+from gptme.util.context_savings import record_context_savings
+
+
+def _make_manager(logdir: Path) -> MagicMock:
+    manager = MagicMock()
+    manager.log = MagicMock()
+    manager.log.messages = [
+        Message("user", "hello"),
+        Message("assistant", "world"),
+    ]
+    manager.logdir = logdir
+    return manager
+
+
+def test_cmd_context_reports_context_savings(tmp_path: Path):
+    record_context_savings(
+        logdir=tmp_path,
+        source="shell",
+        original_tokens=1200,
+        kept_tokens=300,
+        command_info="git log --oneline",
+        saved_path=tmp_path / "tool-outputs" / "shell" / "saved.txt",
+    )
+    ctx = CommandContext(args=[], full_args="", manager=_make_manager(tmp_path))
+
+    with (
+        patch("gptme.llm.models.get_default_model", return_value=None),
+        patch("gptme.util.console.log") as mock_log,
+    ):
+        cmd_context(ctx)
+
+    output = "\n".join(str(call.args[0]) for call in mock_log.call_args_list)
+    assert "Context Savings" in output
+    assert "900" in output
+    assert "shell" in output

--- a/tests/test_tools_shell.py
+++ b/tests/test_tools_shell.py
@@ -1,3 +1,4 @@
+import json
 import os
 import tempfile
 from collections.abc import Generator
@@ -462,6 +463,27 @@ def test_shorten_stdout_blanklines():
 
 l2"""
     assert _shorten_stdout(s) == s
+
+
+def test_shorten_stdout_records_context_savings(tmp_path):
+    stdout = "\n".join(f"line {i}" for i in range(200))
+
+    shortened = _shorten_stdout(
+        stdout,
+        pre_lines=5,
+        post_lines=5,
+        logdir=tmp_path,
+        cmd="git log --oneline",
+    )
+
+    ledger = tmp_path / "context-savings.jsonl"
+    rows = [json.loads(line) for line in ledger.read_text().splitlines()]
+
+    assert "full output saved to" in shortened
+    assert len(rows) == 1
+    assert rows[0]["source"] == "shell"
+    assert rows[0]["command_info"] == "git log --oneline"
+    assert rows[0]["saved_tokens"] > 0
 
 
 def test_is_denylisted_pattern_matches():

--- a/tests/test_util_context_savings.py
+++ b/tests/test_util_context_savings.py
@@ -1,0 +1,78 @@
+import json
+from pathlib import Path
+
+from gptme.util.context_savings import (
+    CONTEXT_SAVINGS_FILENAME,
+    record_context_savings,
+    summarize_context_savings,
+)
+
+
+def test_record_context_savings_appends_jsonl(tmp_path: Path):
+    saved_path = tmp_path / "tool-outputs" / "shell" / "saved.txt"
+    saved_path.parent.mkdir(parents=True)
+    saved_path.write_text("full output")
+
+    record_context_savings(
+        logdir=tmp_path,
+        source="shell",
+        original_tokens=1200,
+        kept_tokens=240,
+        command_info="git log --oneline",
+        saved_path=saved_path,
+    )
+
+    ledger = tmp_path / CONTEXT_SAVINGS_FILENAME
+    rows = [json.loads(line) for line in ledger.read_text().splitlines()]
+    assert len(rows) == 1
+    assert rows[0]["source"] == "shell"
+    assert rows[0]["original_tokens"] == 1200
+    assert rows[0]["kept_tokens"] == 240
+    assert rows[0]["saved_tokens"] == 960
+    assert rows[0]["command_info"] == "git log --oneline"
+    assert rows[0]["saved_path"] == str(saved_path)
+
+
+def test_summarize_context_savings_aggregates_per_source(tmp_path: Path):
+    record_context_savings(
+        logdir=tmp_path,
+        source="shell",
+        original_tokens=1000,
+        kept_tokens=300,
+        command_info="gh issue list",
+        saved_path=tmp_path / "one.txt",
+    )
+    record_context_savings(
+        logdir=tmp_path,
+        source="shell",
+        original_tokens=900,
+        kept_tokens=400,
+        command_info="git log --oneline",
+        saved_path=tmp_path / "two.txt",
+    )
+    record_context_savings(
+        logdir=tmp_path,
+        source="tmux",
+        original_tokens=500,
+        kept_tokens=200,
+        command_info="capture-pane",
+        saved_path=tmp_path / "three.txt",
+    )
+
+    summary = summarize_context_savings(tmp_path)
+
+    assert summary.entries == 3
+    assert summary.total_saved_tokens == 1500
+    assert summary.saved_tokens_by_source == {"shell": 1200, "tmux": 300}
+    assert summary.calls_by_source == {"shell": 2, "tmux": 1}
+    assert summary.max_saved_tokens == 700
+
+
+def test_summarize_context_savings_missing_file(tmp_path: Path):
+    summary = summarize_context_savings(tmp_path)
+
+    assert summary.entries == 0
+    assert summary.total_saved_tokens == 0
+    assert summary.saved_tokens_by_source == {}
+    assert summary.calls_by_source == {}
+    assert summary.max_saved_tokens == 0


### PR DESCRIPTION
## Summary
- record per-conversation token savings when the shell tool truncates oversized output and saves the full result to disk
- surface those totals in `/context`, including per-source breakdown and largest single save
- add regression coverage for the ledger utility, shell hook, and `/context` display

This is the telemetry-first slice of the larger high-output compaction idea: make the current truncation path measurable before adding proactive wrappers.

## Testing
- `uv run pytest tests/test_util_context_savings.py tests/test_tools_shell.py tests/test_commands_llm.py -q`
- `uv run ruff check gptme/commands/llm.py gptme/tools/shell.py gptme/util/context_savings.py tests/test_tools_shell.py tests/test_commands_llm.py tests/test_util_context_savings.py`
