### PR TITLE
feat(browser): support connecting over CDP

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -208,6 +208,10 @@ Besides the configuration files, gptme supports several environment variables to
 
 - ``LLM_API_TIMEOUT`` - Set the timeout in seconds for LLM API requests (default: 600). Must be a valid numeric string (e.g., "600", "1800"). Useful for local LLMs that may take longer to respond.
 
+.. rubric:: Browser Configuration
+
+- ``GPTME_BROWSER_CDP_URL`` - Connect the Playwright browser backend to an existing Chromium-compatible browser over Chrome DevTools Protocol instead of launching Playwright's bundled Chromium. Example: ``http://127.0.0.1:9222``. Start Chrome/Chromium with ``--remote-debugging-port=9222`` to enable this.
+
 .. rubric:: Paths
 
 - ``GPTME_LOGS_HOME`` - Override the default logs folder location

--- a/gptme/tools/_browser_thread.py
+++ b/gptme/tools/_browser_thread.py
@@ -93,6 +93,8 @@ class BrowserThread:
                 return None
             except Exception as e:
                 browser = None  # Ensure browser is None after failed launch
+                error: Exception
+                
                 if "Executable doesn't exist" in str(e):
                     pw_version = importlib.metadata.version("playwright")
                     error = RuntimeError(

--- a/gptme/tools/_browser_thread.py
+++ b/gptme/tools/_browser_thread.py
@@ -7,7 +7,9 @@ from queue import Empty, Queue
 from threading import Event, Lock, Thread
 from typing import Any, Literal, TypeVar
 
-from playwright.sync_api import sync_playwright
+from playwright.sync_api import Browser, Playwright, sync_playwright
+
+from gptme.config import get_config
 
 logger = logging.getLogger(__name__)
 
@@ -27,6 +29,8 @@ def _is_connection_error(error: Exception) -> bool:
             "target closed",
             "connection terminated",
             "pipe closed",
+            "websocket error",
+            "econnreset",
         ]
     )
 
@@ -41,8 +45,20 @@ class Command:
 Action = Literal["stop"]
 
 
+def _connect_or_launch_browser(playwright: Playwright, cdp_url: str | None) -> Browser:
+    if cdp_url:
+        browser = playwright.chromium.connect_over_cdp(cdp_url)
+        logger.info("Connected to browser over CDP")
+        return browser
+
+    browser = playwright.chromium.launch()
+    logger.info("Browser launched")
+    return browser
+
+
 class BrowserThread:
-    def __init__(self):
+    def __init__(self, cdp_url: str | None = None) -> None:
+        self.cdp_url = cdp_url or get_config().get_env("BROWSER_CDP_URL")
         self.queue: Queue[tuple[Command | Action, object]] = Queue()
         self.results: dict[object, tuple[Any, Exception | None]] = {}
         self.lock = Lock()
@@ -59,11 +75,10 @@ class BrowserThread:
         logger.debug("Browser thread started")
 
     def _run(self):
-        playwright = None
-        browser = None
+        playwright: Playwright | None = None
+        browser: Browser | None = None
 
-        def launch_browser():
-            """Launch or relaunch the browser"""
+        def launch_browser() -> Exception | None:
             nonlocal playwright, browser
             if playwright is None:
                 playwright = sync_playwright().start()
@@ -74,24 +89,25 @@ class BrowserThread:
                         browser = None  # Clear reference after close
                     except Exception:
                         browser = None  # Clear reference even if close fails
-                browser = playwright.chromium.launch()
-                logger.info("Browser launched")
-                return True
+                browser = _connect_or_launch_browser(playwright, self.cdp_url)
+                return None
             except Exception as e:
                 browser = None  # Ensure browser is None after failed launch
                 if "Executable doesn't exist" in str(e):
                     pw_version = importlib.metadata.version("playwright")
-                    self._init_error = RuntimeError(
+                    error = RuntimeError(
                         f"Browser executable not found. Run: pipx run playwright=={pw_version} install chromium-headless-shell"
                     )
                 else:
-                    self._init_error = e
+                    error = e
                 logger.error(f"Failed to launch browser: {e}", exc_info=True)
-                return False
+                return error
 
         try:
             # Initial browser launch
-            if not launch_browser():
+            init_error = launch_browser()
+            if init_error:
+                self._init_error = init_error
                 self.ready.set()
                 return
 
@@ -120,12 +136,12 @@ class BrowserThread:
                                 if attempt < max_retries - 1:
                                     # Try to recover by restarting browser
                                     logger.info("Attempting to restart browser...")
-                                    if launch_browser():
+                                    restart_error = launch_browser()
+                                    if restart_error is None:
                                         logger.info("Browser restarted successfully")
                                         continue  # Retry command
-                                    # Create informative error about restart failure
                                     restart_error = RuntimeError(
-                                        f"Browser restart failed after connection error in {command_name}: {e}"
+                                        f"Browser restart failed after connection error in {command_name}: {restart_error}"
                                     )
                                     with self.lock:
                                         self.results[cmd_id] = (None, restart_error)

--- a/gptme/tools/browser.py
+++ b/gptme/tools/browser.py
@@ -23,6 +23,15 @@ Playwright backend:
        PW_VERSION=$(pipx runpip gptme show playwright | grep Version | cut -d' ' -f2)
        pipx run playwright==$PW_VERSION install chromium-headless-shell
 
+ - To use an existing Chromium-compatible browser over Chrome DevTools Protocol
+   instead of launching Playwright's bundled Chromium, start it with remote
+   debugging enabled and set GPTME_BROWSER_CDP_URL:
+
+   .. code-block:: bash
+
+       chromium --remote-debugging-port=9222
+       export GPTME_BROWSER_CDP_URL=http://127.0.0.1:9222
+
 Lynx backend:
  - Text-only browser for basic page reading and searching
  - No screenshot support

--- a/tests/test_tools_browser_thread.py
+++ b/tests/test_tools_browser_thread.py
@@ -20,6 +20,7 @@ from gptme.tools._browser_thread import (
     TIMEOUT,
     BrowserThread,
     Command,
+    _connect_or_launch_browser,
     _is_connection_error,
 )
 
@@ -39,6 +40,8 @@ class TestIsConnectionError:
             "Target closed while processing",
             "Connection terminated by remote",
             "pipe closed during operation",
+            "WebSocket error: read ECONNRESET",
+            "read ECONNRESET",
         ],
     )
     def test_detects_connection_errors(self, msg: str):
@@ -97,6 +100,37 @@ class TestCommand:
 
 
 # =============================================================================
+# Browser launch tests
+# =============================================================================
+
+
+class TestConnectOrLaunchBrowser:
+    def test_launches_bundled_chromium_by_default(self):
+        mock_pw = MagicMock()
+        mock_browser = MagicMock()
+        mock_pw.chromium.launch.return_value = mock_browser
+
+        result = _connect_or_launch_browser(mock_pw, None)
+
+        assert result is mock_browser
+        mock_pw.chromium.launch.assert_called_once_with()
+        mock_pw.chromium.connect_over_cdp.assert_not_called()
+
+    def test_connects_over_cdp_when_configured(self):
+        mock_pw = MagicMock()
+        mock_browser = MagicMock()
+        mock_pw.chromium.connect_over_cdp.return_value = mock_browser
+
+        result = _connect_or_launch_browser(mock_pw, "http://127.0.0.1:9222")
+
+        assert result is mock_browser
+        mock_pw.chromium.connect_over_cdp.assert_called_once_with(
+            "http://127.0.0.1:9222"
+        )
+        mock_pw.chromium.launch.assert_not_called()
+
+
+# =============================================================================
 # BrowserThread tests (mocked playwright)
 # =============================================================================
 
@@ -141,6 +175,40 @@ class TestBrowserThreadInit:
         mock_pw.chromium.launch.side_effect = OSError("cannot allocate memory")
         with pytest.raises(OSError, match="cannot allocate memory"):
             BrowserThread()
+
+    def test_connects_over_cdp_when_configured(self, mock_playwright):
+        mock_pw, _ = mock_playwright
+        mock_cdp_browser = MagicMock()
+        mock_pw.chromium.connect_over_cdp.return_value = mock_cdp_browser
+
+        bt = BrowserThread(cdp_url="http://127.0.0.1:9222")
+        try:
+            mock_pw.chromium.connect_over_cdp.assert_called_once_with(
+                "http://127.0.0.1:9222"
+            )
+            mock_pw.chromium.launch.assert_not_called()
+        finally:
+            bt.stop()
+
+    def test_connects_over_cdp_from_env(self, mock_playwright, monkeypatch):
+        mock_pw, _ = mock_playwright
+        monkeypatch.setenv("GPTME_BROWSER_CDP_URL", "http://127.0.0.1:9223")
+
+        bt = BrowserThread()
+        try:
+            mock_pw.chromium.connect_over_cdp.assert_called_once_with(
+                "http://127.0.0.1:9223"
+            )
+            mock_pw.chromium.launch.assert_not_called()
+        finally:
+            bt.stop()
+
+    def test_cdp_connection_error_propagates(self, mock_playwright):
+        mock_pw, _ = mock_playwright
+        mock_pw.chromium.connect_over_cdp.side_effect = OSError("cdp unavailable")
+
+        with pytest.raises(OSError, match="cdp unavailable"):
+            BrowserThread(cdp_url="http://127.0.0.1:9222")
 
 
 class TestBrowserThreadExecute:
@@ -265,8 +333,10 @@ class TestBrowserThreadRetry:
 
         bt = BrowserThread()
         try:
+            assert bt._init_error is None
             with pytest.raises(RuntimeError, match="Browser restart failed"):
                 bt.execute(fail_func)
+            assert bt._init_error is None
         finally:
             bt.stop()
 


### PR DESCRIPTION
Adds support for configuring the Playwright browser backend to connect to an existing Chromium-compatible browser over Chrome DevTools Protocol, instead of always launching Playwright's bundled Chromium.