### PR TITLE
feat(webui): distinguish connection-refused, CORS, PNA, and timeout errors in disconnected state

### DIFF
--- a/webui/src/components/WelcomeView.tsx
+++ b/webui/src/components/WelcomeView.tsx
@@ -22,6 +22,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import { isLikelyChromeCorsPna } from '@/utils/api';
 
 const DEFAULT_LOCAL_SERVER_URLS = new Set(['http://127.0.0.1:5700', 'http://localhost:5700']);
 
@@ -46,6 +47,7 @@ export const WelcomeView = () => {
   const { api, isConnected$, connectionConfig, switchServer, connect } = useApi();
   const queryClient = useQueryClient();
   const isConnected = use$(isConnected$);
+  const lastConnectionResult = use$(api.lastConnectionResult$);
   const providerStatusVersion = use$(setupWizard$.providerStatusVersion);
   const registry = use$(serverRegistry$);
   const connectedServers = getConnectedServers();
@@ -169,6 +171,35 @@ export const WelcomeView = () => {
   // their disconnected banner is left unchanged.
   const isFirstVisit = !settings.hasCompletedSetup;
   const showGuidedSetup = isDefaultLocalServer && isFirstVisit;
+
+  // Classify the last connection failure into actionable buckets for targeted guidance.
+  const errorBucket = (() => {
+    if (!lastConnectionResult || lastConnectionResult.ok) return 'unknown';
+    const { reason, url } = lastConnectionResult;
+    if (reason === 'cors') return isLikelyChromeCorsPna(url) ? 'pna' : 'cors';
+    return reason; // 'network' | 'timeout' | 'http_error' | 'parse_error'
+  })();
+
+  const disconnectedDesc = (() => {
+    if (errorBucket === 'network') {
+      return isDefaultLocalServer
+        ? 'The gptme server is not running. Start one with the command below.'
+        : 'Connection refused — check that the server is running and the URL is correct.';
+    }
+    if (errorBucket === 'pna') {
+      return `Chrome blocked this connection (Local Network Access). Click Allow if a permission prompt appeared, then retry. If no prompt appeared, try opening ${activeServerBaseUrl} directly in your browser first.`;
+    }
+    if (errorBucket === 'cors') {
+      return `The server rejected cross-origin requests from ${window.location.origin}. Restart it with --cors-origin to allow this page.`;
+    }
+    if (errorBucket === 'timeout') {
+      return 'The connection timed out — the server may be starting up or unreachable. Retry in a moment.';
+    }
+    return isDefaultLocalServer
+      ? 'Start a local gptme server or point the app at another server before starting a chat.'
+      : 'Check the server URL and auth token, then retry the connection.';
+  })();
+
   const bg = settings.welcomeBackground;
   // Determine if the background is an image URL or a CSS gradient/color
   const isImageBg = bg && (bg.startsWith('http') || bg.startsWith('/') || bg.startsWith('data:'));
@@ -211,20 +242,24 @@ export const WelcomeView = () => {
                     : `Cannot reach ${activeServer?.name || 'the configured server'}`}
                 </AlertTitle>
                 <AlertDescription className="space-y-3">
-                  <p>
-                    {isDefaultLocalServer
-                      ? 'Start a local gptme server or point the app at another server before starting a chat.'
-                      : 'Check the server URL and auth token, then retry the connection.'}
-                  </p>
-                  {!isDefaultLocalServer && isHostedOrigin && isActiveServerLoopback && (
-                    <p className="text-xs text-muted-foreground">
-                      On Chrome 142+ (and other Chromium browsers), connecting from a hosted page to
-                      a local server triggers a{' '}
-                      <span className="font-medium">Local Network Access</span> permission prompt —
-                      click <span className="font-medium">Allow</span> if you see one. The{' '}
-                      <code>--cors-origin</code> flag alone is not enough.
-                    </p>
+                  <p>{disconnectedDesc}</p>
+                  {errorBucket === 'cors' && (
+                    <code className="block rounded-md border border-amber-500/20 bg-background/80 px-3 py-2 font-mono text-xs">
+                      {serverCommand}
+                    </code>
                   )}
+                  {errorBucket !== 'pna' &&
+                    !isDefaultLocalServer &&
+                    isHostedOrigin &&
+                    isActiveServerLoopback && (
+                      <p className="text-xs text-muted-foreground">
+                        On Chrome 142+ (and other Chromium browsers), connecting from a hosted page
+                        to a local server triggers a{' '}
+                        <span className="font-medium">Local Network Access</span> permission prompt
+                        — click <span className="font-medium">Allow</span> if you see one. The{' '}
+                        <code>--cors-origin</code> flag alone is not enough.
+                      </p>
+                    )}
                   {showGuidedSetup && (
                     <p className="text-sm text-muted-foreground">
                       New to gptme? The setup guide walks you through installing a local server or

--- a/webui/src/components/WelcomeView.tsx
+++ b/webui/src/components/WelcomeView.tsx
@@ -277,7 +277,7 @@ export const WelcomeView = () => {
                       <code className="block rounded-md border border-amber-500/20 bg-background/80 px-3 py-2 font-mono text-xs">
                         {serverCommand}
                       </code>
-                      {isHostedOrigin && (
+                      {errorBucket !== 'pna' && isHostedOrigin && (
                         <p className="text-xs text-muted-foreground">
                           On Chrome 142+ (and other Chromium browsers), the first connection to a
                           local server also triggers a{' '}

--- a/webui/src/components/WelcomeView.tsx
+++ b/webui/src/components/WelcomeView.tsx
@@ -266,7 +266,7 @@ export const WelcomeView = () => {
                       using the managed gptme.ai option — no copy-pasting required.
                     </p>
                   )}
-                  {isDefaultLocalServer && !isFirstVisit && (
+                  {isDefaultLocalServer && !isFirstVisit && errorBucket !== 'cors' && (
                     <div className="space-y-2">
                       <p className="text-xs text-muted-foreground">
                         New to gptme? Install it, then start a server:

--- a/webui/src/components/__tests__/WelcomeView.test.tsx
+++ b/webui/src/components/__tests__/WelcomeView.test.tsx
@@ -14,7 +14,7 @@ const isConnected$ = observable(true);
 const lastConnectionResult$ = observable<null | {
   ok: false;
   url: string;
-  reason: string;
+  reason: 'network' | 'http_error' | 'parse_error' | 'timeout' | 'cors';
   message: string;
 }>(null);
 let mockBaseUrl = 'http://localhost:5700';
@@ -379,6 +379,30 @@ describe('WelcomeView', () => {
     expect(screen.getByText(/rejected cross-origin requests/i)).toBeInTheDocument();
     // The serverCommand code block contains the full gptme-server invocation
     expect(screen.getByText(/gptme-server --cors-origin/i)).toBeInTheDocument();
+  });
+
+  it('shows PNA guidance when Chrome Local Network Access blocks the connection', () => {
+    mockIsLikelyChromeCorsPna.mockReturnValue(true);
+    isConnected$.set(false);
+    lastConnectionResult$.set({
+      ok: false,
+      url: 'http://localhost:5700/api/v2',
+      reason: 'cors',
+      message: 'CORS error',
+    });
+
+    render(
+      <SettingsProvider>
+        <WelcomeView />
+      </SettingsProvider>
+    );
+
+    expect(
+      screen.getByText(/Chrome blocked this connection.*Local Network Access/i)
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/rejected cross-origin requests/i)).not.toBeInTheDocument();
+
+    mockIsLikelyChromeCorsPna.mockReturnValue(false);
   });
 
   it('shows timeout guidance for a timeout error', () => {

--- a/webui/src/components/__tests__/WelcomeView.test.tsx
+++ b/webui/src/components/__tests__/WelcomeView.test.tsx
@@ -11,7 +11,19 @@ const mockInvalidateQueries = jest.fn();
 const mockConnect = jest.fn();
 const mockFetch = jest.fn();
 const isConnected$ = observable(true);
+const lastConnectionResult$ = observable<null | {
+  ok: false;
+  url: string;
+  reason: string;
+  message: string;
+}>(null);
 let mockBaseUrl = 'http://localhost:5700';
+// Controls whether isLikelyChromeCorsPna() classifies the last probe URL as PNA.
+const mockIsLikelyChromeCorsPna = jest.fn().mockReturnValue(false);
+
+jest.mock('@/utils/api', () => ({
+  isLikelyChromeCorsPna: (...args: unknown[]) => mockIsLikelyChromeCorsPna(...args),
+}));
 
 jest.mock('react-router-dom', () => {
   const actual = jest.requireActual('react-router-dom');
@@ -27,6 +39,7 @@ jest.mock('@/contexts/ApiContext', () => {
       api: {
         createConversationWithPlaceholder: jest.fn(),
         authHeader: null,
+        lastConnectionResult$,
       },
       isConnected$,
       connect: mockConnect,
@@ -72,6 +85,7 @@ describe('WelcomeView', () => {
     // Default to a first-time user (no stored settings → hasCompletedSetup=false).
     localStorage.clear();
     isConnected$.set(true);
+    lastConnectionResult$.set(null);
     mockBaseUrl = 'http://localhost:5700';
     setupWizard$.step.set('welcome');
     setupWizard$.open.set(false);
@@ -81,6 +95,7 @@ describe('WelcomeView', () => {
     mockNavigate.mockClear();
     mockInvalidateQueries.mockClear();
     mockFetch.mockReset();
+    mockIsLikelyChromeCorsPna.mockReturnValue(false);
     mockFetch.mockImplementation(() => new Promise(() => {}));
     Object.defineProperty(window, 'fetch', {
       writable: true,
@@ -301,5 +316,88 @@ describe('WelcomeView', () => {
     await waitFor(() => {
       expect(screen.queryByText('Provider setup required')).not.toBeInTheDocument();
     });
+  });
+
+  it('shows "server not running" guidance for a network/refused error on the default local server', () => {
+    seedReturningUser();
+    isConnected$.set(false);
+    lastConnectionResult$.set({
+      ok: false,
+      url: 'http://localhost:5700/api/v2',
+      reason: 'network',
+      message: 'Could not reach server (connection refused or no DNS)',
+    });
+
+    render(
+      <SettingsProvider>
+        <WelcomeView />
+      </SettingsProvider>
+    );
+
+    expect(screen.getByText(/The gptme server is not running/i)).toBeInTheDocument();
+    expect(
+      screen.queryByText(/Start a local gptme server or point the app/i)
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows "connection refused" guidance for a network error on a custom server', () => {
+    mockBaseUrl = 'http://my-server.example.com:5700';
+    isConnected$.set(false);
+    lastConnectionResult$.set({
+      ok: false,
+      url: 'http://my-server.example.com:5700/api/v2',
+      reason: 'network',
+      message: 'Could not reach server',
+    });
+
+    render(
+      <SettingsProvider>
+        <WelcomeView />
+      </SettingsProvider>
+    );
+
+    expect(screen.getByText(/Connection refused/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Check the server URL and auth token/i)).not.toBeInTheDocument();
+  });
+
+  it('shows CORS guidance and the cors-origin command for a cors error on a custom server', () => {
+    mockBaseUrl = 'http://my-server.example.com:5700';
+    isConnected$.set(false);
+    lastConnectionResult$.set({
+      ok: false,
+      url: 'http://my-server.example.com:5700/api/v2',
+      reason: 'cors',
+      message: 'CORS error',
+    });
+
+    render(
+      <SettingsProvider>
+        <WelcomeView />
+      </SettingsProvider>
+    );
+
+    expect(screen.getByText(/rejected cross-origin requests/i)).toBeInTheDocument();
+    // The serverCommand code block contains the full gptme-server invocation
+    expect(screen.getByText(/gptme-server --cors-origin/i)).toBeInTheDocument();
+  });
+
+  it('shows timeout guidance for a timeout error', () => {
+    seedReturningUser();
+    isConnected$.set(false);
+    lastConnectionResult$.set({
+      ok: false,
+      url: 'http://localhost:5700/api/v2',
+      reason: 'timeout',
+      message: 'Request timed out after 3s',
+    });
+
+    render(
+      <SettingsProvider>
+        <WelcomeView />
+      </SettingsProvider>
+    );
+
+    expect(screen.getByText(/connection timed out/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Start a local gptme server/i)).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Closes #2492

## Summary

- Adds an `errorBucket` classifier driven by `lastConnectionResult$` that maps `reason` → `'network' | 'cors' | 'pna' | 'timeout' | 'unknown'`
- Renders targeted guidance per bucket instead of the previous one-size-fits-all text:
  - **network / localhost**: "The gptme server is not running. Start one with the command below."
  - **network / custom server**: "Connection refused — check that the server is running and the URL is correct."
  - **cors**: Shows the `gptme-server --cors-origin=<origin>` invocation as a code block, with the description explaining why.
  - **pna** (Chrome Local Network Access): Explains the Chrome 142+ permission prompt and gives the direct-open workaround.
  - **timeout**: "The connection timed out — the server may be starting up or unreachable. Retry in a moment."
- Reuses `isLikelyChromeCorsPna()` from `@/utils/api` to distinguish Chrome LNA blocks from ordinary CORS rejections — no new utility added.
- Suppresses the generic LNA hint in the default-server install block when the error is already classified as PNA (avoids redundant guidance).

## Test plan

- [x] All 13 existing + new `WelcomeView` tests pass (`npx jest --testPathPattern=WelcomeView`)
- [x] 4 new tests covering the `network` (default/custom), `cors`, and `timeout` error buckets
- [x] Pre-commit (ESLint + tsc) clean