### PR TITLE
build: exclude webui/tauri/site from Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -43,6 +43,14 @@ demos
 projects
 eval_results*
 
+# Frontend / desktop / static-site sources — not needed by either image.
+# The agent image (scripts/Dockerfile) copies only pyproject/gptme explicitly;
+# the self-host image (scripts/Dockerfile.selfhost) only pip-installs the
+# package. tauri (~8G) and webui (~600M) would otherwise bloat the build context.
+webui
+tauri
+site
+
 # Specific filetypes
 *.csv
 *.jsonl


### PR DESCRIPTION
## Problem

The repo-root `.dockerignore` is a **denylist** (no leading `*`), so any top-level path *not* explicitly listed is included in the Docker build context. `webui` (~600M) and `tauri` (~8G) were never listed, so `docker compose up --build` — and the agent image build — ship roughly **9 GB of frontend/desktop sources** to the daemon as build context.

This contradicts the `scripts/Dockerfile.selfhost` header comment, which claims the context is trimmed to `gptme/`, `pyproject.toml`, `poetry.lock`, and `README.md`, and the image's stated "no Node/agent tooling" intent (added in #2681).

## Fix

Add `webui`, `tauri`, and `site` to `.dockerignore`.

Neither image needs them:
- `scripts/Dockerfile` (agent/eval) copies only `pyproject.toml poetry.lock README.md` + `gptme/` explicitly — it never reads these dirs from context.
- `scripts/Dockerfile.selfhost` does `COPY . /app` then `pip install ".[server]"` — it only needs the Python package files.

So excluding them is safe for both builds and makes the self-host build context lean as intended.

## Verification

- `.dockerignore` semantics: listed top-level dirs are excluded; `webui`/`tauri`/`site` are not in the `!keep` exception list, so the new entries take effect.
- Confirmed the agent Dockerfile uses explicit `COPY` (does not depend on these dirs being present in context).
- pre-commit hooks pass.