### PR TITLE
feat(webui): add _headers for CF Pages cache policies

### DIFF
--- a/webui/public/_headers
+++ b/webui/public/_headers
@@ -2,12 +2,12 @@
 # Audit: knowledge/research/2026-04-28-chat-gptme-org-perf-audit.md
 # Issue: https://github.com/gptme/gptme/issues/2280
 
-# SPA shell — short cache, long stale-while-revalidate so deploys roll
-# the cache forward while visitors still see fresh content quickly.
-/
-  Cache-Control: public, max-age=300, stale-while-revalidate=86400
-
-/index.html
+# SPA shell + deep links — `/*` covers `/`, `/index.html`, and SPA routes
+# (`/chat/...`, `/settings`, etc.) that CF Pages serves via the index.html
+# fallback. Short cache + long stale-while-revalidate lets deploys roll the
+# cache forward while visitors still see fresh content quickly. The more
+# specific `/assets/*` rule below takes precedence for hashed assets.
+/*
   Cache-Control: public, max-age=300, stale-while-revalidate=86400
 
 # Hashed assets are immutable by construction (filename includes content hash),

--- a/webui/public/_headers
+++ b/webui/public/_headers
@@ -1,0 +1,16 @@
+# Cloudflare Pages cache headers
+# Audit: knowledge/research/2026-04-28-chat-gptme-org-perf-audit.md
+# Issue: https://github.com/gptme/gptme/issues/2280
+
+# SPA shell — short cache, long stale-while-revalidate so deploys roll
+# the cache forward while visitors still see fresh content quickly.
+/
+  Cache-Control: public, max-age=300, stale-while-revalidate=86400
+
+/index.html
+  Cache-Control: public, max-age=300, stale-while-revalidate=86400
+
+# Hashed assets are immutable by construction (filename includes content hash),
+# so we can drop revalidation entirely and let the browser keep the cached copy.
+/assets/*
+  Cache-Control: public, max-age=31536000, immutable


### PR DESCRIPTION
Implements the two remaining cache-policy fixes from #2280 (the dead
Lovable script was already removed in #2281).

## Changes

**New file: `webui/public/_headers`** (Cloudflare Pages header rules)

- **HTML shell** (`/` and `/index.html`): Was `cf-cache-status: DYNAMIC`
  on every request because origin was sending `max-age=0, must-revalidate`.
  Now `max-age=300, stale-while-revalidate=86400` — CF edges cache it and
  serve stale while revalidating in the background, so deploys roll the
  cache forward quickly without hammering origin.

- **Hashed assets** (`/assets/*`): Was `must-revalidate, max-age=14400`
  (4h) despite filenames encoding a content hash. Now `immutable,
  max-age=31536000` (1y) — no revalidation round-trips for files that
  can never change under the same URL.

## Verification

After this lands on CF Pages, expected behavior:
```
$ curl -sI https://chat.gptme.org/ | grep -i 'cache\|cf-cache'
# cf-cache-status: HIT (or MISS on first request, HIT on subsequent)
# cache-control: public, max-age=300, stale-while-revalidate=86400

$ curl -sI https://chat.gptme.org/assets/index-*.js | grep cache-control
# cache-control: public, max-age=31536000, immutable
```

Closes #2280