### PR TITLE
fix(server): reject non-string session ids

### DIFF
--- a/gptme/server/api_v2_sessions.py
+++ b/gptme/server/api_v2_sessions.py
@@ -559,7 +559,7 @@ def api_conversation_tool_confirm(conversation_id: str):
 
     if not action:
         return (
-            flask.jsonify({"error": "tool_id and action are required"}),
+            flask.jsonify({"error": "action is required"}),
             400,
         )
 

--- a/gptme/server/api_v2_sessions.py
+++ b/gptme/server/api_v2_sessions.py
@@ -76,6 +76,32 @@ def _get_request_json_object() -> dict | tuple[flask.Response, int]:
     return req_json
 
 
+def _get_required_string_field(
+    req_json: dict, field: str
+) -> str | tuple[flask.Response, int]:
+    """Return a required non-empty string field or a 400 response."""
+    value = req_json.get(field)
+    if value is None:
+        return flask.jsonify({"error": f"{field} is required"}), 400
+    if not isinstance(value, str):
+        return flask.jsonify({"error": f"{field} must be a string"}), 400
+    if not value:
+        return flask.jsonify({"error": f"{field} is required"}), 400
+    return value
+
+
+def _get_optional_string_field(
+    req_json: dict, field: str
+) -> str | None | tuple[flask.Response, int]:
+    """Return an optional string field or a 400 response."""
+    value = req_json.get(field)
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        return flask.jsonify({"error": f"{field} must be a string"}), 400
+    return value
+
+
 # Re-export step-level symbols that other modules may import from here.
 # This preserves backward compatibility after the split.
 __all__ = [
@@ -263,10 +289,9 @@ def api_conversation_step(conversation_id: str):
     req_json = _get_request_json_object()
     if not isinstance(req_json, dict):
         return req_json
-    session_id = req_json.get("session_id")
-
-    if not session_id:
-        return flask.jsonify({"error": "session_id is required"}), 400
+    session_id = _get_required_string_field(req_json, "session_id")
+    if not isinstance(session_id, str):
+        return session_id
 
     session = SessionManager.get_session(session_id)
     if session is None:
@@ -524,11 +549,15 @@ def api_conversation_tool_confirm(conversation_id: str):
     req_json = _get_request_json_object()
     if not isinstance(req_json, dict):
         return req_json
-    session_id = req_json.get("session_id")
-    tool_id = req_json.get("tool_id")
+    session_id = _get_optional_string_field(req_json, "session_id")
+    if isinstance(session_id, tuple):
+        return session_id
+    tool_id = _get_required_string_field(req_json, "tool_id")
+    if not isinstance(tool_id, str):
+        return tool_id
     action = req_json.get("action")
 
-    if not tool_id or not action:
+    if not action:
         return (
             flask.jsonify({"error": "tool_id and action are required"}),
             400,
@@ -688,10 +717,9 @@ def api_conversation_rerun(conversation_id: str):
     req_json = _get_request_json_object()
     if not isinstance(req_json, dict):
         return req_json
-    session_id = req_json.get("session_id")
-
-    if not session_id:
-        return flask.jsonify({"error": "session_id is required"}), 400
+    session_id = _get_required_string_field(req_json, "session_id")
+    if not isinstance(session_id, str):
+        return session_id
 
     session = SessionManager.get_session(session_id)
     if not session:
@@ -968,10 +996,9 @@ def api_conversation_interrupt(conversation_id: str):
     req_json = _get_request_json_object()
     if not isinstance(req_json, dict):
         return req_json
-    session_id = req_json.get("session_id")
-
-    if not session_id:
-        return flask.jsonify({"error": "session_id is required"}), 400
+    session_id = _get_required_string_field(req_json, "session_id")
+    if not isinstance(session_id, str):
+        return session_id
 
     session = SessionManager.get_session(session_id)
     if session is None:

--- a/tests/test_server_v2_sessions.py
+++ b/tests/test_server_v2_sessions.py
@@ -249,6 +249,20 @@ class TestStepEndpoint:
         )
         assert response.status_code == 404
 
+    @pytest.mark.parametrize("bad_session_id", [["boom"], {"boom": 1}, 0, False])
+    def test_non_string_session_id(
+        self, conv, client: FlaskClient, bad_session_id: object
+    ):
+        """Truthy/falsy non-string session_id values must return 400, not 500."""
+        response = client.post(
+            f"/api/v2/conversations/{conv['conversation_id']}/step",
+            json={"session_id": bad_session_id},
+        )
+        assert response.status_code == 400
+        data = response.get_json()
+        assert data is not None
+        assert data["error"] == "session_id must be a string"
+
     def test_invalid_use_acp_type(self, conv, client: FlaskClient):
         """Step with non-boolean use_acp returns 400."""
         response = client.post(
@@ -397,6 +411,20 @@ class TestInterruptEndpoint:
         )
         assert response.status_code == 404
 
+    @pytest.mark.parametrize("bad_session_id", [["boom"], {"boom": 1}, 0, False])
+    def test_non_string_session_id(
+        self, conv, client: FlaskClient, bad_session_id: object
+    ):
+        """Interrupt must reject non-string session_id values with 400."""
+        response = client.post(
+            f"/api/v2/conversations/{conv['conversation_id']}/interrupt",
+            json={"session_id": bad_session_id},
+        )
+        assert response.status_code == 400
+        data = response.get_json()
+        assert data is not None
+        assert data["error"] == "session_id must be a string"
+
     def test_interrupt_when_not_generating(self, conv, client: FlaskClient):
         """Interrupt when not generating is idempotent (returns 200)."""
         response = client.post(
@@ -455,6 +483,51 @@ class TestToolConfirmEndpoint:
             },
         )
         assert response.status_code == 400
+
+    @pytest.mark.parametrize("bad_session_id", [["boom"], {"boom": 1}, 0, False])
+    def test_non_string_session_id(
+        self, conv, client: FlaskClient, bad_session_id: object
+    ):
+        """Optional session_id must still be a string when provided."""
+        session = SessionManager.get_session(conv["session_id"])
+        assert session is not None
+        tool_id = str(uuid.uuid4())
+        session.pending_tools[tool_id] = ToolExecution(
+            tool_id=tool_id,
+            tooluse=ToolUse("bash", [], "echo test"),
+        )
+
+        try:
+            response = client.post(
+                f"/api/v2/conversations/{conv['conversation_id']}/tool/confirm",
+                json={
+                    "session_id": bad_session_id,
+                    "tool_id": tool_id,
+                    "action": "skip",
+                },
+            )
+            assert response.status_code == 400
+            data = response.get_json()
+            assert data is not None
+            assert data["error"] == "session_id must be a string"
+        finally:
+            session.pending_tools.pop(tool_id, None)
+
+    @pytest.mark.parametrize("bad_tool_id", [["boom"], {"boom": 1}, 0, False])
+    def test_non_string_tool_id(self, conv, client: FlaskClient, bad_tool_id: object):
+        """tool_id must be a string before pending-tool lookup."""
+        response = client.post(
+            f"/api/v2/conversations/{conv['conversation_id']}/tool/confirm",
+            json={
+                "session_id": conv["session_id"],
+                "tool_id": bad_tool_id,
+                "action": "skip",
+            },
+        )
+        assert response.status_code == 400
+        data = response.get_json()
+        assert data is not None
+        assert data["error"] == "tool_id must be a string"
 
     def test_tool_not_found_in_session(self, conv, client: FlaskClient):
         """Confirm with unknown tool_id in specific session returns 404."""
@@ -650,6 +723,20 @@ class TestRerunEndpoint:
             json={"session_id": "nonexistent"},
         )
         assert response.status_code == 404
+
+    @pytest.mark.parametrize("bad_session_id", [["boom"], {"boom": 1}, 0, False])
+    def test_non_string_session_id(
+        self, conv, client: FlaskClient, bad_session_id: object
+    ):
+        """Rerun must reject non-string session_id values with 400."""
+        response = client.post(
+            f"/api/v2/conversations/{conv['conversation_id']}/rerun",
+            json={"session_id": bad_session_id},
+        )
+        assert response.status_code == 400
+        data = response.get_json()
+        assert data is not None
+        assert data["error"] == "session_id must be a string"
 
     def test_rerun_while_generating(self, conv, client: FlaskClient):
         """Rerun while generation in progress returns 409."""

--- a/tests/test_server_v2_sessions.py
+++ b/tests/test_server_v2_sessions.py
@@ -483,6 +483,9 @@ class TestToolConfirmEndpoint:
             },
         )
         assert response.status_code == 400
+        data = response.get_json()
+        assert data is not None
+        assert data["error"] == "action is required"
 
     @pytest.mark.parametrize("bad_session_id", [["boom"], {"boom": 1}, 0, False])
     def test_non_string_session_id(


### PR DESCRIPTION
## Summary
- reject non-string `session_id` values on `/step`, `/rerun`, and `/interrupt` before session-map lookups
- reject non-string `session_id` and `tool_id` values on `/tool/confirm` before pending-tool lookups
- add regression coverage for truthy and falsy non-string ID payloads so malformed JSON returns 400 instead of 500

## Repro
Malformed JSON objects like `{ "session_id": ["x"] }` currently trigger `TypeError: unhashable type` and return 500 on multiple session endpoints.

## Testing
- `PYTHONPATH=/tmp/worktrees/gptme-bad-id-input-fb3e /home/bob/gptme/.venv/bin/pytest /tmp/worktrees/gptme-bad-id-input-fb3e/tests/test_server_v2_sessions.py -q`
- direct Flask test-client repro for `/step`, `/interrupt`, `/rerun`, and `/tool/confirm` now returns 400 instead of 500