### PR TITLE
fix(eval): fail fast on disabled staged SWE-bench runner

### DIFF
--- a/gptme/eval/agents/swebench.py
+++ b/gptme/eval/agents/swebench.py
@@ -1,8 +1,8 @@
 """
-Multi-stage SWE-bench agent from bjsi's original work (PR #424).
+Recovered multi-stage SWE-bench runner from bjsi's original work (PR #424).
 
-The understand/reproduce/fix sub-agents are not yet implemented — this is the
-orchestration skeleton that will drive them once they exist.
+The understand/reproduce/fix stages never landed. Keep the replay helpers and
+metadata plumbing, but fail fast until the staged execution path is real.
 """
 
 import logging
@@ -27,11 +27,23 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
+MULTI_STAGE_RUNNER_UNAVAILABLE = (
+    "The recovered SWE-bench multi-stage runner from PR #424 is intentionally "
+    "disabled. The stage agents (Understand/Reproduce/Fix) were never "
+    "implemented, and the current eval chat path cannot write stage-specific "
+    "branch logs because GPTMe eval chats always persist to the main "
+    "conversation log. Use gptme.eval.swebench.main for single-agent runs "
+    "until branch-aware eval logging and concrete stage agents land."
+)
+
 
 class SWEBenchAgent:
     """Multi-stage SWE-bench agent that orchestrates understand/reproduce/fix phases."""
 
     stages = ["understand", "reproduce", "fix"]
+
+    def _raise_stage_runner_unavailable(self) -> None:
+        raise NotImplementedError(MULTI_STAGE_RUNNER_UNAVAILABLE)
 
     def act(
         self,
@@ -43,6 +55,8 @@ class SWEBenchAgent:
         start_stage: str = "understand",
         **kwargs,
     ):
+        self._raise_stage_runner_unavailable()
+
         # Initialize or load trajectory info
         trajectory_info = instance_to_trajectory_info(
             instance,
@@ -137,6 +151,8 @@ class SWEBenchAgent:
         resume_dir: Path | None = None,
         **kwargs,
     ):
+        self._raise_stage_runner_unavailable()
+
         instance_id = instance["instance_id"]
         problem_statement = instance["problem_statement"]
         info = SWEBenchInfo.load_from_log_dir(resume_dir) if resume_dir else None

--- a/gptme/eval/agents/swebench.py
+++ b/gptme/eval/agents/swebench.py
@@ -19,8 +19,6 @@ from gptme.message import print_msg
 from gptme.tools import execute_msg, init_tools
 from gptme.util.auto_naming import generate_conversation_id
 
-from ..swe_extra.swe_bench_test_spec import instance_to_trajectory_info, make_test_spec
-
 try:
     from swebench.harness.constants import SWEbenchInstance
 except ImportError:
@@ -36,6 +34,18 @@ MULTI_STAGE_RUNNER_UNAVAILABLE = (
     "conversation log. Use gptme.eval.swebench.main for single-agent runs "
     "until branch-aware eval logging and concrete stage agents land."
 )
+
+
+def instance_to_trajectory_info(*args, **kwargs):
+    from ..swe_extra.swe_bench_test_spec import instance_to_trajectory_info as impl
+
+    return impl(*args, **kwargs)
+
+
+def make_test_spec(*args, **kwargs):
+    from ..swe_extra.swe_bench_test_spec import make_test_spec as impl
+
+    return impl(*args, **kwargs)
 
 
 class SWEBenchAgent:

--- a/gptme/eval/agents/swebench.py
+++ b/gptme/eval/agents/swebench.py
@@ -10,6 +10,7 @@ import os
 import time
 import uuid
 from pathlib import Path
+from typing import NoReturn
 
 from gptme.dirs import get_logs_dir
 from gptme.eval.swebench import SWEBenchInfo
@@ -42,7 +43,7 @@ class SWEBenchAgent:
 
     stages = ["understand", "reproduce", "fix"]
 
-    def _raise_stage_runner_unavailable(self) -> None:
+    def _raise_stage_runner_unavailable(self) -> NoReturn:
         raise NotImplementedError(MULTI_STAGE_RUNNER_UNAVAILABLE)
 
     def act(
@@ -205,6 +206,8 @@ class SWEBenchAgent:
             logger.info(
                 f"Evaluation completed for instance {instance_id}. Passed: {passed}"
             )
+        except NotImplementedError:
+            raise
         except Exception as e:
             import traceback
 

--- a/gptme/eval/swe_extra/run_swe_extra.py
+++ b/gptme/eval/swe_extra/run_swe_extra.py
@@ -45,10 +45,7 @@ def evaluate_instance_or_exit(
     """Surface staged-runner unavailability without a traceback wall."""
 
     try:
-        if resume_dir is None:
-            agent.evaluate_instance(instance, model=model)
-        else:
-            agent.evaluate_instance(instance, model=model, resume_dir=resume_dir)
+        agent.evaluate_instance(instance, model=model, resume_dir=resume_dir)
     except NotImplementedError as exc:
         raise SystemExit(str(exc)) from exc
 

--- a/gptme/eval/swe_extra/run_swe_extra.py
+++ b/gptme/eval/swe_extra/run_swe_extra.py
@@ -5,13 +5,23 @@ from pathlib import Path
 
 from gptme.dirs import get_logs_dir
 from gptme.eval.agents.swebench import SWEBenchAgent
-from gptme.eval.swe_extra.swe_bench_extra_data import (
-    load_instance_by_id,
-    load_top_50_easiest_task_instances,
-)
 from gptme.eval.swebench import SWEBenchInfo
 from gptme.logmanager import LogManager
 from gptme.tools import init_tools
+
+
+def load_instance_by_id(*args, **kwargs):
+    from gptme.eval.swe_extra.swe_bench_extra_data import load_instance_by_id as impl
+
+    return impl(*args, **kwargs)
+
+
+def load_top_50_easiest_task_instances(*args, **kwargs):
+    from gptme.eval.swe_extra.swe_bench_extra_data import (
+        load_top_50_easiest_task_instances as impl,
+    )
+
+    return impl(*args, **kwargs)
 
 
 def get_most_recent_log_dir():

--- a/gptme/eval/swe_extra/run_swe_extra.py
+++ b/gptme/eval/swe_extra/run_swe_extra.py
@@ -35,6 +35,24 @@ def clear_branch(resume_dir: Path, branch: str) -> None:
     print(f"Cleared branch {branch}")
 
 
+def evaluate_instance_or_exit(
+    agent: SWEBenchAgent,
+    instance: dict,
+    *,
+    model: str,
+    resume_dir: Path | None = None,
+) -> None:
+    """Surface staged-runner unavailability without a traceback wall."""
+
+    try:
+        if resume_dir is None:
+            agent.evaluate_instance(instance, model=model)
+        else:
+            agent.evaluate_instance(instance, model=model, resume_dir=resume_dir)
+    except NotImplementedError as exc:
+        raise SystemExit(str(exc)) from exc
+
+
 def main(
     model: str,
     resume_dir: str | Path | None = None,
@@ -73,10 +91,15 @@ def main(
         if branch_to_clear:
             clear_branch(resume_path, branch_to_clear)
 
-        agent.evaluate_instance(instance, model=info.model_name, resume_dir=resume_path)
+        evaluate_instance_or_exit(
+            agent,
+            instance,
+            model=info.model_name,
+            resume_dir=resume_path,
+        )
     else:
         instance = load_top_50_easiest_task_instances()[0]
-        agent.evaluate_instance(instance, model=model)
+        evaluate_instance_or_exit(agent, instance, model=model)
 
 
 def cli():

--- a/tests/test_eval_swebench.py
+++ b/tests/test_eval_swebench.py
@@ -223,6 +223,52 @@ def test_multi_stage_swebench_evaluate_instance_fails_before_repo_setup(monkeypa
         )
 
 
+def test_multi_stage_swebench_evaluate_instance_reraises_stage_disable_signal(
+    monkeypatch,
+    tmp_path,
+):
+    """Execution-phase NotImplementedError should not be swallowed by the broad catch."""
+    from gptme.eval.agents.swebench import SWEBenchAgent
+
+    agent = SWEBenchAgent()
+
+    class DummyTestSpec:
+        def setup_repo(self):
+            return "/tmp/repo"
+
+        def eval_repo(self):
+            raise AssertionError("eval_repo should not run after staged runner failure")
+
+    monkeypatch.setattr(agent, "_raise_stage_runner_unavailable", lambda: None)
+    monkeypatch.setattr(
+        "gptme.eval.agents.swebench.make_test_spec",
+        lambda instance, repo_dir: DummyTestSpec(),
+    )
+    monkeypatch.setattr(
+        "gptme.eval.agents.swebench.get_logs_dir",
+        lambda: tmp_path,
+    )
+    monkeypatch.setattr(
+        "gptme.eval.agents.swebench.generate_conversation_id",
+        lambda prefix, logs_dir: "disabled-runner-test",
+    )
+    monkeypatch.setattr(
+        "gptme.eval.agents.swebench.SWEBenchAgent.act",
+        lambda self, **kwargs: (_ for _ in ()).throw(
+            NotImplementedError("staged runner unavailable")
+        ),
+    )
+
+    with pytest.raises(NotImplementedError, match="staged runner unavailable"):
+        agent.evaluate_instance(
+            {
+                "instance_id": "django__django-11099",
+                "problem_statement": "Fix a Django bug",
+            },
+            model="test-model",
+        )
+
+
 def test_run_swe_extra_exits_with_helpful_message(monkeypatch):
     """run_swe_extra should surface the staged-runner blocker without traceback spam."""
     from gptme.eval.swe_extra import run_swe_extra

--- a/tests/test_eval_swebench.py
+++ b/tests/test_eval_swebench.py
@@ -3,6 +3,8 @@
 import json
 import textwrap
 
+import pytest
+
 
 def test_write_predictions_jsonl(tmp_path):
     """write_predictions_jsonl produces valid JSONL in the expected format."""
@@ -180,3 +182,66 @@ def test_info_flag_missing_instance_warns(monkeypatch):
     result = runner.invoke(main, ["--info", "-i", "nonexistent__repo-99999"])
     assert result.exit_code == 0
     assert "not found" in result.output
+
+
+def test_multi_stage_swebench_agent_act_fails_fast(tmp_path):
+    """Recovered staged runner should fail loudly instead of silently no-oping."""
+    from gptme.eval.agents.swebench import SWEBenchAgent
+
+    agent = SWEBenchAgent()
+    instance = {"instance_id": "django__django-11099"}
+
+    with pytest.raises(NotImplementedError, match="intentionally disabled"):
+        agent.act(
+            model="test-model",
+            instance=instance,
+            repo_dir="/tmp/repo",
+            log_dir=str(tmp_path),
+        )
+
+    assert not (tmp_path / "swe_bench_info.json").exists()
+
+
+def test_multi_stage_swebench_evaluate_instance_fails_before_repo_setup(monkeypatch):
+    """The disabled staged runner should stop before repo setup or harness work."""
+    from gptme.eval.agents.swebench import SWEBenchAgent
+
+    agent = SWEBenchAgent()
+
+    def fail_if_called(*args, **kwargs):
+        raise AssertionError("make_test_spec should not run for the disabled runner")
+
+    monkeypatch.setattr("gptme.eval.agents.swebench.make_test_spec", fail_if_called)
+
+    with pytest.raises(NotImplementedError, match="branch-aware eval logging"):
+        agent.evaluate_instance(
+            {
+                "instance_id": "django__django-11099",
+                "problem_statement": "Fix a Django bug",
+            },
+            model="test-model",
+        )
+
+
+def test_run_swe_extra_exits_with_helpful_message(monkeypatch):
+    """run_swe_extra should surface the staged-runner blocker without traceback spam."""
+    from gptme.eval.swe_extra import run_swe_extra
+
+    monkeypatch.setattr(run_swe_extra, "init_tools", lambda: None)
+    monkeypatch.setattr(
+        run_swe_extra,
+        "load_top_50_easiest_task_instances",
+        lambda: [{"instance_id": "django__django-11099"}],
+    )
+
+    def disabled_runner(self, instance, model, resume_dir=None):
+        raise NotImplementedError("staged runner unavailable")
+
+    monkeypatch.setattr(
+        run_swe_extra.SWEBenchAgent,
+        "evaluate_instance",
+        disabled_runner,
+    )
+
+    with pytest.raises(SystemExit, match="staged runner unavailable"):
+        run_swe_extra.main(model="test-model")


### PR DESCRIPTION
## Summary
- fail fast when the recovered PR #424 staged SWE-bench runner is invoked
- explain that branch-aware eval logging and concrete stage agents are still missing
- surface the blocker cleanly from `run_swe_extra` and cover it with tests

## Testing
- uv run ruff check gptme/eval/agents/swebench.py gptme/eval/swe_extra/run_swe_extra.py tests/test_eval_swebench.py
- /home/bob/gptme/.venv/bin/python -m pytest tests/test_eval_swebench.py tests/test_swebench_utils.py -q