### PR TITLE
feat(eval): check subagent waited for completion before stating result

### DIFF
--- a/gptme/eval/suites/subagent.py
+++ b/gptme/eval/suites/subagent.py
@@ -85,7 +85,10 @@ def check_subagent_complete_waited_before_result(messages: list[Message]) -> boo
     in the final message or ``answer.txt``, even if the parent *fabricated* the
     answer before the subagent actually finished. This verifies ordering — a
     ``subagent_wait(...)`` call or the completion hook notification must appear
-    at or before the final assistant message that states ``SUM=5050``.
+    before the first assistant message that states ``SUM=5050``.
+
+    Tracking the *first* occurrence (not the last) ensures that fabricate-early
+    trajectories fail even if the agent re-states the result after a later wait.
     """
     completion_idx = None
     result_idx = None
@@ -98,8 +101,8 @@ def check_subagent_complete_waited_before_result(messages: list[Message]) -> boo
             )
         ):
             completion_idx = i
-        if msg.role == "assistant" and "SUM=5050" in msg.content:
-            result_idx = i  # keep the last result-bearing message
+        if result_idx is None and msg.role == "assistant" and "SUM=5050" in msg.content:
+            result_idx = i  # first result-bearing message
     if completion_idx is None or result_idx is None:
         return False
     return completion_idx <= result_idx

--- a/gptme/eval/suites/subagent.py
+++ b/gptme/eval/suites/subagent.py
@@ -78,6 +78,33 @@ def check_subagent_complete_parent_result(messages: list[Message]) -> bool:
     return "SUM=5050" in final_msg or "5050" in final_msg
 
 
+def check_subagent_complete_waited_before_result(messages: list[Message]) -> bool:
+    """Parent must wait for (or be notified of) completion before stating the result.
+
+    A trajectory-only guard: the outcome checks pass whenever ``SUM=5050`` lands
+    in the final message or ``answer.txt``, even if the parent *fabricated* the
+    answer before the subagent actually finished. This verifies ordering — a
+    ``subagent_wait(...)`` call or the completion hook notification must appear
+    at or before the final assistant message that states ``SUM=5050``.
+    """
+    completion_idx = None
+    result_idx = None
+    for i, msg in enumerate(messages):
+        if completion_idx is None and (
+            (msg.role == "assistant" and "subagent_wait(" in msg.content)
+            or (
+                msg.role == "system"
+                and "✅ Subagent 'sum-roundtrip' completed" in msg.content
+            )
+        ):
+            completion_idx = i
+        if msg.role == "assistant" and "SUM=5050" in msg.content:
+            result_idx = i  # keep the last result-bearing message
+    if completion_idx is None or result_idx is None:
+        return False
+    return completion_idx <= result_idx
+
+
 _PARALLEL_A = "alpha beta gamma delta epsilon zeta\n"
 _PARALLEL_B = "one\ntwo\nthree\nfour\n"
 _NOTES = "Keep this brief. The parent can read this between spawn and wait.\n"
@@ -144,6 +171,7 @@ tests: list["EvalSpec"] = [
             "received hook notification": check_subagent_complete_hook_notification,
             "roundtrip returned complete marker": check_subagent_complete_roundtrip_marker,
             "parent used delegated result": check_subagent_complete_parent_result,
+            "waited before stating result": check_subagent_complete_waited_before_result,
         },
     },
 ]

--- a/tests/test_eval_subagent.py
+++ b/tests/test_eval_subagent.py
@@ -3,6 +3,7 @@ from gptme.eval.suites.subagent import (
     check_subagent_complete_parent_result,
     check_subagent_complete_roundtrip_marker,
     check_subagent_complete_spawned,
+    check_subagent_complete_waited_before_result,
     check_subagent_parallel_integrated_results,
     check_subagent_parallel_started_before_wait,
     check_subagent_parallel_used,
@@ -76,6 +77,7 @@ def test_roundtrip_checks_pass_for_hook_completion_trajectory():
     assert check_subagent_complete_hook_notification(messages)
     assert check_subagent_complete_roundtrip_marker(messages)
     assert check_subagent_complete_parent_result(messages)
+    assert check_subagent_complete_waited_before_result(messages)
 
 
 def test_roundtrip_hook_notification_is_required():
@@ -88,3 +90,40 @@ def test_roundtrip_hook_notification_is_required():
     ]
 
     assert not check_subagent_complete_hook_notification(messages)
+
+
+def test_waited_before_result_accepts_explicit_wait_ordering():
+    """An explicit subagent_wait before the result satisfies the ordering check
+    even without the hook notification message."""
+    messages = [
+        Message(
+            "assistant",
+            '```ipython\nsubagent("sum-roundtrip", "Return COMPLETE_SUM: 5050 via complete")\n```',
+        ),
+        Message(
+            "assistant",
+            '```ipython\nsubagent_wait("sum-roundtrip")\n```',
+        ),
+        Message("assistant", "Finished. SUM=5050"),
+    ]
+
+    assert check_subagent_complete_waited_before_result(messages)
+
+
+def test_waited_before_result_rejects_fabricated_answer_before_completion():
+    """Stating the result before any wait/completion is a fabricated trajectory
+    that the outcome checks alone cannot catch."""
+    messages = [
+        Message(
+            "assistant",
+            '```ipython\nsubagent("sum-roundtrip", "Return COMPLETE_SUM: 5050 via complete")\n```',
+        ),
+        # Parent states the answer immediately, before waiting or any completion.
+        Message("assistant", "Finished. SUM=5050"),
+        Message(
+            "assistant",
+            '```ipython\nsubagent_wait("sum-roundtrip")\n```',
+        ),
+    ]
+
+    assert not check_subagent_complete_waited_before_result(messages)

--- a/tests/test_eval_subagent.py
+++ b/tests/test_eval_subagent.py
@@ -127,3 +127,28 @@ def test_waited_before_result_rejects_fabricated_answer_before_completion():
     ]
 
     assert not check_subagent_complete_waited_before_result(messages)
+
+
+def test_waited_before_result_rejects_fabricate_then_repeat():
+    """Fabricating the result early then re-stating it after a real wait must fail.
+
+    Without first-occurrence tracking, this trajectory would bypass the check
+    because the *last* SUM=5050 appears after the wait.
+    """
+    messages = [
+        Message(
+            "assistant",
+            '```ipython\nsubagent("sum-roundtrip", "Return COMPLETE_SUM: 5050 via complete")\n```',
+        ),
+        # Parent fabricates the answer before waiting.
+        Message("assistant", "I already know the answer is SUM=5050."),
+        Message(
+            "assistant",
+            '```ipython\nsubagent_wait("sum-roundtrip")\n```',
+        ),
+        # Re-states the result after the wait — last occurrence would pass with
+        # a naive "track last" strategy, but first occurrence already failed.
+        Message("assistant", "Confirmed. SUM=5050"),
+    ]
+
+    assert not check_subagent_complete_waited_before_result(messages)


### PR DESCRIPTION
Follows up on Erik's request in gptme/gptme#554 to add trajectory-based subagent evals ("evaluate the trajectory, not the outcome/artifacts"), extending the checks added in #2585.

## Gap

The `subagent-complete-roundtrip` eval's outcome checks (`SUM=5050` in `answer.txt` / final message) pass **even if the parent fabricates the answer before the subagent actually finishes**. Nothing verified that the parent genuinely waited for the delegated result.

## Change

Adds `check_subagent_complete_waited_before_result` — a trajectory-only check requiring a `subagent_wait(...)` call or the completion hook notification to appear **at or before** the final message stating `SUM=5050`. It can only be satisfied by a real delegation roundtrip, not a guessed result.

- Wired into the roundtrip spec's `check_log` ("waited before stating result")
- Positive test: explicit-wait ordering passes without the hook message
- Negative test: stating the result before any wait/completion fails

## Verification

```
7 passed (5 existing + 2 new) — tests/test_eval_subagent.py
ruff check + format: clean
```

Ref: gptme/gptme#554