### PR TITLE
fix(models): dedup 'Unknown model' warning via log_warn_once

### DIFF
--- a/gptme/llm/models/resolution.py
+++ b/gptme/llm/models/resolution.py
@@ -286,7 +286,7 @@ def get_model(model: str) -> ModelMeta:
                 )
             return ModelMeta(provider, model_name, context=128_000)
         # Unknown provider
-        logger.warning(f"Unknown model {model}, using fallback metadata")
+        log_warn_once(f"Unknown model {model}, using fallback metadata")
         return ModelMeta(provider="unknown", model=model, context=128_000)
     # try to find model in all providers, starting with static models
     for provider in cast(list[Provider], MODELS.keys()):
@@ -318,7 +318,7 @@ def get_model(model: str) -> ModelMeta:
     except Exception as e:
         logger.debug("Failed to fetch OpenRouter models for %s: %s", model, e)
 
-    logger.warning(f"Unknown model {model}, using fallback metadata")
+    log_warn_once(f"Unknown model {model}, using fallback metadata")
     return ModelMeta(provider="unknown", model=model, context=128_000)
 
 

--- a/tests/test_llm_models_resolution.py
+++ b/tests/test_llm_models_resolution.py
@@ -336,6 +336,24 @@ class TestLogWarnOnce:
             log_warn_once(test_msg)  # second call — should be suppressed
         assert test_msg not in caplog.text
 
+    def test_get_model_unknown_warns_once(self, caplog):
+        """get_model on an unknown model should warn once across repeated calls.
+
+        Regression: the bare-name fallback used raw logger.warning instead of
+        log_warn_once, so resolving the same unknown model twice (as the CLI
+        does during setup) logged "Unknown model ..." twice.
+        """
+        import logging
+
+        unknown = "definitely-not-a-real-model-xyz"
+        with caplog.at_level(logging.WARNING):
+            get_model(unknown)
+            get_model(unknown)
+        warnings = [
+            r for r in caplog.records if f"Unknown model {unknown}" in r.getMessage()
+        ]
+        assert len(warnings) == 1
+
 
 # ── Custom provider resolution ───────────────────────────────────────────
 

--- a/tests/test_llm_models_resolution.py
+++ b/tests/test_llm_models_resolution.py
@@ -345,7 +345,7 @@ class TestLogWarnOnce:
         """
         import logging
 
-        unknown = "definitely-not-a-real-model-xyz"
+        unknown = f"definitely-not-a-real-model-{id(self)}"
         with caplog.at_level(logging.WARNING):
             get_model(unknown)
             get_model(unknown)


### PR DESCRIPTION
## Problem

Passing an unknown `--model` to the gptme CLI logs the same warning twice:

```
$ gptme --model not-a-real-model "hi" --tools none
WARNING  Unknown model not-a-real-model, using fallback metadata   resolution.py:321
WARNING  Unknown model not-a-real-model, using fallback metadata   resolution.py:321
```

`get_model()` is called more than once during CLI setup, and the two unknown-model fallback paths used raw `logger.warning(...)` — unlike the sibling fallback paths in the same function (closest-match, generic-fallback, plugin-not-found), which already route through the dedup-ing `log_warn_once` helper.

## Fix

Route both unknown-model fallback sites (`resolution.py:289` unknown-provider, `:321` bare-name) through `log_warn_once` for consistency with the rest of `get_model()`. The warning now logs once per unique model name.

## Test

Added `TestLogWarnOnce::test_get_model_unknown_warns_once`: resolves the same unknown model twice and asserts exactly one warning record. Verified it fails on `master` (2 records) and passes with the fix.

```
87 passed in tests/test_llm_models_resolution.py
ruff: All checks passed
```

Found while dogfooding the gptme CLI surface.