### PR TITLE
fix(webui): remove unsupported [build] key from wrangler.toml

### DIFF
--- a/webui/wrangler.toml
+++ b/webui/wrangler.toml
@@ -1,10 +1,7 @@
-# Cloudflare Pages build configuration
-# Forces npm over bun, even when bun is in the CF Pages build environment.
-# Without this, CF Pages auto-detects bun and resolves newer package versions
-# than the pinned npm lockfile, causing TypeScript errors.
-# See: https://github.com/gptme/gptme/issues/2269
+# Cloudflare Pages configuration
+# pages_build_output_dir tells CF Pages where Vite puts the build output.
+# The [build] section is NOT supported by CF Pages (Workers-only) — build
+# command must be configured in the CF Pages dashboard.
+# See: https://github.com/gptme/gptme/issues/2277
 name = "gptme-webui"
 pages_build_output_dir = "dist"
-
-[build]
-command = "npm ci && npm run build"


### PR DESCRIPTION
## Problem

CF Pages is failing with:
```
Configuration file for Pages projects does not support "build"
```

The `[build]` section added in #2270 (to enforce npm over bun) is a Workers-only key — CF Pages rejects it entirely, breaking every deployment since merge.

## Fix

Remove the `[build]` section. After #2278 gitignored `bun.lockb`, CF Pages auto-detects the package manager from `package-lock.json` and uses npm — so the override is no longer needed anyway.

The `pages_build_output_dir = "dist"` line stays; that field is valid for CF Pages and tells Wrangler where Vite outputs the build.

If the default npm build ever needs a custom command, it must be set in the CF Pages dashboard (Build settings → Build command), not in `wrangler.toml`.

Fixes #2277