### PR TITLE
fix(ci): move workflow inputs from inline run: interpolation to env:

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -208,8 +208,8 @@ jobs:
       shell: bash
       env:
         GH_TOKEN: ${{ github.token }}
+        TAG: ${{ inputs.tag || github.ref_name }}
       run: |
-        TAG="${{ inputs.tag || github.ref_name }}"
         VERSION="${TAG#v}"
         OS_SUFFIX="${{ runner.os }}-${{ runner.arch }}"
         OS_SUFFIX=$(echo "$OS_SUFFIX" | tr '[:upper:]' '[:lower:]')

--- a/.github/workflows/optimize-prompts.yml
+++ b/.github/workflows/optimize-prompts.yml
@@ -72,22 +72,31 @@ jobs:
           echo "OPENROUTER_API_KEY=${{ secrets.OPENROUTER_API_KEY }}" >> $GITHUB_ENV
 
       - name: Run baseline evaluation
+        env:
+          MODEL: ${{ github.event.inputs.model || 'anthropic/claude-haiku-4-5' }}
         run: |
           python -m gptme.eval.dspy show-prompt \
-            --model "${{ github.event.inputs.model || 'anthropic/claude-haiku-4-5' }}"
+            --model "$MODEL"
 
       - name: Run quick test
+        env:
+          MODEL: ${{ github.event.inputs.model || 'anthropic/claude-haiku-4-5' }}
         run: |
           python -m gptme.eval.dspy -v quick-test \
             --num-examples 5 \
-            --model "${{ github.event.inputs.model || 'anthropic/claude-haiku-4-5' }}"
+            --model "$MODEL"
 
       - name: Run prompt optimization
+        env:
+          OPTIMIZERS: ${{ github.event.inputs.optimizers || 'miprov2,bootstrap' }}
+          MODEL: ${{ github.event.inputs.model || 'anthropic/claude-haiku-4-5' }}
+          MAX_DEMOS: ${{ github.event.inputs.max_demos || '3' }}
+          NUM_TRIALS: ${{ github.event.inputs.num_trials || '10' }}
         run: |
           EXPERIMENT_NAME="automated_optimization_$(date +%Y%m%d_%H%M%S)"
 
           # Convert comma-separated optimizers to multiple flags
-          OPTIMIZERS="${{ github.event.inputs.optimizers || 'miprov2,bootstrap' }}"
+          OPTIMIZERS="$OPTIMIZERS"
           OPTIMIZER_FLAGS=""
           for optimizer in $(echo $OPTIMIZERS | tr ',' ' '); do
             OPTIMIZER_FLAGS="$OPTIMIZER_FLAGS --optimizers $optimizer"
@@ -95,9 +104,9 @@ jobs:
 
           python -m gptme.eval.dspy -v optimize \
             --name "$EXPERIMENT_NAME" \
-            --model "${{ github.event.inputs.model || 'anthropic/claude-haiku-4-5' }}" \
-            --max-demos "${{ github.event.inputs.max_demos || '3' }}" \
-            --num-trials "${{ github.event.inputs.num_trials || '10' }}" \
+            --model "$MODEL" \
+            --max-demos "$MAX_DEMOS" \
+            --num-trials "$NUM_TRIALS" \
             $OPTIMIZER_FLAGS \
             --output-dir ./optimization_results
         continue-on-error: true
@@ -109,12 +118,16 @@ jobs:
 
       - name: Generate summary report
         if: always()
+        env:
+          MODEL: ${{ github.event.inputs.model || 'anthropic/claude-haiku-4-5' }}
+          OPTIMIZERS: ${{ github.event.inputs.optimizers || 'miprov2,bootstrap' }}
+          NUM_TRIALS: ${{ github.event.inputs.num_trials || '10' }}
         run: |
           echo "# Prompt Optimization Summary" > optimization_summary.md
           echo "**Date:** $(date)" >> optimization_summary.md
-          echo "**Model:** ${{ github.event.inputs.model || 'anthropic/claude-haiku-4-5' }}" >> optimization_summary.md
-          echo "**Optimizers:** ${{ github.event.inputs.optimizers || 'miprov2,bootstrap' }}" >> optimization_summary.md
-          echo "**Trials:** ${{ github.event.inputs.num_trials || '10' }}" >> optimization_summary.md
+          echo "**Model:** $MODEL" >> optimization_summary.md
+          echo "**Optimizers:** $OPTIMIZERS" >> optimization_summary.md
+          echo "**Trials:** $NUM_TRIALS" >> optimization_summary.md
           echo "" >> optimization_summary.md
 
           if [ -d "./optimization_results" ]; then
@@ -145,12 +158,14 @@ jobs:
       - name: Create issue with results (on failure)
         if: failure()
         uses: actions/github-script@v9
+        env:
+          MODEL: ${{ github.event.inputs.model || 'anthropic/claude-haiku-4-5' }}
         with:
           script: |
             const fs = require('fs');
             let body = '## Prompt Optimization Failed\n\n';
             body += `**Run:** ${context.runNumber}\n`;
-            body += `**Model:** ${{ github.event.inputs.model || 'anthropic/claude-haiku-4-5' }}\n`;
+            body += `**Model:** ${process.env.MODEL}\n`;
             body += `**Workflow:** [${context.workflow}](${context.payload.repository.html_url}/actions/runs/${context.runId})\n\n`;
 
             if (fs.existsSync('optimization_summary.md')) {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,9 +168,9 @@ jobs:
 
       - name: Bump version
         id: version
-        run: |
-          TYPE="${{ github.event.inputs.release_type || 'dev' }}"
-          bash scripts/bump_version.sh --type "$TYPE"
+        env:
+          TYPE: ${{ github.event.inputs.release_type || 'dev' }}
+        run: bash scripts/bump_version.sh --type "$TYPE"
 
       - name: Generate changelog
         run: |

--- a/.github/workflows/tauri.yml
+++ b/.github/workflows/tauri.yml
@@ -425,8 +425,9 @@ jobs:
 
       - name: Set Tauri bundle version from release tag
         shell: bash
+        env:
+          TAG: ${{ inputs.tag || github.ref_name }}
         run: |
-          TAG="${{ inputs.tag || github.ref_name }}"
           export VERSION="${TAG#v}"
           python3 - <<'PY'
           import json
@@ -619,8 +620,8 @@ jobs:
       - name: Upload APK/AAB to release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ inputs.tag || github.ref_name }}
         run: |
-          TAG="${{ inputs.tag || github.ref_name }}"
           find android-dist -name "*.apk" -o -name "*.aab" | while read -r f; do
             echo "Uploading $f"
             gh release upload "$TAG" "$f" --clobber

--- a/gptme/prompts/context_cmd.py
+++ b/gptme/prompts/context_cmd.py
@@ -48,6 +48,9 @@ def get_project_context_cmd_output(cmd: str, workspace: Path) -> str | None:
     console.log(f"Using project context command: {cmd}")
     try:
         start = time.time()
+        # shell=True is intentional: `cmd` is a user-configured project context
+        # command. The trust model is that the user controls `cmd` and is also
+        # the threat model — no untrusted input should ever reach this path.
         result = subprocess.run(
             cmd,
             check=False,


### PR DESCRIPTION
## Summary

Per GitHub [security hardening guidance](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable), move all \${{ inputs.* }} and \${{ github.event.inputs.* }} values from inline shell interpolation to `env:` blocks. This prevents the inputs from being interpolated at workflow-parse time before any shell quoting can protect them.

Also adds a one-line comment in `context_cmd.py` documenting that `shell=True` is intentional (it's a user-configured project context command — the user is the threat model).

## Changes

- **build.yml**: `TAG` moved to `env:` (line 212)
- **optimize-prompts.yml**: `MODEL` (lines 75, 80, 86), `OPTIMIZERS` (line 90), `MAX_DEMOS` (line 98), `NUM_TRIALS` (line 99) moved to `env:`; shell doc comment section (lines 115-117) moved to `env:`; JS template literal in `actions/github-script` block now reads from `process.env.MODEL` instead of inline interpolation
- **release.yml**: `TYPE` moved to `env:` (line 172)
- **tauri.yml**: `TAG` moved to `env:` in both Set version (line 429) and Upload APK (line 623) steps
- **context_cmd.py**: Added comment documenting `shell=True` trust boundary (line 57)

## Verification

- [x] git diff --check clean
- [x] Pre-commit hooks passed
- [x] No functional changes — all substitutions preserve identical behavior

Closes #2398

Reported-by: elfrost via AI PatchLab scan