### PR TITLE
fix(webui): responsive settings modal on mobile

### DIFF
--- a/webui/src/components/SettingsModal.tsx
+++ b/webui/src/components/SettingsModal.tsx
@@ -395,7 +395,7 @@ export const SettingsModal = forwardRef<HTMLButtonElement, SettingsModalProps>(
     return (
       <Dialog open={open} onOpenChange={setOpen}>
         {children !== undefined && <DialogTrigger asChild>{children}</DialogTrigger>}
-        <DialogContent className="flex max-h-[80vh] max-w-4xl flex-col overflow-hidden p-0">
+        <DialogContent className="flex max-h-[90vh] w-[calc(100vw-2rem)] flex-col overflow-hidden p-0 sm:max-h-[80vh] sm:max-w-4xl">
           <DialogHeader className="border-b px-6 py-3">
             <DialogTitle className="flex items-center gap-2">
               <Settings className="h-5 w-5" />
@@ -404,9 +404,30 @@ export const SettingsModal = forwardRef<HTMLButtonElement, SettingsModalProps>(
             <DialogDescription>Customize your gptme experience</DialogDescription>
           </DialogHeader>
 
-          <div className="flex min-h-0 min-w-0 flex-1">
-            {/* Sidebar */}
-            <div className="w-64 overflow-y-auto border-r bg-muted/20 p-4">
+          <div className="flex min-h-0 min-w-0 flex-1 flex-col sm:flex-row">
+            {/* Mobile: horizontal tab strip */}
+            <div className="flex overflow-x-auto border-b bg-muted/20 p-2 sm:hidden">
+              {categories.map((category) => {
+                const Icon = category.icon;
+                const isActive = activeCategory === category.id;
+                return (
+                  <button
+                    key={category.id}
+                    onClick={() => setActiveCategory(category.id)}
+                    className={cn(
+                      'flex shrink-0 flex-col items-center gap-1 rounded-md px-3 py-2 text-xs transition-colors',
+                      isActive ? 'border bg-background shadow-sm' : 'hover:bg-muted/60'
+                    )}
+                  >
+                    <Icon className="h-4 w-4" />
+                    <span className="font-medium">{category.label}</span>
+                  </button>
+                );
+              })}
+            </div>
+
+            {/* Desktop: vertical sidebar */}
+            <div className="hidden w-48 overflow-y-auto border-r bg-muted/20 p-4 sm:block">
               <nav className="space-y-1">
                 {categories.map((category) => {
                   const Icon = category.icon;
@@ -433,7 +454,7 @@ export const SettingsModal = forwardRef<HTMLButtonElement, SettingsModalProps>(
             </div>
 
             {/* Content */}
-            <div className="min-h-0 min-w-0 flex-1 overflow-y-auto p-6">
+            <div className="min-h-0 min-w-0 flex-1 overflow-y-auto p-4 sm:p-6">
               {renderCategoryContent()}
             </div>
           </div>


### PR DESCRIPTION
## Summary

- On mobile the settings modal had a fixed-width `w-64` (256px) sidebar that consumed most of the viewport, leaving no room for content
- This PR makes the layout responsive: vertical sidebar on desktop (`sm:`), horizontal icon+label tab strip on mobile
- Dialog width is also capped properly on mobile with `w-[calc(100vw-2rem)]`

## Changes

**`SettingsModal.tsx`**:
- Split sidebar into two variants: mobile tab strip (hidden on `sm:`) and desktop sidebar (hidden below `sm:`)
- Mobile: horizontal scrollable row of icon+label buttons
- Desktop: same vertical sidebar, narrowed slightly from `w-64` → `w-48`
- Content padding reduced from `p-6` → `p-4` on mobile (`sm:p-6` on desktop)
- Dialog: `max-h-[90vh]` on mobile, `sm:max-h-[80vh] sm:max-w-4xl` on desktop

Closes #2334