### PR TITLE
feat(tools): add trigger language for shell, read, and gh

### DIFF
--- a/gptme/tools/gh.py
+++ b/gptme/tools/gh.py
@@ -652,7 +652,8 @@ def execute_gh(
 
 
 instructions = """Use this tool when GitHub work needs fewer round-trips, structured CI data,
-or safer merges than a raw `gh` shell command.
+or safer merges than a raw `gh` shell command. Prefer `gh` over shell whenever
+the target is a GitHub issue, PR, run, or merge action.
 
 Refs: full URLs, `owner/repo#N`, `#N`, or bare `N` in a git repo.
 

--- a/gptme/tools/read.py
+++ b/gptme/tools/read.py
@@ -25,6 +25,13 @@ Paths can be relative or absolute.
 For files, output includes line numbers for easy reference.
 For directories, output shows a flat listing of immediate files and subdirectories.
 
+### When to use read
+
+Use `read` when you already know the file or directory you want and need its
+exact current contents, optionally with line numbers. Prefer `read` over
+guessing from file names, comments, or memory when the file itself is the
+source of truth.
+
 To read multiple files in a single call, put one path per line in the code block.
 Lines beginning with '#' are treated as comments and skipped.
 The line-range parameters (start_line, end_line) only apply when reading a single file.

--- a/gptme/tools/read.py
+++ b/gptme/tools/read.py
@@ -27,10 +27,9 @@ For directories, output shows a flat listing of immediate files and subdirectori
 
 ### When to use read
 
-Use `read` when you already know the file or directory you want and need its
-exact current contents, optionally with line numbers. Prefer `read` over
-guessing from file names, comments, or memory when the file itself is the
-source of truth.
+Reading a file directly gives you its exact, current content with line numbers —
+eliminating guesswork from memory, file names, or comments. Prefer `read` over
+those shortcuts when the file itself is the source of truth.
 
 To read multiple files in a single call, put one path per line in the code block.
 Lines beginning with '#' are treated as comments and skipped.

--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -128,6 +128,12 @@ The shell tool will respond with the output of the execution.
 These programs are available, among others:
 {shell_programs_str}
 
+### When to use the shell
+
+Use the shell when you need to inspect the workspace, read or search files,
+check git state, or run existing commands and tests. Prefer the shell over
+answering from memory when the repo can tell you the answer directly.
+
 ### Background Jobs
 
 For long-running commands (dev servers, builds, etc.), use background jobs:

--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -130,7 +130,7 @@ These programs are available, among others:
 
 ### When to use the shell
 
-Use the shell when you need to inspect the workspace, read or search files,
+Use the shell when you need to inspect the workspace, search or examine files,
 check git state, or run existing commands and tests. Prefer the shell over
 answering from memory when the repo can tell you the answer directly.
 


### PR DESCRIPTION
## Summary
Add short "when to use this" trigger language to the `shell`, `read`, and `gh` tool instructions.

The goal is to reduce the knowing-doing gap in tool use by making the action boundary more salient without materially increasing prompt bloat.

## Changes
- add a concise `shell` trigger for workspace inspection, file search, git state, and running commands/tests
- add a concise `read` trigger for exact file contents as the source of truth
- strengthen the `gh` opening so GitHub work routes to `gh` before shell

## Validation
- `python -m pytest tests/test_tools.py -k tool_descriptions_within_openai_limit -q`
- verified resulting instruction sizes remain under the 1024-char tool-format cap:
  - `shell`: 870
  - `read`: 751
  - `gh`: 852
