### PR TITLE
fix(lessons): use description field for semantic matching in hybrid_matcher

### DIFF
--- a/gptme/lessons/hybrid_matcher.py
+++ b/gptme/lessons/hybrid_matcher.py
@@ -359,8 +359,11 @@ class HybridLessonMatcher(LessonMatcher):
 
         import numpy as np
 
-        # Generate lesson embedding from title and body
-        lesson_text = f"{lesson.title}\n{lesson.body[:500]}"  # Limit to first 500 chars
+        # Use description field for semantic matching — it encodes "when to use" in prose,
+        # which is more informative than raw body text for retrieval.
+        # Prefer explicit frontmatter description, fall back to extracted first-paragraph.
+        desc = lesson.metadata.description or lesson.description
+        lesson_text = f"{lesson.title}\n{desc}"
         lesson_embed = self.embedder.encode(lesson_text, convert_to_numpy=True)
 
         # Cosine similarity (guard against zero-norm embeddings)

--- a/gptme/lessons/hybrid_matcher.py
+++ b/gptme/lessons/hybrid_matcher.py
@@ -361,8 +361,10 @@ class HybridLessonMatcher(LessonMatcher):
 
         # Use description field for semantic matching — it encodes "when to use" in prose,
         # which is more informative than raw body text for retrieval.
-        # Prefer explicit frontmatter description, fall back to extracted first-paragraph.
-        desc = lesson.metadata.description or lesson.description
+        # Prefer explicit frontmatter description, fall back to extracted first-paragraph,
+        # then fall back to body[:500] so title-only embedding never silently degrades
+        # lessons that have no description field.
+        desc = lesson.metadata.description or lesson.description or lesson.body[:500]
         lesson_text = f"{lesson.title}\n{desc}"
         lesson_embed = self.embedder.encode(lesson_text, convert_to_numpy=True)
 

--- a/tests/test_hybrid_lessons.py
+++ b/tests/test_hybrid_lessons.py
@@ -444,6 +444,22 @@ def test_semantic_score_uses_description_field():
     assert "Extracted paragraph" in encoded_text
     assert "## Rule" not in encoded_text
 
+    # Fallback to body[:500] when both descriptions are absent — prevents title-only embedding
+    mock_embedder.reset_mock()
+    mock_embedder.encode.return_value = np.ones(384) / np.sqrt(384)
+    lesson_no_desc = Lesson(
+        path=Path("/tmp/lessons/no-desc.md"),
+        metadata=LessonMetadata(),  # no frontmatter description
+        title="No Description Lesson",
+        description="",  # extracted description also empty
+        category="tools",
+        body="## Rule\nDo the right thing.\n\n```bash\necho ok\n```",
+    )
+    matcher._semantic_score(query_embed, lesson_no_desc, context)
+    encoded_text = mock_embedder.encode.call_args[0][0]
+    assert "## Rule" in encoded_text  # body content must appear as last resort
+    assert "No Description Lesson" in encoded_text  # title still present
+
 
 @pytest.mark.timeout(30)
 def test_hybrid_matcher_does_not_eagerly_import_sentence_transformers():

--- a/tests/test_hybrid_lessons.py
+++ b/tests/test_hybrid_lessons.py
@@ -397,6 +397,54 @@ def test_semantic_score_zero_norm_returns_zero():
     assert not np.isinf(score)
 
 
+def test_semantic_score_uses_description_field():
+    """_semantic_score must encode the description field, not body, for retrieval precision."""
+    np = pytest.importorskip("numpy")
+    from unittest.mock import MagicMock
+
+    config = HybridConfig(enable_semantic=True)
+    matcher = HybridLessonMatcher(config=config)
+
+    mock_embedder = MagicMock()
+    mock_embedder.encode.return_value = np.ones(384) / np.sqrt(384)
+    matcher.embedder = mock_embedder
+
+    frontmatter_desc = "Use when saving insights so they persist across sessions"
+    lesson_with_frontmatter_desc = Lesson(
+        path=Path("/tmp/lessons/persistent-learning.md"),
+        metadata=LessonMetadata(description=frontmatter_desc),
+        title="Persistent Learning",
+        description="Extracted first paragraph description",
+        category="patterns",
+        body="## Rule\nAlways persist insights.\n\n```python\n# code example\n```",
+    )
+
+    query_embed = np.ones(384) / np.sqrt(384)
+    context = MatchContext(message="I should save this as a lesson")
+    matcher._semantic_score(query_embed, lesson_with_frontmatter_desc, context)
+
+    # Must encode frontmatter description (not body content)
+    encoded_text = mock_embedder.encode.call_args[0][0]
+    assert frontmatter_desc in encoded_text
+    assert "## Rule" not in encoded_text  # body content must NOT appear
+
+    # Fallback to extracted description when frontmatter description is absent
+    mock_embedder.reset_mock()
+    mock_embedder.encode.return_value = np.ones(384) / np.sqrt(384)
+    lesson_no_frontmatter_desc = Lesson(
+        path=Path("/tmp/lessons/other.md"),
+        metadata=LessonMetadata(),  # no description in frontmatter
+        title="Other Lesson",
+        description="Extracted paragraph: use when doing X",
+        category="tools",
+        body="## Rule\nDo this.\n\n```bash\ncode\n```",
+    )
+    matcher._semantic_score(query_embed, lesson_no_frontmatter_desc, context)
+    encoded_text = mock_embedder.encode.call_args[0][0]
+    assert "Extracted paragraph" in encoded_text
+    assert "## Rule" not in encoded_text
+
+
 @pytest.mark.timeout(30)
 def test_hybrid_matcher_does_not_eagerly_import_sentence_transformers():
     """Importing hybrid_matcher must not trigger a sentence_transformers import.


### PR DESCRIPTION
## Problem

`_semantic_score` in `hybrid_matcher.py` was building the lesson embedding from `title + body[:500]`. The body contains procedure steps, code examples, and rule text — mostly structural noise from a retrieval perspective.

## Fix

Switch to `title + description`:
- Prefer the frontmatter `description:` field — this is purpose-built prose describing *when to use* the lesson
- Fall back to the extracted first-paragraph description when frontmatter is absent

The `description` field is semantically dense for retrieval: it encodes use-case context in natural language, exactly what semantic matching needs to measure.

## Example

**Before**: lesson embedding included `## Rule\nAlways...\n\n```bash\n# code example\n...`  
**After**: lesson embedding is `"Persist insights so they persist across sessions"` (description)

## Test

Added `test_semantic_score_uses_description_field` — verifies the encoded text:
1. Contains frontmatter description when present
2. Falls back to extracted description when frontmatter description is absent
3. Does NOT include body content in either case

Closes #2466