### PR TITLE
feat: add Tavily search backend to browser tool

### DIFF
--- a/gptme/tools/_browser_tavily.py
+++ b/gptme/tools/_browser_tavily.py
@@ -1,0 +1,56 @@
+"""
+Tavily search backend for the browser tool.
+"""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def search_tavily(query: str) -> str:
+    """Search using Tavily API."""
+    try:
+        try:
+            from tavily import TavilyClient
+        except ImportError:
+            return (
+                "Error: tavily-python package not installed. "
+                "Install with: pip install tavily-python"
+            )
+
+        from ..config import get_config
+
+        cfg = get_config()
+        api_key = cfg.get_env("TAVILY_API_KEY")
+        if not api_key:
+            return (
+                "Error: Tavily search not available. Set TAVILY_API_KEY "
+                "environment variable or add it to ~/.config/gptme/config.toml"
+            )
+
+        client = TavilyClient(api_key=api_key)
+        response = client.search(query=query, max_results=5, search_depth="basic")
+
+        results = response.get("results", [])
+        if not results:
+            return "Error: No results from Tavily API"
+
+        parts: list[str] = []
+        for r in results:
+            title = r.get("title", "")
+            url = r.get("url", "")
+            content = r.get("content", "")
+            parts.append(f"### {title}\n{url}\n\n{content}")
+
+        return "\n\n".join(parts)
+
+    except Exception as e:
+        return f"Error searching with Tavily: {e}"
+
+
+def has_tavily_key() -> bool:
+    """Check if Tavily API key is available."""
+    from ..config import get_config
+
+    cfg = get_config()
+    return bool(cfg.get_env("TAVILY_API_KEY"))

--- a/gptme/tools/browser.py
+++ b/gptme/tools/browser.py
@@ -321,6 +321,16 @@ def _convert_with_vips(
     return output_files
 
 
+# Check for Tavily availability
+try:
+    _tavily_mod = importlib.import_module("._browser_tavily", __package__)
+    has_tavily_key = _tavily_mod.has_tavily_key
+    search_tavily = _tavily_mod.search_tavily
+    has_tavily = has_tavily_key()
+except (ImportError, AttributeError):
+    has_tavily = False
+    search_tavily = None
+
 # Check for Perplexity availability
 try:
     _perplexity_mod = importlib.import_module("._browser_perplexity", __package__)
@@ -351,7 +361,7 @@ elif browser == "lynx":
 logger = logging.getLogger(__name__)
 
 # Always include all engine types in the type definition
-EngineType = Literal["google", "duckduckgo", "perplexity"]
+EngineType = Literal["tavily", "google", "duckduckgo", "perplexity"]
 
 SEARCH_ENGINE_ERROR_PREFIX = "Error:"
 
@@ -359,6 +369,9 @@ SEARCH_ENGINE_ERROR_PREFIX = "Error:"
 def _available_search_engines() -> list[EngineType]:
     """Return usable search backends in priority order."""
     engines: list[EngineType] = []
+
+    if has_tavily:
+        engines.append("tavily")
 
     if has_perplexity:
         engines.append("perplexity")
@@ -381,6 +394,15 @@ def _search_with_engine(query: str, engine: EngineType) -> str:
     here so _search_with_engine can be called directly (e.g. in tests) without the
     availability gate.
     """
+    if engine == "tavily":
+        if has_tavily:
+            assert search_tavily is not None
+            return search_tavily(query)
+        return (
+            "Error: Tavily search not available. Set TAVILY_API_KEY "
+            "environment variable or add it to ~/.config/gptme/config.toml"
+        )
+
     if engine == "perplexity":
         if has_perplexity:
             assert search_perplexity is not None
@@ -850,7 +872,7 @@ def search(query: str, engine: EngineType | None = None) -> str:
     if not engines_to_try:
         return (
             "Error: No search backends are currently available. "
-            "Set PERPLEXITY_API_KEY or OPENROUTER_API_KEY, or install a supported browser backend."
+            "Set TAVILY_API_KEY, PERPLEXITY_API_KEY, or OPENROUTER_API_KEY, or install a supported browser backend."
         )
 
     errors: list[str] = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ anthropic = "^0.47"
 ipython = "^8.17.2"
 bashlex = "^0.18"
 playwright = {version = "1.49.1", optional=true}  # version constrained due to annoying to have to run `playwright install` on every update
+tavily-python = {version = ">=0.5.0", optional=true}
 python-xlib = {version = "^0.33", optional=true}  # for X11 interaction
 
 # evals
@@ -157,7 +158,7 @@ tomli = "^2.2.1"
 
 [tool.poetry.extras]
 server = ["flask", "flask-cors", "pydantic"]
-browser = ["playwright"]
+browser = ["playwright", "tavily-python"]
 datascience = ["matplotlib", "pandas", "numpy"]  # pillow (non-opt)
 sounds = ["sounddevice", "scipy"]
 computer = []  # pillow (non-opt)
@@ -178,7 +179,7 @@ all = [
     # acp
     "agent-client-protocol",
     # browser
-    "playwright",
+    "playwright", "tavily-python",
     # datascience
     "matplotlib", "pandas", "numpy", # "pillow",
     # tool sounds
@@ -270,6 +271,10 @@ ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = "playwright.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "tavily.*"
 ignore_missing_imports = true
 
 


### PR DESCRIPTION
## Summary

Adds Tavily as a first-priority configurable search engine option alongside the existing Perplexity, Google, and DuckDuckGo backends in the browser tool. When `TAVILY_API_KEY` is set, Tavily is used first; all existing backends remain available as fallbacks.

The new engine priority order is: **tavily → perplexity → google → duckduckgo**.

## Changes

### New file
- **`gptme/tools/_browser_tavily.py`** — Implements `search_tavily()` and `has_tavily_key()` using the `tavily-python` SDK, following the same pattern as `_browser_perplexity.py`.

### Modified files
- **`gptme/tools/browser.py`**:
  - Added Tavily module import (same lazy pattern as Perplexity)
  - Extended `EngineType` literal to include `'tavily'`
  - Added `'tavily'` as highest-priority entry in `_available_search_engines()`
  - Added dispatch branch for Tavily in `_search_with_engine()`
  - Updated no-backends error message to mention `TAVILY_API_KEY`
- **`pyproject.toml`**:
  - Added `tavily-python` as optional dependency
  - Included in `browser` and `all` extras
  - Added mypy override for `tavily.*` module

## Dependency changes
- Added `tavily-python >=0.5.0` (optional, in `browser` and `all` extras)

## Environment variable changes
- Added `TAVILY_API_KEY` (new, optional) — existing `PERPLEXITY_API_KEY` and `OPENROUTER_API_KEY` are unchanged

## Notes for reviewers
- This is an **additive** change — no existing functionality is removed or modified beyond adding the new option
- Tavily is only used when `TAVILY_API_KEY` is configured; without it, behavior is identical to before


### Automated Review

- Passed after 1 attempt(s)
- Final review: The Tavily migration is well-implemented and correctly scoped. The new `_browser_tavily.py` module follows the exact same pattern as `_browser_perplexity.py`, the `browser.py` integration is consistent with the existing Perplexity dispatch pattern, and `pyproject.toml` correctly registers `tavily-python>=0.5.0` as an optional dependency under both `browser` and `all` extras plus a mypy override. No regressions, no dead code, no unrelated changes.
