### PR TITLE
feat(webui): add max_tokens input with full operation coverage

### DIFF
--- a/webui/src/components/ChatInput.tsx
+++ b/webui/src/components/ChatInput.tsx
@@ -558,11 +558,13 @@ export const ChatInput: FC<Props> = ({
     }
   }, [conversationModel, defaultModel, apiDefaultModel, hasExplicitModelSelection]);
 
-  // Reset explicit selection and maxTokens when conversation changes
+  // Sync local state with store when conversation changes
   useEffect(() => {
     setHasExplicitModelSelection(false);
     setSelectedModel(conversationModel || defaultModel || apiDefaultModel || '');
-    setMaxTokens(undefined);
+    setMaxTokens(
+      conversationId ? conversations$.get(conversationId)?.maxTokens?.peek() : undefined
+    );
   }, [conversationId, conversationModel, defaultModel, apiDefaultModel]);
 
   const [selectedWorkspace, setSelectedWorkspace] = useState<string>(

--- a/webui/src/components/ChatInput.tsx
+++ b/webui/src/components/ChatInput.tsx
@@ -221,7 +221,8 @@ const ChatOptionsPanel: FC<ChatOptionsProps> = ({
         value={maxTokens ?? ''}
         onChange={(e) => {
           const val = e.target.value;
-          setMaxTokens(val === '' ? undefined : Math.max(1, parseInt(val, 10)));
+          const n = Math.round(Number(val));
+          setMaxTokens(val === '' || isNaN(n) ? undefined : Math.max(1, n));
         }}
         disabled={isDisabled}
         className="w-full rounded-md border border-input bg-background px-3 py-1.5 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
@@ -557,10 +558,11 @@ export const ChatInput: FC<Props> = ({
     }
   }, [conversationModel, defaultModel, apiDefaultModel, hasExplicitModelSelection]);
 
-  // Reset explicit selection when conversation changes
+  // Reset explicit selection and maxTokens when conversation changes
   useEffect(() => {
     setHasExplicitModelSelection(false);
     setSelectedModel(conversationModel || defaultModel || apiDefaultModel || '');
+    setMaxTokens(undefined);
   }, [conversationId, conversationModel, defaultModel, apiDefaultModel]);
 
   const [selectedWorkspace, setSelectedWorkspace] = useState<string>(

--- a/webui/src/components/ChatInput.tsx
+++ b/webui/src/components/ChatInput.tsx
@@ -33,7 +33,7 @@ import { Switch } from '@/components/ui/switch';
 import { Label } from '@/components/ui/label';
 import { type Observable } from '@legendapp/state';
 import { Computed, use$ } from '@legendapp/state/react';
-import { conversations$ } from '@/stores/conversations';
+import { conversations$, setMaxTokens as setMaxTokensStore } from '@/stores/conversations';
 import {
   selectedAgent$,
   selectedWorkspace$,
@@ -566,6 +566,13 @@ export const ChatInput: FC<Props> = ({
       conversationId ? conversations$.get(conversationId)?.maxTokens?.peek() : undefined
     );
   }, [conversationId, conversationModel, defaultModel, apiDefaultModel]);
+
+  // Keep store in sync with local maxTokens so regenerate/rerun see the current UI value
+  useEffect(() => {
+    if (conversationId) {
+      setMaxTokensStore(conversationId, maxTokens);
+    }
+  }, [maxTokens, conversationId]);
 
   const [selectedWorkspace, setSelectedWorkspace] = useState<string>(
     // For new conversations, use the selected workspace from sidebar, otherwise default to '.'

--- a/webui/src/components/ChatInput.tsx
+++ b/webui/src/components/ChatInput.tsx
@@ -64,6 +64,8 @@ export interface ChatOptions {
   files?: string[];
   /** Raw File objects to upload after conversation creation (for new chat view) */
   pendingFiles?: File[];
+  /** Max tokens for the model's response. Undefined = provider default. */
+  maxTokens?: number;
 }
 
 interface Props {
@@ -106,6 +108,8 @@ interface ChatOptionsProps {
   baseUrl: string;
   streamingEnabled: boolean;
   setStreamingEnabled: (enabled: boolean) => void;
+  maxTokens: number | undefined;
+  setMaxTokens: (tokens: number | undefined) => void;
   availableWorkspaces: WorkspaceProject[];
   isDisabled: boolean;
   showWorkspaceSelector: boolean;
@@ -122,6 +126,8 @@ const ChatOptionsPanel: FC<ChatOptionsProps> = ({
   baseUrl,
   streamingEnabled,
   setStreamingEnabled,
+  maxTokens,
+  setMaxTokens,
   availableWorkspaces,
   isDisabled,
   showWorkspaceSelector,
@@ -204,6 +210,23 @@ const ChatOptionsPanel: FC<ChatOptionsProps> = ({
       setStreamingEnabled={setStreamingEnabled}
       isDisabled={isDisabled}
     />
+
+    <div className="space-y-1">
+      <Label htmlFor="max-tokens-input">Max tokens</Label>
+      <input
+        id="max-tokens-input"
+        type="number"
+        min={1}
+        placeholder="Model default"
+        value={maxTokens ?? ''}
+        onChange={(e) => {
+          const val = e.target.value;
+          setMaxTokens(val === '' ? undefined : Math.max(1, parseInt(val, 10)));
+        }}
+        disabled={isDisabled}
+        className="w-full rounded-md border border-input bg-background px-3 py-1.5 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+      />
+    </div>
 
     {onOpenChatSettings && (
       <button
@@ -485,6 +508,7 @@ export const ChatInput: FC<Props> = ({
     return '';
   });
   const [streamingEnabled, setStreamingEnabled] = useState(true);
+  const [maxTokens, setMaxTokens] = useState<number | undefined>(undefined);
 
   // When switching conversations, load the new conversation's draft.
   // Use a ref to track the previous key so we can save the outgoing draft first.
@@ -785,6 +809,7 @@ export const ChatInput: FC<Props> = ({
               workspace: selectedWorkspace || undefined,
               files: uploadedPaths,
               pendingFiles,
+              maxTokens,
             },
           },
         ]);
@@ -815,6 +840,7 @@ export const ChatInput: FC<Props> = ({
         workspace: selectedWorkspace || undefined,
         files: uploadedPaths,
         pendingFiles,
+        maxTokens,
       });
       setMessage('');
       cleanupAndClearFiles();
@@ -1082,6 +1108,8 @@ export const ChatInput: FC<Props> = ({
                           baseUrl={connectionConfig.baseUrl.replace(/\/+$/, '')}
                           streamingEnabled={streamingEnabled}
                           setStreamingEnabled={setStreamingEnabled}
+                          maxTokens={maxTokens}
+                          setMaxTokens={setMaxTokens}
                           availableWorkspaces={availableWorkspaces}
                           isDisabled={isDisabled}
                           showWorkspaceSelector={!conversationId}

--- a/webui/src/components/WelcomeView.tsx
+++ b/webui/src/components/WelcomeView.tsx
@@ -99,6 +99,7 @@ export const WelcomeView = () => {
         stream: options?.stream,
         workspace: options?.workspace || '.',
         pendingFiles: options?.pendingFiles,
+        maxTokens: options?.maxTokens,
       });
 
       // Navigate immediately - server-side creation happens in background

--- a/webui/src/components/__tests__/ChatInput.test.tsx
+++ b/webui/src/components/__tests__/ChatInput.test.tsx
@@ -56,6 +56,7 @@ jest.mock('@/stores/conversations', () => {
         })
       ),
     },
+    setMaxTokens: jest.fn(),
   };
 });
 

--- a/webui/src/hooks/useConversation.ts
+++ b/webui/src/hooks/useConversation.ts
@@ -22,6 +22,7 @@ import {
   selectedConversation$,
   updateConversationName,
   setNeedsInitialStep,
+  setMaxTokens,
 } from '@/stores/conversations';
 import { playChime } from '@/utils/audio';
 import { findLatestAssistantIndexForError } from '@/utils/conversationErrorHandling';
@@ -38,6 +39,7 @@ export function useConversation(conversationId: string, serverId?: string) {
   const { toast } = useToast();
   const conversation$ = conversations$.get(conversationId);
   const isConnected = use$(isConnected$);
+  const maxTokens = use$(() => conversation$?.maxTokens.get());
 
   const messageJustCompleted = useRef(false);
 
@@ -341,7 +343,7 @@ export function useConversation(conversationId: string, serverId?: string) {
               if (needsStep) {
                 console.log('[useConversation] Triggering initial step after subscription');
                 setNeedsInitialStep(conversationId, false);
-                api.step(conversationId).catch((error) => {
+                api.step(conversationId, undefined, true, 'main', maxTokens).catch((error) => {
                   console.error('[useConversation] Error triggering initial step:', error);
                   toastStepStartError(toast, error);
                 });
@@ -458,6 +460,8 @@ export function useConversation(conversationId: string, serverId?: string) {
 
       // Start generation
       await api.step(conversationId, options?.model, options?.stream, 'main', options?.maxTokens);
+      // Store maxTokens in conversation state so regenerate/rerun paths can use it
+      setMaxTokens(conversationId, options?.maxTokens);
     } catch (error) {
       console.error('Error sending message:', error);
       const { title, description } = getApiErrorPresentation(error, {
@@ -583,7 +587,7 @@ export function useConversation(conversationId: string, serverId?: string) {
 
       // After truncation, trigger re-generation
       if (truncate) {
-        await api.step(conversationId);
+        await api.step(conversationId, undefined, true, 'main', maxTokens);
       }
     } catch (error) {
       console.error('Error editing message:', error);
@@ -626,7 +630,7 @@ export function useConversation(conversationId: string, serverId?: string) {
         await api.rerunTools(conversationId);
       } catch {
         // No tools found — fall back to step() (regenerate)
-        await api.step(conversationId);
+        await api.step(conversationId, undefined, true, 'main', maxTokens);
       }
     } catch (error) {
       console.error('Error re-running from message:', error);
@@ -648,7 +652,7 @@ export function useConversation(conversationId: string, serverId?: string) {
       if (result.branches) {
         updateBranches(conversationId, result.branches);
       }
-      await api.step(conversationId);
+      await api.step(conversationId, undefined, true, 'main', maxTokens);
     } catch (error) {
       console.error('Error regenerating message:', error);
       const errorMsg = error instanceof Error ? error.message : 'Failed to regenerate';

--- a/webui/src/hooks/useConversation.ts
+++ b/webui/src/hooks/useConversation.ts
@@ -457,7 +457,7 @@ export function useConversation(conversationId: string, serverId?: string) {
       setMessageStatus(conversationId, userMessage.timestamp!, 'sent');
 
       // Start generation
-      await api.step(conversationId, options?.model, options?.stream);
+      await api.step(conversationId, options?.model, options?.stream, 'main', options?.maxTokens);
     } catch (error) {
       console.error('Error sending message:', error);
       const { title, description } = getApiErrorPresentation(error, {

--- a/webui/src/stores/conversations.ts
+++ b/webui/src/stores/conversations.ts
@@ -35,6 +35,9 @@ export interface ConversationState {
   needsInitialStep: boolean;
   // Currently displayed branch name
   currentBranch: string;
+  // Max tokens setting for model responses, persisted across operations.
+  // Set by ChatInput when sending a message; read by all step() call sites.
+  maxTokens?: number;
 }
 
 // Central store for all conversations
@@ -151,6 +154,10 @@ export function initConversation(
 
 export function setNeedsInitialStep(id: string, needsInitialStep: boolean) {
   updateConversation(id, { needsInitialStep });
+}
+
+export function setMaxTokens(id: string, maxTokens: number | undefined) {
+  updateConversation(id, { maxTokens });
 }
 
 // Update conversation data in the store

--- a/webui/src/utils/api.ts
+++ b/webui/src/utils/api.ts
@@ -15,7 +15,7 @@ import { getApiBaseUrl } from '@/utils/connectionConfig';
 import { isLocalUrl, withLocalAddressSpace } from '@/utils/addressSpace';
 import { type Observable } from '@legendapp/state';
 import { observable } from '@legendapp/state';
-import { initConversation } from '@/stores/conversations';
+import { initConversation, setMaxTokens } from '@/stores/conversations';
 
 // Add DOM types
 type RequestInit = globalThis.RequestInit;
@@ -949,6 +949,7 @@ export class ApiClient {
       stream?: boolean;
       workspace?: string;
       pendingFiles?: File[];
+      maxTokens?: number;
     }
   ): Promise<string> {
     // Generate conversation ID immediately
@@ -977,6 +978,9 @@ export class ApiClient {
       },
       { needsInitialStep: true }
     );
+    if (options?.maxTokens !== undefined) {
+      setMaxTokens(conversationId, options.maxTokens);
+    }
 
     if (options?.pendingFiles?.length) {
       // When files are attached: create an empty conversation first (no message yet),

--- a/webui/src/utils/api.ts
+++ b/webui/src/utils/api.ts
@@ -1129,7 +1129,8 @@ export class ApiClient {
     logfile: string,
     model?: string,
     stream: boolean = true,
-    branch: string = 'main'
+    branch: string = 'main',
+    maxTokens?: number
   ): Promise<void> {
     if (!this.isConnected) {
       throw new Error('Not connected to API');
@@ -1172,7 +1173,13 @@ export class ApiClient {
         {
           method: 'POST',
           headers,
-          body: JSON.stringify({ session_id: sessionId, model, branch, stream }),
+          body: JSON.stringify({
+            session_id: sessionId,
+            model,
+            branch,
+            stream,
+            ...(maxTokens !== undefined ? { max_tokens: maxTokens } : {}),
+          }),
           signal: this.controller.signal,
         }
       );


### PR DESCRIPTION
## Description

Adds a **Max tokens** number input to the chat options panel, letting users override the model's default response length. The setting persists across all operations — send, regenerate, rerun, edit/truncate, and initial auto-step — not just new messages.

## Changes

- **ChatInput.tsx**: Number input with min=1, Math.max parsing
- **ChatOptions interface**: Added optional maxTokens field
- **api.ts**: step() gains optional maxTokens parameter, conditionally serialized
- **ConversationState**: New maxTokens field persisted in store
- **useConversation.ts**: All 5 api.step() call sites now pass maxTokens from conversation state; sendMessage stores the value after a successful step

## Fixed

The original PR only threaded maxTokens into sendMessage. The regenerate, rerun, edit/truncate, and initial-step paths all called step() without it, silently dropping the setting. Greptile flagged this in review.

Fixed by storing maxTokens in ConversationState and reading it via use$ observable at all 5 call sites.

## Testing

- npm run typecheck passes
- npm test — all 316 tests pass
- Manual: set max tokens, verify setting is respected on regenerate/rerun/edit operations
