### PR TITLE
fix(cli): remove browser backend noise from utility output

### DIFF
--- a/gptme/tools/browser.py
+++ b/gptme/tools/browser.py
@@ -70,7 +70,6 @@ from typing import Literal
 
 import requests
 
-from ..util import console
 from ..util.context import md_codeblock
 from ..util.gh import (
     get_github_issue_content,
@@ -566,10 +565,6 @@ def _tool_instructions() -> str:
 
 
 def init() -> ToolSpec:
-    if browser == "playwright":
-        console.log("Using browser tool with playwright")
-    elif browser == "lynx":
-        console.log("Using browser tool with lynx")
     # Note: _tool_instructions() is evaluated once at init time, so the
     # "available now:" list reflects backend availability at startup.
     # search() itself always re-evaluates _available_search_engines() at call time.

--- a/tests/test_util_cli.py
+++ b/tests/test_util_cli.py
@@ -56,10 +56,6 @@ def test_chats_list(tmp_path, mocker):
     runner = CliRunner()
 
     mocker.patch("gptme.tools.browser.browser", "playwright")
-    mocker.patch(
-        "gptme.tools.browser.console.log",
-        side_effect=AssertionError("browser init should stay quiet for chats list"),
-    )
 
     # Create test conversations
     logs_dir = tmp_path / "logs"
@@ -214,10 +210,6 @@ def test_tools_list(mocker):
     runner = CliRunner()
 
     mocker.patch("gptme.tools.browser.browser", "playwright")
-    mocker.patch(
-        "gptme.tools.browser.console.log",
-        side_effect=AssertionError("browser init should stay quiet for tools list"),
-    )
 
     # Test basic list
     result = runner.invoke(main, ["tools", "list"])

--- a/tests/test_util_cli.py
+++ b/tests/test_util_cli.py
@@ -55,6 +55,12 @@ def test_chats_list(tmp_path, mocker):
     """Test the chats list command."""
     runner = CliRunner()
 
+    mocker.patch("gptme.tools.browser.browser", "playwright")
+    mocker.patch(
+        "gptme.tools.browser.console.log",
+        side_effect=AssertionError("browser init should stay quiet for chats list"),
+    )
+
     # Create test conversations
     logs_dir = tmp_path / "logs"
     logs_dir.mkdir()
@@ -66,6 +72,7 @@ def test_chats_list(tmp_path, mocker):
     result = runner.invoke(main, ["chats", "list"])
     assert result.exit_code == 0
     assert "No conversations found" in result.output
+    assert "Using browser tool with" not in result.output
 
     # Create test conversation files with names that won't be filtered
     conv1_dir = logs_dir / "2024-01-01-chat-one"
@@ -116,6 +123,7 @@ def test_chats_list(tmp_path, mocker):
     assert "2024-01-01-chat-two" in result.output
     assert "Messages: 1" in result.output  # First chat has 1 message
     assert "Messages: 2" in result.output  # Second chat has 2 messages
+    assert "Using browser tool with" not in result.output
 
 
 def test_chats_list_negative_limit():
@@ -199,16 +207,23 @@ def test_chats_send_help_mentions_queued_follow_up_flow():
     assert re.search(r"running conversation|gptme process.*busy", help_text)
 
 
-def test_tools_list():
+def test_tools_list(mocker):
     """Test the tools list command."""
     import json
 
     runner = CliRunner()
 
+    mocker.patch("gptme.tools.browser.browser", "playwright")
+    mocker.patch(
+        "gptme.tools.browser.console.log",
+        side_effect=AssertionError("browser init should stay quiet for tools list"),
+    )
+
     # Test basic list
     result = runner.invoke(main, ["tools", "list"])
     assert "Available tools" in result.output
     assert result.exit_code == 0
+    assert "Using browser tool with" not in result.output
 
     # Test langtags
     result = runner.invoke(main, ["tools", "list", "--langtags"])


### PR DESCRIPTION
## Summary
- stop browser tool init from printing backend-selection noise during utility command startup
- keep `gptme-util tools list` and `gptme-util chats list` output clean
- add regression coverage for the affected CLI paths

## Repro
```bash
uv run gptme-util tools list | head -3
uv run gptme-util chats list --limit 1 | head -3
```

Before this patch, both commands could start with `Using browser tool with playwright` instead of the requested output.

## Testing
```bash
PYTHONPATH=/tmp/worktrees/gptme-cli-browser-noise /home/bob/gptme/.venv/bin/pytest tests/test_util_cli.py tests/test_chats_json.py -q
```
