### PR TITLE
fix(release): verify artifact build workflows actually started

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -285,16 +285,18 @@ jobs:
         # never starts (e.g. workflow file syntax error on the target branch,
         # missing workflow_dispatch trigger). Without this check a release can
         # silently ship the PyPI package with no binaries/installers built.
-        # Returns 0 if a non-completed workflow_dispatch run registers within
-        # ~30s, else 1. A run that registered but already finished (fast
-        # failure) is reported as registered-then-failed rather than missing,
-        # so the error message doesn't misattribute it.
+        # Returns 0 if any workflow_dispatch run created at or after
+        # TRIGGER_TIME registers within ~30s, else 1. Including recently-
+        # completed runs avoids a misleading "no run registered" error when
+        # the triggered workflow starts and fast-fails before the first poll.
         verify_triggered() {
           local workflow="$1"
           echo "Verifying ${workflow} run started..."
           for i in 1 2 3 4 5 6; do
             count="$(gh run list --workflow="${workflow}" --event=workflow_dispatch \
-              --limit 5 --json status --jq '[.[] | select(.status != "completed")] | length')"
+              --limit 5 --json status,createdAt | \
+              jq --arg since "${TRIGGER_TIME}" \
+              '[.[] | select(.status != "completed" or .createdAt >= $since)] | length')"
             if [ "${count:-0}" -gt 0 ]; then
               echo "✓ ${workflow} run registered (attempt ${i}/6)"
               return 0
@@ -309,6 +311,10 @@ jobs:
           return 1
         }
 
+        # Capture time before dispatching so verify_triggered can distinguish
+        # runs created by this dispatch from pre-existing completed runs.
+        TRIGGER_TIME="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
         echo "Triggering Build workflow for ${TAG}..."
         gh workflow run build.yml -f tag="${TAG}"
         echo "Triggering Tauri workflow for ${TAG}..."
@@ -320,7 +326,3 @@ jobs:
         verify_triggered build.yml || rc=1
         verify_triggered tauri.yml || rc=1
         exit "${rc}"
-
-        # Poll after both triggers so the two dispatches register in parallel.
-        verify_triggered build.yml
-        verify_triggered tauri.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -285,6 +285,10 @@ jobs:
         # never starts (e.g. workflow file syntax error on the target branch,
         # missing workflow_dispatch trigger). Without this check a release can
         # silently ship the PyPI package with no binaries/installers built.
+        # Returns 0 if a non-completed workflow_dispatch run registers within
+        # ~30s, else 1. A run that registered but already finished (fast
+        # failure) is reported as registered-then-failed rather than missing,
+        # so the error message doesn't misattribute it.
         verify_triggered() {
           local workflow="$1"
           echo "Verifying ${workflow} run started..."
@@ -295,10 +299,13 @@ jobs:
               echo "✓ ${workflow} run registered (attempt ${i}/6)"
               return 0
             fi
-            echo "Waiting for ${workflow} run to register... (${i}/6)"
-            sleep 5
+            # Don't sleep after the final attempt — nothing follows it.
+            if [ "${i}" -lt 6 ]; then
+              echo "Waiting for ${workflow} run to register... (${i}/6)"
+              sleep 5
+            fi
           done
-          echo "::error::${workflow} was triggered but no run registered within 30s"
+          echo "::error::${workflow} was triggered but no active run registered within ~30s"
           return 1
         }
 
@@ -306,6 +313,13 @@ jobs:
         gh workflow run build.yml -f tag="${TAG}"
         echo "Triggering Tauri workflow for ${TAG}..."
         gh workflow run tauri.yml -f tag="${TAG}"
+
+        # Check both even if the first fails, so the job reports every missing
+        # trigger in one run (set -eo pipefail would otherwise stop at the first).
+        rc=0
+        verify_triggered build.yml || rc=1
+        verify_triggered tauri.yml || rc=1
+        exit "${rc}"
 
         # Poll after both triggers so the two dispatches register in parallel.
         verify_triggered build.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -280,7 +280,33 @@ jobs:
       env:
         GH_TOKEN: ${{ github.token }}
       run: |
+        # Verify a workflow_dispatch run actually registered after triggering.
+        # `gh workflow run` is fire-and-forget and exits 0 even when the run
+        # never starts (e.g. workflow file syntax error on the target branch,
+        # missing workflow_dispatch trigger). Without this check a release can
+        # silently ship the PyPI package with no binaries/installers built.
+        verify_triggered() {
+          local workflow="$1"
+          echo "Verifying ${workflow} run started..."
+          for i in 1 2 3 4 5 6; do
+            count="$(gh run list --workflow="${workflow}" --event=workflow_dispatch \
+              --limit 5 --json status --jq '[.[] | select(.status != "completed")] | length')"
+            if [ "${count:-0}" -gt 0 ]; then
+              echo "✓ ${workflow} run registered (attempt ${i}/6)"
+              return 0
+            fi
+            echo "Waiting for ${workflow} run to register... (${i}/6)"
+            sleep 5
+          done
+          echo "::error::${workflow} was triggered but no run registered within 30s"
+          return 1
+        }
+
         echo "Triggering Build workflow for ${TAG}..."
         gh workflow run build.yml -f tag="${TAG}"
         echo "Triggering Tauri workflow for ${TAG}..."
         gh workflow run tauri.yml -f tag="${TAG}"
+
+        # Poll after both triggers so the two dispatches register in parallel.
+        verify_triggered build.yml
+        verify_triggered tauri.yml


### PR DESCRIPTION
## Summary

`gh workflow run` is fire-and-forget: it exits 0 even when the dispatched run never registers (workflow syntax error on the target branch, a missing/renamed `workflow_dispatch` trigger, etc.). Today the release job triggers `build.yml` and `tauri.yml` but never confirms they started — so a silent trigger failure ships the PyPI package with **no binaries or installers built**, with a green release job.

This adds a 30s polling loop (6 × 5s) after triggering both workflows that confirms each registered a non-completed `workflow_dispatch` run via `gh run list`, failing the job otherwise. Polling happens after *both* dispatches so they register in parallel.

## Context

Completes **AC3** of the gptme release-pipeline self-review (idea #366). AC1 (vendored `build_changelog.py`) and AC2 (dry-run PyPI publish) shipped in #2644.

## Notes / tradeoff

The check counts any non-completed `workflow_dispatch` run as "registered". A stuck run from a prior dispatch could in theory mask a genuinely-failed new trigger, but for the release path (infrequent, manual-ish dispatch) this is a reasonable, low-risk heuristic that catches the real failure mode — a trigger that produces no run at all. Kept deliberately simple over a before/after run-ID diff.

## Test plan

- [x] YAML parses (`yaml.safe_load`)
- [x] Pre-commit hooks pass
- [ ] Will exercise on next real release dispatch