### PR TITLE
fix(github): rewire stale PR view helper

### DIFF
--- a/docs/lessons/workflows/git.md
+++ b/docs/lessons/workflows/git.md
@@ -59,8 +59,11 @@ gh pr create --title 'Title' --body 'Description'
 
 ### Reading PRs with full context
 ```shell
-# Use the enhanced PR viewer
-~/Programming/gptme/scripts/gh-pr-view-with-pr-comments.sh $PR_URL
+# Canonical path inside gptme: native gh tool surface
+gh pr view $PR_URL
+
+# Compatibility wrapper for terminal use outside the tool surface
+./scripts/gh-pr-view-with-pr-comments.sh $PR_URL
 ```
 
 ### Checking PR status

--- a/docs/lessons/workflows/git.md
+++ b/docs/lessons/workflows/git.md
@@ -59,10 +59,10 @@ gh pr create --title 'Title' --body 'Description'
 
 ### Reading PRs with full context
 ```shell
-# Canonical path inside gptme: native gh tool surface
-gh pr view $PR_URL
+# Canonical path inside gptme: native gh tool surface plus conversation comments
+gh pr view $PR_URL --comments
 
-# Compatibility wrapper for terminal use outside the tool surface
+# Compatibility wrapper from a checkout: also includes inline review threads
 ./scripts/gh-pr-view-with-pr-comments.sh $PR_URL
 ```
 

--- a/scripts/gh-pr-view-with-pr-comments.sh
+++ b/scripts/gh-pr-view-with-pr-comments.sh
@@ -1,168 +1,43 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# This script fetches and formats GitHub PR information, including PR description,
-# comments, reviews, and review comments, showing them in chronological order.
+# Compatibility wrapper around the canonical GitHub PR formatter in
+# gptme.util.gh.get_github_pr_content().
 #
-# This script does what I wish `gh pr view --comments` would do.
-#
-# Features:
-# - Shows PR description and metadata
-# - Shows all comments in chronological order:
-#   - Regular PR comments
-#   - Reviews (with special handling of ellipsis-dev[bot] reviews to reduce noise)
-#   - Review comments with their code context
-# - Handles code suggestions (```suggestion blocks)
-# - Shows referenced code with context
-# - Skips resolved comments
-#
-# The output is formatted in sections:
-# <pr_info>     - PR description and metadata
-# <comments>    - All comments in chronological order
+# Prefer `gh pr view <ref>` inside gptme. Keep this script around for terminal
+# workflows that still want the same formatted output directly from a checkout.
 #
 # Example usage:
 #   ./scripts/gh-pr-view-with-pr-comments.sh https://github.com/owner/repo/pull/123
+#   ./scripts/gh-pr-view-with-pr-comments.sh owner/repo/pull/123
 
-set -e
+set -euo pipefail
 
-# Input can be either:
-#   https://github.com/gptme/gptme/pull/466
-#   gptme/gptme/pull/466
-URL=$1
-
-# Add https://github.com prefix if not present
-[[ $URL != https://* ]] && URL="https://github.com/$URL"
-
-# Extract components from URL
-OWNER=$(echo $URL | awk -F'/' '{print $(NF-3)}')
-REPO=$(echo $URL | awk -F'/' '{print $(NF-2)}')
-ISSUE_ID=$(echo $URL | awk -F'/' '{print $NF}')
-
-# Validate URL components
-if [[ -z "$OWNER" || -z "$REPO" || -z "$ISSUE_ID" ]]; then
-    echo "Error: Invalid URL format. Expected: owner/repo/pull/number"
+if [[ $# -ne 1 ]]; then
+    echo "Usage: $0 <github-pr-url-or-owner/repo/pull/123>" >&2
     exit 1
 fi
-API_PATH="/repos/$OWNER/$REPO/pulls/$ISSUE_ID/comments"
 
-echo "<pr_info>"
-gh pr view $URL | cat
-echo "</pr_info>"
+url=$1
+if [[ $url != https://github.com/* ]]; then
+    url="https://github.com/$url"
+fi
 
-echo
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd -- "$script_dir/.." && pwd)"
 
-# TODO: we may also want to read all the paths and include them in context when used by gptme
-#       https://github.com/gptme/gptme/issues/468
-# TODO: handle resolved conversations (currently we only get individual comments)
-#       https://github.com/gptme/gptme/pull/30 shows an example of resolved conversations
-# TODO: use /pulls/reviews endpoint to get full conversation threads with resolution status
-#       https://docs.github.com/en/rest/pulls/reviews
-# TODO: improve handling of ellipsis-dev[bot] reviews, maybe parse the markdown to extract useful parts
-#       https://github.com/gptme/gptme-webui/pull/30#pullrequestreview-2707423802
+PYTHONPATH="$repo_root${PYTHONPATH:+:$PYTHONPATH}" python3 - "$url" <<'PY'
+import sys
 
-echo "<comments>"
+from gptme.util.gh import get_github_pr_content
 
-# Create a temporary file for all comments
-TMPFILE=$(mktemp)
+url = sys.argv[1]
+content = get_github_pr_content(url)
+if not content:
+    print(
+        "Error: Failed to fetch PR content. Make sure the URL is valid and `gh` is installed and authenticated.",
+        file=sys.stderr,
+    )
+    raise SystemExit(1)
 
-# Get PR comments (non-review)
-gh api \
-    -H "Accept: application/vnd.github+json" \
-    -H "X-GitHub-Api-Version: 2022-11-28" \
-    "/repos/$OWNER/$REPO/issues/$ISSUE_ID/comments" | jq -r '.[] | {
-        type: "pr_comment",
-        user: .user.login,
-        body: .body,
-        created_at: .created_at
-    }' >> "$TMPFILE"
-
-# Get reviews
-gh api \
-    -H "Accept: application/vnd.github+json" \
-    -H "X-GitHub-Api-Version: 2022-11-28" \
-    "/repos/$OWNER/$REPO/pulls/$ISSUE_ID/reviews" | jq -r '.[] | select(.body != "") | {
-        type: "review",
-        user: .user.login,
-        body: .body,
-        created_at: .submitted_at,
-        state: .state,
-        id: .id
-    }' >> "$TMPFILE"
-
-# Get all review comments with thread information
-gh api \
-    -H "Accept: application/vnd.github+json" \
-    -H "X-GitHub-Api-Version: 2022-11-28" \
-    "$API_PATH" | jq -r '.[] | select(.state != "RESOLVED") | {
-        type: "review_comment",
-        user: .user.login,
-        body: .body,
-        created_at: .created_at,
-        path: .path,
-        line: .line,
-        diff_hunk: .diff_hunk,
-        in_reply_to_id: .in_reply_to_id,
-        id: .id,
-        thread_id: (if .in_reply_to_id then .in_reply_to_id else .id end)
-    }' >> "$TMPFILE"
-
-# Sort and format all comments
-jq -rs '
-  # Split and process comments
-  {
-    # Regular comments and reviews
-    other: map(select(.type != "review_comment")) | sort_by(.created_at),
-    # Review comments grouped by thread
-    review_comments: map(select(.type == "review_comment")) |
-      group_by(.thread_id) |
-      map(sort_by(.created_at))
-  } |
-  # Process review comments to add thread markers
-  .review_comments |= map(
-    # For each thread
-    if length > 1 then
-      # Mark first comment as thread start and others as replies
-      [
-        (.[0] + {is_thread_start: true})
-      ] +
-      (.[1:] | map(. + {is_thread_reply: true}))
-    else
-      # Single comment threads stay as-is
-      .
-    end
-  ) |
-  # Combine everything back together
-  (.other + (.review_comments | flatten)) |
-  .[] |
-    # Helper function for suggestion detection
-    def has_suggestion:
-        . | contains("```suggestion");
-
-    # Format based on comment type and thread position
-    if .type == "pr_comment" then
-        "@\(.user):\n\(.body)"
-    elif .type == "review" then
-        if .user == "ellipsis-dev[bot]" then
-            "## Review by @\(.user) (\(.state))\n" + (.body | split("\n")[0])
-        else
-            "## Review by @\(.user) (\(.state))\n\(.body)"
-        end
-    else
-        # Start thread marker if this is the first comment in a thread
-        (if .is_thread_start then "▼ Thread about \(.path):\n" else "" end) +
-        "### Comment by @\(.user):\n" +
-        .body + "\n" +
-        "Referenced code in \(.path):\(.line):" +
-        if (.body | has_suggestion) then
-            "\nSuggested change:\n" +
-            (.body | match("```suggestion\\n([^`]*)```"; "m").captures[0].string)
-        else "" end +
-        # Only show code context for thread start
-        if .is_thread_start then
-            "\nContext:\n```\(.path)\n\(.diff_hunk)\n```"
-        else "" end
-    end + "\n"' "$TMPFILE"
-
-# Cleanup
-rm "$TMPFILE"
-
-echo "</comments>"
+print(content, end="" if content.endswith("\n") else "\n")
+PY

--- a/scripts/gh-pr-view-with-pr-comments.sh
+++ b/scripts/gh-pr-view-with-pr-comments.sh
@@ -28,7 +28,16 @@ repo_root="$(cd -- "$script_dir/.." && pwd)"
 PYTHONPATH="$repo_root${PYTHONPATH:+:$PYTHONPATH}" python3 - "$url" <<'PY'
 import sys
 
-from gptme.util.gh import get_github_pr_content
+try:
+    from gptme.util.gh import get_github_pr_content
+except ImportError as exc:
+    print(
+        "Error: Could not import gptme. Run this from a gptme checkout with dependencies installed "
+        "(for example `uv sync`) or use `gh pr view <ref>` directly.",
+        file=sys.stderr,
+    )
+    print(f"Import error: {exc}", file=sys.stderr)
+    raise SystemExit(1) from exc
 
 url = sys.argv[1]
 content = get_github_pr_content(url)


### PR DESCRIPTION
## Summary
- turn `scripts/gh-pr-view-with-pr-comments.sh` into a thin compatibility wrapper around `gptme.util.gh.get_github_pr_content()`
- keep native `gh pr view` as the canonical docs path and demote the shell script to secondary terminal use
- remove the stale duplicate REST/jq pipeline and its now-wrong TODOs about resolved review threads

## Testing
- `bash -n scripts/gh-pr-view-with-pr-comments.sh`
- `shellcheck scripts/gh-pr-view-with-pr-comments.sh`
- `PYTHONWARNINGS=ignore /home/bob/gptme/.venv/bin/python -m pytest tests/test_util_gh_mocked.py tests/test_tools_gh.py -q`
- `bash scripts/gh-pr-view-with-pr-comments.sh https://github.com/gptme/gptme/pull/271 | head -40`
