### PR TITLE
[codex] improve skills discoverability

### DIFF
--- a/docs/skills.rst
+++ b/docs/skills.rst
@@ -160,6 +160,22 @@ Skills are loaded from the following directories (if they exist):
 The ``~/.agents/`` and ``~/.claude/`` paths provide cross-platform compatibility,
 enabling skills to be shared between gptme and other AI tools.
 
+Discovering Skills
+------------------
+
+Use the utility CLI to see what the current workspace already knows about:
+
+.. code-block:: bash
+
+    gptme-util skills list
+    gptme-util skills list --all
+    gptme-util skills show python-repl
+    gptme-util skills dirs
+
+``skills list`` shows skill names and descriptions. ``--all`` includes regular
+lessons in the same discovery pass, and ``skills dirs`` shows exactly which
+directories are being scanned.
+
 Creating Skills
 ---------------
 

--- a/gptme/cli/cmd_skills.py
+++ b/gptme/cli/cmd_skills.py
@@ -67,6 +67,11 @@ def skills_list(show_all: bool, json_output: bool):
             click.echo(f"  {name or '':30s} {desc}")
     else:
         click.echo("No skills found.")
+        click.echo(
+            "Use 'gptme-util skills dirs' to inspect search paths, "
+            "'gptme-util skills init' to create one, or "
+            "'gptme-util skills install <name>' to add one."
+        )
 
     if not show_all:
         if lessons_items:

--- a/gptme/cli/cmd_skills.py
+++ b/gptme/cli/cmd_skills.py
@@ -69,7 +69,7 @@ def skills_list(show_all: bool, json_output: bool):
         click.echo("No skills found.")
         click.echo(
             "Use 'gptme-util skills dirs' to inspect search paths, "
-            "'gptme-util skills init' to create one, or "
+            "'gptme-util skills init <path>' to create one, or "
             "'gptme-util skills install <name>' to add one."
         )
 

--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -145,6 +145,8 @@ The interface provides /commands during a conversation:
 Utilities (gptme-util):
   gptme-util tools list       List all tools and their availability
   gptme-util tools info TOOL  Show detailed tool instructions/examples
+  gptme-util skills list      List discoverable skills in the current workspace
+  gptme-util skills show NAME Show a skill or lesson by name
   gptme-util chats list       List past conversations
   gptme-util chats search Q   Search conversations for query
   gptme-util chats send ID MSG Queue a prompt for a running chat

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -61,6 +61,8 @@ def runner():
 def test_help(runner: CliRunner):
     result = runner.invoke(cli.main, ["--help"])
     assert result.exit_code == 0
+    assert "gptme-util skills list" in result.output
+    assert "gptme-util skills show NAME" in result.output
 
 
 def test_version(runner: CliRunner):

--- a/tests/test_util_cli_skills.py
+++ b/tests/test_util_cli_skills.py
@@ -80,6 +80,25 @@ def test_skills_list_with_skills(tmp_path, mocker):
     assert "1 lessons available" in result.output
 
 
+def test_skills_list_no_skills_shows_next_steps(tmp_path, mocker):
+    """Test skills list shows actionable hints when only lessons are available."""
+    _create_lesson(tmp_path, "test-lesson")
+
+    mocker.patch(
+        "gptme.lessons.index.LessonIndex._default_dirs",
+        return_value=[tmp_path / "lessons"],
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["skills", "list"])
+    assert result.exit_code == 0
+    assert "No skills found." in result.output
+    assert "gptme-util skills dirs" in result.output
+    assert "gptme-util skills init" in result.output
+    assert "gptme-util skills install <name>" in result.output
+    assert "1 lessons available" in result.output
+
+
 def test_skills_list_all(tmp_path, mocker):
     """Test skills list --all showing skills and lessons."""
     _create_skill(tmp_path, "my-skill", "My skill description")

--- a/tests/test_util_cli_skills.py
+++ b/tests/test_util_cli_skills.py
@@ -94,7 +94,7 @@ def test_skills_list_no_skills_shows_next_steps(tmp_path, mocker):
     assert result.exit_code == 0
     assert "No skills found." in result.output
     assert "gptme-util skills dirs" in result.output
-    assert "gptme-util skills init" in result.output
+    assert "gptme-util skills init <path>" in result.output
     assert "gptme-util skills install <name>" in result.output
     assert "1 lessons available" in result.output
 


### PR DESCRIPTION
## Summary
- surface `gptme-util skills list/show` in the main `gptme --help` utility section
- make `gptme-util skills list` give actionable next steps when a workspace has lessons but no skills
- document the discovery commands in `docs/skills.rst`

## Why
The `skills` utility already exists. The real gap was discoverability: the main CLI help didn't mention it, the skills docs didn't show how to browse installed skills, and the empty state stopped at "No skills found" even when the next action was obvious.

## Validation
- `uv run pytest -q tests/test_cli.py::test_help tests/test_util_cli_skills.py`
- `uv run python -m gptme --help | rg -n "gptme-util skills"`
- `uv run python -m gptme.cli.util skills list`
