### PR TITLE
fix(webui): reset isLoading to false when disconnected in useModels

### DIFF
--- a/webui/src/hooks/useModels.ts
+++ b/webui/src/hooks/useModels.ts
@@ -32,7 +32,10 @@ export function useModels() {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    if (!isConnected) return;
+    if (!isConnected) {
+      setIsLoading(false);
+      return;
+    }
 
     const fetchModels = async () => {
       try {


### PR DESCRIPTION
## Problem

Follow-up to #2513. That PR correctly gated the fetch on `isConnected`, but the early return left `isLoading` stuck at `true` for the disconnected case — spotted by Greptile review on that PR.

`isLoading` is initialized to `true` and only reset inside `fetchModels`'s `finally` block. The early return skips that block entirely, so on a disconnected first visit components like `ServerApiKeySettings` stay permanently locked in "Loading models…" state.

## Fix

Add `setIsLoading(false)` before the early return:

```typescript
if (!isConnected) {
  setIsLoading(false);  // ← new
  return;
}
```

## Related

- Parent fix: #2513 (connection gate)
- Greptile review comment that caught this: https://github.com/gptme/gptme/pull/2513#issuecomment