### PR TITLE
feat(llm): surface diagnostic for generic out-of-credits 402 errors

### DIFF
--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -581,25 +581,53 @@ def _handle_openai_transient_error(e, attempt, max_retries, base_delay):
                 for keyword in ["overload", "internal", "timeout"]
             ):
                 should_retry = True
-            elif e.status_code == 402 and any(
-                hint in combined_error
-                for hint in ("affordable", "more credits", "fewer max_tokens")
-            ):
-                # OpenRouter reserves model.max_output + reasoning_budget worth
-                # of credits when max_tokens is omitted. A partially-spent key
-                # then rejects requests as 402 even with plenty of room for the
-                # actual response. Eval callers silently swallow the resulting
-                # APIStatusError as gen_stderr and write empty conversation.jsonl,
-                # so we surface an actionable diagnostic before re-raising.
-                # See: https://github.com/gptme/gptme/issues/2383
-                logger.warning(
-                    "OpenAI/OpenRouter 402 insufficient credits — the request "
-                    "reservation exceeds available key budget. Lower the "
-                    "reservation by setting --max-tokens (or GPTME_MAX_TOKENS) "
-                    "to a value such as 16000, or top up / switch the key. "
-                    "Detail: %s",
-                    combined_error[:500],
-                )
+            elif e.status_code == 402:
+                # 402 Payment Required is non-transient (we never retry it),
+                # but the bare APIStatusError is opaque. Surface an actionable
+                # diagnostic when the body identifies a credits/budget cause.
+                # A generic 402 (e.g. "Unauthorized") gets no diagnostic so we
+                # don't mislabel auth failures as out-of-credits.
+                if any(
+                    hint in combined_error
+                    for hint in ("affordable", "more credits", "fewer max_tokens")
+                ):
+                    # OpenRouter reserves model.max_output + reasoning_budget
+                    # worth of credits when max_tokens is omitted. A partially-
+                    # spent key then rejects requests as 402 even with plenty of
+                    # room for the actual response. Eval callers silently swallow
+                    # the resulting APIStatusError as gen_stderr and write empty
+                    # conversation.jsonl, so surface guidance before re-raising.
+                    # See: https://github.com/gptme/gptme/issues/2383
+                    logger.warning(
+                        "OpenAI/OpenRouter 402 insufficient credits — the request "
+                        "reservation exceeds available key budget. Lower the "
+                        "reservation by setting --max-tokens (or GPTME_MAX_TOKENS) "
+                        "to a value such as 16000, or top up / switch the key. "
+                        "Detail: %s",
+                        combined_error[:500],
+                    )
+                elif any(
+                    hint in combined_error
+                    for hint in (
+                        "insufficient credit",
+                        "out of credit",
+                        "no credit",
+                        "insufficient_quota",
+                        "insufficient funds",
+                        "insufficient balance",
+                        "credit balance",
+                    )
+                ):
+                    # Generic out-of-credits / payment-required from a provider
+                    # or gateway (e.g. the gptme.ai LLM gateway). Non-transient:
+                    # the account/key needs a top-up or switch, retrying will not
+                    # help. See: https://github.com/gptme/gptme-cloud/issues/61
+                    logger.warning(
+                        "402 payment required — the provider or gateway reports "
+                        "the account is out of credits. Top up or switch the API "
+                        "key / account; gptme will not retry. Detail: %s",
+                        combined_error[:500],
+                    )
 
     # Re-raise if not transient or max retries reached
     if not should_retry or attempt == max_retries - 1:

--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -611,7 +611,7 @@ def _handle_openai_transient_error(e, attempt, max_retries, base_delay):
                     for hint in (
                         "insufficient credit",
                         "out of credit",
-                        "no credit",
+                        "no credits",
                         "insufficient_quota",
                         "insufficient funds",
                         "insufficient balance",

--- a/tests/test_llm_openai.py
+++ b/tests/test_llm_openai.py
@@ -1472,6 +1472,57 @@ class TestOpenAIRetryLogic:
             f"Generic 402 should NOT trigger credits diagnostic, got: {warning_messages}"
         )
 
+    def test_handle_openai_transient_error_gateway_out_of_credits_402(self, caplog):
+        """A gateway/proxy 402 reporting out-of-credits (e.g. the gptme.ai LLM
+        gateway) surfaces an actionable diagnostic and re-raises without retry.
+
+        This is distinct from the OpenRouter reservation case: the body has no
+        "more credits / max_tokens" hints, just a plain out-of-credits message.
+        See: https://github.com/gptme/gptme-cloud/issues/61
+        """
+        import logging
+        from unittest.mock import MagicMock
+
+        import pytest
+        from openai import APIStatusError
+
+        from gptme.llm.llm_openai import _handle_openai_transient_error
+
+        mock_response = MagicMock()
+        mock_response.status_code = 402
+        error = APIStatusError(
+            "Payment required",
+            response=mock_response,
+            body={
+                "error": {
+                    "message": "Insufficient credits remaining on your account.",
+                    "code": 402,
+                }
+            },
+        )
+
+        # 402 is non-transient → must raise immediately even on attempt 0
+        with (
+            caplog.at_level(logging.WARNING, logger="gptme.llm.llm_openai"),
+            pytest.raises(APIStatusError),
+        ):
+            _handle_openai_transient_error(
+                error, attempt=0, max_retries=3, base_delay=0.1
+            )
+
+        warning_messages = [
+            r.message for r in caplog.records if r.levelno >= logging.WARNING
+        ]
+        # Diagnostic should name the cause (credits) without claiming it's the
+        # OpenRouter max_tokens reservation case.
+        assert any(
+            "credit" in msg.lower() and "402" in msg for msg in warning_messages
+        ), f"Expected an out-of-credits 402 diagnostic, got: {warning_messages}"
+        assert not any("max_tokens" in msg.lower() for msg in warning_messages), (
+            f"Gateway out-of-credits 402 should not claim the OpenRouter "
+            f"reservation cause, got: {warning_messages}"
+        )
+
     def test_retry_decorator_retries_on_transient_error(self, monkeypatch):
         """Test that the retry decorator properly retries on transient errors."""
         from unittest.mock import MagicMock, patch


### PR DESCRIPTION
## Problem

The OpenAI retry handler (`_handle_openai_transient_error`) only emits an actionable diagnostic for the **OpenRouter reservation-pattern** 402 (insufficient credits caused by an omitted `max_tokens`, added in #2383). A plain *out-of-credits* 402 from a provider or gateway — e.g. the **gptme.ai LLM gateway** — matches none of those hints (`affordable`, `more credits`, `fewer max_tokens`) and is re-raised as a bare, opaque `APIStatusError`.

This is the core-side half of gptme/gptme-cloud#61 ("out of credits should be displayed clearly and handled well"). The web UI surfacing landed in #2462; this makes the core error legible too.

## Change

Split the `402` branch so it distinguishes three cases:

1. **OpenRouter reservation 402** (`affordable`/`more credits`/`fewer max_tokens`) → existing `--max-tokens` guidance (unchanged).
2. **Generic out-of-credits / payment-required 402** (`insufficient credit`, `out of credit`, `insufficient_quota`, `credit balance`, …) → new clear "out of credits, will not retry — top up or switch the key/account" diagnostic.
3. **Any other 402** (e.g. `Unauthorized`) → still no credits diagnostic, so auth failures aren't mislabeled as billing problems.

Retry behavior is unchanged: 402 stays non-transient (never retried).

## Tests

- `test_handle_openai_transient_error_openrouter_402_diagnostic` — still passes (OpenRouter case handled first).
- `test_handle_openai_transient_error_generic_402_no_diagnostic` — still passes ("Unauthorized" matches no credit hints).
- `test_handle_openai_transient_error_gateway_out_of_credits_402` — **new**: a gateway "Insufficient credits remaining" 402 emits a credits diagnostic mentioning 402, without claiming the OpenRouter `max_tokens` cause, and re-raises without retry.

```
3 passed (402 tests), 13 passed (full retry-logic class)
```

Refs: gptme/gptme-cloud#61