### PR TITLE
feat(webui): add FunctionBrowser panel with /api/v2/tools endpoint

### DIFF
--- a/gptme/server/app.py
+++ b/gptme/server/app.py
@@ -88,6 +88,7 @@ def create_app(
     from .auth import auth_api  # fmt: skip
     from .panels_api import panels_api  # fmt: skip
     from .tasks_api import tasks_api  # fmt: skip
+    from .tools_api import tools_api  # fmt: skip
     from .workspace_api import workspace_api  # fmt: skip
 
     app.register_blueprint(v2_api)
@@ -96,6 +97,7 @@ def create_app(
     app.register_blueprint(tasks_api)
     app.register_blueprint(artifacts_api)
     app.register_blueprint(panels_api)
+    app.register_blueprint(tools_api)
 
     # Register OpenAPI documentation
     from .openapi_docs import docs_api  # fmt: skip

--- a/gptme/server/tools_api.py
+++ b/gptme/server/tools_api.py
@@ -64,7 +64,7 @@ def _serialize_tool(tool) -> ToolOut:
                 name=p.name,
                 type=str(p.type or "string"),
                 description=p.description or "",
-                required=bool(getattr(p, "required", True)),
+                required=bool(getattr(p, "required", False)),
             )
         )
 

--- a/gptme/server/tools_api.py
+++ b/gptme/server/tools_api.py
@@ -1,0 +1,107 @@
+"""
+Tools registry API — list available tools and their metadata.
+
+Exposes ``GET /api/v2/tools`` so the webui can render a FunctionBrowser panel
+that shows the agent's current tool palette, descriptions, block types, and
+parameter schemas.
+"""
+
+import logging
+
+import flask
+from pydantic import BaseModel, Field
+
+from ..tools import get_available_tools
+from .auth import require_auth
+from .openapi_docs import ErrorResponse, api_doc_simple
+
+logger = logging.getLogger(__name__)
+
+tools_api = flask.Blueprint("tools_api", __name__)
+
+
+class ToolParameterOut(BaseModel):
+    name: str = Field(..., description="Parameter name")
+    type: str = Field("string", description="Python type annotation as string")
+    description: str = Field("", description="Parameter description if available")
+    required: bool = Field(True, description="Whether the parameter is required")
+
+
+class ToolOut(BaseModel):
+    name: str = Field(..., description="Tool name (also used as the block type prefix)")
+    desc: str = Field("", description="One-line description of what the tool does")
+    instructions: str = Field(
+        "", description="Full usage instructions shown to the agent"
+    )
+    block_types: list[str] = Field(
+        default_factory=list,
+        description="Code-block type tags this tool handles (e.g. ['shell', 'bash'])",
+    )
+    is_mcp: bool = Field(False, description="Whether this is an MCP-provided tool")
+    is_available: bool = Field(True, description="Whether the tool is currently usable")
+    disabled_by_default: bool = Field(
+        False, description="Whether the tool is excluded from default sessions"
+    )
+    parameters: list[ToolParameterOut] = Field(
+        default_factory=list,
+        description="Callable parameters when the tool exposes Python functions",
+    )
+
+
+class ToolListResponse(BaseModel):
+    tools: list[ToolOut] = Field(..., description="All available tool descriptors")
+
+
+def _serialize_tool(tool) -> ToolOut:
+    from ..tools.base import Parameter
+
+    params: list[ToolParameterOut] = []
+    for p in tool.parameters or []:
+        if not isinstance(p, Parameter):
+            continue
+        params.append(
+            ToolParameterOut(
+                name=p.name,
+                type=str(p.type or "string"),
+                description=p.description or "",
+                required=bool(getattr(p, "required", True)),
+            )
+        )
+
+    return ToolOut(
+        name=tool.name,
+        desc=tool.desc or "",
+        instructions=tool.instructions or "",
+        block_types=list(tool.block_types or []),
+        is_mcp=bool(tool.is_mcp),
+        is_available=bool(tool.is_available),
+        disabled_by_default=bool(tool.disabled_by_default),
+        parameters=params,
+    )
+
+
+@tools_api.route("/api/v2/tools")
+@require_auth
+@api_doc_simple(
+    responses={
+        200: ToolListResponse,
+        500: ErrorResponse,
+    },
+    tags=["tools"],
+)
+def list_tools():
+    """List all available tools and their metadata.
+
+    Returns every tool that is registered in this gptme instance, including
+    MCP tools, with description, block types, availability status, and
+    parameter schemas. The webui uses this to render a searchable
+    FunctionBrowser panel in the right sidebar.
+    """
+    try:
+        tools = get_available_tools(include_mcp=True)
+        return flask.jsonify(
+            {"tools": [_serialize_tool(t).model_dump() for t in tools]}
+        )
+    except Exception as e:
+        logger.exception("Error listing tools")
+        return flask.jsonify({"error": str(e)}), 500

--- a/webui/src/components/FunctionBrowserPanel.tsx
+++ b/webui/src/components/FunctionBrowserPanel.tsx
@@ -1,0 +1,252 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Box, Cpu, Loader2, RefreshCw, Search } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import type { Tool } from '@/types/tool';
+import { useToolsApi } from '@/utils/toolsApi';
+
+export function FunctionBrowserPanel() {
+  const [tools, setTools] = useState<Tool[]>([]);
+  const [selectedToolName, setSelectedToolName] = useState<string | null>(null);
+  const [query, setQuery] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const { listTools } = useToolsApi();
+  const fetchControllerRef = useRef<AbortController | null>(null);
+
+  const loadTools = useCallback(
+    async (signal?: AbortSignal) => {
+      setLoading(true);
+      setError(null);
+      try {
+        const data = await listTools(signal);
+        if (!signal?.aborted) {
+          setTools(data);
+          setLoading(false);
+        }
+      } catch (err) {
+        if (err instanceof DOMException && err.name === 'AbortError') return;
+        setError(err instanceof Error ? err.message : 'Failed to load tools');
+        setLoading(false);
+      }
+    },
+    [listTools]
+  );
+
+  const startLoad = useCallback(() => {
+    fetchControllerRef.current?.abort();
+    const controller = new AbortController();
+    fetchControllerRef.current = controller;
+    void loadTools(controller.signal);
+  }, [loadTools]);
+
+  useEffect(() => {
+    startLoad();
+    return () => fetchControllerRef.current?.abort();
+  }, [startLoad]);
+
+  useEffect(() => {
+    if (!tools.length) {
+      setSelectedToolName(null);
+      return;
+    }
+    if (!selectedToolName || !tools.some((t) => t.name === selectedToolName)) {
+      setSelectedToolName(tools[0].name);
+    }
+  }, [tools, selectedToolName]);
+
+  const lowerQuery = query.toLowerCase();
+  const filtered = tools.filter(
+    (t) =>
+      !lowerQuery ||
+      t.name.toLowerCase().includes(lowerQuery) ||
+      t.desc.toLowerCase().includes(lowerQuery) ||
+      t.block_types.some((bt) => bt.toLowerCase().includes(lowerQuery))
+  );
+
+  const selectedTool = tools.find((t) => t.name === selectedToolName) ?? null;
+
+  return (
+    <div className="flex h-full flex-col">
+      {/* Header */}
+      <div className="flex items-center justify-between border-b p-4">
+        <div className="flex items-center gap-2">
+          <Cpu className="h-4 w-4 text-muted-foreground" />
+          <div>
+            <h2 className="text-sm font-medium">Functions</h2>
+            <p className="text-xs text-muted-foreground">
+              {tools.length} tool{tools.length === 1 ? '' : 's'}
+            </p>
+          </div>
+        </div>
+        <Button variant="outline" size="sm" onClick={startLoad} title="Refresh">
+          <RefreshCw className="mr-2 h-4 w-4" />
+          Refresh
+        </Button>
+      </div>
+
+      {/* Search */}
+      <div className="border-b px-4 py-2">
+        <div className="relative">
+          <Search className="absolute left-2.5 top-2.5 h-3.5 w-3.5 text-muted-foreground" />
+          <Input
+            placeholder="Search tools…"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            className="h-8 pl-8 text-sm"
+          />
+        </div>
+      </div>
+
+      {/* Split pane */}
+      <div className="flex min-h-0 flex-1">
+        {/* Tool list */}
+        <div className="h-full w-2/5 overflow-auto border-r">
+          {loading ? (
+            <div className="flex h-full items-center justify-center">
+              <Loader2 className="h-6 w-6 animate-spin" />
+            </div>
+          ) : error ? (
+            <div className="flex h-full items-center justify-center p-4 text-center text-sm text-destructive">
+              {error}
+            </div>
+          ) : filtered.length === 0 ? (
+            <div className="flex h-full items-center justify-center p-4 text-center text-sm text-muted-foreground">
+              {query ? 'No matching tools.' : 'No tools available.'}
+            </div>
+          ) : (
+            <div className="divide-y">
+              {filtered.map((tool) => {
+                const isSelected = tool.name === selectedToolName;
+                return (
+                  <button
+                    key={tool.name}
+                    type="button"
+                    onClick={() => setSelectedToolName(tool.name)}
+                    className={`w-full px-3 py-2.5 text-left transition-colors hover:bg-muted/50 ${
+                      isSelected ? 'bg-muted' : ''
+                    }`}
+                  >
+                    <div className="flex items-start justify-between gap-2">
+                      <div className="min-w-0">
+                        <span className="block truncate font-mono text-sm font-medium">
+                          {tool.name}
+                        </span>
+                        {tool.desc && (
+                          <span className="block truncate text-xs text-muted-foreground">
+                            {tool.desc}
+                          </span>
+                        )}
+                      </div>
+                      {!tool.is_available && (
+                        <Badge variant="outline" className="shrink-0 text-xs">
+                          unavail
+                        </Badge>
+                      )}
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </div>
+
+        {/* Tool detail */}
+        <div className="h-full w-3/5 overflow-auto p-4">
+          {selectedTool ? (
+            <ToolDetail tool={selectedTool} />
+          ) : (
+            <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+              Select a tool to see details
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ToolDetail({ tool }: { tool: Tool }) {
+  return (
+    <div className="space-y-4 text-sm">
+      {/* Name + badges */}
+      <div>
+        <h3 className="font-mono text-base font-semibold">{tool.name}</h3>
+        <div className="mt-1 flex flex-wrap gap-1.5">
+          {tool.is_mcp && (
+            <Badge variant="secondary" className="text-xs">
+              MCP
+            </Badge>
+          )}
+          {!tool.is_available && (
+            <Badge variant="destructive" className="text-xs">
+              unavailable
+            </Badge>
+          )}
+          {tool.disabled_by_default && (
+            <Badge variant="outline" className="text-xs">
+              opt-in
+            </Badge>
+          )}
+          {tool.block_types.map((bt) => (
+            <Badge key={bt} variant="outline" className="font-mono text-xs">
+              {bt}
+            </Badge>
+          ))}
+        </div>
+      </div>
+
+      {/* Description */}
+      {tool.desc && (
+        <div>
+          <p className="text-muted-foreground">{tool.desc}</p>
+        </div>
+      )}
+
+      {/* Parameters */}
+      {tool.parameters.length > 0 && (
+        <div>
+          <h4 className="mb-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            Parameters
+          </h4>
+          <div className="space-y-2">
+            {tool.parameters.map((p) => (
+              <div key={p.name} className="rounded-md border bg-muted/30 px-3 py-2">
+                <div className="flex items-baseline gap-2">
+                  <span className="font-mono font-medium">{p.name}</span>
+                  <span className="font-mono text-xs text-muted-foreground">{p.type}</span>
+                  {p.required && <span className="text-xs text-destructive">required</span>}
+                </div>
+                {p.description && (
+                  <p className="mt-0.5 text-xs text-muted-foreground">{p.description}</p>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Instructions */}
+      {tool.instructions && (
+        <div>
+          <h4 className="mb-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            Instructions
+          </h4>
+          <div className="rounded-md border bg-muted/30 px-3 py-2">
+            <pre className="whitespace-pre-wrap text-xs leading-relaxed">{tool.instructions}</pre>
+          </div>
+        </div>
+      )}
+
+      {/* No instructions fallback */}
+      {!tool.desc && !tool.instructions && tool.parameters.length === 0 && (
+        <div className="flex items-center gap-2 text-muted-foreground">
+          <Box className="h-4 w-4" />
+          <span>No additional metadata available for this tool.</span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/webui/src/components/FunctionBrowserPanel.tsx
+++ b/webui/src/components/FunctionBrowserPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Box, Cpu, Loader2, RefreshCw, Search } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -47,26 +47,30 @@ export function FunctionBrowserPanel() {
     return () => fetchControllerRef.current?.abort();
   }, [startLoad]);
 
+  const lowerQuery = query.toLowerCase();
+  const filtered = useMemo(
+    () =>
+      tools.filter(
+        (t) =>
+          !lowerQuery ||
+          t.name.toLowerCase().includes(lowerQuery) ||
+          t.desc.toLowerCase().includes(lowerQuery) ||
+          t.block_types.some((bt) => bt.toLowerCase().includes(lowerQuery))
+      ),
+    [tools, lowerQuery]
+  );
+
   useEffect(() => {
-    if (!tools.length) {
+    if (!filtered.length) {
       setSelectedToolName(null);
       return;
     }
-    if (!selectedToolName || !tools.some((t) => t.name === selectedToolName)) {
-      setSelectedToolName(tools[0].name);
+    if (!selectedToolName || !filtered.some((t) => t.name === selectedToolName)) {
+      setSelectedToolName(filtered[0].name);
     }
-  }, [tools, selectedToolName]);
+  }, [filtered, selectedToolName]);
 
-  const lowerQuery = query.toLowerCase();
-  const filtered = tools.filter(
-    (t) =>
-      !lowerQuery ||
-      t.name.toLowerCase().includes(lowerQuery) ||
-      t.desc.toLowerCase().includes(lowerQuery) ||
-      t.block_types.some((bt) => bt.toLowerCase().includes(lowerQuery))
-  );
-
-  const selectedTool = tools.find((t) => t.name === selectedToolName) ?? null;
+  const selectedTool = filtered.find((t) => t.name === selectedToolName) ?? null;
 
   return (
     <div className="flex h-full flex-col">

--- a/webui/src/components/rightSidebarPanels.tsx
+++ b/webui/src/components/rightSidebarPanels.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react';
 import {
+  Cpu,
   Globe,
   FolderOpen,
   LayoutDashboard,
@@ -12,6 +13,7 @@ import type { RightSidebarPanelId } from '@/types/sidebar';
 import { ArtifactsPanel } from './ArtifactsPanel';
 import { BrowserPreview } from './BrowserPreview';
 import { ConversationSettings } from './ConversationSettings';
+import { FunctionBrowserPanel } from './FunctionBrowserPanel';
 import { PanelsPanel } from './PanelsPanel';
 import { WorkspaceExplorer } from './workspace/WorkspaceExplorer';
 
@@ -52,6 +54,12 @@ export const rightSidebarPanels: RightSidebarPanelDefinition[] = [
     label: 'Panels',
     icon: LayoutDashboard,
     render: ({ conversationId }) => <PanelsPanel conversationId={conversationId} />,
+  },
+  {
+    id: 'functions',
+    label: 'Functions',
+    icon: Cpu,
+    render: () => <FunctionBrowserPanel />,
   },
   {
     id: 'browser',

--- a/webui/src/types/sidebar.ts
+++ b/webui/src/types/sidebar.ts
@@ -3,5 +3,6 @@ export type RightSidebarPanelId =
   | 'workspace'
   | 'artifacts'
   | 'panels'
+  | 'functions'
   | 'browser'
   | 'computer';

--- a/webui/src/types/tool.ts
+++ b/webui/src/types/tool.ts
@@ -1,0 +1,21 @@
+export interface ToolParameter {
+  name: string;
+  type: string;
+  description: string;
+  required: boolean;
+}
+
+export interface Tool {
+  name: string;
+  desc: string;
+  instructions: string;
+  block_types: string[];
+  is_mcp: boolean;
+  is_available: boolean;
+  disabled_by_default: boolean;
+  parameters: ToolParameter[];
+}
+
+export interface ToolListResponse {
+  tools: Tool[];
+}

--- a/webui/src/utils/toolsApi.ts
+++ b/webui/src/utils/toolsApi.ts
@@ -1,0 +1,31 @@
+import type { Tool, ToolListResponse } from '@/types/tool';
+import { useApi } from '@/contexts/ApiContext';
+import { withLocalAddressSpace } from '@/utils/addressSpace';
+import { useMemo } from 'react';
+
+export function useToolsApi() {
+  const { api } = useApi();
+
+  return useMemo(() => {
+    async function listTools(signal?: AbortSignal): Promise<Tool[]> {
+      const url = `${api.baseUrl}/api/v2/tools`;
+
+      const response = await fetch(
+        url,
+        withLocalAddressSpace(url, {
+          headers: api.authHeader ? { Authorization: api.authHeader } : undefined,
+          signal,
+        })
+      );
+
+      if (!response.ok) {
+        throw new Error(`Failed to load tools (${response.status})`);
+      }
+
+      const data = (await response.json()) as ToolListResponse;
+      return data.tools;
+    }
+
+    return { listTools };
+  }, [api.baseUrl, api.authHeader]);
+}


### PR DESCRIPTION
## Summary

- Adds a new **Functions** panel to the right sidebar showing all available tools
- New `GET /api/v2/tools` server endpoint returns tool metadata (name, description, block types, parameters, availability)
- Searchable list on the left, full tool details on the right (instructions, parameters, MCP/opt-in badges)
- Follows the same patterns as ArtifactsPanel and PanelsPanel

### Files changed
- `gptme/server/tools_api.py` — new Flask Blueprint with `/api/v2/tools` endpoint
- `gptme/server/app.py` — register the blueprint
- `webui/src/types/tool.ts` — TypeScript types for Tool / ToolListResponse
- `webui/src/utils/toolsApi.ts` — `useToolsApi()` hook
- `webui/src/components/FunctionBrowserPanel.tsx` — searchable 2-pane panel component
- `webui/src/types/sidebar.ts` — add `'functions'` to `RightSidebarPanelId`
- `webui/src/components/rightSidebarPanels.tsx` — register Functions panel with `Cpu` icon

## Test plan

- [ ] Start gptme server, open webui, click the Functions (CPU) icon in the sidebar
- [ ] Verify tool list loads with names and descriptions
- [ ] Search by name, description, or block type (e.g. search "shell")
- [ ] Select a tool to see full details including parameters and instructions
- [ ] MCP tools show "MCP" badge; unavailable tools show "unavailable" badge
- [ ] Opt-in tools show "opt-in" badge
- [ ] Refresh button reloads the list