### PR TITLE
fix(vent): teach resolution-owner taxonomy, capture owner tag

### DIFF
--- a/gptme/tools/vent.py
+++ b/gptme/tools/vent.py
@@ -10,21 +10,30 @@ Rate-limited to one vent per turn to prevent recursive venting spirals
 Usage::
 
     ```vent
-    Stuck on import order: uv run pytest exits 0 with "no tests found"
-    even though tests/test_vent.py exists. Tried --co and explicit path.
-    Type: Type2a (config/permission)
+    pytest exits 0 with "no tests found" even though tests/test_vent.py
+    exists. Tried --co and an explicit path; the discovery config is wrong.
+    Owner: tooling
     ```
 
-Friction types (from Lovable's taxonomy):
-  Type 1  — solvable with better prompting / context
-  Type 2a — solvable with a tool, permission, or config change
-  Type 2b — not solvable in the current stack
+Resolution owner (axis 1 — who/what unblocks this) is an optional, small,
+stable enum captured at vent time. Richer theme/cause clustering happens later
+at analysis time, so keep the capture label thin:
+
+  self          Solvable now with better prompting / context / reasoning
+  tooling       Needs a tool / permission / config / env change
+  operator      Needs a human (decision, credential, approval, account action)
+  upstream      Needs a fix in a dependency we don't own
+  architectural Not solvable in the current stack design
+
+The deprecated ``Type`` labels are still accepted as aliases
+(Type1->self, Type2a->tooling, Type2b->architectural, Type0->operator).
 """
 
 from __future__ import annotations
 
 import json
 import logging
+import re
 from contextvars import ContextVar
 from datetime import datetime, timezone
 from pathlib import Path
@@ -44,6 +53,20 @@ logger = logging.getLogger(__name__)
 # Per-turn rate-limit: blocks a second vent within the same agent turn.
 _vent_this_turn: ContextVar[bool] = ContextVar("vent_this_turn", default=False)
 
+# Axis 1: who/what unblocks this. Small, stable, captured at vent time.
+VALID_OWNERS = ("self", "tooling", "operator", "upstream", "architectural")
+
+# Deprecated Lovable-style type labels -> resolution owner.
+_DEPRECATED_TYPE_MAP = {
+    "type0": "operator",
+    "type1": "self",
+    "type2a": "tooling",
+    "type2b": "architectural",
+}
+
+# A trailing "Owner: X" / "Type: X" / "Resolution: X" line (case-insensitive).
+_OWNER_LINE_RE = re.compile(r"^(?:owner|type|resolution)\s*[:=]\s*(.+)$", re.IGNORECASE)
+
 
 def _get_ledger_path() -> Path:
     """Return the friction ledger path, creating parent dirs if needed."""
@@ -52,6 +75,36 @@ def _get_ledger_path() -> Path:
     path = get_data_dir() / "friction-ledger.jsonl"
     path.parent.mkdir(parents=True, exist_ok=True)
     return path
+
+
+def _parse_resolution_owner(code: str) -> tuple[str, str | None]:
+    """Split an optional trailing owner tag off a vent message.
+
+    Recognizes a final line like ``Owner: tooling``, ``Type: Type2a``, or
+    ``Resolution: operator`` (case-insensitive). Returns the message with that
+    line removed and the normalized resolution owner, or the original message
+    and ``None`` when no valid tag is present (an unrecognized value is left
+    as part of the message rather than silently dropped).
+    """
+    lines = code.rstrip().splitlines()
+    if not lines:
+        return code.strip(), None
+
+    match = _OWNER_LINE_RE.match(lines[-1].strip())
+    if not match:
+        return code.strip(), None
+
+    # Drop any parenthetical note, e.g. "tooling (need API key)" -> "tooling".
+    raw = match.group(1).strip()
+    token = (
+        raw.split("(", 1)[0].split()[0].lower() if raw.split("(", 1)[0].split() else ""
+    )
+    owner = _DEPRECATED_TYPE_MAP.get(token, token)
+    if owner not in VALID_OWNERS:
+        return code.strip(), None
+
+    message = "\n".join(lines[:-1]).strip()
+    return message, owner
 
 
 def execute_vent(
@@ -70,11 +123,17 @@ def execute_vent(
             quiet=True,
         )
 
-    entry = {
+    message, resolution_owner = _parse_resolution_owner(code)
+    if not message:
+        return Message("system", "vent: no message — nothing recorded.", quiet=True)
+
+    entry: dict[str, str] = {
         "timestamp": datetime.now(timezone.utc).isoformat(),
         "workspace": str(Path.cwd()),
-        "message": code.strip(),
+        "message": message,
     }
+    if resolution_owner:
+        entry["resolution_owner"] = resolution_owner
 
     ledger_path = _get_ledger_path()
     with ledger_path.open("a", encoding="utf-8") as fh:
@@ -96,15 +155,19 @@ tool = ToolSpec(
     desc="Emit a real-time friction signal when stuck or frustrated",
     instructions="""
 Use when you are stuck, frustrated, or hitting a repeated failure. Write a
-brief description of what you're trying to do, what's blocking you, and
-optionally classify the type:
+brief description of what you're trying to do and what's blocking you, then
+optionally tag who/what would unblock it on a final line (``Owner: <owner>``):
 
-- **Type 1** — solvable with better prompting or context
-- **Type 2a** — solvable with a tool, permission, or config change
-- **Type 2b** — not solvable in the current stack
+- **self** — solvable now with better prompting / context / reasoning
+- **tooling** — needs a tool, permission, config, or env change
+- **operator** — needs a human (decision, credential, approval, account action)
+- **upstream** — needs a fix in a dependency we don't own
+- **architectural** — not solvable in the current stack design
 
-Using this tool creates a durable record so recurring blockers can be
-identified and fixed, improving your future performance on similar tasks.
+The owner tag is optional and intentionally small; richer cause analysis
+happens later over the ledger. Using this tool creates a durable record so
+recurring blockers can be identified and fixed, improving your future
+performance on similar tasks.
 """.strip(),
     examples="""
 > User: fix the failing test
@@ -112,7 +175,7 @@ identified and fixed, improving your future performance on similar tasks.
 ```vent
 Stuck: test expects a dict but execute returns a plain string.
 No kwarg to change the return shape; need to rethink the API.
-Type: Type1 (need better spec)
+Owner: self
 ```
 > System: Friction signal recorded to /home/user/.local/share/gptme/friction-ledger.jsonl
 """.strip(),

--- a/gptme/tools/vent.py
+++ b/gptme/tools/vent.py
@@ -25,8 +25,9 @@ at analysis time, so keep the capture label thin:
   upstream      Needs a fix in a dependency we don't own
   architectural Not solvable in the current stack design
 
-The deprecated ``Type`` labels are still accepted as aliases
-(Type1->self, Type2a->tooling, Type2b->architectural, Type0->operator).
+The ``Type`` keyword accepts both deprecated legacy aliases
+(Type1->self, Type2a->tooling, Type2b->architectural, Type0->operator) and
+current taxonomy values (e.g. ``Type: self``, ``Type: tooling``).
 """
 
 from __future__ import annotations
@@ -96,9 +97,8 @@ def _parse_resolution_owner(code: str) -> tuple[str, str | None]:
 
     # Drop any parenthetical note, e.g. "tooling (need API key)" -> "tooling".
     raw = match.group(1).strip()
-    token = (
-        raw.split("(", 1)[0].split()[0].lower() if raw.split("(", 1)[0].split() else ""
-    )
+    before_paren = raw.split("(", 1)[0]
+    token = before_paren.split()[0].lower() if before_paren.split() else ""
     owner = _DEPRECATED_TYPE_MAP.get(token, token)
     if owner not in VALID_OWNERS:
         return code.strip(), None
@@ -164,10 +164,10 @@ optionally tag who/what would unblock it on a final line (``Owner: <owner>``):
 - **upstream** — needs a fix in a dependency we don't own
 - **architectural** — not solvable in the current stack design
 
-The owner tag is optional and intentionally small; richer cause analysis
-happens later over the ledger. Using this tool creates a durable record so
-recurring blockers can be identified and fixed, improving your future
-performance on similar tasks.
+Tag it when you know who would unblock you — the tag is optional, and an
+imprecise guess is more useful than none. Using this tool creates a durable
+record so recurring blockers can be identified and fixed, improving your
+future performance on similar tasks.
 """.strip(),
     examples="""
 > User: fix the failing test

--- a/tests/test_vent.py
+++ b/tests/test_vent.py
@@ -4,7 +4,12 @@ import json
 
 import pytest
 
-from gptme.tools.vent import _reset_vent_limit, _vent_this_turn, execute_vent
+from gptme.tools.vent import (
+    _parse_resolution_owner,
+    _reset_vent_limit,
+    _vent_this_turn,
+    execute_vent,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -88,3 +93,78 @@ class TestExecuteVent:
         entries = [json.loads(line) for line in ledger_path.read_text().splitlines()]
         assert len(entries) == 3
         assert [e["message"] for e in entries] == ["Vent 0", "Vent 1", "Vent 2"]
+
+
+class TestParseResolutionOwner:
+    def test_no_tag_returns_none(self):
+        msg, owner = _parse_resolution_owner("Just a plain message with no tag")
+        assert msg == "Just a plain message with no tag"
+        assert owner is None
+
+    @pytest.mark.parametrize(
+        "owner", ["self", "tooling", "operator", "upstream", "architectural"]
+    )
+    def test_valid_owners(self, owner):
+        msg, parsed = _parse_resolution_owner(f"Blocked on X\nOwner: {owner}")
+        assert msg == "Blocked on X"
+        assert parsed == owner
+
+    def test_case_insensitive_keyword_and_value(self):
+        msg, owner = _parse_resolution_owner("Stuck\nOWNER: Tooling")
+        assert msg == "Stuck"
+        assert owner == "tooling"
+
+    @pytest.mark.parametrize(
+        ("label", "expected"),
+        [
+            ("Type0", "operator"),
+            ("Type1", "self"),
+            ("Type2a", "tooling"),
+            ("Type2b", "architectural"),
+        ],
+    )
+    def test_deprecated_type_aliases(self, label, expected):
+        msg, owner = _parse_resolution_owner(f"Old style vent\nType: {label}")
+        assert msg == "Old style vent"
+        assert owner == expected
+
+    def test_parenthetical_note_stripped(self):
+        msg, owner = _parse_resolution_owner(
+            "Need a key\nOwner: tooling (missing API key)"
+        )
+        assert msg == "Need a key"
+        assert owner == "tooling"
+
+    def test_resolution_keyword_and_equals_separator(self):
+        msg, owner = _parse_resolution_owner("Stuck\nResolution = upstream")
+        assert msg == "Stuck"
+        assert owner == "upstream"
+
+    def test_invalid_owner_kept_in_message(self):
+        # An unrecognized value is not silently dropped — it stays in the message.
+        msg, owner = _parse_resolution_owner("Stuck\nOwner: banana")
+        assert msg == "Stuck\nOwner: banana"
+        assert owner is None
+
+    def test_owner_only_yields_empty_message(self):
+        msg, owner = _parse_resolution_owner("Owner: tooling")
+        assert msg == ""
+        assert owner == "tooling"
+
+
+class TestExecuteVentWithOwner:
+    def test_records_resolution_owner(self, ledger_path):
+        execute_vent("Blocked: need a credential\nOwner: operator", None, None)
+        entry = json.loads(ledger_path.read_text().strip())
+        assert entry["message"] == "Blocked: need a credential"
+        assert entry["resolution_owner"] == "operator"
+
+    def test_no_owner_omits_field(self, ledger_path):
+        execute_vent("Plain vent without a tag", None, None)
+        entry = json.loads(ledger_path.read_text().strip())
+        assert "resolution_owner" not in entry
+
+    def test_owner_only_no_description_not_recorded(self, ledger_path):
+        msg = execute_vent("Owner: tooling", None, None)
+        assert "no message" in msg.content.lower()
+        assert not ledger_path.exists()


### PR DESCRIPTION
## Problem

The `vent` tool's `instructions`/`examples` still taught the deprecated Lovable `Type1`/`Type2a`/`Type2b` taxonomy. Everywhere else friction is captured and analyzed has moved to the **resolution-owner** axis (`self`/`tooling`/`operator`/`upstream`/`architectural`) — the cross-harness `vent.py` script, agent `AGENTS.md`/`CLAUDE.md` guidance, and the friction-taxonomy design work. So the in-the-moment label the tool teaches contradicts the label the analysis layer expects, and native gptme vents carried no routing field at all.

## Changes

- Update the module docstring, `instructions`, and `examples` to the resolution-owner taxonomy (who/what unblocks this), keeping the capture label intentionally small.
- Parse an optional trailing `Owner:` / `Type:` / `Resolution:` line into a `resolution_owner` field on the ledger entry. The deprecated `Type0/1/2a/2b` labels are accepted as aliases (`Type1->self`, `Type2a->tooling`, `Type2b->architectural`, `Type0->operator`).
- An unrecognized value (e.g. `Owner: banana`) is left in the message rather than silently dropped.
- Tests for parsing, alias mapping, parenthetical-note stripping, and the `execute_vent` integration.

## Scope

Capture stays thin (the tag is optional, single enum); richer theme/cause clustering remains an analysis-time concern. No change to the rate-limit, ledger path, or block syntax.

## Verification

- `pytest tests/test_vent.py` — 27 passed (12 existing + 15 new)
- `ruff check` / `ruff format` clean