### PR TITLE
fix(tauri,server): watch Tauri PID and self-terminate on death

### DIFF
--- a/gptme/server/cli.py
+++ b/gptme/server/cli.py
@@ -1,5 +1,9 @@
 import json
 import logging
+import os
+import signal
+import threading
+import time
 from pathlib import Path
 
 import click
@@ -14,6 +18,65 @@ from .auth import get_server_token, init_auth
 from .constants import _pick_fallback_model
 
 logger = logging.getLogger(__name__)
+
+
+def _pid_alive(pid: int) -> bool:
+    """Check if a PID is still alive on this host.
+
+    Uses kill(pid, 0) which sends no signal but checks for the existence and
+    permission to signal the target. Returns False if the process is gone or
+    if EPERM means the PID was recycled by a different user.
+    """
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # PID exists but we can't signal it — likely recycled to a different
+        # user. Treat as dead so we don't keep watching a stale PID.
+        return False
+
+
+def _start_parent_death_watcher(
+    watch_pid: int | None = None, poll_interval: float = 0.5
+) -> None:
+    """Spawn a daemon thread that exits the process when a watched PID dies.
+
+    Tauri's macOS Cmd+Q can terminate the parent before its cleanup handlers
+    dispatch SIGKILL to sidecars (gptme/gptme#2260). When that happens, the
+    kernel reparents the orphan to PID 1 (launchd). We detect parent death and
+    self-terminate via SIGTERM so server shutdown still runs.
+
+    If `watch_pid` is given, we watch that specific PID (e.g. the Tauri grand-
+    parent PID, which is needed for PyInstaller-bundled servers because the
+    PyInstaller bootloader survives parent death and stays our `getppid()`).
+    Otherwise we watch our direct parent.
+    """
+    if watch_pid is None:
+        watch_pid = os.getppid()
+    if watch_pid <= 1:
+        # PID 0/1 means we're already orphaned or run directly under init —
+        # there's nothing meaningful to watch.
+        return
+
+    initial_pid = watch_pid
+
+    def _watcher() -> None:
+        while True:
+            time.sleep(poll_interval)
+            if not _pid_alive(initial_pid):
+                logger.warning(
+                    "Watched PID %d is gone, shutting down gptme-server",
+                    initial_pid,
+                )
+                # Send SIGTERM to ourselves so Flask's signal handlers run and
+                # the `finally: shutdown_telemetry()` block fires.
+                os.kill(os.getpid(), signal.SIGTERM)
+                return
+
+    thread = threading.Thread(target=_watcher, name="parent-death-watcher", daemon=True)
+    thread.start()
 
 
 @click.group(cls=DefaultGroup, default="serve", default_if_no_args=True)
@@ -61,6 +124,26 @@ def main():
         "'tauri://localhost,http://tauri.localhost'."
     ),
 )
+@click.option(
+    "--exit-on-parent-death",
+    is_flag=True,
+    default=False,
+    help=(
+        "Exit when the parent process dies. Useful when run as a sidecar "
+        "(e.g. by gptme-tauri) to avoid orphaned servers when the parent "
+        "exits without cleaning up children (gptme/gptme#2260)."
+    ),
+)
+@click.option(
+    "--watch-pid",
+    type=int,
+    default=None,
+    help=(
+        "PID to watch for liveness. If the PID disappears the server exits. "
+        "Used by gptme-tauri to pass its own PID so PyInstaller-bundled servers "
+        "can detect Tauri exit even when the bootloader survives reparenting."
+    ),
+)
 def serve(
     debug: bool,
     verbose: bool,
@@ -69,6 +152,8 @@ def serve(
     port: int,
     tools: str | None,
     cors_origin: str | None,
+    exit_on_parent_death: bool,
+    watch_pid: int | None,
 ):  # pragma: no cover
     """
     Starts a server and web UI for gptme.
@@ -77,6 +162,9 @@ def serve(
     """
     init_logging(verbose)
     set_config_from_workspace(Path.cwd())
+
+    if exit_on_parent_death or watch_pid is not None:
+        _start_parent_death_watcher(watch_pid=watch_pid)
 
     # Try to initialize with provided/configured model
     # If init fails due to missing model/API keys, use fallback

--- a/tauri/src-tauri/src/lib.rs
+++ b/tauri/src-tauri/src/lib.rs
@@ -196,11 +196,24 @@ async fn spawn_server_sidecar(
         cors_origin
     );
 
+    // --watch-pid: belt-and-suspenders backup for cleanup_server_process.
+    // On macOS, Cmd+Q can terminate the Tauri process before our pkill/child.kill()
+    // syscalls finish (gptme/gptme#2260). The PyInstaller bootloader (the direct
+    // parent of the Python gptme-server process) survives reparenting to launchd,
+    // so watching getppid() from inside the Python child is insufficient — it
+    // still sees the bootloader. Pass the Tauri PID explicitly so the server
+    // self-terminates when Tauri itself disappears.
+    let tauri_pid = std::process::id().to_string();
     let sidecar_command = app
         .shell()
         .sidecar("gptme-server")
         .map_err(|e| format!("Sidecar error: {}", e))?
-        .args(["--cors-origin", cors_origin]);
+        .args([
+            "--cors-origin",
+            cors_origin,
+            "--watch-pid",
+            tauri_pid.as_str(),
+        ]);
 
     let (mut rx, child) = sidecar_command
         .spawn()

--- a/tests/test_server_parent_death_watcher.py
+++ b/tests/test_server_parent_death_watcher.py
@@ -1,0 +1,59 @@
+"""Tests for the gptme-server parent-death watcher (gptme/gptme#2260)."""
+
+import os
+import signal
+import threading
+import time
+from unittest.mock import patch
+
+import pytest
+
+pytest.importorskip(
+    "flask", reason="flask not installed, install server extras (-E server)"
+)
+
+from gptme.server.cli import _pid_alive, _start_parent_death_watcher
+
+
+def test_pid_alive_for_self():
+    assert _pid_alive(os.getpid())
+
+
+def test_pid_alive_returns_false_for_dead_pid():
+    # PID 0 / very high never-allocated PIDs always look dead.
+    # PID 1 is init/launchd, always alive on POSIX, so use a guaranteed-dead pid.
+    assert not _pid_alive(2_147_483_646)
+
+
+def test_watcher_skips_when_already_orphaned():
+    # When watch_pid <= 1 we treat as already-orphaned and don't spawn the thread.
+    threads_before = threading.active_count()
+    _start_parent_death_watcher(watch_pid=1, poll_interval=0.01)
+    _start_parent_death_watcher(watch_pid=0, poll_interval=0.01)
+    # Give any (incorrectly-spawned) thread time to start.
+    time.sleep(0.05)
+    assert threading.active_count() == threads_before
+
+
+def test_watcher_sends_sigterm_when_watched_pid_disappears():
+    """When the watched PID is gone the watcher SIGTERMs the current process."""
+    received: list[int] = []
+    original = signal.getsignal(signal.SIGTERM)
+
+    def _handler(signum, _frame):
+        received.append(signum)
+
+    signal.signal(signal.SIGTERM, _handler)
+    try:
+        # _pid_alive returns False immediately → watcher fires SIGTERM on the
+        # first poll. Use a dead PID so we don't depend on real process state.
+        with patch("gptme.server.cli._pid_alive", return_value=False):
+            _start_parent_death_watcher(watch_pid=99_999_999, poll_interval=0.01)
+            # Wait for the watcher to fire.
+            for _ in range(50):
+                if received:
+                    break
+                time.sleep(0.01)
+        assert received == [signal.SIGTERM]
+    finally:
+        signal.signal(signal.SIGTERM, original)


### PR DESCRIPTION
## Problem

Erik reported on `dev202604275` and `dev202604276` that the gptme-server orphan **still persists** on macOS Cmd+Q after #2261, #2262, and #2264:

```
$ ps aux | grep gptme   # after Cmd+Q (851 = gptme-tauri, gone)
501 855   1   /Applications/gptme-tauri.app/Contents/MacOS/gptme-server ...
501 920 855  /Applications/gptme-tauri.app/Contents/MacOS/gptme-server ...
```

`gptme-tauri` exits cleanly, but the gptme-server sidecar (855) and its PyInstaller Python child (920) survive, reparented to launchd. This means `cleanup_server_process` either never runs on Cmd+Q or runs after AppKit has already terminated the Tauri process. **Parent-side cleanup on macOS is fragile.**

## Root cause

There's a race between AppKit's app termination and Tauri's `RunEvent::ExitRequested` event delivery, plus the additional complexity of PyInstaller's bootloader-spawns-Python child layout. None of the parent-side fixes can reliably win that race in 100% of cases.

## Fix

Add a **child-side backup**: gptme-server polls a watched PID and self-terminates via `SIGTERM` when it disappears. This works regardless of how Tauri dies (clean exit, AppKit kill, crash) because the kernel is the source of truth for process liveness.

Watching `os.getppid()` is insufficient — the PyInstaller bootloader is the **direct parent** of the Python child and survives Tauri exit. So the bootloader stays as `getppid()` of the Python process even after Tauri dies. The fix passes the **Tauri PID explicitly** via `--watch-pid` so the Python child watches the *grandparent*, not its immediate parent.

This is **belt-and-suspenders**: the existing parent-side cleanup remains in place; this PR only adds a child-side fallback that fires within `poll_interval` (500ms by default) when the parent-side path fails.

## Changes

- `gptme/server/cli.py`: `--watch-pid PID` and `--exit-on-parent-death` flag options. A daemon thread polls liveness via `kill(pid, 0)` and SIGTERMs the process when the target is gone.
- `tauri/src-tauri/src/lib.rs`: pass `--watch-pid <tauri_pid>` when spawning the sidecar.
- `tests/test_server_parent_death_watcher.py`: unit tests covering no-op (PID ≤ 1), dead-PID detection, and SIGTERM dispatch.

## Verification

End-to-end test on Linux (this can't reproduce the macOS race directly, but verifies the watcher fires):

```bash
$ uv run gptme-server serve --watch-pid <dummy_pid> --port 5777 &
[19:08:11] Server starts...
$ kill <dummy_pid>
[19:08:15] WARNING  Watched PID 2734677 is gone, shutting down gptme-server
$ wait; echo $?  # exit 143 = 128+SIGTERM, clean shutdown via Flask signal handlers
143
```

All 4 unit tests pass:

```
tests/test_server_parent_death_watcher.py::test_pid_alive_for_self PASSED
tests/test_server_parent_death_watcher.py::test_pid_alive_returns_false_for_dead_pid PASSED
tests/test_server_parent_death_watcher.py::test_watcher_skips_when_already_orphaned PASSED
tests/test_server_parent_death_watcher.py::test_watcher_sends_sigterm_when_watched_pid_disappears PASSED
```

mypy: clean. ruff format/check: clean.

## Risks

- PID recycling: the kernel could in theory recycle the Tauri PID before the watcher polls. PIDs recycle every ~32k spawns on macOS, so this is astronomically unlikely within an app session.
- `kill(pid, 0)` returning EPERM: handled — treated as dead so we don't watch a stale PID owned by another user post-recycle.
- The poll thread is a daemon, so it can't keep the process alive past intentional exit.

Refs gptme/gptme#2260, follows up on #2261, #2262, #2264.

cc @ErikBjare — please test on the next dev build after merge.