### PR TITLE
fix(tauri): clean up gptme-server on app exit (Cmd+Q, dock-quit), not just window close

### DIFF
--- a/tauri/src-tauri/src/lib.rs
+++ b/tauri/src-tauri/src/lib.rs
@@ -342,35 +342,52 @@ pub fn run() {
             #[cfg(desktop)]
             if let tauri::WindowEvent::CloseRequested { .. } = event {
                 log::info!("Window close requested, cleaning up gptme-server...");
-
-                let arc = window.state::<ServerProcess>().0.clone();
-                let mut guard = match arc.lock() {
-                    Ok(g) => g,
-                    Err(_) => {
-                        log::error!("Failed to acquire lock on server process");
-                        return;
-                    }
-                };
-                if let Some(child) = guard.take() {
-                    log::info!("Terminating gptme-server process...");
-                    match child.kill() {
-                        Ok(_) => {
-                            log::info!("gptme-server process terminated successfully");
-                        }
-                        Err(e) => {
-                            log::error!("Failed to terminate gptme-server: {}", e);
-                        }
-                    }
-                } else {
-                    log::warn!("No gptme-server process found to terminate");
-                }
+                cleanup_server_process(window.app_handle());
             }
 
             #[cfg(not(desktop))]
             let _ = (window, event);
         })
-        .run(tauri::generate_context!())
-        .expect("error while running tauri application");
+        .build(tauri::generate_context!())
+        .expect("error while building tauri application")
+        .run(|_app_handle, _event| {
+            // ExitRequested fires on app-level exit paths that don't emit a
+            // per-window CloseRequested first (macOS Cmd+Q, dock-quit, system
+            // shutdown). Without this, the sidecar gptme-server outlives the
+            // app and squats on port 5700 (gptme/gptme#2237).
+            //
+            // cleanup_server_process is idempotent — if CloseRequested already
+            // killed and cleared the child, this is a no-op.
+            #[cfg(desktop)]
+            if let tauri::RunEvent::ExitRequested { .. } = _event {
+                log::info!("App exit requested, cleaning up gptme-server...");
+                cleanup_server_process(_app_handle);
+            }
+        });
+}
+
+#[cfg(desktop)]
+fn cleanup_server_process(app: &tauri::AppHandle) {
+    // Pre-setup state may not be registered yet (e.g. very early exit).
+    let state = match app.try_state::<ServerProcess>() {
+        Some(s) => s,
+        None => return,
+    };
+    let arc = state.0.clone();
+    let mut guard = match arc.lock() {
+        Ok(g) => g,
+        Err(_) => {
+            log::error!("Failed to acquire lock on server process");
+            return;
+        }
+    };
+    if let Some(child) = guard.take() {
+        log::info!("Terminating gptme-server process...");
+        match child.kill() {
+            Ok(_) => log::info!("gptme-server process terminated successfully"),
+            Err(e) => log::error!("Failed to terminate gptme-server: {}", e),
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Fixes gptme/gptme#2237 (filed by @0xbrayo today): the bundled `gptme-server` sidecar is left running after the Tauri app closes, squatting on port 5700 and blocking the next launch.

## Root cause

The current cleanup is wired to `WindowEvent::CloseRequested` in `on_window_event`. That fires for the X-button/window-close path on Linux, but **not** for app-level exit paths:

- macOS Cmd+Q (Quit menu)
- macOS dock right-click → Quit
- System shutdown
- Some Wayland session-end paths

On those paths, no `CloseRequested` event reaches the per-window handler, so `child.kill()` never runs and the sidecar is orphaned.

## Fix

1. Switch `.run(tauri::generate_context!())` → `.build(...).run(closure)` so we can observe `RunEvent::ExitRequested`.
2. Extract the cleanup body into `cleanup_server_process(app)` so both the `WindowEvent::CloseRequested` handler and the `RunEvent::ExitRequested` handler share one implementation.
3. The helper is idempotent — `Option::take()` ensures a second call after `CloseRequested` already fired is a no-op.
4. Use `app.try_state::<ServerProcess>()` so very-early-exit paths (before `setup` registered state) silently no-op instead of panicking.

```rust
// Before: only window close
.on_window_event(|window, event| {
    if let WindowEvent::CloseRequested { .. } = event {
        // kill child inline...
    }
})
.run(tauri::generate_context!())
.expect("...");

// After: window close AND app exit, shared helper
.on_window_event(|window, event| {
    if let WindowEvent::CloseRequested { .. } = event {
        cleanup_server_process(window.app_handle());
    }
})
.build(tauri::generate_context!())
.expect("...")
.run(|app_handle, event| {
    if let RunEvent::ExitRequested { .. } = event {
        cleanup_server_process(app_handle);
    }
});
```

Net diff: +41 / -24 in `tauri/src-tauri/src/lib.rs` only.

## Verification

- ✅ `cargo fmt --check` passes
- ⚠️ Full `cargo check` requires GTK system libs (not present on the autonomous VM where this was authored). The change is small idiomatic Tauri 2.x code; the existing `tauri.yml` CI job (Linux + Windows + macOS) will exercise compilation.
- Cross-platform: `RunEvent::ExitRequested` is platform-agnostic; particularly important on macOS where window-close ≠ app-exit by NSApplication default.

## History

The repo has tried to fix this twice before (`440bed1 feat: send SIGTERM to gptme-server on app exit`, `01f91bc fix: store CommandChild for proper server process cleanup on exit`) but both kept the cleanup gated on `WindowEvent::CloseRequested`. This PR closes the remaining gap.

## Test plan

- [ ] CI green on Linux/Windows/macOS via `tauri.yml`
- [ ] Manual smoke on macOS: launch Tauri app → Cmd+Q → confirm `lsof -i :5700` is empty (no orphan `gptme-server`)
- [ ] Manual smoke on Linux: launch → X close → confirm port 5700 is free (regression check on the existing path)