### PR TITLE
fix(cli): reject malformed --output-schema with a usage error

### DIFF
--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -675,6 +675,27 @@ def main(
             f"{missing_path}"
         )
 
+    # Validate and resolve --output-schema early (format: "module:ClassName"),
+    # before creating a logdir or running setup. An explicit but malformed or
+    # unloadable schema is a usage error, not something to silently ignore — the
+    # user explicitly asked for structured output.
+    output_schema_type: type | None = None
+    if output_schema:
+        if ":" not in output_schema:
+            raise click.UsageError(
+                f"Invalid --output-schema format: '{output_schema}'. "
+                "Expected 'module:ClassName' (e.g. 'mymodule:MyModel')."
+            )
+        module_name, class_name = output_schema.rsplit(":", 1)
+        try:
+            module = importlib.import_module(module_name)
+            output_schema_type = getattr(module, class_name)
+        except (ImportError, AttributeError) as e:
+            raise click.UsageError(
+                f"Could not load --output-schema '{output_schema}': {e}. "
+                "Verify the module is installed and the class name is correct."
+            ) from e
+
     prompts = [p.strip() for p in "\n\n".join(prompts).split(sep) if p]
     # File paths in multiprompts are expanded at runtime by include_paths() in
     # _run_chat_loop (gptme/chat.py:194), not at parse time. Each prompt from the
@@ -839,26 +860,6 @@ def main(
     # register a handler for Ctrl-C
     set_interruptible()  # prepare, user should be able to Ctrl+C until user prompt ready
     signal.signal(signal.SIGINT, handle_keyboard_interrupt)
-
-    # Parse output_schema if provided (format: "module:ClassName")
-    output_schema_type: type | None = None
-    if output_schema:
-        try:
-            if ":" in output_schema:
-                module_name, class_name = output_schema.rsplit(":", 1)
-
-                module = importlib.import_module(module_name)
-                output_schema_type = getattr(module, class_name)
-            else:
-                logger.warning(
-                    f"Invalid output_schema format: '{output_schema}'. "
-                    "Expected 'module:ClassName' (e.g. 'mymodule:MyModel')"
-                )
-        except (ImportError, AttributeError) as e:
-            logger.warning(
-                f"Could not load output_schema '{output_schema}': {e}. "
-                "Verify the module is installed and the class name is correct."
-            )
 
     # Architect/editor split: if enabled via CLI flag OR via TOML config
     _toml_architect_enabled = bool(

--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -690,7 +690,7 @@ def main(
         try:
             module = importlib.import_module(module_name)
             output_schema_type = getattr(module, class_name)
-        except (ImportError, AttributeError) as e:
+        except (ImportError, AttributeError, ValueError) as e:
             raise click.UsageError(
                 f"Could not load --output-schema '{output_schema}': {e}. "
                 "Verify the module is installed and the class name is correct."

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -386,6 +386,44 @@ def test_missing_explicit_path_prompt_is_reported_as_usage_error(
     assert "Traceback" not in result.output
 
 
+def test_malformed_output_schema_is_reported_as_usage_error(runner: CliRunner):
+    result = runner.invoke(
+        cli.main,
+        [
+            "--non-interactive",
+            "--name",
+            "malformed-output-schema",
+            "--output-schema",
+            "notamodule",  # missing ':ClassName'
+            "hello",
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert "--output-schema" in result.output
+    assert "notamodule" in result.output
+    assert "Traceback" not in result.output
+
+
+def test_unloadable_output_schema_is_reported_as_usage_error(runner: CliRunner):
+    result = runner.invoke(
+        cli.main,
+        [
+            "--non-interactive",
+            "--name",
+            "unloadable-output-schema",
+            "--output-schema",
+            "gptme.message:NoSuchClass",  # real module, missing class
+            "hello",
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert "--output-schema" in result.output
+    assert "gptme.message:NoSuchClass" in result.output
+    assert "Traceback" not in result.output
+
+
 @pytest.mark.parametrize(
     "prompts",
     [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -405,7 +405,17 @@ def test_malformed_output_schema_is_reported_as_usage_error(runner: CliRunner):
     assert "Traceback" not in result.output
 
 
-def test_unloadable_output_schema_is_reported_as_usage_error(runner: CliRunner):
+@pytest.mark.parametrize(
+    "schema",
+    [
+        "gptme.message:NoSuchClass",  # real module, missing class
+        ":ClassName",  # empty module name
+        "invalid/path:ClassName",  # invalid module name
+    ],
+)
+def test_unloadable_output_schema_is_reported_as_usage_error(
+    runner: CliRunner, schema: str
+):
     result = runner.invoke(
         cli.main,
         [
@@ -413,14 +423,14 @@ def test_unloadable_output_schema_is_reported_as_usage_error(runner: CliRunner):
             "--name",
             "unloadable-output-schema",
             "--output-schema",
-            "gptme.message:NoSuchClass",  # real module, missing class
+            schema,
             "hello",
         ],
     )
 
     assert result.exit_code == 2
     assert "--output-schema" in result.output
-    assert "gptme.message:NoSuchClass" in result.output
+    assert schema in result.output
     assert "Traceback" not in result.output
 
 


### PR DESCRIPTION
## Problem

An explicit but malformed (`--output-schema notamodule`, no `:`) or unloadable (`--output-schema realmod:NoSuchClass`) schema was only logged as a `warning`, then silently dropped — gptme proceeded into a full run with **no structured output**, despite the user explicitly requesting it. This is especially harmful in `--output-format json` mode, where the log warning never reaches the consumer parsing stdout.

Reproduced on `origin/master`: `gptme -n --output-schema notamodule hi` warns and runs anyway (exit 1 from a later, unrelated failure) instead of failing cleanly on the bad input.

## Fix

Validate and resolve `--output-schema` **early** (before logdir creation and setup), raising `click.UsageError` on bad format or load failure. This matches the existing CLI input-hardening pattern (custom tool paths in #2566, missing explicit prompt paths) — fail loud with a clean usage error (exit 2, no traceback) instead of silently ignoring an explicit request, and before any orphan logdir/setup work happens.

## Tests

- `test_malformed_output_schema_is_reported_as_usage_error` (missing `:ClassName`)
- `test_unloadable_output_schema_is_reported_as_usage_error` (real module, missing class)

Both assert exit code 2, the offending value in the message, and no traceback — mirroring the existing usage-error tests. Verified the valid `module:Class` happy path is unaffected.

```
8 passed, 59 deselected
```