### PR TITLE
feat(tools/computer): emit artifact descriptors on screenshot (#830 Phase 2 producers)

### DIFF
--- a/gptme/tools/computer.py
+++ b/gptme/tools/computer.py
@@ -82,7 +82,6 @@ import subprocess
 from enum import Enum
 from typing import TYPE_CHECKING, Literal, TypedDict
 
-from ..message import ArtifactDescriptor, Message, MessageMetadata
 from .base import ToolSpec, ToolUse
 from .computer_transport import get_transport
 from .screenshot import screenshot
@@ -91,6 +90,7 @@ from .vision import view_image
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from ..message import ArtifactDescriptor, Message, MessageMetadata
     from .computer_transport import ComputerTransport
 
 logger = logging.getLogger(__name__)
@@ -102,10 +102,11 @@ IS_MACOS = platform.system() == "Darwin"
 
 def _make_screenshot_msg(path: Path, tool: str = "computer") -> Message | None:
     """Return view_image message augmented with an artifact descriptor."""
-    if not path.exists():
+    msg = view_image(path)
+    if not msg.files:
+        # view_image returns a system error message (no files attached) when path not found
         print("Error: Screenshot failed")
         return None
-    msg = view_image(path)
     descriptor: ArtifactDescriptor = {
         "source_type": "attachment",
         "path": str(path),
@@ -113,7 +114,9 @@ def _make_screenshot_msg(path: Path, tool: str = "computer") -> Message | None:
         "mime_type": "image/png",
         "tool": tool,
     }
-    return dataclasses.replace(msg, metadata=MessageMetadata(artifacts=[descriptor]))
+    existing: MessageMetadata = dict(msg.metadata) if msg.metadata else {}  # type: ignore[assignment]
+    existing["artifacts"] = [*existing.get("artifacts", []), descriptor]
+    return dataclasses.replace(msg, metadata=existing)
 
 
 # Constants from Anthropic's implementation

--- a/gptme/tools/computer.py
+++ b/gptme/tools/computer.py
@@ -72,6 +72,7 @@ Using a single sequence for complex operations ensures proper timing and recogni
 
 from __future__ import annotations
 
+import dataclasses
 import logging
 import os
 import platform
@@ -81,13 +82,15 @@ import subprocess
 from enum import Enum
 from typing import TYPE_CHECKING, Literal, TypedDict
 
+from ..message import ArtifactDescriptor, Message, MessageMetadata
 from .base import ToolSpec, ToolUse
 from .computer_transport import get_transport
 from .screenshot import screenshot
 from .vision import view_image
 
 if TYPE_CHECKING:
-    from ..message import Message
+    from pathlib import Path
+
     from .computer_transport import ComputerTransport
 
 logger = logging.getLogger(__name__)
@@ -95,6 +98,22 @@ logger = logging.getLogger(__name__)
 
 # Platform detection
 IS_MACOS = platform.system() == "Darwin"
+
+
+def _make_screenshot_msg(path: Path, tool: str = "computer") -> Message | None:
+    """Return view_image message augmented with an artifact descriptor."""
+    if not path.exists():
+        print("Error: Screenshot failed")
+        return None
+    msg = view_image(path)
+    descriptor: ArtifactDescriptor = {
+        "source_type": "attachment",
+        "path": str(path),
+        "kind": "image",
+        "mime_type": "image/png",
+        "tool": tool,
+    }
+    return dataclasses.replace(msg, metadata=MessageMetadata(artifacts=[descriptor]))
 
 
 # Constants from Anthropic's implementation
@@ -563,10 +582,7 @@ def _dispatch_transport(
 
     if action == "screenshot":
         path = transport.screenshot()
-        if path.exists():
-            return view_image(path)
-        print("Error: Screenshot failed")
-        return None
+        return _make_screenshot_msg(path)
 
     if action == "cursor_position":
         x, y = transport.cursor_position()
@@ -742,9 +758,7 @@ def computer(
                 raise RuntimeError("Image resize timed out") from e
             except subprocess.CalledProcessError as e:
                 raise RuntimeError(f"Image resize failed: {e.stderr}") from e
-            return view_image(path)
-        print("Error: Screenshot failed")
-        return None
+        return _make_screenshot_msg(path)
     if action == "cursor_position":
         if IS_MACOS:
             try:

--- a/tests/test_computer_artifacts.py
+++ b/tests/test_computer_artifacts.py
@@ -1,0 +1,71 @@
+"""Tests for artifact descriptor emission in the computer tool (#830 Phase 2)."""
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip(
+    "PIL", reason="PIL not installed, install with 'pip install pillow'"
+)
+
+from gptme.tools.computer import _make_screenshot_msg  # fmt: skip
+
+
+def _write_png(path: Path) -> None:
+    """Write a minimal 1x1 white PNG for testing."""
+    from PIL import Image
+
+    img = Image.new("RGB", (1, 1), color=(255, 255, 255))
+    img.save(path, "PNG")
+
+
+class TestMakeScreenshotMsg:
+    def test_returns_none_for_missing_file(self, tmp_path: Path) -> None:
+        path = tmp_path / "ghost.png"
+        assert not path.exists()
+        result = _make_screenshot_msg(path)
+        assert result is None
+
+    def test_returns_message_for_existing_file(self, tmp_path: Path) -> None:
+        path = tmp_path / "shot.png"
+        _write_png(path)
+        result = _make_screenshot_msg(path)
+        assert result is not None
+
+    def test_message_has_artifact_metadata(self, tmp_path: Path) -> None:
+        path = tmp_path / "shot.png"
+        _write_png(path)
+        result = _make_screenshot_msg(path)
+        assert result is not None
+        assert result.metadata is not None
+        assert "artifacts" in result.metadata
+        artifacts = result.metadata["artifacts"]
+        assert len(artifacts) == 1
+
+    def test_artifact_descriptor_fields(self, tmp_path: Path) -> None:
+        path = tmp_path / "shot.png"
+        _write_png(path)
+        result = _make_screenshot_msg(path, tool="computer")
+        assert result is not None
+        descriptor = result.metadata["artifacts"][0]  # type: ignore
+        assert descriptor["source_type"] == "attachment"
+        assert descriptor["path"] == str(path)
+        assert descriptor["kind"] == "image"
+        assert descriptor["mime_type"] == "image/png"
+        assert descriptor["tool"] == "computer"
+
+    def test_custom_tool_name(self, tmp_path: Path) -> None:
+        path = tmp_path / "shot.png"
+        _write_png(path)
+        result = _make_screenshot_msg(path, tool="myrobot")
+        assert result is not None
+        descriptor = result.metadata["artifacts"][0]  # type: ignore
+        assert descriptor["tool"] == "myrobot"
+
+    def test_message_files_still_present(self, tmp_path: Path) -> None:
+        """Artifact metadata should not displace the files attachment."""
+        path = tmp_path / "shot.png"
+        _write_png(path)
+        result = _make_screenshot_msg(path)
+        assert result is not None
+        assert result.files, "message must still carry files for vision"

--- a/tests/test_tools_computer.py
+++ b/tests/test_tools_computer.py
@@ -610,7 +610,7 @@ def test_computer_screenshot_success(
     mock_path = MagicMock(spec=Path)
     mock_path.exists.return_value = True
     mock_screenshot.return_value = mock_path
-    base_msg = Message(role="user", content="[image]")
+    base_msg = Message(role="user", content="[image]", files=[mock_path])
     mock_view_image.return_value = base_msg
     mock_subprocess_run.return_value = subprocess.CompletedProcess(
         args=[], returncode=0

--- a/tests/test_tools_computer.py
+++ b/tests/test_tools_computer.py
@@ -605,10 +605,13 @@ def test_computer_screenshot_success(
     from pathlib import Path
     from unittest.mock import MagicMock
 
+    from gptme.message import Message
+
     mock_path = MagicMock(spec=Path)
     mock_path.exists.return_value = True
     mock_screenshot.return_value = mock_path
-    mock_view_image.return_value = "image_message"
+    base_msg = Message(role="user", content="[image]")
+    mock_view_image.return_value = base_msg
     mock_subprocess_run.return_value = subprocess.CompletedProcess(
         args=[], returncode=0
     )
@@ -620,7 +623,12 @@ def test_computer_screenshot_success(
         result = computer("screenshot")
     mock_screenshot.assert_called_once()
     mock_view_image.assert_called_once_with(mock_path)
-    assert result == "image_message"
+    assert isinstance(result, Message)
+    assert result.metadata is not None
+    artifacts = result.metadata.get("artifacts", [])
+    assert len(artifacts) == 1
+    assert artifacts[0]["kind"] == "image"
+    assert artifacts[0]["tool"] == "computer"
     # Verify resize uses correct API dimensions, not squared coordinates.
     cmd = mock_subprocess_run.call_args[0][0]
     assert "-resize" in cmd


### PR DESCRIPTION
## Summary

Wire the `computer` tool's screenshot action to emit typed `ArtifactDescriptor` metadata alongside the existing `files=` attachment, so the server's artifact registry can surface screenshots via declared provenance instead of filename heuristics.

Part of ErikBjare/bob#830 Phase 2 remaining (gated on #2638, now merged).

### What changed

- **`gptme/tools/computer.py`**: Add `_make_screenshot_msg(path, tool)` helper that calls `view_image()` then attaches an `ArtifactDescriptor` (source_type=attachment, kind=image, mime_type=image/png, tool=computer) via `dataclasses.replace`. Both screenshot paths (native X11/macOS and transport layer) now use this helper.
- **`tests/test_computer_artifacts.py`**: 6 new unit tests covering missing-file → None, message returned, metadata structure, descriptor field values, custom tool name, and files attachment preserved.

### Why it matters

Before this PR, `derive_artifacts()` on the server only knew about screenshots through filename scanning. With this change, every `computer("screenshot")` call explicitly declares its artifact — enabling correct kind classification, provenance tracking, and dedup even when the screenshot path doesn't follow the attachment-directory convention.

## Test plan

- [x] `uv run pytest tests/test_computer_artifacts.py -v` — 6 passed
- [ ] CI green