### PR TITLE
fix(settings): show effective config sources and restore scroll

### DIFF
--- a/gptme/config/user.py
+++ b/gptme/config/user.py
@@ -78,6 +78,64 @@ default_config = UserConfig(
 # Track whether we've already logged the user config message
 _user_config_logged: set[Path] = set()
 
+USER_CONFIG_SOURCE_ENV = "env"
+USER_CONFIG_SOURCE_LOCAL = "config.local.toml"
+USER_CONFIG_SOURCE_MAIN = "config.toml"
+
+
+def get_user_config_paths(path: str | None = None) -> tuple[Path, Path]:
+    """Return the main and local user config paths."""
+    config_file = Path(path or config_path)
+    return config_file, config_file.parent / "config.local.toml"
+
+
+def _get_nested_config_value(doc: TOMLDocument, *keys: str) -> Any | None:
+    """Look up a nested TOML value by key path."""
+    current: Any = doc.unwrap()
+    for key in keys:
+        if not isinstance(current, dict) or key not in current:
+            return None
+        current = current[key]
+    return current
+
+
+def get_user_config_env_source(key: str, path: str | None = None) -> str | None:
+    """Return where an env-backed user setting currently comes from.
+
+    Precedence matches ``Config.get_env`` for the user-config/global portion:
+    process environment first, then ``config.local.toml``, then ``config.toml``.
+    """
+    prefixed = f"GPTME_{key}" if not key.startswith("GPTME_") else key
+    bare = key.removeprefix("GPTME_") if key.startswith("GPTME_") else key
+
+    if prefixed in os.environ or bare in os.environ:
+        return USER_CONFIG_SOURCE_ENV
+
+    config_file, local_path = get_user_config_paths(path)
+    if local_path.exists():
+        with open(local_path) as f:
+            local_doc = tomlkit.load(f)
+        if _get_nested_config_value(local_doc, "env", bare) is not None:
+            return USER_CONFIG_SOURCE_LOCAL
+
+    main_doc = _load_config_doc(str(config_file))
+    if _get_nested_config_value(main_doc, "env", bare) is not None:
+        return USER_CONFIG_SOURCE_MAIN
+
+    return None
+
+
+def get_user_config_runtime_info(path: str | None = None) -> dict[str, str | bool]:
+    """Return read/write path details for the user config UI."""
+    config_file, local_path = get_user_config_paths(path)
+    return {
+        "config_path": str(path_with_tilde(config_file)),
+        "local_config_path": str(path_with_tilde(local_path)),
+        "local_config_exists": local_path.exists(),
+        "write_target": str(path_with_tilde(config_file)),
+        "local_overrides_main": True,
+    }
+
 
 def load_user_config(path: str | None = None) -> UserConfig:
     """Load the user configuration from the config file.
@@ -87,11 +145,10 @@ def load_user_config(path: str | None = None) -> UserConfig:
     This allows committing preferences to dotfiles while keeping secrets separate.
     """
     config_file_path = path or config_path
-    config_file = Path(config_file_path)
+    config_file, local_path = get_user_config_paths(config_file_path)
     config = _load_config_doc(path).unwrap()
 
     # Look for local config file in the same directory
-    local_path = config_file.parent / "config.local.toml"
     has_local = local_path.exists()
     if has_local:
         with open(local_path) as f:

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -41,6 +41,7 @@ from gptme.prompts import get_prompt
 
 from ..commands import handle_cmd
 from ..config import get_project_config
+from ..config.user import get_user_config_env_source, get_user_config_runtime_info
 from ..dirs import get_logs_dir
 from ..logmanager import Log, LogManager, get_user_conversations
 from ..message import Message
@@ -1518,10 +1519,24 @@ def api_user_settings():
     """Return the current user settings state."""
     available = list_available_providers()
     providers = [str(provider) for provider, _ in available]
+    provider_sources = {
+        str(provider): {
+            "auth_source": auth_source,
+            "effective_source": (
+                "oauth"
+                if auth_source == "oauth"
+                else get_user_config_env_source(auth_source)
+            ),
+        }
+        for provider, auth_source in available
+    }
     default_model = get_default_model()
     return flask.jsonify(
         {
             "providers_configured": providers,
+            "provider_sources": provider_sources,
             "default_model": default_model.full if default_model else None,
+            "default_model_source": get_user_config_env_source("MODEL"),
+            "config_files": get_user_config_runtime_info(),
         }
     )

--- a/gptme/server/openapi_docs.py
+++ b/gptme/server/openapi_docs.py
@@ -206,9 +206,31 @@ class UserSettingsResponse(BaseModel):
         ...,
         description="Provider slugs that have an API key or OAuth token configured",
     )
+    provider_sources: dict[str, dict[str, str | None]] = Field(
+        default_factory=dict,
+        description=(
+            "Per-provider configuration metadata. Each entry includes "
+            "`auth_source` (env var or `oauth`) and `effective_source` "
+            "(`env`, `config.local.toml`, `config.toml`, or `oauth`)."
+        ),
+    )
     default_model: str | None = Field(
         None,
         description="Fully qualified default model from config, or null if unset",
+    )
+    default_model_source: str | None = Field(
+        None,
+        description=(
+            "Where the current MODEL value comes from: `env`, `config.local.toml`, "
+            "`config.toml`, or null if unset."
+        ),
+    )
+    config_files: dict[str, str | bool] = Field(
+        default_factory=dict,
+        description=(
+            "Paths and merge behavior for user config files, including the main "
+            "config path, local override path, and the write target used by the UI."
+        ),
     )
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -17,6 +17,13 @@ from gptme.config import (
     load_user_config,
     setup_config_from_cli,
 )
+from gptme.config.user import (
+    USER_CONFIG_SOURCE_ENV,
+    USER_CONFIG_SOURCE_LOCAL,
+    USER_CONFIG_SOURCE_MAIN,
+    get_user_config_env_source,
+    get_user_config_runtime_info,
+)
 
 default_user_config = """[prompt]
 about_user = "I am a curious human programmer."
@@ -982,6 +989,64 @@ def test_user_config_no_local_toml(tmp_path):
     # Should work fine without config.local.toml
     config = Config(user=load_user_config(str(main_config)))
     assert config.user.prompt.about_user == "I am a developer."
+
+
+def test_user_config_env_source_reports_main_local_and_env(tmp_path, monkeypatch):
+    """Effective env-backed setting source should follow env > local > main precedence."""
+    main_config = tmp_path / "config.toml"
+    main_config.write_text('[env]\nMODEL = "anthropic/claude-sonnet-4-7"\n')
+
+    local_config = tmp_path / "config.local.toml"
+    local_config.write_text(
+        '[env]\nOPENAI_API_KEY = "sk-local"\nMODEL = "openai/gpt-5"\n'
+    )
+
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("MODEL", raising=False)
+    monkeypatch.delenv("GPTME_MODEL", raising=False)
+
+    assert (
+        get_user_config_env_source("OPENAI_API_KEY", str(main_config))
+        == USER_CONFIG_SOURCE_LOCAL
+    )
+    assert (
+        get_user_config_env_source("MODEL", str(main_config))
+        == USER_CONFIG_SOURCE_LOCAL
+    )
+
+    monkeypatch.setenv("MODEL", "xai/grok-4")
+    assert (
+        get_user_config_env_source("MODEL", str(main_config)) == USER_CONFIG_SOURCE_ENV
+    )
+
+    monkeypatch.delenv("MODEL", raising=False)
+    local_config.write_text('[env]\nOPENAI_API_KEY = "sk-local"\n')
+    assert (
+        get_user_config_env_source("MODEL", str(main_config)) == USER_CONFIG_SOURCE_MAIN
+    )
+
+
+def test_user_config_runtime_info_reports_paths_and_write_target(tmp_path):
+    """Runtime info should describe config merge and write behavior for the UI."""
+    main_config = tmp_path / "config.toml"
+    main_config.write_text("[env]\n")
+    (tmp_path / "config.local.toml").write_text("[env]\n")
+
+    info = get_user_config_runtime_info(str(main_config))
+
+    config_path = info["config_path"]
+    local_config_path = info["local_config_path"]
+    write_target = info["write_target"]
+
+    assert isinstance(config_path, str)
+    assert isinstance(local_config_path, str)
+    assert isinstance(write_target, str)
+
+    assert config_path.endswith("config.toml")
+    assert local_config_path.endswith("config.local.toml")
+    assert info["local_config_exists"] is True
+    assert write_target.endswith("config.toml")
+    assert info["local_overrides_main"] is True
 
 
 def test_cli_auto_envvar_prefix():

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -1596,12 +1596,40 @@ def test_v2_user_settings_returns_providers_and_model(client: FlaskClient, monke
         "gptme.server.api_v2.list_available_providers",
         lambda: [("anthropic", "ANTHROPIC_API_KEY")],
     )
+    monkeypatch.setattr(
+        "gptme.server.api_v2.get_user_config_env_source",
+        lambda key: (
+            "config.local.toml"
+            if key == "ANTHROPIC_API_KEY"
+            else "config.toml"
+            if key == "MODEL"
+            else None
+        ),
+    )
+    monkeypatch.setattr(
+        "gptme.server.api_v2.get_user_config_runtime_info",
+        lambda: {
+            "config_path": "~/.config/gptme/config.toml",
+            "local_config_path": "~/.config/gptme/config.local.toml",
+            "local_config_exists": True,
+            "write_target": "~/.config/gptme/config.toml",
+            "local_overrides_main": True,
+        },
+    )
 
     response = client.get("/api/v2/user/settings")
     assert response.status_code == 200
     data = response.get_json()
     assert data["providers_configured"] == ["anthropic"]
+    assert data["provider_sources"] == {
+        "anthropic": {
+            "auth_source": "ANTHROPIC_API_KEY",
+            "effective_source": "config.local.toml",
+        }
+    }
     assert data["default_model"] == "anthropic/claude-sonnet-4-5"
+    assert data["default_model_source"] == "config.toml"
+    assert data["config_files"]["write_target"] == "~/.config/gptme/config.toml"
 
 
 def test_v2_user_settings_no_providers_no_model(client: FlaskClient, monkeypatch):
@@ -1611,9 +1639,25 @@ def test_v2_user_settings_no_providers_no_model(client: FlaskClient, monkeypatch
         lambda: [],
     )
     monkeypatch.setattr("gptme.server.api_v2.get_default_model", lambda: None)
+    monkeypatch.setattr(
+        "gptme.server.api_v2.get_user_config_env_source", lambda _key: None
+    )
+    monkeypatch.setattr(
+        "gptme.server.api_v2.get_user_config_runtime_info",
+        lambda: {
+            "config_path": "~/.config/gptme/config.toml",
+            "local_config_path": "~/.config/gptme/config.local.toml",
+            "local_config_exists": False,
+            "write_target": "~/.config/gptme/config.toml",
+            "local_overrides_main": True,
+        },
+    )
 
     response = client.get("/api/v2/user/settings")
     assert response.status_code == 200
     data = response.get_json()
     assert data["providers_configured"] == []
+    assert data["provider_sources"] == {}
     assert data["default_model"] is None
+    assert data["default_model_source"] is None
+    assert data["config_files"]["local_config_exists"] is False

--- a/webui/src/components/SettingsModal.tsx
+++ b/webui/src/components/SettingsModal.tsx
@@ -340,7 +340,7 @@ export const SettingsModal = forwardRef<HTMLButtonElement, SettingsModalProps>(
             </Button>
           )}
         </DialogTrigger>
-        <DialogContent className="max-h-[80vh] max-w-4xl p-0">
+        <DialogContent className="flex max-h-[80vh] max-w-4xl flex-col overflow-hidden p-0">
           <DialogHeader className="border-b px-6 py-3">
             <DialogTitle className="flex items-center gap-2">
               <Settings className="h-5 w-5" />
@@ -349,9 +349,9 @@ export const SettingsModal = forwardRef<HTMLButtonElement, SettingsModalProps>(
             <DialogDescription>Customize your gptme experience</DialogDescription>
           </DialogHeader>
 
-          <div className="flex min-h-[500px]">
+          <div className="flex min-h-0 min-w-0 flex-1">
             {/* Sidebar */}
-            <div className="w-64 border-r bg-muted/20 p-4">
+            <div className="w-64 overflow-y-auto border-r bg-muted/20 p-4">
               <nav className="space-y-1">
                 {categories.map((category) => {
                   const Icon = category.icon;
@@ -378,7 +378,9 @@ export const SettingsModal = forwardRef<HTMLButtonElement, SettingsModalProps>(
             </div>
 
             {/* Content */}
-            <div className="flex-1 overflow-y-auto p-6">{renderCategoryContent()}</div>
+            <div className="min-h-0 min-w-0 flex-1 overflow-y-auto p-6">
+              {renderCategoryContent()}
+            </div>
           </div>
         </DialogContent>
       </Dialog>

--- a/webui/src/components/settings/ServerApiKeySettings.tsx
+++ b/webui/src/components/settings/ServerApiKeySettings.tsx
@@ -4,7 +4,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { useApi } from '@/contexts/ApiContext';
 import { useModels } from '@/hooks/useModels';
-import { useUserSettings } from '@/hooks/useUserSettings';
+import { useUserSettings, type UserSettingsProviderSource } from '@/hooks/useUserSettings';
 import {
   API_KEY_PROVIDER_METADATA,
   API_KEY_PROVIDER_OPTIONS,
@@ -18,6 +18,16 @@ type SaveApiKeyResponse = {
   env_var: string;
   restart_required: boolean;
 };
+
+function describeProviderSource(providerSource?: UserSettingsProviderSource): string {
+  if (!providerSource?.effective_source) {
+    return 'Configured';
+  }
+  if (providerSource.effective_source === 'oauth') {
+    return 'Configured via OAuth token';
+  }
+  return `Configured via ${providerSource.effective_source} (${providerSource.auth_source})`;
+}
 
 export function ServerApiKeySettings() {
   const { api } = useApi();
@@ -33,6 +43,7 @@ export function ServerApiKeySettings() {
     [models, provider]
   );
   const configuredProviders = settings?.providers_configured ?? [];
+  const providerSources = settings?.provider_sources ?? {};
 
   useEffect(() => {
     if (providerModels.length === 0) {
@@ -109,15 +120,23 @@ export function ServerApiKeySettings() {
       </div>
 
       {configuredProviders.length > 0 && (
-        <div className="flex flex-wrap gap-1">
-          {configuredProviders.map((configuredProvider) => (
-            <span
-              key={configuredProvider}
-              className="rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground"
-            >
-              {configuredProvider}
-            </span>
-          ))}
+        <div className="space-y-2 rounded-md bg-muted/40 p-3">
+          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            Already configured
+          </p>
+          <div className="space-y-2">
+            {configuredProviders.map((configuredProvider) => (
+              <div
+                key={configuredProvider}
+                className="flex flex-wrap items-center justify-between gap-2 text-sm"
+              >
+                <span className="font-medium">{configuredProvider}</span>
+                <span className="text-xs text-muted-foreground">
+                  {describeProviderSource(providerSources[configuredProvider])}
+                </span>
+              </div>
+            ))}
+          </div>
         </div>
       )}
 

--- a/webui/src/components/settings/ServerConfiguration.tsx
+++ b/webui/src/components/settings/ServerConfiguration.tsx
@@ -14,6 +14,7 @@ import {
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { Pencil, Trash2, Plus, Plug, Unplug, Copy } from 'lucide-react';
 import { useApi } from '@/contexts/ApiContext';
+import { useUserSettings } from '@/hooks/useUserSettings';
 import { use$ } from '@legendapp/state/react';
 import {
   serverRegistry$,
@@ -70,6 +71,7 @@ const ServerDot: FC<{ serverId: string; className?: string }> = ({ serverId, cla
 
 export const ServerConfiguration: FC = () => {
   const { connect, switchServer } = useApi();
+  const { settings } = useUserSettings();
   const registry = use$(serverRegistry$);
 
   const [editDialogOpen, setEditDialogOpen] = useState(false);
@@ -347,6 +349,34 @@ export const ServerConfiguration: FC = () => {
           );
         })}
       </div>
+
+      {settings?.config_files && (
+        <div className="space-y-2 rounded-lg border border-dashed p-4 text-sm text-muted-foreground">
+          <div>
+            <h4 className="font-medium text-foreground">Config file behavior</h4>
+            <p className="mt-1">
+              gptme always loads <code>{settings.config_files.config_path}</code>.
+            </p>
+            <p className="mt-1">
+              {settings.config_files.local_config_exists ? (
+                <>
+                  <code>{settings.config_files.local_config_path}</code> is present and overrides
+                  overlapping values.
+                </>
+              ) : (
+                <>
+                  If present, <code>{settings.config_files.local_config_path}</code> would override
+                  overlapping values.
+                </>
+              )}
+            </p>
+            <p className="mt-1">
+              Changes from this settings UI are written to{' '}
+              <code>{settings.config_files.write_target}</code>.
+            </p>
+          </div>
+        </div>
+      )}
 
       <ServerApiKeySettings />
       <ServerDefaultModelSettings />

--- a/webui/src/components/settings/ServerDefaultModelSettings.tsx
+++ b/webui/src/components/settings/ServerDefaultModelSettings.tsx
@@ -3,7 +3,7 @@ import { Button } from '@/components/ui/button';
 import { ModelPickerButton } from '@/components/ModelPicker';
 import { useApi } from '@/contexts/ApiContext';
 import { useModels } from '@/hooks/useModels';
-import { useUserSettings } from '@/hooks/useUserSettings';
+import { useUserSettings, type UserSettingSource } from '@/hooks/useUserSettings';
 import { toast } from 'sonner';
 
 type SaveDefaultModelResponse = {
@@ -11,6 +11,19 @@ type SaveDefaultModelResponse = {
   model: string;
   restart_required: boolean;
 };
+
+function describeModelSource(source: UserSettingSource | null): string {
+  if (!source) {
+    return 'unknown source';
+  }
+  if (source === 'env') {
+    return 'environment';
+  }
+  if (source === 'oauth') {
+    return 'OAuth-backed setup';
+  }
+  return source;
+}
 
 export function ServerDefaultModelSettings() {
   const { api } = useApi();
@@ -100,6 +113,7 @@ export function ServerDefaultModelSettings() {
   };
 
   const configuredProviders = settings?.providers_configured ?? [];
+  const defaultModelSource = settings?.default_model_source ?? null;
 
   return (
     <div className="space-y-3 rounded-lg border p-4">
@@ -125,7 +139,12 @@ export function ServerDefaultModelSettings() {
 
       {serverDefaultModel && (
         <p className="text-xs text-muted-foreground">
-          Current default: <code>{serverDefaultModel}</code>
+          Current default: <code>{serverDefaultModel}</code>{' '}
+          {defaultModelSource && (
+            <>
+              from <code>{describeModelSource(defaultModelSource)}</code>
+            </>
+          )}
         </p>
       )}
 

--- a/webui/src/components/settings/__tests__/ServerApiKeySettings.test.tsx
+++ b/webui/src/components/settings/__tests__/ServerApiKeySettings.test.tsx
@@ -40,7 +40,21 @@ jest.mock('@/hooks/useUserSettings', () => ({
   useUserSettings: () => ({
     settings: {
       providers_configured: ['anthropic'],
+      provider_sources: {
+        anthropic: {
+          auth_source: 'ANTHROPIC_API_KEY',
+          effective_source: 'config.local.toml',
+        },
+      },
       default_model: 'anthropic/claude-sonnet-4-7',
+      default_model_source: 'config.toml',
+      config_files: {
+        config_path: '~/.config/gptme/config.toml',
+        local_config_path: '~/.config/gptme/config.local.toml',
+        local_config_exists: true,
+        write_target: '~/.config/gptme/config.toml',
+        local_overrides_main: true,
+      },
     },
     isLoading: false,
     error: null,
@@ -121,5 +135,14 @@ describe('ServerApiKeySettings', () => {
 
     expect(mockSuccess).toHaveBeenCalledWith('API key saved. Restart the server to apply it.');
     expect(mockRefetch).toHaveBeenCalled();
+  });
+
+  it('shows configured provider source details', () => {
+    render(<ServerApiKeySettings />);
+
+    expect(screen.getByText(/already configured/i)).toBeInTheDocument();
+    expect(
+      screen.getByText('Configured via config.local.toml (ANTHROPIC_API_KEY)')
+    ).toBeInTheDocument();
   });
 });

--- a/webui/src/components/settings/__tests__/ServerDefaultModelSettings.test.tsx
+++ b/webui/src/components/settings/__tests__/ServerDefaultModelSettings.test.tsx
@@ -42,7 +42,25 @@ jest.mock('@/hooks/useUserSettings', () => ({
   useUserSettings: () => ({
     settings: {
       providers_configured: ['anthropic', 'openai'],
+      provider_sources: {
+        anthropic: {
+          auth_source: 'ANTHROPIC_API_KEY',
+          effective_source: 'config.local.toml',
+        },
+        openai: {
+          auth_source: 'OPENAI_API_KEY',
+          effective_source: 'config.toml',
+        },
+      },
       default_model: 'anthropic/claude-sonnet-4-7',
+      default_model_source: 'config.toml',
+      config_files: {
+        config_path: '~/.config/gptme/config.toml',
+        local_config_path: '~/.config/gptme/config.local.toml',
+        local_config_exists: true,
+        write_target: '~/.config/gptme/config.toml',
+        local_overrides_main: true,
+      },
     },
     isLoading: false,
     error: null,
@@ -141,7 +159,7 @@ describe('ServerDefaultModelSettings', () => {
     render(<ServerDefaultModelSettings />);
 
     expect(screen.getByText(/current default:/i).closest('p')).toHaveTextContent(
-      'anthropic/claude-sonnet-4-7'
+      'anthropic/claude-sonnet-4-7 from config.toml'
     );
   });
 });

--- a/webui/src/hooks/useUserSettings.ts
+++ b/webui/src/hooks/useUserSettings.ts
@@ -18,10 +18,10 @@ export interface UserSettingsConfigFiles {
 
 export interface UserSettings {
   providers_configured: string[];
-  provider_sources: Record<string, UserSettingsProviderSource>;
+  provider_sources?: Record<string, UserSettingsProviderSource>;
   default_model: string | null;
-  default_model_source: UserSettingSource | null;
-  config_files: UserSettingsConfigFiles;
+  default_model_source?: UserSettingSource | null;
+  config_files?: UserSettingsConfigFiles;
 }
 
 export function useUserSettings() {

--- a/webui/src/hooks/useUserSettings.ts
+++ b/webui/src/hooks/useUserSettings.ts
@@ -1,9 +1,27 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useApi } from '@/contexts/ApiContext';
 
+export type UserSettingSource = 'env' | 'config.local.toml' | 'config.toml' | 'oauth';
+
+export interface UserSettingsProviderSource {
+  auth_source: string;
+  effective_source: UserSettingSource | null;
+}
+
+export interface UserSettingsConfigFiles {
+  config_path: string;
+  local_config_path: string;
+  local_config_exists: boolean;
+  write_target: string;
+  local_overrides_main: boolean;
+}
+
 export interface UserSettings {
   providers_configured: string[];
+  provider_sources: Record<string, UserSettingsProviderSource>;
   default_model: string | null;
+  default_model_source: UserSettingSource | null;
+  config_files: UserSettingsConfigFiles;
 }
 
 export function useUserSettings() {


### PR DESCRIPTION
Closes part of #2193.

## What changed
- add effective-source metadata to `/api/v2/user/settings` for provider keys and `MODEL`
- expose the `config.toml` vs `config.local.toml` merge/write behavior in the settings UI
- show where configured provider keys and the current default model are coming from
- fix the settings modal layout so the Servers pane scrolls to the lower sections again

## Verification
- `uv run --with pytest pytest tests/test_config.py -q -k "user_config_env_source_reports_main_local_and_env or user_config_runtime_info_reports_paths_and_write_target"`
- `uv run --extra server --with pytest pytest tests/test_server_v2.py -q -k "v2_user_settings_returns_providers_and_model or v2_user_settings_no_providers_no_model"`
- `npm test -- --runInBand src/components/settings/__tests__/ServerApiKeySettings.test.tsx src/components/settings/__tests__/ServerDefaultModelSettings.test.tsx`
- `npm run typecheck`
- `npm run build`