### PR TITLE
fix(webui): render a NotFound page for unmatched client-side routes

### DIFF
--- a/webui/src/App.tsx
+++ b/webui/src/App.tsx
@@ -19,6 +19,7 @@ const Agents = lazy(() => import('./pages/Agents'));
 const Workspaces = lazy(() => import('./pages/Workspaces'));
 const History = lazy(() => import('./pages/History'));
 const ExternalSessions = lazy(() => import('./pages/ExternalSessions'));
+const NotFound = lazy(() => import('./pages/NotFound'));
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -82,6 +83,7 @@ const App: FC = () => {
                       <Route path="/history" element={<History />} />
                       <Route path="/external-sessions" element={<ExternalSessions />} />
                       <Route path="/workspace/:id" element={<Workspace />} />
+                      <Route path="*" element={<NotFound />} />
                     </Routes>
                   </Suspense>
                   <SetupWizard />

--- a/webui/src/pages/NotFound.tsx
+++ b/webui/src/pages/NotFound.tsx
@@ -1,0 +1,30 @@
+import type { FC } from 'react';
+import { Link, useLocation } from 'react-router-dom';
+import { MenuBar } from '@/components/MenuBar';
+import { Button } from '@/components/ui/button';
+
+const NotFound: FC = () => {
+  const location = useLocation();
+
+  return (
+    <div className="flex h-screen flex-col">
+      <MenuBar />
+      <div className="flex flex-1 items-center justify-center">
+        <div className="text-center">
+          <h1 className="mb-4 text-2xl font-bold">Page not found</h1>
+          <p className="mb-2 text-muted-foreground">
+            No page matches <code className="font-mono">{location.pathname}</code>.
+          </p>
+          <p className="mb-4 text-sm text-muted-foreground">
+            The link may be broken, or the page may have moved.
+          </p>
+          <Button asChild>
+            <Link to="/">Go to chat</Link>
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default NotFound;


### PR DESCRIPTION
## Problem

The webui router (`webui/src/App.tsx`) had no catch-all route. When a user navigates **client-side** to a path that matches no route — via the command palette, a stale in-app link, or a bad programmatic `navigate()` — React Router renders the persistent chrome (SetupWizard, CommandPalette, Toaster) but a **blank content area** with no way back.

Found by dogfooding the live hosted webui at `chat.gptme.org`: probing routes confirmed every real route (`/`, `/chat`, `/chat/:id`, `/tasks`, `/agents`, `/history`, `/external-sessions`, `/workspaces`, `/workspace/:id`) serves the app shell, but there was no in-app handler for unmatched paths.

## Fix

- Add `webui/src/pages/NotFound.tsx` — a lazy-loaded page (matching the existing `lazy(() => import(...))` convention) that shows the mistyped path and a "Go to chat" link, using the same `MenuBar` + centered empty-state layout as other pages.
- Add `<Route path="*" element={<NotFound />} />` as the final route.

## Scope note

This is the **client-side** fallback only. Direct navigation / refresh to an unknown URL is still handled at the Cloudflare layer via an explicit route allowlist (unknown direct URLs correctly return HTTP 404 rather than masking typos with the app shell). That boundary is intentional and unchanged here.

## Validation

- `npm run typecheck` (tsc --noEmit) — clean
- `npx eslint src/pages/NotFound.tsx src/App.tsx` — clean
- `npx prettier --check` on both files — clean
