### PR TITLE
fix(server): reject non-string transcript call_sid

### DIFF
--- a/gptme/server/api_v2_sessions.py
+++ b/gptme/server/api_v2_sessions.py
@@ -935,8 +935,10 @@ def api_conversation_transcript(conversation_id: str):
         return flask.jsonify({"error": "call_metadata (object) is required"}), 400
 
     call_sid = call_metadata.get("call_sid")
-    if not call_sid:
+    if call_sid is None or call_sid == "":
         return flask.jsonify({"error": "call_metadata.call_sid is required"}), 400
+    if not isinstance(call_sid, str):
+        return flask.jsonify({"error": "call_metadata.call_sid must be a string"}), 400
 
     with LogManager.load(conversation_id, lock=True, create=True) as manager:
         # Idempotency check: scan existing messages for this call_sid in metadata

--- a/tests/test_server_v2_sessions.py
+++ b/tests/test_server_v2_sessions.py
@@ -1098,3 +1098,34 @@ class TestTranscriptEndpointInputValidation:
         assert response.status_code == 200
         data = response.get_json()
         assert data["messages_added"] == 2
+
+    @pytest.mark.parametrize(
+        "bad_call_sid",
+        [12345, 0, True, False, {"nested": "obj"}, {}, [1, 2, 3], []],
+        ids=[
+            "truthy-integer",
+            "falsy-integer",
+            "truthy-bool",
+            "falsy-bool",
+            "truthy-object",
+            "falsy-object",
+            "truthy-array",
+            "falsy-array",
+        ],
+    )
+    def test_transcript_non_string_call_sid_returns_400(
+        self, bad_call_sid, client: FlaskClient
+    ):
+        """call_metadata.call_sid must be a string; non-strings must return 400."""
+        convname = f"test-transcript-{uuid.uuid4().hex[:8]}"
+        response = client.post(
+            f"/api/v2/conversations/{convname}/transcript",
+            json={
+                "turns": [{"role": "user", "text": "hello"}],
+                "call_metadata": {"call_sid": bad_call_sid},
+            },
+        )
+        assert response.status_code == 400
+        data = response.get_json()
+        assert data is not None
+        assert "call_sid" in data["error"]


### PR DESCRIPTION
## Summary
- reject non-string `call_metadata.call_sid` values in `/api/v2/conversations/<id>/transcript`
- keep empty string on the existing required-field path
- add regression coverage for truthy and falsy non-string `call_sid` inputs

## Repro
Before this patch, posting:
```json
{"turns":[{"role":"user","text":"hello"}],"call_metadata":{"call_sid":12345}}
```
returned `200 OK` and appended the message even though the OpenAPI contract declares `call_sid` as a string.

After this patch, the same request returns `400` with `call_metadata.call_sid must be a string`.

## Testing
- `PYTHONPATH=/tmp/worktrees/gptme/transcript-call-sid-type-970b pytest tests/test_server_v2_sessions.py -q`
- manual Flask test-client repro for integer `call_sid` now returns `400`