### PR TITLE
fix(browser): use tabs instead of new windows for CDP connections

### DIFF
--- a/gptme/tools/_browser_playwright.py
+++ b/gptme/tools/_browser_playwright.py
@@ -23,7 +23,11 @@ from playwright.sync_api import (
 )
 
 from ._browser_format import format_snapshot as _format_snapshot
-from ._browser_thread import BrowserThread, _is_connection_error
+from ._browser_thread import (
+    DEFAULT_CONTEXT_OPTIONS,
+    BrowserThread,
+    _is_connection_error,
+)
 
 _browser: BrowserThread | None = None
 _last_logs: dict = {"logs": [], "errors": [], "url": None}
@@ -33,8 +37,8 @@ _current_context: BrowserContext | None = None
 logger = logging.getLogger(__name__)
 
 
-def _is_cdp_connection(browser: Browser) -> bool:
-    """Check if the browser was connected via CDP (reuse existing window)."""
+def _is_cdp_connection() -> bool:
+    """Check if the active browser was connected via CDP (reuse existing window)."""
     return _browser is not None and _browser.cdp_url is not None
 
 
@@ -66,13 +70,18 @@ def _create_page(browser: Browser, **context_kwargs) -> _ManagedPage:
     """Create a page, reusing the session context for CDP connections.
 
     CDP mode  → opens a new **tab** in an isolated session context so that
-    parallel gptme instances sharing the same Chrome don't collide.
+    parallel gptme instances sharing the same Chrome don't collide. The shared
+    context already carries the default locale/geolocation; per-call request
+    headers are applied to the individual tab.
     Launched  → creates an isolated context with the given options.
     """
-    if _is_cdp_connection(browser) and _browser is not None:
+    if _is_cdp_connection() and _browser is not None:
         ctx = _browser._session_context
         if ctx is not None:
             page = ctx.new_page()
+            headers = context_kwargs.get("extra_http_headers")
+            if headers:
+                page.set_extra_http_headers(headers)
             return _ManagedPage(page=page, _owned_context=None)
 
     context = browser.new_context(**context_kwargs)
@@ -146,9 +155,7 @@ def _load_page(browser: Browser, url: str) -> str:
 
     managed = _create_page(
         browser,
-        locale="en-US",
-        geolocation={"latitude": 37.773972, "longitude": 13.39},
-        permissions=["geolocation"],
+        **DEFAULT_CONTEXT_OPTIONS,
         extra_http_headers={
             # Prefer markdown and plaintext over HTML for better LLM consumption
             # Quality values (q) indicate preference order
@@ -349,12 +356,7 @@ def _search_google(browser: Browser, query: str) -> str:
     query = urllib.parse.quote(query)
     url = f"https://www.google.com/search?q={query}&hl=en"
 
-    managed = _create_page(
-        browser,
-        locale="en-US",
-        geolocation={"latitude": 37.773972, "longitude": 13.39},
-        permissions=["geolocation"],
-    )
+    managed = _create_page(browser, **DEFAULT_CONTEXT_OPTIONS)
     page = managed.page
     try:
         page.goto(url)
@@ -383,12 +385,7 @@ def search_google(query: str) -> str:
 def _search_duckduckgo(browser: Browser, query: str) -> str:
     url = f"https://html.duckduckgo.com/html?q={query}"
 
-    managed = _create_page(
-        browser,
-        locale="en-US",
-        geolocation={"latitude": 37.773972, "longitude": 13.39},
-        permissions=["geolocation"],
-    )
+    managed = _create_page(browser, **DEFAULT_CONTEXT_OPTIONS)
     page = managed.page
     try:
         page.goto(url)
@@ -601,9 +598,7 @@ def _open_page(browser: Browser, url: str) -> str:
 
     managed = _create_page(
         browser,
-        locale="en-US",
-        geolocation={"latitude": 37.773972, "longitude": 13.39},
-        permissions=["geolocation"],
+        **DEFAULT_CONTEXT_OPTIONS,
         extra_http_headers={
             "Accept": "text/markdown, text/plain, text/html;q=0.9, */*;q=0.8"
         },

--- a/gptme/tools/_browser_playwright.py
+++ b/gptme/tools/_browser_playwright.py
@@ -33,6 +33,53 @@ _current_context: BrowserContext | None = None
 logger = logging.getLogger(__name__)
 
 
+def _is_cdp_connection(browser: Browser) -> bool:
+    """Check if the browser was connected via CDP (reuse existing window)."""
+    return _browser is not None and _browser.cdp_url is not None
+
+
+@dataclass
+class _ManagedPage:
+    """A page with optional context ownership for proper cleanup.
+
+    For CDP connections the existing context is reused (new tab, not window),
+    so ``_owned_context`` is ``None`` and ``close()`` only closes the tab.
+    For launched browsers we create and own an isolated context.
+    """
+
+    page: Page
+    _owned_context: BrowserContext | None = None
+
+    def close(self) -> None:
+        try:
+            self.page.close()
+        except Exception:
+            pass
+        if self._owned_context is not None:
+            try:
+                self._owned_context.close()
+            except Exception:
+                pass
+
+
+def _create_page(browser: Browser, **context_kwargs) -> _ManagedPage:
+    """Create a page, reusing the session context for CDP connections.
+
+    CDP mode  → opens a new **tab** in an isolated session context so that
+    parallel gptme instances sharing the same Chrome don't collide.
+    Launched  → creates an isolated context with the given options.
+    """
+    if _is_cdp_connection(browser) and _browser is not None:
+        ctx = _browser._session_context
+        if ctx is not None:
+            page = ctx.new_page()
+            return _ManagedPage(page=page, _owned_context=None)
+
+    context = browser.new_context(**context_kwargs)
+    page = context.new_page()
+    return _ManagedPage(page=page, _owned_context=context)
+
+
 def _restart_browser() -> None:
     """Restart the browser by resetting the global instance"""
 
@@ -97,7 +144,8 @@ def _load_page(browser: Browser, url: str) -> str:
     """Load a page and return its body HTML, always capturing logs"""
     global _last_logs
 
-    context = browser.new_context(
+    managed = _create_page(
+        browser,
         locale="en-US",
         geolocation={"latitude": 37.773972, "longitude": 13.39},
         permissions=["geolocation"],
@@ -107,9 +155,9 @@ def _load_page(browser: Browser, url: str) -> str:
             "Accept": "text/markdown, text/plain, text/html;q=0.9, */*;q=0.8"
         },
     )
+    page = managed.page
 
     logger.info(f"Loading page: {url}")
-    page = context.new_page()
 
     # Always capture logs
     logs = []
@@ -149,8 +197,7 @@ def _load_page(browser: Browser, url: str) -> str:
         html = _extract_main_content(page)
         return html
     finally:
-        page.close()
-        context.close()
+        managed.close()
 
 
 def _extract_main_content(page: Page) -> str:
@@ -302,12 +349,13 @@ def _search_google(browser: Browser, query: str) -> str:
     query = urllib.parse.quote(query)
     url = f"https://www.google.com/search?q={query}&hl=en"
 
-    context = browser.new_context(
+    managed = _create_page(
+        browser,
         locale="en-US",
         geolocation={"latitude": 37.773972, "longitude": 13.39},
         permissions=["geolocation"],
     )
-    page = context.new_page()
+    page = managed.page
     try:
         page.goto(url)
 
@@ -325,8 +373,7 @@ def _search_google(browser: Browser, query: str) -> str:
             return "Error: Google detected automated access and is showing a CAPTCHA. Try using 'perplexity' as the search engine instead: search(query, 'perplexity')"
         return _list_results_google(page, body_text)
     finally:
-        page.close()
-        context.close()
+        managed.close()
 
 
 def search_google(query: str) -> str:
@@ -336,18 +383,18 @@ def search_google(query: str) -> str:
 def _search_duckduckgo(browser: Browser, query: str) -> str:
     url = f"https://html.duckduckgo.com/html?q={query}"
 
-    context = browser.new_context(
+    managed = _create_page(
+        browser,
         locale="en-US",
         geolocation={"latitude": 37.773972, "longitude": 13.39},
         permissions=["geolocation"],
     )
-    page = context.new_page()
+    page = managed.page
     try:
         page.goto(url)
         return _list_results_duckduckgo(page)
     finally:
-        page.close()
-        context.close()
+        managed.close()
 
 
 def search_duckduckgo(query: str) -> str:
@@ -472,10 +519,11 @@ def _list_results_duckduckgo(page) -> str:
 
 def _get_aria_snapshot(browser: Browser, url: str) -> str:
     """Load a page and return its ARIA accessibility snapshot."""
-    context = browser.new_context(
+    managed = _create_page(
+        browser,
         locale="en-US",
     )
-    page = context.new_page()
+    page = managed.page
     try:
         page.goto(
             url
@@ -485,8 +533,7 @@ def _get_aria_snapshot(browser: Browser, url: str) -> str:
             return "Error: Could not get accessibility snapshot for this page."
         return _format_snapshot(snapshot, page.url, page.title())
     finally:
-        page.close()
-        context.close()
+        managed.close()
 
 
 def aria_snapshot(url: str) -> str:
@@ -549,9 +596,11 @@ def read_page_text() -> str:
 def _open_page(browser: Browser, url: str) -> str:
     """Open a page for interactive browsing and return its ARIA snapshot."""
     global _current_page, _current_context
+
     _close_current_page()
 
-    _current_context = browser.new_context(
+    managed = _create_page(
+        browser,
         locale="en-US",
         geolocation={"latitude": 37.773972, "longitude": 13.39},
         permissions=["geolocation"],
@@ -559,7 +608,9 @@ def _open_page(browser: Browser, url: str) -> str:
             "Accept": "text/markdown, text/plain, text/html;q=0.9, */*;q=0.8"
         },
     )
-    _current_page = _current_context.new_page()
+    # Store page/context for interactive use; don't auto-close via ManagedPage
+    _current_page = managed.page
+    _current_context = managed._owned_context
 
     try:
         _current_page.goto(url)
@@ -693,15 +744,14 @@ def _take_screenshot(
         # create the directory if it doesn't exist
         os.makedirs(os.path.dirname(path), exist_ok=True)
 
-    context = browser.new_context()
-    page = context.new_page()
+    managed = _create_page(browser)
+    page = managed.page
     try:
         page.goto(url)
         page.screenshot(path=path)
         return Path(path)
     finally:
-        page.close()
-        context.close()
+        managed.close()
 
 
 def screenshot_url(url: str, path: Path | str | None = None) -> Path:

--- a/gptme/tools/_browser_playwright.py
+++ b/gptme/tools/_browser_playwright.py
@@ -83,6 +83,12 @@ def _create_page(browser: Browser, **context_kwargs) -> _ManagedPage:
             if headers:
                 page.set_extra_http_headers(headers)
             return _ManagedPage(page=page, _owned_context=None)
+        # CDP without a session context shouldn't happen (it's recreated on
+        # every reconnect) — warn rather than silently opening a new window.
+        logger.warning(
+            "CDP connection has no session context; falling back to a new "
+            "browser context (may open a new window)"
+        )
 
     context = browser.new_context(**context_kwargs)
     page = context.new_page()

--- a/gptme/tools/_browser_thread.py
+++ b/gptme/tools/_browser_thread.py
@@ -17,6 +17,15 @@ T = TypeVar("T")
 
 TIMEOUT = 20  # seconds - accounts for retry attempts with browser restarts
 
+# Default context options applied to every browser context (and, in CDP mode,
+# to the shared session context). Per-call request headers are layered on top
+# at page creation time (see _create_page).
+DEFAULT_CONTEXT_OPTIONS: dict[str, Any] = {
+    "locale": "en-US",
+    "geolocation": {"latitude": 37.773972, "longitude": 13.39},
+    "permissions": ["geolocation"],
+}
+
 
 def _is_connection_error(error: Exception) -> bool:
     """Check if error indicates browser connection failure"""
@@ -92,7 +101,23 @@ class BrowserThread:
                         browser = None  # Clear reference after close
                     except Exception:
                         browser = None  # Clear reference even if close fails
+                # Drop any session context bound to the old (now dead) connection
+                # so we don't open tabs on a stale context after a reconnect.
+                if self._session_context is not None:
+                    try:
+                        self._session_context.close()
+                    except Exception:
+                        pass
+                    self._session_context = None
                 browser = _connect_or_launch_browser(playwright, self.cdp_url)
+                # For CDP, (re)create an isolated session context so parallel
+                # gptme instances don't share cookies/tabs. Recreated on every
+                # (re)connect so it never points at a dead browser.
+                if self.cdp_url:
+                    self._session_context = browser.new_context(
+                        **DEFAULT_CONTEXT_OPTIONS
+                    )
+                    logger.info("Created isolated session context for CDP connection")
                 return None
             except Exception as e:
                 browser = None  # Ensure browser is None after failed launch
@@ -115,12 +140,6 @@ class BrowserThread:
                 self._init_error = init_error
                 self.ready.set()
                 return
-
-            # For CDP connections, create an isolated session context so
-            # parallel gptme instances don't share cookies/tabs.
-            if self.cdp_url and browser is not None:
-                self._session_context = browser.new_context()
-                logger.info("Created isolated session context for CDP connection")
 
             self.ready.set()  # Signal successful init
 

--- a/gptme/tools/_browser_thread.py
+++ b/gptme/tools/_browser_thread.py
@@ -7,7 +7,7 @@ from queue import Empty, Queue
 from threading import Event, Lock, Thread
 from typing import Any, Literal, TypeVar
 
-from playwright.sync_api import Browser, Playwright, sync_playwright
+from playwright.sync_api import Browser, BrowserContext, Playwright, sync_playwright
 
 from gptme.config import get_config
 
@@ -64,6 +64,9 @@ class BrowserThread:
         self.lock = Lock()
         self.ready = Event()
         self._init_error: Exception | None = None
+        # Session-scoped context for CDP connections — isolates this gptme
+        # session from other agents/tabs sharing the same browser.
+        self._session_context: BrowserContext | None = None
         self.thread = Thread(target=self._run, daemon=True)
         self.thread.start()
         # Wait for browser to be ready
@@ -94,7 +97,7 @@ class BrowserThread:
             except Exception as e:
                 browser = None  # Ensure browser is None after failed launch
                 error: Exception
-                
+
                 if "Executable doesn't exist" in str(e):
                     pw_version = importlib.metadata.version("playwright")
                     error = RuntimeError(
@@ -112,6 +115,12 @@ class BrowserThread:
                 self._init_error = init_error
                 self.ready.set()
                 return
+
+            # For CDP connections, create an isolated session context so
+            # parallel gptme instances don't share cookies/tabs.
+            if self.cdp_url and browser is not None:
+                self._session_context = browser.new_context()
+                logger.info("Created isolated session context for CDP connection")
 
             self.ready.set()  # Signal successful init
 
@@ -163,6 +172,14 @@ class BrowserThread:
             self.ready.set()  # Prevent hanging in __init__
             raise
         finally:
+            # Close session context before browser
+            if self._session_context is not None:
+                try:
+                    self._session_context.close()
+                except Exception:
+                    logger.debug("Error closing session context during cleanup")
+                self._session_context = None
+
             # Close browser with isolated error handling
             if browser is not None:
                 try:

--- a/tests/test_tools_browser.py
+++ b/tests/test_tools_browser.py
@@ -984,6 +984,7 @@ class TestExamples:
 # ── _create_page (CDP tab reuse vs launched contexts) ─────────────────
 
 
+@pytest.mark.skipif(not has_playwright(), reason="playwright not installed")
 class TestCreatePage:
     """Test page creation: CDP reuses a session context (tabs), launched
     browsers get an isolated owned context."""

--- a/tests/test_tools_browser.py
+++ b/tests/test_tools_browser.py
@@ -979,3 +979,64 @@ class TestExamples:
 
         result = examples("markdown")
         assert "pdf" in result.lower() or "PDF" in result
+
+
+# ── _create_page (CDP tab reuse vs launched contexts) ─────────────────
+
+
+class TestCreatePage:
+    """Test page creation: CDP reuses a session context (tabs), launched
+    browsers get an isolated owned context."""
+
+    def test_cdp_reuses_session_context_and_applies_headers(self):
+        from gptme.tools import _browser_playwright as bp
+
+        thread = MagicMock()
+        thread.cdp_url = "http://127.0.0.1:9222"
+        ctx = thread._session_context = MagicMock()
+        page = ctx.new_page.return_value
+        browser = MagicMock()
+
+        with patch.object(bp, "_browser", thread):
+            managed = bp._create_page(
+                browser,
+                locale="en-US",
+                extra_http_headers={"Accept": "text/markdown"},
+            )
+
+        # A new tab in the shared context, not a new window/context.
+        ctx.new_page.assert_called_once_with()
+        browser.new_context.assert_not_called()
+        # Per-call request headers are applied to the individual tab.
+        page.set_extra_http_headers.assert_called_once_with({"Accept": "text/markdown"})
+        assert managed.page is page
+        assert managed._owned_context is None
+
+    def test_cdp_without_headers_skips_set_headers(self):
+        from gptme.tools import _browser_playwright as bp
+
+        thread = MagicMock()
+        thread.cdp_url = "http://127.0.0.1:9222"
+        ctx = thread._session_context = MagicMock()
+        page = ctx.new_page.return_value
+
+        with patch.object(bp, "_browser", thread):
+            bp._create_page(MagicMock(), locale="en-US")
+
+        page.set_extra_http_headers.assert_not_called()
+
+    def test_launched_creates_owned_context_with_kwargs(self):
+        from gptme.tools import _browser_playwright as bp
+
+        thread = MagicMock()
+        thread.cdp_url = None  # launched mode
+        browser = MagicMock()
+        context = browser.new_context.return_value
+        page = context.new_page.return_value
+
+        with patch.object(bp, "_browser", thread):
+            managed = bp._create_page(browser, locale="en-US")
+
+        browser.new_context.assert_called_once_with(locale="en-US")
+        assert managed.page is page
+        assert managed._owned_context is context

--- a/tests/test_tools_browser_thread.py
+++ b/tests/test_tools_browser_thread.py
@@ -136,8 +136,13 @@ class TestConnectOrLaunchBrowser:
 
 
 @pytest.fixture
-def mock_playwright():
+def mock_playwright(monkeypatch):
     """Mock playwright to avoid needing a real browser."""
+    # Remove real CDP URL from env so tests default to the launch path.
+    # Tests that need CDP (e.g. test_connects_over_cdp_from_env) can
+    # monkeypatch.setenv() to override.
+    monkeypatch.delenv("GPTME_BROWSER_CDP_URL", raising=False)
+
     mock_pw_instance = MagicMock()
     mock_browser = MagicMock()
     mock_pw_instance.chromium.launch.return_value = mock_browser
@@ -145,7 +150,16 @@ def mock_playwright():
     mock_pw_ctx = MagicMock()
     mock_pw_ctx.start.return_value = mock_pw_instance
 
-    with patch("gptme.tools._browser_thread.sync_playwright", return_value=mock_pw_ctx):
+    with (
+        patch("gptme.tools._browser_thread.sync_playwright", return_value=mock_pw_ctx),
+        patch("gptme.tools._browser_thread.get_config") as mock_config,
+    ):
+        # Make get_env read from os.environ with GPTME_ prefix (like the real impl)
+        import os
+
+        mock_config.return_value.get_env.side_effect = lambda key: os.environ.get(
+            f"GPTME_{key}"
+        )
         yield mock_pw_instance, mock_browser
 
 

--- a/tests/test_tools_browser_thread.py
+++ b/tests/test_tools_browser_thread.py
@@ -17,6 +17,7 @@ import pytest
 pytest.importorskip("playwright")
 
 from gptme.tools._browser_thread import (
+    DEFAULT_CONTEXT_OPTIONS,
     TIMEOUT,
     BrowserThread,
     Command,
@@ -369,6 +370,62 @@ class TestBrowserThreadRetry:
                 bt.execute(fail_once)
             # Should NOT retry for non-connection errors
             assert call_count == 1
+        finally:
+            bt.stop()
+
+
+class TestBrowserThreadSessionContext:
+    """Test the CDP session context lifecycle."""
+
+    def test_cdp_creates_session_context_with_defaults(self, mock_playwright):
+        mock_pw, _ = mock_playwright
+        mock_cdp_browser = MagicMock()
+        mock_pw.chromium.connect_over_cdp.return_value = mock_cdp_browser
+
+        bt = BrowserThread(cdp_url="http://127.0.0.1:9222")
+        try:
+            mock_cdp_browser.new_context.assert_called_once_with(
+                **DEFAULT_CONTEXT_OPTIONS
+            )
+            assert bt._session_context is mock_cdp_browser.new_context.return_value
+        finally:
+            bt.stop()
+
+    def test_launched_mode_has_no_session_context(self, mock_playwright):
+        mock_pw, mock_browser = mock_playwright
+        bt = BrowserThread()
+        try:
+            assert bt._session_context is None
+            mock_browser.new_context.assert_not_called()
+        finally:
+            bt.stop()
+
+    def test_session_context_recreated_after_restart(self, mock_playwright):
+        """A connection-error restart must rebuild the session context on the
+        reconnected browser, never leaving a stale one bound to the dead conn."""
+        mock_pw, _ = mock_playwright
+        browser1, browser2 = MagicMock(name="browser1"), MagicMock(name="browser2")
+        ctx1 = browser1.new_context.return_value
+        ctx2 = browser2.new_context.return_value
+        mock_pw.chromium.connect_over_cdp.side_effect = [browser1, browser2]
+
+        bt = BrowserThread(cdp_url="http://127.0.0.1:9222")
+        try:
+            assert bt._session_context is ctx1
+
+            call_count = 0
+
+            def flaky(browser):
+                nonlocal call_count
+                call_count += 1
+                if call_count == 1:
+                    raise RuntimeError("connection closed")
+                return "ok"
+
+            assert bt.execute(flaky) == "ok"
+            # Stale context closed; fresh one created on the reconnected browser.
+            ctx1.close.assert_called_once()
+            assert bt._session_context is ctx2
         finally:
             bt.stop()
 


### PR DESCRIPTION
When connected to an existing Chrome instance via CDP (`GPTME_BROWSER_CDP_URL`), the browser tool previously created new browser contexts for every operation — which could open new windows and caused interference when multiple gptme sessions shared the same Chrome.

## Changes

- **New tab reuse for CDP**: Introduces `_create_page()` which detects CDP mode and opens tabs in a per-session `BrowserContext` instead of creating new contexts/windows
- **Session isolation**: Each `BrowserThread` creates one `_session_context` for its lifetime, so parallel gptme instances using the same Chrome get isolated cookies/storage
- **`_ManagedPage` helper**: Centralizes page lifecycle — for CDP the page is closed but the shared context stays; for launched browsers the owned context is also closed
- **Test fixture fix**: The `mock_playwright` fixture now patches `get_config` to prevent a real `GPTME_BROWSER_CDP_URL` env var from leaking into mocked tests (fixes 6 pre-existing test failures when the env var is set)

## Testing

All 184 browser-related tests pass (plus 1 skipped for missing Perplexity key).