### PR TITLE
fix: prevent hang on empty query in chats search

### DIFF
--- a/gptme/cli/cmd_chats.py
+++ b/gptme/cli/cmd_chats.py
@@ -134,8 +134,7 @@ def chats_search(
 ):
     """Search conversation logs."""
     if not query.strip():
-        click.echo("Error: search query cannot be empty.", err=True)
-        raise SystemExit(1)
+        raise click.UsageError("search query cannot be empty")
     _ensure_tools()
 
     if output_json:

--- a/gptme/cli/cmd_chats.py
+++ b/gptme/cli/cmd_chats.py
@@ -133,6 +133,9 @@ def chats_search(
     matches: int,
 ):
     """Search conversation logs."""
+    if not query.strip():
+        click.echo("Error: search query cannot be empty.", err=True)
+        raise SystemExit(1)
     _ensure_tools()
 
     if output_json:

--- a/gptme/tools/chats.py
+++ b/gptme/tools/chats.py
@@ -22,6 +22,8 @@ def _get_matching_messages(
     log_manager, query: str, system=False
 ) -> list[tuple[int, Message]]:
     """Get messages matching the query."""
+    if not query.strip():
+        return []
     return [
         (i, msg)
         for i, msg in enumerate(log_manager.log)
@@ -86,6 +88,10 @@ def search_chats(
         context_size (int): Number of characters to show around each match.
         max_matches (int): Maximum number of matches to show per conversation.
     """
+    if not query.strip():
+        print("Error: search query cannot be empty.")
+        return
+
     from ..logmanager import LogManager, list_conversations  # fmt: skip
 
     results: list[dict] = []

--- a/gptme/tools/chats.py
+++ b/gptme/tools/chats.py
@@ -6,6 +6,7 @@ import json as json_mod
 import logging
 import re
 import statistics
+import sys
 import textwrap
 from collections import Counter
 from datetime import datetime, timedelta, timezone
@@ -89,7 +90,7 @@ def search_chats(
         max_matches (int): Maximum number of matches to show per conversation.
     """
     if not query.strip():
-        print("Error: search query cannot be empty.")
+        print("Error: search query cannot be empty.", file=sys.stderr)
         return
 
     from ..logmanager import LogManager, list_conversations  # fmt: skip


### PR DESCRIPTION
## Summary

`gptme-util chats search ""` (empty query) iterates over all 190+ conversations looking for empty-string matches, creating a very slow, hang-like experience.

## Fix

Added an early-return guard in both layers:
- `search_chats()` in `gptme/tools/chats.py` — returns immediately with an error message
- `chats_search()` CLI command in `gptme/cli/cmd_chats.py` — prints error to stderr and returns exit code 1

## Testing

- All existing chat tests pass (78 tests)