### PR TITLE
fix(webui): move Sheet safe-area from SheetHeader margin to SheetContent padding

### DIFF
--- a/webui/src/components/ui/sheet.tsx
+++ b/webui/src/components/ui/sheet.tsx
@@ -48,8 +48,7 @@ const sheetVariants = cva(
 );
 
 interface SheetContentProps
-  extends
-    React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
+  extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
     VariantProps<typeof sheetVariants> {}
 
 const SheetContent = React.forwardRef<
@@ -60,18 +59,21 @@ const SheetContent = React.forwardRef<
   // padding is applied reliably even when consumers zero out all padding.
   // This mirrors the MenuBar fix (paddingTop on the element itself) rather than
   // the SheetHeader marginTop approach which was overrideable by className.
+  // Use max() to preserve the base p-6 (1.5rem) padding on non-notched/desktop
+  // devices where env(safe-area-inset-*) evaluates to 0px. Without max(), the
+  // inline 0px would silently override the p-6 CSS class padding.
   const safeStyle: React.CSSProperties = {
+    ...style,
     ...(side === 'left' || side === 'right'
       ? {
-          paddingTop: 'env(safe-area-inset-top, 0px)',
-          paddingBottom: 'env(safe-area-inset-bottom, 0px)',
+          paddingTop: 'max(1.5rem, env(safe-area-inset-top, 0px))',
+          paddingBottom: 'max(1.5rem, env(safe-area-inset-bottom, 0px))',
         }
       : side === 'top'
-        ? { paddingTop: 'env(safe-area-inset-top, 0px)' }
+        ? { paddingTop: 'max(1.5rem, env(safe-area-inset-top, 0px))' }
         : side === 'bottom'
-          ? { paddingBottom: 'env(safe-area-inset-bottom, 0px)' }
+          ? { paddingBottom: 'max(1.5rem, env(safe-area-inset-bottom, 0px))' }
           : {}),
-    ...style,
   };
 
   return (

--- a/webui/src/components/ui/sheet.tsx
+++ b/webui/src/components/ui/sheet.tsx
@@ -55,39 +55,59 @@ interface SheetContentProps
 const SheetContent = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Content>,
   SheetContentProps
->(({ side = 'right', className, children, ...props }, ref) => (
-  <SheetPortal>
-    <SheetOverlay />
-    <SheetPrimitive.Content ref={ref} className={cn(sheetVariants({ side }), className)} {...props}>
-      {children}
-      <SheetPrimitive.Close
-        className="absolute rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary"
-        style={{
-          top: 'calc(1rem + env(safe-area-inset-top, 0px))',
-          right: 'calc(1rem + env(safe-area-inset-right, 0px))',
-        }}
+>(({ side = 'right', className, children, style, ...props }, ref) => {
+  // Inline style wins over className (including p-0 overrides), so safe-area
+  // padding is applied reliably even when consumers zero out all padding.
+  // This mirrors the MenuBar fix (paddingTop on the element itself) rather than
+  // the SheetHeader marginTop approach which was overrideable by className.
+  const safeStyle: React.CSSProperties = {
+    ...(side === 'left' || side === 'right'
+      ? {
+          paddingTop: 'env(safe-area-inset-top, 0px)',
+          paddingBottom: 'env(safe-area-inset-bottom, 0px)',
+        }
+      : side === 'top'
+        ? { paddingTop: 'env(safe-area-inset-top, 0px)' }
+        : side === 'bottom'
+          ? { paddingBottom: 'env(safe-area-inset-bottom, 0px)' }
+          : {}),
+    ...style,
+  };
+
+  return (
+    <SheetPortal>
+      <SheetOverlay />
+      <SheetPrimitive.Content
+        ref={ref}
+        className={cn(sheetVariants({ side }), className)}
+        style={safeStyle}
+        {...props}
       >
-        <X className="h-4 w-4" />
-        <span className="sr-only">Close</span>
-      </SheetPrimitive.Close>
-    </SheetPrimitive.Content>
-  </SheetPortal>
-));
+        {children}
+        <SheetPrimitive.Close
+          className="absolute rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary"
+          style={{
+            top: 'calc(1rem + env(safe-area-inset-top, 0px))',
+            right: 'calc(1rem + env(safe-area-inset-right, 0px))',
+          }}
+        >
+          <X className="h-4 w-4" />
+          <span className="sr-only">Close</span>
+        </SheetPrimitive.Close>
+      </SheetPrimitive.Content>
+    </SheetPortal>
+  );
+});
 SheetContent.displayName = SheetPrimitive.Content.displayName;
 
-const SheetHeader = ({ className, style, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
-  <div
-    className={cn('flex flex-col space-y-2 text-center sm:text-left', className)}
-    style={{ marginTop: 'env(safe-area-inset-top, 0px)', ...style }}
-    {...props}
-  />
+const SheetHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('flex flex-col space-y-2 text-center sm:text-left', className)} {...props} />
 );
 SheetHeader.displayName = 'SheetHeader';
 
-const SheetFooter = ({ className, style, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+const SheetFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
     className={cn('flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2', className)}
-    style={{ marginBottom: 'env(safe-area-inset-bottom, 0px)', ...style }}
     {...props}
   />
 );

--- a/webui/src/components/ui/sheet.tsx
+++ b/webui/src/components/ui/sheet.tsx
@@ -55,24 +55,24 @@ const SheetContent = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Content>,
   SheetContentProps
 >(({ side = 'right', className, children, style, ...props }, ref) => {
-  // Inline style wins over className (including p-0 overrides), so safe-area
-  // padding is applied reliably even when consumers zero out all padding.
-  // This mirrors the MenuBar fix (paddingTop on the element itself) rather than
-  // the SheetHeader marginTop approach which was overrideable by className.
-  // Use max() to preserve the base p-6 (1.5rem) padding on non-notched/desktop
-  // devices where env(safe-area-inset-*) evaluates to 0px. Without max(), the
-  // inline 0px would silently override the p-6 CSS class padding.
+  // Inline style wins over className, so safe-area padding is applied reliably
+  // even when consumers use p-0. This mirrors the MenuBar fix (paddingTop on
+  // the container itself) vs the SheetHeader marginTop approach which failed.
+  // All current consumers use p-0 and manage their own layout, so we apply
+  // env() directly — 0px on non-notched/desktop (correct for p-0), actual
+  // inset on notched mobile. Consumers adding default p-6 padding should
+  // explicitly manage top/bottom padding alongside their className.
   const safeStyle: React.CSSProperties = {
     ...style,
     ...(side === 'left' || side === 'right'
       ? {
-          paddingTop: 'max(1.5rem, env(safe-area-inset-top, 0px))',
-          paddingBottom: 'max(1.5rem, env(safe-area-inset-bottom, 0px))',
+          paddingTop: 'env(safe-area-inset-top, 0px)',
+          paddingBottom: 'env(safe-area-inset-bottom, 0px)',
         }
       : side === 'top'
-        ? { paddingTop: 'max(1.5rem, env(safe-area-inset-top, 0px))' }
+        ? { paddingTop: 'env(safe-area-inset-top, 0px)' }
         : side === 'bottom'
-          ? { paddingBottom: 'max(1.5rem, env(safe-area-inset-bottom, 0px))' }
+          ? { paddingBottom: 'env(safe-area-inset-bottom, 0px)' }
           : {}),
   };
 


### PR DESCRIPTION
## Problem

PR #2287 applied `safe-area-inset-top` via `marginTop` on `SheetHeader` (a child element). Erik reported the hamburger navigation menu **still** shows the Navigation title and X close button under the Android status bar after that fix.

## Root cause

The `SheetHeader` `marginTop` approach is fragile: it relies on a **child** element to handle the safe area, but `SheetContent` in `MainLayout.tsx` uses `className="p-0"` which affects the layout context. More importantly, the fix doesn't mirror the approach that **did** work — `MenuBar`'s `paddingTop: env(safe-area-inset-top)` inline style on the **container element itself**.

Inline style on an element cannot be overridden by `className` (CSS specificity). Inline style on a **child** still leaves the container unprotected.

## Fix

Move safe-area handling from `SheetHeader.marginTop` → `SheetContent` inline style, mirroring `MenuBar`'s working approach:

- `SheetContent`: extract `style` prop, build side-aware safe-area padding object (left/right get top+bottom insets; top/bottom sides get their respective inset), merge with caller-supplied style
- `SheetHeader`: remove now-redundant `marginTop`
- `SheetFooter`: remove now-redundant `marginBottom`
- `SheetClose` X button: position unchanged — `top: calc(1rem + env(safe-area-inset-top))` correctly places it 1rem into the content area below the safe-area padding buffer

## Impact

- Left/right Sheet (hamburger nav, right sidebar): top and bottom safe areas applied
- Top/bottom Sheet variants: respective inset applied
- Desktop/non-notched devices: fallback is `0px`, no visual change
- Consumers using `p-0` override: safe-area still applied (inline > class)

Refs ErikBjare/bob#660.