### PR TITLE
fix(tests): add _restore_logged_warnings fixture and fix caplog context in TestLogWarnOnce

### DIFF
--- a/tests/test_llm_models_resolution.py
+++ b/tests/test_llm_models_resolution.py
@@ -56,6 +56,18 @@ def _restore_model_list_cache():
     listing_mod._model_list_cache_time = old_time
 
 
+@pytest.fixture(autouse=True)
+def _restore_logged_warnings():
+    """Save and restore the _logged_warnings set between tests for isolation."""
+    import gptme.llm.models.resolution as res_mod
+
+    old = res_mod._logged_warnings.copy()
+    res_mod._logged_warnings.clear()
+    yield
+    res_mod._logged_warnings.clear()
+    res_mod._logged_warnings.update(old)
+
+
 # ── Default model state ──────────────────────────────────────────────────
 
 
@@ -303,10 +315,7 @@ class TestLogWarnOnce:
 
     def test_warns_first_time(self, caplog):
         """First call with a message should log it."""
-        from gptme.llm.models.resolution import _logged_warnings
-
         test_msg = f"unique-test-message-{id(self)}"
-        _logged_warnings.discard(test_msg)  # ensure clean state
 
         import logging
 
@@ -317,16 +326,14 @@ class TestLogWarnOnce:
     def test_does_not_warn_second_time(self, caplog):
         """Second call with same message should not log again."""
         test_msg = f"dedup-test-message-{id(self)}"
-        from gptme.llm.models.resolution import _logged_warnings
-
-        _logged_warnings.discard(test_msg)
 
         import logging
 
-        log_warn_once(test_msg)  # first call
+        with caplog.at_level(logging.WARNING):
+            log_warn_once(test_msg)  # first call
         caplog.clear()
         with caplog.at_level(logging.WARNING):
-            log_warn_once(test_msg)  # second call
+            log_warn_once(test_msg)  # second call — should be suppressed
         assert test_msg not in caplog.text
 
 


### PR DESCRIPTION
## Problem

`TestLogWarnOnce::test_does_not_warn_second_time` was failing on master:

```
FAILED tests/test_llm_models_resolution.py::TestLogWarnOnce::test_does_not_warn_second_time
AssertionError: assert 'dedup-test-message-...' not in 'WARNING  gptme.llm.models.resolution:resolution.py:59 ...'
```

The test's first call to `log_warn_once` happened **outside** any `caplog.at_level` context, while the second call was inside one. This inconsistency caused the warning to appear in caplog on the second call when it should have been suppressed by `_logged_warnings`.

## Fix

Two changes in `tests/test_llm_models_resolution.py`:

1. **Add `_restore_logged_warnings` autouse fixture** — saves, clears, and restores the module-level `_logged_warnings` set around each test for proper isolation. This removes the need for the ad-hoc `_logged_warnings.discard(test_msg)` cleanup calls in each test.

2. **Wrap the first call in `caplog.at_level` too** — makes both calls consistent with the same log-level context, matching how `test_warns_first_time` is written.

## Test

```
tests/test_llm_models_resolution.py::TestLogWarnOnce::test_warns_first_time PASSED
tests/test_llm_models_resolution.py::TestLogWarnOnce::test_does_not_warn_second_time PASSED
86 passed, 1 warning in 2.82s
```