### PR TITLE
feat(server): plumb max_tokens from chat config through generation

### DIFF
--- a/gptme/config/chat.py
+++ b/gptme/config/chat.py
@@ -55,6 +55,8 @@ class ChatConfig:
     tool_format: "ToolFormat | None" = None
     stream: bool = True
     interactive: bool = True
+    # Max tokens for the model's response. None = provider/model default.
+    max_tokens: int | None = None
     # CLI sessions default to the current directory. Server sessions load
     # through from_logdir/load_or_create to get per-conversation workspaces.
     workspace: Path = field(default_factory=Path.cwd)

--- a/gptme/llm/__init__.py
+++ b/gptme/llm/__init__.py
@@ -398,6 +398,8 @@ def _stream(
     output_schema: type | None = None,
     max_tokens: int | None = None,
 ) -> _StreamWithMetadata:
+    if max_tokens is not None and max_tokens <= 0:
+        raise ValueError(f"max_tokens must be a positive integer, got {max_tokens}")
     max_tokens = _resolve_max_tokens(model, max_tokens)
     provider = get_provider_from_model(model)
     # Custom providers and plugin providers are OpenAI-compatible, route through OpenAI path

--- a/gptme/server/openapi_docs.py
+++ b/gptme/server/openapi_docs.py
@@ -420,6 +420,9 @@ class ChatConfig(BaseModel):
     model: str | None = Field(None, description="Default model")
     tools: list[str] | None = Field(None, description="Enabled tools")
     workspace: str | None = Field(None, description="Workspace path")
+    max_tokens: int | None = Field(
+        None, description="Max tokens for the model's response (None = model default)"
+    )
 
 
 # Helper functions for automatic inference

--- a/gptme/server/openapi_docs.py
+++ b/gptme/server/openapi_docs.py
@@ -421,7 +421,9 @@ class ChatConfig(BaseModel):
     tools: list[str] | None = Field(None, description="Enabled tools")
     workspace: str | None = Field(None, description="Workspace path")
     max_tokens: int | None = Field(
-        None, description="Max tokens for the model's response (None = model default)"
+        None,
+        description="Max tokens for the model's response (None = model default)",
+        gt=0,
     )
 
 

--- a/gptme/server/session_step.py
+++ b/gptme/server/session_step.py
@@ -675,10 +675,14 @@ def step(
         # Handle streaming vs non-streaming differently
         metadata = None
         if stream:
-            stream_wrapper = _stream(msgs, model, tools)
+            stream_wrapper = _stream(
+                msgs, model, tools, max_tokens=chat_config.max_tokens
+            )
             chunks: Iterable[str] = stream_wrapper
         else:
-            response, metadata = _chat_complete(msgs, model, tools)
+            response, metadata = _chat_complete(
+                msgs, model, tools, max_tokens=chat_config.max_tokens
+            )
             chunks = [response]  # Wrap in list to iterate
             stream_wrapper = None
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -537,6 +537,24 @@ def test_default_chat_config_to_toml():
     assert config_new == config
 
 
+def test_chat_config_max_tokens_default_omitted():
+    """max_tokens defaults to None and is omitted from serialization."""
+    config = ChatConfig()
+    assert config.max_tokens is None
+    assert "max_tokens" not in config.to_dict()["chat"]
+
+
+def test_chat_config_max_tokens_roundtrip():
+    """max_tokens is accepted from config and survives a to_dict/from_dict round-trip."""
+    config = ChatConfig.from_dict({"chat": {"max_tokens": 4096}})
+    assert config.max_tokens == 4096
+    assert config.to_dict()["chat"]["max_tokens"] == 4096
+
+    toml_str = tomlkit.dumps(config.to_dict())
+    config_new = ChatConfig.from_dict(tomlkit.loads(toml_str).unwrap())
+    assert config_new.max_tokens == 4096
+
+
 def test_project_config_loaded_from_toml():
     config = ProjectConfig.from_dict(tomlkit.loads(project_config_toml).unwrap())
 

--- a/tests/test_server_v2_hooks.py
+++ b/tests/test_server_v2_hooks.py
@@ -145,7 +145,7 @@ def test_turn_pre_hook(client: FlaskClient, monkeypatch):
     )
     assert response.status_code == 200
 
-    def mock_chat_complete(messages, model, tools=None):
+    def mock_chat_complete(messages, model, tools=None, max_tokens=None):
         return ("Hello! How can I help you?", None)
 
     with unittest.mock.patch(
@@ -194,7 +194,7 @@ def test_message_post_process_hook(client: FlaskClient, monkeypatch):
 
     # Mock _chat_complete (since stream=False)
     # Returns (response, metadata) tuple - the new format
-    def mock_chat_complete(messages, model, tools=None):
+    def mock_chat_complete(messages, model, tools=None, max_tokens=None):
         return ("Hello! How can I help you?", None)
 
     with unittest.mock.patch(


### PR DESCRIPTION
## Summary

`ChatConfig` exposes per-conversation settings, but `max_tokens` was never actually wired into the generation path — the server always called `_stream()`/`_chat_complete()` with no `max_tokens`, so the LLM used the provider/model default regardless of config.

This threads `chat_config.max_tokens` into both generation call sites in `session_step.py`, so a `max_tokens` set in the conversation's chat config (or via the webui chat options) actually constrains the response.

## Changes
- `gptme/config/chat.py`: add `max_tokens: int | None = None` field to `ChatConfig`. Defaults to `None` (omitted from serialization → backwards compatible).
- `gptme/server/session_step.py`: pass `max_tokens=chat_config.max_tokens` to `_stream()` and `_chat_complete()`. `None` preserves existing behavior.
- `gptme/server/openapi_docs.py`: document `max_tokens` on the OpenAPI `ChatConfig` schema for API consumers.
- `tests/test_config.py`: round-trip tests for the new field (default-omitted + set value survives to_dict/from_dict/TOML).

## Scope note
This is the foundational data-path slice. `temperature` and `top_p` are currently **hardcoded constants** (`gptme/constants.py`, consumed directly in `llm_anthropic.chat/stream` and `llm_openai.chat`) and are not threaded through `reply()`/`_chat_complete()` at all. Making those request-driven needs separate, more invasive plumbing through the provider `chat()`/`stream()` paths (including the `supports_reasoning` special-casing) and is left as a follow-up. This PR unblocks the webui exposing a working `max_tokens` control first.

## Test plan
- `uv run pytest tests/test_config.py -k chat_config` → 13 passed
- `mypy` clean on all changed files