### PR TITLE
fix(tests): bump short prompt token limit to 4200

### DIFF
--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -35,7 +35,7 @@ def test_get_prompt_short():
 
     # TODO: make the short prompt shorter
     # Note: Lesson system additions increased prompt size slightly
-    assert 500 < len_tokens(combined_content, "gpt-4") < 4000 + user_config_size
+    assert 500 < len_tokens(combined_content, "gpt-4") < 4200 + user_config_size
 
 
 def test_get_prompt_custom():


### PR DESCRIPTION
Prompt grew to 4017 tokens due to lesson system additions (the existing TODO note in the test anticipated this). Bumps the limit from 4000 to 4200 to restore headroom and unblock master CI.

Closes the regression introduced when #2459 was merged with the pre-existing failure in `test_get_prompt_short`.

## Test
```
pytest tests/test_prompts.py::test_get_prompt_short  # passes
```