### PR TITLE
feat(tools): add when-to-use trigger language for mcp and lessons

### DIFF
--- a/gptme/tools/lessons.py
+++ b/gptme/tools/lessons.py
@@ -453,6 +453,17 @@ tool = ToolSpec(
     name="lessons",
     desc="Lesson system for structured guidance",
     instructions="""
+### When to use the lessons tool
+
+Lessons are **automatically injected** when relevant keywords match — you rarely
+need to call the lessons tool explicitly. Use it only when:
+- Searching for guidance that wasn't auto-injected: `/lesson search <topic>`
+- Browsing available patterns: `/lesson list`
+- Refreshing after lesson files changed: `/lesson refresh`
+
+Do NOT call the lessons tool to re-read lessons already in context, or to
+"apply" lessons — just act on the guidance that was auto-included.
+
 Use lessons to learn and remember skills/tools/workflows, improve your performance, and avoid known failure modes.
 
 How lessons help you:

--- a/gptme/tools/mcp.py
+++ b/gptme/tools/mcp.py
@@ -493,6 +493,16 @@ tool = ToolSpec(
     name="mcp",
     desc="Search, discover, and manage MCP servers",
     instructions="""
+### When to use the mcp tool
+
+Use the mcp tool when you need to extend gptme's capabilities beyond its built-in tools:
+- Discover new tools with `/mcp search <capability>` when a built-in doesn't exist
+- Load an MCP server with `/mcp load <server-name>` to make its tools available
+- Check what's running with `/mcp list` before searching or loading duplicates
+
+Do NOT use the mcp tool to call tools that are already loaded — invoke loaded
+server tools directly as `<server-name>.<tool-name>` instead.
+
 Search, load, and manage MCP servers. Loaded server tools available as `<server-name>.<tool-name>`. Search queries the Official MCP Registry (registry.modelcontextprotocol.io).
 
 **Resource Commands:**


### PR DESCRIPTION
## Summary

Adds explicit `### When to use` sections to the `mcp` and `lessons` tool instructions, matching the pattern shipped for shell, read, gh, browser, computer, morph, elicit, form, and others (idea #320 / #2406+).

**mcp tool**: clarifies that `/mcp` is the management interface (search/load/unload/list), not the way to call already-loaded server tools — those should be invoked directly as `<server-name>.<tool-name>`.

**lessons tool**: clarifies that lessons are auto-injected by keyword matching; only use `/lesson search` or `/lesson list` for explicit lookup when auto-injection didn't fire. This prevents agents from redundantly re-reading lessons already in context.

Closes the remaining coverage gap from the Phase 2b when-to-use audit.

## Test plan
- [x] Both files import cleanly (`uv run python3 -c "from gptme.tools.mcp import tool; from gptme.tools.lessons import tool"`)
- [x] Pre-commit hooks pass
- [x] Existing tests pass (`uv run pytest tests/ -k "mcp or lesson" -q`)