### PR TITLE
feat(webui): persist temperature/top_p/max_tokens in ConversationSettings sidebar

### DIFF
--- a/webui/src/components/ConversationSettings.tsx
+++ b/webui/src/components/ConversationSettings.tsx
@@ -189,6 +189,104 @@ export const ConversationSettings: FC<ConversationSettingsProps> = ({ conversati
                 isSubmitting={isSubmitting}
               />
 
+              {/* Sampling parameters */}
+              <h3 className="text-lg font-medium">Sampling</h3>
+              <div className="space-y-4 rounded-lg border px-3 py-3 shadow-sm">
+                <FormField
+                  control={control}
+                  name="chat.temperature"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Temperature</FormLabel>
+                      <FormControl>
+                        <Input
+                          type="number"
+                          min={0}
+                          max={2}
+                          step={0.1}
+                          placeholder="Model default"
+                          value={field.value ?? ''}
+                          onChange={(e) => {
+                            const v = e.target.value;
+                            const n = Number(v);
+                            field.onChange(
+                              v === '' || isNaN(n) ? undefined : Math.min(2, Math.max(0, n))
+                            );
+                          }}
+                          disabled={isSubmitting}
+                        />
+                      </FormControl>
+                      <FormDescription>
+                        Sampling temperature. 0–2 (OpenAI) · 0–1 (Anthropic/Gemini). Empty = model
+                        default.
+                      </FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={control}
+                  name="chat.top_p"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Top P</FormLabel>
+                      <FormControl>
+                        <Input
+                          type="number"
+                          min={0}
+                          max={1}
+                          step={0.05}
+                          placeholder="Model default"
+                          value={field.value ?? ''}
+                          onChange={(e) => {
+                            const v = e.target.value;
+                            const n = Number(v);
+                            field.onChange(
+                              v === '' || isNaN(n) ? undefined : Math.min(1, Math.max(0, n))
+                            );
+                          }}
+                          disabled={isSubmitting}
+                        />
+                      </FormControl>
+                      <FormDescription>
+                        Nucleus sampling probability mass (0–1). Empty = model default.
+                      </FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={control}
+                  name="chat.max_tokens"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Max Tokens</FormLabel>
+                      <FormControl>
+                        <Input
+                          type="number"
+                          min={1}
+                          step={1}
+                          placeholder="Model default"
+                          value={field.value ?? ''}
+                          onChange={(e) => {
+                            const v = e.target.value;
+                            const n = Math.round(Number(v));
+                            field.onChange(v === '' || isNaN(n) ? undefined : Math.max(1, n));
+                          }}
+                          disabled={isSubmitting}
+                        />
+                      </FormControl>
+                      <FormDescription>
+                        Maximum tokens in the model&apos;s response. Empty = provider/model default.
+                      </FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+
               {/* Advanced/rare toggles */}
               <h3 className="text-lg font-medium">Advanced Settings</h3>
               <div className="space-y-2 rounded-lg border px-3 py-2 shadow-sm">

--- a/webui/src/components/ConversationSettings.tsx
+++ b/webui/src/components/ConversationSettings.tsx
@@ -1,4 +1,4 @@
-import { useState, type FC } from 'react';
+import { useState, useEffect, type FC } from 'react';
 import { DeleteConversationConfirmationDialog } from './DeleteConversationConfirmationDialog';
 import { Trash, Loader2, Download } from 'lucide-react';
 import { conversations$ } from '@/stores/conversations';
@@ -28,6 +28,78 @@ import { useConversationSettings } from '@/hooks/useConversationSettings';
 import { demoConversations } from '@/democonversations';
 import { SessionCostSummary } from './SessionCostSummary';
 
+// Decimal input that avoids mid-typing snapping (Number('0.') === 0 issue).
+// Keeps a raw string in local state and only commits a number on blur.
+function DecimalInput({
+  field,
+  min,
+  max,
+  placeholder,
+  disabled,
+}: {
+  field: {
+    value: number | undefined | null;
+    onChange: (value: number | undefined) => void;
+    onBlur: () => void;
+    name: string;
+  };
+  min: number;
+  max: number;
+  placeholder: string;
+  disabled: boolean;
+}) {
+  const [raw, setRaw] = useState<string>(field.value != null ? String(field.value) : '');
+
+  // Sync raw when field.value changes externally (e.g. form reset), but not
+  // while the user is mid-typing a partial like "0.".
+  useEffect(() => {
+    if (!raw.endsWith('.')) {
+      setRaw(field.value != null ? String(field.value) : '');
+    }
+  }, [field.value]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return (
+    <Input
+      name={field.name}
+      type="text"
+      inputMode="decimal"
+      placeholder={placeholder}
+      disabled={disabled}
+      value={raw}
+      onChange={(e) => {
+        const v = e.target.value;
+        if (v === '' || /^\d*\.?\d*$/.test(v)) {
+          setRaw(v);
+          if (v === '' || v === '.') {
+            field.onChange(undefined);
+          } else {
+            const n = Number(v);
+            if (!isNaN(n)) {
+              field.onChange(Math.min(max, Math.max(min, n)));
+            }
+          }
+        }
+      }}
+      onBlur={() => {
+        if (raw !== '' && raw !== '.') {
+          const n = Number(raw);
+          if (!isNaN(n)) {
+            const clamped = Math.min(max, Math.max(min, n));
+            setRaw(String(clamped));
+            field.onChange(clamped);
+          } else {
+            setRaw(field.value != null ? String(field.value) : '');
+          }
+        } else {
+          setRaw('');
+          field.onChange(undefined);
+        }
+        field.onBlur();
+      }}
+    />
+  );
+}
+
 interface ConversationSettingsProps {
   conversationId: string;
 }
@@ -50,6 +122,13 @@ export const ConversationSettings: FC<ConversationSettingsProps> = ({ conversati
     control,
     formState: { isDirty, isSubmitting },
   } = form;
+
+  const selectedModel = form.watch('chat.model');
+  const currentTemp = form.watch('chat.temperature');
+  const showTempProviderWarning =
+    currentTemp != null &&
+    currentTemp > 1 &&
+    /^(anthropic\/|claude-|google\/|gemini-)/.test(selectedModel ?? '');
 
   const onInvalid = (errors: Record<string, unknown>) => {
     // Surface validation errors so the user knows why save doesn't work
@@ -199,26 +278,22 @@ export const ConversationSettings: FC<ConversationSettingsProps> = ({ conversati
                     <FormItem>
                       <FormLabel>Temperature</FormLabel>
                       <FormControl>
-                        <Input
-                          type="number"
+                        <DecimalInput
+                          field={field}
                           min={0}
                           max={2}
-                          step={0.1}
                           placeholder="Model default"
-                          value={field.value ?? ''}
-                          onChange={(e) => {
-                            const v = e.target.value;
-                            const n = Number(v);
-                            field.onChange(
-                              v === '' || isNaN(n) ? undefined : Math.min(2, Math.max(0, n))
-                            );
-                          }}
                           disabled={isSubmitting}
                         />
                       </FormControl>
                       <FormDescription>
                         Sampling temperature. 0–2 (OpenAI) · 0–1 (Anthropic/Gemini). Empty = model
                         default.
+                        {showTempProviderWarning && (
+                          <span className="block text-amber-500 dark:text-amber-400">
+                            ⚠ Temperature &gt; 1 may be rejected by this provider.
+                          </span>
+                        )}
                       </FormDescription>
                       <FormMessage />
                     </FormItem>
@@ -232,20 +307,11 @@ export const ConversationSettings: FC<ConversationSettingsProps> = ({ conversati
                     <FormItem>
                       <FormLabel>Top P</FormLabel>
                       <FormControl>
-                        <Input
-                          type="number"
+                        <DecimalInput
+                          field={field}
                           min={0}
                           max={1}
-                          step={0.05}
                           placeholder="Model default"
-                          value={field.value ?? ''}
-                          onChange={(e) => {
-                            const v = e.target.value;
-                            const n = Number(v);
-                            field.onChange(
-                              v === '' || isNaN(n) ? undefined : Math.min(1, Math.max(0, n))
-                            );
-                          }}
                           disabled={isSubmitting}
                         />
                       </FormControl>

--- a/webui/src/hooks/useConversationSettings.ts
+++ b/webui/src/hooks/useConversationSettings.ts
@@ -19,6 +19,9 @@ const chatConfigToFormValues = (config: ChatConfig | null): FormSchema => ({
     stream: config?.chat.stream ?? true,
     interactive: config?.chat.interactive ?? false,
     workspace: config?.chat.workspace || '',
+    temperature: config?.chat.temperature ?? undefined,
+    top_p: config?.chat.top_p ?? undefined,
+    max_tokens: config?.chat.max_tokens ?? undefined,
     env: config?.env ? Object.entries(config.env).map(([key, value]) => ({ key, value })) : [],
   },
   mcp: {
@@ -151,6 +154,9 @@ export const useConversationSettings = (conversationId: string) => {
         stream: values.chat.stream,
         interactive: values.chat.interactive,
         workspace: values.chat.workspace,
+        temperature: values.chat.temperature ?? null,
+        top_p: values.chat.top_p ?? null,
+        max_tokens: values.chat.max_tokens ?? null,
       },
       env: newEnv,
       mcp: {

--- a/webui/src/schemas/conversationSettings.ts
+++ b/webui/src/schemas/conversationSettings.ts
@@ -25,6 +25,9 @@ export const formSchema = z.object({
     stream: z.boolean(),
     interactive: z.boolean(),
     workspace: z.string().min(1, 'Workspace directory is required'),
+    temperature: z.number().min(0, 'Must be ≥ 0').max(2, 'Must be ≤ 2').optional(),
+    top_p: z.number().min(0, 'Must be ≥ 0').max(1, 'Must be ≤ 1').optional(),
+    max_tokens: z.number().int('Must be a whole number').positive('Must be > 0').optional(),
     env: z
       .array(
         z.object({ key: z.string().min(1, 'Variable name cannot be empty'), value: z.string() })

--- a/webui/src/types/api.ts
+++ b/webui/src/types/api.ts
@@ -115,6 +115,10 @@ export interface ChatConfig {
     stream: boolean;
     interactive: boolean;
     workspace: string;
+    // Sampling overrides. null/undefined = provider/model default.
+    temperature?: number | null;
+    top_p?: number | null;
+    max_tokens?: number | null;
   };
   env: Record<string, string>;
   mcp: McpConfig;


### PR DESCRIPTION
## Summary

Part B of the per-conversation model/sampling settings work. Part A (#2660) shipped runtime temperature/top_p controls in the ChatInput options popover; the server-side `ChatConfig` already carries `temperature`/`top_p`/`max_tokens` (#2659) and `session_step.py` threads them into generation. But the **ConversationSettings sidebar form** never exposed these fields, so they could not be persisted per-conversation to `config.toml`.

This wires the sidebar form to the existing backend support.

## Changes

- `types/api.ts`: add `temperature`/`top_p`/`max_tokens` to `ChatConfig.chat`
- `schemas/conversationSettings.ts`: validate the three fields (temperature 0–2, top_p 0–1, max_tokens positive int), all optional
- `hooks/useConversationSettings.ts`: map config↔form values in both directions (load + save)
- `components/ConversationSettings.tsx`: number inputs under a new **Sampling** section

Empty input clears the override (`null`), falling back to the provider/model default — matching the ChatInput popover semantics.

## Verification

- `npm run typecheck`: clean
- `eslint` on changed files: clean
- `jest` ChatInput + WelcomeView (18) and settings + ConversationList (22): pass

No dedicated `ConversationSettings` test exists in the suite; behavior is covered by the typed form schema + existing settings render tests.