### PR TITLE
test(chat): cover deferred path expansion in chained prompts

### DIFF
--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -550,7 +550,8 @@ def main(
     # join prompts, grouped by `-` if present, since that's the separator for "chained"/multiple-round prompts
     sep = "\n\n" + MULTIPROMPT_SEPARATOR
     prompts = [p.strip() for p in "\n\n".join(prompts).split(sep) if p]
-    # TODO: referenced file paths in multiprompts should be read when run, not when parsed
+    # Keep raw prompt strings here; include_paths() resolves file references
+    # when each chained prompt is executed.
     prompt_msgs = [Message("user", p) for p in prompts]
 
     def inject_stdin(prompt_msgs, piped_input: str | None) -> list[Message]:

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -590,6 +590,61 @@ def test_chained_prompts_complete_exits_when_last():
         )
 
 
+def test_chained_prompt_paths_are_read_when_executed(tmp_path, monkeypatch):
+    """Later chained prompts should expand file paths at execution time."""
+    import sys
+
+    from gptme.chat import _run_chat_loop
+    from gptme.message import Message
+
+    _chat_mod = sys.modules["gptme.chat"]
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("GPTME_DISABLE_PATH_INCLUDE", raising=False)
+
+    data_file = tmp_path / "notes.txt"
+    data_file.write_text("before")
+
+    manager = MagicMock()
+    manager.log = MagicMock()
+    manager.workspace = tmp_path
+    manager.logdir = tmp_path / "logdir"
+
+    appended_messages: list[Message] = []
+    manager.append.side_effect = appended_messages.append
+
+    call_count = 0
+
+    def mock_process(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            data_file.write_text("after")
+
+    with (
+        patch.object(
+            _chat_mod, "_process_message_conversation", side_effect=mock_process
+        ),
+        patch.object(_chat_mod, "trigger_hook", return_value=[]),
+        patch.object(_chat_mod, "execute_cmd", return_value=False),
+    ):
+        _run_chat_loop(
+            manager=manager,
+            prompt_queue=[
+                Message("user", "update the file"),
+                Message("user", "notes.txt"),
+            ],
+            stream=False,
+            tool_format="markdown",
+            model=None,
+            interactive=False,
+        )
+
+    assert len(appended_messages) == 2
+    assert "after" in appended_messages[1].content
+    assert "before" not in appended_messages[1].content
+
+
 def test_external_queued_prompts_are_drained_between_turns(tmp_path):
     """Queued prompts on disk should be picked up by the next loop iteration."""
     import sys

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -640,6 +640,7 @@ def test_chained_prompt_paths_are_read_when_executed(tmp_path, monkeypatch):
             interactive=False,
         )
 
+    assert call_count == 2, "Both chained prompts should have been processed"
     assert len(appended_messages) == 2
     assert "after" in appended_messages[1].content
     assert "before" not in appended_messages[1].content


### PR DESCRIPTION
## Summary
- add a regression test proving later chained prompts expand file paths when that prompt executes
- replace the stale multiprompt TODO with an explicit note about deferred include_paths handling

## Testing
- /home/bob/gptme/.venv/bin/python -m pytest tests/test_chat.py -k "chained_prompt_paths_are_read_when_executed or chained_prompts_continue_after_complete or chained_prompts_complete_exits_when_last" -q
- uv run ruff check gptme/cli/main.py tests/test_chat.py