### PR TITLE
fix(tools): warn when plain allowlists drop MCP tools

### DIFF
--- a/gptme/tools/__init__.py
+++ b/gptme/tools/__init__.py
@@ -120,6 +120,8 @@ def _discover_tools(module_names: list[str]) -> list[ToolSpec]:
 
 # Global lock for thread-safe tool initialization
 _tools_init_lock = threading.Lock()
+_warned_mcp_allowlists: set[tuple[str, ...]] = set()
+_warned_mcp_allowlists_lock = threading.Lock()
 
 
 def _init_single_tool(tool: ToolSpec) -> ToolSpec:
@@ -261,11 +263,17 @@ def get_toolchain(
                 continue
         tools.append(tool)
     if skipped_mcp_tools:
-        logger.warning(
-            "Tool allowlist excluded MCP tools: %s. Add glob patterns like "
-            "'<server>.*' to include grouped MCP tools.",
-            ", ".join(sorted(skipped_mcp_tools)),
-        )
+        allowlist_key = tuple(allowlist or [])
+        with _warned_mcp_allowlists_lock:
+            should_warn = allowlist_key not in _warned_mcp_allowlists
+            if should_warn:
+                _warned_mcp_allowlists.add(allowlist_key)
+        if should_warn:
+            logger.warning(
+                "Tool allowlist excluded MCP tools: %s. Add glob patterns like "
+                "'<server>.*' to include grouped MCP tools.",
+                ", ".join(sorted(skipped_mcp_tools)),
+            )
     return tools
 
 
@@ -387,6 +395,8 @@ def clear_tools():
     """Clear all context-local tool state."""
     _set_available_tools_cache(None)
     _loaded_tools_var.set([])
+    with _warned_mcp_allowlists_lock:
+        _warned_mcp_allowlists.clear()
 
 
 def get_tools() -> list[ToolSpec]:

--- a/gptme/tools/__init__.py
+++ b/gptme/tools/__init__.py
@@ -6,7 +6,6 @@ import logging
 import pkgutil
 import threading
 from contextvars import ContextVar
-from fnmatch import fnmatchcase
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -16,6 +15,11 @@ from ..plugins import get_plugin_tool_modules
 from ..telemetry import trace_function
 from ..util.interrupt import clear_interruptible
 from ..util.terminal import terminal_state_title
+from ._allowlist import (
+    allowlist_contains_glob,
+    matching_allowlist_tools,
+    tool_matches_allowlist,
+)
 from .base import (
     Parameter,
     ToolFormat,
@@ -130,18 +134,6 @@ def _init_single_tool(tool: ToolSpec) -> ToolSpec:
     return tool
 
 
-def _matching_allowlist_tools(pattern: str, tools: list[ToolSpec]) -> list[ToolSpec]:
-    """Return tools matched by an allowlist entry."""
-
-    return [tool for tool in tools if fnmatchcase(tool.name, pattern)]
-
-
-def _tool_matches_allowlist(tool_name: str, allowlist: list[str]) -> bool:
-    """Return True when a tool name matches any allowlist entry."""
-
-    return any(fnmatchcase(tool_name, pattern) for pattern in allowlist)
-
-
 def init_tools(
     allowlist: list[str] | None = None,
 ) -> list[ToolSpec]:
@@ -201,13 +193,14 @@ def init_tools(
 
         available_tools = get_available_tools()
         for tool_name in tool_names:
-            if _matching_allowlist_tools(tool_name, loaded_tools):
+            if matching_allowlist_tools(tool_name, loaded_tools):
                 continue
-            matched_available = _matching_allowlist_tools(tool_name, available_tools)
+            matched_available = matching_allowlist_tools(tool_name, available_tools)
             if matched_available:
                 if any(tool.is_available for tool in matched_available):
                     raise ValueError(
-                        f"Tool '{tool_name}' matched available tools but none were loaded"
+                        f"Tool '{tool_name}' matched available tools that should "
+                        "have been loaded but were not found in loaded_tools"
                     )
                 logger.warning("Tool %s found but is unavailable", tool_name)
                 continue
@@ -228,7 +221,7 @@ def get_toolchain(
         available_tool_names = [tool.name for tool in available_tools]
 
         for tool_name in allowlist:
-            matched_tools = _matching_allowlist_tools(tool_name, available_tools)
+            matched_tools = matching_allowlist_tools(tool_name, available_tools)
             if not matched_tools:
                 if strict:
                     raise ValueError(
@@ -249,11 +242,17 @@ def get_toolchain(
                 continue
 
     tools = []
+    warn_on_skipped_mcp = False
+    if allowlist:
+        warn_on_skipped_mcp = not allowlist_contains_glob(allowlist)
+    skipped_mcp_tools = []
     for tool in get_available_tools():
-        explicitly_allowed = allowlist is not None and _tool_matches_allowlist(
+        explicitly_allowed = allowlist is not None and tool_matches_allowlist(
             tool.name, allowlist
         )
         if allowlist is not None and not explicitly_allowed:
+            if warn_on_skipped_mcp and tool.is_mcp and tool.is_available:
+                skipped_mcp_tools.append(tool.name)
             continue
         if not tool.is_available:
             continue
@@ -261,6 +260,12 @@ def get_toolchain(
             if not explicitly_allowed:
                 continue
         tools.append(tool)
+    if skipped_mcp_tools:
+        logger.warning(
+            "Tool allowlist excluded MCP tools: %s. Add glob patterns like "
+            "'<server>.*' to include grouped MCP tools.",
+            ", ".join(sorted(skipped_mcp_tools)),
+        )
     return tools
 
 

--- a/gptme/tools/_allowlist.py
+++ b/gptme/tools/_allowlist.py
@@ -1,0 +1,21 @@
+from fnmatch import fnmatchcase
+
+from .base import ToolSpec
+
+
+def allowlist_contains_glob(allowlist: list[str]) -> bool:
+    """Return True when any allowlist entry uses shell-glob syntax."""
+
+    return any(any(char in pattern for char in "*?[") for pattern in allowlist)
+
+
+def matching_allowlist_tools(pattern: str, tools: list[ToolSpec]) -> list[ToolSpec]:
+    """Return tools matched by an allowlist entry."""
+
+    return [tool for tool in tools if fnmatchcase(tool.name, pattern)]
+
+
+def tool_matches_allowlist(tool_name: str, allowlist: list[str]) -> bool:
+    """Return True when a tool name matches any allowlist entry."""
+
+    return any(fnmatchcase(tool_name, pattern) for pattern in allowlist)

--- a/gptme/tools/subagent/execution.py
+++ b/gptme/tools/subagent/execution.py
@@ -18,7 +18,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
 from ...message import Message
-from .. import _matching_allowlist_tools, _tool_matches_allowlist, get_tools, set_tools
+from .. import get_tools, set_tools
+from .._allowlist import matching_allowlist_tools, tool_matches_allowlist
 
 if TYPE_CHECKING:
     from .types import ReturnType, Status, Subagent, SubtaskDef
@@ -150,7 +151,7 @@ def _create_subagent_thread(
         unknown = {
             pattern
             for pattern in tool_allowlist
-            if not _matching_allowlist_tools(pattern, loaded_tools)
+            if not matching_allowlist_tools(pattern, loaded_tools)
         }
         if unknown:
             logger.warning(
@@ -162,7 +163,7 @@ def _create_subagent_thread(
         available_tools = [
             tool
             for tool in loaded_tools
-            if _tool_matches_allowlist(tool.name, tool_allowlist)
+            if tool_matches_allowlist(tool.name, tool_allowlist)
         ]
         # Always include the complete tool so subagent can signal completion
         complete_tools = [t for t in loaded_tools if t.name == "complete"]

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -445,6 +445,7 @@ def test_get_toolchain_warns_when_plain_allowlist_excludes_mcp_tools(caplog):
     """Plain allowlists should warn when they filter out available MCP tools."""
     from gptme.tools.base import ToolSpec
 
+    clear_tools()
     fake_tools = [
         ToolSpec(name="discord.read_channel", desc="Read", is_mcp=True),
         ToolSpec(name="discord.send_message", desc="Send", is_mcp=True),
@@ -456,8 +457,11 @@ def test_get_toolchain_warns_when_plain_allowlist_excludes_mcp_tools(caplog):
         caplog.at_level("WARNING", logger="gptme.tools"),
     ):
         tools = get_toolchain(["save"], strict=True)
+        repeated_tools = get_toolchain(["save"], strict=True)
 
     assert [tool.name for tool in tools] == ["save"]
+    assert [tool.name for tool in repeated_tools] == ["save"]
+    assert caplog.text.count("Tool allowlist excluded MCP tools") == 1
     assert "Tool allowlist excluded MCP tools" in caplog.text
     assert "discord.read_channel" in caplog.text
     assert "discord.send_message" in caplog.text

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -56,6 +56,20 @@ def test_init_tools_allowlist_glob_matches_mcp_tools():
     ]
 
 
+def test_init_tools_error_explains_loaded_tools_mismatch():
+    from gptme.tools.base import ToolSpec
+
+    clear_tools()
+    fake_tools = [ToolSpec(name="save", desc="Save")]
+
+    with (
+        patch("gptme.tools.get_toolchain", return_value=[]),
+        patch("gptme.tools.get_available_tools", return_value=fake_tools),
+        pytest.raises(ValueError, match="should have been loaded"),
+    ):
+        init_tools(allowlist=["save"])
+
+
 def test_init_tools_allowlist_from_env():
     clear_tools()  # ensure clean state regardless of test ordering
 
@@ -425,6 +439,29 @@ def test_get_toolchain_glob_matches_mcp_tools():
         "discord.read_channel",
         "discord.send_message",
     ]
+
+
+def test_get_toolchain_warns_when_plain_allowlist_excludes_mcp_tools(caplog):
+    """Plain allowlists should warn when they filter out available MCP tools."""
+    from gptme.tools.base import ToolSpec
+
+    fake_tools = [
+        ToolSpec(name="discord.read_channel", desc="Read", is_mcp=True),
+        ToolSpec(name="discord.send_message", desc="Send", is_mcp=True),
+        ToolSpec(name="save", desc="Save"),
+    ]
+
+    with (
+        patch("gptme.tools.get_available_tools", return_value=fake_tools),
+        caplog.at_level("WARNING", logger="gptme.tools"),
+    ):
+        tools = get_toolchain(["save"], strict=True)
+
+    assert [tool.name for tool in tools] == ["save"]
+    assert "Tool allowlist excluded MCP tools" in caplog.text
+    assert "discord.read_channel" in caplog.text
+    assert "discord.send_message" in caplog.text
+    assert "<server>.*" in caplog.text
 
 
 def test_tool_descriptions_within_openai_limit():


### PR DESCRIPTION
Follow-up to #2423.

## Summary
- move allowlist glob matching into a shared helper module
- warn when a plain tool allowlist filters out available MCP tools without any glob pattern
- tighten the defensive init_tools error text

## Tests
- uv run --with pytest pytest tests/test_tools.py::test_init_tools_allowlist_glob_matches_mcp_tools tests/test_tools.py::test_init_tools_error_explains_loaded_tools_mismatch tests/test_tools.py::test_get_toolchain_glob_matches_mcp_tools tests/test_tools.py::test_get_toolchain_warns_when_plain_allowlist_excludes_mcp_tools tests/test_tools_subagent.py::test_create_subagent_thread_profile_glob_filters_tools -q
- uv run --with ruff ruff check gptme/tools/__init__.py gptme/tools/_allowlist.py gptme/tools/subagent/execution.py tests/test_tools.py
- uv run --with ruff ruff format --check gptme/tools/__init__.py gptme/tools/_allowlist.py gptme/tools/subagent/execution.py tests/test_tools.py
- uv run --with pytest pytest tests/test_tools.py tests/test_tools_subagent.py -m "not slow and not eval" -q

Note: the unrestricted module run hit tests/test_tools_subagent.py::test_subagent_wait_basic, which is marked slow/eval and failed in the live subagent path before creating its log. The normal marker-filtered run passed.