### PR TITLE
fix(server): validate per-turn dict type in POST /transcript

### DIFF
--- a/gptme/server/api_v2_sessions.py
+++ b/gptme/server/api_v2_sessions.py
@@ -829,6 +829,9 @@ def api_conversation_transcript(conversation_id: str):
 
     if not turns or not isinstance(turns, list):
         return flask.jsonify({"error": "turns (list) is required"}), 400
+    for i, turn in enumerate(turns):
+        if not isinstance(turn, dict):
+            return flask.jsonify({"error": f"turns[{i}] must be an object"}), 400
     if not call_metadata or not isinstance(call_metadata, dict):
         return flask.jsonify({"error": "call_metadata (object) is required"}), 400
 

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -1776,3 +1776,24 @@ def test_v2_conversation_transcript_creates_conversation(client: FlaskClient):
     data = response.get_json()
     assert data["status"] == "ok"
     assert data["messages_added"] == 1
+
+
+def test_v2_conversation_transcript_rejects_non_dict_turns(client: FlaskClient):
+    """Transcript endpoint returns 400 when any turn element is not an object."""
+    conv_id = f"test-transcript-nondict-{random.randint(0, 1000000)}"
+
+    for bad_turns in [
+        ["bare string"],
+        [42],
+        [{"role": "user", "text": "valid"}, "oops"],
+    ]:
+        payload = {
+            "turns": bad_turns,
+            "call_metadata": {"call_sid": "CA_nondict"},
+        }
+        response = client.post(
+            f"/api/v2/conversations/{conv_id}/transcript", json=payload
+        )
+        assert response.status_code == 400
+        data = response.get_json()
+        assert "turns[" in data["error"] and "must be an object" in data["error"]


### PR DESCRIPTION
Fixes #2316, follow-up to #2315 (voice Phase 3).

## Problem

Greptile flagged a P1 in the final review on #2315 that wasn't addressed before merge:

> If any element of `turns` is not a dict (e.g. a bare string or number), `turn.get("role")` raises `AttributeError`, returning an unhandled 500 instead of a clean 400.

The top-level `_get_request_json_object` check validates the outer body but not individual list elements.

## Fix

Iterate over `turns` before entering the `LogManager` lock, return a 400 with a descriptive error (`turns[i] must be an object`) if any element is not a `dict`.

## Tests

Added `test_v2_conversation_transcript_rejects_non_dict_turns` covering:
- bare string list (`["bare string"]`)
- integer list (`[42]`)
- mixed list (one valid dict followed by a bare string)