### PR TITLE
fix(tauri): prevent_exit in ExitRequested to guarantee server cleanup on macOS

### DIFF
--- a/tauri/src-tauri/src/lib.rs
+++ b/tauri/src-tauri/src/lib.rs
@@ -437,19 +437,30 @@ pub fn run() {
         })
         .build(tauri::generate_context!())
         .expect("error while building tauri application")
-        .run(|_app_handle, _event| {
+        .run(|app_handle, event| {
             // ExitRequested fires on app-level exit paths that don't emit a
             // per-window CloseRequested first (macOS Cmd+Q, dock-quit, system
             // shutdown). Without this, the sidecar gptme-server outlives the
             // app and squats on port 5700 (gptme/gptme#2237).
             //
+            // We call api.prevent_exit() so macOS cannot kill the process
+            // before our pkill/kill commands finish — the race that caused #2260
+            // to persist even after #2261.  After cleanup we call exit(0) to
+            // trigger a clean exit; that fires RunEvent::Exit (not another
+            // ExitRequested), so there is no infinite loop.
+            //
             // cleanup_server_process is idempotent — if CloseRequested already
-            // killed and cleared the child, this is a no-op.
+            // killed and cleared the child, the owns_port flag is false and
+            // this becomes a pure no-op before exit(0) is called.
             #[cfg(desktop)]
-            if let tauri::RunEvent::ExitRequested { .. } = _event {
+            if let tauri::RunEvent::ExitRequested { api, .. } = event {
                 log::info!("App exit requested, cleaning up gptme-server...");
-                cleanup_server_process(_app_handle);
+                api.prevent_exit();
+                cleanup_server_process(app_handle);
+                app_handle.exit(0);
             }
+            #[cfg(not(desktop))]
+            let _ = (app_handle, event);
         });
 }
 
@@ -483,8 +494,8 @@ fn cleanup_server_process(app: &tauri::AppHandle) {
         // become orphans that keep port 5700 occupied (#2260).
         kill_subprocesses(pid);
         match child.kill() {
-            Ok(_) => log::info!("gptme-server process terminated successfully"),
-            Err(e) => log::error!("Failed to terminate gptme-server: {}", e),
+            Ok(_) => log::info!("gptme-server process (PID {}) terminated", pid),
+            Err(e) => log::error!("Failed to terminate gptme-server (PID {}): {}", pid, e),
         }
     }
 


### PR DESCRIPTION
## Problem

`gptme-server` orphan processes persist after app exit even after #2261 and #2262. Those PRs fixed the _which processes to kill_ problem. This PR fixes the _race condition_ problem: on macOS (Cmd+Q, dock-quit), the process-termination machinery can kill the Tauri process **before** our `pkill` and `child.kill()` syscalls finish.

## Root Cause

The `ExitRequested` handler runs `cleanup_server_process` synchronously, but without `api.prevent_exit()`, macOS is free to terminate the Tauri process before our kill commands are dispatched to the kernel.

## Fix

Call `api.prevent_exit()` to block the default exit, complete cleanup, then call `app_handle.exit(0)` for a clean exit. `AppHandle::exit(0)` fires `RunEvent::Exit` (not another `ExitRequested`), so there is no infinite loop.

`cleanup_server_process` is already idempotent (via the `owns_port_at_entry` snapshot from #2262): if `CloseRequested` already ran cleanup, `owns_port` is `false` and the function exits immediately before `exit(0)` is called.

Fixes #2260.

Follows up on #2261 and #2262.