### PR TITLE
feat(cli): add gptme-checkpoint for Git-backed workspace recovery

### DIFF
--- a/gptme/checkpoint.py
+++ b/gptme/checkpoint.py
@@ -1,0 +1,436 @@
+"""Workspace checkpoint primitives for ``gptme checkpoint``.
+
+Lightweight, Git-backed recovery markers for single-root Git workspaces:
+record the current ``HEAD``, list previous checkpoints, diff against them,
+and restore by ``git reset --hard <head>``.
+
+This is **not** conversation backtracking (see gptme/gptme#523) — it is purely
+about recovering filesystem state when an agent run touches more than the user
+expected. The implementation is conservative on purpose:
+
+- ``clean_git`` workspaces are checkpointed and restored without ceremony.
+- ``dirty_git`` workspaces require explicit ``--include-dirty``.
+- ``non_git`` and ``multi_root`` workspaces are refused entirely in this MVP.
+
+Storage lives in ``$XDG_STATE_HOME/gptme/checkpoints/<fingerprint>.jsonl``
+(via :func:`gptme.dirs.get_state_dir`) so user repos stay clean — no
+``.gptme/`` directory written into the working tree.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import hashlib
+import json
+import os
+import subprocess
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Literal
+
+from .dirs import get_state_dir
+
+BackendKind = Literal["clean_git", "dirty_git", "non_git", "multi_root"]
+
+CHECKPOINTS_SUBDIR = "checkpoints"
+
+
+class CheckpointError(Exception):
+    """Checkpoint operation refused or failed."""
+
+
+@dataclasses.dataclass(frozen=True)
+class BackendDecision:
+    """Result of inspecting a path for checkpoint backend applicability."""
+
+    kind: BackendKind
+    workspace: Path
+    repo_root: Path | None
+    head_sha: str | None
+    dirty_tracked: int
+    untracked: int
+    worktree_count: int
+    submodule_count: int
+    reason: str
+
+    def safe_to_create(self) -> bool:
+        return self.kind == "clean_git"
+
+    def safe_to_restore(self) -> bool:
+        return self.kind == "clean_git"
+
+
+@dataclasses.dataclass(frozen=True)
+class CheckpointRecord:
+    """A single checkpoint entry in the ledger."""
+
+    session_id: str
+    timestamp: str  # ISO 8601 with timezone
+    head_sha: str
+    workspace: str  # resolved absolute path
+
+    def to_json(self) -> str:
+        return json.dumps(dataclasses.asdict(self), ensure_ascii=False)
+
+
+def _git(repo: Path, *args: str) -> str:
+    """Run ``git`` in ``repo``; return stripped stdout, or ``''`` on non-zero."""
+    try:
+        proc = subprocess.run(
+            ["git", *args],
+            cwd=str(repo),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError:
+        return ""
+    if proc.returncode != 0:
+        return ""
+    return proc.stdout.strip()
+
+
+def _find_repo_root(path: Path) -> Path | None:
+    if not path.exists():
+        return None
+    out = _git(path, "rev-parse", "--show-toplevel")
+    return Path(out) if out else None
+
+
+def _count_worktrees(repo: Path) -> int:
+    out = _git(repo, "worktree", "list", "--porcelain")
+    if not out:
+        return 0
+    return sum(1 for line in out.splitlines() if line.startswith("worktree "))
+
+
+def _count_submodules(repo: Path) -> int:
+    out = _git(repo, "submodule", "status")
+    if not out:
+        return 0
+    return sum(1 for line in out.splitlines() if line.strip())
+
+
+def _porcelain_counts(repo: Path) -> tuple[int, int]:
+    out = _git(repo, "status", "--porcelain")
+    if not out:
+        return (0, 0)
+    dirty = 0
+    untracked = 0
+    for line in out.splitlines():
+        if not line:
+            continue
+        code = line[:2]
+        if code == "??":
+            untracked += 1
+        else:
+            dirty += 1
+    return (dirty, untracked)
+
+
+def classify(path: str | Path) -> BackendDecision:
+    """Classify a workspace path into a checkpoint backend kind.
+
+    Pure inspection: never mutates the workspace. Always returns a populated
+    :class:`BackendDecision` so callers can render a clear explanation rather
+    than guessing.
+    """
+    workspace = Path(path).expanduser().resolve()
+
+    repo = _find_repo_root(workspace)
+    if repo is None:
+        return BackendDecision(
+            kind="non_git",
+            workspace=workspace,
+            repo_root=None,
+            head_sha=None,
+            dirty_tracked=0,
+            untracked=0,
+            worktree_count=0,
+            submodule_count=0,
+            reason="not inside a git repository",
+        )
+
+    head = _git(repo, "rev-parse", "HEAD") or None
+    dirty_tracked, untracked = _porcelain_counts(repo)
+    worktrees = _count_worktrees(repo)
+    submodules = _count_submodules(repo)
+
+    if worktrees > 1 or submodules > 0:
+        bits = []
+        if worktrees > 1:
+            bits.append(f"{worktrees} worktrees")
+        if submodules > 0:
+            bits.append(f"{submodules} submodules")
+        return BackendDecision(
+            kind="multi_root",
+            workspace=workspace,
+            repo_root=repo,
+            head_sha=head,
+            dirty_tracked=dirty_tracked,
+            untracked=untracked,
+            worktree_count=worktrees,
+            submodule_count=submodules,
+            reason="multi-root layout: " + ", ".join(bits),
+        )
+
+    if dirty_tracked > 0 or untracked > 0:
+        return BackendDecision(
+            kind="dirty_git",
+            workspace=workspace,
+            repo_root=repo,
+            head_sha=head,
+            dirty_tracked=dirty_tracked,
+            untracked=untracked,
+            worktree_count=worktrees,
+            submodule_count=submodules,
+            reason=(
+                f"dirty repository: {dirty_tracked} tracked changes, "
+                f"{untracked} untracked"
+            ),
+        )
+
+    return BackendDecision(
+        kind="clean_git",
+        workspace=workspace,
+        repo_root=repo,
+        head_sha=head,
+        dirty_tracked=0,
+        untracked=0,
+        worktree_count=worktrees,
+        submodule_count=submodules,
+        reason="clean single-root git repository",
+    )
+
+
+def repo_fingerprint(repo_root: str | Path) -> str:
+    """Stable, compact fingerprint for an absolute repo path.
+
+    Uses the realpath bytes so symlink chains map to the same checkpoint
+    file. If the repo is later moved, the fingerprint changes — that is
+    deliberate; checkpoints are recovery artifacts, not durable history.
+    """
+    real = os.path.realpath(str(repo_root))
+    return hashlib.sha256(real.encode("utf-8")).hexdigest()[:16]
+
+
+def get_ledger_path(repo_root: str | Path) -> Path:
+    """Return the JSONL ledger path for a repo, under XDG state dir."""
+    fp = repo_fingerprint(repo_root)
+    return get_state_dir() / CHECKPOINTS_SUBDIR / f"{fp}.jsonl"
+
+
+def _last_line(path: Path) -> str | None:
+    if not path.exists():
+        return None
+    with open(path, "rb") as f:
+        f.seek(0, 2)
+        size = f.tell()
+        if size == 0:
+            return None
+        chunk_size = min(size, 4096)
+        f.seek(max(0, size - chunk_size))
+        tail = f.read().decode("utf-8", errors="replace")
+        lines = tail.strip().splitlines()
+        return lines[-1] if lines else None
+
+
+def create_checkpoint(
+    workspace: str | Path,
+    *,
+    session_id: str | None = None,
+    include_dirty: bool = False,
+) -> CheckpointRecord | None:
+    """Create a checkpoint and append it to the XDG ledger.
+
+    Returns the new :class:`CheckpointRecord`, or ``None`` if the workspace
+    is already at the same HEAD as the most recent checkpoint (idempotent).
+
+    Raises:
+        CheckpointError: workspace kind is not checkpointable
+        OSError: ledger write failed
+    """
+    decision = classify(workspace)
+
+    if decision.kind == "clean_git":
+        pass
+    elif decision.kind == "dirty_git" and include_dirty:
+        pass
+    elif decision.kind == "dirty_git":
+        raise CheckpointError(
+            f"cannot create checkpoint in {decision.kind} workspace: "
+            f"{decision.reason} "
+            "(pass --include-dirty to checkpoint uncommitted changes)"
+        )
+    else:
+        raise CheckpointError(
+            f"cannot create checkpoint in {decision.kind} workspace: {decision.reason}"
+        )
+
+    if decision.repo_root is None or decision.head_sha is None:
+        raise CheckpointError("workspace has no repo root or HEAD")
+
+    record = CheckpointRecord(
+        session_id=session_id or uuid.uuid4().hex[:12],
+        timestamp=datetime.now(timezone.utc).isoformat(),
+        head_sha=decision.head_sha,
+        workspace=str(decision.workspace.resolve()),
+    )
+
+    ledger_path = get_ledger_path(decision.repo_root)
+    ledger_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if ledger_path.exists():
+        try:
+            last_line = _last_line(ledger_path)
+            if last_line:
+                last = json.loads(last_line)
+                if last.get("head_sha") == record.head_sha:
+                    return None
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    with open(ledger_path, "a", encoding="utf-8") as f:
+        f.write(record.to_json() + "\n")
+
+    return record
+
+
+def list_checkpoints(repo_root: str | Path) -> list[CheckpointRecord]:
+    """Read all checkpoint records for a repo. Empty list if no ledger."""
+    ledger_path = get_ledger_path(repo_root)
+    if not ledger_path.exists():
+        return []
+
+    records: list[CheckpointRecord] = []
+    with open(ledger_path, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                data = json.loads(line)
+                records.append(
+                    CheckpointRecord(
+                        session_id=data["session_id"],
+                        timestamp=data["timestamp"],
+                        head_sha=data["head_sha"],
+                        workspace=data["workspace"],
+                    )
+                )
+            except (json.JSONDecodeError, KeyError, TypeError):
+                continue
+    return records
+
+
+def _resolve_checkpoint(repo_root: Path, identifier: str) -> CheckpointRecord:
+    """Resolve a 1-based index or SHA prefix to a :class:`CheckpointRecord`."""
+    records = list_checkpoints(repo_root)
+    if not records:
+        raise CheckpointError("no checkpoints found for this repo")
+
+    # Treat short integer-looking strings as 1-based indices.
+    try:
+        idx = int(identifier)
+        if len(identifier) <= 3:
+            if 1 <= idx <= len(records):
+                return records[idx - 1]
+            raise CheckpointError(
+                f"checkpoint index {idx} out of range (1-{len(records)})"
+            )
+    except ValueError:
+        pass
+
+    matches = [r for r in records if r.head_sha.startswith(identifier)]
+    if len(matches) == 1:
+        return matches[0]
+    if len(matches) > 1:
+        raise CheckpointError(f"ambiguous checkpoint SHA prefix {identifier!r}")
+
+    raise CheckpointError(
+        f"checkpoint {identifier!r} not found "
+        f"(use an index 1-{len(records)} or SHA prefix)"
+    )
+
+
+def restore_checkpoint(
+    workspace: str | Path,
+    identifier: str,
+    *,
+    include_dirty: bool = False,
+) -> str:
+    """Restore working tree to a checkpointed HEAD via ``git reset --hard``.
+
+    Refuses ``dirty_git`` without ``include_dirty``; refuses ``non_git`` and
+    ``multi_root`` unconditionally. Returns a human-readable confirmation.
+
+    Raises:
+        CheckpointError: workspace not safe, checkpoint not found, or git failed
+    """
+    decision = classify(workspace)
+
+    if decision.kind == "clean_git":
+        pass
+    elif decision.kind == "dirty_git" and include_dirty:
+        pass
+    elif decision.kind == "dirty_git":
+        raise CheckpointError(
+            "workspace has uncommitted changes — it is not safe to restore "
+            "a checkpoint without --include-dirty. Commit or stash your "
+            "changes first, or pass --include-dirty to discard them."
+        )
+    else:
+        raise CheckpointError(
+            f"cannot restore checkpoint in {decision.kind} workspace: {decision.reason}"
+        )
+
+    if decision.repo_root is None:
+        raise CheckpointError("workspace has no repo root")
+
+    record = _resolve_checkpoint(decision.repo_root, identifier)
+    current_sha = decision.head_sha or "?"
+
+    if record.head_sha == current_sha:
+        return f"Already at checkpoint {record.head_sha[:12]} — nothing to restore."
+
+    result = subprocess.run(
+        ["git", "reset", "--hard", record.head_sha],
+        check=False,
+        cwd=decision.repo_root,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise CheckpointError(
+            f"git reset --hard failed: {result.stderr.strip() or 'unknown error'}"
+        )
+
+    return (
+        f"Restored to checkpoint {record.head_sha[:12]} "
+        f"(session={record.session_id})\n"
+        f"  Reset HEAD from {current_sha[:12]} -> {record.head_sha[:12]}"
+    )
+
+
+def diff_checkpoint(workspace: str | Path, identifier: str) -> str:
+    """Return ``git diff`` output between current HEAD and a checkpoint HEAD."""
+    decision = classify(workspace)
+    if decision.repo_root is None:
+        raise CheckpointError(
+            f"cannot diff checkpoint in {decision.kind} workspace: {decision.reason}"
+        )
+    record = _resolve_checkpoint(decision.repo_root, identifier)
+
+    result = subprocess.run(
+        ["git", "diff", record.head_sha],
+        check=False,
+        cwd=decision.repo_root,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise CheckpointError(
+            f"git diff failed: {result.stderr.strip() or 'unknown error'}"
+        )
+    return result.stdout

--- a/gptme/checkpoint.py
+++ b/gptme/checkpoint.py
@@ -241,11 +241,13 @@ def create_checkpoint(
     *,
     session_id: str | None = None,
     include_dirty: bool = False,
-) -> CheckpointRecord | None:
+) -> tuple[CheckpointRecord | None, str | None]:
     """Create a checkpoint and append it to the XDG ledger.
 
-    Returns the new :class:`CheckpointRecord`, or ``None`` if the workspace
-    is already at the same HEAD as the most recent checkpoint (idempotent).
+    Returns a 2-tuple ``(record, existing_sha)``:
+
+    - ``(CheckpointRecord, None)`` — new checkpoint written to the ledger.
+    - ``(None, sha)`` — already at the same HEAD; ``sha`` is the HEAD for display.
 
     Raises:
         CheckpointError: workspace kind is not checkpointable
@@ -287,14 +289,14 @@ def create_checkpoint(
             if last_line:
                 last = json.loads(last_line)
                 if last.get("head_sha") == record.head_sha:
-                    return None
+                    return None, record.head_sha
         except (json.JSONDecodeError, OSError):
             pass
 
     with open(ledger_path, "a", encoding="utf-8") as f:
         f.write(record.to_json() + "\n")
 
-    return record
+    return record, None
 
 
 def list_checkpoints(repo_root: str | Path) -> list[CheckpointRecord]:

--- a/gptme/checkpoint.py
+++ b/gptme/checkpoint.py
@@ -330,17 +330,12 @@ def _resolve_checkpoint(repo_root: Path, identifier: str) -> CheckpointRecord:
     if not records:
         raise CheckpointError("no checkpoints found for this repo")
 
-    # Treat short integer-looking strings as 1-based indices.
-    try:
+    # Pure decimal integers are unambiguously 1-based indices (SHA prefixes are hex).
+    if identifier.isdigit():
         idx = int(identifier)
-        if len(identifier) <= 3:
-            if 1 <= idx <= len(records):
-                return records[idx - 1]
-            raise CheckpointError(
-                f"checkpoint index {idx} out of range (1-{len(records)})"
-            )
-    except ValueError:
-        pass
+        if 1 <= idx <= len(records):
+            return records[idx - 1]
+        raise CheckpointError(f"checkpoint index {idx} out of range (1-{len(records)})")
 
     matches = [r for r in records if r.head_sha.startswith(identifier)]
     if len(matches) == 1:
@@ -405,6 +400,21 @@ def restore_checkpoint(
         raise CheckpointError(
             f"git reset --hard failed: {result.stderr.strip() or 'unknown error'}"
         )
+
+    if include_dirty:
+        # git reset --hard does not remove untracked files; clean them up so the
+        # workspace is truly restored to the checkpointed state.
+        clean = subprocess.run(
+            ["git", "clean", "-fd"],
+            check=False,
+            cwd=decision.repo_root,
+            capture_output=True,
+            text=True,
+        )
+        if clean.returncode != 0:
+            raise CheckpointError(
+                f"git clean -fd failed: {clean.stderr.strip() or 'unknown error'}"
+            )
 
     return (
         f"Restored to checkpoint {record.head_sha[:12]} "

--- a/gptme/cli/checkpoint.py
+++ b/gptme/cli/checkpoint.py
@@ -1,0 +1,143 @@
+"""``gptme-checkpoint`` CLI for Git-backed workspace recovery.
+
+Top-level entry point that wraps :mod:`gptme.checkpoint`. See the module
+docstring there for the design constraints (clean_git first, XDG-backed
+ledger, conservative restore semantics).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import click
+
+from ..checkpoint import (
+    CheckpointError,
+    classify,
+    create_checkpoint,
+    diff_checkpoint,
+    list_checkpoints,
+    restore_checkpoint,
+)
+
+
+@click.group(context_settings={"help_option_names": ["-h", "--help"]})
+def main() -> None:
+    """Lightweight session-level recovery markers for Git workspaces.
+
+    Records the current ``HEAD`` so an agent run that touches more than
+    expected can be rewound with ``gptme-checkpoint restore``. Not a
+    replacement for ``git`` — see ``gptme-checkpoint create --help``.
+    """
+
+
+@main.command("create")
+@click.argument(
+    "path", required=False, type=click.Path(file_okay=False, path_type=Path)
+)
+@click.option(
+    "--include-dirty",
+    is_flag=True,
+    help="Allow checkpointing a dirty git workspace (records HEAD only).",
+)
+@click.option("--session-id", default=None, help="Custom session identifier.")
+def cmd_create(
+    path: Path | None,
+    include_dirty: bool,
+    session_id: str | None,
+) -> None:
+    """Record a checkpoint at the current HEAD."""
+    target = path or Path.cwd()
+    try:
+        record = create_checkpoint(
+            target,
+            session_id=session_id,
+            include_dirty=include_dirty,
+        )
+    except CheckpointError as exc:
+        click.echo(f"checkpoint: {exc}", err=True)
+        sys.exit(1)
+
+    if record is None:
+        decision = classify(target)
+        head = decision.head_sha[:12] if decision.head_sha else "?"
+        click.echo(f"Already checkpointed at {head} — nothing to do.")
+    else:
+        click.echo(
+            f"Checkpoint created: {record.head_sha[:12]} (session={record.session_id})"
+        )
+
+
+@main.command("list")
+@click.argument(
+    "path", required=False, type=click.Path(file_okay=False, path_type=Path)
+)
+def cmd_list(path: Path | None) -> None:
+    """List recorded checkpoints for the workspace."""
+    target = path or Path.cwd()
+    decision = classify(target)
+    if decision.repo_root is None:
+        click.echo(f"checkpoint: {decision.reason}", err=True)
+        sys.exit(1)
+
+    records = list_checkpoints(decision.repo_root)
+    if not records:
+        click.echo("No checkpoints yet.")
+        return
+
+    current_sha = decision.head_sha or ""
+    click.echo(f"{'#':>3}  {'Session':<14}  {'Timestamp':<20}  {'HEAD':<12}  Workspace")
+    for i, r in enumerate(records, start=1):
+        marker = " *" if r.head_sha == current_sha else ""
+        ts = r.timestamp[:19].replace("T", " ")
+        click.echo(
+            f"{i:>3}  {r.session_id:<14}  {ts:<20}  {r.head_sha[:12]:<12}  "
+            f"{r.workspace}{marker}"
+        )
+
+
+@main.command("diff")
+@click.argument("identifier")
+@click.argument(
+    "path", required=False, type=click.Path(file_okay=False, path_type=Path)
+)
+def cmd_diff(identifier: str, path: Path | None) -> None:
+    """Diff current state against a checkpoint."""
+    target = path or Path.cwd()
+    try:
+        output = diff_checkpoint(target, identifier)
+    except CheckpointError as exc:
+        click.echo(f"checkpoint: {exc}", err=True)
+        sys.exit(1)
+
+    if output:
+        click.echo(output, nl=False)
+    else:
+        click.echo("No changes since checkpoint.")
+
+
+@main.command("restore")
+@click.argument("identifier")
+@click.argument(
+    "path", required=False, type=click.Path(file_okay=False, path_type=Path)
+)
+@click.option(
+    "--include-dirty",
+    is_flag=True,
+    help="Allow restore in a dirty workspace (DISCARDS uncommitted changes).",
+)
+def cmd_restore(identifier: str, path: Path | None, include_dirty: bool) -> None:
+    """Restore working tree to a checkpoint HEAD via ``git reset --hard``."""
+    target = path or Path.cwd()
+    try:
+        result = restore_checkpoint(target, identifier, include_dirty=include_dirty)
+    except CheckpointError as exc:
+        click.echo(f"checkpoint: {exc}", err=True)
+        sys.exit(1)
+
+    click.echo(result)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/gptme/cli/checkpoint.py
+++ b/gptme/cli/checkpoint.py
@@ -50,7 +50,7 @@ def cmd_create(
     """Record a checkpoint at the current HEAD."""
     target = path or Path.cwd()
     try:
-        record = create_checkpoint(
+        record, existing_sha = create_checkpoint(
             target,
             session_id=session_id,
             include_dirty=include_dirty,
@@ -60,8 +60,7 @@ def cmd_create(
         sys.exit(1)
 
     if record is None:
-        decision = classify(target)
-        head = decision.head_sha[:12] if decision.head_sha else "?"
+        head = existing_sha[:12] if existing_sha else "?"
         click.echo(f"Already checkpointed at {head} — nothing to do.")
     else:
         click.echo(

--- a/gptme/dirs.py
+++ b/gptme/dirs.py
@@ -4,7 +4,7 @@ import shutil
 import subprocess
 from pathlib import Path
 
-from platformdirs import user_config_dir, user_data_dir
+from platformdirs import user_config_dir, user_data_dir, user_state_dir
 
 logger = logging.getLogger(__name__)
 
@@ -32,6 +32,17 @@ def get_data_dir() -> Path:
         return old
 
     return Path(user_data_dir("gptme"))
+
+
+def get_state_dir() -> Path:
+    """Get the path for **transient state** (XDG_STATE_HOME).
+
+    Used for recovery artifacts and other state that should persist between
+    invocations but is not important enough to back up — checkpoints, etc.
+    """
+    if "XDG_STATE_HOME" in os.environ:
+        return Path(os.environ["XDG_STATE_HOME"]) / "gptme"
+    return Path(user_state_dir("gptme"))
 
 
 def get_logs_dir() -> Path:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ gptme-doctor = "gptme.cli.doctor:main"
 gptme-auth = "gptme.cli.auth:main"
 gptme-onboard = "gptme.cli.onboard:main"
 gptme-wut = "gptme.cli.wut:main"
+gptme-checkpoint = "gptme.cli.checkpoint:main"
 gptme-dspy = "gptme.eval.dspy:main"
 gptme-eval-trends = "gptme.eval.trends:main"
 

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -1,0 +1,277 @@
+"""Tests for gptme.checkpoint and the gptme-checkpoint CLI."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+from click.testing import CliRunner
+
+from gptme.checkpoint import (
+    CheckpointError,
+    classify,
+    create_checkpoint,
+    diff_checkpoint,
+    get_ledger_path,
+    list_checkpoints,
+    repo_fingerprint,
+    restore_checkpoint,
+)
+from gptme.cli.checkpoint import main as checkpoint_main
+
+# --- Fixtures ---
+
+
+@pytest.fixture(autouse=True)
+def isolated_state_dir(tmp_path, monkeypatch):
+    """Force ledger to live under a per-test XDG_STATE_HOME."""
+    state = tmp_path / "xdg-state"
+    state.mkdir()
+    monkeypatch.setenv("XDG_STATE_HOME", str(state))
+    return state
+
+
+def _git(cwd: Path, *args: str) -> str:
+    return subprocess.check_output(["git", *args], cwd=str(cwd), text=True).strip()
+
+
+@pytest.fixture
+def clean_repo(tmp_path):
+    """Single-root git repo with one committed file, no dirty state."""
+    repo = tmp_path / "clean-repo"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "test-branch")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test")
+    _git(repo, "config", "core.hooksPath", "/dev/null")
+    (repo / "README.md").write_text("hello\n")
+    _git(repo, "add", "README.md")
+    _git(repo, "commit", "-q", "-m", "init")
+    return repo
+
+
+@pytest.fixture
+def dirty_repo(clean_repo):
+    """A clean repo plus an uncommitted edit and an untracked file."""
+    (clean_repo / "README.md").write_text("hello\nmodified\n")
+    (clean_repo / "untracked.txt").write_text("scratch\n")
+    return clean_repo
+
+
+@pytest.fixture
+def non_git_dir(tmp_path):
+    d = tmp_path / "loose"
+    d.mkdir()
+    return d
+
+
+# --- classify ---
+
+
+def test_classify_clean_git(clean_repo):
+    decision = classify(clean_repo)
+    assert decision.kind == "clean_git"
+    assert decision.repo_root == clean_repo.resolve()
+    assert decision.head_sha is not None
+    assert decision.dirty_tracked == 0
+    assert decision.untracked == 0
+    assert decision.safe_to_create()
+    assert decision.safe_to_restore()
+
+
+def test_classify_dirty_git(dirty_repo):
+    decision = classify(dirty_repo)
+    assert decision.kind == "dirty_git"
+    assert decision.dirty_tracked == 1
+    assert decision.untracked == 1
+    assert not decision.safe_to_create()
+
+
+def test_classify_non_git(non_git_dir):
+    decision = classify(non_git_dir)
+    assert decision.kind == "non_git"
+    assert decision.repo_root is None
+    assert decision.head_sha is None
+    assert not decision.safe_to_create()
+
+
+# --- repo_fingerprint / ledger path ---
+
+
+def test_repo_fingerprint_stable(clean_repo):
+    fp1 = repo_fingerprint(clean_repo)
+    fp2 = repo_fingerprint(clean_repo)
+    assert fp1 == fp2
+    assert len(fp1) == 16
+    assert all(c in "0123456789abcdef" for c in fp1)
+
+
+def test_repo_fingerprint_differs_per_repo(tmp_path, clean_repo):
+    other = tmp_path / "other-repo"
+    other.mkdir()
+    assert repo_fingerprint(clean_repo) != repo_fingerprint(other)
+
+
+def test_ledger_path_under_xdg_state(clean_repo, isolated_state_dir):
+    path = get_ledger_path(clean_repo)
+    assert isolated_state_dir in path.parents
+    assert path.suffix == ".jsonl"
+
+
+def test_ledger_path_does_not_dirty_user_repo(clean_repo):
+    """The whole point of XDG storage: never write inside the user repo."""
+    create_checkpoint(clean_repo)
+    assert not (clean_repo / ".gptme").exists()
+    decision = classify(clean_repo)
+    assert decision.kind == "clean_git"  # still clean after checkpoint
+
+
+# --- create_checkpoint ---
+
+
+def test_create_checkpoint_clean(clean_repo):
+    rec = create_checkpoint(clean_repo)
+    assert rec is not None
+    assert rec.head_sha == _git(clean_repo, "rev-parse", "HEAD")
+    assert rec.workspace == str(clean_repo.resolve())
+
+    ledger = get_ledger_path(clean_repo)
+    assert ledger.exists()
+    line = ledger.read_text().strip()
+    data = json.loads(line)
+    assert data["head_sha"] == rec.head_sha
+
+
+def test_create_checkpoint_idempotent_at_same_head(clean_repo):
+    first = create_checkpoint(clean_repo)
+    second = create_checkpoint(clean_repo)
+    assert first is not None
+    assert second is None  # idempotent — no duplicate adjacent records
+    assert len(list_checkpoints(clean_repo)) == 1
+
+
+def test_create_checkpoint_dirty_refused_without_flag(dirty_repo):
+    with pytest.raises(CheckpointError, match="--include-dirty"):
+        create_checkpoint(dirty_repo)
+
+
+def test_create_checkpoint_dirty_with_include_dirty(dirty_repo):
+    rec = create_checkpoint(dirty_repo, include_dirty=True)
+    assert rec is not None
+
+
+def test_create_checkpoint_non_git_refused(non_git_dir):
+    with pytest.raises(CheckpointError, match="non_git"):
+        create_checkpoint(non_git_dir)
+
+
+def test_create_checkpoint_after_new_commit_appends(clean_repo):
+    create_checkpoint(clean_repo)
+    (clean_repo / "second.txt").write_text("two\n")
+    _git(clean_repo, "add", "second.txt")
+    _git(clean_repo, "commit", "-q", "-m", "two")
+    second = create_checkpoint(clean_repo)
+    assert second is not None
+    assert len(list_checkpoints(clean_repo)) == 2
+
+
+# --- restore_checkpoint ---
+
+
+def test_restore_clean_repo_returns_to_checkpoint(clean_repo):
+    first = create_checkpoint(clean_repo)
+    assert first is not None
+
+    (clean_repo / "added.txt").write_text("added\n")
+    _git(clean_repo, "add", "added.txt")
+    _git(clean_repo, "commit", "-q", "-m", "add")
+
+    msg = restore_checkpoint(clean_repo, "1")
+    assert "Restored to checkpoint" in msg
+    assert _git(clean_repo, "rev-parse", "HEAD") == first.head_sha
+    assert not (clean_repo / "added.txt").exists()
+
+
+def test_restore_at_same_head_is_noop(clean_repo):
+    create_checkpoint(clean_repo)
+    msg = restore_checkpoint(clean_repo, "1")
+    assert "Already at checkpoint" in msg
+
+
+def test_restore_dirty_refused_without_flag(clean_repo):
+    create_checkpoint(clean_repo)
+    (clean_repo / "added.txt").write_text("added\n")
+    _git(clean_repo, "add", "added.txt")
+    _git(clean_repo, "commit", "-q", "-m", "add")
+    (clean_repo / "README.md").write_text("now-dirty\n")
+
+    with pytest.raises(CheckpointError, match="--include-dirty"):
+        restore_checkpoint(clean_repo, "1")
+
+
+def test_restore_unknown_identifier(clean_repo):
+    create_checkpoint(clean_repo)
+    with pytest.raises(CheckpointError, match="not found|out of range"):
+        restore_checkpoint(clean_repo, "99")
+
+
+# --- diff_checkpoint ---
+
+
+def test_diff_checkpoint_shows_changes(clean_repo):
+    create_checkpoint(clean_repo)
+    (clean_repo / "new.txt").write_text("new\n")
+    _git(clean_repo, "add", "new.txt")
+    _git(clean_repo, "commit", "-q", "-m", "add new")
+
+    out = diff_checkpoint(clean_repo, "1")
+    assert "new.txt" in out
+
+
+# --- CLI ---
+
+
+def test_cli_create_and_list(clean_repo):
+    runner = CliRunner()
+    result = runner.invoke(checkpoint_main, ["create", str(clean_repo)])
+    assert result.exit_code == 0, result.output
+    assert "Checkpoint created" in result.output
+
+    result = runner.invoke(checkpoint_main, ["list", str(clean_repo)])
+    assert result.exit_code == 0, result.output
+    assert "Workspace" in result.output  # header present
+    assert str(clean_repo.resolve()) in result.output
+
+
+def test_cli_create_dirty_refused(dirty_repo):
+    runner = CliRunner()
+    result = runner.invoke(checkpoint_main, ["create", str(dirty_repo)])
+    assert result.exit_code == 1
+    assert "include-dirty" in result.output
+
+
+def test_cli_restore_roundtrip(clean_repo):
+    first_head = _git(clean_repo, "rev-parse", "HEAD")
+    runner = CliRunner()
+    runner.invoke(checkpoint_main, ["create", str(clean_repo)])
+
+    (clean_repo / "extra.txt").write_text("e\n")
+    _git(clean_repo, "add", "extra.txt")
+    _git(clean_repo, "commit", "-q", "-m", "extra")
+
+    result = runner.invoke(checkpoint_main, ["restore", "1", str(clean_repo)])
+    assert result.exit_code == 0, result.output
+    assert "Restored" in result.output
+    assert _git(clean_repo, "rev-parse", "HEAD") == first_head
+
+
+def test_cli_list_empty_repo(clean_repo):
+    runner = CliRunner()
+    result = runner.invoke(checkpoint_main, ["list", str(clean_repo)])
+    assert result.exit_code == 0
+    assert "No checkpoints" in result.output

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -135,8 +135,9 @@ def test_ledger_path_does_not_dirty_user_repo(clean_repo):
 
 
 def test_create_checkpoint_clean(clean_repo):
-    rec = create_checkpoint(clean_repo)
+    rec, sha = create_checkpoint(clean_repo)
     assert rec is not None
+    assert sha is None
     assert rec.head_sha == _git(clean_repo, "rev-parse", "HEAD")
     assert rec.workspace == str(clean_repo.resolve())
 
@@ -148,10 +149,11 @@ def test_create_checkpoint_clean(clean_repo):
 
 
 def test_create_checkpoint_idempotent_at_same_head(clean_repo):
-    first = create_checkpoint(clean_repo)
-    second = create_checkpoint(clean_repo)
+    first, _ = create_checkpoint(clean_repo)
+    second, existing_sha = create_checkpoint(clean_repo)
     assert first is not None
     assert second is None  # idempotent — no duplicate adjacent records
+    assert existing_sha == first.head_sha  # SHA returned instead of re-running classify
     assert len(list_checkpoints(clean_repo)) == 1
 
 
@@ -161,7 +163,7 @@ def test_create_checkpoint_dirty_refused_without_flag(dirty_repo):
 
 
 def test_create_checkpoint_dirty_with_include_dirty(dirty_repo):
-    rec = create_checkpoint(dirty_repo, include_dirty=True)
+    rec, _ = create_checkpoint(dirty_repo, include_dirty=True)
     assert rec is not None
 
 
@@ -175,7 +177,7 @@ def test_create_checkpoint_after_new_commit_appends(clean_repo):
     (clean_repo / "second.txt").write_text("two\n")
     _git(clean_repo, "add", "second.txt")
     _git(clean_repo, "commit", "-q", "-m", "two")
-    second = create_checkpoint(clean_repo)
+    second, _ = create_checkpoint(clean_repo)
     assert second is not None
     assert len(list_checkpoints(clean_repo)) == 2
 
@@ -184,7 +186,7 @@ def test_create_checkpoint_after_new_commit_appends(clean_repo):
 
 
 def test_restore_clean_repo_returns_to_checkpoint(clean_repo):
-    first = create_checkpoint(clean_repo)
+    first, _ = create_checkpoint(clean_repo)
     assert first is not None
 
     (clean_repo / "added.txt").write_text("added\n")
@@ -222,7 +224,7 @@ def test_restore_unknown_identifier(clean_repo):
 
 def test_restore_include_dirty_removes_untracked(clean_repo):
     """--include-dirty restore must also remove untracked files (git clean -fd)."""
-    first = create_checkpoint(clean_repo, include_dirty=True)
+    first, _ = create_checkpoint(clean_repo, include_dirty=True)
     assert first is not None
 
     # Advance HEAD with a new commit so restore actually moves.
@@ -251,7 +253,7 @@ def test_resolve_index_above_999(clean_repo):
     (clean_repo / "b.txt").write_text("b\n")
     _git(clean_repo, "add", "b.txt")
     _git(clean_repo, "commit", "-q", "-m", "b")
-    second = create_checkpoint(clean_repo)
+    second, _ = create_checkpoint(clean_repo)
     assert second is not None
 
     # "2" should resolve even though len("2") == 1; confirm "10" raises out-of-range

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -220,6 +220,46 @@ def test_restore_unknown_identifier(clean_repo):
         restore_checkpoint(clean_repo, "99")
 
 
+def test_restore_include_dirty_removes_untracked(clean_repo):
+    """--include-dirty restore must also remove untracked files (git clean -fd)."""
+    first = create_checkpoint(clean_repo, include_dirty=True)
+    assert first is not None
+
+    # Advance HEAD with a new commit so restore actually moves.
+    (clean_repo / "second.txt").write_text("two\n")
+    _git(clean_repo, "add", "second.txt")
+    _git(clean_repo, "commit", "-q", "-m", "second")
+
+    # Add an untracked file *after* the checkpoint — simulate agent-created scratch.
+    (clean_repo / "scratch.txt").write_text("scratch\n")
+    assert (clean_repo / "scratch.txt").exists()
+
+    msg = restore_checkpoint(clean_repo, "1", include_dirty=True)
+    assert "Restored" in msg
+    assert _git(clean_repo, "rev-parse", "HEAD") == first.head_sha
+    assert not (clean_repo / "second.txt").exists()
+    assert not (clean_repo / "scratch.txt").exists(), (
+        "untracked file survived --include-dirty restore (git clean -fd not run)"
+    )
+
+
+def test_resolve_index_above_999(clean_repo):
+    """Index resolution must work for indices with 4+ digits."""
+    # Create two checkpoints; verify index "10" (4+ digit threshold doesn't apply
+    # at small counts, but isdigit() should handle large numbers too).
+    create_checkpoint(clean_repo)
+    (clean_repo / "b.txt").write_text("b\n")
+    _git(clean_repo, "add", "b.txt")
+    _git(clean_repo, "commit", "-q", "-m", "b")
+    second = create_checkpoint(clean_repo)
+    assert second is not None
+
+    # "2" should resolve even though len("2") == 1; confirm "10" raises out-of-range
+    # (only 2 records) rather than silently falling through to SHA matching.
+    with pytest.raises(CheckpointError, match="out of range"):
+        restore_checkpoint(clean_repo, "10")
+
+
 # --- diff_checkpoint ---
 
 


### PR DESCRIPTION
## Summary

Implements Phase 1 of #2221: a top-level `gptme-checkpoint` CLI for explicit workspace recovery.

```
gptme-checkpoint create [PATH] [--include-dirty] [--session-id ID]
gptme-checkpoint list [PATH]
gptme-checkpoint diff <id> [PATH]
gptme-checkpoint restore <id> [PATH] [--include-dirty]
```

Conservative on purpose:
- `clean_git` workspaces are checkpointed and restored without ceremony.
- `dirty_git` requires explicit `--include-dirty`.
- `non_git` and `multi_root` (extra worktrees / submodules) are refused for MVP.
- `restore` is `git reset --hard <head>`; idempotent at the same HEAD.
- `create` is idempotent at the same HEAD (no duplicate adjacent records).

## Storage

Per the issue's preference, the JSONL ledger lives under
`$XDG_STATE_HOME/gptme/checkpoints/<repo_fingerprint>.jsonl` via a new
`gptme.dirs.get_state_dir()` helper. Nothing is written into the user's repo
— no `.gptme/checkpoints/` directory in the working tree. `repo_fingerprint`
is `sha256(realpath(repo_root))[:16]`, which is stable across symlinks and
deliberately changes if the repo is later moved (recovery artifacts, not
durable history).

## Scope

- This is **workspace recovery**, not conversation backtracking (that's #523).
- The library lives in `gptme.checkpoint` and is callable from other code paths
  — future hooks, a future chat slash command, etc. — but this PR ships only
  the CLI surface.
- `guard` from the dogfood prototype is intentionally **not** included; per
  the issue, ship `create/list/diff/restore` first and revisit `guard` later.

## Background

Bob has a local prototype with the same semantics (58 tests across the
checkpoint slice) that has been driving the upstream design. This PR is the
upstreaming pass: drop repo-local `.gptme/checkpoints/`, switch to XDG state,
and use Click instead of argparse to match the rest of the gptme CLI surface.

Research and design notes referenced from the issue:
- knowledge/research/2026-04-23-agent-checkpoint-patterns.md (peer survey: Claude Code rewind, Cline shadow git, Aider visible commits, OpenHands sandbox)
- knowledge/technical-designs/gptme-checkpoint-command.md (upstream plan)

## Test plan

- [x] `uv run pytest tests/test_checkpoint.py -q` — 22 tests pass locally
- [x] `uv run ruff check gptme/checkpoint.py gptme/cli/checkpoint.py tests/test_checkpoint.py` — clean
- [x] `uv run ruff format` — applied
- [x] mypy — passes (run via pre-commit)
- [x] `gptme-checkpoint --help` smoke-tested after `pip install -e .`
- [ ] Reviewer: try `gptme-checkpoint create && gptme-checkpoint list && gptme-checkpoint restore 1` against a throwaway clean repo
- [ ] Reviewer: confirm refusal messages on a dirty repo and a non-git directory