### PR TITLE
feat(server): voice Phase 3 — transcript to conversation history

### DIFF
--- a/gptme/message.py
+++ b/gptme/message.py
@@ -6,7 +6,7 @@ import textwrap
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Literal, TypedDict
+from typing import Any, Literal, TypedDict
 from xml.sax.saxutils import escape as xml_escape
 from xml.sax.saxutils import quoteattr
 
@@ -65,6 +65,7 @@ class MessageMetadata(TypedDict, total=False):
     model: str
     cost: float  # Cost in USD
     usage: UsageData
+    voice_call: dict[str, Any]  # Voice call metadata (call_sid, source, etc.)
 
 
 _TOKEN_KEYS = (

--- a/gptme/server/api_v2_sessions.py
+++ b/gptme/server/api_v2_sessions.py
@@ -32,6 +32,8 @@ from .openapi_docs import (
     StatusResponse,
     StepRequest,
     ToolConfirmRequest,
+    TranscriptRequest,
+    TranscriptResponse,
     api_doc,
 )
 
@@ -791,6 +793,99 @@ def api_conversation_elicit_respond(conversation_id: str):
     )
 
     return flask.jsonify({"status": "ok", "message": f"Elicitation {action}ed"})
+
+
+@sessions_api.route(
+    "/api/v2/conversations/<string:conversation_id>/transcript", methods=["POST"]
+)
+@require_auth
+@api_doc(
+    summary="Append voice transcript turns to conversation (V2)",
+    description="Add voice transcript turns as messages to a conversation, creating the conversation if it doesn't exist. Used by the voice server to promote call transcripts to the conversation log.",
+    request_body=TranscriptRequest,
+    responses={200: TranscriptResponse, 400: ErrorResponse, 401: ErrorResponse},
+    parameters=[CONVERSATION_ID_PARAM],
+    tags=["sessions"],
+)
+def api_conversation_transcript(conversation_id: str):
+    """Append voice transcript turns to a conversation.
+
+    This endpoint is called by the voice server after a call ends, promoting
+    the transcript to the caller's conversation log so voice calls become
+    searchable and persistent in the same interface as text chats.
+
+    The conversation_id is the caller's E.164 phone number (e.g. +46765784797).
+    """
+    if error := _validate_conversation_id(conversation_id):
+        return error
+
+    req_json = _get_request_json_object()
+    if not isinstance(req_json, dict):
+        return req_json
+
+    # Validate request matches our expected shape
+    turns = req_json.get("turns")  # type: ignore[union-attr]
+    call_metadata = req_json.get("call_metadata")  # type: ignore[union-attr]
+
+    if not turns or not isinstance(turns, list):
+        return flask.jsonify({"error": "turns (list) is required"}), 400
+    if not call_metadata or not isinstance(call_metadata, dict):
+        return flask.jsonify({"error": "call_metadata (object) is required"}), 400
+
+    call_sid = call_metadata.get("call_sid")
+    if not call_sid:
+        return flask.jsonify({"error": "call_metadata.call_sid is required"}), 400
+
+    # Load or create the conversation logdir
+    logdir = get_logs_dir() / conversation_id
+    logdir.mkdir(parents=True, exist_ok=True)
+
+    manager = LogManager.load(conversation_id, lock=True, create=True)
+
+    # Idempotency check: scan existing messages for this call_sid in metadata
+    for msg in manager.log.messages:
+        if (
+            msg.metadata
+            and msg.metadata.get("voice_call", {}).get("call_sid") == call_sid
+        ):
+            manager._release_lock()
+            return flask.jsonify(
+                {
+                    "status": "already_acked",
+                    "conversation_id": conversation_id,
+                    "messages_added": 0,
+                }
+            )
+
+    messages_added = 0
+    # Append each turn as a Message
+    for turn in turns:
+        role = turn.get("role")
+        text = turn.get("text", "").strip()
+
+        # Skip empty/whitespace-only turns
+        if not text:
+            continue
+        if role not in ("user", "assistant"):
+            continue
+
+        msg = Message(
+            role=role,
+            content=text,
+            metadata={"voice_call": call_metadata},  # type: ignore[arg-type]
+        )
+        manager.append(msg)
+        messages_added += 1
+
+    manager._release_lock()
+
+    return flask.jsonify(
+        {
+            "status": "ok",
+            "conversation_id": conversation_id,
+            "messages_added": messages_added,
+        }
+    )
 
 
 @sessions_api.route(

--- a/gptme/server/api_v2_sessions.py
+++ b/gptme/server/api_v2_sessions.py
@@ -840,44 +840,39 @@ def api_conversation_transcript(conversation_id: str):
     logdir = get_logs_dir() / conversation_id
     logdir.mkdir(parents=True, exist_ok=True)
 
-    manager = LogManager.load(conversation_id, lock=True, create=True)
+    with LogManager.load(conversation_id, lock=True, create=True) as manager:
+        # Idempotency check: scan existing messages for this call_sid in metadata
+        for msg in manager.log.messages:
+            if msg.metadata:
+                voice_call = msg.metadata.get("voice_call")
+                if voice_call and voice_call.get("call_sid") == call_sid:
+                    return flask.jsonify(
+                        {
+                            "status": "already_acked",
+                            "conversation_id": conversation_id,
+                            "messages_added": 0,
+                        }
+                    )
 
-    # Idempotency check: scan existing messages for this call_sid in metadata
-    for msg in manager.log.messages:
-        if (
-            msg.metadata
-            and msg.metadata.get("voice_call", {}).get("call_sid") == call_sid
-        ):
-            manager._release_lock()
-            return flask.jsonify(
-                {
-                    "status": "already_acked",
-                    "conversation_id": conversation_id,
-                    "messages_added": 0,
-                }
+        messages_added = 0
+        # Append each turn as a Message
+        for turn in turns:
+            role = turn.get("role")
+            text = turn.get("text", "").strip()
+
+            # Skip empty/whitespace-only turns
+            if not text:
+                continue
+            if role not in ("user", "assistant"):
+                continue
+
+            msg = Message(
+                role=role,
+                content=text,
+                metadata={"voice_call": call_metadata},
             )
-
-    messages_added = 0
-    # Append each turn as a Message
-    for turn in turns:
-        role = turn.get("role")
-        text = turn.get("text", "").strip()
-
-        # Skip empty/whitespace-only turns
-        if not text:
-            continue
-        if role not in ("user", "assistant"):
-            continue
-
-        msg = Message(
-            role=role,
-            content=text,
-            metadata={"voice_call": call_metadata},  # type: ignore[arg-type]
-        )
-        manager.append(msg)
-        messages_added += 1
-
-    manager._release_lock()
+            manager.append(msg)
+            messages_added += 1
 
     return flask.jsonify(
         {

--- a/gptme/server/api_v2_sessions.py
+++ b/gptme/server/api_v2_sessions.py
@@ -836,10 +836,6 @@ def api_conversation_transcript(conversation_id: str):
     if not call_sid:
         return flask.jsonify({"error": "call_metadata.call_sid is required"}), 400
 
-    # Load or create the conversation logdir
-    logdir = get_logs_dir() / conversation_id
-    logdir.mkdir(parents=True, exist_ok=True)
-
     with LogManager.load(conversation_id, lock=True, create=True) as manager:
         # Idempotency check: scan existing messages for this call_sid in metadata
         for msg in manager.log.messages:

--- a/gptme/server/api_v2_sessions.py
+++ b/gptme/server/api_v2_sessions.py
@@ -814,7 +814,7 @@ def api_conversation_transcript(conversation_id: str):
     the transcript to the caller's conversation log so voice calls become
     searchable and persistent in the same interface as text chats.
 
-    The conversation_id is the caller's E.164 phone number (e.g. +46765784797).
+    The conversation_id is the caller's E.164 phone number (e.g. +15551234567).
     """
     if error := _validate_conversation_id(conversation_id):
         return error

--- a/gptme/server/openapi_docs.py
+++ b/gptme/server/openapi_docs.py
@@ -339,6 +339,48 @@ class InterruptRequest(BaseModel):
     session_id: str = Field(..., description="Session ID")
 
 
+class TranscriptTurn(BaseModel):
+    """A single transcript turn from a voice call."""
+
+    role: str = Field(
+        ...,
+        description="Message role (user or assistant)",
+        pattern="^(user|assistant)$",
+    )
+    text: str = Field(..., description="Transcript text content")
+    ended_at: float | None = Field(
+        None, description="Unix timestamp when this turn ended"
+    )
+
+
+class CallMetadata(BaseModel):
+    """Metadata about a voice call."""
+
+    call_sid: str = Field(
+        ..., description="Twilio/voice provider call SID for idempotency"
+    )
+    source: str | None = Field(None, description="Call source (twilio, local, etc.)")
+    duration_seconds: float | None = Field(None, description="Call duration in seconds")
+    archive_path: str | None = Field(None, description="Path to archived call record")
+
+
+class TranscriptRequest(BaseModel):
+    """Request to append voice transcript turns to a conversation."""
+
+    turns: list[TranscriptTurn] = Field(..., description="Transcript turns to append")
+    call_metadata: CallMetadata = Field(
+        ..., description="Call metadata for idempotency"
+    )
+
+
+class TranscriptResponse(BaseModel):
+    """Response from appending voice transcript turns."""
+
+    status: str = Field(..., description="Operation status (ok or already_acked)")
+    conversation_id: str = Field(..., description="Conversation ID")
+    messages_added: int = Field(..., description="Number of messages added")
+
+
 class AgentCreateRequest(BaseModel):
     """Request to create a new agent."""
 

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -1661,3 +1661,118 @@ def test_v2_user_settings_no_providers_no_model(client: FlaskClient, monkeypatch
     assert data["default_model"] is None
     assert data["default_model_source"] is None
     assert data["config_files"]["local_config_exists"] is False
+
+
+def test_v2_conversation_transcript_append(
+    client: FlaskClient, monkeypatch: pytest.MonkeyPatch
+):
+    """POST /api/v2/conversations/{id}/transcript appends voice transcript turns."""
+    conv_id = f"test-transcript-{random.randint(0, 1000000)}"
+
+    # Create conversation (also creates logdir)
+    response = client.put(f"/api/v2/conversations/{conv_id}", json={"prompt": "Test"})
+    assert response.status_code == 200
+
+    # First call: should add messages
+    transcript_payload = {
+        "turns": [
+            {"role": "user", "text": "Hello Bob!", "ended_at": 1234567890.0},
+            {
+                "role": "assistant",
+                "text": "Hi! How can I help?",
+                "ended_at": 1234567891.0,
+            },
+        ],
+        "call_metadata": {
+            "call_sid": "CA_test123",
+            "source": "twilio",
+            "duration_seconds": 60.0,
+            "archive_path": "state/voice-calls/archive/test.json",
+        },
+    }
+    response = client.post(
+        f"/api/v2/conversations/{conv_id}/transcript", json=transcript_payload
+    )
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["status"] == "ok"
+    assert data["conversation_id"] == conv_id
+    assert data["messages_added"] == 2
+
+    # Second call with same call_sid: idempotent (already_acked)
+    response = client.post(
+        f"/api/v2/conversations/{conv_id}/transcript", json=transcript_payload
+    )
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["status"] == "already_acked"
+    assert data["messages_added"] == 0
+
+    # Different call_sid: should add more messages
+    transcript_payload2 = {
+        "turns": [
+            {"role": "user", "text": "Follow-up question", "ended_at": 1234567892.0},
+            {"role": "assistant", "text": "Sure, go ahead!", "ended_at": 1234567893.0},
+        ],
+        "call_metadata": {
+            "call_sid": "CA_test456",
+            "source": "twilio",
+        },
+    }
+    response = client.post(
+        f"/api/v2/conversations/{conv_id}/transcript", json=transcript_payload2
+    )
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["status"] == "ok"
+    assert data["messages_added"] == 2
+
+
+def test_v2_conversation_transcript_skips_empty_turns(client: FlaskClient):
+    """Transcript endpoint skips whitespace-only and invalid-role turns."""
+    conv_id = f"test-transcript-skip-{random.randint(0, 1000000)}"
+
+    response = client.put(f"/api/v2/conversations/{conv_id}", json={"prompt": "Test"})
+    assert response.status_code == 200
+
+    payload = {
+        "turns": [
+            {"role": "user", "text": "Valid message", "ended_at": 1234567890.0},
+            {
+                "role": "user",
+                "text": "   ",
+                "ended_at": 1234567891.0,
+            },  # whitespace-only
+            {
+                "role": "invalid",
+                "text": "Should skip",
+                "ended_at": 1234567892.0,
+            },  # bad role
+            {"role": "assistant", "text": "", "ended_at": 1234567893.0},  # empty
+        ],
+        "call_metadata": {"call_sid": "CA_skip_test"},
+    }
+    response = client.post(f"/api/v2/conversations/{conv_id}/transcript", json=payload)
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["status"] == "ok"
+    assert data["messages_added"] == 1  # only the valid user message
+
+
+def test_v2_conversation_transcript_creates_conversation(client: FlaskClient):
+    """Transcript endpoint creates a new conversation if one doesn't exist."""
+    conv_id = f"test-new-conv-{random.randint(0, 1000000)}"
+
+    # Don't create the conversation first — transcript endpoint should create it
+    payload = {
+        "turns": [
+            {"role": "user", "text": "First message ever", "ended_at": 1234567890.0}
+        ],
+        "call_metadata": {"call_sid": "CA_new_conv"},
+    }
+    response = client.post(f"/api/v2/conversations/{conv_id}/transcript", json=payload)
+    # Should succeed even without pre-creating the conversation
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["status"] == "ok"
+    assert data["messages_added"] == 1


### PR DESCRIPTION
## Summary

Voice Phase 3: adds POST /api/v2/conversations/{conversation_id}/transcript endpoint.

This endpoint is called by the voice server after a call ends, promoting the transcript to the caller's conversation log so voice calls become searchable and persistent in the same interface as text chats.

## Key design decisions

- conversation_id = caller_id (E.164 phone) — Erik's number +46765784797 becomes the conversation ID. Calling again continues the same thread. No separate voice inbox needed.
- Idempotent via call_sid — if the same call is posted twice (e.g. retry), returns already_acked with messages_added: 0.
- Creates conversation if missing — LogManager.load(..., create=True) ensures the logdir and conversation.jsonl exist.

## Changes

| File | Change |
|------|--------|
| gptme/server/api_v2_sessions.py | New api_conversation_transcript endpoint |
| gptme/server/openapi_docs.py | TranscriptTurn, CallMetadata, TranscriptRequest, TranscriptResponse models |
| tests/test_server_v2.py | 3 tests: append, idempotency, auto-creation |

## Testing

All 3 tests pass:
- test_v2_conversation_transcript_append
- test_v2_conversation_transcript_skips_empty_turns
- test_v2_conversation_transcript_creates_conversation

Related: gptme-voice-integration-into-gptme-core task
