### PR TITLE
fix(server): propagate ContextVars into background threads

### DIFF
--- a/gptme/hooks/registry.py
+++ b/gptme/hooks/registry.py
@@ -4,6 +4,7 @@ Contains the HookRegistry class, context-local registry management,
 and module-level API functions (register_hook, trigger_hook, etc.).
 """
 
+import contextvars
 import functools
 import logging
 import threading
@@ -169,10 +170,14 @@ class HookRegistry:
         # Start async hooks in background threads (fire-and-forget)
         # Note: daemon=True is intentional - async hooks are for non-blocking
         # side effects (logging, telemetry) where completion on exit is not required
+        # Each hook gets its own copy_context() so it inherits the triggering
+        # thread's ContextVars (conversation ID, config, tools) but mutations
+        # inside one hook thread don't affect other hook threads.
         for hook in async_hooks:
+            ctx = contextvars.copy_context()
             thread = threading.Thread(
-                target=self._run_async_hook,
-                args=(hook, args, kwargs),
+                target=ctx.run,
+                args=(self._run_async_hook, hook, args, kwargs),
                 daemon=True,
                 name=f"async-hook-{hook.name}",
             )

--- a/gptme/server/session_step.py
+++ b/gptme/server/session_step.py
@@ -337,154 +337,170 @@ async def _acp_step(
     - No per-token streaming (response arrives in one chunk)
     - Tool confirmations are auto-approved inside the subprocess
     """
+    from ..hooks import current_conversation_id, current_session_id
 
-    # Validate acp_runtime is set (use explicit check, not assert which python -O disables)
-    if session.acp_runtime is None:
-        logger.error(
-            "_acp_step called without acp_runtime for session %s", conversation_id
-        )
-        SessionManager.add_event(
-            conversation_id,
-            {"type": "error", "error": "Internal error: ACP runtime not initialized"},
-        )
-        session.generating = False
-        session.generating_since = None
-        return
-    acp_runtime = session.acp_runtime  # snapshot to avoid TOCTOU races
-
-    logdir = get_logs_dir() / conversation_id
-    chat_config = ChatConfig.load_or_create(logdir, ChatConfig())
-    prepare_execution_environment(
-        workspace=workspace,
-        tools=chat_config.tools,
-        chat_config=chat_config,
-    )
-
-    manager = LogManager.load(conversation_id, lock=False)
-
-    # Keep server-side hook semantics aligned with the in-process step path.
-    assistant_messages = [m for m in manager.log.messages if m.role == "assistant"]
-    if len(assistant_messages) == 0:
-        if session_start_msgs := trigger_hook(
-            HookType.SESSION_START,
-            logdir=logdir,
-            workspace=workspace,
-            initial_msgs=manager.log.messages,
-        ):
-            for hook_msg in session_start_msgs:
-                _append_and_notify(manager, session, hook_msg)
-            manager.write()
-
-    if pre_msgs := trigger_hook(
-        HookType.STEP_PRE,
-        manager=manager,
-    ):
-        for hook_msg in pre_msgs:
-            _append_and_notify(manager, session, hook_msg)
-        manager.write()
-
-    user_messages = [m for m in manager.log.messages if m.role == "user"]
-    if not user_messages:
-        error_event: ErrorEvent = {
-            "type": "error",
-            "error": "No user message to process",
-        }
-        SessionManager.add_event(conversation_id, error_event)
-        session.generating = False
-        session.generating_since = None
-        return
-
-    next_user_index = session.acp_last_user_msg_index + 1
-    pending_user_messages = user_messages[next_user_index:]
-    if not pending_user_messages:
-        duplicate_error_event: ErrorEvent = {
-            "type": "error",
-            "error": "No new user message to process",
-        }
-        SessionManager.add_event(conversation_id, duplicate_error_event)
-        session.generating = False
-        session.generating_since = None
-        return
-
-    SessionManager.add_event(conversation_id, {"type": "generation_started"})
-
-    stream_tokens: list[str] = []
-
-    async def _on_acp_update(_session_id: str, update: Any) -> None:
-        # Best-effort bridge: forward ACP session_update text chunks to SSE.
-        for chunk in _iter_text_from_acp_update(update):
-            if not chunk:
-                continue
-            stream_tokens.append(chunk)
-            SessionManager.add_event(
-                conversation_id,
-                {"type": "generation_progress", "token": chunk},
-            )
-
-    acp_runtime.set_on_update(_on_acp_update)
+    conversation_token = current_conversation_id.set(conversation_id)
+    session_token = current_session_id.set(session.id)
 
     try:
-        final_msg: Message | None = None
-
-        for absolute_index, user_msg in enumerate(
-            pending_user_messages,
-            start=next_user_index,
-        ):
-            text, _raw = await acp_runtime.prompt(user_msg.content)
-            final_text = "".join(stream_tokens) if stream_tokens else text
-            stream_tokens.clear()
-            msg = Message("assistant", final_text)
-            _append_and_notify(manager, session, msg)
-            manager.write()
-            session.acp_last_user_msg_index = absolute_index
-            final_msg = msg
-
-        if post_msgs := trigger_hook(
-            HookType.TURN_POST,
-            manager=manager,
-        ):
-            for hook_msg in post_msgs:
-                _append_and_notify(manager, session, hook_msg)
-
-        manager.write()
-
-        if final_msg is None:
-            # Should not happen: pending_user_messages was non-empty above, but
-            # guard explicitly instead of using assert (disabled by python -O).
-            logger.warning(
-                "ACP step produced no final message for conversation %s",
-                conversation_id,
+        # Validate acp_runtime is set (use explicit check, not assert which python -O disables)
+        if session.acp_runtime is None:
+            logger.error(
+                "_acp_step called without acp_runtime for session %s", conversation_id
             )
-            no_msg_event: ErrorEvent = {
-                "type": "error",
-                "error": "ACP step completed but produced no assistant message",
-            }
-            SessionManager.add_event(conversation_id, no_msg_event)
-        else:
             SessionManager.add_event(
                 conversation_id,
                 {
-                    "type": "generation_complete",
-                    "message": msg2dict(final_msg, manager.workspace, manager.logdir),
+                    "type": "error",
+                    "error": "Internal error: ACP runtime not initialized",
                 },
             )
+            session.generating = False
+            session.generating_since = None
+            return
+        acp_runtime = session.acp_runtime  # snapshot to avoid TOCTOU races
 
-        # Auto-generate display name AFTER signaling generation_complete,
-        # so the event isn't blocked by a potentially slow LLM call.
-        _try_auto_name_and_notify(
-            chat_config,
-            manager.log.messages,
-            chat_config.model or "",
-            conversation_id,
+        logdir = get_logs_dir() / conversation_id
+        chat_config = ChatConfig.load_or_create(logdir, ChatConfig())
+        prepare_execution_environment(
+            workspace=workspace,
+            tools=chat_config.tools,
+            chat_config=chat_config,
         )
-    except Exception as e:
-        logger.exception("Error during ACP step: %s", e)
-        session.last_error = str(e)
-        SessionManager.add_event(conversation_id, {"type": "error", "error": str(e)})
+
+        manager = LogManager.load(conversation_id, lock=False)
+
+        # Keep server-side hook semantics aligned with the in-process step path.
+        assistant_messages = [m for m in manager.log.messages if m.role == "assistant"]
+        if len(assistant_messages) == 0:
+            if session_start_msgs := trigger_hook(
+                HookType.SESSION_START,
+                logdir=logdir,
+                workspace=workspace,
+                initial_msgs=manager.log.messages,
+            ):
+                for hook_msg in session_start_msgs:
+                    _append_and_notify(manager, session, hook_msg)
+                manager.write()
+
+        if pre_msgs := trigger_hook(
+            HookType.STEP_PRE,
+            manager=manager,
+        ):
+            for hook_msg in pre_msgs:
+                _append_and_notify(manager, session, hook_msg)
+            manager.write()
+
+        user_messages = [m for m in manager.log.messages if m.role == "user"]
+        if not user_messages:
+            error_event: ErrorEvent = {
+                "type": "error",
+                "error": "No user message to process",
+            }
+            SessionManager.add_event(conversation_id, error_event)
+            session.generating = False
+            manager.write()
+            session.generating_since = None
+            return
+
+        next_user_index = session.acp_last_user_msg_index + 1
+        pending_user_messages = user_messages[next_user_index:]
+        if not pending_user_messages:
+            duplicate_error_event: ErrorEvent = {
+                "type": "error",
+                "error": "No new user message to process",
+            }
+            SessionManager.add_event(conversation_id, duplicate_error_event)
+            session.generating = False
+            session.generating_since = None
+            return
+
+        SessionManager.add_event(conversation_id, {"type": "generation_started"})
+
+        stream_tokens: list[str] = []
+
+        async def _on_acp_update(_session_id: str, update: Any) -> None:
+            # Best-effort bridge: forward ACP session_update text chunks to SSE.
+            for chunk in _iter_text_from_acp_update(update):
+                if not chunk:
+                    continue
+                stream_tokens.append(chunk)
+                SessionManager.add_event(
+                    conversation_id,
+                    {"type": "generation_progress", "token": chunk},
+                )
+
+        acp_runtime.set_on_update(_on_acp_update)
+
+        try:
+            final_msg: Message | None = None
+
+            for absolute_index, user_msg in enumerate(
+                pending_user_messages,
+                start=next_user_index,
+            ):
+                text, _raw = await acp_runtime.prompt(user_msg.content)
+                final_text = "".join(stream_tokens) if stream_tokens else text
+                stream_tokens.clear()
+                msg = Message("assistant", final_text)
+                _append_and_notify(manager, session, msg)
+                manager.write()
+                session.acp_last_user_msg_index = absolute_index
+                final_msg = msg
+
+            if post_msgs := trigger_hook(
+                HookType.TURN_POST,
+                manager=manager,
+            ):
+                for hook_msg in post_msgs:
+                    _append_and_notify(manager, session, hook_msg)
+
+            manager.write()
+
+            if final_msg is None:
+                # Should not happen: pending_user_messages was non-empty above, but
+                # guard explicitly instead of using assert (disabled by python -O).
+                logger.warning(
+                    "ACP step produced no final message for conversation %s",
+                    conversation_id,
+                )
+                no_msg_event: ErrorEvent = {
+                    "type": "error",
+                    "error": "ACP step completed but produced no assistant message",
+                }
+                SessionManager.add_event(conversation_id, no_msg_event)
+            else:
+                SessionManager.add_event(
+                    conversation_id,
+                    {
+                        "type": "generation_complete",
+                        "message": msg2dict(
+                            final_msg, manager.workspace, manager.logdir
+                        ),
+                    },
+                )
+
+            # Auto-generate display name AFTER signaling generation_complete,
+            # so the event isn't blocked by a potentially slow LLM call.
+            _try_auto_name_and_notify(
+                chat_config,
+                manager.log.messages,
+                chat_config.model or "",
+                conversation_id,
+            )
+        except Exception as e:
+            logger.exception("Error during ACP step: %s", e)
+            session.last_error = str(e)
+            SessionManager.add_event(
+                conversation_id, {"type": "error", "error": str(e)}
+            )
+        finally:
+            acp_runtime.set_on_update(None)
+            session.generating = False
+            session.generating_since = None
     finally:
-        acp_runtime.set_on_update(None)
-        session.generating = False
-        session.generating_since = None
+        current_conversation_id.reset(conversation_token)
+        current_session_id.reset(session_token)
 
 
 def _start_acp_step_thread(
@@ -498,9 +514,16 @@ def _start_acp_step_thread(
     session.generating_since = datetime.now(tz=timezone.utc)
 
     def _run() -> None:
+        from ..hooks import current_conversation_id, current_session_id
+
+        current_conversation_id.set(conversation_id)
+        current_session_id.set(session.id)
         asyncio.run(_acp_step(conversation_id, session, workspace))
 
-    t = threading.Thread(target=_run, daemon=True)
+    # Propagate request-scoped ContextVars (model, config, tools) into the ACP
+    # worker thread; hook/session vars are then set explicitly in that thread.
+    ctx = contextvars.copy_context()
+    t = threading.Thread(target=ctx.run, args=(_run,), daemon=True)
     t.start()
 
 

--- a/gptme/server/session_step.py
+++ b/gptme/server/session_step.py
@@ -9,6 +9,7 @@ handlers in api_v2_sessions.py.
 
 import asyncio
 import atexit
+import contextvars
 import logging
 import os
 import threading
@@ -897,8 +898,9 @@ def start_tool_execution(
         if not session.pending_tools:
             _start_step_thread(conversation_id, session, model, chat_config.workspace)
 
-    # Start execution in a thread
-    thread = threading.Thread(target=execute_tool_thread)
+    # Propagate ContextVars from the request context into the execution thread.
+    ctx = contextvars.copy_context()
+    thread = threading.Thread(target=ctx.run, args=(execute_tool_thread,))
     thread.daemon = True
     thread.start()
     return thread
@@ -932,6 +934,13 @@ def _start_step_thread(
     session.generating_since = datetime.now(tz=timezone.utc)
 
     def step_thread() -> None:
+        # Set conversation/session context vars so hooks triggered during
+        # LLM generation (TURN_PRE, STEP_PRE, TURN_POST, etc.) can identify
+        # which conversation they're operating on.
+        from ..hooks import current_conversation_id, current_session_id
+
+        current_conversation_id.set(conversation_id)
+        current_session_id.set(session.id)
         step(
             conversation_id=conversation_id,
             session=session,
@@ -942,8 +951,10 @@ def _start_step_thread(
             stream=stream,
         )
 
-    # Start step execution in a thread
-    thread = threading.Thread(target=step_thread)
+    # Propagate ContextVars (model, config) from the caller into the step thread.
+    # Each thread gets its own copy so mutations stay isolated between sessions.
+    ctx = contextvars.copy_context()
+    thread = threading.Thread(target=ctx.run, args=(step_thread,))
     thread.daemon = True
     thread.start()
 

--- a/tests/test_acp_session_runtime.py
+++ b/tests/test_acp_session_runtime.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+import contextvars
+import threading
 import time
 import uuid
 from types import SimpleNamespace
@@ -497,12 +499,21 @@ def test_acp_step_runs_session_start_step_pre_and_turn_post_hooks(
 
     monkeypatch.setattr(rt_mod, "GptmeAcpClient", _factory)
 
-    from gptme.hooks import HookType
+    from gptme.hooks import HookType, current_conversation_id, current_session_id
     from gptme.message import Message
     from gptme.server.acp_session_runtime import AcpSessionRuntime
     from gptme.server.api_v2_sessions import ConversationSession, SessionManager
 
+    hook_contexts: list[tuple[HookType, str | None, str | None]] = []
+
     def _fake_trigger_hook(hook_type: HookType, **kwargs):
+        hook_contexts.append(
+            (
+                hook_type,
+                current_conversation_id.get(),
+                current_session_id.get(),
+            )
+        )
         if hook_type == HookType.SESSION_START:
             return [Message("system", "HOOK_SESSION_START")]
         if hook_type == HookType.STEP_PRE:
@@ -542,9 +553,53 @@ def test_acp_step_runs_session_start_step_pre_and_turn_post_hooks(
         assert "HOOK_SESSION_START" in contents
         assert "HOOK_STEP_PRE" in contents
         assert "HOOK_TURN_POST" in contents
+        assert hook_contexts == [
+            (HookType.SESSION_START, conversation_id, "sid-hooks"),
+            (HookType.STEP_PRE, conversation_id, "sid-hooks"),
+            (HookType.TURN_POST, conversation_id, "sid-hooks"),
+        ]
+        assert current_conversation_id.get() is None
+        assert current_session_id.get() is None
     finally:
         SessionManager._sessions.pop("sid-hooks", None)
         SessionManager._conversation_sessions[conversation_id].discard("sid-hooks")
+
+
+def test_start_acp_step_thread_propagates_contextvars(monkeypatch, tmp_path):
+    import gptme.server.session_step as sessions_mod
+    from gptme.hooks import current_conversation_id, current_session_id
+    from gptme.server.api_v2_sessions import ConversationSession
+
+    caller_var: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+        "caller_var", default=None
+    )
+    seen: dict[str, str | None] = {}
+    done = threading.Event()
+
+    async def _fake_acp_step(conversation_id: str, session, workspace) -> None:
+        seen["caller_var"] = caller_var.get()
+        seen["conversation_id"] = current_conversation_id.get()
+        seen["session_id"] = current_session_id.get()
+        session.generating = False
+        session.generating_since = None
+        done.set()
+
+    monkeypatch.setattr(sessions_mod, "_acp_step", _fake_acp_step)
+
+    session = ConversationSession(id="sid-thread", conversation_id="conv-thread")
+
+    token = caller_var.set("copied")
+    try:
+        sessions_mod._start_acp_step_thread("conv-thread", session, tmp_path)
+        assert done.wait(timeout=2), "ACP thread did not complete"
+    finally:
+        caller_var.reset(token)
+
+    assert seen == {
+        "caller_var": "copied",
+        "conversation_id": "conv-thread",
+        "session_id": "sid-thread",
+    }
 
 
 def test_iter_text_from_acp_update_shapes():


### PR DESCRIPTION
## Summary

Follow-up to #502 and #507. Two thread-safety gaps remained after the thread-local → ContextVar migration:

### 1. Async hook threads (`hooks/registry.py`)

Async (fire-and-forget) hook threads were spawned with a bare `threading.Thread`, giving them an empty context. Hooks that read `current_conversation_id`, `_config_var`, etc. for telemetry or logging got `None`.

**Fix**: each async hook gets its own `copy_context()` snapshot before being handed to a thread, so it sees the same ContextVar state as the code that triggered the hook.

### 2. Step and tool execution threads (`server/session_step.py`)

- `_start_step_thread` / `step_thread`: the LLM generation thread never set `current_conversation_id` or `current_session_id`, so hooks triggered during TURN_PRE / STEP_PRE / TURN_POST that tried to identify the current conversation got `None`.
- `start_tool_execution` / `execute_tool_thread`: already set IDs explicitly but didn't propagate other ContextVars (model, config) from the request context.

**Fix**:
- `_start_step_thread`: set `current_conversation_id`/`current_session_id` at thread start (matching the pattern in `execute_tool_thread`) and wrap in `copy_context()`.
- `start_tool_execution`: wrap `execute_tool_thread` in `copy_context()` to propagate the request context in addition to the existing explicit ID sets.

## Test plan

- [ ] `tests/test_server_v2_sse.py` — SSE event stream tests pass
- [ ] `tests/test_server_v2_auto_stepping.py` — auto-stepping tests pass (note: `test_auto_stepping` has a pre-existing flaky message-count assertion that also fails on master; not a regression from this PR)
- [ ] No regressions in hook-based confirmation flow (server_confirm / server_elicit)