### PR TITLE
fix(logs): route log output through shared Rich Console in interactive mode

### DIFF
--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -642,11 +642,11 @@ def main(
         interactive = False
 
     # init logging
-    # Route log output through stdout (via shared Rich Console) when in a TTY
+    # Route log output through stdout (via shared Rich Console) when interactive
     # so that logging and streaming assistant output are serialized through the
     # same Console, preventing stderr/stdout interleave mid-stream.
     # In non-interactive/pipe modes, keep traditional stderr routing.
-    init_logging(verbose, stderr=not sys.stdout.isatty())
+    init_logging(verbose, stderr=not interactive)
 
     if not interactive:
         no_confirm = True


### PR DESCRIPTION
## Context

The core fix for this PR (routing log output through the shared Rich Console in interactive mode) was already merged as part of #2720. This PR now contains only the follow-up improvement identified during Greptile review.

## Change

**`gptme/cli/main.py`**: Use `interactive` flag instead of raw `sys.stdout.isatty()` when deciding whether to route logging through the shared Console.

```python
# Before (in #2720)
init_logging(verbose, stderr=not sys.stdout.isatty())

# After (this PR)
init_logging(verbose, stderr=not interactive)
```

## Why This Matters

The `interactive` variable is already computed to account for:
- `--non-interactive` flag (line 628)
- `PYTEST_CURRENT_TEST` env var (line 642)  
- Pipe detection (line 676)

Using the raw `isatty()` check bypasses all of that. A user running `gptme --non-interactive ...` in a terminal would have `interactive=False` but `isatty()=True`, incorrectly routing log output through the shared Console and breaking `2>/dev/null` log suppression for scripted users.

Closes #2716 (core fix already merged via #2720; this is the correctness follow-up).