### PR TITLE
feat(self-heal): add structured autofix gate

### DIFF
--- a/scripts/github_ci_self_heal.py
+++ b/scripts/github_ci_self_heal.py
@@ -210,28 +210,29 @@ def render_analysis_markdown(analysis: SelfHealAnalysis) -> str:
         f"**Failure class**: {analysis.failure_class}",
     ]
     if analysis.patch.strip():
-        lines.extend(["", "```diff", analysis.patch.rstrip(), "```"])
+        # Escape ``` sequences so LLM-provided content cannot break out of the fence.
+        safe_patch = analysis.patch.rstrip().replace("```", "` ``")
+        lines.extend(["", "```diff", safe_patch, "```"])
     if analysis.validation_commands:
         lines.extend(["", "**Validation**:"])
         lines.extend(f"- `{command}`" for command in analysis.validation_commands)
     if analysis.risk_notes:
         lines.extend(["", "**Risk notes**:"])
-        lines.extend(f"- {note}" for note in analysis.risk_notes)
+        # Strip newlines to prevent multiline injection into the list.
+        lines.extend(
+            f"- {note.replace(chr(10), ' ').strip()}" for note in analysis.risk_notes
+        )
     return "\n".join(lines)
 
 
 def changed_paths_from_diff(diff_text: str) -> set[str]:
     paths: set[str] = set()
     for line in diff_text.splitlines():
-        if not line.startswith("diff --git "):
-            continue
-        parts = line.split()
-        if len(parts) < 4:
-            continue
-        for raw_path in parts[2:4]:
-            path = _normalize_diff_path(raw_path)
-            if path and path != "/dev/null":
-                paths.add(path)
+        parsed = _parse_diff_git_header(line)
+        if parsed:
+            for path in parsed:
+                if path and path != "/dev/null":
+                    paths.add(path)
     return paths
 
 
@@ -244,10 +245,9 @@ def patch_stats(patch: str) -> PatchStats:
 
     for line in patch.splitlines():
         if line.startswith("diff --git "):
-            parts = line.split()
-            if len(parts) >= 4:
-                for raw_path in parts[2:4]:
-                    path = _normalize_diff_path(raw_path)
+            parsed = _parse_diff_git_header(line)
+            if parsed:
+                for path in parsed:
                     if path and path != "/dev/null":
                         paths.add(path)
         elif line.startswith("deleted file mode"):
@@ -377,6 +377,29 @@ def _normalize_diff_path(raw_path: str) -> str:
     if path.startswith(("a/", "b/")):
         path = path[2:]
     return path
+
+
+def _parse_diff_git_header(line: str) -> tuple[str, str] | None:
+    """Parse paths from a 'diff --git a/P b/P' header, handling spaces in paths.
+
+    Git guarantees the path is mirrored on both sides, so we find the ' b/'
+    separator by scanning for the position where both halves agree.
+    """
+    prefix = "diff --git a/"
+    if not line.startswith(prefix):
+        return None
+    rest = line[len(prefix) :]  # "P b/P"
+    sep = " b/"
+    pos = 0
+    while True:
+        idx = rest.find(sep, pos)
+        if idx < 0:
+            return None
+        path_a = rest[:idx]
+        path_b = rest[idx + len(sep) :]
+        if path_a == path_b:
+            return path_a, path_b
+        pos = idx + 1
 
 
 def _metadata_author_login(pr_metadata: dict[str, object]) -> str:
@@ -557,12 +580,16 @@ def _build_parser() -> argparse.ArgumentParser:
 
 def main(argv: list[str] | None = None) -> int:
     argv = sys.argv[1:] if argv is None else argv
-    if not argv or argv[0] not in {"analyze", "gate"}:
-        return _legacy_main(argv)
-
-    parser = _build_parser()
-    args = parser.parse_args(argv)
-    return args.func(args)
+    if argv and argv[0] in {"analyze", "gate"}:
+        parser = _build_parser()
+        args = parser.parse_args(argv)
+        return args.func(args)
+    # Route flags (--help, --version, unrecognised options) through argparse so
+    # users discover the subcommands instead of getting a confusing legacy error.
+    if not argv or argv[0].startswith("-"):
+        _build_parser().parse_args(argv or ["--help"])
+        return 1  # unreachable for --help (argparse calls sys.exit); other flags error
+    return _legacy_main(argv)
 
 
 if __name__ == "__main__":

--- a/scripts/github_ci_self_heal.py
+++ b/scripts/github_ci_self_heal.py
@@ -1,23 +1,72 @@
 #!/usr/bin/env python3
-"""
-CI self-heal script: analyze test failures and propose fixes using Claude.
+"""CI self-heal script: analyze test failures and gate safe auto-fixes."""
 
-Called by .github/workflows/self-heal.yml when CI tests fail on a PR.
+from __future__ import annotations
 
-Usage:
-    github_ci_self_heal.py <failure_log> <pr_diff>
-
-Output (stdout): markdown analysis suitable for posting as a PR comment.
-"""
-
+import argparse
+import json
+import os
+import subprocess
 import sys
+from dataclasses import asdict, dataclass
 from pathlib import Path
+
+WHITELISTED_FAILURE_CLASSES = frozenset(
+    {
+        "syntax_error",
+        "import_error",
+        "missing_symbol",
+        "renamed_symbol",
+        "fixture_typo",
+        "assertion_literal_update",
+        "test_selector_typo",
+    }
+)
+
+
+@dataclass(frozen=True)
+class SelfHealAnalysis:
+    root_cause: str
+    proposed_fix: str
+    confidence: str
+    failure_class: str
+    patch: str
+    validation_commands: list[str]
+    risk_notes: list[str]
+
+
+@dataclass(frozen=True)
+class PatchStats:
+    files: int
+    changed_lines: int
+    paths: list[str]
+    has_deletions: bool = False
+    has_binary: bool = False
+    has_mode_changes: bool = False
+
+
+@dataclass(frozen=True)
+class GateConfig:
+    repository: str
+    allowed_authors: frozenset[str] = frozenset({"TimeToBuildBob"})
+    max_files: int = 3
+    max_changed_lines: int = 40
+    forbidden_prefixes: tuple[str, ...] = (".github/", "docs/")
+    forbidden_paths: frozenset[str] = frozenset({"scripts/github_ci_self_heal.py"})
+    require_validation: bool = True
+
+
+@dataclass(frozen=True)
+class GateResult:
+    eligible: bool
+    reason: str
+    reasons: list[str]
+    patch_stats: PatchStats
+    validation_commands: list[str]
 
 
 def analyze_failure(failure_log: str, pr_diff: str) -> str:
     """Call Claude to analyze CI failure and propose a minimal fix."""
-    import anthropic
-
     # Trim inputs to stay within reasonable token limits
     failure_log = failure_log[-12000:] if len(failure_log) > 12000 else failure_log
     pr_diff = pr_diff[:8000] if len(pr_diff) > 8000 else pr_diff
@@ -42,11 +91,66 @@ Respond in this exact format:
 
 **Confidence**: high / medium / low — and why"""
 
+    return _call_claude(prompt, max_tokens=1024)
+
+
+def analyze_failure_structured(
+    failure_log: str, pr_diff: str
+) -> SelfHealAnalysis | None:
+    """Call Claude for structured analysis used by the auto-fix gate."""
+    failure_log = failure_log[-12000:] if len(failure_log) > 12000 else failure_log
+    pr_diff = pr_diff[:8000] if len(pr_diff) > 8000 else pr_diff
+
+    prompt = f"""A CI test failure occurred on a pull request. Analyze the root cause and propose a minimal fix.
+
+Return only JSON matching this schema:
+{{
+  "root_cause": "short explanation",
+  "proposed_fix": "short explanation",
+  "confidence": "high|medium|low",
+  "failure_class": "syntax_error|import_error|missing_symbol|renamed_symbol|fixture_typo|assertion_literal_update|test_selector_typo|other",
+  "patch": "unified diff, or empty string if no safe patch",
+  "validation_commands": ["targeted command to validate the fix"],
+  "risk_notes": ["short risk note"]
+}}
+
+Only use confidence "high" when the fix is mechanical and directly supported by the log and diff.
+
+## Test failure output (last portion):
+~~~~
+{failure_log}
+~~~~
+
+## Pull request diff:
+~~~~diff
+{pr_diff}
+~~~~"""
+
+    response = _call_claude(prompt, max_tokens=2048)
+    if not response.strip():
+        return None
+    try:
+        return parse_analysis_json(response)
+    except ValueError as exc:
+        return SelfHealAnalysis(
+            root_cause="Model returned malformed structured analysis.",
+            proposed_fix=response[:2000],
+            confidence="low",
+            failure_class="other",
+            patch="",
+            validation_commands=[],
+            risk_notes=[str(exc)],
+        )
+
+
+def _call_claude(prompt: str, *, max_tokens: int) -> str:
+    import anthropic
+
     try:
         client = anthropic.Anthropic()
         message = client.messages.create(
             model="claude-haiku-4-5-20251001",
-            max_tokens=1024,
+            max_tokens=max_tokens,
             messages=[{"role": "user", "content": prompt}],
         )
     except anthropic.AuthenticationError:
@@ -68,15 +172,296 @@ Respond in this exact format:
     return text_blocks[0].text if text_blocks else ""
 
 
-def main() -> int:
-    if len(sys.argv) < 3:
+def parse_analysis_json(text: str) -> SelfHealAnalysis:
+    try:
+        data = json.loads(_strip_json_fence(text))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"invalid analysis JSON: {exc.msg}") from exc
+
+    if not isinstance(data, dict):
+        raise ValueError("analysis JSON must be an object")
+
+    root_cause = _required_str(data, "root_cause")
+    proposed_fix = _required_str(data, "proposed_fix")
+    confidence = _required_str(data, "confidence").lower()
+    failure_class = _required_str(data, "failure_class").lower()
+    patch = _required_str(data, "patch")
+    validation_commands = _str_list(data.get("validation_commands", []))
+    risk_notes = _str_list(data.get("risk_notes", []))
+    return SelfHealAnalysis(
+        root_cause=root_cause,
+        proposed_fix=proposed_fix,
+        confidence=confidence,
+        failure_class=failure_class,
+        patch=patch,
+        validation_commands=validation_commands,
+        risk_notes=risk_notes,
+    )
+
+
+def render_analysis_markdown(analysis: SelfHealAnalysis) -> str:
+    lines = [
+        f"**Root cause**: {analysis.root_cause}",
+        "",
+        f"**Proposed fix**: {analysis.proposed_fix}",
+        "",
+        f"**Confidence**: {analysis.confidence}",
+        "",
+        f"**Failure class**: {analysis.failure_class}",
+    ]
+    if analysis.patch.strip():
+        lines.extend(["", "```diff", analysis.patch.rstrip(), "```"])
+    if analysis.validation_commands:
+        lines.extend(["", "**Validation**:"])
+        lines.extend(f"- `{command}`" for command in analysis.validation_commands)
+    if analysis.risk_notes:
+        lines.extend(["", "**Risk notes**:"])
+        lines.extend(f"- {note}" for note in analysis.risk_notes)
+    return "\n".join(lines)
+
+
+def changed_paths_from_diff(diff_text: str) -> set[str]:
+    paths: set[str] = set()
+    for line in diff_text.splitlines():
+        if not line.startswith("diff --git "):
+            continue
+        parts = line.split()
+        if len(parts) < 4:
+            continue
+        for raw_path in parts[2:4]:
+            path = _normalize_diff_path(raw_path)
+            if path and path != "/dev/null":
+                paths.add(path)
+    return paths
+
+
+def patch_stats(patch: str) -> PatchStats:
+    paths: set[str] = set()
+    changed_lines = 0
+    has_deletions = False
+    has_binary = False
+    has_mode_changes = False
+
+    for line in patch.splitlines():
+        if line.startswith("diff --git "):
+            parts = line.split()
+            if len(parts) >= 4:
+                for raw_path in parts[2:4]:
+                    path = _normalize_diff_path(raw_path)
+                    if path and path != "/dev/null":
+                        paths.add(path)
+        elif line.startswith("deleted file mode"):
+            has_deletions = True
+        elif line.startswith(("old mode ", "new mode ")):
+            has_mode_changes = True
+        elif line.startswith(("Binary files ", "GIT binary patch")):
+            has_binary = True
+        elif line.startswith(("+++", "---")):
+            if line.endswith("/dev/null"):
+                has_deletions = True
+        elif line.startswith(("+", "-")):
+            changed_lines += 1
+
+    return PatchStats(
+        files=len(paths),
+        changed_lines=changed_lines,
+        paths=sorted(paths),
+        has_deletions=has_deletions,
+        has_binary=has_binary,
+        has_mode_changes=has_mode_changes,
+    )
+
+
+def evaluate_autofix_gate(
+    analysis: SelfHealAnalysis,
+    pr_metadata: dict[str, object],
+    pr_diff: str,
+    config: GateConfig,
+    *,
+    repo_root: Path | None = None,
+) -> GateResult:
+    stats = patch_stats(analysis.patch)
+    reasons: list[str] = []
+
+    if analysis.confidence != "high":
+        reasons.append(f"confidence is {analysis.confidence!r}, not 'high'")
+    if analysis.failure_class not in WHITELISTED_FAILURE_CLASSES:
+        reasons.append(f"failure_class {analysis.failure_class!r} is not whitelisted")
+    if not analysis.patch.strip():
+        reasons.append("analysis patch is empty")
+    if config.require_validation and not analysis.validation_commands:
+        reasons.append("analysis has no validation commands")
+
+    author = _metadata_author_login(pr_metadata)
+    if author not in config.allowed_authors:
+        reasons.append(f"PR author {author!r} is not allowlisted")
+
+    if _metadata_head_repository(pr_metadata) != config.repository:
+        reasons.append("PR head repository is not the base repository")
+
+    if stats.files > config.max_files:
+        reasons.append(f"patch touches {stats.files} files, max is {config.max_files}")
+    if stats.changed_lines > config.max_changed_lines:
+        reasons.append(
+            f"patch changes {stats.changed_lines} non-context lines, "
+            f"max is {config.max_changed_lines}"
+        )
+    if stats.has_deletions:
+        reasons.append("patch deletes a file")
+    if stats.has_binary:
+        reasons.append("patch contains binary changes")
+    if stats.has_mode_changes:
+        reasons.append("patch changes file modes")
+
+    pr_paths = changed_paths_from_diff(pr_diff)
+    patch_paths = set(stats.paths)
+    if patch_paths and not patch_paths.issubset(pr_paths):
+        outside = sorted(patch_paths - pr_paths)
+        reasons.append(f"patch touches paths outside the PR diff: {outside}")
+
+    forbidden_paths = _forbidden_patch_paths(patch_paths, config)
+    if forbidden_paths:
+        reasons.append(f"patch touches forbidden paths: {forbidden_paths}")
+
+    if repo_root is not None and analysis.patch.strip():
+        apply_error = _git_apply_check(repo_root, analysis.patch)
+        if apply_error:
+            reasons.append(apply_error)
+
+    return GateResult(
+        eligible=not reasons,
+        reason="eligible" if not reasons else reasons[0],
+        reasons=reasons,
+        patch_stats=stats,
+        validation_commands=analysis.validation_commands,
+    )
+
+
+def gate_result_to_json(result: GateResult) -> dict[str, object]:
+    return {
+        "eligible": result.eligible,
+        "reason": result.reason,
+        "reasons": result.reasons,
+        "patch_stats": asdict(result.patch_stats),
+        "validation_commands": result.validation_commands,
+    }
+
+
+def _strip_json_fence(text: str) -> str:
+    stripped = text.strip()
+    if not stripped.startswith("```"):
+        return stripped
+    lines = stripped.splitlines()
+    if len(lines) >= 3 and lines[0].startswith("```") and lines[-1] == "```":
+        return "\n".join(lines[1:-1]).strip()
+    return stripped
+
+
+def _required_str(data: dict[str, object], key: str) -> str:
+    value = data.get(key)
+    if not isinstance(value, str):
+        raise ValueError(f"analysis field {key!r} must be a string")
+    return value
+
+
+def _str_list(value: object) -> list[str]:
+    if value is None:
+        return []
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        raise ValueError("analysis list fields must be arrays of strings")
+    return value
+
+
+def _normalize_diff_path(raw_path: str) -> str:
+    path = raw_path.strip()
+    if path.startswith(("a/", "b/")):
+        path = path[2:]
+    return path
+
+
+def _metadata_author_login(pr_metadata: dict[str, object]) -> str:
+    author = pr_metadata.get("author")
+    if isinstance(author, dict):
+        login = author.get("login")
+        if isinstance(login, str):
+            return login
+    return ""
+
+
+def _metadata_head_repository(pr_metadata: dict[str, object]) -> str:
+    owner_login = ""
+    owner = pr_metadata.get("headRepositoryOwner")
+    if isinstance(owner, dict):
+        login = owner.get("login")
+        if isinstance(login, str):
+            owner_login = login
+
+    repo_name = ""
+    repo = pr_metadata.get("headRepository")
+    if isinstance(repo, dict):
+        name = repo.get("name")
+        if isinstance(name, str):
+            repo_name = name
+        repo_owner = repo.get("owner")
+        if not owner_login and isinstance(repo_owner, dict):
+            login = repo_owner.get("login")
+            if isinstance(login, str):
+                owner_login = login
+
+    return f"{owner_login}/{repo_name}" if owner_login and repo_name else ""
+
+
+def _forbidden_patch_paths(paths: set[str], config: GateConfig) -> list[str]:
+    return [
+        path
+        for path in sorted(paths)
+        if path in config.forbidden_paths or path.startswith(config.forbidden_prefixes)
+    ]
+
+
+def _git_apply_check(repo_root: Path, patch: str) -> str | None:
+    result = subprocess.run(
+        ["git", "apply", "--check", "-"],
+        input=patch,
+        text=True,
+        cwd=repo_root,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode == 0:
+        return None
+    detail = (result.stderr or result.stdout).strip().splitlines()
+    tail = detail[-1] if detail else "unknown error"
+    return f"git apply --check failed: {tail}"
+
+
+def _read_optional_file(path: Path, missing_text: str) -> str:
+    return path.read_text(errors="replace") if path.exists() else missing_text
+
+
+def _write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text)
+
+
+def _default_gate_config() -> GateConfig:
+    repository = os.environ.get("GITHUB_REPOSITORY", "")
+    authors = os.environ.get("SELF_HEAL_AUTOFIX_AUTHORS", "TimeToBuildBob")
+    allowed_authors = frozenset(
+        author.strip() for author in authors.split(",") if author.strip()
+    )
+    return GateConfig(repository=repository, allowed_authors=allowed_authors)
+
+
+def _legacy_main(argv: list[str]) -> int:
+    if len(argv) < 2:
         print(
             f"Usage: {sys.argv[0]} <failure_log_path> <pr_diff_path>", file=sys.stderr
         )
         return 1
 
-    failure_log_path = Path(sys.argv[1])
-    pr_diff_path = Path(sys.argv[2])
+    failure_log_path = Path(argv[0])
+    pr_diff_path = Path(argv[1])
 
     failure_log = (
         failure_log_path.read_text(errors="replace")
@@ -100,6 +485,84 @@ def main() -> int:
         return 0
     print(analysis)
     return 0
+
+
+def _analyze_main(args: argparse.Namespace) -> int:
+    failure_log_path = Path(args.failure_log)
+    pr_diff_path = Path(args.pr_diff)
+    failure_log = _read_optional_file(failure_log_path, "(no failure log available)")
+    pr_diff = _read_optional_file(pr_diff_path, "(no diff available)")
+
+    analysis = analyze_failure_structured(failure_log, pr_diff)
+    if analysis is None:
+        print("Warning: no analysis produced — skipping output.", file=sys.stderr)
+        return 0
+
+    if args.json_out:
+        _write_text(Path(args.json_out), json.dumps(asdict(analysis), indent=2) + "\n")
+    markdown = render_analysis_markdown(analysis)
+    if args.markdown_out:
+        _write_text(Path(args.markdown_out), markdown + "\n")
+    if not args.json_out and not args.markdown_out:
+        print(markdown)
+    return 0
+
+
+def _gate_main(args: argparse.Namespace) -> int:
+    analysis = parse_analysis_json(Path(args.analysis_json).read_text())
+    pr_metadata = json.loads(Path(args.pr_metadata_json).read_text())
+    if not isinstance(pr_metadata, dict):
+        raise SystemExit("PR metadata JSON must be an object")
+    pr_diff = Path(args.pr_diff).read_text(errors="replace")
+
+    config = _default_gate_config()
+    if args.repository:
+        config = GateConfig(
+            repository=args.repository,
+            allowed_authors=config.allowed_authors,
+        )
+    repo_root = Path(args.repo_root) if args.repo_root else None
+    result = evaluate_autofix_gate(
+        analysis, pr_metadata, pr_diff, config, repo_root=repo_root
+    )
+    payload = json.dumps(gate_result_to_json(result), indent=2) + "\n"
+    if args.json_out:
+        _write_text(Path(args.json_out), payload)
+    else:
+        print(payload, end="")
+    return 0
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command")
+
+    analyze_parser = subparsers.add_parser("analyze")
+    analyze_parser.add_argument("failure_log")
+    analyze_parser.add_argument("pr_diff")
+    analyze_parser.add_argument("--json-out")
+    analyze_parser.add_argument("--markdown-out")
+    analyze_parser.set_defaults(func=_analyze_main)
+
+    gate_parser = subparsers.add_parser("gate")
+    gate_parser.add_argument("analysis_json")
+    gate_parser.add_argument("pr_metadata_json")
+    gate_parser.add_argument("pr_diff")
+    gate_parser.add_argument("--json-out")
+    gate_parser.add_argument("--repository")
+    gate_parser.add_argument("--repo-root")
+    gate_parser.set_defaults(func=_gate_main)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = sys.argv[1:] if argv is None else argv
+    if not argv or argv[0] not in {"analyze", "gate"}:
+        return _legacy_main(argv)
+
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    return args.func(args)
 
 
 if __name__ == "__main__":

--- a/tests/test_github_ci_self_heal.py
+++ b/tests/test_github_ci_self_heal.py
@@ -179,6 +179,44 @@ def test_gate_rejects_forbidden_paths() -> None:
     assert "forbidden paths" in result.reason
 
 
+def test_render_analysis_markdown_escapes_backtick_fence() -> None:
+    """Backtick sequences in model-provided patch must not break the fenced block."""
+    analysis = github_ci_self_heal.SelfHealAnalysis(
+        root_cause="root",
+        proposed_fix="fix",
+        confidence="high",
+        failure_class="import_error",
+        patch="diff --git a/f b/f\n--- a/f\n+++ b/f\n@@ -1 +1 @@\n-```\n+x\n",
+        validation_commands=[],
+        risk_notes=["note with\nnewline"],
+    )
+    md = github_ci_self_heal.render_analysis_markdown(analysis)
+    # The triple-backtick in the patch must not close the outer fence prematurely.
+    assert "```\n```" not in md
+    # Risk note newline must be flattened.
+    assert "note with\nnewline" not in md
+    assert "note with newline" in md
+
+
+def test_parse_diff_git_header_handles_spaces_in_path() -> None:
+    line = "diff --git a/my path/f.py b/my path/f.py"
+    result = github_ci_self_heal._parse_diff_git_header(line)
+    assert result == ("my path/f.py", "my path/f.py")
+
+
+def test_changed_paths_from_diff_handles_spaces() -> None:
+    diff = (
+        "diff --git a/my path/f.py b/my path/f.py\n"
+        "--- a/my path/f.py\n"
+        "+++ b/my path/f.py\n"
+        "@@ -1 +1 @@\n"
+        "-old\n"
+        "+new\n"
+    )
+    paths = github_ci_self_heal.changed_paths_from_diff(diff)
+    assert paths == {"my path/f.py"}
+
+
 def test_gate_cli_writes_json_out(tmp_path: Path) -> None:
     analysis_path = tmp_path / "analysis.json"
     metadata_path = tmp_path / "pr.json"

--- a/tests/test_github_ci_self_heal.py
+++ b/tests/test_github_ci_self_heal.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "scripts/github_ci_self_heal.py"
+spec = importlib.util.spec_from_file_location("github_ci_self_heal", MODULE_PATH)
+assert spec is not None
+github_ci_self_heal = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+sys.modules["github_ci_self_heal"] = github_ci_self_heal
+spec.loader.exec_module(github_ci_self_heal)
+
+
+def _analysis(
+    *,
+    confidence: str = "high",
+    failure_class: str = "import_error",
+    patch_path: str = "tests/test_example.py",
+    validation_commands: list[str] | None = None,
+) -> Any:
+    return github_ci_self_heal.SelfHealAnalysis(
+        root_cause="A test imports a renamed symbol.",
+        proposed_fix="Update the import to the renamed symbol.",
+        confidence=confidence,
+        failure_class=failure_class,
+        patch=(
+            f"diff --git a/{patch_path} b/{patch_path}\n"
+            f"--- a/{patch_path}\n"
+            f"+++ b/{patch_path}\n"
+            "@@ -1 +1 @@\n"
+            "-from package import old_name\n"
+            "+from package import new_name\n"
+        ),
+        validation_commands=validation_commands
+        or ["uv run pytest tests/test_example.py -q"],
+        risk_notes=[],
+    )
+
+
+def _pr_metadata(
+    *, author: str = "TimeToBuildBob", owner: str = "gptme", repo: str = "gptme"
+) -> dict[str, object]:
+    return {
+        "number": 123,
+        "author": {"login": author},
+        "headRepositoryOwner": {"login": owner},
+        "headRepository": {"name": repo, "owner": {"login": owner}},
+    }
+
+
+def _pr_diff(path: str = "tests/test_example.py") -> str:
+    return (
+        f"diff --git a/{path} b/{path}\n"
+        f"--- a/{path}\n"
+        f"+++ b/{path}\n"
+        "@@ -1 +1 @@\n"
+        "-old\n"
+        "+new\n"
+    )
+
+
+def _config() -> Any:
+    return github_ci_self_heal.GateConfig(repository="gptme/gptme")
+
+
+def test_parse_analysis_json_accepts_valid_structured_analysis() -> None:
+    payload = {
+        "root_cause": "Import used an old name.",
+        "proposed_fix": "Update the import.",
+        "confidence": "HIGH",
+        "failure_class": "IMPORT_ERROR",
+        "patch": _analysis().patch,
+        "validation_commands": ["uv run pytest tests/test_example.py -q"],
+        "risk_notes": ["mechanical import-only change"],
+    }
+
+    analysis = github_ci_self_heal.parse_analysis_json(json.dumps(payload))
+
+    assert analysis.confidence == "high"
+    assert analysis.failure_class == "import_error"
+    assert analysis.validation_commands == ["uv run pytest tests/test_example.py -q"]
+
+
+def test_parse_analysis_json_rejects_malformed_json() -> None:
+    with pytest.raises(ValueError, match="invalid analysis JSON"):
+        github_ci_self_heal.parse_analysis_json("{not-json")
+
+
+def test_gate_accepts_safe_high_confidence_same_repo_patch() -> None:
+    result = github_ci_self_heal.evaluate_autofix_gate(
+        _analysis(),
+        _pr_metadata(),
+        _pr_diff(),
+        _config(),
+    )
+
+    assert result.eligible
+    assert result.reason == "eligible"
+    assert result.patch_stats.changed_lines == 2
+
+
+@pytest.mark.parametrize("confidence", ["medium", "low"])
+def test_gate_rejects_non_high_confidence(confidence: str) -> None:
+    result = github_ci_self_heal.evaluate_autofix_gate(
+        _analysis(confidence=confidence),
+        _pr_metadata(),
+        _pr_diff(),
+        _config(),
+    )
+
+    assert not result.eligible
+    assert "not 'high'" in result.reason
+
+
+def test_gate_rejects_non_whitelisted_failure_class() -> None:
+    result = github_ci_self_heal.evaluate_autofix_gate(
+        _analysis(failure_class="behavior_change"),
+        _pr_metadata(),
+        _pr_diff(),
+        _config(),
+    )
+
+    assert not result.eligible
+    assert "not whitelisted" in result.reason
+
+
+def test_gate_rejects_fork_pr_metadata() -> None:
+    result = github_ci_self_heal.evaluate_autofix_gate(
+        _analysis(),
+        _pr_metadata(owner="contributor"),
+        _pr_diff(),
+        _config(),
+    )
+
+    assert not result.eligible
+    assert "head repository" in result.reasons[0]
+
+
+def test_gate_rejects_non_allowlisted_author() -> None:
+    result = github_ci_self_heal.evaluate_autofix_gate(
+        _analysis(),
+        _pr_metadata(author="dependabot[bot]"),
+        _pr_diff(),
+        _config(),
+    )
+
+    assert not result.eligible
+    assert "not allowlisted" in result.reason
+
+
+def test_gate_rejects_patch_touching_paths_outside_pr_diff() -> None:
+    result = github_ci_self_heal.evaluate_autofix_gate(
+        _analysis(patch_path="src/gptme/other.py"),
+        _pr_metadata(),
+        _pr_diff("tests/test_example.py"),
+        _config(),
+    )
+
+    assert not result.eligible
+    assert "outside the PR diff" in result.reason
+
+
+def test_gate_rejects_forbidden_paths() -> None:
+    result = github_ci_self_heal.evaluate_autofix_gate(
+        _analysis(patch_path=".github/workflows/test.yml"),
+        _pr_metadata(),
+        _pr_diff(".github/workflows/test.yml"),
+        _config(),
+    )
+
+    assert not result.eligible
+    assert "forbidden paths" in result.reason
+
+
+def test_gate_cli_writes_json_out(tmp_path: Path) -> None:
+    analysis_path = tmp_path / "analysis.json"
+    metadata_path = tmp_path / "pr.json"
+    diff_path = tmp_path / "pr.diff"
+    output_path = tmp_path / "gate.json"
+    analysis_path.write_text(json.dumps(asdict(_analysis())))
+    metadata_path.write_text(json.dumps(_pr_metadata()))
+    diff_path.write_text(_pr_diff())
+
+    result = github_ci_self_heal.main(
+        [
+            "gate",
+            str(analysis_path),
+            str(metadata_path),
+            str(diff_path),
+            "--repository",
+            "gptme/gptme",
+            "--json-out",
+            str(output_path),
+        ]
+    )
+
+    assert result == 0
+    payload = json.loads(output_path.read_text())
+    assert payload["eligible"] is True
+    assert payload["patch_stats"]["paths"] == ["tests/test_example.py"]


### PR DESCRIPTION
## Summary
- add structured self-heal analysis JSON parsing and markdown rendering
- add conservative autofix gate checks for confidence, failure class, same-repo Bob PRs, patch budget, forbidden paths, and validation commands
- add `analyze` and `gate` CLI subcommands while preserving the legacy positional markdown CLI

## Safety boundary
This is the first Phase 2 slice only. It does not change `.github/workflows/self-heal.yml` permissions and does not push branches or create PRs. The write-capable workflow job comes after this gate is reviewable and green.

## Tests
- `uv run ruff check scripts/github_ci_self_heal.py tests/test_github_ci_self_heal.py`
- `uv run ruff format --check scripts/github_ci_self_heal.py tests/test_github_ci_self_heal.py`
- `uv run python -m pytest tests/test_github_ci_self_heal.py -q`
- `git diff --check -- scripts/github_ci_self_heal.py tests/test_github_ci_self_heal.py`