### PR TITLE
fix(webui): polyfill structuredClone in jest.setup for jsdom

### DIFF
--- a/webui/jest.setup.ts
+++ b/webui/jest.setup.ts
@@ -1,5 +1,10 @@
 import '@testing-library/jest-dom';
 
+// Polyfill structuredClone for jsdom — Node 17+ has it but jsdom doesn't expose it.
+if (typeof structuredClone === 'undefined') {
+  global.structuredClone = <T>(val: T): T => JSON.parse(JSON.stringify(val));
+}
+
 // Shim Vite import.meta.env for Jest.
 // connectionConfig.ts and SetupWizard.tsx wrap import.meta.env accesses in
 // Function() and fall back to process.env when that throws.


### PR DESCRIPTION
jsdom (the jest test environment) does not expose `structuredClone` even though
Node 17+ has it. This caused the test added in #2687 to fail on master:

```
ReferenceError: structuredClone is not defined
  at Object.getConversation (src/utils/demoApiClient.ts:201:37)
```

Fix: add a one-line polyfill in `jest.setup.ts` guarded by a `typeof` check,
so all tests in the jsdom environment have `structuredClone` available, and it
is a no-op in any future environment that already exposes it.
