### PR TITLE
fix(benchmark): raise cold threshold to 10s and increase runs to 10

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -41,7 +41,7 @@ jobs:
 
         # Cold startup: --prepare clears .pyc in repo AND virtualenv, drops OS page cache
         hyperfine \
-          --runs 5 \
+          --runs 10 \
           --prepare "find . '$VENV_PATH' -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null; sudo sh -c 'sync && echo 3 > /proc/sys/vm/drop_caches' 2>/dev/null; true" \
           --export-json cold.json \
           'poetry run python -c "from gptme.cli.main import main"'
@@ -69,7 +69,7 @@ jobs:
         COLD_TIME: ${{ steps.cold.outputs.cold_time }}
         WARM_TIME: ${{ steps.warm.outputs.warm_time }}
         # Thresholds in seconds (with margin for CI variability)
-        COLD_THRESHOLD: "6.0"
+        COLD_THRESHOLD: "10.0"
         WARM_THRESHOLD: "2.5"
       run: |
         echo "=== Startup Benchmark Results (hyperfine medians) ==="


### PR DESCRIPTION
## Summary

- Raises `COLD_THRESHOLD` from `6.0s` to `10.0s` — absorbs GitHub Actions runner variance
- Increases cold startup runs from `5` to `10` — more stable median from fewer outlier-dominated samples

## Why

Master CI has been failing spuriously on the Benchmark workflow. Root cause: the cold startup threshold is too tight for GHA runner noise.

**Observed failure (run 26287191176, commit abe287c8):**
- Cold startup: **8.308s ± 3.157s** (threshold: 6.0s) → FAIL  
- Warm startup: 1.377s ± 0.038s (threshold: 2.5s) → PASS

The stddev (3.157s) is **larger** than the excess over threshold (2.308s). With only 5 runs and `drop_caches` flushing to a variable-speed runner disk, any run can fail by chance. The Tauri icons commit that triggered this failure added zero Python imports — it's not a real regression.

10s still catches real regressions (e.g., a slow new import that adds 3-4s) while surviving slow GHA runners.

Closes #2448