### PR TITLE
fix(logmanager): clamp over-large conversation limit to avoid islice crash

### DIFF
--- a/gptme/logmanager/conversations.py
+++ b/gptme/logmanager/conversations.py
@@ -8,6 +8,7 @@ import json
 import logging
 import re
 import shutil
+import sys
 from collections.abc import Generator
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -335,10 +336,13 @@ def list_conversations(
             If False, uses fast tail-only scan.
     """
     conversation_iter = get_conversations(detail=detail, include_test=include_test)
-    # islice() raises ValueError on negative stop values; clamp so a negative
-    # limit yields an empty result instead of crashing. The CLI rejects
-    # negatives earlier, but this also guards non-CLI callers (webui/server).
-    return list(islice(conversation_iter, max(limit, 0)))
+    # islice() raises ValueError when the stop value is negative OR greater than
+    # sys.maxsize, so clamp into the valid [0, sys.maxsize] range. A negative
+    # limit yields an empty result, and an over-large limit (e.g. ?limit=10**30
+    # or `chats list --limit 999...`) returns everything instead of crashing.
+    # The CLI rejects negatives earlier, but this also guards non-CLI callers
+    # (webui/server) and over-large values that pass the CLI's IntRange(min=1).
+    return list(islice(conversation_iter, min(max(limit, 0), sys.maxsize)))
 
 
 def get_conversation_by_id(

--- a/tests/test_conversations.py
+++ b/tests/test_conversations.py
@@ -1,6 +1,7 @@
 """Tests for conversation metadata, including last message preview."""
 
 import json
+import sys
 from pathlib import Path
 
 import pytest
@@ -342,9 +343,17 @@ def test_get_user_conversations_skips_test_logs_before_scanning(logs_dir, monkey
     assert scanned == ["real-conversation"]
 
 
-@pytest.mark.parametrize(("limit", "expected"), [(-5, 0), (0, 0), (1, 1), (10, 2)])
+@pytest.mark.parametrize(
+    ("limit", "expected"),
+    [(-5, 0), (0, 0), (1, 1), (10, 2), (sys.maxsize + 1, 2), (10**30, 2)],
+)
 def test_list_conversations_limit_bounds(logs_dir, limit, expected):
-    """list_conversations clamps non-positive limits instead of crashing islice()."""
+    """list_conversations clamps out-of-range limits instead of crashing islice().
+
+    islice() rejects stop values outside [0, sys.maxsize], so both negative
+    limits and limits larger than sys.maxsize (e.g. `chats list --limit 10**30`)
+    previously raised ValueError. Clamping returns an empty/full list instead.
+    """
     _make_conversation(
         logs_dir,
         "conv-one",


### PR DESCRIPTION
## Problem

`list_conversations()` already clamped *negative* limits (`max(limit, 0)`, added in #2496), but `itertools.islice()` also rejects stop values **greater than `sys.maxsize`**. An over-large limit reached `islice()` and crashed with a raw traceback:

```
$ gptme-util chats list --limit 999999999999999999999
ValueError: Stop argument for islice() must be None or an integer: 0 <= x <= sys.maxsize.
```

The CLI's `--limit` uses `click.IntRange(min=1)` — a lower bound but **no upper bound** — so any caller can pass a value past `sys.maxsize`. The same gap is reachable via the v2 `GET /api/v2/conversations?limit=...` path for non-clamping callers, and `chats search` is worse since it passes `10 * limit`.

## Fix

Clamp into the valid `[0, sys.maxsize]` range at the single chokepoint:

```python
return list(islice(conversation_iter, min(max(limit, 0), sys.maxsize)))
```

Over-large limits now return everything instead of raising. Found by bad-input dogfooding of the CLI; sibling of #2496.

## Test

Extended the existing `test_list_conversations_limit_bounds` parametrize with `sys.maxsize + 1` and `10**30` cases (both expect the full result set). `tests/test_conversations.py` passes (16/16); mypy clean.