### PR TITLE
docs: improve examples page with subsections and advanced workflows

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -90,7 +90,7 @@ The subagent handles research and planning; ``+computer`` and ``+browser`` handl
 
 .. rubric:: Setting Up a Persistent Agent (gptme-agent)
 
-Create a persistent AI agent — like `Bob <https://github.com/TimeToBuildBob>`_ — that runs autonomously, maintains its own task list, journal, and learns over time.
+Create a persistent AI agent — like the example in :doc:`agents` — that runs autonomously, maintains its own task list, journal, and learns over time.
 
 .. code-block:: bash
 
@@ -114,11 +114,23 @@ Your agent will have its own workspace, task system, journal, and lesson system 
 
 Connect gptme to custom tools and data sources via the Model Context Protocol.
 
+Configure MCP servers in ``~/.config/gptme/config.toml``:
+
+.. code-block:: toml
+
+    [[mcp.servers]]
+    name = "filesystem"
+    command = "npx"
+    args = ["-y", "@modelcontextprotocol/server-filesystem", "/projects"]
+    auto_start = true
+
+Then use gptme as usual — the server starts automatically:
+
 .. code-block:: bash
 
-    # Load a filesystem MCP server to work across projects
-    gptme --mcp '{"command": "npx", "args": ["-y", "@modelcontextprotocol/server-filesystem", "/projects"]}' \
-      'Refactor all my unused imports across all projects under /projects'
+    gptme 'Refactor all my unused imports across all projects under /projects'
+
+See the :doc:`mcp` page for the full list of configuration options.
 
 Automation
 ----------
@@ -129,7 +141,7 @@ gptme can be used in scripts and CI/CD pipelines for automated workflows. See th
 
     # Non-interactive mode for scripts
     git diff | gptme --non-interactive 'review this diff for bugs and security issues'
-    gptme --non-interactive --model 'sonnet' 'generate a changelog from these commits' <<< "$(git log --oneline v1.0..HEAD)"
+    gptme --non-interactive --model 'sonnet' 'generate a changelog to CHANGELOG.md from these commits' <<< "$(git log --oneline v1.0..HEAD)"
 
 The :doc:`automation` page covers code review bots, daily activity summaries, and composable shell pipelines.
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -145,6 +145,52 @@ gptme can be used in scripts and CI/CD pipelines for automated workflows. See th
 
 The :doc:`automation` page covers code review bots, daily activity summaries, and composable shell pipelines.
 
+Community Extensions (gptme-contrib)
+-------------------------------------
+
+`gptme-contrib <https://github.com/gptme/gptme-contrib>`_ is a community repository with plugins, packages, and scripts that extend gptme with additional capabilities.
+
+.. rubric:: Getting Started
+
+Clone the repo and point gptme at it:
+
+.. code-block:: bash
+
+    git clone https://github.com/gptme/gptme-contrib ~/.config/gptme/contrib
+
+Then enable plugins in your ``~/.config/gptme/config.toml``:
+
+.. code-block:: toml
+
+    [plugins]
+    paths = ["~/.config/gptme/contrib/plugins"]
+    enabled = ["gptme_imagen"]
+
+.. rubric:: Image Generation
+
+The ``gptme-imagen`` plugin adds multi-provider image generation (DALL-E, Gemini Imagen):
+
+.. code-block:: bash
+
+    gptme 'generate an image of a futuristic city at night, save to city.png'
+    gptme 'render the mandelbrot set as an image using matplotlib and compare it with an AI-generated version'
+
+.. rubric:: Semantic Context Retrieval
+
+The ``gptme-retrieval`` plugin automatically injects relevant context from your codebase before each step — useful when working on large projects:
+
+.. code-block:: toml
+
+    [plugins]
+    enabled = ["gptme_retrieval"]
+
+    [plugin.retrieval]
+    backend = "qmd"     # semantic search (requires: cargo install qmd)
+    mode = "vsearch"    # vector search
+    max_results = 5
+
+Browse the `full plugin list <https://github.com/gptme/gptme-contrib/tree/master/plugins>`_ — there are also plugins for LSP integration, multi-model consensus, code graph analysis (via ``gptme-codegraph``), voice, and more.
+
 Explore More
 ------------
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -3,36 +3,42 @@ Examples
 
 Here are some examples of how to use gptme and what its capabilities are.
 
-To see example output without running the commands yourself, check out the :doc:`demos`.
+To see example output without running the commands yourself, check out the :doc:`demos` page.
+
+.. contents::
+   :local:
+   :depth: 2
+
+Common Tasks
+------------
+
+Everyday prompts that work well with gptme out of the box.
 
 .. code-block:: bash
 
-    gptme 'write a web app to particles.html which shows off an impressive and colorful particle effect using three.js'
-    gptme 'render mandelbrot set to mandelbrot.png'
-
-    # files
+    # ask questions about files
     gptme 'summarize this' README.md
     gptme 'refactor this' main.py
     gptme 'what do you see?' image.png  # vision
 
-    # stdin
+    # pipe stdin for context
     git status -vv | gptme 'fix TODOs'
     git status -vv | gptme 'commit'
     make test | gptme 'fix the failing tests'
 
-    # if path not directly provided in prompt, it can read files using tools
+    # explore the workspace
     gptme 'explore'
     gptme 'take a screenshot and tell me what you see'
     gptme 'suggest improvements to my vimrc'
 
-    # can read URLs (if browser tool is available)
+    # read URLs and GitHub issues
     gptme 'implement this' https://github.com/gptme/gptme/issues/286
-
-    # can use `gh` shell tool to read issues, PRs, etc.
-    gptme 'implement gptme/gptme/issues/286'
+    gptme 'implement gptme/gptme/issues/286'  # uses `gh` shell tool
 
     # create new projects
     gptme 'create a performant n-body simulation in rust'
+    gptme 'render mandelbrot set to mandelbrot.png'
+    gptme 'write a web app to particles.html which shows off an impressive and colorful particle effect using three.js'
 
     # chaining prompts
     gptme 'make a change' - 'test it' - 'commit it'
@@ -40,6 +46,82 @@ To see example output without running the commands yourself, check out the :doc:
 
     # resume the last conversation
     gptme -r
+
+Advanced Workflows
+------------------
+
+gptme's tool system lets you unlock more powerful workflows. Enable extra tools with the ``--tools`` flag.
+
+.. rubric:: Subagents (Planner Mode)
+
+Use a separate planning agent to research and plan before coding. This is great for complex tasks where you want clear reasoning before any code is written.
+
+.. code-block:: bash
+
+    gptme --tools +subagent \
+      'Plan and implement a CLI tool that monitors CPU/memory usage and alerts when thresholds are exceeded'
+
+The subagent researches the approach, presents a plan, and only then does gptme start writing code. The result is better architecture for complex projects.
+
+.. rubric:: Computer Use
+
+Let gptme interact with your desktop — take screenshots, move the mouse, click buttons, and type. Useful for GUI automation, testing, and workflows that span multiple applications.
+
+.. code-block:: bash
+
+    gptme --tools +computer \
+      'Record a loom-style screencast: open my browser, navigate to the project README, take a screenshot, and explain the architecture'
+
+.. rubric:: Setting Up a Persistent Agent (gptme-agent)
+
+Create a persistent AI agent — like `Bob <https://github.com/TimeToBuildBob>`_ — that runs autonomously, maintains its own task list, journal, and learns over time.
+
+.. code-block:: bash
+
+    # Install the agent template
+    pip install gptme-agent
+    gptme-agent create ~/my-agent --name my-agent
+
+    # Bootstrap it
+    cd ~/my-agent
+    gptme 'explore the workspace, read my identity files, and tell me what I am'
+
+    # Run it autonomously
+    gptme-agent run
+
+Your agent will have its own workspace, task system, journal, and lesson system — everything Bob uses, ready to customize.
+
+.. rubric:: MCP Servers
+
+Connect gptme to custom tools and data sources via the Model Context Protocol.
+
+.. code-block:: bash
+
+    # Load a filesystem MCP server to work across projects
+    gptme --mcp '{"command": "npx", "args": ["-y", "@modelcontextprotocol/server-filesystem", "/projects"]}' \
+      'Refactor all my unused imports across all projects under /projects'
+
+Automation
+----------
+
+gptme can be used in scripts and CI/CD pipelines for automated workflows. See the :doc:`automation` page for full examples.
+
+.. code-block:: bash
+
+    # Non-interactive mode for scripts
+    git diff | gptme --non-interactive 'review this diff for bugs and security issues'
+    gptme --non-interactive --model 'sonnet' 'generate a changelog from these commits' <<< "$(git log --oneline v1.0..HEAD)"
+
+The :doc:`automation` page covers code review bots, daily activity summaries, and composable shell pipelines.
+
+Explore More
+------------
+
+Learn more about gptme with these dedicated pages:
+
+* :doc:`demos` — watch example runs with terminal recordings
+* :doc:`automation` — CI/CD, cron jobs, shell scripts
+* :doc:`Projects </projects>` — things built with gptme
 
 Do you have a cool example? Share it with us in the `Discussions <https://github.com/gptme/gptme/discussions>`_!
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -70,7 +70,23 @@ Let gptme interact with your desktop — take screenshots, move the mouse, click
 .. code-block:: bash
 
     gptme --tools +computer \
-      'Record a loom-style screencast: open my browser, navigate to the project README, take a screenshot, and explain the architecture'
+      'Take a screenshot of my browser, identify any UI issues, and write a bug report to bugs.md'
+
+.. rubric:: Combining Tools for Maximum Power
+
+Enable multiple tools together for complex, autonomous workflows. The most powerful combination is ``+subagent`` (for planning) with ``+computer`` (for desktop interaction):
+
+.. code-block:: bash
+
+    # Plan, implement, and visually verify — all in one session
+    gptme --tools +computer,+subagent \
+      'Research the top Python testing frameworks, implement a comparison benchmark, run it, and take a screenshot of the results'
+
+    # Autonomous agent workflow: plan first, then execute with full tool access
+    gptme --tools +subagent,+computer,+browser \
+      'Find my most-starred GitHub repo, write a blog post about it, and open the draft in my browser'
+
+The subagent handles research and planning; ``+computer`` and ``+browser`` handle execution and verification.
 
 .. rubric:: Setting Up a Persistent Agent (gptme-agent)
 
@@ -78,18 +94,21 @@ Create a persistent AI agent — like `Bob <https://github.com/TimeToBuildBob>`_
 
 .. code-block:: bash
 
-    # Install the agent template
-    pip install gptme-agent
-    gptme-agent create ~/my-agent --name my-agent
+    # Install gptme (includes the gptme-agent command)
+    pipx install gptme
+
+    # Create a new agent workspace from the template
+    gptme-agent create ~/my-agent --name MyAgent
 
     # Bootstrap it
     cd ~/my-agent
     gptme 'explore the workspace, read my identity files, and tell me what I am'
 
-    # Run it autonomously
+    # Run it autonomously on a schedule
+    gptme-agent install
     gptme-agent run
 
-Your agent will have its own workspace, task system, journal, and lesson system — everything Bob uses, ready to customize.
+Your agent will have its own workspace, task system, journal, and lesson system — everything needed for a persistent, self-improving AI agent.
 
 .. rubric:: MCP Servers
 


### PR DESCRIPTION
## Summary

Improves the examples documentation page with organized subsections, advanced workflow examples, and better cross-linking to other docs pages.

Fixes #815

## Changes

- Added table of contents with `.. contents::`
- Organized examples into subsections: Common Tasks, Advanced Workflows, Automation, Explore More
- Moved existing examples under Common Tasks where they belong
- Advanced Workflows section (new):
  - Subagents (Planner Mode) — complex task example
  - Computer Use — GUI automation example
  - Persistent Agent setup — gptme-agent example
  - MCP Servers — extensibility example
- Automation section — links to the dedicated automation docs page with a teaser
- Explore More section — links to Demos, Automation, and Projects subpages
- Added language tags to all codeblocks (rst, bash)
- Improved comment clarity on existing examples
- Moved flashy examples (particles, mandelbrot) to the bottom to lead with practical workflows

## Motivation

Erik's feedback: the examples page should have subsections for different types, keep current ones as basic/common prompts, link to subpages, and include advanced examples like subagents, computer use, and persistent agents.
