### PR TITLE
fix(server): load conversations from validated logdir

### DIFF
--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -862,7 +862,7 @@ def api_conversation_post(conversation_id: str):
             404,
         )
     try:
-        log = LogManager.load(conversation_id, branch=branch)
+        log = LogManager.load(logdir, branch=branch)
     except FileNotFoundError:
         return (
             flask.jsonify({"error": f"Branch not found: {branch}"}),


### PR DESCRIPTION
Follow-up to #2694.

## Summary

- Load the conversation with the already-computed absolute `logdir`
- Avoid re-resolving the relative `conversation_id` through `LogManager.load`
- Keep the conversation existence check and branch lookup on the same path

## Verification

- `poetry run pytest tests/test_server_path_traversal.py::TestFileAttachmentPathValidation -q`
- `poetry run pytest tests/test_server_path_traversal.py -q`
- `poetry run ruff check gptme/server/api_v2.py`
- `git diff --check -- gptme/server/api_v2.py`
