### PR TITLE
feat(webui): add install step + setup-guide link to disconnected banner

### DIFF
--- a/webui/src/components/WelcomeView.tsx
+++ b/webui/src/components/WelcomeView.tsx
@@ -57,6 +57,7 @@ export const WelcomeView = () => {
     ''
   );
   const isDefaultLocalServer = DEFAULT_LOCAL_SERVER_URLS.has(activeServerBaseUrl);
+  const installCommand = `pipx install 'gptme[server]'`;
   const serverCommand = `gptme-server --cors-origin='${window.location.origin}'`;
 
   // Create observables that ChatInput expects
@@ -199,9 +200,17 @@ export const WelcomeView = () => {
                       : 'Check the server URL and auth token, then retry the connection.'}
                   </p>
                   {isDefaultLocalServer && (
-                    <code className="block rounded-md border border-amber-500/20 bg-background/80 px-3 py-2 font-mono text-xs">
-                      {serverCommand}
-                    </code>
+                    <div className="space-y-2">
+                      <p className="text-xs text-muted-foreground">
+                        New to gptme? Install it, then start a server:
+                      </p>
+                      <code className="block rounded-md border border-amber-500/20 bg-background/80 px-3 py-2 font-mono text-xs">
+                        {installCommand}
+                      </code>
+                      <code className="block rounded-md border border-amber-500/20 bg-background/80 px-3 py-2 font-mono text-xs">
+                        {serverCommand}
+                      </code>
+                    </div>
                   )}
                   <div className="flex flex-wrap gap-2">
                     <Button
@@ -234,6 +243,18 @@ export const WelcomeView = () => {
                       Server settings
                     </Button>
                   </div>
+                  <p className="text-xs text-muted-foreground">
+                    Need help connecting?{' '}
+                    <a
+                      href="https://gptme.org/docs/server.html"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="font-medium underline underline-offset-2 hover:text-foreground"
+                    >
+                      Read the server setup guide
+                    </a>
+                    .
+                  </p>
                 </AlertDescription>
               </Alert>
             )}

--- a/webui/src/components/__tests__/WelcomeView.test.tsx
+++ b/webui/src/components/__tests__/WelcomeView.test.tsx
@@ -11,6 +11,7 @@ const mockInvalidateQueries = jest.fn();
 const mockConnect = jest.fn();
 const mockFetch = jest.fn();
 const isConnected$ = observable(true);
+let mockBaseUrl = 'http://localhost:5700';
 
 jest.mock('react-router-dom', () => {
   const actual = jest.requireActual('react-router-dom');
@@ -29,7 +30,7 @@ jest.mock('@/contexts/ApiContext', () => {
       },
       isConnected$,
       connect: mockConnect,
-      connectionConfig: { baseUrl: 'http://localhost:5700' },
+      connectionConfig: { baseUrl: mockBaseUrl },
       switchServer: jest.fn(),
     }),
   };
@@ -63,6 +64,7 @@ jest.mock('../ExamplesSection', () => ({
 describe('WelcomeView', () => {
   beforeEach(() => {
     isConnected$.set(true);
+    mockBaseUrl = 'http://localhost:5700';
     setupWizard$.step.set('welcome');
     setupWizard$.open.set(false);
     setupWizard$.providerStatusVersion.set(0);
@@ -117,6 +119,29 @@ describe('WelcomeView', () => {
     expect(screen.getByRole('button', { name: /copy start command/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /server settings/i })).toBeInTheDocument();
     // Setup-guide link points at the canonical server/CORS docs (#2479, #2478)
+    expect(screen.getByRole('link', { name: /server setup guide/i })).toHaveAttribute(
+      'href',
+      'https://gptme.org/docs/server.html'
+    );
+  });
+
+  it('shows docs link (but not install step) when a non-default server is disconnected', () => {
+    mockBaseUrl = 'http://my-server.example.com:5700';
+    isConnected$.set(false);
+
+    render(
+      <SettingsProvider>
+        <WelcomeView />
+      </SettingsProvider>
+    );
+
+    // Non-default path: different title and description
+    expect(screen.getByText(/Cannot reach/i)).toBeInTheDocument();
+    expect(screen.getByText(/Check the server URL and auth token/i)).toBeInTheDocument();
+    // Install step is only for new users on the default local server
+    expect(screen.queryByText("pipx install 'gptme[server]'")).not.toBeInTheDocument();
+    expect(screen.queryByText(/New to gptme\?/i)).not.toBeInTheDocument();
+    // Docs link is always shown for any disconnected state (CORS/auth help applies too)
     expect(screen.getByRole('link', { name: /server setup guide/i })).toHaveAttribute(
       'href',
       'https://gptme.org/docs/server.html'

--- a/webui/src/components/__tests__/WelcomeView.test.tsx
+++ b/webui/src/components/__tests__/WelcomeView.test.tsx
@@ -108,9 +108,19 @@ describe('WelcomeView', () => {
     expect(
       screen.getByText(/Start a local gptme server or point the app at another server/i)
     ).toBeInTheDocument();
+    // Brand-new users need the install step before the server command (#2479)
+    expect(screen.getByText("pipx install 'gptme[server]'")).toBeInTheDocument();
+    expect(
+      screen.getByText(/New to gptme\? Install it, then start a server:/i)
+    ).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /retry connection/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /copy start command/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /server settings/i })).toBeInTheDocument();
+    // Setup-guide link points at the canonical server/CORS docs (#2479, #2478)
+    expect(screen.getByRole('link', { name: /server setup guide/i })).toHaveAttribute(
+      'href',
+      'https://gptme.org/docs/server.html'
+    );
   });
 
   it('shows a finish-setup banner when the server has no provider configured', async () => {


### PR DESCRIPTION
## What

The WelcomeView disconnected-state banner already explains how to start a local server, but it assumed gptme was installed and offered no path to the docs. A brand-new user landing on `chat.gptme.org` with nothing installed had:

- no in-app install instruction (the banner jumped straight to `gptme-server --cors-origin=...`), and
- no link to the CORS/server setup guide that #2478 just added.

This closes the last onboarding rungs for the primary "try gptme in the browser" surface.

## Changes

In the default-local-server branch of the disconnected banner (`webui/src/components/WelcomeView.tsx`):

- Add an install command — `pipx install 'gptme[server]'` — shown **before** the `gptme-server` command, with a short "New to gptme? Install it, then start a server:" hint.
- Add a "Read the server setup guide" link to `https://gptme.org/docs/server.html` (the page #2478 documented CORS on).

Both additions only render for the default local server (the case where guidance helps); the "cannot reach configured server" path is unchanged.

## Tests

Extends the existing `WelcomeView` disconnected-state test to assert the install command, the hint copy, and the docs link href. All 5 WelcomeView tests pass; `tsc` and `eslint` clean.

Closes #2479