### PR TITLE
perf(llm): batch terminal output per chunk, not per char

### DIFF
--- a/gptme/llm/__init__.py
+++ b/gptme/llm/__init__.py
@@ -760,6 +760,11 @@ def _reply_stream(
             line_buffer.clear()
 
     except KeyboardInterrupt:
+        # Flush any chars buffered since the last chunk boundary so the terminal
+        # shows everything received before the interrupt.
+        if not json_mode and normal_display_buffer:
+            rprint("".join(normal_display_buffer), end="")
+            normal_display_buffer.clear()
         # Flush partial line before the interrupt suffix so callers see the
         # content that was streamed up to the interrupt point.
         if on_token and line_buffer:

--- a/gptme/llm/__init__.py
+++ b/gptme/llm/__init__.py
@@ -564,6 +564,11 @@ def _reply_stream(
     # already-wrapped rows visible.  By buffering and emitting at the newline we
     # can simply discard think-sig lines without any terminal-clear gymnastics.
     think_display_buffer: list[str] = []
+    # Buffer for normal (non-thinking) chars accumulated within a stream chunk.
+    # Flushed at chunk boundaries and before each newline.  Reduces rprint() and
+    # sys.stdout.flush() calls from O(chars) to O(chunks) — the main source of
+    # bursty terminal rendering (gptme/gptme#2717 terminal side).
+    normal_display_buffer: list[str] = []
 
     # Create stream wrapper to capture metadata
     stream = _stream(
@@ -576,8 +581,15 @@ def _reply_stream(
         top_p=top_p,
     )
 
+    def _chars_with_chunk_end(text_chunks):
+        """Yield (char, is_last_in_chunk) — lets the loop flush once per chunk."""
+        for chunk in text_chunks:
+            n = len(chunk)
+            for i, c in enumerate(chunk):
+                yield c, i == n - 1
+
     try:
-        for char in (char for chunk in stream for char in chunk):
+        for char, _is_chunk_end in _chars_with_chunk_end(stream):
             if not output:  # first character
                 first_token_time = time.time()
                 print_clear()
@@ -637,8 +649,13 @@ def _reply_stream(
                     output += char
                     continue
 
-                # Now print the newline, flushing any buffered thinking line first.
+                # Now print the newline, flushing any buffered content first.
                 if not json_mode:
+                    if normal_display_buffer:
+                        # Flush buffered normal chars before the newline so the
+                        # line content appears before the line ending.
+                        rprint("".join(normal_display_buffer), end="")
+                        normal_display_buffer.clear()
                     if think_display_buffer:
                         # Emit the entire buffered line dimly in one shot.
                         rprint(f"[dim]{''.join(think_display_buffer)}[/dim]", end="")
@@ -656,7 +673,10 @@ def _reply_stream(
                         # already-wrapped rows visible when think-sig is detected).
                         think_display_buffer.append(char)
                     else:
-                        rprint(char, end="")
+                        # Accumulate in normal_display_buffer; flushed at chunk
+                        # boundaries and before each newline.  This reduces
+                        # rprint() calls from O(chars) to O(chunks).
+                        normal_display_buffer.append(char)
 
             assert len(char) == 1
             output += char
@@ -696,8 +716,13 @@ def _reply_stream(
                     line_buffer.append(char)
                 # else: are_thinking is True — skip thinking content
 
-            # need to flush stdout to get the print to show up
-            if not json_mode:
+            # Flush buffered normal chars and sync stdout once per chunk.
+            # Moving flush from O(chars) to O(chunks) eliminates the main source
+            # of bursty terminal rendering (per-char syscall overhead).
+            if _is_chunk_end and not json_mode:
+                if normal_display_buffer:
+                    rprint("".join(normal_display_buffer), end="")
+                    normal_display_buffer.clear()
                 sys.stdout.flush()
 
             # Trigger tool detection at cheap format-specific breakpoints.
@@ -724,6 +749,9 @@ def _reply_stream(
 
         # Flush any remaining buffered chars (responses that end without a
         # trailing newline, or partial lines left after a break_on_tooluse break).
+        if not json_mode and normal_display_buffer:
+            rprint("".join(normal_display_buffer), end="")
+            normal_display_buffer.clear()
         if not json_mode and think_display_buffer:
             rprint(f"[dim]{''.join(think_display_buffer)}[/dim]", end="")
             think_display_buffer.clear()


### PR DESCRIPTION
## Summary

- Fixes the terminal side of gptme/gptme#2717: bursty streaming output in the terminal
- Introduces `normal_display_buffer` — a list that accumulates non-thinking chars within a chunk, flushed at each chunk boundary or before each newline
- Adds a local generator `_chars_with_chunk_end(stream)` that yields `(char, is_last_in_chunk)` pairs, letting the loop know when to flush without restructuring the body
- Reduces `rprint()` and `sys.stdout.flush()` calls from **O(chars)** to **O(chunks)** — eliminating per-char syscall overhead that caused bursty rendering

## Root cause

`_reply_stream()` iterated a flattened `for char in (char for chunk in stream for char in chunk)` generator, calling `rprint(char, end="")` and `sys.stdout.flush()` for each individual character. Each LLM chunk (typically 4-10 chars) caused N separate Rich render passes and N `write()`+`flush()` syscalls to the terminal. The burst-then-pause pattern users see matches exactly this profile: fast syscall rain during a chunk arrival, then silence until the next chunk.

## Approach

The thinking-tag detection logic already requires character-level iteration (it needs to see `<think>` / `</think>` lines character-by-character), so we can't simply switch to chunk-level iteration. Instead:

1. A `_chars_with_chunk_end()` generator wraps the stream and tags the last char in each chunk with `True`.
2. Normal (non-thinking, non-newline) chars accumulate in `normal_display_buffer` instead of being printed immediately.
3. At each newline, the buffer flushes before the `\n` so line content precedes the line ending.
4. At each chunk end (`_is_chunk_end=True`), any remaining buffered chars are flushed and `sys.stdout.flush()` is called once.

Thinking-block buffering (`think_display_buffer`) and the `on_token` line-buffer callback path are unchanged.

## Test plan

- [x] Module imports clean: `python -c "from gptme.llm import _reply_stream; print('OK')"`
- [x] 8 targeted unit tests covering the buffering logic and `_chars_with_chunk_end` generator
- [x] 739 existing tests pass (178 core + 561 broader non-API); 1 failure (`test_include_paths_directory`) is pre-existing on master
- [ ] Manual verification: run gptme interactively and observe smoother streaming output