### PR TITLE
fix(llm): apply default max_tokens (16k) for OpenRouter models

### DIFF
--- a/gptme/llm/__init__.py
+++ b/gptme/llm/__init__.py
@@ -146,8 +146,24 @@ def _get_agent_name(config: Config) -> str | None:
     return agent_config.name if agent_config and agent_config.name else None
 
 
+# OpenRouter default: 16k is enough headroom for most coding/eval responses
+# while still reducing the credit reservation from model.max_output (up to
+# 64k) to a value that works with partially-spent daily-budget keys.
+# Override with GPTME_MAX_TOKENS for larger responses.
+_OPENROUTER_DEFAULT_MAX_TOKENS = 16000
+
+
 def _resolve_max_tokens(model: str, max_tokens: int | None) -> int | None:
-    """Apply the GPTME_MAX_TOKENS env override for OpenRouter models only."""
+    """Apply the GPTME_MAX_TOKENS env override or a sane default for OpenRouter models.
+
+    When max_tokens is omitted, OpenRouter reserves model.max_output +
+    reasoning_budget credits per request. For large models like Sonnet 4.6
+    that is ~65k tokens. A partially-spent daily-budget key rejects this
+    with HTTP 402 even when the actual response would fit comfortably.
+
+    Setting a default max_tokens reduces the reservation so partial-budget
+    keys still work.
+    """
 
     if max_tokens is not None:
         return max_tokens
@@ -156,27 +172,25 @@ def _resolve_max_tokens(model: str, max_tokens: int | None) -> int | None:
         return None
 
     raw = get_config().get_env("GPTME_MAX_TOKENS")
-    if raw is None or raw == "":
-        return None
+    if raw is not None and raw != "":
+        global _max_tokens_env_warned
+        try:
+            parsed = int(raw)
+        except ValueError:
+            if not _max_tokens_env_warned:
+                logger.warning("Invalid GPTME_MAX_TOKENS value: %r, ignoring", raw)
+                _max_tokens_env_warned = True
+        else:
+            if parsed > 0:
+                return parsed
+            if not _max_tokens_env_warned:
+                logger.warning(
+                    "GPTME_MAX_TOKENS must be a positive integer, got %r; ignoring",
+                    raw,
+                )
+                _max_tokens_env_warned = True
 
-    global _max_tokens_env_warned
-    try:
-        parsed = int(raw)
-    except ValueError:
-        if not _max_tokens_env_warned:
-            logger.warning("Invalid GPTME_MAX_TOKENS value: %r, ignoring", raw)
-            _max_tokens_env_warned = True
-        return None
-
-    if parsed <= 0:
-        if not _max_tokens_env_warned:
-            logger.warning(
-                "GPTME_MAX_TOKENS must be a positive integer, got %r; ignoring", raw
-            )
-            _max_tokens_env_warned = True
-        return None
-
-    return parsed
+    return _OPENROUTER_DEFAULT_MAX_TOKENS
 
 
 @trace_function(name="llm.reply", attributes={"component": "llm"})

--- a/tests/test_llm_openai.py
+++ b/tests/test_llm_openai.py
@@ -2010,3 +2010,93 @@ class TestOpenrouterModelToModelmeta:
             self._model_data("openrouter/anthropic/claude-sonnet-4-20250514")
         )
         assert meta.full == "openrouter/anthropic/claude-sonnet-4-20250514"
+
+
+class TestResolveMaxTokens:
+    """Tests for _resolve_max_tokens — OpenRouter default-max-tokens behavior."""
+
+    def test_explicit_max_tokens_passthrough(self, monkeypatch):
+        """Explicit max_tokens is passed through unchanged."""
+        from gptme.llm import _resolve_max_tokens
+
+        result = _resolve_max_tokens(
+            "openrouter/anthropic/claude-sonnet-4-20250514", 500
+        )
+        assert result == 500
+
+    def test_non_openrouter_returns_none(self, monkeypatch):
+        """Non-OpenRouter models return None (no default applied)."""
+        from gptme.llm import _resolve_max_tokens
+
+        result = _resolve_max_tokens("openai/gpt-5", None)
+        assert result is None
+
+    def test_openrouter_default_applied(self, monkeypatch):
+        """OpenRouter models get the 16k default when no env var or explicit max_tokens."""
+        from gptme.llm import _resolve_max_tokens
+
+        monkeypatch.delenv("GPTME_MAX_TOKENS", raising=False)
+        result = _resolve_max_tokens(
+            "openrouter/anthropic/claude-sonnet-4-20250514", None
+        )
+        assert result == 16000
+
+    def test_gptme_max_tokens_env_override(self, monkeypatch):
+        """GPTME_MAX_TOKENS env var overrides the default."""
+        from gptme.llm import _resolve_max_tokens
+
+        monkeypatch.setenv("GPTME_MAX_TOKENS", "32000")
+        result = _resolve_max_tokens(
+            "openrouter/anthropic/claude-sonnet-4-20250514", None
+        )
+        assert result == 32000
+
+    def test_explicit_beats_env(self, monkeypatch):
+        """Explicit max_tokens wins over GPTME_MAX_TOKENS env var."""
+        from gptme.llm import _resolve_max_tokens
+
+        monkeypatch.setenv("GPTME_MAX_TOKENS", "32000")
+        result = _resolve_max_tokens(
+            "openrouter/anthropic/claude-sonnet-4-20250514", 1000
+        )
+        assert result == 1000
+
+    def test_env_empty_string_falls_back_to_default(self, monkeypatch):
+        """Empty GPTME_MAX_TOKENS falls back to default, not None."""
+        from gptme.llm import _resolve_max_tokens
+
+        monkeypatch.setenv("GPTME_MAX_TOKENS", "")
+        result = _resolve_max_tokens(
+            "openrouter/anthropic/claude-sonnet-4-20250514", None
+        )
+        assert result == 16000
+
+    def test_env_invalid_string_falls_back_to_default(self, monkeypatch):
+        """Invalid GPTME_MAX_TOKENS falls back to default."""
+        from gptme.llm import _resolve_max_tokens
+
+        monkeypatch.setenv("GPTME_MAX_TOKENS", "sixteen-k")
+        result = _resolve_max_tokens(
+            "openrouter/anthropic/claude-sonnet-4-20250514", None
+        )
+        assert result == 16000
+
+    def test_env_negative_falls_back_to_default(self, monkeypatch):
+        """Negative GPTME_MAX_TOKENS falls back to default."""
+        from gptme.llm import _resolve_max_tokens
+
+        monkeypatch.setenv("GPTME_MAX_TOKENS", "-100")
+        result = _resolve_max_tokens(
+            "openrouter/anthropic/claude-sonnet-4-20250514", None
+        )
+        assert result == 16000
+
+    def test_env_zero_falls_back_to_default(self, monkeypatch):
+        """Zero GPTME_MAX_TOKENS falls back to default."""
+        from gptme.llm import _resolve_max_tokens
+
+        monkeypatch.setenv("GPTME_MAX_TOKENS", "0")
+        result = _resolve_max_tokens(
+            "openrouter/anthropic/claude-sonnet-4-20250514", None
+        )
+        assert result == 16000


### PR DESCRIPTION
When max_tokens is omitted, OpenRouter reserves model.max_output + reasoning_budget credits per request. For Sonnet 4.6 that is ~65k tokens. A partially-spent daily-budget key rejects this with HTTP 402 even though the actual response would fit comfortably.

Set a 16k default for OpenRouter models so partial-budget keys still work. Explicit max_tokens and GPTME_MAX_TOKENS env var take precedence.

This is follow-up (b) from gptme/gptme#2383: the 402 diagnostic shipped in #2388, but the root cause (no default max_tokens) remained unfixed.

## Changes

- Add _OPENROUTER_DEFAULT_MAX_TOKENS = 16000 in gptme/llm/__init__.py
- _resolve_max_tokens() now returns this default when no explicit max_tokens is set and GPTME_MAX_TOKENS is unset/invalid
- 9 tests covering: explicit passthrough, non-OpenRouter returns None, default applied, env override, explicit beats env, empty/invalid/negative/zero env fallback

## Verification

- 83 tests pass in tests/test_llm_openai.py (74 original + 9 new)
- ruff format clean
- mypy passes

Refs: gptme/gptme#2383