### PR TITLE
fix(server): return 'Branch not found' when POST targets a non-existent branch

### DIFF
--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -670,11 +670,18 @@ def api_conversation_post(conversation_id: str):
     except Exception as exc:
         return flask.jsonify({"error": f"Failed to load tool: {exc}"}), 400
 
+    # Check conversation existence before branch to return accurate error messages.
+    logdir = get_logs_dir() / conversation_id
+    if not logdir.exists():
+        return (
+            flask.jsonify({"error": f"Conversation not found: {conversation_id}"}),
+            404,
+        )
     try:
         log = LogManager.load(conversation_id, branch=branch)
     except FileNotFoundError:
         return (
-            flask.jsonify({"error": f"Conversation not found: {conversation_id}"}),
+            flask.jsonify({"error": f"Branch not found: {branch}"}),
             404,
         )
 

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -1111,6 +1111,28 @@ def test_v2_conversation_post(v2_conv, client: FlaskClient):
     assert data["log"][-1]["content"] == "Hello, this is a test message."
 
 
+def test_v2_conversation_post_nonexistent_branch_returns_404(
+    v2_conv, client: FlaskClient
+):
+    """POST to an existing conversation with a non-existent branch returns 404 with
+    a 'Branch not found' error — not the misleading 'Conversation not found' message
+    that would fire when the conversation itself is absent.
+    """
+    conversation_id = v2_conv["conversation_id"]
+
+    response = client.post(
+        f"/api/v2/conversations/{conversation_id}",
+        json={"role": "user", "content": "hello", "branch": "no-such-branch"},
+    )
+
+    assert response.status_code == 404
+    data = response.get_json()
+    assert data is not None
+    # Must say "Branch not found", not "Conversation not found"
+    assert "branch" in data["error"].lower()
+    assert "no-such-branch" in data["error"]
+
+
 @pytest.mark.slow
 @pytest.mark.requires_api
 def test_v2_generate(v2_conv, client: FlaskClient):


### PR DESCRIPTION
## Summary
- When a valid conversation exists but the specified `branch` doesn't, `POST /api/v2/conversations/{id}` was returning `"Conversation not found"` — a misleading error that doesn't help the caller understand whether the conversation or the branch is missing
- Fix: check `logdir.exists()` before `LogManager.load()` to produce accurate, distinct error messages for each case
- Add regression test `test_v2_conversation_post_nonexistent_branch_returns_404`

## Test plan
- [ ] New test passes: `test_v2_conversation_post_nonexistent_branch_returns_404`
- [ ] Existing POST-related server tests still pass (no regressions)
- [ ] CI green