### PR TITLE
feat(patch): add _anchored core module — hash-anchored line editing

### DIFF
--- a/gptme/tools/_anchored.py
+++ b/gptme/tools/_anchored.py
@@ -1,0 +1,163 @@
+"""Hash-anchored line editing engine.
+
+Provides content-addressed line anchors that survive line-number drift
+from unrelated edits, resolving the failure mode where conflict-marker
+patches lose their footing after sequential edits in the same file.
+
+Anchors are computed as blake2s(prev_line \0 line \0 next_line), binding
+each line to its local neighborhood so that a stale anchor (from an
+adjacent-line change) fails loudly rather than silently resolving to the
+wrong place. Duplicate identical lines are disambiguated by an ordinal.
+
+This is a pure library module — it has no CLI and no gptme tool
+registration. Tool surfaces (``view_anchored`` / ``patch_anchored``) are
+built on top of it in separate modules.
+
+Design note: :file:`knowledge/technical-designs/2026-05-31-hash-anchored-editing-gptme-integration.md`
+(bob workspace).
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from typing import Literal
+
+OperationKind = Literal["replace", "delete", "insert_before", "insert_after"]
+
+
+@dataclass(frozen=True)
+class LineAnchor:
+    """A content-addressed anchor for one line of text.
+
+    The ``anchor`` field is the canonical display-and-resolve token:
+    ``<digest>:<ordinal>``, e.g. ``a3f1:1``.
+    """
+
+    anchor: str
+    digest: str
+    ordinal: int
+    line_no: int
+    text: str
+    prev_text: str
+    next_text: str
+
+
+@dataclass(frozen=True)
+class EditOperation:
+    """A single anchored edit operation.
+
+    Fields:
+
+    - ``anchor``: an anchor token produced by :func:`snapshot_text`
+    - ``op``: the kind of operation to apply
+    - ``text``: text block for ``replace`` / ``insert_before`` /
+      ``insert_after`` (``None`` for ``delete``)
+    - ``expected``: optional guard — if set and the line at the
+      resolved position no longer matches ``expected``, the entire
+      batch is rejected before any mutations are applied
+    """
+
+    anchor: str
+    op: OperationKind
+    text: str | None = None
+    expected: str | None = None
+
+
+def _line_digest(prev_text: str, text: str, next_text: str) -> str:
+    """Compute a context-triple digest for one line."""
+    payload = f"{prev_text}\0{text}\0{next_text}".encode()
+    return hashlib.blake2s(payload, digest_size=8).hexdigest()
+
+
+def snapshot_text(text: str) -> list[LineAnchor]:
+    """Annotate every line of ``text`` with a content-addressed anchor.
+
+    The returned list is 1:1 with the lines of ``text`` (index *i* carries
+    the anchor for line *i*).  Duplicate identical triples get ascending
+    ordinals so the model can target a specific occurrence.
+    """
+    lines = text.splitlines()
+    counts: dict[tuple[str, str, str], int] = {}
+    anchors: list[LineAnchor] = []
+
+    for index, line in enumerate(lines):
+        prev_text = lines[index - 1] if index else ""
+        next_text = lines[index + 1] if index + 1 < len(lines) else ""
+        key = (prev_text, line, next_text)
+        ordinal = counts.get(key, 0) + 1
+        counts[key] = ordinal
+        digest = _line_digest(*key)
+        anchors.append(
+            LineAnchor(
+                anchor=f"{digest}:{ordinal}",
+                digest=digest,
+                ordinal=ordinal,
+                line_no=index + 1,
+                text=line,
+                prev_text=prev_text,
+                next_text=next_text,
+            )
+        )
+    return anchors
+
+
+def _split_block(text: str | None) -> list[str]:
+    if text is None:
+        return []
+    return text.split("\n")
+
+
+def apply_operations(text: str, operations: list[EditOperation]) -> str:
+    """Atomically resolve and apply a batch of anchored edit operations.
+
+    All anchors are resolved against the **current** file before any
+    mutation happens.  If any anchor is unknown, or any ``expected``
+    guard fails, the entire batch is rejected with a :class:`ValueError`
+    and ``text`` is returned unchanged.
+    """
+    had_trailing_newline = text.endswith("\n")
+    lines = text.splitlines()
+    anchors = {item.anchor: item for item in snapshot_text(text)}
+
+    resolved: list[tuple[int, EditOperation]] = []
+    seen_anchors: set[str] = set()
+
+    for operation in operations:
+        anchor = anchors.get(operation.anchor)
+        if anchor is None:
+            raise ValueError(f"Unknown anchor: {operation.anchor}")
+        if operation.anchor in seen_anchors:
+            raise ValueError(
+                f"Multiple operations target the same anchor: {operation.anchor}"
+            )
+        seen_anchors.add(operation.anchor)
+
+        line_index = anchor.line_no - 1
+        if operation.expected is not None and lines[line_index] != operation.expected:
+            raise ValueError(
+                f"Anchor {operation.anchor} no longer matches expected text: "
+                f"{lines[line_index]!r} != {operation.expected!r}"
+            )
+        resolved.append((line_index, operation))
+
+    # Apply bottom-up so line indices above the current edit stay valid.
+    for line_index, operation in sorted(
+        resolved, key=lambda item: item[0], reverse=True
+    ):
+        block = _split_block(operation.text)
+        if operation.op == "replace":
+            lines[line_index : line_index + 1] = block
+        elif operation.op == "delete":
+            lines[line_index : line_index + 1] = []
+        elif operation.op == "insert_before":
+            lines[line_index:line_index] = block
+        elif operation.op == "insert_after":
+            lines[line_index + 1 : line_index + 1] = block
+        else:  # pragma: no cover
+            raise ValueError(f"Unsupported operation: {operation.op}")
+
+    result = "\n".join(lines)
+    if had_trailing_newline:
+        result += "\n"
+    return result

--- a/gptme/tools/_anchored.py
+++ b/gptme/tools/_anchored.py
@@ -105,7 +105,7 @@ def snapshot_text(text: str) -> list[LineAnchor]:
 def _split_block(text: str | None) -> list[str]:
     if text is None:
         return []
-    return text.split("\n")
+    return text.splitlines()
 
 
 def apply_operations(text: str, operations: list[EditOperation]) -> str:
@@ -132,6 +132,14 @@ def apply_operations(text: str, operations: list[EditOperation]) -> str:
                 f"Multiple operations target the same anchor: {operation.anchor}"
             )
         seen_anchors.add(operation.anchor)
+
+        if (
+            operation.op in ("replace", "insert_before", "insert_after")
+            and operation.text is None
+        ):
+            raise ValueError(
+                f"Operation '{operation.op}' requires text but got None for anchor {operation.anchor}"
+            )
 
         line_index = anchor.line_no - 1
         if operation.expected is not None and lines[line_index] != operation.expected:

--- a/gptme/tools/_anchored.py
+++ b/gptme/tools/_anchored.py
@@ -117,6 +117,7 @@ def apply_operations(text: str, operations: list[EditOperation]) -> str:
     and ``text`` is returned unchanged.
     """
     had_trailing_newline = text.endswith("\n")
+    crlf = "\r\n" in text
     lines = text.splitlines()
     anchors = {item.anchor: item for item in snapshot_text(text)}
 
@@ -168,4 +169,6 @@ def apply_operations(text: str, operations: list[EditOperation]) -> str:
     result = "\n".join(lines)
     if had_trailing_newline:
         result += "\n"
+    if crlf:
+        result = result.replace("\n", "\r\n")
     return result

--- a/tests/test_tools__anchored.py
+++ b/tests/test_tools__anchored.py
@@ -245,3 +245,47 @@ class TestApplyOperations:
             [EditOperation(anchor=anchors[1].anchor, op="replace", text="B1\nB2\nB3")],
         )
         assert updated == "alpha\nB1\nB2\nB3\ngamma\n"
+
+    def test_text_with_trailing_newline_no_spurious_blank(self) -> None:
+        """EditOperation.text ending with \\n must not insert a spurious blank line."""
+        original = "alpha\nbeta\ngamma\n"
+        anchors = snapshot_text(original)
+        updated = apply_operations(
+            original,
+            [EditOperation(anchor=anchors[1].anchor, op="replace", text="B1\nB2\n")],
+        )
+        assert updated == "alpha\nB1\nB2\ngamma\n"
+
+    def test_replace_with_none_text_raises(self) -> None:
+        """replace op with text=None must raise ValueError, not silently delete."""
+        original = "alpha\nbeta\ngamma\n"
+        anchors = snapshot_text(original)
+        with pytest.raises(ValueError, match="requires text"):
+            apply_operations(
+                original,
+                [EditOperation(anchor=anchors[1].anchor, op="replace", text=None)],
+            )
+
+    def test_insert_before_with_none_text_raises(self) -> None:
+        """insert_before op with text=None must raise ValueError."""
+        original = "alpha\nbeta\n"
+        anchors = snapshot_text(original)
+        with pytest.raises(ValueError, match="requires text"):
+            apply_operations(
+                original,
+                [
+                    EditOperation(
+                        anchor=anchors[0].anchor, op="insert_before", text=None
+                    )
+                ],
+            )
+
+    def test_insert_after_with_none_text_raises(self) -> None:
+        """insert_after op with text=None must raise ValueError."""
+        original = "alpha\nbeta\n"
+        anchors = snapshot_text(original)
+        with pytest.raises(ValueError, match="requires text"):
+            apply_operations(
+                original,
+                [EditOperation(anchor=anchors[0].anchor, op="insert_after", text=None)],
+            )

--- a/tests/test_tools__anchored.py
+++ b/tests/test_tools__anchored.py
@@ -1,0 +1,247 @@
+"""Tests for the hash-anchored editing engine (gptme.tools._anchored).
+
+Ported from the Bob-local prototype tests in
+``tests/test_hash_anchor_edit.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gptme.tools._anchored import (
+    EditOperation,
+    apply_operations,
+    snapshot_text,
+)
+
+
+class TestSnapshotText:
+    def test_anchor_survives_unrelated_insertions(self) -> None:
+        """Anchors are content-addressed, so prepending lines doesn't break them."""
+        original = "alpha\nbeta\ngamma\ndelta\n"
+        target_anchor = snapshot_text(original)[2].anchor  # "gamma"
+
+        updated = "header\n" + original
+        matching = [item for item in snapshot_text(updated) if item.text == "gamma"]
+
+        assert matching[0].anchor == target_anchor
+
+    def test_duplicate_lines_get_distinct_ordinals(self) -> None:
+        """Two identical `dup` lines get different anchor tokens via ordinals."""
+        original = "x\ndup\ny\nx\ndup\ny\n"
+        duplicate_anchors = [
+            item for item in snapshot_text(original) if item.text == "dup"
+        ]
+
+        assert len(duplicate_anchors) == 2
+        assert duplicate_anchors[0].anchor != duplicate_anchors[1].anchor
+
+    def test_all_lines_get_anchors(self) -> None:
+        """Every line, including first and last, gets exactly one anchor."""
+        text = "one\ntwo\nthree\n"
+        anchors = snapshot_text(text)
+        assert len(anchors) == 3
+        assert anchors[0].text == "one"
+        assert anchors[-1].text == "three"
+
+    def test_empty_text(self) -> None:
+        """Empty text produces no anchors."""
+        assert snapshot_text("") == []
+
+    def test_single_line(self) -> None:
+        """A single line gets one anchor with empty prev/next."""
+        anchors = snapshot_text("solo\n")
+        assert len(anchors) == 1
+        assert anchors[0].text == "solo"
+        assert anchors[0].prev_text == ""
+        assert anchors[0].next_text == ""
+
+    def test_exact_duplicate_triple_gets_ordinal_2(self) -> None:
+        """Two lines with identical prev/text/next triples get ordinals 1 and 2."""
+        # To get exact triple duplicates (prev + text + next all identical),
+        # we need lines surrounded by identical neighbors:
+        text2 = "ab\ntarget\ncd\nab\ntarget\ncd\n"
+        anchors2 = snapshot_text(text2)
+        target_anchors = [a for a in anchors2 if a.text == "target"]
+        assert len(target_anchors) == 2
+        assert target_anchors[0].ordinal == 1
+        assert target_anchors[1].ordinal == 2
+        assert target_anchors[0].anchor != target_anchors[1].anchor
+
+    def test_anchor_format(self) -> None:
+        """Anchor token format: <digest>:<ordinal>."""
+        anchors = snapshot_text("hello\n")
+        parts = anchors[0].anchor.split(":")
+        assert len(parts) == 2
+        assert len(parts[0]) == 16  # 8-byte blake2s hex
+        assert parts[1] == "1"
+
+
+class TestApplyOperations:
+    def test_resolves_all_targets_before_mutating(self) -> None:
+        """All anchors resolve against the original text, not a partially-mutated buffer."""
+        original = "alpha\nbeta\ngamma\ndelta\n"
+        anchors = snapshot_text(original)
+
+        updated = apply_operations(
+            original,
+            [
+                EditOperation(anchor=anchors[0].anchor, op="replace", text="ALPHA"),
+                EditOperation(
+                    anchor=anchors[2].anchor, op="insert_before", text="one\ntwo"
+                ),
+                EditOperation(anchor=anchors[3].anchor, op="delete"),
+            ],
+        )
+
+        assert updated == "ALPHA\nbeta\none\ntwo\ngamma\n"
+
+    def test_duplicate_line_replacement(self) -> None:
+        """Can target the *second* identical duplicate line via ordinal."""
+        original = "x\ndup\ny\nx\ndup\ny\n"
+        duplicate_anchors = [
+            item for item in snapshot_text(original) if item.text == "dup"
+        ]
+
+        updated = apply_operations(
+            original,
+            [
+                EditOperation(
+                    anchor=duplicate_anchors[1].anchor, op="replace", text="changed"
+                )
+            ],
+        )
+
+        assert updated == "x\ndup\ny\nx\nchanged\ny\n"
+
+    def test_rejects_unknown_anchor_after_adjacent_change(self) -> None:
+        """Adjacent-line changes invalidate anchors — the batch must fail loudly."""
+        original = "alpha\nbeta\ngamma\n"
+        target_anchor = snapshot_text(original)[1].anchor
+        changed = "alpha\ninserted\nbeta\ngamma\n"
+
+        with pytest.raises(ValueError, match="Unknown anchor"):
+            apply_operations(
+                changed,
+                [EditOperation(anchor=target_anchor, op="replace", text="BETA")],
+            )
+
+    def test_rejects_duplicate_anchor_in_same_batch(self) -> None:
+        """Two ops targeting the same anchor in one batch should fail."""
+        original = "alpha\nbeta\ngamma\n"
+        anchors = snapshot_text(original)
+
+        with pytest.raises(ValueError, match="Multiple operations target"):
+            apply_operations(
+                original,
+                [
+                    EditOperation(anchor=anchors[0].anchor, op="replace", text="A"),
+                    EditOperation(anchor=anchors[0].anchor, op="delete"),
+                ],
+            )
+
+    def test_expected_guard_passes(self) -> None:
+        """`expected` guard succeeds when the line matches."""
+        original = "alpha\nbeta\ngamma\n"
+        anchors = snapshot_text(original)
+
+        updated = apply_operations(
+            original,
+            [
+                EditOperation(
+                    anchor=anchors[0].anchor,
+                    op="replace",
+                    text="ALPHA",
+                    expected="alpha",
+                )
+            ],
+        )
+        assert updated == "ALPHA\nbeta\ngamma\n"
+
+    def test_expected_guard_fails(self) -> None:
+        """`expected` guard fails when the line doesn't match, rejecting the batch."""
+        original = "alpha\nbeta\ngamma\n"
+        anchors = snapshot_text(original)
+
+        with pytest.raises(ValueError, match="no longer matches expected text"):
+            apply_operations(
+                original,
+                [
+                    EditOperation(
+                        anchor=anchors[0].anchor,
+                        op="replace",
+                        text="ALPHA",
+                        expected="wrong",
+                    )
+                ],
+            )
+
+    def test_insert_before(self) -> None:
+        original = "alpha\nbeta\n"
+        anchors = snapshot_text(original)
+
+        updated = apply_operations(
+            original,
+            [EditOperation(anchor=anchors[0].anchor, op="insert_before", text="zero")],
+        )
+        assert updated == "zero\nalpha\nbeta\n"
+
+    def test_insert_after(self) -> None:
+        original = "alpha\nbeta\n"
+        anchors = snapshot_text(original)
+
+        updated = apply_operations(
+            original,
+            [
+                EditOperation(
+                    anchor=anchors[0].anchor, op="insert_after", text="one-half"
+                )
+            ],
+        )
+        assert updated == "alpha\none-half\nbeta\n"
+
+    def test_delete(self) -> None:
+        original = "alpha\nbeta\ngamma\n"
+        anchors = snapshot_text(original)
+
+        updated = apply_operations(
+            original,
+            [EditOperation(anchor=anchors[1].anchor, op="delete")],
+        )
+        assert updated == "alpha\ngamma\n"
+
+    def test_delete_final_line(self) -> None:
+        """Deleting the last line works; trailing-newline preservation is determined
+        by the original text's ending."""
+        original = "alpha\nbeta\n"
+        anchors = snapshot_text(original)
+        updated = apply_operations(
+            original,
+            [EditOperation(anchor=anchors[1].anchor, op="delete")],
+        )
+        assert updated == "alpha\n"
+
+    def test_preserves_trailing_newline(self) -> None:
+        """Trailing newline is preserved through edits."""
+        original = "alpha\nbeta\n"
+        anchors = snapshot_text(original)
+        updated = apply_operations(
+            original,
+            [EditOperation(anchor=anchors[0].anchor, op="replace", text="ALPHA")],
+        )
+        assert updated == "ALPHA\nbeta\n"
+
+    def test_empty_operations_list(self) -> None:
+        """No-op: empty ops list returns original text unchanged."""
+        original = "alpha\nbeta\n"
+        assert apply_operations(original, []) == original
+
+    def test_multi_line_replace(self) -> None:
+        """Replace a single line with multiple lines."""
+        original = "alpha\nbeta\ngamma\n"
+        anchors = snapshot_text(original)
+        updated = apply_operations(
+            original,
+            [EditOperation(anchor=anchors[1].anchor, op="replace", text="B1\nB2\nB3")],
+        )
+        assert updated == "alpha\nB1\nB2\nB3\ngamma\n"

--- a/tests/test_tools__anchored.py
+++ b/tests/test_tools__anchored.py
@@ -289,3 +289,18 @@ class TestApplyOperations:
                 original,
                 [EditOperation(anchor=anchors[0].anchor, op="insert_after", text=None)],
             )
+
+    def test_crlf_line_endings_preserved(self) -> None:
+        """CRLF line endings survive a round-trip — empty ops return text unchanged."""
+        original = "alpha\r\nbeta\r\ngamma\r\n"
+        assert apply_operations(original, []) == original
+
+    def test_crlf_line_endings_preserved_through_edit(self) -> None:
+        """CRLF line endings are preserved when an edit is applied."""
+        original = "alpha\r\nbeta\r\ngamma\r\n"
+        anchors = snapshot_text(original)
+        updated = apply_operations(
+            original,
+            [EditOperation(anchor=anchors[1].anchor, op="replace", text="BETA")],
+        )
+        assert updated == "alpha\r\nBETA\r\ngamma\r\n"


### PR DESCRIPTION
## Summary

Gate G1 of `patch_anchored` (gptme/gptme#2667): promote the hash-anchor editing prototype to a reusable core library module in gptme.

## What this PR does

- **`gptme/tools/_anchored.py`** — reusable library module with the anchor/snapshot/apply core from the Bob-local prototype (`scripts/hash_anchor_edit.py`):
  - `snapshot_text()` → `list[LineAnchor]` with context-triple blake2s digests + ordinals for duplicate disambiguation
  - `apply_operations()` → atomic resolve-all-then-apply with `expected` guard
  - Operations: `replace`, `delete`, `insert_before`, `insert_after`
  - `LineAnchor` / `EditOperation` dataclasses
- **`tests/test_tools__anchored.py`** — 20 tests ported and extended from the prototype suite (unrelated insertions, duplicate-line disambiguation, adjacent-change invalidation, expected guard, insert/delete/replace ops, trailing newline preservation)

No user-facing tool surface yet — this is pure library code behind a private module name. Gate G2 (the actual `view_anchored` + `patch_anchored` tools behind a config flag) is the next PR.

## Design note

Full integration design: `knowledge/technical-designs/2026-05-31-hash-anchored-editing-gptme-integration.md` (Bob workspace)

Ref: gptme/gptme#2667