### PR TITLE
feat(tokens): surface biggest-turn input in /tokens output

### DIFF
--- a/gptme/util/cost_display.py
+++ b/gptme/util/cost_display.py
@@ -187,8 +187,8 @@ def gather_conversation_costs(messages: list[Message]) -> CostData | None:
         request_count=request_count,
     )
 
-    # Only surface biggest_turn when it's meaningful (multiple turns observed
-    # and the peak is a clear outlier vs. average input per turn)
+    # Suppress biggest_turn when the winning turn had zero total input tokens
+    # (degenerate case; outlier-vs-average filtering happens in display_costs).
     if (
         biggest_turn is not None
         and request_count >= 2

--- a/gptme/util/cost_display.py
+++ b/gptme/util/cost_display.py
@@ -23,6 +23,22 @@ class RequestCosts:
 
 
 @dataclass
+class BiggestTurn:
+    """Largest single-turn input observed in a conversation.
+
+    Helps identify when a single tool result blows up the next turn's input.
+    Indexed by assistant-message position (1-based) in the conversation.
+    """
+
+    request_index: int
+    input_tokens: int
+    output_tokens: int
+    cache_read_tokens: int
+    cache_creation_tokens: int
+    cost: float
+
+
+@dataclass
 class TotalCosts:
     """Aggregated cost data."""
 
@@ -42,6 +58,7 @@ class CostData:
     last_request: RequestCosts | None
     total: TotalCosts
     source: str  # "session" | "conversation" | "approximation"
+    biggest_turn: BiggestTurn | None = None
 
 
 def gather_session_costs() -> CostData | None:
@@ -91,19 +108,41 @@ def gather_conversation_costs(messages: list[Message]) -> CostData | None:
     total_cost = 0.0
     request_count = 0
     last_metadata = None
+    biggest_turn: BiggestTurn | None = None
 
     for msg in messages:
         if msg.metadata:
+            usage = msg.metadata.get("usage", {})
+            msg_input = usage.get("input_tokens", 0)
+            msg_output = usage.get("output_tokens", 0)
+            msg_cache_read = usage.get("cache_read_tokens", 0)
+            msg_cache_created = usage.get("cache_creation_tokens", 0)
+            msg_cost = msg.metadata.get("cost", 0.0)
+
             if msg.role == "assistant":
                 last_metadata = msg.metadata
                 request_count += 1
 
-            usage = msg.metadata.get("usage", {})
-            total_input += usage.get("input_tokens", 0)
-            total_output += usage.get("output_tokens", 0)
-            total_cache_read += usage.get("cache_read_tokens", 0)
-            total_cache_created += usage.get("cache_creation_tokens", 0)
-            total_cost += msg.metadata.get("cost", 0.0)
+                turn_input_total = msg_input + msg_cache_read + msg_cache_created
+                if biggest_turn is None or turn_input_total > (
+                    biggest_turn.input_tokens
+                    + biggest_turn.cache_read_tokens
+                    + biggest_turn.cache_creation_tokens
+                ):
+                    biggest_turn = BiggestTurn(
+                        request_index=request_count,
+                        input_tokens=msg_input,
+                        output_tokens=msg_output,
+                        cache_read_tokens=msg_cache_read,
+                        cache_creation_tokens=msg_cache_created,
+                        cost=msg_cost,
+                    )
+
+            total_input += msg_input
+            total_output += msg_output
+            total_cache_read += msg_cache_read
+            total_cache_created += msg_cache_created
+            total_cost += msg_cost
 
     # Check if we have any actual data
     has_data = (
@@ -148,7 +187,21 @@ def gather_conversation_costs(messages: list[Message]) -> CostData | None:
         request_count=request_count,
     )
 
-    return CostData(last_request=last_request, total=total, source="conversation")
+    # Only surface biggest_turn when it's meaningful (multiple turns observed
+    # and the peak is a clear outlier vs. average input per turn)
+    if (
+        biggest_turn is not None
+        and request_count >= 2
+        and (biggest_turn.input_tokens + biggest_turn.cache_read_tokens) == 0
+    ):
+        biggest_turn = None
+
+    return CostData(
+        last_request=last_request,
+        total=total,
+        source="conversation",
+        biggest_turn=biggest_turn,
+    )
 
 
 def display_costs(
@@ -202,6 +255,39 @@ def display_costs(
     ):
         console.log("[bold]Conversation Total:[/bold] (all messages)")
         _display_total(conversation.total)
+
+    # Highlight the largest single-turn input (helps catch context spikes,
+    # e.g. when a tool result blows up the next turn's input).
+    biggest = (
+        conversation.biggest_turn
+        if conversation and conversation.biggest_turn is not None
+        else None
+    )
+    if biggest is not None and conversation and conversation.total.request_count >= 2:
+        biggest_total_in = (
+            biggest.input_tokens
+            + biggest.cache_read_tokens
+            + biggest.cache_creation_tokens
+        )
+        avg_input_per_request = (
+            (
+                conversation.total.input_tokens
+                + conversation.total.cache_read_tokens
+                + conversation.total.cache_creation_tokens
+            )
+            / conversation.total.request_count
+            if conversation.total.request_count
+            else 0
+        )
+        # Only flag if peak is at least 1.5x the average — otherwise it's noise
+        if avg_input_per_request and biggest_total_in >= 1.5 * avg_input_per_request:
+            ratio = biggest_total_in / avg_input_per_request
+            console.log("")
+            console.log(
+                "[bold]Biggest Turn:[/bold] "
+                f"request #{biggest.request_index} — "
+                f"{biggest_total_in:,} in ({ratio:.1f}x avg)"
+            )
 
 
 def _display_total(total: TotalCosts) -> None:

--- a/gptme/util/cost_display.py
+++ b/gptme/util/cost_display.py
@@ -192,7 +192,12 @@ def gather_conversation_costs(messages: list[Message]) -> CostData | None:
     if (
         biggest_turn is not None
         and request_count >= 2
-        and (biggest_turn.input_tokens + biggest_turn.cache_read_tokens) == 0
+        and (
+            biggest_turn.input_tokens
+            + biggest_turn.cache_read_tokens
+            + biggest_turn.cache_creation_tokens
+        )
+        == 0
     ):
         biggest_turn = None
 

--- a/tests/test_cost_display.py
+++ b/tests/test_cost_display.py
@@ -358,8 +358,12 @@ def test_biggest_turn_includes_cache_tokens():
     assert result.biggest_turn.cache_read_tokens == 9000
 
 
-def test_biggest_turn_none_for_single_request():
-    """Biggest turn is meaningful only with multiple requests; otherwise None."""
+def test_biggest_turn_set_for_single_request():
+    """gather_conversation_costs sets biggest_turn even for a single request.
+
+    Suppression for single-request conversations is handled in display_costs,
+    not in gather_conversation_costs.
+    """
     msgs = [
         Message(
             role="assistant",
@@ -372,6 +376,5 @@ def test_biggest_turn_none_for_single_request():
     ]
     result = gather_conversation_costs(msgs)
     assert result is not None
-    # Still set, but display logic skips it for single-request conversations
     assert result.biggest_turn is not None
     assert result.biggest_turn.request_index == 1

--- a/tests/test_cost_display.py
+++ b/tests/test_cost_display.py
@@ -2,6 +2,7 @@
 
 from gptme.message import Message
 from gptme.util.cost_display import (
+    BiggestTurn,
     CostData,
     RequestCosts,
     TotalCosts,
@@ -286,3 +287,91 @@ def test_gather_conversation_costs_no_last_request_when_zero():
     assert result is not None
     # Last metadata has all zeros, so last_request should be None
     assert result.last_request is None
+
+
+def test_biggest_turn_identifies_outlier():
+    """Biggest turn surfaces the largest single-turn input."""
+    msgs = [
+        Message(
+            role="assistant",
+            content="small",
+            metadata={
+                "cost": 0.001,
+                "usage": {"input_tokens": 100, "output_tokens": 20},
+            },
+        ),
+        Message(
+            role="assistant",
+            content="huge tool result",
+            metadata={
+                "cost": 0.05,
+                "usage": {"input_tokens": 5000, "output_tokens": 30},
+            },
+        ),
+        Message(
+            role="assistant",
+            content="small again",
+            metadata={
+                "cost": 0.002,
+                "usage": {"input_tokens": 200, "output_tokens": 25},
+            },
+        ),
+    ]
+    result = gather_conversation_costs(msgs)
+    assert result is not None
+    assert result.biggest_turn is not None
+    assert isinstance(result.biggest_turn, BiggestTurn)
+    assert result.biggest_turn.request_index == 2
+    assert result.biggest_turn.input_tokens == 5000
+
+
+def test_biggest_turn_includes_cache_tokens():
+    """Biggest turn ranks by total input including cache_read + cache_creation."""
+    msgs = [
+        Message(
+            role="assistant",
+            content="cached huge",
+            metadata={
+                "cost": 0.005,
+                "usage": {
+                    "input_tokens": 10,
+                    "output_tokens": 30,
+                    "cache_read_tokens": 9000,
+                    "cache_creation_tokens": 0,
+                },
+            },
+        ),
+        Message(
+            role="assistant",
+            content="non-cached small",
+            metadata={
+                "cost": 0.01,
+                "usage": {"input_tokens": 1000, "output_tokens": 30},
+            },
+        ),
+    ]
+    result = gather_conversation_costs(msgs)
+    assert result is not None
+    assert result.biggest_turn is not None
+    # First turn wins because cache_read pushes it past 1000
+    assert result.biggest_turn.request_index == 1
+    assert result.biggest_turn.cache_read_tokens == 9000
+
+
+def test_biggest_turn_none_for_single_request():
+    """Biggest turn is meaningful only with multiple requests; otherwise None."""
+    msgs = [
+        Message(
+            role="assistant",
+            content="only response",
+            metadata={
+                "cost": 0.005,
+                "usage": {"input_tokens": 100, "output_tokens": 50},
+            },
+        ),
+    ]
+    result = gather_conversation_costs(msgs)
+    assert result is not None
+    # Still set, but display logic skips it for single-request conversations
+    assert result.biggest_turn is not None
+    assert result.biggest_turn.request_index == 1


### PR DESCRIPTION
## Summary

Adds a "Biggest Turn" highlight to the `/tokens` display so users can see when a single turn dominated their conversation cost — directly addresses one of the asks in #2347:

> Detect when a single tool result blows up the next turn's input.

Output (when surfaced):
```
Biggest Turn: request #5 — 12,304 in (3.2x avg)
```

## What changed

- New `BiggestTurn` dataclass on `gptme.util.cost_display` (`request_index`, `input_tokens`, `output_tokens`, `cache_read_tokens`, `cache_creation_tokens`, `cost`).
- `gather_conversation_costs()` tracks the peak turn while iterating messages. Ranking uses **total input** (input + cache_read + cache_creation), so cache-heavy turns count.
- `display_costs()` renders a single-line "Biggest Turn" section only when:
  - `request_count >= 2` (single-request sessions don't have an interesting peak)
  - peak total input is **≥ 1.5× the per-turn average** (avoids noise on uniform conversations)
- New field `biggest_turn: BiggestTurn | None = None` on `CostData` is backward compatible (default `None`, ignored by callers that don't read it).

## Why

`/tokens` currently shows last request + session totals + conversation totals. None of those expose the **distribution** of per-turn cost, so a single 50K-token tool result hidden in turn 4 of a 30-turn conversation is invisible. Identifying the biggest single turn is the simplest, lowest-risk slice of the per-step token visibility ask in #2347.

## Test plan

- [x] `uv run pytest tests/test_cost_display.py -v` — 16/16 passed (3 new + 13 existing)
- [x] `uv run ruff check gptme/util/cost_display.py tests/test_cost_display.py` — clean
- [x] `uv run ruff format --check ...` — already formatted
- [x] Backward compatibility: `CostData` adds an optional field with default `None`; existing tests still pass without changes

## Refs

- #2347 — per-message / per-step token usage in session output and records (this PR addresses one bullet from "Detect when a single tool result blows up the next turn's input")