### PR TITLE
fix(webui): add baseline security headers to Cloudflare Pages _headers

### DIFF
--- a/webui/public/_headers
+++ b/webui/public/_headers
@@ -7,8 +7,22 @@
 # fallback. Short cache + long stale-while-revalidate lets deploys roll the
 # cache forward while visitors still see fresh content quickly. The more
 # specific `/assets/*` rule below takes precedence for hashed assets.
+#
+# Security headers are declared here so the posture is owned by the repo and
+# auditable, rather than depending on invisible Cloudflare zone defaults:
+#   - X-Frame-Options: clickjacking protection. SAMEORIGIN, not DENY, because
+#     nothing cross-origin legitimately frames chat.gptme.org (Tauri uses a
+#     top-level webview, not an iframe, so it is unaffected).
+#   - Strict-Transport-Security: the site is HTTPS-only; pin it. No `preload`
+#     and no `includeSubDomains` to stay conservative for the gptme.org parent.
+#   - X-Content-Type-Options / Referrer-Policy: pinned explicitly so they
+#     survive zone-config changes.
 /*
   Cache-Control: public, max-age=300, stale-while-revalidate=86400
+  X-Frame-Options: SAMEORIGIN
+  Strict-Transport-Security: max-age=31536000
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin-when-cross-origin
 
 # Hashed assets are immutable by construction (filename includes content hash),
 # so we can drop revalidation entirely and let the browser keep the cached copy.

--- a/webui/src/utils/__tests__/cloudflareRedirects.test.ts
+++ b/webui/src/utils/__tests__/cloudflareRedirects.test.ts
@@ -32,4 +32,22 @@ describe('Cloudflare Pages redirect rules', () => {
 
     expect(notFoundPage).toContain('<h1>404 Not Found</h1>');
   });
+
+  it('declares baseline security headers on the SPA shell', () => {
+    const headersPath = path.resolve(__dirname, '../../../public/_headers');
+    const headers = fs.readFileSync(headersPath, 'utf8');
+    const lines = headers
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line && !line.startsWith('#'));
+
+    expect(lines).toEqual(
+      expect.arrayContaining([
+        'X-Frame-Options: SAMEORIGIN',
+        'Strict-Transport-Security: max-age=31536000',
+        'X-Content-Type-Options: nosniff',
+        'Referrer-Policy: strict-origin-when-cross-origin',
+      ])
+    );
+  });
 });

--- a/webui/src/utils/__tests__/cloudflareRedirects.test.ts
+++ b/webui/src/utils/__tests__/cloudflareRedirects.test.ts
@@ -35,13 +35,28 @@ describe('Cloudflare Pages redirect rules', () => {
 
   it('declares baseline security headers on the SPA shell', () => {
     const headersPath = path.resolve(__dirname, '../../../public/_headers');
-    const headers = fs.readFileSync(headersPath, 'utf8');
-    const lines = headers
-      .split('\n')
-      .map((line) => line.trim())
-      .filter((line) => line && !line.startsWith('#'));
+    const content = fs.readFileSync(headersPath, 'utf8');
 
-    expect(lines).toEqual(
+    // Parse _headers into sections: non-indented lines are path rules (section
+    // headers); indented lines are header values scoped to the preceding rule.
+    const sections: Record<string, string[]> = {};
+    let currentSection = '';
+    for (const line of content.split('\n')) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith('#')) continue;
+      if (!/^\s/.test(line)) {
+        currentSection = trimmed;
+        sections[currentSection] = [];
+      } else if (currentSection) {
+        sections[currentSection].push(trimmed);
+      }
+    }
+
+    // Security headers must live under the `/*` wildcard rule so the SPA shell
+    // is actually protected. A header that only appears under `/assets/*` or
+    // any other more-specific rule would leave the shell unprotected.
+    const spaHeaders = sections['/*'] ?? [];
+    expect(spaHeaders).toEqual(
       expect.arrayContaining([
         'X-Frame-Options: SAMEORIGIN',
         'Strict-Transport-Security: max-age=31536000',


### PR DESCRIPTION
## Summary
Found while dogfooding the live hosted webui at chat.gptme.org as a real user. The deploy serves **no `X-Frame-Options`** and **no `Strict-Transport-Security`** header, so the SPA can be framed cross-origin (clickjacking) and the HTTPS-only site isn't pinned via HSTS.

## Live reproduction (before)
```
$ curl -sSI https://chat.gptme.org/ | grep -iE 'x-frame|strict-transport|content-security'
(no output)
```
Only `x-content-type-options: nosniff` and `referrer-policy` were served (from Cloudflare zone defaults, not the repo).

## Change
Declares the security posture in the repo's `webui/public/_headers` (`/*` rule) so it's **owned and auditable** instead of depending on invisible zone config:
- `X-Frame-Options: SAMEORIGIN` — clickjacking protection. SAMEORIGIN not DENY: nothing cross-origin legitimately frames chat.gptme.org (gptme.org/gptme.ai only link to it; Tauri uses a top-level webview, not an iframe, so it's unaffected).
- `Strict-Transport-Security: max-age=31536000` — site is HTTPS-only. No `preload`/`includeSubDomains`, to stay conservative for the `gptme.org` parent.
- Pins the already-served `X-Content-Type-Options: nosniff` and `Referrer-Policy` so they survive zone-config changes.

Verified `_headers` is the effective mechanism: the live `cache-control` exactly matches the existing `/*` rule.

## Verification
- `npx jest cloudflareRedirects` — 3 passed (extended the existing `_redirects`/`404.html` regression test with a security-headers assertion)
- pre-commit (eslint + tsc) green

Distinct from #2742 (which adds `/admin`+`/health` SPA fallback to `_redirects`).