### PR TITLE
fix(cli): raise UsageError for unknown model in llm generate

### DIFF
--- a/gptme/cli/util.py
+++ b/gptme/cli/util.py
@@ -380,7 +380,10 @@ def llm_generate(prompt: str | None, model: str | None, stream: bool):
         console.quiet = True
 
         # Initialize with minimal setup - no tools needed for simple generation
-        init(model, interactive=False, tool_allowlist=[], tool_format="markdown")
+        try:
+            init(model, interactive=False, tool_allowlist=[], tool_format="markdown")
+        except ValueError as e:
+            raise click.UsageError(str(e)) from e
 
         # Get model or use default
         if not model:
@@ -398,8 +401,7 @@ def llm_generate(prompt: str | None, model: str | None, stream: bool):
             provider = get_provider_from_model(model)
             init_llm(provider)
         except ValueError as e:
-            print(f"Error: {e}", file=sys.stderr)
-            sys.exit(1)
+            raise click.UsageError(str(e)) from e
 
     # Create message
     messages = [Message("user", prompt)]

--- a/gptme/cli/util.py
+++ b/gptme/cli/util.py
@@ -389,11 +389,9 @@ def llm_generate(prompt: str | None, model: str | None, stream: bool):
         if not model:
             default_model = get_default_model()
             if not default_model:
-                print(
-                    "Error: No model specified and no default model available.",
-                    file=sys.stderr,
+                raise click.UsageError(
+                    "No model specified and no default model available."
                 )
-                sys.exit(1)
             model = default_model.full
 
         # Ensure provider is initialized

--- a/tests/test_util_cli.py
+++ b/tests/test_util_cli.py
@@ -777,3 +777,16 @@ def test_agents_scan_workspace_passes_through(mocker, tmp_path):
     runner = CliRunner()
     runner.invoke(main, ["agents", "scan", "--workspace", str(tmp_path)])
     mock_scan.assert_called_once_with(workspace=str(tmp_path))
+
+
+def test_llm_generate_unknown_model():
+    """gptme-util llm generate --model unknown/model should fail cleanly, not crash."""
+    runner = CliRunner()
+    result = runner.invoke(
+        main, ["llm", "generate", "--model", "notareal/model", "hello"]
+    )
+    assert result.exit_code != 0
+    # Should show clean error, not a raw ValueError traceback
+    assert result.exception is None or isinstance(result.exception, SystemExit)
+    # Error mentions the unknown provider/model — exact message varies by code path
+    assert "notareal" in result.output or "Unknown" in result.output


### PR DESCRIPTION
## Summary

- `gptme-util llm generate --model notareal/model hello` crashed with a raw `ValueError` traceback from `init()` — no try/except caught it
- The existing `get_provider_from_model()` try/except inside `redirect_stderr()` printed to captured stderr, so the error message was silently swallowed
- Both are now converted to `click.UsageError`, which propagates cleanly out of the `redirect_stderr` context and click renders it as a standard `Error: ...` message with exit code 2

## Reproduction

```
$ gptme-util llm generate --model notareal/model hello
Traceback (most recent call last):
  ...
ValueError: Unknown model 'notareal/model'. Use 'provider/model' with a known provider...
```

After fix:

```
$ gptme-util llm generate --model notareal/model hello
Usage: gptme-util llm generate [OPTIONS] [PROMPT]
Try 'gptme-util llm generate --help' for help.

Error: Unknown provider: notareal
```

## Test plan

- [x] `tests/test_util_cli.py::test_llm_generate_unknown_model` — new regression test
- [x] Full `tests/test_util_cli.py` suite: 27 passed, 1 skipped