### PR TITLE
test(webui): use ConnectionProbeResult type in ApiContext mocks

### DIFF
--- a/webui/src/contexts/__tests__/ApiContext.test.tsx
+++ b/webui/src/contexts/__tests__/ApiContext.test.tsx
@@ -3,6 +3,7 @@ import { render, waitFor } from '@testing-library/react';
 import { observable } from '@legendapp/state';
 import { QueryClient } from '@tanstack/react-query';
 import { ApiProvider } from '../ApiContext';
+import type { ConnectionProbeResult } from '@/utils/api';
 
 const mockCheckConnection = jest.fn();
 const mockSetConnected = jest.fn();
@@ -20,7 +21,7 @@ const mockToastSuccess = jest.fn();
 const mockToastError = jest.fn();
 
 const isConnected$ = observable(false);
-const lastConnectionResult$ = observable<{ ok: boolean } | null>(null);
+const lastConnectionResult$ = observable<ConnectionProbeResult | null>(null);
 
 const mockClient = {
   isConnected$,
@@ -191,7 +192,12 @@ describe('ApiProvider mobile auto-connect', () => {
     // trying to reach a localhost server, or a misconfigured server CORS policy.
     // These do not recover by retrying within the session.
     mockCheckConnection.mockImplementation(async () => {
-      lastConnectionResult$.set({ ok: false, reason: 'cors' } as { ok: boolean });
+      lastConnectionResult$.set({
+        ok: false,
+        url: 'https://bob.example.com',
+        reason: 'cors',
+        message: 'CORS/PNA error',
+      });
       return false;
     });
 
@@ -213,7 +219,12 @@ describe('ApiProvider mobile auto-connect', () => {
     // Generic network failure (server starting up, transient connectivity)
     // should still retry — the user shouldn't have to manually reconnect.
     mockCheckConnection.mockImplementation(async () => {
-      lastConnectionResult$.set({ ok: false, reason: 'network' } as { ok: boolean });
+      lastConnectionResult$.set({
+        ok: false,
+        url: 'https://bob.example.com',
+        reason: 'network',
+        message: 'Could not reach server',
+      });
       return false;
     });
 


### PR DESCRIPTION
## Summary

Small follow-up to #2290. The CORS/PNA retry-stop tests cast partial mocks as `{ok: boolean}`, which silently lets the mock shape drift from `ConnectionProbeResult` in production. This commit imports the real type and constructs full mock objects so any future shape change to `ConnectionProbeResult` is caught at compile time instead of at runtime.

## Changes

- Import `ConnectionProbeResult` in `ApiContext.test.tsx`
- Replace `observable<{ok: boolean} | null>(null)` with `observable<ConnectionProbeResult | null>(null)`
- Replace `set({ok: false, reason: 'cors'} as {ok: boolean})` with full typed object (adds `url` and `message`)
- Same fix for the network-failure test fixture

## Test plan

- [x] `npm test src/contexts/__tests__/ApiContext.test.tsx` — all 4 tests pass
- [x] `tsc -p tsconfig.app.json --noEmit` — clean
- [ ] CI green

No production behavior change. Test-only.