### PR TITLE
feat(hooks): add mcp_namespace_hint hook for @server_name references

### DIFF
--- a/gptme/hooks/__init__.py
+++ b/gptme/hooks/__init__.py
@@ -180,6 +180,9 @@ def init_hooks(
         "agents_md_inject": lambda: __import__(
             "gptme.hooks.agents_md_inject", fromlist=["register"]
         ).register(),
+        "mcp_namespace_hint": lambda: __import__(
+            "gptme.hooks.mcp_namespace_hint", fromlist=["register"]
+        ).register(),
         # Tool confirmation hooks (mode-specific, not registered by default)
         "cli_confirm": lambda: __import__(
             "gptme.hooks.cli_confirm", fromlist=["register"]

--- a/gptme/hooks/mcp_namespace_hint.py
+++ b/gptme/hooks/mcp_namespace_hint.py
@@ -81,14 +81,12 @@ def mcp_namespace_hint(
         total = len(tools)
         lines.append(
             f"\nMCP tool hint for @{server_name}: {total} available tool(s). "
-            f"Use the full tool name (e.g. ``mcp__{server_name}__tool_name``).\n"
+            f"Use the full tool name (e.g. ``{server_name}.tool_name``).\n"
         )
         for tool in tools:
             desc = getattr(tool, "description", "") or ""
             name = getattr(tool, "name", "?")
-            desc_line = f"- `mcp__{server_name}__{name}`" + (
-                f": {desc}" if desc else ""
-            )
+            desc_line = f"- `{server_name}.{name}`" + (f": {desc}" if desc else "")
             lines.append(desc_line)
         lines.append("")
 

--- a/gptme/hooks/mcp_namespace_hint.py
+++ b/gptme/hooks/mcp_namespace_hint.py
@@ -1,0 +1,99 @@
+"""@server MCP namespace hint hook.
+
+Detects @server_name references in user messages and injects tool hints
+so the model knows which MCP tools are available for each server without
+memorizing the flat tool-name namespace.
+
+Gemini CLI feature: `@github list my open PRs` → model gets a tool-use hint.
+"""
+
+import re
+from collections.abc import Generator
+from logging import getLogger
+
+from gptme.message import Message
+
+from . import HookType, StopPropagation, register_hook
+
+logger = getLogger(__name__)
+
+# Match @name patterns — server names are alphanumeric + hyphens
+_MCP_HINT_RE = re.compile(r"@([\w][\w-]*)")
+
+
+def mcp_namespace_hint(
+    messages: list[Message],
+    **kwargs,
+) -> Generator[Message | StopPropagation, None, None]:
+    """Scan the last user message for @server_name and inject MCP tool hints.
+
+    When a user writes ``@github list my issues``, this hook detects ``github``
+    as an MCP server reference and appends a system message listing the
+    available tools on that server so the model can pick the right one.
+
+    Only fires when:
+    - The last user message contains ``@name`` references
+    - At least one reference matches a loaded MCP server
+    - The matched server has tools available
+    """
+    # Find the last user message
+    last_user: Message | None = None
+    for msg in reversed(messages):
+        if msg.role == "user":
+            last_user = msg
+            break
+
+    if not last_user or not last_user.content:
+        return
+
+    # Find @server_name references
+    refs = _MCP_HINT_RE.findall(last_user.content)
+    if not refs:
+        return
+
+    # Get loaded MCP servers and their tool listings
+    from gptme.tools.mcp_adapter import _dynamic_servers, _mcp_clients
+
+    all_clients: dict[str, object] = {**_mcp_clients, **_dynamic_servers}
+    if not all_clients:
+        return
+
+    # Match references to loaded servers (deduplicate via dict)
+    matched: dict[str, list[object]] = {}
+    for ref in refs:
+        if ref in all_clients:
+            client = all_clients[ref]
+            tools = getattr(client, "tools", None)
+            if tools is not None:
+                # tools is ListToolsResult; .tools gives list[Tool]
+                tool_list = getattr(tools, "tools", [])
+                if tool_list:
+                    matched[ref] = tool_list
+
+    if not matched:
+        return
+
+    # Build a compact hint message
+    lines: list[str] = []
+    for server_name, tools in matched.items():
+        total = len(tools)
+        lines.append(
+            f"\nMCP tool hint for @{server_name}: {total} available tool(s). "
+            f"Use the full tool name (e.g. ``mcp__{server_name}__tool_name``).\n"
+        )
+        for tool in tools:
+            desc = getattr(tool, "description", "") or ""
+            name = getattr(tool, "name", "?")
+            desc_line = f"- `mcp__{server_name}__{name}`" + (
+                f": {desc}" if desc else ""
+            )
+            lines.append(desc_line)
+        lines.append("")
+
+    hint = "\n".join(lines)
+    logger.debug(f"Injected MCP namespace hint for {list(matched.keys())}")
+    yield Message("system", hint)
+
+
+def register() -> None:
+    register_hook("mcp_namespace_hint", HookType.GENERATION_PRE, mcp_namespace_hint)

--- a/gptme/hooks/mcp_namespace_hint.py
+++ b/gptme/hooks/mcp_namespace_hint.py
@@ -18,7 +18,9 @@ from . import HookType, StopPropagation, register_hook
 logger = getLogger(__name__)
 
 # Match @name patterns — server names are alphanumeric + hyphens
-_MCP_HINT_RE = re.compile(r"@([\w][\w-]*)")
+# Match @name patterns — server names are alphanumeric + hyphens.
+# Negative lookbehind avoids false positives on email addresses (user@github.com).
+_MCP_HINT_RE = re.compile(r"(?<!\w)@([\w][\w-]*)")
 
 
 def mcp_namespace_hint(
@@ -52,9 +54,9 @@ def mcp_namespace_hint(
         return
 
     # Get loaded MCP servers and their tool listings
-    from gptme.tools.mcp_adapter import _dynamic_servers, _mcp_clients
+    from gptme.tools.mcp_adapter import get_mcp_clients
 
-    all_clients: dict[str, object] = {**_mcp_clients, **_dynamic_servers}
+    all_clients = get_mcp_clients()
     if not all_clients:
         return
 

--- a/gptme/tools/mcp_adapter.py
+++ b/gptme/tools/mcp_adapter.py
@@ -43,6 +43,16 @@ _registry = MCPRegistry()
 _dynamic_servers: dict[str, MCPClient] = {}
 
 
+def get_mcp_clients() -> dict[str, MCPClient]:
+    """Get all loaded MCP clients (pre-configured and dynamic).
+
+    Returns a merged view of all currently loaded MCP clients keyed by
+    server name. The hook layer uses this instead of importing private
+    module-level dicts directly.
+    """
+    return {**_mcp_clients, **_dynamic_servers}
+
+
 def _get_mcp_client(server_name: str) -> MCPClient | None:
     """Get MCP client from either pre-configured or dynamically loaded servers."""
     return _mcp_clients.get(server_name) or _dynamic_servers.get(server_name)

--- a/tests/test_hooks_mcp_namespace_hint.py
+++ b/tests/test_hooks_mcp_namespace_hint.py
@@ -89,10 +89,7 @@ class TestMcpNamespaceHint:
 
     def test_no_loaded_servers_yields_nothing(self):
         msgs = [Message("user", "@github list PRs")]
-        with (
-            patch("gptme.tools.mcp_adapter._mcp_clients", {}),
-            patch("gptme.tools.mcp_adapter._dynamic_servers", {}),
-        ):
+        with patch("gptme.tools.mcp_adapter.get_mcp_clients", return_value={}):
             results = list(mcp_namespace_hint(msgs))
         assert results == []
 

--- a/tests/test_hooks_mcp_namespace_hint.py
+++ b/tests/test_hooks_mcp_namespace_hint.py
@@ -79,7 +79,7 @@ class TestMcpNamespaceHint:
         hint = results[0]
         assert hint.role == "system"
         assert "github" in hint.content
-        assert "mcp__github__list_issues" in hint.content
+        assert "github.list_issues" in hint.content
         assert "List GitHub issues" in hint.content
 
     def test_at_ref_no_matching_server_yields_nothing(self):
@@ -103,8 +103,8 @@ class TestMcpNamespaceHint:
 
         assert len(results) == 1
         content = results[0].content
-        assert "mcp__github__list_issues" in content
-        assert "mcp__linear__create_ticket" in content
+        assert "github.list_issues" in content
+        assert "linear.create_ticket" in content
 
     def test_only_last_user_message_checked(self):
         client = _make_client(("list_issues", "List issues"))
@@ -131,7 +131,7 @@ class TestMcpNamespaceHint:
 
         assert len(results) == 1
         # Tool appears without description suffix
-        assert "mcp__myserver__ping`" in results[0].content
+        assert "myserver.ping`" in results[0].content
 
     def test_hint_format_contains_full_tool_name(self):
         client = _make_client(("do_thing", "Does a thing"))
@@ -139,6 +139,6 @@ class TestMcpNamespaceHint:
         results = _run(msgs, {"srv": client})
         content = results[0].content
         # Full namespaced name must appear
-        assert "mcp__srv__do_thing" in content
+        assert "srv.do_thing" in content
         # Description must appear
         assert "Does a thing" in content

--- a/tests/test_hooks_mcp_namespace_hint.py
+++ b/tests/test_hooks_mcp_namespace_hint.py
@@ -24,10 +24,7 @@ def _make_client(*tool_specs: tuple[str, str]) -> MagicMock:
 
 def _run(messages: list[Message], clients: dict) -> list[Message]:
     """Invoke the hook under a patched MCP adapter state."""
-    with (
-        patch("gptme.tools.mcp_adapter._mcp_clients", clients),
-        patch("gptme.tools.mcp_adapter._dynamic_servers", {}),
-    ):
+    with patch("gptme.tools.mcp_adapter.get_mcp_clients", return_value=clients):
         return [
             item
             for item in mcp_namespace_hint(messages)
@@ -52,6 +49,10 @@ class TestMcpHintRegex:
 
     def test_no_match_plain_text(self):
         assert _MCP_HINT_RE.findall("just some text here") == []
+
+    def test_no_false_positive_on_email_address(self):
+        # word char before @ means it's an email, not an MCP ref
+        assert _MCP_HINT_RE.findall("contact user@github.com for help") == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_hooks_mcp_namespace_hint.py
+++ b/tests/test_hooks_mcp_namespace_hint.py
@@ -1,0 +1,146 @@
+"""Tests for the MCP namespace hint hook."""
+
+from unittest.mock import MagicMock, patch
+
+from gptme.hooks import StopPropagation
+from gptme.hooks.mcp_namespace_hint import _MCP_HINT_RE, mcp_namespace_hint
+from gptme.message import Message
+
+
+def _make_client(*tool_specs: tuple[str, str]) -> MagicMock:
+    """Build a mock MCPClient with the given (name, description) tools."""
+    tools = []
+    for name, desc in tool_specs:
+        t = MagicMock()
+        t.name = name
+        t.description = desc
+        tools.append(t)
+    result = MagicMock()
+    result.tools = tools
+    client = MagicMock()
+    client.tools = result
+    return client
+
+
+def _run(messages: list[Message], clients: dict) -> list[Message]:
+    """Invoke the hook under a patched MCP adapter state."""
+    with (
+        patch("gptme.tools.mcp_adapter._mcp_clients", clients),
+        patch("gptme.tools.mcp_adapter._dynamic_servers", {}),
+    ):
+        return [
+            item
+            for item in mcp_namespace_hint(messages)
+            if not isinstance(item, StopPropagation)
+        ]
+
+
+# ---------------------------------------------------------------------------
+# Regex unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestMcpHintRegex:
+    def test_matches_simple_at_ref(self):
+        assert _MCP_HINT_RE.findall("@github list PRs") == ["github"]
+
+    def test_matches_hyphenated_name(self):
+        assert _MCP_HINT_RE.findall("use @my-server") == ["my-server"]
+
+    def test_matches_multiple_refs(self):
+        assert _MCP_HINT_RE.findall("@github and @linear") == ["github", "linear"]
+
+    def test_no_match_plain_text(self):
+        assert _MCP_HINT_RE.findall("just some text here") == []
+
+
+# ---------------------------------------------------------------------------
+# Hook behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestMcpNamespaceHint:
+    def test_no_messages_yields_nothing(self):
+        results = _run([], {})
+        assert results == []
+
+    def test_no_at_ref_yields_nothing(self):
+        msgs = [Message("user", "list my issues")]
+        results = _run(msgs, {"github": _make_client(("list_issues", "List issues"))})
+        assert results == []
+
+    def test_at_ref_matches_server_yields_hint(self):
+        client = _make_client(("list_issues", "List GitHub issues"))
+        msgs = [Message("user", "@github list my open PRs")]
+        results = _run(msgs, {"github": client})
+
+        assert len(results) == 1
+        hint = results[0]
+        assert hint.role == "system"
+        assert "github" in hint.content
+        assert "mcp__github__list_issues" in hint.content
+        assert "List GitHub issues" in hint.content
+
+    def test_at_ref_no_matching_server_yields_nothing(self):
+        msgs = [Message("user", "@unknown do something")]
+        results = _run(msgs, {"github": _make_client(("list_issues", ""))})
+        assert results == []
+
+    def test_no_loaded_servers_yields_nothing(self):
+        msgs = [Message("user", "@github list PRs")]
+        with (
+            patch("gptme.tools.mcp_adapter._mcp_clients", {}),
+            patch("gptme.tools.mcp_adapter._dynamic_servers", {}),
+        ):
+            results = list(mcp_namespace_hint(msgs))
+        assert results == []
+
+    def test_multiple_servers_in_one_message(self):
+        clients = {
+            "github": _make_client(("list_issues", "List issues")),
+            "linear": _make_client(("create_ticket", "Create ticket")),
+        }
+        msgs = [Message("user", "@github check PRs and @linear create a ticket")]
+        results = _run(msgs, clients)
+
+        assert len(results) == 1
+        content = results[0].content
+        assert "mcp__github__list_issues" in content
+        assert "mcp__linear__create_ticket" in content
+
+    def test_only_last_user_message_checked(self):
+        client = _make_client(("list_issues", "List issues"))
+        msgs = [
+            Message("user", "@github list PRs"),
+            Message("assistant", "Sure"),
+            Message("user", "just plain text"),
+        ]
+        results = _run(msgs, {"github": client})
+        # The last user message has no @ref, so nothing fires
+        assert results == []
+
+    def test_tool_without_description(self):
+        tool = MagicMock()
+        tool.name = "ping"
+        tool.description = ""
+        result = MagicMock()
+        result.tools = [tool]
+        client = MagicMock()
+        client.tools = result
+
+        msgs = [Message("user", "@myserver ping")]
+        results = _run(msgs, {"myserver": client})
+
+        assert len(results) == 1
+        # Tool appears without description suffix
+        assert "mcp__myserver__ping`" in results[0].content
+
+    def test_hint_format_contains_full_tool_name(self):
+        client = _make_client(("do_thing", "Does a thing"))
+        msgs = [Message("user", "@srv do the thing")]
+        results = _run(msgs, {"srv": client})
+        content = results[0].content
+        # Full namespaced name must appear
+        assert "mcp__srv__do_thing" in content
+        # Description must appear
+        assert "Does a thing" in content


### PR DESCRIPTION
## Summary

- Adds a new `mcp_namespace_hint` hook that fires on `GENERATION_PRE` when the last user message contains `@server_name` references matching loaded MCP servers
- Injects a compact system message listing available tools with their full `mcp__server__tool` names, so the model can pick the right tool without memorizing the flat namespace
- Mirrors Gemini CLI's `@`-mention UX for MCP server addressing

## Behaviour

```
User: @github list my open PRs

→ System: MCP tool hint for @github: 5 available tool(s). Use the full tool name (e.g. ``mcp__github__tool_name``).

- `mcp__github__list_issues`: List GitHub issues
- `mcp__github__list_pulls`: List pull requests
...
```

Hook only fires when:
- The last user message has `@name` references
- At least one reference matches a loaded MCP server
- That server has tools registered

## Test plan

- [x] 13 unit tests: regex, edge cases (no match, empty messages, no servers loaded), multi-server, tool-without-description, hint format
- [x] `make typecheck` clean
- [x] `uv run pytest tests/test_hooks_mcp_namespace_hint.py -q` — 13 passed