### PR TITLE
fix(server): return JSON instead of HTML for HTTP errors (404, 405, etc.)

### DIFF
--- a/gptme/server/app.py
+++ b/gptme/server/app.py
@@ -183,6 +183,18 @@ def create_app(
                 return app.send_static_file(path)
             return app.send_static_file("index.html")
 
+    # Register JSON error handlers so all API errors return JSON instead of HTML.
+    # Without these, Flask's default handlers return HTML for 404/405/500 etc.,
+    # which breaks webui clients that expect JSON from every /api/* response.
+    from werkzeug.exceptions import HTTPException  # fmt: skip
+
+    @app.errorhandler(HTTPException)
+    def handle_http_exception(e: HTTPException) -> flask.Response:
+        response = e.get_response()
+        response.data = flask.json.dumps({"error": e.description})
+        response.content_type = "application/json"
+        return response
+
     # Server confirmation hook is now registered via init_hooks(server=True)
     # in server/cli.py
 

--- a/gptme/server/app.py
+++ b/gptme/server/app.py
@@ -176,8 +176,16 @@ def create_app(
         # Router deep-links (/settings, /conversations/xyz, …) work correctly.
         # Actual static assets (JS/CSS/images) are served first because their
         # paths exist in static_folder; only truly unknown paths fall through.
+        # API paths that reach here (unknown routes, bad URL segments) get a
+        # JSON 404 so clients don't receive index.html as an API response.
         @app.route("/<path:path>")
         def spa_fallback(path: str):
+            if path.startswith("api/"):
+                return flask.Response(
+                    response=flask.json.dumps({"error": "Not Found"}),
+                    status=404,
+                    content_type="application/json",
+                )
             asset = static_folder / path
             if asset.is_file():
                 return app.send_static_file(path)
@@ -190,10 +198,11 @@ def create_app(
 
     @app.errorhandler(HTTPException)
     def handle_http_exception(e: HTTPException) -> flask.Response:
-        response = e.get_response()
-        response.data = flask.json.dumps({"error": e.description})
-        response.content_type = "application/json"
-        return response
+        return flask.Response(
+            response=flask.json.dumps({"error": e.description}),
+            status=e.code,
+            content_type="application/json",
+        )
 
     # Server confirmation hook is now registered via init_hooks(server=True)
     # in server/cli.py

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,5 +1,6 @@
 import copy
 import random
+from pathlib import Path
 
 import pytest
 
@@ -527,3 +528,29 @@ def test_http_errors_return_json(client: FlaskClient):
     data = response.get_json()
     assert data is not None
     assert "error" in data
+
+
+def test_spa_fallback_api_returns_json(tmp_path: Path):
+    """In custom-webui mode, unknown api/ paths return JSON 404 (not index.html).
+
+    The spa_fallback catch-all route guards api/ prefixes explicitly so that
+    API clients don't receive index.html when they hit an unknown endpoint.
+    """
+    # Minimal webui build: any directory != static_path triggers is_custom_webui=True
+    (tmp_path / "index.html").write_text("<html></html>")
+
+    from gptme.server.app import create_app  # fmt: skip
+
+    app = create_app(webui_dir=tmp_path)
+    with app.test_client() as c:
+        # api/ path → JSON 404, never index.html
+        response = c.get("/api/v2/this-does-not-exist")
+        assert response.status_code == 404
+        assert response.content_type.startswith("application/json")
+        data = response.get_json()
+        assert data is not None
+        assert "error" in data
+
+        # non-api path → SPA fallback serves index.html
+        response = c.get("/some/deep/link")
+        assert response.status_code == 200

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -524,3 +524,6 @@ def test_http_errors_return_json(client: FlaskClient):
     assert response.content_type.startswith("application/json"), (
         f"Expected JSON, got {response.content_type}: {response.data[:200]}"
     )
+    data = response.get_json()
+    assert data is not None
+    assert "error" in data

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -493,3 +493,34 @@ def test_auth_query_param_still_works(auth_client):
 
     response = client.get(f"/api/v2/conversations?token={token}")
     assert response.status_code == 200
+
+
+def test_http_errors_return_json(client: FlaskClient):
+    """HTTP errors from Flask (404, 405) must return JSON, not HTML.
+
+    Without registered error handlers, Flask returns HTML error pages for routing
+    errors. The webui expects JSON from all /api/* responses, so HTML breaks client
+    error handling.
+    """
+    # 404: nonexistent API route
+    response = client.get("/api/v2/this-does-not-exist")
+    assert response.status_code == 404
+    assert response.content_type.startswith("application/json")
+    data = response.get_json()
+    assert data is not None
+    assert "error" in data
+
+    # 405: valid route but wrong HTTP method
+    response = client.post("/api/v2/models")
+    assert response.status_code == 405
+    assert response.content_type.startswith("application/json")
+    data = response.get_json()
+    assert data is not None
+    assert "error" in data
+
+    # 404: invalid message index type (-1 doesn't match <int:index> pattern)
+    response = client.delete("/api/v2/conversations/any-conv/messages/-1")
+    assert response.status_code in (404, 405)
+    assert response.content_type.startswith("application/json"), (
+        f"Expected JSON, got {response.content_type}: {response.data[:200]}"
+    )


### PR DESCRIPTION
## Problem

Flask's default error handlers return HTML pages for routing errors (404 route not found, 405 method not allowed). The gptme server API had no error handlers registered, so these errors returned `Content-Type: text/html` instead of JSON.

This breaks webui clients that expect JSON from every `/api/*` response: the `fetch()` call succeeds (non-network error), but `response.json()` throws a parse error.

**Reproduction (before this fix):**
```bash
gptme-server serve --port 5700
curl -sI -X POST http://localhost:5700/api/v2/models
# Content-Type: text/html; charset=utf-8  ← wrong
```

**After this fix:**
```bash
curl -s -X POST http://localhost:5700/api/v2/models
# {"error": "The method is not allowed for the requested URL."}
# Content-Type: application/json
```

The issue also affects URL pattern mismatches. Flask's `<int:index>` converter only matches non-negative integers, so `DELETE /api/v2/conversations/{id}/messages/-1` (a valid-looking but out-of-range request) previously returned an HTML 404 page.

## Fix

Register a single `HTTPException` catchall handler in `create_app()` that rewrites all HTTP error responses as JSON `{"error": "<description>"}` with the original status code. This covers 404, 405, 400 from Flask routing, and any other werkzeug HTTP exception.

## Test

Added `test_http_errors_return_json` that covers:
- 404 from unknown route
- 405 from wrong method on valid route
- Integer URL pattern mismatch (`-1` index)