### PR TITLE
fix(tauri): restore execute permission on sidecar after artifact download

### DIFF
--- a/.github/workflows/tauri.yml
+++ b/.github/workflows/tauri.yml
@@ -342,6 +342,10 @@ jobs:
           merge-multiple: true
           path: tauri/bins
 
+      - name: Fix sidecar permissions
+        shell: bash
+        run: chmod +x tauri/bins/gptme-server-* || true
+
       - name: Create placeholder icons for tauri::generate_context!
         shell: bash
         run: |


### PR DESCRIPTION
## Summary
- `upload-artifact`/`download-artifact` strips the execute bit from the sidecar binary
- Without `+x`, macOS cannot launch `gptme-server`, causing the app to hang on "Auto-connecting..."
- Adds `chmod +x` after downloading sidecar artifacts

Verified locally: setting `+x` on the installed sidecar makes the app connect successfully.

## Test plan
- [ ] Merge, trigger dev release, verify sidecar starts and app connects