### PR TITLE
fix(webui): surface payment-required chat errors

### DIFF
--- a/webui/src/hooks/useConversation.ts
+++ b/webui/src/hooks/useConversation.ts
@@ -26,7 +26,7 @@ import {
 import { playChime } from '@/utils/audio';
 import { findLatestAssistantIndexForError } from '@/utils/conversationErrorHandling';
 import { notifyGenerationComplete, notifyToolConfirmation } from '@/utils/notifications';
-import { ApiClientError } from '@/utils/api';
+import { ApiClientError, getApiErrorPresentation } from '@/utils/api';
 import { toastStepStartError } from '@/utils/stepErrorHandling';
 
 const MAX_CONNECTED_CONVERSATIONS = 3;
@@ -460,12 +460,15 @@ export function useConversation(conversationId: string, serverId?: string) {
       await api.step(conversationId, options?.model, options?.stream);
     } catch (error) {
       console.error('Error sending message:', error);
-      const errorMsg = error instanceof Error ? error.message : 'Failed to send message';
-      setMessageStatus(conversationId, userMessage.timestamp!, 'failed', errorMsg);
+      const { title, description } = getApiErrorPresentation(error, {
+        fallbackTitle: 'Failed to send',
+        fallbackDescription: 'Failed to send message',
+      });
+      setMessageStatus(conversationId, userMessage.timestamp!, 'failed', description);
       toast({
         variant: 'destructive',
-        title: 'Failed to send',
-        description: errorMsg,
+        title,
+        description,
       });
     }
   };

--- a/webui/src/hooks/useConversation.ts
+++ b/webui/src/hooks/useConversation.ts
@@ -515,13 +515,18 @@ export function useConversation(conversationId: string, serverId?: string) {
           setPendingTool(conversationId, null, null);
         }
 
+        const fallbackDescription =
+          attempt > 1
+            ? `Failed to confirm tool after ${attempt} attempts`
+            : 'Failed to confirm tool';
+        const { title, description } = getApiErrorPresentation(error, {
+          fallbackTitle: 'Error',
+          fallbackDescription,
+        });
         toast({
           variant: 'destructive',
-          title: 'Error',
-          description:
-            attempt > 1
-              ? `Failed to confirm tool after ${attempt} attempts`
-              : 'Failed to confirm tool',
+          title,
+          description,
         });
 
         throw error;

--- a/webui/src/utils/__tests__/api.test.ts
+++ b/webui/src/utils/__tests__/api.test.ts
@@ -196,4 +196,20 @@ describe('getApiErrorPresentation', () => {
       description: 'Boom',
     });
   });
+
+  it('elevates authentication errors to an authentication-failed title', () => {
+    const error = new ApiClientError('Invalid or expired token.', 401, {
+      type: 'authentication_error',
+    });
+
+    expect(
+      getApiErrorPresentation(error, {
+        fallbackTitle: 'Failed to send',
+        fallbackDescription: 'Failed to send message',
+      })
+    ).toEqual({
+      title: 'Authentication failed',
+      description: 'Invalid or expired token.',
+    });
+  });
 });

--- a/webui/src/utils/__tests__/api.test.ts
+++ b/webui/src/utils/__tests__/api.test.ts
@@ -10,7 +10,7 @@ jest.mock('@/stores/servers', () => ({
   getPrimaryClient: jest.fn(),
 }));
 
-import { ApiClient, ApiClientError, isLikelyChromeCorsPna } from '../api';
+import { ApiClient, ApiClientError, getApiErrorPresentation, isLikelyChromeCorsPna } from '../api';
 
 describe('isLikelyChromeCorsPna', () => {
   const setHostname = (hostname: string) => {
@@ -164,5 +164,36 @@ describe('ApiClient error parsing', () => {
       code: 'no_subscription',
       type: 'payment_required',
     } satisfies Partial<ApiClientError>);
+  });
+});
+
+describe('getApiErrorPresentation', () => {
+  it('elevates payment errors to a payment-required title', () => {
+    const error = new ApiClientError('Insufficient credits. Visit gptme.ai to add more.', 402, {
+      type: 'payment_required',
+      code: 'insufficient_credits',
+    });
+
+    expect(
+      getApiErrorPresentation(error, {
+        fallbackTitle: 'Failed to send',
+        fallbackDescription: 'Failed to send message',
+      })
+    ).toEqual({
+      title: 'Payment required',
+      description: 'Insufficient credits. Visit gptme.ai to add more.',
+    });
+  });
+
+  it('preserves fallback title for generic errors while surfacing the message', () => {
+    expect(
+      getApiErrorPresentation(new Error('Boom'), {
+        fallbackTitle: 'Failed to send',
+        fallbackDescription: 'Failed to send message',
+      })
+    ).toEqual({
+      title: 'Failed to send',
+      description: 'Boom',
+    });
   });
 });

--- a/webui/src/utils/api.ts
+++ b/webui/src/utils/api.ts
@@ -50,6 +50,36 @@ export class ApiClientError extends Error {
   }
 }
 
+export function getApiErrorPresentation(
+  error: unknown,
+  options?: {
+    fallbackTitle?: string;
+    fallbackDescription?: string;
+  }
+): { title: string; description: string } {
+  let title = options?.fallbackTitle ?? 'Error';
+  let description = options?.fallbackDescription ?? 'Something went wrong';
+
+  if (ApiClientError.isApiError(error)) {
+    description = error.message || description;
+
+    if (
+      error.status === 402 ||
+      error.type === 'payment_required' ||
+      error.code === 'insufficient_credits' ||
+      error.code === 'no_subscription'
+    ) {
+      title = 'Payment required';
+    } else if (error.status === 401 || error.type === 'authentication_error') {
+      title = 'Authentication failed';
+    }
+  } else if (error instanceof Error && error.message) {
+    description = error.message;
+  }
+
+  return { title, description };
+}
+
 // Type guard for API error responses
 function isApiErrorResponse(response: unknown): response is ApiError {
   return typeof response === 'object' && response !== null && 'error' in response;


### PR DESCRIPTION
## Summary
- add a small presentation helper for API client errors in the webui
- show a `Payment required` toast title for subscription/credit failures while preserving the real server message
- extend the existing API client tests to lock the payment-error presentation in

## Verification
- `npm test -- api.test.ts`
- `npm test -- ChatMessage.test.tsx`
- `npm run typecheck`

Related to gptme/gptme-cloud#61.