### PR TITLE
feat(openai): add gpt-5.5 and gpt-5.5-pro models

### DIFF
--- a/gptme/llm/llm_openai_models.py
+++ b/gptme/llm/llm_openai_models.py
@@ -21,16 +21,6 @@ _OPENAI_MODELS_ACTIVE: dict[str, "_ModelDictMeta"] = {
         "supports_reasoning": True,
         "supports_parallel_tool_calls": True,
     },
-    # GPT-5.5 Pro — Responses API only, "more compute to think harder"
-    "gpt-5.5-pro": {
-        "context": 1_000_000,
-        "max_output": 128_000,
-        "price_input": 30,
-        "price_output": 180,
-        "supports_vision": True,
-        "supports_reasoning": True,
-        "supports_parallel_tool_calls": True,
-    },
     # GPT-5
     "gpt-5": {
         "context": 400_000,
@@ -155,6 +145,17 @@ OPENAI_MODELS: dict[str, "_ModelDictMeta"] = {
 # API-equivalent cost for comparison. models.py adds default_tool_format="tool".
 # Reasoning level suffix (e.g., :high) is stripped at lookup time in get_model().
 OPENAI_SUBSCRIPTION_MODELS: dict[str, "_ModelDictMeta"] = {
+    # GPT-5.5 Pro — Responses API only, "more compute to think harder"
+    # https://developers.openai.com/api/docs/changelog
+    "gpt-5.5-pro": {
+        "context": 1_000_000,
+        "max_output": 128_000,
+        "price_input": 30,
+        "price_output": 180,
+        "supports_vision": True,
+        "supports_reasoning": True,
+        "supports_parallel_tool_calls": True,
+    },
     # GPT-5.4 — latest flagship, 1M context
     "gpt-5.4": {
         "context": 1_050_000,

--- a/gptme/llm/llm_openai_models.py
+++ b/gptme/llm/llm_openai_models.py
@@ -10,6 +10,27 @@ if TYPE_CHECKING:
 # and merged in below. They still work when explicitly requested via --model.
 
 _OPENAI_MODELS_ACTIVE: dict[str, "_ModelDictMeta"] = {
+    # GPT-5.5 — flagship released April 2026, 1M context
+    # https://developers.openai.com/api/docs/changelog
+    "gpt-5.5": {
+        "context": 1_000_000,
+        "max_output": 128_000,
+        "price_input": 5,
+        "price_output": 30,
+        "supports_vision": True,
+        "supports_reasoning": True,
+        "supports_parallel_tool_calls": True,
+    },
+    # GPT-5.5 Pro — Responses API only, "more compute to think harder"
+    "gpt-5.5-pro": {
+        "context": 1_000_000,
+        "max_output": 128_000,
+        "price_input": 30,
+        "price_output": 180,
+        "supports_vision": True,
+        "supports_reasoning": True,
+        "supports_parallel_tool_calls": True,
+    },
     # GPT-5
     "gpt-5": {
         "context": 400_000,


### PR DESCRIPTION
## Summary

Adds OpenAI's GPT-5.5 and GPT-5.5 Pro to the active OpenAI model list.
Released 2026-04-24 with a 1M-token context window. Both models support
vision, reasoning, and parallel tool calls per OpenAI's changelog.

## Pricing

| Model | Input | Output |
|-------|-------|--------|
| gpt-5.5 | $5 / Mtok | $30 / Mtok |
| gpt-5.5-pro | $30 / Mtok | $180 / Mtok |

## Notes

- `knowledge_cutoff` intentionally omitted — OpenAI's changelog does not
  specify one yet. Matching surrounding entries that lack it (`o3`,
  `o4-mini`) until that lands.
- GPT-5.5 Pro is Responses-API-only per OpenAI; Chat Completions still
  works for plain `gpt-5.5`. The cost-tracking-only entries don't
  affect routing — backend selection is unchanged.

## References

- https://developers.openai.com/api/docs/changelog
- https://simonwillison.net/2026/Apr/23/gpt-5-5/

## Test plan

- [x] `uv run --active pytest tests/test_llm_models.py tests/test_llm_openai.py -m "not slow and not integration and not requires_api"` — 107 passed
- [x] Verified both entries load correctly from `MODELS["openai"]`
- [x] Pre-commit (prek) passes