### PR TITLE
fix(vent): tolerate trailing punctuation in resolution-owner tag

### DIFF
--- a/gptme/tools/vent.py
+++ b/gptme/tools/vent.py
@@ -99,6 +99,10 @@ def _parse_resolution_owner(code: str) -> tuple[str, str | None]:
     raw = match.group(1).strip()
     before_paren = raw.split("(", 1)[0]
     token = before_paren.split()[0].lower() if before_paren.split() else ""
+    # Tolerate trailing sentence punctuation, e.g. "tooling." or "self!".
+    # Only strips the ends, so internal characters like the hyphen in
+    # "self-evident" are preserved (and stay an unrecognized token).
+    token = token.strip(".,;:!?")
     owner = _DEPRECATED_TYPE_MAP.get(token, token)
     if owner not in VALID_OWNERS:
         return code.strip(), None

--- a/tests/test_vent.py
+++ b/tests/test_vent.py
@@ -135,6 +135,23 @@ class TestParseResolutionOwner:
         assert msg == "Need a key"
         assert owner == "tooling"
 
+    @pytest.mark.parametrize(
+        "trailer", ["tooling.", "tooling!", "operator,", "self;", "upstream?"]
+    )
+    def test_trailing_punctuation_tolerated(self, trailer):
+        # Agents often end the tag line with sentence punctuation; the owner
+        # should still be captured rather than silently dropped.
+        expected = trailer.rstrip(".,;:!?")
+        msg, owner = _parse_resolution_owner(f"Blocked on X\nOwner: {trailer}")
+        assert msg == "Blocked on X"
+        assert owner == expected
+
+    def test_internal_hyphen_not_misparsed(self):
+        # Stripping terminal punctuation must not turn "self-evident" into "self".
+        msg, owner = _parse_resolution_owner("Stuck\nOwner: self-evident")
+        assert msg == "Stuck\nOwner: self-evident"
+        assert owner is None
+
     def test_resolution_keyword_and_equals_separator(self):
         msg, owner = _parse_resolution_owner("Stuck\nResolution = upstream")
         assert msg == "Stuck"

--- a/tests/test_vent.py
+++ b/tests/test_vent.py
@@ -141,7 +141,7 @@ class TestParseResolutionOwner:
     def test_trailing_punctuation_tolerated(self, trailer):
         # Agents often end the tag line with sentence punctuation; the owner
         # should still be captured rather than silently dropped.
-        expected = trailer.rstrip(".,;:!?")
+        expected = trailer.strip(".,;:!?")
         msg, owner = _parse_resolution_owner(f"Blocked on X\nOwner: {trailer}")
         assert msg == "Blocked on X"
         assert owner == expected


### PR DESCRIPTION
## Problem

The vent tool parses an optional trailing `Owner: <owner>` line into a structured `resolution_owner` field (added in #2463). The token extractor takes the first whitespace-delimited word verbatim:

```python
token = before_paren.split()[0].lower() if before_paren.split() else ""
```

Agents very commonly end that line with sentence punctuation — `Owner: tooling.`, `Owner: self!`, `Owner: operator,`. The trailing character makes the token (`"tooling."`) fail the `VALID_OWNERS` membership check, so the owner is **silently dropped** *and* the `Owner:` line is left polluting the recorded message. That quietly degrades friction-ledger data quality, which feeds the friction-analysis layer.

## Fix

Strip terminal punctuation (`.,;:!?`) from the extracted token. Only the ends are stripped, so internal characters are preserved: `self-evident` stays an unrecognized token rather than collapsing to `self`.

## Tests

- Parametrized `test_trailing_punctuation_tolerated` over `tooling.`, `tooling!`, `operator,`, `self;`, `upstream?`
- `test_internal_hyphen_not_misparsed` regression guard for the strip-only-ends behavior
- Full `test_vent.py`: 33 passed (RED→GREEN verified)

Surgical: 21 insertions, no behavior change for already-clean tags.