### PR TITLE
fix(cli): guard against empty --name value bypassing ParamType validation

### DIFF
--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -161,6 +161,7 @@ class ConversationName(click.ParamType):
         # crashing with a validation error. This guards against Click version
         # and shell edge cases where --name "" bypasses the ParamType's
         # convert method and passes an empty string straight to main().
+        # Non-empty values still go through conversation_name_error() below.
         if not value or not value.strip():
             return "random"
         if error := conversation_name_error(value):

--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -157,6 +157,12 @@ class ConversationName(click.ParamType):
     def convert(self, value, param, ctx):
         if value == "random":
             return value
+        # Empty/whitespace-only names silently default to "random" instead of
+        # crashing with a validation error. This guards against Click version
+        # and shell edge cases where --name "" bypasses the ParamType's
+        # convert method and passes an empty string straight to main().
+        if not value or not value.strip():
+            return "random"
         if error := conversation_name_error(value):
             self.fail(error, param, ctx)
         return value

--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -498,6 +498,11 @@ def main(
 ):
     """Main entrypoint for the CLI."""
 
+    # Defense-in-depth: handle empty/whitespace names in case Click bypasses convert()
+    # (observed to occur in some Click versions when --name "" is passed)
+    if not name or not name.strip():
+        name = "random"
+
     # Apply agent profile if specified
     selected_profile = None
     if agent_profile:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -155,13 +155,26 @@ def test_name_rejects_path_traversal(bad_name: str, runner: CliRunner):
 
 
 @pytest.mark.parametrize("bad_name", ["", " ", "   ", "\t"])
-def test_name_rejects_empty_or_whitespace_only_values(bad_name: str, runner: CliRunner):
+def test_name_defaults_to_random_for_empty_or_whitespace(
+    bad_name: str, runner: CliRunner
+):
     result = runner.invoke(
         cli.main,
         ["--name", bad_name, "--non-interactive", "hello"],
     )
-    assert result.exit_code == 2
-    assert "conversation name cannot be empty" in result.output
+    # Empty/whitespace names default to "random" to guard against Click/shell
+    # edge cases where --name "" bypasses the ParamType and reaches main() empty
+    assert result.exit_code == 0
+
+
+def test_name_empty_before_output_format(runner: CliRunner):
+    """Regression: --name "" with later flags must not crash with a raw stack trace."""
+    result = runner.invoke(
+        cli.main,
+        ["--name", "", "--output-format", "json", "--non-interactive", "hello"],
+    )
+    # Must not crash with SystemExit(2) or traceback
+    assert result.exit_code == 0
 
 
 @pytest.mark.parametrize(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -156,30 +156,76 @@ def test_name_rejects_path_traversal(bad_name: str, runner: CliRunner):
 
 @pytest.mark.parametrize("bad_name", ["", " ", "   ", "\t"])
 def test_name_defaults_to_random_for_empty_or_whitespace(
-    bad_name: str, runner: CliRunner
+    monkeypatch, tmp_path: Path, bad_name: str, runner: CliRunner
 ):
-    # No prompt: exits early at "non-interactive requires a prompt" (before LLM call).
-    # This keeps the test fast and avoids requiring an API key.
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "state"))
+
+    logdir = tmp_path / "existing-conversation"
+    logdir.mkdir()
+    (logdir / "conversation.jsonl").write_text('{"role":"user","content":"hello"}\n')
+
+    selected_names: list[str] = []
+    selected_logdirs: list[Path] = []
+
+    def fake_get_logdir(name: str) -> Path:
+        selected_names.append(name)
+        return logdir
+
+    def fake_chat(prompt_msgs, initial_msgs, chat_logdir, *args, **kwargs):
+        selected_logdirs.append(chat_logdir)
+
+    monkeypatch.setattr(cli, "get_logdir", fake_get_logdir)
+    monkeypatch.setattr(cli, "chat", fake_chat)
+
     result = runner.invoke(
         cli.main,
-        ["--name", bad_name, "--non-interactive"],
+        ["--name", bad_name, "--non-interactive", "hello"],
+        catch_exceptions=False,
     )
-    # Must not raise a Click name-validation error (exit 2 = UsageError)
-    assert result.exit_code != 2
-    assert "conversation name cannot" not in (result.output or "")
+
+    assert result.exit_code == 0
+    assert "Traceback" not in result.output
+    assert selected_names == ["random"]
+    assert selected_logdirs == [logdir]
 
 
-def test_name_empty_before_output_format(runner: CliRunner):
-    """Regression: --name "" with later flags must not crash with a raw stack trace."""
-    # No prompt: exits early before LLM call, keeping test fast without API key.
+def test_name_empty_before_output_format(
+    monkeypatch, tmp_path: Path, runner: CliRunner
+):
+    """Regression: --name "" with later flags must still normalize to random."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "state"))
+
+    logdir = tmp_path / "existing-conversation"
+    logdir.mkdir()
+    (logdir / "conversation.jsonl").write_text('{"role":"user","content":"hello"}\n')
+
+    selected_names: list[str] = []
+    selected_logdirs: list[Path] = []
+
+    def fake_get_logdir(name: str) -> Path:
+        selected_names.append(name)
+        return logdir
+
+    def fake_chat(prompt_msgs, initial_msgs, chat_logdir, *args, **kwargs):
+        selected_logdirs.append(chat_logdir)
+
+    monkeypatch.setattr(cli, "get_logdir", fake_get_logdir)
+    monkeypatch.setattr(cli, "chat", fake_chat)
+
     result = runner.invoke(
         cli.main,
-        ["--name", "", "--output-format", "json", "--non-interactive"],
+        ["--name", "", "--output-format", "json", "--non-interactive", "hello"],
+        catch_exceptions=False,
     )
-    # Must not crash with a name-validation error or raw traceback
-    assert result.exit_code != 2
-    assert "conversation name cannot" not in (result.output or "")
-    assert result.exception is None or isinstance(result.exception, SystemExit)
+
+    assert result.exit_code == 0
+    assert "Traceback" not in result.output
+    assert selected_names == ["random"]
+    assert selected_logdirs == [logdir]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -158,23 +158,28 @@ def test_name_rejects_path_traversal(bad_name: str, runner: CliRunner):
 def test_name_defaults_to_random_for_empty_or_whitespace(
     bad_name: str, runner: CliRunner
 ):
+    # No prompt: exits early at "non-interactive requires a prompt" (before LLM call).
+    # This keeps the test fast and avoids requiring an API key.
     result = runner.invoke(
         cli.main,
-        ["--name", bad_name, "--non-interactive", "hello"],
+        ["--name", bad_name, "--non-interactive"],
     )
-    # Empty/whitespace names default to "random" to guard against Click/shell
-    # edge cases where --name "" bypasses the ParamType and reaches main() empty
-    assert result.exit_code == 0
+    # Must not raise a Click name-validation error (exit 2 = UsageError)
+    assert result.exit_code != 2
+    assert "conversation name cannot" not in (result.output or "")
 
 
 def test_name_empty_before_output_format(runner: CliRunner):
     """Regression: --name "" with later flags must not crash with a raw stack trace."""
+    # No prompt: exits early before LLM call, keeping test fast without API key.
     result = runner.invoke(
         cli.main,
-        ["--name", "", "--output-format", "json", "--non-interactive", "hello"],
+        ["--name", "", "--output-format", "json", "--non-interactive"],
     )
-    # Must not crash with SystemExit(2) or traceback
-    assert result.exit_code == 0
+    # Must not crash with a name-validation error or raw traceback
+    assert result.exit_code != 2
+    assert "conversation name cannot" not in (result.output or "")
+    assert result.exception is None or isinstance(result.exception, SystemExit)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

`gptme --name "" [prompts]` bypasses the `ConversationName` validation in `gptme/cli/main.py:156` and starts gptme with an empty conversation name instead of rejecting it.

**Three bugs here:**
1. `ConversationName.convert()` validation is bypassed at the Click level for empty string values (exit 0 instead of exit 2)
2. `get_logdir()` runs `logdir.mkdir()` before the validation error is raised, creating an orphan directory
3. Even the `ValueError` in `get_logdir()` is caught somewhere and doesn't kill the process

## Expected behavior (post-fix)

`--name ""` and `--name " "` silently fall back to a random conversation name, identical to omitting `--name` entirely. No crash, no orphan directory, no wrong conversation loaded.

## Actual behavior (pre-fix)

```
$ gptme --name "" --non-interactive what-is-2+2
→ loads existing conversation, produces an LLM response
```

gptme starts up with no conversation name, defaults to the base log directory, and/or resumes an existing conversation.

## Root cause

`ConversationName.convert()` calls `self.fail()` which raises `click.BadParameter`. This works correctly in unit tests via `CliRunner` (exit 2, error message printed). But when invoked through the installed `gptme` CLI entry point with an actual shell argument `""`, the error is swallowed and gptme proceeds.

The code path after the converter passes the empty string to `get_logdir()` at line 1090, where `isinstance("", str)` is true but then `conversation_name_error("")` returns an error string, `ValueError` is raised — but it is raised after `logdir.mkdir(parents=True, exist_ok=True)` has already created the directory.

## Fix

Add an explicit guard in `ConversationName.convert()` that maps empty/whitespace-only values to `"random"` before reaching validation or directory-creation code. This mirrors the behavior of omitting `--name` entirely and is robust to Click version differences.

Rejection-with-error would be cleaner UX, but `self.fail()` is unreliable in real CLI invocations (gets swallowed outside `CliRunner`) — making silent-random the more reliable guard.

## Investigation

- Tested via `click.testing.CliRunner` → works correctly (exit 2 with `Invalid value: conversation name cannot be empty.`)
- Tested via `gptme --name "" --tools none --non-interactive --output-format json "hello"` → gptme starts, loads a logdir, produces response
- Tested on gptme 0.31.0 with Click 8.3.0
- Validation function `conversation_id_error()` at `gptme/util/conversation_ids.py:6` correctly returns error for empty/whitespace strings
- `ConversationName` type at `gptme/cli/main.py:152` with `self.fail()` correctly raises `BadParameter`
