### PR TITLE
feat(webui): sandboxed iframe panel primitive (#830 Phase 3)

### DIFF
--- a/webui/src/components/SandboxedIframePanel.tsx
+++ b/webui/src/components/SandboxedIframePanel.tsx
@@ -38,7 +38,8 @@ export const SandboxedIframePanel: FC<Props> = ({ descriptor, conversationId }) 
 
     const handleMessage = (event: MessageEvent) => {
       // Strict origin gate: only accept messages from the declared src origin.
-      if (expectedOrigin && event.origin !== expectedOrigin) return;
+      // Fail closed: if expectedOrigin is null (origin unresolvable), reject all.
+      if (!expectedOrigin || event.origin !== expectedOrigin) return;
       if (event.source !== iframeRef.current?.contentWindow) return;
       if (!isGptmeIframeMessage(event.data)) return;
 
@@ -46,14 +47,17 @@ export const SandboxedIframePanel: FC<Props> = ({ descriptor, conversationId }) 
         case 'gptme:ready':
           post({
             type: 'gptme:bootstrap',
-            payload: { conversation_id: conversationId, ...(descriptor.bootstrap ?? {}) },
+            // Spread descriptor.bootstrap first so the prop-supplied
+            // conversationId always wins over any key in the bootstrap blob.
+            payload: { ...(descriptor.bootstrap ?? {}), conversation_id: conversationId },
           });
           break;
         case 'gptme:resize': {
           if (descriptor.resize !== 'auto') break;
           const height = (event.data.payload as { height?: unknown } | undefined)?.height;
+          const MAX_IFRAME_HEIGHT = 16_000;
           if (typeof height === 'number' && Number.isFinite(height) && height > 0) {
-            setAutoHeight(height);
+            setAutoHeight(Math.min(height, MAX_IFRAME_HEIGHT));
           }
           break;
         }

--- a/webui/src/components/SandboxedIframePanel.tsx
+++ b/webui/src/components/SandboxedIframePanel.tsx
@@ -1,0 +1,99 @@
+/**
+ * Renders a plugin-owned iframe panel under the strict #830 Phase 3 contract:
+ * src is validated against the allowlist, the sandbox attribute is filtered to
+ * the permitted token set, and all host <-> iframe traffic flows through the
+ * origin-gated postMessage protocol.
+ *
+ * Bootstrap flow:
+ *   1. Render <iframe sandbox=... src=...> but hold the bootstrap payload.
+ *   2. Iframe loads and posts `gptme:ready`.
+ *   3. Host validates the origin and replies with `gptme:bootstrap`.
+ */
+import { useEffect, useRef, useState } from 'react';
+import type { FC } from 'react';
+import type { GptmeIframeMessage, IframePanelDescriptor } from '@/types/panel';
+import { isGptmeIframeMessage } from '@/types/panel';
+import { iframeSrcOrigin, isAllowedIframeSrc, resolveSandbox } from '@/utils/iframePanelPolicy';
+
+interface Props {
+  descriptor: IframePanelDescriptor;
+  conversationId: string;
+}
+
+export const SandboxedIframePanel: FC<Props> = ({ descriptor, conversationId }) => {
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  const [autoHeight, setAutoHeight] = useState<number | null>(null);
+
+  const allowed = isAllowedIframeSrc(descriptor.src);
+  const expectedOrigin = allowed ? iframeSrcOrigin(descriptor.src) : null;
+
+  useEffect(() => {
+    if (!allowed) return;
+
+    const post = (message: GptmeIframeMessage) => {
+      const target = iframeRef.current?.contentWindow;
+      if (!target || !expectedOrigin) return;
+      target.postMessage(message, expectedOrigin);
+    };
+
+    const handleMessage = (event: MessageEvent) => {
+      // Strict origin gate: only accept messages from the declared src origin.
+      if (expectedOrigin && event.origin !== expectedOrigin) return;
+      if (event.source !== iframeRef.current?.contentWindow) return;
+      if (!isGptmeIframeMessage(event.data)) return;
+
+      switch (event.data.type) {
+        case 'gptme:ready':
+          post({
+            type: 'gptme:bootstrap',
+            payload: { conversation_id: conversationId, ...(descriptor.bootstrap ?? {}) },
+          });
+          break;
+        case 'gptme:resize': {
+          if (descriptor.resize !== 'auto') break;
+          const height = (event.data.payload as { height?: unknown } | undefined)?.height;
+          if (typeof height === 'number' && Number.isFinite(height) && height > 0) {
+            setAutoHeight(height);
+          }
+          break;
+        }
+        // Unrecognised gptme:* messages are silently ignored for forward compat.
+        default:
+          break;
+      }
+    };
+
+    window.addEventListener('message', handleMessage);
+    return () => window.removeEventListener('message', handleMessage);
+  }, [allowed, expectedOrigin, conversationId, descriptor.bootstrap, descriptor.resize]);
+
+  if (!allowed) {
+    return (
+      <div
+        role="alert"
+        className="flex h-full flex-col items-center justify-center gap-2 p-6 text-center text-sm text-muted-foreground"
+      >
+        <p className="font-medium text-foreground">Panel blocked</p>
+        <p>
+          The panel source <code className="rounded bg-muted px-1">{descriptor.src}</code> is not an
+          allowed iframe origin. Only localhost tool servers and server-relative paths are
+          permitted.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <iframe
+      ref={iframeRef}
+      src={descriptor.src}
+      title={descriptor.title}
+      sandbox={resolveSandbox(descriptor.sandbox)}
+      allow={descriptor.allow ?? ''}
+      className="w-full rounded-md border-0"
+      style={
+        descriptor.resize === 'auto' && autoHeight ? { height: autoHeight } : { height: '100%' }
+      }
+    />
+  );
+};

--- a/webui/src/components/__tests__/SandboxedIframePanel.test.tsx
+++ b/webui/src/components/__tests__/SandboxedIframePanel.test.tsx
@@ -1,0 +1,113 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { SandboxedIframePanel } from '../SandboxedIframePanel';
+import type { IframePanelDescriptor, IframeSandboxToken } from '@/types/panel';
+
+const baseDescriptor: IframePanelDescriptor = {
+  id: 'webapp-preview',
+  kind: 'iframe',
+  title: 'Webapp Preview',
+  src: 'http://localhost:8080',
+  sandbox: ['allow-scripts'],
+};
+
+function getIframe(): HTMLIFrameElement {
+  const frame = screen.getByTitle('Webapp Preview');
+  return frame as HTMLIFrameElement;
+}
+
+function emitFromIframe(frame: HTMLIFrameElement, origin: string, data: unknown) {
+  window.dispatchEvent(new MessageEvent('message', { data, origin, source: frame.contentWindow }));
+}
+
+describe('SandboxedIframePanel', () => {
+  it('renders a sandboxed iframe with the filtered sandbox attribute', () => {
+    render(
+      <SandboxedIframePanel
+        descriptor={{
+          ...baseDescriptor,
+          // 'allow-popups' is never permitted; cast simulates a tool requesting it.
+          sandbox: ['allow-scripts', 'allow-popups' as IframeSandboxToken],
+        }}
+        conversationId="conv1"
+      />
+    );
+    const frame = getIframe();
+    expect(frame.getAttribute('src')).toBe('http://localhost:8080');
+    // allow-popups is never permitted and must be dropped.
+    expect(frame.getAttribute('sandbox')).toBe('allow-scripts');
+  });
+
+  it('sends gptme:bootstrap with the conversation id after gptme:ready', async () => {
+    render(<SandboxedIframePanel descriptor={baseDescriptor} conversationId="conv-abc" />);
+    const frame = getIframe();
+    const postMessage = jest.fn();
+    Object.defineProperty(frame, 'contentWindow', {
+      value: { postMessage },
+      configurable: true,
+    });
+
+    emitFromIframe(frame, 'http://localhost:8080', { type: 'gptme:ready' });
+
+    await waitFor(() => expect(postMessage).toHaveBeenCalledTimes(1));
+    expect(postMessage).toHaveBeenCalledWith(
+      { type: 'gptme:bootstrap', payload: { conversation_id: 'conv-abc' } },
+      'http://localhost:8080'
+    );
+  });
+
+  it('merges descriptor bootstrap fields into the bootstrap payload', async () => {
+    render(
+      <SandboxedIframePanel
+        descriptor={{ ...baseDescriptor, bootstrap: { artifact_id: 'art_01' } }}
+        conversationId="conv-abc"
+      />
+    );
+    const frame = getIframe();
+    const postMessage = jest.fn();
+    Object.defineProperty(frame, 'contentWindow', { value: { postMessage }, configurable: true });
+
+    emitFromIframe(frame, 'http://localhost:8080', { type: 'gptme:ready' });
+
+    await waitFor(() => expect(postMessage).toHaveBeenCalledTimes(1));
+    expect(postMessage).toHaveBeenCalledWith(
+      { type: 'gptme:bootstrap', payload: { conversation_id: 'conv-abc', artifact_id: 'art_01' } },
+      'http://localhost:8080'
+    );
+  });
+
+  it('ignores messages from a foreign origin', async () => {
+    render(<SandboxedIframePanel descriptor={baseDescriptor} conversationId="conv-abc" />);
+    const frame = getIframe();
+    const postMessage = jest.fn();
+    Object.defineProperty(frame, 'contentWindow', { value: { postMessage }, configurable: true });
+
+    emitFromIframe(frame, 'https://evil.example.com', { type: 'gptme:ready' });
+
+    await new Promise((r) => setTimeout(r, 10));
+    expect(postMessage).not.toHaveBeenCalled();
+  });
+
+  it('ignores unrecognised gptme message types', async () => {
+    render(<SandboxedIframePanel descriptor={baseDescriptor} conversationId="conv-abc" />);
+    const frame = getIframe();
+    const postMessage = jest.fn();
+    Object.defineProperty(frame, 'contentWindow', { value: { postMessage }, configurable: true });
+
+    emitFromIframe(frame, 'http://localhost:8080', { type: 'gptme:unknown' });
+
+    await new Promise((r) => setTimeout(r, 10));
+    expect(postMessage).not.toHaveBeenCalled();
+  });
+
+  it('renders a blocked placeholder for a disallowed src', () => {
+    render(
+      <SandboxedIframePanel
+        descriptor={{ ...baseDescriptor, src: 'https://evil.example.com' }}
+        conversationId="conv1"
+      />
+    );
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByText(/Panel blocked/)).toBeInTheDocument();
+    expect(screen.queryByTitle('Webapp Preview')).not.toBeInTheDocument();
+  });
+});

--- a/webui/src/components/__tests__/SandboxedIframePanel.test.tsx
+++ b/webui/src/components/__tests__/SandboxedIframePanel.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import { SandboxedIframePanel } from '../SandboxedIframePanel';
 import type { IframePanelDescriptor, IframeSandboxToken } from '@/types/panel';
 
@@ -97,6 +97,70 @@ describe('SandboxedIframePanel', () => {
 
     await new Promise((r) => setTimeout(r, 10));
     expect(postMessage).not.toHaveBeenCalled();
+  });
+
+  it('prop conversationId wins over a conversation_id key in the bootstrap blob', async () => {
+    render(
+      <SandboxedIframePanel
+        descriptor={{ ...baseDescriptor, bootstrap: { conversation_id: 'override-attempt' } }}
+        conversationId="real-conv-id"
+      />
+    );
+    const frame = getIframe();
+    const postMessage = jest.fn();
+    Object.defineProperty(frame, 'contentWindow', { value: { postMessage }, configurable: true });
+
+    emitFromIframe(frame, 'http://localhost:8080', { type: 'gptme:ready' });
+
+    await waitFor(() => expect(postMessage).toHaveBeenCalledTimes(1));
+    expect(postMessage).toHaveBeenCalledWith(
+      { type: 'gptme:bootstrap', payload: { conversation_id: 'real-conv-id' } },
+      'http://localhost:8080'
+    );
+  });
+
+  it('rejects postMessage when expectedOrigin cannot be resolved (fail-closed)', async () => {
+    // Simulate an iframe whose src produces a null origin by patching the policy.
+    // We do this indirectly: use a descriptor with an opaque-origin data: src that
+    // passes the allowlist check but returns null from iframeSrcOrigin. The
+    // simplest approach is to render with a server-relative src that resolves fine
+    // but then emit from 'null' (the serialised opaque origin browsers send for
+    // sandboxed iframes without allow-same-origin).
+    render(<SandboxedIframePanel descriptor={baseDescriptor} conversationId="conv-abc" />);
+    const frame = getIframe();
+    const postMessage = jest.fn();
+    Object.defineProperty(frame, 'contentWindow', { value: { postMessage }, configurable: true });
+
+    // 'null' is what browsers serialize as the origin for opaque origins.
+    emitFromIframe(frame, 'null', { type: 'gptme:ready' });
+
+    await new Promise((r) => setTimeout(r, 10));
+    expect(postMessage).not.toHaveBeenCalled();
+  });
+
+  it('caps resize height at 16 000 px', async () => {
+    render(
+      <SandboxedIframePanel
+        descriptor={{ ...baseDescriptor, resize: 'auto' }}
+        conversationId="conv-abc"
+      />
+    );
+    const frame = getIframe();
+    Object.defineProperty(frame, 'contentWindow', {
+      value: { postMessage: jest.fn() },
+      configurable: true,
+    });
+
+    await act(async () => {
+      emitFromIframe(frame, 'http://localhost:8080', {
+        type: 'gptme:resize',
+        payload: { height: 1e15 },
+      });
+    });
+
+    const style = frame.getAttribute('style') ?? '';
+    // height should be capped, not set to 1e15
+    expect(style).toMatch(/16000/);
   });
 
   it('renders a blocked placeholder for a disallowed src', () => {

--- a/webui/src/types/panel.ts
+++ b/webui/src/types/panel.ts
@@ -1,0 +1,52 @@
+/**
+ * Typed iframe panel descriptors and the postMessage envelope for the
+ * constrained iframe extension surface (#830 Phase 3).
+ *
+ * Plugin-owned custom UI never runs inside the core webui bundle. Instead a
+ * tool declares an iframe panel descriptor and the UI runs in a sandboxed
+ * iframe at runtime, communicating with the host only through the typed
+ * postMessage protocol defined here.
+ */
+
+/** Sandbox tokens a descriptor is permitted to request. */
+export type IframeSandboxToken =
+  | 'allow-scripts'
+  | 'allow-same-origin'
+  | 'allow-forms'
+  | 'allow-downloads';
+
+export interface IframePanelDescriptor {
+  /** Unique panel id within the conversation. */
+  id: string;
+  /** Discriminator for the panel registry. */
+  kind: 'iframe';
+  /** Tab label in the sidebar. */
+  title: string;
+  /** Lucide icon name (default: "layout"). */
+  icon?: string;
+  /** URL loaded in the iframe. Validated against the src allowlist. */
+  src: string;
+  /** Subset of the sandbox token allowlist the tool requests. */
+  sandbox: IframeSandboxToken[];
+  /** Feature-Policy string (`""` = deny all). */
+  allow?: string;
+  /** Auto-resize from iframe height messages, or keep a fixed height. */
+  resize?: 'auto' | 'fixed';
+  /** Opaque JSON forwarded to the iframe in the bootstrap message. */
+  bootstrap?: Record<string, unknown>;
+}
+
+/** Typed envelope for all host <-> iframe postMessage traffic. */
+export interface GptmeIframeMessage {
+  type: `gptme:${string}`;
+  payload?: unknown;
+}
+
+export function isGptmeIframeMessage(value: unknown): value is GptmeIframeMessage {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as { type?: unknown }).type === 'string' &&
+    (value as { type: string }).type.startsWith('gptme:')
+  );
+}

--- a/webui/src/utils/__tests__/iframePanelPolicy.test.ts
+++ b/webui/src/utils/__tests__/iframePanelPolicy.test.ts
@@ -55,9 +55,14 @@ describe('iframeSrcOrigin', () => {
 describe('resolveSandbox', () => {
   it('keeps allowlisted tokens', () => {
     expect(resolveSandbox(['allow-scripts'])).toBe('allow-scripts');
-    expect(resolveSandbox(['allow-scripts', 'allow-same-origin'])).toBe(
-      'allow-scripts allow-same-origin'
-    );
+    expect(resolveSandbox(['allow-same-origin'])).toBe('allow-same-origin');
+    expect(resolveSandbox(['allow-forms', 'allow-downloads'])).toBe('allow-forms allow-downloads');
+  });
+
+  it('drops allow-same-origin when allow-scripts is also present (sandbox escape guard)', () => {
+    // Both together let an iframe remove its own sandbox attribute.
+    expect(resolveSandbox(['allow-scripts', 'allow-same-origin'])).toBe('allow-scripts');
+    expect(resolveSandbox(['allow-same-origin', 'allow-scripts'])).toBe('allow-scripts');
   });
 
   it('drops never-allowed tokens', () => {

--- a/webui/src/utils/__tests__/iframePanelPolicy.test.ts
+++ b/webui/src/utils/__tests__/iframePanelPolicy.test.ts
@@ -1,0 +1,75 @@
+import { iframeSrcOrigin, isAllowedIframeSrc, resolveSandbox } from '../iframePanelPolicy';
+
+describe('isAllowedIframeSrc', () => {
+  it('allows localhost and 127.0.0.1 origins on any port', () => {
+    expect(isAllowedIframeSrc('http://localhost:8080')).toBe(true);
+    expect(isAllowedIframeSrc('http://localhost:6080/vnc.html')).toBe(true);
+    expect(isAllowedIframeSrc('https://127.0.0.1:3000/app')).toBe(true);
+    expect(isAllowedIframeSrc('http://[::1]:9000')).toBe(true);
+  });
+
+  it('allows server-relative paths', () => {
+    expect(isAllowedIframeSrc('/preview/app')).toBe(true);
+    expect(isAllowedIframeSrc('/api/v2/conversations/x/ui')).toBe(true);
+  });
+
+  it('rejects protocol-relative and backslash-prefixed values', () => {
+    expect(isAllowedIframeSrc('//evil.example.com')).toBe(false);
+    expect(isAllowedIframeSrc('/\\evil.example.com')).toBe(false);
+  });
+
+  it('rejects arbitrary external origins', () => {
+    expect(isAllowedIframeSrc('https://evil.example.com')).toBe(false);
+    expect(isAllowedIframeSrc('http://localhost.evil.com')).toBe(false);
+    expect(isAllowedIframeSrc('https://notlocalhost')).toBe(false);
+  });
+
+  it('rejects empty, whitespace, and malformed values', () => {
+    expect(isAllowedIframeSrc('')).toBe(false);
+    expect(isAllowedIframeSrc('   ')).toBe(false);
+    expect(isAllowedIframeSrc('not a url')).toBe(false);
+    // @ts-expect-error guarding non-string at runtime
+    expect(isAllowedIframeSrc(undefined)).toBe(false);
+  });
+});
+
+describe('iframeSrcOrigin', () => {
+  it('returns the origin for absolute localhost urls', () => {
+    expect(iframeSrcOrigin('http://localhost:8080/app')).toBe('http://localhost:8080');
+  });
+
+  it('resolves server-relative paths against the host origin', () => {
+    expect(iframeSrcOrigin('/preview', 'https://chat.gptme.org')).toBe('https://chat.gptme.org');
+  });
+
+  it('falls back to the window origin when no host origin is given', () => {
+    // jsdom provides window.location.origin === 'http://localhost'
+    expect(iframeSrcOrigin('/preview')).toBe('http://localhost');
+  });
+
+  it('returns null for malformed values', () => {
+    expect(iframeSrcOrigin('http://', 'http://localhost')).toBe(null);
+  });
+});
+
+describe('resolveSandbox', () => {
+  it('keeps allowlisted tokens', () => {
+    expect(resolveSandbox(['allow-scripts'])).toBe('allow-scripts');
+    expect(resolveSandbox(['allow-scripts', 'allow-same-origin'])).toBe(
+      'allow-scripts allow-same-origin'
+    );
+  });
+
+  it('drops never-allowed tokens', () => {
+    expect(resolveSandbox(['allow-scripts', 'allow-top-navigation', 'allow-popups'])).toBe(
+      'allow-scripts'
+    );
+    expect(resolveSandbox(['allow-modals'])).toBe('');
+  });
+
+  it('collapses duplicates and handles empty input', () => {
+    expect(resolveSandbox(['allow-scripts', 'allow-scripts'])).toBe('allow-scripts');
+    expect(resolveSandbox([])).toBe('');
+    expect(resolveSandbox(undefined)).toBe('');
+  });
+});

--- a/webui/src/utils/iframePanelPolicy.ts
+++ b/webui/src/utils/iframePanelPolicy.ts
@@ -1,0 +1,74 @@
+/**
+ * Source-URL allowlist and sandbox policy enforcement for iframe panels
+ * (#830 Phase 3). These rules are intentionally strict: the iframe escape
+ * hatch exists for local tool servers and controlled deployments, not for
+ * arbitrary third-party embeds.
+ */
+import type { IframeSandboxToken } from '@/types/panel';
+
+/** Sandbox tokens a descriptor may request. Anything else is dropped. */
+const SANDBOX_ALLOWLIST: ReadonlySet<string> = new Set<IframeSandboxToken>([
+  'allow-scripts',
+  'allow-same-origin',
+  'allow-forms',
+  'allow-downloads',
+]);
+
+/**
+ * Validate an iframe `src` before rendering. Accepted, in priority order:
+ *   1. localhost / 127.0.0.1 origins (any scheme/port)
+ *   2. server-relative paths (start with a single "/")
+ * Everything else is rejected.
+ *
+ * Protocol-relative ("//host") and backslash-prefixed values are treated as
+ * absolute and rejected unless they resolve to a localhost origin.
+ */
+export function isAllowedIframeSrc(src: string): boolean {
+  if (typeof src !== 'string' || src.trim() === '') return false;
+  const value = src.trim();
+
+  // Server-relative path: a single leading slash, not "//" (protocol-relative)
+  // and not a backslash variant.
+  if (value.startsWith('/') && !value.startsWith('//') && !value.startsWith('/\\')) {
+    return true;
+  }
+
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return false;
+  }
+
+  const host = url.hostname.toLowerCase();
+  return host === 'localhost' || host === '127.0.0.1' || host === '[::1]' || host === '::1';
+}
+
+/**
+ * Resolve the origin an iframe `src` will load from, for strict postMessage
+ * origin checks. Server-relative paths resolve against the host window origin.
+ * Returns null when the origin cannot be determined.
+ */
+export function iframeSrcOrigin(src: string, hostOrigin?: string): string | null {
+  const base = hostOrigin ?? (typeof window !== 'undefined' ? window.location.origin : undefined);
+  try {
+    return new URL(src, base).origin;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Filter requested sandbox tokens down to the allowlist and return the
+ * space-joined string for the iframe `sandbox` attribute. Unknown or
+ * never-allowed tokens (allow-top-navigation, allow-popups, allow-modals)
+ * are silently dropped. Duplicates are collapsed.
+ */
+export function resolveSandbox(tokens: readonly string[] | undefined): string {
+  if (!tokens || tokens.length === 0) return '';
+  const allowed = new Set<string>();
+  for (const token of tokens) {
+    if (SANDBOX_ALLOWLIST.has(token)) allowed.add(token);
+  }
+  return Array.from(allowed).join(' ');
+}

--- a/webui/src/utils/iframePanelPolicy.ts
+++ b/webui/src/utils/iframePanelPolicy.ts
@@ -63,12 +63,21 @@ export function iframeSrcOrigin(src: string, hostOrigin?: string): string | null
  * space-joined string for the iframe `sandbox` attribute. Unknown or
  * never-allowed tokens (allow-top-navigation, allow-popups, allow-modals)
  * are silently dropped. Duplicates are collapsed.
+ *
+ * The `allow-scripts` + `allow-same-origin` combination is unconditionally
+ * forbidden: together they allow the iframe to remove its own sandbox
+ * attribute and gain full access to the parent page's DOM. When both are
+ * requested, `allow-same-origin` is dropped so scripts still run but cannot
+ * escalate.
  */
 export function resolveSandbox(tokens: readonly string[] | undefined): string {
   if (!tokens || tokens.length === 0) return '';
   const allowed = new Set<string>();
   for (const token of tokens) {
     if (SANDBOX_ALLOWLIST.has(token)) allowed.add(token);
+  }
+  if (allowed.has('allow-scripts') && allowed.has('allow-same-origin')) {
+    allowed.delete('allow-same-origin');
   }
   return Array.from(allowed).join(' ');
 }


### PR DESCRIPTION
## Summary

Adds the frontend core of the **Phase 3 iframe extension surface** from the
approved #830 design (ErikBjare/bob#830). This is the escape hatch for tools
that genuinely need custom UI: plugin-provided UI never runs inside the core
webui bundle — it runs in a sandboxed iframe at runtime and talks to the host
only through an origin-gated `postMessage` protocol.

Builds on the already-merged Phase 1 (#2636 server registry, #2637 webui panel
registry) and Phase 2 (#2638 artifact descriptors). Independently mergeable.

## What's included

- **`types/panel.ts`** — typed `IframePanelDescriptor` and the
  `GptmeIframeMessage` envelope (`gptme:*`), plus a runtime type guard.
- **`utils/iframePanelPolicy.ts`** — the strict security policy:
  - `isAllowedIframeSrc`: only `localhost` / `127.0.0.1` / `[::1]` origins and
    server-relative paths; rejects protocol-relative, backslash, and arbitrary
    external origins.
  - `resolveSandbox`: filters requested sandbox tokens to the permitted set
    (`allow-scripts`, `allow-same-origin`, `allow-forms`, `allow-downloads`);
    silently drops never-allowed tokens (`allow-popups`, `allow-modals`,
    `allow-top-navigation`).
  - `iframeSrcOrigin`: resolves the origin for strict postMessage gating.
- **`components/SandboxedIframePanel.tsx`** — renders the sandboxed iframe and
  runs the bootstrap handshake: on `gptme:ready` from the declared origin it
  replies with `gptme:bootstrap` carrying `conversation_id` + descriptor
  bootstrap fields. Supports `resize: "auto"`, ignores foreign-origin and
  unrecognised messages, and renders a blocked placeholder for disallowed
  sources.

## Tests

18 unit tests (`iframePanelPolicy.test.ts`, `SandboxedIframePanel.test.tsx`):
allowlist accept/reject, sandbox token filtering, the bootstrap handshake,
descriptor bootstrap merge, foreign-origin rejection, unknown-message
tolerance, and the blocked placeholder.

```
Test Suites: 2 passed, 2 total
Tests:       18 passed, 18 total
```

Typecheck clean (`tsc -p tsconfig.app.json --noEmit`); eslint 0 errors.

## Scope / follow-up

This PR is the **frontend primitive only**. Server-side `panel_hints` metadata
parsing and merging into the conversation panel registry is a follow-up
(Phase 3b), as is wiring iframe panels into the sidebar tab list.

Design doc: `webui-artifact-surface-and-plugin-panel-registry` (Phase 3 section).
Refs ErikBjare/bob#830.