### PR TITLE
ci(webui): deploy to Cloudflare Pages (fixes chat.gptme.org)

### DIFF
--- a/.github/workflows/webui.yml
+++ b/.github/workflows/webui.yml
@@ -68,7 +68,7 @@ jobs:
         path: dist
 
     - name: Deploy to Cloudflare Pages
-      uses: cloudflare/wrangler-action@v3
+      uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd  # v3
       with:
         apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/webui.yml
+++ b/.github/workflows/webui.yml
@@ -53,6 +53,27 @@ jobs:
         path: webui/dist
         retention-days: 30
 
+  deploy:
+    if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: chat-gptme-org
+      url: https://chat.gptme.org
+    steps:
+    - name: Download dist artifact
+      uses: actions/download-artifact@v6
+      with:
+        name: webui-dist
+        path: dist
+
+    - name: Deploy to Cloudflare Pages
+      uses: cloudflare/wrangler-action@v3
+      with:
+        apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        command: pages deploy dist --project-name=chat-gptme-org
+
   e2e:
     runs-on: ubuntu-latest
     needs: build


### PR DESCRIPTION
## Summary

`chat.gptme.org` stopped updating when the webui moved from the archived `gptme/gptme-webui` repo into `gptme/gptme`. This adds a `deploy` job to `webui.yml` that runs after the build on push to `master`, downloading the already-built `webui-dist` artifact and deploying it to Cloudflare Pages.

Fixes #2174.

## Changes

- Adds a `deploy` job in `webui.yml` (runs on push to `master` only)
- Downloads the `webui-dist` artifact from the `build` job (no redundant rebuild)
- Deploys via `cloudflare/wrangler-action@v3` to project `chat-gptme-org`
- Declares a GitHub Actions `environment` with URL `https://chat.gptme.org` for deployment tracking

## Required admin setup (one-time)

For the job to succeed, these need to be in place:

1. **Cloudflare Pages project**: Create project named `chat-gptme-org` in the Cloudflare dashboard
2. **CNAME**: Point `chat.gptme.org` → `chat-gptme-org.pages.dev`
3. **Repo secrets**: Add `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` to `gptme/gptme` repository secrets

The PR itself is CI-safe — the `deploy` job only runs on push to `master` (not on PRs), so it won't fail CI on this PR.