### PR TITLE
feat(tools): add vent tool for real-time friction signals

### DIFF
--- a/gptme/tools/vent.py
+++ b/gptme/tools/vent.py
@@ -1,0 +1,130 @@
+"""
+Vent/feedback tool — emits in-the-moment friction signals to a durable ledger.
+
+The agent calls this when stuck or frustrated. Signals are written to:
+  ~/.local/share/gptme/friction-ledger.jsonl
+
+Rate-limited to one vent per turn to prevent recursive venting spirals
+(Lovable found agents can spiral into 43+ vents without this guard).
+
+Usage::
+
+    ```vent
+    Stuck on import order: uv run pytest exits 0 with "no tests found"
+    even though tests/test_vent.py exists. Tried --co and explicit path.
+    Type: Type2a (config/permission)
+    ```
+
+Friction types (from Lovable's taxonomy):
+  Type 1  — solvable with better prompting / context
+  Type 2a — solvable with a tool, permission, or config change
+  Type 2b — not solvable in the current stack
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from contextvars import ContextVar
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from ..hooks import HookType
+from ..message import Message
+from .base import ToolSpec
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from ..logmanager import LogManager
+
+logger = logging.getLogger(__name__)
+
+# Per-turn rate-limit: blocks a second vent within the same agent turn.
+_vent_this_turn: ContextVar[bool] = ContextVar("vent_this_turn", default=False)
+
+
+def _get_ledger_path() -> Path:
+    """Return the friction ledger path, creating parent dirs if needed."""
+    from ..dirs import get_data_dir
+
+    path = get_data_dir() / "friction-ledger.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def execute_vent(
+    code: str | None,
+    args: list[str] | None,
+    kwargs: dict[str, str] | None,
+) -> Message:
+    """Append a friction entry to the ledger."""
+    if not code or not code.strip():
+        return Message("system", "vent: no message — nothing recorded.", quiet=True)
+
+    if _vent_this_turn.get():
+        return Message(
+            "system",
+            "vent: rate limit — only one vent per turn; signal not recorded.",
+            quiet=True,
+        )
+
+    _vent_this_turn.set(True)
+
+    entry = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "workspace": str(Path.cwd()),
+        "message": code.strip(),
+    }
+
+    ledger_path = _get_ledger_path()
+    with ledger_path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(entry) + "\n")
+
+    logger.info("Vent recorded to %s", ledger_path)
+    return Message("system", f"Friction signal recorded to {ledger_path}", quiet=True)
+
+
+def _reset_vent_limit(manager: LogManager) -> Generator[Message, None, None]:
+    """Reset per-turn rate limit before each generation step."""
+    _vent_this_turn.set(False)
+    yield from ()
+
+
+tool = ToolSpec(
+    name="vent",
+    desc="Emit a real-time friction signal when stuck or frustrated",
+    instructions="""
+Use when you are stuck, frustrated, or hitting a repeated failure. Write a
+brief description of what you're trying to do, what's blocking you, and
+optionally classify the type:
+
+- **Type 1** — solvable with better prompting or context
+- **Type 2a** — solvable with a tool, permission, or config change
+- **Type 2b** — not solvable in the current stack
+
+Rate-limited to **one vent per turn** to prevent recursive venting.
+Signals are written to the friction ledger for offline analysis.
+""".strip(),
+    examples="""
+> User: fix the failing test
+> Assistant:
+```vent
+Stuck: test expects a dict but execute returns a plain string.
+No kwarg to change the return shape; need to rethink the API.
+Type: Type1 (need better spec)
+```
+> System: Friction signal recorded to /home/user/.local/share/gptme/friction-ledger.jsonl
+""".strip(),
+    execute=execute_vent,
+    block_types=["vent"],
+    available=True,
+    hooks={
+        "reset_vent_limit": (
+            HookType.STEP_PRE.value,
+            _reset_vent_limit,
+            10,
+        ),
+    },
+)

--- a/gptme/tools/vent.py
+++ b/gptme/tools/vent.py
@@ -70,8 +70,6 @@ def execute_vent(
             quiet=True,
         )
 
-    _vent_this_turn.set(True)
-
     entry = {
         "timestamp": datetime.now(timezone.utc).isoformat(),
         "workspace": str(Path.cwd()),
@@ -82,6 +80,7 @@ def execute_vent(
     with ledger_path.open("a", encoding="utf-8") as fh:
         fh.write(json.dumps(entry) + "\n")
 
+    _vent_this_turn.set(True)
     logger.info("Vent recorded to %s", ledger_path)
     return Message("system", f"Friction signal recorded to {ledger_path}", quiet=True)
 
@@ -104,8 +103,9 @@ optionally classify the type:
 - **Type 2a** — solvable with a tool, permission, or config change
 - **Type 2b** — not solvable in the current stack
 
-Rate-limited to **one vent per turn** to prevent recursive venting.
-Signals are written to the friction ledger for offline analysis.
+Rate-limited to **one vent per turn** to prevent recursive venting spirals.
+Signals are written to the friction ledger for offline analysis and
+can be triaged to produce targeted fixes or lessons.
 """.strip(),
     examples="""
 > User: fix the failing test

--- a/gptme/tools/vent.py
+++ b/gptme/tools/vent.py
@@ -103,9 +103,8 @@ optionally classify the type:
 - **Type 2a** — solvable with a tool, permission, or config change
 - **Type 2b** — not solvable in the current stack
 
-Rate-limited to **one vent per turn** to prevent recursive venting spirals.
-Signals are written to the friction ledger for offline analysis and
-can be triaged to produce targeted fixes or lessons.
+Using this tool creates a durable record so recurring blockers can be
+identified and fixed, improving your future performance on similar tasks.
 """.strip(),
     examples="""
 > User: fix the failing test

--- a/tests/test_vent.py
+++ b/tests/test_vent.py
@@ -1,0 +1,90 @@
+"""Tests for the vent tool (friction signal emitter)."""
+
+import json
+
+import pytest
+
+from gptme.tools.vent import _reset_vent_limit, _vent_this_turn, execute_vent
+
+
+@pytest.fixture(autouse=True)
+def reset_rate_limit():
+    """Reset per-turn rate-limit flag before each test."""
+    _vent_this_turn.set(False)
+    yield
+    _vent_this_turn.set(False)
+
+
+@pytest.fixture()
+def ledger_path(tmp_path, monkeypatch):
+    """Point the vent ledger at a temp directory."""
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    return tmp_path / "gptme" / "friction-ledger.jsonl"
+
+
+class TestExecuteVent:
+    def test_records_entry(self, ledger_path):
+        msg = execute_vent("Stuck on import resolution", None, None)
+        assert "recorded" in msg.content.lower()
+        assert ledger_path.exists()
+        entries = [json.loads(line) for line in ledger_path.read_text().splitlines()]
+        assert len(entries) == 1
+        entry = entries[0]
+        assert entry["message"] == "Stuck on import resolution"
+        assert "timestamp" in entry
+        assert "workspace" in entry
+
+    def test_strips_whitespace(self, ledger_path):
+        execute_vent("  trailing spaces  \n", None, None)
+        entry = json.loads(ledger_path.read_text().strip())
+        assert entry["message"] == "trailing spaces"
+
+    def test_empty_message_no_write(self, ledger_path):
+        msg = execute_vent("", None, None)
+        assert "no message" in msg.content.lower()
+        assert not ledger_path.exists()
+
+    def test_whitespace_only_no_write(self, ledger_path):
+        msg = execute_vent("   \n\t  ", None, None)
+        assert "no message" in msg.content.lower()
+        assert not ledger_path.exists()
+
+    def test_none_message_no_write(self, ledger_path):
+        execute_vent(None, None, None)
+        assert not ledger_path.exists()
+
+    def test_rate_limit_blocks_second_vent(self, ledger_path):
+        execute_vent("First vent", None, None)
+        msg = execute_vent("Second vent", None, None)
+        assert "rate limit" in msg.content.lower()
+        # Only first vent recorded
+        entries = [json.loads(line) for line in ledger_path.read_text().splitlines()]
+        assert len(entries) == 1
+        assert entries[0]["message"] == "First vent"
+
+    def test_rate_limit_resets_after_hook(self, ledger_path):
+        execute_vent("First vent", None, None)
+        # Simulate step_pre hook firing between turns
+        list(_reset_vent_limit(None))  # type: ignore[arg-type]
+        msg = execute_vent("Second vent after reset", None, None)
+        assert "recorded" in msg.content.lower()
+        entries = [json.loads(line) for line in ledger_path.read_text().splitlines()]
+        assert len(entries) == 2
+
+    def test_entry_jsonl_format(self, ledger_path):
+        execute_vent("Line 1", None, None)
+        list(_reset_vent_limit(None))  # type: ignore[arg-type]
+        execute_vent("Line 2", None, None)
+        lines = ledger_path.read_text().splitlines()
+        assert len(lines) == 2
+        for line in lines:
+            json.loads(line)  # must be valid JSON
+
+    def test_ledger_appends_across_calls(self, ledger_path):
+        """Each vent appends; earlier entries are not overwritten."""
+        for i in range(3):
+            list(_reset_vent_limit(None))  # type: ignore[arg-type]
+            execute_vent(f"Vent {i}", None, None)
+        entries = [json.loads(line) for line in ledger_path.read_text().splitlines()]
+        assert len(entries) == 3
+        assert [e["message"] for e in entries] == ["Vent 0", "Vent 1", "Vent 2"]


### PR DESCRIPTION
## Summary

Adds a `vent` tool that lets agents emit in-the-moment friction signals when stuck or frustrated. Inspired by Lovable's `send_feedback` pattern which generates ~10 merged fixes/day.

**Key design:**
- Signals write to `~/.local/share/gptme/friction-ledger.jsonl` (append-only JSONL)
- **Rate-limited to one vent per turn** — Lovable hit a 43-vent recursive death-spiral without this
- Entry schema: `{timestamp, workspace, message}`
- Friction type taxonomy baked into instructions: Type 1 (prompting), Type 2a (config/permission), Type 2b (stack limitation)
- Hook (`step.pre`) resets the rate-limit flag before each new agent turn
- Auto-discovered via normal package scanning (no registration needed)

**Usage:**
```vent
Stuck on import resolution: uv run pytest exits 0 with "no tests found"
even though tests/test_vent.py exists. Tried --co and explicit path.
Type: Type2a (config/permission)
```

**Why this matters:**
Post-hoc friction extraction from journals (our current approach) is lossy — it only captures what made it into narrative. Agent-authored signals at the moment of friction are strictly higher fidelity for finding fixable Type-1/Type-2a blockers.

The ledger is intentionally simple — easy to grep, feed into `metaproductivity.friction`, or wire to a triage bot later.

## Test plan

- [x] 9 tests: basic recording, empty/None input, whitespace stripping, rate limit blocking, limit reset via hook, JSONL format validity, multi-entry append correctness
- [x] `test_tool_descriptions_within_openai_limit` passes (instructions: 485 chars, well under 1024)
- [x] Pre-commit hooks pass (ruff, mypy)