### PR TITLE
fix(webui): restore hosted deep links on Pages

### DIFF
--- a/tests/test_webui_redirects.py
+++ b/tests/test_webui_redirects.py
@@ -41,6 +41,7 @@ def test_webui_cloudflare_pages_redirects_cover_spa_deep_links():
 def test_webui_redirects_do_not_swallow_unknown_api_paths():
     rules = _load_redirect_rules()
     assert ("/*", "/index.html", "200") not in rules
+    assert ("/*", "/", "200") not in rules
     assert all(not source.startswith("/api") for source, _, _ in rules), (
         "API routes should fall through to the hosted 404 page"
     )

--- a/tests/test_webui_redirects.py
+++ b/tests/test_webui_redirects.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+REDIRECTS_PATH = ROOT / "webui" / "public" / "_redirects"
+
+
+def _load_redirect_rules() -> set[tuple[str, str, str]]:
+    rules: set[tuple[str, str, str]] = set()
+    for raw_line in REDIRECTS_PATH.read_text().splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        source, destination, status = line.split()
+        rules.add((source, destination, status))
+    return rules
+
+
+def test_webui_cloudflare_pages_redirects_cover_spa_deep_links():
+    assert REDIRECTS_PATH.exists(), (
+        "webui/public/_redirects is required for hosted deep links"
+    )
+
+    rules = _load_redirect_rules()
+    expected_rules = {
+        ("/chat", "/", "200"),
+        ("/chat/*", "/", "200"),
+        ("/tasks", "/", "200"),
+        ("/tasks/*", "/", "200"),
+        ("/agents", "/", "200"),
+        ("/workspaces", "/", "200"),
+        ("/history", "/", "200"),
+        ("/external-sessions", "/", "200"),
+        ("/workspace/*", "/", "200"),
+    }
+    missing = expected_rules - rules
+    assert not missing, (
+        f"missing Cloudflare Pages deep-link redirects: {sorted(missing)}"
+    )
+
+
+def test_webui_redirects_do_not_swallow_unknown_api_paths():
+    rules = _load_redirect_rules()
+    assert ("/*", "/index.html", "200") not in rules
+    assert all(not source.startswith("/api") for source, _, _ in rules), (
+        "API routes should fall through to the hosted 404 page"
+    )

--- a/webui/public/_redirects
+++ b/webui/public/_redirects
@@ -1,5 +1,15 @@
-# Keep same-origin API misses as real 404s instead of rewriting them to the SPA shell.
-/api/* /404.html 404
-
-# Let client-side routes resolve through the React app.
-/* /index.html 200
+# Cloudflare Pages SPA deep-link fallback for chat.gptme.org.
+#
+# Pages does not support 404 rewrites in `_redirects`, and rewriting wildcard
+# routes to `/index.html` loops because Pages canonicalizes that file back to
+# `/`. Keep the route list explicit and rewrite to `/` so bogus `/api/*` paths
+# still fall through to the hosted 404 page.
+/chat / 200
+/chat/* / 200
+/tasks / 200
+/tasks/* / 200
+/agents / 200
+/workspaces / 200
+/history / 200
+/external-sessions / 200
+/workspace/* / 200

--- a/webui/src/utils/__tests__/cloudflareRedirects.test.ts
+++ b/webui/src/utils/__tests__/cloudflareRedirects.test.ts
@@ -9,12 +9,21 @@ describe('Cloudflare Pages redirect rules', () => {
       .split('\n')
       .map((line) => line.trim())
       .filter((line) => line && !line.startsWith('#'));
-    const apiRuleIndex = rules.indexOf('/api/* /404.html 404');
-    const spaFallbackIndex = rules.indexOf('/* /index.html 200');
+    const expectedSpaRules = [
+      '/chat / 200',
+      '/chat/* / 200',
+      '/tasks / 200',
+      '/tasks/* / 200',
+      '/agents / 200',
+      '/workspaces / 200',
+      '/history / 200',
+      '/external-sessions / 200',
+      '/workspace/* / 200',
+    ];
 
-    expect(apiRuleIndex).toBeGreaterThanOrEqual(0);
-    expect(spaFallbackIndex).toBeGreaterThanOrEqual(0);
-    expect(apiRuleIndex).toBeLessThan(spaFallbackIndex);
+    expect(rules).toEqual(expect.arrayContaining(expectedSpaRules));
+    expect(rules.some((rule) => rule.startsWith('/* '))).toBe(false);
+    expect(rules.some((rule) => rule.startsWith('/api'))).toBe(false);
   });
 
   it('ships a dedicated 404 page for non-SPA misses', () => {


### PR DESCRIPTION
## Summary
- replace the invalid Cloudflare Pages `_redirects` rules with explicit SPA deep-link rewrites to `/`
- keep API misses falling through to the hosted 404 page instead of swallowing them into the SPA shell
- add a regression test covering the hosted deep-link route set and forbidding the old catch-all/API-swallowing pattern

## Reproduction
Live `chat.gptme.org` currently serves the right asset bundle but 404s on deep links:

```txt
GET https://chat.gptme.org/chat -> 404 Not Found
GET https://chat.gptme.org/tasks -> 404 Not Found
GET https://chat.gptme.org/agents -> 404 Not Found
GET https://chat.gptme.org/workspaces -> 404 Not Found
```

The current `_redirects` is invalid for Cloudflare Pages:
- `_redirects` does not support `404` rewrites
- wildcard rewrites to `/index.html` loop because Pages canonicalizes that file to `/`

Wrangler reproduced both failures:
- old rules: `Parsed 0 valid redirect rules` / `Found 2 invalid redirect rules`
- fixed rules: `Parsed 9 valid redirect rules`

## Verification
- `curl https://chat.gptme.org/chat` still returns `404` on the live site before this change
- `/home/bob/gptme/.venv/bin/pytest -q /tmp/worktrees/gptme-webui-deeplink-6b6a/tests/test_webui_redirects.py`
- `npm run build` (worktree `webui/`)
- `npx wrangler pages dev .../webui/dist --port 8790`
  - `GET /chat -> 200`
  - `GET /chat/abc123 -> 200`
  - `GET /api/v2/tasks -> 404`
