### PR TITLE
feat(webui): add Ctrl+F message search with match navigation

### DIFF
--- a/webui/src/components/ConversationContent.tsx
+++ b/webui/src/components/ConversationContent.tsx
@@ -97,12 +97,16 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [isReadOnly, hasSession$, shouldFocus$]);
 
-  // Ctrl+F / Cmd+F to open message search
+  // Ctrl+F / Cmd+F to open message search (or re-focus if already open)
   useEffect(() => {
     const handleSearchKeyDown = (e: KeyboardEvent) => {
       if ((e.ctrlKey || e.metaKey) && e.key === 'f') {
         e.preventDefault();
-        searchVisible$.set(true);
+        if (searchVisible$.get()) {
+          document.querySelector<HTMLInputElement>('[data-search-input]')?.focus();
+        } else {
+          searchVisible$.set(true);
+        }
       }
     };
     window.addEventListener('keydown', handleSearchKeyDown);

--- a/webui/src/components/ConversationContent.tsx
+++ b/webui/src/components/ConversationContent.tsx
@@ -9,6 +9,7 @@ import { computeForkPoints } from '@/utils/branchUtils';
 import { buildStepRoles, type StepRole } from '@/utils/stepGrouping';
 
 import { InlineToolConfirmation } from './InlineToolConfirmation';
+import { MessageSearchBar } from './MessageSearchBar';
 import { InlineToolExecution, ToolCompletionBadge } from './InlineToolExecution';
 import { For, Memo, use$, useObservable, useObserveEffect } from '@legendapp/state/react';
 import { getObservableIndex } from '@legendapp/state';
@@ -44,6 +45,12 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
   const { api, connectionConfig } = useApi();
   const hasSession$ = useObservable<boolean>(false);
   const { defaultModel } = useModels();
+
+  // Message search state — declared early so keyboard handlers can reference them
+  const searchVisible$ = useObservable(false);
+  const searchQuery$ = useObservable('');
+  const searchMatchIndices$ = useObservable<number[]>([]);
+  const searchCurrentMatch$ = useObservable(0);
 
   // Fetch user info once (cached in ApiClient)
   useEffect(() => {
@@ -89,6 +96,18 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [isReadOnly, hasSession$, shouldFocus$]);
+
+  // Ctrl+F / Cmd+F to open message search
+  useEffect(() => {
+    const handleSearchKeyDown = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key === 'f') {
+        e.preventDefault();
+        searchVisible$.set(true);
+      }
+    };
+    window.addEventListener('keydown', handleSearchKeyDown);
+    return () => window.removeEventListener('keydown', handleSearchKeyDown);
+  }, [searchVisible$]);
 
   const firstNonSystemIndex$ = useObservable(() => {
     return conversation$.get()?.data.log.findIndex((msg) => msg.role !== 'system') || 0;
@@ -218,6 +237,93 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
     sendMessage({ message, options });
   };
 
+  // Search helpers: imperative DOM highlight + scroll, avoids re-rendering all messages
+  const highlightSearchMatch = useCallback(
+    (msgIndex: number) => {
+      scrollContainerRef.current
+        ?.querySelectorAll<HTMLElement>('[data-message-index]')
+        .forEach((el) => {
+          el.style.outline = '';
+          el.style.outlineOffset = '';
+        });
+      const el = scrollContainerRef.current?.querySelector<HTMLElement>(
+        `[data-message-index="${msgIndex}"]`
+      );
+      if (el) {
+        el.style.outline = '2px solid rgba(234,179,8,0.6)';
+        el.style.outlineOffset = '-2px';
+        el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      }
+    },
+    [scrollContainerRef]
+  );
+
+  const computeSearchMatches = useCallback(
+    (query: string): number[] => {
+      if (!query.trim()) return [];
+      const q = query.toLowerCase();
+      const messages = conversation$.data.log.get();
+      if (!messages) return [];
+      return messages
+        .map((msg, i) => (msg.content.toLowerCase().includes(q) ? i : -1))
+        .filter((i) => i >= 0);
+    },
+    [conversation$]
+  );
+
+  const handleSearchQueryChange = useCallback(
+    (query: string) => {
+      searchQuery$.set(query);
+      const matches = computeSearchMatches(query);
+      searchMatchIndices$.set(matches);
+      searchCurrentMatch$.set(0);
+      if (matches.length > 0) highlightSearchMatch(matches[0]);
+      else
+        scrollContainerRef.current
+          ?.querySelectorAll<HTMLElement>('[data-message-index]')
+          .forEach((el) => {
+            el.style.outline = '';
+            el.style.outlineOffset = '';
+          });
+    },
+    [
+      searchQuery$,
+      searchMatchIndices$,
+      searchCurrentMatch$,
+      computeSearchMatches,
+      highlightSearchMatch,
+    ]
+  );
+
+  const handleSearchNext = useCallback(() => {
+    const matches = searchMatchIndices$.get();
+    if (!matches.length) return;
+    const next = (searchCurrentMatch$.get() + 1) % matches.length;
+    searchCurrentMatch$.set(next);
+    highlightSearchMatch(matches[next]);
+  }, [searchMatchIndices$, searchCurrentMatch$, highlightSearchMatch]);
+
+  const handleSearchPrev = useCallback(() => {
+    const matches = searchMatchIndices$.get();
+    if (!matches.length) return;
+    const prev = (searchCurrentMatch$.get() - 1 + matches.length) % matches.length;
+    searchCurrentMatch$.set(prev);
+    highlightSearchMatch(matches[prev]);
+  }, [searchMatchIndices$, searchCurrentMatch$, highlightSearchMatch]);
+
+  const handleSearchClose = useCallback(() => {
+    searchVisible$.set(false);
+    searchQuery$.set('');
+    searchMatchIndices$.set([]);
+    searchCurrentMatch$.set(0);
+    scrollContainerRef.current
+      ?.querySelectorAll<HTMLElement>('[data-message-index]')
+      .forEach((el) => {
+        el.style.outline = '';
+        el.style.outlineOffset = '';
+      });
+  }, [searchVisible$, searchQuery$, searchMatchIndices$, searchCurrentMatch$]);
+
   // Handle tool confirmation
   const handleConfirmTool = async () => {
     await confirmTool('confirm');
@@ -261,6 +367,21 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
 
   return (
     <main className="relative flex h-full flex-col">
+      <Memo>
+        {() =>
+          searchVisible$.get() ? (
+            <MessageSearchBar
+              query={searchQuery$.get()}
+              matchCount={searchMatchIndices$.get().length}
+              currentMatch={searchCurrentMatch$.get() + 1}
+              onQueryChange={handleSearchQueryChange}
+              onNext={handleSearchNext}
+              onPrev={handleSearchPrev}
+              onClose={handleSearchClose}
+            />
+          ) : null
+        }
+      </Memo>
       <div
         className="flex-1 overflow-y-auto"
         ref={scrollContainerRef}
@@ -361,7 +482,7 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
             const agentName = conversation$.data.agent?.name?.get();
 
             return (
-              <div key={`${index}-${msg$.timestamp.get()}`}>
+              <div key={`${index}-${msg$.timestamp.get()}`} data-message-index={index}>
                 {/* Show summary bar above first message when group is expanded */}
                 {groupSummary}
                 <ChatMessage

--- a/webui/src/components/ConversationContent.tsx
+++ b/webui/src/components/ConversationContent.tsx
@@ -237,15 +237,51 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
     sendMessage({ message, options });
   };
 
+  const clearSearchHighlights = useCallback(() => {
+    scrollContainerRef.current
+      ?.querySelectorAll<HTMLElement>('[data-message-index]')
+      .forEach((el) => {
+        el.style.outline = '';
+        el.style.outlineOffset = '';
+      });
+  }, [scrollContainerRef]);
+
+  const isMessageHidden = useCallback(
+    (idx: number) => {
+      const messages = conversation$.data.log.get();
+      const msg = messages?.[idx];
+      if (!msg) return false;
+
+      const firstNonSystemIndex = firstNonSystemIndex$.get();
+      const isInitialSystem =
+        msg.role === 'system' && (firstNonSystemIndex === -1 || idx < firstNonSystemIndex);
+      if (isInitialSystem && !showInitialSystem$.get()) return true;
+      if (msg.hide && !showHiddenMessages$.get()) return true;
+
+      const stepRole = stepRoles$.get().get(idx);
+      if (
+        (stepRole?.type === 'group-start' || stepRole?.type === 'grouped') &&
+        !expandedGroups$.get().has(stepRole.groupId)
+      ) {
+        return true;
+      }
+
+      return false;
+    },
+    [
+      conversation$,
+      expandedGroups$,
+      firstNonSystemIndex$,
+      showHiddenMessages$,
+      showInitialSystem$,
+      stepRoles$,
+    ]
+  );
+
   // Search helpers: imperative DOM highlight + scroll, avoids re-rendering all messages
   const highlightSearchMatch = useCallback(
     (msgIndex: number) => {
-      scrollContainerRef.current
-        ?.querySelectorAll<HTMLElement>('[data-message-index]')
-        .forEach((el) => {
-          el.style.outline = '';
-          el.style.outlineOffset = '';
-        });
+      clearSearchHighlights();
       const el = scrollContainerRef.current?.querySelector<HTMLElement>(
         `[data-message-index="${msgIndex}"]`
       );
@@ -255,7 +291,7 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
         el.scrollIntoView({ behavior: 'smooth', block: 'center' });
       }
     },
-    [scrollContainerRef]
+    [clearSearchHighlights, scrollContainerRef]
   );
 
   const computeSearchMatches = useCallback(
@@ -265,11 +301,28 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
       const messages = conversation$.data.log.get();
       if (!messages) return [];
       return messages
-        .map((msg, i) => (msg.content.toLowerCase().includes(q) ? i : -1))
+        .map((msg, i) => {
+          const content = typeof msg.content === 'string' ? msg.content.toLowerCase() : '';
+          return !isMessageHidden(i) && content.includes(q) ? i : -1;
+        })
         .filter((i) => i >= 0);
     },
-    [conversation$]
+    [conversation$, isMessageHidden]
   );
+
+  const resetSearchState = useCallback(() => {
+    searchVisible$.set(false);
+    searchQuery$.set('');
+    searchMatchIndices$.set([]);
+    searchCurrentMatch$.set(0);
+    clearSearchHighlights();
+  }, [
+    clearSearchHighlights,
+    searchCurrentMatch$,
+    searchMatchIndices$,
+    searchQuery$,
+    searchVisible$,
+  ]);
 
   const handleSearchQueryChange = useCallback(
     (query: string) => {
@@ -278,15 +331,10 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
       searchMatchIndices$.set(matches);
       searchCurrentMatch$.set(0);
       if (matches.length > 0) highlightSearchMatch(matches[0]);
-      else
-        scrollContainerRef.current
-          ?.querySelectorAll<HTMLElement>('[data-message-index]')
-          .forEach((el) => {
-            el.style.outline = '';
-            el.style.outlineOffset = '';
-          });
+      else clearSearchHighlights();
     },
     [
+      clearSearchHighlights,
       searchQuery$,
       searchMatchIndices$,
       searchCurrentMatch$,
@@ -312,17 +360,12 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
   }, [searchMatchIndices$, searchCurrentMatch$, highlightSearchMatch]);
 
   const handleSearchClose = useCallback(() => {
-    searchVisible$.set(false);
-    searchQuery$.set('');
-    searchMatchIndices$.set([]);
-    searchCurrentMatch$.set(0);
-    scrollContainerRef.current
-      ?.querySelectorAll<HTMLElement>('[data-message-index]')
-      .forEach((el) => {
-        el.style.outline = '';
-        el.style.outlineOffset = '';
-      });
-  }, [searchVisible$, searchQuery$, searchMatchIndices$, searchCurrentMatch$]);
+    resetSearchState();
+  }, [resetSearchState]);
+
+  useEffect(() => {
+    resetSearchState();
+  }, [conversationId, resetSearchState]);
 
   // Handle tool confirmation
   const handleConfirmTool = async () => {
@@ -418,32 +461,14 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
               return <div key={`${index}-${msg$.timestamp.get()}`} />;
             }
 
-            // Helper to check if a message at a given index is hidden
-            const isHiddenAt = (idx: number) => {
-              const m = conversation$.data.log[idx];
-              if (!m?.get()) return false;
-              const r = m.role.get();
-              const h = m.hide?.get();
-              const isInitial =
-                r === 'system' && (firstNonSystemIndex === -1 || idx < firstNonSystemIndex);
-              if (isInitial && !showInitialSystem$.get()) return true;
-              if (h && !showHiddenMessages$.get()) return true;
-              // Messages in collapsed step groups are visually hidden
-              const role = stepRoles$.get().get(idx);
-              if (role?.type === 'group-start' || role?.type === 'grouped') {
-                if (!expandedGroups$.get().has(role.groupId)) return true;
-              }
-              return false;
-            };
-
             // Get the previous and next *visible* messages for chain context
             // (skip hidden messages so they don't break chain grouping)
             let prevIdx = index - 1;
-            while (prevIdx >= 0 && isHiddenAt(prevIdx)) prevIdx--;
+            while (prevIdx >= 0 && isMessageHidden(prevIdx)) prevIdx--;
             const previousMessage$ = prevIdx >= 0 ? conversation$.data.log[prevIdx] : undefined;
 
             let nextIdx = index + 1;
-            while (conversation$.data.log[nextIdx]?.get() && isHiddenAt(nextIdx)) nextIdx++;
+            while (conversation$.data.log[nextIdx]?.get() && isMessageHidden(nextIdx)) nextIdx++;
             const nextMessage$ = conversation$.data.log[nextIdx]?.get()
               ? conversation$.data.log[nextIdx]
               : undefined;

--- a/webui/src/components/MessageSearchBar.tsx
+++ b/webui/src/components/MessageSearchBar.tsx
@@ -1,0 +1,88 @@
+import type { FC } from 'react';
+import { useRef, useEffect } from 'react';
+import { Search, X, ChevronUp, ChevronDown } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+
+interface Props {
+  query: string;
+  matchCount: number;
+  currentMatch: number; // 1-based, 0 when no matches/empty query
+  onQueryChange: (q: string) => void;
+  onNext: () => void;
+  onPrev: () => void;
+  onClose: () => void;
+}
+
+export const MessageSearchBar: FC<Props> = ({
+  query,
+  matchCount,
+  currentMatch,
+  onQueryChange,
+  onNext,
+  onPrev,
+  onClose,
+}) => {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      if (e.shiftKey) onPrev();
+      else onNext();
+    } else if (e.key === 'Escape') {
+      onClose();
+    }
+  };
+
+  return (
+    <div className="flex items-center gap-1.5 border-b bg-background px-3 py-2">
+      <Search className="h-4 w-4 shrink-0 text-muted-foreground" />
+      <Input
+        ref={inputRef}
+        className="h-7 flex-1 border-none bg-transparent p-0 text-sm shadow-none focus-visible:ring-0"
+        placeholder="Search messages…"
+        value={query}
+        onChange={(e) => onQueryChange(e.target.value)}
+        onKeyDown={handleKeyDown}
+      />
+      {query.length > 0 && (
+        <span className="min-w-[3.5rem] text-center text-xs text-muted-foreground">
+          {matchCount === 0 ? 'No matches' : `${currentMatch}/${matchCount}`}
+        </span>
+      )}
+      <Button
+        variant="ghost"
+        size="icon"
+        className="h-6 w-6"
+        onClick={onPrev}
+        disabled={matchCount === 0}
+        title="Previous match (Shift+Enter)"
+      >
+        <ChevronUp className="h-4 w-4" />
+      </Button>
+      <Button
+        variant="ghost"
+        size="icon"
+        className="h-6 w-6"
+        onClick={onNext}
+        disabled={matchCount === 0}
+        title="Next match (Enter)"
+      >
+        <ChevronDown className="h-4 w-4" />
+      </Button>
+      <Button
+        variant="ghost"
+        size="icon"
+        className="h-6 w-6"
+        onClick={onClose}
+        title="Close search (Escape)"
+      >
+        <X className="h-4 w-4" />
+      </Button>
+    </div>
+  );
+};

--- a/webui/src/components/MessageSearchBar.tsx
+++ b/webui/src/components/MessageSearchBar.tsx
@@ -43,6 +43,7 @@ export const MessageSearchBar: FC<Props> = ({
       <Search className="h-4 w-4 shrink-0 text-muted-foreground" />
       <Input
         ref={inputRef}
+        data-search-input
         className="h-7 flex-1 border-none bg-transparent p-0 text-sm shadow-none focus-visible:ring-0"
         placeholder="Search messages…"
         value={query}

--- a/webui/src/components/ShortcutsDialog.tsx
+++ b/webui/src/components/ShortcutsDialog.tsx
@@ -26,6 +26,7 @@ const SHORTCUT_GROUPS: ShortcutGroup[] = [
     title: 'General',
     shortcuts: [
       { keys: [MOD, 'K'], description: 'Open command palette' },
+      { keys: [MOD, 'F'], description: 'Search messages in conversation' },
       { keys: ['?'], description: 'Show this shortcuts reference' },
       { keys: ['i'], description: 'Focus the message input' },
     ],


### PR DESCRIPTION
## Summary

- Adds `Ctrl+F` / `Cmd+F` keyboard shortcut to open a search bar in the conversation view
- The search bar matches against message content (case-insensitive substring match)
- Shows match count (`3/12`) and supports next/previous navigation via Enter/Shift+Enter or the chevron buttons
- Escape closes the search bar and clears all highlights
- Highlighted matches use an imperative DOM outline to avoid re-rendering the entire message list
- `Ctrl+F` shortcut documented in the keyboard shortcuts reference dialog

## New component

`MessageSearchBar.tsx` — a focused toolbar component with:
- Auto-focus on open
- Match count display
- Next/previous navigation buttons
- Keyboard bindings (Enter, Shift+Enter, Escape)

## Test plan

- [ ] Open a conversation with several messages and press `Ctrl+F`
- [ ] Type a query — match count updates and the first match is highlighted + scrolled to
- [ ] Press Enter / click ↓ to navigate to next match; Shift+Enter / ↑ for previous
- [ ] Press Escape or click X to close and clear all highlights
- [ ] Verify the shortcut appears in the `?` shortcuts reference dialog
- [ ] Verify no TypeScript errors: `tsc -p tsconfig.app.json --noEmit`