### PR TITLE
fix(webui): keep demo mode out of setup probes

### DIFF
--- a/webui/src/components/SetupWizard.tsx
+++ b/webui/src/components/SetupWizard.tsx
@@ -20,7 +20,7 @@ import {
 } from '@/utils/apiKeyProviders';
 import { fetchProviderConfigured } from '@/utils/providerStatus';
 import { isTauriEnvironment, invokeTauri } from '@/utils/tauri';
-import { processConnectionFromHash } from '@/utils/connectionConfig';
+import { isDemoMode, processConnectionFromHash } from '@/utils/connectionConfig';
 import {
   bumpProviderStatusVersion,
   setupWizard$,
@@ -87,6 +87,7 @@ export function SetupWizard() {
   const { settings, updateSettings } = useSettings();
   const { api, isConnected$, connect, connectionConfig } = useApi();
   const isConnected = use$(isConnected$);
+  const demoMode = isDemoMode();
   const [step, setStep] = useState<SetupStep>('welcome');
   // isOpen is a one-time snapshot of hasCompletedSetup taken at mount. It is intentionally
   // NOT derived from settings on subsequent renders — the wizard manages its own visibility
@@ -95,7 +96,7 @@ export function SetupWizard() {
   // Also avoids React batching issues: completeSetup() + setStep('complete') update two separate
   // state atoms in the same event handler; a derived signal would close the dialog before the
   // 'complete' step could render.
-  const [isOpen, setIsOpen] = useState(!settings.hasCompletedSetup);
+  const [isOpen, setIsOpen] = useState(!demoMode && !settings.hasCompletedSetup);
   const [isConnecting, setIsConnecting] = useState(false);
   const [connectError, setConnectError] = useState<string | null>(null);
   const [cloudLoginStarted, setCloudLoginStarted] = useState(false);
@@ -296,7 +297,10 @@ export function SetupWizard() {
   }, [checkProviderAndAdvance, connectionConfig.baseUrl, isConnected, isOpen, step]);
 
   useEffect(() => {
-    if (!externalOpen) {
+    if (!externalOpen || demoMode) {
+      if (demoMode && externalOpen) {
+        setupWizard$.open.set(false);
+      }
       return;
     }
 
@@ -307,7 +311,7 @@ export function SetupWizard() {
     setStep(externalStep);
     setIsOpen(true);
     setupWizard$.open.set(false);
-  }, [externalOpen, externalStep]);
+  }, [demoMode, externalOpen, externalStep]);
 
   useEffect(() => {
     if (!cloudLoginStarted || step !== 'cloud' || isConnected) {

--- a/webui/src/components/WelcomeView.tsx
+++ b/webui/src/components/WelcomeView.tsx
@@ -24,6 +24,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { withLocalAddressSpace } from '@/utils/addressSpace';
 import { isLikelyChromeCorsPna } from '@/utils/api';
+import { isDemoMode } from '@/utils/connectionConfig';
 import { chatRoute } from '@/utils/routes';
 
 const DEFAULT_LOCAL_SERVER_URLS = new Set(['http://127.0.0.1:5700', 'http://localhost:5700']);
@@ -48,6 +49,7 @@ export const WelcomeView = () => {
   const [providerConfigured, setProviderConfigured] = useState<boolean | null>(null);
   const navigate = useNavigate();
   const { api, isConnected$, connectionConfig, switchServer, connect } = useApi();
+  const demoMode = isDemoMode();
   const queryClient = useQueryClient();
   const isConnected = use$(isConnected$);
   const lastConnectionResult = use$(api.lastConnectionResult$);
@@ -176,7 +178,7 @@ export const WelcomeView = () => {
   // settings path. Users on a custom server have already chosen their setup, so
   // their disconnected banner is left unchanged.
   const isFirstVisit = !settings.hasCompletedSetup;
-  const showGuidedSetup = isDefaultLocalServer && isFirstVisit;
+  const showGuidedSetup = isDefaultLocalServer && isFirstVisit && !demoMode;
 
   // Classify the last connection failure into actionable buckets for targeted guidance.
   const errorBucket = (() => {
@@ -189,7 +191,13 @@ export const WelcomeView = () => {
     errorBucket === 'unknown' && isDefaultLocalServer && isHostedOrigin && hostedLoopbackReachable;
 
   useEffect(() => {
-    if (isConnected || !isDefaultLocalServer || !isHostedOrigin || errorBucket !== 'unknown') {
+    if (
+      demoMode ||
+      isConnected ||
+      !isDefaultLocalServer ||
+      !isHostedOrigin ||
+      errorBucket !== 'unknown'
+    ) {
       setHostedLoopbackReachable(false);
       return;
     }
@@ -238,6 +246,7 @@ export const WelcomeView = () => {
   }, [
     activeServerBaseUrl,
     connect,
+    demoMode,
     errorBucket,
     isConnected,
     isDefaultLocalServer,

--- a/webui/src/components/__tests__/SetupWizard.test.tsx
+++ b/webui/src/components/__tests__/SetupWizard.test.tsx
@@ -10,6 +10,7 @@ const mockOpen = jest.fn();
 const mockFetch = jest.fn();
 const mockInvokeTauri = jest.fn();
 const mockProcessConnectionFromHash = jest.fn();
+const mockIsDemoMode = jest.fn(() => false);
 const isConnected$ = observable(false);
 const mockIsTauriEnvironment = jest.fn(() => false);
 const CLOUD_AUTH_BASE_URL = process.env['VITE_GPTME_CLOUD_BASE_URL'] || 'https://gptme.ai';
@@ -64,7 +65,7 @@ jest.mock('@/hooks/useTauriServerStatus', () => ({
 
 jest.mock('@/utils/connectionConfig', () => ({
   processConnectionFromHash: (...args: unknown[]) => mockProcessConnectionFromHash(...args),
-  isDemoMode: jest.fn(() => false),
+  isDemoMode: () => mockIsDemoMode(),
 }));
 
 jest.mock('@legendapp/state/react', () => ({
@@ -153,6 +154,7 @@ describe('SetupWizard', () => {
     mockFetch.mockReset();
     mockInvokeTauri.mockReset();
     mockProcessConnectionFromHash.mockReset();
+    mockIsDemoMode.mockReturnValue(false);
     mockFetch.mockResolvedValue({
       ok: true,
       status: 200,
@@ -177,6 +179,19 @@ describe('SetupWizard', () => {
       writable: true,
       value: mockOpen,
     });
+  });
+
+  it('stays closed in demo mode even for first-time users', () => {
+    mockIsDemoMode.mockReturnValue(true);
+
+    render(
+      <SettingsProvider>
+        <SetupWizard />
+      </SettingsProvider>
+    );
+
+    expect(screen.queryByRole('heading', { name: /welcome to gptme/i })).not.toBeInTheDocument();
+    expect(mockFetch).not.toHaveBeenCalled();
   });
 
   it('closes the wizard via Skip on the welcome step and persists hasCompletedSetup', async () => {

--- a/webui/src/components/__tests__/WelcomeView.test.tsx
+++ b/webui/src/components/__tests__/WelcomeView.test.tsx
@@ -10,6 +10,7 @@ const mockNavigate = jest.fn();
 const mockInvalidateQueries = jest.fn();
 const mockConnect = jest.fn();
 const mockFetch = jest.fn();
+const mockIsDemoMode = jest.fn(() => false);
 const isConnected$ = observable(true);
 const lastConnectionResult$ = observable<null | {
   ok: false;
@@ -37,6 +38,10 @@ const setLocation = (href: string) => {
 
 jest.mock('@/utils/api', () => ({
   isLikelyChromeCorsPna: (...args: unknown[]) => mockIsLikelyChromeCorsPna(...args),
+}));
+
+jest.mock('@/utils/connectionConfig', () => ({
+  isDemoMode: () => mockIsDemoMode(),
 }));
 
 jest.mock('react-router-dom', () => {
@@ -110,12 +115,29 @@ describe('WelcomeView', () => {
     mockNavigate.mockClear();
     mockInvalidateQueries.mockClear();
     mockFetch.mockReset();
+    mockIsDemoMode.mockReturnValue(false);
     mockIsLikelyChromeCorsPna.mockReturnValue(false);
     mockFetch.mockImplementation(() => new Promise(() => {}));
     Object.defineProperty(window, 'fetch', {
       writable: true,
       value: mockFetch,
     });
+  });
+
+  it('does not show first-run setup CTA or probe localhost in demo mode', () => {
+    setLocation('https://chat.gptme.org/?demo=1');
+    isConnected$.set(false);
+    mockIsDemoMode.mockReturnValue(true);
+
+    render(
+      <SettingsProvider>
+        <WelcomeView />
+      </SettingsProvider>
+    );
+
+    expect(screen.queryByRole('button', { name: /get started/i })).not.toBeInTheDocument();
+    expect(screen.queryByText(/The setup guide walks you through/i)).not.toBeInTheDocument();
+    expect(mockFetch).not.toHaveBeenCalled();
   });
 
   it('renders the refreshed new chat copy and quick suggestions', () => {

--- a/webui/src/main.tsx
+++ b/webui/src/main.tsx
@@ -2,6 +2,7 @@ import './polyfills';
 import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
 import './index.css';
+import { isDemoMode } from './utils/connectionConfig';
 import { setupLogging } from './utils/logging';
 
 // Initialize logging as early as possible
@@ -18,7 +19,7 @@ setupLogging()
 // See: gptme/gptme#2236
 (function probeLocalhost() {
   // Only probe in Tauri desktop app; skip in regular browsers
-  if (typeof window === 'undefined' || !window.__TAURI__) {
+  if (typeof window === 'undefined' || !window.__TAURI__ || isDemoMode()) {
     return;
   }
 


### PR DESCRIPTION
## Summary

- keep `?demo=1` out of the first-run setup wizard so shared demo URLs open directly
- suppress hosted loopback probes from `WelcomeView` while demo mode is active
- skip the Tauri localhost permission probe in demo mode
- add regression coverage for setup wizard suppression and hosted-loopback probe suppression

## Verification

- `npm test -- --runTestsByPath src/components/__tests__/SetupWizard.test.tsx src/components/__tests__/WelcomeView.test.tsx --runInBand` (38/38)
- `npm run typecheck`
- `npx prettier --check src/components/SetupWizard.tsx src/components/WelcomeView.tsx src/main.tsx src/components/__tests__/SetupWizard.test.tsx src/components/__tests__/WelcomeView.test.tsx`
- `git diff --check`
- Firefox smoke against local Vite `http://127.0.0.1:5721/?demo=1`: setup heading count 0, Get Started count 0, no requests to loopback `:5700`, `/api/v2/tasks`, `/api/v2/models`, or `demo://offline`
