### PR TITLE
docs(webui): add comment on structuredClone polyfill limitations

### DIFF
--- a/webui/jest.setup.ts
+++ b/webui/jest.setup.ts
@@ -1,6 +1,9 @@
 import '@testing-library/jest-dom';
 
 // Polyfill structuredClone for jsdom — Node 17+ has it but jsdom doesn't expose it.
+// Limitation: JSON.parse/JSON.stringify drops undefined properties, coerces Date to
+// string, throws on BigInt, and silently converts Map/Set to {}. Safe for the current
+// JSON-compatible conversation objects; revisit if tests start using those types.
 if (typeof structuredClone === 'undefined') {
   global.structuredClone = <T>(val: T): T => JSON.parse(JSON.stringify(val));
 }


### PR DESCRIPTION
Follow-up to #2690: address Greptile's feedback about documenting the
`JSON.parse/JSON.stringify` polyfill's trade-offs.

The polyfill silently loses `undefined` properties, coerces `Date` to
strings, throws on `BigInt`, and converts `Map`/`Set` to `{}`. This is
safe for the current JSON-compatible conversation objects, but the comment
makes the limitation explicit for the next person extending the test suite.

Refs: #2690