### PR TITLE
fix(cli): expand tilde in --workspace paths

### DIFF
--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -131,7 +131,7 @@ class WorkspacePath(click.ParamType):
     def convert(self, value, param, ctx):
         if value == "@log":
             return value
-        path = Path(value)
+        path = Path(value).expanduser()
         if not path.exists():
             self.fail(f"directory '{value}' does not exist.", param, ctx)
         if not path.is_dir():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -353,6 +353,18 @@ def test_resume_with_log_workspace_uses_global_latest(
     assert selected_logdirs == [newest_other]
 
 
+def test_workspace_tilde_path_is_expanded(monkeypatch, tmp_path: Path):
+    home = tmp_path / "home"
+    workspace = home / "workspace"
+    workspace.mkdir(parents=True)
+
+    monkeypatch.setenv("HOME", str(home))
+
+    result = cli.WorkspacePath().convert("~/workspace", None, None)
+
+    assert result == str(workspace.resolve())
+
+
 def test_missing_custom_tool_path_is_reported_as_usage_error(
     runner: CliRunner, tmp_path: Path
 ):


### PR DESCRIPTION
## Summary
- expand `~` before validating `--workspace` paths
- keep returning the resolved workspace directory for downstream config
- add a regression test for the workspace path converter

## Testing
- `PYTHONPATH=/tmp/worktrees/gptme-workspace-tilde-47be /home/bob/gptme/.venv/bin/pytest tests/test_cli.py -k 'workspace_tilde_path_is_expanded or resume_with_workspace_uses_matching_conversation or resume_without_explicit_workspace_uses_cwd or resume_with_log_workspace_uses_global_latest'`
- `HOME="$HOME" uv run --directory /tmp/worktrees/gptme-workspace-tilde-47be python3 - <<'PY'
from pathlib import Path
from click.testing import CliRunner
import gptme.cli.main as cli
home = Path.home()
workspace = home / "gptme-workspace-tilde-test"
workspace.mkdir(parents=True, exist_ok=True)
selected = []
def fake_chat(prompt_msgs, initial_msgs, logdir, workspace, *args, **kwargs):
    selected.append(workspace)
cli.chat = fake_chat
runner = CliRunner()
result = runner.invoke(cli.main, ["--non-interactive", "--workspace", "~/gptme-workspace-tilde-test", "hello"], catch_exceptions=False)
print("exit", result.exit_code)
print("selected", selected)
PY`
