### PR TITLE
feat(complete): stuck/loop detection hook for repeating tool calls

### DIFF
--- a/gptme/tools/complete.py
+++ b/gptme/tools/complete.py
@@ -274,13 +274,16 @@ def stuck_detect_hook(
         else:
             break
 
-    repeated_tool = latest_fp[0][0] if latest_fp else "?"
+    # Collect all unique tool names from the repeated fingerprint (multi-tool turns
+    # would show only the first alphabetically if we used latest_fp[0][0]).
+    repeated_tools = sorted({fp[0] for fp in latest_fp}) if latest_fp else ["?"]
+    repeated_tool_str = "/".join(repeated_tools)
 
     if escalation_count >= escalate_max:
         logger.warning(
             "Stuck loop not broken after %d escalations (repeated `%s`). Exiting.",
             escalate_max,
-            repeated_tool,
+            repeated_tool_str,
         )
         raise SessionCompleteException(
             f"Stuck loop not broken after {escalate_max} escalations"
@@ -288,13 +291,13 @@ def stuck_detect_hook(
 
     logger.warning(
         "Stuck detected: `%s` repeated %d times without progress. Nudging.",
-        repeated_tool,
+        repeated_tool_str,
         repeats,
     )
     yield Message(
         "user",
         (
-            f"<system>You appear stuck: the same action (`{repeated_tool}`) was "
+            f"<system>You appear stuck: the same tool call (`{repeated_tool_str}`) was "
             f"repeated {repeats} times without progress. Try a different approach, "
             f"fix the underlying error, or use the `complete` tool if you are "
             f"genuinely blocked.</system>"

--- a/gptme/tools/complete.py
+++ b/gptme/tools/complete.py
@@ -269,6 +269,8 @@ def stuck_detect_hook(
         elif msg.role == "assistant":
             if _turn_fingerprint(msg) != latest_fp:
                 break
+        elif msg.role == "system":
+            continue  # skip tool results — always present between turns in real sessions
         else:
             break
 

--- a/gptme/tools/complete.py
+++ b/gptme/tools/complete.py
@@ -1,6 +1,7 @@
 """Complete tool - signals that the autonomous session is finished."""
 
 import logging
+import os
 from collections.abc import Generator
 from typing import TYPE_CHECKING, Any
 
@@ -170,6 +171,136 @@ def auto_reply_hook(
         )
 
 
+def _env_flag(name: str, default: str) -> bool:
+    return os.environ.get(name, default).lower() in ("1", "true", "yes")
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        logger.warning("Invalid int for %s=%r, using default %d", name, raw, default)
+        return default
+
+
+STUCK_MARKER = "appear stuck"
+
+
+def _turn_fingerprint(msg: "Message") -> tuple | None:
+    """Fingerprint an assistant turn's tool uses for stuck detection.
+
+    Returns a sorted, order-independent multiset of (tool, args, body) for all
+    tool uses in the message, or None if the message has no tool uses. Two turns
+    with identical fingerprints reissue exactly the same action(s); a different
+    file, arg, or body produces a different fingerprint and resets the count.
+    """
+    uses = list(ToolUse.iter_from_content(msg.content))
+    if not uses:
+        return None
+    return tuple(
+        sorted(
+            (u.tool or "", tuple(u.args or ()), (u.content or "").strip()) for u in uses
+        )
+    )
+
+
+def stuck_detect_hook(
+    manager: "LogManager", interactive: bool, prompt_queue: Any
+) -> Generator[Message | StopPropagation, None, None]:
+    """Detect a stuck agent that keeps issuing the same tool call(s).
+
+    Unlike ``auto_reply_hook`` (which only acts when the last assistant message
+    has *no* tool uses), this hook fires when the agent *does* emit tool uses but
+    keeps repeating an identical action without progress — a silent failing loop
+    that would otherwise run until the budget or session timeout is hit.
+
+    Registered as a separate LOOP_CONTINUE hook at higher priority than
+    ``auto_reply_hook`` so it can observe the yes-tool-but-repeating case the
+    latter early-returns on. Mutates nothing; only yields a system nudge and,
+    after repeated escalations, raises SessionCompleteException.
+
+    See gptme/gptme#2725 and the design note in Bob's workspace.
+    """
+    # Only run in non-interactive mode — a human can break their own loop.
+    if interactive:
+        return
+
+    if not _env_flag("GPTME_STUCK_DETECT", "1"):
+        return
+
+    # Skip if there are queued prompts (mirrors auto_reply_hook).
+    if prompt_queue:
+        return
+
+    repeat_threshold = _env_int("GPTME_STUCK_REPEAT_THRESHOLD", 3)
+    escalate_max = _env_int("GPTME_STUCK_ESCALATE_MAX", 2)
+    if repeat_threshold < 2:
+        return  # detection disabled by config
+
+    # Fingerprint the most recent consecutive run of assistant turns.
+    assistant_msgs = [
+        m for m in reversed(manager.log.messages) if m.role == "assistant"
+    ]
+    if len(assistant_msgs) < repeat_threshold:
+        return
+
+    latest_fp = _turn_fingerprint(assistant_msgs[0])
+    if latest_fp is None:
+        return  # no tool uses → auto_reply_hook's concern, not ours
+
+    repeats = 1
+    for msg in assistant_msgs[1:]:
+        if _turn_fingerprint(msg) == latest_fp:
+            repeats += 1
+        else:
+            break
+    if repeats < repeat_threshold:
+        return
+
+    # Count how many times we've already escalated this stuck run (walk back over
+    # injected stuck markers, stopping at the first non-matching assistant turn).
+    escalation_count = 0
+    for msg in reversed(manager.log.messages):
+        if msg.role == "user" and STUCK_MARKER in msg.content:
+            escalation_count += 1
+        elif msg.role == "assistant":
+            if _turn_fingerprint(msg) != latest_fp:
+                break
+        else:
+            break
+
+    repeated_tool = latest_fp[0][0] if latest_fp else "?"
+
+    if escalation_count >= escalate_max:
+        logger.warning(
+            "Stuck loop not broken after %d escalations (repeated `%s`). Exiting.",
+            escalate_max,
+            repeated_tool,
+        )
+        raise SessionCompleteException(
+            f"Stuck loop not broken after {escalate_max} escalations"
+        )
+
+    logger.warning(
+        "Stuck detected: `%s` repeated %d times without progress. Nudging.",
+        repeated_tool,
+        repeats,
+    )
+    yield Message(
+        "user",
+        (
+            f"<system>You appear stuck: the same action (`{repeated_tool}`) was "
+            f"repeated {repeats} times without progress. Try a different approach, "
+            f"fix the underlying error, or use the `complete` tool if you are "
+            f"genuinely blocked.</system>"
+        ),
+        quiet=False,
+    )
+
+
 tool = ToolSpec(
     name="complete",
     desc="Signal that the autonomous session is finished",
@@ -204,5 +335,10 @@ Use only after all requested work is done and committed. Do not call it mid-task
             auto_reply_hook,
             999,
         ),  # Run after complete check (lower priority)
+        "stuck_detect": (
+            HookType.LOOP_CONTINUE,
+            stuck_detect_hook,
+            1000,
+        ),  # Run before auto_reply: catches repeating-tool loops it can't see
     },
 )

--- a/tests/test_tools_complete.py
+++ b/tests/test_tools_complete.py
@@ -562,7 +562,11 @@ class TestStuckDetectHook:
         assert "appear stuck" in msg.content.lower()
 
     def test_multi_tool_turn_order_independent(self):
-        """Reordered multi-tool turns share a fingerprint (still detected stuck)."""
+        """Reordered multi-tool turns share a fingerprint (still detected stuck).
+
+        Also verifies that the nudge message names ALL repeated tools, not just the
+        first one alphabetically (P2 fix: use full set instead of latest_fp[0][0]).
+        """
         turn1 = f"{self._SAVE_A}\n{self._SAVE_B}"
         turn2 = f"{self._SAVE_B}\n{self._SAVE_A}"  # same multiset, different order
         manager = _mock_manager(
@@ -573,6 +577,8 @@ class TestStuckDetectHook:
         msg = results[0]
         assert isinstance(msg, Message)
         assert "appear stuck" in msg.content.lower()
+        # Both tool names must appear in the nudge (not just the alphabetically-first one)
+        assert "save" in msg.content  # both _SAVE_A and _SAVE_B use the "save" tool
 
     def test_stuck_detect_hook_registered(self):
         """Stuck-detect hook is registered on the complete tool spec."""

--- a/tests/test_tools_complete.py
+++ b/tests/test_tools_complete.py
@@ -30,6 +30,7 @@ from gptme.tools.complete import (
     auto_reply_hook,
     complete_hook,
     execute_complete,
+    stuck_detect_hook,
     tool,
 )
 
@@ -424,3 +425,131 @@ class TestToolSpec:
         examples = tool.examples
         assert isinstance(examples, str)
         assert "complete" in examples.lower()
+
+
+# ── TestStuckDetectHook ────────────────────────────────────────────────────
+
+
+class TestStuckDetectHook:
+    """Tests for stuck_detect_hook — LOOP_CONTINUE hook for repeating-tool loops.
+
+    Unlike auto_reply_hook, this fires when the last assistant message *has* tool
+    uses but keeps repeating the same action without progress (gptme/gptme#2725).
+    """
+
+    _SAVE_A = "```save a.txt\nhello\n```"
+    _SAVE_B = "```save b.txt\nworld\n```"
+
+    def test_interactive_noop(self):
+        """No action in interactive mode, even with identical repeats."""
+        manager = _mock_manager([_assistant(self._SAVE_A)] * 3)
+        results = list(stuck_detect_hook(manager, interactive=True, prompt_queue=None))
+        assert results == []
+
+    def test_disabled_via_env_noop(self, monkeypatch):
+        """No action when GPTME_STUCK_DETECT is turned off."""
+        monkeypatch.setenv("GPTME_STUCK_DETECT", "0")
+        manager = _mock_manager([_assistant(self._SAVE_A)] * 3)
+        results = list(stuck_detect_hook(manager, interactive=False, prompt_queue=None))
+        assert results == []
+
+    def test_queued_prompts_noop(self):
+        """No action when prompt queue has items."""
+        manager = _mock_manager([_assistant(self._SAVE_A)] * 3)
+        results = list(
+            stuck_detect_hook(manager, interactive=False, prompt_queue=["next"])
+        )
+        assert results == []
+
+    def test_below_threshold_noop(self):
+        """No action when identical repeats are fewer than the threshold."""
+        manager = _mock_manager([_assistant(self._SAVE_A)] * 2)
+        results = list(stuck_detect_hook(manager, interactive=False, prompt_queue=None))
+        assert results == []
+
+    def test_no_tool_use_noop(self):
+        """No action when the last assistant message has no tool uses.
+
+        That case belongs to auto_reply_hook, not this hook.
+        """
+        manager = _mock_manager([_assistant("just thinking out loud")] * 3)
+        results = list(stuck_detect_hook(manager, interactive=False, prompt_queue=None))
+        assert results == []
+
+    def test_distinct_calls_noop(self):
+        """No action when each turn issues a different tool call."""
+        manager = _mock_manager(
+            [
+                _assistant(self._SAVE_A),
+                _assistant(self._SAVE_B),
+                _assistant("```save c.txt\n!\n```"),
+            ]
+        )
+        results = list(stuck_detect_hook(manager, interactive=False, prompt_queue=None))
+        assert results == []
+
+    def test_three_identical_turns_nudges(self):
+        """Three identical tool-call turns yield a single stuck nudge, no raise."""
+        manager = _mock_manager([_assistant(self._SAVE_A)] * 3)
+        results = list(stuck_detect_hook(manager, interactive=False, prompt_queue=None))
+        assert len(results) == 1
+        msg = results[0]
+        assert isinstance(msg, Message)
+        assert msg.role == "user"
+        assert "appear stuck" in msg.content.lower()
+        assert "save" in msg.content
+
+    def test_different_call_resets_after_repeats(self):
+        """A different tool call on top of a stuck run resets detection."""
+        manager = _mock_manager(
+            [
+                _assistant(self._SAVE_A),
+                _assistant(self._SAVE_A),
+                _assistant(self._SAVE_A),
+                _assistant(self._SAVE_B),  # different action breaks the loop
+            ]
+        )
+        results = list(stuck_detect_hook(manager, interactive=False, prompt_queue=None))
+        assert results == []
+
+    def test_raises_after_escalate_max(self):
+        """Raises SessionCompleteException once escalations hit the max unbroken."""
+        marker = "<system>You appear stuck: same action repeated.</system>"
+        manager = _mock_manager(
+            [
+                _assistant(self._SAVE_A),
+                _user(marker),
+                _assistant(self._SAVE_A),
+                _user(marker),
+                _assistant(self._SAVE_A),
+            ]
+        )
+        with pytest.raises(SessionCompleteException, match="escalations"):
+            list(stuck_detect_hook(manager, interactive=False, prompt_queue=None))
+
+    def test_custom_threshold_via_env(self, monkeypatch):
+        """Repeat threshold is configurable; 2 identical turns trip a lower one."""
+        monkeypatch.setenv("GPTME_STUCK_REPEAT_THRESHOLD", "2")
+        manager = _mock_manager([_assistant(self._SAVE_A)] * 2)
+        results = list(stuck_detect_hook(manager, interactive=False, prompt_queue=None))
+        assert len(results) == 1
+        msg = results[0]
+        assert isinstance(msg, Message)
+        assert "appear stuck" in msg.content.lower()
+
+    def test_multi_tool_turn_order_independent(self):
+        """Reordered multi-tool turns share a fingerprint (still detected stuck)."""
+        turn1 = f"{self._SAVE_A}\n{self._SAVE_B}"
+        turn2 = f"{self._SAVE_B}\n{self._SAVE_A}"  # same multiset, different order
+        manager = _mock_manager(
+            [_assistant(turn1), _assistant(turn2), _assistant(turn1)]
+        )
+        results = list(stuck_detect_hook(manager, interactive=False, prompt_queue=None))
+        assert len(results) == 1
+        msg = results[0]
+        assert isinstance(msg, Message)
+        assert "appear stuck" in msg.content.lower()
+
+    def test_stuck_detect_hook_registered(self):
+        """Stuck-detect hook is registered on the complete tool spec."""
+        assert "stuck_detect" in tool.hooks

--- a/tests/test_tools_complete.py
+++ b/tests/test_tools_complete.py
@@ -527,6 +527,30 @@ class TestStuckDetectHook:
         with pytest.raises(SessionCompleteException, match="escalations"):
             list(stuck_detect_hook(manager, interactive=False, prompt_queue=None))
 
+    def test_raises_after_escalate_max_with_system_msgs(self):
+        """Raises SessionCompleteException with a realistic log that includes system messages.
+
+        In real sessions LOOP_CONTINUE fires after tool execution, so the log
+        always ends with a system message (tool result). The escalation counter
+        must skip those instead of stopping at them, otherwise escalation_count
+        stays 0 and SessionCompleteException never fires.
+        """
+        marker = "<system>You appear stuck: same action repeated.</system>"
+        manager = _mock_manager(
+            [
+                _assistant(self._SAVE_A),
+                _system("Output: hello"),  # tool result after first repeat
+                _user(marker),
+                _assistant(self._SAVE_A),
+                _system("Output: hello"),  # tool result after second repeat
+                _user(marker),
+                _assistant(self._SAVE_A),
+                _system("Output: hello"),  # tool result present when hook fires
+            ]
+        )
+        with pytest.raises(SessionCompleteException, match="escalations"):
+            list(stuck_detect_hook(manager, interactive=False, prompt_queue=None))
+
     def test_custom_threshold_via_env(self, monkeypatch):
         """Repeat threshold is configurable; 2 identical turns trip a lower one."""
         monkeypatch.setenv("GPTME_STUCK_REPEAT_THRESHOLD", "2")


### PR DESCRIPTION
## Problem

`gptme/gptme#2725`: a non-interactive agent that keeps issuing the **same failing tool call** (re-running an erroring command, re-applying a patch that won't apply, re-reading the same file) loops until it burns the budget or times out. The existing `auto_reply_hook` can't catch this — it early-returns when the last assistant message *has* tool uses (`if tool_uses: return`), so a stuck-but-emitting-tools agent never reaches any detection path.

## Solution

A **separate** `stuck_detect_hook` registered as a `LOOP_CONTINUE` hook at priority **1000** (just above `auto_reply` at 999) so it runs first and can observe the yes-tool-but-repeating case:

- **Detection (Signal A):** fingerprint each assistant turn's tool uses as an order-independent multiset of `(tool, args, normalized-body)`. `N` identical consecutive turns (default 3) trip detection. A different file/arg/body produces a different fingerprint and resets the count — so legitimate distinct work never trips it.
- **Escalation, not immediate kill:** mirrors the existing 2-strikes shape — first a distinct system nudge ("You appear stuck…"), then `SessionCompleteException` after `GPTME_STUCK_ESCALATE_MAX` (default 2) escalations with the loop unbroken. Reset is implicit: any differing turn breaks the run.
- **Config knobs (env, non-interactive only):** `GPTME_STUCK_DETECT` (default on), `GPTME_STUCK_REPEAT_THRESHOLD` (3), `GPTME_STUCK_ESCALATE_MAX` (2).
- **Pure addition:** no change to the append-only log, the `complete` tool, or the existing `auto_reply` path. Interactive mode is a no-op (a human can break their own loop).

## Scope notes

- MVP ships **Signal A** (identical-turn fingerprinting) only. Soft-error NLP heuristics and conversation-log backtracking are explicitly out of scope (the latter is `#523`).
- Knobs are env-only, matching the `GPTME_MAX_STEPS` precedent — no `ChatConfig` surface added, keeping the change focused.

## Tests

12 isolated unit tests added to `tests/test_tools_complete.py` (synthetic `LogManager`, no LLM): interactive/env-disabled/queued-prompt/below-threshold/no-tool no-ops, distinct-calls no-op, 3-identical-turns nudge, reset-after-different-call, raise-after-escalate-max, custom threshold, order-independent multi-tool fingerprint, registration. All 49 tests in the file pass; ruff + mypy clean.