### PR TITLE
fix(cli): accept -t=value tool syntax

### DIFF
--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -78,7 +78,12 @@ class CommaSeparatedChoice(click.ParamType):
         self._metavar = metavar
 
     def convert(self, value, param, ctx):
+        # Click keeps the leading "=" for short options passed as `-x=value`.
+        # Normalize that form so documented examples like `-t=-browser` work.
+        value = value.removeprefix("=")
         parts = [v.strip() for v in value.split(",") if v.strip()]
+        if not parts:
+            self.fail("value cannot be empty.", param, ctx)
         for part in parts:
             check = part
             for prefix in self.allow_prefixes:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -640,6 +640,21 @@ def test_comma_separated_choice_minus_prefix():
         csc.convert("-nonexistent", None, None)
 
 
+def test_comma_separated_choice_strips_short_option_equals_prefix():
+    """Accept Click's `-x=value` short-option form for comma-separated choices."""
+    from gptme.cli.main import CommaSeparatedChoice
+
+    csc = CommaSeparatedChoice(
+        ["shell", "browser", "save", "read"], allow_prefixes=["+", "-"]
+    )
+
+    assert csc.convert("=browser", None, None) == "browser"
+    assert csc.convert("=-browser,-save", None, None) == "-browser,-save"
+
+    with pytest.raises(click.exceptions.BadParameter):
+        csc.convert("=", None, None)
+
+
 def test_tool_exclusion_mixed_bare_and_minus_raises():
     """Test that mixing bare tool names with '-' exclusion syntax raises UsageError."""
     from click.testing import CliRunner
@@ -654,3 +669,10 @@ def test_tool_exclusion_mixed_bare_and_minus_raises():
     assert "Cannot mix bare tool names" in error_text, (
         f"Expected 'Cannot mix bare tool names' in output, got: {error_text!r}"
     )
+
+
+def test_tools_short_option_equals_syntax_works(runner: CliRunner):
+    """The documented `-t=-browser` short form should parse successfully."""
+    result = runner.invoke(cli.main, ["-t=-browser", "--version"])
+    assert result.exit_code == 0, result.output
+    assert "gptme v" in result.output


### PR DESCRIPTION
## Summary
- normalize Click's short-option `-x=value` form in `CommaSeparatedChoice`
- make the documented `gptme -t=-browser ...` syntax parse correctly
- add regression coverage for both the parser and the top-level CLI

## Repro
- before this patch, `uv run gptme -t=-browser --version` failed with `invalid choice: =-browser`
- `uv run gptme --tools=-browser --version` and `uv run gptme -t -browser --version` already worked

## Verification
- `uv run --with pytest --with requests python -m pytest tests/test_cli.py -k 'comma_separated_choice or tools_short_option_equals_syntax_works'`
- `uv run gptme -t=-browser --version`
- `uv run gptme -t=browser --version`
