### PR TITLE
fix(server): apply provider API key to os.environ immediately (no restart needed)

### DIFF
--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -6,6 +6,7 @@ Session management, tool execution, and agent creation are handled by separate m
 """
 
 import logging
+import os
 import shutil
 from dataclasses import replace
 from datetime import datetime, timezone
@@ -1401,13 +1402,23 @@ def api_user_api_key():
     set_config_value(f"env.{env_var}", trimmed_api_key, reload=False)
     if trimmed_model is not None:
         set_config_value("env.MODEL", trimmed_model, reload=False)
-    logger.info("Saved %s to user config via /api/v2/user/api-key", env_var)
+
+    # Apply the new key immediately so the running server picks it up without restart.
+    # os.environ takes priority over the config file in Config.get_env(), so the next
+    # LLM call will use the new key.
+    os.environ[env_var] = trimmed_api_key
+    if trimmed_model is not None:
+        os.environ["MODEL"] = trimmed_model
+
+    logger.info(
+        "Saved %s to user config via /api/v2/user/api-key (applied live)", env_var
+    )
     return flask.jsonify(
         {
             "status": "ok",
             "provider": provider,
             "env_var": env_var,
-            "restart_required": True,
+            "restart_required": False,
         }
     )
 

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -126,11 +126,34 @@ def test_v2_user_api_key_persists_env_entry(client: FlaskClient, tmp_path, monke
         "status": "ok",
         "provider": "anthropic",
         "env_var": "ANTHROPIC_API_KEY",
-        "restart_required": True,
+        "restart_required": False,
     }
 
     saved = tomlkit.loads(config_file.read_text()).unwrap()
     assert saved["env"]["ANTHROPIC_API_KEY"] == "sk-ant-test-key"
+
+
+def test_v2_user_api_key_applies_to_env_immediately(
+    client: FlaskClient, tmp_path, monkeypatch
+):
+    """Saving an API key should apply it to os.environ immediately (no restart needed)."""
+    import os
+
+    import gptme.config.user as user_mod
+
+    config_file = tmp_path / "config.toml"
+    monkeypatch.setattr(user_mod, "config_path", str(config_file))
+    monkeypatch.setattr("gptme.config.core.reload_config", lambda: None)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+    response = client.post(
+        "/api/v2/user/api-key",
+        json={"provider": "anthropic", "api_key": "sk-ant-live-key"},
+    )
+
+    assert response.status_code == 200
+    assert response.get_json()["restart_required"] is False
+    assert os.environ.get("ANTHROPIC_API_KEY") == "sk-ant-live-key"
 
 
 def test_v2_user_api_key_persists_default_model(

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -114,6 +114,7 @@ def test_v2_user_api_key_persists_env_entry(client: FlaskClient, tmp_path, monke
     config_file = tmp_path / "config.toml"
     monkeypatch.setattr(user_mod, "config_path", str(config_file))
     monkeypatch.setattr("gptme.config.core.reload_config", lambda: None)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
 
     response = client.post(
         "/api/v2/user/api-key",
@@ -165,6 +166,8 @@ def test_v2_user_api_key_persists_default_model(
     config_file = tmp_path / "config.toml"
     monkeypatch.setattr(user_mod, "config_path", str(config_file))
     monkeypatch.setattr("gptme.config.core.reload_config", lambda: None)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("MODEL", raising=False)
 
     response = client.post(
         "/api/v2/user/api-key",


### PR DESCRIPTION
## Problem

Saving a provider API key via `POST /api/v2/user/api-key` only wrote the key
to the config file and always returned `restart_required: true`. The key was
only available after a server restart, causing the webui to show:

> "API key saved. Restart the server to apply it."

## Fix

After persisting the key to config, also set `os.environ[env_var]` (and
`os.environ["MODEL"]` when a model is specified). Since `Config.get_env()`
reads `os.environ` first, the running server picks up the new key immediately
for the next LLM call.

Now returns `restart_required: false`, and the webui shows just:
> "API key saved."

## Changes

- `gptme/server/api_v2.py`: add `os` import, set `os.environ` after saving to config, return `restart_required: False`
- `tests/test_server_v2.py`: update `restart_required` assertion to `False`; add `test_v2_user_api_key_applies_to_env_immediately` verifying `os.environ` is set

## Testing

```
uv run pytest tests/test_server_v2.py -k "api_key" -v
# 5 passed
```