### PR TITLE
fix(server): validate message content type in PUT conversation

### DIFF
--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -493,6 +493,8 @@ def api_conversation_put(conversation_id: str):
             return flask.jsonify(
                 {"error": "Message missing required 'content' field"}
             ), 400
+        if not isinstance(msg["content"], str):
+            return flask.jsonify({"error": "Message 'content' must be a string"}), 400
         if "timestamp" in msg:
             try:
                 ts: datetime = isoparse(msg["timestamp"])

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -1654,15 +1654,18 @@ def test_v2_create_conversation_missing_content(client: FlaskClient):
     assert "content" in data["error"].lower()
 
 
-def test_v2_create_conversation_non_string_content(client: FlaskClient):
+@pytest.mark.parametrize("bad_content", [12345, None, True])
+def test_v2_create_conversation_non_string_content(
+    client: FlaskClient, bad_content: object
+):
     """Creating a conversation with non-string message content returns 400 (not 500)."""
     import uuid
 
-    conv_id = f"test-int-content-{uuid.uuid4().hex[:8]}"
+    conv_id = f"test-non-str-content-{uuid.uuid4().hex[:8]}"
     response = client.put(
         f"/api/v2/conversations/{conv_id}",
         json={
-            "messages": [{"role": "user", "content": 12345}],
+            "messages": [{"role": "user", "content": bad_content}],
         },
     )
     assert response.status_code == 400

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -1654,6 +1654,23 @@ def test_v2_create_conversation_missing_content(client: FlaskClient):
     assert "content" in data["error"].lower()
 
 
+def test_v2_create_conversation_non_string_content(client: FlaskClient):
+    """Creating a conversation with non-string message content returns 400 (not 500)."""
+    import uuid
+
+    conv_id = f"test-int-content-{uuid.uuid4().hex[:8]}"
+    response = client.put(
+        f"/api/v2/conversations/{conv_id}",
+        json={
+            "messages": [{"role": "user", "content": 12345}],
+        },
+    )
+    assert response.status_code == 400
+    data = response.get_json()
+    assert data is not None
+    assert "content" in data["error"].lower()
+
+
 def test_v2_create_conversation_invalid_timestamp(client: FlaskClient):
     """Creating a conversation with an invalid timestamp returns 400."""
     import uuid


### PR DESCRIPTION
## Summary

- `PUT /api/v2/conversations/<id>` validated that `content` existed but not that it was a string — integer/null/boolean values were silently accepted and stored in the conversation log
- `POST /api/v2/conversations/<id>` already correctly rejects non-string content with a 400; this PR brings PUT into parity
- Adds a regression test (`test_v2_create_conversation_non_string_content`)

**Repro before fix:**
```bash
curl -X PUT http://localhost:9700/api/v2/conversations/bad-conv \
  -H "Content-Type: application/json" \
  -d '{"messages": [{"role": "user", "content": 12345}]}'
# → 200 OK, integer stored in log
```

**After fix:** → 400 `{"error": "Message 'content' must be a string"}`

Found via dogfood sweep: probing the server HTTP API surface with malformed/edge input.

## Test plan

- [x] New test `test_v2_create_conversation_non_string_content` covers integer content → 400
- [x] Existing test `test_v2_create_conversation_missing_content` still passes
- [x] Full `create_conversation` test cluster passes (18 tests)
- [x] Pre-commit hooks pass