### PR TITLE
feat(eval): add --no-lessons flag for no-context baseline runs

### DIFF
--- a/gptme/eval/main.py
+++ b/gptme/eval/main.py
@@ -532,6 +532,11 @@ def aggregate_and_display_results(result_files: list[str]):
     is_flag=True,
     help="Inject adversarial framing into behavioral eval prompts (idea #190 Phase 2).",
 )
+@click.option(
+    "--no-lessons",
+    is_flag=True,
+    help="Disable lesson auto-inclusion during eval runs (for no-context baselines).",
+)
 def main(
     eval_names_or_result_files: list[str],
     _model: list[str],
@@ -549,6 +554,7 @@ def main(
     trends: bool = False,
     trend_days: int = 90,
     adversarial: bool = False,
+    no_lessons: bool = False,
 ):
     """
     Run evals for gptme.
@@ -805,6 +811,7 @@ def main(
         use_docker,
         include_user_context=user_context,
         adversarial=adversarial,
+        no_lessons=no_lessons,
     )
     if not json_output:
         print("=== Finished ===")

--- a/gptme/eval/run.py
+++ b/gptme/eval/run.py
@@ -92,6 +92,7 @@ def run_evals(
     use_docker: bool = False,
     include_user_context: bool = False,
     adversarial: bool = False,
+    no_lessons: bool = False,
 ) -> dict[ModelConfig, list[EvalResult]]:
     """
     Run evals for a list of tests.
@@ -105,6 +106,7 @@ def run_evals(
         include_user_context: Include user-level prompt files and agent
             instructions from ~/.config/gptme in eval runs
         adversarial: Inject adversarial framing into behavioral eval prompts
+        no_lessons: Disable lesson auto-inclusion during eval runs
     """
     # For coverage to work with multiprocessing
     # https://pytest-cov.readthedocs.io/en/latest/subprocess-support.html
@@ -161,6 +163,7 @@ def run_evals(
                     parallel > 1,
                     use_docker,
                     adversarial=adversarial,
+                    no_lessons=no_lessons,
                 )
                 futures.append(future)
                 future_to_model_test[future] = (config, test, agent)
@@ -250,6 +253,7 @@ def execute(
     use_docker: bool = False,
     suppress_output: bool = False,
     adversarial: bool = False,
+    no_lessons: bool = False,
 ) -> EvalResult:
     """
     Executes the code for a specific model with a timeout.
@@ -262,6 +266,10 @@ def execute(
     prompt = test["prompt"]
     if adversarial:
         prompt = _apply_adversarial_framing(test["name"], prompt)
+
+    # Disable lesson auto-injection for no-lessons baseline runs
+    if no_lessons:
+        os.environ["GPTME_LESSONS_AUTO_INCLUDE"] = "false"
 
     with Manager() as manager:
         sync_dict = manager.dict()

--- a/gptme/eval/run.py
+++ b/gptme/eval/run.py
@@ -267,7 +267,9 @@ def execute(
     if adversarial:
         prompt = _apply_adversarial_framing(test["name"], prompt)
 
-    # Disable lesson auto-injection for no-lessons baseline runs
+    # Disable lesson auto-injection for no-lessons baseline runs.
+    # Save/restore to prevent env bleed across reused ProcessPoolExecutor workers.
+    _prev_lessons_env = os.environ.get("GPTME_LESSONS_AUTO_INCLUDE")
     if no_lessons:
         os.environ["GPTME_LESSONS_AUTO_INCLUDE"] = "false"
 
@@ -287,6 +289,11 @@ def execute(
         )
 
         p.start()
+        # Restore parent env immediately after fork; child already has its own copy.
+        if _prev_lessons_env is None:
+            os.environ.pop("GPTME_LESSONS_AUTO_INCLUDE", None)
+        else:
+            os.environ["GPTME_LESSONS_AUTO_INCLUDE"] = _prev_lessons_env
         try:
             p.join(timeout)
             status: Status = "success"

--- a/gptme/eval/run.py
+++ b/gptme/eval/run.py
@@ -288,12 +288,14 @@ def execute(
             ),
         )
 
-        p.start()
-        # Restore parent env immediately after fork; child already has its own copy.
-        if _prev_lessons_env is None:
-            os.environ.pop("GPTME_LESSONS_AUTO_INCLUDE", None)
-        else:
-            os.environ["GPTME_LESSONS_AUTO_INCLUDE"] = _prev_lessons_env
+        try:
+            p.start()
+        finally:
+            # Restore parent env immediately after fork; child already has its own copy.
+            if _prev_lessons_env is None:
+                os.environ.pop("GPTME_LESSONS_AUTO_INCLUDE", None)
+            else:
+                os.environ["GPTME_LESSONS_AUTO_INCLUDE"] = _prev_lessons_env
         try:
             p.join(timeout)
             status: Status = "success"


### PR DESCRIPTION
## What
Adds a `--no-lessons` flag to `gptme eval` that disables lesson auto-inclusion during eval runs by setting `GPTME_LESSONS_AUTO_INCLUDE=false` in the subprocess environment.

## Why
Enables A/B testing of lesson injection vs no-injection on behavioral evals, inspired by the "When Context Hurts" crossover effect (arXiv:2605.04361). The paper finds that more context degrades performance on some tasks — one no-context trial is a cheap diagnostic for whether context helps or hurts.

## Changes
- `gptme/eval/main.py`: `@click.option("--no-lessons")` + plumbed through to `run_evals()`
- `gptme/eval/run.py`: `no_lessons` parameter added to `run_evals()` and `execute()`; sets `GPTME_LESSONS_AUTO_INCLUDE=false` before spawning the eval subprocess

## Testing
```bash
# Existing behavior unchanged (lessons included by default):
gptme eval behavioral --model anthropic/claude-haiku-4-5 --test hello-patch

# New: run without lesson injection
gptme eval behavioral --model anthropic/claude-haiku-4-5 --no-lessons
```

- ruff: clean
- mypy: clean
- pre-commit: all hooks pass

## Context
- Idea backlog: [#224](https://github.com/ErikBjare/bob/issues/224) — crossover effect validation
- Bob session: 28f7