### PR TITLE
fix(messages): merge turns after ephemeral pruning

### DIFF
--- a/gptme/logmanager/manager.py
+++ b/gptme/logmanager/manager.py
@@ -708,7 +708,24 @@ def prune_ephemeral_messages(msgs: list[Message]) -> list[Message]:
         if msg.role == "assistant":
             assistant_turns_after += 1
 
-    return list(reversed(kept_reversed))
+    pruned = list(reversed(kept_reversed))
+    return _merge_consecutive_messages(pruned)
+
+
+def _merge_consecutive_messages(msgs: list[Message]) -> list[Message]:
+    """Merge adjacent same-role messages created by ephemeral pruning.
+
+    Dropping an assistant turn between two user turns creates a sequence strict
+    providers reject.  Merge the adjacent messages while preserving attachments
+    and message flags via Message.concat().
+    """
+    merged: list[Message] = []
+    for msg in msgs:
+        if merged and merged[-1].role == msg.role:
+            merged[-1] = merged[-1].concat(msg)
+        else:
+            merged.append(msg)
+    return merged
 
 
 def ephemeral_cache_boundary(
@@ -750,10 +767,13 @@ def prepare_messages(
 
     # Prune expired ephemeral messages (e.g. thinking blocks) after reduction
     # but before hard context limiting, so the budget goes to durable content.
+    # Adjacent same-role messages created by pruning are merged before provider
+    # formatting; strict APIs reject consecutive user/assistant turns.
     msgs_pruned = prune_ephemeral_messages(msgs_reduced)
     if len(msgs_reduced) != len(msgs_pruned):
         logger.info(
-            f"Pruned {len(msgs_reduced) - len(msgs_pruned)} expired ephemeral messages"
+            "Pruned/merged "
+            f"{len(msgs_reduced) - len(msgs_pruned)} messages during ephemeral cleanup"
         )
 
     model = get_default_model()

--- a/tests/test_ephemeral.py
+++ b/tests/test_ephemeral.py
@@ -22,6 +22,11 @@ def _msg(role: Role, content: str = "hello", ttl: int | None = None) -> Message:
     )  # type: ignore[call-arg]
 
 
+def _assert_no_consecutive_same_role(msgs: list[Message]) -> None:
+    for prev, current in zip(msgs, msgs[1:], strict=False):
+        assert prev.role != current.role
+
+
 # ---------------------------------------------------------------------------
 # Message serialization round-trips
 # ---------------------------------------------------------------------------
@@ -123,8 +128,9 @@ def test_expired_ephemeral_message_pruned():
     # assistant0 should be gone
     contents = [m.content for m in result]
     assert "<think>reasoning</think>Answer 0" not in contents
-    # All other messages preserved
-    assert len(result) == len(msgs) - 1
+    # Adjacent user messages on either side of the pruned assistant are merged.
+    assert "Question 0\n\nQuestion 1" in contents
+    _assert_no_consecutive_same_role(result)
 
 
 def test_pinned_message_never_pruned():
@@ -148,7 +154,7 @@ def test_pinned_message_never_pruned():
     assert len(pinned_msgs) == 1
 
 
-def test_prune_order_preserved():
+def test_prune_merges_consecutive_roles_after_drop():
     msgs = [
         _msg("system", "System"),
         _msg("user", "Q0"),
@@ -160,8 +166,10 @@ def test_prune_order_preserved():
     ]
     result = prune_ephemeral_messages(msgs)
     roles = [m.role for m in result]
-    # Should maintain chronological order
-    assert roles == ["system", "user", "assistant", "user", "user", "assistant"]
+    # Should maintain chronological order and merge the user turns around the
+    # pruned assistant so strict providers do not reject the sequence.
+    assert roles == ["system", "user", "assistant", "user", "assistant"]
+    assert result[3].content == "Q1\n\nQ2"
 
 
 def test_no_ephemeral_messages_unchanged():


### PR DESCRIPTION
Follow-up to the post-merge Greptile P1 on #2330. Refs #444.

## Summary
- merge adjacent same-role messages after expired ephemeral turns are pruned
- preserve files, flags, and TTL semantics through `Message.concat()`
- update ephemeral pruning tests so the output is provider-safe instead of asserting consecutive user turns

## Tests
- `poetry run pytest tests/test_ephemeral.py tests/test_llm_utils.py tests/test_llm_anthropic.py -q`
- `prek run ruff ruff-format --files gptme/logmanager/manager.py tests/test_ephemeral.py`