### PR TITLE
fix(webui): hint when hosted chat hits loopback without CORS

### DIFF
--- a/webui/src/components/WelcomeView.tsx
+++ b/webui/src/components/WelcomeView.tsx
@@ -201,7 +201,7 @@ export const WelcomeView = () => {
         // and the hint would be a false positive — connect directly instead.
         try {
           await fetch(probeUrl, { cache: 'no-store', signal: controller.signal });
-          if (!cancelled) connect(); // CORS is already configured; auto-connect
+          if (!cancelled) void connect(); // CORS is already configured; auto-connect
           return;
         } catch {
           if (controller.signal.aborted || cancelled) return;

--- a/webui/src/components/WelcomeView.tsx
+++ b/webui/src/components/WelcomeView.tsx
@@ -195,23 +195,36 @@ export const WelcomeView = () => {
     const timeoutId = window.setTimeout(() => controller.abort(), 2500);
     let cancelled = false;
 
-    fetch(
-      probeUrl,
-      withLocalAddressSpace(probeUrl, {
-        mode: 'no-cors',
-        cache: 'no-store',
-        signal: controller.signal,
-      })
-    )
-      .then(() => {
+    const runProbe = async () => {
+      try {
+        // First try a regular CORS fetch. If it succeeds, CORS is already configured
+        // and the hint would be a false positive — suppress it.
+        try {
+          await fetch(probeUrl, { cache: 'no-store', signal: controller.signal });
+          if (!cancelled) setHostedLoopbackReachable(false);
+          return;
+        } catch {
+          if (controller.signal.aborted || cancelled) return;
+        }
+        // CORS fetch failed; probe with no-cors to confirm the server is running at all.
+        // If this succeeds the server is up but not yet allowing cross-origin requests.
+        await fetch(
+          probeUrl,
+          withLocalAddressSpace(probeUrl, {
+            mode: 'no-cors',
+            cache: 'no-store',
+            signal: controller.signal,
+          })
+        );
         if (!cancelled) setHostedLoopbackReachable(true);
-      })
-      .catch(() => {
+      } catch {
         if (!cancelled) setHostedLoopbackReachable(false);
-      })
-      .finally(() => {
+      } finally {
         window.clearTimeout(timeoutId);
-      });
+      }
+    };
+
+    runProbe();
 
     return () => {
       cancelled = true;

--- a/webui/src/components/WelcomeView.tsx
+++ b/webui/src/components/WelcomeView.tsx
@@ -22,6 +22,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import { withLocalAddressSpace } from '@/utils/addressSpace';
 import { isLikelyChromeCorsPna } from '@/utils/api';
 
 const DEFAULT_LOCAL_SERVER_URLS = new Set(['http://127.0.0.1:5700', 'http://localhost:5700']);
@@ -30,6 +31,7 @@ export const WelcomeView = () => {
   const [inputValue, setInputValue] = useState(
     () => (typeof window !== 'undefined' ? localStorage.getItem('gptme-draft-new') : null) || ''
   );
+  const [hostedLoopbackReachable, setHostedLoopbackReachable] = useState(false);
   // Persist new-chat draft to localStorage
   useEffect(() => {
     if (typeof window === 'undefined') return;
@@ -179,6 +181,44 @@ export const WelcomeView = () => {
     if (reason === 'cors') return isLikelyChromeCorsPna(url) ? 'pna' : 'cors';
     return reason; // 'network' | 'timeout' | 'http_error' | 'parse_error'
   })();
+  const showHostedLoopbackCorsHint =
+    errorBucket === 'unknown' && isDefaultLocalServer && isHostedOrigin && hostedLoopbackReachable;
+
+  useEffect(() => {
+    if (isConnected || !isDefaultLocalServer || !isHostedOrigin || errorBucket !== 'unknown') {
+      setHostedLoopbackReachable(false);
+      return;
+    }
+
+    const probeUrl = `${activeServerBaseUrl}/api/v2`;
+    const controller = new AbortController();
+    const timeoutId = window.setTimeout(() => controller.abort(), 2500);
+    let cancelled = false;
+
+    fetch(
+      probeUrl,
+      withLocalAddressSpace(probeUrl, {
+        mode: 'no-cors',
+        cache: 'no-store',
+        signal: controller.signal,
+      })
+    )
+      .then(() => {
+        if (!cancelled) setHostedLoopbackReachable(true);
+      })
+      .catch(() => {
+        if (!cancelled) setHostedLoopbackReachable(false);
+      })
+      .finally(() => {
+        window.clearTimeout(timeoutId);
+      });
+
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timeoutId);
+      controller.abort();
+    };
+  }, [activeServerBaseUrl, errorBucket, isConnected, isDefaultLocalServer, isHostedOrigin]);
 
   const disconnectedDesc = (() => {
     if (errorBucket === 'network') {
@@ -194,6 +234,9 @@ export const WelcomeView = () => {
     }
     if (errorBucket === 'timeout') {
       return 'The connection timed out — the server may be starting up or unreachable. Retry in a moment.';
+    }
+    if (showHostedLoopbackCorsHint) {
+      return `The local gptme server appears to be running, but it is not allowing requests from ${window.location.origin} yet. Restart it with --cors-origin to allow this page.`;
     }
     return isDefaultLocalServer
       ? 'Start a local gptme server or point the app at another server before starting a chat.'
@@ -237,13 +280,15 @@ export const WelcomeView = () => {
               <Alert className="mx-auto w-full max-w-2xl border-amber-500/30 bg-amber-500/10 text-left">
                 <Server className="h-4 w-4 text-amber-700 dark:text-amber-300" />
                 <AlertTitle>
-                  {isDefaultLocalServer
-                    ? 'No gptme server connected'
-                    : `Cannot reach ${activeServer?.name || 'the configured server'}`}
+                  {showHostedLoopbackCorsHint || (isDefaultLocalServer && errorBucket === 'cors')
+                    ? 'Local gptme server needs browser access'
+                    : isDefaultLocalServer
+                      ? 'No gptme server connected'
+                      : `Cannot reach ${activeServer?.name || 'the configured server'}`}
                 </AlertTitle>
                 <AlertDescription className="space-y-3">
                   <p>{disconnectedDesc}</p>
-                  {errorBucket === 'cors' && (
+                  {(errorBucket === 'cors' || showHostedLoopbackCorsHint) && (
                     <code className="block rounded-md border border-amber-500/20 bg-background/80 px-3 py-2 font-mono text-xs">
                       {serverCommand}
                     </code>
@@ -266,29 +311,32 @@ export const WelcomeView = () => {
                       using the managed gptme.ai option — no copy-pasting required.
                     </p>
                   )}
-                  {isDefaultLocalServer && !isFirstVisit && errorBucket !== 'cors' && (
-                    <div className="space-y-2">
-                      <p className="text-xs text-muted-foreground">
-                        New to gptme? Install it, then start a server:
-                      </p>
-                      <code className="block rounded-md border border-amber-500/20 bg-background/80 px-3 py-2 font-mono text-xs">
-                        {installCommand}
-                      </code>
-                      <code className="block rounded-md border border-amber-500/20 bg-background/80 px-3 py-2 font-mono text-xs">
-                        {serverCommand}
-                      </code>
-                      {errorBucket !== 'pna' && isHostedOrigin && (
+                  {isDefaultLocalServer &&
+                    !isFirstVisit &&
+                    errorBucket !== 'cors' &&
+                    !showHostedLoopbackCorsHint && (
+                      <div className="space-y-2">
                         <p className="text-xs text-muted-foreground">
-                          On Chrome 142+ (and other Chromium browsers), the first connection to a
-                          local server also triggers a{' '}
-                          <span className="font-medium">Local Network Access</span> permission
-                          prompt. Click <span className="font-medium">Allow</span> so this page can
-                          reach <code>localhost</code> — the <code>--cors-origin</code> flag alone
-                          is not enough.
+                          New to gptme? Install it, then start a server:
                         </p>
-                      )}
-                    </div>
-                  )}
+                        <code className="block rounded-md border border-amber-500/20 bg-background/80 px-3 py-2 font-mono text-xs">
+                          {installCommand}
+                        </code>
+                        <code className="block rounded-md border border-amber-500/20 bg-background/80 px-3 py-2 font-mono text-xs">
+                          {serverCommand}
+                        </code>
+                        {errorBucket !== 'pna' && isHostedOrigin && (
+                          <p className="text-xs text-muted-foreground">
+                            On Chrome 142+ (and other Chromium browsers), the first connection to a
+                            local server also triggers a{' '}
+                            <span className="font-medium">Local Network Access</span> permission
+                            prompt. Click <span className="font-medium">Allow</span> so this page
+                            can reach <code>localhost</code> — the <code>--cors-origin</code> flag
+                            alone is not enough.
+                          </p>
+                        )}
+                      </div>
+                    )}
                   <div className="flex flex-wrap gap-2">
                     {showGuidedSetup && (
                       <Button

--- a/webui/src/components/WelcomeView.tsx
+++ b/webui/src/components/WelcomeView.tsx
@@ -198,10 +198,10 @@ export const WelcomeView = () => {
     const runProbe = async () => {
       try {
         // First try a regular CORS fetch. If it succeeds, CORS is already configured
-        // and the hint would be a false positive — suppress it.
+        // and the hint would be a false positive — connect directly instead.
         try {
           await fetch(probeUrl, { cache: 'no-store', signal: controller.signal });
-          if (!cancelled) setHostedLoopbackReachable(false);
+          if (!cancelled) connect(); // CORS is already configured; auto-connect
           return;
         } catch {
           if (controller.signal.aborted || cancelled) return;
@@ -231,7 +231,14 @@ export const WelcomeView = () => {
       window.clearTimeout(timeoutId);
       controller.abort();
     };
-  }, [activeServerBaseUrl, errorBucket, isConnected, isDefaultLocalServer, isHostedOrigin]);
+  }, [
+    activeServerBaseUrl,
+    connect,
+    errorBucket,
+    isConnected,
+    isDefaultLocalServer,
+    isHostedOrigin,
+  ]);
 
   const disconnectedDesc = (() => {
     if (errorBucket === 'network') {

--- a/webui/src/components/__tests__/WelcomeView.test.tsx
+++ b/webui/src/components/__tests__/WelcomeView.test.tsx
@@ -210,7 +210,8 @@ describe('WelcomeView', () => {
     seedReturningUser();
     setLocation('https://chat.gptme.org/');
     isConnected$.set(false);
-    mockFetch.mockResolvedValue({ ok: true });
+    // Simulate: CORS fetch blocked (server running, no --cors-origin), no-cors probe succeeds.
+    mockFetch.mockRejectedValueOnce(new TypeError('Failed to fetch')).mockResolvedValueOnce({});
 
     render(
       <SettingsProvider>
@@ -226,7 +227,15 @@ describe('WelcomeView', () => {
       screen.getByText(/gptme-server --cors-origin='https:\/\/chat\.gptme\.org'/i)
     ).toBeInTheDocument();
     expect(screen.queryByText(/Install it, then start a server/i)).not.toBeInTheDocument();
-    expect(mockFetch).toHaveBeenCalledWith(
+    // First call: CORS probe (no mode: no-cors).
+    expect(mockFetch).toHaveBeenNthCalledWith(
+      1,
+      'http://localhost:5700/api/v2',
+      expect.objectContaining({ cache: 'no-store' })
+    );
+    // Second call: no-cors probe confirms server is running but CORS is blocking.
+    expect(mockFetch).toHaveBeenNthCalledWith(
+      2,
       'http://localhost:5700/api/v2',
       expect.objectContaining({
         mode: 'no-cors',

--- a/webui/src/components/__tests__/WelcomeView.test.tsx
+++ b/webui/src/components/__tests__/WelcomeView.test.tsx
@@ -21,6 +21,20 @@ let mockBaseUrl = 'http://localhost:5700';
 // Controls whether isLikelyChromeCorsPna() classifies the last probe URL as PNA.
 const mockIsLikelyChromeCorsPna = jest.fn().mockReturnValue(false);
 
+const setLocation = (href: string) => {
+  const url = new URL(href);
+  Object.defineProperty(window, 'location', {
+    value: {
+      ...window.location,
+      href: url.href,
+      origin: url.origin,
+      hostname: url.hostname,
+    },
+    writable: true,
+    configurable: true,
+  });
+};
+
 jest.mock('@/utils/api', () => ({
   isLikelyChromeCorsPna: (...args: unknown[]) => mockIsLikelyChromeCorsPna(...args),
 }));
@@ -84,6 +98,7 @@ describe('WelcomeView', () => {
   beforeEach(() => {
     // Default to a first-time user (no stored settings → hasCompletedSetup=false).
     localStorage.clear();
+    setLocation('http://localhost/');
     isConnected$.set(true);
     lastConnectionResult$.set(null);
     mockBaseUrl = 'http://localhost:5700';
@@ -189,6 +204,36 @@ describe('WelcomeView', () => {
     expect(screen.queryByRole('button', { name: /use gptme\.ai/i })).not.toBeInTheDocument();
     // Retry connection stays available regardless of onboarding state
     expect(screen.getByRole('button', { name: /retry connection/i })).toBeInTheDocument();
+  });
+
+  it('detects a reachable hosted loopback server and shows CORS setup guidance before retry', async () => {
+    seedReturningUser();
+    setLocation('https://chat.gptme.org/');
+    isConnected$.set(false);
+    mockFetch.mockResolvedValue({ ok: true });
+
+    render(
+      <SettingsProvider>
+        <WelcomeView />
+      </SettingsProvider>
+    );
+
+    expect(
+      await screen.findByText(/appears to be running, but it is not allowing requests from/i)
+    ).toBeInTheDocument();
+    expect(screen.getByText('Local gptme server needs browser access')).toBeInTheDocument();
+    expect(
+      screen.getByText(/gptme-server --cors-origin='https:\/\/chat\.gptme\.org'/i)
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/Install it, then start a server/i)).not.toBeInTheDocument();
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://localhost:5700/api/v2',
+      expect.objectContaining({
+        mode: 'no-cors',
+        cache: 'no-store',
+        targetAddressSpace: 'local',
+      })
+    );
   });
 
   it('opens the setup wizard at the welcome step from the first-visit "Get started" CTA', async () => {

--- a/webui/src/components/__tests__/WelcomeView.test.tsx
+++ b/webui/src/components/__tests__/WelcomeView.test.tsx
@@ -245,6 +245,27 @@ describe('WelcomeView', () => {
     );
   });
 
+  it('auto-connects when probe confirms CORS is already configured on the loopback server', async () => {
+    seedReturningUser();
+    setLocation('https://chat.gptme.org/');
+    isConnected$.set(false);
+    // Simulate: CORS fetch succeeds (server has --cors-origin already set).
+    mockFetch.mockResolvedValueOnce({});
+
+    render(
+      <SettingsProvider>
+        <WelcomeView />
+      </SettingsProvider>
+    );
+
+    // connect() should be called automatically once the CORS probe resolves.
+    await waitFor(() => expect(mockConnect).toHaveBeenCalled());
+    // The CORS hint must NOT appear — the server is already configured correctly.
+    expect(
+      screen.queryByText(/appears to be running, but it is not allowing requests from/i)
+    ).not.toBeInTheDocument();
+  });
+
   it('opens the setup wizard at the welcome step from the first-visit "Get started" CTA', async () => {
     isConnected$.set(false);
 


### PR DESCRIPTION
## Summary
- detect when hosted chat is pointed at the default loopback server and a lightweight `no-cors` probe shows the server is alive
- surface targeted `--cors-origin` guidance immediately instead of the generic "No gptme server connected" copy
- cover the hosted-loopback reachability hint in `WelcomeView` tests

## Reproduction
1. Run `gptme-server serve` locally on `http://127.0.0.1:5700` without `--cors-origin='https://chat.gptme.org'`.
2. Open `https://chat.gptme.org/` as a first-party hosted page.
3. Observe the disconnected banner.

## Before
The app intentionally skipped first-load hosted loopback auto-connect, so the banner stayed on the generic "No gptme server connected" path even when the local server was actually up and only missing CORS.

## After
A lightweight hosted-loopback probe detects that the local server is reachable and immediately shows the `--cors-origin` command plus a clearer "Local gptme server needs browser access" banner.

## Verification
- `npm test -- --runInBand src/components/__tests__/WelcomeView.test.tsx`
- `npm run typecheck`
- `npm run build`
