### PR TITLE
test(eval): cover top-level future drain timeout fallback

### DIFF
--- a/gptme/eval/run.py
+++ b/gptme/eval/run.py
@@ -238,12 +238,14 @@ def run_evals(
                 )
             model_results[config][test_name] = result
 
-        # worse-case run time, with some buffer to account for overhead
-        # n_runs accounts for all model×eval combinations, not just evals
+        # Worst-case batch runtime, with buffer for executor overhead.
+        # `execute()` already owns per-eval process termination; this is a
+        # coarse fallback in case the future-drain path itself stalls, so the
+        # eval runner can still synthesize results for every model×eval pair.
+        # `n_runs` accounts for all model×eval combinations, not just evals.
         max_timeout = timeout * n_runs / parallel + 10
         completed = set()
         try:
-            # TODO: can we do better than this? handle timeouts within futures instead?
             for future in tqdm(
                 as_completed(futures, timeout=max_timeout),
                 total=n_runs,
@@ -255,9 +257,9 @@ def run_evals(
                 _handle_future(future)
                 completed.add(future)
         except TimeoutError:
-            # NOTE: this should rarely happen, as `execute` should handle timeouts
             logger.warning(
-                "Timeout reached in top-level (shouldnt happen). Cancelling remaining futures..."
+                "Top-level future drain timeout reached after per-eval timeouts; "
+                "cancelling remaining futures..."
             )
 
             # Cancel any remaining futures

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -3,7 +3,9 @@ import json
 import os
 import subprocess
 import sys
+from concurrent.futures import CancelledError, TimeoutError
 from pathlib import Path
+from types import SimpleNamespace
 from typing import TYPE_CHECKING, cast
 from unittest.mock import patch
 
@@ -14,7 +16,7 @@ from gptme.config import get_config
 from gptme.eval import execute, tests
 from gptme.eval.agents import Agent, GPTMe
 from gptme.eval.main import main, resolve_eval_names, results_to_json
-from gptme.eval.run import ProcessError, SyncedDict, act_process
+from gptme.eval.run import ProcessError, SyncedDict, act_process, run_evals
 from gptme.eval.suites import suites, tests_map
 from gptme.eval.types import CaseResult, EvalResult, ModelConfig
 from gptme.message import Message
@@ -533,6 +535,104 @@ def test_execute_docker_mode_runs_checks_in_docker_env():
     assert result.status == "success"
     assert all(case.passed for case in result.results)
     assert result.run_stdout == "done"
+
+
+def test_run_evals_top_level_timeout_cancels_pending_futures(tmp_path):
+    class FakeFuture:
+        def __init__(self, result: EvalResult):
+            self._result = result
+            self.cancelled = False
+
+        def cancel(self):
+            self.cancelled = True
+            return True
+
+        def result(self, timeout=None):
+            if self.cancelled:
+                raise CancelledError
+            return self._result
+
+    class FakeExecutor:
+        def __init__(self, max_workers):
+            self.max_workers = max_workers
+            self.futures: list[FakeFuture] = []
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def submit(
+            self, fn, test, agent, timeout, parallel, use_docker, **kwargs
+        ) -> FakeFuture:
+            result = EvalResult(
+                name=test["name"],
+                status="success",
+                results=[CaseResult(name="ok", passed=True, duration=0.0)],
+                timings={"gen": 0.0, "run": 0.0, "eval": 0.0},
+                gen_stdout="",
+                gen_stderr="",
+                run_stdout="",
+                run_stderr="",
+                log_dir=agent.log_dir,
+                workspace_dir=agent.workspace_dir,
+            )
+            future = FakeFuture(result)
+            self.futures.append(future)
+            return future
+
+    agent_counter = {"value": 0}
+    observed_timeout: dict[str, float] = {}
+
+    def fake_agent(*args, **kwargs):
+        agent_counter["value"] += 1
+        idx = agent_counter["value"]
+        log_dir = tmp_path / f"log-{idx}"
+        workspace_dir = tmp_path / f"workspace-{idx}"
+        log_dir.mkdir()
+        workspace_dir.mkdir()
+        return SimpleNamespace(log_dir=log_dir, workspace_dir=workspace_dir)
+
+    def fake_as_completed(futures, timeout):
+        observed_timeout["value"] = timeout
+        yield futures[0]
+        raise TimeoutError
+
+    evals: list[EvalSpec] = [
+        {"name": "first", "files": {}, "run": "", "prompt": "", "expect": {}},
+        {"name": "second", "files": {}, "run": "", "prompt": "", "expect": {}},
+    ]
+    model_config = ModelConfig(model="fake/model", tool_format="markdown")
+
+    with (
+        patch("gptme.eval.run.ProcessPoolExecutor", FakeExecutor),
+        patch("gptme.eval.run.as_completed", side_effect=fake_as_completed),
+        patch("gptme.eval.run.tqdm", side_effect=lambda iterable, **kwargs: iterable),
+        patch("gptme.eval.run.GPTMe", side_effect=fake_agent),
+        patch("gptme.eval.run.is_claude_code_model", return_value=False),
+        patch("gptme.eval.run.load_pass_rate_data", return_value=None),
+        patch(
+            "gptme.eval.run.apply_gate",
+            side_effect=lambda model, eval_name, no_lessons, data: (
+                no_lessons,
+                "default",
+            ),
+        ),
+        patch("gptme.eval.run.multiprocessing.active_children", return_value=[]),
+    ):
+        results = run_evals(
+            evals=evals,
+            model_configs=[model_config],
+            timeout=1,
+            parallel=2,
+        )
+
+    model_results = results[model_config]
+    assert observed_timeout["value"] == 11
+    assert [result.name for result in model_results] == ["first", "second"]
+    assert [result.status for result in model_results] == ["success", "timeout"]
+    assert model_results[1].gen_stderr == "Process-level CancelledError"
 
 
 def test_apply_adversarial_framing_prepends_text():


### PR DESCRIPTION
## Summary
- add a deterministic unit test for the mixed top-level timeout drain path in `run_evals()`
- verify completed futures keep their success result while cancelled futures synthesize timeout results
- replace the stale top-level timeout TODO with an explicit fallback contract comment and clearer warning text

## Testing
- `uv run pytest /home/bob/gptme/tests/test_eval.py -q -m 'not requires_api'`
- `uv run pytest /home/bob/gptme/tests/test_eval.py -q -k 'top_level_timeout_cancels_pending_futures or act_process_maps_subprocess_timeout_to_timeout_result or execute_docker_mode_runs_checks_in_docker_env'`
- `uv run pytest /home/bob/gptme/tests/test_eval_timeouts.py -q`
- `uv run ruff check /home/bob/gptme/gptme/eval/run.py /home/bob/gptme/tests/test_eval.py`
