### PR TITLE
feat(tools): add shell_compact git log preview

### DIFF
--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -1176,28 +1176,7 @@ def execute_shell_impl(
         if e.args and isinstance(e.args[0], tuple) and len(e.args[0]) == 2:
             stdout, stderr = e.args[0]
 
-        # Terminate subprocess gracefully
-        logger.info("Shell command interrupted, sending SIGINT to subprocess")
-        try:
-            if _is_windows:
-                shell.process.terminate()
-                shell.process.wait(timeout=2.0)
-            else:
-                pgid = os.getpgid(shell.process.pid)
-                os.killpg(pgid, signal.SIGINT)
-                shell.process.wait(timeout=2.0)
-        except subprocess.TimeoutExpired:
-            logger.info("Process didn't exit gracefully, terminating")
-            try:
-                if _is_windows:
-                    shell.process.kill()
-                else:
-                    pgid = os.getpgid(shell.process.pid)
-                    os.killpg(pgid, signal.SIGTERM)
-            except Exception:
-                pass
-        except Exception as e:
-            logger.warning(f"Error terminating interrupted process: {e}")
+        _terminate_interrupted_shell(shell)
 
         returncode = shell.process.returncode
         interrupted = True
@@ -1221,6 +1200,32 @@ def execute_shell_impl(
 
     if interrupted:
         raise KeyboardInterrupt from None
+
+
+def _terminate_interrupted_shell(
+    shell: ShellSession, log_context: str = "Shell command"
+) -> None:
+    logger.info("%s interrupted, sending SIGINT to subprocess", log_context)
+    try:
+        if _is_windows:
+            shell.process.terminate()
+            shell.process.wait(timeout=2.0)
+        else:
+            pgid = os.getpgid(shell.process.pid)
+            os.killpg(pgid, signal.SIGINT)
+            shell.process.wait(timeout=2.0)
+    except subprocess.TimeoutExpired:
+        logger.info("Process didn't exit gracefully, terminating")
+        try:
+            if _is_windows:
+                shell.process.kill()
+            else:
+                pgid = os.getpgid(shell.process.pid)
+                os.killpg(pgid, signal.SIGTERM)
+        except Exception:
+            pass
+    except Exception as e:
+        logger.warning("Error terminating interrupted process: %s", e)
 
 
 def get_path_fn(*args, **kwargs) -> Path | None:
@@ -1270,6 +1275,23 @@ def _execute_preceding_commands(
             )
     except Exception as e:
         yield Message("system", f"Error running preceding commands: {e}")
+
+
+def _get_timeout() -> float | None:
+    timeout: float | None = 1200.0
+    timeout_env = os.environ.get("GPTME_SHELL_TIMEOUT")
+    if timeout_env is not None:
+        try:
+            timeout = float(timeout_env)
+            if timeout <= 0:
+                timeout = None
+        except ValueError:
+            logger.warning(
+                "Invalid GPTME_SHELL_TIMEOUT value: %s, using default 1200s (20 minutes)",
+                timeout_env,
+            )
+            timeout = 1200.0
+    return timeout
 
 
 def execute_shell(
@@ -1349,20 +1371,7 @@ def execute_shell(
             return
         # Fall through to regular shell execution for other kill commands
 
-    # Check for timeout from environment variable
-    # Default to 20 minutes (1200s) if not set
-    timeout: float | None = 1200.0
-    timeout_env = os.environ.get("GPTME_SHELL_TIMEOUT")
-    if timeout_env is not None:
-        try:
-            timeout = float(timeout_env)
-            if timeout <= 0:
-                timeout = None  # Disable timeout if set to 0 or negative
-        except ValueError:
-            logger.warning(
-                f"Invalid GPTME_SHELL_TIMEOUT value: {timeout_env}, using default 1200s (20 minutes)"
-            )
-            timeout = 1200.0
+    timeout = _get_timeout()
 
     # Check with shellcheck if available
     has_issues, should_block, shellcheck_msg = check_with_shellcheck(cmd)

--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -1224,7 +1224,10 @@ def execute_shell_impl(
 
 
 def get_path_fn(*args, **kwargs) -> Path | None:
-    return None
+    from ..logmanager import LogManager  # fmt: skip
+
+    manager = LogManager.get_current_log()
+    return manager.logdir if manager and manager.logdir else None
 
 
 def _execute_preceding_commands(

--- a/gptme/tools/shell_compact.py
+++ b/gptme/tools/shell_compact.py
@@ -51,7 +51,7 @@ Currently it only compacts `git log --oneline` output.
 - If you need the full raw output, use the `shell` tool instead.
 """.strip()
 
-instructions_format = {}
+instructions_format: dict[str, str] = {}
 
 
 def examples(tool_format):

--- a/gptme/tools/shell_compact.py
+++ b/gptme/tools/shell_compact.py
@@ -132,14 +132,17 @@ def _format_git_log_preview(cmd: str, stdout: str, logdir: Path | None) -> str |
 
     if logdir and saved_path:
         model_name = _default_model_name()
-        record_context_savings(
-            logdir=logdir,
-            source=_COMPACTOR_SOURCE,
-            original_tokens=len_tokens(stdout, model_name),
-            kept_tokens=len_tokens(body, model_name),
-            command_info=f"git_log_oneline: {cmd}",
-            saved_path=saved_path,
-        )
+        try:
+            record_context_savings(
+                logdir=logdir,
+                source=_COMPACTOR_SOURCE,
+                original_tokens=len_tokens(stdout, model_name),
+                kept_tokens=len_tokens(body, model_name),
+                command_info=f"git_log_oneline: {cmd}",
+                saved_path=saved_path,
+            )
+        except OSError as e:
+            logger.warning("Failed to record compact shell telemetry: %s", e)
 
     return body
 

--- a/gptme/tools/shell_compact.py
+++ b/gptme/tools/shell_compact.py
@@ -191,7 +191,10 @@ def _execute_compacted_git_log(
 
     compact_body = None
     if returncode == 0 and not stderr and not interrupted and not timed_out:
-        compact_body = _format_git_log_preview(cmd, stdout, logdir)
+        try:
+            compact_body = _format_git_log_preview(cmd, stdout, logdir)
+        except OSError as e:
+            logger.warning("Failed to format compact shell output: %s", e)
 
     if compact_body is None:
         yield Message(

--- a/gptme/tools/shell_compact.py
+++ b/gptme/tools/shell_compact.py
@@ -9,10 +9,7 @@ to the regular shell tool.
 from __future__ import annotations
 
 import logging
-import os
 import shlex
-import signal
-import subprocess
 from typing import TYPE_CHECKING
 
 from ..message import Message
@@ -24,7 +21,8 @@ from .base import Parameter, ToolSpec, ToolUse
 from .shell import (
     _format_block_smart,
     _format_shell_output,
-    _is_windows,
+    _get_timeout,
+    _terminate_interrupted_shell,
     execute_shell,
     get_path_fn,
     get_shell,
@@ -72,25 +70,8 @@ def5678 feat: add shell_compact git log preview
 """.strip()
 
 
-def _get_timeout() -> float | None:
-    timeout: float | None = 1200.0
-    timeout_env = os.environ.get("GPTME_SHELL_TIMEOUT")
-    if timeout_env is not None:
-        try:
-            timeout = float(timeout_env)
-            if timeout <= 0:
-                timeout = None
-        except ValueError:
-            logger.warning(
-                "Invalid GPTME_SHELL_TIMEOUT value: %s, using default 1200s (20 minutes)",
-                timeout_env,
-            )
-            timeout = 1200.0
-    return timeout
-
-
 def _compact_command_display(cmd: str) -> str:
-    if len(cmd) > 100 or cmd.count("\n") > 2:
+    if len(cmd) > 100 or cmd.count("\n") >= 1:
         first_line = cmd.split("\n")[0][:80]
         line_count = cmd.count("\n") + 1
         return (
@@ -103,7 +84,7 @@ def _default_model_name() -> str:
     from ..llm.models import get_default_model  # fmt: skip
 
     model = get_default_model()
-    return model.model if model else "gpt-4"
+    return model.model if model else "cl100k_base"
 
 
 def _matches_git_log_oneline(cmd: str) -> bool:
@@ -200,27 +181,7 @@ def _execute_compacted_git_log(
         if e.args and isinstance(e.args[0], tuple) and len(e.args[0]) == 2:
             stdout, stderr = e.args[0]
 
-        logger.info("Shell compact command interrupted, sending SIGINT to subprocess")
-        try:
-            if _is_windows:
-                shell.process.terminate()
-                shell.process.wait(timeout=2.0)
-            else:
-                pgid = os.getpgid(shell.process.pid)
-                os.killpg(pgid, signal.SIGINT)
-                shell.process.wait(timeout=2.0)
-        except subprocess.TimeoutExpired:
-            logger.info("Process didn't exit gracefully, terminating")
-            try:
-                if _is_windows:
-                    shell.process.kill()
-                else:
-                    pgid = os.getpgid(shell.process.pid)
-                    os.killpg(pgid, signal.SIGTERM)
-            except Exception:
-                pass
-        except Exception as e:
-            logger.warning("Error terminating interrupted process: %s", e)
+        _terminate_interrupted_shell(shell, "Shell compact command")
 
         returncode = shell.process.returncode
         interrupted = True
@@ -272,10 +233,6 @@ def execute_shell_compact(
     cmd = get_shell_command(code, args, kwargs)
 
     if not _matches_git_log_oneline(cmd):
-        yield from execute_shell(code, args, kwargs)
-        return
-
-    if not shell_compact_allowlist_hook(ToolUse("shell_compact", [], cmd, {})):
         yield from execute_shell(code, args, kwargs)
         return
 

--- a/gptme/tools/shell_compact.py
+++ b/gptme/tools/shell_compact.py
@@ -1,0 +1,309 @@
+"""
+Compact shell wrapper for known high-output command shapes.
+
+Currently this only compacts ``git log --oneline`` by returning the first few
+commits plus a pointer to the full saved output. Unsupported commands fall back
+to the regular shell tool.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shlex
+import signal
+import subprocess
+from typing import TYPE_CHECKING
+
+from ..message import Message
+from ..util.context import md_codeblock
+from ..util.context_savings import record_context_savings
+from ..util.output_storage import save_large_output
+from ..util.tokens import len_tokens
+from .base import Parameter, ToolSpec, ToolUse
+from .shell import (
+    _format_block_smart,
+    _format_shell_output,
+    _is_windows,
+    execute_shell,
+    get_path_fn,
+    get_shell,
+    get_shell_command,
+    strip_ansi_codes,
+)
+
+logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+    from pathlib import Path
+
+_PREVIEW_LINES = 20
+_COMPACTOR_SOURCE = "shell_compact"
+
+instructions = """
+Use this tool for known high-output shell commands that have a compact preview.
+Currently it only compacts `git log --oneline` output.
+
+- Matched commands show the first 20 commits, total count, and where the full
+  output was saved.
+- Unsupported commands fall back to the regular shell tool.
+- If you need the full raw output, use the `shell` tool instead.
+""".strip()
+
+instructions_format = {}
+
+
+def examples(tool_format):
+    preview = """abc1234 fix: wire context savings to current conversation logdir
+def5678 feat: add shell_compact git log preview
+... (23 more commits omitted) ..."""
+    return f"""
+> User: show recent commits compactly
+> Assistant:
+{ToolUse("shell_compact", [], "git log --oneline").to_output(tool_format)}
+> System:
+> Ran allowlisted compact command: `git log --oneline`
+>
+> Showing first 20 of 43 commits. Full output saved to /tmp/.../tool-outputs/shell/...
+> Use `shell` for a raw rerun or `git show <sha>` for a specific commit.
+>
+> {md_codeblock("stdout", preview)}
+""".strip()
+
+
+def _get_timeout() -> float | None:
+    timeout: float | None = 1200.0
+    timeout_env = os.environ.get("GPTME_SHELL_TIMEOUT")
+    if timeout_env is not None:
+        try:
+            timeout = float(timeout_env)
+            if timeout <= 0:
+                timeout = None
+        except ValueError:
+            logger.warning(
+                "Invalid GPTME_SHELL_TIMEOUT value: %s, using default 1200s (20 minutes)",
+                timeout_env,
+            )
+            timeout = 1200.0
+    return timeout
+
+
+def _compact_command_display(cmd: str) -> str:
+    if len(cmd) > 100 or cmd.count("\n") > 2:
+        first_line = cmd.split("\n")[0][:80]
+        line_count = cmd.count("\n") + 1
+        return (
+            f"{first_line}... ({line_count} {'line' if line_count == 1 else 'lines'})"
+        )
+    return cmd
+
+
+def _default_model_name() -> str:
+    from ..llm.models import get_default_model  # fmt: skip
+
+    model = get_default_model()
+    return model.model if model else "gpt-4"
+
+
+def _matches_git_log_oneline(cmd: str) -> bool:
+    if any(ch in cmd for ch in "\n|;&<>"):
+        return False
+
+    try:
+        tokens = shlex.split(cmd)
+    except ValueError:
+        return False
+
+    if len(tokens) < 3 or tokens[:2] != ["git", "log"]:
+        return False
+
+    return any(token == "--oneline" for token in tokens[2:])
+
+
+def _format_git_log_preview(cmd: str, stdout: str, logdir: Path | None) -> str | None:
+    lines = [line for line in strip_ansi_codes(stdout).splitlines() if line.strip()]
+    if len(lines) <= _PREVIEW_LINES:
+        return None
+
+    saved_path: Path | None = None
+    if logdir:
+        _, saved_path = save_large_output(
+            content=stdout,
+            logdir=logdir,
+            output_type="shell",
+            command_info=cmd,
+        )
+
+    omitted = len(lines) - _PREVIEW_LINES
+    preview = "\n".join(
+        lines[:_PREVIEW_LINES] + [f"... ({omitted} more commits omitted) ..."]
+    )
+
+    detail = f"Showing first {_PREVIEW_LINES} of {len(lines)} commits."
+    if saved_path:
+        detail += f" Full output saved to {saved_path}."
+    else:
+        detail += " Full output was not saved because no conversation logdir is active."
+    detail += " Use `shell` for a raw rerun or `git show <sha>` for a specific commit."
+
+    body = detail + "\n\n" + md_codeblock("stdout", preview)
+
+    if logdir and saved_path:
+        model_name = _default_model_name()
+        record_context_savings(
+            logdir=logdir,
+            source=_COMPACTOR_SOURCE,
+            original_tokens=len_tokens(stdout, model_name),
+            kept_tokens=len_tokens(body, model_name),
+            command_info=f"git_log_oneline: {cmd}",
+            saved_path=saved_path,
+        )
+
+    return body
+
+
+def shell_compact_allowlist_hook(
+    tool_use: ToolUse,
+    preview: str | None = None,
+    workspace: Path | None = None,
+):
+    """Auto-confirm compact shell commands with an explicitly supported shape."""
+    del preview, workspace
+
+    from ..hooks.confirm import ConfirmationResult
+
+    if tool_use.tool != "shell_compact":
+        return None
+
+    cmd = tool_use.content.strip() if tool_use.content else ""
+    if not cmd:
+        return None
+
+    if _matches_git_log_oneline(cmd):
+        return ConfirmationResult.confirm()
+
+    return None
+
+
+def _execute_compacted_git_log(
+    cmd: str, logdir: Path | None, timeout: float | None
+) -> Generator[Message, None, None]:
+    shell = get_shell()
+
+    try:
+        returncode, stdout, stderr = shell.run(cmd, timeout=timeout)
+        interrupted = False
+        timed_out = returncode == -124
+    except KeyboardInterrupt as e:
+        stdout = stderr = ""
+        if e.args and isinstance(e.args[0], tuple) and len(e.args[0]) == 2:
+            stdout, stderr = e.args[0]
+
+        logger.info("Shell compact command interrupted, sending SIGINT to subprocess")
+        try:
+            if _is_windows:
+                shell.process.terminate()
+                shell.process.wait(timeout=2.0)
+            else:
+                pgid = os.getpgid(shell.process.pid)
+                os.killpg(pgid, signal.SIGINT)
+                shell.process.wait(timeout=2.0)
+        except subprocess.TimeoutExpired:
+            logger.info("Process didn't exit gracefully, terminating")
+            try:
+                if _is_windows:
+                    shell.process.kill()
+                else:
+                    pgid = os.getpgid(shell.process.pid)
+                    os.killpg(pgid, signal.SIGTERM)
+            except Exception:
+                pass
+        except Exception as e:
+            logger.warning("Error terminating interrupted process: %s", e)
+
+        returncode = shell.process.returncode
+        interrupted = True
+        timed_out = False
+    except Exception as e:
+        raise ValueError(f"Shell error: {e}") from None
+
+    compact_body = None
+    if returncode == 0 and not stderr and not interrupted and not timed_out:
+        compact_body = _format_git_log_preview(cmd, stdout, logdir)
+
+    if compact_body is None:
+        yield Message(
+            "system",
+            _format_shell_output(
+                cmd,
+                stdout,
+                stderr,
+                returncode,
+                interrupted,
+                allowlisted=True,
+                timed_out=timed_out,
+                timeout_value=timeout,
+                logdir=logdir,
+            ),
+        )
+    else:
+        cmd_display = _compact_command_display(cmd)
+        msg = (
+            _format_block_smart(
+                "Ran allowlisted compact command", cmd_display, lang="bash"
+            )
+            + "\n\n"
+            + compact_body
+            + "\n"
+        )
+        yield Message("system", msg)
+
+    if interrupted:
+        raise KeyboardInterrupt from None
+
+
+def execute_shell_compact(
+    code: str | None,
+    args: list[str] | None,
+    kwargs: dict[str, str] | None,
+) -> Generator[Message, None, None]:
+    """Execute a compact shell command when the command shape is supported."""
+    cmd = get_shell_command(code, args, kwargs)
+
+    if not _matches_git_log_oneline(cmd):
+        yield from execute_shell(code, args, kwargs)
+        return
+
+    if not shell_compact_allowlist_hook(ToolUse("shell_compact", [], cmd, {})):
+        yield from execute_shell(code, args, kwargs)
+        return
+
+    yield from _execute_compacted_git_log(
+        cmd,
+        logdir=get_path_fn(),
+        timeout=_get_timeout(),
+    )
+
+
+tool = ToolSpec(
+    name="shell_compact",
+    desc="Executes compact previews for known high-output shell commands.",
+    instructions=instructions,
+    instructions_format=instructions_format,
+    examples=examples,
+    execute=execute_shell_compact,
+    block_types=["shell_compact"],
+    parameters=[
+        Parameter(
+            name="command",
+            type="string",
+            description="The shell command with arguments to execute.",
+            required=True,
+        ),
+    ],
+    hooks={
+        "allowlist": ("tool.confirm", shell_compact_allowlist_hook, 10),
+    },
+)
+__doc__ = tool.get_doc(__doc__)

--- a/gptme/tools/shell_compact.py
+++ b/gptme/tools/shell_compact.py
@@ -88,7 +88,7 @@ def _default_model_name() -> str:
 
 
 def _matches_git_log_oneline(cmd: str) -> bool:
-    if any(ch in cmd for ch in "\n|;&<>"):
+    if any(ch in cmd for ch in "\n|;&<>`$"):
         return False
 
     try:

--- a/tests/data/git-log-oneline.txt
+++ b/tests/data/git-log-oneline.txt
@@ -1,0 +1,27 @@
+7d0c0de fix: wire context savings to current conversation logdir
+f00dbad feat: add shell_compact preview for git log
+1a2b3c4 docs: note compact wrapper fallback behavior
+2b3c4d5 test: cover shell_compact fallback path
+3c4d5e6 refactor: share shell output formatting helpers
+4d5e6f7 feat: surface compact savings in /context
+5e6f708 fix: keep stderr untouched in compact mode
+6f70819 chore: add git log fixture for shell_compact tests
+708192a feat: reuse shell allowlist hook for compact tool
+8192a3b fix: keep full shell output under tool-outputs
+92a3b4c docs: sharpen shell_compact tool description
+a3b4c5d test: verify shell_compact uses existing shell session
+b4c5d6e feat: add compact summary for commit previews
+c5d6e7f refactor: keep compactor routing deterministic
+d6e7f80 fix: avoid compacting multiline shell pipelines
+e7f8091 test: record context savings for compact previews
+f8091a2 feat: add saved-path hint to compact summaries
+091a2b3 chore: sync shell tool examples
+1a2b3c5 docs: capture proactive wrapper spike design
+2b3c4d6 feat: use conversation logdir for shell tool output saves
+3c4d5e7 fix: preserve raw fallback for unsupported commands
+4d5e6f8 test: fallback to shell for git status
+5e6f709 docs: explain when to use shell vs shell_compact
+6f7081a feat: compact first 20 git log lines
+708192b fix: avoid savings rows when nothing is saved
+8192a3c test: short git logs bypass compaction
+92a3b4d chore: prep compact wrapper follow-up PR

--- a/tests/test_shell_allowlist_autoconfirm.py
+++ b/tests/test_shell_allowlist_autoconfirm.py
@@ -15,6 +15,7 @@ from gptme.tools.shell import (
     is_allowlisted,
     shell_allowlist_hook,
 )
+from gptme.tools.shell_compact import shell_compact_allowlist_hook
 
 # Test cases: (command, should_be_allowlisted, description)
 ALLOWLIST_TEST_CASES = [
@@ -107,6 +108,20 @@ class TestShellAllowlistHook:
         )
 
         result = shell_allowlist_hook(tool_use)
+
+        assert result is not None
+        assert result.action.value == "confirm"
+
+    def test_allowlisted_shell_compact_command_auto_confirms(self):
+        """Compact shell commands use their own narrow auto-confirm hook."""
+        tool_use = ToolUse(
+            tool="shell_compact",
+            args=[],
+            kwargs={},
+            content="git log --oneline",
+        )
+
+        result = shell_compact_allowlist_hook(tool_use)
 
         assert result is not None
         assert result.action.value == "confirm"

--- a/tests/test_tools_shell.py
+++ b/tests/test_tools_shell.py
@@ -2,6 +2,7 @@ import json
 import os
 import tempfile
 from collections.abc import Generator
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -10,6 +11,7 @@ from gptme.tools.shell import (
     _format_shell_output,
     _get_truncation_budget,
     _shorten_stdout,
+    get_path_fn,
     is_denylisted,
     split_commands,
 )
@@ -486,6 +488,14 @@ def test_shorten_stdout_records_context_savings(tmp_path):
     assert rows[0]["source"] == "shell"
     assert rows[0]["command_info"] == "git log --oneline"
     assert rows[0]["saved_tokens"] > 0
+
+
+def test_get_path_fn_uses_current_logdir(tmp_path):
+    manager = MagicMock()
+    manager.logdir = tmp_path
+
+    with patch("gptme.logmanager.LogManager.get_current_log", return_value=manager):
+        assert get_path_fn() == tmp_path
 
 
 def test_truncation_budget_default(monkeypatch):

--- a/tests/test_tools_shell_compact.py
+++ b/tests/test_tools_shell_compact.py
@@ -1,0 +1,56 @@
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from gptme.tools.shell_compact import (
+    _format_git_log_preview,
+    execute_shell_compact,
+)
+
+
+def _fixture_text(name: str) -> str:
+    return (Path(__file__).parent / "data" / name).read_text(encoding="utf-8")
+
+
+def test_format_git_log_preview_records_context_savings(tmp_path):
+    stdout = _fixture_text("git-log-oneline.txt")
+
+    preview = _format_git_log_preview("git log --oneline", stdout, tmp_path)
+
+    assert preview is not None
+    assert "Showing first 20 of 27 commits." in preview
+    assert "more commits omitted" in preview
+    assert "Full output saved to" in preview
+
+    ledger = tmp_path / "context-savings.jsonl"
+    rows = ledger.read_text(encoding="utf-8").splitlines()
+    assert len(rows) == 1
+    assert "shell_compact" in rows[0]
+    assert "git_log_oneline: git log --oneline" in rows[0]
+
+
+def test_execute_shell_compact_uses_compactor(tmp_path):
+    stdout = _fixture_text("git-log-oneline.txt")
+
+    with (
+        patch("gptme.tools.shell_compact.get_shell") as mock_get_shell,
+        patch("gptme.tools.shell_compact.get_path_fn", return_value=tmp_path),
+    ):
+        shell = MagicMock()
+        shell.run.return_value = (0, stdout, "")
+        mock_get_shell.return_value = shell
+
+        messages = list(execute_shell_compact("git log --oneline", [], None))
+
+    assert len(messages) == 1
+    assert "Ran allowlisted compact command" in messages[0].content
+    assert "Showing first 20 of 27 commits." in messages[0].content
+    assert "tool-outputs/shell" in messages[0].content
+
+
+def test_execute_shell_compact_falls_back_for_unsupported_command():
+    with patch("gptme.tools.shell_compact.execute_shell") as mock_execute_shell:
+        mock_execute_shell.return_value = iter([])
+
+        list(execute_shell_compact("git status", [], None))
+
+    mock_execute_shell.assert_called_once()

--- a/tests/test_tools_shell_compact.py
+++ b/tests/test_tools_shell_compact.py
@@ -1,9 +1,18 @@
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
+
+from gptme.message import Message
+from gptme.tools.base import ToolUse
 from gptme.tools.shell_compact import (
+    _compact_command_display,
+    _execute_compacted_git_log,
     _format_git_log_preview,
+    _get_timeout,
+    _matches_git_log_oneline,
     execute_shell_compact,
+    shell_compact_allowlist_hook,
 )
 
 
@@ -28,6 +37,27 @@ def test_format_git_log_preview_records_context_savings(tmp_path):
     assert "git_log_oneline: git log --oneline" in rows[0]
 
 
+def test_format_git_log_preview_skips_short_logs(tmp_path):
+    stdout = "\n".join(_fixture_text("git-log-oneline.txt").splitlines()[:3])
+
+    preview = _format_git_log_preview("git log --oneline", stdout, tmp_path)
+
+    assert preview is None
+    assert not (tmp_path / "context-savings.jsonl").exists()
+
+
+def test_format_git_log_preview_without_logdir_does_not_save():
+    stdout = _fixture_text("git-log-oneline.txt")
+
+    preview = _format_git_log_preview("git log --oneline", stdout, None)
+
+    assert preview is not None
+    assert (
+        "Full output was not saved because no conversation logdir is active." in preview
+    )
+    assert "more commits omitted" in preview
+
+
 def test_execute_shell_compact_uses_compactor(tmp_path):
     stdout = _fixture_text("git-log-oneline.txt")
 
@@ -47,6 +77,83 @@ def test_execute_shell_compact_uses_compactor(tmp_path):
     assert "tool-outputs/shell" in messages[0].content
 
 
+def test_execute_compacted_git_log_falls_back_when_command_fails(tmp_path):
+    with (
+        patch("gptme.tools.shell_compact.get_shell") as mock_get_shell,
+        patch(
+            "gptme.tools.shell_compact._format_shell_output",
+            return_value="raw shell output",
+        ) as mock_format,
+    ):
+        shell = MagicMock()
+        shell.run.return_value = (1, "", "fatal: not a git repository")
+        mock_get_shell.return_value = shell
+
+        messages = list(_execute_compacted_git_log("git log --oneline", tmp_path, 7.5))
+
+    assert messages == [Message("system", "raw shell output")]
+    mock_format.assert_called_once()
+    assert mock_format.call_args.kwargs["allowlisted"] is True
+    assert mock_format.call_args.kwargs["timeout_value"] == 7.5
+    assert mock_format.call_args.kwargs["logdir"] == tmp_path
+
+
+def test_execute_compacted_git_log_falls_back_when_timed_out(tmp_path):
+    with (
+        patch("gptme.tools.shell_compact.get_shell") as mock_get_shell,
+        patch(
+            "gptme.tools.shell_compact._format_shell_output",
+            return_value="timed out output",
+        ) as mock_format,
+    ):
+        shell = MagicMock()
+        shell.run.return_value = (-124, "partial", "")
+        mock_get_shell.return_value = shell
+
+        messages = list(_execute_compacted_git_log("git log --oneline", tmp_path, 1.0))
+
+    assert messages == [Message("system", "timed out output")]
+    assert mock_format.call_args.kwargs["timed_out"] is True
+
+
+def test_execute_compacted_git_log_raises_value_error_on_shell_error(tmp_path):
+    with patch("gptme.tools.shell_compact.get_shell") as mock_get_shell:
+        shell = MagicMock()
+        shell.run.side_effect = RuntimeError("boom")
+        mock_get_shell.return_value = shell
+
+        with pytest.raises(ValueError, match="Shell error: boom"):
+            list(_execute_compacted_git_log("git log --oneline", tmp_path, 1.0))
+
+
+def test_execute_compacted_git_log_interrupts_process_group(tmp_path):
+    process = MagicMock()
+    process.pid = 123
+    process.returncode = 130
+
+    with (
+        patch("gptme.tools.shell_compact.get_shell") as mock_get_shell,
+        patch("gptme.tools.shell_compact.os.getpgid", return_value=456) as mock_getpgid,
+        patch("gptme.tools.shell_compact.os.killpg") as mock_killpg,
+        patch(
+            "gptme.tools.shell_compact._format_shell_output",
+            return_value="interrupted output",
+        ),
+    ):
+        shell = MagicMock()
+        shell.process = process
+        shell.run.side_effect = KeyboardInterrupt(("partial stdout", "partial stderr"))
+        mock_get_shell.return_value = shell
+
+        messages = _execute_compacted_git_log("git log --oneline", tmp_path, 1.0)
+        assert next(messages) == Message("system", "interrupted output")
+        with pytest.raises(KeyboardInterrupt):
+            next(messages)
+
+    mock_getpgid.assert_called_once_with(123)
+    mock_killpg.assert_called_once()
+
+
 def test_execute_shell_compact_falls_back_for_unsupported_command():
     with patch("gptme.tools.shell_compact.execute_shell") as mock_execute_shell:
         mock_execute_shell.return_value = iter([])
@@ -54,3 +161,79 @@ def test_execute_shell_compact_falls_back_for_unsupported_command():
         list(execute_shell_compact("git status", [], None))
 
     mock_execute_shell.assert_called_once()
+
+
+def test_execute_shell_compact_falls_back_when_allowlist_hook_declines():
+    with (
+        patch(
+            "gptme.tools.shell_compact.shell_compact_allowlist_hook", return_value=None
+        ),
+        patch("gptme.tools.shell_compact.execute_shell") as mock_execute_shell,
+    ):
+        mock_execute_shell.return_value = iter([Message("system", "fallback")])
+
+        messages = list(execute_shell_compact("git log --oneline", [], None))
+
+    assert messages == [Message("system", "fallback")]
+    mock_execute_shell.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "git log --oneline",
+        "git log --decorate --oneline -n 5",
+        "git log '--oneline'",
+    ],
+)
+def test_matches_git_log_oneline_accepts_supported_shapes(cmd):
+    assert _matches_git_log_oneline(cmd) is True
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "git status --oneline",
+        "git log",
+        "git log --oneline | cat",
+        "git log --oneline; pwd",
+        "git log --oneline\npwd",
+        "git log --oneline > out.txt",
+        "git log '--oneline",
+    ],
+)
+def test_matches_git_log_oneline_rejects_unsupported_shapes(cmd):
+    assert _matches_git_log_oneline(cmd) is False
+
+
+def test_shell_compact_allowlist_hook_rejects_non_matching_tool_uses():
+    assert (
+        shell_compact_allowlist_hook(ToolUse("shell", [], "git log --oneline", {}))
+        is None
+    )
+    assert shell_compact_allowlist_hook(ToolUse("shell_compact", [], "", {})) is None
+    assert (
+        shell_compact_allowlist_hook(ToolUse("shell_compact", [], "git status", {}))
+        is None
+    )
+
+
+def test_get_timeout_reads_environment(monkeypatch):
+    monkeypatch.setenv("GPTME_SHELL_TIMEOUT", "2.5")
+    assert _get_timeout() == 2.5
+
+    monkeypatch.setenv("GPTME_SHELL_TIMEOUT", "0")
+    assert _get_timeout() is None
+
+    monkeypatch.setenv("GPTME_SHELL_TIMEOUT", "not-a-number")
+    assert _get_timeout() == 1200.0
+
+
+def test_compact_command_display_shortens_long_or_multiline_commands():
+    assert _compact_command_display("git log --oneline") == "git log --oneline"
+
+    long_cmd = "git log --oneline " + ("--decorate " * 10)
+    assert _compact_command_display(long_cmd).endswith("... (1 line)")
+
+    multiline_cmd = "git log --oneline\npwd\nwhoami\ndate"
+    assert _compact_command_display(multiline_cmd) == "git log --oneline... (4 lines)"

--- a/tests/test_tools_shell_compact.py
+++ b/tests/test_tools_shell_compact.py
@@ -224,6 +224,9 @@ def test_matches_git_log_oneline_accepts_supported_shapes(cmd):
         "git log --oneline\npwd",
         "git log --oneline > out.txt",
         "git log '--oneline",
+        "git log --oneline $(id)",
+        "git log --oneline `id`",
+        "git log --oneline $HOME",
     ],
 )
 def test_matches_git_log_oneline_rejects_unsupported_shapes(cmd):

--- a/tests/test_tools_shell_compact.py
+++ b/tests/test_tools_shell_compact.py
@@ -133,8 +133,8 @@ def test_execute_compacted_git_log_interrupts_process_group(tmp_path):
 
     with (
         patch("gptme.tools.shell_compact.get_shell") as mock_get_shell,
-        patch("gptme.tools.shell_compact.os.getpgid", return_value=456) as mock_getpgid,
-        patch("gptme.tools.shell_compact.os.killpg") as mock_killpg,
+        patch("gptme.tools.shell.os.getpgid", return_value=456) as mock_getpgid,
+        patch("gptme.tools.shell.os.killpg") as mock_killpg,
         patch(
             "gptme.tools.shell_compact._format_shell_output",
             return_value="interrupted output",
@@ -160,21 +160,6 @@ def test_execute_shell_compact_falls_back_for_unsupported_command():
 
         list(execute_shell_compact("git status", [], None))
 
-    mock_execute_shell.assert_called_once()
-
-
-def test_execute_shell_compact_falls_back_when_allowlist_hook_declines():
-    with (
-        patch(
-            "gptme.tools.shell_compact.shell_compact_allowlist_hook", return_value=None
-        ),
-        patch("gptme.tools.shell_compact.execute_shell") as mock_execute_shell,
-    ):
-        mock_execute_shell.return_value = iter([Message("system", "fallback")])
-
-        messages = list(execute_shell_compact("git log --oneline", [], None))
-
-    assert messages == [Message("system", "fallback")]
     mock_execute_shell.assert_called_once()
 
 
@@ -235,5 +220,5 @@ def test_compact_command_display_shortens_long_or_multiline_commands():
     long_cmd = "git log --oneline " + ("--decorate " * 10)
     assert _compact_command_display(long_cmd).endswith("... (1 line)")
 
-    multiline_cmd = "git log --oneline\npwd\nwhoami\ndate"
-    assert _compact_command_display(multiline_cmd) == "git log --oneline... (4 lines)"
+    multiline_cmd = "git log --oneline\npwd"
+    assert _compact_command_display(multiline_cmd) == "git log --oneline... (2 lines)"

--- a/tests/test_tools_shell_compact.py
+++ b/tests/test_tools_shell_compact.py
@@ -116,22 +116,8 @@ def test_execute_compacted_git_log_falls_back_when_timed_out(tmp_path):
     assert mock_format.call_args.kwargs["timed_out"] is True
 
 
-@pytest.mark.parametrize(
-    ("patched_name", "patched_value", "patched_side_effect"),
-    [
-        ("save_large_output", None, OSError("disk full")),
-        (
-            "record_context_savings",
-            None,
-            OSError("ledger write failed"),
-        ),
-    ],
-)
-def test_execute_compacted_git_log_falls_back_when_preview_io_fails(
-    tmp_path, patched_name, patched_value, patched_side_effect
-):
+def test_execute_compacted_git_log_falls_back_when_output_save_fails(tmp_path):
     stdout = _fixture_text("git-log-oneline.txt")
-    patch_target = f"gptme.tools.shell_compact.{patched_name}"
 
     with (
         patch("gptme.tools.shell_compact.get_shell") as mock_get_shell,
@@ -140,7 +126,8 @@ def test_execute_compacted_git_log_falls_back_when_preview_io_fails(
             return_value="raw shell output",
         ) as mock_format,
         patch(
-            patch_target, return_value=patched_value, side_effect=patched_side_effect
+            "gptme.tools.shell_compact.save_large_output",
+            side_effect=OSError("disk full"),
         ),
     ):
         shell = MagicMock()
@@ -153,6 +140,30 @@ def test_execute_compacted_git_log_falls_back_when_preview_io_fails(
     mock_format.assert_called_once()
     assert mock_format.call_args.kwargs["allowlisted"] is True
     assert mock_format.call_args.args[3] == 0
+
+
+def test_execute_compacted_git_log_keeps_preview_when_telemetry_fails(tmp_path):
+    stdout = _fixture_text("git-log-oneline.txt")
+
+    with (
+        patch("gptme.tools.shell_compact.get_shell") as mock_get_shell,
+        patch("gptme.tools.shell_compact._format_shell_output") as mock_format,
+        patch(
+            "gptme.tools.shell_compact.record_context_savings",
+            side_effect=OSError("ledger write failed"),
+        ),
+    ):
+        shell = MagicMock()
+        shell.run.return_value = (0, stdout, "")
+        mock_get_shell.return_value = shell
+
+        messages = list(_execute_compacted_git_log("git log --oneline", tmp_path, 7.5))
+
+    assert len(messages) == 1
+    assert "Ran allowlisted compact command" in messages[0].content
+    assert "Showing first 20 of 27 commits." in messages[0].content
+    assert "Full output saved to" in messages[0].content
+    mock_format.assert_not_called()
 
 
 def test_execute_compacted_git_log_raises_value_error_on_shell_error(tmp_path):

--- a/tests/test_tools_shell_compact.py
+++ b/tests/test_tools_shell_compact.py
@@ -116,6 +116,45 @@ def test_execute_compacted_git_log_falls_back_when_timed_out(tmp_path):
     assert mock_format.call_args.kwargs["timed_out"] is True
 
 
+@pytest.mark.parametrize(
+    ("patched_name", "patched_value", "patched_side_effect"),
+    [
+        ("save_large_output", None, OSError("disk full")),
+        (
+            "record_context_savings",
+            None,
+            OSError("ledger write failed"),
+        ),
+    ],
+)
+def test_execute_compacted_git_log_falls_back_when_preview_io_fails(
+    tmp_path, patched_name, patched_value, patched_side_effect
+):
+    stdout = _fixture_text("git-log-oneline.txt")
+    patch_target = f"gptme.tools.shell_compact.{patched_name}"
+
+    with (
+        patch("gptme.tools.shell_compact.get_shell") as mock_get_shell,
+        patch(
+            "gptme.tools.shell_compact._format_shell_output",
+            return_value="raw shell output",
+        ) as mock_format,
+        patch(
+            patch_target, return_value=patched_value, side_effect=patched_side_effect
+        ),
+    ):
+        shell = MagicMock()
+        shell.run.return_value = (0, stdout, "")
+        mock_get_shell.return_value = shell
+
+        messages = list(_execute_compacted_git_log("git log --oneline", tmp_path, 7.5))
+
+    assert messages == [Message("system", "raw shell output")]
+    mock_format.assert_called_once()
+    assert mock_format.call_args.kwargs["allowlisted"] is True
+    assert mock_format.call_args.args[3] == 0
+
+
 def test_execute_compacted_git_log_raises_value_error_on_shell_error(tmp_path):
     with patch("gptme.tools.shell_compact.get_shell") as mock_get_shell:
         shell = MagicMock()


### PR DESCRIPTION
## Summary
- add a new `shell_compact` tool that compact-previews `git log --oneline`
- save the full raw output and record context-savings telemetry for the compacted preview
- wire the regular shell tool to the current conversation logdir so savings/output files can actually be written

## Why
This is the smallest bounded slice of the proactive compact-wrapper spike: one explicit command shape, one explicit preview format, and no heuristic routing.

## Testing
- `uv run ruff check gptme/tools/shell.py gptme/tools/shell_compact.py gptme/tools/shell_validation.py tests/test_tools_shell.py tests/test_tools_shell_compact.py tests/test_shell_allowlist_autoconfirm.py`
- `uv run --with pytest python -m pytest tests/test_tools_shell.py tests/test_tools_shell_compact.py tests/test_shell_allowlist_autoconfirm.py tests/test_commands_llm.py tests/test_util_context_savings.py -q`

## Notes
- unsupported `shell_compact` commands fall back to the regular shell tool
- the compact auto-confirm hook is intentionally narrow: only the explicitly supported `git log --oneline` shape is auto-confirmed