### PR TITLE
fix(server): validate agent creation field types

### DIFF
--- a/gptme/server/api_v2_agents.py
+++ b/gptme/server/api_v2_agents.py
@@ -61,25 +61,25 @@ def api_agents_put():
         return flask.jsonify({"error": "Request body must be a JSON object"}), 400
 
     agent_name = req_json.get("name")
-    if not agent_name:
+    if agent_name is None or agent_name == "":
         return flask.jsonify({"error": "name is required"}), 400
     if not isinstance(agent_name, str):
         return flask.jsonify({"error": "name must be a string"}), 400
 
     template_repo = req_json.get("template_repo")
-    if not template_repo:
+    if template_repo is None or template_repo == "":
         return flask.jsonify({"error": "template_repo is required"}), 400
     if not isinstance(template_repo, str):
         return flask.jsonify({"error": "template_repo must be a string"}), 400
 
     template_branch = req_json.get("template_branch")
-    if not template_branch:
+    if template_branch is None or template_branch == "":
         return flask.jsonify({"error": "template_branch is required"}), 400
     if not isinstance(template_branch, str):
         return flask.jsonify({"error": "template_branch must be a string"}), 400
 
     fork_command = req_json.get("fork_command")
-    if not fork_command:
+    if fork_command is None or fork_command == "":
         return flask.jsonify({"error": "fork_command is required"}), 400
     if not isinstance(fork_command, str):
         return flask.jsonify({"error": "fork_command must be a string"}), 400

--- a/gptme/server/api_v2_agents.py
+++ b/gptme/server/api_v2_agents.py
@@ -63,20 +63,30 @@ def api_agents_put():
     agent_name = req_json.get("name")
     if not agent_name:
         return flask.jsonify({"error": "name is required"}), 400
+    if not isinstance(agent_name, str):
+        return flask.jsonify({"error": "name must be a string"}), 400
 
     template_repo = req_json.get("template_repo")
     if not template_repo:
         return flask.jsonify({"error": "template_repo is required"}), 400
+    if not isinstance(template_repo, str):
+        return flask.jsonify({"error": "template_repo must be a string"}), 400
 
     template_branch = req_json.get("template_branch")
     if not template_branch:
         return flask.jsonify({"error": "template_branch is required"}), 400
+    if not isinstance(template_branch, str):
+        return flask.jsonify({"error": "template_branch must be a string"}), 400
 
     fork_command = req_json.get("fork_command")
     if not fork_command:
         return flask.jsonify({"error": "fork_command is required"}), 400
+    if not isinstance(fork_command, str):
+        return flask.jsonify({"error": "fork_command must be a string"}), 400
 
     path = req_json.get("path")
+    if path is not None and not isinstance(path, str):
+        return flask.jsonify({"error": "path must be a string"}), 400
     if not path:
         # Auto-generate path from initial directory + slugified agent name
         agent_slug = slugify_name(agent_name)
@@ -116,9 +126,12 @@ def api_agents_put():
         )
 
     # Parse project config if provided
-    project_config = req_json.get("project_config")
-    if project_config:
-        project_config = ProjectConfig.from_dict(project_config, workspace=path)
+    project_config_raw = req_json.get("project_config")
+    if project_config_raw is not None and not isinstance(project_config_raw, dict):
+        return flask.jsonify({"error": "project_config must be an object"}), 400
+    project_config: ProjectConfig | None = None
+    if project_config_raw:
+        project_config = ProjectConfig.from_dict(project_config_raw, workspace=path)
 
     # Create workspace using shared module
     try:

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -2144,3 +2144,93 @@ def test_v2_agents_put_rejects_malformed_json(client: FlaskClient):
         "Response must be valid JSON, not a raw Werkzeug error page"
     )
     assert "error" in data
+
+
+@pytest.mark.parametrize(
+    ("body", "expected_error"),
+    [
+        (
+            {
+                "name": ["bob"],
+                "template_repo": "https://example.com/repo.git",
+                "template_branch": "master",
+                "fork_command": "echo ok",
+            },
+            "name must be a string",
+        ),
+        (
+            {
+                "name": "bob2",
+                "template_repo": 123,
+                "template_branch": "master",
+                "fork_command": "echo ok",
+            },
+            "template_repo must be a string",
+        ),
+        (
+            {
+                "name": "bob2",
+                "template_repo": "https://example.com/repo.git",
+                "template_branch": ["master"],
+                "fork_command": "echo ok",
+            },
+            "template_branch must be a string",
+        ),
+        (
+            {
+                "name": "bob2",
+                "template_repo": "https://example.com/repo.git",
+                "template_branch": "master",
+                "fork_command": {"cmd": "echo ok"},
+            },
+            "fork_command must be a string",
+        ),
+        (
+            {
+                "name": "bob2",
+                "template_repo": "https://example.com/repo.git",
+                "template_branch": "master",
+                "fork_command": "echo ok",
+                "path": 123,
+            },
+            "path must be a string",
+        ),
+        (
+            {
+                "name": "bob2",
+                "template_repo": "https://example.com/repo.git",
+                "template_branch": "master",
+                "fork_command": "echo ok",
+                "project_config": "bad",
+            },
+            "project_config must be an object",
+        ),
+    ],
+)
+def test_v2_agents_put_rejects_invalid_field_types(
+    client: FlaskClient,
+    monkeypatch: pytest.MonkeyPatch,
+    body: dict,
+    expected_error: str,
+):
+    """Agents PUT should reject invalid field types before any side effects start."""
+
+    def fail_workspace(*args, **kwargs):
+        pytest.fail("create_workspace_from_template should not run for invalid input")
+
+    def fail_project_config(*args, **kwargs):
+        pytest.fail("ProjectConfig.from_dict should not run for invalid input")
+
+    monkeypatch.setattr(
+        "gptme.server.api_v2_agents.create_workspace_from_template", fail_workspace
+    )
+    monkeypatch.setattr(
+        "gptme.server.api_v2_agents.ProjectConfig.from_dict", fail_project_config
+    )
+
+    response = client.put("/api/v2/agents", json=body)
+
+    assert response.status_code == 400
+    data = response.get_json()
+    assert data is not None
+    assert data["error"] == expected_error

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -2160,8 +2160,26 @@ def test_v2_agents_put_rejects_malformed_json(client: FlaskClient):
         ),
         (
             {
+                "name": False,
+                "template_repo": "https://example.com/repo.git",
+                "template_branch": "master",
+                "fork_command": "echo ok",
+            },
+            "name must be a string",
+        ),
+        (
+            {
                 "name": "bob2",
                 "template_repo": 123,
+                "template_branch": "master",
+                "fork_command": "echo ok",
+            },
+            "template_repo must be a string",
+        ),
+        (
+            {
+                "name": "bob2",
+                "template_repo": 0,
                 "template_branch": "master",
                 "fork_command": "echo ok",
             },
@@ -2180,8 +2198,26 @@ def test_v2_agents_put_rejects_malformed_json(client: FlaskClient):
             {
                 "name": "bob2",
                 "template_repo": "https://example.com/repo.git",
+                "template_branch": [],
+                "fork_command": "echo ok",
+            },
+            "template_branch must be a string",
+        ),
+        (
+            {
+                "name": "bob2",
+                "template_repo": "https://example.com/repo.git",
                 "template_branch": "master",
                 "fork_command": {"cmd": "echo ok"},
+            },
+            "fork_command must be a string",
+        ),
+        (
+            {
+                "name": "bob2",
+                "template_repo": "https://example.com/repo.git",
+                "template_branch": "master",
+                "fork_command": False,
             },
             "fork_command must be a string",
         ),
@@ -2234,3 +2270,56 @@ def test_v2_agents_put_rejects_invalid_field_types(
     data = response.get_json()
     assert data is not None
     assert data["error"] == expected_error
+
+
+def test_v2_agents_put_parses_project_config_object(
+    client: FlaskClient, monkeypatch: pytest.MonkeyPatch
+):
+    """Agents PUT should parse a valid project_config object before workspace creation."""
+
+    parsed_project_config = object()
+    called: dict[str, Any] = {}
+
+    def fake_project_config_from_dict(raw_config: dict[str, Any], workspace: Path):
+        called["project_config_raw"] = raw_config
+        called["project_config_workspace"] = workspace
+        return parsed_project_config
+
+    def fake_create_workspace_from_template(**kwargs):
+        called["workspace_kwargs"] = kwargs
+
+    def fake_init_conversation(workspace: Path):
+        called["conversation_workspace"] = workspace
+        return "conv-test"
+
+    monkeypatch.setattr(
+        "gptme.server.api_v2_agents.ProjectConfig.from_dict",
+        fake_project_config_from_dict,
+    )
+    monkeypatch.setattr(
+        "gptme.server.api_v2_agents.create_workspace_from_template",
+        fake_create_workspace_from_template,
+    )
+    monkeypatch.setattr(
+        "gptme.server.api_v2_agents.init_conversation", fake_init_conversation
+    )
+
+    body = {
+        "name": "bob2",
+        "template_repo": "https://example.com/repo.git",
+        "template_branch": "master",
+        "fork_command": "echo ok",
+        "project_config": {"models": {"default": "openai/gpt-4o-mini"}},
+    }
+
+    response = client.put("/api/v2/agents", json=body)
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data is not None
+    assert data["status"] == "ok"
+    assert data["initial_conversation_id"] == "conv-test"
+    assert called["project_config_raw"] == body["project_config"]
+    assert called["project_config_workspace"] == called["workspace_kwargs"]["path"]
+    assert called["workspace_kwargs"]["project_config"] is parsed_project_config
+    assert called["conversation_workspace"] == called["workspace_kwargs"]["path"]


### PR DESCRIPTION
## Summary
- validate `/api/v2/agents` field types before slug/path/config/workspace side effects
- return clean 400 JSON errors for invalid `name`, `template_repo`, `template_branch`, `fork_command`, `path`, and `project_config`
- add regression coverage proving invalid input never reaches workspace creation or project-config parsing

## Repro
Before this patch, requests like `PUT /api/v2/agents` with `{"path":123}` or `{"name":["bob"]}` raised raw Python exceptions and returned 500.

## Verification
- `PYTHONPATH=/tmp/worktrees/gptme-api-dogfood-46f3 /home/bob/gptme/.venv/bin/pytest /tmp/worktrees/gptme-api-dogfood-46f3/tests/test_server_v2.py -q -k agents_put`
- explicit repro check now returns `400 {"error": "path must be a string"}` for `path: 123`