### PR TITLE
fix(server): return 409 for upload name exhaustion

### DIFF
--- a/gptme/server/workspace_api.py
+++ b/gptme/server/workspace_api.py
@@ -316,6 +316,7 @@ def browse_workspace(conversation_id: str, subpath: str | None = None):
         200: UploadFileResponse,
         400: ErrorResponse,
         404: ErrorResponse,
+        409: ErrorResponse,
         413: ErrorResponse,
         500: ErrorResponse,
     },
@@ -379,7 +380,7 @@ def upload_files(conversation_id: str):
                     attachments_dir, filename, reserved_names
                 )
             except ValueError as e:
-                return flask.jsonify({"error": str(e)}), 500
+                return flask.jsonify({"error": str(e)}), 409
             reserved_names.add(file_path.name)
             validated.append((file_path, content))
 

--- a/tests/test_workspace_api.py
+++ b/tests/test_workspace_api.py
@@ -53,6 +53,13 @@ class TestAllocateAttachmentPath:
 
         assert result == tmp_path / "report-1.pdf"
 
+    def test_raises_when_name_space_exhausted(self, tmp_path: Path) -> None:
+        reserved_names = {"report.pdf"}
+        reserved_names.update(f"report-{i}.pdf" for i in range(1, 10001))
+
+        with pytest.raises(ValueError, match="Could not allocate unique name"):
+            allocate_attachment_path(tmp_path, "report.pdf", reserved_names)
+
 
 @pytest.fixture
 def app():
@@ -297,6 +304,31 @@ class TestUploadEndpoint:
         assert result["files"][0]["name"] == "report-1.pdf"
         assert (attachments_dir / "report.pdf").read_text() == "existing"
         assert (attachments_dir / "report-1.pdf").read_text() == "new"
+
+    def test_upload_returns_409_when_name_space_exhausted(
+        self, app, mock_logmanager, mock_auth
+    ) -> None:
+        _, logdir = mock_logmanager
+        attachments_dir = logdir / "attachments"
+        attachments_dir.mkdir()
+        (attachments_dir / "report.pdf").write_text("existing")
+        for i in range(1, 10001):
+            (attachments_dir / f"report-{i}.pdf").write_text("existing")
+
+        with app.test_client() as client:
+            data = {"file": (io.BytesIO(b"new"), "report.pdf")}
+            resp = client.post(
+                "/api/v2/conversations/test-conv/workspace/upload",
+                data=data,
+                content_type="multipart/form-data",
+            )
+
+        assert resp.status_code == 409
+        assert resp.get_json() == {
+            "error": "Could not allocate unique name for report.pdf"
+        }
+        assert (attachments_dir / "report.pdf").read_text() == "existing"
+        assert not (attachments_dir / "report-10001.pdf").exists()
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- return `409 Conflict` instead of `500` when upload filename allocation is exhausted in `/api/v2/conversations/<id>/workspace/upload`
- add regression coverage for allocator exhaustion and the upload endpoint status mapping

## Reproduction
Using the server app directly, I created a conversation attachments dir containing:
- `report.pdf`
- `report-1.pdf` through `report-10000.pdf`

Then posted another `report.pdf` to the upload endpoint.

Before this change:
- `POST /api/v2/conversations/test-conv/workspace/upload` returned `500`
- body: `{"error":"Could not allocate unique name for report.pdf"}`

After this change:
- the same request returns `409`
- body remains `{"error":"Could not allocate unique name for report.pdf"}`

## Verification
- `/home/bob/gptme/.venv/bin/python -m pytest tests/test_workspace_api.py -q`
- direct reproduction script against `create_app()` now returns `409`
