### PR TITLE
test(cli): relax queued prompt help assertions

### DIFF
--- a/tests/test_util_cli.py
+++ b/tests/test_util_cli.py
@@ -164,15 +164,18 @@ def test_chats_send(tmp_path, monkeypatch):
     assert [record["content"] for record in records] == ["follow up"]
 
 
-def test_chats_send_help_mentions_second_terminal():
+def test_chats_send_help_mentions_queued_follow_up_flow():
     """Test that chats send help explains the queued-follow-up workflow."""
+    import re
+
     runner = CliRunner()
 
     result = runner.invoke(main, ["chats", "send", "--help"])
 
     assert result.exit_code == 0
-    assert "another gptme process is busy" in result.output
-    assert "next instruction" in result.output
+    help_text = " ".join(result.output.lower().split())
+    assert re.search(r"queue.*prompt", help_text)
+    assert re.search(r"running conversation|gptme process.*busy", help_text)
 
 
 def test_tools_list():


### PR DESCRIPTION
## Summary
- rename the queued-follow-up help test to describe the behavior it protects
- normalize `--help` output and assert the concept with regexes instead of two exact prose fragments

## Why
- follow-up to #2400: the original regression test worked, but it was too tightly coupled to the exact help wording
- this keeps the discoverability check while making future wording cleanup less noisy

## Validation
- `uv run --with pytest python -m pytest tests/test_util_cli.py -q -k queued_follow_up`
- `uv run --with ruff ruff check tests/test_util_cli.py`
