### PR TITLE
feat(util): add gptme-util status subcommand for operator handoff

### DIFF
--- a/gptme/cli/cmd_status.py
+++ b/gptme/cli/cmd_status.py
@@ -4,7 +4,7 @@ Provides ``gptme-util status`` (via lazy registration in ``util.py``) and
 ``gptme-status`` (standalone entry point registered in ``pyproject.toml``).
 
 Produces a compact, human-readable briefing: active work, PR queue, service
-health, blockers, and ready-next tasks.
+health, blockers, and ready backlog items.
 """
 
 from __future__ import annotations
@@ -12,6 +12,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
@@ -33,17 +34,22 @@ def _run(cmd: list[str], *, timeout: int = 10) -> str:
         return ""
 
 
+def _git_root() -> Path | None:
+    raw = _run(["git", "rev-parse", "--show-toplevel"])
+    return Path(raw) if raw else None
+
+
+def _gh_user() -> str:
+    """Return the current gh CLI authenticated username."""
+    return _run(["gh", "api", "user", "--jq", ".login"], timeout=10)
+
+
 def _is_bob_workspace() -> bool:
     """Detect if we are inside Bob's workspace by checking for Bob-specific files."""
     root = _git_root()
     if not root:
         return False
-    return (root / "tasks").is_dir() and (root / "gptme.toml").is_dir()
-
-
-def _git_root() -> Path | None:
-    raw = _run(["git", "rev-parse", "--show-toplevel"])
-    return Path(raw) if raw else None
+    return (root / "tasks").is_dir() and (root / "gptme.toml").is_file()
 
 
 def _active_tasks(lines: int = 3) -> list[dict]:
@@ -57,9 +63,12 @@ def _active_tasks(lines: int = 3) -> list[dict]:
         # Lines look like "  task-id  Title text here  (N ago)"
         if not line or line.startswith("📋") or "0 tasks" in line or "Summary" in line:
             continue
-        parts = line.split(None, 2)
+        parts = line.split(None, 1)
         if len(parts) >= 2:
-            tasks.append({"_id": parts[0], "title": parts[1] if len(parts) > 1 else ""})
+            task_id = parts[0]
+            # Strip trailing " (N unit ago)" timestamp to get the full title
+            title = re.sub(r"\s+\(\d+\s+\w+\s+ago\)\s*$", "", parts[1]).strip()
+            tasks.append({"_id": task_id, "title": title})
     return tasks[:lines]
 
 
@@ -68,7 +77,11 @@ def _recent_commits(n: int = 3) -> list[str]:
     return raw.splitlines() if raw else []
 
 
-def _pr_queue(repos: list[tuple[str, int | None]]) -> list[dict[str, str]]:
+def _pr_queue(
+    repos: list[tuple[str, int | None]], author: str | None = None
+) -> list[dict[str, str]]:
+    if author is None:
+        author = _gh_user() or "TimeToBuildBob"
     rows: list[dict[str, str]] = []
     for repo, cap in repos:
         prs_json = _run(
@@ -79,7 +92,7 @@ def _pr_queue(repos: list[tuple[str, int | None]]) -> list[dict[str, str]]:
                 "--repo",
                 repo,
                 "--author",
-                "TimeToBuildBob",
+                author,
                 "--state",
                 "open",
                 "--json",
@@ -157,22 +170,38 @@ def _ready_tasks(limit: int = 3) -> list[dict]:
     return tasks[:limit]
 
 
+def _strip_markdown(doc: str) -> str:
+    """Strip Markdown formatting for plain-text output."""
+    lines = []
+    for line in doc.splitlines():
+        line = re.sub(r"^#+\s+", "", line)  # Remove headings
+        line = re.sub(r"\*+([^*]*)\*+", r"\1", line)  # Remove bold/italic
+        line = re.sub(r"`([^`]*)`", r"\1", line)  # Remove inline code
+        if re.match(r"^[|\s\-:]+$", line):  # Skip table dividers
+            continue
+        lines.append(line)
+    return "\n".join(lines)
+
+
 # ── sections ──────────────────────────────────────────────────────────
 
 
 def section_header() -> str:
     now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
     model = os.environ.get("CLAUDE_MODEL", os.environ.get("CC_MODEL", "unknown"))
-    return f"# gptme Status — {now}\n\n**Agent**: Bob | **Model**: {model}\n"
+    agent_name = os.environ.get("GPTME_AGENT_NAME", "")
+    agent_part = f" | **Agent**: {agent_name}" if agent_name else ""
+    return f"# gptme Status — {now}\n\n**Model**: {model}{agent_part}\n"
 
 
-def section_active_work() -> str:
+def section_active_work(is_bob: bool = False) -> str:
     lines = ["## Active Work"]
-    tasks = _active_tasks(3)
-    if tasks:
-        lines.extend(
-            f"- **Task**: `{t['_id']}` — {t.get('title', '')[:60]}" for t in tasks
-        )
+    if is_bob:
+        tasks = _active_tasks(3)
+        if tasks:
+            lines.extend(
+                f"- **Task**: `{t['_id']}` — {t.get('title', '')[:60]}" for t in tasks
+            )
     commits = _recent_commits(3)
     if commits:
         lines.append("- **Recent commits** (last 3):")
@@ -240,14 +269,20 @@ def section_ready_next() -> str:
 
 
 def build_document() -> str:
-    sections = [
+    is_bob = _is_bob_workspace()
+    sections: list[str] = [
         section_header(),
-        section_active_work(),
+        section_active_work(is_bob=is_bob),
         section_pr_queue(),
-        section_services(),
-        section_blockers(),
-        section_ready_next(),
     ]
+    if is_bob:
+        sections.extend(
+            [
+                section_services(),
+                section_blockers(),
+                section_ready_next(),
+            ]
+        )
     doc = "\n\n".join(sections)
     token_est = len(doc) // 4
     doc += f"\n\n---\n*~{token_est} tokens*"
@@ -272,10 +307,9 @@ def build_document() -> str:
     help="Output file path (implies --write).",
 )
 @click.option(
-    "--markdown",
-    is_flag=True,
+    "--markdown/--no-markdown",
     default=True,
-    help="Output as Markdown (default: enabled).",
+    help="Output as Markdown (default: enabled). Use --no-markdown for plain text.",
 )
 def status(write: bool, output: str | None, markdown: bool):
     """Generate a portable operator handoff / session-status document.
@@ -291,8 +325,12 @@ def status(write: bool, output: str | None, markdown: bool):
         gptme-util status --write               # write to status.md
 
         gptme-util status -o /tmp/handoff.md    # write to custom path
+
+        gptme-util status --no-markdown         # plain-text output
     """
     doc = build_document()
+    if not markdown:
+        doc = _strip_markdown(doc)
     out_path: Path | None = None
 
     if output:

--- a/gptme/cli/cmd_status.py
+++ b/gptme/cli/cmd_status.py
@@ -1,0 +1,312 @@
+"""CLI commands for gptme status — portable operator handoff document.
+
+Provides ``gptme-util status`` (via lazy registration in ``util.py``) and
+``gptme-status`` (standalone entry point registered in ``pyproject.toml``).
+
+Produces a compact, human-readable briefing: active work, PR queue, service
+health, blockers, and ready-next tasks.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+
+import click
+
+logger = logging.getLogger(__name__)
+
+
+# ── helpers ────────────────────────────────────────────────────────────
+
+
+def _run(cmd: list[str], *, timeout: int = 10) -> str:
+    try:
+        return subprocess.check_output(
+            cmd, text=True, stderr=subprocess.DEVNULL, timeout=timeout
+        ).strip()
+    except Exception:
+        return ""
+
+
+def _is_bob_workspace() -> bool:
+    """Detect if we are inside Bob's workspace by checking for Bob-specific files."""
+    root = _git_root()
+    if not root:
+        return False
+    return (root / "tasks").is_dir() and (root / "gptme.toml").is_dir()
+
+
+def _git_root() -> Path | None:
+    raw = _run(["git", "rev-parse", "--show-toplevel"])
+    return Path(raw) if raw else None
+
+
+def _active_tasks(lines: int = 3) -> list[dict]:
+    """Parse gptodo status --compact output for active tasks (Bob workspace)."""
+    raw = _run(["gptodo", "status", "--compact"], timeout=15)
+    if not raw:
+        return []
+    tasks: list[dict] = []
+    for line in raw.splitlines():
+        line = line.strip()
+        # Lines look like "  task-id  Title text here  (N ago)"
+        if not line or line.startswith("📋") or "0 tasks" in line or "Summary" in line:
+            continue
+        parts = line.split(None, 2)
+        if len(parts) >= 2:
+            tasks.append({"_id": parts[0], "title": parts[1] if len(parts) > 1 else ""})
+    return tasks[:lines]
+
+
+def _recent_commits(n: int = 3) -> list[str]:
+    raw = _run(["git", "log", "--oneline", f"-{n}", "--no-merges"])
+    return raw.splitlines() if raw else []
+
+
+def _pr_queue(repos: list[tuple[str, int | None]]) -> list[dict[str, str]]:
+    rows: list[dict[str, str]] = []
+    for repo, cap in repos:
+        prs_json = _run(
+            [
+                "gh",
+                "pr",
+                "list",
+                "--repo",
+                repo,
+                "--author",
+                "TimeToBuildBob",
+                "--state",
+                "open",
+                "--json",
+                "number,title",
+            ],
+            timeout=15,
+        )
+        if not prs_json:
+            continue
+        try:
+            prs = json.loads(prs_json)
+        except json.JSONDecodeError:
+            continue
+        count = len(prs)
+        cap_str = (
+            f"{count}/{cap}"
+            + (" ⚠ at limit" if cap is not None and count >= cap else "")
+            if cap is not None
+            else str(count)
+        )
+        rows.append({"repo": repo, "count": cap_str})
+    return rows
+
+
+def _service_status() -> list[dict[str, str]]:
+    services = [
+        ("Operator loop", "bob-operator-loop.service"),
+        ("Autonomous", "bob-autonomous.service"),
+    ]
+    results: list[dict[str, str]] = []
+    for label, unit in services:
+        status = _run(["systemctl", "--user", "is-active", unit])
+        icon = "✓" if status == "active" else ("⚠" if status == "activating" else "✗")
+        results.append({"label": label, "icon": icon, "status": status})
+    return results
+
+
+def _dead_timers() -> int:
+    out = _run(["systemctl", "--user", "list-timers", "--all"])
+    return sum(
+        1
+        for line in out.splitlines()
+        if "dead" in line.lower() and "bob-" in line.lower()
+    )
+
+
+def _blockers(limit: int = 3) -> list[dict]:
+    raw = _run(["gptodo", "ready", "--state", "waiting", "--jsonl"], timeout=15)
+    if not raw:
+        return []
+    blockers: list[dict] = []
+    for line in raw.splitlines():
+        try:
+            t = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if t.get("waiting_for"):
+            blockers.append(t)
+    return blockers[:limit]
+
+
+def _ready_tasks(limit: int = 3) -> list[dict]:
+    raw = _run(["gptodo", "ready", "--state", "backlog", "--jsonl"], timeout=15)
+    if not raw:
+        return []
+    tasks: list[dict] = []
+    for line in raw.splitlines():
+        try:
+            t = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if t.get("waiting_for") or t.get("wait"):
+            continue
+        tasks.append(t)
+    return tasks[:limit]
+
+
+# ── sections ──────────────────────────────────────────────────────────
+
+
+def section_header() -> str:
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    model = os.environ.get("CLAUDE_MODEL", os.environ.get("CC_MODEL", "unknown"))
+    return f"# gptme Status — {now}\n\n**Agent**: Bob | **Model**: {model}\n"
+
+
+def section_active_work() -> str:
+    lines = ["## Active Work"]
+    tasks = _active_tasks(3)
+    if tasks:
+        lines.extend(
+            f"- **Task**: `{t['_id']}` — {t.get('title', '')[:60]}" for t in tasks
+        )
+    commits = _recent_commits(3)
+    if commits:
+        lines.append("- **Recent commits** (last 3):")
+        for commit in commits:
+            sha, _, msg = commit.partition(" ")
+            lines.append(f"  - `{sha}` {msg[:65]}")
+    return "\n".join(lines)
+
+
+def section_pr_queue() -> str:
+    lines = ["## PR Queue"]
+    tracked = [
+        ("gptme/gptme", 10),
+        ("gptme/gptme-cloud", 3),
+        ("ErikBjare/bob", None),
+        ("gptme/gptme-contrib", None),
+    ]
+    rows = _pr_queue(tracked)
+    if rows:
+        lines.append("| Repo | Open |")
+        lines.append("|------|------|")
+        lines.extend(f"| {row['repo']} | {row['count']} |" for row in rows)
+    else:
+        lines.append("- Unable to fetch PR data")
+    return "\n".join(lines)
+
+
+def section_services() -> str:
+    lines = ["## Services"]
+    services = _service_status()
+    lines.extend(f"- {svc['label']}: {svc['icon']} {svc['status']}" for svc in services)
+    dead = _dead_timers()
+    if dead:
+        lines.append(f"- ⚠ {dead} dead bob-* timer(s)")
+    return "\n".join(lines)
+
+
+def section_blockers() -> str:
+    lines = ["## Top Blockers"]
+    blockers = _blockers(3)
+    if blockers:
+        for t in blockers:
+            wf = str(t.get("waiting_for", "")).split("\n")[0][:70]
+            since = t.get("waiting_since", "")
+            since_str = f" (since {since})" if since else ""
+            lines.append(f"- `{t['id']}`: {wf}{since_str}")
+    else:
+        lines.append("- No active blockers with waiting_for set")
+    return "\n".join(lines)
+
+
+def section_ready_next() -> str:
+    lines = ["## Ready Next (top 3)"]
+    ready = _ready_tasks(3)
+    if ready:
+        for i, t in enumerate(ready, 1):
+            title = str(t.get("name", t.get("id", "")))[:65]
+            lines.append(f"{i}. `{t['id']}` — {title}")
+    else:
+        lines.append("- No ready backlog tasks found")
+    return "\n".join(lines)
+
+
+# ── build ─────────────────────────────────────────────────────────────
+
+
+def build_document() -> str:
+    sections = [
+        section_header(),
+        section_active_work(),
+        section_pr_queue(),
+        section_services(),
+        section_blockers(),
+        section_ready_next(),
+    ]
+    doc = "\n\n".join(sections)
+    token_est = len(doc) // 4
+    doc += f"\n\n---\n*~{token_est} tokens*"
+    return doc
+
+
+# ── click command ─────────────────────────────────────────────────────
+
+
+@click.command("status")
+@click.option(
+    "--write",
+    is_flag=True,
+    help="Write status document to status.md in repo root.",
+)
+@click.option(
+    "-o",
+    "--output",
+    type=click.Path(writable=True),
+    default=None,
+    metavar="FILE",
+    help="Output file path (implies --write).",
+)
+@click.option(
+    "--markdown",
+    is_flag=True,
+    default=True,
+    help="Output as Markdown (default: enabled).",
+)
+def status(write: bool, output: str | None, markdown: bool):
+    """Generate a portable operator handoff / session-status document.
+
+    Produces a compact briefing: active work, PR queue, service health,
+    blockers, and ready-next tasks.
+
+    \b
+    Examples:
+
+        gptme-util status                       # stdout
+
+        gptme-util status --write               # write to status.md
+
+        gptme-util status -o /tmp/handoff.md    # write to custom path
+    """
+    doc = build_document()
+    out_path: Path | None = None
+
+    if output:
+        out_path = Path(output)
+    elif write:
+        root = _git_root()
+        out_path = (root or Path.cwd()) / "status.md"
+
+    if out_path:
+        out_path.write_text(doc)
+        click.echo(f"Written to {out_path}")
+    else:
+        click.echo(doc)
+
+
+if __name__ == "__main__":
+    status()  # pragma: no cover

--- a/gptme/cli/util.py
+++ b/gptme/cli/util.py
@@ -47,6 +47,7 @@ _LAZY_COMMANDS: dict[str, tuple[str, str]] = {
     "hooks": (".cmd_hooks", "hooks"),
     "mcp": (".cmd_mcp", "mcp"),
     "skills": (".cmd_skills", "skills"),
+    "status": (".cmd_status", "status"),
 }
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ gptme-checkpoint = "gptme.cli.checkpoint:main"
 gptme-init = "gptme.cli.cmd_init:main"
 gptme-dspy = "gptme.eval.dspy:main"
 gptme-eval-trends = "gptme.eval.trends:main"
+gptme-status = "gptme.cli.cmd_status:status"
 
 [tool.poetry]
 packages = [

--- a/tests/test_cli_status.py
+++ b/tests/test_cli_status.py
@@ -1,0 +1,41 @@
+"""Tests for gptme-util status command."""
+
+from __future__ import annotations
+
+from click.testing import CliRunner
+
+from gptme.cli.cmd_status import status
+from gptme.cli.util import main as util_main
+
+
+def test_status_output_contains_expected_sections():
+    """Verify the status output contains standard sections."""
+    runner = CliRunner()
+    result = runner.invoke(status)
+    assert result.exit_code == 0
+    assert "# gptme Status" in result.output
+    assert "## Active Work" in result.output
+    assert "## PR Queue" in result.output
+    assert "## Services" in result.output
+    assert "## Top Blockers" in result.output
+    assert "## Ready Next" in result.output
+
+
+def test_status_invoked_via_util_subcommand():
+    """Verify gptme-util status dispatches correctly."""
+    runner = CliRunner()
+    result = runner.invoke(util_main, ["status"])
+    assert result.exit_code == 0
+    assert "# gptme Status" in result.output
+
+
+def test_status_write_to_file(tmp_path):
+    """Verify --write creates a file at the repo root equivalent."""
+    runner = CliRunner()
+    output_file = tmp_path / "handoff.md"
+    result = runner.invoke(status, ["-o", str(output_file)])
+    assert result.exit_code == 0
+    assert output_file.exists()
+    content = output_file.read_text()
+    assert "# gptme Status" in content
+    assert "## Active Work" in content

--- a/tests/test_cli_status.py
+++ b/tests/test_cli_status.py
@@ -4,21 +4,20 @@ from __future__ import annotations
 
 from click.testing import CliRunner
 
-from gptme.cli.cmd_status import status
+from gptme.cli.cmd_status import _strip_markdown, status
 from gptme.cli.util import main as util_main
 
 
 def test_status_output_contains_expected_sections():
-    """Verify the status output contains standard sections."""
+    """Verify the status output contains always-present sections."""
     runner = CliRunner()
     result = runner.invoke(status)
     assert result.exit_code == 0
     assert "# gptme Status" in result.output
     assert "## Active Work" in result.output
     assert "## PR Queue" in result.output
-    assert "## Services" in result.output
-    assert "## Top Blockers" in result.output
-    assert "## Ready Next" in result.output
+    # Services/blockers/ready sections are only included in Bob's workspace
+    # (when gptme.toml + tasks/ are present); not asserted here.
 
 
 def test_status_invoked_via_util_subcommand():
@@ -39,3 +38,35 @@ def test_status_write_to_file(tmp_path):
     content = output_file.read_text()
     assert "# gptme Status" in content
     assert "## Active Work" in content
+
+
+def test_status_no_markdown():
+    """Verify --no-markdown strips heading markers from output."""
+    runner = CliRunner()
+    result = runner.invoke(status, ["--no-markdown"])
+    assert result.exit_code == 0
+    assert "# gptme Status" not in result.output
+    assert "gptme Status" in result.output
+
+
+def test_status_agent_name_from_env(monkeypatch):
+    """Verify GPTME_AGENT_NAME env var is reflected in the header."""
+    monkeypatch.setenv("GPTME_AGENT_NAME", "TestAgent")
+    runner = CliRunner()
+    result = runner.invoke(status)
+    assert result.exit_code == 0
+    assert "TestAgent" in result.output
+
+
+def test_strip_markdown_removes_headings():
+    """Unit-test the _strip_markdown helper."""
+    doc = (
+        "# Heading\n\nSome **bold** text and `code`.\n\n| a | b |\n|---|---|\n| 1 | 2 |"
+    )
+    plain = _strip_markdown(doc)
+    assert "# Heading" not in plain
+    assert "Heading" in plain
+    assert "**bold**" not in plain
+    assert "bold" in plain
+    assert "`code`" not in plain
+    assert "code" in plain


### PR DESCRIPTION
## Summary

Add `gptme-util status` (and `gptme-status`) CLI subcommand that generates a portable operator handoff document — inspired by ECC's `ecc status --markdown --write status.md`.

Phase 1 (standalone script) shipped in Bob workspace (session bbfa). This PR registers it as a first-class gptme CLI entry point.

## Changes

- **New file**: `gptme/cli/cmd_status.py` — status document generator with sections:
  - Active Work (active tasks + recent commits)
  - PR Queue (per-repo open PR counts with caps)
  - Services (systemd unit health)
  - Top Blockers (waiting tasks)
  - Ready Next (top backlog tasks)
- **Registration**: Lazy-loaded via `gptme-util status` in `util.py` + standalone `gptme-status` entry point in `pyproject.toml`
- **Tests**: `tests/test_cli_status.py` — import & smoke test

## Usage

```
gptme-util status                    # stdout
gptme-util status --write            # write to status.md
gptme-util status -o report.md       # write to custom path

# Standalone entry point (same behaviour):
gptme-status
```

## Related

- Idea backlog #463
- Phase 1 script: `scripts/gptme-status.py` (Bob workspace)
