### PR TITLE
fix(webui): cross-tab sync for server registry after cloud sign-in

### DIFF
--- a/webui/src/stores/servers.ts
+++ b/webui/src/stores/servers.ts
@@ -129,6 +129,22 @@ serverRegistry$.onChange(({ value }) => {
   persistRegistry(value);
 });
 
+// Cross-tab sync: re-hydrate when another tab writes gptme_servers to localStorage.
+// This makes the SetupWizard auto-connect promise work for web browser users: when
+// the auth callback lands in tab B and registers a new server, tab A's wizard wakes up.
+if (typeof window !== 'undefined') {
+  window.addEventListener('storage', (event: StorageEvent) => {
+    if (event.key === STORAGE_KEY && event.newValue) {
+      try {
+        const updated = JSON.parse(event.newValue) as ServerRegistry;
+        serverRegistry$.set(updated);
+      } catch {
+        // Ignore corrupted storage
+      }
+    }
+  });
+}
+
 export function getActiveServer(): ServerConfig | undefined {
   const registry = serverRegistry$.get();
   return registry.servers.find((s) => s.id === registry.activeServerId);

--- a/webui/src/stores/servers.ts
+++ b/webui/src/stores/servers.ts
@@ -12,32 +12,40 @@ const STORAGE_KEY = 'gptme_servers';
 const LEGACY_BASE_URL_KEY = 'gptme_baseUrl';
 const LEGACY_USER_TOKEN_KEY = 'gptme_userToken';
 
+/** Apply post-parse schema normalization to a registry read from storage.
+ *  Mutates and returns the object. The caller should fall back to
+ *  migrateFromLegacy() if the returned registry has no servers. */
+function normalizeRegistry(parsed: ServerRegistry): ServerRegistry {
+  // Ensure connectedServerIds exists (migration from phase 1 format)
+  if (!parsed.connectedServerIds) {
+    parsed.connectedServerIds = parsed.activeServerId ? [parsed.activeServerId] : [];
+  }
+  // Migrate: remove stale Cloud preset (it pointed at a broken URL)
+  migrateCloudPreset(parsed);
+  // Validate activeServerId points to an existing server
+  if (parsed.servers.length > 0 && !parsed.servers.some((s) => s.id === parsed.activeServerId)) {
+    parsed.activeServerId = parsed.servers[0].id;
+  }
+  // Prune connectedServerIds to only existing servers
+  const serverIds = new Set(parsed.servers.map((s) => s.id));
+  parsed.connectedServerIds = parsed.connectedServerIds.filter((id) => serverIds.has(id));
+  // Ensure activeServerId is in connectedServerIds
+  if (parsed.activeServerId && !parsed.connectedServerIds.includes(parsed.activeServerId)) {
+    parsed.connectedServerIds.push(parsed.activeServerId);
+  }
+  return parsed;
+}
+
 function loadRegistry(): ServerRegistry {
   try {
     const stored = localStorage.getItem(STORAGE_KEY);
     if (stored) {
       const parsed = JSON.parse(stored) as ServerRegistry;
       if (parsed.servers?.length > 0) {
-        // Ensure connectedServerIds exists (migration from phase 1 format)
-        if (!parsed.connectedServerIds) {
-          parsed.connectedServerIds = [parsed.activeServerId];
-        }
-        // Migrate: remove stale Cloud preset (it pointed at a broken URL)
-        migrateCloudPreset(parsed);
+        const normalized = normalizeRegistry(parsed);
         // If migration removed all servers, fall through to fresh migration
-        if (parsed.servers.length === 0) return migrateFromLegacy();
-        // Validate activeServerId points to an existing server
-        if (!parsed.servers.some((s) => s.id === parsed.activeServerId)) {
-          parsed.activeServerId = parsed.servers[0].id;
-        }
-        // Prune connectedServerIds to only existing servers
-        const serverIds = new Set(parsed.servers.map((s) => s.id));
-        parsed.connectedServerIds = parsed.connectedServerIds.filter((id) => serverIds.has(id));
-        // Ensure activeServerId is in connectedServerIds
-        if (!parsed.connectedServerIds.includes(parsed.activeServerId)) {
-          parsed.connectedServerIds.push(parsed.activeServerId);
-        }
-        return parsed;
+        if (normalized.servers.length === 0) return migrateFromLegacy();
+        return normalized;
       }
     }
   } catch {
@@ -124,9 +132,16 @@ function normalizeUrl(url: string): string {
 // Initialize the observable
 export const serverRegistry$ = observable<ServerRegistry>(loadRegistry());
 
-// Persist on every change
+// Guard: suppress onChange write-back when we are applying a cross-tab storage event
+// so that the incoming value is not echoed back to localStorage (which would fire
+// another storage event in other tabs and cascade across N tabs).
+let _syncingFromStorage = false;
+
+// Persist on every change (skip during cross-tab sync to prevent cascade)
 serverRegistry$.onChange(({ value }) => {
-  persistRegistry(value);
+  if (!_syncingFromStorage) {
+    persistRegistry(value);
+  }
 });
 
 // Cross-tab sync: re-hydrate when another tab writes gptme_servers to localStorage.
@@ -136,8 +151,12 @@ if (typeof window !== 'undefined') {
   window.addEventListener('storage', (event: StorageEvent) => {
     if (event.key === STORAGE_KEY && event.newValue) {
       try {
-        const updated = JSON.parse(event.newValue) as ServerRegistry;
-        serverRegistry$.set(updated);
+        const parsed = JSON.parse(event.newValue) as ServerRegistry;
+        if (parsed.servers?.length > 0) {
+          _syncingFromStorage = true;
+          serverRegistry$.set(normalizeRegistry(parsed));
+          _syncingFromStorage = false;
+        }
       } catch {
         // Ignore corrupted storage
       }


### PR DESCRIPTION
## Problem

The SetupWizard shows: _"Waiting for sign-in to complete… This window will update automatically once the app connects."_

But the auto-update **never happens** for web browser users. The sign-in flow opens `gptme.ai/authorize` in a new tab (tab B). Tab B gets redirected back to the webui with `#code=...` or `#baseUrl=...&userToken=...` in the URL fragment, `connectionConfig.ts` processes it at page load, and the new server gets written to `localStorage` via `serverRegistry$`.

Tab A (the original wizard) is completely unaware. `serverRegistry$` uses `@legendapp/state`'s `observable`, which writes to `localStorage` on change but does **not** listen for `storage` events from other tabs. The observable is in-memory only — tab A's wizard stays stuck on "Waiting…" forever. The user has to manually refresh to connect.

## Fix

Add a `window.addEventListener('storage', ...)` listener in `stores/servers.ts` that re-hydrates `serverRegistry$` when another tab updates the `gptme_servers` key. The `storage` event fires in all tabs *except* the one that made the write — exactly the cross-tab propagation needed for the auth callback.

## Test plan

- [ ] Click "Sign in to gptme.ai" in the SetupWizard — tab B opens `gptme.ai/authorize`
- [ ] Complete sign-in in tab B — it redirects back to the webui with auth fragment
- [ ] Verify tab A's wizard auto-updates to connected state (no manual refresh needed)
- [ ] Verify no regressions: opening wizard fresh, adding servers manually, switching servers
- [ ] Bonus: open two tabs, connect a server in one — the other tab picks it up automatically

## Notes

- The `typeof window !== 'undefined'` guard handles SSR/non-browser environments
- The listener is one-way (tab B → tab A) which is correct; the writing tab does not receive its own `storage` events
- Found via dogfooding the cloud UX flow