### PR TITLE
fix(cli): mcp commands exit nonzero on failure

### DIFF
--- a/gptme/cli/cmd_mcp.py
+++ b/gptme/cli/cmd_mcp.py
@@ -1,5 +1,7 @@
 """CLI commands for MCP (Model Context Protocol) server management."""
 
+import sys
+
 import click
 
 from ..config import get_config
@@ -67,16 +69,16 @@ def mcp_test(server_name: str):
 
     if not config.mcp.enabled:
         click.echo("❌ MCP is disabled in config")
-        return
+        sys.exit(1)
 
     server = next((s for s in config.mcp.servers if s.name == server_name), None)
     if not server:
         click.echo(f"❌ Server '{server_name}' not found in config")
-        return
+        sys.exit(1)
 
     if not server.enabled:
         click.echo(f"❌ Server '{server_name}' is disabled")
-        return
+        sys.exit(1)
 
     server_type = "HTTP" if server.is_http else "stdio"
     click.echo(f"🔌 Testing {server_name} ({server_type})...")
@@ -92,6 +94,7 @@ def mcp_test(server_name: str):
 
     except Exception as e:
         click.echo(f"❌ Connection failed: {e}")
+        sys.exit(1)
 
 
 @mcp.command("info")
@@ -150,8 +153,10 @@ def mcp_info(server_name: str):
             else:
                 click.echo(f"❌ Server '{server_name}' not found in registries either.")
                 click.echo("\nTry searching: gptme-util mcp search <query>")
+                sys.exit(1)
         except Exception as e:
             click.echo(f"❌ Registry search failed: {e}")
+            sys.exit(1)
 
 
 @mcp.command("search")
@@ -185,7 +190,7 @@ def mcp_search(query: str, registry: str, limit: int):
             results = reg.search_mcp_so(query, limit)
         else:
             click.echo(f"❌ Unknown registry: {registry}")
-            return
+            sys.exit(1)
 
         if results:
             click.echo(format_server_list(results))
@@ -193,3 +198,4 @@ def mcp_search(query: str, registry: str, limit: int):
             click.echo("No servers found.")
     except Exception as e:
         click.echo(f"❌ Search failed: {e}")
+        sys.exit(1)

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -26,9 +26,9 @@ def test_mcp_cli_commands(monkeypatch):
     # Test with mock data - this would normally use the config system
     runner = CliRunner()
 
-    # Test info command with non-existent server
+    # Test info command with non-existent server - should exit 1 (server not found anywhere)
     result = runner.invoke(mcp_info, ["nonexistent"])
-    assert result.exit_code == 0
+    assert result.exit_code == 1
     # Updated to match improved error message that searches registries
     assert "not configured locally" in result.output
     assert "not found in registries either" in result.output

--- a/tests/test_util_cli_mcp.py
+++ b/tests/test_util_cli_mcp.py
@@ -191,7 +191,7 @@ class TestMCPTest:
         mock_config.mcp.enabled = False
         runner = CliRunner()
         result = runner.invoke(main, ["mcp", "test", "test-server"])
-        assert result.exit_code == 0
+        assert result.exit_code == 1
         assert "MCP is disabled" in result.output
 
     def test_server_not_found(self, mock_config):
@@ -199,7 +199,7 @@ class TestMCPTest:
         mock_config.mcp.servers = []
         runner = CliRunner()
         result = runner.invoke(main, ["mcp", "test", "nonexistent"])
-        assert result.exit_code == 0
+        assert result.exit_code == 1
         assert "not found in config" in result.output
 
     def test_server_disabled(self, mock_config):
@@ -211,7 +211,7 @@ class TestMCPTest:
 
         runner = CliRunner()
         result = runner.invoke(main, ["mcp", "test", "test-server"])
-        assert result.exit_code == 0
+        assert result.exit_code == 1
         assert "is disabled" in result.output
 
     def test_successful_connection(self, mock_config, mock_mcp_client):
@@ -254,7 +254,7 @@ class TestMCPTest:
 
         runner = CliRunner()
         result = runner.invoke(main, ["mcp", "test", "test-server"])
-        assert result.exit_code == 0
+        assert result.exit_code == 1
         assert "Connection failed" in result.output
         assert "Connection timeout" in result.output
 
@@ -395,7 +395,7 @@ class TestMCPInfo:
 
         runner = CliRunner()
         result = runner.invoke(main, ["mcp", "info", "nonexistent"])
-        assert result.exit_code == 0
+        assert result.exit_code == 1
         assert "not found in registries either" in result.output
         assert "Try searching" in result.output
 
@@ -406,7 +406,7 @@ class TestMCPInfo:
 
         runner = CliRunner()
         result = runner.invoke(main, ["mcp", "info", "test"])
-        assert result.exit_code == 0
+        assert result.exit_code == 1
         assert "Registry search failed" in result.output
 
 
@@ -509,6 +509,6 @@ class TestMCPSearch:
 
         runner = CliRunner()
         result = runner.invoke(main, ["mcp", "search", "test"])
-        assert result.exit_code == 0
+        assert result.exit_code == 1
         assert "Search failed" in result.output
         assert "Network timeout" in result.output


### PR DESCRIPTION
## Problem

`gptme-util mcp test/info/search` print an error message but **return exit 0** on genuine failures. A script or CI step calling these commands can't detect failure via exit code — a silent footgun. This is the same bug class as the `tokens count` fix in #2484.

Affected error paths:
- `mcp test`: MCP disabled, server not found in config, server disabled, connection failed
- `mcp info`: server not found in registries (anywhere), registry search exception
- `mcp search`: search exception, unknown registry

## Fix

These error paths now `sys.exit(1)`, matching the convention already used by `tools info` (not-found → exit 1).

Cases that still produce useful output deliberately **stay exit 0**:
- `mcp list` — informational (disabled / no servers configured)
- `mcp info` local-server connection failure — the server config was still shown; the connection test is supplementary (same reasoning as `models info` graceful fallback)
- `mcp search` empty results — an empty result set is not an error

## Tests

Updated `tests/test_util_cli_mcp.py`, which previously asserted `exit_code == 0` for these error conditions and thus codified the footgun. All 28 tests pass; the two legitimate exit-0 cases are kept and asserted as such.

Found via a dogfooding sweep of `gptme-util` error-handling consistency (follow-up to #2484).