### PR TITLE
feat(eval): add partial-credit 'Score' column to eval_results.csv

### DIFF
--- a/gptme/eval/main.py
+++ b/gptme/eval/main.py
@@ -1008,6 +1008,7 @@ def write_results(
             "Tool Format",
             "Test",
             "Passed",
+            "Score",
             "Total Duration",
             "Generation Time",
             "Run Time",
@@ -1027,6 +1028,14 @@ def write_results(
                     else False
                 )
 
+                # Partial-credit score: how many individual checkers passed
+                if result.results:
+                    passed_count = sum(1 for c in result.results if c.passed)
+                    total_count = len(result.results)
+                    score = f"{passed_count}/{total_count}"
+                else:
+                    score = ""
+
                 # Use model/tool_format/test_name directory layout
                 test_dir = results_dir / config.model / config.tool_format / result.name
                 test_dir.mkdir(parents=True, exist_ok=True)
@@ -1042,6 +1051,7 @@ def write_results(
                     "Tool Format": config.tool_format,
                     "Test": result.name,
                     "Passed": "true" if passed else "false",
+                    "Score": score,
                     "Total Duration": round(sum(result.timings.values()), 2),
                     "Generation Time": round(result.timings["gen"], 2),
                     "Run Time": round(result.timings["run"], 2),


### PR DESCRIPTION
Adds a `Score` column (e.g. `2/3`) to the eval output CSV, showing how many individual checkers each test passed.

This enables holdout analysis to use graduated partial-credit scoring instead of binary pass/fail, increasing measurement sensitivity for lesson-effect experiments without requiring more eval runs.

Closes gptme-contrib#0 (part of idea #19 eval-to-lesson feedback loop)