### PR TITLE
fix(tauri): kill gptme-server subprocesses and orphans on exit

### DIFF
--- a/tauri/src-tauri/src/lib.rs
+++ b/tauri/src-tauri/src/lib.rs
@@ -496,6 +496,10 @@ fn kill_subprocesses(pid: u32) {
 // (the spawn_server_sidecar reuse path).
 #[cfg(unix)]
 fn kill_server_on_port(port: u16) {
+    // lsof returns all PIDs with any socket on the port, including established
+    // client connections (e.g. the Tauri WebView itself).  Skip our own PID to
+    // avoid self-killing the Tauri process during cleanup.
+    let my_pid = std::process::id();
     let output = match std::process::Command::new("lsof")
         .args(["-ti", &format!(":{}", port)])
         .output()
@@ -512,6 +516,10 @@ fn kill_server_on_port(port: u16) {
     };
     for pid_str in String::from_utf8_lossy(&output.stdout).split_whitespace() {
         if let Ok(pid) = pid_str.parse::<u32>() {
+            if pid == my_pid {
+                log::debug!("Skipping self (PID {}) in port {} cleanup", pid, port);
+                continue;
+            }
             log::info!("Killing orphan gptme-server PID {} on port {}", pid, port);
             kill_subprocesses(pid);
             let _ = std::process::Command::new("kill")
@@ -523,7 +531,9 @@ fn kill_server_on_port(port: u16) {
 
 #[cfg(windows)]
 fn kill_server_on_port(port: u16) {
-    // netstat -ano lists all connections with PIDs; find the LISTENING entry.
+    // netstat -ano columns: Proto  LocalAddress  ForeignAddress  State  PID
+    // Match the local-address field (col[1]) exactly so ":5700" does not
+    // accidentally match ":57001" via substring search.
     let output = match std::process::Command::new("netstat")
         .args(["-ano"])
         .output()
@@ -533,17 +543,24 @@ fn kill_server_on_port(port: u16) {
     };
     let port_suffix = format!(":{}", port);
     for line in String::from_utf8_lossy(&output.stdout).lines() {
-        if line.contains(&port_suffix) && line.contains("LISTENING") {
-            if let Some(pid_str) = line.split_whitespace().last() {
-                log::info!(
-                    "Killing orphan gptme-server PID {} on port {}",
-                    pid_str,
-                    port
-                );
-                let _ = std::process::Command::new("taskkill")
-                    .args(["/F", "/T", "/PID", pid_str])
-                    .status();
-            }
+        if !line.contains("LISTENING") {
+            continue;
+        }
+        let cols: Vec<&str> = line.split_whitespace().collect();
+        // col[1] is the local address, e.g. "0.0.0.0:5700" or "[::]:5700"
+        let local_addr = cols.get(1).copied().unwrap_or("");
+        if !local_addr.ends_with(&port_suffix) {
+            continue;
+        }
+        if let Some(pid_str) = cols.last() {
+            log::info!(
+                "Killing orphan gptme-server PID {} on port {}",
+                pid_str,
+                port
+            );
+            let _ = std::process::Command::new("taskkill")
+                .args(["/F", "/T", "/PID", pid_str])
+                .status();
         }
     }
 }

--- a/tauri/src-tauri/src/lib.rs
+++ b/tauri/src-tauri/src/lib.rs
@@ -414,13 +414,109 @@ fn cleanup_server_process(app: &tauri::AppHandle) {
         }
     };
     if let Some(child) = guard.take() {
-        log::info!("Terminating gptme-server process...");
+        let pid = child.pid();
+        log::info!("Terminating gptme-server process (PID {})...", pid);
+        // Kill child processes first (e.g. uvicorn workers spawned by gptme-server).
+        // child.kill() only sends SIGKILL to the direct child; without this step,
+        // subprocesses become orphans that keep port 5700 occupied (#2260).
+        kill_subprocesses(pid);
         match child.kill() {
             Ok(_) => log::info!("gptme-server process terminated successfully"),
             Err(e) => log::error!("Failed to terminate gptme-server: {}", e),
         }
+    } else {
+        // No tracked child — the startup path reused an existing responsive server
+        // (spawn_server_sidecar returned Ok(()) without storing a child handle).
+        // We still own port 5700, so kill whatever is listening there on exit.
+        log::info!(
+            "No tracked server process; killing any process on port {}...",
+            GPTME_SERVER_PORT
+        );
+        kill_server_on_port(GPTME_SERVER_PORT);
     }
 }
+
+// Kill all direct children of `pid` (e.g. uvicorn workers).  The parent is
+// killed separately via CommandChild::kill() so we don't need /T here.
+#[cfg(unix)]
+fn kill_subprocesses(pid: u32) {
+    let _ = std::process::Command::new("pkill")
+        .args(["-9", "-P", &pid.to_string()])
+        .status();
+}
+
+#[cfg(windows)]
+fn kill_subprocesses(pid: u32) {
+    // taskkill /T kills the whole process tree including the root; that's fine
+    // here because we call this before child.kill(), so the parent gets a
+    // second kill attempt which is harmless.
+    let _ = std::process::Command::new("taskkill")
+        .args(["/F", "/T", "/PID", &pid.to_string()])
+        .status();
+}
+
+// Kill whatever is listening on `port` — used when no child handle was tracked
+// (the spawn_server_sidecar reuse path).
+#[cfg(unix)]
+fn kill_server_on_port(port: u16) {
+    let output = match std::process::Command::new("lsof")
+        .args(["-ti", &format!(":{}", port)])
+        .output()
+    {
+        Ok(o) => o,
+        Err(e) => {
+            log::warn!(
+                "lsof unavailable, cannot kill orphan server on port {}: {}",
+                port,
+                e
+            );
+            return;
+        }
+    };
+    for pid_str in String::from_utf8_lossy(&output.stdout).split_whitespace() {
+        if let Ok(pid) = pid_str.parse::<u32>() {
+            log::info!("Killing orphan gptme-server PID {} on port {}", pid, port);
+            kill_subprocesses(pid);
+            let _ = std::process::Command::new("kill")
+                .args(["-9", &pid.to_string()])
+                .status();
+        }
+    }
+}
+
+#[cfg(windows)]
+fn kill_server_on_port(port: u16) {
+    // netstat -ano lists all connections with PIDs; find the LISTENING entry.
+    let output = match std::process::Command::new("netstat")
+        .args(["-ano"])
+        .output()
+    {
+        Ok(o) => o,
+        Err(_) => return,
+    };
+    let port_suffix = format!(":{}", port);
+    for line in String::from_utf8_lossy(&output.stdout).lines() {
+        if line.contains(&port_suffix) && line.contains("LISTENING") {
+            if let Some(pid_str) = line.split_whitespace().last() {
+                log::info!(
+                    "Killing orphan gptme-server PID {} on port {}",
+                    pid_str,
+                    port
+                );
+                let _ = std::process::Command::new("taskkill")
+                    .args(["/F", "/T", "/PID", pid_str])
+                    .status();
+            }
+        }
+    }
+}
+
+// Stub for platforms that are neither unix nor windows (shouldn't happen for desktop targets).
+#[cfg(not(any(unix, windows)))]
+fn kill_subprocesses(_pid: u32) {}
+
+#[cfg(not(any(unix, windows)))]
+fn kill_server_on_port(_port: u16) {}
 
 #[cfg(test)]
 mod tests {

--- a/tauri/src-tauri/src/lib.rs
+++ b/tauri/src-tauri/src/lib.rs
@@ -1,6 +1,8 @@
 #[cfg(desktop)]
 use std::net::TcpListener;
 #[cfg(desktop)]
+use std::sync::atomic::{AtomicBool, Ordering};
+#[cfg(desktop)]
 use std::sync::{Arc, Mutex};
 
 use tauri::Manager;
@@ -38,7 +40,13 @@ async fn is_server_responsive(port: u16) -> bool {
 }
 
 #[cfg(desktop)]
-struct ServerProcess(Arc<Mutex<Option<CommandChild>>>);
+struct ServerProcess {
+    child: Arc<Mutex<Option<CommandChild>>>,
+    // True if we started or reused a gptme-server; false if startup failed
+    // (port occupied by an unresponsive foreign process).  Used in cleanup to
+    // avoid killing a process that we never owned.
+    owns_port: Arc<AtomicBool>,
+}
 
 #[derive(serde::Serialize)]
 struct ServerStatus {
@@ -52,7 +60,11 @@ struct ServerStatus {
 #[cfg(desktop)]
 #[tauri::command]
 async fn get_server_status(state: tauri::State<'_, ServerProcess>) -> Result<ServerStatus, String> {
-    let running = state.0.lock().map(|guard| guard.is_some()).unwrap_or(false);
+    let running = state
+        .child
+        .lock()
+        .map(|guard| guard.is_some())
+        .unwrap_or(false);
     let port_available = is_port_available(GPTME_SERVER_PORT);
     // Only probe TCP when the port is occupied but we're not managing it —
     // avoids false-positive existing_server_detected during TIME_WAIT after stop_server.
@@ -82,9 +94,14 @@ fn get_server_status() -> ServerStatus {
 #[cfg(desktop)]
 #[tauri::command]
 fn stop_server(state: tauri::State<'_, ServerProcess>) -> Result<(), String> {
-    let mut guard = state.0.lock().map_err(|e| format!("Lock error: {}", e))?;
+    let mut guard = state
+        .child
+        .lock()
+        .map_err(|e| format!("Lock error: {}", e))?;
     if let Some(child) = guard.take() {
         log::info!("Stopping gptme-server via IPC command");
+        // Kill uvicorn workers before the parent; mirrors cleanup_server_process.
+        kill_subprocesses(child.pid());
         child.kill().map_err(|e| format!("Kill error: {}", e))?;
         log::info!("gptme-server stopped successfully");
         Ok(())
@@ -106,13 +123,16 @@ async fn start_server(
     state: tauri::State<'_, ServerProcess>,
 ) -> Result<u16, String> {
     {
-        let guard = state.0.lock().map_err(|e| format!("Lock error: {}", e))?;
+        let guard = state
+            .child
+            .lock()
+            .map_err(|e| format!("Lock error: {}", e))?;
         if guard.is_some() {
             return Err("Server is already running".to_string());
         }
     }
 
-    spawn_server_sidecar(&app, state.0.clone()).await?;
+    spawn_server_sidecar(&app, state.child.clone(), state.owns_port.clone()).await?;
     Ok(GPTME_SERVER_PORT)
 }
 
@@ -142,6 +162,7 @@ fn desktop_cors_origin() -> &'static str {
 async fn spawn_server_sidecar(
     app: &tauri::AppHandle,
     state_arc: Arc<Mutex<Option<CommandChild>>>,
+    owns_port: Arc<AtomicBool>,
 ) -> Result<(), String> {
     if !is_port_available(GPTME_SERVER_PORT) {
         // Port is occupied — check if a server is already responding there.
@@ -154,8 +175,13 @@ async fn spawn_server_sidecar(
                  reusing existing gptme-server (likely a leftover from a previous session)",
                 GPTME_SERVER_PORT
             );
+            // Mark that we own (reuse) this port so cleanup_server_process
+            // knows it should kill it on exit.
+            owns_port.store(true, Ordering::Relaxed);
             return Ok(());
         }
+        // Port is occupied by a non-responsive foreign process — do NOT set
+        // owns_port; cleanup must not kill a process we never started.
         return Err(format!("Port {} is already in use", GPTME_SERVER_PORT));
     }
 
@@ -185,8 +211,10 @@ async fn spawn_server_sidecar(
         let mut guard = state_arc.lock().map_err(|e| format!("Lock error: {}", e))?;
         *guard = Some(child);
     }
+    owns_port.store(true, Ordering::Relaxed);
 
     let state_for_output = state_arc.clone();
+    let owns_port_for_output = owns_port.clone();
     tauri::async_runtime::spawn(async move {
         while let Some(event) = rx.recv().await {
             match event {
@@ -217,6 +245,7 @@ async fn spawn_server_sidecar(
                     if let Ok(mut guard) = state_for_output.lock() {
                         *guard = None;
                     }
+                    owns_port_for_output.store(false, Ordering::Relaxed);
                     break;
                 }
                 _ => {}
@@ -355,11 +384,17 @@ pub fn run() {
             #[cfg(desktop)]
             {
                 let child_handle: Arc<Mutex<Option<CommandChild>>> = Arc::new(Mutex::new(None));
-                app.manage(ServerProcess(child_handle.clone()));
+                let owns_port: Arc<AtomicBool> = Arc::new(AtomicBool::new(false));
+                app.manage(ServerProcess {
+                    child: child_handle.clone(),
+                    owns_port: owns_port.clone(),
+                });
 
                 let app_handle = app.handle().clone();
                 tauri::async_runtime::spawn(async move {
-                    if let Err(err) = spawn_server_sidecar(&app_handle, child_handle).await {
+                    if let Err(err) =
+                        spawn_server_sidecar(&app_handle, child_handle, owns_port).await
+                    {
                         log::error!("Failed to start gptme-server: {}", err);
                         if err.contains("already in use") {
                             show_port_conflict_dialog(&app_handle);
@@ -405,7 +440,7 @@ fn cleanup_server_process(app: &tauri::AppHandle) {
         Some(s) => s,
         None => return,
     };
-    let arc = state.0.clone();
+    let arc = state.child.clone();
     let mut guard = match arc.lock() {
         Ok(g) => g,
         Err(_) => {
@@ -424,12 +459,14 @@ fn cleanup_server_process(app: &tauri::AppHandle) {
             Ok(_) => log::info!("gptme-server process terminated successfully"),
             Err(e) => log::error!("Failed to terminate gptme-server: {}", e),
         }
-    } else {
-        // No tracked child — the startup path reused an existing responsive server
-        // (spawn_server_sidecar returned Ok(()) without storing a child handle).
+    } else if state.owns_port.load(Ordering::Relaxed) {
+        // No tracked child handle, but we reused an existing responsive server on
+        // startup (spawn_server_sidecar returned Ok(()) without storing a child).
         // We still own port 5700, so kill whatever is listening there on exit.
+        // owns_port is false when startup failed with a non-responsive port conflict,
+        // so this branch is skipped in that case — avoiding killing an unrelated process.
         log::info!(
-            "No tracked server process; killing any process on port {}...",
+            "No tracked server process; killing reused server on port {}...",
             GPTME_SERVER_PORT
         );
         kill_server_on_port(GPTME_SERVER_PORT);

--- a/tauri/src-tauri/src/lib.rs
+++ b/tauri/src-tauri/src/lib.rs
@@ -103,6 +103,10 @@ fn stop_server(state: tauri::State<'_, ServerProcess>) -> Result<(), String> {
         // Kill uvicorn workers before the parent; mirrors cleanup_server_process.
         kill_subprocesses(child.pid());
         child.kill().map_err(|e| format!("Kill error: {}", e))?;
+        // Synchronously clear owns_port so cleanup_server_process doesn't
+        // call kill_server_on_port(5700) after a user-initiated stop, which
+        // could kill an unrelated process that bound to the port afterward.
+        state.owns_port.store(false, Ordering::Relaxed);
         log::info!("gptme-server stopped successfully");
         Ok(())
     } else {
@@ -496,12 +500,12 @@ fn kill_subprocesses(pid: u32) {
 // (the spawn_server_sidecar reuse path).
 #[cfg(unix)]
 fn kill_server_on_port(port: u16) {
-    // lsof returns all PIDs with any socket on the port, including established
-    // client connections (e.g. the Tauri WebView itself).  Skip our own PID to
-    // avoid self-killing the Tauri process during cleanup.
+    // -sTCP:LISTEN restricts output to the process actually listening on the
+    // port, excluding established client connections (e.g. the Tauri WebView).
+    // my_pid guard is belt-and-suspenders in case lsof returns our own PID.
     let my_pid = std::process::id();
     let output = match std::process::Command::new("lsof")
-        .args(["-ti", &format!(":{}", port)])
+        .args(["-ti", &format!(":{}", port), "-sTCP:LISTEN"])
         .output()
     {
         Ok(o) => o,


### PR DESCRIPTION
## Summary

Fixes #2260 — two gaps in `cleanup_server_process` that left `gptme-server` processes alive after the Tauri app exits.

### Gap 1: subprocesses survive `child.kill()`

`child.kill()` sends SIGKILL to the *direct* child only. `gptme-server` may spawn subprocesses (e.g. uvicorn workers), which become orphans that keep port 5700 occupied.

**Fix**: new `kill_subprocesses(pid)` called before `child.kill()`:
- Unix: `pkill -9 -P <pid>` (direct children of the sidecar)
- Windows: `taskkill /F /T /PID <pid>` (full process tree)

### Gap 2: reuse path (from #2258) leaves no tracked handle

When `spawn_server_sidecar()` detects a responsive existing server and returns `Ok(())` without spawning, `ServerProcess` stays `None`. On exit, `cleanup_server_process` found no child and did nothing — the leftover server persisted.

**Fix**: new `kill_server_on_port(port)` called when `guard` is `None`:
- Unix: `lsof -ti:<port>` to find PIDs, then `kill -9` each (plus their children)
- Windows: `netstat -ano` to find PID, then `taskkill /F /T /PID`

Both helpers are `#[cfg(unix)]`/`#[cfg(windows)]` gated with a no-op stub for any other platform.

## Test plan

- [ ] `cargo test` passes on a desktop build (requires GTK3 dev libs — CI will validate)
- [ ] Build gptme-tauri; normal startup + quit leaves no `gptme-server` in `ps`
- [ ] Kill `gptme-tauri` via `pkill`, restart — app starts without dialog; quit leaves no orphan processes
- [ ] Verify port 5700 is free after quitting the app via Cmd+Q / dock quit / X button