### PR TITLE
fix(cli): validate custom tool paths before init

### DIFF
--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -624,11 +624,7 @@ def main(
 
     # Register atexit handler to show conversation ID on exit
     def goodbye_handler():
-        if output_format == "json":
-            return
-
-        log_file = logdir / "conversation.jsonl"
-        if log_file.exists() and log_file.stat().st_size > 0:
+        if _should_print_resume_hint(logdir, output_format):
             print(f"\nGoodbye! (resume with: gptme --name {logdir.name})")
 
     atexit.register(goodbye_handler)
@@ -961,6 +957,14 @@ def get_logdir_resume(name: str = "random") -> Path:
     if conv := next(get_user_conversations(), None):
         return Path(conv.path).parent
     raise ValueError("No previous conversations to resume")
+
+
+def _should_print_resume_hint(logdir: Path, output_format: str) -> bool:
+    if output_format == "json":
+        return False
+
+    log_file = logdir / "conversation.jsonl"
+    return log_file.exists() and log_file.stat().st_size > 0
 
 
 def _read_stdin() -> str:

--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -624,7 +624,11 @@ def main(
 
     # Register atexit handler to show conversation ID on exit
     def goodbye_handler():
-        if output_format != "json":
+        if output_format == "json":
+            return
+
+        log_file = logdir / "conversation.jsonl"
+        if log_file.exists() and log_file.stat().st_size > 0:
             print(f"\nGoodbye! (resume with: gptme --name {logdir.name})")
 
     atexit.register(goodbye_handler)
@@ -637,16 +641,19 @@ def main(
         workspace_path = Path(workspace) if workspace else Path.cwd()
 
     # Setup complete configuration from CLI arguments and workspace
-    config = setup_config_from_cli(
-        workspace=workspace_path,
-        logdir=logdir,
-        model=model,
-        tool_allowlist=tool_allowlist_str,
-        tool_format=tool_format,
-        stream=stream,
-        interactive=interactive,
-        agent_path=Path(agent_path) if agent_path else None,
-    )
+    try:
+        config = setup_config_from_cli(
+            workspace=workspace_path,
+            logdir=logdir,
+            model=model,
+            tool_allowlist=tool_allowlist_str,
+            tool_format=tool_format,
+            stream=stream,
+            interactive=interactive,
+            agent_path=Path(agent_path) if agent_path else None,
+        )
+    except ValueError as e:
+        raise click.UsageError(str(e)) from e
     assert config.chat and config.chat.tool_format
 
     # init telemetry with agent name and interactive mode

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -172,6 +172,32 @@ def test_resume_named_missing_conversation_does_not_fallback_to_latest(
     assert f"No conversation named '{missing}' to resume" in result.output
 
 
+def test_missing_custom_tool_path_is_reported_as_usage_error(
+    runner: CliRunner, tmp_path: Path
+):
+    missing_tool = tmp_path / "missing_tool.py"
+
+    result = runner.invoke(
+        cli.main,
+        [
+            "--non-interactive",
+            "--name",
+            "missing-custom-tool",
+            "-t",
+            str(missing_tool),
+            "hello",
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert "Tool" in result.output
+    assert str(missing_tool) in result.output
+    assert "Traceback" not in result.output
+    assert (
+        "Goodbye! (resume with: gptme --name missing-custom-tool)" not in result.output
+    )
+
+
 def test_command_exit(args: list[str], runner: CliRunner):
     args.append("/exit")
     result = runner.invoke(cli.main, args)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -193,9 +193,28 @@ def test_missing_custom_tool_path_is_reported_as_usage_error(
     assert "Tool" in result.output
     assert str(missing_tool) in result.output
     assert "Traceback" not in result.output
-    assert (
-        "Goodbye! (resume with: gptme --name missing-custom-tool)" not in result.output
-    )
+
+
+def test_should_print_resume_hint_requires_nonempty_conversation_log(tmp_path: Path):
+    logdir = tmp_path / "resume-hint"
+    logdir.mkdir()
+
+    assert not cli._should_print_resume_hint(logdir, "text")
+
+    log_file = logdir / "conversation.jsonl"
+    log_file.write_text("")
+    assert not cli._should_print_resume_hint(logdir, "text")
+
+    log_file.write_text('{"role":"user","content":"hello"}\n')
+    assert cli._should_print_resume_hint(logdir, "text")
+
+
+def test_should_print_resume_hint_is_disabled_for_json_output(tmp_path: Path):
+    logdir = tmp_path / "json-output"
+    logdir.mkdir()
+    (logdir / "conversation.jsonl").write_text('{"role":"user","content":"hello"}\n')
+
+    assert not cli._should_print_resume_hint(logdir, "json")
 
 
 def test_command_exit(args: list[str], runner: CliRunner):


### PR DESCRIPTION
## Summary
- convert invalid custom tool-path failures into CLI usage errors instead of raw tracebacks
- suppress the resume hint unless a real conversation log was actually written
- add a CLI regression test for missing `.py` tool paths

## Repro
```bash
tmp=$(mktemp -d)
HOME="$tmp" XDG_DATA_HOME="$tmp/data" XDG_STATE_HOME="$tmp/state" \
  uv run gptme --non-interactive --name missing-custom-tool -t /tmp/no-such-tool.py hello
```

Before this PR, that command raised a traceback from `get_toolchain(...)` and printed a bogus `Goodbye!` resume hint.

## Testing
- `PYTHONPATH=/tmp/gptme-cli-custom-tool-path-725b /home/bob/gptme/.venv/bin/pytest /tmp/gptme-cli-custom-tool-path-725b/tests/test_cli.py -k "missing_custom_tool_path_is_reported_as_usage_error or resume_named_missing_conversation_does_not_fallback_to_latest or name_rejects_path_traversal" -q`
- `PYTHONPATH=/tmp/gptme-cli-custom-tool-path-725b /home/bob/gptme/.venv/bin/pytest /tmp/gptme-cli-custom-tool-path-725b/tests/test_json_output.py -k "json_requires_noninteractive or json_with_noninteractive_parses" -q`
- `uv run ruff check /tmp/gptme-cli-custom-tool-path-725b/gptme/cli/main.py /tmp/gptme-cli-custom-tool-path-725b/tests/test_cli.py`