### PR TITLE
fix(server): correct conversation sort direction

### DIFF
--- a/gptme/server/static/main.js
+++ b/gptme/server/static/main.js
@@ -92,8 +92,9 @@ new Vue({
     sortedConversations: function () {
       const reverse = this.sortBy[0] === "-";
       const sortBy = reverse ? this.sortBy.slice(1) : this.sortBy;
+      const direction = reverse ? -1 : 1;
       return this.conversations.sort(
-        (a, b) => b[sortBy] - a[sortBy] * (reverse ? -1 : 1)
+        (a, b) => (b[sortBy] - a[sortBy]) * direction
       );
     },
     showAutocomplete: function () {


### PR DESCRIPTION
## Summary
- fix the web UI conversation comparator so reverse sort flips the whole difference instead of only one operand
- keep the existing sort fields and default newest-first behavior unchanged

## Verification
- node --check gptme/server/static/main.js
- node -e behavior probe for ascending/descending modified sort
- uv run --extra server --with pytest pytest tests/test_server.py::test_api_conversation_list tests/test_server.py::test_api_conversation_list_with_limit -q
- git diff --check -- gptme/server/static/main.js