### PR TITLE
fix(webui): restore direct-link fallbacks for admin and health

### DIFF
--- a/.github/workflows/webui.yml
+++ b/.github/workflows/webui.yml
@@ -61,6 +61,8 @@ jobs:
       name: chat-gptme-org
       url: https://chat.gptme.org
     steps:
+    - uses: actions/checkout@v6
+
     - name: Download dist artifact
       uses: actions/download-artifact@v6
       with:
@@ -73,6 +75,13 @@ jobs:
         apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         command: pages deploy dist --project-name=gptme-webui
+
+    - name: Smoke test deployed deep links
+      working-directory: .
+      run: |
+        python3 scripts/verify_cloudflare_pages_deep_links.py \
+          --redirects-path dist/_redirects \
+          --base-url https://chat.gptme.org
 
   e2e:
     runs-on: ubuntu-latest

--- a/scripts/verify_cloudflare_pages_deep_links.py
+++ b/scripts/verify_cloudflare_pages_deep_links.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+
+def load_spa_redirect_sources(redirects_path: Path) -> list[str]:
+    sources: list[str] = []
+    for raw_line in redirects_path.read_text().splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        source, destination, status = line.split()
+        if destination == "/" and status == "200":
+            sources.append(source)
+    if not sources:
+        raise ValueError(f"no SPA redirect rules found in {redirects_path}")
+    return sources
+
+
+def probe_path_for_redirect_source(source: str) -> str:
+    if source.endswith("/*"):
+        return f"{source[:-1]}deep-link-smoke"
+    if "*" in source:
+        return source.replace("*", "deep-link-smoke")
+    return source
+
+
+def verify_deep_links(base_url: str, redirects_path: Path, timeout: float) -> list[str]:
+    failures: list[str] = []
+    sources = load_spa_redirect_sources(redirects_path)
+    probe_paths = sorted({probe_path_for_redirect_source(source) for source in sources})
+    normalized_base = base_url.rstrip("/")
+
+    for probe_path in probe_paths:
+        url = f"{normalized_base}{probe_path}"
+        request = Request(
+            url,
+            headers={"User-Agent": "gptme-webui-deep-link-smoke/1.0"},
+        )
+        try:
+            with urlopen(request, timeout=timeout) as response:
+                status = response.getcode()
+                content_type = response.headers.get("Content-Type", "")
+        except HTTPError as exc:
+            failures.append(f"{probe_path}: HTTP {exc.code}")
+            continue
+        except URLError as exc:
+            failures.append(f"{probe_path}: {exc.reason}")
+            continue
+
+        if status != 200 or "text/html" not in content_type.lower():
+            failures.append(
+                f"{probe_path}: expected 200 text/html, got {status} {content_type!r}"
+            )
+
+    return failures
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Verify that deployed Cloudflare Pages SPA deep links work."
+    )
+    parser.add_argument(
+        "--redirects-path",
+        type=Path,
+        required=True,
+        help="Path to the deployed _redirects file to derive probe routes from.",
+    )
+    parser.add_argument(
+        "--base-url",
+        default="https://chat.gptme.org",
+        help="Base URL to probe. Defaults to the production hosted webui.",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=20.0,
+        help="Per-request timeout in seconds.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    failures = verify_deep_links(args.base_url, args.redirects_path, args.timeout)
+    if failures:
+        for failure in failures:
+            print(f"FAIL {failure}", file=sys.stderr)
+        return 1
+
+    sources = load_spa_redirect_sources(args.redirects_path)
+    probe_paths = sorted({probe_path_for_redirect_source(source) for source in sources})
+    print(f"Verified {len(probe_paths)} deep links against {args.base_url}")
+    for probe_path in probe_paths:
+        print(f"OK   {probe_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_webui_redirects.py
+++ b/tests/test_webui_redirects.py
@@ -1,7 +1,16 @@
+import importlib.util
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 REDIRECTS_PATH = ROOT / "webui" / "public" / "_redirects"
+VERIFY_SCRIPT_PATH = ROOT / "scripts" / "verify_cloudflare_pages_deep_links.py"
+
+_VERIFY_SPEC = importlib.util.spec_from_file_location(
+    "verify_cloudflare_pages_deep_links", VERIFY_SCRIPT_PATH
+)
+assert _VERIFY_SPEC and _VERIFY_SPEC.loader
+verify_cloudflare_pages_deep_links = importlib.util.module_from_spec(_VERIFY_SPEC)
+_VERIFY_SPEC.loader.exec_module(verify_cloudflare_pages_deep_links)
 
 
 def _load_redirect_rules() -> set[tuple[str, str, str]]:
@@ -30,6 +39,8 @@ def test_webui_cloudflare_pages_redirects_cover_spa_deep_links():
         ("/workspaces", "/", "200"),
         ("/history", "/", "200"),
         ("/external-sessions", "/", "200"),
+        ("/admin", "/", "200"),
+        ("/health", "/", "200"),
         ("/workspace/*", "/", "200"),
     }
     missing = expected_rules - rules
@@ -44,4 +55,21 @@ def test_webui_redirects_do_not_swallow_unknown_api_paths():
     assert ("/*", "/", "200") not in rules
     assert all(not source.startswith("/api") for source, _, _ in rules), (
         "API routes should fall through to the hosted 404 page"
+    )
+
+
+def test_probe_path_for_redirect_source_generates_concrete_deep_links():
+    assert (
+        verify_cloudflare_pages_deep_links.probe_path_for_redirect_source("/chat/*")
+        == "/chat/deep-link-smoke"
+    )
+    assert (
+        verify_cloudflare_pages_deep_links.probe_path_for_redirect_source(
+            "/workspace/*"
+        )
+        == "/workspace/deep-link-smoke"
+    )
+    assert (
+        verify_cloudflare_pages_deep_links.probe_path_for_redirect_source("/admin")
+        == "/admin"
     )

--- a/webui/public/_redirects
+++ b/webui/public/_redirects
@@ -12,4 +12,6 @@
 /workspaces / 200
 /history / 200
 /external-sessions / 200
+/admin / 200
+/health / 200
 /workspace/* / 200

--- a/webui/src/App.tsx
+++ b/webui/src/App.tsx
@@ -12,6 +12,7 @@ import { CommandPalette } from './components/CommandPalette';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { ShortcutsDialog } from './components/ShortcutsDialog';
 import { SetupWizard } from './components/SetupWizard';
+import { appRoutes } from './appRoutes';
 
 // Lazy-loaded route pages — code-split at route boundaries for smaller initial bundle
 const Index = lazy(() => import('./pages/Index'));
@@ -78,18 +79,18 @@ const App: FC = () => {
                   <ErrorBoundary>
                     <Suspense fallback={<RouteLoader />}>
                       <Routes>
-                        <Route path="/" element={<Index />} />
-                        <Route path="/chat" element={<Index />} />
-                        <Route path="/chat/:id" element={<Index />} />
-                        <Route path="/tasks" element={<Tasks />} />
-                        <Route path="/tasks/:id" element={<Tasks />} />
-                        <Route path="/agents" element={<Agents />} />
-                        <Route path="/workspaces" element={<Workspaces />} />
-                        <Route path="/history" element={<History />} />
-                        <Route path="/external-sessions" element={<ExternalSessions />} />
-                        <Route path="/admin" element={<Admin />} />
-                        <Route path="/health" element={<Health />} />
-                        <Route path="/workspace/:id" element={<Workspace />} />
+                        <Route path={appRoutes.root} element={<Index />} />
+                        <Route path={appRoutes.chat} element={<Index />} />
+                        <Route path={appRoutes.chatConversation} element={<Index />} />
+                        <Route path={appRoutes.tasks} element={<Tasks />} />
+                        <Route path={appRoutes.taskDetails} element={<Tasks />} />
+                        <Route path={appRoutes.agents} element={<Agents />} />
+                        <Route path={appRoutes.workspaces} element={<Workspaces />} />
+                        <Route path={appRoutes.history} element={<History />} />
+                        <Route path={appRoutes.externalSessions} element={<ExternalSessions />} />
+                        <Route path={appRoutes.admin} element={<Admin />} />
+                        <Route path={appRoutes.health} element={<Health />} />
+                        <Route path={appRoutes.workspace} element={<Workspace />} />
                         <Route path="*" element={<NotFound />} />
                       </Routes>
                     </Suspense>

--- a/webui/src/appRoutes.ts
+++ b/webui/src/appRoutes.ts
@@ -1,0 +1,28 @@
+export const appRoutes = {
+  root: '/',
+  chat: '/chat',
+  chatConversation: '/chat/:id',
+  tasks: '/tasks',
+  taskDetails: '/tasks/:id',
+  agents: '/agents',
+  workspaces: '/workspaces',
+  history: '/history',
+  externalSessions: '/external-sessions',
+  admin: '/admin',
+  health: '/health',
+  workspace: '/workspace/:id',
+} as const;
+
+export const cloudflareSpaRedirectRules = [
+  `${appRoutes.chat} / 200`,
+  `${appRoutes.chat}/* / 200`,
+  `${appRoutes.tasks} / 200`,
+  `${appRoutes.tasks}/* / 200`,
+  `${appRoutes.agents} / 200`,
+  `${appRoutes.workspaces} / 200`,
+  `${appRoutes.history} / 200`,
+  `${appRoutes.externalSessions} / 200`,
+  `${appRoutes.admin} / 200`,
+  `${appRoutes.health} / 200`,
+  '/workspace/* / 200',
+] as const;

--- a/webui/src/appRoutes.ts
+++ b/webui/src/appRoutes.ts
@@ -24,5 +24,5 @@ export const cloudflareSpaRedirectRules = [
   `${appRoutes.externalSessions} / 200`,
   `${appRoutes.admin} / 200`,
   `${appRoutes.health} / 200`,
-  '/workspace/* / 200',
+  `${appRoutes.workspace.replace(/\/:[^/]+$/, '/*')} / 200`,
 ] as const;

--- a/webui/src/utils/__tests__/cloudflareRedirects.test.ts
+++ b/webui/src/utils/__tests__/cloudflareRedirects.test.ts
@@ -1,27 +1,17 @@
 import fs from 'fs';
 import path from 'path';
+import { cloudflareSpaRedirectRules } from '@/appRoutes';
 
 describe('Cloudflare Pages redirect rules', () => {
-  it('keeps API paths out of the SPA fallback', () => {
+  it('covers every SPA deep-link route without catching API paths', () => {
     const redirectsPath = path.resolve(__dirname, '../../../public/_redirects');
     const redirects = fs.readFileSync(redirectsPath, 'utf8');
     const rules = redirects
       .split('\n')
       .map((line) => line.trim())
       .filter((line) => line && !line.startsWith('#'));
-    const expectedSpaRules = [
-      '/chat / 200',
-      '/chat/* / 200',
-      '/tasks / 200',
-      '/tasks/* / 200',
-      '/agents / 200',
-      '/workspaces / 200',
-      '/history / 200',
-      '/external-sessions / 200',
-      '/workspace/* / 200',
-    ];
 
-    expect(rules).toEqual(expect.arrayContaining(expectedSpaRules));
+    expect(rules).toEqual(expect.arrayContaining(cloudflareSpaRedirectRules));
     expect(rules.some((rule) => rule.startsWith('/* '))).toBe(false);
     expect(rules.some((rule) => rule.startsWith('/api'))).toBe(false);
   });


### PR DESCRIPTION
## Summary
- add missing Cloudflare Pages SPA fallback rules for `/admin` and `/health`
- keep route paths in a shared manifest so the app and redirect test stop drifting apart
- extend the redirect regression test to cover the full SPA fallback rule set

## Reproduction
- `curl -sS -o /dev/null -w "%{http_code} %{content_type}\n" https://chat.gptme.org/admin` -> `404 text/html; charset=utf-8`
- `curl -sS -o /dev/null -w "%{http_code} %{content_type}\n" https://chat.gptme.org/health` -> `404 text/html; charset=utf-8`
- other SPA routes like `/chat` and `/tasks` already returned `200`, so the hosted `_redirects` file had simply drifted

## Verification
- `npm test -- cloudflareRedirects.test.ts`
- `npm run build`