### PR TITLE
fix(mcp): deduplicate search_all results across registries

### DIFF
--- a/gptme/mcp/registry.py
+++ b/gptme/mcp/registry.py
@@ -193,14 +193,22 @@ class MCPRegistry:
 
         Args:
             query: Search query
-            limit: Maximum number of results per registry
+            limit: Maximum number of results total (deduplicated by name)
 
         Returns:
-            Combined list of MCPServerInfo objects from all registries
+            Combined, deduplicated list of MCPServerInfo objects from all registries
         """
-        results = []
-        results.extend(self.search_official_registry(query, limit))
-        results.extend(self.search_mcp_so(query, limit))
+        seen: set[str] = set()
+        results: list[MCPServerInfo] = []
+        for server in [
+            *self.search_official_registry(query, limit),
+            *self.search_mcp_so(query, limit),
+        ]:
+            if server.name not in seen:
+                seen.add(server.name)
+                results.append(server)
+                if len(results) >= limit:
+                    break
         return results
 
     def get_server_details(self, name: str) -> MCPServerInfo | None:

--- a/tests/test_mcp_discovery.py
+++ b/tests/test_mcp_discovery.py
@@ -89,6 +89,59 @@ def test_format_server_details():
     assert "[[mcp.servers]]" in result
 
 
+def test_mcp_registry_search_all_deduplication():
+    """search_all must not return the same server twice when it appears in both registries."""
+    registry = MCPRegistry()
+
+    duplicate = MCPServerInfo(
+        name="dup-server", description="Appears in both", registry="official"
+    )
+    official_results = [
+        duplicate,
+        MCPServerInfo(
+            name="only-official", description="Only in official", registry="official"
+        ),
+    ]
+    mcp_so_results = [
+        MCPServerInfo(
+            name="dup-server", description="Appears in both", registry="mcp.so"
+        ),
+        MCPServerInfo(
+            name="only-mcp-so", description="Only in mcp.so", registry="mcp.so"
+        ),
+    ]
+
+    with (
+        patch.object(
+            registry, "search_official_registry", return_value=official_results
+        ),
+        patch.object(registry, "search_mcp_so", return_value=mcp_so_results),
+    ):
+        results = registry.search_all("", limit=10)
+
+    names = [r.name for r in results]
+    assert names.count("dup-server") == 1, f"Duplicate found: {names}"
+    assert len(results) == 3
+
+
+def test_mcp_registry_search_all_respects_limit():
+    """search_all must not return more than `limit` results."""
+    registry = MCPRegistry()
+
+    many = [
+        MCPServerInfo(name=f"server-{i}", description="x", registry="official")
+        for i in range(8)
+    ]
+
+    with (
+        patch.object(registry, "search_official_registry", return_value=many[:5]),
+        patch.object(registry, "search_mcp_so", return_value=many[5:]),
+    ):
+        results = registry.search_all("", limit=4)
+
+    assert len(results) == 4
+
+
 @pytest.mark.slow
 def test_mcp_registry_search_all():
     """Test searching all registries (may fail if registries are down)."""


### PR DESCRIPTION
## Problem

`gptme-util mcp search ""` (and any empty query) returns duplicate entries because `MCPRegistry.search_all()` calls both `search_official_registry()` and `search_mcp_so()` and concatenates the results with no deduplication. A server appearing in both registries appears twice (or more) in the output.

Example output before fix:
```
1. **ac.inference.sh/mcp** (official)
2. **ac.inference.sh/mcp** (official)   ← duplicate
3. **ac.tandem/docs-mcp** (official)
4. **ac.tandem/docs-mcp** (official)    ← duplicate
5. **ac.tandem/docs-mcp** (official)    ← triplicate
```

Also, the `limit` parameter was documented as "per registry" but callers (e.g. `_cmd_mcp_search`) treat it as a total. After deduplication the limit now correctly bounds the total result count.

## Fix

Iterate results from both registries in priority order (official first), track seen names in a `set`, skip duplicates, and stop once `limit` unique results are collected.

## Tests

Two new unit tests (no network calls):
- `test_mcp_registry_search_all_deduplication`: a name appearing in both registries is returned exactly once
- `test_mcp_registry_search_all_respects_limit`: total results never exceed `limit` after deduplication

Found via dogfood testing of `gptme-util mcp search ""`.