### PR TITLE
feat(tokens): add per-step token breakdown to /tokens command

### DIFF
--- a/gptme/commands/llm.py
+++ b/gptme/commands/llm.py
@@ -331,12 +331,14 @@ def cmd_tokens(ctx: CommandContext) -> None:
     from ..util.cost_display import (
         display_costs,
         gather_conversation_costs,
+        gather_per_step_costs,
         gather_session_costs,
     )
 
     session = gather_session_costs()
     conversation = gather_conversation_costs(ctx.manager.log.messages)
-    display_costs(session, conversation)
+    per_step = gather_per_step_costs(ctx.manager.log.messages)
+    display_costs(session, conversation, per_step=per_step)
 
 
 def _print_available_models() -> None:

--- a/gptme/util/cost_display.py
+++ b/gptme/util/cost_display.py
@@ -52,6 +52,23 @@ class TotalCosts:
 
 
 @dataclass
+class StepCost:
+    """Per-step token usage for a single assistant request.
+
+    Used to show per-step breakdown in /tokens output.  Index is 1-based
+    (matching how assistant messages appear in the conversation).
+    """
+
+    step_index: int
+    input_tokens: int
+    output_tokens: int
+    cache_read_tokens: int
+    cache_creation_tokens: int
+    cost: float
+    model: str | None = None
+
+
+@dataclass
 class CostData:
     """Complete cost information from a single source."""
 
@@ -59,6 +76,21 @@ class CostData:
     total: TotalCosts
     source: str  # "session" | "conversation" | "approximation"
     biggest_turn: BiggestTurn | None = None
+
+
+def _short_model_name(full_model: str) -> str:
+    """Extract a short provider/model name for display.
+
+    'openrouter/deepseek/deepseek-v4-pro@deepseek' → 'deepseek-v4-pro'
+    'anthropic/claude-sonnet-4-5' → 'claude-sonnet-4-5'
+    'openai/gpt-5.1-codex-max' → 'gpt-5.1-codex-max'
+    """
+    # Strip provider prefix (e.g. 'openrouter/', 'anthropic/', 'openai/')
+    model = full_model.rsplit("/", 1)[-1] if "/" in full_model else full_model
+    # Strip OpenRouter routing suffix (@provider)
+    if "@" in model:
+        model = model.rsplit("@", 1)[0]
+    return model
 
 
 def gather_session_costs() -> CostData | None:
@@ -209,8 +241,46 @@ def gather_conversation_costs(messages: list[Message]) -> CostData | None:
     )
 
 
+def gather_per_step_costs(messages: list[Message]) -> list[StepCost]:
+    """Extract per-step token usage from conversation messages.
+
+    Returns one StepCost per assistant message that carries metadata.
+    Steps are 1-based (first assistant message = step 1).
+    """
+    steps: list[StepCost] = []
+    step_idx = 0
+
+    for msg in messages:
+        if msg.metadata:
+            usage = msg.metadata.get("usage", {})
+            input_tokens = usage.get("input_tokens", 0)
+            output_tokens = usage.get("output_tokens", 0)
+            cache_read = usage.get("cache_read_tokens", 0)
+            cache_create = usage.get("cache_creation_tokens", 0)
+            cost = msg.metadata.get("cost", 0.0)
+
+            # Only include steps that have some token data
+            if input_tokens > 0 or output_tokens > 0 or cache_read > 0:
+                step_idx += 1
+                steps.append(
+                    StepCost(
+                        step_index=step_idx,
+                        input_tokens=input_tokens,
+                        output_tokens=output_tokens,
+                        cache_read_tokens=cache_read,
+                        cache_creation_tokens=cache_create,
+                        cost=cost,
+                        model=msg.metadata.get("model"),
+                    )
+                )
+
+    return steps
+
+
 def display_costs(
-    session: CostData | None = None, conversation: CostData | None = None
+    session: CostData | None = None,
+    conversation: CostData | None = None,
+    per_step: list[StepCost] | None = None,
 ) -> None:
     """Display costs in unified format.
 
@@ -292,6 +362,48 @@ def display_costs(
                 "[bold]Biggest Turn:[/bold] "
                 f"request #{biggest.request_index} — "
                 f"{biggest_total_in:,} in ({ratio:.1f}x avg)"
+            )
+
+    # Per-step breakdown table (compact, one line per assistant turn)
+    if per_step:
+        console.log("")
+        console.log("[bold]Per-Step Breakdown:[/bold]")
+        # Header
+        console.log(
+            "  "
+            + "Step".rjust(4)
+            + "  "
+            + "Input".rjust(7)
+            + "  "
+            + "Output".rjust(7)
+            + "  "
+            + "Cache".rjust(7)
+            + "  "
+            + "Total".rjust(7)
+            + "  "
+            + "Model"
+        )
+        for step in per_step:
+            total_tokens = (
+                step.input_tokens
+                + step.output_tokens
+                + step.cache_read_tokens
+                + step.cache_creation_tokens
+            )
+            model_short = _short_model_name(step.model) if step.model else ""
+            console.log(
+                "  "
+                + str(step.step_index).rjust(4)
+                + "  "
+                + f"{step.input_tokens:,}".rjust(7)
+                + "  "
+                + f"{step.output_tokens:,}".rjust(7)
+                + "  "
+                + f"{step.cache_read_tokens:,}".rjust(7)
+                + "  "
+                + f"{total_tokens:,}".rjust(7)
+                + "  "
+                + model_short
             )
 
 

--- a/gptme/util/cost_display.py
+++ b/gptme/util/cost_display.py
@@ -251,7 +251,7 @@ def gather_per_step_costs(messages: list[Message]) -> list[StepCost]:
     step_idx = 0
 
     for msg in messages:
-        if msg.metadata:
+        if msg.role == "assistant" and msg.metadata:
             usage = msg.metadata.get("usage", {})
             input_tokens = usage.get("input_tokens", 0)
             output_tokens = usage.get("output_tokens", 0)
@@ -384,12 +384,8 @@ def display_costs(
             + "Model"
         )
         for step in per_step:
-            total_tokens = (
-                step.input_tokens
-                + step.output_tokens
-                + step.cache_read_tokens
-                + step.cache_creation_tokens
-            )
+            cache_tokens = step.cache_read_tokens + step.cache_creation_tokens
+            total_tokens = step.input_tokens + step.output_tokens + cache_tokens
             model_short = _short_model_name(step.model) if step.model else ""
             console.log(
                 "  "
@@ -399,7 +395,7 @@ def display_costs(
                 + "  "
                 + f"{step.output_tokens:,}".rjust(7)
                 + "  "
-                + f"{step.cache_read_tokens:,}".rjust(7)
+                + f"{cache_tokens:,}".rjust(7)
                 + "  "
                 + f"{total_tokens:,}".rjust(7)
                 + "  "

--- a/tests/test_cost_display.py
+++ b/tests/test_cost_display.py
@@ -461,6 +461,33 @@ def test_gather_per_step_costs_multiple_steps():
     assert result[1].input_tokens == 200
 
 
+def test_gather_per_step_costs_cache_arithmetic():
+    """Cache column (read+creation) + input + output == total."""
+    msgs = [
+        Message(
+            role="assistant",
+            content="response",
+            metadata={
+                "usage": {
+                    "input_tokens": 100,
+                    "output_tokens": 50,
+                    "cache_read_tokens": 200,
+                    "cache_creation_tokens": 300,
+                },
+            },
+        ),
+    ]
+    result = gather_per_step_costs(msgs)
+    assert len(result) == 1
+    s = result[0]
+    # cache column = read + creation; total = input + output + cache_read + cache_creation
+    assert s.cache_read_tokens + s.cache_creation_tokens == 500
+    assert (
+        s.input_tokens + s.output_tokens + s.cache_read_tokens + s.cache_creation_tokens
+        == 650
+    )
+
+
 def test_gather_per_step_costs_skips_zero_input():
     """Messages with zero input AND zero output are skipped."""
     msgs = [
@@ -488,9 +515,8 @@ def test_gather_per_step_costs_skips_zero_input():
     assert result[0].input_tokens == 100
 
 
-def test_gather_per_step_costs_counts_user_metadata():
-    """Messages with metadata from any role are counted (step_index follows position)."""
-    # user message with a "system" token hit followed by assistant's actual usage
+def test_gather_per_step_costs_skips_user_metadata():
+    """Only assistant messages are counted; user messages with metadata are ignored."""
     msgs = [
         Message(
             role="user",
@@ -510,7 +536,8 @@ def test_gather_per_step_costs_counts_user_metadata():
         ),
     ]
     result = gather_per_step_costs(msgs)
-    # Both messages carry input_tokens > 0, so both are included
-    assert len(result) == 2
-    assert result[0].step_index == 1  # first with tokens
-    assert result[1].step_index == 2  # second with tokens
+    # Only the assistant message is a step; user metadata is ignored
+    assert len(result) == 1
+    assert result[0].step_index == 1
+    assert result[0].input_tokens == 25000
+    assert result[0].output_tokens == 100

--- a/tests/test_cost_display.py
+++ b/tests/test_cost_display.py
@@ -378,3 +378,139 @@ def test_biggest_turn_set_for_single_request():
     assert result is not None
     assert result.biggest_turn is not None
     assert result.biggest_turn.request_index == 1
+
+
+# --- Tests for gather_per_step_costs ---
+
+from gptme.util.cost_display import gather_per_step_costs
+
+
+def test_gather_per_step_costs_empty():
+    """No messages returns empty list."""
+    result = gather_per_step_costs([])
+    assert result == []
+
+
+def test_gather_per_step_costs_no_metadata():
+    """Messages without metadata return empty list."""
+    msgs = [
+        Message(role="user", content="hello"),
+        Message(role="assistant", content="hi there"),
+    ]
+    result = gather_per_step_costs(msgs)
+    assert result == []
+
+
+def test_gather_per_step_costs_single_step():
+    """Single assistant message with metadata returns one StepCost."""
+    msgs = [
+        Message(role="user", content="hello"),
+        Message(
+            role="assistant",
+            content="hi",
+            metadata={
+                "model": "openrouter/deepseek/deepseek-v4-flash@deepseek",
+                "cost": 0.005,
+                "usage": {
+                    "input_tokens": 100,
+                    "output_tokens": 50,
+                    "cache_read_tokens": 20,
+                    "cache_creation_tokens": 10,
+                },
+            },
+        ),
+    ]
+    result = gather_per_step_costs(msgs)
+    assert len(result) == 1
+    assert result[0].step_index == 1
+    assert result[0].input_tokens == 100
+    assert result[0].output_tokens == 50
+    assert result[0].cache_read_tokens == 20
+    assert result[0].cache_creation_tokens == 10
+    assert result[0].cost == 0.005
+    assert result[0].model is not None
+
+
+def test_gather_per_step_costs_multiple_steps():
+    """Multiple assistant messages return multiple StepCosts with correct indices."""
+    msgs = [
+        Message(role="user", content="hello"),
+        Message(
+            role="assistant",
+            content="first",
+            metadata={
+                "model": "anthropic/claude-sonnet-4-5",
+                "usage": {"input_tokens": 100, "output_tokens": 50},
+            },
+        ),
+        Message(role="user", content="follow-up"),
+        Message(
+            role="assistant",
+            content="second",
+            metadata={
+                "model": "openrouter/deepseek/deepseek-v4-flash@deepseek",
+                "usage": {"input_tokens": 200, "output_tokens": 80},
+            },
+        ),
+    ]
+    result = gather_per_step_costs(msgs)
+    assert len(result) == 2
+    assert result[0].step_index == 1
+    assert result[0].input_tokens == 100
+    assert result[1].step_index == 2
+    assert result[1].input_tokens == 200
+
+
+def test_gather_per_step_costs_skips_zero_input():
+    """Messages with zero input AND zero output are skipped."""
+    msgs = [
+        Message(
+            role="assistant",
+            content="empty",
+            metadata={
+                "usage": {
+                    "input_tokens": 0,
+                    "output_tokens": 0,
+                    "cache_read_tokens": 0,
+                },
+            },
+        ),
+        Message(
+            role="assistant",
+            content="real",
+            metadata={
+                "usage": {"input_tokens": 100, "output_tokens": 50},
+            },
+        ),
+    ]
+    result = gather_per_step_costs(msgs)
+    assert len(result) == 1
+    assert result[0].input_tokens == 100
+
+
+def test_gather_per_step_costs_counts_user_metadata():
+    """Messages with metadata from any role are counted (step_index follows position)."""
+    # user message with a "system" token hit followed by assistant's actual usage
+    msgs = [
+        Message(
+            role="user",
+            content="system context loaded",
+            metadata={
+                "model": "openrouter/deepseek/deepseek-v4-flash@deepseek",
+                "usage": {"input_tokens": 25000, "output_tokens": 0},
+            },
+        ),
+        Message(
+            role="assistant",
+            content="working on it",
+            metadata={
+                "model": "openrouter/deepseek/deepseek-v4-flash@deepseek",
+                "usage": {"input_tokens": 25000, "output_tokens": 100},
+            },
+        ),
+    ]
+    result = gather_per_step_costs(msgs)
+    # Both messages carry input_tokens > 0, so both are included
+    assert len(result) == 2
+    assert result[0].step_index == 1  # first with tokens
+    assert result[1].step_index == 2  # second with tokens


### PR DESCRIPTION
## Problem

gptme currently shows cumulative totals in /tokens but no per-turn breakdown. Other harnesses (Claude Code, Codex) emit per-step token counts, and Erik explicitly asked for this in TimeToBuildBob/bob#738: "gptme should definitely support per-turn/step/message token estimates etc."

## What this does

Adds a compact **Per-Step Breakdown** table to /tokens output:

```
Step     Input   Output    Cache    Total   Model
   1    67,169      878        0   68,047   deepseek-v4-pro
   2     2,566      224   62,377   65,167   deepseek-v4-pro
```

- `StepCost` dataclass for per-step data
- `gather_per_step_costs()` extracts usage from all messages with metadata
- Table only appears when per-step data is available (backward compatible)
- `_short_model_name()` helper strips provider prefixes for compact display

## Changes

- `gptme/util/cost_display.py`: +114 lines (StepCost dataclass, gather_per_step_costs, table rendering)
- `gptme/commands/llm.py`: wire per_step into cmd_tokens
- `tests/test_cost_display.py`: +6 new tests (22 total, all passing)

## Verification

- ✅ 22/22 tests passing (`uv run pytest tests/test_cost_display.py -v`)
- ✅ mypy clean (`uv run mypy gptme/util/cost_display.py gptme/commands/llm.py tests/test_cost_display.py`)
- ✅ Works in practice: gptme sessions already record per-message usage metadata via Anthropic/OpenAI backends

## Coverage

- Works for Anthropic, OpenAI, and OpenRouter backends (all use existing metadata recording)
- Falls back gracefully: if no messages have usage metadata, table simply doesn't appear
- Zero input steps are skipped (degenerate case)

Closes gptme/gptme#2347