### PR TITLE
fix(webui): tag loopback requests correctly

### DIFF
--- a/webui/src/components/__tests__/SetupWizard.test.tsx
+++ b/webui/src/components/__tests__/SetupWizard.test.tsx
@@ -249,10 +249,13 @@ describe('SetupWizard', () => {
     });
 
     await waitFor(() => {
-      expect(mockFetch).toHaveBeenCalledWith('http://127.0.0.1:5700/api/v2', {
-        headers: {},
-        targetAddressSpace: 'local',
-      });
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://127.0.0.1:5700/api/v2',
+        expect.objectContaining({
+          headers: {},
+          targetAddressSpace: 'loopback',
+        })
+      );
     });
 
     await waitFor(() => {

--- a/webui/src/components/__tests__/WelcomeView.test.tsx
+++ b/webui/src/components/__tests__/WelcomeView.test.tsx
@@ -240,7 +240,7 @@ describe('WelcomeView', () => {
       expect.objectContaining({
         mode: 'no-cors',
         cache: 'no-store',
-        targetAddressSpace: 'local',
+        targetAddressSpace: 'loopback',
       })
     );
   });

--- a/webui/src/utils/__tests__/addressSpace.test.ts
+++ b/webui/src/utils/__tests__/addressSpace.test.ts
@@ -4,6 +4,7 @@ describe('isLocalUrl', () => {
   it.each([
     'http://localhost:5700',
     'http://127.0.0.1:5700',
+    'http://[::1]:5700',
     'http://10.0.0.5:5700',
     'http://192.168.1.100:5700',
     'http://172.16.0.1:5700',
@@ -34,6 +35,13 @@ describe('withLocalAddressSpace', () => {
       'loopback'
     );
     expect(init.method).toBe('GET');
+  });
+
+  it("adds targetAddressSpace:'loopback' for an IPv6 loopback URL", () => {
+    const init = withLocalAddressSpace('http://[::1]:5700', { method: 'GET' });
+    expect((init as RequestInit & { targetAddressSpace?: string }).targetAddressSpace).toBe(
+      'loopback'
+    );
   });
 
   it("adds targetAddressSpace:'local' for an RFC1918 private URL", () => {

--- a/webui/src/utils/__tests__/addressSpace.test.ts
+++ b/webui/src/utils/__tests__/addressSpace.test.ts
@@ -28,8 +28,16 @@ describe('isLocalUrl', () => {
 });
 
 describe('withLocalAddressSpace', () => {
-  it("adds targetAddressSpace:'local' for a local URL", () => {
+  it("adds targetAddressSpace:'loopback' for a loopback URL", () => {
     const init = withLocalAddressSpace('http://127.0.0.1:5700', { method: 'GET' });
+    expect((init as RequestInit & { targetAddressSpace?: string }).targetAddressSpace).toBe(
+      'loopback'
+    );
+    expect(init.method).toBe('GET');
+  });
+
+  it("adds targetAddressSpace:'local' for an RFC1918 private URL", () => {
+    const init = withLocalAddressSpace('http://192.168.1.100:5700', { method: 'GET' });
     expect((init as RequestInit & { targetAddressSpace?: string }).targetAddressSpace).toBe(
       'local'
     );
@@ -66,7 +74,7 @@ describe('withLocalAddressSpace', () => {
   it('defaults to an empty init when none is provided', () => {
     const init = withLocalAddressSpace('http://localhost:5700');
     expect((init as RequestInit & { targetAddressSpace?: string }).targetAddressSpace).toBe(
-      'local'
+      'loopback'
     );
   });
 });

--- a/webui/src/utils/addressSpace.ts
+++ b/webui/src/utils/addressSpace.ts
@@ -4,7 +4,19 @@
 // in isolation — unlike connectionConfig.ts, which jest cannot import.
 
 // Matches loopback and RFC1918 private (local-network) hostnames.
-const PRIVATE_ADDRESS_PATTERN = /^(localhost|127\.|10\.|192\.168\.|172\.(1[6-9]|2[0-9]|3[01])\.)/i;
+const LOOPBACK_ADDRESS_PATTERN = /^(localhost|127\..*|(?:\[)?::1(?:\])?)$/i;
+const PRIVATE_ADDRESS_PATTERN = /^(10\.|192\.168\.|172\.(1[6-9]|2[0-9]|3[01])\.)/i;
+
+function getTargetAddressSpace(url: string): 'loopback' | 'local' | null {
+  try {
+    const hostname = new URL(url).hostname;
+    if (LOOPBACK_ADDRESS_PATTERN.test(hostname)) return 'loopback';
+    if (PRIVATE_ADDRESS_PATTERN.test(hostname)) return 'local';
+    return null;
+  } catch {
+    return null;
+  }
+}
 
 /**
  * True when the URL targets a loopback/private (local-network) address.
@@ -12,17 +24,13 @@ const PRIVATE_ADDRESS_PATTERN = /^(localhost|127\.|10\.|192\.168\.|172\.(1[6-9]|
  * only, so connections to remote/cloud servers (gptme.ai) are unaffected.
  */
 export function isLocalUrl(url: string): boolean {
-  try {
-    return PRIVATE_ADDRESS_PATTERN.test(new URL(url).hostname);
-  } catch {
-    return false;
-  }
+  return getTargetAddressSpace(url) !== null;
 }
 
 /**
  * Chrome 142+ Local Network Access (LNA) blocks requests from a public origin
  * (e.g. https://chat.gptme.org) to a loopback/local address *before* CORS is
- * evaluated, unless the request opts in via `targetAddressSpace: 'local'`.
+ * evaluated, unless the request opts in with the matching address space.
  *
  * This RequestInit field is not yet in the TS DOM lib types, so it is attached
  * via a cast. It is applied only when the target URL is local, so requests to
@@ -31,6 +39,7 @@ export function isLocalUrl(url: string): boolean {
  * See https://developer.chrome.com/blog/local-network-access
  */
 export function withLocalAddressSpace(url: string, init: RequestInit = {}): RequestInit {
-  if (!isLocalUrl(url)) return init;
-  return { ...init, targetAddressSpace: 'local' } as RequestInit;
+  const targetAddressSpace = getTargetAddressSpace(url);
+  if (!targetAddressSpace) return init;
+  return { ...init, targetAddressSpace } as RequestInit;
 }


### PR DESCRIPTION
## Summary
Fix the web UI's Local Network Access opt-in so loopback URLs use `targetAddressSpace: "loopback"` instead of being lumped into `"local"`.

## Live repro
From `https://chat.gptme.org/chat` in Chromium headless, the hosted app probes `http://127.0.0.1:5700/api/v2` and logs:
- `Permission was denied for this request to access the \`loopback\` address space.`
- `Request had a target IP address space of \`local\` yet the resource is in address space \`loopback\`.`

That second error points at the bug directly: the probe is annotating loopback as `local`.

## Changes
- distinguish loopback (`localhost`, `127.x.x.x`, `::1`) from RFC1918 private addresses
- return `targetAddressSpace: "loopback"` for loopback URLs
- keep `targetAddressSpace: "local"` for RFC1918 private URLs
- update the focused web UI tests to assert the right address space

## Verification
- `npm test -- --runInBand src/utils/__tests__/addressSpace.test.ts src/components/__tests__/WelcomeView.test.tsx src/components/__tests__/SetupWizard.test.tsx`
- `npm run typecheck`