### PR TITLE
fix(webui): add Skip button to SetupWizard welcome step

### DIFF
--- a/webui/src/components/SetupWizard.tsx
+++ b/webui/src/components/SetupWizard.tsx
@@ -443,7 +443,10 @@ export function SetupWizard() {
                 <span>Works locally or in the cloud</span>
               </div>
             </div>
-            <DialogFooter className="sm:justify-center">
+            <DialogFooter className="flex-col-reverse gap-2 sm:flex-row sm:justify-center">
+              <Button variant="ghost" onClick={closeWizard}>
+                Skip for now
+              </Button>
               <Button onClick={() => setStep('mode')} className="gap-2">
                 Get started
                 <ArrowRight className="h-4 w-4" />

--- a/webui/src/components/__tests__/SetupWizard.test.tsx
+++ b/webui/src/components/__tests__/SetupWizard.test.tsx
@@ -132,6 +132,25 @@ describe('SetupWizard', () => {
     });
   });
 
+  it('closes the wizard via Skip on the welcome step and persists hasCompletedSetup', async () => {
+    render(
+      <SettingsProvider>
+        <SetupWizard />
+      </SettingsProvider>
+    );
+
+    expect(screen.getByRole('heading', { name: /welcome to gptme/i })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /skip for now/i }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole('heading', { name: /welcome to gptme/i })).not.toBeInTheDocument();
+    });
+
+    expect(JSON.parse(localStorage.getItem('gptme-settings') || '{}')).toMatchObject({
+      hasCompletedSetup: true,
+    });
+  });
+
   it('waits for cloud connection before showing completion', async () => {
     const { rerender } = render(
       <SettingsProvider>


### PR DESCRIPTION
## Summary

Erik reported on ErikBjare/bob#660 that on the v6 Android APK, the "Server settings" button in the disconnected card and the gear icon in the server selector dropdown still don't open anything. The PR #2293 fix mounted SettingsModal in mobile layout (correct), but the SetupWizard auto-opens on first launch and its overlay swallows the click.

## Root cause

`SetupWizard` opens automatically when `!hasCompletedSetup`. Its Radix Dialog overlay (`fixed inset-0 z-50 bg-black/80`) covers the entire viewport. The dialog has:
- `[&>button]:hidden` — hides the X close button
- `onPointerDownOutside={(e) => e.preventDefault()}` — blocks click-outside
- ESC handler — but mobile users have no keyboard

The welcome step had only one button: "Get started". The 'mode' step has "Skip for now", but to reach it the user must first tap "Get started" — which they won't do if they want a custom server config. Result: visible "Server settings" button behind the dimmed overlay, taps swallowed, "nothing happens".

## Fix

Add a "Skip for now" button to the welcome step, mirroring the same button on the 'mode' step (line 501). Uses `flex-col-reverse` on mobile so the primary CTA stays on top, falls back to side-by-side on `sm:` and up.

## Reproduction (Playwright @ 390x844 mobile viewport on chat.gptme.org)

| Step | Before this PR | After this PR |
|---|---|---|
| Initial load | Wizard open, disconnected card visible behind dimmed overlay | Same |
| Tap "Server settings" | Click swallowed by overlay → no-op | Click swallowed (expected — wizard still owns the surface) |
| Skip path | Tap "Get started" → tap "Skip for now" → tap "Server settings" → opens | Tap "Skip for now" (one tap) → tap "Server settings" → opens |

## Test plan

- [x] `jest src/components/__tests__/SetupWizard.test.tsx` — 14/14 pass (1 new test, 13 existing)
- [x] `tsc -p tsconfig.app.json --noEmit` — clean
- [x] Playwright reproduction confirms the wizard now exits in one tap from the welcome step
- [ ] Erik smoke-tests on Android with next APK build (v7)

Refs: ErikBjare/bob#660, gptme/gptme#2293