### PR TITLE
fix(webui): preserve structured API errors

### DIFF
--- a/webui/src/components/ui/badge.tsx
+++ b/webui/src/components/ui/badge.tsx
@@ -23,8 +23,7 @@ const badgeVariants = cva(
 );
 
 export interface BadgeProps
-  extends React.HTMLAttributes<HTMLDivElement>,
-    VariantProps<typeof badgeVariants> {}
+  extends React.HTMLAttributes<HTMLDivElement>, VariantProps<typeof badgeVariants> {}
 
 function Badge({ className, variant, ...props }: BadgeProps) {
   return <div className={cn(badgeVariants({ variant }), className)} {...props} />;

--- a/webui/src/components/ui/button.tsx
+++ b/webui/src/components/ui/button.tsx
@@ -32,8 +32,7 @@ const buttonVariants = cva(
 );
 
 export interface ButtonProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
-    VariantProps<typeof buttonVariants> {
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>, VariantProps<typeof buttonVariants> {
   asChild?: boolean;
 }
 

--- a/webui/src/components/ui/sheet.tsx
+++ b/webui/src/components/ui/sheet.tsx
@@ -48,7 +48,8 @@ const sheetVariants = cva(
 );
 
 interface SheetContentProps
-  extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
+  extends
+    React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
     VariantProps<typeof sheetVariants> {}
 
 const SheetContent = React.forwardRef<

--- a/webui/src/types/api.ts
+++ b/webui/src/types/api.ts
@@ -20,9 +20,17 @@ export interface ExternalSessionDetail {
   transcript: Record<string, unknown>;
 }
 
+export interface ApiErrorDetails {
+  message?: string;
+  type?: string;
+  code?: string;
+  status?: number;
+  [key: string]: unknown;
+}
+
 // Error response from any endpoint
 export interface ApiError {
-  error: string;
+  error: string | ApiErrorDetails;
   status?: number;
 }
 

--- a/webui/src/utils/__tests__/api.test.ts
+++ b/webui/src/utils/__tests__/api.test.ts
@@ -10,8 +10,7 @@ jest.mock('@/stores/servers', () => ({
   getPrimaryClient: jest.fn(),
 }));
 
-import { ApiClient, isLikelyChromeCorsPna } from '../api';
-import type { ApiClientError } from '../api';
+import { ApiClient, ApiClientError, isLikelyChromeCorsPna } from '../api';
 
 describe('isLikelyChromeCorsPna', () => {
   const setHostname = (hostname: string) => {
@@ -98,6 +97,30 @@ describe('ApiClient error parsing', () => {
       code: 'insufficient_credits',
       type: 'payment_required',
     } satisfies Partial<ApiClientError>);
+  });
+
+  it('handles null error responses without crashing', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => ({
+        error: null,
+      }),
+    } as Response);
+
+    const client = new ApiClient('http://127.0.0.1:5700');
+    client.setConnected(true);
+
+    // Should not throw TypeError; should surface a graceful error message
+    let caught: ApiClientError | undefined;
+    try {
+      await client.getServerInfo();
+    } catch (e) {
+      caught = e as ApiClientError;
+    }
+    expect(caught).toBeInstanceOf(ApiClientError);
+    expect(caught!.message).toBe('HTTP error! status: 500');
+    expect(caught!.status).toBe(500);
   });
 
   it('preserves nested API errors even when the server replies with HTTP 200', async () => {

--- a/webui/src/utils/__tests__/api.test.ts
+++ b/webui/src/utils/__tests__/api.test.ts
@@ -123,6 +123,24 @@ describe('ApiClient error parsing', () => {
     expect(caught!.status).toBe(500);
   });
 
+  it('preserves HTTP status for plain-string error responses', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      json: async () => ({
+        error: 'Not found',
+      }),
+    } as Response);
+
+    const client = new ApiClient('http://127.0.0.1:5700');
+    client.setConnected(true);
+
+    await expect(client.getServerInfo()).rejects.toMatchObject({
+      message: 'Not found',
+      status: 404,
+    } satisfies Partial<ApiClientError>);
+  });
+
   it('preserves nested API errors even when the server replies with HTTP 200', async () => {
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,

--- a/webui/src/utils/__tests__/api.test.ts
+++ b/webui/src/utils/__tests__/api.test.ts
@@ -10,7 +10,8 @@ jest.mock('@/stores/servers', () => ({
   getPrimaryClient: jest.fn(),
 }));
 
-import { isLikelyChromeCorsPna } from '../api';
+import { ApiClient, isLikelyChromeCorsPna } from '../api';
+import type { ApiClientError } from '../api';
 
 describe('isLikelyChromeCorsPna', () => {
   const setHostname = (hostname: string) => {
@@ -49,5 +50,78 @@ describe('isLikelyChromeCorsPna', () => {
   it('returns false for invalid URL', () => {
     setHostname('chat.gptme.org');
     expect(isLikelyChromeCorsPna('not-a-url')).toBe(false);
+  });
+});
+
+describe('ApiClient error parsing', () => {
+  const originalFetch = global.fetch;
+  const originalCrypto = global.crypto;
+
+  beforeEach(() => {
+    Object.defineProperty(global, 'crypto', {
+      value: {
+        ...originalCrypto,
+        randomUUID: jest.fn(() => 'test-client-id'),
+      },
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    Object.defineProperty(global, 'crypto', {
+      value: originalCrypto,
+      configurable: true,
+    });
+    jest.restoreAllMocks();
+  });
+
+  it('preserves nested API error messages and metadata on non-OK responses', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 402,
+      json: async () => ({
+        error: {
+          message: 'Insufficient credits. Visit gptme.ai to add more.',
+          type: 'payment_required',
+          code: 'insufficient_credits',
+        },
+      }),
+    } as Response);
+
+    const client = new ApiClient('http://127.0.0.1:5700');
+    client.setConnected(true);
+
+    await expect(client.getServerInfo()).rejects.toMatchObject({
+      message: 'Insufficient credits. Visit gptme.ai to add more.',
+      status: 402,
+      code: 'insufficient_credits',
+      type: 'payment_required',
+    } satisfies Partial<ApiClientError>);
+  });
+
+  it('preserves nested API errors even when the server replies with HTTP 200', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        error: {
+          message: 'No active subscription. Visit gptme.ai to subscribe.',
+          type: 'payment_required',
+          code: 'no_subscription',
+        },
+        status: 402,
+      }),
+    } as Response);
+
+    const client = new ApiClient('http://127.0.0.1:5700');
+    client.setConnected(true);
+
+    await expect(client.getServerInfo()).rejects.toMatchObject({
+      message: 'No active subscription. Visit gptme.ai to subscribe.',
+      status: 402,
+      code: 'no_subscription',
+      type: 'payment_required',
+    } satisfies Partial<ApiClientError>);
   });
 });

--- a/webui/src/utils/api.ts
+++ b/webui/src/utils/api.ts
@@ -55,7 +55,10 @@ function isApiErrorResponse(response: unknown): response is ApiError {
   return typeof response === 'object' && response !== null && 'error' in response;
 }
 
-function normalizeApiError(response: ApiError): {
+function normalizeApiError(
+  response: ApiError,
+  httpStatus?: number
+): {
   message: string;
   status?: number;
   code?: string;
@@ -73,7 +76,23 @@ function normalizeApiError(response: ApiError): {
   const fallbackMessage =
     typeof response.status === 'number'
       ? `HTTP error! status: ${response.status}`
-      : 'Unknown API error';
+      : typeof httpStatus === 'number'
+        ? `HTTP error! status: ${httpStatus}`
+        : 'Unknown API error';
+
+  // Guard against null or non-object error details (e.g. {"error": null})
+  if (details == null || typeof details !== 'object') {
+    return {
+      message: fallbackMessage,
+      status:
+        typeof response.status === 'number'
+          ? response.status
+          : typeof httpStatus === 'number'
+            ? httpStatus
+            : undefined,
+    };
+  }
+
   const message =
     typeof details.message === 'string' && details.message.trim().length > 0
       ? details.message
@@ -85,7 +104,9 @@ function normalizeApiError(response: ApiError): {
       ? response.status
       : typeof details.status === 'number'
         ? details.status
-        : undefined;
+        : typeof httpStatus === 'number'
+          ? httpStatus
+          : undefined;
 
   return {
     message,
@@ -326,8 +347,8 @@ export class ApiClient {
     if (!response.ok) {
       // Try to extract error message from response body
       if (isApiErrorResponse(data)) {
-        const apiError = normalizeApiError(data);
-        throw new ApiClientError(apiError.message, apiError.status ?? response.status, apiError);
+        const apiError = normalizeApiError(data, response.status);
+        throw new ApiClientError(apiError.message, apiError.status, apiError);
       } else {
         throw new ApiClientError(`HTTP error! status: ${response.status}`, response.status);
       }
@@ -335,7 +356,7 @@ export class ApiClient {
 
     // Check if the response is an error (for successful HTTP status but API error)
     if (isApiErrorResponse(data)) {
-      const apiError = normalizeApiError(data);
+      const apiError = normalizeApiError(data, response.status);
       throw new ApiClientError(apiError.message, apiError.status, apiError);
     }
 
@@ -1057,8 +1078,8 @@ export class ApiClient {
     const data = await response.json();
     if (!response.ok) {
       if (isApiErrorResponse(data)) {
-        const apiError = normalizeApiError(data);
-        throw new ApiClientError(apiError.message, apiError.status ?? response.status, apiError);
+        const apiError = normalizeApiError(data, response.status);
+        throw new ApiClientError(apiError.message, apiError.status, apiError);
       }
       throw new ApiClientError(`Upload failed: ${response.status}`, response.status);
     }

--- a/webui/src/utils/api.ts
+++ b/webui/src/utils/api.ts
@@ -68,7 +68,7 @@ function normalizeApiError(
   if (typeof response.error === 'string') {
     return {
       message: response.error,
-      status: response.status,
+      status: response.status ?? httpStatus,
     };
   }
 

--- a/webui/src/utils/api.ts
+++ b/webui/src/utils/api.ts
@@ -1,6 +1,7 @@
 import { type CreateAgentResponse, type CreateAgentRequest } from '@/components/CreateAgentDialog';
 import type {
   ApiError,
+  ApiErrorDetails,
   ChatConfig,
   ConversationResponse,
   CreateConversationRequest,
@@ -23,10 +24,24 @@ type HeadersInit = globalThis.HeadersInit;
 // Error type for API client
 export class ApiClientError extends Error {
   status?: number;
+  code?: string;
+  type?: string;
+  details?: ApiErrorDetails;
 
-  constructor(message: string, status?: number) {
+  constructor(
+    message: string,
+    status?: number,
+    options?: {
+      code?: string;
+      type?: string;
+      details?: ApiErrorDetails;
+    }
+  ) {
     super(message);
     this.status = status;
+    this.code = options?.code;
+    this.type = options?.type;
+    this.details = options?.details;
     this.name = 'ApiClientError';
   }
 
@@ -38,6 +53,47 @@ export class ApiClientError extends Error {
 // Type guard for API error responses
 function isApiErrorResponse(response: unknown): response is ApiError {
   return typeof response === 'object' && response !== null && 'error' in response;
+}
+
+function normalizeApiError(response: ApiError): {
+  message: string;
+  status?: number;
+  code?: string;
+  type?: string;
+  details?: ApiErrorDetails;
+} {
+  if (typeof response.error === 'string') {
+    return {
+      message: response.error,
+      status: response.status,
+    };
+  }
+
+  const details = response.error;
+  const fallbackMessage =
+    typeof response.status === 'number'
+      ? `HTTP error! status: ${response.status}`
+      : 'Unknown API error';
+  const message =
+    typeof details.message === 'string' && details.message.trim().length > 0
+      ? details.message
+      : typeof details.code === 'string' && details.code.trim().length > 0
+        ? details.code
+        : fallbackMessage;
+  const status =
+    typeof response.status === 'number'
+      ? response.status
+      : typeof details.status === 'number'
+        ? details.status
+        : undefined;
+
+  return {
+    message,
+    status,
+    code: typeof details.code === 'string' ? details.code : undefined,
+    type: typeof details.type === 'string' ? details.type : undefined,
+    details,
+  };
 }
 
 /**
@@ -270,7 +326,8 @@ export class ApiClient {
     if (!response.ok) {
       // Try to extract error message from response body
       if (isApiErrorResponse(data)) {
-        throw new ApiClientError(data.error, response.status);
+        const apiError = normalizeApiError(data);
+        throw new ApiClientError(apiError.message, apiError.status ?? response.status, apiError);
       } else {
         throw new ApiClientError(`HTTP error! status: ${response.status}`, response.status);
       }
@@ -278,7 +335,8 @@ export class ApiClient {
 
     // Check if the response is an error (for successful HTTP status but API error)
     if (isApiErrorResponse(data)) {
-      throw new ApiClientError(data.error, data.status);
+      const apiError = normalizeApiError(data);
+      throw new ApiClientError(apiError.message, apiError.status, apiError);
     }
 
     return data as T;
@@ -998,10 +1056,11 @@ export class ApiClient {
 
     const data = await response.json();
     if (!response.ok) {
-      throw new ApiClientError(
-        isApiErrorResponse(data) ? data.error : `Upload failed: ${response.status}`,
-        response.status
-      );
+      if (isApiErrorResponse(data)) {
+        const apiError = normalizeApiError(data);
+        throw new ApiClientError(apiError.message, apiError.status ?? response.status, apiError);
+      }
+      throw new ApiClientError(`Upload failed: ${response.status}`, response.status);
     }
     return data;
   }

--- a/webui/src/utils/logging.ts
+++ b/webui/src/utils/logging.ts
@@ -40,9 +40,8 @@ export async function setupLogging() {
 
   try {
     // Dynamically import Tauri logging to avoid module errors in browser
-    const { warn, debug, trace, info, error, attachConsole } = await import(
-      '@tauri-apps/plugin-log'
-    );
+    const { warn, debug, trace, info, error, attachConsole } =
+      await import('@tauri-apps/plugin-log');
 
     // Attach console first to see Rust logs in browser console
     detachConsole = await attachConsole();


### PR DESCRIPTION
## Summary
- preserve nested API error messages from managed-service responses instead of stringifying them as `[object Object]`
- carry structured `code`/`type` metadata on `ApiClientError`
- add regression coverage for payment/subscription error envelopes

## Testing
- npm test -- src/utils/__tests__/api.test.ts
- npx eslint . --fix && npx tsc -p tsconfig.app.json --noEmit

## Related
- gptme/gptme-cloud#61