### PR TITLE
fix(logs): quiet normal runtime noise

### DIFF
--- a/gptme/llm/models/resolution.py
+++ b/gptme/llm/models/resolution.py
@@ -95,7 +95,7 @@ def _find_base_model_properties(
     if provider in MODEL_ALIASES and model_name in MODEL_ALIASES[provider]:
         canonical = MODEL_ALIASES[provider][model_name]
         if canonical in provider_models:
-            logger.info(f"Resolved alias {model_name} -> {canonical}")
+            logger.debug(f"Resolved alias {model_name} -> {canonical}")
             return provider_models[canonical]
 
     # Try stripping date suffix (e.g., -20250929) to find base model

--- a/gptme/logmanager/manager.py
+++ b/gptme/logmanager/manager.py
@@ -782,7 +782,7 @@ def prepare_messages(
     # formatting; strict APIs reject consecutive user/assistant turns.
     msgs_pruned = prune_ephemeral_messages(msgs_reduced)
     if len(msgs_reduced) != len(msgs_pruned):
-        logger.info(
+        logger.debug(
             "Pruned/merged "
             f"{len(msgs_reduced) - len(msgs_pruned)} messages during ephemeral cleanup"
         )
@@ -793,7 +793,7 @@ def prepare_messages(
     if (len_from := len_tokens(msgs, model.model)) != (
         len_to := len_tokens(msgs_pruned, model.model)
     ):
-        logger.info(f"Reduced log from {len_from // 1} to {len_to // 1} tokens")
+        logger.debug(f"Reduced log from {len_from // 1} to {len_to // 1} tokens")
     msgs_limited = limit_log(msgs_pruned)
     if len(msgs_pruned) != len(msgs_limited):
         logger.info(

--- a/gptme/message.py
+++ b/gptme/message.py
@@ -1,6 +1,7 @@
 import dataclasses
 import json
 import logging
+import re
 import shutil
 import sys
 import textwrap
@@ -469,22 +470,13 @@ timestamp = "{self.timestamp.isoformat()}"
 
 
 def _strip_think_sig(content: str) -> str:
-    """Strip think blocks and think-sig comments from message content.
+    """Strip think-sig comments from message content.
 
-    These are Anthropic extended thinking artifacts serialized into message
-    content. They are implementation noise the user shouldn't see.
+    Anthropic extended thinking signatures may be serialized into message
+    content as multiline comments. They are implementation noise the user
+    shouldn't see, while the surrounding thinking text can still be useful.
     """
-    import re
-
-    lt = chr(60)  # <
-    gt = chr(62)  # >
-    # Strip <think>...</think> blocks (may span lines)
-    think_block = lt + "think" + gt + r".*?" + lt + "/think" + gt + r"\s*"
-    content = re.sub(think_block, "", content, flags=re.DOTALL)
-    # Strip standalone <!-- think-sig: ... --> comments
-    sig_comment = lt + "!-- think-sig:.*?--" + gt + r"\s*"
-    content = re.sub(sig_comment, "", content)
-    return content
+    return re.sub(r"<!--\s*think-sig:.*?-->\s*", "", content, flags=re.DOTALL)
 
 
 def format_msgs(

--- a/gptme/message.py
+++ b/gptme/message.py
@@ -468,6 +468,25 @@ timestamp = "{self.timestamp.isoformat()}"
         return tok * price
 
 
+def _strip_think_sig(content: str) -> str:
+    """Strip think blocks and think-sig comments from message content.
+
+    These are Anthropic extended thinking artifacts serialized into message
+    content. They are implementation noise the user shouldn't see.
+    """
+    import re
+
+    lt = chr(60)  # <
+    gt = chr(62)  # >
+    # Strip <think>...</think> blocks (may span lines)
+    think_block = lt + "think" + gt + r".*?" + lt + "/think" + gt + r"\s*"
+    content = re.sub(think_block, "", content, flags=re.DOTALL)
+    # Strip standalone <!-- think-sig: ... --> comments
+    sig_comment = lt + "!-- think-sig:.*?--" + gt + r"\s*"
+    content = re.sub(sig_comment, "", content)
+    return content
+
+
 def format_msgs(
     msgs: list[Message],
     oneline: bool = False,
@@ -491,18 +510,19 @@ def format_msgs(
 
         # get terminal width
         max_len = shutil.get_terminal_size().columns - len(userprefix)
+        stripped_content = _strip_think_sig(msg.content)
         output = ""
         if oneline:
-            content = msg.content.replace("\n", "\\n")
+            content = stripped_content.replace("\n", "\\n")
             if highlight:
                 content = escape_markup(content)
             output += textwrap.shorten(content, width=max_len, placeholder="...")
             if len(output) < 20:
                 output = content[:max_len] + "..."
         else:
-            multiline = len(msg.content.split("\n")) > 1
+            multiline = len(stripped_content.split("\n")) > 1
             output += "\n" + indent * " " if multiline else ""
-            for i, block in enumerate(msg.content.split("```")):
+            for i, block in enumerate(stripped_content.split("```")):
                 if i % 2 == 0:
                     # Escape Rich markup in non-code-block content
                     if highlight:
@@ -594,7 +614,7 @@ def print_msg(
             print(s)
     if skipped_hidden:
         console.print(
-            f"[grey30]Skipped {skipped_hidden} hidden system messages, show with --show-hidden[/]"
+            f"[grey30]Skipped {skipped_hidden} hidden system messages, use /log --hidden to show[/]"
         )
 
 

--- a/gptme/telemetry.py
+++ b/gptme/telemetry.py
@@ -317,7 +317,8 @@ def _calculate_llm_cost(
     """Calculate the cost of an LLM request."""
     from .llm.models import get_model  # lazy — breaks telemetry → llm circular dep
 
-    meta = get_model(f"{model}")
+    lookup_model = model if "/" in model else f"{provider}/{model}"
+    meta = get_model(lookup_model)
     if not (meta and input_tokens and output_tokens):
         return 0.0
 

--- a/gptme/util/cost_display.py
+++ b/gptme/util/cost_display.py
@@ -93,6 +93,13 @@ def _short_model_name(full_model: str) -> str:
     return model
 
 
+def _format_cost(cost: float) -> str:
+    """Format USD costs without rounding tiny positive values to zero."""
+    if 0 < cost < 0.0001:
+        return "<$0.0001"
+    return f"${cost:.4f}"
+
+
 def gather_session_costs() -> CostData | None:
     """Get costs from CostTracker (current session only).
 
@@ -315,7 +322,7 @@ def display_costs(
         console.log(
             f"  Cache:   {last_req.cache_read_tokens:,} read / {last_req.cache_creation_tokens:,} created"
         )
-        console.log(f"  Cost:    ${last_req.cost:.4f}")
+        console.log(f"  Cost:    {_format_cost(last_req.cost)}")
         console.log("")
 
     # Show session total if available
@@ -373,31 +380,40 @@ def display_costs(
             "  "
             + "Step".rjust(4)
             + "  "
-            + "Input".rjust(7)
+            + "TotalIn".rjust(8)
+            + "  "
+            + "Uncached".rjust(8)
             + "  "
             + "Output".rjust(7)
             + "  "
-            + "Cache".rjust(7)
+            + "CacheR".rjust(8)
             + "  "
-            + "Total".rjust(7)
+            + "CacheW".rjust(8)
+            + "  "
+            + "Cost".rjust(9)
             + "  "
             + "Model"
         )
         for step in per_step:
-            cache_tokens = step.cache_read_tokens + step.cache_creation_tokens
-            total_tokens = step.input_tokens + step.output_tokens + cache_tokens
+            total_input_tokens = (
+                step.input_tokens + step.cache_read_tokens + step.cache_creation_tokens
+            )
             model_short = _short_model_name(step.model) if step.model else ""
             console.log(
                 "  "
                 + str(step.step_index).rjust(4)
                 + "  "
-                + f"{step.input_tokens:,}".rjust(7)
+                + f"{total_input_tokens:,}".rjust(8)
+                + "  "
+                + f"{step.input_tokens:,}".rjust(8)
                 + "  "
                 + f"{step.output_tokens:,}".rjust(7)
                 + "  "
-                + f"{cache_tokens:,}".rjust(7)
+                + f"{step.cache_read_tokens:,}".rjust(8)
                 + "  "
-                + f"{total_tokens:,}".rjust(7)
+                + f"{step.cache_creation_tokens:,}".rjust(8)
+                + "  "
+                + _format_cost(step.cost).rjust(9)
                 + "  "
                 + model_short
             )
@@ -412,6 +428,6 @@ def _display_total(total: TotalCosts) -> None:
     console.log(
         f"  Cache:   {total.cache_read_tokens:,} read / {total.cache_creation_tokens:,} created"
     )
-    console.log(f"  Hit rate: {total.cache_hit_rate * 100:.1f}%")
-    console.log(f"  Cost:    ${total.cost:.4f}")
+    console.log(f"  Cache hit rate: {total.cache_hit_rate * 100:.1f}%")
+    console.log(f"  Cost:    {_format_cost(total.cost)}")
     console.log(f"  Requests: {total.request_count}")

--- a/tests/test_cost_display.py
+++ b/tests/test_cost_display.py
@@ -1,11 +1,15 @@
 """Tests for util/cost_display.py — cost aggregation and display."""
 
+from unittest.mock import patch
+
 from gptme.message import Message
 from gptme.util.cost_display import (
     BiggestTurn,
     CostData,
     RequestCosts,
+    StepCost,
     TotalCosts,
+    display_costs,
     gather_conversation_costs,
 )
 
@@ -237,6 +241,53 @@ def test_total_costs_dataclass():
     assert tc.input_tokens == 1000
     assert tc.request_count == 5
     assert tc.cache_hit_rate == 0.15
+
+
+def test_display_costs_uses_explicit_cache_columns():
+    """Per-step display labels cache reads/writes separately."""
+    total = TotalCosts(
+        input_tokens=100,
+        output_tokens=50,
+        cache_read_tokens=200,
+        cache_creation_tokens=300,
+        cost=0.00001,
+        cache_hit_rate=0.4,
+        request_count=1,
+    )
+    conversation = CostData(
+        last_request=RequestCosts(
+            input_tokens=100,
+            output_tokens=50,
+            cache_read_tokens=200,
+            cache_creation_tokens=300,
+            cost=0.00001,
+        ),
+        total=total,
+        source="conversation",
+    )
+    per_step = [
+        StepCost(
+            step_index=1,
+            input_tokens=100,
+            output_tokens=50,
+            cache_read_tokens=200,
+            cache_creation_tokens=300,
+            cost=0.00001,
+            model="anthropic/claude-haiku-4-5",
+        )
+    ]
+
+    with patch("gptme.util.cost_display.console.log") as log:
+        display_costs(conversation=conversation, per_step=per_step)
+
+    output = "\n".join(str(call.args[0]) for call in log.call_args_list)
+    assert "TotalIn" in output
+    assert "Uncached" in output
+    assert "CacheR" in output
+    assert "CacheW" in output
+    assert "Cache hit rate" in output
+    assert "<$0.0001" in output
+    assert "$0.0000" not in output
 
 
 def test_cost_data_dataclass():

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -116,24 +116,24 @@ def test_format_msgs_preserves_codeblocks():
 
 
 def test_format_msgs_strips_think_sig():
-    """Test that think blocks and think-sig comments are stripped."""
+    """Test that think-sig comments are stripped but think blocks remain."""
     from gptme.message import Message, format_msgs
 
     msg = Message(
         "assistant",
-        "<think>\nreasoning\n<!-- think-sig: sig123 -->\n</think>\n\nActual response",
+        "<think>\nreasoning\n<!-- think-sig: sig123\nwrapped -->\n</think>\n\nActual response",
     )
     outputs = format_msgs([msg])
     content = outputs[0]
 
-    assert "reasoning" not in content
+    assert "reasoning" in content
     assert "think-sig" not in content
     assert "Actual response" in content
-    assert "<think>" not in content
+    assert "<think>" in content
 
 
-def test_format_msgs_think_strips_multiline():
-    """Test that multiline think blocks are stripped."""
+def test_format_msgs_preserves_think_blocks():
+    """Test that multiline think blocks are still shown."""
     from gptme.message import Message, format_msgs
 
     msg = Message(
@@ -142,8 +142,27 @@ def test_format_msgs_think_strips_multiline():
     )
     outputs = format_msgs([msg])
     content = outputs[0]
-    assert "Good, another solid turn" not in content
+    assert "Good, another solid turn" in content
+    assert "<think>" in content
+    assert "</think>" in content
     assert "Clean. Everything works" in content
+
+
+def test_format_msgs_strips_standalone_think_sig():
+    """Test that bare multiline think-sig comments are stripped."""
+    from gptme.message import Message, format_msgs
+
+    msg = Message(
+        "assistant",
+        "Before\n<!-- think-sig: abc123\nwrapped-signature -->\nAfter",
+    )
+    outputs = format_msgs([msg])
+    content = outputs[0]
+
+    assert "Before" in content
+    assert "After" in content
+    assert "think-sig" not in content
+    assert "wrapped-signature" not in content
 
 
 def test_message_files_resolve_to_absolute(tmp_path, monkeypatch):

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -115,6 +115,37 @@ def test_format_msgs_preserves_codeblocks():
     # Code blocks should still work with syntax highlighting
 
 
+def test_format_msgs_strips_think_sig():
+    """Test that think blocks and think-sig comments are stripped."""
+    from gptme.message import Message, format_msgs
+
+    msg = Message(
+        "assistant",
+        "<think>\nreasoning\n<!-- think-sig: sig123 -->\n</think>\n\nActual response",
+    )
+    outputs = format_msgs([msg])
+    content = outputs[0]
+
+    assert "reasoning" not in content
+    assert "think-sig" not in content
+    assert "Actual response" in content
+    assert "<think>" not in content
+
+
+def test_format_msgs_think_strips_multiline():
+    """Test that multiline think blocks are stripped."""
+    from gptme.message import Message, format_msgs
+
+    msg = Message(
+        "assistant",
+        "<think>\nGood, another solid turn.\n</think>\n\nClean. Everything works.",
+    )
+    outputs = format_msgs([msg])
+    content = outputs[0]
+    assert "Good, another solid turn" not in content
+    assert "Clean. Everything works" in content
+
+
 def test_message_files_resolve_to_absolute(tmp_path, monkeypatch):
     """Test that file paths are resolved to absolute paths when serializing.
 

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -24,6 +24,32 @@ def test_telemetry_imports_lazy():
     subprocess.check_call([sys.executable, "-c", code])
 
 
+def test_calculate_llm_cost_resolves_anthropic_short_alias():
+    """Anthropic short aliases should use Anthropic pricing metadata."""
+    from gptme.telemetry import _calculate_llm_cost
+
+    usage = {
+        "input_tokens": 1000,
+        "output_tokens": 100,
+        "cache_creation_tokens": 2000,
+        "cache_read_tokens": 3000,
+    }
+
+    alias_cost = _calculate_llm_cost(
+        provider="anthropic",
+        model="claude-haiku-4-5",
+        **usage,
+    )
+    dated_cost = _calculate_llm_cost(
+        provider="anthropic",
+        model="claude-haiku-4-5-20251001",
+        **usage,
+    )
+
+    assert alias_cost > 0
+    assert alias_cost == pytest.approx(dated_cost)
+
+
 @pytest.mark.skipif(
     not pytest.importorskip(
         "opentelemetry", reason="telemetry dependencies not installed"


### PR DESCRIPTION
## What

Quiets normal gptme runtime output by moving implementation-detail logs out of the default info stream, filtering Anthropic thinking signature artifacts from regular message display, and clarifying the `/cost` / `/tokens` cache/cost columns.

Changes:
- downgrade repeated model alias resolver messages from info to debug
- downgrade ephemeral cleanup and reduced-log messages from info to debug
- strip serialized `think-sig` artifacts from regular formatted message output while preserving visible `<think>` content
- update the hidden-message hint to point at `/log --hidden` instead of a startup-looking flag
- clarify per-step token/cost columns as `TotalIn`, `Uncached`, `Output`, `CacheR`, `CacheW`, and `Cost`
- rename the aggregate `Hit rate` label to `Cache hit rate`
- render tiny positive costs as `<$0.0001` instead of `$0.0000`

## Why

ErikBjare/bob#834 reports that ordinary short `gptme` runs print confusing operational noise on every step. These messages are useful diagnostics, but they should not be normal user-facing output.

The same issue also showed confusing `/cost` output where cache reads and writes were mixed into the per-step total and tiny nonzero costs displayed as `$0.0000`. This PR fixes that display layer so users can tell total input, uncached input, cache read/write, output, and actual chargeable cost apart.

## Validation

- `uv run pytest tests/test_message.py -q`
- `uv run pytest tests/test_cost_display.py tests/test_message.py -q`
- `uv run ruff check gptme/llm/models/resolution.py gptme/logmanager/manager.py gptme/message.py tests/test_message.py`
- `uv run ruff check gptme/util/cost_display.py tests/test_cost_display.py gptme/message.py tests/test_message.py`
- pre-commit hooks via `git commit` / `git commit --amend`
