### PR TITLE
feat(tools/python): emit artifact descriptors for plot files (#830 Phase 2)

### DIFF
--- a/gptme/tools/python.py
+++ b/gptme/tools/python.py
@@ -36,8 +36,53 @@ if TYPE_CHECKING:
         InteractiveShell,  # fmt: skip
     )
 
+    from ..message import ArtifactDescriptor, MessageMetadata
+
 
 logger = getLogger(__name__)
+
+_IMAGE_EXTS: frozenset[str] = frozenset(
+    {".png", ".jpg", ".jpeg", ".svg", ".gif", ".pdf"}
+)
+_IMAGE_MIME: dict[str, str] = {
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".svg": "image/svg+xml",
+    ".gif": "image/gif",
+    ".pdf": "application/pdf",
+}
+
+
+def _snapshot_images(cwd: Path) -> dict[Path, float]:
+    """Return a {path: mtime} snapshot of image files directly in *cwd*."""
+    try:
+        return {
+            p: p.stat().st_mtime
+            for p in cwd.iterdir()
+            if p.is_file() and p.suffix.lower() in _IMAGE_EXTS
+        }
+    except OSError:
+        return {}
+
+
+def _make_plot_artifacts(
+    before: dict[Path, float], after: dict[Path, float]
+) -> "list[ArtifactDescriptor]":
+    """Return ArtifactDescriptors for image files created/modified since *before*."""
+    descriptors: list[ArtifactDescriptor] = []
+    for path, mtime in after.items():
+        if path not in before or before[path] != mtime:
+            descriptor: ArtifactDescriptor = {
+                "source_type": "attachment",
+                "path": str(path),
+                "kind": "image",
+                "mime_type": _IMAGE_MIME.get(path.suffix.lower(), "image/png"),
+                "tool": "python",
+            }
+            descriptors.append(descriptor)
+    return descriptors
+
 
 # IPython instance
 _ipython: "InteractiveShell | None" = None
@@ -209,6 +254,10 @@ def execute_python(
     # Create an IPython instance if it doesn't exist yet
     _ipython = _get_ipython()
 
+    # Snapshot image files before execution so we can detect newly created plots
+    cwd = Path.cwd()
+    pre_images = _snapshot_images(cwd)
+
     # Capture and display output in real-time
     with capture_and_display() as (stdout_capture, stderr_capture):
         # Execute the code (output will be displayed in real-time)
@@ -246,7 +295,16 @@ def execute_python(
     # strip ANSI escape sequences (safety net — colors are disabled at the source
     # via NO_COLOR=1 and IPython's NoColor setting, but libraries may still emit them)
     output = re.sub(r"\x1b\[[0-9;]*[a-zA-Z]", "", output)
-    yield Message("system", "Executed code block.\n\n" + output)
+
+    # Detect plot files created or modified during execution and attach descriptors
+    post_images = _snapshot_images(cwd)
+    plot_artifacts = _make_plot_artifacts(pre_images, post_images)
+    msg = Message("system", "Executed code block.\n\n" + output)
+    if plot_artifacts:
+        existing: MessageMetadata = dict(msg.metadata) if msg.metadata else {}  # type: ignore[assignment]
+        existing["artifacts"] = [*existing.get("artifacts", []), *plot_artifacts]
+        msg = dataclasses.replace(msg, metadata=existing)
+    yield msg
 
 
 @functools.lru_cache

--- a/gptme/tools/python.py
+++ b/gptme/tools/python.py
@@ -56,14 +56,18 @@ _IMAGE_MIME: dict[str, str] = {
 
 def _snapshot_images(cwd: Path) -> dict[Path, float]:
     """Return a {path: mtime} snapshot of image files directly in *cwd*."""
+    snapshot: dict[Path, float] = {}
     try:
-        return {
-            p: p.stat().st_mtime
-            for p in cwd.iterdir()
-            if p.is_file() and p.suffix.lower() in _IMAGE_EXTS
-        }
+        entries = list(cwd.iterdir())
     except OSError:
-        return {}
+        return snapshot
+    for p in entries:
+        if p.is_file() and p.suffix.lower() in _IMAGE_EXTS:
+            try:
+                snapshot[p] = p.stat().st_mtime
+            except OSError:
+                pass
+    return snapshot
 
 
 def _make_plot_artifacts(

--- a/tests/test_tools_python.py
+++ b/tests/test_tools_python.py
@@ -8,7 +8,9 @@ from gptme.tools.base import callable_signature
 from gptme.tools.python import (
     _detect_venv,
     _get_venv_site_packages,
+    _make_plot_artifacts,
     _setup_venv_paths,
+    _snapshot_images,
     execute_python,
 )
 
@@ -197,3 +199,110 @@ def test_setup_venv_paths_skips_own_venv():
             assert sys.path == original_path
     finally:
         sys.path[:] = original_path
+
+
+# --- Plot artifact descriptor tests ---
+
+
+def test_snapshot_images_empty(tmp_path):
+    """Empty directory → empty snapshot."""
+    assert _snapshot_images(tmp_path) == {}
+
+
+def test_snapshot_images_captures_images(tmp_path):
+    """Images in directory are captured with their mtimes."""
+    (tmp_path / "plot.png").write_bytes(b"")
+    (tmp_path / "chart.svg").write_bytes(b"")
+    snap = _snapshot_images(tmp_path)
+    assert tmp_path / "plot.png" in snap
+    assert tmp_path / "chart.svg" in snap
+
+
+def test_snapshot_images_ignores_non_images(tmp_path):
+    """Non-image files are not captured."""
+    (tmp_path / "data.csv").write_text("a,b")
+    (tmp_path / "script.py").write_text("pass")
+    assert _snapshot_images(tmp_path) == {}
+
+
+def test_make_plot_artifacts_new_file(tmp_path):
+    """A file present in *after* but not *before* produces a descriptor."""
+    path = tmp_path / "plot.png"
+    path.write_bytes(b"")
+    before: dict[Path, float] = {}
+    after = {path: path.stat().st_mtime}
+    artifacts = _make_plot_artifacts(before, after)
+    assert len(artifacts) == 1
+    assert artifacts[0]["kind"] == "image"
+    assert artifacts[0]["tool"] == "python"
+    assert artifacts[0]["source_type"] == "attachment"
+    assert artifacts[0]["path"] == str(path)
+
+
+def test_make_plot_artifacts_modified_file(tmp_path):
+    """A file whose mtime changed produces a descriptor."""
+    path = tmp_path / "plot.png"
+    path.write_bytes(b"v1")
+    before = {path: 1000.0}
+    after = {path: 2000.0}
+    artifacts = _make_plot_artifacts(before, after)
+    assert len(artifacts) == 1
+
+
+def test_make_plot_artifacts_unchanged_file(tmp_path):
+    """A file with the same mtime in before and after → no descriptor."""
+    path = tmp_path / "old.png"
+    path.write_bytes(b"")
+    mtime = path.stat().st_mtime
+    snap = {path: mtime}
+    assert _make_plot_artifacts(snap, snap) == []
+
+
+def test_make_plot_artifacts_mime_types(tmp_path):
+    """Correct MIME type is assigned per extension."""
+    cases = {
+        "a.png": "image/png",
+        "b.svg": "image/svg+xml",
+        "c.jpg": "image/jpeg",
+        "d.jpeg": "image/jpeg",
+        "e.gif": "image/gif",
+        "f.pdf": "application/pdf",
+    }
+    before: dict[Path, float] = {}
+    after: dict[Path, float] = {}
+    for name in cases:
+        p = tmp_path / name
+        p.write_bytes(b"")
+        after[p] = p.stat().st_mtime
+    artifacts = _make_plot_artifacts(before, after)
+    by_path = {Path(a["path"]).name: a["mime_type"] for a in artifacts}
+    for name, expected_mime in cases.items():
+        assert by_path[name] == expected_mime, (
+            f"{name}: {by_path[name]} != {expected_mime}"
+        )
+
+
+def test_execute_python_plot_artifact(tmp_path):
+    """execute_python attaches an artifact descriptor when code creates an image."""
+    plot_file = tmp_path / "plot.png"
+
+    # Patch Path.cwd() to return tmp_path so the pre/post snapshot sees the file
+    with patch("gptme.tools.python.Path.cwd", return_value=tmp_path):
+        # Write the plot file *during* execution by creating it inside the code
+        code = f"open('{plot_file}', 'wb').write(b'fake png')"
+        msg = next(execute_python(code, [], None))
+
+    assert msg.metadata is not None
+    artifacts = msg.metadata.get("artifacts", [])
+    assert any(a["tool"] == "python" and a["kind"] == "image" for a in artifacts), (
+        f"Expected image artifact, got: {artifacts}"
+    )
+
+
+def test_execute_python_no_plot_no_artifact(tmp_path):
+    """execute_python does NOT add artifacts when no image files are created."""
+    with patch("gptme.tools.python.Path.cwd", return_value=tmp_path):
+        msg = next(execute_python("x = 1 + 1", [], None))
+
+    artifacts = (msg.metadata or {}).get("artifacts", [])
+    assert artifacts == []


### PR DESCRIPTION
## Summary

Extends the Phase 2 artifact producer wiring from #2639 (computer screenshot) to cover matplotlib and any library that saves image files to the working directory.

When Python code creates or modifies image files (`.png`, `.jpg`, `.jpeg`, `.svg`, `.gif`, `.pdf`) in the current working directory during execution, `execute_python` now attaches typed `ArtifactDescriptor` metadata to the system message so the server can surface them via the artifact registry API instead of relying solely on filename heuristics.

### Implementation

- `_snapshot_images(cwd)` — non-recursive scan of cwd for image files before execution, returns `{path: mtime}` dict
- `_make_plot_artifacts(before, after)` — diffs snapshots and returns `ArtifactDescriptor` list for new/modified files
- `execute_python()` — snapshots before execution, attaches descriptors on the output message (metadata-merge follows the #2639 pattern, preserves existing metadata fields)

### Tests (9 new)

- Snapshot helpers: empty dir, captures images, ignores non-images
- Artifact helper: new file, modified file (mtime changed), unchanged file, MIME-type mapping per extension
- Integration: `execute_python` with code that creates a file → artifact descriptor attached; code that creates no image → no artifact

### MIME types

| Extension | MIME |
|-----------|------|
| `.png` | `image/png` |
| `.jpg` / `.jpeg` | `image/jpeg` |
| `.svg` | `image/svg+xml` |
| `.gif` | `image/gif` |
| `.pdf` | `application/pdf` |

Part of ErikBjare/bob#830 Phase 2 remaining (following #2639 computer screenshots).

## Test plan

- [x] 24 tests pass in `tests/test_tools_python.py` (15 existing + 9 new)
- [x] `mypy gptme/tools/python.py` clean
- [x] `ruff check` + `ruff format` clean
- [ ] CI passes