### PR TITLE
refactor(openai): share Responses API helpers

### DIFF
--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -6,11 +6,10 @@ import re
 import time
 from collections.abc import Generator, Iterable
 from functools import lru_cache, wraps
-from typing import TYPE_CHECKING, Any, TypedDict, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import requests
 from openai import NOT_GIVEN, NotGiven
-from typing_extensions import NotRequired
 
 from ..config import Config, get_config
 from ..constants import OPENAI_VERBOSITY, TEMPERATURE, TOP_P
@@ -23,6 +22,20 @@ from .models import (
     ModelMeta,
     Provider,
     is_custom_provider,
+)
+from .openai_responses import (
+    ContentPart,
+    MessageContent,
+    MessageDict,
+    ToolCall,
+    ToolCallFunction,
+    _content_to_responses_input,
+    _extract_usage_token_counts,
+    _filter_duplicate_thinking_text,
+    _longest_suffix_prefix,
+    _messages_dicts_to_responses_input,
+    _obj_get,
+    _tool_spec_to_responses_tool,
 )
 from .utils import (
     apply_cache_control,
@@ -41,6 +54,13 @@ if TYPE_CHECKING:
 clients: dict[Provider, "OpenAI"] = {}
 logger = logging.getLogger(__name__)
 
+__all__ = [
+    "ContentPart",
+    "MessageContent",
+    "_content_to_responses_input",
+    "_messages_dicts_to_responses_input",
+]
+
 
 def _get_provider_api_key(config: Config, provider: Provider, env_var: str) -> str:
     """Resolve a provider key from env/config first, then credentials.toml."""
@@ -54,63 +74,6 @@ def _get_provider_api_key(config: Config, provider: Provider, env_var: str) -> s
     )
 
 
-# Type definitions for message dictionaries used in API transformations
-class ContentPart(TypedDict):
-    """A content part in a multimodal message."""
-
-    type: str  # "text", "image_url", etc. - always required
-    text: NotRequired[str]  # For text parts
-    image_url: NotRequired[dict[str, str]]  # For image parts: {"url": "data:..."}
-
-
-# Type alias for message content (can be string, list of parts, or None)
-MessageContent = str | list[ContentPart | str] | None
-
-
-class ToolCallFunction(TypedDict):
-    """Function details in a tool call."""
-
-    name: str
-    arguments: str
-
-
-class ToolCall(TypedDict):
-    """A tool call in an assistant message."""
-
-    id: str
-    type: str  # "function"
-    function: ToolCallFunction
-
-
-class MessageDict(TypedDict):
-    """
-    Dictionary representation of a chat message for API calls.
-
-    This type covers the internal message format used when preparing
-    messages for various LLM providers. Not all fields are present
-    in all messages - the required fields vary by role.
-    """
-
-    # Core fields (always required)
-    role: str  # "system", "user", "assistant", "tool"
-    content: MessageContent
-
-    # Tool-related fields (optional)
-    tool_calls: NotRequired[list[ToolCall]]  # For assistant messages that call tools
-    tool_call_id: NotRequired[str]  # For tool response messages
-    call_id: NotRequired[
-        str
-    ]  # Legacy field for tool responses (converted to tool_call_id)
-
-    # Reasoning/thinking fields (for models with thinking/reasoning support)
-    reasoning_content: NotRequired[str]
-
-    # Multimodal fields
-    files: NotRequired[
-        list[str]
-    ]  # Image/file attachments as file paths (processed before API call)
-
-
 # OPENROUTER_APP_HEADERS canonical definition is in gptme.llm.constants;
 # re-exported here for backward compatibility with existing
 # `from gptme.llm.llm_openai import OPENROUTER_APP_HEADERS` imports.
@@ -121,37 +84,12 @@ def _record_usage(usage, model: str) -> MessageMetadata | None:
     if not usage:
         return None
 
-    # Extract token counts (OpenAI uses different field names than Anthropic)
-    prompt_tokens = getattr(usage, "prompt_tokens", None)
-    output_tokens = getattr(usage, "completion_tokens", None)
-    details = getattr(usage, "prompt_tokens_details", None)
-    if prompt_tokens is None:
-        prompt_tokens = getattr(usage, "input_tokens", None)
-        details = getattr(usage, "input_tokens_details", None)
-    if output_tokens is None:
-        output_tokens = getattr(usage, "output_tokens", None)
-    cache_read_tokens = getattr(details, "cached_tokens", None)
-    # OpenRouter currently exposes cache writes in two response shapes:
-    # 1) legacy passthrough: usage.cache_creation_input_tokens
-    # 2) current nested usage: usage.prompt_tokens_details.cache_write_tokens
-    # Keep both so telemetry survives provider/schema drift.
-    cache_creation_tokens = getattr(usage, "cache_creation_input_tokens", None)
-    if cache_creation_tokens is None:
-        cache_creation_tokens = getattr(details, "cache_write_tokens", None)
-    total_tokens = getattr(usage, "total_tokens", None)
-
-    # subtract cache_read_tokens AND cache_creation_tokens from prompt_tokens
-    # to avoid double counting — OpenRouter/Anthropic reports prompt_tokens as
-    # the inclusive total.
-    # Ensure we have actual integers, not Mock objects from tests
-    if isinstance(prompt_tokens, int):
-        cache_read = cache_read_tokens if isinstance(cache_read_tokens, int) else 0
-        cache_create = (
-            cache_creation_tokens if isinstance(cache_creation_tokens, int) else 0
-        )
-        input_tokens = prompt_tokens - cache_read - cache_create
-    else:
-        input_tokens = None
+    counts = _extract_usage_token_counts(usage)
+    input_tokens = counts.input_tokens
+    output_tokens = counts.output_tokens
+    cache_read_tokens = counts.cache_read_tokens
+    cache_creation_tokens = counts.cache_creation_tokens
+    total_tokens = counts.total_tokens
 
     # Determine the provider for telemetry
     # For OpenRouter models, detect the underlying provider from the model string
@@ -252,128 +190,6 @@ def _should_use_responses_api(
     )
 
 
-def _obj_get(obj: Any, key: str, default: Any = None) -> Any:
-    if isinstance(obj, dict):
-        return obj.get(key, default)
-    return getattr(obj, key, default)
-
-
-def _longest_suffix_prefix(text: str, pattern: str) -> str:
-    """Return the longest suffix of ``text`` that could continue ``pattern``."""
-    max_len = min(len(text), len(pattern) - 1)
-    for size in range(max_len, 0, -1):
-        suffix = text[-size:]
-        if pattern.startswith(suffix):
-            return suffix
-    return ""
-
-
-def _filter_duplicate_thinking_text(
-    text: str, *, in_thinking_block: bool
-) -> tuple[str, str, bool]:
-    """Strip raw <thinking>...</thinking> spans after structured reasoning events.
-
-    Some Responses API models emit reasoning twice while streaming:
-    - structured ``response.reasoning_text.delta`` events, and
-    - duplicate raw ``<thinking>...</thinking>`` text inside
-      ``response.output_text.delta``.
-
-    When structured reasoning was already emitted, keep only the non-thinking
-    output text and buffer partial tags across chunk boundaries.
-    """
-
-    open_tag = "<thinking>"
-    close_tag = "</thinking>"
-    output_parts: list[str] = []
-    remaining = text
-
-    while remaining:
-        if in_thinking_block:
-            close_index = remaining.find(close_tag)
-            if close_index == -1:
-                pending = _longest_suffix_prefix(remaining, close_tag)
-                return "".join(output_parts), pending, True
-            remaining = remaining[close_index + len(close_tag) :]
-            in_thinking_block = False
-            continue
-
-        open_index = remaining.find(open_tag)
-        if open_index == -1:
-            pending = _longest_suffix_prefix(remaining, open_tag)
-            if pending:
-                output_parts.append(remaining[: -len(pending)])
-            else:
-                output_parts.append(remaining)
-            return "".join(output_parts), pending, False
-
-        output_parts.append(remaining[:open_index])
-        remaining = remaining[open_index + len(open_tag) :]
-        in_thinking_block = True
-
-    return "".join(output_parts), "", in_thinking_block
-
-
-def _content_to_text(content: MessageContent) -> str:
-    if content is None:
-        return ""
-    if isinstance(content, str):
-        return content
-
-    text_parts: list[str] = []
-    for part in content:
-        if isinstance(part, str):
-            text_parts.append(part)
-        elif isinstance(part, dict) and part.get("type") == "text":
-            text_parts.append(part.get("text", ""))
-    return "".join(text_parts)
-
-
-def _content_to_responses_input(content: MessageContent) -> str | list[dict[str, Any]]:
-    if content is None:
-        return ""
-    if isinstance(content, str):
-        return content
-
-    converted: list[dict[str, Any]] = []
-    for part in content:
-        if isinstance(part, str):
-            converted.append({"type": "input_text", "text": part})
-            continue
-        if not isinstance(part, dict):
-            raise TypeError(f"Unsupported content part type: {type(part)!r}")
-
-        part_type = part.get("type")
-        if part_type == "text":
-            converted.append({"type": "input_text", "text": part.get("text", "")})
-        elif part_type == "image_url":
-            image_url = _obj_get(part.get("image_url", {}), "url")
-            if not image_url:
-                raise ValueError("image_url content part missing url")
-            converted.append(
-                {
-                    "type": "input_image",
-                    "image_url": image_url,
-                    "detail": "auto",
-                }
-            )
-        else:
-            raise ValueError(f"Unsupported responses input part type: {part_type!r}")
-
-    if all(item["type"] == "input_text" for item in converted):
-        return "".join(item["text"] for item in converted)
-    return converted
-
-
-def _chat_tool_to_responses_tool(tool: "ChatCompletionToolParam") -> dict[str, Any]:
-    function = tool["function"]
-    return {
-        "type": tool["type"],
-        "name": function["name"],
-        "description": function["description"],
-        "parameters": function["parameters"],
-    }
-
-
 _VALID_VERBOSITY = {"low", "medium", "high"}
 _verbosity_warned = False  # warn at most once per process lifetime
 
@@ -407,69 +223,6 @@ def _make_responses_text_config(
     return text_config or None
 
 
-def _messages_dicts_to_responses_input(
-    messages_dicts: list[MessageDict],
-) -> tuple[str | None, list[dict[str, Any]]]:
-    instructions_parts: list[str] = []
-    items: list[dict[str, Any]] = []
-
-    for message in messages_dicts:
-        role = message["role"]
-        tool_call_id = _obj_get(message, "tool_call_id") or _obj_get(message, "call_id")
-
-        if role == "system" and tool_call_id:
-            items.append(
-                {
-                    "type": "function_call_output",
-                    "call_id": tool_call_id,
-                    "output": _content_to_text(message["content"]),
-                }
-            )
-            continue
-
-        if role == "tool":
-            items.append(
-                {
-                    "type": "function_call_output",
-                    "call_id": tool_call_id,
-                    "output": _content_to_text(message["content"]),
-                }
-            )
-            continue
-
-        if role == "system":
-            text = _content_to_text(message["content"]).strip()
-            if text:
-                instructions_parts.append(text)
-            continue
-
-        if role == "assistant" and message.get("tool_calls"):
-            text = _content_to_text(message.get("content")).strip()
-            if text:
-                items.append({"role": "assistant", "content": text})
-            for tool_call in message["tool_calls"]:
-                function = tool_call["function"]
-                items.append(
-                    {
-                        "type": "function_call",
-                        "call_id": tool_call["id"],
-                        "name": function["name"],
-                        "arguments": function["arguments"],
-                    }
-                )
-            continue
-
-        items.append(
-            {
-                "role": role,
-                "content": _content_to_responses_input(message["content"]),
-            }
-        )
-
-    instructions = "\n\n".join(instructions_parts).strip() or None
-    return instructions, items
-
-
 def _prepare_messages_for_responses_api(
     messages: list[Message],
     model: str,
@@ -482,8 +235,7 @@ def _prepare_messages_for_responses_api(
         msgs2dicts(messages), model_meta
     )
 
-    tools_dict = [_spec2tool(tool, model_meta) for tool in tools] if tools else None
-    if tools_dict is not None:
+    if tools:
         messages_dicts = _merge_tool_results_with_same_call_id(
             _handle_tools(messages_dicts)
         )
@@ -492,9 +244,7 @@ def _prepare_messages_for_responses_api(
     messages_list = list(typed_messages)
     instructions, input_items = _messages_dicts_to_responses_input(messages_list)
     responses_tools = (
-        [_chat_tool_to_responses_tool(tool) for tool in tools_dict]
-        if tools_dict is not None
-        else None
+        [_tool_spec_to_responses_tool(tool) for tool in tools] if tools else None
     )
     return instructions, input_items, responses_tools
 

--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -29,7 +29,7 @@ from .openai_responses import (
     MessageDict,
     ToolCall,
     ToolCallFunction,
-    _content_to_responses_input,
+    _content_to_responses_input,  # noqa: F401
     _extract_usage_token_counts,
     _filter_duplicate_thinking_text,
     _longest_suffix_prefix,
@@ -57,8 +57,6 @@ logger = logging.getLogger(__name__)
 __all__ = [
     "ContentPart",
     "MessageContent",
-    "_content_to_responses_input",
-    "_messages_dicts_to_responses_input",
 ]
 
 

--- a/gptme/llm/llm_openai_subscription.py
+++ b/gptme/llm/llm_openai_subscription.py
@@ -50,8 +50,12 @@ from uuid import uuid4
 import requests
 
 from ..message import Message
-from ..tools.base import ToolSpec
-from .utils import extract_tool_uses_from_assistant_message, parameters2dict
+from .openai_responses import (
+    _filter_duplicate_thinking_text,
+    _longest_suffix_prefix,
+    _messages_to_responses_input,
+    _tool_spec_to_responses_tool,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -443,89 +447,16 @@ def get_auth() -> SubscriptionAuth:
     )
 
 
-def _messages_to_responses_input(messages: list[Message]) -> list[dict[str, Any]]:
-    """Convert gptme Messages to Responses API input items.
-
-    Handles three cases:
-    - System messages with call_id → ``function_call_output`` items
-    - Assistant messages containing tool calls → ``function_call`` items + text message
-    - Regular messages → ``message`` items with role/content
-    """
-    items: list[dict[str, Any]] = []
-    for msg in messages:
-        # Tool result: system message with call_id
-        if msg.role == "system" and msg.call_id:
-            items.append(
-                {
-                    "type": "function_call_output",
-                    "call_id": msg.call_id,
-                    "output": msg.content,
-                }
-            )
-            continue
-
-        # Assistant message: may contain tool calls (e.g. @ipython(call_123): {...})
-        if msg.role == "assistant":
-            content_parts, tool_uses = extract_tool_uses_from_assistant_message(
-                msg.content, tool_format_override="tool"
-            )
-            # Emit function_call items for each tool use found
-            items.extend(
-                {
-                    "type": "function_call",
-                    "name": tooluse.tool,
-                    "call_id": tooluse.call_id or "",
-                    "arguments": json.dumps(tooluse.kwargs or {}),
-                }
-                for tooluse in tool_uses
-            )
-            # Emit remaining text content as a message (if any)
-            text = "".join(
-                p["text"] if isinstance(p, dict) else str(p) for p in content_parts
-            ).strip()
-            if text:
-                items.append({"role": "assistant", "content": text})
-            elif not tool_uses:
-                # No tool uses and no text — still include the message
-                items.append({"role": "assistant", "content": msg.content})
-            continue
-
-        # Regular message (user, system without call_id)
-        items.append({"role": msg.role, "content": msg.content})
-
-    return items
-
-
-def _spec2tool(spec: ToolSpec) -> dict[str, Any]:
-    """Convert a ToolSpec to Responses API function tool format.
-
-    The Responses API uses a flat structure (name/description/parameters at top level),
-    unlike Chat Completions which nests them under a ``function`` key.
-    """
-    name = spec.block_types[0] if spec.block_types else spec.name
-    description = spec.get_instructions("tool")
-    if len(description) > 1024:
-        description = description[:1024]
-    return {
-        "type": "function",
-        "name": name,
-        "description": description,
-        "parameters": parameters2dict(spec.parameters),
-    }
-
-
 def _transform_to_codex_request(
     input_items: list[dict[str, Any]],
     model: str,
+    *,
+    instructions: str | None = None,
     stream: bool = True,
     reasoning_level: str | None = None,
     max_output_tokens: int | None = None,
 ) -> dict[str, Any]:
-    """Build a Responses API request body from pre-converted input items.
-
-    Extracts system messages as ``instructions``, passes everything else
-    (messages, function_call, function_call_output) as ``input``.
-    """
+    """Build a Responses API request body from shared Responses helpers."""
     base_model = model.split(":")[0] if ":" in model else model
     if ":" in model:
         reasoning_level = model.split(":")[1]
@@ -533,23 +464,10 @@ def _transform_to_codex_request(
     if reasoning_level is None:
         reasoning_level = "medium"
 
-    # System messages (role-based, no "type") become instructions
-    system_parts = []
-    api_input = []
-    for item in input_items:
-        if item.get("role") == "system":
-            system_parts.append(item["content"])
-        else:
-            api_input.append(item)
-
-    instructions = (
-        "\n\n".join(system_parts) if system_parts else "You are a helpful assistant."
-    )
-
     body: dict[str, Any] = {
         "model": base_model,
-        "instructions": instructions,
-        "input": api_input,
+        "instructions": instructions or "You are a helpful assistant.",
+        "input": input_items,
         "stream": stream,
         "store": False,
         "reasoning": {
@@ -589,17 +507,18 @@ def stream(
     """Stream completion from ChatGPT subscription API."""
     auth = get_auth()
 
-    api_messages = _messages_to_responses_input(messages)
+    instructions, api_messages = _messages_to_responses_input(messages)
 
     request_body = _transform_to_codex_request(
         input_items=api_messages,
         model=model,
+        instructions=instructions,
         stream=True,
         max_output_tokens=max_tokens,
     )
 
     if tools:
-        request_body["tools"] = [_spec2tool(t) for t in tools]
+        request_body["tools"] = [_tool_spec_to_responses_tool(t) for t in tools]
 
     headers = {
         "Authorization": f"Bearer {auth.access_token}",
@@ -630,6 +549,7 @@ def stream(
     seen_reasoning_delta = False
     # Buffer to detect tags split across SSE chunks (max tag length is ~11 chars)
     pending = ""
+    in_duplicate_thinking_block = False
 
     for line in response.iter_lines():
         if not line:
@@ -677,22 +597,18 @@ def stream(
                 text = pending + delta_text
                 pending = ""
 
-                if not seen_reasoning_delta:
-                    # Hold back potential partial tag suffix to check in next chunk.
-                    # A trailing `<` is buffered because it could be the start of either
-                    # `<thinking>` or `</thinking>`; it will be re-evaluated on the next chunk.
-                    match_found = False
+                if seen_reasoning_delta:
+                    text, pending, in_duplicate_thinking_block = (
+                        _filter_duplicate_thinking_text(
+                            text, in_thinking_block=in_duplicate_thinking_block
+                        )
+                    )
+                else:
                     for tag in ("<thinking>", "</thinking>"):
-                        for i in range(len(tag) - 1, 0, -1):
-                            if text.endswith(tag[:i]):
-                                pending = text[-i:]
-                                text = text[:-i]
-                                match_found = True
-                                break
-                        if match_found:
+                        pending = _longest_suffix_prefix(text, tag)
+                        if pending:
+                            text = text[: -len(pending)]
                             break
-
-                    # Convert <thinking>/<\/thinking> to <think>/<\/think>
                     text = text.replace("<thinking>", "<think>").replace(
                         "</thinking>", "</think>"
                     )
@@ -704,11 +620,11 @@ def stream(
             if in_reasoning_block:
                 yield "\n</think>\n"
                 in_reasoning_block = False
-            if pending:
+            if pending and not in_duplicate_thinking_block:
                 yield pending.replace("<thinking>", "<think>").replace(
                     "</thinking>", "</think>"
                 )
-                pending = ""
+            pending = ""
             item = data.get("item", {})
             if item.get("type") == "function_call":
                 name = item.get("name", "")
@@ -730,7 +646,7 @@ def stream(
     # Close the reasoning block first so any pending text lands outside it.
     if in_reasoning_block:
         yield "\n</think>\n"
-    if pending:
+    if pending and not in_duplicate_thinking_block:
         yield pending.replace("<thinking>", "<think>").replace(
             "</thinking>", "</think>"
         )

--- a/gptme/llm/openai_responses.py
+++ b/gptme/llm/openai_responses.py
@@ -1,0 +1,334 @@
+"""Shared helpers for OpenAI Responses API providers."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, TypedDict
+
+from typing_extensions import NotRequired
+
+from .utils import extract_tool_uses_from_assistant_message, parameters2dict
+
+if TYPE_CHECKING:
+    from ..message import Message
+    from ..tools import ToolSpec
+
+
+class ContentPart(TypedDict):
+    """A content part in a multimodal message."""
+
+    type: str
+    text: NotRequired[str]
+    image_url: NotRequired[dict[str, str]]
+
+
+MessageContent = str | list[ContentPart | str] | None
+
+
+class ToolCallFunction(TypedDict):
+    """Function details in a tool call."""
+
+    name: str
+    arguments: str
+
+
+class ToolCall(TypedDict):
+    """A tool call in an assistant message."""
+
+    id: str
+    type: str
+    function: ToolCallFunction
+
+
+class MessageDict(TypedDict):
+    """Dictionary representation of a chat message for API calls."""
+
+    role: str
+    content: MessageContent
+    tool_calls: NotRequired[list[ToolCall]]
+    tool_call_id: NotRequired[str]
+    call_id: NotRequired[str]
+    reasoning_content: NotRequired[str]
+    files: NotRequired[list[str]]
+
+
+@dataclass(frozen=True)
+class UsageTokenCounts:
+    input_tokens: int | None
+    output_tokens: int | None
+    cache_read_tokens: int | None
+    cache_creation_tokens: int | None
+    total_tokens: int | None
+
+
+def _obj_get(obj: Any, key: str, default: Any = None) -> Any:
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    return getattr(obj, key, default)
+
+
+def _longest_suffix_prefix(text: str, pattern: str) -> str:
+    """Return the longest suffix of ``text`` that could continue ``pattern``."""
+    max_len = min(len(text), len(pattern) - 1)
+    for size in range(max_len, 0, -1):
+        suffix = text[-size:]
+        if pattern.startswith(suffix):
+            return suffix
+    return ""
+
+
+def _filter_duplicate_thinking_text(
+    text: str, *, in_thinking_block: bool
+) -> tuple[str, str, bool]:
+    """Strip raw <thinking>...</thinking> spans after structured reasoning events."""
+
+    open_tag = "<thinking>"
+    close_tag = "</thinking>"
+    output_parts: list[str] = []
+    remaining = text
+
+    while remaining:
+        if in_thinking_block:
+            close_index = remaining.find(close_tag)
+            if close_index == -1:
+                pending = _longest_suffix_prefix(remaining, close_tag)
+                return "".join(output_parts), pending, True
+            remaining = remaining[close_index + len(close_tag) :]
+            in_thinking_block = False
+            continue
+
+        open_index = remaining.find(open_tag)
+        if open_index == -1:
+            pending = _longest_suffix_prefix(remaining, open_tag)
+            if pending:
+                output_parts.append(remaining[: -len(pending)])
+            else:
+                output_parts.append(remaining)
+            return "".join(output_parts), pending, False
+
+        output_parts.append(remaining[:open_index])
+        remaining = remaining[open_index + len(open_tag) :]
+        in_thinking_block = True
+
+    return "".join(output_parts), "", in_thinking_block
+
+
+def _content_to_text(content: MessageContent) -> str:
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+
+    text_parts: list[str] = []
+    for part in content:
+        if isinstance(part, str):
+            text_parts.append(part)
+        elif isinstance(part, dict) and part.get("type") == "text":
+            text_parts.append(part.get("text", ""))
+    return "".join(text_parts)
+
+
+def _content_to_responses_input(content: MessageContent) -> str | list[dict[str, Any]]:
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+
+    converted: list[dict[str, Any]] = []
+    for part in content:
+        if isinstance(part, str):
+            converted.append({"type": "input_text", "text": part})
+            continue
+        if not isinstance(part, dict):
+            raise TypeError(f"Unsupported content part type: {type(part)!r}")
+
+        part_type = part.get("type")
+        if part_type == "text":
+            converted.append({"type": "input_text", "text": part.get("text", "")})
+        elif part_type == "image_url":
+            image_url = _obj_get(part.get("image_url", {}), "url")
+            if not image_url:
+                raise ValueError("image_url content part missing url")
+            converted.append(
+                {
+                    "type": "input_image",
+                    "image_url": image_url,
+                    "detail": "auto",
+                }
+            )
+        else:
+            raise ValueError(f"Unsupported responses input part type: {part_type!r}")
+
+    if all(item["type"] == "input_text" for item in converted):
+        return "".join(item["text"] for item in converted)
+    return converted
+
+
+def _tool_spec_to_responses_tool(spec: ToolSpec) -> dict[str, Any]:
+    """Convert a ToolSpec to the flat Responses API function tool format."""
+    name = spec.block_types[0] if spec.block_types else spec.name
+    description = spec.get_instructions("tool") or spec.desc or ""
+    if len(description) > 1024:
+        description = description[:1024]
+    return {
+        "type": "function",
+        "name": name,
+        "description": description,
+        "parameters": parameters2dict(spec.parameters),
+    }
+
+
+def _messages_dicts_to_responses_input(
+    messages_dicts: list[MessageDict],
+) -> tuple[str | None, list[dict[str, Any]]]:
+    instructions_parts: list[str] = []
+    items: list[dict[str, Any]] = []
+
+    for message in messages_dicts:
+        role = message["role"]
+        tool_call_id = _obj_get(message, "tool_call_id") or _obj_get(message, "call_id")
+
+        if role == "system" and tool_call_id:
+            items.append(
+                {
+                    "type": "function_call_output",
+                    "call_id": tool_call_id,
+                    "output": _content_to_text(message["content"]),
+                }
+            )
+            continue
+
+        if role == "tool":
+            items.append(
+                {
+                    "type": "function_call_output",
+                    "call_id": tool_call_id,
+                    "output": _content_to_text(message["content"]),
+                }
+            )
+            continue
+
+        if role == "system":
+            text = _content_to_text(message["content"]).strip()
+            if text:
+                instructions_parts.append(text)
+            continue
+
+        if role == "assistant" and message.get("tool_calls"):
+            text = _content_to_text(message.get("content")).strip()
+            if text:
+                items.append({"role": "assistant", "content": text})
+            for tool_call in message["tool_calls"]:
+                function = tool_call["function"]
+                items.append(
+                    {
+                        "type": "function_call",
+                        "call_id": tool_call["id"],
+                        "name": function["name"],
+                        "arguments": function["arguments"],
+                    }
+                )
+            continue
+
+        items.append(
+            {
+                "role": role,
+                "content": _content_to_responses_input(message["content"]),
+            }
+        )
+
+    instructions = "\n\n".join(instructions_parts).strip() or None
+    return instructions, items
+
+
+def _messages_to_responses_input(
+    messages: list[Message],
+) -> tuple[str | None, list[dict[str, Any]]]:
+    """Convert gptme messages to Responses API instructions and input items."""
+    instructions_parts: list[str] = []
+    items: list[dict[str, Any]] = []
+
+    for msg in messages:
+        if msg.role == "system" and msg.call_id:
+            items.append(
+                {
+                    "type": "function_call_output",
+                    "call_id": msg.call_id,
+                    "output": msg.content,
+                }
+            )
+            continue
+
+        if msg.role == "system":
+            text = _content_to_text(msg.content).strip()
+            if text:
+                instructions_parts.append(text)
+            continue
+
+        if msg.role == "assistant":
+            content_parts, tool_uses = extract_tool_uses_from_assistant_message(
+                msg.content, tool_format_override="tool"
+            )
+            text = "".join(
+                part["text"] if isinstance(part, dict) else str(part)
+                for part in content_parts
+            ).strip()
+            if text:
+                items.append({"role": "assistant", "content": text})
+            elif not tool_uses:
+                items.append({"role": "assistant", "content": msg.content})
+            items.extend(
+                {
+                    "type": "function_call",
+                    "name": tooluse.tool,
+                    "call_id": tooluse.call_id or "",
+                    "arguments": json.dumps(tooluse.kwargs or {}),
+                }
+                for tooluse in tool_uses
+            )
+            continue
+
+        items.append(
+            {
+                "role": msg.role,
+                "content": _content_to_responses_input(msg.content),
+            }
+        )
+
+    instructions = "\n\n".join(instructions_parts).strip() or None
+    return instructions, items
+
+
+def _extract_usage_token_counts(usage: Any) -> UsageTokenCounts:
+    """Normalize Chat Completions and Responses API usage token fields."""
+    prompt_tokens = getattr(usage, "prompt_tokens", None)
+    output_tokens = getattr(usage, "completion_tokens", None)
+    details = getattr(usage, "prompt_tokens_details", None)
+    if prompt_tokens is None:
+        prompt_tokens = getattr(usage, "input_tokens", None)
+        details = getattr(usage, "input_tokens_details", None)
+    if output_tokens is None:
+        output_tokens = getattr(usage, "output_tokens", None)
+    cache_read_tokens = getattr(details, "cached_tokens", None)
+    cache_creation_tokens = getattr(usage, "cache_creation_input_tokens", None)
+    if cache_creation_tokens is None:
+        cache_creation_tokens = getattr(details, "cache_write_tokens", None)
+    total_tokens = getattr(usage, "total_tokens", None)
+
+    if isinstance(prompt_tokens, int):
+        cache_read = cache_read_tokens if isinstance(cache_read_tokens, int) else 0
+        cache_create = (
+            cache_creation_tokens if isinstance(cache_creation_tokens, int) else 0
+        )
+        input_tokens = prompt_tokens - cache_read - cache_create
+    else:
+        input_tokens = None
+
+    return UsageTokenCounts(
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        cache_read_tokens=cache_read_tokens,
+        cache_creation_tokens=cache_creation_tokens,
+        total_tokens=total_tokens,
+    )

--- a/gptme/llm/openai_responses.py
+++ b/gptme/llm/openai_responses.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, TypedDict
 
@@ -13,6 +14,8 @@ from .utils import extract_tool_uses_from_assistant_message, parameters2dict
 if TYPE_CHECKING:
     from ..message import Message
     from ..tools import ToolSpec
+
+logger = logging.getLogger(__name__)
 
 
 class ContentPart(TypedDict):
@@ -170,6 +173,11 @@ def _tool_spec_to_responses_tool(spec: ToolSpec) -> dict[str, Any]:
     name = spec.block_types[0] if spec.block_types else spec.name
     description = spec.get_instructions("tool") or spec.desc or ""
     if len(description) > 1024:
+        logger.warning(
+            "Description for tool `%s` is too long ( %d > 1024 chars). Truncating...",
+            spec.name,
+            len(description),
+        )
         description = description[:1024]
     return {
         "type": "function",

--- a/tests/test_llm_openai.py
+++ b/tests/test_llm_openai.py
@@ -15,8 +15,6 @@ from gptme.llm.llm_openai import (
     _messages_dicts_to_responses_input,
     _prepare_messages_for_api,
     _should_use_responses_api,
-    _stream_responses,
-    stream,
 )
 from gptme.llm.models import get_default_model, get_model, set_default_model
 from gptme.message import Message
@@ -867,7 +865,7 @@ def test_stream_forwards_output_schema_to_responses_path(monkeypatch):
     monkeypatch.setattr(llm_openai, "_stream_responses", fake_stream_responses)
 
     text, metadata = _collect_stream_result(
-        stream(
+        llm_openai.stream(
             [Message(role="user", content="Return structured output.")],
             "openai/gpt-5",
             None,
@@ -900,7 +898,7 @@ def test_stream_responses_includes_output_schema_in_text_config(monkeypatch):
     monkeypatch.setattr(llm_openai, "_is_proxy", lambda client: False)
 
     text, metadata = _collect_stream_result(
-        _stream_responses(
+        llm_openai._stream_responses(
             [Message(role="user", content="Return structured output.")],
             "openai/gpt-5",
             None,
@@ -964,7 +962,7 @@ def test_stream_responses_emits_function_calls_and_usage(monkeypatch):
     monkeypatch.setattr(llm_openai, "_is_proxy", lambda client: False)
 
     text, metadata = _collect_stream_result(
-        _stream_responses(
+        llm_openai._stream_responses(
             [Message(role="user", content="Save a note.")],
             "openai/gpt-5",
             None,
@@ -1002,7 +1000,7 @@ def test_stream_responses_removes_duplicate_thinking_text_when_reasoning_deltas_
     monkeypatch.setattr(llm_openai, "_is_proxy", lambda client: False)
 
     text, metadata = _collect_stream_result(
-        _stream_responses(
+        llm_openai._stream_responses(
             [Message(role="user", content="Say hello.")],
             "openai/gpt-5",
             None,
@@ -1036,7 +1034,7 @@ def test_stream_responses_converts_split_thinking_tags_without_reasoning_deltas(
     monkeypatch.setattr(llm_openai, "_is_proxy", lambda client: False)
 
     text, metadata = _collect_stream_result(
-        _stream_responses(
+        llm_openai._stream_responses(
             [Message(role="user", content="Think, then answer.")],
             "openai/gpt-5",
             None,

--- a/tests/test_llm_openai.py
+++ b/tests/test_llm_openai.py
@@ -1,3 +1,4 @@
+import logging
 from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import Mock
@@ -17,8 +18,9 @@ from gptme.llm.llm_openai import (
     _should_use_responses_api,
 )
 from gptme.llm.models import get_default_model, get_model, set_default_model
+from gptme.llm.openai_responses import _tool_spec_to_responses_tool
 from gptme.message import Message
-from gptme.tools import get_tool, init_tools
+from gptme.tools import ToolSpec, get_tool, init_tools
 
 
 @pytest.fixture(autouse=True)
@@ -797,6 +799,21 @@ def test_messages_dicts_to_responses_input_collects_instructions_and_tool_events
         },
         {"role": "user", "content": "What next?"},
     ]
+
+
+def test_tool_spec_to_responses_tool_warns_on_truncated_description(caplog):
+    spec = ToolSpec(name="save", desc="x" * 1100)
+
+    with caplog.at_level(logging.WARNING, logger="gptme.llm.openai_responses"):
+        tool = _tool_spec_to_responses_tool(spec)
+
+    assert tool["description"] == "x" * 1024
+    assert "Description for tool `save` is too long" in caplog.text
+
+
+def test_llm_openai_all_excludes_private_responses_helpers():
+    assert "_content_to_responses_input" not in llm_openai.__all__
+    assert "_messages_dicts_to_responses_input" not in llm_openai.__all__
 
 
 def test_should_use_responses_api_requires_direct_openai(monkeypatch):

--- a/tests/test_llm_openai_subscription.py
+++ b/tests/test_llm_openai_subscription.py
@@ -3,8 +3,10 @@ from collections.abc import Iterator
 from typing import Any
 from unittest.mock import patch
 
-from gptme.llm.llm_openai_subscription import SubscriptionAuth, stream
+from gptme.llm import llm_openai_subscription
+from gptme.llm.llm_openai_subscription import SubscriptionAuth
 from gptme.message import Message
+from gptme.tools import get_tool, init_tools
 
 
 def _make_auth() -> SubscriptionAuth:
@@ -35,7 +37,11 @@ def _run_stream(events: list[dict[str, Any]]) -> str:
         patch("gptme.llm.llm_openai_subscription.get_auth", return_value=auth),
         patch("gptme.llm.llm_openai_subscription.requests.post", return_value=response),
     ):
-        return "".join(stream([Message(role="user", content="hello")], "gpt-5.4"))
+        return "".join(
+            llm_openai_subscription.stream(
+                [Message(role="user", content="hello")], "gpt-5.4"
+            )
+        )
 
 
 def test_stream_wraps_reasoning_and_closes_before_text():
@@ -119,11 +125,52 @@ def test_stream_no_double_wrap_when_both_mechanisms_fire():
         ]
     )
 
-    # Should produce exactly one <think> block, not nested <think><think>
-    assert "<think><think>" not in output
-    assert output.count("<think>") == 1
-    assert output.count("</think>") == 1
-    assert "Done." in output
+    assert output == "<think>\nNeed a command\n</think>\nDone."
+
+
+def test_stream_builds_shared_responses_request_shape():
+    response = _FakeSSEStreamResponse([{"type": "response.done"}])
+    init_tools(allowlist=["save"])
+    save_tool = get_tool("save")
+    assert save_tool is not None
+
+    messages = [
+        Message(role="system", content="You are concise."),
+        Message(role="user", content="Save a note."),
+        Message(
+            role="assistant",
+            content='Saving now.\n@save(call_123): {"path": "note.txt", "content": "hi"}',
+        ),
+        Message(role="system", content="Saved to note.txt", call_id="call_123"),
+    ]
+
+    with (
+        patch("gptme.llm.llm_openai_subscription.get_auth", return_value=_make_auth()),
+        patch(
+            "gptme.llm.llm_openai_subscription.requests.post", return_value=response
+        ) as mock_post,
+    ):
+        list(llm_openai_subscription.stream(messages, "gpt-5.4", tools=[save_tool]))
+
+    request_json = mock_post.call_args.kwargs["json"]
+    assert request_json["instructions"] == "You are concise."
+    assert request_json["input"] == [
+        {"role": "user", "content": "Save a note."},
+        {"role": "assistant", "content": "Saving now."},
+        {
+            "type": "function_call",
+            "call_id": "call_123",
+            "name": "save",
+            "arguments": '{"path": "note.txt", "content": "hi"}',
+        },
+        {
+            "type": "function_call_output",
+            "call_id": "call_123",
+            "output": "Saved to note.txt",
+        },
+    ]
+    assert request_json["tools"][0]["type"] == "function"
+    assert request_json["tools"][0]["name"] == "save"
 
 
 def test_stream_forwards_max_tokens_as_max_output_tokens():
@@ -137,7 +184,11 @@ def test_stream_forwards_max_tokens_as_max_output_tokens():
         ) as mock_post,
     ):
         list(
-            stream([Message(role="user", content="hello")], "gpt-5.4", max_tokens=1000)
+            llm_openai_subscription.stream(
+                [Message(role="user", content="hello")],
+                "gpt-5.4",
+                max_tokens=1000,
+            )
         )
 
     request_json = mock_post.call_args.kwargs["json"]
@@ -154,7 +205,11 @@ def test_stream_omits_max_output_tokens_when_not_provided():
             "gptme.llm.llm_openai_subscription.requests.post", return_value=response
         ) as mock_post,
     ):
-        list(stream([Message(role="user", content="hello")], "gpt-5.4"))
+        list(
+            llm_openai_subscription.stream(
+                [Message(role="user", content="hello")], "gpt-5.4"
+            )
+        )
 
     request_json = mock_post.call_args.kwargs["json"]
     assert "max_output_tokens" not in request_json


### PR DESCRIPTION
## Summary
- extract shared OpenAI Responses API conversion helpers into `gptme/llm/openai_responses.py`
- wire both the direct OpenAI provider and `openai-subscription` provider through the shared message/tool conversion path
- normalize Responses usage token extraction through the same helper used by `_record_usage`
- make subscription streaming drop duplicate raw `<thinking>` text once structured reasoning deltas have already arrived

## Testing
- `PATH=/home/bob/gptme/.venv/bin:$PATH python -m ruff check gptme/llm/openai_responses.py gptme/llm/llm_openai.py gptme/llm/llm_openai_subscription.py tests/test_llm_openai.py tests/test_llm_openai_subscription.py`
- `PATH=/home/bob/gptme/.venv/bin:$PATH python -m ruff format --check gptme/llm/openai_responses.py gptme/llm/llm_openai.py gptme/llm/llm_openai_subscription.py tests/test_llm_openai_subscription.py`
- `PATH=/home/bob/gptme/.venv/bin:$PATH python -m pytest tests/test_llm_openai.py tests/test_llm_openai_subscription.py -q`

Refs gptme/gptme#2396
