### PR TITLE
fix(cli): clearer error when calling execute-only tools via 'tools call'

### DIFF
--- a/gptme/cli/util.py
+++ b/gptme/cli/util.py
@@ -840,13 +840,25 @@ def tools_call(tool_name: str, function_name: str, arg: list[str]):
         else None
     )
     if not function:
+        if not tool.functions:
+            # Most core tools (shell, patch, save, read, …) expose their
+            # behaviour through a single ``execute`` entrypoint rather than
+            # discrete named functions, so they cannot be reached via
+            # ``tools call``. Say so explicitly instead of the misleading
+            # "No functions available for this tool."
+            if tool.execute is not None:
+                print(
+                    f"Tool '{tool_name}' has no individually-callable functions; "
+                    "it runs through a single execute entrypoint and is not "
+                    "callable via 'tools call'."
+                )
+            else:
+                print(f"Tool '{tool_name}' exposes no callable functions.")
+            sys.exit(1)
         print(f"Function '{function_name}' not found in tool '{tool_name}'.")
-        if tool.functions:
-            print("Available functions:")
-            for f in tool.functions:
-                print(f"- {f.__name__}")
-        else:
-            print("No functions available for this tool.")
+        print("Available functions:")
+        for f in tool.functions:
+            print(f"- {f.__name__}")
         sys.exit(1)
     else:
         # Parse arguments into a dictionary, ensuring proper typing

--- a/tests/test_util_cli.py
+++ b/tests/test_util_cli.py
@@ -489,6 +489,23 @@ def test_tools_call_non_default_tool():
     assert "Available tools" in result.output
 
 
+def test_tools_call_execute_only_tool_message():
+    """Tools with an execute entrypoint but no discrete functions get a clear
+    message, not the misleading "No functions available for this tool".
+
+    Most core tools (shell, patch, save, read, …) expose behaviour through a
+    single ``execute`` entrypoint with an empty ``functions`` list, so they are
+    not callable via ``tools call``. The error should say so explicitly.
+    """
+    runner = CliRunner()
+
+    result = runner.invoke(main, ["tools", "call", "shell", "no_such_fn"])
+    assert result.exit_code != 0
+    assert "No functions available for this tool" not in result.output
+    assert "execute entrypoint" in result.output
+    assert "shell" in result.output
+
+
 def test_models_list():
     """Test the models list command."""
     import json


### PR DESCRIPTION
## Problem

`gptme-util tools call shell <fn>` (and patch/save/read/gh/ipython/todo/… — **16 of the most common core tools**) prints:

```
No functions available for this tool.
```

That's flatly wrong: those tools clearly work. They just expose behaviour through a single `execute` entrypoint with an empty `functions` list, so they aren't callable via `tools call`. Only 7 niche tools (browser, computer, rag, screenshot, subagent, vision, chats) populate `.functions`, so the common path gives a misleading error.

## Fix

When a tool has no discrete `functions` but does have an `execute` entrypoint, say so explicitly instead of claiming no functions are available:

```
Tool 'shell' has no individually-callable functions; it runs through a single execute entrypoint and is not callable via 'tools call'.
```

Tools that genuinely expose nothing callable get `Tool 'X' exposes no callable functions.`

## Test

Added `test_tools_call_execute_only_tool_message` asserting the misleading string is gone and the execute-entrypoint explanation is present. Existing `tools call` tests still pass.

Found via CLI dogfooding (no LLM call needed to reproduce).