### PR TITLE
feat(server): add docker-compose self-host setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,20 @@
+# Copy this file to .env and fill in your values, then run:
+#   docker compose up --build
+#
+# At least one provider key is required for gptme to run conversations.
+OPENAI_API_KEY=
+ANTHROPIC_API_KEY=
+OPENROUTER_API_KEY=
+
+# Auth token required on every request. gptme-server enables auth by default
+# when bound to 0.0.0.0 (as it is in the container), so set this to a value you
+# choose and configure the web UI with the same token. If left blank, the server
+# auto-generates a token at startup — find it with `docker compose logs`.
+GPTME_SERVER_TOKEN=
+
+# Origin allowed to call the server via CORS. Defaults to the hosted web UI.
+# Set this to your own web UI origin if you self-host the frontend too.
+CORS_ORIGIN=https://chat.gptme.org
+
+# Host port to publish the server on (container always listens on 5700).
+GPTME_SERVER_PORT=5700

--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,6 @@ gptme/server/webui-dist/
 # Cache files written by scripts/build_changelog.py at build time
 scripts/changelog_contributors.csv
 scripts/changelog_contributors_twitter.csv
+
+# Keep the compose example env template tracked
+!.env.example

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,40 @@
+# Self-host gptme-server with one command:
+#
+#   docker compose up --build
+#
+# Then open the hosted web UI at https://chat.gptme.org and point it at
+# http://localhost:5700 — or host your own web UI (see docs/server.rst).
+#
+# Configuration: copy .env.example to .env and fill in at least one provider
+# key. Everything below reads from that .env file (or your shell environment).
+services:
+  gptme-server:
+    build:
+      context: .
+      dockerfile: scripts/Dockerfile.selfhost
+    image: gptme-server:selfhost
+    ports:
+      - "${GPTME_SERVER_PORT:-5700}:5700"
+    environment:
+      # At least one provider key is required to run conversations.
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+      OPENROUTER_API_KEY: ${OPENROUTER_API_KEY:-}
+      # Auth token (the server enables auth by default on 0.0.0.0). Set this and
+      # configure the web UI with the same value; if blank, one is auto-generated
+      # at startup — see `docker compose logs`.
+      GPTME_SERVER_TOKEN: ${GPTME_SERVER_TOKEN:-}
+    # Appended to the image's entrypoint (gptme-server serve --host 0.0.0.0
+    # --port 5700). Allows the configured web UI origin to call this server.
+    command:
+      - --cors-origin
+      - ${CORS_ORIGIN:-https://chat.gptme.org}
+    volumes:
+      # Persist config, credentials, and conversation logs across restarts.
+      - gptme-config:/home/gptme/.config/gptme
+      - gptme-data:/home/gptme/.local/share/gptme
+    restart: unless-stopped
+
+volumes:
+  gptme-config:
+  gptme-data:

--- a/docs/server.rst
+++ b/docs/server.rst
@@ -65,6 +65,38 @@ To use the server with a locally hosted gptme-webui, configure the CORS origin w
     ``http://localhost:5701``) avoids the prompt entirely, since that is a
     local-to-local request.
 
+Self-Hosting with Docker Compose
+--------------------------------
+
+For a self-contained deployment, a ``docker-compose.yml`` is included at the
+repository root. It builds a lean image (``scripts/Dockerfile.selfhost``,
+gptme + the ``server`` extra only — no Node/agent tooling) and runs
+``gptme-server`` with persistent volumes for config and conversation logs.
+
+.. code-block:: bash
+
+   # Clone the repository
+   git clone https://github.com/gptme/gptme.git
+   cd gptme
+
+   # Configure: at least one provider key is required
+   cp .env.example .env
+   $EDITOR .env
+
+   # Build and start the server
+   docker compose up --build
+
+The server listens on http://localhost:5700. Open the hosted web UI at
+`chat.gptme.org <https://chat.gptme.org>`_ and point it at your server, or
+self-host the web UI too (set ``CORS_ORIGIN`` in ``.env`` to its origin).
+
+Key ``.env`` settings:
+
+- ``OPENAI_API_KEY`` / ``ANTHROPIC_API_KEY`` / ``OPENROUTER_API_KEY`` — at least one is required.
+- ``GPTME_SERVER_TOKEN`` — auth token. The server enables auth by default when bound to ``0.0.0.0`` (as in the container), so set this and configure the web UI with the same value. If left blank, a token is auto-generated at startup — find it with ``docker compose logs``.
+- ``CORS_ORIGIN`` — origin allowed to call the server (defaults to the hosted web UI).
+- ``GPTME_SERVER_PORT`` — host port to publish (the container always listens on 5700).
+
 Basic Web UI
 ------------
 

--- a/scripts/Dockerfile.selfhost
+++ b/scripts/Dockerfile.selfhost
@@ -1,0 +1,43 @@
+# Lean image for self-hosting gptme-server.
+#
+# Unlike scripts/Dockerfile (which also bundles Node, the GitHub CLI, and the
+# Claude Code CLI for the agent/eval images), this installs only gptme with the
+# `server` extra — just enough to serve the API that the web UI talks to.
+#
+# Build/run via docker compose (see docker-compose.yml at the repo root):
+#   docker compose up --build
+FROM python:3.12-slim
+
+# git: gptme's git-aware features expect it at runtime. curl: container healthcheck.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# .dockerignore trims the build context to gptme/, pyproject.toml, poetry.lock,
+# and README.md — exactly what's needed to build and install the package.
+COPY . /app
+RUN pip install --no-cache-dir ".[server]"
+
+# Run as a non-root user; named volumes inherit this ownership.
+RUN useradd --create-home --uid 1000 gptme \
+    && mkdir -p /home/gptme/.config/gptme /home/gptme/.local/share/gptme \
+    && chown -R gptme:gptme /home/gptme
+USER gptme
+ENV HOME=/home/gptme
+
+EXPOSE 5700
+
+# gptme-server enables auth by default when bound to 0.0.0.0, so the health
+# endpoint returns 401 without a token. Treat a valid token (200) as healthy,
+# and fall back to "401 means the server is alive and routing" for liveness.
+HEALTHCHECK --interval=30s --timeout=10s --start-period=20s --retries=3 \
+    CMD curl -fsS -H "Authorization: Bearer ${GPTME_SERVER_TOKEN}" http://localhost:5700/api/v2/server/health \
+        || [ "$(curl -s -o /dev/null -w '%{http_code}' http://localhost:5700/api/v2/server/health)" = "401" ]
+
+# Bind to 0.0.0.0 so the port is reachable from the host and other containers.
+# Pass --cors-origin (see docker-compose.yml) to allow a web UI origin, and set
+# GPTME_SERVER_TOKEN to require auth (recommended for any non-localhost exposure).
+ENTRYPOINT ["gptme-server", "serve", "--host", "0.0.0.0", "--port", "5700"]


### PR DESCRIPTION
## What

Adds a one-command self-host path for `gptme-server`:

```bash
git clone https://github.com/gptme/gptme.git && cd gptme
cp .env.example .env   # add a provider key + GPTME_SERVER_TOKEN
docker compose up --build
```

Then open the hosted web UI at [chat.gptme.org](https://chat.gptme.org) and point it at your server (or self-host the web UI too via `CORS_ORIGIN`).

## Why

The existing Docker assets (`scripts/Dockerfile`, `scripts/Dockerfile.server`) are oriented toward the k8s/skaffold build chain (`BASE` ARG, Node + gh + Claude Code layers) and there was no simple `docker compose up` for someone who just wants to self-host the server. Advances the "upload and self-host" idea — a docker-compose path was the explicitly named option.

## Changes

- **`scripts/Dockerfile.selfhost`** — lean image: `pip install .[server]` only (no Node/gh/Claude Code), runs non-root, token-aware `HEALTHCHECK`.
- **`docker-compose.yml`** — builds + runs the server, persistent named volumes for config and conversation logs, passes `--cors-origin` (defaults to the hosted web UI).
- **`.env.example`** — provider keys, `GPTME_SERVER_TOKEN`, `CORS_ORIGIN`, host port. Added a `!.env.example` negation to `.gitignore` so the template tracks.
- **`docs/server.rst`** — new "Self-Hosting with Docker Compose" section.

## Verification

- `docker compose config` validates; `docker compose build` succeeds (image ~390MB).
- Server boots; `GET /api/v2/server/health` returns `200 {"health":"green",...}` with a token and `401` without (auth is on by default when bound to `0.0.0.0` — documented).
- Healthcheck verified `HEALTHY` on both the token path (200) and the no-token liveness fallback (401 = alive + routing).