### PR TITLE
fix(eval): normalize model key in pass-rate gate to handle router prefixes

### DIFF
--- a/gptme/eval/pass_rate_gate.py
+++ b/gptme/eval/pass_rate_gate.py
@@ -81,7 +81,7 @@ def _normalize_model_key(model: str, lookup: dict) -> str:
     Tries an exact match first, then retries after stripping known router
     prefixes (e.g. ``openrouter/anthropic/X`` → ``anthropic/X``). This
     handles the case where gate data was collected via the direct API but
-    evals are executed via an OpenRouter backend, or vice versa.
+    evals are executed via an OpenRouter backend.
     """
     if model in lookup:
         return model

--- a/gptme/eval/pass_rate_gate.py
+++ b/gptme/eval/pass_rate_gate.py
@@ -72,6 +72,32 @@ def load_pass_rate_data(path: Path | str | None = None) -> dict | None:
     return data
 
 
+_ROUTER_PREFIXES = ("openrouter/",)
+
+
+def _normalize_model_key(model: str, lookup: dict) -> str:
+    """Return the best matching key for *model* in *lookup*.
+
+    Tries an exact match first, then retries after stripping known router
+    prefixes (e.g. ``openrouter/anthropic/X`` → ``anthropic/X``). This
+    handles the case where gate data was collected via the direct API but
+    evals are executed via an OpenRouter backend, or vice versa.
+    """
+    if model in lookup:
+        return model
+    for prefix in _ROUTER_PREFIXES:
+        if model.startswith(prefix):
+            candidate = model[len(prefix) :]
+            if candidate in lookup:
+                logger.debug(
+                    "Pass-rate gate: matched '%s' via normalized key '%s'",
+                    model,
+                    candidate,
+                )
+                return candidate
+    return model  # return original; lookup miss handled by caller
+
+
 def get_gate_recommendation(
     model: str,
     eval_name: str,
@@ -81,11 +107,15 @@ def get_gate_recommendation(
 
     Returns ``"default"`` when no data is loaded or the pair is not present —
     callers should treat that as "no override; use existing logic".
+
+    Normalizes the model key by stripping known router prefixes when an exact
+    match is absent (e.g. ``openrouter/anthropic/X`` → ``anthropic/X``).
     """
     if not data:
         return "default"
     lookup = data.get("lookup", {})
-    rec = lookup.get(model, {}).get(eval_name, {}).get("gate_recommendation")
+    key = _normalize_model_key(model, lookup)
+    rec = lookup.get(key, {}).get(eval_name, {}).get("gate_recommendation")
     if rec in ("inject", "suppress"):
         return rec  # type: ignore[return-value]
     return "default"

--- a/tests/test_eval_pass_rate_gate.py
+++ b/tests/test_eval_pass_rate_gate.py
@@ -163,3 +163,36 @@ def test_apply_gate_unknown_pair_passes_through(sample_data):
 def test_invalid_gate_value_treated_as_default(sample_data):
     sample_data["lookup"]["m1"]["e1"]["gate_recommendation"] = "weird"
     assert get_gate_recommendation("m1", "e1", sample_data) == "default"
+
+
+def test_get_gate_recommendation_openrouter_prefix_fallback(sample_data):
+    """Gate data collected via direct API should still apply when eval runs via OpenRouter."""
+    # Gate file has "m1" but eval passes "openrouter/m1"
+    assert get_gate_recommendation("openrouter/m1", "e1", sample_data) == "inject"
+    assert get_gate_recommendation("openrouter/m1", "e2", sample_data) == "suppress"
+    assert get_gate_recommendation("openrouter/m1", "e3", sample_data) == "default"
+
+
+def test_get_gate_recommendation_openrouter_prefix_exact_match_wins():
+    """Exact match takes priority over prefix-stripped fallback."""
+    data = {
+        "lookup": {
+            "openrouter/m1": {
+                "e1": {"gate_recommendation": "suppress"},
+            },
+            "m1": {
+                "e1": {"gate_recommendation": "inject"},
+            },
+        }
+    }
+    # Exact match "openrouter/m1" → suppress (not the fallback "m1" → inject)
+    assert get_gate_recommendation("openrouter/m1", "e1", data) == "suppress"
+
+
+def test_apply_gate_openrouter_prefix_fallback(sample_data):
+    """apply_gate resolves inject/suppress via normalized model key."""
+    eff, decision = apply_gate(
+        model="openrouter/m1", eval_name="e1", no_lessons=True, data=sample_data
+    )
+    assert eff is False
+    assert decision == "inject"

--- a/tests/test_eval_pass_rate_gate.py
+++ b/tests/test_eval_pass_rate_gate.py
@@ -196,3 +196,16 @@ def test_apply_gate_openrouter_prefix_fallback(sample_data):
     )
     assert eff is False
     assert decision == "inject"
+
+
+def test_get_gate_recommendation_openrouter_prefix_no_match(sample_data):
+    """When prefix is stripped but the base key is also absent, returns default."""
+    # "openrouter/unknown" has the prefix, but "unknown" is not in the lookup either
+    assert get_gate_recommendation("openrouter/unknown", "e1", sample_data) == "default"
+
+
+def test_get_gate_recommendation_empty_lookup():
+    """Empty lookup always returns default without errors."""
+    data: dict = {"lookup": {}}
+    assert get_gate_recommendation("openrouter/m1", "e1", data) == "default"
+    assert get_gate_recommendation("m1", "e1", data) == "default"


### PR DESCRIPTION
## Problem

The natural pass-rate gate lookup (`pass_rate_gate.get_gate_recommendation`) does an exact model-key match. When gate data was collected via the direct Anthropic API (key: `anthropic/claude-haiku-4-5`) but the eval runner uses OpenRouter (key: `openrouter/anthropic/claude-haiku-4-5`), the lookup silently falls back to `"default"` — bypassing all inject/suppress decisions.

This caused a real incident: `bob-eval-behavioral.service` was configured with `GPTME_EVAL_PASS_RATE_GATE_FILE` but the gate was never applied to haiku evals because of this prefix mismatch. Sonnet evals were unaffected (both gate data and runs used the `openrouter/` prefix consistently).

## Fix

Add `_normalize_model_key()` that strips known router prefixes (`openrouter/`) on a fallback lookup when the exact key is absent. Exact match still takes priority, so gate files that use the full `openrouter/`-prefixed key continue to work correctly.

## Tests

Added 3 new tests to `test_eval_pass_rate_gate.py`:
- `test_get_gate_recommendation_openrouter_prefix_fallback` — verifies inject/suppress/default resolve correctly when key has `openrouter/` prefix
- `test_get_gate_recommendation_openrouter_prefix_exact_match_wins` — verifies exact match takes priority over fallback
- `test_apply_gate_openrouter_prefix_fallback` — end-to-end via `apply_gate()`

All 19 tests pass.