### PR TITLE
fix(prompts): include version string in custom agent system prompt

### DIFF
--- a/gptme/prompts/templates.py
+++ b/gptme/prompts/templates.py
@@ -102,11 +102,11 @@ def prompt_gptme(
     # use <thinking> tags as a fallback if the model doesn't natively support reasoning
     use_thinking_tags = not model_meta or not model_meta.supports_reasoning
 
-    if agent_name:
-        agent_blurb = f"{agent_name}, an agent running in gptme, letting you act as a general-purpose AI assistant powered by LLMs"
-    else:
-        from ..__version__ import __version__
+    from ..__version__ import __version__
 
+    if agent_name:
+        agent_blurb = f"{agent_name}, an agent running in gptme v{__version__}, letting you act as a general-purpose AI assistant powered by LLMs"
+    else:
         agent_name = f"gptme v{__version__}"
         agent_blurb = f"{agent_name}, a general-purpose AI assistant powered by LLMs"
 


### PR DESCRIPTION
When using `--agent-path` with a custom agent name (e.g. Bob), the gptme version was not included in the system prompt. This meant agents running with custom configs had no way to know which gptme version they were on.

**Before** (with agent name "Bob"):
> You are Bob, an agent running in gptme, letting you act as...

**After**:
> You are Bob, an agent running in gptme v0.31.0, letting you act as...

Without a custom agent name, the prompt already included `gptme v{version}` — this was just missing in the agent_name branch.

One-line change: moved the `__version__` import outside the if/else and included it in the agent blurb.