### PR TITLE
feat(hooks): tool-target agent-instruction loading (Phase 1)

### DIFF
--- a/gptme/hooks/__init__.py
+++ b/gptme/hooks/__init__.py
@@ -180,6 +180,9 @@ def init_hooks(
         "agents_md_inject": lambda: __import__(
             "gptme.hooks.agents_md_inject", fromlist=["register"]
         ).register(),
+        "tool_target_instructions": lambda: __import__(
+            "gptme.hooks.tool_target_instructions", fromlist=["register"]
+        ).register(),
         "mcp_namespace_hint": lambda: __import__(
             "gptme.hooks.mcp_namespace_hint", fromlist=["register"]
         ).register(),

--- a/gptme/hooks/tests/test_tool_target_instructions.py
+++ b/gptme/hooks/tests/test_tool_target_instructions.py
@@ -1,0 +1,217 @@
+"""Tests for tool_target_instructions hook.
+
+Verifies that AGENTS.md/CLAUDE.md/GEMINI.md files are loaded when a structured
+file tool touches a path under a directory that contains them, without
+requiring a CWD change.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from gptme.hooks.tool_target_instructions import (
+    MAX_NEW_FILES,
+    _extract_paths,
+    _resolve_directory,
+    on_tool_execute_post,
+)
+from gptme.logmanager import Log
+from gptme.message import Message
+from gptme.prompts import _loaded_agent_files_var
+from gptme.util.context_dedup import _content_hash
+
+
+@pytest.fixture
+def empty_log() -> Log:
+    return Log()
+
+
+@pytest.fixture(autouse=True)
+def reset_contextvars():
+    """Reset _loaded_agent_files_var between tests."""
+    token = _loaded_agent_files_var.set(None)
+    yield
+    _loaded_agent_files_var.reset(token)
+
+
+def _tool_use(tool: str, *args: str, **kwargs: str) -> SimpleNamespace:
+    """Build a minimal stand-in for ToolUse with the fields we need."""
+    return SimpleNamespace(tool=tool, args=list(args), kwargs=dict(kwargs))
+
+
+class TestExtractPaths:
+    def test_extracts_first_positional_arg(self):
+        tu = _tool_use("read", "/tmp/foo.txt")
+        assert _extract_paths(tu) == ["/tmp/foo.txt"]
+
+    def test_extracts_path_kwarg(self):
+        tu = _tool_use("save", path="/tmp/out.md")
+        assert _extract_paths(tu) == ["/tmp/out.md"]
+
+    def test_dedups_positional_and_kwarg(self):
+        tu = _tool_use("read", "/tmp/foo.txt", path="/tmp/foo.txt")
+        assert _extract_paths(tu) == ["/tmp/foo.txt"]
+
+    def test_no_args_no_kwargs_empty(self):
+        tu = _tool_use("read")
+        assert _extract_paths(tu) == []
+
+    def test_ignores_non_string_args(self):
+        tu = _tool_use("read")
+        tu.args = [123, None]
+        assert _extract_paths(tu) == []
+
+
+class TestResolveDirectory:
+    def test_existing_directory(self, tmp_path: Path):
+        d = tmp_path / "sub"
+        d.mkdir()
+        assert _resolve_directory(str(d)) == d.resolve()
+
+    def test_existing_file_returns_parent(self, tmp_path: Path):
+        f = tmp_path / "x.txt"
+        f.write_text("hi")
+        assert _resolve_directory(str(f)) == tmp_path.resolve()
+
+    def test_nonexistent_file_in_existing_dir_returns_parent(self, tmp_path: Path):
+        target = tmp_path / "newfile.txt"
+        assert _resolve_directory(str(target)) == tmp_path.resolve()
+
+    def test_garbage_path_returns_none(self):
+        # NUL is invalid in path strings on most filesystems.
+        assert _resolve_directory("/\0invalid") is None
+
+    def test_relative_path_resolved_against_cwd(self, tmp_path: Path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        sub = tmp_path / "rel"
+        sub.mkdir()
+        assert _resolve_directory("rel") == sub.resolve()
+
+
+class TestOnToolExecutePost:
+    def test_injects_agents_md_for_subdir_read(
+        self, tmp_path: Path, empty_log: Log, monkeypatch
+    ):
+        """Reading a file in a subdirectory with AGENTS.md should inject it."""
+        # The hook walks from $HOME down to the target, so put both dirs under
+        # the home directory for the test.
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        subdir = tmp_path / "subproject"
+        subdir.mkdir()
+        agents = subdir / "AGENTS.md"
+        agents.write_text("# Subproject instructions\nuse uv run")
+
+        target_file = subdir / "code.py"
+        target_file.write_text("x = 1")
+
+        tu = _tool_use("read", str(target_file))
+        msgs = list(on_tool_execute_post(empty_log, None, tu))
+
+        assert msgs, "expected at least one injected message"
+        msg = msgs[0]
+        assert isinstance(msg, Message)
+        assert msg.role == "system"
+        assert "Subproject instructions" in msg.content
+        assert "<agent-instructions" in msg.content
+
+    def test_no_reinjection_when_already_loaded(
+        self, tmp_path: Path, empty_log: Log, monkeypatch
+    ):
+        """A second tool touching the same dir should not re-inject."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        subdir = tmp_path / "p"
+        subdir.mkdir()
+        agents = subdir / "AGENTS.md"
+        agents.write_text("# P")
+
+        tu1 = _tool_use("read", str(subdir / "a.py"))
+        first = list(on_tool_execute_post(empty_log, None, tu1))
+        assert len(first) == 1
+
+        tu2 = _tool_use("patch", str(subdir / "b.py"))
+        second = list(on_tool_execute_post(empty_log, None, tu2))
+        assert second == []
+
+    def test_dedup_by_content_hash(self, tmp_path: Path, empty_log: Log, monkeypatch):
+        """Two different paths with identical AGENTS.md content -> inject once."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        for name in ("orig", "worktree"):
+            d = tmp_path / name
+            d.mkdir()
+            (d / "AGENTS.md").write_text("# Same content")
+
+        tu1 = _tool_use("read", str(tmp_path / "orig" / "x.py"))
+        first = list(on_tool_execute_post(empty_log, None, tu1))
+        assert len(first) == 1
+
+        tu2 = _tool_use("read", str(tmp_path / "worktree" / "y.py"))
+        second = list(on_tool_execute_post(empty_log, None, tu2))
+        assert second == [], (
+            "identical content from a different path should not be re-injected"
+        )
+
+    def test_skips_unstructured_tools(
+        self, tmp_path: Path, empty_log: Log, monkeypatch
+    ):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        subdir = tmp_path / "p"
+        subdir.mkdir()
+        (subdir / "AGENTS.md").write_text("# P")
+
+        tu = _tool_use("shell", f"ls {subdir}")
+        msgs = list(on_tool_execute_post(empty_log, None, tu))
+        assert msgs == [], "shell payloads are out of scope for Phase 1"
+
+    def test_no_agents_md_no_messages(
+        self, tmp_path: Path, empty_log: Log, monkeypatch
+    ):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        subdir = tmp_path / "empty"
+        subdir.mkdir()
+        tu = _tool_use("read", str(subdir / "x.py"))
+        msgs = list(on_tool_execute_post(empty_log, None, tu))
+        assert msgs == []
+
+    def test_caps_at_max_new_files(self, tmp_path: Path, empty_log: Log, monkeypatch):
+        """If more than MAX_NEW_FILES files exist in the tree, cap injection."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        # Build a deep nested tree, each level has its own AGENTS.md with
+        # different content so the dedup-by-hash short-circuit doesn't fire.
+        current = tmp_path
+        levels = []
+        for i in range(MAX_NEW_FILES + 2):
+            current = current / f"level{i}"
+            current.mkdir()
+            (current / "AGENTS.md").write_text(f"# Level {i} instructions")
+            levels.append(current)
+
+        tu = _tool_use("read", str(current / "target.py"))
+        msgs = list(on_tool_execute_post(empty_log, None, tu))
+        assert len(msgs) == MAX_NEW_FILES
+
+    def test_dedup_against_already_injected_content(
+        self, tmp_path: Path, empty_log: Log, monkeypatch
+    ):
+        """If the loaded-files set already contains a content hash, skip it."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        subdir = tmp_path / "p"
+        subdir.mkdir()
+        content = "# Already loaded"
+        agents = subdir / "AGENTS.md"
+        agents.write_text(content)
+
+        # Pre-seed the loaded set with the content hash
+        from gptme.hooks.tool_target_instructions import _HASH_PREFIX
+
+        _loaded_agent_files_var.set({f"{_HASH_PREFIX}{_content_hash(content)}"})
+
+        tu = _tool_use("read", str(subdir / "a.py"))
+        msgs = list(on_tool_execute_post(empty_log, None, tu))
+        assert msgs == []

--- a/gptme/hooks/tool_target_instructions.py
+++ b/gptme/hooks/tool_target_instructions.py
@@ -1,0 +1,223 @@
+"""
+Inject AGENTS.md/CLAUDE.md/GEMINI.md files when a tool touches a path in a
+directory that has agent instruction files, even if CWD itself didn't change.
+
+This extends ``agents_md_inject`` (which fires on CWD_CHANGED) to also cover
+common real workflows where the agent reads or patches a file in a different
+directory via an explicit path argument while staying in the same CWD.
+
+Examples:
+
+- ``read projects/gptme/webui/src/foo.ts`` from repo root
+- ``patch /tmp/worktrees/feature/file.py`` while CWD is unchanged
+- ``save subdir/AGENTS.md`` content in a sibling repo
+
+Subscribes to ``TOOL_EXECUTE_POST`` so the loaded instructions arrive before
+the next reasoning step. Reuses ``find_agent_files_in_tree`` and the
+``_loaded_agent_files_var`` dedup state from :mod:`agents_md_inject`.
+
+Scope (Phase 1):
+
+- Structured file tools only — ``read``, ``save``, ``append``, ``patch``,
+  ``morph``, ``ls``, ``browse``.
+- Hard caps to keep the hook cheap: at most ``MAX_PATHS_PER_EVENT``
+  directories inspected per tool event and at most ``MAX_NEW_FILES``
+  instruction files injected per event.
+
+See: ``knowledge/technical-designs/tool-targeted-agent-instruction-loading.md``
+in the Bob repo for the full design.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from ..hooks import HookType, register_hook
+from ..message import Message
+from ..prompts import find_agent_files_in_tree
+from ..util.context_dedup import _content_hash
+from .agents_md_inject import _HASH_PREFIX, _get_loaded_files
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from ..hooks import StopPropagation
+    from ..logmanager import Log
+
+logger = logging.getLogger(__name__)
+
+# Tools whose argument shape is structured enough to extract paths from
+# without parsing shell strings. Shell payload parsing is explicitly a Phase 2
+# concern.
+_STRUCTURED_PATH_TOOLS: frozenset[str] = frozenset(
+    {
+        "read",
+        "save",
+        "append",
+        "patch",
+        "morph",
+        "ls",
+        "browse",
+    }
+)
+
+# Caps. Keep small — this hook fires on every tool execution.
+MAX_PATHS_PER_EVENT = 3
+MAX_NEW_FILES = 3
+
+
+def _extract_paths(tool_use: Any) -> list[str]:
+    """Extract candidate path strings from a structured file-tool invocation.
+
+    Phase 1 strategy: take the first positional arg if present, plus any
+    string values under ``path``/``filename``/``directory`` keys in kwargs.
+    Stop early when ``MAX_PATHS_PER_EVENT`` candidates are collected.
+    """
+    candidates: list[str] = []
+    args = getattr(tool_use, "args", None) or []
+    if args:
+        first = args[0]
+        if isinstance(first, str) and first.strip():
+            candidates.append(first.strip())
+    kwargs = getattr(tool_use, "kwargs", None) or {}
+    for key in ("path", "filename", "directory", "file"):
+        val = kwargs.get(key)
+        if isinstance(val, str) and val.strip() and val.strip() not in candidates:
+            candidates.append(val.strip())
+            if len(candidates) >= MAX_PATHS_PER_EVENT:
+                break
+    return candidates[:MAX_PATHS_PER_EVENT]
+
+
+def _resolve_directory(path_str: str) -> Path | None:
+    """Resolve a tool-supplied path to a real directory to inspect.
+
+    - Absolute paths are used as-is.
+    - Relative paths are resolved against the current CWD.
+    - If the path points at a file (or doesn't exist), use its parent.
+    - Returns ``None`` if the path can't be resolved or escapes obvious bounds.
+    """
+    try:
+        p = Path(path_str).expanduser()
+        if not p.is_absolute():
+            p = Path(os.getcwd()) / p
+        resolved = p.resolve()
+    except (OSError, ValueError, RuntimeError):
+        return None
+
+    if resolved.is_dir():
+        return resolved
+    # File or nonexistent — fall back to parent directory, which is a real dir
+    # on disk in the common cases (read/save/patch on an existing or new file
+    # under an existing directory).
+    parent = resolved.parent
+    if parent.is_dir():
+        return parent
+    return None
+
+
+def on_tool_execute_post(
+    log: Log,
+    workspace: Path | None,
+    tool_use: Any,
+) -> Generator[Message | StopPropagation, None, None]:
+    """Discover and inject AGENTS.md-style files for the tool's target path.
+
+    Args:
+        log: The conversation log.
+        workspace: Workspace directory path.
+        tool_use: The ToolUse object that just executed.
+    """
+    tool_name = getattr(tool_use, "tool", None)
+    if tool_name not in _STRUCTURED_PATH_TOOLS:
+        return
+
+    try:
+        path_strs = _extract_paths(tool_use)
+        if not path_strs:
+            return
+
+        # Resolve to directories, dedup while preserving order
+        seen_dirs: set[str] = set()
+        directories: list[Path] = []
+        for path_str in path_strs:
+            d = _resolve_directory(path_str)
+            if d is None:
+                continue
+            key = str(d)
+            if key in seen_dirs:
+                continue
+            seen_dirs.add(key)
+            directories.append(d)
+
+        if not directories:
+            return
+
+        loaded = _get_loaded_files(log)
+        injected = 0
+
+        for directory in directories:
+            if injected >= MAX_NEW_FILES:
+                break
+            new_files = find_agent_files_in_tree(directory, exclude=loaded)
+            for agent_file in new_files:
+                if injected >= MAX_NEW_FILES:
+                    break
+                resolved = str(agent_file.resolve())
+                if resolved in loaded:
+                    continue
+                try:
+                    content = agent_file.read_text()
+                except OSError as e:
+                    logger.warning(f"Could not read agent file {agent_file}: {e}")
+                    continue
+
+                content_key = f"{_HASH_PREFIX}{_content_hash(content)}"
+                if content_key in loaded:
+                    logger.debug(
+                        f"Skipping {agent_file}: identical content already injected"
+                    )
+                    loaded.add(resolved)
+                    continue
+
+                loaded.add(resolved)
+                loaded.add(content_key)
+
+                try:
+                    display_path = str(agent_file.resolve().relative_to(Path.home()))
+                    display_path = f"~/{display_path}"
+                except ValueError:
+                    display_path = str(agent_file)
+
+                logger.info(
+                    f"Injecting agent instructions from {display_path} "
+                    f"(tool={tool_name})"
+                )
+                injected += 1
+                yield Message(
+                    "system",
+                    f'<agent-instructions source="{display_path}">\n'
+                    f"# Agent Instructions ({display_path})\n\n"
+                    f"{content}\n"
+                    f"</agent-instructions>",
+                    files=[agent_file],
+                )
+
+    except Exception as e:
+        logger.exception(f"Error in tool_target_instructions: {e}")
+
+
+def register() -> None:
+    """Register the tool-target agent-instruction injection hook."""
+    register_hook(
+        "tool_target_instructions.on_tool_post",
+        HookType.TOOL_EXECUTE_POST,
+        on_tool_execute_post,
+        # Lower priority than cwd_changed.detect (100) so CWD-driven injection
+        # gets first crack at any new instruction files.
+        priority=10,
+    )
+    logger.debug("Registered tool-target AGENTS.md injection hook")


### PR DESCRIPTION
## Summary

Adds a new `tool_target_instructions` hook (subscribing to `TOOL_EXECUTE_POST`) that discovers and injects `AGENTS.md` / `CLAUDE.md` / `GEMINI.md` files when structured file tools touch paths in directories that contain local instruction files — even if CWD itself does not change.

This extends `agents_md_inject` (which fires on `CWD_CHANGED`) to cover a common real workflow:

- reading `projects/gptme/webui/src/foo.ts` from repo root
- patching `/tmp/worktrees/feature/file.py` while CWD is unchanged
- saving content in a sibling repo by absolute path

Inspired by Gemini CLI's JIT context loading. Design doc: `knowledge/technical-designs/tool-targeted-agent-instruction-loading.md` in the Bob repo.

## Scope (Phase 1)

- Structured file tools only: `read`, `save`, `append`, `patch`, `morph`, `ls`, `browse`.
- Hard caps: max 3 directories inspected per tool event, max 3 new files injected per event.
- Reuses `find_agent_files_in_tree()` and `_loaded_agent_files_var` dedup state from `agents_md_inject`, including content-hash dedup so worktree copies with identical content are not re-injected.

## Non-goals (deferred)

- Shell payload parsing — Phase 2.
- Pre-write guards (intercept the tool call) — Phase 2.
- `@file.md`-style imports — Phase 3.

## Tests

17 new tests in `gptme/hooks/tests/test_tool_target_instructions.py`:

- `_extract_paths`: positional arg, `path` kwarg, dedup, no-args, non-string args.
- `_resolve_directory`: existing dir, existing file (→ parent), nonexistent path (→ parent), garbage path (→ None), relative path resolved against cwd.
- `on_tool_execute_post`: subdir-read injection, no re-injection across tool events, content-hash dedup across paths, unstructured tool skip, no-agents-md no-op, MAX_NEW_FILES cap, pre-seeded content-hash skip.

Full hook test suite (403 tests) green.

## Test plan

- [x] New unit tests pass (`pytest gptme/hooks/tests/test_tool_target_instructions.py -q`)
- [x] Full hook test suite passes (`pytest gptme/hooks/tests/ -q`)
- [x] Ruff format + check clean

Co-Authored-By: Bob <bob@superuserlabs.org>