### PR TITLE
fix: model-aware temperature and top_p for gpt-5 and moonshot

### DIFF
--- a/gptme/llm/__init__.py
+++ b/gptme/llm/__init__.py
@@ -66,6 +66,7 @@ PROVIDER_DEFAULT_MODELS: dict[str, str] = {
     "groq": "groq/llama-3.1-8b-instant",
     "xai": "xai/grok-3-mini",
     "deepseek": "deepseek/deepseek-chat",
+    "moonshot": "moonshot/kimi-k2.6",
 }
 
 # Mapping from provider name to the environment variable that holds its API key.
@@ -78,6 +79,7 @@ PROVIDER_API_KEYS: dict[str, str] = {
     "groq": "GROQ_API_KEY",
     "xai": "XAI_API_KEY",
     "deepseek": "DEEPSEEK_API_KEY",
+    "moonshot": "MOONSHOT_API_KEY",
     "azure": "AZURE_OPENAI_API_KEY",
 }
 

--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -86,20 +86,18 @@ def _get_temperature(provider: Provider, model_meta: "ModelMeta | None" = None) 
     """
     if provider == "moonshot":
         return 1.0
-    if model_meta is not None and model_meta.supports_responses_api:
-        return 1.0
     if provider == "openai" and model_meta is not None and "gpt-5" in model_meta.model:
         return 1.0
     return TEMPERATURE
 
 
-def _get_top_p(provider: Provider, model_meta=None) -> float | None:
+def _get_top_p(provider: Provider, model_meta: "ModelMeta | None" = None) -> float | None:
     """Return the top_p for a given provider.
 
     Moonshot/Kimi models require top_p=0.95. All others use the global default.
     Returns None for models that don't support top_p (e.g., gpt-5.x).
     """
-    if model_meta and provider == "openai" and "gpt-5" in getattr(model_meta, 'model', ''):
+    if model_meta is not None and provider == "openai" and "gpt-5" in model_meta.model:
         return None
     if provider == "moonshot":
         return 0.95

--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -77,6 +77,35 @@ def _get_provider_api_key(config: Config, provider: Provider, env_var: str) -> s
 # `from gptme.llm.llm_openai import OPENROUTER_APP_HEADERS` imports.
 
 
+def _get_temperature(provider: Provider, model_meta: "ModelMeta | None" = None) -> float:
+    """Return the temperature for a given provider/model.
+
+    Moonshot/Kimi models require temperature=1.
+    OpenAI GPT-5 class models require temperature=1.
+    All others use the global default.
+    """
+    if provider == "moonshot":
+        return 1.0
+    if model_meta is not None and model_meta.supports_responses_api:
+        return 1.0
+    if provider == "openai" and model_meta is not None and "gpt-5" in model_meta.model:
+        return 1.0
+    return TEMPERATURE
+
+
+def _get_top_p(provider: Provider, model_meta=None) -> float | None:
+    """Return the top_p for a given provider.
+
+    Moonshot/Kimi models require top_p=0.95. All others use the global default.
+    Returns None for models that don't support top_p (e.g., gpt-5.x).
+    """
+    if model_meta and provider == "openai" and "gpt-5" in getattr(model_meta, 'model', ''):
+        return None
+    if provider == "moonshot":
+        return 0.95
+    return TOP_P
+
+
 def _record_usage(usage, model: str) -> MessageMetadata | None:
     """Record usage metrics as telemetry and return MessageMetadata."""
     if not usage:
@@ -401,6 +430,13 @@ def init(provider: Provider, config: Config):
         api_key = _get_provider_api_key(config, provider, "DEEPSEEK_API_KEY")
         clients[provider] = OpenAI(
             api_key=api_key, base_url="https://api.deepseek.com/v1", timeout=timeout
+        )
+    elif provider == "moonshot":
+        api_key = _get_provider_api_key(config, provider, "MOONSHOT_API_KEY")
+        clients[provider] = OpenAI(
+            api_key=api_key,
+            base_url="https://api.moonshot.ai/v1",
+            timeout=timeout,
         )
     elif provider == "nvidia":
         api_key = _get_provider_api_key(config, provider, "NVIDIA_API_KEY")
@@ -774,8 +810,10 @@ def chat(
         if max_tokens is not None:
             response_kwargs["max_output_tokens"] = max_tokens
         if not is_reasoner:
-            response_kwargs["temperature"] = TEMPERATURE
-            response_kwargs["top_p"] = TOP_P
+            response_kwargs["temperature"] = _get_temperature(provider, model_meta)
+            top_p = _get_top_p(provider, model_meta)
+            if top_p is not None:
+                response_kwargs["top_p"] = top_p
 
         response = client.responses.create(**response_kwargs)
         metadata = _record_usage(response.usage, model)
@@ -810,8 +848,10 @@ def chat(
     # Build optional kwargs to avoid NOT_GIVEN/Omit type mismatch
     optional_kwargs: dict[str, Any] = {}
     if not is_reasoner:
-        optional_kwargs["temperature"] = TEMPERATURE
-        optional_kwargs["top_p"] = TOP_P
+        optional_kwargs["temperature"] = _get_temperature(provider, model_meta)
+        top_p = _get_top_p(provider, model_meta)
+        if top_p is not None:
+            optional_kwargs["top_p"] = top_p
     if tools_dict:
         optional_kwargs["tools"] = tools_dict
     if response_format is not None:
@@ -1001,8 +1041,10 @@ def _stream_responses(
     if max_tokens is not None:
         kwargs["max_output_tokens"] = max_tokens
     if not is_reasoner:
-        kwargs["temperature"] = TEMPERATURE
-        kwargs["top_p"] = TOP_P
+        kwargs["temperature"] = _get_temperature(provider, model_meta)
+        top_p = _get_top_p(provider, model_meta)
+        if top_p is not None:
+            kwargs["top_p"] = top_p
 
     # Track function-call items: output_index -> (item_id, name, call_id)
     func_call_items: dict[int, tuple[str, str, str]] = {}
@@ -1147,8 +1189,10 @@ def stream(
     # Build optional kwargs to avoid NOT_GIVEN/Omit type mismatch
     optional_kwargs: dict[str, Any] = {}
     if not is_reasoner:
-        optional_kwargs["temperature"] = TEMPERATURE
-        optional_kwargs["top_p"] = TOP_P
+        optional_kwargs["temperature"] = _get_temperature(provider, model_meta)
+        top_p = _get_top_p(provider, model_meta)
+        if top_p is not None:
+            optional_kwargs["top_p"] = top_p
     if tools_dict:
         optional_kwargs["tools"] = tools_dict
     if response_format is not None:

--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -86,7 +86,7 @@ def _get_temperature(provider: Provider, model_meta: "ModelMeta | None" = None) 
     """
     if provider == "moonshot":
         return 1.0
-    if provider == "openai" and model_meta is not None and "gpt-5" in model_meta.model:
+    if model_meta is not None and "gpt-5" in model_meta.model:
         return 1.0
     return TEMPERATURE
 
@@ -97,7 +97,7 @@ def _get_top_p(provider: Provider, model_meta: "ModelMeta | None" = None) -> flo
     Moonshot/Kimi models require top_p=0.95. All others use the global default.
     Returns None for models that don't support top_p (e.g., gpt-5.x).
     """
-    if model_meta is not None and provider == "openai" and "gpt-5" in model_meta.model:
+    if model_meta is not None and "gpt-5" in model_meta.model:
         return None
     if provider == "moonshot":
         return 0.95

--- a/gptme/llm/models/data.py
+++ b/gptme/llm/models/data.py
@@ -460,6 +460,26 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
             "preferred_edit_format": "diff",
         },
     },
+    "moonshot": {
+        # https://platform.moonshot.ai/docs
+        # All kimi models require temperature=1; handled in llm_openai.py
+        "kimi-k2.6": {
+            "context": 262_144,
+            "max_output": 262_144,
+            "price_input": 0.60,
+            "price_output": 2.40,
+            "supports_vision": True,
+            "preferred_edit_format": "diff",
+        },
+        "kimi-k2": {
+            "context": 262_144,
+            "max_output": 262_144,
+            "price_input": 0.38,
+            "price_output": 1.52,
+            "supports_vision": True,
+            "preferred_edit_format": "diff",
+        },
+    },
     "nvidia": {},
     "azure": {},
     # gptme managed service — proxies to multiple providers

--- a/gptme/llm/models/types.py
+++ b/gptme/llm/models/types.py
@@ -49,6 +49,7 @@ BuiltinProvider = Literal[
     "groq",
     "xai",
     "deepseek",
+    "moonshot",
     "nvidia",
     "local",
 ]
@@ -95,6 +96,7 @@ PROVIDERS_OPENAI = [
     "xai",
     "groq",
     "deepseek",
+    "moonshot",
     "nvidia",
     "local",
 ]


### PR DESCRIPTION
> **Note:** This PR was authored by Hermes, an AI agent (running on DeepSeek, via Hermes Agent). It was prompted by a user who discovered the top_p bug while running gptme with `openai/gpt-5.5`. All code changes were AI-generated; review accordingly.


## Summary

GPT-5.x models reject the `top_p` parameter (400: `Unsupported parameter: 'top_p' is not supported with this model`). Moonshot/Kimi models require `temperature=1` and `top_p=0.95`. Previously, both parameters were hardcoded constants applied to all providers unconditionally.

This PR replaces the hardcoded `TEMPERATURE` and `TOP_P` constants with model-aware helpers that return provider-appropriate values.

## Changes

### Model-aware helpers
- **`_get_temperature()`** — returns 1.0 for moonshot (requirement) and gpt-5 (requirement), global default for all others
- **`_get_top_p()`** — returns `None` for gpt-5 (unsupported), 0.95 for moonshot, global default for all others

### Call site updates
All 4 locations where temperature/top_p are set now use the helpers:
- Responses API (chat)
- Chat completions API (chat)
- Responses API (stream)
- Chat completions API (stream)

### Moonshot provider support
- Registered as `BuiltinProvider` and `PROVIDERS_OPENAI`
- Client init via `api.moonshot.ai/v1` (OpenAI-compatible)
- Model definitions: kimi-k2.6 ($0.60/$2.40), kimi-k2 ($0.38/$1.52)

## Known issue (from Greptile review)

The `supports_responses_api` branch in `_get_temperature` is dead code — all current responses-API models are reasoners and skip temperature/top_p at the call sites already. This is defensive forward-compatibility. If preferred, it can be removed to keep `_get_temperature` symmetrical with `_get_top_p`.

## Test Plan

- [x] gpt-5.5 via OpenAI: confirmed working (was failing with 400 before fix)
- [x] kimi-k2.6 via Moonshot: confirmed working
- [ ] Existing model behavior unchanged (temperature/top_p unchanged for non-gpt-5, non-moonshot providers)