### PR TITLE
fix(webui): include port in derived server name to prevent name collisions

### DIFF
--- a/webui/src/stores/__tests__/servers.test.ts
+++ b/webui/src/stores/__tests__/servers.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from '@jest/globals';
+import { deriveServerName } from '../servers';
+
+describe('deriveServerName', () => {
+  it('returns "Local" for default-port localhost URLs', () => {
+    expect(deriveServerName('http://127.0.0.1')).toBe('Local');
+    expect(deriveServerName('http://localhost')).toBe('Local');
+    expect(deriveServerName('http://127.0.0.1:80')).toBe('Local');
+    expect(deriveServerName('https://localhost:443')).toBe('Local');
+  });
+
+  it('disambiguates non-default-port localhost URLs by appending port', () => {
+    // Without this, two servers added via #baseUrl= fragments both become "Local",
+    // producing duplicate-named entries in the registry. See chat.gptme.org repro
+    // in the bug report.
+    expect(deriveServerName('http://127.0.0.1:5700')).toBe('Local:5700');
+    expect(deriveServerName('http://127.0.0.1:9999')).toBe('Local:9999');
+    expect(deriveServerName('http://localhost:8080')).toBe('Local:8080');
+  });
+
+  it('uses hostname for default-port remote URLs', () => {
+    expect(deriveServerName('https://example.com')).toBe('example.com');
+    expect(deriveServerName('http://example.com:80')).toBe('example.com');
+    expect(deriveServerName('https://api.example.com:443')).toBe('api.example.com');
+  });
+
+  it('appends port for non-default-port remote URLs', () => {
+    expect(deriveServerName('https://example.com:8443')).toBe('example.com:8443');
+    expect(deriveServerName('http://api.example.com:8080')).toBe('api.example.com:8080');
+  });
+
+  it('returns "Server" for malformed URLs', () => {
+    expect(deriveServerName('not-a-url')).toBe('Server');
+    expect(deriveServerName('')).toBe('Server');
+  });
+});

--- a/webui/src/stores/servers.ts
+++ b/webui/src/stores/servers.ts
@@ -285,13 +285,16 @@ export function findOrCreateServerByUrl(
   });
 }
 
-function deriveServerName(url: string): string {
+export function deriveServerName(url: string): string {
   try {
     const parsed = new URL(url);
-    if (parsed.hostname === '127.0.0.1' || parsed.hostname === 'localhost') {
-      return 'Local';
-    }
-    return parsed.hostname;
+    const isDefaultPort =
+      !parsed.port ||
+      (parsed.protocol === 'http:' && parsed.port === '80') ||
+      (parsed.protocol === 'https:' && parsed.port === '443');
+    const isLocal = parsed.hostname === '127.0.0.1' || parsed.hostname === 'localhost';
+    const base = isLocal ? 'Local' : parsed.hostname;
+    return isDefaultPort ? base : `${base}:${parsed.port}`;
   } catch {
     return 'Server';
   }


### PR DESCRIPTION
## Summary

`deriveServerName()` in `webui/src/stores/servers.ts` returned `'Local'` for any `127.0.0.1`/`localhost` URL regardless of port, so two servers added via `#baseUrl=` URL fragments on different localhost ports coexist with the same name `'Local'` in the registry. Same issue affected non-localhost hosts with multiple ports (e.g. `example.com:443` and `example.com:8080` both named `'example.com'`).

## Reproduction (live, on chat.gptme.org)

1. Open `https://chat.gptme.org/#baseUrl=http://127.0.0.1:5700`
2. Open `https://chat.gptme.org/#baseUrl=http://127.0.0.1:9999`
3. Inspect `localStorage.gptme_servers`:
   ```json
   {
     "servers": [
       {"name": "Local", "baseUrl": "http://127.0.0.1:5700", ...},
       {"name": "Local", "baseUrl": "http://127.0.0.1:9999", ...}
     ]
   }
   ```

The connection-failure banner reads "Cannot reach **Local**" without distinguishing which Local — the user has to dig into Server settings to disambiguate.

## Fix

Append the port to the derived name when it's non-default for the protocol:

| URL | Before | After |
|---|---|---|
| `http://127.0.0.1` | `Local` | `Local` (unchanged) |
| `http://127.0.0.1:5700` | `Local` | `Local:5700` |
| `http://127.0.0.1:9999` | `Local` | `Local:9999` |
| `https://example.com` | `example.com` | `example.com` (unchanged) |
| `https://example.com:8443` | `example.com` | `example.com:8443` |

Default ports (`http:80`, `https:443`) keep their bare names, preserving existing behavior for the common case.

Also exported `deriveServerName` to enable unit testing.

## Test plan

- [x] New unit test `webui/src/stores/__tests__/servers.test.ts` — 5 cases covering localhost/remote × default-port/non-default-port matrix + malformed-URL fallback.
- [x] `npx jest src/stores/__tests__/servers.test.ts` → 5/5 pass
- [x] Full `npx jest` → 20 suites, 180 tests pass (no regressions)
- [x] Live repro verified on chat.gptme.org with Playwright before/after fix

Found while user-testing the recent webui fixes (#2228, #2230, #2231, #2233) on the production deploy.
