### PR TITLE
fix(chats): read finds any conversation by id and exits non-zero when missing

### DIFF
--- a/gptme/cli/cmd_chats.py
+++ b/gptme/cli/cmd_chats.py
@@ -187,7 +187,7 @@ def chats_read(id: str, limit: int, system: bool, context: int, start: int | Non
 
     from ..tools.chats import read_chat  # fmt: skip
 
-    if not (get_logs_dir() / id).exists():
+    if not (get_logs_dir() / id / "conversation.jsonl").exists():
         click.echo(f"Conversation '{id}' not found.")
         raise SystemExit(1)
 

--- a/gptme/cli/cmd_chats.py
+++ b/gptme/cli/cmd_chats.py
@@ -187,6 +187,10 @@ def chats_read(id: str, limit: int, system: bool, context: int, start: int | Non
 
     from ..tools.chats import read_chat  # fmt: skip
 
+    if not (get_logs_dir() / id).exists():
+        click.echo(f"Conversation '{id}' not found.")
+        raise SystemExit(1)
+
     read_chat(
         id,
         max_results=limit,

--- a/gptme/tools/chats.py
+++ b/gptme/tools/chats.py
@@ -215,25 +215,26 @@ def read_chat(
         context_messages (int): Number of messages to show before start_message.
         start_message (int | None): Start from this message number (1-indexed), if specified.
     """
-    from ..logmanager import LogManager, list_conversations  # fmt: skip
+    from ..logmanager import LogManager, get_conversation_by_id  # fmt: skip
 
-    for conv in list_conversations():
-        if conv.id == id:
-            log_path = Path(conv.path)
-            logmanager = LogManager.load(log_path, lock=False)
-            print(f"Reading conversation: {conv.name} ({conv.id})")
-            messages = [
-                msg for msg in logmanager.log if msg.role != "system" or incl_system
-            ]
-            start_idx = 0
-            if start_message is not None:
-                start_idx = max(0, start_message - 1 - context_messages)
-                messages = messages[start_idx:]
-            for i, msg in enumerate(messages[:max_results]):
-                print(f"{start_idx + i + 1}. {msg.format(max_length=100)}")
-            break
-    else:
+    # Look up by id across ALL conversations. Using list_conversations() here
+    # would only scan the 20 most recent, so any older conversation was reported
+    # as "not found" even though it exists.
+    conv = get_conversation_by_id(id)
+    if conv is None:
         print(f"Conversation '{id}' not found.")
+        return
+
+    log_path = Path(conv.path)
+    logmanager = LogManager.load(log_path, lock=False)
+    print(f"Reading conversation: {conv.name} ({conv.id})")
+    messages = [msg for msg in logmanager.log if msg.role != "system" or incl_system]
+    start_idx = 0
+    if start_message is not None:
+        start_idx = max(0, start_message - 1 - context_messages)
+        messages = messages[start_idx:]
+    for i, msg in enumerate(messages[:max_results]):
+        print(f"{start_idx + i + 1}. {msg.format(max_length=100)}")
 
 
 def find_empty_conversations(

--- a/tests/test_util_cli.py
+++ b/tests/test_util_cli.py
@@ -1,6 +1,7 @@
 """Tests for the gptme-util CLI."""
 
 import json
+import os
 import time
 from pathlib import Path
 from types import SimpleNamespace
@@ -130,6 +131,51 @@ def test_chats_list_negative_limit():
         assert "Traceback" not in result.output
         # click.IntRange emits a clear range-violation message
         assert "-5" in result.output
+
+
+def test_chats_read_nonexistent_exits_nonzero(tmp_path, monkeypatch):
+    """Reading a missing conversation should fail (exit!=0), like rename/send/export.
+
+    Previously `chats read` delegated to read_chat() which only printed
+    "not found" and returned, so the CLI exited 0 on an error.
+    """
+    monkeypatch.setenv("GPTME_LOGS_HOME", str(tmp_path))
+    runner = CliRunner()
+
+    result = runner.invoke(main, ["chats", "read", "no-such-conversation"])
+    assert result.exit_code != 0
+    assert "not found" in result.output
+    assert "Traceback" not in result.output
+
+
+def test_chats_read_finds_conversation_beyond_recent_limit(tmp_path, monkeypatch):
+    """`chats read` must find any conversation, not just the 20 most recent.
+
+    read_chat() used list_conversations() (default limit 20), so reading an
+    older conversation by id reported it as "not found" even though it existed.
+    """
+    monkeypatch.setenv("GPTME_LOGS_HOME", str(tmp_path))
+    runner = CliRunner()
+
+    # Create 25 conversations with strictly increasing mtimes so recency order
+    # is deterministic; the oldest sits well outside the old 20-conversation window.
+    target_id = "0000-01-01-oldest-chat"
+    base = time.time() - 10_000
+    for i in range(25):
+        conv_id = "0000-01-01-oldest-chat" if i == 0 else f"2026-01-01-chat-{i:02d}"
+        conv_dir = tmp_path / conv_id
+        conv_dir.mkdir()
+        jsonl = conv_dir / "conversation.jsonl"
+        jsonl.write_text(
+            '{"role": "user", "content": "hello", "timestamp": "2026-01-01T00:00:00+00:00"}\n'
+        )
+        # i=0 (target) is the oldest, i=24 the newest.
+        os.utime(jsonl, (base + i, base + i))
+
+    result = runner.invoke(main, ["chats", "read", target_id])
+    assert result.exit_code == 0, result.output
+    assert "not found" not in result.output
+    assert target_id in result.output
 
 
 def test_context_index_and_retrieve(tmp_path):


### PR DESCRIPTION
## Problem

Dogfooding the `gptme-util chats` surface surfaced two bugs in `chats read`:

1. **Can't read conversations beyond the 20 most recent.** `read_chat()` looked up the conversation via `list_conversations()`, which defaults to `limit=20`. With more than 20 conversations on disk (Bob's instance has 4400+), reading any older one by id printed `Conversation '<id>' not found.` even though it exists.

   ```console
   $ gptme-util chats read run-autonomous-triage-20260524064251-9f35   # exists, 25th most recent
   Conversation 'run-autonomous-triage-20260524064251-9f35' not found.   # ← wrong
   ```

2. **Error path returned exit 0.** `chats read <missing>` exited `0`, unlike its siblings `rename`/`send`/`export`, which all exit `1` on a missing conversation. This breaks scripting (`&&` chains, CI) and the Unix convention.

## Fix

- `read_chat()` now looks up by id with `get_conversation_by_id()` (scans all conversations), the same helper `rename` already uses.
- The CLI `chats read` adds an existence pre-check that exits `1` on a missing id, mirroring `send`/`export`.

## Tests

Added two regression tests in `tests/test_util_cli.py` (both fail on `master`, pass with the fix):
- `test_chats_read_finds_conversation_beyond_recent_limit` — 25 conversations, reads the oldest.
- `test_chats_read_nonexistent_exits_nonzero` — missing id exits non-zero, no traceback.

Full chats + util-CLI suite passes (47 passed, 1 skipped).