### PR TITLE
fix(webui): mount SettingsModal in mobile layout so Server settings works on Android

### DIFF
--- a/webui/src/components/MainLayout.tsx
+++ b/webui/src/components/MainLayout.tsx
@@ -9,6 +9,7 @@ import { RightSidebar } from '@/components/RightSidebar';
 import { RightSidebarContent } from '@/components/RightSidebarContent';
 import { TaskCreationDialog } from '@/components/TaskCreationDialog';
 import { SidebarIcons } from '@/components/SidebarIcons';
+import { SettingsModal } from '@/components/SettingsModal';
 import { MobileBottomNav } from '@/components/MobileBottomNav';
 import { UnifiedSidebar } from '@/components/UnifiedSidebar';
 import { AgentsView } from '@/components/AgentsView';
@@ -571,6 +572,9 @@ const MainLayout: FC<Props> = ({ conversationId, taskId }) => {
 
         {/* Mobile Bottom Navigation */}
         <MobileBottomNav />
+
+        {/* Headless SettingsModal mount — desktop has it inside SidebarIcons, mobile needs it here */}
+        <SettingsModal />
 
         <TaskCreationDialog
           open={showCreateTaskDialog}

--- a/webui/src/components/SettingsModal.tsx
+++ b/webui/src/components/SettingsModal.tsx
@@ -371,13 +371,7 @@ export const SettingsModal = forwardRef<HTMLButtonElement, SettingsModalProps>(
 
     return (
       <Dialog open={open} onOpenChange={setOpen}>
-        <DialogTrigger asChild>
-          {children || (
-            <Button variant="ghost" size="icon" aria-label="Open settings">
-              <Settings className="h-4 w-4" />
-            </Button>
-          )}
-        </DialogTrigger>
+        {children !== undefined && <DialogTrigger asChild>{children}</DialogTrigger>}
         <DialogContent className="flex max-h-[80vh] max-w-4xl flex-col overflow-hidden p-0">
           <DialogHeader className="border-b px-6 py-3">
             <DialogTitle className="flex items-center gap-2">


### PR DESCRIPTION
## Problem

On Android/mobile, clicking \"Server settings\" (in the WelcomeView disconnected card or
inside the ServerSelector dropdown) did nothing. Root cause: `SettingsModal` was only
rendered inside `SidebarIcons`, which has `hidden md:flex` — it's never mounted on
viewports < 768px. Any call to `settingsModal$.set({open: true, ...})` fired into
nothing because no component was subscribed to the observable.

## Fix

Two changes:

1. **`SettingsModal`**: when rendered without `children`, skip the `DialogTrigger` entirely
   (was: always rendered a floating Settings icon button as fallback). The modal still
   listens to `settingsModal$` and opens programmatically.

2. **`MainLayout`**: add `<SettingsModal />` (headless — no trigger button) to the mobile
   layout branch. Now the modal is always mounted regardless of viewport size.

Desktop behavior is unchanged: `SidebarIcons` still wraps the Settings gear button in
`<SettingsModal>` as before.

## Test

Build a new APK and tap "Server settings" from the disconnected card or from the
server selector dropdown — the settings modal should open to the Servers tab.

Fixes Erik's report in ErikBjare/bob#660.