### PR TITLE
fix(json): keep runtime stdout pure in JSON mode

### DIFF
--- a/gptme/init.py
+++ b/gptme/init.py
@@ -22,6 +22,7 @@ from .llm.models import (
     get_recommended_model,
     set_default_model,
 )
+from .message import is_output_json
 from .tools import ToolFormat, init_tools, set_tool_format
 from .util import console
 
@@ -184,7 +185,8 @@ def init_model(
     if model_name is None:
         model_name = get_recommended_model(provider)
     model_full = f"{provider}/{model_name}"
-    console.log(f"Using model: [green]{model_full}[/green]")
+    if not is_output_json():
+        console.log(f"Using model: [green]{model_full}[/green]")
     init_llm(provider)
 
     model_meta = _resolved_meta or get_model(model_full)

--- a/gptme/init.py
+++ b/gptme/init.py
@@ -119,7 +119,7 @@ def init_model(
     if not model:  # pragma: no cover
         # auto-detect depending on if OPENAI_API_KEY or ANTHROPIC_API_KEY is set
         model = guess_provider_from_config()
-        if not model:
+        if not model and not is_output_json():
             console.print("[yellow]No API keys set, no provider available.[/yellow]")
 
     # ask user for API key

--- a/gptme/llm/__init__.py
+++ b/gptme/llm/__init__.py
@@ -12,7 +12,13 @@ from rich import print as rprint
 
 from ..config import Config, get_config
 from ..constants import prompt_assistant
-from ..message import Message, MessageMetadata, format_msgs, len_tokens
+from ..message import (
+    Message,
+    MessageMetadata,
+    format_msgs,
+    is_output_json,
+    len_tokens,
+)
 from ..telemetry import trace_function
 from ..tools import ToolSpec, ToolUse
 from ..util import console
@@ -249,7 +255,9 @@ def reply(
             on_token=on_token,
             max_tokens=max_tokens,
         )
-    rprint(f"{prompt_assistant(agent_name)}: Thinking...", end="\r")
+    json_mode = is_output_json()
+    if not json_mode:
+        rprint(f"{prompt_assistant(agent_name)}: Thinking...", end="\r")
     response, metadata = _chat_complete(
         generation_msgs,
         model,
@@ -257,8 +265,9 @@ def reply(
         output_schema=output_schema,
         max_tokens=max_tokens,
     )
-    rprint(" " * shutil.get_terminal_size().columns, end="\r")
-    rprint(f"{prompt_assistant(agent_name)}: {response}")
+    if not json_mode:
+        rprint(" " * shutil.get_terminal_size().columns, end="\r")
+        rprint(f"{prompt_assistant(agent_name)}: {response}")
     return Message("assistant", response, metadata=metadata)
 
 
@@ -429,9 +438,13 @@ def _reply_stream(
     on_token: Callable[[str], None] | None = None,
     max_tokens: int | None = None,
 ) -> Message:
-    rprint(f"{prompt_assistant(agent_name)}: Thinking...", end="\r")
+    json_mode = is_output_json()
+    if not json_mode:
+        rprint(f"{prompt_assistant(agent_name)}: Thinking...", end="\r")
 
     def print_clear(length: int = 0):
+        if json_mode:
+            return
         length = length or shutil.get_terminal_size().columns
         rprint("\r" + " " * length, end="\r")
 
@@ -457,7 +470,8 @@ def _reply_stream(
             if not output:  # first character
                 first_token_time = time.time()
                 print_clear()
-                rprint(f"{prompt_assistant(agent_name)}: \n", end="")
+                if not json_mode:
+                    rprint(f"{prompt_assistant(agent_name)}: \n", end="")
 
             # Capture thinking state before the tag-detection update below so
             # we can tell whether a transition happened at this newline.
@@ -475,24 +489,28 @@ def _reply_stream(
                     # Print spaces to clear the line
                     print_clear(len(last_line))
                     # Print styled version
-                    rprint(f"[dim]{last_line}[/dim]", end="")
+                    if not json_mode:
+                        rprint(f"[dim]{last_line}[/dim]", end="")
                     are_thinking = True
                 # Check for closing tag
                 elif last_line == "</think>" or last_line == "</thinking>":
                     print_clear(len(last_line))
                     # Print styled version
-                    rprint(f"[dim]{last_line}[/dim]", end="")
+                    if not json_mode:
+                        rprint(f"[dim]{last_line}[/dim]", end="")
                     are_thinking = False
                     just_closed_thinking = True
 
                 # Now print the newline
-                rprint(char, end="")
+                if not json_mode:
+                    rprint(char, end="")
             else:
                 # Print normal characters
-                if are_thinking:
-                    rprint(f"[dim]{char}[/dim]", end="")
-                else:
-                    rprint(char, end="")
+                if not json_mode:
+                    if are_thinking:
+                        rprint(f"[dim]{char}[/dim]", end="")
+                    else:
+                        rprint(char, end="")
 
             assert len(char) == 1
             output += char
@@ -533,7 +551,8 @@ def _reply_stream(
                 # else: are_thinking is True — skip thinking content
 
             # need to flush stdout to get the print to show up
-            sys.stdout.flush()
+            if not json_mode:
+                sys.stdout.flush()
 
             # Trigger the tool detection only if the line is finished.
             # Helps to detect nested start code blocks.
@@ -704,7 +723,8 @@ def guess_provider_from_config() -> Provider | None:
     available = list_available_providers()
     if available:
         provider, _ = available[0]  # Return first available provider
-        console.log(f"Found {provider} API key, using {provider} provider")
+        if not is_output_json():
+            console.log(f"Found {provider} API key, using {provider} provider")
         return provider
     return None
 

--- a/tests/test_json_output.py
+++ b/tests/test_json_output.py
@@ -218,19 +218,26 @@ class TestOutputFormatValidation:
 
 
 class TestJSONRuntimeSuppression:
-    """Runtime output in JSON mode must stay off the human-readable stdout rail."""
+    """Runtime output in JSON mode must stay off the human-readable stdout rail.
 
-    def test_init_model_suppresses_model_banner_in_json_mode(self, monkeypatch, capsys):
+    Uses capfd (capture file descriptors) instead of capsys because Rich's
+    Console/rprint hold a reference to the real sys.stdout at import time, so
+    capsys (which redirects the Python-level sys.stdout object) cannot intercept
+    their output. capfd captures at the OS file-descriptor level and catches
+    everything.
+    """
+
+    def test_init_model_suppresses_model_banner_in_json_mode(self, monkeypatch, capfd):
         set_output_format("json")
         monkeypatch.setattr(gptme_init, "init_llm", lambda _provider: None)
         monkeypatch.setattr(gptme_init, "set_default_model", lambda _model: None)
 
         gptme_init.init_model("openai/gpt-4o-mini", interactive=False)
 
-        captured = capsys.readouterr()
+        captured = capfd.readouterr()
         assert captured.out == ""
 
-    def test_guess_provider_suppresses_banner_in_json_mode(self, monkeypatch, capsys):
+    def test_guess_provider_suppresses_banner_in_json_mode(self, monkeypatch, capfd):
         set_output_format("json")
         monkeypatch.setattr(
             llm,
@@ -240,13 +247,33 @@ class TestJSONRuntimeSuppression:
 
         provider = llm.guess_provider_from_config()
 
-        captured = capsys.readouterr()
+        captured = capfd.readouterr()
         assert provider == "openai"
         assert captured.out == ""
 
-    def test_streaming_reply_suppresses_progress_in_json_mode(
-        self, monkeypatch, capsys
+    def test_init_model_suppresses_no_api_keys_warning_in_json_mode(
+        self, monkeypatch, capfd
     ):
+        """Init model path where no API keys are set must NOT leak the
+        'No API keys set' warning to stdout when --output-format json."""
+        set_output_format("json")
+        mock_config = SimpleNamespace(chat=None, get_env=lambda key, default=None: None)
+        monkeypatch.setattr(gptme_init, "get_config", lambda: mock_config)
+        # Must patch on gptme_init, not llm — init.py imports via `from .llm import ...`,
+        # which creates a module-level global that LOAD_GLOBAL resolves from gptme_init.
+        monkeypatch.setattr(gptme_init, "guess_provider_from_config", lambda: None)
+        monkeypatch.setattr(gptme_init, "init_llm", lambda _provider: None)
+        monkeypatch.setattr(gptme_init, "set_default_model", lambda _model: None)
+
+        # init_model raises ValueError when no keys are available
+        with pytest.raises(ValueError, match="No API key found"):
+            gptme_init.init_model(None, interactive=False)
+
+        captured = capfd.readouterr()
+        # In JSON mode, the warning must NOT leak to stdout
+        assert "No API keys set" not in captured.out
+
+    def test_streaming_reply_suppresses_progress_in_json_mode(self, monkeypatch, capfd):
         set_output_format("json")
 
         def fake_stream():
@@ -269,13 +296,11 @@ class TestJSONRuntimeSuppression:
             agent_name="bob",
         )
 
-        captured = capsys.readouterr()
+        captured = capfd.readouterr()
         assert msg.content == "OK"
         assert captured.out == ""
 
-    def test_nonstream_reply_suppresses_progress_in_json_mode(
-        self, monkeypatch, capsys
-    ):
+    def test_nonstream_reply_suppresses_progress_in_json_mode(self, monkeypatch, capfd):
         set_output_format("json")
         monkeypatch.setattr(llm, "init_llm", lambda _provider: None)
         monkeypatch.setattr(
@@ -291,7 +316,7 @@ class TestJSONRuntimeSuppression:
             stream=False,
         )
 
-        captured = capsys.readouterr()
+        captured = capfd.readouterr()
         assert msg.content == "OK"
         assert captured.out == ""
 

--- a/tests/test_json_output.py
+++ b/tests/test_json_output.py
@@ -14,6 +14,8 @@ import pytest
 from click.testing import CliRunner
 
 import gptme.cli.main as cli
+import gptme.init as gptme_init
+import gptme.llm as llm
 from gptme.message import Message, get_output_format, print_msg, set_output_format
 
 
@@ -213,6 +215,85 @@ class TestOutputFormatValidation:
         result = runner.invoke(cli.main, ["--help"])
         assert result.exit_code == 0
         assert "--output--format" in result.output or "--output-format" in result.output
+
+
+class TestJSONRuntimeSuppression:
+    """Runtime output in JSON mode must stay off the human-readable stdout rail."""
+
+    def test_init_model_suppresses_model_banner_in_json_mode(self, monkeypatch, capsys):
+        set_output_format("json")
+        monkeypatch.setattr(gptme_init, "init_llm", lambda _provider: None)
+        monkeypatch.setattr(gptme_init, "set_default_model", lambda _model: None)
+
+        gptme_init.init_model("openai/gpt-4o-mini", interactive=False)
+
+        captured = capsys.readouterr()
+        assert captured.out == ""
+
+    def test_guess_provider_suppresses_banner_in_json_mode(self, monkeypatch, capsys):
+        set_output_format("json")
+        monkeypatch.setattr(
+            llm,
+            "list_available_providers",
+            lambda: [("openai", "OPENAI_API_KEY")],
+        )
+
+        provider = llm.guess_provider_from_config()
+
+        captured = capsys.readouterr()
+        assert provider == "openai"
+        assert captured.out == ""
+
+    def test_streaming_reply_suppresses_progress_in_json_mode(
+        self, monkeypatch, capsys
+    ):
+        set_output_format("json")
+
+        def fake_stream():
+            yield "OK"
+            return {"model": "openai/gpt-4o-mini"}
+
+        monkeypatch.setattr(
+            llm,
+            "_stream",
+            lambda *args, **kwargs: llm._StreamWithMetadata(
+                fake_stream(), "openai/gpt-4o-mini"
+            ),
+        )
+
+        msg = llm._reply_stream(
+            [Message("user", "hello")],
+            "openai/gpt-4o-mini",
+            tools=None,
+            break_on_tooluse=False,
+            agent_name="bob",
+        )
+
+        captured = capsys.readouterr()
+        assert msg.content == "OK"
+        assert captured.out == ""
+
+    def test_nonstream_reply_suppresses_progress_in_json_mode(
+        self, monkeypatch, capsys
+    ):
+        set_output_format("json")
+        monkeypatch.setattr(llm, "init_llm", lambda _provider: None)
+        monkeypatch.setattr(
+            llm,
+            "_chat_complete",
+            lambda *args, **kwargs: ("OK", {"model": "openai/gpt-4o-mini"}),
+        )
+
+        msg = llm.reply(
+            [Message("user", "hello")],
+            model="openai/gpt-4o-mini",
+            tools=None,
+            stream=False,
+        )
+
+        captured = capsys.readouterr()
+        assert msg.content == "OK"
+        assert captured.out == ""
 
 
 class TestJSONRendering:


### PR DESCRIPTION
## Summary
- suppress human-readable runtime stdout in JSON mode for model/provider banners and LLM progress rendering
- keep `--output-format json` on a pure JSON/stdout rail even when a run fails after startup
- add regression tests covering `init_model`, provider auto-selection, streaming reply, and non-stream reply in JSON mode

## Repro
This surfaced while dogfooding the top-level CLI surface in headless JSON mode.

Before this patch, a command like:

```bash
uv run gptme -n --output-format json --system short --context files --tools none \
  --model openai-subscription/gpt-5.1-codex-mini --name dogfood-json \
  "Reply with exactly OK"
```

could leak human-readable stdout before failing, for example:

```text
[04:53:50] Using model: openai-subscription/gpt-5.1-codex-mini
bob: Thinking...
{"type": "message", ...}
```

That breaks JSONL consumers, supervisors, and shell pipelines expecting stdout to stay machine-readable.

## Testing
- `uv run pytest tests/test_json_output.py -q`
- reran the failing live repro and confirmed stdout now only contains the JSON message line while the fatal auth error stays on stderr
