### PR TITLE
test(config): document chat workspace default

### DIFF
--- a/gptme/config/chat.py
+++ b/gptme/config/chat.py
@@ -38,9 +38,9 @@ class ChatConfig:
     tool_format: "ToolFormat | None" = None
     stream: bool = True
     interactive: bool = True
-    workspace: Path = field(
-        default_factory=Path.cwd
-    )  # TODO: Is default value cwd ok for server?
+    # CLI sessions default to the current directory. Server sessions load
+    # through from_logdir/load_or_create to get per-conversation workspaces.
+    workspace: Path = field(default_factory=Path.cwd)
     agent: Path | None = None
 
     env: dict = field(default_factory=dict)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1231,3 +1231,19 @@ def test_chat_config_from_logdir_uses_existing_workspace(tmp_path):
 
     assert config.workspace.resolve() == workspace.resolve()
     assert (workspace / "existing_file.txt").exists()
+
+
+def test_chat_config_load_or_create_keeps_log_workspace_for_default_cli_config(
+    tmp_path, monkeypatch
+):
+    """Default CLI config must not override a new conversation workspace."""
+    logdir = tmp_path / "conversation-default-cli"
+    server_cwd = tmp_path / "server-cwd"
+    server_cwd.mkdir()
+    monkeypatch.chdir(server_cwd)
+
+    config = ChatConfig.load_or_create(logdir, ChatConfig())
+
+    expected_workspace = logdir / "workspace"
+    assert expected_workspace.is_dir()
+    assert config.workspace.resolve() == expected_workspace.resolve()


### PR DESCRIPTION
## Summary
- replace the stale ChatConfig workspace TODO with the current CLI/server contract
- add a regression test that default CLI config does not override from_logdir()'s per-conversation workspace

## Tests
- uv run python -m pytest tests/test_config.py -q
- uv run python -m ruff check gptme/config/chat.py tests/test_config.py
- uv run python -m ruff format --check gptme/config/chat.py tests/test_config.py
- git diff --check -- gptme/config/chat.py tests/test_config.py