### PR TITLE
feat(webui): temperature and top_p controls in ChatOptionsPanel

### DIFF
--- a/webui/src/components/ChatInput.tsx
+++ b/webui/src/components/ChatInput.tsx
@@ -33,7 +33,12 @@ import { Switch } from '@/components/ui/switch';
 import { Label } from '@/components/ui/label';
 import { type Observable } from '@legendapp/state';
 import { Computed, use$ } from '@legendapp/state/react';
-import { conversations$, setMaxTokens as setMaxTokensStore } from '@/stores/conversations';
+import {
+  conversations$,
+  setMaxTokens as setMaxTokensStore,
+  setTemperature as setTemperatureStore,
+  setTopP as setTopPStore,
+} from '@/stores/conversations';
 import {
   selectedAgent$,
   selectedWorkspace$,
@@ -66,6 +71,10 @@ export interface ChatOptions {
   pendingFiles?: File[];
   /** Max tokens for the model's response. Undefined = provider default. */
   maxTokens?: number;
+  /** Sampling temperature (0–2). Undefined = provider default. */
+  temperature?: number;
+  /** Nucleus sampling top_p (0–1). Undefined = provider default. */
+  topP?: number;
 }
 
 interface Props {
@@ -110,6 +119,10 @@ interface ChatOptionsProps {
   setStreamingEnabled: (enabled: boolean) => void;
   maxTokens: number | undefined;
   setMaxTokens: (tokens: number | undefined) => void;
+  temperature: number | undefined;
+  setTemperature: (temperature: number | undefined) => void;
+  topP: number | undefined;
+  setTopP: (topP: number | undefined) => void;
   availableWorkspaces: WorkspaceProject[];
   isDisabled: boolean;
   showWorkspaceSelector: boolean;
@@ -128,6 +141,10 @@ const ChatOptionsPanel: FC<ChatOptionsProps> = ({
   setStreamingEnabled,
   maxTokens,
   setMaxTokens,
+  temperature,
+  setTemperature,
+  topP,
+  setTopP,
   availableWorkspaces,
   isDisabled,
   showWorkspaceSelector,
@@ -223,6 +240,46 @@ const ChatOptionsPanel: FC<ChatOptionsProps> = ({
           const val = e.target.value;
           const n = Math.round(Number(val));
           setMaxTokens(val === '' || isNaN(n) ? undefined : Math.max(1, n));
+        }}
+        disabled={isDisabled}
+        className="w-full rounded-md border border-input bg-background px-3 py-1.5 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+      />
+    </div>
+
+    <div className="space-y-1">
+      <Label htmlFor="temperature-input">Temperature</Label>
+      <input
+        id="temperature-input"
+        type="number"
+        min={0}
+        max={2}
+        step={0.1}
+        placeholder="Model default"
+        value={temperature ?? ''}
+        onChange={(e) => {
+          const val = e.target.value;
+          const n = Number(val);
+          setTemperature(val === '' || isNaN(n) ? undefined : Math.min(2, Math.max(0, n)));
+        }}
+        disabled={isDisabled}
+        className="w-full rounded-md border border-input bg-background px-3 py-1.5 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+      />
+    </div>
+
+    <div className="space-y-1">
+      <Label htmlFor="top-p-input">Top P</Label>
+      <input
+        id="top-p-input"
+        type="number"
+        min={0}
+        max={1}
+        step={0.05}
+        placeholder="Model default"
+        value={topP ?? ''}
+        onChange={(e) => {
+          const val = e.target.value;
+          const n = Number(val);
+          setTopP(val === '' || isNaN(n) ? undefined : Math.min(1, Math.max(0, n)));
         }}
         disabled={isDisabled}
         className="w-full rounded-md border border-input bg-background px-3 py-1.5 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
@@ -510,6 +567,8 @@ export const ChatInput: FC<Props> = ({
   });
   const [streamingEnabled, setStreamingEnabled] = useState(true);
   const [maxTokens, setMaxTokens] = useState<number | undefined>(undefined);
+  const [temperature, setTemperature] = useState<number | undefined>(undefined);
+  const [topP, setTopP] = useState<number | undefined>(undefined);
 
   // When switching conversations, load the new conversation's draft.
   // Use a ref to track the previous key so we can save the outgoing draft first.
@@ -565,14 +624,30 @@ export const ChatInput: FC<Props> = ({
     setMaxTokens(
       conversationId ? conversations$.get(conversationId)?.maxTokens?.peek() : undefined
     );
+    setTemperature(
+      conversationId ? conversations$.get(conversationId)?.temperature?.peek() : undefined
+    );
+    setTopP(conversationId ? conversations$.get(conversationId)?.topP?.peek() : undefined);
   }, [conversationId, conversationModel, defaultModel, apiDefaultModel]);
 
-  // Keep store in sync with local maxTokens so regenerate/rerun see the current UI value
+  // Keep store in sync with local generation params so regenerate/rerun see the current UI value
   useEffect(() => {
     if (conversationId) {
       setMaxTokensStore(conversationId, maxTokens);
     }
   }, [maxTokens, conversationId]);
+
+  useEffect(() => {
+    if (conversationId) {
+      setTemperatureStore(conversationId, temperature);
+    }
+  }, [temperature, conversationId]);
+
+  useEffect(() => {
+    if (conversationId) {
+      setTopPStore(conversationId, topP);
+    }
+  }, [topP, conversationId]);
 
   const [selectedWorkspace, setSelectedWorkspace] = useState<string>(
     // For new conversations, use the selected workspace from sidebar, otherwise default to '.'
@@ -821,6 +896,8 @@ export const ChatInput: FC<Props> = ({
               files: uploadedPaths,
               pendingFiles,
               maxTokens,
+              temperature,
+              topP,
             },
           },
         ]);
@@ -852,6 +929,8 @@ export const ChatInput: FC<Props> = ({
         files: uploadedPaths,
         pendingFiles,
         maxTokens,
+        temperature,
+        topP,
       });
       setMessage('');
       cleanupAndClearFiles();
@@ -1121,6 +1200,10 @@ export const ChatInput: FC<Props> = ({
                           setStreamingEnabled={setStreamingEnabled}
                           maxTokens={maxTokens}
                           setMaxTokens={setMaxTokens}
+                          temperature={temperature}
+                          setTemperature={setTemperature}
+                          topP={topP}
+                          setTopP={setTopP}
                           availableWorkspaces={availableWorkspaces}
                           isDisabled={isDisabled}
                           showWorkspaceSelector={!conversationId}

--- a/webui/src/components/ChatInput.tsx
+++ b/webui/src/components/ChatInput.tsx
@@ -264,6 +264,7 @@ const ChatOptionsPanel: FC<ChatOptionsProps> = ({
         disabled={isDisabled}
         className="w-full rounded-md border border-input bg-background px-3 py-1.5 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
       />
+      <p className="text-xs text-muted-foreground">0–2 (OpenAI) · 0–1 (Anthropic/Gemini)</p>
     </div>
 
     <div className="space-y-1">

--- a/webui/src/components/WelcomeView.tsx
+++ b/webui/src/components/WelcomeView.tsx
@@ -100,6 +100,8 @@ export const WelcomeView = () => {
         workspace: options?.workspace || '.',
         pendingFiles: options?.pendingFiles,
         maxTokens: options?.maxTokens,
+        temperature: options?.temperature,
+        topP: options?.topP,
       });
 
       // Navigate immediately - server-side creation happens in background

--- a/webui/src/components/__tests__/ChatInput.test.tsx
+++ b/webui/src/components/__tests__/ChatInput.test.tsx
@@ -57,6 +57,8 @@ jest.mock('@/stores/conversations', () => {
       ),
     },
     setMaxTokens: jest.fn(),
+    setTemperature: jest.fn(),
+    setTopP: jest.fn(),
   };
 });
 

--- a/webui/src/hooks/useConversation.ts
+++ b/webui/src/hooks/useConversation.ts
@@ -23,6 +23,8 @@ import {
   updateConversationName,
   setNeedsInitialStep,
   setMaxTokens,
+  setTemperature,
+  setTopP,
 } from '@/stores/conversations';
 import { playChime } from '@/utils/audio';
 import { findLatestAssistantIndexForError } from '@/utils/conversationErrorHandling';
@@ -40,6 +42,8 @@ export function useConversation(conversationId: string, serverId?: string) {
   const conversation$ = conversations$.get(conversationId);
   const isConnected = use$(isConnected$);
   const maxTokens = use$(() => conversation$?.maxTokens.get());
+  const temperature = use$(() => conversation$?.temperature.get());
+  const topP = use$(() => conversation$?.topP.get());
 
   const messageJustCompleted = useRef(false);
 
@@ -343,10 +347,12 @@ export function useConversation(conversationId: string, serverId?: string) {
               if (needsStep) {
                 console.log('[useConversation] Triggering initial step after subscription');
                 setNeedsInitialStep(conversationId, false);
-                api.step(conversationId, undefined, true, 'main', maxTokens).catch((error) => {
-                  console.error('[useConversation] Error triggering initial step:', error);
-                  toastStepStartError(toast, error);
-                });
+                api
+                  .step(conversationId, undefined, true, 'main', maxTokens, temperature, topP)
+                  .catch((error) => {
+                    console.error('[useConversation] Error triggering initial step:', error);
+                    toastStepStartError(toast, error);
+                  });
               }
             },
             onReconnectState: (state) => {
@@ -459,9 +465,19 @@ export function useConversation(conversationId: string, serverId?: string) {
       setMessageStatus(conversationId, userMessage.timestamp!, 'sent');
 
       // Start generation
-      await api.step(conversationId, options?.model, options?.stream, 'main', options?.maxTokens);
-      // Store maxTokens in conversation state so regenerate/rerun paths can use it
+      await api.step(
+        conversationId,
+        options?.model,
+        options?.stream,
+        'main',
+        options?.maxTokens,
+        options?.temperature,
+        options?.topP
+      );
+      // Store generation params in conversation state so regenerate/rerun paths can use them
       setMaxTokens(conversationId, options?.maxTokens);
+      setTemperature(conversationId, options?.temperature);
+      setTopP(conversationId, options?.topP);
     } catch (error) {
       console.error('Error sending message:', error);
       const { title, description } = getApiErrorPresentation(error, {
@@ -587,7 +603,7 @@ export function useConversation(conversationId: string, serverId?: string) {
 
       // After truncation, trigger re-generation
       if (truncate) {
-        await api.step(conversationId, undefined, true, 'main', maxTokens);
+        await api.step(conversationId, undefined, true, 'main', maxTokens, temperature, topP);
       }
     } catch (error) {
       console.error('Error editing message:', error);
@@ -630,7 +646,7 @@ export function useConversation(conversationId: string, serverId?: string) {
         await api.rerunTools(conversationId);
       } catch {
         // No tools found — fall back to step() (regenerate)
-        await api.step(conversationId, undefined, true, 'main', maxTokens);
+        await api.step(conversationId, undefined, true, 'main', maxTokens, temperature, topP);
       }
     } catch (error) {
       console.error('Error re-running from message:', error);
@@ -652,7 +668,7 @@ export function useConversation(conversationId: string, serverId?: string) {
       if (result.branches) {
         updateBranches(conversationId, result.branches);
       }
-      await api.step(conversationId, undefined, true, 'main', maxTokens);
+      await api.step(conversationId, undefined, true, 'main', maxTokens, temperature, topP);
     } catch (error) {
       console.error('Error regenerating message:', error);
       const errorMsg = error instanceof Error ? error.message : 'Failed to regenerate';

--- a/webui/src/stores/conversations.ts
+++ b/webui/src/stores/conversations.ts
@@ -38,6 +38,10 @@ export interface ConversationState {
   // Max tokens setting for model responses, persisted across operations.
   // Set by ChatInput when sending a message; read by all step() call sites.
   maxTokens?: number;
+  // Sampling temperature, persisted across operations. Undefined = provider default.
+  temperature?: number;
+  // Nucleus sampling top_p, persisted across operations. Undefined = provider default.
+  topP?: number;
 }
 
 // Central store for all conversations
@@ -158,6 +162,14 @@ export function setNeedsInitialStep(id: string, needsInitialStep: boolean) {
 
 export function setMaxTokens(id: string, maxTokens: number | undefined) {
   updateConversation(id, { maxTokens });
+}
+
+export function setTemperature(id: string, temperature: number | undefined) {
+  updateConversation(id, { temperature });
+}
+
+export function setTopP(id: string, topP: number | undefined) {
+  updateConversation(id, { topP });
 }
 
 // Update conversation data in the store

--- a/webui/src/utils/api.ts
+++ b/webui/src/utils/api.ts
@@ -16,7 +16,7 @@ import { getApiBaseUrl } from '@/utils/connectionConfig';
 import { isLocalUrl, withLocalAddressSpace } from '@/utils/addressSpace';
 import { type Observable } from '@legendapp/state';
 import { observable } from '@legendapp/state';
-import { initConversation, setMaxTokens } from '@/stores/conversations';
+import { initConversation, setMaxTokens, setTemperature, setTopP } from '@/stores/conversations';
 
 // Add DOM types
 type RequestInit = globalThis.RequestInit;
@@ -951,6 +951,8 @@ export class ApiClient {
       workspace?: string;
       pendingFiles?: File[];
       maxTokens?: number;
+      temperature?: number;
+      topP?: number;
     }
   ): Promise<string> {
     // Generate conversation ID immediately
@@ -981,6 +983,12 @@ export class ApiClient {
     );
     if (options?.maxTokens !== undefined) {
       setMaxTokens(conversationId, options.maxTokens);
+    }
+    if (options?.temperature !== undefined) {
+      setTemperature(conversationId, options.temperature);
+    }
+    if (options?.topP !== undefined) {
+      setTopP(conversationId, options.topP);
     }
 
     if (options?.pendingFiles?.length) {
@@ -1135,7 +1143,9 @@ export class ApiClient {
     model?: string,
     stream: boolean = true,
     branch: string = 'main',
-    maxTokens?: number
+    maxTokens?: number,
+    temperature?: number,
+    topP?: number
   ): Promise<void> {
     if (!this.isConnected) {
       throw new Error('Not connected to API');
@@ -1184,6 +1194,8 @@ export class ApiClient {
             branch,
             stream,
             ...(maxTokens !== undefined ? { max_tokens: maxTokens } : {}),
+            ...(temperature !== undefined ? { temperature } : {}),
+            ...(topP !== undefined ? { top_p: topP } : {}),
           }),
           signal: this.controller.signal,
         }


### PR DESCRIPTION
## Summary

Adds temperature and top_p generation parameter controls to the webui, completing the UI side of the server-side support that landed in #2659.

- **`ChatOptionsPanel`**: temperature (0–2) and top_p (0–1) number inputs; provider range hint shown below temperature (Anthropic/Gemini: 0–1, others: 0–2)
- **`conversations` store**: `temperature` and `topP` fields + setters, persisted across regenerate/rerun
- **`api.step()`**: sends `temperature`/`top_p` in the request body when set
- **`createConversationWithPlaceholder` + `WelcomeView`**: pass-through so new chats inherit the values

## Motivation

Server-side `ChatConfig` already accepted `temperature` and `top_p` as of #2659 but there was no way to set them from the browser. Users who want to tune output randomness had to rely on server-side defaults.

## Test plan

- [x] Jest: 318 passed (2 pre-existing failures in `SetupWizard.test.tsx`, unrelated)
- [x] `tsc --noEmit` clean
- [ ] Manual: open ChatOptionsPanel, set temperature to 0.5, send a message, verify the request body includes `temperature: 0.5`