### PR TITLE
chore: ignore local test artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ __pycache__
 *.gif
 *.cast
 *.png
+*.tmp
 .aider*
 .clean
 

--- a/webui/.gitignore
+++ b/webui/.gitignore
@@ -12,6 +12,11 @@ dist
 dist-ssr
 *.local
 
+# Playwright local test output
+test-results/
+playwright-report/
+blob-report/
+
 # bun is not a supported install path for webui (see #2277).
 # Cloudflare Pages prefers bun when bun.lockb exists, which resolves
 # different package versions than package-lock.json and breaks the


### PR DESCRIPTION
## Summary
- ignore root-level `*.tmp` scratch files
- ignore Playwright local output under `webui/` (`test-results/`, `playwright-report/`, `blob-report/`)

## Verification
- `git diff --check -- .gitignore webui/.gitignore`
- `git check-ignore -v tests/test_browser.py.tmp webui/test-results/example.txt webui/playwright-report/index.html webui/blob-report/report.zip`

Context: these paths showed up as untracked residue in Bob's shared gptme checkout after local browser/webui test work.