### PR TITLE
feat(webui): add keyboard shortcuts reference dialog

### DIFF
--- a/webui/src/App.tsx
+++ b/webui/src/App.tsx
@@ -9,6 +9,7 @@ import { EmbeddedContextProvider } from './contexts/EmbeddedContext';
 import { SettingsProvider } from './contexts/SettingsContext';
 import { lazy, Suspense, type FC } from 'react';
 import { CommandPalette } from './components/CommandPalette';
+import { ShortcutsDialog } from './components/ShortcutsDialog';
 import { SetupWizard } from './components/SetupWizard';
 
 // Lazy-loaded route pages — code-split at route boundaries for smaller initial bundle
@@ -88,6 +89,7 @@ const App: FC = () => {
                   </Suspense>
                   <SetupWizard />
                   <CommandPalette />
+                  <ShortcutsDialog />
                   <Toaster />
                   <Sonner />
                 </BrowserRouter>

--- a/webui/src/components/MenuBar.tsx
+++ b/webui/src/components/MenuBar.tsx
@@ -8,12 +8,13 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from './ui/dropdown-menu';
-import { ChevronDown, Menu, Search, User } from 'lucide-react';
+import { ChevronDown, HelpCircle, Menu, Search, User } from 'lucide-react';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { useEmbeddedContext } from '@/contexts/EmbeddedContext';
 import type { EmbeddedMenuItem } from '@/lib/embeddedContext';
 import { Link } from 'react-router-dom';
 import { commandPaletteOpen$ } from '@/stores/commandPalette';
+import { shortcutsDialogOpen$ } from '@/stores/shortcutsDialog';
 import { leftSidebarVisible$, toggleLeftSidebar } from '@/stores/sidebar';
 import { use$ } from '@legendapp/state/react';
 
@@ -101,6 +102,22 @@ export const MenuBar: FC = () => {
               </Button>
             </TooltipTrigger>
             <TooltipContent side="bottom">Search</TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-7 w-7"
+                onClick={() => shortcutsDialogOpen$.set(true)}
+                aria-label="Keyboard shortcuts"
+              >
+                <HelpCircle className="h-4 w-4" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">Keyboard shortcuts (?)</TooltipContent>
           </Tooltip>
         </TooltipProvider>
         <ServerSelector />

--- a/webui/src/components/ShortcutsDialog.tsx
+++ b/webui/src/components/ShortcutsDialog.tsx
@@ -88,11 +88,15 @@ export function ShortcutsDialog() {
         return;
       }
       e.preventDefault();
-      setOpenState(!shortcutsDialogOpen$.get());
+      setOpen((prev) => {
+        const next = !prev;
+        shortcutsDialogOpen$.set(next);
+        return next;
+      });
     };
     document.addEventListener('keydown', down);
     return () => document.removeEventListener('keydown', down);
-  }, [setOpenState]);
+  }, []);
 
   return (
     <Dialog open={open} onOpenChange={setOpenState}>

--- a/webui/src/components/ShortcutsDialog.tsx
+++ b/webui/src/components/ShortcutsDialog.tsx
@@ -1,0 +1,133 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { shortcutsDialogOpen$ } from '@/stores/shortcutsDialog';
+
+interface Shortcut {
+  keys: string[];
+  description: string;
+}
+
+interface ShortcutGroup {
+  title: string;
+  shortcuts: Shortcut[];
+}
+
+const isMac = typeof navigator !== 'undefined' && /Mac|iPhone|iPad/.test(navigator.platform ?? '');
+const MOD = isMac ? '⌘' : 'Ctrl';
+
+const SHORTCUT_GROUPS: ShortcutGroup[] = [
+  {
+    title: 'General',
+    shortcuts: [
+      { keys: [MOD, 'K'], description: 'Open command palette' },
+      { keys: ['?'], description: 'Show this shortcuts reference' },
+      { keys: ['i'], description: 'Focus the message input' },
+    ],
+  },
+  {
+    title: 'Command palette',
+    shortcuts: [
+      { keys: ['↑', '↓'], description: 'Navigate results' },
+      { keys: ['Enter'], description: 'Select highlighted item' },
+      { keys: ['Esc'], description: 'Close palette' },
+    ],
+  },
+  {
+    title: 'Message input',
+    shortcuts: [
+      { keys: ['Enter'], description: 'Send message' },
+      { keys: ['Shift', 'Enter'], description: 'Insert a new line' },
+      { keys: ['Esc'], description: 'Cancel edit / blur input' },
+    ],
+  },
+  {
+    title: 'Tool confirmation',
+    shortcuts: [{ keys: ['Enter'], description: 'Confirm the pending tool call' }],
+  },
+];
+
+function Kbd({ children }: { children: React.ReactNode }) {
+  return (
+    <kbd className="pointer-events-none inline-flex h-6 min-w-[1.5rem] items-center justify-center rounded border bg-muted px-1.5 font-mono text-[11px] font-medium text-muted-foreground">
+      {children}
+    </kbd>
+  );
+}
+
+export function ShortcutsDialog() {
+  const [open, setOpen] = useState(false);
+
+  const setOpenState = useCallback((value: boolean) => {
+    setOpen(value);
+    shortcutsDialogOpen$.set(value);
+  }, []);
+
+  // Sync with external opens (e.g. MenuBar help button).
+  useEffect(() => {
+    return shortcutsDialogOpen$.onChange(({ value }) => {
+      setOpen(value);
+    });
+  }, []);
+
+  // Toggle with `?` when not typing in an input/textarea/contentEditable.
+  useEffect(() => {
+    const down = (e: KeyboardEvent) => {
+      if (e.key !== '?') return;
+      const target = e.target as HTMLElement | null;
+      if (
+        target instanceof HTMLInputElement ||
+        target instanceof HTMLTextAreaElement ||
+        target?.isContentEditable
+      ) {
+        return;
+      }
+      e.preventDefault();
+      setOpenState(!shortcutsDialogOpen$.get());
+    };
+    document.addEventListener('keydown', down);
+    return () => document.removeEventListener('keydown', down);
+  }, [setOpenState]);
+
+  return (
+    <Dialog open={open} onOpenChange={setOpenState}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Keyboard shortcuts</DialogTitle>
+          <DialogDescription>
+            Press <Kbd>?</Kbd> anytime to open this reference.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4">
+          {SHORTCUT_GROUPS.map((group) => (
+            <div key={group.title}>
+              <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                {group.title}
+              </h3>
+              <ul className="space-y-1.5">
+                {group.shortcuts.map((shortcut) => (
+                  <li
+                    key={shortcut.description}
+                    className="flex items-center justify-between gap-4 text-sm"
+                  >
+                    <span>{shortcut.description}</span>
+                    <span className="flex shrink-0 items-center gap-1">
+                      {shortcut.keys.map((key, i) => (
+                        <Kbd key={i}>{key}</Kbd>
+                      ))}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/webui/src/components/__tests__/ShortcutsDialog.test.tsx
+++ b/webui/src/components/__tests__/ShortcutsDialog.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ShortcutsDialog } from '../ShortcutsDialog';
+import { shortcutsDialogOpen$ } from '@/stores/shortcutsDialog';
+
+// Mock the store with a tiny in-memory observable so opens/changes propagate.
+jest.mock('@/stores/shortcutsDialog', () => {
+  let value = false;
+  const listeners: Array<(arg: { value: boolean }) => void> = [];
+  return {
+    shortcutsDialogOpen$: {
+      get: () => value,
+      set: (v: boolean) => {
+        value = v;
+        listeners.forEach((cb) => cb({ value }));
+      },
+      onChange: (cb: (arg: { value: boolean }) => void) => {
+        listeners.push(cb);
+        return () => {
+          const i = listeners.indexOf(cb);
+          if (i >= 0) listeners.splice(i, 1);
+        };
+      },
+    },
+  };
+});
+
+// Render Dialog content only when open, mirroring the ui/command test pattern.
+jest.mock('../ui/dialog', () => ({
+  Dialog: ({ children, open }: { children: React.ReactNode; open: boolean }) =>
+    open ? <div data-testid="shortcuts-dialog">{children}</div> : null,
+  DialogContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,
+  DialogDescription: ({ children }: { children: React.ReactNode }) => <p>{children}</p>,
+}));
+
+describe('ShortcutsDialog', () => {
+  beforeEach(() => {
+    shortcutsDialogOpen$.set(false);
+  });
+
+  it('is closed by default', () => {
+    render(<ShortcutsDialog />);
+    expect(screen.queryByTestId('shortcuts-dialog')).not.toBeInTheDocument();
+  });
+
+  it('opens when the "?" key is pressed', () => {
+    render(<ShortcutsDialog />);
+    fireEvent.keyDown(document, { key: '?' });
+    expect(screen.getByTestId('shortcuts-dialog')).toBeInTheDocument();
+    expect(screen.getByText('Keyboard shortcuts')).toBeInTheDocument();
+  });
+
+  it('lists shortcut groups and descriptions', () => {
+    render(<ShortcutsDialog />);
+    fireEvent.keyDown(document, { key: '?' });
+    expect(screen.getByText('General')).toBeInTheDocument();
+    expect(screen.getByText('Open command palette')).toBeInTheDocument();
+    expect(screen.getByText('Focus the message input')).toBeInTheDocument();
+    expect(screen.getByText('Send message')).toBeInTheDocument();
+  });
+
+  it('does not open when "?" is typed inside an input', () => {
+    render(
+      <>
+        <input data-testid="text-field" />
+        <ShortcutsDialog />
+      </>
+    );
+    const input = screen.getByTestId('text-field');
+    fireEvent.keyDown(input, { key: '?' });
+    expect(screen.queryByTestId('shortcuts-dialog')).not.toBeInTheDocument();
+  });
+});

--- a/webui/src/stores/shortcutsDialog.ts
+++ b/webui/src/stores/shortcutsDialog.ts
@@ -1,0 +1,3 @@
+import { observable } from '@legendapp/state';
+
+export const shortcutsDialogOpen$ = observable(false);


### PR DESCRIPTION
## Summary

Adds a `?`-triggered keyboard shortcuts reference dialog to gptme-webui. Surfaces existing bindings (Cmd/Ctrl+K, `i`-focus, etc.) that were previously undiscoverable.

Closes gptme-webui-keyboard-shortcuts-ref (Bob workspace task).

## What it does
- Press `?` anywhere (outside an input/textarea/contentEditable) to open a modal listing all shortcuts, grouped by context:
  - **General**: ⌘/Ctrl+K (command palette), `?` (this dialog), `i` (focus input)
  - **Command palette**: ↑/↓ navigate, Enter select, Esc close
  - **Message input**: Enter send, Shift+Enter newline, Esc cancel/blur
  - **Tool confirmation**: Enter confirm
- A help icon (`HelpCircle`) in the `MenuBar` opens the same dialog for discoverability.
- The `?` handler ignores keypresses while typing in inputs/textareas/contentEditable.

## Implementation
- New `ShortcutsDialog` component using the existing `Dialog` primitive (no new deps).
- New `shortcutsDialogOpen$` observable store (mirrors `commandPalette$` pattern) so the MenuBar button can open it.
- Mounted in `App.tsx` alongside `CommandPalette`.

## Testing
- New `ShortcutsDialog.test.tsx` (Jest): default-closed, `?` opens, lists groups/descriptions, and does NOT open when `?` is typed in an input. **4/4 pass.**
- `tsc --noEmit` clean; eslint clean (pre-commit `eslint . --fix` + `tsc` hooks passed).