### PR TITLE
fix(cli): tokens count treats '-' as stdin (Unix convention)

### DIFF
--- a/gptme/cli/util.py
+++ b/gptme/cli/util.py
@@ -257,7 +257,7 @@ def tokens_count(text: str | None, model: str, file: str | None):
     if file:
         with open(file) as f:
             text = f.read()
-    elif not text and not sys.stdin.isatty():
+    elif text == "-" or (not text and not sys.stdin.isatty()):
         text = sys.stdin.read()
 
     if not text:

--- a/tests/test_util_cli.py
+++ b/tests/test_util_cli.py
@@ -47,7 +47,7 @@ def test_tokens_count(tmp_path):
     assert result.exit_code == 0
     assert "Token count" in result.output
     # Should count actual tokens, not 1 (the dash character)
-    count = int(result.output.split(": ")[1].strip())
+    count = int(result.output.split(": ", 1)[1].strip())
     assert count > 1
 
 

--- a/tests/test_util_cli.py
+++ b/tests/test_util_cli.py
@@ -42,6 +42,14 @@ def test_tokens_count(tmp_path):
     assert result.exit_code != 0
     assert "No text provided" in result.output
 
+    # Test stdin via "-" argument (Unix convention: "-" means read from stdin)
+    result = runner.invoke(main, ["tokens", "count", "-"], input="Hello, world!")
+    assert result.exit_code == 0
+    assert "Token count" in result.output
+    # Should count actual tokens, not 1 (the dash character)
+    count = int(result.output.split(": ")[1].strip())
+    assert count > 1
+
 
 def test_chats_list(tmp_path, mocker):
     """Test the chats list command."""


### PR DESCRIPTION
## Summary

- `gptme-util tokens count -` was treating `-` as the literal string "-" (1 token), silently ignoring stdin
- This breaks the standard Unix convention where `-` means "read from stdin"
- Fix: treat `text == "-"` the same as implicit stdin detection

## Reproduction

```bash
# Before fix: returns 1 (counting the dash character, not the piped text)
$ echo "The quick brown fox jumps over the lazy dog" | gptme-util tokens count -
Token count (gpt-4): 1

# After fix: returns the correct token count
$ echo "The quick brown fox jumps over the lazy dog" | gptme-util tokens count -
Token count (gpt-4): 9
```

Note: stdin piping without `-` already worked correctly (implicit tty check). This PR adds the explicit `-` alias for stdin, which is the expected behavior for Unix CLI tools.

## Test plan

- [x] Added test case `test_tokens_count` covering `-` stdin input
- [x] Verified test passes locally
- [x] Pre-commit hooks pass