### PR TITLE
fix(server): reject whitespace-only upload filenames; return 404 for nonexistent workspace subpaths

### DIFF
--- a/gptme/server/workspace_api.py
+++ b/gptme/server/workspace_api.py
@@ -296,6 +296,8 @@ def browse_workspace(conversation_id: str, subpath: str | None = None):
         if path.is_file():
             # Return single file metadata
             return flask.jsonify(WorkspaceFile(path, workspace).to_dict())
+        if not path.exists():
+            return flask.jsonify({"error": "File or directory not found"}), 404
         # Return directory listing
         return flask.jsonify(list_directory(path, workspace, show_hidden))
 
@@ -363,7 +365,7 @@ def upload_files(conversation_id: str):
                 continue
 
             # Sanitize filename (prevent path traversal via filename)
-            filename = Path(file.filename).name
+            filename = Path(file.filename).name.strip()
             if not filename or filename.startswith("."):
                 continue
 

--- a/tests/test_server_workspace.py
+++ b/tests/test_server_workspace.py
@@ -446,6 +446,19 @@ class TestBrowseWorkspaceEndpoint:
         response = client.get("/api/v2/conversations/nonexistent-conv-999/workspace")
         assert response.status_code == 404
 
+    def test_nonexistent_subpath_returns_404_without_path_leak(
+        self, client: FlaskClient, workspace_conv
+    ):
+        """Nonexistent subpath returns 404, not 400 with internal filesystem path."""
+        conv_id = workspace_conv["conversation_id"]
+        response = client.get(
+            f"/api/v2/conversations/{conv_id}/workspace/nonexistent-subdir"
+        )
+        assert response.status_code == 404
+        error = response.get_json()["error"]
+        # Must not expose internal filesystem paths in the error message
+        assert "/" not in error, f"Internal path leaked in error: {error!r}"
+
     def test_file_metadata_fields(self, client: FlaskClient, workspace_conv):
         """Test that file metadata contains all expected fields."""
         conv_id = workspace_conv["conversation_id"]
@@ -976,3 +989,17 @@ class TestUploadFilesEndpoint:
         assert resp.status_code == 200
         result = resp.get_json()
         assert result["files"][0]["size"] == 0
+
+    def test_upload_whitespace_only_filename_rejected(self, client: FlaskClient):
+        """Filenames containing only whitespace must be rejected."""
+        conv_id = self._create_conv(client)
+        for bad_name in ("   ", "\t", " \t "):
+            data = {"file": (io.BytesIO(b"content"), bad_name)}
+            resp = client.post(
+                f"/api/v2/conversations/{conv_id}/workspace/upload",
+                data=data,
+                content_type="multipart/form-data",
+            )
+            assert resp.status_code == 400, (
+                f"Expected 400 for whitespace filename {bad_name!r}, got {resp.status_code}"
+            )


### PR DESCRIPTION
## Summary

Two input-validation bugs found via dogfood probing of the workspace API:

- **Whitespace-only filenames accepted on upload**: A file uploaded with a name like `"   "` or `"\t"` would succeed (HTTP 200) and create a file with that whitespace-only name on disk. The fix strips whitespace before the empty-name check.
- **Internal filesystem path leaked on nonexistent subpath browse**: `GET /workspace/nonexistent-subdir` returned HTTP 400 with `"Path is not a directory: /home/user/.local/share/gptme/logs/.../workspace/nonexistent-subdir"`, exposing the server's internal log directory structure. The fix adds an explicit `path.exists()` check that returns a clean 404 instead.

## Changes

- `gptme/server/workspace_api.py`: `.strip()` filename before validation; add `not path.exists()` guard before `list_directory`
- `tests/test_server_workspace.py`: regression tests for both cases

## Test plan

- [x] `test_upload_whitespace_only_filename_rejected` — whitespace-only names now return 400
- [x] `test_nonexistent_subpath_returns_404_without_path_leak` — missing subpath returns 404 with no filesystem path in error
- [x] Full `test_server_workspace.py` suite: 82/82 passed