### PR TITLE
fix(server): reject non-string elicit ids

### DIFF
--- a/gptme/server/api_v2_sessions.py
+++ b/gptme/server/api_v2_sessions.py
@@ -834,6 +834,8 @@ def api_conversation_elicit_respond(conversation_id: str):
             flask.jsonify({"error": "elicit_id and action are required"}),
             400,
         )
+    if not isinstance(elicit_id, str):
+        return flask.jsonify({"error": "elicit_id must be a string"}), 400
 
     if action not in ("accept", "decline", "cancel"):
         return (

--- a/gptme/server/api_v2_sessions.py
+++ b/gptme/server/api_v2_sessions.py
@@ -829,13 +829,18 @@ def api_conversation_elicit_respond(conversation_id: str):
     elicit_id = req_json.get("elicit_id")
     action = req_json.get("action")
 
-    if not elicit_id or not action:
+    if elicit_id is None or not action:
         return (
             flask.jsonify({"error": "elicit_id and action are required"}),
             400,
         )
     if not isinstance(elicit_id, str):
         return flask.jsonify({"error": "elicit_id must be a string"}), 400
+    if not elicit_id:
+        return (
+            flask.jsonify({"error": "elicit_id and action are required"}),
+            400,
+        )
 
     if action not in ("accept", "decline", "cancel"):
         return (

--- a/tests/test_server_v2_sessions.py
+++ b/tests/test_server_v2_sessions.py
@@ -796,6 +796,18 @@ class TestElicitRespondEndpoint:
         assert data is not None
         assert data["error"] == "elicit_id must be a string"
 
+    @pytest.mark.parametrize("elicit_id", [0, False, []])
+    def test_falsy_non_string_elicit_id(self, conv, client: FlaskClient, elicit_id):
+        """Falsy non-string elicit_id values must return the type error, not the required-fields error."""
+        response = client.post(
+            f"/api/v2/conversations/{conv['conversation_id']}/elicit/respond",
+            json={"elicit_id": elicit_id, "action": "accept"},
+        )
+        assert response.status_code == 400
+        data = response.get_json()
+        assert data is not None
+        assert data["error"] == "elicit_id must be a string"
+
     @patch("gptme.server.api_v2_sessions.resolve_hook_elicitation")
     def test_accept_action(self, mock_resolve, conv, client: FlaskClient):
         """Accept action calls resolve_hook_elicitation correctly."""

--- a/tests/test_server_v2_sessions.py
+++ b/tests/test_server_v2_sessions.py
@@ -785,6 +785,17 @@ class TestElicitRespondEndpoint:
         assert data is not None
         assert "unknown action" in data["error"].lower()
 
+    def test_non_string_elicit_id(self, conv, client: FlaskClient):
+        """Truthy non-string elicit_id values must return 400, not crash the registry lookup."""
+        response = client.post(
+            f"/api/v2/conversations/{conv['conversation_id']}/elicit/respond",
+            json={"elicit_id": ["boom"], "action": "accept"},
+        )
+        assert response.status_code == 400
+        data = response.get_json()
+        assert data is not None
+        assert data["error"] == "elicit_id must be a string"
+
     @patch("gptme.server.api_v2_sessions.resolve_hook_elicitation")
     def test_accept_action(self, mock_resolve, conv, client: FlaskClient):
         """Accept action calls resolve_hook_elicitation correctly."""


### PR DESCRIPTION
## Summary
- reject non-string `elicit_id` values at the `/api/v2/conversations/<id>/elicit/respond` boundary
- add regression coverage for truthy non-string `elicit_id` payloads

## Repro
Before this patch:
- `POST /api/v2/conversations/test-elicitation/elicit/respond` with `{"elicit_id":["boom"],"action":"accept"}` raised `TypeError: unhashable type: 'list'` inside `get_pending()` and returned an HTML 500

After this patch:
- the same request returns `400 {"error":"elicit_id must be a string"}`

## Verification
- `PYTHONPATH=/tmp/worktrees/gptme-api-bad-input-0456 /home/bob/gptme/.venv/bin/pytest /tmp/worktrees/gptme-api-bad-input-0456/tests/test_server_v2_sessions.py -q -k 'ElicitRespondEndpoint or test_non_string_elicit_id'`
- direct test-client repro of the malformed request now returns JSON 400