### PR TITLE
fix(autocompact): record context-savings ledger when tool outputs are summarized

### DIFF
--- a/gptme/util/output_storage.py
+++ b/gptme/util/output_storage.py
@@ -122,7 +122,7 @@ def create_tool_result_summary(
         from .tokens import len_tokens
 
         model = get_default_model()
-        model_name = model.model if model else "gpt-4"
+        model_name = model.model if model else "cl100k_base"
         record_context_savings(
             logdir=logdir,
             source=tool_name,

--- a/gptme/util/output_storage.py
+++ b/gptme/util/output_storage.py
@@ -131,7 +131,7 @@ def create_tool_result_summary(
             command_info=command_info,
             saved_path=saved_path,
         )
-    except (OSError, ImportError) as e:
+    except Exception as e:
         logger.warning("Failed to record autocompact context savings: %s", e)
 
     return summary_msg

--- a/gptme/util/output_storage.py
+++ b/gptme/util/output_storage.py
@@ -112,5 +112,26 @@ def create_tool_result_summary(
         original_tokens=original_tokens,
     )
 
-    # Return message with file reference
-    return f"{base_msg}. Full output saved to: {saved_path}\nYou can read or grep this file if needed."
+    summary_msg = f"{base_msg}. Full output saved to: {saved_path}\nYou can read or grep this file if needed."
+
+    # Record telemetry for the autocompact savings. The replacement message
+    # is what stays in the conversation, so kept_tokens is its token count.
+    try:
+        from ..llm.models import get_default_model
+        from .context_savings import record_context_savings
+        from .tokens import len_tokens
+
+        model = get_default_model()
+        model_name = model.model if model else "gpt-4"
+        record_context_savings(
+            logdir=logdir,
+            source=tool_name,
+            original_tokens=original_tokens,
+            kept_tokens=len_tokens(summary_msg, model_name),
+            command_info=command_info,
+            saved_path=saved_path,
+        )
+    except (OSError, ImportError) as e:
+        logger.warning("Failed to record autocompact context savings: %s", e)
+
+    return summary_msg

--- a/tests/test_util_output_storage.py
+++ b/tests/test_util_output_storage.py
@@ -1,5 +1,6 @@
 """Tests for the output_storage utility module."""
 
+import json
 from pathlib import Path
 
 from gptme.util.output_storage import create_tool_result_summary, save_large_output
@@ -101,3 +102,38 @@ def test_create_tool_result_summary_no_command(tmp_path: Path):
     assert "500 tokens" in result
     # Should not have command info
     assert "Command:" not in result or "Ran command:" not in result
+
+
+def test_create_tool_result_summary_records_savings_ledger(tmp_path: Path):
+    """create_tool_result_summary should append to context-savings.jsonl."""
+    create_tool_result_summary(
+        content="x" * 4000,  # ensure non-trivial original token count
+        original_tokens=10000,
+        logdir=tmp_path,
+        tool_name="autocompact",
+    )
+    ledger = tmp_path / "context-savings.jsonl"
+    assert ledger.exists(), "ledger should be created when logdir is provided"
+
+    rows = [
+        json.loads(line) for line in ledger.read_text().splitlines() if line.strip()
+    ]
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["source"] == "autocompact"
+    assert row["original_tokens"] == 10000
+    assert row["saved_tokens"] > 0
+    assert row["saved_tokens"] == row["original_tokens"] - row["kept_tokens"]
+    assert "saved_path" in row
+
+
+def test_create_tool_result_summary_no_logdir_no_ledger(tmp_path: Path):
+    """Without logdir, no ledger should be written anywhere."""
+    create_tool_result_summary(
+        content="lots of output",
+        original_tokens=10000,
+        logdir=None,
+        tool_name="shell",
+    )
+    # Sanity: the test's tmp_path stays clean
+    assert not (tmp_path / "context-savings.jsonl").exists()


### PR DESCRIPTION
## Problem

`create_tool_result_summary` (autocompact path) saves large tool outputs to disk via `save_large_output` but never appends a row to `context-savings.jsonl`. The shell-truncation path is currently the only thing writing to that ledger, so any savings produced by autocompact are invisible to telemetry.

## Empirical signal

In Bob's workspace this manifested as a fully cold telemetry channel:

- 17,637 gptme conversations
- 95 of them had `tool-outputs/autocompact/` directories (so `save_large_output` did fire)
- **0** of them had a `context-savings.jsonl` ledger

Every conversation with an autocompact tool-output was a missed measurement.

## Fix

Wire `record_context_savings` into `create_tool_result_summary`:

- `original_tokens` is what the caller already passed in
- `kept_tokens` is computed from the replacement summary message that actually stays in the conversation
- `saved_path` and `command_info` are forwarded so the ledger row matches the shell-path schema
- Wrapped in `try/except (OSError, ImportError)` so a tokenizer / model lookup failure can never block the autocompact reduction itself — telemetry is best-effort

## Tests

Two new regression tests in `tests/test_util_output_storage.py`:

- ledger row written with correct `source` / `original_tokens` / `saved_tokens` / `saved_path` when `logdir` is provided
- no ledger written when `logdir` is `None`

\`\`\`
tests/test_util_output_storage.py: 10 passed
tests/test_auto_compact.py:        42 passed
\`\`\`

## Out of scope

This PR does **not** address the parallel observation that the shell-truncation path itself is producing zero ledgers in some workloads (separate issue — looks like the shell `_shorten_stdout` `saved_path` branch isn't firing in autonomous runs even when truncation happens, evidenced by `... (output truncated) ...` messages without the `saved to` suffix). Filing that separately so this PR stays focused on the clearly diagnosable autocompact gap.