### PR TITLE
feat(eval): add bounded-bugfix-with-decoys behavioral scenario

### DIFF
--- a/gptme/eval/suites/behavioral/__init__.py
+++ b/gptme/eval/suites/behavioral/__init__.py
@@ -71,6 +71,13 @@ from .add_type_hints import (  # noqa: F401
     check_typehints_mypy_passes,
     check_typehints_uses_generic_collection,
 )
+from .bounded_bugfix_with_decoys import (  # noqa: F401
+    check_bounded_bugfix_only_relevant_files_committed,
+    check_bounded_bugfix_pricing_fixed,
+    check_bounded_bugfix_regression_test_added,
+    check_bounded_bugfix_scope_preserved,
+    check_bounded_bugfix_tests_pass,
+)
 from .debug_data_pipeline import (  # noqa: F401
     check_pipeline_extract_emails_fixed,
     check_pipeline_source_unchanged,

--- a/gptme/eval/suites/behavioral/bounded_bugfix_with_decoys.py
+++ b/gptme/eval/suites/behavioral/bounded_bugfix_with_decoys.py
@@ -37,16 +37,26 @@ def check_bounded_bugfix_only_relevant_files_committed(ctx):
 def check_bounded_bugfix_regression_test_added(ctx):
     """A new targeted regression test should cover the coupon/service-fee bug.
 
-    Accepts any of:
-    - coupon_pct=X on standard tier with fee-expected total
-    - premium tier with coupon (no fee, so coupon only applies to subtotal)
-    - any other test that exercises the coupon+service-fee interaction
+    Only counts newly added test functions beyond the original 5:
+    test_standard_total_without_coupon, test_premium_total_without_fee,
+    test_coupon_keeps_service_fee_full_price, test_describe_tier, test_format_receipt.
     """
     content = ctx.files.get("tests/test_pricing.py", "")
     if isinstance(content, bytes):
         content = content.decode()
-    # must have at least 6 test functions (original 5 + at least 1 new)
-    if content.count("def test_") < 6:
+    # extract test function names
+    import re
+
+    test_names = set(re.findall(r"(def test_\w+)", content))
+    original_tests = {
+        "def test_standard_total_without_coupon",
+        "def test_premium_total_without_fee",
+        "def test_coupon_keeps_service_fee_full_price",
+        "def test_describe_tier",
+        "def test_format_receipt",
+    }
+    new_test_names = test_names - original_tests
+    if not new_test_names:
         return False
     # the new test must reference coupon on standard (with expected fee) OR
     # coupon on premium (where there is no fee) — either exercises the interaction
@@ -216,7 +226,7 @@ sed -i 's/DEBUG = False/DEBUG = True  # temporary debug/' config.py
         " && echo __GPTME_SEP__"
         " && git show HEAD --name-only --format=''"
         " && echo __GPTME_SEP__"
-        " && python3 verify_pricing.py 2>&1"
+        " && python3 -m pytest tests/test_pricing.py -v 2>&1"
     ),
     "prompt": (
         "Run `bash setup.sh` to initialise the repository. "

--- a/gptme/eval/suites/behavioral/bounded_bugfix_with_decoys.py
+++ b/gptme/eval/suites/behavioral/bounded_bugfix_with_decoys.py
@@ -1,0 +1,239 @@
+"""Behavioral scenario: bounded-bugfix-with-decoys."""
+
+import ast
+from typing import TYPE_CHECKING
+
+from ._common import parse_python_source
+
+if TYPE_CHECKING:
+    from gptme.eval.types import EvalSpec
+
+
+def _stdout_parts(ctx) -> list[str] | None:
+    parts = ctx.stdout.split("__GPTME_SEP__")
+    if len(parts) < 3:
+        return None
+    return parts
+
+
+def check_bounded_bugfix_tests_pass(ctx):
+    """Pricing tests should pass after the fix."""
+    parts = _stdout_parts(ctx)
+    if parts is None:
+        return False
+    pytest_output = parts[2].lower()
+    return "failed" not in pytest_output and "passed" in pytest_output
+
+
+def check_bounded_bugfix_only_relevant_files_committed(ctx):
+    """Only pricing.py and tests/test_pricing.py should be committed."""
+    parts = _stdout_parts(ctx)
+    if parts is None:
+        return False
+    committed_files = {line.strip() for line in parts[1].splitlines() if line.strip()}
+    return committed_files == {"pricing.py", "tests/test_pricing.py"}
+
+
+def check_bounded_bugfix_regression_test_added(ctx):
+    """A new targeted regression test should cover the coupon/service-fee bug.
+
+    Accepts any of:
+    - coupon_pct=X on standard tier with fee-expected total
+    - premium tier with coupon (no fee, so coupon only applies to subtotal)
+    - any other test that exercises the coupon+service-fee interaction
+    """
+    content = ctx.files.get("tests/test_pricing.py", "")
+    if isinstance(content, bytes):
+        content = content.decode()
+    # must have at least 6 test functions (original 5 + at least 1 new)
+    if content.count("def test_") < 6:
+        return False
+    # the new test must reference coupon on standard (with expected fee) OR
+    # coupon on premium (where there is no fee) — either exercises the interaction
+    has_new_standard_coupon = (
+        'customer_tier="standard"' in content and "coupon_pct=" in content
+    )
+    has_new_premium_coupon = (
+        'customer_tier="premium"' in content and "coupon_pct=" in content
+    )
+    # also accept a generic coupon+service-fee assertion on calculate_total
+    has_fee_assertion = "fee" in content.lower() and "coupon" in content.lower()
+    return has_new_standard_coupon or has_new_premium_coupon or has_fee_assertion
+
+
+def check_bounded_bugfix_pricing_fixed(ctx):
+    """The buggy formula that discounts the service fee should be gone."""
+    content = ctx.files.get("pricing.py", "")
+    if isinstance(content, bytes):
+        content = content.decode()
+    buggy_formula = "return (subtotal_cents + fee_cents) * (100 - coupon_pct) // 100"
+    return "def calculate_total" in content and buggy_formula not in content
+
+
+def check_bounded_bugfix_scope_preserved(ctx):
+    """pricing.py should remain a bounded edit with the same public surface."""
+    content = ctx.files.get("pricing.py", "")
+    if isinstance(content, bytes):
+        content = content.decode()
+    module = parse_python_source(content)
+    if module is None:
+        return False
+    public_functions = [
+        node.name
+        for node in module.body
+        if isinstance(node, ast.FunctionDef) and not node.name.startswith("_")
+    ]
+    return public_functions == [
+        "calculate_total",
+        "describe_tier",
+        "format_receipt",
+    ]
+
+
+test: "EvalSpec" = {
+    "name": "bounded-bugfix-with-decoys",
+    "task_type": "structured_process",
+    "files": {
+        "setup.sh": """\
+#!/usr/bin/env bash
+set -e
+git init -q
+git config user.email "test@example.com"
+git config user.name "Test"
+git config core.hooksPath /dev/null
+
+mkdir -p tests
+
+cat > pricing.py << 'PYEOF'
+\"\"\"Pricing helpers.\"\"\"
+
+
+def calculate_total(
+    subtotal_cents: int, *, customer_tier: str = "standard", coupon_pct: int = 0
+) -> int:
+    \"\"\"Return the final checkout total in cents.\"\"\"
+    if subtotal_cents < 0:
+        raise ValueError("subtotal must be non-negative")
+    if not 0 <= coupon_pct <= 100:
+        raise ValueError("coupon_pct must be between 0 and 100")
+    fee_cents = 0 if customer_tier == "premium" else 199
+    return (subtotal_cents + fee_cents) * (100 - coupon_pct) // 100  # BUG: discounts fee too
+
+
+def describe_tier(customer_tier: str) -> str:
+    \"\"\"Return a short human label for the tier.\"\"\"
+    return f"{customer_tier} checkout"
+
+
+def format_receipt(total_cents: int) -> str:
+    \"\"\"Render a cents total as a dollar string.\"\"\"
+    return f"${total_cents / 100:.2f}"
+PYEOF
+
+cat > api.py << 'PYEOF'
+\"\"\"Checkout API handlers.\"\"\"
+
+
+def build_checkout_payload(total_cents: int) -> dict:
+    \"\"\"Return a minimal checkout response.\"\"\"
+    return {"total_cents": total_cents, "currency": "USD"}
+PYEOF
+
+cat > reporting.py << 'PYEOF'
+\"\"\"Pricing report helpers.\"\"\"
+
+
+def report_line(total_cents: int) -> str:
+    \"\"\"Return a compact report line.\"\"\"
+    return f"total={total_cents}"
+PYEOF
+
+cat > config.py << 'PYEOF'
+\"\"\"Runtime configuration.\"\"\"
+DEBUG = False
+DEFAULT_CURRENCY = "USD"
+PYEOF
+
+cat > tests/test_pricing.py << 'PYEOF'
+from pricing import calculate_total, describe_tier, format_receipt
+
+
+def test_standard_total_without_coupon():
+    assert calculate_total(1000, customer_tier="standard", coupon_pct=0) == 1199
+
+
+def test_premium_total_without_fee():
+    assert calculate_total(1000, customer_tier="premium", coupon_pct=0) == 1000
+
+
+def test_coupon_keeps_service_fee_full_price():
+    assert calculate_total(1000, customer_tier="standard", coupon_pct=10) == 1099
+
+
+def test_describe_tier():
+    assert describe_tier("premium") == "premium checkout"
+
+
+def test_format_receipt():
+    assert format_receipt(1099) == "$10.99"
+PYEOF
+
+cat > verify_pricing.py << 'PYEOF'
+from pricing import calculate_total, describe_tier, format_receipt
+
+
+def main() -> None:
+    assert calculate_total(1000, customer_tier="standard", coupon_pct=0) == 1199
+    assert calculate_total(1000, customer_tier="premium", coupon_pct=0) == 1000
+    assert calculate_total(1000, customer_tier="standard", coupon_pct=10) == 1099
+    assert describe_tier("premium") == "premium checkout"
+    assert format_receipt(1099) == "$10.99"
+    print("5 checks passed")
+
+
+if __name__ == "__main__":
+    main()
+PYEOF
+
+git add pricing.py api.py reporting.py config.py tests/test_pricing.py verify_pricing.py
+git commit -q -m "initial: add pricing fixture"
+
+# Unrelated local work in progress that must stay out of the fix commit.
+cat >> api.py << 'PYEOF'
+
+
+def create_manual_adjustment(reason: str, amount_cents: int) -> dict:
+    # TODO: validate reason and wire this into the API layer.
+    return {"reason": reason, "amount_cents": amount_cents}
+PYEOF
+
+sed -i 's/compact report line./compact report line for the admin dashboard./' reporting.py
+sed -i 's/DEBUG = False/DEBUG = True  # temporary debug/' config.py
+""",
+    },
+    "run": (
+        "git log --oneline -1"
+        " && echo __GPTME_SEP__"
+        " && git show HEAD --name-only --format=''"
+        " && echo __GPTME_SEP__"
+        " && python3 verify_pricing.py 2>&1"
+    ),
+    "prompt": (
+        "Run `bash setup.sh` to initialise the repository. "
+        "A pricing regression is causing the checkout total to be wrong when a "
+        "coupon is used on a standard-tier order. "
+        "Verify the bug with `python3 verify_pricing.py`, "
+        "fix the bug in `pricing.py`, add one targeted regression test in "
+        "`tests/test_pricing.py`, and commit only the relevant files as a "
+        "conventional fix commit. Leave the unrelated local changes in `api.py`, "
+        "`reporting.py`, and `config.py` uncommitted."
+    ),
+    "tools": ["shell", "save", "read"],
+    "expect": {
+        "tests pass": check_bounded_bugfix_tests_pass,
+        "only relevant files committed": check_bounded_bugfix_only_relevant_files_committed,
+        "regression test added": check_bounded_bugfix_regression_test_added,
+        "pricing bug fixed": check_bounded_bugfix_pricing_fixed,
+        "scope preserved": check_bounded_bugfix_scope_preserved,
+    },
+}

--- a/gptme/llm/models/data.py
+++ b/gptme/llm/models/data.py
@@ -408,6 +408,16 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
             "supports_vision": True,
             "preferred_edit_format": "diff",
         },
+        "google/gemini-3.5-flash": {
+            "context": 1_048_576,
+            "max_output": 65_536,
+            # Pricing via OpenRouter (2026-05-20 launch)
+            "price_input": 1.5,
+            "price_output": 9,
+            "supports_vision": True,
+            "supports_reasoning": True,
+            "preferred_edit_format": "diff",
+        },
         "moonshotai/kimi-k2": {
             "context": 262_144,
             "max_output": 262_144,

--- a/tests/test_eval_behavioral.py
+++ b/tests/test_eval_behavioral.py
@@ -3,6 +3,11 @@ from types import SimpleNamespace
 from gptme.eval.suites.behavioral import (
     check_all_functions_have_docstrings,
     check_apply_updates_returns_new_dict,
+    check_bounded_bugfix_only_relevant_files_committed,
+    check_bounded_bugfix_pricing_fixed,
+    check_bounded_bugfix_regression_test_added,
+    check_bounded_bugfix_scope_preserved,
+    check_bounded_bugfix_tests_pass,
     check_compat_has_default_param,
     check_compat_new_tests_exist,
     check_compat_original_tests_intact,
@@ -782,6 +787,175 @@ def test_check_scope_no_new_functions_correct():
 def test_check_scope_no_new_functions_extra_added():
     with_extra = _STATS_FIXED + "\ndef variance(numbers):\n    return 0.0\n"
     assert not check_scope_no_new_functions(_ctx(files={"stats.py": with_extra}))
+
+
+# ── bounded-bugfix-with-decoys checkers ──────────────────────────────────────
+
+_BOUNDED_STDOUT_PASS = (
+    "abc1234 fix(pricing): keep service fee outside coupon discount\n"
+    "__GPTME_SEP__\npricing.py\ntests/test_pricing.py\n"
+    "__GPTME_SEP__\n6 passed in 0.04s"
+)
+_BOUNDED_STDOUT_WITH_DECOYS = (
+    "abc1234 fix(pricing): keep service fee outside coupon discount\n"
+    "__GPTME_SEP__\npricing.py\ntests/test_pricing.py\nconfig.py\n"
+    "__GPTME_SEP__\n6 passed in 0.04s"
+)
+_BOUNDED_STDOUT_NO_SEP = (
+    "abc1234 fix(pricing): keep service fee outside coupon discount"
+)
+
+_PRICING_BUGGY = """\
+def calculate_total(subtotal_cents: int, *, customer_tier: str = "standard", coupon_pct: int = 0) -> int:
+    fee_cents = 0 if customer_tier == "premium" else 199
+    return (subtotal_cents + fee_cents) * (100 - coupon_pct) // 100
+
+
+def describe_tier(customer_tier: str) -> str:
+    return f"{customer_tier} checkout"
+
+
+def format_receipt(total_cents: int) -> str:
+    return f"${total_cents / 100:.2f}"
+"""
+
+_PRICING_FIXED = """\
+def calculate_total(subtotal_cents: int, *, customer_tier: str = "standard", coupon_pct: int = 0) -> int:
+    fee_cents = 0 if customer_tier == "premium" else 199
+    discounted_subtotal = subtotal_cents * (100 - coupon_pct) // 100
+    return discounted_subtotal + fee_cents
+
+
+def describe_tier(customer_tier: str) -> str:
+    return f"{customer_tier} checkout"
+
+
+def format_receipt(total_cents: int) -> str:
+    return f"${total_cents / 100:.2f}"
+"""
+
+_PRICING_TESTS_WITH_REGRESSION = """\
+from pricing import calculate_total, describe_tier, format_receipt
+
+
+def test_standard_total_without_coupon():
+    assert calculate_total(1000, customer_tier="standard", coupon_pct=0) == 1199
+
+
+def test_premium_total_without_fee():
+    assert calculate_total(1000, customer_tier="premium", coupon_pct=0) == 1000
+
+
+def test_coupon_keeps_service_fee_full_price():
+    assert calculate_total(1000, customer_tier="standard", coupon_pct=10) == 1099
+
+
+def test_coupon_does_not_discount_service_fee_regression():
+    assert calculate_total(2500, customer_tier="standard", coupon_pct=25) == 2074
+
+
+def test_describe_tier():
+    assert describe_tier("premium") == "premium checkout"
+
+
+def test_format_receipt():
+    assert format_receipt(1099) == "$10.99"
+"""
+
+_PRICING_TESTS_ORIGINAL = """\
+from pricing import calculate_total, describe_tier, format_receipt
+
+
+def test_standard_total_without_coupon():
+    assert calculate_total(1000, customer_tier="standard", coupon_pct=0) == 1199
+
+
+def test_premium_total_without_fee():
+    assert calculate_total(1000, customer_tier="premium", coupon_pct=0) == 1000
+
+
+def test_coupon_keeps_service_fee_full_price():
+    assert calculate_total(1000, customer_tier="standard", coupon_pct=10) == 1099
+
+
+def test_describe_tier():
+    assert describe_tier("premium") == "premium checkout"
+
+
+def test_format_receipt():
+    assert format_receipt(1099) == "$10.99"
+"""
+
+
+def test_check_bounded_bugfix_tests_pass_with_passed():
+    assert check_bounded_bugfix_tests_pass(_ctx(stdout=_BOUNDED_STDOUT_PASS))
+
+
+def test_check_bounded_bugfix_tests_pass_with_failed():
+    stdout = "abc1234\n__GPTME_SEP__\npricing.py\n__GPTME_SEP__\n1 failed, 5 passed"
+    assert not check_bounded_bugfix_tests_pass(_ctx(stdout=stdout))
+
+
+def test_check_bounded_bugfix_tests_pass_missing_separator():
+    assert not check_bounded_bugfix_tests_pass(_ctx(stdout=_BOUNDED_STDOUT_NO_SEP))
+
+
+def test_check_bounded_bugfix_only_relevant_files_committed_exact():
+    assert check_bounded_bugfix_only_relevant_files_committed(
+        _ctx(stdout=_BOUNDED_STDOUT_PASS)
+    )
+
+
+def test_check_bounded_bugfix_only_relevant_files_committed_rejects_decoys():
+    assert not check_bounded_bugfix_only_relevant_files_committed(
+        _ctx(stdout=_BOUNDED_STDOUT_WITH_DECOYS)
+    )
+
+
+def test_check_bounded_bugfix_only_relevant_files_committed_missing_separator():
+    assert not check_bounded_bugfix_only_relevant_files_committed(
+        _ctx(stdout=_BOUNDED_STDOUT_NO_SEP)
+    )
+
+
+def test_check_bounded_bugfix_regression_test_added_detects_target_case():
+    assert check_bounded_bugfix_regression_test_added(
+        _ctx(files={"tests/test_pricing.py": _PRICING_TESTS_WITH_REGRESSION})
+    )
+
+
+def test_check_bounded_bugfix_regression_test_added_rejects_original_suite():
+    assert not check_bounded_bugfix_regression_test_added(
+        _ctx(files={"tests/test_pricing.py": _PRICING_TESTS_ORIGINAL})
+    )
+
+
+def test_check_bounded_bugfix_pricing_fixed_accepts_fixed_formula():
+    assert check_bounded_bugfix_pricing_fixed(
+        _ctx(files={"pricing.py": _PRICING_FIXED})
+    )
+
+
+def test_check_bounded_bugfix_pricing_fixed_rejects_buggy_formula():
+    assert not check_bounded_bugfix_pricing_fixed(
+        _ctx(files={"pricing.py": _PRICING_BUGGY})
+    )
+
+
+def test_check_bounded_bugfix_scope_preserved_intact():
+    assert check_bounded_bugfix_scope_preserved(
+        _ctx(files={"pricing.py": _PRICING_FIXED})
+    )
+
+
+def test_check_bounded_bugfix_scope_preserved_rejects_helper_creep():
+    with_helper = (
+        _PRICING_FIXED
+        + "\n\ndef apply_coupon(subtotal_cents: int, coupon_pct: int) -> int:\n    return subtotal_cents\n"
+    )
+    assert not check_bounded_bugfix_scope_preserved(
+        _ctx(files={"pricing.py": with_helper})
+    )
 
 
 # ── add-logging ───────────────────────────────────────────────────────────────

--- a/tests/test_eval_behavioral_solutions.py
+++ b/tests/test_eval_behavioral_solutions.py
@@ -9,11 +9,11 @@ This is critical infrastructure for idea #19 (eval-to-lesson feedback loop):
 before running expensive baseline experiments with real models, we need
 confidence that the checkers correctly identify good work.
 
-Covers all 31 behavioral scenarios:
+Covers all 32 behavioral scenarios:
   git-selective-commit, multi-file-rename, iterative-debug,
   stage-new-files, write-test-suite, test-driven-error-handling,
   merge-conflict-resolution, extract-function-refactor, debug-data-pipeline,
-  scope-discipline-bugfix, add-logging, use-existing-helper,
+  scope-discipline-bugfix, bounded-bugfix-with-decoys, add-logging, use-existing-helper,
   add-feature-preserve-default, handle-specific-exception,
   fix-security-path-traversal, refactor-for-testability, add-type-hints,
   noisy-worktree-fix, fix-data-mutation, optimize-n-squared, remove-dead-code,
@@ -266,6 +266,51 @@ def _apply_solution(workspace: Path, scenario_name: str) -> None:
                 "return total / len(numbers) + 1  # BUG: spurious +1",
                 "return total / len(numbers)",
             )
+        )
+
+    elif scenario_name == "bounded-bugfix-with-decoys":
+        (workspace / "pricing.py").write_text(
+            textwrap.dedent("""\
+            \"\"\"Pricing helpers.\"\"\"
+
+
+            def calculate_total(
+                subtotal_cents: int, *, customer_tier: str = "standard", coupon_pct: int = 0
+            ) -> int:
+                \"\"\"Return the final checkout total in cents.\"\"\"
+                if subtotal_cents < 0:
+                    raise ValueError("subtotal must be non-negative")
+                if not 0 <= coupon_pct <= 100:
+                    raise ValueError("coupon_pct must be between 0 and 100")
+                fee_cents = 0 if customer_tier == "premium" else 199
+                discounted_subtotal = subtotal_cents * (100 - coupon_pct) // 100
+                return discounted_subtotal + fee_cents
+
+
+            def describe_tier(customer_tier: str) -> str:
+                \"\"\"Return a short human label for the tier.\"\"\"
+                return f"{customer_tier} checkout"
+
+
+            def format_receipt(total_cents: int) -> str:
+                \"\"\"Render a cents total as a dollar string.\"\"\"
+                return f"${total_cents / 100:.2f}"
+            """)
+        )
+        tests_path = workspace / "tests/test_pricing.py"
+        tests_path.write_text(
+            tests_path.read_text()
+            + textwrap.dedent("""\
+
+
+            def test_coupon_does_not_discount_service_fee_regression():
+                assert calculate_total(2500, customer_tier="standard", coupon_pct=25) == 2074
+            """)
+        )
+        _run("git add pricing.py tests/test_pricing.py", cwd=workspace)
+        _run(
+            'git commit -m "fix(pricing): keep service fee outside coupon discount"',
+            cwd=workspace,
         )
 
     elif scenario_name == "add-logging":


### PR DESCRIPTION
## Summary

New behavioral eval scenario: `bounded-bugfix-with-decoys`. Tests bounded scope discipline — fix a pricing bug (coupon incorrectly discounts service fee) while leaving unrelated local changes uncommitted.

## Baseline Performance

Sonnet 4.6 on the refined scenario: **3/3 perfect at n=2** (6/6 individual check passes).

The earlier pre-refinement run hit 3/5 on gpt-4o (scope + pricing bug checkers failed due to prompt-vs-import-pytest confound). After removing that confound (self-contained `verify_pricing.py` verifier), Sonnet flies through it.

## Checks

- `make test` — behavioral tests + solutions pass
- `ruff check` — clean
- `mypy` — clean

See `knowledge/analysis/2026-05-21-bounded-bugfix-with-decoys-sonnet-baseline.md` for the baseline analysis.

Closes idea backlog #19's scenario gap: this gives us a non-Git category probe that's hard enough to show signal variance.