### PR TITLE
feat(webui): wire panel_hints into sidebar as iframe panels (#830 Phase 3b)

### DIFF
--- a/gptme/server/app.py
+++ b/gptme/server/app.py
@@ -86,6 +86,7 @@ def create_app(
     from .api_v2 import v2_api  # fmt: skip
     from .artifacts_api import artifacts_api  # fmt: skip
     from .auth import auth_api  # fmt: skip
+    from .panels_api import panels_api  # fmt: skip
     from .tasks_api import tasks_api  # fmt: skip
     from .workspace_api import workspace_api  # fmt: skip
 
@@ -94,6 +95,7 @@ def create_app(
     app.register_blueprint(workspace_api)
     app.register_blueprint(tasks_api)
     app.register_blueprint(artifacts_api)
+    app.register_blueprint(panels_api)
 
     # Register OpenAPI documentation
     from .openapi_docs import docs_api  # fmt: skip

--- a/gptme/server/panels_api.py
+++ b/gptme/server/panels_api.py
@@ -90,6 +90,10 @@ class IframePanelOut(BaseModel):
     message_index: int | None = Field(
         None, description="Index of the first message that declared this panel"
     )
+    warnings: list[str] = Field(
+        default_factory=list,
+        description="Validation warnings about opaque-origin sandbox limitations",
+    )
 
 
 class PanelListResponse(BaseModel):
@@ -140,16 +144,37 @@ def panels_from_messages(manager: LogManager) -> list[IframePanelOut]:
             if not isinstance(bootstrap, dict):
                 bootstrap = None
 
+            # Phase 3c: warn about server-relative src with allow-scripts
+            # producing an opaque sandbox origin ("null") that breaks the
+            # postMessage bootstrap handshake.
+            warnings: list[str] = []
+            stripped_src = str(src).strip()
+            if stripped_src.startswith("/") and "allow-scripts" in sandbox:
+                warnings.append(
+                    "Server-relative src with 'allow-scripts' sandbox has opaque origin; "
+                    "postMessage bootstrap handshake will not work. "
+                    "Use a localhost absolute URL for full functionality."
+                )
+
+            # Security: never forward the `allow` (Permissions-Policy) attribute.
+            # The sandbox is the primary security boundary; `allow` can grant
+            # hardware permissions (camera, microphone, geolocation) that
+            # bypass the sandbox. Tools that need capabilities should use the
+            # postMessage bootstrap protocol instead.
+            if isinstance(hint.get("allow"), str):
+                warnings.append(
+                    "The 'allow' attribute is not forwarded for security. "
+                    "Use the postMessage bootstrap handshake for controlled capabilities."
+                )
+
             out.append(
                 IframePanelOut(
                     id=panel_id,
                     kind="iframe",
                     title=str(title),
-                    src=str(src).strip(),
+                    src=stripped_src,
                     sandbox=sandbox,
-                    allow=hint.get("allow")
-                    if isinstance(hint.get("allow"), str)
-                    else None,
+                    allow=None,
                     resize=hint.get("resize")
                     if hint.get("resize") in ("auto", "fixed")
                     else None,
@@ -158,6 +183,7 @@ def panels_from_messages(manager: LogManager) -> list[IframePanelOut]:
                     if isinstance(hint.get("icon"), str)
                     else None,
                     message_index=idx,
+                    warnings=warnings,
                 )
             )
 

--- a/gptme/server/panels_api.py
+++ b/gptme/server/panels_api.py
@@ -1,0 +1,198 @@
+"""
+Panel registry API endpoints for conversation-scoped iframe panels.
+
+Phase 3b of the webui artifact surface (#830): parse ``panel_hints`` from
+message metadata and expose them as a typed per-conversation panel registry.
+Tools declare iframe panels at runtime; the server validates src and sandbox
+tokens and the webui renders each via ``SandboxedIframePanel``.
+"""
+
+import logging
+from typing import Any
+from urllib.parse import urlparse
+
+import flask
+from pydantic import BaseModel, Field
+
+from ..logmanager import LogManager
+from .api_v2_common import _validate_conversation_id
+from .auth import require_auth
+from .openapi_docs import ErrorResponse, api_doc_simple
+
+logger = logging.getLogger(__name__)
+
+panels_api = flask.Blueprint("panels_api", __name__)
+
+# Sandbox tokens a descriptor may request — mirrors iframePanelPolicy.ts.
+_SANDBOX_ALLOWLIST: frozenset[str] = frozenset(
+    {"allow-scripts", "allow-same-origin", "allow-forms", "allow-downloads"}
+)
+
+
+def _is_allowed_src(src: object) -> bool:
+    """Mirror the TypeScript ``isAllowedIframeSrc`` allowlist on the server.
+
+    Accepts localhost origins (any scheme/port) and server-relative paths
+    (single leading slash, not ``//``). Everything else is rejected.
+    """
+    if not isinstance(src, str) or not src.strip():
+        return False
+    value = src.strip()
+    # Server-relative path: single leading slash, not protocol-relative.
+    if (
+        value.startswith("/")
+        and not value.startswith("//")
+        and not value.startswith("/\\")
+    ):
+        return True
+    try:
+        url = urlparse(value)
+        host = (url.hostname or "").lower()
+        return host in ("localhost", "127.0.0.1", "[::1]", "::1")
+    except Exception:
+        return False
+
+
+def _resolve_sandbox(raw: object) -> list[str]:
+    """Filter sandbox tokens to the allowlist and drop the dangerous combination.
+
+    When both ``allow-scripts`` and ``allow-same-origin`` are requested for a
+    same-origin src, the iframe can remove its own sandbox attribute.
+    ``allow-same-origin`` is unconditionally dropped in that case so scripts
+    still run but cannot escalate.
+    """
+    if not isinstance(raw, list):
+        return []
+    allowed = [t for t in raw if isinstance(t, str) and t in _SANDBOX_ALLOWLIST]
+    deduped = list(dict.fromkeys(allowed))
+    if "allow-scripts" in deduped and "allow-same-origin" in deduped:
+        deduped.remove("allow-same-origin")
+    return deduped
+
+
+class IframePanelOut(BaseModel):
+    """A validated iframe panel descriptor ready for the webui to render."""
+
+    id: str = Field(..., description="Unique panel id within the conversation")
+    kind: str = Field("iframe", description="Discriminator; always 'iframe' for now")
+    title: str = Field(..., description="Tab label shown in the sidebar")
+    src: str = Field(..., description="Validated iframe src URL")
+    sandbox: list[str] = Field(
+        default_factory=list,
+        description="Filtered sandbox tokens (dangerous combinations removed)",
+    )
+    allow: str | None = Field(None, description="Feature-Policy string for the iframe")
+    resize: str | None = Field(None, description="'auto' or 'fixed' height mode")
+    bootstrap: dict[str, Any] | None = Field(
+        None, description="Opaque JSON forwarded to the iframe on bootstrap"
+    )
+    icon: str | None = Field(None, description="Lucide icon name hint for the tab")
+    message_index: int | None = Field(
+        None, description="Index of the first message that declared this panel"
+    )
+
+
+class PanelListResponse(BaseModel):
+    """Response containing the conversation's declared iframe panels."""
+
+    panels: list[IframePanelOut] = Field(..., description="Validated panel descriptors")
+
+
+def panels_from_messages(manager: LogManager) -> list[IframePanelOut]:
+    """Collect iframe panel hints from ``metadata.panel_hints`` in each message.
+
+    Later declarations with a duplicate ``id`` are dropped — the first
+    declaration wins. The src and sandbox tokens are validated server-side
+    before the descriptor reaches the webui.
+    """
+    seen_ids: set[str] = set()
+    out: list[IframePanelOut] = []
+
+    for idx, msg in enumerate(manager.log):
+        meta: Any = msg.metadata or {}
+        hints = meta.get("panel_hints")
+        if not isinstance(hints, list):
+            continue
+
+        for hint in hints:
+            if not isinstance(hint, dict):
+                continue
+            if hint.get("kind") != "iframe":
+                continue
+
+            panel_id = hint.get("id")
+            if not isinstance(panel_id, str) or not panel_id:
+                continue
+            if panel_id in seen_ids:
+                continue
+
+            src = hint.get("src", "")
+            if not _is_allowed_src(src):
+                logger.debug("Panel %s rejected: src not allowed: %s", panel_id, src)
+                continue
+
+            seen_ids.add(panel_id)
+
+            title = hint.get("title") or panel_id
+            sandbox = _resolve_sandbox(hint.get("sandbox"))
+
+            bootstrap = hint.get("bootstrap")
+            if not isinstance(bootstrap, dict):
+                bootstrap = None
+
+            out.append(
+                IframePanelOut(
+                    id=panel_id,
+                    kind="iframe",
+                    title=str(title),
+                    src=str(src).strip(),
+                    sandbox=sandbox,
+                    allow=hint.get("allow")
+                    if isinstance(hint.get("allow"), str)
+                    else None,
+                    resize=hint.get("resize")
+                    if hint.get("resize") in ("auto", "fixed")
+                    else None,
+                    bootstrap=bootstrap,
+                    icon=hint.get("icon")
+                    if isinstance(hint.get("icon"), str)
+                    else None,
+                    message_index=idx,
+                )
+            )
+
+    return out
+
+
+@panels_api.route("/api/v2/conversations/<string:conversation_id>/panels")
+@require_auth
+@api_doc_simple(
+    responses={
+        200: PanelListResponse,
+        404: ErrorResponse,
+        500: ErrorResponse,
+    },
+    tags=["panels"],
+)
+def list_panels(conversation_id: str):
+    """List iframe panels declared by tools in message metadata.
+
+    Tools emit ``panel_hints`` in their message metadata. The server validates
+    each descriptor's src against the localhost/server-relative allowlist,
+    filters the sandbox tokens, and drops the dangerous
+    ``allow-scripts + allow-same-origin`` combination. The webui renders each
+    validated panel as a ``SandboxedIframePanel`` tab in the right sidebar.
+    """
+    if error := _validate_conversation_id(conversation_id):
+        return error
+    try:
+        try:
+            manager = LogManager.load(conversation_id, lock=False)
+        except FileNotFoundError:
+            return flask.jsonify({"error": "Conversation not found"}), 404
+
+        panels = panels_from_messages(manager)
+        return flask.jsonify({"panels": [p.model_dump() for p in panels]})
+    except Exception as e:
+        logger.exception("Error listing panels for %s", conversation_id)
+        return flask.jsonify({"error": str(e)}), 500

--- a/tests/test_server_panels.py
+++ b/tests/test_server_panels.py
@@ -260,6 +260,122 @@ class TestPanelsFromMessages:
         panels = panels_from_messages(manager)
         assert panels[0].bootstrap == {"token": "abc123"}
 
+    def test_opaque_origin_warning_on_server_relative_with_scripts(self):
+        """Server-relative src + allow-scripts sandbox emits a warning."""
+        manager = _make_manager(
+            [
+                {
+                    "metadata": {
+                        "panel_hints": [
+                            {
+                                "id": "p",
+                                "kind": "iframe",
+                                "title": "P",
+                                "src": "/p/",
+                                "sandbox": ["allow-scripts"],
+                            }
+                        ]
+                    }
+                }
+            ]
+        )
+        panels = panels_from_messages(manager)
+        assert len(panels) == 1
+        assert len(panels[0].warnings) == 1
+        assert "opaque origin" in panels[0].warnings[0]
+
+    def test_no_warning_for_localhost_absolute_src(self):
+        """localhost absolute URL with allow-scripts gets no warning."""
+        manager = _make_manager(
+            [
+                {
+                    "metadata": {
+                        "panel_hints": [
+                            {
+                                "id": "p",
+                                "kind": "iframe",
+                                "title": "P",
+                                "src": "http://localhost:8080/p/",
+                                "sandbox": ["allow-scripts"],
+                            }
+                        ]
+                    }
+                }
+            ]
+        )
+        panels = panels_from_messages(manager)
+        assert panels[0].warnings == []
+
+    def test_no_warning_for_server_relative_without_scripts(self):
+        """Server-relative src without allow-scripts gets no warning."""
+        manager = _make_manager(
+            [
+                {
+                    "metadata": {
+                        "panel_hints": [
+                            {
+                                "id": "p",
+                                "kind": "iframe",
+                                "title": "P",
+                                "src": "/p/",
+                                "sandbox": ["allow-forms"],
+                            }
+                        ]
+                    }
+                }
+            ]
+        )
+        panels = panels_from_messages(manager)
+        assert panels[0].warnings == []
+
+    def test_allow_attribute_stripped_with_warning(self):
+        """The `allow` (Permissions-Policy) attribute is never forwarded; a warning is emitted."""
+        manager = _make_manager(
+            [
+                {
+                    "metadata": {
+                        "panel_hints": [
+                            {
+                                "id": "p",
+                                "kind": "iframe",
+                                "title": "P",
+                                "src": "/p/",
+                                "sandbox": [],
+                                "allow": "camera; microphone; geolocation",
+                            }
+                        ]
+                    }
+                }
+            ]
+        )
+        panels = panels_from_messages(manager)
+        assert len(panels) == 1
+        assert panels[0].allow is None
+        assert any("allow" in w.lower() for w in panels[0].warnings)
+
+    def test_allow_none_is_fine(self):
+        """No `allow` key in the hint is fine — no warning emitted."""
+        manager = _make_manager(
+            [
+                {
+                    "metadata": {
+                        "panel_hints": [
+                            {
+                                "id": "p",
+                                "kind": "iframe",
+                                "title": "P",
+                                "src": "/p/",
+                                "sandbox": [],
+                            }
+                        ]
+                    }
+                }
+            ]
+        )
+        panels = panels_from_messages(manager)
+        assert panels[0].allow is None
+        assert panels[0].warnings == []
+
     def test_missing_id_skipped(self):
         manager = _make_manager(
             [

--- a/tests/test_server_panels.py
+++ b/tests/test_server_panels.py
@@ -1,0 +1,336 @@
+"""Tests for the panel registry API endpoints (ErikBjare/bob#830 Phase 3b).
+
+Covers:
+- src allowlist validation (_is_allowed_src)
+- sandbox token filtering and dangerous-combination removal (_resolve_sandbox)
+- panel hint parsing from message metadata (panels_from_messages)
+- list endpoint, including empty-response and error handling
+"""
+
+from typing import Any
+from unittest import mock
+from uuid import uuid4
+
+import pytest
+
+pytest.importorskip(
+    "flask", reason="flask not installed, install server extras (-E server)"
+)
+
+from gptme.server.panels_api import (  # fmt: skip
+    _is_allowed_src,
+    _resolve_sandbox,
+    panels_from_messages,
+)
+
+pytestmark = [pytest.mark.timeout(10)]
+
+
+# ============================================================
+# Unit tests — src allowlist
+# ============================================================
+
+
+class TestIsAllowedSrc:
+    @pytest.mark.parametrize(
+        "src",
+        [
+            "/demos/my-panel/",
+            "/panel.html",
+            "http://localhost:8080/ui",
+            "http://127.0.0.1:3000/",
+            "http://[::1]/panel",
+        ],
+    )
+    def test_allowed(self, src: str):
+        assert _is_allowed_src(src)
+
+    @pytest.mark.parametrize(
+        "src",
+        [
+            "https://evil.example.com/xss",
+            "//evil.example.com/xss",
+            "/\\evil",
+            "",
+            "   ",
+            123,
+            None,
+        ],
+    )
+    def test_rejected(self, src: Any):
+        assert not _is_allowed_src(src)
+
+
+# ============================================================
+# Unit tests — sandbox token filtering
+# ============================================================
+
+
+class TestResolveSandbox:
+    def test_filters_unknown_tokens(self):
+        result = _resolve_sandbox(["allow-scripts", "allow-popups", "allow-modals"])
+        assert result == ["allow-scripts"]
+
+    def test_drops_same_origin_when_scripts_present(self):
+        result = _resolve_sandbox(["allow-scripts", "allow-same-origin"])
+        assert "allow-same-origin" not in result
+        assert "allow-scripts" in result
+
+    def test_keeps_same_origin_without_scripts(self):
+        result = _resolve_sandbox(["allow-same-origin", "allow-forms"])
+        assert "allow-same-origin" in result
+
+    def test_deduplicates(self):
+        result = _resolve_sandbox(["allow-scripts", "allow-scripts", "allow-forms"])
+        assert result.count("allow-scripts") == 1
+
+    def test_non_list_returns_empty(self):
+        assert _resolve_sandbox(None) == []
+        assert _resolve_sandbox("allow-scripts") == []
+
+
+# ============================================================
+# Integration tests — panels_from_messages
+# ============================================================
+
+
+def _make_manager(messages: list[dict]) -> Any:
+    """Build a minimal mock LogManager with the given messages."""
+    log_entries = []
+    for m in messages:
+        msg = mock.MagicMock()
+        msg.metadata = m.get("metadata")
+        log_entries.append(msg)
+    manager = mock.MagicMock()
+    manager.log = log_entries
+    return manager
+
+
+class TestPanelsFromMessages:
+    def test_empty_log_returns_empty(self):
+        manager = _make_manager([])
+        assert panels_from_messages(manager) == []
+
+    def test_no_panel_hints_key(self):
+        manager = _make_manager([{"metadata": {"artifacts": []}}])
+        assert panels_from_messages(manager) == []
+
+    def test_valid_panel_hint(self):
+        manager = _make_manager(
+            [
+                {
+                    "metadata": {
+                        "panel_hints": [
+                            {
+                                "id": "my-panel",
+                                "kind": "iframe",
+                                "title": "My Panel",
+                                "src": "/demos/my-panel/",
+                                "sandbox": ["allow-scripts"],
+                            }
+                        ]
+                    }
+                }
+            ]
+        )
+        panels = panels_from_messages(manager)
+        assert len(panels) == 1
+        assert panels[0].id == "my-panel"
+        assert panels[0].title == "My Panel"
+        assert panels[0].src == "/demos/my-panel/"
+        assert panels[0].sandbox == ["allow-scripts"]
+        assert panels[0].message_index == 0
+
+    def test_disallowed_src_is_dropped(self):
+        manager = _make_manager(
+            [
+                {
+                    "metadata": {
+                        "panel_hints": [
+                            {
+                                "id": "evil",
+                                "kind": "iframe",
+                                "title": "Evil",
+                                "src": "https://evil.example.com",
+                                "sandbox": [],
+                            }
+                        ]
+                    }
+                }
+            ]
+        )
+        assert panels_from_messages(manager) == []
+
+    def test_duplicate_id_first_wins(self):
+        manager = _make_manager(
+            [
+                {
+                    "metadata": {
+                        "panel_hints": [
+                            {
+                                "id": "panel-1",
+                                "kind": "iframe",
+                                "title": "First",
+                                "src": "/first/",
+                                "sandbox": [],
+                            }
+                        ]
+                    }
+                },
+                {
+                    "metadata": {
+                        "panel_hints": [
+                            {
+                                "id": "panel-1",
+                                "kind": "iframe",
+                                "title": "Second",
+                                "src": "/second/",
+                                "sandbox": [],
+                            }
+                        ]
+                    }
+                },
+            ]
+        )
+        panels = panels_from_messages(manager)
+        assert len(panels) == 1
+        assert panels[0].title == "First"
+
+    def test_non_iframe_kind_skipped(self):
+        manager = _make_manager(
+            [
+                {
+                    "metadata": {
+                        "panel_hints": [
+                            {
+                                "id": "webrtc-panel",
+                                "kind": "webrtc",
+                                "title": "Video",
+                                "src": "/video/",
+                                "sandbox": [],
+                            }
+                        ]
+                    }
+                }
+            ]
+        )
+        assert panels_from_messages(manager) == []
+
+    def test_sandbox_dangerous_combo_stripped(self):
+        manager = _make_manager(
+            [
+                {
+                    "metadata": {
+                        "panel_hints": [
+                            {
+                                "id": "p",
+                                "kind": "iframe",
+                                "title": "P",
+                                "src": "/p/",
+                                "sandbox": ["allow-scripts", "allow-same-origin"],
+                            }
+                        ]
+                    }
+                }
+            ]
+        )
+        panels = panels_from_messages(manager)
+        assert "allow-same-origin" not in panels[0].sandbox
+        assert "allow-scripts" in panels[0].sandbox
+
+    def test_bootstrap_forwarded(self):
+        manager = _make_manager(
+            [
+                {
+                    "metadata": {
+                        "panel_hints": [
+                            {
+                                "id": "p",
+                                "kind": "iframe",
+                                "title": "P",
+                                "src": "/p/",
+                                "sandbox": [],
+                                "bootstrap": {"token": "abc123"},
+                            }
+                        ]
+                    }
+                }
+            ]
+        )
+        panels = panels_from_messages(manager)
+        assert panels[0].bootstrap == {"token": "abc123"}
+
+    def test_missing_id_skipped(self):
+        manager = _make_manager(
+            [
+                {
+                    "metadata": {
+                        "panel_hints": [
+                            {
+                                "kind": "iframe",
+                                "title": "No ID",
+                                "src": "/p/",
+                                "sandbox": [],
+                            }
+                        ]
+                    }
+                }
+            ]
+        )
+        assert panels_from_messages(manager) == []
+
+
+# ============================================================
+# Integration tests — Flask endpoint
+# ============================================================
+
+
+@pytest.fixture()
+def app():
+    pytest.importorskip("flask")
+    from gptme.server.app import create_app
+
+    application = create_app()
+    application.config["TESTING"] = True
+    return application
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture()
+def conversation_id():
+    return f"test-{uuid4().hex[:8]}"
+
+
+class TestListPanelsEndpoint:
+    def test_unknown_conversation_returns_404(self, client):
+        resp = client.get(
+            "/api/v2/conversations/nonexistent-conv-xyz/panels",
+            headers={"Authorization": "Bearer test"},
+        )
+        assert resp.status_code == 404
+
+    def test_empty_panels(self, client, tmp_path, conversation_id, monkeypatch):
+        from gptme.logmanager import LogManager
+
+        log_dir = tmp_path / conversation_id
+        log_dir.mkdir()
+        (log_dir / "conversation.jsonl").write_text("")
+
+        def _fake_load(conv_id, lock=True):
+            manager = mock.MagicMock()
+            manager.log = []
+            manager.logdir = log_dir
+            return manager
+
+        monkeypatch.setattr(LogManager, "load", staticmethod(_fake_load))
+        resp = client.get(
+            f"/api/v2/conversations/{conversation_id}/panels",
+            headers={"Authorization": "Bearer test"},
+        )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data == {"panels": []}

--- a/webui/src/components/PanelsPanel.tsx
+++ b/webui/src/components/PanelsPanel.tsx
@@ -1,0 +1,145 @@
+/**
+ * Right-sidebar panel that lists and renders iframe panels declared by tools
+ * in message metadata (``panel_hints``). Each entry is rendered as a full-height
+ * ``SandboxedIframePanel`` tab when selected.
+ *
+ * Phase 3b of the webui artifact surface (#830).
+ */
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { FC } from 'react';
+import { LayoutDashboard, Loader2, RefreshCw } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { SandboxedIframePanel } from '@/components/SandboxedIframePanel';
+import type { IframePanelEntry } from '@/types/panels';
+import type { IframePanelDescriptor } from '@/types/panel';
+import { usePanelsApi } from '@/utils/panelsApi';
+
+interface PanelsPanelProps {
+  conversationId: string;
+}
+
+function toDescriptor(entry: IframePanelEntry): IframePanelDescriptor {
+  return {
+    id: entry.id,
+    kind: 'iframe',
+    title: entry.title,
+    src: entry.src,
+    sandbox: entry.sandbox,
+    allow: entry.allow ?? undefined,
+    resize: entry.resize ?? undefined,
+    bootstrap: entry.bootstrap ?? undefined,
+    icon: entry.icon ?? undefined,
+  };
+}
+
+export const PanelsPanel: FC<PanelsPanelProps> = ({ conversationId }) => {
+  const [panels, setPanels] = useState<IframePanelEntry[]>([]);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const { listPanels } = usePanelsApi();
+  const controllerRef = useRef<AbortController | null>(null);
+
+  const load = useCallback(
+    async (signal?: AbortSignal) => {
+      setLoading(true);
+      setError(null);
+      try {
+        const data = await listPanels(conversationId, signal);
+        if (!signal?.aborted) {
+          setPanels(data);
+          setLoading(false);
+        }
+      } catch (err) {
+        if (err instanceof DOMException && err.name === 'AbortError') return;
+        setError(err instanceof Error ? err.message : 'Failed to load panels');
+        setLoading(false);
+      }
+    },
+    [conversationId, listPanels]
+  );
+
+  useEffect(() => {
+    const ctrl = new AbortController();
+    controllerRef.current = ctrl;
+    load(ctrl.signal);
+    return () => ctrl.abort();
+  }, [load]);
+
+  const handleRefresh = useCallback(() => {
+    controllerRef.current?.abort();
+    const ctrl = new AbortController();
+    controllerRef.current = ctrl;
+    load(ctrl.signal);
+  }, [load]);
+
+  const selected = panels.find((p) => p.id === selectedId) ?? panels[0] ?? null;
+
+  if (loading) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-2 p-4 text-center">
+        <p className="text-sm text-destructive">{error}</p>
+        <Button variant="outline" size="sm" onClick={handleRefresh}>
+          <RefreshCw className="mr-2 h-4 w-4" />
+          Retry
+        </Button>
+      </div>
+    );
+  }
+
+  if (panels.length === 0) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-2 p-6 text-center text-sm text-muted-foreground">
+        <LayoutDashboard className="h-8 w-8 opacity-40" />
+        <p className="font-medium text-foreground">No panels</p>
+        <p>
+          Tools can declare iframe panels via{' '}
+          <code className="rounded bg-muted px-1">panel_hints</code> in message metadata.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full flex-col">
+      {/* Tab row — only shown when more than one panel is declared */}
+      {panels.length > 1 && (
+        <div className="flex shrink-0 gap-1 border-b px-2 py-1">
+          {panels.map((p) => (
+            <button
+              key={p.id}
+              type="button"
+              onClick={() => setSelectedId(p.id)}
+              className={`rounded px-2 py-1 text-xs font-medium transition-colors ${
+                selected?.id === p.id
+                  ? 'bg-accent text-accent-foreground'
+                  : 'text-muted-foreground hover:bg-accent/50 hover:text-foreground'
+              }`}
+            >
+              {p.title}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* Iframe content */}
+      <div className="min-h-0 flex-1">
+        {selected && (
+          <SandboxedIframePanel
+            descriptor={toDescriptor(selected)}
+            conversationId={conversationId}
+          />
+        )}
+      </div>
+    </div>
+  );
+};

--- a/webui/src/components/SandboxedIframePanel.tsx
+++ b/webui/src/components/SandboxedIframePanel.tsx
@@ -38,7 +38,8 @@ export const SandboxedIframePanel: FC<Props> = ({ descriptor, conversationId }) 
 
     const handleMessage = (event: MessageEvent) => {
       // Strict origin gate: only accept messages from the declared src origin.
-      if (expectedOrigin && event.origin !== expectedOrigin) return;
+      // Fail closed: if expectedOrigin is null (origin unresolvable), reject all.
+      if (!expectedOrigin || event.origin !== expectedOrigin) return;
       if (event.source !== iframeRef.current?.contentWindow) return;
       if (!isGptmeIframeMessage(event.data)) return;
 
@@ -46,14 +47,17 @@ export const SandboxedIframePanel: FC<Props> = ({ descriptor, conversationId }) 
         case 'gptme:ready':
           post({
             type: 'gptme:bootstrap',
-            payload: { conversation_id: conversationId, ...(descriptor.bootstrap ?? {}) },
+            // Spread descriptor.bootstrap first so the prop-supplied
+            // conversationId always wins over any key in the bootstrap blob.
+            payload: { ...(descriptor.bootstrap ?? {}), conversation_id: conversationId },
           });
           break;
         case 'gptme:resize': {
           if (descriptor.resize !== 'auto') break;
           const height = (event.data.payload as { height?: unknown } | undefined)?.height;
+          const MAX_IFRAME_HEIGHT = 16_000;
           if (typeof height === 'number' && Number.isFinite(height) && height > 0) {
-            setAutoHeight(height);
+            setAutoHeight(Math.min(height, MAX_IFRAME_HEIGHT));
           }
           break;
         }

--- a/webui/src/components/SandboxedIframePanel.tsx
+++ b/webui/src/components/SandboxedIframePanel.tsx
@@ -1,0 +1,99 @@
+/**
+ * Renders a plugin-owned iframe panel under the strict #830 Phase 3 contract:
+ * src is validated against the allowlist, the sandbox attribute is filtered to
+ * the permitted token set, and all host <-> iframe traffic flows through the
+ * origin-gated postMessage protocol.
+ *
+ * Bootstrap flow:
+ *   1. Render <iframe sandbox=... src=...> but hold the bootstrap payload.
+ *   2. Iframe loads and posts `gptme:ready`.
+ *   3. Host validates the origin and replies with `gptme:bootstrap`.
+ */
+import { useEffect, useRef, useState } from 'react';
+import type { FC } from 'react';
+import type { GptmeIframeMessage, IframePanelDescriptor } from '@/types/panel';
+import { isGptmeIframeMessage } from '@/types/panel';
+import { iframeSrcOrigin, isAllowedIframeSrc, resolveSandbox } from '@/utils/iframePanelPolicy';
+
+interface Props {
+  descriptor: IframePanelDescriptor;
+  conversationId: string;
+}
+
+export const SandboxedIframePanel: FC<Props> = ({ descriptor, conversationId }) => {
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  const [autoHeight, setAutoHeight] = useState<number | null>(null);
+
+  const allowed = isAllowedIframeSrc(descriptor.src);
+  const expectedOrigin = allowed ? iframeSrcOrigin(descriptor.src) : null;
+
+  useEffect(() => {
+    if (!allowed) return;
+
+    const post = (message: GptmeIframeMessage) => {
+      const target = iframeRef.current?.contentWindow;
+      if (!target || !expectedOrigin) return;
+      target.postMessage(message, expectedOrigin);
+    };
+
+    const handleMessage = (event: MessageEvent) => {
+      // Strict origin gate: only accept messages from the declared src origin.
+      if (expectedOrigin && event.origin !== expectedOrigin) return;
+      if (event.source !== iframeRef.current?.contentWindow) return;
+      if (!isGptmeIframeMessage(event.data)) return;
+
+      switch (event.data.type) {
+        case 'gptme:ready':
+          post({
+            type: 'gptme:bootstrap',
+            payload: { conversation_id: conversationId, ...(descriptor.bootstrap ?? {}) },
+          });
+          break;
+        case 'gptme:resize': {
+          if (descriptor.resize !== 'auto') break;
+          const height = (event.data.payload as { height?: unknown } | undefined)?.height;
+          if (typeof height === 'number' && Number.isFinite(height) && height > 0) {
+            setAutoHeight(height);
+          }
+          break;
+        }
+        // Unrecognised gptme:* messages are silently ignored for forward compat.
+        default:
+          break;
+      }
+    };
+
+    window.addEventListener('message', handleMessage);
+    return () => window.removeEventListener('message', handleMessage);
+  }, [allowed, expectedOrigin, conversationId, descriptor.bootstrap, descriptor.resize]);
+
+  if (!allowed) {
+    return (
+      <div
+        role="alert"
+        className="flex h-full flex-col items-center justify-center gap-2 p-6 text-center text-sm text-muted-foreground"
+      >
+        <p className="font-medium text-foreground">Panel blocked</p>
+        <p>
+          The panel source <code className="rounded bg-muted px-1">{descriptor.src}</code> is not an
+          allowed iframe origin. Only localhost tool servers and server-relative paths are
+          permitted.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <iframe
+      ref={iframeRef}
+      src={descriptor.src}
+      title={descriptor.title}
+      sandbox={resolveSandbox(descriptor.sandbox)}
+      allow={descriptor.allow ?? ''}
+      className="w-full rounded-md border-0"
+      style={
+        descriptor.resize === 'auto' && autoHeight ? { height: autoHeight } : { height: '100%' }
+      }
+    />
+  );
+};

--- a/webui/src/components/__tests__/SandboxedIframePanel.test.tsx
+++ b/webui/src/components/__tests__/SandboxedIframePanel.test.tsx
@@ -1,0 +1,113 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { SandboxedIframePanel } from '../SandboxedIframePanel';
+import type { IframePanelDescriptor, IframeSandboxToken } from '@/types/panel';
+
+const baseDescriptor: IframePanelDescriptor = {
+  id: 'webapp-preview',
+  kind: 'iframe',
+  title: 'Webapp Preview',
+  src: 'http://localhost:8080',
+  sandbox: ['allow-scripts'],
+};
+
+function getIframe(): HTMLIFrameElement {
+  const frame = screen.getByTitle('Webapp Preview');
+  return frame as HTMLIFrameElement;
+}
+
+function emitFromIframe(frame: HTMLIFrameElement, origin: string, data: unknown) {
+  window.dispatchEvent(new MessageEvent('message', { data, origin, source: frame.contentWindow }));
+}
+
+describe('SandboxedIframePanel', () => {
+  it('renders a sandboxed iframe with the filtered sandbox attribute', () => {
+    render(
+      <SandboxedIframePanel
+        descriptor={{
+          ...baseDescriptor,
+          // 'allow-popups' is never permitted; cast simulates a tool requesting it.
+          sandbox: ['allow-scripts', 'allow-popups' as IframeSandboxToken],
+        }}
+        conversationId="conv1"
+      />
+    );
+    const frame = getIframe();
+    expect(frame.getAttribute('src')).toBe('http://localhost:8080');
+    // allow-popups is never permitted and must be dropped.
+    expect(frame.getAttribute('sandbox')).toBe('allow-scripts');
+  });
+
+  it('sends gptme:bootstrap with the conversation id after gptme:ready', async () => {
+    render(<SandboxedIframePanel descriptor={baseDescriptor} conversationId="conv-abc" />);
+    const frame = getIframe();
+    const postMessage = jest.fn();
+    Object.defineProperty(frame, 'contentWindow', {
+      value: { postMessage },
+      configurable: true,
+    });
+
+    emitFromIframe(frame, 'http://localhost:8080', { type: 'gptme:ready' });
+
+    await waitFor(() => expect(postMessage).toHaveBeenCalledTimes(1));
+    expect(postMessage).toHaveBeenCalledWith(
+      { type: 'gptme:bootstrap', payload: { conversation_id: 'conv-abc' } },
+      'http://localhost:8080'
+    );
+  });
+
+  it('merges descriptor bootstrap fields into the bootstrap payload', async () => {
+    render(
+      <SandboxedIframePanel
+        descriptor={{ ...baseDescriptor, bootstrap: { artifact_id: 'art_01' } }}
+        conversationId="conv-abc"
+      />
+    );
+    const frame = getIframe();
+    const postMessage = jest.fn();
+    Object.defineProperty(frame, 'contentWindow', { value: { postMessage }, configurable: true });
+
+    emitFromIframe(frame, 'http://localhost:8080', { type: 'gptme:ready' });
+
+    await waitFor(() => expect(postMessage).toHaveBeenCalledTimes(1));
+    expect(postMessage).toHaveBeenCalledWith(
+      { type: 'gptme:bootstrap', payload: { conversation_id: 'conv-abc', artifact_id: 'art_01' } },
+      'http://localhost:8080'
+    );
+  });
+
+  it('ignores messages from a foreign origin', async () => {
+    render(<SandboxedIframePanel descriptor={baseDescriptor} conversationId="conv-abc" />);
+    const frame = getIframe();
+    const postMessage = jest.fn();
+    Object.defineProperty(frame, 'contentWindow', { value: { postMessage }, configurable: true });
+
+    emitFromIframe(frame, 'https://evil.example.com', { type: 'gptme:ready' });
+
+    await new Promise((r) => setTimeout(r, 10));
+    expect(postMessage).not.toHaveBeenCalled();
+  });
+
+  it('ignores unrecognised gptme message types', async () => {
+    render(<SandboxedIframePanel descriptor={baseDescriptor} conversationId="conv-abc" />);
+    const frame = getIframe();
+    const postMessage = jest.fn();
+    Object.defineProperty(frame, 'contentWindow', { value: { postMessage }, configurable: true });
+
+    emitFromIframe(frame, 'http://localhost:8080', { type: 'gptme:unknown' });
+
+    await new Promise((r) => setTimeout(r, 10));
+    expect(postMessage).not.toHaveBeenCalled();
+  });
+
+  it('renders a blocked placeholder for a disallowed src', () => {
+    render(
+      <SandboxedIframePanel
+        descriptor={{ ...baseDescriptor, src: 'https://evil.example.com' }}
+        conversationId="conv1"
+      />
+    );
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByText(/Panel blocked/)).toBeInTheDocument();
+    expect(screen.queryByTitle('Webapp Preview')).not.toBeInTheDocument();
+  });
+});

--- a/webui/src/components/__tests__/SandboxedIframePanel.test.tsx
+++ b/webui/src/components/__tests__/SandboxedIframePanel.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import { SandboxedIframePanel } from '../SandboxedIframePanel';
 import type { IframePanelDescriptor, IframeSandboxToken } from '@/types/panel';
 
@@ -97,6 +97,70 @@ describe('SandboxedIframePanel', () => {
 
     await new Promise((r) => setTimeout(r, 10));
     expect(postMessage).not.toHaveBeenCalled();
+  });
+
+  it('prop conversationId wins over a conversation_id key in the bootstrap blob', async () => {
+    render(
+      <SandboxedIframePanel
+        descriptor={{ ...baseDescriptor, bootstrap: { conversation_id: 'override-attempt' } }}
+        conversationId="real-conv-id"
+      />
+    );
+    const frame = getIframe();
+    const postMessage = jest.fn();
+    Object.defineProperty(frame, 'contentWindow', { value: { postMessage }, configurable: true });
+
+    emitFromIframe(frame, 'http://localhost:8080', { type: 'gptme:ready' });
+
+    await waitFor(() => expect(postMessage).toHaveBeenCalledTimes(1));
+    expect(postMessage).toHaveBeenCalledWith(
+      { type: 'gptme:bootstrap', payload: { conversation_id: 'real-conv-id' } },
+      'http://localhost:8080'
+    );
+  });
+
+  it('rejects postMessage when expectedOrigin cannot be resolved (fail-closed)', async () => {
+    // Simulate an iframe whose src produces a null origin by patching the policy.
+    // We do this indirectly: use a descriptor with an opaque-origin data: src that
+    // passes the allowlist check but returns null from iframeSrcOrigin. The
+    // simplest approach is to render with a server-relative src that resolves fine
+    // but then emit from 'null' (the serialised opaque origin browsers send for
+    // sandboxed iframes without allow-same-origin).
+    render(<SandboxedIframePanel descriptor={baseDescriptor} conversationId="conv-abc" />);
+    const frame = getIframe();
+    const postMessage = jest.fn();
+    Object.defineProperty(frame, 'contentWindow', { value: { postMessage }, configurable: true });
+
+    // 'null' is what browsers serialize as the origin for opaque origins.
+    emitFromIframe(frame, 'null', { type: 'gptme:ready' });
+
+    await new Promise((r) => setTimeout(r, 10));
+    expect(postMessage).not.toHaveBeenCalled();
+  });
+
+  it('caps resize height at 16 000 px', async () => {
+    render(
+      <SandboxedIframePanel
+        descriptor={{ ...baseDescriptor, resize: 'auto' }}
+        conversationId="conv-abc"
+      />
+    );
+    const frame = getIframe();
+    Object.defineProperty(frame, 'contentWindow', {
+      value: { postMessage: jest.fn() },
+      configurable: true,
+    });
+
+    await act(async () => {
+      emitFromIframe(frame, 'http://localhost:8080', {
+        type: 'gptme:resize',
+        payload: { height: 1e15 },
+      });
+    });
+
+    const style = frame.getAttribute('style') ?? '';
+    // height should be capped, not set to 1e15
+    expect(style).toMatch(/16000/);
   });
 
   it('renders a blocked placeholder for a disallowed src', () => {

--- a/webui/src/components/rightSidebarPanels.tsx
+++ b/webui/src/components/rightSidebarPanels.tsx
@@ -1,10 +1,18 @@
 import type { ReactNode } from 'react';
-import { Globe, FolderOpen, Monitor, Package, SlidersHorizontal } from 'lucide-react';
+import {
+  Globe,
+  FolderOpen,
+  LayoutDashboard,
+  Monitor,
+  Package,
+  SlidersHorizontal,
+} from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 import type { RightSidebarPanelId } from '@/types/sidebar';
 import { ArtifactsPanel } from './ArtifactsPanel';
 import { BrowserPreview } from './BrowserPreview';
 import { ConversationSettings } from './ConversationSettings';
+import { PanelsPanel } from './PanelsPanel';
 import { WorkspaceExplorer } from './workspace/WorkspaceExplorer';
 
 const VNC_URL = 'http://localhost:6080/vnc.html';
@@ -38,6 +46,12 @@ export const rightSidebarPanels: RightSidebarPanelDefinition[] = [
     label: 'Artifacts',
     icon: Package,
     render: ({ conversationId }) => <ArtifactsPanel conversationId={conversationId} />,
+  },
+  {
+    id: 'panels',
+    label: 'Panels',
+    icon: LayoutDashboard,
+    render: ({ conversationId }) => <PanelsPanel conversationId={conversationId} />,
   },
   {
     id: 'browser',

--- a/webui/src/types/panel.ts
+++ b/webui/src/types/panel.ts
@@ -1,0 +1,52 @@
+/**
+ * Typed iframe panel descriptors and the postMessage envelope for the
+ * constrained iframe extension surface (#830 Phase 3).
+ *
+ * Plugin-owned custom UI never runs inside the core webui bundle. Instead a
+ * tool declares an iframe panel descriptor and the UI runs in a sandboxed
+ * iframe at runtime, communicating with the host only through the typed
+ * postMessage protocol defined here.
+ */
+
+/** Sandbox tokens a descriptor is permitted to request. */
+export type IframeSandboxToken =
+  | 'allow-scripts'
+  | 'allow-same-origin'
+  | 'allow-forms'
+  | 'allow-downloads';
+
+export interface IframePanelDescriptor {
+  /** Unique panel id within the conversation. */
+  id: string;
+  /** Discriminator for the panel registry. */
+  kind: 'iframe';
+  /** Tab label in the sidebar. */
+  title: string;
+  /** Lucide icon name (default: "layout"). */
+  icon?: string;
+  /** URL loaded in the iframe. Validated against the src allowlist. */
+  src: string;
+  /** Subset of the sandbox token allowlist the tool requests. */
+  sandbox: IframeSandboxToken[];
+  /** Feature-Policy string (`""` = deny all). */
+  allow?: string;
+  /** Auto-resize from iframe height messages, or keep a fixed height. */
+  resize?: 'auto' | 'fixed';
+  /** Opaque JSON forwarded to the iframe in the bootstrap message. */
+  bootstrap?: Record<string, unknown>;
+}
+
+/** Typed envelope for all host <-> iframe postMessage traffic. */
+export interface GptmeIframeMessage {
+  type: `gptme:${string}`;
+  payload?: unknown;
+}
+
+export function isGptmeIframeMessage(value: unknown): value is GptmeIframeMessage {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as { type?: unknown }).type === 'string' &&
+    (value as { type: string }).type.startsWith('gptme:')
+  );
+}

--- a/webui/src/types/panels.ts
+++ b/webui/src/types/panels.ts
@@ -1,0 +1,26 @@
+/**
+ * Client-side types for the conversation panel registry (#830 Phase 3b).
+ *
+ * The server validates each descriptor's ``src`` and ``sandbox`` tokens before
+ * sending; the webui trusts these values and passes them straight to
+ * ``SandboxedIframePanel``.
+ */
+
+import type { IframeSandboxToken } from '@/types/panel';
+
+export interface IframePanelEntry {
+  id: string;
+  kind: 'iframe';
+  title: string;
+  src: string;
+  sandbox: IframeSandboxToken[];
+  allow?: string | null;
+  resize?: 'auto' | 'fixed' | null;
+  bootstrap?: Record<string, unknown> | null;
+  icon?: string | null;
+  message_index?: number | null;
+}
+
+export interface PanelListResponse {
+  panels: IframePanelEntry[];
+}

--- a/webui/src/types/sidebar.ts
+++ b/webui/src/types/sidebar.ts
@@ -1,1 +1,7 @@
-export type RightSidebarPanelId = 'settings' | 'workspace' | 'artifacts' | 'browser' | 'computer';
+export type RightSidebarPanelId =
+  | 'settings'
+  | 'workspace'
+  | 'artifacts'
+  | 'panels'
+  | 'browser'
+  | 'computer';

--- a/webui/src/utils/__tests__/iframePanelPolicy.test.ts
+++ b/webui/src/utils/__tests__/iframePanelPolicy.test.ts
@@ -55,9 +55,14 @@ describe('iframeSrcOrigin', () => {
 describe('resolveSandbox', () => {
   it('keeps allowlisted tokens', () => {
     expect(resolveSandbox(['allow-scripts'])).toBe('allow-scripts');
-    expect(resolveSandbox(['allow-scripts', 'allow-same-origin'])).toBe(
-      'allow-scripts allow-same-origin'
-    );
+    expect(resolveSandbox(['allow-same-origin'])).toBe('allow-same-origin');
+    expect(resolveSandbox(['allow-forms', 'allow-downloads'])).toBe('allow-forms allow-downloads');
+  });
+
+  it('drops allow-same-origin when allow-scripts is also present (sandbox escape guard)', () => {
+    // Both together let an iframe remove its own sandbox attribute.
+    expect(resolveSandbox(['allow-scripts', 'allow-same-origin'])).toBe('allow-scripts');
+    expect(resolveSandbox(['allow-same-origin', 'allow-scripts'])).toBe('allow-scripts');
   });
 
   it('drops never-allowed tokens', () => {

--- a/webui/src/utils/__tests__/iframePanelPolicy.test.ts
+++ b/webui/src/utils/__tests__/iframePanelPolicy.test.ts
@@ -1,0 +1,75 @@
+import { iframeSrcOrigin, isAllowedIframeSrc, resolveSandbox } from '../iframePanelPolicy';
+
+describe('isAllowedIframeSrc', () => {
+  it('allows localhost and 127.0.0.1 origins on any port', () => {
+    expect(isAllowedIframeSrc('http://localhost:8080')).toBe(true);
+    expect(isAllowedIframeSrc('http://localhost:6080/vnc.html')).toBe(true);
+    expect(isAllowedIframeSrc('https://127.0.0.1:3000/app')).toBe(true);
+    expect(isAllowedIframeSrc('http://[::1]:9000')).toBe(true);
+  });
+
+  it('allows server-relative paths', () => {
+    expect(isAllowedIframeSrc('/preview/app')).toBe(true);
+    expect(isAllowedIframeSrc('/api/v2/conversations/x/ui')).toBe(true);
+  });
+
+  it('rejects protocol-relative and backslash-prefixed values', () => {
+    expect(isAllowedIframeSrc('//evil.example.com')).toBe(false);
+    expect(isAllowedIframeSrc('/\\evil.example.com')).toBe(false);
+  });
+
+  it('rejects arbitrary external origins', () => {
+    expect(isAllowedIframeSrc('https://evil.example.com')).toBe(false);
+    expect(isAllowedIframeSrc('http://localhost.evil.com')).toBe(false);
+    expect(isAllowedIframeSrc('https://notlocalhost')).toBe(false);
+  });
+
+  it('rejects empty, whitespace, and malformed values', () => {
+    expect(isAllowedIframeSrc('')).toBe(false);
+    expect(isAllowedIframeSrc('   ')).toBe(false);
+    expect(isAllowedIframeSrc('not a url')).toBe(false);
+    // @ts-expect-error guarding non-string at runtime
+    expect(isAllowedIframeSrc(undefined)).toBe(false);
+  });
+});
+
+describe('iframeSrcOrigin', () => {
+  it('returns the origin for absolute localhost urls', () => {
+    expect(iframeSrcOrigin('http://localhost:8080/app')).toBe('http://localhost:8080');
+  });
+
+  it('resolves server-relative paths against the host origin', () => {
+    expect(iframeSrcOrigin('/preview', 'https://chat.gptme.org')).toBe('https://chat.gptme.org');
+  });
+
+  it('falls back to the window origin when no host origin is given', () => {
+    // jsdom provides window.location.origin === 'http://localhost'
+    expect(iframeSrcOrigin('/preview')).toBe('http://localhost');
+  });
+
+  it('returns null for malformed values', () => {
+    expect(iframeSrcOrigin('http://', 'http://localhost')).toBe(null);
+  });
+});
+
+describe('resolveSandbox', () => {
+  it('keeps allowlisted tokens', () => {
+    expect(resolveSandbox(['allow-scripts'])).toBe('allow-scripts');
+    expect(resolveSandbox(['allow-scripts', 'allow-same-origin'])).toBe(
+      'allow-scripts allow-same-origin'
+    );
+  });
+
+  it('drops never-allowed tokens', () => {
+    expect(resolveSandbox(['allow-scripts', 'allow-top-navigation', 'allow-popups'])).toBe(
+      'allow-scripts'
+    );
+    expect(resolveSandbox(['allow-modals'])).toBe('');
+  });
+
+  it('collapses duplicates and handles empty input', () => {
+    expect(resolveSandbox(['allow-scripts', 'allow-scripts'])).toBe('allow-scripts');
+    expect(resolveSandbox([])).toBe('');
+    expect(resolveSandbox(undefined)).toBe('');
+  });
+});

--- a/webui/src/utils/iframePanelPolicy.ts
+++ b/webui/src/utils/iframePanelPolicy.ts
@@ -1,0 +1,74 @@
+/**
+ * Source-URL allowlist and sandbox policy enforcement for iframe panels
+ * (#830 Phase 3). These rules are intentionally strict: the iframe escape
+ * hatch exists for local tool servers and controlled deployments, not for
+ * arbitrary third-party embeds.
+ */
+import type { IframeSandboxToken } from '@/types/panel';
+
+/** Sandbox tokens a descriptor may request. Anything else is dropped. */
+const SANDBOX_ALLOWLIST: ReadonlySet<string> = new Set<IframeSandboxToken>([
+  'allow-scripts',
+  'allow-same-origin',
+  'allow-forms',
+  'allow-downloads',
+]);
+
+/**
+ * Validate an iframe `src` before rendering. Accepted, in priority order:
+ *   1. localhost / 127.0.0.1 origins (any scheme/port)
+ *   2. server-relative paths (start with a single "/")
+ * Everything else is rejected.
+ *
+ * Protocol-relative ("//host") and backslash-prefixed values are treated as
+ * absolute and rejected unless they resolve to a localhost origin.
+ */
+export function isAllowedIframeSrc(src: string): boolean {
+  if (typeof src !== 'string' || src.trim() === '') return false;
+  const value = src.trim();
+
+  // Server-relative path: a single leading slash, not "//" (protocol-relative)
+  // and not a backslash variant.
+  if (value.startsWith('/') && !value.startsWith('//') && !value.startsWith('/\\')) {
+    return true;
+  }
+
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return false;
+  }
+
+  const host = url.hostname.toLowerCase();
+  return host === 'localhost' || host === '127.0.0.1' || host === '[::1]' || host === '::1';
+}
+
+/**
+ * Resolve the origin an iframe `src` will load from, for strict postMessage
+ * origin checks. Server-relative paths resolve against the host window origin.
+ * Returns null when the origin cannot be determined.
+ */
+export function iframeSrcOrigin(src: string, hostOrigin?: string): string | null {
+  const base = hostOrigin ?? (typeof window !== 'undefined' ? window.location.origin : undefined);
+  try {
+    return new URL(src, base).origin;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Filter requested sandbox tokens down to the allowlist and return the
+ * space-joined string for the iframe `sandbox` attribute. Unknown or
+ * never-allowed tokens (allow-top-navigation, allow-popups, allow-modals)
+ * are silently dropped. Duplicates are collapsed.
+ */
+export function resolveSandbox(tokens: readonly string[] | undefined): string {
+  if (!tokens || tokens.length === 0) return '';
+  const allowed = new Set<string>();
+  for (const token of tokens) {
+    if (SANDBOX_ALLOWLIST.has(token)) allowed.add(token);
+  }
+  return Array.from(allowed).join(' ');
+}

--- a/webui/src/utils/iframePanelPolicy.ts
+++ b/webui/src/utils/iframePanelPolicy.ts
@@ -63,12 +63,21 @@ export function iframeSrcOrigin(src: string, hostOrigin?: string): string | null
  * space-joined string for the iframe `sandbox` attribute. Unknown or
  * never-allowed tokens (allow-top-navigation, allow-popups, allow-modals)
  * are silently dropped. Duplicates are collapsed.
+ *
+ * The `allow-scripts` + `allow-same-origin` combination is unconditionally
+ * forbidden: together they allow the iframe to remove its own sandbox
+ * attribute and gain full access to the parent page's DOM. When both are
+ * requested, `allow-same-origin` is dropped so scripts still run but cannot
+ * escalate.
  */
 export function resolveSandbox(tokens: readonly string[] | undefined): string {
   if (!tokens || tokens.length === 0) return '';
   const allowed = new Set<string>();
   for (const token of tokens) {
     if (SANDBOX_ALLOWLIST.has(token)) allowed.add(token);
+  }
+  if (allowed.has('allow-scripts') && allowed.has('allow-same-origin')) {
+    allowed.delete('allow-same-origin');
   }
   return Array.from(allowed).join(' ');
 }

--- a/webui/src/utils/panelsApi.ts
+++ b/webui/src/utils/panelsApi.ts
@@ -11,11 +11,16 @@ export function usePanelsApi() {
       conversationId: string,
       signal?: AbortSignal
     ): Promise<IframePanelEntry[]> {
-      const baseUrl = withLocalAddressSpace(api.baseUrl);
+      const url = `${api.baseUrl}/api/v2/conversations/${encodeURIComponent(conversationId)}/panels`;
+
       const response = await fetch(
-        `${baseUrl}/api/v2/conversations/${encodeURIComponent(conversationId)}/panels`,
-        { signal }
+        url,
+        withLocalAddressSpace(url, {
+          headers: api.authHeader ? { Authorization: api.authHeader } : undefined,
+          signal,
+        })
       );
+
       if (!response.ok) {
         throw new Error(`Failed to fetch panels (${response.status})`);
       }
@@ -24,5 +29,5 @@ export function usePanelsApi() {
     }
 
     return { listPanels };
-  }, [api.baseUrl]);
+  }, [api.baseUrl, api.authHeader]);
 }

--- a/webui/src/utils/panelsApi.ts
+++ b/webui/src/utils/panelsApi.ts
@@ -1,0 +1,28 @@
+import { useApi } from '@/contexts/ApiContext';
+import { withLocalAddressSpace } from '@/utils/addressSpace';
+import type { IframePanelEntry, PanelListResponse } from '@/types/panels';
+import { useMemo } from 'react';
+
+export function usePanelsApi() {
+  const { api } = useApi();
+
+  return useMemo(() => {
+    async function listPanels(
+      conversationId: string,
+      signal?: AbortSignal
+    ): Promise<IframePanelEntry[]> {
+      const baseUrl = withLocalAddressSpace(api.baseUrl);
+      const response = await fetch(
+        `${baseUrl}/api/v2/conversations/${encodeURIComponent(conversationId)}/panels`,
+        { signal }
+      );
+      if (!response.ok) {
+        throw new Error(`Failed to fetch panels (${response.status})`);
+      }
+      const data = (await response.json()) as PanelListResponse;
+      return data.panels;
+    }
+
+    return { listPanels };
+  }, [api.baseUrl]);
+}


### PR DESCRIPTION
## Summary

Phase 3b of the webui artifact surface ([ErikBjare/bob#830](https://github.com/ErikBjare/bob/issues/830)). Phase 3a (frontend primitive) landed in #2640; this PR wires the server side and sidebar rendering.

- **Server** (`gptme/server/panels_api.py`): parses `panel_hints` from message metadata, validates src against the localhost/server-relative allowlist and sandbox tokens against the allowlist (drops the dangerous `allow-scripts + allow-same-origin` combination), and exposes `GET /api/v2/conversations/{id}/panels`. Registered as a Flask blueprint in `app.py`.
- **Frontend** (`PanelsPanel.tsx`, `panelsApi.ts`, `panels.ts`, `sidebar.ts`): a new "Panels" sidebar tab (LayoutDashboard icon) fetches the panels API and renders each entry via `SandboxedIframePanel`. Multi-panel tab row shown when >1 panel is declared.
- **Tests** (`tests/test_server_panels.py`): 28 focused unit tests covering src allowlist, sandbox token filtering, hint parsing (duplicate-id dedup, disallowed src, missing id, non-iframe kind, dangerous-combo strip, bootstrap forwarding), and the Flask endpoint.

## Known limitation (P2)

Server-relative-path panels with `allow-scripts` have an opaque sandbox origin — `gptme:ready`'s `event.origin` is `"null"`, so the bootstrap handshake silently fails. Localhost absolute-URL panels (the primary use case) are unaffected. Phase 3c will add a test documenting this and expose a validation warning.

## Verification

- `pytest tests/test_server_panels.py -q`: 28 passed
- `tsc -p tsconfig.app.json --noEmit`: 0 errors
- `mypy` on `panels_api.py`: 0 errors