### PR TITLE
fix(cli): allow --output-format json after headless auto-switch

### DIFF
--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -535,6 +535,7 @@ def main(
         atexit.register(save_profile)
 
     interactive = not non_interactive
+    auto_switched_noninteractive = False
     if version or version_json:
         from ..info import format_version_info
 
@@ -579,6 +580,7 @@ def main(
                 )
                 interactive = False
                 no_confirm = True
+                auto_switched_noninteractive = True
 
     # add prompts to prompt-toolkit history
     for prompt in prompts:
@@ -681,7 +683,9 @@ def main(
     # Validate --output-format json and --non-interactive requirements early,
     # before the expensive get_prompt() call (which can take 10+ seconds).
     # This avoids CI timeouts when the CLI will just exit with usage error.
-    if output_format == "json" and not non_interactive:
+    if output_format == "json" and not (
+        non_interactive or auto_switched_noninteractive
+    ):
         logger.error("--output-format json is only allowed with --non-interactive.")
         sys.exit(1)
 

--- a/tests/test_json_output.py
+++ b/tests/test_json_output.py
@@ -6,6 +6,7 @@ import sys
 from contextlib import redirect_stdout
 from datetime import datetime, timezone
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import patch
 
@@ -45,11 +46,15 @@ def _invoke_cli_with_captured_goodbye(monkeypatch, tmp_path: Path, args: list[st
 class TestOutputFormatValidation:
     """Tests for CLI flag validation."""
 
-    def test_json_requires_noninteractive(self):
+    def test_json_requires_noninteractive(self, monkeypatch):
         """--output-format json should error without --non-interactive."""
         runner = CliRunner()
-        # Simulate an interactive TTY so the auto-switch doesn't trigger
-        with runner.isolated_filesystem():
+        monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+        # Simulate a real interactive TTY so the auto-switch path stays off.
+        with (
+            patch("click.testing._NamedTextIOWrapper.isatty", return_value=True),
+            runner.isolated_filesystem(),
+        ):
             result = runner.invoke(
                 cli.main,
                 ["--output-format", "json", "/exit"],
@@ -77,6 +82,65 @@ class TestOutputFormatValidation:
         assert "output-format" not in exc_str, (
             f"Unexpected output-format error in exception: {result.exception}"
         )
+
+    def test_json_auto_switched_headless_prompt_is_allowed(
+        self, monkeypatch, tmp_path: Path
+    ):
+        """A prompt on non-TTY stdin auto-switches to headless mode and should allow JSON."""
+        received: list[tuple[bool, str]] = []
+
+        fake_config = SimpleNamespace(
+            chat=SimpleNamespace(
+                agent_config=None,
+                tools=[],
+                interactive=False,
+                tool_format="markdown",
+                model="local/test",
+                workspace=tmp_path,
+                stream=False,
+                agent=None,
+            ),
+            project=None,
+        )
+
+        def fake_chat(
+            prompt_msgs,
+            initial_msgs,
+            logdir,
+            workspace,
+            model,
+            stream=True,
+            no_confirm=False,
+            interactive=True,
+            show_hidden=False,
+            tool_allowlist=None,
+            tool_format=None,
+            output_schema=None,
+            output_format="text",
+        ):
+            received.append((interactive, output_format))
+
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
+        monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "state"))
+        monkeypatch.setattr(cli, "setup_config_from_cli", lambda **_: fake_config)
+        monkeypatch.setattr(cli, "init_tools", lambda _: [])
+        monkeypatch.setattr(cli, "get_prompt", lambda **_: [])
+        monkeypatch.setattr(cli, "init_telemetry", lambda **_: None)
+        monkeypatch.setattr(cli, "set_interruptible", lambda: None)
+        monkeypatch.setattr(cli.signal, "signal", lambda *args, **kwargs: None)
+
+        runner = CliRunner()
+        with patch("gptme.cli.main.chat", new=fake_chat):
+            result = runner.invoke(
+                cli.main,
+                ["--output-format", "json", "hello"],
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == 0
+        assert received == [(False, "json")]
 
     def test_json_resume_error_keeps_stdout_clean(self, monkeypatch, tmp_path):
         """JSON mode must not leak Rich logs onto stdout on early resume errors."""


### PR DESCRIPTION
## Problem

From a non-TTY environment with a prompt argument:

\`\`\`bash
gptme --output-format json hello
\`\`\`

The CLI auto-switches to non-interactive mode (`stdin is not a TTY and prompts provided, switching to non-interactive mode`), then immediately exits:

\`\`\`txt
--output-format json is only allowed with --non-interactive.
\`\`\`

This is contradictory: the CLI already decided it's headless, but the JSON gate still checks the raw `--non-interactive` flag instead of the effective mode.

## Fix

Track the auto-switch with `auto_switched_noninteractive` and accept `--output-format json` when either the explicit flag is set **or** the CLI auto-switched to headless. One-line gate change in `gptme/cli/main.py`.

## Verification

\`\`\`bash
pytest tests/test_json_output.py::TestOutputFormatValidation
\`\`\`

8 passed, including the new `test_json_auto_switched_headless_prompt_is_allowed` regression test covering the non-TTY + prompt path.

Closes #2546