### PR TITLE
feat(cost_tracker): add extras dict and record_extra() to SessionCosts

### DIFF
--- a/gptme/util/cost_tracker.py
+++ b/gptme/util/cost_tracker.py
@@ -6,8 +6,11 @@ enabling cost awareness during sessions and eval framework integration.
 See Issue #935 for design context.
 """
 
+from __future__ import annotations
+
 from contextvars import ContextVar
 from dataclasses import dataclass, field
+from typing import Any
 
 
 @dataclass
@@ -40,7 +43,7 @@ class CostSummary:
     request_count: int
 
     @classmethod
-    def from_dict(cls, data: dict) -> "CostSummary":
+    def from_dict(cls, data: dict) -> CostSummary:
         """Create CostSummary from dictionary."""
         return cls(
             session_id=data.get("session_id", ""),
@@ -73,6 +76,18 @@ class SessionCosts:
 
     session_id: str
     entries: list[CostEntry] = field(default_factory=list)
+    # Plugin-provided annotations keyed by plugin name.
+    # Each key maps to a list of dicts recorded via record_extra().
+    extras: dict[str, list[dict[str, Any]]] = field(default_factory=dict)
+
+    def record_extra(self, key: str, **kwargs: Any) -> None:
+        """Store plugin-level annotations alongside cost data.
+
+        Args:
+            key: Plugin identifier (e.g. "headroom_compressor").
+            **kwargs: Arbitrary key-value pairs to store.
+        """
+        self.extras.setdefault(key, []).append(kwargs)
 
     @property
     def total_cost(self) -> float:

--- a/tests/test_cost_tracker.py
+++ b/tests/test_cost_tracker.py
@@ -137,6 +137,8 @@ class TestSessionCosts:
         session.record_extra("plugin_b", value=2)
 
         assert set(session.extras.keys()) == {"plugin_a", "plugin_b"}
+        assert session.extras["plugin_a"] == [{"value": 1}]
+        assert session.extras["plugin_b"] == [{"value": 2}]
 
 
 class TestCostTracker:

--- a/tests/test_cost_tracker.py
+++ b/tests/test_cost_tracker.py
@@ -112,6 +112,32 @@ class TestSessionCosts:
         expected = 800 / (200 + 800 + 200)
         assert abs(session.cache_hit_rate - expected) < 0.0001
 
+    def test_record_extra_accumulates(self):
+        """Test that record_extra accumulates plugin annotations."""
+        session = SessionCosts(session_id="test-session")
+        assert session.extras == {}
+
+        session.record_extra(
+            "headroom_compressor", compressed_count=3, chars_saved=5000
+        )
+        session.record_extra(
+            "headroom_compressor", compressed_count=1, chars_saved=1200
+        )
+
+        assert "headroom_compressor" in session.extras
+        entries = session.extras["headroom_compressor"]
+        assert len(entries) == 2
+        assert entries[0] == {"compressed_count": 3, "chars_saved": 5000}
+        assert entries[1] == {"compressed_count": 1, "chars_saved": 1200}
+
+    def test_record_extra_multiple_keys(self):
+        """Different plugin keys are stored independently."""
+        session = SessionCosts(session_id="test-session")
+        session.record_extra("plugin_a", value=1)
+        session.record_extra("plugin_b", value=2)
+
+        assert set(session.extras.keys()) == {"plugin_a", "plugin_b"}
+
 
 class TestCostTracker:
     """Tests for CostTracker context-safe tracking."""


### PR DESCRIPTION
## Summary

- Add `extras: dict[str, list[dict[str, Any]]]` field to `SessionCosts` for plugin-level annotations
- Add `record_extra(key, **kwargs)` method to store structured plugin metrics alongside LLM cost data
- Add 2 tests covering single-key accumulation and multi-key isolation

## Motivation

The `gptme-headroom-compressor` plugin (gptme-contrib #1049, now merged) needs to record compression stats (count of messages compressed, chars saved) in the session cost tracker. The plugin was already written with `tracker.record_extra(...)` calls, but `SessionCosts` didn't have that method — they were silently swallowed by `except Exception`.

This PR adds the missing API so the compressor (and any future plugin) can annotate session costs without requiring gptme internals access.

## Usage

```python
tracker = CostTracker.get_session_costs()
if tracker is not None:
    tracker.record_extra(
        "headroom_compressor",
        compressed_count=3,
        chars_saved=5000,
    )
# Later:
print(tracker.extras["headroom_compressor"])
# [{"compressed_count": 3, "chars_saved": 5000}]
```

## Test plan

- [x] `test_record_extra_accumulates` — multiple calls to same key stack up
- [x] `test_record_extra_multiple_keys` — different keys are stored independently
- [x] All 93 existing cost tests pass unchanged