### PR TITLE
feat(models): add DeepSeek V4 Pro/Flash/Flash:free via OpenRouter

### DIFF
--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -72,6 +72,7 @@ To select a provider and model, run ``gptme`` with the ``-m``/``--model`` flag s
     gptme "hello" -m openai/gpt-5.5
     gptme "hello" -m anthropic  # will use provider default
     gptme "hello" -m openrouter/x-ai/grok-4
+    gptme "hello" -m openrouter/deepseek/deepseek-v4-pro
     gptme "hello" -m deepseek/deepseek-reasoner
     gptme "hello" -m gemini/gemini-2.5-flash
     gptme "hello" -m groq/llama-3.3-70b-versatile

--- a/gptme/llm/models/data.py
+++ b/gptme/llm/models/data.py
@@ -459,6 +459,29 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
             "supports_vision": True,
             "preferred_edit_format": "diff",
         },
+        # https://openrouter.ai/deepseek/deepseek-v4-pro (pricing verified 2026-05-30)
+        # MIT-licensed open-weight model, ~80.6% SWE-bench Verified
+        "deepseek/deepseek-v4-pro": {
+            "context": 1_000_000,
+            "max_output": 32_768,
+            "price_input": 0.435,
+            "price_output": 0.87,
+            "preferred_edit_format": "diff",
+        },
+        "deepseek/deepseek-v4-flash": {
+            "context": 1_000_000,
+            "max_output": 32_768,
+            "price_input": 0.098,
+            "price_output": 0.197,
+            "preferred_edit_format": "diff",
+        },
+        "deepseek/deepseek-v4-flash:free": {
+            "context": 1_000_000,
+            "max_output": 32_768,
+            "price_input": 0.0,
+            "price_output": 0.0,
+            "preferred_edit_format": "diff",
+        },
     },
     "nvidia": {},
     "azure": {},

--- a/gptme/llm/models/data.py
+++ b/gptme/llm/models/data.py
@@ -466,13 +466,15 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
             "max_output": 32_768,
             "price_input": 0.435,
             "price_output": 0.87,
+            "supports_reasoning": True,
             "preferred_edit_format": "diff",
         },
         "deepseek/deepseek-v4-flash": {
             "context": 1_000_000,
             "max_output": 32_768,
-            "price_input": 0.098,
-            "price_output": 0.197,
+            "price_input": 0.0983,
+            "price_output": 0.1966,
+            "supports_reasoning": True,
             "preferred_edit_format": "diff",
         },
         "deepseek/deepseek-v4-flash:free": {


### PR DESCRIPTION
## Summary

Adds three OpenRouter model entries for DeepSeek V4, a frontier-tier MIT-licensed open-weight model at a fraction of closed-model API costs.

**New model strings:**
- `openrouter/deepseek/deepseek-v4-pro` — $0.435/$0.87 per 1M in/out, 1M context
- `openrouter/deepseek/deepseek-v4-flash` — $0.098/$0.197 per 1M in/out, 1M context
- `openrouter/deepseek/deepseek-v4-flash:free` — free rate-limited tier, 1M context

All three were smoke-tested via OpenRouter (direct chat-completions calls returned `SMOKE_OK`). Pricing sourced from OpenRouter on 2026-05-30.

Also adds a `providers.rst` example showing the V4-Pro OpenRouter path.

## Test plan

- [x] `gptme/llm/models/data.py` assertions pass (all providers have MODELS entry)
- [x] `tests/test_llm_models.py` + `tests/test_llm_models_resolution.py` — 143 tests, all pass
- [ ] Live smoke: `gptme --model openrouter/deepseek/deepseek-v4-pro "hello"` (requires `OPENROUTER_API_KEY`)