### PR TITLE
docs(readme): lead with headless/anywhere framing (Warp variant A)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,14 +56,18 @@
 </p>
 
 <p align="center">
-📜 A personal AI agent in your terminal, with tools to:<br/>
-run shell commands, write code, edit files, browse the web, use vision, and much more.<br/>
-A great coding agent, but general-purpose enough to assist in all kinds of knowledge-work.
+📜 A personal AI agent that runs <i>anywhere a terminal runs</i> — your laptop,
+ssh sessions, tmux, headless servers, CI pipelines.<br/>
+Provider-agnostic, local-first, and unconstrained: ships with shell, Python, web,
+vision, and everything else an agent needs.
 </p>
 
 <p align="center">
-An unconstrained local free and open-source <a href="https://gptme.org/docs/alternatives.html">alternative</a> to Claude Code, Codex, Cursor Agents, etc.<br/>
-One of the first agent CLIs created (Spring 2023) — and still in very active development.
+Free and open-source. Works with Anthropic, OpenAI, Google, xAI, DeepSeek, OpenRouter,
+or fully local via <code>llama.cpp</code> — your data, your models, your terminal.<br/>
+A capable <a href="https://gptme.org/docs/alternatives.html">alternative</a> to Claude Code,
+Codex, Cursor, and Warp — one of the first agent CLIs (Spring 2023), still in very
+active development.
 </p>
 
 ## 📚 Table of Contents


### PR DESCRIPTION
Closes Phase 2 of idea #194.

This PR replaces gptme's current README pitch with variant A from
the positioning proposal doc (ErikBjare/bob# 7e0b5ac18/knowledge/strategic/2026-04-29-gptme-readme-positioning-variants.md).

### What changed

The two-paragraph pitch block now leads with:

1. **Headless/anywhere** — "runs anywhere a terminal runs" is the concrete
   differentiator Warp can't truthfully say (Warp is a Rust desktop app with
   cloud-mediated workflows). Laptop, ssh, tmux, headless servers, CI pipelines.
2. **Provider-agnostic** — explicitly list all supported providers (Anthropic,
   OpenAI, Google, xAI, DeepSeek, OpenRouter, and local via llama.cpp).
3. **Names Warp** — listing Warp alongside Claude Code, Codex, Cursor in the
   alternatives line claims the comparison rather than ducking it.

### Why draft

Draft so Erik can compare the three variants from the proposal doc and pick
A/B/C/none with under 2 min of diff review time.

### Context

Warp went open-source on 2026-04-28 with OpenAI as founding sponsor (38k stars in
24h). The "agentic terminal" is now a validated category. gptme's README
should answer the question "why pick gptme?" at a glance.

Full strategic analysis: Bob's idea-backlog #194.

### Verification

Pre-commit (prek) checks pass
One file changed, net +4 lines
No infra changes, submodule churn, or scope creep
