### PR TITLE
ci(webui): upload dist artifact on master builds

### DIFF
--- a/.github/workflows/webui.yml
+++ b/.github/workflows/webui.yml
@@ -45,6 +45,14 @@ jobs:
     - name: Build
       run: npm run build
 
+    - name: Upload dist artifact
+      if: github.ref == 'refs/heads/master'
+      uses: actions/upload-artifact@v6
+      with:
+        name: webui-dist
+        path: webui/dist
+        retention-days: 30
+
   e2e:
     runs-on: ubuntu-latest
     needs: build


### PR DESCRIPTION
## Summary

Adds a single `upload-artifact` step to `webui.yml` so every master build produces a deployable `webui-dist` artifact (30-day retention). No behavior change for PRs.

## Why

`chat.gptme.org` hasn't been updated since January 2026 (the deployed bundle pre-dates the `Servers` tab I added in #2067 and the improved session provider). The root cause — no deploy workflow after webui moved in-repo — is tracked in #2174 and needs a decision on target (GH Pages subpath, separate repo, Vercel/Netlify — see upcoming comment there).

This PR doesn't solve #2174, but it's cheap to land now:

- Unblocks manual / out-of-band redeploys of `chat.gptme.org` today (`gh run download <run_id> -n webui-dist`, then rsync or similar to whatever hosting target Erik chooses).
- Gives whatever deploy workflow we eventually add something to consume instead of re-running the full build.
- Keeps being useful afterwards for anyone who wants to grab a prebuilt webui without cloning and building.

## Scope

- Master-only (`if: github.ref == 'refs/heads/master'`) — no extra noise on PR runs.
- 30-day retention matches GitHub's default artifact retention budget.
- No CI time impact on PRs; master builds add a few seconds for the upload.

## Test plan

- [x] Workflow syntax validated locally
- [ ] Merge to master, verify `webui-dist` appears under Actions artifacts
- [ ] Follow-up: resolve #2174 with a real deploy target, consume this artifact

Refs: gptme/gptme#2174, ErikBjare/bob#659 (user-testing session that surfaced the stale deployed bundle), ErikBjare/bob (session d689)