### PR TITLE
feat(webui): add compact user avatar treatment

### DIFF
--- a/webui/src/components/ChatMessage.tsx
+++ b/webui/src/components/ChatMessage.tsx
@@ -475,6 +475,9 @@ export const ChatMessage: FC<Props> = ({
         ${visualChain === 'standalone' ? 'mb-4' : 'mb-0'}
       `;
   });
+  const contentOffsetClasses$ = useObservable(() => {
+    return isUser$.get() ? 'pr-10 md:px-12' : 'pl-10 md:px-12';
+  });
 
   return (
     <Memo>
@@ -497,7 +500,7 @@ export const ChatMessage: FC<Props> = ({
                   }
                   userName={api.userInfo$.name?.get()}
                 />
-                <div className="md:px-12">
+                <div className={contentOffsetClasses$.get()}>
                   <div className={`group/message relative ${messageClasses$.get()}`}>
                     {/* Action buttons (top-right) */}
                     <div className="absolute right-1 top-1 z-10 flex gap-0.5 opacity-0 transition-opacity hover:!opacity-100 group-hover/message:opacity-50">

--- a/webui/src/components/MessageAvatar.tsx
+++ b/webui/src/components/MessageAvatar.tsx
@@ -66,7 +66,7 @@ export function MessageAvatar({
           ? 'bg-red-800 text-red-100'
           : isSuccess
             ? 'bg-green-800 text-green-100'
-            : 'bg-slate-500 text-white left-0'
+            : 'bg-slate-500 text-white'
   }`;
 
   // Determine tooltip text

--- a/webui/src/components/MessageAvatar.tsx
+++ b/webui/src/components/MessageAvatar.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Bot, User, Terminal } from 'lucide-react';
+import { Bot, Terminal } from 'lucide-react';
 import type { MessageRole } from '@/types/conversation';
 import { type Observable } from '@legendapp/state';
 import { use$ } from '@legendapp/state/react';
@@ -14,6 +14,16 @@ interface MessageAvatarProps {
   agentName?: string;
   userAvatarUrl?: string;
   userName?: string;
+}
+
+function getInitials(name?: string): string {
+  const parts = name?.trim().split(/\s+/).filter(Boolean).slice(0, 2);
+
+  if (!parts?.length) {
+    return 'U';
+  }
+
+  return parts.map((part) => part[0]?.toUpperCase()).join('');
 }
 
 export function MessageAvatar({
@@ -41,16 +51,17 @@ export function MessageAvatar({
   const showCustomAvatar =
     (isAssistant && agentAvatarUrl && !imageError) || (isUser && userAvatarUrl && !imageError);
   const avatarUrl = isUser ? userAvatarUrl : agentAvatarUrl;
+  const sideClass = isUser ? 'right-0' : 'left-0';
 
-  const avatarClasses = `hidden md:flex flex-shrink-0 w-10 h-10 rounded-full items-center justify-center absolute border-2 border-border ${
+  const avatarClasses = `absolute flex h-8 w-8 flex-shrink-0 select-none items-center justify-center rounded-full border-2 border-border text-xs font-semibold md:h-10 md:w-10 md:text-sm ${sideClass} ${
     isUser
       ? showCustomAvatar
-        ? 'right-0 overflow-hidden'
-        : 'bg-blue-600 text-white right-0'
+        ? 'overflow-hidden'
+        : 'bg-blue-600 text-white'
       : isAssistant
         ? showCustomAvatar
-          ? 'left-0 overflow-hidden'
-          : 'bg-gptme-600 text-white left-0'
+          ? 'overflow-hidden'
+          : 'bg-gptme-600 text-white'
         : isError
           ? 'bg-red-800 text-red-100'
           : isSuccess
@@ -77,13 +88,13 @@ export function MessageAvatar({
       />
     </div>
   ) : (
-    <div className={avatarClasses}>
+    <div className={avatarClasses} aria-label={`${tooltipText} avatar`}>
       {isAssistant ? (
-        <Bot className="h-5 w-5" />
+        <Bot className="h-4 w-4 md:h-5 md:w-5" />
       ) : role === 'system' ? (
-        <Terminal className="h-5 w-5" />
+        <Terminal className="h-4 w-4 md:h-5 md:w-5" />
       ) : (
-        <User className="h-5 w-5" />
+        <span aria-hidden="true">{getInitials(userName)}</span>
       )}
     </div>
   );

--- a/webui/src/components/__tests__/ChatMessage.test.tsx
+++ b/webui/src/components/__tests__/ChatMessage.test.tsx
@@ -1,7 +1,8 @@
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { ChatMessage } from '../ChatMessage';
+import { MessageAvatar } from '../MessageAvatar';
 import '@testing-library/jest-dom';
-import type { Message } from '@/types/conversation';
+import type { Message, MessageRole } from '@/types/conversation';
 import { observable } from '@legendapp/state';
 import { SettingsProvider } from '@/contexts/SettingsContext';
 
@@ -36,6 +37,35 @@ describe('ChatMessage', () => {
 
     renderWithProviders(<ChatMessage message$={message$} conversationId={testConversationId} />);
     expect(screen.getByText('Hello!')).toBeInTheDocument();
+  });
+
+  it('renders a compact visible user avatar fallback', () => {
+    const message$ = observable<Message>({
+      role: 'user',
+      content: 'Hello!',
+      timestamp: new Date().toISOString(),
+    });
+
+    renderWithProviders(<ChatMessage message$={message$} conversationId={testConversationId} />);
+
+    const avatar = screen.getByLabelText('User avatar');
+    expect(avatar).toBeInTheDocument();
+    expect(avatar).toHaveTextContent('U');
+    expect(avatar).not.toHaveClass('hidden');
+  });
+
+  it('uses initials for named user avatar fallback', () => {
+    render(
+      <MessageAvatar
+        role$={observable<MessageRole>('user')}
+        chainType$={observable<'start' | 'middle' | 'end' | 'standalone'>('standalone')}
+        userName="Erik Bjareholt"
+      />
+    );
+
+    const avatar = screen.getByLabelText('Erik Bjareholt avatar');
+    expect(avatar).toHaveTextContent('EB');
+    expect(avatar).not.toHaveClass('hidden');
   });
 
   it('renders assistant message', () => {


### PR DESCRIPTION
## Summary
- show message avatars on narrow viewports with role-aware message padding
- replace generic user fallback icon with a deterministic initials badge
- cover user avatar visibility and initials rendering in ChatMessage tests

## Testing
- npm test -- --runInBand src/components/__tests__/ChatMessage.test.tsx (passes; existing React act warnings from clipboard/tooltip updates)
- npm run typecheck
- npx prettier --check src/components/MessageAvatar.tsx src/components/ChatMessage.tsx src/components/__tests__/ChatMessage.test.tsx