### PR TITLE
fix(cli): ignore disable env in prompts expand

### DIFF
--- a/gptme/cli/util.py
+++ b/gptme/cli/util.py
@@ -621,7 +621,14 @@ def prompts_expand(prompt: tuple[str, ...]):
     from ..util.context import include_paths  # fmt: skip
 
     original_msg = Message("user", full_prompt)
-    expanded_msg = include_paths(original_msg, workspace=Path.cwd())
+    # This utility is for inspecting path expansion itself, so it must ignore
+    # the ambient GPTME_DISABLE_PATH_INCLUDE setting used by automation.
+    disabled_path_include = os.environ.pop("GPTME_DISABLE_PATH_INCLUDE", None)
+    try:
+        expanded_msg = include_paths(original_msg, workspace=Path.cwd())
+    finally:
+        if disabled_path_include is not None:
+            os.environ["GPTME_DISABLE_PATH_INCLUDE"] = disabled_path_include
 
     # Print the expanded content exactly as it would be sent to the LLM
     print(expanded_msg.content)

--- a/tests/test_util_cli.py
+++ b/tests/test_util_cli.py
@@ -254,6 +254,26 @@ def test_context_index_and_retrieve(tmp_path):
     # assert result.output.count("Hello, world!") == 1
 
 
+def test_prompts_expand_ignores_disable_path_include(tmp_path, monkeypatch):
+    """`prompts expand` should still show path expansion under disabled include env.
+
+    The command is an inspection/debugging surface for path expansion itself, so
+    it must not inherit the ambient automation env that disables expansion in
+    normal chat prompts.
+    """
+    runner = CliRunner()
+    test_file = tmp_path / "hello.txt"
+    test_file.write_text("hello\n")
+
+    monkeypatch.setenv("GPTME_DISABLE_PATH_INCLUDE", "1")
+    result = runner.invoke(main, ["prompts", "expand", str(test_file)])
+
+    assert result.exit_code == 0
+    assert "hello" in result.output
+    assert str(test_file) in result.output
+    assert os.environ["GPTME_DISABLE_PATH_INCLUDE"] == "1"
+
+
 def test_chats_send(tmp_path, monkeypatch):
     """Test queueing a prompt for an existing conversation."""
     runner = CliRunner()


### PR DESCRIPTION
## Summary
- make `gptme-util prompts expand` ignore the ambient `GPTME_DISABLE_PATH_INCLUDE` env flag
- restore the env var after expansion so the command remains side-effect free
- add a regression test covering the disabled-env repro

## Repro
```bash
GPTME_DISABLE_PATH_INCLUDE=1 gptme-util prompts expand /tmp/file.txt
```
Before this PR, that printed the literal path instead of the expanded file content.