### PR TITLE
fix(cli): promote no-tool auto-reply logging from info to warning level

### DIFF
--- a/gptme/tools/complete.py
+++ b/gptme/tools/complete.py
@@ -144,14 +144,14 @@ def auto_reply_hook(
 
     # Exit after 2 consecutive auto-replies without tools
     if auto_reply_count >= 2:
-        logger.info("Autonomous mode: No tools used after 2 confirmations. Exiting.")
+        logger.warning("Autonomous mode: No tools used after 2 confirmations. Exiting.")
         raise SessionCompleteException("No tools used after 2 auto-reply confirmations")
 
     # First time - inject auto-reply
     # Check for incomplete todos - if present, remind about them instead of asking about completion
     if has_incomplete_todos():
         incomplete_summary = get_incomplete_todos_summary()
-        logger.info(
+        logger.warning(
             "Auto-reply: Assistant had no tools but has incomplete todos. Reminding to continue..."
         )
         yield Message(
@@ -160,7 +160,7 @@ def auto_reply_hook(
             quiet=False,
         )
     else:
-        logger.info(
+        logger.warning(
             "Auto-reply: Assistant message had no tools. Asking for confirmation..."
         )
         yield Message(


### PR DESCRIPTION
Promotes the three auto-reply log points in `auto_reply_hook` from `logger.info` to `logger.warning` so they're visible in health checks, vitals, and log-scraping tools.

This is the quick fix for the actionable item from Erik in gptme/gptme#2725: logging the no-tool-use re-prompt at WARNING level so it can be detected by Bob's vitals/health checks automatically, without per-session log archaeology.

The three affected lines:
1. The first auto-reply (no incomplete todos) — most common case in interactive mode
2. The first auto-reply with incomplete todos — common in autonomous mode  
3. The exit-after-2-confirmations message — signals a wasted autonomous session

All 53 existing tests pass unchanged.