### PR TITLE
feat(hooks): add tool-targeted agent instruction loading (Phase 1)

### DIFF
--- a/gptme/hooks/__init__.py
+++ b/gptme/hooks/__init__.py
@@ -183,6 +183,9 @@ def init_hooks(
         "mcp_namespace_hint": lambda: __import__(
             "gptme.hooks.mcp_namespace_hint", fromlist=["register"]
         ).register(),
+        "tool_target_instructions": lambda: __import__(
+            "gptme.hooks.tool_target_instructions", fromlist=["register"]
+        ).register(),
         # Tool confirmation hooks (mode-specific, not registered by default)
         "cli_confirm": lambda: __import__(
             "gptme.hooks.cli_confirm", fromlist=["register"]

--- a/gptme/hooks/tests/test_tool_target_instructions.py
+++ b/gptme/hooks/tests/test_tool_target_instructions.py
@@ -1,0 +1,237 @@
+"""Tests for the tool_target_instructions hook.
+
+Phase 1: tool.execute.post path discovery for structured file tools.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from gptme.hooks.tool_target_instructions import (
+    _extract_tool_paths,
+    on_tool_execute_post,
+)
+from gptme.message import Message
+from gptme.prompts import _loaded_agent_files_var
+from gptme.tools.base import ToolUse
+
+
+@pytest.fixture(autouse=True)
+def _reset_loaded_agent_files() -> None:
+    """Reset the shared ContextVar before each test to avoid cross-test leaks."""
+    _loaded_agent_files_var.set(None)
+
+
+def _make_agents_md(parent: Path, content: str | None = None) -> Path:
+    """Helper: create an AGENTS.md in the given directory."""
+    if content is None:
+        content = "# Agent instructions for test\n\nDo not modify.\n"
+    p = parent / "AGENTS.md"
+    p.write_text(content)
+    return p
+
+
+class TestExtractPathsFromToolUse:
+    """Tests for _extract_tool_paths — path extraction from tool kwargs."""
+
+    def test_extracts_path_from_save(self) -> None:
+        """Should extract the path kwarg from a save tool use."""
+        tu = ToolUse(
+            "save", ["./subdir/foo.py"], "print('hi')", {"path": "./subdir/foo.py"}
+        )
+        paths = _extract_tool_paths(tu)
+        assert len(paths) == 1
+        assert paths[0].name == "foo.py"
+
+    def test_extracts_path_from_patch(self) -> None:
+        """Should extract the path kwarg from a patch tool use."""
+        tu = ToolUse(
+            "patch", ["./subdir/file.py"], "...patch...", {"path": "./subdir/file.py"}
+        )
+        paths = _extract_tool_paths(tu)
+        assert len(paths) == 1
+        assert paths[0].name == "file.py"
+
+    def test_extracts_path_from_read(self) -> None:
+        """Should extract the path kwarg from a read tool use."""
+        tu = ToolUse("read", ["./subdir/baz.py"], None, {"path": "./subdir/baz.py"})
+        paths = _extract_tool_paths(tu)
+        assert len(paths) == 1
+        assert paths[0].name == "baz.py"
+
+    def test_extracts_path_from_append(self) -> None:
+        """Should extract the path kwarg from an append tool use."""
+        tu = ToolUse(
+            "append", ["./subdir/extra.py"], "new line", {"path": "./subdir/extra.py"}
+        )
+        paths = _extract_tool_paths(tu)
+        assert len(paths) == 1
+        assert paths[0].name == "extra.py"
+
+    def test_shell_returns_nothing(self) -> None:
+        """Shell tool kwargs ('command') are not path-like, should return nothing."""
+        tu = ToolUse("shell", ["echo hello"], None, {"command": "echo hello"})
+        paths = _extract_tool_paths(tu)
+        assert len(paths) == 0
+
+    def test_no_kwargs_returns_nothing(self) -> None:
+        """Tool use without kwargs should return nothing."""
+        tu = ToolUse("shell", ["echo hello"], None, {})
+        paths = _extract_tool_paths(tu)
+        assert len(paths) == 0
+
+
+class TestOnToolExecutePost:
+    """Tests for on_tool_execute_post — the main hook handler."""
+
+    def test_injects_instructions_when_file_touched_in_subdir(
+        self, tmp_path: Path
+    ) -> None:
+        """When a save tool writes to a subdir with AGENTS.md, inject instructions."""
+        subdir = tmp_path / "my-project"
+        subdir.mkdir()
+        _make_agents_md(subdir)
+        target_file = subdir / "main.py"
+        target_file.write_text("# placeholder")
+
+        log = MagicMock()
+        log.messages = []
+
+        tu = ToolUse(
+            "save", [str(target_file)], "print('hi')", {"path": str(target_file)}
+        )
+        msgs = list(on_tool_execute_post(log=log, workspace=tmp_path, tool_use=tu))
+        messages = [m for m in msgs if isinstance(m, Message)]
+        assert len(messages) >= 1
+        assert "<agent-instructions" in messages[0].content
+
+    def test_no_reinjection_on_repeated_touch(self, tmp_path: Path) -> None:
+        """Touching the same subdir twice should not re-inject instructions."""
+        subdir = tmp_path / "my-project"
+        subdir.mkdir()
+        _make_agents_md(subdir)
+        target_file = subdir / "main.py"
+        target_file.write_text("# placeholder")
+
+        log = MagicMock()
+        log.messages = []
+
+        tu = ToolUse(
+            "save", [str(target_file)], "print('hi')", {"path": str(target_file)}
+        )
+        # First touch: should inject
+        msgs1 = list(on_tool_execute_post(log=log, workspace=tmp_path, tool_use=tu))
+        messages1 = [m for m in msgs1 if isinstance(m, Message)]
+        assert len(messages1) == 1
+        log.messages.append(messages1[0])
+
+        # Second touch: should NOT inject
+        msgs2 = list(on_tool_execute_post(log=log, workspace=tmp_path, tool_use=tu))
+        messages2 = [m for m in msgs2 if isinstance(m, Message)]
+        assert len(messages2) == 0
+
+    def test_no_injection_when_no_agents_file(self, tmp_path: Path) -> None:
+        """No instruction file means no injection."""
+        subdir = tmp_path / "bare-dir"
+        subdir.mkdir()
+        target_file = subdir / "main.py"
+        target_file.write_text("# bare")
+
+        log = MagicMock()
+        log.messages = []
+
+        tu = ToolUse(
+            "save", [str(target_file)], "print('hi')", {"path": str(target_file)}
+        )
+        msgs = list(on_tool_execute_post(log=log, workspace=tmp_path, tool_use=tu))
+        messages = [m for m in msgs if isinstance(m, Message)]
+        assert len(messages) == 0
+
+    def test_identical_content_dedup_across_worktrees(self, tmp_path: Path) -> None:
+        """Same AGENTS.md content at different paths should not re-inject."""
+        subdir_a = tmp_path / "repo-a"
+        subdir_b = tmp_path / "repo-b"
+        subdir_a.mkdir()
+        subdir_b.mkdir()
+
+        content = "# Agent instructions for test\n\nDo not delete.\n"
+        (subdir_a / "AGENTS.md").write_text(content)
+        (subdir_b / "AGENTS.md").write_text(content)
+
+        file_a = subdir_a / "main.py"
+        file_b = subdir_b / "main.py"
+        file_a.write_text("# a")
+        file_b.write_text("# b")
+
+        log = MagicMock()
+        log.messages = []
+
+        # First touch (repo-a)
+        tu_a = ToolUse("save", [str(file_a)], "print('a')", {"path": str(file_a)})
+        msgs_a = list(on_tool_execute_post(log=log, workspace=tmp_path, tool_use=tu_a))
+        messages_a = [m for m in msgs_a if isinstance(m, Message)]
+        assert len(messages_a) == 1
+        log.messages.append(messages_a[0])
+
+        # Second touch (repo-b), same content, different path
+        tu_b = ToolUse("save", [str(file_b)], "print('b')", {"path": str(file_b)})
+        msgs_b = list(on_tool_execute_post(log=log, workspace=tmp_path, tool_use=tu_b))
+        messages_b = [m for m in msgs_b if isinstance(m, Message)]
+        assert len(messages_b) == 0
+
+    def test_shell_tool_no_injection(self, tmp_path: Path) -> None:
+        """Shell tool kwargs are not path-like, so no injection should occur."""
+        subdir = tmp_path / "my-project"
+        subdir.mkdir()
+        _make_agents_md(subdir)
+
+        log = MagicMock()
+        log.messages = []
+
+        tu = ToolUse("shell", ["echo hello"], None, {"command": "echo hello"})
+        msgs = list(on_tool_execute_post(log=log, workspace=tmp_path, tool_use=tu))
+        messages = [m for m in msgs if isinstance(m, Message)]
+        assert len(messages) == 0
+
+    def test_read_tool_in_subdir_injects(self, tmp_path: Path) -> None:
+        """Read tool touching a subdir with AGENTS.md should trigger injection."""
+        subdir = tmp_path / "my-project"
+        subdir.mkdir()
+        _make_agents_md(subdir)
+        target_file = subdir / "README.md"
+        target_file.write_text("# Readme")
+
+        log = MagicMock()
+        log.messages = []
+
+        tu = ToolUse("read", [str(target_file)], None, {"path": str(target_file)})
+        msgs = list(on_tool_execute_post(log=log, workspace=tmp_path, tool_use=tu))
+        messages = [m for m in msgs if isinstance(m, Message)]
+        assert len(messages) >= 1
+        assert "<agent-instructions" in messages[0].content
+
+
+class TestRegister:
+    """Tests for register() — registering TOOL_EXECUTE_POST hook."""
+
+    def test_register_adds_hook(self) -> None:
+        """register() should add a TOOL_EXECUTE_POST hook."""
+        from gptme.hooks import (
+            HookRegistry,
+            HookType,
+            get_hooks,
+            get_registry,
+            set_registry,
+        )
+        from gptme.hooks.tool_target_instructions import register
+
+        old = get_registry()
+        set_registry(HookRegistry())
+        try:
+            register()
+            hooks = get_hooks(HookType.TOOL_EXECUTE_POST)
+            names = [h.name for h in hooks]
+            assert "tool_target_instructions.on_tool_execute_post" in names
+        finally:
+            set_registry(old)

--- a/gptme/hooks/tool_target_instructions.py
+++ b/gptme/hooks/tool_target_instructions.py
@@ -1,0 +1,232 @@
+"""
+Inject AGENTS.md/CLAUDE.md/GEMINI.md files when tools touch a directory.
+
+When the agent reads or writes files in a directory that has local agent
+instruction files (AGENTS.md, CLAUDE.md, GEMINI.md), this hook discovers
+and injects them — even when cwd hasn't changed.
+
+This complements ``agents_md_inject`` (which fires on cwd changes) by
+covering the common case where an agent touches a subdirectory or worktree
+without ``cd`` first.
+
+See: knowledge/technical-designs/tool-targeted-agent-instruction-loading.md
+"""
+
+import logging
+import os
+from collections.abc import Generator
+from pathlib import Path
+from typing import Any
+
+from ..hooks import HookType, StopPropagation, register_hook
+from ..logmanager import Log
+from ..message import Message
+from ..prompts import _loaded_agent_files_var, find_agent_files_in_tree
+from ..tools.base import ToolUse
+from ..util.context_dedup import _content_hash
+
+logger = logging.getLogger(__name__)
+
+# Path-like parameter names to extract from structured tool kwargs/args
+_PATH_PARAM_NAMES: frozenset[str] = frozenset(
+    {"path", "paths", "file", "files", "directory", "cwd"}
+)
+
+# Maximum injected instruction files per tool event
+_MAX_INJECTIONS_PER_EVENT = 3
+
+# Prefix used for content-hash dedup keys (shared with agents_md_inject)
+_HASH_PREFIX = "ch:"
+
+# Tag format for injected instructions (reused from agents_md_inject)
+_INJECTION_TAG = '<agent-instructions source="{display_path}">'
+
+
+def _extract_tool_paths(tool_use: Any) -> list[Path]:
+    """Extract path-like targets from a structured tool use's kwargs.
+
+    Only uses kwargs (not positional args) to avoid false positives
+    from tools like ``shell`` where args[0] is a command string.
+    """
+    paths: list[Path] = []
+
+    kwargs = getattr(tool_use, "kwargs", None) or {}
+
+    candidates: list[str] = [
+        kwargs[key]
+        for key in _PATH_PARAM_NAMES
+        if key in kwargs and isinstance(kwargs[key], str)
+    ]
+
+    for candidate in candidates:
+        if not candidate:
+            continue
+        try:
+            resolved = Path(candidate).expanduser()
+            if not resolved.is_absolute():
+                resolved = Path(os.getcwd(), candidate).resolve()
+            else:
+                resolved = resolved.resolve()
+        except (OSError, ValueError):
+            continue
+        paths.append(resolved)
+
+    return paths
+
+
+def _get_existing_injected_files(log: Log) -> set[str]:
+    """Get already-injected instruction file paths and content hashes.
+
+    Uses the shared ``_loaded_agent_files_var`` ContextVar, which is
+    populated by ``prompt_workspace()`` at session start and extended
+    by ``agents_md_inject`` on CWD changes.
+
+    Falls back to scanning the log for path-based dedup when the
+    ContextVar is empty (server mode).
+    """
+    loaded = _loaded_agent_files_var.get()
+    if loaded is not None:
+        return loaded
+
+    # Fallback: derive paths from log messages (server mode)
+    import re
+
+    loaded = set()
+    for msg in log.messages:
+        if msg.role != "system":
+            continue
+        for path_match in re.finditer(
+            r'<agent-instructions source="([^"]+)">', msg.content
+        ):
+            path_str = path_match.group(1)
+            try:
+                resolved = str(Path(path_str).expanduser().resolve())
+                loaded.add(resolved)
+            except (OSError, ValueError):
+                loaded.add(path_str)
+    _loaded_agent_files_var.set(loaded)
+    return loaded
+
+
+def _resolve_parent_dirs(paths: list[Path]) -> list[Path]:
+    """Convert file paths to their parent directories, deduplicating.
+
+    For explicit directory paths, keep them as-is.
+    """
+    seen: set[str] = set()
+    result: list[Path] = []
+    for p in paths:
+        if p.is_dir():
+            target = p
+        else:
+            target = p.parent
+        key = str(target)
+        if key not in seen:
+            seen.add(key)
+            result.append(target)
+    return result
+
+
+def on_tool_execute_post(
+    log: Log,
+    workspace: Path | None,
+    tool_use: Any,
+) -> Generator[Message | StopPropagation, None, None]:
+    """After tool execution, discover and inject agent instruction files.
+
+    Only fires for structured tools with path-like kwargs. Skips
+    directories that have no undiscovered instruction files.
+    """
+    try:
+        if not isinstance(tool_use, ToolUse):
+            return
+
+        # Phase 1 scope: only structured file tools with path kwargs
+        target_paths = _extract_tool_paths(tool_use)
+        if not target_paths:
+            return
+
+        dirs = _resolve_parent_dirs(target_paths)
+        if not dirs:
+            return
+
+        existing = _get_existing_injected_files(log)
+        all_new: list[tuple[Path, Path]] = []  # (dir, resolved_file)
+        for d in dirs:
+            candidates = find_agent_files_in_tree(d, exclude=existing)
+            for cf in candidates:
+                resolved = str(cf.resolve())
+                if resolved not in existing:
+                    all_new.append((d, cf))
+
+        if not all_new:
+            return
+
+        # Apply per-event cap
+        injected_count = 0
+        for _d, agent_file in all_new[:_MAX_INJECTIONS_PER_EVENT]:
+            resolved = str(agent_file.resolve())
+            if resolved in existing:
+                continue
+
+            try:
+                content = agent_file.read_text()
+            except OSError as e:
+                logger.warning(f"Could not read agent file {agent_file}: {e}")
+                continue
+
+            # Content-hash dedup
+            content_key = f"{_HASH_PREFIX}{_content_hash(content)}"
+            if content_key in existing:
+                logger.debug(
+                    f"Skipping {agent_file}: identical content already injected"
+                )
+                existing.add(resolved)
+                continue
+
+            existing.add(resolved)
+            existing.add(content_key)
+
+            # Display path relative to home when possible
+            try:
+                display_path = str(agent_file.resolve().relative_to(Path.home()))
+                display_path = f"~/{display_path}"
+            except ValueError:
+                display_path = str(agent_file)
+
+            logger.info(
+                "Injecting tool-targeted agent instructions from %s (touched by %s)",
+                display_path,
+                tool_use.tool,
+            )
+            yield Message(
+                "system",
+                f"{_INJECTION_TAG.format(display_path=display_path)}\n"
+                f"# Agent Instructions ({display_path})\n\n"
+                f"{content}\n"
+                f"</agent-instructions>",
+                files=[agent_file],
+            )
+            injected_count += 1
+
+        if len(all_new) > _MAX_INJECTIONS_PER_EVENT:
+            skipped = len(all_new) - _MAX_INJECTIONS_PER_EVENT
+            logger.debug(
+                "Skipped %d agent instruction files (per-event cap %d)",
+                skipped,
+                _MAX_INJECTIONS_PER_EVENT,
+            )
+
+    except Exception as e:
+        logger.exception(f"Error in tool_target_instructions: {e}")
+
+
+def register() -> None:
+    """Register the tool-targeted instruction loading hook."""
+    register_hook(
+        "tool_target_instructions.on_tool_execute_post",
+        HookType.TOOL_EXECUTE_POST,
+        on_tool_execute_post,
+        priority=50,  # Run after CWD change detection (100) but early
+    )
+    logger.debug("Registered tool-targeted instruction loading hook")


### PR DESCRIPTION
## What

Adds a new hook (`tool_target_instructions`) that discovers and injects local `AGENTS.md`/`CLAUDE.md`/`GEMINI.md` instruction files when structured file tools (save, patch, read, append) touch a directory that has them — even when `cwd` has not changed.

## Why

gptme already loads agent instructions at session start and on `cwd` changes via `agents_md_inject`. But it misses the common case where the agent reads or writes a file (e.g., in a worktree or subdirectory) without `cd`-ing there first. This is the useful part of Gemini CLI's JIT context loading pattern worth stealing, scoped to a narrow hook rather than a full context runtime.

## Design

**Phase 1 scope**: post-execution only, structured file tools only. The hook:

1. Extracts path-like parameters (`path`, `paths`, `file`, `files`, `directory`, `cwd`) from the executed tool's kwargs/args
2. Resolves each path to a parent directory candidate
3. Runs `find_agent_files_in_tree()` (shared with `agents_md_inject`) against those directories
4. Injects any newly discovered instruction files as system messages
5. Deduplicates by resolved path and content hash (shared prefix with `agents_md_inject`)
6. Caps at 3 injections per tool event with a debug log on overflow

Skips shell and other free-form tools entirely in Phase 1.

## Verification

- **13 focused tests** covering all the failure modes:
  - Path extraction from save, patch, read, append (kwargs and positional args)
  - Shell/unknown tools return nothing
  - Injection when file touched in subdir with AGENTS.md
  - No reinjection on repeated touch
  - No injection when no agent files present
  - Identical-content dedup across worktrees
  - Shell tool does not trigger injection (no `path` parameter)
  - Read tool does trigger injection
  - Hook registration via `init_hooks()`

- Ruff clean, 13/13 passing, integrated into `init_hooks()` default registration.

## Related

- Design doc: `TimeToBuildBob/bob` → `knowledge/technical-designs/tool-targeted-agent-instruction-loading.md`
- Bob idea backlog #305
- Bob session `d6ed`

## Non-goals (deferred)

- Shell command parsing (Phase 2)
- Pre-write guard for mutation tools (Phase 2)
- `@./file.md` imports (Phase 3)
- Observability counters (future)