### PR TITLE
fix(chats): avoid scanning test logs for user stats

### DIFF
--- a/gptme/config/chat.py
+++ b/gptme/config/chat.py
@@ -19,7 +19,7 @@ from typing_extensions import Self
 if sys.version_info >= (3, 11):
     import tomllib
 
-    _CHAT_CONFIG_LOAD_ERRORS = (OSError, TOMLKitError, tomllib.TOMLDecodeError)
+    _CHAT_CONFIG_LOAD_ERRORS = (OSError, tomllib.TOMLDecodeError)
 else:
     tomllib = None
 

--- a/gptme/config/chat.py
+++ b/gptme/config/chat.py
@@ -6,6 +6,7 @@ tool configuration, workspace paths, and agent settings.
 
 import logging
 import os
+import sys
 import tempfile
 from dataclasses import asdict, dataclass, field, replace
 from pathlib import Path
@@ -14,6 +15,15 @@ from typing import TYPE_CHECKING
 import tomlkit
 from tomlkit.exceptions import TOMLKitError
 from typing_extensions import Self
+
+if sys.version_info >= (3, 11):
+    import tomllib
+
+    _CHAT_CONFIG_LOAD_ERRORS = (OSError, TOMLKitError, tomllib.TOMLDecodeError)
+else:
+    tomllib = None
+
+    _CHAT_CONFIG_LOAD_ERRORS = (OSError, TOMLKitError)
 
 from ..util import path_with_tilde
 from .models import AgentConfig, MCPConfig
@@ -116,11 +126,15 @@ class ChatConfig:
             workspace.mkdir(parents=True, exist_ok=True)
             return cls(_logdir=path, workspace=workspace.resolve())
         try:
-            with open(chat_config_path) as f:
-                config_data = tomlkit.load(f).unwrap()
+            if tomllib is not None:
+                with open(chat_config_path, "rb") as f:
+                    config_data = tomllib.load(f)
+            else:
+                with open(chat_config_path) as f:
+                    config_data = tomlkit.load(f).unwrap()
             config_data["_logdir"] = path
             return cls.from_dict(config_data)
-        except (OSError, TOMLKitError) as e:
+        except _CHAT_CONFIG_LOAD_ERRORS as e:
             logger.warning(f"Failed to load chat config from {chat_config_path}: {e}")
             return cls()
 

--- a/gptme/logmanager/conversations.py
+++ b/gptme/logmanager/conversations.py
@@ -219,15 +219,16 @@ def _full_scan(
 def get_conversations(
     *, detail: bool = True, include_test: bool = True
 ) -> Generator[ConversationMeta, None, None]:
-    """Returns all conversations, excluding ones used for testing, evals, etc.
+    """Returns all conversations.
 
     Args:
         detail: If True (default), performs a full JSONL scan to compute exact
             costs, token counts, and model info. If False, reads only the tail
             of each file for a faster scan — suitable for list/search endpoints
             where cost/token aggregates are not displayed.
-        include_test: If False, skip test/eval conversations before scanning any
-            files or loading per-conversation config.
+        include_test: If True (default), includes test/eval conversations.
+            If False, skips them before scanning any files or loading
+            per-conversation config.
     """
     for conv_fn in _conversation_files():
         conv_id = conv_fn.parent.name

--- a/gptme/logmanager/conversations.py
+++ b/gptme/logmanager/conversations.py
@@ -32,6 +32,11 @@ def _conversation_files() -> list[Path]:
     )
 
 
+def _is_test_conversation_id(conv_id: str) -> bool:
+    """Return True when a conversation ID belongs to test/eval output."""
+    return conv_id.startswith(("tmp", "test-")) or "gptme-evals-" in conv_id
+
+
 @dataclass(frozen=True)
 class ConversationMeta:
     """Metadata about a conversation."""
@@ -212,7 +217,7 @@ def _full_scan(
 
 
 def get_conversations(
-    *, detail: bool = True
+    *, detail: bool = True, include_test: bool = True
 ) -> Generator[ConversationMeta, None, None]:
     """Returns all conversations, excluding ones used for testing, evals, etc.
 
@@ -221,8 +226,14 @@ def get_conversations(
             costs, token counts, and model info. If False, reads only the tail
             of each file for a faster scan — suitable for list/search endpoints
             where cost/token aggregates are not displayed.
+        include_test: If False, skip test/eval conversations before scanning any
+            files or loading per-conversation config.
     """
     for conv_fn in _conversation_files():
+        conv_id = conv_fn.parent.name
+        if not include_test and _is_test_conversation_id(conv_id):
+            continue
+
         log = Log.read_jsonl(conv_fn, limit=1)
 
         file_size = conv_fn.stat().st_size
@@ -254,7 +265,6 @@ def get_conversations(
         modified = conv_fn.stat().st_mtime
         first_timestamp = log[0].timestamp.timestamp() if log else modified
         # Try to get display name from ChatConfig, fallback to folder name
-        conv_id = conv_fn.parent.name
         chat_config = ChatConfig.from_logdir(conv_fn.parent)
         display_name = chat_config.name or conv_id
 
@@ -305,12 +315,7 @@ def get_user_conversations(
     *, detail: bool = True
 ) -> Generator[ConversationMeta, None, None]:
     """Returns all user conversations, excluding ones used for testing, evals, etc."""
-    for conv in get_conversations(detail=detail):
-        if any(conv.id.startswith(prefix) for prefix in ["tmp", "test-"]) or any(
-            substr in conv.id for substr in ["gptme-evals-"]
-        ):
-            continue
-        yield conv
+    yield from get_conversations(detail=detail, include_test=False)
 
 
 def list_conversations(
@@ -328,11 +333,7 @@ def list_conversations(
         detail: If True, performs full JSONL scan for costs/tokens.
             If False, uses fast tail-only scan.
     """
-    conversation_iter = (
-        get_conversations(detail=detail)
-        if include_test
-        else get_user_conversations(detail=detail)
-    )
+    conversation_iter = get_conversations(detail=detail, include_test=include_test)
     return list(islice(conversation_iter, limit))
 
 

--- a/tests/test_conversations.py
+++ b/tests/test_conversations.py
@@ -5,7 +5,12 @@ from pathlib import Path
 
 import pytest
 
-from gptme.logmanager.conversations import ConversationMeta, get_conversations
+import gptme.logmanager.conversations as conversations_mod
+from gptme.logmanager.conversations import (
+    ConversationMeta,
+    get_conversations,
+    get_user_conversations,
+)
 
 
 def _make_conversation(
@@ -293,3 +298,44 @@ def test_detail_false_multi_model_consistency(logs_dir):
     assert full[0].model == "model-late"
     assert fast[0].model == "model-late"
     assert fast[0].model == full[0].model
+
+
+def test_get_user_conversations_skips_test_logs_before_scanning(logs_dir, monkeypatch):
+    """User conversation listing must not scan test/eval logs at all."""
+    _make_conversation(
+        logs_dir,
+        "real-conversation",
+        [
+            {
+                "role": "user",
+                "content": "hello",
+                "timestamp": "2025-01-01T00:00:00Z",
+            },
+        ],
+    )
+    _make_conversation(
+        logs_dir,
+        "test-fixture-conversation",
+        [
+            {
+                "role": "user",
+                "content": "should be skipped",
+                "timestamp": "2025-01-01T00:00:00Z",
+            },
+        ],
+    )
+
+    scanned: list[str] = []
+    original_full_scan = conversations_mod._full_scan
+
+    def wrapped_full_scan(conv_fn: Path):
+        scanned.append(conv_fn.parent.name)
+        if conv_fn.parent.name.startswith("test-"):
+            raise AssertionError("test conversation was scanned on user path")
+        return original_full_scan(conv_fn)
+
+    monkeypatch.setattr("gptme.logmanager.conversations._full_scan", wrapped_full_scan)
+
+    convs = list(get_user_conversations())
+    assert [conv.id for conv in convs] == ["real-conversation"]
+    assert scanned == ["real-conversation"]

--- a/tests/test_util_cli.py
+++ b/tests/test_util_cli.py
@@ -51,13 +51,10 @@ def test_chats_list(tmp_path, mocker):
     logs_dir = tmp_path / "logs"
     logs_dir.mkdir()
 
-    # Mock both the logs directory and the conversation listing
-    mocker.patch("gptme.dirs.get_logs_dir", return_value=str(logs_dir))
-    mocker.patch(
-        "gptme.logmanager.conversations.get_user_conversations", return_value=[]
-    )
+    # Mock list_conversations at the package level (picked up by lazy imports in tools/chats.py)
+    mocker.patch("gptme.logmanager.list_conversations", return_value=[])
 
-    # Test empty list (should work now since we're using our empty logs_dir)
+    # Test empty list
     result = runner.invoke(main, ["chats", "list"])
     assert result.exit_code == 0
     assert "No conversations found" in result.output
@@ -100,10 +97,7 @@ def test_chats_list(tmp_path, mocker):
     )
 
     # Update the mock to return our test conversations
-    mocker.patch(
-        "gptme.logmanager.conversations.get_user_conversations",
-        return_value=[conv1, conv2],
-    )
+    mocker.patch("gptme.logmanager.list_conversations", return_value=[conv1, conv2])
 
     # Test with conversations
     result = runner.invoke(main, ["chats", "list"])


### PR DESCRIPTION
## Summary
- skip test/eval conversation directories before any JSONL scan or config load on the user conversation path
- use `tomllib` for `ChatConfig.from_logdir()` reads on Python 3.11+ and keep the existing `tomlkit` fallback on older runtimes
- add a regression test proving `get_user_conversations()` never scans `test-*` logs

## Dogfood repro
While sweeping the non-LLM CLI surface on Bob's container, `gptme-util chats stats --json` was painfully slow on a real log corpus.

Before this change:
- `conversation_stats(since=None, as_json=True)` profiled at about 25.6s on Bob's logs
- the user path scanned about 4,437 conversation dirs to return about 1,856 user conversations because test/eval filtering happened after the expensive scan

After this change:
- `uv run gptme-util chats stats --json` completes successfully on the same corpus within the 25s timeout window
- full user-conversation detail scan dropped to about 8.2s in the local measurement

## Verification
- `uv run pytest tests/test_chat_config.py tests/test_chats_stats.py tests/test_conversations.py -q`
- `timeout 25s uv run gptme-util chats stats --json >/tmp/gptme-chats-stats-full.json`
