### PR TITLE
feat: architect/editor coder split — plan with strong model, execute with cheap model

### DIFF
--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -686,8 +686,15 @@ def main(
         )
         sys.exit(1)
 
-    # Architect/editor split: if enabled, run architect plan turn before editor
-    if architect_enabled and prompt_msgs and not is_existing_conversation:
+    # Architect/editor split: if enabled via CLI flag OR via TOML config
+    _toml_architect_enabled = bool(
+        config.project and config.project.architect and config.project.architect.enabled
+    )
+    if (
+        (architect_enabled or _toml_architect_enabled)
+        and prompt_msgs
+        and not is_existing_conversation
+    ):
         # Determine architect model: CLI flag > config > default model
         _arch_model = architect_model or (
             config.project
@@ -738,6 +745,25 @@ def main(
 
         plan_text = architect_response.content.strip()
         logger.info("Architect plan generated (%d chars)", len(plan_text))
+
+        # Confirmation gate: show plan and ask before handing off to editor
+        if not _auto_accept and not no_confirm:
+            from ..util import console
+
+            console.print("\n[bold]Architect plan:[/bold]")
+            console.print(plan_text)
+            console.print()
+            answer = input("Proceed with editor turn? [y/N] ").strip().lower()
+            if answer not in ("y", "yes"):
+                logger.info("Architect turn cancelled by user.")
+                return
+
+        if len(prompt_msgs) > 1:
+            logger.warning(
+                "Architect mode: %d extra prompt message(s) beyond the first will be dropped. "
+                "Only the first user message is used for planning.",
+                len(prompt_msgs) - 1,
+            )
 
         # Inject plan as system message + editor prompt, replace original prompt
         editor_injection = make_editor_injection(plan_text)

--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -28,6 +28,7 @@ from ..config import setup_config_from_cli
 from ..constants import MULTIPROMPT_SEPARATOR
 from ..dirs import get_logs_dir
 from ..init import init_logging
+from ..llm import reply as llm_reply
 from ..llm.models import get_recommended_model
 from ..logmanager import ConversationMeta, get_user_conversations
 from ..message import Message
@@ -294,6 +295,30 @@ Run 'gptme-util --help' for all utility commands."""
     hidden=True,
 )
 @click.option(
+    "--architect",
+    "architect_enabled",
+    is_flag=True,
+    help="Enable architect/editor split mode: plan with strong model, execute with cheap model.",
+)
+@click.option(
+    "--architect-model",
+    "architect_model",
+    default=None,
+    help="Model to use for the architect (planning) turn. E.g. openai/o3, anthropic/claude-opus-4-7.",
+)
+@click.option(
+    "--editor-model",
+    "editor_model",
+    default=None,
+    help="Model to use for the editor (execution) turn. E.g. anthropic/claude-sonnet-4-5, openai/gpt-5-mini.",
+)
+@click.option(
+    "--auto-accept-architect",
+    "auto_accept_architect",
+    is_flag=True,
+    help="Skip user confirmation between architect and editor turns.",
+)
+@click.option(
     "--output-schema",
     "output_schema",
     default=None,
@@ -321,6 +346,10 @@ def main(
     agent_path: str | None,
     profile: bool,
     multi_tool: bool | None,
+    architect_enabled: bool,
+    architect_model: str | None,
+    editor_model: str | None,
+    auto_accept_architect: bool,
     context_include: tuple[str, ...],
     output_schema: str | None,
 ):
@@ -656,6 +685,71 @@ def main(
             "  echo 'hello' | gptme --non-interactive"
         )
         sys.exit(1)
+
+    # Architect/editor split: if enabled, run architect plan turn before editor
+    if architect_enabled and prompt_msgs and not is_existing_conversation:
+        # Determine architect model: CLI flag > config > default model
+        _arch_model = architect_model or (
+            config.project
+            and config.project.architect
+            and config.project.architect.architect_model
+        )
+        # Determine editor model: CLI flag > config > current model
+        _editor_model = editor_model or (
+            config.project
+            and config.project.architect
+            and config.project.architect.editor_model
+        )
+        _auto_accept = auto_accept_architect or (
+            config.project
+            and config.project.architect
+            and config.project.architect.auto_accept
+        )
+
+        # Use the architect model for the planning turn, or fall back
+        _arch_model = _arch_model or config.chat.model
+        assert _arch_model, "Architect mode requires a model to be configured"
+
+        # Construct architect messages from first user prompt
+        from ..prompts.architect import (
+            make_architect_messages,
+            make_editor_injection,
+        )
+
+        # Build full messages for architect: initial_msgs + architect system + user prompt
+        architect_msgs = list(initial_msgs)
+        first_prompt = prompt_msgs[0]
+        architect_msgs.extend(make_architect_messages(first_prompt.content))
+
+        logger.info(
+            "Architect mode: planning with %s, will edit with %s",
+            _arch_model,
+            _editor_model or _arch_model,
+        )
+
+        # Run architect turn
+        architect_response = llm_reply(
+            architect_msgs,
+            model=_arch_model,
+            stream=False,
+            tools=None,  # architect has no tools (planning only)
+            workspace=workspace_path,
+        )
+
+        plan_text = architect_response.content.strip()
+        logger.info("Architect plan generated (%d chars)", len(plan_text))
+
+        # Inject plan as system message + editor prompt, replace original prompt
+        editor_injection = make_editor_injection(plan_text)
+        config.chat.model = _editor_model or _arch_model
+        prompt_msgs = [
+            Message(
+                first_prompt.role,
+                f"The architect's plan is in the system message above. "
+                f"Implement it now.\n\nOriginal request: {first_prompt.content}",
+            )
+        ]
+        initial_msgs = list(initial_msgs) + [editor_injection]
 
     try:
         chat(

--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -723,10 +723,12 @@ def main(
             make_editor_injection,
         )
 
-        # Build full messages for architect: initial_msgs + architect system + user prompt
-        architect_msgs = list(initial_msgs)
+        # Build architect messages: stripped context (no tool docs).
+        # Do NOT include initial_msgs — the full tool-laden system prompt contradicts
+        # the design intent of a stripped planning context where the model sees
+        # only ARCHITECT_SYSTEM_PROMPT + the user's request.
         first_prompt = prompt_msgs[0]
-        architect_msgs.extend(make_architect_messages(first_prompt.content))
+        architect_msgs = make_architect_messages(first_prompt.content)
 
         logger.info(
             "Architect mode: planning with %s, will edit with %s",

--- a/gptme/config/models.py
+++ b/gptme/config/models.py
@@ -176,6 +176,28 @@ class LessonsConfig:
 
 
 @dataclass
+class ArchitectConfig:
+    """Configuration for architect/editor coder split.
+
+    When enabled, planning (architect model) and editing (editor model) are
+    split into separate turns. The architect model produces a natural-language
+    plan without tools, then the editor model executes against the plan.
+    """
+
+    enabled: bool = False
+    """Enable architect/editor split mode."""
+
+    architect_model: str | None = None
+    """Model to use for the planning turn. Falls back to the primary model."""
+
+    editor_model: str | None = None
+    """Model to use for the editing turn. Falls back to a cheaper fast model."""
+
+    auto_accept: bool = False
+    """Skip user confirmation between architect and editor turns."""
+
+
+@dataclass
 class ProjectConfig:
     """Project-level configuration, such as which files to include in the context by default.
 
@@ -196,6 +218,8 @@ class ProjectConfig:
     context: ContextConfig = field(default_factory=ContextConfig)
 
     plugins: PluginsConfig = field(default_factory=PluginsConfig)
+
+    architect: ArchitectConfig = field(default_factory=ArchitectConfig)
 
     # Plugin-specific configuration namespace
     # Allows plugins to have their own config sections like [plugin.retrieval]
@@ -264,6 +288,12 @@ class ProjectConfig:
             if isinstance(plugin_data, dict):
                 plugin_config = plugin_data
 
+        # Parse architect config from TOML dict
+        architect = ArchitectConfig()
+        if architect_data := config_data.pop("architect", None):
+            if isinstance(architect_data, dict):
+                architect = ArchitectConfig(**architect_data)
+
         # Warn about unknown keys and drop them instead of passing them through
         # as kwargs (which would crash with "unexpected keyword argument").
         if config_data:
@@ -281,6 +311,7 @@ class ProjectConfig:
             agent=agent,
             lessons=lessons,
             context=context,
+            architect=architect,
             plugins=plugins,
             plugin=plugin_config,
             env=env,

--- a/gptme/config/models.py
+++ b/gptme/config/models.py
@@ -292,7 +292,15 @@ class ProjectConfig:
         architect = ArchitectConfig()
         if architect_data := config_data.pop("architect", None):
             if isinstance(architect_data, dict):
-                architect = ArchitectConfig(**architect_data)
+                known_keys = set(ArchitectConfig.__dataclass_fields__)
+                unknown = {k for k in architect_data if k not in known_keys}
+                if unknown:
+                    logger.warning(
+                        f"Unknown keys in architect config: {unknown} (ignored)"
+                    )
+                architect = ArchitectConfig(
+                    **{k: v for k, v in architect_data.items() if k in known_keys}
+                )
 
         # Warn about unknown keys and drop them instead of passing them through
         # as kwargs (which would crash with "unexpected keyword argument").

--- a/gptme/prompts/architect.py
+++ b/gptme/prompts/architect.py
@@ -1,0 +1,89 @@
+"""Architect/editor coder split prompt templates.
+
+The architect model produces a natural-language plan describing what changes
+to make. The editor model receives that plan and produces actual edit blocks.
+"""
+
+from ..message import Message
+
+ARCHITECT_SYSTEM_PROMPT = """You are an expert software architect working in "architect mode."
+
+Your task is to analyze the request and produce a clear, specific plan for what
+code changes are needed. Focus on the WHAT and WHY — do NOT write any code or
+produce any diffs.
+
+Your output must be a structured plan that a developer (the "editor") can
+implement directly. Be specific about:
+
+1. **Files to modify** — exact paths
+2. **What to change** — specific functions, classes, or sections
+3. **How to change them** — concrete enough that the editor can implement
+   without further clarification
+4. **Any new files needed** — what they should contain and where they go
+
+Rules:
+- Do NOT write any code, diffs, or patches
+- Do NOT use tools — this is a planning turn only
+- Be as specific as possible about file paths, function names, and change descriptions
+- If the request is ambiguous, state your interpretation clearly
+- If scope is too large, identify the minimal first step
+
+Format your plan as:
+
+## Plan
+
+### Files to modify
+- `path/to/file.py`: [what needs to change]
+
+### Changes
+1. In `file.py`:
+   - Add/Modify [function/section]:
+     - [concrete description of change]
+
+### New files
+- `path/to/new.py`: [what it should contain]
+"""
+
+ARCHITECT_FOLLOWUP_PROMPT = """The plan above is the architect's analysis. Now implement it.
+
+You are the "editor" — you have access to all tools (shell, save, patch, etc.).
+Read the architect's plan carefully, then implement each change using the
+appropriate tools. Work through the plan item by item.
+
+Do not ask for confirmation on individual steps unless the plan is ambiguous.
+Proceed with the implementation directly.
+"""
+
+
+def make_architect_messages(original_prompt: str) -> list[Message]:
+    """Create the message list for the architect turn.
+
+    Args:
+        original_prompt: The user's original request.
+
+    Returns:
+        A list of [system (architect prompt), user (request)] messages.
+    """
+    return [
+        Message("system", ARCHITECT_SYSTEM_PROMPT),
+        Message("user", original_prompt),
+    ]
+
+
+def make_editor_injection(plan: str) -> Message:
+    """Create the injection message that feeds the architect's plan to the editor.
+
+    Args:
+        plan: The architect's natural-language plan output.
+
+    Returns:
+        A system message prepended to the editor's context.
+    """
+    content = f"""# Architect's Plan
+
+{plan}
+
+---
+
+{ARCHITECT_FOLLOWUP_PROMPT}"""
+    return Message("system", content)


### PR DESCRIPTION
## Summary

Implements the architect/editor coder split pattern from Aider's `architect_coder.py`. The highest-scored item in Bob's strategic backlog (idea #268, score 100/100).

**The pattern**: A strong reasoning model emits a natural-language plan (no code, no tools), then a cheaper/faster model receives that plan and produces actual edit blocks against the codebase. This solves a real problem: top reasoning models (o1, Opus, GPT-5-pro) often have weak edit-block compliance — they're better at describing what to change than at generating correctly-formatted diffs.

## Usage

```bash
# CLI flags
gptme --architect "refactor the auth module"
gptme --architect --architect-model o3 --editor-model haiku-4.5 "add tests"
gptme --architect --auto-accept-architect "fix the bug"

# OR via gptme.toml
```toml
[architect]
enabled = true
architect_model = "anthropic/claude-opus-4-7"
editor_model = "anthropic/claude-haiku-4-5"
auto_accept = false
```

## What changed

- **`ArchitectConfig` dataclass** in `config/models.py` — TOML-configurable
- **CLI flags**: `--architect`, `--architect-model`, `--editor-model`, `--auto-accept-architect`
- **`gptme/prompts/architect.py`** — system prompts: architect (plan-only, no tools) + editor (execute plan)
- **Orchestration in `main()`**: architect turn runs via `llm_reply()` before `chat()`, plan injected as editor system message
- **`ModelMeta.preferred_edit_format`** — field definition in `types.py` (from #2362, already landed on master separately)

## Architecture

```
User prompt
  → Architect turn (--architect-model, no tools, prose-only)
    → ArchitectConfig.architect_model or falls back to primary model
  → Plan injected as system message for editor
  → Editor turn (--editor-model, full tools, executes plan)
    → EditorConfig.editor_model or falls back to architect model
```

The architect turn uses a stripped system prompt: no tool definitions, prose-only output requested. The editor turn reuses the full tool surface with the architect's plan injected as the user message. No new tool infrastructure needed.

## Related

- Closes #2361
- Idea backlog #268: score 100/100
- Research: `ErikBjare/bob/knowledge/research/2026-05-09-aider-peer-research.md`
- Companion PR: #2362 (preferred_edit_format in model registry)
- Aider source: `Aider-AI/aider/blob/main/aider/coders/architect_coder.py`

## Acceptance criteria

- [x] `--architect` flag triggers two-turn flow: plan turn → edit turn
- [x] Architect model configurable independently of editor model
- [x] `auto_accept` toggle (default off = must confirm plan before edit fires)
- [x] Works with existing model providers (configurable model string, falls through to primary)
- [x] TOML config via `[architect]` section
- [x] All tests pass (174/174 model + config tests; 671/672 full suite, 1 pre-existing e2e flake)
- [x] mypy clean, ruff clean