### PR TITLE
feat(setup): add confirmation prompt for fish completions

### DIFF
--- a/gptme/cli/setup.py
+++ b/gptme/cli/setup.py
@@ -178,7 +178,9 @@ def _install_fish_completions(fish_completions_file: Path, source_file: Path):
         )
     )
 
-    # TODO: prompt for confirmation?
+    if not Confirm.ask("Install fish completions?", default=True):
+        console.print("   [dim]Skipping fish completions[/dim]")
+        return
     try:
         fish_completions_file.symlink_to(source_file)
         console.print(

--- a/gptme/cli/setup.py
+++ b/gptme/cli/setup.py
@@ -99,7 +99,10 @@ def _setup_completions():
                     )
                     return
             else:
-                _install_fish_completions(fish_completions_file, source_file)
+                if Confirm.ask("Install fish completions?", default=True):
+                    _install_fish_completions(fish_completions_file, source_file)
+                else:
+                    console.print("   [dim]Skipping fish completions[/dim]")
                 return
 
         except ImportError:
@@ -178,9 +181,6 @@ def _install_fish_completions(fish_completions_file: Path, source_file: Path):
         )
     )
 
-    if not Confirm.ask("Install fish completions?", default=True):
-        console.print("   [dim]Skipping fish completions[/dim]")
-        return
     try:
         fish_completions_file.symlink_to(source_file)
         console.print(


### PR DESCRIPTION
Adds a confirmation prompt before installing fish shell completions, replacing the `# TODO: prompt for confirmation?` comment.

**Change**: A single `Confirm.ask()` call before the symlink/copy step. If the user declines, completions are skipped with a dimmed message.

**Testing**: Import check passes. `Confirm` is already imported in the file (used in 3 other places in the same module).

**Found via**: Bob cross-repo scouting (`scripts/cross_repo_offline_supply.py` → local TODO seed at `gptme/cli/setup.py:181`).