### PR TITLE
feat(cli): list dynamic models for gptme provider

### DIFF
--- a/gptme/llm/__init__.py
+++ b/gptme/llm/__init__.py
@@ -760,7 +760,7 @@ def get_available_models(provider: Provider) -> list[ModelMeta]:
         ValueError: If provider doesn't support listing models
         Exception: If API request fails
     """
-    if provider in ("openrouter", "local") or is_custom_provider(provider):
+    if provider in ("openrouter", "local", "gptme") or is_custom_provider(provider):
         from .llm_openai import get_available_models as get_openai_models
 
         return get_openai_models(provider)

--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -1723,8 +1723,6 @@ def _openai_compatible_model_to_modelmeta(
 
     model_id = model_data.get("id", model_data.get("name", "unknown"))
 
-    # Ollama models typically have context of 128k, but this may vary
-    # Try to extract from model data if available
     context = model_data.get("context_length", 128_000)
 
     # Use CustomProvider for non-builtin providers, "local" for local provider
@@ -1736,15 +1734,24 @@ def _openai_compatible_model_to_modelmeta(
     else:
         provider = CustomProvider(provider_name)
 
+    # Detect vision support from architecture/modality info if available
+    architecture = model_data.get("architecture", {})
+    input_modalities = architecture.get("input_modalities", [])
+    supports_vision = "image" in input_modalities
+    if not supports_vision and not input_modalities:
+        modality = architecture.get("modality", "")
+        input_side = modality.split("->")[0] if "->" in modality else ""
+        supports_vision = "image" in input_side
+
     return ModelMeta(
         provider=provider,
         model=model_id,
         context=context,
-        max_output=None,  # Ollama doesn't typically report this
+        max_output=None,
         supports_streaming=True,
-        supports_vision=False,  # Could be enhanced to detect vision models
+        supports_vision=supports_vision,
         supports_reasoning=False,
-        price_input=0,  # Local models are free
+        price_input=0,  # pricing unknown for dynamically discovered models
         price_output=0,
     )
 

--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -1618,12 +1618,22 @@ def get_available_models(provider: Provider) -> list[ModelMeta]:
     if is_custom_provider(provider):
         custom = next((p for p in config.user.providers if p.name == provider), None)
         if custom:
-            return _get_local_models(config, provider, custom.base_url)
+            return _get_openai_compatible_models(config, provider, custom.base_url)
         # Fall through to local if custom provider not found in config
-        return _get_local_models(config, provider)
+        return _get_openai_compatible_models(config, provider)
 
     if provider == "local":
-        return _get_local_models(config, provider)
+        return _get_openai_compatible_models(config, provider)
+
+    if provider == "gptme":
+        from .llm_gptme import get_api_key, get_base_url
+
+        return _get_openai_compatible_models(
+            config,
+            provider,
+            base_url=get_base_url(config),
+            api_key=get_api_key(config),
+        )
 
     if provider != "openrouter":
         raise ValueError(f"Provider {provider} does not support listing models")
@@ -1665,10 +1675,13 @@ def get_available_models(provider: Provider) -> list[ModelMeta]:
         raise
 
 
-def _get_local_models(
-    config, provider_name: str = "local", base_url: str | None = None
+def _get_openai_compatible_models(
+    config,
+    provider_name: str = "local",
+    base_url: str | None = None,
+    api_key: str | None = None,
 ) -> list[ModelMeta]:
-    """Get available models from local provider (ollama or other OpenAI-compatible server)."""
+    """Get models from an OpenAI-compatible provider."""
     # Get base URL from parameter (custom provider) or env var (local provider)
     if base_url is None:
         base_url = config.get_env("OPENAI_BASE_URL", "http://localhost:11434/v1")
@@ -1683,13 +1696,17 @@ def _get_local_models(
         models_url = f"{base_url.rstrip('/')}/v1/models"
 
     try:
-        response = requests.get(models_url, timeout=10)
+        headers = {"Authorization": f"Bearer {api_key}"} if api_key else None
+        response = requests.get(models_url, headers=headers, timeout=10)
         response.raise_for_status()
         data = response.json()
 
         # OpenAI-compatible format: {"data": [...], "object": "list"}
         raw_models = data.get("data", [])
-        return [_local_model_to_modelmeta(model, provider_name) for model in raw_models]
+        return [
+            _openai_compatible_model_to_modelmeta(model, provider_name)
+            for model in raw_models
+        ]
     except requests.RequestException as e:
         logger.debug(f"Failed to retrieve models from {provider_name} provider: {e}")
         # Return empty list instead of raising - local server might not be running
@@ -1699,8 +1716,10 @@ def _get_local_models(
         return []
 
 
-def _local_model_to_modelmeta(model_data: dict, provider_name: str) -> ModelMeta:
-    """Convert local/ollama model data to ModelMeta object."""
+def _openai_compatible_model_to_modelmeta(
+    model_data: dict, provider_name: str
+) -> ModelMeta:
+    """Convert OpenAI-compatible model data to ModelMeta."""
 
     model_id = model_data.get("id", model_data.get("name", "unknown"))
 
@@ -1709,9 +1728,13 @@ def _local_model_to_modelmeta(model_data: dict, provider_name: str) -> ModelMeta
     context = model_data.get("context_length", 128_000)
 
     # Use CustomProvider for non-builtin providers, "local" for local provider
-    provider: Provider = (
-        "local" if provider_name == "local" else CustomProvider(provider_name)
-    )
+    provider: Provider
+    if provider_name == "local":
+        provider = "local"
+    elif provider_name == "gptme":
+        provider = "gptme"
+    else:
+        provider = CustomProvider(provider_name)
 
     return ModelMeta(
         provider=provider,

--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -1708,11 +1708,13 @@ def _get_openai_compatible_models(
             for model in raw_models
         ]
     except requests.RequestException as e:
-        logger.debug(f"Failed to retrieve models from {provider_name} provider: {e}")
+        log_fn = logger.debug if provider_name == "local" else logger.warning
+        log_fn(f"Failed to retrieve models from {provider_name} provider: {e}")
         # Return empty list instead of raising - local server might not be running
         return []
     except Exception as e:
-        logger.debug(f"Unexpected error retrieving {provider_name} models: {e}")
+        log_fn = logger.debug if provider_name == "local" else logger.warning
+        log_fn(f"Unexpected error retrieving {provider_name} models: {e}")
         return []
 
 

--- a/gptme/llm/models/listing.py
+++ b/gptme/llm/models/listing.py
@@ -250,7 +250,7 @@ def _print_detailed_format(
     else:
         print(f"\n{provider}:")
 
-    if dynamic_fetch and provider == "openrouter" and len(models) > 0:
+    if dynamic_fetch and provider in ("openrouter", "gptme") and len(models) > 0:
         print(f"  ({len(models)} models available via API)")
 
     # Show up to 10 models with details

--- a/gptme/llm/models/listing.py
+++ b/gptme/llm/models/listing.py
@@ -64,18 +64,24 @@ def _get_models_for_provider(
             dynamic_models = get_available_models(provider)
             models_to_show = dynamic_models
         except Exception as e:
-            # Fall back to static models (only for built-in providers)
-            logger.debug(
-                "Failed to fetch dynamic models for %s, falling back to static: %s",
-                provider,
-                e,
-            )
-            if provider in MODELS:
-                static_models = [
-                    get_model(f"{provider}/{name}") for name in MODELS[provider]
-                ]
-                models_to_show = static_models
-            # Custom providers have no static fallback
+            from ..llm_gptme import GptmeAuthError  # fmt: skip
+
+            if isinstance(e, GptmeAuthError):
+                # Auth error: surface the actionable hint to the user
+                logger.warning("gptme provider: %s", e)
+            else:
+                # Fall back to static models (only for built-in providers)
+                logger.debug(
+                    "Failed to fetch dynamic models for %s, falling back to static: %s",
+                    provider,
+                    e,
+                )
+                if provider in MODELS:
+                    static_models = [
+                        get_model(f"{provider}/{name}") for name in MODELS[provider]
+                    ]
+                    models_to_show = static_models
+                # Custom providers have no static fallback
     else:
         # Use static models
         if MODELS.get(provider):

--- a/gptme/llm/models/listing.py
+++ b/gptme/llm/models/listing.py
@@ -58,7 +58,7 @@ def _get_models_for_provider(
 
     # Try dynamic fetching first for supported providers
     if dynamic_fetch and (
-        provider in ("openrouter", "local") or is_custom_provider(provider)
+        provider in ("openrouter", "local", "gptme") or is_custom_provider(provider)
     ):
         try:
             dynamic_models = get_available_models(provider)

--- a/gptme/llm/models/resolution.py
+++ b/gptme/llm/models/resolution.py
@@ -229,7 +229,7 @@ def get_model(model: str) -> ModelMeta:
                 )
 
             # For providers that support dynamic fetching, use _get_models_for_provider
-            if provider == "openrouter":
+            if provider in ("openrouter", "gptme"):
                 try:
                     from .listing import _get_models_for_provider  # fmt: skip
 
@@ -259,7 +259,8 @@ def get_model(model: str) -> ModelMeta:
                 except Exception as e:
                     # Fall back to unknown model metadata
                     logger.debug(
-                        "Failed to fetch OpenRouter models for %s: %s",
+                        "Failed to fetch dynamic %s models for %s: %s",
+                        provider,
                         model_name,
                         e,
                     )

--- a/tests/test_llm_models.py
+++ b/tests/test_llm_models.py
@@ -75,6 +75,20 @@ def test_get_model_dynamic_fetch_success(mock_get_models):
 
 
 @patch("gptme.llm.models.listing._get_models_for_provider")
+def test_get_model_gptme_dynamic_fetch_success(mock_get_models):
+    """Test successful dynamic model fetching for gptme."""
+    dynamic_model = ModelMeta(provider="gptme", model="openai/gpt-5", context=256_000)
+    mock_get_models.return_value = [dynamic_model]
+
+    model = get_model("gptme/openai/gpt-5")
+    assert model.provider == "gptme"
+    assert model.model == "openai/gpt-5"
+    assert model.context == 256_000
+
+    mock_get_models.assert_called_once_with("gptme", dynamic_fetch=True)
+
+
+@patch("gptme.llm.models.listing._get_models_for_provider")
 def test_get_model_dynamic_fetch_failure(mock_get_models):
     """Test fallback when dynamic model fetching fails."""
     mock_get_models.side_effect = Exception("API error")
@@ -103,6 +117,18 @@ def test_get_models_for_provider():
     openai_models = _get_models_for_provider("openai", dynamic_fetch=False)
     assert len(openai_models) > 0
     assert all(m.provider == "openai" for m in openai_models)
+
+
+@patch("gptme.llm.get_available_models")
+def test_get_models_for_provider_gptme_dynamic_fetch(mock_get_available_models):
+    """gptme provider should use dynamic fetching for model listing."""
+    dynamic_model = ModelMeta(provider="gptme", model="openai/gpt-5", context=256_000)
+    mock_get_available_models.return_value = [dynamic_model]
+
+    models = _get_models_for_provider("gptme", dynamic_fetch=True)
+
+    assert models == [dynamic_model]
+    mock_get_available_models.assert_called_once_with("gptme")
 
 
 @patch("gptme.llm.models.listing._get_models_for_provider")

--- a/tests/test_llm_openai.py
+++ b/tests/test_llm_openai.py
@@ -1,7 +1,7 @@
 import logging
 from types import SimpleNamespace
 from typing import Any, cast
-from unittest.mock import Mock
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 from pydantic import BaseModel
@@ -2562,6 +2562,46 @@ class TestOpenrouterModelToModelmeta:
             self._model_data("openrouter/anthropic/claude-sonnet-4-20250514")
         )
         assert meta.full == "openrouter/anthropic/claude-sonnet-4-20250514"
+
+
+class TestGetAvailableModels:
+    """Tests for OpenAI-compatible model listing helpers."""
+
+    @patch("gptme.llm.llm_openai.requests.get")
+    @patch("gptme.llm.llm_openai.get_config")
+    @patch("gptme.llm.llm_gptme.get_base_url")
+    @patch("gptme.llm.llm_gptme.get_api_key")
+    def test_gptme_provider_uses_authenticated_models_endpoint(
+        self,
+        mock_get_api_key,
+        mock_get_base_url,
+        mock_get_config,
+        mock_requests_get,
+    ):
+        """gptme model listing should hit its OpenAI-compatible /models endpoint."""
+        from gptme.llm.llm_openai import get_available_models
+
+        get_available_models.cache_clear()
+        mock_get_config.return_value = MagicMock()
+        mock_get_api_key.return_value = "gptme-token"
+        mock_get_base_url.return_value = "https://fleet.gptme.ai/v1"
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "data": [{"id": "openai/gpt-5", "context_length": 256000}]
+        }
+        mock_requests_get.return_value = mock_response
+
+        models = get_available_models("gptme")
+
+        mock_requests_get.assert_called_once_with(
+            "https://fleet.gptme.ai/v1/models",
+            headers={"Authorization": "Bearer gptme-token"},
+            timeout=10,
+        )
+        assert len(models) == 1
+        assert models[0].provider == "gptme"
+        assert models[0].model == "openai/gpt-5"
+        assert models[0].context == 256_000
 
 
 class TestResolveMaxTokens:


### PR DESCRIPTION
## Summary
- add dynamic `/v1/models` fetching for the `gptme` provider instead of treating it as static-only
- reuse the OpenAI-compatible model-listing helper for authenticated `gptme` listings
- use dynamically fetched `gptme/...` model metadata during model resolution when the model is not in the static registry

## Testing
- `/home/bob/gptme/.venv/bin/python -m pytest -q tests/test_gptme_provider.py tests/test_llm_models.py tests/test_llm_openai.py`
- `/home/bob/gptme/.venv/bin/python -m ruff check gptme/llm/__init__.py gptme/llm/llm_openai.py gptme/llm/models/listing.py gptme/llm/models/resolution.py tests/test_llm_models.py tests/test_llm_openai.py`

Refs #2586
