### PR TITLE
fix(server): avoid full JSONL scan in agents listing endpoint

### DIFF
--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -1405,7 +1405,7 @@ def _serve_agent_avatar(agent_path_str: str):
 def api_agents():
     """List agents extracted from conversations."""
     agent_map: dict[str, dict] = {}
-    for conv in get_user_conversations():
+    for conv in get_user_conversations(detail=False):
         if not conv.agent_path:
             continue
         path = conv.agent_path


### PR DESCRIPTION
## Problem

The `/api/v2/agents` endpoint calls `get_user_conversations()` with `detail=True`, which performs a full JSONL scan of every conversation to compute cost/token statistics. With 9000+ conversations, this causes the endpoint to hang indefinitely (Flask workers blocked on synchronous I/O).

## Fix

Switched to `detail=False` in the agents listing endpoint, which uses the fast tail-only scan instead. The agents endpoint only needs `agent_path`, `agent_name`, `agent_avatar`, `agent_urls`, and `modified` timestamps — none of which come from the cost/token scan.

## Impact

Before: `GET /api/v2/agents` = timeout after 5s+ (never returns)  
After: `GET /api/v2/agents` = 200 in ~3.3s for 9000+ conversations

(A full fix would add a dedicated scan, but this removes the 80-char-wide JSONL overhead per conv which dominates the runtime.)

## Verification

- `curl` test confirms endpoint returns 200 in ~3.3s vs hang
- Existing `api_v2` tests pass
- Server starts cleanly with `gptme-server --port X`

## Related

Discovered during dogfood sweep (session 295a).