### PR TITLE
fix(server): validate tools field type before calling init_tools

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -335,13 +335,18 @@ def test_api_v2_conversation_post_tools_validation(conv, client: FlaskClient):
         json={"role": "user", "content": "hello", "tools": 42},
     )
     assert response.status_code == 400
+    data = response.get_json()
+    assert "tools" in data.get("error", "").lower()
 
     # Valid list of tools should still work
     response = client.post(
         f"/api/v2/conversations/{conv}",
         json={"role": "user", "content": "hello", "tools": ["shell"]},
     )
-    assert response.status_code == 200
+    body = response.get_json()
+    assert response.status_code == 200, (
+        f"Expected 200 for valid tools list, got {response.status_code}: {body}"
+    )
 
 
 # --- Cookie-based authentication tests ---

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -314,6 +314,36 @@ def test_api_v2_conversation_path_not_command(conv, client: FlaskClient):
     assert "command" not in data
 
 
+def test_api_v2_conversation_post_tools_validation(conv, client: FlaskClient):
+    """Test that the tools field is validated before calling init_tools.
+
+    A non-list value (string, int) should return 400 instead of crashing
+    with a 500 when get_toolchain iterates over characters.
+    """
+    # String tools should be rejected with 400
+    response = client.post(
+        f"/api/v2/conversations/{conv}",
+        json={"role": "user", "content": "hello", "tools": "malformed"},
+    )
+    assert response.status_code == 400
+    data = response.get_json()
+    assert "tools" in data.get("error", "").lower()
+
+    # Integer tools should be rejected with 400
+    response = client.post(
+        f"/api/v2/conversations/{conv}",
+        json={"role": "user", "content": "hello", "tools": 42},
+    )
+    assert response.status_code == 400
+
+    # Valid list of tools should still work
+    response = client.post(
+        f"/api/v2/conversations/{conv}",
+        json={"role": "user", "content": "hello", "tools": ["shell"]},
+    )
+    assert response.status_code == 200
+
+
 # --- Cookie-based authentication tests ---
 
 


### PR DESCRIPTION
## Summary

Validates the `tools` field type in `api_conversation_post` before passing it to `init_tools()`. A non-list value (string, int) causes `get_toolchain()` to iterate over the value as a character sequence, producing a confusing `Tool 't' not found` 500 error instead of a clear 400.

## Changes

- **`gptme/server/api_v2.py`**: Added type check for `tools` field in `api_conversation_post()` — non-list values now return `400` with ``tools must be a list of strings``
- **`tests/test_server.py`**: Added regression test covering string, integer, and valid-list tools values

Found while dogfooding the gptme server/HTTP API surface.