### PR TITLE
feat: add GPTME_DISABLE_PATH_INCLUDE env var to skip path expansion

### DIFF
--- a/gptme/util/context.py
+++ b/gptme/util/context.py
@@ -473,17 +473,22 @@ def include_paths(msg: Message, workspace: Path | None = None) -> Message:
     In interactive mode, asks for confirmation before reading URLs to prevent
     accidental context bloat from pasted logs containing URLs.
 
-    When GPTME_DISABLE_PATH_INCLUDE is set (to any truthy value), all path
-    expansion is skipped. This is useful for autonomous/non-interactive modes
-    where prompts are programmatically constructed and path references should
-    be passed to the model as-is.
+    When GPTME_DISABLE_PATH_INCLUDE is set to a truthy value (1, true, yes, on),
+    all path expansion is skipped. This is useful for autonomous/non-interactive
+    modes where prompts are programmatically constructed and path references
+    should be passed to the model as-is.
 
     Args:
         msg: Message to process
         workspace: If provided, paths will be stored relative to this directory
     """
     # Check for explicit disable to prevent silent prompt bloat in autonomous mode
-    if os.environ.get("GPTME_DISABLE_PATH_INCLUDE"):
+    if os.environ.get("GPTME_DISABLE_PATH_INCLUDE", "").lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    ):
         logger.debug("GPTME_DISABLE_PATH_INCLUDE is set; skipping path expansion")
         return msg
 

--- a/gptme/util/context.py
+++ b/gptme/util/context.py
@@ -473,10 +473,20 @@ def include_paths(msg: Message, workspace: Path | None = None) -> Message:
     In interactive mode, asks for confirmation before reading URLs to prevent
     accidental context bloat from pasted logs containing URLs.
 
+    When GPTME_DISABLE_PATH_INCLUDE is set (to any truthy value), all path
+    expansion is skipped. This is useful for autonomous/non-interactive modes
+    where prompts are programmatically constructed and path references should
+    be passed to the model as-is.
+
     Args:
         msg: Message to process
         workspace: If provided, paths will be stored relative to this directory
     """
+    # Check for explicit disable to prevent silent prompt bloat in autonomous mode
+    if os.environ.get("GPTME_DISABLE_PATH_INCLUDE"):
+        logger.debug("GPTME_DISABLE_PATH_INCLUDE is set; skipping path expansion")
+        return msg
+
     # Skip processing for non-user messages
     if msg.role != "user":
         return msg

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -100,6 +100,25 @@ def test_include_paths_no_duplicate_embeddings(tmp_path, monkeypatch):
     assert result.content.count("unique-content-marker") == 1
 
 
+def test_include_paths_disabled_via_env_var(tmp_path, monkeypatch):
+    """Test that GPTME_DISABLE_PATH_INCLUDE skips all path expansion."""
+    from gptme.message import Message
+    from gptme.util.context import include_paths
+
+    monkeypatch.chdir(tmp_path)
+    data_file = tmp_path / "data.txt"
+    data_file.write_text("sensitive-content-should-not-appear")
+
+    monkeypatch.setenv("GPTME_DISABLE_PATH_INCLUDE", "1")
+
+    msg = Message("user", "See `data.txt` for details")
+    result = include_paths(msg)
+
+    # The file content should NOT appear when the env var is set
+    assert "sensitive-content-should-not-appear" not in result.content
+    assert result.files == []
+
+
 def test_include_paths_skips_system_messages():
     """Test that include_paths skips role=system messages (tool output) entirely."""
     from gptme.message import Message

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -119,6 +119,28 @@ def test_include_paths_disabled_via_env_var(tmp_path, monkeypatch):
     assert result.files == []
 
 
+@pytest.mark.parametrize("falsy_val", ["0", "false", "False", "no", "off", ""])
+def test_include_paths_not_disabled_by_falsy_env_var(tmp_path, monkeypatch, falsy_val):
+    """Test that GPTME_DISABLE_PATH_INCLUDE=false/0/no/off does NOT disable expansion."""
+    from gptme.message import Message
+    from gptme.util.context import include_paths
+
+    monkeypatch.chdir(tmp_path)
+    data_file = tmp_path / "data.txt"
+    data_file.write_text("content-should-appear")
+
+    if falsy_val:
+        monkeypatch.setenv("GPTME_DISABLE_PATH_INCLUDE", falsy_val)
+    else:
+        monkeypatch.delenv("GPTME_DISABLE_PATH_INCLUDE", raising=False)
+
+    msg = Message("user", "See `data.txt` for details")
+    result = include_paths(msg)
+
+    # Content SHOULD appear — falsy values must not disable expansion
+    assert "content-should-appear" in result.content
+
+
 def test_include_paths_skips_system_messages():
     """Test that include_paths skips role=system messages (tool output) entirely."""
     from gptme.message import Message


### PR DESCRIPTION
## Summary

Adds `GPTME_DISABLE_PATH_INCLUDE` env var. When set (to any truthy value),
`include_paths()` skips all file/URL expansion and returns the message
unchanged. This prevents silent prompt bloat in autonomous/non-interactive
modes where prompts are programmatically constructed.

## Background

In autonomous Bob runs, backtick-wrapped file paths in user prompts (e.g.,
``./scripts/cascade-selector.py``, ``knowledge/strategic/idea-backlog.md``)
were being expanded by `include_paths()` into ~280KB of file content plus
another ~50-100KB of bare-dir listings. Weak models (grok-4.20, kimi-k2.6,
codex:gpt-5.5) silently fail on oversized prompts — return zero assistant
messages, session times out, scored as failed.

The workaround was rewriting prompts to avoid path-like tokens
(ErikBjare/bob@3820d7ec9). This env var provides a proper fix.

## Changes

1. **`gptme/util/context.py`**: Early return in `include_paths()` when
   `GPTME_DISABLE_PATH_INCLUDE` is set.
2. **`tests/test_chat.py`**: New test
   `test_include_paths_disabled_via_env_var` verifying the env var prevents
   file expansion.

## Usage

```bash
export GPTME_DISABLE_PATH_INCLUDE=1
gptme "prompt"
```

## Related

- Closes #2333
- ErikBjare/bob#726 — downstream issue tracking weak-arm failures