### PR TITLE
fix(webui): make SetupWizard X close button visible and persist hasCompletedSetup

### DIFF
--- a/webui/src/components/SetupWizard.tsx
+++ b/webui/src/components/SetupWizard.tsx
@@ -419,9 +419,16 @@ export function SetupWizard() {
   };
 
   return (
-    <Dialog open={isOpen} onOpenChange={() => {}}>
+    <Dialog
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) {
+          closeWizard();
+        }
+      }}
+    >
       <DialogContent
-        className="sm:max-w-md [&>button]:hidden"
+        className="sm:max-w-md"
         onPointerDownOutside={(e) => e.preventDefault()}
         onEscapeKeyDown={closeWizard}
       >

--- a/webui/src/components/__tests__/SetupWizard.test.tsx
+++ b/webui/src/components/__tests__/SetupWizard.test.tsx
@@ -62,15 +62,47 @@ jest.mock('@legendapp/state/react', () => ({
   use$: (obs: { get: () => unknown }) => obs.get(),
 }));
 
-jest.mock('@/components/ui/dialog', () => ({
-  Dialog: ({ open, children }: { open: boolean; children: React.ReactNode }) =>
-    open ? <div>{children}</div> : null,
-  DialogContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  DialogDescription: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  DialogFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  DialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  DialogTitle: ({ children }: { children: React.ReactNode }) => <h1>{children}</h1>,
-}));
+// Mock the Dialog primitives. The real DialogContent (from `@/components/ui/dialog`)
+// renders a Radix `<DialogPrimitive.Close>` X button that calls `onOpenChange(false)`
+// when clicked. Mirror that here so tests can exercise the close behavior wired
+// through `onOpenChange` (e.g. the welcome step's X close → closeWizard path).
+jest.mock('@/components/ui/dialog', () => {
+  const DialogContext = (jest.requireActual('react') as typeof import('react')).createContext<
+    ((open: boolean) => void) | null
+  >(null);
+  const useContext = (jest.requireActual('react') as typeof import('react')).useContext;
+  return {
+    Dialog: ({
+      open,
+      onOpenChange,
+      children,
+    }: {
+      open: boolean;
+      onOpenChange?: (open: boolean) => void;
+      children: React.ReactNode;
+    }) =>
+      open ? (
+        <DialogContext.Provider value={onOpenChange ?? null}>
+          <div>{children}</div>
+        </DialogContext.Provider>
+      ) : null,
+    DialogContent: ({ children }: { children: React.ReactNode }) => {
+      const onOpenChange = useContext(DialogContext);
+      return (
+        <div>
+          {children}
+          <button aria-label="Close" onClick={() => onOpenChange?.(false)}>
+            <span>X</span>
+          </button>
+        </div>
+      );
+    },
+    DialogDescription: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    DialogFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    DialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    DialogTitle: ({ children }: { children: React.ReactNode }) => <h1>{children}</h1>,
+  };
+});
 
 jest.mock('@/components/ui/button', () => ({
   Button: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
@@ -141,6 +173,25 @@ describe('SetupWizard', () => {
 
     expect(screen.getByRole('heading', { name: /welcome to gptme/i })).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: /skip for now/i }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole('heading', { name: /welcome to gptme/i })).not.toBeInTheDocument();
+    });
+
+    expect(JSON.parse(localStorage.getItem('gptme-settings') || '{}')).toMatchObject({
+      hasCompletedSetup: true,
+    });
+  });
+
+  it('closes the wizard via the X close button and persists hasCompletedSetup', async () => {
+    render(
+      <SettingsProvider>
+        <SetupWizard />
+      </SettingsProvider>
+    );
+
+    expect(screen.getByRole('heading', { name: /welcome to gptme/i })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /^close$/i }));
 
     await waitFor(() => {
       expect(screen.queryByRole('heading', { name: /welcome to gptme/i })).not.toBeInTheDocument();


### PR DESCRIPTION
## Summary

The SetupWizard's X close button was hidden via `[&>button]:hidden` and `onOpenChange` was a no-op. Combined with `onPointerDownOutside={(e) => e.preventDefault()}`, this left users with only Skip/ESC as escape hatches.

On mobile, users naturally tap on what they want (e.g. "Server settings" visible behind the dim overlay), which gets swallowed by the modal — the exact "nothing happens" symptom Erik reported in [ErikBjare/bob#660](https://github.com/ErikBjare/bob/issues/660#issuecomment-4341708537) on v7 APK testing, even after #2294 added the Skip button.

## Two changes

- Remove `[&>button]:hidden` so Radix's Close X is visible in the corner
- Wire `onOpenChange` to `closeWizard` so the X (and any future external close trigger) persists `hasCompletedSetup` instead of silently closing

## Why not click-outside?

Click-outside still preventDefaults intentionally — accidental dismissal during a multi-step flow (e.g. while typing an API key on the provider step) would lose user progress. ESC + Skip + the X button now provide three clear ways to dismiss.

## Test plan

- [x] New `closes the wizard via the X close button and persists hasCompletedSetup` test verifies the full path
- [x] All 14 existing SetupWizard tests still pass (15/15 total)
- [x] Typecheck clean
- [ ] Erik confirms tap-to-close works on v8 APK (built post-merge)

## Context

Follows the chain: #2293 (mount SettingsModal in mobile) → #2294 (add Skip button) → this PR (make wizard truly dismissable for mobile users who don't realize they need to tap Skip first).