### PR TITLE
fix(cli): reject directory passed to 'tokens count --file'

### DIFF
--- a/gptme/cli/util.py
+++ b/gptme/cli/util.py
@@ -247,7 +247,10 @@ def tokens():
 @click.argument("text", required=False)
 @click.option("-m", "--model", default="gpt-4", help="Model to use for token counting.")
 @click.option(
-    "-f", "--file", type=click.Path(exists=True), help="File to count tokens in."
+    "-f",
+    "--file",
+    type=click.Path(exists=True, dir_okay=False),
+    help="File to count tokens in.",
 )
 def tokens_count(text: str | None, model: str, file: str | None):
     """Count tokens in text or file."""

--- a/tests/test_util_cli.py
+++ b/tests/test_util_cli.py
@@ -51,6 +51,13 @@ def test_tokens_count(tmp_path):
     count = int(result.output.split(": ", 1)[1].strip())
     assert count > 1
 
+    # Test directory passed to --file: should fail cleanly, not raise
+    # IsADirectoryError as an uncaught traceback.
+    result = runner.invoke(main, ["tokens", "count", "-f", str(tmp_path)])
+    assert result.exit_code == 2
+    assert result.exception is None or isinstance(result.exception, SystemExit)
+    assert "is a directory" in result.output.lower()
+
 
 def test_chats_list(tmp_path, mocker):
     """Test the chats list command."""


### PR DESCRIPTION
## Problem

Passing a directory to `gptme-util tokens count -f/--file` crashed with an uncaught traceback:

```
$ gptme-util tokens count --file /tmp --model gpt-4
...
  File "gptme/cli/util.py", line 258, in tokens_count
    with open(file) as f:
IsADirectoryError: [Errno 21] Is a directory: '/tmp'
```

The nonexistent-file case was already handled cleanly (Click `exists=True` → exit 2), but directories slipped through to `open()`.

## Fix

Add `dir_okay=False` to the `click.Path` type so directories are rejected before reaching `open()`, with a clean message consistent with the nonexistent-file path:

```
Error: Invalid value for '-f' / '--file': File '/tmp' is a directory.
```
(exit 2)

## Test

Extends `test_tokens_count` with a directory-input case asserting exit 2 and no uncaught exception.

Found via CLI dogfooding sweep (feeding bad input to the non-LLM CLI surface).