### PR TITLE
fix(cli): preserve custom tool file allowlists

### DIFF
--- a/gptme/config/cli_setup.py
+++ b/gptme/config/cli_setup.py
@@ -34,7 +34,13 @@ def _get_model_default_tool_format(model: str | None) -> str | None:
 
 
 def _is_tool_file_path(value: str) -> bool:
-    return value.endswith(".py") or "/" in value or "\\" in value
+    return (
+        value.endswith(".py")
+        or value.startswith(("/", "./", "../", "~"))
+        or (
+            len(value) > 2 and value[1] == ":" and value[2] in "/\\"  # Windows C:\...
+        )
+    )
 
 
 def _normalize_tool_allowlist(allowlist: list[str] | None) -> list[str] | None:

--- a/gptme/config/cli_setup.py
+++ b/gptme/config/cli_setup.py
@@ -33,6 +33,46 @@ def _get_model_default_tool_format(model: str | None) -> str | None:
         return None
 
 
+def _is_tool_file_path(value: str) -> bool:
+    return value.endswith(".py") or "/" in value or "\\" in value
+
+
+def _normalize_tool_allowlist(allowlist: list[str] | None) -> list[str] | None:
+    """Normalize an allowlist while preserving custom tool file paths.
+
+    ``get_toolchain()`` validates and expands named tools, but custom tool files
+    are loaded later by ``init_tools()`` and must remain as file paths.
+    """
+    if allowlist is None:
+        return None
+
+    normalized: list[str] = []
+    seen: set[str] = set()
+
+    for item in allowlist:
+        if _is_tool_file_path(item):
+            resolved = Path(item).expanduser().resolve()
+            if not resolved.exists():
+                raise ValueError(f"Tool file does not exist: {item}")
+            if not resolved.is_file():
+                raise ValueError(f"Tool path is not a file: {item}")
+            if resolved.suffix != ".py":
+                raise ValueError(f"Tool file must be a .py file: {item}")
+            normalized_item = str(resolved)
+            if normalized_item not in seen:
+                normalized.append(normalized_item)
+                seen.add(normalized_item)
+            continue
+
+        for tool in get_toolchain([item]):
+            if tool.name in seen:
+                continue
+            normalized.append(tool.name)
+            seen.add(tool.name)
+
+    return normalized
+
+
 def setup_config_from_cli(
     workspace: Path,
     logdir: Path,
@@ -176,9 +216,7 @@ def setup_config_from_cli(
 
     # Set tools if not already set or if CLI override provided
     if config.chat.tools is None or tool_allowlist is not None:
-        config.chat.tools = [
-            tool.name for tool in get_toolchain(resolved_tool_allowlist)
-        ]
+        config.chat.tools = _normalize_tool_allowlist(resolved_tool_allowlist)
 
     # Save and set the final config
     config.chat.save()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1146,6 +1146,33 @@ def test_tool_exclusion_multiple(tmp_path):
         )
 
 
+def test_custom_tool_file_allowlist_preserved(tmp_path):
+    """Custom .py tool paths should survive CLI config setup unchanged."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    logdir = tmp_path / "logs"
+    logdir.mkdir()
+    tool_file = tmp_path / "custom_tool.py"
+    tool_file.write_text(
+        "from gptme.tools.base import ToolSpec\n\n"
+        "custom_tool = ToolSpec(name='custom_tool', desc='Custom tool')\n"
+    )
+
+    config = setup_config_from_cli(
+        workspace=workspace,
+        logdir=logdir,
+        model=None,
+        tool_allowlist=str(tool_file),
+        tool_format=None,
+        stream=True,
+        interactive=True,
+        agent_path=None,
+    )
+
+    assert config.chat is not None
+    assert config.chat.tools == [str(tool_file.resolve())]
+
+
 def test_set_config_value_creates_intermediate_sections(tmp_path, monkeypatch):
     """Test that set_config_value creates missing intermediate TOML sections.
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1173,6 +1173,36 @@ def test_custom_tool_file_allowlist_preserved(tmp_path):
     assert config.chat.tools == [str(tool_file.resolve())]
 
 
+def test_custom_tool_file_mixed_allowlist(tmp_path):
+    """Named tools and custom .py file paths should both be preserved in a mixed allowlist."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    logdir = tmp_path / "logs"
+    logdir.mkdir()
+    tool_file = tmp_path / "custom_tool.py"
+    tool_file.write_text(
+        "from gptme.tools.base import ToolSpec\n\n"
+        "custom_tool = ToolSpec(name='custom_tool', desc='Custom tool')\n"
+    )
+
+    config = setup_config_from_cli(
+        workspace=workspace,
+        logdir=logdir,
+        model=None,
+        tool_allowlist=f"shell,{tool_file}",
+        tool_format=None,
+        stream=True,
+        interactive=True,
+        agent_path=None,
+    )
+
+    assert config.chat is not None
+    tools = config.chat.tools
+    assert tools is not None
+    assert "shell" in tools
+    assert str(tool_file.resolve()) in tools
+
+
 def test_set_config_value_creates_intermediate_sections(tmp_path, monkeypatch):
     """Test that set_config_value creates missing intermediate TOML sections.
 


### PR DESCRIPTION
## Summary
- preserve custom `.py` tool file paths during CLI config setup instead of forcing them through named-tool expansion
- validate and resolve custom tool paths while still using `get_toolchain()` for named tools
- add a regression test covering `setup_config_from_cli(..., tool_allowlist=<tool.py>)`

## Repro
`gptme --tools path/to/custom_tool.py ...` is documented and `init_tools()` supports it, but `setup_config_from_cli()` normalized the allowlist via `get_toolchain()` and dropped file-path semantics before tool loading.

## Testing
- `uv run pytest tests/test_config.py -q`
- manual CLI check: `gptme -n -t /tmp/custom_tool.py` now loads the custom tool and exits at the expected prompt-required gate instead of dying in config resolution