### PR TITLE
fix(bot): avoid duplicate resolve failure comments

### DIFF
--- a/.github/actions/bot/action.yml
+++ b/.github/actions/bot/action.yml
@@ -80,7 +80,7 @@ runs:
         python /tmp/github_bot.py --mode "${{ inputs.mode }}" --workspace .
 
     - name: Report error
-      if: failure()
+      if: failure() && env.GPTME_BOT_HANDLED_FAILURE != '1'
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}

--- a/scripts/github_bot.py
+++ b/scripts/github_bot.py
@@ -74,6 +74,15 @@ def get_env(name: str, default: str | None = None, required: bool = False) -> st
     return value or ""
 
 
+def set_github_env(name: str, value: str) -> None:
+    """Expose state to subsequent GitHub Actions steps when available."""
+    github_env = os.environ.get("GITHUB_ENV")
+    if not github_env:
+        return
+    with Path(github_env).open("a", encoding="utf-8") as f:
+        f.write(f"{name}={value}\n")
+
+
 def run_command(
     cmd: list[str],
     check: bool = True,
@@ -223,6 +232,8 @@ def post_resolve_failure_comment(
             message,
         ]
     )
+    # Tell the composite action its generic fallback comment is no longer needed.
+    set_github_env("GPTME_BOT_HANDLED_FAILURE", "1")
 
 
 def check_allowlist(author: str, allowlist: str) -> bool:

--- a/tests/test_github_bot.py
+++ b/tests/test_github_bot.py
@@ -1,0 +1,64 @@
+"""Regression tests for scripts/github_bot.py."""
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+
+def _load_github_bot_module():
+    module_path = Path(__file__).resolve().parents[1] / "scripts" / "github_bot.py"
+    spec = importlib.util.spec_from_file_location("test_github_bot_module", module_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+github_bot = _load_github_bot_module()
+
+
+def test_post_resolve_failure_comment_marks_handled_failure(
+    monkeypatch, tmp_path: Path
+):
+    env_file = tmp_path / "github_env"
+    monkeypatch.setenv("GITHUB_ENV", str(env_file))
+
+    calls: list[list[str]] = []
+
+    def fake_run_command(
+        cmd: list[str],
+        check: bool = True,
+        capture: bool = False,
+        cwd: str | None = None,
+    ):
+        assert check is True
+        assert capture is False
+        assert cwd is None
+        calls.append(cmd)
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(github_bot, "run_command", fake_run_command)
+
+    github_bot.post_resolve_failure_comment(
+        "gptme/gptme",
+        2445,
+        "The gptme run failed or timed out.",
+        token="dummy",
+    )
+
+    assert calls == [
+        [
+            "gh",
+            "issue",
+            "comment",
+            "2445",
+            "--repo",
+            "gptme/gptme",
+            "--body",
+            "🤖 **gptme-bot** was unable to resolve this issue. The gptme run failed or timed out.",
+        ]
+    ]
+    assert env_file.read_text(encoding="utf-8") == "GPTME_BOT_HANDLED_FAILURE=1\n"


### PR DESCRIPTION
## Summary
- mark resolve-mode failures as already reported when `github_bot.py` posts a specific issue comment
- gate the composite action's generic fallback comment on that handled-failure flag
- add a regression test for the handled-failure marker

## Root Cause
PR #2445 taught resolve mode to post explicit issue-level failure comments, but the composite action still used `if: failure()` to decide whether to post its generic fallback comment. When `gptme` failed or timed out, both paths fired and the issue got two failure comments.

## Impact
Resolve-mode failures still produce a red workflow run, but the issue thread now gets one clear failure comment instead of a specific comment plus a generic duplicate.

## Validation
- `uv run --with requests --with pytest python -m pytest tests/test_github_bot.py -q`
- `uv run --with ruff python -m ruff check scripts/github_bot.py tests/test_github_bot.py`
- `python3 -m py_compile scripts/github_bot.py`
