### PR TITLE
feat(webui): add open conversation directory action

### DIFF
--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -587,6 +587,7 @@ def api_conversation(conversation_id: str):
     logdir = get_logs_dir() / conversation_id
     chat_config = ChatConfig.load_or_create(logdir, ChatConfig()).save()
     log_dict = manager.to_dict(branches=True)
+    log_dict["logdir"] = str(logdir)
 
     # make all paths relative to workspace or logdir (no "../" or absolute paths)
     for msg in log_dict["log"]:

--- a/gptme/server/openapi_docs.py
+++ b/gptme/server/openapi_docs.py
@@ -101,6 +101,7 @@ class ConversationResponse(BaseModel):
 
     name: str = Field(..., description="Conversation name")
     log: list[dict] = Field(..., description="Message history as raw objects")
+    logdir: str = Field(..., description="Conversation log directory path")
     workspace: str = Field(..., description="Workspace path")
     session: dict | None = Field(
         None,

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -1172,6 +1172,7 @@ def test_v2_conversation_get(v2_conv, client: FlaskClient):
     data = response.get_json()
     assert data is not None
     assert "log" in data
+    assert data["logdir"] == str(Path(data["logfile"]).parent)
 
     # Should contain system messages (custom system prompt + possibly workspace prompt)
     assert len(data["log"]) >= 1  # At least custom system prompt

--- a/webui/src/components/ConversationContent.tsx
+++ b/webui/src/components/ConversationContent.tsx
@@ -11,6 +11,7 @@ import { buildStepRoles, type StepRole } from '@/utils/stepGrouping';
 import { InlineToolConfirmation } from './InlineToolConfirmation';
 import { MessageSearchBar } from './MessageSearchBar';
 import { InlineToolExecution, ToolCompletionBadge } from './InlineToolExecution';
+import { OpenConversationPathButton } from './OpenConversationPathButton';
 import { For, Memo, use$, useObservable, useObserveEffect } from '@legendapp/state/react';
 import { getObservableIndex } from '@legendapp/state';
 import { useApi } from '@/contexts/ApiContext';
@@ -483,6 +484,15 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
           }
         }}
       >
+        <Memo>
+          {() => (
+            <OpenConversationPathButton
+              logdir={conversation$.data.logdir.get()}
+              baseUrl={connectionConfig.baseUrl}
+            />
+          )}
+        </Memo>
+
         <For each={conversation$.data.log}>
           {(msg$) => {
             const index = getObservableIndex(msg$);

--- a/webui/src/components/OpenConversationPathButton.tsx
+++ b/webui/src/components/OpenConversationPathButton.tsx
@@ -1,0 +1,80 @@
+import { Copy, ExternalLink, FolderOpen } from 'lucide-react';
+import { toast } from 'sonner';
+
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { buildFileUri, isLocalApiBaseUrl } from '@/utils/openConversationPath';
+
+interface OpenConversationPathButtonProps {
+  logdir?: string;
+  baseUrl: string;
+}
+
+export function OpenConversationPathButton({ logdir, baseUrl }: OpenConversationPathButtonProps) {
+  if (!logdir || !isLocalApiBaseUrl(baseUrl)) {
+    return null;
+  }
+
+  const copyPath = async () => {
+    if (!navigator.clipboard?.writeText) {
+      toast.error('Clipboard unavailable');
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(logdir);
+      toast.success('Conversation path copied');
+    } catch (error) {
+      console.error('Failed to copy conversation path:', error);
+      toast.error('Failed to copy conversation path');
+    }
+  };
+
+  const openDirectory = () => {
+    const fileUri = buildFileUri(logdir);
+    if (!window.open(fileUri, '_blank', 'noopener,noreferrer')) {
+      window.location.href = fileUri;
+    }
+  };
+
+  return (
+    <div className="sticky top-0 z-20 mx-auto flex max-w-3xl justify-end px-3 pt-3">
+      <DropdownMenu>
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon"
+                  className="h-8 w-8 bg-background/90 shadow-sm backdrop-blur"
+                  aria-label="Open conversation directory"
+                >
+                  <FolderOpen className="h-4 w-4" />
+                </Button>
+              </DropdownMenuTrigger>
+            </TooltipTrigger>
+            <TooltipContent>Open conversation directory</TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+        <DropdownMenuContent align="end" className="w-48">
+          <DropdownMenuItem onClick={openDirectory}>
+            <ExternalLink className="mr-2 h-4 w-4" />
+            Open directory
+          </DropdownMenuItem>
+          <DropdownMenuItem onClick={() => void copyPath()}>
+            <Copy className="mr-2 h-4 w-4" />
+            Copy path
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}

--- a/webui/src/types/api.ts
+++ b/webui/src/types/api.ts
@@ -96,6 +96,7 @@ export interface ConversationResponse {
   name: string;
   log: (Message | StreamingMessage)[];
   logfile: string;
+  logdir?: string;
   branches: Record<string, Message[]>;
   workspace: string;
   agent?: AgentInfo;

--- a/webui/src/utils/__tests__/openConversationPath.test.ts
+++ b/webui/src/utils/__tests__/openConversationPath.test.ts
@@ -1,0 +1,34 @@
+import { buildFileUri, isLocalApiBaseUrl } from '../openConversationPath';
+
+describe('isLocalApiBaseUrl', () => {
+  it.each([
+    ['http://localhost:5700'],
+    ['http://127.0.0.1:5700'],
+    ['http://[::1]:5700'],
+    ['http://bob.localhost:5700'],
+    ['/api/v2'],
+  ])('allows local API URL %s', (baseUrl) => {
+    expect(isLocalApiBaseUrl(baseUrl, 'http://localhost:3000')).toBe(true);
+  });
+
+  it.each([['https://gptme.ai'], ['https://example.com/api'], ['http://192.168.1.144:5700']])(
+    'rejects remote API URL %s',
+    (baseUrl) => {
+      expect(isLocalApiBaseUrl(baseUrl, 'https://gptme.ai')).toBe(false);
+    }
+  );
+});
+
+describe('buildFileUri', () => {
+  it('builds a file URI for POSIX paths', () => {
+    expect(buildFileUri('/home/bob/gptme logs/chat #1')).toBe(
+      'file:///home/bob/gptme%20logs/chat%20%231'
+    );
+  });
+
+  it('builds a file URI for Windows paths', () => {
+    expect(buildFileUri('C:\\Users\\Bob\\gptme logs\\chat #1')).toBe(
+      'file:///C:/Users/Bob/gptme%20logs/chat%20%231'
+    );
+  });
+});

--- a/webui/src/utils/openConversationPath.ts
+++ b/webui/src/utils/openConversationPath.ts
@@ -1,0 +1,32 @@
+const LOCAL_HOSTNAMES = new Set(['localhost', '127.0.0.1', '[::1]', '0.0.0.0']);
+
+export function isLocalApiBaseUrl(baseUrl: string, currentOrigin?: string): boolean {
+  const origin =
+    currentOrigin ||
+    (typeof window !== 'undefined' && window.location?.origin
+      ? window.location.origin
+      : 'http://localhost');
+
+  try {
+    const url = new URL(baseUrl, origin);
+    return LOCAL_HOSTNAMES.has(url.hostname) || url.hostname.endsWith('.localhost');
+  } catch {
+    return false;
+  }
+}
+
+export function buildFileUri(path: string): string {
+  const slashPath = path.replace(/\\/g, '/');
+  const encodedPath = slashPath
+    .split('/')
+    .map((segment, index) =>
+      index === 0 && /^[A-Za-z]:$/.test(segment) ? segment : encodeURIComponent(segment)
+    )
+    .join('/');
+
+  if (encodedPath.startsWith('/')) {
+    return `file://${encodedPath}`;
+  }
+
+  return `file:///${encodedPath}`;
+}


### PR DESCRIPTION
## What
- Adds `logdir` to the V2 conversation response so clients can locate the backing conversation directory.
- Adds a local-only conversation directory action in the webui with options to open the folder in VS Code or copy the path.
- Adds focused coverage for local/remote API URL gating and VS Code URI construction.

## Why
Power users currently need to reconstruct `~/.config/gptme/logs/<conversation-id>/` manually when they want to inspect raw logs or open the conversation directory in an editor.

## Verification
- `uv run python3 -m pytest tests/test_server_v2.py::test_v2_conversation_get -q`
- `npm test -- openConversationPath.test.ts --runInBand`
- `npm run typecheck`
- `npx prettier --check src/components/OpenConversationPathButton.tsx src/utils/openConversationPath.ts src/utils/__tests__/openConversationPath.test.ts src/components/ConversationContent.tsx src/types/api.ts`
- `uv run ruff check gptme/server/api_v2.py gptme/server/openapi_docs.py tests/test_server_v2.py`
- `npx eslint src/components/OpenConversationPathButton.tsx src/utils/openConversationPath.ts src/utils/__tests__/openConversationPath.test.ts src/components/ConversationContent.tsx src/types/api.ts`
- pre-commit via `git commit`