### PR TITLE
feat(webui): add artifacts sidebar panel and registry

### DIFF
--- a/webui/src/components/ArtifactsPanel.tsx
+++ b/webui/src/components/ArtifactsPanel.tsx
@@ -59,17 +59,19 @@ export function ArtifactsPanel({ conversationId }: ArtifactsPanelProps) {
 
   const loadArtifacts = useCallback(
     async (signal?: AbortSignal) => {
+      setLoading(true);
+      setError(null);
       try {
-        setLoading(true);
-        setError(null);
         const data = await listArtifacts(conversationId, signal);
-        setArtifacts(data);
+        if (!signal?.aborted) {
+          setArtifacts(data);
+          setLoading(false);
+        }
       } catch (err) {
         if (err instanceof DOMException && err.name === 'AbortError') return;
         console.error('Error loading artifacts:', err);
         setError(err instanceof Error ? err.message : 'Failed to load artifacts');
-      } finally {
-        if (!signal?.aborted) setLoading(false);
+        setLoading(false);
       }
     },
     [conversationId, listArtifacts]

--- a/webui/src/components/ArtifactsPanel.tsx
+++ b/webui/src/components/ArtifactsPanel.tsx
@@ -33,6 +33,12 @@ function toPreviewFile(artifact: Artifact): FileType | null {
   };
 }
 
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
 function formatCreatedAt(createdAt: string): string {
   const createdDate = new Date(createdAt);
   if (Number.isNaN(createdDate.getTime())) {
@@ -50,22 +56,28 @@ export function ArtifactsPanel({ conversationId }: ArtifactsPanelProps) {
 
   const { listArtifacts } = useArtifactsApi();
 
-  const loadArtifacts = useCallback(async () => {
-    try {
-      setLoading(true);
-      setError(null);
-      const data = await listArtifacts(conversationId);
-      setArtifacts(data);
-    } catch (err) {
-      console.error('Error loading artifacts:', err);
-      setError(err instanceof Error ? err.message : 'Failed to load artifacts');
-    } finally {
-      setLoading(false);
-    }
-  }, [conversationId, listArtifacts]);
+  const loadArtifacts = useCallback(
+    async (signal?: AbortSignal) => {
+      try {
+        setLoading(true);
+        setError(null);
+        const data = await listArtifacts(conversationId, signal);
+        setArtifacts(data);
+      } catch (err) {
+        if (err instanceof DOMException && err.name === 'AbortError') return;
+        console.error('Error loading artifacts:', err);
+        setError(err instanceof Error ? err.message : 'Failed to load artifacts');
+      } finally {
+        setLoading(false);
+      }
+    },
+    [conversationId, listArtifacts]
+  );
 
   useEffect(() => {
-    void loadArtifacts();
+    const controller = new AbortController();
+    void loadArtifacts(controller.signal);
+    return () => controller.abort();
   }, [loadArtifacts]);
 
   useEffect(() => {
@@ -108,7 +120,7 @@ export function ArtifactsPanel({ conversationId }: ArtifactsPanelProps) {
           <div>
             <h2 className="text-sm font-medium">Artifacts</h2>
             <p className="text-xs text-muted-foreground">
-              {artifacts.length} attachment-backed artifact{artifacts.length === 1 ? '' : 's'}
+              {artifacts.length} artifact{artifacts.length === 1 ? '' : 's'}
             </p>
           </div>
         </div>
@@ -164,9 +176,7 @@ export function ArtifactsPanel({ conversationId }: ArtifactsPanelProps) {
                         <div className="truncate text-sm font-medium">{artifact.title}</div>
                         <div className="mt-1 text-xs text-muted-foreground">
                           {formatCreatedAt(artifact.created_at)}
-                          {artifact.size !== null
-                            ? ` • ${(artifact.size / 1024).toFixed(1)} KB`
-                            : ''}
+                          {artifact.size !== null ? ` • ${formatFileSize(artifact.size)}` : ''}
                         </div>
                       </div>
                       <Badge variant="secondary" className="shrink-0 lowercase">

--- a/webui/src/components/ArtifactsPanel.tsx
+++ b/webui/src/components/ArtifactsPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { formatDistanceToNow } from 'date-fns';
 import { FolderOpen, Loader2, Package, RefreshCw } from 'lucide-react';
 import { FilePreview } from '@/components/workspace/FilePreview';
@@ -55,6 +55,7 @@ export function ArtifactsPanel({ conversationId }: ArtifactsPanelProps) {
   const [error, setError] = useState<string | null>(null);
 
   const { listArtifacts } = useArtifactsApi();
+  const fetchControllerRef = useRef<AbortController | null>(null);
 
   const loadArtifacts = useCallback(
     async (signal?: AbortSignal) => {
@@ -68,17 +69,23 @@ export function ArtifactsPanel({ conversationId }: ArtifactsPanelProps) {
         console.error('Error loading artifacts:', err);
         setError(err instanceof Error ? err.message : 'Failed to load artifacts');
       } finally {
-        setLoading(false);
+        if (!signal?.aborted) setLoading(false);
       }
     },
     [conversationId, listArtifacts]
   );
 
-  useEffect(() => {
+  const startLoad = useCallback(() => {
+    fetchControllerRef.current?.abort();
     const controller = new AbortController();
+    fetchControllerRef.current = controller;
     void loadArtifacts(controller.signal);
-    return () => controller.abort();
   }, [loadArtifacts]);
+
+  useEffect(() => {
+    startLoad();
+    return () => fetchControllerRef.current?.abort();
+  }, [startLoad]);
 
   useEffect(() => {
     if (!artifacts.length) {
@@ -126,7 +133,7 @@ export function ArtifactsPanel({ conversationId }: ArtifactsPanelProps) {
         </div>
 
         <div className="flex items-center gap-2">
-          <Button variant="outline" size="sm" onClick={() => void loadArtifacts()} title="Refresh">
+          <Button variant="outline" size="sm" onClick={startLoad} title="Refresh">
             <RefreshCw className="mr-2 h-4 w-4" />
             Refresh
           </Button>

--- a/webui/src/components/ArtifactsPanel.tsx
+++ b/webui/src/components/ArtifactsPanel.tsx
@@ -1,0 +1,203 @@
+import { useCallback, useEffect, useState } from 'react';
+import { formatDistanceToNow } from 'date-fns';
+import { FolderOpen, Loader2, Package, RefreshCw } from 'lucide-react';
+import { FilePreview } from '@/components/workspace/FilePreview';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { rightSidebarActiveTab$, rightSidebarVisible$ } from '@/stores/sidebar';
+import { workspaceNavigateTo$ } from '@/stores/workspaceExplorer';
+import type { Artifact } from '@/types/artifact';
+import type { FileType } from '@/types/workspace';
+import { useArtifactsApi } from '@/utils/artifactsApi';
+
+interface ArtifactsPanelProps {
+  conversationId: string;
+}
+
+function getAttachmentRelativePath(sourcePath: string): string {
+  return sourcePath.replace(/^attachments\/?/, '');
+}
+
+function toPreviewFile(artifact: Artifact): FileType | null {
+  if (artifact.source.type !== 'attachment' || !artifact.source.path) {
+    return null;
+  }
+
+  return {
+    name: artifact.title,
+    path: getAttachmentRelativePath(artifact.source.path),
+    type: 'file',
+    size: artifact.size ?? 0,
+    modified: artifact.created_at,
+    mime_type: artifact.mime_type,
+  };
+}
+
+function formatCreatedAt(createdAt: string): string {
+  const createdDate = new Date(createdAt);
+  if (Number.isNaN(createdDate.getTime())) {
+    return 'Unknown time';
+  }
+
+  return formatDistanceToNow(createdDate, { addSuffix: true });
+}
+
+export function ArtifactsPanel({ conversationId }: ArtifactsPanelProps) {
+  const [artifacts, setArtifacts] = useState<Artifact[]>([]);
+  const [selectedArtifactId, setSelectedArtifactId] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const { listArtifacts } = useArtifactsApi();
+
+  const loadArtifacts = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const data = await listArtifacts(conversationId);
+      setArtifacts(data);
+    } catch (err) {
+      console.error('Error loading artifacts:', err);
+      setError(err instanceof Error ? err.message : 'Failed to load artifacts');
+    } finally {
+      setLoading(false);
+    }
+  }, [conversationId, listArtifacts]);
+
+  useEffect(() => {
+    void loadArtifacts();
+  }, [loadArtifacts]);
+
+  useEffect(() => {
+    if (!artifacts.length) {
+      setSelectedArtifactId(null);
+      return;
+    }
+
+    if (!selectedArtifactId || !artifacts.some((artifact) => artifact.id === selectedArtifactId)) {
+      setSelectedArtifactId(artifacts[0].id);
+    }
+  }, [artifacts, selectedArtifactId]);
+
+  const selectedArtifact = artifacts.find((artifact) => artifact.id === selectedArtifactId) ?? null;
+  const selectedFile = selectedArtifact ? toPreviewFile(selectedArtifact) : null;
+
+  const handleOpenInWorkspace = () => {
+    if (!selectedArtifact?.source.path) {
+      return;
+    }
+
+    const relativePath = getAttachmentRelativePath(selectedArtifact.source.path);
+    const directory = relativePath.includes('/')
+      ? relativePath.slice(0, relativePath.lastIndexOf('/'))
+      : '';
+
+    workspaceNavigateTo$.set({
+      path: directory,
+      root: 'attachments',
+    });
+    rightSidebarVisible$.set(true);
+    rightSidebarActiveTab$.set('workspace');
+  };
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex items-center justify-between border-b p-4">
+        <div className="flex items-center gap-2">
+          <Package className="h-4 w-4 text-muted-foreground" />
+          <div>
+            <h2 className="text-sm font-medium">Artifacts</h2>
+            <p className="text-xs text-muted-foreground">
+              {artifacts.length} attachment-backed artifact{artifacts.length === 1 ? '' : 's'}
+            </p>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <Button variant="outline" size="sm" onClick={() => void loadArtifacts()} title="Refresh">
+            <RefreshCw className="mr-2 h-4 w-4" />
+            Refresh
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleOpenInWorkspace}
+            disabled={!selectedArtifact?.source.path}
+            title="Open in workspace viewer"
+          >
+            <FolderOpen className="mr-2 h-4 w-4" />
+            Open in workspace
+          </Button>
+        </div>
+      </div>
+
+      <div className="flex min-h-0 flex-1">
+        <div className="h-full w-1/2 overflow-auto border-r">
+          {loading ? (
+            <div className="flex h-full items-center justify-center">
+              <Loader2 className="h-6 w-6 animate-spin" />
+            </div>
+          ) : error ? (
+            <div className="flex h-full items-center justify-center p-4 text-center text-destructive">
+              {error}
+            </div>
+          ) : artifacts.length === 0 ? (
+            <div className="flex h-full items-center justify-center p-4 text-center text-muted-foreground">
+              No artifacts yet. Uploaded files and generated attachments will show up here.
+            </div>
+          ) : (
+            <div className="divide-y">
+              {artifacts.map((artifact) => {
+                const isSelected = artifact.id === selectedArtifactId;
+
+                return (
+                  <button
+                    key={artifact.id}
+                    type="button"
+                    onClick={() => setSelectedArtifactId(artifact.id)}
+                    className={`w-full px-4 py-3 text-left transition-colors hover:bg-muted/50 ${
+                      isSelected ? 'bg-muted' : ''
+                    }`}
+                  >
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <div className="truncate text-sm font-medium">{artifact.title}</div>
+                        <div className="mt-1 text-xs text-muted-foreground">
+                          {formatCreatedAt(artifact.created_at)}
+                          {artifact.size !== null
+                            ? ` • ${(artifact.size / 1024).toFixed(1)} KB`
+                            : ''}
+                        </div>
+                      </div>
+                      <Badge variant="secondary" className="shrink-0 lowercase">
+                        {artifact.kind}
+                      </Badge>
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </div>
+
+        <div className="h-full w-1/2 overflow-hidden">
+          {selectedArtifact && selectedFile ? (
+            <FilePreview file={selectedFile} conversationId={conversationId} root="attachments" />
+          ) : selectedArtifact ? (
+            <div className="flex h-full flex-col items-center justify-center gap-2 p-4 text-center">
+              <Package className="h-8 w-8 text-muted-foreground" />
+              <div className="text-sm font-medium">{selectedArtifact.title}</div>
+              <div className="text-sm text-muted-foreground">
+                Preview is not available for this artifact type yet.
+              </div>
+            </div>
+          ) : (
+            <div className="flex h-full items-center justify-center text-muted-foreground">
+              Select an artifact to preview
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/webui/src/components/ArtifactsPanel.tsx
+++ b/webui/src/components/ArtifactsPanel.tsx
@@ -104,7 +104,7 @@ export function ArtifactsPanel({ conversationId }: ArtifactsPanelProps) {
   const selectedFile = selectedArtifact ? toPreviewFile(selectedArtifact) : null;
 
   const handleOpenInWorkspace = () => {
-    if (!selectedArtifact?.source.path) {
+    if (selectedArtifact?.source.type !== 'attachment' || !selectedArtifact.source.path) {
       return;
     }
 
@@ -143,7 +143,9 @@ export function ArtifactsPanel({ conversationId }: ArtifactsPanelProps) {
             variant="outline"
             size="sm"
             onClick={handleOpenInWorkspace}
-            disabled={!selectedArtifact?.source.path}
+            disabled={
+              selectedArtifact?.source.type !== 'attachment' || !selectedArtifact?.source.path
+            }
             title="Open in workspace viewer"
           >
             <FolderOpen className="mr-2 h-4 w-4" />

--- a/webui/src/components/RightSidebar.tsx
+++ b/webui/src/components/RightSidebar.tsx
@@ -1,40 +1,31 @@
-import { Monitor, SlidersHorizontal, Globe, FolderOpen } from 'lucide-react';
 import type { FC } from 'react';
 import { rightSidebarVisible$, rightSidebarActiveTab$ } from '@/stores/sidebar';
-import { use$, useObservable } from '@legendapp/state/react';
+import type { RightSidebarPanelId } from '@/types/sidebar';
+import { use$ } from '@legendapp/state/react';
 import { NavigationIcons } from './NavigationIcons';
+import { rightSidebarPanels } from './rightSidebarPanels';
 
 interface Props {
   conversationId: string;
 }
 
-const navItems = [
-  { id: 'settings', label: 'Chat Settings', icon: SlidersHorizontal },
-  { id: 'workspace', label: 'Workspace', icon: FolderOpen },
-  { id: 'browser', label: 'Browser', icon: Globe },
-  { id: 'computer', label: 'Computer', icon: Monitor },
-];
-
 export const RightSidebar: FC<Props> = ({ conversationId: _conversationId }) => {
-  const activeTab$ = useObservable<string | null>(null);
-  const activeTab = use$(activeTab$);
+  const activeTab = use$(rightSidebarActiveTab$);
 
   const handleTabSelect = (tabId: string) => {
     if (tabId === activeTab) {
-      activeTab$.set(null);
       rightSidebarVisible$.set(false);
       rightSidebarActiveTab$.set(null);
     } else {
-      activeTab$.set(tabId);
       rightSidebarVisible$.set(true);
-      rightSidebarActiveTab$.set(tabId);
+      rightSidebarActiveTab$.set(tabId as RightSidebarPanelId);
     }
   };
 
   return (
     <div className="flex h-full w-12 flex-col border-l bg-background p-1">
       <NavigationIcons
-        navItems={navItems}
+        navItems={rightSidebarPanels}
         activeTab={activeTab || ''}
         onTabSelect={handleTabSelect}
       />

--- a/webui/src/components/RightSidebarContent.tsx
+++ b/webui/src/components/RightSidebarContent.tsx
@@ -1,37 +1,14 @@
 import type { FC } from 'react';
-import { ConversationSettings } from './ConversationSettings';
-import { BrowserPreview } from './BrowserPreview';
-import { WorkspaceExplorer } from './workspace/WorkspaceExplorer';
+import type { RightSidebarPanelId } from '@/types/sidebar';
+import { getRightSidebarPanel } from './rightSidebarPanels';
 
 interface Props {
   conversationId: string;
-  activeTab: string;
+  activeTab: RightSidebarPanelId;
 }
 
-const VNC_URL = 'http://localhost:6080/vnc.html';
-
 export const RightSidebarContent: FC<Props> = ({ conversationId, activeTab }) => {
-  const renderContent = () => {
-    switch (activeTab) {
-      case 'settings':
-        return <ConversationSettings conversationId={conversationId} />;
-      case 'workspace':
-        return <WorkspaceExplorer conversationId={conversationId} />;
-      case 'computer':
-        return (
-          <iframe
-            src={VNC_URL}
-            className="h-full w-full rounded-md border-0"
-            allow="clipboard-read; clipboard-write"
-            title="VNC Viewer"
-          />
-        );
-      case 'browser':
-        return <BrowserPreview />;
-      default:
-        return null;
-    }
-  };
+  const panel = getRightSidebarPanel(activeTab);
 
-  return <div className="h-full border-l bg-background">{renderContent()}</div>;
+  return <div className="h-full border-l bg-background">{panel?.render({ conversationId })}</div>;
 };

--- a/webui/src/components/__tests__/ArtifactsPanel.test.tsx
+++ b/webui/src/components/__tests__/ArtifactsPanel.test.tsx
@@ -89,7 +89,9 @@ describe('ArtifactsPanel', () => {
     render(<ArtifactsPanel conversationId="conv-2" />);
 
     await waitFor(() => {
-      expect(screen.getByTitle('Open in workspace viewer')).toBeInTheDocument();
+      const btn = screen.getByTitle('Open in workspace viewer');
+      expect(btn).toBeInTheDocument();
+      expect(btn).not.toBeDisabled();
     });
 
     fireEvent.click(screen.getByTitle('Open in workspace viewer'));

--- a/webui/src/components/__tests__/ArtifactsPanel.test.tsx
+++ b/webui/src/components/__tests__/ArtifactsPanel.test.tsx
@@ -1,0 +1,114 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { ArtifactsPanel } from '../ArtifactsPanel';
+import type { Artifact } from '@/types/artifact';
+
+const mockListArtifacts = jest.fn();
+const mockSetters = {
+  workspaceNavigate: jest.fn(),
+  rightSidebarActiveTab: jest.fn(),
+  rightSidebarVisible: jest.fn(),
+};
+
+jest.mock('@/utils/artifactsApi', () => ({
+  useArtifactsApi: () => ({
+    listArtifacts: mockListArtifacts,
+  }),
+}));
+
+jest.mock('../workspace/FilePreview', () => ({
+  FilePreview: ({ file }: { file: { name: string; path: string } }) => (
+    <div data-testid="file-preview">
+      {file.name}:{file.path}
+    </div>
+  ),
+}));
+
+jest.mock('@/stores/workspaceExplorer', () => ({
+  workspaceNavigateTo$: {
+    set: (...args: unknown[]) => mockSetters.workspaceNavigate(...args),
+  },
+}));
+
+jest.mock('@/stores/sidebar', () => ({
+  rightSidebarActiveTab$: {
+    set: (...args: unknown[]) => mockSetters.rightSidebarActiveTab(...args),
+  },
+  rightSidebarVisible$: {
+    set: (...args: unknown[]) => mockSetters.rightSidebarVisible(...args),
+  },
+}));
+
+describe('ArtifactsPanel', () => {
+  const artifact: Artifact = {
+    id: 'art_hero',
+    kind: 'image',
+    title: 'hero.png',
+    source: {
+      type: 'attachment',
+      path: 'attachments/nested/hero.png',
+      url: null,
+    },
+    created_at: '2026-05-30T12:00:00Z',
+    size: 4096,
+    mime_type: 'image/png',
+    provenance: {
+      message_index: 2,
+      tool: null,
+    },
+    preview: {
+      type: 'image',
+    },
+    actions: [],
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('loads artifacts and previews the first attachment-backed artifact', async () => {
+    mockListArtifacts.mockResolvedValue([artifact]);
+
+    render(<ArtifactsPanel conversationId="conv-1" />);
+
+    await waitFor(() => {
+      expect(screen.getByText('hero.png')).toBeInTheDocument();
+    });
+
+    expect(mockListArtifacts).toHaveBeenCalledWith('conv-1');
+    expect(screen.getByTestId('file-preview')).toHaveTextContent('hero.png:nested/hero.png');
+  });
+
+  it('routes the selected artifact to the workspace viewer', async () => {
+    mockListArtifacts.mockResolvedValue([artifact]);
+
+    render(<ArtifactsPanel conversationId="conv-2" />);
+
+    await waitFor(() => {
+      expect(screen.getByTitle('Open in workspace viewer')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTitle('Open in workspace viewer'));
+
+    expect(mockSetters.workspaceNavigate).toHaveBeenCalledWith({
+      path: 'nested',
+      root: 'attachments',
+    });
+    expect(mockSetters.rightSidebarVisible).toHaveBeenCalledWith(true);
+    expect(mockSetters.rightSidebarActiveTab).toHaveBeenCalledWith('workspace');
+  });
+
+  it('shows an error when artifact loading fails', async () => {
+    mockListArtifacts.mockRejectedValue(new Error('Artifacts unavailable'));
+
+    render(<ArtifactsPanel conversationId="conv-3" />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Artifacts unavailable')).toBeInTheDocument();
+    });
+  });
+});

--- a/webui/src/components/__tests__/ArtifactsPanel.test.tsx
+++ b/webui/src/components/__tests__/ArtifactsPanel.test.tsx
@@ -79,7 +79,7 @@ describe('ArtifactsPanel', () => {
       expect(screen.getByText('hero.png')).toBeInTheDocument();
     });
 
-    expect(mockListArtifacts).toHaveBeenCalledWith('conv-1');
+    expect(mockListArtifacts).toHaveBeenCalledWith('conv-1', expect.any(AbortSignal));
     expect(screen.getByTestId('file-preview')).toHaveTextContent('hero.png:nested/hero.png');
   });
 

--- a/webui/src/components/__tests__/RightSidebarContent.test.tsx
+++ b/webui/src/components/__tests__/RightSidebarContent.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react';
+import { RightSidebarContent } from '../RightSidebarContent';
+
+jest.mock('../ConversationSettings', () => ({
+  ConversationSettings: ({ conversationId }: { conversationId: string }) => (
+    <div data-testid="settings-panel">{conversationId}</div>
+  ),
+}));
+
+jest.mock('../BrowserPreview', () => ({
+  BrowserPreview: () => <div data-testid="browser-panel">browser</div>,
+}));
+
+jest.mock('../ArtifactsPanel', () => ({
+  ArtifactsPanel: ({ conversationId }: { conversationId: string }) => (
+    <div data-testid="artifacts-panel">{conversationId}</div>
+  ),
+}));
+
+jest.mock('../workspace/WorkspaceExplorer', () => ({
+  WorkspaceExplorer: ({ conversationId }: { conversationId: string }) => (
+    <div data-testid="workspace-panel">{conversationId}</div>
+  ),
+}));
+
+describe('RightSidebarContent', () => {
+  it('renders the artifacts panel through the sidebar registry', () => {
+    render(<RightSidebarContent conversationId="conv-art" activeTab="artifacts" />);
+
+    expect(screen.getByTestId('artifacts-panel')).toHaveTextContent('conv-art');
+  });
+
+  it('renders the computer panel iframe', () => {
+    render(<RightSidebarContent conversationId="conv-vnc" activeTab="computer" />);
+
+    expect(screen.getByTitle('VNC Viewer')).toBeInTheDocument();
+  });
+});

--- a/webui/src/components/rightSidebarPanels.tsx
+++ b/webui/src/components/rightSidebarPanels.tsx
@@ -1,0 +1,67 @@
+import type { ReactNode } from 'react';
+import { Globe, FolderOpen, Monitor, Package, SlidersHorizontal } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
+import type { RightSidebarPanelId } from '@/types/sidebar';
+import { ArtifactsPanel } from './ArtifactsPanel';
+import { BrowserPreview } from './BrowserPreview';
+import { ConversationSettings } from './ConversationSettings';
+import { WorkspaceExplorer } from './workspace/WorkspaceExplorer';
+
+const VNC_URL = 'http://localhost:6080/vnc.html';
+
+interface RightSidebarPanelRenderProps {
+  conversationId: string;
+}
+
+export interface RightSidebarPanelDefinition {
+  id: RightSidebarPanelId;
+  label: string;
+  icon: LucideIcon;
+  render: (props: RightSidebarPanelRenderProps) => ReactNode;
+}
+
+export const rightSidebarPanels: RightSidebarPanelDefinition[] = [
+  {
+    id: 'settings',
+    label: 'Chat Settings',
+    icon: SlidersHorizontal,
+    render: ({ conversationId }) => <ConversationSettings conversationId={conversationId} />,
+  },
+  {
+    id: 'workspace',
+    label: 'Workspace',
+    icon: FolderOpen,
+    render: ({ conversationId }) => <WorkspaceExplorer conversationId={conversationId} />,
+  },
+  {
+    id: 'artifacts',
+    label: 'Artifacts',
+    icon: Package,
+    render: ({ conversationId }) => <ArtifactsPanel conversationId={conversationId} />,
+  },
+  {
+    id: 'browser',
+    label: 'Browser',
+    icon: Globe,
+    render: () => <BrowserPreview />,
+  },
+  {
+    id: 'computer',
+    label: 'Computer',
+    icon: Monitor,
+    render: () => (
+      <iframe
+        src={VNC_URL}
+        className="h-full w-full rounded-md border-0"
+        allow="clipboard-read; clipboard-write"
+        title="VNC Viewer"
+      />
+    ),
+  },
+];
+
+export function getRightSidebarPanel(
+  panelId: RightSidebarPanelId
+): RightSidebarPanelDefinition | undefined {
+  return rightSidebarPanels.find((panel) => panel.id === panelId);
+}

--- a/webui/src/stores/sidebar.ts
+++ b/webui/src/stores/sidebar.ts
@@ -1,4 +1,5 @@
 import { type Agent } from '@/utils/workspaceUtils';
+import type { RightSidebarPanelId } from '@/types/sidebar';
 import { observable } from '@legendapp/state';
 import type { ImperativePanelHandle } from 'react-resizable-panels';
 
@@ -6,7 +7,7 @@ export const leftSidebarVisible$ = observable(false);
 export const leftSidebarCollapsed$ = observable(false);
 export const rightSidebarVisible$ = observable(true);
 export const rightSidebarCollapsed$ = observable(false);
-export const rightSidebarActiveTab$ = observable<string | null>(null);
+export const rightSidebarActiveTab$ = observable<RightSidebarPanelId | null>(null);
 
 // Selected workspace for filtering conversations
 export const selectedWorkspace$ = observable<string | null>(null);

--- a/webui/src/types/artifact.ts
+++ b/webui/src/types/artifact.ts
@@ -1,0 +1,52 @@
+export type ArtifactKind =
+  | 'image'
+  | 'audio'
+  | 'video'
+  | 'html'
+  | 'markdown'
+  | 'pdf'
+  | 'diff'
+  | 'dataset'
+  | 'webapp'
+  | 'binary'
+  | 'other';
+
+export type ArtifactPreviewType = 'image' | 'audio' | 'video' | 'text' | 'pdf' | 'none';
+
+export interface ArtifactSource {
+  type: 'attachment' | 'workspace' | 'external' | 'inline';
+  path: string | null;
+  url: string | null;
+}
+
+export interface ArtifactProvenance {
+  message_index: number | null;
+  tool: string | null;
+}
+
+export interface ArtifactPreview {
+  type: ArtifactPreviewType;
+}
+
+export interface ArtifactAction {
+  type: string;
+  panel: string | null;
+  artifact_id: string | null;
+}
+
+export interface Artifact {
+  id: string;
+  kind: ArtifactKind;
+  title: string;
+  source: ArtifactSource;
+  created_at: string;
+  size: number | null;
+  mime_type: string | null;
+  provenance: ArtifactProvenance;
+  preview: ArtifactPreview;
+  actions: ArtifactAction[];
+}
+
+export interface ArtifactListResponse {
+  artifacts: Artifact[];
+}

--- a/webui/src/types/sidebar.ts
+++ b/webui/src/types/sidebar.ts
@@ -1,0 +1,1 @@
+export type RightSidebarPanelId = 'settings' | 'workspace' | 'artifacts' | 'browser' | 'computer';

--- a/webui/src/utils/artifactsApi.ts
+++ b/webui/src/utils/artifactsApi.ts
@@ -24,13 +24,17 @@ export function useArtifactsApi() {
   const { api } = useApi();
 
   return useMemo(() => {
-    async function listArtifacts(conversationId: string): Promise<Artifact[]> {
+    async function listArtifacts(
+      conversationId: string,
+      signal?: AbortSignal
+    ): Promise<Artifact[]> {
       const url = `${api.baseUrl}/api/v2/conversations/${conversationId}/artifacts`;
 
       const response = await fetch(
         url,
         withLocalAddressSpace(url, {
           headers: api.authHeader ? { Authorization: api.authHeader } : undefined,
+          signal,
         })
       );
 

--- a/webui/src/utils/artifactsApi.ts
+++ b/webui/src/utils/artifactsApi.ts
@@ -1,6 +1,7 @@
 import type { ApiError } from '@/types/api';
 import type { Artifact, ArtifactListResponse } from '@/types/artifact';
 import { useApi } from '@/contexts/ApiContext';
+import { withLocalAddressSpace } from '@/utils/addressSpace';
 import { useMemo } from 'react';
 
 async function readApiError(response: Response, fallback: string): Promise<string> {
@@ -26,9 +27,12 @@ export function useArtifactsApi() {
     async function listArtifacts(conversationId: string): Promise<Artifact[]> {
       const url = `${api.baseUrl}/api/v2/conversations/${conversationId}/artifacts`;
 
-      const response = await fetch(url, {
-        headers: api.authHeader ? { Authorization: api.authHeader } : undefined,
-      });
+      const response = await fetch(
+        url,
+        withLocalAddressSpace(url, {
+          headers: api.authHeader ? { Authorization: api.authHeader } : undefined,
+        })
+      );
 
       if (!response.ok) {
         throw new Error(await readApiError(response, 'Failed to load artifacts'));

--- a/webui/src/utils/artifactsApi.ts
+++ b/webui/src/utils/artifactsApi.ts
@@ -1,0 +1,45 @@
+import type { ApiError } from '@/types/api';
+import type { Artifact, ArtifactListResponse } from '@/types/artifact';
+import { useApi } from '@/contexts/ApiContext';
+import { useMemo } from 'react';
+
+async function readApiError(response: Response, fallback: string): Promise<string> {
+  try {
+    const error = (await response.json()) as ApiError;
+    if (typeof error.error === 'string') {
+      return error.error;
+    }
+    if (typeof error.error?.message === 'string') {
+      return error.error.message;
+    }
+  } catch {
+    // Fall through to the generic message when the error body is not JSON.
+  }
+
+  return `${fallback} (${response.status})`;
+}
+
+export function useArtifactsApi() {
+  const { api } = useApi();
+
+  return useMemo(() => {
+    async function listArtifacts(conversationId: string): Promise<Artifact[]> {
+      const url = `${api.baseUrl}/api/v2/conversations/${conversationId}/artifacts`;
+
+      const response = await fetch(url, {
+        headers: api.authHeader ? { Authorization: api.authHeader } : undefined,
+      });
+
+      if (!response.ok) {
+        throw new Error(await readApiError(response, 'Failed to load artifacts'));
+      }
+
+      const data = (await response.json()) as ArtifactListResponse;
+      return data.artifacts;
+    }
+
+    return {
+      listArtifacts,
+    };
+  }, [api.baseUrl, api.authHeader]);
+}


### PR DESCRIPTION
## What

Adds the webui half of #830 Phase 1:

- a typed right-sidebar panel registry instead of the hardcoded tab switch
- a new `Artifacts` tab/panel that lists conversation artifacts
- a small artifacts API client plus typed artifact/sidebar models
- focused tests for the new panel and registry mapping

## Why

The server artifact registry in #2636 gives the webui a typed artifact surface. This PR consumes that surface and makes artifacts a first-class sidebar panel instead of burying everything in the workspace tree.

## Notes

- Draft on purpose: this depends on #2636 landing first, otherwise the new tab will only surface a backend error against current `master`.
- The artifact panel deliberately reuses the existing attachments preview/download plumbing instead of inventing a second preview path.

## Tests

- `npm test -- --runInBand ArtifactsPanel.test.tsx RightSidebarContent.test.tsx`
- `npm run typecheck`