### PR TITLE
docs(readme): add multi-agent and provider support rows to comparison table

### DIFF
--- a/README.md
+++ b/README.md
@@ -671,7 +671,7 @@ gptme is a **personal AI agent that runs anywhere a terminal runs** — your lap
 | **Autonomy** | Autonomous agents | One-shot | IDE-assisted | Terminal AI |
 | **Multi-agent** | ✅ Concurrent agents | ❌ | ❌ | ❌ |
 | **Local-first** | ✅ Full support | ❌ API required | ❌ API required | ❌ API required |
-| **Provider support** | 100+ models | Anthropic | Anthropic/OpenAI/Google | OpenAI (built-in) |
+| **Provider support** | ✅ 100+ models (OpenRouter/local) | Anthropic/Bedrock/Vertex | Anthropic/OpenAI/Google | OpenAI (built-in) |
 | **MCP Support** | ✅ Built-in | ✅ Built-in | ❌ | ❌ |
 | **Plugin System** | ✅ Full plugins | ❌ | ✅ Extensions | ❌ |
 | **Web Browsing** | ✅ Playwright | ❌ | ❌ | ❌ |

--- a/README.md
+++ b/README.md
@@ -669,7 +669,9 @@ gptme is a **personal AI agent that runs anywhere a terminal runs** — your lap
 |---------|-------|-------------|--------|------|
 | **Environment** | Any terminal | Terminal | IDE | Terminal |
 | **Autonomy** | Autonomous agents | One-shot | IDE-assisted | Terminal AI |
+| **Multi-agent** | ✅ Concurrent agents | ❌ | ❌ | ❌ |
 | **Local-first** | ✅ Full support | ❌ API required | ❌ API required | ❌ API required |
+| **Provider support** | 100+ models | Anthropic | Anthropic/OpenAI/Google | OpenAI (built-in) |
 | **MCP Support** | ✅ Built-in | ✅ Built-in | ❌ | ❌ |
 | **Plugin System** | ✅ Full plugins | ❌ | ✅ Extensions | ❌ |
 | **Web Browsing** | ✅ Playwright | ❌ | ❌ | ❌ |


### PR DESCRIPTION
## Summary

- Adds a **Multi-agent** row to the FAQ comparison table — gptme's concurrent multi-agent capability (Bob, Alice, Gordon, Sven running in parallel) is the clearest differentiator vs Claude Code, Cursor, and Warp, but was missing from the table.
- Adds a **Provider support** row showing gptme's 100+ model breadth vs single-vendor competitors (Anthropic-only, OpenAI-only), highlighting the local-first + provider-agnostic wedge.

## Motivation

Post-Warp open-sourcing (April 2026), the terminal-AI space is more crowded. The existing comparison table already has "Local-first" and "Self-hosting" rows, but didn't make the multi-agent angle explicit — which is gptme's strongest structural differentiator that no other terminal agent currently matches.

## Test plan

- [ ] Visually verify the table renders correctly on GitHub
- [ ] Verify provider claims are accurate (gptme: 100+ via OpenRouter/5 providers, Claude Code: Anthropic, Cursor: Anthropic/OpenAI/Google, Warp: OpenAI built-in)