### PR TITLE
feat(webui): server connection health panel with /api/v2/server/health endpoint

### DIFF
--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -267,6 +267,65 @@ def api_session_delete(session_id: str):
     return flask.jsonify({"status": "ok", "message": f"Session {session_id} deleted"})
 
 
+@v2_api.route("/api/v2/server/health")
+@require_auth
+@api_doc_simple(tags=["admin"])
+def api_server_health():
+    """Server connection health summary.
+
+    Returns a compact health snapshot: total session count, generating/idle
+    breakdown, a per-slot strip, and a color-coded health indicator —
+    without the per-session log-reading overhead of ``/api/v2/sessions``.
+
+    Health levels:
+    - ``green``  — no active generations or very light load
+    - ``yellow`` — some sessions generating
+    - ``red``    — all slots busy (every session is generating)
+    """
+    from .api_v2_sessions import SessionManager
+
+    now = datetime.now(tz=timezone.utc)
+    all_sessions = SessionManager.get_all_sessions()
+
+    total = len(all_sessions)
+    generating_count = 0
+    slots = []
+
+    for session_id, session in all_sessions:
+        is_gen = bool(session.generating)
+        if is_gen:
+            generating_count += 1
+        elapsed: float | None = None
+        if is_gen and session.generating_since:
+            elapsed = (now - session.generating_since).total_seconds()
+        slots.append(
+            {
+                "id": session_id[:8],
+                "generating": is_gen,
+                "elapsed_seconds": elapsed,
+            }
+        )
+
+    idle_count = total - generating_count
+
+    if total == 0 or generating_count == 0:
+        health = "green"
+    elif generating_count < total:
+        health = "yellow"
+    else:
+        health = "red"
+
+    return flask.jsonify(
+        {
+            "session_count": total,
+            "generating_count": generating_count,
+            "idle_count": idle_count,
+            "health": health,
+            "slots": slots,
+        }
+    )
+
+
 @v2_api.route("/api/v2")
 @api_doc_simple(responses={200: ApiRootResponse}, tags=["meta"])
 def api_root():

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -846,8 +846,13 @@ def test_external_session_gptme_directory_no_jsonl_skipped(tmp_path: Path):
     assert items == [], f"Expected no sessions, got: {items}"
 
 
-def test_v2_server_health_empty(client: FlaskClient):
+def test_v2_server_health_empty(client: FlaskClient, monkeypatch):
     """Server health endpoint returns green status with no active sessions."""
+    monkeypatch.setattr(
+        "gptme.server.api_v2.SessionManager.get_all_sessions",
+        lambda: [],
+    )
+
     response = client.get("/api/v2/server/health")
     assert response.status_code == 200
     data = response.get_json()
@@ -859,8 +864,19 @@ def test_v2_server_health_empty(client: FlaskClient):
     assert data["slots"] == []
 
 
-def test_v2_server_health_with_session(v2_conv, client: FlaskClient):
+def test_v2_server_health_with_session(v2_conv, client: FlaskClient, monkeypatch):
     """Server health endpoint reports idle session after creation."""
+    from gptme.server.session_models import SessionManager
+
+    session_id = v2_conv["session_id"]
+    session = SessionManager.get_session(session_id)
+    assert session is not None
+
+    monkeypatch.setattr(
+        "gptme.server.api_v2.SessionManager.get_all_sessions",
+        lambda: [(session_id, session)],
+    )
+
     response = client.get("/api/v2/server/health")
     assert response.status_code == 200
     data = response.get_json()

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -846,6 +846,35 @@ def test_external_session_gptme_directory_no_jsonl_skipped(tmp_path: Path):
     assert items == [], f"Expected no sessions, got: {items}"
 
 
+def test_v2_server_health_empty(client: FlaskClient):
+    """Server health endpoint returns green status with no active sessions."""
+    response = client.get("/api/v2/server/health")
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data is not None
+    assert data["session_count"] == 0
+    assert data["generating_count"] == 0
+    assert data["idle_count"] == 0
+    assert data["health"] == "green"
+    assert data["slots"] == []
+
+
+def test_v2_server_health_with_session(v2_conv, client: FlaskClient):
+    """Server health endpoint reports idle session after creation."""
+    response = client.get("/api/v2/server/health")
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data is not None
+    assert data["session_count"] == 1
+    assert data["generating_count"] == 0
+    assert data["idle_count"] == 1
+    assert data["health"] == "green"
+    assert len(data["slots"]) == 1
+    slot = data["slots"][0]
+    assert not slot["generating"]
+    assert slot["elapsed_seconds"] is None
+
+
 def test_v2_conversations_list(client: FlaskClient):
     """Test listing V2 conversations."""
     response = client.get("/api/v2/conversations")

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -1,7 +1,7 @@
 import random
 import time
 import unittest.mock
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, cast
 
@@ -873,6 +873,69 @@ def test_v2_server_health_with_session(v2_conv, client: FlaskClient):
     slot = data["slots"][0]
     assert not slot["generating"]
     assert slot["elapsed_seconds"] is None
+
+
+def test_v2_server_health_yellow(client: FlaskClient, monkeypatch):
+    """Server health returns yellow when some sessions are generating."""
+    from gptme.server.session_models import ConversationSession
+
+    now = datetime.now(tz=timezone.utc)
+    idle_session = ConversationSession(id="idle-1234", conversation_id="conv-1")
+    gen_session = ConversationSession(
+        id="gen-5678",
+        conversation_id="conv-2",
+        generating=True,
+        generating_since=now - timedelta(seconds=30),
+    )
+    monkeypatch.setattr(
+        "gptme.server.api_v2.SessionManager.get_all_sessions",
+        lambda: [("idle-1234", idle_session), ("gen-5678", gen_session)],
+    )
+
+    response = client.get("/api/v2/server/health")
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data is not None
+    assert data["session_count"] == 2
+    assert data["generating_count"] == 1
+    assert data["idle_count"] == 1
+    assert data["health"] == "yellow"
+    assert len(data["slots"]) == 2
+    # Verify generating slot has elapsed time
+    gen_slot = next(s for s in data["slots"] if s["generating"])
+    assert gen_slot["elapsed_seconds"] is not None
+    assert gen_slot["elapsed_seconds"] >= 0  # type: ignore[operator]
+
+
+def test_v2_server_health_red(client: FlaskClient, monkeypatch):
+    """Server health returns red when all sessions are generating."""
+    from gptme.server.session_models import ConversationSession
+
+    now = datetime.now(tz=timezone.utc)
+    sessions = [
+        ConversationSession(
+            id=f"gen-{i:04d}",
+            conversation_id=f"conv-{i}",
+            generating=True,
+            generating_since=now - timedelta(seconds=10 + i),
+        )
+        for i in range(3)
+    ]
+    monkeypatch.setattr(
+        "gptme.server.api_v2.SessionManager.get_all_sessions",
+        lambda: [(s.id, s) for s in sessions],
+    )
+
+    response = client.get("/api/v2/server/health")
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data is not None
+    assert data["session_count"] == 3
+    assert data["generating_count"] == 3
+    assert data["idle_count"] == 0
+    assert data["health"] == "red"
+    assert len(data["slots"]) == 3
+    assert all(s["generating"] for s in data["slots"])
 
 
 def test_v2_conversations_list(client: FlaskClient):

--- a/webui/src/App.tsx
+++ b/webui/src/App.tsx
@@ -22,6 +22,7 @@ const Workspaces = lazy(() => import('./pages/Workspaces'));
 const History = lazy(() => import('./pages/History'));
 const ExternalSessions = lazy(() => import('./pages/ExternalSessions'));
 const Admin = lazy(() => import('./pages/Admin'));
+const Health = lazy(() => import('./pages/Health'));
 const NotFound = lazy(() => import('./pages/NotFound'));
 
 const queryClient = new QueryClient({
@@ -87,6 +88,7 @@ const App: FC = () => {
                         <Route path="/history" element={<History />} />
                         <Route path="/external-sessions" element={<ExternalSessions />} />
                         <Route path="/admin" element={<Admin />} />
+                        <Route path="/health" element={<Health />} />
                         <Route path="/workspace/:id" element={<Workspace />} />
                         <Route path="*" element={<NotFound />} />
                       </Routes>

--- a/webui/src/components/dashboard/ServerHealthPanel.tsx
+++ b/webui/src/components/dashboard/ServerHealthPanel.tsx
@@ -1,0 +1,133 @@
+import { type FC } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Activity, Server, Loader2 } from 'lucide-react';
+import { useApi } from '@/contexts/ApiContext';
+import { use$ } from '@legendapp/state/react';
+import type { ServerHealth } from '@/types/api';
+
+const REFRESH_INTERVAL_MS = 5000;
+
+const HEALTH_CONFIG = {
+  green: { label: 'Healthy', className: 'bg-emerald-500', textClass: 'text-emerald-600' },
+  yellow: { label: 'Active', className: 'bg-amber-400', textClass: 'text-amber-600' },
+  red: { label: 'Busy', className: 'bg-red-500', textClass: 'text-red-600' },
+} satisfies Record<ServerHealth['health'], { label: string; className: string; textClass: string }>;
+
+/** Compact slot strip: one colored pip per server session slot. */
+const SlotStrip: FC<{ health: ServerHealth }> = ({ health }) => {
+  if (health.slots.length === 0) {
+    return <span className="text-xs text-muted-foreground">No active sessions</span>;
+  }
+  return (
+    <div className="flex flex-wrap gap-1" title="Each pip represents one active session slot">
+      {health.slots.map((slot) => (
+        <div
+          key={slot.id}
+          className={`h-3 w-3 rounded-sm ${slot.generating ? 'animate-pulse bg-amber-400' : 'bg-emerald-400'}`}
+          title={
+            slot.generating ? `Generating (${Math.round(slot.elapsed_seconds ?? 0)}s)` : 'Idle'
+          }
+        />
+      ))}
+    </div>
+  );
+};
+
+/**
+ * Compact server connection health panel.
+ *
+ * Shows session count, generating/idle breakdown, a per-slot status strip,
+ * and a color-coded health indicator. Designed to be embedded in admin views
+ * or dashboard layouts.
+ */
+export const ServerHealthPanel: FC = () => {
+  const { api } = useApi();
+  const isConnected = use$(api.isConnected$);
+
+  const {
+    data: health,
+    isLoading,
+    error,
+  } = useQuery<ServerHealth>({
+    queryKey: ['server-health'],
+    queryFn: () => api.getServerHealth(),
+    enabled: isConnected,
+    refetchInterval: REFRESH_INTERVAL_MS,
+    staleTime: 0,
+  });
+
+  if (!isConnected) {
+    return (
+      <div className="flex items-center gap-2 rounded-md border bg-muted/30 px-3 py-2 text-sm text-muted-foreground">
+        <Server className="h-4 w-4 shrink-0" />
+        <span>Not connected</span>
+      </div>
+    );
+  }
+
+  if (isLoading && !health) {
+    return (
+      <div className="flex items-center gap-2 rounded-md border bg-card px-3 py-2 text-sm text-muted-foreground">
+        <Loader2 className="h-4 w-4 shrink-0 animate-spin" />
+        <span>Loading health…</span>
+      </div>
+    );
+  }
+
+  if (error || !health) {
+    return (
+      <div className="flex items-center gap-2 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+        <Server className="h-4 w-4 shrink-0" />
+        <span>Health endpoint unavailable</span>
+      </div>
+    );
+  }
+
+  const cfg = HEALTH_CONFIG[health.health];
+
+  return (
+    <div className="rounded-md border bg-card px-4 py-3">
+      {/* Header row */}
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <Server className="h-4 w-4 shrink-0 text-muted-foreground" />
+          <span className="text-sm font-medium">Server Health</span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <span className={`h-2 w-2 rounded-full ${cfg.className}`} />
+          <span className={`text-xs font-medium ${cfg.textClass}`}>{cfg.label}</span>
+        </div>
+      </div>
+
+      {/* Stats row */}
+      <div className="mt-2 flex gap-4 text-xs text-muted-foreground">
+        <span>
+          <span className="font-semibold tabular-nums text-foreground">{health.session_count}</span>{' '}
+          session{health.session_count !== 1 ? 's' : ''}
+        </span>
+        {health.generating_count > 0 && (
+          <span className="flex items-center gap-1">
+            <Activity className="h-3 w-3 text-amber-500" />
+            <span className="font-semibold tabular-nums text-foreground">
+              {health.generating_count}
+            </span>{' '}
+            generating
+          </span>
+        )}
+        {health.idle_count > 0 && (
+          <span>
+            <span className="font-semibold tabular-nums text-foreground">{health.idle_count}</span>{' '}
+            idle
+          </span>
+        )}
+      </div>
+
+      {/* Slot strip */}
+      {health.slots.length > 0 && (
+        <div className="mt-2">
+          <SlotStrip health={health} />
+        </div>
+      )}
+    </div>
+  );
+};

--- a/webui/src/pages/Health.tsx
+++ b/webui/src/pages/Health.tsx
@@ -1,12 +1,12 @@
 import { type FC } from 'react';
 import { MenuBar } from '@/components/MenuBar';
-import { AdminView } from '@/components/AdminView';
 import { ServerHealthPanel } from '@/components/dashboard/ServerHealthPanel';
 import { SidebarIcons } from '@/components/SidebarIcons';
 import { MobileBottomNav } from '@/components/MobileBottomNav';
 import { useTasksQuery } from '@/stores/tasks';
 
-const Admin: FC = () => {
+/** Standalone server health page — a lightweight single-panel view. */
+const Health: FC = () => {
   const { data: tasks = [] } = useTasksQuery();
 
   return (
@@ -14,13 +14,9 @@ const Admin: FC = () => {
       <MenuBar />
       <div className="flex min-h-0 flex-1">
         <SidebarIcons tasks={tasks} />
-        <div className="flex flex-1 flex-col overflow-hidden">
-          <div className="border-b px-4 py-3">
-            <ServerHealthPanel />
-          </div>
-          <div className="flex-1 overflow-hidden">
-            <AdminView />
-          </div>
+        <div className="flex flex-1 flex-col gap-4 overflow-auto p-6">
+          <h1 className="text-lg font-semibold">Server Health</h1>
+          <ServerHealthPanel />
         </div>
       </div>
       <MobileBottomNav />
@@ -28,4 +24,4 @@ const Admin: FC = () => {
   );
 };
 
-export default Admin;
+export default Health;

--- a/webui/src/types/api.ts
+++ b/webui/src/types/api.ts
@@ -1,5 +1,20 @@
 import type { Message, StreamingMessage } from './conversation';
 
+// Server connection health summary (from /api/v2/server/health)
+export interface ServerHealthSlot {
+  id: string;
+  generating: boolean;
+  elapsed_seconds: number | null;
+}
+
+export interface ServerHealth {
+  session_count: number;
+  generating_count: number;
+  idle_count: number;
+  health: 'green' | 'yellow' | 'red';
+  slots: ServerHealthSlot[];
+}
+
 // Active server-side session (from /api/v2/sessions)
 export interface ActiveSession {
   id: string;

--- a/webui/src/utils/api.ts
+++ b/webui/src/utils/api.ts
@@ -9,6 +9,7 @@ import type {
   ExternalSessionCatalogItem,
   ExternalSessionDetail,
   SendMessageRequest,
+  ServerHealth,
   UserInfo,
 } from '@/types/api';
 import type { ConversationSummary, Message, ToolUse } from '@/types/conversation';
@@ -1388,6 +1389,11 @@ export class ApiClient {
   async getSessions(): Promise<ActiveSession[]> {
     const url = `${this.baseUrl}/api/v2/sessions`;
     return await this.fetchJson<ActiveSession[]>(url);
+  }
+
+  async getServerHealth(): Promise<ServerHealth> {
+    const url = `${this.baseUrl}/api/v2/server/health`;
+    return await this.fetchJson<ServerHealth>(url);
   }
 
   async deleteSession(sessionId: string): Promise<void> {


### PR DESCRIPTION
## Summary

Adds a compact server health panel to the WebUI and the backing API endpoint.

### Backend: `GET /api/v2/server/health`
- Returns session count, generating/idle breakdown, per-slot strip, and health indicator
- Lighter than `/api/v2/sessions` — no per-session log-reading overhead
- Health levels: `green` (idle/no sessions), `yellow` (some generating), `red` (all slots generating)

### Frontend: `ServerHealthPanel`
- New `webui/src/components/dashboard/ServerHealthPanel.tsx`
- Color-coded health badge (emerald/amber/red)
- Stats row: total sessions, generating count, idle count
- Animated per-slot pip strip (amber pulse = generating, green = idle)
- Auto-refreshes every 5 seconds

### Wiring
- Embedded as a compact header bar on the existing `/admin` page, above the session table
- Also available as a standalone `/health` route

### Tests
- 2 new pytest tests for `/api/v2/server/health`: empty server (green) and with idle session

## Files
- `gptme/server/api_v2.py` — new health endpoint
- `webui/src/types/api.ts` — `ServerHealth`, `ServerHealthSlot` types
- `webui/src/utils/api.ts` — `getServerHealth()` API method
- `webui/src/components/dashboard/ServerHealthPanel.tsx` — panel component
- `webui/src/pages/Health.tsx` — standalone health page
- `webui/src/pages/Admin.tsx` — wired panel into admin layout
- `webui/src/App.tsx` — registered `/health` route
- `tests/test_server_v2.py` — 2 new tests