### PR TITLE
fix(config): validate temperature/top_p/max_tokens types in ChatConfig.from_dict

### DIFF
--- a/gptme/config/chat.py
+++ b/gptme/config/chat.py
@@ -123,6 +123,20 @@ class ChatConfig:
             raise ValueError("mcp must be an object")
         mcp = MCPConfig.from_dict(mcp_data) if mcp_data is not None else None
 
+        # Type-validate numeric fields so wrong-type values raise ValueError here
+        # (at the API boundary) instead of silently storing bad types that crash later.
+        for field_name in ("temperature", "top_p"):
+            val = chat_data.get(field_name)
+            if val is not None and not isinstance(val, (int, float)):
+                raise ValueError(
+                    f"chat.{field_name} must be a number, got {type(val).__name__}"
+                )
+        max_tokens_val = chat_data.get("max_tokens")
+        if max_tokens_val is not None and not isinstance(max_tokens_val, int):
+            raise ValueError(
+                f"chat.max_tokens must be an integer, got {type(max_tokens_val).__name__}"
+            )
+
         # Check for unknown keys
         if config_data:
             logger.warning(f"Unknown keys in chat config: {config_data.keys()}")

--- a/gptme/config/chat.py
+++ b/gptme/config/chat.py
@@ -127,7 +127,7 @@ class ChatConfig:
         # (at the API boundary) instead of silently storing bad types that crash later.
         for field_name in ("temperature", "top_p"):
             val = chat_data.get(field_name)
-            if val is not None and not isinstance(val, (int, float)):
+            if val is not None and not isinstance(val, int | float):
                 raise ValueError(
                     f"chat.{field_name} must be a number, got {type(val).__name__}"
                 )

--- a/gptme/config/chat.py
+++ b/gptme/config/chat.py
@@ -132,7 +132,9 @@ class ChatConfig:
                     f"chat.{field_name} must be a number, got {type(val).__name__}"
                 )
         max_tokens_val = chat_data.get("max_tokens")
-        if max_tokens_val is not None and not isinstance(max_tokens_val, int):
+        if max_tokens_val is not None and (
+            not isinstance(max_tokens_val, int) or isinstance(max_tokens_val, bool)
+        ):
             raise ValueError(
                 f"chat.max_tokens must be an integer, got {type(max_tokens_val).__name__}"
             )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -586,9 +586,11 @@ def test_chat_config_numeric_fields_reject_wrong_types():
         ChatConfig.from_dict({"chat": {"top_p": "high"}})
     with pytest.raises(ValueError, match="max_tokens"):
         ChatConfig.from_dict({"chat": {"max_tokens": "a lot"}})
-    # booleans are a subtype of int — accept them (edge case)
-    cfg = ChatConfig.from_dict({"chat": {"max_tokens": True}})
-    assert cfg.max_tokens is True
+    # booleans are a subtype of int but semantically wrong for max_tokens (0 or 1 token)
+    with pytest.raises(ValueError, match="max_tokens"):
+        ChatConfig.from_dict({"chat": {"max_tokens": True}})
+    with pytest.raises(ValueError, match="max_tokens"):
+        ChatConfig.from_dict({"chat": {"max_tokens": False}})
 
 
 def test_project_config_loaded_from_toml():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -578,6 +578,19 @@ def test_chat_config_temperature_top_p_roundtrip():
     assert config_new.top_p == 0.9
 
 
+def test_chat_config_numeric_fields_reject_wrong_types():
+    """temperature, top_p, and max_tokens raise ValueError for non-numeric input."""
+    with pytest.raises(ValueError, match="temperature"):
+        ChatConfig.from_dict({"chat": {"temperature": "banana"}})
+    with pytest.raises(ValueError, match="top_p"):
+        ChatConfig.from_dict({"chat": {"top_p": "high"}})
+    with pytest.raises(ValueError, match="max_tokens"):
+        ChatConfig.from_dict({"chat": {"max_tokens": "a lot"}})
+    # booleans are a subtype of int — accept them (edge case)
+    cfg = ChatConfig.from_dict({"chat": {"max_tokens": True}})
+    assert cfg.max_tokens is True
+
+
 def test_project_config_loaded_from_toml():
     config = ProjectConfig.from_dict(tomlkit.loads(project_config_toml).unwrap())
 


### PR DESCRIPTION
## Summary

- `ChatConfig.from_dict` now raises `ValueError` for wrong-type values on `temperature`, `top_p`, and `max_tokens`
- Previously these fields accepted any value (Python dataclasses don't type-check), so `temperature="banana"` was silently stored and caused a 500 at generation time when passed to the LLM API
- Now raises `ValueError` which the server converts to a clean 400 at the API boundary

## What was wrong

```python
# Before: silently accepted
cfg = ChatConfig.from_dict({"chat": {"temperature": "banana"}})
# cfg.temperature == "banana" → crash at LLM call time (500)

# After: rejected at the boundary
# ValueError: chat.temperature must be a number, got str → 400
```

## Range validation

Numeric range checks (`temperature < 0`, `temperature > 1` for Anthropic, etc.) are intentionally left to the LLM client layer — valid ranges are provider-dependent and already validated there.

## Test plan

- [x] `test_chat_config_numeric_fields_reject_wrong_types` — new regression test for string values on all three fields
- [x] All 59 existing `tests/test_config.py` tests still pass (including the existing temperature/top_p/max_tokens roundtrip tests)

Discovered via bad-input dogfood sweep of new ChatConfig surfaces (post-2026-05-28).