### PR TITLE
fix(bot): verify sha256 of downloaded github_bot.py

### DIFF
--- a/.github/actions/bot/action.yml
+++ b/.github/actions/bot/action.yml
@@ -70,12 +70,15 @@ runs:
       run: |
         # Prefer the local script when running inside the gptme repo itself.
         # Fall back to downloading a pinned version for use as a reusable external action.
-        # Pin to specific commit for supply chain security (248aac98)
+        # Pin to specific commit for supply chain security (248aac98).
+        # When bumping the pin, update SCRIPT_SHA256 to match the new commit's script.
+        SCRIPT_SHA256="331d70f7c3e77544a2a4d017e2e243324726a2043de39f73ff0e5ed0f6a7ca16"
         if [ -f "scripts/github_bot.py" ]; then
           cp scripts/github_bot.py /tmp/github_bot.py
         else
           SCRIPT_URL="https://raw.githubusercontent.com/gptme/gptme/248aac98c02113009837c4b582dd72ed0604dd63/scripts/github_bot.py"
           curl -fsL "$SCRIPT_URL" > /tmp/github_bot.py
+          echo "${SCRIPT_SHA256}  /tmp/github_bot.py" | sha256sum -c -
         fi
         python /tmp/github_bot.py --mode "${{ inputs.mode }}" --workspace .
 


### PR DESCRIPTION
## Summary

- Adds `SCRIPT_SHA256` variable alongside the pinned commit URL in the external-action download path
- After `curl`, verifies the download with `sha256sum -c -` and fails the step if it mismatches
- Local path (in-repo copy) is trusted via git commit hash and not checked

## Motivation

The pinned commit SHA (`248aac98`) prevents script drift but a CDN or MITM compromise could still serve unexpected content at that URL. The sha256 gate catches that.

Greptile flagged this as a non-blocking supply-chain concern in gptme/gptme#2468 (the PR that bumped the pin).

## Maintenance note

When bumping the pin (per `lessons/tools/pinned-action-script-version-skew.md`), update `SCRIPT_SHA256` in the same change:
```bash
curl -fsL "https://raw.githubusercontent.com/gptme/gptme/<new-sha>/scripts/github_bot.py" | sha256sum
```