### PR TITLE
fix(hooks): never crash gptme-util hooks run on malformed CC event JSON

### DIFF
--- a/gptme/cli/cmd_hooks.py
+++ b/gptme/cli/cmd_hooks.py
@@ -285,9 +285,16 @@ def run(workspace: Path | None = None) -> None:
             # No input — return empty (CC may call hooks with empty stdin)
             _output_empty()
             return
-        hook_input: dict = json.loads(raw)
+        hook_input = json.loads(raw)
     except (json.JSONDecodeError, OSError) as e:
         logger.debug("Failed to parse hook input: %s", e)
+        _output_empty()
+        return
+
+    if not isinstance(hook_input, dict):
+        # Valid JSON but not an object (e.g. a list or scalar) — CC always
+        # sends an object, so anything else is malformed. Pass through.
+        logger.debug("Hook input is not a JSON object: %s", type(hook_input).__name__)
         _output_empty()
         return
 
@@ -312,7 +319,8 @@ def run(workspace: Path | None = None) -> None:
         _output_empty()
         return
 
-    if not match_text.strip():
+    if not isinstance(match_text, str) or not match_text.strip():
+        # A malformed event may carry a non-string "prompt" — treat as no match.
         _output_empty()
         return
 
@@ -522,7 +530,11 @@ def _extract_pretooluse_text(hook_input: dict) -> str:
     # Recent transcript (assistant + tool output) for context-aware matching
     transcript = hook_input.get("transcript", [])
     recent_text: list[str] = []
+    if not isinstance(transcript, list):
+        transcript = []
     for entry in transcript[-6:]:  # Last 6 entries
+        if not isinstance(entry, dict):
+            continue
         role = entry.get("role", "")
         content = entry.get("content", "")
         if role in ("assistant", "tool") and isinstance(content, str):

--- a/gptme/cli/cmd_hooks.py
+++ b/gptme/cli/cmd_hooks.py
@@ -520,7 +520,7 @@ def _extract_pretooluse_text(hook_input: dict) -> str:
     parts: list[str] = []
 
     tool_name = hook_input.get("tool_name", "")
-    if tool_name:
+    if isinstance(tool_name, str) and tool_name:
         parts.append(tool_name)
 
     tool_input = hook_input.get("tool_input", {})

--- a/tests/test_util_hooks.py
+++ b/tests/test_util_hooks.py
@@ -284,6 +284,47 @@ def test_run_invalid_json_returns_continue(runner: CliRunner) -> None:
     assert out.get("continue") is True
 
 
+@pytest.mark.parametrize(
+    "payload",
+    [
+        pytest.param("[1, 2, 3]", id="json-array"),
+        pytest.param("12345", id="json-int"),
+        pytest.param('"a bare string"', id="json-string"),
+        pytest.param("null", id="json-null"),
+        pytest.param("true", id="json-bool"),
+        pytest.param(
+            '{"hook_event_name": "UserPromptSubmit", "prompt": 123}', id="prompt-int"
+        ),
+        pytest.param(
+            '{"hook_event_name": "UserPromptSubmit", "prompt": ["a", "b"]}',
+            id="prompt-list",
+        ),
+        pytest.param(
+            '{"hook_event_name": "PreToolUse", "tool_name": "Bash", "transcript": 999}',
+            id="transcript-not-list",
+        ),
+        pytest.param(
+            '{"hook_event_name": "PreToolUse", "tool_name": "Bash", "transcript": ["x", 42]}',
+            id="transcript-nondict-entries",
+        ),
+    ],
+)
+def test_run_malformed_input_returns_continue(runner: CliRunner, payload: str) -> None:
+    """Valid-JSON-but-malformed events must never crash the hook.
+
+    The command is the registered CC hook entrypoint; if it raises instead of
+    emitting valid JSON, the hook integration breaks. Non-object top-level JSON
+    and wrong-typed fields (prompt, transcript) previously raised AttributeError
+    / TypeError.
+    """
+    result = runner.invoke(
+        main, ["hooks", "run"], input=payload, catch_exceptions=False
+    )
+    assert result.exit_code == 0, result.output
+    out = json.loads(result.output)
+    assert out.get("continue") is True
+
+
 def test_run_no_matching_lesson_returns_continue(
     runner: CliRunner, tmp_path: Path
 ) -> None:

--- a/tests/test_util_hooks.py
+++ b/tests/test_util_hooks.py
@@ -300,6 +300,10 @@ def test_run_invalid_json_returns_continue(runner: CliRunner) -> None:
             id="prompt-list",
         ),
         pytest.param(
+            '{"hook_event_name": "PreToolUse", "tool_name": 123}',
+            id="tool-name-int",
+        ),
+        pytest.param(
             '{"hook_event_name": "PreToolUse", "tool_name": "Bash", "transcript": 999}',
             id="transcript-not-list",
         ),


### PR DESCRIPTION
## Problem

`gptme-util hooks run` is the command CC registers in `settings.json` for lesson injection. Its design contract (per the docstring and existing fallbacks) is that it **must always emit valid JSON** (`{"continue": true}`) and never crash — a traceback would break the hook integration for every prompt/tool call in that CC session.

Empty stdin and invalid JSON already degrade cleanly, but valid-but-malformed events still crashed:

| Input | Crash |
|-------|-------|
| Top-level JSON that isn't an object (`[1,2,3]`, `12345`, `null`) | `AttributeError: 'list' object has no attribute 'get'` |
| Non-string `prompt` (`{"prompt": 123}`) | `AttributeError: 'int' object has no attribute 'strip'` |
| Non-list `transcript` (`{"transcript": 999}`) | `TypeError: 'int' object is not subscriptable` |
| `transcript` entries that aren't dicts (`["x", 42]`) | `AttributeError: 'str' object has no attribute 'get'` |

Found by dogfooding the CLI surface with malformed input.

## Fix

Guard the three input-boundary spots so a malformed event degrades to the existing no-match fallback instead of raising:
- reject non-object top-level JSON right after `json.loads`
- require `match_text` to be a `str` before `.strip()`
- in `_extract_pretooluse_text`, skip a non-list `transcript` and non-dict entries

## Test

Adds a parametrized regression test (`test_run_malformed_input_returns_continue`) covering each variant; all assert `exit_code == 0` and `continue == True`.

```
36 passed in 1.40s
```
ruff check + format clean.