### PR TITLE
feat(webui): surface gptme.ai as cloud alternative in disconnected banner

### DIFF
--- a/webui/src/components/WelcomeView.tsx
+++ b/webui/src/components/WelcomeView.tsx
@@ -273,6 +273,24 @@ export const WelcomeView = () => {
                       Server settings
                     </Button>
                   </div>
+                  {isDefaultLocalServer && (
+                    <p className="text-sm text-muted-foreground">
+                      Prefer not to run a local server?{' '}
+                      <Button
+                        type="button"
+                        variant="link"
+                        size="sm"
+                        className="h-auto p-0 text-sm"
+                        onClick={() => {
+                          setupWizard$.step.set('cloud');
+                          setupWizard$.open.set(true);
+                        }}
+                      >
+                        Use gptme.ai
+                      </Button>{' '}
+                      for a managed option — no install required.
+                    </p>
+                  )}
                   <p className="text-xs text-muted-foreground">
                     Need help connecting?{' '}
                     <a

--- a/webui/src/components/__tests__/WelcomeView.test.tsx
+++ b/webui/src/components/__tests__/WelcomeView.test.tsx
@@ -118,11 +118,29 @@ describe('WelcomeView', () => {
     expect(screen.getByRole('button', { name: /retry connection/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /copy start command/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /server settings/i })).toBeInTheDocument();
+    // Cloud alternative completes the two-path onboarding story (#2485)
+    expect(screen.getByRole('button', { name: /use gptme\.ai/i })).toBeInTheDocument();
     // Setup-guide link points at the canonical server/CORS docs (#2479, #2478)
     expect(screen.getByRole('link', { name: /server setup guide/i })).toHaveAttribute(
       'href',
       'https://gptme.org/docs/server.html'
     );
+  });
+
+  it('opens the setup wizard at the cloud step from the disconnected banner', async () => {
+    isConnected$.set(false);
+
+    render(
+      <SettingsProvider>
+        <WelcomeView />
+      </SettingsProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /use gptme\.ai/i }));
+
+    await waitFor(() => {
+      expect(setupWizard$.get()).toMatchObject({ open: true, step: 'cloud' });
+    });
   });
 
   it('shows docs link (but not install step) when a non-default server is disconnected', () => {
@@ -141,6 +159,8 @@ describe('WelcomeView', () => {
     // Install step is only for new users on the default local server
     expect(screen.queryByText("pipx install 'gptme[server]'")).not.toBeInTheDocument();
     expect(screen.queryByText(/New to gptme\?/i)).not.toBeInTheDocument();
+    // Cloud CTA is local-server-only; a custom server user already chose their path
+    expect(screen.queryByRole('button', { name: /use gptme\.ai/i })).not.toBeInTheDocument();
     // Docs link is always shown for any disconnected state (CORS/auth help applies too)
     expect(screen.getByRole('link', { name: /server setup guide/i })).toHaveAttribute(
       'href',


### PR DESCRIPTION
## Problem

When `chat.gptme.org` cannot reach a local server, the disconnected banner only guides users through local server setup (install gptme, run `gptme-server`). A first-time user who doesn't want to install and run a local server has no obvious path forward.

## Change

Add a secondary call-to-action below the local-setup buttons that launches the existing `SetupWizard` at the **cloud** step:

> Prefer not to run a local server? **Use gptme.ai** for a managed option — no install required.

Design choices:
- **Local-server-only**: gated on `isDefaultLocalServer`, so users who already configured a custom server (and just hit a connection blip) don't see it.
- **Visually secondary**: rendered as a link-style button, not competing with the primary local-setup path.
- **Reuses the cloud onboarding flow**: opens `setupWizard$` at the `cloud` step (same pattern as the existing provider-required banner) rather than a raw external link, so users land in the in-app managed sign-in.

This completes the two-path onboarding story started by the install-step + setup-guide link (#2481).

## Testing

- Added a test asserting the CTA appears in the disconnected banner and clicking it opens the wizard at the `cloud` step.
- Extended the non-default-server test to assert the CTA is hidden there.
- `npx jest WelcomeView` → 7/7 pass; `eslint`, `prettier --check`, and `tsc -p tsconfig.app.json --noEmit` all clean.

Closes #2485
Related: ErikBjare/bob#745 (durable work-supply via dogfooding gptme.ai)