### PR TITLE
fix(webui): gate useModels on connection state

### DIFF
--- a/webui/src/hooks/useModels.ts
+++ b/webui/src/hooks/useModels.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { use$ } from '@legendapp/state/react';
 import { useApi } from '@/contexts/ApiContext';
 import { buildModelsFetchError } from '@/utils/modelsError';
 
@@ -22,7 +23,8 @@ export interface ModelsResponse {
 }
 
 export function useModels() {
-  const { api } = useApi();
+  const { api, isConnected$ } = useApi();
+  const isConnected = use$(isConnected$);
   const [models, setModels] = useState<ModelInfo[]>([]);
   const [defaultModel, setDefaultModel] = useState<string | null>(null);
   const [recommendedModels, setRecommendedModels] = useState<string[]>([]);
@@ -30,6 +32,8 @@ export function useModels() {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
+    if (!isConnected) return;
+
     const fetchModels = async () => {
       try {
         setIsLoading(true);
@@ -68,7 +72,7 @@ export function useModels() {
     };
 
     fetchModels();
-  }, [api.baseUrl, api.authHeader]);
+  }, [api.baseUrl, api.authHeader, isConnected]);
 
   const availableModels = models.map((model) => model.id);
 


### PR DESCRIPTION
## Problem

`useModels` fetched from `/api/v2/models` unconditionally via a `useEffect`, firing even when disconnected from the server. On a hosted first visit (chat.gptme.org with no local gptme server), this produces CORS/PNA console errors:

```
[error] Access to fetch at 'http://127.0.0.1:5700/api/v2/models' from origin 'https://chat.gptme.org' 
        has been blocked by CORS policy: Permission was denied for this request to access the `loopback` address space.
[error] Failed to fetch models: TypeError: Failed to fetch
```

This fires **after** the ApiContext has already logged `CORS/PNA failure — stopping auto-connect`, so the app knows it's disconnected but `useModels` still tries.

## Fix

Gate the fetch on `isConnected` (same pattern as the `useTasksQuery` fix in #2501):

```typescript
const { api, isConnected$ } = useApi();
const isConnected = use$(isConnected$);

useEffect(() => {
  if (!isConnected) return;  // ← new gate
  // ... fetch models ...
}, [api.baseUrl, api.authHeader, isConnected]);
```

## Verification

Live reproduction at chat.gptme.org (disconnected first visit) — before this fix the console shows `Failed to fetch models` errors. TypeScript passes clean (`tsc --noEmit`).

## Related

- Companion fix: #2501 (`useTasksQuery` connection gate, same root cause)
- Callers (`ChatInput`, `ModelPicker`, `ConversationContent`, `ServerApiKeySettings`, `ServerDefaultModelSettings`) will silently skip the fetch when disconnected — correct behavior