### PR TITLE
fix(cli): skip context_cmd when resuming via --name <existing>

### DIFF
--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -585,11 +585,14 @@ def main(
 
     # Check if we're resuming an existing conversation
     # If so, skip generating initial messages (including expensive context_cmd)
-    # as they're already in the loaded log
+    # as they're already in the loaded log.
+    # The check is independent of `--resume` because users can also resume via
+    # `--name <existing>`. Either way, if the log already has content, we
+    # should not re-run context_cmd (whose result LogManager.load would
+    # discard anyway, but whose side effect — running a shell command — is
+    # what we want to avoid).
     log_file = logdir / "conversation.jsonl"
-    is_existing_conversation = (
-        resume and log_file.exists() and log_file.stat().st_size > 0
-    )
+    is_existing_conversation = log_file.exists() and log_file.stat().st_size > 0
 
     if is_existing_conversation:
         logger.debug(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -492,6 +492,39 @@ def test_comma_separated_choice_minus_prefix():
         csc.convert("-nonexistent", None, None)
 
 
+def test_resume_skips_context_cmd(name: str, runner: CliRunner, tmp_path):
+    """Resuming an existing conversation must NOT re-run context_cmd.
+
+    Regression: gptme/gptme#2252 — context_cmd ran on `--name <existing>`
+    even though the conversation log already had content. The side effect
+    (running a shell command) was happening despite LogManager.load
+    discarding the resulting initial_msgs.
+    """
+    from gptme.cli.main import get_logdir
+
+    # Workspace with a context_cmd that writes a marker file when executed.
+    workspace = tmp_path / "project"
+    workspace.mkdir()
+    marker = tmp_path / "context_cmd_was_run"
+    (workspace / "gptme.toml").write_text(f'[prompt]\ncontext_cmd = "touch {marker}"\n')
+
+    # Pre-create a conversation log with one system message so the resume
+    # guard treats this as an existing conversation.
+    logdir = get_logdir(name)
+    (logdir / "conversation.jsonl").write_text(
+        '{"role": "system", "content": "previous session", "timestamp": "2026-04-27T00:00:00"}\n'
+    )
+
+    args = ["--name", name, "--workspace", str(workspace), "/exit"]
+    result = runner.invoke(cli.main, args)
+
+    assert result.exit_code == 0
+    assert not marker.exists(), (
+        "context_cmd ran on resume — it should be skipped when the conversation "
+        "log already has content"
+    )
+
+
 def test_tool_exclusion_mixed_bare_and_minus_raises():
     """Test that mixing bare tool names with '-' exclusion syntax raises UsageError."""
     from click.testing import CliRunner


### PR DESCRIPTION
## Summary

Fixes ErikBjare/bob#... — actually, fixes gptme/gptme#2252.

The `is_existing_conversation` guard at `gptme/cli/main.py` previously required `--resume` to be set:

```python
is_existing_conversation = (
    resume and log_file.exists() and log_file.stat().st_size > 0
)
```

But users can also resume by passing `--name <existing>` directly. In that path, `get_prompt()` ran every time, which executes `context_cmd` as a side effect — even though `LogManager.load` would discard the resulting `initial_msgs` (`log.messages or initial_msgs or []`).

The user-visible bug is that `context_cmd` (which can be a slow shell command, fail with missing PATH entries, or add stale context) runs on every resume, even when there's nothing to do with the result.

## Fix

Drop the `resume and` requirement. If the log file already has content, skip initial-prompt generation regardless of how the user got there.

```python
is_existing_conversation = log_file.exists() and log_file.stat().st_size > 0
```

Behavior matrix:

| Invocation | Log state | Before | After |
|---|---|---|---|
| `gptme --resume` | has content | skip ✓ | skip ✓ |
| `gptme --resume` | empty/missing | run | run (no change) |
| `gptme --name existing` | has content | **run (bug)** | **skip (fixed)** |
| `gptme --name new` | missing | run ✓ | run ✓ |

## Test plan

- [x] New test `test_resume_skips_context_cmd` in `tests/test_cli.py` — pre-creates a log with content, runs `gptme --name <existing>`, asserts a marker file from `context_cmd = "touch <marker>"` was NOT created.
- [x] Verified the test fails on un-fixed code (assertion fires because marker was created).
- [x] Verified the test passes with the fix.
- [x] Full `tests/test_cli.py` suite: 23 passed, 8 skipped.