### PR TITLE
feat(webui): add /admin session management panel

### DIFF
--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -188,6 +188,81 @@ v2_api.register_blueprint(sessions_api)
 v2_api.register_blueprint(agents_api)
 
 
+@v2_api.route("/api/v2/sessions")
+@require_auth
+@api_doc_simple(tags=["admin"])
+def api_sessions_list():
+    """List all active sessions.
+
+    Returns a snapshot of all in-memory sessions with basic metadata useful
+    for the admin panel (session ID, conversation ID, model, message count,
+    generating status, elapsed time).
+    """
+    from ..dirs import get_logs_dir
+    from .api_v2_sessions import SessionManager
+
+    now = datetime.now(tz=timezone.utc)
+    result = []
+    for session_id, session in SessionManager.get_all_sessions():
+        conversation_id = session.conversation_id
+
+        # Count messages in the conversation log (best-effort; skip on error)
+        message_count = 0
+        model: str | None = None
+        if conversation_id:
+            try:
+                manager = LogManager.load(conversation_id, lock=False)
+                message_count = len(list(manager.log.messages))
+                logdir = get_logs_dir() / conversation_id
+                chat_config = ChatConfig.load_or_create(logdir, ChatConfig())
+                model = chat_config.model
+            except Exception:
+                pass
+
+        elapsed_seconds: float | None = None
+        if session.generating and session.generating_since:
+            elapsed_seconds = (now - session.generating_since).total_seconds()
+
+        result.append(
+            {
+                "id": session_id,
+                "conversation_id": conversation_id,
+                "model": model,
+                "message_count": message_count,
+                "generating": session.generating,
+                "elapsed_seconds": elapsed_seconds,
+                "created_at": session.created_at.isoformat(),
+                "last_activity": session.last_activity.isoformat(),
+            }
+        )
+
+    return flask.jsonify(result)
+
+
+@v2_api.route("/api/v2/sessions/<string:session_id>", methods=["DELETE"])
+@require_auth
+@api_doc_simple(tags=["admin"])
+def api_session_delete(session_id: str):
+    """Delete (kill) a session by ID.
+
+    Interrupts any in-progress generation and removes the session from memory.
+    The conversation log is not deleted.
+    """
+    from .api_v2_sessions import SessionManager
+
+    session = SessionManager.get_session(session_id)
+    if session is None:
+        return flask.jsonify({"error": f"Session not found: {session_id}"}), 404
+
+    # Mark as not generating before removal so the step thread exits cleanly
+    session.generating = False
+    session.generating_since = None
+    session.pending_tools.clear()
+
+    SessionManager.remove_session(session_id)
+    return flask.jsonify({"status": "ok", "message": f"Session {session_id} deleted"})
+
+
 @v2_api.route("/api/v2")
 @api_doc_simple(responses={200: ApiRootResponse}, tags=["meta"])
 def api_root():

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -259,6 +259,10 @@ def api_session_delete(session_id: str):
     session.generating_since = None
     session.pending_tools.clear()
 
+    # Notify SSE clients before removing so they can react (avoids zombie streams)
+    if session.conversation_id:
+        SessionManager.add_event(session.conversation_id, {"type": "interrupted"})
+
     SessionManager.remove_session(session_id)
     return flask.jsonify({"status": "ok", "message": f"Session {session_id} deleted"})
 

--- a/webui/src/App.tsx
+++ b/webui/src/App.tsx
@@ -20,6 +20,7 @@ const Agents = lazy(() => import('./pages/Agents'));
 const Workspaces = lazy(() => import('./pages/Workspaces'));
 const History = lazy(() => import('./pages/History'));
 const ExternalSessions = lazy(() => import('./pages/ExternalSessions'));
+const Admin = lazy(() => import('./pages/Admin'));
 const NotFound = lazy(() => import('./pages/NotFound'));
 
 const queryClient = new QueryClient({
@@ -83,6 +84,7 @@ const App: FC = () => {
                       <Route path="/workspaces" element={<Workspaces />} />
                       <Route path="/history" element={<History />} />
                       <Route path="/external-sessions" element={<ExternalSessions />} />
+                      <Route path="/admin" element={<Admin />} />
                       <Route path="/workspace/:id" element={<Workspace />} />
                       <Route path="*" element={<NotFound />} />
                     </Routes>

--- a/webui/src/components/AdminView.tsx
+++ b/webui/src/components/AdminView.tsx
@@ -1,0 +1,256 @@
+import { type FC, useState, useCallback } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { Shield, RefreshCw, Trash2, AlertCircle, Loader2, Activity } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { useApi } from '@/contexts/ApiContext';
+import { use$ } from '@legendapp/state/react';
+import type { ActiveSession } from '@/types/api';
+import { getRelativeTimeString } from '@/utils/time';
+
+// Auto-refresh interval (ms)
+const REFRESH_INTERVAL_MS = 5000;
+
+function formatElapsed(seconds: number | null): string {
+  if (seconds === null) return '—';
+  if (seconds < 60) return `${Math.round(seconds)}s`;
+  const mins = Math.floor(seconds / 60);
+  const secs = Math.round(seconds % 60);
+  return `${mins}m ${secs}s`;
+}
+
+interface SessionRowProps {
+  session: ActiveSession;
+  onKill: (id: string) => void;
+  isKilling: boolean;
+}
+
+const SessionRow: FC<SessionRowProps> = ({ session, onKill, isKilling }) => {
+  const lastActivity = session.last_activity
+    ? getRelativeTimeString(new Date(session.last_activity))
+    : '—';
+
+  const handleKill = () => {
+    if (
+      window.confirm(
+        `Kill session ${session.id.slice(0, 8)}…?\nThis will interrupt any running generation.`
+      )
+    ) {
+      onKill(session.id);
+    }
+  };
+
+  return (
+    <tr className="border-b transition-colors last:border-b-0 hover:bg-muted/30">
+      <td className="px-4 py-3 font-mono text-xs text-muted-foreground">
+        {session.id.slice(0, 8)}
+        <span className="text-muted-foreground/50">…</span>
+      </td>
+      <td className="px-4 py-3 text-sm">
+        {session.conversation_id ? (
+          <span className="font-mono text-xs">{session.conversation_id}</span>
+        ) : (
+          <span className="text-muted-foreground">—</span>
+        )}
+      </td>
+      <td className="px-4 py-3 text-sm">
+        {session.model ? (
+          <span className="font-mono text-xs">{session.model}</span>
+        ) : (
+          <span className="text-muted-foreground">—</span>
+        )}
+      </td>
+      <td className="px-4 py-3 text-right text-sm tabular-nums">{session.message_count}</td>
+      <td className="px-4 py-3">
+        <div className="flex items-center gap-1.5">
+          {session.generating ? (
+            <>
+              <Badge variant="default" className="h-5 gap-1 px-1.5 text-[10px]">
+                <Activity className="h-2.5 w-2.5" />
+                generating
+              </Badge>
+              <span className="text-xs tabular-nums text-muted-foreground">
+                {formatElapsed(session.elapsed_seconds)}
+              </span>
+            </>
+          ) : (
+            <Badge variant="secondary" className="h-5 px-1.5 text-[10px]">
+              idle
+            </Badge>
+          )}
+        </div>
+      </td>
+      <td className="px-4 py-3 text-xs text-muted-foreground">{lastActivity}</td>
+      <td className="px-4 py-3">
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7 text-destructive hover:bg-destructive/10 hover:text-destructive"
+          onClick={handleKill}
+          disabled={isKilling}
+          aria-label={`Kill session ${session.id.slice(0, 8)}`}
+        >
+          {isKilling ? (
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          ) : (
+            <Trash2 className="h-3.5 w-3.5" />
+          )}
+        </Button>
+      </td>
+    </tr>
+  );
+};
+
+export const AdminView: FC = () => {
+  const { api } = useApi();
+  const isConnected = use$(api.isConnected$);
+  const queryClient = useQueryClient();
+  const [killingIds, setKillingIds] = useState<Set<string>>(new Set());
+
+  const {
+    data: sessions = [],
+    isLoading,
+    error,
+    dataUpdatedAt,
+    refetch,
+  } = useQuery<ActiveSession[]>({
+    queryKey: ['admin-sessions'],
+    queryFn: () => api.getSessions(),
+    enabled: isConnected,
+    refetchInterval: REFRESH_INTERVAL_MS,
+    staleTime: 0,
+  });
+
+  const killMutation = useMutation({
+    mutationFn: (sessionId: string) => api.deleteSession(sessionId),
+    onMutate: (sessionId) => {
+      setKillingIds((prev) => new Set(prev).add(sessionId));
+    },
+    onSettled: (_, __, sessionId) => {
+      setKillingIds((prev) => {
+        const next = new Set(prev);
+        next.delete(sessionId);
+        return next;
+      });
+      void queryClient.invalidateQueries({ queryKey: ['admin-sessions'] });
+    },
+  });
+
+  const handleKill = useCallback(
+    (sessionId: string) => {
+      killMutation.mutate(sessionId);
+    },
+    [killMutation]
+  );
+
+  const lastRefresh = dataUpdatedAt ? new Date(dataUpdatedAt).toLocaleTimeString() : null;
+
+  const activeSessions = sessions.filter((s) => s.generating);
+
+  return (
+    <div className="flex h-full flex-col">
+      {/* Header */}
+      <div className="border-b px-6 py-4">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <Shield className="h-5 w-5 text-muted-foreground" />
+            <div>
+              <h1 className="text-base font-semibold">Admin Panel</h1>
+              <p className="text-xs text-muted-foreground">
+                Active server sessions — auto-refreshes every 5s
+              </p>
+            </div>
+          </div>
+          <div className="flex items-center gap-3">
+            {lastRefresh && (
+              <span className="text-xs text-muted-foreground">Updated {lastRefresh}</span>
+            )}
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-8 gap-1.5"
+              onClick={() => refetch()}
+              disabled={isLoading}
+            >
+              <RefreshCw className={`h-3.5 w-3.5 ${isLoading ? 'animate-spin' : ''}`} />
+              Refresh
+            </Button>
+          </div>
+        </div>
+
+        {/* Summary stats */}
+        <div className="mt-3 flex gap-4">
+          <div className="rounded-md border bg-card px-3 py-1.5">
+            <p className="text-xs text-muted-foreground">Total sessions</p>
+            <p className="text-lg font-semibold tabular-nums">{sessions.length}</p>
+          </div>
+          <div className="rounded-md border bg-card px-3 py-1.5">
+            <p className="text-xs text-muted-foreground">Generating</p>
+            <p className="text-lg font-semibold tabular-nums text-primary">
+              {activeSessions.length}
+            </p>
+          </div>
+          <div className="rounded-md border bg-card px-3 py-1.5">
+            <p className="text-xs text-muted-foreground">Idle</p>
+            <p className="text-lg font-semibold tabular-nums text-muted-foreground">
+              {sessions.length - activeSessions.length}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 overflow-auto">
+        {error ? (
+          <div className="flex h-full flex-col items-center justify-center gap-3 p-8 text-center">
+            <AlertCircle className="h-10 w-10 text-destructive" />
+            <div>
+              <p className="font-medium">Failed to load sessions</p>
+              <p className="mt-1 text-sm text-muted-foreground">
+                {error instanceof Error ? error.message : 'An unexpected error occurred.'}
+              </p>
+            </div>
+            <Button variant="outline" size="sm" onClick={() => refetch()}>
+              Retry
+            </Button>
+          </div>
+        ) : isLoading && sessions.length === 0 ? (
+          <div className="flex h-full items-center justify-center gap-2 text-muted-foreground">
+            <Loader2 className="h-5 w-5 animate-spin" />
+            <span className="text-sm">Loading sessions…</span>
+          </div>
+        ) : sessions.length === 0 ? (
+          <div className="flex h-full flex-col items-center justify-center gap-2 p-8 text-center text-muted-foreground">
+            <Shield className="h-10 w-10" />
+            <p className="text-sm font-medium">No active sessions</p>
+            <p className="text-xs">Sessions appear here when users open conversations.</p>
+          </div>
+        ) : (
+          <table className="w-full text-sm">
+            <thead className="sticky top-0 border-b bg-background">
+              <tr className="text-left text-xs text-muted-foreground">
+                <th className="px-4 py-2 font-medium">Session ID</th>
+                <th className="px-4 py-2 font-medium">Conversation</th>
+                <th className="px-4 py-2 font-medium">Model</th>
+                <th className="px-4 py-2 text-right font-medium">Messages</th>
+                <th className="px-4 py-2 font-medium">Status</th>
+                <th className="px-4 py-2 font-medium">Last activity</th>
+                <th className="sr-only px-4 py-2 font-medium">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {sessions.map((session) => (
+                <SessionRow
+                  key={session.id}
+                  session={session}
+                  onKill={handleKill}
+                  isKilling={killingIds.has(session.id)}
+                />
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/webui/src/components/AdminView.tsx
+++ b/webui/src/components/AdminView.tsx
@@ -3,6 +3,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { Shield, RefreshCw, Trash2, AlertCircle, Loader2, Activity } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
+import { useToast } from '@/components/ui/use-toast';
 import { useApi } from '@/contexts/ApiContext';
 import { use$ } from '@legendapp/state/react';
 import type { ActiveSession } from '@/types/api';
@@ -105,6 +106,7 @@ export const AdminView: FC = () => {
   const { api } = useApi();
   const isConnected = use$(api.isConnected$);
   const queryClient = useQueryClient();
+  const { toast } = useToast();
   const [killingIds, setKillingIds] = useState<Set<string>>(new Set());
 
   const {
@@ -125,6 +127,16 @@ export const AdminView: FC = () => {
     mutationFn: (sessionId: string) => api.deleteSession(sessionId),
     onMutate: (sessionId) => {
       setKillingIds((prev) => new Set(prev).add(sessionId));
+    },
+    onError: (error, sessionId) => {
+      toast({
+        variant: 'destructive',
+        title: 'Failed to kill session',
+        description:
+          error instanceof Error
+            ? error.message
+            : `Could not kill session ${sessionId.slice(0, 8)}`,
+      });
     },
     onSettled: (_, __, sessionId) => {
       setKillingIds((prev) => {

--- a/webui/src/components/SidebarIcons.tsx
+++ b/webui/src/components/SidebarIcons.tsx
@@ -11,6 +11,7 @@ import {
   Layers,
   ChevronRight,
   ChevronLeft,
+  Shield,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
@@ -84,9 +85,13 @@ export const SidebarIcons: FC<Props> = ({ tasks }) => {
           ? 'workspaces'
           : location.pathname.startsWith('/external-sessions')
             ? 'external-sessions'
-            : 'chat';
+            : location.pathname.startsWith('/admin')
+              ? 'admin'
+              : 'chat';
 
-  const handleNavigateToSection = (section: NavItem['section']) => {
+  const handleNavigateToSection = (
+    section: 'chat' | 'tasks' | 'history' | 'agents' | 'workspaces' | 'external-sessions' | 'admin'
+  ) => {
     navigate(`/${section === 'chat' ? 'chat' : section}`);
   };
 
@@ -153,6 +158,22 @@ export const SidebarIcons: FC<Props> = ({ tasks }) => {
         })}
 
         {/* Search */}
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant={currentSection === 'admin' ? 'secondary' : 'ghost'}
+                size="icon"
+                className="h-8 w-8"
+                onClick={() => handleNavigateToSection('admin')}
+              >
+                <Shield className="h-4 w-4" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="right">Admin</TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+
         <TooltipProvider>
           <Tooltip>
             <TooltipTrigger asChild>

--- a/webui/src/pages/Admin.tsx
+++ b/webui/src/pages/Admin.tsx
@@ -1,0 +1,25 @@
+import { type FC } from 'react';
+import { MenuBar } from '@/components/MenuBar';
+import { AdminView } from '@/components/AdminView';
+import { SidebarIcons } from '@/components/SidebarIcons';
+import { MobileBottomNav } from '@/components/MobileBottomNav';
+import { useTasksQuery } from '@/stores/tasks';
+
+const Admin: FC = () => {
+  const { data: tasks = [] } = useTasksQuery();
+
+  return (
+    <div className="flex h-screen flex-col">
+      <MenuBar />
+      <div className="flex min-h-0 flex-1">
+        <SidebarIcons tasks={tasks} />
+        <div className="flex-1 overflow-hidden">
+          <AdminView />
+        </div>
+      </div>
+      <MobileBottomNav />
+    </div>
+  );
+};
+
+export default Admin;

--- a/webui/src/types/api.ts
+++ b/webui/src/types/api.ts
@@ -1,5 +1,17 @@
 import type { Message, StreamingMessage } from './conversation';
 
+// Active server-side session (from /api/v2/sessions)
+export interface ActiveSession {
+  id: string;
+  conversation_id: string | null;
+  model: string | null;
+  message_count: number;
+  generating: boolean;
+  elapsed_seconds: number | null;
+  created_at: string;
+  last_activity: string;
+}
+
 // External session catalog item (from /api/v2/external-sessions)
 export interface ExternalSessionCatalogItem {
   id: string;

--- a/webui/src/utils/api.ts
+++ b/webui/src/utils/api.ts
@@ -1,5 +1,6 @@
 import { type CreateAgentResponse, type CreateAgentRequest } from '@/components/CreateAgentDialog';
 import type {
+  ActiveSession,
   ApiError,
   ApiErrorDetails,
   ChatConfig,
@@ -1340,6 +1341,16 @@ export class ApiClient {
   async getExternalSession(id: string, days = 30): Promise<ExternalSessionDetail> {
     const url = `${this.baseUrl}/api/v2/external-sessions/${id}?days=${days}`;
     return await this.fetchJson<ExternalSessionDetail>(url);
+  }
+
+  async getSessions(): Promise<ActiveSession[]> {
+    const url = `${this.baseUrl}/api/v2/sessions`;
+    return await this.fetchJson<ActiveSession[]>(url);
+  }
+
+  async deleteSession(sessionId: string): Promise<void> {
+    const url = `${this.baseUrl}/api/v2/sessions/${sessionId}`;
+    await this.fetchJson<{ status: string }>(url, { method: 'DELETE' });
   }
 }
 


### PR DESCRIPTION
## Summary
- Adds `/admin` route to gptme webui with a live session management panel
- Lists all active server-side sessions with ID, conversation, model, message count, status (idle/generating with elapsed time), and last activity
- Kill button with confirmation prompt calls `DELETE /api/v2/sessions/{id}` and removes the row
- Auto-refreshes every 5s via react-query `refetchInterval`

## Motivation
Erik currently needs CLI/ssh access to inspect or kill running sessions. This panel gives browser-based visibility into active sessions and one-click kill without leaving the webui.

## Changes

### Server (`gptme/server/api_v2.py`)
- `GET /api/v2/sessions` — returns snapshot of all `ConversationSession` objects from `SessionManager` with model (from chat config), message count, generating flag, elapsed seconds, and timestamps
- `DELETE /api/v2/sessions/<id>` — interrupts generation, clears pending tools, removes session via `SessionManager.remove_session()`

### Webui
- `src/components/AdminView.tsx` — sessions table with stats header (total/generating/idle counts), per-row kill button, loading/error/empty states
- `src/pages/Admin.tsx` — page shell (same pattern as ExternalSessions)
- `src/App.tsx` — lazy `/admin` route
- `src/components/SidebarIcons.tsx` — Shield icon nav entry
- `src/types/api.ts` — `ActiveSession` interface
- `src/utils/api.ts` — `getSessions()` and `deleteSession()` methods on `ApiClient`

## Test plan
- [ ] Open `/admin` in browser — sessions table renders with correct columns
- [ ] Kill button shows confirmation dialog, then calls DELETE and table refreshes
- [ ] Panel auto-refreshes every 5s when new sessions start/stop
- [ ] Empty state shown when no sessions active
- [ ] Generating sessions show elapsed time badge