### PR TITLE
fix(cli): reject whitespace-only prompts in non-interactive mode

### DIFF
--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -699,7 +699,9 @@ def main(
                 "Verify the module is installed and the class name is correct."
             ) from e
 
-    prompts = [p.strip() for p in "\n\n".join(prompts).split(sep) if p]
+    prompts = [
+        stripped for p in "\n\n".join(prompts).split(sep) if (stripped := p.strip())
+    ]
     # File paths in multiprompts are expanded at runtime by include_paths() in
     # _run_chat_loop (gptme/chat.py:194), not at parse time. Each prompt from the
     # queue goes through include_paths when popped, ensuring fresh content.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -565,6 +565,29 @@ def test_noninteractive_missing_prompt_does_not_leave_orphan_logdir(
     assert not logs_dir.exists() or not any(logs_dir.iterdir())
 
 
+def test_noninteractive_whitespace_only_prompt_rejected(monkeypatch, tmp_path: Path):
+    """Whitespace-only prompts should be treated as missing, not sent to the LLM."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "state"))
+
+    runner = CliRunner()
+
+    for whitespace_prompt in ["   ", "\t", "\n", "  \t  "]:
+        result = runner.invoke(
+            cli.main,
+            ["--non-interactive", "--name", "ws-prompt", whitespace_prompt],
+            input="",
+        )
+        assert result.exit_code != 0, (
+            f"Expected non-zero exit for whitespace prompt {whitespace_prompt!r}"
+        )
+        assert not (cli.get_logs_dir() / "ws-prompt").exists(), (
+            f"Orphan logdir created for whitespace prompt {whitespace_prompt!r}"
+        )
+
+
 def test_should_print_resume_hint_requires_nonempty_conversation_log(tmp_path: Path):
     logdir = tmp_path / "resume-hint"
     logdir.mkdir()


### PR DESCRIPTION
## Problem

Whitespace-only prompts (e.g. `gptme -n "   "`) bypassed the empty-prompt validation and caused:
1. An orphan log directory to be created
2. A `Message("user", "")` to reach the LLM, triggering `WARNING: Skipping message with role 'user' - all content was filtered out` from the Anthropic provider
3. An unnecessary (and potentially expensive) LLM API call for a semantically empty input

**Root cause**: Line 702 used `if p` to filter prompts before `.strip()`:
```python
# Before (wrong): whitespace '   ' is truthy, passes the filter, then strips to ""
prompts = [p.strip() for p in "\n\n".join(prompts).split(sep) if p]
```
The resulting `""` string created a non-empty `prompt_msgs` list that bypassed the `not prompt_msgs` guard on line 819.

## Fix

Filter on the stripped value using a walrus operator:
```python
# After: whitespace strips to "" which is falsy, so it's filtered out
prompts = [stripped for p in "\n\n".join(prompts).split(sep) if (stripped := p.strip())]
```

## Test

Added `test_noninteractive_whitespace_only_prompt_rejected` covering `"   "`, `"\t"`, `"\n"`, and `"  \t  "` — all must exit non-zero and leave no orphan log directory.

## Reproduction

```bash
# Before fix: created a log dir and tried to call the LLM
gptme -n "   "
# WARNING  Skipping message with role 'user' - all content was filtered out
# ERROR    Error code: 401 (if no API key) or LLM call with empty content

# After fix: clean error, no log dir created
gptme -n "   "
# ERROR    Non-interactive mode requires a prompt...
# exit 1
```