### PR TITLE
feat(computer): add pluggable transport abstraction layer

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -160,6 +160,8 @@ nitpick_ignore = [
     # Hook confirmation system types
     ("py:class", "gptme.hooks.confirm.ToolConfirmHook"),
     ("py:class", "gptme.hooks.elicitation.ElicitationHook"),
+    # computer transport abstraction types
+    ("py:class", "Action"),
 ]
 
 # -- Options for HTML output -------------------------------------------------

--- a/gptme/tools/computer.py
+++ b/gptme/tools/computer.py
@@ -546,14 +546,18 @@ def _dispatch_transport(
         print(f"Moved mouse to {x},{y}")
         return None
 
-    click_map = {
-        "left_click": lambda: transport.left_click(),
-        "right_click": lambda: transport.right_click(),
-        "middle_click": lambda: transport.middle_click(),
-        "double_click": lambda: transport.double_click(),
-    }
-    if action in click_map:
-        click_map[action]()
+    click_actions = {"left_click", "right_click", "middle_click", "double_click"}
+    if action in click_actions:
+        if coordinate:
+            x, y = coordinate
+            transport.mouse_move(x, y)
+        click_fn = {
+            "left_click": transport.left_click,
+            "right_click": transport.right_click,
+            "middle_click": transport.middle_click,
+            "double_click": transport.double_click,
+        }[action]
+        click_fn()
         print(f"Performed {action}")
         return None
 

--- a/gptme/tools/computer.py
+++ b/gptme/tools/computer.py
@@ -133,6 +133,25 @@ class _ScalingSource(Enum):
     API = "api"
 
 
+def _get_api_resolution() -> tuple[int, int]:
+    """Return the configured API-space resolution (WIDTH/HEIGHT env or display-ratio defaults)."""
+    display_width, display_height = _get_display_resolution()
+    display_ratio = display_width / display_height
+    default_resolution: _Resolution | None = None
+    closest_ratio_diff = float("inf")
+    for res in MAX_SCALING_TARGETS.values():
+        ratio = res["width"] / res["height"]
+        ratio_diff = abs(ratio - display_ratio)
+        if ratio_diff < closest_ratio_diff:
+            closest_ratio_diff = ratio_diff
+            default_resolution = res
+    if default_resolution is None:
+        default_resolution = MAX_SCALING_TARGETS["XGA"]
+    width = int(os.getenv("WIDTH", str(default_resolution["width"])))
+    height = int(os.getenv("HEIGHT", str(default_resolution["height"])))
+    return width, height
+
+
 def _chunks(s: str, chunk_size: int) -> list[str]:
     """Split string into chunks for typing simulation."""
     return [s[i : i + chunk_size] for i in range(0, len(s), chunk_size)]
@@ -566,7 +585,7 @@ def computer(
     """
     # Optional transport-layer dispatch (env: GPTME_COMPUTER_TRANSPORT)
     transport = get_transport()
-    if transport and action != "screenshot":
+    if transport:
         return _dispatch_transport(transport, action, text, coordinate)
 
     display = os.getenv("DISPLAY", ":1")

--- a/gptme/tools/computer.py
+++ b/gptme/tools/computer.py
@@ -70,6 +70,8 @@ Examples:
 Using a single sequence for complex operations ensures proper timing and recognition of keyboard shortcuts.
 """
 
+from __future__ import annotations
+
 import logging
 import os
 import platform
@@ -77,12 +79,16 @@ import shlex
 import shutil
 import subprocess
 from enum import Enum
-from typing import Literal, TypedDict
+from typing import TYPE_CHECKING, Literal, TypedDict
 
-from ..message import Message
 from .base import ToolSpec, ToolUse
+from .computer_transport import get_transport
 from .screenshot import screenshot
 from .vision import view_image
+
+if TYPE_CHECKING:
+    from ..message import Message
+    from .computer_transport import ComputerTransport
 
 logger = logging.getLogger(__name__)
 
@@ -489,6 +495,64 @@ def _macos_drag(x: int, y: int) -> None:
         raise RuntimeError(f"Failed to drag: {e.stderr}") from e
 
 
+def _dispatch_transport(
+    transport: ComputerTransport,
+    action: Action,
+    text: str | None = None,
+    coordinate: tuple[int, int] | None = None,
+) -> Message | None:
+    """Route a computer action through the transport layer."""
+    if action == "key":
+        if not text:
+            raise ValueError("text is required for key")
+        transport.key(text)
+        print(f"Sent key sequence: {text}")
+        return None
+
+    if action == "type":
+        if not text:
+            raise ValueError("text is required for type")
+        transport.type_text(text)
+        print(f"Typed text: {text}")
+        return None
+
+    if action in ("mouse_move", "left_click_drag"):
+        if not coordinate:
+            raise ValueError(f"coordinate is required for {action}")
+        x, y = coordinate
+        if action == "mouse_move":
+            transport.mouse_move(x, y)
+        else:
+            transport.left_click_drag(x, y)
+        print(f"Moved mouse to {x},{y}")
+        return None
+
+    click_map = {
+        "left_click": lambda: transport.left_click(),
+        "right_click": lambda: transport.right_click(),
+        "middle_click": lambda: transport.middle_click(),
+        "double_click": lambda: transport.double_click(),
+    }
+    if action in click_map:
+        click_map[action]()
+        print(f"Performed {action}")
+        return None
+
+    if action == "screenshot":
+        path = transport.screenshot()
+        if path.exists():
+            return view_image(path)
+        print("Error: Screenshot failed")
+        return None
+
+    if action == "cursor_position":
+        x, y = transport.cursor_position()
+        print(f"Cursor position: X={x},Y={y}")
+        return None
+
+    raise ValueError(f"Invalid action: {action}")
+
+
 def computer(
     action: Action, text: str | None = None, coordinate: tuple[int, int] | None = None
 ) -> Message | None:
@@ -500,6 +564,11 @@ def computer(
         text: Text to type or key sequence to send
         coordinate: X,Y coordinates for mouse actions
     """
+    # Optional transport-layer dispatch (env: GPTME_COMPUTER_TRANSPORT)
+    transport = get_transport()
+    if transport and action != "screenshot":
+        return _dispatch_transport(transport, action, text, coordinate)
+
     display = os.getenv("DISPLAY", ":1")
     # Default API space resolution
     # Get actual display resolution and calculate aspect ratio

--- a/gptme/tools/computer.py
+++ b/gptme/tools/computer.py
@@ -541,9 +541,10 @@ def _dispatch_transport(
         x, y = coordinate
         if action == "mouse_move":
             transport.mouse_move(x, y)
+            print(f"Moved mouse to {x},{y}")
         else:
             transport.left_click_drag(x, y)
-        print(f"Moved mouse to {x},{y}")
+            print(f"Dragged to {x},{y}")
         return None
 
     click_actions = {"left_click", "right_click", "middle_click", "double_click"}

--- a/gptme/tools/computer_transport.py
+++ b/gptme/tools/computer_transport.py
@@ -262,13 +262,18 @@ class NativeComputerTransport(ComputerTransport):
         if IS_MACOS:
             import subprocess
 
-            output = subprocess.run(
-                ["cliclick", "p"],
-                capture_output=True,
-                text=True,
-                check=True,
-                timeout=10,
-            ).stdout.strip()
+            try:
+                output = subprocess.run(
+                    ["cliclick", "p"],
+                    capture_output=True,
+                    text=True,
+                    check=True,
+                    timeout=10,
+                ).stdout.strip()
+            except subprocess.TimeoutExpired as e:
+                raise RuntimeError("cliclick cursor position query timed out") from e
+            except subprocess.CalledProcessError as e:
+                raise RuntimeError(f"Failed to get cursor position: {e.stderr}") from e
             x, y = map(int, output.split(","))
         else:
             import os

--- a/gptme/tools/computer_transport.py
+++ b/gptme/tools/computer_transport.py
@@ -331,17 +331,21 @@ class CuaComputerTransport(ComputerTransport):
         """
         import asyncio
 
+        # Detect a running loop with a narrow try so we don't accidentally
+        # swallow RuntimeErrors raised by the coroutine itself.
         try:
             asyncio.get_running_loop()
-            # A loop is already running on this thread — delegate to a worker thread.
+            has_running_loop = True
+        except RuntimeError:
+            has_running_loop = False
+
+        if has_running_loop:
             import concurrent.futures
 
             with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
                 future: concurrent.futures.Future = pool.submit(asyncio.run, coro)  # type: ignore[arg-type]
                 return future.result()
-        except RuntimeError:
-            # No running loop — safe to call asyncio.run() directly.
-            return asyncio.run(coro)  # type: ignore[arg-type]
+        return asyncio.run(coro)  # type: ignore[arg-type]
 
     def key(self, text: str) -> None:
         self._ensure_sandbox()

--- a/gptme/tools/computer_transport.py
+++ b/gptme/tools/computer_transport.py
@@ -25,10 +25,6 @@ from __future__ import annotations
 
 import abc
 from pathlib import Path
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    pass
 
 
 class ComputerTransport(abc.ABC):
@@ -110,8 +106,7 @@ class NativeComputerTransport(ComputerTransport):
     def __init__(self) -> None:
         from .computer import IS_MACOS, _ensure_cliclick
 
-        self._is_macos = IS_MACOS
-        if self._is_macos:
+        if IS_MACOS:
             _ensure_cliclick()
 
     def key(self, text: str) -> None:

--- a/gptme/tools/computer_transport.py
+++ b/gptme/tools/computer_transport.py
@@ -138,8 +138,17 @@ class NativeComputerTransport(ComputerTransport):
             _linux_type(text, display)
 
     def mouse_move(self, x: int, y: int) -> None:
-        from .computer import IS_MACOS, _macos_mouse_move, _run_xdotool
+        from .computer import (
+            IS_MACOS,
+            _get_api_resolution,
+            _macos_mouse_move,
+            _run_xdotool,
+            _scale_coordinates,
+            _ScalingSource,
+        )
 
+        api_w, api_h = _get_api_resolution()
+        x, y = _scale_coordinates(_ScalingSource.API, x, y, api_w, api_h)
         if IS_MACOS:
             _macos_mouse_move(x, y)
         else:
@@ -199,8 +208,17 @@ class NativeComputerTransport(ComputerTransport):
             _run_xdotool("click --repeat 2 --delay 100 1", display)
 
     def left_click_drag(self, x: int, y: int) -> None:
-        from .computer import IS_MACOS, _macos_drag, _run_xdotool
+        from .computer import (
+            IS_MACOS,
+            _get_api_resolution,
+            _macos_drag,
+            _run_xdotool,
+            _scale_coordinates,
+            _ScalingSource,
+        )
 
+        api_w, api_h = _get_api_resolution()
+        x, y = _scale_coordinates(_ScalingSource.API, x, y, api_w, api_h)
         if IS_MACOS:
             _macos_drag(x, y)
         else:
@@ -274,24 +292,26 @@ class CuaComputerTransport(ComputerTransport):
     """
 
     def __init__(self) -> None:
-        self._sandbox: object | None = None  # typed as Any for attribute access
-        self._initialized: bool = False
-
-    def _ensure_sandbox(self) -> None:
-        """Lazy-init: import cua_sandbox and create a Docker sandbox."""
-        if self._initialized:
-            return
-
+        # Probe import eagerly so get_transport()'s try/except catches missing deps.
         try:
-            from cua_sandbox import (
-                Sandbox,  # type: ignore[import-untyped,import-not-found]
-            )
+            import cua_sandbox as _  # type: ignore[import-untyped,import-not-found] # noqa: F401
         except ImportError:
             raise RuntimeError(
                 "cua-sandbox not installed. Install with: pip install cua-sandbox"
             ) from None
+        self._sandbox: object | None = None  # typed as Any for attribute access
+        self._initialized: bool = False
+
+    def _ensure_sandbox(self) -> None:
+        """Lazy-init: create the Docker sandbox on first use."""
+        if self._initialized:
+            return
 
         import asyncio
+
+        from cua_sandbox import (
+            Sandbox,  # type: ignore[import-untyped,import-not-found]
+        )
 
         async def _create() -> object:
             sandbox = await Sandbox.create()
@@ -301,10 +321,25 @@ class CuaComputerTransport(ComputerTransport):
         self._initialized = True
 
     def _run_async(self, coro: object) -> object:
-        """Run an async cua call synchronously."""
+        """Run an async cua call synchronously.
+
+        Uses a thread pool when called from inside a running event loop (e.g.
+        gptme's server path) to avoid the 'This event loop is already running'
+        RuntimeError from asyncio.run().
+        """
         import asyncio
 
-        return asyncio.run(coro)  # type: ignore[arg-type]
+        try:
+            asyncio.get_running_loop()
+            # A loop is already running on this thread — delegate to a worker thread.
+            import concurrent.futures
+
+            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+                future: concurrent.futures.Future = pool.submit(asyncio.run, coro)  # type: ignore[arg-type]
+                return future.result()
+        except RuntimeError:
+            # No running loop — safe to call asyncio.run() directly.
+            return asyncio.run(coro)  # type: ignore[arg-type]
 
     def key(self, text: str) -> None:
         self._ensure_sandbox()
@@ -354,7 +389,11 @@ class CuaComputerTransport(ComputerTransport):
 
         async def _capture() -> Path:
             ss = await self._sandbox.screen.screenshot()  # type: ignore[attr-defined, union-attr]
-            path = Path(tempfile.mktemp(suffix=".png"))
+            fd, tmp = tempfile.mkstemp(suffix=".png")
+            import os as _os
+
+            _os.close(fd)
+            path = Path(tmp)
             ss.save(str(path))
             if width and height:
                 ss = ss.resize((width, height))

--- a/gptme/tools/computer_transport.py
+++ b/gptme/tools/computer_transport.py
@@ -385,7 +385,7 @@ class CuaComputerTransport(ComputerTransport):
 # ---------------------------------------------------------------------------
 
 _transport: ComputerTransport | None = None
-_transport_loaded: bool = False
+_transport_name: str | None = None  # env-var value the cache was built for
 
 
 def get_transport() -> ComputerTransport | None:
@@ -396,22 +396,32 @@ def get_transport() -> ComputerTransport | None:
     - ``native`` → ``NativeComputerTransport`` (explicit opt-in to
       transport-layer wrapper around xdotool/cliclick)
     - ``cua`` → ``CuaComputerTransport`` (Docker sandbox via cua-sandbox)
+
+    Caches the transport object.  Re-validates against the current env
+    var on every call so that tests can switch backends without process
+    restarts.
     """
-    global _transport, _transport_loaded
+    global _transport, _transport_name
 
-    if _transport_loaded:
-        return _transport
-
-    _transport_loaded = True
     import os
 
-    transport_name = os.getenv("GPTME_COMPUTER_TRANSPORT", "").strip()
-    if not transport_name:
+    current = os.getenv("GPTME_COMPUTER_TRANSPORT", "").strip()
+
+    # Cache hit — env var hasn't changed since last creation
+    if _transport is not None and _transport_name == current:
+        return _transport
+
+    # No transport requested
+    if not current:
+        _transport = None
+        _transport_name = None
         return None
 
-    if transport_name == "native":
+    _transport_name = current
+
+    if current == "native":
         _transport = NativeComputerTransport()
-    elif transport_name == "cua":
+    elif current == "cua":
         try:
             _transport = CuaComputerTransport()
         except RuntimeError as e:
@@ -428,7 +438,7 @@ def get_transport() -> ComputerTransport | None:
         logger = logging.getLogger(__name__)
         logger.warning(
             "Unknown GPTME_COMPUTER_TRANSPORT=%r; falling back to native",
-            transport_name,
+            current,
         )
         _transport = NativeComputerTransport()
 

--- a/gptme/tools/computer_transport.py
+++ b/gptme/tools/computer_transport.py
@@ -309,8 +309,6 @@ class CuaComputerTransport(ComputerTransport):
         if self._initialized:
             return
 
-        import asyncio
-
         from cua_sandbox import (
             Sandbox,  # type: ignore[import-untyped,import-not-found]
         )
@@ -319,7 +317,7 @@ class CuaComputerTransport(ComputerTransport):
             sandbox = await Sandbox.create()
             return sandbox
 
-        self._sandbox = asyncio.run(_create())
+        self._sandbox = self._run_async(_create())
         self._initialized = True
 
     def _run_async(self, coro: object) -> object:

--- a/gptme/tools/computer_transport.py
+++ b/gptme/tools/computer_transport.py
@@ -201,6 +201,8 @@ class NativeComputerTransport(ComputerTransport):
                 )
             except subprocess.TimeoutExpired as e:
                 raise RuntimeError("cliclick double-click timed out") from e
+            except subprocess.CalledProcessError as e:
+                raise RuntimeError(f"cliclick double-click failed: {e.stderr}") from e
         else:
             import os
 
@@ -450,9 +452,13 @@ def get_transport() -> ComputerTransport | None:
     if _transport is not None and _transport_name == current:
         return _transport
 
+    # Env var changed — close the stale transport to avoid resource leaks
+    if _transport is not None and _transport_name != current:
+        _transport.close()
+        _transport = None
+
     # No transport requested
     if not current:
-        _transport = None
         _transport_name = None
         return None
 

--- a/gptme/tools/computer_transport.py
+++ b/gptme/tools/computer_transport.py
@@ -478,13 +478,13 @@ def get_transport() -> ComputerTransport | None:
         _transport_name = None
         return None
 
-    _transport_name = current
-
     if current == "native":
         _transport = NativeComputerTransport()
+        _transport_name = current
     elif current == "cua":
         try:
             _transport = CuaComputerTransport()
+            _transport_name = current  # only cache on success
         except RuntimeError as e:
             import logging
 
@@ -493,6 +493,9 @@ def get_transport() -> ComputerTransport | None:
                 "CuaComputerTransport init failed: %s; falling back to native", e
             )
             _transport = NativeComputerTransport()
+            # Leave _transport_name as None so the next call retries CuaComputerTransport
+            # (allows recovery from transient failures like Docker not yet running)
+            _transport_name = None
     else:
         import logging
 
@@ -502,5 +505,6 @@ def get_transport() -> ComputerTransport | None:
             current,
         )
         _transport = NativeComputerTransport()
+        _transport_name = current
 
     return _transport

--- a/gptme/tools/computer_transport.py
+++ b/gptme/tools/computer_transport.py
@@ -251,7 +251,13 @@ class NativeComputerTransport(ComputerTransport):
         return path
 
     def cursor_position(self) -> tuple[int, int]:
-        from .computer import IS_MACOS, _run_xdotool
+        from .computer import (
+            IS_MACOS,
+            _get_api_resolution,
+            _run_xdotool,
+            _scale_coordinates,
+            _ScalingSource,
+        )
 
         if IS_MACOS:
             import subprocess
@@ -264,13 +270,16 @@ class NativeComputerTransport(ComputerTransport):
                 timeout=10,
             ).stdout.strip()
             x, y = map(int, output.split(","))
-            return x, y
-        import os
+        else:
+            import os
 
-        display = os.getenv("DISPLAY", ":1")
-        output = _run_xdotool("getmouselocation --shell", display)
-        x = int(output.split("X=")[1].split("\n")[0])
-        y = int(output.split("Y=")[1].split("\n")[0])
+            display = os.getenv("DISPLAY", ":1")
+            output = _run_xdotool("getmouselocation --shell", display)
+            x = int(output.split("X=")[1].split("\n")[0])
+            y = int(output.split("Y=")[1].split("\n")[0])
+
+        api_w, api_h = _get_api_resolution()
+        x, y = _scale_coordinates(_ScalingSource.COMPUTER, x, y, api_w, api_h)
         return x, y
 
     def close(self) -> None:

--- a/gptme/tools/computer_transport.py
+++ b/gptme/tools/computer_transport.py
@@ -1,0 +1,435 @@
+"""
+Transport abstraction for computer interaction.
+
+Provides a pluggable transport layer that allows gptme's computer tool
+to dispatch through different backends:
+
+- **Native** (xdotool+scrot or cliclick) — default, zero-dependency
+- **Cua Sandbox** — opt-in via ``GPTME_COMPUTER_TRANSPORT=cua`` env var
+
+Usage::
+
+    from gptme.tools.computer_transport import get_transport
+
+    transport = get_transport()
+    if transport:
+        transport.mouse_move(100, 200)
+        transport.left_click()
+        path = transport.screenshot()
+
+Architecture follows the two-layer abstraction from trycua/cua:
+Transport (command protocol) → Interface classes (typed surface).
+"""
+
+from __future__ import annotations
+
+import abc
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    pass
+
+
+class ComputerTransport(abc.ABC):
+    """ABC for the computer interaction transport layer.
+
+    Maps 1:1 to the action surface of ``computer()`` in ``computer.py``.
+    Each method corresponds to one ``Action`` literal.
+    """
+
+    @abc.abstractmethod
+    def key(self, text: str) -> None:
+        """Send a key sequence (e.g. 'Return', 'ctrl+c')."""
+        ...
+
+    @abc.abstractmethod
+    def type_text(self, text: str) -> None:
+        """Type text with realistic delays."""
+        ...
+
+    @abc.abstractmethod
+    def mouse_move(self, x: int, y: int) -> None:
+        """Move mouse to (x, y) in API-space coordinates."""
+        ...
+
+    @abc.abstractmethod
+    def left_click(self) -> None:
+        """Click left mouse button at current position."""
+        ...
+
+    @abc.abstractmethod
+    def right_click(self) -> None:
+        """Click right mouse button at current position."""
+        ...
+
+    @abc.abstractmethod
+    def middle_click(self) -> None:
+        """Click middle mouse button at current position."""
+        ...
+
+    @abc.abstractmethod
+    def double_click(self) -> None:
+        """Double-click left mouse button at current position."""
+        ...
+
+    @abc.abstractmethod
+    def left_click_drag(self, x: int, y: int) -> None:
+        """Click and drag from current position to (x, y)."""
+        ...
+
+    @abc.abstractmethod
+    def screenshot(self, width: int = 0, height: int = 0) -> Path:
+        """Capture and save a screenshot. Returns path to the image file."""
+        ...
+
+    @abc.abstractmethod
+    def cursor_position(self) -> tuple[int, int]:
+        """Return current cursor position as (x, y) in API-space."""
+        ...
+
+    @abc.abstractmethod
+    def close(self) -> None:
+        """Release any resources held by this transport."""
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Native transport: delegates to existing xdotool/cliclick helpers
+# ---------------------------------------------------------------------------
+
+
+class NativeComputerTransport(ComputerTransport):
+    """Default transport: xdotool+scrot (Linux) / cliclick (macOS).
+
+    Thin wrapper around the existing helpers in ``computer.py``.
+    Provides the transport interface without changing the underlying
+    subprocess dispatch.
+    """
+
+    def __init__(self) -> None:
+        from .computer import IS_MACOS, _ensure_cliclick
+
+        self._is_macos = IS_MACOS
+        if self._is_macos:
+            _ensure_cliclick()
+
+    def key(self, text: str) -> None:
+        from .computer import _linux_handle_key_sequence, _macos_key, IS_MACOS  # noqa
+
+        if IS_MACOS:
+            _macos_key(text)
+        else:
+            import os
+
+            display = os.getenv("DISPLAY", ":1")
+            _linux_handle_key_sequence(text, display)
+
+    def type_text(self, text: str) -> None:
+        from .computer import IS_MACOS, _chunks, _linux_type, _macos_type
+
+        if IS_MACOS:
+            for chunk in _chunks(text, 50):
+                _macos_type(chunk)
+        else:
+            import os
+
+            display = os.getenv("DISPLAY", ":1")
+            _linux_type(text, display)
+
+    def mouse_move(self, x: int, y: int) -> None:
+        from .computer import IS_MACOS, _macos_mouse_move, _run_xdotool
+
+        if IS_MACOS:
+            _macos_mouse_move(x, y)
+        else:
+            import os
+
+            display = os.getenv("DISPLAY", ":1")
+            _run_xdotool(f"mousemove --sync {x} {y}", display)
+
+    def left_click(self) -> None:
+        self._click(1)
+
+    def right_click(self) -> None:
+        self._click(3)
+
+    def middle_click(self) -> None:
+        self._click(2)
+
+    def _click(self, button: int) -> None:
+        from .computer import IS_MACOS, _macos_click, _run_xdotool
+
+        if IS_MACOS:
+            _macos_click(button)
+        else:
+            import os
+
+            display = os.getenv("DISPLAY", ":1")
+            _run_xdotool(f"click {button}", display)
+
+    def double_click(self) -> None:
+        from .computer import IS_MACOS, _run_xdotool
+
+        if IS_MACOS:
+            import subprocess
+
+            try:
+                result = subprocess.run(
+                    ["cliclick", "p"],
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                )
+                pos = result.stdout.strip()
+                subprocess.run(
+                    ["cliclick", f"dc:{pos}"],
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                )
+            except subprocess.TimeoutExpired as e:
+                raise RuntimeError("cliclick double-click timed out") from e
+        else:
+            import os
+
+            display = os.getenv("DISPLAY", ":1")
+            _run_xdotool("click --repeat 2 --delay 100 1", display)
+
+    def left_click_drag(self, x: int, y: int) -> None:
+        from .computer import IS_MACOS, _macos_drag, _run_xdotool
+
+        if IS_MACOS:
+            _macos_drag(x, y)
+        else:
+            import os
+
+            display = os.getenv("DISPLAY", ":1")
+            _run_xdotool(f"mousedown 1 mousemove --sync {x} {y} mouseup 1", display)
+
+    def screenshot(self, width: int = 0, height: int = 0) -> Path:
+        from .screenshot import screenshot as take_screenshot
+
+        path = take_screenshot()
+        if not path.exists():
+            raise RuntimeError("Screenshot failed")
+        if width and height:
+            import subprocess
+
+            try:
+                subprocess.run(
+                    ["convert", str(path), "-resize", f"{width}x{height}!", str(path)],
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                    timeout=30,
+                )
+            except subprocess.CalledProcessError as e:
+                raise RuntimeError(f"Image resize failed: {e.stderr}") from e
+        return path
+
+    def cursor_position(self) -> tuple[int, int]:
+        from .computer import IS_MACOS, _run_xdotool
+
+        if IS_MACOS:
+            import subprocess
+
+            output = subprocess.run(
+                ["cliclick", "p"],
+                capture_output=True,
+                text=True,
+                check=True,
+                timeout=10,
+            ).stdout.strip()
+            x, y = map(int, output.split(","))
+            return x, y
+        import os
+
+        display = os.getenv("DISPLAY", ":1")
+        output = _run_xdotool("getmouselocation --shell", display)
+        x = int(output.split("X=")[1].split("\n")[0])
+        y = int(output.split("Y=")[1].split("\n")[0])
+        return x, y
+
+    def close(self) -> None:
+        pass  # No resources to release for native transport
+
+
+# ---------------------------------------------------------------------------
+# Cua sandbox transport: delegates to trycua/cua Sandbox
+# ---------------------------------------------------------------------------
+
+
+class CuaComputerTransport(ComputerTransport):
+    """Transport backed by a trycua/cua Docker sandbox.
+
+    Opt-in via ``GPTME_COMPUTER_TRANSPORT=cua``. Requires the
+    ``cua-sandbox`` Python package installed in the environment.
+
+    The sandbox is created on first use (lazy init) and lives for the
+    lifetime of the transport. All calls are synchronous wrappers
+    around cua's async interfaces.
+    """
+
+    def __init__(self) -> None:
+        self._sandbox: object | None = None  # typed as Any for attribute access
+        self._initialized: bool = False
+
+    def _ensure_sandbox(self) -> None:
+        """Lazy-init: import cua_sandbox and create a Docker sandbox."""
+        if self._initialized:
+            return
+
+        try:
+            from cua_sandbox import (
+                Sandbox,  # type: ignore[import-untyped,import-not-found]
+            )
+        except ImportError:
+            raise RuntimeError(
+                "cua-sandbox not installed. Install with: pip install cua-sandbox"
+            ) from None
+
+        import asyncio
+
+        async def _create() -> object:
+            sandbox = await Sandbox.create()
+            return sandbox
+
+        self._sandbox = asyncio.run(_create())
+        self._initialized = True
+
+    def _run_async(self, coro: object) -> object:
+        """Run an async cua call synchronously."""
+        import asyncio
+
+        return asyncio.run(coro)  # type: ignore[arg-type]
+
+    def key(self, text: str) -> None:
+        self._ensure_sandbox()
+        assert self._sandbox is not None
+        self._run_async(self._sandbox.keyboard.key(text))  # type: ignore[attr-defined, union-attr]
+
+    def type_text(self, text: str) -> None:
+        self._ensure_sandbox()
+        assert self._sandbox is not None
+        self._run_async(self._sandbox.keyboard.type(text))  # type: ignore[attr-defined, union-attr]
+
+    def mouse_move(self, x: int, y: int) -> None:
+        self._ensure_sandbox()
+        assert self._sandbox is not None
+        self._run_async(self._sandbox.mouse.move(x, y))  # type: ignore[attr-defined, union-attr]
+
+    def left_click(self) -> None:
+        self._ensure_sandbox()
+        assert self._sandbox is not None
+        self._run_async(self._sandbox.mouse.click("left"))  # type: ignore[attr-defined, union-attr]
+
+    def right_click(self) -> None:
+        self._ensure_sandbox()
+        assert self._sandbox is not None
+        self._run_async(self._sandbox.mouse.click("right"))  # type: ignore[attr-defined, union-attr]
+
+    def middle_click(self) -> None:
+        self._ensure_sandbox()
+        assert self._sandbox is not None
+        self._run_async(self._sandbox.mouse.click("middle"))  # type: ignore[attr-defined, union-attr]
+
+    def double_click(self) -> None:
+        self._ensure_sandbox()
+        assert self._sandbox is not None
+        self._run_async(self._sandbox.mouse.double_click())  # type: ignore[attr-defined, union-attr]
+
+    def left_click_drag(self, x: int, y: int) -> None:
+        self._ensure_sandbox()
+        assert self._sandbox is not None
+        self._run_async(self._sandbox.mouse.drag(x, y))  # type: ignore[attr-defined, union-attr]
+
+    def screenshot(self, width: int = 0, height: int = 0) -> Path:
+        self._ensure_sandbox()
+        assert self._sandbox is not None
+
+        import tempfile
+
+        async def _capture() -> Path:
+            ss = await self._sandbox.screen.screenshot()  # type: ignore[attr-defined, union-attr]
+            path = Path(tempfile.mktemp(suffix=".png"))
+            ss.save(str(path))
+            if width and height:
+                ss = ss.resize((width, height))
+                ss.save(str(path))
+            return path
+
+        return self._run_async(_capture())  # type: ignore[return-value]
+
+    def cursor_position(self) -> tuple[int, int]:
+        self._ensure_sandbox()
+        assert self._sandbox is not None
+
+        async def _pos() -> tuple[int, int]:
+            pos = await self._sandbox.mouse.get_position()  # type: ignore[attr-defined, union-attr]
+            return (pos.x, pos.y)
+
+        return self._run_async(_pos())  # type: ignore[return-value]
+
+    def close(self) -> None:
+        if self._sandbox is not None:
+            self._run_async(self._sandbox.close())  # type: ignore[attr-defined, union-attr]
+            self._sandbox = None
+            self._initialized = False
+
+
+# ---------------------------------------------------------------------------
+# Transport factory
+# ---------------------------------------------------------------------------
+
+_transport: ComputerTransport | None = None
+_transport_loaded: bool = False
+
+
+def get_transport() -> ComputerTransport | None:
+    """Return the configured transport, or None for native (default) path.
+
+    Reads ``GPTME_COMPUTER_TRANSPORT`` env var:
+    - unset / empty → None (use existing computer.py native code path)
+    - ``native`` → ``NativeComputerTransport`` (explicit opt-in to
+      transport-layer wrapper around xdotool/cliclick)
+    - ``cua`` → ``CuaComputerTransport`` (Docker sandbox via cua-sandbox)
+    """
+    global _transport, _transport_loaded
+
+    if _transport_loaded:
+        return _transport
+
+    _transport_loaded = True
+    import os
+
+    transport_name = os.getenv("GPTME_COMPUTER_TRANSPORT", "").strip()
+    if not transport_name:
+        return None
+
+    if transport_name == "native":
+        _transport = NativeComputerTransport()
+    elif transport_name == "cua":
+        try:
+            _transport = CuaComputerTransport()
+        except RuntimeError as e:
+            import logging
+
+            logger = logging.getLogger(__name__)
+            logger.warning(
+                "CuaComputerTransport init failed: %s; falling back to native", e
+            )
+            _transport = NativeComputerTransport()
+    else:
+        import logging
+
+        logger = logging.getLogger(__name__)
+        logger.warning(
+            "Unknown GPTME_COMPUTER_TRANSPORT=%r; falling back to native",
+            transport_name,
+        )
+        _transport = NativeComputerTransport()
+
+    return _transport

--- a/gptme/tools/computer_transport.py
+++ b/gptme/tools/computer_transport.py
@@ -265,16 +265,26 @@ class NativeComputerTransport(ComputerTransport):
                     check=True,
                     timeout=10,
                 ).stdout.strip()
+                x, y = map(int, output.split(","))
             except subprocess.TimeoutExpired as e:
                 raise RuntimeError("cliclick cursor position query timed out") from e
             except subprocess.CalledProcessError as e:
                 raise RuntimeError(f"Failed to get cursor position: {e.stderr}") from e
-            x, y = map(int, output.split(","))
+            except FileNotFoundError as e:
+                raise RuntimeError(
+                    "cliclick not found. Install with: brew install cliclick"
+                ) from e
+            except ValueError as e:
+                raise RuntimeError(
+                    f"Unexpected cliclick output format: {output!r}"
+                ) from e
         else:
             import os
 
             display = os.getenv("DISPLAY", ":1")
             output = _run_xdotool("getmouselocation --shell", display)
+            if "X=" not in output or "Y=" not in output:
+                raise RuntimeError(f"Unexpected xdotool output format: {output!r}")
             x = int(output.split("X=")[1].split("\n")[0])
             y = int(output.split("Y=")[1].split("\n")[0])
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -294,6 +294,10 @@ ignore_missing_imports = true
 module = "sounddevice.*"
 ignore_missing_imports = true
 
+[[tool.mypy.overrides]]
+module = "cua_sandbox"
+ignore_missing_imports = true
+
 [tool.pytest.ini_options]
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",

--- a/tests/test_computer_transport.py
+++ b/tests/test_computer_transport.py
@@ -8,13 +8,15 @@ Deep xdotool/subprocess integration tests live in computer.py's
 existing test suite — this file validates the abstraction layer.
 """
 
+import asyncio
 import os
 import unittest
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from gptme.tools.computer_transport import (
     ComputerTransport,
+    CuaComputerTransport,
     NativeComputerTransport,
     get_transport,
 )
@@ -158,6 +160,104 @@ class TestGetTransport(unittest.TestCase):
         """Unknown transport name falls back to native with a warning."""
         transport = get_transport()
         self.assertIsInstance(transport, NativeComputerTransport)
+
+    @patch.dict(os.environ, {"GPTME_COMPUTER_TRANSPORT": "cua"}, clear=True)
+    def test_cua_missing_package_falls_back_to_native(self):
+        """GPTME_COMPUTER_TRANSPORT=cua falls back gracefully when cua-sandbox is absent."""
+        with patch.dict("sys.modules", {"cua_sandbox": None}):
+            transport = get_transport()
+        self.assertIsInstance(transport, NativeComputerTransport)
+
+
+class TestScreenshotNotBypassed(unittest.TestCase):
+    """Verify the screenshot action is routed through the transport (not local fallback)."""
+
+    def setUp(self):
+        import gptme.tools.computer_transport as ct
+
+        ct._transport = None
+        ct._transport_name = None
+
+    def test_screenshot_dispatched_through_transport(self):
+        """When a transport is active, screenshot() must be called on the transport."""
+        stub = StubTransport()
+        stub.screenshot = MagicMock(return_value=Path("/tmp/stub.png"))  # type: ignore[method-assign]
+
+        with (
+            patch(
+                "gptme.tools.computer._dispatch_transport",
+                wraps=lambda t, a, *args, **kw: (
+                    t.screenshot() if a == "screenshot" else None
+                ),
+            ) as mock_dispatch,
+            patch("gptme.tools.computer.get_transport", return_value=stub),
+        ):
+            from gptme.tools.computer import computer
+
+            computer("screenshot")
+
+        mock_dispatch.assert_called_once()
+        stub.screenshot.assert_called_once()
+
+
+class TestNativeTransportCoordinateScaling(unittest.TestCase):
+    """Verify NativeComputerTransport applies API→physical coordinate scaling."""
+
+    def test_mouse_move_scales_coordinates(self):
+        """mouse_move() must scale from API-space to physical before calling xdotool."""
+        transport = NativeComputerTransport()
+        called_with: list[tuple[int, int]] = []
+
+        def fake_xdotool(cmd: str, display: str) -> str:
+            # Extract the x,y from "mousemove --sync X Y"
+            parts = cmd.split()
+            called_with.append((int(parts[-2]), int(parts[-1])))
+            return ""
+
+        with (
+            patch("gptme.tools.computer.IS_MACOS", False),
+            patch(
+                "gptme.tools.computer._get_display_resolution",
+                return_value=(1920, 1080),
+            ),
+            patch("gptme.tools.computer._run_xdotool", fake_xdotool),
+            patch.dict(os.environ, {"WIDTH": "1366", "HEIGHT": "768", "DISPLAY": ":1"}),
+        ):
+            transport.mouse_move(683, 384)  # mid-point in API space
+
+        self.assertEqual(len(called_with), 1)
+        phys_x, phys_y = called_with[0]
+        # At 1920x1080 physical vs 1366x768 API, scaling is ~1.406x and ~1.406x
+        self.assertAlmostEqual(phys_x, round(683 * 1920 / 1366), delta=2)
+        self.assertAlmostEqual(phys_y, round(384 * 1080 / 768), delta=2)
+
+
+class TestCuaTransportAsyncio(unittest.TestCase):
+    """Verify _run_async() works both inside and outside a running event loop."""
+
+    def test_run_async_outside_loop(self):
+        """_run_async should work normally when no event loop is running."""
+        transport = CuaComputerTransport.__new__(CuaComputerTransport)
+
+        async def _coro() -> int:
+            return 42
+
+        with patch.object(CuaComputerTransport, "__init__", return_value=None):
+            result = transport._run_async(_coro())
+        self.assertEqual(result, 42)
+
+    def test_run_async_inside_loop(self):
+        """_run_async must not raise when called from inside a running event loop."""
+        transport = CuaComputerTransport.__new__(CuaComputerTransport)
+
+        async def _coro() -> int:
+            return 99
+
+        async def _runner() -> int:
+            return transport._run_async(_coro())  # type: ignore[return-value]
+
+        result = asyncio.run(_runner())
+        self.assertEqual(result, 99)
 
 
 if __name__ == "__main__":

--- a/tests/test_computer_transport.py
+++ b/tests/test_computer_transport.py
@@ -441,7 +441,7 @@ class TestNativeCursorPositionErrorHandling(unittest.TestCase):
                 "gptme.tools.computer._get_display_resolution",
                 return_value=(1920, 1080),
             ),
-            self.assertRaises((RuntimeError, ValueError)),
+            self.assertRaises(RuntimeError),
         ):
             transport.cursor_position()
 

--- a/tests/test_computer_transport.py
+++ b/tests/test_computer_transport.py
@@ -260,5 +260,68 @@ class TestCuaTransportAsyncio(unittest.TestCase):
         self.assertEqual(result, 99)
 
 
+class TestTransportCloseOnEnvVarChange(unittest.TestCase):
+    """Verify get_transport() closes the old transport when the env var changes."""
+
+    def setUp(self):
+        import gptme.tools.computer_transport as ct
+
+        ct._transport = None
+        ct._transport_name = None
+
+    def tearDown(self):
+        import gptme.tools.computer_transport as ct
+
+        ct._transport = None
+        ct._transport_name = None
+
+    def test_old_transport_closed_on_env_var_change(self):
+        """Switching transport via env var must close the previous transport."""
+        closed: list[bool] = []
+
+        class RecordingTransport(StubTransport):
+            def close(self) -> None:
+                closed.append(True)
+
+        import gptme.tools.computer_transport as ct
+
+        # Pre-seed the module-level singleton as if "native" was previously active.
+        ct._transport = RecordingTransport()
+        ct._transport_name = "native"
+
+        # Switching to an empty env var should close the previous transport.
+        with patch.dict(os.environ, {}, clear=True):
+            os.environ.pop("GPTME_COMPUTER_TRANSPORT", None)
+            get_transport()
+
+        self.assertEqual(
+            len(closed), 1, "close() must be called once on the stale transport"
+        )
+
+
+class TestNativeDoubleClickCalledProcessError(unittest.TestCase):
+    """macOS double_click must wrap CalledProcessError into RuntimeError."""
+
+    def test_double_click_macos_wraps_called_process_error(self):
+        """CalledProcessError from cliclick must be re-raised as RuntimeError."""
+        import subprocess
+
+        transport = NativeComputerTransport.__new__(NativeComputerTransport)
+
+        def raise_called_process_error(*args, **kwargs):
+            raise subprocess.CalledProcessError(
+                1, "cliclick", stderr="permission denied"
+            )
+
+        with (
+            patch("gptme.tools.computer.IS_MACOS", True),
+            patch("subprocess.run", side_effect=raise_called_process_error),
+            self.assertRaises(RuntimeError) as ctx,
+        ):
+            transport.double_click()
+
+        self.assertIn("failed", str(ctx.exception))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_computer_transport.py
+++ b/tests/test_computer_transport.py
@@ -323,6 +323,51 @@ class TestTransportCloseOnEnvVarChange(unittest.TestCase):
         )
 
 
+class TestDispatchTransportClickCoordinateForwarding(unittest.TestCase):
+    """_dispatch_transport must forward click coordinates via mouse_move."""
+
+    def test_click_with_coordinate_calls_mouse_move_first(self):
+        """When coordinate is provided to a click action, mouse_move is called before the click."""
+        stub = StubTransport()
+        stub.mouse_move = MagicMock()  # type: ignore[method-assign]
+        stub.left_click = MagicMock()  # type: ignore[method-assign]
+
+        from gptme.tools.computer import _dispatch_transport
+
+        _dispatch_transport(stub, "left_click", coordinate=(100, 200))
+
+        stub.mouse_move.assert_called_once_with(100, 200)
+        stub.left_click.assert_called_once()
+
+    def test_click_without_coordinate_does_not_call_mouse_move(self):
+        """When no coordinate is provided, mouse_move must not be called."""
+        stub = StubTransport()
+        stub.mouse_move = MagicMock()  # type: ignore[method-assign]
+        stub.right_click = MagicMock()  # type: ignore[method-assign]
+
+        from gptme.tools.computer import _dispatch_transport
+
+        _dispatch_transport(stub, "right_click")
+
+        stub.mouse_move.assert_not_called()
+        stub.right_click.assert_called_once()
+
+    def test_all_click_actions_forward_coordinate(self):
+        """All four click types forward the coordinate via mouse_move."""
+        from gptme.tools.computer import _dispatch_transport
+
+        for action in ("left_click", "right_click", "middle_click", "double_click"):
+            with self.subTest(action=action):
+                stub = StubTransport()
+                stub.mouse_move = MagicMock()  # type: ignore[method-assign]
+                setattr(stub, action, MagicMock())
+
+                _dispatch_transport(stub, action, coordinate=(50, 75))  # type: ignore[arg-type]
+
+                stub.mouse_move.assert_called_once_with(50, 75)
+                getattr(stub, action).assert_called_once()
+
+
 class TestNativeDoubleClickCalledProcessError(unittest.TestCase):
     """macOS double_click must wrap CalledProcessError into RuntimeError."""
 

--- a/tests/test_computer_transport.py
+++ b/tests/test_computer_transport.py
@@ -1,0 +1,164 @@
+"""
+Tests for the computer transport abstraction layer.
+
+Covers the transport ABC contract, native transport instantiation,
+and the get_transport() factory function.
+
+Deep xdotool/subprocess integration tests live in computer.py's
+existing test suite — this file validates the abstraction layer.
+"""
+
+import os
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from gptme.tools.computer_transport import (
+    ComputerTransport,
+    NativeComputerTransport,
+    get_transport,
+)
+
+
+class StubTransport(ComputerTransport):
+    """Minimal concrete transport for testing the ABC contract."""
+
+    def close(self) -> None:
+        pass
+
+    def key(self, text: str) -> None:
+        pass
+
+    def type_text(self, text: str) -> None:
+        pass
+
+    def mouse_move(self, x: int, y: int) -> None:
+        pass
+
+    def left_click(self) -> None:
+        pass
+
+    def right_click(self) -> None:
+        pass
+
+    def middle_click(self) -> None:
+        pass
+
+    def double_click(self) -> None:
+        pass
+
+    def left_click_drag(self, x: int, y: int) -> None:
+        pass
+
+    def screenshot(self, width: int = 0, height: int = 0) -> Path:
+        return Path("/tmp/stub.png")
+
+    def cursor_position(self) -> tuple[int, int]:
+        return (42, 17)
+
+
+class TestComputerTransportABC(unittest.TestCase):
+    """Abstract base class contract tests."""
+
+    def test_concrete_subclass_instantiable(self):
+        """A full concrete subclass should instantiate and work."""
+        transport = StubTransport()
+        self.assertIsInstance(transport, ComputerTransport)
+        self.assertEqual(transport.cursor_position(), (42, 17))
+        self.assertIsInstance(transport.screenshot(), Path)
+
+    def test_incomplete_subclass_raises_typeerror(self):
+        """Subclass missing abstract methods must fail at instantiation."""
+
+        class IncompleteTransport(ComputerTransport):
+            pass
+
+        with self.assertRaises(TypeError):
+            IncompleteTransport()  # type: ignore[abstract]
+
+    def test_abstract_method_surface_matches_expected(self):
+        """The 11 abstract methods match gptme's computer() action set."""
+        abstract = {
+            name
+            for name in dir(ComputerTransport)
+            if getattr(
+                getattr(ComputerTransport, name, None),
+                "__isabstractmethod__",
+                False,
+            )
+        }
+        expected = {
+            "close",
+            "key",
+            "type_text",
+            "mouse_move",
+            "left_click",
+            "right_click",
+            "middle_click",
+            "double_click",
+            "left_click_drag",
+            "screenshot",
+            "cursor_position",
+        }
+        self.assertEqual(abstract, expected)
+
+
+class TestNativeComputerTransport(unittest.TestCase):
+    """Smoke tests for the native (xdotool+scrot/cliclick) transport."""
+
+    def test_instantiation(self):
+        """Instantiation does not touch subprocess."""
+        transport = NativeComputerTransport()
+        self.assertIsInstance(transport, ComputerTransport)
+
+    def test_close_is_noop(self):
+        """close() should be safe to call repeatedly."""
+        transport = NativeComputerTransport()
+        transport.close()
+        transport.close()  # No exception
+
+    def test_screenshot_signature_and_type(self):
+        """screenshot() accepts optional width/height and declares Path return."""
+        import inspect
+
+        sig = inspect.signature(NativeComputerTransport.screenshot)
+        params = list(sig.parameters.keys())
+        self.assertEqual(params, ["self", "width", "height"])
+        # from __future__ import annotations stringifies annotations
+        self.assertIn(
+            sig.return_annotation,
+            (Path, "Path"),
+        )
+
+
+class TestGetTransport(unittest.TestCase):
+    """Transport factory function tests."""
+
+    def setUp(self):
+        # Reset the module-level cache between tests
+        import gptme.tools.computer_transport as ct
+
+        ct._transport_loaded = False
+        ct._transport = None
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_default_returns_none(self):
+        """Without env var, return None — use existing computer.py code path."""
+        transport = get_transport()
+        self.assertIsNone(transport)
+
+    @patch.dict(os.environ, {"GPTME_COMPUTER_TRANSPORT": "native"}, clear=True)
+    def test_native_env_returns_native_transport(self):
+        """GPTME_COMPUTER_TRANSPORT=native selects NativeComputerTransport."""
+        transport = get_transport()
+        self.assertIsInstance(transport, NativeComputerTransport)
+
+    @patch.dict(os.environ, {"GPTME_COMPUTER_TRANSPORT": "bogus"}, clear=True)
+    def test_unknown_value_falls_back_gracefully(self):
+        """Unknown transport name falls back to native with a warning."""
+        transport = get_transport()
+        self.assertIsInstance(transport, NativeComputerTransport)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_computer_transport.py
+++ b/tests/test_computer_transport.py
@@ -168,6 +168,21 @@ class TestGetTransport(unittest.TestCase):
             transport = get_transport()
         self.assertIsInstance(transport, NativeComputerTransport)
 
+    @patch.dict(os.environ, {"GPTME_COMPUTER_TRANSPORT": "cua"}, clear=True)
+    def test_cua_fallback_does_not_poison_cache(self):
+        """After CuaComputerTransport fallback, _transport_name must not be set to 'cua'.
+
+        A poisoned cache would prevent retries after transient failures
+        (e.g. Docker not yet running when the first call is made).
+        """
+        import gptme.tools.computer_transport as ct
+
+        with patch.dict("sys.modules", {"cua_sandbox": None}):
+            get_transport()
+
+        # Cache must NOT be poisoned: _transport_name should be None (retryable)
+        self.assertIsNone(ct._transport_name)
+
 
 class TestScreenshotNotBypassed(unittest.TestCase):
     """Verify the screenshot action is routed through the transport (not local fallback)."""

--- a/tests/test_computer_transport.py
+++ b/tests/test_computer_transport.py
@@ -231,6 +231,30 @@ class TestNativeTransportCoordinateScaling(unittest.TestCase):
         self.assertAlmostEqual(phys_x, round(683 * 1920 / 1366), delta=2)
         self.assertAlmostEqual(phys_y, round(384 * 1080 / 768), delta=2)
 
+    def test_cursor_position_scales_to_api_space(self):
+        """cursor_position() must convert physical pixels → API-space before returning."""
+        transport = NativeComputerTransport()
+
+        # Simulate xdotool reporting physical-pixel position (mid-screen at 1920x1080)
+        fake_xdotool_output = "X=960\nY=540\nSCREEN=0\n"
+
+        with (
+            patch("gptme.tools.computer.IS_MACOS", False),
+            patch(
+                "gptme.tools.computer._get_display_resolution",
+                return_value=(1920, 1080),
+            ),
+            patch(
+                "gptme.tools.computer._run_xdotool", return_value=fake_xdotool_output
+            ),
+            patch.dict(os.environ, {"WIDTH": "1366", "HEIGHT": "768", "DISPLAY": ":1"}),
+        ):
+            api_x, api_y = transport.cursor_position()
+
+        # Physical 960,540 on 1920x1080 → API ~683,384 on 1366x768
+        self.assertAlmostEqual(api_x, round(960 * 1366 / 1920), delta=2)
+        self.assertAlmostEqual(api_y, round(540 * 768 / 1080), delta=2)
+
 
 class TestCuaTransportAsyncio(unittest.TestCase):
     """Verify _run_async() works both inside and outside a running event loop."""

--- a/tests/test_computer_transport.py
+++ b/tests/test_computer_transport.py
@@ -407,5 +407,61 @@ class TestNativeDoubleClickCalledProcessError(unittest.TestCase):
         self.assertIn("failed", str(ctx.exception))
 
 
+class TestNativeCursorPositionErrorHandling(unittest.TestCase):
+    """NativeComputerTransport.cursor_position() must surface RuntimeError, not raw OS errors."""
+
+    def test_macos_file_not_found_raises_runtime_error_with_install_hint(self):
+        """Missing cliclick binary must produce a RuntimeError with install instructions."""
+        transport = NativeComputerTransport.__new__(NativeComputerTransport)
+
+        with (
+            patch("gptme.tools.computer.IS_MACOS", True),
+            patch(
+                "subprocess.run", side_effect=FileNotFoundError("cliclick not found")
+            ),
+            self.assertRaises(RuntimeError) as ctx,
+        ):
+            transport.cursor_position()
+
+        self.assertIn("brew install cliclick", str(ctx.exception))
+
+    def test_macos_malformed_output_raises_runtime_error(self):
+        """Malformed cliclick output must raise RuntimeError, not ValueError."""
+
+        transport = NativeComputerTransport.__new__(NativeComputerTransport)
+
+        mock_result = MagicMock()
+        mock_result.stdout = "not,valid,coordinates,extra"
+
+        with (
+            patch("gptme.tools.computer.IS_MACOS", True),
+            patch("subprocess.run", return_value=mock_result),
+            patch("gptme.tools.computer._get_api_resolution", return_value=(1366, 768)),
+            patch(
+                "gptme.tools.computer._get_display_resolution",
+                return_value=(1920, 1080),
+            ),
+            self.assertRaises((RuntimeError, ValueError)),
+        ):
+            transport.cursor_position()
+
+    def test_linux_bad_xdotool_output_raises_runtime_error(self):
+        """Unexpected xdotool output must raise RuntimeError, not IndexError."""
+        transport = NativeComputerTransport.__new__(NativeComputerTransport)
+
+        with (
+            patch("gptme.tools.computer.IS_MACOS", False),
+            patch(
+                "gptme.tools.computer._run_xdotool",
+                return_value="ERROR: display not found",
+            ),
+            patch.dict(os.environ, {"DISPLAY": ":1"}),
+            self.assertRaises(RuntimeError) as ctx,
+        ):
+            transport.cursor_position()
+
+        self.assertIn("Unexpected xdotool output format", str(ctx.exception))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_computer_transport.py
+++ b/tests/test_computer_transport.py
@@ -138,8 +138,8 @@ class TestGetTransport(unittest.TestCase):
         # Reset the module-level cache between tests
         import gptme.tools.computer_transport as ct
 
-        ct._transport_loaded = False
         ct._transport = None
+        ct._transport_name = None
 
     @patch.dict(os.environ, {}, clear=True)
     def test_default_returns_none(self):


### PR DESCRIPTION
## Problem

gptme's `computer()` tool shells out directly to xdotool+scrot (Linux) or cliclick (macOS). There is no abstraction that allows the same keyboard/mouse/screenshot/cursor tools to work through sandboxed environments, Docker containers, remote VMs, or Android emulators.

This follows the two-layer transport abstraction pattern from [trycua/cua](https://github.com/trycua/cua) (Transport ABC → typed Interface classes), researched in Bob session 922a.

## What this does

Adds `gptme/tools/computer_transport.py`:
- **`ComputerTransport` ABC** — 11 abstract methods (key, type_text, mouse_move, left_click, right_click, middle_click, double_click, left_click_drag, screenshot, cursor_position, close)
- **`NativeComputerTransport`** — wraps xdotool/cliclick via the existing `computer.py` helpers. Identical behavior to current code.
- **`CuaComputerTransport`** — delegates to a trycua/cua Docker sandbox (opt-in via `GPTME_COMPUTER_TRANSPORT=cua`). Lazy-init, synchronous wrappers around cua's async interfaces.
- **`get_transport()`** — factory reading `GPTME_COMPUTER_TRANSPORT` env var. Returns None (default native path), `NativeComputerTransport`, or `CuaComputerTransport`.

Integrates into `gptme/tools/computer.py`:
- `computer()` now consults `get_transport()` at the top. If a transport is available, dispatches through it as a fast path.
- Default (no env var) → None → falls through to existing xdotool/cliclick code unchanged.
- Semicolon-separated key sequences (e.g. `"ctrl+c;t:hello"`) are now handled through the transport layer.

Tests (`tests/test_computer_transport.py`, 9 tests):
- ABC conformance (abstract method surface, concrete subclass, incomplete subclass)
- Native transport path (instantiation, close, screenshot signature)
- Transport factory (default=none, native env var, unknown value falls back gracefully)

## Why in core

Computer-use is a core tool. The transport layer is 260 lines of ABC + native wrapper — zero new dependencies (cua path is optional and gated by import). This is the same pattern as the existing `browser` tool's optional Playwright dependency.

## Out of scope

- macOS-specific transport (cua's `cua-driver` Swift library)
- Cloud transport / multi-client session manager (gated on gptme serve multi-client support)
- Replacing the core screenshot-based vision loop

## Related

- Bob idea backlog #227 (trycua/cua transport abstraction)
- Companion research: `knowledge/research/2026-05-10-trycua-cua-phase-2-transport-layer-peer-research.md`
- Companion task: `tasks/cua-transport-prototype.md`
- cua source: https://github.com/trycua/cua