### PR TITLE
fix(ci): route Anthropic tests through OpenRouter to use per-key spend limits

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -193,6 +193,7 @@ jobs:
 
   # API tests: only run requires_api tests, across multiple cheap models
   # Skipped on docs/config-only PRs to reduce API spend (~$30+/day in Haiku costs)
+  # Note: Anthropic tests route through OpenRouter (OPENROUTER_API_KEY) for cost controls
   test-api:
     needs: changes
     # Run on push to master, or on PRs when API-related code changed (and not a fork)
@@ -210,7 +211,7 @@ jobs:
       matrix:
         include:
           - model: 'openai/gpt-4o-mini'
-          - model: 'anthropic/claude-haiku-4-5'
+          - model: 'openrouter/anthropic/claude-haiku-4-5'
           # - model: 'openrouter/minimax/minimax-m2.5'  # disabled: too brittle (SSL errors, inconsistent stop reasons)
           #   experimental: true
 


### PR DESCRIPTION
## Summary

- Switches the `anthropic/claude-haiku-4-5` CI matrix entry to `openrouter/anthropic/claude-haiku-4-5`
- This routes Anthropic API calls through OpenRouter which already has `OPENROUTER_API_KEY` as a CI secret with configurable per-key spending limits
- The direct `ANTHROPIC_API_KEY` was intentionally disabled after accumulating $100+ spend (see #2296)

## Why OpenRouter

- `OPENROUTER_API_KEY` is already a configured CI secret
- OpenRouter supports per-key spending limits, preventing runaway costs
- No code changes needed — gptme already supports `openrouter/anthropic/claude-haiku-4-5` routing

Fixes #2296