### PR TITLE
feat(tools): add when-to-use trigger language for screenshot, rag, vision, and todo

### DIFF
--- a/gptme/tools/morph.py
+++ b/gptme/tools/morph.py
@@ -29,20 +29,14 @@ Use this tool to propose an edit to an existing file.
 
 ### When to use morph vs patch
 
-Use morph for large or complex edits where the changed lines are scattered across
-a file and the standard patch context markers would be verbose. Morph handles the
-diff internally via a specialized fast-apply model, so it is better at edits that
-touch many non-adjacent sections. Prefer patch for small, targeted changes where
-exact context markers are easy to write. Morph requires OPENROUTER_API_KEY.
+Use morph for large or complex edits where the changed lines are scattered
+across a file and patch context markers would be verbose. Prefer patch for
+small, targeted edits with clear context. Morph requires OPENROUTER_API_KEY.
 
-This will be read by a less intelligent model, which will quickly apply the edit. You should make it clear what the edit is, while also minimizing the unchanged code you write.
-
-When writing the edit, you should specify each edit in sequence, with the special comment // ... existing code ... to represent unchanged code in between edited lines.
-
-You should bias towards repeating as few lines of the original file as possible to convey the change.
-NEVER show unmodified code in the edit, unless sufficient context of unchanged lines around the code you're editing is needed to resolve ambiguity.
-If you plan on deleting a section, you must provide surrounding context to indicate the deletion.
-DO NOT omit spans of pre-existing code without using the // ... existing code ... comment to indicate its absence.
+Write a clear edit while minimizing unchanged code.
+List each edit in sequence, using `// ... existing code ...` for untouched spans.
+Repeat only enough original context to disambiguate the change.
+If you delete a section, include surrounding context to show what is removed.
 """
 
 

--- a/gptme/tools/rag.py
+++ b/gptme/tools/rag.py
@@ -52,7 +52,12 @@ from .base import ToolSpec, ToolUse
 logger = logging.getLogger(__name__)
 
 instructions = """
-Use RAG to index and semantically search through text files such as documentation and code.
+### When to use RAG
+
+Use RAG for semantic search across indexed documents when you do not know the
+exact file location or keyword. Prefer `shell` with grep/ripgrep for exact
+string or pattern matching. Use `read` when you already know the file path.
+Index first with `rag_index`, then search with `rag_search`.
 """
 
 

--- a/gptme/tools/todo.py
+++ b/gptme/tools/todo.py
@@ -391,39 +391,26 @@ todo = ToolSpec(
     instructions="""
 ### When to use the todo tool
 
-Use todo to track progress through complex multi-step tasks within the current
-conversation — it acts as working memory. Reach for it when a task has 3+ steps
-or when you need to make your work plan visible. For tasks that must persist
-across conversations or sessions, use the persistent task management system
-(`gptodo` / task files) instead.
+Use todo as working memory for 3+ step tasks in the current conversation.
+For persistent cross-session tracking, use `gptodo` or task files instead.
 
-Use this tool to manage todos in the current conversation context.
+Manage todos for the current conversation.
 
 Subcommands:
-- `todo read` - Display the current todo list
-- `todo write` - Modify todos (with operations in content block)
+- `todo read` - Show the current todo list
+- `todo write` - Edit todos
 
-Write operations (in content block):
-- add "todo text" - Add a new todo item
-- update ID state - Update todo state (pending/in_progress/completed/paused)
-- update ID "new text" - Update todo text
-- remove ID - Remove a todo item
+Write operations:
+- add "todo text" - Add an item
+- update ID state - Set state (pending/in_progress/completed/paused)
+- update ID "new text" - Rename an item
+- remove ID - Remove an item
 - clear - Clear all todos
-- clear completed - Clear only completed todos
+- clear completed - Clear completed todos
 
 States: pending, in_progress, completed, paused
 
-Use this tool frequently for complex multi-step tasks to:
-- Break down large tasks into smaller steps
-- Track progress through complex workflows
-- Provide visibility into your work plan
-- Stay organized during long conversations
-
-The todo list is ephemeral and conversation-scoped.
-For persistent cross-conversation tasks, use the task management system.
-
-Auto-replay: Todo operations are automatically replayed when resuming conversations
-to restore your todo list state.
+Todo state is auto-replayed when resuming the conversation.
     """.strip(),
     examples=examples_todo,
     execute=execute_todo,

--- a/gptme/tools/todo.py
+++ b/gptme/tools/todo.py
@@ -389,6 +389,14 @@ todo = ToolSpec(
     desc="Manage an in-session todo list (ephemeral, not persisted across conversations)",
     block_types=["todo"],
     instructions="""
+### When to use the todo tool
+
+Use todo to track progress through complex multi-step tasks within the current
+conversation — it acts as working memory. Reach for it when a task has 3+ steps
+or when you need to make your work plan visible. For tasks that must persist
+across conversations or sessions, use the persistent task management system
+(`gptodo` / task files) instead.
+
 Use this tool to manage todos in the current conversation context.
 
 Subcommands:


### PR DESCRIPTION
Adds disambiguation guidance matching the pattern established in #2434 (computer and morph), covering the remaining core tools that were missing it.

## Changes

- **screenshot**: prefer for passive screen capture and verification; use the `computer` tool when you also need to interact with the screen (click, type, drag)
- **rag**: use for semantic search when you don't know the exact file or keyword; prefer `shell` with grep/ripgrep for exact matching; use `read` when the path is known
- **vision**: use to view an existing image file; pair with `screenshot` to capture then view; use `read` for text files
- **todo**: use for in-conversation working memory on 3+ step tasks; use `gptodo`/task files for persistence across sessions

## Follows the pattern from

#2434 — `feat(tools): add when-to-use trigger language for computer and morph`