### PR TITLE
fix(server): reject malformed JSON before field validation

### DIFF
--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -459,7 +459,7 @@ def api_conversation_put(conversation_id: str):
     req_json = request.get_json(silent=True)
     if req_json is None:
         if request.get_data(cache=True):
-            return flask.jsonify({"error": "No JSON data provided"}), 400
+            return flask.jsonify({"error": "Malformed JSON in request body"}), 400
         req_json = {}
     if not isinstance(req_json, dict):
         return flask.jsonify({"error": "JSON body must be an object"}), 400
@@ -781,7 +781,7 @@ def api_conversation_edit_message(conversation_id: str, index: int):
     req_json = request.get_json(silent=True)
     if req_json is None:
         if request.get_data(cache=True):
-            return flask.jsonify({"error": "No JSON data provided"}), 400
+            return flask.jsonify({"error": "Malformed JSON in request body"}), 400
         req_json = {}
     elif not isinstance(req_json, dict):
         return flask.jsonify({"error": "JSON body must be an object"}), 400

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -780,6 +780,8 @@ def api_conversation_edit_message(conversation_id: str, index: int):
 
     req_json = request.get_json(silent=True)
     if req_json is None:
+        if request.get_data(cache=True):
+            return flask.jsonify({"error": "No JSON data provided"}), 400
         req_json = {}
     elif not isinstance(req_json, dict):
         return flask.jsonify({"error": "JSON body must be an object"}), 400

--- a/gptme/server/api_v2_sessions.py
+++ b/gptme/server/api_v2_sessions.py
@@ -73,7 +73,7 @@ def _get_request_json_object() -> dict | tuple[flask.Response, int]:
     req_json = request.get_json(silent=True)
     if req_json is None:
         if request.get_data(cache=True):
-            return flask.jsonify({"error": "No JSON data provided"}), 400
+            return flask.jsonify({"error": "Malformed JSON in request body"}), 400
         return {}
     if not isinstance(req_json, dict):
         return flask.jsonify({"error": "JSON body must be an object"}), 400

--- a/gptme/server/api_v2_sessions.py
+++ b/gptme/server/api_v2_sessions.py
@@ -66,10 +66,14 @@ def _get_request_json_object() -> dict | tuple[flask.Response, int]:
     """Return request JSON as an object or a 400 error response.
 
     Session endpoints expect JSON objects. Arrays/strings/numbers would make
-    later `.get()` access crash with AttributeError and return 500s.
+    later `.get()` access crash with AttributeError and return 500s. When the
+    client sends a non-empty malformed JSON body, surface a structured 400 here
+    instead of falling through to misleading "field is required" errors.
     """
     req_json = request.get_json(silent=True)
     if req_json is None:
+        if request.get_data(cache=True):
+            return flask.jsonify({"error": "No JSON data provided"}), 400
         return {}
     if not isinstance(req_json, dict):
         return flask.jsonify({"error": "JSON body must be an object"}), 400

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -1840,6 +1840,30 @@ def test_v2_create_conversation_malformed_json_body(client: FlaskClient):
     assert "No JSON data" in data["error"]
 
 
+def test_v2_edit_message_malformed_json_body(client: FlaskClient):
+    """PATCH /messages/<index> with malformed JSON should return a JSON 400."""
+    conversation_id = create_conversation(client)["conversation_id"]
+    response = client.post(
+        f"/api/v2/conversations/{conversation_id}",
+        json={"role": "user", "content": "Original message"},
+    )
+    assert response.status_code == 200
+
+    conversation = client.get(f"/api/v2/conversations/{conversation_id}").get_json()
+    assert conversation is not None
+    user_index = len(conversation["log"]) - 1
+
+    response = client.patch(
+        f"/api/v2/conversations/{conversation_id}/messages/{user_index}",
+        data="{bad:",
+        content_type="application/json",
+    )
+    assert response.status_code == 400
+    data = response.get_json()
+    assert data is not None
+    assert "No JSON data" in data["error"]
+
+
 @pytest.mark.parametrize("messages", ["not-a-list", 42, {"key": "val"}])
 def test_v2_create_conversation_messages_not_list(
     client: FlaskClient, messages: object

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -1823,7 +1823,7 @@ def test_v2_create_conversation_malformed_json_body(client: FlaskClient):
 
     When get_json(silent=True) encounters malformed JSON (e.g. {bad:),
     it returns None rather than raising BadRequest.  The endpoint should
-    surface a structured "No JSON data provided" error instead of the
+    surface a structured "Malformed JSON in request body" error instead of the
     raw Werkzeug 400 that flask.request.json would have produced.
     """
     import uuid
@@ -1837,7 +1837,7 @@ def test_v2_create_conversation_malformed_json_body(client: FlaskClient):
     assert response.status_code == 400
     data = response.get_json()
     assert data is not None
-    assert "No JSON data" in data["error"]
+    assert data == {"error": "Malformed JSON in request body"}
 
 
 def test_v2_edit_message_malformed_json_body(client: FlaskClient):
@@ -1861,7 +1861,7 @@ def test_v2_edit_message_malformed_json_body(client: FlaskClient):
     assert response.status_code == 400
     data = response.get_json()
     assert data is not None
-    assert "No JSON data" in data["error"]
+    assert data == {"error": "Malformed JSON in request body"}
 
 
 @pytest.mark.parametrize("messages", ["not-a-list", 42, {"key": "val"}])

--- a/tests/test_server_v2_sessions.py
+++ b/tests/test_server_v2_sessions.py
@@ -392,6 +392,23 @@ def test_session_endpoints_reject_non_object_json(
     assert response.get_json() == {"error": "JSON body must be an object"}
 
 
+@pytest.mark.parametrize(
+    "endpoint", ["step", "tool/confirm", "rerun", "elicit/respond", "interrupt"]
+)
+def test_session_endpoints_reject_malformed_json(
+    conv, client: FlaskClient, endpoint: str
+):
+    """Malformed JSON should return a structured 400 before field validation."""
+    response = client.post(
+        f"/api/v2/conversations/{conv['conversation_id']}/{endpoint}",
+        data="{bad:",
+        content_type="application/json",
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "No JSON data provided"}
+
+
 class TestInterruptEndpoint:
     """Test POST /api/v2/conversations/<id>/interrupt validation."""
 

--- a/tests/test_server_v2_sessions.py
+++ b/tests/test_server_v2_sessions.py
@@ -406,7 +406,7 @@ def test_session_endpoints_reject_malformed_json(
     )
 
     assert response.status_code == 400
-    assert response.get_json() == {"error": "No JSON data provided"}
+    assert response.get_json() == {"error": "Malformed JSON in request body"}
 
 
 class TestInterruptEndpoint:


### PR DESCRIPTION
## Summary
Reject malformed non-empty JSON bodies at the request boundary for:
- V2 session endpoints (`step`, `tool/confirm`, `rerun`, `elicit/respond`, `interrupt`)
- V2 edit-message endpoint

Previously these requests fell through to field-level validation and returned misleading errors like `session_id is required`, `tool_id is required`, or `content or files is required`.

## Reproduction
Before this patch, sending `Content-Type: application/json` with a malformed body like `{bad:` produced:
- `POST /api/v2/conversations/<id>/step` -> `400 {"error": "session_id is required"}`
- `POST /api/v2/conversations/<id>/tool/confirm` -> `400 {"error": "tool_id is required"}`
- `PATCH /api/v2/conversations/<id>/messages/<index>` -> `400 {"error": "content or files is required"}`

After this patch, all of them return the correct boundary error:
- `400 {"error": "No JSON data provided"}`

## Tests
- `uv run --directory /tmp/gptme-server-json-27e9 --extra server --with pytest --with pytest-timeout python -m pytest -q tests/test_server_v2_sessions.py -k "malformed_json or reject_non_object_json"`
- `uv run --directory /tmp/gptme-server-json-27e9 --extra server --with pytest --with pytest-timeout python -m pytest -q tests/test_server_v2.py -k "edit_message_malformed_json_body or create_conversation_malformed_json_body"`
