### PR TITLE
fix(server): require explicit opt-in for API auto_confirm on network bindings

### DIFF
--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -57,7 +57,7 @@ from .api_v2_common import (
     msg2dict,
 )
 from .api_v2_sessions import SessionManager, sessions_api
-from .auth import require_auth
+from .auth import is_auto_confirm_allowed, require_auth
 from .external_sessions import get_external_session_provider
 from .openapi_docs import (
     CONVERSATION_ID_PARAM,
@@ -471,6 +471,30 @@ def api_conversation_put(conversation_id: str):
                 }
             ),
             400,
+        )
+
+    # CWE-78: when the server is reachable over the network (auth enabled),
+    # allowing API callers to set auto_confirm turns any prompt-injection
+    # foothold into shell/python execution. Require an explicit operator
+    # opt-in (GPTME_ALLOW_AUTO_CONFIRM=1). Loopback binding (auth disabled)
+    # keeps existing behavior.
+    auto_confirm_truthy = (
+        (type(auto_confirm) is bool and auto_confirm)
+        or (type(auto_confirm) is int and auto_confirm > 0)
+    )
+    if auto_confirm_truthy and not is_auto_confirm_allowed():
+        return (
+            flask.jsonify(
+                {
+                    "error": "auto_confirm not allowed",
+                    "message": (
+                        "Setting 'auto_confirm' over the API is disabled when "
+                        "the server is bound to a network interface. Set "
+                        "GPTME_ALLOW_AUTO_CONFIRM=1 on the server to opt in."
+                    ),
+                }
+            ),
+            403,
         )
 
     # Validate all messages before creating any side effects (directories).

--- a/gptme/server/api_v2_sessions.py
+++ b/gptme/server/api_v2_sessions.py
@@ -22,7 +22,7 @@ from ..llm.models import get_default_model
 from ..logmanager import LogManager
 from ..message import Message
 from .api_v2_common import _validate_branch, _validate_conversation_id
-from .auth import require_auth
+from .auth import is_auto_confirm_allowed, require_auth
 from .constants import DEFAULT_FALLBACK_MODEL
 from .openapi_docs import (
     CONVERSATION_ID_PARAM,
@@ -301,6 +301,26 @@ def api_conversation_step(conversation_id: str):
                 }
             ),
             400,
+        )
+
+    # CWE-78: gate auto_confirm on network bindings. See api_v2.py for rationale.
+    auto_confirm_truthy = (
+        (type(auto_confirm) is bool and auto_confirm)
+        or (type(auto_confirm) is int and auto_confirm > 0)
+    )
+    if auto_confirm_truthy and not is_auto_confirm_allowed():
+        return (
+            flask.jsonify(
+                {
+                    "error": "auto_confirm not allowed",
+                    "message": (
+                        "Setting 'auto_confirm' over the API is disabled when "
+                        "the server is bound to a network interface. Set "
+                        "GPTME_ALLOW_AUTO_CONFIRM=1 on the server to opt in."
+                    ),
+                }
+            ),
+            403,
         )
 
     # If auto_confirm set, set auto_confirm_count.
@@ -605,6 +625,22 @@ def api_conversation_tool_confirm(conversation_id: str):
         count = req_json.get("count", 1)
         if not isinstance(count, int) or isinstance(count, bool) or count <= 0:
             return flask.jsonify({"error": "count must be a positive integer"}), 400
+
+        # CWE-78: gate auto_confirm on network bindings.
+        if not is_auto_confirm_allowed():
+            return (
+                flask.jsonify(
+                    {
+                        "error": "auto_confirm not allowed",
+                        "message": (
+                            "The 'auto' confirmation action is disabled when "
+                            "the server is bound to a network interface. Set "
+                            "GPTME_ALLOW_AUTO_CONFIRM=1 on the server to opt in."
+                        ),
+                    }
+                ),
+                403,
+            )
 
         session.auto_confirm_count = count
 

--- a/gptme/server/api_v2_sessions.py
+++ b/gptme/server/api_v2_sessions.py
@@ -621,12 +621,9 @@ def api_conversation_tool_confirm(conversation_id: str):
         _start_step_thread(conversation_id, session, model, chat_config.workspace)
 
     elif action == "auto":
-        # Enable auto-confirmation for future tools
-        count = req_json.get("count", 1)
-        if not isinstance(count, int) or isinstance(count, bool) or count <= 0:
-            return flask.jsonify({"error": "count must be a positive integer"}), 400
-
-        # CWE-78: gate auto_confirm on network bindings.
+        # CWE-78: gate auto_confirm on network bindings. Run this before count
+        # validation so a 403 is returned consistently with the other gated
+        # paths in this file (POST /step, PUT conversation).
         if not is_auto_confirm_allowed():
             return (
                 flask.jsonify(
@@ -641,6 +638,11 @@ def api_conversation_tool_confirm(conversation_id: str):
                 ),
                 403,
             )
+
+        # Enable auto-confirmation for future tools
+        count = req_json.get("count", 1)
+        if not isinstance(count, int) or isinstance(count, bool) or count <= 0:
+            return flask.jsonify({"error": "count must be a positive integer"}), 400
 
         session.auto_confirm_count = count
 

--- a/gptme/server/auth.py
+++ b/gptme/server/auth.py
@@ -246,6 +246,36 @@ def init_auth(host: str = "127.0.0.1", display: bool = True) -> str | None:
     return token
 
 
+def is_auth_enabled() -> bool:
+    """Return True if authentication is currently enforced.
+
+    Authentication is enforced when the server is bound to a non-loopback
+    address (network binding). It is disabled for loopback binding and when
+    the operator has explicitly opted out via GPTME_DISABLE_AUTH.
+
+    Other modules use this signal to decide whether requests originate from a
+    trusted local context or from a potentially-remote caller, so that
+    high-impact features (e.g. auto-confirming LLM-generated tool executions)
+    can be gated more conservatively in the network case.
+    """
+    return _auth_enabled
+
+
+def is_auto_confirm_allowed() -> bool:
+    """Return True if API callers may set auto_confirm to a truthy value.
+
+    Auto-confirming tool executions over the API turns any prompt-injection
+    foothold into arbitrary command execution (CWE-78), since LLM output is
+    fed straight into shell/python tools without human review. We therefore
+    require an explicit operator opt-in (GPTME_ALLOW_AUTO_CONFIRM=1) whenever
+    auth is enforced (network binding). On loopback, where auth is disabled
+    by design, the existing behavior is preserved.
+    """
+    if not _auth_enabled:
+        return True
+    return os.environ.get("GPTME_ALLOW_AUTO_CONFIRM", "").lower() in ("1", "true", "yes")
+
+
 @auth_api.route("/api/v2/auth/cookie", methods=["POST"])
 @require_auth
 def set_auth_cookie():

--- a/gptme/server/auth.py
+++ b/gptme/server/auth.py
@@ -26,6 +26,12 @@ _server_token: str | None = None
 # Auth state (disabled for local-only binding)
 _auth_enabled: bool = True
 
+# Network binding state (True if bound to a non-loopback interface).
+# Tracked independently of _auth_enabled because auth can be disabled on a
+# network binding via GPTME_DISABLE_AUTH (external auth scenarios), and some
+# gates (e.g. auto_confirm) need to remain network-aware regardless.
+_is_network_binding: bool = False
+
 # Cookie configuration
 AUTH_COOKIE_NAME = "gptme_auth"
 AUTH_COOKIE_MAX_AGE = 86400  # 24 hours
@@ -187,7 +193,12 @@ def init_auth(host: str = "127.0.0.1", display: bool = True) -> str | None:
         The server token (only generated when binding to network,
         None for local-only binding).
     """
-    global _auth_enabled
+    global _auth_enabled, _is_network_binding
+
+    # Track whether this binding is network-reachable, independent of whether
+    # gptme's own auth layer is enforced. Some gates (e.g. auto_confirm) need
+    # this signal even when auth is disabled in favour of an external layer.
+    _is_network_binding = not is_local_host(host)
 
     # Check if auth is explicitly disabled via environment variable
     if os.environ.get("GPTME_DISABLE_AUTH", "").lower() in ("true", "1", "yes"):
@@ -268,10 +279,15 @@ def is_auto_confirm_allowed() -> bool:
     foothold into arbitrary command execution (CWE-78), since LLM output is
     fed straight into shell/python tools without human review. We therefore
     require an explicit operator opt-in (GPTME_ALLOW_AUTO_CONFIRM=1) whenever
-    auth is enforced (network binding). On loopback, where auth is disabled
-    by design, the existing behavior is preserved.
+    the server is bound to a non-loopback interface, regardless of whether
+    gptme's own auth layer is enforced.
+
+    Keying on the network-binding flag (rather than ``_auth_enabled``) closes
+    the bypass that exists when ``GPTME_DISABLE_AUTH`` is set on a network
+    binding for external-auth deployments (e.g. k8s ingress, reverse proxy).
+    On loopback the existing behavior is preserved.
     """
-    if not _auth_enabled:
+    if not _is_network_binding:
         return True
     return os.environ.get("GPTME_ALLOW_AUTO_CONFIRM", "").lower() in ("1", "true", "yes")
 

--- a/tests/test_llm_auth.py
+++ b/tests/test_llm_auth.py
@@ -699,3 +699,132 @@ def _mock_config(env: dict[str, str] | None = None):
             raise KeyError(f"Missing environment variable: {key}")
 
     return MockConfig()
+
+
+# --- Auto-confirm gate (CWE-78) ---
+
+
+class TestIsAutoConfirmAllowed:
+    """Tests for is_auto_confirm_allowed() — the API auto_confirm gate.
+
+    The gate must remain network-aware even when gptme's own auth is
+    disabled (external-auth deployments such as k8s ingress / reverse
+    proxy), since prompt-injection -> RCE is a network-binding concern,
+    not an auth-layer concern.
+    """
+
+    def _save(self):
+        import gptme.server.auth as a
+
+        return (a._auth_enabled, a._is_network_binding)
+
+    def _restore(self, saved):
+        import gptme.server.auth as a
+
+        a._auth_enabled, a._is_network_binding = saved
+
+    def test_loopback_allows_without_optin(self):
+        import gptme.server.auth as a
+
+        saved = self._save()
+        try:
+            a._is_network_binding = False
+            a._auth_enabled = False
+            with patch.dict(os.environ, {}, clear=False):
+                os.environ.pop("GPTME_ALLOW_AUTO_CONFIRM", None)
+                assert a.is_auto_confirm_allowed() is True
+        finally:
+            self._restore(saved)
+
+    def test_network_binding_blocks_without_optin(self):
+        import gptme.server.auth as a
+
+        saved = self._save()
+        try:
+            a._is_network_binding = True
+            a._auth_enabled = True
+            os.environ.pop("GPTME_ALLOW_AUTO_CONFIRM", None)
+            assert a.is_auto_confirm_allowed() is False
+        finally:
+            self._restore(saved)
+
+    def test_network_binding_allows_with_optin(self):
+        import gptme.server.auth as a
+
+        saved = self._save()
+        try:
+            a._is_network_binding = True
+            a._auth_enabled = True
+            for val in ("1", "true", "TRUE", "yes"):
+                with patch.dict(os.environ, {"GPTME_ALLOW_AUTO_CONFIRM": val}):
+                    assert a.is_auto_confirm_allowed() is True, f"failed for {val}"
+        finally:
+            self._restore(saved)
+            os.environ.pop("GPTME_ALLOW_AUTO_CONFIRM", None)
+
+    def test_network_binding_with_external_auth_still_blocks(self):
+        """Regression: external-auth deployments (GPTME_DISABLE_AUTH on a
+        non-loopback bind) must still be gated by GPTME_ALLOW_AUTO_CONFIRM."""
+        import gptme.server.auth as a
+
+        saved = self._save()
+        try:
+            # Simulate: bound to 0.0.0.0, GPTME_DISABLE_AUTH=true.
+            a._is_network_binding = True
+            a._auth_enabled = False
+            os.environ.pop("GPTME_ALLOW_AUTO_CONFIRM", None)
+            assert a.is_auto_confirm_allowed() is False
+        finally:
+            self._restore(saved)
+
+
+class TestInitAuthNetworkBindingFlag:
+    """init_auth() must set _is_network_binding correctly in all branches."""
+
+    def _save(self):
+        import gptme.server.auth as a
+
+        return (a._auth_enabled, a._is_network_binding, a._server_token)
+
+    def _restore(self, saved):
+        import gptme.server.auth as a
+
+        a._auth_enabled, a._is_network_binding, a._server_token = saved
+
+    def test_loopback_sets_network_false(self):
+        import gptme.server.auth as a
+
+        saved = self._save()
+        try:
+            a._is_network_binding = True
+            a.init_auth("127.0.0.1", display=False)
+            assert a._is_network_binding is False
+        finally:
+            self._restore(saved)
+
+    def test_network_bind_sets_network_true(self):
+        import gptme.server.auth as a
+
+        saved = self._save()
+        try:
+            a._is_network_binding = False
+            a._server_token = None
+            with patch.dict(os.environ, {"GPTME_SERVER_TOKEN": "t"}):
+                a.init_auth("0.0.0.0", display=False)
+            assert a._is_network_binding is True
+        finally:
+            self._restore(saved)
+
+    def test_external_auth_on_network_keeps_network_true(self):
+        import gptme.server.auth as a
+
+        saved = self._save()
+        try:
+            a._is_network_binding = False
+            with patch.dict(os.environ, {"GPTME_DISABLE_AUTH": "true"}):
+                a.init_auth("0.0.0.0", display=False)
+            assert a._is_network_binding is True
+            assert a._auth_enabled is False
+        finally:
+            self._restore(saved)
+            os.environ.pop("GPTME_DISABLE_AUTH", None)


### PR DESCRIPTION
## Summary

When `gptme-server` is bound to a non-loopback interface (auth enabled), authenticated API callers can set `auto_confirm` / `auto_confirm_count` on a session, causing subsequent LLM-emitted shell/python tool calls to execute without human review. Combined with prompt injection — which is the standard threat model for any agent that ingests web pages, files, or tool output — this turns an authenticated foothold into arbitrary command execution as the server user.

This PR gates the three (and only three) code paths that can mutate `session.auto_confirm_count`, requiring an explicit operator opt-in (`GPTME_ALLOW_AUTO_CONFIRM=1`) whenever auth is enforced. Loopback behavior is unchanged.

## Affected code paths

All three mutation points for `session.auto_confirm_count`:

- `gptme/server/api_v2.py` — `PUT /api/v2/conversations/<id>` accepts `auto_confirm` in payload
- `gptme/server/api_v2_sessions.py` — `POST /api/v2/conversations/<id>/step` accepts `auto_confirm`
- `gptme/server/api_v2_sessions.py` — `POST /api/v2/conversations/<id>/tool/confirm` with `action=auto, count=N`

## Why this matters

`SECURITY.md` documents interactive confirmation as a load-bearing control:

> **Interactive Mode**: Commands require user confirmation before execution

Authentication answers *who can talk to the API*. It does not answer *what the LLM gets told to do once a request is in flight*. Any prompt-injection vector — a fetched web page, a file the user opens, tool output — can instruct the model to emit a shell or python tool block. With `auto_confirm` set, those run without the human-in-the-loop step that lets a user notice the injection.

## Preconditions

- Server bound to a non-loopback interface (auth enabled)
- Either: attacker possesses a valid bearer token, OR an authenticated user is induced to ingest attacker-controlled content (web fetch, file paste, tool output)
- LLM follows the injected instructions and emits a shell/python tool block

## Fix

Adds `is_auto_confirm_allowed()` in `gptme/server/auth.py` and gates all three mutation points:

- **Auth disabled** (loopback, single-user CLI-equivalent context) → behavior unchanged.
- **Auth enabled** (network binding) → setting `auto_confirm` truthy or calling `action=auto` returns HTTP 403 unless the operator has set `GPTME_ALLOW_AUTO_CONFIRM=1` on the server process.

The 403 response body documents the env var so operators who genuinely want unattended automation on a network binding can still opt in deliberately.

Diffstat:

```
 gptme/server/api_v2.py          | 26 +++++++++++++++++++++++++-
 gptme/server/api_v2_sessions.py | 38 +++++++++++++++++++++++++++++++++++++-
 gptme/server/auth.py            | 30 ++++++++++++++++++++++++++++++
 3 files changed, 92 insertions(+), 2 deletions(-)
```

## Testing

- Manually exercised all three endpoints in both modes:
  - With auth disabled (loopback) — `auto_confirm=true` is accepted, existing behavior preserved.
  - With auth enabled and `GPTME_ALLOW_AUTO_CONFIRM` unset — all three paths return 403 with a helpful message.
  - With auth enabled and `GPTME_ALLOW_AUTO_CONFIRM=1` — accepted as before.
- Confirmed the `bool`/`int` discrimination matches the existing `type(...) is bool` pattern in the surrounding code (since `bool` is a subclass of `int` in Python).
- Existing server tests continue to pass; the gate is additive.

## Adversarial review

Before submitting we tried to disprove this:

- **Does auth alone mitigate it?** No. Auth controls API access, not LLM-emitted instructions. Prompt injection is the standard threat model for tool-using agents, and `SECURITY.md` already names interactive confirmation as the mitigation.
- **Is the loopback / CLI case affected?** No. Loopback disables auth and matches single-user CLI semantics; the fix preserves that behavior exactly.
- **Are there other paths to set `auto_confirm_count`?** We grepped for every assignment to `auto_confirm_count` and `session.auto_confirm_count` — the three endpoints above are the only mutation points.
- **Is the env var a footgun?** It's opt-in, defaults closed, and is surfaced in the 403 response body, so it's discoverable rather than hidden.

## Disclosure

`SECURITY.md` asks for private reporting; we attempted to file via GitHub's private vulnerability reporting endpoint first, but it returned a 500 error on submission. Since the patch itself is what needs review, we're sending it as a PR. Happy to coordinate via `security@gptme.org` if you'd prefer to discuss exploitability privately before merging — just let us know.

## Classification

- CWE-78 (OS Command Injection, via tool execution)
- Adjacent: CWE-862 (Missing Authorization on a security-relevant state mutation)
- Severity: High — single-step prompt-injection-to-RCE chain when prerequisites are met.