### PR TITLE
fix(cli): resolve bare provider-less model names instead of crashing

### DIFF
--- a/gptme/init.py
+++ b/gptme/init.py
@@ -15,6 +15,7 @@ from .llm import guess_provider_from_config, init_llm, is_custom_provider
 from .llm.models import (
     PROVIDERS,
     CustomProvider,
+    ModelMeta,
     Provider,
     get_model,
     get_recommended_model,
@@ -136,6 +137,10 @@ def init_model(
             "Full guide: https://gptme.org/docs/getting-started.html"
         )
 
+    # Holds a pre-resolved ModelMeta when the resolution step already fetched it,
+    # so the final get_model(model_full) call below can be skipped.
+    _resolved_meta: ModelMeta | None = None
+
     # Check if model has provider/model format
     if "/" in model:
         provider_part = model.split("/")[0]
@@ -161,6 +166,7 @@ def init_model(
                 )
             provider = resolved.provider
             model_name = resolved.model
+            _resolved_meta = resolved  # reuse below; avoids a redundant second lookup
     else:
         # No slash - check if it's a custom provider with default model
         if is_custom_provider(model):
@@ -180,7 +186,7 @@ def init_model(
     console.log(f"Using model: [green]{model_full}[/green]")
     init_llm(provider)
 
-    model_meta = get_model(model_full)
+    model_meta = _resolved_meta or get_model(model_full)
 
     # Apply GPTME_CONTEXT_LENGTH override (useful for local models with non-standard context)
     context_length_str = os.environ.get("GPTME_CONTEXT_LENGTH")

--- a/gptme/init.py
+++ b/gptme/init.py
@@ -147,8 +147,20 @@ def init_model(
             provider = CustomProvider(provider_part)
             model_name = "/".join(model.split("/")[1:])  # Rest after provider
         else:
-            # Unknown provider format, treat as provider only
-            provider, model_name = cast(tuple[Provider, str], (model, None))
+            # Unrecognized provider prefix. Delegate to get_model(), which can
+            # still resolve provider-less model names (e.g. OpenRouter's
+            # "meta-llama/llama-3.1-405b-instruct") via dynamic lookup.
+            # Previously this mistook the whole "a/b" string for a provider name
+            # and crashed in get_recommended_model() with a misleading message.
+            resolved = get_model(model)
+            if resolved.provider == "unknown":
+                raise ValueError(
+                    f"Unknown model {model!r}. Use 'provider/model' with a known "
+                    f"provider (e.g. 'openrouter/{model}'), or configure a custom "
+                    f"provider. Run 'gptme-util models list' to see available models."
+                )
+            provider = resolved.provider
+            model_name = resolved.model
     else:
         # No slash - check if it's a custom provider with default model
         if is_custom_provider(model):

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -566,7 +566,7 @@ class TestInitModelParsing:
     @patch("gptme.init.is_custom_provider", return_value=False)
     @patch("gptme.init.get_config")
     @patch("gptme.init.console")
-    def test_unknown_provider_treated_as_provider_only(
+    def test_bare_provider_less_model_resolved_via_get_model(
         self,
         mock_console,
         mock_config_fn,
@@ -577,20 +577,63 @@ class TestInitModelParsing:
         mock_set_default,
         dummy_model_meta,
     ):
-        """'unknownprov/model' where unknownprov is neither builtin nor custom
-        should treat the entire string as provider, model=None."""
+        """A provider-less model name with a slash (e.g. OpenRouter's
+        'meta-llama/llama-3.1-405b-instruct') should be resolved via get_model(),
+        not mistaken for a provider name. Regression test: the CLI previously
+        crashed on model names that get_model() resolves fine."""
         from gptme.init import init_model
 
         mock_config_fn.return_value = MagicMock(
             chat=MagicMock(model=None), get_env=MagicMock(return_value=None)
         )
-        mock_recommend.return_value = "default-model"
-        mock_get_model.return_value = dummy_model_meta
+        # get_model resolves the bare OpenRouter-style name to provider=openrouter
+        mock_get_model.return_value = ModelMeta(
+            provider="openrouter",
+            model="meta-llama/llama-3.1-405b-instruct",
+            context=128_000,
+        )
 
-        init_model(model="unknownprov/some-model")
+        init_model(model="meta-llama/llama-3.1-405b-instruct")
 
-        # Should have called get_recommended_model since model_name was None
-        mock_recommend.assert_called_once()
+        # Provider resolved from get_model, not from treating the whole string
+        # as a provider; model_name was resolved so get_recommended_model is unused.
+        mock_init_llm.assert_called_once_with("openrouter")
+        mock_recommend.assert_not_called()
+
+    @patch("gptme.init.set_default_model")
+    @patch("gptme.init.get_model")
+    @patch("gptme.init.init_llm")
+    @patch("gptme.init.get_recommended_model")
+    @patch("gptme.init.is_custom_provider", return_value=False)
+    @patch("gptme.init.get_config")
+    @patch("gptme.init.console")
+    def test_unresolvable_model_raises_clear_error(
+        self,
+        mock_console,
+        mock_config_fn,
+        mock_custom,
+        mock_recommend,
+        mock_init_llm,
+        mock_get_model,
+        mock_set_default,
+        dummy_model_meta,
+    ):
+        """A genuinely unresolvable 'a/b' model (get_model falls back to
+        provider='unknown') should raise a clear error, not the misleading
+        'provider requires a model' crash from get_recommended_model()."""
+        from gptme.init import init_model
+
+        mock_config_fn.return_value = MagicMock(
+            chat=MagicMock(model=None), get_env=MagicMock(return_value=None)
+        )
+        mock_get_model.return_value = ModelMeta(
+            provider="unknown",
+            model="totally/nonexistent-model",
+            context=128_000,
+        )
+
+        with pytest.raises(ValueError, match="Unknown model"):
+            init_model(model="totally/nonexistent-model")
 
     @patch("gptme.init.set_default_model")
     @patch("gptme.init.get_model")


### PR DESCRIPTION
## Problem

When `-m provider/model` is given with an **unrecognized provider prefix**, `init_model()` treats the entire string as a provider name and crashes with a misleading error:

```
$ gptme -m meta-llama/llama-3.1-405b-instruct
ERROR  Provider 'meta-llama/llama-3.1-405b-instruct' requires specifying a model,
       e.g. gptme -m meta-llama/llama-3.1-405b-instruct/your-model-name
```

…even though `get_model('meta-llama/llama-3.1-405b-instruct')` resolves that exact name fine (`provider='openrouter'` via dynamic lookup). A user following [OpenRouter's own model naming](https://openrouter.ai/models) without the `openrouter/` prefix hits a confusing crash, and the suggested fix (`.../your-model-name`) just appends another slash to an already-bad string.

Found via a dogfooding pass on the CLI.

## Fix

The `else` branch (slash present, prefix is neither a builtin nor a custom provider) now delegates to `get_model()` — the same resolver the rest of gptme uses — instead of mistaking the whole `a/b` string for a provider:

- **Bare OpenRouter names** (`meta-llama/llama-3.1-405b-instruct`) → resolve to `openrouter/meta-llama/llama-3.1-405b-instruct` and work.
- **Genuinely unresolvable models** → a clear, actionable error instead of the misleading `get_recommended_model()` crash:
  > Unknown model 'totally/nope'. Use 'provider/model' with a known provider (e.g. 'openrouter/totally/nope'), or configure a custom provider. Run 'gptme-util models list' to see available models.

This aligns the CLI init path with library `get_model()` behavior (the library already handled these names; only the CLI entry path crashed).

## Tests

- Replaced `test_unknown_provider_treated_as_provider_only` (which encoded the buggy behavior and only passed because `get_model` was mocked) with:
  - `test_bare_provider_less_model_resolved_via_get_model` — bare OpenRouter name resolves via `get_model`, `init_llm` called with `openrouter`, `get_recommended_model` unused.
  - `test_unresolvable_model_raises_clear_error` — `provider='unknown'` fallback raises a clear `ValueError`.
- Full `tests/test_init.py`: **75 passed**.
- Integration check with the real `get_model` confirms both paths (resolve / clear-error).