### PR TITLE
feat(shell): make output truncation thresholds configurable via env vars

### DIFF
--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -7,6 +7,14 @@ Configuration:
         - Set to 0 to disable timeout
         - Invalid values default to 1200 seconds (20 minutes)
         - If not set, defaults to 1200 seconds (20 minutes)
+
+    GPTME_SHELL_TRUNC_PRE_TOKENS / GPTME_SHELL_TRUNC_POST_TOKENS: Override the
+    head/tail token budget for stdout truncation. Defaults: 2000 / 8000.
+    GPTME_SHELL_TRUNC_STDERR_PRE_TOKENS / GPTME_SHELL_TRUNC_STDERR_POST_TOKENS:
+    Same overrides for stderr. Defaults: 2000 / 2000. Lowering these makes the
+    truncation path fire on smaller outputs, which surfaces savings telemetry
+    in `context-savings.jsonl` and the `/context` command. Invalid values fall
+    back to defaults.
 """
 
 import atexit
@@ -1016,6 +1024,38 @@ def preview_shell(cmd: str, _: Path | None) -> str:
     return cmd
 
 
+def _get_truncation_budget(
+    pre_env: str,
+    post_env: str,
+    default_pre: int,
+    default_post: int,
+) -> tuple[int, int]:
+    """Resolve head/tail token budgets for output truncation.
+
+    Reads ``pre_env`` and ``post_env`` env vars, falling back to defaults on
+    missing or invalid values. Negative or zero values fall back too — the
+    truncation path requires both to be positive.
+    """
+
+    def _resolve(name: str, default: int) -> int:
+        raw = os.environ.get(name)
+        if raw is None:
+            return default
+        try:
+            value = int(raw)
+        except ValueError:
+            logger.warning("Invalid %s value: %r, using default %d", name, raw, default)
+            return default
+        if value <= 0:
+            logger.warning(
+                "Non-positive %s value: %d, using default %d", name, value, default
+            )
+            return default
+        return value
+
+    return _resolve(pre_env, default_pre), _resolve(post_env, default_post)
+
+
 def _format_shell_output(
     cmd: str,
     stdout: str,
@@ -1033,11 +1073,31 @@ def _format_shell_output(
     stderr = strip_ansi_codes(stderr)
 
     # Apply shortening logic with output storage
+    pre_tokens, post_tokens = _get_truncation_budget(
+        "GPTME_SHELL_TRUNC_PRE_TOKENS",
+        "GPTME_SHELL_TRUNC_POST_TOKENS",
+        default_pre=2000,
+        default_post=8000,
+    )
+    stderr_pre_tokens, stderr_post_tokens = _get_truncation_budget(
+        "GPTME_SHELL_TRUNC_STDERR_PRE_TOKENS",
+        "GPTME_SHELL_TRUNC_STDERR_POST_TOKENS",
+        default_pre=2000,
+        default_post=2000,
+    )
     stdout = _shorten_stdout(
-        stdout, pre_tokens=2000, post_tokens=8000, logdir=logdir, cmd=cmd
+        stdout,
+        pre_tokens=pre_tokens,
+        post_tokens=post_tokens,
+        logdir=logdir,
+        cmd=cmd,
     )
     stderr = _shorten_stdout(
-        stderr, pre_tokens=2000, post_tokens=2000, logdir=logdir, cmd=f"{cmd} (stderr)"
+        stderr,
+        pre_tokens=stderr_pre_tokens,
+        post_tokens=stderr_post_tokens,
+        logdir=logdir,
+        cmd=f"{cmd} (stderr)",
     )
 
     # Format header

--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -1030,14 +1030,6 @@ def preview_shell(cmd: str, _: Path | None) -> str:
     return cmd
 
 
-# Default token budgets for shell output truncation.
-# Override at runtime via env vars (see module docstring).
-_TRUNC_PRE_TOKENS_DEFAULT = 2000
-_TRUNC_POST_TOKENS_DEFAULT = 8000
-_TRUNC_STDERR_PRE_TOKENS_DEFAULT = 2000
-_TRUNC_STDERR_POST_TOKENS_DEFAULT = 2000
-
-
 def _get_truncation_budget(
     pre_env: str,
     post_env: str,

--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -88,6 +88,12 @@ def strip_ansi_codes(text: str) -> str:
 
 logger = logging.getLogger(__name__)
 
+# Default token budgets for shell output truncation (overridable via env vars).
+_TRUNC_PRE_TOKENS_DEFAULT = 2000
+_TRUNC_POST_TOKENS_DEFAULT = 8000
+_TRUNC_STDERR_PRE_TOKENS_DEFAULT = 2000
+_TRUNC_STDERR_POST_TOKENS_DEFAULT = 2000
+
 
 candidates = (
     # platform-specific
@@ -1076,14 +1082,14 @@ def _format_shell_output(
     pre_tokens, post_tokens = _get_truncation_budget(
         "GPTME_SHELL_TRUNC_PRE_TOKENS",
         "GPTME_SHELL_TRUNC_POST_TOKENS",
-        default_pre=2000,
-        default_post=8000,
+        default_pre=_TRUNC_PRE_TOKENS_DEFAULT,
+        default_post=_TRUNC_POST_TOKENS_DEFAULT,
     )
     stderr_pre_tokens, stderr_post_tokens = _get_truncation_budget(
         "GPTME_SHELL_TRUNC_STDERR_PRE_TOKENS",
         "GPTME_SHELL_TRUNC_STDERR_POST_TOKENS",
-        default_pre=2000,
-        default_post=2000,
+        default_pre=_TRUNC_STDERR_PRE_TOKENS_DEFAULT,
+        default_post=_TRUNC_STDERR_POST_TOKENS_DEFAULT,
     )
     stdout = _shorten_stdout(
         stdout,

--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -1030,6 +1030,14 @@ def preview_shell(cmd: str, _: Path | None) -> str:
     return cmd
 
 
+# Default token budgets for shell output truncation.
+# Override at runtime via env vars (see module docstring).
+_TRUNC_PRE_TOKENS_DEFAULT = 2000
+_TRUNC_POST_TOKENS_DEFAULT = 8000
+_TRUNC_STDERR_PRE_TOKENS_DEFAULT = 2000
+_TRUNC_STDERR_POST_TOKENS_DEFAULT = 2000
+
+
 def _get_truncation_budget(
     pre_env: str,
     post_env: str,
@@ -1041,6 +1049,9 @@ def _get_truncation_budget(
     Reads ``pre_env`` and ``post_env`` env vars, falling back to defaults on
     missing or invalid values. Negative or zero values fall back too — the
     truncation path requires both to be positive.
+
+    Env vars are re-read on every call so that users can adjust thresholds at
+    runtime (e.g. via a shell alias) without restarting gptme.
     """
 
     def _resolve(name: str, default: int) -> int:

--- a/tests/test_tools_shell.py
+++ b/tests/test_tools_shell.py
@@ -7,6 +7,8 @@ import pytest
 
 from gptme.tools.shell import (
     ShellSession,
+    _format_shell_output,
+    _get_truncation_budget,
     _shorten_stdout,
     is_denylisted,
     split_commands,
@@ -484,6 +486,68 @@ def test_shorten_stdout_records_context_savings(tmp_path):
     assert rows[0]["source"] == "shell"
     assert rows[0]["command_info"] == "git log --oneline"
     assert rows[0]["saved_tokens"] > 0
+
+
+def test_truncation_budget_default(monkeypatch):
+    monkeypatch.delenv("GPTME_SHELL_TRUNC_PRE_TOKENS", raising=False)
+    monkeypatch.delenv("GPTME_SHELL_TRUNC_POST_TOKENS", raising=False)
+    pre, post = _get_truncation_budget(
+        "GPTME_SHELL_TRUNC_PRE_TOKENS",
+        "GPTME_SHELL_TRUNC_POST_TOKENS",
+        default_pre=2000,
+        default_post=8000,
+    )
+    assert (pre, post) == (2000, 8000)
+
+
+def test_truncation_budget_env_override(monkeypatch):
+    monkeypatch.setenv("GPTME_SHELL_TRUNC_PRE_TOKENS", "300")
+    monkeypatch.setenv("GPTME_SHELL_TRUNC_POST_TOKENS", "1500")
+    pre, post = _get_truncation_budget(
+        "GPTME_SHELL_TRUNC_PRE_TOKENS",
+        "GPTME_SHELL_TRUNC_POST_TOKENS",
+        default_pre=2000,
+        default_post=8000,
+    )
+    assert (pre, post) == (300, 1500)
+
+
+def test_truncation_budget_invalid_falls_back(monkeypatch):
+    monkeypatch.setenv("GPTME_SHELL_TRUNC_PRE_TOKENS", "not-a-number")
+    monkeypatch.setenv("GPTME_SHELL_TRUNC_POST_TOKENS", "0")
+    pre, post = _get_truncation_budget(
+        "GPTME_SHELL_TRUNC_PRE_TOKENS",
+        "GPTME_SHELL_TRUNC_POST_TOKENS",
+        default_pre=2000,
+        default_post=8000,
+    )
+    assert (pre, post) == (2000, 8000)
+
+
+def test_format_shell_output_lower_threshold_records_savings(monkeypatch, tmp_path):
+    """Lowered env-var threshold should make truncation fire on smaller outputs."""
+    monkeypatch.setenv("GPTME_SHELL_TRUNC_PRE_TOKENS", "20")
+    monkeypatch.setenv("GPTME_SHELL_TRUNC_POST_TOKENS", "20")
+
+    stdout = "\n".join(f"line {i} with some content to bulk it up" for i in range(200))
+
+    output = _format_shell_output(
+        cmd="echo loop",
+        stdout=stdout,
+        stderr="",
+        returncode=0,
+        interrupted=False,
+        allowlisted=False,
+        logdir=tmp_path,
+    )
+
+    assert "output truncated" in output or "lines truncated" in output
+    ledger = tmp_path / "context-savings.jsonl"
+    assert ledger.exists()
+    rows = [
+        json.loads(line) for line in ledger.read_text().splitlines() if line.strip()
+    ]
+    assert any(row["source"] == "shell" and row["saved_tokens"] > 0 for row in rows)
 
 
 def test_is_denylisted_pattern_matches():


### PR DESCRIPTION
## Summary

Adds env vars to override the head/tail token budget used by shell tool output truncation:

- `GPTME_SHELL_TRUNC_PRE_TOKENS` / `GPTME_SHELL_TRUNC_POST_TOKENS` — stdout (defaults: 2000 / 8000)
- `GPTME_SHELL_TRUNC_STDERR_PRE_TOKENS` / `GPTME_SHELL_TRUNC_STDERR_POST_TOKENS` — stderr (defaults: 2000 / 2000)

Defaults unchanged. Invalid or non-positive values fall back to defaults.

## Why

Empirical observation: in 47+ recent gptme conversations after #2213 merged, **zero** `context-savings.jsonl` files were created — the existing 10K-token default rarely fires. Most shell outputs are sub-10k cumulatively, not single giant dumps, so the truncation path is cold and the new `/context` savings panel has nothing to show.

This PR doesn't pick a new default. It just lets users opt into a lower threshold to surface telemetry and gather distribution data before any global change. The existing `record_context_savings()` ledger and `/context` summary now have something to chew on.

Example usage:

```bash
GPTME_SHELL_TRUNC_PRE_TOKENS=300 GPTME_SHELL_TRUNC_POST_TOKENS=1500 gptme ...
```

After a few sessions, inspect `context-savings.jsonl` to see the distribution of `original_tokens` per shell call.

## Test plan

- [x] `test_truncation_budget_default` — env unset → defaults
- [x] `test_truncation_budget_env_override` — env values used
- [x] `test_truncation_budget_invalid_falls_back` — non-numeric / non-positive → defaults
- [x] `test_format_shell_output_lower_threshold_records_savings` — end-to-end: lowered threshold causes truncation + savings.jsonl write
- [x] Existing `tests/test_tools_shell.py` (59 tests) all pass
- [x] `ruff check` + `ruff format` clean