### PR TITLE
fix(server): return 400 for conversation_id/branch names exceeding NAME_MAX

### DIFF
--- a/gptme/server/api_v2_common.py
+++ b/gptme/server/api_v2_common.py
@@ -12,7 +12,7 @@ from typing_extensions import NotRequired
 from ..message import Message
 from ..util.uri import URI, is_uri
 
-_MAX_ID_LENGTH = 255  # Linux ENAMETOOLONG limit for a single path component
+_MAX_ID_LENGTH = 255  # Linux NAME_MAX: 255 UTF-8 bytes for a single path component
 
 
 def _validate_conversation_id(
@@ -33,7 +33,7 @@ def _validate_conversation_id(
     would otherwise bubble up as an unhandled 500 for IDs longer than the
     filesystem's NAME_MAX (typically 255 on Linux ext4/xfs).
     """
-    if len(conversation_id) > _MAX_ID_LENGTH:
+    if len(conversation_id.encode()) > _MAX_ID_LENGTH:
         return flask.jsonify({"error": "conversation_id too long"}), 400
     if "/" in conversation_id or ".." in conversation_id or "\\" in conversation_id:
         return flask.jsonify({"error": "Invalid conversation_id"}), 400
@@ -50,7 +50,7 @@ def _validate_branch(branch: object) -> tuple[flask.Response, int] | None:
     """
     if not isinstance(branch, str):
         return flask.jsonify({"error": "Invalid branch name"}), 400
-    if len(branch) > _MAX_ID_LENGTH:
+    if len(branch.encode()) > _MAX_ID_LENGTH:
         return flask.jsonify({"error": "branch name too long"}), 400
     if "/" in branch or ".." in branch or "\\" in branch:
         return flask.jsonify({"error": "Invalid branch name"}), 400

--- a/gptme/server/api_v2_common.py
+++ b/gptme/server/api_v2_common.py
@@ -13,6 +13,9 @@ from ..message import Message
 from ..util.uri import URI, is_uri
 
 _MAX_ID_LENGTH = 255  # Linux NAME_MAX: 255 UTF-8 bytes for a single path component
+_BRANCH_SUFFIX_LEN = len(
+    ".jsonl"
+)  # branches/{name}.jsonl on disk — suffix counts against NAME_MAX
 
 
 def _validate_conversation_id(
@@ -46,11 +49,15 @@ def _validate_branch(branch: object) -> tuple[flask.Response, int] | None:
     Branch names are used to construct file paths like ``branches/{branch}.jsonl``,
     so they must not contain path separators or traversal sequences.
 
+    The effective byte limit is ``NAME_MAX - len(".jsonl")`` because the on-disk
+    filename is ``{branch}.jsonl``; a branch name filling all 255 bytes would
+    produce a 261-byte filename, still triggering ``OSError: [Errno 36]``.
+
     Returns None if valid, or (error_response, status_code) if invalid.
     """
     if not isinstance(branch, str):
         return flask.jsonify({"error": "Invalid branch name"}), 400
-    if len(branch.encode()) > _MAX_ID_LENGTH:
+    if len(branch.encode()) > _MAX_ID_LENGTH - _BRANCH_SUFFIX_LEN:
         return flask.jsonify({"error": "branch name too long"}), 400
     if "/" in branch or ".." in branch or "\\" in branch:
         return flask.jsonify({"error": "Invalid branch name"}), 400

--- a/gptme/server/api_v2_common.py
+++ b/gptme/server/api_v2_common.py
@@ -12,11 +12,13 @@ from typing_extensions import NotRequired
 from ..message import Message
 from ..util.uri import URI, is_uri
 
+_MAX_ID_LENGTH = 255  # Linux ENAMETOOLONG limit for a single path component
+
 
 def _validate_conversation_id(
     conversation_id: str,
 ) -> tuple[flask.Response, int] | None:
-    """Validate conversation_id to prevent path traversal attacks.
+    """Validate conversation_id to prevent path traversal attacks and OS errors.
 
     Returns None if valid, or (error_response, status_code) if invalid.
 
@@ -26,14 +28,20 @@ def _validate_conversation_id(
     single-component form is a bare ``..``, but substring matching is simpler
     and the false-positive risk (rejecting ``..`` in a real conversation name)
     is negligible in practice.
+
+    The length check prevents ``OSError: [Errno 36] File name too long`` which
+    would otherwise bubble up as an unhandled 500 for IDs longer than the
+    filesystem's NAME_MAX (typically 255 on Linux ext4/xfs).
     """
+    if len(conversation_id) > _MAX_ID_LENGTH:
+        return flask.jsonify({"error": "conversation_id too long"}), 400
     if "/" in conversation_id or ".." in conversation_id or "\\" in conversation_id:
         return flask.jsonify({"error": "Invalid conversation_id"}), 400
     return None
 
 
 def _validate_branch(branch: object) -> tuple[flask.Response, int] | None:
-    """Validate branch name to prevent path traversal attacks (CWE-22).
+    """Validate branch name to prevent path traversal attacks and OS errors.
 
     Branch names are used to construct file paths like ``branches/{branch}.jsonl``,
     so they must not contain path separators or traversal sequences.
@@ -42,6 +50,8 @@ def _validate_branch(branch: object) -> tuple[flask.Response, int] | None:
     """
     if not isinstance(branch, str):
         return flask.jsonify({"error": "Invalid branch name"}), 400
+    if len(branch) > _MAX_ID_LENGTH:
+        return flask.jsonify({"error": "branch name too long"}), 400
     if "/" in branch or ".." in branch or "\\" in branch:
         return flask.jsonify({"error": "Invalid branch name"}), 400
     return None

--- a/tests/test_server_path_traversal.py
+++ b/tests/test_server_path_traversal.py
@@ -497,6 +497,94 @@ class TestAgentCreationPathValidation:
         assert "alphanumeric" in data["error"].lower()
 
 
+class TestConversationIdLengthValidation:
+    """conversation_id values longer than NAME_MAX must return 400, not 500.
+
+    Linux filesystems (ext4, xfs) raise OSError ENAMETOOLONG for path components
+    longer than NAME_MAX (typically 255).  The server used to catch only
+    FileNotFoundError, so an over-long ID triggered an unhandled 500.
+    """
+
+    def test_too_long_id_returns_400_not_500(self, client: FlaskClient):
+        """A 256-char conversation_id must return 400, not 500 (OSError)."""
+        long_id = "a" * 256
+        response = client.get(f"/api/v2/conversations/{long_id}")
+        assert response.status_code == 400
+        data = response.get_json()
+        assert data is not None
+        assert "too long" in data["error"]
+
+    def test_exactly_255_chars_is_accepted(self, client: FlaskClient):
+        """A 255-char ID is at the limit and must not be rejected by length check."""
+        ok_id = "a" * 255
+        response = client.get(f"/api/v2/conversations/{ok_id}")
+        # Should not be rejected for length — may be 404 (not found) but not 400 length
+        if response.status_code == 400:
+            data = response.get_json()
+            assert data is None or "too long" not in data.get("error", "")
+
+    def test_very_long_id_unit(self):
+        """Unit test: _validate_conversation_id returns error for over-limit IDs."""
+        from gptme.server.api_v2_common import _validate_conversation_id
+        from gptme.server.app import create_app
+
+        app = create_app()
+        with app.app_context():
+            result = _validate_conversation_id("a" * 256)
+            assert result is not None
+            _response, status_code = result
+            assert status_code == 400
+
+    def test_255_char_id_passes_unit(self):
+        """Unit test: _validate_conversation_id accepts IDs up to 255 chars."""
+        from gptme.server.api_v2_common import _validate_conversation_id
+        from gptme.server.app import create_app
+
+        app = create_app()
+        with app.app_context():
+            assert _validate_conversation_id("a" * 255) is None
+
+
+class TestBranchLengthValidation:
+    """Branch names longer than NAME_MAX must return 400, not 500."""
+
+    def test_too_long_branch_unit(self):
+        """Unit test: _validate_branch returns error for over-limit names."""
+        from gptme.server.api_v2_common import _validate_branch
+        from gptme.server.app import create_app
+
+        app = create_app()
+        with app.app_context():
+            result = _validate_branch("b" * 256)
+            assert result is not None
+            _response, status_code = result
+            assert status_code == 400
+
+    def test_255_char_branch_passes_unit(self):
+        """Unit test: _validate_branch accepts names up to 255 chars."""
+        from gptme.server.api_v2_common import _validate_branch
+        from gptme.server.app import create_app
+
+        app = create_app()
+        with app.app_context():
+            assert _validate_branch("b" * 255) is None
+
+    def test_too_long_branch_via_endpoint(self, client: FlaskClient):
+        """Over-limit branch name in generate request must return 400."""
+        response = client.post(
+            "/api/v2/conversations/test-conv",
+            json={
+                "role": "user",
+                "content": "hello",
+                "branch": "b" * 256,
+            },
+        )
+        assert response.status_code == 400
+        data = response.get_json()
+        assert data is not None
+        assert "too long" in data["error"]
+
+
 class TestValidateBranchUnit:
     """Unit tests for _validate_branch function (requires Flask app context)."""
 

--- a/tests/test_server_path_traversal.py
+++ b/tests/test_server_path_traversal.py
@@ -569,49 +569,71 @@ class TestBranchLengthValidation:
     """Branch names longer than NAME_MAX must return 400, not 500."""
 
     def test_too_long_branch_unit(self):
-        """Unit test: _validate_branch returns error for over-limit names."""
+        """Unit test: _validate_branch returns error for over-limit names.
+
+        Effective limit is NAME_MAX - len(".jsonl") = 249 bytes because the
+        on-disk filename is ``{branch}.jsonl``.
+        """
         from gptme.server.api_v2_common import _validate_branch
         from gptme.server.app import create_app
 
         app = create_app()
         with app.app_context():
-            result = _validate_branch("b" * 256)
+            result = _validate_branch("b" * 250)
             assert result is not None
             _response, status_code = result
             assert status_code == 400
 
-    def test_255_char_branch_passes_unit(self):
-        """Unit test: _validate_branch accepts names up to 255 chars."""
+    def test_249_char_branch_passes_unit(self):
+        """Unit test: _validate_branch accepts names up to 249 bytes.
+
+        249 bytes is the effective limit: NAME_MAX (255) minus the 6-byte
+        ``.jsonl`` suffix that is appended when the branch is stored on disk.
+        """
         from gptme.server.api_v2_common import _validate_branch
         from gptme.server.app import create_app
 
         app = create_app()
         with app.app_context():
-            assert _validate_branch("b" * 255) is None
+            # 249 bytes: at the effective limit — must pass
+            assert _validate_branch("b" * 249) is None
+            # 250 bytes: one over the limit — must be rejected
+            result = _validate_branch("b" * 250)
+            assert result is not None
+            _response, status_code = result
+            assert status_code == 400
 
     def test_multibyte_branch_over_limit_rejected(self):
-        """Multi-byte branch names counted by UTF-8 bytes, not code points."""
+        """Multi-byte branch names counted by UTF-8 bytes, not code points.
+
+        Effective limit is 249 bytes (NAME_MAX - len(".jsonl")).
+        Each CJK char is 3 UTF-8 bytes, so 83 chars = 249 bytes (OK),
+        84 chars = 252 bytes (over limit).
+        """
         from gptme.server.api_v2_common import _validate_branch
         from gptme.server.app import create_app
 
         app = create_app()
         with app.app_context():
-            # 85 CJK chars = 255 bytes (at limit, OK)
-            assert _validate_branch("あ" * 85) is None
-            # 86 CJK chars = 258 bytes (over limit, must reject)
-            result = _validate_branch("あ" * 86)
+            # 83 CJK chars = 249 bytes (at effective limit, OK)
+            assert _validate_branch("あ" * 83) is None
+            # 84 CJK chars = 252 bytes (over effective limit, must reject)
+            result = _validate_branch("あ" * 84)
             assert result is not None
             _response, status_code = result
             assert status_code == 400
 
     def test_too_long_branch_via_endpoint(self, client: FlaskClient):
-        """Over-limit branch name in generate request must return 400."""
+        """Over-limit branch name in generate request must return 400.
+
+        Effective limit is 249 bytes; 250 bytes must be rejected.
+        """
         response = client.post(
             "/api/v2/conversations/test-conv",
             json={
                 "role": "user",
                 "content": "hello",
-                "branch": "b" * 256,
+                "branch": "b" * 250,
             },
         )
         assert response.status_code == 400

--- a/tests/test_server_path_traversal.py
+++ b/tests/test_server_path_traversal.py
@@ -518,7 +518,8 @@ class TestConversationIdLengthValidation:
         """A 255-char ID is at the limit and must not be rejected by length check."""
         ok_id = "a" * 255
         response = client.get(f"/api/v2/conversations/{ok_id}")
-        # Should not be rejected for length — may be 404 (not found) but not 400 length
+        # Must not crash (500) and must not be rejected for length
+        assert response.status_code != 500
         if response.status_code == 400:
             data = response.get_json()
             assert data is None or "too long" not in data.get("error", "")
@@ -544,6 +545,25 @@ class TestConversationIdLengthValidation:
         with app.app_context():
             assert _validate_conversation_id("a" * 255) is None
 
+    def test_multibyte_over_limit_rejected(self):
+        """Multi-byte chars counted by UTF-8 bytes, not code points.
+
+        255 CJK chars = 765 bytes > NAME_MAX and must be rejected even though
+        len() == 255 (code points).
+        """
+        from gptme.server.api_v2_common import _validate_conversation_id
+        from gptme.server.app import create_app
+
+        app = create_app()
+        with app.app_context():
+            # Each CJK char is 3 UTF-8 bytes; 85 * 3 = 255 bytes (at limit, OK)
+            assert _validate_conversation_id("あ" * 85) is None
+            # 86 * 3 = 258 bytes (over limit, must reject)
+            result = _validate_conversation_id("あ" * 86)
+            assert result is not None
+            _response, status_code = result
+            assert status_code == 400
+
 
 class TestBranchLengthValidation:
     """Branch names longer than NAME_MAX must return 400, not 500."""
@@ -568,6 +588,21 @@ class TestBranchLengthValidation:
         app = create_app()
         with app.app_context():
             assert _validate_branch("b" * 255) is None
+
+    def test_multibyte_branch_over_limit_rejected(self):
+        """Multi-byte branch names counted by UTF-8 bytes, not code points."""
+        from gptme.server.api_v2_common import _validate_branch
+        from gptme.server.app import create_app
+
+        app = create_app()
+        with app.app_context():
+            # 85 CJK chars = 255 bytes (at limit, OK)
+            assert _validate_branch("あ" * 85) is None
+            # 86 CJK chars = 258 bytes (over limit, must reject)
+            result = _validate_branch("あ" * 86)
+            assert result is not None
+            _response, status_code = result
+            assert status_code == 400
 
     def test_too_long_branch_via_endpoint(self, client: FlaskClient):
         """Over-limit branch name in generate request must return 400."""


### PR DESCRIPTION
## Summary

- Over-long conversation IDs (>255 chars) caused `OSError: [Errno 36] File name too long` to propagate as an unhandled 500 when the server tries to open/create the log file
- Add `_MAX_ID_LENGTH = 255` constant (Linux `NAME_MAX`) and a length check in `_validate_conversation_id()` and `_validate_branch()` that returns a clean 400 before any filesystem operation is attempted
- Same pattern applied to branch name validation for consistency

Discovered during dogfood bug-triage pass exercising the server API with edge inputs.

## Test plan

- [ ] `TestConversationIdLengthValidation.test_too_long_id_returns_400_not_500` — 256-char ID → 400 (not 500)
- [ ] `TestConversationIdLengthValidation.test_exactly_255_chars_is_accepted` — 255-char ID not rejected for length
- [ ] `TestBranchLengthValidation.test_too_long_branch_via_endpoint` — 256-char branch name via POST → 400
- [ ] All 100 existing server tests still pass