### PR TITLE
feat(server): expose session last_error in conversation GET response

### DIFF
--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -411,6 +411,22 @@ def api_conversation(conversation_id: str):
         if chat_config.agent:
             log_dict["agent"]["path"] = str(chat_config.agent)
 
+    # Surface session-level state so REST polling clients can see generation
+    # status and the last step error without subscribing to SSE.
+    # Errors during /step propagate via SSE error events, but clients that
+    # only poll the conversation would otherwise see {"status": "ok"} from
+    # /step and never learn the LLM call failed.
+    sessions = SessionManager.get_sessions_for_conversation(conversation_id)
+    if sessions:
+        # Pick the most recently active session — it's the one a polling
+        # client would care about.
+        latest = max(sessions, key=lambda s: s.last_activity)
+        log_dict["session"] = {
+            "id": latest.id,
+            "generating": latest.generating,
+            "last_error": latest.last_error,
+        }
+
     return flask.jsonify(log_dict)
 
 

--- a/gptme/server/openapi_docs.py
+++ b/gptme/server/openapi_docs.py
@@ -99,6 +99,10 @@ class ConversationResponse(BaseModel):
     name: str = Field(..., description="Conversation name")
     log: list[dict] = Field(..., description="Message history as raw objects")
     workspace: str = Field(..., description="Workspace path")
+    session: dict | None = Field(
+        None,
+        description="Most-recently-active session state (id, generating, last_error); omitted when no session exists",
+    )
 
 
 class ConversationListResponse(BaseModel):

--- a/tests/test_server_v2_sessions.py
+++ b/tests/test_server_v2_sessions.py
@@ -694,9 +694,8 @@ class TestConversationGetSessionState:
 
     def test_session_field_omitted_when_no_session(self, client: FlaskClient):
         """Conversations without an active session omit the session field."""
-        # Create a conversation without going through PUT (which creates a session)
+        # Create a conversation via PUT, then manually remove the session to simulate no-session case
         convname = f"test-no-session-{uuid.uuid4().hex[:8]}"
-        # Use POST to add a message — this creates a conversation with no session
         response = client.put(
             f"/api/v2/conversations/{convname}",
             json={"prompt": "test"},

--- a/tests/test_server_v2_sessions.py
+++ b/tests/test_server_v2_sessions.py
@@ -661,3 +661,52 @@ class TestEventsEndpoint:
         # SSE endpoint returns 200 with streaming content
         assert response.status_code == 200
         assert response.content_type.startswith("text/event-stream")
+
+
+class TestConversationGetSessionState:
+    """Test GET /api/v2/conversations/<id> exposes session state.
+
+    REST polling clients need to see generation status and the last step
+    error without subscribing to SSE — otherwise they can't tell that an
+    LLM call failed (issue gptme/gptme-cloud#172).
+    """
+
+    def test_session_field_present_when_session_exists(self, conv, client: FlaskClient):
+        """GET conversation includes session.id, generating, last_error."""
+        response = client.get(f"/api/v2/conversations/{conv['conversation_id']}")
+        assert response.status_code == 200
+        data = response.get_json()
+        assert "session" in data
+        assert data["session"]["id"] == conv["session_id"]
+        assert data["session"]["generating"] is False
+        assert data["session"]["last_error"] is None
+
+    def test_last_error_surfaces_in_get_response(self, conv, client: FlaskClient):
+        """A session.last_error set by a failed step is visible via GET."""
+        session = SessionManager.get_session(conv["session_id"])
+        assert session is not None
+        session.last_error = "LLM call failed: rate limit exceeded"
+
+        response = client.get(f"/api/v2/conversations/{conv['conversation_id']}")
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data["session"]["last_error"] == "LLM call failed: rate limit exceeded"
+
+    def test_session_field_omitted_when_no_session(self, client: FlaskClient):
+        """Conversations without an active session omit the session field."""
+        # Create a conversation without going through PUT (which creates a session)
+        convname = f"test-no-session-{uuid.uuid4().hex[:8]}"
+        # Use POST to add a message — this creates a conversation with no session
+        response = client.put(
+            f"/api/v2/conversations/{convname}",
+            json={"prompt": "test"},
+        )
+        assert response.status_code == 200
+        # Manually remove the session to simulate the no-session case
+        session_id = response.get_json()["session_id"]
+        SessionManager.remove_session(session_id)
+
+        response = client.get(f"/api/v2/conversations/{convname}")
+        assert response.status_code == 200
+        data = response.get_json()
+        assert "session" not in data


### PR DESCRIPTION
## Summary

The V2 `/step` endpoint dispatches generation in a background thread and returns 200 immediately. If the LLM call fails, the error sets `session.last_error` but only propagates to clients via SSE. REST polling clients see `{"status": "ok"}` from `/step` and have no way to learn the call failed.

This adds a `session` field to `GET /api/v2/conversations/<id>` exposing the most recently active session's `id`, `generating` flag, and `last_error`. Clients that don't subscribe to SSE can now poll the conversation to detect failures.

Reported in [gptme/gptme-cloud#172](https://github.com/gptme/gptme-cloud/issues/172) — silent LLM failures became visible to users only as an infinite loading spinner.

## Changes

- `gptme/server/api_v2.py`: lookup sessions for the conversation in `api_conversation` and include the most-recently-active session's state in the response
- `tests/test_server_v2_sessions.py`: add `TestConversationGetSessionState` (3 tests) covering the field present, last_error surfacing, and graceful absence when no session exists

## Test plan

- [x] New tests pass: `uv run pytest tests/test_server_v2_sessions.py::TestConversationGetSessionState -v` → 3/3 pass
- [x] Existing tests still pass: `uv run pytest tests/test_server_v2_sessions.py tests/test_server_v2_hooks.py` → 64/64 pass
- [x] Pre-commit + ruff format clean