### PR TITLE
feat(webui): speech-to-text dictation button

### DIFF
--- a/webui/src/components/ChatInput.tsx
+++ b/webui/src/components/ChatInput.tsx
@@ -19,9 +19,11 @@ import {
   useRef,
   useCallback,
   type FC,
+  type Dispatch,
   type FormEvent,
   type KeyboardEvent,
   type DragEvent,
+  type SetStateAction,
 } from 'react';
 import { useApi } from '@/contexts/ApiContext';
 import { Badge } from '@/components/ui/badge';
@@ -86,7 +88,7 @@ interface Props {
   defaultModel?: string;
   autoFocus$: Observable<boolean>;
   value?: string;
-  onChange?: (value: string) => void;
+  onChange?: Dispatch<SetStateAction<string>>;
   // Edit mode: reuse ChatInput for inline message editing with attachment support
   editMode?: boolean;
   editFiles?: string[]; // Pre-existing file paths from the message being edited
@@ -1247,7 +1249,7 @@ export const ChatInput: FC<Props> = ({
 
                     <SpeechInputButton
                       onTranscript={(text) =>
-                        setMessage(message ? message + ' ' + text.trim() : text.trim())
+                        setMessage((prev) => (prev ? prev + ' ' + text.trim() : text.trim()))
                       }
                       disabled={isDisabled || isGenerating}
                     />

--- a/webui/src/components/ChatInput.tsx
+++ b/webui/src/components/ChatInput.tsx
@@ -994,6 +994,13 @@ export const ChatInput: FC<Props> = ({
     }
   };
 
+  const handleTranscript = useCallback(
+    (text: string) => {
+      setMessage((prev) => (prev ? prev + ' ' + text.trim() : text.trim()));
+    },
+    [setMessage]
+  );
+
   const handlePaste = useCallback(
     (e: React.ClipboardEvent) => {
       const items = e.clipboardData?.items;
@@ -1248,9 +1255,7 @@ export const ChatInput: FC<Props> = ({
                     </div>
 
                     <SpeechInputButton
-                      onTranscript={(text) =>
-                        setMessage((prev) => (prev ? prev + ' ' + text.trim() : text.trim()))
-                      }
+                      onTranscript={handleTranscript}
                       disabled={isDisabled || isGenerating}
                     />
                     {settings.voiceServerUrl && (

--- a/webui/src/components/ChatInput.tsx
+++ b/webui/src/components/ChatInput.tsx
@@ -53,6 +53,7 @@ import { useAgents } from '@/hooks/useAgents';
 import { useFileAutocomplete } from '@/hooks/useFileAutocomplete';
 import { FileAutocomplete } from '@/components/FileAutocomplete';
 import { VoiceButton } from '@/components/VoiceButton';
+import { SpeechInputButton } from '@/components/SpeechInputButton';
 import { useSettings } from '@/contexts/SettingsContext';
 import {
   Select,
@@ -1244,6 +1245,12 @@ export const ChatInput: FC<Props> = ({
                         )}
                     </div>
 
+                    <SpeechInputButton
+                      onTranscript={(text) =>
+                        setMessage(message ? message + ' ' + text.trim() : text.trim())
+                      }
+                      disabled={isDisabled || isGenerating}
+                    />
                     {settings.voiceServerUrl && (
                       <VoiceButton voiceServerUrl={settings.voiceServerUrl} />
                     )}

--- a/webui/src/components/ChatMessage.tsx
+++ b/webui/src/components/ChatMessage.tsx
@@ -585,7 +585,11 @@ export const ChatMessage: FC<Props> = ({
                           conversationId={conversationId}
                           autoFocus$={editAutoFocus$}
                           value={editContent$.get()}
-                          onChange={(v) => editContent$.set(v)}
+                          onChange={(next) =>
+                            editContent$.set(
+                              typeof next === 'function' ? next(editContent$.get()) : next
+                            )
+                          }
                           editMode
                           editFiles={message$.files?.get()?.map(String)}
                           onEditSave={(content, files, pendingFiles, truncate) => {

--- a/webui/src/components/SpeechInputButton.tsx
+++ b/webui/src/components/SpeechInputButton.tsx
@@ -1,0 +1,78 @@
+import { Mic, MicOff, Loader2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { useEffect } from 'react';
+import { useSpeechToText } from '@/hooks/useSpeechToText';
+
+interface Props {
+  /** Called with each finalized speech segment; caller appends to textarea */
+  onTranscript: (text: string) => void;
+  /** Called when interim (unstable) transcript changes */
+  onInterimTranscript?: (text: string) => void;
+  disabled?: boolean;
+}
+
+export function SpeechInputButton({ onTranscript, onInterimTranscript, disabled }: Props) {
+  const { state, isSupported, interimTranscript, startListening, stopListening, onFinalResult } =
+    useSpeechToText();
+
+  useEffect(() => {
+    onFinalResult(onTranscript);
+  }, [onFinalResult, onTranscript]);
+
+  useEffect(() => {
+    onInterimTranscript?.(interimTranscript);
+  }, [interimTranscript, onInterimTranscript]);
+
+  if (!isSupported) return null;
+
+  const isListening = state === 'listening';
+  const isError = state === 'error';
+
+  const handleClick = () => {
+    if (isListening) stopListening();
+    else startListening();
+  };
+
+  const label = isError
+    ? 'Mic error — click to retry'
+    : isListening
+      ? 'Listening… click to stop'
+      : 'Dictate message (speech-to-text)';
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          onClick={handleClick}
+          disabled={disabled}
+          className={[
+            'relative h-8 w-8 shrink-0 rounded-full transition-colors',
+            isError ? 'text-destructive' : '',
+            isListening ? 'text-blue-500 hover:text-blue-600' : 'text-muted-foreground',
+          ].join(' ')}
+          aria-label={label}
+          aria-pressed={isListening}
+        >
+          {/* Pulse ring while listening */}
+          {isListening && (
+            <span className="absolute inset-0 animate-ping rounded-full bg-blue-500/20" />
+          )}
+          {state === 'error' ? (
+            <MicOff className="h-4 w-4" />
+          ) : isListening ? (
+            <Loader2 className="relative h-4 w-4 animate-spin" />
+          ) : (
+            <Mic className="h-4 w-4" />
+          )}
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent side="top">
+        <p>{label}</p>
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/webui/src/components/SpeechInputButton.tsx
+++ b/webui/src/components/SpeechInputButton.tsx
@@ -16,6 +16,8 @@ export function SpeechInputButton({ onTranscript, onInterimTranscript, disabled 
   const { state, isSupported, interimTranscript, startListening, stopListening, onFinalResult } =
     useSpeechToText();
 
+  const isListening = state === 'listening';
+
   useEffect(() => {
     onFinalResult(onTranscript);
   }, [onFinalResult, onTranscript]);
@@ -24,9 +26,12 @@ export function SpeechInputButton({ onTranscript, onInterimTranscript, disabled 
     onInterimTranscript?.(interimTranscript);
   }, [interimTranscript, onInterimTranscript]);
 
-  if (!isSupported) return null;
+  // Stop mic when button becomes disabled (e.g. during response generation)
+  useEffect(() => {
+    if (disabled && isListening) stopListening();
+  }, [disabled, isListening, stopListening]);
 
-  const isListening = state === 'listening';
+  if (!isSupported) return null;
   const isError = state === 'error';
 
   const handleClick = () => {

--- a/webui/src/components/SpeechInputButton.tsx
+++ b/webui/src/components/SpeechInputButton.tsx
@@ -56,8 +56,11 @@ export function SpeechInputButton({ onTranscript, onInterimTranscript, disabled 
           disabled={disabled}
           className={[
             'relative h-8 w-8 shrink-0 rounded-full transition-colors',
-            isError ? 'text-destructive' : '',
-            isListening ? 'text-blue-500 hover:text-blue-600' : 'text-muted-foreground',
+            isError
+              ? 'text-destructive'
+              : isListening
+                ? 'text-blue-500 hover:text-blue-600'
+                : 'text-muted-foreground',
           ].join(' ')}
           aria-label={label}
           aria-pressed={isListening}

--- a/webui/src/hooks/useSpeechToText.ts
+++ b/webui/src/hooks/useSpeechToText.ts
@@ -76,7 +76,8 @@ export function useSpeechToText(): UseSpeechToTextReturn {
     };
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    recognition.onerror = (_event: any) => {
+    recognition.onerror = (event: any) => {
+      console.warn('SpeechRecognition error:', event.error);
       if (recognitionRef.current !== recognition) return; // stale closure guard
       setState('error');
       recognitionRef.current = null;

--- a/webui/src/hooks/useSpeechToText.ts
+++ b/webui/src/hooks/useSpeechToText.ts
@@ -75,13 +75,16 @@ export function useSpeechToText(): UseSpeechToTextReturn {
       }
     };
 
-    recognition.onerror = () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    recognition.onerror = (_event: any) => {
+      if (recognitionRef.current !== recognition) return; // stale closure guard
       setState('error');
       recognitionRef.current = null;
       setInterimTranscript('');
     };
 
     recognition.onend = () => {
+      if (recognitionRef.current !== recognition) return; // stale closure guard
       recognitionRef.current = null;
       setState('idle');
       setInterimTranscript('');

--- a/webui/src/hooks/useSpeechToText.ts
+++ b/webui/src/hooks/useSpeechToText.ts
@@ -1,0 +1,131 @@
+import { useState, useRef, useCallback, useEffect } from 'react';
+
+export type STTState = 'idle' | 'listening' | 'error';
+
+export interface UseSpeechToTextReturn {
+  state: STTState;
+  isSupported: boolean;
+  interimTranscript: string;
+  startListening: () => void;
+  stopListening: () => void;
+  onFinalResult: (handler: (text: string) => void) => void;
+}
+
+// SpeechRecognition is not in TypeScript's standard DOM lib on all targets.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyWindow = Window & { SpeechRecognition?: any; webkitSpeechRecognition?: any };
+
+const getSpeechRecognitionClass = ():
+  | (new () => {
+      continuous: boolean;
+      interimResults: boolean;
+      lang: string;
+
+      onstart: (() => void) | null;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      onresult: ((event: any) => void) | null;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      onerror: ((event: any) => void) | null;
+      onend: (() => void) | null;
+      start: () => void;
+      stop: () => void;
+      abort: () => void;
+    })
+  | null => {
+  if (typeof window === 'undefined') return null;
+  const w = window as AnyWindow;
+  return w.SpeechRecognition ?? w.webkitSpeechRecognition ?? null;
+};
+
+export function useSpeechToText(): UseSpeechToTextReturn {
+  const [state, setState] = useState<STTState>('idle');
+  const [interimTranscript, setInterimTranscript] = useState('');
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const recognitionRef = useRef<any>(null);
+  const finalHandlerRef = useRef<((text: string) => void) | null>(null);
+  const SpeechRecognitionClass = getSpeechRecognitionClass();
+  const isSupported = SpeechRecognitionClass !== null;
+
+  const startListening = useCallback(() => {
+    if (!SpeechRecognitionClass) return;
+    if (recognitionRef.current) return;
+
+    const recognition = new SpeechRecognitionClass();
+    recognition.continuous = true;
+    recognition.interimResults = true;
+    recognition.lang = navigator.language || 'en-US';
+
+    recognition.onstart = () => setState('listening');
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    recognition.onresult = (event: any) => {
+      let interim = '';
+      let final = '';
+      for (let i = event.resultIndex; i < event.results.length; i++) {
+        const result = event.results[i];
+        if (result.isFinal) {
+          final += result[0].transcript;
+        } else {
+          interim += result[0].transcript;
+        }
+      }
+      setInterimTranscript(interim);
+      if (final && finalHandlerRef.current) {
+        finalHandlerRef.current(final);
+      }
+    };
+
+    recognition.onerror = () => {
+      setState('error');
+      recognitionRef.current = null;
+      setInterimTranscript('');
+    };
+
+    recognition.onend = () => {
+      recognitionRef.current = null;
+      setState('idle');
+      setInterimTranscript('');
+    };
+
+    recognitionRef.current = recognition;
+    try {
+      recognition.start();
+    } catch {
+      recognitionRef.current = null;
+      setState('error');
+    }
+  }, [SpeechRecognitionClass]);
+
+  const stopListening = useCallback(() => {
+    if (recognitionRef.current) {
+      recognitionRef.current.stop();
+      recognitionRef.current = null;
+    }
+    setState('idle');
+    setInterimTranscript('');
+  }, []);
+
+  const onFinalResult = useCallback((handler: (text: string) => void) => {
+    finalHandlerRef.current = handler;
+  }, []);
+
+  // Auto-reset error state after 1.5s
+  useEffect(() => {
+    if (state !== 'error') return;
+    const t = setTimeout(() => setState('idle'), 1500);
+    return () => clearTimeout(t);
+  }, [state]);
+
+  // Cleanup on unmount
+  useEffect(
+    () => () => {
+      if (recognitionRef.current) {
+        recognitionRef.current.abort();
+        recognitionRef.current = null;
+      }
+    },
+    []
+  );
+
+  return { state, isSupported, interimTranscript, startListening, stopListening, onFinalResult };
+}


### PR DESCRIPTION
## Summary

Adds a lightweight speech-to-text dictation button to the chat input using the browser's native Web Speech API.

- **`useSpeechToText` hook**: continuous SpeechRecognition, interim + final transcript, `idle`/`listening`/`error` state, cleanup on unmount, browser compat via `window.SpeechRecognition ?? webkitSpeechRecognition`
- **`SpeechInputButton` component**: mic icon with pulsing ring while listening, MicOff on error, tooltip with state label — returns `null` when unsupported so the layout is unchanged on Firefox/Safari
- **ChatInput integration**: renders `SpeechInputButton` to the left of the existing `VoiceButton`; final transcript appended to current message text

## Difference from VoiceButton

The existing `VoiceButton` opens a full bidirectional voice session via WebSocket to `gptme-voice-server`. This button is a standalone dictation aid: click to speak, transcript appears in the textarea, send normally. No server configuration required.

## Browser support

Supported: Chrome, Edge, Safari (partial). Not available on Firefox (no `SpeechRecognition` API). The button hides itself on unsupported browsers via an `isSupported` guard.

## Test plan

- [ ] Open gptme webui in Chrome/Edge
- [ ] Mic button appears to the left of the voice session button (if configured)
- [ ] Click mic → pulsing ring, spoken words appear in textarea
- [ ] Click again → stops listening
- [ ] On Firefox: mic button is absent, no layout regression