### PR TITLE
fix(agents_md_inject): skip re-injection when content already loaded from different path

### DIFF
--- a/gptme/hooks/agents_md_inject.py
+++ b/gptme/hooks/agents_md_inject.py
@@ -34,6 +34,11 @@ from ..hooks import HookType, StopPropagation, register_hook
 from ..logmanager import Log
 from ..message import Message
 from ..prompts import _loaded_agent_files_var, find_agent_files_in_tree
+from ..util.context_dedup import _content_hash
+
+# Prefix used to store content hashes (vs file paths) in _loaded_agent_files_var.
+# Prevents path-identical-content re-injection when cwd changes to a git worktree.
+_HASH_PREFIX = "ch:"
 
 logger = logging.getLogger(__name__)
 
@@ -45,19 +50,31 @@ def _derive_loaded_files_from_log(log: Log) -> set[str]:
     contexts, causing _loaded_agent_files_var to start as None each request.
     Parses <agent-instructions source="..."> tags in system messages to rebuild
     the loaded-files set from the persistent conversation state.
+
+    Also records content hashes (prefixed with ``ch:``) so that worktree copies
+    with the same content but a different path are not re-injected.
     """
     loaded: set[str] = set()
     for msg in log.messages:
         if msg.role == "system":
-            for match in re.finditer(
+            # Extract source paths from opening tags (works even if closing tag missing).
+            for path_match in re.finditer(
                 r'<agent-instructions source="([^"]+)">', msg.content
             ):
-                path_str = match.group(1)
+                path_str = path_match.group(1)
                 try:
                     resolved = str(Path(path_str).expanduser().resolve())
                     loaded.add(resolved)
                 except (OSError, ValueError):
                     loaded.add(path_str)
+            # Extract content hashes from complete blocks so worktree copies with
+            # identical content are also skipped.
+            for block_match in re.finditer(
+                r'<agent-instructions source="[^"]*">(.*?)</agent-instructions>',
+                msg.content,
+                re.DOTALL,
+            ):
+                loaded.add(f"{_HASH_PREFIX}{_content_hash(block_match.group(1))}")
     return loaded
 
 
@@ -118,7 +135,18 @@ def on_cwd_changed(
                 logger.warning(f"Could not read agent file {agent_file}: {e}")
                 continue
 
+            # Skip if identical content was already injected from a different path
+            # (e.g. switching cwd to a git worktree that shares the same AGENTS.md).
+            content_key = f"{_HASH_PREFIX}{_content_hash(content)}"
+            if content_key in loaded:
+                logger.debug(
+                    f"Skipping {agent_file}: identical content already injected"
+                )
+                loaded.add(resolved)
+                continue
+
             loaded.add(resolved)
+            loaded.add(content_key)
 
             # Make the path relative to home for cleaner display
             try:

--- a/gptme/hooks/tests/test_agents_md_inject.py
+++ b/gptme/hooks/tests/test_agents_md_inject.py
@@ -11,12 +11,14 @@ from pathlib import Path
 import pytest
 
 from gptme.hooks.agents_md_inject import (
+    _HASH_PREFIX,
     _derive_loaded_files_from_log,
     _get_loaded_files,
     on_cwd_changed,
 )
 from gptme.message import Message
 from gptme.prompts import _loaded_agent_files_var
+from gptme.util.context_dedup import _content_hash
 
 
 @pytest.fixture
@@ -298,6 +300,89 @@ class TestOnCwdChanged:
             agent_msgs = [m for m in msgs if isinstance(m, Message)]
             assert len(agent_msgs) >= 1
             assert "source=" in agent_msgs[0].content
+        finally:
+            os.chdir(original)
+
+    def test_skips_injection_when_content_already_loaded(
+        self, tmp_path: Path, empty_log
+    ):
+        """Content-hash dedup: same content in different path must not be re-injected.
+
+        This is the worktree scenario described in gptme/gptme#2254: cwd changes from
+        ~/Programming/gptme/ to /tmp/worktrees/gptme-version-fix/ — both have the same
+        AGENTS.md but different absolute paths, so path-based dedup misses the duplicate.
+        """
+        # Simulate original repo directory
+        orig_dir = tmp_path / "original"
+        orig_dir.mkdir()
+        orig_file = orig_dir / "AGENTS.md"
+        shared_content = "# Shared Instructions\nDo great things."
+        orig_file.write_text(shared_content)
+
+        # Simulate worktree directory with IDENTICAL content at a different path
+        worktree_dir = tmp_path / "worktree"
+        worktree_dir.mkdir()
+        worktree_file = worktree_dir / "AGENTS.md"
+        worktree_file.write_text(shared_content)
+
+        # Simulate prompt_workspace() having loaded the original file at session start:
+        # it adds both the resolved path AND the content hash to the tracking set.
+        loaded = _get_loaded_files()
+        loaded.add(str(orig_file.resolve()))
+        loaded.add(f"{_HASH_PREFIX}{_content_hash(shared_content)}")
+
+        original = os.getcwd()
+        os.chdir(worktree_dir)
+        try:
+            msgs = list(
+                on_cwd_changed(
+                    log=empty_log,
+                    workspace=worktree_dir,
+                    old_cwd=str(orig_dir),
+                    new_cwd=str(worktree_dir),
+                    tool_use=None,
+                )
+            )
+            agent_msgs = [m for m in msgs if isinstance(m, Message)]
+            assert len(agent_msgs) == 0, (
+                "Identical content from a different path should not be re-injected"
+            )
+        finally:
+            os.chdir(original)
+
+    def test_different_content_in_different_path_is_injected(
+        self, tmp_path: Path, empty_log
+    ):
+        """Sanity check: different content at a new path must still be injected."""
+        orig_dir = tmp_path / "original"
+        orig_dir.mkdir()
+        orig_file = orig_dir / "AGENTS.md"
+        orig_file.write_text("# Original instructions.")
+
+        worktree_dir = tmp_path / "worktree"
+        worktree_dir.mkdir()
+        worktree_file = worktree_dir / "AGENTS.md"
+        worktree_file.write_text("# Different instructions — unique to worktree.")
+
+        # Mark the original as already loaded
+        loaded = _get_loaded_files()
+        loaded.add(str(orig_file.resolve()))
+
+        original = os.getcwd()
+        os.chdir(worktree_dir)
+        try:
+            msgs = list(
+                on_cwd_changed(
+                    log=empty_log,
+                    workspace=worktree_dir,
+                    old_cwd=str(orig_dir),
+                    new_cwd=str(worktree_dir),
+                    tool_use=None,
+                )
+            )
+            agent_msgs = [m for m in msgs if isinstance(m, Message)]
+            assert len(agent_msgs) >= 1, "Different content should be injected"
+            assert "unique to worktree" in agent_msgs[0].content
         finally:
             os.chdir(original)
 

--- a/gptme/prompts/workspace.py
+++ b/gptme/prompts/workspace.py
@@ -7,9 +7,12 @@ from typing import TYPE_CHECKING
 from ..config import config_path, get_config, get_project_config
 from ..message import Message
 from ..util.context import md_codeblock
+from ..util.context_dedup import _content_hash
 from ..util.tree import get_tree_output
 from . import AGENT_FILES, DEFAULT_CONTEXT_FILES, _loaded_agent_files_var
 from .context_cmd import get_project_context_cmd_output
+
+_HASH_PREFIX = "ch:"
 
 if TYPE_CHECKING:
     from ..util.uri import FilePath
@@ -219,6 +222,12 @@ def prompt_workspace(
                     agent_files.append(user_file)
                     seen_paths.add(resolved)
                     loaded_agent_files.add(resolved)
+                    try:
+                        loaded_agent_files.add(
+                            f"{_HASH_PREFIX}{_content_hash(user_file.read_text())}"
+                        )
+                    except OSError:
+                        pass
                     logger.debug(f"Loaded user-level agent file: {user_file}")
 
     # 2. Walk from home down to workspace, loading any AGENT_FILES found
@@ -233,6 +242,12 @@ def prompt_workspace(
             agent_files.append(agent_file)
             seen_paths.add(resolved)
             loaded_agent_files.add(resolved)
+            try:
+                loaded_agent_files.add(
+                    f"{_HASH_PREFIX}{_content_hash(agent_file.read_text())}"
+                )
+            except OSError:
+                pass
             logger.debug(f"Loaded agent file from tree: {agent_file}")
 
     # Determine which additional file patterns to use (from config or defaults)


### PR DESCRIPTION
## Summary

- **Root cause**: `_loaded_agent_files_var` tracked loaded agent files by *path*, so switching cwd to a git worktree with the same `AGENTS.md` content caused a duplicate injection.
- **Fix**: Also track a content hash (prefixed `ch:`) in the same set. Both `prompt_workspace()` and `on_cwd_changed()` check the hash before injecting; `_derive_loaded_files_from_log()` (server-mode fallback) also extracts hashes from complete `<agent-instructions>` blocks in the log.
- No change to the injected message format.

Fixes #2254.

## Test plan

- [ ] New test `test_skips_injection_when_content_already_loaded`: two directories, same `AGENTS.md` content — cwd change to the second does NOT re-inject.
- [ ] New test `test_different_content_in_different_path_is_injected`: sanity check that *different* content at a new path still gets injected.
- [ ] All 17 existing `test_agents_md_inject` tests continue to pass.