### PR TITLE
feat(webui): import exported conversation JSON

### DIFF
--- a/webui/src/components/UnifiedSidebar.tsx
+++ b/webui/src/components/UnifiedSidebar.tsx
@@ -174,6 +174,7 @@ export const UnifiedSidebar: FC<Props> = ({
         const imported = parseConversationImportJSON(await file.text());
         const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
         const conversationId = `chat-${timestamp}`;
+        let restoredName = !imported.name;
 
         await api.createConversation(conversationId, imported.messages);
 
@@ -189,12 +190,12 @@ export const UnifiedSidebar: FC<Props> = ({
                 name: imported.name,
               },
             });
+            restoredName = true;
           } catch (error) {
             console.warn(
               '[UnifiedSidebar] Imported conversation but failed to restore the name:',
               error
             );
-            toast.error('Imported messages, but failed to restore the conversation name');
           }
         }
 
@@ -211,7 +212,11 @@ export const UnifiedSidebar: FC<Props> = ({
           queryKey: ['conversations', connectionConfig.baseUrl, isConnected],
         });
 
-        toast.success('Conversation imported');
+        toast.success(
+          restoredName
+            ? 'Conversation imported'
+            : 'Conversation imported, but the conversation name could not be restored'
+        );
         onSelectConversation(conversationId);
       } catch (error) {
         toast.error(error instanceof Error ? error.message : 'Failed to import conversation');

--- a/webui/src/components/UnifiedSidebar.tsx
+++ b/webui/src/components/UnifiedSidebar.tsx
@@ -1,4 +1,14 @@
-import { PenSquare, Plus, Filter } from 'lucide-react';
+import {
+  PenSquare,
+  Plus,
+  Filter,
+  Upload,
+  Clock,
+  CheckCircle,
+  XCircle,
+  RefreshCw,
+  GitBranch,
+} from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { ConversationList } from './ConversationList';
 import { useLocation, useNavigate } from 'react-router-dom';
@@ -7,12 +17,16 @@ import type { Task } from '@/types/task';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { selectedWorkspace$, selectedAgent$ } from '@/stores/sidebar';
 import { Card, CardContent } from '@/components/ui/card';
-import { Clock, CheckCircle, XCircle, RefreshCw, GitBranch } from 'lucide-react';
+import { useApi } from '@/contexts/ApiContext';
+import { initConversation } from '@/stores/conversations';
+import { parseConversationImportJSON } from '@/utils/exportConversation';
+import { useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
 
-import type { FC } from 'react';
+import type { ChangeEvent, FC } from 'react';
 import { use$ } from '@legendapp/state/react';
 import { type Observable } from '@legendapp/state';
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useRef, useCallback } from 'react';
 
 // Simplified task display component for sidebar
 const TaskListItem: FC<{ task: Task; isSelected: boolean; onClick: () => void }> = ({
@@ -103,6 +117,10 @@ export const UnifiedSidebar: FC<Props> = ({
   const selectedAgent = use$(selectedAgent$);
   const location = useLocation();
   const navigate = useNavigate();
+  const { api, connectionConfig, isConnected$ } = useApi();
+  const isConnected = use$(isConnected$);
+  const queryClient = useQueryClient();
+  const importInputRef = useRef<HTMLInputElement>(null);
 
   // Navigation state - agents/workspaces show chat sidebar content
   const currentSection = location.pathname.startsWith('/tasks') ? 'tasks' : 'chat';
@@ -145,9 +163,84 @@ export const UnifiedSidebar: FC<Props> = ({
     navigate('/chat');
   };
 
+  const handleImportConversation = useCallback(
+    async (file: File) => {
+      if (!isConnected) {
+        toast.error('Connect to a gptme server before importing a conversation');
+        return;
+      }
+
+      try {
+        const imported = parseConversationImportJSON(await file.text());
+        const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+        const conversationId = `chat-${timestamp}`;
+
+        await api.createConversation(conversationId, imported.messages);
+
+        let workspace = '.';
+        if (imported.name) {
+          try {
+            const currentConfig = await api.getChatConfig(conversationId);
+            workspace = currentConfig.chat.workspace || '.';
+            await api.updateChatConfig(conversationId, {
+              ...currentConfig,
+              chat: {
+                ...currentConfig.chat,
+                name: imported.name,
+              },
+            });
+          } catch (error) {
+            console.warn(
+              '[UnifiedSidebar] Imported conversation but failed to restore the name:',
+              error
+            );
+            toast.error('Imported messages, but failed to restore the conversation name');
+          }
+        }
+
+        initConversation(conversationId, {
+          id: conversationId,
+          name: imported.name || conversationId,
+          log: imported.messages,
+          logfile: conversationId,
+          branches: {},
+          workspace,
+        });
+
+        await queryClient.invalidateQueries({
+          queryKey: ['conversations', connectionConfig.baseUrl, isConnected],
+        });
+
+        toast.success('Conversation imported');
+        onSelectConversation(conversationId);
+      } catch (error) {
+        toast.error(error instanceof Error ? error.message : 'Failed to import conversation');
+      }
+    },
+    [api, connectionConfig.baseUrl, isConnected, onSelectConversation, queryClient]
+  );
+
+  const handleImportChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0];
+      event.target.value = '';
+      if (!file) return;
+      void handleImportConversation(file);
+    },
+    [handleImportConversation]
+  );
+
   // Content for the selected section only (navigation is handled by SidebarIcons)
   return (
     <div className="flex h-full flex-col">
+      <input
+        ref={importInputRef}
+        type="file"
+        accept=".json,application/json"
+        className="hidden"
+        aria-label="Import conversation JSON"
+        onChange={handleImportChange}
+      />
       {/* Chats Section Header */}
       {currentSection === 'chat' && (
         <div className="flex items-center gap-2 bg-background p-2">
@@ -183,6 +276,16 @@ export const UnifiedSidebar: FC<Props> = ({
             </TooltipProvider>
           )}
           <div className="flex-1" />
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-6 w-6"
+            onClick={() => importInputRef.current?.click()}
+            aria-label="Import conversation JSON"
+            disabled={!isConnected}
+          >
+            <Upload className="h-4 w-4" />
+          </Button>
           <Button
             variant="ghost"
             size="icon"

--- a/webui/src/utils/__tests__/exportConversation.test.ts
+++ b/webui/src/utils/__tests__/exportConversation.test.ts
@@ -24,6 +24,15 @@ const sampleMessages: Message[] = [
   },
 ];
 
+async function readBlobAsText(blob: Blob): Promise<string> {
+  return await new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(String(reader.result));
+    reader.onerror = () => reject(reader.error ?? new Error('Failed to read blob'));
+    reader.readAsText(blob);
+  });
+}
+
 describe('getExportableMessages', () => {
   it('excludes system and hidden messages by default', () => {
     const result = getExportableMessages(sampleMessages);
@@ -207,6 +216,28 @@ describe('exportConversationAsJSON', () => {
     expect(capturedBlob!.size).toBeGreaterThan(0);
   });
 
+  it('filters tool messages so exported JSON can be re-imported', async () => {
+    let capturedBlob: Blob | undefined;
+    (global.URL.createObjectURL as jest.Mock).mockImplementation((blob: Blob) => {
+      capturedBlob = blob;
+      return 'blob:test';
+    });
+
+    exportConversationAsJSON('conv-123', 'Test Chat', [
+      ...sampleMessages,
+      { role: 'tool', content: 'Tool output' },
+    ]);
+
+    const exportedText = await readBlobAsText(capturedBlob!);
+    const exported = JSON.parse(exportedText) as {
+      messages: Array<{ role: string; content: string }>;
+    };
+    expect(exported.messages.some((message) => message.role === 'tool')).toBe(false);
+
+    const imported = parseConversationImportJSON(exportedText);
+    expect(imported.messages).toEqual(sampleMessages);
+  });
+
   it('generates a .json filename', () => {
     const createElementSpy = jest.spyOn(document, 'createElement');
     exportConversationAsJSON('conv-123', 'Test Chat', sampleMessages);
@@ -253,16 +284,46 @@ describe('parseConversationImportJSON', () => {
     ).toThrow('Imported message 1 is missing a string content field');
   });
 
-  it('throws when a message uses an unsupported role', () => {
+  it('skips tool messages from older exports', () => {
+    const result = parseConversationImportJSON(
+      JSON.stringify({
+        name: 'Imported Chat',
+        messages: [
+          { role: 'user', content: 'Hello' },
+          { role: 'tool', content: 'Tool output' },
+          { role: 'assistant', content: 'Hi' },
+        ],
+      })
+    );
+
+    expect(result.messages).toEqual([
+      { role: 'user', content: 'Hello' },
+      { role: 'assistant', content: 'Hi' },
+    ]);
+  });
+
+  it('throws when a message uses an unknown role', () => {
     expect(() =>
       parseConversationImportJSON(
         JSON.stringify({
           name: 'Broken import',
-          messages: [{ role: 'tool', content: 'Tool output' }],
+          messages: [{ role: 'critic', content: 'Nope' }],
         })
       )
     ).toThrow(
-      'Imported message 1 has unsupported role "tool". Only system, user, and assistant messages can be restored.'
+      'Imported message 1 has unsupported role "critic". Only system, user, and assistant messages can be restored.'
     );
+  });
+
+  it('preserves an explicitly empty name', () => {
+    const result = parseConversationImportJSON(
+      JSON.stringify({
+        id: 'conv-123',
+        name: '',
+        messages: [{ role: 'user', content: 'Hello' }],
+      })
+    );
+
+    expect(result.name).toBe('');
   });
 });

--- a/webui/src/utils/__tests__/exportConversation.test.ts
+++ b/webui/src/utils/__tests__/exportConversation.test.ts
@@ -4,6 +4,7 @@ import {
   exportConversationAsMarkdown,
   exportConversationAsJSON,
   getExportableMessages,
+  parseConversationImportJSON,
 } from '../exportConversation';
 import type { Message } from '@/types/conversation';
 
@@ -213,5 +214,55 @@ describe('exportConversationAsJSON', () => {
     const anchor = createElementSpy.mock.results[0]?.value as HTMLAnchorElement;
     expect(anchor.download).toBe('Test-Chat.json');
     createElementSpy.mockRestore();
+  });
+});
+
+describe('parseConversationImportJSON', () => {
+  it('parses a valid exported conversation', () => {
+    const result = parseConversationImportJSON(
+      JSON.stringify({
+        id: 'conv-123',
+        name: 'Imported Chat',
+        exported_at: '2026-03-28T10:03:00Z',
+        messages: sampleMessages,
+      })
+    );
+
+    expect(result.name).toBe('Imported Chat');
+    expect(result.messages).toEqual(sampleMessages);
+  });
+
+  it('throws for invalid JSON', () => {
+    expect(() => parseConversationImportJSON('{not json')).toThrow('Invalid JSON file');
+  });
+
+  it('throws when messages is missing', () => {
+    expect(() => parseConversationImportJSON(JSON.stringify({ name: 'Missing messages' }))).toThrow(
+      'Conversation import must include a messages array'
+    );
+  });
+
+  it('throws when a message is missing content', () => {
+    expect(() =>
+      parseConversationImportJSON(
+        JSON.stringify({
+          name: 'Broken import',
+          messages: [{ role: 'user' }],
+        })
+      )
+    ).toThrow('Imported message 1 is missing a string content field');
+  });
+
+  it('throws when a message uses an unsupported role', () => {
+    expect(() =>
+      parseConversationImportJSON(
+        JSON.stringify({
+          name: 'Broken import',
+          messages: [{ role: 'tool', content: 'Tool output' }],
+        })
+      )
+    ).toThrow(
+      'Imported message 1 has unsupported role "tool". Only system, user, and assistant messages can be restored.'
+    );
   });
 });

--- a/webui/src/utils/exportConversation.ts
+++ b/webui/src/utils/exportConversation.ts
@@ -24,6 +24,12 @@ export function getExportableMessages(
   return messages.filter((msg) => !msg.hide && (includeSystem || msg.role !== 'system'));
 }
 
+function getImportableMessages(messages: Message[]): Message[] {
+  return getExportableMessages(messages, { includeSystem: true }).filter((msg) =>
+    importableRoles.has(msg.role)
+  );
+}
+
 /**
  * Format a conversation's messages as a Markdown document.
  */
@@ -95,7 +101,7 @@ export function exportConversationAsJSON(
     id: conversationId,
     name,
     exported_at: new Date().toISOString(),
-    messages,
+    messages: getImportableMessages(messages),
   };
   const json = JSON.stringify(data, null, 2);
   const safeName = (name || conversationId)
@@ -138,6 +144,10 @@ export function parseConversationImportJSON(json: string): ImportedConversationD
 
     const { role, content, timestamp } = message;
 
+    if (role === 'tool') {
+      return null;
+    }
+
     if (typeof role !== 'string' || !importableRoles.has(role as Message['role'])) {
       const roleLabel = typeof role === 'string' ? `"${role}"` : 'a valid role';
       throw new Error(
@@ -162,8 +172,11 @@ export function parseConversationImportJSON(json: string): ImportedConversationD
 
   return {
     name:
-      (typeof parsed.name === 'string' && parsed.name) ||
-      (typeof parsed.id === 'string' ? parsed.id : ''),
-    messages,
+      typeof parsed.name === 'string'
+        ? parsed.name
+        : typeof parsed.id === 'string'
+          ? parsed.id
+          : '',
+    messages: messages.filter((message): message is Message => message !== null),
   };
 }

--- a/webui/src/utils/exportConversation.ts
+++ b/webui/src/utils/exportConversation.ts
@@ -5,6 +5,17 @@ export interface ExportMarkdownOptions {
   includeTimestamps?: boolean;
 }
 
+export interface ImportedConversationData {
+  name: string;
+  messages: Message[];
+}
+
+const importableRoles = new Set<Message['role']>(['system', 'user', 'assistant']);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
 export function getExportableMessages(
   messages: Message[],
   options?: Pick<ExportMarkdownOptions, 'includeSystem'>
@@ -93,4 +104,66 @@ export function exportConversationAsJSON(
     .replace(/-+/g, '-')
     .slice(0, 100);
   downloadAsFile(json, `${safeName}.json`, 'application/json');
+}
+
+export function parseConversationImportJSON(json: string): ImportedConversationData {
+  let parsed: unknown;
+
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    throw new Error('Invalid JSON file');
+  }
+
+  if (!isRecord(parsed)) {
+    throw new Error('Conversation import must be a JSON object');
+  }
+
+  if ('name' in parsed && parsed.name != null && typeof parsed.name !== 'string') {
+    throw new Error('Conversation import name must be a string');
+  }
+
+  if ('id' in parsed && parsed.id != null && typeof parsed.id !== 'string') {
+    throw new Error('Conversation import id must be a string');
+  }
+
+  if (!Array.isArray(parsed.messages)) {
+    throw new Error('Conversation import must include a messages array');
+  }
+
+  const messages = parsed.messages.map((message, index) => {
+    if (!isRecord(message)) {
+      throw new Error(`Imported message ${index + 1} must be an object`);
+    }
+
+    const { role, content, timestamp } = message;
+
+    if (typeof role !== 'string' || !importableRoles.has(role as Message['role'])) {
+      const roleLabel = typeof role === 'string' ? `"${role}"` : 'a valid role';
+      throw new Error(
+        `Imported message ${index + 1} has unsupported role ${roleLabel}. Only system, user, and assistant messages can be restored.`
+      );
+    }
+
+    if (typeof content !== 'string') {
+      throw new Error(`Imported message ${index + 1} is missing a string content field`);
+    }
+
+    if (timestamp !== undefined && typeof timestamp !== 'string') {
+      throw new Error(`Imported message ${index + 1} has an invalid timestamp`);
+    }
+
+    return {
+      role: role as Message['role'],
+      content,
+      ...(timestamp !== undefined ? { timestamp } : {}),
+    };
+  });
+
+  return {
+    name:
+      (typeof parsed.name === 'string' && parsed.name) ||
+      (typeof parsed.id === 'string' ? parsed.id : ''),
+    messages,
+  };
 }


### PR DESCRIPTION
## Summary
- add JSON import parsing and validation for exported webui conversations
- add a sidebar import action that creates a new conversation from the selected export file
- add focused parser tests covering valid imports and clear failure modes

## Testing
- npm test -- --runInBand src/utils/__tests__/exportConversation.test.ts
- npm run typecheck
