### PR TITLE
fix(util-cli): reject empty --model in llm generate

### DIFF
--- a/gptme/cli/util.py
+++ b/gptme/cli/util.py
@@ -613,6 +613,11 @@ def llm_generate(
         print("Error: Empty prompt provided.", file=sys.stderr)
         sys.exit(1)
 
+    # Validate empty model before initialization (before redirect_stderr
+    # so Click can print the UsageError to real stderr, not the captured sink)
+    if model is not None and not model.strip():
+        raise click.UsageError("Model name cannot be empty.")
+
     # Capture stderr to suppress console output during initialization
     stderr_capture = io.StringIO()
 

--- a/tests/test_util_cli.py
+++ b/tests/test_util_cli.py
@@ -859,6 +859,15 @@ def test_llm_generate_unknown_model():
     assert "notareal" in result.output or "Unknown" in result.output
 
 
+def test_llm_generate_empty_model():
+    """gptme-util llm generate --model '' should error cleanly, not silently fall back to default."""
+    runner = CliRunner()
+    result = runner.invoke(main, ["llm", "generate", "--model", "", "hello"])
+    assert result.exit_code == 2
+    assert "Traceback" not in result.output
+    assert "empty" in result.output.lower()
+
+
 def test_llm_generate_prepends_system_message(monkeypatch):
     """llm generate must prepend a system message so Anthropic-compatible providers don't reject it."""
     import unittest.mock as mock


### PR DESCRIPTION
The `gptme-util llm generate` subcommand silently accepted `--model ''`, falling through to the default model without error. Unlike the main CLI (already fixed in #2577), the util-cli path had no empty-string guard.

**Fix**: Adds a pre-init validation in `llm_generate()` that raises `UsageError` for empty/whitespace-only `--model` values, plus a regression test.

**Before**: `gptme-util llm generate --model '' 'hello'` → falls through to default model (silently ignores explicit empty input)
**After**: `gptme-util llm generate --model '' 'hello'` → `Error: Model name cannot be empty.` (exit 2)