### PR TITLE
fix(telemetry): honor OTEL_EXPORTER_OTLP_TIMEOUT for export and flush

### DIFF
--- a/gptme/util/_telemetry.py
+++ b/gptme/util/_telemetry.py
@@ -307,7 +307,7 @@ def _otlp_timeout_seconds(default: float) -> float:
         return default
     try:
         seconds = int(float(raw)) / 1000.0
-    except ValueError:
+    except (ValueError, OverflowError):
         logger.warning(
             "Invalid OTEL_EXPORTER_OTLP_TIMEOUT=%r (expected integer milliseconds); "
             "using %ss",
@@ -451,7 +451,7 @@ def init_telemetry(
 
         otlp_exporter = OTLPSpanExporter(
             endpoint=trace_endpoint,
-            timeout=export_timeout,
+            timeout=int(export_timeout),
         )
         span_processor = BatchSpanProcessor(
             otlp_exporter,
@@ -471,7 +471,7 @@ def init_telemetry(
 
             otlp_metric_exporter = OTLPMetricExporter(
                 endpoint=metric_endpoint,
-                timeout=export_timeout,
+                timeout=int(export_timeout),
             )
             metric_reader = PeriodicExportingMetricReader(
                 otlp_metric_exporter,

--- a/gptme/util/_telemetry.py
+++ b/gptme/util/_telemetry.py
@@ -306,7 +306,7 @@ def _otlp_timeout_seconds(default: float) -> float:
     if not raw:
         return default
     try:
-        seconds = int(float(raw)) / 1000.0
+        ms = int(float(raw))
     except (ValueError, OverflowError):
         logger.warning(
             "Invalid OTEL_EXPORTER_OTLP_TIMEOUT=%r (expected integer milliseconds); "
@@ -315,7 +315,15 @@ def _otlp_timeout_seconds(default: float) -> float:
             default,
         )
         return default
-    return max(0.001, seconds)
+    if ms <= 0:
+        logger.warning(
+            "Invalid OTEL_EXPORTER_OTLP_TIMEOUT=%r (must be a positive integer); "
+            "using %ss",
+            raw,
+            default,
+        )
+        return default
+    return max(0.001, ms / 1000.0)
 
 
 def init_telemetry(

--- a/gptme/util/_telemetry.py
+++ b/gptme/util/_telemetry.py
@@ -451,7 +451,7 @@ def init_telemetry(
 
         otlp_exporter = OTLPSpanExporter(
             endpoint=trace_endpoint,
-            timeout=export_timeout,
+            timeout=int(export_timeout),
         )
         span_processor = BatchSpanProcessor(
             otlp_exporter,
@@ -471,7 +471,7 @@ def init_telemetry(
 
             otlp_metric_exporter = OTLPMetricExporter(
                 endpoint=metric_endpoint,
-                timeout=export_timeout,
+                timeout=int(export_timeout),
             )
             metric_reader = PeriodicExportingMetricReader(
                 otlp_metric_exporter,

--- a/gptme/util/_telemetry.py
+++ b/gptme/util/_telemetry.py
@@ -289,6 +289,35 @@ def enrich_span_with_llm_metrics(
         span.set_attribute("llm.cost.usd", cost)
 
 
+def _otlp_timeout_seconds(default: float) -> float:
+    """OTLP export timeout in seconds, honoring the standard OTel env var.
+
+    gptme previously hardcoded the OTLP export and force-flush timeouts. When a
+    collector accepts the TCP connection but stalls on the HTTP request (a
+    half-wedged collector), every session then blocks for the full timeout on
+    shutdown, with no way to fast-fail.
+
+    This honors the standard ``OTEL_EXPORTER_OTLP_TIMEOUT`` env var (milliseconds,
+    per the OpenTelemetry spec) so operators can fast-fail an unreachable
+    collector, e.g. ``OTEL_EXPORTER_OTLP_TIMEOUT=1000`` for a 1s timeout. Falls
+    back to ``default`` seconds when unset or invalid.
+    """
+    raw = os.getenv("OTEL_EXPORTER_OTLP_TIMEOUT")
+    if not raw:
+        return default
+    try:
+        seconds = int(raw) / 1000.0
+    except ValueError:
+        logger.warning(
+            "Invalid OTEL_EXPORTER_OTLP_TIMEOUT=%r (expected integer milliseconds); "
+            "using %ss",
+            raw,
+            default,
+        )
+        return default
+    return max(0.001, seconds)
+
+
 def init_telemetry(
     service_name: str = "gptme",
     enable_flask_instrumentation: bool = True,
@@ -416,9 +445,13 @@ def init_telemetry(
         if not trace_endpoint.endswith("/v1/traces"):
             trace_endpoint = trace_endpoint.rstrip("/") + "/v1/traces"
 
+        # Export timeout (seconds). Defaults to 10s but honors
+        # OTEL_EXPORTER_OTLP_TIMEOUT so operators can fast-fail a wedged collector.
+        export_timeout = _otlp_timeout_seconds(default=10.0)
+
         otlp_exporter = OTLPSpanExporter(
             endpoint=trace_endpoint,
-            timeout=10,  # 10 second timeout for exports
+            timeout=export_timeout,
         )
         span_processor = BatchSpanProcessor(
             otlp_exporter,
@@ -438,12 +471,12 @@ def init_telemetry(
 
             otlp_metric_exporter = OTLPMetricExporter(
                 endpoint=metric_endpoint,
-                timeout=10,  # 10 second timeout for exports
+                timeout=export_timeout,
             )
             metric_reader = PeriodicExportingMetricReader(
                 otlp_metric_exporter,
                 export_interval_millis=10000,  # Export every 10 seconds (faster feedback)
-                export_timeout_millis=10000,  # 10 second timeout for export
+                export_timeout_millis=int(export_timeout * 1000),
             )
             # Configure custom histogram buckets for different metrics
             # Tool durations: 0.1s to 5min (most tools: 0.1-30s)
@@ -593,12 +626,16 @@ def shutdown_telemetry() -> None:
         logger.warning("Cannot shut down telemetry: %s", e)
         return
 
+    # Flush timeout (ms). Defaults to 5s but honors OTEL_EXPORTER_OTLP_TIMEOUT so
+    # a wedged collector doesn't block session shutdown for the full default.
+    flush_timeout_millis = int(_otlp_timeout_seconds(default=5.0) * 1000)
+
     try:
         # Force flush any pending spans before shutdown
         tracer_provider = trace.get_tracer_provider()
         if hasattr(tracer_provider, "force_flush"):
             logger.debug("Flushing pending traces...")
-            tracer_provider.force_flush(timeout_millis=5000)  # 5 second timeout
+            tracer_provider.force_flush(timeout_millis=flush_timeout_millis)
 
         # Shutdown tracer provider
         if hasattr(tracer_provider, "shutdown"):
@@ -608,7 +645,7 @@ def shutdown_telemetry() -> None:
         meter_provider = metrics.get_meter_provider()
         if hasattr(meter_provider, "force_flush"):
             logger.debug("Flushing pending metrics...")
-            meter_provider.force_flush(timeout_millis=5000)  # 5 second timeout
+            meter_provider.force_flush(timeout_millis=flush_timeout_millis)
         if hasattr(meter_provider, "shutdown"):
             logger.debug("Shutting down meter provider...")
             meter_provider.shutdown()

--- a/gptme/util/_telemetry.py
+++ b/gptme/util/_telemetry.py
@@ -451,7 +451,7 @@ def init_telemetry(
 
         otlp_exporter = OTLPSpanExporter(
             endpoint=trace_endpoint,
-            timeout=max(1, round(export_timeout)),
+            timeout=export_timeout,
         )
         span_processor = BatchSpanProcessor(
             otlp_exporter,
@@ -471,7 +471,7 @@ def init_telemetry(
 
             otlp_metric_exporter = OTLPMetricExporter(
                 endpoint=metric_endpoint,
-                timeout=max(1, round(export_timeout)),
+                timeout=export_timeout,
             )
             metric_reader = PeriodicExportingMetricReader(
                 otlp_metric_exporter,

--- a/gptme/util/_telemetry.py
+++ b/gptme/util/_telemetry.py
@@ -451,7 +451,9 @@ def init_telemetry(
 
         otlp_exporter = OTLPSpanExporter(
             endpoint=trace_endpoint,
-            timeout=int(export_timeout),
+            # round() returns int (SDK requires int); max(1, ...) avoids truncating
+            # sub-second values to 0 (which causes immediate timeout).
+            timeout=max(1, round(export_timeout)),
         )
         span_processor = BatchSpanProcessor(
             otlp_exporter,
@@ -471,7 +473,9 @@ def init_telemetry(
 
             otlp_metric_exporter = OTLPMetricExporter(
                 endpoint=metric_endpoint,
-                timeout=int(export_timeout),
+                # round() returns int (SDK requires int); max(1, ...) avoids truncating
+                # sub-second values to 0 (which causes immediate timeout).
+                timeout=max(1, round(export_timeout)),
             )
             metric_reader = PeriodicExportingMetricReader(
                 otlp_metric_exporter,

--- a/gptme/util/_telemetry.py
+++ b/gptme/util/_telemetry.py
@@ -451,7 +451,7 @@ def init_telemetry(
 
         otlp_exporter = OTLPSpanExporter(
             endpoint=trace_endpoint,
-            timeout=int(export_timeout),
+            timeout=max(1, round(export_timeout)),
         )
         span_processor = BatchSpanProcessor(
             otlp_exporter,
@@ -471,7 +471,7 @@ def init_telemetry(
 
             otlp_metric_exporter = OTLPMetricExporter(
                 endpoint=metric_endpoint,
-                timeout=int(export_timeout),
+                timeout=max(1, round(export_timeout)),
             )
             metric_reader = PeriodicExportingMetricReader(
                 otlp_metric_exporter,

--- a/gptme/util/_telemetry.py
+++ b/gptme/util/_telemetry.py
@@ -306,7 +306,7 @@ def _otlp_timeout_seconds(default: float) -> float:
     if not raw:
         return default
     try:
-        seconds = int(raw) / 1000.0
+        seconds = int(float(raw)) / 1000.0
     except ValueError:
         logger.warning(
             "Invalid OTEL_EXPORTER_OTLP_TIMEOUT=%r (expected integer milliseconds); "
@@ -628,6 +628,12 @@ def shutdown_telemetry() -> None:
 
     # Flush timeout (ms). Defaults to 5s but honors OTEL_EXPORTER_OTLP_TIMEOUT so
     # a wedged collector doesn't block session shutdown for the full default.
+    # Note: OTEL_EXPORTER_OTLP_TIMEOUT is technically a per-request HTTP timeout,
+    # but we reuse it here for the overall flush window too. Setting it short
+    # (e.g. 2000 for 2s) caps the entire force_flush, not just a single export —
+    # if the collector is slow the flush may abort before a batch completes.
+    # This is intentional: fast-fail is the point, and a separate env var would
+    # add complexity with little gain for gptme's single-batch shutdown pattern.
     flush_timeout_millis = int(_otlp_timeout_seconds(default=5.0) * 1000)
 
     try:

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -238,12 +238,20 @@ def test_otlp_timeout_seconds_invalid_falls_back(monkeypatch):
     assert _otlp_timeout_seconds(default=10.0) == 10.0
 
 
-def test_otlp_timeout_seconds_clamps_to_minimum(monkeypatch):
-    """A zero/negative timeout is clamped to a small positive value."""
+def test_otlp_timeout_seconds_zero_falls_back(monkeypatch):
+    """A zero timeout is spec-invalid (must be positive) and falls back to default."""
     from gptme.util._telemetry import _otlp_timeout_seconds
 
     monkeypatch.setenv("OTEL_EXPORTER_OTLP_TIMEOUT", "0")
-    assert _otlp_timeout_seconds(default=10.0) == 0.001
+    assert _otlp_timeout_seconds(default=10.0) == 10.0
+
+
+def test_otlp_timeout_seconds_negative_falls_back(monkeypatch):
+    """A negative timeout is spec-invalid and falls back to default with a warning."""
+    from gptme.util._telemetry import _otlp_timeout_seconds
+
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_TIMEOUT", "-1000")
+    assert _otlp_timeout_seconds(default=10.0) == 10.0
 
 
 def test_otlp_timeout_seconds_overflow_falls_back(monkeypatch):

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -244,3 +244,11 @@ def test_otlp_timeout_seconds_clamps_to_minimum(monkeypatch):
 
     monkeypatch.setenv("OTEL_EXPORTER_OTLP_TIMEOUT", "0")
     assert _otlp_timeout_seconds(default=10.0) == 0.001
+
+
+def test_otlp_timeout_seconds_overflow_falls_back(monkeypatch):
+    """An 'inf' value triggers OverflowError on int() and falls back to the default."""
+    from gptme.util._telemetry import _otlp_timeout_seconds
+
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_TIMEOUT", "inf")
+    assert _otlp_timeout_seconds(default=10.0) == 10.0

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -209,3 +209,38 @@ def test_record_hook_call_records_span():
             },
         )
     ]
+
+
+def test_otlp_timeout_seconds_default_when_unset(monkeypatch):
+    """Unset OTEL_EXPORTER_OTLP_TIMEOUT falls back to the provided default."""
+    from gptme.util._telemetry import _otlp_timeout_seconds
+
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_TIMEOUT", raising=False)
+    assert _otlp_timeout_seconds(default=10.0) == 10.0
+    assert _otlp_timeout_seconds(default=5.0) == 5.0
+
+
+def test_otlp_timeout_seconds_honors_env_milliseconds(monkeypatch):
+    """OTEL_EXPORTER_OTLP_TIMEOUT is read in milliseconds and converted to seconds."""
+    from gptme.util._telemetry import _otlp_timeout_seconds
+
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_TIMEOUT", "1000")
+    assert _otlp_timeout_seconds(default=10.0) == 1.0
+    # Same env value applies regardless of the default (fast-fail override).
+    assert _otlp_timeout_seconds(default=5.0) == 1.0
+
+
+def test_otlp_timeout_seconds_invalid_falls_back(monkeypatch):
+    """A non-integer env value falls back to the default instead of raising."""
+    from gptme.util._telemetry import _otlp_timeout_seconds
+
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_TIMEOUT", "not-a-number")
+    assert _otlp_timeout_seconds(default=10.0) == 10.0
+
+
+def test_otlp_timeout_seconds_clamps_to_minimum(monkeypatch):
+    """A zero/negative timeout is clamped to a small positive value."""
+    from gptme.util._telemetry import _otlp_timeout_seconds
+
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_TIMEOUT", "0")
+    assert _otlp_timeout_seconds(default=10.0) == 0.001


### PR DESCRIPTION
## Problem

The OTLP export and shutdown force-flush timeouts in `gptme/util/_telemetry.py` are **hardcoded**: 10s for the span/metric exporters and 5s per force-flush on shutdown. The standard OpenTelemetry env var `OTEL_EXPORTER_OTLP_TIMEOUT` is silently ignored because the explicit `timeout=` constructor args override the SDK's native env handling.

When a collector accepts the TCP connection but stalls on the HTTP request (a half-wedged collector), **every session blocks for the full timeout on shutdown** (~10s), with no way to fast-fail.

I hit this running gptme against an internal OTLP collector that accepts TCP on `:4318` but hangs HTTP `/v1/traces` until the 10s `ReadTimeout` — so every session paid ~10s at shutdown even though no data was being collected.

## Change

Honor the standard `OTEL_EXPORTER_OTLP_TIMEOUT` env var (milliseconds, per the OTel spec) for both the span/metric exporters and the shutdown force-flush.

- **Defaults unchanged**: 10s export, 5s flush. This is a no-op unless the var is set.
- Set `OTEL_EXPORTER_OTLP_TIMEOUT=1000` to fast-fail an unreachable collector with a 1s timeout, cutting the worst-case shutdown penalty from ~10s to ~2s.
- Invalid values log a warning and fall back to the default; values are clamped to a small positive minimum.

## Test plan

- Added `tests/test_telemetry.py` cases for `_otlp_timeout_seconds`: default-when-unset, env override (ms→s), invalid-falls-back, clamp-to-minimum.
- `ruff check` / `ruff format --check` clean.

Co-authored-by: Bob <bob@superuserlabs.org>