### PR TITLE
[codex] queue prompts for running chats

### DIFF
--- a/gptme/chat.py
+++ b/gptme/chat.py
@@ -22,6 +22,7 @@ from .llm import reply
 from .llm.models import get_default_model, get_model
 from .logmanager import Log, LogManager, prepare_messages
 from .message import Message
+from .prompt_queue import drain_prompt_queue
 from .telemetry import set_conversation_context, trace_function
 from .tools import (
     ToolFormat,
@@ -171,6 +172,7 @@ def _run_chat_loop(
     """Main chat loop - extracted to allow clean exception handling."""
 
     while True:
+        _drain_external_prompt_queue(manager, prompt_queue)
         msg: Message | None = None
         try:
             # Process next message (either from prompt queue or user input)
@@ -190,6 +192,7 @@ def _run_chat_loop(
                         manager, stream, tool_format, model, output_schema
                     )
                 except SessionCompleteException:
+                    _drain_external_prompt_queue(manager, prompt_queue)
                     if not prompt_queue:
                         # No more prompts, properly exit
                         raise
@@ -273,6 +276,22 @@ def _run_chat_loop(
     ):
         for msg in session_end_msgs:
             manager.append(msg)
+
+
+def _drain_external_prompt_queue(
+    manager: LogManager, prompt_queue: list[Message]
+) -> None:
+    """Merge any durable queued prompts into the in-memory queue."""
+    capacity = MAX_PROMPT_QUEUE_SIZE - len(prompt_queue)
+    if capacity <= 0:
+        return
+
+    drained = drain_prompt_queue(manager.logdir, max_items=capacity)
+    if not drained:
+        return
+
+    prompt_queue.extend(drained)
+    logger.info("Loaded %d queued prompt(s) for %s", len(drained), manager.logdir.name)
 
 
 def _process_message_conversation(

--- a/gptme/cli/cmd_chats.py
+++ b/gptme/cli/cmd_chats.py
@@ -10,6 +10,7 @@ import click
 from ..dirs import get_logs_dir
 from ..logmanager import LogManager
 from ..logmanager.conversations import ConversationMeta
+from ..prompt_queue import queue_prompt
 from ..tools import get_tools, init_tools
 from ..tools.chats import find_empty_conversations, list_chats, search_chats
 
@@ -193,6 +194,24 @@ def chats_rename(id: str, name: str):
     else:
         print(f"Chat '{id}' not found")
         sys.exit(1)
+
+
+@chats.command("send")
+@click.argument("id")
+@click.argument("message", nargs=-1, required=True)
+def chats_send(id: str, message: tuple[str, ...]):
+    """Queue a prompt for the next turn of a running conversation."""
+    logdir = get_logs_dir() / id
+    if not logdir.exists():
+        click.echo(f"Chat '{id}' not found")
+        raise SystemExit(1)
+
+    content = " ".join(message).strip()
+    if not content:
+        raise click.UsageError("Queued message must not be empty.")
+
+    queue_prompt(logdir, content)
+    click.echo(f"Queued prompt for '{id}'")
 
 
 @chats.command("export")

--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -147,6 +147,7 @@ Utilities (gptme-util):
   gptme-util tools info TOOL  Show detailed tool instructions/examples
   gptme-util chats list       List past conversations
   gptme-util chats search Q   Search conversations for query
+  gptme-util chats send ID MSG Queue a prompt for a running chat
   gptme-util chats rename     Rename a conversation
   gptme-util models list      List available models
   gptme-util context index    Index project files for RAG

--- a/gptme/prompt_queue.py
+++ b/gptme/prompt_queue.py
@@ -1,0 +1,108 @@
+"""Durable queued prompts for active conversations."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import logging
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any
+
+from .message import Message
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+try:
+    fcntl: Any = importlib.import_module("fcntl")
+except ImportError:  # pragma: no cover
+    fcntl = None
+
+
+QUEUE_FILENAME = "prompt-queue.jsonl"
+LOCK_FILENAME = ".prompt-queue.lock"
+
+
+def get_prompt_queue_path(logdir: Path) -> Path:
+    return logdir / QUEUE_FILENAME
+
+
+def _get_prompt_queue_lock_path(logdir: Path) -> Path:
+    return logdir / LOCK_FILENAME
+
+
+@contextmanager
+def _prompt_queue_lock(logdir: Path):
+    lock_path = _get_prompt_queue_lock_path(logdir)
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path.touch(exist_ok=True)
+
+    with lock_path.open("r+") as fd:
+        if fcntl is not None:
+            fcntl.flock(fd, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            if fcntl is not None:
+                fcntl.flock(fd, fcntl.LOCK_UN)
+
+
+def queue_prompt(logdir: Path, content: str) -> None:
+    """Append a prompt to a conversation queue."""
+    queue_path = get_prompt_queue_path(logdir)
+    record = {
+        "content": content,
+        "queued_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+    with _prompt_queue_lock(logdir), queue_path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(record) + "\n")
+
+
+def drain_prompt_queue(logdir: Path, max_items: int | None = None) -> list[Message]:
+    """Drain queued prompts into in-memory Message objects.
+
+    If ``max_items`` is set, any extra prompts remain on disk in FIFO order.
+    """
+    queue_path = get_prompt_queue_path(logdir)
+    if not queue_path.exists():
+        return []
+
+    with _prompt_queue_lock(logdir):
+        if not queue_path.exists():
+            return []
+
+        lines = queue_path.read_text(encoding="utf-8").splitlines()
+        drained: list[Message] = []
+        remaining: list[str] = []
+
+        for line in lines:
+            if not line.strip():
+                continue
+
+            if max_items is not None and len(drained) >= max_items:
+                remaining.append(line)
+                continue
+
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                logger.warning("Skipping malformed queued prompt in %s", queue_path)
+                continue
+
+            content = str(record.get("content", "")).strip()
+            if not content:
+                logger.warning("Skipping empty queued prompt in %s", queue_path)
+                continue
+
+            drained.append(Message("user", content, quiet=True))
+
+        if remaining:
+            queue_path.write_text("\n".join(remaining) + "\n", encoding="utf-8")
+        else:
+            queue_path.unlink(missing_ok=True)
+
+        return drained

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -590,6 +590,99 @@ def test_chained_prompts_complete_exits_when_last():
         )
 
 
+def test_external_queued_prompts_are_drained_between_turns(tmp_path):
+    """Queued prompts on disk should be picked up by the next loop iteration."""
+    import sys
+
+    from gptme.chat import _run_chat_loop
+    from gptme.prompt_queue import get_prompt_queue_path, queue_prompt
+
+    _chat_mod = sys.modules["gptme.chat"]
+
+    logdir = tmp_path / "chat"
+    logdir.mkdir()
+    queue_prompt(logdir, "queued prompt")
+
+    manager = MagicMock()
+    manager.log = MagicMock()
+    manager.workspace = tmp_path
+    manager.logdir = logdir
+
+    processed: list[str] = []
+
+    def mock_append(msg):
+        processed.append(msg.content)
+
+    manager.append.side_effect = mock_append
+
+    with (
+        patch.object(_chat_mod, "_process_message_conversation", return_value=None),
+        patch.object(_chat_mod, "trigger_hook", return_value=[]),
+        patch.object(_chat_mod, "include_paths", side_effect=lambda msg, ws: msg),
+        patch.object(_chat_mod, "execute_cmd", return_value=False),
+    ):
+        _run_chat_loop(
+            manager=manager,
+            prompt_queue=[],
+            stream=False,
+            tool_format="markdown",
+            model=None,
+            interactive=False,
+        )
+
+    assert processed == ["queued prompt"]
+    assert not get_prompt_queue_path(logdir).exists()
+
+
+def test_complete_checks_external_queue_before_exiting(tmp_path):
+    """External queued prompts should keep the loop alive after complete."""
+    import sys
+
+    from gptme.chat import _run_chat_loop
+    from gptme.message import Message
+    from gptme.prompt_queue import get_prompt_queue_path, queue_prompt
+    from gptme.tools.complete import SessionCompleteException
+
+    _chat_mod = sys.modules["gptme.chat"]
+
+    logdir = tmp_path / "chat"
+    logdir.mkdir()
+    queue_prompt(logdir, "queued follow-up")
+
+    manager = MagicMock()
+    manager.log = MagicMock()
+    manager.workspace = tmp_path
+    manager.logdir = logdir
+
+    call_count = 0
+
+    def mock_process(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise SessionCompleteException("first prompt done")
+
+    with (
+        patch.object(
+            _chat_mod, "_process_message_conversation", side_effect=mock_process
+        ),
+        patch.object(_chat_mod, "trigger_hook", return_value=[]),
+        patch.object(_chat_mod, "include_paths", side_effect=lambda msg, ws: msg),
+        patch.object(_chat_mod, "execute_cmd", return_value=False),
+    ):
+        _run_chat_loop(
+            manager=manager,
+            prompt_queue=[Message("user", "first prompt")],
+            stream=False,
+            tool_format="markdown",
+            model=None,
+            interactive=False,
+        )
+
+    assert call_count == 2
+    assert not get_prompt_queue_path(logdir).exists()
+
+
 def test_complete_hook_does_not_refire_on_next_prompt():
     """complete_hook must not raise when the complete tool call is in a prior turn.
 

--- a/tests/test_util_cli.py
+++ b/tests/test_util_cli.py
@@ -1,5 +1,6 @@
 """Tests for the gptme-util CLI."""
 
+import json
 import time
 from pathlib import Path
 from types import SimpleNamespace
@@ -141,6 +142,26 @@ def test_context_index_and_retrieve(tmp_path):
     assert result.exit_code == 0
     assert result.output.count("Hello, world!") > 0
     # assert result.output.count("Hello, world!") == 1
+
+
+def test_chats_send(tmp_path, monkeypatch):
+    """Test queueing a prompt for an existing conversation."""
+    runner = CliRunner()
+
+    logs_dir = tmp_path / "logs"
+    conv_dir = logs_dir / "chat-123"
+    conv_dir.mkdir(parents=True)
+
+    monkeypatch.setattr("gptme.cli.cmd_chats.get_logs_dir", lambda: logs_dir)
+
+    result = runner.invoke(main, ["chats", "send", "chat-123", "follow", "up"])
+
+    assert result.exit_code == 0
+    assert "Queued prompt for 'chat-123'" in result.output
+
+    queue_path = conv_dir / "prompt-queue.jsonl"
+    records = [json.loads(line) for line in queue_path.read_text().splitlines()]
+    assert [record["content"] for record in records] == ["follow up"]
 
 
 def test_tools_list():


### PR DESCRIPTION
## Summary
- add a durable per-conversation prompt queue for active chats
- add `gptme-util chats send <id> ...` to queue follow-up prompts from another terminal while a chat is busy
- drain queued prompts between turns, including after `complete`, so queued follow-ups are not dropped

## Why
Fixes #569.

The CLI already had an in-memory `prompt_queue`, but there was no way to feed it while a conversation was running. Trying to support live typing into the same streaming terminal is a mess. This MVP takes the simpler path: queue prompts against the conversation logdir and let the chat loop pick them up safely on the next turn.

## Validation
- `ruff check gptme/prompt_queue.py gptme/chat.py gptme/cli/cmd_chats.py gptme/cli/main.py tests/test_chat.py tests/test_util_cli.py`
- `python -m pytest tests/test_chat.py::test_external_queued_prompts_are_drained_between_turns tests/test_chat.py::test_complete_checks_external_queue_before_exiting tests/test_util_cli.py::test_chats_send -q`

## Notes
- This is intentionally a queue-from-another-terminal flow, not same-terminal live editing.
- The full `tests/test_chat.py` file still has an unrelated pre-existing failure in `test_image_auto_attach_end_to_end` on this machine, so validation stayed scoped to the new regressions.
