### PR TITLE
fix(logs): demote reasoning_budget and auto-naming retry messages to debug

### DIFF
--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -897,7 +897,7 @@ def extra_body(
                     )
                     reasoning_budget = 0
                 elif available < reasoning_budget:
-                    logger.warning(
+                    logger.debug(
                         "max_tokens=%d cannot accommodate reasoning_budget=%d; "
                         "reducing to %d (reserving %d tokens for response).",
                         max_tokens,

--- a/gptme/util/auto_naming.py
+++ b/gptme/util/auto_naming.py
@@ -50,7 +50,7 @@ def generate_conversation_name(
             # on subsequent turns when more context is available
             name = _generate_llm_name(messages, model, dash_separated)
             if not name:
-                logger.info(
+                logger.debug(
                     "LLM naming failed, returning None to allow retry on next turn"
                 )
                 return None
@@ -217,7 +217,7 @@ Conversation:
         if name:
             # Check for explicit sentinel indicating LLM couldn't generate name
             if name.upper() == no_name_sentinel:
-                logger.info("LLM indicated insufficient context for naming (NO_NAME)")
+                logger.debug("LLM indicated insufficient context for naming (NO_NAME)")
                 return None
             # Validate that the response is a proper title, not an error message
             # (fallback safety net for models that don't follow sentinel instruction)
@@ -336,7 +336,7 @@ def try_auto_name(
             config.save()
             logger.info(f"Auto-generated conversation name: {display_name}")
             return display_name
-        logger.info("Auto-naming returned no result, will retry on next message")
+        logger.debug("Auto-naming returned no result, will retry on next message")
         return None
     except Exception:
         logger.warning("Failed to auto-generate name", exc_info=True)


### PR DESCRIPTION
Addresses remaining logspam items from ErikBjare/bob#834.

## Changes

**`llm_openai.py`**: `max_tokens cannot accommodate reasoning_budget` was a `WARNING` that fired on every step when using an OpenRouter reasoning model with `max_tokens=16000` and `_OPENROUTER_REASONING_DEFAULT=20000`. This is expected adjustment behaviour, not an error — demoted to `debug`.

**`auto_naming.py`**: Three `INFO` messages that fire during normal auto-naming retry cycles:
- `"LLM naming failed, returning None to allow retry on next turn"` — normal early-turn retry
- `"LLM indicated insufficient context for naming (NO_NAME)"` — expected sentinel response
- `"Auto-naming returned no result, will retry on next message"` — same retry path

All three are expected during normal operation and were visually interfering with prompts mid-session (see Erik's report). Demoted to `debug`. The success path (`"Auto-generated conversation name: {name}"`) stays at `INFO`.

## Test

74 tests pass (`test_llm_utils.py`, `test_telemetry.py`, `test_message.py`).

Fixes: ErikBjare/bob#834 (remaining logspam items)