### PR TITLE
fix(webui): support same-window postMessage in EmbeddedContextProvider

### DIFF
--- a/webui/src/contexts/EmbeddedContext.tsx
+++ b/webui/src/contexts/EmbeddedContext.tsx
@@ -38,16 +38,18 @@ export const EmbeddedContextProvider: FC<PropsWithChildren> = ({ children }) => 
   const parentOriginRef = useRef<string | null>(null);
 
   useEffect(() => {
-    if (!isEmbedded || typeof window === 'undefined' || window.parent === window) {
+    if (!isEmbedded || typeof window === 'undefined') {
       return;
     }
 
-    const referrerOrigin = getEmbeddedParentOrigin(document.referrer);
+    const inIframe = window.parent !== window;
+    const referrerOrigin = inIframe ? getEmbeddedParentOrigin(document.referrer) : null;
     parentOriginRef.current = referrerOrigin;
     setParentOrigin(referrerOrigin);
 
     const handleMessage = (event: MessageEvent) => {
-      if (event.source !== window.parent) {
+      // Accept messages from parent frame (iframe case) or self (same-window case)
+      if (event.source !== window.parent && event.source !== window) {
         return;
       }
 
@@ -76,11 +78,13 @@ export const EmbeddedContextProvider: FC<PropsWithChildren> = ({ children }) => 
     };
 
     window.addEventListener('message', handleMessage);
-    // Ready signal carries no sensitive payload; '*' fallback is acceptable for the handshake
-    window.parent.postMessage(
-      { type: 'gptme-webui:embedded-context-ready' },
-      referrerOrigin ?? '*'
-    );
+    if (inIframe) {
+      // Ready signal to parent; '*' fallback is acceptable for the handshake
+      window.parent.postMessage(
+        { type: 'gptme-webui:embedded-context-ready' },
+        referrerOrigin ?? '*'
+      );
+    }
 
     return () => {
       window.removeEventListener('message', handleMessage);
@@ -89,7 +93,16 @@ export const EmbeddedContextProvider: FC<PropsWithChildren> = ({ children }) => 
 
   const sendAction = useCallback(
     (action: string, itemId?: string) => {
-      if (!isEmbedded || typeof window === 'undefined' || window.parent === window) {
+      if (!isEmbedded || typeof window === 'undefined') {
+        return;
+      }
+      const inIframe = window.parent !== window;
+      // Same-window embedding: post to self. Iframe: post to confirmed parent origin only.
+      if (!inIframe) {
+        window.postMessage(
+          { type: 'gptme-webui:embedded-action', action, itemId },
+          window.location.origin
+        );
         return;
       }
       if (!parentOrigin) {

--- a/webui/src/contexts/EmbeddedContext.tsx
+++ b/webui/src/contexts/EmbeddedContext.tsx
@@ -49,7 +49,7 @@ export const EmbeddedContextProvider: FC<PropsWithChildren> = ({ children }) => 
 
     const handleMessage = (event: MessageEvent) => {
       // Accept messages from parent frame (iframe case) or self (same-window case)
-      if (event.source !== window.parent && event.source !== window) {
+      if (inIframe ? event.source !== window.parent : event.source !== window) {
         return;
       }
 


### PR DESCRIPTION
## Problem

When `VITE_EMBEDDED_MODE=true` but the webui is embedded via direct React component import (not an `<iframe>`), `window.parent === window`. The previous `useEffect` guard:

```ts
if (!isEmbedded || typeof window === 'undefined' || window.parent === window) {
  return;
}
```

...prevented the `message` listener from being added entirely, making it impossible for the host to inject menu items via `postMessage`.

This blocks gptme-cloud from using the `EmbeddedContextProvider` in its direct-component embedding (`Chat.tsx` imports `Index` / `Tasks` / `Workspace` as React components, not an iframe).

## Changes

**`EmbeddedContext.tsx`**:

1. **Remove `window.parent === window` guard from `useEffect`** — the listener is now always registered when `isEmbedded=true`. `inIframe` is derived locally to still gate the ready-signal `postMessage` (avoids a no-op message to self on same-window pages).

2. **Fix `sendAction` for same-window case** — instead of no-op when `window.parent === window`, it posts the action to `window` itself (same origin). The host can listen for `gptme-webui:embedded-action` events on `window` to handle actions like `sign_out`.

## How gptme-cloud uses this

After updating the gptme submodule, `Chat.tsx` will:
1. Wrap gptme-webui components with `EmbeddedContextProvider`
2. Post `accountNavItems` as `{ type: 'gptme-host:embedded-context', payload: { menuItems } }` on mount and on auth state change
3. Listen for `gptme-webui:embedded-action` events on `window` to handle `sign_out`

## Backward compatibility

- Iframe embedding unchanged — `inIframe` derives to `true`, ready-signal still sent to `window.parent`, `sendAction` still posts to `window.parent`
- Tests unchanged — helpers (`parseEmbeddedContextMessage`, `isEmbeddedContextEventAllowed`) are unaffected

Closes gptme/gptme-cloud#215 (partially — cloud-side follow-up in separate PR)
