### PR TITLE
feat(server): add conversation artifact registry API (#830 Phase 1)

### DIFF
--- a/gptme/server/app.py
+++ b/gptme/server/app.py
@@ -84,6 +84,7 @@ def create_app(
     # Register v2 API, workspace API, tasks API, and auth API
     # noreorder
     from .api_v2 import v2_api  # fmt: skip
+    from .artifacts_api import artifacts_api  # fmt: skip
     from .auth import auth_api  # fmt: skip
     from .tasks_api import tasks_api  # fmt: skip
     from .workspace_api import workspace_api  # fmt: skip
@@ -92,6 +93,7 @@ def create_app(
     app.register_blueprint(auth_api)
     app.register_blueprint(workspace_api)
     app.register_blueprint(tasks_api)
+    app.register_blueprint(artifacts_api)
 
     # Register OpenAPI documentation
     from .openapi_docs import docs_api  # fmt: skip

--- a/gptme/server/artifacts_api.py
+++ b/gptme/server/artifacts_api.py
@@ -1,0 +1,313 @@
+"""
+Artifact registry API endpoints for conversation-scoped artifacts.
+
+Phase 1 of the webui artifact surface (see ErikBjare/bob#830): expose a typed,
+conversation-scoped list of artifacts computed on read from the existing
+attachments directory. No new tool APIs or persisted manifest are required yet
+-- richer structured emission from tools/plugins is a later phase.
+
+The descriptor shape intentionally mirrors the design doc so the webui can
+render artifacts and choose a preview renderer from typed data instead of
+filename heuristics.
+"""
+
+import hashlib
+import logging
+import mimetypes
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Literal
+
+import flask
+from pydantic import BaseModel, Field
+
+from ..logmanager import LogManager
+from .api_v2_common import _validate_conversation_id
+from .auth import require_auth
+from .openapi_docs import ErrorResponse, api_doc_simple
+
+logger = logging.getLogger(__name__)
+
+artifacts_api = flask.Blueprint("artifacts_api", __name__)
+
+# Artifact kinds the webui knows how to render. Anything unrecognized falls
+# back to "binary" (downloadable but not previewable inline).
+ArtifactKind = Literal[
+    "image",
+    "audio",
+    "video",
+    "html",
+    "markdown",
+    "pdf",
+    "diff",
+    "dataset",
+    "webapp",
+    "binary",
+    "other",
+]
+
+# Coarse renderer hint, deliberately smaller than the kind enum.
+PreviewType = Literal["image", "audio", "video", "text", "pdf", "none"]
+
+
+class ArtifactSource(BaseModel):
+    """Where an artifact's bytes come from."""
+
+    type: Literal["attachment", "workspace", "external", "inline"] = Field(
+        ..., description="Source category"
+    )
+    path: str | None = Field(
+        None, description="Logdir-relative path (attachment/workspace sources)"
+    )
+    url: str | None = Field(None, description="External URL (external sources)")
+
+
+class ArtifactProvenance(BaseModel):
+    """Best-effort origin metadata for an artifact."""
+
+    message_index: int | None = Field(
+        None, description="Index of the first message referencing this artifact"
+    )
+    tool: str | None = Field(
+        None, description="Tool that produced the artifact, if known"
+    )
+
+
+class ArtifactPreview(BaseModel):
+    """Typed preview hint so the webui can pick a renderer without heuristics."""
+
+    type: PreviewType = Field(..., description="Renderer hint")
+
+
+class ArtifactAction(BaseModel):
+    """A user-facing action available for an artifact."""
+
+    type: str = Field(
+        ..., description="Action identifier (download, open_workspace, ...)"
+    )
+    panel: str | None = Field(
+        None, description="Target panel id for open_panel actions"
+    )
+    artifact_id: str | None = Field(
+        None, description="Artifact id for open_panel actions"
+    )
+
+
+class Artifact(BaseModel):
+    """A conversation-scoped artifact descriptor."""
+
+    id: str = Field(..., description="Stable artifact id (derived from its source)")
+    kind: ArtifactKind = Field(..., description="Artifact kind")
+    title: str = Field(..., description="Human-readable title")
+    source: ArtifactSource = Field(..., description="Where the artifact comes from")
+    created_at: str = Field(..., description="Creation timestamp (ISO format)")
+    size: int | None = Field(
+        None, description="Size in bytes for file-backed artifacts"
+    )
+    mime_type: str | None = Field(None, description="MIME type if known")
+    provenance: ArtifactProvenance = Field(
+        ..., description="Best-effort origin metadata"
+    )
+    preview: ArtifactPreview = Field(..., description="Preview/renderer hint")
+    actions: list[ArtifactAction] = Field(..., description="Available user actions")
+
+
+class ArtifactListResponse(BaseModel):
+    """Response containing the conversation's artifacts."""
+
+    artifacts: list[Artifact] = Field(..., description="Artifact descriptors")
+
+
+# Extensions that should be classified ahead of (or in absence of) a MIME type.
+_EXTENSION_KINDS: dict[str, ArtifactKind] = {
+    ".md": "markdown",
+    ".markdown": "markdown",
+    ".diff": "diff",
+    ".patch": "diff",
+    ".html": "html",
+    ".htm": "html",
+    ".csv": "dataset",
+    ".tsv": "dataset",
+    ".json": "dataset",
+    ".parquet": "dataset",
+}
+
+_PREVIEW_FOR_KIND: dict[ArtifactKind, PreviewType] = {
+    "image": "image",
+    "audio": "audio",
+    "video": "video",
+    "pdf": "pdf",
+    "markdown": "text",
+    "html": "text",
+    "diff": "text",
+    "dataset": "text",
+}
+
+
+def classify_kind(path: Path, mime_type: str | None) -> ArtifactKind:
+    """Classify an artifact kind from its extension and MIME type.
+
+    Extension wins for the cases where MIME is ambiguous (e.g. ``.md`` and
+    ``.diff`` are both ``text/plain`` or ``text/markdown`` depending on the
+    platform), then we fall back to the MIME top-level type.
+    """
+    ext = path.suffix.lower()
+    if ext in _EXTENSION_KINDS:
+        return _EXTENSION_KINDS[ext]
+
+    if mime_type:
+        top = mime_type.split("/", 1)[0]
+        if top == "image":
+            return "image"
+        if top == "audio":
+            return "audio"
+        if top == "video":
+            return "video"
+        if mime_type == "application/pdf":
+            return "pdf"
+        if mime_type in ("text/html", "application/xhtml+xml"):
+            return "html"
+        if mime_type == "text/markdown":
+            return "markdown"
+        if top == "text":
+            return "other"
+        return "binary"
+
+    return "other"
+
+
+def _artifact_id(rel_path: str) -> str:
+    """Derive a stable artifact id from its logdir-relative source path."""
+    digest = hashlib.sha1(rel_path.encode("utf-8")).hexdigest()[:12]
+    return f"art_{digest}"
+
+
+def _provenance_index(manager: LogManager, filename: str) -> int | None:
+    """Best-effort: first message index whose attached files match ``filename``."""
+    for idx, msg in enumerate(manager.log):
+        for f in msg.files:
+            try:
+                if Path(str(f)).name == filename:
+                    return idx
+            except (TypeError, ValueError):
+                continue
+    return None
+
+
+def derive_artifacts(manager: LogManager) -> list[Artifact]:
+    """Compute the artifact list for a conversation from its attachments.
+
+    Phase 1 only reads the ``attachments/`` directory. This is intentionally a
+    pure function (no Flask state) so it can be unit tested directly.
+    """
+    attachments_dir = manager.logdir / "attachments"
+    if not attachments_dir.is_dir():
+        return []
+
+    artifacts: list[Artifact] = []
+    for item in sorted(attachments_dir.iterdir(), key=lambda p: p.name.lower()):
+        if not item.is_file() or item.name.startswith("."):
+            continue
+
+        rel_path = f"attachments/{item.name}"
+        mime_type, _ = mimetypes.guess_type(item.name)
+        kind = classify_kind(item, mime_type)
+
+        try:
+            stat = item.stat()
+            size: int | None = stat.st_size
+            created_at = datetime.fromtimestamp(
+                stat.st_mtime, tz=timezone.utc
+            ).isoformat()
+        except OSError:
+            size = None
+            created_at = ""
+
+        artifact_id = _artifact_id(rel_path)
+        actions = [
+            ArtifactAction(type="download", panel=None, artifact_id=None),
+            ArtifactAction(type="open_workspace", panel=None, artifact_id=None),
+            ArtifactAction(
+                type="open_panel", panel="artifacts", artifact_id=artifact_id
+            ),
+        ]
+        artifacts.append(
+            Artifact(
+                id=artifact_id,
+                kind=kind,
+                title=item.name,
+                source=ArtifactSource(type="attachment", path=rel_path, url=None),
+                created_at=created_at,
+                size=size,
+                mime_type=mime_type,
+                provenance=ArtifactProvenance(
+                    message_index=_provenance_index(manager, item.name), tool=None
+                ),
+                preview=ArtifactPreview(type=_PREVIEW_FOR_KIND.get(kind, "none")),
+                actions=actions,
+            )
+        )
+    return artifacts
+
+
+@artifacts_api.route("/api/v2/conversations/<string:conversation_id>/artifacts")
+@require_auth
+@api_doc_simple(
+    responses={
+        200: ArtifactListResponse,
+        404: ErrorResponse,
+        500: ErrorResponse,
+    },
+    tags=["artifacts"],
+)
+def list_artifacts(conversation_id: str):
+    """List artifacts for a conversation.
+
+    Returns typed artifact descriptors computed on read from the conversation's
+    attachments. The webui uses these to render a first-class Artifacts surface
+    instead of relying on filename heuristics.
+    """
+    if error := _validate_conversation_id(conversation_id):
+        return error
+    try:
+        try:
+            manager = LogManager.load(conversation_id, lock=False)
+        except FileNotFoundError:
+            return flask.jsonify({"error": "Conversation not found"}), 404
+
+        artifacts = derive_artifacts(manager)
+        return flask.jsonify({"artifacts": [a.model_dump() for a in artifacts]})
+    except Exception as e:
+        logger.exception("Error listing artifacts")
+        return flask.jsonify({"error": str(e)}), 500
+
+
+@artifacts_api.route(
+    "/api/v2/conversations/<string:conversation_id>/artifacts/<string:artifact_id>"
+)
+@require_auth
+@api_doc_simple(
+    responses={
+        200: Artifact,
+        404: ErrorResponse,
+        500: ErrorResponse,
+    },
+    tags=["artifacts"],
+)
+def get_artifact(conversation_id: str, artifact_id: str):
+    """Get a single artifact descriptor by id."""
+    if error := _validate_conversation_id(conversation_id):
+        return error
+    try:
+        try:
+            manager = LogManager.load(conversation_id, lock=False)
+        except FileNotFoundError:
+            return flask.jsonify({"error": "Conversation not found"}), 404
+
+        for artifact in derive_artifacts(manager):
+            if artifact.id == artifact_id:
+                return flask.jsonify(artifact.model_dump())
+        return flask.jsonify({"error": "Artifact not found"}), 404
+    except Exception as e:
+        logger.exception("Error getting artifact")
+        return flask.jsonify({"error": str(e)}), 500

--- a/gptme/server/artifacts_api.py
+++ b/gptme/server/artifacts_api.py
@@ -194,11 +194,16 @@ def _provenance_index(manager: LogManager, filename: str) -> int | None:
     return None
 
 
-def derive_artifacts(manager: LogManager) -> list[Artifact]:
+def derive_artifacts(
+    manager: LogManager, target_id: str | None = None
+) -> list[Artifact]:
     """Compute the artifact list for a conversation from its attachments.
 
     Phase 1 only reads the ``attachments/`` directory. This is intentionally a
     pure function (no Flask state) so it can be unit tested directly.
+
+    Pass ``target_id`` to short-circuit after the matching artifact is found,
+    avoiding the O(files × messages) provenance scan for every detail request.
     """
     attachments_dir = manager.logdir / "attachments"
     if not attachments_dir.is_dir():
@@ -210,20 +215,27 @@ def derive_artifacts(manager: LogManager) -> list[Artifact]:
             continue
 
         rel_path = f"attachments/{item.name}"
+        artifact_id = _artifact_id(rel_path)
+
+        # Skip non-target files early to avoid the provenance scan.
+        if target_id is not None and artifact_id != target_id:
+            continue
+
         mime_type, _ = mimetypes.guess_type(item.name)
         kind = classify_kind(item, mime_type)
 
         try:
             stat = item.stat()
             size: int | None = stat.st_size
+            # st_mtime is the last-modification time; used as a creation-time
+            # proxy because st_birthtime is only available on macOS/BSD.
             created_at = datetime.fromtimestamp(
                 stat.st_mtime, tz=timezone.utc
             ).isoformat()
         except OSError:
-            size = None
-            created_at = ""
+            # File disappeared between iterdir() and stat() — skip it.
+            continue
 
-        artifact_id = _artifact_id(rel_path)
         actions = [
             ArtifactAction(type="download", panel=None, artifact_id=None),
             ArtifactAction(type="open_workspace", panel=None, artifact_id=None),
@@ -247,6 +259,11 @@ def derive_artifacts(manager: LogManager) -> list[Artifact]:
                 actions=actions,
             )
         )
+
+        # Found what we came for — no need to scan further.
+        if target_id is not None:
+            break
+
     return artifacts
 
 
@@ -304,9 +321,9 @@ def get_artifact(conversation_id: str, artifact_id: str):
         except FileNotFoundError:
             return flask.jsonify({"error": "Conversation not found"}), 404
 
-        for artifact in derive_artifacts(manager):
-            if artifact.id == artifact_id:
-                return flask.jsonify(artifact.model_dump())
+        artifacts = derive_artifacts(manager, target_id=artifact_id)
+        if artifacts:
+            return flask.jsonify(artifacts[0].model_dump())
         return flask.jsonify({"error": "Artifact not found"}), 404
     except Exception as e:
         logger.exception("Error getting artifact")

--- a/tests/test_server_artifacts.py
+++ b/tests/test_server_artifacts.py
@@ -1,0 +1,155 @@
+"""Tests for the artifact registry API endpoints (ErikBjare/bob#830 Phase 1).
+
+Covers:
+- kind classification from extension/MIME
+- computed-on-read artifact derivation from attachments
+- list and detail endpoints, including error handling
+"""
+
+import io
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+# Skip if flask not installed
+pytest.importorskip(
+    "flask", reason="flask not installed, install server extras (-E server)"
+)
+
+from flask.testing import FlaskClient  # fmt: skip
+
+from gptme.server.artifacts_api import (  # fmt: skip
+    _artifact_id,
+    classify_kind,
+)
+
+pytestmark = [pytest.mark.timeout(10)]
+
+
+# ============================================================
+# Unit tests for kind classification
+# ============================================================
+
+
+class TestClassifyKind:
+    @pytest.mark.parametrize(
+        ("name", "mime", "expected"),
+        [
+            ("hero.png", "image/png", "image"),
+            ("clip.mp3", "audio/mpeg", "audio"),
+            ("demo.mp4", "video/mp4", "video"),
+            ("report.pdf", "application/pdf", "pdf"),
+            ("page.html", "text/html", "html"),
+            ("notes.md", "text/markdown", "markdown"),
+            ("change.diff", "text/x-diff", "diff"),
+            ("change.patch", None, "diff"),
+            ("data.csv", "text/csv", "dataset"),
+            ("data.json", "application/json", "dataset"),
+            ("plain.txt", "text/plain", "other"),
+            ("blob.bin", "application/octet-stream", "binary"),
+            ("mystery", None, "other"),
+        ],
+    )
+    def test_classify(self, name, mime, expected):
+        assert classify_kind(Path(name), mime) == expected
+
+    def test_extension_wins_over_ambiguous_mime(self):
+        # .md is sometimes guessed as text/plain; extension must still win
+        assert classify_kind(Path("notes.md"), "text/plain") == "markdown"
+
+
+class TestArtifactId:
+    def test_stable_and_prefixed(self):
+        a = _artifact_id("attachments/hero.png")
+        b = _artifact_id("attachments/hero.png")
+        assert a == b
+        assert a.startswith("art_")
+
+    def test_distinct_paths_distinct_ids(self):
+        assert _artifact_id("attachments/a.png") != _artifact_id("attachments/b.png")
+
+
+# ============================================================
+# Integration tests for the endpoints
+# ============================================================
+
+
+def _create_conv(client: FlaskClient) -> str:
+    convname = f"test-artifacts-{uuid4().hex[:8]}"
+    resp = client.put(f"/api/v2/conversations/{convname}", json={"prompt": "Test."})
+    assert resp.status_code == 200
+    return convname
+
+
+def _upload(client: FlaskClient, conv_id: str, content: bytes, name: str) -> None:
+    resp = client.post(
+        f"/api/v2/conversations/{conv_id}/workspace/upload",
+        data={"file": (io.BytesIO(content), name)},
+        content_type="multipart/form-data",
+    )
+    assert resp.status_code == 200
+
+
+class TestListArtifactsEndpoint:
+    def test_empty_conversation_returns_empty_list(self, client: FlaskClient):
+        conv_id = _create_conv(client)
+        resp = client.get(f"/api/v2/conversations/{conv_id}/artifacts")
+        assert resp.status_code == 200
+        assert resp.get_json() == {"artifacts": []}
+
+    def test_uploaded_file_becomes_artifact(self, client: FlaskClient):
+        conv_id = _create_conv(client)
+        _upload(client, conv_id, b"\x89PNG fake", "hero.png")
+
+        resp = client.get(f"/api/v2/conversations/{conv_id}/artifacts")
+        assert resp.status_code == 200
+        artifacts = resp.get_json()["artifacts"]
+        assert len(artifacts) == 1
+        art = artifacts[0]
+        assert art["kind"] == "image"
+        assert art["title"] == "hero.png"
+        assert art["source"] == {
+            "type": "attachment",
+            "path": "attachments/hero.png",
+            "url": None,
+        }
+        assert art["preview"]["type"] == "image"
+        assert art["id"].startswith("art_")
+        action_types = {a["type"] for a in art["actions"]}
+        assert {"download", "open_workspace", "open_panel"} <= action_types
+
+    def test_multiple_files_sorted_by_name(self, client: FlaskClient):
+        conv_id = _create_conv(client)
+        _upload(client, conv_id, b"a", "zebra.txt")
+        _upload(client, conv_id, b"b", "alpha.md")
+
+        resp = client.get(f"/api/v2/conversations/{conv_id}/artifacts")
+        artifacts = resp.get_json()["artifacts"]
+        titles = [a["title"] for a in artifacts]
+        assert titles == ["alpha.md", "zebra.txt"]
+
+    def test_nonexistent_conversation_returns_404(self, client: FlaskClient):
+        resp = client.get("/api/v2/conversations/does-not-exist-xyz/artifacts")
+        assert resp.status_code == 404
+
+
+class TestGetArtifactEndpoint:
+    def test_detail_roundtrip(self, client: FlaskClient):
+        conv_id = _create_conv(client)
+        _upload(client, conv_id, b"data", "report.pdf")
+
+        listed = client.get(f"/api/v2/conversations/{conv_id}/artifacts").get_json()
+        artifact_id = listed["artifacts"][0]["id"]
+
+        resp = client.get(f"/api/v2/conversations/{conv_id}/artifacts/{artifact_id}")
+        assert resp.status_code == 200
+        detail = resp.get_json()
+        assert detail["id"] == artifact_id
+        assert detail["kind"] == "pdf"
+        assert detail["title"] == "report.pdf"
+
+    def test_unknown_artifact_returns_404(self, client: FlaskClient):
+        conv_id = _create_conv(client)
+        resp = client.get(f"/api/v2/conversations/{conv_id}/artifacts/art_deadbeef0000")
+        assert resp.status_code == 404


### PR DESCRIPTION
## What

Adds the server foundation for a first-class **Artifacts** surface in the webui, Phase 1 of the design in `ErikBjare/bob#830` (Erik approved the direction on 2026-05-30).

New endpoints:

- `GET /api/v2/conversations/<id>/artifacts` — list typed artifact descriptors
- `GET /api/v2/conversations/<id>/artifacts/<artifact_id>` — single artifact detail

## How

Artifacts are **computed on read** from the conversation's existing `attachments/` directory — no new tool APIs, message-metadata changes, or persisted manifest required yet (that's Phase 2). The deriving logic is a pure, unit-testable function.

Each artifact descriptor carries:

- a stable `id` (sha1 of the source path, so detail lookups are deterministic)
- a `kind`: `image`/`audio`/`video`/`html`/`markdown`/`pdf`/`diff`/`dataset`/`webapp`/`binary`/`other`
- `source` (attachment path), `size`, `mime_type`, `created_at`
- best-effort `provenance` (first message index that references the file)
- a typed `preview` renderer hint (`image`/`audio`/`video`/`text`/`pdf`/`none`)
- `actions` (`download`, `open_workspace`, `open_panel`)

Kind classification prefers the file extension for MIME-ambiguous cases (`.md`, `.diff`, `.patch`) and otherwise falls back to the MIME top-level type. This lets the webui choose a renderer from typed data instead of filename heuristics.

## Why this shape

Per the design, the webui should render artifacts from server-declared typed descriptors rather than re-deriving them from paths/extensions client-side. This PR is the minimal backend the Artifacts panel and the panel-registry sidebar refactor build on, and it ships value immediately (uploaded/generated attachments become a real artifact list) without waiting on richer tool emission.

Design doc (in Bob's workspace): `knowledge/technical-designs/webui-artifact-surface-and-plugin-panel-registry.md`

## Tests

`tests/test_server_artifacts.py` — 22 tests covering kind classification, stable id derivation, list/detail endpoints, sorting, and 404 handling. All green; ruff + mypy clean via pre-commit.