### PR TITLE
fix(cli): honor --name when resuming conversations

### DIFF
--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -30,7 +30,11 @@ from ..dirs import get_logs_dir
 from ..init import init_logging
 from ..llm import reply as llm_reply
 from ..llm.models import get_recommended_model
-from ..logmanager import ConversationMeta, get_user_conversations
+from ..logmanager import (
+    ConversationMeta,
+    get_conversation_by_id,
+    get_user_conversations,
+)
 from ..message import Message
 from ..profiles import get_profile
 from ..prompts import ContextMode, get_prompt
@@ -598,7 +602,10 @@ def main(
         return prompt_msgs
 
     if resume:
-        logdir = get_logdir_resume()
+        try:
+            logdir = get_logdir_resume(name)
+        except ValueError as e:
+            raise click.UsageError(str(e)) from e
         prompt_msgs = inject_stdin(prompt_msgs, piped_input)
     # don't run pick in tests/non-interactive mode, or if the user specifies a name
     elif (
@@ -936,7 +943,12 @@ def get_logdir(logdir: Path | str | Literal["random"]) -> Path:
     return logdir
 
 
-def get_logdir_resume() -> Path:
+def get_logdir_resume(name: str = "random") -> Path:
+    if name != "random":
+        if conv := get_conversation_by_id(name):
+            return Path(conv.path).parent
+        raise ValueError(f"No conversation named '{name}' to resume")
+
     if conv := next(get_user_conversations(), None):
         return Path(conv.path).parent
     raise ValueError("No previous conversations to resume")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -58,6 +58,15 @@ def runner():
         yield runner
 
 
+def _write_conversation(conv_id: str, content: str = "hello") -> Path:
+    conv_dir = cli.get_logs_dir() / conv_id
+    conv_dir.mkdir(parents=True, exist_ok=True)
+    (conv_dir / "conversation.jsonl").write_text(
+        f'{{"role":"user","content":"{content}"}}\n'
+    )
+    return conv_dir
+
+
 def test_help(runner: CliRunner):
     result = runner.invoke(cli.main, ["--help"])
     assert result.exit_code == 0
@@ -79,6 +88,30 @@ def test_name_rejects_path_traversal(bad_name: str, runner: CliRunner):
     )
     assert result.exit_code == 2
     assert "conversation name must be a single path component" in result.output
+
+
+def test_get_logdir_resume_named_conversation_prefers_explicit_name(runid: int):
+    target_dir = _write_conversation(f"resume-target-{runid}", content="target")
+    recent_dir = _write_conversation(f"resume-recent-{runid}", content="recent")
+    os.utime(target_dir / "conversation.jsonl", (1, 1))
+    os.utime(recent_dir / "conversation.jsonl", (2, 2))
+
+    assert cli.get_logdir_resume(f"resume-target-{runid}") == target_dir
+
+
+def test_resume_named_missing_conversation_does_not_fallback_to_latest(
+    runner: CliRunner, runid: int
+):
+    _write_conversation(f"resume-recent-{runid}", content="recent")
+    missing = f"resume-missing-{runid}"
+
+    result = runner.invoke(
+        cli.main,
+        ["--resume", "--name", missing, "--non-interactive"],
+    )
+
+    assert result.exit_code == 2
+    assert f"No conversation named '{missing}' to resume" in result.output
 
 
 def test_command_exit(args: list[str], runner: CliRunner):


### PR DESCRIPTION
## Summary
- honor `--name` when `--resume` is used instead of always loading the most recent conversation
- fail with a clean usage error when the named conversation does not exist
- add regression coverage for named resume selection and missing-name handling

## Repro
1. Have any existing conversation in your logs.
2. Run `gptme --resume --name does-not-exist --non-interactive`.
3. Before this patch, gptme ignored `--name` and resumed the most recent conversation.
4. After this patch, gptme exits with `No conversation named 'does-not-exist' to resume`.

## Verification
- `/home/bob/gptme/.venv/bin/python -m pytest tests/test_cli.py -k 'resume_named_missing_conversation_does_not_fallback_to_latest or get_logdir_resume_named_conversation_prefers_explicit_name or test_name_rejects_path_traversal' -q`
- `uv run ruff check gptme/cli/main.py tests/test_cli.py`
