### PR TITLE
fix(webui): handle cloud auth postMessage handoff from popup

### DIFF
--- a/webui/src/components/SetupWizard.tsx
+++ b/webui/src/components/SetupWizard.tsx
@@ -20,6 +20,7 @@ import {
 } from '@/utils/apiKeyProviders';
 import { fetchProviderConfigured } from '@/utils/providerStatus';
 import { isTauriEnvironment, invokeTauri } from '@/utils/tauri';
+import { processConnectionFromHash } from '@/utils/connectionConfig';
 import {
   bumpProviderStatusVersion,
   setupWizard$,
@@ -62,6 +63,8 @@ function getCloudAuthUrl(): string {
 }
 
 const CLOUD_AUTH_URL = getCloudAuthUrl();
+const CLOUD_AUTH_ORIGIN = new URL(CLOUD_AUTH_URL).origin;
+const CLOUD_AUTH_MESSAGE_TYPE = 'gptme-cloud-auth-code';
 const SERVER_START_RETRY_COUNT = 6;
 const SERVER_START_RETRY_DELAY_MS = 250;
 const SERVER_READY_RETRY_COUNT = 10;
@@ -305,6 +308,51 @@ export function SetupWizard() {
     setIsOpen(true);
     setupWizard$.open.set(false);
   }, [externalOpen, externalStep]);
+
+  useEffect(() => {
+    if (!cloudLoginStarted || step !== 'cloud' || isConnected) {
+      return;
+    }
+
+    let cancelled = false;
+
+    const handleCloudAuthMessage = (event: MessageEvent) => {
+      if (event.origin !== CLOUD_AUTH_ORIGIN) {
+        return;
+      }
+
+      const data = event.data as { type?: string; code?: string } | null;
+      if (data?.type !== CLOUD_AUTH_MESSAGE_TYPE || typeof data.code !== 'string') {
+        return;
+      }
+      const authCode = data.code;
+
+      void (async () => {
+        setConnectError(null);
+
+        try {
+          const config = await processConnectionFromHash(`code=${encodeURIComponent(authCode)}`);
+          if (cancelled) {
+            return;
+          }
+          await connect(config);
+        } catch (error) {
+          if (cancelled) {
+            return;
+          }
+          setConnectError(
+            error instanceof Error ? error.message : 'Could not complete cloud sign-in.'
+          );
+        }
+      })();
+    };
+
+    window.addEventListener('message', handleCloudAuthMessage);
+    return () => {
+      cancelled = true;
+      window.removeEventListener('message', handleCloudAuthMessage);
+    };
+  }, [cloudLoginStarted, connect, isConnected, step]);
 
   // Close the dialog. Also calls completeSetup() so that skipping or finishing always persists.
   const closeWizard = () => {

--- a/webui/src/components/SetupWizard.tsx
+++ b/webui/src/components/SetupWizard.tsx
@@ -315,6 +315,7 @@ export function SetupWizard() {
     }
 
     let cancelled = false;
+    let handled = false;
 
     const handleCloudAuthMessage = (event: MessageEvent) => {
       if (event.origin !== CLOUD_AUTH_ORIGIN) {
@@ -325,6 +326,13 @@ export function SetupWizard() {
       if (data?.type !== CLOUD_AUTH_MESSAGE_TYPE || typeof data.code !== 'string') {
         return;
       }
+
+      // Once-guard: ignore duplicate messages (popup may emit the same code twice)
+      if (handled) {
+        return;
+      }
+      handled = true;
+
       const authCode = data.code;
 
       void (async () => {

--- a/webui/src/components/SetupWizard.tsx
+++ b/webui/src/components/SetupWizard.tsx
@@ -348,6 +348,7 @@ export function SetupWizard() {
           if (cancelled) {
             return;
           }
+          handled = false;
           setConnectError(
             error instanceof Error ? error.message : 'Could not complete cloud sign-in.'
           );

--- a/webui/src/components/__tests__/SetupWizard.test.tsx
+++ b/webui/src/components/__tests__/SetupWizard.test.tsx
@@ -315,6 +315,65 @@ describe('SetupWizard', () => {
     expect(mockConnect).toHaveBeenCalledTimes(1);
   });
 
+  it('allows retrying cloud auth after a failed code exchange', async () => {
+    mockProcessConnectionFromHash
+      .mockRejectedValueOnce(new Error('expired code'))
+      .mockResolvedValueOnce({
+        baseUrl: 'https://fleet.gptme.ai/api/v1/instances/test',
+        authToken: 'tok-123',
+        useAuthToken: true,
+      });
+    mockConnect.mockImplementation(async () => {
+      isConnected$.set(true);
+    });
+
+    render(
+      <SettingsProvider>
+        <SetupWizard />
+      </SettingsProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /get started/i }));
+    fireEvent.click(screen.getByRole('button', { name: /cloud/i }));
+    fireEvent.click(screen.getByRole('button', { name: /sign in to gptme.ai/i }));
+
+    await act(async () => {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          origin: CLOUD_AUTH_ORIGIN,
+          data: { type: 'gptme-cloud-auth-code', code: 'expired' },
+        })
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('expired code')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /sign in to gptme.ai/i }));
+
+    await act(async () => {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          origin: CLOUD_AUTH_ORIGIN,
+          data: { type: 'gptme-cloud-auth-code', code: 'fresh-code' },
+        })
+      );
+    });
+
+    await waitFor(() => {
+      expect(mockProcessConnectionFromHash).toHaveBeenNthCalledWith(2, 'code=fresh-code');
+    });
+
+    await waitFor(() => {
+      expect(mockConnect).toHaveBeenCalledWith({
+        baseUrl: 'https://fleet.gptme.ai/api/v1/instances/test',
+        authToken: 'tok-123',
+        useAuthToken: true,
+      });
+    });
+  });
+
   it('marks setup complete after local connect succeeds', async () => {
     mockConnect.mockImplementation(async () => {
       isConnected$.set(true);

--- a/webui/src/components/__tests__/SetupWizard.test.tsx
+++ b/webui/src/components/__tests__/SetupWizard.test.tsx
@@ -9,6 +9,7 @@ const mockConnect = jest.fn();
 const mockOpen = jest.fn();
 const mockFetch = jest.fn();
 const mockInvokeTauri = jest.fn();
+const mockProcessConnectionFromHash = jest.fn();
 const isConnected$ = observable(false);
 const mockIsTauriEnvironment = jest.fn(() => false);
 
@@ -56,6 +57,10 @@ jest.mock('@/utils/tauri', () => ({
 
 jest.mock('@/hooks/useTauriServerStatus', () => ({
   useTauriServerStatus: () => mockUseTauriServerStatus(),
+}));
+
+jest.mock('@/utils/connectionConfig', () => ({
+  processConnectionFromHash: (...args: unknown[]) => mockProcessConnectionFromHash(...args),
 }));
 
 jest.mock('@legendapp/state/react', () => ({
@@ -143,10 +148,16 @@ describe('SetupWizard', () => {
     mockOpen.mockReset();
     mockFetch.mockReset();
     mockInvokeTauri.mockReset();
+    mockProcessConnectionFromHash.mockReset();
     mockFetch.mockResolvedValue({
       ok: true,
       status: 200,
       json: async () => ({ provider_configured: true }),
+    });
+    mockProcessConnectionFromHash.mockResolvedValue({
+      baseUrl: 'https://fleet.gptme.ai/api/v1/instances/test',
+      authToken: 'tok-123',
+      useAuthToken: true,
     });
     Object.defineProperty(window, 'fetch', {
       writable: true,
@@ -226,6 +237,46 @@ describe('SetupWizard', () => {
 
     await waitFor(() => {
       expect(screen.getByRole('heading', { name: /you're all set/i })).toBeInTheDocument();
+    });
+  });
+
+  it('processes cloud auth codes posted back from the authorize popup', async () => {
+    mockConnect.mockImplementation(async () => {
+      isConnected$.set(true);
+    });
+
+    render(
+      <SettingsProvider>
+        <SetupWizard />
+      </SettingsProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /get started/i }));
+    fireEvent.click(screen.getByRole('button', { name: /cloud/i }));
+    fireEvent.click(screen.getByRole('button', { name: /sign in to gptme.ai/i }));
+
+    await act(async () => {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          origin: 'https://gptme.ai',
+          data: {
+            type: 'gptme-cloud-auth-code',
+            code: 'deadbeef',
+          },
+        })
+      );
+    });
+
+    await waitFor(() => {
+      expect(mockProcessConnectionFromHash).toHaveBeenCalledWith('code=deadbeef');
+    });
+
+    await waitFor(() => {
+      expect(mockConnect).toHaveBeenCalledWith({
+        baseUrl: 'https://fleet.gptme.ai/api/v1/instances/test',
+        authToken: 'tok-123',
+        useAuthToken: true,
+      });
     });
   });
 

--- a/webui/src/components/__tests__/SetupWizard.test.tsx
+++ b/webui/src/components/__tests__/SetupWizard.test.tsx
@@ -12,6 +12,9 @@ const mockInvokeTauri = jest.fn();
 const mockProcessConnectionFromHash = jest.fn();
 const isConnected$ = observable(false);
 const mockIsTauriEnvironment = jest.fn(() => false);
+const CLOUD_AUTH_BASE_URL = process.env['VITE_GPTME_CLOUD_BASE_URL'] || 'https://gptme.ai';
+const CLOUD_AUTH_URL = `${CLOUD_AUTH_BASE_URL}/authorize`;
+const CLOUD_AUTH_ORIGIN = new URL(CLOUD_AUTH_URL).origin;
 
 type MockTauriServerStatus = {
   running: boolean;
@@ -224,7 +227,7 @@ describe('SetupWizard', () => {
     fireEvent.click(screen.getByRole('button', { name: /cloud/i }));
     fireEvent.click(screen.getByRole('button', { name: /sign in to gptme.ai/i }));
 
-    expect(mockOpen).toHaveBeenCalledWith('https://gptme.ai/authorize', '_blank');
+    expect(mockOpen).toHaveBeenCalledWith(CLOUD_AUTH_URL, '_blank');
     expect(screen.getByText(/waiting for sign-in to complete/i)).toBeInTheDocument();
     expect(screen.queryByText(/you're all set/i)).not.toBeInTheDocument();
 
@@ -258,7 +261,7 @@ describe('SetupWizard', () => {
     await act(async () => {
       window.dispatchEvent(
         new MessageEvent('message', {
-          origin: 'https://gptme.ai',
+          origin: CLOUD_AUTH_ORIGIN,
           data: {
             type: 'gptme-cloud-auth-code',
             code: 'deadbeef',
@@ -296,7 +299,7 @@ describe('SetupWizard', () => {
     fireEvent.click(screen.getByRole('button', { name: /sign in to gptme.ai/i }));
 
     const authMessage = new MessageEvent('message', {
-      origin: 'https://gptme.ai',
+      origin: CLOUD_AUTH_ORIGIN,
       data: { type: 'gptme-cloud-auth-code', code: 'deadbeef' },
     });
 

--- a/webui/src/components/__tests__/SetupWizard.test.tsx
+++ b/webui/src/components/__tests__/SetupWizard.test.tsx
@@ -280,6 +280,38 @@ describe('SetupWizard', () => {
     });
   });
 
+  it('ignores duplicate cloud auth postMessages (once-guard)', async () => {
+    mockConnect.mockImplementation(async () => {
+      isConnected$.set(true);
+    });
+
+    render(
+      <SettingsProvider>
+        <SetupWizard />
+      </SettingsProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /get started/i }));
+    fireEvent.click(screen.getByRole('button', { name: /cloud/i }));
+    fireEvent.click(screen.getByRole('button', { name: /sign in to gptme.ai/i }));
+
+    const authMessage = new MessageEvent('message', {
+      origin: 'https://gptme.ai',
+      data: { type: 'gptme-cloud-auth-code', code: 'deadbeef' },
+    });
+
+    await act(async () => {
+      window.dispatchEvent(authMessage);
+      window.dispatchEvent(authMessage); // duplicate
+    });
+
+    await waitFor(() => {
+      expect(mockProcessConnectionFromHash).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mockConnect).toHaveBeenCalledTimes(1);
+  });
+
   it('marks setup complete after local connect succeeds', async () => {
     mockConnect.mockImplementation(async () => {
       isConnected$.set(true);


### PR DESCRIPTION
## Problem

When a user clicked "Sign in with gptme.ai" in `chat.gptme.org`, a popup opened and completed auth successfully, but the original tab stayed stuck on "Waiting for sign-in to complete…" forever.

Root cause: the authorize popup had no way to pass the one-time auth code back to the browser opener — it was only wired for deep-link (`gptme://`) which has no handler in a browser context.

## Fix

**SetupWizard** (opener side): adds a `useEffect` that listens for a `postMessage` from the cloud auth popup. On receiving a `gptme-cloud-auth-code` message from the trusted `CLOUD_AUTH_ORIGIN`, it processes the auth code and calls `connect()` inline — the same path as the hash-based connection flow.

The effect is scoped: only active while `cloudLoginStarted && step === 'cloud' && !isConnected`. On cleanup it removes the listener and sets a `cancelled` flag to guard the async path.

## Pairing

Paired with gptme/gptme-cloud#321 which makes the Authorize popup post the code back to the opener instead of falling into the dead deep-link path.

## Tests

- `SetupWizard.test.tsx`: new test "processes cloud auth codes posted back from the authorize popup" covers the full message → connect flow with a mocked auth handler

## Verification

Reproduced the bug (original tab stuck after successful popup auth), then confirmed the fix closes the opener tab and auto-connects in the same tab with this change + the paired gptme-cloud change.