### PR TITLE
fix(cli): avoid full conversation scans on resume

### DIFF
--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -33,7 +33,6 @@ from ..llm import reply as llm_reply
 from ..llm.models import get_recommended_model
 from ..logmanager import (
     ConversationMeta,
-    get_conversation_by_id,
     get_user_conversations,
 )
 from ..message import Message
@@ -971,11 +970,12 @@ def get_logdir(logdir: Path | str | Literal["random"]) -> Path:
 
 def get_logdir_resume(name: str = "random") -> Path:
     if name != "random":
-        if conv := get_conversation_by_id(name):
-            return Path(conv.path).parent
+        logdir = get_logs_dir() / name
+        if (logdir / "conversation.jsonl").exists():
+            return logdir
         raise ValueError(f"No conversation named '{name}' to resume")
 
-    if conv := next(get_user_conversations(), None):
+    if conv := next(get_user_conversations(detail=False), None):
         return Path(conv.path).parent
     raise ValueError("No previous conversations to resume")
 

--- a/gptme/logmanager/conversations.py
+++ b/gptme/logmanager/conversations.py
@@ -341,7 +341,9 @@ def list_conversations(
     return list(islice(conversation_iter, max(limit, 0)))
 
 
-def get_conversation_by_id(conv_id: str) -> ConversationMeta | None:
+def get_conversation_by_id(
+    conv_id: str, *, detail: bool = True
+) -> ConversationMeta | None:
     """
     Get a conversation by its ID.
 
@@ -351,7 +353,7 @@ def get_conversation_by_id(conv_id: str) -> ConversationMeta | None:
     Returns:
         ConversationMeta if found, None otherwise
     """
-    for conv in get_conversations():
+    for conv in get_conversations(detail=detail):
         if conv.id == conv_id:
             return conv
     return None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -178,10 +178,10 @@ def test_get_logdir_resume_named_conversation_skips_conversation_scan(
     conv_id = f"resume-fast-{runid}"
     conv_dir = _write_conversation(conv_id, content="fast")
 
-    def fail_get_conversation_by_id(*args, **kwargs):
+    def fail_get_user_conversations(*args, **kwargs):
         raise AssertionError("named resume should not scan conversation metadata")
 
-    monkeypatch.setattr(cli, "get_conversation_by_id", fail_get_conversation_by_id)
+    monkeypatch.setattr(cli, "get_user_conversations", fail_get_user_conversations)
 
     assert cli.get_logdir_resume(conv_id) == conv_dir
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -172,6 +172,20 @@ def test_resume_named_missing_conversation_does_not_fallback_to_latest(
     assert f"No conversation named '{missing}' to resume" in result.output
 
 
+def test_get_logdir_resume_named_conversation_skips_conversation_scan(
+    monkeypatch, runid: int
+):
+    conv_id = f"resume-fast-{runid}"
+    conv_dir = _write_conversation(conv_id, content="fast")
+
+    def fail_get_conversation_by_id(*args, **kwargs):
+        raise AssertionError("named resume should not scan conversation metadata")
+
+    monkeypatch.setattr(cli, "get_conversation_by_id", fail_get_conversation_by_id)
+
+    assert cli.get_logdir_resume(conv_id) == conv_dir
+
+
 def test_missing_custom_tool_path_is_reported_as_usage_error(
     runner: CliRunner, tmp_path: Path
 ):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -671,7 +671,6 @@ def test_comma_separated_choice_strips_short_option_equals_prefix():
 def test_comma_separated_choice_allows_excluding_unavailable_tools():
     """Allow `-tool` exclusions even when that tool is unavailable locally."""
     from gptme.cli.main import CommaSeparatedChoice
-
     csc = CommaSeparatedChoice(
         ["shell", "save", "read"],
         allow_prefixes=["+", "-"],
@@ -685,6 +684,8 @@ def test_comma_separated_choice_allows_excluding_unavailable_tools():
 
     with pytest.raises(click.exceptions.BadParameter):
         csc.convert("+browser", None, None)
+
+
 def test_tool_exclusion_mixed_bare_and_minus_raises():
     """Test that mixing bare tool names with '-' exclusion syntax raises UsageError."""
     from click.testing import CliRunner


### PR DESCRIPTION
## Summary
- make named `gptme --resume --name ...` use a direct logdir existence check instead of scanning all conversation metadata
- make default `--resume` use the cheaper conversation listing path
- add a regression test that fails if named resume falls back to metadata scanning again

## Verification
- `PYTHONPATH=/tmp/gptme-cli-surface-ea11 /home/bob/gptme/.venv/bin/pytest tests/test_cli.py -q -k "resume_named_missing_conversation or get_logdir_resume_named_conversation or missing_custom_tool_path"`
- `timeout 15 uv run gptme --resume --name does-not-exist --non-interactive`
- `timeout 15 uv run gptme --tools /definitely/missing.py --non-interactive "hi"`