### PR TITLE
feat(hooks): add Windows agent scanning

### DIFF
--- a/gptme/hooks/tests/test_workspace_agents.py
+++ b/gptme/hooks/tests/test_workspace_agents.py
@@ -25,6 +25,7 @@ from gptme.hooks.workspace_agents import (
     _has_flag,
     _init_tracking,
     _parse_etime,
+    _split_windows_cmdline,
     assess_staleness,
     detect_runtime,
     scan_agents,
@@ -226,6 +227,99 @@ class TestGetProcessMemoryMb:
 
 
 class TestWindowsProcessIntrospection:
+    def test_split_windows_cmdline_direct(self) -> None:
+        import ctypes
+
+        raw_cmdline = 'codex exec --model "gpt-5" "Run tests"'
+        expected = ["codex", "exec", "--model", "gpt-5", "Run tests"]
+        local_free_calls: list[object] = []
+
+        class FakeCommandLineToArgvW:
+            def __init__(self) -> None:
+                self.restype = None
+                self.argtypes = None
+                self.calls: list[str] = []
+
+            def __call__(self, cmdline: str, argc_ref: object) -> list[str]:
+                argc_ref._obj.value = len(expected)  # type: ignore[attr-defined]
+                self.calls.append(cmdline)
+                return expected
+
+        class FakeShell32:
+            def __init__(self, parser: FakeCommandLineToArgvW) -> None:
+                self.CommandLineToArgvW = parser
+
+        class FakeKernel32:
+            def LocalFree(self, ptr: object) -> None:
+                local_free_calls.append(ptr)
+
+        parser = FakeCommandLineToArgvW()
+
+        def fake_windll(
+            name: str, *args: object, **kwargs: object
+        ) -> FakeShell32 | FakeKernel32:
+            if name == "shell32":
+                return FakeShell32(parser)
+            if name == "kernel32":
+                return FakeKernel32()
+            raise AssertionError(f"Unexpected DLL: {name}")
+
+        with patch.object(ctypes, "WinDLL", side_effect=fake_windll, create=True):
+            assert _split_windows_cmdline(raw_cmdline) == expected
+
+        assert parser.calls == [raw_cmdline]
+        assert parser.restype == ctypes.POINTER(ctypes.c_wchar_p)
+        assert parser.argtypes == [
+            ctypes.c_wchar_p,
+            ctypes.POINTER(ctypes.c_int),
+        ]
+        assert local_free_calls == [expected]
+
+    def test_split_windows_cmdline_falls_back_on_typeerror(self) -> None:
+        import ctypes
+
+        raw_cmdline = 'codex exec --model "gpt-5" "Run tests"'
+        local_free_calls: list[object] = []
+
+        class FakeCommandLineToArgvW:
+            def __init__(self) -> None:
+                self.restype = None
+                self.argtypes = None
+
+            def __call__(self, cmdline: str, argc_ref: object) -> int:
+                argc_ref._obj.value = 1  # type: ignore[attr-defined]
+                return 123
+
+        class FakeShell32:
+            def __init__(self, parser: FakeCommandLineToArgvW) -> None:
+                self.CommandLineToArgvW = parser
+
+        class FakeKernel32:
+            def LocalFree(self, ptr: object) -> None:
+                local_free_calls.append(ptr)
+
+        parser = FakeCommandLineToArgvW()
+
+        def fake_windll(
+            name: str, *args: object, **kwargs: object
+        ) -> FakeShell32 | FakeKernel32:
+            if name == "shell32":
+                return FakeShell32(parser)
+            if name == "kernel32":
+                return FakeKernel32()
+            raise AssertionError(f"Unexpected DLL: {name}")
+
+        with patch.object(ctypes, "WinDLL", side_effect=fake_windll, create=True):
+            assert _split_windows_cmdline(raw_cmdline) == [
+                "codex",
+                "exec",
+                "--model",
+                "gpt-5",
+                "Run tests",
+            ]
+
+        assert local_free_calls == [123]
+
     def test_get_process_cwd_windows_dispatch(self) -> None:
         with (
             patch(

--- a/gptme/hooks/tests/test_workspace_agents.py
+++ b/gptme/hooks/tests/test_workspace_agents.py
@@ -17,7 +17,11 @@ from gptme.hooks.workspace_agents import (
     _extract_flag,
     _format_agent_line,
     _format_duration,
+    _get_all_pids,
+    _get_process_cmdline,
+    _get_process_cwd,
     _get_process_memory_mb,
+    _get_process_timing,
     _has_flag,
     _init_tracking,
     _parse_etime,
@@ -219,6 +223,76 @@ class TestGetProcessMemoryMb:
     def test_missing_pid_returns_none(self) -> None:
         # PID 2**31 - 1 is effectively guaranteed not to exist.
         assert _get_process_memory_mb(2**31 - 1) is None
+
+
+class TestWindowsProcessIntrospection:
+    def test_get_process_cwd_windows_dispatch(self) -> None:
+        with (
+            patch(
+                "gptme.hooks.workspace_agents.platform.system", return_value="Windows"
+            ),
+            patch(
+                "gptme.hooks.workspace_agents._get_windows_process_strings",
+                return_value=(r"C:\\workspace", "codex exec"),
+            ),
+        ):
+            assert _get_process_cwd(123) == r"C:\\workspace"
+
+    def test_get_process_cmdline_windows_dispatch(self) -> None:
+        raw_cmdline = 'codex exec --model "gpt-5" "Run tests"'
+        expected = ["codex", "exec", "--model", "gpt-5", "Run tests"]
+        with (
+            patch(
+                "gptme.hooks.workspace_agents.platform.system", return_value="Windows"
+            ),
+            patch(
+                "gptme.hooks.workspace_agents._get_windows_process_strings",
+                return_value=(r"C:\\workspace", raw_cmdline),
+            ),
+            patch(
+                "gptme.hooks.workspace_agents._split_windows_cmdline",
+                return_value=expected,
+            ) as mock_split,
+        ):
+            assert _get_process_cmdline(123) == expected
+        mock_split.assert_called_once_with(raw_cmdline)
+
+    def test_get_all_pids_windows_dispatch(self) -> None:
+        with (
+            patch(
+                "gptme.hooks.workspace_agents.platform.system", return_value="Windows"
+            ),
+            patch(
+                "gptme.hooks.workspace_agents._get_windows_pids",
+                return_value=[101, 202],
+            ),
+        ):
+            assert _get_all_pids() == [101, 202]
+
+    def test_get_process_timing_windows_dispatch(self) -> None:
+        expected = (120, 4.5, None)
+        with (
+            patch(
+                "gptme.hooks.workspace_agents.platform.system", return_value="Windows"
+            ),
+            patch(
+                "gptme.hooks.workspace_agents._get_windows_process_timing",
+                return_value=expected,
+            ),
+        ):
+            assert _get_process_timing(123) == expected
+
+    def test_get_process_memory_windows_dispatch(self) -> None:
+        with (
+            patch(
+                "gptme.hooks.workspace_agents.platform.system", return_value="Windows"
+            ),
+            patch(
+                "gptme.hooks.workspace_agents._get_windows_process_memory_mb",
+                return_value=64.0,
+            ),
+        ):
+            assert _get_process_memory_mb(123) == 64.0
 
 
 class TestFormatAgentLineMemory:

--- a/gptme/hooks/workspace_agents.py
+++ b/gptme/hooks/workspace_agents.py
@@ -27,7 +27,7 @@ import time
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from ..hooks import HookType, StopPropagation, register_hook
 from ..message import Message
@@ -132,6 +132,294 @@ class AgentInfo:
 # ---------------------------------------------------------------------------
 
 
+def _split_windows_cmdline(raw_cmdline: str) -> list[str]:
+    """Split a Windows command-line string into argv."""
+    try:
+        import ctypes
+
+        argc = ctypes.c_int()
+        argv = ctypes.windll.shell32.CommandLineToArgvW(  # type: ignore[attr-defined]
+            raw_cmdline, ctypes.byref(argc)
+        )
+        if not argv:
+            raise OSError("CommandLineToArgvW returned null")
+        try:
+            return [argv[i] for i in range(argc.value)]
+        finally:
+            ctypes.windll.kernel32.LocalFree(argv)  # type: ignore[attr-defined]
+    except (AttributeError, OSError, ValueError):
+        try:
+            return shlex.split(raw_cmdline)
+        except ValueError:
+            return [raw_cmdline]
+
+
+def _get_windows_process_strings(pid: int) -> tuple[str | None, str | None]:
+    """Return ``(cwd, command_line)`` for a Windows process."""
+    try:
+        import ctypes
+        from ctypes import wintypes
+    except ImportError:
+        return None, None
+
+    PROCESS_QUERY_INFORMATION = 0x0400
+    PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+    PROCESS_VM_READ = 0x0010
+    process_query_access = (
+        PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_VM_READ,
+        PROCESS_QUERY_INFORMATION | PROCESS_VM_READ,
+    )
+
+    class PROCESS_BASIC_INFORMATION(ctypes.Structure):
+        _fields_ = [
+            ("Reserved1", ctypes.c_void_p),
+            ("PebBaseAddress", ctypes.c_void_p),
+            ("Reserved2_0", ctypes.c_void_p),
+            ("Reserved2_1", ctypes.c_void_p),
+            ("UniqueProcessId", ctypes.c_void_p),
+            ("Reserved3", ctypes.c_void_p),
+        ]
+
+    class UNICODE_STRING(ctypes.Structure):
+        _fields_ = [
+            ("Length", wintypes.USHORT),
+            ("MaximumLength", wintypes.USHORT),
+            ("Buffer", ctypes.c_void_p),
+        ]
+
+    class CURDIR(ctypes.Structure):
+        _fields_ = [
+            ("DosPath", UNICODE_STRING),
+            ("Handle", ctypes.c_void_p),
+        ]
+
+    class RTL_USER_PROCESS_PARAMETERS(ctypes.Structure):
+        _fields_ = [
+            ("MaximumLength", wintypes.ULONG),
+            ("Length", wintypes.ULONG),
+            ("Flags", wintypes.ULONG),
+            ("DebugFlags", wintypes.ULONG),
+            ("ConsoleHandle", ctypes.c_void_p),
+            ("ConsoleFlags", wintypes.ULONG),
+            ("StandardInput", ctypes.c_void_p),
+            ("StandardOutput", ctypes.c_void_p),
+            ("StandardError", ctypes.c_void_p),
+            ("CurrentDirectory", CURDIR),
+            ("DllPath", UNICODE_STRING),
+            ("ImagePathName", UNICODE_STRING),
+            ("CommandLine", UNICODE_STRING),
+        ]
+
+    class PEB(ctypes.Structure):
+        _fields_ = [
+            ("Reserved1", ctypes.c_ubyte * 2),
+            ("BeingDebugged", ctypes.c_ubyte),
+            ("Reserved2", ctypes.c_ubyte),
+            ("Reserved3", ctypes.c_void_p * 2),
+            ("Ldr", ctypes.c_void_p),
+            ("ProcessParameters", ctypes.c_void_p),
+        ]
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)  # type: ignore[attr-defined]
+    ntdll = ctypes.WinDLL("ntdll")  # type: ignore[attr-defined]
+
+    handle = None
+    for access in process_query_access:
+        handle = kernel32.OpenProcess(access, False, pid)
+        if handle:
+            break
+    if not handle:
+        return None, None
+
+    def _read_process_bytes(address: int, size: int) -> bytes | None:
+        if not address or size <= 0:
+            return None
+        buffer = ctypes.create_string_buffer(size)
+        bytes_read = ctypes.c_size_t()
+        ok = kernel32.ReadProcessMemory(
+            handle,
+            ctypes.c_void_p(address),
+            buffer,
+            size,
+            ctypes.byref(bytes_read),
+        )
+        if not ok:
+            return None
+        return buffer.raw[: bytes_read.value]
+
+    def _read_process_struct(address: int, struct_type: type[Any]) -> Any | None:
+        raw = _read_process_bytes(address, ctypes.sizeof(struct_type))
+        if raw is None or len(raw) < ctypes.sizeof(struct_type):
+            return None
+        return struct_type.from_buffer_copy(raw)
+
+    def _read_process_unicode(value: UNICODE_STRING) -> str | None:
+        if not value.Buffer or value.Length == 0:
+            return None
+        raw = _read_process_bytes(int(value.Buffer), int(value.Length))
+        if raw is None:
+            return None
+        return raw.decode("utf-16-le", errors="replace").rstrip("\x00")
+
+    try:
+        pbi = PROCESS_BASIC_INFORMATION()
+        return_length = wintypes.ULONG()
+        status = ntdll.NtQueryInformationProcess(
+            handle,
+            0,  # ProcessBasicInformation
+            ctypes.byref(pbi),
+            ctypes.sizeof(pbi),
+            ctypes.byref(return_length),
+        )
+        if status != 0 or not pbi.PebBaseAddress:
+            return None, None
+
+        peb = cast(PEB | None, _read_process_struct(int(pbi.PebBaseAddress), PEB))
+        if peb is None or not peb.ProcessParameters:
+            return None, None
+
+        proc_params = cast(
+            RTL_USER_PROCESS_PARAMETERS | None,
+            _read_process_struct(
+                int(peb.ProcessParameters), RTL_USER_PROCESS_PARAMETERS
+            ),
+        )
+        if proc_params is None:
+            return None, None
+
+        cwd = _read_process_unicode(proc_params.CurrentDirectory.DosPath)
+        cmdline = _read_process_unicode(proc_params.CommandLine)
+        return cwd, cmdline
+    finally:
+        kernel32.CloseHandle(handle)
+
+
+def _get_windows_pids() -> list[int]:
+    """Enumerate process IDs on Windows."""
+    try:
+        import ctypes
+        from ctypes import wintypes
+    except ImportError:
+        return []
+
+    psapi = ctypes.WinDLL("psapi")  # type: ignore[attr-defined]
+    capacity = 1024
+
+    while True:
+        buffer = (wintypes.DWORD * capacity)()
+        bytes_needed = wintypes.DWORD()
+        ok = psapi.EnumProcesses(
+            ctypes.byref(buffer),
+            ctypes.sizeof(buffer),
+            ctypes.byref(bytes_needed),
+        )
+        if not ok:
+            return []
+        count = bytes_needed.value // ctypes.sizeof(wintypes.DWORD)
+        if count < capacity:
+            return [pid for pid in buffer[:count] if pid]
+        capacity *= 2
+
+
+def _get_windows_process_timing(
+    pid: int,
+) -> tuple[int | None, float | None, str | None]:
+    """Get Windows process uptime and CPU time."""
+    try:
+        import ctypes
+        from ctypes import wintypes
+    except ImportError:
+        return None, None, None
+
+    PROCESS_QUERY_INFORMATION = 0x0400
+    PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+    access = PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_QUERY_INFORMATION
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)  # type: ignore[attr-defined]
+    handle = kernel32.OpenProcess(access, False, pid)
+    if not handle:
+        return None, None, None
+
+    def _filetime_to_seconds(filetime: wintypes.FILETIME) -> float:
+        ticks = (filetime.dwHighDateTime << 32) | filetime.dwLowDateTime
+        return ticks / 10_000_000.0
+
+    def _filetime_to_unix(filetime: wintypes.FILETIME) -> float:
+        return _filetime_to_seconds(filetime) - 11_644_473_600.0
+
+    try:
+        creation = wintypes.FILETIME()
+        exit_time = wintypes.FILETIME()
+        kernel_time = wintypes.FILETIME()
+        user_time = wintypes.FILETIME()
+        ok = kernel32.GetProcessTimes(
+            handle,
+            ctypes.byref(creation),
+            ctypes.byref(exit_time),
+            ctypes.byref(kernel_time),
+            ctypes.byref(user_time),
+        )
+        if not ok:
+            return None, None, None
+
+        creation_unix = _filetime_to_unix(creation)
+        uptime = max(0, int(time.time() - creation_unix))
+        cpu = _filetime_to_seconds(kernel_time) + _filetime_to_seconds(user_time)
+        return uptime, cpu, None
+    finally:
+        kernel32.CloseHandle(handle)
+
+
+def _get_windows_process_memory_mb(pid: int) -> float | None:
+    """Get Windows process resident memory in MB."""
+    try:
+        import ctypes
+        from ctypes import wintypes
+    except ImportError:
+        return None
+
+    PROCESS_QUERY_INFORMATION = 0x0400
+    PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+    PROCESS_VM_READ = 0x0010
+    access = (
+        PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_QUERY_INFORMATION | PROCESS_VM_READ
+    )
+
+    class PROCESS_MEMORY_COUNTERS(ctypes.Structure):
+        _fields_ = [
+            ("cb", wintypes.DWORD),
+            ("PageFaultCount", wintypes.DWORD),
+            ("PeakWorkingSetSize", ctypes.c_size_t),
+            ("WorkingSetSize", ctypes.c_size_t),
+            ("QuotaPeakPagedPoolUsage", ctypes.c_size_t),
+            ("QuotaPagedPoolUsage", ctypes.c_size_t),
+            ("QuotaPeakNonPagedPoolUsage", ctypes.c_size_t),
+            ("QuotaNonPagedPoolUsage", ctypes.c_size_t),
+            ("PagefileUsage", ctypes.c_size_t),
+            ("PeakPagefileUsage", ctypes.c_size_t),
+        ]
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)  # type: ignore[attr-defined]
+    psapi = ctypes.WinDLL("psapi")  # type: ignore[attr-defined]
+    handle = kernel32.OpenProcess(access, False, pid)
+    if not handle:
+        return None
+
+    try:
+        counters = PROCESS_MEMORY_COUNTERS()
+        counters.cb = ctypes.sizeof(PROCESS_MEMORY_COUNTERS)
+        ok = psapi.GetProcessMemoryInfo(
+            handle,
+            ctypes.byref(counters),
+            counters.cb,
+        )
+        if not ok:
+            return None
+        return counters.WorkingSetSize / (1024.0 * 1024.0)
+    finally:
+        kernel32.CloseHandle(handle)
+
+
 def _get_process_cwd(pid: int) -> str | None:
     """Get process CWD, cross-platform."""
     system = platform.system()
@@ -157,7 +445,9 @@ def _get_process_cwd(pid: int) -> str | None:
             FileNotFoundError,
         ):
             return None
-    # TODO: Windows — use wmic or ctypes
+    elif system == "Windows":
+        cwd, _ = _get_windows_process_strings(pid)
+        return cwd
     return None
 
 
@@ -186,7 +476,11 @@ def _get_process_cmdline(pid: int) -> list[str]:
             ValueError,
         ):
             return []
-    # TODO: Windows — use wmic
+    elif system == "Windows":
+        _, raw_cmdline = _get_windows_process_strings(pid)
+        if not raw_cmdline:
+            return []
+        return _split_windows_cmdline(raw_cmdline)
     return []
 
 
@@ -207,7 +501,8 @@ def _get_all_pids() -> list[int]:
             FileNotFoundError,
         ):
             return []
-    # TODO: Windows — use tasklist or ctypes
+    if system == "Windows":
+        return _get_windows_pids()
     return []
 
 
@@ -271,6 +566,8 @@ def _get_process_timing(pid: int) -> tuple[int | None, float | None, str | None]
             FileNotFoundError,
         ):
             return None, None, None
+    elif system == "Windows":
+        return _get_windows_process_timing(pid)
     return None, None, None
 
 
@@ -311,7 +608,8 @@ def _get_process_memory_mb(pid: int) -> float | None:
             ValueError,
         ):
             return None
-    # TODO: Windows
+    elif system == "Windows":
+        return _get_windows_process_memory_mb(pid)
     return None
 
 

--- a/gptme/hooks/workspace_agents.py
+++ b/gptme/hooks/workspace_agents.py
@@ -137,17 +137,23 @@ def _split_windows_cmdline(raw_cmdline: str) -> list[str]:
     try:
         import ctypes
 
+        shell32 = ctypes.WinDLL("shell32")  # type: ignore[attr-defined]
+        shell32.CommandLineToArgvW.restype = ctypes.POINTER(ctypes.c_wchar_p)
+        shell32.CommandLineToArgvW.argtypes = [
+            ctypes.c_wchar_p,
+            ctypes.POINTER(ctypes.c_int),
+        ]
+        kernel32 = ctypes.WinDLL("kernel32")  # type: ignore[attr-defined]
+
         argc = ctypes.c_int()
-        argv = ctypes.windll.shell32.CommandLineToArgvW(  # type: ignore[attr-defined]
-            raw_cmdline, ctypes.byref(argc)
-        )
+        argv = shell32.CommandLineToArgvW(raw_cmdline, ctypes.byref(argc))
         if not argv:
             raise OSError("CommandLineToArgvW returned null")
         try:
             return [argv[i] for i in range(argc.value)]
         finally:
-            ctypes.windll.kernel32.LocalFree(argv)  # type: ignore[attr-defined]
-    except (AttributeError, OSError, ValueError):
+            kernel32.LocalFree(argv)
+    except (AttributeError, OSError, TypeError, ValueError):
         try:
             return shlex.split(raw_cmdline)
         except ValueError:


### PR DESCRIPTION
## Summary
- add Windows process introspection helpers for `workspace_agents`
- wire process cwd, command line, PID enumeration, uptime, and memory lookups through the Windows path
- add mocked Windows dispatch tests so Linux CI covers the new branches

## Why
The hook already supports Linux and macOS, but Windows still had hard TODOs in the core process-discovery path. That meant `scan_agents()` silently skipped every Windows process because it could not enumerate PIDs or resolve process metadata.

## Test plan
- `uv run ruff check gptme/hooks/workspace_agents.py gptme/hooks/tests/test_workspace_agents.py`
- `uv run --with pytest python3 -m pytest gptme/hooks/tests/test_workspace_agents.py -q`
- `uv run --with pytest python3 -m pytest tests/test_workspace_agents.py -q`
- pre-commit via `git commit`
