### PR TITLE
feat(lessons): load manifest-backed skills lazily from index.json

### DIFF
--- a/gptme/cli/cmd_hooks.py
+++ b/gptme/cli/cmd_hooks.py
@@ -374,7 +374,7 @@ def run(workspace: Path | None = None) -> None:
     # Take top N
     new_results = new_results[:max_lessons]
     for result in new_results:
-        if getattr(result.lesson, "is_stub", False) is True:
+        if result.lesson.is_stub:
             result.lesson = index.materialize_lesson(result.lesson)
 
     # Build context text

--- a/gptme/cli/cmd_hooks.py
+++ b/gptme/cli/cmd_hooks.py
@@ -373,6 +373,9 @@ def run(workspace: Path | None = None) -> None:
 
     # Take top N
     new_results = new_results[:max_lessons]
+    for result in new_results:
+        if getattr(result.lesson, "is_stub", False) is True:
+            result.lesson = index.materialize_lesson(result.lesson)
 
     # Build context text
     parts = []

--- a/gptme/cli/cmd_skills.py
+++ b/gptme/cli/cmd_skills.py
@@ -109,6 +109,8 @@ def skills_show(name: str):
     # Search by skill name first, then lesson title/filename
     for item in index.lessons:
         if item.metadata.name and name_lower in item.metadata.name.lower():
+            if getattr(item, "is_stub", False) is True:
+                item = index.materialize_lesson(item)
             click.echo(f"# {item.metadata.name}")
             if item.metadata.description:
                 click.echo(f"\n{item.metadata.description}")
@@ -118,6 +120,8 @@ def skills_show(name: str):
 
     for item in index.lessons:
         if name_lower in item.title.lower() or name_lower in item.path.stem.lower():
+            if getattr(item, "is_stub", False) is True:
+                item = index.materialize_lesson(item)
             click.echo(f"# {item.title}")
             click.echo(f"\nPath: {item.path}\n")
             click.echo(item.body)

--- a/gptme/cli/cmd_skills.py
+++ b/gptme/cli/cmd_skills.py
@@ -109,7 +109,7 @@ def skills_show(name: str):
     # Search by skill name first, then lesson title/filename
     for item in index.lessons:
         if item.metadata.name and name_lower in item.metadata.name.lower():
-            if getattr(item, "is_stub", False) is True:
+            if item.is_stub:
                 item = index.materialize_lesson(item)
             click.echo(f"# {item.metadata.name}")
             if item.metadata.description:
@@ -120,7 +120,7 @@ def skills_show(name: str):
 
     for item in index.lessons:
         if name_lower in item.title.lower() or name_lower in item.path.stem.lower():
-            if getattr(item, "is_stub", False) is True:
+            if item.is_stub:
                 item = index.materialize_lesson(item)
             click.echo(f"# {item.title}")
             click.echo(f"\nPath: {item.path}\n")

--- a/gptme/lessons/auto_include.py
+++ b/gptme/lessons/auto_include.py
@@ -126,7 +126,7 @@ def auto_include_lessons(
         # Limit to top N (matcher may already limit, but ensure it)
         matches = matches[:max_lessons]
         for match in matches:
-            if getattr(match.lesson, "is_stub", False) is True:
+            if match.lesson.is_stub:
                 match.lesson = index.materialize_lesson(match.lesson)
 
         # Format lessons for inclusion, respecting token budget

--- a/gptme/lessons/auto_include.py
+++ b/gptme/lessons/auto_include.py
@@ -125,6 +125,9 @@ def auto_include_lessons(
 
         # Limit to top N (matcher may already limit, but ensure it)
         matches = matches[:max_lessons]
+        for match in matches:
+            if getattr(match.lesson, "is_stub", False) is True:
+                match.lesson = index.materialize_lesson(match.lesson)
 
         # Format lessons for inclusion, respecting token budget
         lesson_content, dropped_count, subsequent_tokens = _format_with_budget(

--- a/gptme/lessons/commands.py
+++ b/gptme/lessons/commands.py
@@ -160,6 +160,8 @@ def _lesson_show(lesson_name: str) -> str:
             file_match = lesson_name_lower in lesson.path.stem.lower()
 
             if title_match or file_match:
+                if getattr(lesson, "is_stub", False) is True:
+                    lesson = index.materialize_lesson(lesson)
                 return f"# {lesson.title}\n\n{lesson.body}"
 
         return f"Lesson not found: {lesson_name}"
@@ -278,6 +280,8 @@ def _skills_read(name: str) -> str:
         # First check skills (by metadata.name)
         for item in index.lessons:
             if item.metadata.name and name_lower in item.metadata.name.lower():
+                if getattr(item, "is_stub", False) is True:
+                    item = index.materialize_lesson(item)
                 return f"# {item.metadata.name}\n\n{item.body}"
 
         # Then check lessons (by title or filename)
@@ -286,6 +290,8 @@ def _skills_read(name: str) -> str:
             file_match = name_lower in item.path.stem.lower()
 
             if title_match or file_match:
+                if getattr(item, "is_stub", False) is True:
+                    item = index.materialize_lesson(item)
                 return f"# {item.title}\n\n{item.body}"
 
         return f"Skill or lesson not found: {name}"

--- a/gptme/lessons/commands.py
+++ b/gptme/lessons/commands.py
@@ -160,7 +160,7 @@ def _lesson_show(lesson_name: str) -> str:
             file_match = lesson_name_lower in lesson.path.stem.lower()
 
             if title_match or file_match:
-                if getattr(lesson, "is_stub", False) is True:
+                if lesson.is_stub:
                     lesson = index.materialize_lesson(lesson)
                 return f"# {lesson.title}\n\n{lesson.body}"
 
@@ -280,7 +280,7 @@ def _skills_read(name: str) -> str:
         # First check skills (by metadata.name)
         for item in index.lessons:
             if item.metadata.name and name_lower in item.metadata.name.lower():
-                if getattr(item, "is_stub", False) is True:
+                if item.is_stub:
                     item = index.materialize_lesson(item)
                 return f"# {item.metadata.name}\n\n{item.body}"
 
@@ -290,7 +290,7 @@ def _skills_read(name: str) -> str:
             file_match = name_lower in item.path.stem.lower()
 
             if title_match or file_match:
-                if getattr(item, "is_stub", False) is True:
+                if item.is_stub:
                     item = index.materialize_lesson(item)
                 return f"# {item.title}\n\n{item.body}"
 

--- a/gptme/lessons/index.py
+++ b/gptme/lessons/index.py
@@ -601,7 +601,7 @@ class LessonIndex:
                 results.append(lesson)
                 continue
 
-        return results
+        return [self.materialize_lesson(lesson) for lesson in results]
 
     def get_by_category(self, category: str) -> list[Lesson]:
         """Get all lessons in a category.

--- a/gptme/lessons/index.py
+++ b/gptme/lessons/index.py
@@ -5,7 +5,7 @@ import logging
 import os
 from pathlib import Path
 
-from .parser import Lesson, parse_lesson
+from .parser import Lesson, LessonMetadata, parse_lesson
 
 logger = logging.getLogger(__name__)
 
@@ -426,6 +426,10 @@ class LessonIndex:
             logger.warning(f"Failed to read skill manifest {manifest_path}: {e}")
             return [], set()
 
+        if not isinstance(manifest, dict):
+            logger.warning(f"Skill manifest {manifest_path} is not a JSON object")
+            return [], set()
+
         skills = manifest.get("skills")
         if not isinstance(skills, list):
             logger.warning(
@@ -507,8 +511,6 @@ class LessonIndex:
         depends: list[str],
         status: str,
     ):
-        from .parser import LessonMetadata
-
         return LessonMetadata(
             name=name,
             description=description,

--- a/gptme/lessons/index.py
+++ b/gptme/lessons/index.py
@@ -559,8 +559,12 @@ class LessonIndex:
         if not lesson.is_stub:
             return lesson
 
-        materialized, _ = self._load_lesson_file(lesson.path)
-        return materialized
+        try:
+            materialized, _ = self._load_lesson_file(lesson.path)
+            return materialized
+        except Exception as e:
+            logger.warning(f"Failed to materialize stub {lesson.path}: {e}")
+            return lesson
 
     def search(self, query: str) -> list[Lesson]:
         """Search lessons by keyword or content.
@@ -612,9 +616,13 @@ class LessonIndex:
             category: Category name (e.g., "tools", "patterns")
 
         Returns:
-            List of lessons in category
+            List of lessons in category (stubs are materialized on return)
         """
-        return [lesson for lesson in self.lessons if lesson.category == category]
+        return [
+            self.materialize_lesson(lesson)
+            for lesson in self.lessons
+            if lesson.category == category
+        ]
 
     def refresh(self) -> None:
         """Refresh the index by re-parsing all lessons."""

--- a/gptme/lessons/index.py
+++ b/gptme/lessons/index.py
@@ -1,5 +1,6 @@
 """Lesson index for discovery and search."""
 
+import json
 import logging
 import os
 from pathlib import Path
@@ -325,6 +326,24 @@ class LessonIndex:
         cache_misses = 0
         skipped_duplicates = 0
 
+        manifest_lessons, manifest_skill_paths = self._load_manifest_skill_stubs(
+            directory
+        )
+        for lesson in manifest_lessons:
+            if not self._claim_lesson_slot(
+                lesson.path, directory, seen_paths, seen_rel_paths
+            ):
+                skipped_duplicates += 1
+                continue
+
+            if lesson.metadata.status != "active":
+                logger.debug(
+                    f"Skipping {lesson.metadata.status} lesson: {lesson.path.relative_to(directory)}"
+                )
+                continue
+
+            self.lessons.append(lesson)
+
         # Find both .md and .mdc files
         lesson_files = list(directory.rglob("*.md")) + list(directory.rglob("*.mdc"))
 
@@ -333,6 +352,9 @@ class LessonIndex:
         excluded_patterns = ["worktree/", "/.git/"]
 
         for lesson_file in lesson_files:
+            if lesson_file in manifest_skill_paths:
+                continue
+
             # Skip special files
             if lesson_file.name.lower() in ("readme.md", "todo.md"):
                 continue
@@ -345,46 +367,18 @@ class LessonIndex:
                 logger.debug(f"Skipping lesson in excluded directory: {lesson_file}")
                 continue
 
-            # Deduplication: Skip if lesson with same resolved path already indexed
-            # This handles symlinks pointing to the same file
-            resolved_path = os.path.realpath(lesson_file)
-            if resolved_path in seen_paths:
-                logger.debug(
-                    f"Skipping duplicate lesson: {lesson_file.relative_to(directory)} "
-                    f"(resolves to already indexed file)"
-                )
+            if not self._claim_lesson_slot(
+                lesson_file, directory, seen_paths, seen_rel_paths
+            ):
                 skipped_duplicates += 1
                 continue
-
-            # Deduplication: Skip if lesson with same relative path already indexed
-            # from a different directory. This handles the common case where workspace
-            # lessons/ and gptme-contrib/lessons/ both contain e.g. social/foo.md
-            # First directory wins (per configured order), regardless of active status.
-            relative_name = lesson_file.relative_to(directory).as_posix()
-            if relative_name in seen_rel_paths:
-                logger.debug(
-                    f"Skipping duplicate lesson: {lesson_file.relative_to(directory)} "
-                    f"(same relative path already indexed from earlier directory)"
-                )
-                skipped_duplicates += 1
-                continue
-
-            # Always mark as seen (regardless of status) to enforce "first dir wins"
-            # An inactive lesson in an earlier dir suppresses all copies in later dirs.
-            seen_paths.add(resolved_path)
-            seen_rel_paths.add(relative_name)
 
             try:
-                # Try to use cached lesson first
-                lesson = _get_cached_lesson(lesson_file)
-
-                if lesson is None:
-                    # Cache miss or invalid, parse and cache
-                    lesson = parse_lesson(lesson_file)
-                    _cache_lesson(lesson_file, lesson)
-                    cache_misses += 1
-                else:
+                lesson, from_cache = self._load_lesson_file(lesson_file)
+                if from_cache:
                     cache_hits += 1
+                else:
+                    cache_misses += 1
 
                 # Filter based on status - only include active lessons
                 if lesson.metadata.status != "active":
@@ -398,6 +392,173 @@ class LessonIndex:
                 logger.warning(f"Failed to parse lesson {lesson_file}: {e}")
 
         return cache_hits, cache_misses, skipped_duplicates
+
+    @staticmethod
+    def _load_lesson_file(path: Path) -> tuple[Lesson, bool]:
+        """Load a lesson file, using the cache when possible."""
+        lesson = _get_cached_lesson(path)
+        if lesson is not None:
+            return lesson, True
+
+        lesson = parse_lesson(path)
+        _cache_lesson(path, lesson)
+        return lesson, False
+
+    @staticmethod
+    def _skill_path_from_manifest_entry(directory: Path, entry_path: str) -> Path:
+        """Resolve a manifest entry path to its SKILL.md file."""
+        skill_path = directory / Path(entry_path)
+        if skill_path.name.lower() != "skill.md":
+            skill_path = skill_path / "SKILL.md"
+        return skill_path
+
+    def _load_manifest_skill_stubs(
+        self, directory: Path
+    ) -> tuple[list[Lesson], set[Path]]:
+        """Load lightweight skill stubs from ``index.json`` when present."""
+        manifest_path = directory / "index.json"
+        if not manifest_path.is_file():
+            return [], set()
+
+        try:
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as e:
+            logger.warning(f"Failed to read skill manifest {manifest_path}: {e}")
+            return [], set()
+
+        skills = manifest.get("skills")
+        if not isinstance(skills, list):
+            logger.warning(
+                f"Skill manifest {manifest_path} is missing a top-level 'skills' list"
+            )
+            return [], set()
+
+        stubs: list[Lesson] = []
+        manifest_paths: set[Path] = set()
+
+        for entry in skills:
+            if not isinstance(entry, dict):
+                continue
+
+            name = entry.get("name")
+            entry_path = entry.get("path")
+            if not isinstance(name, str) or not name.strip():
+                continue
+            if not isinstance(entry_path, str) or not entry_path.strip():
+                continue
+
+            skill_file = self._skill_path_from_manifest_entry(directory, entry_path)
+            manifest_paths.add(skill_file)
+
+            if not skill_file.is_file():
+                logger.warning(
+                    f"Skill manifest {manifest_path} references missing file: {skill_file}"
+                )
+                continue
+
+            raw_keywords = entry.get("keywords", [])
+            if isinstance(raw_keywords, str):
+                raw_keywords = [raw_keywords]
+            elif not isinstance(raw_keywords, list):
+                raw_keywords = []
+            keywords = [kw for kw in raw_keywords if isinstance(kw, str) and kw.strip()]
+
+            raw_depends = entry.get("depends", [])
+            if isinstance(raw_depends, str):
+                raw_depends = [raw_depends]
+            elif not isinstance(raw_depends, list):
+                raw_depends = []
+            depends = [dep for dep in raw_depends if isinstance(dep, str) and dep]
+
+            description = entry.get("description", "")
+            if not isinstance(description, str):
+                description = ""
+
+            status = entry.get("status", "active")
+            if not isinstance(status, str):
+                status = "active"
+
+            stubs.append(
+                Lesson(
+                    path=skill_file,
+                    metadata=self._manifest_metadata(
+                        name=name.strip(),
+                        description=description.strip(),
+                        keywords=keywords,
+                        depends=depends,
+                        status=status,
+                    ),
+                    title=name.strip(),
+                    description=description.strip(),
+                    category=skill_file.parent.name,
+                    body="",
+                    is_stub=True,
+                )
+            )
+
+        return stubs, manifest_paths
+
+    @staticmethod
+    def _manifest_metadata(
+        *,
+        name: str,
+        description: str,
+        keywords: list[str],
+        depends: list[str],
+        status: str,
+    ):
+        from .parser import LessonMetadata
+
+        return LessonMetadata(
+            name=name,
+            description=description,
+            depends=depends,
+            keywords=keywords,
+            status=status,
+        )
+
+    @staticmethod
+    def _claim_lesson_slot(
+        lesson_file: Path,
+        directory: Path,
+        seen_paths: set[str],
+        seen_rel_paths: set[str],
+    ) -> bool:
+        """Reserve a lesson slot for deduplication, first directory wins."""
+        try:
+            relative_name = lesson_file.relative_to(directory).as_posix()
+        except ValueError:
+            logger.warning(
+                f"Skipping out-of-tree lesson while indexing {directory}: {lesson_file}"
+            )
+            return False
+
+        resolved_path = os.path.realpath(lesson_file)
+        if resolved_path in seen_paths:
+            logger.debug(
+                f"Skipping duplicate lesson: {relative_name} "
+                f"(resolves to already indexed file)"
+            )
+            return False
+
+        if relative_name in seen_rel_paths:
+            logger.debug(
+                f"Skipping duplicate lesson: {relative_name} "
+                f"(same relative path already indexed from earlier directory)"
+            )
+            return False
+
+        seen_paths.add(resolved_path)
+        seen_rel_paths.add(relative_name)
+        return True
+
+    def materialize_lesson(self, lesson: Lesson) -> Lesson:
+        """Load the full lesson body/title for manifest-backed skill stubs."""
+        if not lesson.is_stub:
+            return lesson
+
+        materialized, _ = self._load_lesson_file(lesson.path)
+        return materialized
 
     def search(self, query: str) -> list[Lesson]:
         """Search lessons by keyword or content.

--- a/gptme/lessons/index.py
+++ b/gptme/lessons/index.py
@@ -452,13 +452,14 @@ class LessonIndex:
                 continue
 
             skill_file = self._skill_path_from_manifest_entry(directory, entry_path)
-            manifest_paths.add(skill_file)
 
             if not skill_file.is_file():
                 logger.warning(
                     f"Skill manifest {manifest_path} references missing file: {skill_file}"
                 )
                 continue
+
+            manifest_paths.add(skill_file)
 
             raw_keywords = entry.get("keywords", [])
             if isinstance(raw_keywords, str):

--- a/gptme/lessons/parser.py
+++ b/gptme/lessons/parser.py
@@ -72,6 +72,7 @@ class Lesson:
     description: str
     category: str
     body: str
+    is_stub: bool = False
 
 
 def _extract_title(content: str) -> str:

--- a/gptme/tools/lessons.py
+++ b/gptme/tools/lessons.py
@@ -382,7 +382,7 @@ def auto_include_lessons_hook(
             return
 
         for match in new_matches:
-            if getattr(match.lesson, "is_stub", False) is True:
+            if match.lesson.is_stub:
                 match.lesson = index.materialize_lesson(match.lesson)
 
         # Format lessons as system message

--- a/gptme/tools/lessons.py
+++ b/gptme/tools/lessons.py
@@ -381,6 +381,10 @@ def auto_include_lessons_hook(
             logger.debug("No new lessons to include")
             return
 
+        for match in new_matches:
+            if getattr(match.lesson, "is_stub", False) is True:
+                match.lesson = index.materialize_lesson(match.lesson)
+
         # Format lessons as system message
         content_parts = ["# Relevant Lessons\n"]
         for match in new_matches:

--- a/tests/test_lessons_auto_include.py
+++ b/tests/test_lessons_auto_include.py
@@ -1,13 +1,17 @@
 """Tests for auto-include lesson system with token budget."""
 
+import json
 from pathlib import Path
 
 from gptme.lessons.auto_include import (
     _estimate_tokens,
     _format_with_budget,
     _get_token_budget,
+    auto_include_lessons,
 )
+from gptme.lessons.index import LessonIndex, clear_cache
 from gptme.lessons.parser import Lesson, LessonMetadata
+from gptme.message import Message
 
 
 def _make_lesson(title: str, body: str, path: str | Path = "/tmp/test.md") -> Lesson:
@@ -190,3 +194,57 @@ def test_get_token_budget_negative_env(monkeypatch):
     monkeypatch.setenv("GPTME_LESSONS_TOKEN_BUDGET", "-1000")
     budget = _get_token_budget()
     assert budget == 50000
+
+
+def test_auto_include_materializes_manifest_backed_skill(tmp_path: Path, monkeypatch):
+    """Matching a manifest-backed skill should load the full SKILL.md before injection."""
+    skill_dir = tmp_path / "skills" / "python-repl"
+    skill_dir.mkdir(parents=True)
+    skill_file = skill_dir / "SKILL.md"
+    skill_file.write_text(
+        """---
+name: python-repl
+description: Use Python REPL for quick computations
+keywords:
+  - python repl
+  - quick computation
+---
+
+# Python REPL Skill
+
+Execute Python code interactively.
+"""
+    )
+    (tmp_path / "skills" / "index.json").write_text(
+        json.dumps(
+            {
+                "version": "1.0",
+                "skills": [
+                    {
+                        "name": "python-repl",
+                        "description": "Use Python REPL for quick computations",
+                        "path": "python-repl",
+                        "keywords": ["python repl", "quick computation"],
+                    }
+                ],
+            }
+        )
+    )
+
+    monkeypatch.setattr(
+        LessonIndex,
+        "_default_dirs",
+        staticmethod(lambda: [tmp_path / "skills"]),
+    )
+    clear_cache()
+
+    messages = [
+        Message("system", "System prompt"),
+        Message("user", "Use the python repl for a quick computation"),
+    ]
+    updated = auto_include_lessons(messages)
+
+    assert len(updated) == 3
+    lesson_msg = updated[1]
+    assert "Python REPL Skill" in lesson_msg.content
+    assert "Execute Python code interactively." in lesson_msg.content

--- a/tests/test_lessons_index.py
+++ b/tests/test_lessons_index.py
@@ -1,5 +1,6 @@
 """Tests for lesson index module."""
 
+import json
 import tempfile
 from pathlib import Path
 
@@ -86,6 +87,55 @@ class TestLessonIndex:
 
         index = LessonIndex([temp_lesson_dir])
         assert len(index.lessons) == 1
+
+    def test_manifest_index_builds_skill_stub_then_materializes(self, tmp_path: Path):
+        """index.json should avoid eager SKILL.md parsing but still support full reads."""
+        clear_cache()
+        skills_dir = tmp_path / "skills"
+        skill_dir = skills_dir / "deploy-helper"
+        skill_dir.mkdir(parents=True)
+        skill_file = skill_dir / "SKILL.md"
+        skill_file.write_text(
+            """---
+name: deploy-helper
+description: Automates deployment workflows
+keywords:
+  - deployment workflow
+---
+
+# Production Deployment Tool
+
+Content about deployments.
+"""
+        )
+        (skills_dir / "index.json").write_text(
+            json.dumps(
+                {
+                    "version": "1.0",
+                    "skills": [
+                        {
+                            "name": "deploy-helper",
+                            "description": "Automates deployment workflows",
+                            "path": "deploy-helper",
+                            "keywords": ["deployment workflow"],
+                        }
+                    ],
+                }
+            )
+        )
+
+        index = LessonIndex([skills_dir])
+        assert len(index.lessons) == 1
+
+        skill = index.lessons[0]
+        assert skill.is_stub is True
+        assert skill.metadata.name == "deploy-helper"
+        assert skill.body == ""
+
+        materialized = index.materialize_lesson(skill)
+        assert materialized.is_stub is False
+        assert materialized.title == "Production Deployment Tool"
+        assert "Content about deployments." in materialized.body
 
 
 class TestLessonDeduplication:


### PR DESCRIPTION
## Summary
- load lightweight skill stubs from `skills/index.json` when a configured skill directory provides a manifest
- hydrate matched/read skills back to full `SKILL.md` content before injection or display so prompt/CLI behavior stays intact
- add regression coverage for manifest-backed indexing and auto-inclusion

Closes #2602.

## Testing
- `PYTHONPATH=/tmp/worktrees/gptme-skill-index-6dac /home/bob/gptme/.venv/bin/python -m pytest /tmp/worktrees/gptme-skill-index-6dac/tests/test_lessons.py /tmp/worktrees/gptme-skill-index-6dac/tests/test_lessons_matcher.py /tmp/worktrees/gptme-skill-index-6dac/tests/test_lessons_integration.py /tmp/worktrees/gptme-skill-index-6dac/tests/test_tools_lessons.py /tmp/worktrees/gptme-skill-index-6dac/tests/test_lessons_index.py /tmp/worktrees/gptme-skill-index-6dac/tests/test_lessons_auto_include.py /tmp/worktrees/gptme-skill-index-6dac/tests/test_prompt_skills_summary.py /tmp/worktrees/gptme-skill-index-6dac/tests/test_util_cli_skills.py /tmp/worktrees/gptme-skill-index-6dac/tests/test_lessons_commands.py -q`
