### PR TITLE
test(webui): cover provider setup server settings action

### DIFF
--- a/webui/src/components/__tests__/WelcomeView.test.tsx
+++ b/webui/src/components/__tests__/WelcomeView.test.tsx
@@ -4,6 +4,7 @@ import { observable } from '@legendapp/state';
 import { SettingsProvider } from '@/contexts/SettingsContext';
 import { WelcomeView } from '../WelcomeView';
 import { setupWizard$ } from '@/stores/setupWizard';
+import { settingsModal$ } from '@/stores/settingsModal';
 
 const mockNavigate = jest.fn();
 const mockInvalidateQueries = jest.fn();
@@ -65,6 +66,7 @@ describe('WelcomeView', () => {
     setupWizard$.step.set('welcome');
     setupWizard$.open.set(false);
     setupWizard$.providerStatusVersion.set(0);
+    settingsModal$.set({ open: false, category: 'appearance' });
     mockConnect.mockReset();
     mockNavigate.mockClear();
     mockInvalidateQueries.mockClear();
@@ -145,6 +147,27 @@ describe('WelcomeView', () => {
 
     await waitFor(() => {
       expect(setupWizard$.get()).toMatchObject({ open: true, step: 'provider' });
+    });
+  });
+
+  it('opens server settings from the provider-required banner', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ provider_configured: false }),
+    });
+
+    render(
+      <SettingsProvider>
+        <WelcomeView />
+      </SettingsProvider>
+    );
+
+    expect(await screen.findByText('Provider setup required')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /server settings/i }));
+
+    await waitFor(() => {
+      expect(settingsModal$.get()).toMatchObject({ open: true, category: 'servers' });
     });
   });
 


### PR DESCRIPTION
## Summary\n- add a WelcomeView regression test for the provider-required banner's `Server settings` CTA\n- reset `settingsModal$` between WelcomeView tests so the modal state assertion is deterministic\n- keep coverage aligned with the onboarding/settings flows that already exist on `master`\n\n## Why\nIssue #2193's original product gap is mostly already green on `master`: the setup wizard, provider-required banner, and server API-key settings are all in place. The missing piece here was regression coverage for the settings entrypoint from the provider-required state, which is exactly the path users need when the server is reachable but no provider is configured.\n\n## Verification\n- `cd /tmp/worktrees/gptme/bob-2193-tauri-onboarding/webui && npm test -- --runInBand src/components/__tests__/SetupWizard.test.tsx src/components/__tests__/WelcomeView.test.tsx src/components/settings/__tests__/ServerApiKeySettings.test.tsx`\n\nRefs #2193