### PR TITLE
fix(server): reject invalid message tool allowlists

### DIFF
--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -127,6 +127,18 @@ def _validate_model_input(model: str, expected_provider: str | None = None) -> s
     return trimmed_model
 
 
+def _get_optional_string_list_field(
+    req_json: dict, field: str
+) -> list[str] | None | tuple[flask.Response, int]:
+    """Return an optional list[str] field or a 400 response."""
+    value = req_json.get(field)
+    if value is None:
+        return None
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        return flask.jsonify({"error": f"{field} must be a list of strings"}), 400
+    return value
+
+
 def _persist_default_model(model: str) -> bool:
     """Persist env.MODEL and try to apply it in-process.
 
@@ -647,9 +659,14 @@ def api_conversation_post(conversation_id: str):
     branch = req_json.get("branch", "main")
     if error := _validate_branch(branch):
         return error
-    tool_allowlist = req_json.get("tools", None)
+    tool_allowlist = _get_optional_string_list_field(req_json, "tools")
+    if isinstance(tool_allowlist, tuple):
+        return tool_allowlist
 
-    init_tools(tool_allowlist)
+    try:
+        init_tools(tool_allowlist)
+    except ValueError as exc:
+        return flask.jsonify({"error": str(exc)}), 400
 
     try:
         log = LogManager.load(conversation_id, branch=branch)

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -667,6 +667,8 @@ def api_conversation_post(conversation_id: str):
         init_tools(tool_allowlist)
     except ValueError as exc:
         return flask.jsonify({"error": str(exc)}), 400
+    except Exception as exc:
+        return flask.jsonify({"error": f"Failed to load tool: {exc}"}), 400
 
     try:
         log = LogManager.load(conversation_id, branch=branch)

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -677,12 +677,10 @@ def api_conversation_post(conversation_id: str):
         )
 
     # Validate and convert file paths from JSON strings to Path objects
-    files_raw = req_json.get("files", [])
-    if not isinstance(files_raw, list) or not all(
-        isinstance(f, str) for f in files_raw
-    ):
-        return flask.jsonify({"error": "files must be a list of strings"}), 400
-    file_paths = [Path(f) for f in files_raw]
+    files_result = _get_optional_string_list_field(req_json, "files")
+    if isinstance(files_result, tuple):
+        return files_result
+    file_paths = [Path(f) for f in files_result] if files_result is not None else []
     msg = Message(
         req_json["role"],
         req_json["content"],

--- a/gptme/server/openapi_docs.py
+++ b/gptme/server/openapi_docs.py
@@ -59,6 +59,9 @@ class MessageCreateRequest(BaseModel):
     role: str = Field(..., description="Message role")
     content: str = Field(..., description="Message content")
     files: list[str] | None = Field(None, description="Associated files")
+    tools: list[str] | None = Field(
+        None, description="Optional per-request tool allowlist"
+    )
     branch: str = Field("main", description="Conversation branch")
 
 

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -1492,6 +1492,44 @@ def test_v2_post_message_rejects_invalid_files_payload(
     assert response.get_json() == {"error": "files must be a list of strings"}
 
 
+@pytest.mark.parametrize(
+    "tools_payload",
+    [
+        "bash",
+        ["shell", 123],
+        {"name": "shell"},
+    ],
+)
+def test_v2_post_message_rejects_invalid_tools_payload(
+    client: FlaskClient, tools_payload: object
+):
+    """POST message should reject malformed tool allowlists with 400."""
+    conversation_id = create_conversation(client)["conversation_id"]
+    response = client.post(
+        f"/api/v2/conversations/{conversation_id}",
+        json={"role": "user", "content": "Test message", "tools": tools_payload},
+    )
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "tools must be a list of strings"}
+
+
+def test_v2_post_message_rejects_unknown_tool_name(client: FlaskClient):
+    """POST message should surface unknown tool names as a 400, not a 500."""
+    conversation_id = create_conversation(client)["conversation_id"]
+    response = client.post(
+        f"/api/v2/conversations/{conversation_id}",
+        json={
+            "role": "user",
+            "content": "Test message",
+            "tools": ["definitely-not-a-real-tool"],
+        },
+    )
+    assert response.status_code == 400
+    data = response.get_json()
+    assert data is not None
+    assert "Tool 'definitely-not-a-real-tool' not found" in data["error"]
+
+
 @pytest.mark.parametrize("body", [[], [1, 2, 3], "string", 42])
 def test_v2_post_message_rejects_non_object_json(client: FlaskClient, body: object):
     """POST /conversations/<id> should reject non-object JSON bodies with 400."""


### PR DESCRIPTION
## Summary
- validate the optional per-message `tools` field on `POST /api/v2/conversations/<id>`
- turn `init_tools()` lookup failures into structured 400 responses instead of uncaught exceptions
- add regression coverage for malformed tool payloads and unknown tool names

## Testing
- `PYTHONPATH=/tmp/gptme-dc0c-tools /home/bob/gptme/.venv/bin/pytest /tmp/gptme-dc0c-tools/tests/test_server_v2.py -k 'post_message_rejects_invalid_tools_payload or post_message_rejects_unknown_tool_name or post_message_rejects_invalid_files_payload'`
