### PR TITLE
fix(server): reject non-object v2 JSON bodies

### DIFF
--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -456,10 +456,11 @@ def api_conversation_put(conversation_id: str):
 
     logdir = get_logs_dir() / conversation_id
 
-    req_json = flask.request.json
-    if req_json is not None and not isinstance(req_json, dict):
+    req_json = request.get_json(silent=True)
+    if req_json is None:
+        return flask.jsonify({"error": "No JSON data provided"}), 400
+    if not isinstance(req_json, dict):
         return flask.jsonify({"error": "JSON body must be an object"}), 400
-    req_json = req_json or {}
 
     # Validate auto_confirm type before any side effects (CWE-20: truthy coercion).
     # "false" (string) is truthy in Python — must reject non-bool/int values.

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -458,7 +458,9 @@ def api_conversation_put(conversation_id: str):
 
     req_json = request.get_json(silent=True)
     if req_json is None:
-        return flask.jsonify({"error": "No JSON data provided"}), 400
+        if request.get_data(cache=True):
+            return flask.jsonify({"error": "No JSON data provided"}), 400
+        req_json = {}
     if not isinstance(req_json, dict):
         return flask.jsonify({"error": "JSON body must be an object"}), 400
 

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -606,9 +606,11 @@ def api_conversation_post(conversation_id: str):
     if error := _validate_conversation_id(conversation_id):
         return error
 
-    req_json = flask.request.json
-    if not req_json:
+    req_json = request.get_json(silent=True)
+    if req_json is None:
         return flask.jsonify({"error": "No JSON data provided"}), 400
+    if not isinstance(req_json, dict):
+        return flask.jsonify({"error": "JSON body must be an object"}), 400
 
     if "role" not in req_json or "content" not in req_json:
         return flask.jsonify({"error": "Missing required fields (role, content)"}), 400
@@ -1419,9 +1421,11 @@ def api_user():
 )
 def api_user_api_key():
     """Persist a provider API key into user config."""
-    req_json = flask.request.json
-    if not req_json:
+    req_json = request.get_json(silent=True)
+    if req_json is None:
         return flask.jsonify({"error": "No JSON data provided"}), 400
+    if not isinstance(req_json, dict):
+        return flask.jsonify({"error": "JSON body must be an object"}), 400
 
     provider = req_json.get("provider")
     api_key = req_json.get("api_key")
@@ -1484,9 +1488,11 @@ def api_user_api_key():
 )
 def api_user_default_model():
     """Persist the default model into user config."""
-    req_json = flask.request.json
-    if not req_json:
+    req_json = request.get_json(silent=True)
+    if req_json is None:
         return flask.jsonify({"error": "No JSON data provided"}), 400
+    if not isinstance(req_json, dict):
+        return flask.jsonify({"error": "JSON body must be an object"}), 400
 
     model = req_json.get("model")
     if not isinstance(model, str):

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -255,6 +255,20 @@ def test_v2_user_default_model_rejects_unqualified_model(client: FlaskClient):
     assert data == {"error": "model must be fully qualified as provider/model"}
 
 
+@pytest.mark.parametrize(
+    "endpoint", ["/api/v2/user/api-key", "/api/v2/user/default-model"]
+)
+@pytest.mark.parametrize("body", [[], [1, 2, 3], "string", 42])
+def test_v2_user_endpoints_reject_non_object_json(
+    client: FlaskClient, endpoint: str, body: object
+):
+    """User-setting endpoints should reject non-object JSON bodies with 400."""
+    response = client.post(endpoint, json=body)
+
+    assert response.status_code == 400
+    assert "object" in response.get_json()["error"].lower()
+
+
 class _FakeExternalSessionItem:
     def __init__(self):
         self.id = "abc123"
@@ -1426,6 +1440,20 @@ def test_v2_post_message_rejects_invalid_files_payload(
     )
     assert response.status_code == 400
     assert response.get_json() == {"error": "files must be a list of strings"}
+
+
+@pytest.mark.parametrize("body", [[], [1, 2, 3], "string", 42])
+def test_v2_post_message_rejects_non_object_json(client: FlaskClient, body: object):
+    """POST /conversations/<id> should reject non-object JSON bodies with 400."""
+    conversation_id = create_conversation(client)["conversation_id"]
+
+    response = client.post(
+        f"/api/v2/conversations/{conversation_id}",
+        json=body,
+    )
+
+    assert response.status_code == 400
+    assert "object" in response.get_json()["error"].lower()
 
 
 def test_v2_edit_message_preserves_uri_files(client: FlaskClient):

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -1738,7 +1738,7 @@ def test_v2_create_conversation_non_string_timestamp(client: FlaskClient):
     assert "timestamp" in data["error"].lower()
 
 
-@pytest.mark.parametrize("body", [[], "string", 42])
+@pytest.mark.parametrize("body", [[], [1, 2, 3], "string", 42])
 def test_v2_create_conversation_non_object_body(client: FlaskClient, body: object):
     """PUT /conversations/<id> with a non-object JSON body returns 400 (not 500)."""
     import uuid
@@ -1752,6 +1752,28 @@ def test_v2_create_conversation_non_object_body(client: FlaskClient, body: objec
     data = response.get_json()
     assert data is not None
     assert "object" in data["error"].lower()
+
+
+def test_v2_create_conversation_malformed_json_body(client: FlaskClient):
+    """PUT /conversations/<id> with malformed JSON returns 400 (not Werkzeug 400).
+
+    When get_json(silent=True) encounters malformed JSON (e.g. {bad:),
+    it returns None rather than raising BadRequest.  The endpoint should
+    surface a structured "No JSON data provided" error instead of the
+    raw Werkzeug 400 that flask.request.json would have produced.
+    """
+    import uuid
+
+    conv_id = f"test-malformed-json-{uuid.uuid4().hex[:8]}"
+    response = client.put(
+        f"/api/v2/conversations/{conv_id}",
+        data="{bad:",  # malformed JSON: unclosed brace
+        content_type="application/json",
+    )
+    assert response.status_code == 400
+    data = response.get_json()
+    assert data is not None
+    assert "No JSON data" in data["error"]
 
 
 @pytest.mark.parametrize("messages", ["not-a-list", 42, {"key": "val"}])

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -1754,6 +1754,20 @@ def test_v2_create_conversation_non_object_body(client: FlaskClient, body: objec
     assert "object" in data["error"].lower()
 
 
+def test_v2_create_conversation_empty_body_defaults(client: FlaskClient):
+    """PUT /conversations/<id> with no body creates a default conversation."""
+    import uuid
+
+    conv_id = f"test-empty-body-{uuid.uuid4().hex[:8]}"
+    response = client.put(f"/api/v2/conversations/{conv_id}")
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data is not None
+    assert data["conversation_id"] == conv_id
+    assert "session_id" in data
+
+
 def test_v2_create_conversation_malformed_json_body(client: FlaskClient):
     """PUT /conversations/<id> with malformed JSON returns 400 (not Werkzeug 400).
 


### PR DESCRIPTION
## Summary
- reject non-object JSON bodies before calling `.get(...)` in three v2 server endpoints
- return structured 400 responses instead of Flask 500s for malformed scalar/list request bodies
- add regression tests for the user settings endpoints and conversation message POST

## Repro
Before this patch these all raised 500s:
- `POST /api/v2/user/api-key` with `json=42`
- `POST /api/v2/user/default-model` with `json=42`
- `POST /api/v2/conversations/<id>` with `json=42`

After this patch they return:
- `400 {"error": "JSON body must be an object"}`

## Verification
- `/home/bob/gptme/.venv/bin/python -m pytest /tmp/gptme-948e/tests/test_server_v2.py -k 'test_v2_user_endpoints_reject_non_object_json or test_v2_post_message_rejects_non_object_json or test_v2_user_api_key_rejects_unknown_provider or test_v2_user_default_model_rejects_unqualified_model or test_v2_post_message_rejects_invalid_files_payload' -q`
