### PR TITLE
feat(webui): add config file editor

### DIFF
--- a/gptme/config/user.py
+++ b/gptme/config/user.py
@@ -259,9 +259,7 @@ def _load_config_doc(path: str | None = None) -> tomlkit.TOMLDocument:
     return doc
 
 
-def set_config_value(
-    key: str, value: str, reload: bool = True
-) -> None:  # pragma: no cover
+def set_config_value(key: str, value: Any, reload: bool = True) -> None:
     """Set a value in the user config file."""
     doc: TOMLDocument | Container = _load_config_doc()
 

--- a/gptme/config/user.py
+++ b/gptme/config/user.py
@@ -259,21 +259,42 @@ def _load_config_doc(path: str | None = None) -> tomlkit.TOMLDocument:
     return doc
 
 
-def set_config_value(key: str, value: Any, reload: bool = True) -> None:
-    """Set a value in the user config file."""
-    doc: TOMLDocument | Container = _load_config_doc()
+def set_config_value(
+    key: str, value: Any, reload: bool = True, local: bool = False
+) -> None:
+    """Set a value in the user config file.
+
+    Args:
+        key: Dot-separated key path (e.g. "env.ANTHROPIC_API_KEY").
+        value: Value to set. Type is preserved in the TOML output.
+        reload: Whether to reload the in-memory config after writing.
+        local: If True, write to config.local.toml instead of config.toml.
+               Use for secrets (API keys) that should not be in the shared config.
+    """
+    if local:
+        _, local_path = get_user_config_paths()
+        write_path = str(local_path)
+        # Load existing local config or start empty (no defaults)
+        doc: TOMLDocument | Container = (
+            _load_config_doc(write_path) if local_path.exists() else tomlkit.document()
+        )
+    else:
+        write_path = config_path
+        doc = _load_config_doc()
 
     # Set the value
     keypath = key.split(".")
     d: TOMLDocument | Container = doc
-    for key in keypath[:-1]:
-        if key not in d:
-            d[key] = tomlkit.table()
-        d = d[key]  # type: ignore[assignment]
+    for k in keypath[:-1]:
+        if k not in d:
+            d[k] = tomlkit.table()
+        d = d[k]  # type: ignore[assignment]
     d[keypath[-1]] = value
 
     # Write the config
-    with open(config_path, "w") as config_file:
+    if local:
+        os.makedirs(os.path.dirname(write_path), exist_ok=True)
+    with open(write_path, "w") as config_file:
         tomlkit.dump(doc, config_file)
 
     if reload:

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -1696,9 +1696,9 @@ def api_user_api_key():
         return flask.jsonify({"error": str(exc)}), 400
 
     env_var = PROVIDER_API_KEYS[provider]
-    set_config_value(f"env.{env_var}", trimmed_api_key, reload=False)
+    set_config_value(f"env.{env_var}", trimmed_api_key, reload=False, local=True)
     if trimmed_model is not None:
-        set_config_value("env.MODEL", trimmed_model, reload=False)
+        set_config_value("env.MODEL", trimmed_model, reload=False, local=True)
 
     # Apply the new key immediately so the running server picks it up without restart.
     # os.environ takes priority over the config file in Config.get_env(), so the next

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -1846,6 +1846,9 @@ def api_user_config_file_put():
     config_file, _local_path = get_user_config_paths()
     config_file.parent.mkdir(parents=True, exist_ok=True)
     config_file.write_text(content)
+    from gptme.config.core import reload_config
+
+    reload_config()
 
     response = _get_user_config_file_response(content)
     response["status"] = "ok"

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -1878,7 +1878,7 @@ def api_user_config_file_patch():
     reload_config = req_json.get("reload", True)
     if not isinstance(key, str):
         return flask.jsonify({"error": "key must be a string"}), 400
-    if not isinstance(value, (str, int, float, bool)):
+    if not isinstance(value, str | int | float | bool):
         return flask.jsonify(
             {"error": "value must be a JSON scalar (string, number, or boolean)"}
         ), 400

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import Literal, cast
 
 import flask
+import tomlkit
 from dateutil.parser import isoparse
 from flask import request
 
@@ -42,7 +43,11 @@ from gptme.prompts import get_prompt
 
 from ..commands import handle_cmd
 from ..config import get_project_config
-from ..config.user import get_user_config_env_source, get_user_config_runtime_info
+from ..config.user import (
+    get_user_config_env_source,
+    get_user_config_paths,
+    get_user_config_runtime_info,
+)
 from ..dirs import get_logs_dir
 from ..logmanager import Log, LogManager, get_user_conversations
 from ..message import Message
@@ -73,6 +78,11 @@ from .openapi_docs import (
     StatusResponse,
     UserApiKeySaveRequest,
     UserApiKeySaveResponse,
+    UserConfigFilePatchRequest,
+    UserConfigFilePatchResponse,
+    UserConfigFileResponse,
+    UserConfigFileSaveRequest,
+    UserConfigFileSaveResponse,
     UserDefaultModelSaveRequest,
     UserDefaultModelSaveResponse,
     UserSettingsResponse,
@@ -178,6 +188,36 @@ def _validate_api_key_input(api_key: str) -> str:
         raise ValueError("API key is too long")
     if any(ord(ch) < 32 or ord(ch) == 127 for ch in trimmed):
         raise ValueError("API key contains control characters")
+    return trimmed
+
+
+def _get_user_config_file_response(content: str) -> dict[str, str | bool]:
+    """Return raw config text with the same path metadata as user settings."""
+    runtime_info = get_user_config_runtime_info()
+    return {
+        "content": content,
+        "path": runtime_info["config_path"],
+        "write_target": runtime_info["write_target"],
+        "local_config_path": runtime_info["local_config_path"],
+        "local_config_exists": runtime_info["local_config_exists"],
+        "local_overrides_main": runtime_info["local_overrides_main"],
+    }
+
+
+def _read_user_config_file_text() -> str:
+    """Read config.toml, creating the default file first if it is missing."""
+    config_file, _local_path = get_user_config_paths()
+    if not config_file.exists():
+        load_user_config()
+    return config_file.read_text()
+
+
+def _validate_config_key_path(key: str) -> str:
+    trimmed = key.strip()
+    if not trimmed:
+        raise ValueError("key must not be empty")
+    if any(not segment.strip() for segment in trimmed.split(".")):
+        raise ValueError("key must be a dotted path with non-empty segments")
     return trimmed
 
 
@@ -1758,6 +1798,101 @@ def api_user_avatar():
         return flask.jsonify({"error": "Avatar must be a valid image file"}), 400
 
     return flask.send_file(full_path)
+
+
+@v2_api.route("/api/v2/user/config-file", methods=["GET"])
+@require_auth
+@api_doc(
+    summary="Get raw user config file",
+    description="Return the raw TOML contents of the user's main config.toml file.",
+    responses={200: UserConfigFileResponse},
+    tags=["user"],
+)
+def api_user_config_file_get():
+    """Return raw config.toml contents for the settings UI."""
+    content = _read_user_config_file_text()
+    return flask.jsonify(_get_user_config_file_response(content))
+
+
+@v2_api.route("/api/v2/user/config-file", methods=["PUT"])
+@require_auth
+@api_doc(
+    summary="Replace raw user config file",
+    description=(
+        "Validate and replace the user's main config.toml file. "
+        "Malformed TOML is rejected before anything is written."
+    ),
+    request_body=UserConfigFileSaveRequest,
+    responses={200: UserConfigFileSaveResponse, 400: ErrorResponse},
+    tags=["user"],
+)
+def api_user_config_file_put():
+    """Replace config.toml with validated TOML text."""
+    req_json = request.get_json(silent=True)
+    if req_json is None:
+        return flask.jsonify({"error": "No JSON data provided"}), 400
+    if not isinstance(req_json, dict):
+        return flask.jsonify({"error": "JSON body must be an object"}), 400
+
+    content = req_json.get("content")
+    if not isinstance(content, str):
+        return flask.jsonify({"error": "content must be a string"}), 400
+
+    try:
+        tomlkit.loads(content)
+    except Exception as exc:
+        return flask.jsonify({"error": f"Invalid TOML: {exc}"}), 400
+
+    config_file, _local_path = get_user_config_paths()
+    config_file.parent.mkdir(parents=True, exist_ok=True)
+    config_file.write_text(content)
+
+    response = _get_user_config_file_response(content)
+    response["status"] = "ok"
+    return flask.jsonify(response)
+
+
+@v2_api.route("/api/v2/user/config-file", methods=["PATCH"])
+@require_auth
+@api_doc(
+    summary="Update one user config value",
+    description=(
+        "Update a single dotted key path in the user's main config.toml file "
+        "using the same persistence helper as the server settings endpoints."
+    ),
+    request_body=UserConfigFilePatchRequest,
+    responses={200: UserConfigFilePatchResponse, 400: ErrorResponse},
+    tags=["user"],
+)
+def api_user_config_file_patch():
+    """Persist one dotted key path into config.toml."""
+    req_json = request.get_json(silent=True)
+    if req_json is None:
+        return flask.jsonify({"error": "No JSON data provided"}), 400
+    if not isinstance(req_json, dict):
+        return flask.jsonify({"error": "JSON body must be an object"}), 400
+
+    key = req_json.get("key")
+    value = req_json.get("value")
+    reload_config = req_json.get("reload", True)
+    if not isinstance(key, str):
+        return flask.jsonify({"error": "key must be a string"}), 400
+    if not isinstance(value, str):
+        return flask.jsonify({"error": "value must be a string"}), 400
+    if not isinstance(reload_config, bool):
+        return flask.jsonify({"error": "reload must be a boolean"}), 400
+
+    try:
+        key = _validate_config_key_path(key)
+    except ValueError as exc:
+        return flask.jsonify({"error": str(exc)}), 400
+
+    set_config_value(key, value, reload=reload_config)
+    content = _read_user_config_file_text()
+    response = _get_user_config_file_response(content)
+    response["status"] = "ok"
+    response["key"] = key
+    return flask.jsonify(response)
 
 
 @v2_api.route("/api/v2/user/settings", methods=["GET"])

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -1857,8 +1857,9 @@ def api_user_config_file_put():
 @api_doc(
     summary="Update one user config value",
     description=(
-        "Update a single dotted key path in the user's main config.toml file "
-        "using the same persistence helper as the server settings endpoints."
+        "Update a single dotted key path in the user's main config.toml file. "
+        "JSON scalar values preserve their TOML type on write: strings stay "
+        "strings, booleans stay booleans, and numbers stay numbers."
     ),
     request_body=UserConfigFilePatchRequest,
     responses={200: UserConfigFilePatchResponse, 400: ErrorResponse},
@@ -1877,8 +1878,10 @@ def api_user_config_file_patch():
     reload_config = req_json.get("reload", True)
     if not isinstance(key, str):
         return flask.jsonify({"error": "key must be a string"}), 400
-    if not isinstance(value, str):
-        return flask.jsonify({"error": "value must be a string"}), 400
+    if not isinstance(value, (str, int, float, bool)):
+        return flask.jsonify(
+            {"error": "value must be a JSON scalar (string, number, or boolean)"}
+        ), 400
     if not isinstance(reload_config, bool):
         return flask.jsonify({"error": "reload must be a boolean"}), 400
 

--- a/gptme/server/openapi_docs.py
+++ b/gptme/server/openapi_docs.py
@@ -207,6 +207,50 @@ class UserDefaultModelSaveResponse(BaseModel):
     )
 
 
+class UserConfigFileResponse(BaseModel):
+    """Raw user config file contents plus path metadata."""
+
+    content: str = Field(..., description="Raw TOML contents of config.toml")
+    path: str = Field(..., description="Main config file path")
+    write_target: str = Field(..., description="Config path writes are applied to")
+    local_config_path: str = Field(..., description="Local override config path")
+    local_config_exists: bool = Field(
+        ..., description="Whether config.local.toml exists"
+    )
+    local_overrides_main: bool = Field(
+        True, description="Whether local config values override main config values"
+    )
+
+
+class UserConfigFileSaveRequest(BaseModel):
+    """Request to replace the raw user config file."""
+
+    content: str = Field(..., description="Raw TOML contents to write to config.toml")
+
+
+class UserConfigFileSaveResponse(UserConfigFileResponse):
+    """Response after replacing the raw user config file."""
+
+    status: str = Field(..., description="Operation status")
+
+
+class UserConfigFilePatchRequest(BaseModel):
+    """Request to update one dotted key in the user config file."""
+
+    key: str = Field(..., description="Dotted key path, for example env.MODEL")
+    value: str = Field(..., description="String value to persist at the key path")
+    reload: bool = Field(
+        True, description="Whether to reload gptme config after writing the value"
+    )
+
+
+class UserConfigFilePatchResponse(UserConfigFileResponse):
+    """Response after updating one config value."""
+
+    status: str = Field(..., description="Operation status")
+    key: str = Field(..., description="Dotted key path that was updated")
+
+
 class UserSettingsResponse(BaseModel):
     """Current user settings state (read-only snapshot)."""
 

--- a/gptme/server/openapi_docs.py
+++ b/gptme/server/openapi_docs.py
@@ -238,7 +238,13 @@ class UserConfigFilePatchRequest(BaseModel):
     """Request to update one dotted key in the user config file."""
 
     key: str = Field(..., description="Dotted key path, for example env.MODEL")
-    value: str = Field(..., description="String value to persist at the key path")
+    value: str | int | float | bool = Field(
+        ...,
+        description=(
+            "JSON scalar value to persist at the key path. Strings remain "
+            "strings; booleans and numbers keep their TOML type."
+        ),
+    )
     reload: bool = Field(
         True, description="Whether to reload gptme config after writing the value"
     )

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -323,6 +323,109 @@ def test_v2_user_default_model_rejects_unqualified_model(client: FlaskClient):
     assert data == {"error": "model must be fully qualified as provider/model"}
 
 
+def test_v2_user_config_file_get_reads_raw_toml(
+    client: FlaskClient, tmp_path, monkeypatch
+):
+    """GET /api/v2/user/config-file should return the raw main config.toml text."""
+    import gptme.config.user as user_mod
+
+    config_file = tmp_path / "config.toml"
+    config_file.write_text('[env]\nMODEL = "anthropic/claude-sonnet-4-7"\n')
+    monkeypatch.setattr(user_mod, "config_path", str(config_file))
+
+    response = client.get("/api/v2/user/config-file")
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["content"] == '[env]\nMODEL = "anthropic/claude-sonnet-4-7"\n'
+    assert data["path"] == str(config_file)
+    assert data["write_target"] == str(config_file)
+    assert data["local_config_exists"] is False
+
+
+def test_v2_user_config_file_get_creates_missing_config(
+    client: FlaskClient, tmp_path, monkeypatch
+):
+    """GET should create the default config.toml when the file is missing."""
+    import gptme.config.user as user_mod
+
+    config_file = tmp_path / "config.toml"
+    monkeypatch.setattr(user_mod, "config_path", str(config_file))
+
+    response = client.get("/api/v2/user/config-file")
+
+    assert response.status_code == 200
+    assert config_file.exists()
+    assert response.get_json()["content"] == config_file.read_text()
+
+
+def test_v2_user_config_file_put_validates_and_writes_toml(
+    client: FlaskClient, tmp_path, monkeypatch
+):
+    """PUT /api/v2/user/config-file should reject bad TOML and write valid TOML."""
+    import gptme.config.user as user_mod
+
+    config_file = tmp_path / "config.toml"
+    config_file.write_text('[env]\nMODEL = "old/model"\n')
+    monkeypatch.setattr(user_mod, "config_path", str(config_file))
+
+    invalid_response = client.put(
+        "/api/v2/user/config-file",
+        json={"content": "[env\nMODEL = broken"},
+    )
+    assert invalid_response.status_code == 400
+    assert "Invalid TOML" in invalid_response.get_json()["error"]
+    assert config_file.read_text() == '[env]\nMODEL = "old/model"\n'
+
+    valid_content = '[env]\nMODEL = "anthropic/claude-sonnet-4-7"\n'
+    response = client.put(
+        "/api/v2/user/config-file",
+        json={"content": valid_content},
+    )
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["status"] == "ok"
+    assert data["content"] == valid_content
+    assert config_file.read_text() == valid_content
+
+
+def test_v2_user_config_file_patch_updates_dotted_key(
+    client: FlaskClient, tmp_path, monkeypatch
+):
+    """PATCH /api/v2/user/config-file should persist one dotted key."""
+    import gptme.config.user as user_mod
+
+    config_file = tmp_path / "config.toml"
+    monkeypatch.setattr(user_mod, "config_path", str(config_file))
+
+    response = client.patch(
+        "/api/v2/user/config-file",
+        json={
+            "key": "env.MODEL",
+            "value": "anthropic/claude-sonnet-4-7",
+            "reload": False,
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["status"] == "ok"
+    assert data["key"] == "env.MODEL"
+    saved = tomlkit.loads(config_file.read_text()).unwrap()
+    assert saved["env"]["MODEL"] == "anthropic/claude-sonnet-4-7"
+
+
+def test_v2_user_config_file_patch_rejects_invalid_key(client: FlaskClient):
+    response = client.patch(
+        "/api/v2/user/config-file",
+        json={"key": "env..MODEL", "value": "anthropic/claude-sonnet-4-7"},
+    )
+
+    assert response.status_code == 400
+    assert "dotted path" in response.get_json()["error"]
+
+
 @pytest.mark.parametrize(
     "endpoint", ["/api/v2/user/api-key", "/api/v2/user/default-model"]
 )

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -198,7 +198,8 @@ def test_v2_user_api_key_persists_env_entry(client: FlaskClient, tmp_path, monke
         "restart_required": False,
     }
 
-    saved = tomlkit.loads(config_file.read_text()).unwrap()
+    local_file = tmp_path / "config.local.toml"
+    saved = tomlkit.loads(local_file.read_text()).unwrap()
     assert saved["env"]["ANTHROPIC_API_KEY"] == "sk-ant-test-key"
 
 
@@ -247,7 +248,8 @@ def test_v2_user_api_key_persists_default_model(
     )
 
     assert response.status_code == 200
-    saved = tomlkit.loads(config_file.read_text()).unwrap()
+    local_file = tmp_path / "config.local.toml"
+    saved = tomlkit.loads(local_file.read_text()).unwrap()
     assert saved["env"]["ANTHROPIC_API_KEY"] == "sk-ant-test-key"
     assert saved["env"]["MODEL"] == "anthropic/claude-sonnet-4-7"
 

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -416,6 +416,29 @@ def test_v2_user_config_file_patch_updates_dotted_key(
     assert saved["env"]["MODEL"] == "anthropic/claude-sonnet-4-7"
 
 
+def test_v2_user_config_file_patch_preserves_boolean_value(
+    client: FlaskClient, tmp_path, monkeypatch
+):
+    """PATCH /api/v2/user/config-file should preserve non-string JSON scalars."""
+    import gptme.config.user as user_mod
+
+    config_file = tmp_path / "config.toml"
+    monkeypatch.setattr(user_mod, "config_path", str(config_file))
+
+    response = client.patch(
+        "/api/v2/user/config-file",
+        json={
+            "key": "lessons.enabled",
+            "value": True,
+            "reload": False,
+        },
+    )
+
+    assert response.status_code == 200
+    saved = tomlkit.loads(config_file.read_text()).unwrap()
+    assert saved["lessons"]["enabled"] is True
+
+
 def test_v2_user_config_file_patch_rejects_invalid_key(client: FlaskClient):
     response = client.patch(
         "/api/v2/user/config-file",

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -366,8 +366,12 @@ def test_v2_user_config_file_put_validates_and_writes_toml(
     import gptme.config.user as user_mod
 
     config_file = tmp_path / "config.toml"
+    reload_calls: list[str] = []
     config_file.write_text('[env]\nMODEL = "old/model"\n')
     monkeypatch.setattr(user_mod, "config_path", str(config_file))
+    monkeypatch.setattr(
+        "gptme.config.core.reload_config", lambda: reload_calls.append("reload")
+    )
 
     invalid_response = client.put(
         "/api/v2/user/config-file",
@@ -388,6 +392,7 @@ def test_v2_user_config_file_put_validates_and_writes_toml(
     assert data["status"] == "ok"
     assert data["content"] == valid_content
     assert config_file.read_text() == valid_content
+    assert reload_calls == ["reload"]
 
 
 def test_v2_user_config_file_patch_updates_dotted_key(

--- a/webui/src/components/settings/ConfigFileEditor.tsx
+++ b/webui/src/components/settings/ConfigFileEditor.tsx
@@ -158,6 +158,18 @@ export function ConfigFileEditor() {
         </div>
       )}
 
+      {/\[\s*env\s*\]/.test(savedContent) && (
+        <div className="flex items-start gap-2 rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-200">
+          <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+          <span>
+            This config contains an <code className="text-xs">[env]</code> section. API keys stored
+            here are readable by anyone with access to this file. Use the <strong>API Keys</strong>{' '}
+            panel to manage provider keys — they are stored in{' '}
+            <code className="text-xs">config.local.toml</code> instead.
+          </span>
+        </div>
+      )}
+
       <div className="space-y-2">
         <Label htmlFor="settings-config-file-editor">TOML</Label>
         <Textarea

--- a/webui/src/components/settings/ConfigFileEditor.tsx
+++ b/webui/src/components/settings/ConfigFileEditor.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
-import { AlertCircle, RefreshCw, RotateCcw, Save } from 'lucide-react';
+import { AlertCircle, AlertTriangle, RefreshCw, RotateCcw, Save } from 'lucide-react';
 import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
@@ -144,6 +144,17 @@ export function ConfigFileEditor() {
         <div className="flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive">
           <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
           <span>{error}</span>
+        </div>
+      )}
+
+      {configFile?.local_config_exists && configFile?.local_overrides_main && (
+        <div className="flex items-start gap-2 rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-200">
+          <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+          <span>
+            A local override config also exists at{' '}
+            <code className="text-xs">{configFile.local_config_path}</code> and takes precedence.
+            Changes saved here may be shadowed by values in the local file.
+          </span>
         </div>
       )}
 

--- a/webui/src/components/settings/ConfigFileEditor.tsx
+++ b/webui/src/components/settings/ConfigFileEditor.tsx
@@ -1,0 +1,189 @@
+import { useCallback, useEffect, useState } from 'react';
+import { AlertCircle, RefreshCw, RotateCcw, Save } from 'lucide-react';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { useApi } from '@/contexts/ApiContext';
+
+type ConfigFileResponse = {
+  content: string;
+  path: string;
+  write_target: string;
+  local_config_path: string;
+  local_config_exists: boolean;
+  local_overrides_main: boolean;
+  status?: string;
+};
+
+type ConfigFileErrorResponse = {
+  error?: string;
+};
+
+async function parseConfigFileResponse(
+  response: Response,
+  fallbackMessage: string
+): Promise<ConfigFileResponse> {
+  const data = (await response.json().catch(() => null)) as
+    | ConfigFileResponse
+    | ConfigFileErrorResponse
+    | null;
+
+  if (!response.ok) {
+    throw new Error(data && 'error' in data && data.error ? data.error : fallbackMessage);
+  }
+
+  if (!data || !('content' in data)) {
+    throw new Error(fallbackMessage);
+  }
+
+  return data;
+}
+
+export function ConfigFileEditor() {
+  const { api } = useApi();
+  const [configFile, setConfigFile] = useState<ConfigFileResponse | null>(null);
+  const [content, setContent] = useState('');
+  const [savedContent, setSavedContent] = useState('');
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const requestHeaders = useCallback(
+    (json = false): Record<string, string> => {
+      const headers: Record<string, string> = {};
+      if (json) {
+        headers['Content-Type'] = 'application/json';
+      }
+      if (api.authHeader) {
+        headers.Authorization = api.authHeader;
+      }
+      return headers;
+    },
+    [api.authHeader]
+  );
+
+  const loadConfig = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const response = await fetch(`${api.baseUrl}/api/v2/user/config-file`, {
+        headers: requestHeaders(),
+      });
+      const data = await parseConfigFileResponse(response, 'Failed to load config file');
+      setConfigFile(data);
+      setContent(data.content);
+      setSavedContent(data.content);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to load config file';
+      setError(message);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [api.baseUrl, requestHeaders]);
+
+  useEffect(() => {
+    void loadConfig();
+  }, [loadConfig]);
+
+  const handleSave = async () => {
+    setIsSaving(true);
+    setError(null);
+    try {
+      const response = await fetch(`${api.baseUrl}/api/v2/user/config-file`, {
+        method: 'PUT',
+        headers: requestHeaders(true),
+        body: JSON.stringify({ content }),
+      });
+      const data = await parseConfigFileResponse(response, 'Failed to save config file');
+      setConfigFile(data);
+      setContent(data.content);
+      setSavedContent(data.content);
+      toast.success('Config file saved.');
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to save config file';
+      setError(message);
+      toast.error(message);
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const hasChanges = content !== savedContent;
+  const pathLabel = configFile?.write_target ?? configFile?.path ?? 'config.toml';
+
+  return (
+    <div className="space-y-3 rounded-lg border p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <h4 className="text-sm font-medium">Raw config file</h4>
+          <p className="mt-1 break-all text-xs text-muted-foreground">
+            <code>{pathLabel}</code>
+          </p>
+        </div>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8 shrink-0"
+              onClick={() => void loadConfig()}
+              disabled={isLoading || isSaving}
+            >
+              <RefreshCw className="h-4 w-4" />
+              <span className="sr-only">Refresh config file</span>
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Refresh</TooltipContent>
+        </Tooltip>
+      </div>
+
+      {error && (
+        <div className="flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive">
+          <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+          <span>{error}</span>
+        </div>
+      )}
+
+      <div className="space-y-2">
+        <Label htmlFor="settings-config-file-editor">TOML</Label>
+        <Textarea
+          id="settings-config-file-editor"
+          value={content}
+          onChange={(event) => setContent(event.target.value)}
+          disabled={isLoading || isSaving}
+          spellCheck={false}
+          className="min-h-72 resize-y font-mono text-xs leading-5"
+          aria-label="gptme config TOML"
+        />
+      </div>
+
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <span className="text-xs text-muted-foreground">
+          {isLoading ? 'Loading config file…' : hasChanges ? 'Unsaved changes' : 'Saved'}
+        </span>
+        <div className="flex items-center gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => setContent(savedContent)}
+            disabled={isLoading || isSaving || !hasChanges}
+          >
+            <RotateCcw className="mr-2 h-4 w-4" />
+            Discard
+          </Button>
+          <Button
+            type="button"
+            onClick={() => void handleSave()}
+            disabled={isLoading || isSaving || !hasChanges}
+          >
+            <Save className="mr-2 h-4 w-4" />
+            {isSaving ? 'Saving…' : 'Save'}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/webui/src/components/settings/ServerConfiguration.tsx
+++ b/webui/src/components/settings/ServerConfiguration.tsx
@@ -28,6 +28,7 @@ import { getClientForServer } from '@/stores/serverClients';
 import type { ServerConfig } from '@/types/servers';
 import { toast } from 'sonner';
 import { cn } from '@/lib/utils';
+import { ConfigFileEditor } from './ConfigFileEditor';
 import { ServerDefaultModelSettings } from './ServerDefaultModelSettings';
 import { ServerApiKeySettings } from './ServerApiKeySettings';
 
@@ -378,6 +379,7 @@ export const ServerConfiguration: FC = () => {
         </div>
       )}
 
+      <ConfigFileEditor />
       <ServerApiKeySettings />
       <ServerDefaultModelSettings />
 

--- a/webui/src/components/settings/__tests__/ConfigFileEditor.test.tsx
+++ b/webui/src/components/settings/__tests__/ConfigFileEditor.test.tsx
@@ -1,0 +1,115 @@
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { ConfigFileEditor } from '../ConfigFileEditor';
+
+const mockSuccess = jest.fn();
+const mockError = jest.fn();
+const mockFetch = jest.fn();
+
+jest.mock('@/contexts/ApiContext', () => ({
+  useApi: () => ({
+    api: {
+      baseUrl: 'http://127.0.0.1:5700',
+      authHeader: 'Bearer test-token',
+    },
+  }),
+}));
+
+jest.mock('@/components/ui/button', () => ({
+  Button: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button {...props}>{children}</button>
+  ),
+}));
+
+jest.mock('@/components/ui/label', () => ({
+  Label: ({
+    children,
+    ...props
+  }: React.LabelHTMLAttributes<HTMLLabelElement> & { children: React.ReactNode }) => (
+    <label {...props}>{children}</label>
+  ),
+}));
+
+jest.mock('@/components/ui/textarea', () => ({
+  Textarea: (props: React.TextareaHTMLAttributes<HTMLTextAreaElement>) => <textarea {...props} />,
+}));
+
+jest.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+jest.mock('sonner', () => ({
+  toast: {
+    success: (...args: unknown[]) => mockSuccess(...args),
+    error: (...args: unknown[]) => mockError(...args),
+  },
+}));
+
+const configResponse = {
+  content: '[env]\nMODEL = "old/model"\n',
+  path: '~/.config/gptme/config.toml',
+  write_target: '~/.config/gptme/config.toml',
+  local_config_path: '~/.config/gptme/config.local.toml',
+  local_config_exists: false,
+  local_overrides_main: true,
+};
+
+describe('ConfigFileEditor', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    mockSuccess.mockReset();
+    mockError.mockReset();
+    Object.defineProperty(window, 'fetch', {
+      writable: true,
+      value: mockFetch,
+    });
+  });
+
+  it('loads and saves the raw config file through the server API', async () => {
+    const updatedContent = '[env]\nMODEL = "anthropic/claude-sonnet-4-7"\n';
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => configResponse,
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          ...configResponse,
+          content: updatedContent,
+          status: 'ok',
+        }),
+      });
+
+    render(<ConfigFileEditor />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('gptme config TOML')).toHaveValue(configResponse.content);
+    });
+    expect(mockFetch).toHaveBeenCalledWith('http://127.0.0.1:5700/api/v2/user/config-file', {
+      headers: {
+        Authorization: 'Bearer test-token',
+      },
+    });
+
+    fireEvent.change(screen.getByLabelText('gptme config TOML'), {
+      target: { value: updatedContent },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenLastCalledWith('http://127.0.0.1:5700/api/v2/user/config-file', {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer test-token',
+        },
+        body: JSON.stringify({ content: updatedContent }),
+      });
+    });
+    expect(mockSuccess).toHaveBeenCalledWith('Config file saved.');
+    expect(screen.getByLabelText('gptme config TOML')).toHaveValue(updatedContent);
+  });
+});

--- a/webui/src/components/settings/__tests__/ConfigFileEditor.test.tsx
+++ b/webui/src/components/settings/__tests__/ConfigFileEditor.test.tsx
@@ -112,4 +112,35 @@ describe('ConfigFileEditor', () => {
     expect(mockSuccess).toHaveBeenCalledWith('Config file saved.');
     expect(screen.getByLabelText('gptme config TOML')).toHaveValue(updatedContent);
   });
+
+  it('shows env-section warning when config contains [env]', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => configResponse, // configResponse.content contains [env]
+    });
+
+    render(<ConfigFileEditor />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('gptme config TOML')).toHaveValue(configResponse.content);
+    });
+    expect(screen.getByText(/This config contains an/)).toBeInTheDocument();
+  });
+
+  it('does not show env-section warning when config has no [env] section', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        ...configResponse,
+        content: '[model]\ndefault = "anthropic/claude-3-5-sonnet"\n',
+      }),
+    });
+
+    render(<ConfigFileEditor />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('gptme config TOML')).toBeInTheDocument();
+    });
+    expect(screen.queryByText(/This config contains an/)).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- add authenticated `GET`/`PUT`/`PATCH /api/v2/user/config-file` endpoints with raw TOML validation and config path metadata
- add a settings-panel raw TOML editor with refresh, discard, save, auth headers, and error toasts
- add OpenAPI schemas plus backend and frontend regression tests

## Verification
- `/home/bob/gptme/.venv/bin/python -m pytest tests/test_server_v2.py -k user_config_file -q`
- `npm test -- --runTestsByPath src/components/settings/__tests__/ConfigFileEditor.test.tsx --runInBand`
- `npm run typecheck`
- pre-commit hooks passed during commit