### PR TITLE
docs: describe account provider onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,11 +405,14 @@ This stack is simple and composable: selectors improve work choice, lessons stee
 ### Prerequisites
 
 - Python 3.10 or newer
-- An API key for at least one LLM provider:
-  - [Anthropic](https://console.anthropic.com/) (set `ANTHROPIC_API_KEY`)
-  - [OpenAI](https://platform.openai.com/) (set `OPENAI_API_KEY`)
-  - [OpenRouter](https://openrouter.ai/) (set `OPENROUTER_API_KEY`)
-  - Local models via `llama.cpp` (no key required — see [providers docs][docs-providers])
+- Credentials for at least one LLM provider:
+  - OpenRouter can be configured interactively with `/account setup openrouter`
+    inside gptme, using browser OAuth onboarding.
+  - You can also set API keys manually for [Anthropic](https://console.anthropic.com/)
+    (`ANTHROPIC_API_KEY`), [OpenAI](https://platform.openai.com/)
+    (`OPENAI_API_KEY`), [OpenRouter](https://openrouter.ai/)
+    (`OPENROUTER_API_KEY`), and other providers.
+  - Local models via `llama.cpp` need no key — see [providers docs][docs-providers].
 
 ### Installation
 

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -79,11 +79,21 @@ To select a provider and model, run ``gptme`` with the ``-m``/``--model`` flag s
     gptme "hello" -m local/llama3.2:1b
     gptme "hello" -m gptme/claude-sonnet-4-6
 
-You can list the models known to gptme using ``gptme '/models' - '/exit'``
+You can list the models known to gptme using ``gptme '/models' - '/exit'``.
 
-On first startup API key will be prompted for if no model and no API keys are set in the config/environment. The key will be saved in the configuration file, the provider will be inferred, and its default model used.
+To configure provider credentials interactively, run ``/account`` inside gptme:
 
-Use the ``[env]`` section in the :ref:`global-config` file to store API keys using the same format as the environment variables:
+.. code-block:: text
+
+    /account
+    /account setup
+    /account setup openrouter
+
+``/account setup openrouter`` starts browser-based OpenRouter sign-in using OAuth / PKCE, stores the resulting key in ``~/.config/gptme/credentials.toml``, and switches the default model to OpenRouter's recommended default.
+
+For providers without OAuth onboarding yet, ``/account setup <provider>`` prompts for the key without putting it in shell history and stores it in ``credentials.toml``. Supported manual providers currently include ``anthropic``, ``openai``, ``deepseek``, ``gemini``, ``groq``, and ``xai``.
+
+You can still use the ``[env]`` section in the :ref:`global-config` file to store API keys using the same format as the environment variables:
 
 - ``OPENAI_API_KEY="your-api-key"``
 - ``ANTHROPIC_API_KEY="your-api-key"``

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -91,7 +91,7 @@ To configure provider credentials interactively, run ``/account`` inside gptme:
 
 ``/account setup openrouter`` starts browser-based OpenRouter sign-in using OAuth / PKCE, stores the resulting key in ``~/.config/gptme/credentials.toml``, and switches the default model to OpenRouter's recommended default.
 
-For providers without OAuth onboarding yet, ``/account setup <provider>`` prompts for the key without putting it in shell history and stores it in ``~/.config/gptme/credentials.toml``. Supported manual providers currently include ``anthropic``, ``openai``, ``deepseek``, ``gemini``, ``groq``, and ``xai``.
+For providers without OAuth onboarding yet, ``/account setup <provider>`` prompts for the key without putting it in shell history and stores it in ``~/.config/gptme/credentials.toml`` (or ``$XDG_CONFIG_HOME/gptme/credentials.toml`` if set). Supported manual providers currently include ``anthropic``, ``openai``, ``deepseek``, ``gemini``, ``groq``, and ``xai``.
 
 You can still use the ``[env]`` section in the :ref:`global-config` file to store API keys using the same format as the environment variables:
 

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -91,7 +91,7 @@ To configure provider credentials interactively, run ``/account`` inside gptme:
 
 ``/account setup openrouter`` starts browser-based OpenRouter sign-in using OAuth / PKCE, stores the resulting key in ``~/.config/gptme/credentials.toml``, and switches the default model to OpenRouter's recommended default.
 
-For providers without OAuth onboarding yet, ``/account setup <provider>`` prompts for the key without putting it in shell history and stores it in ``credentials.toml``. Supported manual providers currently include ``anthropic``, ``openai``, ``deepseek``, ``gemini``, ``groq``, and ``xai``.
+For providers without OAuth onboarding yet, ``/account setup <provider>`` prompts for the key without putting it in shell history and stores it in ``~/.config/gptme/credentials.toml``. Supported manual providers currently include ``anthropic``, ``openai``, ``deepseek``, ``gemini``, ``groq``, and ``xai``.
 
 You can still use the ``[env]`` section in the :ref:`global-config` file to store API keys using the same format as the environment variables:
 


### PR DESCRIPTION
## Summary
- update README prerequisites to point OpenRouter users at `/account setup openrouter`
- document `/account setup` provider onboarding and `credentials.toml` storage in provider docs
- keep manual env/config key setup documented for existing workflows

## Verification
- `git diff --check`
- `uv run --with pytest pytest tests/test_commands_account.py -q`
- `python3 scripts/check_rst_formatting.py docs/`