### PR TITLE
fix(server): validate stream and tool-confirm action inputs

### DIFF
--- a/gptme/server/api_v2_sessions.py
+++ b/gptme/server/api_v2_sessions.py
@@ -324,6 +324,16 @@ def api_conversation_step(conversation_id: str):
         return flask.jsonify({"error": "model must be a string"}), 400
 
     stream = req_json.get("stream", chat_config.stream)
+    if not isinstance(stream, bool):
+        return (
+            flask.jsonify(
+                {
+                    "error": "Invalid 'stream' value",
+                    "message": "'stream' must be a boolean",
+                }
+            ),
+            400,
+        )
 
     # ACP opt-in: sticky once enabled for a session.
     # Default can be set server-wide via GPTME_USE_ACP_DEFAULT=true env var.
@@ -559,13 +569,11 @@ def api_conversation_tool_confirm(conversation_id: str):
     tool_id = _get_required_string_field(req_json, "tool_id")
     if not isinstance(tool_id, str):
         return tool_id
-    action = req_json.get("action")
-
-    if not action:
-        return (
-            flask.jsonify({"error": "action is required"}),
-            400,
-        )
+    action = _get_required_string_field(req_json, "action")
+    if not isinstance(action, str):
+        return action
+    if action not in {"confirm", "edit", "skip", "auto"}:
+        return flask.jsonify({"error": f"Unknown action: {action}"}), 400
 
     session: ConversationSession | None = None
 
@@ -689,8 +697,6 @@ def api_conversation_tool_confirm(conversation_id: str):
         start_tool_execution(
             conversation_id, session, tool_id, tool_exec.tooluse, model, chat_config
         )
-    else:
-        return flask.jsonify({"error": f"Unknown action: {action}"}), 400
 
     return flask.jsonify({"status": "ok", "message": f"Tool {action}ed"})
 

--- a/gptme/server/api_v2_sessions.py
+++ b/gptme/server/api_v2_sessions.py
@@ -323,17 +323,20 @@ def api_conversation_step(conversation_id: str):
     if model is not None and not isinstance(model, str):
         return flask.jsonify({"error": "model must be a string"}), 400
 
-    stream = req_json.get("stream", chat_config.stream)
-    if not isinstance(stream, bool):
-        return (
-            flask.jsonify(
-                {
-                    "error": "Invalid 'stream' value",
-                    "message": "'stream' must be a boolean",
-                }
-            ),
-            400,
-        )
+    if "stream" in req_json:
+        stream = req_json["stream"]
+        if not isinstance(stream, bool):
+            return (
+                flask.jsonify(
+                    {
+                        "error": "Invalid 'stream' value",
+                        "message": "'stream' must be a boolean",
+                    }
+                ),
+                400,
+            )
+    else:
+        stream = chat_config.stream
 
     # ACP opt-in: sticky once enabled for a session.
     # Default can be set server-wide via GPTME_USE_ACP_DEFAULT=true env var.

--- a/tests/test_server_v2_sessions.py
+++ b/tests/test_server_v2_sessions.py
@@ -277,6 +277,20 @@ class TestStepEndpoint:
         assert data is not None
         assert "use_acp" in data["error"]
 
+    def test_invalid_stream_type(self, conv, client: FlaskClient):
+        """Step with non-boolean stream returns 400."""
+        response = client.post(
+            f"/api/v2/conversations/{conv['conversation_id']}/step",
+            json={
+                "session_id": conv["session_id"],
+                "stream": "false",  # string, not bool
+            },
+        )
+        assert response.status_code == 400
+        data = response.get_json()
+        assert data is not None
+        assert "stream" in data["error"]
+
     def test_invalid_auto_confirm_type(self, conv, client: FlaskClient):
         """Step with invalid auto_confirm type returns 400."""
         response = client.post(
@@ -504,6 +518,22 @@ class TestToolConfirmEndpoint:
         assert data is not None
         assert data["error"] == "action is required"
 
+    @pytest.mark.parametrize("bad_action", [["confirm"], {"confirm": True}, 0, False])
+    def test_non_string_action(self, conv, client: FlaskClient, bad_action: object):
+        """action must be a string before any pending-tool lookup."""
+        response = client.post(
+            f"/api/v2/conversations/{conv['conversation_id']}/tool/confirm",
+            json={
+                "session_id": conv["session_id"],
+                "tool_id": "some-tool",
+                "action": bad_action,
+            },
+        )
+        assert response.status_code == 400
+        data = response.get_json()
+        assert data is not None
+        assert data["error"] == "action must be a string"
+
     @pytest.mark.parametrize("bad_session_id", [["boom"], {"boom": 1}, 0, False])
     def test_non_string_session_id(
         self, conv, client: FlaskClient, bad_session_id: object
@@ -571,6 +601,20 @@ class TestToolConfirmEndpoint:
             },
         )
         assert response.status_code == 404
+
+    def test_unknown_action_checked_before_tool_lookup(self, conv, client: FlaskClient):
+        """Unknown actions should return 400 even when tool_id is missing."""
+        response = client.post(
+            f"/api/v2/conversations/{conv['conversation_id']}/tool/confirm",
+            json={
+                "tool_id": "nonexistent-tool",
+                "action": "invalid_action",
+            },
+        )
+        assert response.status_code == 400
+        data = response.get_json()
+        assert data is not None
+        assert "unknown action" in data["error"].lower()
 
     def test_unknown_action(self, conv, client: FlaskClient):
         """Confirm with unknown action returns 400."""

--- a/tests/test_server_v2_sessions.py
+++ b/tests/test_server_v2_sessions.py
@@ -603,7 +603,7 @@ class TestToolConfirmEndpoint:
         assert response.status_code == 404
 
     def test_unknown_action_checked_before_tool_lookup(self, conv, client: FlaskClient):
-        """Unknown actions should return 400 even when tool_id is missing."""
+        """Unknown actions should return 400 before the tool_id lookup."""
         response = client.post(
             f"/api/v2/conversations/{conv['conversation_id']}/tool/confirm",
             json={


### PR DESCRIPTION
## Summary
- reject non-boolean `stream` values on the session step endpoint
- validate tool-confirm `action` as a string enum before any tool lookup
- add regression coverage for both bad-input paths

## Testing
- `uv run python3 -m pytest tests/test_server_v2_sessions.py -k 'invalid_stream_type or non_string_action or unknown_action_checked_before_tool_lookup or unknown_action or invalid_auto_confirm_type or invalid_use_acp_type'`\n- `uv run ruff check gptme/server/api_v2_sessions.py tests/test_server_v2_sessions.py`