### PR TITLE
fix(server): use get_json(silent=True) in tasks and agents endpoints

### DIFF
--- a/gptme/server/api_v2_agents.py
+++ b/gptme/server/api_v2_agents.py
@@ -54,8 +54,10 @@ agents_api = flask.Blueprint("agents_api", __name__)
 )
 def api_agents_put():
     """Create a new agent."""
-    req_json = flask.request.json
-    if req_json is None or not isinstance(req_json, dict):
+    req_json = flask.request.get_json(silent=True)
+    if req_json is None:
+        return flask.jsonify({"error": "No JSON data provided"}), 400
+    if not isinstance(req_json, dict):
         return flask.jsonify({"error": "Request body must be a JSON object"}), 400
 
     agent_name = req_json.get("name")

--- a/gptme/server/tasks_api.py
+++ b/gptme/server/tasks_api.py
@@ -714,9 +714,11 @@ def api_tasks_create():
     Create a new task with the specified content and configuration.
     A conversation will be automatically created for the task.
     """
-    req_json = flask.request.json
-    if not req_json or not isinstance(req_json, dict):
+    req_json = flask.request.get_json(silent=True)
+    if req_json is None:
         return flask.jsonify({"error": "No JSON data provided"}), 400
+    if not isinstance(req_json, dict):
+        return flask.jsonify({"error": "Request body must be a JSON object"}), 400
 
     if "content" not in req_json:
         return flask.jsonify({"error": "Missing required field: content"}), 400
@@ -830,8 +832,10 @@ def api_tasks_update(task_id: str):
     if not task:
         return flask.jsonify({"error": f"Task not found: {task_id}"}), 404
 
-    req_json = flask.request.json
-    if not req_json or not isinstance(req_json, dict):
+    req_json = flask.request.get_json(silent=True)
+    if req_json is None:
+        return flask.jsonify({"error": "No JSON data provided"}), 400
+    if not isinstance(req_json, dict):
         return flask.jsonify({"error": "Request body must be a JSON object"}), 400
 
     # Validate field types before applying

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -1993,3 +1993,73 @@ def test_v2_conversation_transcript_rejects_non_dict_turns(client: FlaskClient):
         assert response.status_code == 400
         data = response.get_json()
         assert "turns[" in data["error"] and "must be an object" in data["error"]
+
+
+# --- Tasks and Agents malformed-JSON regression tests ---
+
+
+@pytest.mark.parametrize("body", [[1, 2, 3], "string", 42])
+def test_v2_tasks_post_rejects_non_object_json(client: FlaskClient, body: object):
+    """Task POST should reject non-object JSON bodies with 400."""
+    response = client.post("/api/v2/tasks", json=body)
+    assert response.status_code == 400
+    assert "object" in response.get_json()["error"].lower()
+
+
+def test_v2_tasks_post_rejects_malformed_json(client: FlaskClient):
+    """Task POST should return 400 (not 400 Werkzeug HTML) on truly malformed JSON."""
+    response = client.post(
+        "/api/v2/tasks",
+        data=b"{bad:",
+        content_type="application/json",
+    )
+    assert response.status_code == 400
+    data = response.get_json()
+    assert data is not None, (
+        "Response must be valid JSON, not a raw Werkzeug error page"
+    )
+    assert "error" in data
+
+
+def test_v2_tasks_put_rejects_malformed_json(client: FlaskClient):
+    """Task PUT should return clean JSON 400 on truly malformed JSON body."""
+    create_resp = client.post(
+        "/api/v2/tasks", json={"content": "task for put malformed"}
+    )
+    assert create_resp.status_code == 201
+    task_id = create_resp.get_json()["id"]
+
+    response = client.put(
+        f"/api/v2/tasks/{task_id}",
+        data=b"{bad:",
+        content_type="application/json",
+    )
+    assert response.status_code == 400
+    data = response.get_json()
+    assert data is not None, (
+        "Response must be valid JSON, not a raw Werkzeug error page"
+    )
+    assert "error" in data
+
+
+@pytest.mark.parametrize("body", [[1, 2, 3], "string", 42])
+def test_v2_agents_put_rejects_non_object_json(client: FlaskClient, body: object):
+    """Agents PUT should reject non-object JSON bodies with 400."""
+    response = client.put("/api/v2/agents", json=body)
+    assert response.status_code == 400
+    assert "object" in response.get_json()["error"].lower()
+
+
+def test_v2_agents_put_rejects_malformed_json(client: FlaskClient):
+    """Agents PUT should return clean JSON 400 on truly malformed JSON body."""
+    response = client.put(
+        "/api/v2/agents",
+        data=b"{bad:",
+        content_type="application/json",
+    )
+    assert response.status_code == 400
+    data = response.get_json()
+    assert data is not None, (
+        "Response must be valid JSON, not a raw Werkzeug error page"
+    )
+    assert "error" in data


### PR DESCRIPTION
## Summary

`flask.request.json` raises a raw Werkzeug `BadRequest` (HTML 400) when the request body is malformed JSON (e.g. `{bad:`). The endpoints had clean JSON error handling, but it was only reachable for `None`/wrong-type bodies — parse failures still escaped as Werkzeug HTML errors.

Fixes three remaining call sites missed in #2517 and #2521:
- `tasks_api.py::api_tasks_create`
- `tasks_api.py::api_tasks_update`
- `api_v2_agents.py::api_agents_put`

Switch to `request.get_json(silent=True)`, matching the pattern used in the rest of `api_v2.py`.

## Test plan

- [x] `test_v2_tasks_post_rejects_non_object_json` — non-object valid JSON → 400
- [x] `test_v2_tasks_post_rejects_malformed_json` — `{bad:` body → clean JSON 400
- [x] `test_v2_tasks_put_rejects_malformed_json` — `{bad:` body → clean JSON 400
- [x] `test_v2_agents_put_rejects_non_object_json` — non-object valid JSON → 400
- [x] `test_v2_agents_put_rejects_malformed_json` — `{bad:` body → clean JSON 400
- [x] All 9 new tests green against fixed code; all 6 bug-specific tests fail against original