### PR TITLE
fix(cli): suppress resume hint after fatal exit

### DIFF
--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -749,9 +749,13 @@ def main(
         logdir = get_logdir(name)
         prompt_msgs = inject_stdin(prompt_msgs, piped_input)
 
+    show_resume_hint_on_exit = False
+
     # Register atexit handler to show conversation ID on exit
     def goodbye_handler():
-        if _should_print_resume_hint(logdir, output_format):
+        if show_resume_hint_on_exit and _should_print_resume_hint(
+            logdir, output_format
+        ):
             print(f"\nGoodbye! (resume with: {_format_resume_hint(logdir.name)})")
 
     atexit.register(goodbye_handler)
@@ -990,6 +994,7 @@ def main(
             output_schema_type,
             output_format,
         )
+        show_resume_hint_on_exit = True
     except (RuntimeError, Exception) as e:
         logger.error("Fatal error occurred")
         if verbose:

--- a/tests/test_json_output.py
+++ b/tests/test_json_output.py
@@ -249,17 +249,55 @@ class TestOutputFormatValidation:
         self, monkeypatch, tmp_path: Path
     ):
         """The goodbye handler should print once a conversation log exists."""
-        _, goodbye_handler = _invoke_cli_with_captured_goodbye(
-            monkeypatch, tmp_path, ["--non-interactive", "--name", "resume-test"]
+
+        def fake_chat(prompt_msgs, initial_msgs, logdir, *args, **kwargs):
+            (logdir / "conversation.jsonl").write_text(
+                '{"role":"user","content":"hello"}\n'
+            )
+
+        monkeypatch.setattr(cli, "chat", fake_chat)
+        result, goodbye_handler = _invoke_cli_with_captured_goodbye(
+            monkeypatch,
+            tmp_path,
+            ["--non-interactive", "--name", "resume-test", "hello"],
         )
-        log_file = cli.get_logdir("resume-test") / "conversation.jsonl"
-        log_file.write_text('{"role":"user","content":"hello"}\n')
 
         goodbye_output = io.StringIO()
         with redirect_stdout(goodbye_output):
             goodbye_handler()
 
+        assert result.exit_code == 0
         assert "resume with: gptme --name resume-test" in goodbye_output.getvalue()
+
+    def test_fatal_chat_error_has_no_fake_resume_hint(
+        self, monkeypatch, tmp_path: Path
+    ):
+        """Fatal chat errors must not advertise a resume hint for the failed run."""
+
+        def fake_chat(prompt_msgs, initial_msgs, logdir, *args, **kwargs):
+            (logdir / "conversation.jsonl").write_text(
+                '{"role":"user","content":"hello"}\n'
+            )
+            raise RuntimeError(f"Another gptme instance is using {logdir}")
+
+        monkeypatch.setattr(cli, "chat", fake_chat)
+        result, goodbye_handler = _invoke_cli_with_captured_goodbye(
+            monkeypatch,
+            tmp_path,
+            ["--non-interactive", "--name", "fatal-resume", "hello"],
+        )
+
+        goodbye_output = io.StringIO()
+        with redirect_stdout(goodbye_output):
+            goodbye_handler()
+
+        output = (result.output or "").lower()
+        goodbye_text = goodbye_output.getvalue().lower()
+        assert result.exit_code != 0
+        assert "fatal error occurred" in output
+        assert "another gptme instance is using" in output
+        assert "resume with:" not in goodbye_text
+        assert "goodbye!" not in goodbye_text
 
     def test_should_print_resume_hint_handles_missing_conversation_log(
         self, tmp_path: Path

--- a/tests/test_json_output.py
+++ b/tests/test_json_output.py
@@ -35,6 +35,30 @@ def _invoke_cli_with_captured_goodbye(monkeypatch, tmp_path: Path, args: list[st
     monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "state"))
     monkeypatch.setattr(cli.atexit, "register", handlers.append)
 
+    # Pre-chat mocks to make tests environment-independent.
+    # Without these the full setup_config_from_cli → init_tools → get_prompt
+    # pipeline runs in a bare tmp_path with no model configured, so the CLI
+    # exits through UsageError before reaching chat().
+    fake_config = SimpleNamespace(
+        chat=SimpleNamespace(
+            agent_config=None,
+            tools=[],
+            interactive=False,
+            tool_format="markdown",
+            model="local/test",
+            workspace=tmp_path,
+            stream=False,
+            agent=None,
+        ),
+        project=None,
+    )
+    monkeypatch.setattr(cli, "setup_config_from_cli", lambda **_: fake_config)
+    monkeypatch.setattr(cli, "init_tools", lambda _: [])
+    monkeypatch.setattr(cli, "get_prompt", lambda **_: [])
+    monkeypatch.setattr(cli, "init_telemetry", lambda **_: None)
+    monkeypatch.setattr(cli, "set_interruptible", lambda: None)
+    monkeypatch.setattr(cli.signal, "signal", lambda *args, **kwargs: None)
+
     runner = CliRunner()
     result = runner.invoke(cli.main, args, input="")
     goodbye_handler = next(


### PR DESCRIPTION
## Summary
- suppress the goodbye/resume hint unless `chat()` returns successfully
- keep the successful resume-hint path covered with a fake chat that writes a real conversation log
- add a regression test for fatal chat errors so locked/broken runs do not advertise a bogus retry hint

## Repro
Before this change, running `gptme --workspace @log -n -r --tools none` against an already-running conversation emitted the lock error and then still printed `Goodbye! (resume with: gptme --name ...)` for the same locked chat.

With this patch, the fatal error still surfaces, but the misleading resume hint is gone.

## Testing
- `PYTHONPATH=/tmp/gptme-cli-resume-hint-a76c /home/bob/bob/.venv/bin/pytest /tmp/gptme-cli-resume-hint-a76c/tests/test_json_output.py -k "resume_hint or missing_prompt" -q`
- `PYTHONPATH=/tmp/gptme-cli-resume-hint-a76c /home/bob/bob/.venv/bin/pytest /tmp/gptme-cli-resume-hint-a76c/tests/test_json_output.py -k "fatal_chat_error or existing_conversation or missing_prompt" -q`
- `uv run ruff check /tmp/gptme-cli-resume-hint-a76c/gptme/cli/main.py /tmp/gptme-cli-resume-hint-a76c/tests/test_json_output.py`
