### PR TITLE
feat(commands): add /account provider onboarding with OAuth

### DIFF
--- a/gptme/commands/__init__.py
+++ b/gptme/commands/__init__.py
@@ -18,6 +18,7 @@ from .. import llm as _llm  # noqa: F401
 
 # Import command modules to register their commands
 from . import (  # noqa: F401
+    account,
     export,
     llm,
     meta,

--- a/gptme/commands/account.py
+++ b/gptme/commands/account.py
@@ -1,0 +1,214 @@
+"""Account management command for provider onboarding and status."""
+
+import logging
+from typing import cast
+
+from rich.prompt import Prompt
+
+from ..config import set_config_value
+from ..credentials import (
+    STORED_CREDENTIALS_SOURCE,
+    get_stored_api_key,
+    mask_secret,
+    set_stored_api_key,
+)
+from ..llm import PROVIDER_DEFAULT_MODELS, list_available_providers
+from ..llm.validate import validate_api_key
+from .base import CommandContext, command
+
+logger = logging.getLogger(__name__)
+
+MANUAL_SETUP_PROVIDERS = ("anthropic", "openai", "deepseek", "gemini", "groq", "xai")
+SETUP_PROVIDER_HELP = {
+    "openrouter": "Browser sign-in (OAuth / PKCE)",
+    "anthropic": "Paste API key",
+    "openai": "Paste API key",
+    "deepseek": "Paste API key",
+    "gemini": "Paste API key",
+    "groq": "Paste API key",
+    "xai": "Paste API key",
+}
+
+
+def _get_available_providers() -> list[tuple[str, str]]:
+    """List configured providers with their auth source."""
+    return sorted(
+        (str(provider), source) for provider, source in list_available_providers()
+    )
+
+
+def _get_active_provider() -> str | None:
+    """Detect the currently active provider."""
+    from ..llm.models import get_default_model
+
+    model = get_default_model()
+    if model:
+        return model.provider
+    return None
+
+
+def _switch_anthropic(api_key: str) -> None:
+    """Reinit Anthropic client with new key."""
+    from ..llm.llm_anthropic import reinit as reinit_anthropic
+
+    reinit_anthropic(api_key)
+    logger.debug("Anthropic client re-initialized")
+
+
+def _switch_openai_like(provider: str, api_key: str) -> None:
+    """Reinit OpenAI-compatible client with new key."""
+    from ..llm.llm_openai import reinit as reinit_openai
+    from ..llm.models.types import Provider
+
+    reinit_openai(cast(Provider, provider), api_key=api_key)
+    logger.debug("OpenAI client re-initialized for %s", provider)
+
+
+def _refresh_runtime_provider(provider: str, api_key: str) -> None:
+    """Update the in-memory client if the provider is already initialized."""
+    try:
+        if provider == "anthropic":
+            _switch_anthropic(api_key)
+        elif provider in ("openai", "openrouter", "deepseek", "gemini", "groq", "xai"):
+            _switch_openai_like(provider, api_key)
+    except ValueError:
+        logger.debug(
+            "Provider %s is not initialized in this session; skipping refresh", provider
+        )
+
+
+def _get_key_preview(provider: str, source: str) -> str:
+    """Render a safe preview for the configured auth source."""
+    from ..config import get_config
+
+    if source == STORED_CREDENTIALS_SOURCE:
+        api_key = get_stored_api_key(provider)
+        return mask_secret(api_key) if api_key else "-"
+    if source == "oauth":
+        return "token on disk"
+    api_key = get_config().get_env(source)
+    return mask_secret(api_key) if api_key else "-"
+
+
+def _select_setup_provider() -> str:
+    """Interactively choose a provider for `/account setup`."""
+    provider_items = list(SETUP_PROVIDER_HELP.items())
+    print("Choose a provider to set up:")
+    for idx, (provider, help_text) in enumerate(provider_items, start=1):
+        print(f"  {idx}. {provider:10s} {help_text}")
+
+    while True:
+        choice = Prompt.ask("Provider", default="1").strip().lower()
+        try:
+            index = int(choice) - 1
+        except ValueError:
+            index = -1
+        if 0 <= index < len(provider_items):
+            return provider_items[index][0]
+        if choice in SETUP_PROVIDER_HELP:
+            return choice
+        print(f"Unknown provider: {choice}")
+
+
+def _set_default_model(provider: str) -> None:
+    """Switch the default model to the provider's recommended default."""
+    model = PROVIDER_DEFAULT_MODELS.get(provider)
+    if not model:
+        return
+    set_config_value("env.MODEL", model)
+    print(f"Default model set to {model}.")
+
+
+def _setup_openrouter() -> None:
+    """Run the OpenRouter OAuth flow and persist the resulting key."""
+    from ..oauth.openrouter import OAuthError, authenticate
+
+    print("Starting OpenRouter browser sign-in...")
+    try:
+        api_key = authenticate()
+    except OAuthError as e:
+        print(f"OpenRouter OAuth failed: {e}")
+        return
+
+    path = set_stored_api_key("openrouter", api_key)
+    _refresh_runtime_provider("openrouter", api_key)
+    _set_default_model("openrouter")
+    print(f"Stored OpenRouter key in {path}.")
+
+
+def _setup_manual_provider(provider: str, provided_api_key: str | None = None) -> None:
+    """Prompt for a provider API key, validate it, and store it."""
+    api_key = (
+        provided_api_key or Prompt.ask(f"{provider} API key", password=True).strip()
+    )
+    if not api_key:
+        print("No API key provided.")
+        return
+
+    is_valid, message = validate_api_key(api_key, provider)
+    if not is_valid:
+        print(f"{provider} API key validation failed: {message}")
+        return
+
+    path = set_stored_api_key(provider, api_key)
+    _refresh_runtime_provider(provider, api_key)
+    _set_default_model(provider)
+    print(f"Stored {provider} key in {path}.")
+    if message:
+        print(message)
+
+
+def _list_accounts() -> None:
+    """Print configured provider credentials."""
+    available = _get_available_providers()
+    active = _get_active_provider()
+
+    if not available:
+        print("No configured provider credentials found.")
+        print("Run /account setup to add one.")
+        return
+
+    print(f"Configured accounts (active: {active or 'none'}):")
+    print()
+    for provider, source in available:
+        marker = " ◀ (active)" if provider == active else ""
+        preview = _get_key_preview(provider, source)
+        print(f"  {provider:18s} {source:16s} {preview}{marker}")
+
+
+@command("account", aliases=["creds"])
+def cmd_account(ctx: CommandContext):
+    """Show account status and run provider onboarding.
+
+    Usage:
+        /account
+        /account list
+        /account setup
+        /account setup openrouter
+        /account setup anthropic
+    """
+    if not ctx.args or ctx.args[0] == "list":
+        _list_accounts()
+        return
+
+    subcommand = ctx.args[0]
+
+    if subcommand == "setup":
+        provider = (
+            ctx.args[1].lower() if len(ctx.args) >= 2 else _select_setup_provider()
+        )
+        if provider == "openrouter":
+            _setup_openrouter()
+            return
+        if provider in MANUAL_SETUP_PROVIDERS:
+            _setup_manual_provider(
+                provider, provided_api_key=ctx.args[2] if len(ctx.args) >= 3 else None
+            )
+            return
+
+        print(f"Unknown provider: {provider}")
+        print("Supported: openrouter, anthropic, openai, deepseek, gemini, groq, xai")
+        return
+
+    print(f"Unknown subcommand: {subcommand}")
+    print("Usage: /account [list|setup [provider]]")

--- a/gptme/commands/account.py
+++ b/gptme/commands/account.py
@@ -138,6 +138,11 @@ def _setup_openrouter() -> None:
 
 def _setup_manual_provider(provider: str, provided_api_key: str | None = None) -> None:
     """Prompt for a provider API key, validate it, and store it."""
+    if provided_api_key:
+        print(
+            "Warning: passing keys inline is visible in conversation logs. "
+            "Use the interactive prompt instead."
+        )
     api_key = (
         provided_api_key or Prompt.ask(f"{provider} API key", password=True).strip()
     )

--- a/gptme/commands/account.py
+++ b/gptme/commands/account.py
@@ -136,16 +136,9 @@ def _setup_openrouter() -> None:
     print(f"Stored OpenRouter key in {path}.")
 
 
-def _setup_manual_provider(provider: str, provided_api_key: str | None = None) -> None:
+def _setup_manual_provider(provider: str) -> None:
     """Prompt for a provider API key, validate it, and store it."""
-    if provided_api_key:
-        print(
-            "Warning: passing keys inline is visible in conversation logs. "
-            "Use the interactive prompt instead."
-        )
-    api_key = (
-        provided_api_key or Prompt.ask(f"{provider} API key", password=True).strip()
-    )
+    api_key = Prompt.ask(f"{provider} API key", password=True).strip()
     if not api_key:
         print("No API key provided.")
         return
@@ -206,9 +199,13 @@ def cmd_account(ctx: CommandContext):
             _setup_openrouter()
             return
         if provider in MANUAL_SETUP_PROVIDERS:
-            _setup_manual_provider(
-                provider, provided_api_key=ctx.args[2] if len(ctx.args) >= 3 else None
-            )
+            if len(ctx.args) >= 3:
+                print(
+                    "Passing API keys on the command line is not supported. "
+                    f"Re-run `/account setup {provider}` and paste the key into the hidden prompt."
+                )
+                return
+            _setup_manual_provider(provider)
             return
 
         print(f"Unknown provider: {provider}")

--- a/gptme/credentials.py
+++ b/gptme/credentials.py
@@ -58,11 +58,14 @@ def set_stored_api_key(provider: str, api_key: str) -> Path:
         providers = tomlkit.table()
         doc["providers"] = providers
     providers[provider] = api_key
-    # Use os.open with mode 0o600 at creation time to avoid a world-readable window.
-    # open(path, "w") would create the file with umask permissions first, then chmod.
+    # Create with 0o600, then tighten existing files before writing new secrets.
     fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
-    with os.fdopen(fd, "w") as f:
+    if hasattr(os, "fchmod"):
+        os.fchmod(fd, 0o600)
+    with os.fdopen(fd, "w", encoding="utf-8") as f:
         tomlkit.dump(doc, f)
+    if not hasattr(os, "fchmod"):
+        path.chmod(0o600)
     return path
 
 

--- a/gptme/credentials.py
+++ b/gptme/credentials.py
@@ -58,9 +58,11 @@ def set_stored_api_key(provider: str, api_key: str) -> Path:
         providers = tomlkit.table()
         doc["providers"] = providers
     providers[provider] = api_key
-    with open(path, "w") as f:
+    # Use os.open with mode 0o600 at creation time to avoid a world-readable window.
+    # open(path, "w") would create the file with umask permissions first, then chmod.
+    fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w") as f:
         tomlkit.dump(doc, f)
-    path.chmod(0o600)
     return path
 
 

--- a/gptme/credentials.py
+++ b/gptme/credentials.py
@@ -1,0 +1,71 @@
+"""Persistent credential storage for provider API keys."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import tomlkit
+
+STORED_CREDENTIALS_SOURCE = "credentials.toml"
+
+
+def _get_credentials_path() -> Path:
+    """Return the path to gptme's persisted credential store."""
+    config_dir = Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config"))
+    config_dir = config_dir / "gptme"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    return config_dir / STORED_CREDENTIALS_SOURCE
+
+
+def _load_credentials_doc(path: Path | None = None):
+    path = path or _get_credentials_path()
+    if not path.exists():
+        return tomlkit.document()
+    with open(path) as f:
+        return tomlkit.load(f)
+
+
+def get_stored_api_key(provider: str) -> str | None:
+    """Return the stored API key for a provider, if present."""
+    doc = _load_credentials_doc()
+    providers = doc.get("providers")
+    if providers is None or not hasattr(providers, "get"):
+        return None
+    api_key = providers.get(provider)
+    return api_key if isinstance(api_key, str) and api_key else None
+
+
+def list_stored_credentials() -> list[tuple[str, str]]:
+    """List stored provider credentials as ``(provider, api_key)`` tuples."""
+    doc = _load_credentials_doc()
+    providers = doc.get("providers")
+    if providers is None or not hasattr(providers, "items"):
+        return []
+    return sorted(
+        (str(provider), api_key)
+        for provider, api_key in providers.items()
+        if isinstance(api_key, str) and api_key
+    )
+
+
+def set_stored_api_key(provider: str, api_key: str) -> Path:
+    """Persist an API key for ``provider`` and return the storage path."""
+    path = _get_credentials_path()
+    doc = _load_credentials_doc(path)
+    providers = doc.get("providers")
+    if providers is None or not hasattr(providers, "__setitem__"):
+        providers = tomlkit.table()
+        doc["providers"] = providers
+    providers[provider] = api_key
+    with open(path, "w") as f:
+        tomlkit.dump(doc, f)
+    path.chmod(0o600)
+    return path
+
+
+def mask_secret(secret: str) -> str:
+    """Render a short preview of a secret without exposing the full value."""
+    if len(secret) <= 8:
+        return "*" * len(secret)
+    return f"{secret[:4]}...{secret[-4:]}"

--- a/gptme/llm/__init__.py
+++ b/gptme/llm/__init__.py
@@ -614,24 +614,35 @@ def list_available_providers() -> list[tuple[Provider, str]]:
         auth_source is an env var name for API key providers, or "oauth" for
         OAuth-based providers like openai-subscription.
     """
+    from ..credentials import STORED_CREDENTIALS_SOURCE, list_stored_credentials
+
     config = get_config()
     available = []
+    seen: set[str] = set()
 
     for provider, env_var in PROVIDER_API_KEYS.items():
         if config.get_env(env_var):
             available.append((cast(Provider, provider), env_var))
+            seen.add(provider)
+
+    for provider, _api_key in list_stored_credentials():
+        if provider not in seen:
+            available.append((cast(Provider, provider), STORED_CREDENTIALS_SOURCE))
+            seen.add(provider)
 
     # Check OAuth-based providers (no API key, use token file)
     # Note: compute path directly to avoid side-effecting mkdir in _get_token_storage_path()
     _config_dir = Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config"))
     _token_path = _config_dir / "gptme" / "oauth" / "openai_subscription.json"
-    if _token_path.exists():
+    if _token_path.exists() and "openai-subscription" not in seen:
         available.append((cast(Provider, "openai-subscription"), "oauth"))
+        seen.add("openai-subscription")
 
     # Include plugin providers that have their API key configured
     for plugin_name, env_var in get_plugin_api_keys().items():
-        if config.get_env(env_var):
+        if config.get_env(env_var) and plugin_name not in seen:
             available.append((CustomProvider(plugin_name), env_var))
+            seen.add(plugin_name)
 
     return available
 

--- a/gptme/llm/llm_anthropic.py
+++ b/gptme/llm/llm_anthropic.py
@@ -538,8 +538,12 @@ def _init_anthropic(
 
     from anthropic import NOT_GIVEN, Anthropic  # fmt: skip
 
+    from ..config import get_config  # fmt: skip
+
+    config = get_config()
+
     # Get configurable API timeout (default: client's own default of 10 minutes)
-    timeout_str = os.environ.get("LLM_API_TIMEOUT")
+    timeout_str = config.get_env("LLM_API_TIMEOUT")
     try:
         timeout = float(timeout_str) if timeout_str else NOT_GIVEN
     except ValueError as parse_err:

--- a/gptme/llm/llm_anthropic.py
+++ b/gptme/llm/llm_anthropic.py
@@ -522,7 +522,9 @@ def reinit(
     Both streaming and non-streaming calls use the same module-level client,
     so the old client is discarded and replaced.
     """
-    _init_anthropic(api_key or "<missing>", proxy_url, proxy_key)
+    if not api_key:
+        raise ValueError("api_key must be a non-empty string")
+    _init_anthropic(api_key, proxy_url, proxy_key)
 
 
 def _init_anthropic(

--- a/gptme/llm/llm_anthropic.py
+++ b/gptme/llm/llm_anthropic.py
@@ -497,17 +497,47 @@ def retry_generator_on_overloaded(max_retries: int = 5, base_delay: float = 1.0)
 
 def init(config):
     global _anthropic, _is_proxy
+    from ..credentials import get_stored_api_key
+
     proxy_url = config.get_env("LLM_PROXY_URL", None)
     proxy_key = config.get_env("LLM_PROXY_API_KEY")
-    api_key = proxy_key or config.get_env_required("ANTHROPIC_API_KEY")
+    api_key = (
+        proxy_key
+        or config.get_env("ANTHROPIC_API_KEY")
+        or get_stored_api_key("anthropic")
+    )
+    if not api_key:
+        raise KeyError(
+            "Environment variable ANTHROPIC_API_KEY not set in env/config or credentials.toml"
+        )
+    _init_anthropic(api_key, proxy_url, proxy_key)
+
+
+def reinit(
+    api_key: str, proxy_url: str | None = None, proxy_key: str | None = None
+) -> None:
+    """Reinitialize the Anthropic client with a new API key at runtime.
+
+    Call this to switch credentials mid-session without restarting gptme.
+    Both streaming and non-streaming calls use the same module-level client,
+    so the old client is discarded and replaced.
+    """
+    _init_anthropic(api_key or "<missing>", proxy_url, proxy_key)
+
+
+def _init_anthropic(
+    api_key: str,
+    proxy_url: str | None = None,
+    proxy_key: str | None = None,
+) -> None:
+    global _anthropic, _is_proxy
+    proxy_key = proxy_key or None
+    proxy_url = proxy_url or None
 
     from anthropic import NOT_GIVEN, Anthropic  # fmt: skip
 
     # Get configurable API timeout (default: client's own default of 10 minutes)
-    # If not set explicitly via LLM_API_TIMEOUT, we use NOT_GIVEN to let the
-    # client use its own default behavior, which handles streaming vs non-streaming
-    # requests differently and may evolve with future client versions.
-    timeout_str = config.get_env("LLM_API_TIMEOUT")
+    timeout_str = os.environ.get("LLM_API_TIMEOUT")
     try:
         timeout = float(timeout_str) if timeout_str else NOT_GIVEN
     except ValueError as parse_err:

--- a/gptme/llm/llm_anthropic.py
+++ b/gptme/llm/llm_anthropic.py
@@ -523,7 +523,7 @@ def reinit(
     so the old client is discarded and replaced.
     """
     if not api_key:
-        raise ValueError("api_key must be a non-empty string")
+        raise ValueError("api_key must be non-empty")
     _init_anthropic(api_key, proxy_url, proxy_key)
 
 

--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -284,7 +284,9 @@ def reinit(provider: Provider, api_key: str) -> None:
         )
     if provider == "azure":
         raise ValueError("Runtime credential switch not supported for Azure")
-    _init_openai_client(provider, api_key=api_key)
+    existing = clients[provider]
+    base_url = str(existing.base_url) if getattr(existing, "base_url", None) else None
+    _init_openai_client(provider, api_key=api_key, base_url=base_url)
 
 
 def init(provider: Provider, config: Config):

--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -9,7 +9,7 @@ from functools import lru_cache, wraps
 from typing import TYPE_CHECKING, Any, TypedDict, cast
 
 import requests
-from openai import NOT_GIVEN
+from openai import NOT_GIVEN, NotGiven
 from typing_extensions import NotRequired
 
 from ..config import Config, get_config
@@ -40,6 +40,18 @@ if TYPE_CHECKING:
 # Dictionary to store clients for each provider (includes custom providers)
 clients: dict[Provider, "OpenAI"] = {}
 logger = logging.getLogger(__name__)
+
+
+def _get_provider_api_key(config: Config, provider: Provider, env_var: str) -> str:
+    """Resolve a provider key from env/config first, then credentials.toml."""
+    from ..credentials import get_stored_api_key
+
+    api_key = config.get_env(env_var) or get_stored_api_key(str(provider))
+    if api_key:
+        return api_key
+    raise KeyError(
+        f"Environment variable {env_var} not set in env/config or credentials.toml"
+    )
 
 
 # Type definitions for message dictionaries used in API transformations
@@ -217,6 +229,64 @@ def _make_response_format(output_schema):
     }
 
 
+def _init_openai_client(
+    provider: Provider,
+    api_key: str,
+    base_url: str | None = None,
+    timeout: float | NotGiven | None = None,
+) -> None:
+    """Internal helper to create and register an OpenAI client for a provider.
+
+    Handles Azure vs regular OpenAI client selection automatically.
+    """
+    from openai import AzureOpenAI, OpenAI  # fmt: skip
+
+    from ..config import get_config  # fmt: skip
+
+    config = get_config()
+
+    if timeout is None:
+        timeout_str = config.get_env("LLM_API_TIMEOUT")
+        try:
+            timeout = float(timeout_str) if timeout_str else NOT_GIVEN  # type: ignore[assignment]
+        except ValueError as parse_err:
+            raise ValueError(
+                f"Invalid LLM_API_TIMEOUT value: {timeout_str!r}. Must be a valid number."
+            ) from parse_err
+
+    if provider == "azure":
+        azure_endpoint = base_url or config.get_env_required("AZURE_OPENAI_ENDPOINT")
+        clients[provider] = AzureOpenAI(
+            api_key=api_key,
+            api_version="2023-07-01-preview",
+            azure_endpoint=azure_endpoint,
+            timeout=timeout,  # type: ignore[arg-type]
+        )
+    else:
+        clients[provider] = OpenAI(
+            api_key=api_key,
+            base_url=base_url or None,
+            timeout=timeout,  # type: ignore[arg-type]
+        )
+
+
+def reinit(provider: Provider, api_key: str) -> None:
+    """Reinitialize an OpenAI-compatible provider with a new API key at runtime.
+
+    This is the counterpart to ``init()`` for the ``/account`` command.
+    Currently only supports providers backed by a plain ``OpenAI`` client
+    (e.g. openai, openrouter, deepseek, groq, xai, gemini, custom providers).
+    Azure is not supported for runtime reinit.
+    """
+    if provider not in clients:
+        raise ValueError(
+            f"Cannot reinit provider {provider!r}: not currently initialized"
+        )
+    if provider == "azure":
+        raise ValueError("Runtime credential switch not supported for Azure")
+    _init_openai_client(provider, api_key=api_key)
+
+
 def init(provider: Provider, config: Config):
     """Initialize OpenAI client for a given provider."""
     from openai import AzureOpenAI, OpenAI  # fmt: skip
@@ -241,11 +311,9 @@ def init(provider: Provider, config: Config):
         ) from parse_err
 
     if provider == "openai":
-        api_key = proxy_key or config.get_env_required("OPENAI_API_KEY")
-        clients[provider] = OpenAI(
-            api_key=api_key,
-            base_url=proxy_url or None,
-            timeout=timeout,
+        api_key = proxy_key or _get_provider_api_key(config, provider, "OPENAI_API_KEY")
+        _init_openai_client(
+            provider, api_key=api_key, base_url=proxy_url or None, timeout=timeout
         )
     elif provider == "azure":
         api_key = config.get_env_required("AZURE_OPENAI_API_KEY")
@@ -257,7 +325,9 @@ def init(provider: Provider, config: Config):
             timeout=timeout,
         )
     elif provider == "openrouter":
-        api_key = proxy_key or config.get_env_required("OPENROUTER_API_KEY")
+        api_key = proxy_key or _get_provider_api_key(
+            config, provider, "OPENROUTER_API_KEY"
+        )
         clients[provider] = OpenAI(
             api_key=api_key,
             base_url=proxy_url or "https://openrouter.ai/api/v1",
@@ -274,29 +344,29 @@ def init(provider: Provider, config: Config):
             timeout=timeout,
         )
     elif provider == "gemini":
-        api_key = config.get_env_required("GEMINI_API_KEY")
+        api_key = _get_provider_api_key(config, provider, "GEMINI_API_KEY")
         clients[provider] = OpenAI(
             api_key=api_key,
             base_url="https://generativelanguage.googleapis.com/v1beta",
             timeout=timeout,
         )
     elif provider == "xai":
-        api_key = config.get_env_required("XAI_API_KEY")
+        api_key = _get_provider_api_key(config, provider, "XAI_API_KEY")
         clients[provider] = OpenAI(
             api_key=api_key, base_url="https://api.x.ai/v1", timeout=timeout
         )
     elif provider == "groq":
-        api_key = config.get_env_required("GROQ_API_KEY")
+        api_key = _get_provider_api_key(config, provider, "GROQ_API_KEY")
         clients[provider] = OpenAI(
             api_key=api_key, base_url="https://api.groq.com/openai/v1", timeout=timeout
         )
     elif provider == "deepseek":
-        api_key = config.get_env_required("DEEPSEEK_API_KEY")
+        api_key = _get_provider_api_key(config, provider, "DEEPSEEK_API_KEY")
         clients[provider] = OpenAI(
             api_key=api_key, base_url="https://api.deepseek.com/v1", timeout=timeout
         )
     elif provider == "nvidia":
-        api_key = config.get_env_required("NVIDIA_API_KEY")
+        api_key = _get_provider_api_key(config, provider, "NVIDIA_API_KEY")
         clients[provider] = OpenAI(
             api_key=api_key,
             base_url="https://integrate.api.nvidia.com/v1",

--- a/tests/test_commands_account.py
+++ b/tests/test_commands_account.py
@@ -101,13 +101,13 @@ def test_account_setup_prompts_for_provider_when_missing():
         if isinstance(result, Generator):
             list(result)
 
-    mock_setup.assert_called_once_with("anthropic", provided_api_key=None)
+    mock_setup.assert_called_once_with("anthropic")
 
 
-def test_account_setup_manual_provider_with_inline_key():
+def test_account_setup_manual_provider_dispatches():
     ctx = CommandContext(
-        args=["setup", "anthropic", "sk-ant-test"],
-        full_args="setup anthropic sk-ant-test",
+        args=["setup", "anthropic"],
+        full_args="setup anthropic",
         manager=_make_manager(),
     )
     with patch("gptme.commands.account._setup_manual_provider") as mock_setup:
@@ -115,7 +115,29 @@ def test_account_setup_manual_provider_with_inline_key():
         if isinstance(result, Generator):
             list(result)
 
-    mock_setup.assert_called_once_with("anthropic", provided_api_key="sk-ant-test")
+    mock_setup.assert_called_once_with("anthropic")
+
+
+def test_account_setup_manual_provider_rejects_inline_key():
+    ctx = CommandContext(
+        args=["setup", "anthropic", "sk-ant-test"],
+        full_args="setup anthropic sk-ant-test",
+        manager=_make_manager(),
+    )
+    with (
+        patch("gptme.commands.account._setup_manual_provider") as mock_setup,
+        patch("builtins.print") as mock_print,
+    ):
+        result = cmd_account(ctx)
+        if isinstance(result, Generator):
+            list(result)
+
+    mock_setup.assert_not_called()
+    printed = " ".join(
+        str(call.args[0]) for call in mock_print.call_args_list if call.args
+    )
+    assert "command line" in printed
+    assert "/account setup anthropic" in printed
 
 
 def test_setup_openrouter_stores_key_and_sets_default_model():

--- a/tests/test_commands_account.py
+++ b/tests/test_commands_account.py
@@ -1,0 +1,177 @@
+"""Tests for the /account command."""
+
+from collections.abc import Generator
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from gptme.commands.account import cmd_account
+from gptme.commands.base import CommandContext, _command_registry
+
+
+def _make_manager() -> MagicMock:
+    manager = MagicMock()
+    manager.log = MagicMock()
+    manager.log.messages = []
+    return manager
+
+
+def test_account_command_registered():
+    """The /account command is registered in the global registry."""
+    assert "account" in _command_registry
+
+
+def test_account_command_has_aliases():
+    """/account has /creds as an alias."""
+    assert "creds" in _command_registry
+
+
+def test_account_list_with_no_providers():
+    """/account with no available providers shows setup guidance."""
+    ctx = CommandContext(args=[], full_args="", manager=_make_manager())
+    with (
+        patch("gptme.commands.account._get_available_providers", return_value=[]),
+        patch("builtins.print") as mock_print,
+    ):
+        result = cmd_account(ctx)
+        if isinstance(result, Generator):
+            list(result)
+
+    printed = " ".join(
+        str(call.args[0]) for call in mock_print.call_args_list if call.args
+    )
+    assert "No configured provider credentials" in printed
+    assert "/account setup" in printed
+
+
+def test_account_list_with_providers():
+    """/account lists configured providers with safe previews."""
+    ctx = CommandContext(args=[], full_args="", manager=_make_manager())
+    with (
+        patch(
+            "gptme.commands.account._get_available_providers",
+            return_value=[
+                ("anthropic", "credentials.toml"),
+                ("openrouter", "OPENROUTER_API_KEY"),
+            ],
+        ),
+        patch("gptme.commands.account._get_active_provider", return_value="anthropic"),
+        patch(
+            "gptme.commands.account._get_key_preview",
+            side_effect=["sk-a...1234", "sk-o...5678"],
+        ),
+        patch("builtins.print") as mock_print,
+    ):
+        result = cmd_account(ctx)
+        if isinstance(result, Generator):
+            list(result)
+
+    printed = " ".join(
+        str(call.args[0]) for call in mock_print.call_args_list if call.args
+    )
+    assert "Configured accounts" in printed
+    assert "anthropic" in printed
+    assert "openrouter" in printed
+    assert "credentials.toml" in printed
+    assert "sk-a...1234" in printed
+
+
+def test_account_setup_openrouter_dispatches():
+    ctx = CommandContext(
+        args=["setup", "openrouter"],
+        full_args="setup openrouter",
+        manager=_make_manager(),
+    )
+    with patch("gptme.commands.account._setup_openrouter") as mock_setup:
+        result = cmd_account(ctx)
+        if isinstance(result, Generator):
+            list(result)
+
+    mock_setup.assert_called_once_with()
+
+
+def test_account_setup_prompts_for_provider_when_missing():
+    ctx = CommandContext(args=["setup"], full_args="setup", manager=_make_manager())
+    with (
+        patch(
+            "gptme.commands.account._select_setup_provider", return_value="anthropic"
+        ),
+        patch("gptme.commands.account._setup_manual_provider") as mock_setup,
+    ):
+        result = cmd_account(ctx)
+        if isinstance(result, Generator):
+            list(result)
+
+    mock_setup.assert_called_once_with("anthropic", provided_api_key=None)
+
+
+def test_account_setup_manual_provider_with_inline_key():
+    ctx = CommandContext(
+        args=["setup", "anthropic", "sk-ant-test"],
+        full_args="setup anthropic sk-ant-test",
+        manager=_make_manager(),
+    )
+    with patch("gptme.commands.account._setup_manual_provider") as mock_setup:
+        result = cmd_account(ctx)
+        if isinstance(result, Generator):
+            list(result)
+
+    mock_setup.assert_called_once_with("anthropic", provided_api_key="sk-ant-test")
+
+
+def test_setup_openrouter_stores_key_and_sets_default_model():
+    from gptme.commands.account import _setup_openrouter
+
+    with (
+        patch(
+            "gptme.oauth.openrouter.authenticate", return_value="sk-or-test-12345678"
+        ),
+        patch("gptme.commands.account.set_stored_api_key") as mock_store,
+        patch("gptme.commands.account._refresh_runtime_provider") as mock_refresh,
+        patch("gptme.commands.account._set_default_model") as mock_set_model,
+        patch("builtins.print"),
+    ):
+        _setup_openrouter()
+
+    mock_store.assert_called_once_with("openrouter", "sk-or-test-12345678")
+    mock_refresh.assert_called_once_with("openrouter", "sk-or-test-12345678")
+    mock_set_model.assert_called_once_with("openrouter")
+
+
+def test_setup_manual_provider_validates_and_stores():
+    from gptme.commands.account import _setup_manual_provider
+
+    with (
+        patch("rich.prompt.Prompt.ask", return_value="sk-ant-test-1234"),
+        patch(
+            "gptme.commands.account.validate_api_key",
+            return_value=(True, "Validated successfully"),
+        ),
+        patch(
+            "gptme.commands.account.set_stored_api_key",
+            return_value=Path("/tmp/credentials.toml"),
+        ) as mock_store,
+        patch("gptme.commands.account._refresh_runtime_provider") as mock_refresh,
+        patch("gptme.commands.account._set_default_model") as mock_set_model,
+        patch("builtins.print"),
+    ):
+        _setup_manual_provider("anthropic")
+
+    mock_store.assert_called_once_with("anthropic", "sk-ant-test-1234")
+    mock_refresh.assert_called_once_with("anthropic", "sk-ant-test-1234")
+    mock_set_model.assert_called_once_with("anthropic")
+
+
+def test_account_unknown_subcommand():
+    """/account with unknown subcommand shows an error."""
+    ctx = CommandContext(
+        args=["nonexistent"], full_args="nonexistent", manager=_make_manager()
+    )
+    with patch("builtins.print") as mock_print:
+        result = cmd_account(ctx)
+        if isinstance(result, Generator):
+            list(result)
+
+    printed = " ".join(
+        str(call.args[0]) for call in mock_print.call_args_list if call.args
+    )
+    assert "Unknown" in printed

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -27,6 +27,24 @@ def test_stored_credentials_permissions(monkeypatch, tmp_path: Path):
     assert oct(path.stat().st_mode & 0o777) == "0o600"
 
 
+def test_stored_credentials_existing_file_permissions_tightened(
+    monkeypatch, tmp_path: Path
+):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+    path = _get_credentials_path()
+    path.write_text("[providers]\nopenrouter = 'sk-or-old'\n", encoding="utf-8")
+    path.chmod(0o644)
+
+    set_stored_api_key("anthropic", "sk-ant-test")
+
+    assert oct(path.stat().st_mode & 0o777) == "0o600"
+    assert list_stored_credentials() == [
+        ("anthropic", "sk-ant-test"),
+        ("openrouter", "sk-or-old"),
+    ]
+
+
 def test_mask_secret():
     assert mask_secret("abcdefgh") == "********"
     assert mask_secret("sk-ant-12345678") == "sk-a...5678"

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+from gptme.credentials import (
+    _get_credentials_path,
+    get_stored_api_key,
+    list_stored_credentials,
+    mask_secret,
+    set_stored_api_key,
+)
+
+
+def test_stored_credentials_roundtrip(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+    path = set_stored_api_key("openrouter", "sk-or-test-12345678")
+
+    assert path == _get_credentials_path()
+    assert get_stored_api_key("openrouter") == "sk-or-test-12345678"
+    assert list_stored_credentials() == [("openrouter", "sk-or-test-12345678")]
+
+
+def test_stored_credentials_permissions(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+    path = set_stored_api_key("anthropic", "sk-ant-test")
+
+    assert oct(path.stat().st_mode & 0o777) == "0o600"
+
+
+def test_mask_secret():
+    assert mask_secret("abcdefgh") == "********"
+    assert mask_secret("sk-ant-12345678") == "sk-a...5678"

--- a/tests/test_credentials_integration.py
+++ b/tests/test_credentials_integration.py
@@ -1,0 +1,30 @@
+from unittest.mock import MagicMock, patch
+
+from gptme.credentials import set_stored_api_key
+from gptme.llm import list_available_providers
+from gptme.llm.llm_openai import _get_provider_api_key
+
+
+def test_list_available_providers_includes_credentials_store(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    set_stored_api_key("openrouter", "sk-or-test-12345678")
+
+    config = MagicMock()
+    config.get_env.return_value = None
+
+    with patch("gptme.llm.get_config", return_value=config):
+        available = {
+            (str(provider), source) for provider, source in list_available_providers()
+        }
+    assert ("openrouter", "credentials.toml") in available
+
+
+def test_get_provider_api_key_falls_back_to_credentials_store():
+    config = MagicMock()
+    config.get_env.return_value = None
+
+    with patch("gptme.credentials.get_stored_api_key", return_value="sk-or-test"):
+        assert (
+            _get_provider_api_key(config, "openrouter", "OPENROUTER_API_KEY")
+            == "sk-or-test"
+        )

--- a/tests/test_llm_anthropic.py
+++ b/tests/test_llm_anthropic.py
@@ -3,6 +3,7 @@ import os
 
 import pytest
 
+import gptme.llm.llm_anthropic as llm_anthropic
 from gptme.llm.llm_anthropic import (
     _HAS_OUTPUT_CONFIG,
     _adjust_thinking_budget,
@@ -16,6 +17,11 @@ from gptme.llm.llm_anthropic import (
 from gptme.message import Message
 from gptme.prompts import SYSTEM_PROMPT_CACHE_BOUNDARY
 from gptme.tools import get_tool, init_tools
+
+
+def test_reinit_requires_non_empty_api_key():
+    with pytest.raises(ValueError, match="api_key must be non-empty"):
+        llm_anthropic.reinit("")
 
 
 def test_message_conversion():

--- a/tests/test_llm_openai.py
+++ b/tests/test_llm_openai.py
@@ -523,6 +523,36 @@ def test_timeout_invalid_value(monkeypatch):
         llm_openai.init("openai", config)
 
 
+def test_reinit_preserves_existing_base_url(monkeypatch):
+    from types import SimpleNamespace
+
+    import gptme.llm.llm_openai as llm_openai
+
+    llm_openai.clients.clear()
+    llm_openai.clients["openrouter"] = SimpleNamespace(
+        base_url="https://openrouter.ai/api/v1"
+    )  # type: ignore[assignment]
+
+    captured: dict[str, str | None] = {}
+
+    def fake_init_openai_client(provider, api_key, base_url=None, timeout=None):
+        captured["provider"] = provider
+        captured["api_key"] = api_key
+        captured["base_url"] = base_url
+        captured["timeout"] = str(timeout) if timeout is not None else None
+
+    monkeypatch.setattr(llm_openai, "_init_openai_client", fake_init_openai_client)
+
+    llm_openai.reinit("openrouter", "sk-or-test-12345678")
+
+    assert captured == {
+        "provider": "openrouter",
+        "api_key": "sk-or-test-12345678",
+        "base_url": "https://openrouter.ai/api/v1",
+        "timeout": None,
+    }
+
+
 def test_message_conversion_gpt5_with_tool_results():
     """Test that gpt-5 models preserve tool result messages (system with call_id).
 


### PR DESCRIPTION
## Summary

Builds on the OpenRouter PKCE OAuth foundation from #2355 to add a proper `/account` command for provider onboarding.

- **`/account`** — show current provider and credential status
- **`/account setup openrouter`** — full PKCE OAuth flow: browser → localhost:3000 callback → key stored
- **`/account setup anthropic/openai/deepseek/gemini/groq/xai`** — manual key paste fallback for providers without OAuth
- **`/account list`** — list configured credentials with masked keys
- **`gptme/credentials.py`** — new `credentials.toml`-backed store with `0o600` permissions

New providers added via `/account setup` fall back to `credentials.toml` automatically (both `llm_openai.py` and `llm_anthropic.py` discovery updated). No breaking changes to existing env-var-based key handling.

Closes #2313

## Test plan

- [x] `tests/test_commands_account.py` — `/account` command dispatch
- [x] `tests/test_credentials.py` — credentials store unit tests
- [x] `tests/test_credentials_integration.py` — end-to-end store + provider loading
- [x] `tests/test_oauth_openrouter.py` — PKCE OAuth flow (from #2355)
- [x] 25 tests pass, mypy clean, ruff clean