### PR TITLE
fix(cli): reject unsafe conversation names

### DIFF
--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -120,10 +120,10 @@ def _conversation_name_error(value: str) -> str | None:
         return "conversation name cannot be empty."
     if len(value.encode()) > _MAX_CONVERSATION_NAME_BYTES:
         return "conversation name too long."
-    if "/" in value or "\\" in value or ".." in value:
+    if value == "." or "/" in value or "\\" in value or ".." in value:
         return (
             "conversation name must be a single path component "
-            "(no '/', '\\\\', or '..')."
+            "(no '.', '/', '\\\\', or '..')."
         )
     return None
 

--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -46,6 +46,7 @@ logger = logging.getLogger(__name__)
 
 
 script_path = Path(os.path.realpath(__file__))
+_MAX_CONVERSATION_NAME_BYTES = 255  # Linux NAME_MAX for a single path component
 
 
 class CommaSeparatedChoice(click.ParamType):
@@ -113,6 +114,33 @@ class WorkspacePath(click.ParamType):
         return str(path.resolve())
 
 
+def _conversation_name_error(value: str) -> str | None:
+    """Return a validation error for unsafe conversation names, if any."""
+    if not value:
+        return "conversation name cannot be empty."
+    if len(value.encode()) > _MAX_CONVERSATION_NAME_BYTES:
+        return "conversation name too long."
+    if "/" in value or "\\" in value or ".." in value:
+        return (
+            "conversation name must be a single path component "
+            "(no '/', '\\\\', or '..')."
+        )
+    return None
+
+
+class ConversationName(click.ParamType):
+    """Click type for conversation names stored under the logs directory."""
+
+    name = "TEXT"
+
+    def convert(self, value, param, ctx):
+        if value == "random":
+            return value
+        if error := _conversation_name_error(value):
+            self.fail(error, param, ctx)
+        return value
+
+
 commands_help = "\n".join(_gen_help(incl_langtags=False))
 _available_tools = sorted(
     tool.name for tool in get_available_tools(include_mcp=False) if tool.is_available
@@ -169,6 +197,7 @@ Run 'gptme-util --help' for all utility commands."""
 @click.option(
     "--name",
     default="random",
+    type=ConversationName(),
     help="Conversation ID (used to resume). Defaults to a random name.",
 )
 @click.option(
@@ -898,6 +927,9 @@ def get_logdir(logdir: Path | str | Literal["random"]) -> Path:
     if logdir == "random":
         logdir = logs_dir / generate_conversation_id(name="random", logs_dir=logs_dir)
     elif isinstance(logdir, str):
+        error = _conversation_name_error(logdir)
+        if error:
+            raise ValueError(error)
         logdir = logs_dir / logdir
 
     logdir.mkdir(parents=True, exist_ok=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -71,10 +71,11 @@ def test_version(runner: CliRunner):
     assert "gptme" in result.output
 
 
-def test_name_rejects_path_traversal(runner: CliRunner):
+@pytest.mark.parametrize("bad_name", ["../bad-name", ".", "..", "foo/bar", "foo\\bar"])
+def test_name_rejects_path_traversal(bad_name: str, runner: CliRunner):
     result = runner.invoke(
         cli.main,
-        ["--name", "../bad-name", "--non-interactive", "hello"],
+        ["--name", bad_name, "--non-interactive", "hello"],
     )
     assert result.exit_code == 2
     assert "conversation name must be a single path component" in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -71,6 +71,15 @@ def test_version(runner: CliRunner):
     assert "gptme" in result.output
 
 
+def test_name_rejects_path_traversal(runner: CliRunner):
+    result = runner.invoke(
+        cli.main,
+        ["--name", "../bad-name", "--non-interactive", "hello"],
+    )
+    assert result.exit_code == 2
+    assert "conversation name must be a single path component" in result.output
+
+
 def test_command_exit(args: list[str], runner: CliRunner):
     args.append("/exit")
     result = runner.invoke(cli.main, args)


### PR DESCRIPTION
## Summary
- reject `--name` values that are not a single safe path component
- keep a defense-in-depth validation in `get_logdir()`
- add a CLI regression test for `--name ../bad-name`

## Repro
```bash
uv run gptme -n --name ../bad-name "hello"
```
Before this change, the CLI fell through into logdir creation and died later with `Too many levels of symbolic links`.

## Verification
- `uv run gptme -n --name ../bad-name "hello"`
- `uv run python -m pytest tests/test_cli.py -k "test_name_rejects_path_traversal or test_help or test_version"`
