### PR TITLE
feat(tools): add when-to-use trigger language for python, save, patch tools

### DIFF
--- a/gptme/tools/patch.py
+++ b/gptme/tools/patch.py
@@ -26,17 +26,18 @@ from .base import (
 instructions = """
 To patch/modify files, we use an adapted version of git conflict markers.
 
-This can be used to edit files, without having to rewrite the whole file.
-Multiple ORIGINAL/UPDATED blocks can be included in a single patch to make several changes at once.
-Try to keep each patch as small as possible. Avoid placeholders, as they may make the patch fail.
+Multiple ORIGINAL/UPDATED blocks can be included in a single patch to make multiple changes.
+Try to keep patches small — scope each change to a function/class, and use `save` for large rewrites.
 
-To keep patches small, try to scope each change to imports/function/class.
-If the total patch is large, consider using the save tool to rewrite the whole file.
+### When to use patch vs save
 
-Note: When patching markdown files, avoid replacing partial codeblocks (e.g., just the opening
-or closing backticks). The patch content is parsed as nested markdown, which requires complete
-codeblocks. For simple codeblock boundary changes (like modifying a language tag), use shell
-commands like `sed` or `perl` instead.
+Use `patch` for targeted edits to existing files — changing a few lines or a method body.
+Prefer `save` when creating new files, full replacements, or changes large enough
+that patch markers become unwieldy.
+
+Note: When patching markdown files, avoid replacing partial codeblocks (just the opening
+or closing backticks). The parser needs complete codeblocks. For simple codeblock
+boundary changes (like a language tag), use `sed` or `perl` instead.
 """.strip()
 
 instructions_format = {

--- a/gptme/tools/patch.py
+++ b/gptme/tools/patch.py
@@ -26,18 +26,18 @@ from .base import (
 instructions = """
 To patch/modify files, we use an adapted version of git conflict markers.
 
-Multiple ORIGINAL/UPDATED blocks can be included in a single patch to make multiple changes.
-Try to keep patches small — scope each change to a function/class, and use `save` for large rewrites.
+Multiple ORIGINAL/UPDATED blocks can make several changes in one patch.
+Keep patches small. Scope each change to a function/class. Avoid placeholders
+in ORIGINAL blocks; they must match the file exactly or the patch will fail.
 
 ### When to use patch vs save
 
-Use `patch` for targeted edits to existing files — changing a few lines or a method body.
-Prefer `save` when creating new files, full replacements, or changes large enough
-that patch markers become unwieldy.
+Use `patch` for targeted edits to existing files.
+Use `save` for new files, full rewrites, or changes too large for patch markers.
 
-Note: When patching markdown files, avoid replacing partial codeblocks (just the opening
-or closing backticks). The parser needs complete codeblocks. For simple codeblock
-boundary changes (like a language tag), use `sed` or `perl` instead.
+Note: When patching markdown, avoid replacing partial codeblocks (just the opening
+or closing backticks). The parser needs complete codeblocks. For simple
+codeblock-boundary changes (like a language tag), use `sed` or `perl` instead.
 """.strip()
 
 instructions_format = {

--- a/gptme/tools/python.py
+++ b/gptme/tools/python.py
@@ -279,6 +279,13 @@ def get_functions():
 instructions = """
 Use this tool to execute Python code in an interactive IPython session.
 It will respond with the output and result of the execution.
+
+### When to use the python tool
+
+Use the python tool when you need to run code, compute something, transform
+data, or automate file processing. Prefer `python` over the shell when the
+task is purely computational or involves structured data — python gives you
+iterative execution with persistent variables and access to rich libraries.
 """.strip()
 
 instructions_format = {

--- a/gptme/tools/python.py
+++ b/gptme/tools/python.py
@@ -278,14 +278,13 @@ def get_functions():
 
 instructions = """
 Use this tool to execute Python code in an interactive IPython session.
-It will respond with the output and result of the execution.
+It responds with the execution output and final result.
 
 ### When to use the python tool
 
-Use the python tool when you need to run code, compute something, transform
-data, or automate file processing. Prefer `python` over the shell when the
-task is purely computational or involves structured data — python gives you
-iterative execution with persistent variables and access to rich libraries.
+Use `python` for computation, structured data, and file-processing automation.
+Prefer it over the shell for pure computation or when you need persistent
+state or Python libraries.
 """.strip()
 
 instructions_format = {

--- a/gptme/tools/save.py
+++ b/gptme/tools/save.py
@@ -26,10 +26,8 @@ If the current directory changes, the path will be relative to the new directory
 
 ### When to use save vs patch
 
-Use `save` when creating a new file, replacing an entire file's content, or
-when the change touches most of the file. `save` rewrites the entire file.
-For targeted edits to existing files, prefer `patch` — it preserves unchanged
-content and keeps diffs readable.
+Use `save` for new files, full rewrites, or edits that touch most of a file.
+Use `patch` for targeted edits to existing files; it keeps surrounding content intact.
 """.strip()
 
 instructions_format = {

--- a/gptme/tools/save.py
+++ b/gptme/tools/save.py
@@ -23,6 +23,13 @@ Create or overwrite a file with the given content.
 
 The path can be relative to the current directory, or absolute.
 If the current directory changes, the path will be relative to the new directory.
+
+### When to use save vs patch
+
+Use `save` when creating a new file, replacing an entire file's content, or
+when the change touches most of the file. `save` rewrites the entire file.
+For targeted edits to existing files, prefer `patch` — it preserves unchanged
+content and keeps diffs readable.
 """.strip()
 
 instructions_format = {

--- a/tests/test_llm_anthropic.py
+++ b/tests/test_llm_anthropic.py
@@ -18,6 +18,18 @@ from gptme.message import Message
 from gptme.prompts import SYSTEM_PROMPT_CACHE_BOUNDARY
 from gptme.tools import get_tool, init_tools
 
+EXPECTED_SAVE_TOOL_DESCRIPTION = (
+    "Create or overwrite a file with the given content.\n\n"
+    "The path can be relative to the current directory, or absolute.\n"
+    "If the current directory changes, the path will be relative to the new "
+    "directory.\n\n"
+    "### When to use save vs patch\n\n"
+    "Use `save` for new files, full rewrites, or edits that touch most of a "
+    "file.\n"
+    "Use `patch` for targeted edits to existing files; it keeps surrounding "
+    "content intact."
+)
+
 
 def test_reinit_requires_non_empty_api_key():
     with pytest.raises(ValueError, match="api_key must be non-empty"):
@@ -125,14 +137,13 @@ def test_message_conversion_with_tools():
     tool_save = get_tool("save")
 
     assert tool_save
-    tool_save_description = tool_save.get_instructions("tool") or tool_save.desc
 
     messages_dicts, _, tools = _prepare_messages_for_api(messages, [tool_save])
 
     assert tools == [
         {
             "name": "save",
-            "description": tool_save_description,
+            "description": EXPECTED_SAVE_TOOL_DESCRIPTION,
             "input_schema": {
                 "type": "object",
                 "properties": {

--- a/tests/test_llm_anthropic.py
+++ b/tests/test_llm_anthropic.py
@@ -125,16 +125,14 @@ def test_message_conversion_with_tools():
     tool_save = get_tool("save")
 
     assert tool_save
+    tool_save_description = tool_save.get_instructions("tool") or tool_save.desc
 
     messages_dicts, _, tools = _prepare_messages_for_api(messages, [tool_save])
 
     assert tools == [
         {
             "name": "save",
-            "description": "Create or overwrite a file with the given content.\n\n"
-            "The path can be relative to the current directory, or absolute.\n"
-            "If the current directory changes, the path will be relative to the "
-            "new directory.",
+            "description": tool_save_description,
             "input_schema": {
                 "type": "object",
                 "properties": {

--- a/tests/test_llm_openai.py
+++ b/tests/test_llm_openai.py
@@ -143,6 +143,7 @@ def test_message_conversion_with_tools():
 
     tool_save = get_tool("save")
     assert tool_save
+    tool_save_description = tool_save.get_instructions("tool") or tool_save.desc
 
     model = get_model("openai/gpt-4o")
     messages_dicts, tools_dict = _prepare_messages_for_api(
@@ -154,10 +155,7 @@ def test_message_conversion_with_tools():
             "type": "function",
             "function": {
                 "name": "save",
-                "description": "Create or overwrite a file with the given content.\n\n"
-                "The path can be relative to the current directory, or absolute.\n"
-                "If the current directory changes, the path will be relative to the "
-                "new directory.",
+                "description": tool_save_description,
                 "parameters": {
                     "type": "object",
                     "properties": {

--- a/tests/test_llm_openai.py
+++ b/tests/test_llm_openai.py
@@ -22,6 +22,18 @@ from gptme.llm.openai_responses import _tool_spec_to_responses_tool
 from gptme.message import Message
 from gptme.tools import ToolSpec, get_tool, init_tools
 
+EXPECTED_SAVE_TOOL_DESCRIPTION = (
+    "Create or overwrite a file with the given content.\n\n"
+    "The path can be relative to the current directory, or absolute.\n"
+    "If the current directory changes, the path will be relative to the new "
+    "directory.\n\n"
+    "### When to use save vs patch\n\n"
+    "Use `save` for new files, full rewrites, or edits that touch most of a "
+    "file.\n"
+    "Use `patch` for targeted edits to existing files; it keeps surrounding "
+    "content intact."
+)
+
 
 @pytest.fixture(autouse=True)
 def reset_default_model():
@@ -143,7 +155,6 @@ def test_message_conversion_with_tools():
 
     tool_save = get_tool("save")
     assert tool_save
-    tool_save_description = tool_save.get_instructions("tool") or tool_save.desc
 
     model = get_model("openai/gpt-4o")
     messages_dicts, tools_dict = _prepare_messages_for_api(
@@ -155,7 +166,7 @@ def test_message_conversion_with_tools():
             "type": "function",
             "function": {
                 "name": "save",
-                "description": tool_save_description,
+                "description": EXPECTED_SAVE_TOOL_DESCRIPTION,
                 "parameters": {
                     "type": "object",
                     "properties": {


### PR DESCRIPTION
## Summary

Extends the trigger language pattern from PR #2406 to three more high-volume tools: `python`, `save`, and `patch`. Each gets a brief "When to use" section explaining the action boundary — when to prefer this tool over alternatives.

## Changes

- **`python`**: adds trigger language for computational/data tasks vs shell
- **`save`**: adds trigger language for when to use save vs patch
- **`patch`**: refines existing trigger language, trims to fit under 1024-char limit (was 1259, now 847)

## Validation

- `test_tool_descriptions_within_openai_limit` passes (patch: 847 chars, all under 1024)
- `ruff check` clean, `ruff format` already formatted
- Pre-commit hooks passed
