### PR TITLE
feat(webui): add ErrorBoundary to catch render crashes and chunk-load failures

### DIFF
--- a/webui/src/App.tsx
+++ b/webui/src/App.tsx
@@ -9,6 +9,7 @@ import { EmbeddedContextProvider } from './contexts/EmbeddedContext';
 import { SettingsProvider } from './contexts/SettingsContext';
 import { lazy, Suspense, type FC } from 'react';
 import { CommandPalette } from './components/CommandPalette';
+import { ErrorBoundary } from './components/ErrorBoundary';
 import { ShortcutsDialog } from './components/ShortcutsDialog';
 import { SetupWizard } from './components/SetupWizard';
 
@@ -73,22 +74,24 @@ const App: FC = () => {
                     v7_relativeSplatPath: true,
                   }}
                 >
-                  <Suspense fallback={<RouteLoader />}>
-                    <Routes>
-                      <Route path="/" element={<Index />} />
-                      <Route path="/chat" element={<Index />} />
-                      <Route path="/chat/:id" element={<Index />} />
-                      <Route path="/tasks" element={<Tasks />} />
-                      <Route path="/tasks/:id" element={<Tasks />} />
-                      <Route path="/agents" element={<Agents />} />
-                      <Route path="/workspaces" element={<Workspaces />} />
-                      <Route path="/history" element={<History />} />
-                      <Route path="/external-sessions" element={<ExternalSessions />} />
-                      <Route path="/admin" element={<Admin />} />
-                      <Route path="/workspace/:id" element={<Workspace />} />
-                      <Route path="*" element={<NotFound />} />
-                    </Routes>
-                  </Suspense>
+                  <ErrorBoundary>
+                    <Suspense fallback={<RouteLoader />}>
+                      <Routes>
+                        <Route path="/" element={<Index />} />
+                        <Route path="/chat" element={<Index />} />
+                        <Route path="/chat/:id" element={<Index />} />
+                        <Route path="/tasks" element={<Tasks />} />
+                        <Route path="/tasks/:id" element={<Tasks />} />
+                        <Route path="/agents" element={<Agents />} />
+                        <Route path="/workspaces" element={<Workspaces />} />
+                        <Route path="/history" element={<History />} />
+                        <Route path="/external-sessions" element={<ExternalSessions />} />
+                        <Route path="/admin" element={<Admin />} />
+                        <Route path="/workspace/:id" element={<Workspace />} />
+                        <Route path="*" element={<NotFound />} />
+                      </Routes>
+                    </Suspense>
+                  </ErrorBoundary>
                   <SetupWizard />
                   <CommandPalette />
                   <ShortcutsDialog />

--- a/webui/src/App.tsx
+++ b/webui/src/App.tsx
@@ -2,12 +2,12 @@ import { Toaster } from '@/components/ui/toaster';
 import { Toaster as Sonner } from '@/components/ui/sonner';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { BrowserRouter, Routes, Route, useLocation } from 'react-router-dom';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { ThemeProvider } from 'next-themes';
 import { ApiProvider } from './contexts/ApiContext';
 import { EmbeddedContextProvider } from './contexts/EmbeddedContext';
 import { SettingsProvider } from './contexts/SettingsContext';
-import { lazy, Suspense, type FC, type ReactNode } from 'react';
+import { lazy, Suspense, type FC } from 'react';
 import { CommandPalette } from './components/CommandPalette';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { ShortcutsDialog } from './components/ShortcutsDialog';
@@ -47,12 +47,6 @@ const queryClient = new QueryClient({
   },
 });
 
-/** Resets the error boundary whenever the user navigates to a different route. */
-function LocationAwareErrorBoundary({ children }: { children: ReactNode }) {
-  const { key } = useLocation();
-  return <ErrorBoundary key={key}>{children}</ErrorBoundary>;
-}
-
 /** Lightweight fallback shown while a lazy-route chunk is loading. */
 const RouteLoader: FC = () => (
   <div className="flex h-64 items-center justify-center">
@@ -80,7 +74,7 @@ const App: FC = () => {
                     v7_relativeSplatPath: true,
                   }}
                 >
-                  <LocationAwareErrorBoundary>
+                  <ErrorBoundary>
                     <Suspense fallback={<RouteLoader />}>
                       <Routes>
                         <Route path="/" element={<Index />} />
@@ -97,7 +91,7 @@ const App: FC = () => {
                         <Route path="*" element={<NotFound />} />
                       </Routes>
                     </Suspense>
-                  </LocationAwareErrorBoundary>
+                  </ErrorBoundary>
                   <SetupWizard />
                   <CommandPalette />
                   <ShortcutsDialog />

--- a/webui/src/App.tsx
+++ b/webui/src/App.tsx
@@ -2,12 +2,12 @@ import { Toaster } from '@/components/ui/toaster';
 import { Toaster as Sonner } from '@/components/ui/sonner';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { BrowserRouter, Routes, Route, useLocation } from 'react-router-dom';
 import { ThemeProvider } from 'next-themes';
 import { ApiProvider } from './contexts/ApiContext';
 import { EmbeddedContextProvider } from './contexts/EmbeddedContext';
 import { SettingsProvider } from './contexts/SettingsContext';
-import { lazy, Suspense, type FC } from 'react';
+import { lazy, Suspense, type FC, type ReactNode } from 'react';
 import { CommandPalette } from './components/CommandPalette';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { ShortcutsDialog } from './components/ShortcutsDialog';
@@ -47,6 +47,12 @@ const queryClient = new QueryClient({
   },
 });
 
+/** Resets the error boundary whenever the user navigates to a different route. */
+function LocationAwareErrorBoundary({ children }: { children: ReactNode }) {
+  const { key } = useLocation();
+  return <ErrorBoundary key={key}>{children}</ErrorBoundary>;
+}
+
 /** Lightweight fallback shown while a lazy-route chunk is loading. */
 const RouteLoader: FC = () => (
   <div className="flex h-64 items-center justify-center">
@@ -74,7 +80,7 @@ const App: FC = () => {
                     v7_relativeSplatPath: true,
                   }}
                 >
-                  <ErrorBoundary>
+                  <LocationAwareErrorBoundary>
                     <Suspense fallback={<RouteLoader />}>
                       <Routes>
                         <Route path="/" element={<Index />} />
@@ -91,7 +97,7 @@ const App: FC = () => {
                         <Route path="*" element={<NotFound />} />
                       </Routes>
                     </Suspense>
-                  </ErrorBoundary>
+                  </LocationAwareErrorBoundary>
                   <SetupWizard />
                   <CommandPalette />
                   <ShortcutsDialog />

--- a/webui/src/components/ErrorBoundary.tsx
+++ b/webui/src/components/ErrorBoundary.tsx
@@ -1,0 +1,84 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+
+interface Props {
+  children: ReactNode;
+  fallback?: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+  error: Error | null;
+  isChunkLoadError: boolean;
+}
+
+function isChunkLoadError(error: Error): boolean {
+  return (
+    error.name === 'ChunkLoadError' ||
+    /Loading chunk .* failed/.test(error.message) ||
+    /Failed to fetch dynamically imported module/.test(error.message)
+  );
+}
+
+/** Global error fallback shown when a chunk fails to load or a component crashes. */
+function ErrorFallback({ error, onReload }: { error: Error | null; onReload: () => void }) {
+  const isChunk = error ? isChunkLoadError(error) : false;
+  return (
+    <div className="flex min-h-[400px] flex-col items-center justify-center gap-4 p-8 text-center">
+      <div className="text-4xl">⚠️</div>
+      <h2 className="text-xl font-semibold">
+        {isChunk ? 'Failed to load page' : 'Something went wrong'}
+      </h2>
+      <p className="max-w-md text-sm text-muted-foreground">
+        {isChunk
+          ? 'A required script failed to load. This can happen after an update — reloading usually fixes it.'
+          : 'An unexpected error occurred. Reloading the page may help.'}
+      </p>
+      {error && !isChunk && (
+        <pre className="max-w-md overflow-auto rounded bg-muted px-4 py-2 text-left text-xs text-muted-foreground">
+          {error.message}
+        </pre>
+      )}
+      <button
+        onClick={onReload}
+        className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+      >
+        Reload page
+      </button>
+    </div>
+  );
+}
+
+/**
+ * Catches render errors and chunk-load failures anywhere in the component tree,
+ * preventing the entire app from going blank. Shows a recovery UI with a reload button.
+ */
+export class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false, error: null, isChunkLoadError: false };
+  }
+
+  static getDerivedStateFromError(error: Error): State {
+    return {
+      hasError: true,
+      error,
+      isChunkLoadError: isChunkLoadError(error),
+    };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error('ErrorBoundary caught:', error, info.componentStack);
+  }
+
+  handleReload = () => {
+    window.location.reload();
+  };
+
+  render() {
+    if (this.state.hasError) {
+      if (this.props.fallback) return this.props.fallback;
+      return <ErrorFallback error={this.state.error} onReload={this.handleReload} />;
+    }
+    return this.props.children;
+  }
+}

--- a/webui/src/components/ErrorBoundary.tsx
+++ b/webui/src/components/ErrorBoundary.tsx
@@ -8,7 +8,6 @@ interface Props {
 interface State {
   hasError: boolean;
   error: Error | null;
-  isChunkLoadError: boolean;
 }
 
 function isChunkLoadError(error: Error): boolean {
@@ -55,15 +54,11 @@ function ErrorFallback({ error, onReload }: { error: Error | null; onReload: () 
 export class ErrorBoundary extends Component<Props, State> {
   constructor(props: Props) {
     super(props);
-    this.state = { hasError: false, error: null, isChunkLoadError: false };
+    this.state = { hasError: false, error: null };
   }
 
   static getDerivedStateFromError(error: Error): State {
-    return {
-      hasError: true,
-      error,
-      isChunkLoadError: isChunkLoadError(error),
-    };
+    return { hasError: true, error };
   }
 
   componentDidCatch(error: Error, info: ErrorInfo) {

--- a/webui/src/components/__tests__/ErrorBoundary.test.tsx
+++ b/webui/src/components/__tests__/ErrorBoundary.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react';
+import { ErrorBoundary } from '../ErrorBoundary';
+
+// Component that throws on first render
+function Bomb({ shouldThrow }: { shouldThrow: boolean }) {
+  if (shouldThrow) throw new Error('Test render error');
+  return <div data-testid="ok">rendered</div>;
+}
+
+// Suppress expected React error boundary console output in tests
+beforeEach(() => {
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  (console.error as jest.Mock).mockRestore();
+});
+
+describe('ErrorBoundary', () => {
+  it('renders children when no error', () => {
+    render(
+      <ErrorBoundary>
+        <Bomb shouldThrow={false} />
+      </ErrorBoundary>
+    );
+    expect(screen.getByTestId('ok')).toBeInTheDocument();
+  });
+
+  it('shows fallback UI on render error', () => {
+    render(
+      <ErrorBoundary>
+        <Bomb shouldThrow={true} />
+      </ErrorBoundary>
+    );
+    expect(screen.queryByTestId('ok')).not.toBeInTheDocument();
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /reload/i })).toBeInTheDocument();
+  });
+
+  it('shows chunk-load message for chunk errors', () => {
+    function ChunkBomb(): never {
+      throw new Error('Failed to fetch dynamically imported module');
+    }
+    render(
+      <ErrorBoundary>
+        <ChunkBomb />
+      </ErrorBoundary>
+    );
+    expect(screen.getByText('Failed to load page')).toBeInTheDocument();
+  });
+
+  it('renders custom fallback when provided', () => {
+    render(
+      <ErrorBoundary fallback={<div data-testid="custom-fallback">oops</div>}>
+        <Bomb shouldThrow={true} />
+      </ErrorBoundary>
+    );
+    expect(screen.getByTestId('custom-fallback')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `ErrorBoundary.tsx` — a class component with `getDerivedStateFromError`/`componentDidCatch` that catches render crashes and chunk-load failures anywhere in the route tree
- Wraps the `<Suspense>` in `App.tsx` with `<ErrorBoundary>` so the entire lazy-loaded route tree is covered
- Shows a user-facing fallback UI with a **Reload page** button; distinguishes chunk-load failures (e.g. "Failed to load page — reloading usually fixes it") from general render errors (which also show the error message)
- 4 tests: no-error passthrough, render error fallback, chunk-load error message, custom fallback prop

## Why this matters

Without an `ErrorBoundary`, any unhandled render crash or `Failed to fetch dynamically imported module` error (which happens after a deploy when a user's tab is stale) produces a completely blank page with no recovery option. This is the minimal fix.

## Test plan

- [ ] `npm test` passes (39 tests, 0 failures)
- [ ] `tsc --noEmit` clean
- [ ] `eslint` clean (only pre-existing warnings from other files)