### PR TITLE
fix(server): reject non-string step models

### DIFF
--- a/gptme/server/api_v2_sessions.py
+++ b/gptme/server/api_v2_sessions.py
@@ -290,6 +290,10 @@ def api_conversation_step(conversation_id: str):
     logdir = get_logs_dir() / conversation_id
     chat_config = ChatConfig.load_or_create(logdir, ChatConfig())
 
+    model = req_json.get("model")
+    if model is not None and not isinstance(model, str):
+        return flask.jsonify({"error": "model must be a string"}), 400
+
     stream = req_json.get("stream", chat_config.stream)
 
     # ACP opt-in: sticky once enabled for a session.
@@ -371,7 +375,6 @@ def api_conversation_step(conversation_id: str):
         # Get model from request, config, or default (in that order).
         # The frontend only sends model when the user explicitly selected one
         # (hasExplicitModelSelection), so any value here is a genuine choice.
-        model = req_json.get("model")
         if model and model != chat_config.model:
             chat_config.model = model
             chat_config.save()

--- a/tests/test_server_v2_sessions.py
+++ b/tests/test_server_v2_sessions.py
@@ -277,6 +277,27 @@ class TestStepEndpoint:
         assert data is not None
         assert "auto_confirm" in data["error"]
 
+    @pytest.mark.parametrize("bad_model", [["bad-model"], {"bad": "model"}, 123])
+    def test_invalid_model_type(self, conv, client: FlaskClient, bad_model: object):
+        """Step with non-string model returns 400 without starting generation."""
+        session = SessionManager.get_session(conv["session_id"])
+        assert session is not None
+        assert session.generating is False
+
+        response = client.post(
+            f"/api/v2/conversations/{conv['conversation_id']}/step",
+            json={
+                "session_id": conv["session_id"],
+                "model": bad_model,
+            },
+        )
+
+        assert response.status_code == 400
+        data = response.get_json()
+        assert data is not None
+        assert "model" in data["error"]
+        assert session.generating is False
+
     def test_no_model_returns_400(self, conv, client: FlaskClient):
         """Step without model when no default model set returns 400."""
         with (


### PR DESCRIPTION
## Summary
- reject non-string `model` values on `POST /api/v2/conversations/<id>/step`
- add regression coverage proving invalid `model` payloads return `400` without starting generation

## Repro
Before this patch, the server accepted:

```bash
curl -sS -X POST http://127.0.0.1:5710/api/v2/conversations/<id>/step \
  -H 'Content-Type: application/json' \
  -d '{"session_id":"...","model":["bad-model"]}'
```

The endpoint returned `200 {"status":"ok","message":"Step started",...}` and then the background step thread crashed with:

```txt
AttributeError: 'list' object has no attribute 'startswith'
```

## Testing
- `PYTHONPATH=/tmp/worktrees/gptme-api-bad-input-d90d /home/bob/gptme/.venv/bin/pytest tests/test_server_v2_sessions.py -q`
- live repro against local `gptme-server`: bad `model` payload now returns `400 {"error":"model must be a string"}` with no thread traceback
