### PR TITLE
fix(server): strip whitespace from session_id before emptiness check

### DIFF
--- a/gptme/server/api_v2_sessions.py
+++ b/gptme/server/api_v2_sessions.py
@@ -89,7 +89,7 @@ def _get_required_string_field(
         return flask.jsonify({"error": f"{field} is required"}), 400
     if not isinstance(value, str):
         return flask.jsonify({"error": f"{field} must be a string"}), 400
-    if not value:
+    if not value.strip():
         return flask.jsonify({"error": f"{field} is required"}), 400
     return value
 

--- a/gptme/server/api_v2_sessions.py
+++ b/gptme/server/api_v2_sessions.py
@@ -89,9 +89,10 @@ def _get_required_string_field(
         return flask.jsonify({"error": f"{field} is required"}), 400
     if not isinstance(value, str):
         return flask.jsonify({"error": f"{field} must be a string"}), 400
-    if not value.strip():
+    stripped = value.strip()
+    if not stripped:
         return flask.jsonify({"error": f"{field} is required"}), 400
-    return value
+    return stripped
 
 
 def _get_optional_string_field(
@@ -111,7 +112,7 @@ def _get_optional_string_field(
     stripped = value.strip()
     if not stripped:
         return flask.jsonify({"error": f"{field} must be a non-empty string"}), 400
-    return value
+    return stripped
 
 
 # Re-export step-level symbols that other modules may import from here.

--- a/gptme/server/api_v2_sessions.py
+++ b/gptme/server/api_v2_sessions.py
@@ -97,12 +97,20 @@ def _get_required_string_field(
 def _get_optional_string_field(
     req_json: dict, field: str
 ) -> str | None | tuple[flask.Response, int]:
-    """Return an optional string field or a 400 response."""
+    """Return an optional string field or a 400 response.
+
+    Rejects whitespace-only values with a 400 error, matching the
+    behavior of _get_required_string_field, to prevent misleading
+    404 errors when whitespace-only strings pass truthiness checks.
+    """
     value = req_json.get(field)
     if value is None:
         return None
     if not isinstance(value, str):
         return flask.jsonify({"error": f"{field} must be a string"}), 400
+    stripped = value.strip()
+    if not stripped:
+        return flask.jsonify({"error": f"{field} must be a non-empty string"}), 400
     return value
 
 

--- a/tests/test_server_v2_sessions.py
+++ b/tests/test_server_v2_sessions.py
@@ -857,16 +857,22 @@ class TestRerunEndpoint:
         assert data is not None
         assert data["error"] == "session_id must be a string"
 
-    def test_whitespace_session_id(self, conv, client: FlaskClient):
-        """Rerun with whitespace-only session_id returns 400."""
+    @pytest.mark.parametrize(
+        "whitespace_id",
+        ["   ", "\t", "\n", " \t\n "],
+    )
+    def test_whitespace_only_session_id(
+        self, conv, client: FlaskClient, whitespace_id: str
+    ):
+        """Whitespace-only session_id should be rejected with 400, not 404."""
         response = client.post(
             f"/api/v2/conversations/{conv['conversation_id']}/rerun",
-            json={"session_id": "   "},
+            json={"session_id": whitespace_id},
         )
         assert response.status_code == 400
         data = response.get_json()
         assert data is not None
-        assert "session_id" in data["error"]
+        assert data["error"] == "session_id is required"
 
     def test_rerun_while_generating(self, conv, client: FlaskClient):
         """Rerun while generation in progress returns 409."""

--- a/tests/test_server_v2_sessions.py
+++ b/tests/test_server_v2_sessions.py
@@ -263,6 +263,23 @@ class TestStepEndpoint:
         assert data is not None
         assert data["error"] == "session_id must be a string"
 
+    @pytest.mark.parametrize(
+        "whitespace_id",
+        ["   ", "\t", "\n", " \t\n "],
+    )
+    def test_whitespace_only_session_id(
+        self, conv, client: FlaskClient, whitespace_id: str
+    ):
+        """Whitespace-only session_id should be rejected with 400, not 404."""
+        response = client.post(
+            f"/api/v2/conversations/{conv['conversation_id']}/step",
+            json={"session_id": whitespace_id},
+        )
+        assert response.status_code == 400
+        data = response.get_json()
+        assert data is not None
+        assert data["error"] == "session_id is required"
+
     def test_invalid_use_acp_type(self, conv, client: FlaskClient):
         """Step with non-boolean use_acp returns 400."""
         response = client.post(
@@ -455,6 +472,23 @@ class TestInterruptEndpoint:
         data = response.get_json()
         assert data is not None
         assert data["error"] == "session_id must be a string"
+
+    @pytest.mark.parametrize(
+        "whitespace_id",
+        ["   ", "\t", "\n", " \t\n "],
+    )
+    def test_whitespace_only_session_id(
+        self, conv, client: FlaskClient, whitespace_id: str
+    ):
+        """Whitespace-only session_id should be rejected with 400, not 404."""
+        response = client.post(
+            f"/api/v2/conversations/{conv['conversation_id']}/interrupt",
+            json={"session_id": whitespace_id},
+        )
+        assert response.status_code == 400
+        data = response.get_json()
+        assert data is not None
+        assert data["error"] == "session_id is required"
 
     def test_interrupt_when_not_generating(self, conv, client: FlaskClient):
         """Interrupt when not generating is idempotent (returns 200)."""
@@ -801,6 +835,17 @@ class TestRerunEndpoint:
         data = response.get_json()
         assert data is not None
         assert data["error"] == "session_id must be a string"
+
+    def test_whitespace_session_id(self, conv, client: FlaskClient):
+        """Rerun with whitespace-only session_id returns 400."""
+        response = client.post(
+            f"/api/v2/conversations/{conv['conversation_id']}/rerun",
+            json={"session_id": "   "},
+        )
+        assert response.status_code == 400
+        data = response.get_json()
+        assert data is not None
+        assert "session_id" in data["error"]
 
     def test_rerun_while_generating(self, conv, client: FlaskClient):
         """Rerun while generation in progress returns 409."""

--- a/tests/test_server_v2_sessions.py
+++ b/tests/test_server_v2_sessions.py
@@ -568,6 +568,27 @@ class TestToolConfirmEndpoint:
         assert data is not None
         assert data["error"] == "action must be a string"
 
+    @pytest.mark.parametrize(
+        "whitespace_session_id",
+        ["", "   ", "\t", "\n", "  \t\n  "],
+    )
+    def test_whitespace_session_id(
+        self, conv, client: FlaskClient, whitespace_session_id: str
+    ):
+        """Whitespace-only session_id returns 400 in tool confirm endpoint."""
+        response = client.post(
+            f"/api/v2/conversations/{conv['conversation_id']}/tool/confirm",
+            json={
+                "session_id": whitespace_session_id,
+                "tool_id": "some-tool",
+                "action": "confirm",
+            },
+        )
+        assert response.status_code == 400
+        data = response.get_json()
+        assert data is not None
+        assert "session_id" in data["error"]
+
     @pytest.mark.parametrize("bad_session_id", [["boom"], {"boom": 1}, 0, False])
     def test_non_string_session_id(
         self, conv, client: FlaskClient, bad_session_id: object


### PR DESCRIPTION
`_get_required_string_field` and `_get_optional_string_field` did not
strip whitespace from string values before the emptiness check,
so whitespace-only session_ids passed validation only to fail
with a misleading 404 ("Session not found") instead of a clear 400
("session_id is required").

Fixes by adding `.strip()` to the emptiness check so whitespace-only
values are rejected at the validation layer with the same 400 error
as empty strings.

Pre-existing test coverage for non-string session_id types
(list, dict, int, bool) was already complete and unaffected.

Found via dogfooding: `state/dogfood/server-v2-edge-findings-2026-05-30.jsonl`