### PR TITLE
fix(webui): encode chat route conversation ids

### DIFF
--- a/webui/src/components/CommandPalette.tsx
+++ b/webui/src/components/CommandPalette.tsx
@@ -28,6 +28,7 @@ import {
   exportConversationAsJSON,
   getExportableMessages,
 } from '@/utils/exportConversation';
+import { chatRoute } from '@/utils/routes';
 import { toast } from 'sonner';
 import { settingsModal$ } from '@/stores/settingsModal';
 
@@ -322,7 +323,7 @@ export function CommandPalette() {
                   key={`conv-${conv.id}`}
                   value={`conv-${conv.id} ${conv.name}`}
                   onSelect={() => {
-                    navigate(`/chat/${conv.id}`);
+                    navigate(chatRoute(conv.id));
                     setOpen(false);
                   }}
                 >

--- a/webui/src/components/CreateAgentDialog.tsx
+++ b/webui/src/components/CreateAgentDialog.tsx
@@ -28,6 +28,7 @@ import { ApiClientError } from '@/utils/api';
 import { useNavigate } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
 import { selectedAgent$ } from '@/stores/sidebar';
+import { chatRoute } from '@/utils/routes';
 
 export interface CreateAgentRequest {
   name: string;
@@ -103,7 +104,7 @@ const CreateAgentDialog: FC<Props> = ({ open, onOpenChange, onAgentCreated }) =>
 
       // Navigate and force a refresh if needed
       const conversationId = response.initial_conversation_id;
-      navigate(`/chat/${conversationId}`);
+      navigate(chatRoute(conversationId));
     } catch (error) {
       console.error('Error creating agent:', error);
 

--- a/webui/src/components/HistoryView.tsx
+++ b/webui/src/components/HistoryView.tsx
@@ -21,6 +21,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { useApi } from '@/contexts/ApiContext';
 import { ActivityCalendar } from '@/components/ActivityCalendar';
 import { getRelativeTimeString, toISODate } from '@/utils/time';
+import { chatRoute } from '@/utils/routes';
 import type { ConversationSummary } from '@/types/conversation';
 
 const PAGE_SIZE = 50;
@@ -256,7 +257,7 @@ export const HistoryView: FC = () => {
 
   const handleConversationClick = useCallback(
     (conv: ConversationSummary) => {
-      navigate(`/chat/${conv.id}`);
+      navigate(chatRoute(conv.id));
     },
     [navigate]
   );

--- a/webui/src/components/MainLayout.tsx
+++ b/webui/src/components/MainLayout.tsx
@@ -17,6 +17,7 @@ import { WorkspacesView } from '@/components/WorkspacesView';
 import { useToast } from '@/components/ui/use-toast';
 import { setDocumentTitle } from '@/utils/title';
 import { toastStepStartError } from '@/utils/stepErrorHandling';
+import { chatRoute } from '@/utils/routes';
 import { useQueryClient } from '@tanstack/react-query';
 import { useConversationsInfiniteQuery } from '@/hooks/useConversationsInfiniteQuery';
 import { useSecondaryServerConversations } from '@/hooks/useMultiServerConversations';
@@ -150,7 +151,7 @@ const MainLayout: FC<Props> = ({ conversationId, taskId }) => {
           const newSearchParams = new URLSearchParams(searchParams);
           newSearchParams.delete('step');
           const queryString = newSearchParams.toString();
-          const url = `/chat/${conversationId}${queryString ? `?${queryString}` : ''}`;
+          const url = chatRoute(conversationId, queryString);
           navigate(url, { replace: true });
         } else {
           setTimeout(checkAndStart, 100);
@@ -296,7 +297,7 @@ const MainLayout: FC<Props> = ({ conversationId, taskId }) => {
         newParams.delete('server');
       }
       const queryString = newParams.toString();
-      const url = `/chat/${id}${queryString ? `?${queryString}` : ''}`;
+      const url = chatRoute(id, queryString);
       navigate(url);
     },
     [queryClient, navigate, searchParams]

--- a/webui/src/components/SuggestedActionsPanel.tsx
+++ b/webui/src/components/SuggestedActionsPanel.tsx
@@ -22,6 +22,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Separator } from '@/components/ui/separator';
 import { useArchiveTaskMutation, useUnarchiveTaskMutation } from '@/stores/tasks';
+import { chatRoute } from '@/utils/routes';
 import type { Task, TaskAction } from '@/types/task';
 
 interface Props {
@@ -250,7 +251,7 @@ const SuggestedActionsPanel: FC<Props> = ({ task }) => {
         // Navigate to conversation view using the latest conversation ID
         const conversationId = getLatestConversationId();
         if (conversationId) {
-          navigate(`/chat/${conversationId}`);
+          navigate(chatRoute(conversationId));
         }
         break;
       }

--- a/webui/src/components/TaskDetails.tsx
+++ b/webui/src/components/TaskDetails.tsx
@@ -19,6 +19,7 @@ import { Progress } from '@/components/ui/progress';
 import { Separator } from '@/components/ui/separator';
 import { SuggestedActionsPanel } from '@/components/SuggestedActionsPanel';
 import { SuggestedActionsTips } from '@/components/SuggestedActionsTips';
+import { chatRoute } from '@/utils/routes';
 import type { Task, TaskStatus } from '@/types/task';
 
 interface Props {
@@ -239,7 +240,7 @@ const TaskDetails: FC<Props> = ({ task }) => {
                         return (
                           <div key={conversationId} className="flex items-center gap-2">
                             <button
-                              onClick={() => navigate(`/chat/${conversationId}`)}
+                              onClick={() => navigate(chatRoute(conversationId))}
                               className={`font-mono text-xs hover:underline ${
                                 isActive
                                   ? 'font-semibold text-blue-600'

--- a/webui/src/components/WelcomeView.tsx
+++ b/webui/src/components/WelcomeView.tsx
@@ -24,6 +24,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { withLocalAddressSpace } from '@/utils/addressSpace';
 import { isLikelyChromeCorsPna } from '@/utils/api';
+import { chatRoute } from '@/utils/routes';
 
 const DEFAULT_LOCAL_SERVER_URLS = new Set(['http://127.0.0.1:5700', 'http://localhost:5700']);
 
@@ -106,7 +107,7 @@ export const WelcomeView = () => {
 
       // Navigate immediately - server-side creation happens in background
       // Errors from backend are handled via toast in api.ts
-      navigate(`/chat/${conversationId}`);
+      navigate(chatRoute(conversationId));
 
       // Invalidate conversations query to refresh the list (async, don't block)
       queryClient.invalidateQueries({

--- a/webui/src/pages/Index.tsx
+++ b/webui/src/pages/Index.tsx
@@ -2,6 +2,7 @@ import { type FC } from 'react';
 import { useParams } from 'react-router-dom';
 import { MenuBar } from '@/components/MenuBar';
 import MainLayout from '@/components/MainLayout';
+import { decodeRouteParam } from '@/utils/routes';
 
 interface Props {
   className?: string;
@@ -9,11 +10,12 @@ interface Props {
 
 const Index: FC<Props> = () => {
   const { id } = useParams<{ id?: string }>();
+  const conversationId = decodeRouteParam(id);
 
   return (
     <div className="flex h-screen flex-col">
       <MenuBar />
-      <MainLayout conversationId={id} />
+      <MainLayout conversationId={conversationId} />
     </div>
   );
 };

--- a/webui/src/utils/__tests__/routes.test.ts
+++ b/webui/src/utils/__tests__/routes.test.ts
@@ -1,0 +1,18 @@
+import { chatRoute, decodeRouteParam } from '../routes';
+
+describe('chatRoute', () => {
+  it('encodes conversation IDs as one route segment', () => {
+    expect(chatRoute('demo/conv-123')).toBe('/chat/demo%2Fconv-123');
+    expect(chatRoute('demo/conv-123', 'server=secondary')).toBe(
+      '/chat/demo%2Fconv-123?server=secondary'
+    );
+  });
+});
+
+describe('decodeRouteParam', () => {
+  it('decodes encoded route params and tolerates invalid values', () => {
+    expect(decodeRouteParam('demo%2Fconv-123')).toBe('demo/conv-123');
+    expect(decodeRouteParam('%')).toBe('%');
+    expect(decodeRouteParam(undefined)).toBeUndefined();
+  });
+});

--- a/webui/src/utils/routes.ts
+++ b/webui/src/utils/routes.ts
@@ -1,0 +1,16 @@
+export function chatRoute(conversationId: string, queryString?: string): string {
+  const encodedId = encodeURIComponent(conversationId);
+  return `/chat/${encodedId}${queryString ? `?${queryString}` : ''}`;
+}
+
+export function decodeRouteParam(value: string | undefined): string | undefined {
+  if (!value) {
+    return value;
+  }
+
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}

--- a/webui/src/utils/taskApi.ts
+++ b/webui/src/utils/taskApi.ts
@@ -1,6 +1,7 @@
 import type { Task, CreateTaskRequest, TaskAction } from '@/types/task';
 import { getApiBaseUrl, getAuthHeader } from '@/utils/connectionConfig';
 import { withLocalAddressSpace } from '@/utils/addressSpace';
+import { chatRoute } from '@/utils/routes';
 
 /**
  * Helper function to add auth headers to fetch options.
@@ -178,7 +179,7 @@ export const taskApi = {
    */
   viewTaskConversation(taskId: string): void {
     // Navigate to the conversation page for this task
-    window.location.href = `/chat/${taskId}`;
+    window.location.href = chatRoute(taskId);
   },
 
   /**


### PR DESCRIPTION
## Summary
- Add shared route helpers for chat conversation IDs
- Encode chat IDs when navigating so IDs like `demo/conv-*` stay in a single route segment
- Decode route params before passing them into `MainLayout`

## Verification
- `npm test -- --runTestsByPath src/utils/__tests__/routes.test.ts src/utils/__tests__/demoApiClient.test.ts`
- `npm run typecheck`
- pre-commit hooks during commit
- Browser smoke: opened `/?demo=1`, sent a prompt, landed on `/chat/demo%2Fconv-*`, and saw the replayed final assistant response

## Follow-up
- The browser smoke still shows demo mode leaking non-demo fetches to `/api/v2` and `/api/v2/tasks`; that should be the next offline-demo slice.