### PR TITLE
fix(context): deduplicate paths in _find_potential_paths to prevent repeated file embeddings

### DIFF
--- a/gptme/util/context.py
+++ b/gptme/util/context.py
@@ -591,7 +591,8 @@ def _find_potential_paths(content: str) -> list[str]:
     # List current directory contents for relative path matching
     cwd_files = [f.name for f in Path.cwd().iterdir()]
 
-    paths = []
+    paths: list[str] = []
+    seen_paths: set[str] = set()
 
     def is_path_like(word: str) -> bool:
         """Helper to check if a word looks like a path.
@@ -626,12 +627,19 @@ def _find_potential_paths(content: str) -> list[str]:
         """Strip leading @ from path references (e.g. @src/file.py -> src/file.py)."""
         return word.removeprefix("@")
 
+    def _add_path(word: str) -> None:
+        """Add a path to the list if not already seen (preserves first-seen order)."""
+        path = _strip_at_prefix(word)
+        if path not in seen_paths:
+            seen_paths.add(path)
+            paths.append(path)
+
     # First find backtick-wrapped content
     for match in re.finditer(r"`([^`]+)`", content_no_xml):
         word = match.group(1).strip()
         word = word.rstrip("?").rstrip(".").rstrip(",").rstrip("!")
         if is_path_like(word):
-            paths.append(_strip_at_prefix(word))
+            _add_path(word)
 
     # Then find non-backtick-wrapped words
     # Remove backtick-wrapped content first to avoid double-processing
@@ -643,7 +651,7 @@ def _find_potential_paths(content: str) -> list[str]:
             continue
 
         if is_path_like(word):
-            paths.append(_strip_at_prefix(word))
+            _add_path(word)
 
     return paths
 

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -61,6 +61,45 @@ def test_find_potential_paths_empty():
     assert _find_potential_paths("just some text") == []
 
 
+def test_find_potential_paths_deduplication():
+    """Paths mentioned multiple times should appear only once in the result."""
+    content = """
+    See `./scripts/foo.py --flag` for details.
+    Also `./scripts/foo.py --other` does the same.
+    And again: `./scripts/foo.py`
+    The plain word /abs/path appears twice: /abs/path
+    """
+    paths = _find_potential_paths(content)
+
+    # Each unique path must appear exactly once, even if mentioned multiple times
+    assert paths.count("./scripts/foo.py --flag") == 1
+    assert paths.count("/abs/path") == 1
+
+    # All unique paths should still be present
+    assert "./scripts/foo.py --flag" in paths
+    assert "/abs/path" in paths
+
+
+def test_include_paths_no_duplicate_embeddings(tmp_path, monkeypatch):
+    """include_paths must not embed the same file content multiple times."""
+    from gptme.message import Message
+    from gptme.util.context import include_paths
+
+    monkeypatch.chdir(tmp_path)
+    data_file = tmp_path / "data.txt"
+    data_file.write_text("unique-content-marker")
+
+    # Reference the same file four times
+    msg = Message(
+        "user",
+        "See `data.txt` and also `data.txt`. Then `data.txt` again and data.txt bare.",
+    )
+    result = include_paths(msg)
+
+    # The unique marker should appear exactly once, not four times
+    assert result.content.count("unique-content-marker") == 1
+
+
 def test_include_paths_skips_system_messages():
     """Test that include_paths skips role=system messages (tool output) entirely."""
     from gptme.message import Message


### PR DESCRIPTION
## Problem

`include_paths()` calls `_find_potential_paths()` which returns a path once per occurrence in the prompt text. A file mentioned N times gets embedded N times, ballooning context by N×file_size.

**Real-world impact**: In Bob's autonomous-run prompt template, `knowledge/strategic/idea-backlog.md` (99 KB) was backtick-quoted 4 times and `./scripts/cascade-selector.py` (99 KB) was quoted 2 times, causing the user message to expand from ~6 KB to **561,205 chars** and two consecutive sessions to fail with 0.1 grade (context exhausted before the model could produce any output). Closes #2306.

## Fix

Add a `seen_paths` set inside `_find_potential_paths()` so each unique path string is added to the result list at most once, preserving first-seen order. Minimal change: 7 lines.

## Tests

Two new regression tests in `tests/test_chat.py`:
- `test_find_potential_paths_deduplication`: verifies duplicates are removed at the return value level
- `test_include_paths_no_duplicate_embeddings`: end-to-end test verifying file content appears exactly once even when referenced 4× in the prompt