### PR TITLE
feat(hooks): tool-target AGENTS.md injection for path-aware file tools

### DIFF
--- a/gptme/hooks/agents_md_inject.py
+++ b/gptme/hooks/agents_md_inject.py
@@ -26,7 +26,7 @@ See: https://github.com/gptme/gptme/issues/1958
 
 import logging
 import re
-from collections.abc import Generator
+from collections.abc import Generator, Iterable
 from pathlib import Path
 from typing import Any
 
@@ -94,6 +94,104 @@ def _get_loaded_files(log: Log | None = None) -> set[str]:
     return files
 
 
+def _format_display_path(agent_file: Path) -> str:
+    """Format an agent file path for transcript display."""
+    try:
+        relative = agent_file.resolve().relative_to(Path.home())
+        return f"~/{relative}"
+    except ValueError:
+        return str(agent_file.resolve())
+
+
+def inject_agent_instruction_files(
+    log: Log | None,
+    agent_files: Iterable[Path],
+    *,
+    max_files: int | None = None,
+    max_bytes: int | None = None,
+    skip_tag: str = "agent-instructions-skipped",
+) -> Generator[Message, None, None]:
+    """Inject discovered agent instruction files with shared dedup semantics.
+
+    Args:
+        log: Conversation log used for server-mode dedup fallback.
+        agent_files: Candidate AGENTS/CLAUDE/GEMINI files to inject.
+        max_files: Optional per-call cap on injected files.
+        max_bytes: Optional per-call cap on combined injected content size.
+        skip_tag: XML-ish tag used for skip-note system messages.
+    """
+    loaded = _get_loaded_files(log)
+    seen_candidates: set[str] = set()
+    injected = 0
+    bytes_injected = 0
+
+    for agent_file in agent_files:
+        resolved = str(agent_file.resolve())
+        if resolved in loaded or resolved in seen_candidates:
+            continue
+        seen_candidates.add(resolved)
+
+        try:
+            content = agent_file.read_text()
+        except OSError as e:
+            logger.warning(f"Could not read agent file {agent_file}: {e}")
+            continue
+
+        # Skip if identical content was already injected from a different path
+        # (e.g. switching cwd to a git worktree that shares the same AGENTS.md).
+        content_key = f"{_HASH_PREFIX}{_content_hash(content)}"
+        if content_key in loaded:
+            logger.debug(f"Skipping {agent_file}: identical content already injected")
+            loaded.add(resolved)
+            continue
+
+        display_path = _format_display_path(agent_file)
+        content_bytes = len(content.encode("utf-8"))
+
+        if max_files is not None and injected >= max_files:
+            logger.info(
+                "Skipping %s: reached per-event injection cap (%d)",
+                display_path,
+                max_files,
+            )
+            yield Message(
+                "system",
+                f'<{skip_tag} source="{display_path}">\n'
+                f"Skipped: reached per-event injection cap of {max_files} files.\n"
+                f"</{skip_tag}>",
+            )
+            continue
+
+        if max_bytes is not None and bytes_injected + content_bytes > max_bytes:
+            logger.info(
+                "Skipping %s: would exceed per-event budget (%d bytes)",
+                display_path,
+                max_bytes,
+            )
+            yield Message(
+                "system",
+                f'<{skip_tag} source="{display_path}">\n'
+                f"Skipped: would exceed per-event budget of {max_bytes} bytes.\n"
+                f"</{skip_tag}>",
+            )
+            continue
+
+        loaded.add(resolved)
+        loaded.add(content_key)
+        injected += 1
+        bytes_injected += content_bytes
+
+        logger.info(f"Injecting agent instructions from {display_path}")
+        yield Message(
+            "system",
+            f'<agent-instructions source="{display_path}">\n'
+            f"# Agent Instructions ({display_path})\n\n"
+            f"{content}\n"
+            f"</agent-instructions>",
+            files=[agent_file],
+        )
+
+
 def on_cwd_changed(
     log: Log,
     workspace: Path | None,
@@ -111,59 +209,12 @@ def on_cwd_changed(
         tool_use: The tool that caused the change
     """
     try:
-        # find_agent_files_in_tree() is shared with prompt_workspace() in prompts.py
-        # Pass the log so server mode can derive loaded files from conversation history
-        # when the ContextVar is empty (ContextVars reset per Flask request context).
         new_files = find_agent_files_in_tree(
             Path(new_cwd), exclude=_get_loaded_files(log)
         )
         if not new_files:
             return
-
-        loaded = _get_loaded_files(log)
-
-        # Read and inject each new file
-        for agent_file in new_files:
-            resolved = str(agent_file.resolve())
-            # Double-check (could have been added by concurrent call)
-            if resolved in loaded:
-                continue
-
-            try:
-                content = agent_file.read_text()
-            except OSError as e:
-                logger.warning(f"Could not read agent file {agent_file}: {e}")
-                continue
-
-            # Skip if identical content was already injected from a different path
-            # (e.g. switching cwd to a git worktree that shares the same AGENTS.md).
-            content_key = f"{_HASH_PREFIX}{_content_hash(content)}"
-            if content_key in loaded:
-                logger.debug(
-                    f"Skipping {agent_file}: identical content already injected"
-                )
-                loaded.add(resolved)
-                continue
-
-            loaded.add(resolved)
-            loaded.add(content_key)
-
-            # Make the path relative to home for cleaner display
-            try:
-                display_path = str(agent_file.resolve().relative_to(Path.home()))
-                display_path = f"~/{display_path}"
-            except ValueError:
-                display_path = str(agent_file)
-
-            logger.info(f"Injecting agent instructions from {display_path}")
-            yield Message(
-                "system",
-                f'<agent-instructions source="{display_path}">\n'
-                f"# Agent Instructions ({display_path})\n\n"
-                f"{content}\n"
-                f"</agent-instructions>",
-                files=[agent_file],
-            )
+        yield from inject_agent_instruction_files(log, new_files)
 
     except Exception as e:
         logger.exception(f"Error in agents_md on CWD change: {e}")

--- a/gptme/hooks/tests/test_tool_target_instructions.py
+++ b/gptme/hooks/tests/test_tool_target_instructions.py
@@ -1,26 +1,30 @@
 """Tests for tool_target_instructions hook.
 
-Verifies that AGENTS.md/CLAUDE.md/GEMINI.md files are loaded when a structured
-file tool touches a path under a directory that contains them, without
-requiring a CWD change.
+Covers the four scenarios from the design doc
+(knowledge/technical-designs/tool-targeted-agent-instruction-loading.md):
+
+- read file in subdir without cd
+- patch file in worktree without cd
+- identical-content dedup across repo/worktree
+- no reinjection on repeated reads in same directory
 """
 
-from __future__ import annotations
-
 from pathlib import Path
-from types import SimpleNamespace
 
 import pytest
 
+from gptme.hooks.agents_md_inject import _HASH_PREFIX, _get_loaded_files
 from gptme.hooks.tool_target_instructions import (
-    MAX_NEW_FILES,
+    _MAX_BYTES_PER_EVENT,
+    _MAX_INJECT_PER_EVENT,
+    _candidate_directories,
     _extract_paths,
-    _resolve_directory,
     on_tool_execute_post,
 )
 from gptme.logmanager import Log
 from gptme.message import Message
 from gptme.prompts import _loaded_agent_files_var
+from gptme.tools.base import ToolUse
 from gptme.util.context_dedup import _content_hash
 
 
@@ -31,187 +35,365 @@ def empty_log() -> Log:
 
 @pytest.fixture(autouse=True)
 def reset_contextvars():
-    """Reset _loaded_agent_files_var between tests."""
     token = _loaded_agent_files_var.set(None)
     yield
     _loaded_agent_files_var.reset(token)
 
 
-def _tool_use(tool: str, *args: str, **kwargs: str) -> SimpleNamespace:
-    """Build a minimal stand-in for ToolUse with the fields we need."""
-    return SimpleNamespace(tool=tool, args=list(args), kwargs=dict(kwargs))
+def _make_use(tool: str, *, args=None, kwargs=None, content=None) -> ToolUse:
+    return ToolUse(tool=tool, args=args, content=content, kwargs=kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Argument extraction
+# ---------------------------------------------------------------------------
 
 
 class TestExtractPaths:
-    def test_extracts_first_positional_arg(self):
-        tu = _tool_use("read", "/tmp/foo.txt")
-        assert _extract_paths(tu) == ["/tmp/foo.txt"]
+    def test_kwargs_path(self):
+        use = _make_use("read", kwargs={"path": "/tmp/foo.md"})
+        assert _extract_paths(use) == [Path("/tmp/foo.md")]
 
-    def test_extracts_path_kwarg(self):
-        tu = _tool_use("save", path="/tmp/out.md")
-        assert _extract_paths(tu) == ["/tmp/out.md"]
+    def test_positional_args(self):
+        use = _make_use("save", args=["/tmp/foo.md"])
+        assert _extract_paths(use) == [Path("/tmp/foo.md")]
 
-    def test_dedups_positional_and_kwarg(self):
-        tu = _tool_use("read", "/tmp/foo.txt", path="/tmp/foo.txt")
-        assert _extract_paths(tu) == ["/tmp/foo.txt"]
+    def test_multi_path_kwarg(self):
+        use = _make_use("read", kwargs={"paths": "/tmp/a.md\n/tmp/b.md"})
+        result = _extract_paths(use)
+        assert Path("/tmp/a.md") in result and Path("/tmp/b.md") in result
 
-    def test_no_args_no_kwargs_empty(self):
-        tu = _tool_use("read")
-        assert _extract_paths(tu) == []
+    def test_unknown_tool_returns_empty(self):
+        use = _make_use("shell", args=["ls /tmp"])
+        assert _extract_paths(use) == []
 
-    def test_ignores_non_string_args(self):
-        tu = _tool_use("read")
-        tu.args = [123, None]
-        assert _extract_paths(tu) == []
+    def test_no_args_returns_empty(self):
+        use = _make_use("read")
+        assert _extract_paths(use) == []
+
+    def test_read_batch_content(self):
+        use = _make_use("read", args=[], content="/tmp/a.md\n# comment\n/tmp/b.md")
+        result = _extract_paths(use)
+        assert Path("/tmp/a.md") in result and Path("/tmp/b.md") in result
+
+    def test_tilde_expansion(self):
+        use = _make_use("read", kwargs={"path": "~/some-file.md"})
+        result = _extract_paths(use)
+        assert result and result[0].is_absolute()
+        assert "~" not in str(result[0])
+
+    def test_multi_positional_args_uses_first_only(self):
+        """Multi-arg tool calls should extract only the first arg as path."""
+        use = _make_use("save", args=["/tmp/target.md", "extra arg"])
+        result = _extract_paths(use)
+        assert result == [Path("/tmp/target.md")], (
+            "only the first positional arg is a path; joining all args creates a bogus path"
+        )
 
 
-class TestResolveDirectory:
-    def test_existing_directory(self, tmp_path: Path):
-        d = tmp_path / "sub"
-        d.mkdir()
-        assert _resolve_directory(str(d)) == d.resolve()
+# ---------------------------------------------------------------------------
+# Directory candidate resolution
+# ---------------------------------------------------------------------------
 
-    def test_existing_file_returns_parent(self, tmp_path: Path):
-        f = tmp_path / "x.txt"
+
+class TestCandidateDirectories:
+    def test_existing_file_uses_parent(self, tmp_path: Path):
+        f = tmp_path / "foo.md"
         f.write_text("hi")
-        assert _resolve_directory(str(f)) == tmp_path.resolve()
+        assert _candidate_directories([f]) == [tmp_path.resolve()]
 
-    def test_nonexistent_file_in_existing_dir_returns_parent(self, tmp_path: Path):
-        target = tmp_path / "newfile.txt"
-        assert _resolve_directory(str(target)) == tmp_path.resolve()
+    def test_existing_directory_used_directly(self, tmp_path: Path):
+        assert _candidate_directories([tmp_path]) == [tmp_path.resolve()]
 
-    def test_garbage_path_returns_none(self):
-        # NUL is invalid in path strings on most filesystems.
-        assert _resolve_directory("/\0invalid") is None
+    def test_nonexistent_path_uses_parent(self, tmp_path: Path):
+        assert _candidate_directories([tmp_path / "ghost.md"]) == [tmp_path.resolve()]
 
-    def test_relative_path_resolved_against_cwd(self, tmp_path: Path, monkeypatch):
-        monkeypatch.chdir(tmp_path)
-        sub = tmp_path / "rel"
-        sub.mkdir()
-        assert _resolve_directory("rel") == sub.resolve()
+    def test_dedups_same_directory(self, tmp_path: Path):
+        (tmp_path / "a.md").write_text("a")
+        (tmp_path / "b.md").write_text("b")
+        result = _candidate_directories([tmp_path / "a.md", tmp_path / "b.md"])
+        assert result == [tmp_path.resolve()]
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: the four design-doc scenarios
+# ---------------------------------------------------------------------------
 
 
 class TestOnToolExecutePost:
-    def test_injects_agents_md_for_subdir_read(
-        self, tmp_path: Path, empty_log: Log, monkeypatch
-    ):
-        """Reading a file in a subdirectory with AGENTS.md should inject it."""
-        # The hook walks from $HOME down to the target, so put both dirs under
-        # the home directory for the test.
-        monkeypatch.setattr(Path, "home", lambda: tmp_path)
-
-        subdir = tmp_path / "subproject"
+    def test_read_file_in_subdir_without_cd(self, tmp_path: Path, empty_log: Log):
+        """Reading a file in a subdir with AGENTS.md injects those instructions."""
+        subdir = tmp_path / "project"
         subdir.mkdir()
         agents = subdir / "AGENTS.md"
-        agents.write_text("# Subproject instructions\nuse uv run")
+        agents.write_text("# Project instructions\nFollow style X.")
+        target = subdir / "main.py"
+        target.write_text("print('hello')")
 
-        target_file = subdir / "code.py"
-        target_file.write_text("x = 1")
+        use = _make_use("read", kwargs={"path": str(target)})
+        msgs = list(
+            on_tool_execute_post(log=empty_log, workspace=tmp_path, tool_use=use)
+        )
+        injected = [m for m in msgs if isinstance(m, Message)]
+        assert injected, "expected AGENTS.md injection for subdir read"
+        assert "Project instructions" in injected[0].content
+        assert "Follow style X" in injected[0].content
+        # The file is also marked loaded so re-reads stay quiet.
+        assert str(agents.resolve()) in _get_loaded_files()
 
-        tu = _tool_use("read", str(target_file))
-        msgs = list(on_tool_execute_post(empty_log, None, tu))
+    def test_patch_in_worktree_without_cd(self, tmp_path: Path, empty_log: Log):
+        """Patching a file in a worktree triggers the worktree's AGENTS.md."""
+        worktree = tmp_path / "worktrees" / "feature"
+        worktree.mkdir(parents=True)
+        agents = worktree / "AGENTS.md"
+        agents.write_text("# Worktree-specific rules\nNo force pushes.")
+        target = worktree / "src" / "main.py"
+        target.parent.mkdir()
+        target.write_text("# code")
 
-        assert msgs, "expected at least one injected message"
-        msg = msgs[0]
-        assert isinstance(msg, Message)
-        assert msg.role == "system"
-        assert "Subproject instructions" in msg.content
-        assert "<agent-instructions" in msg.content
+        use = _make_use("patch", kwargs={"path": str(target)})
+        msgs = list(
+            on_tool_execute_post(log=empty_log, workspace=tmp_path, tool_use=use)
+        )
+        injected = [m for m in msgs if isinstance(m, Message)]
+        assert injected, "patch in worktree should pull AGENTS.md"
+        assert "Worktree-specific rules" in injected[0].content
 
-    def test_no_reinjection_when_already_loaded(
-        self, tmp_path: Path, empty_log: Log, monkeypatch
+    def test_content_hash_dedup_across_worktree_copies(
+        self, tmp_path: Path, empty_log: Log
     ):
-        """A second tool touching the same dir should not re-inject."""
-        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        """Identical AGENTS.md content in two paths is injected only once."""
+        original = tmp_path / "repo"
+        worktree = tmp_path / "worktree"
+        original.mkdir()
+        worktree.mkdir()
+        shared = "# Shared instructions\nDo great things."
+        (original / "AGENTS.md").write_text(shared)
+        (worktree / "AGENTS.md").write_text(shared)
 
-        subdir = tmp_path / "p"
-        subdir.mkdir()
-        agents = subdir / "AGENTS.md"
-        agents.write_text("# P")
+        # First touch: original repo.
+        msgs1 = list(
+            on_tool_execute_post(
+                log=empty_log,
+                workspace=tmp_path,
+                tool_use=_make_use("read", kwargs={"path": str(original / "x.md")}),
+            )
+        )
+        # Second touch: worktree copy with identical content.
+        msgs2 = list(
+            on_tool_execute_post(
+                log=empty_log,
+                workspace=tmp_path,
+                tool_use=_make_use("read", kwargs={"path": str(worktree / "y.md")}),
+            )
+        )
+        injected1 = [m for m in msgs1 if isinstance(m, Message)]
+        injected2 = [m for m in msgs2 if isinstance(m, Message)]
+        assert len(injected1) == 1, "original repo should inject AGENTS.md once"
+        assert injected2 == [], "worktree copy with identical content must dedup"
+        # Both paths are marked loaded; the content hash is recorded too.
+        loaded = _get_loaded_files()
+        assert str((original / "AGENTS.md").resolve()) in loaded
+        assert str((worktree / "AGENTS.md").resolve()) in loaded
+        assert f"{_HASH_PREFIX}{_content_hash(shared)}" in loaded
 
-        tu1 = _tool_use("read", str(subdir / "a.py"))
-        first = list(on_tool_execute_post(empty_log, None, tu1))
-        assert len(first) == 1
+    def test_no_reinjection_on_repeated_reads(self, tmp_path: Path, empty_log: Log):
+        """Reading two files in the same directory injects AGENTS.md only once."""
+        project = tmp_path / "project"
+        project.mkdir()
+        (project / "AGENTS.md").write_text("# Instructions")
+        (project / "a.py").write_text("# a")
+        (project / "b.py").write_text("# b")
 
-        tu2 = _tool_use("patch", str(subdir / "b.py"))
-        second = list(on_tool_execute_post(empty_log, None, tu2))
-        assert second == []
+        first = list(
+            on_tool_execute_post(
+                log=empty_log,
+                workspace=tmp_path,
+                tool_use=_make_use("read", kwargs={"path": str(project / "a.py")}),
+            )
+        )
+        second = list(
+            on_tool_execute_post(
+                log=empty_log,
+                workspace=tmp_path,
+                tool_use=_make_use("read", kwargs={"path": str(project / "b.py")}),
+            )
+        )
+        injected1 = [m for m in first if isinstance(m, Message)]
+        injected2 = [m for m in second if isinstance(m, Message)]
+        assert len(injected1) == 1
+        assert injected2 == []
 
-    def test_dedup_by_content_hash(self, tmp_path: Path, empty_log: Log, monkeypatch):
-        """Two different paths with identical AGENTS.md content -> inject once."""
-        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    def test_unknown_tool_does_nothing(self, tmp_path: Path, empty_log: Log):
+        """Shell and other free-form tools must not trigger path scanning."""
+        project = tmp_path / "project"
+        project.mkdir()
+        (project / "AGENTS.md").write_text("# Instructions")
+        use = _make_use("shell", args=[f"cat {project / 'foo.md'}"])
+        msgs = list(
+            on_tool_execute_post(log=empty_log, workspace=tmp_path, tool_use=use)
+        )
+        assert [m for m in msgs if isinstance(m, Message)] == []
 
-        for name in ("orig", "worktree"):
-            d = tmp_path / name
-            d.mkdir()
-            (d / "AGENTS.md").write_text("# Same content")
+    def test_no_agents_md_means_no_injection(self, tmp_path: Path, empty_log: Log):
+        """Touching a directory with no agent files is a no-op."""
+        # Use a temp path well outside $HOME so the tree walk doesn't pick up
+        # any ambient AGENTS.md files higher up.
+        plain = tmp_path / "plain"
+        plain.mkdir()
+        target = plain / "readme.txt"
+        target.write_text("nothing")
+        use = _make_use("read", kwargs={"path": str(target)})
+        msgs = list(
+            on_tool_execute_post(log=empty_log, workspace=tmp_path, tool_use=use)
+        )
+        injected = [
+            m
+            for m in msgs
+            if isinstance(m, Message) and "agent-instructions" in m.content
+        ]
+        # Only count injections that touch our temp dir, not ambient ones.
+        local_injections = [m for m in injected if str(plain) in m.content]
+        assert local_injections == []
 
-        tu1 = _tool_use("read", str(tmp_path / "orig" / "x.py"))
-        first = list(on_tool_execute_post(empty_log, None, tu1))
-        assert len(first) == 1
+    def test_already_loaded_file_not_reinjected(self, tmp_path: Path, empty_log: Log):
+        """If prompt_workspace already loaded the file, this hook skips it."""
+        project = tmp_path / "project"
+        project.mkdir()
+        agents = project / "AGENTS.md"
+        agents.write_text("# Already loaded")
+        # Simulate session-start loading.
+        loaded = _get_loaded_files()
+        loaded.add(str(agents.resolve()))
 
-        tu2 = _tool_use("read", str(tmp_path / "worktree" / "y.py"))
-        second = list(on_tool_execute_post(empty_log, None, tu2))
-        assert second == [], (
-            "identical content from a different path should not be re-injected"
+        use = _make_use("read", kwargs={"path": str(project / "main.py")})
+        msgs = list(
+            on_tool_execute_post(log=empty_log, workspace=tmp_path, tool_use=use)
+        )
+        local = [
+            m for m in msgs if isinstance(m, Message) and str(project) in m.content
+        ]
+        assert local == []
+
+    def test_read_batch_content_injects_without_cd(
+        self, tmp_path: Path, empty_log: Log
+    ):
+        """Batch-read content paths should trigger injection just like kwargs paths."""
+        project = tmp_path / "project"
+        project.mkdir()
+        agents = project / "AGENTS.md"
+        agents.write_text("# Batch instructions\nHandle multi-read paths.")
+        target = project / "a.py"
+        target.write_text("print('hi')")
+
+        use = _make_use("read", args=[], content=f"{target}\n# keep going")
+        msgs = list(
+            on_tool_execute_post(log=empty_log, workspace=tmp_path, tool_use=use)
         )
 
-    def test_skips_unstructured_tools(
-        self, tmp_path: Path, empty_log: Log, monkeypatch
+        injected = [
+            m
+            for m in msgs
+            if isinstance(m, Message) and "agent-instructions" in m.content
+        ]
+        assert len(injected) == 1
+        assert "Batch instructions" in injected[0].content
+        assert str(agents.resolve()) in _get_loaded_files()
+
+    def test_oversized_instructions_are_skipped_but_not_marked_loaded(
+        self, tmp_path: Path, empty_log: Log
     ):
-        monkeypatch.setattr(Path, "home", lambda: tmp_path)
-        subdir = tmp_path / "p"
-        subdir.mkdir()
-        (subdir / "AGENTS.md").write_text("# P")
+        """Skipped oversized files should emit a note and remain eligible later."""
+        project = tmp_path / "project"
+        project.mkdir()
+        agents = project / "AGENTS.md"
+        agents.write_text("# Big\n" + ("x" * (_MAX_BYTES_PER_EVENT + 32)))
+        target = project / "main.py"
+        target.write_text("print('hi')")
 
-        tu = _tool_use("shell", f"ls {subdir}")
-        msgs = list(on_tool_execute_post(empty_log, None, tu))
-        assert msgs == [], "shell payloads are out of scope for Phase 1"
+        use = _make_use("read", kwargs={"path": str(target)})
+        first = list(
+            on_tool_execute_post(log=empty_log, workspace=tmp_path, tool_use=use)
+        )
+        second = list(
+            on_tool_execute_post(log=empty_log, workspace=tmp_path, tool_use=use)
+        )
 
-    def test_no_agents_md_no_messages(
-        self, tmp_path: Path, empty_log: Log, monkeypatch
-    ):
-        monkeypatch.setattr(Path, "home", lambda: tmp_path)
-        subdir = tmp_path / "empty"
-        subdir.mkdir()
-        tu = _tool_use("read", str(subdir / "x.py"))
-        msgs = list(on_tool_execute_post(empty_log, None, tu))
-        assert msgs == []
+        for msgs in (first, second):
+            skip_notes = [
+                m
+                for m in msgs
+                if isinstance(m, Message) and "agent-instructions-skipped" in m.content
+            ]
+            injected = [
+                m
+                for m in msgs
+                if isinstance(m, Message)
+                and '<agent-instructions source="' in m.content
+            ]
+            assert len(skip_notes) == 1
+            assert injected == []
 
-    def test_caps_at_max_new_files(self, tmp_path: Path, empty_log: Log, monkeypatch):
-        """If more than MAX_NEW_FILES files exist in the tree, cap injection."""
-        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        loaded = _get_loaded_files()
+        assert str(agents.resolve()) not in loaded
+        assert f"{_HASH_PREFIX}{_content_hash(agents.read_text())}" not in loaded
 
-        # Build a deep nested tree, each level has its own AGENTS.md with
-        # different content so the dedup-by-hash short-circuit doesn't fire.
-        current = tmp_path
+    def test_cap_prioritises_most_specific_file(self, tmp_path: Path, empty_log: Log):
+        """When >MAX_INJECT_PER_EVENT files exist in the tree, the deepest (most
+        project-specific) files are injected and the shallow (home-level) ones
+        are dropped via a skip-note."""
+        # Build a tree with more levels than the cap:
+        # tmp_path/AGENTS.md  (general — should be skipped)
+        # tmp_path/a/AGENTS.md
+        # tmp_path/a/b/AGENTS.md
+        # tmp_path/a/b/c/AGENTS.md  (most specific — must be injected)
         levels = []
-        for i in range(MAX_NEW_FILES + 2):
-            current = current / f"level{i}"
+        current = tmp_path
+        for letter in ["a", "b", "c", "d"]:
+            current = current / letter
             current.mkdir()
-            (current / "AGENTS.md").write_text(f"# Level {i} instructions")
-            levels.append(current)
+            agents = current / "AGENTS.md"
+            agents.write_text(f"# Level {letter}")
+            levels.append((letter, agents))
 
-        tu = _tool_use("read", str(current / "target.py"))
-        msgs = list(on_tool_execute_post(empty_log, None, tu))
-        assert len(msgs) == MAX_NEW_FILES
+        # Also put one at the root so there are _MAX_INJECT_PER_EVENT + 1 total
+        (tmp_path / "AGENTS.md").write_text("# Root level — should be skipped")
 
-    def test_dedup_against_already_injected_content(
-        self, tmp_path: Path, empty_log: Log, monkeypatch
-    ):
-        """If the loaded-files set already contains a content hash, skip it."""
-        monkeypatch.setattr(Path, "home", lambda: tmp_path)
-        subdir = tmp_path / "p"
-        subdir.mkdir()
-        content = "# Already loaded"
-        agents = subdir / "AGENTS.md"
-        agents.write_text(content)
+        deepest_dir = tmp_path / "a" / "b" / "c" / "d"
+        target_file = deepest_dir / "main.py"
+        target_file.write_text("x = 1")
 
-        # Pre-seed the loaded set with the content hash
-        from gptme.hooks.tool_target_instructions import _HASH_PREFIX
+        use = _make_use("read", kwargs={"path": str(target_file)})
 
-        _loaded_agent_files_var.set({f"{_HASH_PREFIX}{_content_hash(content)}"})
+        # Mock home to tmp_path so find_agent_files_in_tree walks our tree
+        from unittest.mock import patch
 
-        tu = _tool_use("read", str(subdir / "a.py"))
-        msgs = list(on_tool_execute_post(empty_log, None, tu))
-        assert msgs == []
+        with patch("gptme.prompts.workspace.Path.home", return_value=tmp_path):
+            msgs = list(
+                on_tool_execute_post(log=empty_log, workspace=tmp_path, tool_use=use)
+            )
+
+        injected = [
+            m
+            for m in msgs
+            if isinstance(m, Message) and '<agent-instructions source="' in m.content
+        ]
+        skipped = [
+            m
+            for m in msgs
+            if isinstance(m, Message) and "agent-instructions-skipped" in m.content
+        ]
+        # Must inject exactly _MAX_INJECT_PER_EVENT files
+        assert len(injected) == _MAX_INJECT_PER_EVENT, (
+            f"expected {_MAX_INJECT_PER_EVENT} injected; got {len(injected)}"
+        )
+        # The deepest file must be among the injected ones
+        assert any("Level d" in m.content for m in injected), (
+            "most-specific (deepest) AGENTS.md must be injected when cap hits"
+        )
+        # The root-level general file must NOT be in the injected content
+        assert not any("Root level" in m.content for m in injected), (
+            "general root-level AGENTS.md must be dropped when cap hits, not injected"
+        )
+        # At least one skip-note should have been emitted (for the dropped files)
+        assert skipped, "expected skip-notes for files beyond the cap"

--- a/gptme/hooks/tool_target_instructions.py
+++ b/gptme/hooks/tool_target_instructions.py
@@ -1,122 +1,149 @@
 """
-Inject AGENTS.md/CLAUDE.md/GEMINI.md files when a tool touches a path in a
-directory that has agent instruction files, even if CWD itself didn't change.
+Inject AGENTS.md / CLAUDE.md / GEMINI.md files when tools touch new directories.
 
-This extends ``agents_md_inject`` (which fires on CWD_CHANGED) to also cover
-common real workflows where the agent reads or patches a file in a different
-directory via an explicit path argument while staying in the same CWD.
+Extends `agents_md_inject` from cwd-aware to tool-target-aware: when a structured
+file tool (read, save, append, patch, etc.) references a path outside the
+already-loaded directory tree, this hook discovers local agent instruction files
+near that path and injects them before the next reasoning step.
 
-Examples:
+Reuses the existing agent-file discovery (`find_agent_files_in_tree`) and the
+`_loaded_agent_files_var` dedup set populated by `prompt_workspace()` and
+`agents_md_inject`. Identical-content files (worktree copies) are skipped via
+content-hash dedup.
 
-- ``read projects/gptme/webui/src/foo.ts`` from repo root
-- ``patch /tmp/worktrees/feature/file.py`` while CWD is unchanged
-- ``save subdir/AGENTS.md`` content in a sibling repo
+Phase 1: structured file tools only (read/save/append/patch/morph). Shell command
+parsing is intentionally out of scope — `cwd.changed` covers that.
 
-Subscribes to ``TOOL_EXECUTE_POST`` so the loaded instructions arrive before
-the next reasoning step. Reuses ``find_agent_files_in_tree`` and the
-``_loaded_agent_files_var`` dedup state from :mod:`agents_md_inject`.
-
-Scope (Phase 1):
-
-- Structured file tools only — ``read``, ``save``, ``append``, ``patch``,
-  ``morph``, ``ls``, ``browse``.
-- Hard caps to keep the hook cheap: at most ``MAX_PATHS_PER_EVENT``
-  directories inspected per tool event and at most ``MAX_NEW_FILES``
-  instruction files injected per event.
-
-See: ``knowledge/technical-designs/tool-targeted-agent-instruction-loading.md``
-in the Bob repo for the full design.
+See: knowledge/technical-designs/tool-targeted-agent-instruction-loading.md
 """
 
-from __future__ import annotations
-
 import logging
-import os
+from collections.abc import Generator
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from ..hooks import HookType, register_hook
+from ..hooks import HookType, StopPropagation, register_hook
+from ..logmanager import Log
 from ..message import Message
 from ..prompts import find_agent_files_in_tree
-from ..util.context_dedup import _content_hash
-from .agents_md_inject import _HASH_PREFIX, _get_loaded_files
+from .agents_md_inject import _get_loaded_files, inject_agent_instruction_files
 
 if TYPE_CHECKING:
-    from collections.abc import Generator
-
-    from ..hooks import StopPropagation
-    from ..logmanager import Log
+    from ..tools.base import ToolUse  # fmt: skip
 
 logger = logging.getLogger(__name__)
 
-# Tools whose argument shape is structured enough to extract paths from
-# without parsing shell strings. Shell payload parsing is explicitly a Phase 2
-# concern.
-_STRUCTURED_PATH_TOOLS: frozenset[str] = frozenset(
+# Tools whose arguments name a target file or directory. Free-form tools
+# (shell, ipython, browser_query) are excluded — their target is implicit
+# and would produce too many false positives.
+_PATH_TOOLS: frozenset[str] = frozenset(
     {
-        "read",
         "save",
         "append",
         "patch",
         "morph",
-        "ls",
-        "browse",
+        "read",
     }
 )
 
-# Caps. Keep small — this hook fires on every tool execution.
-MAX_PATHS_PER_EVENT = 3
-MAX_NEW_FILES = 3
+# kwarg keys that contain explicit path-like values for the tools above.
+_PATH_KWARG_KEYS: tuple[str, ...] = (
+    "path",
+    "paths",
+    "file",
+    "files",
+    "directory",
+    "cwd",
+)
+
+# Hard caps per tool event — keep the hook fast and prevent prompt-cache thrash.
+_MAX_INJECT_PER_EVENT = 3
+_MAX_BYTES_PER_EVENT = 12_000
 
 
-def _extract_paths(tool_use: Any) -> list[str]:
-    """Extract candidate path strings from a structured file-tool invocation.
+def _extract_paths(tool_use: "ToolUse") -> list[Path]:
+    """Extract explicit file/directory path candidates from a tool's arguments.
 
-    Phase 1 strategy: take the first positional arg if present, plus any
-    string values under ``path``/``filename``/``directory`` keys in kwargs.
-    Stop early when ``MAX_PATHS_PER_EVENT`` candidates are collected.
+    Returns expanded `Path` objects for downstream resolution. Free text and
+    unknown tools yield an empty list — phase 1 keeps the extractor strict.
     """
+    if tool_use is None or tool_use.tool not in _PATH_TOOLS:
+        return []
+
     candidates: list[str] = []
-    args = getattr(tool_use, "args", None) or []
-    if args:
-        first = args[0]
-        if isinstance(first, str) and first.strip():
-            candidates.append(first.strip())
-    kwargs = getattr(tool_use, "kwargs", None) or {}
-    for key in ("path", "filename", "directory", "file"):
-        val = kwargs.get(key)
-        if isinstance(val, str) and val.strip() and val.strip() not in candidates:
-            candidates.append(val.strip())
-            if len(candidates) >= MAX_PATHS_PER_EVENT:
-                break
-    return candidates[:MAX_PATHS_PER_EVENT]
+
+    # 1. Structured kwargs from tool/function-calling formats.
+    if tool_use.kwargs:
+        for key in _PATH_KWARG_KEYS:
+            value = tool_use.kwargs.get(key)
+            if not value:
+                continue
+            # `paths` / `files` may be newline- or comma-separated.
+            if key in ("paths", "files"):
+                for part in str(value).replace(",", "\n").splitlines():
+                    part = part.strip()
+                    if part:
+                        candidates.append(part)
+            else:
+                candidates.append(str(value))
+
+    # 2. Positional args from markdown-format tool blocks. The first arg is
+    #    conventionally the path for save/append/patch/morph/read.
+    if not candidates and tool_use.args:
+        first = tool_use.args[0].strip()
+        if first:
+            candidates.append(first)
+
+    # 3. Markdown-format batch reads put paths in the content block rather
+    #    than positional args. Support one-path-per-line with comment lines.
+    if not candidates and tool_use.tool == "read" and tool_use.content:
+        for line in tool_use.content.splitlines():
+            line = line.strip()
+            if line and not line.startswith("#"):
+                candidates.append(line)
+
+    paths: list[Path] = []
+    seen: set[str] = set()
+    for raw in candidates:
+        try:
+            path = Path(raw).expanduser()
+        except (OSError, ValueError):
+            continue
+        key = str(path)
+        if key in seen:
+            continue
+        seen.add(key)
+        paths.append(path)
+    return paths
 
 
-def _resolve_directory(path_str: str) -> Path | None:
-    """Resolve a tool-supplied path to a real directory to inspect.
+def _candidate_directories(paths: list[Path]) -> list[Path]:
+    """Resolve each input path to a directory to scan.
 
-    - Absolute paths are used as-is.
-    - Relative paths are resolved against the current CWD.
-    - If the path points at a file (or doesn't exist), use its parent.
-    - Returns ``None`` if the path can't be resolved or escapes obvious bounds.
+    File paths → parent directory. Directory paths → themselves. Non-existent
+    paths are still resolved so we walk what the agent *intended* to touch.
+    Duplicate directories are deduped while preserving order.
     """
-    try:
-        p = Path(path_str).expanduser()
-        if not p.is_absolute():
-            p = Path(os.getcwd()) / p
-        resolved = p.resolve()
-    except (OSError, ValueError, RuntimeError):
-        return None
-
-    if resolved.is_dir():
-        return resolved
-    # File or nonexistent — fall back to parent directory, which is a real dir
-    # on disk in the common cases (read/save/patch on an existing or new file
-    # under an existing directory).
-    parent = resolved.parent
-    if parent.is_dir():
-        return parent
-    return None
+    dirs: list[Path] = []
+    seen: set[str] = set()
+    for path in paths:
+        try:
+            resolved = path.resolve()
+        except (OSError, ValueError):
+            continue
+        if resolved.is_dir():
+            directory = resolved
+        elif resolved.exists():
+            directory = resolved.parent
+        else:
+            # For unborn files (e.g. about-to-be-saved), use the parent.
+            directory = resolved.parent
+        key = str(directory)
+        if key in seen:
+            continue
+        seen.add(key)
+        dirs.append(directory)
+    return dirs
 
 
 def on_tool_execute_post(
@@ -124,100 +151,64 @@ def on_tool_execute_post(
     workspace: Path | None,
     tool_use: Any,
 ) -> Generator[Message | StopPropagation, None, None]:
-    """Discover and inject AGENTS.md-style files for the tool's target path.
+    """Discover and inject AGENTS.md files for paths touched by structured tools.
 
     Args:
-        log: The conversation log.
+        log: The conversation log (used as a fallback for the loaded-files set
+            in server mode, mirroring `agents_md_inject`).
         workspace: Workspace directory path.
-        tool_use: The ToolUse object that just executed.
+        tool_use: The tool that just executed.
     """
-    tool_name = getattr(tool_use, "tool", None)
-    if tool_name not in _STRUCTURED_PATH_TOOLS:
-        return
-
     try:
-        path_strs = _extract_paths(tool_use)
-        if not path_strs:
+        paths = _extract_paths(tool_use)
+        if not paths:
             return
 
-        # Resolve to directories, dedup while preserving order
-        seen_dirs: set[str] = set()
-        directories: list[Path] = []
-        for path_str in path_strs:
-            d = _resolve_directory(path_str)
-            if d is None:
-                continue
-            key = str(d)
-            if key in seen_dirs:
-                continue
-            seen_dirs.add(key)
-            directories.append(d)
-
-        if not directories:
+        candidate_dirs = _candidate_directories(paths)
+        if not candidate_dirs:
             return
 
         loaded = _get_loaded_files(log)
-        injected = 0
+        candidate_files: list[Path] = []
+        seen_files: set[str] = set()
 
-        for directory in directories:
-            if injected >= MAX_NEW_FILES:
-                break
+        for directory in candidate_dirs:
             new_files = find_agent_files_in_tree(directory, exclude=loaded)
+            if not new_files:
+                continue
+
             for agent_file in new_files:
-                if injected >= MAX_NEW_FILES:
-                    break
                 resolved = str(agent_file.resolve())
-                if resolved in loaded:
+                if resolved in seen_files:
                     continue
-                try:
-                    content = agent_file.read_text()
-                except OSError as e:
-                    logger.warning(f"Could not read agent file {agent_file}: {e}")
-                    continue
+                seen_files.add(resolved)
+                candidate_files.append(agent_file)
 
-                content_key = f"{_HASH_PREFIX}{_content_hash(content)}"
-                if content_key in loaded:
-                    logger.debug(
-                        f"Skipping {agent_file}: identical content already injected"
-                    )
-                    loaded.add(resolved)
-                    continue
+        if not candidate_files:
+            return
 
-                loaded.add(resolved)
-                loaded.add(content_key)
-
-                try:
-                    display_path = str(agent_file.resolve().relative_to(Path.home()))
-                    display_path = f"~/{display_path}"
-                except ValueError:
-                    display_path = str(agent_file)
-
-                logger.info(
-                    f"Injecting agent instructions from {display_path} "
-                    f"(tool={tool_name})"
-                )
-                injected += 1
-                yield Message(
-                    "system",
-                    f'<agent-instructions source="{display_path}">\n'
-                    f"# Agent Instructions ({display_path})\n\n"
-                    f"{content}\n"
-                    f"</agent-instructions>",
-                    files=[agent_file],
-                )
+        # Reverse so most-specific (deepest) files come first — when the
+        # per-event cap fires, general/home-level files are dropped rather
+        # than the project-level ones the tool is actually targeting.
+        yield from inject_agent_instruction_files(
+            log,
+            reversed(candidate_files),
+            max_files=_MAX_INJECT_PER_EVENT,
+            max_bytes=_MAX_BYTES_PER_EVENT,
+        )
 
     except Exception as e:
-        logger.exception(f"Error in tool_target_instructions: {e}")
+        logger.exception(f"Error in tool_target_instructions hook: {e}")
 
 
 def register() -> None:
-    """Register the tool-target agent-instruction injection hook."""
+    """Register the tool-target agent instruction injection hook."""
     register_hook(
         "tool_target_instructions.on_tool_post",
         HookType.TOOL_EXECUTE_POST,
         on_tool_execute_post,
-        # Lower priority than cwd_changed.detect (100) so CWD-driven injection
-        # gets first crack at any new instruction files.
+        # Lower priority than cwd_changed.detect (100) so cwd-driven loading
+        # runs first when a tool both changes cwd and touches a path.
         priority=10,
     )
-    logger.debug("Registered tool-target AGENTS.md injection hook")
+    logger.debug("Registered tool_target_instructions hook")


### PR DESCRIPTION
## Summary

Extends `agents_md_inject` from **cwd-aware** to **tool-target-aware**: when a structured file tool (`read`, `save`, `append`, `patch`, `morph`) touches a path outside the already-loaded directory tree, this new `tool_target_instructions` hook discovers local `AGENTS.md` / `CLAUDE.md` / `GEMINI.md` / `COPILOT.md` files near that path and injects them before the next reasoning step.

This is the Phase 1 of the [tool-targeted agent-instruction loading design](https://github.com/ErikBjare/bob/blob/master/knowledge/technical-designs/tool-targeted-agent-instruction-loading.md). It steals the useful part of Gemini CLI's JIT context pattern without re-running `context_cmd` after every tool call.

### What's in scope (Phase 1)

- Structured file tools only — `read`, `save`, `append`, `patch`, `morph`
- Argument extraction from `kwargs["path"|"paths"|"file"|"files"|"directory"|"cwd"]`, positional args, and read-tool batch content
- Hard caps per tool event: max 3 newly-injected files, ~12KB combined
- Shared dedup logic via the new `inject_agent_instruction_files()` helper extracted from `agents_md_inject`
- Content-hash dedup so worktree copies sharing the same `AGENTS.md` are not re-injected

### What's deliberately out of scope

- Shell command parsing (`cwd_changed` covers that path)
- Pre-write guard (Phase 2)
- `@file.md` inline imports (Phase 3)

## Why this matters

Existing instruction loading misses a very common real workflow: the agent reads or edits a file in a different directory without `cd` first. Examples:

- read `projects/gptme/webui/src/...` while staying in repo root
- patch a file inside `/tmp/worktrees/...` without changing cwd
- inspect a sibling repo via explicit path arguments

In those cases the local instruction file exists, but the runtime does not see it until too late (or ever). This closes that gap.

## Test plan

- [x] `pytest gptme/hooks/tests/test_tool_target_instructions.py` (17 tests covering extraction, directory resolution, and the four design-doc scenarios)
- [x] `pytest gptme/hooks/tests/test_agents_md_inject.py` (still passes after the refactor — 20 tests)
- [x] `pytest gptme/hooks/tests/` (403 tests pass)
- [x] `ruff check` + `ruff format` clean
- [x] `mypy gptme/hooks/tool_target_instructions.py gptme/hooks/agents_md_inject.py` clean

## Commits

1. `feat(hooks): tool-target AGENTS.md injection for path-aware file tools` — new hook + tests, registered in `init_hooks()`
2. `refactor(hooks): extract inject_agent_instruction_files helper` — factor the per-file injection loop out of `agents_md_inject` and route both hooks through it

## Related

- Design doc: [`tool-targeted-agent-instruction-loading.md`](https://github.com/ErikBjare/bob/blob/master/knowledge/technical-designs/tool-targeted-agent-instruction-loading.md)
- Inspired by: [Gemini CLI peer research](https://github.com/ErikBjare/bob/blob/master/knowledge/research/2026-05-09-gemini-cli-deep-peer-research.md)