### PR TITLE
docs(readme): fix truncated initial-commit SHA link

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ active development.
 - **2024-10** - [First viral tweet](https://x.com/rohanpaul_ai/status/1841999030999470326) bringing widespread attention
 - **2024-08** - [Show HN](https://news.ycombinator.com/item?id=41204256), Anthropic Claude support, tmux tool
 - **2023-09** - [Initial public release](https://news.ycombinator.com/item?id=37394845) on HN, [Reddit](https://www.reddit.com/r/LocalLLaMA/comments/16atlia/), [Twitter](https://x.com/ErikBjare/status/1699097896451289115)
-- **2023-03** - [Initial commit](https://github.com/gptme/gptme/commit/d00e9aae68cbd6b89bbc474ed7721d08796dc) - one of the first agent CLIs
+- **2023-03** - [Initial commit](https://github.com/gptme/gptme/commit/d00e9aae68cbd6b89bbc474ed7721d08798f96dc) - one of the first agent CLIs
 
 
 <!-- source of truth: docs/timeline.rst and docs/changelog.rst -->


### PR DESCRIPTION
## Summary

The "Timeline" / About section links the project's initial commit:

> **2023-03** - [Initial commit](https://github.com/gptme/gptme/commit/d00e9aae68cbd6b89bbc474ed7721d08796dc) - one of the first agent CLIs

The SHA is 37 chars long, so GitHub 404s the page. The real first commit on `master` is `d00e9aae68cbd6b89bbc474ed7721d08798f96dc` (40 chars) — the `8f9` bytes were dropped somewhere along the way.

## Verification

```
$ gh api repos/gptme/gptme/commits/d00e9aae68cbd6b89bbc474ed7721d08796dc 2>&1 | head -1
HTTP 422 Unprocessable Entity: ...

$ gh api repos/gptme/gptme/commits/d00e9aae68cbd6b89bbc474ed7721d08798f96dc | jq '{sha, date: .commit.author.date, msg: .commit.message}'
{
  "sha": "d00e9aae68cbd6b89bbc474ed7721d08798f96dc",
  "date": "2023-03-24T16:29:54Z",
  "msg": "initial commit\n"
}
```

One-character-class fix in `README.md` line 109. No other content changes.

## Test plan

- [x] New URL renders the commit page (200)
- [x] Date / message match the "2023-03" claim in the timeline entry
- [x] No other README link broken by this change
