### PR TITLE
docs(cli): document JSONL automation mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,6 +467,9 @@ gptme -y 'run the test suite and fix any failing tests'
 
 # Fully non-interactive/autonomous mode (no user interaction possible, safe for scripts/CI)
 gptme -n 'run the test suite and fix any failing tests'
+
+# Machine-readable automation output (JSONL on stdout)
+gptme --non-interactive --output-format json 'summarize the current git diff'
 ```
 
 For more, see the [Getting Started][docs-getting-started] guide and the [Examples][docs-examples] in the [documentation][docs].
@@ -548,6 +551,9 @@ Options:
   -r, --resume           Load most recent conversation.
   -y, --no-confirm       Skip all confirmation prompts.
   -n, --non-interactive  Non-interactive mode. Implies --no-confirm.
+  --output-format [text|json]
+                         Output format for non-interactive mode. 'json'
+                         emits one JSON object per line on stdout.
   --system TEXT          System prompt. Options: 'full', 'short', or something
                          custom.
   -t, --tools TEXT       Tools to allow as comma-separated list. Available:
@@ -561,6 +567,11 @@ Options:
   --version              Show version and configuration information
   --help                 Show this message and exit.
 ```
+
+Pair ``--non-interactive`` with ``--output-format json`` when stdout needs to
+be machine-readable, for example in CI or a supervising process. Use
+``--resume`` to continue an existing automated conversation or pick up queued
+follow-up prompts without passing a new prompt.
 
 ## 🌍 Ecosystem
 

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -262,6 +262,7 @@ gptme supports several automation modes:
 
 - ``gptme -y`` — auto-approve tool confirmations (user can still watch and interrupt)
 - ``gptme -n`` — fully non-interactive/autonomous mode (safe for scripts and CI)
+- ``gptme -n --output-format json`` — JSONL stdout for scripts, CI, and supervisor processes
 - **GitHub Bot** — request changes from PR and issue comments, runs in GitHub Actions
 - **Subagent spawning** — delegate subtasks to parallel agent instances via tmux
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -197,6 +197,25 @@ The ``--non-interactive`` flag runs gptme in a mode that terminates after comple
 
 Note: ``--non-interactive`` implies ``--no-confirm``, so you don't need to specify both.
 
+Machine-readable output
+^^^^^^^^^^^^^^^^^^^^^^^
+
+Pair ``--non-interactive`` with ``--output-format json`` when stdout needs to
+be consumed by another program. In JSON mode, gptme emits one JSON object per
+line on stdout (JSONL):
+
+.. code-block:: bash
+
+    gptme --non-interactive --output-format json 'summarize this repository'
+
+Use ``--resume`` to continue an existing automated conversation without
+supplying a new prompt. This also picks up any queued follow-up prompts for the
+current conversation before exiting:
+
+.. code-block:: bash
+
+    gptme --non-interactive --output-format json --resume
+
 .. _pre-commit:
 
 Pre-commit Integration


### PR DESCRIPTION
Documents `--output-format json` JSONL automation mode and `--resume` for headless runs, across README.md, docs/usage.rst, and docs/features.rst.

The CLI gained `--output-format json` in [#2392](https://github.com/gptme/gptme/pull/2392) and `--resume` earlier, but the user-facing docs still only described `--non-interactive`. This PR surfaces both features for automation and headless use cases.

**Changes:**
- `README.md`: Add JSONL automation example commands and surface JSON format in embedded `--help` output
- `docs/usage.rst`: Add automation guidance section with `--output-format json` and `--resume` examples
- `docs/features.rst`: Add `--output-format json` to the automation feature list