### PR TITLE
fix(telemetry): suppress OTLP timeout tracebacks

### DIFF
--- a/gptme/util/_telemetry.py
+++ b/gptme/util/_telemetry.py
@@ -26,7 +26,7 @@ _session_id: ContextVar[str | None] = ContextVar("session_id", default=None)
 
 
 class TelemetryConnectionErrorFilter(logging.Filter):
-    """Filter to debounce and truncate verbose connection error traces from OpenTelemetry.
+    """Filter to debounce and truncate verbose network/export traces from OpenTelemetry.
 
     This filter:
     1. Simplifies verbose stack traces to single-line messages
@@ -34,8 +34,17 @@ class TelemetryConnectionErrorFilter(logging.Filter):
     3. Periodically shows a count of suppressed errors
 
     The filter ensures users see at least one error message when telemetry fails,
-    but prevents spam from repeated connection failures.
+    but prevents spam from repeated exporter network failures.
     """
+
+    _NETWORK_ERROR_NAME_FRAGMENTS = (
+        "ConnectionError",
+        "NewConnectionError",
+        "MaxRetryError",
+        "ReadTimeout",
+        "ConnectTimeout",
+        "TimeoutError",
+    )
 
     def __init__(self, cooldown_seconds: float = 300.0):
         super().__init__()
@@ -55,14 +64,12 @@ class TelemetryConnectionErrorFilter(logging.Filter):
         ):
             return True
 
-        # Check if this is a connection error
+        # Check if this is a connection/export error
         if record.levelno == logging.ERROR and record.exc_info:
             exc_type, exc_value, _ = record.exc_info
-            # Check if it's a connection-related error
-            if exc_type and (
-                "ConnectionError" in exc_type.__name__
-                or "NewConnectionError" in exc_type.__name__
-                or "MaxRetryError" in exc_type.__name__
+            if exc_type and any(
+                fragment in exc_type.__name__
+                for fragment in self._NETWORK_ERROR_NAME_FRAGMENTS
             ):
                 # Create error key for deduplication (type + truncated message)
                 error_key = f"{exc_type.__name__}"
@@ -82,13 +89,14 @@ class TelemetryConnectionErrorFilter(logging.Filter):
                     # Replace verbose stack trace with simple message
                     record.exc_info = None
                     record.exc_text = None
+                    record.args = ()
 
                     if count == 1:
-                        record.msg = f"Telemetry connection failed: {exc_value}"
+                        record.msg = f"Telemetry export failed: {exc_value}"
                     else:
                         # Show count of suppressed errors
                         record.msg = (
-                            f"Telemetry connection still failing "
+                            f"Telemetry export still failing "
                             f"({count} occurrences): {exc_value}"
                         )
                     return True

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,5 +1,6 @@
 """Tests for telemetry functionality."""
 
+import logging
 import subprocess
 import sys
 from unittest.mock import patch
@@ -79,6 +80,63 @@ def test_pushgateway_periodic_push(monkeypatch):
 
         # Cleanup
         shutdown_telemetry()
+
+
+def test_connection_error_filter_truncates_read_timeout_traceback():
+    """Timeout-style OTLP export errors should be reduced to one-line noise."""
+    from gptme.util._telemetry import TelemetryConnectionErrorFilter
+
+    class ReadTimeout(Exception):
+        pass
+
+    record = logging.LogRecord(
+        name="opentelemetry.sdk._shared_internal",
+        level=logging.ERROR,
+        pathname=__file__,
+        lineno=1,
+        msg="Exception while exporting Span.",
+        args=("stale-format-arg",),
+        exc_info=(ReadTimeout, ReadTimeout("read timed out"), None),
+    )
+
+    filter_ = TelemetryConnectionErrorFilter(cooldown_seconds=300.0)
+
+    assert filter_.filter(record) is True
+    assert record.exc_info is None
+    assert record.exc_text is None
+    assert record.args == ()
+    assert record.msg == "Telemetry export failed: read timed out"
+
+
+def test_connection_error_filter_debounces_repeated_timeouts():
+    """Repeated OTLP timeout errors should be suppressed inside the cooldown."""
+    from gptme.util._telemetry import TelemetryConnectionErrorFilter
+
+    class ReadTimeout(Exception):
+        pass
+
+    filter_ = TelemetryConnectionErrorFilter(cooldown_seconds=300.0)
+    first = logging.LogRecord(
+        name="opentelemetry.sdk._shared_internal",
+        level=logging.ERROR,
+        pathname=__file__,
+        lineno=1,
+        msg="Exception while exporting Span.",
+        args=("stale-format-arg",),
+        exc_info=(ReadTimeout, ReadTimeout("read timed out"), None),
+    )
+    second = logging.LogRecord(
+        name="opentelemetry.sdk._shared_internal",
+        level=logging.ERROR,
+        pathname=__file__,
+        lineno=2,
+        msg="Exception while exporting Span.",
+        args=("stale-format-arg",),
+        exc_info=(ReadTimeout, ReadTimeout("read timed out"), None),
+    )
+
+    assert filter_.filter(first) is True
+    assert filter_.filter(second) is False
 
 
 def test_record_hook_call_records_span():


### PR DESCRIPTION
## Summary
- treat OTLP timeout-style exporter failures the same way as existing connection failures
- clear rewritten log args so the simplified telemetry message doesn't trigger logging-format errors during shutdown
- add regression coverage for timeout truncation and debounce behavior

## Repro
Before this patch, a non-interactive auth failure like:

```bash
PYTHONPATH=/tmp/gptme-43b6-telemetry-timeout /home/bob/gptme/.venv/bin/python3 - <<'PY'
from gptme.cli.main import main
main.main(args=['-n', '--output-format', 'json', '--tools', 'none', '--context', 'files', '--system', 'short', 'hello'], prog_name='gptme', standalone_mode=True)
PY
```

would print the expected Anthropic `401 invalid x-api-key` error and then dump an unrelated OpenTelemetry exporter traceback, or trip a `Failed to shutdown telemetry` formatter error when the filter rewrote the log message but left stale `record.args` behind.

After this patch, the same failure path stays focused on the real auth error and degrades telemetry to a single short timeout line instead of a traceback.

## Testing
- `PYTHONPATH=/tmp/gptme-43b6-telemetry-timeout /home/bob/gptme/.venv/bin/python3 -m pytest tests/test_telemetry.py -q`
- real CLI repro above: confirms `authentication_error` remains visible, `Exception while exporting Span.` and traceback text disappear, and telemetry shutdown completes cleanly
