### PR TITLE
fix(webui): keep api misses out of SPA fallback

### DIFF
--- a/webui/public/404.html
+++ b/webui/public/404.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Not Found</title>
+  </head>
+  <body>
+    <main>
+      <h1>404 Not Found</h1>
+      <p>The requested path does not exist on this hosted web UI.</p>
+    </main>
+  </body>
+  </html>

--- a/webui/public/_redirects
+++ b/webui/public/_redirects
@@ -1,0 +1,5 @@
+# Keep same-origin API misses as real 404s instead of rewriting them to the SPA shell.
+/api/* /404.html 404
+
+# Let client-side routes resolve through the React app.
+/* /index.html 200

--- a/webui/src/utils/__tests__/cloudflareRedirects.test.ts
+++ b/webui/src/utils/__tests__/cloudflareRedirects.test.ts
@@ -1,0 +1,22 @@
+import fs from 'fs';
+import path from 'path';
+
+describe('Cloudflare Pages redirect rules', () => {
+  it('keeps API paths out of the SPA fallback', () => {
+    const redirectsPath = path.resolve(process.cwd(), 'public/_redirects');
+    const redirects = fs.readFileSync(redirectsPath, 'utf8');
+    const rules = redirects
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line && !line.startsWith('#'));
+
+    expect(rules).toEqual(['/api/* /404.html 404', '/* /index.html 200']);
+  });
+
+  it('ships a dedicated 404 page for non-SPA misses', () => {
+    const notFoundPath = path.resolve(process.cwd(), 'public/404.html');
+    const notFoundPage = fs.readFileSync(notFoundPath, 'utf8');
+
+    expect(notFoundPage).toContain('<h1>404 Not Found</h1>');
+  });
+});

--- a/webui/src/utils/__tests__/cloudflareRedirects.test.ts
+++ b/webui/src/utils/__tests__/cloudflareRedirects.test.ts
@@ -3,18 +3,22 @@ import path from 'path';
 
 describe('Cloudflare Pages redirect rules', () => {
   it('keeps API paths out of the SPA fallback', () => {
-    const redirectsPath = path.resolve(process.cwd(), 'public/_redirects');
+    const redirectsPath = path.resolve(__dirname, '../../../public/_redirects');
     const redirects = fs.readFileSync(redirectsPath, 'utf8');
     const rules = redirects
       .split('\n')
       .map((line) => line.trim())
       .filter((line) => line && !line.startsWith('#'));
+    const apiRuleIndex = rules.indexOf('/api/* /404.html 404');
+    const spaFallbackIndex = rules.indexOf('/* /index.html 200');
 
-    expect(rules).toEqual(['/api/* /404.html 404', '/* /index.html 200']);
+    expect(apiRuleIndex).toBeGreaterThanOrEqual(0);
+    expect(spaFallbackIndex).toBeGreaterThanOrEqual(0);
+    expect(apiRuleIndex).toBeLessThan(spaFallbackIndex);
   });
 
   it('ships a dedicated 404 page for non-SPA misses', () => {
-    const notFoundPath = path.resolve(process.cwd(), 'public/404.html');
+    const notFoundPath = path.resolve(__dirname, '../../../public/404.html');
     const notFoundPage = fs.readFileSync(notFoundPath, 'utf8');
 
     expect(notFoundPage).toContain('<h1>404 Not Found</h1>');


### PR DESCRIPTION
## Summary
- add Cloudflare Pages redirect rules so `/api/*` returns a real 404 instead of the SPA shell
- add a dedicated `404.html` for non-SPA misses
- add a Jest guard to keep the API rule ahead of the catch-all SPA fallback

## Reproduction
Live hosted repro before this patch:
```sh
curl -i https://chat.gptme.org/api/v2
curl -i https://chat.gptme.org/api/v2/tasks
```
Both returned `HTTP/2 200` with `content-type: text/html; charset=utf-8` and the webui shell instead of a failing API response.

## Verification
- `node /home/bob/gptme/webui/node_modules/jest/bin/jest.js cloudflareRedirects.test.ts --runInBand --ci`
