### PR TITLE
fix(cli): reject negative chats --limit instead of crashing islice()

### DIFF
--- a/gptme/cli/cmd_chats.py
+++ b/gptme/cli/cmd_chats.py
@@ -164,7 +164,13 @@ def chats_search(
 
 @chats.command("read")
 @click.argument("id")
-@click.option("-n", "--limit", default=20, help="Maximum number of messages to show.")
+@click.option(
+    "-n",
+    "--limit",
+    default=20,
+    type=click.IntRange(min=1),
+    help="Maximum number of messages to show.",
+)
 @click.option("--system", is_flag=True, help="Include system messages.")
 @click.option(
     "-c", "--context", default=0, help="Messages of context before start message."

--- a/gptme/cli/cmd_chats.py
+++ b/gptme/cli/cmd_chats.py
@@ -57,7 +57,13 @@ def chats():
 
 
 @chats.command("list")
-@click.option("-n", "--limit", default=20, help="Maximum number of chats to show.")
+@click.option(
+    "-n",
+    "--limit",
+    default=20,
+    type=click.IntRange(min=1),
+    help="Maximum number of chats to show.",
+)
 @click.option(
     "--summarize", is_flag=True, help="Generate LLM-based summaries for chats"
 )
@@ -88,7 +94,13 @@ def chats_list(limit: int, summarize: bool, output_json: bool):
 
 @chats.command("search")
 @click.argument("query")
-@click.option("-n", "--limit", default=20, help="Maximum number of chats to show.")
+@click.option(
+    "-n",
+    "--limit",
+    default=20,
+    type=click.IntRange(min=1),
+    help="Maximum number of chats to show.",
+)
 @click.option(
     "--summarize", is_flag=True, help="Generate LLM-based summaries for chats"
 )

--- a/gptme/logmanager/conversations.py
+++ b/gptme/logmanager/conversations.py
@@ -335,7 +335,10 @@ def list_conversations(
             If False, uses fast tail-only scan.
     """
     conversation_iter = get_conversations(detail=detail, include_test=include_test)
-    return list(islice(conversation_iter, limit))
+    # islice() raises ValueError on negative stop values; clamp so a negative
+    # limit yields an empty result instead of crashing. The CLI rejects
+    # negatives earlier, but this also guards non-CLI callers (webui/server).
+    return list(islice(conversation_iter, max(limit, 0)))
 
 
 def get_conversation_by_id(conv_id: str) -> ConversationMeta | None:

--- a/tests/test_conversations.py
+++ b/tests/test_conversations.py
@@ -10,6 +10,7 @@ from gptme.logmanager.conversations import (
     ConversationMeta,
     get_conversations,
     get_user_conversations,
+    list_conversations,
 )
 
 
@@ -339,3 +340,22 @@ def test_get_user_conversations_skips_test_logs_before_scanning(logs_dir, monkey
     convs = list(get_user_conversations())
     assert [conv.id for conv in convs] == ["real-conversation"]
     assert scanned == ["real-conversation"]
+
+
+@pytest.mark.parametrize(("limit", "expected"), [(-5, 0), (0, 0), (1, 1), (10, 2)])
+def test_list_conversations_limit_bounds(logs_dir, limit, expected):
+    """list_conversations clamps non-positive limits instead of crashing islice()."""
+    _make_conversation(
+        logs_dir,
+        "conv-one",
+        [{"role": "user", "content": "hi", "timestamp": "2025-01-01T00:00:00Z"}],
+    )
+    _make_conversation(
+        logs_dir,
+        "conv-two",
+        [{"role": "user", "content": "yo", "timestamp": "2025-01-02T00:00:00Z"}],
+    )
+
+    # Previously list_conversations(-5) raised ValueError from islice().
+    convs = list_conversations(limit)
+    assert len(convs) == expected

--- a/tests/test_util_cli.py
+++ b/tests/test_util_cli.py
@@ -118,6 +118,20 @@ def test_chats_list(tmp_path, mocker):
     assert "Messages: 2" in result.output  # Second chat has 2 messages
 
 
+def test_chats_list_negative_limit():
+    """A negative --limit should be rejected cleanly, not crash islice()."""
+    runner = CliRunner()
+
+    # Both plain and --json paths funnel through list_conversations(limit),
+    # which previously passed a negative limit straight to islice() (ValueError).
+    for extra in ([], ["--json"]):
+        result = runner.invoke(main, ["chats", "list", "--limit", "-5", *extra])
+        assert result.exit_code != 0
+        assert "Traceback" not in result.output
+        # click.IntRange emits a clear range-violation message
+        assert "-5" in result.output
+
+
 def test_context_index_and_retrieve(tmp_path):
     """Test the context index and retrieve commands."""
     # Skip if gptme-rag not available


### PR DESCRIPTION
## Problem

`gptme-util chats list --limit -5` crashes with an uncaught traceback:

```
ValueError: Indices for islice() must be None or an integer: 0 <= x <= sys.maxsize.
```

Found by dogfooding the CLI surface. The negative `--limit` flows straight into `itertools.islice()` via `list_conversations()`. The `--json` path crashes the same way, and `chats search --limit -N` shares the option.

## Fix

- **CLI boundary**: `click.IntRange(min=1)` on the `--limit` option of `chats list` and `chats search` — bad input now gets a clean Click error + non-zero exit instead of a traceback. (Other `gptme-util` error paths like `skills show <missing>` and `mcp info <missing>` already exit non-zero; this brings `chats` in line.)
- **Library defense-in-depth**: `list_conversations()` clamps negative limits to `0` (empty result), so non-CLI callers (webui/server) can't trigger the same `islice` crash.

## Behavior change

`--limit 0` and negatives are now rejected (exit 2). A limit of 0 ("show 0 chats") was a no-op before; this makes the contract explicit.

## Tests

- `tests/test_util_cli.py::test_chats_list_negative_limit` — CLI rejects `-5` on both plain and `--json` paths, no traceback.
- `tests/test_conversations.py::test_list_conversations_limit_bounds` — library clamps `-5`/`0` to empty, `1`/`10` return expected counts.

Verified the original code reproduces the crash and the fix resolves it. `ruff check` clean, touched-file tests pass (49 passed, 1 skipped).