### PR TITLE
feat(hooks): emit aw-watcher tool activity heartbeats

### DIFF
--- a/gptme/hooks/aw_watcher_agent.py
+++ b/gptme/hooks/aw_watcher_agent.py
@@ -3,7 +3,8 @@
 This hook plugin is intentionally small and fail-open:
 
 - it shells out to the external ``aw-watcher-agent`` CLI if configured
-- it emits only ``session.start`` / ``session.end`` lifecycle events
+- it emits ``session.start`` / ``session.end`` lifecycle events and per-tool
+  activity heartbeats
 - failures are logged and ignored so telemetry never breaks a session
 
 Activation:
@@ -18,21 +19,31 @@ import logging
 import os
 import shlex
 import subprocess
+import time
+from contextvars import ContextVar
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 from ..hooks import HookType, register_hook
 from ..llm.models import get_default_model
+from ..logmanager import LogManager
 from ..plugins.plugin import GptmePlugin
+from .server_confirm import current_session_id
 
 if TYPE_CHECKING:
     from collections.abc import Generator
 
     from ..hooks import StopPropagation
-    from ..logmanager import LogManager
+    from ..logmanager import Log
     from ..message import Message
+    from ..tools.base import ToolUse
 
 logger = logging.getLogger(__name__)
+
+_tool_start_times_var: ContextVar[dict[int, float] | None] = ContextVar(
+    "aw_watcher_agent_tool_start_times",
+    default=None,
+)
 
 
 def _enabled() -> bool:
@@ -114,6 +125,22 @@ def _run_aw(argv: list[str]) -> None:
         logger.debug("aw-watcher-agent stderr: %s", result.stderr.strip())
 
 
+def _ensure_tool_start_times() -> dict[int, float]:
+    tool_start_times = _tool_start_times_var.get()
+    if tool_start_times is None:
+        tool_start_times = {}
+        _tool_start_times_var.set(tool_start_times)
+    return tool_start_times
+
+
+def _current_tool_session_id() -> str | None:
+    manager = LogManager.get_current_log()
+    logdir = getattr(manager, "logdir", None) if manager is not None else None
+    if logdir is not None:
+        return Path(logdir).name
+    return current_session_id.get()
+
+
 def emit_start(
     logdir: Path,
     workspace: Path | None,
@@ -147,10 +174,68 @@ def emit_end(
     yield
 
 
+def record_tool_start(
+    log: Log,
+    workspace: Path | None,
+    tool_use: ToolUse,
+) -> Generator[Message | StopPropagation, None, None]:
+    """Record the start time for a tool so the post hook can emit duration."""
+    del log, workspace
+    if not _enabled():
+        return
+    tool_start_times = _ensure_tool_start_times()
+    tool_start_times[id(tool_use)] = time.monotonic()
+    _tool_start_times_var.set(tool_start_times)
+    return
+    yield
+
+
+def emit_tool_activity(
+    log: Log,
+    workspace: Path | None,
+    tool_use: ToolUse,
+) -> Generator[Message | StopPropagation, None, None]:
+    """Emit one per-tool activity heartbeat after a tool finishes."""
+    del log
+    if not _enabled():
+        return
+
+    session_id = _current_tool_session_id()
+    if not session_id:
+        return
+
+    tool_start_times = _ensure_tool_start_times()
+    started_at = tool_start_times.pop(id(tool_use), None)
+    _tool_start_times_var.set(tool_start_times)
+    duration_ms = 0
+    if started_at is not None:
+        duration_ms = max(int(round((time.monotonic() - started_at) * 1000)), 0)
+
+    argv = _command_prefix() + [
+        "emit-activity",
+        *_base_args(session_id, workspace),
+        "--tool",
+        tool_use.tool,
+        "--status",
+        "success",
+        "--duration-ms",
+        str(duration_ms),
+    ]
+    _run_aw(argv)
+    return
+    yield
+
+
 def register() -> None:
     """Register aw-watcher-agent lifecycle hooks."""
     register_hook("aw_watcher_agent.start", HookType.SESSION_START, emit_start)
     register_hook("aw_watcher_agent.end", HookType.SESSION_END, emit_end)
+    register_hook(
+        "aw_watcher_agent.tool_pre", HookType.TOOL_EXECUTE_PRE, record_tool_start
+    )
+    register_hook(
+        "aw_watcher_agent.tool_post", HookType.TOOL_EXECUTE_POST, emit_tool_activity
+    )
     logger.debug("Registered aw-watcher-agent hooks")
 
 

--- a/gptme/hooks/aw_watcher_agent.py
+++ b/gptme/hooks/aw_watcher_agent.py
@@ -44,6 +44,8 @@ _tool_start_times_var: ContextVar[dict[int, float] | None] = ContextVar(
     "aw_watcher_agent_tool_start_times",
     default=None,
 )
+# Prune entries older than this to prevent accumulation when POST is skipped (e.g. tool exception)
+_MAX_TOOL_AGE_S = 300
 
 
 def _enabled() -> bool:
@@ -184,7 +186,13 @@ def record_tool_start(
     if not _enabled():
         return
     tool_start_times = _ensure_tool_start_times()
-    tool_start_times[id(tool_use)] = time.monotonic()
+    # Prune stale entries from tools whose POST hook was never called (e.g. exception).
+    # Do this at PRE time so the POST path stays side-effect-free.
+    now = time.monotonic()
+    stale = [k for k, v in tool_start_times.items() if now - v > _MAX_TOOL_AGE_S]
+    for k in stale:
+        del tool_start_times[k]
+    tool_start_times[id(tool_use)] = now
     _tool_start_times_var.set(tool_start_times)
     return
     yield
@@ -217,6 +225,8 @@ def emit_tool_activity(
         "--tool",
         tool_use.tool,
         "--status",
+        # TOOL_EXECUTE_POST only fires on the success path in tools/base.py;
+        # exceptions skip the post hook entirely, so "success" is accurate here.
         "success",
         "--duration-ms",
         str(duration_ms),

--- a/gptme/hooks/tests/test_aw_watcher_agent.py
+++ b/gptme/hooks/tests/test_aw_watcher_agent.py
@@ -7,7 +7,8 @@ from unittest.mock import patch
 
 from gptme.hooks import HookRegistry, HookType, get_registry, set_registry, trigger_hook
 from gptme.hooks.aw_watcher_agent import emit_end, emit_start
-from gptme.logmanager import LogManager
+from gptme.logmanager import LogManager, _current_log_var
+from gptme.tools.base import ToolUse
 
 
 def _completed(returncode: int = 0, stdout: str = "", stderr: str = ""):
@@ -102,3 +103,68 @@ def test_emit_start_noops_when_disabled(monkeypatch):
         assert list(emit_start(Path("/tmp/conv123"), Path("/tmp/workspace"), [])) == []
 
     run.assert_not_called()
+
+
+def test_tool_activity_hooks_emit_heartbeat_when_registered(monkeypatch):
+    """Registered tool hooks should emit one activity heartbeat per tool call."""
+    from gptme.hooks.aw_watcher_agent import register
+
+    monkeypatch.setenv("GPTME_AW_WATCHER_AGENT", "1")
+    manager = cast(
+        LogManager,
+        SimpleNamespace(
+            logdir=Path("/tmp/conv123"),
+            workspace=Path("/tmp/workspace"),
+        ),
+    )
+    tool_use = ToolUse(tool="shell", args=[], content="echo hi")
+    token = _current_log_var.set(manager)
+
+    old = get_registry()
+    set_registry(HookRegistry())
+    try:
+        register()
+        with (
+            patch("gptme.hooks.aw_watcher_agent.get_default_model", return_value=None),
+            patch(
+                "gptme.hooks.aw_watcher_agent.time.monotonic", side_effect=[10.0, 10.35]
+            ),
+            patch(
+                "gptme.hooks.aw_watcher_agent.subprocess.run",
+                return_value=_completed(),
+            ) as run,
+        ):
+            assert (
+                list(
+                    trigger_hook(
+                        HookType.TOOL_EXECUTE_PRE,
+                        log=SimpleNamespace(messages=[]),
+                        workspace=Path("/tmp/workspace"),
+                        tool_use=tool_use,
+                    )
+                )
+                == []
+            )
+            assert (
+                list(
+                    trigger_hook(
+                        HookType.TOOL_EXECUTE_POST,
+                        log=SimpleNamespace(messages=[]),
+                        workspace=Path("/tmp/workspace"),
+                        tool_use=tool_use,
+                    )
+                )
+                == []
+            )
+
+        run.assert_called_once()
+        argv = run.call_args.args[0]
+        assert argv[:2] == ["aw-watcher-agent", "emit-activity"]
+        assert "--session-id" in argv and "conv123" in argv
+        assert "--workspace" in argv and "workspace" in argv
+        assert "--tool" in argv and "shell" in argv
+        assert "--status" in argv and "success" in argv
+        assert "--duration-ms" in argv and "350" in argv
+    finally:
+        set_registry(old)
+        _current_log_var.reset(token)


### PR DESCRIPTION
## Summary
- register `aw_watcher_agent` tool pre/post hooks so gptme emits per-tool ActivityWatch heartbeats
- derive the session id from the current log manager (with server-session fallback) and include measured tool duration
- cover the registered hook path with a targeted integration-style test

Depends on gptme/gptme-contrib#1009.

## Testing
- `PYTHONPATH=/tmp/gptme-aw-416b /home/bob/gptme/.venv/bin/pytest /tmp/gptme-aw-416b/gptme/hooks/tests/test_aw_watcher_agent.py -q`