### PR TITLE
feat(webui): submit SetupWizard inputs on Enter key

### DIFF
--- a/webui/src/components/SetupWizard.tsx
+++ b/webui/src/components/SetupWizard.tsx
@@ -517,6 +517,12 @@ export function SetupWizard() {
                     placeholder="https://bob.example.com"
                     value={remoteBaseUrl}
                     onChange={(event) => setRemoteBaseUrl(event.target.value)}
+                    onKeyDown={(event) => {
+                      if (event.key === 'Enter' && !isConnecting) {
+                        event.preventDefault();
+                        void handleRemoteSetup();
+                      }
+                    }}
                   />
                   <Input
                     autoComplete="off"
@@ -524,6 +530,12 @@ export function SetupWizard() {
                     type="password"
                     value={remoteAuthToken}
                     onChange={(event) => setRemoteAuthToken(event.target.value)}
+                    onKeyDown={(event) => {
+                      if (event.key === 'Enter' && !isConnecting) {
+                        event.preventDefault();
+                        void handleRemoteSetup();
+                      }
+                    }}
                   />
                   <p className="text-xs text-muted-foreground">
                     For Bob or other self-hosted servers, paste the base URL and token here.
@@ -725,6 +737,12 @@ export function SetupWizard() {
                         placeholder={API_KEY_PROVIDER_METADATA[apiKeyProvider].placeholder}
                         value={apiKey}
                         onChange={(e) => setApiKey(e.target.value)}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter' && !apiKeySaving && apiKey.trim().length > 0) {
+                            e.preventDefault();
+                            void handleSaveApiKey();
+                          }
+                        }}
                         disabled={apiKeySaving}
                       />
                     </div>

--- a/webui/src/components/__tests__/SetupWizard.test.tsx
+++ b/webui/src/components/__tests__/SetupWizard.test.tsx
@@ -309,6 +309,41 @@ describe('SetupWizard', () => {
     });
   });
 
+  it('submits remote server form when pressing Enter in the URL field', async () => {
+    mockIsTauriEnvironment.mockReturnValue(true);
+    mockUseTauriServerStatus.mockReturnValue({
+      isLoading: false,
+      managesLocalServer: false,
+      serverStatus: {
+        running: false,
+        port: 5700,
+        port_available: false,
+        manages_local_server: false,
+      },
+    });
+    mockConnect.mockResolvedValue(undefined);
+
+    render(
+      <SettingsProvider>
+        <SetupWizard />
+      </SettingsProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /get started/i }));
+    fireEvent.click(screen.getByRole('button', { name: /remote server/i }));
+    const urlInput = screen.getByPlaceholderText('https://bob.example.com');
+    fireEvent.change(urlInput, { target: { value: 'https://bob.example.com/' } });
+    fireEvent.keyDown(urlInput, { key: 'Enter' });
+
+    await waitFor(() => {
+      expect(mockConnect).toHaveBeenCalledWith({
+        baseUrl: 'https://bob.example.com',
+        authToken: null,
+        useAuthToken: false,
+      });
+    });
+  });
+
   it('waits for tauri status before enabling the server mode choice', () => {
     mockIsTauriEnvironment.mockReturnValue(true);
     mockUseTauriServerStatus.mockReturnValue({
@@ -417,6 +452,135 @@ describe('SetupWizard', () => {
     await waitFor(() => {
       expect(screen.getByRole('heading', { name: /you're all set/i })).toBeInTheDocument();
     });
+  });
+
+  it('saves an API key when pressing Enter in the API key field', async () => {
+    mockIsTauriEnvironment.mockReturnValue(true);
+    mockUseTauriServerStatus.mockReturnValue({
+      isLoading: false,
+      managesLocalServer: true,
+      serverStatus: {
+        running: true,
+        port: 5700,
+        port_available: false,
+        manages_local_server: true,
+      },
+    });
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ provider_configured: false }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          models: [
+            {
+              id: 'anthropic/claude-sonnet-4-7',
+              provider: 'anthropic',
+              model: 'claude-sonnet-4-7',
+            },
+          ],
+          recommended: ['anthropic/claude-sonnet-4-7'],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ status: 'ok', env_var: 'ANTHROPIC_API_KEY' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ provider_configured: true }),
+      });
+    mockConnect.mockImplementation(async () => {
+      isConnected$.set(true);
+    });
+    mockInvokeTauri.mockResolvedValue(undefined);
+
+    render(
+      <SettingsProvider>
+        <SetupWizard />
+      </SettingsProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /get started/i }));
+    fireEvent.click(screen.getByRole('button', { name: /monitor local/i }));
+    fireEvent.click(screen.getByRole('button', { name: /connect/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: /configure a provider/i })).toBeInTheDocument();
+    });
+
+    const apiKeyInput = screen.getByLabelText(/api key/i);
+    fireEvent.change(apiKeyInput, { target: { value: 'sk-ant-test-key' } });
+    fireEvent.keyDown(apiKeyInput, { key: 'Enter' });
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith('http://127.0.0.1:5700/api/v2/user/api-key', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          provider: 'anthropic',
+          api_key: 'sk-ant-test-key',
+          model: 'anthropic/claude-sonnet-4-7',
+        }),
+      });
+    });
+  });
+
+  it('does not submit API key on Enter when the field is empty', async () => {
+    mockIsTauriEnvironment.mockReturnValue(true);
+    mockUseTauriServerStatus.mockReturnValue({
+      isLoading: false,
+      managesLocalServer: true,
+      serverStatus: {
+        running: true,
+        port: 5700,
+        port_available: false,
+        manages_local_server: true,
+      },
+    });
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ provider_configured: false }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ models: [], recommended: [] }),
+      });
+    mockConnect.mockImplementation(async () => {
+      isConnected$.set(true);
+    });
+
+    render(
+      <SettingsProvider>
+        <SetupWizard />
+      </SettingsProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /get started/i }));
+    fireEvent.click(screen.getByRole('button', { name: /monitor local/i }));
+    fireEvent.click(screen.getByRole('button', { name: /connect/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: /configure a provider/i })).toBeInTheDocument();
+    });
+
+    const apiKeyInput = screen.getByLabelText(/api key/i);
+    fireEvent.keyDown(apiKeyInput, { key: 'Enter' });
+
+    // No POST to /api/v2/user/api-key should have been made.
+    const calls = mockFetch.mock.calls.map((c) => c[0]);
+    expect(calls).not.toContain('http://127.0.0.1:5700/api/v2/user/api-key');
   });
 
   it('shows an error instead of falsely completing when the restarted server never comes back', async () => {


### PR DESCRIPTION
## Summary

Pressing **Enter** in the SetupWizard's remote-server URL/token fields and the BYOK API key field now submits the form, matching standard web-form behavior. Previously users had to click the action button, which is unusual friction in a keyboard-driven onboarding flow.

The API key Enter handler also guards against empty submission (the existing button has the same guard), so a stray keypress in an empty field doesn't trigger the "Enter an API key before saving" error path.

Part of the Q2 tauri/webui first-run polish ([gptme/gptme#2193](https://github.com/gptme/gptme/issues/2193)).

## Changes

- `webui/src/components/SetupWizard.tsx`: add `onKeyDown` handlers on the remote-server URL/token inputs (calling `handleRemoteSetup`) and the API key input (calling `handleSaveApiKey`).
- `webui/src/components/__tests__/SetupWizard.test.tsx`: 3 new Jest tests covering URL Enter-submit, API key Enter-submit, and the empty-field Enter no-op.

## Test plan

- [x] `npx jest src/components/__tests__/SetupWizard.test.tsx` — 12/12 pass (3 new)
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint webui/src/components/SetupWizard.tsx webui/src/components/__tests__/SetupWizard.test.tsx` — clean
- [ ] Manual verification on next dev AppImage build (release schedule ~2026-04-26): Enter in URL field on remote-mode setup, Enter in API key field on local-mode provider step.