### PR TITLE
feat(cost-awareness): warn on cold Anthropic prompt cache

### DIFF
--- a/gptme/hooks/cost_awareness.py
+++ b/gptme/hooks/cost_awareness.py
@@ -75,6 +75,10 @@ def anthropic_cache_cold_warning(
     if not anthropic_entries:
         return None
 
+    # Only warn when cache was actually written; uncached requests have nothing cold
+    if not any(entry.cache_creation_tokens > 0 for entry in anthropic_entries):
+        return None
+
     last_timestamp = max(entry.timestamp for entry in anthropic_entries)
     age_seconds = (time.time() if now is None else now) - last_timestamp
     if age_seconds <= ANTHROPIC_CACHE_TTL_SECONDS:

--- a/gptme/hooks/cost_awareness.py
+++ b/gptme/hooks/cost_awareness.py
@@ -9,6 +9,7 @@ See Issue #935 for design context.
 """
 
 import logging
+import time
 from collections.abc import Generator
 from contextvars import ContextVar
 from pathlib import Path
@@ -16,7 +17,7 @@ from typing import TYPE_CHECKING, Any
 
 from ..hooks import HookType, StopPropagation, register_hook
 from ..message import Message
-from ..util.cost_tracker import CostTracker
+from ..util.cost_tracker import CostTracker, SessionCosts
 
 if TYPE_CHECKING:
     from ..logmanager import LogManager
@@ -50,6 +51,41 @@ COST_WARNING_THRESHOLDS = [
     500.00,
     1000.00,  # Large session warnings
 ]
+
+ANTHROPIC_CACHE_TTL_SECONDS = 5 * 60
+
+
+def _is_direct_anthropic_model(model: str | None) -> bool:
+    """Return True for direct Anthropic model IDs recorded by gptme."""
+    return bool(model and model.startswith(("anthropic/", "claude-")))
+
+
+def anthropic_cache_cold_warning(
+    costs: SessionCosts | None,
+    model: str | None,
+    now: float | None = None,
+) -> str | None:
+    """Return a warning when the next Anthropic turn is likely cache-cold."""
+    if not _is_direct_anthropic_model(model) or not costs:
+        return None
+
+    anthropic_entries = [
+        entry for entry in costs.entries if _is_direct_anthropic_model(entry.model)
+    ]
+    if not anthropic_entries:
+        return None
+
+    last_timestamp = max(entry.timestamp for entry in anthropic_entries)
+    age_seconds = (time.time() if now is None else now) - last_timestamp
+    if age_seconds <= ANTHROPIC_CACHE_TTL_SECONDS:
+        return None
+
+    age_minutes = age_seconds / 60
+    ttl_minutes = ANTHROPIC_CACHE_TTL_SECONDS // 60
+    return (
+        "Anthropic prompt cache likely cold "
+        f"({age_minutes:.1f} min since last Anthropic turn; TTL {ttl_minutes} min)"
+    )
 
 
 def session_start_cost_tracking(
@@ -142,12 +178,25 @@ def inject_pending_warning(
         System message with pending warning if one exists
     """
     pending_warning = _pending_warning_var.get()
+    should_inject = bool(messages and messages[-1].role == "user")
+
+    if should_inject:
+        cache_warning = anthropic_cache_cold_warning(
+            CostTracker.get_session_costs(),
+            kwargs.get("model"),
+        )
+        if cache_warning:
+            from ..util import console
+
+            console.log(f"[yellow]Warning: {cache_warning}[/yellow]")
+            yield Message(
+                "system",
+                f"<system_warning>{cache_warning}</system_warning>",
+                hide=True,
+            )
 
     # Only inject if there's a pending warning and the last message is from user
-    if not pending_warning:
-        return
-
-    if messages and messages[-1].role == "user":
+    if pending_warning and should_inject:
         yield Message(
             "system",
             pending_warning,

--- a/gptme/hooks/tests/test_cost_awareness.py
+++ b/gptme/hooks/tests/test_cost_awareness.py
@@ -332,6 +332,29 @@ class TestAnthropicCacheColdWarning:
 
         assert warning is None
 
+    def test_no_warning_when_no_cache_created(self):
+        """No warning when prior Anthropic turns never wrote to cache."""
+        CostTracker.start_session("test")
+        CostTracker.record(
+            CostEntry(
+                timestamp=10,
+                model="claude-sonnet-4-6",
+                input_tokens=100,
+                output_tokens=50,
+                cache_read_tokens=0,
+                cache_creation_tokens=0,  # no cache written
+                cost=0.01,
+            )
+        )
+
+        warning = anthropic_cache_cold_warning(
+            CostTracker.get_session_costs(),
+            model="anthropic/claude-sonnet-4-6",
+            now=10 + ANTHROPIC_CACHE_TTL_SECONDS + 1,
+        )
+
+        assert warning is None
+
     def test_no_warning_within_ttl(self):
         """Anthropic cache is considered warm inside the 5-minute TTL."""
         CostTracker.start_session("test")

--- a/gptme/hooks/tests/test_cost_awareness.py
+++ b/gptme/hooks/tests/test_cost_awareness.py
@@ -8,8 +8,10 @@ from unittest.mock import patch
 import pytest
 
 from gptme.hooks.cost_awareness import (
+    ANTHROPIC_CACHE_TTL_SECONDS,
     COST_WARNING_THRESHOLDS,
     _pending_warning_var,
+    anthropic_cache_cold_warning,
     cost_warning_hook,
     inject_pending_warning,
     session_end_cost_summary,
@@ -231,6 +233,152 @@ class TestInjectPendingWarning:
         _pending_warning_var.set("<system_warning>test</system_warning>")
         msgs = list(inject_pending_warning([]))
         assert msgs == []
+
+    def test_injects_cache_cold_warning_for_anthropic_model(self):
+        """Injects and prints a warning when Anthropic cache is likely cold."""
+        CostTracker.start_session("test")
+        CostTracker.record(
+            CostEntry(
+                timestamp=time.time() - ANTHROPIC_CACHE_TTL_SECONDS - 60,
+                model="claude-sonnet-4-6",
+                input_tokens=100,
+                output_tokens=50,
+                cache_read_tokens=0,
+                cache_creation_tokens=100,
+                cost=0.01,
+            )
+        )
+
+        messages = [Message("user", "hello")]
+        with patch("gptme.util.console.log") as mock_log:
+            msgs = list(
+                inject_pending_warning(
+                    messages,
+                    model="anthropic/claude-sonnet-4-6",
+                )
+            )
+
+        assert len(msgs) == 1
+        msg = cast(Message, msgs[0])
+        assert msg.role == "system"
+        assert msg.hide is True
+        assert "Anthropic prompt cache likely cold" in msg.content
+        mock_log.assert_called_once()
+        assert "Warning: Anthropic prompt cache likely cold" in mock_log.call_args[0][0]
+
+    def test_does_not_inject_cache_cold_warning_after_assistant_message(self):
+        """Cache cold warning only fires before user-triggered generation."""
+        CostTracker.start_session("test")
+        CostTracker.record(
+            CostEntry(
+                timestamp=time.time() - ANTHROPIC_CACHE_TTL_SECONDS - 60,
+                model="claude-sonnet-4-6",
+                input_tokens=100,
+                output_tokens=50,
+                cache_read_tokens=0,
+                cache_creation_tokens=100,
+                cost=0.01,
+            )
+        )
+
+        messages = [Message("assistant", "response")]
+        with patch("gptme.util.console.log") as mock_log:
+            msgs = list(
+                inject_pending_warning(
+                    messages,
+                    model="anthropic/claude-sonnet-4-6",
+                )
+            )
+
+        assert msgs == []
+        mock_log.assert_not_called()
+
+
+class TestAnthropicCacheColdWarning:
+    """Tests for Anthropic prompt-cache TTL warning logic."""
+
+    def test_no_warning_for_non_anthropic_model(self):
+        """Non-Anthropic generations ignore Anthropic cache timing."""
+        CostTracker.start_session("test")
+        CostTracker.record(
+            CostEntry(
+                timestamp=0,
+                model="claude-sonnet-4-6",
+                input_tokens=100,
+                output_tokens=50,
+                cache_read_tokens=0,
+                cache_creation_tokens=100,
+                cost=0.01,
+            )
+        )
+
+        warning = anthropic_cache_cold_warning(
+            CostTracker.get_session_costs(),
+            model="openai/gpt-4o",
+            now=ANTHROPIC_CACHE_TTL_SECONDS + 1,
+        )
+
+        assert warning is None
+
+    def test_no_warning_for_first_anthropic_turn(self):
+        """First Anthropic request has no prior cache state to warn about."""
+        CostTracker.start_session("test")
+
+        warning = anthropic_cache_cold_warning(
+            CostTracker.get_session_costs(),
+            model="anthropic/claude-sonnet-4-6",
+            now=ANTHROPIC_CACHE_TTL_SECONDS + 1,
+        )
+
+        assert warning is None
+
+    def test_no_warning_within_ttl(self):
+        """Anthropic cache is considered warm inside the 5-minute TTL."""
+        CostTracker.start_session("test")
+        CostTracker.record(
+            CostEntry(
+                timestamp=10,
+                model="claude-sonnet-4-6",
+                input_tokens=100,
+                output_tokens=50,
+                cache_read_tokens=0,
+                cache_creation_tokens=100,
+                cost=0.01,
+            )
+        )
+
+        warning = anthropic_cache_cold_warning(
+            CostTracker.get_session_costs(),
+            model="anthropic/claude-sonnet-4-6",
+            now=10 + ANTHROPIC_CACHE_TTL_SECONDS,
+        )
+
+        assert warning is None
+
+    def test_warning_after_ttl(self):
+        """Anthropic cache is likely cold once the prior turn is older than TTL."""
+        CostTracker.start_session("test")
+        CostTracker.record(
+            CostEntry(
+                timestamp=10,
+                model="claude-sonnet-4-6",
+                input_tokens=100,
+                output_tokens=50,
+                cache_read_tokens=0,
+                cache_creation_tokens=100,
+                cost=0.01,
+            )
+        )
+
+        warning = anthropic_cache_cold_warning(
+            CostTracker.get_session_costs(),
+            model="anthropic/claude-sonnet-4-6",
+            now=10 + ANTHROPIC_CACHE_TTL_SECONDS + 1,
+        )
+
+        assert warning is not None
+        assert "Anthropic prompt cache likely cold" in warning
+        assert "TTL 5 min" in warning
 
 
 class TestSessionEndCostSummary:

--- a/gptme/hooks/types.py
+++ b/gptme/hooks/types.py
@@ -182,6 +182,7 @@ class GenerationPreHook(Protocol):
         messages: List of conversation messages
         workspace: Workspace directory path (optional)
         manager: Conversation manager (optional, currently always None)
+        model: Fully-qualified model name used for this generation (optional)
     """
 
     def __call__(

--- a/gptme/llm/__init__.py
+++ b/gptme/llm/__init__.py
@@ -163,7 +163,11 @@ def reply(
 
     context_msgs = list(
         trigger_hook(
-            HookType.GENERATION_PRE, messages, workspace=workspace, manager=None
+            HookType.GENERATION_PRE,
+            messages,
+            workspace=workspace,
+            manager=None,
+            model=model,
         )
     )
 


### PR DESCRIPTION
## Summary
- pass the current model into generation.pre hooks
- warn on user-triggered Anthropic generations when the prior Anthropic request is older than the 5-minute prompt cache TTL
- print a CLI warning and inject a hidden system warning so the agent also sees the cost signal

Closes #2320

## Tests
- uv run --with pytest --with pytest-mock --with pytest-dotenv pytest gptme/hooks/tests/test_cost_awareness.py tests/test_cost_awareness_delayed_warning.py tests/test_cost_tracker.py -q
- uv run --with ruff ruff check gptme/hooks/cost_awareness.py gptme/hooks/tests/test_cost_awareness.py gptme/hooks/types.py gptme/llm/__init__.py
- uv run --with ruff ruff format --check gptme/hooks/cost_awareness.py gptme/hooks/tests/test_cost_awareness.py gptme/hooks/types.py gptme/llm/__init__.py
- uv run --with mypy mypy gptme/hooks/cost_awareness.py gptme/hooks/types.py gptme/llm/__init__.py