### PR TITLE
fix(reduce): drop orphaned tool results in limit_log when tool-use is dropped

### DIFF
--- a/gptme/util/reduce.py
+++ b/gptme/util/reduce.py
@@ -292,6 +292,16 @@ def limit_log(log: list[Message]) -> list[Message]:
         idx = log_by_id.get(id(msg))
         if idx is None or idx == 0:
             return False
-        return id(log[idx - 1]) not in result_id_set
+        # Walk backward through the original log to find the nearest
+        # non-system anchor message. System messages are tool results;
+        # their anchor is the assistant (or user) message that produced
+        # them. If that anchor was dropped by the context limit, this
+        # result is orphaned.
+        for j in range(idx - 1, -1, -1):
+            if log[j].role != "system":
+                return id(log[j]) not in result_id_set
+        # No non-system predecessor found — shouldn't happen for a
+        # non-initial system message, but treat as not orphaned.
+        return False
 
     return [m for m in result if not _is_orphaned(m)]

--- a/gptme/util/reduce.py
+++ b/gptme/util/reduce.py
@@ -275,4 +275,23 @@ def limit_log(log: list[Message]) -> list[Message]:
         # skip the last message
         msgs.pop()
 
-    return initial_system_msgs + list(reversed(msgs))
+    result = initial_system_msgs + list(reversed(msgs))
+
+    # Ensure tool_use/tool_result atomicity: if a non-initial system message's
+    # immediate predecessor in the original log was dropped by the context limit,
+    # drop the system message too. System messages that follow a dropped message
+    # are almost certainly orphaned tool results — keeping them without their
+    # tool-use anchor produces an incoherent log.
+    result_id_set = {id(m) for m in result}
+    log_by_id = {id(m): i for i, m in enumerate(log)}
+    initial_id_set = {id(m) for m in initial_system_msgs}
+
+    def _is_orphaned(msg: Message) -> bool:
+        if msg.role != "system" or id(msg) in initial_id_set:
+            return False
+        idx = log_by_id.get(id(msg))
+        if idx is None or idx == 0:
+            return False
+        return id(log[idx - 1]) not in result_id_set
+
+    return [m for m in result if not _is_orphaned(m)]

--- a/tests/test_reduce.py
+++ b/tests/test_reduce.py
@@ -279,25 +279,88 @@ def test_limit_log_tool_pair_atomicity():
     tool result with no preceding call. limit_log should drop it rather than
     return an incoherent log.
     """
-    # Context=10: fits system prompt (2 tok) + tool result (1 tok) but not the
-    # assistant tool-use (13 tok) on top of that.
-    tiny_model = ModelMeta(provider="unknown", model="gpt-4", context=10)
-    set_default_model(tiny_model)
+    from gptme.llm.models.resolution import _default_model_var
 
-    # assistant message with a shell tool call (13 tokens)
-    tool_use_content = "I will run a command.\n```shell\necho hello\n```"
-    msgs = [
-        Message("system", "system prompt"),  # 2 tok — initial system msg
-        Message("assistant", tool_use_content),  # 13 tok — tool use
-        Message("system", "hello"),  # 1 tok — tool result
-    ]
+    # Save and restore default model to avoid ContextVar contamination.
+    original_model = _default_model_var.get()
+    try:
+        # Context=10: fits system prompt (2 tok) + tool result (1 tok) but not the
+        # assistant tool-use (13 tok) on top of that.
+        tiny_model = ModelMeta(provider="unknown", model="gpt-4", context=10)
+        set_default_model(tiny_model)
 
-    result = limit_log(msgs)
+        # assistant message with a shell tool call (13 tokens)
+        tool_use_content = "I will run a command.\n```shell\necho hello\n```"
+        msgs = [
+            Message("system", "system prompt"),  # 2 tok — initial system msg
+            Message("assistant", tool_use_content),  # 13 tok — tool use
+            Message("system", "hello"),  # 1 tok — tool result
+        ]
 
-    # The orphaned tool result ("hello") must not appear without its tool use.
-    result_contents = [m.content for m in result]
-    assert "hello" not in result_contents, (
-        "Orphaned tool result should be dropped when its tool-use was not included"
-    )
-    # The initial system prompt must always be kept.
-    assert any(m.content == "system prompt" for m in result)
+        result = limit_log(msgs)
+
+        # The orphaned tool result ("hello") must not appear without its tool use.
+        result_contents = [m.content for m in result]
+        assert "hello" not in result_contents, (
+            "Orphaned tool result should be dropped when its tool-use was not included"
+        )
+        # The initial system prompt must always be kept.
+        assert any(m.content == "system prompt" for m in result)
+    finally:
+        set_default_model(original_model) if original_model else _default_model_var.set(
+            None
+        )
+
+
+def test_limit_log_cascading_orphans():
+    """limit_log drops ALL tool results when their shared anchor is dropped.
+
+    When break_on_tooluse=False causes multiple consecutive system messages
+    (tool results) after a single assistant message that gets dropped by the
+    context limit, ALL of them should be orphaned — not just the first one
+    whose immediate predecessor is the dropped assistant.
+
+    Regression: before the anchor-walking fix in limit_log, only the first
+    orphaned result was caught; the remaining tool results had their immediate
+    predecessor (another system message) present in the result set and survived
+    the filter.
+    """
+    from gptme.llm.models.resolution import _default_model_var
+
+    original_model = _default_model_var.get()
+    try:
+        # Context=12: fits system prompt (2 tok) + both tool results (1+1 tok)
+        # but not the assistant tool-use (~20 tok) on top of that.
+        tiny_model = ModelMeta(provider="unknown", model="gpt-4", context=12)
+        set_default_model(tiny_model)
+
+        # Assistant message with two tool calls (simulating break_on_tooluse=False)
+        tool_use_content = (
+            "I will run two commands.\n"
+            "```shell\necho hello\n```\n"
+            "```shell\necho world\n```"
+        )
+        msgs = [
+            Message("system", "system prompt"),  # 2 tok — initial system msg
+            Message("assistant", tool_use_content),  # ~20 tok — tool use (both)
+            Message("system", "hello"),  # 1 tok — first tool result
+            Message("system", "world"),  # 1 tok — second tool result
+        ]
+
+        result = limit_log(msgs)
+
+        # Neither orphaned tool result should survive.
+        result_contents = [m.content for m in result]
+        assert "hello" not in result_contents, (
+            "First orphaned tool result should be dropped"
+        )
+        assert "world" not in result_contents, (
+            "Second orphaned tool result should be dropped (regression: "
+            "immediate-predecessor check missed cascading orphans)"
+        )
+        # The initial system prompt must always be kept.
+        assert any(m.content == "system prompt" for m in result)
+    finally:
+        set_default_model(original_model) if original_model else _default_model_var.set(
+            None
+        )

--- a/tests/test_reduce.py
+++ b/tests/test_reduce.py
@@ -2,8 +2,15 @@ from pathlib import Path
 
 import pytest
 
+from gptme.llm.models.resolution import set_default_model
+from gptme.llm.models.types import ModelMeta
 from gptme.message import Message, len_tokens
-from gptme.util.reduce import _truncate_details_blocks, reduce_log, truncate_msg
+from gptme.util.reduce import (
+    _truncate_details_blocks,
+    limit_log,
+    reduce_log,
+    truncate_msg,
+)
 
 # Project root
 root = Path(__file__).parent.parent
@@ -262,3 +269,35 @@ def test_reduce_log():
 
     assert len_pre > len_post
     assert len_post < limit
+
+
+def test_limit_log_tool_pair_atomicity():
+    """limit_log should drop orphaned tool results instead of splitting pairs.
+
+    When the context limit causes the assistant tool-use message to be dropped
+    but the subsequent system tool-result message fits, the result is an orphaned
+    tool result with no preceding call. limit_log should drop it rather than
+    return an incoherent log.
+    """
+    # Context=10: fits system prompt (2 tok) + tool result (1 tok) but not the
+    # assistant tool-use (13 tok) on top of that.
+    tiny_model = ModelMeta(provider="unknown", model="gpt-4", context=10)
+    set_default_model(tiny_model)
+
+    # assistant message with a shell tool call (13 tokens)
+    tool_use_content = "I will run a command.\n```shell\necho hello\n```"
+    msgs = [
+        Message("system", "system prompt"),  # 2 tok — initial system msg
+        Message("assistant", tool_use_content),  # 13 tok — tool use
+        Message("system", "hello"),  # 1 tok — tool result
+    ]
+
+    result = limit_log(msgs)
+
+    # The orphaned tool result ("hello") must not appear without its tool use.
+    result_contents = [m.content for m in result]
+    assert "hello" not in result_contents, (
+        "Orphaned tool result should be dropped when its tool-use was not included"
+    )
+    # The initial system prompt must always be kept.
+    assert any(m.content == "system prompt" for m in result)


### PR DESCRIPTION
## Problem

`limit_log` cuts messages newest-to-oldest until context is full. When a `system` message (tool result) fits but its preceding `assistant` message (tool use) does not, the tool result becomes an orphan — it appears in the log without the tool call that generated it. This produces an incoherent conversation state that can confuse the model or cause downstream parsing issues.

The companion function `reduce_log` already guards against this via `message_contains_tool_use`, but `limit_log` (the final hard cut in `prepare_messages`) had no such guard.

## Fix

After building the `result` list, a post-processing pass drops any non-initial `system` message whose immediate predecessor in the original log was dropped. Uses object identity (`id()`) to match messages since `limit_log` picks objects directly from the input list without copying.

```python
def _is_orphaned(msg: Message) -> bool:
    if msg.role != "system" or id(msg) in initial_id_set:
        return False
    idx = log_by_id.get(id(msg))
    if idx is None or idx == 0:
        return False
    return id(log[idx - 1]) not in result_id_set
```

## Test

Added `test_limit_log_tool_pair_atomicity` in `tests/test_reduce.py`:
- Sets up a 3-message log: system prompt (2 tok) + assistant tool-use (13 tok) + system tool-result (1 tok)
- Uses a tiny 10-token context model so the tool-use is dropped but the tool-result would otherwise fit
- Asserts the orphaned tool-result is dropped from the output

All 13 non-slow reduce tests pass.