### PR TITLE
fix(cost): drain stream after tool break to capture message_delta usage

### DIFF
--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -642,7 +642,11 @@ def main(
         interactive = False
 
     # init logging
-    init_logging(verbose)
+    # Route log output through stdout (via shared Rich Console) when in a TTY
+    # so that logging and streaming assistant output are serialized through the
+    # same Console, preventing stderr/stdout interleave mid-stream.
+    # In non-interactive/pipe modes, keep traditional stderr routing.
+    init_logging(verbose, stderr=not sys.stdout.isatty())
 
     if not interactive:
         no_confirm = True

--- a/gptme/init.py
+++ b/gptme/init.py
@@ -246,9 +246,17 @@ def _maybe_authenticate_gptme_interactively(
 
 
 def init_logging(verbose, *, stderr: bool = True):
-    handler = RichHandler(
-        console=Console(stderr=stderr, log_path=False)
-    )  # show_time=False
+    if not stderr:
+        # Use the shared Rich Console (same instance rprint uses) so log
+        # output is serialized with streaming assistant output through a
+        # single Console, preventing stderr/stdout interleave mid-stream.
+        from rich import get_console as _get_console
+
+        handler = RichHandler(console=_get_console())
+    else:
+        handler = RichHandler(
+            console=Console(stderr=True, log_path=False)
+        )  # show_time=False
     logging.basicConfig(
         level=logging.DEBUG if verbose else logging.INFO,
         format="%(message)s",

--- a/gptme/llm/__init__.py
+++ b/gptme/llm/__init__.py
@@ -67,7 +67,8 @@ def _drain_toolbreak_stream(stream: "_StreamWithMetadata") -> None:
     """
     discarded = 0
     try:
-        for _ in stream.gen:
+        while True:
+            next(stream.gen)
             discarded += 1
     except StopIteration as e:
         # Capture the metadata that the provider generator set as its

--- a/gptme/llm/__init__.py
+++ b/gptme/llm/__init__.py
@@ -54,6 +54,33 @@ def _tooluse_break_check_char(char: str) -> bool:
     return char == "\n"
 
 
+def _drain_toolbreak_stream(stream: "_StreamWithMetadata") -> None:
+    """Drain the generator after a break_on_tooluse to capture message_delta.
+
+    When break_on_tooluse fires before message_delta, the output tokens and
+    cost ($0.0000) are lost from the per-step breakdown.  Draining the
+    remaining generator processes the pending events (including message_delta)
+    so the metadata is complete.
+
+    This is safe because after the tool-use break, we discard the drained
+    content — it's only the side-effects (metadata capture) we care about.
+    """
+    discarded = 0
+    try:
+        for _ in stream.gen:
+            discarded += 1
+    except StopIteration as e:
+        # Capture the metadata that the provider generator set as its
+        # return value (e.g. Anthropic message_delta usage, OpenAI
+        # response.completed usage).  This overwrites the partial fallback
+        # (message_start only has input/cache counts) so the per-step
+        # breakdown shows accurate output tokens and cost.
+        if e.value:
+            stream.metadata = e.value
+    if discarded:
+        logger.debug("Drained %d chunks after tool-use break", discarded)
+
+
 # Cheap/fast default model per provider for first-run / fallback scenarios.
 # Azure is intentionally absent: deployments are tenant-specific, so there is
 # no universal default — users must supply a full model name.
@@ -406,7 +433,13 @@ class _StreamWithMetadata:
             while True:
                 yield next(self.gen)
         except StopIteration as e:
-            self.metadata = e.value
+            if self.metadata is None:
+                # Only capture from StopIteration if the drain didn't already
+                # set it.  _drain_toolbreak_stream consumes the generator and
+                # sets metadata from message_delta / response.completed, but
+                # the exhausted generator then raises StopIteration a second
+                # time with value=None — don't overwrite the rich metadata.
+                self.metadata = e.value
         finally:
             if self.metadata is None:
                 # Fall back to partial metadata captured from message_start if
@@ -681,6 +714,11 @@ def _reply_stream(
                 ]
                 if tooluses:
                     logger.debug("Found tool use, breaking")
+                    # Drain remaining stream to capture message_delta (output tokens).
+                    # When break_on_tooluse fires before message_delta, the
+                    # _StreamWithMetadata fallback only has input/cache counts from
+                    # message_start — output tokens and cost are lost.
+                    _drain_toolbreak_stream(stream)
                     break
 
         # Flush any remaining buffered chars (responses that end without a

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1555,6 +1555,28 @@ class TestInitLogging:
         )
         assert handler.console.stderr is True
 
+    def test_rich_handler_stderr_false_uses_shared_console(self):
+        """stderr=False should use the shared rich Console for single-console output."""
+        import sys
+
+        from rich import get_console as _get_console
+        from rich.logging import RichHandler as _RichHandler
+
+        from gptme.init import init_logging
+
+        init_logging(verbose=False, stderr=False)
+        handler = next(
+            h for h in logging.getLogger().handlers if isinstance(h, _RichHandler)
+        )
+        shared = _get_console()
+        assert handler.console is shared, (
+            "RichHandler should reuse the shared Console when stderr=False"
+        )
+        # Should NOT be writing to stderr directly
+        assert handler.console.file != sys.stderr, (
+            "should not use stderr when stderr=False"
+        )
+
     def test_atexit_cleanup_registered(self):
         """An atexit cleanup handler should be registered."""
         from gptme.init import init_logging


### PR DESCRIPTION
When `break_on_tooluse` fires before `message_delta` arrives with `--tool-format tool`, output token counts from `message_delta` are never recorded. This causes the per-step breakdown to show 0 output tokens and $0.0000 cost for all tool-call steps, since only the final text step receives `message_delta`.

## Root cause

- `message_start` provides input/cache token counts (captured as fallback in #2703)
- `message_delta` provides output token counts and the final cumulative usage
- `break_on_tooluse` closes the stream before `message_delta` arrives
- The `_StreamWithMetadata` fallback (`message_start` data) has no `output_tokens`
- The openai-compat path (used for `tool` format) has the same shape: `response.completed` fires after the break event

## Fix

Added `_drain_toolbreak_stream()` that, after the tool-use break fires, consumes the remaining generator events to process pending events (`message_delta` / `response.completed`) and capture their metadata. The drained content is discarded — only the side-effect of metadata capture matters.

Closes #2718