### PR TITLE
feat(webui): add embedded MenuBar context slot

### DIFF
--- a/webui/src/App.tsx
+++ b/webui/src/App.tsx
@@ -5,6 +5,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { ThemeProvider } from 'next-themes';
 import { ApiProvider } from './contexts/ApiContext';
+import { EmbeddedContextProvider } from './contexts/EmbeddedContext';
 import { SettingsProvider } from './contexts/SettingsContext';
 import Index from './pages/Index';
 import Tasks from './pages/Tasks';
@@ -42,40 +43,47 @@ const queryClient = new QueryClient({
 
 const App: FC = () => {
   return (
-    <SettingsProvider>
-      <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
-        <QueryClientProvider client={queryClient}>
-          <TooltipProvider>
-            <ApiProvider queryClient={queryClient}>
-              <BrowserRouter
-                basename={import.meta.env.BASE_URL}
-                future={{
-                  v7_startTransition: true,
-                  v7_relativeSplatPath: true,
-                }}
-              >
-                <Routes>
-                  <Route path="/" element={<Index />} />
-                  <Route path="/chat" element={<Index />} />
-                  <Route path="/chat/:id" element={<Index />} />
-                  <Route path="/tasks" element={<Tasks />} />
-                  <Route path="/tasks/:id" element={<Tasks />} />
-                  <Route path="/agents" element={<Agents />} />
-                  <Route path="/workspaces" element={<Workspaces />} />
-                  <Route path="/history" element={<History />} />
-                  <Route path="/external-sessions" element={<ExternalSessions />} />
-                  <Route path="/workspace/:id" element={<Workspace />} />
-                </Routes>
-                <SetupWizard />
-                <CommandPalette />
-                <Toaster />
-                <Sonner />
-              </BrowserRouter>
-            </ApiProvider>
-          </TooltipProvider>
-        </QueryClientProvider>
-      </ThemeProvider>
-    </SettingsProvider>
+    <EmbeddedContextProvider>
+      <SettingsProvider>
+        <ThemeProvider
+          attribute="class"
+          defaultTheme="system"
+          enableSystem
+          disableTransitionOnChange
+        >
+          <QueryClientProvider client={queryClient}>
+            <TooltipProvider>
+              <ApiProvider queryClient={queryClient}>
+                <BrowserRouter
+                  basename={import.meta.env.BASE_URL}
+                  future={{
+                    v7_startTransition: true,
+                    v7_relativeSplatPath: true,
+                  }}
+                >
+                  <Routes>
+                    <Route path="/" element={<Index />} />
+                    <Route path="/chat" element={<Index />} />
+                    <Route path="/chat/:id" element={<Index />} />
+                    <Route path="/tasks" element={<Tasks />} />
+                    <Route path="/tasks/:id" element={<Tasks />} />
+                    <Route path="/agents" element={<Agents />} />
+                    <Route path="/workspaces" element={<Workspaces />} />
+                    <Route path="/history" element={<History />} />
+                    <Route path="/external-sessions" element={<ExternalSessions />} />
+                    <Route path="/workspace/:id" element={<Workspace />} />
+                  </Routes>
+                  <SetupWizard />
+                  <CommandPalette />
+                  <Toaster />
+                  <Sonner />
+                </BrowserRouter>
+              </ApiProvider>
+            </TooltipProvider>
+          </QueryClientProvider>
+        </ThemeProvider>
+      </SettingsProvider>
+    </EmbeddedContextProvider>
   );
 };
 

--- a/webui/src/components/MenuBar.tsx
+++ b/webui/src/components/MenuBar.tsx
@@ -36,8 +36,7 @@ function groupEmbeddedMenuItems(menuItems: EmbeddedMenuItem[]) {
 
 export const MenuBar: FC = () => {
   const leftSidebarOpen = use$(leftSidebarVisible$);
-  const { menuItems, sendAction } = useEmbeddedContext();
-  const isEmbedded = import.meta.env.VITE_EMBEDDED_MODE === 'true';
+  const { menuItems, sendAction, isEmbedded } = useEmbeddedContext();
   const embeddedMenuGroups = groupEmbeddedMenuItems(menuItems);
   const hasEmbeddedMenu = isEmbedded && embeddedMenuGroups.length > 0;
 

--- a/webui/src/components/MenuBar.tsx
+++ b/webui/src/components/MenuBar.tsx
@@ -1,16 +1,45 @@
 import { ServerSelector } from './ServerSelector';
 import { Button } from './ui/button';
-import { User, Search, Menu } from 'lucide-react';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from './ui/dropdown-menu';
+import { ChevronDown, Menu, Search, User } from 'lucide-react';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { useEmbeddedContext } from '@/contexts/EmbeddedContext';
+import type { EmbeddedMenuItem } from '@/lib/embeddedContext';
 import { Link } from 'react-router-dom';
 import { commandPaletteOpen$ } from '@/stores/commandPalette';
 import { leftSidebarVisible$, toggleLeftSidebar } from '@/stores/sidebar';
 import { use$ } from '@legendapp/state/react';
 
-import type { FC } from 'react';
+import { Fragment, type FC } from 'react';
+
+function groupEmbeddedMenuItems(menuItems: EmbeddedMenuItem[]) {
+  return menuItems.reduce<{ section?: string; items: EmbeddedMenuItem[] }[]>((groups, item) => {
+    const section = item.section?.trim() || undefined;
+    const lastGroup = groups.at(-1);
+
+    if (lastGroup && lastGroup.section === section) {
+      lastGroup.items.push(item);
+      return groups;
+    }
+
+    groups.push({ section, items: [item] });
+    return groups;
+  }, []);
+}
 
 export const MenuBar: FC = () => {
   const leftSidebarOpen = use$(leftSidebarVisible$);
+  const { menuItems, sendAction } = useEmbeddedContext();
+  const isEmbedded = import.meta.env.VITE_EMBEDDED_MODE === 'true';
+  const embeddedMenuGroups = groupEmbeddedMenuItems(menuItems);
+  const hasEmbeddedMenu = isEmbedded && embeddedMenuGroups.length > 0;
 
   return (
     <div
@@ -76,19 +105,69 @@ export const MenuBar: FC = () => {
           </Tooltip>
         </TooltipProvider>
         <ServerSelector />
-        {import.meta.env.VITE_EMBEDDED_MODE === 'true' && (
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Link to="/account">
-                  <Button variant="ghost" size="icon" className="h-8 w-8" aria-label="Dashboard">
-                    <User className="h-4 w-4" />
-                  </Button>
-                </Link>
-              </TooltipTrigger>
-              <TooltipContent side="bottom">Dashboard</TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
+        {hasEmbeddedMenu ? (
+          <DropdownMenu>
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-8 gap-1 px-2"
+                      aria-label="Account menu"
+                    >
+                      <User className="h-4 w-4" />
+                      <ChevronDown className="h-3 w-3" />
+                    </Button>
+                  </DropdownMenuTrigger>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">Account</TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+            <DropdownMenuContent align="end" className="w-56">
+              {embeddedMenuGroups.map((group, groupIndex) => (
+                <Fragment key={group.section ?? `group-${groupIndex}`}>
+                  {groupIndex > 0 && <DropdownMenuSeparator />}
+                  {group.section && <DropdownMenuLabel>{group.section}</DropdownMenuLabel>}
+                  {group.items.map((item) =>
+                    item.kind === 'link' ? (
+                      <DropdownMenuItem key={item.id} asChild>
+                        <a href={item.href} target="_top" rel="noreferrer">
+                          {item.label}
+                        </a>
+                      </DropdownMenuItem>
+                    ) : (
+                      <DropdownMenuItem
+                        key={item.id}
+                        className={
+                          item.destructive ? 'text-destructive focus:text-destructive' : undefined
+                        }
+                        onSelect={() => sendAction(item.action, item.id)}
+                      >
+                        {item.label}
+                      </DropdownMenuItem>
+                    )
+                  )}
+                </Fragment>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        ) : (
+          isEmbedded && (
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <a href="/account" target="_top" rel="noreferrer">
+                    <Button variant="ghost" size="icon" className="h-8 w-8" aria-label="Dashboard">
+                      <User className="h-4 w-4" />
+                    </Button>
+                  </a>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">Dashboard</TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          )
         )}
       </div>
     </div>

--- a/webui/src/components/MenuBar.tsx
+++ b/webui/src/components/MenuBar.tsx
@@ -126,7 +126,7 @@ export const MenuBar: FC = () => {
             </TooltipProvider>
             <DropdownMenuContent align="end" className="w-56">
               {embeddedMenuGroups.map((group, groupIndex) => (
-                <Fragment key={group.section ?? `group-${groupIndex}`}>
+                <Fragment key={`${group.section ?? 'group'}-${groupIndex}`}>
                   {groupIndex > 0 && <DropdownMenuSeparator />}
                   {group.section && <DropdownMenuLabel>{group.section}</DropdownMenuLabel>}
                   {group.items.map((item) =>

--- a/webui/src/contexts/EmbeddedContext.tsx
+++ b/webui/src/contexts/EmbeddedContext.tsx
@@ -1,0 +1,102 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type FC,
+  type PropsWithChildren,
+} from 'react';
+import {
+  getEmbeddedParentOrigin,
+  isEmbeddedContextEventAllowed,
+  parseEmbeddedContextMessage,
+  type EmbeddedMenuItem,
+} from '@/lib/embeddedContext';
+
+interface EmbeddedContextValue {
+  isEmbedded: boolean;
+  menuItems: EmbeddedMenuItem[];
+  parentOrigin: string | null;
+  sendAction: (action: string, itemId?: string) => void;
+}
+
+const EmbeddedContext = createContext<EmbeddedContextValue>({
+  isEmbedded: false,
+  menuItems: [],
+  parentOrigin: null,
+  sendAction: () => {},
+});
+
+export const EmbeddedContextProvider: FC<PropsWithChildren> = ({ children }) => {
+  const isEmbedded = import.meta.env.VITE_EMBEDDED_MODE === 'true';
+  const [menuItems, setMenuItems] = useState<EmbeddedMenuItem[]>([]);
+  const [parentOrigin, setParentOrigin] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isEmbedded || typeof window === 'undefined' || window.parent === window) {
+      return;
+    }
+
+    const resolvedParentOrigin = getEmbeddedParentOrigin(document.referrer);
+    setParentOrigin(resolvedParentOrigin);
+
+    const handleMessage = (event: MessageEvent) => {
+      if (
+        !isEmbeddedContextEventAllowed(event.origin, resolvedParentOrigin, window.location.origin)
+      ) {
+        return;
+      }
+
+      const parsedItems = parseEmbeddedContextMessage(event.data);
+      if (parsedItems) {
+        setMenuItems(parsedItems);
+      }
+    };
+
+    window.addEventListener('message', handleMessage);
+    window.parent.postMessage(
+      {
+        type: 'gptme-webui:embedded-context-ready',
+      },
+      resolvedParentOrigin ?? '*'
+    );
+
+    return () => {
+      window.removeEventListener('message', handleMessage);
+    };
+  }, [isEmbedded]);
+
+  const sendAction = useCallback(
+    (action: string, itemId?: string) => {
+      if (!isEmbedded || typeof window === 'undefined' || window.parent === window) {
+        return;
+      }
+
+      window.parent.postMessage(
+        {
+          type: 'gptme-webui:embedded-action',
+          action,
+          itemId,
+        },
+        parentOrigin ?? '*'
+      );
+    },
+    [isEmbedded, parentOrigin]
+  );
+
+  const value = useMemo(
+    () => ({
+      isEmbedded,
+      menuItems,
+      parentOrigin,
+      sendAction,
+    }),
+    [isEmbedded, menuItems, parentOrigin, sendAction]
+  );
+
+  return <EmbeddedContext.Provider value={value}>{children}</EmbeddedContext.Provider>;
+};
+
+export const useEmbeddedContext = (): EmbeddedContextValue => useContext(EmbeddedContext);

--- a/webui/src/contexts/EmbeddedContext.tsx
+++ b/webui/src/contexts/EmbeddedContext.tsx
@@ -47,25 +47,32 @@ export const EmbeddedContextProvider: FC<PropsWithChildren> = ({ children }) => 
     setParentOrigin(referrerOrigin);
 
     const handleMessage = (event: MessageEvent) => {
+      if (event.source !== window.parent) {
+        return;
+      }
+
+      const parsedItems = parseEmbeddedContextMessage(event.data);
+      if (!parsedItems) {
+        return;
+      }
+
       if (
         !isEmbeddedContextEventAllowed(
           event.origin,
           parentOriginRef.current,
-          window.location.origin
+          window.location.origin,
+          { allowUnknownParentOrigin: true }
         )
       ) {
         return;
       }
 
-      const parsedItems = parseEmbeddedContextMessage(event.data);
-      if (parsedItems) {
-        setMenuItems(parsedItems);
-        // Capture confirmed parent origin from first valid inbound when referrer was absent
-        if (!parentOriginRef.current) {
-          parentOriginRef.current = event.origin;
-          setParentOrigin(event.origin);
-        }
+      if (!parentOriginRef.current) {
+        parentOriginRef.current = event.origin;
+        setParentOrigin(event.origin);
       }
+
+      setMenuItems(parsedItems);
     };
 
     window.addEventListener('message', handleMessage);

--- a/webui/src/contexts/EmbeddedContext.tsx
+++ b/webui/src/contexts/EmbeddedContext.tsx
@@ -4,6 +4,7 @@ import {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
   type FC,
   type PropsWithChildren,
@@ -33,18 +34,25 @@ export const EmbeddedContextProvider: FC<PropsWithChildren> = ({ children }) => 
   const isEmbedded = import.meta.env.VITE_EMBEDDED_MODE === 'true';
   const [menuItems, setMenuItems] = useState<EmbeddedMenuItem[]>([]);
   const [parentOrigin, setParentOrigin] = useState<string | null>(null);
+  // Ref so the message handler closure always reads the latest confirmed origin
+  const parentOriginRef = useRef<string | null>(null);
 
   useEffect(() => {
     if (!isEmbedded || typeof window === 'undefined' || window.parent === window) {
       return;
     }
 
-    const resolvedParentOrigin = getEmbeddedParentOrigin(document.referrer);
-    setParentOrigin(resolvedParentOrigin);
+    const referrerOrigin = getEmbeddedParentOrigin(document.referrer);
+    parentOriginRef.current = referrerOrigin;
+    setParentOrigin(referrerOrigin);
 
     const handleMessage = (event: MessageEvent) => {
       if (
-        !isEmbeddedContextEventAllowed(event.origin, resolvedParentOrigin, window.location.origin)
+        !isEmbeddedContextEventAllowed(
+          event.origin,
+          parentOriginRef.current,
+          window.location.origin
+        )
       ) {
         return;
       }
@@ -52,15 +60,19 @@ export const EmbeddedContextProvider: FC<PropsWithChildren> = ({ children }) => 
       const parsedItems = parseEmbeddedContextMessage(event.data);
       if (parsedItems) {
         setMenuItems(parsedItems);
+        // Capture confirmed parent origin from first valid inbound when referrer was absent
+        if (!parentOriginRef.current) {
+          parentOriginRef.current = event.origin;
+          setParentOrigin(event.origin);
+        }
       }
     };
 
     window.addEventListener('message', handleMessage);
+    // Ready signal carries no sensitive payload; '*' fallback is acceptable for the handshake
     window.parent.postMessage(
-      {
-        type: 'gptme-webui:embedded-context-ready',
-      },
-      resolvedParentOrigin ?? '*'
+      { type: 'gptme-webui:embedded-context-ready' },
+      referrerOrigin ?? '*'
     );
 
     return () => {
@@ -73,14 +85,13 @@ export const EmbeddedContextProvider: FC<PropsWithChildren> = ({ children }) => 
       if (!isEmbedded || typeof window === 'undefined' || window.parent === window) {
         return;
       }
-
+      if (!parentOrigin) {
+        // Don't send to '*' — skip until parent origin is confirmed via handshake
+        return;
+      }
       window.parent.postMessage(
-        {
-          type: 'gptme-webui:embedded-action',
-          action,
-          itemId,
-        },
-        parentOrigin ?? '*'
+        { type: 'gptme-webui:embedded-action', action, itemId },
+        parentOrigin
       );
     },
     [isEmbedded, parentOrigin]

--- a/webui/src/contexts/__tests__/EmbeddedContext.test.ts
+++ b/webui/src/contexts/__tests__/EmbeddedContext.test.ts
@@ -1,0 +1,84 @@
+import {
+  getEmbeddedParentOrigin,
+  isEmbeddedContextEventAllowed,
+  parseEmbeddedContextMessage,
+} from '@/lib/embeddedContext';
+
+describe('EmbeddedContext helpers', () => {
+  it('derives the parent origin from document.referrer', () => {
+    expect(getEmbeddedParentOrigin('https://gptme.ai/chat')).toBe('https://gptme.ai');
+    expect(getEmbeddedParentOrigin('')).toBeNull();
+    expect(getEmbeddedParentOrigin('not-a-url')).toBeNull();
+  });
+
+  it('parses valid embedded context messages', () => {
+    expect(
+      parseEmbeddedContextMessage({
+        type: 'gptme-host:embedded-context',
+        payload: {
+          menuItems: [
+            {
+              kind: 'link',
+              id: 'dashboard',
+              label: 'Dashboard',
+              href: '/account',
+              section: 'General',
+            },
+            {
+              kind: 'action',
+              id: 'sign-out',
+              label: 'Sign out',
+              action: 'sign_out',
+              destructive: true,
+            },
+          ],
+        },
+      })
+    ).toEqual([
+      { kind: 'link', id: 'dashboard', label: 'Dashboard', href: '/account', section: 'General' },
+      { kind: 'action', id: 'sign-out', label: 'Sign out', action: 'sign_out', destructive: true },
+    ]);
+  });
+
+  it('rejects malformed embedded context messages', () => {
+    expect(
+      parseEmbeddedContextMessage({
+        type: 'gptme-host:embedded-context',
+        payload: {
+          menuItems: [{ kind: 'link', id: 'dashboard', label: 'Dashboard' }],
+        },
+      })
+    ).toBeNull();
+
+    expect(
+      parseEmbeddedContextMessage({
+        type: 'wrong-type',
+        payload: {
+          menuItems: [],
+        },
+      })
+    ).toBeNull();
+  });
+
+  it('only accepts messages from the parent origin when known', () => {
+    expect(
+      isEmbeddedContextEventAllowed('https://gptme.ai', 'https://gptme.ai', 'http://localhost:5173')
+    ).toBe(true);
+    expect(
+      isEmbeddedContextEventAllowed(
+        'https://evil.example',
+        'https://gptme.ai',
+        'http://localhost:5173'
+      )
+    ).toBe(false);
+  });
+
+  it('falls back to same-origin messages when no parent origin is known', () => {
+    expect(
+      isEmbeddedContextEventAllowed('http://localhost:5173', null, 'http://localhost:5173')
+    ).toBe(true);
+    expect(isEmbeddedContextEventAllowed('https://gptme.ai', null, 'http://localhost:5173')).toBe(
+      false
+    );
+  });
+});

--- a/webui/src/contexts/__tests__/EmbeddedContext.test.ts
+++ b/webui/src/contexts/__tests__/EmbeddedContext.test.ts
@@ -102,4 +102,12 @@ describe('EmbeddedContext helpers', () => {
       false
     );
   });
+
+  it('can accept a first validated bootstrap message from an unknown parent origin', () => {
+    expect(
+      isEmbeddedContextEventAllowed('https://gptme.ai', null, 'http://localhost:5173', {
+        allowUnknownParentOrigin: true,
+      })
+    ).toBe(true);
+  });
 });

--- a/webui/src/contexts/__tests__/EmbeddedContext.test.ts
+++ b/webui/src/contexts/__tests__/EmbeddedContext.test.ts
@@ -60,6 +60,27 @@ describe('EmbeddedContext helpers', () => {
     ).toBeNull();
   });
 
+  it('rejects unsafe href protocols in link menu items', () => {
+    const makeMsg = (href: string) => ({
+      type: 'gptme-host:embedded-context',
+      payload: { menuItems: [{ kind: 'link', id: 'x', label: 'X', href }] },
+    });
+
+    // Safe: relative paths and http/https
+    expect(parseEmbeddedContextMessage(makeMsg('/account'))).not.toBeNull();
+    expect(parseEmbeddedContextMessage(makeMsg('./relative'))).not.toBeNull();
+    expect(parseEmbeddedContextMessage(makeMsg('#anchor'))).not.toBeNull();
+    expect(parseEmbeddedContextMessage(makeMsg('https://example.com'))).not.toBeNull();
+    expect(parseEmbeddedContextMessage(makeMsg('http://localhost:3000'))).not.toBeNull();
+
+    // Unsafe: javascript: and other non-http protocols
+    expect(parseEmbeddedContextMessage(makeMsg('javascript:alert(1)'))).toBeNull();
+    expect(
+      parseEmbeddedContextMessage(makeMsg('data:text/html,<script>alert(1)</script>'))
+    ).toBeNull();
+    expect(parseEmbeddedContextMessage(makeMsg('vbscript:msgbox(1)'))).toBeNull();
+  });
+
   it('only accepts messages from the parent origin when known', () => {
     expect(
       isEmbeddedContextEventAllowed('https://gptme.ai', 'https://gptme.ai', 'http://localhost:5173')

--- a/webui/src/lib/embeddedContext.ts
+++ b/webui/src/lib/embeddedContext.ts
@@ -4,7 +4,30 @@ const embeddedLinkMenuItemSchema = z.object({
   kind: z.literal('link'),
   id: z.string().min(1),
   label: z.string().min(1),
-  href: z.string().min(1),
+  href: z
+    .string()
+    .min(1)
+    .refine(
+      (val) => {
+        // Allow relative paths (safe by definition)
+        if (
+          val.startsWith('/') ||
+          val.startsWith('./') ||
+          val.startsWith('../') ||
+          val.startsWith('#')
+        ) {
+          return true;
+        }
+        // For absolute URLs only allow http/https — blocks javascript: and other unsafe protocols
+        try {
+          const url = new URL(val);
+          return url.protocol === 'https:' || url.protocol === 'http:';
+        } catch {
+          return false;
+        }
+      },
+      { message: 'href must use http/https protocol or be a relative path' }
+    ),
   section: z.string().min(1).optional(),
 });
 

--- a/webui/src/lib/embeddedContext.ts
+++ b/webui/src/lib/embeddedContext.ts
@@ -1,0 +1,61 @@
+import { z } from 'zod';
+
+const embeddedLinkMenuItemSchema = z.object({
+  kind: z.literal('link'),
+  id: z.string().min(1),
+  label: z.string().min(1),
+  href: z.string().min(1),
+  section: z.string().min(1).optional(),
+});
+
+const embeddedActionMenuItemSchema = z.object({
+  kind: z.literal('action'),
+  id: z.string().min(1),
+  label: z.string().min(1),
+  action: z.string().min(1),
+  section: z.string().min(1).optional(),
+  destructive: z.boolean().optional(),
+});
+
+export const embeddedMenuItemSchema = z.discriminatedUnion('kind', [
+  embeddedLinkMenuItemSchema,
+  embeddedActionMenuItemSchema,
+]);
+
+const embeddedContextMessageSchema = z.object({
+  type: z.literal('gptme-host:embedded-context'),
+  payload: z.object({
+    menuItems: z.array(embeddedMenuItemSchema),
+  }),
+});
+
+export type EmbeddedMenuItem = z.infer<typeof embeddedMenuItemSchema>;
+
+export function getEmbeddedParentOrigin(referrer: string): string | null {
+  if (!referrer) {
+    return null;
+  }
+
+  try {
+    return new URL(referrer).origin;
+  } catch {
+    return null;
+  }
+}
+
+export function parseEmbeddedContextMessage(data: unknown): EmbeddedMenuItem[] | null {
+  const parsed = embeddedContextMessageSchema.safeParse(data);
+  return parsed.success ? parsed.data.payload.menuItems : null;
+}
+
+export function isEmbeddedContextEventAllowed(
+  eventOrigin: string,
+  parentOrigin: string | null,
+  ownOrigin: string
+): boolean {
+  if (parentOrigin) {
+    return eventOrigin === parentOrigin;
+  }
+
+  return eventOrigin === ownOrigin;
+}

--- a/webui/src/lib/embeddedContext.ts
+++ b/webui/src/lib/embeddedContext.ts
@@ -74,10 +74,15 @@ export function parseEmbeddedContextMessage(data: unknown): EmbeddedMenuItem[] |
 export function isEmbeddedContextEventAllowed(
   eventOrigin: string,
   parentOrigin: string | null,
-  ownOrigin: string
+  ownOrigin: string,
+  options: { allowUnknownParentOrigin?: boolean } = {}
 ): boolean {
   if (parentOrigin) {
     return eventOrigin === parentOrigin;
+  }
+
+  if (options.allowUnknownParentOrigin) {
+    return true;
   }
 
   return eventOrigin === ownOrigin;


### PR DESCRIPTION
## Summary
- add an `EmbeddedContextProvider` for host-injected MenuBar items in embedded mode
- support grouped link/action items over a `postMessage` contract with origin checks
- render embedded host links with `target="_top"` and keep the current dashboard icon as fallback

## Testing
- `cd webui && npm run typecheck`
- `cd webui && npm test -- --runInBand src/contexts/__tests__/EmbeddedContext.test.ts`

## Related
- Closes #2318
- Follow-up host integration: gptme/gptme-cloud#215
