### PR TITLE
feat(llm): surface actionable diagnostic for OpenRouter 402 insufficient-credits errors

### DIFF
--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -546,6 +546,25 @@ def _handle_openai_transient_error(e, attempt, max_retries, base_delay):
                 for keyword in ["overload", "internal", "timeout"]
             ):
                 should_retry = True
+            elif e.status_code == 402 and any(
+                hint in combined_error
+                for hint in ("affordable", "more credits", "fewer max_tokens")
+            ):
+                # OpenRouter reserves model.max_output + reasoning_budget worth
+                # of credits when max_tokens is omitted. A partially-spent key
+                # then rejects requests as 402 even with plenty of room for the
+                # actual response. Eval callers silently swallow the resulting
+                # APIStatusError as gen_stderr and write empty conversation.jsonl,
+                # so we surface an actionable diagnostic before re-raising.
+                # See: https://github.com/gptme/gptme/issues/2383
+                logger.warning(
+                    "OpenAI/OpenRouter 402 insufficient credits — the request "
+                    "reservation exceeds available key budget. Lower the "
+                    "reservation by setting --max-tokens (or GPTME_MAX_TOKENS) "
+                    "to a value such as 16000, or top up / switch the key. "
+                    "Detail: %s",
+                    combined_error[:500],
+                )
 
     # Re-raise if not transient or max retries reached
     if not should_retry or attempt == max_retries - 1:

--- a/tests/test_llm_openai.py
+++ b/tests/test_llm_openai.py
@@ -976,6 +976,40 @@ class TestOpenAIRetryLogic:
             f"Expected an actionable 402 diagnostic mentioning max_tokens, got: {warning_messages}"
         )
 
+    def test_handle_openai_transient_error_generic_402_no_diagnostic(self, caplog):
+        """Test that a generic 402 (no OpenRouter hint keywords) does NOT emit the
+        credits diagnostic, proving the detection branch is keyword-gated."""
+        import logging
+        from unittest.mock import MagicMock
+
+        import pytest
+        from openai import APIStatusError
+
+        from gptme.llm.llm_openai import _handle_openai_transient_error
+
+        mock_response = MagicMock()
+        mock_response.status_code = 402
+        error = APIStatusError(
+            "Payment required",
+            response=mock_response,
+            body={"error": {"message": "Unauthorized.", "code": 402}},
+        )
+
+        with (
+            caplog.at_level(logging.WARNING, logger="gptme.llm.llm_openai"),
+            pytest.raises(APIStatusError),
+        ):
+            _handle_openai_transient_error(
+                error, attempt=0, max_retries=3, base_delay=0.1
+            )
+
+        warning_messages = [
+            r.message for r in caplog.records if r.levelno >= logging.WARNING
+        ]
+        assert not any("max_tokens" in msg.lower() for msg in warning_messages), (
+            f"Generic 402 should NOT trigger credits diagnostic, got: {warning_messages}"
+        )
+
     def test_retry_decorator_retries_on_transient_error(self, monkeypatch):
         """Test that the retry decorator properly retries on transient errors."""
         from unittest.mock import MagicMock, patch

--- a/tests/test_llm_openai.py
+++ b/tests/test_llm_openai.py
@@ -922,6 +922,60 @@ class TestOpenAIRetryLogic:
             # On last attempt, should not sleep (no retry)
             mock_sleep.assert_not_called()
 
+    def test_handle_openai_transient_error_openrouter_402_diagnostic(self, caplog):
+        """Test that OpenRouter 402 'insufficient credits' errors surface an
+        actionable diagnostic before re-raising.
+
+        OpenRouter reserves max_tokens + reasoning_budget worth of credits when
+        max_tokens is omitted, so a partially-spent key can return 402 with an
+        "affordable: X, requested: Y" body. Without a hint, the eval pipeline
+        catches the APIStatusError silently and writes empty conversation.jsonl.
+        See: https://github.com/gptme/gptme/issues/2383
+        """
+        import logging
+        from unittest.mock import MagicMock
+
+        import pytest
+        from openai import APIStatusError
+
+        from gptme.llm.llm_openai import _handle_openai_transient_error
+
+        mock_response = MagicMock()
+        mock_response.status_code = 402
+        error = APIStatusError(
+            "Payment required",
+            response=mock_response,
+            body={
+                "error": {
+                    "message": (
+                        "This request requires more credits, or fewer "
+                        "max_tokens. You requested up to 65536 tokens, but "
+                        "can only afford 14993."
+                    ),
+                    "code": 402,
+                }
+            },
+        )
+
+        # 402 is non-transient → must raise immediately even on attempt 0
+        with (
+            caplog.at_level(logging.WARNING, logger="gptme.llm.llm_openai"),
+            pytest.raises(APIStatusError),
+        ):
+            _handle_openai_transient_error(
+                error, attempt=0, max_retries=3, base_delay=0.1
+            )
+
+        # The diagnostic must mention max_tokens so users can act on it.
+        warning_messages = [
+            r.message for r in caplog.records if r.levelno >= logging.WARNING
+        ]
+        assert any(
+            "max_tokens" in msg.lower() and "402" in msg for msg in warning_messages
+        ), (
+            f"Expected an actionable 402 diagnostic mentioning max_tokens, got: {warning_messages}"
+        )
+
     def test_retry_decorator_retries_on_transient_error(self, monkeypatch):
         """Test that the retry decorator properly retries on transient errors."""
         from unittest.mock import MagicMock, patch


### PR DESCRIPTION
## Summary

- Detect OpenRouter HTTP 402 \"insufficient credits\" rejections (the \"affordable: N, requested: M, fewer max_tokens\" pattern) in `_handle_openai_transient_error` and log a clear actionable warning before re-raising.
- The warning names the exact lever: `--max-tokens` / `GPTME_MAX_TOKENS`, with `16000` as a safe starting value.
- Runtime behavior is otherwise unchanged: 402 still fails fast (it is not transient).

## Why

When `max_tokens` is omitted, OpenRouter reserves `model.max_output + reasoning_budget` worth of credits per request. For Sonnet 4.6 that is 65536 tokens. A partially-spent daily-budget OpenRouter key then returns HTTP 402 even for calls whose actual output would fit comfortably.

The eval pipeline catches the resulting `APIStatusError` silently as `gen_stderr` and writes empty `conversation.jsonl` rows with `run_time=0` / `eval_time=0`, masking the budget rejection behind what externally looks like a behavioral regression (e.g. 0/32 holdout). This caused gptme/gptme#2383.

## What this is (and is not)

- This is follow-up (a) from #2383: surface the silent 402 with a concrete next step.
- It is **not** a behavior change for OpenRouter routing or default `max_tokens` (follow-up (b)) — that would be a wider scope and is left for a separate PR.

## Test plan

- [x] New regression test `test_handle_openai_transient_error_openrouter_402_diagnostic` asserts the warning fires and mentions `max_tokens` + `402`.
- [x] All 11 retry tests in `TestOpenAIRetryLogic` still pass.
- [x] Full `tests/test_llm_openai.py` suite: 73 passed.
- [x] `ruff check` + `ruff format` clean.

Refs: #2383