### PR TITLE
fix(cli): reject unsafe /fork names

### DIFF
--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -35,6 +35,7 @@ from ..logmanager import (
     ConversationMeta,
     get_user_conversations,
 )
+from ..logmanager.manager import conversation_name_error
 from ..message import Message
 from ..profiles import get_profile
 from ..prompts import ContextMode, get_prompt
@@ -50,7 +51,6 @@ logger = logging.getLogger(__name__)
 
 
 script_path = Path(os.path.realpath(__file__))
-_MAX_CONVERSATION_NAME_BYTES = 255  # Linux NAME_MAX for a single path component
 _STDIN_PIPE_GRACE_PERIOD = 1.0
 
 
@@ -137,20 +137,6 @@ class WorkspacePath(click.ParamType):
         return str(path.resolve())
 
 
-def _conversation_name_error(value: str) -> str | None:
-    """Return a validation error for unsafe conversation names, if any."""
-    if not value:
-        return "conversation name cannot be empty."
-    if len(value.encode()) > _MAX_CONVERSATION_NAME_BYTES:
-        return "conversation name too long."
-    if value == "." or "/" in value or "\\" in value or ".." in value:
-        return (
-            "conversation name must be a single path component "
-            "(no '.', '/', '\\\\', or '..')."
-        )
-    return None
-
-
 class ConversationName(click.ParamType):
     """Click type for conversation names stored under the logs directory."""
 
@@ -159,7 +145,7 @@ class ConversationName(click.ParamType):
     def convert(self, value, param, ctx):
         if value == "random":
             return value
-        if error := _conversation_name_error(value):
+        if error := conversation_name_error(value):
             self.fail(error, param, ctx)
         return value
 
@@ -959,7 +945,7 @@ def get_logdir(logdir: Path | str | Literal["random"]) -> Path:
     if logdir == "random":
         logdir = logs_dir / generate_conversation_id(name="random", logs_dir=logs_dir)
     elif isinstance(logdir, str):
-        error = _conversation_name_error(logdir)
+        error = conversation_name_error(logdir)
         if error:
             raise ValueError(error)
         logdir = logs_dir / logdir

--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -33,9 +33,9 @@ from ..llm import reply as llm_reply
 from ..llm.models import get_recommended_model
 from ..logmanager import (
     ConversationMeta,
+    conversation_name_error,
     get_user_conversations,
 )
-from ..logmanager.manager import conversation_name_error
 from ..message import Message
 from ..profiles import get_profile
 from ..prompts import ContextMode, get_prompt

--- a/gptme/commands/session.py
+++ b/gptme/commands/session.py
@@ -66,7 +66,11 @@ def _complete_fork(partial: str, _prev_args: list[str]) -> list[tuple[str, str]]
 def cmd_fork(ctx: CommandContext) -> None:
     """Fork the conversation."""
     new_name = ctx.args[0] if ctx.args else input("New name: ")
-    ctx.manager.fork(new_name)
+    try:
+        ctx.manager.fork(new_name)
+    except ValueError as exc:
+        print(f"❌ {exc}")
+        return
     print(f"✅ Forked conversation to: {ctx.manager.logdir}")
 
 

--- a/gptme/logmanager/__init__.py
+++ b/gptme/logmanager/__init__.py
@@ -22,6 +22,7 @@ from .manager import (
     _current_log_var,
     _gen_read_jsonl,
     check_for_modifications,
+    conversation_name_error,
     ephemeral_cache_boundary,
     prepare_messages,
     prune_ephemeral_messages,
@@ -41,6 +42,7 @@ __all__ = [
     "ephemeral_cache_boundary",
     "check_for_modifications",
     "_gen_read_jsonl",
+    "conversation_name_error",
     # Conversation management
     "ConversationMeta",
     "get_conversations",

--- a/gptme/logmanager/manager.py
+++ b/gptme/logmanager/manager.py
@@ -54,9 +54,25 @@ logger = logging.getLogger(__name__)
 
 RoleLiteral = Literal["user", "assistant", "system"]
 
+_MAX_CONVERSATION_NAME_BYTES = 255  # Linux NAME_MAX for a single path component
+
 # Field names accepted by Message.__init__, used to drop unknown keys when
 # reading stored logs (forward-compatibility with logs from newer versions).
 _MESSAGE_FIELD_NAMES = frozenset(f.name for f in fields(Message))
+
+
+def conversation_name_error(value: str) -> str | None:
+    """Return a validation error for unsafe conversation names, if any."""
+    if not value:
+        return "conversation name cannot be empty."
+    if len(value.encode()) > _MAX_CONVERSATION_NAME_BYTES:
+        return "conversation name too long."
+    if value == "." or "/" in value or "\\" in value or ".." in value:
+        return (
+            "conversation name must be a single path component "
+            "(no '.', '/', '\\\\', or '..')."
+        )
+    return None
 
 
 @dataclass(frozen=True, repr=False)
@@ -656,6 +672,8 @@ class LogManager:
         """
         Copy the conversation folder to a new name.
         """
+        if error := conversation_name_error(name):
+            raise ValueError(error)
         self.write()
         logsdir = get_logs_dir()
         shutil.copytree(self.logfile.parent, logsdir / name, symlinks=True)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -522,6 +522,17 @@ class TestBuiltinCommands:
         list(handle_cmd("/fork test-fork-name", mock_manager))
         mock_manager.fork.assert_called_once_with("test-fork-name")
 
+    def test_fork_command_rejects_path_traversal(self, mock_manager, capsys):
+        """The /fork command should reject unsafe conversation names."""
+        mock_manager.fork.side_effect = ValueError(
+            "conversation name must be a single path component (no '.', '/', '\\\\', or '..')."
+        )
+
+        list(handle_cmd("/fork ../escape", mock_manager))
+
+        captured = capsys.readouterr()
+        assert "conversation name must be a single path component" in captured.out
+
     def test_export_command(self, mock_manager):
         """The /export command should call export_chat_to_html."""
         with patch("gptme.util.export.export_chat_to_html") as mock_export:

--- a/tests/test_logmanager.py
+++ b/tests/test_logmanager.py
@@ -52,6 +52,21 @@ def test_branch():
     assert "dev" in d["branches"]
 
 
+def test_fork_rejects_path_traversal(tmp_path: Path, monkeypatch):
+    """Fork names must stay within the logs directory."""
+    monkeypatch.setenv("GPTME_LOGS_HOME", str(tmp_path / "logs"))
+    log = LogManager(logdir=get_logs_dir() / "seed")
+    log.append(Message("user", "hello"))
+    log.write()
+
+    with pytest.raises(
+        ValueError, match="conversation name must be a single path component"
+    ):
+        log.fork("../escape")
+
+    assert not (tmp_path / "escape").exists()
+
+
 def test_write_persists_main_branch_when_on_other_branch(tmp_path: Path, monkeypatch):
     """Regression test: writing while on a non-main branch should also persist
     the main branch to conversation.jsonl."""


### PR DESCRIPTION
## Summary
- reject unsafe conversation names in the low-level fork path
- reuse the shared conversation-name validator from the CLI entrypoints
- surface a friendly `/fork` error and add regression coverage for the manager and command layers

## Reproduction
Before this patch, a real CLI run like:

```bash
gptme --name seed -n "/fork ../escape"
```

would create a sibling conversation directory outside the current log dir (`logs/../escape`).

## Testing
- `PYTHONPATH=/tmp/worktrees/gptme/fix-fork-name-validation-a90f /home/bob/gptme/.venv/bin/pytest /tmp/worktrees/gptme/fix-fork-name-validation-a90f/tests/test_logmanager.py -k 'fork_rejects_path_traversal' -q`
- `PYTHONPATH=/tmp/worktrees/gptme/fix-fork-name-validation-a90f /home/bob/gptme/.venv/bin/pytest /tmp/worktrees/gptme/fix-fork-name-validation-a90f/tests/test_commands.py -k 'fork_command' -q`
- `PYTHONPATH=/tmp/worktrees/gptme/fix-fork-name-validation-a90f /home/bob/gptme/.venv/bin/pytest /tmp/worktrees/gptme/fix-fork-name-validation-a90f/tests/test_cli.py -k 'name_rejects_path_traversal or command_fork' -q`
- real CLI repro after the fix with `PYTHONPATH=/tmp/worktrees/gptme/fix-fork-name-validation-a90f OTEL_SDK_DISABLED=true`: `/fork ../escape` now prints a validation error and does not create the escaped directory
