### PR TITLE
feat(webui): add per-conversation cost badge to ConversationList

### DIFF
--- a/webui/src/components/ConversationList.tsx
+++ b/webui/src/components/ConversationList.tsx
@@ -376,7 +376,6 @@ export const ConversationList: FC<Props> = ({
                         <Tooltip>
                           <TooltipTrigger asChild>
                             <span className="flex items-center text-muted-foreground">
-                              <span className="mr-1 text-[10px]">$</span>
                               <span>{formatCost(cost.totalCost)}</span>
                               <span className="ml-0.5 text-[10px] text-muted-foreground/60">
                                 · {formatTokens(cost.totalTokens)}

--- a/webui/src/components/ConversationList.tsx
+++ b/webui/src/components/ConversationList.tsx
@@ -24,6 +24,7 @@ import {
   ContextMenuTrigger,
 } from '@/components/ui/context-menu';
 import { getRelativeTimeString, groupByDate } from '@/utils/time';
+import { computeConversationCost, formatCost, formatTokens } from '@/utils/conversationCost';
 import { useApi } from '@/contexts/ApiContext';
 import { demoConversations, getDemoMessages } from '@/democonversations';
 import {
@@ -357,6 +358,48 @@ export const ConversationList: FC<Props> = ({
                         </Tooltip>
                       ) : (
                         messageCountElement
+                      );
+                    }}
+                  </Computed>
+
+                  {/* Cost badge: show per-conversation total cost from loaded data */}
+                  <Computed>
+                    {() => {
+                      const storeConv = conversations$.get(conv.id)?.get();
+                      const isLoaded = storeConv?.data?.log?.length > 0;
+                      if (!isLoaded) return null;
+
+                      const cost = computeConversationCost(storeConv!.data!.log);
+                      if (!cost.hasData) return null;
+
+                      return (
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <span className="flex items-center text-muted-foreground">
+                              <span className="mr-1 text-[10px]">$</span>
+                              <span>{formatCost(cost.totalCost)}</span>
+                              <span className="ml-0.5 text-[10px] text-muted-foreground/60">
+                                · {formatTokens(cost.totalTokens)}
+                              </span>
+                            </span>
+                          </TooltipTrigger>
+                          <TooltipContent>
+                            <div className="space-y-1 text-xs">
+                              <div className="font-medium">Session cost</div>
+                              <div>Input: {formatTokens(cost.inputTokens)} tokens</div>
+                              <div>Output: {formatTokens(cost.outputTokens)} tokens</div>
+                              {cost.cacheReadTokens > 0 && (
+                                <div>Cache read: {formatTokens(cost.cacheReadTokens)} tokens</div>
+                              )}
+                              {cost.cacheCreationTokens > 0 && (
+                                <div>
+                                  Cache create: {formatTokens(cost.cacheCreationTokens)} tokens
+                                </div>
+                              )}
+                              <div>Total: {formatTokens(cost.totalTokens)} tokens</div>
+                            </div>
+                          </TooltipContent>
+                        </Tooltip>
                       );
                     }}
                   </Computed>

--- a/webui/src/types/conversation.ts
+++ b/webui/src/types/conversation.ts
@@ -58,6 +58,7 @@ export interface ConversationSummary {
   total_input_tokens?: number;
   total_output_tokens?: number;
   total_cache_read_tokens?: number;
+  total_cache_creation_tokens?: number;
 }
 
 export interface GenerateCallbacks {

--- a/webui/src/types/conversation.ts
+++ b/webui/src/types/conversation.ts
@@ -53,6 +53,11 @@ export interface ConversationSummary {
   last_message_preview?: string;
   serverId?: string; // which server this conversation is from (multi-backend)
   serverName?: string; // display name for the server label
+  // Cost/token summary (populated by server when detail=True)
+  total_cost?: number;
+  total_input_tokens?: number;
+  total_output_tokens?: number;
+  total_cache_read_tokens?: number;
 }
 
 export interface GenerateCallbacks {


### PR DESCRIPTION
## Summary

Adds a per-conversation cost badge (`$0.03 · 1,234 tokens`) to each conversation in the ConversationList sidebar. Builds on the `computeConversationCost` utility shipped in #2643.

## Changes

- **`webui/src/components/ConversationList.tsx`**: Added cost badge component inside the existing `<For>` loop, shown when conversation messages are loaded and cost data is available. Includes tooltip with breakdown (input, output, cache read, cache creation tokens).
- **`webui/src/types/conversation.ts`**: Added optional `total_cost`, `total_input_tokens`, `total_output_tokens`, `total_cache_read_tokens` fields to `ConversationSummary` — populated by server when `detail=True`.

## Testing

- All 316 Jest tests pass
- `npm run typecheck` clean
- Badge is reactive: shows when messages load, hides gracefully when no cost data

## Related

Closes #2643 (remaining slice: ConversationList cost badge)
