### PR TITLE
fix(config): give server sessions an isolated workspace directory

### DIFF
--- a/gptme/config/chat.py
+++ b/gptme/config/chat.py
@@ -108,13 +108,13 @@ class ChatConfig:
         """Load ChatConfig from a log directory."""
         chat_config_path = path / "config.toml"
         if not chat_config_path.exists():
-            if (path / "workspace").exists():
-                workspace = (path / "workspace").resolve()
-                return cls(_logdir=path, workspace=workspace)
-            logger.debug(
-                f"No existing config found at {path}, using default config for new conversation."
-            )
-            return cls(_logdir=path)
+            # For new conversations without a saved config, use a
+            # per-conversation workspace directory under the logdir.
+            # This ensures server sessions get isolated workspaces
+            # instead of sharing the server process's cwd.
+            workspace = path / "workspace"
+            workspace.mkdir(parents=True, exist_ok=True)
+            return cls(_logdir=path, workspace=workspace.resolve())
         try:
             with open(chat_config_path) as f:
                 config_data = tomlkit.load(f).unwrap()
@@ -191,16 +191,26 @@ class ChatConfig:
         if self.workspace != workspace_path:
             if workspace_path.exists():
                 if workspace_path.is_dir() and not workspace_path.is_symlink():
-                    # It's a directory with potential user content, don't delete it
-                    raise ValueError(
-                        f"Workspace directory '{workspace_path}' already exists and contains data. "
-                        "Cannot change workspace when directory is in use. "
-                        "Please move or rename the existing directory first."
-                    )
-                # It's a file or symlink, safe to remove
-                workspace_path.unlink()
+                    try:
+                        # If it's an empty directory (e.g., auto-created by
+                        # from_logdir for a new conversation), it's safe to
+                        # remove and replace with a symlink.
+                        workspace_path.rmdir()
+                    except OSError:
+                        raise ValueError(
+                            f"Workspace directory '{workspace_path}' already exists and contains data. "
+                            "Cannot change workspace when directory is in use. "
+                            "Please move or rename the existing directory first."
+                        ) from None
+                else:
+                    # It's a file or symlink, safe to remove
+                    workspace_path.unlink()
             workspace_path.symlink_to(self.workspace)
-        # If workspace IS the log workspace, no symlink needed - directory already exists
+        else:
+            # Workspace IS the log workspace — ensure the directory exists
+            # (from_logdir creates it for new conversations, but callers
+            # constructing ChatConfig directly may not have)
+            self.workspace.mkdir(parents=True, exist_ok=True)
 
         return self
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1168,6 +1168,26 @@ def test_set_config_value_creates_intermediate_sections(tmp_path, monkeypatch):
     assert result["user"]["name"] == "Alice"
 
 
+def test_chat_config_save_transition_empty_dir_to_symlink(tmp_path):
+    """Test that save() replaces an empty from_logdir workspace directory with a symlink."""
+    logdir = tmp_path / "conversation-save-transition"
+
+    # Simulate from_logdir creating workspace dir
+    config = ChatConfig.from_logdir(logdir)
+    assert (logdir / "workspace").is_dir()
+    assert not (logdir / "workspace").is_symlink()
+
+    # Now save() with a workspace change — the empty dir should become a symlink
+    custom_workspace = tmp_path / "custom-workspace"
+    custom_workspace.mkdir()
+    config = replace(config, workspace=custom_workspace)
+    config._logdir = logdir
+    config.save()
+
+    assert (logdir / "workspace").is_symlink()
+    assert (logdir / "workspace").resolve() == custom_workspace
+
+
 def test_get_env_required_checks_gptme_prefix(monkeypatch):
     """Test that get_env_required checks GPTME_ prefixed env vars like get_env does."""
     from gptme.config.models import UserConfig
@@ -1180,3 +1200,34 @@ def test_get_env_required_checks_gptme_prefix(monkeypatch):
 
     result = config.get_env_required("OPENAI_API_KEY")
     assert result == "test-key-123"
+
+
+def test_chat_config_from_logdir_creates_workspace(tmp_path):
+    """Test that from_logdir creates a per-conversation workspace directory."""
+    logdir = tmp_path / "conversation-abc"
+    workspace = logdir / "workspace"
+
+    assert not logdir.exists()
+    assert not workspace.exists()
+
+    config = ChatConfig.from_logdir(logdir)
+
+    assert workspace.is_dir()
+    assert config.workspace.resolve() == workspace.resolve()
+    assert config._logdir == logdir
+
+
+def test_chat_config_from_logdir_uses_existing_workspace(tmp_path):
+    """Test that from_logdir reuses an existing workspace directory."""
+    logdir = tmp_path / "conversation-existing"
+    workspace = logdir / "workspace"
+    workspace.mkdir(parents=True)
+    (workspace / "existing_file.txt").write_text("hello")
+
+    assert logdir.is_dir()
+    assert workspace.is_dir()
+
+    config = ChatConfig.from_logdir(logdir)
+
+    assert config.workspace.resolve() == workspace.resolve()
+    assert (workspace / "existing_file.txt").exists()


### PR DESCRIPTION
## Problem

Server sessions were using `Path.cwd()` as the default workspace because `ChatConfig.from_logdir()` for new conversations (no saved `config.toml`) returned `cls(_logdir=path)` — which falls back to the cwd default. This means all server-side agent sessions shared the host process's working directory.

## Fix

- **`from_logdir()`**: For new conversations without a saved config, creates a per-conversation `workspace/` directory under the logdir instead of returning a config without a workspace set.

- **`save()`**: 
  - Hardened to `rmdir()` an empty directory (left from `from_logdir`) before replacing it with a symlink — previously raised `ValueError` for any directory.
  - When the workspace IS the log workspace, ensures the directory exists with `mkdir(parents=True, exist_ok=True)`.

## Tests

- `test_chat_config_from_logdir_creates_workspace` — verifies `from_logdir` creates a per-conversation workspace dir for new conversations
- `test_chat_config_from_logdir_uses_existing_workspace` — verifies existing workspace dirs are reused without creating duplicates
- `test_chat_config_save_transition_empty_dir_to_symlink` — verifies `save()` handles the empty-dir-to-symlink transition cleanly

All 38 `test_config.py` tests pass.