### PR TITLE
fix(tauri): allow multi-origin CORS so AppImage local setup works

### DIFF
--- a/gptme/server/app.py
+++ b/gptme/server/app.py
@@ -68,20 +68,21 @@ def create_app(cors_origin: str | None = None, host: str = "127.0.0.1") -> flask
         # multiple known webview origins (tauri://localhost on macOS/Linux,
         # http://tauri.localhost on Windows, etc.) in a single flag.
         origins_list = [o.strip() for o in cors_origin.split(",") if o.strip()]
-        origins: str | list[str] = (
-            origins_list[0] if len(origins_list) == 1 else origins_list
-        )
-        # Browsers reject credentials with a wildcard origin.
-        allow_credentials = "*" not in origins_list
-        CORS(
-            app,
-            resources={
-                r"/api/*": {
-                    "origins": origins,
-                    "supports_credentials": allow_credentials,
-                }
-            },
-        )
+        if origins_list:
+            origins: str | list[str] = (
+                origins_list[0] if len(origins_list) == 1 else origins_list
+            )
+            # Browsers reject credentials with a wildcard origin.
+            allow_credentials = "*" not in origins_list
+            CORS(
+                app,
+                resources={
+                    r"/api/*": {
+                        "origins": origins,
+                        "supports_credentials": allow_credentials,
+                    }
+                },
+            )
 
     # Initialize auth (defaults to local-only, no auth required)
     from .auth import init_auth  # fmt: skip

--- a/gptme/server/app.py
+++ b/gptme/server/app.py
@@ -23,7 +23,10 @@ def create_app(cors_origin: str | None = None, host: str = "127.0.0.1") -> flask
     """Create the Flask app.
 
     Args:
-        cors_origin: CORS origin to allow. Use '*' to allow all origins.
+        cors_origin: CORS origin(s) to allow. Use '*' to allow all origins.
+            A comma-separated string allows multiple origins, e.g.
+            "tauri://localhost,http://tauri.localhost". Whitespace around
+            entries is ignored.
     """
     app = flask.Flask(__name__, static_folder=static_path)
 
@@ -61,13 +64,20 @@ def create_app(cors_origin: str | None = None, host: str = "127.0.0.1") -> flask
     logger.info("OpenAPI documentation available at /api/docs/")
 
     if cors_origin:
-        # Only allow credentials if a specific origin is set (not '*')
-        allow_credentials = cors_origin != "*" if cors_origin else False
+        # Support comma-separated origins so the desktop sidecar can allow
+        # multiple known webview origins (tauri://localhost on macOS/Linux,
+        # http://tauri.localhost on Windows, etc.) in a single flag.
+        origins_list = [o.strip() for o in cors_origin.split(",") if o.strip()]
+        origins: str | list[str] = (
+            origins_list[0] if len(origins_list) == 1 else origins_list
+        )
+        # Browsers reject credentials with a wildcard origin.
+        allow_credentials = "*" not in origins_list
         CORS(
             app,
             resources={
                 r"/api/*": {
-                    "origins": cors_origin,
+                    "origins": origins,
                     "supports_credentials": allow_credentials,
                 }
             },

--- a/gptme/server/cli.py
+++ b/gptme/server/cli.py
@@ -55,7 +55,11 @@ def main():
 @click.option(
     "--cors-origin",
     default=None,
-    help="CORS origin to allow. Use '*' to allow all origins.",
+    help=(
+        "CORS origin(s) to allow. Use '*' to allow all origins. Pass a "
+        "comma-separated list to allow multiple origins, e.g. "
+        "'tauri://localhost,http://tauri.localhost'."
+    ),
 )
 def serve(
     debug: bool,

--- a/tauri/src-tauri/src/lib.rs
+++ b/tauri/src-tauri/src/lib.rs
@@ -106,10 +106,15 @@ async fn start_server() -> Result<u16, String> {
 fn desktop_cors_origin() -> &'static str {
     if cfg!(debug_assertions) {
         "http://localhost:5701"
-    } else if cfg!(target_os = "macos") {
-        "tauri://localhost"
     } else {
-        "http://tauri.localhost"
+        // Webview origin differs per platform and Tauri version:
+        //   - WKWebView (macOS) / WebKitGTK (Linux) send tauri://localhost
+        //   - WebView2 (Windows) sends http://tauri.localhost
+        //     (and historically https://tauri.localhost)
+        // gptme-server accepts a comma-separated list, so allow all known
+        // origins and let the running webview match whichever it sends.
+        // See: gptme/gptme#2226
+        "tauri://localhost,http://tauri.localhost,https://tauri.localhost"
     }
 }
 

--- a/tests/test_server_cors.py
+++ b/tests/test_server_cors.py
@@ -77,6 +77,17 @@ def test_cors_comma_separated_tolerates_whitespace():
     assert resp.headers.get("Access-Control-Allow-Origin") == "http://tauri.localhost"
 
 
+def test_cors_degenerate_input_ignored():
+    """Degenerate cors_origin values that produce no valid entries are ignored (no crash)."""
+    from gptme.server.app import create_app
+
+    for bad_input in (",", " , ", "  "):
+        app = create_app(cors_origin=bad_input)
+        resp = _api_response_with_origin(app, "tauri://localhost")
+        assert resp.status_code == 200
+        assert "Access-Control-Allow-Origin" not in resp.headers
+
+
 def test_cors_wildcard_disables_credentials():
     """Browsers reject credentials with Access-Control-Allow-Origin: *,
     so create_app must not advertise credentials when '*' is in the list."""

--- a/tests/test_server_cors.py
+++ b/tests/test_server_cors.py
@@ -1,0 +1,89 @@
+"""Tests for the gptme-server CORS origin configuration.
+
+Regression coverage for gptme/gptme#2226: the Tauri sidecar passes a
+comma-separated list of origins so the desktop app works regardless of
+which origin (tauri://localhost, http://tauri.localhost, https://tauri.localhost)
+the platform's webview actually sends.
+"""
+
+import pytest
+
+flask = pytest.importorskip(
+    "flask", reason="flask not installed, install server extras (-E server)"
+)
+pytest.importorskip(
+    "flask_cors", reason="flask-cors not installed, install server extras (-E server)"
+)
+
+
+def _api_response_with_origin(app, origin: str):
+    with app.test_client() as client:
+        return client.get("/api/v2", headers={"Origin": origin})
+
+
+def test_cors_single_origin_allows_match():
+    from gptme.server.app import create_app
+
+    app = create_app(cors_origin="tauri://localhost")
+    resp = _api_response_with_origin(app, "tauri://localhost")
+    assert resp.status_code == 200
+    assert resp.headers.get("Access-Control-Allow-Origin") == "tauri://localhost"
+
+
+def test_cors_single_origin_rejects_mismatch():
+    from gptme.server.app import create_app
+
+    app = create_app(cors_origin="tauri://localhost")
+    resp = _api_response_with_origin(app, "http://tauri.localhost")
+    # The request still succeeds at the Flask level, but Flask-CORS does not
+    # echo the Allow-Origin header back when the origin does not match.
+    assert resp.status_code == 200
+    assert "Access-Control-Allow-Origin" not in resp.headers
+
+
+def test_cors_comma_separated_allows_each_origin():
+    """Regression for gptme/gptme#2226 — sidecar must accept all platform webview origins."""
+    from gptme.server.app import create_app
+
+    app = create_app(
+        cors_origin="tauri://localhost,http://tauri.localhost,https://tauri.localhost"
+    )
+
+    for origin in (
+        "tauri://localhost",
+        "http://tauri.localhost",
+        "https://tauri.localhost",
+    ):
+        resp = _api_response_with_origin(app, origin)
+        assert resp.status_code == 200, origin
+        assert resp.headers.get("Access-Control-Allow-Origin") == origin, origin
+
+
+def test_cors_comma_separated_rejects_unlisted_origin():
+    from gptme.server.app import create_app
+
+    app = create_app(cors_origin="tauri://localhost,http://tauri.localhost")
+    resp = _api_response_with_origin(app, "https://evil.example")
+    assert resp.status_code == 200
+    assert "Access-Control-Allow-Origin" not in resp.headers
+
+
+def test_cors_comma_separated_tolerates_whitespace():
+    from gptme.server.app import create_app
+
+    app = create_app(cors_origin=" tauri://localhost , http://tauri.localhost ")
+    resp = _api_response_with_origin(app, "http://tauri.localhost")
+    assert resp.status_code == 200
+    assert resp.headers.get("Access-Control-Allow-Origin") == "http://tauri.localhost"
+
+
+def test_cors_wildcard_disables_credentials():
+    """Browsers reject credentials with Access-Control-Allow-Origin: *,
+    so create_app must not advertise credentials when '*' is in the list."""
+    from gptme.server.app import create_app
+
+    app = create_app(cors_origin="*")
+    resp = _api_response_with_origin(app, "https://example.com")
+    assert resp.status_code == 200
+    # No credentials header should be set when wildcard is in use
+    assert resp.headers.get("Access-Control-Allow-Credentials") != "true"


### PR DESCRIPTION
## Summary

Fixes gptme/gptme#2226 — the packaged Tauri AppImage on Linux fails first-run local setup because the bundled `gptme-server` is started with CORS origin `http://tauri.localhost`, but the WebKitGTK webview actually sends `Origin: tauri://localhost`. The sidecar is healthy, but the webview can't talk to it.

The webview origin differs by platform/engine:

| Platform | Engine | Origin |
|---|---|---|
| macOS | WKWebView | `tauri://localhost` |
| Linux | WebKitGTK | `tauri://localhost` |
| Windows | WebView2 | `http://tauri.localhost` (and historically `https://`) |

Rather than hardcode a per-OS branch in Rust (and risk the next Tauri version flipping it again), allow multiple origins.

## Changes

- **`gptme/server/app.py`** — `--cors-origin` now accepts a comma-separated list. Single origins keep their old behavior; lists are passed to Flask-CORS as a list. Wildcard (`*`) anywhere in the list disables credentials (browsers reject credentials with wildcard).
- **`gptme/server/cli.py`** — help text documents the comma-separated form.
- **`tauri/src-tauri/src/lib.rs`** — release builds now pass `tauri://localhost,http://tauri.localhost,https://tauri.localhost` for all platforms. The running webview matches whichever origin it actually sends; the others are inert.
- **`tests/test_server_cors.py`** — new regression tests:
  - single origin allowed match / mismatch rejected
  - comma-separated: each listed origin allowed
  - comma-separated: unlisted origin rejected
  - whitespace tolerated around entries
  - wildcard disables credentials

## Test plan

- [x] `pytest tests/test_server_cors.py` — 6/6 pass locally
- [x] `pytest tests/test_server.py -k "test_root or test_api_root"` — existing server tests still pass
- [ ] CI: clippy + full test suite (clippy was skipped locally — this VM doesn't have gtk dev libs installed; CI runs it cleanly)
- [ ] Manual: rebuild AppImage and verify `Connect` succeeds in the Local setup wizard on Linux

## Notes

This addresses the CORS half of #2226. The second observation in that issue ("the wizard falls back to the non-Tauri/manual branches, suggesting `isTauriEnvironment()` is false in packaged builds") is a separate bug that needs its own PR — not touched here.

Fixes gptme/gptme#2226