### PR TITLE
fix(tools): keep mcp and lessons under OpenAI limit

### DIFF
--- a/gptme/tools/lessons.py
+++ b/gptme/tools/lessons.py
@@ -455,26 +455,24 @@ tool = ToolSpec(
     instructions="""
 ### When to use the lessons tool
 
-Lessons are **automatically injected** when relevant keywords match — you rarely
-need to call the lessons tool explicitly. Use it only when:
-- Searching for guidance that wasn't auto-injected: `/lesson search <topic>`
-- Browsing available patterns: `/lesson list`
-- Refreshing after lesson files changed: `/lesson refresh`
+Lessons are auto-injected on keyword and tool matches. Use `/lesson` only to
+search for missing guidance (`/lesson search <topic>`), browse patterns
+(`/lesson list`), or refresh after lesson files change (`/lesson refresh`).
 
-Do NOT call the lessons tool to re-read lessons already in context, or to
-"apply" lessons — just act on the guidance that was auto-included.
+Do not re-read or "apply" lessons explicitly; follow the ones already in
+context.
 
-Use lessons to learn and remember skills/tools/workflows, improve your performance, and avoid known failure modes.
+Use lessons to remember useful patterns and avoid known failure modes.
 
-How lessons help you:
-- Automatically included when relevant keywords or tools match
-- Extracted from both user and assistant messages in the conversation
-- Session-wide limit (default 20) prevents context bloat
+How lessons help:
+- Auto-included when relevant keywords or tools match
+- Extracted from user and assistant messages
+- Session limit (default 20) prevents context bloat
 
-Leverage lessons for self-improvement:
-- Pay attention to lessons included in context
+For self-improvement:
+- Pay attention to included lessons
 - Apply patterns and avoid anti-patterns
-- Reference lessons when making decisions
+- Reference lessons in decisions
 - Learn from past failures documented in lessons
 """.strip(),
     examples="",

--- a/gptme/tools/mcp.py
+++ b/gptme/tools/mcp.py
@@ -495,31 +495,22 @@ tool = ToolSpec(
     instructions="""
 ### When to use the mcp tool
 
-Use the mcp tool when you need to extend gptme's capabilities beyond its built-in tools:
-- Discover new tools with `/mcp search <capability>` when a built-in doesn't exist
-- Load an MCP server with `/mcp load <server-name>` to make its tools available
-- Check what's running with `/mcp list` before searching or loading duplicates
+Use mcp to discover, load, inspect, and manage MCP servers:
+- `/mcp search <capability>` finds new servers
+- `/mcp load <server-name>` loads one
+- `/mcp list` shows what is already loaded
 
-Do NOT use the mcp tool to call tools that are already loaded — invoke loaded
-server tools directly as `<server-name>.<tool-name>` instead.
+Do not use mcp to call loaded tools; invoke them directly as
+`<server-name>.<tool-name>`.
 
-Search, load, and manage MCP servers. Loaded server tools available as `<server-name>.<tool-name>`. Search queries the Official MCP Registry (registry.modelcontextprotocol.io).
+Search uses the Official MCP Registry (registry.modelcontextprotocol.io).
 
-**Resource Commands:**
-- `resources list <server>` - List available resources
-- `resources read <server> <uri>` - Read a resource by URI
-- `templates list <server>` - List resource templates
-
-**Prompt Commands:**
-- `prompts list <server>` - List available prompts
-- `prompts get <server> <name> [args]` - Get a prompt with optional args
-
-**Roots Commands** (operational boundaries):
-- `roots list [server]` - List configured roots
-- `roots add <server> <uri> [name]` - Add a root URI
-- `roots remove <server> <uri>` - Remove a root
-
-Roots are advisory URIs (file paths, HTTP URLs) defining workspace boundaries.
+Other commands:
+- `info <server>` shows server details
+- `resources list/read` browses server resources
+- `templates list` lists resource templates
+- `prompts list/get` lists or fetches prompts
+- `roots list/add/remove` manages advisory workspace roots
 """.strip(),
     examples=examples,
     execute=execute_mcp,


### PR DESCRIPTION
## Summary

Fixes the regression introduced by #2440 where the new `When to use` guidance pushed the OpenAI tool-format descriptions past the 1024-character limit enforced by `tests.test_tools::test_tool_descriptions_within_openai_limit`.

This keeps the new behavior guidance but compresses the prose:
- `lessons`: keeps the auto-injection / explicit-lookup distinction while trimming redundant wording
- `mcp`: keeps the management-vs-direct-tool-call distinction while shortening the command catalog

Local post-fix lengths:
- `lessons`: 765
- `mcp`: 637

## Test plan

- [x] `/home/bob/gptme/.venv/bin/python -m pytest tests/test_tools.py -k tool_descriptions_within_openai_limit -q`
- [x] `/home/bob/gptme/.venv/bin/python -m pytest tests/test_prompts.py -k get_prompt_short -q`
