### PR TITLE
feat(hooks): trace sync hook execution spans

### DIFF
--- a/gptme/hooks/registry.py
+++ b/gptme/hooks/registry.py
@@ -40,6 +40,34 @@ from .types import (
 logger = logging.getLogger(__name__)
 
 
+def _record_sync_hook_call(
+    hook: Hook,
+    duration: float,
+    *,
+    success: bool,
+    error: Exception | None = None,
+    start_time_ns: int | None = None,
+) -> None:
+    """Record hook telemetry without letting tracing failures break hook execution."""
+    try:
+        from ..telemetry import record_hook_call
+
+        record_hook_call(
+            hook_name=hook.name,
+            hook_type=hook.hook_type.value,
+            async_mode=hook.async_mode,
+            duration=duration,
+            success=success,
+            error_type=type(error).__name__ if error else None,
+            error_message=str(error) if error else None,
+            start_time_ns=start_time_ns,
+        )
+    except Exception:
+        logger.debug(
+            "Failed to record telemetry for hook '%s'", hook.name, exc_info=True
+        )
+
+
 class HookRegistry:
     """Registry for managing hooks."""
 
@@ -153,17 +181,12 @@ class HookRegistry:
 
         # Process sync hooks as before (yielding messages)
         for hook in sync_hooks:
+            t_start = time()
+            start_time_ns = int(t_start * 1_000_000_000)
+            t_delta = 0.0
             try:
-                # TODO: emit span for tracing
-                t_start = time()
                 result = hook.func(*args, **kwargs)
-                t_end = time()
-                t_delta = t_end - t_start
-                logger.debug(f"Hook '{hook.name}' took {t_delta:.4f}s")
-                if t_delta > 5.0:
-                    logger.warning(
-                        f"Hook '{hook.name}' is taking a long time ({t_delta:.4f}s)"
-                    )
+                t_delta = time() - t_start
 
                 # If hook returns a generator, yield from it
                 # Note: ToolConfirmHooks may return None (fall-through) or ConfirmationResult
@@ -173,9 +196,32 @@ class HookRegistry:
                     and not isinstance(result, str | bytes)
                 ):
                     try:
-                        for msg in result:
+                        iterator = iter(result)
+                        while True:
+                            t_next_start = time()
+                            try:
+                                msg = next(iterator)
+                            except StopIteration:
+                                t_delta += time() - t_next_start
+                                break
+                            except Exception:
+                                t_delta += time() - t_next_start
+                                raise
+
+                            t_delta += time() - t_next_start
                             if isinstance(msg, StopPropagation):
                                 logger.debug(f"Hook '{hook.name}' stopped propagation")
+                                logger.debug(f"Hook '{hook.name}' took {t_delta:.4f}s")
+                                if t_delta > 5.0:
+                                    logger.warning(
+                                        f"Hook '{hook.name}' is taking a long time ({t_delta:.4f}s)"
+                                    )
+                                _record_sync_hook_call(
+                                    hook,
+                                    t_delta,
+                                    success=True,
+                                    start_time_ns=start_time_ns,
+                                )
                                 return  # Stop processing remaining hooks
                             elif isinstance(msg, Message):
                                 yield msg
@@ -188,9 +234,41 @@ class HookRegistry:
                 # If hook returns StopPropagation, stop
                 elif isinstance(result, StopPropagation):
                     logger.debug(f"Hook '{hook.name}' stopped propagation")
+                    logger.debug(f"Hook '{hook.name}' took {t_delta:.4f}s")
+                    if t_delta > 5.0:
+                        logger.warning(
+                            f"Hook '{hook.name}' is taking a long time ({t_delta:.4f}s)"
+                        )
+                    _record_sync_hook_call(
+                        hook,
+                        t_delta,
+                        success=True,
+                        start_time_ns=start_time_ns,
+                    )
                     return
 
+                logger.debug(f"Hook '{hook.name}' took {t_delta:.4f}s")
+                if t_delta > 5.0:
+                    logger.warning(
+                        f"Hook '{hook.name}' is taking a long time ({t_delta:.4f}s)"
+                    )
+                _record_sync_hook_call(
+                    hook,
+                    t_delta,
+                    success=True,
+                    start_time_ns=start_time_ns,
+                )
+
             except Exception as e:
+                if t_delta == 0.0:
+                    t_delta = time() - t_start
+                _record_sync_hook_call(
+                    hook,
+                    t_delta,
+                    success=False,
+                    error=e,
+                    start_time_ns=start_time_ns,
+                )
                 # Special handling for session termination
                 if e.__class__.__name__ == "SessionCompleteException":
                     logger.info(f"Hook '{hook.name}' signaled session completion")

--- a/gptme/telemetry.py
+++ b/gptme/telemetry.py
@@ -40,6 +40,7 @@ __all__ = [
     "record_tokens",
     "record_request_duration",
     "record_tool_call",
+    "record_hook_call",
     "record_conversation_change",
     "record_llm_request",
     "measure_tokens_per_second",
@@ -233,6 +234,64 @@ def record_tool_call(
 
     if duration is not None and tool_duration_histogram is not None:
         tool_duration_histogram.record(duration, attributes)
+
+
+def record_hook_call(
+    hook_name: str,
+    hook_type: str,
+    async_mode: bool,
+    duration: float,
+    success: bool = True,
+    error_type: str | None = None,
+    error_message: str | None = None,
+    start_time_ns: int | None = None,
+) -> None:
+    """Record hook execution spans for Jaeger analysis."""
+    if not is_telemetry_enabled():
+        return
+
+    telemetry_objects = get_telemetry_objects()
+    tracer = telemetry_objects["tracer"]
+
+    if tracer is None:
+        return
+
+    span_kwargs: dict[str, Any] = {}
+    if start_time_ns is not None:
+        span_kwargs["start_time"] = start_time_ns
+
+    span = tracer.start_span(f"hook.{hook_type}.{hook_name}", **span_kwargs)
+    try:
+        enrich_span_with_context(span)
+        span.set_attribute("hook.name", hook_name)
+        span.set_attribute("hook.type", hook_type)
+        span.set_attribute("hook.async_mode", async_mode)
+        span.set_attribute("hook.success", success)
+        span.set_attribute("hook.duration_seconds", duration)
+        if error_type:
+            span.set_attribute("hook.error.type", error_type)
+        if error_message:
+            span.set_attribute("hook.error.message", error_message[:200])
+
+        if success:
+            span.add_event(
+                "hook_completed",
+                attributes={"hook": hook_name, "hook_type": hook_type},
+            )
+        else:
+            span.add_event(
+                "hook_failed",
+                attributes={
+                    "hook": hook_name,
+                    "hook_type": hook_type,
+                    "error_type": error_type or "unknown",
+                },
+            )
+    finally:
+        if start_time_ns is None:
+            span.end()
+        else:
+            span.end(end_time=start_time_ns + int(duration * 1_000_000_000))
 
 
 def record_conversation_change(delta: int) -> None:

--- a/tests/test_hooks_registry.py
+++ b/tests/test_hooks_registry.py
@@ -409,6 +409,71 @@ class TestTriggerSync:
         assert "from hook 1" in contents
         assert "from hook 2" in contents
 
+    def test_trigger_records_hook_telemetry_for_generator_runtime(self):
+        registry = HookRegistry()
+        msg = Message("system", "hello from hook")
+        registry.register("telemetry-hook", HookType.STEP_PRE, _make_hook_func([msg]))
+
+        with (
+            unittest.mock.patch(
+                "gptme.hooks.registry.time",
+                side_effect=[10.0, 10.1, 10.2, 10.8, 11.0, 11.3],
+            ),
+            unittest.mock.patch("gptme.telemetry.record_hook_call") as mock_record,
+        ):
+            messages = list(registry.trigger(HookType.STEP_PRE))
+
+        assert len(messages) == 1
+        mock_record.assert_called_once()
+        kwargs = mock_record.call_args.kwargs
+        assert kwargs["hook_name"] == "telemetry-hook"
+        assert kwargs["hook_type"] == HookType.STEP_PRE.value
+        assert kwargs["async_mode"] is False
+        assert kwargs["success"] is True
+        assert kwargs["duration"] == pytest.approx(1.0)
+        assert kwargs["start_time_ns"] == 10_000_000_000
+
+    def test_trigger_records_hook_telemetry_for_errors(self):
+        registry = HookRegistry()
+        tracker: list[str] = []
+
+        registry.register(
+            "error-hook",
+            HookType.STEP_PRE,
+            _make_error_hook(ValueError("test error")),
+            priority=10,
+        )
+        registry.register(
+            "good-hook",
+            HookType.STEP_PRE,
+            _make_tracking_hook(tracker, "good"),
+            priority=1,
+        )
+
+        with (
+            unittest.mock.patch(
+                "gptme.hooks.registry.time",
+                side_effect=[20.0, 20.4, 30.0, 30.2],
+            ),
+            unittest.mock.patch("gptme.telemetry.record_hook_call") as mock_record,
+        ):
+            list(registry.trigger(HookType.STEP_PRE))
+
+        assert "good" in tracker
+        assert mock_record.call_count == 2
+
+        error_call = mock_record.call_args_list[0].kwargs
+        assert error_call["hook_name"] == "error-hook"
+        assert error_call["success"] is False
+        assert error_call["error_type"] == "ValueError"
+        assert error_call["error_message"] == "test error"
+        assert error_call["duration"] == pytest.approx(0.4)
+
+        success_call = mock_record.call_args_list[1].kwargs
+        assert success_call["hook_name"] == "good-hook"
+        assert success_call["success"] is True
+        assert success_call["duration"] == pytest.approx(0.2)
+
 
 # ── HookRegistry: StopPropagation ────────────────────────────────────
 

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -79,3 +79,75 @@ def test_pushgateway_periodic_push(monkeypatch):
 
         # Cleanup
         shutdown_telemetry()
+
+
+def test_record_hook_call_records_span():
+    """Hook spans should preserve timing and attributes for tracing."""
+    from gptme.telemetry import record_hook_call
+
+    class FakeSpan:
+        def __init__(self, name, start_time=None):
+            self.name = name
+            self.start_time = start_time
+            self.attributes = {}
+            self.events = []
+            self.end_time = None
+
+        def set_attribute(self, key, value):
+            self.attributes[key] = value
+
+        def add_event(self, name, attributes=None):
+            self.events.append((name, attributes))
+
+        def end(self, end_time=None):
+            self.end_time = end_time
+
+    class FakeTracer:
+        def __init__(self):
+            self.spans = []
+
+        def start_span(self, name, **kwargs):
+            span = FakeSpan(name, kwargs.get("start_time"))
+            self.spans.append(span)
+            return span
+
+    tracer = FakeTracer()
+
+    with (
+        patch("gptme.telemetry.is_telemetry_enabled", return_value=True),
+        patch("gptme.telemetry.get_telemetry_objects", return_value={"tracer": tracer}),
+        patch("gptme.telemetry.enrich_span_with_context"),
+    ):
+        record_hook_call(
+            hook_name="hook-a",
+            hook_type="step.pre",
+            async_mode=False,
+            duration=1.25,
+            success=False,
+            error_type="ValueError",
+            error_message="bad hook",
+            start_time_ns=123,
+        )
+
+    assert len(tracer.spans) == 1
+    span = tracer.spans[0]
+    assert span.name == "hook.step.pre.hook-a"
+    assert span.start_time == 123
+    assert span.end_time == 1_250_000_123
+    assert span.attributes["hook.name"] == "hook-a"
+    assert span.attributes["hook.type"] == "step.pre"
+    assert span.attributes["hook.async_mode"] is False
+    assert span.attributes["hook.success"] is False
+    assert span.attributes["hook.duration_seconds"] == 1.25
+    assert span.attributes["hook.error.type"] == "ValueError"
+    assert span.attributes["hook.error.message"] == "bad hook"
+    assert span.events == [
+        (
+            "hook_failed",
+            {
+                "hook": "hook-a",
+                "hook_type": "step.pre",
+                "error_type": "ValueError",
+            },
+        )
+    ]


### PR DESCRIPTION
## Summary
- add hook-level telemetry spans without forcing eager OpenTelemetry imports
- measure sync hook runtime across generator iteration and direct returns
- cover telemetry recording and hook error paths with focused tests

## Testing
- PYTHONPATH=/tmp/worktrees/gptme-hooks-bf8c /home/bob/gptme/.venv/bin/python -m pytest /tmp/worktrees/gptme-hooks-bf8c/tests/test_hooks_registry.py -q
- PYTHONPATH=/tmp/worktrees/gptme-hooks-bf8c /home/bob/gptme/.venv/bin/python -m pytest /tmp/worktrees/gptme-hooks-bf8c/tests/test_telemetry.py -q
- uv run ruff check /tmp/worktrees/gptme-hooks-bf8c/gptme/hooks/registry.py /tmp/worktrees/gptme-hooks-bf8c/gptme/telemetry.py /tmp/worktrees/gptme-hooks-bf8c/tests/test_hooks_registry.py /tmp/worktrees/gptme-hooks-bf8c/tests/test_telemetry.py