### PR TITLE
fix(server): reject non-object conversation config

### DIFF
--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -517,6 +517,10 @@ def api_conversation_put(conversation_id: str):
             ts = datetime.now(tz=timezone.utc)
         validated_msgs.append((cast(_RoleType, msg["role"]), msg["content"], ts))
 
+    config_raw = req_json.get("config", {})
+    if not isinstance(config_raw, dict):
+        return flask.jsonify({"error": "'config' must be an object"}), 400
+
     # Create the log directory atomically to avoid TOCTOU race
     try:
         logdir.mkdir(parents=True)
@@ -527,7 +531,7 @@ def api_conversation_put(conversation_id: str):
         )
 
     # Load or create the chat config, overriding values from request config if provided
-    config_dict = req_json.get("config", {})
+    config_dict = dict(config_raw)
     config_dict["_logdir"] = logdir  # Pass logdir for "@log" workspace resolution
     request_config = ChatConfig.from_dict(config_dict)
     chat_config = ChatConfig.load_or_create(logdir, request_config)

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -1054,6 +1054,23 @@ def test_v2_create_conversation_webui_html_hint_disabled(
     )
 
 
+def test_v2_create_conversation_rejects_non_object_config_without_side_effects(
+    client: FlaskClient, tmp_path, monkeypatch
+):
+    logs_dir = tmp_path / "logs"
+    conversation_id = "test-server-v2-bad-config"
+    monkeypatch.setattr("gptme.server.api_v2.get_logs_dir", lambda: logs_dir)
+
+    response = client.put(
+        f"/api/v2/conversations/{conversation_id}",
+        json={"config": []},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "'config' must be an object"}
+    assert not (logs_dir / conversation_id).exists()
+
+
 def test_v2_conversation_post(v2_conv, client: FlaskClient):
     """Test posting a message to a V2 conversation."""
     conversation_id = v2_conv["conversation_id"]


### PR DESCRIPTION
## Summary

- reject non-object `config` payloads on `PUT /api/v2/conversations/<id>` with a JSON 400 instead of a Flask 500
- validate `config` before creating the conversation logdir so bad requests do not leave orphaned conversation directories behind
- add a regression test covering both the 400 response and the no-side-effects guarantee

## Reproduction

Before this patch, the following request crashed on `origin/master`:

```json
{"config": []}
```

Observed behavior:
- 500 from Flask (`TypeError: list indices must be integers or slices, not str`)
- orphaned conversation directory created before the crash

Verified after the fix:
- response is `400` with `{"error": "'config' must be an object"}`
- no conversation log directory is created

## Testing

- `PYTHONPATH=/tmp/worktrees/gptme/bob-api-dogfood-d67e /home/bob/gptme/.venv/bin/python -m pytest /tmp/worktrees/gptme/bob-api-dogfood-d67e/tests/test_server_v2.py -k "non_object_config or chat_config_saved_on_conversation_create or conversation_post" -q`
