### PR TITLE
fix(webui): add missing getServerHealth to demoApiClient

### DIFF
--- a/webui/src/utils/demoApiClient.ts
+++ b/webui/src/utils/demoApiClient.ts
@@ -16,7 +16,7 @@
  */
 import { observable } from '@legendapp/state';
 import type { ConnectionProbeResult, IApiClient } from '@/utils/api';
-import type { UserInfo } from '@/types/api';
+import type { ServerHealth, UserInfo } from '@/types/api';
 
 /** Thrown by demo-client paths that have no recorded fixture yet (slice 1). */
 export class DemoModeError extends Error {
@@ -73,6 +73,13 @@ export function createDemoApiClient(baseUrl: string = DEMO_BASE_URL): IApiClient
     getConversationsPaginated: async () => ({ conversations: [], nextCursor: undefined }),
     getExternalSessions: async () => [],
     getSessions: async () => [],
+    getServerHealth: async (): Promise<ServerHealth> => ({
+      session_count: 0,
+      generating_count: 0,
+      idle_count: 0,
+      health: 'green',
+      slots: [],
+    }),
 
     // Read paths — not yet fixture-backed; later slices will provide recorded data.
     getUserInfo: async () => notImpl('getUserInfo'),


### PR DESCRIPTION
## Problem

Master CI (Tauri/Android build) is failing with:

```
src/utils/demoApiClient.ts(49,9): error TS2741: Property 'getServerHealth' is missing in type '...' but required in type 'IApiClient'.
```

`getServerHealth` was added to `ApiClient` / `IApiClient` but `demoApiClient.ts` was not updated to implement it.

## Fix

- Import `ServerHealth` from `@/types/api`
- Add `getServerHealth` returning a demo green state (zero sessions, `health: 'green'`, empty slots) in the "serve empty collections" read-path section alongside `getSessions`

This matches the existing pattern: `getServerInfo` returns `{ version: 'demo' }` — health reads return sensible static data rather than throwing `DemoModeError`.

## Verification

`npx tsc -p tsconfig.app.json --noEmit` passes cleanly in the worktree.