### PR TITLE
fix(cli): skip context_cmd when opening any existing conversation, not just --resume

### DIFF
--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -583,18 +583,14 @@ def main(
     logger.debug(f"Using tools: {config.chat.tools}")
     tools = init_tools(config.chat.tools)
 
-    # Check if we're resuming an existing conversation
+    # Check if we're opening an existing conversation (via --resume, --name, or pick)
     # If so, skip generating initial messages (including expensive context_cmd)
     # as they're already in the loaded log
     log_file = logdir / "conversation.jsonl"
-    is_existing_conversation = (
-        resume and log_file.exists() and log_file.stat().st_size > 0
-    )
+    is_existing_conversation = log_file.exists() and log_file.stat().st_size > 0
 
     if is_existing_conversation:
-        logger.debug(
-            "Resuming existing conversation, skipping initial prompt generation"
-        )
+        logger.debug("Existing conversation found, skipping initial prompt generation")
         initial_msgs = []
     else:
         # Infer context mode: --context-include implies selective mode


### PR DESCRIPTION
## Root cause

`is_existing_conversation` in `cli/main.py` had an extra `resume and` guard:

```python
is_existing_conversation = (
    resume and log_file.exists() and log_file.stat().st_size > 0
)
```

This correctly skips `context_cmd` when using `--resume`, but `gptme --name <existing-name>` also opens an existing conversation without setting `resume=True`. In that case the check returned `False`, so `get_prompt` ran again and re-executed `context_cmd` — which can fail (e.g. missing `uv` in PATH on macOS) or inject stale context on top of an already-full log.

## Fix

Remove the `resume` prerequisite. The only thing that matters is whether `conversation.jsonl` already has content:

```python
is_existing_conversation = log_file.exists() and log_file.stat().st_size > 0
```

New conversations (random or named) won't have a file yet, so `get_prompt` still runs for them. Existing conversations — opened via `--resume`, `--name`, or the interactive picker — now all skip the redundant prompt regeneration.

## Testing

`tests/test_prompts.py` and `tests/test_cli.py` — 37 passed, 0 failures.

Fixes #2252.