### PR TITLE
feat(llm): add gptme.ai as provider alias for gptme

### DIFF
--- a/gptme/llm/models/__init__.py
+++ b/gptme/llm/models/__init__.py
@@ -30,6 +30,7 @@ from .resolution import (
 )
 from .types import (
     MODEL_ALIASES,
+    PROVIDER_ALIASES,
     PROVIDERS,
     PROVIDERS_OPENAI,
     BuiltinProvider,
@@ -51,6 +52,7 @@ __all__ = [
     "_ModelDictMeta",
     # Constants
     "MODEL_ALIASES",
+    "PROVIDER_ALIASES",
     "MODELS",
     "PROVIDERS",
     "PROVIDERS_OPENAI",

--- a/gptme/llm/models/resolution.py
+++ b/gptme/llm/models/resolution.py
@@ -8,6 +8,7 @@ from .types import (
     _DATE_SUFFIX_PATTERN,
     _MODEL_FAMILY_PATTERN,
     MODEL_ALIASES,
+    PROVIDER_ALIASES,
     PROVIDERS,
     ModelMeta,
     Provider,
@@ -162,6 +163,14 @@ def _find_closest_model_properties(
 
 
 def get_model(model: str) -> ModelMeta:
+    # Apply provider aliases (e.g. "gptme.ai" -> "gptme")
+    if "/" in model:
+        prefix, rest = model.split("/", 1)
+        if prefix in PROVIDER_ALIASES:
+            model = f"{PROVIDER_ALIASES[prefix]}/{rest}"
+    elif model in PROVIDER_ALIASES:
+        model = PROVIDER_ALIASES[model]
+
     # if only provider is given, get recommended model
     if model in PROVIDERS:
         provider = cast(Provider, model)

--- a/gptme/llm/models/types.py
+++ b/gptme/llm/models/types.py
@@ -37,6 +37,12 @@ MODEL_ALIASES: dict[str, dict[str, str]] = {
     },
 }
 
+# Provider aliases: maps friendly alias strings to their canonical built-in provider name.
+# Allows users to write e.g. ``gptme.ai/model`` as a synonym for ``gptme/model``.
+PROVIDER_ALIASES: dict[str, str] = {
+    "gptme.ai": "gptme",
+}
+
 # Built-in providers (static list)
 BuiltinProvider = Literal[
     "openai",

--- a/gptme/llm/models/types.py
+++ b/gptme/llm/models/types.py
@@ -37,12 +37,6 @@ MODEL_ALIASES: dict[str, dict[str, str]] = {
     },
 }
 
-# Provider aliases: maps friendly alias strings to their canonical built-in provider name.
-# Allows users to write e.g. ``gptme.ai/model`` as a synonym for ``gptme/model``.
-PROVIDER_ALIASES: dict[str, str] = {
-    "gptme.ai": "gptme",
-}
-
 # Built-in providers (static list)
 BuiltinProvider = Literal[
     "openai",
@@ -60,6 +54,15 @@ BuiltinProvider = Literal[
 ]
 PROVIDERS: list[BuiltinProvider] = cast(
     list[BuiltinProvider], get_args(BuiltinProvider)
+)
+
+# Provider aliases: maps friendly alias strings to their canonical built-in provider name.
+# Allows users to write e.g. ``gptme.ai/model`` as a synonym for ``gptme/model``.
+PROVIDER_ALIASES: dict[str, str] = {
+    "gptme.ai": "gptme",
+}
+assert all(v in PROVIDERS for v in PROVIDER_ALIASES.values()), (
+    f"PROVIDER_ALIASES contains invalid target(s): {set(PROVIDER_ALIASES.values()) - set(PROVIDERS)}"
 )
 
 

--- a/tests/test_llm_models_resolution.py
+++ b/tests/test_llm_models_resolution.py
@@ -27,7 +27,7 @@ from gptme.llm.models.resolution import (
     log_warn_once,
     set_default_model,
 )
-from gptme.llm.models.types import MODEL_ALIASES
+from gptme.llm.models.types import MODEL_ALIASES, PROVIDER_ALIASES
 
 # ── Fixtures ─────────────────────────────────────────────────────────────
 
@@ -181,6 +181,36 @@ class TestAliasResolution:
         props = _find_base_model_properties("anthropic", "claude-nonexistent-9-9")
         # Should be None since there's no alias and no base model after stripping date
         assert props is None
+
+
+# ── Provider alias resolution ────────────────────────────────────────────
+
+
+class TestProviderAliasResolution:
+    """Tests for PROVIDER_ALIASES — e.g. gptme.ai -> gptme."""
+
+    def test_provider_aliases_defined(self):
+        """PROVIDER_ALIASES should contain at least the gptme.ai entry."""
+        assert "gptme.ai" in PROVIDER_ALIASES
+        assert PROVIDER_ALIASES["gptme.ai"] == "gptme"
+
+    def test_gptme_ai_model_resolves_to_gptme_provider(self):
+        """get_model('gptme.ai/model') should produce a gptme-provider ModelMeta."""
+        model = get_model("gptme.ai/claude-sonnet-4-6")
+        assert model.provider == "gptme"
+        assert "claude-sonnet-4-6" in model.model
+
+    def test_gptme_ai_alone_resolves_to_gptme_recommended(self):
+        """get_model('gptme.ai') alone should resolve like get_model('gptme')."""
+        model_alias = get_model("gptme.ai")
+        model_canonical = get_model("gptme")
+        assert model_alias.provider == model_canonical.provider
+        assert model_alias.model == model_canonical.model
+
+    def test_unknown_alias_unchanged(self):
+        """A provider prefix not in PROVIDER_ALIASES passes through unmodified."""
+        model = get_model("anthropic/claude-sonnet-4-6")
+        assert model.provider == "anthropic"
 
 
 # ── Date suffix stripping ────────────────────────────────────────────────

--- a/tests/test_llm_models_resolution.py
+++ b/tests/test_llm_models_resolution.py
@@ -199,6 +199,7 @@ class TestProviderAliasResolution:
         model = get_model("gptme.ai/claude-sonnet-4-6")
         assert model.provider == "gptme"
         assert "claude-sonnet-4-6" in model.model
+        assert model.full.startswith("gptme/")
 
     def test_gptme_ai_alone_resolves_to_gptme_recommended(self):
         """get_model('gptme.ai') alone should resolve like get_model('gptme')."""


### PR DESCRIPTION
## Summary

- Adds `PROVIDER_ALIASES` dict in `gptme/llm/models/types.py` mapping `"gptme.ai"` → `"gptme"`
- Applies alias at the top of `get_model()` in `resolution.py` before any other routing
- Exports `PROVIDER_ALIASES` from the `models` package `__init__.py`
- 4 new tests in `test_llm_models_resolution.py::TestProviderAliasResolution`

After this, users can write either form:
```
gptme -m gptme.ai/claude-sonnet-4-6   # alias form
gptme -m gptme/claude-sonnet-4-6      # canonical form (unchanged)
gptme -m gptme.ai                     # resolves to gptme recommended model
```

This closes the remaining ergonomics gap described in #2586. The proxy-like architecture is already in place (`llm_gptme.py` routes through `fleet.gptme.ai/v1`); this just lets users address it by domain name.

Closes #2586

## Test plan
- [ ] `pytest tests/test_llm_models_resolution.py::TestProviderAliasResolution` — 4 new tests all pass
- [ ] `pytest tests/test_llm_models_resolution.py` — 91 existing tests unchanged
- [ ] `pytest tests/test_gptme_provider.py` — 17 existing tests unchanged