### PR TITLE
fix(llm): suppress arg-type errors in stream() after anthropic SDK 0.105 bump

### DIFF
--- a/gptme/llm/llm_anthropic.py
+++ b/gptme/llm/llm_anthropic.py
@@ -779,7 +779,7 @@ def stream(
 
     _temperature = temperature if temperature is not None else TEMPERATURE
     _top_p = top_p if top_p is not None else TOP_P
-    with _anthropic.messages.stream(  # type: ignore[call-arg, misc]
+    with _anthropic.messages.stream(  # type: ignore[call-arg, arg-type, misc]
         model=api_model,
         messages=messages_dicts,
         system=system_messages,


### PR DESCRIPTION
The anthropic SDK 0.105 bump (PR #2710) causes 3 mypy `arg-type` errors in the streaming path because `NOT_GIVEN` is now typed as `NotGiven` instead of compatible with `Omit` in the newer SDK:

```
gptme/llm/llm_anthropic.py:787: error: Argument "top_p" to "stream" of "Messages" has incompatible type "float | NotGiven"; expected "float | Omit"
gptme/llm/llm_anthropic.py:789: error: Argument "tools" to "stream" of "Messages" has incompatible type "list[ToolParam] | NotGiven"; expected "Iterable[...] | Omit"
gptme/llm/llm_anthropic.py:791: error: Argument "output_config" to "stream" of "Messages" has incompatible type "_OutputConfig"; expected "OutputConfigParam | Omit"
```

This is a type-stub mismatch, not a runtime issue — the `NOT_GIVEN` sentinel is accepted at runtime but the newer SDK's type annotations use `Omit` instead. The non-streaming `create()` path already has `# type: ignore[call-overload, misc]` which covers it there.

Fix: add `arg-type` to the existing `# type: ignore` comment on the `stream()` call to suppress these false positives.
