### PR TITLE
feat(hooks): add turn.pre and aw watcher consumer

### DIFF
--- a/docs/hooks.rst
+++ b/docs/hooks.rst
@@ -11,27 +11,33 @@ Hook Types
 
 The following hook types are available:
 
-Message Lifecycle Hooks
-~~~~~~~~~~~~~~~~~~~~~~~~
+Turn And Step Lifecycle Hooks
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- ``MESSAGE_PRE_PROCESS``: Before processing a user message
-- ``MESSAGE_POST_PROCESS``: After message processing completes
-- ``MESSAGE_TRANSFORM``: Transform message content before processing
+- ``TURN_PRE``: Once per submitted user prompt, before the turn starts
+- ``STEP_PRE``: Before each generation/tool-execution step within a turn
+- ``STEP_POST``: After each step completes
+- ``TURN_POST``: After the whole turn completes
+- ``MESSAGE_TRANSFORM``: Rewrite assistant message content before persistence/display
+
+``TURN_PRE`` is the clean "user prompt submitted" surface. ``STEP_PRE`` may run
+multiple times inside one turn if the assistant keeps calling tools.
 
 Tool Lifecycle Hooks
-~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~
 
-- ``TOOL_PRE_EXECUTE``: Before executing any tool
-- ``TOOL_POST_EXECUTE``: After executing any tool
+- ``TOOL_EXECUTE_PRE``: Before executing any tool
+- ``TOOL_EXECUTE_POST``: After executing any tool
 - ``TOOL_TRANSFORM``: Transform tool execution
+- ``TOOL_CONFIRM``: Blocking confirmation/deny decision before execution
 
 File Operation Hooks
 ~~~~~~~~~~~~~~~~~~~~~
 
-- ``FILE_PRE_SAVE``: Before saving a file
-- ``FILE_POST_SAVE``: After saving a file
-- ``FILE_PRE_PATCH``: Before patching a file
-- ``FILE_POST_PATCH``: After patching a file
+- ``FILE_SAVE_PRE``: Before saving a file
+- ``FILE_SAVE_POST``: After saving a file
+- ``FILE_PATCH_PRE``: Before patching a file
+- ``FILE_PATCH_POST``: After patching a file
 
 Session Lifecycle Hooks
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -71,8 +77,8 @@ Tools can register hooks in their ``ToolSpec`` definition:
        name="linter",
        desc="Automatic linting tool",
        hooks={
-           "file_save": (
-               HookType.FILE_POST_SAVE.value,  # Hook type
+            "file_save": (
+               HookType.FILE_SAVE_POST.value,  # Hook type
                on_file_save,                    # Hook function
                10                               # Priority (higher = runs first)
            )
@@ -87,15 +93,16 @@ You can also register hooks directly:
 .. code-block:: python
 
    from gptme.hooks import register_hook, HookType
+   from gptme.hooks.confirm import ConfirmationResult
 
-   def my_hook_function(log, workspace):
+   def my_hook_function(manager):
        """Custom hook function."""
        # Do something
        return Message("system", "Hook executed!")
 
    register_hook(
        name="my_custom_hook",
-       hook_type=HookType.MESSAGE_PRE_PROCESS,
+       hook_type=HookType.TURN_PRE,
        func=my_hook_function,
        priority=0,
        enabled=True
@@ -108,21 +115,25 @@ Hook functions receive different arguments depending on the hook type:
 
 .. code-block:: python
 
-   # Message hooks
-   def message_hook(log, workspace):
+   # Turn/step hooks
+   def turn_hook(manager):
        pass
 
    # Tool hooks
-   def tool_hook(tool_name, tool_use):
+   def tool_hook(log, workspace, tool_use):
        pass
 
    # File hooks
-   def file_hook(path, content, created=False):
+   def file_hook(log, workspace, path, content, created=False):
        pass
 
    # Session hooks
-   def session_hook(logdir, workspace, manager=None, initial_msgs=None):
+   def session_hook(logdir, workspace, initial_msgs):
        pass
+
+   # Confirmation hooks
+   def confirm_hook(tool_use, preview=None, workspace=None):
+       return ConfirmationResult.confirm()
 
 Hook functions can:
 
@@ -145,7 +156,7 @@ Query Hooks
    all_hooks = get_hooks()
 
    # Get hooks of a specific type
-   tool_hooks = get_hooks(HookType.TOOL_POST_EXECUTE)
+   tool_hooks = get_hooks(HookType.TOOL_EXECUTE_POST)
 
 Enable/Disable Hooks
 ~~~~~~~~~~~~~~~~~~~~
@@ -168,7 +179,7 @@ Unregister Hooks
    from gptme.hooks import unregister_hook, HookType
 
    # Unregister from specific type
-   unregister_hook("my_hook", HookType.FILE_POST_SAVE)
+   unregister_hook("my_hook", HookType.FILE_SAVE_POST)
 
    # Unregister from all types
    unregister_hook("my_hook")
@@ -210,7 +221,7 @@ Automatically run pre-commit checks after files are saved:
        desc="Automatic pre-commit checks",
        hooks={
            "precommit_check": (
-               HookType.FILE_POST_SAVE.value,
+               HookType.FILE_SAVE_POST.value,
                run_precommit,
                5  # Run after other hooks
            )
@@ -268,7 +279,7 @@ Automatically lint files after saving:
        name="linter",
        desc="Automatic Python linting",
        hooks={
-           "lint": (HookType.FILE_POST_SAVE.value, lint_file, 5)
+           "lint": (HookType.FILE_SAVE_POST.value, lint_file, 5)
        }
    )
 
@@ -375,7 +386,7 @@ Example: Converting pre-commit checks to a hook
    tool = ToolSpec(
        name="precommit",
        hooks={
-           "check": (HookType.MESSAGE_POST_PROCESS.value, precommit_hook, 5)
+           "check": (HookType.TURN_POST.value, precommit_hook, 5)
        }
    )
 

--- a/gptme/chat.py
+++ b/gptme/chat.py
@@ -198,6 +198,14 @@ def _run_chat_loop(
                 if msg.role == "user" and execute_cmd(msg, manager):
                     continue
 
+                if msg.role == "user":
+                    if turn_pre_msgs := trigger_hook(
+                        HookType.TURN_PRE,
+                        manager=manager,
+                    ):
+                        for hook_msg in turn_pre_msgs:
+                            manager.append(hook_msg)
+
                 # Process the message and get response
                 try:
                     _process_message_conversation(
@@ -245,6 +253,16 @@ def _run_chat_loop(
                     # Handle user commands
                     if msg.role == "user" and execute_cmd(msg, manager):
                         continue
+
+                    # Trigger turn.pre hooks once per submitted user prompt,
+                    # after the prompt is appended and command handling has
+                    # declined to consume it.
+                    if turn_pre_msgs := trigger_hook(
+                        HookType.TURN_PRE,
+                        manager=manager,
+                    ):
+                        for hook_msg in turn_pre_msgs:
+                            manager.append(hook_msg)
 
                     # Process the message and get response
                     _process_message_conversation(

--- a/gptme/hooks/aw_watcher_agent.py
+++ b/gptme/hooks/aw_watcher_agent.py
@@ -1,0 +1,191 @@
+"""Opt-in ActivityWatch session emission via aw-watcher-agent.
+
+This hook plugin is intentionally small and fail-open:
+
+- it shells out to the external ``aw-watcher-agent`` CLI if configured
+- it emits only ``session.start`` / ``session.end`` lifecycle events
+- failures are logged and ignored so telemetry never breaks a session
+
+Activation:
+
+- set ``GPTME_AW_WATCHER_AGENT=1``, or
+- add ``[plugin.aw_watcher_agent]`` to config to enable it automatically
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shlex
+import subprocess
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from ..hooks import HookType, register_hook
+from ..llm.models import get_default_model
+from ..plugins.plugin import GptmePlugin
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from ..hooks import StopPropagation
+    from ..logmanager import LogManager
+    from ..message import Message
+
+logger = logging.getLogger(__name__)
+
+
+def _enabled() -> bool:
+    return os.environ.get("GPTME_AW_WATCHER_AGENT", "").lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    )
+
+
+def _command_prefix() -> list[str]:
+    raw = os.environ.get("GPTME_AW_WATCHER_AGENT_COMMAND", "aw-watcher-agent")
+    parts = shlex.split(raw)
+    return parts or ["aw-watcher-agent"]
+
+
+def _workspace_name(workspace: Path | None) -> str | None:
+    if workspace is None:
+        return None
+    try:
+        return workspace.name or str(workspace)
+    except Exception:  # pragma: no cover - defensive
+        return str(workspace)
+
+
+def _model_name() -> str | None:
+    model = get_default_model()
+    if model is None:
+        return None
+    return model.full
+
+
+def _base_args(session_id: str, workspace: Path | None) -> list[str]:
+    args = [
+        "--harness",
+        "gptme",
+        "--session-id",
+        session_id,
+    ]
+    if model := _model_name():
+        args.extend(["--model", model])
+    if workspace_name := _workspace_name(workspace):
+        args.extend(["--workspace", workspace_name])
+    if trigger := os.environ.get("GPTME_AW_WATCHER_TRIGGER"):
+        args.extend(["--trigger", trigger])
+    if category := os.environ.get("GPTME_AW_WATCHER_CATEGORY"):
+        args.extend(["--category", category])
+    if server := os.environ.get("GPTME_AW_WATCHER_SERVER"):
+        args.extend(["--server", server])
+    if hostname := os.environ.get("GPTME_AW_WATCHER_HOSTNAME"):
+        args.extend(["--hostname", hostname])
+    return args
+
+
+def _run_aw(argv: list[str]) -> None:
+    try:
+        result = subprocess.run(
+            argv,
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except OSError as exc:
+        logger.debug("aw-watcher-agent unavailable: %s", exc)
+        return
+    except subprocess.TimeoutExpired as exc:
+        logger.warning("aw-watcher-agent timed out: %s", exc)
+        return
+
+    if result.returncode != 0:
+        logger.warning(
+            "aw-watcher-agent exited %s: %s",
+            result.returncode,
+            (result.stderr or result.stdout).strip(),
+        )
+    elif result.stderr.strip():
+        logger.debug("aw-watcher-agent stderr: %s", result.stderr.strip())
+
+
+def emit_start(
+    logdir: Path,
+    workspace: Path | None,
+    initial_msgs: list[Message],
+) -> Generator[Message | StopPropagation, None, None]:
+    """Emit a session-start event keyed by the conversation/logdir id."""
+    del initial_msgs
+    if not _enabled():
+        return
+    session_id = logdir.name
+    argv = _command_prefix() + ["emit-start", *_base_args(session_id, workspace)]
+    _run_aw(argv)
+    return
+    yield
+
+
+def emit_end(manager: LogManager) -> Generator[Message | StopPropagation, None, None]:
+    """Emit a session-end event matching the earlier session-start emission."""
+    if not _enabled():
+        return
+    logdir = getattr(manager, "logdir", None)
+    workspace = getattr(manager, "workspace", None)
+    if logdir is None:
+        return
+    session_id = Path(logdir).name
+    argv = _command_prefix() + ["emit-end", *_base_args(session_id, workspace)]
+    _run_aw(argv)
+    return
+    yield
+
+
+def register() -> None:
+    """Register aw-watcher-agent lifecycle hooks."""
+    register_hook("aw_watcher_agent.start", HookType.SESSION_START, emit_start)
+    register_hook("aw_watcher_agent.end", HookType.SESSION_END, emit_end)
+    logger.debug("Registered aw-watcher-agent hooks")
+
+
+def _init_from_config(config: object) -> None:
+    """Enable the plugin when ``[plugin.aw_watcher_agent]`` exists."""
+    user_cfg = getattr(getattr(config, "user", None), "plugin", {}) or {}
+    project = getattr(config, "project", None)
+    project_cfg = getattr(project, "plugin", {}) or {} if project else {}
+
+    merged: dict[str, object] = {}
+    if isinstance(user_cfg, dict):
+        merged.update(user_cfg.get("aw_watcher_agent", {}) or {})
+    if isinstance(project_cfg, dict):
+        merged.update(project_cfg.get("aw_watcher_agent", {}) or {})
+
+    if (
+        merged
+        or (isinstance(user_cfg, dict) and "aw_watcher_agent" in user_cfg)
+        or (isinstance(project_cfg, dict) and "aw_watcher_agent" in project_cfg)
+    ):
+        os.environ.setdefault("GPTME_AW_WATCHER_AGENT", "1")
+
+    config_to_env = {
+        "command": "GPTME_AW_WATCHER_AGENT_COMMAND",
+        "server": "GPTME_AW_WATCHER_SERVER",
+        "hostname": "GPTME_AW_WATCHER_HOSTNAME",
+        "trigger": "GPTME_AW_WATCHER_TRIGGER",
+        "category": "GPTME_AW_WATCHER_CATEGORY",
+    }
+    for key, env_name in config_to_env.items():
+        value = merged.get(key)
+        if value not in (None, ""):
+            os.environ.setdefault(env_name, str(value))
+
+
+plugin = GptmePlugin(
+    name="aw_watcher_agent",
+    register_hooks=register,
+    init=_init_from_config,
+)

--- a/gptme/hooks/test.py
+++ b/gptme/hooks/test.py
@@ -21,6 +21,11 @@ def test_message_pre_process_hook(manager) -> Generator[Message, None, None]:
     yield Message("system", "TEST_STEP_PRE hook triggered")
 
 
+def test_turn_pre_hook(manager) -> Generator[Message, None, None]:
+    """Test hook for TURN_PRE (turn.pre - once per submitted prompt)."""
+    yield Message("system", "TEST_TURN_PRE hook triggered")
+
+
 def test_message_post_process_hook(manager) -> Generator[Message, None, None]:
     """Test hook for TURN_POST (turn.post - after turn completes)."""
     yield Message("system", "TEST_TURN_POST hook triggered")
@@ -40,6 +45,12 @@ def register_test_hooks() -> None:
         "test_step_pre",
         HookType.STEP_PRE,
         test_message_pre_process_hook,
+        priority=100,
+    )
+    register_hook(
+        "test_turn_pre",
+        HookType.TURN_PRE,
+        test_turn_pre_hook,
         priority=100,
     )
     register_hook(

--- a/gptme/hooks/tests/test_aw_watcher_agent.py
+++ b/gptme/hooks/tests/test_aw_watcher_agent.py
@@ -1,0 +1,67 @@
+"""Tests for aw_watcher_agent lifecycle hook integration."""
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import patch
+
+from gptme.hooks.aw_watcher_agent import emit_end, emit_start
+from gptme.logmanager import LogManager
+
+
+def _completed(returncode: int = 0, stdout: str = "", stderr: str = ""):
+    return SimpleNamespace(returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+def test_emit_start_shells_out_when_enabled(monkeypatch):
+    """session.start should emit a best-effort aw-watcher-agent CLI call."""
+    monkeypatch.setenv("GPTME_AW_WATCHER_AGENT", "1")
+    model = SimpleNamespace(full="anthropic/test-model")
+
+    with (
+        patch("gptme.hooks.aw_watcher_agent.get_default_model", return_value=model),
+        patch(
+            "gptme.hooks.aw_watcher_agent.subprocess.run",
+            return_value=_completed(),
+        ) as run,
+    ):
+        assert list(emit_start(Path("/tmp/conv123"), Path("/tmp/workspace"), [])) == []
+
+    argv = run.call_args.args[0]
+    assert argv[:2] == ["aw-watcher-agent", "emit-start"]
+    assert "--session-id" in argv and "conv123" in argv
+    assert "--workspace" in argv and "workspace" in argv
+    assert "--model" in argv and "anthropic/test-model" in argv
+
+
+def test_emit_end_shells_out_when_enabled(monkeypatch):
+    """session.end should emit the matching aw-watcher-agent close event."""
+    monkeypatch.setenv("GPTME_AW_WATCHER_AGENT", "1")
+
+    manager = cast(
+        LogManager,
+        SimpleNamespace(
+            logdir=Path("/tmp/conv123"),
+            workspace=Path("/tmp/workspace"),
+        ),
+    )
+
+    with patch(
+        "gptme.hooks.aw_watcher_agent.subprocess.run",
+        return_value=_completed(),
+    ) as run:
+        assert list(emit_end(manager)) == []
+
+    argv = run.call_args.args[0]
+    assert argv[:2] == ["aw-watcher-agent", "emit-end"]
+    assert "--session-id" in argv and "conv123" in argv
+
+
+def test_emit_start_noops_when_disabled(monkeypatch):
+    """No subprocess call should happen when the plugin is disabled."""
+    monkeypatch.delenv("GPTME_AW_WATCHER_AGENT", raising=False)
+
+    with patch("gptme.hooks.aw_watcher_agent.subprocess.run") as run:
+        assert list(emit_start(Path("/tmp/conv123"), Path("/tmp/workspace"), [])) == []
+
+    run.assert_not_called()

--- a/gptme/server/session_step.py
+++ b/gptme/server/session_step.py
@@ -590,6 +590,18 @@ def step(
         )
         os.chdir(workspace)
 
+    # Trigger TURN_PRE once per submitted user prompt before the step starts.
+    # This gives hooks a stable "user prompt submitted" lifecycle point that is
+    # distinct from step.pre, which may run multiple times inside one turn.
+    if turn_pre_msgs := trigger_hook(
+        HookType.TURN_PRE,
+        manager=manager,
+    ):
+        for msg in turn_pre_msgs:
+            _append_and_notify(manager, session, msg)
+        manager.write()
+        logger.debug("Wrote turn.pre hook messages to disk")
+
     # Trigger STEP_PRE hook BEFORE preparing messages
     # This ensures hook messages are included in the LLM input
     if pre_msgs := trigger_hook(

--- a/gptme/server/session_step.py
+++ b/gptme/server/session_step.py
@@ -591,16 +591,25 @@ def step(
         os.chdir(workspace)
 
     # Trigger TURN_PRE once per submitted user prompt before the step starts.
-    # This gives hooks a stable "user prompt submitted" lifecycle point that is
-    # distinct from step.pre, which may run multiple times inside one turn.
-    if turn_pre_msgs := trigger_hook(
-        HookType.TURN_PRE,
-        manager=manager,
-    ):
-        for msg in turn_pre_msgs:
-            _append_and_notify(manager, session, msg)
-        manager.write()
-        logger.debug("Wrote turn.pre hook messages to disk")
+    # Guard against tool-continuation calls: step() is re-entered after every
+    # tool execution, so TURN_PRE must only fire when this is a fresh user turn
+    # (the last user message is newer than the last assistant message).
+    log_msgs = manager.log.messages
+    last_user_idx = max(
+        (i for i, m in enumerate(log_msgs) if m.role == "user"), default=-1
+    )
+    last_asst_idx = max(
+        (i for i, m in enumerate(log_msgs) if m.role == "assistant"), default=-1
+    )
+    if last_user_idx > last_asst_idx:
+        if turn_pre_msgs := trigger_hook(
+            HookType.TURN_PRE,
+            manager=manager,
+        ):
+            for msg in turn_pre_msgs:
+                _append_and_notify(manager, session, msg)
+            manager.write()
+            logger.debug("Wrote turn.pre hook messages to disk")
 
     # Trigger STEP_PRE hook BEFORE preparing messages
     # This ensures hook messages are included in the LLM input

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ Issues = "https://github.com/gptme/gptme/issues"
 
 [project.entry-points."gptme.plugins"]
 auto_snapshots = "gptme.hooks.auto_snapshots:plugin"
+aw_watcher_agent = "gptme.hooks.aw_watcher_agent:plugin"
 
 [project.scripts]
 gptme = "gptme.cli.main:main"

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -690,6 +690,46 @@ def test_external_queued_prompts_are_drained_between_turns(tmp_path):
     assert not get_prompt_queue_path(logdir).exists()
 
 
+def test_turn_pre_hook_runs_once_per_prompt():
+    """TURN_PRE should fire once when a queued prompt becomes an active turn."""
+    import sys
+
+    from gptme.chat import _run_chat_loop
+    from gptme.hooks import HookType
+    from gptme.message import Message
+
+    _chat_mod = sys.modules["gptme.chat"]
+
+    manager = MagicMock()
+    manager.log = MagicMock()
+    manager.workspace = Path("/tmp")
+    manager.logdir = Path("/tmp/logdir")
+
+    seen_hooks = []
+
+    def track_hooks(hook_type, *args, **kwargs):
+        del args, kwargs
+        seen_hooks.append(hook_type)
+        return []
+
+    with (
+        patch.object(_chat_mod, "_process_message_conversation", return_value=None),
+        patch.object(_chat_mod, "trigger_hook", side_effect=track_hooks),
+        patch.object(_chat_mod, "include_paths", side_effect=lambda msg, ws: msg),
+        patch.object(_chat_mod, "execute_cmd", return_value=False),
+    ):
+        _run_chat_loop(
+            manager=manager,
+            prompt_queue=[Message("user", "queued prompt")],
+            stream=False,
+            tool_format="markdown",
+            model=None,
+            interactive=False,
+        )
+
+    assert seen_hooks.count(HookType.TURN_PRE) == 1
+
+
 def test_complete_checks_external_queue_before_exiting(tmp_path):
     """External queued prompts should keep the loop alive after complete."""
     import sys

--- a/tests/test_server_v2_hooks.py
+++ b/tests/test_server_v2_hooks.py
@@ -133,6 +133,8 @@ def test_message_pre_process_hook(client: FlaskClient, monkeypatch):
 
 def test_turn_pre_hook(client: FlaskClient, monkeypatch):
     """Test that TURN_PRE hooks fire once when a user prompt starts a turn."""
+    import unittest.mock
+
     monkeypatch.setenv("HOOK_ALLOWLIST", "test")
 
     conv = create_conversation(client)
@@ -143,16 +145,22 @@ def test_turn_pre_hook(client: FlaskClient, monkeypatch):
     )
     assert response.status_code == 200
 
-    response = client.post(
-        f"/api/v2/conversations/{conv['conversation_id']}/step",
-        json={
-            "session_id": conv["session_id"],
-            "stream": False,
-        },
-    )
+    def mock_chat_complete(messages, model, tools=None):
+        return ("Hello! How can I help you?", None)
 
-    assert response.status_code in (200, 500)
-    time.sleep(2)
+    with unittest.mock.patch(
+        "gptme.server.session_step._chat_complete", mock_chat_complete
+    ):
+        response = client.post(
+            f"/api/v2/conversations/{conv['conversation_id']}/step",
+            json={
+                "session_id": conv["session_id"],
+                "stream": False,
+            },
+        )
+
+        assert response.status_code == 200
+        time.sleep(2)
 
     response = client.get(f"/api/v2/conversations/{conv['conversation_id']}")
     assert response.status_code == 200

--- a/tests/test_server_v2_hooks.py
+++ b/tests/test_server_v2_hooks.py
@@ -131,6 +131,42 @@ def test_message_pre_process_hook(client: FlaskClient, monkeypatch):
     )
 
 
+def test_turn_pre_hook(client: FlaskClient, monkeypatch):
+    """Test that TURN_PRE hooks fire once when a user prompt starts a turn."""
+    monkeypatch.setenv("HOOK_ALLOWLIST", "test")
+
+    conv = create_conversation(client)
+
+    response = client.post(
+        f"/api/v2/conversations/{conv['conversation_id']}",
+        json={"role": "user", "content": "Say hello"},
+    )
+    assert response.status_code == 200
+
+    response = client.post(
+        f"/api/v2/conversations/{conv['conversation_id']}/step",
+        json={
+            "session_id": conv["session_id"],
+            "stream": False,
+        },
+    )
+
+    assert response.status_code in (200, 500)
+    time.sleep(2)
+
+    response = client.get(f"/api/v2/conversations/{conv['conversation_id']}")
+    assert response.status_code == 200
+    data = response.get_json()
+
+    messages = data.get("log", [])
+    test_hook_messages = [
+        m for m in messages if "TEST_TURN_PRE hook triggered" in m.get("content", "")
+    ]
+    assert len(test_hook_messages) > 0, (
+        f"TEST_TURN_PRE hook message should be in log. Found {len(messages)} messages total"
+    )
+
+
 def test_message_post_process_hook(client: FlaskClient, monkeypatch):
     """Test that TURN_POST hooks work."""
     import unittest.mock


### PR DESCRIPTION
## Summary
- wire `turn.pre` into both CLI and server turn execution paths
- add an opt-in `aw_watcher_agent` hook plugin that emits `session.start` / `session.end` events to the external ActivityWatch CLI
- refresh hook docs and tests around the current hook names and lifecycle semantics

## Testing
- `PYTHONPATH=/tmp/gptme-runtime-hook-phase1 /home/bob/gptme/.venv/bin/pytest /tmp/gptme-runtime-hook-phase1/tests/test_chat.py -k turn_pre_hook_runs_once_per_prompt -q`
- `PYTHONPATH=/tmp/gptme-runtime-hook-phase1 /home/bob/gptme/.venv/bin/pytest /tmp/gptme-runtime-hook-phase1/tests/test_server_v2_hooks.py -k 'turn_pre_hook or message_pre_process_hook or message_post_process_hook' -q`\n- `PYTHONPATH=/tmp/gptme-runtime-hook-phase1 /home/bob/gptme/.venv/bin/pytest /tmp/gptme-runtime-hook-phase1/gptme/hooks/tests/test_aw_watcher_agent.py -q`\n- `PYTHONPATH=/tmp/gptme-runtime-hook-phase1 /home/bob/gptme/.venv/bin/python -m py_compile /tmp/gptme-runtime-hook-phase1/gptme/hooks/aw_watcher_agent.py`