### PR TITLE
refactor(hooks): use typed HookData dataclass for tool execution hooks

### DIFF
--- a/gptme/hooks/auto_snapshots.py
+++ b/gptme/hooks/auto_snapshots.py
@@ -56,7 +56,7 @@ if TYPE_CHECKING:
     from collections.abc import Generator
 
     from ..hooks import StopPropagation
-    from ..logmanager import Log
+    from ..hooks.types import ToolExecutePostData, ToolExecutePreData
     from ..message import Message
 
 logger = logging.getLogger(__name__)
@@ -223,19 +223,20 @@ def _shadow_for(workspace: Path | None) -> Shadow | None:
 
 
 def _pre(
-    log: Log, workspace: Path | None, tool_use: Any
+    data: ToolExecutePreData,
 ) -> Generator[Message | StopPropagation, None, None]:
     """Capture pre-tool snapshot if the tool is mutating."""
     if not _enabled():
         return
-    if tool_use is None:
+    if data.tool_use is None:
         return
+    tool_use = data.tool_use
     tool_name = getattr(tool_use, "tool", None) or ""
     content = _tool_payload(tool_use)
     if not classify_tool_use(tool_name, content):
         _pre_tree_var.set(None)
         return
-    shadow = _shadow_for(workspace)
+    shadow = _shadow_for(data.workspace)
     if shadow is None:
         return
     try:
@@ -253,18 +254,19 @@ def _pre(
 
 
 def _post(
-    log: Log, workspace: Path | None, tool_use: Any, **kwargs: Any
+    data: ToolExecutePostData,
 ) -> Generator[Message | StopPropagation, None, None]:
     """Emit post-tool snapshot only when the workspace tree actually changed."""
     if not _enabled():
         return
-    if tool_use is None:
+    if data.tool_use is None:
         return
+    tool_use = data.tool_use
     tool_name = getattr(tool_use, "tool", None) or ""
     content = _tool_payload(tool_use)
     if not classify_tool_use(tool_name, content):
         return
-    shadow = _shadow_for(workspace)
+    shadow = _shadow_for(data.workspace)
     if shadow is None:
         return
     try:

--- a/gptme/hooks/aw_watcher_agent.py
+++ b/gptme/hooks/aw_watcher_agent.py
@@ -22,7 +22,7 @@ import subprocess
 import time
 from contextvars import ContextVar
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from ..hooks import HookType, register_hook
 from ..llm.models import get_default_model

--- a/gptme/hooks/aw_watcher_agent.py
+++ b/gptme/hooks/aw_watcher_agent.py
@@ -34,9 +34,8 @@ if TYPE_CHECKING:
     from collections.abc import Generator
 
     from ..hooks import StopPropagation
-    from ..logmanager import Log
+    from ..hooks.types import ToolExecutePostData, ToolExecutePreData
     from ..message import Message
-    from ..tools.base import ToolUse
 
 logger = logging.getLogger(__name__)
 
@@ -177,12 +176,9 @@ def emit_end(
 
 
 def record_tool_start(
-    log: Log,
-    workspace: Path | None,
-    tool_use: ToolUse,
+    data: ToolExecutePreData,
 ) -> Generator[Message | StopPropagation, None, None]:
     """Record the start time for a tool so the post hook can emit duration."""
-    del log, workspace
     if not _enabled():
         return
     tool_start_times = _ensure_tool_start_times()
@@ -192,21 +188,23 @@ def record_tool_start(
     stale = [k for k, v in tool_start_times.items() if now - v > _MAX_TOOL_AGE_S]
     for k in stale:
         del tool_start_times[k]
-    tool_start_times[id(tool_use)] = now
+    if data.tool_use is not None:
+        tool_start_times[id(data.tool_use)] = now
     _tool_start_times_var.set(tool_start_times)
     return
     yield
 
 
 def emit_tool_activity(
-    log: Log,
-    workspace: Path | None,
-    tool_use: ToolUse,
-    **kwargs: Any,
+    data: ToolExecutePostData,
 ) -> Generator[Message | StopPropagation, None, None]:
     """Emit one per-tool activity heartbeat after a tool finishes."""
-    del log
     if not _enabled():
+        return
+
+    tool_use = data.tool_use
+    workspace = data.workspace
+    if tool_use is None:
         return
 
     session_id = _current_tool_session_id()

--- a/gptme/hooks/cwd_changed.py
+++ b/gptme/hooks/cwd_changed.py
@@ -8,16 +8,20 @@ implementing their own pre/post CWD comparison.
 See: https://github.com/gptme/gptme/issues/1521
 """
 
+from __future__ import annotations
+
 import logging
 import os
-from collections.abc import Generator
 from contextvars import ContextVar
-from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING
 
 from ..hooks import HookType, StopPropagation, register_hook, trigger_hook
-from ..logmanager import Log
-from ..message import Message
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from ..hooks.types import ToolExecutePostData, ToolExecutePreData
+    from ..message import Message
 
 logger = logging.getLogger(__name__)
 
@@ -26,7 +30,7 @@ _cwd_before_var: ContextVar[str | None] = ContextVar("cwd_changed_before", defau
 
 
 def _store_cwd(
-    log: Log, workspace: Path | None, tool_use: Any
+    data: ToolExecutePreData,
 ) -> Generator[Message | StopPropagation, None, None]:
     """Store the current working directory before tool execution."""
     try:
@@ -39,7 +43,7 @@ def _store_cwd(
 
 
 def _detect_change(
-    log: Log, workspace: Path | None, tool_use: Any, **kwargs: Any
+    data: ToolExecutePostData,
 ) -> Generator[Message | StopPropagation, None, None]:
     """Detect CWD changes and trigger CWD_CHANGED hooks."""
     try:
@@ -53,11 +57,11 @@ def _detect_change(
             logger.debug(f"CWD changed: {prev_cwd} → {current_cwd}")
             yield from trigger_hook(
                 HookType.CWD_CHANGED,
-                log=log,
-                workspace=workspace,
+                log=data.log,
+                workspace=data.workspace,
                 old_cwd=prev_cwd,
                 new_cwd=current_cwd,
-                tool_use=tool_use,
+                tool_use=data.tool_use,
             )
     except Exception as e:
         logger.exception(f"Error detecting CWD change: {e}")
@@ -75,6 +79,5 @@ def register() -> None:
         "cwd_changed.detect",
         HookType.TOOL_EXECUTE_POST,
         _detect_change,
-        priority=100,  # High priority — trigger before other POST hooks
+        priority=100,  # High priority — run first to detect CWD changes
     )
-    logger.debug("Registered centralized CWD change detection")

--- a/gptme/hooks/injection_screening.py
+++ b/gptme/hooks/injection_screening.py
@@ -10,13 +10,10 @@ Hook type: TOOL_EXECUTE_POST
 import logging
 import re
 from collections.abc import Generator
-from pathlib import Path
-from typing import Any
 
 from ..hooks import HookType, register_hook
-from ..logmanager import Log
+from ..hooks.types import ToolExecutePostData
 from ..message import Message
-from ..tools.base import ToolUse
 
 logger = logging.getLogger(__name__)
 
@@ -84,11 +81,7 @@ def _has_injection_pattern(text: str | None) -> tuple[bool, str]:
 
 
 def injection_screening(
-    log: Log | None = None,
-    workspace: Path | None = None,
-    tool_use: ToolUse | None = None,
-    result_msgs: list[Message] | None = None,
-    **kwargs: Any,
+    data: ToolExecutePostData,
 ) -> Generator[Message, None, None]:
     """TOOL_EXECUTE_POST hook that flags untrusted external content in tool output.
 
@@ -96,6 +89,8 @@ def injection_screening(
     patterns, this hook yields a system warning that appears before the model
     processes the tool results.
     """
+    tool_use = data.tool_use
+    result_msgs = data.result_msgs
     if tool_use is None or not result_msgs:
         return
 

--- a/gptme/hooks/registry.py
+++ b/gptme/hooks/registry.py
@@ -35,7 +35,8 @@ from .types import (
     SessionEndHook,
     SessionStartHook,
     StopPropagation,
-    ToolExecuteHook,
+    ToolExecutePostHook,
+    ToolExecutePreHook,
 )
 
 logger = logging.getLogger(__name__)
@@ -428,11 +429,19 @@ def register_hook(
 @overload
 def register_hook(
     name: str,
-    hook_type: Literal[
-        HookType.TOOL_EXECUTE_PRE,
-        HookType.TOOL_EXECUTE_POST,
-    ],
-    func: ToolExecuteHook,
+    hook_type: Literal[HookType.TOOL_EXECUTE_PRE],
+    func: ToolExecutePreHook,
+    priority: int = 0,
+    enabled: bool = True,
+    async_mode: bool = False,
+) -> None: ...
+
+
+@overload
+def register_hook(
+    name: str,
+    hook_type: Literal[HookType.TOOL_EXECUTE_POST],
+    func: ToolExecutePostHook,
     priority: int = 0,
     enabled: bool = True,
     async_mode: bool = False,

--- a/gptme/hooks/tests/test_aw_watcher_agent.py
+++ b/gptme/hooks/tests/test_aw_watcher_agent.py
@@ -2,11 +2,12 @@
 
 from pathlib import Path
 from types import SimpleNamespace
-from typing import cast
+from typing import Any, cast
 from unittest.mock import patch
 
 from gptme.hooks import HookRegistry, HookType, get_registry, set_registry, trigger_hook
 from gptme.hooks.aw_watcher_agent import emit_end, emit_start
+from gptme.hooks.types import ToolExecutePostData, ToolExecutePreData
 from gptme.logmanager import LogManager, _current_log_var
 from gptme.tools.base import ToolUse
 
@@ -138,9 +139,11 @@ def test_tool_activity_hooks_emit_heartbeat_when_registered(monkeypatch):
                 list(
                     trigger_hook(
                         HookType.TOOL_EXECUTE_PRE,
-                        log=SimpleNamespace(messages=[]),
-                        workspace=Path("/tmp/workspace"),
-                        tool_use=tool_use,
+                        ToolExecutePreData(
+                            log=cast(Any, SimpleNamespace(messages=[])),
+                            workspace=Path("/tmp/workspace"),
+                            tool_use=tool_use,
+                        ),
                     )
                 )
                 == []
@@ -149,9 +152,11 @@ def test_tool_activity_hooks_emit_heartbeat_when_registered(monkeypatch):
                 list(
                     trigger_hook(
                         HookType.TOOL_EXECUTE_POST,
-                        log=SimpleNamespace(messages=[]),
-                        workspace=Path("/tmp/workspace"),
-                        tool_use=tool_use,
+                        ToolExecutePostData(
+                            log=cast(Any, SimpleNamespace(messages=[])),
+                            workspace=Path("/tmp/workspace"),
+                            tool_use=tool_use,
+                        ),
                     )
                 )
                 == []

--- a/gptme/hooks/tests/test_injection_screening.py
+++ b/gptme/hooks/tests/test_injection_screening.py
@@ -10,6 +10,7 @@ from ..injection_screening import (
     injection_screening,
     register,
 )
+from ..types import ToolExecutePostData
 
 
 def _make_tool_use(tool: str, content: str | None = None) -> ToolUse:
@@ -106,7 +107,8 @@ def _run_hook(
 ) -> list[Message]:
     tool_use = _make_tool_use(tool, content)
     result_msgs = _make_result_msgs(*result_texts)
-    return list(injection_screening(tool_use=tool_use, result_msgs=result_msgs))
+    data = ToolExecutePostData(tool_use=tool_use, result_msgs=tuple(result_msgs))
+    return list(injection_screening(data))
 
 
 def test_hook_flags_injection_in_browser_output():
@@ -169,12 +171,16 @@ def test_hook_no_warning_for_shell_output():
 
 def test_hook_no_warning_when_no_result_msgs():
     tool_use = _make_tool_use("browser")
-    result = list(injection_screening(tool_use=tool_use, result_msgs=None))
+    result = list(
+        injection_screening(ToolExecutePostData(tool_use=tool_use, result_msgs=None))
+    )
     assert result == []
 
 
 def test_hook_no_warning_when_no_tool_use():
-    result = list(injection_screening(tool_use=None, result_msgs=[]))
+    result = list(
+        injection_screening(ToolExecutePostData(tool_use=None, result_msgs=()))
+    )
     assert result == []
 
 

--- a/gptme/hooks/tests/test_time_awareness.py
+++ b/gptme/hooks/tests/test_time_awareness.py
@@ -2,7 +2,6 @@
 
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any, cast
 
 import pytest
 
@@ -12,6 +11,7 @@ from gptme.hooks.time_awareness import (
     _shown_milestones_var,
     add_time_message,
 )
+from gptme.hooks.types import ToolExecutePostData
 from gptme.message import Message
 
 
@@ -37,7 +37,9 @@ def _call_add_time_message(
     """Helper to call add_time_message with a dummy log, returning only Messages."""
     # The hook doesn't use the log parameter, so we pass a sentinel
     results = list(
-        add_time_message(log=cast(Any, None), workspace=workspace, tool_use=None)
+        add_time_message(
+            ToolExecutePostData(log=None, workspace=workspace, tool_use=None)
+        )
     )
     return [r for r in results if isinstance(r, Message)]
 

--- a/gptme/hooks/tests/test_token_awareness.py
+++ b/gptme/hooks/tests/test_token_awareness.py
@@ -16,6 +16,7 @@ from gptme.hooks.token_awareness import (
     add_token_budget,
     add_token_usage_warning,
 )
+from gptme.hooks.types import ToolExecutePostData
 from gptme.message import Message
 
 
@@ -102,7 +103,11 @@ class TestAddTokenUsageWarning:
             return_value=_make_model(),
         ):
             log: Any = None
-            msgs = list(add_token_usage_warning(log, None, None))
+            msgs = list(
+                add_token_usage_warning(
+                    ToolExecutePostData(log=log, workspace=None, tool_use=None)
+                )
+            )
         assert msgs == []
 
     def test_no_model_yields_nothing(self):
@@ -112,7 +117,11 @@ class TestAddTokenUsageWarning:
             return_value=None,
         ):
             log = self._make_log()
-            msgs = list(add_token_usage_warning(log, None, None))
+            msgs = list(
+                add_token_usage_warning(
+                    ToolExecutePostData(log=log, workspace=None, tool_use=None)
+                )
+            )
         assert msgs == []
 
     def test_no_workspace_always_warns(self):
@@ -129,7 +138,11 @@ class TestAddTokenUsageWarning:
             ),
         ):
             log = self._make_log()
-            msgs = list(add_token_usage_warning(log, None, None))
+            msgs = list(
+                add_token_usage_warning(
+                    ToolExecutePostData(log=log, workspace=None, tool_use=None)
+                )
+            )
         assert len(msgs) == 1
         msg = cast(Message, msgs[0])
         assert msg.role == "system"
@@ -152,7 +165,11 @@ class TestAddTokenUsageWarning:
             ),
         ):
             log = self._make_log()
-            msgs = list(add_token_usage_warning(log, workspace, None))
+            msgs = list(
+                add_token_usage_warning(
+                    ToolExecutePostData(log=log, workspace=workspace, tool_use=None)
+                )
+            )
 
         # 110k / 200k = 55% → crosses 50% threshold → should warn
         assert len(msgs) == 1
@@ -176,7 +193,11 @@ class TestAddTokenUsageWarning:
                 return_value=5_000,
             ),
         ):
-            list(add_token_usage_warning(log1, workspace, None))
+            list(
+                add_token_usage_warning(
+                    ToolExecutePostData(log=log1, workspace=workspace, tool_use=None)
+                )
+            )
 
         # Add more messages
         msgs2 = msgs1 + [Message("user", "more"), Message("assistant", "ok")]
@@ -195,7 +216,11 @@ class TestAddTokenUsageWarning:
             # Second call: total = 5000 + 5000 = 10000
             # 10k / 200k = 5% → below thresholds
             # But (10000 - 0) >= 10000 → WARNING_INTERVAL threshold crossed
-            msgs = list(add_token_usage_warning(log2, workspace, None))
+            msgs = list(
+                add_token_usage_warning(
+                    ToolExecutePostData(log=log2, workspace=workspace, tool_use=None)
+                )
+            )
 
         assert len(msgs) == 1
         assert "10000/200000" in cast(Message, msgs[0]).content
@@ -216,7 +241,11 @@ class TestAddTokenUsageWarning:
             ),
         ):
             log = self._make_log()
-            list(add_token_usage_warning(log, workspace, None))
+            list(
+                add_token_usage_warning(
+                    ToolExecutePostData(log=log, workspace=workspace, tool_use=None)
+                )
+            )
 
         # Now call again with no new messages → no token change → no warning
         with (
@@ -229,7 +258,11 @@ class TestAddTokenUsageWarning:
                 return_value=0,
             ),
         ):
-            msgs = list(add_token_usage_warning(log, workspace, None))
+            msgs = list(
+                add_token_usage_warning(
+                    ToolExecutePostData(log=log, workspace=workspace, tool_use=None)
+                )
+            )
         assert msgs == []
 
     def test_percentage_threshold_crossing(self, tmp_path: Path):
@@ -249,7 +282,11 @@ class TestAddTokenUsageWarning:
             ),
         ):
             log = self._make_log()
-            list(add_token_usage_warning(log, workspace, None))
+            list(
+                add_token_usage_warning(
+                    ToolExecutePostData(log=log, workspace=workspace, tool_use=None)
+                )
+            )
 
         # Now we're at 40k, last_warning=40k. Add 36k more → 76k → crosses 75%
         msgs2 = [Message("user", "hi")] * 4
@@ -265,7 +302,11 @@ class TestAddTokenUsageWarning:
                 return_value=36_000,
             ),
         ):
-            msgs = list(add_token_usage_warning(log2, workspace, None))
+            msgs = list(
+                add_token_usage_warning(
+                    ToolExecutePostData(log=log2, workspace=workspace, tool_use=None)
+                )
+            )
 
         assert len(msgs) == 1
         assert "76000/100000" in cast(Message, msgs[0]).content
@@ -277,7 +318,11 @@ class TestAddTokenUsageWarning:
             side_effect=RuntimeError("bad"),
         ):
             log = self._make_log()
-            msgs = list(add_token_usage_warning(log, tmp_path, None))
+            msgs = list(
+                add_token_usage_warning(
+                    ToolExecutePostData(log=log, workspace=tmp_path, tool_use=None)
+                )
+            )
         assert msgs == []
 
     def test_warning_constants(self):

--- a/gptme/hooks/tests/test_tool_target_instructions.py
+++ b/gptme/hooks/tests/test_tool_target_instructions.py
@@ -21,6 +21,7 @@ from gptme.hooks.tool_target_instructions import (
     _extract_paths,
     on_tool_execute_post,
 )
+from gptme.hooks.types import ToolExecutePostData
 from gptme.logmanager import Log
 from gptme.message import Message
 from gptme.prompts import _loaded_agent_files_var
@@ -132,7 +133,9 @@ class TestOnToolExecutePost:
 
         use = _make_use("read", kwargs={"path": str(target)})
         msgs = list(
-            on_tool_execute_post(log=empty_log, workspace=tmp_path, tool_use=use)
+            on_tool_execute_post(
+                ToolExecutePostData(log=empty_log, workspace=tmp_path, tool_use=use)
+            )
         )
         injected = [m for m in msgs if isinstance(m, Message)]
         assert injected, "expected AGENTS.md injection for subdir read"
@@ -153,7 +156,9 @@ class TestOnToolExecutePost:
 
         use = _make_use("patch", kwargs={"path": str(target)})
         msgs = list(
-            on_tool_execute_post(log=empty_log, workspace=tmp_path, tool_use=use)
+            on_tool_execute_post(
+                ToolExecutePostData(log=empty_log, workspace=tmp_path, tool_use=use)
+            )
         )
         injected = [m for m in msgs if isinstance(m, Message)]
         assert injected, "patch in worktree should pull AGENTS.md"
@@ -174,17 +179,21 @@ class TestOnToolExecutePost:
         # First touch: original repo.
         msgs1 = list(
             on_tool_execute_post(
-                log=empty_log,
-                workspace=tmp_path,
-                tool_use=_make_use("read", kwargs={"path": str(original / "x.md")}),
+                ToolExecutePostData(
+                    log=empty_log,
+                    workspace=tmp_path,
+                    tool_use=_make_use("read", kwargs={"path": str(original / "x.md")}),
+                )
             )
         )
         # Second touch: worktree copy with identical content.
         msgs2 = list(
             on_tool_execute_post(
-                log=empty_log,
-                workspace=tmp_path,
-                tool_use=_make_use("read", kwargs={"path": str(worktree / "y.md")}),
+                ToolExecutePostData(
+                    log=empty_log,
+                    workspace=tmp_path,
+                    tool_use=_make_use("read", kwargs={"path": str(worktree / "y.md")}),
+                )
             )
         )
         injected1 = [m for m in msgs1 if isinstance(m, Message)]
@@ -207,16 +216,20 @@ class TestOnToolExecutePost:
 
         first = list(
             on_tool_execute_post(
-                log=empty_log,
-                workspace=tmp_path,
-                tool_use=_make_use("read", kwargs={"path": str(project / "a.py")}),
+                ToolExecutePostData(
+                    log=empty_log,
+                    workspace=tmp_path,
+                    tool_use=_make_use("read", kwargs={"path": str(project / "a.py")}),
+                )
             )
         )
         second = list(
             on_tool_execute_post(
-                log=empty_log,
-                workspace=tmp_path,
-                tool_use=_make_use("read", kwargs={"path": str(project / "b.py")}),
+                ToolExecutePostData(
+                    log=empty_log,
+                    workspace=tmp_path,
+                    tool_use=_make_use("read", kwargs={"path": str(project / "b.py")}),
+                )
             )
         )
         injected1 = [m for m in first if isinstance(m, Message)]
@@ -231,7 +244,9 @@ class TestOnToolExecutePost:
         (project / "AGENTS.md").write_text("# Instructions")
         use = _make_use("shell", args=[f"cat {project / 'foo.md'}"])
         msgs = list(
-            on_tool_execute_post(log=empty_log, workspace=tmp_path, tool_use=use)
+            on_tool_execute_post(
+                ToolExecutePostData(log=empty_log, workspace=tmp_path, tool_use=use)
+            )
         )
         assert [m for m in msgs if isinstance(m, Message)] == []
 
@@ -245,7 +260,9 @@ class TestOnToolExecutePost:
         target.write_text("nothing")
         use = _make_use("read", kwargs={"path": str(target)})
         msgs = list(
-            on_tool_execute_post(log=empty_log, workspace=tmp_path, tool_use=use)
+            on_tool_execute_post(
+                ToolExecutePostData(log=empty_log, workspace=tmp_path, tool_use=use)
+            )
         )
         injected = [
             m
@@ -268,7 +285,9 @@ class TestOnToolExecutePost:
 
         use = _make_use("read", kwargs={"path": str(project / "main.py")})
         msgs = list(
-            on_tool_execute_post(log=empty_log, workspace=tmp_path, tool_use=use)
+            on_tool_execute_post(
+                ToolExecutePostData(log=empty_log, workspace=tmp_path, tool_use=use)
+            )
         )
         local = [
             m for m in msgs if isinstance(m, Message) and str(project) in m.content
@@ -288,7 +307,9 @@ class TestOnToolExecutePost:
 
         use = _make_use("read", args=[], content=f"{target}\n# keep going")
         msgs = list(
-            on_tool_execute_post(log=empty_log, workspace=tmp_path, tool_use=use)
+            on_tool_execute_post(
+                ToolExecutePostData(log=empty_log, workspace=tmp_path, tool_use=use)
+            )
         )
 
         injected = [
@@ -313,10 +334,14 @@ class TestOnToolExecutePost:
 
         use = _make_use("read", kwargs={"path": str(target)})
         first = list(
-            on_tool_execute_post(log=empty_log, workspace=tmp_path, tool_use=use)
+            on_tool_execute_post(
+                ToolExecutePostData(log=empty_log, workspace=tmp_path, tool_use=use)
+            )
         )
         second = list(
-            on_tool_execute_post(log=empty_log, workspace=tmp_path, tool_use=use)
+            on_tool_execute_post(
+                ToolExecutePostData(log=empty_log, workspace=tmp_path, tool_use=use)
+            )
         )
 
         for msgs in (first, second):
@@ -370,7 +395,9 @@ class TestOnToolExecutePost:
 
         with patch("gptme.prompts.workspace.Path.home", return_value=tmp_path):
             msgs = list(
-                on_tool_execute_post(log=empty_log, workspace=tmp_path, tool_use=use)
+                on_tool_execute_post(
+                    ToolExecutePostData(log=empty_log, workspace=tmp_path, tool_use=use)
+                )
             )
 
         injected = [

--- a/gptme/hooks/time_awareness.py
+++ b/gptme/hooks/time_awareness.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 """
 Time awareness hook.
 
@@ -14,15 +16,19 @@ Shows time elapsed messages at: 1min, 5min, 10min, 15min, 20min, then every 10mi
 """
 
 import logging
-from collections.abc import Generator
 from contextvars import ContextVar
 from datetime import datetime, timezone
-from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING
 
 from ..hooks import HookType, StopPropagation, register_hook
-from ..logmanager import Log
 from ..message import Message
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from ..hooks.types import ToolExecutePostData
+
+logger = logging.getLogger(__name__)
 
 logger = logging.getLogger(__name__)
 
@@ -44,18 +50,17 @@ def _ensure_locals():
 
 
 def add_time_message(
-    log: Log, workspace: Path | None, tool_use: Any, **kwargs: Any
+    data: ToolExecutePostData,
 ) -> Generator[Message | StopPropagation, None, None]:
     """Add time elapsed message after tool execution.
 
     Shows messages at: 1min, 5min, 10min, 15min, 20min, then every 10min.
 
     Args:
-        log: The conversation log
-        workspace: Workspace directory path
-        tool_use: The tool being executed (unused)
+        data: Post-execution context (log, workspace, tool_use).
     """
     try:
+        workspace = data.workspace
         if workspace is None:
             return
 

--- a/gptme/hooks/time_awareness.py
+++ b/gptme/hooks/time_awareness.py
@@ -30,8 +30,6 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-logger = logging.getLogger(__name__)
-
 # Context-local storage for time tracking (ensures context safety in gptme-server)
 _conversation_start_times_var: ContextVar[dict[str, datetime] | None] = ContextVar(
     "conversation_start_times", default=None

--- a/gptme/hooks/token_awareness.py
+++ b/gptme/hooks/token_awareness.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 """
 Token budget awareness hook.
 
@@ -10,14 +12,17 @@ Adds:
 """
 
 import logging
-from collections.abc import Generator
 from contextvars import ContextVar
-from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING
 
 from ..hooks import HookType, StopPropagation, register_hook
-from ..logmanager import Log
 from ..message import Message, len_tokens
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+    from pathlib import Path
+
+    from ..hooks.types import ToolExecutePostData
 
 logger = logging.getLogger(__name__)
 
@@ -86,21 +91,19 @@ def add_token_budget(
 
 
 def add_token_usage_warning(
-    log: Log, workspace: Path | None, tool_use: Any, **kwargs: Any
+    data: ToolExecutePostData,
 ) -> Generator[Message | StopPropagation, None, None]:
     """Add token usage warning after tool execution.
 
     Uses incremental token counting to avoid O(N²) behavior.
     Only shows warnings at meaningful thresholds to avoid noise.
 
-    Args:
-        log: The conversation log
-        workspace: Workspace directory path
-        tool_use: The tool being executed (unused)
-
     Yields:
         System message with token usage warning (only at thresholds)
     """
+    log = data.log
+    workspace = data.workspace
+
     # Guard against None log (can happen in edge cases like tests)
     if log is None:
         logger.debug("No log provided, skipping token usage warning")

--- a/gptme/hooks/tool_target_instructions.py
+++ b/gptme/hooks/tool_target_instructions.py
@@ -17,18 +17,21 @@ parsing is intentionally out of scope — `cwd.changed` covers that.
 See: knowledge/technical-designs/tool-targeted-agent-instruction-loading.md
 """
 
+from __future__ import annotations
+
 import logging
-from collections.abc import Generator
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from ..hooks import HookType, StopPropagation, register_hook
-from ..logmanager import Log
-from ..message import Message
 from ..prompts import find_agent_files_in_tree
 from .agents_md_inject import _get_loaded_files, inject_agent_instruction_files
 
 if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from ..hooks.types import ToolExecutePostData
+    from ..message import Message
     from ..tools.base import ToolUse  # fmt: skip
 
 logger = logging.getLogger(__name__)
@@ -61,7 +64,7 @@ _MAX_INJECT_PER_EVENT = 3
 _MAX_BYTES_PER_EVENT = 12_000
 
 
-def _extract_paths(tool_use: "ToolUse") -> list[Path]:
+def _extract_paths(tool_use: ToolUse) -> list[Path]:
     """Extract explicit file/directory path candidates from a tool's arguments.
 
     Returns expanded `Path` objects for downstream resolution. Free text and
@@ -147,19 +150,20 @@ def _candidate_directories(paths: list[Path]) -> list[Path]:
 
 
 def on_tool_execute_post(
-    log: Log,
-    workspace: Path | None,
-    tool_use: Any,
-    **kwargs: Any,
+    data: ToolExecutePostData,
 ) -> Generator[Message | StopPropagation, None, None]:
     """Discover and inject AGENTS.md files for paths touched by structured tools.
 
+    Receives a ToolExecutePostData dataclass so new fields can be added without
+    breaking existing hook signatures. Extracts log/workspace/tool_use from data.
+
     Args:
-        log: The conversation log (used as a fallback for the loaded-files set
-            in server mode, mirroring `agents_md_inject`).
-        workspace: Workspace directory path.
-        tool_use: The tool that just executed.
+        data: Post-execution context (log, workspace, tool_use).
     """
+    log = data.log
+    tool_use = data.tool_use
+    if tool_use is None:
+        return
     try:
         paths = _extract_paths(tool_use)
         if not paths:

--- a/gptme/hooks/types.py
+++ b/gptme/hooks/types.py
@@ -23,6 +23,34 @@ if TYPE_CHECKING:
     from ..tools.base import ToolUse  # fmt: skip
 
 
+@dataclass
+class ToolExecuteData:
+    """Base data for tool execution hooks.
+
+    Shared fields between TOOL_EXECUTE_PRE and TOOL_EXECUTE_POST.
+    """
+
+    log: "Log | None" = None
+    workspace: Path | None = None
+    tool_use: "ToolUse | None" = None
+
+
+@dataclass
+class ToolExecutePreData(ToolExecuteData):
+    """Data passed to TOOL_EXECUTE_PRE hooks."""
+
+
+@dataclass
+class ToolExecutePostData(ToolExecuteData):
+    """Data passed to TOOL_EXECUTE_POST hooks.
+
+    Extends the base with tool result messages so post-hooks can inspect
+    what the tool actually returned.
+    """
+
+    result_msgs: tuple["Message", ...] | None = None
+
+
 class StopPropagation:
     """Sentinel class that hooks can yield to stop execution of lower-priority hooks.
 
@@ -127,27 +155,40 @@ class SessionEndHook(Protocol):
     ) -> Generator[Message | StopPropagation, None, None]: ...
 
 
-class ToolExecuteHook(Protocol):
-    """Hook called before/after tool execution.
+class ToolExecutePreHook(Protocol):
+    """Hook called before tool execution.
 
-    Note: Receives log/workspace separately since manager isn't available in ToolUse.execute() context.
+    Receives a single ToolExecutePreData object instead of positional args,
+    so adding new fields never breaks existing hook signatures.
 
     Args:
-        log: The conversation log
-        workspace: Workspace directory path
-        tool_use: The tool being executed
-
-    TOOL_EXECUTE_POST hooks also receive ``result_msgs: list[Message]`` as a
-    keyword argument (the messages yielded by the tool). Hooks that want to
-    inspect tool output should accept ``**kwargs`` and extract it from there.
+        data: Pre-execution context (log, workspace, tool_use).
     """
 
     def __call__(
         self,
-        log: "Log",
-        workspace: Path | None,
-        tool_use: "ToolUse",
+        data: ToolExecutePreData,
     ) -> Generator[Message | StopPropagation, None, None]: ...
+
+
+class ToolExecutePostHook(Protocol):
+    """Hook called after tool execution.
+
+    Receives a single ToolExecutePostData object that includes the tool's
+    result messages in addition to the execution context.
+
+    Args:
+        data: Post-execution context (log, workspace, tool_use, result_msgs).
+    """
+
+    def __call__(
+        self,
+        data: ToolExecutePostData,
+    ) -> Generator[Message | StopPropagation, None, None]: ...
+
+
+# ToolExecuteHook kept as union alias for backward compat in HookFunc
+ToolExecuteHook = ToolExecutePreHook | ToolExecutePostHook
 
 
 class MessageProcessHook(Protocol):
@@ -299,7 +340,8 @@ class FilePostSaveHook(Protocol):
 HookFunc = (
     SessionStartHook
     | SessionEndHook
-    | ToolExecuteHook
+    | ToolExecutePreHook
+    | ToolExecutePostHook
     | CwdChangedHook
     | MessageProcessHook
     | LoopContinueHook

--- a/gptme/tools/base.py
+++ b/gptme/tools/base.py
@@ -466,12 +466,17 @@ class ToolUse:
             tool = get_tool(self.tool)
             if tool and tool.execute:
                 try:
+                    from ..hooks.types import ToolExecutePreData  # fmt: skip
+
                     # Trigger pre-execution hooks (tool.execute.pre)
-                    if pre_hook_msgs := trigger_hook(
-                        HookType.TOOL_EXECUTE_PRE,
+                    pre_data = ToolExecutePreData(
                         log=log,
                         workspace=workspace,
                         tool_use=self,
+                    )
+                    if pre_hook_msgs := trigger_hook(
+                        HookType.TOOL_EXECUTE_PRE,
+                        pre_data,
                     ):
                         yield from pre_hook_msgs
 
@@ -518,13 +523,20 @@ class ToolUse:
                         tool_format=self._format,
                     )
 
+                    from ..hooks.types import ToolExecutePostData  # fmt: skip
+
                     # Trigger post-execution hooks (tool.execute.post)
-                    if post_hook_msgs := trigger_hook(
-                        HookType.TOOL_EXECUTE_POST,
+                    post_data = ToolExecutePostData(
                         log=log,
                         workspace=workspace,
                         tool_use=self,
-                        result_msgs=result_msgs,
+                        result_msgs=tuple(result_msgs)
+                        if isinstance(ex, Generator)
+                        else None,
+                    )
+                    if post_hook_msgs := trigger_hook(
+                        HookType.TOOL_EXECUTE_POST,
+                        post_data,
                     ):
                         yield from post_hook_msgs
 

--- a/tests/test_hooks_cwd_changed.py
+++ b/tests/test_hooks_cwd_changed.py
@@ -19,6 +19,7 @@ from gptme.hooks import (
 )
 from gptme.hooks.cwd_awareness import on_cwd_changed
 from gptme.hooks.cwd_changed import _cwd_before_var, _detect_change, _store_cwd
+from gptme.hooks.types import ToolExecutePostData, ToolExecutePreData
 from gptme.message import Message
 
 
@@ -45,7 +46,13 @@ class TestCwdChangedDetector:
         orig_cwd = os.getcwd()
         try:
             os.chdir(tmp_path)
-            list(_store_cwd(log=MagicMock(), workspace=None, tool_use=MagicMock()))
+            list(
+                _store_cwd(
+                    ToolExecutePreData(
+                        log=MagicMock(), workspace=None, tool_use=MagicMock()
+                    )
+                )
+            )
             assert _cwd_before_var.get() == str(tmp_path)
         finally:
             os.chdir(orig_cwd)
@@ -57,7 +64,11 @@ class TestCwdChangedDetector:
             os.chdir(tmp_path)
             _cwd_before_var.set(str(tmp_path))
             msgs = list(
-                _detect_change(log=MagicMock(), workspace=None, tool_use=MagicMock())
+                _detect_change(
+                    ToolExecutePostData(
+                        log=MagicMock(), workspace=None, tool_use=MagicMock()
+                    )
+                )
             )
             assert msgs == []
         finally:
@@ -83,7 +94,13 @@ class TestCwdChangedDetector:
         try:
             _cwd_before_var.set(str(tmp_path))
             os.chdir(subdir)
-            list(_detect_change(log=MagicMock(), workspace=None, tool_use=MagicMock()))
+            list(
+                _detect_change(
+                    ToolExecutePostData(
+                        log=MagicMock(), workspace=None, tool_use=MagicMock()
+                    )
+                )
+            )
             assert len(captured) == 1
             assert captured[0]["old"] == str(tmp_path)
             assert captured[0]["new"] == str(subdir)
@@ -97,7 +114,11 @@ class TestCwdChangedDetector:
             os.chdir(tmp_path)
             _cwd_before_var.set(None)
             msgs = list(
-                _detect_change(log=MagicMock(), workspace=None, tool_use=MagicMock())
+                _detect_change(
+                    ToolExecutePostData(
+                        log=MagicMock(), workspace=None, tool_use=MagicMock()
+                    )
+                )
             )
             assert msgs == []
         finally:
@@ -122,10 +143,22 @@ class TestCwdChangedDetector:
         orig_cwd = os.getcwd()
         try:
             os.chdir(tmp_path)
-            list(_store_cwd(log=MagicMock(), workspace=None, tool_use=MagicMock()))
+            list(
+                _store_cwd(
+                    ToolExecutePreData(
+                        log=MagicMock(), workspace=None, tool_use=MagicMock()
+                    )
+                )
+            )
 
             os.chdir(subdir)
-            list(_detect_change(log=MagicMock(), workspace=None, tool_use=MagicMock()))
+            list(
+                _detect_change(
+                    ToolExecutePostData(
+                        log=MagicMock(), workspace=None, tool_use=MagicMock()
+                    )
+                )
+            )
 
             assert len(triggered) == 1
             assert triggered[0] == str(subdir)
@@ -217,13 +250,21 @@ class TestIntegration:
         orig_cwd = os.getcwd()
         try:
             os.chdir(tmp_path)
-            list(_store_cwd(log=MagicMock(), workspace=None, tool_use=MagicMock()))
+            list(
+                _store_cwd(
+                    ToolExecutePreData(
+                        log=MagicMock(), workspace=None, tool_use=MagicMock()
+                    )
+                )
+            )
 
             os.chdir(subdir)
             msgs = _messages_only(
                 list(
                     _detect_change(
-                        log=MagicMock(), workspace=None, tool_use=MagicMock()
+                        ToolExecutePostData(
+                            log=MagicMock(), workspace=None, tool_use=MagicMock()
+                        )
                     )
                 )
             )
@@ -244,11 +285,21 @@ class TestIntegration:
         orig_cwd = os.getcwd()
         try:
             os.chdir(tmp_path)
-            list(_store_cwd(log=MagicMock(), workspace=None, tool_use=MagicMock()))
+            list(
+                _store_cwd(
+                    ToolExecutePreData(
+                        log=MagicMock(), workspace=None, tool_use=MagicMock()
+                    )
+                )
+            )
 
             # CWD stays the same
             msgs = list(
-                _detect_change(log=MagicMock(), workspace=None, tool_use=MagicMock())
+                _detect_change(
+                    ToolExecutePostData(
+                        log=MagicMock(), workspace=None, tool_use=MagicMock()
+                    )
+                )
             )
             assert msgs == []
         finally:

--- a/tests/test_tools_time_awareness.py
+++ b/tests/test_tools_time_awareness.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta, timezone
 import pytest
 
 from gptme.hooks import HookType, clear_hooks, get_hooks, trigger_hook
+from gptme.hooks.types import ToolExecutePostData
 from gptme.logmanager import Log
 
 
@@ -95,7 +96,8 @@ def test_time_milestones(load_time_awareness_tool, tmp_path, monkeypatch):
         # Trigger TOOL_EXECUTE_POST (tool.execute.post) hook
         messages = list(
             trigger_hook(
-                HookType.TOOL_EXECUTE_POST, log=log, workspace=workspace, tool_use=None
+                HookType.TOOL_EXECUTE_POST,
+                ToolExecutePostData(log=log, workspace=workspace, tool_use=None),
             )
         )
 
@@ -138,7 +140,8 @@ def test_milestone_progression(load_time_awareness_tool, tmp_path):
     for i in range(3):
         messages = list(
             trigger_hook(
-                HookType.TOOL_EXECUTE_POST, log=log, workspace=workspace, tool_use=None
+                HookType.TOOL_EXECUTE_POST,
+                ToolExecutePostData(log=log, workspace=workspace, tool_use=None),
             )
         )
 
@@ -158,7 +161,10 @@ def test_no_workspace_graceful_handling(
 
     # Trigger hook without workspace
     messages = list(
-        trigger_hook(HookType.TOOL_EXECUTE_POST, log=log, workspace=None, tool_use=None)
+        trigger_hook(
+            HookType.TOOL_EXECUTE_POST,
+            ToolExecutePostData(log=log, workspace=None, tool_use=None),
+        )
     )
 
     # Should not crash, should not produce messages
@@ -193,7 +199,8 @@ def test_time_format_hours(load_time_awareness_tool, tmp_path):
     # Trigger hook
     messages = list(
         trigger_hook(
-            HookType.TOOL_EXECUTE_POST, log=log, workspace=workspace, tool_use=None
+            HookType.TOOL_EXECUTE_POST,
+            ToolExecutePostData(log=log, workspace=workspace, tool_use=None),
         )
     )
 
@@ -233,7 +240,8 @@ def test_every_10min_after_20(load_time_awareness_tool, tmp_path):
 
         messages = list(
             trigger_hook(
-                HookType.TOOL_EXECUTE_POST, log=log, workspace=workspace, tool_use=None
+                HookType.TOOL_EXECUTE_POST,
+                ToolExecutePostData(log=log, workspace=workspace, tool_use=None),
             )
         )
 

--- a/tests/test_tools_token_awareness.py
+++ b/tests/test_tools_token_awareness.py
@@ -3,6 +3,7 @@
 import pytest
 
 from gptme.hooks import HookType, clear_hooks, get_hooks, trigger_hook
+from gptme.hooks.types import ToolExecutePostData
 from gptme.logmanager import Log
 from gptme.message import Message
 
@@ -95,7 +96,10 @@ def test_add_token_usage_warning_hook(load_token_awareness_tool, tmp_path):
 
     # Use workspace=None to trigger fallback behavior (shows warning every time)
     results = list(
-        trigger_hook(HookType.TOOL_EXECUTE_POST, log=log, workspace=None, tool_use=None)
+        trigger_hook(
+            HookType.TOOL_EXECUTE_POST,
+            ToolExecutePostData(log=log, workspace=None, tool_use=None),
+        )
     )
 
     # Should have at least one message from the hook
@@ -139,7 +143,10 @@ def test_token_calculation_accuracy(load_token_awareness_tool, tmp_path):
 
     # Use workspace=None to trigger fallback behavior (shows warning every time)
     results = list(
-        trigger_hook(HookType.TOOL_EXECUTE_POST, log=log, workspace=None, tool_use=None)
+        trigger_hook(
+            HookType.TOOL_EXECUTE_POST,
+            ToolExecutePostData(log=log, workspace=None, tool_use=None),
+        )
     )
 
     # Find the usage warning
@@ -207,7 +214,10 @@ def test_multiple_usage_warnings(load_token_awareness_tool, tmp_path):
     # Use workspace=None to trigger fallback behavior (shows warning every time)
     # Trigger hook first time
     results1 = list(
-        trigger_hook(HookType.TOOL_EXECUTE_POST, log=log, workspace=None, tool_use=None)
+        trigger_hook(
+            HookType.TOOL_EXECUTE_POST,
+            ToolExecutePostData(log=log, workspace=None, tool_use=None),
+        )
     )
     assert len([m for m in results1 if "<system_warning>" in m.content]) >= 1
 
@@ -217,7 +227,10 @@ def test_multiple_usage_warnings(load_token_awareness_tool, tmp_path):
 
     # Trigger hook second time
     results2 = list(
-        trigger_hook(HookType.TOOL_EXECUTE_POST, log=log, workspace=None, tool_use=None)
+        trigger_hook(
+            HookType.TOOL_EXECUTE_POST,
+            ToolExecutePostData(log=log, workspace=None, tool_use=None),
+        )
     )
     assert len([m for m in results2 if "<system_warning>" in m.content]) >= 1
 

--- a/tests/test_workspace_snapshot.py
+++ b/tests/test_workspace_snapshot.py
@@ -24,6 +24,7 @@ from gptme.hooks.auto_snapshots import (
     is_mutating_shell_payload,
     is_mutating_tmux_payload,
 )
+from gptme.hooks.types import ToolExecutePostData, ToolExecutePreData
 from gptme.tools.base import ToolUse
 from gptme.workspace_snapshot import (
     Shadow,
@@ -298,8 +299,8 @@ def test_pre_post_noop_when_disabled(isolated_state_dir, workspace, monkeypatch)
     monkeypatch.delenv("GPTME_AUTO_SNAPSHOTS", raising=False)
     tu = MagicMock(tool="save", content="x")
     # Generator returns nothing and does not create a shadow.
-    list(_pre(MagicMock(), workspace, tu))
-    list(_post(MagicMock(), workspace, tu))
+    list(_pre(ToolExecutePreData(log=MagicMock(), workspace=workspace, tool_use=tu)))
+    list(_post(ToolExecutePostData(log=MagicMock(), workspace=workspace, tool_use=tu)))
     # No XDG shadow created.
     snaps_dir = isolated_state_dir / "gptme" / "workspace-snapshots"
     assert not snaps_dir.exists()
@@ -313,7 +314,7 @@ def test_pre_post_snapshot_round_trip_via_hook(
 
     # Simulate a save tool call.
     tu = MagicMock(tool="save", content="anything")
-    list(_pre(MagicMock(), workspace, tu))
+    list(_pre(ToolExecutePreData(log=MagicMock(), workspace=workspace, tool_use=tu)))
     # Hook ran on a clean workspace — at least the initial snapshot is recorded.
     shadow = Shadow.for_workspace(workspace)
     assert shadow.initialized()
@@ -323,7 +324,7 @@ def test_pre_post_snapshot_round_trip_via_hook(
 
     # Mutate the workspace, then run post hook.
     (workspace / "after-save.txt").write_text("new\n")
-    list(_post(MagicMock(), workspace, tu))
+    list(_post(ToolExecutePostData(log=MagicMock(), workspace=workspace, tool_use=tu)))
     snaps_after = list_snapshots(shadow, limit=100)
     post_labels = [label for _, label in snaps_after]
     assert any(label == "post:save" for label in post_labels)
@@ -335,12 +336,12 @@ def test_post_skips_when_no_mutation(isolated_state_dir, workspace, monkeypatch)
     _pre_tree_var.set(None)
     tu = MagicMock(tool="shell", content="echo hi > out.txt")
 
-    list(_pre(MagicMock(), workspace, tu))
+    list(_pre(ToolExecutePreData(log=MagicMock(), workspace=workspace, tool_use=tu)))
     shadow = Shadow.for_workspace(workspace)
     pre_count = len(list_snapshots(shadow, limit=100))
 
     # Run post immediately, no actual workspace mutation.
-    list(_post(MagicMock(), workspace, tu))
+    list(_post(ToolExecutePostData(log=MagicMock(), workspace=workspace, tool_use=tu)))
     post_count = len(list_snapshots(shadow, limit=100))
     # Pre adds one snapshot; post adds zero because tree is unchanged.
     assert post_count == pre_count
@@ -359,14 +360,14 @@ def test_pre_post_snapshot_round_trip_via_tool_format_shell_kwargs(
         _format="tool",
     )
 
-    list(_pre(MagicMock(), workspace, tu))
+    list(_pre(ToolExecutePreData(log=MagicMock(), workspace=workspace, tool_use=tu)))
     shadow = Shadow.for_workspace(workspace)
     assert shadow.initialized()
     pre_labels = [label for _, label in list_snapshots(shadow, limit=100)]
     assert any(label == "pre:shell" for label in pre_labels)
 
     (workspace / "smoke.txt").write_text("alpha\nbeta\n")
-    list(_post(MagicMock(), workspace, tu))
+    list(_post(ToolExecutePostData(log=MagicMock(), workspace=workspace, tool_use=tu)))
     post_labels = [label for _, label in list_snapshots(shadow, limit=100)]
     assert any(label == "post:shell" for label in post_labels)
 
@@ -375,7 +376,7 @@ def test_hook_skips_non_mutating_shell(isolated_state_dir, workspace, monkeypatc
     monkeypatch.setenv("GPTME_AUTO_SNAPSHOTS", "1")
     _pre_tree_var.set(None)
     tu = MagicMock(tool="shell", content="ls -la")
-    list(_pre(MagicMock(), workspace, tu))
+    list(_pre(ToolExecutePreData(log=MagicMock(), workspace=workspace, tool_use=tu)))
     # No shadow should be initialized for a plain read.
     snaps_dir = isolated_state_dir / "gptme" / "workspace-snapshots"
     assert not snaps_dir.exists()


### PR DESCRIPTION
## Summary

Follow-up to #2650. Erik requested HookData typed dataclasses instead of `**kwargs` for the hook calling convention ([comment](https://github.com/gptme/gptme/pull/2650#issuecomment-4586296481)).

### Changes

Replaces positional args (`log`, `workspace`, `tool_use`) with typed dataclasses:

- **`ToolExecutePreData`** — for `TOOL_EXECUTE_PRE` hooks (log, workspace, tool_use)
- **`ToolExecutePostData`** — extends base with `result_msgs` (tuple of Messages) so post-hooks can inspect tool output

The `ToolExecuteHook` protocol is split into `ToolExecutePreHook` + `ToolExecutePostHook` with a union alias for `HookFunc` backward compatibility.

### Updated hooks

All 6 built-in TOOL_EXECUTE hooks now accept a single data object:

- `token_awareness`: `add_token_usage_warning`
- `time_awareness`: `add_time_message`
- `cwd_changed`: `_store_cwd`, `_detect_change`
- `auto_snapshots`: `_pre`, `_post`
- `tool_target_instructions`: `on_tool_execute_post`
- `aw_watcher_agent`: `record_tool_start`, `emit_tool_activity`
- `injection_screening`: `injection_screening` (new, already used the pattern)

### Test plan

- [x] `uv run pytest gptme/hooks/tests/ -x` — 437 passed
- [x] `uv run mypy gptme/hooks/ gptme/tools/base.py` — clean
- [x] `uv run ruff check --select TC gptme/hooks/ gptme/tools/base.py` — clean