### PR TITLE
feat(tools): add gh issue/pr list preview to shell output

### DIFF
--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -1090,7 +1090,7 @@ def _matches_git_log_oneline(cmd: str) -> bool:
 
 
 def _matches_gh_list(cmd: str) -> bool:
-    """Detect ``gh issue list`` or ``gh pr list`` commands."""
+    """Detect ``gh issue list`` or ``gh pr list`` commands (tabular output only)."""
     if any(ch in cmd for ch in "\n|;&<>`$"):
         return False
 
@@ -1102,7 +1102,19 @@ def _matches_gh_list(cmd: str) -> bool:
     if len(tokens) < 3 or tokens[0] != "gh":
         return False
 
-    return tokens[1] in ("issue", "pr") and tokens[2] == "list"
+    if not (tokens[1] in ("issue", "pr") and tokens[2] == "list"):
+        return False
+
+    # Reject JSON output formats — truncating a JSON array at line boundaries
+    # produces invalid JSON that the model cannot parse.
+    flags = tokens[3:]
+    for i, tok in enumerate(flags):
+        if tok.startswith("--json"):
+            return False
+        if tok == "--format" and i + 1 < len(flags) and flags[i + 1] == "json":
+            return False
+
+    return True
 
 
 def _format_git_log_preview(cmd: str, stdout: str, logdir: Path | None) -> str | None:

--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -1111,6 +1111,8 @@ def _matches_gh_list(cmd: str) -> bool:
     for i, tok in enumerate(flags):
         if tok.startswith("--json"):
             return False
+        if tok.startswith("--format="):
+            return False
         if tok == "--format" and i + 1 < len(flags) and flags[i + 1] == "json":
             return False
 

--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -1183,7 +1183,7 @@ def _format_gh_list_preview(cmd: str, stdout: str, logdir: Path | None) -> str |
     else:
         detail += (
             " Full output was not saved because no conversation logdir is active."
-            " To get the full list, pipe through cat: `gh issue list | cat`."
+            f" To get the full list, pipe through cat: `{cmd} | cat`."
         )
     detail += " Use `gh issue view <number>` or `gh pr view <number>` for details."
 

--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -94,6 +94,7 @@ _TRUNC_POST_TOKENS_DEFAULT = 8000
 _TRUNC_STDERR_PRE_TOKENS_DEFAULT = 2000
 _TRUNC_STDERR_POST_TOKENS_DEFAULT = 2000
 _GIT_LOG_PREVIEW_LINES = 20
+_GH_LIST_PREVIEW_LINES = 10
 
 
 candidates = (
@@ -1088,6 +1089,22 @@ def _matches_git_log_oneline(cmd: str) -> bool:
     return any(token == "--oneline" for token in tokens[2:])
 
 
+def _matches_gh_list(cmd: str) -> bool:
+    """Detect ``gh issue list`` or ``gh pr list`` commands."""
+    if any(ch in cmd for ch in "\n|;&<>`$"):
+        return False
+
+    try:
+        tokens = shlex.split(cmd)
+    except ValueError:
+        return False
+
+    if len(tokens) < 3 or tokens[0] != "gh":
+        return False
+
+    return tokens[1] in ("issue", "pr") and tokens[2] == "list"
+
+
 def _format_git_log_preview(cmd: str, stdout: str, logdir: Path | None) -> str | None:
     lines = [line for line in strip_ansi_codes(stdout).splitlines() if line.strip()]
     if len(lines) <= _GIT_LOG_PREVIEW_LINES:
@@ -1138,6 +1155,57 @@ def _format_git_log_preview(cmd: str, stdout: str, logdir: Path | None) -> str |
     return body
 
 
+def _format_gh_list_preview(cmd: str, stdout: str, logdir: Path | None) -> str | None:
+    """Format a compact preview for ``gh issue list`` / ``gh pr list`` output."""
+    lines = [line for line in strip_ansi_codes(stdout).splitlines() if line.strip()]
+    if len(lines) <= _GH_LIST_PREVIEW_LINES:
+        return None
+
+    saved_path: Path | None = None
+    if logdir:
+        _, saved_path = save_large_output(
+            content=stdout,
+            logdir=logdir,
+            output_type="shell",
+            command_info=cmd,
+        )
+
+    omitted = len(lines) - _GH_LIST_PREVIEW_LINES
+    preview = "\n".join(
+        lines[:_GH_LIST_PREVIEW_LINES] + [f"... ({omitted} more items omitted) ..."]
+    )
+
+    detail = f"Showing first {_GH_LIST_PREVIEW_LINES} of {len(lines)} items."
+    if saved_path:
+        detail += (
+            f" Full output saved to {saved_path}; read that file for the complete list."
+        )
+    else:
+        detail += (
+            " Full output was not saved because no conversation logdir is active."
+            " To get the full list, pipe through cat: `gh issue list | cat`."
+        )
+    detail += " Use `gh issue view <number>` or `gh pr view <number>` for details."
+
+    body = detail + "\n\n" + md_codeblock("stdout", preview)
+
+    if logdir and saved_path:
+        model_name = _default_model_name()
+        try:
+            record_context_savings(
+                logdir=logdir,
+                source="shell",
+                original_tokens=len_tokens(stdout, model_name),
+                kept_tokens=len_tokens(body, model_name),
+                command_info=f"gh_list: {cmd}",
+                saved_path=saved_path,
+            )
+        except OSError as e:
+            logger.warning("Failed to record compact shell telemetry: %s", e)
+
+    return body
+
+
 def _format_shell_output(
     cmd: str,
     stdout: str,
@@ -1165,6 +1233,19 @@ def _format_shell_output(
     ):
         try:
             compact_stdout = _format_git_log_preview(cmd, stdout, logdir)
+        except OSError as e:
+            logger.warning("Failed to format compact shell output: %s", e)
+
+    if compact_stdout is None and (
+        returncode == 0
+        and stdout
+        and not stderr
+        and not interrupted
+        and not timed_out
+        and _matches_gh_list(cmd)
+    ):
+        try:
+            compact_stdout = _format_gh_list_preview(cmd, stdout, logdir)
         except OSError as e:
             logger.warning("Failed to format compact shell output: %s", e)
 

--- a/tests/data/gh-issue-list.txt
+++ b/tests/data/gh-issue-list.txt
@@ -1,0 +1,25 @@
+#301  fix: broken import in tools/shell.py           open   2025-01-15
+#302  feat: add gh list compaction                   open   2025-01-15
+#303  docs: update CLAUDE.md conventions             open   2025-01-15
+#304  chore: bump dependencies                       open   2025-01-16
+#305  fix: handle edge case in shorten_stdout        open   2025-01-16
+#306  feat: add context savings telemetry            open   2025-01-17
+#307  docs: add usage examples for shell_compact     open   2025-01-17
+#308  fix: typo in error message                     open   2025-01-18
+#309  feat: add support for gh pr list preview       open   2025-01-18
+#310  chore: update CI configuration                 open   2025-01-19
+#311  feat: extend shell compaction to more commands open   2025-01-20
+#312  fix: race condition in save_large_output       open   2025-01-21
+#313  feat: add per-command context savings detail   open   2025-01-22
+#314  docs: document context-savings.jsonl format    open   2025-01-22
+#315  fix: incorrect token count for multiline msgs  open   2025-01-23
+#316  feat: add shell compaction for gh run list     open   2025-01-24
+#317  chore: clean up dead code in shell_compact     open   2025-01-25
+#318  fix: handle empty output in preview formatter  open   2025-01-25
+#319  feat: add ANSI stripping before token count    open   2025-01-26
+#320  docs: add integration tests for shell preview  open   2025-01-27
+#321  fix: edge case with piped commands detection   open   2025-01-28
+#322  feat: add context savings to PR review flow    open   2025-01-29
+#323  chore: bump minimum Python version to 3.11     open   2025-01-30
+#324  fix: wrong file path in save_large_output log  open   2025-01-31
+#325  feat: expose context savings via /context cmd  open   2025-02-01

--- a/tests/test_tools_shell.py
+++ b/tests/test_tools_shell.py
@@ -736,6 +736,8 @@ def test_matches_gh_list_accepts_supported_shapes(cmd):
         "gh pr list --json number,state",
         "gh issue list --format json",
         "gh pr list --format json",
+        "gh issue list --format=json",
+        "gh pr list --format=json",
     ],
 )
 def test_matches_gh_list_rejects_unsupported_shapes(cmd):

--- a/tests/test_tools_shell.py
+++ b/tests/test_tools_shell.py
@@ -730,6 +730,12 @@ def test_matches_gh_list_accepts_supported_shapes(cmd):
         "gh issue list $(id)",
         "gh issue list `id`",
         "gh issue list $HOME",
+        # JSON output: truncating a JSON array at line boundaries produces invalid JSON
+        "gh issue list --json number,title",
+        "gh issue list --json number",
+        "gh pr list --json number,state",
+        "gh issue list --format json",
+        "gh pr list --format json",
     ],
 )
 def test_matches_gh_list_rejects_unsupported_shapes(cmd):

--- a/tests/test_tools_shell.py
+++ b/tests/test_tools_shell.py
@@ -9,9 +9,11 @@ import pytest
 
 from gptme.tools.shell import (
     ShellSession,
+    _format_gh_list_preview,
     _format_git_log_preview,
     _format_shell_output,
     _get_truncation_budget,
+    _matches_gh_list,
     _matches_git_log_oneline,
     _shorten_stdout,
     get_path_fn,
@@ -700,6 +702,100 @@ def test_matches_git_log_oneline_accepts_supported_shapes(cmd):
 )
 def test_matches_git_log_oneline_rejects_unsupported_shapes(cmd):
     assert _matches_git_log_oneline(cmd) is False
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "gh issue list",
+        "gh pr list",
+        "gh issue list --state open",
+        "gh pr list --limit 50",
+    ],
+)
+def test_matches_gh_list_accepts_supported_shapes(cmd):
+    assert _matches_gh_list(cmd) is True
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "gh run list",
+        "gh repo list",
+        "gh issue view 1",
+        "gh issue list | cat",
+        "gh issue list; pwd",
+        "gh issue list\npwd",
+        "gh issue list > out.txt",
+        "gh issue list $(id)",
+        "gh issue list `id`",
+        "gh issue list $HOME",
+    ],
+)
+def test_matches_gh_list_rejects_unsupported_shapes(cmd):
+    assert _matches_gh_list(cmd) is False
+
+
+def test_format_gh_list_preview_records_context_savings(tmp_path):
+    stdout = _fixture_text("gh-issue-list.txt")
+
+    preview = _format_gh_list_preview("gh issue list", stdout, tmp_path)
+
+    assert preview is not None
+    assert "Showing first 10 of 25 items." in preview
+    assert "more items omitted" in preview
+    assert "Full output saved to" in preview
+
+    ledger = tmp_path / "context-savings.jsonl"
+    rows = [
+        json.loads(line) for line in ledger.read_text().splitlines() if line.strip()
+    ]
+    assert len(rows) == 1
+    assert rows[0]["source"] == "shell"
+    assert rows[0]["command_info"] == "gh_list: gh issue list"
+
+
+def test_format_gh_list_preview_without_logdir_does_not_save():
+    stdout = _fixture_text("gh-issue-list.txt")
+
+    with patch("gptme.tools.shell.save_large_output") as save_large_output:
+        preview = _format_gh_list_preview("gh issue list", stdout, None)
+
+    assert preview is not None
+    assert "Showing first 10 of 25 items." in preview
+    assert (
+        "Full output was not saved because no conversation logdir is active" in preview
+    )
+    assert "gh issue list | cat" in preview
+    save_large_output.assert_not_called()
+
+
+def test_format_gh_list_preview_skips_short_lists(tmp_path):
+    stdout = "\n".join(_fixture_text("gh-issue-list.txt").splitlines()[:3])
+
+    preview = _format_gh_list_preview("gh issue list", stdout, tmp_path)
+
+    assert preview is None
+    assert not (tmp_path / "context-savings.jsonl").exists()
+
+
+def test_format_shell_output_uses_gh_list_preview(tmp_path):
+    stdout = _fixture_text("gh-issue-list.txt")
+
+    output = _format_shell_output(
+        cmd="gh issue list",
+        stdout=stdout,
+        stderr="",
+        returncode=0,
+        interrupted=False,
+        allowlisted=False,
+        logdir=tmp_path,
+    )
+
+    assert "Ran command: `gh issue list`" in output
+    assert "Showing first 10 of 25 items." in output
+    assert "more items omitted" in output
+    assert "Full output saved to" in output
 
 
 def test_is_denylisted_pattern_matches():

--- a/tests/test_tools_shell.py
+++ b/tests/test_tools_shell.py
@@ -770,6 +770,17 @@ def test_format_gh_list_preview_without_logdir_does_not_save():
     save_large_output.assert_not_called()
 
 
+def test_format_gh_list_preview_without_logdir_uses_actual_cmd():
+    """Hint must echo the real command, not always say 'gh issue list'."""
+    stdout = _fixture_text("gh-issue-list.txt")
+
+    preview = _format_gh_list_preview("gh pr list --limit 50", stdout, None)
+
+    assert preview is not None
+    assert "gh pr list --limit 50 | cat" in preview
+    assert "gh issue list | cat" not in preview
+
+
 def test_format_gh_list_preview_skips_short_lists(tmp_path):
     stdout = "\n".join(_fixture_text("gh-issue-list.txt").splitlines()[:3])
 
@@ -794,6 +805,25 @@ def test_format_shell_output_uses_gh_list_preview(tmp_path):
 
     assert "Ran command: `gh issue list`" in output
     assert "Showing first 10 of 25 items." in output
+    assert "more items omitted" in output
+    assert "Full output saved to" in output
+
+
+def test_format_shell_output_uses_gh_list_preview_for_pr_list(tmp_path):
+    stdout = _fixture_text("gh-issue-list.txt")
+
+    output = _format_shell_output(
+        cmd="gh pr list",
+        stdout=stdout,
+        stderr="",
+        returncode=0,
+        interrupted=False,
+        allowlisted=False,
+        logdir=tmp_path,
+    )
+
+    assert "Ran command: `gh pr list`" in output
+    assert "Showing first 10 of" in output
     assert "more items omitted" in output
     assert "Full output saved to" in output
 


### PR DESCRIPTION
## Summary

Ports `gh issue list` and `gh pr list` compaction into `shell.py`, following the git log preview pattern added in #2340.

When a `gh issue list` or `gh pr list` command returns more than 10 items, the output is truncated to the first 10 with a summary line, the full output is saved to the conversation logdir, and context savings are recorded.

## Changes

- `_GH_LIST_PREVIEW_LINES = 10` constant
- `_matches_gh_list()` — detects `gh issue list` / `gh pr list` without pipes or shell operators
- `_format_gh_list_preview()` — formats preview, saves full output, records context savings telemetry
- Wired into `_format_shell_output()` after the git log check
- Tests (18 new) and `tests/data/gh-issue-list.txt` fixture

## Motivation

#2338 and #2339 were closed with Erik's feedback: `shell_compact` shouldn't be a separate tool — fold it into `shell` or remove. PR #2340 folded git log into shell and removed shell_compact entirely, but gh list preview was dropped. This PR closes that gap by folding gh list directly into `shell.py`.

## Escape hatch

If you want the raw output: `gh issue list | cat`