### PR TITLE
feat(models): add preferred_edit_format field to model registry

### DIFF
--- a/gptme/llm/llm_openai_models.py
+++ b/gptme/llm/llm_openai_models.py
@@ -74,6 +74,8 @@ _OPENAI_MODELS_ACTIVE: dict[str, "_ModelDictMeta"] = {
         "price_output": 1.6,
         "supports_vision": True,
         "supports_parallel_tool_calls": True,
+        # "diff" despite "mini" in name — GPT-4.1-mini (Apr 2025) is a newer, more capable
+        # generation than gpt-4o-mini, with substantially better instruction-following.
         "preferred_edit_format": "diff",
         "knowledge_cutoff": datetime(2024, 6, 1, tzinfo=timezone.utc),
     },

--- a/gptme/llm/llm_openai_models.py
+++ b/gptme/llm/llm_openai_models.py
@@ -20,6 +20,7 @@ _OPENAI_MODELS_ACTIVE: dict[str, "_ModelDictMeta"] = {
         "supports_vision": True,
         "supports_reasoning": True,
         "supports_parallel_tool_calls": True,
+        "preferred_edit_format": "diff",
     },
     # GPT-5
     "gpt-5": {
@@ -30,6 +31,7 @@ _OPENAI_MODELS_ACTIVE: dict[str, "_ModelDictMeta"] = {
         "supports_vision": True,
         "supports_reasoning": True,
         "supports_parallel_tool_calls": True,
+        "preferred_edit_format": "diff",
         "knowledge_cutoff": datetime(2024, 9, 30, tzinfo=timezone.utc),
     },
     "gpt-5-mini": {
@@ -40,6 +42,7 @@ _OPENAI_MODELS_ACTIVE: dict[str, "_ModelDictMeta"] = {
         "supports_vision": True,
         "supports_reasoning": True,
         "supports_parallel_tool_calls": True,
+        "preferred_edit_format": "diff",
         "knowledge_cutoff": datetime(2024, 5, 31, tzinfo=timezone.utc),
     },
     "gpt-5-nano": {
@@ -50,6 +53,7 @@ _OPENAI_MODELS_ACTIVE: dict[str, "_ModelDictMeta"] = {
         "supports_vision": True,
         "supports_reasoning": True,
         "supports_parallel_tool_calls": True,
+        "preferred_edit_format": "whole",
         "knowledge_cutoff": datetime(2024, 5, 31, tzinfo=timezone.utc),
     },
     # GPT-4.1
@@ -60,6 +64,7 @@ _OPENAI_MODELS_ACTIVE: dict[str, "_ModelDictMeta"] = {
         "price_output": 8,
         "supports_vision": True,
         "supports_parallel_tool_calls": True,
+        "preferred_edit_format": "diff",
         "knowledge_cutoff": datetime(2024, 6, 1, tzinfo=timezone.utc),
     },
     "gpt-4.1-mini": {
@@ -69,6 +74,7 @@ _OPENAI_MODELS_ACTIVE: dict[str, "_ModelDictMeta"] = {
         "price_output": 1.6,
         "supports_vision": True,
         "supports_parallel_tool_calls": True,
+        "preferred_edit_format": "diff",
         "knowledge_cutoff": datetime(2024, 6, 1, tzinfo=timezone.utc),
     },
     "gpt-4.1-nano": {
@@ -78,6 +84,7 @@ _OPENAI_MODELS_ACTIVE: dict[str, "_ModelDictMeta"] = {
         "price_output": 0.4,
         "supports_vision": True,
         "supports_parallel_tool_calls": True,
+        "preferred_edit_format": "whole",
         "knowledge_cutoff": datetime(2024, 6, 1, tzinfo=timezone.utc),
     },
     # GPT-4o
@@ -87,6 +94,7 @@ _OPENAI_MODELS_ACTIVE: dict[str, "_ModelDictMeta"] = {
         "price_output": 15,
         "supports_vision": True,
         "supports_parallel_tool_calls": True,
+        "preferred_edit_format": "diff",
         # October 2023
         "knowledge_cutoff": datetime(2023, 10, 1, tzinfo=timezone.utc),
     },
@@ -96,6 +104,7 @@ _OPENAI_MODELS_ACTIVE: dict[str, "_ModelDictMeta"] = {
         "price_input": 0.15,
         "price_output": 0.6,
         "supports_vision": True,
+        "preferred_edit_format": "whole",
         "knowledge_cutoff": datetime(2023, 10, 1, tzinfo=timezone.utc),
     },
     # OpenAI o4-mini
@@ -106,6 +115,7 @@ _OPENAI_MODELS_ACTIVE: dict[str, "_ModelDictMeta"] = {
         "price_output": 4.4,
         "supports_vision": True,
         "supports_reasoning": True,
+        "preferred_edit_format": "diff",
     },
     # OpenAI o3
     "o3": {
@@ -115,6 +125,7 @@ _OPENAI_MODELS_ACTIVE: dict[str, "_ModelDictMeta"] = {
         "price_output": 8,
         "supports_vision": True,
         "supports_reasoning": True,
+        "preferred_edit_format": "diff",
     },
     "o3-mini": {
         "context": 200_000,
@@ -122,6 +133,7 @@ _OPENAI_MODELS_ACTIVE: dict[str, "_ModelDictMeta"] = {
         "price_input": 1.1,
         "price_output": 4.4,
         "supports_reasoning": True,
+        "preferred_edit_format": "diff",
     },
     # OpenAI o1
     "o1": {
@@ -130,6 +142,7 @@ _OPENAI_MODELS_ACTIVE: dict[str, "_ModelDictMeta"] = {
         "price_input": 15,
         "price_output": 60,
         "supports_reasoning": True,
+        "preferred_edit_format": "diff",
     },
 }
 
@@ -155,6 +168,7 @@ OPENAI_SUBSCRIPTION_MODELS: dict[str, "_ModelDictMeta"] = {
         "supports_vision": True,
         "supports_reasoning": True,
         "supports_parallel_tool_calls": True,
+        "preferred_edit_format": "diff",
     },
     # GPT-5.5 — flagship released April 2026, 1M context
     # https://developers.openai.com/api/docs/changelog
@@ -166,6 +180,7 @@ OPENAI_SUBSCRIPTION_MODELS: dict[str, "_ModelDictMeta"] = {
         "supports_vision": True,
         "supports_reasoning": True,
         "supports_parallel_tool_calls": True,
+        "preferred_edit_format": "diff",
     },
     # GPT-5.4 — latest flagship, 1M context
     "gpt-5.4": {
@@ -175,6 +190,7 @@ OPENAI_SUBSCRIPTION_MODELS: dict[str, "_ModelDictMeta"] = {
         "price_output": 15,
         "supports_vision": True,
         "supports_reasoning": True,
+        "preferred_edit_format": "diff",
         "knowledge_cutoff": datetime(2025, 8, 31, tzinfo=timezone.utc),
     },
     # GPT-5.3 Codex — top-tier agentic coding model
@@ -185,6 +201,7 @@ OPENAI_SUBSCRIPTION_MODELS: dict[str, "_ModelDictMeta"] = {
         "price_output": 14,
         "supports_vision": True,
         "supports_reasoning": True,
+        "preferred_edit_format": "diff",
         "knowledge_cutoff": datetime(2025, 8, 31, tzinfo=timezone.utc),
     },
     # GPT-5.3 Codex Spark — fast text-only coding (1000+ tok/s)
@@ -192,6 +209,7 @@ OPENAI_SUBSCRIPTION_MODELS: dict[str, "_ModelDictMeta"] = {
         "context": 128_000,
         "max_output": 128_000,
         "supports_reasoning": True,
+        "preferred_edit_format": "whole",
         "knowledge_cutoff": datetime(2025, 8, 31, tzinfo=timezone.utc),
     },
     # GPT-5.2
@@ -202,6 +220,7 @@ OPENAI_SUBSCRIPTION_MODELS: dict[str, "_ModelDictMeta"] = {
         "price_output": 14,
         "supports_vision": True,
         "supports_reasoning": True,
+        "preferred_edit_format": "diff",
         "knowledge_cutoff": datetime(2025, 8, 31, tzinfo=timezone.utc),
     },
     # GPT-5.2 Codex — agentic coding variant of 5.2
@@ -212,6 +231,7 @@ OPENAI_SUBSCRIPTION_MODELS: dict[str, "_ModelDictMeta"] = {
         "price_output": 14,
         "supports_vision": True,
         "supports_reasoning": True,
+        "preferred_edit_format": "diff",
         "knowledge_cutoff": datetime(2025, 8, 31, tzinfo=timezone.utc),
     },
     # GPT-5.1 Codex Max — multi-context-window compaction
@@ -222,6 +242,7 @@ OPENAI_SUBSCRIPTION_MODELS: dict[str, "_ModelDictMeta"] = {
         "price_output": 10,
         "supports_vision": True,
         "supports_reasoning": True,
+        "preferred_edit_format": "diff",
         "knowledge_cutoff": datetime(2024, 9, 30, tzinfo=timezone.utc),
     },
     # GPT-5.1 Codex — agentic coding variant of 5.1
@@ -232,6 +253,7 @@ OPENAI_SUBSCRIPTION_MODELS: dict[str, "_ModelDictMeta"] = {
         "price_output": 10,
         "supports_vision": True,
         "supports_reasoning": True,
+        "preferred_edit_format": "diff",
         "knowledge_cutoff": datetime(2024, 9, 30, tzinfo=timezone.utc),
     },
     # GPT-5.1 Codex Mini — smaller/cheaper coding variant
@@ -242,6 +264,7 @@ OPENAI_SUBSCRIPTION_MODELS: dict[str, "_ModelDictMeta"] = {
         "price_output": 2,
         "supports_vision": True,
         "supports_reasoning": True,
+        "preferred_edit_format": "diff",
         "knowledge_cutoff": datetime(2024, 9, 30, tzinfo=timezone.utc),
     },
     # GPT-5.1
@@ -252,6 +275,7 @@ OPENAI_SUBSCRIPTION_MODELS: dict[str, "_ModelDictMeta"] = {
         "price_output": 10,
         "supports_vision": True,
         "supports_reasoning": True,
+        "preferred_edit_format": "diff",
         "knowledge_cutoff": datetime(2024, 9, 30, tzinfo=timezone.utc),
     },
 }

--- a/gptme/llm/models/data.py
+++ b/gptme/llm/models/data.py
@@ -27,6 +27,7 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
             "supports_vision": True,
             "supports_reasoning": True,
             "supports_parallel_tool_calls": True,
+            "preferred_edit_format": "diff",
             "knowledge_cutoff": datetime(
                 2025, 8, 1, tzinfo=timezone.utc
             ),  # training cutoff Aug 2025
@@ -40,6 +41,7 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
             "supports_vision": True,
             "supports_reasoning": True,
             "supports_parallel_tool_calls": True,
+            "preferred_edit_format": "diff",
             "knowledge_cutoff": datetime(
                 2025, 8, 1, tzinfo=timezone.utc
             ),  # training cutoff Aug 2025, reliable May 2025
@@ -53,6 +55,7 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
             "supports_vision": True,
             "supports_reasoning": True,
             "supports_parallel_tool_calls": True,  # verified: emits multiple tool calls per response
+            "preferred_edit_format": "diff",
             "knowledge_cutoff": datetime(
                 2026, 1, 1, tzinfo=timezone.utc
             ),  # training cutoff Jan 2026, reliable Aug 2025
@@ -65,6 +68,7 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
             "supports_vision": True,
             "supports_reasoning": True,
             "supports_parallel_tool_calls": True,
+            "preferred_edit_format": "diff",
             "knowledge_cutoff": datetime(
                 2025, 8, 1, tzinfo=timezone.utc
             ),  # training cutoff Aug 2025, reliable May 2025
@@ -77,6 +81,7 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
             "supports_vision": True,
             "supports_reasoning": True,
             "supports_parallel_tool_calls": True,
+            "preferred_edit_format": "diff",
             "knowledge_cutoff": datetime(
                 2025, 7, 1, tzinfo=timezone.utc
             ),  # training cutoff Jul 2025, reliable Jan 2025
@@ -90,6 +95,7 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
             "supports_reasoning": True,
             # supports_parallel_tool_calls intentionally absent (defaults to False):
             # unlike Sonnet/Opus 4.5, Haiku 4.5 does not emit multiple tool calls per response
+            "preferred_edit_format": "diff",
             "knowledge_cutoff": datetime(
                 2025, 7, 1, tzinfo=timezone.utc
             ),  # "reliable cutoff" is Feb 2025
@@ -102,6 +108,7 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
             "supports_vision": True,
             "supports_reasoning": True,
             "supports_parallel_tool_calls": True,
+            "preferred_edit_format": "diff",
             "knowledge_cutoff": datetime(2025, 3, 1, tzinfo=timezone.utc),
         },
         "claude-opus-4-20250514": {
@@ -112,6 +119,7 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
             "supports_vision": True,
             "supports_reasoning": True,
             "supports_parallel_tool_calls": True,
+            "preferred_edit_format": "diff",
             "knowledge_cutoff": datetime(2025, 3, 1, tzinfo=timezone.utc),
         },
         "claude-sonnet-4-20250514": {
@@ -122,6 +130,7 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
             "supports_vision": True,
             "supports_reasoning": True,
             "supports_parallel_tool_calls": True,
+            "preferred_edit_format": "diff",
             "knowledge_cutoff": datetime(2025, 3, 1, tzinfo=timezone.utc),
         },
         # Deprecated models merged from separate file
@@ -234,12 +243,14 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
             # 10x better price for cache hits
             "price_input": 0.14,
             "price_output": 1.1,
+            "preferred_edit_format": "diff",
         },
         "deepseek-reasoner": {
             "context": 128_000,
             "max_output": 8192,
             "price_input": 0.55,
             "price_output": 2.19,
+            "preferred_edit_format": "diff",
         },
     },
     # https://groq.com/pricing/
@@ -249,6 +260,7 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
             "max_output": 32_768,
             "price_input": 0.59,
             "price_output": 0.79,
+            "preferred_edit_format": "diff",
         },
     },
     # https://docs.x.ai/docs/models
@@ -260,6 +272,7 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
             "price_output": 0.5,
             "supports_vision": True,
             "supports_reasoning": True,
+            "preferred_edit_format": "diff",
         },
         "grok-code-fast-1": {
             "context": 256_000,
@@ -267,6 +280,7 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
             "price_input": 0.2,
             "price_output": 1.5,
             "supports_reasoning": True,
+            "preferred_edit_format": "diff",
         },
         "grok-4-fast": {
             "context": 2_000_000,
@@ -275,6 +289,7 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
             "price_output": 0.5,
             "supports_reasoning": True,
             "supports_vision": True,
+            "preferred_edit_format": "diff",
         },
         "grok-4": {
             "context": 256_000,
@@ -283,6 +298,7 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
             "price_output": 15,
             "supports_reasoning": True,
             "supports_vision": True,
+            "preferred_edit_format": "diff",
         },
         "grok-3": {
             "context": 131_072,
@@ -291,6 +307,7 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
             "price_output": 15,
             "supports_reasoning": True,
             "supports_vision": True,
+            "preferred_edit_format": "diff",
         },
         "grok-3-mini": {
             "context": 131_072,
@@ -298,6 +315,7 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
             "price_input": 0.3,
             "price_output": 0.5,
             "supports_reasoning": True,
+            "preferred_edit_format": "diff",
         },
         "grok-2-vision-1212": {
             "context": 32_768,
@@ -305,6 +323,7 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
             "price_input": 2,
             "price_output": 10,
             "supports_vision": True,
+            "preferred_edit_format": "whole",
         },
     },
     "openrouter": {

--- a/gptme/llm/models/data.py
+++ b/gptme/llm/models/data.py
@@ -147,6 +147,7 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
             "price_output": 12,
             "supports_vision": True,
             "supports_reasoning": True,
+            "preferred_edit_format": "diff",
         },
         "gemini-3-pro-preview": {
             "context": 1_000_000,
@@ -155,6 +156,7 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
             "price_output": 12,
             "supports_vision": True,
             "supports_reasoning": True,
+            "preferred_edit_format": "diff",
         },
         "gemini-3-flash-preview": {
             "context": 1_000_000,
@@ -163,6 +165,7 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
             "price_output": 3,
             "supports_vision": True,
             "supports_reasoning": True,
+            "preferred_edit_format": "diff",
         },
         "gemini-2.0-flash": {
             "context": 1_048_576,
@@ -170,6 +173,7 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
             "price_input": 0.10,
             "price_output": 0.40,
             "supports_vision": True,
+            "preferred_edit_format": "whole",
         },
         "gemini-1.5-flash-latest": {
             "context": 1_048_576,
@@ -177,6 +181,7 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
             "price_input": 0.15,
             "price_output": 0.60,
             "supports_vision": True,
+            "preferred_edit_format": "whole",
         },
         "gemini-2.0-flash-thinking-exp-01-21": {
             "context": 1_048_576,
@@ -185,12 +190,14 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
             "price_output": 0.60,
             "supports_vision": True,
             "supports_reasoning": True,
+            "preferred_edit_format": "diff",
         },
         "gemini-2.0-flash-lite": {
             "context": 1_048_576,
             "max_output": 8192,
             "price_input": 0.075,
             "price_output": 0.30,
+            "preferred_edit_format": "whole",
         },
         "gemini-2.5-flash-preview-04-17": {
             "context": 1_048_576,
@@ -200,6 +207,7 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
             "price_output": 0.60,
             "supports_vision": True,
             "supports_reasoning": True,
+            "preferred_edit_format": "diff",
         },
         "gemini-2.5-pro-preview-05-06": {
             "context": 1_048_576,
@@ -209,6 +217,7 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
             "price_output": 10,
             "supports_vision": True,
             "supports_reasoning": True,
+            "preferred_edit_format": "diff",
         },
         "gemini-2.5-flash-lite": {
             "context": 1_000_000,
@@ -216,6 +225,7 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
             "price_input": 0.1,
             "price_output": 0.4,
             "supports_vision": True,
+            "preferred_edit_format": "whole",
         },
         "gemini-2.5-flash": {
             "context": 1_048_576,
@@ -224,6 +234,7 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
             "price_output": 2.5,
             "supports_vision": True,
             "supports_reasoning": True,
+            "preferred_edit_format": "diff",
         },
         "gemini-2.5-pro": {
             "context": 1_048_576,
@@ -233,6 +244,7 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
             "price_output": 10,
             "supports_vision": True,
             "supports_reasoning": True,
+            "preferred_edit_format": "diff",
         },
     },
     # https://api-docs.deepseek.com/quick_start/pricing

--- a/gptme/llm/models/listing.py
+++ b/gptme/llm/models/listing.py
@@ -37,6 +37,8 @@ def model_to_dict(model: ModelMeta) -> dict[str, Any]:
         d["knowledge_cutoff"] = model.knowledge_cutoff.isoformat()
     if model.deprecated:
         d["deprecated"] = True
+    if model.preferred_edit_format is not None:
+        d["preferred_edit_format"] = model.preferred_edit_format
     return d
 
 

--- a/gptme/llm/models/types.py
+++ b/gptme/llm/models/types.py
@@ -117,6 +117,13 @@ class ModelMeta:
     # preferred tool format for this model (used as fallback when not explicitly set)
     default_tool_format: "ToolFormat | None" = None
 
+    # preferred code-edit format for this model (hint: "diff" for patch/morph,
+    # "whole" for save/whole-file).  Derived from Aider's empirical per-model
+    # edit-format registry.  Used by callers that want to steer the model
+    # toward the format it handles best.
+    # See gptme/gptme#2362.
+    preferred_edit_format: str | None = None
+
     @property
     def full(self) -> str:
         # For unknown providers (including custom providers), the model field
@@ -210,3 +217,6 @@ class _ModelDictMeta(TypedDict):
 
     # preferred tool format for this model
     default_tool_format: NotRequired["ToolFormat"]
+
+    # preferred edit format for this model
+    preferred_edit_format: NotRequired[str]

--- a/gptme/llm/models/types.py
+++ b/gptme/llm/models/types.py
@@ -122,7 +122,7 @@ class ModelMeta:
     # edit-format registry.  Used by callers that want to steer the model
     # toward the format it handles best.
     # See gptme/gptme#2362.
-    preferred_edit_format: str | None = None
+    preferred_edit_format: Literal["diff", "whole"] | None = None
 
     @property
     def full(self) -> str:
@@ -219,4 +219,4 @@ class _ModelDictMeta(TypedDict):
     default_tool_format: NotRequired["ToolFormat"]
 
     # preferred edit format for this model
-    preferred_edit_format: NotRequired[str]
+    preferred_edit_format: NotRequired[Literal["diff", "whole"]]

--- a/tests/test_util_cli.py
+++ b/tests/test_util_cli.py
@@ -302,6 +302,7 @@ def test_models_list_json_suppresses_provider_noise(mocker):
                 price_output=None,
                 knowledge_cutoff=None,
                 deprecated=False,
+                preferred_edit_format=None,
             )
         ]
 
@@ -340,6 +341,7 @@ def test_models_list_json_available_keeps_plugin_models(mocker):
                 price_output=0,
                 knowledge_cutoff=None,
                 deprecated=False,
+                preferred_edit_format=None,
             )
         ],
     )


### PR DESCRIPTION
Add `preferred_edit_format` field to `ModelMeta` and populate it for all models in the registry, using Aider's empirical per-model edit-format data.

## What this does

- Adds `preferred_edit_format: str | None` to `ModelMeta` dataclass and `_ModelDictMeta` TypedDict
- Populates `preferred_edit_format` for all models in `llm_openai_models.py` and `models/data.py`
- Values: `"diff"` for strong reasoning models (Claude 4+, GPT-5, o1/o3/o4, DeepSeek), `"whole"` for weaker/smaller models (gpt-5-nano, gpt-4o-mini, gpt-4.1-nano)
- The field is a **hint**, not a constraint — downstream tool selection can use it to steer toward the edit format each model handles best

## Why

Strong reasoning models (Claude Opus, GPT-5-pro, o1) often have weak edit-block compliance but excellent planning ability. Smaller models (Qwen, mini/nano variants) fail hard on diff/patch format and need whole-file saves. Aider has 12+ months of empirical data on this and the community has largely converged on which models need which format. Adding this to our model registry is a cheap quality win.

## Related

- Closes: gptme/gptme#2362
- Source data: Aider's `aider/models.py` (`apply_generic_model_settings()`)
- Strategic context: Bob's `knowledge/research/2026-05-09-aider-peer-research.md` (idea #270, score 60)

## Verification

```python
>>> from gptme.llm.models import get_model
>>> get_model("anthropic/claude-opus-4-7").preferred_edit_format
"diff"
>>> get_model("openai/gpt-4o-mini").preferred_edit_format
"whole"
```