### PR TITLE
fix(bot): update model default, fix checkout version, tighten permissions

### DIFF
--- a/.github/actions/bot/action.yml
+++ b/.github/actions/bot/action.yml
@@ -10,7 +10,7 @@ inputs:
   model:
     description: 'Model to use'
     required: false
-    default: 'anthropic/claude-sonnet-4-20250514'
+    default: 'anthropic/claude-sonnet-4-6'
   github_token:
     description: 'GitHub Token'
     required: true
@@ -70,11 +70,11 @@ runs:
       run: |
         # Prefer the local script when running inside the gptme repo itself.
         # Fall back to downloading a pinned version for use as a reusable external action.
-        # Pin to specific commit for supply chain security (ba3c0233)
+        # Pin to specific commit for supply chain security (248aac98)
         if [ -f "scripts/github_bot.py" ]; then
           cp scripts/github_bot.py /tmp/github_bot.py
         else
-          SCRIPT_URL="https://raw.githubusercontent.com/gptme/gptme/ba3c0233f5f047ef210c732fb59d0c52b9bdd9e5/scripts/github_bot.py"
+          SCRIPT_URL="https://raw.githubusercontent.com/gptme/gptme/248aac98c02113009837c4b582dd72ed0604dd63/scripts/github_bot.py"
           curl -fsL "$SCRIPT_URL" > /tmp/github_bot.py
         fi
         python /tmp/github_bot.py --mode "${{ inputs.mode }}" --workspace .

--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -4,7 +4,10 @@ on:
   issue_comment:
     types: [created]
 
-permissions: write-all
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
 
 jobs:
   run-bot:
@@ -16,7 +19,7 @@ jobs:
     steps:
       # needed to run the action in the same repo
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Run gptme-bot action
         uses: ./.github/actions/bot


### PR DESCRIPTION
## Summary

Three fixes to the gptme-bot infrastructure that accumulated since the resolver was shipped:

- **Outdated model default** (`action.yml`): Default model was `claude-sonnet-4-20250514` (Sonnet 4.0, released May 2025). Updated to `claude-sonnet-4-6` (current Sonnet). Both `bot.yml` and `resolve.yml` already override this with the correct model, but external repos using the action without specifying a model were silently using an outdated model.

- **Nonexistent checkout action** (`bot.yml`): `actions/checkout@v6` does not exist (latest stable is v4). Updated to `@v4` to match `resolve.yml` and `action.yml`'s own checkout step. This would cause the bot workflow to fail on any run that reached the checkout step.

- **Overly broad permissions** (`bot.yml`): `permissions: write-all` replaced with specific `contents: write`, `issues: write`, `pull-requests: write` — matching the scoped permissions already used in `resolve.yml`.

- **Pinned script commit** (`action.yml`): Advanced the pinned script URL from `ba3c0233` to `248aac98` (includes the resolver duplicate-comment fix from #2447). External repos using the action now get the resolver improvements.

## Test plan

- [ ] Verify `bot.yml` workflow runs without failing on the checkout step
- [ ] Verify action works with default model when no `model:` input is provided
- [ ] CI passes