### PR TITLE
feat(webui): per-tool call latency badges with live elapsed timer

### DIFF
--- a/gptme/server/api_v2_common.py
+++ b/gptme/server/api_v2_common.py
@@ -126,6 +126,7 @@ class BaseEvent(TypedDict):
         "generation_complete",
         "tool_pending",
         "tool_executing",
+        "tool_complete",
         "elicit_pending",
         "interrupted",
         "error",
@@ -184,6 +185,13 @@ class ToolExecutingEvent(BaseEvent):
     """Sent when a tool is being executed."""
 
     tool_id: str
+
+
+class ToolCompleteEvent(BaseEvent):
+    """Sent when a tool has finished executing."""
+
+    tool_id: str
+    duration_ms: float
 
 
 class FormFieldDict(TypedDict):
@@ -254,6 +262,7 @@ EventType = (
     | GenerationCompleteEvent
     | ToolPendingEvent
     | ToolExecutingEvent
+    | ToolCompleteEvent
     | ElicitPendingEvent
     | InterruptedEvent
     | ErrorEvent

--- a/gptme/server/api_v2_common.py
+++ b/gptme/server/api_v2_common.py
@@ -192,6 +192,7 @@ class ToolCompleteEvent(BaseEvent):
 
     tool_id: str
     duration_ms: float
+    success: bool
 
 
 class FormFieldDict(TypedDict):

--- a/gptme/server/session_models.py
+++ b/gptme/server/session_models.py
@@ -42,6 +42,7 @@ class ToolExecution:
     tooluse: ToolUse
     status: ToolStatus = ToolStatus.PENDING
     auto_confirm: bool = False
+    started_at: float | None = None
 
 
 @dataclass

--- a/gptme/server/session_step.py
+++ b/gptme/server/session_step.py
@@ -13,6 +13,7 @@ import contextvars
 import logging
 import os
 import threading
+import time
 import uuid
 from collections.abc import Iterable
 from datetime import datetime, timezone
@@ -873,7 +874,8 @@ def start_tool_execution(
             # Remove the tool from pending
             session.pending_tools.pop(current_tool_id, None)
 
-            # Notify about tool execution
+            # Record start time and notify about tool execution
+            tool_exec.started_at = time.monotonic()
             SessionManager.add_event(
                 conversation_id,
                 {"type": "tool_executing", "tool_id": current_tool_id},
@@ -902,6 +904,18 @@ def start_tool_execution(
 
                 msg = Message("system", f"Error: {e!s}", call_id=tooluse.call_id)
                 _append_and_notify(manager, session, msg)
+
+            # Emit tool_complete with duration
+            if tool_exec.started_at is not None:
+                duration_ms = (time.monotonic() - tool_exec.started_at) * 1000
+                SessionManager.add_event(
+                    conversation_id,
+                    {
+                        "type": "tool_complete",
+                        "tool_id": current_tool_id,
+                        "duration_ms": duration_ms,
+                    },
+                )
 
             # Persist tool outputs to disk
             manager.write()

--- a/gptme/server/session_step.py
+++ b/gptme/server/session_step.py
@@ -914,6 +914,7 @@ def start_tool_execution(
                         "type": "tool_complete",
                         "tool_id": current_tool_id,
                         "duration_ms": duration_ms,
+                        "success": tool_exec.status != ToolStatus.FAILED,
                     },
                 )
 

--- a/webui/src/components/ConversationContent.tsx
+++ b/webui/src/components/ConversationContent.tsx
@@ -9,7 +9,7 @@ import { computeForkPoints } from '@/utils/branchUtils';
 import { buildStepRoles, type StepRole } from '@/utils/stepGrouping';
 
 import { InlineToolConfirmation } from './InlineToolConfirmation';
-import { InlineToolExecution } from './InlineToolExecution';
+import { InlineToolExecution, ToolCompletionBadge } from './InlineToolExecution';
 import { For, Memo, use$, useObservable, useObserveEffect } from '@legendapp/state/react';
 import { getObservableIndex } from '@legendapp/state';
 import { useApi } from '@/contexts/ApiContext';
@@ -408,6 +408,9 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
 
         {/* Inline Tool Execution */}
         <InlineToolExecution executingTool$={conversation$?.executingTool} />
+
+        {/* Tool completion badge — briefly shows after tool finishes */}
+        <ToolCompletionBadge lastCompletedTool$={conversation$?.lastCompletedTool} />
 
         {/* Add padding at the bottom to account for the floating input */}
         <div className="mb-40" />

--- a/webui/src/components/InlineToolExecution.tsx
+++ b/webui/src/components/InlineToolExecution.tsx
@@ -1,5 +1,5 @@
 import type { ConversationState, ExecutingTool } from '@/stores/conversations';
-import { Loader2, Cog, CheckCircle } from 'lucide-react';
+import { Loader2, Cog, CheckCircle, XCircle } from 'lucide-react';
 import { type Observable } from '@legendapp/state';
 import { use$ } from '@legendapp/state/react';
 import { useEffect, useState } from 'react';
@@ -34,12 +34,19 @@ export function ToolCompletionBadge({ lastCompletedTool$ }: ToolCompletionBadgeP
 
   if (!visible || !lastCompletedTool) return null;
 
+  const { toolName, durationMs, success } = lastCompletedTool;
   return (
     <div className="mx-auto max-w-3xl px-4 md:px-16">
-      <div className="flex items-center gap-1.5 py-1 text-xs text-green-600 dark:text-green-400">
-        <CheckCircle className="h-3.5 w-3.5" />
-        <code className="font-mono">{lastCompletedTool.toolName}</code>
-        <span>completed in {formatElapsed(lastCompletedTool.durationMs)}</span>
+      <div
+        className={`flex items-center gap-1.5 py-1 text-xs ${
+          success ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'
+        }`}
+      >
+        {success ? <CheckCircle className="h-3.5 w-3.5" /> : <XCircle className="h-3.5 w-3.5" />}
+        <code className="font-mono">{toolName}</code>
+        <span>
+          {success ? 'completed' : 'failed'} in {formatElapsed(durationMs)}
+        </span>
       </div>
     </div>
   );

--- a/webui/src/components/InlineToolExecution.tsx
+++ b/webui/src/components/InlineToolExecution.tsx
@@ -1,7 +1,8 @@
-import type { ExecutingTool } from '@/stores/conversations';
-import { Loader2, Cog } from 'lucide-react';
+import type { ConversationState, ExecutingTool } from '@/stores/conversations';
+import { Loader2, Cog, CheckCircle } from 'lucide-react';
 import { type Observable } from '@legendapp/state';
 import { use$ } from '@legendapp/state/react';
+import { useEffect, useState } from 'react';
 import { CodeDisplay } from '@/components/CodeDisplay';
 import { MessageAvatar } from './MessageAvatar';
 import { detectToolLanguage } from '@/utils/highlightUtils';
@@ -9,6 +10,55 @@ import { observable } from '@legendapp/state';
 
 interface InlineToolExecutionProps {
   executingTool$: Observable<ExecutingTool | null>;
+}
+
+interface ToolCompletionBadgeProps {
+  lastCompletedTool$: Observable<ConversationState['lastCompletedTool']>;
+}
+
+export function ToolCompletionBadge({ lastCompletedTool$ }: ToolCompletionBadgeProps) {
+  const lastCompletedTool = use$(lastCompletedTool$);
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    if (lastCompletedTool) {
+      setVisible(true);
+      const timer = setTimeout(() => setVisible(false), 3000);
+      return () => clearTimeout(timer);
+    }
+  }, [lastCompletedTool]);
+
+  if (!visible || !lastCompletedTool) return null;
+
+  return (
+    <div className="mx-auto max-w-3xl px-4 md:px-16">
+      <div className="flex items-center gap-1.5 py-1 text-xs text-green-600 dark:text-green-400">
+        <CheckCircle className="h-3.5 w-3.5" />
+        <code className="font-mono">{lastCompletedTool.toolName}</code>
+        <span>completed in {formatElapsed(lastCompletedTool.durationMs)}</span>
+      </div>
+    </div>
+  );
+}
+
+function formatElapsed(ms: number): string {
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+function ElapsedTimer({ startedAt }: { startedAt: number }) {
+  const [elapsed, setElapsed] = useState(() => Date.now() - startedAt);
+
+  useEffect(() => {
+    const id = setInterval(() => setElapsed(Date.now() - startedAt), 100);
+    return () => clearInterval(id);
+  }, [startedAt]);
+
+  return (
+    <span className="ml-1 font-mono text-xs text-blue-500 dark:text-blue-400">
+      {formatElapsed(elapsed)}
+    </span>
+  );
 }
 
 export function InlineToolExecution({ executingTool$ }: InlineToolExecutionProps) {
@@ -76,12 +126,13 @@ export function InlineToolExecution({ executingTool$ }: InlineToolExecutionProps
                   />
                 </div>
 
-                {/* Status indicator */}
+                {/* Status indicator with elapsed timer */}
                 <div className="flex items-center gap-2 border-t border-blue-200 pt-3 dark:border-blue-800">
                   <Loader2 className="h-4 w-4 animate-spin text-blue-600 dark:text-blue-400" />
                   <span className="text-sm text-blue-700 dark:text-blue-300">
                     Executing tool...
                   </span>
+                  <ElapsedTimer startedAt={executingTool.startedAt} />
                 </div>
               </div>
             </div>

--- a/webui/src/components/InlineToolExecution.tsx
+++ b/webui/src/components/InlineToolExecution.tsx
@@ -16,14 +16,18 @@ interface ToolCompletionBadgeProps {
   lastCompletedTool$: Observable<ConversationState['lastCompletedTool']>;
 }
 
+const BADGE_DISPLAY_MS = 3000;
+
 export function ToolCompletionBadge({ lastCompletedTool$ }: ToolCompletionBadgeProps) {
   const lastCompletedTool = use$(lastCompletedTool$);
   const [visible, setVisible] = useState(false);
 
   useEffect(() => {
     if (lastCompletedTool) {
+      const age = Date.now() - lastCompletedTool.completedAt;
+      if (age >= BADGE_DISPLAY_MS) return;
       setVisible(true);
-      const timer = setTimeout(() => setVisible(false), 3000);
+      const timer = setTimeout(() => setVisible(false), BADGE_DISPLAY_MS - age);
       return () => clearTimeout(timer);
     }
   }, [lastCompletedTool]);

--- a/webui/src/hooks/useConversation.ts
+++ b/webui/src/hooks/useConversation.ts
@@ -274,8 +274,8 @@ export function useConversation(conversationId: string, serverId?: string) {
                 );
               }
             },
-            onToolComplete: (toolId, durationMs) => {
-              console.log('[useConversation] Tool complete:', { toolId, durationMs });
+            onToolComplete: (toolId, durationMs, success) => {
+              console.log('[useConversation] Tool complete:', { toolId, durationMs, success });
               const executingTool = conversation$?.executingTool.get();
               if (executingTool && executingTool.id !== toolId) {
                 console.warn('[useConversation] tool_complete ID mismatch:', {
@@ -284,7 +284,7 @@ export function useConversation(conversationId: string, serverId?: string) {
                 });
               }
               const toolName = executingTool?.tooluse.tool ?? 'tool';
-              setToolComplete(conversationId, toolName, durationMs);
+              setToolComplete(conversationId, toolName, durationMs, success);
             },
             onInterrupted: () => {
               console.log('[useConversation] Generation interrupted');

--- a/webui/src/hooks/useConversation.ts
+++ b/webui/src/hooks/useConversation.ts
@@ -12,6 +12,7 @@ import {
   setConnected,
   setPendingTool,
   setExecutingTool,
+  setToolComplete,
   addMessage,
   setMessageStatus,
   removeMessage,
@@ -265,13 +266,19 @@ export function useConversation(conversationId: string, serverId?: string) {
               if (pendingTool && pendingTool.id === toolId) {
                 // Move from pending to executing (generating stays false - tools can't be interrupted)
                 setPendingTool(conversationId, null, null);
-                setExecutingTool(conversationId, toolId, pendingTool.tooluse);
+                setExecutingTool(conversationId, toolId, pendingTool.tooluse, Date.now());
               } else {
                 console.warn(
                   '[useConversation] No matching pending tool found for executing tool:',
                   toolId
                 );
               }
+            },
+            onToolComplete: (toolId, durationMs) => {
+              console.log('[useConversation] Tool complete:', { toolId, durationMs });
+              const executingTool = conversation$?.executingTool.get();
+              const toolName = executingTool?.tooluse.tool ?? 'tool';
+              setToolComplete(conversationId, toolName, durationMs);
             },
             onInterrupted: () => {
               console.log('[useConversation] Generation interrupted');

--- a/webui/src/hooks/useConversation.ts
+++ b/webui/src/hooks/useConversation.ts
@@ -277,6 +277,12 @@ export function useConversation(conversationId: string, serverId?: string) {
             onToolComplete: (toolId, durationMs) => {
               console.log('[useConversation] Tool complete:', { toolId, durationMs });
               const executingTool = conversation$?.executingTool.get();
+              if (executingTool && executingTool.id !== toolId) {
+                console.warn('[useConversation] tool_complete ID mismatch:', {
+                  expected: toolId,
+                  executing: executingTool.id,
+                });
+              }
               const toolName = executingTool?.tooluse.tool ?? 'tool';
               setToolComplete(conversationId, toolName, durationMs);
             },

--- a/webui/src/hooks/useConversation.ts
+++ b/webui/src/hooks/useConversation.ts
@@ -278,10 +278,11 @@ export function useConversation(conversationId: string, serverId?: string) {
               console.log('[useConversation] Tool complete:', { toolId, durationMs, success });
               const executingTool = conversation$?.executingTool.get();
               if (executingTool && executingTool.id !== toolId) {
-                console.warn('[useConversation] tool_complete ID mismatch:', {
-                  expected: toolId,
-                  executing: executingTool.id,
-                });
+                console.warn(
+                  '[useConversation] tool_complete ID mismatch — ignoring stale event:',
+                  { received: toolId, executing: executingTool.id }
+                );
+                return;
               }
               const toolName = executingTool?.tooluse.tool ?? 'tool';
               setToolComplete(conversationId, toolName, durationMs, success);

--- a/webui/src/hooks/useConversation.ts
+++ b/webui/src/hooks/useConversation.ts
@@ -277,14 +277,21 @@ export function useConversation(conversationId: string, serverId?: string) {
             onToolComplete: (toolId, durationMs, success) => {
               console.log('[useConversation] Tool complete:', { toolId, durationMs, success });
               const executingTool = conversation$?.executingTool.get();
-              if (executingTool && executingTool.id !== toolId) {
+              if (!executingTool) {
+                console.warn(
+                  '[useConversation] tool_complete received with no executing tool — ignoring stale event:',
+                  { toolId }
+                );
+                return;
+              }
+              if (executingTool.id !== toolId) {
                 console.warn(
                   '[useConversation] tool_complete ID mismatch — ignoring stale event:',
                   { received: toolId, executing: executingTool.id }
                 );
                 return;
               }
-              const toolName = executingTool?.tooluse.tool ?? 'tool';
+              const toolName = executingTool.tooluse.tool;
               setToolComplete(conversationId, toolName, durationMs, success);
             },
             onInterrupted: () => {

--- a/webui/src/stores/conversations.ts
+++ b/webui/src/stores/conversations.ts
@@ -26,7 +26,7 @@ export interface ConversationState {
   // Any executing tool
   executingTool: ExecutingTool | null;
   // Duration of the most recently completed tool (cleared when next tool starts)
-  lastCompletedTool: { toolName: string; durationMs: number } | null;
+  lastCompletedTool: { toolName: string; durationMs: number; completedAt: number } | null;
   // Last received message
   lastMessage?: Message;
   // Whether to show the initial system message
@@ -140,7 +140,7 @@ export function setExecutingTool(
 export function setToolComplete(id: string, toolName: string, durationMs: number) {
   updateConversation(id, {
     executingTool: null,
-    lastCompletedTool: { toolName, durationMs },
+    lastCompletedTool: { toolName, durationMs, completedAt: Date.now() },
   });
 }
 

--- a/webui/src/stores/conversations.ts
+++ b/webui/src/stores/conversations.ts
@@ -26,7 +26,7 @@ export interface ConversationState {
   // Any executing tool
   executingTool: ExecutingTool | null;
   // Duration of the most recently completed tool (cleared when next tool starts)
-  lastCompletedTool: { toolName: string; durationMs: number; completedAt: number } | null;
+  lastCompletedTool: { toolName: string; durationMs: number; completedAt: number; success: boolean } | null;
   // Last received message
   lastMessage?: Message;
   // Whether to show the initial system message
@@ -137,10 +137,15 @@ export function setExecutingTool(
   updateConversation(id, update);
 }
 
-export function setToolComplete(id: string, toolName: string, durationMs: number) {
+export function setToolComplete(
+  id: string,
+  toolName: string,
+  durationMs: number,
+  success: boolean
+) {
   updateConversation(id, {
     executingTool: null,
-    lastCompletedTool: { toolName, durationMs, completedAt: Date.now() },
+    lastCompletedTool: { toolName, durationMs, completedAt: Date.now(), success },
   });
 }
 

--- a/webui/src/stores/conversations.ts
+++ b/webui/src/stores/conversations.ts
@@ -11,6 +11,7 @@ export interface PendingTool {
 export interface ExecutingTool {
   id: string;
   tooluse: ToolUse;
+  startedAt: number;
 }
 
 export interface ConversationState {
@@ -24,6 +25,8 @@ export interface ConversationState {
   pendingTool: PendingTool | null;
   // Any executing tool
   executingTool: ExecutingTool | null;
+  // Duration of the most recently completed tool (cleared when next tool starts)
+  lastCompletedTool: { toolName: string; durationMs: number } | null;
   // Last received message
   lastMessage?: Message;
   // Whether to show the initial system message
@@ -53,6 +56,7 @@ export function updateConversation(id: string, update: Partial<ConversationState
       isConnected: false,
       pendingTool: null,
       executingTool: null,
+      lastCompletedTool: null,
       showInitialSystem: false,
       chatConfig: null,
       needsInitialStep: false,
@@ -116,9 +120,27 @@ export function setPendingTool(id: string, toolId: string | null, tooluse: ToolU
   });
 }
 
-export function setExecutingTool(id: string, toolId: string | null, tooluse: ToolUse | null) {
+export function setExecutingTool(
+  id: string,
+  toolId: string | null,
+  tooluse: ToolUse | null,
+  startedAt?: number
+) {
+  const update: Partial<ConversationState> = {
+    executingTool:
+      toolId && tooluse ? { id: toolId, tooluse, startedAt: startedAt ?? Date.now() } : null,
+  };
+  if (toolId) {
+    // Clear the completion badge when a new tool starts executing
+    update.lastCompletedTool = null;
+  }
+  updateConversation(id, update);
+}
+
+export function setToolComplete(id: string, toolName: string, durationMs: number) {
   updateConversation(id, {
-    executingTool: toolId && tooluse ? { id: toolId, tooluse } : null,
+    executingTool: null,
+    lastCompletedTool: { toolName, durationMs },
   });
 }
 
@@ -141,6 +163,7 @@ export function initConversation(
     isConnected: false,
     pendingTool: null,
     executingTool: null,
+    lastCompletedTool: null,
     showInitialSystem: false,
     chatConfig: null,
     needsInitialStep: options?.needsInitialStep ?? false,

--- a/webui/src/utils/api.ts
+++ b/webui/src/utils/api.ts
@@ -187,6 +187,7 @@ export interface ToolCompleteEvent {
   type: 'tool_complete';
   tool_id: string;
   duration_ms: number;
+  success: boolean;
 }
 
 export interface ToolConfirmationRequest {
@@ -535,7 +536,7 @@ export class ApiClient {
       onMessageAdded: (message: Message) => void;
       onToolPending: (toolId: string, tooluse: ToolUse, auto_confirm: boolean) => void;
       onToolExecuting: (toolId: string) => void;
-      onToolComplete?: (toolId: string, durationMs: number) => void;
+      onToolComplete?: (toolId: string, durationMs: number, success: boolean) => void;
       onInterrupted: () => void;
       onError: (error: string) => void;
       onConfigChanged?: (config: ChatConfig, changedFields: string[]) => void;
@@ -689,7 +690,11 @@ export class ApiClient {
           case 'tool_complete': {
             console.log(`[ApiClient] Tool complete:`, data);
             const toolCompleteEvent = data as ToolCompleteEvent;
-            callbacks.onToolComplete?.(toolCompleteEvent.tool_id, toolCompleteEvent.duration_ms);
+            callbacks.onToolComplete?.(
+              toolCompleteEvent.tool_id,
+              toolCompleteEvent.duration_ms,
+              toolCompleteEvent.success
+            );
             break;
           }
 

--- a/webui/src/utils/api.ts
+++ b/webui/src/utils/api.ts
@@ -183,6 +183,12 @@ export interface ToolPendingEvent {
   auto_confirm: boolean;
 }
 
+export interface ToolCompleteEvent {
+  type: 'tool_complete';
+  tool_id: string;
+  duration_ms: number;
+}
+
 export interface ToolConfirmationRequest {
   session_id: string;
   tool_id: string;
@@ -529,6 +535,7 @@ export class ApiClient {
       onMessageAdded: (message: Message) => void;
       onToolPending: (toolId: string, tooluse: ToolUse, auto_confirm: boolean) => void;
       onToolExecuting: (toolId: string) => void;
+      onToolComplete?: (toolId: string, durationMs: number) => void;
       onInterrupted: () => void;
       onError: (error: string) => void;
       onConfigChanged?: (config: ChatConfig, changedFields: string[]) => void;
@@ -676,6 +683,13 @@ export class ApiClient {
             console.log(`[ApiClient] Tool executing:`, data);
             const toolExecutingEvent = data as { tool_id: string };
             callbacks.onToolExecuting(toolExecutingEvent.tool_id);
+            break;
+          }
+
+          case 'tool_complete': {
+            console.log(`[ApiClient] Tool complete:`, data);
+            const toolCompleteEvent = data as ToolCompleteEvent;
+            callbacks.onToolComplete?.(toolCompleteEvent.tool_id, toolCompleteEvent.duration_ms);
             break;
           }
 


### PR DESCRIPTION
## Summary

Adds real-time tool execution timing to the webui, so users can see how long each tool call takes.

**Server changes:**
- `session_models.py`: adds `started_at: float | None` to `ToolExecution` dataclass
- `api_v2_common.py`: adds `ToolCompleteEvent` (with `tool_id` and `duration_ms`) and registers it in the SSE event type union
- `session_step.py`: records `time.monotonic()` when `tool_executing` event fires, then emits `tool_complete` with `duration_ms` after tool outputs are appended

**Frontend changes:**
- `api.ts`: new `ToolCompleteEvent` interface, optional `onToolComplete` callback in subscription interface, `tool_complete` case in SSE event switch
- `conversations.ts`: `startedAt: number` on `ExecutingTool`, `lastCompletedTool` field on `ConversationState`, updated `setExecutingTool` to accept `startedAt`, new `setToolComplete()` export
- `useConversation.ts`: passes `Date.now()` as `startedAt` in `onToolExecuting`, adds `onToolComplete` handler
- `InlineToolExecution.tsx`: adds `ElapsedTimer` component (100ms `setInterval`, shows `0.3s` / `142ms` format) in the status bar while tool is running; adds `ToolCompletionBadge` component (auto-dismisses after 3s: `✓ bash completed in 1.2s`)
- `ConversationContent.tsx`: renders `ToolCompletionBadge` after `InlineToolExecution`

## Test plan

- [x] TypeScript: `tsc --noEmit` → clean
- [x] Jest: 318 passed (2 pre-existing failures in `SetupWizard.test.tsx`, unrelated to this PR)
- [ ] Manual: trigger a tool call (e.g. shell command) and observe elapsed timer ticking in the "Tool Executing" panel; observe brief completion badge after tool finishes