### PR TITLE
docs(readme): drop brittle undated session counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ gptme-agent install   # runs on a schedule
 gptme-agent status    # check on it
 ```
 
-[**Bob**](https://github.com/TimeToBuildBob) is the reference implementation — a production autonomous agent with 1700+ completed sessions. Bob opens PRs, reviews code, fixes CI, manages his own task queue, maintains 100+ behavioral lessons, posts on [Twitter](https://twitter.com/TimeToBuildBob), responds on Discord, and writes [blog posts](https://timetobuildbob.github.io/).
+[**Bob**](https://github.com/TimeToBuildBob) is the reference implementation — a production autonomous agent that's been running continuously since late 2024. Bob opens PRs, reviews code, fixes CI, manages his own task queue, maintains a growing set of behavioral lessons, posts on [Twitter](https://twitter.com/TimeToBuildBob), responds on Discord, and writes [blog posts](https://timetobuildbob.github.io/).
 
 Multiple specialized agents can run in parallel — e.g. Bob (engineering) and [Alice](https://github.com/TimeToLearnAlice) (personal assistant & orchestration) — coordinating through shared infrastructure.
 
@@ -569,7 +569,7 @@ gptme is more than a CLI — it's a platform with a growing ecosystem:
 | [gptme.ai](https://gptme.ai) | Managed cloud service (WIP) |
 
 **Community agents powered by gptme:**
-- [Bob](https://github.com/TimeToBuildBob) — autonomous AI agent, 1700+ sessions, contributes to open source, manages his own tasks
+- [Bob](https://github.com/TimeToBuildBob) — autonomous AI agent, running continuously since late 2024, contributes to open source and manages his own tasks
 - [Alice](https://github.com/TimeToLearnAlice) — personal assistant & agent orchestrator, forked from the same architecture
 
 ## 💬 Community


### PR DESCRIPTION
## Summary

Two undated references to a stale "1700+ sessions" figure in `README.md` get replaced with a stable, date-anchored phrasing that won't drift over time.

- Line 350: "Bob is the reference implementation — a production autonomous agent with 1700+ completed sessions" → "running continuously since late 2024"
- Line 572: "Bob — autonomous AI agent, 1700+ sessions" → "running continuously since late 2024"

The 2026-01 news entry on line 92 keeps its specific count — that line is implicitly anchored by its date prefix and reflects state at a known point.

## Why

Per recent feedback (ErikBjare/bob#711, comment 4347919621): number-go-up metrics in evergreen material (READMEs, wikis) either need a date anchor like "at time of writing" or should be replaced with stable framing. Otherwise they decay and either look wrong or trigger needless updates.

## Test plan

- [x] `git diff` shows only the two intended substitutions
- [x] Pre-commit hooks pass
- [x] Line 92 (2026-01 news entry) untouched, still date-anchored