### PR TITLE
fix(server): validate config patch tool allowlist

### DIFF
--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -1177,6 +1177,18 @@ def api_conversation_config_patch(conversation_id: str):
         return flask.jsonify({"error": "No JSON data provided"}), 400
     if not isinstance(req_json, dict):
         return flask.jsonify({"error": "JSON body must be an object"}), 400
+    chat_patch = req_json.get("chat")
+    if isinstance(chat_patch, dict) and "tools" in chat_patch:
+        tool_allowlist = _get_optional_string_list_field(chat_patch, "tools")
+        if isinstance(tool_allowlist, tuple):
+            return tool_allowlist
+        if tool_allowlist is not None:
+            try:
+                init_tools(tool_allowlist)
+            except ValueError as exc:
+                return flask.jsonify({"error": str(exc)}), 400
+            except Exception as exc:
+                return flask.jsonify({"error": f"Failed to load tool: {exc}"}), 400
 
     logdir = get_logs_dir() / conversation_id
 

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -1177,18 +1177,17 @@ def api_conversation_config_patch(conversation_id: str):
         return flask.jsonify({"error": "No JSON data provided"}), 400
     if not isinstance(req_json, dict):
         return flask.jsonify({"error": "JSON body must be an object"}), 400
+
+    # Extract tool allowlist early for type-checking (no side effects).
+    # init_tools validation is deferred to after the 404/409 guards because it
+    # mutates process-wide state (loaded_tools, _tools_init_lock).
+    tool_allowlist: list[str] | None = None
     chat_patch = req_json.get("chat")
     if isinstance(chat_patch, dict) and "tools" in chat_patch:
-        tool_allowlist = _get_optional_string_list_field(chat_patch, "tools")
-        if isinstance(tool_allowlist, tuple):
-            return tool_allowlist
-        if tool_allowlist is not None:
-            try:
-                init_tools(tool_allowlist)
-            except ValueError as exc:
-                return flask.jsonify({"error": str(exc)}), 400
-            except Exception as exc:
-                return flask.jsonify({"error": f"Failed to load tool: {exc}"}), 400
+        raw_allowlist = _get_optional_string_list_field(chat_patch, "tools")
+        if isinstance(raw_allowlist, tuple):
+            return raw_allowlist  # 400: bad type, no side effects
+        tool_allowlist = raw_allowlist  # narrowed to list[str] | None
 
     logdir = get_logs_dir() / conversation_id
 
@@ -1223,6 +1222,16 @@ def api_conversation_config_patch(conversation_id: str):
                 ),
                 409,
             )
+
+    # Validate tool allowlist now that 404/409 guards have passed.
+    # init_tools mutates process-wide state; must run AFTER guards, not before.
+    if tool_allowlist is not None:
+        try:
+            init_tools(tool_allowlist)
+        except ValueError as exc:
+            return flask.jsonify({"error": str(exc)}), 400
+        except Exception as exc:
+            return flask.jsonify({"error": f"Failed to load tool: {exc}"}), 400
 
     # Create and set config
     req_json["_logdir"] = logdir  # Pass logdir for "@log" workspace resolution

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -1459,6 +1459,30 @@ def test_v2_chat_config_patch_rejects_invalid_workspace_type(
     assert response.get_json() == {"error": "chat.workspace must be a string path"}
 
 
+@pytest.mark.parametrize(
+    ("tools_payload", "expected_error"),
+    [
+        ("shell", "tools must be a list of strings"),
+        (["definitely-not-a-tool"], "Tool 'definitely-not-a-tool' not found"),
+    ],
+)
+def test_v2_chat_config_patch_validates_tools_before_init(
+    client: FlaskClient, tools_payload: object, expected_error: str
+):
+    """Config PATCH should reject malformed tool allowlists with 400."""
+    conv = create_conversation(client)
+    conversation_id = conv["conversation_id"]
+
+    response = client.patch(
+        f"/api/v2/conversations/{conversation_id}/config",
+        json={"chat": {"tools": tools_payload}},
+    )
+
+    assert response.status_code == 400
+    data = response.get_json()
+    assert expected_error in data["error"]
+
+
 def test_v2_chat_config_patch_rejected_during_generation(client: FlaskClient):
     """Config PATCH should return 409 when a session is actively generating."""
     conv = create_conversation(client)


### PR DESCRIPTION
## Summary
- validate `chat.tools` in `PATCH /api/v2/conversations/{id}/config` before config save / tool init
- return 400 for non-list payloads and unknown tool names instead of letting `init_tools()` raise a 500
- add config-patch regression coverage next to the existing server V2 patch tests

## Repro
```bash
curl -X PATCH http://127.0.0.1:5700/api/v2/conversations/<id>/config \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  --data {chat:{tools:shell}}
```

Before: HTTP 500 because the config patch path accepted the string, saved it, then `init_tools()` iterated characters.
After: HTTP 400 with `tools must be a list of strings`.

This also returns 400 for unknown tool names like `{"chat":{"tools":["definitely-not-a-tool"]}}` instead of another 500.

## Testing
- `PYTHONPATH=/tmp/gptme-cfgpatch-8c90 /home/bob/gptme/.venv/bin/python -m pytest -q tests/test_server_v2.py tests/test_server.py -k "chat_config_patch or conversation_post_tools_validation"`
