### PR TITLE
fix(cli): warn when 'models info' falls back for an unrecognized provider

### DIFF
--- a/gptme/cli/util.py
+++ b/gptme/cli/util.py
@@ -710,6 +710,25 @@ def models_info(model_name: str, as_json: bool):
         print(f"Error getting model info: {e}")
         sys.exit(1)
 
+    # Warn (on stderr, so it never corrupts stdout/JSON) when the provider
+    # prefix isn't recognized — get_model() returns generic fallback metadata
+    # for unknown providers, so a typo like 'anthropc/...' silently shows fake
+    # values. Mirror the provider check that `models test` performs. Only
+    # applies to fully-qualified 'provider/model' names; bare names and known
+    # custom providers (e.g. lmstudio/...) don't trigger the warning.
+    if "/" in model_name:
+        from ..llm import get_provider_from_model  # fmt: skip
+
+        try:
+            get_provider_from_model(model_name)
+        except Exception:
+            click.echo(
+                f"⚠️  Unrecognized provider in '{model_name}'; showing generic "
+                "fallback metadata. Run 'gptme-util models list --available' "
+                "to see known models.",
+                err=True,
+            )
+
     if as_json:
         print(json.dumps(model_to_dict(model), indent=2))
         return

--- a/gptme/cli/util.py
+++ b/gptme/cli/util.py
@@ -721,7 +721,7 @@ def models_info(model_name: str, as_json: bool):
 
         try:
             get_provider_from_model(model_name)
-        except Exception:
+        except ValueError:
             click.echo(
                 f"⚠️  Unrecognized provider in '{model_name}'; showing generic "
                 "fallback metadata. Run 'gptme-util models list --available' "

--- a/tests/test_util_cli_models.py
+++ b/tests/test_util_cli_models.py
@@ -1,6 +1,8 @@
 """Tests for the models-related gptme-util CLI commands."""
 
 import json
+import subprocess
+import sys
 from unittest.mock import Mock, patch
 
 from click.testing import CliRunner
@@ -172,30 +174,45 @@ class TestModelsInfo:
         assert result.exit_code == 0
         assert "detailed information about a specific model" in result.output
 
+    @staticmethod
+    def _run_models_info(*args: str) -> "subprocess.CompletedProcess[str]":
+        """Invoke 'gptme-util models info' as a subprocess for separate stdout/stderr."""
+        return subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "import sys; sys.argv=['gptme-util'] + sys.argv[1:];"
+                "from gptme.cli.util import main; main()",
+                "models",
+                "info",
+                *args,
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
     def test_known_model_no_warning(self):
         """A recognized provider/model shows info with no fallback warning."""
-        runner = CliRunner()
-        result = runner.invoke(main, ["models", "info", "anthropic/claude-opus-4-7"])
-        assert result.exit_code == 0, result.output
-        assert "Provider: anthropic" in result.output
+        result = self._run_models_info("anthropic/claude-opus-4-7")
+        assert result.returncode == 0, result.stderr
+        assert "Provider: anthropic" in result.stdout
         assert "Unrecognized provider" not in result.stderr
 
     def test_unknown_provider_warns_on_stderr(self):
         """An unrecognized provider prefix still shows fallback metadata, but
         warns on stderr so the user knows the values are generic."""
-        runner = CliRunner()
-        result = runner.invoke(main, ["models", "info", "bogus/model"])
+        result = self._run_models_info("bogus/model")
         # Lenient behaviour preserved: still exits 0 with fallback metadata.
-        assert result.exit_code == 0, result.output
-        assert "Model: bogus/model" in result.output
+        assert result.returncode == 0, result.stderr
+        assert "Model: bogus/model" in result.stdout
         # Warning lands on stderr (so it never corrupts piped stdout).
         assert "Unrecognized provider" in result.stderr
 
     def test_unknown_provider_json_stays_clean(self):
         """With --json, the warning goes to stderr, keeping stdout JSON clean."""
-        runner = CliRunner()
-        result = runner.invoke(main, ["models", "info", "bogus/model", "--json"])
-        assert result.exit_code == 0, result.output
+        result = self._run_models_info("bogus/model", "--json")
+        assert result.returncode == 0, result.stderr
         # Warning is isolated to stderr.
         assert "Unrecognized provider" in result.stderr
         # stdout is valid JSON and contains the expected model field.

--- a/tests/test_util_cli_models.py
+++ b/tests/test_util_cli_models.py
@@ -192,16 +192,12 @@ class TestModelsInfo:
         assert "Unrecognized provider" in result.stderr
 
     def test_unknown_provider_json_stays_clean(self):
-        """With --json, the warning goes to stderr, keeping stdout JSON clean.
-
-        CliRunner combines streams in ``result.output``; the meaningful contract
-        is that the warning is isolated to stderr while the JSON payload is
-        emitted on stdout (verified at the fd level by ``2>/dev/null`` usage).
-        """
+        """With --json, the warning goes to stderr, keeping stdout JSON clean."""
         runner = CliRunner()
         result = runner.invoke(main, ["models", "info", "bogus/model", "--json"])
         assert result.exit_code == 0, result.output
         # Warning is isolated to stderr.
         assert "Unrecognized provider" in result.stderr
-        # JSON payload (on stdout) is present and well-formed for the model.
-        assert '"model": "bogus/model"' in result.output
+        # stdout is valid JSON and contains the expected model field.
+        data = json.loads(result.stdout)
+        assert data["model"] == "bogus/model"

--- a/tests/test_util_cli_models.py
+++ b/tests/test_util_cli_models.py
@@ -161,3 +161,47 @@ class TestModelsTest:
         assert (
             "azure/my-deployment" in result.output or "full model name" in result.output
         )
+
+
+class TestModelsInfo:
+    """Tests for 'models info' command."""
+
+    def test_help(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ["models", "info", "--help"])
+        assert result.exit_code == 0
+        assert "detailed information about a specific model" in result.output
+
+    def test_known_model_no_warning(self):
+        """A recognized provider/model shows info with no fallback warning."""
+        runner = CliRunner()
+        result = runner.invoke(main, ["models", "info", "anthropic/claude-opus-4-7"])
+        assert result.exit_code == 0, result.output
+        assert "Provider: anthropic" in result.output
+        assert "Unrecognized provider" not in result.stderr
+
+    def test_unknown_provider_warns_on_stderr(self):
+        """An unrecognized provider prefix still shows fallback metadata, but
+        warns on stderr so the user knows the values are generic."""
+        runner = CliRunner()
+        result = runner.invoke(main, ["models", "info", "bogus/model"])
+        # Lenient behaviour preserved: still exits 0 with fallback metadata.
+        assert result.exit_code == 0, result.output
+        assert "Model: bogus/model" in result.output
+        # Warning lands on stderr (so it never corrupts piped stdout).
+        assert "Unrecognized provider" in result.stderr
+
+    def test_unknown_provider_json_stays_clean(self):
+        """With --json, the warning goes to stderr, keeping stdout JSON clean.
+
+        CliRunner combines streams in ``result.output``; the meaningful contract
+        is that the warning is isolated to stderr while the JSON payload is
+        emitted on stdout (verified at the fd level by ``2>/dev/null`` usage).
+        """
+        runner = CliRunner()
+        result = runner.invoke(main, ["models", "info", "bogus/model", "--json"])
+        assert result.exit_code == 0, result.output
+        # Warning is isolated to stderr.
+        assert "Unrecognized provider" in result.stderr
+        # JSON payload (on stdout) is present and well-formed for the model.
+        assert '"model": "bogus/model"' in result.output


### PR DESCRIPTION
## Problem

`gptme-util models info <provider>/<model>` resolves an **unknown provider** to generic 128k fallback metadata and exits 0, so a typo'd provider silently shows fabricated values:

```
$ gptme-util models info anthropc/claude-opus-4-7   # note the typo
Model: anthropc/claude-opus-4-7
Provider: unknown
Context window: 128,000 tokens
Streaming: Yes
...
```

The user gets no signal that the provider wasn't recognized. Its sibling command `models test` already rejects unknown providers (`get_provider_from_model()` raises `Unknown provider: ...`), so the two are inconsistent.

## Fix

Emit a **stderr** warning when the provider prefix isn't recognized, while preserving the lenient behaviour:

- Still exits 0 and shows the generic fallback metadata — so custom/plugin providers and forward-compatible model names keep working.
- The warning goes to **stderr**, so piped/`--json` stdout stays clean (verified: `models info bogus/model --json 2>/dev/null` is valid JSON).
- Only applies to fully-qualified `provider/model` names; bare names and known custom providers (e.g. `lmstudio/...`) don't trigger it.

```
$ gptme-util models info bogus/model
⚠️  Unrecognized provider in 'bogus/model'; showing generic fallback metadata. Run 'gptme-util models list --available' to see known models.
Model: bogus/model
...
```

## Tests

Adds `TestModelsInfo` (the command had no coverage before): known provider (no warning), unknown-provider warning on stderr, and JSON-stdout cleanliness. `tests/test_util_cli_models.py` passes (13 passed).

## How this was found

Dogfooding the gptme CLI surface — `models info` vs `models test` behaved inconsistently on an unknown provider.