### PR TITLE
fix(cli): validate custom tool paths before startup

### DIFF
--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -152,6 +152,33 @@ class ConversationName(click.ParamType):
         return value
 
 
+def _looks_like_tool_file_path(value: str) -> bool:
+    return (
+        value.endswith(".py")
+        or value.startswith(("/", "./", "../", "~"))
+        or (len(value) > 2 and value[1] == ":" and value[2] in "/\\")
+    )
+
+
+def _validate_custom_tool_paths(tool_allowlist: str | None) -> None:
+    """Fail fast on missing custom tool files before config/logging init."""
+    if not tool_allowlist:
+        return
+
+    for raw_item in tool_allowlist.split(","):
+        item = raw_item.strip().removeprefix("+").removeprefix("-")
+        if not item or not _looks_like_tool_file_path(item):
+            continue
+
+        path = Path(item).expanduser()
+        if not path.exists():
+            raise click.UsageError(f"Tool file does not exist: {item}")
+        if not path.is_file():
+            raise click.UsageError(f"Tool path is not a file: {item}")
+        if path.suffix != ".py":
+            raise click.UsageError(f"Tool file must be a .py file: {item}")
+
+
 def _extract_missing_explicit_local_path(prompt: str) -> str | None:
     """Return an explicit local-path prompt that is missing on disk.
 
@@ -542,6 +569,8 @@ def main(
     else:
         # User explicitly provided empty list (e.g., no -t flags with multiple=True)
         tool_allowlist_str = None
+
+    _validate_custom_tool_paths(tool_allowlist_str)
 
     if profile:
         print("Profiling enabled...")

--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -171,12 +171,12 @@ def _validate_custom_tool_paths(tool_allowlist: str | None) -> None:
             continue
 
         path = Path(item).expanduser()
+        if path.suffix != ".py":
+            raise click.UsageError(f"Tool file must be a .py file: {item}")
         if not path.exists():
             raise click.UsageError(f"Tool file does not exist: {item}")
         if not path.is_file():
             raise click.UsageError(f"Tool path is not a file: {item}")
-        if path.suffix != ".py":
-            raise click.UsageError(f"Tool file must be a .py file: {item}")
 
 
 def _extract_missing_explicit_local_path(prompt: str) -> str | None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ import pytest
 import requests
 
 import gptme.init as _gptme_init
-from gptme.config import get_config
+from gptme.config import get_config, set_config
 from gptme.init import init
 from gptme.tools import clear_tools
 from gptme.tools import shell as shell_module
@@ -210,6 +210,15 @@ def clear_tools_before():
     # Without this, the _init_done guard prevents init_tools() from re-running
     # after clear_tools(), leaving get_tool() returning None for all tools.
     _gptme_init._init_done = False
+    # Reset config.chat to prevent stale tool allowlists from tests that call
+    # setup_config_from_cli() (e.g. test_custom_tool_file_mixed_allowlist).
+    # Without this, init_tools(allowlist=None) picks up the previous test's
+    # chat.tools and loads only those tools, skipping standard tools like 'save'.
+    from dataclasses import replace
+
+    config = get_config()
+    if config.chat is not None:
+        set_config(replace(config, chat=None))
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -941,3 +941,22 @@ def test_tools_short_option_equals_syntax_works(runner: CliRunner):
     result = runner.invoke(cli.main, ["-t=-browser", "--version"])
     assert result.exit_code == 0, result.output
     assert "gptme v" in result.output
+
+
+@pytest.mark.parametrize(
+    "tool_spec",
+    ["./definitely-missing-custom-tool.py", "+./definitely-missing-custom-tool.py"],
+)
+def test_missing_custom_tool_path_fails_before_config_init(
+    runner: CliRunner, tool_spec: str
+):
+    result = runner.invoke(cli.main, ["-n", "--tools", tool_spec, "hi"])
+
+    assert result.exit_code != 0
+    assert (
+        "Tool file does not exist: ./definitely-missing-custom-tool.py" in result.output
+    )
+    assert "Skipping all confirmation prompts." not in result.output
+    assert "stdin is not a TTY and prompts provided" not in result.output
+    assert "Using project configuration" not in result.output
+    assert "Using local configuration" not in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -964,3 +964,28 @@ def test_missing_custom_tool_path_fails_before_config_init(
     assert "stdin is not a TTY and prompts provided" not in result.output
     assert "Using project configuration" not in result.output
     assert "Using local configuration" not in result.output
+
+
+@pytest.mark.parametrize(
+    "tool_spec",
+    [
+        "./definitely-missing-custom-tool.bash",
+        "+./definitely-missing-custom-tool.bash",
+        "-./definitely-missing-custom-tool.bash",
+    ],
+)
+def test_non_python_custom_tool_path_reports_suffix_before_existence(
+    runner: CliRunner, tool_spec: str
+):
+    result = runner.invoke(cli.main, ["-n", "--tools", tool_spec, "hi"])
+
+    assert result.exit_code != 0
+    assert (
+        "Tool file must be a .py file: ./definitely-missing-custom-tool.bash"
+        in result.output
+    )
+    assert "Tool file does not exist" not in result.output
+    assert "Skipping all confirmation prompts." not in result.output
+    assert "stdin is not a TTY and prompts provided" not in result.output
+    assert "Using project configuration" not in result.output
+    assert "Using local configuration" not in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -945,7 +945,11 @@ def test_tools_short_option_equals_syntax_works(runner: CliRunner):
 
 @pytest.mark.parametrize(
     "tool_spec",
-    ["./definitely-missing-custom-tool.py", "+./definitely-missing-custom-tool.py"],
+    [
+        "./definitely-missing-custom-tool.py",
+        "+./definitely-missing-custom-tool.py",
+        "-./definitely-missing-custom-tool.py",
+    ],
 )
 def test_missing_custom_tool_path_fails_before_config_init(
     runner: CliRunner, tool_spec: str


### PR DESCRIPTION
## Summary
- fail fast on missing custom `--tools` file paths before logging/config startup
- keep the existing error message, but surface it as an input-boundary failure
- add regression coverage for raw and additive custom tool path specs

## Repro
```bash
PYTHONPATH=/tmp/gptme-cli-dogfood-8c02 /home/bob/gptme/.venv/bin/python -m gptme -n --tools ./definitely-missing-custom-tool.py hi
```
Before this change, that emitted startup/config noise before the actual error.
After this change, it fails immediately with the missing-tool-path error.

## Testing
- `PYTHONPATH=/tmp/gptme-cli-dogfood-8c02 /home/bob/gptme/.venv/bin/pytest -q /tmp/gptme-cli-dogfood-8c02/tests/test_cli.py`
- `uv run --directory /tmp/gptme-cli-dogfood-8c02 ruff check gptme/cli/main.py tests/test_cli.py`
- manual repro for `--tools ./definitely-missing-custom-tool.py` and `--tools +./definitely-missing-custom-tool.py`
