### PR TITLE
feat(tools): add when-to-use trigger language for computer and morph

### DIFF
--- a/gptme/tools/computer.py
+++ b/gptme/tools/computer.py
@@ -891,6 +891,15 @@ instructions = """
 You can interact with the computer through the `computer` Python function.
 Works on both Linux (X11) and macOS.
 
+### When to use the computer tool
+
+Use computer for GUI interactions that cannot be done through the shell: clicking
+elements in running applications, typing into GUI windows, taking screenshots to
+verify visual state, and keyboard shortcuts in desktop apps. Prefer the shell or
+tmux over computer for anything that has a CLI equivalent. Use computer when the
+task requires direct screen interaction — for example, operating a browser UI,
+a desktop app, or an interactive installer that has no headless mode.
+
 The key input syntax works consistently across platforms with:
 
 Available actions:

--- a/gptme/tools/morph.py
+++ b/gptme/tools/morph.py
@@ -27,6 +27,14 @@ from .base import (
 instructions = """
 Use this tool to propose an edit to an existing file.
 
+### When to use morph vs patch
+
+Use morph for large or complex edits where the changed lines are scattered across
+a file and the standard patch context markers would be verbose. Morph handles the
+diff internally via a specialized fast-apply model, so it is better at edits that
+touch many non-adjacent sections. Prefer patch for small, targeted changes where
+exact context markers are easy to write. Morph requires OPENROUTER_API_KEY.
+
 This will be read by a less intelligent model, which will quickly apply the edit. You should make it clear what the edit is, while also minimizing the unchanged code you write.
 
 When writing the edit, you should specify each edit in sequence, with the special comment // ... existing code ... to represent unchanged code in between edited lines.


### PR DESCRIPTION
## Summary

- Adds `### When to use the computer tool` to `computer.py` — distinguishes from shell/tmux when the task requires GUI interaction with no CLI equivalent
- Adds `### When to use morph vs patch` to `morph.py` — clarifies that morph suits scattered multi-section edits while patch is better for small targeted changes; also notes the OPENROUTER_API_KEY dependency

Follows the pattern established in #2406 (shell, read, gh), #2412 (python, save, patch), and b8c8e26 (tmux, browser).

## Test plan

- [ ] `python3 -c "import ast; ast.parse(open('gptme/tools/computer.py').read())"` passes
- [ ] `python3 -c "import ast; ast.parse(open('gptme/tools/morph.py').read())"` passes
- [ ] CI passes