### PR TITLE
fix(test): use CliRunner instead of subprocess in TestModelsInfo to prevent CI timeouts

### DIFF
--- a/tests/test_util_cli_models.py
+++ b/tests/test_util_cli_models.py
@@ -1,8 +1,7 @@
 """Tests for the models-related gptme-util CLI commands."""
 
 import json
-import subprocess
-import sys
+import types
 from unittest.mock import Mock, patch
 
 from click.testing import CliRunner
@@ -175,22 +174,20 @@ class TestModelsInfo:
         assert "detailed information about a specific model" in result.output
 
     @staticmethod
-    def _run_models_info(*args: str) -> "subprocess.CompletedProcess[str]":
-        """Invoke 'gptme-util models info' as a subprocess for separate stdout/stderr."""
-        return subprocess.run(
-            [
-                sys.executable,
-                "-c",
-                "import sys; sys.argv=['gptme-util'] + sys.argv[1:];"
-                "from gptme.cli.util import main; main()",
-                "models",
-                "info",
-                *args,
-            ],
-            capture_output=True,
-            text=True,
-            check=False,
+    def _run_models_info(*args: str):
+        """Invoke 'gptme-util models info' via CliRunner for separate stdout/stderr capture.
+
+        Uses mix_stderr=False so stdout and stderr are independently accessible without
+        spawning a subprocess (which is slow on CI and can hit pytest timeouts).
+        """
+        runner = CliRunner(mix_stderr=False)  # type: ignore[call-arg]
+        r = runner.invoke(main, ["models", "info", *args])
+        result = types.SimpleNamespace(
+            returncode=r.exit_code,
+            stdout=r.output,
+            stderr=r.stderr or "",
         )
+        return result
 
     def test_known_model_no_warning(self):
         """A recognized provider/model shows info with no fallback warning."""


### PR DESCRIPTION
## Problem

`TestModelsInfo._run_models_info` spawns a full Python subprocess with no timeout.
On slow CI runners, `test_unknown_provider_warns_on_stderr` takes ~10s, hitting
pytest's 10s timeout and causing the master CI run to fail:

```
FAILED tests/test_util_cli_models.py::TestModelsInfo::test_unknown_provider_warns_on_stderr - Failed: Timeout >10.0s
```

The root cause: cold-starting a Python process that imports gptme for a
`bogus/model` lookup is significantly slower than `anthropic/claude-opus-4-7`
(which hit a cache path earlier in the same test run).

## Fix

Replace `subprocess.run()` with `CliRunner(mix_stderr=False)`. This is:
- **In-process**: no Python startup overhead
- **Correct**: `mix_stderr=False` preserves separate stdout/stderr capture, so
  the existing assertions (`result.stdout`, `result.stderr`) work unchanged
- **Fast**: verified locally at ~0.2s per test vs the former ~10s

## Test

All 4 `TestModelsInfo` tests pass locally in 5.01s total (down from one test
nearly consuming the full 10s budget alone).

```
tests/test_util_cli_models.py::TestModelsInfo::test_help PASSED
tests/test_util_cli_models.py::TestModelsInfo::test_known_model_no_warning PASSED
tests/test_util_cli_models.py::TestModelsInfo::test_unknown_provider_warns_on_stderr PASSED
tests/test_util_cli_models.py::TestModelsInfo::test_unknown_provider_json_stays_clean PASSED
4 passed in 5.01s
```