### PR TITLE
fix(logmanager): tolerate unknown message fields when reading logs

### DIFF
--- a/gptme/logmanager/manager.py
+++ b/gptme/logmanager/manager.py
@@ -26,7 +26,7 @@ if os.name == "nt":
         pass
 from collections.abc import Generator, Iterator
 from contextvars import ContextVar
-from dataclasses import dataclass, field, replace
+from dataclasses import dataclass, field, fields, replace
 from datetime import datetime, timezone
 from itertools import islice, zip_longest
 from pathlib import Path
@@ -53,6 +53,10 @@ PathLike: TypeAlias = str | Path
 logger = logging.getLogger(__name__)
 
 RoleLiteral = Literal["user", "assistant", "system"]
+
+# Field names accepted by Message.__init__, used to drop unknown keys when
+# reading stored logs (forward-compatibility with logs from newer versions).
+_MESSAGE_FIELD_NAMES = frozenset(f.name for f in fields(Message))
 
 
 @dataclass(frozen=True, repr=False)
@@ -850,4 +854,14 @@ def _gen_read_jsonl(path: PathLike) -> Generator[Message, None, None]:
             # Migrate flat metadata format to nested usage format
             if json_data.get("metadata"):
                 json_data["metadata"] = _migrate_metadata(json_data["metadata"])
+            # Drop unknown keys so logs written by a newer gptme version (with
+            # message fields this version doesn't know about) stay readable
+            # instead of crashing the whole read with a TypeError.
+            unknown = set(json_data) - _MESSAGE_FIELD_NAMES
+            if unknown:
+                logger.warning(
+                    f"Ignoring unknown message field(s) {sorted(unknown)} in {path}"
+                )
+                for key in unknown:
+                    del json_data[key]
             yield Message(**json_data, files=files, file_hashes=file_hashes)

--- a/tests/test_logmanager.py
+++ b/tests/test_logmanager.py
@@ -336,3 +336,19 @@ def test_read_jsonl_malformed(tmp_path):
     assert len(log.messages) == 2
     assert log.messages[0].content == "hello"
     assert log.messages[1].content == "world"
+
+
+def test_read_jsonl_unknown_field(tmp_path):
+    """Unknown message fields (e.g. from a newer gptme version) should be
+    dropped rather than crashing the whole read with a TypeError."""
+    jsonl_file = tmp_path / "test.jsonl"
+    jsonl_file.write_text(
+        '{"role": "user", "content": "hello", "timestamp": "2025-01-01T00:00:00Z", '
+        '"some_future_field": 42}\n'
+        '{"role": "assistant", "content": "world", "timestamp": "2025-01-01T00:00:01Z"}\n'
+    )
+    log = Log.read_jsonl(jsonl_file)
+    # Both messages must survive; the unknown key is just ignored.
+    assert len(log.messages) == 2
+    assert log.messages[0].content == "hello"
+    assert log.messages[1].content == "world"


### PR DESCRIPTION
## Problem

`gptme-util chats list` (and any conversation load) crashes with a `TypeError` when a stored log contains a message field the running version doesn't know about:

```
TypeError: Message.__init__() got an unexpected keyword argument 'ephemeral_ttl'
  File ".../gptme/logmanager/manager.py", line 853, in _gen_read_jsonl
    yield Message(**json_data, files=files, file_hashes=file_hashes)
```

`_gen_read_jsonl` builds `Message(**json_data)` directly, so a **single** forward-incompatible log line takes down the entire read — a user can't list *any* chats. This happens whenever a log was written by a newer gptme version (e.g. one that added `ephemeral_ttl`) and then read by an older one, or any time the on-disk schema gains a field ahead of the reader.

The sibling case — malformed JSON lines — is already handled gracefully (skip + warn); unknown-field handling was the gap.

## Fix

Drop unknown keys with a warning before constructing `Message`, mirroring the existing malformed-line handling. The affected message still loads (minus the unknown field) instead of killing the whole read. Forward/backward compatible.

## How this was found

Dogfooding the gptme CLI surface — `gptme-util chats list` crashed live on a real log directory containing `ephemeral_ttl`-tagged messages written by a newer build.

## Reproduce (on master, before fix)

```python
import tempfile, json
from gptme.logmanager.manager import _gen_read_jsonl
with tempfile.NamedTemporaryFile("w", suffix=".jsonl", delete=False) as f:
    f.write(json.dumps({"role":"user","content":"hi","timestamp":"2026-01-01T00:00:00Z","some_future_field":42})+"\n")
    path = f.name
list(_gen_read_jsonl(path))   # TypeError: ... unexpected keyword argument 'some_future_field'
```

## Test

Added `test_read_jsonl_unknown_field` next to the existing `test_read_jsonl_malformed`. `tests/test_logmanager.py` + `tests/test_ephemeral.py` pass (41 passed).
