### PR TITLE
fix(util-cli): keep tools info JSON machine-readable

### DIFF
--- a/gptme/cli/util.py
+++ b/gptme/cli/util.py
@@ -501,9 +501,21 @@ def tools_info(
         if tool_name in available_dict:
             tool = available_dict[tool_name]
         else:
-            print(f"Tool '{tool_name}' not found. Available tools:")
-            for name in sorted(available_dict.keys()):
-                print(f"  - {name}")
+            if as_json:
+                click.echo(
+                    json.dumps(
+                        {
+                            "tool": tool_name,
+                            "error": f"Tool '{tool_name}' not found",
+                            "available_tools": sorted(available_dict.keys()),
+                        },
+                        indent=2,
+                    )
+                )
+            else:
+                print(f"Tool '{tool_name}' not found. Available tools:")
+                for name in sorted(available_dict.keys()):
+                    print(f"  - {name}")
             sys.exit(1)
 
     if as_json:

--- a/tests/test_util_cli.py
+++ b/tests/test_util_cli.py
@@ -391,6 +391,21 @@ def test_tools_info():
     assert isinstance(data["is_mcp"], bool)
 
 
+def test_tools_info_json_invalid_tool_stays_machine_readable():
+    """tools info --json should return a JSON error payload for missing tools."""
+    import json
+
+    runner = CliRunner()
+
+    result = runner.invoke(main, ["tools", "info", "nonexistent-tool", "--json"])
+
+    assert result.exit_code == 1
+    data = json.loads(result.output)
+    assert data["tool"] == "nonexistent-tool"
+    assert "not found" in data["error"]
+    assert "shell" in data["available_tools"]
+
+
 def test_tools_call_non_default_tool():
     """Non-default tools that expose functions must be callable.
 


### PR DESCRIPTION
## Summary
- keep `gptme-util tools info --json` machine-readable when the tool name is invalid
- return a JSON error payload with `tool`, `error`, and `available_tools` instead of plain text on stdout
- add a regression test for the missing-tool JSON path

## Repro
```bash
uv run python -m gptme.cli.util tools info --json definitely-not-a-real-tool
```

Before this change, the command exited nonzero and printed human-readable text to stdout, which broke automation expecting JSON.

## Testing
- `PYTHONPATH=/tmp/worktrees/gptme-cli-dogfood-4f73 /home/bob/gptme/.venv/bin/pytest /tmp/worktrees/gptme-cli-dogfood-4f73/tests/test_util_cli.py -k 'test_tools_info' -q`
