### PR TITLE
feat(tools): add when-to-use trigger language for choice, complete, and restart

### DIFF
--- a/gptme/tools/choice.py
+++ b/gptme/tools/choice.py
@@ -15,6 +15,10 @@ instructions = """
 The options can be provided as a question on the first line and each option on a separate line.
 
 The tool will present an interactive menu allowing the user to select an option using arrow keys and Enter, or by typing the number of the option.
+
+### When to use choice
+
+Use when the user needs to select from a discrete set of named alternatives and free-text input would be ambiguous. Don't use for simple yes/no confirmations; don't use when the next step is already clear from context.
 """.strip()
 
 instructions_format = {

--- a/gptme/tools/choice.py
+++ b/gptme/tools/choice.py
@@ -18,7 +18,7 @@ The tool will present an interactive menu allowing the user to select an option 
 
 ### When to use choice
 
-Use when the user needs to select from a discrete set of named alternatives and free-text input would be ambiguous. Don't use for simple yes/no confirmations; don't use when the next step is already clear from context.
+Use when you need to present the user with a discrete set of named alternatives and free-text input would be ambiguous. Don't use for simple yes/no confirmations; don't use when the next step is already clear from context.
 """.strip()
 
 instructions_format = {

--- a/gptme/tools/complete.py
+++ b/gptme/tools/complete.py
@@ -178,6 +178,10 @@ tool = ToolSpec(
 Use this tool to signal that you have completed your work and the autonomous session should end.
 
 Make sure you have actually completely finished before calling this tool.
+
+### When to use complete
+
+Use only after all requested work is done and committed. Do not call it mid-task or while blocked on something fixable — only call when work is genuinely finished or you have hit a hard blocker requiring human intervention.
 """,
     examples="""
 > User: Everything done, just complete

--- a/gptme/tools/restart.py
+++ b/gptme/tools/restart.py
@@ -252,6 +252,10 @@ The restart preserves the current conversation by reloading it from disk.
 All command-line arguments are preserved in the new process.
 
 This tool is disabled by default and must be explicitly enabled with `--tools restart`.
+
+### When to use restart
+
+Use after modifying gptme configuration or tool files when a fresh process is needed to apply changes. Don't use as a workaround for unrelated errors — diagnose and fix the root cause instead.
 """,
     examples="""
 > User: restart gptme to apply the config changes


### PR DESCRIPTION
Continues the when-to-use trigger language series (following #2434, #2435, #2437, #2439, #2440, #2441).

Adds a `### When to use` section to the three remaining user-facing tools that were missing it:

- **choice**: use when the user needs to select from a discrete set of named alternatives and free-text would be ambiguous; don't use for simple yes/no or when the next step is clear
- **complete**: use only after all work is done and committed; don't call mid-task or while blocked on something fixable
- **restart**: use after modifying gptme config/tool files when a fresh process is needed; don't use as a workaround for unrelated errors

## Test plan
- [x] `test_tool_descriptions_within_openai_limit` passes — all three remain under the 1024-char OpenAI limit
- [x] `ruff format` and `ruff check` clean