### PR TITLE
docs(server): add systemd unit template for pipx self-hosters

### DIFF
--- a/docs/server.rst
+++ b/docs/server.rst
@@ -225,6 +225,13 @@ The template runs the server as a dedicated ``gptme`` user, reads secrets from
     sudo useradd --system --create-home --shell /usr/sbin/nologin gptme
     sudo -u gptme pipx install 'gptme[server]'
 
+    # Pre-create config/data dirs (required: ProtectHome=read-only only bind-mounts
+    # paths that already exist; gptme initialises them at import time, which fails
+    # under the sandbox on a fresh install before any request is served)
+    sudo -u gptme mkdir -p /home/gptme/.config/gptme \
+                           /home/gptme/.local/share/gptme \
+                           /home/gptme/.local/state/gptme
+
     # Secrets file (provider keys, optional GPTME_SERVER_TOKEN), not world-readable
     sudo install -d -m 750 -o gptme -g gptme /etc/gptme
     sudo install -m 640 -o gptme -g gptme /dev/null /etc/gptme/server.env

--- a/docs/server.rst
+++ b/docs/server.rst
@@ -207,6 +207,39 @@ itself (for example, behind a VPN or an SSH tunnel), skip the proxy entirely and
 keep the default loopback bind — open an SSH tunnel from your client with
 ``ssh -L 5700:127.0.0.1:5700 user@host`` and use ``http://localhost:5700``.
 
+Running as a systemd Service (pipx)
+-----------------------------------
+
+If you installed gptme directly with ``pipx`` rather than Docker, you can run
+the server as a systemd service so it starts on boot and restarts on failure.
+A ready-to-edit unit template ships at `scripts/gptme-server.service
+<https://github.com/gptme/gptme/blob/master/scripts/gptme-server.service>`_.
+
+The template runs the server as a dedicated ``gptme`` user, reads secrets from
+``/etc/gptme/server.env``, binds loopback, and applies systemd hardening
+(``ProtectSystem=strict``, ``NoNewPrivileges``, etc.). Install it with:
+
+.. code-block:: bash
+
+    # Dedicated service user + pipx install of the entrypoint
+    sudo useradd --system --create-home --shell /usr/sbin/nologin gptme
+    sudo -u gptme pipx install 'gptme[server]'
+
+    # Secrets file (provider keys, optional GPTME_SERVER_TOKEN), not world-readable
+    sudo install -d -m 750 -o gptme -g gptme /etc/gptme
+    sudo install -m 640 -o gptme -g gptme /dev/null /etc/gptme/server.env
+    sudoedit /etc/gptme/server.env   # add ANTHROPIC_API_KEY=... etc.
+
+    # Install and start the unit (adjust User=, the ExecStart path, --cors-origin)
+    sudo cp scripts/gptme-server.service /etc/systemd/system/
+    sudo systemctl daemon-reload
+    sudo systemctl enable --now gptme-server
+
+Tail logs with ``journalctl -u gptme-server -f``. Because the unit binds
+``127.0.0.1``, pair it with the nginx reverse proxy above to expose it over TLS;
+on loopback the auth token is optional (set ``GPTME_SERVER_TOKEN`` in the env
+file if you change the bind to a public interface).
+
 Basic Web UI
 ------------
 

--- a/docs/server.rst
+++ b/docs/server.rst
@@ -237,8 +237,9 @@ The template runs the server as a dedicated ``gptme`` user, reads secrets from
     sudo install -m 640 -o gptme -g gptme /dev/null /etc/gptme/server.env
     sudoedit /etc/gptme/server.env   # add ANTHROPIC_API_KEY=... etc.
 
-    # Install and start the unit (adjust User=, the ExecStart path, --cors-origin)
-    sudo cp scripts/gptme-server.service /etc/systemd/system/
+    # Download and install the unit (adjust User=, the ExecStart path, --cors-origin)
+    sudo curl -fsSL https://raw.githubusercontent.com/gptme/gptme/master/scripts/gptme-server.service \
+        -o /etc/systemd/system/gptme-server.service
     sudo systemctl daemon-reload
     sudo systemctl enable --now gptme-server
 

--- a/scripts/gptme-server.service
+++ b/scripts/gptme-server.service
@@ -43,7 +43,7 @@ Group=gptme
 # Provider keys (OPENAI_API_KEY / ANTHROPIC_API_KEY / OPENROUTER_API_KEY) and an
 # optional GPTME_SERVER_TOKEN live here, one KEY=value per line. Keep it 0640
 # and owned by the service user so secrets are not world-readable.
-EnvironmentFile=/etc/gptme/server.env
+EnvironmentFile=-/etc/gptme/server.env
 
 # Adjust the path to wherever pipx installed the entrypoint for User= above.
 # Bind loopback and front it with a reverse proxy; set --cors-origin to the

--- a/scripts/gptme-server.service
+++ b/scripts/gptme-server.service
@@ -9,12 +9,18 @@
 #   1. sudo useradd --system --create-home --shell /usr/sbin/nologin gptme
 #   2. sudo -u gptme pipx install 'gptme[server]'
 #        (binary lands at /home/gptme/.local/bin/gptme-server)
-#   3. sudo install -d -m 750 -o gptme -g gptme /etc/gptme
+#   3. sudo -u gptme mkdir -p /home/gptme/.config/gptme \
+#                              /home/gptme/.local/share/gptme \
+#                              /home/gptme/.local/state/gptme
+#      # Required: ProtectHome=read-only + ReadWritePaths only bind-mounts
+#      # paths that already exist; gptme creates them at import time if absent,
+#      # which fails under the sandbox before a single request is served.
+#   4. sudo install -d -m 750 -o gptme -g gptme /etc/gptme
 #      sudo install -m 640 -o gptme -g gptme /dev/null /etc/gptme/server.env
 #      # then edit /etc/gptme/server.env (see the EnvironmentFile keys below)
-#   4. sudo cp scripts/gptme-server.service /etc/systemd/system/
+#   5. sudo cp scripts/gptme-server.service /etc/systemd/system/
 #      # adjust User=, the ExecStart path, and --cors-origin to match your setup
-#   5. sudo systemctl daemon-reload && sudo systemctl enable --now gptme-server
+#   6. sudo systemctl daemon-reload && sudo systemctl enable --now gptme-server
 #
 # The server binds to loopback (127.0.0.1) by design: terminate TLS and expose
 # it with a reverse proxy (see the "Production Deployment" section of
@@ -56,7 +62,7 @@ ProtectSystem=strict
 ProtectHome=read-only
 # gptme persists config and conversation logs under the service user's home;
 # grant write access to just those paths (matches the User= home above).
-ReadWritePaths=/home/gptme/.config/gptme /home/gptme/.local/share/gptme
+ReadWritePaths=/home/gptme/.config/gptme /home/gptme/.local/share/gptme /home/gptme/.local/state/gptme
 ProtectControlGroups=true
 ProtectKernelModules=true
 ProtectKernelTunables=true

--- a/scripts/gptme-server.service
+++ b/scripts/gptme-server.service
@@ -1,0 +1,67 @@
+# systemd unit template for running gptme-server as a persistent service.
+#
+# This is the pipx self-host counterpart to the Docker Compose setup
+# (docker-compose.yml): use it when you installed gptme directly with
+#   pipx install 'gptme[server]'
+# and want the server to start on boot and restart on failure, without Docker.
+#
+# Install (system-wide, runs as a dedicated user):
+#   1. sudo useradd --system --create-home --shell /usr/sbin/nologin gptme
+#   2. sudo -u gptme pipx install 'gptme[server]'
+#        (binary lands at /home/gptme/.local/bin/gptme-server)
+#   3. sudo install -d -m 750 -o gptme -g gptme /etc/gptme
+#      sudo install -m 640 -o gptme -g gptme /dev/null /etc/gptme/server.env
+#      # then edit /etc/gptme/server.env (see the EnvironmentFile keys below)
+#   4. sudo cp scripts/gptme-server.service /etc/systemd/system/
+#      # adjust User=, the ExecStart path, and --cors-origin to match your setup
+#   5. sudo systemctl daemon-reload && sudo systemctl enable --now gptme-server
+#
+# The server binds to loopback (127.0.0.1) by design: terminate TLS and expose
+# it with a reverse proxy (see the "Production Deployment" section of
+# docs/server.rst). On loopback, gptme-server does not require an auth token;
+# set GPTME_SERVER_TOKEN in the EnvironmentFile if you bind a public interface.
+#
+# Inspect logs with:  journalctl -u gptme-server -f
+
+[Unit]
+Description=gptme-server (gptme web/REST API)
+Documentation=https://gptme.org/docs/server.html
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=gptme
+Group=gptme
+
+# Provider keys (OPENAI_API_KEY / ANTHROPIC_API_KEY / OPENROUTER_API_KEY) and an
+# optional GPTME_SERVER_TOKEN live here, one KEY=value per line. Keep it 0640
+# and owned by the service user so secrets are not world-readable.
+EnvironmentFile=/etc/gptme/server.env
+
+# Adjust the path to wherever pipx installed the entrypoint for User= above.
+# Bind loopback and front it with a reverse proxy; set --cors-origin to the
+# origin your web UI is served from (the hosted UI is https://chat.gptme.org).
+ExecStart=/home/gptme/.local/bin/gptme-server serve \
+    --host 127.0.0.1 --port 5700 \
+    --cors-origin https://chat.gptme.org
+
+Restart=on-failure
+RestartSec=5
+
+# --- Hardening (loosen only if your setup needs it) ---
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=read-only
+# gptme persists config and conversation logs under the service user's home;
+# grant write access to just those paths (matches the User= home above).
+ReadWritePaths=/home/gptme/.config/gptme /home/gptme/.local/share/gptme
+ProtectControlGroups=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+RestrictNamespaces=true
+RestrictRealtime=true
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## What

Adds a systemd service template for running `gptme-server` persistently when installed via `pipx` (not Docker):

- **`scripts/gptme-server.service`** — hardened unit template: dedicated `gptme` user, `EnvironmentFile=/etc/gptme/server.env` for secrets, loopback bind, `Restart=on-failure`, and systemd sandboxing (`ProtectSystem=strict`, `NoNewPrivileges`, `ReadWritePaths` scoped to the config/data dirs).
- **`docs/server.rst`** — a "Running as a systemd Service (pipx)" section with copy-paste install steps.

## Why

The Docker Compose self-host path (#2681) gives users an auto-restarting, persistent server, but the documented primary install (`pipx install 'gptme[server]'`) had **no** persistent-service story — `restart: unless-stopped` only helps Docker users. This fills that gap and pairs with the nginx reverse proxy guide (#2684) for TLS exposure.

## Verification

- `scripts/check_rst_formatting.py docs/server.rst` → clean
- `systemd-analyze verify scripts/gptme-server.service` → only flags the template `ExecStart` path not existing on this machine (expected for a template); no directive/syntax errors
- pre-commit (ruff, mypy, rst-formatting, whitespace, EOF) → all passed
- `gptme-server serve --host ... --port ... --cors-origin ...` invocation verified against `gptme/server/cli.py` (DefaultGroup, default `serve`)