### PR TITLE
fix(webui): refresh stale fallback model to claude-sonnet-4-6

### DIFF
--- a/webui/src/components/ChatInput.tsx
+++ b/webui/src/components/ChatInput.tsx
@@ -518,7 +518,7 @@ export const ChatInput: FC<Props> = ({
   const [selectedModel, setSelectedModel] = useState('');
 
   // Fallback model when no other default is available
-  const fallbackModel = 'anthropic/claude-sonnet-4-20250514';
+  const fallbackModel = 'anthropic/claude-sonnet-4-6';
 
   // Compute the effective model to use (explicit selection or conversation default)
   const effectiveModel = hasExplicitModelSelection


### PR DESCRIPTION
## Summary

Dogfooding the live `chat.gptme.org` first-run flow (no server connected) surfaced that the model picker defaults to and shows `claude-sonnet-4-20250514` — the original May-2025 Sonnet 4, now superseded by Sonnet 4.5/4.6.

The cause is a hardcoded fallback in `webui/src/components/ChatInput.tsx`:

```ts
const fallbackModel = 'anthropic/claude-sonnet-4-20250514';
```

This `fallbackModel` is the last resort when `conversationModel`, `defaultModel`, and `apiDefaultModel` are all empty — exactly the first-run "No gptme server connected" state every new user hits before connecting a server. So new users see an outdated model as the default.

This PR aligns it with the server's own default, `DEFAULT_FALLBACK_MODEL = "anthropic/claude-sonnet-4-6"` in [`gptme/server/constants.py`](https://github.com/gptme/gptme/blob/master/gptme/server/constants.py).

## Reproduction

1. Open https://chat.gptme.org/ with no gptme server connected
2. The model selector shows `claude-sonnet-4-20250514`

(Reproduced live via headless browser; the model picker renders the hardcoded fallback when `/api/v2/models` has no default.)

## Test plan

- [x] `tsc --noEmit` passes
- [ ] CI green