### PR TITLE
fix(cli): reject unsafe /fork conversation ids

### DIFF
--- a/gptme/cli/cmd_chats.py
+++ b/gptme/cli/cmd_chats.py
@@ -13,8 +13,7 @@ from ..logmanager.conversations import ConversationMeta
 from ..prompt_queue import queue_prompt
 from ..tools import get_tools, init_tools
 from ..tools.chats import find_empty_conversations, list_chats, search_chats
-
-_MAX_ID_LEN = 255  # Linux NAME_MAX: max UTF-8 bytes for one path component
+from ..util.conversation_ids import is_valid_conversation_id
 
 
 def _is_valid_id(id: str) -> bool:
@@ -25,7 +24,7 @@ def _is_valid_id(id: str) -> bool:
     These would otherwise raise ``OSError: [Errno 36] File name too long``
     deep inside ``Path.exists()`` or ``os.stat()``.
     """
-    return len(id.encode()) <= _MAX_ID_LEN and "/" not in id and id not in {".", ".."}
+    return is_valid_conversation_id(id)
 
 
 def _ensure_tools():

--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -136,7 +136,6 @@ class WorkspacePath(click.ParamType):
             self.fail(f"'{value}' is not a directory.", param, ctx)
         return str(path.resolve())
 
-
 class ConversationName(click.ParamType):
     """Click type for conversation names stored under the logs directory."""
 

--- a/gptme/commands/session.py
+++ b/gptme/commands/session.py
@@ -11,7 +11,6 @@ if TYPE_CHECKING:
     from ..logmanager import LogManager
     from ..message import Message
 
-from ..util.conversation_ids import conversation_id_error
 from .base import CommandContext, command
 
 

--- a/gptme/commands/session.py
+++ b/gptme/commands/session.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
     from ..logmanager import LogManager
     from ..message import Message
 
+from ..util.conversation_ids import conversation_id_error
 from .base import CommandContext, command
 
 

--- a/gptme/logmanager/manager.py
+++ b/gptme/logmanager/manager.py
@@ -45,6 +45,7 @@ from ..dirs import get_logs_dir
 from ..message import Message, _migrate_metadata, len_tokens, print_msg
 from ..tools import ToolUse
 from ..util.context import enrich_messages_with_context
+from ..util.conversation_ids import validate_conversation_id
 from ..util.reduce import limit_log, reduce_log
 from ..util.uri import URI
 
@@ -672,8 +673,7 @@ class LogManager:
         """
         Copy the conversation folder to a new name.
         """
-        if error := conversation_name_error(name):
-            raise ValueError(error)
+        validate_conversation_id(name)
         self.write()
         logsdir = get_logs_dir()
         shutil.copytree(self.logfile.parent, logsdir / name, symlinks=True)

--- a/gptme/server/api_v2_common.py
+++ b/gptme/server/api_v2_common.py
@@ -10,6 +10,7 @@ import flask
 from typing_extensions import NotRequired
 
 from ..message import Message
+from ..util.conversation_ids import conversation_id_error
 from ..util.uri import URI, is_uri
 
 _MAX_ID_LENGTH = 255  # Linux NAME_MAX: 255 UTF-8 bytes for a single path component
@@ -25,20 +26,12 @@ def _validate_conversation_id(
 
     Returns None if valid, or (error_response, status_code) if invalid.
 
-    The ``..`` check is intentionally conservative: it rejects any ID containing
-    two consecutive dots, including names like ``my..project`` that aren't true
-    traversals. Since ``/`` and ``\\`` are already blocked, the only dangerous
-    single-component form is a bare ``..``, but substring matching is simpler
-    and the false-positive risk (rejecting ``..`` in a real conversation name)
-    is negligible in practice.
-
-    The length check prevents ``OSError: [Errno 36] File name too long`` which
-    would otherwise bubble up as an unhandled 500 for IDs longer than the
-    filesystem's NAME_MAX (typically 255 on Linux ext4/xfs).
+    The shared validator owns the exact filesystem-safety rules. This wrapper
+    keeps the server API's historical response strings stable.
     """
-    if len(conversation_id.encode()) > _MAX_ID_LENGTH:
-        return flask.jsonify({"error": "conversation_id too long"}), 400
-    if "/" in conversation_id or ".." in conversation_id or "\\" in conversation_id:
+    if error := conversation_id_error(conversation_id):
+        if "too long" in error:
+            return flask.jsonify({"error": "conversation_id too long"}), 400
         return flask.jsonify({"error": "Invalid conversation_id"}), 400
     return None
 

--- a/gptme/util/conversation_ids.py
+++ b/gptme/util/conversation_ids.py
@@ -1,0 +1,29 @@
+"""Helpers for validating conversation identifiers stored under the logs dir."""
+
+_MAX_CONVERSATION_ID_BYTES = 255  # Linux NAME_MAX for a single path component
+
+
+def conversation_id_error(value: str) -> str | None:
+    """Return a validation error for unsafe conversation identifiers, if any."""
+    if not value:
+        return "conversation name cannot be empty."
+    if len(value.encode()) > _MAX_CONVERSATION_ID_BYTES:
+        return "conversation name too long."
+    if value == "." or "/" in value or "\\" in value or ".." in value:
+        return (
+            "conversation name must be a single path component "
+            "(no '.', '/', '\\\\', or '..')."
+        )
+    return None
+
+
+def is_valid_conversation_id(value: str) -> bool:
+    """Return True when ``value`` is safe to use as a logs-dir child name."""
+    return conversation_id_error(value) is None
+
+
+def validate_conversation_id(value: str) -> str:
+    """Validate and return a safe conversation identifier."""
+    if error := conversation_id_error(value):
+        raise ValueError(error)
+    return value

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -148,6 +148,20 @@ def test_name_rejects_path_traversal(bad_name: str, runner: CliRunner):
     assert "conversation name must be a single path component" in result.output
 
 
+def test_command_fork_rejects_path_traversal(runner: CliRunner, runid: int, name: str):
+    escape_name = f"../escape-{runid}"
+    escape_path = cli.get_logs_dir().parent / f"escape-{runid}"
+
+    result = runner.invoke(
+        cli.main,
+        ["--name", name, "--non-interactive", f"/fork {escape_name}"],
+    )
+
+    assert result.exit_code == 0
+    assert "conversation name must be a single path component" in result.output
+    assert not escape_path.exists()
+
+
 def test_get_logdir_resume_named_conversation_prefers_explicit_name(runid: int):
     target_dir = _write_conversation(f"resume-target-{runid}", content="target")
     recent_dir = _write_conversation(f"resume-recent-{runid}", content="recent")

--- a/tests/test_server_path_traversal.py
+++ b/tests/test_server_path_traversal.py
@@ -25,9 +25,10 @@ from flask.testing import FlaskClient  # fmt: skip
 pytestmark = [pytest.mark.timeout(10)]
 
 
-# Payloads that bypass Flask's URL routing (no '/' so <string:> matches them)
-# Payloads with '/' are already blocked by Flask routing (<string:> doesn't match '/')
+# Payloads that bypass Flask's URL routing (no '/' so <string:> matches them).
+# Payloads with '/' are already blocked by Flask routing (<string:> doesn't match '/').
 TRAVERSAL_PAYLOADS = [
+    ".",
     "..",
     "test\\..\\..\\secret",
     "..\\..\\etc\\passwd",


### PR DESCRIPTION
## Summary
- add a shared conversation-id validator for logs-dir child names
- reject unsafe `/fork` targets before `copytree` can escape the logs directory
- cover the regression with a top-level CLI test for `/fork ../escape`

## Repro
```bash
XDG_DATA_HOME=$(mktemp -d) uv run gptme --name seed --non-interactive '/fork ../escape'
```

Before this patch, `/fork ../escape` created a sibling directory outside `logs/`.
After this patch, it prints a validation error and leaves the copied conversation inside the logs tree only.

## Test
```bash
python -m pytest tests/test_cli.py -k 'fork_rejects_path_traversal or name_rejects_path_traversal' -q
```
