### PR TITLE
feat(webui): offline demo ApiClient seam (IApiClient + createDemoApiClient)

### DIFF
--- a/webui/src/contexts/ApiContext.tsx
+++ b/webui/src/contexts/ApiContext.tsx
@@ -1,4 +1,4 @@
-import type { ApiClient } from '@/utils/api';
+import type { IApiClient } from '@/utils/api';
 import {
   getConnectionConfigFromSources,
   processConnectionFromHash,
@@ -23,9 +23,9 @@ import { toast } from 'sonner';
 
 interface ApiContextType {
   /** The primary server's client (shorthand for getClient(activeServerId)) */
-  api: ApiClient;
+  api: IApiClient;
   /** Get a client for any connected server. Defaults to primary. */
-  getClient: (serverId?: string) => ApiClient;
+  getClient: (serverId?: string) => IApiClient;
   isConnecting$: Observable<boolean>;
   isConnected$: Observable<boolean>;
   isAutoConnecting$: Observable<boolean>;
@@ -120,7 +120,7 @@ export function ApiProvider({
   const { isLoading: isLoadingTauriStatus, managesLocalServer } = useTauriServerStatus();
 
   // Get client for any server from the shared pool
-  const getClient = useCallback((serverId?: string): ApiClient => {
+  const getClient = useCallback((serverId?: string): IApiClient => {
     if (serverId) {
       const client = getClientForServer(serverId);
       if (client) return client;

--- a/webui/src/stores/serverClients.ts
+++ b/webui/src/stores/serverClients.ts
@@ -12,6 +12,9 @@ import { serverRegistry$ } from './servers';
 
 const clientPool = new Map<string, IApiClient>();
 
+// Cache isDemoMode() once — URL params don't change without a page reload.
+const _isDemoMode = isDemoMode();
+
 // In demo mode every server resolves to a single shared offline client.
 let demoClient: IApiClient | null = null;
 function getDemoClient(): IApiClient {
@@ -27,7 +30,7 @@ function getDemoClient(): IApiClient {
  * In demo mode (`?demo=1`) every server resolves to the offline demo client.
  */
 export function getClientForServer(serverId: string): IApiClient | null {
-  if (isDemoMode()) {
+  if (_isDemoMode) {
     return getDemoClient();
   }
 
@@ -49,7 +52,7 @@ export function getClientForServer(serverId: string): IApiClient | null {
 
 /** Get the client for the primary (active) server. */
 export function getPrimaryClient(): IApiClient {
-  if (isDemoMode()) {
+  if (_isDemoMode) {
     return getDemoClient();
   }
 

--- a/webui/src/stores/serverClients.ts
+++ b/webui/src/stores/serverClients.ts
@@ -5,16 +5,32 @@
  * for the "primary" server. The primary designation only controls which server
  * is the default for new conversations.
  */
-import { createApiClient, type ApiClient } from '@/utils/api';
+import { createApiClient, type IApiClient } from '@/utils/api';
+import { createDemoApiClient } from '@/utils/demoApiClient';
+import { isDemoMode } from '@/utils/connectionConfig';
 import { serverRegistry$ } from './servers';
 
-const clientPool = new Map<string, ApiClient>();
+const clientPool = new Map<string, IApiClient>();
+
+// In demo mode every server resolves to a single shared offline client.
+let demoClient: IApiClient | null = null;
+function getDemoClient(): IApiClient {
+  if (!demoClient) {
+    demoClient = createDemoApiClient();
+  }
+  return demoClient;
+}
 
 /**
  * Get or create an ApiClient for a specific server.
  * Clients are cached and invalidated when baseUrl or auth changes.
+ * In demo mode (`?demo=1`) every server resolves to the offline demo client.
  */
-export function getClientForServer(serverId: string): ApiClient | null {
+export function getClientForServer(serverId: string): IApiClient | null {
+  if (isDemoMode()) {
+    return getDemoClient();
+  }
+
   const registry = serverRegistry$.get();
   const server = registry.servers.find((s) => s.id === serverId);
   if (!server) return null;
@@ -32,7 +48,11 @@ export function getClientForServer(serverId: string): ApiClient | null {
 }
 
 /** Get the client for the primary (active) server. */
-export function getPrimaryClient(): ApiClient {
+export function getPrimaryClient(): IApiClient {
+  if (isDemoMode()) {
+    return getDemoClient();
+  }
+
   const registry = serverRegistry$.get();
   const client = getClientForServer(registry.activeServerId);
   if (!client) {

--- a/webui/src/utils/__tests__/demoApiClient.test.ts
+++ b/webui/src/utils/__tests__/demoApiClient.test.ts
@@ -1,0 +1,48 @@
+// Mock connectionConfig (uses import.meta, not parseable by jest) — see api.test.ts.
+jest.mock('@/utils/connectionConfig', () => ({
+  getApiBaseUrl: jest.fn(() => 'http://127.0.0.1:5700'),
+  isDemoMode: jest.fn(() => false),
+}));
+
+import { createDemoApiClient, DemoModeError } from '@/utils/demoApiClient';
+
+describe('createDemoApiClient', () => {
+  it('reports a connected, no-auth offline client', async () => {
+    const client = createDemoApiClient();
+    expect(client.authHeader).toBeNull();
+    expect(client.isConnected$.get()).toBe(true);
+    expect(await client.checkConnection()).toBe(true);
+    const probe = client.lastConnectionResult$.get();
+    expect(probe?.ok).toBe(true);
+  });
+
+  it('serves empty collections for read paths', async () => {
+    const client = createDemoApiClient();
+    expect(await client.getConversations()).toEqual([]);
+    expect(await client.searchConversations('anything')).toEqual([]);
+    expect(await client.getConversationsPaginated()).toEqual({
+      conversations: [],
+      nextCursor: undefined,
+    });
+    expect(await client.getSessions()).toEqual([]);
+    expect(await client.getExternalSessions()).toEqual([]);
+  });
+
+  it('throws DemoModeError for write paths without fixtures (slice 1)', async () => {
+    const client = createDemoApiClient();
+    await expect(
+      client.sendMessage('chat-1', { role: 'user', content: 'hi' })
+    ).rejects.toBeInstanceOf(DemoModeError);
+    await expect(client.createConversation('chat-1', [])).rejects.toBeInstanceOf(DemoModeError);
+    await expect(client.getConversation('chat-1')).rejects.toBeInstanceOf(DemoModeError);
+  });
+
+  it('keeps streaming and no-op lifecycle calls harmless', async () => {
+    const client = createDemoApiClient();
+    await expect(client.subscribeToEvents('chat-1', {} as never)).resolves.toBeUndefined();
+    expect(() => client.closeEventStream('chat-1')).not.toThrow();
+    await expect(client.interruptGeneration('chat-1')).resolves.toBeUndefined();
+    client.setConnected(false);
+    expect(client.isConnected$.get()).toBe(false);
+  });
+});

--- a/webui/src/utils/api.ts
+++ b/webui/src/utils/api.ts
@@ -1377,6 +1377,20 @@ export class ApiClient {
   }
 }
 
+/**
+ * Public surface of {@link ApiClient}, with the class's private members
+ * stripped. `keyof` on a class type excludes `private`/`protected` members, so
+ * `Pick<ApiClient, keyof ApiClient>` yields exactly the public API as a plain
+ * structural type — `ApiClient` satisfies it for free, and an alternative
+ * implementation (e.g. the offline `createDemoApiClient`) can satisfy it
+ * *without* re-declaring the private fields a `class … extends ApiClient`
+ * would inherit. This is the seam the client pool (`stores/serverClients.ts`)
+ * and `ApiContext` are typed against so a live or demo backend can be swapped
+ * transparently. Self-maintaining: a new public method on `ApiClient` is
+ * automatically required of every `IApiClient` implementation.
+ */
+export type IApiClient = Pick<ApiClient, keyof ApiClient>;
+
 export const createApiClient = (baseUrl?: string, authHeader?: string | null): ApiClient => {
   return new ApiClient(baseUrl, authHeader);
 };

--- a/webui/src/utils/connectionConfig.ts
+++ b/webui/src/utils/connectionConfig.ts
@@ -13,6 +13,18 @@ function trimTrailingSlash(url: string): string {
   return url.replace(/\/+$/, '');
 }
 
+/**
+ * Whether the app should run in offline demo mode (fixture-backed, no live
+ * backend, no auth). Activated by a `?demo=1` URL flag so a demo can be shared
+ * as a plain link. Safe to call outside a browser (returns false).
+ */
+export function isDemoMode(): boolean {
+  if (typeof window === 'undefined' || !window.location) {
+    return false;
+  }
+  return new URLSearchParams(window.location.search).get('demo') === '1';
+}
+
 // Vite statically replaces `import.meta.env.VITE_*` at build time for browser
 // bundles. Jest can't parse import.meta syntax (it's ESM-only), so we wrap it
 // in a Function() body to defer evaluation, then fall back to process.env

--- a/webui/src/utils/demoApiClient.ts
+++ b/webui/src/utils/demoApiClient.ts
@@ -1,0 +1,98 @@
+/**
+ * Offline demo ApiClient.
+ *
+ * `createDemoApiClient` returns an {@link IApiClient} that needs no live gptme
+ * backend, no auth, and makes no network calls. It powers sales demos,
+ * onboarding flows, and trade-show presentations from a static bundle (see the
+ * `?demo=1` flag wired in `connectionConfig.isDemoMode`).
+ *
+ * Slice 1 (this file) is the *seam*: a structurally-complete client that
+ * reports "connected", serves empty collections for the read paths, and throws
+ * a clear {@link DemoModeError} for the write/stream paths that later slices
+ * back with recorded fixtures. Because it is typed against `IApiClient` (the
+ * public surface of `ApiClient` with the private brand stripped), the compiler
+ * guarantees every public method is accounted for — adding a method to
+ * `ApiClient` will fail this file until it is handled here too.
+ */
+import { observable } from '@legendapp/state';
+import type { ConnectionProbeResult, IApiClient } from '@/utils/api';
+import type { UserInfo } from '@/types/api';
+
+/** Thrown by demo-client paths that have no recorded fixture yet (slice 1). */
+export class DemoModeError extends Error {
+  constructor(method: string) {
+    super(`Demo mode: ${method}() is not available without a live backend`);
+    this.name = 'DemoModeError';
+  }
+}
+
+const DEMO_BASE_URL = 'demo://offline';
+
+/**
+ * Build an offline demo client. Parameter types are inferred from the
+ * `IApiClient` contract via contextual typing, so the giant streaming-callback
+ * signatures never need to be hand-copied here.
+ */
+export function createDemoApiClient(baseUrl: string = DEMO_BASE_URL): IApiClient {
+  const isConnected$ = observable(true);
+  const lastConnectionResult$ = observable<ConnectionProbeResult | null>({
+    ok: true,
+    url: baseUrl,
+  });
+  const sessions$ = observable(new Map<string, string>());
+  const userInfo$ = observable<UserInfo | null>(null);
+
+  const notImpl = (method: string): never => {
+    throw new DemoModeError(method);
+  };
+
+  const client: IApiClient = {
+    baseUrl,
+    authHeader: null,
+    isConnected$,
+    lastConnectionResult$,
+    sessions$,
+    userInfo$,
+
+    // Connection lifecycle — the demo is permanently "connected".
+    checkConnection: async () => true,
+    setConnected: (connected) => {
+      isConnected$.set(connected);
+    },
+    cancelPendingRequests: async () => {},
+
+    // Streaming — no SSE in the static bundle; later slices replay fixtures.
+    subscribeToEvents: async () => {},
+    closeEventStream: () => {},
+    interruptGeneration: async () => {},
+
+    // Read paths — serve empty collections so the UI renders cleanly.
+    getUserInfo: async () => notImpl('getUserInfo'),
+    getServerInfo: async () => ({ version: 'demo' }),
+    getConversations: async () => [],
+    searchConversations: async () => [],
+    getConversationsPaginated: async () => ({ conversations: [], nextCursor: undefined }),
+    getConversation: async () => notImpl('getConversation'),
+    getChatConfig: async () => notImpl('getChatConfig'),
+    getExternalSessions: async () => [],
+    getExternalSession: async () => notImpl('getExternalSession'),
+    getSessions: async () => [],
+
+    // Write / mutation paths — fixture-backed in later slices.
+    createConversation: async () => notImpl('createConversation'),
+    createConversationWithPlaceholder: async () => notImpl('createConversationWithPlaceholder'),
+    sendMessage: async () => notImpl('sendMessage'),
+    editMessage: async () => notImpl('editMessage'),
+    deleteMessage: async () => notImpl('deleteMessage'),
+    rerunTools: async () => notImpl('rerunTools'),
+    uploadFiles: async () => notImpl('uploadFiles'),
+    step: async () => notImpl('step'),
+    confirmTool: async () => notImpl('confirmTool'),
+    updateChatConfig: async () => {},
+    deleteConversation: async () => {},
+    createAgent: async () => notImpl('createAgent'),
+    deleteSession: async () => {},
+  };
+
+  return client;
+}

--- a/webui/src/utils/demoApiClient.ts
+++ b/webui/src/utils/demoApiClient.ts
@@ -67,16 +67,18 @@ export function createDemoApiClient(baseUrl: string = DEMO_BASE_URL): IApiClient
     interruptGeneration: async () => {},
 
     // Read paths — serve empty collections so the UI renders cleanly.
-    getUserInfo: async () => notImpl('getUserInfo'),
     getServerInfo: async () => ({ version: 'demo' }),
     getConversations: async () => [],
     searchConversations: async () => [],
     getConversationsPaginated: async () => ({ conversations: [], nextCursor: undefined }),
+    getExternalSessions: async () => [],
+    getSessions: async () => [],
+
+    // Read paths — not yet fixture-backed; later slices will provide recorded data.
+    getUserInfo: async () => notImpl('getUserInfo'),
     getConversation: async () => notImpl('getConversation'),
     getChatConfig: async () => notImpl('getChatConfig'),
-    getExternalSessions: async () => [],
     getExternalSession: async () => notImpl('getExternalSession'),
-    getSessions: async () => [],
 
     // Write / mutation paths — fixture-backed in later slices.
     createConversation: async () => notImpl('createConversation'),


### PR DESCRIPTION
## What

Slice 1 of an **offline/static demo mode** for the gptme webui (powers gptme-cloud demos, onboarding, trade-show presentations without a live backend — idea #386). This PR lands the *seam*, not yet the fixtures.

- **`IApiClient = Pick<ApiClient, keyof ApiClient>`** (`utils/api.ts`) — the public surface of `ApiClient` with the class's private brand stripped. `keyof` on a class type excludes private/protected members, so this is exactly the public API as a structural type. `ApiClient` satisfies it for free, and a non-subclass implementation can satisfy it too (a `class … extends ApiClient` would be forced to re-declare private fields). **Self-maintaining**: adding a public method to `ApiClient` automatically requires it of every `IApiClient` implementation — this already caught `sessions$`/`userInfo$` during development.
- **`createDemoApiClient()`** (`utils/demoApiClient.ts`) — an `IApiClient` needing no backend/auth/network. Reports connected, serves empty collections for read paths, and throws a clear `DemoModeError` for write/stream paths that later slices back with recorded fixtures. Built as an object literal typed against `IApiClient`, so parameter types (including the large streaming-callback signatures) are inferred via contextual typing rather than hand-copied.
- **`isDemoMode()`** (`utils/connectionConfig.ts`) — activates demo mode via a `?demo=1` URL flag, so a demo is a shareable link. Safe outside a browser.
- **Seam wiring** — the client pool (`stores/serverClients.ts`) and `ApiContext` are typed against `IApiClient`; `getClientForServer`/`getPrimaryClient` return the shared demo client when demo mode is active.

## No behavior change when demo mode is off

`createApiClient` still returns a real `ApiClient` (which is structurally an `IApiClient`). With `?demo=1` absent, the path is identical to before.

## Verification

- `tsc -p tsconfig.app.json --noEmit` clean
- 4 new tests (`demoApiClient.test.ts`) + 27 affected tests (`servers`, `api`, `ApiContext`) pass
- eslint + prettier clean

## Follow-up (later slices)

Back the write/stream paths with recorded conversation fixtures (new conversation, tool call, streaming response, history) so the full demo flow works end-to-end.

Design: gptme/gptme-cloud#323