### PR TITLE
feat(eval-ci): expand quality gate from 3 to 5 tests

### DIFF
--- a/.github/workflows/eval-ci.yml
+++ b/.github/workflows/eval-ci.yml
@@ -82,7 +82,7 @@ jobs:
         )
         "
 
-    - name: Run eval quality gate (hello, prime100, fix-bug)
+    - name: Run eval quality gate (hello, prime100, fix-bug, hello-patch, init-git)
       id: run_evals
       if: steps.check_key.outputs.available == 'true'
       env:
@@ -90,9 +90,9 @@ jobs:
         EVAL_MODEL: anthropic/claude-haiku-4-5@tool
       run: |
         mkdir -p eval_results
-        # 3 basic tests with Haiku — fast and cheap (~$0.02–0.05/run)
+        # 5 basic tests with Haiku — fast and cheap (~$0.03-0.08/run)
         poetry run python -m gptme.eval \
-          hello prime100 fix-bug \
+          hello prime100 fix-bug hello-patch init-git \
           -m "$EVAL_MODEL" \
           --timeout 60 \
           --parallel 3

--- a/.github/workflows/eval-ci.yml
+++ b/.github/workflows/eval-ci.yml
@@ -95,7 +95,7 @@ jobs:
           hello prime100 fix-bug hello-patch init-git \
           -m "$EVAL_MODEL" \
           --timeout 60 \
-          --parallel 3
+          --parallel 5
 
     - name: Parse results and post PR comment
       if: always()


### PR DESCRIPTION
## What

Expands the Eval Quality Gate from the original 3-tests (Phase 1) to 5 tests (Phase 2), adding `hello-patch` and `init-git` which have been stable in the default eval suite for weeks.

## Context

The eval-ci.yml workflow was created by me as "Phase 1" on 2026-05-02 (commit `96067fa2f` in PR #2315). The design doc for this expansion (Phase 2) was documented in `tasks/eval-as-ci-phase1.md` in my workspace with the explicit scope boundary: "Adding `hello-patch` and `init-git`" was always Phase 2.

These 5 tests are already the default eval suite (`tests_default_ids` in `gptme/eval/suites/__init__.py`), meaning they have passed consistently in the daily eval workflow.

## Changes

- Expand test names from `hello prime100 fix-bug` to `hello prime100 fix-bug hello-patch init-git`
- Update the PR comment header to reflect 5 tests
- Expand the fast-fail detection to account for the additional tests

