### PR TITLE
fix(hooks): harden Windows process handles

### DIFF
--- a/gptme/hooks/tests/test_workspace_agents.py
+++ b/gptme/hooks/tests/test_workspace_agents.py
@@ -360,14 +360,25 @@ class TestWindowsProcessIntrospection:
         ):
             assert _get_process_cwd(123) == r"C:\\workspace"
 
-    def test_get_process_cwd_windows_dispatch_handles_lookup_error(self) -> None:
+    @pytest.mark.parametrize(
+        "error",
+        [
+            OSError("boom"),
+            AttributeError("boom"),
+            TypeError("boom"),
+            ValueError("boom"),
+        ],
+    )
+    def test_get_process_cwd_windows_dispatch_handles_lookup_error(
+        self, error: Exception
+    ) -> None:
         with (
             patch(
                 "gptme.hooks.workspace_agents.platform.system", return_value="Windows"
             ),
             patch(
                 "gptme.hooks.workspace_agents._get_windows_process_strings",
-                side_effect=OSError("boom"),
+                side_effect=error,
             ),
         ):
             assert _get_process_cwd(123) is None
@@ -391,14 +402,25 @@ class TestWindowsProcessIntrospection:
             assert _get_process_cmdline(123) == expected
         mock_split.assert_called_once_with(raw_cmdline)
 
-    def test_get_process_cmdline_windows_dispatch_handles_lookup_error(self) -> None:
+    @pytest.mark.parametrize(
+        "error",
+        [
+            OSError("boom"),
+            AttributeError("boom"),
+            TypeError("boom"),
+            ValueError("boom"),
+        ],
+    )
+    def test_get_process_cmdline_windows_dispatch_handles_lookup_error(
+        self, error: Exception
+    ) -> None:
         with (
             patch(
                 "gptme.hooks.workspace_agents.platform.system", return_value="Windows"
             ),
             patch(
                 "gptme.hooks.workspace_agents._get_windows_process_strings",
-                side_effect=OSError("boom"),
+                side_effect=error,
             ),
         ):
             assert _get_process_cmdline(123) == []
@@ -428,6 +450,29 @@ class TestWindowsProcessIntrospection:
         ):
             assert _get_process_timing(123) == expected
 
+    @pytest.mark.parametrize(
+        "error",
+        [
+            OSError("boom"),
+            AttributeError("boom"),
+            TypeError("boom"),
+            ValueError("boom"),
+        ],
+    )
+    def test_get_process_timing_windows_dispatch_handles_lookup_error(
+        self, error: Exception
+    ) -> None:
+        with (
+            patch(
+                "gptme.hooks.workspace_agents.platform.system", return_value="Windows"
+            ),
+            patch(
+                "gptme.hooks.workspace_agents._get_windows_process_timing",
+                side_effect=error,
+            ),
+        ):
+            assert _get_process_timing(123) == (None, None, None)
+
     def test_get_process_memory_windows_dispatch(self) -> None:
         with (
             patch(
@@ -439,6 +484,29 @@ class TestWindowsProcessIntrospection:
             ),
         ):
             assert _get_process_memory_mb(123) == 64.0
+
+    @pytest.mark.parametrize(
+        "error",
+        [
+            OSError("boom"),
+            AttributeError("boom"),
+            TypeError("boom"),
+            ValueError("boom"),
+        ],
+    )
+    def test_get_process_memory_windows_dispatch_handles_lookup_error(
+        self, error: Exception
+    ) -> None:
+        with (
+            patch(
+                "gptme.hooks.workspace_agents.platform.system", return_value="Windows"
+            ),
+            patch(
+                "gptme.hooks.workspace_agents._get_windows_process_memory_mb",
+                side_effect=error,
+            ),
+        ):
+            assert _get_process_memory_mb(123) is None
 
 
 class TestFormatAgentLineMemory:

--- a/gptme/hooks/tests/test_workspace_agents.py
+++ b/gptme/hooks/tests/test_workspace_agents.py
@@ -14,6 +14,7 @@ import pytest
 from gptme.hooks.workspace_agents import (
     AGENT_BINARIES,
     AgentInfo,
+    _configure_windows_kernel32_process_functions,
     _extract_flag,
     _format_agent_line,
     _format_duration,
@@ -227,6 +228,33 @@ class TestGetProcessMemoryMb:
 
 
 class TestWindowsProcessIntrospection:
+    def test_configure_windows_kernel32_process_functions(self) -> None:
+        import ctypes
+        from ctypes import wintypes
+
+        class FakeFunction:
+            def __init__(self) -> None:
+                self.argtypes = None
+                self.restype = None
+
+        class FakeKernel32:
+            def __init__(self) -> None:
+                self.OpenProcess = FakeFunction()
+                self.CloseHandle = FakeFunction()
+
+        kernel32 = FakeKernel32()
+
+        _configure_windows_kernel32_process_functions(kernel32, ctypes, wintypes)
+
+        assert kernel32.OpenProcess.argtypes == [
+            wintypes.DWORD,
+            wintypes.BOOL,
+            wintypes.DWORD,
+        ]
+        assert kernel32.OpenProcess.restype == wintypes.HANDLE
+        assert kernel32.CloseHandle.argtypes == [wintypes.HANDLE]
+        assert kernel32.CloseHandle.restype == wintypes.BOOL
+
     def test_split_windows_cmdline_direct(self) -> None:
         import ctypes
 
@@ -332,6 +360,18 @@ class TestWindowsProcessIntrospection:
         ):
             assert _get_process_cwd(123) == r"C:\\workspace"
 
+    def test_get_process_cwd_windows_dispatch_handles_lookup_error(self) -> None:
+        with (
+            patch(
+                "gptme.hooks.workspace_agents.platform.system", return_value="Windows"
+            ),
+            patch(
+                "gptme.hooks.workspace_agents._get_windows_process_strings",
+                side_effect=OSError("boom"),
+            ),
+        ):
+            assert _get_process_cwd(123) is None
+
     def test_get_process_cmdline_windows_dispatch(self) -> None:
         raw_cmdline = 'codex exec --model "gpt-5" "Run tests"'
         expected = ["codex", "exec", "--model", "gpt-5", "Run tests"]
@@ -350,6 +390,18 @@ class TestWindowsProcessIntrospection:
         ):
             assert _get_process_cmdline(123) == expected
         mock_split.assert_called_once_with(raw_cmdline)
+
+    def test_get_process_cmdline_windows_dispatch_handles_lookup_error(self) -> None:
+        with (
+            patch(
+                "gptme.hooks.workspace_agents.platform.system", return_value="Windows"
+            ),
+            patch(
+                "gptme.hooks.workspace_agents._get_windows_process_strings",
+                side_effect=OSError("boom"),
+            ),
+        ):
+            assert _get_process_cmdline(123) == []
 
     def test_get_all_pids_windows_dispatch(self) -> None:
         with (

--- a/gptme/hooks/workspace_agents.py
+++ b/gptme/hooks/workspace_agents.py
@@ -160,6 +160,20 @@ def _split_windows_cmdline(raw_cmdline: str) -> list[str]:
             return [raw_cmdline]
 
 
+def _configure_windows_kernel32_process_functions(
+    kernel32: Any, ctypes_module: Any, wintypes_module: Any
+) -> None:
+    """Set Win32 function signatures used for process handles."""
+    kernel32.OpenProcess.argtypes = [
+        wintypes_module.DWORD,
+        wintypes_module.BOOL,
+        wintypes_module.DWORD,
+    ]
+    kernel32.OpenProcess.restype = wintypes_module.HANDLE
+    kernel32.CloseHandle.argtypes = [wintypes_module.HANDLE]
+    kernel32.CloseHandle.restype = wintypes_module.BOOL
+
+
 def _get_windows_process_strings(pid: int) -> tuple[str | None, str | None]:
     """Return ``(cwd, command_line)`` for a Windows process."""
     try:
@@ -228,6 +242,7 @@ def _get_windows_process_strings(pid: int) -> tuple[str | None, str | None]:
 
     kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)  # type: ignore[attr-defined]
     ntdll = ctypes.WinDLL("ntdll")  # type: ignore[attr-defined]
+    _configure_windows_kernel32_process_functions(kernel32, ctypes, wintypes)
 
     handle = None
     for access in process_query_access:
@@ -342,6 +357,7 @@ def _get_windows_process_timing(
     access = PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_QUERY_INFORMATION
 
     kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)  # type: ignore[attr-defined]
+    _configure_windows_kernel32_process_functions(kernel32, ctypes, wintypes)
     handle = kernel32.OpenProcess(access, False, pid)
     if not handle:
         return None, None, None
@@ -407,6 +423,7 @@ def _get_windows_process_memory_mb(pid: int) -> float | None:
 
     kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)  # type: ignore[attr-defined]
     psapi = ctypes.WinDLL("psapi")  # type: ignore[attr-defined]
+    _configure_windows_kernel32_process_functions(kernel32, ctypes, wintypes)
     handle = kernel32.OpenProcess(access, False, pid)
     if not handle:
         return None
@@ -452,8 +469,11 @@ def _get_process_cwd(pid: int) -> str | None:
         ):
             return None
     elif system == "Windows":
-        cwd, _ = _get_windows_process_strings(pid)
-        return cwd
+        try:
+            cwd, _ = _get_windows_process_strings(pid)
+            return cwd
+        except (AttributeError, OSError, TypeError, ValueError):
+            return None
     return None
 
 
@@ -483,7 +503,10 @@ def _get_process_cmdline(pid: int) -> list[str]:
         ):
             return []
     elif system == "Windows":
-        _, raw_cmdline = _get_windows_process_strings(pid)
+        try:
+            _, raw_cmdline = _get_windows_process_strings(pid)
+        except (AttributeError, OSError, TypeError, ValueError):
+            return []
         if not raw_cmdline:
             return []
         return _split_windows_cmdline(raw_cmdline)

--- a/gptme/hooks/workspace_agents.py
+++ b/gptme/hooks/workspace_agents.py
@@ -596,7 +596,10 @@ def _get_process_timing(pid: int) -> tuple[int | None, float | None, str | None]
         ):
             return None, None, None
     elif system == "Windows":
-        return _get_windows_process_timing(pid)
+        try:
+            return _get_windows_process_timing(pid)
+        except (AttributeError, OSError, TypeError, ValueError):
+            return None, None, None
     return None, None, None
 
 
@@ -638,7 +641,10 @@ def _get_process_memory_mb(pid: int) -> float | None:
         ):
             return None
     elif system == "Windows":
-        return _get_windows_process_memory_mb(pid)
+        try:
+            return _get_windows_process_memory_mb(pid)
+        except (AttributeError, OSError, TypeError, ValueError):
+            return None
     return None
 
 


### PR DESCRIPTION
## Summary
- set explicit `OpenProcess`/`CloseHandle` ctypes signatures in the Windows helpers
- make Windows cwd/cmdline dispatch return safe defaults when process lookup fails
- add focused tests for the handle signatures and defensive wrappers

Follow-up to #2420, which merged before this hardening commit landed.

## Test plan
- `uv run ruff check gptme/hooks/workspace_agents.py gptme/hooks/tests/test_workspace_agents.py`
- `uv run --with pytest python3 -m pytest gptme/hooks/tests/test_workspace_agents.py -q`
- `uv run --with pytest python3 -m pytest tests/test_workspace_agents.py -q`