### PR TITLE
feat(auth): retarget device flow from fleet-operator to Supabase edge fn

### DIFF
--- a/gptme/cli/auth.py
+++ b/gptme/cli/auth.py
@@ -34,7 +34,16 @@ def main():
     "--url",
     default="https://fleet.gptme.ai",
     show_default=True,
-    help="gptme service URL to authenticate with.",
+    help="gptme service URL (used for LLM API and token storage).",
+)
+@click.option(
+    "--auth-url",
+    default=None,
+    show_default=False,
+    help=(
+        "Override the device-auth endpoint base URL. "
+        "Defaults to the Supabase edge function used by gptme.ai."
+    ),
 )
 @click.option(
     "--no-browser",
@@ -42,7 +51,7 @@ def main():
     default=False,
     help="Don't open the browser automatically.",
 )
-def auth_login(url: str, no_browser: bool):
+def auth_login(url: str, auth_url: str | None, no_browser: bool):
     """Login to gptme cloud using RFC 8628 Device Flow.
 
     Initiates an OAuth Device Authorization Grant flow:
@@ -55,9 +64,12 @@ def auth_login(url: str, no_browser: bool):
 
     Works great for SSH sessions and headless environments.
     """
+    from ..llm.llm_gptme import DEFAULT_DEVICE_AUTH_URL
+
     base_url = url.rstrip("/")
-    authorize_url = f"{base_url}/api/v1/auth/device/authorize"
-    token_url = f"{base_url}/api/v1/auth/device/token"
+    auth_base = (auth_url or DEFAULT_DEVICE_AUTH_URL).rstrip("/")
+    authorize_url = f"{auth_base}/authorize"
+    token_url = f"{auth_base}/token"
 
     console.print(f"\n[bold]Logging in to {base_url}[/bold]\n")
 

--- a/gptme/cli/auth.py
+++ b/gptme/cli/auth.py
@@ -75,11 +75,11 @@ def auth_login(url: str, auth_url: str | None, no_browser: bool):
 
     # Step 1: Request device authorization
     try:
-        resp = requests.post(authorize_url, timeout=15)
+        resp = requests.post(authorize_url, json={"client_id": "gptme-cli"}, timeout=15)
         resp.raise_for_status()
     except requests.exceptions.ConnectionError:
-        console.print(f"[red]✗ Could not connect to {base_url}[/red]")
-        console.print("  Is the service running? Check your --url argument.")
+        console.print(f"[red]✗ Could not connect to {auth_base}[/red]")
+        console.print("  Check your --auth-url argument.")
         sys.exit(1)
     except requests.exceptions.HTTPError as e:
         console.print(
@@ -130,6 +130,7 @@ def auth_login(url: str, auth_url: str | None, no_browser: bool):
             poll_resp = requests.post(
                 token_url,
                 json={
+                    "client_id": "gptme-cli",
                     "device_code": device_code,
                     "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
                 },

--- a/gptme/llm/llm_gptme.py
+++ b/gptme/llm/llm_gptme.py
@@ -36,6 +36,11 @@ DEFAULT_BASE_URL = "https://fleet.gptme.ai/v1"
 # Default service URL (for auth endpoints, without /v1)
 DEFAULT_SERVICE_URL = "https://fleet.gptme.ai"
 
+# Device auth has moved off fleet-operator and onto Supabase edge functions.
+# The CLI polls these two endpoints during the RFC 8628 device authorization flow.
+_SUPABASE_URL = "https://kpkxgnfpyntahyhckhgm.supabase.co"
+DEFAULT_DEVICE_AUTH_URL = f"{_SUPABASE_URL}/functions/v1/device-auth"
+
 # Token storage directory
 _TOKEN_DIR = (
     Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config")) / "gptme" / "auth"
@@ -132,24 +137,30 @@ def get_base_url(config: Config) -> str:
     return DEFAULT_BASE_URL
 
 
-def device_flow_authenticate(server_url: str = DEFAULT_SERVICE_URL) -> dict:
+def device_flow_authenticate(
+    server_url: str = DEFAULT_SERVICE_URL,
+    device_auth_url: str = DEFAULT_DEVICE_AUTH_URL,
+) -> dict:
     """Perform RFC 8628 Device Flow authentication.
 
     Args:
-        server_url: Base URL of the gptme service (without /v1 suffix).
+        server_url: Base URL of the gptme LLM service (without /v1 suffix).
+            Used only for token storage keying, not for auth endpoints.
+        device_auth_url: Base URL of the device-auth edge function.
+            Defaults to the Supabase edge function that replaced the fleet-operator
+            auth endpoints (gptme-cloud#287).
 
     Returns:
         Token data dict with access_token, expires_at, server_url.
     """
     import requests
 
-    # Strip /v1 suffix for auth endpoints
-    auth_base = server_url.rstrip("/")
-    auth_base = auth_base.removesuffix("/v1")
+    auth_base = device_auth_url.rstrip("/")
+    service_base = server_url.rstrip("/").removesuffix("/v1")
 
     # Step 1: Request device authorization
     resp = requests.post(
-        f"{auth_base}/api/v1/auth/device/authorize",
+        f"{auth_base}/authorize",
         json={"client_id": "gptme-cli"},
         timeout=30,
     )
@@ -176,7 +187,7 @@ def device_flow_authenticate(server_url: str = DEFAULT_SERVICE_URL) -> dict:
 
         try:
             poll_resp = requests.post(
-                f"{auth_base}/api/v1/auth/device/token",
+                f"{auth_base}/token",
                 json={
                     "device_code": device_code,
                     "client_id": "gptme-cli",
@@ -194,13 +205,13 @@ def device_flow_authenticate(server_url: str = DEFAULT_SERVICE_URL) -> dict:
             except (json.JSONDecodeError, KeyError) as e:
                 raise RuntimeError(f"Invalid token response: {e}") from e
 
-            # Save token
+            # Save token; keyed by service URL (fleet), not auth URL (supabase)
             result = {
                 "access_token": access_token,
                 "expires_at": time.time() + token_data.get("expires_in", 86400),
-                "server_url": auth_base,
+                "server_url": service_base,
             }
-            _save_token(result, auth_base)
+            _save_token(result, service_base)
             return result
 
         if poll_resp.status_code == 428:


### PR DESCRIPTION
## Summary

- `DEFAULT_DEVICE_AUTH_URL` constant added, pointing at the new Supabase edge function (`kpkxgnfpyntahyhckhgm.supabase.co/functions/v1/device-auth`)
- `device_flow_authenticate()` now accepts an optional `device_auth_url` arg and polls `{url}/authorize` + `{url}/token` instead of the old `fleet.gptme.ai/api/v1/auth/device/*` paths
- `gptme-auth login` gets a `--auth-url` override flag for self-hosted / dev setups
- Token storage remains keyed by `server_url` (`fleet.gptme.ai`) so existing stored tokens continue to work

## Why

Companion PR to gptme/gptme-cloud#287 which moves the device-auth state machine off `fleet-operator` and onto a Supabase edge function. This PR completes the client-side cutover — the CLI was still polling the old fleet endpoints.

## Test plan

- [ ] `gptme-auth login` initiates device flow against the Supabase edge function
- [ ] `gptme-auth login --auth-url http://localhost:54321/functions/v1/device-auth` works for local dev
- [ ] Existing stored tokens (keyed to `fleet.gptme.ai`) still load correctly after upgrade
- [ ] `python3 -m py_compile gptme/cli/auth.py gptme/llm/llm_gptme.py` passes