### PR TITLE
fix(eval): attach fixture files to local eval prompts

### DIFF
--- a/gptme/eval/agents/__init__.py
+++ b/gptme/eval/agents/__init__.py
@@ -2,6 +2,7 @@ import logging
 import uuid
 from abc import abstractmethod
 from pathlib import Path
+from typing import TYPE_CHECKING, cast
 
 from gptme import Message, get_prompt
 from gptme import chat as gptme_chat
@@ -13,6 +14,9 @@ from ...tools import ToolFormat
 from ..execenv import DockerGPTMeEnv
 from ..filestore import FileStore
 from ..types import Files
+
+if TYPE_CHECKING:
+    from gptme.util.uri import FilePath
 
 logger = logging.getLogger(__name__)
 
@@ -75,7 +79,7 @@ class GPTMe(Agent):
 
         if self.use_docker:
             return self._act_docker(store, prompt)
-        return self._act_local(store, prompt)
+        return self._act_local(store, prompt, files)
 
     def _act_docker(self, store: FileStore, prompt: str) -> Files:
         """Execute gptme inside a Docker container for isolation."""
@@ -123,7 +127,7 @@ class GPTMe(Agent):
         print("--- Finished generation (Docker-isolated) ---\n")
         return store.download()
 
-    def _act_local(self, store: FileStore, prompt: str) -> Files:
+    def _act_local(self, store: FileStore, prompt: str, files: Files | None) -> Files:
         """Execute gptme directly in the current process."""
         # Prepare execution environment and get initialized tools
         _, tools = prepare_execution_environment(
@@ -158,9 +162,13 @@ class GPTMe(Agent):
             prompt_sys_msgs[0] = prompt_sys_msgs[0].replace(
                 content=prompt_sys_msgs[0].content + eval_instructions
             )
+        # Attach workspace fixture files so the eval prompt deterministically
+        # embeds the exact scenario inputs instead of relying on incidental
+        # workspace reads or provider-specific behavior.
+        user_files = [self.workspace_dir / name for name in files] if files else []
         try:
             gptme_chat(
-                [Message("user", prompt)],
+                [Message("user", prompt, files=cast("list[FilePath]", user_files))],
                 prompt_sys_msgs,
                 logdir=self.log_dir,
                 model=self.model,

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -366,6 +366,42 @@ def test_eval_agent_passes_user_context_flag(monkeypatch, tmp_path):
     assert captured == [False, True]
 
 
+def test_eval_agent_attaches_fixture_files(monkeypatch, tmp_path):
+    """GPTMe eval agent should attach workspace fixtures to the user prompt."""
+    captured_messages: list[Message] = []
+
+    monkeypatch.setattr("gptme.eval.agents.get_logs_dir", lambda: tmp_path)
+    monkeypatch.setattr(
+        "gptme.eval.agents.generate_conversation_id",
+        lambda prefix, _log_dir: prefix,
+    )
+    monkeypatch.setattr(
+        "gptme.eval.agents.prepare_execution_environment",
+        lambda workspace, tools: (None, []),
+    )
+    monkeypatch.setattr(
+        "gptme.eval.agents.get_prompt",
+        lambda *args, **kwargs: [Message("system", "base prompt")],
+    )
+
+    def fake_chat(messages, *args, **kwargs):
+        captured_messages.extend(messages)
+
+    monkeypatch.setattr("gptme.eval.agents.gptme_chat", fake_chat)
+
+    agent = GPTMe(model="test-model", tool_format="markdown")
+    agent.act({"stats.py": "x = 1\n", "test_stats.py": "assert True\n"}, "fix bug")
+
+    assert len(captured_messages) == 1
+    msg = captured_messages[0]
+    assert msg.content == "fix bug"
+    fixture_paths = [f for f in msg.files if isinstance(f, Path)]
+    assert len(fixture_paths) == 2
+    assert [p.name for p in fixture_paths] == ["stats.py", "test_stats.py"]
+    assert all(p.parent == agent.workspace_dir for p in fixture_paths)
+    assert all(p.exists() for p in fixture_paths)
+
+
 def _detect_model():
     # detect which model is configured (manual since init() hasn't run in tests)
     config = get_config()

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -397,7 +397,7 @@ def test_eval_agent_attaches_fixture_files(monkeypatch, tmp_path):
     assert msg.content == "fix bug"
     fixture_paths = [f for f in msg.files if isinstance(f, Path)]
     assert len(fixture_paths) == 2
-    assert [p.name for p in fixture_paths] == ["stats.py", "test_stats.py"]
+    assert {p.name for p in fixture_paths} == {"stats.py", "test_stats.py"}
     assert all(p.parent == agent.workspace_dir for p in fixture_paths)
     assert all(p.exists() for p in fixture_paths)
 


### PR DESCRIPTION
## Summary
- attach uploaded eval fixture files to the local GPTMe eval user message
- make the prompt shape deterministic instead of relying on incidental workspace reads
- add a regression test covering fixture attachment in the eval agent

## Why
Recent `scope-discipline-bugfix` holdout failures showed a prompt-shape regression: fast-failing runs logged only the bare task instruction, while earlier successful runs included the scenario files inline. Attaching the workspace fixtures explicitly restores the reliable path.

## Testing
- `PYTHONPATH=/home/bob/tmp/gptme-f2c8 /home/bob/gptme/.venv/bin/pytest /home/bob/tmp/gptme-f2c8/tests/test_eval.py -q -k "user_context_flag or attaches_fixture_files"`
- `cd /home/bob/tmp/gptme-f2c8 && PYTHONPATH=/home/bob/tmp/gptme-f2c8 /home/bob/gptme/.venv/bin/mypy gptme/eval/agents/__init__.py tests/test_eval.py`
