### PR TITLE
feat(webui): add conversation system prompt override

### DIFF
--- a/gptme/config/chat.py
+++ b/gptme/config/chat.py
@@ -65,6 +65,7 @@ class ChatConfig:
     # through from_logdir/load_or_create to get per-conversation workspaces.
     workspace: Path = field(default_factory=Path.cwd)
     agent: Path | None = None
+    system_prompt: str | None = None
 
     env: dict = field(default_factory=dict)
     mcp: MCPConfig | None = None
@@ -114,6 +115,10 @@ class ChatConfig:
             agent = None
         else:
             agent = _coerce_config_path(agent_path, "agent")
+
+        system_prompt = chat_data.get("system_prompt")
+        if system_prompt is not None and not isinstance(system_prompt, str):
+            raise ValueError("chat.system_prompt must be a string")
 
         env = config_data.pop("env", {})
         if not isinstance(env, dict):
@@ -325,5 +330,10 @@ class ChatConfig:
             if project_config and project_config.agent:
                 config = replace(config, agent=config.workspace)
                 logger.debug(f"Auto-detected agent workspace: {config.workspace}")
+
+        # API clients use empty-string as an explicit clear signal for optional
+        # text fields that would otherwise be indistinguishable from "omitted".
+        if config.system_prompt == "":
+            config = replace(config, system_prompt=None)
 
         return config

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -133,6 +133,14 @@ def _validate_model_input(model: str, expected_provider: str | None = None) -> s
     return trimmed_model
 
 
+def _append_conversation_system_prompt(
+    messages: list[Message], system_prompt: str | None
+) -> None:
+    """Append a conversation-local system prompt override when configured."""
+    if system_prompt:
+        messages.append(Message("system", system_prompt))
+
+
 def _get_optional_string_list_field(
     req_json: dict, field: str
 ) -> list[str] | None | tuple[flask.Response, int]:
@@ -640,14 +648,16 @@ def api_conversation_put(conversation_id: str):
 
     chat_config = ChatConfig.load_or_create(logdir, request_config)
 
-    msgs = get_prompt(
-        tools=list(get_toolchain(chat_config.tools, strict=False)),
-        interactive=chat_config.interactive,
-        tool_format=chat_config.tool_format or "markdown",
-        model=chat_config.model,
-        prompt=prompt,
-        workspace=chat_config.workspace,
-        agent_path=chat_config.agent,
+    msgs = list(
+        get_prompt(
+            tools=list(get_toolchain(chat_config.tools, strict=False)),
+            interactive=chat_config.interactive,
+            tool_format=chat_config.tool_format or "markdown",
+            model=chat_config.model,
+            prompt=prompt,
+            workspace=chat_config.workspace,
+            agent_path=chat_config.agent,
+        )
     )
 
     # Inject output-format capability hint for webui mode
@@ -667,6 +677,8 @@ def api_conversation_put(conversation_id: str):
                 "use ```html blocks — they render live in a sandboxed preview panel.",
             )
         )
+
+    _append_conversation_system_prompt(msgs, chat_config.system_prompt)
 
     for role, content, timestamp in validated_msgs:
         msgs.append(Message(role, content, timestamp=timestamp))
@@ -1348,6 +1360,7 @@ def api_conversation_config_patch(conversation_id: str):
                 agent_path=chat_config.agent,
             )
         )
+        _append_conversation_system_prompt(new_system_msgs, chat_config.system_prompt)
         manager.log = Log(new_system_msgs + remaining_msgs)
     manager.write()
 

--- a/tests/test_chat_config.py
+++ b/tests/test_chat_config.py
@@ -113,3 +113,22 @@ def test_chat_config_save_new_section_uses_header(tmp_path: Path):
     saved = config_path.read_text()
     # Should serialize as [env] header, not inline: env = {MY_VAR = "hello"}
     assert "[env]" in saved, f"Expected [env] section header, got:\n{saved}"
+
+
+def test_chat_config_system_prompt_roundtrip(tmp_path: Path):
+    """system_prompt survives a save/load round-trip."""
+    config = ChatConfig(_logdir=tmp_path, system_prompt="Answer tersely.")
+    config.save()
+
+    loaded = ChatConfig.from_logdir(tmp_path)
+    assert loaded.system_prompt == "Answer tersely."
+
+
+def test_chat_config_load_or_create_empty_system_prompt_clears_existing(tmp_path: Path):
+    """An empty-string override clears an existing system_prompt."""
+    existing = ChatConfig(_logdir=tmp_path, system_prompt="Old prompt")
+    existing.save()
+
+    cleared = ChatConfig.load_or_create(tmp_path, ChatConfig(system_prompt="")).save()
+    assert cleared.system_prompt is None
+    assert "system_prompt" not in cleared.to_dict()["chat"]

--- a/tests/test_chat_config.py
+++ b/tests/test_chat_config.py
@@ -1,6 +1,7 @@
 from dataclasses import replace as dc_replace
 from pathlib import Path
 
+import pytest
 import tomlkit
 
 from gptme.config import ChatConfig
@@ -132,3 +133,12 @@ def test_chat_config_load_or_create_empty_system_prompt_clears_existing(tmp_path
     cleared = ChatConfig.load_or_create(tmp_path, ChatConfig(system_prompt="")).save()
     assert cleared.system_prompt is None
     assert "system_prompt" not in cleared.to_dict()["chat"]
+
+
+def test_chat_config_system_prompt_from_dict_validation(tmp_path: Path):
+    """Non-string system_prompt in from_dict raises ValueError."""
+    config = ChatConfig(_logdir=tmp_path)
+    data = config.to_dict()
+    data["chat"]["system_prompt"] = {"nested": "dict"}
+    with pytest.raises(ValueError, match="chat.system_prompt must be a string"):
+        ChatConfig.from_dict(data)

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -1245,6 +1245,17 @@ def _normalize_config_for_comparison(config_dict: dict) -> dict:
     return result
 
 
+def test_v2_conversation_put_injects_system_prompt(client: FlaskClient):
+    """Creating a conversation with system_prompt should inject it via api_conversation_put."""
+    config = ChatConfig(system_prompt="Answer in bullet points.")
+    conversation = create_conversation(client, config=config)
+    conversation_id = conversation["conversation_id"]
+
+    data = client.get(f"/api/v2/conversations/{conversation_id}").get_json()
+    system_messages = [m["content"] for m in data["log"] if m["role"] == "system"]
+    assert "Answer in bullet points." in system_messages
+
+
 def test_v2_chat_config_saved_on_conversation_create(client: FlaskClient):
     """Test that the chat config is saved on conversation create."""
     input_config = ChatConfig(model="openai/gpt-4o")

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -1343,6 +1343,47 @@ def test_v2_chat_config_update_works(client: FlaskClient):
     ) == _normalize_config_for_comparison(input_config.to_dict())
 
 
+def test_v2_chat_config_system_prompt_roundtrip_and_clear(client: FlaskClient):
+    """Config PATCH should persist, apply, and clear a conversation-local system prompt."""
+    conversation_id = create_conversation(client)["conversation_id"]
+    system_prompt = "Answer in bullet points."
+
+    response = client.patch(
+        f"/api/v2/conversations/{conversation_id}/config",
+        json={"chat": {"system_prompt": system_prompt}},
+    )
+    assert response.status_code == 200
+
+    config_response = client.get(f"/api/v2/conversations/{conversation_id}/config")
+    config = ChatConfig.from_dict(config_response.get_json())
+    assert config.system_prompt == system_prompt
+
+    conversation = client.get(f"/api/v2/conversations/{conversation_id}").get_json()
+    system_messages = [
+        m["content"] for m in conversation["log"] if m["role"] == "system"
+    ]
+    assert system_messages[-1] == system_prompt
+
+    clear_response = client.patch(
+        f"/api/v2/conversations/{conversation_id}/config",
+        json={"chat": {"system_prompt": ""}},
+    )
+    assert clear_response.status_code == 200
+
+    cleared_config = client.get(
+        f"/api/v2/conversations/{conversation_id}/config"
+    ).get_json()
+    assert "system_prompt" not in cleared_config["chat"]
+
+    cleared_conversation = client.get(
+        f"/api/v2/conversations/{conversation_id}"
+    ).get_json()
+    cleared_system_messages = [
+        m["content"] for m in cleared_conversation["log"] if m["role"] == "system"
+    ]
+    assert system_prompt not in cleared_system_messages
+
+
 def test_v2_chat_config_update_missing_conversation_returns_404(client: FlaskClient):
     """Test that updating config for a missing conversation returns a 404.
 

--- a/webui/src/components/ConversationSettings.tsx
+++ b/webui/src/components/ConversationSettings.tsx
@@ -21,6 +21,7 @@ import {
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Switch } from '@/components/ui/switch';
+import { Textarea } from '@/components/ui/textarea';
 import { EnvironmentVariables } from './settings/EnvironmentVariables';
 import { ToolsConfiguration } from './settings/ToolsConfiguration';
 import { McpConfiguration } from './settings/McpConfiguration';
@@ -356,6 +357,30 @@ export const ConversationSettings: FC<ConversationSettingsProps> = ({ conversati
               {/* Advanced/rare toggles */}
               <h3 className="text-lg font-medium">Advanced Settings</h3>
               <div className="space-y-2 rounded-lg border px-3 py-2 shadow-sm">
+                <FormField
+                  control={control}
+                  name="chat.system_prompt"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>System Prompt Override</FormLabel>
+                      <FormControl>
+                        <Textarea
+                          placeholder="Optional conversation-only system prompt override..."
+                          {...field}
+                          value={field.value || ''}
+                          disabled={isSubmitting}
+                          rows={8}
+                        />
+                      </FormControl>
+                      <FormDescription>
+                        Appended as an extra system message for this conversation only. It does not
+                        edit global config, profiles, or agent bootstrap files.
+                      </FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
                 {/* Stream Field */}
                 <FormField
                   control={control}

--- a/webui/src/hooks/useConversationSettings.ts
+++ b/webui/src/hooks/useConversationSettings.ts
@@ -19,6 +19,7 @@ const chatConfigToFormValues = (config: ChatConfig | null): FormSchema => ({
     stream: config?.chat.stream ?? true,
     interactive: config?.chat.interactive ?? false,
     workspace: config?.chat.workspace || '',
+    system_prompt: config?.chat.system_prompt || '',
     temperature: config?.chat.temperature ?? undefined,
     top_p: config?.chat.top_p ?? undefined,
     max_tokens: config?.chat.max_tokens ?? undefined,
@@ -113,9 +114,16 @@ export const useConversationSettings = (conversationId: string) => {
 
     // Capture original tools for comparison later
     const originalTools = originalConfig.chat.tools;
+    const originalSystemPrompt = originalConfig.chat.system_prompt || '';
 
     const toolsStringArray = values.chat.tools?.map((tool) => tool.name);
     const newTools = toolsStringArray?.length ? toolsStringArray : null;
+    const systemPromptInput = values.chat.system_prompt || '';
+    const newSystemPrompt = systemPromptInput.trim()
+      ? systemPromptInput
+      : originalSystemPrompt
+        ? ''
+        : null;
     const newEnv =
       values.chat.env?.reduce(
         (acc, { key, value }) => {
@@ -154,6 +162,7 @@ export const useConversationSettings = (conversationId: string) => {
         stream: values.chat.stream,
         interactive: values.chat.interactive,
         workspace: values.chat.workspace,
+        system_prompt: newSystemPrompt,
         temperature: values.chat.temperature ?? null,
         top_p: values.chat.top_p ?? null,
         max_tokens: values.chat.max_tokens ?? null,

--- a/webui/src/hooks/useConversationSettings.ts
+++ b/webui/src/hooks/useConversationSettings.ts
@@ -187,8 +187,9 @@ export const useConversationSettings = (conversationId: string) => {
       const mcpServersChanged =
         JSON.stringify(originalConfig.mcp?.servers?.slice().sort()) !==
         JSON.stringify(newConfig.mcp?.servers?.slice().sort());
+      const systemPromptChanged = originalSystemPrompt !== (newConfig.chat.system_prompt || '');
 
-      if (toolsChanged || mcpChanged || mcpServersChanged) {
+      if (toolsChanged || mcpChanged || mcpServersChanged || systemPromptChanged) {
         const conversationData = await api.getConversation(conversationId);
         updateConversation(conversationId, { data: conversationData, chatConfig: newConfig });
       } else {

--- a/webui/src/schemas/conversationSettings.ts
+++ b/webui/src/schemas/conversationSettings.ts
@@ -25,6 +25,7 @@ export const formSchema = z.object({
     stream: z.boolean(),
     interactive: z.boolean(),
     workspace: z.string().min(1, 'Workspace directory is required'),
+    system_prompt: z.string().optional(),
     temperature: z.number().min(0, 'Must be ≥ 0').max(2, 'Must be ≤ 2').optional(),
     top_p: z.number().min(0, 'Must be ≥ 0').max(1, 'Must be ≤ 1').optional(),
     max_tokens: z.number().int('Must be a whole number').positive('Must be > 0').optional(),

--- a/webui/src/types/api.ts
+++ b/webui/src/types/api.ts
@@ -115,6 +115,7 @@ export interface ChatConfig {
     stream: boolean;
     interactive: boolean;
     workspace: string;
+    system_prompt?: string | null;
     // Sampling overrides. null/undefined = provider/model default.
     temperature?: number | null;
     top_p?: number | null;


### PR DESCRIPTION
## Summary
- add a persisted conversation-level `chat.system_prompt` field to `ChatConfig`
- append that field as the last system message during conversation creation and config regeneration
- expose the field in webui `ConversationSettings` as an advanced conversation-only textarea

## Config Contract
- `GET/PATCH /api/v2/conversations/{id}/config` now round-trips `chat.system_prompt`
- the field is conversation-scoped and is appended as an extra system message after gptme's generated prompt stack
- clearing from the webui uses an empty-string sentinel on PATCH, which the server normalizes back to `None`

## Verification
- `.venv/bin/python -m pytest tests/test_chat_config.py tests/test_server_v2.py -k "system_prompt or chat_config_update_works or chat_config_get_works"`
- `npm run typecheck`
