### PR TITLE
feat(tools): add gh_list compactor to shell_compact

### DIFF
--- a/gptme/tools/shell_compact.py
+++ b/gptme/tools/shell_compact.py
@@ -1,9 +1,11 @@
 """
 Compact shell wrapper for known high-output command shapes.
 
-Currently this only compacts ``git log --oneline`` by returning the first few
-commits plus a pointer to the full saved output. Unsupported commands fall back
-to the regular shell tool.
+Currently supports:
+- ``git log --oneline`` — first 20 commits + total count
+- ``gh <noun> list`` / ``gh <noun> status`` — first 20 items + count + grep hint
+
+Unsupported commands fall back to the regular shell tool.
 """
 
 from __future__ import annotations
@@ -41,21 +43,26 @@ _COMPACTOR_SOURCE = "shell_compact"
 
 instructions = """
 Use this tool for known high-output shell commands that have a compact preview.
-Currently it only compacts `git log --oneline` output.
 
-- Matched commands show the first 20 commits, total count, and where the full
-  output was saved.
-- Unsupported commands fall back to the regular shell tool.
-- If you need the full raw output, use the `shell` tool instead.
+Supported commands:
+- `git log --oneline` — shows first 20 commits, total count, and saved path
+- `gh issue list`, `gh pr list`, `gh pr status`, `gh run list` etc. — shows
+  first 20 items with total count and a grep hint
+
+Unsupported commands fall back to the regular shell tool.
+If you need the full raw output, use the `shell` tool instead.
 """.strip()
 
 instructions_format: dict[str, str] = {}
 
 
 def examples(tool_format):
-    preview = """abc1234 fix: wire context savings to current conversation logdir
+    git_preview = """abc1234 fix: wire context savings to current conversation logdir
 def5678 feat: add shell_compact git log preview
 ... (23 more commits omitted) ..."""
+    gh_list_preview = """2334	Settings modal squished on mobile	bug		2026-05-05
+2333	Add GPTME_DISABLE_PATH_INCLUDE env var		2026-05-05
+... (4 more items omitted) ..."""
     return f"""
 > User: show recent commits compactly
 > Assistant:
@@ -66,7 +73,18 @@ def5678 feat: add shell_compact git log preview
 > Showing first 20 of 43 commits. Full output saved to /tmp/.../tool-outputs/shell/...
 > Use `shell` for a raw rerun or `git show <sha>` for a specific commit.
 >
-> {md_codeblock("stdout", preview)}
+> {md_codeblock("stdout", git_preview)}
+
+> User: show open issues
+> Assistant:
+{ToolUse("shell_compact", [], "gh issue list --repo gptme/gptme").to_output(tool_format)}
+> System:
+> Ran allowlisted compact command: `gh issue list --repo gptme/gptme`
+>
+> Showing first 20 of 24 items. Full output saved to /tmp/.../tool-outputs/shell/...
+> Use `shell` for a raw rerun or pipe to `grep` to narrow results.
+>
+> {md_codeblock("stdout", gh_list_preview)}
 """.strip()
 
 
@@ -147,6 +165,122 @@ def _format_git_log_preview(cmd: str, stdout: str, logdir: Path | None) -> str |
     return body
 
 
+_GH_LIST_PATTERNS: list[list[str]] = [
+    ["issue", "list"],
+    ["pr", "list"],
+    ["pr", "status"],
+    ["run", "list"],
+    ["release", "list"],
+    ["repo", "list"],
+    ["repo", "list", "--json", "nameWithOwner"],
+]
+
+
+def _matches_gh_list(cmd: str) -> bool:
+    """Check if a command is a `gh <noun> list|status` pattern."""
+    if any(ch in cmd for ch in "\n|;&<>`$"):
+        return False
+
+    try:
+        tokens = shlex.split(cmd)
+    except ValueError:
+        return False
+
+    if len(tokens) < 3 or tokens[0] != "gh":
+        return False
+
+    # Match: gh <noun> list|status (with optional flags/args after)
+    for pattern in _GH_LIST_PATTERNS:
+        match_len = len(pattern)
+        if len(tokens) >= match_len and tokens[1 : 1 + match_len] == pattern:
+            # Ensure we don't match when gh is being used with subcommands
+            # like `gh issue view` which isn't a list
+            return True
+
+    return False
+
+
+def _compact_body_via_save(
+    cmd: str,
+    stdout: str,
+    logdir: Path | None,
+    compactor_name: str,
+    line_label: str,  # e.g. "commits", "items", "issues"
+    detail_suffix: str,  # e.g. 'Use `shell` for a raw rerun.'
+) -> str | None:
+    """Build a compact preview body, save full output, and record telemetry.
+
+    Returns None if the output is short enough that no compacting is needed.
+    """
+    lines = [line for line in strip_ansi_codes(stdout).splitlines() if line.strip()]
+    if len(lines) <= _PREVIEW_LINES:
+        return None
+
+    saved_path: Path | None = None
+    if logdir:
+        _, saved_path = save_large_output(
+            content=stdout,
+            logdir=logdir,
+            output_type="shell",
+            command_info=cmd,
+        )
+
+    omitted = len(lines) - _PREVIEW_LINES
+    preview = "\n".join(
+        lines[:_PREVIEW_LINES] + [f"... ({omitted} more {line_label} omitted) ..."]
+    )
+
+    detail = f"Showing first {_PREVIEW_LINES} of {len(lines)} {line_label}."
+    if saved_path:
+        detail += f" Full output saved to {saved_path}."
+    else:
+        detail += " Full output was not saved because no conversation logdir is active."
+    detail += " " + detail_suffix
+
+    body = detail + "\n\n" + md_codeblock("stdout", preview)
+
+    if logdir and saved_path:
+        model_name = _default_model_name()
+        try:
+            record_context_savings(
+                logdir=logdir,
+                source=_COMPACTOR_SOURCE,
+                original_tokens=len_tokens(stdout, model_name),
+                kept_tokens=len_tokens(body, model_name),
+                command_info=f"{compactor_name}: {cmd}",
+                saved_path=saved_path,
+            )
+        except OSError as e:
+            logger.warning("Failed to record compact shell telemetry: %s", e)
+
+    return body
+
+
+def _format_gh_list_preview(cmd: str, stdout: str, logdir: Path | None) -> str | None:
+    """Compact gh list output: first 20 items + count + grep hint."""
+    return _compact_body_via_save(
+        cmd=cmd,
+        stdout=stdout,
+        logdir=logdir,
+        compactor_name="gh_list",
+        line_label="items",
+        detail_suffix="Use `shell` for a raw rerun or pipe to `grep` to narrow results.",
+    )
+
+
+def _dispatch_compactor(cmd: str, stdout: str, logdir: Path | None) -> str | None:
+    """Route to the right compactor based on command shape.
+
+    Returns the compact body, or None if no compactor matched or output was
+    already short enough.
+    """
+    if _matches_git_log_oneline(cmd):
+        return _format_git_log_preview(cmd, stdout, logdir)
+    if _matches_gh_list(cmd):
+        return _format_gh_list_preview(cmd, stdout, logdir)
+    return None  # no matching compactor
+
+
 def shell_compact_allowlist_hook(
     tool_use: ToolUse,
     preview: str | None = None,
@@ -164,15 +298,23 @@ def shell_compact_allowlist_hook(
     if not cmd:
         return None
 
-    if _matches_git_log_oneline(cmd):
+    if _matches_git_log_oneline(cmd) or _matches_gh_list(cmd):
         return ConfirmationResult.confirm()
 
     return None
 
 
-def _execute_compacted_git_log(
+def _execute_compacted(
     cmd: str, logdir: Path | None, timeout: float | None
 ) -> Generator[Message, None, None]:
+    """Execute a command and return compacted preview if the shape is supported.
+
+    Falls back to raw shell output if:
+    - The command fails
+    - No compactor matches the command shape
+    - The compactor returns None (output already short enough)
+    - The compactor raises OSError
+    """
     shell = get_shell()
 
     try:
@@ -195,7 +337,7 @@ def _execute_compacted_git_log(
     compact_body = None
     if returncode == 0 and not stderr and not interrupted and not timed_out:
         try:
-            compact_body = _format_git_log_preview(cmd, stdout, logdir)
+            compact_body = _dispatch_compactor(cmd, stdout, logdir)
         except OSError as e:
             logger.warning("Failed to format compact shell output: %s", e)
 
@@ -238,11 +380,11 @@ def execute_shell_compact(
     """Execute a compact shell command when the command shape is supported."""
     cmd = get_shell_command(code, args, kwargs)
 
-    if not _matches_git_log_oneline(cmd):
+    if not _matches_git_log_oneline(cmd) and not _matches_gh_list(cmd):
         yield from execute_shell(code, args, kwargs)
         return
 
-    yield from _execute_compacted_git_log(
+    yield from _execute_compacted(
         cmd,
         logdir=get_path_fn(),
         timeout=_get_timeout(),

--- a/tests/data/gh-issue-list.txt
+++ b/tests/data/gh-issue-list.txt
@@ -1,0 +1,24 @@
+2334	Settings modal squished on mobile	bug		2026-05-05T12:02:45Z
+2333	Add GPTME_DISABLE_PATH_INCLUDE env var for non-interactive prompts		2026-05-05T20:53:57Z
+2328	No Android apk/aab in releases	bug	2026-05-04T20:50:31Z
+2320	feat(cost-awareness): warn when cache is cold	enhancement	2026-05-03T04:07:30Z
+2318	Add EmbeddedContext slot for host-injected MenuBar	enhancement	2026-05-03T21:35:59Z
+2313	feat(cli): /account command for multi-credential switching		2026-05-04T20:19:46Z
+2193	desktop/tauri: user-testing — onboarding, settings, cloud integration	enhancement	2026-04-27T09:58:35Z
+1593	feat(tauri): first-run experience and welcome screen	enhancement	2026-03-04T13:51:38Z
+1532	Add shell_compact tool for high-output commands	enhancement	2026-02-15T10:22:10Z
+1501	Fix memory leak in long-running sessions	bug	2026-02-10T14:33:45Z
+1420	Add JSON output formatter for tools	enhancement	2026-01-28T09:15:22Z
+1389	Race condition in message queue	bug	2026-01-20T16:42:08Z
+1350	Config reload command	enhancement	2026-01-15T11:05:30Z
+1310	Auth token not refreshed automatically	bug	2026-01-08T08:30:15Z
+1280	Plugin hot-reload support	enhancement	2026-01-02T14:20:00Z
+1245	Network timeout not configurable	bug	2025-12-28T10:00:00Z
+1210	Workspace templates	enhancement	2025-12-20T12:30:00Z
+1180	Export to PDF	enhancement	2025-12-15T09:45:00Z
+1150	Batch operations support	enhancement	2025-12-10T15:20:00Z
+1120	UI freezes on large file handling	bug	2025-12-05T11:10:00Z
+1090	Add CLI reference docs	docs	2025-11-30T08:00:00Z
+1050	Progress bar not updating in TUI	bug	2025-11-25T16:30:00Z
+1020	Login flow redirects wrong	bug	2025-11-20T13:00:00Z
+0980	Configuration file not found after upgrade	bug	2025-11-15T10:15:00Z

--- a/tests/test_tools_shell_compact.py
+++ b/tests/test_tools_shell_compact.py
@@ -6,10 +6,14 @@ import pytest
 from gptme.message import Message
 from gptme.tools.base import ToolUse
 from gptme.tools.shell_compact import (
+    _compact_body_via_save,
     _compact_command_display,
-    _execute_compacted_git_log,
+    _dispatch_compactor,
+    _execute_compacted,
+    _format_gh_list_preview,
     _format_git_log_preview,
     _get_timeout,
+    _matches_gh_list,
     _matches_git_log_oneline,
     execute_shell_compact,
     shell_compact_allowlist_hook,
@@ -77,7 +81,7 @@ def test_execute_shell_compact_uses_compactor(tmp_path):
     assert "tool-outputs/shell" in messages[0].content
 
 
-def test_execute_compacted_git_log_falls_back_when_command_fails(tmp_path):
+def test_execute_compacted_falls_back_when_command_fails(tmp_path):
     with (
         patch("gptme.tools.shell_compact.get_shell") as mock_get_shell,
         patch(
@@ -89,7 +93,7 @@ def test_execute_compacted_git_log_falls_back_when_command_fails(tmp_path):
         shell.run.return_value = (1, "", "fatal: not a git repository")
         mock_get_shell.return_value = shell
 
-        messages = list(_execute_compacted_git_log("git log --oneline", tmp_path, 7.5))
+        messages = list(_execute_compacted("git log --oneline", tmp_path, 7.5))
 
     assert messages == [Message("system", "raw shell output")]
     mock_format.assert_called_once()
@@ -98,7 +102,7 @@ def test_execute_compacted_git_log_falls_back_when_command_fails(tmp_path):
     assert mock_format.call_args.kwargs["logdir"] == tmp_path
 
 
-def test_execute_compacted_git_log_falls_back_when_timed_out(tmp_path):
+def test_execute_compacted_falls_back_when_timed_out(tmp_path):
     with (
         patch("gptme.tools.shell_compact.get_shell") as mock_get_shell,
         patch(
@@ -110,13 +114,13 @@ def test_execute_compacted_git_log_falls_back_when_timed_out(tmp_path):
         shell.run.return_value = (-124, "partial", "")
         mock_get_shell.return_value = shell
 
-        messages = list(_execute_compacted_git_log("git log --oneline", tmp_path, 1.0))
+        messages = list(_execute_compacted("git log --oneline", tmp_path, 1.0))
 
     assert messages == [Message("system", "timed out output")]
     assert mock_format.call_args.kwargs["timed_out"] is True
 
 
-def test_execute_compacted_git_log_falls_back_when_output_save_fails(tmp_path):
+def test_execute_compacted_falls_back_when_output_save_fails(tmp_path):
     stdout = _fixture_text("git-log-oneline.txt")
 
     with (
@@ -134,7 +138,7 @@ def test_execute_compacted_git_log_falls_back_when_output_save_fails(tmp_path):
         shell.run.return_value = (0, stdout, "")
         mock_get_shell.return_value = shell
 
-        messages = list(_execute_compacted_git_log("git log --oneline", tmp_path, 7.5))
+        messages = list(_execute_compacted("git log --oneline", tmp_path, 7.5))
 
     assert messages == [Message("system", "raw shell output")]
     mock_format.assert_called_once()
@@ -142,7 +146,7 @@ def test_execute_compacted_git_log_falls_back_when_output_save_fails(tmp_path):
     assert mock_format.call_args.args[3] == 0
 
 
-def test_execute_compacted_git_log_keeps_preview_when_telemetry_fails(tmp_path):
+def test_execute_compacted_keeps_preview_when_telemetry_fails(tmp_path):
     stdout = _fixture_text("git-log-oneline.txt")
 
     with (
@@ -157,7 +161,7 @@ def test_execute_compacted_git_log_keeps_preview_when_telemetry_fails(tmp_path):
         shell.run.return_value = (0, stdout, "")
         mock_get_shell.return_value = shell
 
-        messages = list(_execute_compacted_git_log("git log --oneline", tmp_path, 7.5))
+        messages = list(_execute_compacted("git log --oneline", tmp_path, 7.5))
 
     assert len(messages) == 1
     assert "Ran allowlisted compact command" in messages[0].content
@@ -166,17 +170,17 @@ def test_execute_compacted_git_log_keeps_preview_when_telemetry_fails(tmp_path):
     mock_format.assert_not_called()
 
 
-def test_execute_compacted_git_log_raises_value_error_on_shell_error(tmp_path):
+def test_execute_compacted_raises_value_error_on_shell_error(tmp_path):
     with patch("gptme.tools.shell_compact.get_shell") as mock_get_shell:
         shell = MagicMock()
         shell.run.side_effect = RuntimeError("boom")
         mock_get_shell.return_value = shell
 
         with pytest.raises(ValueError, match="Shell error: boom"):
-            list(_execute_compacted_git_log("git log --oneline", tmp_path, 1.0))
+            list(_execute_compacted("git log --oneline", tmp_path, 1.0))
 
 
-def test_execute_compacted_git_log_interrupts_process_group(tmp_path):
+def test_execute_compacted_interrupts_process_group(tmp_path):
     process = MagicMock()
     process.pid = 123
     process.returncode = 130
@@ -195,7 +199,7 @@ def test_execute_compacted_git_log_interrupts_process_group(tmp_path):
         shell.run.side_effect = KeyboardInterrupt(("partial stdout", "partial stderr"))
         mock_get_shell.return_value = shell
 
-        messages = _execute_compacted_git_log("git log --oneline", tmp_path, 1.0)
+        messages = _execute_compacted("git log --oneline", tmp_path, 1.0)
         assert next(messages) == Message("system", "interrupted output")
         with pytest.raises(KeyboardInterrupt):
             next(messages)
@@ -275,3 +279,175 @@ def test_compact_command_display_shortens_long_or_multiline_commands():
 
     multiline_cmd = "git log --oneline\npwd"
     assert _compact_command_display(multiline_cmd) == "git log --oneline... (2 lines)"
+
+
+# ── gh_list compactor tests ────────────────────────────────────────────────
+
+
+def test_matches_gh_list_accepts_issue_list():
+    assert _matches_gh_list("gh issue list --repo gptme/gptme") is True
+
+
+def test_matches_gh_list_accepts_pr_list():
+    assert _matches_gh_list("gh pr list --state open") is True
+    assert _matches_gh_list("gh pr list --author TimeToBuildBob --limit 50") is True
+
+
+def test_matches_gh_list_accepts_pr_status():
+    assert _matches_gh_list("gh pr status") is True
+
+
+def test_matches_gh_list_accepts_run_list():
+    assert _matches_gh_list("gh run list --limit 10") is True
+
+
+def test_matches_gh_list_accepts_release_list():
+    assert _matches_gh_list("gh release list") is True
+
+
+def test_matches_gh_list_accepts_repo_list():
+    assert _matches_gh_list("gh repo list gptme --limit 100") is True
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "gh issue view 123",
+        "gh pr checkout 456",
+        "gh run watch 789",
+        "gh pr create",
+        "gh issue close 123",
+        "gh --version",
+        "ls",
+        "git log",
+        "git status",
+    ],
+)
+def test_matches_gh_list_rejects_non_list_commands(cmd):
+    assert _matches_gh_list(cmd) is False
+
+
+def test_matches_gh_list_rejects_shell_chars():
+    assert _matches_gh_list("gh issue list; rm -rf /") is False
+    assert _matches_gh_list("gh issue list | grep foo") is False
+    assert _matches_gh_list("gh issue list$(id)") is False
+    assert _matches_gh_list("gh issue list `id`") is False
+
+
+def test_format_gh_list_preview_records_context_savings(tmp_path):
+    stdout = _fixture_text("gh-issue-list.txt")
+
+    preview = _format_gh_list_preview(
+        "gh issue list --repo gptme/gptme", stdout, tmp_path
+    )
+
+    assert preview is not None
+    assert "Showing first 20 of 24 items." in preview
+    assert "more items omitted" in preview
+    assert "Full output saved to" in preview
+    assert "pipe to `grep` to narrow" in preview
+
+    ledger = tmp_path / "context-savings.jsonl"
+    rows = ledger.read_text(encoding="utf-8").splitlines()
+    assert len(rows) == 1
+    assert "shell_compact" in rows[0]
+    assert "gh_list:" in rows[0]
+
+
+def test_format_gh_list_preview_skips_short_lists(tmp_path):
+    stdout = "\n".join(_fixture_text("gh-issue-list.txt").splitlines()[:5])
+
+    preview = _format_gh_list_preview("gh issue list", stdout, tmp_path)
+
+    assert preview is None
+    assert not (tmp_path / "context-savings.jsonl").exists()
+
+
+def test_format_gh_list_preview_without_logdir(tmp_path):
+    stdout = _fixture_text("gh-issue-list.txt")
+
+    preview = _format_gh_list_preview("gh issue list", stdout, None)
+
+    assert preview is not None
+    assert (
+        "Full output was not saved because no conversation logdir is active." in preview
+    )
+    assert "pipe to `grep` to narrow" in preview
+
+
+def test_dispatch_compactor_routes_gh_list(tmp_path):
+    stdout = _fixture_text("gh-issue-list.txt")
+    result = _dispatch_compactor("gh issue list --repo gptme/gptme", stdout, tmp_path)
+    assert result is not None
+    assert "Showing first 20 of 24 items." in result
+
+
+def test_dispatch_compactor_routes_git_log(tmp_path):
+    stdout = _fixture_text("git-log-oneline.txt")
+    result = _dispatch_compactor("git log --oneline", stdout, tmp_path)
+    assert result is not None
+    assert "Showing first 20 of 27 commits." in result
+
+
+def test_dispatch_compactor_returns_none_for_unknown(tmp_path):
+    result = _dispatch_compactor("cat README.md", "some content\n", tmp_path)
+    assert result is None
+
+
+def test_execute_shell_compact_uses_gh_list_compactor(tmp_path):
+    stdout = _fixture_text("gh-issue-list.txt")
+
+    with (
+        patch("gptme.tools.shell_compact.get_shell") as mock_get_shell,
+        patch("gptme.tools.shell_compact.get_path_fn", return_value=tmp_path),
+    ):
+        shell = MagicMock()
+        shell.run.return_value = (0, stdout, "")
+        mock_get_shell.return_value = shell
+
+        messages = list(
+            execute_shell_compact("gh issue list --repo gptme/gptme", [], None)
+        )
+
+    assert len(messages) == 1
+    assert "Ran allowlisted compact command" in messages[0].content
+    assert "Showing first 20 of 24 items." in messages[0].content
+
+
+def test_shell_compact_allowlist_hook_confirms_gh_list():
+    """The allowlist hook should auto-confirm gh list commands."""
+    result = shell_compact_allowlist_hook(
+        ToolUse("shell_compact", [], "gh issue list --repo gptme/gptme")
+    )
+    assert result is not None
+
+
+def test_shell_compact_allowlist_hook_rejects_non_list():
+    assert (
+        shell_compact_allowlist_hook(ToolUse("shell_compact", [], "gh issue view 123"))
+        is None
+    )
+
+
+def test_compact_body_via_save_short_output(tmp_path):
+    """Short output returns None (no compacting needed)."""
+    result = _compact_body_via_save(
+        "echo hello", "hello\nworld\n", tmp_path, "test", "lines", ""
+    )
+    assert result is None
+
+
+def test_compact_body_via_save_uses_provided_logdir(tmp_path):
+    lines = "\n".join(f"line {i}" for i in range(30))
+    result = _compact_body_via_save(
+        "cat data.txt",
+        lines,
+        tmp_path,
+        "test",
+        "lines",
+        "Use `shell` for full output.",
+    )
+    assert result is not None
+    assert "Showing first 20 of 30 lines." in result
+    assert "Full output saved to" in result
+    assert "Use `shell` for full output." in result


### PR DESCRIPTION
## Summary

Add a new compactor for `gh <noun> list|status` commands to the `shell_compact` tool, following the same pattern as the existing `git_log_oneline` compactor.

Supports: `gh issue list`, `gh pr list`, `gh pr status`, `gh run list`, `gh release list`, `gh repo list`.

## What changed

- `_matches_gh_list()` — detects gh list/status command shapes
- `_format_gh_list_preview()` — shows first 20 items + total count + grep hint
- `_compact_body_via_save()` — extracted helper to reduce duplication between compactors
- `_dispatch_compactor()` — generic routing between compactors
- Renamed `_execute_compacted_git_log` → `_execute_compacted` for generic dispatch
- Updated tool instructions, examples, and allowlist hook

## Testing

- `ruff check` — clean
- `ruff format --check` — clean after formatting
- `pytest tests/test_tools_shell_compact.py tests/test_tools_shell.py tests/test_util_context_savings.py` — 164 passed

## Next

After this, the next compactors from the design spike can be added incrementally: `find_files`, `journalctl`, `gh_pr_view`.