### PR TITLE
fix(cli): bare model name without provider gives misleading error

### DIFF
--- a/gptme/init.py
+++ b/gptme/init.py
@@ -180,8 +180,26 @@ def init_model(
             model_name = "/".join(
                 model_meta.model.split("/")[1:]
             )  # Strip provider prefix
-        else:
+        elif model in PROVIDERS:
+            # Bare builtin provider name (e.g. "anthropic"): use its
+            # recommended model below via get_recommended_model().
             provider, model_name = cast(tuple[Provider, str], (model, None))
+        else:
+            # Not a provider at all - treat as a bare model name and resolve it
+            # via get_model() (e.g. "gpt-4o" -> openai/gpt-4o). Previously this
+            # blindly cast the model name to a provider, then crashed in
+            # get_recommended_model() with the misleading "Provider 'X' requires
+            # specifying a model" message. Mirrors the slash-path handling above.
+            resolved = get_model(model)
+            if resolved.provider == "unknown":
+                raise ValueError(
+                    f"Unknown model {model!r}. Use 'provider/model' with a known "
+                    f"provider (e.g. 'openai/{model}'), or configure a custom "
+                    f"provider. Run 'gptme-util models list' to see available models."
+                )
+            provider = resolved.provider
+            model_name = resolved.model
+            _resolved_meta = resolved  # reuse below; avoids a redundant second lookup
 
     # set up API_KEY and API_BASE, needs to be done before loading history to avoid saving API_KEY
     if model_name is None:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -639,6 +639,83 @@ class TestInitModelParsing:
     @patch("gptme.init.set_default_model")
     @patch("gptme.init.get_model")
     @patch("gptme.init.init_llm")
+    @patch("gptme.init.get_recommended_model")
+    @patch("gptme.init.is_custom_provider", return_value=False)
+    @patch("gptme.init.get_config")
+    @patch("gptme.init.console")
+    def test_bare_model_name_without_slash_resolved_via_get_model(
+        self,
+        mock_console,
+        mock_config_fn,
+        mock_custom,
+        mock_recommend,
+        mock_init_llm,
+        mock_get_model,
+        mock_set_default,
+        dummy_model_meta,
+    ):
+        """A bare model name without a slash (e.g. 'gpt-4o') that get_model()
+        resolves should be treated as a model, not a provider. Regression test:
+        the no-slash path previously cast the whole string to a provider and
+        crashed in get_recommended_model() with the misleading
+        'Provider X requires specifying a model' message."""
+        from gptme.init import init_model
+
+        mock_config_fn.return_value = MagicMock(
+            chat=MagicMock(model=None), get_env=MagicMock(return_value=None)
+        )
+        mock_get_model.return_value = ModelMeta(
+            provider="openai",
+            model="gpt-4o",
+            context=128_000,
+        )
+
+        init_model(model="gpt-4o")
+
+        # Provider resolved from get_model, model_name already known so the
+        # recommended-model fallback is never reached.
+        mock_init_llm.assert_called_once_with("openai")
+        mock_recommend.assert_not_called()
+
+    @patch("gptme.init.set_default_model")
+    @patch("gptme.init.get_model")
+    @patch("gptme.init.init_llm")
+    @patch("gptme.init.get_recommended_model")
+    @patch("gptme.init.is_custom_provider", return_value=False)
+    @patch("gptme.init.get_config")
+    @patch("gptme.init.console")
+    def test_bare_unknown_model_without_slash_raises_clear_error(
+        self,
+        mock_console,
+        mock_config_fn,
+        mock_custom,
+        mock_recommend,
+        mock_init_llm,
+        mock_get_model,
+        mock_set_default,
+        dummy_model_meta,
+    ):
+        """A bare unresolvable model name (get_model falls back to
+        provider='unknown') should raise the clear 'Unknown model' error, not
+        the misleading 'provider requires a model' crash. This is the no-slash
+        sibling of test_unresolvable_model_raises_clear_error."""
+        from gptme.init import init_model
+
+        mock_config_fn.return_value = MagicMock(
+            chat=MagicMock(model=None), get_env=MagicMock(return_value=None)
+        )
+        mock_get_model.return_value = ModelMeta(
+            provider="unknown",
+            model="claude-sonnet",
+            context=128_000,
+        )
+
+        with pytest.raises(ValueError, match="Unknown model"):
+            init_model(model="claude-sonnet")
+
+    @patch("gptme.init.set_default_model")
+    @patch("gptme.init.get_model")
+    @patch("gptme.init.init_llm")
     @patch("gptme.init.get_recommended_model", return_value="gemini-pro")
     @patch("gptme.init.is_custom_provider", return_value=False)
     @patch("gptme.init.get_config")


### PR DESCRIPTION
## Problem

`gptme -m gpt-4o` — a real OpenAI model, just without the `openai/` prefix — crashes:

```
ERROR    Fatal error occurred
ERROR    Provider 'gpt-4o' requires specifying a model, e.g. gptme -m gpt-4o/your-model-name
```

That message is misleading: `gpt-4o` is a model, not a provider. The user did nothing structurally wrong; the prefix is just optional sugar that `get_model()` can resolve. Same for any bare model name (`gptme -m gpt-5`, etc.).

## Root cause

`init_model()` already had a fix for the **slash** path (`a/b`): an unrecognized provider prefix is delegated to `get_model()`, and a genuinely unknown model raises a clean `Unknown model ...` error. But the **no-slash** path never got the equivalent treatment — it blindly cast any non-custom-provider string to a `Provider`, then crashed in `get_recommended_model()` with the misleading message.

## Fix

Distinguish three no-slash cases:
- **custom provider** → resolve default model (unchanged)
- **builtin provider name** (e.g. `anthropic`) → use its recommended model (unchanged)
- **bare model name** → resolve via `get_model()`; raise the clean actionable `Unknown model` error if it can't be resolved

This mirrors the existing slash-path handling, so both paths now behave consistently.

### Before / after

| input | before | after |
|-------|--------|-------|
| `gpt-4o` | crash: "Provider 'gpt-4o' requires specifying a model" | resolves to `openai/gpt-4o` |
| `claude-sonnet` (typo) | crash: "Provider 'claude-sonnet' requires specifying a model" | clean: "Unknown model 'claude-sonnet'. Use 'provider/model'..." |

## Tests

Two regression tests (no-slash siblings of the existing slash-path tests):
- `test_bare_model_name_without_slash_resolved_via_get_model` — `gpt-4o` → openai, recommended-model fallback never hit
- `test_bare_unknown_model_without_slash_raises_clear_error` — unresolvable bare name raises the clean error

All 82 `tests/test_init.py` tests pass; ruff clean.

Found via a dogfooding sweep of the gptme CLI surface.