### PR TITLE
fix(computer): handle missing/timed-out ImageMagick convert in screenshot resize

### DIFF
--- a/gptme/tools/computer_transport.py
+++ b/gptme/tools/computer_transport.py
@@ -97,6 +97,34 @@ class ComputerTransport(abc.ABC):
         ...
 
 
+def _resize_image(path: Path, width: int, height: int) -> None:
+    """Resize an image in place with ImageMagick's ``convert``.
+
+    Raises a ``RuntimeError`` with an actionable message when ``convert`` is
+    missing, times out, or fails, instead of leaking a raw subprocess error.
+    """
+    import subprocess
+
+    try:
+        subprocess.run(
+            ["convert", str(path), "-resize", f"{width}x{height}!", str(path)],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except FileNotFoundError as e:
+        raise RuntimeError(
+            "ImageMagick 'convert' not found. Install ImageMagick to enable "
+            "screenshot resizing (e.g. 'apt install imagemagick' or "
+            "'brew install imagemagick')."
+        ) from e
+    except subprocess.TimeoutExpired as e:
+        raise RuntimeError("Image resize timed out") from e
+    except subprocess.CalledProcessError as e:
+        raise RuntimeError(f"Image resize failed: {e.stderr}") from e
+
+
 # ---------------------------------------------------------------------------
 # Native transport: delegates to existing xdotool/cliclick helpers
 # ---------------------------------------------------------------------------
@@ -238,18 +266,7 @@ class NativeComputerTransport(ComputerTransport):
         if not path.exists():
             raise RuntimeError("Screenshot failed")
         if width and height:
-            import subprocess
-
-            try:
-                subprocess.run(
-                    ["convert", str(path), "-resize", f"{width}x{height}!", str(path)],
-                    check=True,
-                    capture_output=True,
-                    text=True,
-                    timeout=30,
-                )
-            except subprocess.CalledProcessError as e:
-                raise RuntimeError(f"Image resize failed: {e.stderr}") from e
+            _resize_image(path, width, height)
         return path
 
     def cursor_position(self) -> tuple[int, int]:
@@ -533,7 +550,6 @@ class CuaComputerTransport(ComputerTransport):
         self._ensure_sandbox()
         assert self._sandbox is not None
 
-        import subprocess
         import tempfile
 
         async def _capture() -> Path:
@@ -555,13 +571,7 @@ class CuaComputerTransport(ComputerTransport):
 
         path: Path = self._run_async(_capture())  # type: ignore[assignment]
         if width and height:
-            subprocess.run(
-                ["convert", str(path), "-resize", f"{width}x{height}!", str(path)],
-                check=True,
-                capture_output=True,
-                text=True,
-                timeout=30,
-            )
+            _resize_image(path, width, height)
         return path
 
     def cursor_position(self) -> tuple[int, int]:

--- a/tests/test_computer_transport.py
+++ b/tests/test_computer_transport.py
@@ -19,6 +19,7 @@ from gptme.tools.computer_transport import (
     ComputerTransport,
     CuaComputerTransport,
     NativeComputerTransport,
+    _resize_image,
     get_transport,
 )
 
@@ -679,6 +680,49 @@ class TestNativeCursorPositionErrorHandling(unittest.TestCase):
             transport.cursor_position()
 
         self.assertIn("Unexpected xdotool output format", str(ctx.exception))
+
+
+class TestResizeImage(unittest.TestCase):
+    """Error handling for the ImageMagick resize helper."""
+
+    def test_missing_convert_raises_actionable_runtime_error(self):
+        """A missing `convert` binary must surface an install hint, not FileNotFoundError."""
+        with (
+            patch("subprocess.run", side_effect=FileNotFoundError()),
+            self.assertRaises(RuntimeError) as ctx,
+        ):
+            _resize_image(Path("/tmp/shot.png"), 100, 100)
+        self.assertIn("ImageMagick", str(ctx.exception))
+
+    def test_convert_timeout_raises_runtime_error(self):
+        """A convert timeout must raise RuntimeError, not leak TimeoutExpired."""
+        import subprocess
+
+        with (
+            patch(
+                "subprocess.run",
+                side_effect=subprocess.TimeoutExpired(cmd="convert", timeout=30),
+            ),
+            self.assertRaises(RuntimeError) as ctx,
+        ):
+            _resize_image(Path("/tmp/shot.png"), 100, 100)
+        self.assertIn("timed out", str(ctx.exception))
+
+    def test_convert_failure_includes_stderr(self):
+        """A non-zero convert exit must raise RuntimeError carrying stderr."""
+        import subprocess
+
+        with (
+            patch(
+                "subprocess.run",
+                side_effect=subprocess.CalledProcessError(
+                    returncode=1, cmd="convert", stderr="bad image"
+                ),
+            ),
+            self.assertRaises(RuntimeError) as ctx,
+        ):
+            _resize_image(Path("/tmp/shot.png"), 100, 100)
+        self.assertIn("bad image", str(ctx.exception))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

Both `screenshot()` transports in `computer_transport.py` shell out to ImageMagick's `convert` for width/height resizing, but error handling was incomplete:

- **NativeComputerTransport**: caught only `subprocess.CalledProcessError` — a missing `convert` binary raised a raw, unhelpful `FileNotFoundError`, and the `timeout=30` could raise an uncaught `TimeoutExpired`.
- **CuaComputerTransport**: had **no** error handling at all on the resize call.

## Fix

Extract a shared `_resize_image(path, width, height)` helper that raises an actionable `RuntimeError` for all three failure modes (missing binary, timeout, non-zero exit), mirroring the install-hint pattern already used for `cliclick` in `cursor_position()`. Both transports now call it, removing duplicated logic.

```
ImageMagick 'convert' not found. Install ImageMagick to enable screenshot
resizing (e.g. 'apt install imagemagick' or 'brew install imagemagick').
```

## Tests

Added `TestResizeImage` covering each error path (missing binary → install hint, timeout, non-zero exit → stderr surfaced).

```
37 passed, 4 subtests passed
```

ruff + mypy clean.

Addresses persisted review findings `f-20260512011227180123` (security lens: unhandled FileNotFoundError) and `f-20260512011227673355` (test coverage: missing error-handling test).