### PR TITLE
fix(site): remove broken homepage TOC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,10 +119,9 @@ site: site/dist/index.html site/dist/docs site/dist/downloads/index.html
 .PHONY: site/dist/index.html
 site/dist/index.html: README.md site/dist/style.css site/template.html
 	mkdir -p site/dist
-	sed '1s/Website/GitHub/;1s|https://gptme.org/|https://github.com/gptme/gptme|' README.md | \
-	cat README.md \
+	awk 'BEGIN { skip=0 } /^## .*Table of Contents$$/ { skip=1; next } skip && /^## / { skip=0 } !skip { print }' README.md \
 		| sed '0,/Website/{s/Website/GitHub/}' - \
-		| sed '0,/gptme.org\/\"/{s/gptme.org\/\"/github.com\/ErikBjare\/gptme\"/}' - \
+		| sed '0,/gptme.org\/\"/{s/gptme.org\/\"/github.com\/gptme\/gptme\"/}' - \
 		| pandoc -s -f gfm -t html5 -o $@ --metadata title="gptme - agent in your terminal" --css style.css --template=site/template.html
 	cp -r media site/dist
 


### PR DESCRIPTION
## Summary
- strip the manual README table of contents from the `gptme.org` homepage build
- keep the README unchanged on GitHub, where the manual TOC still works
- fix the homepage's rewritten GitHub link to point at `gptme/gptme`

## Why
The homepage is rendered from `README.md` via pandoc, and pandoc's heading IDs do not match the README's GitHub-authored TOC slugs for emoji headings. That leaves most homepage TOC links dead.

Removing the manual TOC from the homepage build is the smallest fix: it avoids README churn and avoids trying to emulate GitHub's slugger inside pandoc.

## Verification
- `make site/dist/index.html`
- confirmed `site/dist/index.html` no longer contains the manual TOC links
- confirmed the rendered top-nav GitHub link now points at `https://github.com/gptme/gptme`
