### PR TITLE
fix(webui): surface auto-step startup failures

### DIFF
--- a/webui/src/components/MainLayout.tsx
+++ b/webui/src/components/MainLayout.tsx
@@ -14,7 +14,9 @@ import { MobileBottomNav } from '@/components/MobileBottomNav';
 import { UnifiedSidebar } from '@/components/UnifiedSidebar';
 import { AgentsView } from '@/components/AgentsView';
 import { WorkspacesView } from '@/components/WorkspacesView';
+import { useToast } from '@/components/ui/use-toast';
 import { setDocumentTitle } from '@/utils/title';
+import { toastStepStartError } from '@/utils/stepErrorHandling';
 import { useQueryClient } from '@tanstack/react-query';
 import { useConversationsInfiniteQuery } from '@/hooks/useConversationsInfiniteQuery';
 import { useSecondaryServerConversations } from '@/hooks/useMultiServerConversations';
@@ -54,6 +56,7 @@ const MainLayout: FC<Props> = ({ conversationId, taskId }) => {
   const stepParam = searchParams.get('step');
   const serverParam = searchParams.get('server');
   const { api, isConnected$ } = useApi();
+  const { toast } = useToast();
   const queryClient = useQueryClient();
   const isConnected = use$(isConnected$);
   const conversation$ = useObservable<ConversationSummary | undefined>(undefined);
@@ -141,6 +144,7 @@ const MainLayout: FC<Props> = ({ conversationId, taskId }) => {
 
           api.step(conversationId).catch((error) => {
             console.error('[MainLayout] Failed to start generation:', error);
+            toastStepStartError(toast, error);
           });
 
           const newSearchParams = new URLSearchParams(searchParams);
@@ -155,7 +159,7 @@ const MainLayout: FC<Props> = ({ conversationId, taskId }) => {
 
       checkAndStart();
     }
-  }, [stepParam, conversationId, isConnected, api, navigate, searchParams]);
+  }, [stepParam, conversationId, isConnected, api, navigate, searchParams, toast]);
 
   // Fetch conversations from primary server
   const { data, isError, error, isLoading, isFetching, fetchNextPage, hasNextPage, refetch } =

--- a/webui/src/hooks/useConversation.ts
+++ b/webui/src/hooks/useConversation.ts
@@ -27,6 +27,7 @@ import { playChime } from '@/utils/audio';
 import { findLatestAssistantIndexForError } from '@/utils/conversationErrorHandling';
 import { notifyGenerationComplete, notifyToolConfirmation } from '@/utils/notifications';
 import { ApiClientError } from '@/utils/api';
+import { toastStepStartError } from '@/utils/stepErrorHandling';
 
 const MAX_CONNECTED_CONVERSATIONS = 3;
 
@@ -342,6 +343,7 @@ export function useConversation(conversationId: string, serverId?: string) {
                 setNeedsInitialStep(conversationId, false);
                 api.step(conversationId).catch((error) => {
                   console.error('[useConversation] Error triggering initial step:', error);
+                  toastStepStartError(toast, error);
                 });
               }
             },

--- a/webui/src/utils/__tests__/stepErrorHandling.test.ts
+++ b/webui/src/utils/__tests__/stepErrorHandling.test.ts
@@ -1,0 +1,30 @@
+import { getStepStartErrorMessage, toastStepStartError } from '../stepErrorHandling';
+
+describe('getStepStartErrorMessage', () => {
+  it('prefers the Error message when present', () => {
+    expect(getStepStartErrorMessage(new Error('rate limit exceeded'))).toBe('rate limit exceeded');
+  });
+
+  it('accepts non-empty string errors', () => {
+    expect(getStepStartErrorMessage('fleet API key exhausted')).toBe('fleet API key exhausted');
+  });
+
+  it('falls back when the error is empty or unknown', () => {
+    expect(getStepStartErrorMessage(new Error(''))).toBe('Failed to start generation');
+    expect(getStepStartErrorMessage(undefined)).toBe('Failed to start generation');
+  });
+});
+
+describe('toastStepStartError', () => {
+  it('emits a destructive generation toast', () => {
+    const toast = jest.fn();
+
+    toastStepStartError(toast, new Error('rate limit exceeded'));
+
+    expect(toast).toHaveBeenCalledWith({
+      variant: 'destructive',
+      title: 'Generation failed',
+      description: 'rate limit exceeded',
+    });
+  });
+});

--- a/webui/src/utils/stepErrorHandling.ts
+++ b/webui/src/utils/stepErrorHandling.ts
@@ -1,0 +1,25 @@
+type StepErrorToast = (props: {
+  variant: 'destructive';
+  title: string;
+  description: string;
+}) => void;
+
+export function getStepStartErrorMessage(error: unknown): string {
+  if (error instanceof Error && error.message.trim()) {
+    return error.message;
+  }
+
+  if (typeof error === 'string' && error.trim()) {
+    return error;
+  }
+
+  return 'Failed to start generation';
+}
+
+export function toastStepStartError(toast: StepErrorToast, error: unknown): void {
+  toast({
+    variant: 'destructive',
+    title: 'Generation failed',
+    description: getStepStartErrorMessage(error),
+  });
+}


### PR DESCRIPTION
## Summary
- surface `api.step()` failures in the two auto-step paths that still only logged to the console
- reuse a small shared helper so both startup flows show the same destructive toast
- add a webui regression test for the helper

## Testing
- ./node_modules/.bin/jest --runTestsByPath src/utils/__tests__/stepErrorHandling.test.ts src/utils/__tests__/conversationErrorHandling.test.ts
- ./node_modules/.bin/tsc -p tsconfig.app.json --noEmit
- ./node_modules/.bin/eslint src/components/MainLayout.tsx src/hooks/useConversation.ts src/utils/stepErrorHandling.ts src/utils/__tests__/stepErrorHandling.test.ts
- ./node_modules/.bin/prettier --check src/components/MainLayout.tsx src/hooks/useConversation.ts src/utils/stepErrorHandling.ts src/utils/__tests__/stepErrorHandling.test.ts

Related: gptme/gptme-cloud#172