### PR TITLE
[codex] docs(cli): surface queued follow-up prompts

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -127,6 +127,20 @@ The ``-`` separator allows you to chain multiple prompts together, letting the a
 
 This is particularly useful for breaking down complex tasks into steps and creating :doc:`automation` workflows.
 
+Queue follow-up prompts
+^^^^^^^^^^^^^^^^^^^^^^^
+
+If another ``gptme`` process is already busy in a conversation, queue the next
+user turn from a second terminal instead of waiting for the current step to
+finish:
+
+.. code-block:: bash
+
+    gptme-util chats send chat-123 "once the tests finish, summarize the failures"
+
+The running conversation will drain the queued prompt on its next turn. Use
+``gptme-util chats list`` if you need to look up the conversation ID first.
+
 Tool Selection Patterns
 ^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/gptme/cli/cmd_chats.py
+++ b/gptme/cli/cmd_chats.py
@@ -53,7 +53,7 @@ def _format_size(size_bytes: int) -> str:
 
 @click.group()
 def chats():
-    """Commands for managing chat logs."""
+    """Commands for managing chat logs and queued follow-ups."""
 
 
 @chats.command("list")
@@ -200,7 +200,11 @@ def chats_rename(id: str, name: str):
 @click.argument("id")
 @click.argument("message", nargs=-1, required=True)
 def chats_send(id: str, message: tuple[str, ...]):
-    """Queue a prompt for the next turn of a running conversation."""
+    """Queue a prompt for the next turn of a running conversation.
+
+    This is useful when another gptme process is busy in the same chat and you
+    already know the next instruction you want to send.
+    """
     logdir = get_logs_dir() / id
     if not logdir.exists():
         click.echo(f"Chat '{id}' not found")

--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -149,7 +149,7 @@ Utilities (gptme-util):
   gptme-util skills show NAME Show a skill or lesson by name
   gptme-util chats list       List past conversations
   gptme-util chats search Q   Search conversations for query
-  gptme-util chats send ID MSG Queue a prompt for a running chat
+  gptme-util chats send ID MSG Queue a prompt for a running chat from another terminal
   gptme-util chats rename     Rename a conversation
   gptme-util models list      List available models
   gptme-util context index    Index project files for RAG

--- a/tests/test_util_cli.py
+++ b/tests/test_util_cli.py
@@ -164,6 +164,17 @@ def test_chats_send(tmp_path, monkeypatch):
     assert [record["content"] for record in records] == ["follow up"]
 
 
+def test_chats_send_help_mentions_second_terminal():
+    """Test that chats send help explains the queued-follow-up workflow."""
+    runner = CliRunner()
+
+    result = runner.invoke(main, ["chats", "send", "--help"])
+
+    assert result.exit_code == 0
+    assert "another gptme process is busy" in result.output
+    assert "next instruction" in result.output
+
+
 def test_tools_list():
     """Test the tools list command."""
     import json


### PR DESCRIPTION
## Summary
- surface the existing `gptme-util chats send` queued-prompt workflow in CLI help and usage docs
- add a focused CLI regression test so the help text keeps explaining the second-terminal follow-up flow

## Why
- issue #569 claims the CLI cannot queue prompts while another chat is busy, but the feature already exists in the live code
- the real gap is discoverability: the command was easy to miss unless you already knew to look under `gptme-util chats send`

## User Impact
- makes it much clearer that follow-up prompts can be queued from another terminal while a conversation is still running
- gives users a concrete command and example instead of leaving the capability buried in utility subcommands

## Validation
- `poetry run pytest tests/test_util_cli.py -q`
- `poetry run ruff check gptme/cli/cmd_chats.py tests/test_util_cli.py`
- `poetry run gptme-util chats send --help`
