### PR TITLE
feat(server): consume tool-declared artifact descriptors from message metadata (#830 Phase 2)

### DIFF
--- a/gptme/message.py
+++ b/gptme/message.py
@@ -67,6 +67,24 @@ class UsageData(TypedDict, total=False):
     cache_creation_tokens: int
 
 
+class ArtifactDescriptor(TypedDict, total=False):
+    """A tool/plugin-emitted artifact descriptor (see ErikBjare/bob#830).
+
+    Phase 2 of the webui artifact surface: tools attach these to a message's
+    metadata so the server can surface artifacts via typed declarations instead
+    of filename heuristics. Only ``source_type`` plus one of ``path``/``url`` is
+    required; the server fills in id, timestamps, preview hint, and actions.
+    """
+
+    source_type: Literal["attachment", "workspace", "external", "inline"]
+    path: str  # logdir-relative (attachment) or workspace path
+    url: str  # external URL (external sources)
+    kind: str  # optional kind override; server classifies when absent
+    title: str  # optional human-readable title; defaults to basename/url
+    mime_type: str  # optional MIME type
+    tool: str  # producing tool name (provenance)
+
+
 class MessageMetadata(TypedDict, total=False):
     """
     Metadata stored with each message.
@@ -93,6 +111,7 @@ class MessageMetadata(TypedDict, total=False):
     cost: float  # Cost in USD
     usage: UsageData
     voice_call: dict[str, Any]  # Voice call metadata (call_sid, source, etc.)
+    artifacts: list[ArtifactDescriptor]  # tool/plugin-emitted artifact descriptors
 
 
 _TOKEN_KEYS = (
@@ -135,16 +154,33 @@ def _format_toml_value(value: object) -> str:
     return str(value)
 
 
+def _format_toml_inline_table(d: dict) -> str:
+    """Format a dict as a TOML inline table, recursing into nested dicts/lists."""
+    items = [f'"{k}" = {_format_toml_member(v)}' for k, v in d.items()]
+    return f"{{ {', '.join(items)} }}"
+
+
+def _format_toml_array(lst: list) -> str:
+    """Format a list as a TOML array, recursing into nested dicts/lists."""
+    return f"[{', '.join(_format_toml_member(v) for v in lst)}]"
+
+
+def _format_toml_member(value: object) -> str:
+    """Format any metadata member (scalar, dict, or list) for TOML."""
+    if isinstance(value, dict):
+        return _format_toml_inline_table(value)
+    if isinstance(value, list):
+        return _format_toml_array(value)
+    return _format_toml_value(value)
+
+
 def _format_metadata_toml(metadata: MessageMetadata) -> str:
-    """Format metadata as TOML inline table, handling nested ``usage``."""
-    meta_items = []
-    for k, v in metadata.items():
-        if k == "usage" and isinstance(v, dict):
-            # Format usage as a nested inline table
-            usage_items = [f'"{uk}" = {_format_toml_value(uv)}' for uk, uv in v.items()]
-            meta_items.append(f'"usage" = {{ {", ".join(usage_items)} }}')
-        else:
-            meta_items.append(f'"{k}" = {_format_toml_value(v)}')
+    """Format metadata as a TOML inline table.
+
+    Handles scalars, nested dicts (e.g. ``usage``), and lists of inline tables
+    (e.g. ``artifacts``) so all metadata round-trips through hand-editing.
+    """
+    meta_items = [f'"{k}" = {_format_toml_member(v)}' for k, v in metadata.items()]
     return f"metadata = {{ {', '.join(meta_items)} }}"
 
 

--- a/gptme/server/artifacts_api.py
+++ b/gptme/server/artifacts_api.py
@@ -16,7 +16,7 @@ import logging
 import mimetypes
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Literal
+from typing import Any, Literal, cast, get_args
 
 import flask
 from pydantic import BaseModel, Field
@@ -194,6 +194,114 @@ def _provenance_index(manager: LogManager, filename: str) -> int | None:
     return None
 
 
+# Valid artifact kinds, derived from the ArtifactKind literal so a tool-supplied
+# ``kind`` override is validated rather than trusted blindly.
+_ARTIFACT_KINDS: frozenset[str] = frozenset(get_args(ArtifactKind))
+
+# Source types a descriptor may declare.
+_SOURCE_TYPES = frozenset({"attachment", "workspace", "external", "inline"})
+
+
+def _artifact_from_descriptor(
+    desc: object,
+    message_index: int,
+    logdir: Path,
+    default_created_at: str,
+) -> Artifact | None:
+    """Build an :class:`Artifact` from a tool-emitted descriptor.
+
+    Returns ``None`` for malformed descriptors so one bad entry never breaks the
+    whole artifact list. The server owns id derivation, preview hint, and
+    actions; the tool only declares source, kind, title, and provenance.
+    """
+    if not isinstance(desc, dict):
+        return None
+
+    source_type = desc.get("source_type", "attachment")
+    if source_type not in _SOURCE_TYPES:
+        return None
+
+    path = desc.get("path")
+    url = desc.get("url")
+
+    # Stable id key per source type. Attachment/workspace ids hash the path so a
+    # tool-declared attachment dedups against the attachment-scan artifact.
+    if source_type == "external":
+        if not url:
+            return None
+        id_key = str(url)
+    elif source_type == "inline":
+        id_key = f"inline:{message_index}:{desc.get('title', '')}"
+    else:  # attachment / workspace
+        if not path:
+            return None
+        id_key = str(path)
+    artifact_id = _artifact_id(id_key)
+
+    title = desc.get("title") or (Path(path).name if path else url) or "artifact"
+
+    ref_name = path or url or title
+    mime_type = desc.get("mime_type")
+    if mime_type is None:
+        mime_type, _ = mimetypes.guess_type(ref_name)
+
+    kind_raw = desc.get("kind")
+    if kind_raw in _ARTIFACT_KINDS:
+        kind = cast(ArtifactKind, kind_raw)
+    else:
+        kind = classify_kind(Path(ref_name), mime_type)
+
+    # File-backed sources: stat the real file for size and creation proxy.
+    size: int | None = None
+    created_at = default_created_at
+    if source_type in ("attachment", "workspace") and path:
+        candidate = logdir / path if source_type == "attachment" else Path(path)
+        try:
+            stat = candidate.stat()
+            size = stat.st_size
+            created_at = datetime.fromtimestamp(
+                stat.st_mtime, tz=timezone.utc
+            ).isoformat()
+        except OSError:
+            pass
+
+    actions = [
+        ArtifactAction(type="download", panel=None, artifact_id=None),
+        ArtifactAction(type="open_workspace", panel=None, artifact_id=None),
+        ArtifactAction(type="open_panel", panel="artifacts", artifact_id=artifact_id),
+    ]
+    return Artifact(
+        id=artifact_id,
+        kind=kind,
+        title=str(title),
+        source=ArtifactSource(type=source_type, path=path, url=url),
+        created_at=created_at,
+        size=size,
+        mime_type=mime_type,
+        provenance=ArtifactProvenance(
+            message_index=message_index, tool=desc.get("tool")
+        ),
+        preview=ArtifactPreview(type=_PREVIEW_FOR_KIND.get(kind, "none")),
+        actions=actions,
+    )
+
+
+def _artifacts_from_messages(manager: LogManager) -> list[Artifact]:
+    """Collect artifacts declared in message metadata (``metadata.artifacts``)."""
+    out: list[Artifact] = []
+    for idx, msg in enumerate(manager.log):
+        meta: Any = msg.metadata or {}
+        descriptors = meta.get("artifacts")
+        if not isinstance(descriptors, list):
+            continue
+        default_created = msg.timestamp.isoformat()
+        for desc in descriptors:
+            art = _artifact_from_descriptor(desc, idx, manager.logdir, default_created)
+            if art is not None:
+                out.append(art)
+    return out
+
+
 def derive_artifacts(
     manager: LogManager, target_id: str | None = None
 ) -> list[Artifact]:
@@ -202,49 +310,52 @@ def derive_artifacts(
     Phase 1 only reads the ``attachments/`` directory. This is intentionally a
     pure function (no Flask state) so it can be unit tested directly.
 
-    Pass ``target_id`` to short-circuit after the matching artifact is found,
-    avoiding the O(files × messages) provenance scan for every detail request.
+    Two sources are merged: the ``attachments/`` directory scan (Phase 1) and
+    tool/plugin-declared descriptors in message metadata (Phase 2). When both
+    describe the same artifact id, the message-declared one wins because it
+    carries richer provenance (the producing tool).
+
+    Pass ``target_id`` to filter to a single artifact, avoiding the
+    O(files × messages) provenance scan for every detail request.
     """
+    by_id: dict[str, Artifact] = {}
+
     attachments_dir = manager.logdir / "attachments"
-    if not attachments_dir.is_dir():
-        return []
+    if attachments_dir.is_dir():
+        for item in sorted(attachments_dir.iterdir(), key=lambda p: p.name.lower()):
+            if not item.is_file() or item.name.startswith("."):
+                continue
 
-    artifacts: list[Artifact] = []
-    for item in sorted(attachments_dir.iterdir(), key=lambda p: p.name.lower()):
-        if not item.is_file() or item.name.startswith("."):
-            continue
+            rel_path = f"attachments/{item.name}"
+            artifact_id = _artifact_id(rel_path)
 
-        rel_path = f"attachments/{item.name}"
-        artifact_id = _artifact_id(rel_path)
+            # Skip non-target files early to avoid the provenance scan.
+            if target_id is not None and artifact_id != target_id:
+                continue
 
-        # Skip non-target files early to avoid the provenance scan.
-        if target_id is not None and artifact_id != target_id:
-            continue
+            mime_type, _ = mimetypes.guess_type(item.name)
+            kind = classify_kind(item, mime_type)
 
-        mime_type, _ = mimetypes.guess_type(item.name)
-        kind = classify_kind(item, mime_type)
+            try:
+                stat = item.stat()
+                size: int | None = stat.st_size
+                # st_mtime is the last-modification time; used as a creation-time
+                # proxy because st_birthtime is only available on macOS/BSD.
+                created_at = datetime.fromtimestamp(
+                    stat.st_mtime, tz=timezone.utc
+                ).isoformat()
+            except OSError:
+                # File disappeared between iterdir() and stat() — skip it.
+                continue
 
-        try:
-            stat = item.stat()
-            size: int | None = stat.st_size
-            # st_mtime is the last-modification time; used as a creation-time
-            # proxy because st_birthtime is only available on macOS/BSD.
-            created_at = datetime.fromtimestamp(
-                stat.st_mtime, tz=timezone.utc
-            ).isoformat()
-        except OSError:
-            # File disappeared between iterdir() and stat() — skip it.
-            continue
-
-        actions = [
-            ArtifactAction(type="download", panel=None, artifact_id=None),
-            ArtifactAction(type="open_workspace", panel=None, artifact_id=None),
-            ArtifactAction(
-                type="open_panel", panel="artifacts", artifact_id=artifact_id
-            ),
-        ]
-        artifacts.append(
-            Artifact(
+            actions = [
+                ArtifactAction(type="download", panel=None, artifact_id=None),
+                ArtifactAction(type="open_workspace", panel=None, artifact_id=None),
+                ArtifactAction(
+                    type="open_panel", panel="artifacts", artifact_id=artifact_id
+                ),
+            ]
+            by_id[artifact_id] = Artifact(
                 id=artifact_id,
                 kind=kind,
                 title=item.name,
@@ -258,13 +369,14 @@ def derive_artifacts(
                 preview=ArtifactPreview(type=_PREVIEW_FOR_KIND.get(kind, "none")),
                 actions=actions,
             )
-        )
 
-        # Found what we came for — no need to scan further.
-        if target_id is not None:
-            break
+    # Merge in tool/plugin-declared artifacts; these win on id collision.
+    for art in _artifacts_from_messages(manager):
+        if target_id is not None and art.id != target_id:
+            continue
+        by_id[art.id] = art
 
-    return artifacts
+    return sorted(by_id.values(), key=lambda a: a.title.lower())
 
 
 @artifacts_api.route("/api/v2/conversations/<string:conversation_id>/artifacts")

--- a/gptme/server/artifacts_api.py
+++ b/gptme/server/artifacts_api.py
@@ -205,6 +205,7 @@ _SOURCE_TYPES = frozenset({"attachment", "workspace", "external", "inline"})
 def _artifact_from_descriptor(
     desc: object,
     message_index: int,
+    desc_index: int,
     logdir: Path,
     default_created_at: str,
 ) -> Artifact | None:
@@ -231,7 +232,7 @@ def _artifact_from_descriptor(
             return None
         id_key = str(url)
     elif source_type == "inline":
-        id_key = f"inline:{message_index}:{desc.get('title', '')}"
+        id_key = f"inline:{message_index}:{desc_index}:{desc.get('title', '')}"
     else:  # attachment / workspace
         if not path:
             return None
@@ -300,8 +301,10 @@ def _artifacts_from_messages(
         if ts.tzinfo is None:
             ts = ts.replace(tzinfo=timezone.utc)
         default_created = ts.isoformat()
-        for desc in descriptors:
-            art = _artifact_from_descriptor(desc, idx, manager.logdir, default_created)
+        for desc_idx, desc in enumerate(descriptors):
+            art = _artifact_from_descriptor(
+                desc, idx, desc_idx, manager.logdir, default_created
+            )
             if art is not None:
                 if target_id is None or art.id == target_id:
                     out.append(art)

--- a/gptme/server/artifacts_api.py
+++ b/gptme/server/artifacts_api.py
@@ -217,7 +217,7 @@ def _artifact_from_descriptor(
     if not isinstance(desc, dict):
         return None
 
-    source_type = desc.get("source_type", "attachment")
+    source_type = desc.get("source_type")
     if source_type not in _SOURCE_TYPES:
         return None
 
@@ -286,7 +286,9 @@ def _artifact_from_descriptor(
     )
 
 
-def _artifacts_from_messages(manager: LogManager) -> list[Artifact]:
+def _artifacts_from_messages(
+    manager: LogManager, target_id: str | None = None
+) -> list[Artifact]:
     """Collect artifacts declared in message metadata (``metadata.artifacts``)."""
     out: list[Artifact] = []
     for idx, msg in enumerate(manager.log):
@@ -294,11 +296,15 @@ def _artifacts_from_messages(manager: LogManager) -> list[Artifact]:
         descriptors = meta.get("artifacts")
         if not isinstance(descriptors, list):
             continue
-        default_created = msg.timestamp.isoformat()
+        ts = msg.timestamp
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=timezone.utc)
+        default_created = ts.isoformat()
         for desc in descriptors:
             art = _artifact_from_descriptor(desc, idx, manager.logdir, default_created)
             if art is not None:
-                out.append(art)
+                if target_id is None or art.id == target_id:
+                    out.append(art)
     return out
 
 
@@ -371,9 +377,7 @@ def derive_artifacts(
             )
 
     # Merge in tool/plugin-declared artifacts; these win on id collision.
-    for art in _artifacts_from_messages(manager):
-        if target_id is not None and art.id != target_id:
-            continue
+    for art in _artifacts_from_messages(manager, target_id=target_id):
         by_id[art.id] = art
 
     return sorted(by_id.values(), key=lambda a: a.title.lower())

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -254,6 +254,54 @@ def test_message_metadata():
     assert msg3.metadata == meta
 
 
+def test_message_metadata_artifacts_roundtrip():
+    """Tool-emitted artifact descriptors (list of dicts) survive round-trips.
+
+    Phase 2 of ErikBjare/bob#830 stores ``artifacts`` as a list of inline
+    tables in metadata; this guards both the JSON and TOML serializers.
+    """
+    import json
+
+    from dateutil.parser import isoparse
+
+    from gptme.message import Message, MessageMetadata
+
+    meta: MessageMetadata = {
+        "model": "claude-sonnet",
+        "artifacts": [
+            {
+                "source_type": "attachment",
+                "path": "attachments/plot.png",
+                "kind": "image",
+                "title": "plot.png",
+                "tool": "python",
+            },
+            {
+                "source_type": "external",
+                "url": "https://example.com/report.pdf",
+                "tool": "browser",
+            },
+        ],
+    }
+    msg = Message(role="assistant", content="Generated a plot", metadata=meta)
+
+    # JSON/JSONL roundtrip
+    d = msg.to_dict()
+    json_data = json.loads(json.dumps(d))
+    json_data["timestamp"] = isoparse(json_data["timestamp"])
+    msg2 = Message(**json_data)
+    assert msg2.metadata == meta
+
+    # TOML roundtrip (list of inline tables)
+    toml_str = msg.to_toml()
+    msg3 = Message.from_toml(toml_str)
+    assert msg3.metadata is not None
+    artifacts3 = msg3.metadata["artifacts"]
+    assert [a["source_type"] for a in artifacts3] == ["attachment", "external"]
+    assert artifacts3[0]["tool"] == "python"
+    assert artifacts3[1]["url"] == "https://example.com/report.pdf"
+
+
 def test_message_metadata_migration():
     """Test backward-compatible migration from flat to nested usage format."""
     import json

--- a/tests/test_server_artifacts.py
+++ b/tests/test_server_artifacts.py
@@ -274,6 +274,25 @@ class TestArtifactsFromMessages:
         arts = derive_artifacts(_manager_with_messages(tmp_path, [msg]))
         assert [a.title for a in arts] == ["ok.txt"]
 
+    def test_inline_duplicate_title_no_collision(self, tmp_path):
+        # Two inline descriptors in the same message with the same (or absent)
+        # title must not collide — desc_index makes their ids unique.
+        msg = Message(
+            "assistant",
+            "x",
+            metadata={
+                "artifacts": [
+                    {"source_type": "inline", "title": "result"},
+                    {"source_type": "inline", "title": "result"},
+                    {"source_type": "inline"},  # both title absent
+                    {"source_type": "inline"},
+                ]
+            },
+        )
+        arts = derive_artifacts(_manager_with_messages(tmp_path, [msg]))
+        assert len(arts) == 4
+        assert len({a.id for a in arts}) == 4  # all ids distinct
+
     def test_target_id_filters_message_artifacts(self, tmp_path):
         msg = Message(
             "assistant",

--- a/tests/test_server_artifacts.py
+++ b/tests/test_server_artifacts.py
@@ -8,6 +8,7 @@ Covers:
 
 import io
 from pathlib import Path
+from typing import cast
 from uuid import uuid4
 
 import pytest
@@ -153,3 +154,140 @@ class TestGetArtifactEndpoint:
         conv_id = _create_conv(client)
         resp = client.get(f"/api/v2/conversations/{conv_id}/artifacts/art_deadbeef0000")
         assert resp.status_code == 404
+
+
+# ============================================================
+# Phase 2: tool/plugin-declared artifacts (message metadata)
+# ============================================================
+
+from gptme.logmanager import LogManager  # fmt: skip
+from gptme.message import Message, MessageMetadata  # fmt: skip
+from gptme.server.artifacts_api import derive_artifacts  # fmt: skip
+
+
+def _manager_with_messages(tmp_path, messages: list[Message]) -> LogManager:
+    return LogManager(log=messages, logdir=tmp_path, lock=False)
+
+
+class TestArtifactsFromMessages:
+    def test_attachment_descriptor_sets_tool_provenance(self, tmp_path):
+        msg = Message(
+            "assistant",
+            "made an image",
+            metadata={
+                "artifacts": [
+                    {
+                        "source_type": "attachment",
+                        "path": "attachments/plot.png",
+                        "tool": "python",
+                    }
+                ]
+            },
+        )
+        arts = derive_artifacts(_manager_with_messages(tmp_path, [msg]))
+        assert len(arts) == 1
+        assert arts[0].kind == "image"
+        assert arts[0].title == "plot.png"
+        assert arts[0].provenance.tool == "python"
+        assert arts[0].provenance.message_index == 0
+
+    def test_tool_descriptor_overrides_attachment_scan(self, tmp_path):
+        # A file on disk (Phase 1 scan) plus a message declaring the same path.
+        att = tmp_path / "attachments"
+        att.mkdir()
+        (att / "plot.png").write_bytes(b"\x89PNG")
+        msg = Message(
+            "assistant",
+            "made an image",
+            metadata={
+                "artifacts": [
+                    {
+                        "source_type": "attachment",
+                        "path": "attachments/plot.png",
+                        "tool": "python",
+                    }
+                ]
+            },
+        )
+        arts = derive_artifacts(_manager_with_messages(tmp_path, [msg]))
+        # Deduped to one artifact; the tool-declared provenance wins.
+        assert len(arts) == 1
+        assert arts[0].provenance.tool == "python"
+        assert arts[0].size == 4  # real file size still picked up
+
+    def test_external_source(self, tmp_path):
+        msg = Message(
+            "assistant",
+            "fetched a page",
+            metadata={
+                "artifacts": [
+                    {
+                        "source_type": "external",
+                        "url": "https://example.com/report.pdf",
+                        "tool": "browser",
+                    }
+                ]
+            },
+        )
+        arts = derive_artifacts(_manager_with_messages(tmp_path, [msg]))
+        assert len(arts) == 1
+        assert arts[0].source.type == "external"
+        assert arts[0].source.url == "https://example.com/report.pdf"
+        assert arts[0].kind == "pdf"
+        assert arts[0].size is None
+
+    def test_kind_override_validated(self, tmp_path):
+        # An invalid kind is ignored and reclassified; a valid one is honored.
+        msg = Message(
+            "assistant",
+            "x",
+            metadata={
+                "artifacts": [
+                    {"source_type": "workspace", "path": "out/app", "kind": "webapp"},
+                    {"source_type": "workspace", "path": "data.csv", "kind": "bogus"},
+                ]
+            },
+        )
+        arts = {
+            a.title: a
+            for a in derive_artifacts(_manager_with_messages(tmp_path, [msg]))
+        }
+        assert arts["app"].kind == "webapp"
+        assert arts["data.csv"].kind == "dataset"  # reclassified from extension
+
+    def test_malformed_descriptors_skipped(self, tmp_path):
+        # Deliberately invalid descriptors (cast past the TypedDict) to prove
+        # one bad entry never breaks the list.
+        bad_metadata = cast(
+            MessageMetadata,
+            {
+                "artifacts": [
+                    "not-a-dict",
+                    {"source_type": "attachment"},  # missing path
+                    {"source_type": "external"},  # missing url
+                    {"source_type": "bogus", "path": "x"},  # bad source type
+                    {"source_type": "attachment", "path": "attachments/ok.txt"},
+                ]
+            },
+        )
+        msg = Message("assistant", "x", metadata=bad_metadata)
+        arts = derive_artifacts(_manager_with_messages(tmp_path, [msg]))
+        assert [a.title for a in arts] == ["ok.txt"]
+
+    def test_target_id_filters_message_artifacts(self, tmp_path):
+        msg = Message(
+            "assistant",
+            "x",
+            metadata={
+                "artifacts": [
+                    {"source_type": "external", "url": "https://a.example/x.png"},
+                    {"source_type": "external", "url": "https://b.example/y.png"},
+                ]
+            },
+        )
+        manager = _manager_with_messages(tmp_path, [msg])
+        all_arts = derive_artifacts(manager)
+        target = all_arts[0].id
+        filtered = derive_artifacts(manager, target_id=target)
+        assert len(filtered) == 1
+        assert filtered[0].id == target


### PR DESCRIPTION
Phase 2 of the webui artifact surface (ErikBjare/bob#830). Builds on the merged Phase 1 (#2636 server artifact registry + #2637 webui panel).

## What

Tools/plugins can now declare artifacts through a message's `metadata` instead of relying solely on the `attachments/` filename scan.

- **`ArtifactDescriptor` added to `MessageMetadata`** — minimal tool-emitted shape: `source_type` + `path`/`url`, plus optional `kind`/`title`/`mime_type`/`tool`. The server owns id derivation, timestamps, preview hint, and actions; a tool only declares source and provenance.
- **`derive_artifacts()` merges both sources** — attachment-scan artifacts (Phase 1) and message-declared descriptors, deduped by id. A tool-declared descriptor **wins on id collision**, so `provenance.tool` gets populated and `workspace`/`external`/`inline` sources surface even without a file in `attachments/`.
- **Generalized the metadata TOML formatter** — `_format_metadata_toml` now handles lists of inline tables and nested dicts. This fixes a latent crash on *any* non-scalar metadata value (previously only the `usage` dict was special-cased) and lets the `artifacts` list round-trip through hand-editing.

## Why

Phase 1 classified artifacts purely from filenames and could never know which tool produced a file (`provenance.tool` was always `null`). This lets a producing tool (python plots, browser captures, tts audio, generated webapps) declare a typed descriptor once, and the webui — which already renders whatever the server returns — surfaces it with correct kind and provenance. No producer is wired in this PR; that's a follow-up per-tool slice. The contract + consumer is independently valuable and fully testable at the server layer.

## Tests

`tests/test_server_artifacts.py` (new `TestArtifactsFromMessages`): descriptor→Artifact mapping, attachment dedup/override, external + workspace sources, kind-override validation, malformed-descriptor skipping, `target_id` filtering.
`tests/test_message.py`: JSON + TOML metadata round-trip for the artifacts list.

Local: 49 passed, mypy clean, ruff clean.

Refs ErikBjare/bob#830.