### PR TITLE
fix(webui): show HTTP status in auth code exchange error instead of 'Unknown error'

### DIFF
--- a/webui/src/utils/connectionConfig.ts
+++ b/webui/src/utils/connectionConfig.ts
@@ -40,8 +40,25 @@ export async function exchangeAuthCode(
   });
 
   if (!response.ok) {
-    const error = await response.json().catch(() => ({ error: 'Unknown error' }));
-    throw new Error(error.hint || error.error || `Auth code exchange failed: ${response.status}`);
+    // Default to HTTP status — shown when JSON parsing fails (e.g. nginx HTML error page)
+    let errorMessage = `Auth code exchange failed: HTTP ${response.status}`;
+    try {
+      const body = await response.text();
+      try {
+        const parsed = JSON.parse(body);
+        if (parsed.hint) {
+          errorMessage = parsed.hint;
+        } else if (parsed.error) {
+          errorMessage = parsed.error;
+        }
+      } catch {
+        // Non-JSON body (nginx HTML error page, etc.) — log for diagnostics
+        console.error('[ConnectionConfig] Non-JSON error response body:', body.slice(0, 300));
+      }
+    } catch {
+      // Body unreadable — keep status-based message
+    }
+    throw new Error(errorMessage);
   }
 
   return response.json();


### PR DESCRIPTION
## Summary

- Fix error message logic in `exchangeAuthCode()` that always showed "Unknown error" when the fleet-operator returned a non-JSON response (e.g. nginx HTML error page on 502/503/404)
- Root cause: `response.json().catch(() => ({ error: 'Unknown error' }))` — the fallback object's `.error = 'Unknown error'` evaluated as truthy, so the `|| response.status` fallback was never reached
- New logic: read body as text first, try JSON parse, log raw body for diagnostics, fall back to HTTP status string when JSON fails

## Details

Before this fix, any non-JSON error response from the exchange endpoint (e.g. an nginx 502 HTML page) would show the user "Auth code exchange failed: Error: Unknown error" with no actionable information. After this fix, the user sees e.g. "Auth code exchange failed: HTTP 502", making the issue self-diagnosing on next occurrence.

Fixes: gptme/gptme-cloud#237