### PR TITLE
fix(install): error on missing TTY instead of silently assuming yes

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -57,7 +57,12 @@ confirm() {
   [ "$YES" -eq 1 ] && return 0
   # When piped from curl, stdin is the script — read from the terminal directly.
   printf '%s [y/N] ' "$1"
-  read -r ans </dev/tty 2>/dev/null || { warn "Could not read from terminal; assuming yes."; return 0; }
+  if ! read -r ans </dev/tty 2>/dev/null; then
+    printf '\033[1;31merror:\033[0m No terminal available for confirmation.\n' >&2
+    printf '  Re-run with --yes/-y to install non-interactively:\n' >&2
+    printf '  curl -sSf %s | sh -s -- --yes\n' "$SCRIPT_URL" >&2
+    exit 1
+  fi
   case "$ans" in y|Y|yes|YES) return 0 ;; *) return 1 ;; esac
 }
 


### PR DESCRIPTION
## Summary

`confirm()` in `scripts/install.sh` reads the user's y/N answer from `/dev/tty` (because stdin is the piped script under `curl | sh`). When `/dev/tty` is unavailable — fully non-interactive contexts like CI, Docker, or nested pipes — the previous behavior **warned and assumed yes**, silently installing without consent.

This changes it to error out with a clear, actionable hint:

```
error: No terminal available for confirmation.
  Re-run with --yes/-y to install non-interactively:
  curl -sSf https://gptme.ai/install.sh | sh -s -- --yes
```

Requiring an explicit `--yes` in non-interactive mode matches modern installer convention (rustup, etc.) and removes a footgun where a `curl | sh` in an automated context would install unprompted.

## Why now / source-vs-artifact alignment

The hosted copy at `gptme.ai/install.sh` (served from `gptme-cloud/public/install.sh`, gptme-cloud#304) **already ships this safer behavior** — but it was added directly in the *synced downstream artifact*, not here in the declared source. The served file's own header instructs re-syncing via `curl …master/scripts/install.sh > public/install.sh`, so the next sync would have silently clobbered the improvement back to assume-yes. Upstreaming it here keeps the source canonical and the two copies convergent.

## Testing
- `sh -n scripts/install.sh` — valid POSIX sh
- `shellcheck scripts/install.sh` — clean
- Interactive path unchanged; `--yes` short-circuit (`[ "$YES" -eq 1 ] && return 0`) still bypasses the prompt entirely.

Related: #2586, #2592, gptme-cloud#304