### PR TITLE
Add LLM cost change analysis to CI

### DIFF
--- a/.github/workflows/llm-costs.yml
+++ b/.github/workflows/llm-costs.yml
@@ -1,0 +1,17 @@
+name: LLM Cost Analysis
+
+on:
+  pull_request:
+    branches: [main, master]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  cost-analysis:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: Jwrede/tokentoll@v0.3.0


### PR DESCRIPTION
## Summary

Add [tokentoll](https://github.com/Jwrede/tokentoll) GitHub Action to analyze LLM API cost changes on pull requests.

When a PR modifies code that makes LLM API calls (model swaps, max_tokens changes, new call sites), tokentoll posts a comment showing the projected cost impact. It stays silent on PRs that don't touch LLM code.

## What it detects

tokentoll uses Python AST analysis (zero runtime dependencies) to find calls to:
- OpenAI (`chat.completions.create`, `responses.create`, `embeddings.create`)
- Anthropic (`messages.create`)
- Google GenAI (`generate_content`)
- LiteLLM (`completion`, `embedding`)
- LangChain (`ChatOpenAI`, `ChatAnthropic`, `init_chat_model`)

## Current scan of this project

## tokentoll Scan Report

| File | Line | SDK | Model | Est. Cost/Call | Monthly |
|------|------|-----|-------|---------------|---------|
| `gptme/llm/llm_anthropic.py` | 614 | anthropic | <dynamic> | N/A | N/A |
| `gptme/llm/llm_anthropic.py` | 710 | anthropic | <dynamic> | N/A | N/A |
| `gptme/llm/llm_openai.py` | 624 | openai | <dynamic> | N/A | N/A |
| `gptme/llm/llm_openai.py` | 800 | openai | <dynamic> | N/A | N/A |
| `gptme/tools/_browser_perplexity.py` | 68 | openai | sonar-pro | $0.03 | $30.01 |
| `tests/conftest.py` | 70 | anthropic | claude-haiku-4-5-20251001 | $0.000006 | $0.006000 |

**Total estimated monthly cost: $30.01**

<details>
<summary>Assumptions</summary>

- 1000 calls/month per call site

</details>

*Generated by [tokentoll](https://github.com/Jwrede/tokentoll)*


## How it works

- Runs only on PRs, compares base vs head
- Posts a sticky comment (updates in place, no duplicates)
- Only comments when LLM calls are added, removed, or modified
- First run posts an initial scan (this PR) so you can see the output
- Zero runtime dependencies, ~1s scan time for most projects
- [PyPI](https://pypi.org/project/tokentoll/) | [GitHub](https://github.com/Jwrede/tokentoll)

## Changes

- Adds `.github/workflows/llm-costs.yml` (17 lines)
- No code changes, no new dependencies