### PR TITLE
perf(llm): lazy-load provider imports to speed CLI startup ~1.7s

### DIFF
--- a/gptme/llm/__init__.py
+++ b/gptme/llm/__init__.py
@@ -6,7 +6,7 @@ import time
 from collections.abc import Callable, Generator, Iterator
 from functools import lru_cache
 from pathlib import Path
-from typing import cast
+from typing import Any, cast
 
 from rich import print as rprint
 
@@ -85,7 +85,7 @@ _LAZY_PROVIDER_ATTRS = {
 }
 
 
-def __getattr__(name: str):
+def __getattr__(name: str) -> Any:
     if name in _LAZY_PROVIDER_ATTRS:
         from importlib import import_module
 

--- a/gptme/llm/__init__.py
+++ b/gptme/llm/__init__.py
@@ -16,17 +16,6 @@ from ..message import Message, MessageMetadata, format_msgs, len_tokens
 from ..telemetry import trace_function
 from ..tools import ToolSpec, ToolUse
 from ..util import console
-from .llm_anthropic import chat as chat_anthropic
-from .llm_anthropic import get_client as get_anthropic_client
-from .llm_anthropic import init as init_anthropic
-from .llm_anthropic import stream as stream_anthropic
-from .llm_openai import chat as chat_openai
-from .llm_openai import has_client as has_openai_client
-from .llm_openai import init as init_openai
-from .llm_openai import stream as stream_openai
-from .llm_openai_subscription import chat as chat_subscription
-from .llm_openai_subscription import init as init_subscription
-from .llm_openai_subscription import stream as stream_subscription
 from .models import (
     MODELS,
     PROVIDERS_OPENAI,
@@ -78,12 +67,48 @@ PROVIDER_API_KEYS: dict[str, str] = {
 _subscription_initialized = False
 
 
+# PEP 562 lazy attribute resolution for provider-specific functions.
+# Preserves `from gptme.llm import init_anthropic` (and similar) for external
+# callers without eagerly importing openai/anthropic at module load time.
+_LAZY_PROVIDER_ATTRS = {
+    "chat_anthropic": (".llm_anthropic", "chat"),
+    "stream_anthropic": (".llm_anthropic", "stream"),
+    "init_anthropic": (".llm_anthropic", "init"),
+    "get_anthropic_client": (".llm_anthropic", "get_client"),
+    "chat_openai": (".llm_openai", "chat"),
+    "stream_openai": (".llm_openai", "stream"),
+    "init_openai": (".llm_openai", "init"),
+    "has_openai_client": (".llm_openai", "has_client"),
+    "chat_subscription": (".llm_openai_subscription", "chat"),
+    "stream_subscription": (".llm_openai_subscription", "stream"),
+    "init_subscription": (".llm_openai_subscription", "init"),
+}
+
+
+def __getattr__(name: str):
+    if name in _LAZY_PROVIDER_ATTRS:
+        from importlib import import_module
+
+        module_name, attr_name = _LAZY_PROVIDER_ATTRS[name]
+        module = import_module(module_name, package=__name__)
+        attr = getattr(module, attr_name)
+        globals()[name] = attr
+        return attr
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
 def init_llm(provider: Provider):
     """Initialize LLM client for a given provider if not already initialized.
 
     Args:
         provider: Provider name (built-in or custom)
     """
+    from .llm_anthropic import get_client as get_anthropic_client
+    from .llm_anthropic import init as init_anthropic
+    from .llm_openai import has_client as has_openai_client
+    from .llm_openai import init as init_openai
+    from .llm_openai_subscription import init as init_subscription
+
     global _subscription_initialized
     config = get_config()
 
@@ -235,10 +260,14 @@ def _chat_complete(
         or is_custom_provider(provider)
         or is_plugin_provider(str(provider))
     ):
+        from .llm_openai import chat as chat_openai
+
         return chat_openai(
             messages, model, tools, output_schema=output_schema, max_tokens=max_tokens
         )
     if provider == "anthropic":
+        from .llm_anthropic import chat as chat_anthropic
+
         return chat_anthropic(
             messages,
             _get_base_model(model),
@@ -247,6 +276,8 @@ def _chat_complete(
             max_tokens=max_tokens,
         )
     if provider == "openai-subscription":
+        from .llm_openai_subscription import chat as chat_subscription
+
         content = chat_subscription(
             messages, _get_base_model(model), tools, max_tokens=max_tokens
         )
@@ -300,11 +331,15 @@ def _stream(
         or is_custom_provider(provider)
         or is_plugin_provider(str(provider))
     ):
+        from .llm_openai import stream as stream_openai
+
         gen = stream_openai(
             messages, model, tools, output_schema=output_schema, max_tokens=max_tokens
         )
         return _StreamWithMetadata(gen, model)
     if provider == "anthropic":
+        from .llm_anthropic import stream as stream_anthropic
+
         gen = stream_anthropic(
             messages,
             _get_base_model(model),
@@ -314,6 +349,8 @@ def _stream(
         )
         return _StreamWithMetadata(gen, model)
     if provider == "openai-subscription":
+        from .llm_openai_subscription import stream as stream_subscription
+
         gen = stream_subscription(
             messages, _get_base_model(model), tools, max_tokens=max_tokens
         )

--- a/gptme/llm/constants.py
+++ b/gptme/llm/constants.py
@@ -4,3 +4,10 @@
 # is active. Prevents near-zero response budgets when the caller supplies a
 # max_tokens value that is only slightly above the thinking budget.
 _MIN_RESPONSE_TOKENS = 256
+
+# Shows in rankings on openrouter.ai. Defined here so importers (e.g. the
+# Perplexity browser backend) don't pull in the openai SDK transitively.
+OPENROUTER_APP_HEADERS = {
+    "HTTP-Referer": "https://github.com/gptme/gptme",
+    "X-Title": "gptme",
+}

--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -17,7 +17,7 @@ from ..constants import OPENAI_VERBOSITY, TEMPERATURE, TOP_P
 from ..message import Message, MessageMetadata, UsageData, msgs2dicts
 from ..telemetry import _calculate_llm_cost, record_llm_request
 from ..tools import ToolSpec
-from .constants import _MIN_RESPONSE_TOKENS
+from .constants import _MIN_RESPONSE_TOKENS, OPENROUTER_APP_HEADERS
 from .models import (
     CustomProvider,
     ModelMeta,
@@ -99,11 +99,9 @@ class MessageDict(TypedDict):
     ]  # Image/file attachments as file paths (processed before API call)
 
 
-# Shows in rankings on openrouter.ai
-OPENROUTER_APP_HEADERS = {
-    "HTTP-Referer": "https://github.com/gptme/gptme",
-    "X-Title": "gptme",
-}
+# OPENROUTER_APP_HEADERS canonical definition is in gptme.llm.constants;
+# re-exported above (line 20) for backward compatibility with existing
+# `from gptme.llm.llm_openai import OPENROUTER_APP_HEADERS` imports.
 
 
 def _record_usage(usage, model: str) -> MessageMetadata | None:

--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -100,7 +100,7 @@ class MessageDict(TypedDict):
 
 
 # OPENROUTER_APP_HEADERS canonical definition is in gptme.llm.constants;
-# re-exported above (line 20) for backward compatibility with existing
+# re-exported here for backward compatibility with existing
 # `from gptme.llm.llm_openai import OPENROUTER_APP_HEADERS` imports.
 
 

--- a/gptme/tools/_browser_perplexity.py
+++ b/gptme/tools/_browser_perplexity.py
@@ -4,7 +4,7 @@ Perplexity search backend for the browser tool.
 
 import logging
 
-from ..llm.llm_openai import OPENROUTER_APP_HEADERS
+from ..llm.constants import OPENROUTER_APP_HEADERS
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_provider_plugins.py
+++ b/tests/test_provider_plugins.py
@@ -317,10 +317,10 @@ class TestPluginRouting:
                 return_value=[_make_entry_point(plugin)],
             ),
             patch(
-                "gptme.llm.has_openai_client",
+                "gptme.llm.llm_openai.has_client",
                 side_effect=lambda _provider: client_registered,
             ),
-            patch("gptme.llm.init_openai") as mock_init_openai,
+            patch("gptme.llm.llm_openai.init") as mock_init_openai,
         ):
             init_llm(CustomProvider("myprovider"))
 
@@ -339,8 +339,8 @@ class TestPluginRouting:
                 "importlib.metadata.entry_points",
                 return_value=[_make_entry_point(plugin)],
             ),
-            patch("gptme.llm.has_openai_client", return_value=False),
-            patch("gptme.llm.init_openai") as mock_init_openai,
+            patch("gptme.llm.llm_openai.has_client", return_value=False),
+            patch("gptme.llm.llm_openai.init") as mock_init_openai,
             pytest.raises(
                 RuntimeError,
                 match="did not register an OpenAI-compatible client",
@@ -363,7 +363,9 @@ class TestPluginRouting:
                 "importlib.metadata.entry_points",
                 return_value=[_make_entry_point(plugin)],
             ),
-            patch("gptme.llm.chat_openai", return_value=expected) as mock_chat_openai,
+            patch(
+                "gptme.llm.llm_openai.chat", return_value=expected
+            ) as mock_chat_openai,
         ):
             result = _chat_complete(messages, "myprovider/test-model-v1", None)
 
@@ -392,7 +394,7 @@ class TestPluginRouting:
                 return_value=[_make_entry_point(plugin)],
             ),
             patch(
-                "gptme.llm.stream_openai", side_effect=fake_stream
+                "gptme.llm.llm_openai.stream", side_effect=fake_stream
             ) as mock_stream_openai,
         ):
             stream = _stream(messages, "myprovider/test-model-v1", None)


### PR DESCRIPTION
## Summary

Eagerly importing the openai/anthropic SDKs at module load time made every CLI invocation pay for it, even commands like `gptme --help` and `gptme --version` that never make an LLM call. Same pattern as #2218 (lazy opentelemetry).

## Changes

- **`gptme/llm/__init__.py`**: move `llm_anthropic` / `llm_openai` / `llm_openai_subscription` imports out of module top-level into the functions that use them (`init_llm`, `_chat_complete`, `_stream`). Add PEP 562 `__getattr__` so module-level access (`from gptme.llm import init_anthropic`) still works for external callers like `tests/test_cli.py`.
- **`gptme/llm/constants.py`**: become canonical home for `OPENROUTER_APP_HEADERS` so the Perplexity browser backend doesn't transitively pull in the openai SDK via `from ..llm.llm_openai import OPENROUTER_APP_HEADERS` (which `gptme/tools/browser.py` imports eagerly via `importlib.import_module`).
- **`gptme/llm/llm_openai.py`**: re-export `OPENROUTER_APP_HEADERS` from constants for backward compatibility.
- **`gptme/tools/_browser_perplexity.py`**: import the constant from the lighter `gptme.llm.constants` instead.

## Measured

Local timings, mean of warm runs (`time gptme --help > /dev/null`):

| command         | before | after | delta   |
|-----------------|--------|-------|---------|
| `gptme --help`    | 3.59s  | 1.85s | **-1.74s (-48%)** |
| `gptme --version` | 2.74s  | 2.55s | -0.19s  |

`importtime`: `gptme.cli.main` cumulative drops from 2.56s → 1.79s. `openai` SDK no longer appears in the import chain for `--help` at all.

## Compatibility

`from gptme.llm import init_anthropic` (and the other 10 provider symbols) still resolve through the new `__getattr__` — verified all 11 symbols load and resolve to their original module/function. `OPENROUTER_APP_HEADERS` identity is preserved across the three import paths (`gptme.llm.llm_openai`, `gptme.llm.constants`, `gptme.tools._browser_perplexity`).

## Test plan

- [x] `tests/test_llm_anthropic.py`, `tests/test_llm_openai.py`, `tests/test_llm_models.py`, `tests/test_llm_openai_subscription.py` — 178 tests pass
- [x] `tests/test_cli.py` — 22 passed, 8 skipped
- [x] `tests/test_browser.py`, `tests/test_tools.py` — 29 passed, 1 skipped (perplexity backend touched)
- [x] `gptme --help`, `gptme --version` smoke
- [x] `from gptme.llm import init_anthropic` still works (lazy via `__getattr__`)