### PR TITLE
fix(tauri): codesign sidecar binary on macOS

### DIFF
--- a/.github/workflows/tauri.yml
+++ b/.github/workflows/tauri.yml
@@ -342,6 +342,29 @@ jobs:
           merge-multiple: true
           path: tauri/bins
 
+      - name: Codesign sidecar binary (macOS)
+        if: matrix.platform == 'macos-latest' && env.HAS_APPLE_SIGNING == 'true'
+        shell: bash
+        run: |
+          # Tauri only signs the .app bundle, not sidecar binaries.
+          # macOS Gatekeeper rejects unsigned binaries inside signed apps,
+          # so we must codesign the PyInstaller-built sidecar before bundling.
+          # Entitlements allow JIT and unsigned memory access (required by PyInstaller).
+          # See: https://github.com/tauri-apps/tauri/discussions/2269
+          TRIPLE=$(rustc -Vv | grep host | cut -f2 -d' ')
+          SIDECAR="tauri/bins/gptme-server-${TRIPLE}"
+          if [ -f "$SIDECAR" ]; then
+            echo "Signing sidecar: $SIDECAR"
+            codesign --force --options runtime --timestamp \
+              --entitlements tauri/entitlements.plist \
+              --sign "$APPLE_SIGNING_IDENTITY" \
+              "$SIDECAR"
+            codesign --verify --verbose "$SIDECAR"
+          else
+            echo "Warning: Sidecar not found at $SIDECAR, skipping codesign"
+            ls -la tauri/bins/ || true
+          fi
+
       - name: Create placeholder icons for tauri::generate_context!
         shell: bash
         run: |

--- a/.github/workflows/tauri.yml
+++ b/.github/workflows/tauri.yml
@@ -342,29 +342,6 @@ jobs:
           merge-multiple: true
           path: tauri/bins
 
-      - name: Codesign sidecar binary (macOS)
-        if: matrix.platform == 'macos-latest' && env.HAS_APPLE_SIGNING == 'true'
-        shell: bash
-        run: |
-          # Tauri only signs the .app bundle, not sidecar binaries.
-          # macOS Gatekeeper rejects unsigned binaries inside signed apps,
-          # so we must codesign the PyInstaller-built sidecar before bundling.
-          # Entitlements allow JIT and unsigned memory access (required by PyInstaller).
-          # See: https://github.com/tauri-apps/tauri/discussions/2269
-          TRIPLE=$(rustc -Vv | grep host | cut -f2 -d' ')
-          SIDECAR="tauri/bins/gptme-server-${TRIPLE}"
-          if [ -f "$SIDECAR" ]; then
-            echo "Signing sidecar: $SIDECAR"
-            codesign --force --options runtime --timestamp \
-              --entitlements tauri/entitlements.plist \
-              --sign "$APPLE_SIGNING_IDENTITY" \
-              "$SIDECAR"
-            codesign --verify --verbose "$SIDECAR"
-          else
-            echo "Warning: Sidecar not found at $SIDECAR, skipping codesign"
-            ls -la tauri/bins/ || true
-          fi
-
       - name: Create placeholder icons for tauri::generate_context!
         shell: bash
         run: |
@@ -418,6 +395,29 @@ jobs:
           CERT_INFO=$(security find-identity -v -p codesigning build.keychain | head -n 1)
           SIGNING_IDENTITY=$(echo "$CERT_INFO" | awk -F'"' '{print $2}')
           echo "APPLE_SIGNING_IDENTITY=$SIGNING_IDENTITY" >> $GITHUB_ENV
+
+      - name: Codesign sidecar binary (macOS)
+        if: matrix.platform == 'macos-latest' && env.HAS_APPLE_SIGNING == 'true'
+        shell: bash
+        run: |
+          # Tauri only signs the .app bundle, not sidecar binaries.
+          # macOS Gatekeeper rejects unsigned binaries inside signed apps,
+          # so we must codesign the PyInstaller-built sidecar before bundling.
+          # Entitlements allow JIT and unsigned memory access (required by PyInstaller).
+          # See: https://github.com/tauri-apps/tauri/discussions/2269
+          TRIPLE=$(rustc -Vv | grep host | cut -f2 -d' ')
+          SIDECAR="tauri/bins/gptme-server-${TRIPLE}"
+          if [ -f "$SIDECAR" ]; then
+            echo "Signing sidecar: $SIDECAR"
+            codesign --force --options runtime --timestamp \
+              --entitlements tauri/entitlements.plist \
+              --sign "$APPLE_SIGNING_IDENTITY" \
+              "$SIDECAR"
+            codesign --verify --verbose "$SIDECAR"
+          else
+            echo "Warning: Sidecar not found at $SIDECAR, skipping codesign"
+            ls -la tauri/bins/ || true
+          fi
 
       - name: Set Tauri bundle version from release tag
         shell: bash

--- a/tauri/entitlements.plist
+++ b/tauri/entitlements.plist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!-- Required for PyInstaller-built binaries -->
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- Adds a codesigning step in the Tauri release job that signs the PyInstaller-built `gptme-server` sidecar with the Developer ID certificate before Tauri bundles it into the `.app`
- Adds `entitlements.plist` with JIT/unsigned-memory entitlements required by PyInstaller binaries
- Without this, macOS Gatekeeper rejects the unsigned sidecar inside the signed app at runtime

Approach matches ActivityWatch's codesigning strategy (see `scripts/package/build_app_tauri.sh`), simplified for gptme's single-binary sidecar case.

Ref: https://github.com/tauri-apps/tauri/discussions/2269

Closes #1590

## Test plan
- [ ] Merge, trigger a dev release, verify the macOS Release job's "Codesign sidecar binary" step succeeds
- [ ] Download the `.dmg`, verify `codesign --verify --verbose` passes on the sidecar inside the app bundle
- [ ] Verify the app launches without Gatekeeper warnings