### PR TITLE
ci: pass GITHUB_TOKEN to dorny/paths-filter to avoid unauthenticated fetch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,7 @@ jobs:
     - uses: dorny/paths-filter@v4
       id: filter
       with:
+        token: ${{ secrets.GITHUB_TOKEN }}
         filters: |
           code:
             - 'gptme/**'


### PR DESCRIPTION
## Problem

The `Detect changes` job (using `dorny/paths-filter@v4`) intermittently fails on pushes to master with:

```
fatal: could not read Username for 'https://github.com': No such device or address
fatal: the remote end hung up unexpectedly
```

When the workflow runs on a push event, `paths-filter` needs to compare against the previous commit. Since checkout is shallow (depth=1), the previous commit isn't present locally. The action falls back to fetching it via unauthenticated HTTPS — which fails when the CI runner hits DNS/network issues.

This caused run https://github.com/gptme/gptme/actions/runs/26332362309 to fail, skipping all actual tests.

## Fix

Pass `token: ${{ secrets.GITHUB_TOKEN }}` to `dorny/paths-filter`. With the token, the action uses the GitHub API to compute the diff instead of falling back to unauthenticated git fetch. This is the [documented fix](https://github.com/dorny/paths-filter?tab=readme-ov-file#token) for this class of failure.

## Testing

Already re-ran the failing CI job — this PR adds the structural fix so the failure can't recur.