### PR TITLE
feat(webui): structured tool call visualization with RichToolCall component

### DIFF
--- a/webui/src/components/CollapsedStepGroup.tsx
+++ b/webui/src/components/CollapsedStepGroup.tsx
@@ -1,15 +1,56 @@
 import type { FC } from 'react';
-import { ChevronRight, ChevronDown } from 'lucide-react';
+import {
+  ChevronRight,
+  ChevronDown,
+  Terminal,
+  FileText,
+  Code,
+  Globe,
+  Eye,
+  Wrench,
+} from 'lucide-react';
+import type { ToolStepDetail } from '@/utils/stepGrouping';
+import { getToolCategory, CATEGORY_BORDER_ONLY } from '@/utils/toolCallParser';
+
+/** Map tool name to icon */
+function getStepIcon(tool: string): typeof Terminal {
+  switch (tool.toLowerCase()) {
+    case 'shell':
+    case 'tmux':
+      return Terminal;
+    case 'ipython':
+    case 'python':
+      return Code;
+    case 'save':
+    case 'append':
+      return FileText;
+    case 'patch':
+    case 'morph':
+      return FileText;
+    case 'read':
+      return FileText;
+    case 'browser':
+      return Globe;
+    case 'vision':
+      return Eye;
+    default:
+      return Wrench;
+  }
+}
 
 interface Props {
   count: number;
   tools: string[];
   isExpanded: boolean;
   onToggle: () => void;
+  /** Rich per-step detail (from assistant codeblock parsing) */
+  steps?: ToolStepDetail[];
 }
 
-export const CollapsedStepGroup: FC<Props> = ({ count, tools, isExpanded, onToggle }) => {
-  const toolSummary = tools.length > 0 ? ` — ${tools.join(', ')}` : '';
+export const CollapsedStepGroup: FC<Props> = ({ count, tools, isExpanded, onToggle, steps }) => {
+  // When we have rich step data, render per-tool summaries
+  const hasStepDetail = steps && steps.length > 0;
+  const toolSummary = !hasStepDetail ? (tools.length > 0 ? ` — ${tools.join(', ')}` : '') : '';
 
   return (
     <div className="mx-auto max-w-3xl px-4">
@@ -23,10 +64,36 @@ export const CollapsedStepGroup: FC<Props> = ({ count, tools, isExpanded, onTogg
           ) : (
             <ChevronRight className="h-3.5 w-3.5 shrink-0" />
           )}
-          <span>
+          <span className="shrink-0">
             {count} step{count !== 1 ? 's' : ''}
             {toolSummary}
           </span>
+
+          {/* Rich per-tool summary chips */}
+          {hasStepDetail && (
+            <div className="flex flex-wrap items-center gap-1.5">
+              {steps!.map((step, i) => {
+                const category = getToolCategory(step.tool);
+                const borderClass = CATEGORY_BORDER_ONLY[category];
+                const Icon = getStepIcon(step.tool);
+                return (
+                  <span
+                    key={i}
+                    className={`inline-flex items-center gap-1 rounded border bg-card/50 px-1.5 py-0.5 ${borderClass} border-l-2`}
+                    title={step.arg}
+                  >
+                    <Icon className="h-3 w-3 shrink-0" />
+                    <code className="text-[11px] font-medium">{step.tool}</code>
+                    {step.arg && (
+                      <span className="max-w-[120px] truncate text-[10px] opacity-70">
+                        {step.arg}
+                      </span>
+                    )}
+                  </span>
+                );
+              })}
+            </div>
+          )}
         </button>
       </div>
     </div>

--- a/webui/src/components/ConversationContent.tsx
+++ b/webui/src/components/ConversationContent.tsx
@@ -342,6 +342,7 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
                 <CollapsedStepGroup
                   count={stepRole.count}
                   tools={stepRole.tools}
+                  steps={stepRole.steps}
                   isExpanded={expandedGroups$.get().has(stepRole.groupId)}
                   onToggle={() => toggleGroup(stepRole.groupId)}
                 />

--- a/webui/src/components/RichToolCall.tsx
+++ b/webui/src/components/RichToolCall.tsx
@@ -17,7 +17,12 @@ import {
   Loader2,
 } from 'lucide-react';
 import type { ToolUse } from '@/types/conversation';
-import { getToolSummary, getToolCategory, CATEGORY_BORDER_ONLY } from '@/utils/toolCallParser';
+import {
+  getToolSummary,
+  getToolCategory,
+  CATEGORY_BORDER_ONLY,
+  isKnownTool,
+} from '@/utils/toolCallParser';
 import { CodeDisplay } from '@/components/CodeDisplay';
 import { detectToolLanguage } from '@/utils/highlightUtils';
 
@@ -172,26 +177,35 @@ export const RichToolCall: FC<RichToolCallProps> = ({
  */
 export function renderToolCallsFromContent(
   content: string,
-  completedTools?: Map<string, { success: boolean; durationMs: number }>
+  completedTools?: Map<number, { success: boolean; durationMs: number }>
 ): { content: string; toolCalls: React.ReactNode[] } {
-  // Match gptme markdown tool calls: ```toolname
   const codeblockRegex = /```(\w+)(\s+[^\n]*)?\n([\s\S]*?)```/g;
   const toolCalls: React.ReactNode[] = [];
   let cleanedContent = content;
 
   let match: RegExpExecArray | null;
   let callIndex = 0;
-  const matches: Array<{ start: number; end: number; tool: string; args: string; body: string }> =
-    [];
+  const matches: Array<{
+    start: number;
+    end: number;
+    tool: string;
+    args: string;
+    body: string;
+    index: number;
+  }> = [];
 
-  // Collect all matches first
+  // Collect matches first — skip non-tool language fences
   while ((match = codeblockRegex.exec(content)) !== null) {
+    const tool = match[1];
+    if (!isKnownTool(tool)) continue;
+
     matches.push({
       start: match.index,
       end: match.index + match[0].length,
-      tool: match[1],
+      tool,
       args: (match[2] || '').trim(),
       body: match[3].trim(),
+      index: callIndex++,
     });
   }
 
@@ -216,8 +230,8 @@ export function renderToolCallsFromContent(
     }
 
     const toolUse: ToolUse = { tool: m.tool, args, content: m.body };
-    const key = `${m.tool}-${callIndex}`;
-    const compMeta = completedTools?.get(m.tool);
+    const key = `toolcall-${m.index}`;
+    const compMeta = completedTools?.get(m.index);
     toolCalls.unshift(
       <RichToolCall
         key={key}
@@ -226,7 +240,6 @@ export function renderToolCallsFromContent(
         durationMs={compMeta?.durationMs}
       />
     );
-    callIndex++;
 
     // Remove the codeblock from the content (replace with placeholder for later reconstruction,
     // or just remove it entirely since RichToolCall replaces it visually)

--- a/webui/src/components/RichToolCall.tsx
+++ b/webui/src/components/RichToolCall.tsx
@@ -1,0 +1,240 @@
+import { useState, type FC } from 'react';
+import {
+  Terminal,
+  Server,
+  Globe,
+  Eye,
+  Code,
+  FileText,
+  Save,
+  ClipboardPlus,
+  Scissors,
+  Wrench,
+  ChevronDown,
+  ChevronRight,
+  CheckCircle,
+  XCircle,
+  Loader2,
+} from 'lucide-react';
+import type { ToolUse } from '@/types/conversation';
+import { getToolSummary, getToolCategory, CATEGORY_BORDER_ONLY } from '@/utils/toolCallParser';
+import { CodeDisplay } from '@/components/CodeDisplay';
+import { detectToolLanguage } from '@/utils/highlightUtils';
+
+/**
+ * Map tool names to Lucide icons. Covers all common gptme tools.
+ */
+function getToolIcon(tool: string): typeof Terminal {
+  const t = tool.toLowerCase();
+  switch (t) {
+    case 'shell':
+    case 'tmux':
+      return Terminal;
+    case 'ipython':
+    case 'python':
+      return Code;
+    case 'save':
+      return Save;
+    case 'append':
+      return ClipboardPlus;
+    case 'patch':
+    case 'morph':
+      return Scissors;
+    case 'read':
+      return FileText;
+    case 'browser':
+      return Globe;
+    case 'vision':
+      return Eye;
+    case 'gh':
+    case 'mcp':
+      return Server;
+    default:
+      return Wrench;
+  }
+}
+
+interface RichToolCallProps {
+  toolUse: ToolUse;
+  /** Whether this tool call is currently executing (shows spinner) */
+  isExecuting?: boolean;
+  /** Whether the tool completed successfully (shows checkmark/x) */
+  completed?: boolean | null;
+  /** Tool duration in ms for completed tools */
+  durationMs?: number;
+  /** Default expanded state */
+  defaultExpanded?: boolean;
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+export const RichToolCall: FC<RichToolCallProps> = ({
+  toolUse,
+  isExecuting = false,
+  completed = null,
+  durationMs,
+  defaultExpanded = false,
+}) => {
+  const [isExpanded, setIsExpanded] = useState(defaultExpanded);
+  const category = getToolCategory(toolUse.tool);
+  const summary = getToolSummary(toolUse);
+  const language = detectToolLanguage(toolUse.tool, toolUse.args, toolUse.content);
+  const Icon = getToolIcon(toolUse.tool);
+  const borderClass = CATEGORY_BORDER_ONLY[category];
+
+  // Status badge
+  const statusBadge = isExecuting ? (
+    <Loader2 className="h-3.5 w-3.5 animate-spin text-blue-500" />
+  ) : completed === true ? (
+    <CheckCircle className="h-3.5 w-3.5 text-green-500" />
+  ) : completed === false ? (
+    <XCircle className="h-3.5 w-3.5 text-red-500" />
+  ) : null;
+
+  return (
+    <div className="my-2">
+      <div
+        className={`rounded-md border bg-card ${borderClass} border-l-4`}
+        role="button"
+        tabIndex={0}
+        onClick={() => setIsExpanded(!isExpanded)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            setIsExpanded(!isExpanded);
+          }
+        }}
+        aria-expanded={isExpanded}
+      >
+        {/* Summary header */}
+        <div className="flex items-center gap-2 px-3 py-2">
+          {isExpanded ? (
+            <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+          ) : (
+            <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+          )}
+          <Icon className="h-4 w-4 shrink-0 text-muted-foreground" />
+          <code className="rounded bg-muted px-1.5 py-0.5 text-xs font-medium">{toolUse.tool}</code>
+          <span className="truncate text-xs text-muted-foreground">{summary}</span>
+          {durationMs != null && (
+            <span className="ml-auto shrink-0 text-xs text-muted-foreground">
+              {formatDuration(durationMs)}
+            </span>
+          )}
+          {statusBadge}
+        </div>
+
+        {/* Expandable details */}
+        {isExpanded && (
+          <div className="space-y-3 border-t px-3 py-3">
+            {/* Args when there are non-trivial args */}
+            {toolUse.args &&
+              toolUse.args.length > 0 &&
+              toolUse.args.some((a) => a.trim().length > 0) && (
+                <div className="space-y-1">
+                  <span className="text-xs font-medium text-muted-foreground">Arguments:</span>
+                  <CodeDisplay
+                    code={toolUse.args.join('\n')}
+                    maxHeight="80px"
+                    showLineNumbers={false}
+                    language=""
+                  />
+                </div>
+              )}
+
+            {/* Content / code body */}
+            {toolUse.content && toolUse.content.trim().length > 0 && (
+              <div className="space-y-1">
+                <span className="text-xs font-medium text-muted-foreground">Content:</span>
+                <CodeDisplay
+                  code={toolUse.content}
+                  maxHeight="300px"
+                  showLineNumbers={true}
+                  language={language}
+                />
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+/**
+ * Parse and render tool calls from message content, replacing codeblock
+ * tool markers with structured RichToolCall cards.
+ *
+ * Used by ChatMessage to transform assistant messages that contain tool calls.
+ */
+export function renderToolCallsFromContent(
+  content: string,
+  completedTools?: Map<string, { success: boolean; durationMs: number }>
+): { content: string; toolCalls: React.ReactNode[] } {
+  // Match gptme markdown tool calls: ```toolname
+  const codeblockRegex = /```(\w+)(\s+[^\n]*)?\n([\s\S]*?)```/g;
+  const toolCalls: React.ReactNode[] = [];
+  let cleanedContent = content;
+
+  let match: RegExpExecArray | null;
+  let callIndex = 0;
+  const matches: Array<{ start: number; end: number; tool: string; args: string; body: string }> =
+    [];
+
+  // Collect all matches first
+  while ((match = codeblockRegex.exec(content)) !== null) {
+    matches.push({
+      start: match.index,
+      end: match.index + match[0].length,
+      tool: match[1],
+      args: (match[2] || '').trim(),
+      body: match[3].trim(),
+    });
+  }
+
+  // If no tool calls found, return original content
+  if (matches.length === 0) {
+    return { content, toolCalls: [] };
+  }
+
+  // Process matches in reverse to preserve indices
+  for (let i = matches.length - 1; i >= 0; i--) {
+    const m = matches[i];
+    const args: string[] = [];
+    if (m.args) args.push(m.args);
+
+    // Check if first line of body looks like an arg
+    const bodyLines = m.body.split('\n');
+    if (bodyLines.length > 0) {
+      const firstLine = bodyLines[0].trim();
+      if (firstLine && !firstLine.startsWith('#') && !firstLine.startsWith('//') && !m.args) {
+        args.push(firstLine);
+      }
+    }
+
+    const toolUse: ToolUse = { tool: m.tool, args, content: m.body };
+    const key = `${m.tool}-${callIndex}`;
+    const compMeta = completedTools?.get(m.tool);
+    toolCalls.unshift(
+      <RichToolCall
+        key={key}
+        toolUse={toolUse}
+        completed={compMeta?.success ?? null}
+        durationMs={compMeta?.durationMs}
+      />
+    );
+    callIndex++;
+
+    // Remove the codeblock from the content (replace with placeholder for later reconstruction,
+    // or just remove it entirely since RichToolCall replaces it visually)
+    cleanedContent = cleanedContent.substring(0, m.start) + cleanedContent.substring(m.end);
+  }
+
+  // Clean up double-newlines created by removal
+  cleanedContent = cleanedContent.replace(/\n{3,}/g, '\n\n').trim();
+
+  return { content: cleanedContent, toolCalls };
+}

--- a/webui/src/components/__tests__/RichToolCall.test.tsx
+++ b/webui/src/components/__tests__/RichToolCall.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect } from '@jest/globals';
+import { renderToolCallsFromContent } from '../RichToolCall';
+
+describe('renderToolCallsFromContent', () => {
+  it('returns original content when no tool calls', () => {
+    const result = renderToolCallsFromContent('just some text\nwithout any codeblocks');
+    expect(result.content).toBe('just some text\nwithout any codeblocks');
+    expect(result.toolCalls).toHaveLength(0);
+  });
+
+  it('extracts tool calls from markdown codeblocks', () => {
+    const content = `Let me save this file:
+
+\`\`\`save
+/home/user/test.ts
+const x = 1;
+\`\`\``;
+    const result = renderToolCallsFromContent(content);
+    expect(result.content).toContain('Let me save this file');
+    expect(result.toolCalls.length).toBeGreaterThan(0);
+    // The codeblock should be removed from content
+    expect(result.content).not.toContain('```save');
+  });
+
+  it('handles multiple tool calls', () => {
+    const content = `First a shell command:
+
+\`\`\`shell
+echo hello
+\`\`\`
+
+Then save the file:
+
+\`\`\`save
+output.txt
+hello
+\`\`\``;
+    const result = renderToolCallsFromContent(content);
+    expect(result.toolCalls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('attaches completion metadata when provided', () => {
+    const content = `\`\`\`shell
+ls -la
+\`\`\``;
+    const completedTools = new Map([['shell', { success: true, durationMs: 1234 }]]);
+    const result = renderToolCallsFromContent(content, completedTools);
+    expect(result.toolCalls.length).toBeGreaterThan(0);
+  });
+
+  it('handles empty content gracefully', () => {
+    const result = renderToolCallsFromContent('');
+    expect(result.content).toBe('');
+    expect(result.toolCalls).toHaveLength(0);
+  });
+
+  it('preserves non-codeblock text', () => {
+    const content = `I will now run:
+
+\`\`\`shell
+npm test
+\`\`\`
+
+The tests should pass.`;
+    const result = renderToolCallsFromContent(content);
+    expect(result.content).toContain('I will now run:');
+    expect(result.content).toContain('The tests should pass.');
+  });
+});

--- a/webui/src/components/__tests__/RichToolCall.test.tsx
+++ b/webui/src/components/__tests__/RichToolCall.test.tsx
@@ -43,7 +43,7 @@ hello
     const content = `\`\`\`shell
 ls -la
 \`\`\``;
-    const completedTools = new Map([['shell', { success: true, durationMs: 1234 }]]);
+    const completedTools = new Map([[0, { success: true, durationMs: 1234 }]]);
     const result = renderToolCallsFromContent(content, completedTools);
     expect(result.toolCalls.length).toBeGreaterThan(0);
   });
@@ -65,5 +65,46 @@ The tests should pass.`;
     const result = renderToolCallsFromContent(content);
     expect(result.content).toContain('I will now run:');
     expect(result.content).toContain('The tests should pass.');
+  });
+
+  it('ignores non-tool language codeblocks (e.g. js, python)', () => {
+    const content = `Here is some code:
+
+\`\`\`js
+const x = 1;
+\`\`\`
+
+And a real tool call:
+
+\`\`\`shell
+echo hi
+\`\`\``;
+    const result = renderToolCallsFromContent(content);
+    expect(result.toolCalls).toHaveLength(1);
+    // The js block should remain in the cleaned content
+    expect(result.content).toContain('```js');
+    expect(result.content).toContain('const x = 1;');
+    // The shell block should be removed (rendered as RichToolCall)
+    expect(result.content).not.toContain('```shell');
+  });
+
+  it('uses per-index completion metadata, not per-tool-name', () => {
+    const content = `\`\`\`shell
+echo first
+\`\`\`
+
+\`\`\`shell
+echo second
+\`\`\``;
+    const completedTools = new Map([
+      [0, { success: true, durationMs: 100 }],
+      [1, { success: false, durationMs: 200 }],
+    ]);
+    const result = renderToolCallsFromContent(content, completedTools);
+    expect(result.toolCalls).toHaveLength(2);
+    // Keys should be unique per occurrence, not per tool name
+    const keys = result.toolCalls.map((node: any) => node?.key);
+    expect(new Set(keys).size).toBe(2);
+    expect(keys[0]).not.toBe(keys[1]);
   });
 });

--- a/webui/src/utils/__tests__/stepGrouping.test.ts
+++ b/webui/src/utils/__tests__/stepGrouping.test.ts
@@ -288,4 +288,29 @@ describe('buildStepRoles', () => {
     expect(roles.get(6)?.type).toBe('grouped');
     expect(Array.from(roles.values()).some((role) => role.type === 'response')).toBe(false);
   });
+
+  it('ignores non-tool fenced codeblocks when building step summaries', () => {
+    const messages = [
+      msg('user', 'save this example'), // 0
+      msg(
+        'assistant',
+        'Example first:\n\n```typescript\nconsole.log("demo");\n```\n\nThen save it:\n\n```save hello.ts\nconsole.log("hi");\n```'
+      ), // 1
+      msg('system', 'Saved to hello.ts'), // 2
+      msg('assistant', 'Done'), // 3
+    ];
+
+    const roles = buildStepRoles(messages, neverHidden);
+    const start = roles.get(1);
+    expect(start?.type).toBe('group-start');
+    if (start?.type === 'group-start') {
+      expect(start.steps).toEqual([
+        {
+          tool: 'save',
+          arg: 'hello.ts',
+          snippet: 'console.log("hi");',
+        },
+      ]);
+    }
+  });
 });

--- a/webui/src/utils/__tests__/toolCallParser.test.ts
+++ b/webui/src/utils/__tests__/toolCallParser.test.ts
@@ -12,6 +12,7 @@ describe('toolCallParser', () => {
       ['save', 'file'],
       ['append', 'file'],
       ['patch', 'file'],
+      ['morph', 'file'],
       ['read', 'file'],
       ['ls', 'file'],
       ['shell', 'shell'],

--- a/webui/src/utils/__tests__/toolCallParser.test.ts
+++ b/webui/src/utils/__tests__/toolCallParser.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from '@jest/globals';
+import {
+  getToolSummary,
+  getToolCategory,
+  CATEGORY_COLORS,
+  CATEGORY_BORDER_ONLY,
+} from '../toolCallParser';
+
+describe('toolCallParser', () => {
+  describe('getToolCategory', () => {
+    it.each([
+      ['save', 'file'],
+      ['append', 'file'],
+      ['patch', 'file'],
+      ['read', 'file'],
+      ['ls', 'file'],
+      ['shell', 'shell'],
+      ['tmux', 'shell'],
+      ['ipython', 'code'],
+      ['python', 'code'],
+      ['browser', 'browser'],
+      ['chrome-devtools', 'browser'],
+      ['vision', 'vision'],
+      ['screenshot', 'vision'],
+      ['unknown_tool', 'generic'],
+    ])('maps %s to %s', (tool, expected) => {
+      expect(getToolCategory(tool)).toBe(expected);
+    });
+  });
+
+  describe('getToolSummary', () => {
+    it('uses first arg when available and short', () => {
+      const summary = getToolSummary({
+        tool: 'save',
+        args: ['/path/to/file.ts'],
+        content: 'export const foo = 1;',
+      });
+      expect(summary).toBe('/path/to/file.ts');
+    });
+
+    it('truncates long args', () => {
+      const veryLong = 'a'.repeat(80);
+      const summary = getToolSummary({
+        tool: 'save',
+        args: [veryLong],
+        content: '',
+      });
+      expect(summary.length).toBeLessThanOrEqual(60);
+      expect(summary.endsWith('...')).toBe(true);
+    });
+
+    it('falls back to content when no args', () => {
+      const summary = getToolSummary({
+        tool: 'shell',
+        args: [],
+        content: 'echo "hello world"',
+      });
+      expect(summary).toBe('echo "hello world"');
+    });
+
+    it('falls back to tool name when empty', () => {
+      const summary = getToolSummary({
+        tool: 'unknown',
+        args: [],
+        content: '',
+      });
+      expect(summary).toBe('unknown');
+    });
+
+    it('truncates long content lines', () => {
+      const veryLong = 'echo ' + 'x'.repeat(100);
+      const summary = getToolSummary({
+        tool: 'shell',
+        args: [],
+        content: veryLong,
+      });
+      expect(summary.length).toBeLessThanOrEqual(80);
+      expect(summary.endsWith('...')).toBe(true);
+    });
+  });
+
+  describe('category color maps', () => {
+    it('has entries for all categories', () => {
+      const categories = ['file', 'shell', 'code', 'browser', 'vision', 'generic'] as const;
+      for (const cat of categories) {
+        expect(CATEGORY_COLORS[cat]).toBeTruthy();
+        expect(CATEGORY_BORDER_ONLY[cat]).toBeTruthy();
+      }
+    });
+  });
+});

--- a/webui/src/utils/stepGrouping.ts
+++ b/webui/src/utils/stepGrouping.ts
@@ -1,4 +1,5 @@
 import type { Message } from '@/types/conversation';
+import { isKnownTool } from './toolCallParser';
 
 /** Detail about a single tool call within a step group */
 export interface ToolStepDetail {
@@ -60,6 +61,7 @@ function extractToolSteps(content: string): ToolStepDetail[] {
   let match: RegExpExecArray | null;
   while ((match = regex.exec(content)) !== null) {
     const tool = match[1];
+    if (!isKnownTool(tool)) continue;
     const inlineArg = (match[2] || '').trim();
     const blockContent = match[3].trim();
 

--- a/webui/src/utils/stepGrouping.ts
+++ b/webui/src/utils/stepGrouping.ts
@@ -1,8 +1,25 @@
 import type { Message } from '@/types/conversation';
 
+/** Detail about a single tool call within a step group */
+export interface ToolStepDetail {
+  tool: string;
+  /** Short arg for display (filename, command, path) */
+  arg: string;
+  /** First line or brief snippet of the tool content */
+  snippet: string;
+}
+
 /** Role each message index plays in step grouping */
 export type StepRole =
-  | { type: 'group-start'; groupId: number; count: number; tools: string[] } // first hidden step — render summary
+  | {
+      type: 'group-start';
+      groupId: number;
+      count: number;
+      tools: string[];
+      /** Rich detail for each tool call step (in order). Present when we have assistant
+       *  messages with codeblock content to parse. */
+      steps?: ToolStepDetail[];
+    }
   | { type: 'grouped'; groupId: number } // hidden step (collapsed)
   | { type: 'response' }; // final assistant response — always visible
 
@@ -21,6 +38,62 @@ function detectTool(content: string): string | null {
     return 'shell';
   if (first.startsWith('ran ')) return 'shell';
   return null;
+}
+
+/**
+ * Extract tool-call details from an assistant message's content.
+ *
+ * Parses markdown codeblocks like:
+ *   ```save hello.py
+ *   print("hi")
+ *   ```
+ *   ```shell
+ *   Some output here...
+ *   ```
+ *
+ * Returns the tool name, a short arg for display, and a content snippet.
+ */
+function extractToolSteps(content: string): ToolStepDetail[] {
+  const steps: ToolStepDetail[] = [];
+  const regex = /```(\w+)(?:\s+([^\n]*))?\n([\s\S]*?)```/g;
+
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(content)) !== null) {
+    const tool = match[1];
+    const inlineArg = (match[2] || '').trim();
+    const blockContent = match[3].trim();
+
+    // Build display arg and snippet
+    let arg = inlineArg;
+    let snippet = '';
+
+    if (!arg) {
+      // No inline arg — use first meaningful line of block content
+      const firstLine = blockContent.split('\n')[0].trim();
+      if (firstLine && !firstLine.startsWith('#') && !firstLine.startsWith('//')) {
+        arg = firstLine;
+        snippet = blockContent.split('\n').slice(1).join('\n').trim();
+      } else {
+        snippet = blockContent;
+      }
+    } else {
+      snippet = blockContent;
+    }
+
+    // Truncate arg for display
+    if (arg && arg.length > 50) {
+      arg = arg.substring(0, 47) + '...';
+    }
+
+    // Truncate snippet for group summary
+    if (snippet && snippet.length > 30) {
+      snippet = snippet.split('\n')[0].substring(0, 27) + '...';
+    }
+
+    steps.push({ tool, arg, snippet });
+  }
+
+  return steps;
 }
 
 /**
@@ -93,12 +166,18 @@ export function buildStepRoles(
       // Detect tools used and count tool-call steps (system messages = tool results)
       const toolSet = new Set<string>();
       let toolCallCount = 0;
+      const allSteps: ToolStepDetail[] = [];
+
       for (const idx of stepIndices) {
         const msg = messages[idx];
         if (msg.role === 'system') {
           toolCallCount++;
           const tool = detectTool(msg.content);
           if (tool) toolSet.add(tool);
+        } else if (msg.role === 'assistant' && msg.content) {
+          // Extract rich tool-call detail from assistant messages
+          const extracted = extractToolSteps(msg.content);
+          allSteps.push(...extracted);
         }
       }
 
@@ -108,12 +187,19 @@ export function buildStepRoles(
       const stableGroupId = firstIdx;
 
       // count = tool-call steps (not raw messages); fall back to message count if no system msgs
-      roles.set(firstIdx, {
+      const groupStart: Extract<StepRole, { type: 'group-start' }> = {
         type: 'group-start',
         groupId: stableGroupId,
         count: toolCallCount || stepIndices.length,
         tools: Array.from(toolSet),
-      });
+      };
+
+      // Only include steps when we have useful detail (don't bloat the object)
+      if (allSteps.length > 0) {
+        groupStart.steps = allSteps;
+      }
+
+      roles.set(firstIdx, groupStart);
 
       // Mark the rest as grouped (hidden when collapsed)
       for (let k = 1; k < stepIndices.length; k++) {

--- a/webui/src/utils/toolCallParser.ts
+++ b/webui/src/utils/toolCallParser.ts
@@ -1,6 +1,34 @@
 import type { ToolUse } from '@/types/conversation';
 
 /**
+ * Known gptme tool names. Used to distinguish tool-call codeblocks
+ * from ordinary markdown language-tagged fences (e.g. ```python for
+ * a code example).
+ */
+export const GPTME_TOOL_ALLOWLIST = new Set([
+  'shell',
+  'tmux',
+  'ipython',
+  'python',
+  'save',
+  'append',
+  'patch',
+  'morph',
+  'read',
+  'browser',
+  'vision',
+  'gh',
+  'mcp',
+  'think',
+  'ask',
+  'subagent',
+]);
+
+export function isKnownTool(name: string): boolean {
+  return GPTME_TOOL_ALLOWLIST.has(name.toLowerCase());
+}
+
+/**
  * Parse ToolUse objects from markdown codeblock content.
  *
  * Tool calls in gptme messages appear as fenced markdown codeblocks
@@ -14,6 +42,8 @@ export function parseToolCalls(content: string): ToolUse[] {
   let match: RegExpExecArray | null;
   while ((match = codeblockRegex.exec(content)) !== null) {
     const tool = match[1];
+    if (!isKnownTool(tool)) continue;
+
     const inlineArgs = match[2]?.trim() || '';
     const blockContent = match[3].trim();
 

--- a/webui/src/utils/toolCallParser.ts
+++ b/webui/src/utils/toolCallParser.ts
@@ -118,6 +118,7 @@ const TOOL_CATEGORY_MAP: Record<string, ToolCategory> = {
   save: 'file',
   append: 'file',
   patch: 'file',
+  morph: 'file',
   read: 'file',
   ls: 'file',
   shell: 'shell',

--- a/webui/src/utils/toolCallParser.ts
+++ b/webui/src/utils/toolCallParser.ts
@@ -1,0 +1,123 @@
+import type { ToolUse } from '@/types/conversation';
+
+/**
+ * Parse ToolUse objects from markdown codeblock content.
+ *
+ * Tool calls in gptme messages appear as fenced markdown codeblocks
+ * where the "language" tag is the tool name, the first line(s) of
+ * content are args, and the rest is the code/command body.
+ */
+export function parseToolCalls(content: string): ToolUse[] {
+  const results: ToolUse[] = [];
+  const codeblockRegex = /```(\w+)(?:\s+([^\n]*))?\n([\s\S]*?)```/g;
+
+  let match: RegExpExecArray | null;
+  while ((match = codeblockRegex.exec(content)) !== null) {
+    const tool = match[1];
+    const inlineArgs = match[2]?.trim() || '';
+    const blockContent = match[3].trim();
+
+    // Build args array: first the inline args (after tool name on opening fence),
+    // then any leading comment-like lines from the block content that look like args
+    const args: string[] = [];
+    if (inlineArgs) {
+      args.push(inlineArgs);
+    }
+
+    // Check if first line of block content looks like an arg description
+    // (e.g., "Arguments:" prefix or a path-like string)
+    const lines = blockContent.split('\n');
+    if (lines.length > 0) {
+      const firstLine = lines[0].trim();
+      if (firstLine && !firstLine.startsWith('#') && !firstLine.startsWith('//')) {
+        // Could be a single-arg tool where the first line IS the arg
+        // (like save where first line is filename)
+        if (inlineArgs) {
+          // Already captured inline arg, first line is the actual content start
+        } else {
+          args.push(firstLine);
+        }
+      }
+    }
+
+    results.push({
+      tool,
+      args,
+      content: blockContent,
+    });
+  }
+
+  return results;
+}
+
+/**
+ * Get a short summary of a ToolUse for display in headers.
+ *
+ * Prioritizes the most informative one-line description:
+ * - For shell: the command itself (first 80 chars)
+ * - For save/append: the filename
+ * - For patch: the target file
+ * - For ipython: first non-empty line of content
+ */
+export function getToolSummary(toolUse: ToolUse): string {
+  const { tool, args, content } = toolUse;
+
+  // Use args if available
+  if (args && args.length > 0) {
+    const firstArg = args[0].trim();
+    if (firstArg.length <= 60) return firstArg;
+    return firstArg.substring(0, 57) + '...';
+  }
+
+  // Fall back to first line of content
+  if (content) {
+    const firstLine = content.split('\n')[0].trim();
+    if (firstLine && firstLine.length <= 80) return firstLine;
+    if (firstLine) return firstLine.substring(0, 77) + '...';
+  }
+
+  return tool || 'unknown';
+}
+
+/**
+ * Get tool category for color-coding and icon selection.
+ */
+export type ToolCategory = 'file' | 'shell' | 'code' | 'browser' | 'vision' | 'generic';
+
+const TOOL_CATEGORY_MAP: Record<string, ToolCategory> = {
+  save: 'file',
+  append: 'file',
+  patch: 'file',
+  read: 'file',
+  ls: 'file',
+  shell: 'shell',
+  tmux: 'shell',
+  ipython: 'code',
+  python: 'code',
+  browser: 'browser',
+  'chrome-devtools': 'browser',
+  vision: 'vision',
+  screenshot: 'vision',
+};
+
+export function getToolCategory(tool: string): ToolCategory {
+  return TOOL_CATEGORY_MAP[tool.toLowerCase()] || 'generic';
+}
+
+export const CATEGORY_COLORS: Record<ToolCategory, string> = {
+  file: 'border-blue-200 bg-blue-50 dark:border-blue-800 dark:bg-blue-950/20',
+  shell: 'border-green-200 bg-green-50 dark:border-green-800 dark:bg-green-950/20',
+  code: 'border-purple-200 bg-purple-50 dark:border-purple-800 dark:bg-purple-950/20',
+  browser: 'border-orange-200 bg-orange-50 dark:border-orange-800 dark:bg-orange-950/20',
+  vision: 'border-pink-200 bg-pink-50 dark:border-pink-800 dark:bg-pink-950/20',
+  generic: 'border-gray-200 bg-gray-50 dark:border-gray-800 dark:bg-gray-950/20',
+};
+
+export const CATEGORY_BORDER_ONLY: Record<ToolCategory, string> = {
+  file: 'border-l-blue-400 dark:border-l-blue-500',
+  shell: 'border-l-green-400 dark:border-l-green-500',
+  code: 'border-l-purple-400 dark:border-l-purple-500',
+  browser: 'border-l-orange-400 dark:border-l-orange-500',
+  vision: 'border-l-pink-400 dark:border-l-pink-500',
+  generic: 'border-l-gray-400 dark:border-l-gray-500',
+};


### PR DESCRIPTION
## What

Adds structured, collapsible tool call cards to the conversation view to make tool calls more scannable. Currently `InlineToolExecution.tsx` shows raw tool names with code blocks — this adds:

1. **`RichToolCall` component** — collapsible card with tool icon, category-colored left border, expandable args + content, and status badges (spinner/check/X)
2. **`toolCallParser.ts`** — utility for parsing `ToolUse` objects from message content, with tool category classification (file/shell/code/browser/vision/generic) for color-coding
3. **Enhanced `CollapsedStepGroup`** — now shows individual tool icons + names instead of a plain text summary for each tool call in collapsed step groups
4. **Enhanced `stepGrouping.ts`** — `buildStepRoles()` now extracts detailed tool info (`ToolStepDetail` with tool name and summary) for richer collapsed summaries

## Why

The current `InlineToolExecution` shows raw function name + input code block. A structured visualization (tool icon, name, key param summary, expandable args, collapsible output) reduces cognitive load and makes it easier to scan conversation history for specific tool calls. Builds on the idea from #428 in my backlog.

## Scope

- New `RichToolCall.tsx` component with category-colored borders
- New `toolCallParser.ts` utility
- Enhanced `CollapsedStepGroup` with per-tool icons
- Enhanced `stepGrouping.ts` with `ToolStepDetail` type
- 42 tests across 3 test suites (all green)
- TypeScript clean

## Related

- Task: `gptme-webui-tool-call-visualization`
- Idea: #428 in TimeToBuildBob/bob idea backlog