### PR TITLE
fix(hooks): replace invalid noqa directives in auto_snapshots

### DIFF
--- a/gptme/hooks/auto_snapshots.py
+++ b/gptme/hooks/auto_snapshots.py
@@ -249,7 +249,7 @@ def _pre(
     except Exception as e:  # pragma: no cover — defensive
         logger.warning("auto-snapshot pre failed: %s", e)
     return
-    yield  # noqa: unreachable — presence of `yield` makes this a generator; matches cwd_changed.py shape
+    yield  # make generator — presence of `yield` makes this a generator; matches cwd_changed.py shape
 
 
 def _post(
@@ -279,7 +279,7 @@ def _post(
     except Exception as e:  # pragma: no cover — defensive
         logger.warning("auto-snapshot post failed: %s", e)
     return
-    yield  # noqa: unreachable — presence of `yield` makes this a generator; matches cwd_changed.py shape
+    yield  # make generator — presence of `yield` makes this a generator; matches cwd_changed.py shape
 
 
 def register() -> None:


### PR DESCRIPTION
## Problem

`gptme/hooks/auto_snapshots.py` has two `yield` lines annotated with `# noqa: unreachable`:

```python
return
yield  # noqa: unreachable — presence of `yield` makes this a generator; ...
```

`unreachable` is **not a valid ruff rule code**, so `ruff check` emits a warning on every run:

```
warning: Invalid `# noqa` directive on gptme/hooks/auto_snapshots.py:252: expected a comma-separated list of codes (e.g., `# noqa: F401, F841`).
warning: Invalid `# noqa` directive on gptme/hooks/auto_snapshots.py:282: ...
```

There is nothing real to suppress — ruff has no unreachable-code rule, and the sibling hook `cwd_changed.py` uses the same `return; yield` generator idiom with a plain `# make generator` comment and no noqa.

## Fix

Convert the malformed directives to plain comments, matching the canonical `cwd_changed.py` shape. Behavior is unchanged (comment-only edit).

## Verification

- `ruff check gptme/` — no more invalid-noqa warnings (exit 0, clean)
- `ruff format --check` — clean
- Comment-only change; generator semantics unchanged