### PR TITLE
fix(webui): replace structuredClone with JSON.parse/stringify for jsdom compat

### DIFF
--- a/webui/src/utils/demoApiClient.ts
+++ b/webui/src/utils/demoApiClient.ts
@@ -198,7 +198,7 @@ export function createDemoApiClient(baseUrl: string = DEMO_BASE_URL): IApiClient
 
     // Conversation detail — serve the fixture or local in-memory conversations.
     getConversation: async (logfile) => {
-      if (logfile === DEMO_CONV_ID) return structuredClone(DEMO_CONV_RESPONSE);
+      if (logfile === DEMO_CONV_ID) return JSON.parse(JSON.stringify(DEMO_CONV_RESPONSE));
       const local = localConversations.get(logfile);
       if (local) return local;
       throw new DemoModeError(`getConversation(${logfile})`);


### PR DESCRIPTION
## Summary

Fixes master WebUI CI failure introduced by #2687.

`structuredClone` is not available in Jest's `jsdom` test environment (the
environment configured in `jest.config.ts`), causing `demoApiClient.test.ts`
to fail with `ReferenceError: structuredClone is not defined` on Node 20.x CI.

`DEMO_CONV_RESPONSE` is plain JSON-serializable data, so
`JSON.parse(JSON.stringify(x))` is equivalent and works in all environments
(Node, jsdom, older browsers).

## Test plan
- [ ] `demoApiClient.test.ts` passes (was the failing suite)
- [ ] WebUI `build (20.x)` check goes green