### PR TITLE
feat(cli): prompt inline gptme auth on first use

### DIFF
--- a/gptme/init.py
+++ b/gptme/init.py
@@ -10,7 +10,7 @@ from rich.logging import RichHandler
 
 from .cli.setup import ask_for_api_key
 from .commands import init_commands
-from .config import get_config
+from .config import Config, get_config
 from .hooks import init_hooks
 from .llm import guess_provider_from_config, init_llm, is_custom_provider
 from .llm.llm_gptme import GptmeAuthError
@@ -216,7 +216,7 @@ def init_model(
 def _maybe_authenticate_gptme_interactively(
     provider: Provider,
     interactive: bool,
-    config,
+    config: Config,
 ) -> bool:
     """Offer inline gptme.ai device-flow auth and return True if it completed."""
     if provider != "gptme" or not interactive or is_output_json():

--- a/gptme/init.py
+++ b/gptme/init.py
@@ -187,7 +187,14 @@ def init_model(
     model_full = f"{provider}/{model_name}"
     if not is_output_json():
         console.log(f"Using model: [green]{model_full}[/green]")
-    init_llm(provider)
+    try:
+        init_llm(provider)
+    except KeyError as e:
+        if not _maybe_authenticate_gptme_interactively(
+            provider, interactive, config, e
+        ):
+            raise
+        init_llm(provider)
 
     model_meta = _resolved_meta or get_model(model_full)
 
@@ -205,6 +212,32 @@ def init_model(
             logger.info(f"Context length overridden to {context_length} tokens")
 
     set_default_model(model_meta)
+
+
+def _maybe_authenticate_gptme_interactively(
+    provider: Provider,
+    interactive: bool,
+    config,
+    error: KeyError,
+) -> bool:
+    """Offer inline gptme.ai device-flow auth and return True if it completed."""
+    if provider != "gptme" or not interactive or is_output_json():
+        return False
+    if "gptme provider requires authentication" not in str(error):
+        return False
+
+    response = console.input(
+        "[yellow]No gptme.ai login found.[/yellow] Start device-flow login now? [Y/n] "
+    ).strip()
+    if response and response.lower() not in {"y", "yes"}:
+        return False
+
+    from .llm.llm_gptme import DEFAULT_SERVICE_URL, device_flow_authenticate
+
+    service_url = config.get_env("GPTME_CLOUD_BASE_URL") or DEFAULT_SERVICE_URL
+    service_url = service_url.rstrip("/").removesuffix("/v1")
+    device_flow_authenticate(server_url=service_url)
+    return True
 
 
 def init_logging(verbose, *, stderr: bool = True):

--- a/gptme/init.py
+++ b/gptme/init.py
@@ -13,6 +13,7 @@ from .commands import init_commands
 from .config import get_config
 from .hooks import init_hooks
 from .llm import guess_provider_from_config, init_llm, is_custom_provider
+from .llm.llm_gptme import GptmeAuthError
 from .llm.models import (
     PROVIDERS,
     CustomProvider,
@@ -189,10 +190,8 @@ def init_model(
         console.log(f"Using model: [green]{model_full}[/green]")
     try:
         init_llm(provider)
-    except KeyError as e:
-        if not _maybe_authenticate_gptme_interactively(
-            provider, interactive, config, e
-        ):
+    except GptmeAuthError:
+        if not _maybe_authenticate_gptme_interactively(provider, interactive, config):
             raise
         init_llm(provider)
 
@@ -218,12 +217,9 @@ def _maybe_authenticate_gptme_interactively(
     provider: Provider,
     interactive: bool,
     config,
-    error: KeyError,
 ) -> bool:
     """Offer inline gptme.ai device-flow auth and return True if it completed."""
     if provider != "gptme" or not interactive or is_output_json():
-        return False
-    if "gptme provider requires authentication" not in str(error):
         return False
 
     response = console.input(

--- a/gptme/llm/llm_gptme.py
+++ b/gptme/llm/llm_gptme.py
@@ -30,6 +30,11 @@ from ..config import Config
 
 logger = logging.getLogger(__name__)
 
+
+class GptmeAuthError(KeyError):
+    """Raised when no valid gptme.ai credentials are found."""
+
+
 # Default base URL for the gptme cloud API proxy
 DEFAULT_BASE_URL = "https://fleet.gptme.ai/v1"
 
@@ -103,7 +108,7 @@ def get_api_key(config: Config) -> str:
     if api_key:
         return api_key
 
-    raise KeyError(
+    raise GptmeAuthError(
         "gptme provider requires authentication. Either:\n"
         "  1. Run `gptme-auth login` to authenticate via Device Flow\n"
         "  2. Set the GPTME_CLOUD_API_KEY environment variable"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1259,6 +1259,115 @@ class TestInitModelInteractive:
 
         mock_ask.assert_not_called()
 
+    @patch("gptme.init.set_default_model")
+    @patch("gptme.init.get_model")
+    @patch("gptme.init.init_llm")
+    @patch("gptme.llm.llm_gptme.device_flow_authenticate")
+    @patch("gptme.init.is_output_json", return_value=False)
+    @patch("gptme.init.get_config")
+    @patch("gptme.init.console")
+    def test_interactive_gptme_missing_auth_runs_inline_device_flow(
+        self,
+        mock_console,
+        mock_config_fn,
+        mock_json_mode,
+        mock_device_flow,
+        mock_init_llm,
+        mock_get_model,
+        mock_set_default,
+        dummy_model_meta,
+    ):
+        """Interactive gptme runs should offer inline login and retry init."""
+        from gptme.init import init_model
+
+        config = MagicMock()
+        config.chat = MagicMock(model=None)
+        config.get_env.return_value = None
+        mock_config_fn.return_value = config
+        mock_console.input.return_value = ""
+        mock_get_model.return_value = dummy_model_meta
+        mock_init_llm.side_effect = [
+            KeyError("gptme provider requires authentication"),
+            None,
+        ]
+
+        init_model(model="gptme/claude-sonnet-4-6", interactive=True)
+
+        mock_console.input.assert_called_once()
+        mock_device_flow.assert_called_once_with(server_url="https://fleet.gptme.ai")
+        assert mock_init_llm.call_args_list == [call("gptme"), call("gptme")]
+
+    @patch("gptme.init.set_default_model")
+    @patch("gptme.init.get_model")
+    @patch("gptme.init.init_llm")
+    @patch("gptme.llm.llm_gptme.device_flow_authenticate")
+    @patch("gptme.init.is_output_json", return_value=False)
+    @patch("gptme.init.get_config")
+    @patch("gptme.init.console")
+    def test_interactive_gptme_decline_keeps_keyerror(
+        self,
+        mock_console,
+        mock_config_fn,
+        mock_json_mode,
+        mock_device_flow,
+        mock_init_llm,
+        mock_get_model,
+        mock_set_default,
+        dummy_model_meta,
+    ):
+        """Declining the inline gptme login should preserve the original failure."""
+        from gptme.init import init_model
+
+        config = MagicMock()
+        config.chat = MagicMock(model=None)
+        config.get_env.return_value = None
+        mock_config_fn.return_value = config
+        mock_console.input.return_value = "n"
+        mock_get_model.return_value = dummy_model_meta
+        mock_init_llm.side_effect = KeyError("gptme provider requires authentication")
+
+        with pytest.raises(KeyError, match="gptme provider requires authentication"):
+            init_model(model="gptme/claude-sonnet-4-6", interactive=True)
+
+        mock_console.input.assert_called_once()
+        mock_device_flow.assert_not_called()
+        mock_init_llm.assert_called_once_with("gptme")
+
+    @patch("gptme.init.set_default_model")
+    @patch("gptme.init.get_model")
+    @patch("gptme.init.init_llm")
+    @patch("gptme.llm.llm_gptme.device_flow_authenticate")
+    @patch("gptme.init.is_output_json", return_value=False)
+    @patch("gptme.init.get_config")
+    @patch("gptme.init.console")
+    def test_non_interactive_gptme_missing_auth_does_not_prompt(
+        self,
+        mock_console,
+        mock_config_fn,
+        mock_json_mode,
+        mock_device_flow,
+        mock_init_llm,
+        mock_get_model,
+        mock_set_default,
+        dummy_model_meta,
+    ):
+        """Non-interactive gptme runs should still fail fast without prompting."""
+        from gptme.init import init_model
+
+        config = MagicMock()
+        config.chat = MagicMock(model=None)
+        config.get_env.return_value = None
+        mock_config_fn.return_value = config
+        mock_get_model.return_value = dummy_model_meta
+        mock_init_llm.side_effect = KeyError("gptme provider requires authentication")
+
+        with pytest.raises(KeyError, match="gptme provider requires authentication"):
+            init_model(model="gptme/claude-sonnet-4-6", interactive=False)
+
+        mock_console.input.assert_not_called()
+        mock_device_flow.assert_not_called()
+        mock_init_llm.assert_called_once_with("gptme")
+
 
 # ===========================================================================
 # init_model() — all builtin providers

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -12,6 +12,7 @@ from unittest.mock import MagicMock, call, patch
 
 import pytest
 
+from gptme.llm.llm_gptme import GptmeAuthError
 from gptme.llm.models.types import CustomProvider, ModelMeta
 
 # ---------------------------------------------------------------------------
@@ -1287,7 +1288,7 @@ class TestInitModelInteractive:
         mock_console.input.return_value = ""
         mock_get_model.return_value = dummy_model_meta
         mock_init_llm.side_effect = [
-            KeyError("gptme provider requires authentication"),
+            GptmeAuthError("gptme provider requires authentication"),
             None,
         ]
 
@@ -1324,9 +1325,13 @@ class TestInitModelInteractive:
         mock_config_fn.return_value = config
         mock_console.input.return_value = "n"
         mock_get_model.return_value = dummy_model_meta
-        mock_init_llm.side_effect = KeyError("gptme provider requires authentication")
+        mock_init_llm.side_effect = GptmeAuthError(
+            "gptme provider requires authentication"
+        )
 
-        with pytest.raises(KeyError, match="gptme provider requires authentication"):
+        with pytest.raises(
+            GptmeAuthError, match="gptme provider requires authentication"
+        ):
             init_model(model="gptme/claude-sonnet-4-6", interactive=True)
 
         mock_console.input.assert_called_once()
@@ -1359,9 +1364,13 @@ class TestInitModelInteractive:
         config.get_env.return_value = None
         mock_config_fn.return_value = config
         mock_get_model.return_value = dummy_model_meta
-        mock_init_llm.side_effect = KeyError("gptme provider requires authentication")
+        mock_init_llm.side_effect = GptmeAuthError(
+            "gptme provider requires authentication"
+        )
 
-        with pytest.raises(KeyError, match="gptme provider requires authentication"):
+        with pytest.raises(
+            GptmeAuthError, match="gptme provider requires authentication"
+        ):
             init_model(model="gptme/claude-sonnet-4-6", interactive=False)
 
         mock_console.input.assert_not_called()


### PR DESCRIPTION
This addresses the main remaining UX gap from #2586: if a user starts an interactive session with `gptme -m gptme/...` and has no stored token or `GPTME_CLOUD_API_KEY`, the CLI now offers to start the existing device-flow login inline instead of just crashing with a `KeyError`.

What changed:
- catch missing `gptme` auth during interactive init and offer inline device-flow login
- retry provider init after successful auth
- keep non-interactive and JSON-output paths fail-fast/non-prompting
- add focused tests for accept/decline/non-interactive behavior

Verification:
- `ruff check gptme/init.py tests/test_init.py`
- `python -m pytest tests/test_init.py tests/test_gptme_provider.py -q`

This is intentionally partial for #2586; provider aliasing and model discovery are still separate follow-ups.