### PR TITLE
docs(webui): explain Chrome 142+ Local Network Access for hosted UI → local server

### DIFF
--- a/docs/server.rst
+++ b/docs/server.rst
@@ -52,6 +52,19 @@ To use the server with a locally hosted gptme-webui, configure the CORS origin w
 
     gptme-server --cors-origin 'http://localhost:5701'
 
+.. note::
+
+    **Connecting the hosted web UI to a local server (Chrome 142+).**
+    When you use the hosted web UI at `chat.gptme.org <https://chat.gptme.org>`_
+    with a ``gptme-server`` running on ``localhost``, recent Chromium browsers
+    (Chrome 142+) gate the connection behind a *Local Network Access* permission
+    prompt. This check runs *before* CORS headers are evaluated, so the
+    ``--cors-origin`` flag is necessary but no longer sufficient — you must also
+    click **Allow** on the permission prompt for the page to reach your local
+    server. Serving the web UI from a local origin (for example
+    ``http://localhost:5701``) avoids the prompt entirely, since that is a
+    local-to-local request.
+
 Basic Web UI
 ------------
 

--- a/webui/src/components/WelcomeView.tsx
+++ b/webui/src/components/WelcomeView.tsx
@@ -65,6 +65,11 @@ export const WelcomeView = () => {
   const isHostedOrigin = !/^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])([:/]|$)/.test(
     window.location.origin
   );
+  // True when the configured server URL points at a loopback address (any port),
+  // not just the two well-known defaults — used to show the LNA hint for custom ports.
+  const isActiveServerLoopback = /^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])([:/]|$)/.test(
+    activeServerBaseUrl
+  );
 
   // Create observables that ChatInput expects
   const autoFocus$ = observable(true);
@@ -205,6 +210,15 @@ export const WelcomeView = () => {
                       ? 'Start a local gptme server or point the app at another server before starting a chat.'
                       : 'Check the server URL and auth token, then retry the connection.'}
                   </p>
+                  {!isDefaultLocalServer && isHostedOrigin && isActiveServerLoopback && (
+                    <p className="text-xs text-muted-foreground">
+                      On Chrome 142+ (and other Chromium browsers), connecting from a hosted page to
+                      a local server triggers a{' '}
+                      <span className="font-medium">Local Network Access</span> permission prompt —
+                      click <span className="font-medium">Allow</span> if you see one. The{' '}
+                      <code>--cors-origin</code> flag alone is not enough.
+                    </p>
+                  )}
                   {isDefaultLocalServer && (
                     <div className="space-y-2">
                       <p className="text-xs text-muted-foreground">

--- a/webui/src/components/WelcomeView.tsx
+++ b/webui/src/components/WelcomeView.tsx
@@ -59,6 +59,12 @@ export const WelcomeView = () => {
   const isDefaultLocalServer = DEFAULT_LOCAL_SERVER_URLS.has(activeServerBaseUrl);
   const installCommand = `pipx install 'gptme[server]'`;
   const serverCommand = `gptme-server --cors-origin='${window.location.origin}'`;
+  // Chrome 142+ Local Network Access only gates requests from a non-local page
+  // origin to a loopback/local server, so the permission hint below is only
+  // relevant when the web UI itself is served from a hosted (non-local) origin.
+  const isHostedOrigin = !/^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])([:/]|$)/.test(
+    window.location.origin
+  );
 
   // Create observables that ChatInput expects
   const autoFocus$ = observable(true);
@@ -210,6 +216,16 @@ export const WelcomeView = () => {
                       <code className="block rounded-md border border-amber-500/20 bg-background/80 px-3 py-2 font-mono text-xs">
                         {serverCommand}
                       </code>
+                      {isHostedOrigin && (
+                        <p className="text-xs text-muted-foreground">
+                          On Chrome 142+ (and other Chromium browsers), the first connection to a
+                          local server also triggers a{' '}
+                          <span className="font-medium">Local Network Access</span> permission
+                          prompt. Click <span className="font-medium">Allow</span> so this page can
+                          reach <code>localhost</code> — the <code>--cors-origin</code> flag alone
+                          is not enough.
+                        </p>
+                      )}
                     </div>
                   )}
                   <div className="flex flex-wrap gap-2">


### PR DESCRIPTION
## Problem

While **live-dogfooding** chat.gptme.org (no local server running), the hosted UI's auto-probe of `http://127.0.0.1:5700` is blocked by Chrome with:

```
Access to fetch at 'http://127.0.0.1:5700/api/v2' from origin 'https://chat.gptme.org'
has been blocked by CORS policy: Permission was denied for this request to access
the `loopback` address space.
```

This is **Chrome 142+ Local Network Access (LNA)** ([Chrome for Developers blog](https://developer.chrome.com/blog/local-network-access)): requests from a public/hosted page origin to a loopback/local address are gated behind a *Local Network Access* permission prompt. Critically, **this check runs before CORS headers are evaluated** — so the `gptme-server --cors-origin=...` instruction we shipped in #2478 / #2481 is now *necessary but no longer sufficient*. A user with a correctly-configured server still can't connect from the hosted UI unless they also Allow the LNA prompt.

## Changes

- **`WelcomeView.tsx`** disconnected banner: add a short hint telling users to click **Allow** on the Local Network Access prompt. Gated on `isHostedOrigin` (regex check) so it only shows when the UI is served from a non-local origin — running the UI locally (`http://localhost:5701`) is a local→local request and never triggers the prompt.
- **`docs/server.rst`**: add a note to the CORS section explaining the prompt and that serving the UI locally avoids it.

## What this does *not* do (follow-up)

The site-side technical mitigation Chrome offers is annotating the probe fetches with `fetch(url, { targetAddressSpace: 'local' })`. That needs to be applied conditionally (local URLs only, so it doesn't affect connections to remote/cloud servers) and can't be verified in a headless browser (headless auto-denies LNA regardless). Left as a focused follow-up rather than shipping an unverifiable change here.

## Verification

- `npm run typecheck` ✅
- `npx jest WelcomeView.test.tsx` ✅ (6/6)
- `npx prettier --check` ✅ / `npx eslint` ✅
- Reproduction captured via headless Playwright against the live https://chat.gptme.org

Found while dogfooding for ErikBjare/bob#745 (durable work-supply pipeline).