### PR TITLE
fix(webui): skip hosted loopback auto-connect

### DIFF
--- a/webui/src/components/ui/badge.tsx
+++ b/webui/src/components/ui/badge.tsx
@@ -23,7 +23,8 @@ const badgeVariants = cva(
 );
 
 export interface BadgeProps
-  extends React.HTMLAttributes<HTMLDivElement>, VariantProps<typeof badgeVariants> {}
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
 
 function Badge({ className, variant, ...props }: BadgeProps) {
   return <div className={cn(badgeVariants({ variant }), className)} {...props} />;

--- a/webui/src/components/ui/button.tsx
+++ b/webui/src/components/ui/button.tsx
@@ -32,7 +32,8 @@ const buttonVariants = cva(
 );
 
 export interface ButtonProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement>, VariantProps<typeof buttonVariants> {
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
   asChild?: boolean;
 }
 

--- a/webui/src/components/ui/sheet.tsx
+++ b/webui/src/components/ui/sheet.tsx
@@ -48,8 +48,7 @@ const sheetVariants = cva(
 );
 
 interface SheetContentProps
-  extends
-    React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
+  extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
     VariantProps<typeof sheetVariants> {}
 
 const SheetContent = React.forwardRef<

--- a/webui/src/contexts/ApiContext.tsx
+++ b/webui/src/contexts/ApiContext.tsx
@@ -63,8 +63,25 @@ const MAX_AUTO_CONNECT_ATTEMPTS = 10;
 const INITIAL_RETRY_DELAY = 1000;
 const DEFAULT_LOCAL_SERVER_URL = 'http://127.0.0.1:5700';
 
-function isInitialMobileLocalTarget(baseUrl: string): boolean {
+function isDefaultLoopbackTarget(baseUrl: string): boolean {
   return ['http://127.0.0.1:5700', 'http://localhost:5700'].includes(baseUrl.replace(/\/+$/, ''));
+}
+
+export function shouldSkipHostedLoopbackAutoConnect(
+  baseUrl: string,
+  pageOrigin: string,
+  isTauri: boolean
+): boolean {
+  if (isTauri || !isDefaultLoopbackTarget(baseUrl)) {
+    return false;
+  }
+
+  try {
+    const parsedOrigin = new URL(pageOrigin);
+    return !['localhost', '127.0.0.1', '[::1]'].includes(parsedOrigin.hostname);
+  } catch {
+    return false;
+  }
 }
 
 const stopAutoConnect = () => {
@@ -365,7 +382,12 @@ export function ApiProvider({
     : { baseUrl: DEFAULT_LOCAL_SERVER_URL, authToken: null, useAuthToken: false };
 
   const shouldSkipInitialMobileAutoConnect =
-    isTauri && managesLocalServer === false && isInitialMobileLocalTarget(connectionConfig.baseUrl);
+    isTauri && managesLocalServer === false && isDefaultLoopbackTarget(connectionConfig.baseUrl);
+  const shouldSkipHostedLoopbackAutoConnectOnFirstLoad = shouldSkipHostedLoopbackAutoConnect(
+    connectionConfig.baseUrl,
+    window.location.origin,
+    isTauri
+  );
 
   // Primary client from pool (re-resolved each render to pick up changes)
   const api = getPrimaryClient();
@@ -376,6 +398,7 @@ export function ApiProvider({
     if (hasAuthCodeInHash(currentHash)) return;
     if (isTauri && isLoadingTauriStatus) return;
     if (shouldSkipInitialMobileAutoConnect) return;
+    if (shouldSkipHostedLoopbackAutoConnectOnFirstLoad) return;
 
     void (async () => {
       console.log('[ApiContext] Attempting initial connection');
@@ -386,6 +409,7 @@ export function ApiProvider({
     connectionConfig.baseUrl,
     isLoadingTauriStatus,
     isTauri,
+    shouldSkipHostedLoopbackAutoConnectOnFirstLoad,
     shouldSkipInitialMobileAutoConnect,
   ]);
 

--- a/webui/src/contexts/__tests__/ApiContext.test.tsx
+++ b/webui/src/contexts/__tests__/ApiContext.test.tsx
@@ -266,4 +266,10 @@ describe('shouldSkipHostedLoopbackAutoConnect', () => {
       )
     ).toBe(false);
   });
+
+  it('does not skip when running in Tauri (isTauri=true)', () => {
+    expect(
+      shouldSkipHostedLoopbackAutoConnect('http://127.0.0.1:5700', 'https://chat.gptme.org', true)
+    ).toBe(false);
+  });
 });

--- a/webui/src/contexts/__tests__/ApiContext.test.tsx
+++ b/webui/src/contexts/__tests__/ApiContext.test.tsx
@@ -2,7 +2,7 @@ import '@testing-library/jest-dom';
 import { render, waitFor } from '@testing-library/react';
 import { observable } from '@legendapp/state';
 import { QueryClient } from '@tanstack/react-query';
-import { ApiProvider } from '../ApiContext';
+import { ApiProvider, shouldSkipHostedLoopbackAutoConnect } from '../ApiContext';
 import type { ConnectionProbeResult } from '@/utils/api';
 
 const mockCheckConnection = jest.fn();
@@ -241,5 +241,29 @@ describe('ApiProvider mobile auto-connect', () => {
       },
       { timeout: 2000 }
     );
+  });
+});
+
+describe('shouldSkipHostedLoopbackAutoConnect', () => {
+  it('skips loopback auto-connect on hosted browser origins', () => {
+    expect(
+      shouldSkipHostedLoopbackAutoConnect('http://127.0.0.1:5700', 'https://chat.gptme.org', false)
+    ).toBe(true);
+  });
+
+  it('keeps loopback auto-connect for localhost dev origins', () => {
+    expect(
+      shouldSkipHostedLoopbackAutoConnect('http://127.0.0.1:5700', 'http://localhost:4173', false)
+    ).toBe(false);
+  });
+
+  it('does not skip non-loopback targets', () => {
+    expect(
+      shouldSkipHostedLoopbackAutoConnect(
+        'https://bob.example.com',
+        'https://chat.gptme.org',
+        false
+      )
+    ).toBe(false);
   });
 });

--- a/webui/src/utils/logging.ts
+++ b/webui/src/utils/logging.ts
@@ -40,8 +40,9 @@ export async function setupLogging() {
 
   try {
     // Dynamically import Tauri logging to avoid module errors in browser
-    const { warn, debug, trace, info, error, attachConsole } =
-      await import('@tauri-apps/plugin-log');
+    const { warn, debug, trace, info, error, attachConsole } = await import(
+      '@tauri-apps/plugin-log'
+    );
 
     // Attach console first to see Rust logs in browser console
     detachConsole = await attachConsole();


### PR DESCRIPTION
## Summary
- skip first-render auto-connect when a hosted browser session is still pointed at the default loopback server
- keep the existing auto-connect behavior for localhost dev origins and non-loopback targets
- add a regression test for the hosted-origin loopback case

## Reproduction
1. Open `https://chat.gptme.org/` in a fresh browser profile.
2. Before choosing a connection mode, the web UI auto-probes `http://127.0.0.1:5700/api/v2`.
3. On hosted origins this fails immediately (HAR captured `GET -1 http://127.0.0.1:5700/api/v2`) and surfaces the Chrome Local Network Access failure state before the user opts into local mode.

## Fix
Hosted/browser origins now skip that implicit loopback auto-connect on first load. Users can still explicitly retry or configure a local/remote server, and localhost/Tauri flows keep their current behavior.

## Testing
- `cd webui && npm test -- --runTestsByPath src/contexts/__tests__/ApiContext.test.tsx`
- `cd webui && npm run typecheck`
