### PR TITLE
fix(server): block /edit command in server mode

### DIFF
--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -699,9 +699,12 @@ def api_conversation_post(conversation_id: str):
     # Check if the message is a slash command (e.g. /help, /model, /tools)
     if msg.role == "user" and is_message_command(msg.content):
         # Block commands that are unsafe in server context (would crash or block server)
+        # - exit/restart: terminate or restart the server process
+        # - edit: launches an interactive $EDITOR subprocess on the server host,
+        #   blocking the worker thread (see commands/session.py::_edit)
         parts = msg.content.lstrip("/").split()
         cmd_name = parts[0] if parts else ""
-        server_blocked_commands = {"exit", "restart"}
+        server_blocked_commands = {"exit", "restart", "edit"}
         if cmd_name in server_blocked_commands:
             return flask.jsonify(
                 {"error": f"Command /{cmd_name} is not available in server mode"}

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -86,6 +86,12 @@ logger = logging.getLogger(__name__)
 # SVG excluded: can embed <script> tags (XSS via crafted SVG).
 _ALLOWED_AVATAR_EXTS = {".jpg", ".jpeg", ".png", ".gif", ".webp", ".ico"}
 
+# Commands that must not run in server mode:
+# - exit/restart: terminate or restart the server process
+# - edit: launches an interactive $EDITOR subprocess, blocking the worker thread
+# - delete (without --force): calls input() waiting for stdin that never arrives
+_SERVER_BLOCKED_COMMANDS = {"exit", "restart", "edit", "delete"}
+
 
 def _is_valid_image_content(path: "Path") -> bool:
     """Validate file content is a recognised image format using Pillow.
@@ -698,14 +704,10 @@ def api_conversation_post(conversation_id: str):
 
     # Check if the message is a slash command (e.g. /help, /model, /tools)
     if msg.role == "user" and is_message_command(msg.content):
-        # Block commands that are unsafe in server context (would crash or block server)
-        # - exit/restart: terminate or restart the server process
-        # - edit: launches an interactive $EDITOR subprocess on the server host,
-        #   blocking the worker thread (see commands/session.py::_edit)
+        # Block commands that are unsafe in server context (see _SERVER_BLOCKED_COMMANDS)
         parts = msg.content.lstrip("/").split()
         cmd_name = parts[0] if parts else ""
-        server_blocked_commands = {"exit", "restart", "edit"}
-        if cmd_name in server_blocked_commands:
+        if cmd_name in _SERVER_BLOCKED_COMMANDS:
             return flask.jsonify(
                 {"error": f"Command /{cmd_name} is not available in server mode"}
             ), 400

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -1133,14 +1133,15 @@ def test_v2_conversation_post_nonexistent_branch_returns_404(
     assert "no-such-branch" in data["error"]
 
 
-@pytest.mark.parametrize("cmd", ["exit", "restart", "edit"])
+@pytest.mark.parametrize("cmd", ["exit", "restart", "edit", "delete"])
 def test_v2_conversation_post_blocks_unsafe_commands(
     v2_conv, client: FlaskClient, cmd: str
 ):
     """Commands that would crash or block the server are rejected with a clean 400.
 
     /exit and /restart terminate/restart the server process; /edit launches an
-    interactive $EDITOR subprocess on the server host, blocking the worker thread.
+    interactive $EDITOR subprocess on the server host; /delete without --force
+    calls input() waiting for stdin that never arrives in server mode.
     None should be dispatched to handle_cmd in server mode.
     """
     conversation_id = v2_conv["conversation_id"]

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -1133,6 +1133,29 @@ def test_v2_conversation_post_nonexistent_branch_returns_404(
     assert "no-such-branch" in data["error"]
 
 
+@pytest.mark.parametrize("cmd", ["exit", "restart", "edit"])
+def test_v2_conversation_post_blocks_unsafe_commands(
+    v2_conv, client: FlaskClient, cmd: str
+):
+    """Commands that would crash or block the server are rejected with a clean 400.
+
+    /exit and /restart terminate/restart the server process; /edit launches an
+    interactive $EDITOR subprocess on the server host, blocking the worker thread.
+    None should be dispatched to handle_cmd in server mode.
+    """
+    conversation_id = v2_conv["conversation_id"]
+
+    response = client.post(
+        f"/api/v2/conversations/{conversation_id}",
+        json={"role": "user", "content": f"/{cmd}"},
+    )
+
+    assert response.status_code == 400
+    data = response.get_json()
+    assert data is not None
+    assert "not available in server mode" in data["error"]
+
+
 @pytest.mark.slow
 @pytest.mark.requires_api
 def test_v2_generate(v2_conv, client: FlaskClient):


### PR DESCRIPTION
## Problem

Found while dogfooding the gptme server / HTTP API with malformed/edge input.

The `/edit` slash command launches an interactive `\$EDITOR` subprocess on the host:

`commands/session.py::cmd_edit` → `_edit` → `edit_text_with_editor` → `subprocess.run([editor, temp_filename])` (defaults to `nano`).

The server's `POST /api/v2/conversations/<id>` message path already blocks `exit`/`restart` via `server_blocked_commands` (commands that "would crash or block server"), but `edit` slips through. A client-supplied `/edit` message in server mode therefore either:

- spawns an editor that **blocks the worker thread** (when `\$EDITOR` points at a real editor with no usable stdin), or
- fails with a logged traceback (`RuntimeError: Editor exited with non-zero exit code`).

Neither is acceptable for a client-triggered request to a headless server.

## Fix

Add `"edit"` to `server_blocked_commands` so it's rejected with a clean `400 "Command /edit is not available in server mode"` before reaching `handle_cmd`, matching the existing `exit`/`restart` handling.

Commands that have valid non-interactive arg paths are **unaffected**:
- `/replay last|all|<tool>` (only the no-arg branch prompts via `input()`)
- `/rename <name>`, `/fork <name>` (only prompt when args are omitted)

## Test

Added `test_v2_conversation_post_blocks_unsafe_commands`, parametrized over `exit`/`restart`/`edit`, asserting a 400 with the "not available in server mode" message.

```
tests/test_server_v2.py::test_v2_conversation_post_blocks_unsafe_commands[exit] PASSED
tests/test_server_v2.py::test_v2_conversation_post_blocks_unsafe_commands[restart] PASSED
tests/test_server_v2.py::test_v2_conversation_post_blocks_unsafe_commands[edit] PASSED
```