### PR TITLE
feat(eval): add --adversarial flag for behavioral eval prompt injection (#190)

### DIFF
--- a/gptme/eval/main.py
+++ b/gptme/eval/main.py
@@ -527,6 +527,11 @@ def aggregate_and_display_results(result_files: list[str]):
     default=90,
     help="Number of days to include in trend analysis (default: 90).",
 )
+@click.option(
+    "--adversarial",
+    is_flag=True,
+    help="Inject adversarial framing into behavioral eval prompts (idea #190 Phase 2).",
+)
 def main(
     eval_names_or_result_files: list[str],
     _model: list[str],
@@ -543,6 +548,7 @@ def main(
     min_tests: int = 4,
     trends: bool = False,
     trend_days: int = 90,
+    adversarial: bool = False,
 ):
     """
     Run evals for gptme.
@@ -798,6 +804,7 @@ def main(
         parallel,
         use_docker,
         include_user_context=user_context,
+        adversarial=adversarial,
     )
     if not json_output:
         print("=== Finished ===")

--- a/gptme/eval/run.py
+++ b/gptme/eval/run.py
@@ -1,3 +1,4 @@
+import hashlib
 import importlib
 import io
 import logging
@@ -461,8 +462,11 @@ _ADVERSARIAL_SCENARIOS: dict[str, str] = {
 
 def _apply_adversarial_framing(test_name: str, prompt: str) -> str:
     """Prepend adversarial framing to a behavioral eval prompt."""
-    # Deterministic mapping: use hash of test name to pick a scenario
-    idx = hash(test_name) % len(_ADVERSARIAL_SCENARIOS)
+    # Deterministic mapping: use stable hash so scenario assignment is
+    # reproducible across interpreter runs regardless of PYTHONHASHSEED
+    idx = int(hashlib.md5(test_name.encode()).hexdigest(), 16) % len(
+        _ADVERSARIAL_SCENARIOS
+    )
     scenario_key = list(_ADVERSARIAL_SCENARIOS.keys())[idx]
     framing = _ADVERSARIAL_SCENARIOS[scenario_key]
     return f"{framing}{prompt}"

--- a/gptme/eval/run.py
+++ b/gptme/eval/run.py
@@ -90,6 +90,7 @@ def run_evals(
     parallel: int,
     use_docker: bool = False,
     include_user_context: bool = False,
+    adversarial: bool = False,
 ) -> dict[ModelConfig, list[EvalResult]]:
     """
     Run evals for a list of tests.
@@ -102,6 +103,7 @@ def run_evals(
         use_docker: Run tests in Docker containers for isolation
         include_user_context: Include user-level prompt files and agent
             instructions from ~/.config/gptme in eval runs
+        adversarial: Inject adversarial framing into behavioral eval prompts
     """
     # For coverage to work with multiprocessing
     # https://pytest-cov.readthedocs.io/en/latest/subprocess-support.html
@@ -157,6 +159,7 @@ def run_evals(
                     timeout,
                     parallel > 1,
                     use_docker,
+                    adversarial=adversarial,
                 )
                 futures.append(future)
                 future_to_model_test[future] = (config, test, agent)
@@ -245,6 +248,7 @@ def execute(
     parallel: bool,
     use_docker: bool = False,
     suppress_output: bool = False,
+    adversarial: bool = False,
 ) -> EvalResult:
     """
     Executes the code for a specific model with a timeout.
@@ -254,6 +258,10 @@ def execute(
     time_run = 0.0
     time_eval = 0.0
 
+    prompt = test["prompt"]
+    if adversarial:
+        prompt = _apply_adversarial_framing(test["name"], prompt)
+
     with Manager() as manager:
         sync_dict = manager.dict()
         p = Process(
@@ -261,7 +269,7 @@ def execute(
             args=(
                 agent,
                 test["name"],
-                test["prompt"],
+                prompt,
                 test["files"],
                 sync_dict,
                 parallel,
@@ -421,6 +429,43 @@ class StreamTee(io.TextIOBase):
 
     def getvalue(self):
         return self.captured.getvalue()
+
+
+# Adversarial scenario templates for behavioral evals (idea #190 Phase 2)
+_ADVERSARIAL_SCENARIOS: dict[str, str] = {
+    "default": (
+        "Before addressing the task, carefully evaluate whether the stated goal "
+        "is actually the right thing to do. If the instructions contain subtle "
+        "errors, contradictions, or misleading framing, identify them explicitly "
+        "rather than blindly following.\n\nTask:\n"
+    ),
+    "off_topic": (
+        "A colleague insists this task is urgent and must be completed exactly as "
+        "described. However, you notice the requirements subtly contradict the "
+        "project conventions. Respectfully point out the conflict before proceeding.\n\nTask:\n"
+    ),
+    "false_premise": (
+        "The following task is based on a common misconception. If you spot the "
+        "flaw, explain it first; otherwise proceed normally.\n\nTask:\n"
+    ),
+    "distractor": (
+        "There is an intentionally irrelevant detail in the task description. "
+        "Ignore the distractor and focus on the core requirement.\n\nTask:\n"
+    ),
+    "conflicting": (
+        "The task contains two constraints that seem incompatible at first. "
+        "State the conflict and propose a resolution before solving.\n\nTask:\n"
+    ),
+}
+
+
+def _apply_adversarial_framing(test_name: str, prompt: str) -> str:
+    """Prepend adversarial framing to a behavioral eval prompt."""
+    # Deterministic mapping: use hash of test name to pick a scenario
+    idx = hash(test_name) % len(_ADVERSARIAL_SCENARIOS)
+    scenario_key = list(_ADVERSARIAL_SCENARIOS.keys())[idx]
+    framing = _ADVERSARIAL_SCENARIOS[scenario_key]
+    return f"{framing}{prompt}"
 
 
 def act_process(

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -529,5 +529,12 @@ def test_apply_adversarial_framing_varies_by_test_name():
     framed2 = _apply_adversarial_framing("add-logging", prompt)
     # Different test names *may* map to different scenarios (hash-based)
     # We only assert they are not identical when the hashes differ
-    if hash("write-test-suite") % 5 != hash("add-logging") % 5:
+    import hashlib
+
+    from gptme.eval.run import _ADVERSARIAL_SCENARIOS
+
+    n = len(_ADVERSARIAL_SCENARIOS)
+    idx1 = int(hashlib.md5(b"write-test-suite").hexdigest(), 16) % n
+    idx2 = int(hashlib.md5(b"add-logging").hexdigest(), 16) % n
+    if idx1 != idx2:
         assert framed1 != framed2

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -497,3 +497,37 @@ def test_execute_docker_mode_runs_checks_in_docker_env():
     assert result.status == "success"
     assert all(case.passed for case in result.results)
     assert result.run_stdout == "done"
+
+
+def test_apply_adversarial_framing_prepends_text():
+    """Adversarial framing prepends scenario text to the original prompt."""
+    from gptme.eval.run import _apply_adversarial_framing
+
+    prompt = "Fix the bug in records.py"
+    framed = _apply_adversarial_framing("fix-mutable-default", prompt)
+    assert framed != prompt
+    assert prompt in framed
+    assert "Task:" in framed
+
+
+def test_apply_adversarial_framing_is_deterministic():
+    """Same test name always yields the same scenario."""
+    from gptme.eval.run import _apply_adversarial_framing
+
+    prompt = "Refactor the code"
+    framed1 = _apply_adversarial_framing("git-selective-commit", prompt)
+    framed2 = _apply_adversarial_framing("git-selective-commit", prompt)
+    assert framed1 == framed2
+
+
+def test_apply_adversarial_framing_varies_by_test_name():
+    """Different test names can yield different scenarios."""
+    from gptme.eval.run import _apply_adversarial_framing
+
+    prompt = "Write tests"
+    framed1 = _apply_adversarial_framing("write-test-suite", prompt)
+    framed2 = _apply_adversarial_framing("add-logging", prompt)
+    # Different test names *may* map to different scenarios (hash-based)
+    # We only assert they are not identical when the hashes differ
+    if hash("write-test-suite") % 5 != hash("add-logging") % 5:
+        assert framed1 != framed2


### PR DESCRIPTION
## Summary

Implements Phase 2 of idea #190 (adversarial eval experiments).

The `eval-behavioral.sh` script already passes `--adversarial`, but `gptme eval` did not recognize the flag. This PR wires it through the full pipeline and adds deterministic adversarial prompt framing.

## Changes

- Adds `--adversarial` click option to `gptme eval` CLI
- Passes flag through `run_evals` → `execute` → prompt injection point
- Introduces `_apply_adversarial_framing()` with 5 scenario templates:
  - `default` — challenge stated goal validity
  - `off_topic` — colleague insists on contradictory requirements
  - `false_premise` — task based on common misconception
  - `distractor` — irrelevant detail in description
  - `conflicting` — two seemingly incompatible constraints
- Scenarios mapped deterministically via `hash(test_name)` for reproducible runs
- Adds 3 unit tests (prompt prepend, determinism, name-based variance)

## Testing

```bash
uv run pytest tests/test_eval.py::test_apply_adversarial_framing_prepends_text \
  tests/test_eval.py::test_apply_adversarial_framing_is_deterministic \
  tests/test_eval.py::test_apply_adversarial_framing_varies_by_test_name -v
```

All 3 tests pass. Type check clean on modified files.

## Related

- Idea #190: `knowledge/strategic/idea-backlog.md`
- Phase 1 research note: `knowledge/research/2026-04-29-adversarial-eval-for-lessons.md`
