### PR TITLE
feat(lessons): cap lesson injection at 50K tokens to prevent sys_prompt bloat

### DIFF
--- a/gptme/lessons/auto_include.py
+++ b/gptme/lessons/auto_include.py
@@ -1,6 +1,7 @@
 """Automatic lesson inclusion based on context."""
 
 import logging
+import os
 from typing import TYPE_CHECKING
 
 from .index import LessonIndex
@@ -20,6 +21,31 @@ except ImportError:
     HYBRID_AVAILABLE = False
     logger.info("Hybrid matching not available, using keyword-only matching")
 
+# Default token budget for lesson injection (50K tokens).
+# Configurable via GPTME_LESSONS_TOKEN_BUDGET env var.
+_DEFAULT_TOKEN_BUDGET = 50000
+
+
+def _get_token_budget() -> int:
+    """Get the lesson token budget from environment or default."""
+    try:
+        return int(
+            os.environ.get("GPTME_LESSONS_TOKEN_BUDGET", str(_DEFAULT_TOKEN_BUDGET))
+        )
+    except (ValueError, TypeError):
+        return _DEFAULT_TOKEN_BUDGET
+
+
+def _estimate_tokens(text: str) -> int:
+    """Estimate token count for a text string.
+
+    Uses a simple character-based heuristic (~4 chars per token for English text,
+    adjusted for code/markdown density). This is a rough estimate sufficient for
+    budget enforcement — actual tokenization varies by model.
+    """
+    # Use conservative estimate: 3.5 chars per token for code-heavy content
+    return max(1, len(text) // 3)
+
 
 def auto_include_lessons(
     messages: list["Message"],
@@ -27,6 +53,7 @@ def auto_include_lessons(
     enabled: bool = True,
     use_hybrid: bool = False,
     hybrid_config: "HybridConfig | None" = None,
+    max_tokens: int | None = None,
 ) -> list["Message"]:
     """Automatically include relevant lessons in message context.
 
@@ -36,12 +63,17 @@ def auto_include_lessons(
         enabled: Whether auto-inclusion is enabled
         use_hybrid: Use hybrid matching (semantic + effectiveness)
         hybrid_config: Configuration for hybrid matching
+        max_tokens: Maximum token budget for lesson content (default from env GPTME_LESSONS_TOKEN_BUDGET)
 
     Returns:
         Updated message list with lessons included
     """
     if not enabled:
         return messages
+
+    # Resolve token budget
+    if max_tokens is None:
+        max_tokens = _get_token_budget()
 
     # Get last user message
     user_msg = None
@@ -86,8 +118,25 @@ def auto_include_lessons(
         # Limit to top N (matcher may already limit, but ensure it)
         matches = matches[:max_lessons]
 
-        # Format lessons for inclusion
-        lesson_content = _format_lessons(matches)
+        # Format lessons for inclusion, respecting token budget
+        lesson_content, dropped_count = _format_with_budget(matches, max_tokens)
+
+        if not lesson_content:
+            logger.warning(
+                "All matched lessons exceed token budget, skipping inclusion"
+            )
+            return messages
+
+        # Log if we dropped lessons due to budget
+        if dropped_count > 0:
+            logger.warning(
+                "Lesson token budget exceeded: dropped %d/%d matched lessons"
+                " (%dK/%dK budget)",
+                dropped_count,
+                len(matches),
+                _estimate_tokens(lesson_content) // 1000,
+                max_tokens // 1000,
+            )
 
         # Create system message with lessons
         from ..message import Message
@@ -109,8 +158,53 @@ def auto_include_lessons(
         return messages
 
 
+def _format_with_budget(matches: list, max_tokens: int) -> tuple[str, int]:
+    """Format matched lessons with token budget enforcement.
+
+    Args:
+        matches: List of match results (already sorted by score, descending)
+        max_tokens: Maximum token budget
+
+    Returns:
+        Tuple of (formatted content, number of lessons dropped due to budget)
+    """
+    included: list[str] = []
+    dropped = 0
+    total_tokens = 0
+
+    for match in matches:
+        lesson = match.lesson
+
+        # Build individual lesson content (same format as _format_lessons)
+        parts = []
+        if included:
+            parts.append("\n")
+        parts.append(f"## {lesson.title}\n")
+        parts.append(f"\n*Path: {lesson.path}*\n")
+        parts.append(f"\n*Category: {lesson.category or 'general'}*\n")
+        if match.matched_by:
+            parts.append(f"\n*Matched by: {len(match.matched_by)} keyword(s)*\n")
+        parts.append(f"\n{lesson.body}\n")
+
+        lesson_str = "".join(parts)
+        lesson_tokens = _estimate_tokens(lesson_str)
+
+        # Check if adding this lesson would exceed budget
+        if included and total_tokens + lesson_tokens > max_tokens:
+            dropped += 1
+        else:
+            included.append(lesson_str)
+            total_tokens += lesson_tokens
+
+    return "".join(included), dropped
+
+
 def _format_lessons(matches: list) -> str:
-    """Format matched lessons for inclusion."""
+    """Format matched lessons for inclusion.
+
+    Note: This function is kept for backward compatibility.
+    The token-budget-aware _format_with_budget is preferred.
+    """
     parts = []
 
     for i, match in enumerate(matches, 1):

--- a/gptme/lessons/auto_include.py
+++ b/gptme/lessons/auto_include.py
@@ -155,16 +155,24 @@ def auto_include_lessons(
 def _format_with_budget(matches: list, max_tokens: int) -> tuple[str, int]:
     """Format matched lessons with token budget enforcement.
 
+    The highest-scored lesson is always included regardless of size.
+    Subsequent lessons are included only if their tokens fit within max_tokens
+    counting only the non-first lessons — so an oversized first lesson does not
+    consume the budget available to smaller subsequent ones.
+
     Args:
         matches: List of match results (already sorted by score, descending)
-        max_tokens: Maximum token budget
+        max_tokens: Maximum token budget for non-first lessons
 
     Returns:
         Tuple of (formatted content, number of lessons dropped due to budget)
     """
     included: list[str] = []
     dropped = 0
-    total_tokens = 0
+    # Track tokens for budget enforcement separately from the first (forced) lesson.
+    # This prevents an oversized first lesson from consuming the budget available
+    # to smaller subsequent lessons.
+    subsequent_tokens = 0
 
     for match in matches:
         lesson = match.lesson
@@ -183,12 +191,14 @@ def _format_with_budget(matches: list, max_tokens: int) -> tuple[str, int]:
         lesson_str = "".join(parts)
         lesson_tokens = _estimate_tokens(lesson_str)
 
-        # Check if adding this lesson would exceed budget
-        if included and total_tokens + lesson_tokens > max_tokens:
+        if not included:
+            # Always include the first (highest-scored) lesson regardless of size
+            included.append(lesson_str)
+        elif subsequent_tokens + lesson_tokens > max_tokens:
             dropped += 1
         else:
             included.append(lesson_str)
-            total_tokens += lesson_tokens
+            subsequent_tokens += lesson_tokens
 
     return "".join(included), dropped
 

--- a/gptme/lessons/auto_include.py
+++ b/gptme/lessons/auto_include.py
@@ -70,7 +70,8 @@ def auto_include_lessons(
         enabled: Whether auto-inclusion is enabled
         use_hybrid: Use hybrid matching (semantic + effectiveness)
         hybrid_config: Configuration for hybrid matching
-        max_tokens: Maximum token budget for lesson content (default from env GPTME_LESSONS_TOKEN_BUDGET)
+        max_tokens: Token budget for lessons beyond the first (default from env GPTME_LESSONS_TOKEN_BUDGET).
+            The highest-scored lesson is always force-included regardless of this limit.
 
     Returns:
         Updated message list with lessons included
@@ -126,16 +127,18 @@ def auto_include_lessons(
         matches = matches[:max_lessons]
 
         # Format lessons for inclusion, respecting token budget
-        lesson_content, dropped_count = _format_with_budget(matches, max_tokens)
+        lesson_content, dropped_count, subsequent_tokens = _format_with_budget(
+            matches, max_tokens
+        )
 
         # Log if we dropped lessons due to budget
         if dropped_count > 0:
             logger.warning(
                 "Lesson token budget exceeded: dropped %d/%d matched lessons"
-                " (%dK/%dK budget)",
+                " (%dK/%dK subsequent-lesson budget used)",
                 dropped_count,
                 len(matches),
-                _estimate_tokens(lesson_content) // 1000,
+                subsequent_tokens // 1000,
                 max_tokens // 1000,
             )
 
@@ -159,7 +162,7 @@ def auto_include_lessons(
         return messages
 
 
-def _format_with_budget(matches: list, max_tokens: int) -> tuple[str, int]:
+def _format_with_budget(matches: list, max_tokens: int) -> tuple[str, int, int]:
     """Format matched lessons with token budget enforcement.
 
     The highest-scored lesson is always included regardless of size.
@@ -172,7 +175,8 @@ def _format_with_budget(matches: list, max_tokens: int) -> tuple[str, int]:
         max_tokens: Maximum token budget for non-first lessons
 
     Returns:
-        Tuple of (formatted content, number of lessons dropped due to budget)
+        Tuple of (formatted content, number of lessons dropped due to budget,
+        tokens used by subsequent (non-first) lessons)
     """
     included: list[str] = []
     dropped = 0
@@ -207,7 +211,7 @@ def _format_with_budget(matches: list, max_tokens: int) -> tuple[str, int]:
             included.append(lesson_str)
             subsequent_tokens += lesson_tokens
 
-    return "".join(included), dropped
+    return "".join(included), dropped, subsequent_tokens
 
 
 def _format_lessons(matches: list) -> str:

--- a/gptme/lessons/auto_include.py
+++ b/gptme/lessons/auto_include.py
@@ -29,9 +29,17 @@ _DEFAULT_TOKEN_BUDGET = 50000
 def _get_token_budget() -> int:
     """Get the lesson token budget from environment or default."""
     try:
-        return int(
+        budget = int(
             os.environ.get("GPTME_LESSONS_TOKEN_BUDGET", str(_DEFAULT_TOKEN_BUDGET))
         )
+        if budget <= 0:
+            logger.warning(
+                "GPTME_LESSONS_TOKEN_BUDGET=%d is non-positive, using default %d",
+                budget,
+                _DEFAULT_TOKEN_BUDGET,
+            )
+            return _DEFAULT_TOKEN_BUDGET
+        return budget
     except (ValueError, TypeError):
         return _DEFAULT_TOKEN_BUDGET
 
@@ -39,11 +47,10 @@ def _get_token_budget() -> int:
 def _estimate_tokens(text: str) -> int:
     """Estimate token count for a text string.
 
-    Uses a simple character-based heuristic (~4 chars per token for English text,
-    adjusted for code/markdown density). This is a rough estimate sufficient for
-    budget enforcement — actual tokenization varies by model.
+    Uses a simple character-based heuristic (~3 chars per token, conservative for
+    code/markdown density). This is a rough estimate sufficient for budget
+    enforcement — actual tokenization varies by model.
     """
-    # Use conservative estimate: 3.5 chars per token for code-heavy content
     return max(1, len(text) // 3)
 
 

--- a/gptme/lessons/auto_include.py
+++ b/gptme/lessons/auto_include.py
@@ -121,12 +121,6 @@ def auto_include_lessons(
         # Format lessons for inclusion, respecting token budget
         lesson_content, dropped_count = _format_with_budget(matches, max_tokens)
 
-        if not lesson_content:
-            logger.warning(
-                "All matched lessons exceed token budget, skipping inclusion"
-            )
-            return messages
-
         # Log if we dropped lessons due to budget
         if dropped_count > 0:
             logger.warning(

--- a/tests/test_lessons_auto_include.py
+++ b/tests/test_lessons_auto_include.py
@@ -54,7 +54,7 @@ def test_format_with_budget_all_fit():
     matches = [
         _MockMatch(lesson=lesson, score=2.0 - i) for i, lesson in enumerate(lessons)
     ]
-    content, dropped = _format_with_budget(matches, max_tokens=10000)
+    content, dropped, _ = _format_with_budget(matches, max_tokens=10000)
     assert dropped == 0
     assert "Test 1" in content
     assert "Test 2" in content
@@ -70,7 +70,7 @@ def test_format_with_budget_drops_lowest():
         _MockMatch(lesson=lesson, score=2.0 - i) for i, lesson in enumerate(lessons)
     ]
     # Budget just enough for one lesson
-    content, dropped = _format_with_budget(matches, max_tokens=100)
+    content, dropped, _ = _format_with_budget(matches, max_tokens=100)
     # First lesson (highest score) should fit, second should be dropped
     assert dropped == 1
     assert "High Score" in content
@@ -83,7 +83,7 @@ def test_format_with_budget_first_lesson_too_large():
         _make_lesson("Huge Lesson", "body " * 10000),  # ~50000 chars, ~16666 tokens
     ]
     matches = [_MockMatch(lesson=lesson, score=10.0) for lesson in lessons]
-    content, dropped = _format_with_budget(matches, max_tokens=100)
+    content, dropped, _ = _format_with_budget(matches, max_tokens=100)
     # First/highest-scored lesson is always included regardless of size
     assert dropped == 0  # Only one lesson — nothing left to drop
     assert "Huge Lesson" in content
@@ -99,7 +99,7 @@ def test_format_with_budget_oversized_first_does_not_block_small_subsequent():
         _MockMatch(lesson=lesson, score=2.0 - i) for i, lesson in enumerate(lessons)
     ]
     # Budget of 1000 — first lesson far exceeds it, but second lesson is tiny
-    content, dropped = _format_with_budget(matches, max_tokens=1000)
+    content, dropped, _ = _format_with_budget(matches, max_tokens=1000)
     # Tiny second lesson should still be included because it fits the subsequent budget
     assert dropped == 0
     assert "Huge Lesson" in content
@@ -117,7 +117,7 @@ def test_format_with_budget_drops_multiple():
     matches = [
         _MockMatch(lesson=lesson, score=5.0 - i) for i, lesson in enumerate(lessons)
     ]
-    content, dropped = _format_with_budget(matches, max_tokens=1000)
+    content, dropped, _ = _format_with_budget(matches, max_tokens=1000)
     # Best should always fit (small). Medium might depending on total.
     # At least worst/worstest should be dropped.
     assert dropped >= 1
@@ -128,12 +128,33 @@ def test_format_with_budget_includes_metadata():
     """Check that lesson metadata is included in formatted output."""
     lesson = _make_lesson("Metadata Test", "body content")
     match = _MockMatch(lesson, matched_by=["keyword:test"])
-    content, dropped = _format_with_budget([match], max_tokens=10000)
+    content, dropped, _ = _format_with_budget([match], max_tokens=10000)
     assert dropped == 0
     assert "Metadata Test" in content  # title
     assert "/tmp/test.md" in content  # path
     assert "test" in content  # category
     assert "1 keyword(s)" in content  # match info
+
+
+def test_format_with_budget_subsequent_tokens_excludes_first():
+    """subsequent_tokens must not include the force-included first lesson.
+
+    The warning log compares subsequent_tokens against max_tokens (which only
+    governs non-first lessons). If subsequent_tokens included the first lesson
+    the comparison would be misleading.
+    """
+    big_body = "word " * 5000  # ~8333 tokens, well over any subsequent budget
+    lessons = [
+        _make_lesson("First", big_body),
+        _make_lesson("Second", "tiny"),
+    ]
+    matches = [
+        _MockMatch(lesson=lesson, score=2.0 - i) for i, lesson in enumerate(lessons)
+    ]
+    _, dropped, subsequent_tokens = _format_with_budget(matches, max_tokens=10000)
+    # Second lesson is tiny so it fits; first is excluded from subsequent_tokens count
+    assert dropped == 0
+    assert subsequent_tokens < 100  # only "tiny" second lesson counts
 
 
 def test_get_token_budget_default(monkeypatch):

--- a/tests/test_lessons_auto_include.py
+++ b/tests/test_lessons_auto_include.py
@@ -1,0 +1,139 @@
+"""Tests for auto-include lesson system with token budget."""
+
+from pathlib import Path
+
+from gptme.lessons.auto_include import (
+    _estimate_tokens,
+    _format_with_budget,
+    _get_token_budget,
+)
+from gptme.lessons.parser import Lesson, LessonMetadata
+
+
+def _make_lesson(title: str, body: str, path: str | Path = "/tmp/test.md") -> Lesson:
+    """Create a test lesson."""
+    return Lesson(
+        title=title,
+        description=title,
+        body=body,
+        path=Path(path) if isinstance(path, str) else path,
+        metadata=LessonMetadata(keywords=[]),
+        category="test",
+    )
+
+
+class _MockMatch:
+    """Simple mock for match results."""
+
+    def __init__(self, lesson, score=1.0, matched_by=None):
+        self.lesson = lesson
+        self.score = score
+        self.matched_by = matched_by or []
+
+
+def test_estimate_tokens_empty():
+    assert _estimate_tokens("") == 1
+
+
+def test_estimate_tokens_short():
+    assert _estimate_tokens("hello") == 1  # 5//3 = 1
+    assert _estimate_tokens("hello world") == 3  # 11//3 = 3
+
+
+def test_estimate_tokens_long():
+    text = "a" * 3000
+    assert _estimate_tokens(text) == 1000  # 3000//3 = 1000
+
+
+def test_format_with_budget_all_fit():
+    """All lessons fit within budget."""
+    lessons = [
+        _make_lesson("Test 1", "short body"),
+        _make_lesson("Test 2", "another short body"),
+    ]
+    matches = [
+        _MockMatch(lesson=lesson, score=2.0 - i) for i, lesson in enumerate(lessons)
+    ]
+    content, dropped = _format_with_budget(matches, max_tokens=10000)
+    assert dropped == 0
+    assert "Test 1" in content
+    assert "Test 2" in content
+
+
+def test_format_with_budget_drops_lowest():
+    """Lowest-scored lessons are dropped when budget is tight."""
+    lessons = [
+        _make_lesson("High Score", "body " * 100),  # ~200 chars, ~66 tokens
+        _make_lesson("Low Score", "body " * 100),
+    ]
+    matches = [
+        _MockMatch(lesson=lesson, score=2.0 - i) for i, lesson in enumerate(lessons)
+    ]
+    # Budget just enough for one lesson
+    content, dropped = _format_with_budget(matches, max_tokens=100)
+    # First lesson (highest score) should fit, second should be dropped
+    assert dropped == 1
+    assert "High Score" in content
+    assert "Low Score" not in content
+
+
+def test_format_with_budget_first_lesson_too_large():
+    """If even the first (highest-scored) lesson exceeds budget, all are dropped."""
+    lessons = [
+        _make_lesson("Huge Lesson", "body " * 10000),  # ~50000 chars, ~16666 tokens
+    ]
+    matches = [_MockMatch(lesson=lesson, score=10.0) for lesson in lessons]
+    content, dropped = _format_with_budget(matches, max_tokens=100)
+    # First lesson exceeds budget but is included (minimum of 1 lesson)
+    assert dropped == 0  # First/highest-scored always included
+    assert "Huge Lesson" in content
+
+
+def test_format_with_budget_drops_multiple():
+    """Multiple low-scored lessons are dropped."""
+    lessons = [
+        _make_lesson("Best", "small body"),
+        _make_lesson("Medium", "body " * 500),  # ~2500 chars, ~833 tokens
+        _make_lesson("Worst", "body " * 500),
+        _make_lesson("Worstest", "body " * 500),
+    ]
+    matches = [
+        _MockMatch(lesson=lesson, score=5.0 - i) for i, lesson in enumerate(lessons)
+    ]
+    content, dropped = _format_with_budget(matches, max_tokens=1000)
+    # Best should always fit (small). Medium might depending on total.
+    # At least worst/worstest should be dropped.
+    assert dropped >= 1
+    assert "Best" in content
+
+
+def test_format_with_budget_includes_metadata():
+    """Check that lesson metadata is included in formatted output."""
+    lesson = _make_lesson("Metadata Test", "body content")
+    match = _MockMatch(lesson, matched_by=["keyword:test"])
+    content, dropped = _format_with_budget([match], max_tokens=10000)
+    assert dropped == 0
+    assert "Metadata Test" in content  # title
+    assert "/tmp/test.md" in content  # path
+    assert "test" in content  # category
+    assert "1 keyword(s)" in content  # match info
+
+
+def test_get_token_budget_default():
+    """Default token budget from the function."""
+    budget = _get_token_budget()
+    assert budget == 50000
+
+
+def test_get_token_budget_env(monkeypatch):
+    """Token budget can be configured via env var."""
+    monkeypatch.setenv("GPTME_LESSONS_TOKEN_BUDGET", "10000")
+    budget = _get_token_budget()
+    assert budget == 10000
+
+
+def test_get_token_budget_invalid_env(monkeypatch):
+    """Invalid env var falls back to default."""
+    monkeypatch.setenv("GPTME_LESSONS_TOKEN_BUDGET", "not-a-number")
+    budget = _get_token_budget()
+    assert budget == 50000

--- a/tests/test_lessons_auto_include.py
+++ b/tests/test_lessons_auto_include.py
@@ -78,14 +78,14 @@ def test_format_with_budget_drops_lowest():
 
 
 def test_format_with_budget_first_lesson_too_large():
-    """If even the first (highest-scored) lesson exceeds budget, all are dropped."""
+    """First lesson is force-included even if it exceeds the budget (minimum 1)."""
     lessons = [
         _make_lesson("Huge Lesson", "body " * 10000),  # ~50000 chars, ~16666 tokens
     ]
     matches = [_MockMatch(lesson=lesson, score=10.0) for lesson in lessons]
     content, dropped = _format_with_budget(matches, max_tokens=100)
-    # First lesson exceeds budget but is included (minimum of 1 lesson)
-    assert dropped == 0  # First/highest-scored always included
+    # First/highest-scored lesson is always included regardless of size
+    assert dropped == 0  # Only one lesson — nothing left to drop
     assert "Huge Lesson" in content
 
 

--- a/tests/test_lessons_auto_include.py
+++ b/tests/test_lessons_auto_include.py
@@ -136,8 +136,9 @@ def test_format_with_budget_includes_metadata():
     assert "1 keyword(s)" in content  # match info
 
 
-def test_get_token_budget_default():
+def test_get_token_budget_default(monkeypatch):
     """Default token budget from the function."""
+    monkeypatch.delenv("GPTME_LESSONS_TOKEN_BUDGET", raising=False)
     budget = _get_token_budget()
     assert budget == 50000
 
@@ -152,5 +153,19 @@ def test_get_token_budget_env(monkeypatch):
 def test_get_token_budget_invalid_env(monkeypatch):
     """Invalid env var falls back to default."""
     monkeypatch.setenv("GPTME_LESSONS_TOKEN_BUDGET", "not-a-number")
+    budget = _get_token_budget()
+    assert budget == 50000
+
+
+def test_get_token_budget_zero_env(monkeypatch):
+    """Zero budget falls back to default (non-positive is not allowed)."""
+    monkeypatch.setenv("GPTME_LESSONS_TOKEN_BUDGET", "0")
+    budget = _get_token_budget()
+    assert budget == 50000
+
+
+def test_get_token_budget_negative_env(monkeypatch):
+    """Negative budget falls back to default."""
+    monkeypatch.setenv("GPTME_LESSONS_TOKEN_BUDGET", "-1000")
     budget = _get_token_budget()
     assert budget == 50000

--- a/tests/test_lessons_auto_include.py
+++ b/tests/test_lessons_auto_include.py
@@ -89,6 +89,23 @@ def test_format_with_budget_first_lesson_too_large():
     assert "Huge Lesson" in content
 
 
+def test_format_with_budget_oversized_first_does_not_block_small_subsequent():
+    """Oversized first lesson must not consume the budget for subsequent small lessons."""
+    lessons = [
+        _make_lesson("Huge Lesson", "body " * 10000),  # ~16666 tokens, well over budget
+        _make_lesson("Tiny Lesson", "hi"),  # ~1 token
+    ]
+    matches = [
+        _MockMatch(lesson=lesson, score=2.0 - i) for i, lesson in enumerate(lessons)
+    ]
+    # Budget of 1000 — first lesson far exceeds it, but second lesson is tiny
+    content, dropped = _format_with_budget(matches, max_tokens=1000)
+    # Tiny second lesson should still be included because it fits the subsequent budget
+    assert dropped == 0
+    assert "Huge Lesson" in content
+    assert "Tiny Lesson" in content
+
+
 def test_format_with_budget_drops_multiple():
     """Multiple low-scored lessons are dropped."""
     lessons = [


### PR DESCRIPTION
## Problem

gptme currently injects all matched lessons into the system prompt with no token budget. With 162 lesson files totaling ~89K tokens, heavy-match sessions can exceed 89K — consuming a large portion of peak context before the first user message.

See #759 (ErikBjare/bob) and #738 (ErikBjare/bob) for full analysis.

## Changes

1. **Token budget enforcement** in `auto_include_lessons`: after matching lessons, total formatted content is estimated (simple char-based heuristic) and compared against a budget. Lessons beyond budget are dropped, starting from lowest-scored.

2. **Configurable via env var**: `GPTME_LESSONS_TOKEN_BUDGET` defaults to 50000 (50K tokens).

3. **Logging**: warns when budget is exceeded, showing how many lessons were dropped.

4. **New tests**: 11 tests covering budget enforcement, edge cases (single oversized lesson, multiple drops), env var configuration, and invalid input.

## Implementation details

- Token estimation uses `len(text) // 3` (conservative ~3.5 chars/token for code-markdown content). This is sufficient for budget enforcement — actual tokenization varies by model.
- Only the `_format_with_budget` function was added; the original `_format_lessons` is preserved for backward compatibility.
- The highest-scored lesson is always included even if it exceeds budget alone (minimum of 1).

Closes ErikBjare/bob#759