### PR TITLE
fix(cli): make non-default tools callable via gptme-util tools call

### DIFF
--- a/gptme/cli/util.py
+++ b/gptme/cli/util.py
@@ -535,11 +535,18 @@ def tools_call(tool_name: str, function_name: str, arg: list[str]):
     # Load the requested tool even if it is not part of the default toolchain.
     # Some tools (e.g. computer, rag, subagent) expose callable functions but
     # are not loaded by default, so a bare init_tools() would leave them
-    # uncallable. Fall back to a default init for unknown names so the
-    # not-found branch can still list the full set of available tools.
-    try:
+    # uncallable. init_tools raises ValueError for two distinct reasons:
+    #   (1) tool name is genuinely unknown — safe to fall back to default init
+    #       so the not-found branch can enumerate the full tool list.
+    #   (2) tool matched get_available_tools() but was inexplicably absent from
+    #       loaded_tools after init — internal consistency failure, must not be
+    #       swallowed.
+    # Pre-flighting against get_available_tools() separates the two cases
+    # without needing to parse error message text.
+    available_names = {t.name for t in get_available_tools()}
+    if tool_name in available_names:
         init_tools(allowlist=[tool_name])
-    except ValueError:
+    else:
         init_tools()
 
     tool = get_tool(tool_name)

--- a/gptme/cli/util.py
+++ b/gptme/cli/util.py
@@ -542,8 +542,11 @@ def tools_call(tool_name: str, function_name: str, arg: list[str]):
     #       loaded_tools after init — internal consistency failure, must not be
     #       swallowed.
     # Pre-flighting against get_available_tools() separates the two cases
-    # without needing to parse error message text.
-    available_names = {t.name for t in get_available_tools()}
+    # without needing to parse error message text. Only route to targeted init
+    # when the tool is available (has its runtime deps installed); tools that
+    # are discovered but unavailable (is_available=False) fall through to the
+    # default init so get_toolchain's strict-mode dep check is never hit.
+    available_names = {t.name for t in get_available_tools() if t.is_available}
     if tool_name in available_names:
         init_tools(allowlist=[tool_name])
     else:

--- a/gptme/cli/util.py
+++ b/gptme/cli/util.py
@@ -530,15 +530,22 @@ def tools_info(
 )
 def tools_call(tool_name: str, function_name: str, arg: list[str]):
     """Call a tool with the given arguments."""
-    from ..tools import get_tool, get_tools, init_tools  # fmt: skip
+    from ..tools import get_available_tools, get_tool, init_tools  # fmt: skip
 
-    # Initialize tools
-    init_tools()
+    # Load the requested tool even if it is not part of the default toolchain.
+    # Some tools (e.g. computer, rag, subagent) expose callable functions but
+    # are not loaded by default, so a bare init_tools() would leave them
+    # uncallable. Fall back to a default init for unknown names so the
+    # not-found branch can still list the full set of available tools.
+    try:
+        init_tools(allowlist=[tool_name])
+    except ValueError:
+        init_tools()
 
     tool = get_tool(tool_name)
     if not tool:
         print(f"Tool '{tool_name}' not found. Available tools:")
-        for t in get_tools():
+        for t in sorted(get_available_tools(), key=lambda t: t.name):
             print(f"- {t.name}")
         sys.exit(1)
 

--- a/tests/test_util_cli.py
+++ b/tests/test_util_cli.py
@@ -271,6 +271,37 @@ def test_tools_info():
     assert isinstance(data["is_mcp"], bool)
 
 
+def test_tools_call_non_default_tool():
+    """Non-default tools that expose functions must be callable.
+
+    Tools like ``subagent`` are not loaded by default, but they expose
+    callable functions and ``tools call`` should still reach them instead of
+    reporting the tool as missing. Regression test for the bare ``init_tools()``
+    that left non-default tools uncallable.
+    """
+    runner = CliRunner()
+
+    # subagent is not in the default toolchain but exposes functions.
+    # Calling without the required arg should reach the function (and fail on
+    # the missing argument), NOT report the tool as not found.
+    result = runner.invoke(main, ["tools", "call", "subagent", "subagent_status"])
+    assert result.exit_code != 0
+    assert "Tool 'subagent' not found" not in result.output
+    assert "Error calling function" in result.output
+
+    # Unknown function on a loaded non-default tool lists its functions.
+    result = runner.invoke(main, ["tools", "call", "subagent", "nosuchfn"])
+    assert result.exit_code != 0
+    assert "not found in tool 'subagent'" in result.output
+    assert "Available functions" in result.output
+
+    # Genuinely unknown tool still errors and lists available tools.
+    result = runner.invoke(main, ["tools", "call", "definitely-not-a-tool", "fn"])
+    assert result.exit_code != 0
+    assert "not found" in result.output
+    assert "Available tools" in result.output
+
+
 def test_models_list():
     """Test the models list command."""
     import json


### PR DESCRIPTION
## Problem

`gptme-util tools call <tool> <function>` initialized tools with a bare `init_tools()`, which only loads the **default** toolchain. Tools that expose callable functions but are not loaded by default — `computer`, `rag`, `subagent` — were therefore completely uncallable, and the error was misleading:

```
$ gptme-util tools call subagent subagent_status
Tool 'subagent' not found. Available tools:
- append
- autocommit
...
```

`subagent` **is** a valid tool — it shows up in `tools list` (marked `[+]` = not loaded by default) and works fine with `tools info subagent`. Only `tools call` failed, because it never loaded non-default tools. That makes ~1/3 of the tools that actually expose callable functions unreachable through this command.

## Fix

Load the requested tool explicitly via `init_tools(allowlist=[tool_name])` (falling back to a default init for unknown names so the not-found branch can still enumerate all tools). This properly runs the tool's init hooks so its functions are callable. This mirrors the loaded-vs-available handling that `tools info` already uses, and the not-found error now lists the full set of available tools rather than only the loaded defaults.

After:

```
$ gptme-util tools call subagent subagent_status -a agent_id=nope
ValueError: Subagent with ID nope not found.   # function actually runs now
$ gptme-util tools call definitely-not-a-tool fn
Tool 'definitely-not-a-tool' not found. Available tools:
- append
...
```

Default tools (e.g. `chats list_chats`) are unaffected.

## Test

Adds `test_tools_call_non_default_tool` covering:
- a non-default tool (`subagent`) is now reached instead of reported missing,
- the function-not-found branch on a loaded non-default tool,
- the genuinely-unknown-tool branch.

Found via CLI dogfooding (ErikBjare/bob#745).