### PR TITLE
feat(server): add --webui-dir flag to serve a custom web UI build

### DIFF
--- a/gptme/server/app.py
+++ b/gptme/server/app.py
@@ -4,7 +4,9 @@ Flask application factory for gptme server.
 
 import atexit
 import logging
+import os
 from importlib import resources
+from pathlib import Path
 
 import flask
 from flask_cors import CORS
@@ -19,7 +21,29 @@ media_path = _root_path.parent / "media"
 atexit.register(_gptme_path_ctx.__exit__, None, None, None)
 
 
-def create_app(cors_origin: str | None = None, host: str = "127.0.0.1") -> flask.Flask:
+def _resolve_static_folder(webui_dir: str | Path | None = None) -> Path:
+    """Resolve which directory the web UI is served from.
+
+    Precedence: explicit ``webui_dir`` argument > ``GPTME_WEBUI_DIR`` env var >
+    the embedded legacy static bundle. A configured directory must exist so
+    that a typo fails loudly at startup instead of silently serving 404s.
+    """
+    candidate = webui_dir or os.environ.get("GPTME_WEBUI_DIR")
+    if not candidate:
+        return static_path
+    path = Path(candidate).expanduser()
+    if not path.is_dir():
+        raise FileNotFoundError(
+            f"webui_dir does not exist or is not a directory: {path}"
+        )
+    return path
+
+
+def create_app(
+    cors_origin: str | None = None,
+    host: str = "127.0.0.1",
+    webui_dir: str | Path | None = None,
+) -> flask.Flask:
     """Create the Flask app.
 
     Args:
@@ -27,8 +51,13 @@ def create_app(cors_origin: str | None = None, host: str = "127.0.0.1") -> flask
             A comma-separated string allows multiple origins, e.g.
             "tauri://localhost,http://tauri.localhost". Whitespace around
             entries is ignored.
+        webui_dir: Optional directory containing a web UI build (e.g. the
+            modern React webui's ``dist/``) to serve instead of the bundled
+            legacy UI. Falls back to the ``GPTME_WEBUI_DIR`` environment
+            variable, then to the embedded legacy static bundle.
     """
-    app = flask.Flask(__name__, static_folder=static_path)
+    static_folder = _resolve_static_folder(webui_dir)
+    app = flask.Flask(__name__, static_folder=static_folder)
 
     # Capture the server's default model from the startup context
     # This is needed because ContextVar doesn't propagate across request contexts

--- a/gptme/server/app.py
+++ b/gptme/server/app.py
@@ -118,6 +118,10 @@ def create_app(
 
     init_auth(host=host, display=False)
 
+    # Track whether we're serving a custom webui build (not the legacy bundle).
+    # Used below to gate SPA-specific route behaviour.
+    is_custom_webui = static_folder != static_path
+
     # Register static file routes directly on the app
     @app.route("/")
     def root():
@@ -125,6 +129,10 @@ def create_app(
 
     @app.route("/computer")
     def computer():
+        # Legacy bundle ships computer.html; a custom React build does not —
+        # fall back to index.html and let client-side routing take over.
+        if is_custom_webui or not (static_folder / "computer.html").exists():
+            return app.send_static_file("index.html")
         return app.send_static_file("computer.html")
 
     @app.route("/chat")
@@ -134,6 +142,18 @@ def create_app(
     @app.route("/favicon.png")
     def favicon():
         return flask.send_from_directory(media_path, "logo.png")
+
+    if is_custom_webui:
+        # SPA catch-all: serve any unknown path as index.html so that React
+        # Router deep-links (/settings, /conversations/xyz, …) work correctly.
+        # Actual static assets (JS/CSS/images) are served first because their
+        # paths exist in static_folder; only truly unknown paths fall through.
+        @app.route("/<path:path>")
+        def spa_fallback(path: str):
+            asset = static_folder / path
+            if asset.is_file():
+                return app.send_static_file(path)
+            return app.send_static_file("index.html")
 
     # Server confirmation hook is now registered via init_hooks(server=True)
     # in server/cli.py

--- a/gptme/server/cli.py
+++ b/gptme/server/cli.py
@@ -127,6 +127,17 @@ def main():
     ),
 )
 @click.option(
+    "--webui-dir",
+    type=click.Path(exists=True, file_okay=False, dir_okay=True, path_type=Path),
+    default=None,
+    envvar="GPTME_WEBUI_DIR",
+    help=(
+        "Directory containing a web UI build (e.g. the modern React webui's "
+        "dist/) to serve instead of the bundled legacy UI. Can also be set "
+        "via the GPTME_WEBUI_DIR environment variable."
+    ),
+)
+@click.option(
     "--exit-on-parent-death",
     is_flag=True,
     default=False,
@@ -154,6 +165,7 @@ def serve(
     port: int,
     tools: str | None,
     cors_origin: str | None,
+    webui_dir: Path | None,
     exit_on_parent_death: bool,
     watch_pid: int | None,
 ):  # pragma: no cover
@@ -221,7 +233,7 @@ def serve(
     # Initialize authentication and display token
     init_auth(host=host, display=True)
 
-    app = create_app(cors_origin=cors_origin, host=host)
+    app = create_app(cors_origin=cors_origin, host=host, webui_dir=webui_dir)
 
     try:
         app.run(debug=debug, host=host, port=port)

--- a/tests/test_server_webui_dir.py
+++ b/tests/test_server_webui_dir.py
@@ -64,3 +64,53 @@ def test_missing_webui_dir_raises(tmp_path):
     missing = tmp_path / "does-not-exist"
     with pytest.raises(FileNotFoundError):
         create_app(webui_dir=missing)
+
+
+def test_computer_route_falls_back_to_index_for_custom_webui(tmp_path):
+    """Custom webui builds (React/Vite) don't ship computer.html; /computer must
+    serve index.html so client-side routing handles it instead of 404-ing."""
+    from gptme.server.app import create_app
+
+    (tmp_path / "index.html").write_text("<html>spa</html>")
+    # Intentionally no computer.html in tmp_path
+    app = create_app(webui_dir=tmp_path)
+
+    with app.test_client() as client:
+        resp = client.get("/computer")
+        assert resp.status_code == 200
+        assert b"spa" in resp.data
+
+
+def test_spa_catch_all_serves_index_for_unknown_paths(tmp_path):
+    """Unknown deep-link paths (e.g. /settings, /conversations/xyz) should
+    return index.html when a custom webui dir is configured."""
+    from gptme.server.app import create_app
+
+    (tmp_path / "index.html").write_text("<html>spa</html>")
+    app = create_app(webui_dir=tmp_path)
+
+    with app.test_client() as client:
+        resp = client.get("/settings")
+        assert resp.status_code == 200
+        assert b"spa" in resp.data
+
+        resp = client.get("/conversations/some-id")
+        assert resp.status_code == 200
+        assert b"spa" in resp.data
+
+
+def test_spa_catch_all_serves_actual_asset_files(tmp_path):
+    """Existing static assets (JS/CSS/images) must be served as-is, not
+    replaced with index.html, when the custom webui dir is active."""
+    from gptme.server.app import create_app
+
+    (tmp_path / "index.html").write_text("<html>spa</html>")
+    assets = tmp_path / "assets"
+    assets.mkdir()
+    (assets / "main.js").write_text("console.log('hi')")
+    app = create_app(webui_dir=tmp_path)
+
+    with app.test_client() as client:
+        resp = client.get("/assets/main.js")
+        assert resp.status_code == 200
+        assert b"console.log" in resp.data

--- a/tests/test_server_webui_dir.py
+++ b/tests/test_server_webui_dir.py
@@ -1,0 +1,66 @@
+"""Tests for serving a custom web UI directory from gptme-server.
+
+Coverage for gptme/gptme#2612: a self-hoster can point gptme-server at the
+modern React webui build via ``--webui-dir`` / ``GPTME_WEBUI_DIR`` instead of
+the bundled legacy static UI.
+"""
+
+import pytest
+
+flask = pytest.importorskip(
+    "flask", reason="flask not installed, install server extras (-E server)"
+)
+pytest.importorskip(
+    "flask_cors", reason="flask-cors not installed, install server extras (-E server)"
+)
+
+
+def test_default_static_folder_is_legacy_bundle():
+    from gptme.server.app import create_app, static_path
+
+    app = create_app()
+    assert app.static_folder == str(static_path)
+
+
+def test_webui_dir_arg_overrides_static_folder(tmp_path):
+    from gptme.server.app import create_app
+
+    (tmp_path / "index.html").write_text("<html>modern</html>")
+    app = create_app(webui_dir=tmp_path)
+
+    assert app.static_folder == str(tmp_path)
+    with app.test_client() as client:
+        resp = client.get("/")
+        assert resp.status_code == 200
+        assert b"modern" in resp.data
+
+
+def test_webui_dir_env_var_overrides_static_folder(tmp_path, monkeypatch):
+    from gptme.server.app import create_app
+
+    (tmp_path / "index.html").write_text("<html>env-modern</html>")
+    monkeypatch.setenv("GPTME_WEBUI_DIR", str(tmp_path))
+    app = create_app()
+
+    assert app.static_folder == str(tmp_path)
+
+
+def test_webui_dir_arg_takes_precedence_over_env(tmp_path, monkeypatch):
+    from gptme.server.app import create_app
+
+    arg_dir = tmp_path / "arg"
+    env_dir = tmp_path / "env"
+    arg_dir.mkdir()
+    env_dir.mkdir()
+    monkeypatch.setenv("GPTME_WEBUI_DIR", str(env_dir))
+    app = create_app(webui_dir=arg_dir)
+
+    assert app.static_folder == str(arg_dir)
+
+
+def test_missing_webui_dir_raises(tmp_path):
+    from gptme.server.app import create_app
+
+    missing = tmp_path / "does-not-exist"
+    with pytest.raises(FileNotFoundError):
+        create_app(webui_dir=missing)


### PR DESCRIPTION
## Summary

Implements layer 1 of #2612: lets `gptme-server serve` serve a custom web UI build (e.g. the modern React webui's `dist/`) instead of the bundled **legacy** static UI.

- New `--webui-dir` CLI flag + `GPTME_WEBUI_DIR` env var, threaded into `create_app(webui_dir=...)`.
- Precedence: explicit `webui_dir` arg → `GPTME_WEBUI_DIR` env → embedded legacy static bundle (unchanged default).
- A configured directory must exist, so a typo fails loudly at startup instead of silently serving 404s.

This unblocks self-hosters (surfaced while self-hosting gptme-server for Bob, ErikBjare/bob#811): instead of the two-port workaround (`:5700` API + a separate `:5701` standalone webui), point one server at the build:

```
gptme-server serve --webui-dir /path/to/webui/dist
# or
GPTME_WEBUI_DIR=/path/to/webui/dist gptme-server serve
```

Layer 2 from the issue — bundling `webui/dist/` inside the wheel so the modern UI is the default out of the box — is a CI/packaging follow-up and intentionally **not** in this PR.

## Test plan

- [x] `tests/test_server_webui_dir.py` (5 new tests): default uses legacy bundle; arg and env override `static_folder`; arg takes precedence over env; serving `index.html` from the custom dir works; missing dir raises `FileNotFoundError`.
- [x] `tests/test_server_cors.py` still green (no regression in `create_app`).
- [x] `mypy` clean on `app.py` / `cli.py`; `--webui-dir` shows in `gptme-server serve --help`.

Closes #2612 (layer 1).