### PR TITLE
fix(tools): fall back to current LogManager when shell logdir is None

### DIFF
--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -1648,18 +1648,43 @@ def _shorten_stdout(
 
     # If truncation will happen, save full output to file
     saved_path = None
-    if (will_truncate_by_lines or will_truncate_by_tokens) and logdir:
-        command_info = f"Command: {cmd}" if cmd else None
-        original_tokens = (
-            len(tokens) if (will_truncate_by_tokens and tokenizer is not None) else None
-        )
-        _, saved_path = save_large_output(
-            content=stdout,
-            logdir=logdir,
-            output_type="shell",
-            command_info=command_info,
-            original_tokens=original_tokens,
-        )
+    if will_truncate_by_lines or will_truncate_by_tokens:
+        # Fallback: if the caller didn't pass logdir (e.g. a code path that
+        # bypassed execute_shell's get_path_fn), try the current LogManager
+        # context directly. This avoids silent telemetry loss in cases where
+        # the parameter wasn't threaded through correctly.
+        if logdir is None:
+            from ..logmanager import LogManager  # fmt: skip
+
+            manager = LogManager.get_current_log()
+            if manager and manager.logdir:
+                logdir = manager.logdir
+                logger.debug(
+                    "_shorten_stdout: recovered logdir from current LogManager"
+                )
+
+        if logdir is not None:
+            command_info = f"Command: {cmd}" if cmd else None
+            original_tokens = (
+                len(tokens)
+                if (will_truncate_by_tokens and tokenizer is not None)
+                else None
+            )
+            _, saved_path = save_large_output(
+                content=stdout,
+                logdir=logdir,
+                output_type="shell",
+                command_info=command_info,
+                original_tokens=original_tokens,
+            )
+        else:
+            logger.warning(
+                "_shorten_stdout: truncating output but no logdir is available; "
+                "full output will not be saved and context-savings ledger entry "
+                "will be skipped (cmd=%s, lines=%s)",
+                cmd,
+                len(lines),
+            )
 
     # NOTE: This can cause issues when, for example, reading a CSV with dates in the first column
     if strip_dates:

--- a/tests/test_tools_shell.py
+++ b/tests/test_tools_shell.py
@@ -507,6 +507,61 @@ def test_get_path_fn_uses_current_logdir(tmp_path):
         assert get_path_fn() == tmp_path
 
 
+def test_shorten_stdout_falls_back_to_current_logdir(tmp_path):
+    """When logdir param is None, _shorten_stdout falls back to LogManager."""
+    stdout = "\n".join(f"line {i}" for i in range(200))
+
+    manager = MagicMock()
+    manager.logdir = tmp_path
+
+    with patch("gptme.logmanager.LogManager.get_current_log", return_value=manager):
+        shortened = _shorten_stdout(
+            stdout,
+            pre_lines=5,
+            post_lines=5,
+            logdir=None,
+            cmd="git log --oneline",
+        )
+
+    ledger = tmp_path / "context-savings.jsonl"
+    assert ledger.exists(), "context-savings.jsonl should be written via fallback"
+    rows = [json.loads(line) for line in ledger.read_text().splitlines()]
+    assert "full output saved to" in shortened
+    assert len(rows) == 1
+    assert rows[0]["source"] == "shell"
+    assert rows[0]["saved_tokens"] > 0
+
+
+def test_shorten_stdout_warns_when_no_logdir_available(tmp_path, caplog):
+    """When neither logdir param nor LogManager has a logdir, log a warning."""
+    import logging
+
+    stdout = "\n".join(f"line {i}" for i in range(200))
+
+    with (
+        patch("gptme.logmanager.LogManager.get_current_log", return_value=None),
+        caplog.at_level(logging.WARNING, logger="gptme.tools.shell"),
+    ):
+        shortened = _shorten_stdout(
+            stdout,
+            pre_lines=5,
+            post_lines=5,
+            logdir=None,
+            cmd="echo hello",
+        )
+
+    # Truncation still happens (preserves context budget) but no save and no record
+    assert "lines truncated" in shortened
+    assert "full output saved to" not in shortened
+    assert not (tmp_path / "context-savings.jsonl").exists()
+    # And we got a warning so the case is visible in logs
+    assert any(
+        "no logdir is available" in record.message for record in caplog.records
+    ), (
+        f"Expected warning about missing logdir, got: {[r.message for r in caplog.records]}"
+    )
+
+
 def test_truncation_budget_default(monkeypatch):
     monkeypatch.delenv("GPTME_SHELL_TRUNC_PRE_TOKENS", raising=False)
     monkeypatch.delenv("GPTME_SHELL_TRUNC_POST_TOKENS", raising=False)


### PR DESCRIPTION
## Summary

Closes #2343.

When `_shorten_stdout` was called with `logdir=None` and truncation actually fired,
the function silently dropped the full output and skipped the context-savings
ledger entry. This produced 23 occurrences of the bare `(output truncated)` message
in real autonomous-research transcripts with no `tool-outputs/` directory and no
`context-savings.jsonl` ledger to back them up.

## Fix

- If `logdir` is None at the truncation site, fall back to `LogManager.get_current_log()`
  so paths that didn't thread the parameter through still get a chance to save and
  record telemetry.
- If both the parameter and the ContextVar are None, log a warning instead of
  silently dropping the data, so the case is visible in logs.

## Test plan

- [x] `tests/test_tools_shell.py::test_shorten_stdout_falls_back_to_current_logdir` — recovery path saves the file and writes the ledger
- [x] `tests/test_tools_shell.py::test_shorten_stdout_warns_when_no_logdir_available` — truncation message still produced, warning emitted
- [x] All 111 tests in `test_tools_shell.py` + `test_util_context_savings.py` pass
- [x] ruff check + format clean