### PR TITLE
fix(logs): suppress think-sig chars mid-stream before newline

### DIFF
--- a/gptme/llm/__init__.py
+++ b/gptme/llm/__init__.py
@@ -598,9 +598,25 @@ def _reply_stream(
                 # Print normal characters
                 if not json_mode:
                     if in_think_sig:
-                        pass  # suppress think-sig comment body chars
+                        # Suppress think-sig comment body chars.
+                        # Reset when the closing --> is seen so subsequent
+                        # thinking content renders normally.
+                        current_line = output.rsplit("\n", 1)[-1] + char
+                        if current_line.endswith("-->"):
+                            in_think_sig = False
                     elif are_thinking:
-                        rprint(f"[dim]{char}[/dim]", end="")
+                        # Detect think-sig prefix early (before newline) so
+                        # we can suppress the long base64 body that would
+                        # otherwise wrap across multiple terminal lines and
+                        # resist print_clear.  The already-printed prefix
+                        # (≤14 chars) is short enough that print_clear
+                        # reliably erases it.
+                        current_line = output.rsplit("\n", 1)[-1] + char
+                        if current_line.startswith("<!-- think-sig:"):
+                            print_clear(len(current_line))
+                            in_think_sig = True
+                        else:
+                            rprint(f"[dim]{char}[/dim]", end="")
                     else:
                         rprint(char, end="")
 


### PR DESCRIPTION
## Summary

Fixes the remaining `<!-- think-sig: ... -->` visibility issue reported in ErikBjare/bob#834.

**Root cause**: The think-sig HTML comment detection only triggered at `\n` boundaries. Since the base64 body is one long continuous line, it wrapped across many terminal lines and was printed dimly before the `\n` handler could detect it.

**Fix**: Detect `<!-- think-sig:` prefix character-by-character in the `are_thinking` branch. When the full 14-char prefix is seen, erase the already-printed prefix with `print_clear()`, set `in_think_sig=True`, and suppress all subsequent chars until `-->` is seen. The `\n` handler remains the authoritative flag-toggler for lines where the comment boundary coincides with a newline.

**Test plan**:
- `test_reply_stream_multiline_think_sig_suppressed` — still passes (all lines suppressed from on_token output, content intact in log)
- `test_reply_stream_on_token_thinking_tag_suppressed` — no regression
- Full `tests/test_llm_utils.py` + `tests/test_message.py` — 73 passed