### PR TITLE
fix(cli): reject overlong conversation IDs before filesystem access

### DIFF
--- a/gptme/cli/cmd_chats.py
+++ b/gptme/cli/cmd_chats.py
@@ -25,7 +25,7 @@ def _is_valid_id(id: str) -> bool:
     These would otherwise raise ``OSError: [Errno 36] File name too long``
     deep inside ``Path.exists()`` or ``os.stat()``.
     """
-    return len(id.encode()) <= _MAX_ID_LEN and "/" not in id and ".." not in id
+    return len(id.encode()) <= _MAX_ID_LEN and "/" not in id and id != ".."
 
 
 def _ensure_tools():

--- a/gptme/cli/cmd_chats.py
+++ b/gptme/cli/cmd_chats.py
@@ -288,7 +288,7 @@ def chats_export(id: str, fmt: str, output: str | None):
     from ..util.export import export_chat_to_html, export_chat_to_markdown  # fmt: skip
 
     logdir = get_logs_dir() / id
-    if not logdir.exists():
+    if not _is_valid_id(id) or not logdir.exists():
         click.echo(f"Chat '{id}' not found")
         raise SystemExit(1)
 

--- a/gptme/cli/cmd_chats.py
+++ b/gptme/cli/cmd_chats.py
@@ -14,6 +14,19 @@ from ..prompt_queue import queue_prompt
 from ..tools import get_tools, init_tools
 from ..tools.chats import find_empty_conversations, list_chats, search_chats
 
+_MAX_ID_LEN = 255  # Linux NAME_MAX: max UTF-8 bytes for one path component
+
+
+def _is_valid_id(id: str) -> bool:
+    """Return True if id is a plausible conversation identifier.
+
+    Rejects IDs that are too long for the filesystem (Linux NAME_MAX is 255
+    UTF-8 bytes per path component) or contain path-traversal sequences.
+    These would otherwise raise ``OSError: [Errno 36] File name too long``
+    deep inside ``Path.exists()`` or ``os.stat()``.
+    """
+    return len(id.encode()) <= _MAX_ID_LEN and "/" not in id and ".." not in id
+
 
 def _ensure_tools():
     """Lazily initialize tools only when needed."""
@@ -187,7 +200,10 @@ def chats_read(id: str, limit: int, system: bool, context: int, start: int | Non
 
     from ..tools.chats import read_chat  # fmt: skip
 
-    if not (get_logs_dir() / id / "conversation.jsonl").exists():
+    if (
+        not _is_valid_id(id)
+        or not (get_logs_dir() / id / "conversation.jsonl").exists()
+    ):
         click.echo(f"Conversation '{id}' not found.")
         raise SystemExit(1)
 
@@ -211,11 +227,11 @@ def chats_rename(id: str, name: str):
     """
     from ..logmanager import rename_conversation  # fmt: skip
 
-    if rename_conversation(id, name):
-        print(f"Renamed '{id}' to '{name}'")
-    else:
+    if not _is_valid_id(id) or not rename_conversation(id, name):
         print(f"Chat '{id}' not found")
         sys.exit(1)
+    else:
+        print(f"Renamed '{id}' to '{name}'")
 
 
 @chats.command("send")
@@ -227,6 +243,9 @@ def chats_send(id: str, message: tuple[str, ...]):
     This is useful when another gptme process is busy in the same chat and you
     already know the next instruction you want to send.
     """
+    if not _is_valid_id(id):
+        click.echo(f"Chat '{id}' not found")
+        raise SystemExit(1)
     logdir = get_logs_dir() / id
     if not logdir.exists():
         click.echo(f"Chat '{id}' not found")

--- a/gptme/cli/cmd_chats.py
+++ b/gptme/cli/cmd_chats.py
@@ -25,7 +25,7 @@ def _is_valid_id(id: str) -> bool:
     These would otherwise raise ``OSError: [Errno 36] File name too long``
     deep inside ``Path.exists()`` or ``os.stat()``.
     """
-    return len(id.encode()) <= _MAX_ID_LEN and "/" not in id and id != ".."
+    return len(id.encode()) <= _MAX_ID_LEN and "/" not in id and id not in {".", ".."}
 
 
 def _ensure_tools():

--- a/tests/test_util_cli.py
+++ b/tests/test_util_cli.py
@@ -169,6 +169,21 @@ def test_chats_read_too_long_id_exits_cleanly(tmp_path, monkeypatch):
     assert "OSError" not in result.output
 
 
+def test_chats_read_dot_id_exits_cleanly(tmp_path, monkeypatch):
+    """``chats read .`` must exit non-zero without accessing the logs root directory.
+
+    A single-dot ID resolves to the logs root directory itself, which can exist and
+    cause ``chats_send``/``chats_export`` to operate on the whole log tree.
+    """
+    monkeypatch.setenv("GPTME_LOGS_HOME", str(tmp_path))
+    runner = CliRunner()
+
+    result = runner.invoke(main, ["chats", "read", "."])
+    assert result.exit_code != 0
+    assert "not found" in result.output
+    assert "Traceback" not in result.output
+
+
 def test_chats_read_finds_conversation_beyond_recent_limit(tmp_path, monkeypatch):
     """`chats read` must find any conversation, not just the 20 most recent.
 

--- a/tests/test_util_cli.py
+++ b/tests/test_util_cli.py
@@ -152,6 +152,23 @@ def test_chats_read_nonexistent_exits_nonzero(tmp_path, monkeypatch):
     assert "Traceback" not in result.output
 
 
+def test_chats_read_too_long_id_exits_cleanly(tmp_path, monkeypatch):
+    """``chats read`` with a >255-byte ID must exit non-zero without an OSError traceback.
+
+    Passing a 300-character ID previously caused ``OSError: [Errno 36] File name too long``
+    to bubble up unhandled from ``Path.exists()`` inside the command.
+    """
+    monkeypatch.setenv("GPTME_LOGS_HOME", str(tmp_path))
+    runner = CliRunner()
+
+    long_id = "a" * 300
+    result = runner.invoke(main, ["chats", "read", long_id])
+    assert result.exit_code != 0
+    assert "not found" in result.output
+    assert "Traceback" not in result.output
+    assert "OSError" not in result.output
+
+
 def test_chats_read_finds_conversation_beyond_recent_limit(tmp_path, monkeypatch):
     """`chats read` must find any conversation, not just the 20 most recent.
 


### PR DESCRIPTION
## Summary

- `chats read`, `chats rename`, and `chats send` passed the raw conversation ID straight into `Path.exists()` without length validation
- IDs longer than 255 bytes (Linux `NAME_MAX`) caused an unhandled `OSError: [Errno 36] File name too long` to bubble up from inside `Path.exists()`
- Added `_MAX_ID_LEN = 255` constant and `_is_valid_id()` helper; applied as a guard before any filesystem access in the three affected commands
- Also guards against `/` and `..` path-traversal sequences
- The server already had equivalent validation (PR #2498); this brings the CLI in sync

## Test plan

- [ ] `test_chats_read_too_long_id_exits_cleanly` — new regression test: 300-char ID exits non-zero with "not found", no traceback
- [ ] `test_chats_read_nonexistent_exits_nonzero` — existing test still passes
- [ ] `test_chats_list_negative_limit` — existing test still passes
- [ ] CI green