### PR TITLE
fix(autocompact): preserve tool-call messages

### DIFF
--- a/gptme/tools/autocompact/engine.py
+++ b/gptme/tools/autocompact/engine.py
@@ -19,7 +19,7 @@ from ...util.master_context import (
     create_master_context_reference,
 )
 from ...util.output_storage import create_tool_result_summary
-from ...util.reduce import reduce_log
+from ...util.reduce import message_contains_tool_use, reduce_log
 from .scoring import compress_content
 
 logger = logging.getLogger(__name__)
@@ -93,6 +93,7 @@ def auto_compact_log(
     needs_phase3_compression = any(
         (log_length - idx - 1) >= 3  # Don't compress very recent messages
         and msg.role == "assistant"  # Only compress assistant responses
+        and not message_contains_tool_use(msg)  # Keep tool-call pairs parseable
         and len_tokens(msg.content, model.model) > 1000  # Only compress long messages
         for idx, msg in enumerate(log)
     )
@@ -223,6 +224,7 @@ def auto_compact_log(
         if (
             distance_from_end >= 3  # Don't compress very recent messages
             and msg.role == "assistant"  # Only compress assistant responses
+            and not message_contains_tool_use(msg)  # Preserve tool-call pairs
             and msg_tokens > 1000  # Only compress long messages
         ):
             compressed_content = compress_content(msg.content, target_ratio=0.7)

--- a/gptme/util/reduce.py
+++ b/gptme/util/reduce.py
@@ -7,12 +7,34 @@ Typically used when the log exceeds a token limit and needs to be shortened.
 import logging
 import re
 from collections.abc import Generator
+from typing import Literal
 
 from ..codeblock import Codeblock
 from ..llm.models import get_default_model, get_model
 from ..message import Message, len_tokens
 
 logger = logging.getLogger(__name__)
+
+
+def message_contains_tool_use(msg: Message) -> bool:
+    """Return True when an assistant message contains a runnable tool call.
+
+    Tool-call messages must stay parseable so later tool results do not become
+    orphaned after compaction. We probe both formats explicitly because
+    conversations may contain markdown, XML, or structured ``tool`` syntax.
+    """
+    if msg.role != "assistant":
+        return False
+
+    from ..tools.base import ToolUse
+
+    tool_formats: tuple[Literal["tool", "xml"], ...] = ("tool", "xml")
+    for tool_format in tool_formats:
+        if any(
+            ToolUse.iter_from_content(msg.content, tool_format_override=tool_format)
+        ):
+            return True
+    return False
 
 
 def reduce_log(
@@ -37,10 +59,17 @@ def reduce_log(
         return
 
     logger.info(f"Log exceeded limit of {limit}, was {tokens}, reducing")
-    # filter out pinned messages
-    non_pinned = [(i, m) for i, m in enumerate(log) if not m.pinned]
+    # Filter out pinned messages and assistant tool-call messages. Tool-call
+    # messages must remain parseable so paired tool results keep their anchor.
+    non_pinned = [
+        (i, m)
+        for i, m in enumerate(log)
+        if not m.pinned and not message_contains_tool_use(m)
+    ]
     if not non_pinned:
-        logger.warning("Cannot reduce log: all messages are pinned")
+        logger.warning(
+            "Cannot reduce log: all messages are pinned or protected tool calls"
+        )
         yield from log
         return
 
@@ -75,6 +104,10 @@ def reduce_log(
 
 def truncate_msg(msg: Message, lines_pre=10, lines_post=10) -> Message | None:
     """Truncates message codeblocks and <details> blocks to the first and last `lines_pre` and `lines_post` lines, keeping the rest as `[...]`."""
+    if message_contains_tool_use(msg):
+        logger.debug("truncate_msg: preserving tool-call message")
+        return None
+
     content_staged = msg.content
 
     # Truncate long codeblocks

--- a/tests/test_auto_compact.py
+++ b/tests/test_auto_compact.py
@@ -508,18 +508,33 @@ def test_auto_compact_phase3_compresses_long_messages():
 
 
 def test_auto_compact_phase3_preserves_tool_use_messages():
-    """Phase 3 must not rewrite assistant messages that contain tool calls."""
-    tool_lines = "\n".join(f"echo line_{i}" for i in range(220))
+    """Phase 3 must not rewrite assistant messages that contain tool calls.
+
+    The guard in Phase 3 skips messages where message_contains_tool_use() is True.
+    This test verifies that guard actually fires: it places a long (>1000 token)
+    tool-call message alongside a long non-tool-use message that triggers
+    needs_phase3_compression=True, then confirms the tool-call message is
+    unchanged while the non-tool-use message is compressed.
+    """
+    # >1000 tokens so Phase 3 would compress it if not for the guard
+    tool_lines = "\n".join(f"echo line_{i}" for i in range(300))
     tool_msg = Message(
         "assistant",
         f"Planning before tool.\n```shell\n{tool_lines}\n```\nAfter the tool call.",
     )
     tool_result = Message("system", "Command executed successfully.")
+
+    # Long non-tool-use assistant message at distance >= 3 from end — this is
+    # what makes needs_phase3_compression=True and causes Phase 3 to actually run.
+    long_content = "This is a detailed analysis sentence. " * 200
+    long_content += "\n```python\ndef example(): pass\n```\n"
+    long_content += "Final conclusion. " * 50
+
     messages = [
         Message("user", "Hello"),
-        Message("assistant", "Short response"),
+        Message("assistant", long_content),  # idx 1, distance 5 — triggers Phase 3
         Message("user", "Tell me more"),
-        tool_msg,
+        tool_msg,  # idx 3, distance 3 — >1000 tokens but protected by guard
         tool_result,
         Message("assistant", "You're welcome"),
         Message("user", "One more thing"),
@@ -527,6 +542,10 @@ def test_auto_compact_phase3_preserves_tool_use_messages():
 
     compacted = list(auto_compact_log(messages, limit=100000))
 
+    # Phase 3 ran: the long non-tool-use message was compressed
+    assert len(compacted[1].content) < len(long_content)
+
+    # The tool-call message must be preserved exactly despite being >1000 tokens
     assert compacted[3].content == tool_msg.content
     assert compacted[4].content == tool_result.content
 

--- a/tests/test_auto_compact.py
+++ b/tests/test_auto_compact.py
@@ -507,6 +507,30 @@ def test_auto_compact_phase3_compresses_long_messages():
     assert "def important():" in compacted[long_msg_idx].content
 
 
+def test_auto_compact_phase3_preserves_tool_use_messages():
+    """Phase 3 must not rewrite assistant messages that contain tool calls."""
+    tool_lines = "\n".join(f"echo line_{i}" for i in range(220))
+    tool_msg = Message(
+        "assistant",
+        f"Planning before tool.\n```shell\n{tool_lines}\n```\nAfter the tool call.",
+    )
+    tool_result = Message("system", "Command executed successfully.")
+    messages = [
+        Message("user", "Hello"),
+        Message("assistant", "Short response"),
+        Message("user", "Tell me more"),
+        tool_msg,
+        tool_result,
+        Message("assistant", "You're welcome"),
+        Message("user", "One more thing"),
+    ]
+
+    compacted = list(auto_compact_log(messages, limit=100000))
+
+    assert compacted[3].content == tool_msg.content
+    assert compacted[4].content == tool_result.content
+
+
 def test_estimate_compaction_savings():
     """Test that estimate_compaction_savings correctly estimates potential savings."""
     from gptme.tools.autocompact import estimate_compaction_savings

--- a/tests/test_reduce.py
+++ b/tests/test_reduce.py
@@ -209,6 +209,41 @@ def test_truncate_msg_quad_fence():
     assert "```python" not in truncated.content.replace("````python", "")
 
 
+def test_truncate_msg_preserves_tool_use_codeblocks():
+    """Tool-call messages must stay parseable after reduction."""
+    tool_lines = "\n".join(f"echo line_{i}" for i in range(50))
+    msg = Message(
+        "assistant",
+        content=f"Planning.\n```shell\n{tool_lines}\n```\nAfter the tool call.",
+    )
+
+    truncated = truncate_msg(msg)
+
+    assert truncated is None
+
+
+def test_reduce_log_skips_tool_use_messages():
+    """reduce_log should compact a different message before touching tool calls."""
+    tool_lines = "\n".join(f"echo line_{i}" for i in range(80))
+    filler_lines = "\n".join(f"value_{i} = {i}" for i in range(70))
+    tool_msg = Message(
+        "assistant",
+        content=f"Planning.\n```shell\n{tool_lines}\n```\nAfter the tool call.",
+    )
+    filler_msg = Message("assistant", content=f"```python\n{filler_lines}\n```")
+    msgs = [
+        Message("system", content="system prompt"),
+        tool_msg,
+        Message("system", content="command executed successfully"),
+        filler_msg,
+    ]
+
+    reduced = list(reduce_log(msgs, limit=150))
+
+    assert reduced[1].content == tool_msg.content
+    assert "[...]" in reduced[3].content
+
+
 @pytest.mark.slow
 def test_reduce_log():
     msgs = [


### PR DESCRIPTION
## Summary
- protect assistant messages that contain real tool-use syntax from generic truncation
- skip Phase 3 assistant-message compression for tool-call messages so paired tool results keep a parseable anchor
- add regression tests for both `reduce_log` and `auto_compact_log`

## Testing
- `PYTHONPATH=/home/bob/gptme-tmp-compaction-0d1d VIRTUAL_ENV=/home/bob/gptme/.venv PATH=/home/bob/gptme/.venv/bin:$PATH pytest /home/bob/gptme-tmp-compaction-0d1d/tests/test_reduce.py /home/bob/gptme-tmp-compaction-0d1d/tests/test_auto_compact.py -q`