### PR TITLE
fix(tests): put both log_warn_once calls inside caplog.at_level context

### DIFF
--- a/tests/test_llm_models_resolution.py
+++ b/tests/test_llm_models_resolution.py
@@ -323,9 +323,9 @@ class TestLogWarnOnce:
 
         import logging
 
-        log_warn_once(test_msg)  # first call
-        caplog.clear()
         with caplog.at_level(logging.WARNING):
+            log_warn_once(test_msg)  # first call
+            caplog.clear()
             log_warn_once(test_msg)  # second call
         assert test_msg not in caplog.text
 


### PR DESCRIPTION
## Problem

`TestLogWarnOnce::test_does_not_warn_second_time` fails intermittently on master CI (run with `-n 16 --log-level INFO`).

The test's first `log_warn_once` call was outside the `caplog.at_level` context manager:

```python
log_warn_once(test_msg)  # first call — outside caplog context!
caplog.clear()
with caplog.at_level(logging.WARNING):
    log_warn_once(test_msg)  # second call
```

With `--log-level INFO` set session-wide, the caplog handler behavior outside `caplog.at_level` can differ from within it. In some pytest+xdist configurations the first warning isn't properly reflected in the logger's in-context capture state, so `_logged_warnings` doesn't deduplicate the second call as expected.

## Fix

Move both calls inside the same `caplog.at_level` context, clearing captured records between them:

```python
with caplog.at_level(logging.WARNING):
    log_warn_once(test_msg)  # first call
    caplog.clear()
    log_warn_once(test_msg)  # second call
assert test_msg not in caplog.text
```

This is consistent, deterministic, and independent of session-level log configuration.

## Test

Both `test_warns_first_time` and `test_does_not_warn_second_time` pass.