### PR TITLE
docs(readme): sharpen positioning post-Warp — lead with headless/anywhere framing

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,14 +56,19 @@
 </p>
 
 <p align="center">
-📜 A personal AI agent in your terminal, with tools to:<br/>
-run shell commands, write code, edit files, browse the web, use vision, and much more.<br/>
+📜 A personal AI agent that runs <i>anywhere a terminal runs</i> — your laptop,
+ssh sessions, tmux, headless servers, CI pipelines.<br/>
+Provider-agnostic, local-first, and unconstrained: ships with shell, Python, web,
+vision, and everything else an agent needs.<br/>
 A great coding agent, but general-purpose enough to assist in all kinds of knowledge-work.
 </p>
 
 <p align="center">
-An unconstrained local free and open-source <a href="https://gptme.org/docs/alternatives.html">alternative</a> to Claude Code, Codex, Cursor Agents, etc.<br/>
-One of the first agent CLIs created (Spring 2023) — and still in very active development.
+Free and open-source. Works with Anthropic, OpenAI, Google, xAI, DeepSeek, OpenRouter,
+or fully local via <code>llama.cpp</code> — your data, your models, your terminal.<br/>
+A capable <a href="https://gptme.org/docs/alternatives.html">alternative</a> to Claude Code,
+Codex, Cursor, and Warp — one of the first agent CLIs (Spring 2023), still in very
+active development.
 </p>
 
 ## 📚 Table of Contents


### PR DESCRIPTION
## What

Sharpens gptme's README pitch to explicitly differentiate from Warp's open-source terminal agent (April 2026). Leads with "anywhere a terminal runs" — headless, ssh, tmux, CI — which Warp cannot match as a desktop app. Explicitly names Warp in the alternatives line.

## Why

Warp's open-sourcing (38k★ in 24h) made "agentic terminal" a category, not a curiosity. gptme's current README still reads as a feature list rather than answering "why gptme over Warp's agent?"

## Change

Replaces the generic pitch block with:

- **Lede**: "anywhere a terminal runs" — concrete differentiator Warp cannot claim
- **Provider list**: Anthropic/OpenAI/Google/xAI/DeepSeek/OpenRouter/local — vs Warp's OpenAI coupling
- **Alternatives line**: adds "and Warp" explicitly
- **Preserves**: "general-purpose enough for knowledge-work" line (not lost)

## Proposal Doc

Full analysis: [ErikBjare/bob#194](https://github.com/ErikBjare/bob/issues/194)
Proposal with 3 variants (A/B/C): `knowledge/strategic/2026-04-29-gptme-readme-positioning-variants.md` in Bob's repo.
This PR implements **Variant A** (Bob's recommendation).

## Decision

This is a draft. Erik should review and either:
1. **Merge** if Variant A looks right
2. **Request B or C** — Bob will update
3. **Close** if the current copy is preferred