### PR TITLE
feat(tools): add when-to-use trigger language for gh

### DIFF
--- a/gptme/tools/gh.py
+++ b/gptme/tools/gh.py
@@ -651,9 +651,16 @@ def execute_gh(
         yield from _passthrough_gh(args, code)
 
 
-instructions = """Use this tool when GitHub work needs fewer round-trips, structured CI data,
-or safer merges than a raw `gh` shell command. Prefer `gh` over shell whenever
-the target is a GitHub issue, PR, run, or merge action.
+instructions = """### When to use the gh tool
+
+Use the gh tool when working with GitHub issues, pull requests, CI runs, or
+merges — it collapses multiple API calls into one response, keeps CI state
+structured, and adds merge safety guards that are easy to miss with raw
+shell commands.
+
+Prefer `gh` over `shell` whenever the target is a GitHub issue, PR, run, or
+merge action. It reduces hallucination risk and token waste compared to reading
+raw JSON from `gh api` calls in the shell tool.
 
 Refs: full URLs, `owner/repo#N`, `#N`, or bare `N` in a git repo.
 

--- a/gptme/tools/gh.py
+++ b/gptme/tools/gh.py
@@ -651,20 +651,15 @@ def execute_gh(
         yield from _passthrough_gh(args, code)
 
 
-instructions = """### When to use the gh tool
+instructions = """### When to use
 
-Use the gh tool when working with GitHub issues, pull requests, CI runs, or
-merges — it collapses multiple API calls into one response, keeps CI state
-structured, and adds merge safety guards that are easy to miss with raw
-shell commands.
+Use `gh` instead of shell for GitHub issues, PRs, CI runs, and merges.
+Native paths collapse API calls, keep CI state structured, and add merge
+safety guards easy to miss with raw shell commands.
 
-Prefer `gh` over `shell` whenever the target is a GitHub issue, PR, run, or
-merge action. It reduces hallucination risk and token waste compared to reading
-raw JSON from `gh api` calls in the shell tool.
+Refs: full URLs, `owner/repo#N`, `#N`, or bare `N`.
 
-Refs: full URLs, `owner/repo#N`, `#N`, or bare `N` in a git repo.
-
-Native paths help the agent finish GitHub tasks with less hallucination risk:
+Native paths help avoid hallucination:
 - `gh issue view <ref>` gets issue body and comments in one result
 - `gh pr view <ref>` gets PR body, comments, review threads, CI, and mergeability in one result
 - `gh pr status <ref> [commit_sha]` returns structured CI state with run IDs
@@ -672,7 +667,7 @@ Native paths help the agent finish GitHub tasks with less hallucination risk:
 - `gh pr merge <ref> ...` adds squash-by-default and optional head-commit protection
 - `gh run view <run-id>` extracts failed-job logs
 
-All other valid `gh` subcommands pass through unchanged."""
+All other `gh` subcommands pass through unchanged."""
 
 
 def examples(tool_format):


### PR DESCRIPTION
Continues the tool-use reliability work from #320 (idea-backlog #320) —
adding an explicit "When to use the gh tool" section to the gh tool instructions,
matching the pattern already established for shell, read, vision, form, computer,
morph, elicit, chats, rag, screenshot, and todo.

The trigger language makes it clearer when the model should prefer the gh
native tool over raw shell `gh` commands — especially in autonomous contexts
where the model sometimes defaults to shell instead of the richer native paths
that collapse multiple API calls, structure CI state, and add merge safety guards.

See also: gptme/gptme#2406 (shell/read/gh — the shell+read part), gptme/gptme#2434 (computer+morph),
gptme/gptme#2435 (vision+screenshot), gptme/gptme#2436 (screenshot+rag+vision+todo),
gptme/gptme#2437 (elicit+form+chats).