### PR TITLE
feat(tauri): sync version to 0.31.0 and show server version in About panel

### DIFF
--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -186,10 +186,13 @@ def api_root():
 
     provider_configured = get_default_model() is not None
 
+    from gptme.__version__ import __version__
+
     return flask.jsonify(
         {
             "message": "gptme v2 API",
             "documentation": "https://gptme.org/docs/server.html",
+            "version": __version__,
             "capabilities": capabilities,
             "provider_configured": provider_configured,
         }

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -18,6 +18,7 @@ import flask
 from dateutil.parser import isoparse
 from flask import request
 
+from gptme.__version__ import __version__
 from gptme.config import (
     ChatConfig,
     Config,
@@ -185,8 +186,6 @@ def api_root():
         capabilities.update(provider.capabilities)
 
     provider_configured = get_default_model() is not None
-
-    from gptme.__version__ import __version__
 
     return flask.jsonify(
         {

--- a/gptme/server/openapi_docs.py
+++ b/gptme/server/openapi_docs.py
@@ -147,6 +147,7 @@ class ApiRootResponse(BaseModel):
 
     message: str = Field(..., description="API description")
     documentation: str = Field(..., description="Documentation URL")
+    version: str = Field(..., description="gptme server version")
     capabilities: ApiCapabilities = Field(
         ..., description="Advertised optional server capabilities"
     )

--- a/tauri/package.json
+++ b/tauri/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gptme-tauri",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.31.0",
   "type": "module",
   "scripts": {
     "tauri": "tauri"

--- a/tauri/src-tauri/Cargo.toml
+++ b/tauri/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gptme-tauri"
-version = "0.1.0"
+version = "0.31.0"
 description = "Desktop application for gptme"
 authors = ["Brayo", "Erik Bjäreholt"]
 edition = "2021"

--- a/tauri/src-tauri/tauri.conf.json
+++ b/tauri/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "gptme-tauri",
-  "version": "0.1.0",
+  "version": "0.31.0",
   "identifier": "org.gptme.tauri",
   "build": {
     "beforeDevCommand": "cd ../webui && npm run dev",

--- a/webui/src/components/SettingsModal.tsx
+++ b/webui/src/components/SettingsModal.tsx
@@ -19,6 +19,7 @@ import { cn } from '@/lib/utils';
 import { ServerConfiguration } from '@/components/settings/ServerConfiguration';
 import { use$ } from '@legendapp/state/react';
 import { settingsModal$, type SettingsCategory } from '@/stores/settingsModal';
+import { getPrimaryClient } from '@/stores/serverClients';
 export type { SettingsCategory } from '@/stores/settingsModal';
 export { settingsModal$ } from '@/stores/settingsModal';
 
@@ -65,6 +66,17 @@ export const SettingsModal = forwardRef<HTMLButtonElement, SettingsModalProps>(
     const { theme, setTheme } = useTheme();
     const [open, setOpen] = useState(false);
     const [activeCategory, setActiveCategory] = useState<SettingsCategory>('appearance');
+    const [serverVersion, setServerVersion] = useState<string | null>(null);
+
+    useEffect(() => {
+      if (activeCategory !== 'about') return;
+      const client = getPrimaryClient();
+      if (!client) return;
+      client
+        .getServerInfo()
+        .then((info) => setServerVersion(info.version ?? null))
+        .catch(() => setServerVersion(null));
+    }, [activeCategory]);
 
     // Allow external code to open the modal to a specific category
     const externalRequest = use$(settingsModal$);
@@ -296,6 +308,13 @@ export const SettingsModal = forwardRef<HTMLButtonElement, SettingsModalProps>(
               </div>
 
               <div className="space-y-4">
+                {serverVersion && (
+                  <div className="space-y-1">
+                    <h4 className="text-sm font-medium">Version</h4>
+                    <p className="font-mono text-sm text-muted-foreground">gptme {serverVersion}</p>
+                  </div>
+                )}
+
                 <div className="space-y-3">
                   <h4 className="text-sm font-medium">Related Projects</h4>
                   <div className="flex flex-col space-y-2">

--- a/webui/src/utils/api.ts
+++ b/webui/src/utils/api.ts
@@ -655,6 +655,11 @@ export class ApiClient {
     return info;
   }
 
+  async getServerInfo(): Promise<{ version?: string }> {
+    const data = await this.fetchJson<{ version?: string }>(`${this.baseUrl}/api/v2`);
+    return data;
+  }
+
   async getConversations(limit: number = 100): Promise<ConversationSummary[]> {
     if (!this.isConnected) {
       throw new ApiClientError('Not connected to API');

--- a/webui/src/utils/api.ts
+++ b/webui/src/utils/api.ts
@@ -656,6 +656,9 @@ export class ApiClient {
   }
 
   async getServerInfo(): Promise<{ version?: string }> {
+    if (!this.isConnected) {
+      throw new ApiClientError('Not connected to API');
+    }
     const data = await this.fetchJson<{ version?: string }>(`${this.baseUrl}/api/v2`);
     return data;
   }


### PR DESCRIPTION
Fixes #2285

## Changes

**Tauri version sync** (Cargo.toml, tauri.conf.json, tauri/package.json):
- Default version updated from `0.1.0` → `0.31.0` so Android APK builds show the correct version
- Desktop release CI already patches these from the git tag at build time, but local/APK builds were still showing `0.1.0`

**Server API**:
- Add `version` field to `/api/v2` response, returning the gptme Python package version

**WebUI About panel** (Settings → About):
- Add `getServerInfo()` method to `ApiClient`
- Fetch server version on About tab open and display it as `gptme <version>`

## Screenshot
After this change, Settings → About shows:
```
Version
gptme 0.31.0
```