### PR TITLE
fix(cli): reject missing path args before prompt merge

### DIFF
--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -211,6 +211,19 @@ def _extract_missing_explicit_local_path(prompt: str) -> str | None:
     return candidate
 
 
+def _find_missing_explicit_local_path(prompts: list[str]) -> str | None:
+    """Return the first missing explicit local-path prompt in raw CLI argv order.
+
+    This catches mixed positional argv like ``gptme missing.py "fix it"`` before
+    prompt arguments are merged into a single message, where the path would
+    otherwise be masked by surrounding text.
+    """
+    for prompt in prompts:
+        if missing := _extract_missing_explicit_local_path(prompt):
+            return missing
+    return None
+
+
 commands_help = "\n".join(_gen_help(incl_langtags=False))
 _builtin_tools = get_available_tools(include_mcp=False)
 _known_tool_names = sorted(tool.name for tool in _builtin_tools)
@@ -655,6 +668,13 @@ def main(
 
     # join prompts, grouped by `-` if present, since that's the separator for "chained"/multiple-round prompts
     sep = "\n\n" + MULTIPROMPT_SEPARATOR
+
+    if missing_path := _find_missing_explicit_local_path(prompts):
+        raise click.UsageError(
+            "Prompt looks like an explicit local path, but it does not exist: "
+            f"{missing_path}"
+        )
+
     prompts = [p.strip() for p in "\n\n".join(prompts).split(sep) if p]
     # File paths in multiprompts are expanded at runtime by include_paths() in
     # _run_chat_loop (gptme/chat.py:194), not at parse time. Each prompt from the

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -386,6 +386,34 @@ def test_missing_explicit_path_prompt_is_reported_as_usage_error(
     assert "Traceback" not in result.output
 
 
+@pytest.mark.parametrize(
+    "prompts",
+    [
+        ["MISSING_PATH", "hello"],
+        ["hello", "MISSING_PATH"],
+    ],
+)
+def test_missing_explicit_path_prompt_with_other_prompt_is_usage_error(
+    runner: CliRunner, tmp_path: Path, prompts: list[str]
+):
+    missing_path = tmp_path / "missing-prompt.txt"
+    argv = [
+        "--non-interactive",
+        "--name",
+        "missing-explicit-path-plus-prompt",
+    ]
+    argv.extend(
+        str(missing_path) if prompt == "MISSING_PATH" else prompt for prompt in prompts
+    )
+
+    result = runner.invoke(cli.main, argv)
+
+    assert result.exit_code == 2
+    assert "explicit local path" in result.output
+    assert str(missing_path) in result.output
+    assert "Traceback" not in result.output
+
+
 @pytest.mark.parametrize("flag", ["--architect-model", "--editor-model"])
 def test_architect_model_unqualified_is_usage_error(
     flag: str, runner: CliRunner, runid: int

--- a/tests/test_json_output.py
+++ b/tests/test_json_output.py
@@ -193,6 +193,39 @@ class TestOutputFormatValidation:
         assert "explicit local path" in result.stderr
         assert str(missing_path) in result.stderr
 
+    def test_json_missing_explicit_path_with_other_prompt_keeps_stdout_clean(
+        self, tmp_path
+    ):
+        """Mixed prompt/path argv should still fail before any JSON stdout output."""
+        runner_cls: Any = CliRunner
+        try:
+            runner = runner_cls(mix_stderr=False)
+        except TypeError:
+            runner = runner_cls()
+        missing_path = tmp_path / "missing-prompt.txt"
+        result = runner.invoke(
+            cli.main,
+            [
+                "--output-format",
+                "json",
+                "--non-interactive",
+                str(missing_path),
+                "hello",
+            ],
+            env={
+                "HOME": str(tmp_path),
+                "XDG_DATA_HOME": str(tmp_path),
+                "XDG_STATE_HOME": str(tmp_path / "state"),
+            },
+        )
+
+        assert result.exit_code == 2
+        assert result.stdout.strip() == "", (
+            "stdout must stay empty on early JSON-mode prompt validation errors"
+        )
+        assert "explicit local path" in result.stderr
+        assert str(missing_path) in result.stderr
+
     def test_noninteractive_missing_prompt_has_no_fake_resume_hint(
         self, monkeypatch, tmp_path: Path
     ):


### PR DESCRIPTION
## Summary
Reject missing explicit local-path prompt args before positional prompts are merged into one message.

## Repro
Before this change:
- `gptme /definitely/missing/file.py --non-interactive hi`
- `gptme hi /definitely/missing/file.py --non-interactive`

would skip the early path validator, treat the missing path as plain prompt text, and continue into a real chat run.

## Fix
- validate raw positional prompt args before prompt merging
- keep the existing post-merge validator for single-prompt / chained-prompt cases
- add CLI and JSON-mode regressions for mixed prompt+missing-path argv

## Verification
- `uv run --with pytest --with requests python3 -m pytest tests/test_cli.py -q -k missing_explicit_path_prompt`
- `uv run --with pytest --with requests python3 -m pytest tests/test_json_output.py -q -k missing_explicit_path`
- `uv run --with ruff ruff check gptme/cli/main.py tests/test_cli.py tests/test_json_output.py`
- `uv run gptme /definitely/missing/file.py --non-interactive hi`
- `uv run gptme hello /definitely/missing/file.py --non-interactive`
