### PR TITLE
fix(llm): stop tool-format streams without newline

### DIFF
--- a/gptme/llm/__init__.py
+++ b/gptme/llm/__init__.py
@@ -20,7 +20,7 @@ from ..message import (
     len_tokens,
 )
 from ..telemetry import trace_function
-from ..tools import ToolSpec, ToolUse
+from ..tools import ToolSpec, ToolUse, get_tool_format
 from ..util import console
 from .models import (
     MODELS,
@@ -40,6 +40,18 @@ from .provider_plugins import (
 
 logger = logging.getLogger(__name__)
 _max_tokens_env_warned = False
+
+
+def _tooluse_break_check_char(char: str) -> bool:
+    """Return whether this character can complete a runnable tool call."""
+    current_format = get_tool_format()
+    if current_format == "markdown":
+        return char == "\n"
+    if current_format == "tool":
+        return char in {"}", "\n"}
+    if current_format == "xml":
+        return char in {">", "\n"}
+    return char == "\n"
 
 
 # Cheap/fast default model per provider for first-run / fallback scenarios.
@@ -554,9 +566,11 @@ def _reply_stream(
             if not json_mode:
                 sys.stdout.flush()
 
-            # Trigger the tool detection only if the line is finished.
-            # Helps to detect nested start code blocks.
-            if break_on_tooluse and char == "\n":
+            # Trigger tool detection at cheap format-specific breakpoints.
+            # Markdown tools need line completion; XML/tool formats can finish
+            # before a trailing newline, so waiting only for "\n" can leak
+            # extra assistant text past the breakpoint.
+            if break_on_tooluse and _tooluse_break_check_char(char):
                 # TODO: make this more robust/general, maybe with a callback that runs on each char/chunk
                 # pause inference on finished code-block, letting user run the command before continuing
                 # Use streaming=True to require blank line after code blocks during streaming

--- a/tests/test_llm_utils.py
+++ b/tests/test_llm_utils.py
@@ -547,6 +547,55 @@ def test_reply_stream_on_token_break_on_tooluse_tool_format_without_newline(
     assert suffix not in received_text
 
 
+def test_reply_stream_on_token_break_on_tooluse_xml_format_without_newline(
+    monkeypatch,
+):
+    """xml-format breakpoint must not wait for a trailing newline."""
+    from gptme.llm import _reply_stream
+    from gptme.message import Message
+    from gptme.tools import get_tool_format, init_tools, set_tool_format
+
+    init_tools()
+
+    tool_call = "<tool-use>\n<shell>\necho hi\n</shell>\n</tool-use>"
+    suffix = "This text should not be reached"
+
+    def _fake_gen(chunks):
+        yield from chunks
+
+    class _FakeStream:
+        def __init__(self, chunks):
+            self.gen = _fake_gen(chunks)
+            self.metadata = {"model": "test/model"}
+
+        def __iter__(self):
+            yield from self.gen
+
+    monkeypatch.setattr(
+        "gptme.llm._stream",
+        lambda *args, **kwargs: _FakeStream([tool_call + suffix]),
+    )
+
+    collected: list[str] = []
+    previous_format = get_tool_format()
+    set_tool_format("xml")
+    try:
+        result = _reply_stream(
+            messages=[Message("user", "hi")],
+            model="test/model",
+            tools=None,
+            on_token=collected.append,
+            break_on_tooluse=True,
+        )
+    finally:
+        set_tool_format(previous_format)
+
+    received_text = "".join(collected)
+    assert received_text == tool_call
+    assert result.content == tool_call
+    assert suffix not in received_text
+
+
 def test_reply_stream_on_token_thinking_tag_suppressed(monkeypatch):
     """on_token must not receive thinking-tag lines or their content.
 

--- a/tests/test_llm_utils.py
+++ b/tests/test_llm_utils.py
@@ -498,6 +498,55 @@ def test_reply_stream_on_token_break_on_tooluse(monkeypatch):
     assert len(collected) < len(tool_block)
 
 
+def test_reply_stream_on_token_break_on_tooluse_tool_format_without_newline(
+    monkeypatch,
+):
+    """tool-format breakpoint must not wait for a trailing newline."""
+    from gptme.llm import _reply_stream
+    from gptme.message import Message
+    from gptme.tools import get_tool_format, init_tools, set_tool_format
+
+    init_tools()
+
+    tool_call = '@shell(tool_uid): {"command": "echo hi"}'
+    suffix = "This text should not be reached"
+
+    def _fake_gen(chunks):
+        yield from chunks
+
+    class _FakeStream:
+        def __init__(self, chunks):
+            self.gen = _fake_gen(chunks)
+            self.metadata = {"model": "test/model"}
+
+        def __iter__(self):
+            yield from self.gen
+
+    monkeypatch.setattr(
+        "gptme.llm._stream",
+        lambda *args, **kwargs: _FakeStream([tool_call + suffix]),
+    )
+
+    collected: list[str] = []
+    previous_format = get_tool_format()
+    set_tool_format("tool")
+    try:
+        result = _reply_stream(
+            messages=[Message("user", "hi")],
+            model="test/model",
+            tools=None,
+            on_token=collected.append,
+            break_on_tooluse=True,
+        )
+    finally:
+        set_tool_format(previous_format)
+
+    received_text = "".join(collected)
+    assert received_text == tool_call
+    assert result.content == tool_call
+    assert suffix not in received_text
+
+
 def test_reply_stream_on_token_thinking_tag_suppressed(monkeypatch):
     """on_token must not receive thinking-tag lines or their content.
 


### PR DESCRIPTION
## Summary
- stop `break_on_tooluse` on format-specific completion characters instead of waiting only for newlines
- preserve existing markdown behavior while letting `tool`/XML streams break as soon as a runnable tool call is complete
- add a regression test for a `tool`-format call with no trailing newline and inline suffix text

## Testing
- PYTHONPATH=/home/bob/gptme-tmp-fix-2556 VIRTUAL_ENV=/home/bob/gptme/.venv PATH=/home/bob/gptme/.venv/bin:$PATH pytest /home/bob/gptme-tmp-fix-2556/tests/test_llm_utils.py -q