### PR TITLE
feat(webui): recover dropped event streams

### DIFF
--- a/webui/src/components/ConversationContent.tsx
+++ b/webui/src/components/ConversationContent.tsx
@@ -15,7 +15,7 @@ import { getObservableIndex } from '@legendapp/state';
 import { useApi } from '@/contexts/ApiContext';
 import { useSettings } from '@/contexts/SettingsContext';
 import { useModels } from '@/hooks/useModels';
-import { ArrowDown } from 'lucide-react';
+import { ArrowDown, RefreshCw, WifiOff } from 'lucide-react';
 
 interface Props {
   conversationId: string;
@@ -36,6 +36,11 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
     confirmTool,
     interruptGeneration,
   } = useConversation(conversationId, serverId);
+  const connectionStatus = use$(() => conversation$?.connectionStatus.get() ?? 'disconnected');
+  const reconnectAttempt = use$(() => conversation$?.reconnectAttempt.get() ?? null);
+  const reconnectMaxAttempts = use$(() => conversation$?.reconnectMaxAttempts.get() ?? null);
+  const reconnectRetryInMs = use$(() => conversation$?.reconnectRetryInMs.get() ?? null);
+  const connectionError = use$(() => conversation$?.connectionError.get() ?? null);
   // State to track when to auto-focus the input
   const shouldFocus$ = useObservable(false);
   // Store the previous conversation ID to detect changes
@@ -251,6 +256,11 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
     isScrolledUp$.set(false);
   };
 
+  const showConnectionBanner =
+    !isReadOnly && (connectionStatus === 'reconnecting' || connectionStatus === 'disconnected');
+  const reconnectRetrySeconds =
+    reconnectRetryInMs && reconnectRetryInMs > 0 ? Math.ceil(reconnectRetryInMs / 1000) : null;
+
   if (!conversation$) {
     return (
       <div className="flex h-full items-center justify-center">
@@ -426,6 +436,28 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
         >
           <ArrowDown className="h-4 w-4" />
         </button>
+      )}
+
+      {showConnectionBanner && (
+        <div className="absolute bottom-28 left-1/2 z-20 w-[min(calc(100%_-_2rem),42rem)] -translate-x-1/2 rounded-md border border-border bg-background/95 px-3 py-2 text-sm shadow-sm">
+          {connectionStatus === 'reconnecting' ? (
+            <div className="flex items-center gap-2 text-muted-foreground">
+              <RefreshCw className="h-4 w-4 shrink-0 animate-spin text-amber-500" />
+              <span className="truncate">
+                Reconnecting event stream
+                {reconnectAttempt && reconnectMaxAttempts
+                  ? ` (${reconnectAttempt}/${reconnectMaxAttempts})`
+                  : ''}
+                {reconnectRetrySeconds ? ` in ${reconnectRetrySeconds}s` : ''}
+              </span>
+            </div>
+          ) : (
+            <div className="flex items-center gap-2 text-muted-foreground">
+              <WifiOff className="h-4 w-4 shrink-0 text-destructive" />
+              <span className="truncate">{connectionError || 'Event stream disconnected'}</span>
+            </div>
+          )}
+        </div>
       )}
 
       <div className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-background via-background/80 to-transparent">

--- a/webui/src/components/ConversationContent.tsx
+++ b/webui/src/components/ConversationContent.tsx
@@ -1,5 +1,5 @@
 import type { FC } from 'react';
-import { useRef, useEffect, useCallback } from 'react';
+import { useRef, useEffect, useCallback, useState } from 'react';
 import { ChatMessage } from './ChatMessage';
 import { ChatInput, type ChatOptions } from './ChatInput';
 import { CollapsedStepGroup } from './CollapsedStepGroup';
@@ -258,8 +258,33 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
 
   const showConnectionBanner =
     !isReadOnly && (connectionStatus === 'reconnecting' || connectionStatus === 'disconnected');
-  const reconnectRetrySeconds =
-    reconnectRetryInMs && reconnectRetryInMs > 0 ? Math.ceil(reconnectRetryInMs / 1000) : null;
+
+  // Live countdown timer — decrements every second while reconnecting
+  const [reconnectRetrySeconds, setReconnectRetrySeconds] = useState<number | null>(null);
+  useEffect(() => {
+    if (connectionStatus !== 'reconnecting' || !reconnectRetryInMs) {
+      setReconnectRetrySeconds(null);
+      return;
+    }
+    // Compute remaining seconds from the retry interval
+    const computeRemaining = () => {
+      if (!conversation$?.reconnectRetryStartedAt?.get()) return null;
+      const elapsed = Date.now() - conversation$.reconnectRetryStartedAt.get()!;
+      const remaining = Math.max(0, reconnectRetryInMs! - elapsed);
+      return Math.ceil(remaining / 1000);
+    };
+    setReconnectRetrySeconds(computeRemaining());
+    const interval = setInterval(() => {
+      const remaining = computeRemaining();
+      if (remaining !== null && remaining <= 0) {
+        setReconnectRetrySeconds(null);
+        clearInterval(interval);
+      } else {
+        setReconnectRetrySeconds(remaining);
+      }
+    }, 250); // update 4×/s for smooth countdown
+    return () => clearInterval(interval);
+  }, [connectionStatus, reconnectRetryInMs, conversation$]);
 
   if (!conversation$) {
     return (

--- a/webui/src/hooks/useConversation.ts
+++ b/webui/src/hooks/useConversation.ts
@@ -10,6 +10,7 @@ import {
   updateConversation,
   setGenerating,
   setConnected,
+  setConnectionStatus,
   setPendingTool,
   setExecutingTool,
   setToolOutput,
@@ -381,6 +382,26 @@ export function useConversation(conversationId: string, serverId?: string) {
                     console.error('[useConversation] Error triggering initial step:', error);
                     toastStepStartError(toast, error);
                   });
+              }
+            },
+            onConnectionState: (state) => {
+              switch (state.status) {
+                case 'connected':
+                  setConnectionStatus(conversationId, 'connected');
+                  break;
+                case 'reconnecting':
+                  setConnectionStatus(conversationId, 'reconnecting', {
+                    attempt: state.attempt,
+                    maxAttempts: state.maxAttempts,
+                    retryInMs: state.retryInMs,
+                  });
+                  break;
+                case 'disconnected':
+                  setConnectionStatus(conversationId, 'disconnected', { error: state.message });
+                  break;
+                case 'connecting':
+                  setConnectionStatus(conversationId, 'connecting');
+                  break;
               }
             },
             onReconnectState: (state) => {

--- a/webui/src/hooks/useConversation.ts
+++ b/webui/src/hooks/useConversation.ts
@@ -368,8 +368,6 @@ export function useConversation(conversationId: string, serverId?: string) {
               }
             },
             onConnected: () => {
-              setConnected(conversationId, true);
-
               // Check if this conversation needs initial step (was created from WelcomeView)
               // This fixes the race condition where step() was called before subscription
               const needsStep = conversation$?.needsInitialStep?.get();

--- a/webui/src/stores/conversations.ts
+++ b/webui/src/stores/conversations.ts
@@ -15,6 +15,12 @@ export interface ExecutingTool {
   partialOutput: string;
 }
 
+export type ConversationConnectionStatus =
+  | 'connecting'
+  | 'connected'
+  | 'reconnecting'
+  | 'disconnected';
+
 export interface ConversationState {
   // The conversation data
   data: ConversationResponse;
@@ -22,6 +28,11 @@ export interface ConversationState {
   isGenerating: boolean;
   // Whether this conversation has an active event stream
   isConnected: boolean;
+  connectionStatus: ConversationConnectionStatus;
+  reconnectAttempt: number | null;
+  reconnectMaxAttempts: number | null;
+  reconnectRetryInMs: number | null;
+  connectionError: string | null;
   // Any pending tool
   pendingTool: PendingTool | null;
   // Any executing tool
@@ -67,6 +78,11 @@ export function updateConversation(id: string, update: Partial<ConversationState
       data: { id, name: '', log: [], logfile: id, branches: {}, workspace: '/default/workspace' },
       isGenerating: false,
       isConnected: false,
+      connectionStatus: 'disconnected',
+      reconnectAttempt: null,
+      reconnectMaxAttempts: null,
+      reconnectRetryInMs: null,
+      connectionError: null,
       pendingTool: null,
       executingTool: null,
       lastCompletedTool: null,
@@ -124,7 +140,34 @@ export function setGenerating(id: string, isGenerating: boolean) {
 }
 
 export function setConnected(id: string, isConnected: boolean) {
-  updateConversation(id, { isConnected });
+  updateConversation(id, {
+    isConnected,
+    connectionStatus: isConnected ? 'connected' : 'disconnected',
+    reconnectAttempt: null,
+    reconnectMaxAttempts: null,
+    reconnectRetryInMs: null,
+    connectionError: null,
+  });
+}
+
+export function setConnectionStatus(
+  id: string,
+  status: ConversationConnectionStatus,
+  options?: {
+    attempt?: number;
+    maxAttempts?: number;
+    retryInMs?: number;
+    error?: string | null;
+  }
+) {
+  updateConversation(id, {
+    isConnected: status === 'connected',
+    connectionStatus: status,
+    reconnectAttempt: options?.attempt ?? null,
+    reconnectMaxAttempts: options?.maxAttempts ?? null,
+    reconnectRetryInMs: options?.retryInMs ?? null,
+    connectionError: options?.error ?? null,
+  });
 }
 
 export function setPendingTool(id: string, toolId: string | null, tooluse: ToolUse | null) {
@@ -192,6 +235,11 @@ export function initConversation(
     },
     isGenerating: false,
     isConnected: false,
+    connectionStatus: 'disconnected',
+    reconnectAttempt: null,
+    reconnectMaxAttempts: null,
+    reconnectRetryInMs: null,
+    connectionError: null,
     pendingTool: null,
     executingTool: null,
     lastCompletedTool: null,

--- a/webui/src/stores/conversations.ts
+++ b/webui/src/stores/conversations.ts
@@ -32,6 +32,7 @@ export interface ConversationState {
   reconnectAttempt: number | null;
   reconnectMaxAttempts: number | null;
   reconnectRetryInMs: number | null;
+  reconnectRetryStartedAt: number | null;
   connectionError: string | null;
   // Any pending tool
   pendingTool: PendingTool | null;
@@ -83,6 +84,7 @@ export function updateConversation(id: string, update: Partial<ConversationState
       reconnectMaxAttempts: null,
       reconnectRetryInMs: null,
       connectionError: null,
+      reconnectRetryStartedAt: null,
       pendingTool: null,
       executingTool: null,
       lastCompletedTool: null,
@@ -166,6 +168,7 @@ export function setConnectionStatus(
     reconnectAttempt: options?.attempt ?? null,
     reconnectMaxAttempts: options?.maxAttempts ?? null,
     reconnectRetryInMs: options?.retryInMs ?? null,
+    reconnectRetryStartedAt: status === 'reconnecting' && options?.retryInMs ? Date.now() : null,
     connectionError: options?.error ?? null,
   });
 }
@@ -240,6 +243,7 @@ export function initConversation(
     reconnectMaxAttempts: null,
     reconnectRetryInMs: null,
     connectionError: null,
+    reconnectRetryStartedAt: null,
     pendingTool: null,
     executingTool: null,
     lastCompletedTool: null,

--- a/webui/src/utils/__tests__/api.test.ts
+++ b/webui/src/utils/__tests__/api.test.ts
@@ -12,6 +12,46 @@ jest.mock('@/stores/servers', () => ({
 
 import { ApiClient, ApiClientError, getApiErrorPresentation, isLikelyChromeCorsPna } from '../api';
 
+class MockEventSource {
+  static instances: MockEventSource[] = [];
+
+  onopen: (() => void) | null = null;
+  onmessage: ((event: { data: string }) => void) | null = null;
+  onerror: ((event: Event) => void) | null = null;
+  close = jest.fn();
+
+  constructor(
+    public url: string,
+    public init?: EventSourceInit
+  ) {
+    MockEventSource.instances.push(this);
+  }
+
+  emitOpen() {
+    this.onopen?.();
+  }
+
+  emitMessage(data: unknown) {
+    this.onmessage?.({ data: JSON.stringify(data) });
+  }
+
+  emitError() {
+    this.onerror?.(new Event('error'));
+  }
+}
+
+const createSseCallbacks = () => ({
+  onMessageStart: jest.fn(),
+  onToken: jest.fn(),
+  onMessageComplete: jest.fn(),
+  onMessageAdded: jest.fn(),
+  onToolPending: jest.fn(),
+  onToolExecuting: jest.fn(),
+  onInterrupted: jest.fn(),
+  onError: jest.fn(),
+  onConnectionState: jest.fn(),
+});
+
 describe('isLikelyChromeCorsPna', () => {
   const setHostname = (hostname: string) => {
     Object.defineProperty(window, 'location', {
@@ -164,6 +204,90 @@ describe('ApiClient error parsing', () => {
       code: 'no_subscription',
       type: 'payment_required',
     } satisfies Partial<ApiClientError>);
+  });
+});
+
+describe('ApiClient event stream reconnection', () => {
+  const originalEventSource = global.EventSource;
+  const originalCrypto = global.crypto;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    MockEventSource.instances = [];
+    Object.defineProperty(global, 'EventSource', {
+      value: MockEventSource,
+      configurable: true,
+    });
+    Object.defineProperty(global, 'crypto', {
+      value: {
+        ...originalCrypto,
+        randomUUID: jest.fn(() => 'test-client-id'),
+      },
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    Object.defineProperty(global, 'EventSource', {
+      value: originalEventSource,
+      configurable: true,
+    });
+    Object.defineProperty(global, 'crypto', {
+      value: originalCrypto,
+      configurable: true,
+    });
+    jest.restoreAllMocks();
+  });
+
+  it('reports reconnect state and reuses the session id after a transient drop', async () => {
+    const client = new ApiClient('http://127.0.0.1:5700');
+    const callbacks = createSseCallbacks();
+
+    await client.subscribeToEvents('conv-1', callbacks);
+
+    const first = MockEventSource.instances[0];
+    first.emitOpen();
+    first.emitMessage({ type: 'connected', session_id: 'session-1' });
+    expect(callbacks.onConnectionState).toHaveBeenLastCalledWith({ status: 'connected' });
+
+    first.emitError();
+
+    expect(first.close).toHaveBeenCalled();
+    expect(callbacks.onConnectionState).toHaveBeenLastCalledWith({
+      status: 'reconnecting',
+      attempt: 1,
+      maxAttempts: 5,
+      retryInMs: 1000,
+    });
+
+    first.emitMessage({ type: 'generation_progress', token: 'stale' });
+    expect(callbacks.onToken).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(1000);
+    await Promise.resolve();
+
+    expect(MockEventSource.instances).toHaveLength(2);
+    expect(MockEventSource.instances[1].url).toContain('session_id=session-1');
+    expect(callbacks.onError).not.toHaveBeenCalled();
+  });
+
+  it('cancels pending reconnect timers when the stream is closed manually', async () => {
+    const client = new ApiClient('http://127.0.0.1:5700');
+    const callbacks = createSseCallbacks();
+
+    await client.subscribeToEvents('conv-1', callbacks);
+
+    const first = MockEventSource.instances[0];
+    first.emitOpen();
+    first.emitMessage({ type: 'connected', session_id: 'session-1' });
+    first.emitError();
+
+    client.closeEventStream('conv-1');
+    jest.advanceTimersByTime(1000);
+    await Promise.resolve();
+
+    expect(MockEventSource.instances).toHaveLength(1);
   });
 });
 

--- a/webui/src/utils/api.ts
+++ b/webui/src/utils/api.ts
@@ -811,9 +811,9 @@ export class ApiClient {
       }
     };
 
-    eventSource.onerror = (error) => {
+    eventSource.onerror = (_error) => {
       if (!isCurrentEventSource()) return;
-      console.error(`[ApiClient] Event stream error for ${conversationId}:`, error);
+      console.error(`[ApiClient] Event stream error for ${conversationId}:`);
 
       // Clear the session ID timeout
       window.clearTimeout(sessionIdTimeout);
@@ -822,56 +822,53 @@ export class ApiClient {
         sessionIdTimeout: undefined,
       });
 
-      // If we were previously connected, try to reconnect
+      // Close the old EventSource and clean up — we'll reconnect from scratch
+      const wasConnected = isConnected;
       if (isConnected) {
-        console.log(`[ApiClient] Connection was established before, attempting to reconnect...`);
         isConnected = false;
-        eventSource.close();
-        this.eventSources.delete(conversationId);
+      }
+      eventSource.close();
+      this.eventSources.delete(conversationId);
 
-        // Only auto-reconnect if we haven't exceeded the max reconnects
-        if (reconnectCount < maxReconnects) {
-          reconnectCount++;
+      // Attempt retry with exponential backoff regardless of whether
+      // we were previously connected (dropped stream) or never connected
+      // (initial failure). Both paths use the same retry budget.
+      if (reconnectCount < maxReconnects) {
+        reconnectCount++;
 
-          // Exponential backoff for reconnection (1s, 2s, 4s, 8s, 16s)
-          const delay = Math.pow(2, reconnectCount - 1) * 1000;
+        const delay = Math.pow(2, reconnectCount - 1) * 1000;
 
-          console.log(
-            `[ApiClient] Reconnecting in ${delay}ms (attempt ${reconnectCount}/${maxReconnects})`
-          );
+        console.log(
+          `[ApiClient] Reconnecting in ${delay}ms (attempt ${reconnectCount}/${maxReconnects})`
+        );
 
-          callbacks.onConnectionState?.({
-            status: 'reconnecting',
-            attempt: reconnectCount,
-            maxAttempts: maxReconnects,
-            retryInMs: delay,
-          });
+        callbacks.onConnectionState?.({
+          status: 'reconnecting',
+          attempt: reconnectCount,
+          maxAttempts: maxReconnects,
+          retryInMs: delay,
+        });
 
-          // Set a new timer for reconnection
-          const reconnectTimer = window.setTimeout(() => {
-            reconnect(reconnectCount);
-          }, delay);
-          this.eventStreamTimers.set(conversationId, {
-            ...this.eventStreamTimers.get(conversationId),
-            reconnectTimer,
-          });
-        } else {
-          console.warn(`[ApiClient] Max reconnects (${maxReconnects}) reached, giving up`);
-          callbacks.onConnectionState?.({
-            status: 'disconnected',
-            message: 'Connection lost and max reconnects reached',
-          });
-          callbacks.onError?.('Connection lost and max reconnects reached');
-        }
+        const reconnectTimer = window.setTimeout(() => {
+          reconnect(reconnectCount);
+        }, delay);
+        this.eventStreamTimers.set(conversationId, {
+          ...this.eventStreamTimers.get(conversationId),
+          reconnectTimer,
+        });
       } else {
-        // We never established a connection, report the error
-        eventSource.close();
-        this.eventSources.delete(conversationId);
+        console.warn(`[ApiClient] Max reconnects (${maxReconnects}) reached, giving up`);
         callbacks.onConnectionState?.({
           status: 'disconnected',
-          message: 'Failed to connect to event stream',
+          message: wasConnected
+            ? 'Connection lost and max reconnects reached'
+            : 'Failed to connect to event stream',
         });
-        callbacks.onError?.('Failed to connect to event stream');
+        callbacks.onError?.(
+          wasConnected
+            ? 'Connection lost and max reconnects reached'
+            : 'Failed to connect to event stream'
+        );
       }
     };
   }

--- a/webui/src/utils/api.ts
+++ b/webui/src/utils/api.ts
@@ -200,6 +200,17 @@ export interface ToolConfirmationRequest {
   count?: number;
 }
 
+export type EventStreamConnectionState =
+  | { status: 'connecting' }
+  | { status: 'connected' }
+  | {
+      status: 'reconnecting';
+      attempt: number;
+      maxAttempts: number;
+      retryInMs: number;
+    }
+  | { status: 'disconnected'; message: string };
+
 export class ApiClient {
   public baseUrl: string;
   public authHeader: string | null = null;
@@ -211,6 +222,8 @@ export class ApiClient {
   public sessions$: Observable<Map<string, string>> = observable(new Map()); // Map conversation IDs to session IDs
   public userInfo$: Observable<UserInfo | null> = observable<UserInfo | null>(null);
   private eventSources: Map<string, EventSource> = new Map(); // Map conversation IDs to EventSource instances
+  private eventStreamTimers: Map<string, { reconnectTimer?: number; sessionIdTimeout?: number }> =
+    new Map();
   private isCleaningUp = false;
   private authCookieSet = false;
   private authCookieSetAt: number | null = null;
@@ -425,9 +438,8 @@ export class ApiClient {
       }
 
       // Close all event sources
-      for (const [conversationId, eventSource] of this.eventSources.entries()) {
-        eventSource.close();
-        this.eventSources.delete(conversationId);
+      for (const conversationId of Array.from(this.eventSources.keys())) {
+        this.closeEventStream(conversationId);
       }
     } finally {
       this.isCleaningUp = false;
@@ -544,6 +556,7 @@ export class ApiClient {
       onError: (error: string) => void;
       onConfigChanged?: (config: ChatConfig, changedFields: string[]) => void;
       onConnected?: () => void;
+      onConnectionState?: (state: EventStreamConnectionState) => void;
       onReconnectState?: (state: {
         generating: boolean;
         pendingTools: Array<{
@@ -558,32 +571,65 @@ export class ApiClient {
         log: Message[];
         branches: Record<string, Message[]>;
       }) => void;
-    }
+    },
+    reconnectAttempt = 0
   ): Promise<void> {
+    const maxReconnects = 5;
+
     // Close any existing event stream for this conversation
     this.closeEventStream(conversationId);
+    callbacks.onConnectionState?.(
+      reconnectAttempt > 0
+        ? {
+            status: 'reconnecting',
+            attempt: reconnectAttempt,
+            maxAttempts: maxReconnects,
+            retryInMs: 0,
+          }
+        : { status: 'connecting' }
+    );
 
     // Function to reconnect to the event stream if it fails, or we fail to get a session ID
-    const reconnect = () => {
+    const reconnect = (attempt: number) => {
       console.log(`[ApiClient] Attempting reconnection for ${conversationId}`);
       this.closeEventStream(conversationId);
       // Reset cookie state so expired cookies (24h TTL) are re-fetched on reconnect
       this.resetAuthCookie();
-      this.subscribeToEvents(conversationId, callbacks).catch((err) => {
+      this.subscribeToEvents(conversationId, callbacks, attempt).catch((err) => {
         console.error('[ApiClient] Reconnect failed:', err);
         callbacks.onError?.(String(err));
       });
     };
 
     // Create a timeout that will reconnect if we don't get a session ID after 5 seconds
-    const sessionIdTimeout = setTimeout(() => {
+    const sessionIdTimeout = window.setTimeout(() => {
       if (!this.sessions$.has(conversationId)) {
         console.log(
           `[ApiClient] Timed out waiting for session ID for ${conversationId}, reconnecting`
         );
-        reconnect();
+        const nextAttempt = reconnectAttempt + 1;
+        if (nextAttempt <= maxReconnects) {
+          callbacks.onConnectionState?.({
+            status: 'reconnecting',
+            attempt: nextAttempt,
+            maxAttempts: maxReconnects,
+            retryInMs: 0,
+          });
+          reconnect(nextAttempt);
+        } else {
+          this.closeEventStream(conversationId);
+          callbacks.onConnectionState?.({
+            status: 'disconnected',
+            message: 'Timed out waiting for event stream session',
+          });
+          callbacks.onError?.('Timed out waiting for event stream session');
+        }
       }
     }, 5000);
+    this.eventStreamTimers.set(conversationId, {
+      ...this.eventStreamTimers.get(conversationId),
+      sessionIdTimeout,
+    });
 
     /**
      * For SSE connections, we prefer cookie-based authentication (set via
@@ -623,23 +669,23 @@ export class ApiClient {
     }
 
     const eventSource = new EventSource(url.toString(), { withCredentials: true });
+    this.eventSources.set(conversationId, eventSource);
 
     // Add connect event notification
     let isConnected = false;
+    let reconnectCount = reconnectAttempt;
 
-    // Track reconnection attempts
-    let reconnectCount = 0;
-    const maxReconnects = 5;
-    let reconnectTimer: number | null = null;
+    const isCurrentEventSource = () => this.eventSources.get(conversationId) === eventSource;
 
     // Handle connection open
     eventSource.onopen = () => {
+      if (!isCurrentEventSource()) return;
       console.log(`[ApiClient] Event stream connected for ${conversationId}`);
       isConnected = true;
-      reconnectCount = 0; // Reset reconnect count on successful connection
     };
 
     eventSource.onmessage = (event) => {
+      if (!isCurrentEventSource()) return;
       try {
         const data = JSON.parse(event.data);
 
@@ -722,8 +768,14 @@ export class ApiClient {
             // Resolve the promise with the session ID
             this.sessions$.set(conversationId, data.session_id);
             // Clear the session ID timeout
-            clearTimeout(sessionIdTimeout);
+            window.clearTimeout(sessionIdTimeout);
+            this.eventStreamTimers.set(conversationId, {
+              ...this.eventStreamTimers.get(conversationId),
+              sessionIdTimeout: undefined,
+            });
+            reconnectCount = 0; // Reset reconnect count after the server handshake succeeds
             // Notify that connection is established
+            callbacks.onConnectionState?.({ status: 'connected' });
             callbacks.onConnected?.();
             // Restore state on reconnect (pending tools, generating flag)
             if (callbacks.onReconnectState && (data.pending_tools?.length || data.generating)) {
@@ -760,15 +812,22 @@ export class ApiClient {
     };
 
     eventSource.onerror = (error) => {
+      if (!isCurrentEventSource()) return;
       console.error(`[ApiClient] Event stream error for ${conversationId}:`, error);
 
       // Clear the session ID timeout
-      clearTimeout(sessionIdTimeout);
+      window.clearTimeout(sessionIdTimeout);
+      this.eventStreamTimers.set(conversationId, {
+        ...this.eventStreamTimers.get(conversationId),
+        sessionIdTimeout: undefined,
+      });
 
       // If we were previously connected, try to reconnect
       if (isConnected) {
         console.log(`[ApiClient] Connection was established before, attempting to reconnect...`);
         isConnected = false;
+        eventSource.close();
+        this.eventSources.delete(conversationId);
 
         // Only auto-reconnect if we haven't exceeded the max reconnects
         if (reconnectCount < maxReconnects) {
@@ -781,30 +840,52 @@ export class ApiClient {
             `[ApiClient] Reconnecting in ${delay}ms (attempt ${reconnectCount}/${maxReconnects})`
           );
 
-          // Clear any existing timer
-          if (reconnectTimer !== null) {
-            window.clearTimeout(reconnectTimer);
-          }
+          callbacks.onConnectionState?.({
+            status: 'reconnecting',
+            attempt: reconnectCount,
+            maxAttempts: maxReconnects,
+            retryInMs: delay,
+          });
 
           // Set a new timer for reconnection
-          reconnectTimer = window.setTimeout(() => {
-            reconnect();
+          const reconnectTimer = window.setTimeout(() => {
+            reconnect(reconnectCount);
           }, delay);
+          this.eventStreamTimers.set(conversationId, {
+            ...this.eventStreamTimers.get(conversationId),
+            reconnectTimer,
+          });
         } else {
           console.warn(`[ApiClient] Max reconnects (${maxReconnects}) reached, giving up`);
+          callbacks.onConnectionState?.({
+            status: 'disconnected',
+            message: 'Connection lost and max reconnects reached',
+          });
           callbacks.onError?.('Connection lost and max reconnects reached');
         }
       } else {
         // We never established a connection, report the error
+        eventSource.close();
+        this.eventSources.delete(conversationId);
+        callbacks.onConnectionState?.({
+          status: 'disconnected',
+          message: 'Failed to connect to event stream',
+        });
         callbacks.onError?.('Failed to connect to event stream');
       }
     };
-
-    // Store the event source
-    this.eventSources.set(conversationId, eventSource);
   }
 
   closeEventStream(conversationId: string): void {
+    const timers = this.eventStreamTimers.get(conversationId);
+    if (timers?.reconnectTimer !== undefined) {
+      window.clearTimeout(timers.reconnectTimer);
+    }
+    if (timers?.sessionIdTimeout !== undefined) {
+      window.clearTimeout(timers.sessionIdTimeout);
+    }
+    this.eventStreamTimers.delete(conversationId);
+
     if (this.eventSources.has(conversationId)) {
       this.eventSources.get(conversationId)!.close();
       this.eventSources.delete(conversationId);


### PR DESCRIPTION
## Summary
- track per-conversation event-stream state (`connecting`, `reconnecting`, `connected`, `disconnected`)
- clear reconnect/session timers when streams are closed and ignore stale EventSource events after reconnect
- show a compact reconnect/disconnected banner above the chat input
- add focused ApiClient tests for transient drops, session reuse, stale event suppression, and manual close timer cleanup

## Verification
- `npm test -- --runInBand src/utils/__tests__/api.test.ts --silent`
- `npm run typecheck` (passed in pre-commit)
- `npx eslint src/utils/api.ts src/stores/conversations.ts src/hooks/useConversation.ts src/components/ConversationContent.tsx src/utils/__tests__/api.test.ts` (0 errors; existing warnings only)
