### PR TITLE
feat(commands): add checkpoint slash command

### DIFF
--- a/gptme/commands/__init__.py
+++ b/gptme/commands/__init__.py
@@ -19,6 +19,7 @@ from .. import llm as _llm  # noqa: F401
 # Import command modules to register their commands
 from . import (  # noqa: F401
     account,
+    checkpoint,
     export,
     llm,
     meta,

--- a/gptme/commands/checkpoint.py
+++ b/gptme/commands/checkpoint.py
@@ -79,7 +79,7 @@ def cmd_checkpoint(ctx: CommandContext) -> None:
                 session_id=session_id,
                 include_dirty=include_dirty,
             )
-        except CheckpointError as exc:
+        except (CheckpointError, OSError) as exc:
             print(f"checkpoint: {exc}")
             return
 

--- a/gptme/commands/checkpoint.py
+++ b/gptme/commands/checkpoint.py
@@ -104,7 +104,11 @@ def cmd_checkpoint(ctx: CommandContext) -> None:
             print(f"checkpoint: {decision.reason}")
             return
 
-        records = list_checkpoints(decision.repo_root)
+        try:
+            records = list_checkpoints(decision.repo_root)
+        except (CheckpointError, OSError) as exc:
+            print(f"checkpoint: {exc}")
+            return
         if not records:
             print("No checkpoints yet.")
             return
@@ -127,7 +131,7 @@ def cmd_checkpoint(ctx: CommandContext) -> None:
             return
         try:
             output = diff_checkpoint(target, args[0])
-        except CheckpointError as exc:
+        except (CheckpointError, OSError) as exc:
             print(f"checkpoint: {exc}")
             return
         if output:
@@ -154,7 +158,7 @@ def cmd_checkpoint(ctx: CommandContext) -> None:
                 remaining[0],
                 include_dirty=include_dirty,
             )
-        except CheckpointError as exc:
+        except (CheckpointError, OSError) as exc:
             print(f"checkpoint: {exc}")
             return
         print(result)

--- a/gptme/commands/checkpoint.py
+++ b/gptme/commands/checkpoint.py
@@ -1,0 +1,164 @@
+"""
+Checkpoint commands for workspace recovery.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ..checkpoint import (
+    CheckpointError,
+    classify,
+    create_checkpoint,
+    diff_checkpoint,
+    list_checkpoints,
+    restore_checkpoint,
+)
+from .base import CommandContext, command
+
+
+def _print_usage() -> None:
+    print("Usage: /checkpoint <create|list|diff|restore> ...")
+    print()
+    print("Commands:")
+    print("  create [--include-dirty] [--session-id ID]")
+    print("      Record a checkpoint at the current workspace HEAD.")
+    print("  list")
+    print("      List recorded checkpoints for the current workspace.")
+    print("  diff <identifier>")
+    print("      Diff current state against a checkpoint.")
+    print("  restore <identifier> [--include-dirty]")
+    print("      Restore the workspace to a checkpoint.")
+
+
+def _workspace_path(ctx: CommandContext) -> Path | None:
+    workspace = getattr(ctx.manager, "workspace", None)
+    if workspace is None:
+        print("checkpoint: no workspace configured for this session")
+        return None
+    return Path(workspace)
+
+
+@command("checkpoint")
+def cmd_checkpoint(ctx: CommandContext) -> None:
+    """Manage workspace checkpoints."""
+    target = _workspace_path(ctx)
+    if target is None:
+        return
+
+    if not ctx.args or ctx.args[0] in {"help", "-h", "--help"}:
+        _print_usage()
+        return
+
+    subcommand = ctx.args[0]
+    args = ctx.args[1:]
+
+    if subcommand == "create":
+        include_dirty = False
+        session_id: str | None = None
+        idx = 0
+        while idx < len(args):
+            arg = args[idx]
+            if arg == "--include-dirty":
+                include_dirty = True
+            elif arg == "--session-id":
+                idx += 1
+                if idx >= len(args):
+                    print("checkpoint: --session-id requires a value")
+                    return
+                session_id = args[idx]
+            else:
+                print(f"checkpoint: unknown argument {arg!r}")
+                _print_usage()
+                return
+            idx += 1
+
+        try:
+            record, existing_sha = create_checkpoint(
+                target,
+                session_id=session_id,
+                include_dirty=include_dirty,
+            )
+        except CheckpointError as exc:
+            print(f"checkpoint: {exc}")
+            return
+
+        if record is None:
+            head = existing_sha[:12] if existing_sha else "?"
+            print(f"Already checkpointed at {head} — nothing to do.")
+        else:
+            print(
+                f"Checkpoint created: {record.head_sha[:12]} "
+                f"(session={record.session_id})"
+            )
+        return
+
+    if subcommand == "list":
+        if args:
+            print(f"checkpoint: unknown argument {args[0]!r}")
+            _print_usage()
+            return
+
+        decision = classify(target)
+        if decision.repo_root is None:
+            print(f"checkpoint: {decision.reason}")
+            return
+
+        records = list_checkpoints(decision.repo_root)
+        if not records:
+            print("No checkpoints yet.")
+            return
+
+        current_sha = decision.head_sha or ""
+        print(f"{'#':>3}  {'Session':<14}  {'Timestamp':<20}  {'HEAD':<12}  Workspace")
+        for i, record in enumerate(records, start=1):
+            marker = " *" if record.head_sha == current_sha else ""
+            ts = record.timestamp[:19].replace("T", " ")
+            print(
+                f"{i:>3}  {record.session_id:<14}  {ts:<20}  "
+                f"{record.head_sha[:12]:<12}  {record.workspace}{marker}"
+            )
+        return
+
+    if subcommand == "diff":
+        if len(args) != 1:
+            print("checkpoint: diff requires a checkpoint identifier")
+            _print_usage()
+            return
+        try:
+            output = diff_checkpoint(target, args[0])
+        except CheckpointError as exc:
+            print(f"checkpoint: {exc}")
+            return
+        if output:
+            print(output, end="")
+        else:
+            print("No changes since checkpoint.")
+        return
+
+    if subcommand == "restore":
+        include_dirty = False
+        remaining: list[str] = []
+        for arg in args:
+            if arg == "--include-dirty":
+                include_dirty = True
+            else:
+                remaining.append(arg)
+        if len(remaining) != 1:
+            print("checkpoint: restore requires a checkpoint identifier")
+            _print_usage()
+            return
+        try:
+            result = restore_checkpoint(
+                target,
+                remaining[0],
+                include_dirty=include_dirty,
+            )
+        except CheckpointError as exc:
+            print(f"checkpoint: {exc}")
+            return
+        print(result)
+        return
+
+    print(f"checkpoint: unknown subcommand {subcommand!r}")
+    _print_usage()

--- a/gptme/commands/meta.py
+++ b/gptme/commands/meta.py
@@ -13,6 +13,7 @@ from .base import CommandContext, command
 
 Actions = Literal[
     "log",
+    "checkpoint",
     "undo",
     "edit",
     "rename",
@@ -41,6 +42,7 @@ Actions = Literal[
 action_descriptions: dict[Actions, str] = {
     "undo": "Undo the last action",
     "log": "Show the conversation log",
+    "checkpoint": "Manage workspace checkpoints",
     "edit": "Edit the conversation in your editor",
     "rename": "Rename the conversation",
     "fork": "Create a copy of the conversation",

--- a/tests/test_acp_agent.py
+++ b/tests/test_acp_agent.py
@@ -958,6 +958,7 @@ class TestGetCommandsWithDescriptions:
         from gptme.commands import get_commands_with_descriptions
 
         names = {name for name, _ in get_commands_with_descriptions()}
+        assert "checkpoint" in names
         assert "help" in names
         assert "model" in names
         assert "tools" in names

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -592,6 +592,32 @@ class TestBuiltinCommands:
         assert "sess-123" in captured.out
         assert "abcdef123456" in captured.out
 
+    def test_checkpoint_list_command_handles_oserror(self, mock_manager, capsys):
+        """The /checkpoint list command should print OSError failures."""
+
+        @dataclass
+        class Decision:
+            repo_root: Path | None
+            reason: str
+            head_sha: str | None
+
+        with (
+            patch("gptme.commands.checkpoint.classify") as mock_classify,
+            patch(
+                "gptme.commands.checkpoint.list_checkpoints",
+                side_effect=OSError("permission denied"),
+            ),
+        ):
+            mock_classify.return_value = Decision(
+                repo_root=Path("/tmp/test-workspace"),
+                reason="",
+                head_sha="abcdef1234567890",
+            )
+            list(handle_cmd("/checkpoint list", mock_manager))
+
+        captured = capsys.readouterr()
+        assert "checkpoint: permission denied" in captured.out
+
     def test_checkpoint_restore_command(self, mock_manager, capsys):
         """The /checkpoint restore command should call restore_checkpoint."""
         with patch("gptme.commands.checkpoint.restore_checkpoint") as mock_restore:
@@ -606,6 +632,17 @@ class TestBuiltinCommands:
         captured = capsys.readouterr()
         assert "Restored to checkpoint abcdef123456." in captured.out
 
+    def test_checkpoint_restore_command_handles_oserror(self, mock_manager, capsys):
+        """The /checkpoint restore command should print OSError failures."""
+        with patch(
+            "gptme.commands.checkpoint.restore_checkpoint",
+            side_effect=OSError("permission denied"),
+        ):
+            list(handle_cmd("/checkpoint restore 1", mock_manager))
+
+        captured = capsys.readouterr()
+        assert "checkpoint: permission denied" in captured.out
+
     def test_checkpoint_diff_command(self, mock_manager, capsys):
         """The /checkpoint diff command should call diff_checkpoint and print output."""
         with patch("gptme.commands.checkpoint.diff_checkpoint") as mock_diff:
@@ -617,3 +654,14 @@ class TestBuiltinCommands:
         mock_diff.assert_called_once_with(Path("/tmp/test-workspace"), "1")
         captured = capsys.readouterr()
         assert "diff --git" in captured.out
+
+    def test_checkpoint_diff_command_handles_oserror(self, mock_manager, capsys):
+        """The /checkpoint diff command should print OSError failures."""
+        with patch(
+            "gptme.commands.checkpoint.diff_checkpoint",
+            side_effect=OSError("permission denied"),
+        ):
+            list(handle_cmd("/checkpoint diff 1", mock_manager))
+
+        captured = capsys.readouterr()
+        assert "checkpoint: permission denied" in captured.out

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -10,6 +10,7 @@ Tests the core command infrastructure in gptme/commands/base.py:
 """
 
 from collections.abc import Generator
+from dataclasses import dataclass
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -451,6 +452,7 @@ class TestBuiltinCommands:
     def test_builtin_commands_registered(self):
         """All expected built-in commands should be registered."""
         expected = [
+            "checkpoint",
             "help",
             "exit",
             "log",
@@ -528,3 +530,78 @@ class TestBuiltinCommands:
             # First arg is conversation name, third arg is output path
             args = mock_export.call_args
             assert args[0][2] == Path("output.html")
+
+    def test_checkpoint_create_command(self, mock_manager, capsys):
+        """The /checkpoint create command should call create_checkpoint."""
+
+        @dataclass
+        class Record:
+            head_sha: str
+            session_id: str
+
+        with patch("gptme.commands.checkpoint.create_checkpoint") as mock_create:
+            mock_create.return_value = (Record("abcdef1234567890", "sess-123"), None)
+            list(handle_cmd("/checkpoint create --session-id sess-123", mock_manager))
+
+        mock_create.assert_called_once_with(
+            Path("/tmp/test-workspace"),
+            session_id="sess-123",
+            include_dirty=False,
+        )
+        captured = capsys.readouterr()
+        assert "Checkpoint created: abcdef123456" in captured.out
+        assert "session=sess-123" in captured.out
+
+    def test_checkpoint_list_command(self, mock_manager, capsys):
+        """The /checkpoint list command should print checkpoint rows."""
+
+        @dataclass
+        class Decision:
+            repo_root: Path | None
+            reason: str
+            head_sha: str | None
+
+        @dataclass
+        class Record:
+            session_id: str
+            timestamp: str
+            head_sha: str
+            workspace: str
+
+        with (
+            patch("gptme.commands.checkpoint.classify") as mock_classify,
+            patch("gptme.commands.checkpoint.list_checkpoints") as mock_list,
+        ):
+            mock_classify.return_value = Decision(
+                repo_root=Path("/tmp/test-workspace"),
+                reason="",
+                head_sha="abcdef1234567890",
+            )
+            mock_list.return_value = [
+                Record(
+                    session_id="sess-123",
+                    timestamp="2026-05-10T12:34:56+00:00",
+                    head_sha="abcdef1234567890",
+                    workspace="/tmp/test-workspace",
+                )
+            ]
+            list(handle_cmd("/checkpoint list", mock_manager))
+
+        captured = capsys.readouterr()
+        assert "Session" in captured.out
+        assert "sess-123" in captured.out
+        assert "abcdef123456" in captured.out
+
+    def test_checkpoint_restore_command(self, mock_manager, capsys):
+        """The /checkpoint restore command should call restore_checkpoint."""
+        with patch("gptme.commands.checkpoint.restore_checkpoint") as mock_restore:
+            mock_restore.return_value = "Restored to checkpoint abcdef123456."
+            list(handle_cmd("/checkpoint restore 1 --include-dirty", mock_manager))
+
+        mock_restore.assert_called_once_with(
+            Path("/tmp/test-workspace"),
+            "1",
+            include_dirty=True,
+        )
+        captured = capsys.readouterr()
+        assert "Restored to checkpoint abcdef123456." in captured.out

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -605,3 +605,15 @@ class TestBuiltinCommands:
         )
         captured = capsys.readouterr()
         assert "Restored to checkpoint abcdef123456." in captured.out
+
+    def test_checkpoint_diff_command(self, mock_manager, capsys):
+        """The /checkpoint diff command should call diff_checkpoint and print output."""
+        with patch("gptme.commands.checkpoint.diff_checkpoint") as mock_diff:
+            mock_diff.return_value = (
+                "diff --git a/foo.py b/foo.py\n--- a/foo.py\n+++ b/foo.py\n"
+            )
+            list(handle_cmd("/checkpoint diff 1", mock_manager))
+
+        mock_diff.assert_called_once_with(Path("/tmp/test-workspace"), "1")
+        captured = capsys.readouterr()
+        assert "diff --git" in captured.out


### PR DESCRIPTION
## Summary
- add a built-in `/checkpoint` slash command that exposes the existing checkpoint create/list/diff/restore primitives inside interactive and ACP sessions
- wire the command into built-in command metadata so ACP autocomplete advertises it
- add command and ACP coverage for the new slash command surface

## Testing
- uv run pytest tests/test_commands.py tests/test_acp_agent.py -q
- uv run pytest tests/test_checkpoint.py -q
- uv run ruff check gptme/commands/checkpoint.py gptme/commands/__init__.py gptme/commands/meta.py tests/test_commands.py tests/test_acp_agent.py