### PR TITLE
feat(ci): self-heal workflow — analyze test failures and propose fixes (Phase 1)

### DIFF
--- a/.github/workflows/self-heal.yml
+++ b/.github/workflows/self-heal.yml
@@ -138,7 +138,7 @@ jobs:
             --body-file /tmp/comment.md
 
       - name: Report error if analysis failed
-        if: steps.pr.outputs.found == 'true' && failure() && (steps.analyze.outcome == 'failure' || steps.post_comment.outcome == 'failure')
+        if: steps.pr.outputs.found == 'true' && failure()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BOT_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/self-heal.yml
+++ b/.github/workflows/self-heal.yml
@@ -30,10 +30,11 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - name: Checkout head commit
+      - name: Checkout base repo
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.workflow_run.head_sha }}
+        # No ref: defaults to base branch (master), not the fork's head SHA.
+        # This prevents a malicious fork from exfiltrating secrets by modifying
+        # scripts/github_ci_self_heal.py — we always run the trusted base copy.
 
       - name: Get PR number
         id: pr

--- a/.github/workflows/self-heal.yml
+++ b/.github/workflows/self-heal.yml
@@ -46,12 +46,15 @@ jobs:
             --jq ".[] | select(.head.sha == \"$HEAD_SHA\") | .number" | head -1)
           if [ -z "$PR_NUMBER" ]; then
             echo "No open PR found for sha $HEAD_SHA — skipping"
+            echo "found=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+          echo "found=true" >> "$GITHUB_OUTPUT"
           echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
           echo "PR: #$PR_NUMBER"
 
       - name: Download failure log
+        if: steps.pr.outputs.found == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -61,6 +64,7 @@ jobs:
           echo "Failure log size: $(wc -c < /tmp/failure.log) bytes"
 
       - name: Download PR diff
+        if: steps.pr.outputs.found == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -70,14 +74,17 @@ jobs:
           echo "PR diff size: $(wc -c < /tmp/pr.diff) bytes"
 
       - name: Set up Python
+        if: steps.pr.outputs.found == 'true'
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
 
       - name: Install dependencies
+        if: steps.pr.outputs.found == 'true'
         run: pip install anthropic --quiet
 
       - name: Analyze failure
+        if: steps.pr.outputs.found == 'true'
         id: analyze
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -88,7 +95,7 @@ jobs:
           cat /tmp/analysis.txt
 
       - name: Post analysis as PR comment
-        if: success() && steps.analyze.outcome == 'success'
+        if: steps.pr.outputs.found == 'true' && success() && steps.analyze.outcome == 'success'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FAILED_RUN_URL: ${{ github.event.workflow_run.html_url }}
@@ -120,7 +127,7 @@ jobs:
             --body-file /tmp/comment.md
 
       - name: Report error if analysis failed
-        if: failure() && steps.analyze.outcome == 'failure'
+        if: steps.pr.outputs.found == 'true' && failure() && steps.analyze.outcome == 'failure'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BOT_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/self-heal.yml
+++ b/.github/workflows/self-heal.yml
@@ -1,0 +1,120 @@
+name: self-heal
+
+# Triggered when the Test workflow completes with a failure on a pull request.
+# Analyzes the failing tests and posts a fix proposal as a PR comment.
+#
+# Uses workflow_run (not pull_request) so secrets are available for fork PRs too —
+# workflow_run always runs in the context of the base repo, not the fork.
+#
+# Phase 1: comment-only. No auto-merge, no auto-push.
+# Phase 2 (future): auto-open a draft fix PR when confidence is high.
+
+on:
+  workflow_run:
+    workflows: ["Test"]
+    types: [completed]
+
+permissions:
+  contents: read
+  pull-requests: write
+  actions: read
+
+jobs:
+  self-heal:
+    name: Analyze failure and propose fix
+    # Only run when tests actually failed AND the trigger was a pull_request event.
+    # event == 'pull_request' guarantees pull_requests is non-empty.
+    if: |
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout head commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Get PR number
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER="${{ github.event.workflow_run.pull_requests[0].number }}"
+          echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "PR: #$PR_NUMBER"
+
+      - name: Download failure log
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh run view ${{ github.event.workflow_run.id }} \
+            --repo ${{ github.repository }} \
+            --log-failed 2>&1 | tail -c 15000 > /tmp/failure.log
+          echo "Failure log size: $(wc -c < /tmp/failure.log) bytes"
+
+      - name: Download PR diff
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr diff ${{ steps.pr.outputs.number }} \
+            --repo ${{ github.repository }} 2>/dev/null \
+            | head -c 10000 > /tmp/pr.diff || true
+          echo "PR diff size: $(wc -c < /tmp/pr.diff) bytes"
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: pip install anthropic --quiet
+
+      - name: Analyze failure
+        id: analyze
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          python scripts/github_ci_self_heal.py /tmp/failure.log /tmp/pr.diff \
+            > /tmp/analysis.txt
+          echo "Analysis complete ($(wc -c < /tmp/analysis.txt) bytes)"
+          cat /tmp/analysis.txt
+
+      - name: Post analysis as PR comment
+        if: success() && steps.analyze.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FAILED_RUN_URL: ${{ github.event.workflow_run.html_url }}
+          BOT_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          {
+            echo "## 🔧 gptme-bot: Self-heal analysis"
+            echo ""
+            echo "Tests failed on this PR. Here's my analysis:"
+            echo ""
+            cat /tmp/analysis.txt
+            echo ""
+            echo "---"
+            echo "*[Failing run](${FAILED_RUN_URL}) · [Analysis run](${BOT_RUN_URL})*"
+          } > /tmp/comment.md
+
+          gh pr comment ${{ steps.pr.outputs.number }} \
+            --repo ${{ github.repository }} \
+            --body-file /tmp/comment.md
+
+      - name: Report error if analysis failed
+        if: failure() && steps.analyze.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BOT_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          {
+            echo "## 🔧 gptme-bot: Self-heal (error)"
+            echo ""
+            echo "I attempted to analyze the CI failure but encountered an error."
+            echo "[Check the bot run](${BOT_RUN_URL}) for details."
+          } > /tmp/error-comment.md
+          gh pr comment ${{ steps.pr.outputs.number }} \
+            --repo ${{ github.repository }} \
+            --body-file /tmp/error-comment.md

--- a/.github/workflows/self-heal.yml
+++ b/.github/workflows/self-heal.yml
@@ -103,8 +103,10 @@ jobs:
           PR_NUMBER: ${{ steps.pr.outputs.number }}
         run: |
           # Dedup: skip if a self-heal comment already exists for this PR.
+          # --paginate ensures all pages are checked, not just the first 30.
           EXISTING=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
-            --jq '[.[] | select(.body | contains("<!-- gptme-self-heal -->"))] | length')
+            --paginate \
+            --jq '.[] | select(.body | contains("<!-- gptme-self-heal -->")) | .id' | wc -l)
           if [ "${EXISTING:-0}" -gt "0" ]; then
             echo "Self-heal comment already exists — skipping duplicate"
             exit 0
@@ -133,6 +135,14 @@ jobs:
           BOT_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}
         run: |
+          # Dedup: skip if a self-heal comment already exists (same guard as success path).
+          EXISTING=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+            --paginate \
+            --jq '.[] | select(.body | contains("<!-- gptme-self-heal -->")) | .id' | wc -l)
+          if [ "${EXISTING:-0}" -gt "0" ]; then
+            echo "Self-heal comment already exists — skipping duplicate error comment"
+            exit 0
+          fi
           {
             echo "<!-- gptme-self-heal -->"
             echo "## 🔧 gptme-bot: Self-heal (error)"

--- a/.github/workflows/self-heal.yml
+++ b/.github/workflows/self-heal.yml
@@ -23,7 +23,6 @@ jobs:
   self-heal:
     name: Analyze failure and propose fix
     # Only run when tests actually failed AND the trigger was a pull_request event.
-    # event == 'pull_request' guarantees pull_requests is non-empty.
     if: |
       github.event.workflow_run.conclusion == 'failure' &&
       github.event.workflow_run.event == 'pull_request'
@@ -41,7 +40,14 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          PR_NUMBER="${{ github.event.workflow_run.pull_requests[0].number }}"
+          # pull_requests[] is empty for fork PRs — look up by head SHA instead.
+          HEAD_SHA="${{ github.event.workflow_run.head_sha }}"
+          PR_NUMBER=$(gh api "repos/${{ github.repository }}/pulls?state=open&per_page=100" \
+            --jq ".[] | select(.head.sha == \"$HEAD_SHA\") | .number" | head -1)
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No open PR found for sha $HEAD_SHA — skipping"
+            exit 0
+          fi
           echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
           echo "PR: #$PR_NUMBER"
 
@@ -87,8 +93,18 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FAILED_RUN_URL: ${{ github.event.workflow_run.html_url }}
           BOT_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
         run: |
+          # Dedup: skip if a self-heal comment already exists for this PR.
+          EXISTING=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+            --jq '[.[] | select(.body | contains("<!-- gptme-self-heal -->"))] | length')
+          if [ "${EXISTING:-0}" -gt "0" ]; then
+            echo "Self-heal comment already exists — skipping duplicate"
+            exit 0
+          fi
+
           {
+            echo "<!-- gptme-self-heal -->"
             echo "## 🔧 gptme-bot: Self-heal analysis"
             echo ""
             echo "Tests failed on this PR. Here's my analysis:"
@@ -99,7 +115,7 @@ jobs:
             echo "*[Failing run](${FAILED_RUN_URL}) · [Analysis run](${BOT_RUN_URL})*"
           } > /tmp/comment.md
 
-          gh pr comment ${{ steps.pr.outputs.number }} \
+          gh pr comment "${PR_NUMBER}" \
             --repo ${{ github.repository }} \
             --body-file /tmp/comment.md
 
@@ -108,13 +124,15 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BOT_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
         run: |
           {
+            echo "<!-- gptme-self-heal -->"
             echo "## 🔧 gptme-bot: Self-heal (error)"
             echo ""
             echo "I attempted to analyze the CI failure but encountered an error."
             echo "[Check the bot run](${BOT_RUN_URL}) for details."
           } > /tmp/error-comment.md
-          gh pr comment ${{ steps.pr.outputs.number }} \
+          gh pr comment "${PR_NUMBER}" \
             --repo ${{ github.repository }} \
             --body-file /tmp/error-comment.md

--- a/.github/workflows/self-heal.yml
+++ b/.github/workflows/self-heal.yml
@@ -65,6 +65,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          set -o pipefail
           gh run view ${{ github.event.workflow_run.id }} \
             --repo ${{ github.repository }} \
             --log-failed 2>&1 | tail -c 15000 > /tmp/failure.log

--- a/.github/workflows/self-heal.yml
+++ b/.github/workflows/self-heal.yml
@@ -42,9 +42,14 @@ jobs:
         run: |
           # pull_requests[] is empty for fork PRs — look up by head SHA instead.
           HEAD_SHA="${{ github.event.workflow_run.head_sha }}"
-          PR_NUMBER=$(gh api "repos/${{ github.repository }}/pulls?state=open&per_page=100" \
+          # Collect all matching PR numbers first, then take the first.
+          # Piping --paginate directly to head -1 triggers SIGPIPE and can abort
+          # the step under pipefail before GITHUB_OUTPUT is written.
+          PR_NUMBERS=$(gh api "repos/${{ github.repository }}/pulls?state=open&per_page=100" \
             --paginate \
-            --jq ".[] | select(.head.sha == \"$HEAD_SHA\") | .number" | head -1)
+            --jq ".[] | select(.head.sha == \"$HEAD_SHA\") | .number" \
+            2>/dev/null || true)
+          PR_NUMBER=$(echo "${PR_NUMBERS}" | head -1)
           if [ -z "$PR_NUMBER" ]; then
             echo "No open PR found for sha $HEAD_SHA — skipping"
             echo "found=false" >> "$GITHUB_OUTPUT"
@@ -96,6 +101,7 @@ jobs:
           cat /tmp/analysis.txt
 
       - name: Post analysis as PR comment
+        id: post_comment
         if: steps.pr.outputs.found == 'true' && success() && steps.analyze.outcome == 'success'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -130,7 +136,7 @@ jobs:
             --body-file /tmp/comment.md
 
       - name: Report error if analysis failed
-        if: steps.pr.outputs.found == 'true' && failure() && steps.analyze.outcome == 'failure'
+        if: steps.pr.outputs.found == 'true' && failure() && (steps.analyze.outcome == 'failure' || steps.post_comment.outcome == 'failure')
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BOT_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/self-heal.yml
+++ b/.github/workflows/self-heal.yml
@@ -43,6 +43,7 @@ jobs:
           # pull_requests[] is empty for fork PRs — look up by head SHA instead.
           HEAD_SHA="${{ github.event.workflow_run.head_sha }}"
           PR_NUMBER=$(gh api "repos/${{ github.repository }}/pulls?state=open&per_page=100" \
+            --paginate \
             --jq ".[] | select(.head.sha == \"$HEAD_SHA\") | .number" | head -1)
           if [ -z "$PR_NUMBER" ]; then
             echo "No open PR found for sha $HEAD_SHA — skipping"

--- a/scripts/github_ci_self_heal.py
+++ b/scripts/github_ci_self_heal.py
@@ -27,14 +27,14 @@ def analyze_failure(failure_log: str, pr_diff: str) -> str:
     prompt = f"""A CI test failure occurred on a pull request. Analyze the root cause and propose a minimal fix.
 
 ## Test failure output (last portion):
-```
+~~~~
 {failure_log}
-```
+~~~~
 
 ## Pull request diff:
-```diff
+~~~~diff
 {pr_diff}
-```
+~~~~
 
 Respond in this exact format:
 

--- a/scripts/github_ci_self_heal.py
+++ b/scripts/github_ci_self_heal.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""
+CI self-heal script: analyze test failures and propose fixes using Claude.
+
+Called by .github/workflows/self-heal.yml when CI tests fail on a PR.
+
+Usage:
+    github_ci_self_heal.py <failure_log> <pr_diff>
+
+Output (stdout): markdown analysis suitable for posting as a PR comment.
+"""
+
+import sys
+from pathlib import Path
+
+
+def analyze_failure(failure_log: str, pr_diff: str) -> str:
+    """Call Claude to analyze CI failure and propose a minimal fix."""
+    import anthropic
+
+    client = anthropic.Anthropic()
+
+    # Trim inputs to stay within reasonable token limits
+    failure_log = failure_log[-12000:] if len(failure_log) > 12000 else failure_log
+    pr_diff = pr_diff[:8000] if len(pr_diff) > 8000 else pr_diff
+
+    prompt = f"""A CI test failure occurred on a pull request. Analyze the root cause and propose a minimal fix.
+
+## Test failure output (last portion):
+```
+{failure_log}
+```
+
+## Pull request diff:
+```diff
+{pr_diff}
+```
+
+Respond in this exact format:
+
+**Root cause**: (1-2 sentences identifying exactly what broke and why)
+
+**Proposed fix**: (minimal code change as a unified diff, or a clear explanation if the fix is not straightforward)
+
+**Confidence**: high / medium / low — and why"""
+
+    message = client.messages.create(
+        model="claude-haiku-4-5-20251001",
+        max_tokens=1024,
+        messages=[{"role": "user", "content": prompt}],
+    )
+
+    return message.content[0].text
+
+
+def main() -> int:
+    if len(sys.argv) < 3:
+        print(
+            f"Usage: {sys.argv[0]} <failure_log_path> <pr_diff_path>", file=sys.stderr
+        )
+        return 1
+
+    failure_log_path = Path(sys.argv[1])
+    pr_diff_path = Path(sys.argv[2])
+
+    failure_log = (
+        failure_log_path.read_text()
+        if failure_log_path.exists()
+        else "(no failure log available)"
+    )
+    pr_diff = (
+        pr_diff_path.read_text() if pr_diff_path.exists() else "(no diff available)"
+    )
+
+    if not failure_log_path.exists():
+        print(f"Warning: failure log not found at {failure_log_path}", file=sys.stderr)
+    if not pr_diff_path.exists():
+        print(f"Warning: PR diff not found at {pr_diff_path}", file=sys.stderr)
+
+    analysis = analyze_failure(failure_log, pr_diff)
+    print(analysis)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/github_ci_self_heal.py
+++ b/scripts/github_ci_self_heal.py
@@ -73,7 +73,7 @@ def main() -> int:
     )
     pr_diff = (
         pr_diff_path.read_text(errors="replace")
-        if pr_diff_path.exists()
+        if pr_diff_path.exists() and pr_diff_path.stat().st_size > 0
         else "(no diff available)"
     )
 
@@ -83,7 +83,7 @@ def main() -> int:
         print(f"Warning: PR diff not found at {pr_diff_path}", file=sys.stderr)
 
     analysis = analyze_failure(failure_log, pr_diff)
-    if not analysis:
+    if not analysis.strip():
         print("Error: Claude returned an empty response.", file=sys.stderr)
         return 1
     print(analysis)

--- a/scripts/github_ci_self_heal.py
+++ b/scripts/github_ci_self_heal.py
@@ -50,7 +50,10 @@ Respond in this exact format:
         messages=[{"role": "user", "content": prompt}],
     )
 
-    return message.content[0].text
+    from anthropic.types import TextBlock
+
+    text_blocks = [b for b in message.content if isinstance(b, TextBlock)]
+    return text_blocks[0].text if text_blocks else ""
 
 
 def main() -> int:

--- a/scripts/github_ci_self_heal.py
+++ b/scripts/github_ci_self_heal.py
@@ -83,6 +83,9 @@ def main() -> int:
         print(f"Warning: PR diff not found at {pr_diff_path}", file=sys.stderr)
 
     analysis = analyze_failure(failure_log, pr_diff)
+    if not analysis:
+        print("Error: Claude returned an empty response.", file=sys.stderr)
+        return 1
     print(analysis)
     return 0
 

--- a/scripts/github_ci_self_heal.py
+++ b/scripts/github_ci_self_heal.py
@@ -67,12 +67,14 @@ def main() -> int:
     pr_diff_path = Path(sys.argv[2])
 
     failure_log = (
-        failure_log_path.read_text()
+        failure_log_path.read_text(errors="replace")
         if failure_log_path.exists()
         else "(no failure log available)"
     )
     pr_diff = (
-        pr_diff_path.read_text() if pr_diff_path.exists() else "(no diff available)"
+        pr_diff_path.read_text(errors="replace")
+        if pr_diff_path.exists()
+        else "(no diff available)"
     )
 
     if not failure_log_path.exists():


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/self-heal.yml` — triggers on `workflow_run` completion when the Test workflow fails on a PR
- Adds `scripts/github_ci_self_heal.py` — calls Claude (Haiku) with the failure log + PR diff and returns a root-cause/fix-proposal analysis
- Posts the analysis as a PR comment (comment-only, no auto-merge or auto-push)

## Why `workflow_run` instead of `pull_request`

`workflow_run` runs in the context of the base repo, so `ANTHROPIC_API_KEY` is available even for fork PRs — unlike `pull_request` which blocks secrets from forks for security.

## Flow

```
Test workflow fails on PR
  → self-heal triggers (workflow_run)
  → downloads failure log (gh run view --log-failed)
  → downloads PR diff (gh pr diff)
  → calls Claude Haiku via scripts/github_ci_self_heal.py
  → posts analysis comment on the PR
```

## Example comment output

> **Root cause**: The new `parse_foo()` function doesn't handle empty string input, causing `test_parse_empty` to fail with `AttributeError`.
>
> **Proposed fix**: Add a guard at the top of `parse_foo()`: `if not s: return None`
>
> **Confidence**: high — the diff adds the function and the test directly tests the edge case.

## Non-goals (Phase 1)

- Auto-merge of fixes
- Creating fix PRs automatically
- Cross-repo propagation

## Test plan

- [ ] CI passes on this PR
- [ ] Manually verify by checking workflow triggers with a deliberately broken test on a test PR