### PR TITLE
fix(webui): preserve demo query across chat navigation

### DIFF
--- a/webui/src/utils/__tests__/routes.test.ts
+++ b/webui/src/utils/__tests__/routes.test.ts
@@ -1,6 +1,10 @@
 import { chatRoute, decodeRouteParam } from '../routes';
 
 describe('chatRoute', () => {
+  beforeEach(() => {
+    window.history.replaceState(null, '', '/');
+  });
+
   it('encodes conversation IDs as one route segment', () => {
     expect(chatRoute('demo/conv-123')).toBe('/chat/demo%2Fconv-123');
     expect(chatRoute('demo/conv-123', 'server=secondary')).toBe(

--- a/webui/src/utils/__tests__/routes.test.ts
+++ b/webui/src/utils/__tests__/routes.test.ts
@@ -21,6 +21,16 @@ describe('chatRoute', () => {
     window.history.replaceState(null, '', '/?demo=1');
     expect(chatRoute('demo/conv-123', '')).toBe('/chat/demo%2Fconv-123');
   });
+
+  it('does not forward ephemeral params like step=true', () => {
+    window.history.replaceState(null, '', '/?step=true');
+    expect(chatRoute('conv-123')).toBe('/chat/conv-123');
+  });
+
+  it('forwards demo but strips step when both are present', () => {
+    window.history.replaceState(null, '', '/?demo=1&step=true');
+    expect(chatRoute('demo/conv-123')).toBe('/chat/demo%2Fconv-123?demo=1');
+  });
 });
 
 describe('decodeRouteParam', () => {

--- a/webui/src/utils/__tests__/routes.test.ts
+++ b/webui/src/utils/__tests__/routes.test.ts
@@ -7,6 +7,16 @@ describe('chatRoute', () => {
       '/chat/demo%2Fconv-123?server=secondary'
     );
   });
+
+  it('preserves the current query string by default', () => {
+    window.history.replaceState(null, '', '/?demo=1');
+    expect(chatRoute('demo/conv-123')).toBe('/chat/demo%2Fconv-123?demo=1');
+  });
+
+  it('allows callers to intentionally omit query params', () => {
+    window.history.replaceState(null, '', '/?demo=1');
+    expect(chatRoute('demo/conv-123', '')).toBe('/chat/demo%2Fconv-123');
+  });
 });
 
 describe('decodeRouteParam', () => {

--- a/webui/src/utils/routes.ts
+++ b/webui/src/utils/routes.ts
@@ -4,12 +4,25 @@ export function chatRoute(conversationId: string, queryString?: string): string 
   return `/chat/${encodedId}${search ? `?${search}` : ''}`;
 }
 
+// Only forward params that are safe to carry across navigation.
+// ?step=true is ephemeral (cleaned up by MainLayout's replace); forwarding it
+// would trigger auto-generation on the wrong conversation if the user navigates
+// before the cleanup fires.
+const FORWARDED_PARAMS = new Set(['demo']);
+
 function currentSearchParams(): string {
   if (typeof window === 'undefined') {
     return '';
   }
 
-  return window.location.search.replace(/^\?/, '');
+  const params = new URLSearchParams(window.location.search);
+  const forwarded = new URLSearchParams();
+  for (const [key, value] of params) {
+    if (FORWARDED_PARAMS.has(key)) {
+      forwarded.set(key, value);
+    }
+  }
+  return forwarded.toString();
 }
 
 export function decodeRouteParam(value: string | undefined): string | undefined {

--- a/webui/src/utils/routes.ts
+++ b/webui/src/utils/routes.ts
@@ -1,6 +1,15 @@
 export function chatRoute(conversationId: string, queryString?: string): string {
   const encodedId = encodeURIComponent(conversationId);
-  return `/chat/${encodedId}${queryString ? `?${queryString}` : ''}`;
+  const search = queryString ?? currentSearchParams();
+  return `/chat/${encodedId}${search ? `?${search}` : ''}`;
+}
+
+function currentSearchParams(): string {
+  if (typeof window === 'undefined') {
+    return '';
+  }
+
+  return window.location.search.replace(/^\?/, '');
 }
 
 export function decodeRouteParam(value: string | undefined): string | undefined {


### PR DESCRIPTION
## Summary
- preserve the active query string when building chat routes by default
- keep the explicit `queryString` override for callers that intentionally pass server-specific params or an empty query
- add route-helper regression coverage for `?demo=1`

## Why
Browser verification of the merged offline demo path found that the initial `/?demo=1` page was quiet, but sending the first prompt navigated to `/chat/demo%2Fconv-*` without `?demo=1`. Dropping the flag disabled demo guards on the chat page and reintroduced live requests to `127.0.0.1:5700/api/v2/tasks` and `demo://offline/api/v2/models`.

## Verification
- `cd /tmp/gptme-demo-verify-33e5/webui && npm test -- --runTestsByPath src/utils/__tests__/routes.test.ts --runInBand`
- `cd /tmp/gptme-demo-verify-33e5/webui && npm run typecheck`
- Playwright smoke on local Vite port 5716: open `/?demo=1`, close onboarding, send "Show me the demo tool flow", verify final URL matches `/chat/demo%2Fconv-*?demo=1` and captured backend request list is empty.
