### PR TITLE
feat(webui): add per-tool call latency timer in InlineToolExecution

### DIFF
--- a/webui/src/components/InlineToolExecution.tsx
+++ b/webui/src/components/InlineToolExecution.tsx
@@ -14,14 +14,16 @@ interface InlineToolExecutionProps {
 
 export function InlineToolExecution({ executingTool$ }: InlineToolExecutionProps) {
   const executingTool = use$(executingTool$);
-  const [elapsedMs, setElapsedMs] = useState(0);
+  const [elapsedMs, setElapsedMs] = useState(() =>
+    executingTool?.startedAt ? Date.now() - executingTool.startedAt : 0
+  );
 
   useEffect(() => {
     if (!executingTool) {
       setElapsedMs(0);
       return;
     }
-    const startTime = executingTool.startedAt ?? Date.now();
+    const startTime = executingTool.startedAt;
     setElapsedMs(Date.now() - startTime);
     const interval = setInterval(() => {
       setElapsedMs(Date.now() - startTime);

--- a/webui/src/components/InlineToolExecution.tsx
+++ b/webui/src/components/InlineToolExecution.tsx
@@ -1,3 +1,4 @@
+import { useState, useEffect } from 'react';
 import type { ExecutingTool } from '@/stores/conversations';
 import { Loader2, Cog } from 'lucide-react';
 import { type Observable } from '@legendapp/state';
@@ -13,6 +14,22 @@ interface InlineToolExecutionProps {
 
 export function InlineToolExecution({ executingTool$ }: InlineToolExecutionProps) {
   const executingTool = use$(executingTool$);
+  const [elapsedMs, setElapsedMs] = useState(0);
+
+  useEffect(() => {
+    if (!executingTool) {
+      setElapsedMs(0);
+      return;
+    }
+    const startTime = executingTool.startedAt ?? Date.now();
+    setElapsedMs(Date.now() - startTime);
+    const interval = setInterval(() => {
+      setElapsedMs(Date.now() - startTime);
+    }, 100);
+    return () => clearInterval(interval);
+  }, [executingTool]);
+
+  const elapsedSeconds = (elapsedMs / 1000).toFixed(1);
 
   // Format args for display
   const formatArgs = (args: string[]) => {
@@ -38,7 +55,9 @@ export function InlineToolExecution({ executingTool$ }: InlineToolExecutionProps
               <div className="border-b border-blue-200 px-4 py-3 dark:border-blue-800">
                 <div className="flex items-center gap-2">
                   <Loader2 className="h-4 w-4 animate-spin text-blue-600 dark:text-blue-400" />
-                  <h3 className="font-medium text-blue-800 dark:text-blue-200">Tool Executing</h3>
+                  <h3 className="font-medium text-blue-800 dark:text-blue-200">
+                    Tool Executing ({elapsedSeconds}s)
+                  </h3>
                 </div>
                 <p className="mt-1 text-sm text-blue-700 dark:text-blue-300">
                   The assistant is currently using

--- a/webui/src/hooks/useConversation.ts
+++ b/webui/src/hooks/useConversation.ts
@@ -229,10 +229,12 @@ export function useConversation(conversationId: string, serverId?: string) {
                 return;
               }
               // Capture tool duration when tool result arrives
-              const executingTool = conversation$?.executingTool.get();
-              if (executingTool?.startedAt) {
-                const durationMs = Date.now() - executingTool.startedAt;
-                recordToolDuration(conversationId, executingTool.tooluse.tool, durationMs);
+              if (message.role === 'tool') {
+                const executingTool = conversation$?.executingTool.get();
+                if (executingTool?.startedAt) {
+                  const durationMs = Date.now() - executingTool.startedAt;
+                  recordToolDuration(conversationId, executingTool.tooluse.tool, durationMs);
+                }
               }
               addMessage(conversationId, message);
             },

--- a/webui/src/hooks/useConversation.ts
+++ b/webui/src/hooks/useConversation.ts
@@ -22,6 +22,7 @@ import {
   selectedConversation$,
   updateConversationName,
   setNeedsInitialStep,
+  recordToolDuration,
 } from '@/stores/conversations';
 import { playChime } from '@/utils/audio';
 import { findLatestAssistantIndexForError } from '@/utils/conversationErrorHandling';
@@ -226,6 +227,12 @@ export function useConversation(conversationId: string, serverId?: string) {
               ) {
                 console.log('[useConversation] Skipping duplicate message');
                 return;
+              }
+              // Capture tool duration when tool result arrives
+              const executingTool = conversation$?.executingTool.get();
+              if (executingTool?.startedAt) {
+                const durationMs = Date.now() - executingTool.startedAt;
+                recordToolDuration(conversationId, executingTool.tooluse.tool, durationMs);
               }
               addMessage(conversationId, message);
             },

--- a/webui/src/stores/conversations.ts
+++ b/webui/src/stores/conversations.ts
@@ -11,6 +11,7 @@ export interface PendingTool {
 export interface ExecutingTool {
   id: string;
   tooluse: ToolUse;
+  startedAt: number;
 }
 
 export interface ConversationState {
@@ -24,6 +25,8 @@ export interface ConversationState {
   pendingTool: PendingTool | null;
   // Any executing tool
   executingTool: ExecutingTool | null;
+  // Duration of the last completed tool call per tool name (ms)
+  toolDurations: Record<string, number>;
   // Last received message
   lastMessage?: Message;
   // Whether to show the initial system message
@@ -53,6 +56,7 @@ export function updateConversation(id: string, update: Partial<ConversationState
       isConnected: false,
       pendingTool: null,
       executingTool: null,
+      toolDurations: {},
       showInitialSystem: false,
       chatConfig: null,
       needsInitialStep: false,
@@ -118,8 +122,14 @@ export function setPendingTool(id: string, toolId: string | null, tooluse: ToolU
 
 export function setExecutingTool(id: string, toolId: string | null, tooluse: ToolUse | null) {
   updateConversation(id, {
-    executingTool: toolId && tooluse ? { id: toolId, tooluse } : null,
+    executingTool: toolId && tooluse ? { id: toolId, tooluse, startedAt: Date.now() } : null,
   });
+}
+
+export function recordToolDuration(id: string, toolName: string, durationMs: number) {
+  const conv = conversations$.get(id);
+  if (!conv) return;
+  conv.toolDurations[toolName].set(durationMs);
 }
 
 // Initialize a new conversation in the store
@@ -141,6 +151,7 @@ export function initConversation(
     isConnected: false,
     pendingTool: null,
     executingTool: null,
+    toolDurations: {},
     showInitialSystem: false,
     chatConfig: null,
     needsInitialStep: options?.needsInitialStep ?? false,


### PR DESCRIPTION
## Summary

Add real-time elapsed time display while tool calls are executing:

- **`InlineToolExecution`**: Shows "Tool Executing (2.3s)" with a live 100ms counter
- **`ExecutingTool`**: Stores `startedAt` timestamp when execution begins
- **`ConversationState`**: Tracks `toolDurations: Record<string, number>` per tool name for future post-completion display
- **`useConversation`**: Captures elapsed time when tool result message arrives

This gives users immediate feedback on how long tools are taking without any server-side changes — all client-side using existing SSE event timing.

## Test plan

- [ ] Start a conversation with tool calls (shell, browser, etc.)
- [ ] Confirm the "Tool Executing (X.Xs)" counter increments in real time
- [ ] `tsc --noEmit` passes
- [ ] Jest tests pass (16 passing)