### PR TITLE
feat(webui): add real-time voice session support

### DIFF
--- a/webui/package.json
+++ b/webui/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
-    "@icons-pack/react-simple-icons": "^13.7.0",
+    "@icons-pack/react-simple-icons": "13.7.0",
     "@legendapp/state": "^3.0.0-beta.30",
     "@radix-ui/react-accordion": "^1.2.0",
     "@radix-ui/react-alert-dialog": "^1.1.1",
@@ -73,7 +73,7 @@
     "react-resizable-panels": "^2.1.3",
     "react-router-dom": "^6.26.2",
     "recharts": "^2.12.7",
-    "simple-icons": "^15.9.0",
+    "simple-icons": "15.9.0",
     "sonner": "^1.5.0",
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",

--- a/webui/public/pcm-recorder-worklet.js
+++ b/webui/public/pcm-recorder-worklet.js
@@ -1,0 +1,41 @@
+/**
+ * AudioWorklet processor: downsamples mic input to 16 kHz PCM16 LE mono.
+ *
+ * Loaded at runtime via audioContext.audioWorklet.addModule('/pcm-recorder-worklet.js').
+ * Must be plain JS (no ES module imports) — AudioWorklet scope has no module loader.
+ */
+class PCMRecorderProcessor extends AudioWorkletProcessor {
+  constructor() {
+    super();
+    // ratio is computed on first process() call when sampleRate global is available
+    this._ratio = null;
+    this._targetRate = 16000;
+  }
+
+  process(inputs) {
+    const input = inputs[0];
+    if (!input || !input[0]) return true;
+    const samples = input[0]; // Float32Array at AudioContext native rate
+
+    if (this._ratio === null) {
+      // sampleRate is a global in AudioWorklet scope
+      this._ratio = sampleRate / this._targetRate;
+    }
+
+    // Simple nearest-neighbor downsampling (acceptable quality for speech)
+    const outputLength = Math.floor(samples.length / this._ratio);
+    if (outputLength === 0) return true;
+
+    const output = new Int16Array(outputLength);
+    for (let i = 0; i < outputLength; i++) {
+      const srcIdx = Math.min(Math.round(i * this._ratio), samples.length - 1);
+      const s = Math.max(-1, Math.min(1, samples[srcIdx]));
+      output[i] = s < 0 ? Math.round(s * 32768) : Math.round(s * 32767);
+    }
+
+    this.port.postMessage(output.buffer, [output.buffer]);
+    return true;
+  }
+}
+
+registerProcessor('pcm-recorder-processor', PCMRecorderProcessor);

--- a/webui/src/audio/pcm-player.ts
+++ b/webui/src/audio/pcm-player.ts
@@ -1,0 +1,70 @@
+/**
+ * PCMPlayer: buffers and schedules raw PCM16 LE playback at a fixed sample rate.
+ *
+ * Incoming binary frames from the voice server are raw Int16 mono PCM (no container).
+ * We hand-build AudioBuffer objects (decodeAudioData is for container formats, not raw PCM)
+ * and schedule them end-to-end so consecutive utterances never gap.
+ */
+
+// Extend Window to cover webkit-prefixed AudioContext
+interface WindowWithWebkit extends Window {
+  webkitAudioContext?: typeof AudioContext;
+}
+
+export class PCMPlayer {
+  private ctx: AudioContext;
+  private sampleRate: number;
+  private nextStart: number;
+
+  constructor(sampleRate = 24000) {
+    const win = window as WindowWithWebkit;
+    const AudioCtx = window.AudioContext ?? win.webkitAudioContext;
+    if (!AudioCtx) throw new Error('AudioContext not supported');
+    this.ctx = new AudioCtx();
+    this.sampleRate = sampleRate;
+    this.nextStart = 0;
+  }
+
+  /** Queue a raw PCM16 LE ArrayBuffer for gapless playback. */
+  feed(buffer: ArrayBuffer): void {
+    if (buffer.byteLength === 0) return;
+
+    const int16 = new Int16Array(buffer);
+    const float32 = new Float32Array(int16.length);
+    for (let i = 0; i < int16.length; i++) {
+      float32[i] = int16[i] / 32768;
+    }
+
+    const audioBuffer = this.ctx.createBuffer(1, float32.length, this.sampleRate);
+    audioBuffer.copyToChannel(float32, 0);
+
+    const source = this.ctx.createBufferSource();
+    source.buffer = audioBuffer;
+    source.connect(this.ctx.destination);
+
+    const now = this.ctx.currentTime;
+    const when = Math.max(now + 0.01, this.nextStart); // 10 ms lookahead
+    source.start(when);
+    this.nextStart = when + audioBuffer.duration;
+  }
+
+  /** Resume suspended AudioContext (required after user gesture in some browsers). */
+  async resume(): Promise<void> {
+    if (this.ctx.state === 'suspended') {
+      await this.ctx.resume();
+    }
+  }
+
+  /** Reset scheduling cursor (call between utterances if needed). */
+  reset(): void {
+    this.nextStart = 0;
+  }
+
+  close(): void {
+    void this.ctx.close();
+  }
+
+  get audioContext(): AudioContext {
+    return this.ctx;
+  }
+}

--- a/webui/src/audio/pcm-player.ts
+++ b/webui/src/audio/pcm-player.ts
@@ -15,6 +15,7 @@ export class PCMPlayer {
   private ctx: AudioContext;
   private sampleRate: number;
   private nextStart: number;
+  private scheduledSources: AudioBufferSourceNode[] = [];
 
   constructor(sampleRate = 24000) {
     const win = window as WindowWithWebkit;
@@ -41,6 +42,11 @@ export class PCMPlayer {
     const source = this.ctx.createBufferSource();
     source.buffer = audioBuffer;
     source.connect(this.ctx.destination);
+    this.scheduledSources.push(source);
+    source.onended = () => {
+      const idx = this.scheduledSources.indexOf(source);
+      if (idx >= 0) this.scheduledSources.splice(idx, 1);
+    };
 
     const now = this.ctx.currentTime;
     const when = Math.max(now + 0.01, this.nextStart); // 10 ms lookahead
@@ -55,8 +61,16 @@ export class PCMPlayer {
     }
   }
 
-  /** Reset scheduling cursor (call between utterances if needed). */
+  /** Stop in-flight audio and reset the scheduling cursor between utterances. */
   reset(): void {
+    for (const src of this.scheduledSources) {
+      try {
+        src.stop();
+      } catch {
+        // already ended — ignore
+      }
+    }
+    this.scheduledSources = [];
     this.nextStart = 0;
   }
 

--- a/webui/src/components/ChatInput.tsx
+++ b/webui/src/components/ChatInput.tsx
@@ -47,6 +47,8 @@ import { useModels } from '@/hooks/useModels';
 import { useAgents } from '@/hooks/useAgents';
 import { useFileAutocomplete } from '@/hooks/useFileAutocomplete';
 import { FileAutocomplete } from '@/components/FileAutocomplete';
+import { VoiceButton } from '@/components/VoiceButton';
+import { useSettings } from '@/contexts/SettingsContext';
 import {
   Select,
   SelectContent,
@@ -461,6 +463,7 @@ export const ChatInput: FC<Props> = ({
   onEditCancel,
 }) => {
   const { isConnected$, connectionConfig } = useApi();
+  const { settings } = useSettings();
   const sidebarSelectedWorkspace = use$(selectedWorkspace$);
   const sidebarSelectedAgent = use$(selectedAgent$);
 
@@ -1118,6 +1121,9 @@ export const ChatInput: FC<Props> = ({
                         )}
                     </div>
 
+                    {settings.voiceServerUrl && (
+                      <VoiceButton voiceServerUrl={settings.voiceServerUrl} />
+                    )}
                     <SubmitButton
                       isGenerating={isGenerating}
                       isDisabled={isDisabled}

--- a/webui/src/components/SettingsModal.tsx
+++ b/webui/src/components/SettingsModal.tsx
@@ -8,6 +8,7 @@ import {
   DialogTrigger,
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
 import { Separator } from '@/components/ui/separator';
@@ -195,6 +196,24 @@ export const SettingsModal = forwardRef<HTMLButtonElement, SettingsModalProps>(
                   id="chime-toggle"
                   checked={settings.chimeEnabled}
                   onCheckedChange={(checked) => updateSettings({ chimeEnabled: checked })}
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="voice-server-url" className="text-sm">
+                  Voice server URL
+                </Label>
+                <p className="text-xs text-muted-foreground">
+                  WebSocket URL of a running gptme-voice-server instance, e.g.{' '}
+                  <code className="rounded bg-muted px-1">ws://localhost:5700/voice</code>. Leave
+                  empty to hide the voice button.
+                </p>
+                <Input
+                  id="voice-server-url"
+                  type="url"
+                  placeholder="ws://localhost:5700/voice"
+                  value={settings.voiceServerUrl}
+                  onChange={(e) => updateSettings({ voiceServerUrl: e.target.value.trim() })}
                 />
               </div>
             </div>

--- a/webui/src/components/SettingsModal.tsx
+++ b/webui/src/components/SettingsModal.tsx
@@ -210,7 +210,7 @@ export const SettingsModal = forwardRef<HTMLButtonElement, SettingsModalProps>(
                 </p>
                 <Input
                   id="voice-server-url"
-                  type="url"
+                  type="text"
                   placeholder="ws://localhost:5700/voice"
                   value={settings.voiceServerUrl}
                   onChange={(e) => updateSettings({ voiceServerUrl: e.target.value.trim() })}

--- a/webui/src/components/VoiceButton.tsx
+++ b/webui/src/components/VoiceButton.tsx
@@ -1,0 +1,79 @@
+import { Mic, MicOff, Loader2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { useVoiceSession, type VoiceState } from '@/hooks/useVoiceSession';
+
+interface Props {
+  voiceServerUrl: string;
+}
+
+function stateLabel(s: VoiceState, error: string | null): string {
+  if (error) return `Voice error: ${error}`;
+  switch (s) {
+    case 'connecting':
+      return 'Connecting to voice server…';
+    case 'recording':
+      return 'Recording — click to stop';
+    case 'ended':
+      return 'Ending session…';
+    default:
+      return 'Start voice session';
+  }
+}
+
+export function VoiceButton({ voiceServerUrl }: Props) {
+  const { state, error, level, start, stop } = useVoiceSession(voiceServerUrl);
+
+  const isActive = state === 'recording' || state === 'connecting';
+  const isLoading = state === 'connecting';
+  const hasError = !!error;
+
+  const handleClick = () => {
+    if (isActive) stop();
+    else start();
+  };
+
+  // Mic level ring: scale from 1.0 to 1.3 based on audio level
+  const ringScale = 1 + level * 0.3;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          onClick={handleClick}
+          className={[
+            'relative h-8 w-8 shrink-0 rounded-full transition-colors',
+            hasError ? 'text-destructive' : '',
+            state === 'recording' ? 'text-red-500 hover:text-red-600' : 'text-muted-foreground',
+          ].join(' ')}
+          aria-label={stateLabel(state, error)}
+          aria-pressed={isActive}
+        >
+          {/* Level ring behind the icon */}
+          {state === 'recording' && (
+            <span
+              className="absolute inset-0 rounded-full bg-red-500/20 transition-transform duration-75"
+              style={{ transform: `scale(${ringScale})` }}
+            />
+          )}
+
+          {isLoading ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : isActive ? (
+            <Mic className="relative h-4 w-4" />
+          ) : hasError ? (
+            <MicOff className="h-4 w-4" />
+          ) : (
+            <Mic className="h-4 w-4" />
+          )}
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent side="top">
+        <p>{stateLabel(state, error)}</p>
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/webui/src/components/__tests__/ChatInput.test.tsx
+++ b/webui/src/components/__tests__/ChatInput.test.tsx
@@ -5,6 +5,22 @@ import { ChatInput } from '../ChatInput';
 
 const mockUploadFiles = jest.fn();
 
+jest.mock('@/contexts/SettingsContext', () => ({
+  useSettings: () => ({
+    settings: {
+      chimeEnabled: true,
+      blocksDefaultOpen: true,
+      showHiddenMessages: false,
+      showInitialSystem: false,
+      hasCompletedSetup: true,
+      welcomeBackground: '',
+      voiceServerUrl: '',
+    },
+    updateSettings: jest.fn(),
+    resetSettings: jest.fn(),
+  }),
+}));
+
 jest.mock('@/contexts/ApiContext', () => {
   const { observable } = jest.requireActual('@legendapp/state');
   return {

--- a/webui/src/contexts/SettingsContext.tsx
+++ b/webui/src/contexts/SettingsContext.tsx
@@ -8,6 +8,11 @@ export interface Settings {
   hasCompletedSetup: boolean;
   /** CSS background for the welcome/new-chat view (image URL or gradient) */
   welcomeBackground: string;
+  /**
+   * WebSocket URL for the gptme-voice-server /voice endpoint, e.g. ws://localhost:5700/voice.
+   * Leave empty to hide the VoiceButton.
+   */
+  voiceServerUrl: string;
 }
 
 interface SettingsContextType {
@@ -23,6 +28,7 @@ const defaultSettings: Settings = {
   showInitialSystem: false,
   hasCompletedSetup: false,
   welcomeBackground: '',
+  voiceServerUrl: '',
 };
 
 function loadSettingsFromStorage(): Settings {

--- a/webui/src/hooks/useVoiceSession.ts
+++ b/webui/src/hooks/useVoiceSession.ts
@@ -53,9 +53,16 @@ export function useVoiceSession(voiceServerUrl: string): UseVoiceSessionReturn {
     setState('connecting');
 
     void (async () => {
+      // Declared outside try so catch can release them if addModule fails
+      // before sessionRef is assigned (cleanup() would be a no-op otherwise).
+      let stream: MediaStream | null = null;
+      let ctx: AudioContext | null = null;
       try {
-        const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-        const ctx = new AudioContext();
+        stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+        ctx = new AudioContext();
+        // Resume immediately — browsers may auto-suspend an AudioContext created
+        // after an async getUserMedia() call (outside the user-gesture stack).
+        if (ctx.state === 'suspended') await ctx.resume();
 
         await ctx.audioWorklet.addModule('/pcm-recorder-worklet.js');
         const workletNode = new AudioWorkletNode(ctx, 'pcm-recorder-processor');
@@ -78,7 +85,7 @@ export function useVoiceSession(voiceServerUrl: string): UseVoiceSessionReturn {
         ws.binaryType = 'arraybuffer';
 
         // Stash session before async events can fire
-        const session: Session = { ws, player, audioCtx: ctx, stream, rafId: 0 };
+        const session: Session = { ws, player, audioCtx: ctx!, stream: stream!, rafId: 0 };
         sessionRef.current = session;
 
         ws.onmessage = (evt) => {
@@ -127,6 +134,12 @@ export function useVoiceSession(voiceServerUrl: string): UseVoiceSessionReturn {
           cleanup();
         };
       } catch (err) {
+        // If setup failed before sessionRef was assigned, cleanup() is a no-op;
+        // release mic and recording context explicitly to prevent leaks.
+        if (!sessionRef.current) {
+          stream?.getTracks().forEach((t) => t.stop());
+          void ctx?.close();
+        }
         setError(err instanceof Error ? err.message : 'Voice setup failed');
         setState('ended');
         cleanup();

--- a/webui/src/hooks/useVoiceSession.ts
+++ b/webui/src/hooks/useVoiceSession.ts
@@ -1,0 +1,160 @@
+import { useState, useRef, useCallback, useEffect } from 'react';
+import { PCMPlayer } from '@/audio/pcm-player';
+
+export type VoiceState = 'idle' | 'connecting' | 'recording' | 'ended';
+
+export interface UseVoiceSessionReturn {
+  state: VoiceState;
+  error: string | null;
+  /** Level 0–1 from mic analyser (0 when not recording). */
+  level: number;
+  start: () => void;
+  stop: () => void;
+  /** Flush the server's VAD input buffer (optional push-to-talk signal). */
+  commit: () => void;
+}
+
+interface Session {
+  ws: WebSocket;
+  player: PCMPlayer;
+  audioCtx: AudioContext;
+  stream: MediaStream;
+  rafId: number;
+}
+
+export function useVoiceSession(voiceServerUrl: string): UseVoiceSessionReturn {
+  const [state, setState] = useState<VoiceState>('idle');
+  const [error, setError] = useState<string | null>(null);
+  const [level, setLevel] = useState(0);
+
+  const sessionRef = useRef<Session | null>(null);
+
+  const cleanup = useCallback(() => {
+    const s = sessionRef.current;
+    if (!s) return;
+    sessionRef.current = null;
+
+    cancelAnimationFrame(s.rafId);
+    s.stream.getTracks().forEach((t) => t.stop());
+    s.ws.onopen = null;
+    s.ws.onmessage = null;
+    s.ws.onerror = null;
+    s.ws.onclose = null;
+    if (s.ws.readyState <= WebSocket.OPEN) s.ws.close();
+    s.player.close();
+    void s.audioCtx.close();
+    setLevel(0);
+  }, []);
+
+  const start = useCallback(() => {
+    if (!voiceServerUrl || sessionRef.current) return;
+
+    setError(null);
+    setState('connecting');
+
+    void (async () => {
+      try {
+        const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+        const ctx = new AudioContext();
+
+        await ctx.audioWorklet.addModule('/pcm-recorder-worklet.js');
+        const workletNode = new AudioWorkletNode(ctx, 'pcm-recorder-processor');
+
+        // Level meter
+        const analyser = ctx.createAnalyser();
+        analyser.fftSize = 256;
+
+        // Route mic → analyser + worklet; mute to speakers
+        const silentGain = ctx.createGain();
+        silentGain.gain.value = 0;
+        const micSource = ctx.createMediaStreamSource(stream);
+        micSource.connect(analyser);
+        micSource.connect(workletNode);
+        workletNode.connect(silentGain);
+        silentGain.connect(ctx.destination);
+
+        const player = new PCMPlayer(24000);
+        const ws = new WebSocket(voiceServerUrl);
+        ws.binaryType = 'arraybuffer';
+
+        // Stash session before async events can fire
+        const session: Session = { ws, player, audioCtx: ctx, stream, rafId: 0 };
+        sessionRef.current = session;
+
+        ws.onmessage = (evt) => {
+          if (typeof evt.data === 'string') {
+            try {
+              const msg = JSON.parse(evt.data) as { type: string };
+              if (msg.type === 'ready') {
+                void player.resume();
+                setState('recording');
+
+                // Wire worklet output → WebSocket
+                workletNode.port.onmessage = (e: MessageEvent<ArrayBuffer>) => {
+                  if (ws.readyState === WebSocket.OPEN) ws.send(e.data);
+                };
+
+                // Start level meter loop
+                const levelBuf = new Uint8Array(analyser.frequencyBinCount);
+                const tick = () => {
+                  analyser.getByteFrequencyData(levelBuf);
+                  const avg = levelBuf.reduce((sum, v) => sum + v, 0) / levelBuf.length;
+                  setLevel(Math.min(1, avg / 64));
+                  const id = requestAnimationFrame(tick);
+                  if (sessionRef.current === session) session.rafId = id;
+                };
+                session.rafId = requestAnimationFrame(tick);
+              } else if (msg.type === 'audio_end') {
+                player.reset();
+              }
+            } catch {
+              // non-JSON control frame — ignore
+            }
+          } else {
+            // Binary: raw PCM from the model
+            player.feed(evt.data as ArrayBuffer);
+          }
+        };
+
+        ws.onerror = () => {
+          setError('Voice connection error');
+          setState('ended');
+          cleanup();
+        };
+
+        ws.onclose = () => {
+          setState('ended');
+          cleanup();
+        };
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Voice setup failed');
+        setState('ended');
+        cleanup();
+      }
+    })();
+  }, [voiceServerUrl, cleanup]);
+
+  const stop = useCallback(() => {
+    setState('ended');
+    cleanup();
+  }, [cleanup]);
+
+  const commit = useCallback(() => {
+    const ws = sessionRef.current?.ws;
+    if (ws?.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify({ type: 'commit' }));
+    }
+  }, []);
+
+  // Auto-reset ended → idle so the button becomes clickable again
+  useEffect(() => {
+    if (state !== 'ended') return;
+    const t = setTimeout(() => setState('idle'), 1500);
+    return () => clearTimeout(t);
+  }, [state]);
+
+  // Cleanup on unmount
+  useEffect(() => () => cleanup(), [cleanup]);
+
+  return { state, error, level, start, stop, commit };
+}

--- a/webui/src/hooks/useVoiceSession.ts
+++ b/webui/src/hooks/useVoiceSession.ts
@@ -28,6 +28,8 @@ export function useVoiceSession(voiceServerUrl: string): UseVoiceSessionReturn {
   const [level, setLevel] = useState(0);
 
   const sessionRef = useRef<Session | null>(null);
+  // Incremented on each start/stop call to cancel in-flight async setup.
+  const setupGenRef = useRef(0);
 
   const cleanup = useCallback(() => {
     const s = sessionRef.current;
@@ -51,6 +53,7 @@ export function useVoiceSession(voiceServerUrl: string): UseVoiceSessionReturn {
 
     setError(null);
     setState('connecting');
+    const gen = ++setupGenRef.current;
 
     void (async () => {
       // Declared outside try so catch can release them if setup fails
@@ -60,12 +63,28 @@ export function useVoiceSession(voiceServerUrl: string): UseVoiceSessionReturn {
       let player: PCMPlayer | null = null;
       try {
         stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+        // stop() may have been called while we were awaiting getUserMedia.
+        if (setupGenRef.current !== gen) {
+          stream.getTracks().forEach((t) => t.stop());
+          return;
+        }
+
         ctx = new AudioContext();
         // Resume immediately — browsers may auto-suspend an AudioContext created
         // after an async getUserMedia() call (outside the user-gesture stack).
         if (ctx.state === 'suspended') await ctx.resume();
+        if (setupGenRef.current !== gen) {
+          stream.getTracks().forEach((t) => t.stop());
+          void ctx.close();
+          return;
+        }
 
         await ctx.audioWorklet.addModule('/pcm-recorder-worklet.js');
+        if (setupGenRef.current !== gen) {
+          stream.getTracks().forEach((t) => t.stop());
+          void ctx.close();
+          return;
+        }
         const workletNode = new AudioWorkletNode(ctx, 'pcm-recorder-processor');
 
         // Level meter
@@ -131,8 +150,12 @@ export function useVoiceSession(voiceServerUrl: string): UseVoiceSessionReturn {
         };
 
         ws.onclose = () => {
-          setState('ended');
-          cleanup();
+          // Guard against double-setState: onerror fires before onclose on errors,
+          // and cleanup() already cleared sessionRef. Only act if session is still active.
+          if (sessionRef.current === session) {
+            setState('ended');
+            cleanup();
+          }
         };
       } catch (err) {
         // If setup failed before sessionRef was assigned, cleanup() is a no-op;
@@ -142,14 +165,18 @@ export function useVoiceSession(voiceServerUrl: string): UseVoiceSessionReturn {
           player?.close();
           void ctx?.close();
         }
-        setError(err instanceof Error ? err.message : 'Voice setup failed');
-        setState('ended');
+        // Don't update UI state if this setup was already cancelled by stop().
+        if (setupGenRef.current === gen) {
+          setError(err instanceof Error ? err.message : 'Voice setup failed');
+          setState('ended');
+        }
         cleanup();
       }
     })();
   }, [voiceServerUrl, cleanup]);
 
   const stop = useCallback(() => {
+    setupGenRef.current++; // cancel any in-flight async setup IIFE
     setState('ended');
     cleanup();
   }, [cleanup]);

--- a/webui/src/hooks/useVoiceSession.ts
+++ b/webui/src/hooks/useVoiceSession.ts
@@ -195,8 +195,9 @@ export function useVoiceSession(voiceServerUrl: string): UseVoiceSessionReturn {
     return () => clearTimeout(t);
   }, [state]);
 
-  // Cleanup on unmount
-  useEffect(() => () => cleanup(), [cleanup]);
+  // Cleanup on unmount — call stop() not cleanup() so setupGenRef is incremented,
+  // which cancels any in-flight async setup that is still awaiting getUserMedia/addModule.
+  useEffect(() => () => stop(), [stop]);
 
   return { state, error, level, start, stop, commit };
 }

--- a/webui/src/hooks/useVoiceSession.ts
+++ b/webui/src/hooks/useVoiceSession.ts
@@ -53,10 +53,11 @@ export function useVoiceSession(voiceServerUrl: string): UseVoiceSessionReturn {
     setState('connecting');
 
     void (async () => {
-      // Declared outside try so catch can release them if addModule fails
+      // Declared outside try so catch can release them if setup fails
       // before sessionRef is assigned (cleanup() would be a no-op otherwise).
       let stream: MediaStream | null = null;
       let ctx: AudioContext | null = null;
+      let player: PCMPlayer | null = null;
       try {
         stream = await navigator.mediaDevices.getUserMedia({ audio: true });
         ctx = new AudioContext();
@@ -80,12 +81,12 @@ export function useVoiceSession(voiceServerUrl: string): UseVoiceSessionReturn {
         workletNode.connect(silentGain);
         silentGain.connect(ctx.destination);
 
-        const player = new PCMPlayer(24000);
+        player = new PCMPlayer(24000);
         const ws = new WebSocket(voiceServerUrl);
         ws.binaryType = 'arraybuffer';
 
         // Stash session before async events can fire
-        const session: Session = { ws, player, audioCtx: ctx!, stream: stream!, rafId: 0 };
+        const session: Session = { ws, player: player!, audioCtx: ctx!, stream: stream!, rafId: 0 };
         sessionRef.current = session;
 
         ws.onmessage = (evt) => {
@@ -93,7 +94,7 @@ export function useVoiceSession(voiceServerUrl: string): UseVoiceSessionReturn {
             try {
               const msg = JSON.parse(evt.data) as { type: string };
               if (msg.type === 'ready') {
-                void player.resume();
+                void session.player.resume();
                 setState('recording');
 
                 // Wire worklet output → WebSocket
@@ -112,14 +113,14 @@ export function useVoiceSession(voiceServerUrl: string): UseVoiceSessionReturn {
                 };
                 session.rafId = requestAnimationFrame(tick);
               } else if (msg.type === 'audio_end') {
-                player.reset();
+                session.player.reset();
               }
             } catch {
               // non-JSON control frame — ignore
             }
           } else {
             // Binary: raw PCM from the model
-            player.feed(evt.data as ArrayBuffer);
+            session.player.feed(evt.data as ArrayBuffer);
           }
         };
 
@@ -135,9 +136,10 @@ export function useVoiceSession(voiceServerUrl: string): UseVoiceSessionReturn {
         };
       } catch (err) {
         // If setup failed before sessionRef was assigned, cleanup() is a no-op;
-        // release mic and recording context explicitly to prevent leaks.
+        // release mic, recording context, and player explicitly to prevent leaks.
         if (!sessionRef.current) {
           stream?.getTracks().forEach((t) => t.stop());
+          player?.close();
           void ctx?.close();
         }
         setError(err instanceof Error ? err.message : 'Voice setup failed');


### PR DESCRIPTION
## Summary

Wires [gptme-contrib#785](https://github.com/gptme/gptme-contrib/pull/785) (merged 2026-04-27) — the `/voice` WebSocket route on `gptme-voice-server` — into the webui via a `VoiceButton` in `ChatInput`.

**New files:**
- `webui/public/pcm-recorder-worklet.js` — AudioWorklet processor: downsamples mic audio (any native rate) to 16 kHz PCM16 LE mono via nearest-neighbor resampling, posts transferable `ArrayBuffer`s per frame.
- `webui/src/audio/pcm-player.ts` — `PCMPlayer`: gapless playback of raw 24 kHz PCM16 LE binary frames from the model. Hand-builds `AudioBuffer` objects (raw PCM, not a container — `decodeAudioData` doesn't apply here).
- `webui/src/hooks/useVoiceSession.ts` — `useVoiceSession` hook: state machine `idle → connecting → recording → ended`, opens WebSocket to `/voice`, wires worklet output → `send()`, feeds binary frames → `PCMPlayer`, exposes `start / stop / commit` and a 0–1 mic level.
- `webui/src/components/VoiceButton.tsx` — Mic icon button with level-ring animation while recording. Hidden when `voiceServerUrl` is empty.

**Modified files:**
- `SettingsContext.tsx` — adds `voiceServerUrl: string` (default `""`).
- `SettingsModal.tsx` — adds a URL input under the Audio tab.
- `ChatInput.tsx` — renders `VoiceButton` next to Submit when `voiceServerUrl` is set.

## Wire protocol

Per [gptme-contrib#785](https://github.com/gptme/gptme-contrib/pull/785):
- Client → server: binary PCM16 LE mono @ 16 kHz + optional `{"type":"commit"}` text frame
- Server → client: `{"type":"ready", ...}` on accept, binary PCM16 LE mono @ 24 kHz utterances, `{"type":"audio_end"}` between utterances

## Usage

1. Run `gptme-voice-server --enable-browser-routes` (or with Bob's existing setup on port 5700)
2. Go to Settings → Audio → enter `ws://localhost:5700/voice`
3. Mic icon appears in ChatInput toolbar — click to start, click again to end

## Test plan

- [ ] Typecheck passes (`npm run typecheck`)
- [ ] VoiceButton hidden when `voiceServerUrl` is empty
- [ ] VoiceButton visible after setting a URL in Audio settings
- [ ] Click connects → spinner shown → "ready" from server → turns red
- [ ] Mic audio flows to voice server (verify in server logs)
- [ ] Server PCM audio plays back in browser
- [ ] Clicking stop closes WebSocket cleanly
- [ ] Level ring animates with mic volume while recording

## Related

- Design doc: [`knowledge/technical-designs/voice-phase-2-webui-browser-transport.md`](https://github.com/TimeToBuildBob/bob/blob/master/knowledge/technical-designs/voice-phase-2-webui-browser-transport.md)
- Phase 1 server PR: gptme/gptme-contrib#785 (merged)
- Task: `tasks/gptme-voice-integration-into-gptme-core.md`