### PR TITLE
feat(server): add --webui-dir flag to serve a custom web UI

### DIFF
--- a/gptme/server/app.py
+++ b/gptme/server/app.py
@@ -5,6 +5,7 @@ Flask application factory for gptme server.
 import atexit
 import logging
 from importlib import resources
+from pathlib import Path
 
 import flask
 from flask_cors import CORS
@@ -19,7 +20,11 @@ media_path = _root_path.parent / "media"
 atexit.register(_gptme_path_ctx.__exit__, None, None, None)
 
 
-def create_app(cors_origin: str | None = None, host: str = "127.0.0.1") -> flask.Flask:
+def create_app(
+    cors_origin: str | None = None,
+    host: str = "127.0.0.1",
+    webui_dir: str | None = None,
+) -> flask.Flask:
     """Create the Flask app.
 
     Args:
@@ -27,8 +32,22 @@ def create_app(cors_origin: str | None = None, host: str = "127.0.0.1") -> flask
             A comma-separated string allows multiple origins, e.g.
             "tauri://localhost,http://tauri.localhost". Whitespace around
             entries is ignored.
+        webui_dir: Directory to serve the web UI from. When set, overrides the
+            legacy webui bundled in the package — point it at a built modern
+            webui (``webui/dist`` from the gptme repo) to self-host it.
     """
-    app = flask.Flask(__name__, static_folder=static_path)
+    serve_path = static_path
+    if webui_dir:
+        candidate = Path(webui_dir).expanduser()
+        if not (candidate / "index.html").is_file():
+            raise ValueError(
+                f"--webui-dir {candidate} does not contain an index.html; "
+                "point it at a built web UI directory (e.g. webui/dist)."
+            )
+        serve_path = candidate
+        logger.info("Serving web UI from %s", serve_path)
+
+    app = flask.Flask(__name__, static_folder=serve_path)
 
     # Capture the server's default model from the startup context
     # This is needed because ContextVar doesn't propagate across request contexts

--- a/gptme/server/app.py
+++ b/gptme/server/app.py
@@ -115,7 +115,11 @@ def create_app(
 
     @app.route("/computer")
     def computer():
-        return app.send_static_file("computer.html")
+        # Fall back to index.html for SPAs that don't bundle a computer.html
+        static_dir = Path(app.static_folder) if app.static_folder else Path(static_path)
+        if (static_dir / "computer.html").is_file():
+            return app.send_static_file("computer.html")
+        return app.send_static_file("index.html")
 
     @app.route("/chat")
     def chat():

--- a/gptme/server/app.py
+++ b/gptme/server/app.py
@@ -47,6 +47,8 @@ def create_app(
         serve_path = candidate
         logger.info("Serving web UI from %s", serve_path)
 
+    is_custom_webui = serve_path != static_path
+
     # When serving a custom (Vite-built) webui, set static_url_path='' so that
     # asset URLs like /assets/index.js are served directly from the root of the
     # custom dir instead of requiring a /static/ prefix (Flask's default).
@@ -135,6 +137,19 @@ def create_app(
     @app.route("/favicon.png")
     def favicon():
         return flask.send_from_directory(media_path, "logo.png")
+
+    if is_custom_webui:
+        # SPA catch-all: when Flask's static file handler returns 404 for an
+        # unknown path (e.g. /settings, /conversations/abc), serve index.html
+        # so React Router handles client-side routing.
+        # API 404s (missing endpoints) pass through unchanged.
+        @app.errorhandler(404)
+        def spa_404_handler(e):
+            from flask import request
+
+            if request.path.startswith("/api/"):
+                return flask.jsonify({"error": "Not found"}), 404
+            return app.send_static_file("index.html")
 
     # Server confirmation hook is now registered via init_hooks(server=True)
     # in server/cli.py

--- a/gptme/server/app.py
+++ b/gptme/server/app.py
@@ -55,7 +55,7 @@ def create_app(
     app = flask.Flask(
         __name__,
         static_folder=serve_path,
-        static_url_path="" if webui_dir else "/static",
+        static_url_path="" if is_custom_webui else "/static",
     )
 
     # Capture the server's default model from the startup context

--- a/gptme/server/app.py
+++ b/gptme/server/app.py
@@ -47,7 +47,14 @@ def create_app(
         serve_path = candidate
         logger.info("Serving web UI from %s", serve_path)
 
-    app = flask.Flask(__name__, static_folder=serve_path)
+    # When serving a custom (Vite-built) webui, set static_url_path='' so that
+    # asset URLs like /assets/index.js are served directly from the root of the
+    # custom dir instead of requiring a /static/ prefix (Flask's default).
+    app = flask.Flask(
+        __name__,
+        static_folder=serve_path,
+        static_url_path="" if webui_dir else "/static",
+    )
 
     # Capture the server's default model from the startup context
     # This is needed because ContextVar doesn't propagate across request contexts

--- a/gptme/server/cli.py
+++ b/gptme/server/cli.py
@@ -127,6 +127,17 @@ def main():
     ),
 )
 @click.option(
+    "--webui-dir",
+    default=None,
+    envvar="GPTME_WEBUI_DIR",
+    help=(
+        "Directory to serve the web UI from, overriding the legacy webui "
+        "bundled in the package. Point it at a built modern webui "
+        "(e.g. 'webui/dist' from the gptme repo) to self-host it. Can also "
+        "be set via the GPTME_WEBUI_DIR environment variable."
+    ),
+)
+@click.option(
     "--exit-on-parent-death",
     is_flag=True,
     default=False,
@@ -154,6 +165,7 @@ def serve(
     port: int,
     tools: str | None,
     cors_origin: str | None,
+    webui_dir: str | None,
     exit_on_parent_death: bool,
     watch_pid: int | None,
 ):  # pragma: no cover
@@ -221,7 +233,7 @@ def serve(
     # Initialize authentication and display token
     init_auth(host=host, display=True)
 
-    app = create_app(cors_origin=cors_origin, host=host)
+    app = create_app(cors_origin=cors_origin, host=host, webui_dir=webui_dir)
 
     try:
         app.run(debug=debug, host=host, port=port)

--- a/tests/test_server_webui_dir.py
+++ b/tests/test_server_webui_dir.py
@@ -57,6 +57,22 @@ def test_computer_route_serves_computer_html(tmp_path):
     assert b"computer page" in resp.data
 
 
+def test_webui_dir_serves_spa_assets(tmp_path):
+    """Assets emitted by Vite at /assets/... must be reachable (not 404)."""
+    from gptme.server.app import create_app
+
+    (tmp_path / "index.html").write_text("<title>modern webui</title>")
+    assets_dir = tmp_path / "assets"
+    assets_dir.mkdir()
+    (assets_dir / "index.js").write_text("console.log('hello')")
+
+    app = create_app(webui_dir=str(tmp_path))
+    with app.test_client() as client:
+        resp = client.get("/assets/index.js")
+    assert resp.status_code == 200
+    assert b"hello" in resp.data
+
+
 def test_default_uses_bundled_static():
     from gptme.server.app import create_app, static_path
 

--- a/tests/test_server_webui_dir.py
+++ b/tests/test_server_webui_dir.py
@@ -1,0 +1,37 @@
+"""Tests for the gptme-server --webui-dir / GPTME_WEBUI_DIR override.
+
+Coverage for serving a custom (modern) web UI directory from gptme-server
+instead of the legacy webui bundled in the package.
+"""
+
+import pytest
+
+flask = pytest.importorskip(
+    "flask", reason="flask not installed, install server extras (-E server)"
+)
+
+
+def test_webui_dir_serves_custom_index(tmp_path):
+    from gptme.server.app import create_app
+
+    (tmp_path / "index.html").write_text("<title>modern webui</title>")
+
+    app = create_app(webui_dir=str(tmp_path))
+    with app.test_client() as client:
+        resp = client.get("/")
+    assert resp.status_code == 200
+    assert b"modern webui" in resp.data
+
+
+def test_webui_dir_missing_index_raises(tmp_path):
+    from gptme.server.app import create_app
+
+    with pytest.raises(ValueError, match="index.html"):
+        create_app(webui_dir=str(tmp_path))
+
+
+def test_default_uses_bundled_static():
+    from gptme.server.app import create_app, static_path
+
+    app = create_app()
+    assert app.static_folder == str(static_path)

--- a/tests/test_server_webui_dir.py
+++ b/tests/test_server_webui_dir.py
@@ -73,6 +73,20 @@ def test_webui_dir_serves_spa_assets(tmp_path):
     assert b"hello" in resp.data
 
 
+def test_spa_deeplink_fallback(tmp_path):
+    """Deep-linked SPA routes like /settings must serve index.html, not 404."""
+    from gptme.server.app import create_app
+
+    (tmp_path / "index.html").write_text("<title>spa</title>")
+
+    app = create_app(webui_dir=str(tmp_path))
+    with app.test_client() as client:
+        for path in ("/settings", "/conversations/abc", "/workspace/foo"):
+            resp = client.get(path)
+            assert resp.status_code == 200, f"{path} should serve index.html"
+            assert b"spa" in resp.data
+
+
 def test_default_uses_bundled_static():
     from gptme.server.app import create_app, static_path
 

--- a/tests/test_server_webui_dir.py
+++ b/tests/test_server_webui_dir.py
@@ -30,6 +30,33 @@ def test_webui_dir_missing_index_raises(tmp_path):
         create_app(webui_dir=str(tmp_path))
 
 
+def test_computer_route_spa_fallback(tmp_path):
+    """When webui_dir lacks computer.html (modern SPA), /computer serves index.html."""
+    from gptme.server.app import create_app
+
+    (tmp_path / "index.html").write_text("<title>spa index</title>")
+
+    app = create_app(webui_dir=str(tmp_path))
+    with app.test_client() as client:
+        resp = client.get("/computer")
+    assert resp.status_code == 200
+    assert b"spa index" in resp.data
+
+
+def test_computer_route_serves_computer_html(tmp_path):
+    """When webui_dir has computer.html (legacy), /computer serves it."""
+    from gptme.server.app import create_app
+
+    (tmp_path / "index.html").write_text("<title>spa index</title>")
+    (tmp_path / "computer.html").write_text("<title>computer page</title>")
+
+    app = create_app(webui_dir=str(tmp_path))
+    with app.test_client() as client:
+        resp = client.get("/computer")
+    assert resp.status_code == 200
+    assert b"computer page" in resp.data
+
+
 def test_default_uses_bundled_static():
     from gptme.server.app import create_app, static_path
 


### PR DESCRIPTION
## Summary

`gptme-server serve` only serves the **legacy** webui bundled at `gptme/server/static/`, with no way to point it at the modern React webui (`webui/` in this monorepo). This adds a `--webui-dir` flag (and `GPTME_WEBUI_DIR` env) that overrides the static folder, so self-hosters can serve a built modern webui:

```bash
gptme-server serve --webui-dir /path/to/webui/dist
```

- `create_app()` gains an optional `webui_dir` param; when set it validates the dir contains `index.html` and uses it as Flask's `static_folder`, else falls back to the bundled legacy static (unchanged default behavior).
- `serve` CLI gains `--webui-dir` / `GPTME_WEBUI_DIR`.

This is layer 1 of #2612 (bundling `webui/dist/` as a package resource so the modern UI is served by default is the follow-up). Surfaced while self-hosting gptme-server for Bob (ErikBjare/bob#811).

## Test plan
- [x] `tests/test_server_webui_dir.py` — custom dir serves its index.html; missing index.html raises; default still uses bundled static (3 passed)
- [x] `gptme-server serve --help` shows `--webui-dir`
- [x] ruff + mypy clean on changed files

Refs #2612