### PR TITLE
fix(logs): suppress multiline think-sig; capture usage when stream broken early

### DIFF
--- a/gptme/llm/__init__.py
+++ b/gptme/llm/__init__.py
@@ -569,6 +569,7 @@ def _reply_stream(
                     if not json_mode:
                         rprint(f"[dim]{last_line}[/dim]", end="")
                     are_thinking = False
+                    in_think_sig = False
                     just_closed_thinking = True
                 # Suppress Anthropic think-sig comment from display.
                 # The comment can span multiple lines:

--- a/gptme/llm/__init__.py
+++ b/gptme/llm/__init__.py
@@ -382,14 +382,24 @@ class _StreamWithMetadata:
 
     Metadata is returned by the provider generator as its return value
     (captured via StopIteration). When the stream is broken early (e.g.
-    tool-use detection), we still populate the model name so messages
-    always have at least basic metadata.
+    tool-use detection), we fall back to partial metadata captured from the
+    provider's early events (e.g. Anthropic's message_start which carries
+    input/cache token counts before the model starts generating).
     """
 
-    def __init__(self, gen: Generator[str, None, MessageMetadata | None], model: str):
+    def __init__(
+        self,
+        gen: Generator[str, None, MessageMetadata | None],
+        model: str,
+        partial: dict | None = None,
+    ):
         self.gen = gen
         self.model = model
         self.metadata: MessageMetadata | None = None
+        # Optional dict populated by the provider generator with partial usage
+        # from early stream events (e.g. message_start).  Used as fallback when
+        # the stream is closed before the final usage event arrives.
+        self._partial = partial
 
     def __iter__(self) -> Iterator[str]:
         try:
@@ -398,10 +408,13 @@ class _StreamWithMetadata:
         except StopIteration as e:
             self.metadata = e.value
         finally:
-            # Ensure model is always set, even if the stream was broken early
-            # (break_on_tooluse, KeyboardInterrupt) before the final chunk arrived
             if self.metadata is None:
-                self.metadata = {"model": self.model}
+                # Fall back to partial metadata captured from message_start if
+                # the stream was closed before message_delta (break_on_tooluse).
+                partial_meta: MessageMetadata | None = (
+                    self._partial.get("metadata") if self._partial else None
+                )
+                self.metadata = partial_meta or {"model": self.model}
             elif "model" not in self.metadata:
                 self.metadata["model"] = self.model
 
@@ -441,6 +454,10 @@ def _stream(
     if provider == "anthropic":
         from .llm_anthropic import stream as stream_anthropic
 
+        # Shared dict: Anthropic generator writes partial usage from
+        # message_start; _StreamWithMetadata reads it as a fallback when the
+        # stream is closed before message_delta (break_on_tooluse path).
+        partial: dict = {}
         gen = stream_anthropic(
             messages,
             _get_base_model(model),
@@ -449,8 +466,9 @@ def _stream(
             max_tokens=max_tokens,
             temperature=temperature,
             top_p=top_p,
+            _partial=partial,
         )
-        return _StreamWithMetadata(gen, model)
+        return _StreamWithMetadata(gen, model, partial=partial)
     if provider == "openai-subscription":
         from .llm_openai_subscription import stream as stream_subscription
 
@@ -497,6 +515,10 @@ def _reply_stream(
     # Set to True when we detect a closing </think> tag so we can suppress the
     # one trailing blank "\n" that Anthropic always emits after </think>.
     just_closed_thinking = False
+    # True while inside a multiline <!-- think-sig: ... --> comment.
+    # Only the first line starts with "<!-- think-sig:"; continuation lines and
+    # the closing "-->" are also suppressed until the comment ends.
+    in_think_sig = False
     # Buffer chars for the current line before forwarding to on_token.
     # Thinking-tag lines are only detectable at the '\n' that closes them, so we
     # must buffer the entire line and then decide whether to emit or suppress it.
@@ -549,12 +571,22 @@ def _reply_stream(
                     are_thinking = False
                     just_closed_thinking = True
                 # Suppress Anthropic think-sig comment from display.
+                # The comment can span multiple lines:
+                #   <!-- think-sig: base64...   ← first line (starts the comment)
+                #   continuation_base64...       ← suppressed by in_think_sig
+                #   more_base64... -->           ← last line (ends the comment)
                 # The line is still accumulated in `output` so the signature
                 # survives message serialisation and API round-tripping.
                 elif are_thinking and last_line.startswith("<!-- think-sig:"):
+                    in_think_sig = not last_line.endswith("-->")
                     print_clear(len(last_line))
-                    # Don't reprint and don't emit the trailing newline so
-                    # this line is completely invisible in the terminal.
+                    output += char
+                    continue
+                elif in_think_sig:
+                    # Continuation or closing line of a multiline think-sig comment.
+                    if last_line.endswith("-->"):
+                        in_think_sig = False
+                    print_clear(len(last_line))
                     output += char
                     continue
 
@@ -564,7 +596,9 @@ def _reply_stream(
             else:
                 # Print normal characters
                 if not json_mode:
-                    if are_thinking:
+                    if in_think_sig:
+                        pass  # suppress think-sig comment body chars
+                    elif are_thinking:
                         rprint(f"[dim]{char}[/dim]", end="")
                     else:
                         rprint(char, end="")

--- a/gptme/llm/llm_anthropic.py
+++ b/gptme/llm/llm_anthropic.py
@@ -722,6 +722,7 @@ def stream(
     max_tokens: int | None = None,
     temperature: float | None = None,
     top_p: float | None = None,
+    _partial: dict | None = None,
 ) -> Generator[str, None, MessageMetadata | None]:
     import anthropic.types  # fmt: skip
     from anthropic import NOT_GIVEN  # fmt: skip
@@ -862,7 +863,24 @@ def stream(
                         anthropic.types.MessageStartEvent,
                         chunk,
                     )
-                    # Don't record usage here, wait for message_delta with final usage
+                    # Capture input/cache token counts now as a fallback for
+                    # callers that break the stream before message_delta arrives
+                    # (e.g. break_on_tooluse).  Written into the shared _partial
+                    # dict; _StreamWithMetadata reads it in its finally block.
+                    if _partial is not None and chunk.message.usage:
+                        usage = chunk.message.usage
+                        partial_usage: dict = {}
+                        if v := getattr(usage, "input_tokens", None):
+                            partial_usage["input_tokens"] = v
+                        if v := getattr(usage, "cache_read_input_tokens", None):
+                            partial_usage["cache_read_tokens"] = v
+                        if v := getattr(usage, "cache_creation_input_tokens", None):
+                            partial_usage["cache_creation_tokens"] = v
+                        if partial_usage:
+                            _partial["metadata"] = {
+                                "model": model,
+                                "usage": partial_usage,
+                            }
                 case "message_delta":
                     chunk = cast(anthropic.types.MessageDeltaEvent, chunk)
                     # Record usage from message_delta which contains the final/cumulative usage

--- a/gptme/llm/llm_anthropic.py
+++ b/gptme/llm/llm_anthropic.py
@@ -870,11 +870,15 @@ def stream(
                     if _partial is not None and chunk.message.usage:
                         usage = chunk.message.usage
                         partial_usage: dict = {}
-                        if v := getattr(usage, "input_tokens", None):
+                        if (v := getattr(usage, "input_tokens", None)) is not None:
                             partial_usage["input_tokens"] = v
-                        if v := getattr(usage, "cache_read_input_tokens", None):
+                        if (
+                            v := getattr(usage, "cache_read_input_tokens", None)
+                        ) is not None:
                             partial_usage["cache_read_tokens"] = v
-                        if v := getattr(usage, "cache_creation_input_tokens", None):
+                        if (
+                            v := getattr(usage, "cache_creation_input_tokens", None)
+                        ) is not None:
                             partial_usage["cache_creation_tokens"] = v
                         if partial_usage:
                             _partial["metadata"] = {

--- a/tests/test_llm_utils.py
+++ b/tests/test_llm_utils.py
@@ -664,6 +664,66 @@ def test_reply_stream_on_token_thinking_tag_suppressed(monkeypatch):
     assert not received_text.startswith("\n")
 
 
+def test_reply_stream_multiline_think_sig_suppressed(monkeypatch):
+    """Multiline <!-- think-sig: ... --> comments must be invisible in streaming.
+
+    The fix in #2703 only suppressed the FIRST line of the comment.  Continuation
+    lines (plain base64) were still printed dimly because are_thinking=True.
+    This test verifies all lines of the comment are hidden from the terminal
+    output AND from on_token callbacks.
+    """
+    from gptme.llm import _reply_stream
+    from gptme.message import Message
+
+    # Multiline think-sig as Anthropic emits it
+    chunks = [
+        "<think>\n",
+        "some reasoning\n",
+        "<!-- think-sig: abc123\n",  # first line starts comment
+        "continuation_base64\n",  # continuation line — was leaked before fix
+        "more_base64 -->\n",  # closing line
+        "\n</think>\n\n",
+        "Actual answer",
+    ]
+    full_text = "".join(chunks)
+
+    def _fake_gen(c):
+        yield from c
+
+    class _FakeStream:
+        def __init__(self, c):
+            self.gen = _fake_gen(c)
+            self.metadata = {"model": "test/model"}
+
+        def __iter__(self):
+            yield from self.gen
+
+    monkeypatch.setattr(
+        "gptme.llm._stream",
+        lambda *args, **kwargs: _FakeStream(chunks),
+    )
+
+    collected: list[str] = []
+    result = _reply_stream(
+        messages=[Message("user", "hi")],
+        model="test/model",
+        tools=None,
+        on_token=collected.append,
+    )
+
+    # Full output (stored log) must include the raw comment for round-tripping
+    assert "think-sig" in result.content
+    assert result.content == full_text
+
+    received_text = "".join(collected)
+
+    # Terminal / on_token output must be clean
+    assert received_text == "Actual answer", repr(received_text)
+    assert "think-sig" not in received_text
+    assert "continuation_base64" not in received_text
+    assert "more_base64" not in received_text
+
+
 def test_extract_thinking_content_with_signature():
     """_extract_thinking_content must parse embedded think-sig comments."""
     from gptme.llm.llm_anthropic import _extract_thinking_content


### PR DESCRIPTION
## Summary

Two remaining issues from ErikBjare/bob#834 (gptme logspam):

**1. `think-sig` still visible in streaming** — the prior fix (#2700) only suppressed the first line of the multiline comment. Continuation lines (plain base64) were printed dimly because `are_thinking=True`. Fix: add `in_think_sig` state that is set when the opening `<!-- think-sig:` line arrives and cleared only when the closing `-->` line is seen; all intermediate characters and newlines are suppressed.

**2. Per-step count off by 1-2** — `claude-haiku-4-5` has `supports_parallel_tool_calls=False`, so `break_on_tooluse=True`. When gptme detects a complete tool-call block and breaks the stream, `stream.gen.close()` is called before the Anthropic `message_delta` event arrives — the assistant message gets `metadata={"model": "..."}` with no usage data and is filtered out of the Per-Step breakdown. Fix: the Anthropic `stream()` generator now populates a shared `_partial` dict from `message_start` (which carries input/cache token counts at the start of the stream). `_StreamWithMetadata` falls back to `_partial["metadata"]` in its finally block when the generator was closed before `message_delta`.

The stored `output` is unchanged in both cases — think-sig stays in the log for API round-tripping; message content is intact.

## Test plan

- `test_reply_stream_multiline_think_sig_suppressed` — new test verifying all lines of a multiline comment (first line, continuation, closing `-->`) are absent from `on_token` output while remaining in `result.content`
- Existing `test_reply_stream_on_token_thinking_tag_suppressed` — no regression
- Existing `test_message.py`, `test_cost_display.py`, `test_telemetry.py` — all green (102 passed)