### PR TITLE
fix(cli): reject shell-hostile conversation names

### DIFF
--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -5,6 +5,7 @@ import logging
 import os
 import pstats
 import select
+import shlex
 import shutil
 import signal
 import sys
@@ -751,7 +752,7 @@ def main(
     # Register atexit handler to show conversation ID on exit
     def goodbye_handler():
         if _should_print_resume_hint(logdir, output_format):
-            print(f"\nGoodbye! (resume with: gptme --name {logdir.name})")
+            print(f"\nGoodbye! (resume with: {_format_resume_hint(logdir.name)})")
 
     atexit.register(goodbye_handler)
 
@@ -1116,6 +1117,10 @@ def _should_print_resume_hint(logdir: Path, output_format: str) -> bool:
         return log_file.stat().st_size > 0
     except OSError:
         return False
+
+
+def _format_resume_hint(name: str) -> str:
+    return f"gptme --name {shlex.quote(name)}"
 
 
 def _cleanup_aborted_new_logdir(logdir: Path, *, preexisting: bool) -> None:

--- a/gptme/logmanager/manager.py
+++ b/gptme/logmanager/manager.py
@@ -45,7 +45,7 @@ from ..dirs import get_logs_dir
 from ..message import Message, _migrate_metadata, len_tokens, print_msg
 from ..tools import ToolUse
 from ..util.context import enrich_messages_with_context
-from ..util.conversation_ids import validate_conversation_id
+from ..util.conversation_ids import conversation_id_error, validate_conversation_id
 from ..util.reduce import limit_log, reduce_log
 from ..util.uri import URI
 
@@ -55,8 +55,6 @@ logger = logging.getLogger(__name__)
 
 RoleLiteral = Literal["user", "assistant", "system"]
 
-_MAX_CONVERSATION_NAME_BYTES = 255  # Linux NAME_MAX for a single path component
-
 # Field names accepted by Message.__init__, used to drop unknown keys when
 # reading stored logs (forward-compatibility with logs from newer versions).
 _MESSAGE_FIELD_NAMES = frozenset(f.name for f in fields(Message))
@@ -64,16 +62,7 @@ _MESSAGE_FIELD_NAMES = frozenset(f.name for f in fields(Message))
 
 def conversation_name_error(value: str) -> str | None:
     """Return a validation error for unsafe conversation names, if any."""
-    if not value or not value.strip():
-        return "conversation name cannot be empty."
-    if len(value.encode()) > _MAX_CONVERSATION_NAME_BYTES:
-        return "conversation name too long."
-    if value == "." or "/" in value or "\\" in value or ".." in value:
-        return (
-            "conversation name must be a single path component "
-            "(no '.', '/', '\\\\', or '..')."
-        )
-    return None
+    return conversation_id_error(value)
 
 
 @dataclass(frozen=True, repr=False)

--- a/gptme/util/conversation_ids.py
+++ b/gptme/util/conversation_ids.py
@@ -7,18 +7,16 @@ def conversation_id_error(value: str) -> str | None:
     """Return a validation error for unsafe conversation identifiers, if any."""
     if not value or not value.strip():
         return "conversation name cannot be empty."
+    if value != value.strip():
+        return "conversation name cannot start or end with whitespace."
     if len(value.encode()) > _MAX_CONVERSATION_ID_BYTES:
         return "conversation name too long."
-    if (
-        value == "."
-        or "/" in value
-        or "\\" in value
-        or ".." in value
-        or "\x00" in value
-    ):
+    if any(not ch.isprintable() for ch in value):
+        return "conversation name cannot contain control characters."
+    if value == "." or "/" in value or "\\" in value or ".." in value:
         return (
             "conversation name must be a single path component "
-            "(no '.', '/', '\\\\', '..', or null bytes)."
+            "(no '.', '/', '\\\\', or '..')."
         )
     return None
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -164,6 +164,27 @@ def test_name_rejects_empty_or_whitespace_only_values(bad_name: str, runner: Cli
     assert "conversation name cannot be empty" in result.output
 
 
+@pytest.mark.parametrize(
+    ("bad_name", "expected_message"),
+    [
+        (" leading", "conversation name cannot start or end with whitespace"),
+        ("trailing ", "conversation name cannot start or end with whitespace"),
+        (" leading-trailing ", "conversation name cannot start or end with whitespace"),
+        ("foo\tbar", "conversation name cannot contain control characters"),
+        ("foo\nbar", "conversation name cannot contain control characters"),
+    ],
+)
+def test_name_rejects_control_characters_and_edge_whitespace(
+    bad_name: str, expected_message: str, runner: CliRunner
+):
+    result = runner.invoke(
+        cli.main,
+        ["--name", bad_name, "--non-interactive", "hello"],
+    )
+    assert result.exit_code == 2
+    assert expected_message in result.output
+
+
 def test_command_fork_rejects_path_traversal(runner: CliRunner, runid: int, name: str):
     escape_name = f"../escape-{runid}"
     escape_path = cli.get_logs_dir().parent / f"escape-{runid}"
@@ -630,6 +651,10 @@ def test_should_print_resume_hint_is_disabled_for_json_output(tmp_path: Path):
     (logdir / "conversation.jsonl").write_text('{"role":"user","content":"hello"}\n')
 
     assert not cli._should_print_resume_hint(logdir, "json")
+
+
+def test_format_resume_hint_shell_quotes_space_containing_name():
+    assert cli._format_resume_hint("foo bar") == "gptme --name 'foo bar'"
 
 
 def test_command_exit(args: list[str], runner: CliRunner):

--- a/tests/test_logmanager.py
+++ b/tests/test_logmanager.py
@@ -3,7 +3,12 @@ from pathlib import Path
 import pytest
 
 from gptme.dirs import get_logs_dir
-from gptme.logmanager import Log, LogManager, check_for_modifications
+from gptme.logmanager import (
+    Log,
+    LogManager,
+    check_for_modifications,
+    conversation_name_error,
+)
 from gptme.message import Message
 from gptme.tools import init_tools
 
@@ -65,6 +70,21 @@ def test_fork_rejects_path_traversal(tmp_path: Path, monkeypatch):
         log.fork("../escape")
 
     assert not (tmp_path / "escape").exists()
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (" leading", "conversation name cannot start or end with whitespace."),
+        ("trailing ", "conversation name cannot start or end with whitespace."),
+        ("foo\tbar", "conversation name cannot contain control characters."),
+        ("foo\nbar", "conversation name cannot contain control characters."),
+    ],
+)
+def test_conversation_name_error_rejects_control_and_edge_whitespace(
+    value: str, expected: str
+):
+    assert conversation_name_error(value) == expected
 
 
 def test_write_persists_main_branch_when_on_other_branch(tmp_path: Path, monkeypatch):

--- a/tests/test_server_path_traversal.py
+++ b/tests/test_server_path_traversal.py
@@ -558,6 +558,21 @@ class TestConversationIdLengthValidation:
             _response, status_code = result
             assert status_code == 400
 
+    @pytest.mark.parametrize(
+        "bad_id", [" leading", "trailing ", "foo\tbar", "foo\nbar"]
+    )
+    def test_control_or_edge_whitespace_id_rejected_unit(self, bad_id: str):
+        """Control chars and edge whitespace should fail before filesystem access."""
+        from gptme.server.api_v2_common import _validate_conversation_id
+        from gptme.server.app import create_app
+
+        app = create_app()
+        with app.app_context():
+            result = _validate_conversation_id(bad_id)
+            assert result is not None
+            _response, status_code = result
+            assert status_code == 400
+
     def test_multibyte_over_limit_rejected(self):
         """Multi-byte chars counted by UTF-8 bytes, not code points.
 


### PR DESCRIPTION
## Summary
- reject conversation names with leading/trailing whitespace or control characters
- reuse the shared conversation-id validator from logmanager instead of duplicating the rules
- shell-quote the CLI resume hint so valid names with spaces still round-trip cleanly

## Repro
Before this patch, these all succeeded and created shell-hostile resume flows:
- `gptme --name $'foo\nbar' --non-interactive /help`
- `gptme --name $'foo\tbar' --non-interactive /help`
- `gptme --name ' leading-trailing ' --non-interactive /help`

That produced ugly logdirs and a broken hint like:
- `Goodbye! (resume with: gptme --name foo`
- `bar)`

After this patch, control chars and edge whitespace are rejected up front, while a valid spaced name still prints a safe hint:
- `Goodbye! (resume with: gptme --name 'foo bar')`

## Testing
- `uv run --directory /tmp/gptme-conv-name-45fc python -m pytest tests/test_cli.py -k "name_rejects or resume_hint"`
- `uv run --directory /tmp/gptme-conv-name-45fc python -m pytest tests/test_logmanager.py -k "conversation_name_error or fork_rejects_path_traversal"`
- `uv run --directory /tmp/gptme-conv-name-45fc python -m pytest tests/test_server_path_traversal.py -k "whitespace_only_id_rejected_unit or control_or_edge_whitespace_id_rejected_unit or 255_char_id_passes_unit or very_long_id_unit or multibyte_over_limit_rejected"`
