### PR TITLE
feat(tools/read): support batch reads via newline-separated paths

### DIFF
--- a/gptme/tools/read.py
+++ b/gptme/tools/read.py
@@ -26,6 +26,7 @@ For files, output includes line numbers for easy reference.
 For directories, output shows a flat listing of immediate files and subdirectories.
 
 To read multiple files in a single call, put one path per line in the code block.
+Lines beginning with '#' are treated as comments and skipped.
 The line-range parameters (start_line, end_line) only apply when reading a single file.
 """.strip()
 

--- a/gptme/tools/read.py
+++ b/gptme/tools/read.py
@@ -69,7 +69,7 @@ def _get_read_paths(
     callers and CLI invocations). The markdown code-block entry point may
     contain multiple newline-separated paths for batch reading.
     """
-    if kwargs and "path" in kwargs:
+    if kwargs and kwargs.get("path"):
         return [Path(kwargs["path"]).expanduser()]
     if args:
         return [Path(" ".join(args)).expanduser()]
@@ -236,8 +236,9 @@ tool = ToolSpec(
         Parameter(
             name="path",
             type="string",
-            description="The path of the file or directory to read",
-            required=True,
+            description="The path of the file or directory to read. "
+            "Optional when multiple paths are supplied in the code block (one per line).",
+            required=False,
         ),
         Parameter(
             name="start_line",

--- a/gptme/tools/read.py
+++ b/gptme/tools/read.py
@@ -1,8 +1,11 @@
 """
-Read the contents of a file or list the contents of a directory.
+Read the contents of one or more files, or list the contents of a directory.
 
 Provides a sandboxed file reading capability that works without shell access.
 Useful for restricted tool sets (e.g., ``--tools read,patch,save``).
+
+Multiple paths can be passed in the code block (one per line) to read several
+files in a single tool call, reducing roundtrips when exploring a codebase.
 """
 
 from collections.abc import Generator
@@ -17,18 +20,25 @@ from .base import (
 )
 
 instructions = """
-Read the content of a file or list the contents of a directory.
-The path can be relative or absolute.
+Read the content of one or more files, or list the contents of a directory.
+Paths can be relative or absolute.
 For files, output includes line numbers for easy reference.
 For directories, output shows a flat listing of immediate files and subdirectories.
+
+To read multiple files in a single call, put one path per line in the code block.
+The line-range parameters (start_line, end_line) only apply when reading a single file.
 """.strip()
 
 instructions_format = {
-    "markdown": "Use a code block with the language tag: `read <path>` to read a file.",
+    "markdown": (
+        "Use a code block with the language tag: `read <path>` to read a file. "
+        "For multiple files, place one path per line inside the code block."
+    ),
 }
 
 
 def examples(tool_format):
+    batch_paths = "hello.py\ngoodbye.py"
     return f"""
 > User: read hello.py
 > Assistant:
@@ -37,20 +47,40 @@ def examples(tool_format):
 >    1\tprint("Hello world")
 >    2\tprint("Goodbye world")
 > ```
+
+> User: read both source files
+> Assistant:
+{ToolUse("read", [], batch_paths).to_output(tool_format)}
+> System: ```hello.py
+>    1\tprint("Hello world")
+> ```
+> ```goodbye.py
+>    1\tprint("Goodbye world")
+> ```
 """.strip()
 
 
-def _get_read_path(
+def _get_read_paths(
     code: str | None, args: list[str] | None, kwargs: dict[str, str] | None
-) -> Path | None:
-    """Extract the file path from args or kwargs."""
+) -> list[Path]:
+    """Extract one or more file paths from args or kwargs.
+
+    The kwargs and args entry points always carry a single path (tool-format
+    callers and CLI invocations). The markdown code-block entry point may
+    contain multiple newline-separated paths for batch reading.
+    """
     if kwargs and "path" in kwargs:
-        return Path(kwargs["path"]).expanduser()
+        return [Path(kwargs["path"]).expanduser()]
     if args:
-        return Path(" ".join(args)).expanduser()
+        return [Path(" ".join(args)).expanduser()]
     if code and code.strip():
-        return Path(code.strip()).expanduser()
-    return None
+        paths = [
+            Path(line.strip()).expanduser()
+            for line in code.splitlines()
+            if line.strip() and not line.strip().startswith("#")
+        ]
+        return paths
+    return []
 
 
 _MAX_DIR_ENTRIES = 100
@@ -84,17 +114,12 @@ def _list_directory(path: Path) -> Generator[Message, None, None]:
     )
 
 
-def execute_read(
-    code: str | None,
-    args: list[str] | None,
-    kwargs: dict[str, str] | None,
+def _read_one(
+    path: Path,
+    start_line: int = 1,
+    end_line: int | None = None,
 ) -> Generator[Message, None, None]:
-    """Read a file and return its contents with line numbers."""
-    path = _get_read_path(code, args, kwargs)
-    if not path:
-        yield Message("system", "No path provided")
-        return
-
+    """Read a single file or directory and yield messages with the result."""
     # Path traversal protection: validate relative paths stay within cwd
     path_display = path
     path = path.expanduser().resolve()
@@ -121,29 +146,6 @@ def execute_read(
     if not path.is_file():
         yield Message("system", f"Not a file: {path}")
         return
-
-    # Parse optional line range from kwargs
-    start_line = 1
-    end_line = None
-    if kwargs:
-        if "start_line" in kwargs:
-            try:
-                start_line = int(kwargs["start_line"])
-            except ValueError:
-                yield Message(
-                    "system",
-                    f"Invalid start_line: {kwargs['start_line']!r} (expected integer)",
-                )
-                return
-        if "end_line" in kwargs:
-            try:
-                end_line = int(kwargs["end_line"])
-            except ValueError:
-                yield Message(
-                    "system",
-                    f"Invalid end_line: {kwargs['end_line']!r} (expected integer)",
-                )
-                return
 
     try:
         content = path.read_text(encoding="utf-8")
@@ -176,9 +178,55 @@ def execute_read(
     yield Message("system", md_codeblock(f"{path}{range_info}", numbered))
 
 
+def execute_read(
+    code: str | None,
+    args: list[str] | None,
+    kwargs: dict[str, str] | None,
+) -> Generator[Message, None, None]:
+    """Read one or more files (or a directory) and return their contents."""
+    paths = _get_read_paths(code, args, kwargs)
+    if not paths:
+        yield Message("system", "No path provided")
+        return
+
+    # Parse optional line range from kwargs (single-path only)
+    start_line = 1
+    end_line = None
+    if kwargs:
+        if "start_line" in kwargs:
+            try:
+                start_line = int(kwargs["start_line"])
+            except ValueError:
+                yield Message(
+                    "system",
+                    f"Invalid start_line: {kwargs['start_line']!r} (expected integer)",
+                )
+                return
+        if "end_line" in kwargs:
+            try:
+                end_line = int(kwargs["end_line"])
+            except ValueError:
+                yield Message(
+                    "system",
+                    f"Invalid end_line: {kwargs['end_line']!r} (expected integer)",
+                )
+                return
+
+    # Line ranges only meaningful for single-file reads.
+    if len(paths) > 1 and (start_line != 1 or end_line is not None):
+        yield Message(
+            "system",
+            "start_line/end_line ignored when reading multiple paths",
+        )
+        start_line, end_line = 1, None
+
+    for path in paths:
+        yield from _read_one(path, start_line=start_line, end_line=end_line)
+
+
 tool = ToolSpec(
     name="read",
-    desc="Read the content of a file or list directory contents",
+    desc="Read the content of one or more files, or list directory contents",
     instructions=instructions,
     instructions_format=instructions_format,
     examples=examples,
@@ -194,13 +242,15 @@ tool = ToolSpec(
         Parameter(
             name="start_line",
             type="integer",
-            description="Line number to start reading from (1-indexed)",
+            description="Line number to start reading from (1-indexed). "
+            "Ignored when reading multiple files.",
             required=False,
         ),
         Parameter(
             name="end_line",
             type="integer",
-            description="Line number to stop reading at (inclusive)",
+            description="Line number to stop reading at (inclusive). "
+            "Ignored when reading multiple files.",
             required=False,
         ),
     ],

--- a/tests/test_tools_read.py
+++ b/tests/test_tools_read.py
@@ -140,3 +140,80 @@ def test_read_no_path():
     messages = list(execute_read(None, None, None))
     assert len(messages) == 1
     assert "No path provided" in messages[0].content
+
+
+def test_read_multiple_files_via_code(tmp_path: Path):
+    """Test batch reading: multiple paths in the code block, one per line."""
+    p1 = tmp_path / "a.txt"
+    p2 = tmp_path / "b.txt"
+    p1.write_text("alpha 1\nalpha 2\n")
+    p2.write_text("beta 1\nbeta 2\n")
+
+    code = f"{p1}\n{p2}\n"
+    messages = list(execute_read(code, None, None))
+
+    # One message per file.
+    assert len(messages) == 2
+    assert "alpha 1" in messages[0].content
+    assert "alpha 2" in messages[0].content
+    assert "beta 1" in messages[1].content
+    assert "beta 2" in messages[1].content
+
+
+def test_read_multiple_files_skips_blanks_and_comments(tmp_path: Path):
+    """Test batch reading ignores blank lines and # comments."""
+    p1 = tmp_path / "a.txt"
+    p2 = tmp_path / "b.txt"
+    p1.write_text("alpha\n")
+    p2.write_text("beta\n")
+
+    code = f"\n# header comment\n{p1}\n\n# another comment\n{p2}\n"
+    messages = list(execute_read(code, None, None))
+
+    assert len(messages) == 2
+    assert "alpha" in messages[0].content
+    assert "beta" in messages[1].content
+
+
+def test_read_multiple_files_partial_failure(tmp_path: Path):
+    """Test batch reading: missing files don't abort the whole batch."""
+    p1 = tmp_path / "exists.txt"
+    p1.write_text("hello\n")
+    missing = tmp_path / "missing.txt"
+    p3 = tmp_path / "also-exists.txt"
+    p3.write_text("world\n")
+
+    code = f"{p1}\n{missing}\n{p3}\n"
+    messages = list(execute_read(code, None, None))
+
+    assert len(messages) == 3
+    assert "hello" in messages[0].content
+    assert "File not found" in messages[1].content
+    assert "world" in messages[2].content
+
+
+def test_read_multiple_files_ignores_line_range(tmp_path: Path):
+    """Test that start_line/end_line is ignored when reading multiple files."""
+    p1 = tmp_path / "a.txt"
+    p2 = tmp_path / "b.txt"
+    p1.write_text("a1\na2\na3\n")
+    p2.write_text("b1\nb2\nb3\n")
+
+    code = f"{p1}\n{p2}\n"
+    messages = list(execute_read(code, None, {"start_line": "2"}))
+
+    # First message is the notice, then one per file (full content).
+    assert len(messages) == 3
+    assert "ignored when reading multiple paths" in messages[0].content
+    assert "a1" in messages[1].content and "a3" in messages[1].content
+    assert "b1" in messages[2].content and "b3" in messages[2].content
+
+
+def test_read_single_path_via_code_unchanged(tmp_path: Path):
+    """Single-path code block keeps existing behavior."""
+    p = tmp_path / "test.txt"
+    p.write_text("only line\n")
+
+    messages = list(execute_read(str(p), None, None))
+    assert len(messages) == 1
+    assert "only line" in messages[0].content

--- a/tests/test_tools_read.py
+++ b/tests/test_tools_read.py
@@ -1,6 +1,10 @@
 """Tests for the read tool."""
 
+import os
+import stat
 from pathlib import Path
+
+import pytest
 
 from gptme.tools.read import execute_read
 
@@ -217,3 +221,89 @@ def test_read_single_path_via_code_unchanged(tmp_path: Path):
     messages = list(execute_read(str(p), None, None))
     assert len(messages) == 1
     assert "only line" in messages[0].content
+
+
+def test_read_invalid_start_line(tmp_path: Path):
+    """Test that a non-integer start_line returns an error message."""
+    path = tmp_path / "test.txt"
+    path.write_text("line 1\n")
+
+    messages = list(execute_read(None, None, {"path": str(path), "start_line": "abc"}))
+    assert len(messages) == 1
+    assert "Invalid start_line" in messages[0].content
+
+
+def test_read_invalid_end_line(tmp_path: Path):
+    """Test that a non-integer end_line returns an error message."""
+    path = tmp_path / "test.txt"
+    path.write_text("line 1\n")
+
+    messages = list(execute_read(None, None, {"path": str(path), "end_line": "xyz"}))
+    assert len(messages) == 1
+    assert "Invalid end_line" in messages[0].content
+
+
+def test_read_path_traversal(tmp_path: Path, monkeypatch):
+    """Test that relative paths traversing outside cwd are blocked."""
+    external = tmp_path / "external.txt"
+    external.write_text("secret\n")
+    subdir = tmp_path / "workdir"
+    subdir.mkdir()
+
+    monkeypatch.chdir(subdir)
+
+    # "../external.txt" resolves outside cwd → path traversal
+    messages = list(execute_read(None, ["../external.txt"], None))
+    assert len(messages) == 1
+    assert "Path traversal detected" in messages[0].content
+
+
+@pytest.mark.skipif(os.getuid() == 0, reason="root bypasses permissions")
+def test_read_permission_denied_file(tmp_path: Path):
+    """Test that a file with no read permission returns Permission denied."""
+    path = tmp_path / "secret.txt"
+    path.write_text("top secret\n")
+    path.chmod(0o000)
+
+    try:
+        messages = list(execute_read(None, [str(path)], None))
+        assert len(messages) == 1
+        assert "Permission denied" in messages[0].content
+    finally:
+        path.chmod(stat.S_IRUSR | stat.S_IWUSR)
+
+
+@pytest.mark.skipif(os.getuid() == 0, reason="root bypasses permissions")
+def test_read_permission_denied_directory(tmp_path: Path):
+    """Test that a directory with no read permission returns Permission denied."""
+    subdir = tmp_path / "locked"
+    subdir.mkdir()
+    (subdir / "file.txt").write_text("content")
+    subdir.chmod(0o000)
+
+    try:
+        messages = list(execute_read(None, [str(subdir)], None))
+        assert len(messages) == 1
+        assert "Permission denied" in messages[0].content
+    finally:
+        subdir.chmod(stat.S_IRWXU)
+
+
+def test_read_directory_truncated(tmp_path: Path):
+    """Test that directories with >100 entries show a truncation notice."""
+    for i in range(101):
+        (tmp_path / f"file_{i:03d}.txt").write_text("")
+
+    messages = list(execute_read(None, [str(tmp_path)], None))
+    assert len(messages) == 1
+    assert "more entries" in messages[0].content
+
+
+def test_read_not_a_file(tmp_path: Path):
+    """Test that a named pipe (non-file, non-dir) returns 'Not a file'."""
+    fifo = tmp_path / "myfifo"
+    os.mkfifo(str(fifo))
+
+    messages = list(execute_read(None, [str(fifo)], None))
+    assert len(messages) == 1
+    assert "Not a file" in messages[0].content


### PR DESCRIPTION
## Summary

Extend the `read` tool to accept multiple newline-separated paths in a single
code block, so the agent can grab context from several files in one tool call
instead of N sequential ones.

```markdown
```read
gptme/tools/read.py
gptme/tools/save.py
gptme/tools/patch.py
\`\`\`
```

Single-path semantics preserved (`read foo.py` still works as before). Line-range
params (`start_line`/`end_line`) only apply to single-file reads and emit a notice
if used with a batch. Blank lines and `# ...` comments inside the code block are
skipped, so callers can group paths with section comments.

## Why

Inspired by [Dirac](https://github.com/dirac-run/dirac) (currently #1 on
TerminalBench 2.0 at 65.2%), which attributes part of its ~64.8% lower API cost
to multi-file batching: a single LLM roundtrip can read several files before
committing to an edit, instead of repeating context headers and cache pressure
across sequential reads.

This is the smallest concrete win from idea-backlog #187.

## Behavior summary

| Input | Behavior |
|-------|----------|
| `path` kwarg or args | Single read (unchanged) |
| Code block with one line | Single read (unchanged) |
| Code block with N lines | One read per line, in order |
| `# ...` line | Skipped |
| Empty line | Skipped |
| Missing path inside batch | Per-path error message; batch continues |
| `start_line`/`end_line` + N>1 paths | Notice emitted, params ignored |

## Test plan

- [x] All 11 existing read-tool tests still pass
- [x] New tests cover: multi-file batch, comment/blank skipping, partial failure (missing file mid-batch), line-range ignored notice, single-path-via-code unchanged
- [x] `mypy gptme/tools/read.py` passes
- [x] `ruff check` + `ruff format` clean
- [x] Pre-commit clean (Python 3.10 compat: avoided `\\n` in f-string)

## Follow-ups (out of scope)

- Idea-backlog #188: TerminalBench 2.0 baseline for gptme
- Hash-anchored edits (Dirac's other efficiency win) — would touch `patch.py`
  and is a larger change

Co-Authored-By: Bob <bob@superuserlabs.org>