### PR TITLE
fix(cli): keep slash commands on json rail

### DIFF
--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -65,9 +65,11 @@ class CommaSeparatedChoice(click.ParamType):
         choices: list[str],
         allow_prefix: str | None = None,
         allow_prefixes: list[str] | None = None,
+        extra_choices_for_prefix: dict[str, list[str]] | None = None,
         metavar: str | None = None,
     ):
         self.choices = choices
+        self._choice_set = set(choices)
         # Support both single prefix and multiple prefixes
         if allow_prefixes:
             self.allow_prefixes = allow_prefixes
@@ -75,6 +77,10 @@ class CommaSeparatedChoice(click.ParamType):
             self.allow_prefixes = [allow_prefix]
         else:
             self.allow_prefixes = []
+        self.extra_choices_for_prefix = {
+            prefix: set(prefix_choices)
+            for prefix, prefix_choices in (extra_choices_for_prefix or {}).items()
+        }
         self._metavar = metavar
 
     def convert(self, value, param, ctx):
@@ -86,14 +92,21 @@ class CommaSeparatedChoice(click.ParamType):
             self.fail("value cannot be empty.", param, ctx)
         for part in parts:
             check = part
+            matched_prefix = None
             for prefix in self.allow_prefixes:
                 if check.startswith(prefix):
                     check = check[len(prefix) :]
+                    matched_prefix = prefix
                     break
             # Allow file paths (e.g. path/to/tool.py) to pass through
             if check.endswith(".py") or "/" in check or "\\" in check:
                 continue
-            if check not in self.choices:
+            extra_choices = (
+                self.extra_choices_for_prefix.get(matched_prefix, set())
+                if matched_prefix is not None
+                else set()
+            )
+            if check not in self._choice_set and check not in extra_choices:
                 self.fail(
                     f"invalid choice: {part}. (choose from {', '.join(self.choices)})",
                     param,
@@ -153,9 +166,9 @@ class ConversationName(click.ParamType):
 
 
 commands_help = "\n".join(_gen_help(incl_langtags=False))
-_available_tools = sorted(
-    tool.name for tool in get_available_tools(include_mcp=False) if tool.is_available
-)
+_builtin_tools = get_available_tools(include_mcp=False)
+_known_tool_names = sorted(tool.name for tool in _builtin_tools)
+_available_tools = sorted(tool.name for tool in _builtin_tools if tool.is_available)
 available_tool_names = ", ".join(_available_tools)
 
 
@@ -271,7 +284,10 @@ Run 'gptme-util --help' for all utility commands."""
     default=None,
     multiple=True,
     type=CommaSeparatedChoice(
-        _available_tools + ["none"], allow_prefixes=["+", "-"], metavar="TOOL"
+        _available_tools + ["none"],
+        allow_prefixes=["+", "-"],
+        extra_choices_for_prefix={"-": _known_tool_names},
+        metavar="TOOL",
     ),
     help=f"Tools to allow. Comma-separated or repeated. Use '+tool' to add to defaults (e.g., '-t +subagent'). Use '-tool' to exclude from defaults (e.g., '-t=-browser'). Use 'none' to disable all tools. Supports .py file paths for custom tools (e.g., '-t path/to/tool.py'). Available: {available_tool_names}.",
 )

--- a/gptme/commands/base.py
+++ b/gptme/commands/base.py
@@ -179,13 +179,59 @@ def _emit_json_command_output(content: str) -> None:
         print_msg(Message("assistant", content))
 
 
+def _collect_command_outputs(*captured_outputs: str) -> list[str]:
+    """Collect distinct captured outputs while preserving order."""
+    outputs: list[str] = []
+    seen: set[str] = set()
+    for output in captured_outputs:
+        output = output.rstrip("\n")
+        if output and output not in seen:
+            outputs.append(output)
+            seen.add(output)
+    return outputs
+
+
+def _yield_json_command_output(
+    handler: CommandHandler,
+    ctx: CommandContext,
+) -> Generator["Message", None, None]:
+    """Capture command stdout per generator step without hijacking yielded messages."""
+    from ..util import console  # fmt: skip
+
+    command_iter = iter(handler(ctx))
+    while True:
+        stdout_buffer = io.StringIO()
+        next_msg = None
+        completed = False
+        error = None
+        with console.capture() as console_capture, redirect_stdout(stdout_buffer):
+            try:
+                next_msg = next(command_iter)
+            except StopIteration:
+                completed = True
+            except Exception as exc:  # pragma: no cover - passthrough
+                error = exc
+
+        outputs = _collect_command_outputs(
+            stdout_buffer.getvalue(),
+            console_capture.get(),
+        )
+        if outputs:
+            _emit_json_command_output("\n".join(outputs))
+        if error is not None:
+            raise error
+        if completed:
+            return
+        assert next_msg is not None
+        yield next_msg
+
+
 def handle_cmd(
     cmd: str,
     manager: "LogManager",
 ) -> Generator["Message", None, None]:
     """Handles a command."""
     from ..message import is_output_json  # fmt: skip
-    from ..util import console  # fmt: skip
 
     cmd = cmd.lstrip("/")
     logger.debug(f"Executing command: {cmd}")
@@ -194,23 +240,12 @@ def handle_cmd(
 
     # Check if command is registered
     if name in _command_registry:
+        handler = _command_registry[name]
         ctx = CommandContext(args=args, full_args=full_args, manager=manager)
         if is_output_json():
-            stdout_buffer = io.StringIO()
-            with console.capture() as console_capture, redirect_stdout(stdout_buffer):
-                yield from _command_registry[name](ctx)
-
-            outputs = []
-            stdout_output = stdout_buffer.getvalue().rstrip("\n")
-            console_output = console_capture.get().rstrip("\n")
-            if stdout_output:
-                outputs.append(stdout_output)
-            if console_output and console_output not in outputs:
-                outputs.append(console_output)
-            if outputs:
-                _emit_json_command_output("\n".join(outputs))
+            yield from _yield_json_command_output(handler, ctx)
             return
-        yield from _command_registry[name](ctx)
+        yield from handler(ctx)
         return
 
     # Fallback to tool execution

--- a/gptme/commands/base.py
+++ b/gptme/commands/base.py
@@ -2,9 +2,11 @@
 Core command registry, decorator, and base types.
 """
 
+import io
 import logging
 import re
 from collections.abc import Callable, Generator
+from contextlib import redirect_stdout
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -168,11 +170,23 @@ def execute_cmd(msg: "Message", log: "LogManager") -> bool:
     return False
 
 
+def _emit_json_command_output(content: str) -> None:
+    """Emit captured command output as a JSON-mode assistant message."""
+    from ..message import Message, print_msg  # fmt: skip
+
+    content = content.rstrip("\n")
+    if content:
+        print_msg(Message("assistant", content))
+
+
 def handle_cmd(
     cmd: str,
     manager: "LogManager",
 ) -> Generator["Message", None, None]:
     """Handles a command."""
+    from ..message import is_output_json  # fmt: skip
+    from ..util import console  # fmt: skip
+
     cmd = cmd.lstrip("/")
     logger.debug(f"Executing command: {cmd}")
     name, *args = [s for s in re.split(r"[\n\s]", cmd) if s]
@@ -181,6 +195,21 @@ def handle_cmd(
     # Check if command is registered
     if name in _command_registry:
         ctx = CommandContext(args=args, full_args=full_args, manager=manager)
+        if is_output_json():
+            stdout_buffer = io.StringIO()
+            with console.capture() as console_capture, redirect_stdout(stdout_buffer):
+                yield from _command_registry[name](ctx)
+
+            outputs = []
+            stdout_output = stdout_buffer.getvalue().rstrip("\n")
+            console_output = console_capture.get().rstrip("\n")
+            if stdout_output:
+                outputs.append(stdout_output)
+            if console_output and console_output not in outputs:
+                outputs.append(console_output)
+            if outputs:
+                _emit_json_command_output("\n".join(outputs))
+            return
         yield from _command_registry[name](ctx)
         return
 
@@ -192,7 +221,12 @@ def handle_cmd(
         yield from tooluse.execute(log=manager.log, workspace=manager.workspace)
     else:
         manager.undo(1, quiet=True)
-        print("Unknown command. Use /help to see available commands.")
+        if is_output_json():
+            _emit_json_command_output(
+                "Unknown command. Use /help to see available commands."
+            )
+        else:
+            print("Unknown command. Use /help to see available commands.")
 
 
 def get_commands_with_descriptions() -> list[tuple[str, str]]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -654,7 +654,23 @@ def test_comma_separated_choice_strips_short_option_equals_prefix():
     with pytest.raises(click.exceptions.BadParameter):
         csc.convert("=", None, None)
 
+def test_comma_separated_choice_allows_excluding_unavailable_tools():
+    """Allow `-tool` exclusions even when that tool is unavailable locally."""
+    from gptme.cli.main import CommaSeparatedChoice
 
+    csc = CommaSeparatedChoice(
+        ["shell", "save", "read"],
+        allow_prefixes=["+", "-"],
+        extra_choices_for_prefix={"-": ["browser"]},
+    )
+
+    assert csc.convert("-browser", None, None) == "-browser"
+
+    with pytest.raises(click.exceptions.BadParameter):
+        csc.convert("browser", None, None)
+
+    with pytest.raises(click.exceptions.BadParameter):
+        csc.convert("+browser", None, None)
 def test_tool_exclusion_mixed_bare_and_minus_raises():
     """Test that mixing bare tool names with '-' exclusion syntax raises UsageError."""
     from click.testing import CliRunner

--- a/tests/test_json_output.py
+++ b/tests/test_json_output.py
@@ -487,3 +487,28 @@ class TestJSONOutputIntegration:
         assert objects[0]["content"] == "/tokens"
         assert objects[-1]["role"] == "assistant"
         assert "No cost data available" in objects[-1]["content"]
+
+    def test_impersonate_command_stdout_stays_jsonl(self, tmp_path: Path):
+        """Commands that yield Messages must still emit those messages directly in JSON mode."""
+        result = self._invoke_real_json_cli(tmp_path, "/impersonate hello")
+
+        assert result.exit_code == 0, result.stderr
+        objects = self._assert_pure_jsonl(result.stdout, min_lines=2)
+        assert len(objects) == 2
+        assert objects[0]["content"] == "/impersonate hello"
+        assert objects[1]["role"] == "assistant"
+        assert objects[1]["content"] == "hello"
+
+    def test_unknown_command_stdout_stays_jsonl(self, tmp_path: Path):
+        """Unknown commands should also stay on the JSONL rail."""
+        result = self._invoke_real_json_cli(tmp_path, "/definitely-not-a-command")
+
+        assert result.exit_code == 0, result.stderr
+        objects = self._assert_pure_jsonl(result.stdout, min_lines=2)
+        assert len(objects) == 2
+        assert objects[0]["content"] == "/definitely-not-a-command"
+        assert objects[1]["role"] == "assistant"
+        assert (
+            objects[1]["content"]
+            == "Unknown command. Use /help to see available commands."
+        )

--- a/tests/test_json_output.py
+++ b/tests/test_json_output.py
@@ -385,6 +385,23 @@ class TestJSONOutputIntegration:
             objects.append(obj)
         return objects
 
+    def _invoke_real_json_cli(self, tmp_path: Path, prompt: str):
+        """Invoke the real CLI in JSON mode with isolated data dirs and split stdout/stderr."""
+        runner_cls: Any = CliRunner
+        try:
+            runner = runner_cls(mix_stderr=False)
+        except TypeError:
+            runner = runner_cls()
+        return runner.invoke(
+            cli.main,
+            ["--output-format", "json", "--non-interactive", prompt],
+            env={
+                "HOME": str(tmp_path),
+                "XDG_DATA_HOME": str(tmp_path),
+                "XDG_STATE_HOME": str(tmp_path / "state"),
+            },
+        )
+
     def test_stdout_is_pure_jsonl(self):
         """Core invariant: stdout contains ONLY valid JSON objects, zero non-JSON lines."""
         messages = [
@@ -448,3 +465,25 @@ class TestJSONOutputIntegration:
         assert received_format == ["json"], (
             f"CLI must pass output_format='json' to chat(); got {received_format}"
         )
+
+    def test_help_command_stdout_stays_jsonl(self, tmp_path: Path):
+        """Slash commands must not leak plain text onto stdout in JSON mode."""
+        result = self._invoke_real_json_cli(tmp_path, "/help")
+
+        assert result.exit_code == 0, result.stderr
+        objects = self._assert_pure_jsonl(result.stdout, min_lines=2)
+        assert objects[0]["role"] == "user"
+        assert objects[0]["content"] == "/help"
+        assert objects[-1]["role"] == "assistant"
+        assert "Available commands:" in objects[-1]["content"]
+        assert "Keyboard shortcuts:" in objects[-1]["content"]
+
+    def test_tokens_command_stdout_stays_jsonl(self, tmp_path: Path):
+        """Rich console command output must also stay on the JSONL rail."""
+        result = self._invoke_real_json_cli(tmp_path, "/tokens")
+
+        assert result.exit_code == 0, result.stderr
+        objects = self._assert_pure_jsonl(result.stdout, min_lines=2)
+        assert objects[0]["content"] == "/tokens"
+        assert objects[-1]["role"] == "assistant"
+        assert "No cost data available" in objects[-1]["content"]


### PR DESCRIPTION
## Summary
- capture slash-command stdout/Rich output in JSON mode instead of leaking plain text onto stdout
- re-emit that command output as JSONL assistant messages so machine readers stay on the NDJSON rail
- add regression coverage for `/help` and `/tokens` in non-interactive JSON mode

## Repro
Before this patch, both of these leaked plain text after the initial JSON user event:
- `uv run gptme -n --output-format json /help`
- `uv run gptme -n --output-format json /tokens`

That broke the documented `--output-format json` contract (`one JSON object per line on stdout`).

## Validation
- `uv run --with pytest --with requests python -m pytest tests/test_json_output.py -q`
- live repro: `uv run gptme -n --output-format json /help`
- live repro: `uv run gptme -n --output-format json /tokens`