### PR TITLE
fix(webui): delete stale api.gptme.ai Cloud preset on migration

### DIFF
--- a/webui/src/stores/servers.ts
+++ b/webui/src/stores/servers.ts
@@ -22,8 +22,10 @@ function loadRegistry(): ServerRegistry {
         if (!parsed.connectedServerIds) {
           parsed.connectedServerIds = [parsed.activeServerId];
         }
-        // Migrate: make old Cloud preset removable (it pointed at a stale URL)
+        // Migrate: remove stale Cloud preset (it pointed at a broken URL)
         migrateCloudPreset(parsed);
+        // If migration removed all servers, fall through to fresh migration
+        if (parsed.servers.length === 0) return migrateFromLegacy();
         // Validate activeServerId points to an existing server
         if (!parsed.servers.some((s) => s.id === parsed.activeServerId)) {
           parsed.activeServerId = parsed.servers[0].id;
@@ -48,12 +50,14 @@ function loadRegistry(): ServerRegistry {
 
 /** Migration: remove stale Cloud preset entries.
  *  The generic Cloud preset (https://api.gptme.ai) was broken — managed cloud auth returns
- *  an instance-specific URL, so the hardcoded preset was always stale and causes CSP errors. */
+ *  an instance-specific URL, so the hardcoded preset was always stale and causes CSP errors.
+ *  Note: the previous migration only deleted the isPreset flag, so we filter by URL alone
+ *  to also clean up entries that went through the old migration. */
 function migrateCloudPreset(registry: ServerRegistry): void {
   const STALE_CLOUD_URL = 'https://api.gptme.ai';
   const normalized = (url: string) => url.toLowerCase().replace(/\/+$/, '');
   registry.servers = registry.servers.filter(
-    (s) => !(s.isPreset && normalized(s.baseUrl) === normalized(STALE_CLOUD_URL))
+    (s) => normalized(s.baseUrl) !== normalized(STALE_CLOUD_URL)
   );
 }
 

--- a/webui/src/stores/servers.ts
+++ b/webui/src/stores/servers.ts
@@ -46,17 +46,15 @@ function loadRegistry(): ServerRegistry {
   return migrateFromLegacy();
 }
 
-/** Migration: remove isPreset flag from old Cloud preset entries so they become removable.
+/** Migration: remove stale Cloud preset entries.
  *  The generic Cloud preset (https://api.gptme.ai) was broken — managed cloud auth returns
- *  an instance-specific URL, so the hardcoded preset was always stale. */
+ *  an instance-specific URL, so the hardcoded preset was always stale and causes CSP errors. */
 function migrateCloudPreset(registry: ServerRegistry): void {
   const STALE_CLOUD_URL = 'https://api.gptme.ai';
   const normalized = (url: string) => url.toLowerCase().replace(/\/+$/, '');
-  for (const server of registry.servers) {
-    if (server.isPreset && normalized(server.baseUrl) === normalized(STALE_CLOUD_URL)) {
-      delete server.isPreset;
-    }
-  }
+  registry.servers = registry.servers.filter(
+    (s) => !(s.isPreset && normalized(s.baseUrl) === normalized(STALE_CLOUD_URL))
+  );
 }
 
 function migrateFromLegacy(): ServerRegistry {


### PR DESCRIPTION
## Problem

Users who had the old hardcoded `https://api.gptme.ai` Cloud preset in their `gptme_servers` localStorage hit two issues:

1. The preset points to the wrong URL — managed cloud auth gives each user a unique instance URL, not a generic endpoint.
2. The stale URL is blocked by the gptme.ai Content-Security-Policy (`connect-src` only allows `fleet.gptme.ai`, not `api.gptme.ai`), causing a CSP error in the console and a silent connection failure.

The previous `migrateCloudPreset` only removed `isPreset` (making the entry deletable), but **left the broken server in the registry**. Users had to manually delete it.

## Fix

Strengthen the migration to fully remove the stale entry via `.filter()` instead of just un-setting `isPreset`. After `migrateCloudPreset` runs, `loadRegistry()` already re-validates `activeServerId` and prunes `connectedServerIds`, so affected users gracefully land on their Local server and can reconnect via the Go to Chat flow on the gptme.ai dashboard.

## Related

- gptme/gptme-cloud#237 — user report of the CSP error and broken cross-device server config