### PR TITLE
fix(webui): show actionable connection error details

### DIFF
--- a/webui/src/contexts/ApiContext.tsx
+++ b/webui/src/contexts/ApiContext.tsx
@@ -147,6 +147,16 @@ export function ApiProvider({
         const connected = await client.checkConnection();
         console.log('[ApiContext] Connected:', connected);
         if (!connected) {
+          // Build an informative error from the structured probe result
+          const probe = client.lastConnectionResult$.get();
+          if (probe && !probe.ok) {
+            const err = new Error(probe.message);
+            (err as Error & { probeUrl?: string; probeStatus?: number }).probeUrl = probe.url;
+            if (probe.status !== undefined) {
+              (err as Error & { probeStatus?: number }).probeStatus = probe.status;
+            }
+            throw err;
+          }
           throw new Error('Failed to connect to API');
         }
 
@@ -163,8 +173,29 @@ export function ApiProvider({
         console.error('Failed to connect to API:', error);
         client.setConnected(false);
 
+        const probe = client.lastConnectionResult$.get();
         let errorMessage = 'Could not connect to gptme instance.';
-        if (error instanceof Error) {
+        if (probe && !probe.ok) {
+          // Show the URL we tried, distinguish 401 from "server not running",
+          // and explain CORS issues so users know what to fix.
+          errorMessage += ` Tried ${probe.url}.`;
+          if (probe.reason === 'http_error' && probe.status === 401) {
+            errorMessage +=
+              ' Server is running but rejected the request (401). Check the API key / auth token in settings.';
+          } else if (probe.reason === 'http_error' && probe.status === 403) {
+            errorMessage += ' Server returned 403 Forbidden — check auth token / permissions.';
+          } else if (probe.reason === 'http_error') {
+            errorMessage += ` ${probe.message}.`;
+          } else if (probe.reason === 'cors') {
+            errorMessage += ` ${probe.message}.`;
+          } else if (probe.reason === 'parse_error') {
+            errorMessage += ` ${probe.message} — is this URL really a gptme server?`;
+          } else if (probe.reason === 'timeout') {
+            errorMessage += ' Request timed out after 3s — server may be slow or unreachable.';
+          } else {
+            errorMessage += ` ${probe.message}.`;
+          }
+        } else if (error instanceof Error) {
           if (error.message.includes('NetworkError') || error.message.includes('CORS')) {
             errorMessage +=
               ' CORS issue detected - ensure the server has CORS enabled and is accepting requests from ' +

--- a/webui/src/contexts/ApiContext.tsx
+++ b/webui/src/contexts/ApiContext.tsx
@@ -150,12 +150,7 @@ export function ApiProvider({
           // Build an informative error from the structured probe result
           const probe = client.lastConnectionResult$.get();
           if (probe && !probe.ok) {
-            const err = new Error(probe.message);
-            (err as Error & { probeUrl?: string; probeStatus?: number }).probeUrl = probe.url;
-            if (probe.status !== undefined) {
-              (err as Error & { probeStatus?: number }).probeStatus = probe.status;
-            }
-            throw err;
+            throw new Error(probe.message);
           }
           throw new Error('Failed to connect to API');
         }
@@ -191,7 +186,7 @@ export function ApiProvider({
           } else if (probe.reason === 'parse_error') {
             errorMessage += ` ${probe.message} — is this URL really a gptme server?`;
           } else if (probe.reason === 'timeout') {
-            errorMessage += ' Request timed out after 3s — server may be slow or unreachable.';
+            errorMessage += ` ${probe.message}.`;
           } else {
             errorMessage += ` ${probe.message}.`;
           }

--- a/webui/src/contexts/__tests__/ApiContext.test.tsx
+++ b/webui/src/contexts/__tests__/ApiContext.test.tsx
@@ -20,9 +20,11 @@ const mockToastSuccess = jest.fn();
 const mockToastError = jest.fn();
 
 const isConnected$ = observable(false);
+const lastConnectionResult$ = observable<{ ok: boolean } | null>(null);
 
 const mockClient = {
   isConnected$,
+  lastConnectionResult$,
   checkConnection: (...args: unknown[]) => mockCheckConnection(...args),
   setConnected: (...args: [boolean]) => mockSetConnected(...args),
 };
@@ -123,6 +125,7 @@ describe('ApiProvider mobile auto-connect', () => {
     window.history.replaceState(null, '', '/');
     jest.clearAllMocks();
     isConnected$.set(false);
+    lastConnectionResult$.set(null);
     setActiveServerBaseUrl('http://127.0.0.1:5700');
 
     mockSetConnected.mockImplementation((connected: boolean) => {

--- a/webui/src/utils/api.ts
+++ b/webui/src/utils/api.ts
@@ -40,6 +40,17 @@ function isApiErrorResponse(response: unknown): response is ApiError {
   return typeof response === 'object' && response !== null && 'error' in response;
 }
 
+// Result of a connection probe — captures enough context for a useful user-facing message.
+export type ConnectionProbeResult =
+  | { ok: true; url: string }
+  | {
+      ok: false;
+      url: string;
+      reason: 'network' | 'http_error' | 'parse_error' | 'timeout' | 'cors';
+      status?: number;
+      message: string;
+    };
+
 export interface ToolPendingEvent {
   type: 'tool_pending';
   tool_id: string;
@@ -59,6 +70,8 @@ export class ApiClient {
   public baseUrl: string;
   public authHeader: string | null = null;
   public readonly isConnected$: Observable<boolean> = observable(false);
+  public readonly lastConnectionResult$: Observable<ConnectionProbeResult | null> =
+    observable<ConnectionProbeResult | null>(null);
   private identifier: string;
   private controller: AbortController | null = null;
   public sessions$: Observable<Map<string, string>> = observable(new Map()); // Map conversation IDs to session IDs
@@ -280,14 +293,21 @@ export class ApiClient {
   }
 
   async checkConnection(): Promise<boolean> {
+    const url = `${this.baseUrl}/api/v2`;
+    console.log('[ApiClient] Checking connection to', this.baseUrl);
     try {
-      // Check the API
-      console.log('[ApiClient] Checking connection to', this.baseUrl);
-      const url = `${this.baseUrl}/api/v2`;
       const response = await this.fetchWithTimeout(url, {}, 3000);
       if (!response.ok) {
         console.error('API endpoint returned non-OK status:', response.status);
         this.isConnected$.set(false);
+        this.lastConnectionResult$.set({
+          ok: false,
+          url,
+          reason: 'http_error',
+          status: response.status,
+          message:
+            `Server responded with HTTP ${response.status} ${response.statusText || ''}`.trim(),
+        });
         return false;
       }
 
@@ -297,18 +317,58 @@ export class ApiClient {
       } catch (parseError) {
         console.error(`[ApiClient] Failed to parse API response from ${url}:`, parseError);
         this.isConnected$.set(false);
+        this.lastConnectionResult$.set({
+          ok: false,
+          url,
+          reason: 'parse_error',
+          message:
+            parseError instanceof Error
+              ? `Server response was not valid JSON: ${parseError.message}`
+              : 'Server response was not valid JSON',
+        });
         return false;
       }
 
       this.isConnected$.set(true);
+      this.lastConnectionResult$.set({ ok: true, url });
       return true;
     } catch (error) {
-      if (error instanceof TypeError && error.message.includes('Failed to fetch')) {
-        console.error('[ApiClient] Network error - server may be down or CORS not configured');
+      const isAbort =
+        (error instanceof DOMException && error.name === 'AbortError') ||
+        (error instanceof Error && error.name === 'AbortError');
+      const isNetwork =
+        error instanceof TypeError &&
+        (error.message.includes('Failed to fetch') ||
+          error.message.includes('NetworkError') ||
+          error.message.includes('CORS'));
+      let reason: 'network' | 'cors' | 'timeout';
+      let message: string;
+      if (isAbort) {
+        reason = 'timeout';
+        message = 'Request timed out after 3s — server may be slow or unreachable';
+      } else if (
+        error instanceof TypeError &&
+        (error.message.includes('CORS') || error.message.includes('NetworkError'))
+      ) {
+        reason = 'cors';
+        message =
+          'Network or CORS error — server may not allow requests from this origin: ' +
+          (typeof window !== 'undefined' ? window.location.origin : 'unknown');
+      } else if (isNetwork) {
+        reason = 'network';
+        message = 'Could not reach server (connection refused or no DNS)';
+      } else {
+        reason = 'network';
+        message = error instanceof Error ? error.message : String(error);
+      }
+
+      if (isNetwork || isAbort) {
+        console.error('[ApiClient] Connection check failed:', message);
       } else {
         console.error('[ApiClient] Connection check failed:', error);
       }
       this.isConnected$.set(false);
+      this.lastConnectionResult$.set({ ok: false, url, reason, message });
       return false;
     }
   }


### PR DESCRIPTION
## Summary

Fixes Friction #2 from gptme/gptme#2225: the "Failed to connect to API" toast threw away all diagnostic context, so users who followed Local setup instructions correctly got stuck with no idea what to fix.

**Before:**
> Could not connect to gptme instance. Error: Failed to connect to API

**After (a few examples):**
> Could not connect to gptme instance. Tried `http://127.0.0.1:5700/api/v2`. Server is running but rejected the request (401). Check the API key / auth token in settings.

> Could not connect to gptme instance. Tried `http://127.0.0.1:5700/api/v2`. Request timed out after 3s — server may be slow or unreachable.

> Could not connect to gptme instance. Tried `https://other:5700/api/v2`. Network or CORS error — server may not allow requests from this origin: https://chat.gptme.org.

## Approach

- New exported type `ConnectionProbeResult` (discriminated union) capturing url, reason (`network` / `http_error` / `parse_error` / `timeout` / `cors`), HTTP status, and a human message.
- `ApiClient.lastConnectionResult$` observable populated by `checkConnection()` on every probe — success and failure paths both write it.
- `ApiContext.tsx` reads the structured result on connection failure to build a precise toast (special-cased 401/403 since those are common in this onboarding flow).
- `checkConnection()` retains its `Promise<boolean>` signature, so the three other callers (`ServerSelector`, `ServerConfiguration`, second ApiContext call site) don't change.

## Verification

- `npm run lint` ✅
- `npm run typecheck` ✅
- `npm test` → 19 suites / 172 tests, all pass ✅
- `npm run build` ✅

## Out of scope

- Friction #1 (auto-start bundled server) and Friction #3 (auth flow in Local setup) from gptme/gptme#2225 are separate fixes. This PR addresses #2 only.

## References

- gptme/gptme#2225 (Friction #2)