### PR TITLE
fix(webui): add missing getServerHealth to demo ApiClient

### DIFF
--- a/webui/src/utils/demoApiClient.ts
+++ b/webui/src/utils/demoApiClient.ts
@@ -68,6 +68,13 @@ export function createDemoApiClient(baseUrl: string = DEMO_BASE_URL): IApiClient
 
     // Read paths — serve empty collections so the UI renders cleanly.
     getServerInfo: async () => ({ version: 'demo' }),
+    getServerHealth: async () => ({
+      session_count: 0,
+      generating_count: 0,
+      idle_count: 0,
+      health: 'green',
+      slots: [],
+    }),
     getConversations: async () => [],
     searchConversations: async () => [],
     getConversationsPaginated: async () => ({ conversations: [], nextCursor: undefined }),


### PR DESCRIPTION
## Summary

- `getServerHealth` was added to `ApiClient` in the same commit that introduced `IApiClient = Pick<ApiClient, keyof ApiClient>`, but the offline `createDemoApiClient` implementation was missing it, causing a TypeScript build error (`TS2741`) in the Tauri CI workflow.
- The fix adds `getServerHealth` to the "empty collections" read-path group in `demoApiClient.ts`, returning a `{ session_count: 0, generating_count: 0, idle_count: 0, health: 'green', slots: [] }` mock consistent with the "demo is permanently connected" contract.
- tsc passes locally after this change.

## Test plan

- [ ] Tauri CI (`Build Android (APK/AAB)`) should go green with this fix
- [ ] Local: `cd webui && npx tsc -p tsconfig.app.json --noEmit` exits 0