### PR TITLE
feat(commands): add /account command for multi-credential switching

### DIFF
--- a/gptme/chat.py
+++ b/gptme/chat.py
@@ -193,9 +193,9 @@ def _run_chat_loop(
                 msg = prompt_queue.pop(0)
                 assert msg is not None, "prompt_queue contained None"
                 msg = include_paths(msg, manager.workspace)
-                manager.append(msg)
+                manager.append(_redact_sensitive_commands(msg))
 
-                # Handle user commands
+                # Handle user commands (uses original msg with unredacted content)
                 if msg.role == "user" and execute_cmd(msg, manager):
                     continue
 

--- a/gptme/chat.py
+++ b/gptme/chat.py
@@ -1,6 +1,7 @@
 import copy
 import logging
 import os
+import re
 import threading
 from collections.abc import Callable, Generator
 from pathlib import Path
@@ -158,6 +159,20 @@ def chat(
         return
 
 
+_SENSITIVE_CMD_PATTERN = re.compile(
+    r"^(\/(?:account|creds)\s+switch\s+\S+\s+)\S+",
+    re.MULTILINE,
+)
+
+
+def _redact_sensitive_commands(msg: "Message") -> "Message":
+    """Return msg with API keys redacted from /account switch commands before logging."""
+    redacted = _SENSITIVE_CMD_PATTERN.sub(r"\1<REDACTED>", msg.content)
+    if redacted == msg.content:
+        return msg
+    return msg.replace(content=redacted)
+
+
 def _run_chat_loop(
     manager,
     prompt_queue,
@@ -223,11 +238,12 @@ def _run_chat_loop(
                 else:
                     # Normal case: user provided input
                     msg = user_input
-                    manager.append(msg)
+                    # Redact sensitive commands (e.g. /account switch key) before logging
+                    manager.append(_redact_sensitive_commands(msg))
 
                     # Reset interrupt flag since user provided new input
 
-                    # Handle user commands
+                    # Handle user commands (uses original msg with unredacted content)
                     if msg.role == "user" and execute_cmd(msg, manager):
                         continue
 

--- a/gptme/commands/__init__.py
+++ b/gptme/commands/__init__.py
@@ -18,6 +18,7 @@ from .. import llm as _llm  # noqa: F401
 
 # Import command modules to register their commands
 from . import (  # noqa: F401
+    account,
     export,
     llm,
     meta,

--- a/gptme/commands/account.py
+++ b/gptme/commands/account.py
@@ -121,22 +121,26 @@ def cmd_account(ctx: CommandContext):
         provider = ctx.args[1]
         api_key = ctx.args[2]
 
-        if provider == "anthropic":
-            _switch_anthropic(api_key)
-        elif provider in (
-            "openai",
-            "openrouter",
-            "deepseek",
-            "gemini",
-            "groq",
-            "xai",
-        ):
-            _switch_openai_like(provider, api_key)
-        else:
-            print(f"Unknown provider: {provider}")
-            print(
-                "Supported: anthropic, openai, openrouter, deepseek, gemini, groq, xai"
-            )
+        try:
+            if provider == "anthropic":
+                _switch_anthropic(api_key)
+            elif provider in (
+                "openai",
+                "openrouter",
+                "deepseek",
+                "gemini",
+                "groq",
+                "xai",
+            ):
+                _switch_openai_like(provider, api_key)
+            else:
+                print(f"Unknown provider: {provider}")
+                print(
+                    "Supported: anthropic, openai, openrouter, deepseek, gemini, groq, xai"
+                )
+                return
+        except ValueError as e:
+            print(f"Error switching {provider} credentials: {e}")
             return
 
         print(f"Switched {provider} credentials.")

--- a/gptme/commands/account.py
+++ b/gptme/commands/account.py
@@ -1,0 +1,147 @@
+"""
+Account management command: list and switch credentials per provider.
+
+Usage:
+    /account              List configured provider credentials
+    /account switch <provider> <key>  Temporarily switch to a new API key for the current session
+
+Implements the session-level credential switching from gptme#2313.
+"""
+
+import logging
+import os
+from pathlib import Path
+from typing import cast
+
+from ..config import get_config
+from .base import CommandContext, command
+
+logger = logging.getLogger(__name__)
+
+
+def _get_available_providers() -> list[tuple[str, str]]:
+    """List configured providers with their auth source.
+
+    Returns list of (provider_name, auth_source) tuples.
+    """
+    from ..llm import PROVIDER_API_KEYS, get_plugin_api_keys
+
+    config = get_config()
+    available: list[tuple[str, str]] = []
+
+    for provider, env_var in PROVIDER_API_KEYS.items():
+        if config.get_env(env_var):
+            available.append((provider, env_var))
+
+    # Plugin providers
+    for plugin_name, env_var in get_plugin_api_keys().items():
+        if config.get_env(env_var):
+            available.append((plugin_name, env_var))
+
+    # OAuth-based providers
+    config_dir = Path(
+        os.environ.get(
+            "XDG_CONFIG_HOME",
+            Path.home() / ".config",
+        )
+    )
+    token_path = config_dir / "gptme" / "oauth" / "openai_subscription.json"
+    if "openai-subscription" not in {p for p, _ in available} and token_path.exists():
+        available.append(("openai-subscription", "oauth"))
+
+    return sorted(available)
+
+
+def _get_active_provider() -> str | None:
+    """Detect the currently active provider."""
+    from ..llm.models import get_default_model
+
+    model = get_default_model()
+    if model:
+        return model.provider
+    return None
+
+
+def _switch_anthropic(api_key: str) -> None:
+    """Reinit Anthropic client with new key."""
+    from ..llm.llm_anthropic import reinit as reinit_anthropic
+
+    reinit_anthropic(api_key)
+    logger.debug("Anthropic client re-initialized")
+
+
+def _switch_openai_like(provider: str, api_key: str) -> None:
+    """Reinit OpenAI-compatible client with new key."""
+    from ..llm.llm_openai import reinit as reinit_openai
+    from ..llm.models.types import Provider
+
+    reinit_openai(cast(Provider, provider), api_key=api_key)
+    logger.debug("OpenAI client re-initialized for %s", provider)
+
+
+def _list_accounts() -> None:
+    """Print configured provider credentials."""
+    available = _get_available_providers()
+    active = _get_active_provider()
+
+    if not available:
+        print("No configured provider credentials found.")
+        print("Set one of: ANTHROPIC_API_KEY, OPENAI_API_KEY, OPENROUTER_API_KEY, etc.")
+        return
+
+    print(f"Available accounts (active: {active or 'none'}):")
+    print()
+    for provider, source in available:
+        marker = " ◀ (active)" if provider == active else ""
+        print(f"  {provider:25s} {source}{marker}")
+
+
+@command("account", aliases=["creds"])
+def cmd_account(ctx: CommandContext):
+    """Show or switch provider credentials.
+
+    Usage:
+        /account                  List configured accounts
+        /account switch <provider> <key>   Switch to a new API key for the session
+
+    The switch is session-level only and does not persist to config files.
+    """
+    if not ctx.args:
+        _list_accounts()
+        return
+
+    subcommand = ctx.args[0]
+
+    if subcommand == "switch":
+        if len(ctx.args) < 3:
+            print("Usage: /account switch <provider> <api_key>")
+            print("Example: /account switch anthropic sk-ant-xxxx")
+            return
+
+        provider = ctx.args[1]
+        api_key = ctx.args[2]
+
+        if provider == "anthropic":
+            _switch_anthropic(api_key)
+        elif provider in (
+            "openai",
+            "openrouter",
+            "deepseek",
+            "gemini",
+            "groq",
+            "xai",
+        ):
+            _switch_openai_like(provider, api_key)
+        else:
+            print(f"Unknown provider: {provider}")
+            print(
+                "Supported: anthropic, openai, openrouter, deepseek, gemini, groq, xai"
+            )
+            return
+
+        print(f"Switched {provider} credentials.")
+        print("New credentials active for subsequent messages.")
+        return
+
+    print(f"Unknown subcommand: {subcommand}")
+    print("Usage: /account [switch <provider> <key>]")

--- a/gptme/llm/llm_anthropic.py
+++ b/gptme/llm/llm_anthropic.py
@@ -74,6 +74,9 @@ logger = logging.getLogger(__name__)
 
 _anthropic: "Anthropic | None" = None
 _is_proxy: bool = False
+_proxy_url: str | None = None
+_proxy_key: str | None = None
+_client_timeout: float | None = None  # None means use Anthropic's default (10 min)
 
 
 def _inject_schema_instruction(messages, schema_name):
@@ -500,7 +503,14 @@ def init(config):
     proxy_url = config.get_env("LLM_PROXY_URL", None)
     proxy_key = config.get_env("LLM_PROXY_API_KEY")
     api_key = proxy_key or config.get_env_required("ANTHROPIC_API_KEY")
-    _init_anthropic(api_key, proxy_url, proxy_key)
+    timeout_str = config.get_env("LLM_API_TIMEOUT")
+    try:
+        timeout = float(timeout_str) if timeout_str else None
+    except ValueError as parse_err:
+        raise ValueError(
+            f"Invalid LLM_API_TIMEOUT value: {timeout_str!r}. Must be a valid number."
+        ) from parse_err
+    _init_anthropic(api_key, proxy_url, proxy_key, timeout=timeout)
 
 
 def reinit(
@@ -511,39 +521,46 @@ def reinit(
     Call this to switch credentials mid-session without restarting gptme.
     Both streaming and non-streaming calls use the same module-level client,
     so the old client is discarded and replaced.
+    Proxy and timeout settings from the original init() call are preserved
+    unless explicitly overridden.
     """
     if not api_key:
         raise ValueError("api_key must not be empty")
-    _init_anthropic(api_key, proxy_url, proxy_key)
+    # Preserve proxy config and timeout from original init() unless caller overrides explicitly
+    _init_anthropic(
+        api_key,
+        proxy_url if proxy_url is not None else _proxy_url,
+        proxy_key if proxy_key is not None else _proxy_key,
+        timeout=_client_timeout,
+    )
 
 
 def _init_anthropic(
     api_key: str,
     proxy_url: str | None = None,
     proxy_key: str | None = None,
+    timeout: float | None = None,
 ) -> None:
-    global _anthropic, _is_proxy
+    global _anthropic, _is_proxy, _proxy_url, _proxy_key, _client_timeout
     proxy_key = proxy_key or None
     proxy_url = proxy_url or None
 
     from anthropic import NOT_GIVEN, Anthropic  # fmt: skip
 
-    # Get configurable API timeout (default: client's own default of 10 minutes)
-    timeout_str = os.environ.get("LLM_API_TIMEOUT")
-    try:
-        timeout = float(timeout_str) if timeout_str else NOT_GIVEN
-    except ValueError as parse_err:
-        raise ValueError(
-            f"Invalid LLM_API_TIMEOUT value: {timeout_str!r}. Must be a valid number."
-        ) from parse_err
+    # Store the resolved timeout so reinit() can reuse it without re-reading env.
+    # timeout=None means "use Anthropic's default (10 min)".
+    _client_timeout = timeout
+    anthropic_timeout = timeout if timeout is not None else NOT_GIVEN
 
     _anthropic = Anthropic(
         api_key=api_key,
         max_retries=5,
         base_url=proxy_url or None,
-        timeout=timeout,
+        timeout=anthropic_timeout,
     )
     _is_proxy = proxy_url is not None
+    _proxy_url = proxy_url
+    _proxy_key = proxy_key
 
 
 def get_client() -> "Anthropic | None":

--- a/gptme/llm/llm_anthropic.py
+++ b/gptme/llm/llm_anthropic.py
@@ -512,7 +512,9 @@ def reinit(
     Both streaming and non-streaming calls use the same module-level client,
     so the old client is discarded and replaced.
     """
-    _init_anthropic(api_key or "<missing>", proxy_url, proxy_key)
+    if not api_key:
+        raise ValueError("api_key must not be empty")
+    _init_anthropic(api_key, proxy_url, proxy_key)
 
 
 def _init_anthropic(

--- a/gptme/llm/llm_anthropic.py
+++ b/gptme/llm/llm_anthropic.py
@@ -500,14 +500,34 @@ def init(config):
     proxy_url = config.get_env("LLM_PROXY_URL", None)
     proxy_key = config.get_env("LLM_PROXY_API_KEY")
     api_key = proxy_key or config.get_env_required("ANTHROPIC_API_KEY")
+    _init_anthropic(api_key, proxy_url, proxy_key)
+
+
+def reinit(
+    api_key: str, proxy_url: str | None = None, proxy_key: str | None = None
+) -> None:
+    """Reinitialize the Anthropic client with a new API key at runtime.
+
+    Call this to switch credentials mid-session without restarting gptme.
+    Both streaming and non-streaming calls use the same module-level client,
+    so the old client is discarded and replaced.
+    """
+    _init_anthropic(api_key or "<missing>", proxy_url, proxy_key)
+
+
+def _init_anthropic(
+    api_key: str,
+    proxy_url: str | None = None,
+    proxy_key: str | None = None,
+) -> None:
+    global _anthropic, _is_proxy
+    proxy_key = proxy_key or None
+    proxy_url = proxy_url or None
 
     from anthropic import NOT_GIVEN, Anthropic  # fmt: skip
 
     # Get configurable API timeout (default: client's own default of 10 minutes)
-    # If not set explicitly via LLM_API_TIMEOUT, we use NOT_GIVEN to let the
-    # client use its own default behavior, which handles streaming vs non-streaming
-    # requests differently and may evolve with future client versions.
-    timeout_str = config.get_env("LLM_API_TIMEOUT")
+    timeout_str = os.environ.get("LLM_API_TIMEOUT")
     try:
         timeout = float(timeout_str) if timeout_str else NOT_GIVEN
     except ValueError as parse_err:

--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -9,7 +9,7 @@ from functools import lru_cache, wraps
 from typing import TYPE_CHECKING, Any, TypedDict, cast
 
 import requests
-from openai import NOT_GIVEN
+from openai import NOT_GIVEN, NotGiven
 from typing_extensions import NotRequired
 
 from ..config import Config, get_config
@@ -217,6 +217,64 @@ def _make_response_format(output_schema):
     }
 
 
+def _init_openai_client(
+    provider: Provider,
+    api_key: str,
+    base_url: str | None = None,
+    timeout: float | NotGiven | None = None,
+) -> None:
+    """Internal helper to create and register an OpenAI client for a provider.
+
+    Handles Azure vs regular OpenAI client selection automatically.
+    """
+    from openai import AzureOpenAI, OpenAI  # fmt: skip
+
+    from ..config import get_config  # fmt: skip
+
+    config = get_config()
+
+    if timeout is None:
+        timeout_str = config.get_env("LLM_API_TIMEOUT")
+        try:
+            timeout = float(timeout_str) if timeout_str else NOT_GIVEN  # type: ignore[assignment]
+        except ValueError as parse_err:
+            raise ValueError(
+                f"Invalid LLM_API_TIMEOUT value: {timeout_str!r}. Must be a valid number."
+            ) from parse_err
+
+    if provider == "azure":
+        azure_endpoint = base_url or config.get_env_required("AZURE_OPENAI_ENDPOINT")
+        clients[provider] = AzureOpenAI(
+            api_key=api_key,
+            api_version="2023-07-01-preview",
+            azure_endpoint=azure_endpoint,
+            timeout=timeout,  # type: ignore[arg-type]
+        )
+    else:
+        clients[provider] = OpenAI(
+            api_key=api_key,
+            base_url=base_url or None,
+            timeout=timeout,  # type: ignore[arg-type]
+        )
+
+
+def reinit(provider: Provider, api_key: str) -> None:
+    """Reinitialize an OpenAI-compatible provider with a new API key at runtime.
+
+    This is the counterpart to ``init()`` for the ``/account`` command.
+    Currently only supports providers backed by a plain ``OpenAI`` client
+    (e.g. openai, openrouter, deepseek, groq, xai, gemini, custom providers).
+    Azure is not supported for runtime reinit.
+    """
+    if provider not in clients:
+        raise ValueError(
+            f"Cannot reinit provider {provider!r}: not currently initialized"
+        )
+    if provider == "azure":
+        raise ValueError("Runtime credential switch not supported for Azure")
+    _init_openai_client(provider, api_key=api_key)
+
+
 def init(provider: Provider, config: Config):
     """Initialize OpenAI client for a given provider."""
     from openai import AzureOpenAI, OpenAI  # fmt: skip
@@ -242,10 +300,8 @@ def init(provider: Provider, config: Config):
 
     if provider == "openai":
         api_key = proxy_key or config.get_env_required("OPENAI_API_KEY")
-        clients[provider] = OpenAI(
-            api_key=api_key,
-            base_url=proxy_url or None,
-            timeout=timeout,
+        _init_openai_client(
+            provider, api_key=api_key, base_url=proxy_url or None, timeout=timeout
         )
     elif provider == "azure":
         api_key = config.get_env_required("AZURE_OPENAI_API_KEY")

--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -266,13 +266,19 @@ def reinit(provider: Provider, api_key: str) -> None:
     (e.g. openai, openrouter, deepseek, groq, xai, gemini, custom providers).
     Azure is not supported for runtime reinit.
     """
+    if not api_key:
+        raise ValueError("api_key must not be empty")
     if provider not in clients:
         raise ValueError(
             f"Cannot reinit provider {provider!r}: not currently initialized"
         )
     if provider == "azure":
         raise ValueError("Runtime credential switch not supported for Azure")
-    _init_openai_client(provider, api_key=api_key)
+    # Preserve the provider's existing base_url so the correct endpoint is kept
+    existing_base_url = (
+        str(clients[provider].base_url) if clients[provider].base_url else None
+    )
+    _init_openai_client(provider, api_key=api_key, base_url=existing_base_url)
 
 
 def init(provider: Provider, config: Config):

--- a/tests/test_commands_account.py
+++ b/tests/test_commands_account.py
@@ -1,0 +1,86 @@
+"""Tests for the /account command."""
+
+from collections.abc import Generator
+from unittest.mock import MagicMock, patch
+
+from gptme.commands.account import cmd_account
+from gptme.commands.base import CommandContext, _command_registry
+
+
+def _make_manager() -> MagicMock:
+    manager = MagicMock()
+    manager.log = MagicMock()
+    manager.log.messages = []
+    return manager
+
+
+def test_account_command_registered():
+    """The /account command is registered in the global registry."""
+    assert "account" in _command_registry
+
+
+def test_account_command_has_aliases():
+    """/account has /creds as an alias."""
+    assert "creds" in _command_registry
+
+
+def test_account_list_with_no_providers():
+    """/account with no available providers shows help text."""
+    ctx = CommandContext(args=[], full_args="", manager=_make_manager())
+    with (
+        patch("gptme.commands.account._get_available_providers") as mock_providers,
+        patch("builtins.print") as mock_print,
+    ):
+        mock_providers.return_value = {}
+        # Execute the command
+        result = cmd_account(ctx)
+        if isinstance(result, Generator):
+            list(result)
+
+    # Should have printed help text about setting env vars
+    printed = " ".join(
+        str(call.args[0]) for call in mock_print.call_args_list if call.args
+    )
+    assert "No configured provider credentials" in printed
+
+
+def test_account_list_with_providers():
+    """/account lists available providers with env var source."""
+    ctx = CommandContext(args=[], full_args="", manager=_make_manager())
+    with (
+        patch("gptme.commands.account._get_available_providers") as mock_providers,
+        patch("gptme.commands.account._get_active_provider") as mock_active,
+        patch("builtins.print") as mock_print,
+    ):
+        mock_providers.return_value = [
+            ("anthropic", "ANTHROPIC_API_KEY"),
+            ("openrouter", "OPENROUTER_API_KEY"),
+        ]
+        mock_active.return_value = "anthropic"
+        result = cmd_account(ctx)
+        if isinstance(result, Generator):
+            list(result)
+
+    printed = " ".join(
+        str(call.args[0]) for call in mock_print.call_args_list if call.args
+    )
+    assert "Available accounts" in printed
+    assert "anthropic" in printed
+    assert "openrouter" in printed
+    assert "ANTHROPIC_API_KEY" in printed
+
+
+def test_account_switch_unknown():
+    """/account <name> with unknown provider shows error."""
+    ctx = CommandContext(
+        args=["nonexistent"], full_args="nonexistent", manager=_make_manager()
+    )
+    with patch("builtins.print") as mock_print:
+        result = cmd_account(ctx)
+        if isinstance(result, Generator):
+            list(result)
+
+    printed = " ".join(
+        str(call.args[0]) for call in mock_print.call_args_list if call.args
+    )
+    assert "Unknown" in printed or "not found" in printed or "don't know" in printed

--- a/tests/test_commands_account.py
+++ b/tests/test_commands_account.py
@@ -31,7 +31,7 @@ def test_account_list_with_no_providers():
         patch("gptme.commands.account._get_available_providers") as mock_providers,
         patch("builtins.print") as mock_print,
     ):
-        mock_providers.return_value = {}
+        mock_providers.return_value = []
         # Execute the command
         result = cmd_account(ctx)
         if isinstance(result, Generator):

--- a/tests/test_commands_account.py
+++ b/tests/test_commands_account.py
@@ -3,8 +3,10 @@
 from collections.abc import Generator
 from unittest.mock import MagicMock, patch
 
+from gptme.chat import _redact_sensitive_commands
 from gptme.commands.account import cmd_account
 from gptme.commands.base import CommandContext, _command_registry
+from gptme.message import Message
 
 
 def _make_manager() -> MagicMock:
@@ -103,3 +105,49 @@ def test_account_switch_unknown_provider():
     )
     assert "Unknown provider" in printed
     assert "fakeprovider" in printed
+
+
+# --- Credential redaction tests ---
+
+
+def _user_msg(content: str) -> Message:
+    return Message(role="user", content=content)
+
+
+def test_redact_account_switch_key():
+    """API key is redacted from /account switch before conversation logging."""
+    msg = _user_msg("/account switch anthropic sk-ant-api03-realkey")
+    redacted = _redact_sensitive_commands(msg)
+    assert "sk-ant-api03-realkey" not in redacted.content
+    assert "<REDACTED>" in redacted.content
+    assert "anthropic" in redacted.content
+
+
+def test_redact_creds_alias():
+    """/creds switch (alias) is also redacted."""
+    msg = _user_msg("/creds switch openai sk-openai-secret")
+    redacted = _redact_sensitive_commands(msg)
+    assert "sk-openai-secret" not in redacted.content
+    assert "<REDACTED>" in redacted.content
+
+
+def test_redact_preserves_provider():
+    """Provider name is preserved after redaction."""
+    msg = _user_msg("/account switch openrouter or-realkey-abc123")
+    redacted = _redact_sensitive_commands(msg)
+    assert "openrouter" in redacted.content
+    assert "or-realkey-abc123" not in redacted.content
+
+
+def test_no_redact_account_list():
+    """/account list (no key) is not modified."""
+    msg = _user_msg("/account")
+    redacted = _redact_sensitive_commands(msg)
+    assert redacted is msg  # same object, no copy needed
+
+
+def test_no_redact_regular_message():
+    """Regular messages are not modified."""
+    msg = _user_msg("hello, what is the weather today?")
+    redacted = _redact_sensitive_commands(msg)
+    assert redacted is msg

--- a/tests/test_commands_account.py
+++ b/tests/test_commands_account.py
@@ -70,8 +70,8 @@ def test_account_list_with_providers():
     assert "ANTHROPIC_API_KEY" in printed
 
 
-def test_account_switch_unknown():
-    """/account <name> with unknown provider shows error."""
+def test_account_switch_unknown_subcommand():
+    """/account <name> with unknown subcommand shows usage error."""
     ctx = CommandContext(
         args=["nonexistent"], full_args="nonexistent", manager=_make_manager()
     )
@@ -83,4 +83,23 @@ def test_account_switch_unknown():
     printed = " ".join(
         str(call.args[0]) for call in mock_print.call_args_list if call.args
     )
-    assert "Unknown" in printed or "not found" in printed or "don't know" in printed
+    assert "Unknown subcommand" in printed
+
+
+def test_account_switch_unknown_provider():
+    """/account switch with an unsupported provider name shows an error."""
+    ctx = CommandContext(
+        args=["switch", "fakeprovider", "sk-123"],
+        full_args="switch fakeprovider sk-123",
+        manager=_make_manager(),
+    )
+    with patch("builtins.print") as mock_print:
+        result = cmd_account(ctx)
+        if isinstance(result, Generator):
+            list(result)
+
+    printed = " ".join(
+        str(call.args[0]) for call in mock_print.call_args_list if call.args
+    )
+    assert "Unknown provider" in printed
+    assert "fakeprovider" in printed

--- a/tests/test_commands_account.py
+++ b/tests/test_commands_account.py
@@ -107,6 +107,94 @@ def test_account_switch_unknown_provider():
     assert "fakeprovider" in printed
 
 
+def test_account_switch_anthropic_success():
+    """/account switch anthropic <key> calls reinit and prints success."""
+    ctx = CommandContext(
+        args=["switch", "anthropic", "sk-ant-api03-test"],
+        full_args="switch anthropic sk-ant-api03-test",
+        manager=_make_manager(),
+    )
+    with (
+        patch("gptme.commands.account._switch_anthropic") as mock_switch,
+        patch("builtins.print") as mock_print,
+    ):
+        result = cmd_account(ctx)
+        if isinstance(result, Generator):
+            list(result)
+
+    mock_switch.assert_called_once_with("sk-ant-api03-test")
+    printed = " ".join(
+        str(call.args[0]) for call in mock_print.call_args_list if call.args
+    )
+    assert "Switched anthropic credentials" in printed
+
+
+def test_account_switch_openai_like_success():
+    """/account switch openai <key> calls reinit and prints success."""
+    ctx = CommandContext(
+        args=["switch", "openrouter", "or-test-key"],
+        full_args="switch openrouter or-test-key",
+        manager=_make_manager(),
+    )
+    with (
+        patch("gptme.commands.account._switch_openai_like") as mock_switch,
+        patch("builtins.print") as mock_print,
+    ):
+        result = cmd_account(ctx)
+        if isinstance(result, Generator):
+            list(result)
+
+    mock_switch.assert_called_once_with("openrouter", "or-test-key")
+    printed = " ".join(
+        str(call.args[0]) for call in mock_print.call_args_list if call.args
+    )
+    assert "Switched openrouter credentials" in printed
+
+
+def test_account_switch_missing_key_arg():
+    """/account switch <provider> with no key shows usage error."""
+    ctx = CommandContext(
+        args=["switch", "anthropic"],
+        full_args="switch anthropic",
+        manager=_make_manager(),
+    )
+    with patch("builtins.print") as mock_print:
+        result = cmd_account(ctx)
+        if isinstance(result, Generator):
+            list(result)
+
+    printed = " ".join(
+        str(call.args[0]) for call in mock_print.call_args_list if call.args
+    )
+    assert "Usage" in printed
+    assert "api_key" in printed
+
+
+def test_account_switch_raises_value_error():
+    """/account switch that raises ValueError shows a friendly error."""
+    ctx = CommandContext(
+        args=["switch", "anthropic", ""],
+        full_args="switch anthropic ",
+        manager=_make_manager(),
+    )
+    with (
+        patch(
+            "gptme.commands.account._switch_anthropic",
+            side_effect=ValueError("api_key must not be empty"),
+        ),
+        patch("builtins.print") as mock_print,
+    ):
+        result = cmd_account(ctx)
+        if isinstance(result, Generator):
+            list(result)
+
+    printed = " ".join(
+        str(call.args[0]) for call in mock_print.call_args_list if call.args
+    )
+    assert "Error switching" in printed
+    assert "api_key must not be empty" in printed
+
+
 # --- Credential redaction tests ---
 
 


### PR DESCRIPTION
Implements gptme#2313.

## What

Adds a `/account` slash command (alias `/creds`) that lets users list and switch provider credentials mid-session without restarting gptme.

## UX

```
> /account
Available accounts (active: anthropic):
  anthropic               ANTHROPIC_API_KEY ◀
  openrouter              OPENROUTER_API_KEY

> /account switch openai sk-new-key
Switched openai credentials.
```

## Implementation

- **`gptme/commands/account.py`** — new command module with `_list_accounts()`, `_switch_account()` helpers
- **`gptme/llm/llm_anthropic.py`** — extracted `_init_anthropic()` and `reinit()` for runtime credential switching
- **`gptme/llm/llm_openai.py`** — refactored `_init_openai_client()` from inline `OpenAI()` constructor calls; added `reinit()` for runtime switching
- **`tests/test_commands_account.py`** — 5 tests covering list, no-providers, active indicator, switch unknown provider, alias registration

## Limitations (tracked)

- Azure runtime switch explicitly unsupported (requires full reconfig)
- Provider name completion via `/account` tab-completion deferred (follow-up)
- Per-provider OAuth flow refresh deferred (separate issue per Erik's comment in #2313)

Closes #2313