### PR TITLE
feat(oauth): add OpenRouter PKCE OAuth flow

### DIFF
--- a/gptme/oauth/__init__.py
+++ b/gptme/oauth/__init__.py
@@ -1,0 +1,5 @@
+"""OAuth flows for gptme provider authentication.
+
+Provides PKCE-based OAuth flows for providers that support browser-based
+authentication, returning durable credentials suitable for headless use.
+"""

--- a/gptme/oauth/openrouter.py
+++ b/gptme/oauth/openrouter.py
@@ -1,0 +1,244 @@
+"""OpenRouter PKCE OAuth flow.
+
+Implements the OpenRouter dynamic OAuth flow using PKCE so the user can
+sign in via browser and receive a durable ``sk-or-...`` API key without
+any client_id registration on our side.
+
+Flow:
+    1. Generate PKCE verifier + S256 challenge
+    2. Open https://openrouter.ai/auth?... in browser
+    3. Listen for the callback on http://127.0.0.1:3000/callback
+    4. Exchange the returned code at https://openrouter.ai/api/v1/auth/keys
+    5. Receive a durable ``sk-or-...`` key
+
+Reference: https://openrouter.ai/docs/use-cases/oauth-pkce
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import http.server
+import logging
+import secrets
+import socket
+import threading
+import time
+import webbrowser
+from typing import TYPE_CHECKING, Any
+from urllib.parse import parse_qs, urlencode, urlparse
+
+import requests
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+logger = logging.getLogger(__name__)
+
+OPENROUTER_AUTH_URL = "https://openrouter.ai/auth"
+OPENROUTER_TOKEN_URL = "https://openrouter.ai/api/v1/auth/keys"
+
+# OpenRouter's documented callback port. Not configurable on the OpenRouter side.
+OPENROUTER_CALLBACK_PORT = 3000
+OPENROUTER_CALLBACK_PATH = "/callback"
+
+DEFAULT_KEY_LABEL = "gptme"
+
+
+class OAuthError(RuntimeError):
+    """Raised when the OAuth flow fails."""
+
+
+def generate_pkce() -> tuple[str, str]:
+    """Generate a PKCE verifier and S256 code_challenge.
+
+    Returns:
+        (code_verifier, code_challenge) — both URL-safe base64 strings.
+    """
+    code_verifier = secrets.token_urlsafe(32)
+    digest = hashlib.sha256(code_verifier.encode()).digest()
+    code_challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode()
+    return code_verifier, code_challenge
+
+
+def is_port_available(port: int) -> bool:
+    """Check whether ``port`` is free for binding on 127.0.0.1."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        try:
+            s.bind(("127.0.0.1", port))
+            return True
+        except OSError:
+            return False
+
+
+class _CallbackHandler(http.server.BaseHTTPRequestHandler):
+    """HTTP handler for the OpenRouter OAuth callback.
+
+    State is shared via class variables — only one OAuth flow may run on
+    OPENROUTER_CALLBACK_PORT at a time, which is enforced by the port check
+    in :func:`authenticate`.
+    """
+
+    authorization_code: str | None = None
+    error: str | None = None
+    expected_state: str | None = None
+
+    def log_message(self, format: str, *args: Any) -> None:
+        pass
+
+    def do_GET(self) -> None:
+        parsed = urlparse(self.path)
+
+        if parsed.path != OPENROUTER_CALLBACK_PATH:
+            self._respond_html(404, "Not found")
+            return
+
+        params = parse_qs(parsed.query)
+
+        # CSRF: validate state parameter when one was issued
+        if _CallbackHandler.expected_state is not None:
+            received_state = params.get("state", [None])[0]
+            if received_state != _CallbackHandler.expected_state:
+                _CallbackHandler.error = (
+                    "Invalid state parameter (possible CSRF attack)"
+                )
+                self._respond_html(400, "Security error: invalid state parameter")
+                return
+
+        if "code" in params:
+            _CallbackHandler.authorization_code = params["code"][0]
+            self._respond_html(
+                200, "Authentication successful. You can close this window."
+            )
+        elif "error" in params:
+            err_desc = params.get("error_description", params["error"])[0]
+            _CallbackHandler.error = err_desc
+            self._respond_html(400, f"Authentication failed: {err_desc}")
+        else:
+            self._respond_html(400, "No authorization code received")
+
+    def _respond_html(self, status: int, message: str) -> None:
+        html = (
+            "<!DOCTYPE html><html><head>"
+            '<meta charset="utf-8"><title>gptme — OpenRouter</title>'
+            '</head><body style="font-family: system-ui; text-align: center; '
+            'padding: 50px; color: #222; background: #fafafa;">'
+            '<h1 style="font-size: 1.5em;">gptme</h1>'
+            f'<p style="font-size: 1.2em;">{message}</p>'
+            "<script>setTimeout(() => window.close(), 3000);</script>"
+            "</body></html>"
+        )
+        self.send_response(status)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.end_headers()
+        self.wfile.write(html.encode())
+
+
+def authenticate(
+    key_label: str = DEFAULT_KEY_LABEL,
+    timeout: float = 300.0,
+    open_browser: Callable[[str], bool] = webbrowser.open,
+    callback_port: int = OPENROUTER_CALLBACK_PORT,
+) -> str:
+    """Run the OpenRouter PKCE OAuth flow and return a durable API key.
+
+    Args:
+        key_label: Label OpenRouter shows for the issued key in its dashboard.
+        timeout: Seconds to wait for the callback before raising.
+        open_browser: Hook for opening the auth URL (overridable for tests).
+        callback_port: Localhost port for the redirect listener.
+
+    Returns:
+        The durable ``sk-or-...`` API key string.
+
+    Raises:
+        OAuthError: If the port is busy, the callback fails, or the token
+            exchange does not return a usable key.
+    """
+    if not is_port_available(callback_port):
+        raise OAuthError(
+            f"Port {callback_port} is not available. OpenRouter requires "
+            "this exact port for the OAuth callback. Close any process "
+            "using it and try again."
+        )
+
+    code_verifier, code_challenge = generate_pkce()
+    state = secrets.token_urlsafe(16)
+
+    callback_url = f"http://127.0.0.1:{callback_port}{OPENROUTER_CALLBACK_PATH}"
+    auth_params = {
+        "callback_url": callback_url,
+        "code_challenge": code_challenge,
+        "code_challenge_method": "S256",
+        "state": state,
+        "key_label": key_label,
+    }
+    auth_url = f"{OPENROUTER_AUTH_URL}?{urlencode(auth_params)}"
+
+    # Reset shared state for this flow
+    _CallbackHandler.authorization_code = None
+    _CallbackHandler.error = None
+    _CallbackHandler.expected_state = state
+
+    server = http.server.HTTPServer(("127.0.0.1", callback_port), _CallbackHandler)
+    server_thread = threading.Thread(target=server.serve_forever, daemon=True)
+    server_thread.start()
+
+    try:
+        print(f"Opening browser to {OPENROUTER_AUTH_URL} ...")
+        try:
+            open_browser(auth_url)
+        except Exception as e:  # pragma: no cover — webbrowser is best-effort
+            logger.warning(f"Could not auto-open browser: {e}")
+        print(f"If the browser did not open, visit:\n  {auth_url}")
+        print(f"Waiting for callback on {callback_url} ...")
+
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            if _CallbackHandler.authorization_code or _CallbackHandler.error:
+                break
+            time.sleep(0.2)
+    finally:
+        server.shutdown()
+        server.server_close()
+
+    if _CallbackHandler.error:
+        raise OAuthError(f"OAuth callback error: {_CallbackHandler.error}")
+    if not _CallbackHandler.authorization_code:
+        raise OAuthError(f"OAuth flow timed out after {timeout:.0f}s")
+
+    code = _CallbackHandler.authorization_code
+    return _exchange_code_for_key(code, code_verifier)
+
+
+def _exchange_code_for_key(code: str, code_verifier: str) -> str:
+    """Exchange a PKCE code for a durable OpenRouter API key.
+
+    Returns the ``sk-or-...`` key string from the response.
+    """
+    response = requests.post(
+        OPENROUTER_TOKEN_URL,
+        json={
+            "code": code,
+            "code_verifier": code_verifier,
+            "code_challenge_method": "S256",
+        },
+        timeout=30,
+    )
+    if response.status_code != 200:
+        raise OAuthError(
+            f"OpenRouter token exchange failed: HTTP {response.status_code} — {response.text}"
+        )
+
+    try:
+        data = response.json()
+    except ValueError as e:
+        raise OAuthError(f"OpenRouter token response was not valid JSON: {e}") from e
+
+    key = data.get("key")
+    if not isinstance(key, str) or not key.startswith("sk-or-"):
+        raise OAuthError(
+            "OpenRouter token response did not include a usable 'key' field. "
+            f"Response: {data!r}"
+        )
+    return key

--- a/gptme/oauth/openrouter.py
+++ b/gptme/oauth/openrouter.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import base64
 import hashlib
+import html
 import http.server
 import logging
 import secrets
@@ -71,67 +72,69 @@ def is_port_available(port: int) -> bool:
             return False
 
 
-class _CallbackHandler(http.server.BaseHTTPRequestHandler):
-    """HTTP handler for the OpenRouter OAuth callback.
+def _make_callback_handler(state_holder: dict) -> type:
+    """Return a per-flow handler class whose state is isolated to ``state_holder``.
 
-    State is shared via class variables — only one OAuth flow may run on
-    OPENROUTER_CALLBACK_PORT at a time, which is enforced by the port check
-    in :func:`authenticate`.
+    Using a factory instead of class variables means two concurrent
+    ``authenticate()`` calls on different ports cannot corrupt each other's
+    CSRF state or authorization code.
     """
 
-    authorization_code: str | None = None
-    error: str | None = None
-    expected_state: str | None = None
+    class _Handler(http.server.BaseHTTPRequestHandler):
+        def log_message(self, format: str, *args: Any) -> None:
+            pass
 
-    def log_message(self, format: str, *args: Any) -> None:
-        pass
+        def do_GET(self) -> None:
+            parsed = urlparse(self.path)
 
-    def do_GET(self) -> None:
-        parsed = urlparse(self.path)
-
-        if parsed.path != OPENROUTER_CALLBACK_PATH:
-            self._respond_html(404, "Not found")
-            return
-
-        params = parse_qs(parsed.query)
-
-        # CSRF: validate state parameter when one was issued
-        if _CallbackHandler.expected_state is not None:
-            received_state = params.get("state", [None])[0]
-            if received_state != _CallbackHandler.expected_state:
-                _CallbackHandler.error = (
-                    "Invalid state parameter (possible CSRF attack)"
-                )
-                self._respond_html(400, "Security error: invalid state parameter")
+            if parsed.path != OPENROUTER_CALLBACK_PATH:
+                self._respond_html(404, "Not found")
                 return
 
-        if "code" in params:
-            _CallbackHandler.authorization_code = params["code"][0]
-            self._respond_html(
-                200, "Authentication successful. You can close this window."
-            )
-        elif "error" in params:
-            err_desc = params.get("error_description", params["error"])[0]
-            _CallbackHandler.error = err_desc
-            self._respond_html(400, f"Authentication failed: {err_desc}")
-        else:
-            self._respond_html(400, "No authorization code received")
+            params = parse_qs(parsed.query)
 
-    def _respond_html(self, status: int, message: str) -> None:
-        html = (
-            "<!DOCTYPE html><html><head>"
-            '<meta charset="utf-8"><title>gptme — OpenRouter</title>'
-            '</head><body style="font-family: system-ui; text-align: center; '
-            'padding: 50px; color: #222; background: #fafafa;">'
-            '<h1 style="font-size: 1.5em;">gptme</h1>'
-            f'<p style="font-size: 1.2em;">{message}</p>'
-            "<script>setTimeout(() => window.close(), 3000);</script>"
-            "</body></html>"
-        )
-        self.send_response(status)
-        self.send_header("Content-Type", "text/html; charset=utf-8")
-        self.end_headers()
-        self.wfile.write(html.encode())
+            # CSRF: validate state parameter when one was issued
+            if state_holder["expected_state"] is not None:
+                received_state = params.get("state", [None])[0]
+                if received_state != state_holder["expected_state"]:
+                    state_holder["error"] = (
+                        "Invalid state parameter (possible CSRF attack)"
+                    )
+                    self._respond_html(400, "Security error: invalid state parameter")
+                    return
+
+            if "code" in params:
+                state_holder["authorization_code"] = params["code"][0]
+                self._respond_html(
+                    200, "Authentication successful. You can close this window."
+                )
+            elif "error" in params:
+                err_desc = params.get("error_description", params["error"])[0]
+                state_holder["error"] = err_desc
+                # html.escape() prevents reflected injection from the error_description param
+                self._respond_html(
+                    400, f"Authentication failed: {html.escape(err_desc)}"
+                )
+            else:
+                self._respond_html(400, "No authorization code received")
+
+        def _respond_html(self, status: int, message: str) -> None:
+            body = (
+                "<!DOCTYPE html><html><head>"
+                '<meta charset="utf-8"><title>gptme — OpenRouter</title>'
+                '</head><body style="font-family: system-ui; text-align: center; '
+                'padding: 50px; color: #222; background: #fafafa;">'
+                '<h1 style="font-size: 1.5em;">gptme</h1>'
+                f'<p style="font-size: 1.2em;">{message}</p>'
+                "<script>setTimeout(() => window.close(), 3000);</script>"
+                "</body></html>"
+            )
+            self.send_response(status)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.end_headers()
+            self.wfile.write(body.encode())
+
+    return _Handler
 
 
 def authenticate(
@@ -175,39 +178,51 @@ def authenticate(
     }
     auth_url = f"{OPENROUTER_AUTH_URL}?{urlencode(auth_params)}"
 
-    # Reset shared state for this flow
-    _CallbackHandler.authorization_code = None
-    _CallbackHandler.error = None
-    _CallbackHandler.expected_state = state
+    # Per-flow state dict passed via closure — isolated from any concurrent flow
+    state_holder: dict = {
+        "authorization_code": None,
+        "error": None,
+        "expected_state": state,
+    }
+    handler_class = _make_callback_handler(state_holder)
 
-    server = http.server.HTTPServer(("127.0.0.1", callback_port), _CallbackHandler)
+    # Wrap HTTPServer construction to catch races between is_port_available() and bind()
+    try:
+        server = http.server.HTTPServer(("127.0.0.1", callback_port), handler_class)
+    except OSError as e:
+        raise OAuthError(
+            f"Port {callback_port} is not available. OpenRouter requires "
+            "this exact port for the OAuth callback. Close any process "
+            "using it and try again."
+        ) from e
+
     server_thread = threading.Thread(target=server.serve_forever, daemon=True)
     server_thread.start()
 
     try:
-        print(f"Opening browser to {OPENROUTER_AUTH_URL} ...")
+        logger.info(f"Opening browser to {OPENROUTER_AUTH_URL} ...")
         try:
             open_browser(auth_url)
         except Exception as e:  # pragma: no cover — webbrowser is best-effort
             logger.warning(f"Could not auto-open browser: {e}")
-        print(f"If the browser did not open, visit:\n  {auth_url}")
-        print(f"Waiting for callback on {callback_url} ...")
+        logger.info(f"If the browser did not open, visit:\n  {auth_url}")
+        logger.info(f"Waiting for callback on {callback_url} ...")
 
         deadline = time.time() + timeout
         while time.time() < deadline:
-            if _CallbackHandler.authorization_code or _CallbackHandler.error:
+            if state_holder["authorization_code"] or state_holder["error"]:
                 break
             time.sleep(0.2)
     finally:
         server.shutdown()
         server.server_close()
 
-    if _CallbackHandler.error:
-        raise OAuthError(f"OAuth callback error: {_CallbackHandler.error}")
-    if not _CallbackHandler.authorization_code:
+    if state_holder["error"]:
+        raise OAuthError(f"OAuth callback error: {state_holder['error']}")
+    if not state_holder["authorization_code"]:
         raise OAuthError(f"OAuth flow timed out after {timeout:.0f}s")
 
-    code = _CallbackHandler.authorization_code
+    code = state_holder["authorization_code"]
     return _exchange_code_for_key(code, code_verifier)
 
 

--- a/tests/test_oauth_openrouter.py
+++ b/tests/test_oauth_openrouter.py
@@ -1,0 +1,276 @@
+"""Tests for the OpenRouter PKCE OAuth flow."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import http.client
+import socket
+import threading
+import time
+from contextlib import contextmanager
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+from gptme.oauth import openrouter as orouter
+
+
+def _free_port() -> int:
+    """Pick a free localhost port for tests so we don't conflict with port 3000."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def test_generate_pkce_produces_valid_s256_pair() -> None:
+    verifier, challenge = orouter.generate_pkce()
+
+    assert isinstance(verifier, str) and len(verifier) >= 43
+    assert isinstance(challenge, str) and challenge
+
+    # The challenge must be the URL-safe base64 (no padding) of SHA-256(verifier)
+    expected = (
+        base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest())
+        .rstrip(b"=")
+        .decode()
+    )
+    assert challenge == expected
+
+
+def test_generate_pkce_is_random() -> None:
+    pairs = {orouter.generate_pkce() for _ in range(5)}
+    assert len(pairs) == 5
+
+
+def test_is_port_available_true_for_free_port() -> None:
+    assert orouter.is_port_available(_free_port()) is True
+
+
+def test_is_port_available_false_for_busy_port() -> None:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        s.listen(1)
+        busy_port = s.getsockname()[1]
+        assert orouter.is_port_available(busy_port) is False
+
+
+def test_authenticate_raises_when_port_busy() -> None:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        s.listen(1)
+        busy_port = s.getsockname()[1]
+        with pytest.raises(orouter.OAuthError, match="not available"):
+            orouter.authenticate(callback_port=busy_port, open_browser=lambda _u: True)
+
+
+@contextmanager
+def _run_flow_in_thread(
+    callback_port: int,
+    open_browser_fn,
+    *,
+    timeout: float = 5.0,
+) -> Iterator[dict[str, object]]:
+    """Drive ``authenticate`` in a background thread and yield its result."""
+    holder: dict[str, object] = {}
+
+    def target() -> None:
+        try:
+            holder["key"] = orouter.authenticate(
+                callback_port=callback_port,
+                open_browser=open_browser_fn,
+                timeout=timeout,
+            )
+        except Exception as e:
+            holder["error"] = e
+
+    t = threading.Thread(target=target)
+    t.start()
+    try:
+        yield holder
+    finally:
+        t.join(timeout=timeout + 2)
+
+
+def _send_callback(port: int, query: str) -> None:
+    """Hit the local callback server with a GET request."""
+    # Retry briefly while the server thread starts up
+    deadline = time.time() + 5.0
+    while time.time() < deadline:
+        try:
+            conn = http.client.HTTPConnection("127.0.0.1", port, timeout=2)
+            conn.request("GET", f"/callback?{query}")
+            conn.getresponse().read()
+            conn.close()
+            return
+        except OSError:
+            time.sleep(0.05)
+    raise AssertionError(f"Callback server on port {port} never came up")
+
+
+def test_authenticate_full_flow_exchanges_code_for_key() -> None:
+    port = _free_port()
+    captured: dict[str, object] = {}
+
+    def fake_open(url: str) -> bool:
+        captured["url"] = url
+        # Parse the state out of the auth URL so the callback can echo it back
+        from urllib.parse import parse_qs, urlparse
+
+        params = parse_qs(urlparse(url).query)
+        state = params["state"][0]
+        captured["state"] = state
+        captured["code_challenge"] = params["code_challenge"][0]
+        captured["code_challenge_method"] = params["code_challenge_method"][0]
+        captured["callback_url"] = params["callback_url"][0]
+
+        # Simulate the user signing in and OpenRouter redirecting to our server
+        threading.Thread(
+            target=_send_callback,
+            args=(port, f"code=ABCDEF&state={state}"),
+            daemon=True,
+        ).start()
+        return True
+
+    class FakeResponse:
+        status_code = 200
+
+        def json(self) -> dict[str, str]:
+            return {"key": "sk-or-test-12345"}
+
+    with (
+        patch.object(orouter.requests, "post", return_value=FakeResponse()) as post,
+        _run_flow_in_thread(port, fake_open) as holder,
+    ):
+        pass
+
+    assert holder.get("error") is None, holder.get("error")
+    assert holder["key"] == "sk-or-test-12345"
+    assert captured["code_challenge_method"] == "S256"
+    assert captured["callback_url"] == f"http://127.0.0.1:{port}/callback"
+
+    # Token exchange was called with the same verifier that derived the challenge
+    assert post.call_count == 1
+    payload = post.call_args.kwargs["json"]
+    assert payload["code"] == "ABCDEF"
+    assert payload["code_challenge_method"] == "S256"
+    derived = (
+        base64.urlsafe_b64encode(
+            hashlib.sha256(payload["code_verifier"].encode()).digest()
+        )
+        .rstrip(b"=")
+        .decode()
+    )
+    assert derived == captured["code_challenge"]
+
+
+def test_authenticate_rejects_state_mismatch() -> None:
+    port = _free_port()
+
+    def fake_open(_url: str) -> bool:
+        threading.Thread(
+            target=_send_callback,
+            args=(port, "code=ABC&state=tampered"),
+            daemon=True,
+        ).start()
+        return True
+
+    with _run_flow_in_thread(port, fake_open) as holder:
+        pass
+
+    err = holder.get("error")
+    assert isinstance(err, orouter.OAuthError)
+    assert "state" in str(err).lower()
+
+
+def test_authenticate_surfaces_provider_error() -> None:
+    port = _free_port()
+
+    def fake_open(url: str) -> bool:
+        from urllib.parse import parse_qs, urlparse
+
+        state = parse_qs(urlparse(url).query)["state"][0]
+        threading.Thread(
+            target=_send_callback,
+            args=(
+                port,
+                f"error=access_denied&error_description=user+cancelled&state={state}",
+            ),
+            daemon=True,
+        ).start()
+        return True
+
+    with _run_flow_in_thread(port, fake_open) as holder:
+        pass
+
+    err = holder.get("error")
+    assert isinstance(err, orouter.OAuthError)
+    assert "user cancelled" in str(err)
+
+
+def test_authenticate_token_exchange_failure_raises() -> None:
+    port = _free_port()
+
+    def fake_open(url: str) -> bool:
+        from urllib.parse import parse_qs, urlparse
+
+        state = parse_qs(urlparse(url).query)["state"][0]
+        threading.Thread(
+            target=_send_callback,
+            args=(port, f"code=XYZ&state={state}"),
+            daemon=True,
+        ).start()
+        return True
+
+    class FakeResponse:
+        status_code = 502
+        text = "bad gateway"
+
+        def json(self) -> dict[str, str]:  # pragma: no cover — not reached
+            return {}
+
+    with (
+        patch.object(orouter.requests, "post", return_value=FakeResponse()),
+        _run_flow_in_thread(port, fake_open) as holder,
+    ):
+        pass
+
+    err = holder.get("error")
+    assert isinstance(err, orouter.OAuthError)
+    assert "502" in str(err)
+
+
+def test_authenticate_rejects_response_without_key() -> None:
+    port = _free_port()
+
+    def fake_open(url: str) -> bool:
+        from urllib.parse import parse_qs, urlparse
+
+        state = parse_qs(urlparse(url).query)["state"][0]
+        threading.Thread(
+            target=_send_callback,
+            args=(port, f"code=XYZ&state={state}"),
+            daemon=True,
+        ).start()
+        return True
+
+    class FakeResponse:
+        status_code = 200
+        text = '{"unexpected": "shape"}'
+
+        def json(self) -> dict[str, str]:
+            return {"unexpected": "shape"}
+
+    with (
+        patch.object(orouter.requests, "post", return_value=FakeResponse()),
+        _run_flow_in_thread(port, fake_open) as holder,
+    ):
+        pass
+
+    err = holder.get("error")
+    assert isinstance(err, orouter.OAuthError)
+    assert "key" in str(err).lower()


### PR DESCRIPTION
## Summary

Adds a `gptme.oauth.openrouter` module that runs OpenRouter's dynamic OAuth/PKCE flow:

1. Generate PKCE verifier + S256 challenge
2. Open browser to `https://openrouter.ai/auth?...`
3. Listen for callback on `http://127.0.0.1:3000/callback`
4. Exchange the code at `https://openrouter.ai/api/v1/auth/keys`
5. Receive a durable `sk-or-...` API key

OpenRouter's flow needs **no client_id registration** on our side and returns a **permanent API key** (not a JWT), so the result is suitable for both interactive setup and headless automation.

## Why this exists

Foundation for the redesigned `/account setup openrouter` flow that #2313 originally asked for. Closed PR #2353 went the "swap raw API keys" route, which Erik pushed back on (["kinda meh and pointless"](https://github.com/gptme/gptme/pull/2353#issuecomment-4410173983)) — the more ambitious shape is OAuth-first onboarding so users go from `pip install gptme` to a working agent without ever pasting a key.

This PR ships **only the OAuth module** so the surface stays small and reviewable. The `/account` command wiring will land in a follow-up.

## Design notes

- Standalone module, zero coupling to the existing `llm_openai_subscription.py` flow (which is JWT-based and OpenAI-specific). No risk of regressing OpenAI subscription auth.
- `authenticate(open_browser=...)` accepts an injectable browser hook so the full happy path is testable without a real browser.
- CSRF state validation matches the existing OpenAI subscription handler's approach.
- Error surface is collapsed into one `OAuthError` — port-busy, callback errors, token-exchange failures, and malformed responses all raise the same exception type with a descriptive message.
- Port 3000 is fixed by OpenRouter (not configurable on their side); the module surfaces a clear error if it's busy.

## Test plan

- [x] `poetry run pytest tests/test_oauth_openrouter.py -v` — 10 passed
- [x] `poetry run ruff check gptme/oauth/ tests/test_oauth_openrouter.py` — All checks passed
- [x] `poetry run ruff format gptme/oauth/ tests/test_oauth_openrouter.py` — clean
- [x] `poetry run mypy gptme/oauth/openrouter.py` — Success: no issues found

Tests cover:
- PKCE S256 challenge derivation matches `urlsafe_b64encode(sha256(verifier))`
- PKCE generation is non-deterministic (5 distinct pairs in 5 calls)
- Port-busy detection (`is_port_available`)
- `authenticate()` raises `OAuthError` when port busy
- Full happy-path flow with mocked browser + mocked token exchange (verifier/challenge round-trip is verified)
- CSRF state mismatch is rejected
- Provider-side `error=...` callbacks surface the description verbatim
- Token-exchange HTTP failure raises `OAuthError`
- Token-exchange response without a `sk-or-...` key raises `OAuthError`

## Follow-up

A separate PR will wire this module into a `/account setup openrouter` command and store the issued key in the gptme credential config. That PR depends on this one but stays out of scope here so review can focus on the OAuth flow itself.

Refs: #2313 (original ask), #2353 (closed predecessor PR — different approach).