### PR TITLE
feat(webui): stream tool outputs live via SSE tool_output events

### DIFF
--- a/gptme/server/api_v2_common.py
+++ b/gptme/server/api_v2_common.py
@@ -126,6 +126,7 @@ class BaseEvent(TypedDict):
         "generation_complete",
         "tool_pending",
         "tool_executing",
+        "tool_output",
         "tool_complete",
         "elicit_pending",
         "interrupted",
@@ -185,6 +186,13 @@ class ToolExecutingEvent(BaseEvent):
     """Sent when a tool is being executed."""
 
     tool_id: str
+
+
+class ToolOutputEvent(BaseEvent):
+    """Sent when a tool produces partial output during execution."""
+
+    tool_id: str
+    output: str
 
 
 class ToolCompleteEvent(BaseEvent):
@@ -263,6 +271,7 @@ EventType = (
     | GenerationCompleteEvent
     | ToolPendingEvent
     | ToolExecutingEvent
+    | ToolOutputEvent
     | ToolCompleteEvent
     | ElicitPendingEvent
     | InterruptedEvent

--- a/gptme/server/session_step.py
+++ b/gptme/server/session_step.py
@@ -895,23 +895,32 @@ def start_tool_execution(
             # Execute the tool
             try:
                 logger.info(f"Executing tool: {tooluse.tool}")
-                # Iterate generator to stream tool_output events as outputs arrive
-                tool_outputs: list[Message] = []
-                for tool_output in tooluse.execute(
-                    log=manager.log, workspace=manager.workspace
-                ):
-                    tool_outputs.append(tool_output)
-                    # Emit tool_output event for each output message so the
-                    # frontend can display partial results in real time.
-                    if tool_output.role == "system":
+                stream_tool_id = current_tool_id
+
+                def stream_tool_output(
+                    tool_output: Message, tool_id: str = stream_tool_id
+                ) -> None:
+                    if (
+                        tool_output.role == "system"
+                        and not tool_output.hide
+                        and not tool_output.quiet
+                    ):
                         SessionManager.add_event(
                             conversation_id,
                             {
                                 "type": "tool_output",
-                                "tool_id": current_tool_id,
+                                "tool_id": tool_id,
                                 "output": tool_output.content,
                             },
                         )
+
+                tool_outputs = list(
+                    tooluse.execute(
+                        log=manager.log,
+                        workspace=manager.workspace,
+                        on_result_message=stream_tool_output,
+                    )
+                )
                 logger.info(f"Tool execution complete, outputs: {len(tool_outputs)}")
 
                 # Store the tool outputs, propagating call_id to pair results

--- a/gptme/server/session_step.py
+++ b/gptme/server/session_step.py
@@ -895,9 +895,23 @@ def start_tool_execution(
             # Execute the tool
             try:
                 logger.info(f"Executing tool: {tooluse.tool}")
-                tool_outputs = list(
-                    tooluse.execute(log=manager.log, workspace=manager.workspace)
-                )
+                # Iterate generator to stream tool_output events as outputs arrive
+                tool_outputs: list[Message] = []
+                for tool_output in tooluse.execute(
+                    log=manager.log, workspace=manager.workspace
+                ):
+                    tool_outputs.append(tool_output)
+                    # Emit tool_output event for each output message so the
+                    # frontend can display partial results in real time.
+                    if tool_output.role == "system":
+                        SessionManager.add_event(
+                            conversation_id,
+                            {
+                                "type": "tool_output",
+                                "tool_id": current_tool_id,
+                                "output": tool_output.content,
+                            },
+                        )
                 logger.info(f"Tool execution complete, outputs: {len(tool_outputs)}")
 
                 # Store the tool outputs, propagating call_id to pair results

--- a/gptme/tools/base.py
+++ b/gptme/tools/base.py
@@ -454,6 +454,7 @@ class ToolUse:
         self,
         log: Log | None = None,
         workspace: Path | None = None,
+        on_result_message: Callable[[Message], None] | None = None,
     ) -> Generator[Message, None, None]:
         """Executes a tool-use tag and returns the output."""
         # noreorder
@@ -504,11 +505,13 @@ class ToolUse:
                         if isinstance(ex, Generator):
                             # Convert generator to list to measure execution time properly
                             result_msgs = list(ex)
-                            yield from result_msgs
                         else:
                             if ex is not None:
                                 result_msgs = [ex]
-                            yield from result_msgs
+                        if on_result_message:
+                            for msg in result_msgs:
+                                on_result_message(msg)
+                        yield from result_msgs
                     finally:
                         _current_tool_use.reset(token)
 

--- a/gptme/tools/base.py
+++ b/gptme/tools/base.py
@@ -502,16 +502,23 @@ class ToolUse:
                             self.args,
                             self.kwargs,
                         )
-                        if isinstance(ex, Generator):
-                            # Convert generator to list to measure execution time properly
-                            result_msgs = list(ex)
-                        else:
-                            if ex is not None:
-                                result_msgs = [ex]
-                        if on_result_message:
-                            for msg in result_msgs:
-                                on_result_message(msg)
-                        yield from result_msgs
+                        generator_result = ex if isinstance(ex, Generator) else None
+                        single_result = (
+                            None
+                            if generator_result is not None
+                            else cast(Message | None, ex)
+                        )
+                        if generator_result is not None:
+                            for msg in generator_result:
+                                result_msgs.append(msg)
+                                if on_result_message:
+                                    on_result_message(msg)
+                                yield msg
+                        elif single_result is not None:
+                            result_msgs = [single_result]
+                            if on_result_message:
+                                on_result_message(single_result)
+                            yield single_result
                     finally:
                         _current_tool_use.reset(token)
 
@@ -534,7 +541,7 @@ class ToolUse:
                         workspace=workspace,
                         tool_use=self,
                         result_msgs=tuple(result_msgs)
-                        if isinstance(ex, Generator)
+                        if generator_result is not None
                         else None,
                     )
                     if post_hook_msgs := trigger_hook(

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -80,6 +80,74 @@ def test_v2_api_root(client: FlaskClient, monkeypatch):
     assert "provider_configured" in data
 
 
+def test_start_tool_execution_streams_only_real_tool_output(
+    v2_conv, client: FlaskClient, monkeypatch
+):
+    from gptme.message import Message
+    from gptme.server.session_models import SessionManager, ToolExecution
+    from gptme.server.session_step import start_tool_execution
+    from gptme.tools import ToolUse
+
+    conversation_id = v2_conv["conversation_id"]
+    session_id = v2_conv["session_id"]
+    session = SessionManager.get_session(session_id)
+    assert session is not None
+
+    tool_id = "tool-1"
+    session.pending_tools[tool_id] = ToolExecution(
+        tool_id=tool_id,
+        tooluse=ToolUse("shell", [], "echo hello", call_id="call-1"),
+    )
+
+    def fake_execute(self, log=None, workspace=None, on_result_message=None):
+        pre_hook = Message("system", "pre hook chatter")
+        actual_output = Message("system", "real tool output")
+        post_hook = Message("system", "post hook chatter")
+        yield pre_hook
+        if on_result_message:
+            on_result_message(actual_output)
+        yield actual_output
+        yield post_hook
+
+    monkeypatch.setattr("gptme.tools.base.ToolUse.execute", fake_execute)
+    monkeypatch.setattr(
+        "gptme.server.session_step.prepare_execution_environment",
+        lambda workspace, tools, chat_config: None,
+    )
+    monkeypatch.setattr(
+        "gptme.server.session_step._start_step_thread",
+        lambda *args, **kwargs: None,
+    )
+
+    thread = start_tool_execution(
+        conversation_id=conversation_id,
+        session=session,
+        tool_id=tool_id,
+        edited_tooluse=None,
+        model="openai/mock-model",
+        chat_config=ChatConfig(),
+    )
+    thread.join(timeout=5)
+    assert not thread.is_alive()
+
+    tool_output_events = [e for e in session.events if e["type"] == "tool_output"]
+    assert tool_output_events == [
+        {
+            "type": "tool_output",
+            "tool_id": tool_id,
+            "output": "real tool output",
+        }
+    ]
+
+    response = client.get(f"/api/v2/conversations/{conversation_id}")
+    assert response.status_code == 200
+    messages = response.get_json()["log"]
+    system_messages = [m["content"] for m in messages if m["role"] == "system"]
+    assert "pre hook chatter" in system_messages
+    assert "real tool output" in system_messages
+    assert "post hook chatter" in system_messages
+
+
 def test_v2_api_root_provider_configured(client: FlaskClient, monkeypatch):
     """provider_configured reflects whether get_default_model() returns a model."""
     from gptme.llm.models.types import ModelMeta

--- a/tests/test_tools_base.py
+++ b/tests/test_tools_base.py
@@ -11,6 +11,8 @@ from typing import Literal, Union
 
 import pytest
 
+from gptme.hooks import HookType
+from gptme.message import Message
 from gptme.tools.base import (
     Parameter,
     ToolSpec,
@@ -374,6 +376,38 @@ class TestToolUseFormatting:
         result = tu.to_output("xml")
         # quoteattr wraps in single-quotes when the value contains double-quotes
         assert "args='file \"name\".py'" in result
+
+    def test_execute_on_result_message_excludes_hook_messages(self, monkeypatch):
+        actual_output = Message("system", "actual output")
+
+        def execute(code, args, kwargs):
+            yield actual_output
+
+        fake_tool = ToolSpec(name="test_tool", desc="test", execute=execute)
+
+        def fake_trigger_hook(hook_type, data):
+            if hook_type == HookType.TOOL_EXECUTE_PRE:
+                return [Message("system", "pre hook")]
+            if hook_type == HookType.TOOL_EXECUTE_POST:
+                return [Message("system", "post hook")]
+            return []
+
+        monkeypatch.setattr("gptme.tools.get_tool", lambda name: fake_tool)
+        monkeypatch.setattr("gptme.hooks.trigger_hook", fake_trigger_hook)
+
+        streamed: list[Message] = []
+        yielded = list(
+            ToolUse("test_tool", [], None, start=0).execute(
+                on_result_message=streamed.append
+            )
+        )
+
+        assert [msg.content for msg in yielded] == [
+            "pre hook",
+            "actual output",
+            "post hook",
+        ]
+        assert streamed == [actual_output]
 
 
 # ── ToolUse._iter_from_xml ─────────────────────────────────────────

--- a/tests/test_tools_base.py
+++ b/tests/test_tools_base.py
@@ -409,6 +409,47 @@ class TestToolUseFormatting:
         ]
         assert streamed == [actual_output]
 
+    def test_execute_on_result_message_streams_generator_progressively(
+        self, monkeypatch
+    ):
+        first_output = Message("system", "first output")
+        second_output = Message("system", "second output")
+        events: list[str] = []
+
+        def execute(code, args, kwargs):
+            events.append("tool:start")
+            yield first_output
+            events.append("tool:between")
+            yield second_output
+            events.append("tool:end")
+
+        fake_tool = ToolSpec(name="test_tool", desc="test", execute=execute)
+
+        monkeypatch.setattr("gptme.tools.get_tool", lambda name: fake_tool)
+        monkeypatch.setattr("gptme.hooks.trigger_hook", lambda hook_type, data: [])
+
+        streamed: list[Message] = []
+
+        def on_result_message(msg: Message) -> None:
+            events.append(f"callback:{msg.content}")
+            streamed.append(msg)
+
+        yielded = list(
+            ToolUse("test_tool", [], None, start=0).execute(
+                on_result_message=on_result_message
+            )
+        )
+
+        assert yielded == [first_output, second_output]
+        assert streamed == [first_output, second_output]
+        assert events == [
+            "tool:start",
+            "callback:first output",
+            "tool:between",
+            "callback:second output",
+            "tool:end",
+        ]
+
 
 # ── ToolUse._iter_from_xml ─────────────────────────────────────────
 

--- a/webui/src/components/InlineToolExecution.tsx
+++ b/webui/src/components/InlineToolExecution.tsx
@@ -2,7 +2,7 @@ import type { ConversationState, ExecutingTool } from '@/stores/conversations';
 import { Loader2, Cog, CheckCircle, XCircle, Terminal } from 'lucide-react';
 import { type Observable } from '@legendapp/state';
 import { use$ } from '@legendapp/state/react';
-import { useEffect, useState, useMemo } from 'react';
+import { useEffect, useState } from 'react';
 import { CodeDisplay } from '@/components/CodeDisplay';
 import { MessageAvatar } from './MessageAvatar';
 import { detectToolLanguage } from '@/utils/highlightUtils';
@@ -145,7 +145,7 @@ export function InlineToolExecution({ executingTool$ }: InlineToolExecutionProps
                       Output
                     </div>
                     <CodeDisplay
-                      code={executingTool.partialOutput.join('')}
+                      code={executingTool.partialOutput}
                       maxHeight="200px"
                       showLineNumbers={false}
                       language=""

--- a/webui/src/components/InlineToolExecution.tsx
+++ b/webui/src/components/InlineToolExecution.tsx
@@ -1,8 +1,8 @@
 import type { ConversationState, ExecutingTool } from '@/stores/conversations';
-import { Loader2, Cog, CheckCircle, XCircle } from 'lucide-react';
+import { Loader2, Cog, CheckCircle, XCircle, Terminal } from 'lucide-react';
 import { type Observable } from '@legendapp/state';
 import { use$ } from '@legendapp/state/react';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useMemo } from 'react';
 import { CodeDisplay } from '@/components/CodeDisplay';
 import { MessageAvatar } from './MessageAvatar';
 import { detectToolLanguage } from '@/utils/highlightUtils';
@@ -136,6 +136,22 @@ export function InlineToolExecution({ executingTool$ }: InlineToolExecutionProps
                     )}
                   />
                 </div>
+
+                {/* Partial output */}
+                {executingTool.partialOutput && executingTool.partialOutput.length > 0 && (
+                  <div className="space-y-2">
+                    <div className="flex items-center gap-1.5 text-sm font-medium text-muted-foreground">
+                      <Terminal className="h-3.5 w-3.5" />
+                      Output
+                    </div>
+                    <CodeDisplay
+                      code={executingTool.partialOutput.join('')}
+                      maxHeight="200px"
+                      showLineNumbers={false}
+                      language=""
+                    />
+                  </div>
+                )}
 
                 {/* Status indicator with elapsed timer */}
                 <div className="flex items-center gap-2 border-t border-blue-200 pt-3 dark:border-blue-800">

--- a/webui/src/hooks/useConversation.ts
+++ b/webui/src/hooks/useConversation.ts
@@ -12,6 +12,7 @@ import {
   setConnected,
   setPendingTool,
   setExecutingTool,
+  setToolOutput,
   setToolComplete,
   addMessage,
   setMessageStatus,
@@ -278,6 +279,12 @@ export function useConversation(conversationId: string, serverId?: string) {
                   '[useConversation] No matching pending tool found for executing tool:',
                   toolId
                 );
+              }
+            },
+            onToolOutput: (toolId, content) => {
+              const executingTool = conversation$?.executingTool.get();
+              if (executingTool && executingTool.id === toolId) {
+                setToolOutput(conversationId, content);
               }
             },
             onToolComplete: (toolId, durationMs, success) => {

--- a/webui/src/stores/conversations.ts
+++ b/webui/src/stores/conversations.ts
@@ -12,6 +12,7 @@ export interface ExecutingTool {
   id: string;
   tooluse: ToolUse;
   startedAt: number;
+  partialOutput: string;
 }
 
 export interface ConversationState {
@@ -26,7 +27,12 @@ export interface ConversationState {
   // Any executing tool
   executingTool: ExecutingTool | null;
   // Duration of the most recently completed tool (cleared when next tool starts)
-  lastCompletedTool: { toolName: string; durationMs: number; completedAt: number; success: boolean } | null;
+  lastCompletedTool: {
+    toolName: string;
+    durationMs: number;
+    completedAt: number;
+    success: boolean;
+  } | null;
   // Last received message
   lastMessage?: Message;
   // Whether to show the initial system message
@@ -142,6 +148,17 @@ export function setExecutingTool(
     update.lastCompletedTool = null;
   }
   updateConversation(id, update);
+}
+
+export function setToolOutput(id: string, output: string) {
+  const conversation = conversations$.get(id);
+  if (!conversation) return;
+  const executing = conversation.executingTool.get();
+  if (!executing) return;
+  conversation.executingTool.set({
+    ...executing,
+    partialOutput: (executing.partialOutput || '') + output,
+  });
 }
 
 export function setToolComplete(

--- a/webui/src/stores/conversations.ts
+++ b/webui/src/stores/conversations.ts
@@ -141,7 +141,9 @@ export function setExecutingTool(
 ) {
   const update: Partial<ConversationState> = {
     executingTool:
-      toolId && tooluse ? { id: toolId, tooluse, startedAt: startedAt ?? Date.now() } : null,
+      toolId && tooluse
+        ? { id: toolId, tooluse, startedAt: startedAt ?? Date.now(), partialOutput: '' }
+        : null,
   };
   if (toolId) {
     // Clear the completion badge when a new tool starts executing

--- a/webui/src/utils/api.ts
+++ b/webui/src/utils/api.ts
@@ -537,6 +537,7 @@ export class ApiClient {
       onMessageAdded: (message: Message) => void;
       onToolPending: (toolId: string, tooluse: ToolUse, auto_confirm: boolean) => void;
       onToolExecuting: (toolId: string) => void;
+      onToolOutput?: (toolId: string, output: string) => void;
       onToolComplete?: (toolId: string, durationMs: number, success: boolean) => void;
       onInterrupted: () => void;
       onError: (error: string) => void;
@@ -685,6 +686,13 @@ export class ApiClient {
             console.log(`[ApiClient] Tool executing:`, data);
             const toolExecutingEvent = data as { tool_id: string };
             callbacks.onToolExecuting(toolExecutingEvent.tool_id);
+            break;
+          }
+
+          case 'tool_output': {
+            console.log(`[ApiClient] Tool output:`, data);
+            const toolOutputEvent = data as { tool_id: string; output: string };
+            callbacks.onToolOutput?.(toolOutputEvent.tool_id, toolOutputEvent.output);
             break;
           }
 


### PR DESCRIPTION
## What

Adds real-time streaming of tool execution output to the web UI via a new `tool_output` SSE event type.

Previously, tool output only appeared after the tool completed (via `message_added` events). This meant long-running shell commands showed no progress — the UI appeared frozen until completion.

## Changes

### Backend (`gptme/server/`)
- **New `tool_output` SSE event type** in `api_v2_common.py` — carries `tool_id` and `output` (string)
- **Emit `tool_output` events as tool outputs arrive** in `session_step.py` — the tool executor now emits an event for each output message from the tool generator, allowing partial results to stream to the frontend

### Frontend (`webui/`)
- **`ExecutingTool`** interface extended with `partialOutput: string` field
- **`setToolOutput()`** action added to conversations store — accumulates partial output chunks
- **`onToolOutput` callback** added to SSE event subscription in `api.ts`
- **`InlineToolExecution.tsx`** — renders partial output live in a terminal-style code block while the spinner shows

## How to test

```bash
# Start server with CORS
uv run gptme-server --cors-origin=http://localhost:5701

# In web UI, run a long command like:
# sleep 3 && echo "hello"

# Before: no output until completion
# After: partial output streams live in InlineToolExecution
```

## Screenshots

N/A (needs interactive test — the diff is 77 lines, 6 files)

## Related

- Idea #425 from Bobs idea backlog
- `tasks/gptme-webui-streaming-tool-calls.md`