### PR TITLE
fix(server): reject invalid chat config path types

### DIFF
--- a/gptme/config/chat.py
+++ b/gptme/config/chat.py
@@ -37,7 +37,7 @@ logger = logging.getLogger(__name__)
 
 def _coerce_config_path(value: object, field_name: str) -> Path:
     """Convert a JSON-provided path value to a resolved Path."""
-    if not isinstance(value, (str, os.PathLike)):
+    if not isinstance(value, str | os.PathLike):
         raise ValueError(f"chat.{field_name} must be a string path")
     return Path(value).expanduser().resolve()
 
@@ -74,7 +74,7 @@ class ChatConfig:
         return None
 
     @classmethod
-    def from_dict(cls, config_data: dict) -> Self:
+    def from_dict(cls, config_data: dict, *, create_workspace: bool = True) -> Self:
         """Create a ChatConfig instance from a dictionary. Warns about unknown keys."""
         _logdir = config_data.pop("_logdir", None)
 
@@ -91,8 +91,8 @@ class ChatConfig:
                 if not _logdir:
                     raise ValueError("Cannot use '@log' workspace without logdir")
                 chat_data["workspace"] = (_logdir / "workspace").resolve()
-                # Ensure the workspace directory exists
-                chat_data["workspace"].mkdir(parents=True, exist_ok=True)
+                if create_workspace:
+                    chat_data["workspace"].mkdir(parents=True, exist_ok=True)
             else:
                 chat_data["workspace"] = _coerce_config_path(
                     workspace_value, "workspace"

--- a/gptme/config/chat.py
+++ b/gptme/config/chat.py
@@ -35,6 +35,13 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _coerce_config_path(value: object, field_name: str) -> Path:
+    """Convert a JSON-provided path value to a resolved Path."""
+    if not isinstance(value, (str, os.PathLike)):
+        raise ValueError(f"chat.{field_name} must be a string path")
+    return Path(value).expanduser().resolve()
+
+
 @dataclass
 class ChatConfig:
     """Configuration for a chat session."""
@@ -73,6 +80,8 @@ class ChatConfig:
 
         # Extract chat settings
         chat_data = config_data.pop("chat", {})
+        if not isinstance(chat_data, dict):
+            raise ValueError("chat must be an object")
 
         # Convert workspace to Path if present and resolve to absolute path
         if "workspace" in chat_data:
@@ -85,21 +94,28 @@ class ChatConfig:
                 # Ensure the workspace directory exists
                 chat_data["workspace"].mkdir(parents=True, exist_ok=True)
             else:
-                chat_data["workspace"] = Path(workspace_value).expanduser().resolve()
+                chat_data["workspace"] = _coerce_config_path(
+                    workspace_value, "workspace"
+                )
         # For old-style config, check if workspace is in the logdir
         elif _logdir and (_logdir / "workspace").exists():
             chat_data["workspace"] = (_logdir / "workspace").resolve()
 
         # Extract agent
-        agent_path = chat_data.pop("agent", None)
-        agent = Path(agent_path).expanduser().resolve() if agent_path else None
+        _missing = object()
+        agent_path = chat_data.pop("agent", _missing)
+        if agent_path is _missing or agent_path is None or agent_path == "":
+            agent = None
+        else:
+            agent = _coerce_config_path(agent_path, "agent")
 
         env = config_data.pop("env", {})
-        mcp = (
-            MCPConfig.from_dict(config_data.pop("mcp", {}))
-            if "mcp" in config_data
-            else None
-        )
+        if not isinstance(env, dict):
+            raise ValueError("env must be an object")
+        mcp_data = config_data.pop("mcp", None)
+        if mcp_data is not None and not isinstance(mcp_data, dict):
+            raise ValueError("mcp must be an object")
+        mcp = MCPConfig.from_dict(mcp_data) if mcp_data is not None else None
 
         # Check for unknown keys
         if config_data:

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -521,6 +521,14 @@ def api_conversation_put(conversation_id: str):
     if not isinstance(config_raw, dict):
         return flask.jsonify({"error": "'config' must be an object"}), 400
 
+    # Load or create the chat config, overriding values from request config if provided
+    config_dict = dict(config_raw)
+    config_dict["_logdir"] = logdir  # Pass logdir for "@log" workspace resolution
+    try:
+        request_config = ChatConfig.from_dict(config_dict, create_workspace=False)
+    except ValueError as exc:
+        return flask.jsonify({"error": str(exc)}), 400
+
     # Create the log directory atomically to avoid TOCTOU race
     try:
         logdir.mkdir(parents=True)
@@ -530,13 +538,6 @@ def api_conversation_put(conversation_id: str):
             409,
         )
 
-    # Load or create the chat config, overriding values from request config if provided
-    config_dict = dict(config_raw)
-    config_dict["_logdir"] = logdir  # Pass logdir for "@log" workspace resolution
-    try:
-        request_config = ChatConfig.from_dict(config_dict)
-    except ValueError as exc:
-        return flask.jsonify({"error": str(exc)}), 400
     chat_config = ChatConfig.load_or_create(logdir, request_config)
     prompt = req_json.get("prompt", "full")
 

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -533,7 +533,10 @@ def api_conversation_put(conversation_id: str):
     # Load or create the chat config, overriding values from request config if provided
     config_dict = dict(config_raw)
     config_dict["_logdir"] = logdir  # Pass logdir for "@log" workspace resolution
-    request_config = ChatConfig.from_dict(config_dict)
+    try:
+        request_config = ChatConfig.from_dict(config_dict)
+    except ValueError as exc:
+        return flask.jsonify({"error": str(exc)}), 400
     chat_config = ChatConfig.load_or_create(logdir, request_config)
     prompt = req_json.get("prompt", "full")
 
@@ -1177,8 +1180,11 @@ def api_conversation_config_patch(conversation_id: str):
 
     # Create and set config
     req_json["_logdir"] = logdir  # Pass logdir for "@log" workspace resolution
-    request_config = ChatConfig.from_dict(req_json)
-    chat_config = ChatConfig.load_or_create(logdir, request_config).save()
+    try:
+        request_config = ChatConfig.from_dict(req_json)
+        chat_config = ChatConfig.load_or_create(logdir, request_config).save()
+    except ValueError as exc:
+        return flask.jsonify({"error": str(exc)}), 400
     config = Config.from_workspace(workspace=chat_config.workspace)
     config.chat = chat_config
     set_config(config)

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -1380,6 +1380,23 @@ def test_v2_chat_config_patch_rejects_non_object_json(
     assert response.get_json() == {"error": "JSON body must be an object"}
 
 
+@pytest.mark.parametrize("bad_workspace", [[], 42, {"path": "~/tmp"}])
+def test_v2_chat_config_patch_rejects_invalid_workspace_type(
+    client: FlaskClient, bad_workspace: object
+):
+    """Config PATCH should reject non-string workspace paths with 400."""
+    conv = create_conversation(client)
+    conversation_id = conv["conversation_id"]
+
+    response = client.patch(
+        f"/api/v2/conversations/{conversation_id}/config",
+        json={"chat": {"workspace": bad_workspace}},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "chat.workspace must be a string path"}
+
+
 def test_v2_chat_config_patch_rejected_during_generation(client: FlaskClient):
     """Config PATCH should return 409 when a session is actively generating."""
     conv = create_conversation(client)
@@ -1823,6 +1840,23 @@ def test_v2_create_conversation_messages_not_list(
     data = response.get_json()
     assert data is not None
     assert "messages" in data["error"].lower()
+
+
+@pytest.mark.parametrize("bad_agent", [[], 42, {"path": "~/agent"}])
+def test_v2_create_conversation_rejects_invalid_agent_type(
+    client: FlaskClient, bad_agent: object
+):
+    """PUT /conversations/<id> should reject non-string config.chat.agent values."""
+    import uuid
+
+    conv_id = f"test-bad-agent-{uuid.uuid4().hex[:8]}"
+    response = client.put(
+        f"/api/v2/conversations/{conv_id}",
+        json={"config": {"chat": {"agent": bad_agent}}},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "chat.agent must be a string path"}
 
 
 def test_v2_create_conversation_message_not_object(client: FlaskClient):

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -1071,6 +1071,22 @@ def test_v2_create_conversation_rejects_non_object_config_without_side_effects(
     assert not (logs_dir / conversation_id).exists()
 
 
+def test_v2_create_conversation_accepts_log_workspace(
+    client: FlaskClient, tmp_path, monkeypatch
+):
+    logs_dir = tmp_path / "logs"
+    conversation_id = "test-server-v2-log-workspace"
+    monkeypatch.setattr("gptme.server.api_v2.get_logs_dir", lambda: logs_dir)
+
+    response = client.put(
+        f"/api/v2/conversations/{conversation_id}",
+        json={"prompt": "none", "config": {"chat": {"workspace": "@log"}}},
+    )
+
+    assert response.status_code == 200
+    assert (logs_dir / conversation_id / "workspace").is_dir()
+
+
 def test_v2_conversation_post(v2_conv, client: FlaskClient):
     """Test posting a message to a V2 conversation."""
     conversation_id = v2_conv["conversation_id"]
@@ -1844,11 +1860,13 @@ def test_v2_create_conversation_messages_not_list(
 
 @pytest.mark.parametrize("bad_agent", [[], 42, {"path": "~/agent"}])
 def test_v2_create_conversation_rejects_invalid_agent_type(
-    client: FlaskClient, bad_agent: object
+    client: FlaskClient, tmp_path, monkeypatch, bad_agent: object
 ):
     """PUT /conversations/<id> should reject non-string config.chat.agent values."""
     import uuid
 
+    logs_dir = tmp_path / "logs"
+    monkeypatch.setattr("gptme.server.api_v2.get_logs_dir", lambda: logs_dir)
     conv_id = f"test-bad-agent-{uuid.uuid4().hex[:8]}"
     response = client.put(
         f"/api/v2/conversations/{conv_id}",
@@ -1857,6 +1875,10 @@ def test_v2_create_conversation_rejects_invalid_agent_type(
 
     assert response.status_code == 400
     assert response.get_json() == {"error": "chat.agent must be a string path"}
+    assert not (logs_dir / conv_id).exists()
+
+    retry = client.put(f"/api/v2/conversations/{conv_id}", json={"prompt": "none"})
+    assert retry.status_code == 200
 
 
 def test_v2_create_conversation_message_not_object(client: FlaskClient):


### PR DESCRIPTION
## Summary
- reject invalid nested chat config path fields before they reach pathlib
- return structured JSON 400s instead of raw 500 HTML pages from conversation create/config PATCH
- add regression coverage for bad `chat.workspace` and `chat.agent` payloads

## Repro
- `PATCH /api/v2/conversations/<id>/config` with `{"chat":{"workspace":["oops"]}}` returned a 500
- `PUT /api/v2/conversations/<id>` with `{"config":{"chat":{"agent":["oops"]}}}` returned a 500

## Testing
- `PYTHONPATH=/tmp/gptme-dogfood-3d92 /home/bob/gptme/.venv/bin/python -m pytest tests/test_server_v2.py -k "invalid_workspace_type or invalid_agent_type or chat_config_patch_rejects_non_object_json or create_conversation_non_object_body" -q`