### PR TITLE
docs(tools): add missing autocommit, precommit, and vent tool entries

### DIFF
--- a/docs/tools.rst
+++ b/docs/tools.rst
@@ -20,6 +20,8 @@ Overview
 - `Python`_ - Execute Python code interactively with full library access
 - `Shell`_ - Run shell commands and manage system processes
 - `GH`_ - Interact with GitHub issues, PRs, and repositories
+- `Precommit`_ - Automatically run pre-commit checks after file saves
+- `Autocommit`_ - Automatically prompt for git commits after file modifications
 
 🌐 Web & Research
 ^^^^^^^^^^^^^^^^^
@@ -49,6 +51,7 @@ Overview
 - `Subagent`_ - Delegate subtasks to specialized agent instances
 - `Complete`_ - Signal that the autonomous session is finished
 - `Restart`_ - Restart the gptme process after configuration changes
+- `Vent`_ - Emit in-the-moment friction signals to a durable ledger
 
 🧠 Knowledge & Planning
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -201,6 +204,27 @@ Form
 ----
 
 .. automodule:: gptme.tools.form
+    :members:
+    :noindex:
+
+Precommit
+---------
+
+.. automodule:: gptme.tools.precommit
+    :members:
+    :noindex:
+
+Autocommit
+----------
+
+.. automodule:: gptme.tools.autocommit
+    :members:
+    :noindex:
+
+Vent
+----
+
+.. automodule:: gptme.tools.vent
     :members:
     :noindex:
 


### PR DESCRIPTION
## Summary

- Adds `Autocommit`, `Precommit`, and `Vent` to the Tools overview in `docs/tools.rst`
- Adds `automodule` directive sections for each so their docstrings appear in the rendered docs
- `Precommit`/`Autocommit` listed under "💻 Code & Development"; `Vent` listed under "⚡ Advanced Workflows"

These three tools exist in `gptme/tools/` and are shipped in the package but were missing from the documentation overview entirely.

## Test plan

- [ ] Verify Sphinx build renders the three new sections without errors (`make -C docs html`)
- [ ] Check that the overview links (`Precommit_`, `Autocommit_`, `Vent_`) resolve correctly