### PR TITLE
feat(tools): add when-to-use trigger language for vision and screenshot

### DIFF
--- a/gptme/tools/screenshot.py
+++ b/gptme/tools/screenshot.py
@@ -16,11 +16,25 @@ IS_MACOS = platform.system() == "Darwin"
 IS_WAYLAND = os.environ.get("XDG_SESSION_TYPE") == "wayland"
 
 # TODO: check for screen recording permissions instead of prompting the llm
-INSTRUCTIONS = (
+_MACOS_HINT = (
     "If all you see is a wallpaper, the user may have to allow screen capture in `System Preferences -> Security & Privacy -> Screen Recording`."
     if IS_MACOS
     else ""
 )
+
+INSTRUCTIONS = f"""
+### When to use screenshot
+
+Use screenshot to capture the current state of the desktop or a running
+application — to verify a UI change, observe what the user sees, or document
+visual output before and after an action.
+
+Do **not** use screenshot for:
+- Viewing an already-saved image file — use the `vision` tool instead
+- Capturing a specific webpage — use `browser` with a screenshot action instead
+
+{_MACOS_HINT}
+""".strip()
 
 
 def _is_available() -> bool:

--- a/gptme/tools/vision.py
+++ b/gptme/tools/vision.py
@@ -101,8 +101,6 @@ def view_image(image_path: "Path | str | Image.Image") -> Message:
 
 
 instructions = """
-Use the `view_image` Python function with `ipython` tool to view an image file.
-
 ### When to use vision
 
 Use vision when you have a local image file (screenshot, photo, diagram, chart,
@@ -112,6 +110,8 @@ from filenames — pass the actual pixels to the model.
 Do **not** use vision for:
 - Images at a URL — fetch with `read` or visit with `browser` instead
 - Taking a new screenshot — use the `screenshot` tool, then pass the path to vision
+
+Use the `view_image` Python function with `ipython` tool to view an image file.
 """.strip()
 
 tool = ToolSpec(

--- a/gptme/tools/vision.py
+++ b/gptme/tools/vision.py
@@ -102,6 +102,16 @@ def view_image(image_path: "Path | str | Image.Image") -> Message:
 
 instructions = """
 Use the `view_image` Python function with `ipython` tool to view an image file.
+
+### When to use vision
+
+Use vision when you have a local image file (screenshot, photo, diagram, chart,
+or plot) that needs visual inspection or analysis. Prefer vision over guessing
+from filenames — pass the actual pixels to the model.
+
+Do **not** use vision for:
+- Images at a URL — fetch with `read` or visit with `browser` instead
+- Taking a new screenshot — use the `screenshot` tool, then pass the path to vision
 """.strip()
 
 tool = ToolSpec(


### PR DESCRIPTION
## Summary

Adds `### When to use` sections to the `vision` and `screenshot` tool instruction strings, completing the series started in #2406, #2413, and #2434.

- **vision**: use when you have a local image file (screenshot, photo, diagram, chart) that needs visual inspection; not for URL images or taking new screenshots
- **screenshot**: use to capture live desktop/app state to verify UI changes or observe what the user sees; not for viewing saved image files (use `vision`) or capturing specific webpages (use `browser`)

The `### When to use` format is now consistent across all major interaction tools: `shell`, `read`, `gh`, `tmux`, `browser`, `computer`, `morph`, `vision`, and `screenshot`.

## Test plan

- [x] `uv run ruff check gptme/tools/vision.py gptme/tools/screenshot.py` — clean
- [x] `uv run ruff format --check` — already formatted
- [x] Import + assertion smoke test: both instruction strings contain the expected `When to use` headers and both tools import cleanly
- [ ] CI green