### PR TITLE
fix(webui): surface missing provider setup on welcome view

### DIFF
--- a/webui/src/components/SetupWizard.tsx
+++ b/webui/src/components/SetupWizard.tsx
@@ -19,10 +19,11 @@ import {
   type ApiKeyProvider,
 } from '@/utils/apiKeyProviders';
 import { isTauriEnvironment, invokeTauri } from '@/utils/tauri';
+import { setupWizard$, type SetupWizardStep } from '@/stores/setupWizard';
 import { use$ } from '@legendapp/state/react';
 import { Monitor, Cloud, ArrowRight, Check, Terminal, ExternalLink } from 'lucide-react';
 
-type SetupStep = 'welcome' | 'mode' | 'local' | 'cloud' | 'provider' | 'complete';
+type SetupStep = SetupWizardStep;
 type SetupModelInfo = {
   id: string;
   provider: string;
@@ -87,6 +88,8 @@ export function SetupWizard() {
   const lastAutoAdvanceBaseUrlRef = useRef<string | null>(null);
   const isTauri = isTauriEnvironment();
   const { isLoading: isLoadingTauriStatus, managesLocalServer } = useTauriServerStatus();
+  const externalOpen = use$(setupWizard$.open);
+  const externalStep = use$(setupWizard$.step);
   const isRemoteOnlyTauri = isTauri && managesLocalServer === false;
   const isDeterminingTauriMode = isTauri && isLoadingTauriStatus;
   const canManageApiKeyInApp = isTauri && managesLocalServer === true;
@@ -280,6 +283,20 @@ export function SetupWizard() {
     setCloudLoginStarted(false);
     void checkProviderAndAdvance();
   }, [checkProviderAndAdvance, connectionConfig.baseUrl, isConnected, isOpen, step]);
+
+  useEffect(() => {
+    if (!externalOpen) {
+      return;
+    }
+
+    setConnectError(null);
+    setCloudLoginStarted(false);
+    setApiKeyError(null);
+    lastAutoAdvanceBaseUrlRef.current = null;
+    setStep(externalStep);
+    setIsOpen(true);
+    setupWizard$.open.set(false);
+  }, [externalOpen, externalStep]);
 
   // Close the dialog. Also calls completeSetup() so that skipping or finishing always persists.
   const closeWizard = () => {

--- a/webui/src/components/SetupWizard.tsx
+++ b/webui/src/components/SetupWizard.tsx
@@ -18,8 +18,13 @@ import {
   API_KEY_PROVIDER_OPTIONS,
   type ApiKeyProvider,
 } from '@/utils/apiKeyProviders';
+import { fetchProviderConfigured } from '@/utils/providerStatus';
 import { isTauriEnvironment, invokeTauri } from '@/utils/tauri';
-import { setupWizard$, type SetupWizardStep } from '@/stores/setupWizard';
+import {
+  bumpProviderStatusVersion,
+  setupWizard$,
+  type SetupWizardStep,
+} from '@/stores/setupWizard';
 import { use$ } from '@legendapp/state/react';
 import { Monitor, Cloud, ArrowRight, Check, Terminal, ExternalLink } from 'lucide-react';
 
@@ -109,18 +114,14 @@ export function SetupWizard() {
 
   const completeSetup = useCallback(() => {
     updateSettings({ hasCompletedSetup: true });
+    bumpProviderStatusVersion();
   }, [updateSettings]);
 
-  const fetchProviderConfigured = useCallback(async () => {
-    const resp = await fetch(`${connectionConfig.baseUrl}/api/v2`, {
-      headers: withAuthHeaders(api.authHeader),
-    });
-    if (!resp.ok) {
-      throw new Error(`Failed to verify provider status (${resp.status})`);
-    }
-    const data = (await resp.json()) as { provider_configured?: boolean };
-    return data.provider_configured !== false;
-  }, [api.authHeader, connectionConfig.baseUrl]);
+  const checkProviderConfigured = useCallback(
+    (signal?: AbortSignal) =>
+      fetchProviderConfigured(connectionConfig.baseUrl, api.authHeader, signal),
+    [api.authHeader, connectionConfig.baseUrl]
+  );
 
   const saveApiKeyToServer = useCallback(
     async (provider: ApiKeyProvider, apiKeyValue: string, model?: string) => {
@@ -208,7 +209,7 @@ export function SetupWizard() {
   const checkProviderAndAdvance = useCallback(
     async ({ assumeConfiguredOnError = true }: { assumeConfiguredOnError?: boolean } = {}) => {
       try {
-        if (!(await fetchProviderConfigured())) {
+        if (!(await checkProviderConfigured())) {
           setStep('provider');
           return;
         }
@@ -221,7 +222,7 @@ export function SetupWizard() {
       completeSetup();
       setStep('complete');
     },
-    [completeSetup, fetchProviderConfigured]
+    [checkProviderConfigured, completeSetup]
   );
 
   const startServerWithRetry = useCallback(async () => {
@@ -251,7 +252,7 @@ export function SetupWizard() {
   const waitForRestartedServer = useCallback(async () => {
     for (let attempt = 0; attempt < SERVER_READY_RETRY_COUNT; attempt += 1) {
       try {
-        if (await fetchProviderConfigured()) {
+        if (await checkProviderConfigured()) {
           completeSetup();
           setStep('complete');
           return;
@@ -268,7 +269,7 @@ export function SetupWizard() {
         await sleep(SERVER_READY_RETRY_DELAY_MS);
       }
     }
-  }, [completeSetup, fetchProviderConfigured]);
+  }, [checkProviderConfigured, completeSetup]);
 
   useEffect(() => {
     if (!isConnected) {

--- a/webui/src/components/WelcomeView.tsx
+++ b/webui/src/components/WelcomeView.tsx
@@ -13,6 +13,7 @@ import { ExamplesSection } from '@/components/ExamplesSection';
 import { serverRegistry$, getConnectedServers } from '@/stores/servers';
 import { getExamples } from '@/utils/examples';
 import { settingsModal$ } from '@/stores/settingsModal';
+import { setupWizard$ } from '@/stores/setupWizard';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import {
   DropdownMenu,
@@ -39,6 +40,7 @@ export const WelcomeView = () => {
 
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isRetryingConnection, setIsRetryingConnection] = useState(false);
+  const [providerConfigured, setProviderConfigured] = useState<boolean | null>(null);
   const navigate = useNavigate();
   const { api, isConnected$, connectionConfig, switchServer, connect } = useApi();
   const queryClient = useQueryClient();
@@ -120,6 +122,44 @@ export const WelcomeView = () => {
     }
   };
 
+  useEffect(() => {
+    if (!isConnected) {
+      setProviderConfigured(null);
+      return;
+    }
+
+    const controller = new AbortController();
+
+    const fetchProviderStatus = async () => {
+      try {
+        const headers: Record<string, string> = {};
+        if (api.authHeader) {
+          headers.Authorization = api.authHeader;
+        }
+
+        const response = await fetch(`${connectionConfig.baseUrl}/api/v2`, {
+          headers,
+          signal: controller.signal,
+        });
+        if (!response.ok) {
+          throw new Error(`Failed to fetch provider status (${response.status})`);
+        }
+
+        const data = (await response.json()) as { provider_configured?: boolean };
+        setProviderConfigured(data.provider_configured !== false);
+      } catch (error) {
+        if (error instanceof Error && error.name === 'AbortError') {
+          return;
+        }
+        setProviderConfigured(null);
+      }
+    };
+
+    void fetchProviderStatus();
+
+    return () => controller.abort();
+  }, [api.authHeader, connectionConfig.baseUrl, isConnected]);
+
   const { settings } = useSettings();
   const bg = settings.welcomeBackground;
   // Determine if the background is an image URL or a CSS gradient/color
@@ -195,6 +235,40 @@ export const WelcomeView = () => {
                         Copy start command
                       </Button>
                     )}
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="outline"
+                      onClick={() => settingsModal$.set({ open: true, category: 'servers' })}
+                    >
+                      Server settings
+                    </Button>
+                  </div>
+                </AlertDescription>
+              </Alert>
+            )}
+
+            {isConnected && providerConfigured === false && (
+              <Alert className="mx-auto w-full max-w-2xl border-sky-500/30 bg-sky-500/10 text-left">
+                <Server className="h-4 w-4 text-sky-700 dark:text-sky-300" />
+                <AlertTitle>Provider setup required</AlertTitle>
+                <AlertDescription className="space-y-3">
+                  <p>
+                    This server is reachable, but it does not have an LLM provider configured yet.
+                    Finish setup to add an API key or switch to gptme.ai before starting a chat.
+                  </p>
+                  <div className="flex flex-wrap gap-2">
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="secondary"
+                      onClick={() => {
+                        setupWizard$.step.set('provider');
+                        setupWizard$.open.set(true);
+                      }}
+                    >
+                      Finish setup
+                    </Button>
                     <Button
                       type="button"
                       size="sm"

--- a/webui/src/components/WelcomeView.tsx
+++ b/webui/src/components/WelcomeView.tsx
@@ -13,6 +13,7 @@ import { ExamplesSection } from '@/components/ExamplesSection';
 import { serverRegistry$, getConnectedServers } from '@/stores/servers';
 import { getExamples } from '@/utils/examples';
 import { settingsModal$ } from '@/stores/settingsModal';
+import { fetchProviderConfigured } from '@/utils/providerStatus';
 import { setupWizard$ } from '@/stores/setupWizard';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import {
@@ -45,6 +46,7 @@ export const WelcomeView = () => {
   const { api, isConnected$, connectionConfig, switchServer, connect } = useApi();
   const queryClient = useQueryClient();
   const isConnected = use$(isConnected$);
+  const providerStatusVersion = use$(setupWizard$.providerStatusVersion);
   const registry = use$(serverRegistry$);
   const connectedServers = getConnectedServers();
   const activeServer = registry.servers.find((s) => s.id === registry.activeServerId);
@@ -132,21 +134,9 @@ export const WelcomeView = () => {
 
     const fetchProviderStatus = async () => {
       try {
-        const headers: Record<string, string> = {};
-        if (api.authHeader) {
-          headers.Authorization = api.authHeader;
-        }
-
-        const response = await fetch(`${connectionConfig.baseUrl}/api/v2`, {
-          headers,
-          signal: controller.signal,
-        });
-        if (!response.ok) {
-          throw new Error(`Failed to fetch provider status (${response.status})`);
-        }
-
-        const data = (await response.json()) as { provider_configured?: boolean };
-        setProviderConfigured(data.provider_configured !== false);
+        setProviderConfigured(
+          await fetchProviderConfigured(connectionConfig.baseUrl, api.authHeader, controller.signal)
+        );
       } catch (error) {
         if (error instanceof Error && error.name === 'AbortError') {
           return;
@@ -158,7 +148,7 @@ export const WelcomeView = () => {
     void fetchProviderStatus();
 
     return () => controller.abort();
-  }, [api.authHeader, connectionConfig.baseUrl, isConnected]);
+  }, [api.authHeader, connectionConfig.baseUrl, isConnected, providerStatusVersion]);
 
   const { settings } = useSettings();
   const bg = settings.welcomeBackground;

--- a/webui/src/components/__tests__/SetupWizard.test.tsx
+++ b/webui/src/components/__tests__/SetupWizard.test.tsx
@@ -106,6 +106,7 @@ describe('SetupWizard', () => {
     isConnected$.set(false);
     setupWizard$.step.set('welcome');
     setupWizard$.open.set(false);
+    setupWizard$.providerStatusVersion.set(0);
     mockConnect.mockReset();
     mockOpen.mockReset();
     mockFetch.mockReset();
@@ -188,6 +189,7 @@ describe('SetupWizard', () => {
         hasCompletedSetup: true,
       });
     });
+    expect(setupWizard$.providerStatusVersion.get()).toBe(1);
     expect(screen.getByRole('heading', { name: /you're all set/i })).toBeInTheDocument();
   });
 

--- a/webui/src/components/__tests__/SetupWizard.test.tsx
+++ b/webui/src/components/__tests__/SetupWizard.test.tsx
@@ -1,8 +1,9 @@
 import '@testing-library/jest-dom';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { observable } from '@legendapp/state';
 import { SetupWizard } from '../SetupWizard';
 import { SettingsProvider } from '@/contexts/SettingsContext';
+import { setupWizard$ } from '@/stores/setupWizard';
 
 const mockConnect = jest.fn();
 const mockOpen = jest.fn();
@@ -103,6 +104,8 @@ describe('SetupWizard', () => {
   beforeEach(() => {
     localStorage.clear();
     isConnected$.set(false);
+    setupWizard$.step.set('welcome');
+    setupWizard$.open.set(false);
     mockConnect.mockReset();
     mockOpen.mockReset();
     mockFetch.mockReset();
@@ -230,6 +233,35 @@ describe('SetupWizard', () => {
     expect(screen.getByRole('option', { name: /deepseek/i })).toBeInTheDocument();
     expect(JSON.parse(localStorage.getItem('gptme-settings') || '{}')).not.toMatchObject({
       hasCompletedSetup: true,
+    });
+  });
+
+  it('reopens directly to provider setup when requested externally', async () => {
+    localStorage.setItem('gptme-settings', JSON.stringify({ hasCompletedSetup: true }));
+
+    const { rerender } = render(
+      <SettingsProvider>
+        <SetupWizard />
+      </SettingsProvider>
+    );
+
+    expect(
+      screen.queryByRole('heading', { name: /configure a provider/i })
+    ).not.toBeInTheDocument();
+
+    act(() => {
+      setupWizard$.step.set('provider');
+      setupWizard$.open.set(true);
+    });
+
+    rerender(
+      <SettingsProvider>
+        <SetupWizard />
+      </SettingsProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: /configure a provider/i })).toBeInTheDocument();
     });
   });
 

--- a/webui/src/components/__tests__/WelcomeView.test.tsx
+++ b/webui/src/components/__tests__/WelcomeView.test.tsx
@@ -64,6 +64,7 @@ describe('WelcomeView', () => {
     isConnected$.set(true);
     setupWizard$.step.set('welcome');
     setupWizard$.open.set(false);
+    setupWizard$.providerStatusVersion.set(0);
     mockConnect.mockReset();
     mockNavigate.mockClear();
     mockInvalidateQueries.mockClear();
@@ -144,6 +145,34 @@ describe('WelcomeView', () => {
 
     await waitFor(() => {
       expect(setupWizard$.get()).toMatchObject({ open: true, step: 'provider' });
+    });
+  });
+
+  it('rechecks provider status after setup completion', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ provider_configured: false }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ provider_configured: true }),
+      });
+
+    render(
+      <SettingsProvider>
+        <WelcomeView />
+      </SettingsProvider>
+    );
+
+    expect(await screen.findByText('Provider setup required')).toBeInTheDocument();
+
+    act(() => {
+      setupWizard$.providerStatusVersion.set(1);
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText('Provider setup required')).not.toBeInTheDocument();
     });
   });
 });

--- a/webui/src/components/__tests__/WelcomeView.test.tsx
+++ b/webui/src/components/__tests__/WelcomeView.test.tsx
@@ -1,12 +1,14 @@
 import '@testing-library/jest-dom';
-import { render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { observable } from '@legendapp/state';
 import { SettingsProvider } from '@/contexts/SettingsContext';
 import { WelcomeView } from '../WelcomeView';
+import { setupWizard$ } from '@/stores/setupWizard';
 
 const mockNavigate = jest.fn();
 const mockInvalidateQueries = jest.fn();
 const mockConnect = jest.fn();
+const mockFetch = jest.fn();
 const isConnected$ = observable(true);
 
 jest.mock('react-router-dom', () => {
@@ -22,6 +24,7 @@ jest.mock('@/contexts/ApiContext', () => {
     useApi: () => ({
       api: {
         createConversationWithPlaceholder: jest.fn(),
+        authHeader: null,
       },
       isConnected$,
       connect: mockConnect,
@@ -59,9 +62,17 @@ jest.mock('../ExamplesSection', () => ({
 describe('WelcomeView', () => {
   beforeEach(() => {
     isConnected$.set(true);
+    setupWizard$.step.set('welcome');
+    setupWizard$.open.set(false);
     mockConnect.mockReset();
     mockNavigate.mockClear();
     mockInvalidateQueries.mockClear();
+    mockFetch.mockReset();
+    mockFetch.mockImplementation(() => new Promise(() => {}));
+    Object.defineProperty(window, 'fetch', {
+      writable: true,
+      value: mockFetch,
+    });
   });
 
   it('renders the refreshed new chat copy and quick suggestions', () => {
@@ -97,5 +108,42 @@ describe('WelcomeView', () => {
     expect(screen.getByRole('button', { name: /retry connection/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /copy start command/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /server settings/i })).toBeInTheDocument();
+  });
+
+  it('shows a finish-setup banner when the server has no provider configured', async () => {
+    let resolveFetch:
+      | ((value: { ok: boolean; json: () => Promise<{ provider_configured: boolean }> }) => void)
+      | null = null;
+    mockFetch.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveFetch = resolve;
+        })
+    );
+
+    render(
+      <SettingsProvider>
+        <WelcomeView />
+      </SettingsProvider>
+    );
+
+    await act(async () => {
+      resolveFetch?.({
+        ok: true,
+        json: async () => ({ provider_configured: false }),
+      });
+      await Promise.resolve();
+    });
+
+    expect(await screen.findByText('Provider setup required')).toBeInTheDocument();
+    expect(
+      screen.getByText(/it does not have an LLM provider configured yet/i)
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /finish setup/i }));
+
+    await waitFor(() => {
+      expect(setupWizard$.get()).toMatchObject({ open: true, step: 'provider' });
+    });
   });
 });

--- a/webui/src/stores/setupWizard.ts
+++ b/webui/src/stores/setupWizard.ts
@@ -6,4 +6,9 @@ export type SetupWizardStep = 'welcome' | 'mode' | 'local' | 'cloud' | 'provider
 export const setupWizard$ = observable({
   open: false,
   step: 'welcome' as SetupWizardStep,
+  providerStatusVersion: 0,
 });
+
+export function bumpProviderStatusVersion() {
+  setupWizard$.providerStatusVersion.set((version) => version + 1);
+}

--- a/webui/src/stores/setupWizard.ts
+++ b/webui/src/stores/setupWizard.ts
@@ -1,0 +1,9 @@
+import { observable } from '@legendapp/state';
+
+export type SetupWizardStep = 'welcome' | 'mode' | 'local' | 'cloud' | 'provider' | 'complete';
+
+/** Observable to reopen the setup wizard to a specific step from outside the component tree. */
+export const setupWizard$ = observable({
+  open: false,
+  step: 'welcome' as SetupWizardStep,
+});

--- a/webui/src/utils/providerStatus.ts
+++ b/webui/src/utils/providerStatus.ts
@@ -1,0 +1,13 @@
+export async function fetchProviderConfigured(
+  baseUrl: string,
+  authHeader: string | null,
+  signal?: AbortSignal
+): Promise<boolean> {
+  const headers: Record<string, string> = authHeader ? { Authorization: authHeader } : {};
+  const response = await fetch(`${baseUrl}/api/v2`, { headers, signal });
+  if (!response.ok) {
+    throw new Error(`Failed to verify provider status (${response.status})`);
+  }
+  const data = (await response.json()) as { provider_configured?: boolean };
+  return data.provider_configured !== false;
+}


### PR DESCRIPTION
## Summary
- detect when the connected server is reachable but still has no provider configured
- show a welcome-view alert with direct paths to finish setup or open server settings
- allow the setup wizard to be reopened directly to the provider step from elsewhere in the UI

## Testing
- `cd webui && npm test -- --runTestsByPath src/components/__tests__/SetupWizard.test.tsx src/components/__tests__/WelcomeView.test.tsx --runInBand`
- `cd webui && npm run lint`

Refs gptme/gptme#2193