### PR TITLE
feat(webui): launch SetupWizard from disconnected banner on first visit

### DIFF
--- a/webui/e2e/setup-wizard.spec.ts
+++ b/webui/e2e/setup-wizard.spec.ts
@@ -21,7 +21,12 @@ test.describe('Setup wizard', () => {
 
     await expect(page.getByRole('heading', { name: /welcome to gptme/i })).toBeVisible();
 
-    await page.getByRole('button', { name: /get started/i }).click();
+    // Scope to the dialog — the disconnected banner also has a "Get started"
+    // button on first visit, so a global role query would hit two elements.
+    await page
+      .getByRole('dialog')
+      .getByRole('button', { name: /get started/i })
+      .click();
     await expect(page.getByRole('heading', { name: /choose your setup/i })).toBeVisible();
 
     await page.getByRole('button', { name: /cloud\s/i }).click();

--- a/webui/src/components/WelcomeView.tsx
+++ b/webui/src/components/WelcomeView.tsx
@@ -163,6 +163,12 @@ export const WelcomeView = () => {
   }, [api.authHeader, connectionConfig.baseUrl, isConnected, providerStatusVersion]);
 
   const { settings } = useSettings();
+  // First-time users on the default local server (typically chat.gptme.org) get a
+  // guided "Get started" CTA into the setup wizard instead of the raw install/
+  // settings path. Users on a custom server have already chosen their setup, so
+  // their disconnected banner is left unchanged.
+  const isFirstVisit = !settings.hasCompletedSetup;
+  const showGuidedSetup = isDefaultLocalServer && isFirstVisit;
   const bg = settings.welcomeBackground;
   // Determine if the background is an image URL or a CSS gradient/color
   const isImageBg = bg && (bg.startsWith('http') || bg.startsWith('/') || bg.startsWith('data:'));
@@ -219,7 +225,13 @@ export const WelcomeView = () => {
                       <code>--cors-origin</code> flag alone is not enough.
                     </p>
                   )}
-                  {isDefaultLocalServer && (
+                  {showGuidedSetup && (
+                    <p className="text-sm text-muted-foreground">
+                      New to gptme? The setup guide walks you through installing a local server or
+                      using the managed gptme.ai option — no copy-pasting required.
+                    </p>
+                  )}
+                  {isDefaultLocalServer && !isFirstVisit && (
                     <div className="space-y-2">
                       <p className="text-xs text-muted-foreground">
                         New to gptme? Install it, then start a server:
@@ -243,6 +255,18 @@ export const WelcomeView = () => {
                     </div>
                   )}
                   <div className="flex flex-wrap gap-2">
+                    {showGuidedSetup && (
+                      <Button
+                        type="button"
+                        size="sm"
+                        onClick={() => {
+                          setupWizard$.step.set('welcome');
+                          setupWizard$.open.set(true);
+                        }}
+                      >
+                        Get started
+                      </Button>
+                    )}
                     <Button
                       type="button"
                       size="sm"
@@ -253,7 +277,7 @@ export const WelcomeView = () => {
                       <RotateCcw className="mr-2 h-4 w-4" />
                       {isRetryingConnection ? 'Retrying...' : 'Retry connection'}
                     </Button>
-                    {isDefaultLocalServer && (
+                    {isDefaultLocalServer && !isFirstVisit && (
                       <Button
                         type="button"
                         size="sm"
@@ -264,16 +288,18 @@ export const WelcomeView = () => {
                         Copy start command
                       </Button>
                     )}
-                    <Button
-                      type="button"
-                      size="sm"
-                      variant="outline"
-                      onClick={() => settingsModal$.set({ open: true, category: 'servers' })}
-                    >
-                      Server settings
-                    </Button>
+                    {!showGuidedSetup && (
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="outline"
+                        onClick={() => settingsModal$.set({ open: true, category: 'servers' })}
+                      >
+                        Server settings
+                      </Button>
+                    )}
                   </div>
-                  {isDefaultLocalServer && (
+                  {isDefaultLocalServer && !isFirstVisit && (
                     <p className="text-sm text-muted-foreground">
                       Prefer not to run a local server?{' '}
                       <Button

--- a/webui/src/components/__tests__/WelcomeView.test.tsx
+++ b/webui/src/components/__tests__/WelcomeView.test.tsx
@@ -62,7 +62,15 @@ jest.mock('../ExamplesSection', () => ({
 }));
 
 describe('WelcomeView', () => {
+  // Returning users (who have completed the setup wizard) see the efficient
+  // raw install/settings path; first-time users get the guided "Get started" CTA.
+  const seedReturningUser = () => {
+    localStorage.setItem('gptme-settings', JSON.stringify({ hasCompletedSetup: true }));
+  };
+
   beforeEach(() => {
+    // Default to a first-time user (no stored settings → hasCompletedSetup=false).
+    localStorage.clear();
     isConnected$.set(true);
     mockBaseUrl = 'http://localhost:5700';
     setupWizard$.step.set('welcome');
@@ -98,6 +106,7 @@ describe('WelcomeView', () => {
   });
 
   it('shows an actionable disconnected-state banner when no server is connected', () => {
+    seedReturningUser();
     isConnected$.set(false);
 
     render(
@@ -128,6 +137,7 @@ describe('WelcomeView', () => {
   });
 
   it('opens the setup wizard at the cloud step from the disconnected banner', async () => {
+    seedReturningUser();
     isConnected$.set(false);
 
     render(
@@ -140,6 +150,45 @@ describe('WelcomeView', () => {
 
     await waitFor(() => {
       expect(setupWizard$.get()).toMatchObject({ open: true, step: 'cloud' });
+    });
+  });
+
+  it('shows a guided "Get started" CTA for first-time users on the default local server', () => {
+    // No seeded settings → first-time user (hasCompletedSetup=false).
+    isConnected$.set(false);
+
+    render(
+      <SettingsProvider>
+        <WelcomeView />
+      </SettingsProvider>
+    );
+
+    expect(screen.getByText('No gptme server connected')).toBeInTheDocument();
+    // Guided path: a "Get started" CTA and a wizard-oriented intro line
+    expect(screen.getByRole('button', { name: /get started/i })).toBeInTheDocument();
+    expect(screen.getByText(/The setup guide walks you through/i)).toBeInTheDocument();
+    // Returning-user clutter is hidden for first-timers
+    expect(screen.queryByText("pipx install 'gptme[server]'")).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /copy start command/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /server settings/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /use gptme\.ai/i })).not.toBeInTheDocument();
+    // Retry connection stays available regardless of onboarding state
+    expect(screen.getByRole('button', { name: /retry connection/i })).toBeInTheDocument();
+  });
+
+  it('opens the setup wizard at the welcome step from the first-visit "Get started" CTA', async () => {
+    isConnected$.set(false);
+
+    render(
+      <SettingsProvider>
+        <WelcomeView />
+      </SettingsProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /get started/i }));
+
+    await waitFor(() => {
+      expect(setupWizard$.get()).toMatchObject({ open: true, step: 'welcome' });
     });
   });
 


### PR DESCRIPTION
## Summary

First-time users on the default local server (e.g. `chat.gptme.org`) who hit the disconnected banner now get a guided **Get started** CTA that opens the `SetupWizard` at the welcome step, instead of the raw install code blocks + server-settings form.

Returning users (`hasCompletedSetup=true`) keep the efficient existing path: install commands, copy start command, server settings, and the gptme.ai link.

The whole first-visit branch is gated on `isDefaultLocalServer && !hasCompletedSetup` (`showGuidedSetup`), so the **custom-server** disconnected banner is left byte-for-byte unchanged — a user who configured a custom server has already made a setup choice.

This is a natural re-entry point: the wizard auto-opens once on first mount; if the user dismisses it without completing setup, the banner's **Get started** button lets them back into the guided flow.

## First visit (setup not complete)
`[ Get started ] [ Retry connection ]` + a short wizard-oriented intro line. Raw install blocks / copy / server-settings / gptme.ai link are hidden.

## Returning user (setup complete, server unreachable)
`[ Retry connection ] [ Copy start command ] [ Server settings ]` + install instructions + gptme.ai link (unchanged).

## Testing
- `npx jest WelcomeView` → **9/9 pass** (2 new tests: first-visit CTA visibility, and Get started → wizard `welcome` step; existing disconnected-banner tests updated to seed a returning user).
- `eslint`, `prettier --check`, `tsc -p tsconfig.app.json --noEmit` all clean.

Closes #2486