### PR TITLE
fix(cli): remove dead logdirs on startup validation

### DIFF
--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -5,6 +5,7 @@ import logging
 import os
 import pstats
 import select
+import shutil
 import signal
 import sys
 import traceback
@@ -610,6 +611,8 @@ def main(
             )
         return prompt_msgs
 
+    logdir_preexisting = True
+
     if resume:
         try:
             logdir = get_logdir_resume(name)
@@ -626,6 +629,7 @@ def main(
     ):
         logdir = pick_log()
     else:
+        logdir_preexisting = name != "random" and (get_logs_dir() / name).exists()
         logdir = get_logdir(name)
         prompt_msgs = inject_stdin(prompt_msgs, piped_input)
 
@@ -686,10 +690,12 @@ def main(
     if output_format == "json" and not (
         non_interactive or auto_switched_noninteractive
     ):
+        _cleanup_aborted_new_logdir(logdir, preexisting=logdir_preexisting)
         logger.error("--output-format json is only allowed with --non-interactive.")
         sys.exit(1)
 
     if not interactive and not prompt_msgs and not is_existing_conversation:
+        _cleanup_aborted_new_logdir(logdir, preexisting=logdir_preexisting)
         logger.error(
             "Non-interactive mode requires a prompt. Provide a prompt as an argument, "
             "use --resume to continue an existing conversation, or pipe input via stdin.\n\n"
@@ -978,6 +984,24 @@ def _should_print_resume_hint(logdir: Path, output_format: str) -> bool:
         return log_file.stat().st_size > 0
     except OSError:
         return False
+
+
+def _cleanup_aborted_new_logdir(logdir: Path, *, preexisting: bool) -> None:
+    """Remove logdirs created for a conversation that never actually started."""
+    if preexisting:
+        return
+
+    log_file = logdir / "conversation.jsonl"
+    try:
+        if log_file.exists() and log_file.stat().st_size > 0:
+            return
+    except OSError:
+        return
+
+    try:
+        shutil.rmtree(logdir)
+    except OSError:
+        pass
 
 
 def _read_stdin() -> str:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -223,6 +223,30 @@ def test_missing_custom_tool_path_is_reported_as_usage_error(
     assert "Traceback" not in result.output
 
 
+def test_noninteractive_missing_prompt_does_not_leave_orphan_logdir(
+    monkeypatch, tmp_path: Path
+):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "state"))
+
+    runner = CliRunner()
+
+    named = runner.invoke(
+        cli.main,
+        ["--non-interactive", "--name", "missing-prompt"],
+        input="",
+    )
+    assert named.exit_code != 0
+    assert not (cli.get_logs_dir() / "missing-prompt").exists()
+
+    random = runner.invoke(cli.main, ["--non-interactive"], input="")
+    assert random.exit_code != 0
+    logs_dir = cli.get_logs_dir()
+    assert not logs_dir.exists() or not any(logs_dir.iterdir())
+
+
 def test_should_print_resume_hint_requires_nonempty_conversation_log(tmp_path: Path):
     logdir = tmp_path / "resume-hint"
     logdir.mkdir()


### PR DESCRIPTION
## Summary
- remove brand-new conversation logdirs when CLI startup exits on validation before any conversation begins
- cover both explicit `--name` and random-name non-interactive missing-prompt failures

## Reproduction
```bash
tmp=$(mktemp -d)
HOME="$tmp" XDG_DATA_HOME="$tmp/data" XDG_STATE_HOME="$tmp/state" \
  gptme --non-interactive --name missing-prompt
```

Before this patch, the command exited with the expected validation error but still left:
- `data/gptme/logs/missing-prompt/config.toml`
- `data/gptme/logs/missing-prompt/workspace/`

The same dead-logdir residue also happened on the random-name empty-stdin path.

## Testing
- `PYTHONPATH=/tmp/worktrees/gptme/fix-cli-empty-stdin-resume-hint-ff9d /home/bob/gptme/.venv/bin/python -m pytest tests/test_cli.py -q -k 'orphan_logdir or should_print_resume_hint or missing_custom_tool_path or resume_named_missing_conversation'`
