### PR TITLE
fix(server): correct upload path field description and add upload tests

### DIFF
--- a/gptme/server/workspace_api.py
+++ b/gptme/server/workspace_api.py
@@ -60,7 +60,9 @@ class UploadedFileMetadata(BaseModel):
 
     name: str = Field(..., description="File name")
     path: str = Field(
-        ..., description="Absolute filesystem path for use in message files"
+        ...,
+        description="Path relative to conversation logdir (e.g. 'attachments/filename'). "
+        "Use with GET /api/v2/conversations/{id}/files/<path> to retrieve the file.",
     )
     type: Literal["file", "directory"] = Field(..., description="File type")
     size: int = Field(..., description="File size in bytes")
@@ -329,7 +331,9 @@ def upload_files(conversation_id: str):
     (<logdir>/attachments/). Accepts multipart/form-data with file fields.
     Uploaded files are intended for the agent to read as context; the agent can
     move them into the workspace if it needs to modify them.
-    Returns absolute file paths so they can be included directly in message files.
+    Returns logdir-relative paths (e.g. ``attachments/filename``) for each
+    uploaded file. Retrieve a file via
+    ``GET /api/v2/conversations/{id}/files/<path>``.
     """
     if error := _validate_conversation_id(conversation_id):
         return error

--- a/tests/test_server_workspace.py
+++ b/tests/test_server_workspace.py
@@ -867,3 +867,136 @@ class TestWorkspaceEdgeCases:
         assert response.status_code == 200
         data = response.get_json()
         assert isinstance(data, list)
+
+
+class TestUploadFilesEndpoint:
+    """Tests for the upload_files API endpoint."""
+
+    def _create_conv(self, client: FlaskClient) -> str:
+        convname = f"test-upload-{uuid4().hex[:8]}"
+        resp = client.put(
+            f"/api/v2/conversations/{convname}",
+            json={"prompt": "Test."},
+        )
+        assert resp.status_code == 200
+        return convname
+
+    def test_upload_success_returns_logdir_relative_path(self, client: FlaskClient):
+        """Uploaded file path is logdir-relative (e.g. attachments/filename)."""
+        import io
+
+        conv_id = self._create_conv(client)
+        data = {"file": (io.BytesIO(b"hello world"), "test.txt")}
+        resp = client.post(
+            f"/api/v2/conversations/{conv_id}/workspace/upload",
+            data=data,
+            content_type="multipart/form-data",
+        )
+        assert resp.status_code == 200
+        result = resp.get_json()
+        assert result is not None
+        assert "files" in result
+        assert len(result["files"]) == 1
+        f = result["files"][0]
+        assert f["name"] == "test.txt"
+        # Path is logdir-relative, not absolute
+        from pathlib import Path
+
+        assert not Path(f["path"]).is_absolute()
+        assert f["path"] == "attachments/test.txt"
+        assert f["size"] == len(b"hello world")
+        assert f["type"] == "file"
+
+    def test_upload_no_files_returns_400(self, client: FlaskClient):
+        conv_id = self._create_conv(client)
+        resp = client.post(
+            f"/api/v2/conversations/{conv_id}/workspace/upload",
+            data={},
+            content_type="multipart/form-data",
+        )
+        assert resp.status_code == 400
+        assert "No files provided" in resp.get_json()["error"]
+
+    def test_upload_hidden_filename_rejected(self, client: FlaskClient):
+        """Files whose names start with '.' are skipped → 400."""
+        import io
+
+        conv_id = self._create_conv(client)
+        data = {"file": (io.BytesIO(b"secret"), ".hidden")}
+        resp = client.post(
+            f"/api/v2/conversations/{conv_id}/workspace/upload",
+            data=data,
+            content_type="multipart/form-data",
+        )
+        assert resp.status_code == 400
+        assert "No valid files uploaded" in resp.get_json()["error"]
+
+    def test_upload_path_traversal_filename_sanitized(self, client: FlaskClient):
+        """Path-traversal component in filename is stripped to basename."""
+        import io
+
+        conv_id = self._create_conv(client)
+        data = {"file": (io.BytesIO(b"pwned"), "../../../etc/evil.txt")}
+        resp = client.post(
+            f"/api/v2/conversations/{conv_id}/workspace/upload",
+            data=data,
+            content_type="multipart/form-data",
+        )
+        assert resp.status_code == 200
+        result = resp.get_json()
+        assert result["files"][0]["name"] == "evil.txt"
+        assert "etc" not in result["files"][0]["path"]
+
+    def test_upload_duplicate_filename_renamed(self, client: FlaskClient):
+        """Second upload with same name gets a unique suffix."""
+        import io
+
+        conv_id = self._create_conv(client)
+        for i in range(2):
+            data = {"file": (io.BytesIO(f"content {i}".encode()), "dup.txt")}
+            resp = client.post(
+                f"/api/v2/conversations/{conv_id}/workspace/upload",
+                data=data,
+                content_type="multipart/form-data",
+            )
+            assert resp.status_code == 200
+
+        # The second upload must have a different name
+        # (re-upload and collect both)
+        names = []
+        for i in range(2):
+            data = {"file": (io.BytesIO(f"c{i}".encode()), "same.txt")}
+            resp = client.post(
+                f"/api/v2/conversations/{conv_id}/workspace/upload",
+                data=data,
+                content_type="multipart/form-data",
+            )
+            assert resp.status_code == 200
+            names.append(resp.get_json()["files"][0]["name"])
+        assert names[0] != names[1], "Duplicate filenames must be renamed"
+
+    def test_upload_nonexistent_conversation_returns_404(self, client: FlaskClient):
+        import io
+
+        data = {"file": (io.BytesIO(b"x"), "x.txt")}
+        resp = client.post(
+            "/api/v2/conversations/nonexistent-conv-xyz/workspace/upload",
+            data=data,
+            content_type="multipart/form-data",
+        )
+        assert resp.status_code == 404
+
+    def test_upload_empty_file_accepted(self, client: FlaskClient):
+        """Zero-byte files are valid uploads."""
+        import io
+
+        conv_id = self._create_conv(client)
+        data = {"file": (io.BytesIO(b""), "empty.txt")}
+        resp = client.post(
+            f"/api/v2/conversations/{conv_id}/workspace/upload",
+            data=data,
+            content_type="multipart/form-data",
+        )
+        assert resp.status_code == 200
+        result = resp.get_json()
+        assert result["files"][0]["size"] == 0

--- a/tests/test_server_workspace.py
+++ b/tests/test_server_workspace.py
@@ -8,6 +8,7 @@ Tests browse_workspace and preview_file endpoints, including:
 - Error handling
 """
 
+import io
 import shutil
 from pathlib import Path
 from uuid import uuid4
@@ -883,8 +884,6 @@ class TestUploadFilesEndpoint:
 
     def test_upload_success_returns_logdir_relative_path(self, client: FlaskClient):
         """Uploaded file path is logdir-relative (e.g. attachments/filename)."""
-        import io
-
         conv_id = self._create_conv(client)
         data = {"file": (io.BytesIO(b"hello world"), "test.txt")}
         resp = client.post(
@@ -900,8 +899,6 @@ class TestUploadFilesEndpoint:
         f = result["files"][0]
         assert f["name"] == "test.txt"
         # Path is logdir-relative, not absolute
-        from pathlib import Path
-
         assert not Path(f["path"]).is_absolute()
         assert f["path"] == "attachments/test.txt"
         assert f["size"] == len(b"hello world")
@@ -919,8 +916,6 @@ class TestUploadFilesEndpoint:
 
     def test_upload_hidden_filename_rejected(self, client: FlaskClient):
         """Files whose names start with '.' are skipped → 400."""
-        import io
-
         conv_id = self._create_conv(client)
         data = {"file": (io.BytesIO(b"secret"), ".hidden")}
         resp = client.post(
@@ -933,8 +928,6 @@ class TestUploadFilesEndpoint:
 
     def test_upload_path_traversal_filename_sanitized(self, client: FlaskClient):
         """Path-traversal component in filename is stripped to basename."""
-        import io
-
         conv_id = self._create_conv(client)
         data = {"file": (io.BytesIO(b"pwned"), "../../../etc/evil.txt")}
         resp = client.post(
@@ -949,20 +942,7 @@ class TestUploadFilesEndpoint:
 
     def test_upload_duplicate_filename_renamed(self, client: FlaskClient):
         """Second upload with same name gets a unique suffix."""
-        import io
-
         conv_id = self._create_conv(client)
-        for i in range(2):
-            data = {"file": (io.BytesIO(f"content {i}".encode()), "dup.txt")}
-            resp = client.post(
-                f"/api/v2/conversations/{conv_id}/workspace/upload",
-                data=data,
-                content_type="multipart/form-data",
-            )
-            assert resp.status_code == 200
-
-        # The second upload must have a different name
-        # (re-upload and collect both)
         names = []
         for i in range(2):
             data = {"file": (io.BytesIO(f"c{i}".encode()), "same.txt")}
@@ -976,8 +956,6 @@ class TestUploadFilesEndpoint:
         assert names[0] != names[1], "Duplicate filenames must be renamed"
 
     def test_upload_nonexistent_conversation_returns_404(self, client: FlaskClient):
-        import io
-
         data = {"file": (io.BytesIO(b"x"), "x.txt")}
         resp = client.post(
             "/api/v2/conversations/nonexistent-conv-xyz/workspace/upload",
@@ -988,8 +966,6 @@ class TestUploadFilesEndpoint:
 
     def test_upload_empty_file_accepted(self, client: FlaskClient):
         """Zero-byte files are valid uploads."""
-        import io
-
         conv_id = self._create_conv(client)
         data = {"file": (io.BytesIO(b""), "empty.txt")}
         resp = client.post(


### PR DESCRIPTION
## Summary

- `UploadedFileMetadata.path` was documented as *"Absolute filesystem path for use in message files"* but PR #1906 intentionally changed the return value to a **logdir-relative path** (e.g. `attachments/filename`) when the `/files/<path>` serving endpoint was added. The code comment even says `# logdir-relative: "attachments/filename"` but the OpenAPI field description and the function docstring were never updated.
- Fixes both stale strings to accurately describe the actual behaviour.
- Adds 7 tests for `upload_files` — the endpoint previously had **zero test coverage** in `test_server_workspace.py`.

## Root cause

`744cc1cf` (feat: file upload) returned `str(file_path)` — absolute. `2abccb4d` (fix #1906) changed it to `file_path.relative_to(manager.logdir)` for the new files-serving endpoint, but the OpenAPI description and function docstring were left pointing at the old design.

## Test plan

- [x] `uv run pytest tests/test_server_workspace.py::TestUploadFilesEndpoint -v` — 7/7 pass
- [x] All pre-commit hooks pass