### PR TITLE
fix(tools): split comma-separated choice options

### DIFF
--- a/gptme/tools/choice.py
+++ b/gptme/tools/choice.py
@@ -82,7 +82,8 @@ def parse_options_from_kwargs(kwargs: dict[str, str]) -> tuple[str | None, list[
     """Parse options from args and kwargs, returning (question, options)."""
     question = kwargs.get("question")
     options_str = kwargs.get("options", "")
-    options = [opt.strip() for opt in options_str.split("\n") if opt.strip()]
+    separator = "\n" if "\n" in options_str else ","
+    options = [opt.strip() for opt in options_str.split(separator) if opt.strip()]
     if not question:
         if options and options[0].endswith("?"):
             question = options[0]
@@ -168,7 +169,7 @@ tool_choice = ToolSpec(
         Parameter(
             name="options",
             type="string",
-            description="The question to ask and a comma-separated list of options to choose from",
+            description="The question to ask and a newline- or comma-separated list of options to choose from",
             required=True,
         ),
     ],

--- a/gptme/tools/choice.py
+++ b/gptme/tools/choice.py
@@ -13,6 +13,7 @@ from .base import (
 
 instructions = """
 The options can be provided as a question on the first line and each option on a separate line.
+When using the ``options`` keyword argument, options may also be comma-separated.
 
 The tool will present an interactive menu allowing the user to select an option using arrow keys and Enter, or by typing the number of the option.
 

--- a/tests/test_tools_choice.py
+++ b/tests/test_tools_choice.py
@@ -125,6 +125,24 @@ def test_parse_kwargs_strips_option_whitespace():
     assert options == ["A", "B", "C"]
 
 
+def test_parse_kwargs_comma_separated_options():
+    """Single-line comma-separated options are split."""
+    question, options = parse_options_from_kwargs(
+        {"question": "Pick one:", "options": "Alpha, Beta, Gamma"}
+    )
+    assert question == "Pick one:"
+    assert options == ["Alpha", "Beta", "Gamma"]
+
+
+def test_parse_kwargs_comma_separated_question_in_options():
+    """Comma-separated options can include the question as the first item."""
+    question, options = parse_options_from_kwargs(
+        {"options": "What to pick?, Foo, Bar"}
+    )
+    assert question == "What to pick?"
+    assert options == ["Foo", "Bar"]
+
+
 # --- execute_choice ---
 
 


### PR DESCRIPTION
## Summary
- split single-line comma-separated `choice` kwargs into separate options
- keep newline-separated option parsing unchanged
- update the `options` parameter description to match both supported forms

## Tests
- `uv run --with requests --with pytest python3 -m pytest tests/test_tools_choice.py -q`
- `uv run --with ruff ruff check gptme/tools/choice.py tests/test_tools_choice.py`
- `git diff --check -- gptme/tools/choice.py tests/test_tools_choice.py`

Root cause: the tool schema promised comma-separated options, but the kwargs parser only split on newlines.