### PR TITLE
feat(resilience): add CircuitBreaker for flaky MCP/tool calls

### DIFF
--- a/gptme/circuit_breaker.py
+++ b/gptme/circuit_breaker.py
@@ -30,14 +30,12 @@ import logging
 import threading
 import time
 from enum import Enum
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from collections.abc import Callable
 
 logger = logging.getLogger(__name__)
-
-F = TypeVar("F")
 
 
 class CircuitState(Enum):
@@ -85,6 +83,7 @@ class CircuitBreaker:
         self._opened_at: float | None = (
             None  # monotonic timestamp of last OPEN transition
         )
+        self._probing: bool = False  # True while a HALF_OPEN probe is in flight
 
     # ------------------------------------------------------------------
     # Public read-only properties
@@ -106,12 +105,26 @@ class CircuitBreaker:
     # Core call interface
     # ------------------------------------------------------------------
 
-    def call(self, func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+    def call(
+        self,
+        func: Callable[..., Any],
+        *args: Any,
+        ignore_exceptions: tuple[type[Exception], ...] = (),
+        **kwargs: Any,
+    ) -> Any:
         """Call *func* with circuit-breaker protection.
+
+        Args:
+            func: Callable to invoke.
+            *args: Positional arguments forwarded to *func*.
+            ignore_exceptions: Exception types that should NOT count as failures.
+                Useful for user-cancellation errors (e.g. ``MCPInterruptedError``)
+                that should not trip the breaker.
+            **kwargs: Keyword arguments forwarded to *func*.
 
         Raises:
             CircuitOpenError: If the breaker is OPEN and the cooldown has not
-                elapsed yet.
+                elapsed yet, or if a HALF_OPEN probe is already in flight.
             Exception: Any exception raised by *func* (recorded as a failure).
         """
         with self._lock:
@@ -126,16 +139,27 @@ class CircuitBreaker:
                     self.name,
                 )
                 self._state = CircuitState.HALF_OPEN
+                self._probing = False
 
-            # CLOSED or HALF_OPEN: let the call through
-            # Release the lock while executing so we don't block other threads
-            # (they'll see HALF_OPEN and be rejected or wait).
+            if self._state == CircuitState.HALF_OPEN:
+                if self._probing:
+                    # Another probe is already in flight — reject until it resolves
+                    raise CircuitOpenError(self.name, retry_after=self.cooldown)
+                self._probing = True
+
+            # CLOSED or HALF_OPEN (probe claimed): let the call through.
+            # Release the lock while executing so we don't block other threads.
             current_state = self._state
 
         # Execute outside the lock
         try:
             result = func(*args, **kwargs)
         except Exception as exc:
+            if ignore_exceptions and isinstance(exc, ignore_exceptions):
+                if current_state == CircuitState.HALF_OPEN:
+                    with self._lock:
+                        self._probing = False
+                raise
             self._record_failure(current_state, exc)
             raise
 
@@ -160,6 +184,7 @@ class CircuitBreaker:
             self._state = CircuitState.CLOSED
             self._failure_count = 0
             self._opened_at = None
+            self._probing = False
 
     def _record_failure(self, previous_state: CircuitState, exc: Exception) -> None:
         with self._lock:
@@ -172,6 +197,7 @@ class CircuitBreaker:
                 )
                 self._state = CircuitState.OPEN
                 self._opened_at = time.monotonic()
+                self._probing = False
                 return
 
             # CLOSED state — increment counter
@@ -202,6 +228,7 @@ class CircuitBreaker:
             self._state = CircuitState.CLOSED
             self._failure_count = 0
             self._opened_at = None
+            self._probing = False
 
     def seconds_until_probe(self) -> float:
         """Return seconds remaining before a probe is allowed, or 0 if now."""

--- a/gptme/circuit_breaker.py
+++ b/gptme/circuit_breaker.py
@@ -209,7 +209,10 @@ class CircuitBreaker:
                 self.failure_threshold,
                 exc,
             )
-            if self._failure_count >= self.failure_threshold:
+            if (
+                self._failure_count >= self.failure_threshold
+                and self._state == CircuitState.CLOSED
+            ):
                 logger.warning(
                     "CircuitBreaker '%s': threshold reached (%d), transitioning to OPEN",
                     self.name,

--- a/gptme/circuit_breaker.py
+++ b/gptme/circuit_breaker.py
@@ -1,0 +1,262 @@
+"""Circuit breaker for flaky tool/MCP calls.
+
+Implements the classic CLOSED → OPEN → HALF_OPEN state machine per tool or
+per server name.  After ``failure_threshold`` consecutive failures the breaker
+OPEN-circuits and subsequent calls fail immediately without hitting the server.
+After ``cooldown`` seconds a single *probe* call is allowed (HALF_OPEN); if it
+succeeds the breaker resets to CLOSED, otherwise the open timer is reset.
+
+Thread-safety is provided by a per-breaker ``threading.Lock``.
+
+Usage::
+
+    from gptme.circuit_breaker import CircuitBreaker, CircuitOpenError
+
+    cb = CircuitBreaker(name="my_tool", failure_threshold=5, cooldown=30.0)
+
+    try:
+        result = cb.call(my_function, arg1, kwarg=value)
+    except CircuitOpenError:
+        # tool is currently tripped; handle gracefully
+        ...
+    except Exception as exc:
+        # real failure from the underlying call; breaker recorded it
+        ...
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from enum import Enum
+from typing import TYPE_CHECKING, Any, TypeVar
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+logger = logging.getLogger(__name__)
+
+F = TypeVar("F")
+
+
+class CircuitState(Enum):
+    CLOSED = "closed"
+    OPEN = "open"
+    HALF_OPEN = "half_open"
+
+
+class CircuitOpenError(Exception):
+    """Raised when a call is rejected because the circuit breaker is open."""
+
+    def __init__(self, name: str, retry_after: float | None = None) -> None:
+        self.name = name
+        self.retry_after = retry_after
+        msg = f"Circuit breaker '{name}' is OPEN"
+        if retry_after is not None:
+            msg += f"; retry after {retry_after:.1f}s"
+        super().__init__(msg)
+
+
+class CircuitBreaker:
+    """Per-resource circuit breaker with CLOSED/OPEN/HALF_OPEN states.
+
+    Args:
+        name: Human-readable identifier for logging and error messages.
+        failure_threshold: Number of consecutive failures before opening.
+            Defaults to 5.
+        cooldown: Seconds to wait after opening before allowing a probe.
+            Defaults to 30.0.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        failure_threshold: int = 5,
+        cooldown: float = 30.0,
+    ) -> None:
+        self.name = name
+        self.failure_threshold = failure_threshold
+        self.cooldown = cooldown
+
+        self._lock = threading.Lock()
+        self._state: CircuitState = CircuitState.CLOSED
+        self._failure_count: int = 0
+        self._opened_at: float | None = (
+            None  # monotonic timestamp of last OPEN transition
+        )
+
+    # ------------------------------------------------------------------
+    # Public read-only properties
+    # ------------------------------------------------------------------
+
+    @property
+    def state(self) -> CircuitState:
+        """Current state (thread-safe snapshot)."""
+        with self._lock:
+            return self._state
+
+    @property
+    def failure_count(self) -> int:
+        """Current consecutive failure count (thread-safe snapshot)."""
+        with self._lock:
+            return self._failure_count
+
+    # ------------------------------------------------------------------
+    # Core call interface
+    # ------------------------------------------------------------------
+
+    def call(self, func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+        """Call *func* with circuit-breaker protection.
+
+        Raises:
+            CircuitOpenError: If the breaker is OPEN and the cooldown has not
+                elapsed yet.
+            Exception: Any exception raised by *func* (recorded as a failure).
+        """
+        with self._lock:
+            if self._state == CircuitState.OPEN:
+                elapsed = time.monotonic() - (self._opened_at or 0.0)
+                remaining = self.cooldown - elapsed
+                if remaining > 0:
+                    raise CircuitOpenError(self.name, retry_after=remaining)
+                # Cooldown elapsed — allow one probe
+                logger.debug(
+                    "CircuitBreaker '%s': cooldown elapsed, transitioning to HALF_OPEN",
+                    self.name,
+                )
+                self._state = CircuitState.HALF_OPEN
+
+            # CLOSED or HALF_OPEN: let the call through
+            # Release the lock while executing so we don't block other threads
+            # (they'll see HALF_OPEN and be rejected or wait).
+            current_state = self._state
+
+        # Execute outside the lock
+        try:
+            result = func(*args, **kwargs)
+        except Exception as exc:
+            self._record_failure(current_state, exc)
+            raise
+
+        self._record_success(current_state)
+        return result
+
+    # ------------------------------------------------------------------
+    # Internal state transitions
+    # ------------------------------------------------------------------
+
+    def _record_success(self, previous_state: CircuitState) -> None:
+        with self._lock:
+            if previous_state == CircuitState.HALF_OPEN:
+                logger.info(
+                    "CircuitBreaker '%s': probe succeeded, resetting to CLOSED",
+                    self.name,
+                )
+            else:
+                logger.debug(
+                    "CircuitBreaker '%s': call succeeded, resetting counters", self.name
+                )
+            self._state = CircuitState.CLOSED
+            self._failure_count = 0
+            self._opened_at = None
+
+    def _record_failure(self, previous_state: CircuitState, exc: Exception) -> None:
+        with self._lock:
+            if previous_state == CircuitState.HALF_OPEN:
+                # Probe failed — reset the open timer so we wait another cooldown
+                logger.warning(
+                    "CircuitBreaker '%s': probe FAILED (%s), resetting open timer",
+                    self.name,
+                    exc,
+                )
+                self._state = CircuitState.OPEN
+                self._opened_at = time.monotonic()
+                return
+
+            # CLOSED state — increment counter
+            self._failure_count += 1
+            logger.debug(
+                "CircuitBreaker '%s': failure %d/%d (%s)",
+                self.name,
+                self._failure_count,
+                self.failure_threshold,
+                exc,
+            )
+            if self._failure_count >= self.failure_threshold:
+                logger.warning(
+                    "CircuitBreaker '%s': threshold reached (%d), transitioning to OPEN",
+                    self.name,
+                    self._failure_count,
+                )
+                self._state = CircuitState.OPEN
+                self._opened_at = time.monotonic()
+
+    # ------------------------------------------------------------------
+    # Convenience / introspection
+    # ------------------------------------------------------------------
+
+    def reset(self) -> None:
+        """Manually reset the breaker to CLOSED (useful for testing)."""
+        with self._lock:
+            self._state = CircuitState.CLOSED
+            self._failure_count = 0
+            self._opened_at = None
+
+    def seconds_until_probe(self) -> float:
+        """Return seconds remaining before a probe is allowed, or 0 if now."""
+        with self._lock:
+            if self._state != CircuitState.OPEN or self._opened_at is None:
+                return 0.0
+            elapsed = time.monotonic() - self._opened_at
+            return max(0.0, self.cooldown - elapsed)
+
+    def __repr__(self) -> str:
+        with self._lock:
+            return (
+                f"CircuitBreaker(name={self.name!r}, state={self._state.value}, "
+                f"failures={self._failure_count}/{self.failure_threshold})"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Registry: per-name singleton breakers shared across threads
+# ---------------------------------------------------------------------------
+
+_registry_lock = threading.Lock()
+_registry: dict[str, CircuitBreaker] = {}
+
+
+def get_breaker(
+    name: str,
+    failure_threshold: int = 5,
+    cooldown: float = 30.0,
+) -> CircuitBreaker:
+    """Return the (cached) CircuitBreaker for *name*, creating it if needed.
+
+    Parameters are only applied on first creation; subsequent calls return the
+    existing breaker unchanged.
+    """
+    with _registry_lock:
+        if name not in _registry:
+            _registry[name] = CircuitBreaker(
+                name=name,
+                failure_threshold=failure_threshold,
+                cooldown=cooldown,
+            )
+        return _registry[name]
+
+
+def clear_registry() -> None:
+    """Remove all registered breakers.  Primarily for test isolation."""
+    with _registry_lock:
+        _registry.clear()
+
+
+__all__ = [
+    "CircuitBreaker",
+    "CircuitOpenError",
+    "CircuitState",
+    "get_breaker",
+    "clear_registry",
+]

--- a/gptme/mcp/client.py
+++ b/gptme/mcp/client.py
@@ -11,6 +11,7 @@ from mcp.client.session import RequestContext
 from mcp.client.stdio import StdioServerParameters, stdio_client
 from mcp.client.streamable_http import streamablehttp_client
 
+from gptme.circuit_breaker import CircuitBreaker, CircuitOpenError  # noqa: F401
 from gptme.config import Config, get_config
 
 # Type alias for elicitation callback
@@ -67,6 +68,9 @@ class MCPClient:
         self.stack: AsyncExitStack | None = None
         self.roots: list[types.Root] = []
         self._elicitation_callback: ElicitationCallback | None = None
+        # Per-client circuit breaker, keyed by server name after connect().
+        # The breaker protects call_tool() calls from hammering a broken server.
+        self._circuit_breaker: CircuitBreaker | None = None
 
     def _run_async(self, coro):
         """Run a coroutine in the event loop.
@@ -268,11 +272,19 @@ class MCPClient:
             )
             tools, session = self._run_async(self._setup_stdio_connection(params))
 
+        # Create a per-server circuit breaker (default: 5 failures / 30s cooldown).
+        self._circuit_breaker = CircuitBreaker(name=f"mcp:{server_name}")
         logger.info(f"Tools: {tools}")
         return tools, session
 
     def call_tool(self, tool_name: str, arguments: dict) -> str:
-        """Synchronous tool call method"""
+        """Synchronous tool call method.
+
+        Raises:
+            CircuitOpenError: If the circuit breaker for this server is open
+                (i.e. consecutive failures have exceeded the threshold).  Callers
+                should treat this as a transient error and surface it to the user.
+        """
         if not self.session:
             raise RuntimeError("Not connected to MCP server")
 
@@ -297,6 +309,10 @@ class MCPClient:
                         return content.text
             return str(result)
 
+        # Wrap the synchronous _run_async call with the circuit breaker so that
+        # consecutive transport or server-side failures trip the breaker.
+        if self._circuit_breaker is not None:
+            return self._circuit_breaker.call(self._run_async, _call_tool())
         return self._run_async(_call_tool())
 
     def list_resources(self) -> types.ListResourcesResult:

--- a/gptme/mcp/client.py
+++ b/gptme/mcp/client.py
@@ -11,7 +11,7 @@ from mcp.client.session import RequestContext
 from mcp.client.stdio import StdioServerParameters, stdio_client
 from mcp.client.streamable_http import streamablehttp_client
 
-from gptme.circuit_breaker import CircuitBreaker, CircuitOpenError  # noqa: F401
+from gptme.circuit_breaker import CircuitBreaker
 from gptme.config import Config, get_config
 
 # Type alias for elicitation callback
@@ -311,8 +311,14 @@ class MCPClient:
 
         # Wrap the synchronous _run_async call with the circuit breaker so that
         # consecutive transport or server-side failures trip the breaker.
+        # Use a lambda so the coroutine is only created if the breaker allows
+        # the call through — avoids RuntimeWarning on every open-circuit fast-fail.
+        # MCPInterruptedError (user Ctrl-C) is excluded from failure counting.
         if self._circuit_breaker is not None:
-            return self._circuit_breaker.call(self._run_async, _call_tool())
+            return self._circuit_breaker.call(
+                lambda: self._run_async(_call_tool()),
+                ignore_exceptions=(MCPInterruptedError,),
+            )
         return self._run_async(_call_tool())
 
     def list_resources(self) -> types.ListResourcesResult:

--- a/tests/test_circuit_breaker.py
+++ b/tests/test_circuit_breaker.py
@@ -1,0 +1,402 @@
+"""Tests for gptme.circuit_breaker.
+
+Covers:
+- All three state transitions (CLOSED → OPEN → HALF_OPEN → CLOSED)
+- Probe-on-HALF_OPEN: success resets, failure re-opens
+- Concurrent access (multiple threads hitting the breaker simultaneously)
+- Edge cases: threshold=1, zero cooldown, manual reset
+- Registry helpers (get_breaker, clear_registry)
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from gptme.circuit_breaker import (
+    CircuitBreaker,
+    CircuitOpenError,
+    CircuitState,
+    clear_registry,
+    get_breaker,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_breaker(
+    name: str = "test",
+    failure_threshold: int = 3,
+    cooldown: float = 60.0,
+    **_kwargs: object,
+) -> CircuitBreaker:
+    """Return a fresh CircuitBreaker with sensible test defaults."""
+    return CircuitBreaker(
+        name=name, failure_threshold=failure_threshold, cooldown=cooldown
+    )
+
+
+def _fail(exc: Exception | None = None) -> None:
+    raise exc if exc is not None else RuntimeError("boom")
+
+
+def _succeed(value: str = "ok") -> str:
+    return value
+
+
+# ---------------------------------------------------------------------------
+# Basic state machine
+# ---------------------------------------------------------------------------
+
+
+class TestClosedState:
+    def test_starts_closed(self):
+        cb = _make_breaker()
+        assert cb.state == CircuitState.CLOSED
+
+    def test_success_stays_closed(self):
+        cb = _make_breaker()
+        result = cb.call(_succeed)
+        assert result == "ok"
+        assert cb.state == CircuitState.CLOSED
+        assert cb.failure_count == 0
+
+    def test_failure_increments_count(self):
+        cb = _make_breaker(failure_threshold=3)
+        with pytest.raises(RuntimeError):
+            cb.call(_fail)
+        assert cb.failure_count == 1
+        assert cb.state == CircuitState.CLOSED
+
+    def test_success_resets_failure_count(self):
+        cb = _make_breaker(failure_threshold=3)
+        # Two failures
+        for _ in range(2):
+            with pytest.raises(RuntimeError):
+                cb.call(_fail)
+        assert cb.failure_count == 2
+        # One success resets the count
+        cb.call(_succeed)
+        assert cb.failure_count == 0
+        assert cb.state == CircuitState.CLOSED
+
+
+class TestClosedToOpen:
+    def test_opens_after_threshold(self):
+        cb = _make_breaker(failure_threshold=3)
+        for _ in range(3):
+            with pytest.raises(RuntimeError):
+                cb.call(_fail)
+        assert cb.state == CircuitState.OPEN
+
+    def test_call_raises_circuit_open_when_open(self):
+        cb = _make_breaker(failure_threshold=1, cooldown=60.0)
+        with pytest.raises(RuntimeError):
+            cb.call(_fail)
+        # Now open — next call should raise CircuitOpenError, not RuntimeError
+        with pytest.raises(CircuitOpenError) as exc_info:
+            cb.call(_succeed)
+        assert exc_info.value.name == "test"
+        assert exc_info.value.retry_after is not None
+        assert exc_info.value.retry_after > 0
+
+    def test_circuit_open_error_message(self):
+        cb = _make_breaker(failure_threshold=1, cooldown=60.0)
+        with pytest.raises(RuntimeError):
+            cb.call(_fail)
+        with pytest.raises(CircuitOpenError) as exc_info:
+            cb.call(_fail)
+        assert "OPEN" in str(exc_info.value)
+
+    def test_fails_fast_multiple_times(self):
+        cb = _make_breaker(failure_threshold=2, cooldown=60.0)
+        for _ in range(2):
+            with pytest.raises(RuntimeError):
+                cb.call(_fail)
+        # All subsequent calls should be fast-fail, not actually calling the function
+        mock_fn = MagicMock(side_effect=RuntimeError("should not be called"))
+        for _ in range(5):
+            with pytest.raises(CircuitOpenError):
+                cb.call(mock_fn)
+        mock_fn.assert_not_called()
+
+
+class TestOpenToHalfOpen:
+    def test_transitions_to_half_open_after_cooldown(self, monkeypatch):
+        cb = _make_breaker(failure_threshold=1, cooldown=1.0)
+        with pytest.raises(RuntimeError):
+            cb.call(_fail)
+        assert cb.state == CircuitState.OPEN
+
+        # Fast-forward time past cooldown
+        original_monotonic = time.monotonic
+        monkeypatch.setattr(time, "monotonic", lambda: original_monotonic() + 2.0)
+
+        # Next call should be allowed as a probe (HALF_OPEN)
+        result = cb.call(_succeed)
+        assert result == "ok"
+        assert cb.state == CircuitState.CLOSED
+
+    def test_seconds_until_probe_decreases(self, monkeypatch):
+        cb = _make_breaker(failure_threshold=1, cooldown=10.0)
+        base = time.monotonic()
+        with pytest.raises(RuntimeError):
+            cb.call(_fail)
+
+        # At t=0: full wait remaining
+        monkeypatch.setattr(time, "monotonic", lambda: base)
+        remaining_0 = cb.seconds_until_probe()
+        assert remaining_0 > 0
+
+        # At t=5: half the wait gone
+        monkeypatch.setattr(time, "monotonic", lambda: base + 5.0)
+        remaining_5 = cb.seconds_until_probe()
+        assert remaining_5 < remaining_0
+
+        # After cooldown: no wait
+        monkeypatch.setattr(time, "monotonic", lambda: base + 11.0)
+        assert cb.seconds_until_probe() == 0.0
+
+
+class TestHalfOpen:
+    def test_probe_success_resets_to_closed(self, monkeypatch):
+        cb = _make_breaker(failure_threshold=1, cooldown=1.0)
+        with pytest.raises(RuntimeError):
+            cb.call(_fail)
+
+        original = time.monotonic
+        monkeypatch.setattr(time, "monotonic", lambda: original() + 2.0)
+        cb.call(_succeed)
+
+        assert cb.state == CircuitState.CLOSED
+        assert cb.failure_count == 0
+
+    def test_probe_failure_resets_open_timer(self, monkeypatch):
+        cb = _make_breaker(failure_threshold=1, cooldown=2.0)
+        t0 = time.monotonic()
+        with pytest.raises(RuntimeError):
+            cb.call(_fail)
+
+        # Advance past cooldown to allow a probe
+        monkeypatch.setattr(time, "monotonic", lambda: t0 + 3.0)
+        with pytest.raises(RuntimeError):
+            cb.call(_fail)
+
+        # State should still be OPEN with a fresh timer
+        assert cb.state == CircuitState.OPEN
+        # The timer was reset, so seconds_until_probe should be close to cooldown
+        remaining = cb.seconds_until_probe()
+        assert 0.0 < remaining <= 2.0
+
+    def test_only_one_probe_allowed_at_a_time(self, monkeypatch):
+        """After cooldown, only one call transitions to HALF_OPEN.
+
+        Concurrent threads should see CircuitOpenError until the probe resolves.
+        This test simulates that by checking the second call is rejected after
+        the state transitions to HALF_OPEN mid-flight.
+        """
+        cb = _make_breaker(failure_threshold=1, cooldown=1.0)
+        with pytest.raises(RuntimeError):
+            cb.call(_fail)
+
+        original = time.monotonic
+        monkeypatch.setattr(time, "monotonic", lambda: original() + 2.0)
+
+        # Manually set to HALF_OPEN to test the second-call rejection
+        with cb._lock:
+            cb._state = CircuitState.HALF_OPEN
+
+        # While one probe is in-flight (state=HALF_OPEN), another thread calling
+        # would see HALF_OPEN and be allowed through too (this is intentional —
+        # HALF_OPEN acts as a single-probe window in this implementation since
+        # we transition state *after* the call completes).  Verify the probe works.
+        result = cb.call(_succeed)
+        assert result == "ok"
+        assert cb.state == CircuitState.CLOSED
+
+
+# ---------------------------------------------------------------------------
+# Manual reset
+# ---------------------------------------------------------------------------
+
+
+class TestReset:
+    def test_reset_clears_state(self):
+        cb = _make_breaker(failure_threshold=1, cooldown=60.0)
+        with pytest.raises(RuntimeError):
+            cb.call(_fail)
+        assert cb.state == CircuitState.OPEN
+        cb.reset()
+        assert cb.state == CircuitState.CLOSED
+        assert cb.failure_count == 0
+
+    def test_reset_allows_calls_again(self):
+        cb = _make_breaker(failure_threshold=1, cooldown=60.0)
+        with pytest.raises(RuntimeError):
+            cb.call(_fail)
+        cb.reset()
+        result = cb.call(_succeed)
+        assert result == "ok"
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_threshold_one(self):
+        cb = _make_breaker(failure_threshold=1, cooldown=60.0)
+        with pytest.raises(RuntimeError):
+            cb.call(_fail)
+        assert cb.state == CircuitState.OPEN
+
+    def test_zero_cooldown_allows_immediate_probe(self, monkeypatch):
+        cb = _make_breaker(failure_threshold=1, cooldown=0.0)
+        with pytest.raises(RuntimeError):
+            cb.call(_fail)
+        # With cooldown=0, the probe should be immediately available
+        result = cb.call(_succeed)
+        assert result == "ok"
+        assert cb.state == CircuitState.CLOSED
+
+    def test_different_exception_types_count(self):
+        cb = _make_breaker(failure_threshold=2)
+        with pytest.raises(ValueError, match="v"):
+            cb.call(lambda: (_ for _ in ()).throw(ValueError("v")))
+        with pytest.raises(OSError, match="io"):
+            cb.call(lambda: (_ for _ in ()).throw(OSError("io")))
+        assert cb.state == CircuitState.OPEN
+
+    def test_repr(self):
+        cb = _make_breaker(failure_threshold=5, cooldown=30.0)
+        r = repr(cb)
+        assert "test" in r
+        assert "closed" in r
+        assert "0/5" in r
+
+
+# ---------------------------------------------------------------------------
+# Concurrent access
+# ---------------------------------------------------------------------------
+
+
+class TestConcurrentAccess:
+    def test_thread_safe_failure_counting(self):
+        """Many threads failing simultaneously should not corrupt the counter."""
+        cb = _make_breaker(failure_threshold=100, cooldown=60.0)
+        n_threads = 50
+        errors: list[Exception] = []
+
+        def do_fail():
+            try:
+                cb.call(_fail)
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=do_fail) for _ in range(n_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        # All exceptions should be RuntimeError (circuit still closed since threshold=100)
+        assert all(isinstance(e, RuntimeError) for e in errors)
+        assert cb.failure_count == n_threads
+        assert cb.state == CircuitState.CLOSED
+
+    def test_circuit_opens_exactly_once_under_concurrency(self):
+        """Only one thread should see the CLOSED→OPEN transition."""
+        threshold = 5
+        cb = _make_breaker(failure_threshold=threshold, cooldown=60.0)
+        n_threads = 20
+        open_errors: list[CircuitOpenError] = []
+        runtime_errors: list[RuntimeError] = []
+        lock = threading.Lock()
+
+        def do_fail():
+            try:
+                cb.call(_fail)
+            except CircuitOpenError as e:
+                with lock:
+                    open_errors.append(e)
+            except RuntimeError as e:
+                with lock:
+                    runtime_errors.append(e)
+
+        threads = [threading.Thread(target=do_fail) for _ in range(n_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        # Exactly `threshold` RuntimeErrors; rest are CircuitOpenErrors
+        assert len(runtime_errors) == threshold
+        assert len(open_errors) == n_threads - threshold
+        assert cb.state == CircuitState.OPEN
+
+    def test_concurrent_successes_reset_cleanly(self):
+        """Concurrent successes should not corrupt state."""
+        cb = _make_breaker(failure_threshold=10, cooldown=60.0)
+        results: list[str] = []
+        lock = threading.Lock()
+
+        def do_succeed():
+            r = cb.call(_succeed)
+            with lock:
+                results.append(r)
+
+        threads = [threading.Thread(target=do_succeed) for _ in range(20)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert len(results) == 20
+        assert all(r == "ok" for r in results)
+        assert cb.state == CircuitState.CLOSED
+        assert cb.failure_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+class TestRegistry:
+    def setup_method(self):
+        clear_registry()
+
+    def test_get_breaker_returns_same_instance(self):
+        b1 = get_breaker("svc-a")
+        b2 = get_breaker("svc-a")
+        assert b1 is b2
+
+    def test_get_breaker_different_names(self):
+        b1 = get_breaker("svc-a")
+        b2 = get_breaker("svc-b")
+        assert b1 is not b2
+
+    def test_get_breaker_applies_params_on_first_call(self):
+        b = get_breaker("svc", failure_threshold=2, cooldown=5.0)
+        assert b.failure_threshold == 2
+        assert b.cooldown == 5.0
+
+    def test_get_breaker_ignores_params_on_second_call(self):
+        b1 = get_breaker("svc", failure_threshold=2, cooldown=5.0)
+        b2 = get_breaker("svc", failure_threshold=99, cooldown=999.0)
+        # Params from first call win
+        assert b1 is b2
+        assert b2.failure_threshold == 2
+        assert b2.cooldown == 5.0
+
+    def test_clear_registry(self):
+        b1 = get_breaker("svc")
+        clear_registry()
+        b2 = get_breaker("svc")
+        assert b1 is not b2

--- a/tests/test_circuit_breaker.py
+++ b/tests/test_circuit_breaker.py
@@ -197,8 +197,6 @@ class TestHalfOpen:
         """After cooldown, only one call transitions to HALF_OPEN.
 
         Concurrent threads should see CircuitOpenError until the probe resolves.
-        This test simulates that by checking the second call is rejected after
-        the state transitions to HALF_OPEN mid-flight.
         """
         cb = _make_breaker(failure_threshold=1, cooldown=1.0)
         with pytest.raises(RuntimeError):
@@ -207,14 +205,19 @@ class TestHalfOpen:
         original = time.monotonic
         monkeypatch.setattr(time, "monotonic", lambda: original() + 2.0)
 
-        # Manually set to HALF_OPEN to test the second-call rejection
+        # Simulate an in-flight probe by setting HALF_OPEN + _probing=True
         with cb._lock:
             cb._state = CircuitState.HALF_OPEN
+            cb._probing = True
 
-        # While one probe is in-flight (state=HALF_OPEN), another thread calling
-        # would see HALF_OPEN and be allowed through too (this is intentional —
-        # HALF_OPEN acts as a single-probe window in this implementation since
-        # we transition state *after* the call completes).  Verify the probe works.
+        # A second call while the probe is in flight should be rejected
+        with pytest.raises(CircuitOpenError):
+            cb.call(_succeed)
+
+        # Once the probe finishes (probing cleared), a new probe is allowed
+        with cb._lock:
+            cb._probing = False
+
         result = cb.call(_succeed)
         assert result == "ok"
         assert cb.state == CircuitState.CLOSED
@@ -280,6 +283,52 @@ class TestEdgeCases:
         assert "closed" in r
         assert "0/5" in r
 
+    def test_ignore_exceptions_does_not_count_as_failure(self):
+        """Exceptions listed in ignore_exceptions should not trip the breaker."""
+        cb = _make_breaker(failure_threshold=2, cooldown=60.0)
+
+        class UserCancel(Exception):
+            pass
+
+        for _ in range(10):
+            with pytest.raises(UserCancel):
+                cb.call(
+                    lambda: (_ for _ in ()).throw(UserCancel("cancelled")),
+                    ignore_exceptions=(UserCancel,),
+                )
+
+        # Breaker should still be CLOSED — cancellations are not failures
+        assert cb.state == CircuitState.CLOSED
+        assert cb.failure_count == 0
+
+    def test_ignore_exceptions_in_half_open_clears_probe_flag(self):
+        """Ignored exceptions during HALF_OPEN clear _probing without recording a failure."""
+        cb = _make_breaker(failure_threshold=1, cooldown=0.0)
+
+        class UserCancel(Exception):
+            pass
+
+        with pytest.raises(RuntimeError):
+            cb.call(_fail)
+        assert cb.state == CircuitState.OPEN
+
+        # Force HALF_OPEN with no probe in flight so call() can claim the probe
+        with cb._lock:
+            cb._state = CircuitState.HALF_OPEN
+            cb._probing = False
+
+        # An ignored exception: probe flag should be cleared, state stays HALF_OPEN
+        with pytest.raises(UserCancel):
+            cb.call(
+                lambda: (_ for _ in ()).throw(UserCancel()),
+                ignore_exceptions=(UserCancel,),
+            )
+
+        # _probing cleared; a new probe is now allowed; state not moved to CLOSED/OPEN
+        with cb._lock:
+            assert not cb._probing
+            assert cb._state == CircuitState.HALF_OPEN
+
 
 # ---------------------------------------------------------------------------
 # Concurrent access
@@ -335,9 +384,12 @@ class TestConcurrentAccess:
         for t in threads:
             t.join()
 
-        # Exactly `threshold` RuntimeErrors; rest are CircuitOpenErrors
-        assert len(runtime_errors) == threshold
-        assert len(open_errors) == n_threads - threshold
+        # All threads see exactly one outcome
+        assert len(runtime_errors) + len(open_errors) == n_threads
+        # At least threshold failures are needed to trip the breaker; concurrent
+        # threads can all pass the pre-call state check before any failure is
+        # recorded, so the exact count is non-deterministic — only the lower bound holds.
+        assert len(runtime_errors) >= threshold
         assert cb.state == CircuitState.OPEN
 
     def test_concurrent_successes_reset_cleanly(self):

--- a/tests/test_circuit_breaker.py
+++ b/tests/test_circuit_breaker.py
@@ -392,6 +392,41 @@ class TestConcurrentAccess:
         assert len(runtime_errors) >= threshold
         assert cb.state == CircuitState.OPEN
 
+    def test_opened_at_not_reset_by_concurrent_failures_past_threshold(self):
+        """_opened_at should only be stamped once on the first CLOSED→OPEN transition.
+
+        When many threads all fail past the threshold, only the first one should
+        set _opened_at.  Later concurrent failures must NOT overwrite it, otherwise
+        the effective cooldown window drifts forward.
+        """
+        threshold = 3
+        cb = _make_breaker(failure_threshold=threshold, cooldown=60.0)
+        n_threads = 20
+        barrier = threading.Barrier(n_threads)
+
+        def _fail_after_barrier() -> None:
+            barrier.wait()
+            _fail()
+
+        def do_fail():
+            try:
+                cb.call(_fail_after_barrier)
+            except Exception:
+                pass
+
+        threads = [threading.Thread(target=do_fail) for _ in range(n_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert cb.state == CircuitState.OPEN
+        # _opened_at must be a single value, not NaN or unreasonably far in the future.
+        # Specifically the cooldown should not have been pushed forward by N extra
+        # monotonic() calls — if it had, seconds_until_probe() would exceed cooldown.
+        assert cb._opened_at is not None
+        assert cb.seconds_until_probe() <= cb.cooldown
+
     def test_concurrent_successes_reset_cleanly(self):
         """Concurrent successes should not corrupt state."""
         cb = _make_breaker(failure_threshold=10, cooldown=60.0)


### PR DESCRIPTION
## Summary

- Adds `gptme/circuit_breaker.py` — a thread-safe `CircuitBreaker` class with `CLOSED`/`OPEN`/`HALF_OPEN` states, configurable `failure_threshold` (default 5) and `cooldown` (default 30s), plus a module-level registry (`get_breaker` / `clear_registry`)
- Wires the breaker into `MCPClient.call_tool()` in `gptme/mcp/client.py` so that after N consecutive failures calls fail fast with `CircuitOpenError` without hitting the server; a single probe is allowed after the cooldown
- Adds `tests/test_circuit_breaker.py` with 27 tests covering all state transitions, HALF_OPEN probe semantics, concurrent access (50-thread counting + 20-thread race), edge cases, and registry helpers

## Design

The state machine per instance:
```
CLOSED --[threshold failures]--> OPEN --[cooldown elapsed + probe fails]--> OPEN (timer reset)
                                         |
                                         +--[cooldown elapsed + probe succeeds]--> CLOSED
```

`MCPClient` creates one `CircuitBreaker` per server on `connect()`, keyed as `mcp:<server_name>`.  `CircuitOpenError` bubbles up to the caller with a `retry_after` hint so the UI can surface it gracefully.

## Test plan

- [x] All 27 unit tests pass locally (`pytest tests/test_circuit_breaker.py`)
- [x] Existing MCP tests unchanged: `pytest tests/test_mcp.py tests/test_mcp_adapter.py tests/test_tools_mcp.py` — 100 passed, 2 xfailed, 2 xpassed
- [x] Pre-commit hooks (ruff, ruff-format, mypy) pass