### PR TITLE
docs(skills): note Agent Skills open standard conformance

### DIFF
--- a/docs/features.rst
+++ b/docs/features.rst
@@ -140,7 +140,7 @@ See :doc:`lessons`.
 🧠 Skills
 ^^^^^^^^^
 
-Lightweight workflow bundles (Anthropic format) that auto-load when mentioned by name. Great for packaging reusable instructions and helper scripts.
+Lightweight workflow bundles (`Agents Skills open standard <https://agentskills.io>`_ format) that auto-load when mentioned by name. Great for packaging reusable instructions and helper scripts. Compatible with **26+ tools** (Claude Code, Codex, Cursor, Copilot, Gemini CLI, and more).
 
 See :doc:`skills`.
 

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -140,7 +140,7 @@ See :doc:`lessons`.
 🧠 Skills
 ^^^^^^^^^
 
-Lightweight workflow bundles (`Agents Skills open standard <https://agentskills.io>`_ format) that auto-load when mentioned by name. Great for packaging reusable instructions and helper scripts. Compatible with **26+ tools** (Claude Code, Codex, Cursor, Copilot, Gemini CLI, and more).
+Lightweight workflow bundles (`Agent Skills open standard <https://agentskills.io>`_ format) that auto-load when mentioned by name. Great for packaging reusable instructions and helper scripts. Compatible with **26+ tools** (Claude Code, Codex, Cursor, Copilot, Gemini CLI, and more).
 
 See :doc:`skills`.
 

--- a/docs/skills.rst
+++ b/docs/skills.rst
@@ -1,6 +1,12 @@
 Skills
 ======
 
+gptme's skill system fully conforms to the **`Agent Skills open standard
+<https://agentskills.io>`_**, the cross-vendor format originally developed by
+Anthropic and adopted by 26+ tools (Claude Code, OpenAI Codex, Gemini CLI,
+GitHub Copilot, Cursor, and more). Skills authored for gptme work in those
+tools, and vice versa — the same interop play gptme makes for :doc:`MCP <mcp>`.
+
 .. note::
 
    Skills are a **special case of lessons** using Anthropic's folder-style format.

--- a/docs/skills.rst
+++ b/docs/skills.rst
@@ -16,12 +16,12 @@ tools, and vice versa — the same interop play gptme makes for :doc:`MCP <mcp>`
    :doc:`plugins`.
 
 The skills system extends gptme's :doc:`lessons` to support reusable workflow
-instructions inspired by Anthropic's Skills format and Cursor's rules system.
+instructions following the Agent Skills open standard.
 
 Overview
 --------
 
-**Skills** are lessons that follow Anthropic's format and can include:
+**Skills** are lessons that follow the Agent Skills open standard format and can include:
 
 - Instructional content (like lessons)
 - References to helper files colocated with ``SKILL.md``
@@ -105,7 +105,7 @@ Skill vs. Lesson vs. Plugin
 Skill Format
 ------------
 
-Skills use YAML frontmatter following Anthropic's format:
+Skills use YAML frontmatter following the Agent Skills open standard format:
 
 .. code-block:: yaml
 
@@ -139,7 +139,7 @@ Skills are organized parallel to lessons:
         ├── tools/        # Tool-specific lessons
         ├── patterns/     # General patterns
         ├── workflows/    # Workflow lessons
-        └── skills/       # Skills (Anthropic format)
+        └── skills/       # Skills (Agent Skills open standard format)
             └── python-repl/
                 ├── SKILL.md
                 ├── python_helpers.py
@@ -199,7 +199,7 @@ Identify:
 
 Create a skill directory in one of the `supported paths`_ above (e.g. ``~/.config/gptme/skills/skill-name/`` or ``./skills/skill-name/``) with at minimum:
 
-**SKILL.md** (Anthropic format):
+**SKILL.md** (Agent Skills open standard format):
 
 .. code-block:: yaml
 
@@ -259,7 +259,7 @@ You may place helper scripts in the same directory as the skill for manual use:
 What Skills Support (and Don't)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To stay compatible with the Anthropic Skills format and avoid inventing
+To stay compatible with the Agent Skills open standard and avoid inventing
 tool-specific conventions, gptme currently supports:
 
 - Skill discovery and listing

--- a/docs/skills.rst
+++ b/docs/skills.rst
@@ -1,15 +1,15 @@
 Skills
 ======
 
-gptme's skill system fully conforms to the **`Agent Skills open standard
-<https://agentskills.io>`_**, the cross-vendor format originally developed by
+gptme's skill system fully conforms to the `Agent Skills open standard
+<https://agentskills.io>`_, the cross-vendor format originally developed by
 Anthropic and adopted by 26+ tools (Claude Code, OpenAI Codex, Gemini CLI,
 GitHub Copilot, Cursor, and more). Skills authored for gptme work in those
 tools, and vice versa — the same interop play gptme makes for :doc:`MCP <mcp>`.
 
 .. note::
 
-   Skills are a **special case of lessons** using Anthropic's folder-style format.
+   Skills are a **special case of lessons** using the Agent Skills open standard format.
    In gptme, skills auto-load when their **name appears in the message** (e.g.,
    mentioning "python-repl" loads that skill). This differs from lessons which
    auto-load by keywords/patterns/tools. For deep runtime integration, use


### PR DESCRIPTION
Documents that gptme's skill system conforms to the [Agent Skills open standard](https://agentskills.io),
the cross-vendor format adopted by 26+ tools (Claude Code, OpenAI Codex, Gemini CLI, etc.).

**Changes:**
- `docs/skills.rst`: Added conformance note at top
- `docs/features.rst`: Updated Skills mention to note interop

No code changes — documentation positioning update.