### PR TITLE
docs(webui): document CORS origin for hosted UI + local server

### DIFF
--- a/gptme/server/cli.py
+++ b/gptme/server/cli.py
@@ -121,7 +121,9 @@ def main():
     help=(
         "CORS origin(s) to allow. Use '*' to allow all origins. Pass a "
         "comma-separated list to allow multiple origins, e.g. "
-        "'tauri://localhost,http://tauri.localhost'."
+        "'https://chat.gptme.org,tauri://localhost,http://tauri.localhost'. "
+        "Set this to the origin of the web UI you load (for the hosted UI, "
+        "'https://chat.gptme.org')."
     ),
 )
 @click.option(

--- a/webui/README.md
+++ b/webui/README.md
@@ -35,6 +35,25 @@ pipx install 'gptme[server]'
 gptme-server --cors-origin='http://localhost:5701'
 ```
 
+### Using the hosted UI with your own server
+
+The **Hosted (open)** mode at [chat.gptme.org](https://chat.gptme.org/) is a
+static frontend that connects to a server you run. It comes pre-configured to
+talk to a local server at `http://127.0.0.1:5700` (see [Pre-configured
+servers](#pre-configured-servers)), so you only need to start one:
+
+```sh
+pipx install 'gptme[server]'
+gptme-server --cors-origin='https://chat.gptme.org'
+```
+
+The `--cors-origin` must match the origin you load the UI from. Pointing the
+hosted UI at a server started without it (or with only the local-dev origin
+`http://localhost:5701`) fails with a browser CORS error and a "server may not
+allow requests from this origin" message in the console — the server is
+reachable, it just rejects the cross-origin request. Pass a comma-separated
+list to allow several origins at once.
+
 ## Multi-Backend Support
 
 The web UI can connect to multiple gptme servers at once, showing conversations from all connected servers in a unified sidebar.


### PR DESCRIPTION
## What

Document the `--cors-origin` a user must set to use the **Hosted (open)** web UI ([chat.gptme.org](https://chat.gptme.org/)) with their own local `gptme-server`.

## Why

`webui/README.md` lists "Hosted (open) — bring your own server" as a supported deployment mode, and the UI ships pre-configured to connect to a local server at `http://127.0.0.1:5700`. But the only documented `--cors-origin` example is the local-dev origin (`http://localhost:5701`). A user who loads the hosted UI and starts a local server following the docs hits a browser CORS error ("server may not allow requests from this origin") with no guidance — the server is reachable, it just rejects the cross-origin request.

Found via a user-testing sweep of the gptme ecosystem: loading chat.gptme.org against a local server configured with a different origin reproduces the console CORS failures.

## Changes

- `webui/README.md`: add a **Using the hosted UI with your own server** subsection with the correct command (`gptme-server --cors-origin='https://chat.gptme.org'`) and the failure mode it prevents.
- `gptme/server/cli.py`: surface `https://chat.gptme.org` as an example in the `--cors-origin` help text and note it should match the UI origin.

Docs + help-text only; no behavior change.