### PR TITLE
fix(server): reject non-string conversation prompt

### DIFF
--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -522,7 +522,7 @@ def api_conversation_put(conversation_id: str):
         return flask.jsonify({"error": "'config' must be an object"}), 400
     prompt = req_json.get("prompt", "full")
     if not isinstance(prompt, str):
-        return flask.jsonify({"error": "prompt must be a string"}), 400
+        return flask.jsonify({"error": "'prompt' must be a string"}), 400
 
     # Load or create the chat config, overriding values from request config if provided
     config_dict = dict(config_raw)

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -520,6 +520,9 @@ def api_conversation_put(conversation_id: str):
     config_raw = req_json.get("config", {})
     if not isinstance(config_raw, dict):
         return flask.jsonify({"error": "'config' must be an object"}), 400
+    prompt = req_json.get("prompt", "full")
+    if not isinstance(prompt, str):
+        return flask.jsonify({"error": "prompt must be a string"}), 400
 
     # Load or create the chat config, overriding values from request config if provided
     config_dict = dict(config_raw)
@@ -539,7 +542,6 @@ def api_conversation_put(conversation_id: str):
         )
 
     chat_config = ChatConfig.load_or_create(logdir, request_config)
-    prompt = req_json.get("prompt", "full")
 
     msgs = get_prompt(
         tools=list(get_toolchain(chat_config.tools, strict=False)),

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -1899,7 +1899,7 @@ def test_v2_create_conversation_rejects_non_string_prompt(
     )
 
     assert response.status_code == 400
-    assert response.get_json() == {"error": "prompt must be a string"}
+    assert response.get_json() == {"error": "'prompt' must be a string"}
     assert not (logs_dir / conv_id).exists()
 
     retry = client.put(f"/api/v2/conversations/{conv_id}", json={"prompt": "none"})

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -1882,6 +1882,30 @@ def test_v2_create_conversation_messages_not_list(
     assert "messages" in data["error"].lower()
 
 
+@pytest.mark.parametrize("bad_prompt", [None, [], 42, {"mode": "full"}])
+def test_v2_create_conversation_rejects_non_string_prompt(
+    client: FlaskClient, tmp_path, monkeypatch, bad_prompt: object
+):
+    """PUT /conversations/<id> should reject non-string prompt values before side effects."""
+    import uuid
+
+    logs_dir = tmp_path / "logs"
+    monkeypatch.setattr("gptme.server.api_v2.get_logs_dir", lambda: logs_dir)
+    conv_id = f"test-bad-prompt-{uuid.uuid4().hex[:8]}"
+
+    response = client.put(
+        f"/api/v2/conversations/{conv_id}",
+        json={"prompt": bad_prompt},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "prompt must be a string"}
+    assert not (logs_dir / conv_id).exists()
+
+    retry = client.put(f"/api/v2/conversations/{conv_id}", json={"prompt": "none"})
+    assert retry.status_code == 200
+
+
 @pytest.mark.parametrize("bad_agent", [[], 42, {"path": "~/agent"}])
 def test_v2_create_conversation_rejects_invalid_agent_type(
     client: FlaskClient, tmp_path, monkeypatch, bad_agent: object


### PR DESCRIPTION
## Summary
- reject non-string `prompt` values in `PUT /api/v2/conversations/<id>` with a JSON 400
- validate `prompt` before creating the conversation directory to avoid orphaned side effects on bad input
- add a regression test covering non-string prompt values and retry-after-failure behavior

## Repro
Before this patch, the server returned a raw HTML 500 for:
```json
{"prompt": ["bad"]}
```
when sent to `PUT /api/v2/conversations/<id>`.

Live repro against `gptme-server` showed a traceback from `get_prompt()` / `_join_messages()` (`TypeError: sequence item 0: expected str instance, list found`).

## Testing
- `PYTHONPATH=/tmp/gptme-prompt-validation-b8d2 /home/bob/gptme/.venv/bin/python -m pytest /tmp/gptme-prompt-validation-b8d2/tests/test_server_v2.py::test_v2_create_conversation_rejects_non_string_prompt /tmp/gptme-prompt-validation-b8d2/tests/test_server_v2.py::test_v2_create_conversation_rejects_invalid_agent_type -q`
- `uv run ruff check gptme/server/api_v2.py tests/test_server_v2.py`
- `uv run ruff format --check gptme/server/api_v2.py tests/test_server_v2.py`