### PR TITLE
docs: add FAQ section for common questions

### DIFF
--- a/README.md
+++ b/README.md
@@ -592,6 +592,50 @@ Contributions welcome! See the [contributing guide](https://gptme.org/docs/contr
 [pepy]: https://pepy.tech/project/gptme
 [pypistats]: https://pypistats.org/packages/gptme
 
+## 🔗 Links
+
+- [Website][website]
+- [Documentation][docs]
+- [GitHub][github]
+- [Discord][discord]
+
+<!-- links -->
+
+[website]: https://gptme.org/
+[discord]: https://discord.gg/NMaCmmkxWv
+[github]: https://github.com/gptme/gptme
+[gptme.vim]: https://github.com/gptme/gptme.vim
+[gptme-webui]: https://github.com/gptme/gptme/tree/master/webui
+[gptme-rag]: https://github.com/gptme/gptme-rag
+[gptme-contrib]: https://github.com/gptme/gptme-contrib
+[gptme-tauri]: https://github.com/gptme/gptme-tauri
+[agent-template]: https://github.com/gptme/gptme-agent-template
+[bob]: https://github.com/TimeToBuildBob
+[docs]: https://gptme.org/docs/
+[docs-getting-started]: https://gptme.org/docs/getting-started.html
+[docs-examples]: https://gptme.org/docs/examples.html
+[docs-demos]: https://gptme.org/docs/demos.html
+[docs-providers]: https://gptme.org/docs/providers.html
+[docs-tools]: https://gptme.org/docs/tools.html
+[docs-tools-python]: https://gptme.org/docs/tools.html#python
+[docs-tools-shell]: https://gptme.org/docs/tools.html#shell
+[docs-tools-patch]: https://gptme.org/docs/tools.html#patch
+[docs-tools-browser]: https://gptme.org/docs/tools.html#browser
+[docs-tools-computer]: https://gptme.org/docs/tools.html#computer
+[docs-lessons]: https://gptme.org/docs/lessons.html
+[docs-skills]: https://gptme.org/docs/skills.html
+[docs-bot]: https://gptme.org/docs/bot.html
+[docs-server]: https://gptme.org/docs/server.html
+[docs-evals]: https://gptme.org/docs/evals.html
+[docs-config]: https://gptme.org/docs/config.html
+[docs-arewetiny]: https://gptme.org/docs/arewetiny.html
+[docs-plugins]: https://gptme.org/docs/plugins.html
+[docs-hooks]: https://gptme.org/docs/hooks.html
+[docs-commands]: https://gptme.org/docs/commands.html
+[docs-mcp]: https://gptme.org/docs/mcp.html
+[docs-acp]: https://gptme.org/docs/acp.html
+[anthropic-computer-use]: https://www.anthropic.com/news/3-5-models-and-computer-use
+
 ## ❓ FAQ
 
 ### What models are supported?
@@ -623,7 +667,7 @@ export OPENAI_API_BASE="http://localhost:4000"
 By default, gptme asks for confirmation before executing tools (shell commands, file writes, etc.) for safety. You can:
 - Press `y` to approve individual actions
 - Use `--non-interactive` flag for fully autonomous mode (no confirmations, use with caution)
-- Configure auto-approve for specific tools in `gptme.toml`
+- For repeated workflows, the server API and ACP runtime accept a session-level `auto_confirm` parameter
 
 ### How do I use gptme with local models?
 
@@ -678,47 +722,3 @@ Contributions are welcome! See the [contributing guide](https://gptme.org/docs/c
 - **Discord**: [Join our community][discord]
 - **Issues**: [GitHub Issues](https://github.com/gptme/gptme/issues)
 - **Discussions**: [GitHub Discussions](https://github.com/gptme/gptme/discussions)
-
-## 🔗 Links
-
-- [Website][website]
-- [Documentation][docs]
-- [GitHub][github]
-- [Discord][discord]
-
-<!-- links -->
-
-[website]: https://gptme.org/
-[discord]: https://discord.gg/NMaCmmkxWv
-[github]: https://github.com/gptme/gptme
-[gptme.vim]: https://github.com/gptme/gptme.vim
-[gptme-webui]: https://github.com/gptme/gptme/tree/master/webui
-[gptme-rag]: https://github.com/gptme/gptme-rag
-[gptme-contrib]: https://github.com/gptme/gptme-contrib
-[gptme-tauri]: https://github.com/gptme/gptme-tauri
-[agent-template]: https://github.com/gptme/gptme-agent-template
-[bob]: https://github.com/TimeToBuildBob
-[docs]: https://gptme.org/docs/
-[docs-getting-started]: https://gptme.org/docs/getting-started.html
-[docs-examples]: https://gptme.org/docs/examples.html
-[docs-demos]: https://gptme.org/docs/demos.html
-[docs-providers]: https://gptme.org/docs/providers.html
-[docs-tools]: https://gptme.org/docs/tools.html
-[docs-tools-python]: https://gptme.org/docs/tools.html#python
-[docs-tools-shell]: https://gptme.org/docs/tools.html#shell
-[docs-tools-patch]: https://gptme.org/docs/tools.html#patch
-[docs-tools-browser]: https://gptme.org/docs/tools.html#browser
-[docs-tools-computer]: https://gptme.org/docs/tools.html#computer
-[docs-lessons]: https://gptme.org/docs/lessons.html
-[docs-skills]: https://gptme.org/docs/skills.html
-[docs-bot]: https://gptme.org/docs/bot.html
-[docs-server]: https://gptme.org/docs/server.html
-[docs-evals]: https://gptme.org/docs/evals.html
-[docs-config]: https://gptme.org/docs/config.html
-[docs-arewetiny]: https://gptme.org/docs/arewetiny.html
-[docs-plugins]: https://gptme.org/docs/plugins.html
-[docs-hooks]: https://gptme.org/docs/hooks.html
-[docs-commands]: https://gptme.org/docs/commands.html
-[docs-mcp]: https://gptme.org/docs/mcp.html
-[docs-acp]: https://gptme.org/docs/acp.html
-[anthropic-computer-use]: https://www.anthropic.com/news/3-5-models-and-computer-use

--- a/README.md
+++ b/README.md
@@ -592,6 +592,93 @@ Contributions welcome! See the [contributing guide](https://gptme.org/docs/contr
 [pepy]: https://pepy.tech/project/gptme
 [pypistats]: https://pypistats.org/packages/gptme
 
+## ❓ FAQ
+
+### What models are supported?
+
+gptme supports any model provider compatible with OpenAI API format, including:
+- **OpenAI**: GPT-4o, GPT-4.1, o3, o4-mini
+- **Anthropic**: Claude 4 Sonnet, Claude 4 Opus, Claude 3.5 Sonnet
+- **Local models**: Via LiteLLM proxy (Ollama, vLLM, etc.)
+- **Other providers**: Azure, Groq, Bedrock, Vertex AI
+
+Set your model via `MODEL` environment variable or in `gptme.toml`.
+
+### How do I configure API keys?
+
+Set the appropriate environment variable for your provider:
+```bash
+# OpenAI
+export OPENAI_API_KEY="sk-..."
+
+# Anthropic
+export ANTHROPIC_API_KEY="sk-ant-..."
+
+# Custom endpoint (via LiteLLM)
+export OPENAI_API_BASE="http://localhost:4000"
+```
+
+### Why is gptme asking for tool confirmations?
+
+By default, gptme asks for confirmation before executing tools (shell commands, file writes, etc.) for safety. You can:
+- Press `y` to approve individual actions
+- Use `--non-interactive` flag for fully autonomous mode (no confirmations, use with caution)
+- Configure auto-approve for specific tools in `gptme.toml`
+
+### How do I use gptme with local models?
+
+Use LiteLLM as a proxy to connect local models:
+```bash
+# Install LiteLLM proxy
+pip install "litellm[proxy]"
+
+# Start proxy with Ollama
+litellm --model ollama/llama3
+
+# Point gptme to the proxy
+export OPENAI_API_BASE="http://localhost:4000"
+export OPENAI_API_KEY="dummy"
+```
+
+### What is the difference between Skills and Plugins?
+
+- **Skills**: Lightweight workflow bundles (Anthropic format) that auto-load when mentioned. Great for reusable instructions without writing Python.
+- **Plugins**: Python modules that extend gptme with new tools and capabilities. More powerful but require Python knowledge.
+- **Lessons**: Contextual guidance that auto-injects based on keywords, tools, and patterns.
+
+### How do I run gptme in autonomous mode?
+
+Use the `--non-interactive` flag for fully autonomous operation:
+```bash
+gptme --non-interactive "Research the latest developments in AI agents and write a summary"
+```
+
+⚠️ **Warning**: In autonomous mode, gptme can execute commands without confirmation. Use only in safe, isolated environments.
+
+### Can I use gptme as a server/API?
+
+Yes! gptme includes a built-in server mode:
+```bash
+gptme-server
+```
+
+This exposes a REST API for integrating gptme into other applications. See the [Server documentation][docs-server] for details.
+
+### How do I contribute to gptme?
+
+Contributions are welcome! See the [contributing guide](https://gptme.org/docs/contributing.html). Key areas:
+- Bug fixes and feature improvements
+- New tools and plugins
+- Documentation improvements
+- Testing and evaluation
+
+### Where can I get help?
+
+- **Documentation**: [gptme.org/docs](https://gptme.org/docs/)
+- **Discord**: [Join our community][discord]
+- **Issues**: [GitHub Issues](https://github.com/gptme/gptme/issues)
+- **Discussions**: [GitHub Discussions](https://github.com/gptme/gptme/discussions)
+
 ## 🔗 Links
 
 - [Website][website]


### PR DESCRIPTION
## Summary

Add a comprehensive FAQ section to the README to help new users quickly find answers to common questions about gptme.

## Changes

Added FAQ section covering:
- **Model support**: Supported providers (OpenAI, Anthropic, local models via LiteLLM)
- **API key configuration**: Environment variable setup for different providers
- **Tool confirmations**: Understanding and configuring safety prompts
- **Local models**: Using LiteLLM proxy with Ollama/vLLM
- **Skills vs Plugins**: Understanding the extensibility system
- **Autonomous mode**: Running gptme non-interactively
- **Server/API mode**: Using gptme as a REST API server
- **Contributing**: How to contribute to the project
- **Getting help**: Links to documentation, Discord, and issues

## Motivation

The README is comprehensive but lacks a quick-reference FAQ section. New users often have the same questions about model configuration, tool usage, and setup. This FAQ addresses the most common questions directly in the README.

## Checklist
- [x] Content is relevant to gptme's features and configuration
- [x] FAQ entries are specific to this project (not generic)
- [x] Links to existing documentation are preserved
- [x] Changes follow the existing README format and style