### PR TITLE
perf(lessons): cache lesson embeddings across turns in hybrid matcher

### DIFF
--- a/gptme/lessons/hybrid_matcher.py
+++ b/gptme/lessons/hybrid_matcher.py
@@ -216,6 +216,11 @@ class HybridLessonMatcher(LessonMatcher):
         )
         self._ts_posteriors = _load_effectiveness_scores(state_file)
 
+        # Cache of lesson embeddings keyed on the encoded lesson text. Lessons are
+        # matched on every turn but their text is static, so re-encoding the same
+        # candidates each turn is wasted compute. See _semantic_score.
+        self._lesson_embed_cache: dict[str, Any] = {}
+
     def match(
         self, lessons: list[Lesson], context: MatchContext, threshold: float = 0.0
     ) -> list[MatchResult]:
@@ -366,7 +371,15 @@ class HybridLessonMatcher(LessonMatcher):
         # lessons that have no description field.
         desc = lesson.metadata.description or lesson.description or lesson.body[:500]
         lesson_text = f"{lesson.title}\n{desc}"
-        lesson_embed = self.embedder.encode(lesson_text, convert_to_numpy=True)
+
+        # Cache embeddings on the lesson text: matching runs every turn, but the
+        # text is static, so re-encoding the same candidates each turn is wasted
+        # compute. Keying on the text means an edited description naturally yields
+        # a fresh embedding — no stale-cache risk.
+        lesson_embed = self._lesson_embed_cache.get(lesson_text)
+        if lesson_embed is None:
+            lesson_embed = self.embedder.encode(lesson_text, convert_to_numpy=True)
+            self._lesson_embed_cache[lesson_text] = lesson_embed
 
         # Cosine similarity (guard against zero-norm embeddings)
         query_norm = np.linalg.norm(query_embed)

--- a/tests/test_hybrid_lessons.py
+++ b/tests/test_hybrid_lessons.py
@@ -461,6 +461,56 @@ def test_semantic_score_uses_description_field():
     assert "No Description Lesson" in encoded_text  # title still present
 
 
+def test_semantic_score_caches_lesson_embeddings():
+    """A lesson's embedding is encoded once and reused across turns.
+
+    Matching runs every turn, but lesson text is static, so re-encoding the same
+    candidate each turn is wasted compute. The cache must avoid that while still
+    returning the correct score.
+    """
+    np = pytest.importorskip("numpy")
+    from unittest.mock import MagicMock
+
+    config = HybridConfig(enable_semantic=True)
+    matcher = HybridLessonMatcher(config=config)
+
+    mock_embedder = MagicMock()
+    lesson_vec = np.ones(384) / np.sqrt(384)
+    mock_embedder.encode.return_value = lesson_vec
+    matcher.embedder = mock_embedder
+
+    lesson = Lesson(
+        path=Path("/tmp/lessons/cached.md"),
+        metadata=LessonMetadata(description="Use when caching matters"),
+        title="Cached Lesson",
+        description="",
+        category="tools",
+        body="## Rule\nCache it.",
+    )
+    query_embed = np.ones(384) / np.sqrt(384)
+    context = MatchContext(message="caching question")
+
+    first = matcher._semantic_score(query_embed, lesson, context)
+    second = matcher._semantic_score(query_embed, lesson, context)
+
+    # Same score both turns, but only encoded once (query embedding is supplied,
+    # so every encode call here is for the lesson text).
+    assert first == second
+    assert mock_embedder.encode.call_count == 1
+
+    # A different lesson text is a cache miss and triggers a fresh encode.
+    other = Lesson(
+        path=Path("/tmp/lessons/other.md"),
+        metadata=LessonMetadata(description="A different purpose entirely"),
+        title="Other Lesson",
+        description="",
+        category="tools",
+        body="## Rule\nDo other.",
+    )
+    matcher._semantic_score(query_embed, other, context)
+    assert mock_embedder.encode.call_count == 2
+
+
 @pytest.mark.timeout(30)
 def test_hybrid_matcher_does_not_eagerly_import_sentence_transformers():
     """Importing hybrid_matcher must not trigger a sentence_transformers import.


### PR DESCRIPTION
## Problem

`HybridLessonMatcher._semantic_score` re-encodes each candidate lesson's text (`title + description`) with a sentence-transformer forward pass **on every turn**. Lessons are matched every turn (the code comment in `match` notes this explicitly), but a lesson's text is static — so encoding the same ~20 candidates' text each turn is wasted compute. Only the query embedding genuinely changes per turn.

## Fix

Cache lesson embeddings in an instance-level `dict[str, Any]` keyed on the encoded lesson text:

- The per-turn query embedding is still computed fresh.
- Keying on the **text** (not the path) means an edited `description` produces a different key and thus a fresh embedding — no stale-cache risk.
- Memory is bounded by the number of distinct lessons (~hundreds), each a 384-dim vector (~1.5 KB) — negligible.

Builds directly on #2469, which switched the embedded text to `title + description`.

## Test

Adds `test_semantic_score_caches_lesson_embeddings`:
- Same lesson scored twice → identical score, embedder `encode` called once.
- A distinct lesson text → cache miss → fresh encode (call count increments).

All 24 tests in `tests/test_hybrid_lessons.py` pass.