### PR TITLE
feat(serve): inject webui HTML rendering hint into system prompt

### DIFF
--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -530,6 +530,19 @@ def api_conversation_put(conversation_id: str):
         agent_path=chat_config.agent,
     )
 
+    # Inject output-format capability hint for webui mode
+    # gptme-webui renders ```html code blocks in a sandboxed iframe with
+    # Code/Preview tabs — inform the model so it can use HTML when it provides
+    # a richer experience for the reader.
+    msgs.append(
+        Message(
+            "system",
+            "Output format: you are in a web interface. "
+            "For interactive content (dashboards, tables, diagrams), "
+            "use ```html blocks — they render live in a sandboxed preview panel.",
+        )
+    )
+
     for role, content, timestamp in validated_msgs:
         msgs.append(Message(role, content, timestamp=timestamp))
 

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -535,7 +535,10 @@ def api_conversation_put(conversation_id: str):
     # Code/Preview tabs — inform the model so it can use HTML when it provides
     # a richer experience for the reader.
     # Set GPTME_SERVE_HTML_HINT=false to disable for non-webui API clients.
-    if os.environ.get("GPTME_SERVE_HTML_HINT", "true").lower() != "false":
+    if (
+        os.environ.get("GPTME_SERVE_HTML_HINT", "true").lower() != "false"
+        and prompt != "none"
+    ):
         msgs.append(
             Message(
                 "system",

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -534,14 +534,16 @@ def api_conversation_put(conversation_id: str):
     # gptme-webui renders ```html code blocks in a sandboxed iframe with
     # Code/Preview tabs — inform the model so it can use HTML when it provides
     # a richer experience for the reader.
-    msgs.append(
-        Message(
-            "system",
-            "Output format: you are in a web interface. "
-            "For interactive content (dashboards, tables, diagrams), "
-            "use ```html blocks — they render live in a sandboxed preview panel.",
+    # Set GPTME_SERVE_HTML_HINT=false to disable for non-webui API clients.
+    if os.environ.get("GPTME_SERVE_HTML_HINT", "true").lower() != "false":
+        msgs.append(
+            Message(
+                "system",
+                "Output format: you are in a web interface. "
+                "For interactive content (dashboards, tables, diagrams), "
+                "use ```html blocks — they render live in a sandboxed preview panel.",
+            )
         )
-    )
 
     for role, content, timestamp in validated_msgs:
         msgs.append(Message(role, content, timestamp=timestamp))

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -916,11 +916,12 @@ def test_v2_create_conversation_default_system_prompt(
     assert data is not None
     assert "log" in data
     assert (
-        len(data["log"]) == 2
-    )  # Only system prompt + user message (no workspace context)
+        len(data["log"]) == 3
+    )  # System prompt + webui hint + user message (no workspace context)
     assert data["log"][0]["role"] == "system"  # Primary system prompt
-    assert data["log"][1]["role"] == "user"
-    assert data["log"][1]["content"] == "Hello, this is a test message."
+    assert data["log"][1]["role"] == "system"  # Webui hint
+    assert data["log"][2]["role"] == "user"
+    assert data["log"][2]["content"] == "Hello, this is a test message."
 
     # Check that the system prompt is the default one
     prompt_msgs = get_prompt(
@@ -932,6 +933,57 @@ def test_v2_create_conversation_default_system_prompt(
         workspace=tmp_path,
     )
     assert data["log"][0]["content"] == prompt_msgs[0].content
+
+
+def test_v2_create_conversation_webui_html_hint(
+    client: FlaskClient, tmp_path, monkeypatch
+):
+    """Test that V2 conversations get the webui HTML output-format hint."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("GPTME_CHAT_HISTORY", "false")
+
+    from gptme.config import Config, set_config
+    from gptme.config.user import default_config
+
+    set_config(Config(user=default_config))
+    monkeypatch.setattr(
+        "gptme.prompts.workspace.config_path",
+        str(tmp_path / "config.toml"),
+    )
+
+    convname = f"test-server-v2-webui-hint-{random.randint(0, 1000000)}"
+    response = client.put(
+        f"/api/v2/conversations/{convname}",
+        json={
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "Hello from webui test",
+                    "timestamp": datetime.now(tz=timezone.utc).isoformat(),
+                }
+            ]
+        },
+    )
+    assert response.status_code == 200
+    conversation_id = response.get_json()["conversation_id"]
+
+    response = client.get(f"/api/v2/conversations/{conversation_id}")
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data is not None
+    system_msgs = [m for m in data["log"] if m["role"] == "system"]
+
+    # Check that the HTML rendering hint is in the system messages
+    hint_found = any(
+        "Output format:" in m["content"]
+        and "web interface" in m["content"]
+        and "```html" in m["content"]
+        for m in system_msgs
+    )
+    assert hint_found, (
+        f"WebUI HTML output hint not found in system messages. "
+        f"System contents: {[m['content'][:80] for m in system_msgs]}"
+    )
 
 
 def test_v2_conversation_post(v2_conv, client: FlaskClient):

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -878,6 +878,8 @@ def test_v2_create_conversation_default_system_prompt(
     monkeypatch.chdir(tmp_path)
     # Explicitly disable chat history for this test
     monkeypatch.setenv("GPTME_CHAT_HISTORY", "false")
+    # Pin env var so test is deterministic regardless of caller's environment
+    monkeypatch.setenv("GPTME_SERVE_HTML_HINT", "true")
 
     # Fully isolate from user config.
     # Patching gptme.config.config_path alone is insufficient because:
@@ -941,6 +943,7 @@ def test_v2_create_conversation_webui_html_hint(
     """Test that V2 conversations get the webui HTML output-format hint."""
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("GPTME_CHAT_HISTORY", "false")
+    monkeypatch.setenv("GPTME_SERVE_HTML_HINT", "true")
 
     from gptme.config import Config, set_config
     from gptme.config.user import default_config

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -986,6 +986,55 @@ def test_v2_create_conversation_webui_html_hint(
     )
 
 
+def test_v2_create_conversation_webui_html_hint_disabled(
+    client: FlaskClient, tmp_path, monkeypatch
+):
+    """Test that GPTME_SERVE_HTML_HINT=false suppresses the webui HTML hint."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("GPTME_CHAT_HISTORY", "false")
+    monkeypatch.setenv("GPTME_SERVE_HTML_HINT", "false")
+
+    from gptme.config import Config, set_config
+    from gptme.config.user import default_config
+
+    set_config(Config(user=default_config))
+    monkeypatch.setattr(
+        "gptme.prompts.workspace.config_path",
+        str(tmp_path / "config.toml"),
+    )
+
+    convname = f"test-server-v2-no-hint-{random.randint(0, 1000000)}"
+    response = client.put(
+        f"/api/v2/conversations/{convname}",
+        json={
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "Hello from non-webui client",
+                    "timestamp": datetime.now(tz=timezone.utc).isoformat(),
+                }
+            ]
+        },
+    )
+    assert response.status_code == 200
+    conversation_id = response.get_json()["conversation_id"]
+
+    response = client.get(f"/api/v2/conversations/{conversation_id}")
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data is not None
+    system_msgs = [m for m in data["log"] if m["role"] == "system"]
+
+    hint_found = any(
+        "Output format:" in m["content"] and "web interface" in m["content"]
+        for m in system_msgs
+    )
+    assert not hint_found, (
+        "WebUI HTML hint should be absent when GPTME_SERVE_HTML_HINT=false. "
+        f"System contents: {[m['content'][:80] for m in system_msgs]}"
+    )
+
+
 def test_v2_conversation_post(v2_conv, client: FlaskClient):
     """Test posting a message to a V2 conversation."""
     conversation_id = v2_conv["conversation_id"]


### PR DESCRIPTION
Closes gptme/gptme#2366

## Problem
gptme-webui already renders ```html code blocks in a sandboxed iframe preview with Code/Preview tabs (`TabbedCodeBlock.tsx`). But agents default to Markdown output because the system prompt says nothing about the rendering layer.

## Change
When creating a conversation via the V2 API (used by `gptme serve`), inject a short hint into the system prompt:

> Output format: you are in a web interface. For interactive content (dashboards, tables, diagrams), use ```html blocks — they render live in a sandboxed preview panel.

This is gated behind a `GPTME_SERVE_HTML_HINT` env var (default: true) with a dedicated test.

## Verification
- `test_v2_create_conversation_webui_html_hint`: new test that the hint appears in created conversations
- `test_v2_create_conversation_default_system_prompt`: existing test updated to account for the extra system message