### PR TITLE
fix(logs): suppress think-sig in streaming; restore CLI workspace default

### DIFF
--- a/gptme/config/chat.py
+++ b/gptme/config/chat.py
@@ -293,6 +293,9 @@ class ChatConfig:
     @classmethod
     def load_or_create(cls, logdir: Path, cli_config: Self) -> Self:
         """Load or create a chat config, applying CLI overrides."""
+        # Check before from_logdir: it may create dirs but never writes config.toml.
+        is_new_conversation = not (logdir / "config.toml").exists()
+
         # Load existing config if it exists
         config = cls.from_logdir(logdir)
         defaults = cls()
@@ -304,8 +307,16 @@ class ChatConfig:
             cli_value = getattr(cli_config, field_name)
             default_value = getattr(defaults, field_name)
 
+            if field_name == "workspace" and is_new_conversation:
+                # For new conversations from_logdir creates logdir/workspace as a
+                # server-safe default, but CLI callers want their own cwd.  Always
+                # use the cli_config workspace for new conversations so the caller
+                # controls where work lands.  Server sessions must pass an explicit
+                # workspace (e.g. "@log" → logdir/workspace) in the request config.
+                logger.debug(f"New conversation: using CLI workspace: {cli_value}")
+                config = replace(config, workspace=cli_value)
             # For optional fields that default to None, check if explicitly provided
-            if (
+            elif (
                 field_name in ["model", "tool_format", "tools", "agent"]
                 and cli_value is not None
             ):

--- a/gptme/llm/__init__.py
+++ b/gptme/llm/__init__.py
@@ -548,6 +548,15 @@ def _reply_stream(
                         rprint(f"[dim]{last_line}[/dim]", end="")
                     are_thinking = False
                     just_closed_thinking = True
+                # Suppress Anthropic think-sig comment from display.
+                # The line is still accumulated in `output` so the signature
+                # survives message serialisation and API round-tripping.
+                elif are_thinking and last_line.startswith("<!-- think-sig:"):
+                    print_clear(len(last_line))
+                    # Don't reprint and don't emit the trailing newline so
+                    # this line is completely invisible in the terminal.
+                    output += char
+                    continue
 
                 # Now print the newline
                 if not json_mode:

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -727,6 +727,8 @@ def api_conversation_put(conversation_id: str):
     # don't inherit the server process's cwd.  Clients can override by passing an
     # explicit workspace in the request config.
     config_dict.setdefault("chat", {})
+    if not isinstance(config_dict["chat"], dict):
+        return flask.jsonify({"error": "'config.chat' must be an object"}), 400
     config_dict["chat"].setdefault("workspace", "@log")
     try:
         request_config = ChatConfig.from_dict(config_dict, create_workspace=False)

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -723,6 +723,11 @@ def api_conversation_put(conversation_id: str):
     # Load or create the chat config, overriding values from request config if provided
     config_dict = dict(config_raw)
     config_dict["_logdir"] = logdir  # Pass logdir for "@log" workspace resolution
+    # Server sessions default to an isolated per-conversation workspace so they
+    # don't inherit the server process's cwd.  Clients can override by passing an
+    # explicit workspace in the request config.
+    config_dict.setdefault("chat", {})
+    config_dict["chat"].setdefault("workspace", "@log")
     try:
         request_config = ChatConfig.from_dict(config_dict, create_workspace=False)
     except ValueError as exc:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1361,17 +1361,41 @@ def test_chat_config_from_logdir_uses_existing_workspace(tmp_path):
     assert (workspace / "existing_file.txt").exists()
 
 
-def test_chat_config_load_or_create_keeps_log_workspace_for_default_cli_config(
+def test_chat_config_load_or_create_uses_cli_cwd_for_new_conversation(
     tmp_path, monkeypatch
 ):
-    """Default CLI config must not override a new conversation workspace."""
-    logdir = tmp_path / "conversation-default-cli"
+    """New conversations use the CLI workspace (cwd), not the auto-created logdir workspace.
+
+    from_logdir creates logdir/workspace as a server-safe default, but CLI sessions
+    should land in the user's current directory, not an isolated per-conversation dir.
+    Server sessions must explicitly pass workspace='@log' in their request config.
+    """
+    logdir = tmp_path / "conversation-new"
+    cli_cwd = tmp_path / "user-project"
+    cli_cwd.mkdir()
+    monkeypatch.chdir(cli_cwd)
+
+    config = ChatConfig.load_or_create(logdir, ChatConfig())
+
+    # CLI workspace (cwd) wins over the auto-created logdir/workspace.
+    assert config.workspace.resolve() == cli_cwd.resolve()
+
+
+def test_chat_config_load_or_create_server_explicit_log_workspace(
+    tmp_path, monkeypatch
+):
+    """Server sessions get logdir/workspace when they explicitly request '@log'."""
+    logdir = tmp_path / "conversation-server"
     server_cwd = tmp_path / "server-cwd"
     server_cwd.mkdir()
     monkeypatch.chdir(server_cwd)
 
-    config = ChatConfig.load_or_create(logdir, ChatConfig())
+    # Simulate what api_v2.py does: explicitly request @log workspace.
+    request_config = ChatConfig.from_dict(
+        {"_logdir": logdir, "chat": {"workspace": "@log"}},
+        create_workspace=False,
+    )
+    config = ChatConfig.load_or_create(logdir, request_config)
 
-    expected_workspace = logdir / "workspace"
-    assert expected_workspace.is_dir()
-    assert config.workspace.resolve() == expected_workspace.resolve()
+    expected_workspace = (logdir / "workspace").resolve()
+    assert config.workspace.resolve() == expected_workspace


### PR DESCRIPTION
## Summary

Two regressions from the prior `#2698` and `#2427` fixes:

- **think-sig still visible in streaming**: `<!-- think-sig: ... -->` was still printed dimmed during live streaming. The previous fix stripped it only from stored-message display (`format_msgs`). Now `_reply_stream` detects the think-sig line at the trailing newline, calls `print_clear` to erase the already-printed dimmed characters, and skips emitting the newline — making the line completely invisible. The signature is still appended to `output` so it survives serialisation and API round-tripping.

- **Workspace regression (CLI sessions land in logdir/workspace)**: New `gptme 'prompt'` sessions were using `logdir/workspace` as the working directory instead of the user's cwd. Root cause: `from_logdir` creates `logdir/workspace` for new conversations (server-isolation default from #2427), but `load_or_create`'s override check compared `cli_value == Path.cwd()` against `defaults.workspace == Path.cwd()` — always equal, so the logdir path was never overwritten. Fix: for **new** conversations (no `config.toml` yet), always use the `cli_config` workspace. Server sessions now explicitly request `workspace="@log"` via `api_v2.py`'s `setdefault` (client-supplied workspace still wins).

## Test plan

- Updated `test_chat_config_load_or_create_keeps_log_workspace_for_default_cli_config` → now verifies CLI gets cwd, not logdir/workspace
- Added `test_chat_config_load_or_create_server_explicit_log_workspace` → verifies server "@log" path still resolves to logdir/workspace
- 106 tests pass locally