### PR TITLE
fix(tests): skip test_search_perplexity on Perplexity/OpenRouter quota exhaustion

### DIFF
--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -197,6 +197,22 @@ def test_available_search_engines_prioritize_perplexity(monkeypatch):
     assert _available_search_engines() == ["perplexity", "google", "duckduckgo"]
 
 
+# Error patterns from Perplexity/OpenRouter that indicate quota or auth issues.
+# Tests that hit these should skip, not fail (same philosophy as conftest _QUOTA_ERROR_PATTERNS).
+_PERPLEXITY_SKIP_PATTERNS = [
+    "insufficient_quota",
+    "authentication_error",
+    "invalid x-api-key",
+    "invalid_api_key",
+]
+
+
+def _check_perplexity_skip(results: str, source: str = "Perplexity") -> None:
+    """Skip the test if results contain a quota or auth error."""
+    if any(p in results.lower() for p in _PERPLEXITY_SKIP_PATTERNS):
+        pytest.skip(f"{source} API quota/key issue: {results[:120]}")
+
+
 @pytest.mark.slow
 def test_search_perplexity(monkeypatch):
     """Test Perplexity search with both API types."""
@@ -212,9 +228,8 @@ def test_search_perplexity(monkeypatch):
     # Test the search works
     results = search("what is gptme", "perplexity")
     assert results, "Should get results from Perplexity"
-    assert "error" not in results.lower() or "Error" not in results, (
-        f"Got error: {results}"
-    )
+    _check_perplexity_skip(results)
+    assert "error" not in results.lower(), f"Got error: {results}"
 
     # If we have OpenRouter key, test that it works too
     if has_openrouter and not has_perplexity:
@@ -222,9 +237,8 @@ def test_search_perplexity(monkeypatch):
         monkeypatch.delenv("PERPLEXITY_API_KEY", raising=False)
         results2 = search("what is gptme", "perplexity")
         assert results2, "Should get results from OpenRouter"
-        assert "error" not in results2.lower() or "Error" not in results2, (
-            f"Got error: {results2}"
-        )
+        _check_perplexity_skip(results2, source="OpenRouter/Perplexity")
+        assert "error" not in results2.lower(), f"Got error: {results2}"
 
 
 @pytest.mark.slow

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -204,6 +204,11 @@ _PERPLEXITY_SKIP_PATTERNS = [
     "authentication_error",
     "invalid x-api-key",
     "invalid_api_key",
+    "rate limit",
+    "quota exceeded",
+    "billing hard limit",
+    "exceeded your current quota",
+    "spending limit",
 ]
 
 
@@ -227,8 +232,8 @@ def test_search_perplexity(monkeypatch):
 
     # Test the search works
     results = search("what is gptme", "perplexity")
-    assert results, "Should get results from Perplexity"
     _check_perplexity_skip(results)
+    assert results, "Should get results from Perplexity"
     assert "error" not in results.lower(), f"Got error: {results}"
 
     # If we have OpenRouter key, test that it works too
@@ -236,8 +241,8 @@ def test_search_perplexity(monkeypatch):
         # Clear Perplexity key to force OpenRouter usage
         monkeypatch.delenv("PERPLEXITY_API_KEY", raising=False)
         results2 = search("what is gptme", "perplexity")
-        assert results2, "Should get results from OpenRouter"
         _check_perplexity_skip(results2, source="OpenRouter/Perplexity")
+        assert results2, "Should get results from OpenRouter"
         assert "error" not in results2.lower(), f"Got error: {results2}"
 
 


### PR DESCRIPTION
## Summary

`test_search_perplexity` was failing (not skipping) when `OPENROUTER_API_KEY` is set but the Perplexity quota is exhausted via OpenRouter. Same root cause as #2444 (API key present but unusable) but for the Perplexity search path.

**Two fixes:**
- Add `_PERPLEXITY_SKIP_PATTERNS` and `_check_perplexity_skip()` helper that converts quota/auth errors to `pytest.skip()` calls, matching the spirit of `conftest._QUOTA_ERROR_PATTERNS`  
- Simplify the logically redundant assertion `"error" not in results.lower() or "Error" not in results` to `"error" not in results.lower()` (the `or` made the second condition dead code since lowercase check already covers it)

**Verified:** `test_search_perplexity` now `SKIPPED` instead of `FAILED` when quota is exhausted.

## Test plan

- [x] Run `pytest tests/test_browser.py::test_search_perplexity -v` with exhausted quota → `SKIPPED`
- [x] Pre-commit hooks pass