### PR TITLE
feat(models): add gpt-5.5 to openai-subscription provider models

### DIFF
--- a/gptme/llm/llm_openai_models.py
+++ b/gptme/llm/llm_openai_models.py
@@ -156,6 +156,17 @@ OPENAI_SUBSCRIPTION_MODELS: dict[str, "_ModelDictMeta"] = {
         "supports_reasoning": True,
         "supports_parallel_tool_calls": True,
     },
+    # GPT-5.5 — flagship released April 2026, 1M context
+    # https://developers.openai.com/api/docs/changelog
+    "gpt-5.5": {
+        "context": 1_000_000,
+        "max_output": 128_000,
+        "price_input": 5,
+        "price_output": 30,
+        "supports_vision": True,
+        "supports_reasoning": True,
+        "supports_parallel_tool_calls": True,
+    },
     # GPT-5.4 — latest flagship, 1M context
     "gpt-5.4": {
         "context": 1_050_000,


### PR DESCRIPTION
GPT-5.5 was already in the regular OpenAI models registry (`_OPENAI_MODELS_ACTIVE`) but not in `OPENAI_SUBSCRIPTION_MODELS`, so gptme couldn't resolve `openai-subscription/gpt-5.5` without falling back to closest-match metadata.

Adds the same model metadata as the active registry entry:
- 1M context
- 128K max output
- $5/$30 pricing (API-equivalent for comparison)
- Vision + reasoning + parallel tool calls support

Closes the gap that was preventing Bob from using GPT-5.5 through the subscription provider for autonomous sessions.