### PR TITLE
fix(webui): include status code and server error in models fetch failure

### DIFF
--- a/webui/src/hooks/useModels.ts
+++ b/webui/src/hooks/useModels.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useApi } from '@/contexts/ApiContext';
+import { buildModelsFetchError } from '@/utils/modelsError';
 
 export interface ModelInfo {
   id: string;
@@ -47,7 +48,7 @@ export function useModels() {
         });
 
         if (!response.ok) {
-          throw new Error(`Failed to fetch models: ${response.statusText}`);
+          throw await buildModelsFetchError(response);
         }
 
         const data: ModelsResponse = await response.json();

--- a/webui/src/utils/__tests__/modelsError.test.ts
+++ b/webui/src/utils/__tests__/modelsError.test.ts
@@ -1,0 +1,61 @@
+import { buildModelsFetchError } from '../modelsError';
+
+interface MockResponseOpts {
+  status: number;
+  statusText?: string;
+  jsonBody?: unknown;
+  jsonThrows?: boolean;
+}
+
+// Minimal stand-in for the parts of `Response` that buildModelsFetchError uses
+// (jsdom does not provide a usable global Response).
+function mockResponse(opts: MockResponseOpts): Response {
+  return {
+    status: opts.status,
+    statusText: opts.statusText ?? '',
+    clone() {
+      return {
+        json: async () => {
+          if (opts.jsonThrows) {
+            throw new Error('not json');
+          }
+          return opts.jsonBody;
+        },
+      };
+    },
+  } as unknown as Response;
+}
+
+describe('buildModelsFetchError', () => {
+  it('surfaces the status code and server error body for a 401 with empty statusText', async () => {
+    const err = await buildModelsFetchError(
+      mockResponse({
+        status: 401,
+        statusText: '',
+        jsonBody: { error: 'Missing authentication credentials' },
+      })
+    );
+    expect(err.message).toBe('Failed to fetch models: 401 Missing authentication credentials');
+  });
+
+  it('falls back to statusText when the body has no error field', async () => {
+    const err = await buildModelsFetchError(
+      mockResponse({ status: 500, statusText: 'Internal Server Error', jsonBody: {} })
+    );
+    expect(err.message).toBe('Failed to fetch models: 500 Internal Server Error');
+  });
+
+  it('falls back to statusText when the body is not JSON', async () => {
+    const err = await buildModelsFetchError(
+      mockResponse({ status: 502, statusText: 'Bad Gateway', jsonThrows: true })
+    );
+    expect(err.message).toBe('Failed to fetch models: 502 Bad Gateway');
+  });
+
+  it('still reports the status code when neither body error nor statusText is present', async () => {
+    const err = await buildModelsFetchError(
+      mockResponse({ status: 401, statusText: '', jsonThrows: true })
+    );
+    expect(err.message).toBe('Failed to fetch models: 401');
+  });
+});

--- a/webui/src/utils/modelsError.ts
+++ b/webui/src/utils/modelsError.ts
@@ -1,0 +1,23 @@
+/**
+ * Build an informative error for a failed `/api/v2/models` response.
+ *
+ * `response.statusText` is frequently empty over HTTP/2 and behind proxies, so
+ * the previous `Failed to fetch models: ${response.statusText}` could degrade
+ * to "Failed to fetch models: " with no indication of the cause (e.g. a 401
+ * from an auth-protected server). This includes the status code and, when
+ * available, the server-provided error body (e.g.
+ * `{"error":"Missing authentication credentials"}`).
+ */
+export async function buildModelsFetchError(response: Response): Promise<Error> {
+  let detail = response.statusText;
+  try {
+    const body = await response.clone().json();
+    if (body && typeof body.error === 'string' && body.error) {
+      detail = body.error;
+    }
+  } catch {
+    // Body is not JSON or already consumed; fall back to statusText.
+  }
+  const suffix = detail ? ` ${detail}` : '';
+  return new Error(`Failed to fetch models: ${response.status}${suffix}`);
+}


### PR DESCRIPTION
## Problem

The model list fetch in `useModels` threw:

```ts
throw new Error(`Failed to fetch models: ${response.statusText}`);
```

`response.statusText` is frequently **empty** over HTTP/2 and behind proxies, so the message degraded to `Failed to fetch models: ` with no indication of the cause, and the response body (which carries the real diagnostic) was never read.

## How I found it

Live user-testing of the gptme-tauri desktop app (dev build `0.31.1-dev.20260521`) on a clean profile. The app reused a leftover **auth-protected** `gptme-server` on `:5700`; `/api/v2/models` returned `401 {"error":"Missing authentication credentials"}`, but the webview only logged the opaque:

```
[webview][ERROR] Failed to fetch models: {}
```

(The `{}` is the classic `JSON.stringify(Error)` → `{}` over the Tauri log bridge, on top of the empty `statusText`.)

## Fix

Extract `buildModelsFetchError(response)` (in `webui/src/utils/modelsError.ts`) which includes the HTTP **status code** and, when available, the server-provided **error body** (e.g. `{"error":"..."}`), falling back to `statusText`. The 401 case now reads:

```
Failed to fetch models: 401 Missing authentication credentials
```

## Tests

`webui/src/utils/__tests__/modelsError.test.ts` — 4 cases (401 + empty statusText with body error, statusText fallback when body lacks `error`, non-JSON body fallback, status-only when both empty). All pass; `tsc -p tsconfig.app.json --noEmit` clean.

## Notes / follow-ups (out of scope)

Found during the same session, filed separately if confirmed: the tauri "reuse any listener on :5700" heuristic doesn't verify it can authenticate against that server, which is what surfaces this error in the first place.

Co-authored-by: Bob <bob@superuserlabs.org>