### PR TITLE
fix(cli): raise UsageError for empty --model string

### DIFF
--- a/gptme/config/cli_setup.py
+++ b/gptme/config/cli_setup.py
@@ -109,6 +109,8 @@ def setup_config_from_cli(
     # For new conversations: CLI args -> env vars/config files -> defaults
     resolved_model: str | None
     if model is not None:
+        if not model.strip():
+            raise ValueError("Model name cannot be empty.")
         # CLI override always takes precedence
         resolved_model = model
     elif existing_chat_config and existing_chat_config.model:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -493,6 +493,26 @@ def test_architect_model_unqualified_is_usage_error(
     assert "provider prefix" in result.output
 
 
+def test_empty_model_is_usage_error(runner: CliRunner, runid: int):
+    # --model "" should give a clean UsageError, not silently fall back to the
+    # default model with a warning. An empty string is an obvious user mistake.
+    result = runner.invoke(
+        cli.main,
+        [
+            "--non-interactive",
+            "--name",
+            f"test-empty-model-{runid}",
+            "--model",
+            "",
+            "hello",
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert "Traceback" not in result.output
+    assert "empty" in result.output.lower()
+
+
 def test_unknown_agent_profile_stays_off_stdout_in_json_mode():
     # Click < 8.2 defaults to mix_stderr=True; Click 8.2 removed that kwarg
     # and separates streams by default. Use try/except to handle both.


### PR DESCRIPTION
## Summary

- `--model ""` was silently accepted: the `model is not None` guard in `setup_config_from_cli` passed for an empty string, which then propagated downstream and printed `WARNING Unknown model , using fallback metadata` before falling back to the configured default
- Added an explicit check in `setup_config_from_cli`: if `model` is not None but is empty/whitespace, raise `ValueError("Model name cannot be empty.")`, which `main.py` converts to a clean `UsageError` (exit 2, no traceback)
- Added `test_empty_model_is_usage_error` to `tests/test_cli.py`

## Before

```
$ gptme --model "" -n "hello"
WARNING  Unknown model , using fallback metadata
...falls through to default model, then fails on auth...
```

## After

```
$ gptme --model "" -n "hello"
Error: Model name cannot be empty.
exit 2
```

## Test plan

- [x] `uv run pytest tests/test_cli.py::test_empty_model_is_usage_error -xvs` passes
- [x] `uv run pytest tests/test_cli.py -q` — 62 passed, 4 skipped
- [x] pre-commit (prek) passes