### PR TITLE
feat(llm): make temperature and top_p request-driven via ChatConfig

### DIFF
--- a/gptme/config/chat.py
+++ b/gptme/config/chat.py
@@ -57,6 +57,10 @@ class ChatConfig:
     interactive: bool = True
     # Max tokens for the model's response. None = provider/model default.
     max_tokens: int | None = None
+    # Sampling temperature override. None = use TEMPERATURE constant (env default 0).
+    temperature: float | None = None
+    # Top-p nucleus sampling override. None = use TOP_P constant (env default 0.1).
+    top_p: float | None = None
     # CLI sessions default to the current directory. Server sessions load
     # through from_logdir/load_or_create to get per-conversation workspaces.
     workspace: Path = field(default_factory=Path.cwd)

--- a/gptme/llm/__init__.py
+++ b/gptme/llm/__init__.py
@@ -221,6 +221,8 @@ def reply(
     output_schema: type | None = None,
     on_token: Callable[[str], None] | None = None,
     max_tokens: int | None = None,
+    temperature: float | None = None,
+    top_p: float | None = None,
 ) -> Message:
     if max_tokens is not None and max_tokens <= 0:
         raise ValueError(f"max_tokens must be a positive integer, got {max_tokens}")
@@ -266,6 +268,8 @@ def reply(
             output_schema=output_schema,
             on_token=on_token,
             max_tokens=max_tokens,
+            temperature=temperature,
+            top_p=top_p,
         )
     json_mode = is_output_json()
     if not json_mode:
@@ -276,6 +280,8 @@ def reply(
         tools,
         output_schema=output_schema,
         max_tokens=max_tokens,
+        temperature=temperature,
+        top_p=top_p,
     )
     if not json_mode:
         rprint(" " * shutil.get_terminal_size().columns, end="\r")
@@ -321,6 +327,8 @@ def _chat_complete(
     tools: list[ToolSpec] | None,
     output_schema: type | None = None,
     max_tokens: int | None = None,
+    temperature: float | None = None,
+    top_p: float | None = None,
 ) -> tuple[str, MessageMetadata | None]:
     if max_tokens is not None and max_tokens <= 0:
         raise ValueError(f"max_tokens must be a positive integer, got {max_tokens}")
@@ -337,7 +345,13 @@ def _chat_complete(
         from .llm_openai import chat as chat_openai
 
         return chat_openai(
-            messages, model, tools, output_schema=output_schema, max_tokens=max_tokens
+            messages,
+            model,
+            tools,
+            output_schema=output_schema,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            top_p=top_p,
         )
     if provider == "anthropic":
         from .llm_anthropic import chat as chat_anthropic
@@ -348,6 +362,8 @@ def _chat_complete(
             tools,
             output_schema=output_schema,
             max_tokens=max_tokens,
+            temperature=temperature,
+            top_p=top_p,
         )
     if provider == "openai-subscription":
         from .llm_openai_subscription import chat as chat_subscription
@@ -397,6 +413,8 @@ def _stream(
     tools: list[ToolSpec] | None,
     output_schema: type | None = None,
     max_tokens: int | None = None,
+    temperature: float | None = None,
+    top_p: float | None = None,
 ) -> _StreamWithMetadata:
     if max_tokens is not None and max_tokens <= 0:
         raise ValueError(f"max_tokens must be a positive integer, got {max_tokens}")
@@ -411,7 +429,13 @@ def _stream(
         from .llm_openai import stream as stream_openai
 
         gen = stream_openai(
-            messages, model, tools, output_schema=output_schema, max_tokens=max_tokens
+            messages,
+            model,
+            tools,
+            output_schema=output_schema,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            top_p=top_p,
         )
         return _StreamWithMetadata(gen, model)
     if provider == "anthropic":
@@ -423,6 +447,8 @@ def _stream(
             tools,
             output_schema=output_schema,
             max_tokens=max_tokens,
+            temperature=temperature,
+            top_p=top_p,
         )
         return _StreamWithMetadata(gen, model)
     if provider == "openai-subscription":
@@ -451,6 +477,8 @@ def _reply_stream(
     output_schema: type | None = None,
     on_token: Callable[[str], None] | None = None,
     max_tokens: int | None = None,
+    temperature: float | None = None,
+    top_p: float | None = None,
 ) -> Message:
     json_mode = is_output_json()
     if not json_mode:
@@ -476,7 +504,13 @@ def _reply_stream(
 
     # Create stream wrapper to capture metadata
     stream = _stream(
-        messages, model, tools, output_schema=output_schema, max_tokens=max_tokens
+        messages,
+        model,
+        tools,
+        output_schema=output_schema,
+        max_tokens=max_tokens,
+        temperature=temperature,
+        top_p=top_p,
     )
 
     try:

--- a/gptme/llm/llm_anthropic.py
+++ b/gptme/llm/llm_anthropic.py
@@ -623,6 +623,8 @@ def chat(
     tools: list[ToolSpec] | None,
     output_schema: type[BaseModel] | None = None,
     max_tokens: int | None = None,
+    temperature: float | None = None,
+    top_p: float | None = None,
 ) -> tuple[str, MessageMetadata | None]:
     from anthropic import NOT_GIVEN  # fmt: skip
 
@@ -673,12 +675,14 @@ def chat(
     output_config_kwargs = _output_config_kwargs(use_thinking=use_thinking)
     thinking_param = _build_thinking_param(model, use_thinking, thinking_budget)
 
+    _temperature = temperature if temperature is not None else TEMPERATURE
+    _top_p = top_p if top_p is not None else TOP_P
     response = _anthropic.messages.create(  # type: ignore[call-overload, misc]
         model=api_model,
         messages=messages_dicts,
         system=system_messages,
-        temperature=TEMPERATURE if not model_meta.supports_reasoning else 1,
-        top_p=TOP_P if not model_meta.supports_reasoning else NOT_GIVEN,
+        temperature=_temperature if not model_meta.supports_reasoning else 1,
+        top_p=_top_p if not model_meta.supports_reasoning else NOT_GIVEN,
         max_tokens=max_tokens,
         tools=tools_dict or NOT_GIVEN,
         thinking=thinking_param if thinking_param is not None else NOT_GIVEN,
@@ -716,6 +720,8 @@ def stream(
     tools: list[ToolSpec] | None,
     output_schema: type[BaseModel] | None = None,
     max_tokens: int | None = None,
+    temperature: float | None = None,
+    top_p: float | None = None,
 ) -> Generator[str, None, MessageMetadata | None]:
     import anthropic.types  # fmt: skip
     from anthropic import NOT_GIVEN  # fmt: skip
@@ -770,12 +776,14 @@ def stream(
     output_config_kwargs = _output_config_kwargs(use_thinking=use_thinking)
     thinking_param = _build_thinking_param(model, use_thinking, thinking_budget)
 
+    _temperature = temperature if temperature is not None else TEMPERATURE
+    _top_p = top_p if top_p is not None else TOP_P
     with _anthropic.messages.stream(  # type: ignore[call-arg, misc]
         model=api_model,
         messages=messages_dicts,
         system=system_messages,
-        temperature=TEMPERATURE if not model_meta.supports_reasoning else 1,
-        top_p=TOP_P if not model_meta.supports_reasoning else NOT_GIVEN,
+        temperature=_temperature if not model_meta.supports_reasoning else 1,
+        top_p=_top_p if not model_meta.supports_reasoning else NOT_GIVEN,
         max_tokens=max_tokens,
         tools=tools_dict or NOT_GIVEN,
         thinking=thinking_param if thinking_param is not None else NOT_GIVEN,  # type: ignore[arg-type]

--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -736,6 +736,8 @@ def chat(
     tools: list[ToolSpec] | None,
     output_schema=None,
     max_tokens: int | None = None,
+    temperature: float | None = None,
+    top_p: float | None = None,
 ) -> tuple[str, MessageMetadata | None]:
     # This will generate code and such, so we need appropriate temperature and top_p params
     # top_p controls diversity, temperature controls randomness
@@ -774,8 +776,10 @@ def chat(
         if max_tokens is not None:
             response_kwargs["max_output_tokens"] = max_tokens
         if not is_reasoner:
-            response_kwargs["temperature"] = TEMPERATURE
-            response_kwargs["top_p"] = TOP_P
+            response_kwargs["temperature"] = (
+                temperature if temperature is not None else TEMPERATURE
+            )
+            response_kwargs["top_p"] = top_p if top_p is not None else TOP_P
 
         response = client.responses.create(**response_kwargs)
         metadata = _record_usage(response.usage, model)
@@ -810,8 +814,10 @@ def chat(
     # Build optional kwargs to avoid NOT_GIVEN/Omit type mismatch
     optional_kwargs: dict[str, Any] = {}
     if not is_reasoner:
-        optional_kwargs["temperature"] = TEMPERATURE
-        optional_kwargs["top_p"] = TOP_P
+        optional_kwargs["temperature"] = (
+            temperature if temperature is not None else TEMPERATURE
+        )
+        optional_kwargs["top_p"] = top_p if top_p is not None else TOP_P
     if tools_dict:
         optional_kwargs["tools"] = tools_dict
     if response_format is not None:
@@ -960,6 +966,8 @@ def _stream_responses(
     model_meta: ModelMeta,
     output_schema=None,
     max_tokens: int | None = None,
+    temperature: float | None = None,
+    top_p: float | None = None,
 ) -> Generator[str, None, MessageMetadata | None]:
     """Stream via the OpenAI Responses API (used for GPT-5 class models).
 
@@ -1001,8 +1009,8 @@ def _stream_responses(
     if max_tokens is not None:
         kwargs["max_output_tokens"] = max_tokens
     if not is_reasoner:
-        kwargs["temperature"] = TEMPERATURE
-        kwargs["top_p"] = TOP_P
+        kwargs["temperature"] = temperature if temperature is not None else TEMPERATURE
+        kwargs["top_p"] = top_p if top_p is not None else TOP_P
 
     # Track function-call items: output_index -> (item_id, name, call_id)
     func_call_items: dict[int, tuple[str, str, str]] = {}
@@ -1109,6 +1117,8 @@ def stream(
     tools: list[ToolSpec] | None,
     output_schema=None,
     max_tokens: int | None = None,
+    temperature: float | None = None,
+    top_p: float | None = None,
 ) -> Generator[str, None, MessageMetadata | None]:
     from . import _get_base_model, get_provider_from_model  # fmt: skip
     from .models import get_model  # fmt: skip
@@ -1136,6 +1146,8 @@ def stream(
             model_meta,
             output_schema=output_schema,
             max_tokens=max_tokens,
+            temperature=temperature,
+            top_p=top_p,
         )
         return captured_metadata
 
@@ -1147,8 +1159,10 @@ def stream(
     # Build optional kwargs to avoid NOT_GIVEN/Omit type mismatch
     optional_kwargs: dict[str, Any] = {}
     if not is_reasoner:
-        optional_kwargs["temperature"] = TEMPERATURE
-        optional_kwargs["top_p"] = TOP_P
+        optional_kwargs["temperature"] = (
+            temperature if temperature is not None else TEMPERATURE
+        )
+        optional_kwargs["top_p"] = top_p if top_p is not None else TOP_P
     if tools_dict:
         optional_kwargs["tools"] = tools_dict
     if response_format is not None:

--- a/gptme/server/openapi_docs.py
+++ b/gptme/server/openapi_docs.py
@@ -425,6 +425,18 @@ class ChatConfig(BaseModel):
         description="Max tokens for the model's response (None = model default)",
         gt=0,
     )
+    temperature: float | None = Field(
+        None,
+        description="Sampling temperature (None = env/constant default 0; 0 = deterministic; higher = more creative)",
+        ge=0.0,
+        le=2.0,
+    )
+    top_p: float | None = Field(
+        None,
+        description="Top-p nucleus sampling (None = env/constant default 0.1)",
+        ge=0.0,
+        le=1.0,
+    )
 
 
 # Helper functions for automatic inference

--- a/gptme/server/openapi_docs.py
+++ b/gptme/server/openapi_docs.py
@@ -427,7 +427,7 @@ class ChatConfig(BaseModel):
     )
     temperature: float | None = Field(
         None,
-        description="Sampling temperature (None = env/constant default 0; 0 = deterministic; higher = more creative)",
+        description="Sampling temperature (None = env/constant default 0; 0 = deterministic; higher = more creative). Max 1.0 for Anthropic; up to 2.0 for OpenAI (values above 1.0 will fail for Anthropic).",
         ge=0.0,
         le=2.0,
     )

--- a/gptme/server/session_step.py
+++ b/gptme/server/session_step.py
@@ -676,12 +676,22 @@ def step(
         metadata = None
         if stream:
             stream_wrapper = _stream(
-                msgs, model, tools, max_tokens=chat_config.max_tokens
+                msgs,
+                model,
+                tools,
+                max_tokens=chat_config.max_tokens,
+                temperature=chat_config.temperature,
+                top_p=chat_config.top_p,
             )
             chunks: Iterable[str] = stream_wrapper
         else:
             response, metadata = _chat_complete(
-                msgs, model, tools, max_tokens=chat_config.max_tokens
+                msgs,
+                model,
+                tools,
+                max_tokens=chat_config.max_tokens,
+                temperature=chat_config.temperature,
+                top_p=chat_config.top_p,
             )
             chunks = [response]  # Wrap in list to iterate
             stream_wrapper = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -478,7 +478,9 @@ def mock_generation():
     def create(responses: list[str]):
         response_iter = iter(responses)
 
-        def mock_stream(messages, model, tools=None, max_tokens=None):
+        def mock_stream(
+            messages, model, tools=None, max_tokens=None, temperature=None, top_p=None
+        ):
             try:
                 content = next(response_iter)
                 # Yield the content as a single chunk that will be iterated over char by char

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -555,6 +555,29 @@ def test_chat_config_max_tokens_roundtrip():
     assert config_new.max_tokens == 4096
 
 
+def test_chat_config_temperature_top_p_default_omitted():
+    """temperature/top_p default to None and are omitted from serialization."""
+    config = ChatConfig()
+    assert config.temperature is None
+    assert config.top_p is None
+    assert "temperature" not in config.to_dict()["chat"]
+    assert "top_p" not in config.to_dict()["chat"]
+
+
+def test_chat_config_temperature_top_p_roundtrip():
+    """temperature and top_p survive a to_dict/from_dict round-trip."""
+    config = ChatConfig.from_dict({"chat": {"temperature": 0.7, "top_p": 0.9}})
+    assert config.temperature == 0.7
+    assert config.top_p == 0.9
+    assert config.to_dict()["chat"]["temperature"] == 0.7
+    assert config.to_dict()["chat"]["top_p"] == 0.9
+
+    toml_str = tomlkit.dumps(config.to_dict())
+    config_new = ChatConfig.from_dict(tomlkit.loads(toml_str).unwrap())
+    assert config_new.temperature == 0.7
+    assert config_new.top_p == 0.9
+
+
 def test_project_config_loaded_from_toml():
     config = ProjectConfig.from_dict(tomlkit.loads(project_config_toml).unwrap())
 

--- a/tests/test_llm_openai.py
+++ b/tests/test_llm_openai.py
@@ -873,7 +873,14 @@ def test_stream_forwards_output_schema_to_responses_path(monkeypatch):
     seen: dict[str, Any] = {}
 
     def fake_stream_responses(
-        messages, model, tools, model_meta, output_schema=None, max_tokens=None
+        messages,
+        model,
+        tools,
+        model_meta,
+        output_schema=None,
+        max_tokens=None,
+        temperature=None,
+        top_p=None,
     ):
         seen["messages"] = messages
         seen["model"] = model

--- a/tests/test_llm_utils.py
+++ b/tests/test_llm_utils.py
@@ -903,7 +903,15 @@ class TestMaxTokensEnvOverride:
 
         captured: dict[str, Any] = {}
 
-        def fake_chat(messages, model, tools, output_schema=None, max_tokens=None):
+        def fake_chat(
+            messages,
+            model,
+            tools,
+            output_schema=None,
+            max_tokens=None,
+            temperature=None,
+            top_p=None,
+        ):
             captured["max_tokens"] = max_tokens
             return "ok", {"model": model}
 
@@ -926,7 +934,15 @@ class TestMaxTokensEnvOverride:
 
         captured: dict[str, Any] = {}
 
-        def fake_chat(messages, model, tools, output_schema=None, max_tokens=None):
+        def fake_chat(
+            messages,
+            model,
+            tools,
+            output_schema=None,
+            max_tokens=None,
+            temperature=None,
+            top_p=None,
+        ):
             captured["max_tokens"] = max_tokens
             return "ok", {"model": model}
 
@@ -948,7 +964,15 @@ class TestMaxTokensEnvOverride:
 
         captured: dict[str, Any] = {}
 
-        def fake_chat(messages, model, tools, output_schema=None, max_tokens=None):
+        def fake_chat(
+            messages,
+            model,
+            tools,
+            output_schema=None,
+            max_tokens=None,
+            temperature=None,
+            top_p=None,
+        ):
             captured["max_tokens"] = max_tokens
             return "ok", {"model": model}
 
@@ -969,7 +993,15 @@ class TestMaxTokensEnvOverride:
 
         captured: dict[str, Any] = {}
 
-        def fake_stream(messages, model, tools, output_schema=None, max_tokens=None):
+        def fake_stream(
+            messages,
+            model,
+            tools,
+            output_schema=None,
+            max_tokens=None,
+            temperature=None,
+            top_p=None,
+        ):
             captured["max_tokens"] = max_tokens
             if False:
                 yield ""
@@ -994,7 +1026,15 @@ class TestMaxTokensEnvOverride:
 
         captured: dict[str, Any] = {}
 
-        def fake_stream(messages, model, tools, output_schema=None, max_tokens=None):
+        def fake_stream(
+            messages,
+            model,
+            tools,
+            output_schema=None,
+            max_tokens=None,
+            temperature=None,
+            top_p=None,
+        ):
             captured["max_tokens"] = max_tokens
             if False:
                 yield ""

--- a/tests/test_provider_plugins.py
+++ b/tests/test_provider_plugins.py
@@ -376,6 +376,8 @@ class TestPluginRouting:
             None,
             output_schema=None,
             max_tokens=None,
+            temperature=None,
+            top_p=None,
         )
 
     def test_stream_routes_plugin_provider_through_openai(self):
@@ -408,6 +410,8 @@ class TestPluginRouting:
             None,
             output_schema=None,
             max_tokens=None,
+            temperature=None,
+            top_p=None,
         )
 
 

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -1749,7 +1749,9 @@ def test_v2_step_error_returned_in_response(v2_conv, client: FlaskClient):
     assert response.status_code == 200
 
     # Mock _stream to raise an error (simulating an API auth failure)
-    def mock_stream_error(messages, model, tools=None, max_tokens=None):
+    def mock_stream_error(
+        messages, model, tools=None, max_tokens=None, temperature=None, top_p=None
+    ):
         raise RuntimeError("API key is invalid")
 
     with unittest.mock.patch("gptme.server.session_step._stream", mock_stream_error):
@@ -1790,7 +1792,9 @@ def test_v2_step_last_error_set_on_failure(v2_conv, client: FlaskClient):
     )
     assert response.status_code == 200
 
-    def mock_stream_error(messages, model, tools=None, max_tokens=None):
+    def mock_stream_error(
+        messages, model, tools=None, max_tokens=None, temperature=None, top_p=None
+    ):
         raise ValueError("Model not found: fake-model")
 
     with unittest.mock.patch("gptme.server.session_step._stream", mock_stream_error):

--- a/tests/test_server_v2_hooks.py
+++ b/tests/test_server_v2_hooks.py
@@ -145,7 +145,9 @@ def test_turn_pre_hook(client: FlaskClient, monkeypatch):
     )
     assert response.status_code == 200
 
-    def mock_chat_complete(messages, model, tools=None, max_tokens=None):
+    def mock_chat_complete(
+        messages, model, tools=None, max_tokens=None, temperature=None, top_p=None
+    ):
         return ("Hello! How can I help you?", None)
 
     with unittest.mock.patch(
@@ -194,7 +196,9 @@ def test_message_post_process_hook(client: FlaskClient, monkeypatch):
 
     # Mock _chat_complete (since stream=False)
     # Returns (response, metadata) tuple - the new format
-    def mock_chat_complete(messages, model, tools=None, max_tokens=None):
+    def mock_chat_complete(
+        messages, model, tools=None, max_tokens=None, temperature=None, top_p=None
+    ):
         return ("Hello! How can I help you?", None)
 
     with unittest.mock.patch(


### PR DESCRIPTION
## Summary

- Add `temperature: float | None` and `top_p: float | None` to `ChatConfig` (both default to `None`, preserving backward-compatible fallback to `TEMPERATURE`/`TOP_P` constants from `constants.py`)
- Thread the overrides through the full call chain: `reply()` → `_reply_stream()` / `_chat_complete()` → `_stream()` → provider functions
- `session_step.py` reads `chat_config.temperature`/`top_p` and passes them to `_stream()` / `_chat_complete()`
- OpenAPI schema documents both fields with `ge`/`le` bounds for the webui API

Provider behavior:
- **Anthropic**: uses override when provided, falls back to `TEMPERATURE`/`TOP_P`; `supports_reasoning` branch preserved (hardcoded `1` / `NOT_GIVEN`)
- **OpenAI**: same — uses override, falls back to constants; `is_reasoner` branch preserved (no temperature/top_p for reasoning models)

## Test plan

- [x] `uv run pytest tests/test_config.py` — includes 4 new tests for `temperature`/`top_p` default, roundtrip, and omission from serialization
- [x] `uv run pytest tests/test_server_session_models.py tests/test_server_v2_hooks.py` — 139 tests pass
- [x] `uv run mypy gptme/llm/__init__.py gptme/llm/llm_anthropic.py gptme/llm/llm_openai.py gptme/config/chat.py gptme/server/session_step.py gptme/server/openapi_docs.py` — clean

## Context

This is slice 3 of 4 in `gptme-webui: Model temperature/params controls`. Slice 1 (server `max_tokens`) shipped in #2649; slice 2 (webui `max_tokens` input) shipped in #2652. This slice makes `temperature`/`top_p` server-driven. Slice 4 (webui sliders for temperature/top_p) depends on this PR.