### PR TITLE
fix(cli): tokens count exits nonzero when no input is provided

### DIFF
--- a/gptme/cli/util.py
+++ b/gptme/cli/util.py
@@ -262,7 +262,7 @@ def tokens_count(text: str | None, model: str, file: str | None):
 
     if not text:
         print("Error: No text provided. Use --file or pipe text to stdin.")
-        return
+        sys.exit(1)
 
     # Validate model
     try:

--- a/tests/test_util_cli.py
+++ b/tests/test_util_cli.py
@@ -37,6 +37,11 @@ def test_tokens_count(tmp_path):
     assert result.exit_code == 0
     assert "Token count" in result.output
 
+    # Test no input: should exit nonzero (error), not silently succeed
+    result = runner.invoke(main, ["tokens", "count"], input="")
+    assert result.exit_code != 0
+    assert "No text provided" in result.output
+
 
 def test_chats_list(tmp_path, mocker):
     """Test the chats list command."""


### PR DESCRIPTION
## Problem

`gptme-util tokens count` with no text (and no `--file`, empty/tty stdin) prints an error but **exits 0**:

```
$ gptme-util tokens count </dev/null
Error: No text provided. Use --file or pipe text to stdin.
$ echo $?
0
```

Silent success on an error condition is a scripting footgun, and it's inconsistent with the sibling error path right below it (unsupported model), which already does `sys.exit(1)`.

## Fix

One-line change: the `if not text:` branch now uses `sys.exit(1)` instead of a bare `return`, matching the model-validation error path.

## Verification

- Added a regression case to `test_tokens_count` asserting nonzero exit + "No text provided" on empty input.
- `pytest tests/test_util_cli.py::test_tokens_count` passes; ruff check + format clean.

Found via CLI-surface dogfooding (ErikBjare/bob#745).