### PR TITLE
test(server): relax tool confirmation log assertions

### DIFF
--- a/tests/test_server_v2_tool_confirmation.py
+++ b/tests/test_server_v2_tool_confirmation.py
@@ -11,7 +11,7 @@ from gptme.tools import ToolUse
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.timeout(20)
+@pytest.mark.timeout(30)
 def test_tool_confirmation_flow(
     init_, setup_conversation, event_listener, mock_generation, wait_for_event
 ):
@@ -41,7 +41,12 @@ def test_tool_confirmation_flow(
     )
 
     # Start generation with mocked response
-    with unittest.mock.patch("gptme.server.session_step._stream", mock_stream):
+    with (
+        unittest.mock.patch("gptme.server.session_step._stream", mock_stream),
+        unittest.mock.patch(
+            "gptme.server.session_step._try_auto_name_and_notify", return_value=None
+        ),
+    ):
         # Request a step
         requests.post(
             f"http://localhost:{port}/api/v2/conversations/{conversation_id}/step",
@@ -74,21 +79,26 @@ def test_tool_confirmation_flow(
     )
     assert resp.status_code == 200
 
-    # Check message sequence
-    # Note: Message order can vary depending on hook execution order
-    # Message count varies: 6 (CI, no lessons) or 7 (local, with lessons)
-    # Expect: system prompt, user message, TOKEN_BUDGET, possibly lessons, then assistant/system messages
-    # Temp fix: added 5 due to test flakiness
+    # Check message sequence.
+    # Hook-injected hidden context can legitimately add system messages here
+    # (token budget, lessons, active context, output-format hints, etc.), so
+    # assert the flow invariants instead of a brittle exact message count.
     messages = resp.json()["log"]
-    assert len(messages) in [5, 6, 7], f"Expected 6 or 7 messages, got {len(messages)}"
+    assert len(messages) >= 5, f"Expected at least 5 messages, got {len(messages)}"
 
     # Verify message content
     assert messages[0]["role"] == "system" and "testing" in messages[0]["content"]
 
-    # Find the user message (should be early in sequence)
+    # Find the user message and verify the assistant/tool flow follows it.
     user_msg_idx = next(i for i, m in enumerate(messages) if m["role"] == "user")
-    assert user_msg_idx <= 2, "User message should be within first 3 messages"
     assert "List files" in messages[user_msg_idx]["content"]
+
+    assistant_tool_idx = next(
+        i
+        for i, m in enumerate(messages)
+        if m["role"] == "assistant" and "ls -la" in m["content"]
+    )
+    assert user_msg_idx < assistant_tool_idx
 
     # Verify TOKEN_BUDGET message exists
     assert any(
@@ -99,6 +109,7 @@ def test_tool_confirmation_flow(
 
     # Verify final assistant message
     assert messages[-1]["role"] == "assistant"
+    assert "Done" in messages[-1]["content"]
 
 
 @pytest.mark.timeout(20)

--- a/tests/test_server_v2_tool_confirmation.py
+++ b/tests/test_server_v2_tool_confirmation.py
@@ -90,14 +90,21 @@ def test_tool_confirmation_flow(
     assert messages[0]["role"] == "system" and "testing" in messages[0]["content"]
 
     # Find the user message and verify the assistant/tool flow follows it.
-    user_msg_idx = next(i for i, m in enumerate(messages) if m["role"] == "user")
+    user_msg_idx = next(
+        (i for i, m in enumerate(messages) if m["role"] == "user"), None
+    )
+    assert user_msg_idx is not None, "No user message found in conversation"
     assert "List files" in messages[user_msg_idx]["content"]
 
     assistant_tool_idx = next(
-        i
-        for i, m in enumerate(messages)
-        if m["role"] == "assistant" and "ls -la" in m["content"]
+        (
+            i
+            for i, m in enumerate(messages)
+            if m["role"] == "assistant" and "ls -la" in m["content"]
+        ),
+        None,
     )
+    assert assistant_tool_idx is not None, "No assistant tool message (ls -la) found"
     assert user_msg_idx < assistant_tool_idx
 
     # Verify TOKEN_BUDGET message exists
@@ -141,7 +148,12 @@ def test_tool_confirmation_without_session_id(
     )
 
     # Start generation with mocked response
-    with unittest.mock.patch("gptme.server.session_step._stream", mock_stream):
+    with (
+        unittest.mock.patch("gptme.server.session_step._stream", mock_stream),
+        unittest.mock.patch(
+            "gptme.server.session_step._try_auto_name_and_notify", return_value=None
+        ),
+    ):
         # Request a step
         requests.post(
             f"http://localhost:{port}/api/v2/conversations/{conversation_id}/step",


### PR DESCRIPTION
## Summary

- Fixes the master `Test` workflow failure in run 26338915711.
- Relaxes the V2 tool-confirmation test to assert required flow invariants instead of exact hidden-message counts.
- Disables incidental auto-naming inside this test so localhost LLM retries do not eat most of the timeout budget.

## Verification

- `poetry run pytest tests/test_server_v2_tool_confirmation.py::test_tool_confirmation_flow -vv --log-level INFO --timeout 60`
- `poetry run pytest tests/test_server_v2_tool_confirmation.py -vv --log-level INFO --timeout 60`
- `poetry run ruff check tests/test_server_v2_tool_confirmation.py`
