### PR TITLE
feat(server): bundle modern webui into package (gptme#2612 Part 2)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -240,6 +240,19 @@ jobs:
     - name: Install poetry
       run: pipx install poetry
 
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+        cache: 'npm'
+        cache-dependency-path: webui/package-lock.json
+
+    - name: Build and bundle webui
+      run: |
+        cd webui && npm ci && npm run build
+        cd ..
+        make bundle-webui
+
     - name: Build Python packages
       run: |
         rm -f dist/*.whl dist/*.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ config.toml
 .vscode
 profiles/
 uv.lock
+
+# Bundled webui build artifact (populated by `make bundle-webui` / CI release)
+gptme/server/webui-dist/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-api docs build build-docker check-rst install-completions help tauri-dev tauri-build tauri-lint tauri-build-sidecar
+.PHONY: test test-api docs build build-docker check-rst install-completions help tauri-dev tauri-build tauri-lint tauri-build-sidecar bundle-webui
 
 # set default shell
 SHELL := $(shell which bash)
@@ -35,6 +35,12 @@ build-docker-full: ## Build full Docker images with Rust and Playwright
 
 build-server-exe: ## Build gptme-server executable with PyInstaller
 	bash ./scripts/build_server_executable.sh
+
+bundle-webui: ## Bundle the modern webui dist into the package (run after `cd webui && npm run build`)
+	@if [ ! -d webui/dist ]; then echo "ERROR: webui/dist not found — run 'npm run build' in the webui/ dir first"; exit 1; fi
+	mkdir -p gptme/server/webui-dist
+	rsync -a --delete webui/dist/ gptme/server/webui-dist/
+	@echo "Bundled webui/dist → gptme/server/webui-dist/ ($(ls gptme/server/webui-dist | wc -l) files at top level)"
 
 test: ## Run tests
 	@# if SLOW is not set, pass `-m "not slow"` to skip slow tests

--- a/gptme/server/app.py
+++ b/gptme/server/app.py
@@ -17,6 +17,8 @@ logger = logging.getLogger(__name__)
 _gptme_path_ctx = resources.as_file(resources.files("gptme"))
 _root_path = _gptme_path_ctx.__enter__()
 static_path = _root_path / "server" / "static"
+# Bundled modern webui (populated by `make bundle-webui` or the release workflow)
+_bundled_webui_path = _root_path / "server" / "webui-dist"
 media_path = _root_path.parent / "media"
 atexit.register(_gptme_path_ctx.__exit__, None, None, None)
 
@@ -25,18 +27,23 @@ def _resolve_static_folder(webui_dir: str | Path | None = None) -> Path:
     """Resolve which directory the web UI is served from.
 
     Precedence: explicit ``webui_dir`` argument > ``GPTME_WEBUI_DIR`` env var >
+    bundled modern webui (``gptme/server/webui-dist/``) >
     the embedded legacy static bundle. A configured directory must exist so
     that a typo fails loudly at startup instead of silently serving 404s.
     """
     candidate = webui_dir or os.environ.get("GPTME_WEBUI_DIR")
-    if not candidate:
-        return static_path
-    path = Path(candidate).expanduser()
-    if not path.is_dir():
-        raise FileNotFoundError(
-            f"webui_dir does not exist or is not a directory: {path}"
-        )
-    return path
+    if candidate:
+        path = Path(candidate).expanduser()
+        if not path.is_dir():
+            raise FileNotFoundError(
+                f"webui_dir does not exist or is not a directory: {path}"
+            )
+        return path
+    # Prefer the bundled modern webui when it has been populated.
+    if _bundled_webui_path.is_dir() and any(_bundled_webui_path.iterdir()):
+        logger.debug("Serving bundled modern webui from %s", _bundled_webui_path)
+        return _bundled_webui_path
+    return static_path
 
 
 def create_app(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ gptme-eval-trends = "gptme.eval.trends:main"
 packages = [
     { include = "gptme" },
 ]
-include = ["gptme/server/static/**/*", "gptme/eval/tbench/setup.sh", "media/*.png", "media/*.wav"]
+include = ["gptme/server/static/**/*", "gptme/server/webui-dist/**/*", "gptme/eval/tbench/setup.sh", "media/*.png", "media/*.wav"]
 
 [tool.poetry.dependencies]
 python = "^3.10"

--- a/tests/test_server_webui_dir.py
+++ b/tests/test_server_webui_dir.py
@@ -19,9 +19,13 @@ pytest.importorskip(
 )
 
 
-def test_default_static_folder_is_legacy_bundle():
+def test_default_static_folder_is_legacy_bundle(tmp_path, monkeypatch):
+    import gptme.server.app as app_mod
     from gptme.server.app import create_app, static_path
 
+    monkeypatch.delenv("GPTME_WEBUI_DIR", raising=False)
+    # Ensure no bundled webui-dist interferes (e.g. after `make bundle-webui`)
+    monkeypatch.setattr(app_mod, "_bundled_webui_path", tmp_path / "webui-dist")
     app = create_app()
     assert app.static_folder == str(static_path)
 

--- a/tests/test_server_webui_dir.py
+++ b/tests/test_server_webui_dir.py
@@ -1,8 +1,12 @@
 """Tests for serving a custom web UI directory from gptme-server.
 
-Coverage for gptme/gptme#2612: a self-hoster can point gptme-server at the
+Coverage for gptme/gptme#2612 Part 1: a self-hoster can point gptme-server at the
 modern React webui build via ``--webui-dir`` / ``GPTME_WEBUI_DIR`` instead of
 the bundled legacy static UI.
+
+Coverage for gptme/gptme#2612 Part 2: when the package ships a bundled
+``gptme/server/webui-dist/`` (populated by ``make bundle-webui`` or the release
+CI), the server auto-detects and prefers it over the legacy static bundle.
 """
 
 import pytest
@@ -114,3 +118,78 @@ def test_spa_catch_all_serves_actual_asset_files(tmp_path):
         resp = client.get("/assets/main.js")
         assert resp.status_code == 200
         assert b"console.log" in resp.data
+
+
+# ── Part 2: bundled webui-dist ────────────────────────────────────────────────
+
+
+def test_bundled_webui_dist_used_when_populated(tmp_path, monkeypatch):
+    """When gptme/server/webui-dist/ is non-empty, the server auto-prefers it."""
+    import gptme.server.app as app_mod
+    from gptme.server.app import create_app
+
+    bundled = tmp_path / "webui-dist"
+    bundled.mkdir()
+    (bundled / "index.html").write_text("<html>bundled-modern</html>")
+
+    monkeypatch.setattr(app_mod, "_bundled_webui_path", bundled)
+    app = create_app()
+
+    assert app.static_folder == str(bundled)
+    with app.test_client() as client:
+        resp = client.get("/")
+        assert resp.status_code == 200
+        assert b"bundled-modern" in resp.data
+
+
+def test_bundled_webui_dist_empty_falls_back_to_legacy(tmp_path, monkeypatch):
+    """An empty (or missing) webui-dist dir falls back to the legacy bundle."""
+    import gptme.server.app as app_mod
+    from gptme.server.app import create_app, static_path
+
+    empty = tmp_path / "webui-dist"
+    empty.mkdir()  # exists but no files
+
+    monkeypatch.setattr(app_mod, "_bundled_webui_path", empty)
+    app = create_app()
+
+    assert app.static_folder == str(static_path)
+
+
+def test_explicit_webui_dir_beats_bundled(tmp_path, monkeypatch):
+    """An explicit --webui-dir arg takes priority over the bundled webui-dist."""
+    import gptme.server.app as app_mod
+    from gptme.server.app import create_app
+
+    bundled = tmp_path / "bundled"
+    bundled.mkdir()
+    (bundled / "index.html").write_text("<html>bundled</html>")
+
+    explicit = tmp_path / "explicit"
+    explicit.mkdir()
+    (explicit / "index.html").write_text("<html>explicit</html>")
+
+    monkeypatch.setattr(app_mod, "_bundled_webui_path", bundled)
+    app = create_app(webui_dir=explicit)
+
+    assert app.static_folder == str(explicit)
+
+
+def test_env_var_beats_bundled(tmp_path, monkeypatch):
+    """GPTME_WEBUI_DIR env var takes priority over the bundled webui-dist."""
+    import gptme.server.app as app_mod
+    from gptme.server.app import create_app
+
+    bundled = tmp_path / "bundled"
+    bundled.mkdir()
+    (bundled / "index.html").write_text("<html>bundled</html>")
+
+    env_dir = tmp_path / "env"
+    env_dir.mkdir()
+    (env_dir / "index.html").write_text("<html>env</html>")
+
+    monkeypatch.setattr(app_mod, "_bundled_webui_path", bundled)
+    monkeypatch.setenv("GPTME_WEBUI_DIR", str(env_dir))
+    app = create_app()
+
+    assert app.static_folder == str(env_dir)

--- a/tests/test_server_webui_dir.py
+++ b/tests/test_server_webui_dir.py
@@ -128,6 +128,7 @@ def test_bundled_webui_dist_used_when_populated(tmp_path, monkeypatch):
     import gptme.server.app as app_mod
     from gptme.server.app import create_app
 
+    monkeypatch.delenv("GPTME_WEBUI_DIR", raising=False)
     bundled = tmp_path / "webui-dist"
     bundled.mkdir()
     (bundled / "index.html").write_text("<html>bundled-modern</html>")
@@ -147,6 +148,7 @@ def test_bundled_webui_dist_empty_falls_back_to_legacy(tmp_path, monkeypatch):
     import gptme.server.app as app_mod
     from gptme.server.app import create_app, static_path
 
+    monkeypatch.delenv("GPTME_WEBUI_DIR", raising=False)
     empty = tmp_path / "webui-dist"
     empty.mkdir()  # exists but no files
 


### PR DESCRIPTION
## Summary

Completes Part 2 of #2612: ship the modern React webui inside the wheel so `pip install gptme && gptme-server serve` serves the modern UI without the `--webui-dir` flag.

- **Auto-detection**: `_resolve_static_folder` now checks `gptme/server/webui-dist/` (new bundle slot) and prefers it over the legacy `server/static/` when non-empty. Full precedence: `--webui-dir arg` > `GPTME_WEBUI_DIR` env > bundled `webui-dist/` > legacy static.
- **`make bundle-webui`**: copies `webui/dist/ → gptme/server/webui-dist/` for local dev/testing.
- **`pyproject.toml`**: includes `gptme/server/webui-dist/**/*` in the wheel.
- **`.gitignore`**: excludes the generated directory from git.
- **`release.yml`**: adds `setup-node@v4` + `npm ci && npm run build` + `make bundle-webui` before `poetry build`, so PyPI releases ship the modern UI automatically.
- **Tests**: 4 new tests in `test_server_webui_dir.py` covering bundled-webui preference, empty-dir fallback, and `--webui-dir`/env-var override precedence.

## Test plan

- [x] `uv run pytest tests/test_server_webui_dir.py -v` — 12/12 passed
- [ ] Verify CI release workflow builds the webui and includes it in the wheel
- [ ] `pip install gptme && gptme-server serve` should serve the modern webui without flags

## Notes

The `gptme/server/webui-dist/` directory is gitignored (it's a build artifact). It gets populated either by `make bundle-webui` (for local testing) or by the release CI workflow (for published wheels). Users on editable installs who want the modern UI without a flag can run `make bundle-webui` locally after `cd webui && npm run build`.

Closes #2612