### PR TITLE
feat(tools): add when-to-use trigger language for elicit and form

### DIFF
--- a/gptme/tools/chats.py
+++ b/gptme/tools/chats.py
@@ -555,9 +555,26 @@ Assistant: Certainly! I'll search our past conversations for mentions of "python
 """
 
 
+instructions = """
+### When to use chats
+
+Use chats when the user asks about or wants to reference a past conversation:
+- "remember when we discussed X?" → search_chats('X')
+- "find our earlier chat about Y" → search_chats('Y')
+- "what did we say about Z last week?" → search_chats('Z')
+- Listing recent sessions to give the user an overview → list_chats()
+- Reading a specific prior conversation by ID → read_chat(id)
+
+Do **not** use chats for:
+- The current conversation — its content is already in the context window.
+- Searching files or code — use the shell or read tool instead.
+- Web or documentation search — use the browser tool.
+""".strip()
+
 tool = ToolSpec(
     name="chats",
     desc="List, search, and summarize past conversation logs",
+    instructions=instructions,
     instructions_format={
         # Compact description for OpenAI tool format (full docstrings exceed 1024 chars)
         "tool": "Access past conversations: list recent chats with list_chats(), "

--- a/gptme/tools/elicit.py
+++ b/gptme/tools/elicit.py
@@ -9,9 +9,10 @@ Elicitation supports multiple input types:
 - ``confirmation``: Yes/No question
 - ``form``: Multiple fields collected at once
 
-Secret values are handled specially: they are stored/used as directed by the
-agent but are NEVER added to the conversation history, ensuring credentials
-don't leak into the LLM context.
+Secret values are handled specially: the value is hidden from the chat display
+(``hide=True``) so it does not appear on screen, but it is passed to the LLM
+in-context so the agent can act on it (e.g. set it as an env var). The value
+is stored in the on-disk conversation log.
 """
 
 import json
@@ -37,8 +38,10 @@ instructions = """
 
 Use elicit when you need structured user input that a plain text reply cannot
 cleanly provide:
-- **secret** — API keys, passwords, tokens. The value is returned to you but
-  NOT added to conversation history, preventing credential leaks.
+- **secret** — API keys, passwords, tokens. The value is hidden from the chat
+  display so it does not appear over someone's shoulder; the LLM still receives
+  it in-context so it can act on it (e.g. export as an env var or pass to a
+  command). The conversation log on disk will contain the value.
 - **choice / multi_choice** — present a fixed set of options so the user
   selects rather than types a free-form answer that you then have to parse.
 - **confirmation** — ask yes/no before a destructive or irreversible action.
@@ -53,7 +56,7 @@ chat — a plain assistant message is clearer and less disruptive in those cases
 - text: Free-form text input
 - choice: Single selection from a list (specify options)
 - multi_choice: Multiple selections from a list (specify options)
-- secret: Hidden input for API keys/passwords (NOT stored in conversation)
+- secret: Hidden from display; LLM receives the value in-context to act on it
 - confirmation: Yes/No question
 - form: Multiple fields at once (specify JSON field definitions)
 """.strip()

--- a/gptme/tools/elicit.py
+++ b/gptme/tools/elicit.py
@@ -33,16 +33,29 @@ from .base import (
 logger = logging.getLogger(__name__)
 
 instructions = """
-Request structured input from the user. Supports these types:
+### When to use elicit
+
+Use elicit when you need structured user input that a plain text reply cannot
+cleanly provide:
+- **secret** — API keys, passwords, tokens. The value is returned to you but
+  NOT added to conversation history, preventing credential leaks.
+- **choice / multi_choice** — present a fixed set of options so the user
+  selects rather than types a free-form answer that you then have to parse.
+- **confirmation** — ask yes/no before a destructive or irreversible action.
+- **form** — collect several related fields in one interaction instead of a
+  back-and-forth sequence.
+
+Do **not** use elicit for simple open-ended questions that read naturally in
+chat — a plain assistant message is clearer and less disruptive in those cases.
+
+### Input types
+
 - text: Free-form text input
 - choice: Single selection from a list (specify options)
 - multi_choice: Multiple selections from a list (specify options)
 - secret: Hidden input for API keys/passwords (NOT stored in conversation)
 - confirmation: Yes/No question
 - form: Multiple fields at once (specify JSON field definitions)
-
-For secrets: the value is returned to you but NOT added to conversation history.
-Use the secret type when asking for API keys, passwords, or other credentials.
 """.strip()
 
 instructions_format = {

--- a/gptme/tools/elicit.py
+++ b/gptme/tools/elicit.py
@@ -5,7 +5,7 @@ Elicitation supports multiple input types:
 - ``text``: Free-form text input
 - ``choice``: Single selection from options
 - ``multi_choice``: Multiple selections from options
-- ``secret``: Hidden input (API keys, passwords) - NOT added to LLM context
+- ``secret``: Hidden input (API keys, passwords) with UI redaction
 - ``confirmation``: Yes/No question
 - ``form``: Multiple fields collected at once
 
@@ -71,7 +71,7 @@ def examples(tool_format):
 ### Ask for a secret API key
 
 > User: Set up the OpenAI integration
-> Assistant: I need your OpenAI API key to proceed. It will not be stored in the conversation.
+> Assistant: I need your OpenAI API key to proceed. It will be hidden from normal chat display.
 {
         ToolUse(
             "elicit",
@@ -80,7 +80,7 @@ def examples(tool_format):
                 {
                     "type": "secret",
                     "prompt": "Enter your OpenAI API key:",
-                    "description": "Required for the OpenAI integration. Will not be logged.",
+                    "description": "Required for the OpenAI integration. Hidden from normal chat display.",
                 },
                 indent=2,
             ),
@@ -206,8 +206,7 @@ def execute_elicit(
 ) -> Generator[Message, None, None]:
     """Execute elicitation and return user's response.
 
-    For secret types, the value is returned to the agent but a redacted
-    message is stored in conversation history (to avoid leaking credentials).
+    For secret types, the value is returned to the agent with UI redaction.
     """
     if not code:
         yield Message("system", "No elicitation spec provided")

--- a/gptme/tools/form.py
+++ b/gptme/tools/form.py
@@ -17,7 +17,21 @@ from .base import (
 )
 
 instructions = """
-Present a form with multiple fields for user input.
+### When to use the form tool
+
+Use the form tool when you need to collect multiple related fields from the
+user in a single interaction. It is well suited for structured data collection
+where field types are text, select (choose from a list), boolean (yes/no), or
+number.
+
+For **secrets** (API keys, passwords) use the ``elicit`` tool instead — form
+does not have a secret type, so credentials would appear in the conversation
+history.
+
+For a single question or free-form input, a plain assistant message is simpler.
+Prefer form when collecting two or more related fields at once.
+
+### Form syntax
 
 Each field is specified on a separate line with the format:
   field_name: Prompt text [options]

--- a/gptme/tools/form.py
+++ b/gptme/tools/form.py
@@ -25,8 +25,7 @@ where field types are text, select (choose from a list), boolean (yes/no), or
 number.
 
 For **secrets** (API keys, passwords) use the ``elicit`` tool instead — form
-does not have a secret type, so credentials would appear in the conversation
-history.
+does not have a secret type, so credentials would appear in the chat display.
 
 For a single question or free-form input, a plain assistant message is simpler.
 Prefer form when collecting two or more related fields at once.


### PR DESCRIPTION
## Summary

Adds `### When to use` sections to `elicit.py`, `form.py`, and `chats.py`, continuing the pattern from #2434 and #2435.

- **elicit**: clarifies when to use each input type (particularly `secret` for credentials that must not appear in conversation history), when to prefer structured elicitation over plain chat, and lists all input types
- **form**: explains when to use a form vs elicit (form lacks `secret` type — important safety note), when single questions are simpler, and consolidates the field-syntax docs under a clear heading
- **chats**: adds `instructions` field (was missing entirely) with when-to-use guidance for searching/reading past conversations vs current context vs files

All three tools now follow the same `### When to use` + "Do not use for" pattern established in the previous PRs.

## Test plan

- [x] All three modules import cleanly
- [x] Pre-commit hooks pass on both commits
- [x] Consistent with pattern in shell.py, python.py, computer.py, morph.py, vision.py, screenshot.py