### PR TITLE
fix(webui): update auth base URL from fleet.gptme.ai to gptme.ai

### DIFF
--- a/webui/src/components/SetupWizard.tsx
+++ b/webui/src/components/SetupWizard.tsx
@@ -39,7 +39,7 @@ type SetupModelsResponse = {
   recommended: string[];
 };
 
-// The gptme cloud service is hosted on fleet.gptme.ai (the cloud.gptme.ai domain
+// The gptme cloud service is hosted on gptme.ai (the cloud.gptme.ai domain
 // is a planned alias). Use a small runtime helper so Jest doesn't choke on import.meta.
 function getCloudAuthUrl(): string {
   let cloudBaseUrl: string | undefined;
@@ -52,7 +52,7 @@ function getCloudAuthUrl(): string {
     cloudBaseUrl = undefined;
   }
 
-  return `${cloudBaseUrl || 'https://fleet.gptme.ai'}/authorize`;
+  return `${cloudBaseUrl || 'https://gptme.ai'}/authorize`;
 }
 
 const CLOUD_AUTH_URL = getCloudAuthUrl();

--- a/webui/src/components/__tests__/SetupWizard.test.tsx
+++ b/webui/src/components/__tests__/SetupWizard.test.tsx
@@ -213,7 +213,7 @@ describe('SetupWizard', () => {
     fireEvent.click(screen.getByRole('button', { name: /cloud/i }));
     fireEvent.click(screen.getByRole('button', { name: /sign in to gptme.ai/i }));
 
-    expect(mockOpen).toHaveBeenCalledWith('https://fleet.gptme.ai/authorize', '_blank');
+    expect(mockOpen).toHaveBeenCalledWith('https://gptme.ai/authorize', '_blank');
     expect(screen.getByText(/waiting for sign-in to complete/i)).toBeInTheDocument();
     expect(screen.queryByText(/you're all set/i)).not.toBeInTheDocument();
 

--- a/webui/src/utils/__tests__/api.test.ts
+++ b/webui/src/utils/__tests__/api.test.ts
@@ -1,7 +1,7 @@
 // Mock modules that use import.meta (not available in jest)
 jest.mock('@/utils/connectionConfig', () => ({
   getApiBaseUrl: jest.fn(() => 'http://127.0.0.1:5700'),
-  CLOUD_BASE_URL: 'https://fleet.gptme.ai',
+  CLOUD_BASE_URL: 'https://gptme.ai',
 }));
 jest.mock('@/stores/conversations', () => ({}));
 jest.mock('@/stores/servers', () => ({

--- a/webui/src/utils/connectionConfig.ts
+++ b/webui/src/utils/connectionConfig.ts
@@ -7,9 +7,9 @@ import {
 
 const DEFAULT_API_URL = 'http://127.0.0.1:5700';
 
-// Cloud service URL for auth code exchange (fleet.gptme.ai)
+// Cloud service URL for auth code exchange (gptme.ai)
 // Configure via VITE_GPTME_CLOUD_BASE_URL environment variable
-const CLOUD_BASE_URL = import.meta.env.VITE_GPTME_CLOUD_BASE_URL || 'https://fleet.gptme.ai';
+const CLOUD_BASE_URL = import.meta.env.VITE_GPTME_CLOUD_BASE_URL || 'https://gptme.ai';
 
 export interface ConnectionConfig {
   baseUrl: string;


### PR DESCRIPTION
Part of resolving gptme/gptme-cloud#195 (nginx 500 outage on /login + /authorize).

PR #216 added an auth-redirect ingress so fleet.gptme.ai/authorize 302-redirects to gptme.ai/authorize. But the webui still hardcodes fleet.gptme.ai as the auth base URL — auth should live at gptme.ai directly.

## Changes

- **`webui/src/utils/connectionConfig.ts`**: CLOUD_BASE_URL default → `https://gptme.ai`
- **`webui/src/components/SetupWizard.tsx`**: auth URL default → `https://gptme.ai/authorize`
- **`webui/src/components/__tests__/SetupWizard.test.tsx`**: update assertion to match

Tests (setup wizard test) pass with the updated assertion. Pre-commit lint/typecheck aren't available in a worktree environment but the changes are trivially correct string replacements (no logic changes).