### PR TITLE
fix(webui): gitignore bun.lockb to prevent silent CF Pages breakage

### DIFF
--- a/webui/.gitignore
+++ b/webui/.gitignore
@@ -12,6 +12,13 @@ dist
 dist-ssr
 *.local
 
+# bun is not a supported install path for webui (see #2277).
+# Cloudflare Pages prefers bun when bun.lockb exists, which resolves
+# different package versions than package-lock.json and breaks the
+# preview build. Ignore the lockfile so a stray local `bun install`
+# can't silently re-break CF Pages.
+bun.lockb
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/webui/.gitignore
+++ b/webui/.gitignore
@@ -18,6 +18,7 @@ dist-ssr
 # preview build. Ignore the lockfile so a stray local `bun install`
 # can't silently re-break CF Pages.
 bun.lockb
+bun.lock
 
 # Editor directories and files
 .vscode/*


### PR DESCRIPTION
## Summary

A stray `bun install` regenerates `webui/bun.lockb`. When committed, Cloudflare Pages prefers bun over npm and resolves newer package versions than `package-lock.json`, silently re-breaking preview builds — the root cause of #2269.

This adds `bun.lockb` to `webui/.gitignore` so the failure mode can't recur.

Tracks #2277 (which captures the broader "bun has never produced a working build" story). The `webui/wrangler.toml` enforcement from #2270 forces npm on CF Pages but does not stop `bun.lockb` from being committed; this PR closes that gap.

## Test plan

- [ ] CI passes (this is gitignore-only, no build impact)
- [ ] Verify `git status` shows `bun.lockb` as ignored if regenerated locally