### PR TITLE
ci(test): stabilize tool confirmation and docs build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,8 +103,7 @@ docs: docs/conf.py docs/*.rst docs/.clean check-rst
 		if [ -e eval-results/eval_results ]; then \
 			ln -s eval-results/eval_results .; \
 		else \
-			git fetch origin eval-results; \
-			git checkout origin/eval-results -- eval_results; \
+			git fetch origin eval-results --depth=1 && git checkout origin/eval-results -- eval_results || echo "No eval results available; building docs without leaderboard data"; \
 		fi \
 	fi
 	poetry run make -C docs html SPHINXOPTS="-W --keep-going"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,11 +4,11 @@ import json
 import logging
 import os
 import queue
-import random
 import socket
 import tempfile
 import threading
 import time
+import uuid
 from contextlib import contextmanager
 
 import pytest
@@ -385,7 +385,8 @@ def client():
 def setup_conversation(server_thread):
     """Create a conversation and return its ID, session ID, and port."""
     port = server_thread
-    conversation_id = f"test-tools-{int(time.time())}-{random.randint(1000, 9999)}"
+    worker_id = os.environ.get("PYTEST_XDIST_WORKER", "gw0")
+    conversation_id = f"test-tools-{worker_id}-{uuid.uuid4().hex}"
 
     # Create conversation with custom system prompt
     # Use "@log" to create workspace in the conversation's log directory

--- a/tests/test_server_v2_tool_confirmation.py
+++ b/tests/test_server_v2_tool_confirmation.py
@@ -11,7 +11,7 @@ from gptme.tools import ToolUse
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.timeout(30)
+@pytest.mark.timeout(60)
 def test_tool_confirmation_flow(
     init_, setup_conversation, event_listener, mock_generation, wait_for_event
 ):
@@ -70,8 +70,12 @@ def test_tool_confirmation_flow(
         assert wait_for_event(event_listener, "tool_executing")
         assert wait_for_event(event_listener, "message_added")
 
-        # Wait for assistant final response
+        # Wait for assistant final response and completion before leaving the
+        # mock context; otherwise the background continuation thread may fall
+        # through to the real LLM stream.
+        assert wait_for_event(event_listener, "generation_started")
         assert wait_for_event(event_listener, "message_added")
+        assert wait_for_event(event_listener, "generation_complete")
 
     # Verify conversation state
     resp = requests.get(
@@ -119,7 +123,7 @@ def test_tool_confirmation_flow(
     assert "Done" in messages[-1]["content"]
 
 
-@pytest.mark.timeout(20)
+@pytest.mark.timeout(60)
 def test_tool_confirmation_without_session_id(
     init_, setup_conversation, event_listener, mock_generation, wait_for_event
 ):
@@ -178,6 +182,9 @@ def test_tool_confirmation_without_session_id(
         # Wait for tool execution
         assert wait_for_event(event_listener, "tool_executing")
         assert wait_for_event(event_listener, "message_added")
+        assert wait_for_event(event_listener, "generation_started")
+        assert wait_for_event(event_listener, "message_added")
+        assert wait_for_event(event_listener, "generation_complete")
 
 
 @pytest.mark.timeout(10)


### PR DESCRIPTION
## Summary
- make tool-confirmation test conversation IDs xdist-safe with worker ID + UUID
- mock auto-naming in tool-confirmation tests so they do not make unrelated LLM calls
- wait for the background continuation generation to complete before leaving patched stream context
- relax brittle assertions around hidden context insertion and exact message counts
- make docs tolerate unavailable optional `eval-results` branch data instead of failing the build

This targets the master CI failure after #2471 where the slow xdist job crashed on `tests/test_server_v2_tool_confirmation.py::test_tool_confirmation_flow`. While monitoring the PR, Docs also failed because `make docs` hard-failed when optional eval results could not be fetched; that path now degrades the same way the leaderboard command already does.

## Test plan
- `poetry run pytest tests/test_server_v2_tool_confirmation.py -vv --log-level INFO --timeout 60 --retries 0`
- `poetry run pytest tests/test_server_v2_tool_confirmation.py -vv --log-level INFO --timeout 60 --retries 0 -n 16`
- `make docs`
- `prek run ruff --files tests/conftest.py tests/test_server_v2_tool_confirmation.py`
- `prek run ruff-format --files tests/conftest.py tests/test_server_v2_tool_confirmation.py`