### PR TITLE
fix(cli): avoid blocking on idle stdin pipes

### DIFF
--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -52,7 +52,7 @@ logger = logging.getLogger(__name__)
 
 script_path = Path(os.path.realpath(__file__))
 _MAX_CONVERSATION_NAME_BYTES = 255  # Linux NAME_MAX for a single path component
-_STDIN_POLL_TIMEOUT = 0.1
+_STDIN_PIPE_GRACE_PERIOD = 1.0
 
 
 class CommaSeparatedChoice(click.ParamType):
@@ -958,10 +958,11 @@ def get_logdir_resume(name: str = "random") -> Path:
 
 def _read_stdin() -> str:
     # In automation, stdin is often an open pipe with no bytes pending yet.
-    # Wait briefly for readability so we don't block forever on read-until-EOF.
+    # Wait briefly for readability so we don't block forever on read-until-EOF,
+    # while still giving moderately slow pipeline producers time to write.
     try:
         readable, _, _ = select.select(
-            [sys.stdin.fileno()], [], [], _STDIN_POLL_TIMEOUT
+            [sys.stdin.fileno()], [], [], _STDIN_PIPE_GRACE_PERIOD
         )
     except (AttributeError, OSError, ValueError):
         readable = [True]

--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -4,6 +4,7 @@ import importlib
 import logging
 import os
 import pstats
+import select
 import signal
 import sys
 import traceback
@@ -51,6 +52,7 @@ logger = logging.getLogger(__name__)
 
 script_path = Path(os.path.realpath(__file__))
 _MAX_CONVERSATION_NAME_BYTES = 255  # Linux NAME_MAX for a single path component
+_STDIN_POLL_TIMEOUT = 0.1
 
 
 class CommaSeparatedChoice(click.ParamType):
@@ -955,6 +957,18 @@ def get_logdir_resume(name: str = "random") -> Path:
 
 
 def _read_stdin() -> str:
+    # In automation, stdin is often an open pipe with no bytes pending yet.
+    # Wait briefly for readability so we don't block forever on read-until-EOF.
+    try:
+        readable, _, _ = select.select(
+            [sys.stdin.fileno()], [], [], _STDIN_POLL_TIMEOUT
+        )
+    except (AttributeError, OSError, ValueError):
+        readable = [True]
+
+    if not readable:
+        return ""
+
     chunk_size = 1024  # 1 KB
     all_data = ""
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,8 @@ import os
 import random
 import signal
 import tempfile
+import threading
+import time
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
@@ -92,7 +94,7 @@ def test_read_stdin_open_pipe_without_data_returns_empty(monkeypatch):
         raise TimeoutError("stdin read blocked on an idle pipe")
 
     previous_handler = signal.signal(signal.SIGALRM, _timeout)
-    signal.setitimer(signal.ITIMER_REAL, 0.5)
+    signal.setitimer(signal.ITIMER_REAL, 1.5)
     try:
         assert cli._read_stdin() == ""
     finally:
@@ -113,6 +115,26 @@ def test_read_stdin_pipe_with_data_reads_all(monkeypatch):
     try:
         assert cli._read_stdin() == "hello from pipe"
     finally:
+        read_file.close()
+
+
+def test_read_stdin_waits_briefly_for_slow_pipe_writer(monkeypatch):
+    """A slightly slow producer should still count as piped stdin."""
+    read_fd, write_fd = os.pipe()
+    read_file = os.fdopen(read_fd)
+    monkeypatch.setattr(cli.sys, "stdin", read_file)
+
+    def _writer():
+        time.sleep(0.2)
+        os.write(write_fd, b"hello after delay")
+        os.close(write_fd)
+
+    writer = threading.Thread(target=_writer)
+    writer.start()
+    try:
+        assert cli._read_stdin() == "hello after delay"
+    finally:
+        writer.join()
         read_file.close()
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 import os
 import random
+import signal
 import tempfile
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -78,6 +79,41 @@ def test_version(runner: CliRunner):
     result = runner.invoke(cli.main, ["--version"])
     assert result.exit_code == 0
     assert "gptme" in result.output
+
+
+@pytest.mark.skipif(os.name == "nt", reason="SIGALRM-based pipe guard is POSIX-only")
+def test_read_stdin_open_pipe_without_data_returns_empty(monkeypatch):
+    """An idle pipe should not block forever waiting for stdin bytes."""
+    read_fd, write_fd = os.pipe()
+    read_file = os.fdopen(read_fd)
+    monkeypatch.setattr(cli.sys, "stdin", read_file)
+
+    def _timeout(_signum, _frame):
+        raise TimeoutError("stdin read blocked on an idle pipe")
+
+    previous_handler = signal.signal(signal.SIGALRM, _timeout)
+    signal.setitimer(signal.ITIMER_REAL, 0.5)
+    try:
+        assert cli._read_stdin() == ""
+    finally:
+        signal.setitimer(signal.ITIMER_REAL, 0)
+        signal.signal(signal.SIGALRM, previous_handler)
+        read_file.close()
+        os.close(write_fd)
+
+
+def test_read_stdin_pipe_with_data_reads_all(monkeypatch):
+    """Actual piped stdin should still be consumed fully."""
+    read_fd, write_fd = os.pipe()
+    os.write(write_fd, b"hello from pipe")
+    os.close(write_fd)
+    read_file = os.fdopen(read_fd)
+    monkeypatch.setattr(cli.sys, "stdin", read_file)
+
+    try:
+        assert cli._read_stdin() == "hello from pipe"
+    finally:
+        read_file.close()
 
 
 @pytest.mark.parametrize("bad_name", ["../bad-name", ".", "..", "foo/bar", "foo\\bar"])


### PR DESCRIPTION
## Summary
- avoid blocking forever on idle non-TTY stdin pipes before deciding whether input was actually piped
- keep real piped stdin working by only short-circuiting when the pipe never becomes readable
- add regression tests for idle-pipe and data-present pipe behavior in `_read_stdin()`

## Reproduction
Before this patch, this hangs because `gptme` blindly reads stdin until EOF whenever stdin is not a TTY:

```bash
python -c 'from gptme.cli.main import main; main()' -- --non-interactive
```

One concrete reproducer is launching it from Python with `stdin=subprocess.PIPE` and no input bytes written.

## Root cause
`gptme.cli.main._read_stdin()` always looped on `sys.stdin.read()` until EOF. In automation that often means an open pipe with no pending bytes yet, so the CLI blocks before it can emit the normal "Non-interactive mode requires a prompt" error.

## Testing
- `PYTHONPATH=/tmp/worktrees/gptme/dogfood-cli-surface-bc58${PYTHONPATH:+:$PYTHONPATH} /home/bob/projects/gptme/.venv/bin/python -m pytest tests/test_cli.py -k 'read_stdin_open_pipe_without_data_returns_empty or read_stdin_pipe_with_data_reads_all or test_name_rejects_path_traversal or test_resume_named_missing_conversation_does_not_fallback_to_latest' -q`
- `PYTHONPATH=/tmp/worktrees/gptme/dogfood-cli-surface-bc58${PYTHONPATH:+:$PYTHONPATH} /home/bob/projects/gptme/.venv/bin/python -m pytest tests/test_json_output.py -k 'json_with_noninteractive_parses' -q`
