### PR TITLE
fix(self-heal): handle invalid ANTHROPIC_API_KEY gracefully

### DIFF
--- a/.github/workflows/self-heal.yml
+++ b/.github/workflows/self-heal.yml
@@ -111,6 +111,12 @@ jobs:
           BOT_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}
         run: |
+          # Skip if analysis produced no content (e.g. transient API error).
+          if [ ! -s /tmp/analysis.txt ]; then
+            echo "No analysis content — skipping comment"
+            exit 0
+          fi
+
           # Dedup: skip if a self-heal comment already exists for this PR.
           # --paginate ensures all pages are checked, not just the first 30.
           EXISTING=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \

--- a/scripts/github_ci_self_heal.py
+++ b/scripts/github_ci_self_heal.py
@@ -18,8 +18,6 @@ def analyze_failure(failure_log: str, pr_diff: str) -> str:
     """Call Claude to analyze CI failure and propose a minimal fix."""
     import anthropic
 
-    client = anthropic.Anthropic()
-
     # Trim inputs to stay within reasonable token limits
     failure_log = failure_log[-12000:] if len(failure_log) > 12000 else failure_log
     pr_diff = pr_diff[:8000] if len(pr_diff) > 8000 else pr_diff
@@ -45,6 +43,7 @@ Respond in this exact format:
 **Confidence**: high / medium / low — and why"""
 
     try:
+        client = anthropic.Anthropic()
         message = client.messages.create(
             model="claude-haiku-4-5-20251001",
             max_tokens=1024,

--- a/scripts/github_ci_self_heal.py
+++ b/scripts/github_ci_self_heal.py
@@ -44,11 +44,24 @@ Respond in this exact format:
 
 **Confidence**: high / medium / low — and why"""
 
-    message = client.messages.create(
-        model="claude-haiku-4-5-20251001",
-        max_tokens=1024,
-        messages=[{"role": "user", "content": prompt}],
-    )
+    try:
+        message = client.messages.create(
+            model="claude-haiku-4-5-20251001",
+            max_tokens=1024,
+            messages=[{"role": "user", "content": prompt}],
+        )
+    except anthropic.AuthenticationError:
+        print(
+            "Warning: ANTHROPIC_API_KEY is invalid or expired — skipping analysis.",
+            file=sys.stderr,
+        )
+        return "⚠️ Self-heal analysis skipped: the `ANTHROPIC_API_KEY` repository secret is invalid or expired. A maintainer needs to update it in **Settings → Secrets and variables → Actions**."
+    except anthropic.APIError as e:
+        print(
+            f"Warning: Anthropic API error ({type(e).__name__}) — skipping analysis.",
+            file=sys.stderr,
+        )
+        return ""
 
     from anthropic.types import TextBlock
 
@@ -84,8 +97,8 @@ def main() -> int:
 
     analysis = analyze_failure(failure_log, pr_diff)
     if not analysis.strip():
-        print("Error: Claude returned an empty response.", file=sys.stderr)
-        return 1
+        print("Warning: no analysis produced — skipping comment.", file=sys.stderr)
+        return 0
     print(analysis)
     return 0
 


### PR DESCRIPTION
## Summary

The `self-heal` workflow was failing on master CI because `ANTHROPIC_API_KEY` is invalid/expired, causing `github_ci_self_heal.py` to crash with a 401 `AuthenticationError` (exit 1).

- Catch `anthropic.AuthenticationError` and return an informative message — PRs get a comment explaining the secret needs updating
- Catch other `anthropic.APIError` variants and exit 0 silently
- Add a `[ -s /tmp/analysis.txt ]` guard in the workflow to skip posting when there's no content
- Change empty-response exit code from 1 → 0 (graceful skip, not error)

The immediate fix for the expired key itself requires a maintainer to update `ANTHROPIC_API_KEY` in **Settings → Secrets and variables → Actions**.

## Test plan

- [ ] Workflow no longer marks master CI as failed when `ANTHROPIC_API_KEY` is invalid
- [ ] When the key IS valid, workflow still posts the analysis comment as before
- [ ] When analysis.txt is empty (other API errors), no comment is posted