### PR TITLE
feat(extension): add Chrome extension MVP — Slice 1 skeleton

### DIFF
--- a/gptme-extension/.gitignore
+++ b/gptme-extension/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+*.js.map

--- a/gptme-extension/README.md
+++ b/gptme-extension/README.md
@@ -1,0 +1,59 @@
+# gptme Browser Extension
+
+Ask gptme about anything on the web. Select text on any page, open the side panel, and get answers from your local gptme instance.
+
+## Status
+
+MVP Slice 1 — skeleton + side panel shell. Functional chat with streaming responses.
+
+## Requirements
+
+- Chrome 114+ (Side Panel API)
+- A running [gptme server](https://gptme.org/docs/server.html): `gptme server`
+- Node.js (for building from source)
+
+## Quick Start
+
+```bash
+# Install deps and build
+cd gptme-extension
+npm install
+npm run build
+
+# Load in Chrome:
+# 1. Open chrome://extensions
+# 2. Enable "Developer mode" (top right)
+# 3. Click "Load unpacked" → select the dist/ folder
+```
+
+## Usage
+
+1. Click the gptme icon in the Chrome toolbar → side panel opens
+2. Type a question and press Enter
+3. Select text on any page first to add it as context
+
+If the server is offline, you'll see a "Server offline" indicator. Start it with `gptme server`.
+
+## Configuration
+
+Click ⚙ in the side panel or visit the extension options page to set:
+- **Server URL** — default `http://localhost:5700`
+- **API Key** — only needed if you started gptme with `--auth`
+
+## Architecture
+
+See [../../knowledge/technical-designs/gptme-chrome-extension-mvp.md](../../knowledge/technical-designs/gptme-chrome-extension-mvp.md) for the full spec.
+
+| File | Purpose |
+|------|---------|
+| `background.ts` | Service worker: `GptmeClient` + message bus |
+| `sidepanel/panel.ts` | Chat UI, SSE token streaming |
+| `content/content.ts` | Text selection capture |
+| `options/options.ts` | Settings page |
+| `build.sh` | esbuild compile script |
+
+## Roadmap
+
+- **Slice 2** — Conversation history (list + reload prior conversations)
+- **Slice 3** — API key auth + tool call visualization
+- **Slice 4** — gptme.ai remote server support

--- a/gptme-extension/background.ts
+++ b/gptme-extension/background.ts
@@ -40,62 +40,89 @@ class GptmeClient {
   async createConversation(id: string, systemMsg?: string): Promise<void> {
     const body: Record<string, unknown> = {};
     if (systemMsg) body.system = systemMsg;
-    await fetch(`${this.baseUrl}/api/v2/conversations/${id}`, {
+    const resp = await fetch(`${this.baseUrl}/api/v2/conversations/${id}`, {
       method: 'PUT',
       headers: this.headers(),
       body: JSON.stringify(body),
     });
+    if (!resp.ok) throw new Error(`createConversation failed: ${resp.status}`);
   }
 
   async postMessage(convId: string, content: string, role = 'user'): Promise<void> {
-    await fetch(`${this.baseUrl}/api/v2/conversations/${convId}`, {
+    const resp = await fetch(`${this.baseUrl}/api/v2/conversations/${convId}`, {
       method: 'POST',
       headers: this.headers(),
       body: JSON.stringify({ role, content }),
     });
+    if (!resp.ok) throw new Error(`postMessage failed: ${resp.status}`);
   }
 
   async step(convId: string): Promise<void> {
-    await fetch(`${this.baseUrl}/api/v2/conversations/${convId}/step`, {
+    const resp = await fetch(`${this.baseUrl}/api/v2/conversations/${convId}/step`, {
       method: 'POST',
       headers: this.headers(),
     });
+    if (!resp.ok) throw new Error(`step failed: ${resp.status}`);
   }
 
+  // Uses fetch instead of EventSource so the Authorization header can be sent
+  // (EventSource does not support custom headers, which would force the API key
+  // into the URL query string where it appears in server logs).
   subscribeEvents(
     convId: string,
     onToken: (text: string) => void,
     onComplete: () => void,
     onError: (msg: string) => void,
   ): () => void {
-    const url = new URL(`${this.baseUrl}/api/v2/conversations/${convId}/events`);
-    if (this.apiKey) url.searchParams.set('api_key', this.apiKey);
+    const controller = new AbortController();
 
-    const source = new EventSource(url.toString());
-
-    source.onmessage = (event) => {
-      try {
-        const data = JSON.parse(event.data as string) as {
-          type: string;
-          data?: { content?: string };
-        };
-        if (data.type === 'generation_progress' && data.data?.content) {
-          onToken(data.data.content);
-        } else if (data.type === 'generation_complete') {
-          onComplete();
-          source.close();
-        }
-      } catch {
-        // skip non-JSON events
+    fetch(`${this.baseUrl}/api/v2/conversations/${convId}/events`, {
+      headers: { ...this.headers(), Accept: 'text/event-stream' },
+      signal: controller.signal,
+    }).then(async (resp) => {
+      if (!resp.ok || !resp.body) {
+        onError(`SSE request failed: ${resp.status}`);
+        return;
       }
-    };
+      const reader = resp.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
 
-    source.onerror = () => {
-      onError('SSE connection lost');
-      source.close();
-    };
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) {
+          onComplete();
+          break;
+        }
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split('\n');
+        buffer = lines.pop() ?? '';
 
-    return () => source.close();
+        for (const line of lines) {
+          if (!line.startsWith('data: ')) continue;
+          try {
+            const data = JSON.parse(line.slice(6)) as {
+              type: string;
+              data?: { content?: string };
+            };
+            if (data.type === 'generation_progress' && data.data?.content) {
+              onToken(data.data.content);
+            } else if (data.type === 'generation_complete') {
+              onComplete();
+              return;
+            }
+          } catch {
+            // skip non-JSON lines
+          }
+        }
+      }
+    }).catch((err: Error) => {
+      if (err.name !== 'AbortError') {
+        onError('SSE connection lost');
+      }
+    });
+
+    return () => controller.abort();
   }
 }
 
@@ -191,6 +218,9 @@ chrome.runtime.onMessage.addListener(
         sendResponse(data);
         return;
       }
+
+      // Unknown message type — reply immediately so the channel closes
+      sendResponse({ ok: false, error: `Unknown type: ${String(msg.type)}` });
     })();
     return true; // keep channel open for async sendResponse
   },

--- a/gptme-extension/background.ts
+++ b/gptme-extension/background.ts
@@ -1,0 +1,204 @@
+// background.ts — service worker: GptmeClient + message bus
+
+const DEFAULT_SERVER_URL = 'http://localhost:5700';
+
+interface StorageSync {
+  serverUrl?: string;
+  apiKey?: string;
+}
+
+interface StorageSession {
+  lastSelection?: string;
+  lastSelectionUrl?: string;
+  lastSelectionTitle?: string;
+}
+
+class GptmeClient {
+  constructor(
+    private readonly baseUrl: string,
+    private readonly apiKey?: string,
+  ) {}
+
+  private headers(): Record<string, string> {
+    const h: Record<string, string> = { 'Content-Type': 'application/json' };
+    if (this.apiKey) h['Authorization'] = `Bearer ${this.apiKey}`;
+    return h;
+  }
+
+  async ping(): Promise<boolean> {
+    try {
+      const resp = await fetch(`${this.baseUrl}/api/v2/server/health`, {
+        headers: this.headers(),
+        signal: AbortSignal.timeout(3000),
+      });
+      return resp.ok;
+    } catch {
+      return false;
+    }
+  }
+
+  async createConversation(id: string, systemMsg?: string): Promise<void> {
+    const body: Record<string, unknown> = {};
+    if (systemMsg) body.system = systemMsg;
+    await fetch(`${this.baseUrl}/api/v2/conversations/${id}`, {
+      method: 'PUT',
+      headers: this.headers(),
+      body: JSON.stringify(body),
+    });
+  }
+
+  async postMessage(convId: string, content: string, role = 'user'): Promise<void> {
+    await fetch(`${this.baseUrl}/api/v2/conversations/${convId}`, {
+      method: 'POST',
+      headers: this.headers(),
+      body: JSON.stringify({ role, content }),
+    });
+  }
+
+  async step(convId: string): Promise<void> {
+    await fetch(`${this.baseUrl}/api/v2/conversations/${convId}/step`, {
+      method: 'POST',
+      headers: this.headers(),
+    });
+  }
+
+  subscribeEvents(
+    convId: string,
+    onToken: (text: string) => void,
+    onComplete: () => void,
+    onError: (msg: string) => void,
+  ): () => void {
+    const url = new URL(`${this.baseUrl}/api/v2/conversations/${convId}/events`);
+    if (this.apiKey) url.searchParams.set('api_key', this.apiKey);
+
+    const source = new EventSource(url.toString());
+
+    source.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data as string) as {
+          type: string;
+          data?: { content?: string };
+        };
+        if (data.type === 'generation_progress' && data.data?.content) {
+          onToken(data.data.content);
+        } else if (data.type === 'generation_complete') {
+          onComplete();
+          source.close();
+        }
+      } catch {
+        // skip non-JSON events
+      }
+    };
+
+    source.onerror = () => {
+      onError('SSE connection lost');
+      source.close();
+    };
+
+    return () => source.close();
+  }
+}
+
+async function getClient(): Promise<GptmeClient> {
+  const data = (await chrome.storage.sync.get(['serverUrl', 'apiKey'])) as StorageSync;
+  return new GptmeClient(data.serverUrl ?? DEFAULT_SERVER_URL, data.apiKey);
+}
+
+// Active SSE subscriptions keyed by conversationId
+const activeStreams = new Map<string, () => void>();
+
+chrome.runtime.onMessage.addListener(
+  (
+    msg: Record<string, unknown>,
+    _sender: chrome.runtime.MessageSender,
+    sendResponse: (r: unknown) => void,
+  ) => {
+    (async () => {
+      if (msg.type === 'PING') {
+        const cl = await getClient();
+        const ok = await cl.ping();
+        sendResponse({ ok });
+        return;
+      }
+
+      if (msg.type === 'CREATE_CONV') {
+        const cl = await getClient();
+        await cl.createConversation(msg.convId as string, msg.systemMsg as string | undefined);
+        sendResponse({ ok: true });
+        return;
+      }
+
+      if (msg.type === 'SEND_AND_STEP') {
+        const cl = await getClient();
+        const convId = msg.convId as string;
+        await cl.postMessage(convId, msg.content as string);
+        await cl.step(convId);
+        sendResponse({ ok: true });
+
+        // Cancel any existing stream for this conversation
+        activeStreams.get(convId)?.();
+
+        const unsub = cl.subscribeEvents(
+          convId,
+          (token) => {
+            chrome.runtime.sendMessage({ type: 'TOKEN', convId, token }).catch(() => {});
+          },
+          () => {
+            chrome.runtime.sendMessage({ type: 'DONE', convId }).catch(() => {});
+            activeStreams.delete(convId);
+          },
+          (error) => {
+            chrome.runtime.sendMessage({ type: 'ERROR', convId, error }).catch(() => {});
+            activeStreams.delete(convId);
+          },
+        );
+        activeStreams.set(convId, unsub);
+        return;
+      }
+
+      if (msg.type === 'CANCEL') {
+        const convId = msg.convId as string;
+        activeStreams.get(convId)?.();
+        activeStreams.delete(convId);
+        sendResponse({ ok: true });
+        return;
+      }
+
+      if (msg.type === 'SELECTION') {
+        // Store selection for panel retrieval on open
+        await chrome.storage.session.set({
+          lastSelection: msg.selection as string | undefined,
+          lastSelectionUrl: msg.url as string | undefined,
+          lastSelectionTitle: msg.title as string | undefined,
+        } satisfies StorageSession);
+        // Broadcast to open panels
+        chrome.runtime.sendMessage({
+          type: 'SELECTION_UPDATE',
+          selection: msg.selection,
+          url: msg.url,
+          title: msg.title,
+        }).catch(() => {});
+        sendResponse({ ok: true });
+        return;
+      }
+
+      if (msg.type === 'GET_SELECTION') {
+        const data = (await chrome.storage.session.get([
+          'lastSelection',
+          'lastSelectionUrl',
+          'lastSelectionTitle',
+        ])) as StorageSession;
+        sendResponse(data);
+        return;
+      }
+    })();
+    return true; // keep channel open for async sendResponse
+  },
+);
+
+// Open side panel on action click
+chrome.action.onClicked.addListener(async (tab) => {
+  if (tab.id) {
+    await chrome.sidePanel.open({ tabId: tab.id });
+  }
+});

--- a/gptme-extension/background.ts
+++ b/gptme-extension/background.ts
@@ -149,37 +149,49 @@ chrome.runtime.onMessage.addListener(
       }
 
       if (msg.type === 'CREATE_CONV') {
-        const cl = await getClient();
-        await cl.createConversation(msg.convId as string, msg.systemMsg as string | undefined);
-        sendResponse({ ok: true });
+        try {
+          const cl = await getClient();
+          await cl.createConversation(msg.convId as string, msg.systemMsg as string | undefined);
+          sendResponse({ ok: true });
+        } catch (e) {
+          sendResponse({ ok: false, error: e instanceof Error ? e.message : String(e) });
+        }
         return;
       }
 
       if (msg.type === 'SEND_AND_STEP') {
-        const cl = await getClient();
         const convId = msg.convId as string;
-        await cl.postMessage(convId, msg.content as string);
-        await cl.step(convId);
-        sendResponse({ ok: true });
+        try {
+          const cl = await getClient();
+          await cl.postMessage(convId, msg.content as string);
 
-        // Cancel any existing stream for this conversation
-        activeStreams.get(convId)?.();
+          // Cancel any existing stream, then subscribe BEFORE step so early tokens aren't missed
+          activeStreams.get(convId)?.();
 
-        const unsub = cl.subscribeEvents(
-          convId,
-          (token) => {
-            chrome.runtime.sendMessage({ type: 'TOKEN', convId, token }).catch(() => {});
-          },
-          () => {
-            chrome.runtime.sendMessage({ type: 'DONE', convId }).catch(() => {});
-            activeStreams.delete(convId);
-          },
-          (error) => {
-            chrome.runtime.sendMessage({ type: 'ERROR', convId, error }).catch(() => {});
-            activeStreams.delete(convId);
-          },
-        );
-        activeStreams.set(convId, unsub);
+          const unsub = cl.subscribeEvents(
+            convId,
+            (token) => {
+              chrome.runtime.sendMessage({ type: 'TOKEN', convId, token }).catch(() => {});
+            },
+            () => {
+              chrome.runtime.sendMessage({ type: 'DONE', convId }).catch(() => {});
+              activeStreams.delete(convId);
+            },
+            (error) => {
+              chrome.runtime.sendMessage({ type: 'ERROR', convId, error }).catch(() => {});
+              activeStreams.delete(convId);
+            },
+          );
+          activeStreams.set(convId, unsub);
+
+          await cl.step(convId);
+          sendResponse({ ok: true });
+        } catch (e) {
+          // Clean up any stream we may have started before failing
+          activeStreams.get(convId)?.();
+          activeStreams.delete(convId);
+          sendResponse({ ok: false, error: e instanceof Error ? e.message : String(e) });
+        }
         return;
       }
 

--- a/gptme-extension/background.ts
+++ b/gptme-extension/background.ts
@@ -7,6 +7,10 @@ interface StorageSync {
   apiKey?: string;
 }
 
+interface StorageLocal {
+  apiKey?: string;
+}
+
 interface StorageSession {
   lastSelection?: string;
   lastSelectionUrl?: string;
@@ -75,6 +79,21 @@ class GptmeClient {
     onError: (msg: string) => void,
   ): () => void {
     const controller = new AbortController();
+    let reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
+    let closed = false;
+
+    const closeStream = async () => {
+      if (closed) return;
+      closed = true;
+      if (reader) {
+        try {
+          await reader.cancel();
+        } catch {
+          // ignore stream-close errors during teardown
+        }
+      }
+      controller.abort();
+    };
 
     fetch(`${this.baseUrl}/api/v2/conversations/${convId}/events`, {
       headers: { ...this.headers(), Accept: 'text/event-stream' },
@@ -84,15 +103,18 @@ class GptmeClient {
         onError(`SSE request failed: ${resp.status}`);
         return;
       }
-      const reader = resp.body.getReader();
+      reader = resp.body.getReader();
       const decoder = new TextDecoder();
       let buffer = '';
 
       while (true) {
         const { done, value } = await reader.read();
         if (done) {
-          onComplete();
-          break;
+          if (!closed) {
+            await closeStream();
+            onComplete();
+          }
+          return;
         }
         buffer += decoder.decode(value, { stream: true });
         const lines = buffer.split('\n');
@@ -108,6 +130,7 @@ class GptmeClient {
             if (data.type === 'generation_progress' && data.data?.content) {
               onToken(data.data.content);
             } else if (data.type === 'generation_complete') {
+              await closeStream();
               onComplete();
               return;
             }
@@ -117,18 +140,41 @@ class GptmeClient {
         }
       }
     }).catch((err: Error) => {
-      if (err.name !== 'AbortError') {
+      if (!closed && err.name !== 'AbortError') {
         onError('SSE connection lost');
       }
     });
 
-    return () => controller.abort();
+    return () => {
+      void closeStream();
+    };
   }
 }
 
+async function getSettings(): Promise<{ serverUrl: string; apiKey?: string }> {
+  const [syncData, localData] = await Promise.all([
+    chrome.storage.sync.get(['serverUrl', 'apiKey']) as Promise<StorageSync>,
+    chrome.storage.local.get(['apiKey']) as Promise<StorageLocal>,
+  ]);
+
+  let apiKey = localData.apiKey;
+  if (!apiKey && syncData.apiKey) {
+    apiKey = syncData.apiKey;
+    await chrome.storage.local.set({ apiKey });
+  }
+  if (syncData.apiKey) {
+    await chrome.storage.sync.remove('apiKey');
+  }
+
+  return {
+    serverUrl: syncData.serverUrl ?? DEFAULT_SERVER_URL,
+    apiKey,
+  };
+}
+
 async function getClient(): Promise<GptmeClient> {
-  const data = (await chrome.storage.sync.get(['serverUrl', 'apiKey'])) as StorageSync;
-  return new GptmeClient(data.serverUrl ?? DEFAULT_SERVER_URL, data.apiKey);
+  const data = await getSettings();
+  return new GptmeClient(data.serverUrl, data.apiKey);
 }
 
 // Active SSE subscriptions keyed by conversationId

--- a/gptme-extension/build.sh
+++ b/gptme-extension/build.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+WATCH="${1:-}"
+OUTDIR="dist"
+
+mkdir -p "$OUTDIR/sidepanel" "$OUTDIR/content" "$OUTDIR/options" "$OUTDIR/icons"
+
+COMMON=(
+  --bundle
+  --sourcemap
+  --target=chrome120
+)
+[[ "$WATCH" == "--watch" ]] && COMMON+=(--watch)
+
+# Background: ESM module (MV3 service worker with type:module)
+npx esbuild background.ts "${COMMON[@]}" --format=esm --outfile="$OUTDIR/background.js"
+
+# Side panel: ESM (loaded via <script type="module">)
+npx esbuild sidepanel/panel.ts "${COMMON[@]}" --format=esm --outfile="$OUTDIR/sidepanel/panel.js"
+
+# Content script: IIFE (injected directly by Chrome, no module support)
+npx esbuild content/content.ts "${COMMON[@]}" --format=iife --outfile="$OUTDIR/content/content.js"
+
+# Options page: ESM
+npx esbuild options/options.ts "${COMMON[@]}" --format=esm --outfile="$OUTDIR/options/options.js"
+
+# Static files
+cp manifest.json "$OUTDIR/manifest.json"
+cp sidepanel/index.html "$OUTDIR/sidepanel/index.html"
+cp sidepanel/panel.css "$OUTDIR/sidepanel/panel.css"
+cp options/options.html "$OUTDIR/options/options.html"
+cp -r icons/ "$OUTDIR/icons/" 2>/dev/null || true
+
+echo "Build complete → $OUTDIR/"

--- a/gptme-extension/content/content.ts
+++ b/gptme-extension/content/content.ts
@@ -1,0 +1,19 @@
+// content.ts — capture text selection and page context, relay to background
+
+let lastSelection = '';
+
+document.addEventListener('mouseup', () => {
+  const sel = window.getSelection()?.toString().trim() ?? '';
+  if (sel && sel !== lastSelection) {
+    lastSelection = sel;
+    chrome.runtime.sendMessage({
+      type: 'SELECTION',
+      // Truncate long selections to stay within reasonable token budgets
+      selection: sel.length > 2000 ? sel.slice(0, 2000) + '…' : sel,
+      url: location.href,
+      title: document.title,
+    }).catch(() => {
+      // Panel may not be open — ignore
+    });
+  }
+});

--- a/gptme-extension/manifest.json
+++ b/gptme-extension/manifest.json
@@ -4,7 +4,7 @@
   "version": "0.1.0",
   "description": "Ask gptme about anything on the web",
   "permissions": ["storage", "sidePanel", "activeTab"],
-  "host_permissions": ["http://localhost/*"],
+  "host_permissions": ["http://localhost/*", "https://localhost/*"],
   "background": {
     "service_worker": "background.js",
     "type": "module"

--- a/gptme-extension/manifest.json
+++ b/gptme-extension/manifest.json
@@ -1,0 +1,34 @@
+{
+  "manifest_version": 3,
+  "name": "gptme",
+  "version": "0.1.0",
+  "description": "Ask gptme about anything on the web",
+  "permissions": ["storage", "sidePanel", "activeTab"],
+  "host_permissions": ["http://localhost/*"],
+  "background": {
+    "service_worker": "background.js",
+    "type": "module"
+  },
+  "side_panel": { "default_path": "sidepanel/index.html" },
+  "options_ui": {
+    "page": "options/options.html",
+    "open_in_tab": true
+  },
+  "action": {
+    "default_title": "Open gptme",
+    "default_icon": {
+      "16": "icons/icon16.png",
+      "48": "icons/icon48.png",
+      "128": "icons/icon128.png"
+    }
+  },
+  "icons": {
+    "16": "icons/icon16.png",
+    "48": "icons/icon48.png",
+    "128": "icons/icon128.png"
+  },
+  "content_scripts": [{
+    "matches": ["<all_urls>"],
+    "js": ["content/content.js"]
+  }]
+}

--- a/gptme-extension/options/options.html
+++ b/gptme-extension/options/options.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>gptme Settings</title>
+  <style>
+    body {
+      font-family: system-ui, -apple-system, sans-serif;
+      max-width: 420px;
+      margin: 48px auto;
+      padding: 0 20px;
+      color: #333;
+      line-height: 1.5;
+    }
+    h1 { font-size: 20px; margin-bottom: 6px; }
+    p.hint { font-size: 12px; color: #777; margin-bottom: 24px; }
+    label { display: block; font-size: 13px; font-weight: 600; margin-bottom: 4px; }
+    input {
+      width: 100%;
+      padding: 8px 10px;
+      font-size: 14px;
+      border: 1px solid #ccc;
+      border-radius: 6px;
+      margin-bottom: 6px;
+      box-sizing: border-box;
+    }
+    input:focus { outline: none; border-color: #569cd6; box-shadow: 0 0 0 2px #569cd620; }
+    .field-hint { font-size: 11px; color: #888; margin-bottom: 16px; }
+    button {
+      background: #569cd6;
+      color: #fff;
+      border: none;
+      border-radius: 6px;
+      padding: 9px 20px;
+      font-size: 14px;
+      font-weight: 600;
+      cursor: pointer;
+    }
+    button:hover { background: #4a8bc0; }
+    #saved { margin-left: 12px; color: #2a9d8f; font-size: 13px; opacity: 0; transition: opacity 0.3s; }
+    #saved.visible { opacity: 1; }
+  </style>
+</head>
+<body>
+  <h1>gptme Settings</h1>
+  <p class="hint">
+    Configure the connection to your local gptme server.
+    Start the server with <code>gptme server</code>.
+  </p>
+
+  <label for="serverUrl">Server URL</label>
+  <input type="url" id="serverUrl" placeholder="http://localhost:5700" autocomplete="url" />
+  <div class="field-hint">Default: http://localhost:5700</div>
+
+  <label for="apiKey">API Key <span style="font-weight: normal; color: #888;">(optional)</span></label>
+  <input type="password" id="apiKey" placeholder="Leave blank for unauthenticated local server" autocomplete="off" />
+  <div class="field-hint">Only required if you started gptme server with <code>--auth</code>.</div>
+
+  <button id="save-btn">Save</button>
+  <span id="saved">Saved ✓</span>
+
+  <script type="module" src="options.js"></script>
+</body>
+</html>

--- a/gptme-extension/options/options.html
+++ b/gptme-extension/options/options.html
@@ -54,7 +54,7 @@
 
   <label for="apiKey">API Key <span style="font-weight: normal; color: #888;">(optional)</span></label>
   <input type="password" id="apiKey" placeholder="Leave blank for unauthenticated local server" autocomplete="off" />
-  <div class="field-hint">Only required if you started gptme server with <code>--auth</code>.</div>
+  <div class="field-hint">Only required if you started gptme server with <code>--auth</code>. Stored only in local browser storage, not Chrome sync.</div>
 
   <button id="save-btn">Save</button>
   <span id="saved">Saved ✓</span>

--- a/gptme-extension/options/options.ts
+++ b/gptme-extension/options/options.ts
@@ -1,17 +1,44 @@
-// options.ts — read/write server URL and API key from chrome.storage.sync
+// options.ts — server URL syncs, API key stays local-only
 export {};
 
 const DEFAULT_URL = 'http://localhost:5700';
+
+interface StorageSync {
+  serverUrl?: string;
+  apiKey?: string;
+}
+
+interface StorageLocal {
+  apiKey?: string;
+}
 
 function el<T extends HTMLElement>(id: string): T {
   return document.getElementById(id) as T;
 }
 
-document.addEventListener('DOMContentLoaded', async () => {
-  const data = await chrome.storage.sync.get(['serverUrl', 'apiKey']) as {
-    serverUrl?: string;
-    apiKey?: string;
+async function loadSettings(): Promise<{ serverUrl: string; apiKey: string }> {
+  const [syncData, localData] = await Promise.all([
+    chrome.storage.sync.get(['serverUrl', 'apiKey']) as Promise<StorageSync>,
+    chrome.storage.local.get(['apiKey']) as Promise<StorageLocal>,
+  ]);
+
+  let apiKey = localData.apiKey ?? '';
+  if (!apiKey && syncData.apiKey) {
+    apiKey = syncData.apiKey;
+    await chrome.storage.local.set({ apiKey });
+  }
+  if (syncData.apiKey) {
+    await chrome.storage.sync.remove('apiKey');
+  }
+
+  return {
+    serverUrl: syncData.serverUrl ?? DEFAULT_URL,
+    apiKey,
   };
+}
+
+document.addEventListener('DOMContentLoaded', async () => {
+  const data = await loadSettings();
 
   el<HTMLInputElement>('serverUrl').value = data.serverUrl ?? DEFAULT_URL;
   el<HTMLInputElement>('apiKey').value = data.apiKey ?? '';
@@ -20,7 +47,13 @@ document.addEventListener('DOMContentLoaded', async () => {
     const serverUrl = el<HTMLInputElement>('serverUrl').value.trim() || DEFAULT_URL;
     const apiKey = el<HTMLInputElement>('apiKey').value.trim() || undefined;
 
-    await chrome.storage.sync.set({ serverUrl, apiKey });
+    await chrome.storage.sync.set({ serverUrl });
+    if (apiKey) {
+      await chrome.storage.local.set({ apiKey });
+    } else {
+      await chrome.storage.local.remove('apiKey');
+    }
+    await chrome.storage.sync.remove('apiKey');
 
     const saved = el('saved');
     saved.classList.add('visible');

--- a/gptme-extension/options/options.ts
+++ b/gptme-extension/options/options.ts
@@ -1,0 +1,29 @@
+// options.ts — read/write server URL and API key from chrome.storage.sync
+export {};
+
+const DEFAULT_URL = 'http://localhost:5700';
+
+function el<T extends HTMLElement>(id: string): T {
+  return document.getElementById(id) as T;
+}
+
+document.addEventListener('DOMContentLoaded', async () => {
+  const data = await chrome.storage.sync.get(['serverUrl', 'apiKey']) as {
+    serverUrl?: string;
+    apiKey?: string;
+  };
+
+  el<HTMLInputElement>('serverUrl').value = data.serverUrl ?? DEFAULT_URL;
+  el<HTMLInputElement>('apiKey').value = data.apiKey ?? '';
+
+  el('save-btn').addEventListener('click', async () => {
+    const serverUrl = el<HTMLInputElement>('serverUrl').value.trim() || DEFAULT_URL;
+    const apiKey = el<HTMLInputElement>('apiKey').value.trim() || undefined;
+
+    await chrome.storage.sync.set({ serverUrl, apiKey });
+
+    const saved = el('saved');
+    saved.classList.add('visible');
+    setTimeout(() => saved.classList.remove('visible'), 2500);
+  });
+});

--- a/gptme-extension/package-lock.json
+++ b/gptme-extension/package-lock.json
@@ -1,0 +1,532 @@
+{
+  "name": "gptme-extension",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "gptme-extension",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@types/chrome": "^0.0.300",
+        "esbuild": "^0.24.0",
+        "typescript": "^5.6.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.24.2.tgz",
+      "integrity": "sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.24.2.tgz",
+      "integrity": "sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.24.2.tgz",
+      "integrity": "sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.24.2.tgz",
+      "integrity": "sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.24.2.tgz",
+      "integrity": "sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.24.2.tgz",
+      "integrity": "sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.24.2.tgz",
+      "integrity": "sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.24.2.tgz",
+      "integrity": "sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.24.2.tgz",
+      "integrity": "sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.24.2.tgz",
+      "integrity": "sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.24.2.tgz",
+      "integrity": "sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.24.2.tgz",
+      "integrity": "sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.24.2.tgz",
+      "integrity": "sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.24.2.tgz",
+      "integrity": "sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.24.2.tgz",
+      "integrity": "sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.24.2.tgz",
+      "integrity": "sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.24.2.tgz",
+      "integrity": "sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.24.2.tgz",
+      "integrity": "sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.24.2.tgz",
+      "integrity": "sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.24.2.tgz",
+      "integrity": "sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.24.2.tgz",
+      "integrity": "sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.24.2.tgz",
+      "integrity": "sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/chrome": {
+      "version": "0.0.300",
+      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.300.tgz",
+      "integrity": "sha512-vS5bUmNjMrbPut43Q8plS8GTAiJE+pBOxw1ovGC4LcwiGNKTithAH7TxhzHeX4wNq/FsaLj5KaW7riI0CgYjIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/filesystem": "*",
+        "@types/har-format": "*"
+      }
+    },
+    "node_modules/@types/filesystem": {
+      "version": "0.0.36",
+      "resolved": "https://registry.npmjs.org/@types/filesystem/-/filesystem-0.0.36.tgz",
+      "integrity": "sha512-vPDXOZuannb9FZdxgHnqSwAG/jvdGM8Wq+6N4D/d80z+D4HWH+bItqsZaVRQykAn6WEVeEkLm2oQigyHtgb0RA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/filewriter": "*"
+      }
+    },
+    "node_modules/@types/filewriter": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/@types/filewriter/-/filewriter-0.0.33.tgz",
+      "integrity": "sha512-xFU8ZXTw4gd358lb2jw25nxY9QAgqn2+bKKjKOYfNCzN4DKCFetK7sPtrlpg66Ywe3vWY9FNxprZawAh9wfJ3g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/har-format": {
+      "version": "1.2.16",
+      "resolved": "https://registry.npmjs.org/@types/har-format/-/har-format-1.2.16.tgz",
+      "integrity": "sha512-fluxdy7ryD3MV6h8pTfTYpy/xQzCFC7m89nOH9y94cNqJ1mDIDPut7MnRHI3F6qRmh/cT2fUjG1MLdCNb4hE9A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.24.2.tgz",
+      "integrity": "sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.24.2",
+        "@esbuild/android-arm": "0.24.2",
+        "@esbuild/android-arm64": "0.24.2",
+        "@esbuild/android-x64": "0.24.2",
+        "@esbuild/darwin-arm64": "0.24.2",
+        "@esbuild/darwin-x64": "0.24.2",
+        "@esbuild/freebsd-arm64": "0.24.2",
+        "@esbuild/freebsd-x64": "0.24.2",
+        "@esbuild/linux-arm": "0.24.2",
+        "@esbuild/linux-arm64": "0.24.2",
+        "@esbuild/linux-ia32": "0.24.2",
+        "@esbuild/linux-loong64": "0.24.2",
+        "@esbuild/linux-mips64el": "0.24.2",
+        "@esbuild/linux-ppc64": "0.24.2",
+        "@esbuild/linux-riscv64": "0.24.2",
+        "@esbuild/linux-s390x": "0.24.2",
+        "@esbuild/linux-x64": "0.24.2",
+        "@esbuild/netbsd-arm64": "0.24.2",
+        "@esbuild/netbsd-x64": "0.24.2",
+        "@esbuild/openbsd-arm64": "0.24.2",
+        "@esbuild/openbsd-x64": "0.24.2",
+        "@esbuild/sunos-x64": "0.24.2",
+        "@esbuild/win32-arm64": "0.24.2",
+        "@esbuild/win32-ia32": "0.24.2",
+        "@esbuild/win32-x64": "0.24.2"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/gptme-extension/package.json
+++ b/gptme-extension/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "gptme-extension",
+  "version": "0.1.0",
+  "description": "gptme browser extension — ask gptme about anything on the web",
+  "private": true,
+  "scripts": {
+    "build": "bash build.sh",
+    "watch": "bash build.sh --watch"
+  },
+  "devDependencies": {
+    "@types/chrome": "^0.0.300",
+    "esbuild": "^0.24.0",
+    "typescript": "^5.6.0"
+  }
+}

--- a/gptme-extension/sidepanel/index.html
+++ b/gptme-extension/sidepanel/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>gptme</title>
+  <link rel="stylesheet" href="panel.css" />
+</head>
+<body>
+  <header>
+    <span class="logo">gptme</span>
+    <span id="status" class="status checking">● Connecting…</span>
+    <a href="../options/options.html" target="_blank" class="icon-btn" title="Settings">⚙</a>
+    <button id="clear-btn" class="icon-btn" title="New conversation">✕</button>
+  </header>
+
+  <div id="selection-bar" class="selection-bar hidden">
+    <span id="selection-label">Context: </span>
+    <button id="clear-selection" title="Remove context">×</button>
+  </div>
+
+  <div id="messages" class="messages"></div>
+
+  <footer>
+    <textarea id="input" placeholder="Ask gptme… (Enter to send, Shift+Enter for newline)" rows="2"></textarea>
+    <button id="send-btn">Send</button>
+  </footer>
+
+  <script type="module" src="panel.js"></script>
+</body>
+</html>

--- a/gptme-extension/sidepanel/panel.css
+++ b/gptme-extension/sidepanel/panel.css
@@ -1,0 +1,184 @@
+:root {
+  --bg: #1e1e1e;
+  --surface: #252526;
+  --border: #3c3c3c;
+  --text: #d4d4d4;
+  --text-muted: #888;
+  --accent: #569cd6;
+  --online: #4ec9b0;
+  --offline: #f44747;
+  --user-bg: #1a3a4a;
+  --user-text: #c3e4f5;
+  --assistant-bg: #2d2d2d;
+  --selection-bg: #2a2a1e;
+  --selection-border: #6b6020;
+  --radius: 6px;
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  font-size: 13px;
+  background: var(--bg);
+  color: var(--text);
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  overflow: hidden;
+}
+
+/* Header */
+header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+.logo { font-weight: 700; font-size: 14px; color: var(--accent); }
+
+.status { font-size: 11px; flex: 1; transition: color 0.2s; }
+.status.online  { color: var(--online); }
+.status.offline { color: var(--offline); }
+.status.checking { color: var(--text-muted); }
+
+.icon-btn {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 14px;
+  padding: 3px 6px;
+  border-radius: 4px;
+  text-decoration: none;
+  line-height: 1;
+}
+.icon-btn:hover { background: var(--border); color: var(--text); }
+
+/* Selection context bar */
+.selection-bar {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 12px;
+  background: var(--selection-bg);
+  border-bottom: 1px solid var(--selection-border);
+  font-size: 11px;
+  color: #c8b855;
+  flex-shrink: 0;
+}
+.selection-bar.hidden { display: none; }
+
+#selection-label {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+#clear-selection {
+  background: none;
+  border: none;
+  color: #888;
+  cursor: pointer;
+  font-size: 14px;
+  padding: 0 2px;
+  line-height: 1;
+}
+#clear-selection:hover { color: var(--offline); }
+
+/* Messages */
+.messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  scroll-behavior: smooth;
+}
+
+.message {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.message .label {
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+}
+
+.message .text {
+  padding: 8px 10px;
+  border-radius: var(--radius);
+  white-space: pre-wrap;
+  word-break: break-word;
+  line-height: 1.55;
+}
+
+.message.user  { align-items: flex-end; }
+.message.user .text { background: var(--user-bg); color: var(--user-text); }
+
+.message.assistant .text { background: var(--assistant-bg); }
+
+.message.assistant .text:empty::after {
+  content: '▋';
+  animation: blink 1s step-end infinite;
+}
+
+.message.system .text {
+  background: transparent;
+  color: var(--offline);
+  font-size: 11px;
+  padding: 2px 0;
+}
+
+@keyframes blink { 0%, 100% { opacity: 1; } 50% { opacity: 0; } }
+
+/* Footer */
+footer {
+  display: flex;
+  gap: 8px;
+  padding: 10px 12px;
+  background: var(--surface);
+  border-top: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+#input {
+  flex: 1;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text);
+  padding: 8px 10px;
+  font-size: 13px;
+  font-family: inherit;
+  resize: none;
+  outline: none;
+  line-height: 1.4;
+}
+#input:focus { border-color: var(--accent); }
+
+#send-btn {
+  background: var(--accent);
+  border: none;
+  border-radius: var(--radius);
+  color: #fff;
+  padding: 8px 14px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  align-self: flex-end;
+  transition: background 0.15s;
+}
+#send-btn:hover    { background: #4a8bc0; }
+#send-btn:disabled { background: var(--border); color: #555; cursor: not-allowed; }

--- a/gptme-extension/sidepanel/panel.ts
+++ b/gptme-extension/sidepanel/panel.ts
@@ -6,6 +6,7 @@ interface State {
   serverOnline: boolean;
   generating: boolean;
   currentAssistantText: string;
+  currentAssistantDiv: HTMLElement | null;
   selection: string | null;
 }
 
@@ -14,6 +15,7 @@ const state: State = {
   serverOnline: false,
   generating: false,
   currentAssistantText: '',
+  currentAssistantDiv: null,
   selection: null,
 };
 
@@ -112,12 +114,24 @@ async function sendMessage(): Promise<void> {
   const assistantDiv = appendMessage('assistant', '');
   const textEl = assistantDiv.querySelector('.text') as HTMLElement;
   state.currentAssistantText = '';
+  state.currentAssistantDiv = assistantDiv;
 
   chrome.runtime.sendMessage({
     type: 'SEND_AND_STEP',
     convId: state.convId,
     content,
+  }).then((resp: { ok: boolean; error?: string } | undefined) => {
+    if (resp && !resp.ok) {
+      assistantDiv.remove();
+      state.currentAssistantDiv = null;
+      appendMessage('system', `Failed: ${resp.error ?? 'server error'}`);
+      state.generating = false;
+      el<HTMLButtonElement>('send-btn').disabled = false;
+    }
+    // ok: true → wait for TOKEN/DONE/ERROR from background
   }).catch(() => {
+    assistantDiv.remove();
+    state.currentAssistantDiv = null;
     appendMessage('system', 'Failed to send message. Is the server running?');
     state.generating = false;
     el<HTMLButtonElement>('send-btn').disabled = false;
@@ -129,6 +143,7 @@ function clearConversation(): void {
   state.convId = `gptme-ext-${Date.now()}`;
   state.generating = false;
   state.currentAssistantText = '';
+  state.currentAssistantDiv = null;
   el('messages').innerHTML = '';
   el<HTMLButtonElement>('send-btn').disabled = false;
   setSelectionBar(null);
@@ -150,12 +165,18 @@ chrome.runtime.onMessage.addListener((msg: Record<string, unknown>) => {
 
   if (msg.type === 'DONE' && msg.convId === state.convId) {
     state.generating = false;
+    state.currentAssistantDiv = null;
     el<HTMLButtonElement>('send-btn').disabled = false;
     el<HTMLTextAreaElement>('input').focus();
     return;
   }
 
   if (msg.type === 'ERROR' && msg.convId === state.convId) {
+    // Remove empty assistant bubble (no tokens received) before showing error
+    if (state.currentAssistantDiv && !state.currentAssistantText) {
+      state.currentAssistantDiv.remove();
+    }
+    state.currentAssistantDiv = null;
     state.generating = false;
     el<HTMLButtonElement>('send-btn').disabled = false;
     appendMessage('system', `Error: ${String(msg.error)}`);

--- a/gptme-extension/sidepanel/panel.ts
+++ b/gptme-extension/sidepanel/panel.ts
@@ -1,0 +1,194 @@
+// panel.ts — side panel chat UI
+export {};
+
+interface State {
+  convId: string;
+  serverOnline: boolean;
+  generating: boolean;
+  currentAssistantText: string;
+  selection: string | null;
+}
+
+const state: State = {
+  convId: `gptme-ext-${Date.now()}`,
+  serverOnline: false,
+  generating: false,
+  currentAssistantText: '',
+  selection: null,
+};
+
+function el<T extends HTMLElement>(id: string): T {
+  return document.getElementById(id) as T;
+}
+
+// --- DOM helpers ---
+
+function appendMessage(
+  role: 'user' | 'assistant' | 'system',
+  content: string,
+): HTMLElement {
+  const messages = el('messages');
+  const div = document.createElement('div');
+  div.className = `message ${role}`;
+
+  if (role !== 'system') {
+    const label = document.createElement('span');
+    label.className = 'label';
+    label.textContent = role === 'user' ? 'You' : 'gptme';
+    div.appendChild(label);
+  }
+
+  const text = document.createElement('div');
+  text.className = 'text';
+  text.textContent = content;
+  div.appendChild(text);
+
+  messages.appendChild(div);
+  messages.scrollTop = messages.scrollHeight;
+  return div;
+}
+
+function setStatus(msg: string, cls: 'online' | 'offline' | 'checking'): void {
+  const s = el('status');
+  s.textContent = msg;
+  s.className = `status ${cls}`;
+}
+
+function setSelectionBar(text: string | null): void {
+  const bar = el('selection-bar');
+  const label = el<HTMLSpanElement>('selection-label');
+  if (text) {
+    const preview = text.length > 60 ? text.slice(0, 60) + '…' : text;
+    label.textContent = `Context: "${preview}"`;
+    bar.classList.remove('hidden');
+  } else {
+    bar.classList.add('hidden');
+  }
+  state.selection = text;
+}
+
+// --- Network calls (via background) ---
+
+async function ping(): Promise<void> {
+  setStatus('● Connecting…', 'checking');
+  try {
+    const resp = await chrome.runtime.sendMessage({ type: 'PING' }) as { ok: boolean };
+    if (resp.ok) {
+      setStatus('● Connected', 'online');
+      state.serverOnline = true;
+      await chrome.runtime.sendMessage({
+        type: 'CREATE_CONV',
+        convId: state.convId,
+        systemMsg: 'You are a helpful assistant. You are accessible via a browser extension called gptme. Be concise.',
+      });
+    } else {
+      setStatus('● Server offline — run `gptme server`', 'offline');
+      state.serverOnline = false;
+    }
+  } catch {
+    setStatus('● Connection error', 'offline');
+    state.serverOnline = false;
+  }
+}
+
+async function sendMessage(): Promise<void> {
+  if (!state.serverOnline || state.generating) return;
+
+  const input = el<HTMLTextAreaElement>('input');
+  const question = input.value.trim();
+  if (!question) return;
+
+  input.value = '';
+  state.generating = true;
+  el<HTMLButtonElement>('send-btn').disabled = true;
+
+  // Build content with optional selection context
+  let content = question;
+  if (state.selection) {
+    content = `[Page context]\nSelected text:\n> ${state.selection}\n\n${question}`;
+  }
+
+  appendMessage('user', question);
+  const assistantDiv = appendMessage('assistant', '');
+  const textEl = assistantDiv.querySelector('.text') as HTMLElement;
+  state.currentAssistantText = '';
+
+  chrome.runtime.sendMessage({
+    type: 'SEND_AND_STEP',
+    convId: state.convId,
+    content,
+  }).catch(() => {
+    appendMessage('system', 'Failed to send message. Is the server running?');
+    state.generating = false;
+    el<HTMLButtonElement>('send-btn').disabled = false;
+  });
+}
+
+function clearConversation(): void {
+  state.convId = `gptme-ext-${Date.now()}`;
+  state.generating = false;
+  state.currentAssistantText = '';
+  el('messages').innerHTML = '';
+  el<HTMLButtonElement>('send-btn').disabled = false;
+  setSelectionBar(null);
+  ping();
+}
+
+// --- Incoming messages from background ---
+
+chrome.runtime.onMessage.addListener((msg: Record<string, unknown>) => {
+  if (msg.type === 'TOKEN' && msg.convId === state.convId) {
+    state.currentAssistantText += msg.token as string;
+    const messages = el('messages');
+    const last = messages.querySelector('.message.assistant:last-child .text');
+    if (last) last.textContent = state.currentAssistantText;
+    messages.scrollTop = messages.scrollHeight;
+    return;
+  }
+
+  if (msg.type === 'DONE' && msg.convId === state.convId) {
+    state.generating = false;
+    el<HTMLButtonElement>('send-btn').disabled = false;
+    el<HTMLTextAreaElement>('input').focus();
+    return;
+  }
+
+  if (msg.type === 'ERROR' && msg.convId === state.convId) {
+    state.generating = false;
+    el<HTMLButtonElement>('send-btn').disabled = false;
+    appendMessage('system', `Error: ${String(msg.error)}`);
+    return;
+  }
+
+  if (msg.type === 'SELECTION_UPDATE') {
+    setSelectionBar(msg.selection as string);
+    return;
+  }
+});
+
+// --- Init ---
+
+document.addEventListener('DOMContentLoaded', async () => {
+  el('send-btn').addEventListener('click', () => { void sendMessage(); });
+  el('clear-btn').addEventListener('click', clearConversation);
+  el('clear-selection').addEventListener('click', () => setSelectionBar(null));
+
+  el<HTMLTextAreaElement>('input').addEventListener('keydown', (e) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      void sendMessage();
+    }
+  });
+
+  // Load any existing selection from when the panel was closed
+  try {
+    const data = await chrome.runtime.sendMessage({ type: 'GET_SELECTION' }) as {
+      lastSelection?: string;
+    };
+    if (data.lastSelection) setSelectionBar(data.lastSelection);
+  } catch {
+    // background may not be ready yet
+  }
+
+  await ping();
+});

--- a/gptme-extension/sidepanel/panel.ts
+++ b/gptme-extension/sidepanel/panel.ts
@@ -73,23 +73,31 @@ function setSelectionBar(text: string | null): void {
 
 async function ping(): Promise<void> {
   setStatus('● Connecting…', 'checking');
+  state.serverOnline = false;
   try {
-    const resp = await chrome.runtime.sendMessage({ type: 'PING' }) as { ok: boolean };
-    if (resp.ok) {
-      setStatus('● Connected', 'online');
-      state.serverOnline = true;
-      await chrome.runtime.sendMessage({
-        type: 'CREATE_CONV',
-        convId: state.convId,
-        systemMsg: 'You are a helpful assistant. You are accessible via a browser extension called gptme. Be concise.',
-      });
-    } else {
+    const pingResp = await chrome.runtime.sendMessage({ type: 'PING' }) as { ok: boolean };
+    if (!pingResp.ok) {
       setStatus('● Server offline — run `gptme server`', 'offline');
-      state.serverOnline = false;
+      return;
     }
+
+    const createResp = await chrome.runtime.sendMessage({
+      type: 'CREATE_CONV',
+      convId: state.convId,
+      systemMsg: 'You are a helpful assistant. You are accessible via a browser extension called gptme. Be concise.',
+    }) as { ok: boolean; error?: string };
+    if (!createResp.ok) {
+      setStatus(
+        `● Server error — ${createResp.error ?? 'failed to create conversation'}`,
+        'offline',
+      );
+      return;
+    }
+
+    setStatus('● Connected', 'online');
+    state.serverOnline = true;
   } catch {
     setStatus('● Connection error', 'offline');
-    state.serverOnline = false;
   }
 }
 

--- a/gptme-extension/sidepanel/panel.ts
+++ b/gptme-extension/sidepanel/panel.ts
@@ -125,12 +125,14 @@ async function sendMessage(): Promise<void> {
 }
 
 function clearConversation(): void {
+  const oldConvId = state.convId;
   state.convId = `gptme-ext-${Date.now()}`;
   state.generating = false;
   state.currentAssistantText = '';
   el('messages').innerHTML = '';
   el<HTMLButtonElement>('send-btn').disabled = false;
   setSelectionBar(null);
+  chrome.runtime.sendMessage({ type: 'CANCEL', convId: oldConvId }).catch(() => {});
   ping();
 }
 

--- a/gptme-extension/tsconfig.json
+++ b/gptme-extension/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["ES2020", "DOM"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "outDir": "dist",
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["./**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

Adds `gptme-extension/` — a Chrome MV3 browser extension that brings gptme to the browser. Users can select text on any web page, open a side panel, and chat with their local gptme server.

**Slice 1 (this PR)** — skeleton + side panel shell:
- `manifest.json` — MV3, side panel, content scripts, permissions
- `background.ts` — `GptmeClient` (REST + SSE), message bus, action handler
- `sidepanel/` — streaming chat UI with selection context bar
- `content/content.ts` — text selection capture → background relay
- `options/` — server URL + API key configuration page
- `build.sh` — esbuild compile script (background=ESM, content=IIFE)
- Placeholder icons (16/48/128px)

TypeScript compiles clean (`tsc --noEmit`). esbuild output: background.js 4.6kb, panel.js 4.5kb, content.js 608b, options.js 767b.

## Usage

```bash
cd gptme-extension
npm install
npm run build
# Load dist/ in chrome://extensions (Developer mode → Load unpacked)
```

Start gptme server first: `gptme server`

## Architecture

Extension talks only to the existing gptme v2 API — no backend changes needed. The background service worker handles all HTTP/SSE calls; the side panel is a lightweight vanilla TS UI.

See [`knowledge/technical-designs/gptme-chrome-extension-mvp.md`](https://github.com/gptme/gptme/blob/master/knowledge/technical-designs/gptme-chrome-extension-mvp.md) for the full spec.

## Roadmap (follow-up slices)

- Slice 2: Conversation history (list + reload)
- Slice 3: API key auth + tool call visualization
- Slice 4: gptme.ai remote server support

## Test plan

- [ ] `cd gptme-extension && npm install && npm run build` — build succeeds
- [ ] Load `dist/` in Chrome (Developer mode) — extension loads without errors
- [ ] Click extension icon — side panel opens
- [ ] Side panel with gptme server running — shows "Connected" status
- [ ] Side panel without server — shows "Server offline" error state
- [ ] Type a message + Enter — sends to gptme, response streams in
- [ ] Select text on a page, open panel — context bar shows selection
- [ ] Options page (⚙) — can change server URL and API key