### PR TITLE
fix(llm): buffer thinking-block display to prevent think-sig wrapping

### DIFF
--- a/gptme/llm/__init__.py
+++ b/gptme/llm/__init__.py
@@ -523,6 +523,13 @@ def _reply_stream(
     # Thinking-tag lines are only detectable at the '\n' that closes them, so we
     # must buffer the entire line and then decide whether to emit or suppress it.
     line_buffer: list[str] = []
+    # Buffer chars inside thinking blocks for display purposes.
+    # We emit per-line rather than per-char so that long think-sig lines (hundreds
+    # of base64 chars) never get printed to the terminal: printing char-by-char and
+    # then calling print_clear() only erases the current terminal row, leaving
+    # already-wrapped rows visible.  By buffering and emitting at the newline we
+    # can simply discard think-sig lines without any terminal-clear gymnastics.
+    think_display_buffer: list[str] = []
 
     # Create stream wrapper to capture metadata
     stream = _stream(
@@ -564,8 +571,9 @@ def _reply_stream(
                     are_thinking = True
                 # Check for closing tag
                 elif last_line == "</think>" or last_line == "</thinking>":
-                    print_clear(len(last_line))
-                    # Print styled version
+                    # Chars were buffered in think_display_buffer, not printed;
+                    # no print_clear needed.
+                    think_display_buffer.clear()
                     if not json_mode:
                         rprint(f"[dim]{last_line}[/dim]", end="")
                     are_thinking = False
@@ -580,19 +588,27 @@ def _reply_stream(
                 # survives message serialisation and API round-tripping.
                 elif are_thinking and last_line.startswith("<!-- think-sig:"):
                     in_think_sig = not last_line.endswith("-->")
-                    print_clear(len(last_line))
+                    # Chars were buffered in think_display_buffer, not printed;
+                    # just discard — no print_clear needed.
+                    think_display_buffer.clear()
                     output += char
                     continue
                 elif in_think_sig:
                     # Continuation or closing line of a multiline think-sig comment.
                     if last_line.endswith("-->"):
                         in_think_sig = False
-                    print_clear(len(last_line))
+                    # in_think_sig chars are suppressed (not buffered), so
+                    # think_display_buffer is already empty; clear defensively.
+                    think_display_buffer.clear()
                     output += char
                     continue
 
-                # Now print the newline
+                # Now print the newline, flushing any buffered thinking line first.
                 if not json_mode:
+                    if think_display_buffer:
+                        # Emit the entire buffered line dimly in one shot.
+                        rprint(f"[dim]{''.join(think_display_buffer)}[/dim]", end="")
+                        think_display_buffer.clear()
                     rprint(char, end="")
             else:
                 # Print normal characters
@@ -600,7 +616,11 @@ def _reply_stream(
                     if in_think_sig:
                         pass  # suppress think-sig comment body chars
                     elif are_thinking:
-                        rprint(f"[dim]{char}[/dim]", end="")
+                        # Buffer instead of printing char-by-char.  Per-char dim
+                        # printing causes terminal-wrap issues for long lines
+                        # (print_clear only erases the current row, leaving
+                        # already-wrapped rows visible when think-sig is detected).
+                        think_display_buffer.append(char)
                     else:
                         rprint(char, end="")
 
@@ -665,6 +685,9 @@ def _reply_stream(
 
         # Flush any remaining buffered chars (responses that end without a
         # trailing newline, or partial lines left after a break_on_tooluse break).
+        if not json_mode and think_display_buffer:
+            rprint(f"[dim]{''.join(think_display_buffer)}[/dim]", end="")
+            think_display_buffer.clear()
         if on_token and line_buffer and not are_thinking:
             on_token("".join(line_buffer))
             line_buffer.clear()

--- a/tests/test_llm_utils.py
+++ b/tests/test_llm_utils.py
@@ -724,6 +724,67 @@ def test_reply_stream_multiline_think_sig_suppressed(monkeypatch):
     assert "more_base64" not in received_text
 
 
+def test_reply_stream_think_sig_long_line_not_printed(monkeypatch):
+    """Long think-sig lines must never reach rprint (terminal display).
+
+    The previous fix (#2703) called print_clear() after printing each char
+    dim one-by-one.  For lines longer than the terminal width the content
+    already wrapped, and print_clear() (which only issues \\r + spaces for
+    the current row) could not erase the wrapped rows.
+
+    The fix: buffer thinking-block chars and emit per-line, so think-sig lines
+    are simply discarded from the buffer without ever touching the terminal.
+    """
+    from gptme.llm import _reply_stream
+    from gptme.message import Message
+
+    # A long base64-looking think-sig line that would wrap in an 80-col terminal
+    long_sig = "A" * 300
+    chunks = [
+        "<think>\n",
+        "short reasoning\n",
+        f"<!-- think-sig: {long_sig}\n",  # first line (>80 chars)
+        f"{long_sig} -->\n",  # closing line still long
+        "</think>\n\n",
+        "Answer",
+    ]
+
+    def _fake_gen(c):
+        yield from c
+
+    class _FakeStream:
+        def __init__(self, c):
+            self.gen = _fake_gen(c)
+            self.metadata = {"model": "test/model"}
+
+        def __iter__(self):
+            yield from self.gen
+
+    monkeypatch.setattr(
+        "gptme.llm._stream",
+        lambda *args, **kwargs: _FakeStream(chunks),
+    )
+
+    printed: list[str] = []
+    monkeypatch.setattr("gptme.llm.rprint", lambda *a, **kw: printed.append(str(a)))
+
+    result = _reply_stream(
+        messages=[Message("user", "hi")],
+        model="test/model",
+        tools=None,
+    )
+
+    # The raw signature must survive in stored content for round-tripping
+    assert "think-sig" in result.content
+
+    # No think-sig content must ever have been passed to rprint
+    printed_text = " ".join(printed)
+    assert "think-sig" not in printed_text, (
+        f"think-sig leaked to terminal: {printed_text[:200]}"
+    )
+    assert long_sig not in printed_text, "long sig line leaked to terminal"
+
+
 def test_extract_thinking_content_with_signature():
     """_extract_thinking_content must parse embedded think-sig comments."""
     from gptme.llm.llm_anthropic import _extract_thinking_content


### PR DESCRIPTION
## Summary

Third attempt at silencing `<!-- think-sig: ... -->` in streaming output — this time fixing the actual root cause.

**Root cause**: Inside `<think>` blocks, characters were printed dim one-by-one via `rprint(f"[dim]{char}[/dim]")`. A `<!-- think-sig:` line is several hundred base64 characters long. By the time the closing `\n` arrived and the line was detected as think-sig, the content had already wrapped across multiple terminal rows. `print_clear()` only issues `\r` + spaces for the *current* row, leaving the already-wrapped rows visible on screen.

**Fix**: Buffer characters inside thinking blocks into `think_display_buffer` instead of printing them immediately. Emit the entire line dimly when the `\n` arrives — if the line turns out to be think-sig, silently discard the buffer (nothing was printed, nothing to clear).

This is a pure display-path change: `output` still accumulates every character including the think-sig content for message serialisation and API round-tripping.

## Test plan

- `test_reply_stream_multiline_think_sig_suppressed` — existing test, still passes; verifies think-sig content does not reach `on_token` callbacks
- `test_reply_stream_think_sig_long_line_not_printed` — **new test** that monkeypatches `rprint` and asserts think-sig content (including a 300-char long-sig line that would wrap in any terminal) is never passed to the terminal renderer

Refs: ErikBjare/bob#834