### PR TITLE
feat(settings): add Re-run Setup button to re-open setup wizard

### DIFF
--- a/webui/src/components/SettingsModal.tsx
+++ b/webui/src/components/SettingsModal.tsx
@@ -19,6 +19,7 @@ import { cn } from '@/lib/utils';
 import { ServerConfiguration } from '@/components/settings/ServerConfiguration';
 import { use$ } from '@legendapp/state/react';
 import { settingsModal$, type SettingsCategory } from '@/stores/settingsModal';
+import { setupWizard$ } from '@/stores/setupWizard';
 import { getPrimaryClient } from '@/stores/serverClients';
 export type { SettingsCategory } from '@/stores/settingsModal';
 export { settingsModal$ } from '@/stores/settingsModal';
@@ -336,6 +337,28 @@ export const SettingsModal = forwardRef<HTMLButtonElement, SettingsModalProps>(
                       <ExternalLink className="mr-2 h-3 w-3" />
                       gptme-webui - Web interface
                     </a>
+                  </div>
+                </div>
+
+                <Separator />
+
+                <div className="space-y-2">
+                  <h4 className="text-sm font-medium">Setup Wizard</h4>
+                  <div className="flex items-center justify-between">
+                    <p className="text-xs text-muted-foreground">
+                      Re-run the setup wizard to change server or sign in to gptme.ai
+                    </p>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => {
+                        setOpen(false);
+                        setupWizard$.step.set('welcome');
+                        setupWizard$.open.set(true);
+                      }}
+                    >
+                      Re-run Setup
+                    </Button>
                   </div>
                 </div>
 


### PR DESCRIPTION
## Summary

- Adds a **"Re-run Setup"** button in Settings → Appearance section, above "Reset Settings"
- Clicking it closes the modal and re-opens the setup wizard from the welcome step
- Uses the existing `setupWizard$` observable (same mechanism as WelcomeView's provider setup button) — no new patterns introduced
- Does **not** change `hasCompletedSetup` in localStorage, so closing the browser mid-wizard doesn't auto-reopen on next load

## Motivation

Currently there is no UI path to get back to the setup wizard after completing or skipping it. To try the cloud/gptme.ai auth path or switch servers from the wizard, users had to open DevTools and run `localStorage.removeItem('gptme-settings')` — not discoverable.

Requested in ErikBjare/bob#660 ("gptme android app") where Erik asked: "Can't figure out how to try the cloud path in gptme-tauri on desktop though, nor how to get back to the onboarding once through."

## Test plan

- [ ] Open Settings → appearance tab → "Setup Wizard" section appears above "Reset Settings"
- [ ] Click "Re-run Setup" → modal closes, setup wizard opens at the welcome step
- [ ] Step through to the "cloud" option → redirects to fleet.gptme.ai/authorize
- [ ] Closing the wizard via X or Skip persists completion state (wizard does not auto-reopen on reload)