### PR TITLE
fix(tauri): reuse existing gptme-server on startup instead of blocking error dialog

### DIFF
--- a/tauri/src-tauri/Cargo.lock
+++ b/tauri/src-tauri/Cargo.lock
@@ -1505,6 +1505,7 @@ dependencies = [
  "tauri-plugin-opener",
  "tauri-plugin-shell",
  "tauri-plugin-single-instance",
+ "tokio",
  "url",
 ]
 
@@ -4402,7 +4403,19 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/tauri/src-tauri/Cargo.toml
+++ b/tauri/src-tauri/Cargo.toml
@@ -27,6 +27,7 @@ tauri-plugin-deep-link = "2"
 url = "2"
 log = "0.4"
 tauri-plugin-log = "2"
+tokio = { version = "1", features = ["net", "time"] }
 
 [target.'cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))'.dependencies]
 tauri-plugin-shell = "2"
@@ -34,3 +35,4 @@ tauri-plugin-single-instance = { version = "2", features = ["deep-link"] }
 
 [dev-dependencies]
 tauri = { version = "2", features = ["test"] }
+tokio = { version = "1", features = ["rt", "macros"] }

--- a/tauri/src-tauri/src/lib.rs
+++ b/tauri/src-tauri/src/lib.rs
@@ -26,13 +26,15 @@ fn is_port_available(port: u16) -> bool {
 }
 
 #[cfg(desktop)]
-fn is_server_responsive(port: u16) -> bool {
-    use std::net::TcpStream;
+async fn is_server_responsive(port: u16) -> bool {
     use std::time::Duration;
-    let addr: std::net::SocketAddr = format!("127.0.0.1:{}", port)
-        .parse()
-        .expect("valid socket addr");
-    TcpStream::connect_timeout(&addr, Duration::from_millis(500)).is_ok()
+    use tokio::net::TcpStream;
+    use tokio::time::timeout;
+    let addr = format!("127.0.0.1:{}", port);
+    timeout(Duration::from_millis(500), TcpStream::connect(&addr))
+        .await
+        .map(|r| r.is_ok())
+        .unwrap_or(false)
 }
 
 #[cfg(desktop)]
@@ -49,15 +51,19 @@ struct ServerStatus {
 
 #[cfg(desktop)]
 #[tauri::command]
-fn get_server_status(state: tauri::State<'_, ServerProcess>) -> ServerStatus {
+async fn get_server_status(state: tauri::State<'_, ServerProcess>) -> ServerStatus {
     let running = state.0.lock().map(|guard| guard.is_some()).unwrap_or(false);
     let port_available = is_port_available(GPTME_SERVER_PORT);
+    // Only probe TCP when the port is occupied but we're not managing it —
+    // avoids false-positive existing_server_detected during TIME_WAIT after stop_server.
+    let existing_server_detected =
+        !running && !port_available && is_server_responsive(GPTME_SERVER_PORT).await;
     ServerStatus {
         running,
         port: GPTME_SERVER_PORT,
         port_available,
         manages_local_server: true,
-        existing_server_detected: !running && !port_available,
+        existing_server_detected,
     }
 }
 
@@ -106,7 +112,7 @@ async fn start_server(
         }
     }
 
-    spawn_server_sidecar(&app, state.0.clone())?;
+    spawn_server_sidecar(&app, state.0.clone()).await?;
     Ok(GPTME_SERVER_PORT)
 }
 
@@ -133,7 +139,7 @@ fn desktop_cors_origin() -> &'static str {
 }
 
 #[cfg(desktop)]
-fn spawn_server_sidecar(
+async fn spawn_server_sidecar(
     app: &tauri::AppHandle,
     state_arc: Arc<Mutex<Option<CommandChild>>>,
 ) -> Result<(), String> {
@@ -142,7 +148,7 @@ fn spawn_server_sidecar(
         // This is the common crash-recovery case: the gptme-server sidecar
         // outlived the Tauri process and is still listening on the port.
         // Reuse it silently rather than showing a blocking error dialog.
-        if is_server_responsive(GPTME_SERVER_PORT) {
+        if is_server_responsive(GPTME_SERVER_PORT).await {
             log::info!(
                 "Port {} is occupied and a server is already responding — \
                  reusing existing gptme-server (likely a leftover from a previous session)",
@@ -353,7 +359,7 @@ pub fn run() {
 
                 let app_handle = app.handle().clone();
                 tauri::async_runtime::spawn(async move {
-                    if let Err(err) = spawn_server_sidecar(&app_handle, child_handle) {
+                    if let Err(err) = spawn_server_sidecar(&app_handle, child_handle).await {
                         log::error!("Failed to start gptme-server: {}", err);
                         if err.contains("already in use") {
                             show_port_conflict_dialog(&app_handle);
@@ -439,14 +445,14 @@ mod tests {
         assert!(is_port_available(port));
     }
 
-    #[test]
+    #[tokio::test]
     #[cfg(desktop)]
-    fn test_is_server_responsive_on_listening_port() {
+    async fn test_is_server_responsive_on_listening_port() {
         let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
         let port = listener.local_addr().unwrap().port();
-        assert!(is_server_responsive(port));
+        assert!(is_server_responsive(port).await);
         drop(listener);
-        assert!(!is_server_responsive(port));
+        assert!(!is_server_responsive(port).await);
     }
 
     #[test]

--- a/tauri/src-tauri/src/lib.rs
+++ b/tauri/src-tauri/src/lib.rs
@@ -26,6 +26,16 @@ fn is_port_available(port: u16) -> bool {
 }
 
 #[cfg(desktop)]
+fn is_server_responsive(port: u16) -> bool {
+    use std::net::TcpStream;
+    use std::time::Duration;
+    let addr: std::net::SocketAddr = format!("127.0.0.1:{}", port)
+        .parse()
+        .expect("valid socket addr");
+    TcpStream::connect_timeout(&addr, Duration::from_millis(500)).is_ok()
+}
+
+#[cfg(desktop)]
 struct ServerProcess(Arc<Mutex<Option<CommandChild>>>);
 
 #[derive(serde::Serialize)]
@@ -34,17 +44,20 @@ struct ServerStatus {
     port: u16,
     port_available: bool,
     manages_local_server: bool,
+    existing_server_detected: bool,
 }
 
 #[cfg(desktop)]
 #[tauri::command]
 fn get_server_status(state: tauri::State<'_, ServerProcess>) -> ServerStatus {
     let running = state.0.lock().map(|guard| guard.is_some()).unwrap_or(false);
+    let port_available = is_port_available(GPTME_SERVER_PORT);
     ServerStatus {
         running,
         port: GPTME_SERVER_PORT,
-        port_available: is_port_available(GPTME_SERVER_PORT),
+        port_available,
         manages_local_server: true,
+        existing_server_detected: !running && !port_available,
     }
 }
 
@@ -56,6 +69,7 @@ fn get_server_status() -> ServerStatus {
         port: GPTME_SERVER_PORT,
         port_available: false,
         manages_local_server: false,
+        existing_server_detected: false,
     }
 }
 
@@ -124,6 +138,18 @@ fn spawn_server_sidecar(
     state_arc: Arc<Mutex<Option<CommandChild>>>,
 ) -> Result<(), String> {
     if !is_port_available(GPTME_SERVER_PORT) {
+        // Port is occupied — check if a server is already responding there.
+        // This is the common crash-recovery case: the gptme-server sidecar
+        // outlived the Tauri process and is still listening on the port.
+        // Reuse it silently rather than showing a blocking error dialog.
+        if is_server_responsive(GPTME_SERVER_PORT) {
+            log::info!(
+                "Port {} is occupied and a server is already responding — \
+                 reusing existing gptme-server (likely a leftover from a previous session)",
+                GPTME_SERVER_PORT
+            );
+            return Ok(());
+        }
         return Err(format!("Port {} is already in use", GPTME_SERVER_PORT));
     }
 
@@ -414,6 +440,16 @@ mod tests {
     }
 
     #[test]
+    #[cfg(desktop)]
+    fn test_is_server_responsive_on_listening_port() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        assert!(is_server_responsive(port));
+        drop(listener);
+        assert!(!is_server_responsive(port));
+    }
+
+    #[test]
     fn test_extract_auth_code_valid() {
         let url = url::Url::parse("gptme://pairing-complete?code=abc123def").unwrap();
         assert_eq!(extract_auth_code(&url), Some("abc123def".to_string()));
@@ -458,12 +494,14 @@ mod tests {
             port: 5700,
             port_available: true,
             manages_local_server: true,
+            existing_server_detected: false,
         };
         let json = serde_json::to_string(&status).unwrap();
         assert!(json.contains("\"running\":false"));
         assert!(json.contains("\"port\":5700"));
         assert!(json.contains("\"port_available\":true"));
         assert!(json.contains("\"manages_local_server\":true"));
+        assert!(json.contains("\"existing_server_detected\":false"));
     }
 
     #[test]

--- a/tauri/src-tauri/src/lib.rs
+++ b/tauri/src-tauri/src/lib.rs
@@ -51,20 +51,20 @@ struct ServerStatus {
 
 #[cfg(desktop)]
 #[tauri::command]
-async fn get_server_status(state: tauri::State<'_, ServerProcess>) -> ServerStatus {
+async fn get_server_status(state: tauri::State<'_, ServerProcess>) -> Result<ServerStatus, String> {
     let running = state.0.lock().map(|guard| guard.is_some()).unwrap_or(false);
     let port_available = is_port_available(GPTME_SERVER_PORT);
     // Only probe TCP when the port is occupied but we're not managing it —
     // avoids false-positive existing_server_detected during TIME_WAIT after stop_server.
     let existing_server_detected =
         !running && !port_available && is_server_responsive(GPTME_SERVER_PORT).await;
-    ServerStatus {
+    Ok(ServerStatus {
         running,
         port: GPTME_SERVER_PORT,
         port_available,
         manages_local_server: true,
         existing_server_detected,
-    }
+    })
 }
 
 #[cfg(not(desktop))]

--- a/webui/src/hooks/useTauriServerStatus.ts
+++ b/webui/src/hooks/useTauriServerStatus.ts
@@ -7,6 +7,7 @@ interface TauriServerStatus {
   port: number;
   port_available: boolean;
   manages_local_server: boolean;
+  existing_server_detected: boolean;
 }
 
 let cachedServerStatus: TauriServerStatus | null = null;
@@ -67,6 +68,7 @@ export function useTauriServerStatus() {
           port: 5700,
           port_available: false,
           manages_local_server: false,
+          existing_server_detected: false,
         });
       })
       .finally(() => {


### PR DESCRIPTION
## Summary

Fixes #2253 — the "port already in use" blocking dialog that appears when gptme-tauri is restarted after a crash or force-quit.

**Root cause**: When the app crashes, the `gptme-server` sidecar keeps running on port 5700. On next startup, `is_port_available()` returns false and the app showed a blocking error dialog with no recovery path.

**Fix**: Before showing the error dialog, do a TCP connectivity check (`TcpStream::connect_timeout`, 500ms). If something is already listening on port 5700, it's almost certainly a leftover sidecar from the previous session — silently reuse it instead of erroring. Only show the dialog for a genuine port conflict (port bound by something unresponsive).

- `is_server_responsive(port)` — new helper using `TcpStream::connect_timeout`
- `spawn_server_sidecar` — reuse path returns `Ok(())` with an info log
- `ServerStatus.existing_server_detected` — new field (`!running && !port_available`) so the frontend can show "connected to existing server" vs "no server" vs "we started it"
- TypeScript interface updated to match
- Tests: `test_is_server_responsive_on_listening_port` added

## Test plan

- [ ] Build gptme-tauri and verify normal startup works
- [ ] Kill the app via `pkill gptme-tauri` (leaving sidecar running) and relaunch — should start without dialog
- [ ] Verify the error dialog still appears when port 5700 is occupied by a non-responsive process (e.g. `nc -l 5700`)
- [ ] `cargo test` passes on a machine with GTK dev libs