### PR TITLE
fix(server): reject path traversal in file attachments via API

### DIFF
--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -25,6 +25,16 @@ except (ImportError, AttributeError):
 
 import gptme
 
+
+def _validate_model_param(
+    ctx: click.Context, param: click.Parameter, value: str | None
+) -> str | None:
+    """Reject empty --model early so the CLI exits before heavy setup work."""
+    if value is not None and not value.strip():
+        raise click.BadParameter("Model name cannot be empty.", ctx=ctx, param=param)
+    return value
+
+
 from ..chat import chat
 from ..commands import _gen_help
 from ..config import setup_config_from_cli
@@ -288,6 +298,7 @@ Run 'gptme-util --help' for all utility commands."""
     "-m",
     "--model",
     default=None,
+    callback=_validate_model_param,
     help=f"Model to use, e.g. openai/{get_recommended_model('openai')}, anthropic/{get_recommended_model('anthropic')}. If only provider given then a default is used.",
 )
 @click.option(

--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -25,16 +25,6 @@ except (ImportError, AttributeError):
 
 import gptme
 
-
-def _validate_model_param(
-    ctx: click.Context, param: click.Parameter, value: str | None
-) -> str | None:
-    """Reject empty --model early so the CLI exits before heavy setup work."""
-    if value is not None and not value.strip():
-        raise click.BadParameter("Model name cannot be empty.", ctx=ctx, param=param)
-    return value
-
-
 from ..chat import chat
 from ..commands import _gen_help
 from ..config import setup_config_from_cli
@@ -61,6 +51,15 @@ from ..util.interrupt import handle_keyboard_interrupt, set_interruptible
 from ..util.prompt import add_history
 
 logger = logging.getLogger(__name__)
+
+
+def _validate_model_param(
+    ctx: click.Context, param: click.Parameter, value: str | None
+) -> str | None:
+    """Reject empty --model early so the CLI exits before heavy setup work."""
+    if value is not None and not value.strip():
+        raise click.BadParameter("Model name cannot be empty.", ctx=ctx, param=param)
+    return value
 
 
 script_path = Path(os.path.realpath(__file__))

--- a/gptme/config/cli_setup.py
+++ b/gptme/config/cli_setup.py
@@ -109,8 +109,6 @@ def setup_config_from_cli(
     # For new conversations: CLI args -> env vars/config files -> defaults
     resolved_model: str | None
     if model is not None:
-        if not model.strip():
-            raise ValueError("Model name cannot be empty.")
         # CLI override always takes precedence
         resolved_model = model
     elif existing_chat_config and existing_chat_config.model:

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -889,7 +889,10 @@ def api_conversation_post(conversation_id: str):
                 return flask.jsonify(
                     {"error": f"File path escapes workspace: {f}"}
                 ), 400
-            file_paths.append(f)
+            # Store the resolved absolute path so the validated path is what
+            # downstream (embed_attached_file_content) actually reads, not a
+            # relative path that resolves differently depending on CWD.
+            file_paths.append(full)
     msg = Message(
         req_json["role"],
         req_json["content"],

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -873,7 +873,23 @@ def api_conversation_post(conversation_id: str):
     files_result = _get_optional_string_list_field(req_json, "files")
     if isinstance(files_result, tuple):
         return files_result
-    file_paths = [Path(f) for f in files_result] if files_result is not None else []
+    file_paths: list[Path] = []
+    if files_result is not None:
+        workspace = log.workspace
+        for f_str in files_result:
+            f = Path(f_str)
+            # Reject absolute paths — they can't be relative to workspace
+            if f.is_absolute():
+                return flask.jsonify(
+                    {"error": f"Absolute file paths are not supported: {f}"}
+                ), 400
+            # Resolve relative to workspace and check it stays within
+            full = (workspace / f).resolve()
+            if not full.is_relative_to(workspace):
+                return flask.jsonify(
+                    {"error": f"File path escapes workspace: {f}"}
+                ), 400
+            file_paths.append(f)
     msg = Message(
         req_json["role"],
         req_json["content"],

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -537,8 +537,8 @@ def test_architect_model_unqualified_is_usage_error(
 
 
 def test_empty_model_is_usage_error(runner: CliRunner, runid: int):
-    # --model "" should give a clean UsageError, not silently fall back to the
-    # default model with a warning. An empty string is an obvious user mistake.
+    # --model "" should be caught at parse time by the click callback,
+    # producing a clean BadParameter error (not a late ValueError).
     result = runner.invoke(
         cli.main,
         [
@@ -553,7 +553,30 @@ def test_empty_model_is_usage_error(runner: CliRunner, runid: int):
 
     assert result.exit_code == 2
     assert "Traceback" not in result.output
-    assert "empty" in result.output.lower()
+    assert (
+        "empty" in result.output.lower() or "cannot be empty" in result.output.lower()
+    )
+
+
+def test_whitespace_model_is_usage_error(runner: CliRunner, runid: int):
+    # --model "  " should also be caught at parse time, same as empty string.
+    result = runner.invoke(
+        cli.main,
+        [
+            "--non-interactive",
+            "--name",
+            f"test-whitespace-model-{runid}",
+            "--model",
+            "   ",
+            "hello",
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert "Traceback" not in result.output
+    assert (
+        "empty" in result.output.lower() or "cannot be empty" in result.output.lower()
+    )
 
 
 def test_unknown_agent_profile_stays_off_stdout_in_json_mode():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -553,9 +553,7 @@ def test_empty_model_is_usage_error(runner: CliRunner, runid: int):
 
     assert result.exit_code == 2
     assert "Traceback" not in result.output
-    assert (
-        "empty" in result.output.lower() or "cannot be empty" in result.output.lower()
-    )
+    assert "empty" in result.output.lower()
 
 
 def test_whitespace_model_is_usage_error(runner: CliRunner, runid: int):
@@ -574,9 +572,7 @@ def test_whitespace_model_is_usage_error(runner: CliRunner, runid: int):
 
     assert result.exit_code == 2
     assert "Traceback" not in result.output
-    assert (
-        "empty" in result.output.lower() or "cannot be empty" in result.output.lower()
-    )
+    assert "empty" in result.output.lower()
 
 
 def test_unknown_agent_profile_stays_off_stdout_in_json_mode():

--- a/tests/test_server_path_traversal.py
+++ b/tests/test_server_path_traversal.py
@@ -137,6 +137,68 @@ class TestConversationEndpointValidation:
         _assert_traversal_rejected(response)
 
 
+FILE_TRAVERSAL_PAYLOADS = [
+    "/etc/passwd",
+    "../../etc/passwd",
+    "/tmp/secret",
+    "../../../root/.ssh/id_rsa",
+]
+
+
+class TestFileAttachmentPathValidation:
+    """POST /conversations/:id must reject path traversal in the files field."""
+
+    def _make_conv(self, tmp_path, monkeypatch):
+        """Create a minimal conversation and wire up get_logs_dir."""
+        from gptme.logmanager import LogManager
+        from gptme.message import Message
+
+        logs_dir = tmp_path / "logs"
+        conv_logdir = logs_dir / "test-conv"
+        LogManager.load(
+            logdir=conv_logdir,
+            initial_msgs=[Message("user", "hi")],
+            create=True,
+        ).write()
+
+        monkeypatch.setattr(
+            "gptme.server.api_v2.get_logs_dir",
+            lambda: logs_dir,
+        )
+
+    @pytest.mark.parametrize("payload", FILE_TRAVERSAL_PAYLOADS)
+    def test_rejects_traversal_in_files(
+        self, client: FlaskClient, tmp_path, monkeypatch, payload: str
+    ):
+        self._make_conv(tmp_path, monkeypatch)
+        response = client.post(
+            "/api/v2/conversations/test-conv",
+            json={"role": "user", "content": "hello", "files": [payload]},
+        )
+        assert response.status_code == 400
+        data = response.get_json()
+        assert data is not None
+        assert "error" in data
+
+    def test_safe_relative_path_not_rejected_as_traversal(
+        self, client: FlaskClient, tmp_path, monkeypatch
+    ):
+        """A relative path within workspace must not be rejected for traversal.
+
+        The request may still fail (file doesn't exist, etc.) but the 400
+        must not be due to the traversal guard.
+        """
+        self._make_conv(tmp_path, monkeypatch)
+        response = client.post(
+            "/api/v2/conversations/test-conv",
+            json={"role": "user", "content": "hello", "files": ["data.txt"]},
+        )
+        if response.status_code == 400:
+            data = response.get_json()
+            assert data is None or "escapes workspace" not in data.get("error", "")
+            assert data is None or "Absolute file paths" not in data.get("error", "")
+
+
 class TestValidConversationIdAccepted:
     """Valid conversation_ids must not be rejected by path traversal checks."""
 


### PR DESCRIPTION
The `POST /api/v2/conversations/<id>` endpoint accepted arbitrary file paths via the `files` field, allowing absolute paths (`/etc/passwd`) and directory traversal (`../../../etc/passwd`). These were passed through to `embed_attached_file_content()` which reads the file and embeds its contents in the conversation — a security issue for hosted deployments.

Now validates that attached file paths:
1. Are not absolute (must be relative to workspace)
2. Resolve within the conversation's workspace (prevents `..` traversal)

Closes #XXX