### PR TITLE
fix(webui): app-wide safe-area insets via Sheet primitive

### DIFF
--- a/webui/src/components/ui/sheet.tsx
+++ b/webui/src/components/ui/sheet.tsx
@@ -48,7 +48,8 @@ const sheetVariants = cva(
 );
 
 interface SheetContentProps
-  extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
+  extends
+    React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
     VariantProps<typeof sheetVariants> {}
 
 const SheetContent = React.forwardRef<
@@ -59,7 +60,13 @@ const SheetContent = React.forwardRef<
     <SheetOverlay />
     <SheetPrimitive.Content ref={ref} className={cn(sheetVariants({ side }), className)} {...props}>
       {children}
-      <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
+      <SheetPrimitive.Close
+        className="absolute rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary"
+        style={{
+          top: 'calc(1rem + env(safe-area-inset-top, 0px))',
+          right: 'calc(1rem + env(safe-area-inset-right, 0px))',
+        }}
+      >
         <X className="h-4 w-4" />
         <span className="sr-only">Close</span>
       </SheetPrimitive.Close>
@@ -68,14 +75,19 @@ const SheetContent = React.forwardRef<
 ));
 SheetContent.displayName = SheetPrimitive.Content.displayName;
 
-const SheetHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
-  <div className={cn('flex flex-col space-y-2 text-center sm:text-left', className)} {...props} />
+const SheetHeader = ({ className, style, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn('flex flex-col space-y-2 text-center sm:text-left', className)}
+    style={{ marginTop: 'env(safe-area-inset-top, 0px)', ...style }}
+    {...props}
+  />
 );
 SheetHeader.displayName = 'SheetHeader';
 
-const SheetFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+const SheetFooter = ({ className, style, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
     className={cn('flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2', className)}
+    style={{ marginBottom: 'env(safe-area-inset-bottom, 0px)', ...style }}
     {...props}
   />
 );


### PR DESCRIPTION
## Summary

Follow-up to #2284. Erik tested the v2 APK (`ErikBjare/bob#660`) and reported that the hamburger menu still sits under the status-bar on notched phones — the `Navigation` title and the X close button are partly hidden behind the notch. He explicitly asked for an **app-wide** fix at the shadcn primitive layer, not per-container.

## Root cause

`#2284` patched `MenuBar` and `MobileBottomNav` directly, but the navigation drawer is a shadcn `Sheet` (`side="left"`, full-height via `inset-y-0`). Sheets cover the entire viewport including the notch area, and nothing inside `SheetContent` was inset-aware.

## Change

Push the safe-area handling into `webui/src/components/ui/sheet.tsx`:

- **`SheetClose` (the X button)**: position via `calc(1rem + env(safe-area-inset-top, 0px))` and `calc(1rem + env(safe-area-inset-right, 0px))` so the tap target clears the notch on portrait and landscape notches alike.
- **`SheetHeader`**: `marginTop: env(safe-area-inset-top, 0px)`. Margin (not padding) is intentional — it composes cleanly with consumer-supplied padding (`MainLayout` uses `<SheetContent className="p-0">` + `<SheetHeader className="p-4">`) instead of fighting it via specificity.
- **`SheetFooter`**: `marginBottom: env(safe-area-inset-bottom, 0px)` for symmetry with the home-bar area.

Fallback is `0px`, so desktop and non-notched devices are unaffected.

## Why not Dialog too

`DialogContent` is centered via `translate-y -50%`. In the gptme webui it always renders within the viewport (`max-w-lg`, content-sized height), so it doesn't reach the notch. Adding margin to `DialogHeader`/`DialogFooter` would create unwanted spacing on notched phones for centered modals. Left for a separate PR if a future use ever needs it.

## Test plan

- [x] `tsc --noEmit -p webui/tsconfig.app.json` passes
- [x] `vite build` produces a clean production bundle
- [x] `eslint webui/src/components/ui/sheet.tsx` clean
- [ ] Erik smoke-tests the next gptme-tauri Android APK (notched phone) — verify the hamburger menu's `Navigation` title and X close button now clear the status bar.

Refs: ErikBjare/bob#660