### PR TITLE
fix(webui): retire dead cloud preset URL

### DIFF
--- a/webui/README.md
+++ b/webui/README.md
@@ -18,7 +18,7 @@ The web UI is used in several different configurations:
 | **Local dev** | Run alongside `gptme-server` for local development | `http://127.0.0.1:5700` |
 | **Desktop app** | Bundled in [gptme-tauri](https://github.com/gptme/gptme-tauri) as a native desktop app | Local gptme-server embedded |
 | **Hosted (open)** | Hosted at [chat.gptme.org](https://chat.gptme.org/) — bring your own server | User-configured |
-| **Cloud** | Managed service at [gptme.ai](https://gptme.ai) — no server setup needed | `https://api.gptme.ai` |
+| **Cloud** | Managed service at [gptme.ai](https://gptme.ai) — no server setup needed | Auto-discovered instance URL via the `gptme.ai` auth flow |
 | **Custom remote** | Connect to remote servers (VMs, workstations, agent instances) | User-configured |
 
 All modes use the same codebase. The multi-backend feature lets you connect to several of these simultaneously.

--- a/webui/src/stores/__tests__/servers.test.ts
+++ b/webui/src/stores/__tests__/servers.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from '@jest/globals';
-import { deriveServerName } from '../servers';
+import type { ServerRegistry } from '@/types/servers';
+import { deriveServerName, migrateCloudPreset } from '../servers';
 
 describe('deriveServerName', () => {
   it('returns "Local" for default-port localhost URLs', () => {
@@ -32,5 +33,44 @@ describe('deriveServerName', () => {
   it('returns "Server" for malformed URLs', () => {
     expect(deriveServerName('not-a-url')).toBe('Server');
     expect(deriveServerName('')).toBe('Server');
+  });
+});
+
+describe('migrateCloudPreset', () => {
+  it('removes the retired api.gptme.ai cloud preset by URL alone', () => {
+    const registry: ServerRegistry = {
+      activeServerId: 'stale',
+      connectedServerIds: ['stale', 'local'],
+      servers: [
+        {
+          id: 'stale',
+          name: 'Cloud',
+          baseUrl: 'https://API.GPTME.AI/',
+          authToken: 'token',
+          useAuthToken: true,
+          createdAt: 1,
+          lastUsedAt: 1,
+        },
+        {
+          id: 'local',
+          name: 'Local',
+          baseUrl: 'http://127.0.0.1:5700',
+          authToken: null,
+          useAuthToken: false,
+          createdAt: 2,
+          lastUsedAt: 2,
+          isPreset: true,
+        },
+      ],
+    };
+
+    migrateCloudPreset(registry);
+
+    expect(registry.servers).toEqual([
+      expect.objectContaining({
+        id: 'local',
+        baseUrl: 'http://127.0.0.1:5700',
+      }),
+    ]);
   });
 });

--- a/webui/src/stores/servers.ts
+++ b/webui/src/stores/servers.ts
@@ -53,7 +53,7 @@ function loadRegistry(): ServerRegistry {
  *  an instance-specific URL, so the hardcoded preset was always stale and causes CSP errors.
  *  Note: the previous migration only deleted the isPreset flag, so we filter by URL alone
  *  to also clean up entries that went through the old migration. */
-function migrateCloudPreset(registry: ServerRegistry): void {
+export function migrateCloudPreset(registry: ServerRegistry): void {
   const STALE_CLOUD_URL = 'https://api.gptme.ai';
   const normalized = (url: string) => url.toLowerCase().replace(/\/+$/, '');
   registry.servers = registry.servers.filter(


### PR DESCRIPTION
## Summary
- remove the dead `https://api.gptme.ai` URL from the public webui README
- add regression coverage for the stale-cloud-preset migration in `servers.ts`
- keep the existing auth-exchange routing coverage that points managed-cloud exchange to `fleet.gptme.ai`

## Repro
- `getent hosts api.gptme.ai` returns no records
- `curl -sS https://api.gptme.ai/api/v2/user` fails with `Could not resolve host`
- the hosted webui already contains migration code treating `api.gptme.ai` as stale, so the README was the remaining user-facing trap

## Testing
- `npm test -- --runInBand src/stores/__tests__/servers.test.ts src/utils/__tests__/connectionConfig.test.ts`