### PR TITLE
fix(tauri): trigger macOS local-network permission at app startup

### DIFF
--- a/webui/src/main.tsx
+++ b/webui/src/main.tsx
@@ -13,4 +13,35 @@ setupLogging()
     console.error('Failed to setup logging:', err);
   });
 
+// Early localhost probe to trigger macOS local-network permission dialog
+// at app startup, before the user reaches the Connect step.
+// See: gptme/gptme#2236
+(function probeLocalhost() {
+  // Only probe in Tauri desktop app; skip in regular browsers
+  if (typeof window === 'undefined' || !window.__TAURI__) {
+    return;
+  }
+
+  const MAX_RETRIES = 10;
+  const INTERVAL_MS = 500;
+  let attempts = 0;
+
+  const tryConnect = () => {
+    attempts++;
+    fetch('http://127.0.0.1:5700/api/v2', { mode: 'no-cors', cache: 'no-store' })
+      .then(() => {
+        console.info('[Probe] localhost connection established');
+      })
+      .catch(() => {
+        if (attempts < MAX_RETRIES) {
+          setTimeout(tryConnect, INTERVAL_MS);
+        }
+      });
+  };
+
+  // Start probing immediately; this intentionally races with server startup
+  // so that the macOS permission dialog appears early, not mid-flow.
+  tryConnect();
+})();
+
 createRoot(document.getElementById('root')!).render(<App />);


### PR DESCRIPTION
Fixes gptme/gptme#2236.

## Problem
On macOS, the first time gptme-tauri tries to connect to the bundled sidecar server on localhost, the OS shows a permission dialog after the user has already clicked "Local → Connect". This feels like a delay or failure rather than an expected permission prompt.

## Solution
Add an early localhost connection probe in main.tsx that fires immediately on app load when running inside the Tauri desktop app. This causes macOS to surface the local-network permission dialog at startup, before the user reaches the Connect step.

The probe retries up to 10 times with 500 ms backoff to account for the race with gptme-server startup, and stops as soon as the connection succeeds. It is skipped entirely in regular browsers (where window.__TAURI__ is undefined).

## Verification
- npm run typecheck - clean
- npm run lint - clean
