### PR TITLE
feat(openai): support OPENAI_VERBOSITY env var for GPT-5+ models

### DIFF
--- a/gptme/constants.py
+++ b/gptme/constants.py
@@ -12,6 +12,7 @@ TOP_P = float(os.getenv("TOP_P", "0.1"))
 
 # Verbosity level for GPT-5+ OpenAI models. One of "low", "medium", "high".
 # Unset (default) means the parameter is not sent and OpenAI's default applies.
+# NOTE: getting the environment variable like this ignores if it is set in the gptme config
 # See: https://platform.openai.com/docs/guides/latest-model
 OPENAI_VERBOSITY = os.getenv("OPENAI_VERBOSITY")
 

--- a/gptme/constants.py
+++ b/gptme/constants.py
@@ -10,6 +10,11 @@ import os
 TEMPERATURE = float(os.getenv("TEMPERATURE", "0"))
 TOP_P = float(os.getenv("TOP_P", "0.1"))
 
+# Verbosity level for GPT-5+ OpenAI models. One of "low", "medium", "high".
+# Unset (default) means the parameter is not sent and OpenAI's default applies.
+# See: https://platform.openai.com/docs/guides/latest-model
+OPENAI_VERBOSITY = os.getenv("OPENAI_VERBOSITY")
+
 # separator for multiple rounds of prompts on the command line
 # demarcates the end of the user's prompt, and start of the assistant's response
 # e.g. /gptme "generate a poem" "-" "save it to poem.txt"

--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -13,7 +13,7 @@ from openai import NOT_GIVEN
 from typing_extensions import NotRequired
 
 from ..config import Config, get_config
-from ..constants import TEMPERATURE, TOP_P
+from ..constants import OPENAI_VERBOSITY, TEMPERATURE, TOP_P
 from ..message import Message, MessageMetadata, UsageData, msgs2dicts
 from ..telemetry import _calculate_llm_cost, record_llm_request
 from ..tools import ToolSpec
@@ -551,6 +551,32 @@ def retry_generator_on_openai_error(max_retries: int = 5, base_delay: float = 1.
     return decorator
 
 
+_VALID_VERBOSITY = {"low", "medium", "high"}
+
+
+def _maybe_apply_verbosity(
+    optional_kwargs: dict[str, Any], model_meta: ModelMeta
+) -> None:
+    """Add verbosity kwarg for GPT-5+ models when OPENAI_VERBOSITY is set.
+
+    GPT-5 family models support a `verbosity` parameter to control output length.
+    Unset or invalid values result in the parameter being omitted (OpenAI default
+    of "medium" applies).
+    """
+    if not OPENAI_VERBOSITY:
+        return
+    if not model_meta.model.startswith("gpt-5"):
+        return
+    if OPENAI_VERBOSITY not in _VALID_VERBOSITY:
+        logger.warning(
+            "OPENAI_VERBOSITY=%r is not one of %s; ignoring.",
+            OPENAI_VERBOSITY,
+            sorted(_VALID_VERBOSITY),
+        )
+        return
+    optional_kwargs["verbosity"] = OPENAI_VERBOSITY
+
+
 @retry_on_openai_error()
 def chat(
     messages: list[Message],
@@ -592,6 +618,7 @@ def chat(
         optional_kwargs["response_format"] = response_format
     if max_tokens is not None:
         optional_kwargs["max_tokens"] = max_tokens
+    _maybe_apply_verbosity(optional_kwargs, model_meta)
 
     response = client.chat.completions.create(
         model=api_model.split("@")[0],
@@ -767,6 +794,7 @@ def stream(
         optional_kwargs["response_format"] = response_format
     if max_tokens is not None:
         optional_kwargs["max_tokens"] = max_tokens
+    _maybe_apply_verbosity(optional_kwargs, model_meta)
 
     for chunk_raw in client.chat.completions.create(
         model=api_model.split("@")[0],

--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -555,10 +555,8 @@ _VALID_VERBOSITY = {"low", "medium", "high"}
 _verbosity_warned = False  # warn at most once per process lifetime
 
 
-def _maybe_apply_verbosity(
-    optional_kwargs: dict[str, Any], model_meta: ModelMeta
-) -> None:
-    """Add verbosity kwarg for GPT-5+ models when OPENAI_VERBOSITY is set.
+def _maybe_apply_verbosity(body: dict[str, Any], model_meta: ModelMeta) -> None:
+    """Add verbosity request-body field for GPT-5+ models when set.
 
     GPT-5 family models support a `verbosity` parameter to control output length.
     Unset or invalid values result in the parameter being omitted (OpenAI default
@@ -578,7 +576,7 @@ def _maybe_apply_verbosity(
             )
             _verbosity_warned = True
         return
-    optional_kwargs["verbosity"] = OPENAI_VERBOSITY
+    body["verbosity"] = OPENAI_VERBOSITY
 
 
 @retry_on_openai_error()
@@ -622,7 +620,6 @@ def chat(
         optional_kwargs["response_format"] = response_format
     if max_tokens is not None:
         optional_kwargs["max_tokens"] = max_tokens
-    _maybe_apply_verbosity(optional_kwargs, model_meta)
 
     response = client.chat.completions.create(
         model=api_model.split("@")[0],
@@ -676,6 +673,7 @@ def extra_body(
 ) -> dict[str, Any]:
     """Return extra body for the OpenAI API based on the model."""
     body: dict[str, Any] = {}
+    _maybe_apply_verbosity(body, model_meta)
     if provider == "openrouter":
         # Enable detailed usage info including cached tokens
         # See: https://openrouter.ai/docs/guides/usage-accounting
@@ -798,7 +796,6 @@ def stream(
         optional_kwargs["response_format"] = response_format
     if max_tokens is not None:
         optional_kwargs["max_tokens"] = max_tokens
-    _maybe_apply_verbosity(optional_kwargs, model_meta)
 
     for chunk_raw in client.chat.completions.create(
         model=api_model.split("@")[0],

--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -552,6 +552,7 @@ def retry_generator_on_openai_error(max_retries: int = 5, base_delay: float = 1.
 
 
 _VALID_VERBOSITY = {"low", "medium", "high"}
+_verbosity_warned = False  # warn at most once per process lifetime
 
 
 def _maybe_apply_verbosity(
@@ -563,16 +564,19 @@ def _maybe_apply_verbosity(
     Unset or invalid values result in the parameter being omitted (OpenAI default
     of "medium" applies).
     """
+    global _verbosity_warned
     if not OPENAI_VERBOSITY:
         return
     if not model_meta.model.startswith("gpt-5"):
         return
     if OPENAI_VERBOSITY not in _VALID_VERBOSITY:
-        logger.warning(
-            "OPENAI_VERBOSITY=%r is not one of %s; ignoring.",
-            OPENAI_VERBOSITY,
-            sorted(_VALID_VERBOSITY),
-        )
+        if not _verbosity_warned:
+            logger.warning(
+                "OPENAI_VERBOSITY=%r is not one of %s; ignoring.",
+                OPENAI_VERBOSITY,
+                sorted(_VALID_VERBOSITY),
+            )
+            _verbosity_warned = True
         return
     optional_kwargs["verbosity"] = OPENAI_VERBOSITY
 

--- a/tests/test_llm_openai.py
+++ b/tests/test_llm_openai.py
@@ -1795,7 +1795,24 @@ class TestMaybeApplyVerbosity:
 
     def test_invalid_level_ignored(self, monkeypatch, caplog):
         monkeypatch.setattr(llm_openai, "OPENAI_VERBOSITY", "verbose")
+        monkeypatch.setattr(llm_openai, "_verbosity_warned", False)
         kwargs: dict = {}
         model = get_model("openai/gpt-5")
-        _maybe_apply_verbosity(kwargs, model)
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="gptme.llm.llm_openai"):
+            _maybe_apply_verbosity(kwargs, model)
         assert "verbosity" not in kwargs
+        assert "OPENAI_VERBOSITY" in caplog.text
+        assert "verbose" in caplog.text
+
+    def test_invalid_level_warns_only_once(self, monkeypatch, caplog):
+        monkeypatch.setattr(llm_openai, "OPENAI_VERBOSITY", "verbose")
+        monkeypatch.setattr(llm_openai, "_verbosity_warned", False)
+        model = get_model("openai/gpt-5")
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="gptme.llm.llm_openai"):
+            _maybe_apply_verbosity({}, model)
+            _maybe_apply_verbosity({}, model)
+        assert caplog.text.count("OPENAI_VERBOSITY") == 1

--- a/tests/test_llm_openai.py
+++ b/tests/test_llm_openai.py
@@ -1762,47 +1762,47 @@ class TestRecordUsageCacheTokens:
 
 
 class TestMaybeApplyVerbosity:
-    """Tests for OPENAI_VERBOSITY env var handling on GPT-5+ models."""
+    """Tests for OPENAI_VERBOSITY request-body handling on GPT-5+ models."""
 
     def test_unset_skips(self, monkeypatch):
         monkeypatch.setattr(llm_openai, "OPENAI_VERBOSITY", None)
-        kwargs: dict = {}
+        body: dict = {}
         model = get_model("openai/gpt-5")
-        _maybe_apply_verbosity(kwargs, model)
-        assert "verbosity" not in kwargs
+        _maybe_apply_verbosity(body, model)
+        assert "verbosity" not in body
 
     def test_non_gpt5_model_skipped(self, monkeypatch):
         monkeypatch.setattr(llm_openai, "OPENAI_VERBOSITY", "high")
-        kwargs: dict = {}
+        body: dict = {}
         model = get_model("openai/gpt-4o")
-        _maybe_apply_verbosity(kwargs, model)
-        assert "verbosity" not in kwargs
+        _maybe_apply_verbosity(body, model)
+        assert "verbosity" not in body
 
     @pytest.mark.parametrize("level", ["low", "medium", "high"])
     def test_valid_level_applied_to_gpt5(self, monkeypatch, level):
         monkeypatch.setattr(llm_openai, "OPENAI_VERBOSITY", level)
-        kwargs: dict = {}
+        body: dict = {}
         model = get_model("openai/gpt-5")
-        _maybe_apply_verbosity(kwargs, model)
-        assert kwargs["verbosity"] == level
+        _maybe_apply_verbosity(body, model)
+        assert body["verbosity"] == level
 
     def test_valid_level_applied_to_gpt5_5(self, monkeypatch):
         monkeypatch.setattr(llm_openai, "OPENAI_VERBOSITY", "low")
-        kwargs: dict = {}
+        body: dict = {}
         model = get_model("openai/gpt-5.5")
-        _maybe_apply_verbosity(kwargs, model)
-        assert kwargs["verbosity"] == "low"
+        _maybe_apply_verbosity(body, model)
+        assert body["verbosity"] == "low"
 
     def test_invalid_level_ignored(self, monkeypatch, caplog):
         monkeypatch.setattr(llm_openai, "OPENAI_VERBOSITY", "verbose")
         monkeypatch.setattr(llm_openai, "_verbosity_warned", False)
-        kwargs: dict = {}
+        body: dict = {}
         model = get_model("openai/gpt-5")
         import logging
 
         with caplog.at_level(logging.WARNING, logger="gptme.llm.llm_openai"):
-            _maybe_apply_verbosity(kwargs, model)
-        assert "verbosity" not in kwargs
+            _maybe_apply_verbosity(body, model)
+        assert "verbosity" not in body
         assert "OPENAI_VERBOSITY" in caplog.text
         assert "verbose" in caplog.text
 

--- a/tests/test_llm_openai.py
+++ b/tests/test_llm_openai.py
@@ -1,7 +1,8 @@
 import pytest
 
 from gptme.config import get_config
-from gptme.llm.llm_openai import _prepare_messages_for_api
+from gptme.llm import llm_openai
+from gptme.llm.llm_openai import _maybe_apply_verbosity, _prepare_messages_for_api
 from gptme.llm.models import get_default_model, get_model, set_default_model
 from gptme.message import Message
 from gptme.tools import get_tool, init_tools
@@ -1758,3 +1759,43 @@ class TestRecordUsageCacheTokens:
         # Both explicit zeros preserved in metadata (truthy-check would drop them)
         assert metadata["usage"]["cache_read_tokens"] == 0
         assert metadata["usage"]["cache_creation_tokens"] == 0
+
+
+class TestMaybeApplyVerbosity:
+    """Tests for OPENAI_VERBOSITY env var handling on GPT-5+ models."""
+
+    def test_unset_skips(self, monkeypatch):
+        monkeypatch.setattr(llm_openai, "OPENAI_VERBOSITY", None)
+        kwargs: dict = {}
+        model = get_model("openai/gpt-5")
+        _maybe_apply_verbosity(kwargs, model)
+        assert "verbosity" not in kwargs
+
+    def test_non_gpt5_model_skipped(self, monkeypatch):
+        monkeypatch.setattr(llm_openai, "OPENAI_VERBOSITY", "high")
+        kwargs: dict = {}
+        model = get_model("openai/gpt-4o")
+        _maybe_apply_verbosity(kwargs, model)
+        assert "verbosity" not in kwargs
+
+    @pytest.mark.parametrize("level", ["low", "medium", "high"])
+    def test_valid_level_applied_to_gpt5(self, monkeypatch, level):
+        monkeypatch.setattr(llm_openai, "OPENAI_VERBOSITY", level)
+        kwargs: dict = {}
+        model = get_model("openai/gpt-5")
+        _maybe_apply_verbosity(kwargs, model)
+        assert kwargs["verbosity"] == level
+
+    def test_valid_level_applied_to_gpt5_5(self, monkeypatch):
+        monkeypatch.setattr(llm_openai, "OPENAI_VERBOSITY", "low")
+        kwargs: dict = {}
+        model = get_model("openai/gpt-5.5")
+        _maybe_apply_verbosity(kwargs, model)
+        assert kwargs["verbosity"] == "low"
+
+    def test_invalid_level_ignored(self, monkeypatch, caplog):
+        monkeypatch.setattr(llm_openai, "OPENAI_VERBOSITY", "verbose")
+        kwargs: dict = {}
+        model = get_model("openai/gpt-5")
+        _maybe_apply_verbosity(kwargs, model)
+        assert "verbosity" not in kwargs


### PR DESCRIPTION
## Summary

GPT-5 family models support a \`verbosity\` parameter (low/medium/high) on Chat Completions to control output length. This adds an \`OPENAI_VERBOSITY\` env var that gptme passes through for any \`gpt-5*\` model.

Mirrors what [\`llm\` 0.31](https://simonwillison.net/2026/Apr/24/llm/) shipped and what [OpenAI's GPT-5.5 prompting guide](https://simonwillison.net/2026/Apr/25/gpt-5-5-prompting-guide/) recommends for tuning response length without changing the system prompt.

## Behavior

- **Unset** (default): not sent — OpenAI's server-side default (\`medium\`) applies. No behavior change for existing users.
- **\`low\` / \`medium\` / \`high\`**: sent as a top-level kwarg to \`chat.completions.create()\` for any model whose name starts with \`gpt-5\`.
- **Non-gpt-5 models**: env var is ignored (same as if unset).
- **Invalid value**: logged as a warning and ignored.

## Implementation

A small \`_maybe_apply_verbosity()\` helper is wired into both \`chat()\` and \`stream()\` in \`llm_openai.py\` next to the existing \`optional_kwargs\` build. Verbosity is only applied for \`gpt-5*\` models — other models pass through unchanged.

## Test plan

- [x] Unit tests cover unset, non-gpt5, valid (low/medium/high), gpt-5.5, and invalid-value paths
- [x] \`pytest tests/test_llm_openai.py::TestMaybeApplyVerbosity\` — 7 passed
- [x] Pre-commit (prek) hooks pass
- [ ] Manual smoke test with a real \`gpt-5.5\` request once a reviewer has access (no API key changes needed)

## Notes

- \`OPENAI_VERBOSITY\` follows the existing env-var convention used for \`TEMPERATURE\` / \`TOP_P\` in \`gptme/constants.py\`. Could be promoted to a per-model option later if other providers add similar knobs.
- No subscription-backend (\`llm_openai_subscription.py\`) changes — that path uses a private Codex protocol and isn't where verbosity lives.