### PR TITLE
fix(server): validate transcript turn text type to prevent 500 on non-string input

### DIFF
--- a/gptme/server/api_v2_sessions.py
+++ b/gptme/server/api_v2_sessions.py
@@ -886,6 +886,9 @@ def api_conversation_transcript(conversation_id: str):
     for i, turn in enumerate(turns):
         if not isinstance(turn, dict):
             return flask.jsonify({"error": f"turns[{i}] must be an object"}), 400
+        text = turn.get("text")
+        if text is not None and not isinstance(text, str):
+            return flask.jsonify({"error": f"turns[{i}].text must be a string"}), 400
     if not call_metadata or not isinstance(call_metadata, dict):
         return flask.jsonify({"error": "call_metadata (object) is required"}), 400
 
@@ -911,7 +914,7 @@ def api_conversation_transcript(conversation_id: str):
         # Append each turn as a Message
         for turn in turns:
             role = turn.get("role")
-            text = turn.get("text", "").strip()
+            text = (turn.get("text") or "").strip()
 
             # Skip empty/whitespace-only turns
             if not text:

--- a/tests/test_server_v2_sessions.py
+++ b/tests/test_server_v2_sessions.py
@@ -887,3 +887,63 @@ class TestConversationGetSessionState:
         assert response.status_code == 200
         data = response.get_json()
         assert "session" not in data
+
+
+class TestTranscriptEndpointInputValidation:
+    """Test that /transcript rejects invalid turn field types with 400, not 500."""
+
+    @pytest.mark.parametrize(
+        "bad_text",
+        [12345, True, {"nested": "obj"}, [1, 2, 3]],
+        ids=["integer", "bool", "object", "array"],
+    )
+    def test_transcript_non_string_text_returns_400(
+        self, bad_text, client: FlaskClient
+    ):
+        """turns[i].text must be a string; non-strings must return 400, not 500."""
+        convname = f"test-transcript-{uuid.uuid4().hex[:8]}"
+        response = client.post(
+            f"/api/v2/conversations/{convname}/transcript",
+            json={
+                "turns": [{"role": "user", "text": bad_text}],
+                "call_metadata": {"call_sid": "CA-test-text-type"},
+            },
+        )
+        assert response.status_code == 400
+        data = response.get_json()
+        assert data is not None
+        assert "text" in data["error"]
+
+    def test_transcript_null_text_is_skipped(self, client: FlaskClient):
+        """turns with null text are silently skipped (treated as empty)."""
+        convname = f"test-transcript-{uuid.uuid4().hex[:8]}"
+        response = client.post(
+            f"/api/v2/conversations/{convname}/transcript",
+            json={
+                "turns": [
+                    {"role": "user", "text": None},
+                    {"role": "user", "text": "hello"},
+                ],
+                "call_metadata": {"call_sid": "CA-test-null-text"},
+            },
+        )
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data["messages_added"] == 1
+
+    def test_transcript_valid_turns_succeed(self, client: FlaskClient):
+        """Baseline: valid turns with string text return 200."""
+        convname = f"test-transcript-{uuid.uuid4().hex[:8]}"
+        response = client.post(
+            f"/api/v2/conversations/{convname}/transcript",
+            json={
+                "turns": [
+                    {"role": "user", "text": "hello"},
+                    {"role": "assistant", "text": "hi there"},
+                ],
+                "call_metadata": {"call_sid": "CA-test-valid"},
+            },
+        )
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data["messages_added"] == 2


### PR DESCRIPTION
## Summary

- Sending a non-string value for `turns[i].text` (integer, null, bool, object, array) in `POST /api/v2/conversations/<id>/transcript` caused an unhandled `AttributeError` from `.strip()`, returning HTTP 500 instead of a clean 400
- Integer/null text in transcript turns is the same bug class as the content-type validation gap fixed in #2511 (PUT conversation non-string content)

## Changes

- `gptme/server/api_v2_sessions.py`: Add per-turn `text` type validation in the pre-processing loop; also guard the processing step with `(turn.get("text") or "").strip()` so null/missing text is handled safely without crashing
- `tests/test_server_v2_sessions.py`: Add `TestTranscriptEndpointInputValidation` with 6 tests covering integer, bool, object, array (→ 400), null (→ skipped), and valid string (→ 200)

## Test plan

- [x] `test_transcript_non_string_text_returns_400[integer]` — PASSED
- [x] `test_transcript_non_string_text_returns_400[bool]` — PASSED
- [x] `test_transcript_non_string_text_returns_400[object]` — PASSED
- [x] `test_transcript_non_string_text_returns_400[array]` — PASSED
- [x] `test_transcript_null_text_is_skipped` — PASSED
- [x] `test_transcript_valid_turns_succeed` — PASSED
- [x] Full `test_server_v2_sessions.py` suite: 78/78 passed