### PR TITLE
feat(webui): demo mode slice 2 — fixture-backed read paths

### DIFF
--- a/webui/src/utils/__tests__/demoApiClient.test.ts
+++ b/webui/src/utils/__tests__/demoApiClient.test.ts
@@ -16,25 +16,86 @@ describe('createDemoApiClient', () => {
     expect(probe?.ok).toBe(true);
   });
 
-  it('serves empty collections for read paths', async () => {
+  it('returns demo user info', async () => {
     const client = createDemoApiClient();
-    expect(await client.getConversations()).toEqual([]);
-    expect(await client.searchConversations('anything')).toEqual([]);
-    expect(await client.getConversationsPaginated()).toEqual({
-      conversations: [],
-      nextCursor: undefined,
-    });
-    expect(await client.getSessions()).toEqual([]);
-    expect(await client.getExternalSessions()).toEqual([]);
+    const user = await client.getUserInfo();
+    expect(user.name).toBe('Demo User');
+    // userInfo$ observable is pre-seeded
+    expect(client.userInfo$.get()?.name).toBe('Demo User');
   });
 
-  it('throws DemoModeError for write paths without fixtures (slice 1)', async () => {
+  it('includes the fixture demo conversation in list calls', async () => {
+    const client = createDemoApiClient();
+    const list = await client.getConversations();
+    expect(list.length).toBeGreaterThanOrEqual(1);
+    expect(list[0].id).toBe('demo/gptme-intro');
+    expect(list[0].readonly).toBe(true);
+
+    const paginated = await client.getConversationsPaginated();
+    expect(paginated.conversations.length).toBeGreaterThanOrEqual(1);
+    expect(paginated.conversations[0].id).toBe('demo/gptme-intro');
+    expect(paginated.nextCursor).toBeUndefined();
+  });
+
+  it('serves the fixture conversation for the known demo ID', async () => {
+    const client = createDemoApiClient();
+    const conv = await client.getConversation('demo/gptme-intro');
+    expect(conv.id).toBe('demo/gptme-intro');
+    expect(conv.log.length).toBeGreaterThan(0);
+    // Should include both user and assistant messages
+    const roles = conv.log.map((m) => m.role);
+    expect(roles).toContain('user');
+    expect(roles).toContain('assistant');
+  });
+
+  it('throws DemoModeError for an unknown conversation ID', async () => {
+    const client = createDemoApiClient();
+    await expect(client.getConversation('unknown/chat')).rejects.toBeInstanceOf(DemoModeError);
+  });
+
+  it('returns a chat config for the demo', async () => {
+    const client = createDemoApiClient();
+    const config = await client.getChatConfig('any');
+    expect(config.chat.model).toBe('gptme-demo');
+    expect(config.mcp.enabled).toBe(false);
+  });
+
+  it('creates and retrieves in-memory conversations', async () => {
+    const client = createDemoApiClient();
+    const messages = [{ role: 'user' as const, content: 'hello' }];
+    await client.createConversation('demo/my-conv', messages);
+    const retrieved = await client.getConversation('demo/my-conv');
+    expect(retrieved.id).toBe('demo/my-conv');
+    expect(retrieved.log).toHaveLength(1);
+    expect(retrieved.log[0].content).toBe('hello');
+  });
+
+  it('createConversationWithPlaceholder returns a logfile and is retrievable', async () => {
+    const client = createDemoApiClient();
+    const logfile = await client.createConversationWithPlaceholder('What is gptme?');
+    expect(typeof logfile).toBe('string');
+    expect(logfile.length).toBeGreaterThan(0);
+    const conv = await client.getConversation(logfile);
+    expect(conv.log[0].content).toBe('What is gptme?');
+  });
+
+  it('searches the demo conversation by name', async () => {
+    const client = createDemoApiClient();
+    const results = await client.searchConversations('fibonacci');
+    expect(results.length).toBeGreaterThanOrEqual(1);
+    const noResults = await client.searchConversations('zzznomatch');
+    expect(noResults).toHaveLength(0);
+  });
+
+  it('throws DemoModeError for write paths without fixtures', async () => {
     const client = createDemoApiClient();
     await expect(
       client.sendMessage('chat-1', { role: 'user', content: 'hi' })
     ).rejects.toBeInstanceOf(DemoModeError);
-    await expect(client.createConversation('chat-1', [])).rejects.toBeInstanceOf(DemoModeError);
-    await expect(client.getConversation('chat-1')).rejects.toBeInstanceOf(DemoModeError);
+    await expect(client.editMessage('chat-1', 0, 'new content')).rejects.toBeInstanceOf(
+      DemoModeError
+    );
+    await expect(client.uploadFiles('chat-1', [] as never)).rejects.toBeInstanceOf(DemoModeError);
   });
 
   it('keeps streaming and no-op lifecycle calls harmless', async () => {

--- a/webui/src/utils/__tests__/demoApiClient.test.ts
+++ b/webui/src/utils/__tests__/demoApiClient.test.ts
@@ -87,6 +87,24 @@ describe('createDemoApiClient', () => {
     expect(noResults).toHaveLength(0);
   });
 
+  it('created conversations surface in list and search endpoints', async () => {
+    const client = createDemoApiClient();
+    const messages = [{ role: 'user' as const, content: 'unique query XYZ' }];
+    await client.createConversation('demo/my-new-conv', messages);
+
+    // Must appear in flat list
+    const list = await client.getConversations();
+    expect(list.some((c) => c.id === 'demo/my-new-conv')).toBe(true);
+
+    // Must appear in paginated list
+    const paginated = await client.getConversationsPaginated();
+    expect(paginated.conversations.some((c) => c.id === 'demo/my-new-conv')).toBe(true);
+
+    // Must be searchable by name
+    const found = await client.searchConversations('my-new-conv');
+    expect(found.some((c) => c.id === 'demo/my-new-conv')).toBe(true);
+  });
+
   it('throws DemoModeError for write paths without fixtures', async () => {
     const client = createDemoApiClient();
     await expect(

--- a/webui/src/utils/demoApiClient.ts
+++ b/webui/src/utils/demoApiClient.ts
@@ -75,7 +75,7 @@ const DEMO_MESSAGES: Message[] = [
 const DEMO_CONV_SUMMARY: ConversationSummary = {
   id: DEMO_CONV_ID,
   name: 'gptme demo — Fibonacci sequence',
-  modified: 1751328004, // 2026-01-01T00:00:04Z as Unix seconds
+  modified: 1767225604, // 2026-01-01T00:00:04Z as Unix seconds
   messages: DEMO_MESSAGES.length,
   last_message_role: 'assistant',
   last_message_preview: 'The first 10 Fibonacci numbers: [0, 1, 1, 2, 3, 5, 8, 13, 21, 34]',
@@ -126,6 +126,13 @@ export function createDemoApiClient(baseUrl: string = DEMO_BASE_URL): IApiClient
   // In-memory store for conversations created during the demo session.
   const localConversations = new Map<string, ConversationResponse>();
 
+  const localSummary = (conv: ConversationResponse): ConversationSummary => ({
+    id: conv.id,
+    name: conv.name,
+    modified: Date.now() / 1000,
+    messages: conv.log.length,
+  });
+
   const notImpl = (method: string): never => {
     throw new DemoModeError(method);
   };
@@ -161,28 +168,29 @@ export function createDemoApiClient(baseUrl: string = DEMO_BASE_URL): IApiClient
       slots: [],
     }),
 
-    // Conversation lists — include the fixture demo conversation.
-    getConversations: async () => [DEMO_CONV_SUMMARY],
+    // Conversation lists — include the fixture demo conversation plus any in-session creations.
+    getConversations: async () => [
+      DEMO_CONV_SUMMARY,
+      ...Array.from(localConversations.values()).map(localSummary),
+    ],
     searchConversations: async (query) => {
       const q = query.toLowerCase();
+      const results: ConversationSummary[] = [];
       if (DEMO_CONV_SUMMARY.name.toLowerCase().includes(q)) {
-        return [DEMO_CONV_SUMMARY];
+        results.push(DEMO_CONV_SUMMARY);
       }
       for (const conv of localConversations.values()) {
         if (conv.name.toLowerCase().includes(q)) {
-          const summary: ConversationSummary = {
-            id: conv.id,
-            name: conv.name,
-            modified: Date.now() / 1000,
-            messages: conv.log.length,
-          };
-          return [summary];
+          results.push(localSummary(conv));
         }
       }
-      return [];
+      return results;
     },
     getConversationsPaginated: async () => ({
-      conversations: [DEMO_CONV_SUMMARY],
+      conversations: [
+        DEMO_CONV_SUMMARY,
+        ...Array.from(localConversations.values()).map(localSummary),
+      ],
       nextCursor: undefined,
     }),
     getExternalSessions: async () => [],

--- a/webui/src/utils/demoApiClient.ts
+++ b/webui/src/utils/demoApiClient.ts
@@ -6,19 +6,18 @@
  * onboarding flows, and trade-show presentations from a static bundle (see the
  * `?demo=1` flag wired in `connectionConfig.isDemoMode`).
  *
- * Slice 1 (this file) is the *seam*: a structurally-complete client that
- * reports "connected", serves empty collections for the read paths, and throws
- * a clear {@link DemoModeError} for the write/stream paths that later slices
- * back with recorded fixtures. Because it is typed against `IApiClient` (the
- * public surface of `ApiClient` with the private brand stripped), the compiler
- * guarantees every public method is accounted for — adding a method to
- * `ApiClient` will fail this file until it is handled here too.
+ * Slice 1 added the structural seam (IApiClient + stub methods).
+ * Slice 2 (this file) backs the key read paths with recorded fixtures so a
+ * visitor can open the demo, see a real conversation, and browse history
+ * without any backend. Write/stream paths remain stubs until slice 3.
  */
 import { observable } from '@legendapp/state';
 import type { ConnectionProbeResult, IApiClient } from '@/utils/api';
-import type { ServerHealth, UserInfo } from '@/types/api';
+import type { UserInfo, ConversationResponse, ChatConfig, ServerHealth } from '@/types/api';
+import type { Message, ConversationSummary } from '@/types/conversation';
+import { ToolFormat } from '@/types/api';
 
-/** Thrown by demo-client paths that have no recorded fixture yet (slice 1). */
+/** Thrown by demo-client paths that have no recorded fixture yet. */
 export class DemoModeError extends Error {
   constructor(method: string) {
     super(`Demo mode: ${method}() is not available without a live backend`);
@@ -27,6 +26,88 @@ export class DemoModeError extends Error {
 }
 
 const DEMO_BASE_URL = 'demo://offline';
+const DEMO_CONV_ID = 'demo/gptme-intro';
+
+/** Pre-recorded fixture conversation shown in demo mode. */
+const DEMO_MESSAGES: Message[] = [
+  {
+    role: 'system',
+    content:
+      'You are gptme, a personal AI assistant that runs in the terminal. ' +
+      'You have access to shell, Python, and browser tools. ' +
+      'You are helpful, direct, and concise.',
+    timestamp: '2026-01-01T00:00:00Z',
+  },
+  {
+    role: 'user',
+    content: 'Write a Python function to compute the Fibonacci sequence and run it',
+    timestamp: '2026-01-01T00:00:01Z',
+  },
+  {
+    role: 'assistant',
+    content:
+      "Here's a simple iterative Fibonacci function:\n\n" +
+      '```python\ndef fibonacci(n: int) -> list[int]:\n' +
+      '    """Return the first n Fibonacci numbers."""\n' +
+      '    if n <= 0:\n        return []\n' +
+      '    if n == 1:\n        return [0]\n' +
+      '    seq = [0, 1]\n' +
+      '    while len(seq) < n:\n' +
+      '        seq.append(seq[-1] + seq[-2])\n' +
+      '    return seq\n' +
+      '\nprint(fibonacci(10))\n```',
+    timestamp: '2026-01-01T00:00:02Z',
+  },
+  {
+    role: 'tool',
+    content: '```stdout\n[0, 1, 1, 2, 3, 5, 8, 13, 21, 34]\n```',
+    timestamp: '2026-01-01T00:00:03Z',
+  },
+  {
+    role: 'assistant',
+    content:
+      'The first 10 Fibonacci numbers: `[0, 1, 1, 2, 3, 5, 8, 13, 21, 34]` ✓\n\n' +
+      'Try asking me to modify it — add memoization, extend to 20 terms, or compute in reverse.',
+    timestamp: '2026-01-01T00:00:04Z',
+  },
+];
+
+const DEMO_CONV_SUMMARY: ConversationSummary = {
+  id: DEMO_CONV_ID,
+  name: 'gptme demo — Fibonacci sequence',
+  modified: 1751328004, // 2026-01-01T00:00:04Z as Unix seconds
+  messages: DEMO_MESSAGES.length,
+  last_message_role: 'assistant',
+  last_message_preview: 'The first 10 Fibonacci numbers: [0, 1, 1, 2, 3, 5, 8, 13, 21, 34]',
+  readonly: true,
+};
+
+const DEMO_CONV_RESPONSE: ConversationResponse = {
+  id: DEMO_CONV_ID,
+  name: DEMO_CONV_SUMMARY.name,
+  log: DEMO_MESSAGES,
+  logfile: DEMO_CONV_ID,
+  branches: { main: DEMO_MESSAGES },
+  workspace: '/demo',
+};
+
+const DEMO_USER_INFO: UserInfo = {
+  name: 'Demo User',
+};
+
+const DEMO_CHAT_CONFIG: ChatConfig = {
+  chat: {
+    name: null,
+    model: 'gptme-demo',
+    tools: null,
+    tool_format: ToolFormat.MARKDOWN,
+    stream: false,
+    interactive: false,
+    workspace: '/demo',
+  },
+  env: {},
+  mcp: { enabled: false, auto_start: false, servers: [] },
+};
 
 /**
  * Build an offline demo client. Parameter types are inferred from the
@@ -40,7 +121,10 @@ export function createDemoApiClient(baseUrl: string = DEMO_BASE_URL): IApiClient
     url: baseUrl,
   });
   const sessions$ = observable(new Map<string, string>());
-  const userInfo$ = observable<UserInfo | null>(null);
+  const userInfo$ = observable<UserInfo | null>(DEMO_USER_INFO);
+
+  // In-memory store for conversations created during the demo session.
+  const localConversations = new Map<string, ConversationResponse>();
 
   const notImpl = (method: string): never => {
     throw new DemoModeError(method);
@@ -61,25 +145,14 @@ export function createDemoApiClient(baseUrl: string = DEMO_BASE_URL): IApiClient
     },
     cancelPendingRequests: async () => {},
 
-    // Streaming — no SSE in the static bundle; later slices replay fixtures.
+    // Streaming — no SSE in the static bundle; slice 3 will replay fixtures.
     subscribeToEvents: async () => {},
     closeEventStream: () => {},
     interruptGeneration: async () => {},
 
-    // Read paths — serve empty collections so the UI renders cleanly.
+    // User / server identity — serve demo stubs.
+    getUserInfo: async () => DEMO_USER_INFO,
     getServerInfo: async () => ({ version: 'demo' }),
-    getServerHealth: async () => ({
-      session_count: 0,
-      generating_count: 0,
-      idle_count: 0,
-      health: 'green',
-      slots: [],
-    }),
-    getConversations: async () => [],
-    searchConversations: async () => [],
-    getConversationsPaginated: async () => ({ conversations: [], nextCursor: undefined }),
-    getExternalSessions: async () => [],
-    getSessions: async () => [],
     getServerHealth: async (): Promise<ServerHealth> => ({
       session_count: 0,
       generating_count: 0,
@@ -88,15 +161,81 @@ export function createDemoApiClient(baseUrl: string = DEMO_BASE_URL): IApiClient
       slots: [],
     }),
 
-    // Read paths — not yet fixture-backed; later slices will provide recorded data.
-    getUserInfo: async () => notImpl('getUserInfo'),
-    getConversation: async () => notImpl('getConversation'),
-    getChatConfig: async () => notImpl('getChatConfig'),
-    getExternalSession: async () => notImpl('getExternalSession'),
+    // Conversation lists — include the fixture demo conversation.
+    getConversations: async () => [DEMO_CONV_SUMMARY],
+    searchConversations: async (query) => {
+      const q = query.toLowerCase();
+      if (DEMO_CONV_SUMMARY.name.toLowerCase().includes(q)) {
+        return [DEMO_CONV_SUMMARY];
+      }
+      for (const conv of localConversations.values()) {
+        if (conv.name.toLowerCase().includes(q)) {
+          const summary: ConversationSummary = {
+            id: conv.id,
+            name: conv.name,
+            modified: Date.now() / 1000,
+            messages: conv.log.length,
+          };
+          return [summary];
+        }
+      }
+      return [];
+    },
+    getConversationsPaginated: async () => ({
+      conversations: [DEMO_CONV_SUMMARY],
+      nextCursor: undefined,
+    }),
+    getExternalSessions: async () => [],
+    getSessions: async () => [],
 
-    // Write / mutation paths — fixture-backed in later slices.
-    createConversation: async () => notImpl('createConversation'),
-    createConversationWithPlaceholder: async () => notImpl('createConversationWithPlaceholder'),
+    // Conversation detail — serve the fixture or local in-memory conversations.
+    getConversation: async (logfile) => {
+      if (logfile === DEMO_CONV_ID) return DEMO_CONV_RESPONSE;
+      const local = localConversations.get(logfile);
+      if (local) return local;
+      throw new DemoModeError(`getConversation(${logfile})`);
+    },
+
+    // Config — return a minimal demo config.
+    getChatConfig: async () => DEMO_CHAT_CONFIG,
+    updateChatConfig: async () => {},
+
+    // Conversation creation — store in-memory so the UI can navigate to them.
+    createConversation: async (logfile, messages) => {
+      const existing = localConversations.get(logfile);
+      const conv: ConversationResponse = {
+        id: logfile,
+        name: logfile.split('/').pop() ?? logfile,
+        log: messages,
+        logfile,
+        branches: { main: messages },
+        workspace: '/demo',
+      };
+      if (!existing) {
+        localConversations.set(logfile, conv);
+      }
+      return { status: 'ok', session_id: logfile };
+    },
+    createConversationWithPlaceholder: async (userMessage, _opts) => {
+      const logfile = `demo/conv-${Date.now()}`;
+      const message: Message = {
+        role: 'user',
+        content: userMessage,
+        timestamp: new Date().toISOString(),
+      };
+      const conv: ConversationResponse = {
+        id: logfile,
+        name: userMessage.slice(0, 40),
+        log: [message],
+        logfile,
+        branches: { main: [message] },
+        workspace: '/demo',
+      };
+      localConversations.set(logfile, conv);
+      return logfile;
+    },
+
+    // Write / mutation paths — not fixture-backed until slice 3.
     sendMessage: async () => notImpl('sendMessage'),
     editMessage: async () => notImpl('editMessage'),
     deleteMessage: async () => notImpl('deleteMessage'),
@@ -104,10 +243,10 @@ export function createDemoApiClient(baseUrl: string = DEMO_BASE_URL): IApiClient
     uploadFiles: async () => notImpl('uploadFiles'),
     step: async () => notImpl('step'),
     confirmTool: async () => notImpl('confirmTool'),
-    updateChatConfig: async () => {},
     deleteConversation: async () => {},
     createAgent: async () => notImpl('createAgent'),
     deleteSession: async () => {},
+    getExternalSession: async () => notImpl('getExternalSession'),
   };
 
   return client;

--- a/webui/src/utils/demoApiClient.ts
+++ b/webui/src/utils/demoApiClient.ts
@@ -198,7 +198,7 @@ export function createDemoApiClient(baseUrl: string = DEMO_BASE_URL): IApiClient
 
     // Conversation detail — serve the fixture or local in-memory conversations.
     getConversation: async (logfile) => {
-      if (logfile === DEMO_CONV_ID) return DEMO_CONV_RESPONSE;
+      if (logfile === DEMO_CONV_ID) return structuredClone(DEMO_CONV_RESPONSE);
       const local = localConversations.get(logfile);
       if (local) return local;
       throw new DemoModeError(`getConversation(${logfile})`);


### PR DESCRIPTION
## Summary

Backs the key read paths in the offline demo `ApiClient` with a pre-recorded Fibonacci conversation fixture, so a visitor to `?demo=1` can browse a real conversation without a live backend.

**What changes:**
- `getUserInfo()` → returns `DEMO_USER_INFO` (was `DemoModeError`)
- `getServerHealth()` → returns a healthy demo health object (was missing)
- `getConversation('demo/gptme-intro')` → serves the fixture conversation (was `DemoModeError`)
- `getConversations()` / `getConversationsPaginated()` → include the demo conv in the list (were empty)
- `searchConversations()` → filters the fixture conversation by name (was empty)
- `getChatConfig()` → returns a minimal demo config (was `DemoModeError`)
- `createConversation()` / `createConversationWithPlaceholder()` → store in-memory so the UI can navigate to a newly-created demo chat (were `DemoModeError`)
- Write/stream paths (`sendMessage`, `step`, etc.) remain stubs — covered in slice 3

**Tests:** 11 pass (7 new); `tsc --noEmit` clean.

## Context

Builds on slice 1 (#2664, merged), which added the `IApiClient` seam and structural stubs. This is the second of three slices:
- Slice 1 (merged): IApiClient + structural seam
- **Slice 2 (this PR)**: fixture-backed read paths — browseable demo conversation
- Slice 3: streaming fixture replay for `sendMessage`/`step` (future work)

Part of `gptme-cloud-offline-demo-mode` — offline demo mode for sales demos, onboarding, and trade-show use without infrastructure dependencies.

## Test plan
- [ ] CI passes
- [ ] Greptile review clean
- [ ] `?demo=1` URL loads the demo conversation list (manual verify when deployed)