### PR TITLE
fix(hooks): tolerate session-end trigger kwargs

### DIFF
--- a/gptme/hooks/aw_watcher_agent.py
+++ b/gptme/hooks/aw_watcher_agent.py
@@ -130,11 +130,13 @@ def emit_start(
     yield
 
 
-def emit_end(manager: LogManager) -> Generator[Message | StopPropagation, None, None]:
+def emit_end(
+    manager: LogManager, **kwargs
+) -> Generator[Message | StopPropagation, None, None]:
     """Emit a session-end event matching the earlier session-start emission."""
     if not _enabled():
         return
-    logdir = getattr(manager, "logdir", None)
+    logdir = getattr(manager, "logdir", None) or kwargs.get("logdir")
     workspace = getattr(manager, "workspace", None)
     if logdir is None:
         return

--- a/gptme/hooks/tests/test_aw_watcher_agent.py
+++ b/gptme/hooks/tests/test_aw_watcher_agent.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 from typing import cast
 from unittest.mock import patch
 
+from gptme.hooks import HookRegistry, HookType, get_registry, set_registry, trigger_hook
 from gptme.hooks.aw_watcher_agent import emit_end, emit_start
 from gptme.logmanager import LogManager
 
@@ -55,6 +56,42 @@ def test_emit_end_shells_out_when_enabled(monkeypatch):
     argv = run.call_args.args[0]
     assert argv[:2] == ["aw-watcher-agent", "emit-end"]
     assert "--session-id" in argv and "conv123" in argv
+
+
+def test_session_end_hook_accepts_trigger_kwargs(monkeypatch):
+    """Registered session.end hook should tolerate extra trigger kwargs."""
+    from gptme.hooks.aw_watcher_agent import register
+
+    monkeypatch.setenv("GPTME_AW_WATCHER_AGENT", "1")
+    manager = cast(
+        LogManager,
+        SimpleNamespace(
+            logdir=Path("/tmp/conv123"),
+            workspace=Path("/tmp/workspace"),
+        ),
+    )
+
+    old = get_registry()
+    set_registry(HookRegistry())
+    try:
+        register()
+        with patch(
+            "gptme.hooks.aw_watcher_agent.subprocess.run",
+            return_value=_completed(),
+        ) as run:
+            assert (
+                list(
+                    trigger_hook(
+                        HookType.SESSION_END,
+                        logdir=Path("/tmp/conv123"),
+                        manager=manager,
+                    )
+                )
+                == []
+            )
+        run.assert_called_once()
+    finally:
+        set_registry(old)
 
 
 def test_emit_start_noops_when_disabled(monkeypatch):


### PR DESCRIPTION
## Summary
- make `aw_watcher_agent.emit_end()` tolerate the extra `logdir=` kwarg passed by `SESSION_END` trigger sites
- fall back to the kwarg logdir if the manager does not expose one
- add a regression test that registers the hook and exercises the real `trigger_hook(HookType.SESSION_END, ...)` path

## Repro
1. Create any existing conversation with a non-empty `conversation.jsonl`.
2. Run `gptme --non-interactive --resume --name <that-conversation> /help`.
3. Before this patch, the CLI printed `Error executing hook 'aw_watcher_agent.end': emit_end() got an unexpected keyword argument 'logdir'`.\n\n## Validation\n- `PYTHONPATH=/tmp/worktrees/gptme/dogfood-cli-58aa /home/bob/gptme/.venv/bin/python -m pytest gptme/hooks/tests/test_aw_watcher_agent.py -q`\n- `PYTHONPATH=/tmp/worktrees/gptme/dogfood-cli-58aa /home/bob/gptme/.venv/bin/python -m pytest tests/test_cli.py -q -k "resume_named_missing_conversation or tools_short_option_equals_syntax_works or command_help"`\n- live repro: reran `uv run gptme --non-interactive --resume --name full-resume /help` in an isolated XDG tempdir and confirmed the hook error disappeared\n