### PR TITLE
fix(cli): reject whitespace-only conversation names

### DIFF
--- a/gptme/logmanager/manager.py
+++ b/gptme/logmanager/manager.py
@@ -64,7 +64,7 @@ _MESSAGE_FIELD_NAMES = frozenset(f.name for f in fields(Message))
 
 def conversation_name_error(value: str) -> str | None:
     """Return a validation error for unsafe conversation names, if any."""
-    if not value:
+    if not value or not value.strip():
         return "conversation name cannot be empty."
     if len(value.encode()) > _MAX_CONVERSATION_NAME_BYTES:
         return "conversation name too long."

--- a/gptme/util/conversation_ids.py
+++ b/gptme/util/conversation_ids.py
@@ -5,7 +5,7 @@ _MAX_CONVERSATION_ID_BYTES = 255  # Linux NAME_MAX for a single path component
 
 def conversation_id_error(value: str) -> str | None:
     """Return a validation error for unsafe conversation identifiers, if any."""
-    if not value:
+    if not value or not value.strip():
         return "conversation name cannot be empty."
     if len(value.encode()) > _MAX_CONVERSATION_ID_BYTES:
         return "conversation name too long."

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -154,6 +154,16 @@ def test_name_rejects_path_traversal(bad_name: str, runner: CliRunner):
     assert "conversation name must be a single path component" in result.output
 
 
+@pytest.mark.parametrize("bad_name", ["", " ", "   ", "\t"])
+def test_name_rejects_empty_or_whitespace_only_values(bad_name: str, runner: CliRunner):
+    result = runner.invoke(
+        cli.main,
+        ["--name", bad_name, "--non-interactive", "hello"],
+    )
+    assert result.exit_code == 2
+    assert "conversation name cannot be empty" in result.output
+
+
 def test_command_fork_rejects_path_traversal(runner: CliRunner, runid: int, name: str):
     escape_name = f"../escape-{runid}"
     escape_path = cli.get_logs_dir().parent / f"escape-{runid}"

--- a/tests/test_server_path_traversal.py
+++ b/tests/test_server_path_traversal.py
@@ -546,6 +546,18 @@ class TestConversationIdLengthValidation:
         with app.app_context():
             assert _validate_conversation_id("a" * 255) is None
 
+    def test_whitespace_only_id_rejected_unit(self):
+        """Whitespace-only conversation IDs must be rejected before hitting disk."""
+        from gptme.server.api_v2_common import _validate_conversation_id
+        from gptme.server.app import create_app
+
+        app = create_app()
+        with app.app_context():
+            result = _validate_conversation_id("   ")
+            assert result is not None
+            _response, status_code = result
+            assert status_code == 400
+
     def test_multibyte_over_limit_rejected(self):
         """Multi-byte chars counted by UTF-8 bytes, not code points.
 


### PR DESCRIPTION
## Summary
- reject whitespace-only `--name` values the same way we already reject empty conversation names
- apply the same validation to server/API conversation ids so the rule stays consistent
- add CLI and server regression coverage

## Repro
Before this patch, `gptme -n --name " "` accepted the conversation name, created a garbage logdir, and printed a blank resume hint.

## Testing
- `uv run pytest tests/test_cli.py tests/test_server_path_traversal.py -q`
- `uv run ruff check gptme/util/conversation_ids.py gptme/logmanager/manager.py tests/test_cli.py tests/test_server_path_traversal.py`