### PR TITLE
fix(server): move :key from Vue template to child elements

### DIFF
--- a/gptme/server/static/index.html
+++ b/gptme/server/static/index.html
@@ -138,8 +138,9 @@
                 <div class="text-sm" v-html="message.html"></div>
                 <!-- File attachments (images rendered inline, others as download links) -->
                 <div v-if="message.files && message.files.length" class="mt-3 flex flex-wrap gap-2">
-                  <template v-for="file in message.files" :key="file">
+                  <template v-for="file in message.files">
                     <a v-if="isImage(file)"
+                       :key="file"
                        :href="fileUrl(file)"
                        target="_blank"
                        class="block">
@@ -149,6 +150,7 @@
                            @error="$event.target.parentElement.style.display='none'" />
                     </a>
                     <a v-else
+                       :key="file"
                        :href="fileUrl(file)"
                        target="_blank"
                        class="inline-flex items-center gap-1 px-2 py-1 bg-gray-100 hover:bg-gray-200 rounded text-sm text-gray-700 transition">


### PR DESCRIPTION
## Problem

The gptme server web UI shows a Vue warning in the browser console:

```
[Vue warn]: Error compiling template:
<template> cannot be keyed. Place the key on real elements instead.
```

This occurs when file attachments (images/downloads) are rendered — the `:key` is on a `<template v-for>` tag, which Vue 3 does not allow.

## Fix

Move `:key="file"` from the `<template>` tag to the child `<a>` elements. Since `v-if`/`v-else` ensures only one `<a>` element renders per iteration, using the same key on both branches is safe.

Before:
```html
<template v-for="file in message.files" :key="file">
  <a v-if="isImage(file)" ...>
  <a v-else ...>
</template>
```

After:
```html
<template v-for="file in message.files">
  <a v-if="isImage(file)" :key="file" ...>
  <a v-else :key="file" ...>
</template>
```

## Testing

- No Vue warning in browser console when file attachments are rendered
- Existing server behavior unchanged

Found via Playwright-based visual testing during a Bob autonomous session.
