### PR TITLE
docs(server): point self-hosters to the same-origin bundled web UI

### DIFF
--- a/docs/server.rst
+++ b/docs/server.rst
@@ -86,9 +86,17 @@ gptme + the ``server`` extra only — no Node/agent tooling) and runs
    # Build and start the server
    docker compose up --build
 
-The server listens on http://localhost:5700. Open the hosted web UI at
-`chat.gptme.org <https://chat.gptme.org>`_ and point it at your server, or
-self-host the web UI too (set ``CORS_ORIGIN`` in ``.env`` to its origin).
+The server listens on http://localhost:5700.
+
+The simplest way to use it is the basic web UI the server bundles at the same
+origin — just open http://localhost:5700 in a browser. Being same-origin, it
+needs no CORS setup (you will still need the server token; see below).
+
+To use the full-featured hosted web UI instead, open
+`chat.gptme.org <https://chat.gptme.org>`_ and point it at your server. That is
+a cross-origin setup, so the server must allow the UI's origin — the default
+``CORS_ORIGIN`` already permits ``chat.gptme.org``. Set ``CORS_ORIGIN`` in
+``.env`` to a different origin if you self-host the web UI yourself.
 
 Key ``.env`` settings:
 


### PR DESCRIPTION
## What

The Docker Compose self-host walkthrough (added in #2681) steered users straight to the **cross-origin** `chat.gptme.org` UI without surfacing the simplest path: the basic web UI the server already bundles at the **same origin** (`http://localhost:5700`).

## Why

Cross-origin client→server is the #1 self-hoster confusion (CORS, Chrome Private Network Access, configuring the token in a third-party UI). The bundled same-origin UI sidesteps all of it but was only mentioned in a separate "Basic Web UI" section further down, not linked from the self-host steps.

This reorders the prose to lead with the same-origin option and reframes `chat.gptme.org` as the cross-origin alternative the default `CORS_ORIGIN` already permits. Accurate against the server's CORS handling in `gptme/server/app.py` (named-origin opt-in for credentials + PNA).

## Scope

Docs-only (`docs/server.rst`), no code change.