### PR TITLE
fix(webui): remove dead Lovable bootstrap script

### DIFF
--- a/webui/index.html
+++ b/webui/index.html
@@ -31,7 +31,6 @@
 
   <body>
     <div id="root"></div>
-    <script src="https://cdn.gpteng.co/gptengineer.js" type="module"></script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary

Remove the leftover `<script src="https://cdn.gpteng.co/gptengineer.js">` tag from `webui/index.html`. It's a vestige of the original Lovable scaffolding — the remote endpoint now serves 0 bytes and forces revalidation on every page load:

```
$ curl -sI https://cdn.gpteng.co/gptengineer.js
HTTP/2 200
content-length: 0
cache-control: max-age=0, must-revalidate
```

So every `chat.gptme.org` page load currently pays DNS + TLS handshake + RTT to fetch nothing.

## Why

Found during the chat.gptme.org perf audit in #2280. This is the trivial part of that audit — the other two findings (HTML shell `cf-cache-status: DYNAMIC`, hashed-asset `must-revalidate`) require Cloudflare Pages config changes and stay on #2280 for discussion.

## Test plan

- [ ] CF Pages preview build succeeds
- [ ] App still loads on the preview URL
- [ ] No console errors related to missing `gptengineer.js` (there shouldn't be — nothing in `webui/src/` imports or references it)

Closes part of #2280.