### PR TITLE
feat(eval): add subagent trajectory checks

### DIFF
--- a/gptme/eval/run.py
+++ b/gptme/eval/run.py
@@ -22,6 +22,7 @@ from typing import TypedDict
 
 from tqdm import tqdm
 
+from ..logmanager import LogManager
 from .agents import Agent, GPTMe
 from .agents.claude_code import ClaudeCodeAgent, is_claude_code_model
 from .cost import get_eval_costs
@@ -436,19 +437,32 @@ def execute(
             ctx = ResultContext(files, stdout_run, stderr_run, exit_code)
             results: list[CaseResult] = []
             print(f"\n--- Results for '{test['name']}' with {agent.model} ---")
-            for name, case in test["expect"].items():
-                eval_start = time.time()
+
+            def _evaluate_checks(checks, payload):
+                for name, case in checks.items():
+                    eval_start = time.time()
+                    try:
+                        passed = case(payload)
+                    except Exception as e:
+                        print(f"Error while checking {name}: {e}")
+                        passed = False
+                    eval_duration = time.time() - eval_start
+                    checkmark = "✅" if passed else "❌"
+                    print(f"{checkmark} {name:20s}")
+                    results.append(
+                        CaseResult(name=name, passed=passed, duration=eval_duration)
+                    )
+
+            _evaluate_checks(test["expect"], ctx)
+
+            check_log = test.get("check_log", {})
+            if check_log:
                 try:
-                    passed = case(ctx)
+                    messages = LogManager.load(log_dir, lock=False).log.messages
                 except Exception as e:
-                    print(f"Error while checking {name}: {e}")
-                    passed = False
-                eval_duration = time.time() - eval_start
-                checkmark = "✅" if passed else "❌"
-                print(f"{checkmark} {name:20s}")
-                results.append(
-                    CaseResult(name=name, passed=passed, duration=eval_duration)
-                )
+                    print(f"Error while loading conversation log: {e}")
+                    messages = []
+                _evaluate_checks(check_log, messages)
             print("--- End of results ---")
 
             time_eval = sum(r.duration for r in results)
@@ -544,8 +558,15 @@ def act_process(
 
     # Runs in a process for each eval
     # each eval has a process group, so we can kill all child processes
-    os.setpgrp()
-    pgrp = os.getpgrp()
+    pgrp: int | None = None
+    try:
+        os.setpgrp()
+        pgrp = os.getpgrp()
+    except PermissionError as e:
+        subprocess_logger.warning(
+            "Could not create a dedicated process group for eval cleanup: %s",
+            e,
+        )
 
     # Fix #130: Suppress verbose gptme output during optimization
     # Only keep output if not in parallel mode (i.e., interactive testing)
@@ -565,6 +586,10 @@ def act_process(
 
     start = time.time()
 
+    def cleanup_process_group() -> None:
+        if pgrp is not None:
+            _graceful_killpg(pgrp)
+
     def error_handler(e):
         duration = time.time() - start
         if not isinstance(e, KeyboardInterrupt):
@@ -579,7 +604,7 @@ def act_process(
         sync_dict["result"] = result_error
 
         # kill child processes gracefully
-        _graceful_killpg(pgrp)
+        cleanup_process_group()
 
     # handle SIGTERM
     def sigterm_handler(*_):
@@ -611,7 +636,7 @@ def act_process(
         # Reset SIGTERM handler before cleanup to prevent self-SIGTERM
         # from overwriting the timeout result (same guard as the success path).
         signal.signal(signal.SIGTERM, signal.SIG_IGN)
-        _graceful_killpg(pgrp)
+        cleanup_process_group()
         return
     except Exception as e:
         error_handler(e)
@@ -642,4 +667,4 @@ def act_process(
     signal.signal(signal.SIGTERM, signal.SIG_IGN)
 
     # kill child processes gracefully
-    _graceful_killpg(pgrp)
+    cleanup_process_group()

--- a/gptme/eval/suites/subagent.py
+++ b/gptme/eval/suites/subagent.py
@@ -32,7 +32,8 @@ def check_subagent_parallel_started_before_wait(messages: list[Message]) -> bool
     assistant_log = _role_contents(messages, "assistant")
     first_wait = assistant_log.find("subagent_wait(")
     if first_wait == -1:
-        return False
+        # subagent_batch manages its own parallelism without explicit waits
+        return "subagent_batch(" in assistant_log
     before_wait = assistant_log[:first_wait]
     return (
         "subagent_batch(" in before_wait

--- a/gptme/eval/suites/subagent.py
+++ b/gptme/eval/suites/subagent.py
@@ -1,0 +1,148 @@
+"""Trajectory-focused evals for the subagent tool."""
+
+from typing import TYPE_CHECKING
+
+from gptme.message import Message
+
+if TYPE_CHECKING:
+    from gptme.eval.types import EvalSpec
+
+
+def _role_contents(messages: list[Message], role: str) -> str:
+    return "\n".join(msg.content for msg in messages if msg.role == role)
+
+
+def _any_message_contains(messages: list[Message], role: str, needle: str) -> bool:
+    return any(msg.role == role and needle in msg.content for msg in messages)
+
+
+def _last_assistant_content(messages: list[Message]) -> str:
+    assistants = [msg.content for msg in messages if msg.role == "assistant"]
+    return assistants[-1] if assistants else ""
+
+
+def check_subagent_parallel_used(messages: list[Message]) -> bool:
+    """Parent log should show subagent delegation."""
+    assistant_log = _role_contents(messages, "assistant")
+    return "subagent(" in assistant_log or "subagent_batch(" in assistant_log
+
+
+def check_subagent_parallel_started_before_wait(messages: list[Message]) -> bool:
+    """Parallel work should be launched before any wait call."""
+    assistant_log = _role_contents(messages, "assistant")
+    first_wait = assistant_log.find("subagent_wait(")
+    if first_wait == -1:
+        return False
+    before_wait = assistant_log[:first_wait]
+    return (
+        "subagent_batch(" in before_wait
+        or 'mode="planner"' in before_wait
+        or "mode='planner'" in before_wait
+        or before_wait.count("subagent(") >= 2
+    )
+
+
+def check_subagent_parallel_integrated_results(messages: list[Message]) -> bool:
+    """Final assistant reply should integrate all delegated results."""
+    final_msg = _last_assistant_content(messages)
+    return all(marker in final_msg for marker in ("WORDS=6", "LINES=4", "EXISTS=yes"))
+
+
+def check_subagent_complete_spawned(messages: list[Message]) -> bool:
+    """Parent log should show the roundtrip subagent being started."""
+    assistant_log = _role_contents(messages, "assistant")
+    return (
+        'subagent("sum-roundtrip"' in assistant_log
+        or "subagent('sum-roundtrip'" in assistant_log
+    )
+
+
+def check_subagent_complete_hook_notification(messages: list[Message]) -> bool:
+    """Parent should receive the completion hook notification."""
+    return _any_message_contains(
+        messages,
+        "system",
+        "✅ Subagent 'sum-roundtrip' completed: COMPLETE_SUM: 5050",
+    )
+
+
+def check_subagent_complete_roundtrip_marker(messages: list[Message]) -> bool:
+    """The completion marker should make it back to the parent log."""
+    return _any_message_contains(messages, "system", "COMPLETE_SUM: 5050")
+
+
+def check_subagent_complete_parent_result(messages: list[Message]) -> bool:
+    """Final assistant reply should use the delegated result."""
+    final_msg = _last_assistant_content(messages)
+    return "SUM=5050" in final_msg or "5050" in final_msg
+
+
+_PARALLEL_A = "alpha beta gamma delta epsilon zeta\n"
+_PARALLEL_B = "one\ntwo\nthree\nfour\n"
+_NOTES = "Keep this brief. The parent can read this between spawn and wait.\n"
+
+
+tests: list["EvalSpec"] = [
+    {
+        "name": "subagent-parallel-delegation",
+        "files": {
+            "a.txt": _PARALLEL_A,
+            "b.txt": _PARALLEL_B,
+            "c.txt": "present\n",
+        },
+        "run": "cat answer.txt",
+        "prompt": (
+            "Use subagents, not parent-side direct computation, to solve three "
+            "independent tasks concurrently: "
+            "(1) count the whitespace-separated words in a.txt, "
+            "(2) count the newline-delimited lines in b.txt, and "
+            "(3) check whether c.txt exists. "
+            "Start all delegated work before waiting on any single result. "
+            "A planner-mode subagent or subagent_batch is fine; sequential one-at-a-time waiting is not. "
+            "When finished, write answer.txt containing exactly:\n"
+            "WORDS=6\nLINES=4\nEXISTS=yes\n"
+            "and include those same three markers in your final assistant message."
+        ),
+        "tools": ["read", "save", "shell", "ipython", "subagent"],
+        "expect": {
+            "writes WORDS marker": lambda ctx: "WORDS=6" in ctx.stdout,
+            "writes LINES marker": lambda ctx: "LINES=4" in ctx.stdout,
+            "writes EXISTS marker": lambda ctx: "EXISTS=yes" in ctx.stdout,
+            "clean exit": lambda ctx: ctx.exit_code == 0,
+        },
+        "check_log": {
+            "used subagent delegation": check_subagent_parallel_used,
+            "started parallel work before waiting": check_subagent_parallel_started_before_wait,
+            "integrated delegated results": check_subagent_parallel_integrated_results,
+        },
+    },
+    {
+        "name": "subagent-complete-roundtrip",
+        "files": {
+            "notes.txt": _NOTES,
+        },
+        "run": "cat answer.txt",
+        "prompt": (
+            "Delegate the computation to a subagent with agent_id 'sum-roundtrip'. "
+            "In the subagent prompt, require it to use the complete tool and return exactly:\n"
+            "COMPLETE_SUM: 5050\n"
+            "Do not compute the sum in the parent. "
+            "After spawning the subagent, do one brief parent-side step before waiting "
+            "(for example, read notes.txt) so the hook system has a chance to deliver "
+            "the completion notification. Then wait for the subagent, write answer.txt "
+            "containing exactly:\nSUM=5050\n"
+            "and mention 5050 in your final assistant message."
+        ),
+        "tools": ["read", "save", "shell", "ipython", "subagent"],
+        "expect": {
+            "writes SUM marker": lambda ctx: "SUM=5050" in ctx.stdout,
+            "clean exit": lambda ctx: ctx.exit_code == 0,
+        },
+        "check_log": {
+            "spawned roundtrip subagent": check_subagent_complete_spawned,
+            "received hook notification": check_subagent_complete_hook_notification,
+            "roundtrip returned complete marker": check_subagent_complete_roundtrip_marker,
+            "parent used delegated result": check_subagent_complete_parent_result,
+        },
+    },
+]

--- a/gptme/eval/types.py
+++ b/gptme/eval/types.py
@@ -8,6 +8,7 @@ from typing_extensions import NotRequired
 if TYPE_CHECKING:
     from .cost import CostSummary
 
+from ..message import Message
 from ..tools import ToolFormat
 
 Files = dict[str, str | bytes]
@@ -115,6 +116,13 @@ class EvalSpec(TypedDict):
     run: str
     prompt: str
     expect: dict[str, Callable[[ResultContext], bool]]
+    check_log: NotRequired[dict[str, Callable[[list[Message]], bool]]]
+    """Optional trajectory checks against the parent conversation log.
+
+    These are evaluated after generation using the messages stored in the eval
+    conversation log, enabling checks on delegation/tool-use behavior in
+    addition to file/stdout/stderr assertions.
+    """
     tools: NotRequired[list[str]]
     task_type: NotRequired[Literal["structured_process", "creative_restructuring"]]
     """Task category for lesson injection gating.

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -537,6 +537,48 @@ def test_execute_docker_mode_runs_checks_in_docker_env():
     assert result.run_stdout == "done"
 
 
+def test_execute_runs_check_log_against_conversation_messages():
+    test: EvalSpec = {
+        "name": "trajectory-check",
+        "files": {},
+        "prompt": "write output",
+        "run": "cat out.txt",
+        "expect": {"has output": lambda ctx: ctx.files.get("out.txt") == "done"},
+        "check_log": {
+            "saw delegated assistant message": lambda messages: any(
+                msg.role == "assistant" and "delegated to subagent" in msg.content
+                for msg in messages
+            )
+        },
+    }
+    agent = SuccessAgent(model="claude-code/test")
+    fake_messages = [
+        Message("assistant", "delegated to subagent"),
+        Message("system", "✅ Subagent 'demo' completed: done"),
+    ]
+
+    with (
+        patch("gptme.eval.run.SimpleExecutionEnv") as MockEnv,
+        patch("gptme.eval.run.LogManager.load") as mock_load,
+    ):
+        env = MockEnv.return_value
+        env.run.return_value = ("done", "", 0)
+        env.download.return_value = {"out.txt": "done"}
+        mock_load.return_value = SimpleNamespace(
+            log=SimpleNamespace(messages=fake_messages)
+        )
+
+        result = execute(test=test, agent=agent, timeout=5, parallel=False)
+
+    assert result.status == "success"
+    assert [case.name for case in result.results] == [
+        "has output",
+        "saw delegated assistant message",
+    ]
+    assert all(case.passed for case in result.results)
+    mock_load.assert_called_once_with(agent.log_dir, lock=False)
+
+
 def test_run_evals_top_level_timeout_cancels_pending_futures(tmp_path):
     class FakeFuture:
         def __init__(self, result: EvalResult):

--- a/tests/test_eval_subagent.py
+++ b/tests/test_eval_subagent.py
@@ -28,6 +28,20 @@ def test_parallel_checks_pass_for_planner_style_trajectory():
     assert check_subagent_parallel_integrated_results(messages)
 
 
+def test_parallel_checks_pass_for_subagent_batch_only_trajectory():
+    """subagent_batch without explicit subagent_wait should still pass."""
+    messages = [
+        Message(
+            "assistant",
+            '```ipython\nsubagent_batch([{"agent_id": "a"}, {"agent_id": "b"}, {"agent_id": "c"}])\n```',
+        ),
+        Message("assistant", "Done. WORDS=6 LINES=4 EXISTS=yes"),
+    ]
+
+    assert check_subagent_parallel_used(messages)
+    assert check_subagent_parallel_started_before_wait(messages)
+
+
 def test_parallel_started_before_wait_rejects_sequential_launch():
     messages = [
         Message(

--- a/tests/test_eval_subagent.py
+++ b/tests/test_eval_subagent.py
@@ -1,0 +1,76 @@
+from gptme.eval.suites.subagent import (
+    check_subagent_complete_hook_notification,
+    check_subagent_complete_parent_result,
+    check_subagent_complete_roundtrip_marker,
+    check_subagent_complete_spawned,
+    check_subagent_parallel_integrated_results,
+    check_subagent_parallel_started_before_wait,
+    check_subagent_parallel_used,
+)
+from gptme.message import Message
+
+
+def test_parallel_checks_pass_for_planner_style_trajectory():
+    messages = [
+        Message(
+            "assistant",
+            '```ipython\nsubagent("parallel-demo", "run tasks", mode="planner", execution_mode="parallel")\n```',
+        ),
+        Message(
+            "assistant",
+            '```ipython\nsubagent_wait("parallel-demo-a")\nsubagent_wait("parallel-demo-b")\nsubagent_wait("parallel-demo-c")\n```',
+        ),
+        Message("assistant", "Done. WORDS=6 LINES=4 EXISTS=yes"),
+    ]
+
+    assert check_subagent_parallel_used(messages)
+    assert check_subagent_parallel_started_before_wait(messages)
+    assert check_subagent_parallel_integrated_results(messages)
+
+
+def test_parallel_started_before_wait_rejects_sequential_launch():
+    messages = [
+        Message(
+            "assistant",
+            '```ipython\nsubagent("only-one", "task one")\nsubagent_wait("only-one")\n```',
+        ),
+        Message("assistant", "Done. WORDS=6 LINES=4 EXISTS=yes"),
+    ]
+
+    assert not check_subagent_parallel_started_before_wait(messages)
+
+
+def test_roundtrip_checks_pass_for_hook_completion_trajectory():
+    messages = [
+        Message(
+            "assistant",
+            '```ipython\nsubagent("sum-roundtrip", "Return COMPLETE_SUM: 5050 via complete")\n```',
+        ),
+        Message("assistant", "I will read notes.txt before waiting."),
+        Message(
+            "system",
+            "✅ Subagent 'sum-roundtrip' completed: COMPLETE_SUM: 5050",
+        ),
+        Message(
+            "assistant",
+            '```ipython\nsubagent_wait("sum-roundtrip")\n```',
+        ),
+        Message("assistant", "Finished. SUM=5050"),
+    ]
+
+    assert check_subagent_complete_spawned(messages)
+    assert check_subagent_complete_hook_notification(messages)
+    assert check_subagent_complete_roundtrip_marker(messages)
+    assert check_subagent_complete_parent_result(messages)
+
+
+def test_roundtrip_hook_notification_is_required():
+    messages = [
+        Message(
+            "assistant",
+            '```ipython\nsubagent("sum-roundtrip", "Return COMPLETE_SUM: 5050 via complete")\n```',
+        ),
+        Message("assistant", "Finished. SUM=5050"),
+    ]
+
+    assert not check_subagent_complete_hook_notification(messages)


### PR DESCRIPTION
## Summary
- add optional `check_log` trajectory checks to eval specs and runner execution
- add a new `subagent` eval suite for parallel delegation and complete-tool roundtrip behavior
- add unit coverage for `check_log` wiring and the new subagent trajectory checkers

## Verification
- `PYTHONPATH=/tmp/worktrees/gptme-subagent-trajectory-evals-3f39 /home/bob/bob/.venv/bin/python -m pytest /tmp/worktrees/gptme-subagent-trajectory-evals-3f39/tests/test_eval.py /tmp/worktrees/gptme-subagent-trajectory-evals-3f39/tests/test_eval_subagent.py /tmp/worktrees/gptme-subagent-trajectory-evals-3f39/tests/test_tools_subagent.py -q`
- `uv run --directory /tmp/worktrees/gptme-subagent-trajectory-evals-3f39 ruff check /tmp/worktrees/gptme-subagent-trajectory-evals-3f39/gptme/eval/types.py /tmp/worktrees/gptme-subagent-trajectory-evals-3f39/gptme/eval/run.py /tmp/worktrees/gptme-subagent-trajectory-evals-3f39/gptme/eval/suites/subagent.py /tmp/worktrees/gptme-subagent-trajectory-evals-3f39/tests/test_eval.py /tmp/worktrees/gptme-subagent-trajectory-evals-3f39/tests/test_eval_subagent.py`

## Notes
- Live model execution of the two new evals was not run in this shell because no `MODEL`, `ANTHROPIC_API_KEY`, or `OPENAI_API_KEY` env was configured here.
- Includes a small robustness fix in `act_process()` so eval subprocess setup degrades safely when `os.setpgrp()` is denied by the runner.