### PR TITLE
fix(webui): improve history accessibility

### DIFF
--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -73,6 +73,7 @@
         "@tailwindcss/typography": "^0.5.15",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
+        "@testing-library/user-event": "^14.6.1",
         "@types/jest": "^29.5.14",
         "@types/node": "^22.19.15",
         "@types/react": "^18.3.3",
@@ -4217,6 +4218,20 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@tootallnate/once": {

--- a/webui/package.json
+++ b/webui/package.json
@@ -86,6 +86,7 @@
     "@tailwindcss/typography": "^0.5.15",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/jest": "^29.5.14",
     "@types/node": "^22.19.15",
     "@types/react": "^18.3.3",

--- a/webui/src/components/ExternalSessionsView.tsx
+++ b/webui/src/components/ExternalSessionsView.tsx
@@ -134,7 +134,13 @@ const SessionDetail: FC<SessionDetailProps> = ({ sessionId, onClose }) => {
     <div className="flex h-full flex-col">
       <div className="flex items-center justify-between border-b px-4 py-2">
         <h2 className="text-sm font-medium">Session details</h2>
-        <Button variant="ghost" size="icon" className="h-7 w-7" onClick={onClose}>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7"
+          onClick={onClose}
+          aria-label="Close session details"
+        >
           <X className="h-4 w-4" />
         </Button>
       </div>
@@ -238,6 +244,7 @@ export const ExternalSessionsView: FC = () => {
               placeholder="Search sessions…"
               value={search}
               onChange={(e) => setSearch(e.target.value)}
+              aria-label="Search external sessions"
             />
           </div>
         </div>

--- a/webui/src/components/HistoryView.tsx
+++ b/webui/src/components/HistoryView.tsx
@@ -64,8 +64,9 @@ const ConversationRow: FC<{
   conv: ConversationSummary;
   onClick: (conv: ConversationSummary) => void;
 }> = ({ conv, onClick }) => (
-  <div
-    className="flex cursor-pointer items-start gap-3 border-b px-4 py-3 last:border-b-0 hover:bg-accent/50"
+  <button
+    type="button"
+    className="flex w-full items-start gap-3 border-b px-4 py-3 text-left last:border-b-0 hover:bg-accent/50"
     onClick={() => onClick(conv)}
   >
     <div className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-md bg-muted">
@@ -103,7 +104,7 @@ const ConversationRow: FC<{
         )}
       </div>
     </div>
-  </div>
+  </button>
 );
 
 export const HistoryView: FC = () => {
@@ -283,7 +284,13 @@ export const HistoryView: FC = () => {
       {/* Header */}
       <div className="flex-shrink-0 border-b px-6 py-4">
         <div className="flex items-center gap-3">
-          <Button variant="ghost" size="icon" onClick={() => navigate('/chat')} className="h-8 w-8">
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={() => navigate('/chat')}
+            className="h-8 w-8"
+            aria-label="Back to chat"
+          >
             <ArrowLeft className="h-4 w-4" />
           </Button>
           <div>
@@ -333,6 +340,7 @@ export const HistoryView: FC = () => {
                   size="icon"
                   className="h-7 w-7"
                   onClick={handleYearPrev}
+                  aria-label="Previous year"
                   disabled={
                     selectedYear !== null &&
                     selectedYear <= (availableYears[availableYears.length - 1] ?? selectedYear)
@@ -348,6 +356,7 @@ export const HistoryView: FC = () => {
                   size="icon"
                   className="h-7 w-7"
                   onClick={handleYearNext}
+                  aria-label="Next year"
                   disabled={selectedYear === null}
                 >
                   <ChevronRight className="h-4 w-4" />
@@ -406,6 +415,7 @@ export const HistoryView: FC = () => {
                   value={searchQuery}
                   onChange={(e) => setSearchQuery(e.target.value)}
                   className="h-8 pl-8"
+                  aria-label="Search conversations"
                 />
               </div>
             </div>

--- a/webui/src/components/__tests__/ExternalSessionsView.test.tsx
+++ b/webui/src/components/__tests__/ExternalSessionsView.test.tsx
@@ -1,0 +1,67 @@
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ExternalSessionsView } from '../ExternalSessionsView';
+
+const mockUseQuery = jest.fn();
+
+jest.mock('@tanstack/react-query', () => ({
+  useQuery: (...args: unknown[]) => mockUseQuery(...args),
+}));
+
+jest.mock('@legendapp/state/react', () => ({
+  use$: jest.fn(() => true),
+}));
+
+jest.mock('@/contexts/ApiContext', () => ({
+  useApi: () => ({
+    api: {
+      isConnected$: {},
+      getExternalSessions: jest.fn(),
+      getExternalSession: jest.fn(),
+    },
+  }),
+}));
+
+describe('ExternalSessionsView', () => {
+  beforeEach(() => {
+    mockUseQuery.mockReset();
+    mockUseQuery.mockImplementation(({ queryKey }: { queryKey: unknown[] }) => {
+      if (queryKey[0] === 'external-sessions') {
+        return {
+          data: [
+            {
+              id: 'session-1',
+              session_id: 'session-1',
+              harness: 'codex',
+              session_name: 'Imported session',
+              project: 'bob',
+              model: 'gpt-5.4',
+              started_at: '2026-05-31T12:00:00Z',
+              last_activity: '2026-05-31T12:05:00Z',
+              capabilities: ['shell'],
+              trajectory_path: '/tmp/trajectory.jsonl',
+            },
+          ],
+          isLoading: false,
+          error: null,
+        };
+      }
+
+      return {
+        data: { transcript: { hello: 'world' } },
+        isLoading: false,
+        error: null,
+      };
+    });
+  });
+
+  it('labels the search field and detail close button', () => {
+    render(<ExternalSessionsView />);
+
+    expect(screen.getByRole('textbox', { name: 'Search external sessions' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Imported session/i }));
+
+    expect(screen.getByRole('button', { name: 'Close session details' })).toBeInTheDocument();
+  });
+});

--- a/webui/src/components/__tests__/ExternalSessionsView.test.tsx
+++ b/webui/src/components/__tests__/ExternalSessionsView.test.tsx
@@ -1,5 +1,6 @@
 import '@testing-library/jest-dom';
-import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '@testing-library/react';
 import { ExternalSessionsView } from '../ExternalSessionsView';
 
 const mockUseQuery = jest.fn();
@@ -55,12 +56,13 @@ describe('ExternalSessionsView', () => {
     });
   });
 
-  it('labels the search field and detail close button', () => {
+  it('labels the search field and detail close button', async () => {
+    const user = userEvent.setup();
     render(<ExternalSessionsView />);
 
     expect(screen.getByRole('textbox', { name: 'Search external sessions' })).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('button', { name: /Imported session/i }));
+    await user.click(screen.getByRole('button', { name: /Imported session/i }));
 
     expect(screen.getByRole('button', { name: 'Close session details' })).toBeInTheDocument();
   });

--- a/webui/src/components/__tests__/HistoryView.test.tsx
+++ b/webui/src/components/__tests__/HistoryView.test.tsx
@@ -1,0 +1,79 @@
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { HistoryView } from '../HistoryView';
+import { TooltipProvider } from '@/components/ui/tooltip';
+
+const mockNavigate = jest.fn();
+const mockUseQuery = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+jest.mock('@tanstack/react-query', () => ({
+  useQuery: (...args: unknown[]) => mockUseQuery(...args),
+}));
+
+jest.mock('@legendapp/state/react', () => ({
+  use$: jest.fn(() => true),
+}));
+
+jest.mock('@/contexts/ApiContext', () => ({
+  useApi: () => ({
+    api: {
+      isConnected$: {},
+      getConversationsPaginated: jest.fn(),
+    },
+    connectionConfig: { baseUrl: 'http://localhost:5700' },
+  }),
+}));
+
+jest.mock('@/components/ActivityCalendar', () => ({
+  ActivityCalendar: () => <div data-testid="activity-calendar" />,
+}));
+
+describe('HistoryView', () => {
+  const renderHistoryView = () =>
+    render(
+      <TooltipProvider>
+        <HistoryView />
+      </TooltipProvider>
+    );
+
+  beforeEach(() => {
+    mockNavigate.mockReset();
+    mockUseQuery.mockReset();
+    mockUseQuery.mockReturnValue({
+      data: [
+        {
+          id: 'chat-1',
+          name: 'Accessible chat',
+          modified: Date.UTC(2026, 4, 31, 12, 0, 0) / 1000,
+          messages: 3,
+          last_message_preview: 'Latest preview',
+          last_message_role: 'user',
+          workspace: '.',
+        },
+      ],
+      isLoading: false,
+    });
+  });
+
+  it('labels history controls and exposes conversation rows as buttons', () => {
+    renderHistoryView();
+
+    expect(screen.getByRole('button', { name: 'Back to chat' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Previous year' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Next year' })).toBeInTheDocument();
+    expect(screen.getByRole('textbox', { name: 'Search conversations' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Accessible chat/i })).toBeInTheDocument();
+  });
+
+  it('navigates when a conversation row button is clicked', () => {
+    renderHistoryView();
+
+    fireEvent.click(screen.getByRole('button', { name: /Accessible chat/i }));
+
+    expect(mockNavigate).toHaveBeenCalledWith('/chat/chat-1');
+  });
+});

--- a/webui/src/components/__tests__/HistoryView.test.tsx
+++ b/webui/src/components/__tests__/HistoryView.test.tsx
@@ -1,5 +1,6 @@
 import '@testing-library/jest-dom';
-import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '@testing-library/react';
 import { HistoryView } from '../HistoryView';
 import { TooltipProvider } from '@/components/ui/tooltip';
 
@@ -69,10 +70,11 @@ describe('HistoryView', () => {
     expect(screen.getByRole('button', { name: /Accessible chat/i })).toBeInTheDocument();
   });
 
-  it('navigates when a conversation row button is clicked', () => {
+  it('navigates when a conversation row button is clicked', async () => {
+    const user = userEvent.setup();
     renderHistoryView();
 
-    fireEvent.click(screen.getByRole('button', { name: /Accessible chat/i }));
+    await user.click(screen.getByRole('button', { name: /Accessible chat/i }));
 
     expect(mockNavigate).toHaveBeenCalledWith('/chat/chat-1');
   });


### PR DESCRIPTION
## Summary
- make history rows real buttons so keyboard users can open conversations
- add accessible labels to history navigation/search controls and external session controls
- cover the new accessible roles and labels with focused component tests

## Testing
- npm test -- --runInBand src/components/__tests__/HistoryView.test.tsx src/components/__tests__/ExternalSessionsView.test.tsx
- npm run typecheck