### PR TITLE
fix(tools): clarify derive_type docstring and use identity checks for type origins

### DIFF
--- a/gptme/tools/base.py
+++ b/gptme/tools/base.py
@@ -176,8 +176,14 @@ class Parameter:
     required: bool = False
 
 
-# TODO: there must be a better way?
 def derive_type(t) -> str:
+    """Convert a type annotation to a human-readable string for tool signatures.
+
+    Python's stdlib has no clean public API for this — ``str(t)`` includes
+    the ``typing.`` prefix and ``__repr__`` is inconsistent across versions.
+    This produces the concise form used in JSON schemas and LLM-readable
+    function descriptions (``Literal["foo"]``, ``Union[int, str]``, etc.).
+    """
     # Handle None value (e.g., return type of Callable[[...], None])
     if t is None:
         return "None"
@@ -194,12 +200,12 @@ def derive_type(t) -> str:
     origin = get_origin(t)
 
     # Handle Literal types
-    if origin == Literal:
+    if origin is Literal:
         v = ", ".join(f'"{a}"' for a in get_args(t))
         return f"Literal[{v}]"
 
     # Handle Union types (both typing.Union and types.UnionType)
-    if origin == Union or origin == types.UnionType:
+    if origin is Union or origin is types.UnionType:
         v = ", ".join(derive_type(a) for a in get_args(t))
         return f"Union[{v}]"
 


### PR DESCRIPTION
## What
Three small improvements to `derive_type()` in `gptme/tools/base.py`:

1. **Add docstring** explaining why the hand-rolled dispatch exists — Python's stdlib (`get_type_hints`, `str(t)`) doesn't cleanly produce the concise form needed for JSON schemas and LLM-readable function signatures
2. **Remove TODO comment** — the docstring now explains the design rationale
3. **Use `is` instead of `==` for type-origin identity checks** — `get_origin()` returns singletons (`Literal`, `Union`, `types.UnionType`), so identity comparison is more correct than equality

## Why
The TODO comment has been in the codebase since at least 2024. The right fix isn't to replace the dispatch (stdlib doesn't handle the concise representation needed here) but to explain *why* the hand-rolled approach is intentional.

The `==` → `is` change is a minor correctness improvement: type origin objects are singletons and identity comparison is the conventional idiom for them.

## Changes
- `gptme/tools/base.py`: Add docstring, remove TODO, fix type-origin comparisons
- No logic changes — same output, same callers, same behavior

## Testing
- `tests/test_tools_base.py`: 87 passed
- ruff check: clean
- ruff format: clean