### PR TITLE
fix(server): validate PUT conversation body and messages types

### DIFF
--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -457,6 +457,8 @@ def api_conversation_put(conversation_id: str):
     logdir = get_logs_dir() / conversation_id
 
     req_json = flask.request.json or {}
+    if not isinstance(req_json, dict):
+        return flask.jsonify({"error": "JSON body must be an object"}), 400
 
     # Validate auto_confirm type before any side effects (CWE-20: truthy coercion).
     # "false" (string) is truthy in Python — must reject non-bool/int values.
@@ -476,10 +478,15 @@ def api_conversation_put(conversation_id: str):
     # Validate all messages before creating any side effects (directories).
     # This prevents orphaned directories when validation fails: if logdir.mkdir()
     # runs before a 400 is returned, the same conversation_id gets a 409 on retry.
+    messages_raw = req_json.get("messages", [])
+    if not isinstance(messages_raw, list):
+        return flask.jsonify({"error": "'messages' must be a list"}), 400
     _RoleType = Literal["system", "user", "assistant"]
     valid_roles = ("system", "user", "assistant")
     validated_msgs: list[tuple[_RoleType, str, datetime]] = []
-    for msg in req_json.get("messages", []):
+    for msg in messages_raw:
+        if not isinstance(msg, dict):
+            return flask.jsonify({"error": "Each message must be an object"}), 400
         if msg.get("role") not in valid_roles:
             return (
                 flask.jsonify(

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -456,9 +456,10 @@ def api_conversation_put(conversation_id: str):
 
     logdir = get_logs_dir() / conversation_id
 
-    req_json = flask.request.json or {}
-    if not isinstance(req_json, dict):
+    req_json = flask.request.json
+    if req_json is not None and not isinstance(req_json, dict):
         return flask.jsonify({"error": "JSON body must be an object"}), 400
+    req_json = req_json or {}
 
     # Validate auto_confirm type before any side effects (CWE-20: truthy coercion).
     # "false" (string) is truthy in Python — must reject non-bool/int values.

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -1710,6 +1710,55 @@ def test_v2_create_conversation_non_string_timestamp(client: FlaskClient):
     assert "timestamp" in data["error"].lower()
 
 
+@pytest.mark.parametrize("body", ["string", 42])
+def test_v2_create_conversation_non_object_body(client: FlaskClient, body: object):
+    """PUT /conversations/<id> with a non-object JSON body returns 400 (not 500)."""
+    import uuid
+
+    conv_id = f"test-non-object-body-{uuid.uuid4().hex[:8]}"
+    response = client.put(
+        f"/api/v2/conversations/{conv_id}",
+        json=body,
+    )
+    assert response.status_code == 400
+    data = response.get_json()
+    assert data is not None
+    assert "object" in data["error"].lower()
+
+
+@pytest.mark.parametrize("messages", ["not-a-list", 42, {"key": "val"}])
+def test_v2_create_conversation_messages_not_list(
+    client: FlaskClient, messages: object
+):
+    """PUT /conversations/<id> with non-list 'messages' returns 400 (not 500)."""
+    import uuid
+
+    conv_id = f"test-msgs-not-list-{uuid.uuid4().hex[:8]}"
+    response = client.put(
+        f"/api/v2/conversations/{conv_id}",
+        json={"messages": messages},
+    )
+    assert response.status_code == 400
+    data = response.get_json()
+    assert data is not None
+    assert "messages" in data["error"].lower()
+
+
+def test_v2_create_conversation_message_not_object(client: FlaskClient):
+    """PUT /conversations/<id> with a non-object message item returns 400 (not 500)."""
+    import uuid
+
+    conv_id = f"test-msg-not-obj-{uuid.uuid4().hex[:8]}"
+    response = client.put(
+        f"/api/v2/conversations/{conv_id}",
+        json={"messages": [1, 2, 3]},
+    )
+    assert response.status_code == 400
+    data = response.get_json()
+    assert data is not None
+    assert "object" in data["error"].lower()
+
+
 @pytest.mark.parametrize("body", [[], [1, 2, 3], "string", 42])
 def test_v2_tasks_put_rejects_non_object_json(client: FlaskClient, body: object):
     """Task PUT should reject non-object JSON bodies with 400."""

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -1710,7 +1710,7 @@ def test_v2_create_conversation_non_string_timestamp(client: FlaskClient):
     assert "timestamp" in data["error"].lower()
 
 
-@pytest.mark.parametrize("body", ["string", 42])
+@pytest.mark.parametrize("body", [[], "string", 42])
 def test_v2_create_conversation_non_object_body(client: FlaskClient, body: object):
     """PUT /conversations/<id> with a non-object JSON body returns 400 (not 500)."""
     import uuid


### PR DESCRIPTION
## Summary

Fixes two 500 → 400 regressions in `PUT /api/v2/conversations/<id>` found during dogfood bad-input sweep.

**Bug 1**: When the request body is a JSON string or number (not an object), `flask.request.json` returns the parsed value directly. `req_json = flask.request.json or {}` then sets `req_json` to that string (it's truthy), causing `req_json.get(...)` to crash with `AttributeError` → 500.

**Bug 2**: When `messages` is a non-list value (e.g. `"foo"`, `42`), the `for msg in req_json.get("messages", [])` loop iterates over characters (for a string), each of which is not a dict, crashing on `msg.get(...)` → 500.

**Bug 3** (defensive): when `messages` is a list but contains non-dict items (e.g. `[1, 2, 3]`), `msg.get(...)` crashes → 500.

### Fixes

Added three type-guards before any side effects (directory creation, config write):
1. `isinstance(req_json, dict)` — rejects strings, numbers, arrays
2. `isinstance(messages_raw, list)` — rejects non-list `messages` field
3. `isinstance(msg, dict)` per item — rejects non-object message items

### Regression tests

6 new parametrized tests in `test_server_v2.py`:
- `test_v2_create_conversation_non_object_body` (body = `"string"`, `42`)
- `test_v2_create_conversation_messages_not_list` (messages = `"not-a-list"`, `42`, `{...}`)
- `test_v2_create_conversation_message_not_object` (messages = `[1, 2, 3]`)

## Test plan

- [x] `uv run pytest tests/test_server_v2.py::test_v2_create_conversation_non_object_body tests/test_server_v2.py::test_v2_create_conversation_messages_not_list tests/test_server_v2.py::test_v2_create_conversation_message_not_object -v` — 6/6 pass
- [x] Live server probe: `curl -X PUT .../conversations/X -d '"hello"'` → 400 (was 500)
- [x] Live server probe: `curl -X PUT .../conversations/X -d '{"messages":"foo"}'` → 400 (was 500)