### PR TITLE
fix(webui): gate useTasksQuery on connection state

### DIFF
--- a/webui/src/stores/tasks.ts
+++ b/webui/src/stores/tasks.ts
@@ -1,7 +1,9 @@
 import React from 'react';
 import { observable, mergeIntoObservable } from '@legendapp/state';
+import { use$ } from '@legendapp/state/react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { taskApi } from '@/utils/taskApi';
+import { useApi } from '@/contexts/ApiContext';
 import type { Task, CreateTaskRequest } from '@/types/task';
 
 export interface TaskState {
@@ -69,9 +71,12 @@ export function updateTasks(newTasks: Task[]) {
 
 // Query hooks
 export function useTasksQuery() {
+  const { isConnected$ } = useApi();
+  const isConnected = use$(isConnected$);
   const query = useQuery({
     queryKey: ['tasks', { includeArchived: showArchived$.get() }],
     queryFn: () => taskApi.listTasks(showArchived$.get()),
+    enabled: isConnected,
   });
 
   // Update store when data changes


### PR DESCRIPTION
## Summary

`useTasksQuery()` ran unconditionally — unlike its sibling `useTaskQuery()`, it had no `enabled` gate. On a disconnected first visit to the hosted webui (no local gptme server), this fired `GET /api/v2/tasks` (with react-query's default 3 retries), producing repeated failed requests + CORS/network console errors before any connection exists.

This gates the query on connection state, mirroring `useTaskQuery`'s `enabled` pattern and the existing `HistoryView` / `ExternalSessionsView` gates.

## Change

```ts
export function useTasksQuery() {
  const { isConnected$ } = useApi();
  const isConnected = use$(isConnected$);
  const query = useQuery({
    queryKey: ['tasks', { includeArchived: showArchived$.get() }],
    queryFn: () => taskApi.listTasks(showArchived$.get()),
    enabled: isConnected,   // <-- gate
  });
```

When `enabled` transitions false→true (connection established), react-query runs the query automatically, so connected behavior is unchanged. Consumers (`MainLayout`, `History`, `ExternalSessions`) already default `data` to `[]`, so disconnected rendering is unaffected.

## Verification

- `npm run typecheck` — clean
- `npx eslint src/stores/tasks.ts` — clean
- No direct unit tests exist for the tasks store; change is a one-line behavioral gate matching established patterns.

Closes gptme/gptme#2501