### PR TITLE
feat(tools): add atomic patch_many tool

### DIFF
--- a/gptme/tools/patch_many.py
+++ b/gptme/tools/patch_many.py
@@ -202,7 +202,7 @@ def execute_patch_many_impl(
             # Roll back any already-written files to preserve atomicity
             for rolled_back in written:
                 try:
-                    rolled_back.write_text(originals[rolled_back])
+                    rolled_back.write_text(originals[rolled_back], encoding="utf-8")
                 except OSError:
                     pass  # best-effort rollback
             yield Message(

--- a/gptme/tools/patch_many.py
+++ b/gptme/tools/patch_many.py
@@ -24,10 +24,45 @@ instructions = """
 Apply patches to multiple files in one atomic operation.
 Patches are validated in-memory: if ANY fails, NO files are written.
 
-Space-separated paths follow the opening fence; write one conflict-marker patch
-per path (same format as `patch`), in the same order.
+Two markdown formats are supported:
+
+**Simple** (one hunk per file) — paths in the fence header:
+  ```patch_many path1.py path2.py
+  <<<<<<< ORIGINAL
+  old content for path1
+  =======
+  new content for path1
+  >>>>>>> UPDATED
+  <<<<<<< ORIGINAL
+  old content for path2
+  =======
+  new content for path2
+  >>>>>>> UPDATED
+  ```
+
+**Multi-hunk** (any number of hunks per file) — paths embedded with === PATH: ... === headers:
+  ```patch_many
+  === PATH: path1.py ===
+  <<<<<<< ORIGINAL
+  first hunk original
+  =======
+  first hunk updated
+  >>>>>>> UPDATED
+  <<<<<<< ORIGINAL
+  second hunk original
+  =======
+  second hunk updated
+  >>>>>>> UPDATED
+  === PATH: path2.py ===
+  <<<<<<< ORIGINAL
+  path2 original
+  =======
+  path2 updated
+  >>>>>>> UPDATED
+  ```
 
 Tool-call: pass `patches` as a JSON array of {"path": "...", "patch": "..."} entries.
+Each "patch" string may contain multiple ORIGINAL/UPDATED blocks for that file.
 """.strip()
 
 
@@ -235,13 +270,13 @@ def execute_patch_many(
     """Execute patch_many from a markdown block or tool/function-call kwargs."""
     if code is None and kwargs is not None and "patches" in kwargs:
         try:
-            patch_entries = _parse_patches_from_kwargs(kwargs)
+            kwarg_entries = _parse_patches_from_kwargs(kwargs)
         except (ValueError, json.JSONDecodeError) as e:
             yield Message("system", f"Error parsing patches from kwargs: {e}")
             return
 
         yield from execute_with_confirmation(
-            _serialize_confirmation_payload(patch_entries),
+            _serialize_confirmation_payload(kwarg_entries),
             args,
             kwargs,
             execute_fn=_execute_patch_many_confirmed,
@@ -254,6 +289,26 @@ def execute_patch_many(
         yield Message("system", "No patch content provided")
         return
 
+    # Multi-hunk format: paths embedded in content with === PATH: ... === headers
+    if _CONFIRM_HEADER in code:
+        try:
+            patch_entries: list[tuple[Path, str | Patch]] = list(
+                _parse_confirmation_payload(code)
+            )
+        except ValueError as e:
+            yield Message("system", f"Error parsing patches: {e}")
+            return
+        yield from execute_with_confirmation(
+            _serialize_confirmation_payload(patch_entries),
+            args,
+            kwargs,
+            execute_fn=_execute_patch_many_confirmed,
+            get_path_fn=_get_confirmation_path,
+            allow_edit=True,
+        )
+        return
+
+    # Simple format: space-separated paths in fence header, one hunk per file
     if not args or not args[0]:
         yield Message(
             "system",
@@ -263,7 +318,9 @@ def execute_patch_many(
 
     try:
         paths = [_resolve_path(arg) for arg in args]
-        patch_pairs = _parse_patches_from_content(code, paths)
+        patch_pairs: list[tuple[Path, str | Patch]] = list(
+            _parse_patches_from_content(code, paths)
+        )
     except ValueError as e:
         yield Message("system", f"Error parsing patches: {e}")
         return

--- a/gptme/tools/patch_many.py
+++ b/gptme/tools/patch_many.py
@@ -55,9 +55,16 @@ def _parse_patches_from_content(
     """Parse multiple conflict-marker patches from markdown content and pair with paths."""
     patches = list(Patch.from_codeblock(content))
     if len(patches) != len(paths):
+        if len(patches) > len(paths):
+            raise ValueError(
+                f"Got {len(patches)} patch(es) but {len(paths)} file path(s). "
+                "The markdown format supports exactly one hunk per file. "
+                "For multi-hunk patches, use the kwargs format: pass a 'patches' array "
+                "where each entry's 'patch' field contains all hunks for that file."
+            )
         raise ValueError(
             f"Got {len(patches)} patch(es) but {len(paths)} file path(s). "
-            "The number of patches must match the number of file paths."
+            "Each file path must have a corresponding conflict-marker patch."
         )
     return list(zip(paths, patches))
 

--- a/gptme/tools/patch_many.py
+++ b/gptme/tools/patch_many.py
@@ -21,39 +21,13 @@ if TYPE_CHECKING:
     from collections.abc import Generator, Mapping, Sequence
 
 instructions = """
-Apply multiple patches to multiple files in a single atomic operation.
+Apply patches to multiple files in one atomic operation.
+Patches are validated in-memory: if ANY fails, NO files are written.
 
-All patches are resolved in-memory first. If ANY patch fails, NO files are written.
-Use this for cross-cutting changes that touch multiple files.
+Space-separated paths follow the opening fence; write one conflict-marker patch
+per path (same format as `patch`), in the same order.
 
-### Format
-
-The codeblock takes space-separated file paths and one conflict-marker patch per file:
-
-    ```patch_many path/to/file1.py path/to/file2.py
-
-    <<<<<<< ORIGINAL
-    original content
-    =======
-    updated content
-    >>>>>>> UPDATED
-
-    <<<<<<< ORIGINAL
-    original content
-    =======
-    updated content
-    >>>>>>> UPDATED
-    ```
-
-Each patch corresponds to the file at the same position in the path list.
-All patches are validated in-memory before writing any file.
-
-For tool/function-call format, pass a `patches` JSON array string:
-
-    [
-      {"path": "path/to/file1.py", "patch": "<<<<<<< ORIGINAL\\n..."},
-      {"path": "path/to/file2.py", "patch": "<<<<<<< ORIGINAL\\n..."}
-    ]
+Tool-call: pass `patches` as a JSON array of {"path": "...", "patch": "..."} entries.
 """.strip()
 
 

--- a/gptme/tools/patch_many.py
+++ b/gptme/tools/patch_many.py
@@ -8,12 +8,14 @@ where the model would otherwise issue N separate patch calls, one per file.
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 from ..message import Message
+from ..util.ask_execute import execute_with_confirmation
 from .base import Parameter, ToolSpec
-from .patch import Patch, apply
+from .patch import DIVIDER, ORIGINAL, UPDATED, Patch, apply
 
 if TYPE_CHECKING:
     from collections.abc import Generator, Mapping, Sequence
@@ -117,6 +119,63 @@ def _parse_patches_from_kwargs(kwargs: Mapping[str, object]) -> list[tuple[Path,
     return result
 
 
+_CONFIRM_HEADER = "=== PATH: "
+_CONFIRM_HEADER_RE = re.compile(
+    rf"(?ms)^{re.escape(_CONFIRM_HEADER)}(?P<path>.+?) ===\n"
+    r"(?P<patch>.*?)(?=^=== PATH: |\Z)"
+)
+
+
+def _stringify_patch(patch_src: str | Patch) -> str:
+    """Serialize a patch source into the standard conflict-marker format."""
+    if isinstance(patch_src, Patch):
+        return (
+            f"{ORIGINAL}{patch_src.original}{DIVIDER}{patch_src.updated}{UPDATED}"
+        ).strip()
+    return patch_src.strip()
+
+
+def _serialize_confirmation_payload(
+    patches: Sequence[tuple[Path, str | Patch]],
+) -> str:
+    """Build an editable multi-file payload for the confirmation hook."""
+    return "\n\n".join(
+        f"{_CONFIRM_HEADER}{path} ===\n{_stringify_patch(patch_src)}"
+        for path, patch_src in patches
+    )
+
+
+def _parse_confirmation_payload(content: str) -> list[tuple[Path, str]]:
+    """Parse the confirmation payload back into path/patch pairs."""
+    matches = list(_CONFIRM_HEADER_RE.finditer(content.strip()))
+    if not matches:
+        raise ValueError(
+            "Invalid patch_many payload: expected one or more '=== PATH: ... ===' sections"
+        )
+
+    return [
+        (_resolve_path(match.group("path")), match.group("patch").strip())
+        for match in matches
+    ]
+
+
+def _get_confirmation_path(
+    code: str | None, args: list[str] | None, kwargs: dict[str, str] | None
+) -> Path | None:
+    """patch_many confirms a multi-file payload, so there is no single target path."""
+    del code, args, kwargs
+    return None
+
+
+def _execute_patch_many_confirmed(
+    content: str, path: Path | None
+) -> Generator[Message, None, None]:
+    """Execute a confirmed patch_many payload."""
+    del path
+    patches = _parse_confirmation_payload(content)
+    yield from execute_patch_many_impl(patches)
+
+
 def execute_patch_many_impl(
     patches: Sequence[tuple[Path, str | Patch]],
 ) -> Generator[Message, None, None]:
@@ -200,7 +259,14 @@ def execute_patch_many(
             yield Message("system", f"Error parsing patches from kwargs: {e}")
             return
 
-        yield from execute_patch_many_impl(patch_entries)
+        yield from execute_with_confirmation(
+            _serialize_confirmation_payload(patch_entries),
+            args,
+            kwargs,
+            execute_fn=_execute_patch_many_confirmed,
+            get_path_fn=_get_confirmation_path,
+            allow_edit=True,
+        )
         return
 
     if not code:
@@ -221,7 +287,14 @@ def execute_patch_many(
         yield Message("system", f"Error parsing patches: {e}")
         return
 
-    yield from execute_patch_many_impl(patch_pairs)
+    yield from execute_with_confirmation(
+        _serialize_confirmation_payload(patch_pairs),
+        args,
+        kwargs,
+        execute_fn=_execute_patch_many_confirmed,
+        get_path_fn=_get_confirmation_path,
+        allow_edit=True,
+    )
 
 
 tool_patch_many = ToolSpec(

--- a/gptme/tools/patch_many.py
+++ b/gptme/tools/patch_many.py
@@ -86,9 +86,12 @@ def _resolve_path(raw_path: str) -> Path:
 
 def _parse_patches_from_content(
     content: str, paths: list[Path]
-) -> list[tuple[Path, Patch]]:
+) -> list[tuple[Path, str]]:
     """Parse multiple conflict-marker patches from markdown content and pair with paths."""
-    patches = list(Patch.from_codeblock(content))
+    # Count top-level ORIGINAL/UPDATED blocks here, not placeholder-expanded hunks.
+    # A single patch block may legitimately expand to multiple replacements when
+    # `apply()` handles placeholder markers like `# ...`.
+    patches = [_stringify_patch(patch) for patch in Patch._from_codeblock(content)]
     if len(patches) != len(paths):
         if len(patches) > len(paths):
             raise ValueError(

--- a/gptme/tools/patch_many.py
+++ b/gptme/tools/patch_many.py
@@ -126,6 +126,7 @@ def execute_patch_many_impl(
         return
 
     resolved: list[tuple[Path, str]] = []
+    originals: dict[Path, str] = {}
 
     for path, patch_src in patches:
         if not path.exists():
@@ -158,16 +159,31 @@ def execute_patch_many_impl(
             return
 
         resolved.append((path, new_content))
+        originals[path] = original
 
-    written: list[str] = []
+    written: list[Path] = []
     for path, new_content in resolved:
-        path.write_text(new_content, encoding="utf-8")
-        written.append(str(path))
+        try:
+            path.write_text(new_content, encoding="utf-8")
+        except OSError as e:
+            # Roll back any already-written files to preserve atomicity
+            for rolled_back in written:
+                try:
+                    rolled_back.write_text(originals[rolled_back])
+                except OSError:
+                    pass  # best-effort rollback
+            yield Message(
+                "system",
+                f"Atomic patch failed: write error on `{path}`: {e}. "
+                f"Rolled back {len(written)} file(s). No files were modified.",
+            )
+            return
+        written.append(path)
 
     yield Message(
         "system",
         f"Applied {len(written)} patch(es) atomically to:\n"
-        + "\n".join(f"  - {path}" for path in written),
+        + "\n".join(f"  - {p}" for p in written),
     )
 
 

--- a/gptme/tools/patch_many.py
+++ b/gptme/tools/patch_many.py
@@ -290,7 +290,9 @@ def execute_patch_many(
         return
 
     # Multi-hunk format: paths embedded in content with === PATH: ... === headers
-    if _CONFIRM_HEADER in code:
+    # Use the anchored regex (not a bare substring check) to avoid misrouting
+    # simple-format patches whose content happens to contain "=== PATH: ".
+    if _CONFIRM_HEADER_RE.search(code):
         try:
             patch_entries: list[tuple[Path, str | Patch]] = list(
                 _parse_confirmation_payload(code)

--- a/gptme/tools/patch_many.py
+++ b/gptme/tools/patch_many.py
@@ -21,10 +21,10 @@ if TYPE_CHECKING:
     from collections.abc import Generator, Mapping, Sequence
 
 instructions = """
-Apply patches to multiple files in one atomic operation.
+Apply patches to multiple files atomically.
 Patches are validated in-memory: if ANY fails, NO files are written.
 
-Two markdown formats are supported:
+Two formats:
 
 **Simple** (one hunk per file) — paths in the fence header:
   ```patch_many path1.py path2.py

--- a/gptme/tools/patch_many.py
+++ b/gptme/tools/patch_many.py
@@ -1,0 +1,229 @@
+"""
+Gives the LLM agent the ability to patch multiple files atomically in one tool call.
+
+Intended for cross-cutting changes ("rename this class", "add a param and update callers")
+where the model would otherwise issue N separate patch calls, one per file.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from ..message import Message
+from .base import Parameter, ToolSpec
+from .patch import Patch, apply
+
+if TYPE_CHECKING:
+    from collections.abc import Generator, Mapping, Sequence
+
+instructions = """
+Apply multiple patches to multiple files in a single atomic operation.
+
+All patches are resolved in-memory first. If ANY patch fails, NO files are written.
+Use this for cross-cutting changes that touch multiple files.
+
+### Format
+
+The codeblock takes space-separated file paths and one conflict-marker patch per file:
+
+    ```patch_many path/to/file1.py path/to/file2.py
+
+    <<<<<<< ORIGINAL
+    original content
+    =======
+    updated content
+    >>>>>>> UPDATED
+
+    <<<<<<< ORIGINAL
+    original content
+    =======
+    updated content
+    >>>>>>> UPDATED
+    ```
+
+Each patch corresponds to the file at the same position in the path list.
+All patches are validated in-memory before writing any file.
+
+For tool/function-call format, pass a `patches` JSON array string:
+
+    [
+      {"path": "path/to/file1.py", "patch": "<<<<<<< ORIGINAL\\n..."},
+      {"path": "path/to/file2.py", "patch": "<<<<<<< ORIGINAL\\n..."}
+    ]
+""".strip()
+
+
+def _resolve_path(raw_path: str) -> Path:
+    """Resolve a path and reject relative traversal outside the current directory."""
+    path_display = Path(raw_path).expanduser()
+    path = path_display.resolve()
+
+    if not path_display.is_absolute():
+        cwd = Path.cwd().resolve()
+        try:
+            path.relative_to(cwd)
+        except ValueError as err:
+            raise ValueError(
+                f"Path traversal detected: {path_display} resolves to {path} "
+                f"which is outside current directory {cwd}"
+            ) from err
+
+    return path
+
+
+def _parse_patches_from_content(
+    content: str, paths: list[Path]
+) -> list[tuple[Path, Patch]]:
+    """Parse multiple conflict-marker patches from markdown content and pair with paths."""
+    patches = list(Patch.from_codeblock(content))
+    if len(patches) != len(paths):
+        raise ValueError(
+            f"Got {len(patches)} patch(es) but {len(paths)} file path(s). "
+            "The number of patches must match the number of file paths."
+        )
+    return list(zip(paths, patches))
+
+
+def _parse_patches_from_kwargs(kwargs: Mapping[str, object]) -> list[tuple[Path, str]]:
+    """Parse patches from kwargs format: {patches: [{path, patch}, ...]}."""
+    raw = kwargs.get("patches")
+    if raw is None:
+        raise ValueError("Missing 'patches' in kwargs")
+
+    if isinstance(raw, str):
+        raw = json.loads(raw)
+
+    if not isinstance(raw, list):
+        raise ValueError("'patches' must be a list or a JSON-encoded list")
+
+    result: list[tuple[Path, str]] = []
+    for i, entry in enumerate(raw, start=1):
+        if not isinstance(entry, dict):
+            raise ValueError(f"Patch entry {i} must be an object")
+
+        path_value = entry.get("path")
+        patch_value = entry.get("patch")
+        if path_value is None or patch_value is None:
+            raise ValueError(f"Patch entry {i} must include both 'path' and 'patch'")
+        if not isinstance(path_value, str) or not isinstance(patch_value, str):
+            raise ValueError(
+                f"Patch entry {i} must use string 'path' and 'patch' values"
+            )
+
+        result.append((_resolve_path(path_value), patch_value))
+
+    return result
+
+
+def execute_patch_many_impl(
+    patches: Sequence[tuple[Path, str | Patch]],
+) -> Generator[Message, None, None]:
+    """Resolve all patches in-memory before writing any files."""
+    if not patches:
+        yield Message("system", "Atomic patch aborted: no patches were provided.")
+        return
+
+    resolved: list[tuple[Path, str]] = []
+
+    for path, patch_src in patches:
+        if not path.exists():
+            yield Message(
+                "system",
+                f"Atomic patch aborted: file not found `{path}`. No files were written.",
+            )
+            return
+
+        try:
+            original = path.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, PermissionError, OSError) as e:
+            yield Message(
+                "system",
+                f"Atomic patch aborted: could not read `{path}`: {e}. No files were written.",
+            )
+            return
+
+        try:
+            if isinstance(patch_src, Patch):
+                new_content = patch_src.apply(original)
+            else:
+                new_content = apply(patch_src, original)
+        except ValueError as e:
+            yield Message(
+                "system",
+                f"Atomic patch aborted: patch failed for `{path}`: {e}. "
+                "No files were written.",
+            )
+            return
+
+        resolved.append((path, new_content))
+
+    written: list[str] = []
+    for path, new_content in resolved:
+        path.write_text(new_content, encoding="utf-8")
+        written.append(str(path))
+
+    yield Message(
+        "system",
+        f"Applied {len(written)} patch(es) atomically to:\n"
+        + "\n".join(f"  - {path}" for path in written),
+    )
+
+
+def execute_patch_many(
+    code: str | None,
+    args: list[str] | None,
+    kwargs: dict[str, str] | None,
+) -> Generator[Message, None, None]:
+    """Execute patch_many from a markdown block or tool/function-call kwargs."""
+    if code is None and kwargs is not None and "patches" in kwargs:
+        try:
+            patch_entries = _parse_patches_from_kwargs(kwargs)
+        except (ValueError, json.JSONDecodeError) as e:
+            yield Message("system", f"Error parsing patches from kwargs: {e}")
+            return
+
+        yield from execute_patch_many_impl(patch_entries)
+        return
+
+    if not code:
+        yield Message("system", "No patch content provided")
+        return
+
+    if not args or not args[0]:
+        yield Message(
+            "system",
+            "No file paths provided. Usage: ```patch_many path1 path2 ...",
+        )
+        return
+
+    try:
+        paths = [_resolve_path(arg) for arg in args]
+        patch_pairs = _parse_patches_from_content(code, paths)
+    except ValueError as e:
+        yield Message("system", f"Error parsing patches: {e}")
+        return
+
+    yield from execute_patch_many_impl(patch_pairs)
+
+
+tool_patch_many = ToolSpec(
+    name="patch_many",
+    desc="Apply multiple patches to multiple files atomically",
+    instructions=instructions,
+    execute=execute_patch_many,
+    block_types=["patch_many"],
+    parameters=[
+        Parameter(
+            name="patches",
+            type="string",
+            description=(
+                "JSON array string of {path, patch} objects. Each patch string uses "
+                "the same conflict-marker format as the patch tool."
+            ),
+            required=True,
+        )
+    ],
+)
+__doc__ = tool_patch_many.get_doc(__doc__)

--- a/tests/test_tools_patch_many.py
+++ b/tests/test_tools_patch_many.py
@@ -298,6 +298,46 @@ def test_markdown_multihunk_path_header_format(tmp_path):
     assert "also_old" not in content
 
 
+def test_simple_format_placeholder_patch_round_trip(tmp_path):
+    """Simple markdown format should accept placeholder-based multi-edit patches."""
+    f = tmp_path / "module.py"
+    f.write_text(
+        """
+def hello():
+    print("hello")
+
+if __name__ == "__main__":
+    hello()
+""".strip()
+    )
+
+    code = _patch_text(
+        """
+def hello():
+    print("hello")
+    # ...
+if __name__ == "__main__":
+    hello()
+""".strip(),
+        """
+def hello_world():
+    print("hello")
+    # ...
+if __name__ == "__main__":
+    hello_world()
+""".strip(),
+    )
+
+    messages = list(execute_patch_many(code, [str(f)], None))
+    assert messages
+    assert "atomically" in messages[0].content.lower()
+    content = f.read_text()
+    assert "def hello_world()" in content
+    assert "hello_world()" in content
+    assert "def hello():" not in content
+    assert "    hello()" not in content
+
+
 def test_execute_patch_many_markdown_round_trip(tmp_path):
     """Test the markdown entrypoint, including confirmation-hook execution."""
     f1 = tmp_path / "file1.py"

--- a/tests/test_tools_patch_many.py
+++ b/tests/test_tools_patch_many.py
@@ -1,0 +1,274 @@
+"""Tests for patch_many: atomic multi-file patch tool."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from gptme.tools import clear_tools, get_tool, init_tools
+from gptme.tools.patch import Patch
+from gptme.tools.patch_many import (
+    _parse_patches_from_content,
+    _parse_patches_from_kwargs,
+    execute_patch_many_impl,
+)
+
+
+def test_basic_parse():
+    """Test parsing patches from codeblock content."""
+    paths = [Path("/tmp/a.txt"), Path("/tmp/b.txt")]
+    pairs = _parse_patches_from_content(
+        """
+<<<<<<< ORIGINAL
+a content
+=======
+a modified
+>>>>>>> UPDATED
+
+<<<<<<< ORIGINAL
+b content
+=======
+b modified
+>>>>>>> UPDATED
+""".strip(),
+        paths,
+    )
+    assert len(pairs) == 2
+
+
+def test_path_count_mismatch():
+    """Test that mismatched path/patch counts raise."""
+    paths = [Path("/tmp/a.txt")]
+    with pytest.raises(ValueError, match="2 patch\\(es\\) but 1 file"):
+        _parse_patches_from_content(
+            """
+<<<<<<< ORIGINAL
+a content
+=======
+a modified
+>>>>>>> UPDATED
+
+<<<<<<< ORIGINAL
+b content
+=======
+b modified
+>>>>>>> UPDATED
+""".strip(),
+            paths,
+        )
+
+
+def test_atomicity(tmp_path):
+    """Test that if one patch fails, NO files are written."""
+    f1 = tmp_path / "file1.py"
+    f2 = tmp_path / "file2.py"
+    f1.write_text("original content")
+    f2.write_text("original content")
+
+    patches = [
+        (f1, Patch("original content", "modified content")),
+        (f2, Patch("nonexistent content", "modified content")),
+    ]
+
+    messages = list(execute_patch_many_impl(patches))
+    assert messages
+    assert "aborted" in messages[0].content
+    assert "patch failed" in messages[0].content.lower()
+    assert f1.read_text() == "original content"
+    assert f2.read_text() == "original content"
+
+
+def test_atomic_success(tmp_path):
+    """Test that all files are patched when all patches match."""
+    f1 = tmp_path / "file1.py"
+    f2 = tmp_path / "file2.py"
+    f1.write_text("original a")
+    f2.write_text("original b")
+
+    patches = [
+        (f1, Patch("original a", "modified a")),
+        (f2, Patch("original b", "modified b")),
+    ]
+
+    messages = list(execute_patch_many_impl(patches))
+    assert messages
+    assert "atomically" in messages[0].content.lower()
+    assert "2" in messages[0].content
+    assert f1.read_text() == "modified a"
+    assert f2.read_text() == "modified b"
+
+
+def test_atomic_missing_file(tmp_path):
+    """Test that a missing file aborts the entire batch."""
+    f1 = tmp_path / "exists.py"
+    f2 = tmp_path / "missing.py"
+    f1.write_text("original")
+
+    patches = [
+        (f1, Patch("original", "modified")),
+        (f2, Patch("original", "modified")),
+    ]
+
+    messages = list(execute_patch_many_impl(patches))
+    assert messages
+    assert "aborted" in messages[0].content
+    assert "file not found" in messages[0].content.lower()
+    assert f1.read_text() == "original"
+
+
+def test_atomic_single_file(tmp_path):
+    """Test patch_many with a single file."""
+    f = tmp_path / "single.py"
+    f.write_text("single file content")
+
+    messages = list(
+        execute_patch_many_impl(
+            [(f, Patch("single file content", "single file modified"))]
+        )
+    )
+    assert messages
+    assert "atomically" in messages[0].content.lower()
+    assert f.read_text() == "single file modified"
+
+
+def test_apply_updates_segment(tmp_path):
+    """Test patching only part of a file via patch_many."""
+    f = tmp_path / "module.py"
+    f.write_text(
+        """
+def old_func():
+    return 1
+
+def untouched():
+    return 2
+""".strip()
+    )
+
+    patches = [
+        (
+            f,
+            Patch(
+                "def old_func():\n    return 1",
+                "def new_func():\n    return 42",
+            ),
+        ),
+    ]
+
+    list(execute_patch_many_impl(patches))
+    content = f.read_text()
+    assert "new_func" in content
+    assert "untouched" in content
+    assert "old_func" not in content
+
+
+def test_kwargs_parse_simple():
+    """Test parsing patches from kwargs format."""
+    entries = _parse_patches_from_kwargs(
+        {
+            "patches": [
+                {
+                    "path": "/tmp/x.txt",
+                    "patch": "<<<<<<< ORIGINAL\nx\n=======\ny\n>>>>>>> UPDATED",
+                },
+                {
+                    "path": "/tmp/y.txt",
+                    "patch": "<<<<<<< ORIGINAL\ny\n=======\nz\n>>>>>>> UPDATED",
+                },
+            ]
+        }
+    )
+    assert len(entries) == 2
+    assert entries[0][0] == Path("/tmp/x.txt")
+    assert isinstance(entries[1][1], str)
+
+
+def test_kwargs_json_string():
+    """Test parsing patches from a JSON string in kwargs."""
+    entries = _parse_patches_from_kwargs(
+        {
+            "patches": json.dumps(
+                [
+                    {
+                        "path": "/tmp/z.txt",
+                        "patch": "<<<<<<< ORIGINAL\nz\n=======\nw\n>>>>>>> UPDATED",
+                    },
+                ]
+            )
+        }
+    )
+    assert len(entries) == 1
+    assert entries[0][0] == Path("/tmp/z.txt")
+
+
+def test_kwargs_missing_field():
+    """Test that missing 'patches' in kwargs raises."""
+    with pytest.raises(ValueError, match="Missing 'patches'"):
+        _parse_patches_from_kwargs({"wrong_key": "value"})
+
+
+def test_kwargs_multi_hunk_patch(tmp_path):
+    """Test that kwargs patches support multiple hunks for a single file."""
+    f = tmp_path / "module.py"
+    f.write_text(
+        """
+def old_func():
+    return 1
+
+def old_name():
+    return 2
+""".strip()
+    )
+
+    patch = """
+<<<<<<< ORIGINAL
+def old_func():
+    return 1
+=======
+def new_func():
+    return 42
+>>>>>>> UPDATED
+
+<<<<<<< ORIGINAL
+def old_name():
+    return 2
+=======
+def new_name():
+    return 3
+>>>>>>> UPDATED
+""".strip()
+
+    list(execute_patch_many_impl([(f, patch)]))
+    content = f.read_text()
+    assert "new_func" in content
+    assert "new_name" in content
+    assert "old_func" not in content
+    assert "old_name" not in content
+
+
+def test_kwargs_rejects_path_traversal(tmp_path, monkeypatch):
+    """Test that relative paths cannot escape the current working directory."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    monkeypatch.chdir(workspace)
+
+    with pytest.raises(ValueError, match="Path traversal detected"):
+        _parse_patches_from_kwargs(
+            {
+                "patches": [
+                    {
+                        "path": "../escape.txt",
+                        "patch": "<<<<<<< ORIGINAL\nx\n=======\ny\n>>>>>>> UPDATED",
+                    }
+                ]
+            }
+        )
+
+
+def test_patch_many_tool_is_discoverable():
+    """Test that patch_many can be loaded through tool discovery."""
+    clear_tools()
+    init_tools(allowlist=["patch_many"])
+
+    tool = get_tool("patch_many")
+    assert tool is not None
+    assert tool.name == "patch_many"

--- a/tests/test_tools_patch_many.py
+++ b/tests/test_tools_patch_many.py
@@ -66,6 +66,28 @@ b modified
         )
 
 
+def test_markdown_multi_hunk_error():
+    """Test that multi-hunk markdown patches give an actionable error pointing to kwargs."""
+    paths = [Path("/tmp/a.txt")]
+    with pytest.raises(ValueError, match="kwargs format"):
+        _parse_patches_from_content(
+            """
+<<<<<<< ORIGINAL
+first line
+=======
+first modified
+>>>>>>> UPDATED
+
+<<<<<<< ORIGINAL
+second line
+=======
+second modified
+>>>>>>> UPDATED
+""".strip(),
+            paths,
+        )
+
+
 def test_atomicity(tmp_path):
     """Test that if one patch fails, NO files are written."""
     f1 = tmp_path / "file1.py"

--- a/tests/test_tools_patch_many.py
+++ b/tests/test_tools_patch_many.py
@@ -471,6 +471,22 @@ def test_atomic_write_failure_rollback(tmp_path, monkeypatch):
     assert f2.read_text() == "original b"
 
 
+def test_simple_format_not_misrouted_when_content_contains_path_header(tmp_path):
+    """Simple-format patch whose content contains '=== PATH: ' must not be misrouted."""
+    f = tmp_path / "Makefile"
+    # Content that contains the literal string that used to trigger misrouting
+    f.write_text("# old line\n=== PATH: some/file ===\nmore content\n")
+
+    code = _patch_text(
+        "# old line",
+        "# new line",
+    )
+    messages = list(execute_patch_many(code, [str(f)], None))
+    assert messages
+    assert "error" not in messages[0].content.lower(), messages[0].content
+    assert "# new line" in f.read_text()
+
+
 def test_patch_many_tool_is_discoverable():
     """Test that patch_many can be loaded through tool discovery."""
     clear_tools()

--- a/tests/test_tools_patch_many.py
+++ b/tests/test_tools_patch_many.py
@@ -264,6 +264,39 @@ def test_kwargs_rejects_path_traversal(tmp_path, monkeypatch):
         )
 
 
+def test_atomic_write_failure_rollback(tmp_path, monkeypatch):
+    """Test that an OSError during write rolls back already-written files."""
+    f1 = tmp_path / "file1.py"
+    f2 = tmp_path / "file2.py"
+    f1.write_text("original a")
+    f2.write_text("original b")
+
+    patches = [
+        (f1, Patch("original a", "modified a")),
+        (f2, Patch("original b", "modified b")),
+    ]
+
+    # Make the second write fail
+    original_write_text = Path.write_text
+    call_count = [0]
+
+    def failing_write_text(self, *args, **kwargs):
+        call_count[0] += 1
+        if self == f2:
+            raise OSError("disk full")
+        return original_write_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "write_text", failing_write_text)
+
+    messages = list(execute_patch_many_impl(patches))
+    assert messages
+    assert "write error" in messages[0].content.lower()
+    assert "rolled back" in messages[0].content.lower()
+    # Both files should have their original content
+    assert f1.read_text() == "original a"
+    assert f2.read_text() == "original b"
+
+
 def test_patch_many_tool_is_discoverable():
     """Test that patch_many can be loaded through tool discovery."""
     clear_tools()

--- a/tests/test_tools_patch_many.py
+++ b/tests/test_tools_patch_many.py
@@ -2,16 +2,24 @@
 
 import json
 from pathlib import Path
+from typing import cast
 
 import pytest
 
+import gptme.tools.patch_many as patch_many_tool
+from gptme.message import Message
 from gptme.tools import clear_tools, get_tool, init_tools
-from gptme.tools.patch import Patch
+from gptme.tools.patch import DIVIDER, ORIGINAL, UPDATED, Patch
 from gptme.tools.patch_many import (
     _parse_patches_from_content,
     _parse_patches_from_kwargs,
+    execute_patch_many,
     execute_patch_many_impl,
 )
+
+
+def _patch_text(original: str, updated: str) -> str:
+    return f"{ORIGINAL}{original}{DIVIDER}{updated}{UPDATED}".strip()
 
 
 def test_basic_parse():
@@ -243,6 +251,127 @@ def new_name():
     assert "new_name" in content
     assert "old_func" not in content
     assert "old_name" not in content
+
+
+def test_execute_patch_many_markdown_round_trip(tmp_path):
+    """Test the markdown entrypoint, including confirmation-hook execution."""
+    f1 = tmp_path / "file1.py"
+    f2 = tmp_path / "file2.py"
+    f1.write_text("original a")
+    f2.write_text("original b")
+
+    code = "\n\n".join(
+        [
+            _patch_text("original a", "modified a"),
+            _patch_text("original b", "modified b"),
+        ]
+    )
+
+    messages = list(execute_patch_many(code, [str(f1), str(f2)], None))
+    assert messages
+    assert "atomically" in messages[0].content.lower()
+    assert f1.read_text() == "modified a"
+    assert f2.read_text() == "modified b"
+
+
+def test_execute_patch_many_kwargs_round_trip(tmp_path):
+    """Test the kwargs entrypoint, including confirmation-hook execution."""
+    f1 = tmp_path / "file1.py"
+    f2 = tmp_path / "file2.py"
+    f1.write_text("original a")
+    f2.write_text("original b")
+
+    kwargs = {
+        "patches": json.dumps(
+            [
+                {
+                    "path": str(f1),
+                    "patch": _patch_text("original a", "modified a"),
+                },
+                {
+                    "path": str(f2),
+                    "patch": _patch_text("original b", "modified b"),
+                },
+            ]
+        )
+    }
+
+    messages = list(execute_patch_many(None, None, kwargs))
+    assert messages
+    assert "atomically" in messages[0].content.lower()
+    assert f1.read_text() == "modified a"
+    assert f2.read_text() == "modified b"
+
+
+def test_execute_patch_many_markdown_uses_confirmation(tmp_path, monkeypatch):
+    """Test that markdown patch_many routes through execute_with_confirmation."""
+    f = tmp_path / "file.py"
+    f.write_text("original")
+    captured: dict[str, object] = {}
+
+    def fake_execute_with_confirmation(code, args, tool_kwargs, **helper_kwargs):
+        captured["code"] = code
+        captured["args"] = args
+        captured["tool_kwargs"] = tool_kwargs
+        captured["helper_kwargs"] = helper_kwargs
+        yield Message("system", "stub")
+
+    monkeypatch.setattr(
+        patch_many_tool, "execute_with_confirmation", fake_execute_with_confirmation
+    )
+
+    messages = list(
+        patch_many_tool.execute_patch_many(
+            _patch_text("original", "modified"),
+            [str(f)],
+            None,
+        )
+    )
+
+    assert [message.content for message in messages] == ["stub"]
+    captured_code = cast(str, captured["code"])
+    assert str(f) in captured_code
+    assert "ORIGINAL" in captured_code
+
+
+def test_execute_patch_many_kwargs_uses_confirmation(tmp_path, monkeypatch):
+    """Test that kwargs patch_many routes through execute_with_confirmation."""
+    f = tmp_path / "file.py"
+    f.write_text("original")
+    captured: dict[str, object] = {}
+
+    def fake_execute_with_confirmation(code, args, tool_kwargs, **helper_kwargs):
+        captured["code"] = code
+        captured["args"] = args
+        captured["tool_kwargs"] = tool_kwargs
+        captured["helper_kwargs"] = helper_kwargs
+        yield Message("system", "stub")
+
+    monkeypatch.setattr(
+        patch_many_tool, "execute_with_confirmation", fake_execute_with_confirmation
+    )
+
+    messages = list(
+        patch_many_tool.execute_patch_many(
+            None,
+            None,
+            {
+                "patches": json.dumps(
+                    [
+                        {
+                            "path": str(f),
+                            "patch": _patch_text("original", "modified"),
+                        }
+                    ]
+                )
+            },
+        )
+    )
+
+    assert [message.content for message in messages] == ["stub"]
+    captured_code = cast(str, captured["code"])
+    assert str(f) in captured_code
+    assert "ORIGINAL" in captured_code
 
 
 def test_kwargs_rejects_path_traversal(tmp_path, monkeypatch):

--- a/tests/test_tools_patch_many.py
+++ b/tests/test_tools_patch_many.py
@@ -11,6 +11,7 @@ from gptme.message import Message
 from gptme.tools import clear_tools, get_tool, init_tools
 from gptme.tools.patch import DIVIDER, ORIGINAL, UPDATED, Patch
 from gptme.tools.patch_many import (
+    _CONFIRM_HEADER,
     _parse_patches_from_content,
     _parse_patches_from_kwargs,
     execute_patch_many,
@@ -273,6 +274,28 @@ def new_name():
     assert "new_name" in content
     assert "old_func" not in content
     assert "old_name" not in content
+
+
+def test_markdown_multihunk_path_header_format(tmp_path):
+    """Test multi-hunk markdown using === PATH: ... === headers (no paths in fence)."""
+    f = tmp_path / "module.py"
+    f.write_text("def old_func():\n    return 1\n\ndef also_old():\n    return 2\n")
+
+    code = (
+        f"{_CONFIRM_HEADER}{f} ===\n"
+        + _patch_text("def old_func():\n    return 1", "def new_func():\n    return 42")
+        + "\n\n"
+        + _patch_text("def also_old():\n    return 2", "def also_new():\n    return 3")
+    )
+
+    messages = list(execute_patch_many(code, None, None))
+    assert messages
+    assert "atomically" in messages[0].content.lower()
+    content = f.read_text()
+    assert "new_func" in content
+    assert "also_new" in content
+    assert "old_func" not in content
+    assert "also_old" not in content
 
 
 def test_execute_patch_many_markdown_round_trip(tmp_path):


### PR DESCRIPTION
## Summary
- add a new `patch_many` tool for explicit multi-file batch edits
- apply all patches in-memory first and abort the whole batch if any target fails
- add focused tests for rollback, kwargs parsing, multi-hunk support, traversal rejection, and tool discovery

## Verification
- ./.venv/bin/python -m pytest tests/test_tools_patch_many.py -q
- ./.venv/bin/python -m pytest tests/test_tools.py -q -k "get_tool or load_tool or has_tool"