### PR TITLE
feat(webui): opt into Chrome LNA for local-server fetches (targetAddressSpace)

### DIFF
--- a/webui/src/components/__tests__/SetupWizard.test.tsx
+++ b/webui/src/components/__tests__/SetupWizard.test.tsx
@@ -251,6 +251,7 @@ describe('SetupWizard', () => {
     await waitFor(() => {
       expect(mockFetch).toHaveBeenCalledWith('http://127.0.0.1:5700/api/v2', {
         headers: {},
+        targetAddressSpace: 'local',
       });
     });
 

--- a/webui/src/utils/__tests__/addressSpace.test.ts
+++ b/webui/src/utils/__tests__/addressSpace.test.ts
@@ -1,0 +1,72 @@
+import { isLocalUrl, withLocalAddressSpace } from '../addressSpace';
+
+describe('isLocalUrl', () => {
+  it.each([
+    'http://localhost:5700',
+    'http://127.0.0.1:5700',
+    'http://10.0.0.5:5700',
+    'http://192.168.1.100:5700',
+    'http://172.16.0.1:5700',
+    'http://172.31.255.255:5700',
+  ])('returns true for local/private address %s', (url) => {
+    expect(isLocalUrl(url)).toBe(true);
+  });
+
+  it.each([
+    'https://gptme.ai',
+    'https://chat.gptme.org',
+    'https://api.example.com:8080',
+    'http://172.15.0.1:5700', // 172.15 is public (outside 172.16-31)
+    'http://172.32.0.1:5700', // 172.32 is public
+  ])('returns false for remote/public address %s', (url) => {
+    expect(isLocalUrl(url)).toBe(false);
+  });
+
+  it('returns false for an invalid URL', () => {
+    expect(isLocalUrl('not-a-url')).toBe(false);
+  });
+});
+
+describe('withLocalAddressSpace', () => {
+  it("adds targetAddressSpace:'local' for a local URL", () => {
+    const init = withLocalAddressSpace('http://127.0.0.1:5700', { method: 'GET' });
+    expect((init as RequestInit & { targetAddressSpace?: string }).targetAddressSpace).toBe(
+      'local'
+    );
+    expect(init.method).toBe('GET');
+  });
+
+  it('does NOT add targetAddressSpace for a remote URL', () => {
+    const init = withLocalAddressSpace('https://gptme.ai', { method: 'POST' });
+    expect(
+      (init as RequestInit & { targetAddressSpace?: string }).targetAddressSpace
+    ).toBeUndefined();
+    expect(init.method).toBe('POST');
+  });
+
+  it('preserves existing init fields (headers, signal)', () => {
+    const controller = new AbortController();
+    const headers = { Authorization: 'Bearer x' };
+    const init = withLocalAddressSpace('http://localhost:5700', {
+      headers,
+      signal: controller.signal,
+    });
+    expect(init.headers).toEqual(headers);
+    expect(init.signal).toBe(controller.signal);
+  });
+
+  it('does not mutate the input init object', () => {
+    const original: RequestInit = { method: 'GET' };
+    withLocalAddressSpace('http://localhost:5700', original);
+    expect(
+      (original as RequestInit & { targetAddressSpace?: string }).targetAddressSpace
+    ).toBeUndefined();
+  });
+
+  it('defaults to an empty init when none is provided', () => {
+    const init = withLocalAddressSpace('http://localhost:5700');
+    expect((init as RequestInit & { targetAddressSpace?: string }).targetAddressSpace).toBe(
+      'local'
+    );
+  });
+});

--- a/webui/src/utils/addressSpace.ts
+++ b/webui/src/utils/addressSpace.ts
@@ -1,0 +1,36 @@
+// Helpers for scoping browser fetch behavior to local-network servers.
+//
+// Kept dependency-free (no `import.meta`, no stores) so it can be unit-tested
+// in isolation — unlike connectionConfig.ts, which jest cannot import.
+
+// Matches loopback and RFC1918 private (local-network) hostnames.
+const PRIVATE_ADDRESS_PATTERN = /^(localhost|127\.|10\.|192\.168\.|172\.(1[6-9]|2[0-9]|3[01])\.)/i;
+
+/**
+ * True when the URL targets a loopback/private (local-network) address.
+ * Used to scope browser behaviors (e.g. Chrome LNA opt-in) to local servers
+ * only, so connections to remote/cloud servers (gptme.ai) are unaffected.
+ */
+export function isLocalUrl(url: string): boolean {
+  try {
+    return PRIVATE_ADDRESS_PATTERN.test(new URL(url).hostname);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Chrome 142+ Local Network Access (LNA) blocks requests from a public origin
+ * (e.g. https://chat.gptme.org) to a loopback/local address *before* CORS is
+ * evaluated, unless the request opts in via `targetAddressSpace: 'local'`.
+ *
+ * This RequestInit field is not yet in the TS DOM lib types, so it is attached
+ * via a cast. It is applied only when the target URL is local, so requests to
+ * remote/cloud servers keep the default address-space behavior.
+ *
+ * See https://developer.chrome.com/blog/local-network-access
+ */
+export function withLocalAddressSpace(url: string, init: RequestInit = {}): RequestInit {
+  if (!isLocalUrl(url)) return init;
+  return { ...init, targetAddressSpace: 'local' } as RequestInit;
+}

--- a/webui/src/utils/api.ts
+++ b/webui/src/utils/api.ts
@@ -12,7 +12,7 @@ import type {
 } from '@/types/api';
 import type { ConversationSummary, Message, ToolUse } from '@/types/conversation';
 import { getApiBaseUrl } from '@/utils/connectionConfig';
-import { withLocalAddressSpace } from '@/utils/addressSpace';
+import { isLocalUrl, withLocalAddressSpace } from '@/utils/addressSpace';
 import { type Observable } from '@legendapp/state';
 import { observable } from '@legendapp/state';
 import { initConversation } from '@/stores/conversations';
@@ -157,12 +157,8 @@ function normalizeApiError(
  */
 export function isLikelyChromeCorsPna(targetUrl: string): boolean {
   try {
-    const target = new URL(targetUrl);
-    const privatePattern = /^(localhost|127\.|10\.|192\.168\.|172\.(1[6-9]|2[0-9]|3[01])\.)/i;
-    const isTargetPrivate = privatePattern.test(target.hostname);
-    const isPublicOrigin =
-      typeof window !== 'undefined' && !privatePattern.test(window.location.hostname);
-    return isTargetPrivate && isPublicOrigin;
+    const isPublicOrigin = typeof window !== 'undefined' && !isLocalUrl(window.location.href);
+    return isLocalUrl(targetUrl) && isPublicOrigin;
   } catch {
     return false;
   }

--- a/webui/src/utils/api.ts
+++ b/webui/src/utils/api.ts
@@ -12,6 +12,7 @@ import type {
 } from '@/types/api';
 import type { ConversationSummary, Message, ToolUse } from '@/types/conversation';
 import { getApiBaseUrl } from '@/utils/connectionConfig';
+import { withLocalAddressSpace } from '@/utils/addressSpace';
 import { type Observable } from '@legendapp/state';
 import { observable } from '@legendapp/state';
 import { initConversation } from '@/stores/conversations';
@@ -264,11 +265,15 @@ export class ApiClient {
     if (this.authCookieSet || !this.authHeader) return;
 
     try {
-      const response = await fetch(`${this.baseUrl}/api/v2/auth/cookie`, {
-        method: 'POST',
-        headers: { Authorization: this.authHeader },
-        credentials: 'include',
-      });
+      const cookieUrl = `${this.baseUrl}/api/v2/auth/cookie`;
+      const response = await fetch(
+        cookieUrl,
+        withLocalAddressSpace(cookieUrl, {
+          method: 'POST',
+          headers: { Authorization: this.authHeader },
+          credentials: 'include',
+        })
+      );
       if (response.ok) {
         this.authCookieSet = true;
         this.authCookieSetAt = Date.now();
@@ -311,11 +316,14 @@ export class ApiClient {
       }
 
       try {
-        const response = await fetch(url, {
-          ...options,
-          headers,
-          signal: controller.signal,
-        });
+        const response = await fetch(
+          url,
+          withLocalAddressSpace(url, {
+            ...options,
+            headers,
+            signal: controller.signal,
+          })
+        );
         console.log('[ApiClient] Fetch completed, clearing timeout');
         clearTimeout(timeoutId);
         return response;
@@ -367,10 +375,13 @@ export class ApiClient {
       (headers as Record<string, string>)['Authorization'] = this.authHeader;
     }
 
-    const response = await fetch(url, {
-      ...options,
-      headers,
-    });
+    const response = await fetch(
+      url,
+      withLocalAddressSpace(url, {
+        ...options,
+        headers,
+      })
+    );
 
     const data = await response.json();
 
@@ -1100,9 +1111,10 @@ export class ApiClient {
     }
     // Note: do NOT set Content-Type — browser sets it with boundary for multipart
 
+    const uploadUrl = `${this.baseUrl}/api/v2/conversations/${conversationId}/workspace/upload`;
     const response = await fetch(
-      `${this.baseUrl}/api/v2/conversations/${conversationId}/workspace/upload`,
-      { method: 'POST', headers, body: formData }
+      uploadUrl,
+      withLocalAddressSpace(uploadUrl, { method: 'POST', headers, body: formData })
     );
 
     const data = await response.json();

--- a/webui/src/utils/api.ts
+++ b/webui/src/utils/api.ts
@@ -157,7 +157,8 @@ function normalizeApiError(
  */
 export function isLikelyChromeCorsPna(targetUrl: string): boolean {
   try {
-    const isPublicOrigin = typeof window !== 'undefined' && !isLocalUrl(window.location.href);
+    const hostname = typeof window !== 'undefined' ? window.location.hostname : '';
+    const isPublicOrigin = !isLocalUrl(`http://${hostname}`);
     return isLocalUrl(targetUrl) && isPublicOrigin;
   } catch {
     return false;

--- a/webui/src/utils/providerStatus.ts
+++ b/webui/src/utils/providerStatus.ts
@@ -1,10 +1,13 @@
+import { withLocalAddressSpace } from '@/utils/addressSpace';
+
 export async function fetchProviderConfigured(
   baseUrl: string,
   authHeader: string | null,
   signal?: AbortSignal
 ): Promise<boolean> {
   const headers: Record<string, string> = authHeader ? { Authorization: authHeader } : {};
-  const response = await fetch(`${baseUrl}/api/v2`, { headers, signal });
+  const url = `${baseUrl}/api/v2`;
+  const response = await fetch(url, withLocalAddressSpace(url, { headers, signal }));
   if (!response.ok) {
     throw new Error(`Failed to verify provider status (${response.status})`);
   }

--- a/webui/src/utils/taskApi.ts
+++ b/webui/src/utils/taskApi.ts
@@ -1,8 +1,11 @@
 import type { Task, CreateTaskRequest, TaskAction } from '@/types/task';
 import { getApiBaseUrl, getAuthHeader } from '@/utils/connectionConfig';
+import { withLocalAddressSpace } from '@/utils/addressSpace';
 
 /**
- * Helper function to add auth headers to fetch options
+ * Helper function to add auth headers to fetch options.
+ * Also opts into Chrome LNA (`targetAddressSpace: 'local'`) when the active
+ * server is a local address, so a hosted page can reach a loopback gptme-server.
  */
 const getFetchOptions = (options: RequestInit = {}): RequestInit => {
   const authHeader = getAuthHeader();
@@ -14,10 +17,10 @@ const getFetchOptions = (options: RequestInit = {}): RequestInit => {
     (headers as Record<string, string>)['Authorization'] = authHeader;
   }
 
-  return {
+  return withLocalAddressSpace(getApiBaseUrl(), {
     ...options,
     headers,
-  };
+  });
 };
 
 /**


### PR DESCRIPTION
## Summary

Follow-up to #2483 (docs/banner guidance). This is the deeper **site-side code mitigation** for Chrome 142+ Local Network Access (LNA).

Chrome 142+ LNA blocks requests from a hosted page origin (e.g. `https://chat.gptme.org`) to a loopback/local `gptme-server` *before* CORS is evaluated. The documented browser opt-in is annotating the request:

```ts
fetch(url, { targetAddressSpace: 'local' })
```

## What changed

- New dependency-free helper `webui/src/utils/addressSpace.ts`:
  - `isLocalUrl(url)` — loopback / RFC1918 detection
  - `withLocalAddressSpace(url, init)` — adds `targetAddressSpace: 'local'` **only** when the target URL is local, so connections to remote/cloud servers (gptme.ai managed server) are unaffected.
- Applied at the webui fetch sites:
  - `providerStatus.ts` — the `/api/v2` connection probe (fires first)
  - `api.ts` — central `ApiClient` fetch paths (`fetchWithTimeout`, `fetchJson`), auth-cookie, workspace upload
  - `taskApi.ts` — centralized via `getFetchOptions()`

The field is not yet in the TS DOM lib types, so it is attached via a `RequestInit` cast (isolated inside the helper).

## Why a separate, dependency-free module

`connectionConfig.ts` uses `import.meta.env`, which jest cannot import (every test mocks it). Putting the pure helpers in `addressSpace.ts` keeps the local-only conditional **directly unit-testable**.

## Tests

- New `addressSpace.test.ts` — covers the local-only conditional, init-field preservation, no-mutation, and edge cases (invalid URL, 172.16–31 boundary).
- `tsc --noEmit` clean; existing `api.test.ts` / `ApiContext.test.tsx` still pass.

## Verification gap (honest)

This **cannot be E2E-verified headless** — headless Chromium auto-denies LNA regardless of the annotation. It needs a real Chrome 142+ with a localhost `gptme-server` and a user granting/denying the prompt. The unit tests verify the conditional logic (the part that could regress silently); the annotation itself follows the documented Chrome API.

Ref: https://developer.chrome.com/blog/local-network-access