### PR TITLE
docs(config): document default_config defaults for about, response_preference, and prompt.project

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -73,7 +73,7 @@ The ``user`` section configures user identity:
 The ``prompt`` section contains options included in both interactive and non-interactive runs:
 
 - ``files``: A list of additional files to always include in context. Supports absolute paths, ``~`` expansion, and paths relative to the config directory.
-- ``project``: A table of project descriptions, keyed by project name, included when working in the matching Git repository. The default config includes descriptions for ``activitywatch`` and ``gptme`` — when a git repository's remote matches one of these keys, the description is automatically injected into the system prompt.
+- ``project``: A table of project descriptions, keyed by project name, included when working in the matching Git repository. The default config includes descriptions for ``activitywatch`` and ``gptme`` — when the git root directory name matches one of these keys, the description is automatically injected into the system prompt.
 
 The ``env`` section contains environment variables that gptme will fall back to if they are not set in the shell environment. This is useful for setting the default model and API keys for :doc:`providers`. It can also be used to set default tool configuration options, see :doc:`custom_tool` for more information.
 

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -25,7 +25,7 @@ Here is an example:
     [user]
     name = "Erik"
     about = "I am a curious human programmer."
-    response_preference = "Don't explain basic concepts"
+    response_preference = "Basic concepts don't need to be explained."
     avatar = "~/Pictures/avatar.jpg"  # Path to avatar image (or URL)
 
     [prompt]

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -62,8 +62,8 @@ Here is an example:
 The ``user`` section configures user identity:
 
 - ``name``: Your display name, shown at the CLI input prompt and as a tooltip on avatar in the web UI (default: ``"User"``).
-- ``about``: A description of yourself, included in the system prompt so the assistant knows who it's talking to.
-- ``response_preference``: Preferences for how the assistant should respond (e.g. level of detail).
+- ``about``: A description of yourself, included in the system prompt so the assistant knows who it's talking to (default: ``"I am a curious human programmer."``).
+- ``response_preference``: Preferences for how the assistant should respond (e.g. level of detail, default: ``"Basic concepts don't need to be explained."``).
 - ``avatar``: Path to your avatar image (supports ``~`` expansion) or URL. Displayed in the web UI next to your messages.
 
 .. note::
@@ -73,7 +73,7 @@ The ``user`` section configures user identity:
 The ``prompt`` section contains options included in both interactive and non-interactive runs:
 
 - ``files``: A list of additional files to always include in context. Supports absolute paths, ``~`` expansion, and paths relative to the config directory.
-- ``project``: A table of project descriptions, keyed by project name, included when working in the matching Git repository.
+- ``project``: A table of project descriptions, keyed by project name, included when working in the matching Git repository. The default config includes descriptions for ``activitywatch`` and ``gptme`` — when a git repository's remote matches one of these keys, the description is automatically injected into the system prompt.
 
 The ``env`` section contains environment variables that gptme will fall back to if they are not set in the shell environment. This is useful for setting the default model and API keys for :doc:`providers`. It can also be used to set default tool configuration options, see :doc:`custom_tool` for more information.
 

--- a/gptme/config/user.py
+++ b/gptme/config/user.py
@@ -55,7 +55,6 @@ ABOUT_ACTIVITYWATCH = """ActivityWatch is a free and open-source automated time-
 ABOUT_GPTME = "gptme is a CLI to interact with large language models in a Chat-style interface, enabling the assistant to execute commands and code on the local machine, letting them assist in all kinds of development and terminal-based work."
 
 
-# TODO: include this in docs
 default_config = UserConfig(
     user=UserIdentityConfig(
         name="User",


### PR DESCRIPTION
Closes a long-standing TODO from `gptme/config/user.py:58` by documenting the default values for the `user.about`, `user.response_preference`, and `prompt.project` config options in the RST docs.

**Before:** These three fields had no default values documented. Users reading `docs/config.rst` would not know what the built-in defaults are.

**After:** Each field shows its default value inline, and `prompt.project` explains the auto-injection behavior for `activitywatch` and `gptme` descriptions.

```
- about: A description of yourself ... (default: "I am a curious human programmer.")
- response_preference: Preferences ... (default: "Basic concepts don't need to be explained.")
- project: A table of project descriptions ... The default config includes descriptions for `activitywatch` and `gptme`.
```

Closes `# TODO: include this in docs` at `gptme/config/user.py:58`.