### PR TITLE
fix(cli): validate architect/editor model names with clean usage error

### DIFF
--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -30,6 +30,7 @@ from ..config import setup_config_from_cli
 from ..constants import MULTIPROMPT_SEPARATOR
 from ..dirs import get_logs_dir
 from ..init import init_logging
+from ..llm import get_provider_from_model
 from ..llm import reply as llm_reply
 from ..llm.models import get_recommended_model
 from ..logmanager import (
@@ -839,6 +840,20 @@ def main(
         # Use the architect model for the planning turn, or fall back
         _arch_model = _arch_model or config.chat.model
         assert _arch_model, "Architect mode requires a model to be configured"
+
+        # Validate architect/editor model names up front so a malformed value
+        # (e.g. missing provider prefix) surfaces as a clean usage error rather
+        # than a raw traceback from llm_reply mid-planning. Mirrors the main
+        # --model path, which validates inside setup_config_from_cli above.
+        for _flag, _value in (
+            ("--architect-model", _arch_model),
+            ("--editor-model", _editor_model),
+        ):
+            if _value:
+                try:
+                    get_provider_from_model(_value)
+                except ValueError as e:
+                    raise click.UsageError(f"{_flag}: {e}") from e
 
         # Construct architect messages from first user prompt
         from ..prompts.architect import (

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -298,6 +298,7 @@ def test_missing_custom_tool_path_is_reported_as_usage_error(
     assert str(missing_tool) in result.output
     assert "Traceback" not in result.output
 
+
 def test_missing_explicit_path_prompt_is_reported_as_usage_error(
     runner: CliRunner, tmp_path: Path
 ):
@@ -316,6 +317,7 @@ def test_missing_explicit_path_prompt_is_reported_as_usage_error(
     assert "explicit local path" in result.output
     assert str(missing_path) in result.output
     assert "Traceback" not in result.output
+
 
 @pytest.mark.parametrize("flag", ["--architect-model", "--editor-model"])
 def test_architect_model_unqualified_is_usage_error(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -298,12 +298,10 @@ def test_missing_custom_tool_path_is_reported_as_usage_error(
     assert str(missing_tool) in result.output
     assert "Traceback" not in result.output
 
-
 def test_missing_explicit_path_prompt_is_reported_as_usage_error(
     runner: CliRunner, tmp_path: Path
 ):
     missing_path = tmp_path / "missing-prompt.txt"
-
     result = runner.invoke(
         cli.main,
         [
@@ -318,6 +316,36 @@ def test_missing_explicit_path_prompt_is_reported_as_usage_error(
     assert "explicit local path" in result.output
     assert str(missing_path) in result.output
     assert "Traceback" not in result.output
+
+@pytest.mark.parametrize("flag", ["--architect-model", "--editor-model"])
+def test_architect_model_unqualified_is_usage_error(
+    flag: str, runner: CliRunner, runid: int
+):
+    # A malformed architect/editor model name (no provider prefix) should be
+    # reported as a clean usage error, not a raw ValueError traceback from
+    # llm_reply mid-planning. The other model is given a valid value so the
+    # failure is unambiguously the unqualified one being validated.
+    other = "--editor-model" if flag == "--architect-model" else "--architect-model"
+
+    result = runner.invoke(
+        cli.main,
+        [
+            "--non-interactive",
+            "--name",
+            f"test-architect-model-{runid}-{flag.strip('-')}",
+            "--architect",
+            flag,
+            "bad-no-provider",
+            other,
+            "anthropic/claude-sonnet-4-5",
+            "hello",
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert "Traceback" not in result.output
+    assert flag in result.output
+    assert "provider prefix" in result.output
 
 
 def test_noninteractive_missing_prompt_does_not_leave_orphan_logdir(


### PR DESCRIPTION
## Problem

A malformed `--architect-model` / `--editor-model` value (e.g. missing the provider prefix) flowed straight into `llm_reply` during the architect planning turn and surfaced as a **raw `ValueError` traceback**:

```
$ gptme -n --architect --architect-model bad "hi"
...
ValueError: Model name must be fully qualified with provider prefix: bad
```

This is inconsistent with the main `--model` path, which validates inside `setup_config_from_cli` and reports a clean `click.UsageError` (exit code 2, no traceback).

## Fix

Validate both architect/editor model names up front in the architect block via `get_provider_from_model`, converting `ValueError` to a `click.UsageError`. Doing it before the planning turn means a bad `--editor-model` is also caught early, before any API call.

## Testing

Added a parametrized regression test (`test_architect_model_unqualified_is_usage_error`) covering both flags — asserts exit code 2, no traceback, and a helpful message. Confirmed reproduce-first: both cases fail without the fix, pass with it. Full `tests/test_cli.py` passes (43 passed, 8 skipped).

Found via the gptme CLI dogfood sweep (ErikBjare/bob#745 work-supply).