### PR TITLE
fix(context): add per-message size budget to include_paths

### DIFF
--- a/gptme/constants.py
+++ b/gptme/constants.py
@@ -65,3 +65,7 @@ MAX_PROMPT_QUEUE_SIZE = 100
 # Content above WARN threshold logs warning and gets truncated
 CONTENT_SIZE_INFO_THRESHOLD = 50_000  # 50KB - log info
 CONTENT_SIZE_WARN_THRESHOLD = 100_000  # 100KB - warn and truncate
+
+# Maximum total characters to append via include_paths across all files/URLs
+# Prevents context-window saturation when prompts reference many large files
+INCLUDE_PATHS_MAX_CONTENT = 200_000  # 200KB

--- a/gptme/util/context.py
+++ b/gptme/util/context.py
@@ -526,8 +526,9 @@ def include_paths(msg: Message, workspace: Path | None = None) -> Message:
         # If not using fresh context, include text file contents in the message
         if not use_fresh_context():
             if total_content_size >= INCLUDE_PATHS_MAX_CONTENT:
-                # Budget exhausted: skip I/O for text; fall through to binary check below
+                # Budget exhausted: skip entirely (text and binary alike)
                 skipped_paths.append(word)
+                continue
             elif (
                 # Fast stat-based pre-check: skip reading if even the truncated content
                 # (capped at CONTENT_SIZE_WARN_THRESHOLD by _check_content_size) would
@@ -538,7 +539,10 @@ def include_paths(msg: Message, workspace: Path | None = None) -> Message:
                 > INCLUDE_PATHS_MAX_CONTENT
             ):
                 skipped_paths.append(word)
-                # fall through so binary files still get attached via msg.files
+                mime, _ = mimetypes.guess_type(str(f))
+                if not mime or mime.startswith("text/"):
+                    continue  # text file: skip binary handling too
+                # Binary/image file: fall through so it still gets attached via msg.files
             elif contents := _resource_to_codeblock(word, confirmed_urls=None):
                 content_size = len(contents)
                 if total_content_size + content_size > INCLUDE_PATHS_MAX_CONTENT:
@@ -547,7 +551,7 @@ def include_paths(msg: Message, workspace: Path | None = None) -> Message:
                 total_content_size += content_size
                 append_msg += "\n\n" + contents
                 continue  # processed as text: skip binary handling
-        # Binary/image attachment: runs when use_fresh_context(), budget exhausted, or
+        # Binary/image attachment: runs when use_fresh_context() or
         # _resource_to_codeblock returned None (binary file unrepresentable as text)
         file = _parse_prompt_files(word)
         if file:

--- a/gptme/util/context.py
+++ b/gptme/util/context.py
@@ -524,28 +524,31 @@ def include_paths(msg: Message, workspace: Path | None = None) -> Message:
     for word in file_paths:
         logger.debug(f"potential path: {word=}")
         # If not using fresh context, include text file contents in the message
-        if not use_fresh_context() and (
-            contents := _resource_to_codeblock(word, confirmed_urls=None)
-        ):
-            content_size = len(contents)
-            if total_content_size + content_size > INCLUDE_PATHS_MAX_CONTENT:
+        if not use_fresh_context():
+            if total_content_size >= INCLUDE_PATHS_MAX_CONTENT:
+                # Budget exhausted: skip I/O for text; fall through to binary check below
                 skipped_paths.append(word)
-                continue
-            total_content_size += content_size
-            append_msg += "\n\n" + contents
-        else:
-            # if we found a non-text file, include it in msg.files
-            file = _parse_prompt_files(word)
-            if file:
-                # Store path relative to workspace if provided
-                file = file.expanduser()
-                if workspace and not file.is_absolute():
-                    try:
-                        file = file.absolute().relative_to(workspace)
-                    except ValueError:
-                        file = file.absolute()
-                logger.debug(f"auto-attaching file: {file}")
-                files.append(file)
+            elif contents := _resource_to_codeblock(word, confirmed_urls=None):
+                content_size = len(contents)
+                if total_content_size + content_size > INCLUDE_PATHS_MAX_CONTENT:
+                    skipped_paths.append(word)
+                    continue  # text file: skip binary handling
+                total_content_size += content_size
+                append_msg += "\n\n" + contents
+                continue  # processed as text: skip binary handling
+        # Binary/image attachment: runs when use_fresh_context(), budget exhausted, or
+        # _resource_to_codeblock returned None (binary file unrepresentable as text)
+        file = _parse_prompt_files(word)
+        if file:
+            # Store path relative to workspace if provided
+            file = file.expanduser()
+            if workspace and not file.is_absolute():
+                try:
+                    file = file.absolute().relative_to(workspace)
+                except ValueError:
+                    file = file.absolute()
+            logger.debug(f"auto-attaching file: {file}")
+            files.append(file)
 
     # Process URLs (only confirmed ones in interactive mode)
     for url in urls_found:
@@ -553,20 +556,23 @@ def include_paths(msg: Message, workspace: Path | None = None) -> Message:
             logger.debug(f"Skipping unconfirmed URL: {url}")
             continue
         logger.debug(f"potential url: {url=}")
-        if not use_fresh_context() and (
-            contents := _resource_to_codeblock(url, confirmed_urls=confirmed_urls)
-        ):
-            content_size = len(contents)
-            if total_content_size + content_size > INCLUDE_PATHS_MAX_CONTENT:
+        if not use_fresh_context():
+            # Early exit: skip network fetch entirely if budget already exhausted
+            if total_content_size >= INCLUDE_PATHS_MAX_CONTENT:
                 skipped_paths.append(url)
                 continue
-            total_content_size += content_size
-            append_msg += "\n\n" + contents
+            if contents := _resource_to_codeblock(url, confirmed_urls=confirmed_urls):
+                content_size = len(contents)
+                if total_content_size + content_size > INCLUDE_PATHS_MAX_CONTENT:
+                    skipped_paths.append(url)
+                    continue
+                total_content_size += content_size
+                append_msg += "\n\n" + contents
 
     if skipped_paths:
         logger.warning(
             "include_paths: per-message content budget exceeded "
-            f"({total_content_size} >= {INCLUDE_PATHS_MAX_CONTENT}), "
+            f"({total_content_size} chars used, limit {INCLUDE_PATHS_MAX_CONTENT}), "
             f"skipped {len(skipped_paths)} path(s): {skipped_paths}"
         )
 

--- a/gptme/util/context.py
+++ b/gptme/util/context.py
@@ -528,6 +528,17 @@ def include_paths(msg: Message, workspace: Path | None = None) -> Message:
             if total_content_size >= INCLUDE_PATHS_MAX_CONTENT:
                 # Budget exhausted: skip I/O for text; fall through to binary check below
                 skipped_paths.append(word)
+            elif (
+                # Fast stat-based pre-check: skip reading if even the truncated content
+                # (capped at CONTENT_SIZE_WARN_THRESHOLD by _check_content_size) would
+                # exceed the remaining budget.  Path.stat() is a single syscall — far
+                # cheaper than reading the file only to discard the content.
+                (f := Path(word).expanduser()).is_file()
+                and min(f.stat().st_size, CONTENT_SIZE_WARN_THRESHOLD) + total_content_size
+                > INCLUDE_PATHS_MAX_CONTENT
+            ):
+                skipped_paths.append(word)
+                # fall through so binary files still get attached via msg.files
             elif contents := _resource_to_codeblock(word, confirmed_urls=None):
                 content_size = len(contents)
                 if total_content_size + content_size > INCLUDE_PATHS_MAX_CONTENT:
@@ -571,9 +582,9 @@ def include_paths(msg: Message, workspace: Path | None = None) -> Message:
 
     if skipped_paths:
         logger.warning(
-            "include_paths: per-message content budget exceeded "
-            f"({total_content_size} chars used, limit {INCLUDE_PATHS_MAX_CONTENT}), "
-            f"skipped {len(skipped_paths)} path(s): {skipped_paths}"
+            f"include_paths: per-message content budget reached "
+            f"({total_content_size}/{INCLUDE_PATHS_MAX_CONTENT} chars used); "
+            f"skipped {len(skipped_paths)} path(s) to stay within limit: {skipped_paths}"
         )
 
     if files:

--- a/gptme/util/context.py
+++ b/gptme/util/context.py
@@ -15,7 +15,11 @@ from datetime import datetime
 from pathlib import Path
 
 from ..config import get_config
-from ..constants import CONTENT_SIZE_INFO_THRESHOLD, CONTENT_SIZE_WARN_THRESHOLD
+from ..constants import (
+    CONTENT_SIZE_INFO_THRESHOLD,
+    CONTENT_SIZE_WARN_THRESHOLD,
+    INCLUDE_PATHS_MAX_CONTENT,
+)
 from ..message import Message
 from ..tools import has_tool
 from .gh import (
@@ -513,6 +517,8 @@ def include_paths(msg: Message, workspace: Path | None = None) -> Message:
 
     append_msg = ""
     files = []
+    total_content_size = 0
+    skipped_paths: list[str] = []
 
     # Process file paths
     for word in file_paths:
@@ -521,6 +527,11 @@ def include_paths(msg: Message, workspace: Path | None = None) -> Message:
         if not use_fresh_context() and (
             contents := _resource_to_codeblock(word, confirmed_urls=None)
         ):
+            content_size = len(contents)
+            if total_content_size + content_size > INCLUDE_PATHS_MAX_CONTENT:
+                skipped_paths.append(word)
+                continue
+            total_content_size += content_size
             append_msg += "\n\n" + contents
         else:
             # if we found a non-text file, include it in msg.files
@@ -545,7 +556,19 @@ def include_paths(msg: Message, workspace: Path | None = None) -> Message:
         if not use_fresh_context() and (
             contents := _resource_to_codeblock(url, confirmed_urls=confirmed_urls)
         ):
+            content_size = len(contents)
+            if total_content_size + content_size > INCLUDE_PATHS_MAX_CONTENT:
+                skipped_paths.append(url)
+                continue
+            total_content_size += content_size
             append_msg += "\n\n" + contents
+
+    if skipped_paths:
+        logger.warning(
+            "include_paths: per-message content budget exceeded "
+            f"({total_content_size} >= {INCLUDE_PATHS_MAX_CONTENT}), "
+            f"skipped {len(skipped_paths)} path(s): {skipped_paths}"
+        )
 
     if files:
         logger.debug(

--- a/gptme/util/context.py
+++ b/gptme/util/context.py
@@ -529,7 +529,7 @@ def include_paths(msg: Message, workspace: Path | None = None) -> Message:
                 # Budget exhausted: skip entirely (text and binary alike)
                 skipped_paths.append(word)
                 continue
-            elif (
+            if (
                 # Fast stat-based pre-check: skip reading if even the truncated content
                 # (capped at CONTENT_SIZE_WARN_THRESHOLD by _check_content_size) would
                 # exceed the remaining budget.  Path.stat() is a single syscall — far

--- a/gptme/util/context.py
+++ b/gptme/util/context.py
@@ -535,14 +535,16 @@ def include_paths(msg: Message, workspace: Path | None = None) -> Message:
                 # exceed the remaining budget.  Path.stat() is a single syscall — far
                 # cheaper than reading the file only to discard the content.
                 (f := Path(word).expanduser()).is_file()
-                and min(f.stat().st_size, CONTENT_SIZE_WARN_THRESHOLD) + total_content_size
+                and min(f.stat().st_size, CONTENT_SIZE_WARN_THRESHOLD)
+                + total_content_size
                 > INCLUDE_PATHS_MAX_CONTENT
             ):
-                skipped_paths.append(word)
                 mime, _ = mimetypes.guess_type(str(f))
                 if not mime or mime.startswith("text/"):
+                    skipped_paths.append(word)
                     continue  # text file: skip binary handling too
                 # Binary/image file: fall through so it still gets attached via msg.files
+                # (binary attachments are not counted against the text budget)
             elif contents := _resource_to_codeblock(word, confirmed_urls=None):
                 content_size = len(contents)
                 if total_content_size + content_size > INCLUDE_PATHS_MAX_CONTENT:

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -377,7 +377,7 @@ def test_include_paths_per_message_size_budget(tmp_path, monkeypatch, caplog):
 
     # Warning should be logged about the skipped paths
     log_messages = [r.message for r in caplog.records if r.levelno == logging.WARNING]
-    assert any("per-message content budget exceeded" in m for m in log_messages)
+    assert any("per-message content budget reached" in m for m in log_messages)
     assert any("doc_2.txt" in m for m in log_messages)
 
 

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -380,6 +380,10 @@ def test_include_paths_per_message_size_budget(tmp_path, monkeypatch, caplog):
     assert any("per-message content budget reached" in m for m in log_messages)
     assert any("doc_2.txt" in m for m in log_messages)
 
+    # Skipped file must not be attached via msg.files (budget bypass via _parse_prompt_files)
+    attached_names = [f.name for f in (result.files or []) if isinstance(f, Path)]
+    assert "doc_2.txt" not in attached_names
+
 
 def test_embed_attached_preserves_image_files(tmp_path):
     """Images in msg.files should survive embed_attached_file_content.

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -343,6 +343,44 @@ def test_include_paths_image_in_text(tmp_path):
     assert Path(str(result.files[0])).name == "screenshot.png"
 
 
+def test_include_paths_per_message_size_budget(tmp_path, monkeypatch, caplog):
+    """include_paths must stop embedding files once the per-message budget is exceeded."""
+    import logging
+
+    from gptme.message import Message
+    from gptme.util.context import include_paths
+
+    monkeypatch.chdir(tmp_path)
+
+    # Create several moderately sized files that collectively exceed the budget
+    # INCLUDE_PATHS_MAX_CONTENT = 200_000. Create 3 files at ~80KB each (~240KB total)
+    chunk_size = 80_000
+    files = []
+    for i in range(3):
+        f = tmp_path / f"doc_{i}.txt"
+        # Use unique per-file content so dedup doesn't interfere
+        body = f"marker_{i}_" + "x" * (chunk_size - len(f"marker_{i}_"))
+        f.write_text(body)
+        files.append(f)
+
+    # Reference all three files in the message
+    refs = "\n".join(f"`{f.name}`" for f in files)
+    msg = Message("user", f"Read these:\n{refs}")
+    caplog.set_level(logging.WARNING)
+
+    result = include_paths(msg)
+
+    # First two files should be embedded (~160KB), third should be skipped
+    assert "marker_0_" in result.content
+    assert "marker_1_" in result.content
+    assert "marker_2_" not in result.content
+
+    # Warning should be logged about the skipped paths
+    log_messages = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+    assert any("per-message content budget exceeded" in m for m in log_messages)
+    assert any("doc_2.txt" in m for m in log_messages)
+
+
 def test_embed_attached_preserves_image_files(tmp_path):
     """Images in msg.files should survive embed_attached_file_content.
 


### PR DESCRIPTION
## Problem

`include_paths` has a per-file size cap (100KB via `_check_content_size`) but no per-message budget. A prompt that references many moderately-sized files can silently blow up the context window.

PR #2307 fixed the deduplication issue (same file no longer embedded N times), but the aggregate budget was still unconstrained.

## Fix

Adds `INCLUDE_PATHS_MAX_CONTENT` (200KB default) to cap the total content appended by `include_paths`. When exceeded:

- Remaining files/URLs are **skipped** (not truncated mid-file)
- A **warning** is logged listing the skipped paths

This is a defense-in-depth layer on top of the per-file cap — even with dedup, a prompt referencing 5 unique 100KB files could silently push a 200K-context model over its window. Now it can't.

## Test

- `test_include_paths_per_message_size_budget`: creates 3 files at 80KB each (~240KB total), verifies only first 2 are embedded and the warning is logged
- All existing include_paths tests continue to pass (dedup, skip-system, at-prefix, image-attach, image-in-text)

Refs: #2306