### PR TITLE
docs(tools): add 9 missing tools to tools.rst

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -162,6 +162,10 @@ nitpick_ignore = [
     ("py:class", "gptme.hooks.elicitation.ElicitationHook"),
     # computer transport abstraction types
     ("py:class", "Action"),
+    # hook/command types referenced in new tool docstrings
+    ("py:class", "gptme.hooks.elicitation.ElicitationRequest"),
+    ("py:class", "gptme.hooks.types.StopPropagation"),
+    ("py:class", "gptme.commands.base.CommandContext"),
 ]
 
 # -- Options for HTML output -------------------------------------------------

--- a/docs/tools.rst
+++ b/docs/tools.rst
@@ -232,8 +232,6 @@ Todo
     :members:
     :noindex:
 
-.. _mcp:
-
 MCP
 ---
 

--- a/docs/tools.rst
+++ b/docs/tools.rst
@@ -12,12 +12,14 @@ Overview
 - `Read`_ - Read files in any format
 - `Save`_ - Create and overwrite files
 - `Patch`_ - Apply precise changes to existing files
+- `Morph`_ - Apply fast targeted edits using Morph Fast Apply
 
 💻 Code & Development
 ^^^^^^^^^^^^^^^^^^^^^
 
 - `Python`_ - Execute Python code interactively with full library access
 - `Shell`_ - Run shell commands and manage system processes
+- `GH`_ - Interact with GitHub issues, PRs, and repositories
 
 🌐 Web & Research
 ^^^^^^^^^^^^^^^^^
@@ -33,11 +35,31 @@ Overview
 - `Screenshot`_ - Capture your screen for visual context
 - `Computer`_ - Control desktop applications through visual interface
 
+🤝 User Interaction
+^^^^^^^^^^^^^^^^^^^
+
+- `Choice`_ - Present multiple-choice options to the user
+- `Elicit`_ - Request structured single-field input from the user
+- `Form`_ - Present a multi-field form for structured user input
+
 ⚡ Advanced Workflows
 ^^^^^^^^^^^^^^^^^^^^^
 
 - `Tmux`_ - Manage long-running processes in terminal sessions
 - `Subagent`_ - Delegate subtasks to specialized agent instances
+- `Complete`_ - Signal that the autonomous session is finished
+- `Restart`_ - Restart the gptme process after configuration changes
+
+🧠 Knowledge & Planning
+^^^^^^^^^^^^^^^^^^^^^^^
+
+- `Lessons`_ - Access contextual lessons and behavioral guidance
+- `Todo`_ - Manage a conversation-scoped working memory task list
+
+🔌 Extensions
+^^^^^^^^^^^^^
+
+- `MCP`_ - Discover and connect Model Context Protocol servers
 
 Combinations
 ^^^^^^^^^^^^
@@ -145,8 +167,79 @@ RAG
     :members:
     :noindex:
 
+Morph
+-----
+
+.. automodule:: gptme.tools.morph
+    :members:
+    :noindex:
+
+.. _gh:
+
+GH
+--
+
+.. automodule:: gptme.tools.gh
+    :members:
+    :noindex:
+
+Choice
+------
+
+.. automodule:: gptme.tools.choice
+    :members:
+    :noindex:
+
+Elicit
+------
+
+.. automodule:: gptme.tools.elicit
+    :members:
+    :noindex:
+
+Form
+----
+
+.. automodule:: gptme.tools.form
+    :members:
+    :noindex:
+
+Complete
+--------
+
+.. automodule:: gptme.tools.complete
+    :members:
+    :noindex:
+
+Restart
+-------
+
+.. automodule:: gptme.tools.restart
+    :members:
+    :noindex:
+
+Lessons
+-------
+
+.. automodule:: gptme.tools.lessons
+    :members:
+    :noindex:
+
+Todo
+----
+
+.. automodule:: gptme.tools.todo
+    :members:
+    :noindex:
+
+.. _mcp:
+
 MCP
 ---
 
 The Model Context Protocol (MCP) allows you to extend gptme with custom tools through external servers.
 See :doc:`mcp` for configuration and usage details.
+
+.. automodule:: gptme.tools.mcp
+    :members:
+    :noindex:

--- a/gptme/tools/base.py
+++ b/gptme/tools/base.py
@@ -321,10 +321,15 @@ class ToolSpec:
 
 {indent(self.instructions, "    ")}\n\n"""
         if self.get_examples():
+            examples_raw = self.get_examples()
+            examples_rst = transform_examples_to_chat_directives(examples_raw)
+            if ".. chat::" not in examples_rst:
+                # examples not in conversation format; render as literal code block
+                examples_rst = ".. code-block:: text\n\n" + indent(examples_raw, "   ")
             doc += f"""
 .. rubric:: Examples
 
-{transform_examples_to_chat_directives(self.get_examples())}\n\n
+{examples_rst}\n\n
 """
         # doc += """.. rubric:: Members"""
         return doc.strip()


### PR DESCRIPTION
## Summary

- Adds documentation entries for 9 user-facing tools that had module docstrings but no `docs/tools.rst` entries: `morph`, `gh`, `choice`, `elicit`, `form`, `complete`, `restart`, `lessons`, `todo`
- Expands the MCP section with `.. automodule::` so the module docstring renders
- Adds three new overview categories: **User Interaction**, **Knowledge & Planning**, **Extensions**
- All 9 tools already have `### When to use` trigger language (shipped in PRs #2434–#2442)

## Test plan

- [ ] All RST references resolve (validated with local Python script)
- [ ] CI docs build passes