### PR TITLE
fix(cli): reject missing explicit path prompts early

### DIFF
--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -9,7 +9,6 @@ import shutil
 import signal
 import sys
 import traceback
-import urllib.parse
 from datetime import datetime, timezone
 from itertools import islice
 from pathlib import Path
@@ -174,10 +173,6 @@ def _extract_missing_explicit_local_path(prompt: str) -> str | None:
         and candidate[0].isalpha()
     )
     if not explicit_local:
-        return None
-
-    parsed = urllib.parse.urlparse(candidate)
-    if parsed.scheme in ("http", "https") and parsed.netloc:
         return None
 
     try:

--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -9,6 +9,7 @@ import shutil
 import signal
 import sys
 import traceback
+import urllib.parse
 from datetime import datetime, timezone
 from itertools import islice
 from pathlib import Path
@@ -137,6 +138,7 @@ class WorkspacePath(click.ParamType):
             self.fail(f"'{value}' is not a directory.", param, ctx)
         return str(path.resolve())
 
+
 class ConversationName(click.ParamType):
     """Click type for conversation names stored under the logs directory."""
 
@@ -148,6 +150,42 @@ class ConversationName(click.ParamType):
         if error := conversation_name_error(value):
             self.fail(error, param, ctx)
         return value
+
+
+def _extract_missing_explicit_local_path(prompt: str) -> str | None:
+    """Return an explicit local-path prompt that is missing on disk.
+
+    Only catches unambiguous local path forms so ordinary text prompts and
+    repo/host-style strings like ``github.com/org/repo`` keep working.
+    """
+    from ..util.content import is_message_command
+
+    stripped = prompt.strip()
+    if not stripped or any(ch.isspace() for ch in stripped):
+        return None
+    if is_message_command(stripped):
+        return None
+
+    candidate = stripped.removeprefix("@")
+    explicit_local = candidate.startswith(("/", "~/", "./", "../")) or (
+        len(candidate) >= 3
+        and candidate[1] == ":"
+        and candidate[2] in ("/", "\\")
+        and candidate[0].isalpha()
+    )
+    if not explicit_local:
+        return None
+
+    parsed = urllib.parse.urlparse(candidate)
+    if parsed.scheme in ("http", "https") and parsed.netloc:
+        return None
+
+    try:
+        if Path(candidate).expanduser().exists():
+            return None
+    except OSError:
+        return None
+    return candidate
 
 
 commands_help = "\n".join(_gen_help(incl_langtags=False))
@@ -639,6 +677,15 @@ def main(
             print(f"\nGoodbye! (resume with: gptme --name {logdir.name})")
 
     atexit.register(goodbye_handler)
+
+    for prompt_msg in prompt_msgs:
+        missing_path = _extract_missing_explicit_local_path(prompt_msg.content)
+        if missing_path:
+            _cleanup_aborted_new_logdir(logdir, preexisting=logdir_preexisting)
+            raise click.UsageError(
+                "Prompt looks like an explicit local path, but it does not exist: "
+                f"{missing_path}"
+            )
 
     if workspace == "@log":
         workspace_path: Path | None = logdir / "workspace"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -223,6 +223,27 @@ def test_missing_custom_tool_path_is_reported_as_usage_error(
     assert "Traceback" not in result.output
 
 
+def test_missing_explicit_path_prompt_is_reported_as_usage_error(
+    runner: CliRunner, tmp_path: Path
+):
+    missing_path = tmp_path / "missing-prompt.txt"
+
+    result = runner.invoke(
+        cli.main,
+        [
+            "--non-interactive",
+            "--name",
+            "missing-explicit-path-prompt",
+            str(missing_path),
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert "explicit local path" in result.output
+    assert str(missing_path) in result.output
+    assert "Traceback" not in result.output
+
+
 def test_noninteractive_missing_prompt_does_not_leave_orphan_logdir(
     monkeypatch, tmp_path: Path
 ):
@@ -706,9 +727,11 @@ def test_comma_separated_choice_strips_short_option_equals_prefix():
     with pytest.raises(click.exceptions.BadParameter):
         csc.convert("=", None, None)
 
+
 def test_comma_separated_choice_allows_excluding_unavailable_tools():
     """Allow `-tool` exclusions even when that tool is unavailable locally."""
     from gptme.cli.main import CommaSeparatedChoice
+
     csc = CommaSeparatedChoice(
         ["shell", "save", "read"],
         allow_prefixes=["+", "-"],

--- a/tests/test_json_output.py
+++ b/tests/test_json_output.py
@@ -166,6 +166,31 @@ class TestOutputFormatValidation:
         )
         assert "No previous conversations to resume" in result.stderr
 
+    def test_json_missing_explicit_path_prompt_keeps_stdout_clean(self, tmp_path):
+        """A missing explicit path prompt must fail before any JSON-mode stdout output."""
+        runner_cls: Any = CliRunner
+        try:
+            runner = runner_cls(mix_stderr=False)
+        except TypeError:
+            runner = runner_cls()
+        missing_path = tmp_path / "missing-prompt.txt"
+        result = runner.invoke(
+            cli.main,
+            ["--output-format", "json", "--non-interactive", str(missing_path)],
+            env={
+                "HOME": str(tmp_path),
+                "XDG_DATA_HOME": str(tmp_path),
+                "XDG_STATE_HOME": str(tmp_path / "state"),
+            },
+        )
+
+        assert result.exit_code == 2
+        assert result.stdout.strip() == "", (
+            "stdout must stay empty on early JSON-mode prompt validation errors"
+        )
+        assert "explicit local path" in result.stderr
+        assert str(missing_path) in result.stderr
+
     def test_noninteractive_missing_prompt_has_no_fake_resume_hint(
         self, monkeypatch, tmp_path: Path
     ):


### PR DESCRIPTION
## Summary
- reject prompts that are just a missing explicit local path before chat/model startup
- keep the check narrow to unambiguous local-path forms so ordinary text and repo/host strings still work
- add regressions for both normal CLI usage errors and clean JSON-mode stdout

## Repro
```bash
gptme --output-format json --non-interactive /tmp/definitely-missing-76bc.txt
```

Before this patch, `gptme` treated the missing path as a plain user message and proceeded toward a model call.
After this patch, it exits early with a usage error and leaves stdout empty in JSON mode.

## Testing
- `PYTHONPATH=/tmp/gptme-cli-missing-path-76bc /home/bob/gptme/.venv/bin/pytest /tmp/gptme-cli-missing-path-76bc/tests/test_cli.py -q -k "missing_explicit_path_prompt or missing_custom_tool_path"`
- `PYTHONPATH=/tmp/gptme-cli-missing-path-76bc /home/bob/gptme/.venv/bin/pytest /tmp/gptme-cli-missing-path-76bc/tests/test_json_output.py -q -k "missing_explicit_path_prompt_keeps_stdout_clean or json_resume_error_keeps_stdout_clean"`
- `uvx --from ruff ruff check /tmp/gptme-cli-missing-path-76bc/gptme/cli/main.py /tmp/gptme-cli-missing-path-76bc/tests/test_cli.py /tmp/gptme-cli-missing-path-76bc/tests/test_json_output.py`
