### PR TITLE
fix(cli): scope implicit resume to cwd workspace

### DIFF
--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -647,8 +647,11 @@ def main(
     logdir_preexisting = True
 
     resume_workspace_filter: Path | None = None
-    if workspace not in (None, "@log"):
-        assert workspace is not None
+    if workspace == "@log":
+        resume_workspace_filter = None
+    elif workspace is None:
+        resume_workspace_filter = Path.cwd()
+    else:
         resume_workspace_filter = Path(workspace)
 
     if resume:

--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -646,15 +646,13 @@ def main(
 
     logdir_preexisting = True
 
-    resume_workspace_filter: Path | None = None
-    if workspace == "@log":
-        resume_workspace_filter = None
-    elif workspace is None:
-        resume_workspace_filter = Path.cwd()
-    else:
-        resume_workspace_filter = Path(workspace)
-
     if resume:
+        if workspace == "@log":
+            resume_workspace_filter: Path | None = None
+        elif workspace is None:
+            resume_workspace_filter = Path.cwd()
+        else:
+            resume_workspace_filter = Path(workspace)
         try:
             logdir = get_logdir_resume(name, workspace=resume_workspace_filter)
         except ValueError as e:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -276,6 +276,39 @@ def test_resume_with_workspace_uses_matching_conversation(
     assert selected_logdirs == [target]
 
 
+def test_resume_without_explicit_workspace_uses_cwd(
+    monkeypatch, runner: CliRunner, tmp_path: Path, runid: int
+):
+    workspace_a = tmp_path / "workspace-a"
+    workspace_b = tmp_path / "workspace-b"
+
+    target = _write_conversation(
+        f"resume-cwd-target-{runid}", content="target", workspace=workspace_a
+    )
+    newer_other = _write_conversation(
+        f"resume-cwd-other-{runid}", content="other", workspace=workspace_b
+    )
+    os.utime(target / "conversation.jsonl", (1, 1))
+    os.utime(newer_other / "conversation.jsonl", (2, 2))
+
+    selected_logdirs: list[Path] = []
+
+    def fake_chat(prompt_msgs, initial_msgs, logdir, *args, **kwargs):
+        selected_logdirs.append(logdir)
+
+    monkeypatch.setattr(cli, "chat", fake_chat)
+    monkeypatch.setattr(cli.Path, "cwd", classmethod(lambda cls: workspace_a))
+
+    result = runner.invoke(
+        cli.main,
+        ["--resume", "--non-interactive"],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    assert selected_logdirs == [target]
+
+
 def test_missing_custom_tool_path_is_reported_as_usage_error(
     runner: CliRunner, tmp_path: Path
 ):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -309,6 +309,40 @@ def test_resume_without_explicit_workspace_uses_cwd(
     assert selected_logdirs == [target]
 
 
+def test_resume_with_log_workspace_uses_global_latest(
+    monkeypatch, runner: CliRunner, tmp_path: Path, runid: int
+):
+    workspace_a = tmp_path / "workspace-a"
+    workspace_b = tmp_path / "workspace-b"
+
+    older_target = _write_conversation(
+        f"resume-log-target-{runid}", content="target", workspace=workspace_a
+    )
+    newest_other = _write_conversation(
+        f"resume-log-other-{runid}", content="other", workspace=workspace_b
+    )
+    now = time.time()
+    os.utime(older_target / "conversation.jsonl", (now, now))
+    os.utime(newest_other / "conversation.jsonl", (now + 1, now + 1))
+
+    selected_logdirs: list[Path] = []
+
+    def fake_chat(prompt_msgs, initial_msgs, logdir, *args, **kwargs):
+        selected_logdirs.append(logdir)
+
+    monkeypatch.setattr(cli, "chat", fake_chat)
+    monkeypatch.setattr(cli.Path, "cwd", classmethod(lambda cls: workspace_a))
+
+    result = runner.invoke(
+        cli.main,
+        ["--resume", "--workspace", "@log", "--non-interactive"],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    assert selected_logdirs == [newest_other]
+
+
 def test_missing_custom_tool_path_is_reported_as_usage_error(
     runner: CliRunner, tmp_path: Path
 ):


### PR DESCRIPTION
## Summary
- scope unnamed `--resume` to the current working directory when `--workspace` is not passed
- keep `--workspace @log` unfiltered since it cannot be resolved before picking a logdir
- add a regression test for `gptme --resume` from cwd without an explicit workspace flag

## Repro
1. Start a live gptme session in workspace A so it becomes the newest global conversation.
2. From a different workspace B, run:
   ```bash
   gptme --non-interactive --resume /path/to/workspace-b
   ```
3. Before this patch, gptme could select workspace A's active conversation and fail on its log lock instead of scoping resume to workspace B.

## Verification
- `pytest tests/test_cli.py -q -k 'resume_with_workspace_uses_matching_conversation or resume_without_explicit_workspace_uses_cwd or get_logdir_resume_random_filters_by_workspace or get_logdir_resume_random_workspace_without_match_errors'`
- `ruff check gptme/cli/main.py tests/test_cli.py`
- Live repro from a clean worktree now returns `No previous conversations to resume for workspace '/tmp/worktrees/gptme-cli-sweep-4c9e'` instead of grabbing Bob's active session.
