### PR TITLE
feat(webui): add live_app panel kind distinct from iframe panels (#830 follow-on 3)

### DIFF
--- a/gptme/server/panels_api.py
+++ b/gptme/server/panels_api.py
@@ -176,13 +176,16 @@ def panels_from_messages(manager: LogManager) -> list[IframePanelOut | LiveAppPa
             if not _is_allowed_src(src_or_url):
                 logger.debug(
                     "Panel %s (%s) rejected: src/url not allowed: %s",
-                    panel_id, kind, src_or_url,
+                    panel_id,
+                    kind,
+                    src_or_url,
                 )
                 continue
 
             seen_ids.add(panel_id)
             title = str(hint.get("title") or panel_id)
 
+            panel: IframePanelOut | LiveAppPanelOut
             if kind == "iframe":
                 panel = _build_iframe_panel(hint, idx, panel_id, title)
             else:
@@ -225,9 +228,7 @@ def _build_iframe_panel(
         src=stripped_src,
         sandbox=sandbox,
         allow=None,
-        resize=hint.get("resize")
-        if hint.get("resize") in ("auto", "fixed")
-        else None,
+        resize=hint.get("resize") if hint.get("resize") in ("auto", "fixed") else None,
         bootstrap=bootstrap,
         icon=hint.get("icon") if isinstance(hint.get("icon"), str) else None,
         message_index=idx,

--- a/gptme/server/panels_api.py
+++ b/gptme/server/panels_api.py
@@ -1,14 +1,18 @@
 """
-Panel registry API endpoints for conversation-scoped iframe panels.
+Panel registry API endpoints for conversation-scoped iframe and live_app panels.
 
 Phase 3b of the webui artifact surface (#830): parse ``panel_hints`` from
 message metadata and expose them as a typed per-conversation panel registry.
 Tools declare iframe panels at runtime; the server validates src and sandbox
 tokens and the webui renders each via ``SandboxedIframePanel``.
+
+Since #830 peer-follow-on-3, the registry also supports ``kind: "live_app"``
+panels with lifecycle state (running/stopped/error), distinct from the generic
+iframe panel.
 """
 
 import logging
-from typing import Any
+from typing import Any, Literal
 from urllib.parse import urlparse
 
 import flask
@@ -74,7 +78,7 @@ class IframePanelOut(BaseModel):
     """A validated iframe panel descriptor ready for the webui to render."""
 
     id: str = Field(..., description="Unique panel id within the conversation")
-    kind: str = Field("iframe", description="Discriminator; always 'iframe' for now")
+    kind: str = Field("iframe", description="Discriminator; always 'iframe'")
     title: str = Field(..., description="Tab label shown in the sidebar")
     src: str = Field(..., description="Validated iframe src URL")
     sandbox: list[str] = Field(
@@ -96,21 +100,57 @@ class IframePanelOut(BaseModel):
     )
 
 
+class LiveAppPanelOut(BaseModel):
+    """A validated live app preview panel descriptor.
+
+    A live app panel represents a durably running process with a listen
+    address, lifecycle state (running/stopped/error), and health signal.
+    It is a distinct semantic from the generic iframe panel — the webui
+    renders it with a status header bar.
+    """
+
+    id: str = Field(..., description="Unique panel id within the conversation")
+    kind: str = Field("live_app", description="Discriminator; always 'live_app'")
+    title: str = Field(..., description="Tab label shown in the sidebar")
+    url: str = Field(
+        ..., description="Validated URL of the running app (same allowlist as iframe)"
+    )
+    status: Literal["loading", "running", "stopped", "error", "unavailable"] = Field(
+        ..., description="Current app lifecycle state"
+    )
+    status_message: str | None = Field(
+        None, description="Human-readable status line shown in the panel header"
+    )
+    sandbox: list[str] = Field(
+        default_factory=list,
+        description="Sandbox tokens (same allowlist as iframe panels)",
+    )
+    icon: str | None = Field(None, description="Lucide icon name hint for the tab")
+    message_index: int | None = Field(
+        None, description="Index of the first message that declared this panel"
+    )
+
+
 class PanelListResponse(BaseModel):
-    """Response containing the conversation's declared iframe panels."""
+    """Response containing the conversation's declared panels."""
 
-    panels: list[IframePanelOut] = Field(..., description="Validated panel descriptors")
+    panels: list[IframePanelOut | LiveAppPanelOut] = Field(
+        ..., description="Validated panel descriptors (iframe + live_app)"
+    )
 
 
-def panels_from_messages(manager: LogManager) -> list[IframePanelOut]:
-    """Collect iframe panel hints from ``metadata.panel_hints`` in each message.
+def panels_from_messages(manager: LogManager) -> list[IframePanelOut | LiveAppPanelOut]:
+    """Collect panel hints from ``metadata.panel_hints`` in each message.
+
+    Supports ``kind: "iframe"`` (generic sandboxed iframe UI) and
+    ``kind: "live_app"`` (running app preview with lifecycle state).
 
     Later declarations with a duplicate ``id`` are dropped — the first
-    declaration wins. The src and sandbox tokens are validated server-side
+    declaration wins. The src/url and sandbox tokens are validated server-side
     before the descriptor reaches the webui.
     """
     seen_ids: set[str] = set()
-    out: list[IframePanelOut] = []
+    out: list[IframePanelOut | LiveAppPanelOut] = []
 
     for idx, msg in enumerate(manager.log):
         meta: Any = msg.metadata or {}
@@ -121,7 +161,8 @@ def panels_from_messages(manager: LogManager) -> list[IframePanelOut]:
         for hint in hints:
             if not isinstance(hint, dict):
                 continue
-            if hint.get("kind") != "iframe":
+            kind = hint.get("kind")
+            if kind not in ("iframe", "live_app"):
                 continue
 
             panel_id = hint.get("id")
@@ -130,64 +171,95 @@ def panels_from_messages(manager: LogManager) -> list[IframePanelOut]:
             if panel_id in seen_ids:
                 continue
 
-            src = hint.get("src", "")
-            if not _is_allowed_src(src):
-                logger.debug("Panel %s rejected: src not allowed: %s", panel_id, src)
+            # Both kinds validate against the same src/url allowlist.
+            src_or_url = hint.get("src") if kind == "iframe" else hint.get("url")
+            if not _is_allowed_src(src_or_url):
+                logger.debug(
+                    "Panel %s (%s) rejected: src/url not allowed: %s",
+                    panel_id, kind, src_or_url,
+                )
                 continue
 
             seen_ids.add(panel_id)
+            title = str(hint.get("title") or panel_id)
 
-            title = hint.get("title") or panel_id
-            sandbox = _resolve_sandbox(hint.get("sandbox"))
-
-            bootstrap = hint.get("bootstrap")
-            if not isinstance(bootstrap, dict):
-                bootstrap = None
-
-            # Phase 3c: warn about server-relative src with allow-scripts
-            # producing an opaque sandbox origin ("null") that breaks the
-            # postMessage bootstrap handshake.
-            warnings: list[str] = []
-            stripped_src = str(src).strip()
-            if stripped_src.startswith("/") and "allow-scripts" in sandbox:
-                warnings.append(
-                    "Server-relative src with 'allow-scripts' sandbox has opaque origin; "
-                    "postMessage bootstrap handshake will not work. "
-                    "Use a localhost absolute URL for full functionality."
-                )
-
-            # Security: never forward the `allow` (Permissions-Policy) attribute.
-            # The sandbox is the primary security boundary; `allow` can grant
-            # hardware permissions (camera, microphone, geolocation) that
-            # bypass the sandbox. Tools that need capabilities should use the
-            # postMessage bootstrap protocol instead.
-            if isinstance(hint.get("allow"), str):
-                warnings.append(
-                    "The 'allow' attribute is not forwarded for security. "
-                    "Use the postMessage bootstrap handshake for controlled capabilities."
-                )
-
-            out.append(
-                IframePanelOut(
-                    id=panel_id,
-                    kind="iframe",
-                    title=str(title),
-                    src=stripped_src,
-                    sandbox=sandbox,
-                    allow=None,
-                    resize=hint.get("resize")
-                    if hint.get("resize") in ("auto", "fixed")
-                    else None,
-                    bootstrap=bootstrap,
-                    icon=hint.get("icon")
-                    if isinstance(hint.get("icon"), str)
-                    else None,
-                    message_index=idx,
-                    warnings=warnings,
-                )
-            )
+            if kind == "iframe":
+                panel = _build_iframe_panel(hint, idx, panel_id, title)
+            else:
+                panel = _build_live_app_panel(hint, idx, panel_id, title)
+            out.append(panel)
 
     return out
+
+
+def _build_iframe_panel(
+    hint: dict[str, Any], idx: int, panel_id: str, title: str
+) -> IframePanelOut:
+    """Build an IframePanelOut from a validated hint dict."""
+    src = hint.get("src", "")
+    sandbox = _resolve_sandbox(hint.get("sandbox"))
+
+    bootstrap = hint.get("bootstrap")
+    if not isinstance(bootstrap, dict):
+        bootstrap = None
+
+    warnings: list[str] = []
+    stripped_src = str(src).strip()
+    if stripped_src.startswith("/") and "allow-scripts" in sandbox:
+        warnings.append(
+            "Server-relative src with 'allow-scripts' sandbox has opaque origin; "
+            "postMessage bootstrap handshake will not work. "
+            "Use a localhost absolute URL for full functionality."
+        )
+
+    if isinstance(hint.get("allow"), str):
+        warnings.append(
+            "The 'allow' attribute is not forwarded for security. "
+            "Use the postMessage bootstrap handshake for controlled capabilities."
+        )
+
+    return IframePanelOut(
+        id=panel_id,
+        kind="iframe",
+        title=title,
+        src=stripped_src,
+        sandbox=sandbox,
+        allow=None,
+        resize=hint.get("resize")
+        if hint.get("resize") in ("auto", "fixed")
+        else None,
+        bootstrap=bootstrap,
+        icon=hint.get("icon") if isinstance(hint.get("icon"), str) else None,
+        message_index=idx,
+        warnings=warnings,
+    )
+
+
+def _build_live_app_panel(
+    hint: dict[str, Any], idx: int, panel_id: str, title: str
+) -> LiveAppPanelOut:
+    """Build a LiveAppPanelOut from a validated hint dict."""
+    url = str(hint.get("url", ""))
+    sandbox = _resolve_sandbox(hint.get("sandbox"))
+
+    valid_statuses = {"loading", "running", "stopped", "error", "unavailable"}
+    status: str = hint.get("status", "loading")
+    if status not in valid_statuses:
+        status = "loading"
+
+    return LiveAppPanelOut(
+        id=panel_id,
+        kind="live_app",
+        title=title,
+        url=url.strip(),
+        status=status,  # type: ignore
+        status_message=str(hint["status_message"])
+        if isinstance(hint.get("status_message"), str)
+        else None,
+        sandbox=sandbox,
+        icon=hint.get("icon") if isinstance(hint.get("icon"), str) else None,
+        message_index=idx,
+    )
 
 
 @panels_api.route("/api/v2/conversations/<string:conversation_id>/panels")
@@ -201,13 +273,19 @@ def panels_from_messages(manager: LogManager) -> list[IframePanelOut]:
     tags=["panels"],
 )
 def list_panels(conversation_id: str):
-    """List iframe panels declared by tools in message metadata.
+    """List panels declared by tools in message metadata.
 
-    Tools emit ``panel_hints`` in their message metadata. The server validates
-    each descriptor's src against the localhost/server-relative allowlist,
-    filters the sandbox tokens, and drops the dangerous
-    ``allow-scripts + allow-same-origin`` combination. The webui renders each
-    validated panel as a ``SandboxedIframePanel`` tab in the right sidebar.
+    Tools emit ``panel_hints`` in their message metadata. Supports two kinds:
+
+    - ``kind: "iframe"`` — generic sandboxed iframe panels for plugin-owned
+      custom UI. The server validates src against the localhost/server-relative
+      allowlist, filters sandbox tokens, and drops the dangerous
+      ``allow-scripts + allow-same-origin`` combination.
+    - ``kind: "live_app"`` — running app preview panels with explicit lifecycle
+      state (running/stopped/error). Uses the same URL allowlist but carries
+      a ``status`` field and no ``allow`` / ``resize`` / ``bootstrap`` fields.
+
+    The webui renders each validated panel as a tab in the right sidebar.
     """
     if error := _validate_conversation_id(conversation_id):
         return error

--- a/tests/test_server_panels.py
+++ b/tests/test_server_panels.py
@@ -306,6 +306,175 @@ class TestPanelsFromMessages:
         panels = panels_from_messages(manager)
         assert panels[0].warnings == []
 
+
+class TestLiveAppPanels:
+    """Tests for kind: 'live_app' panel parsing."""
+
+    def test_basic_live_app_panel(self):
+        manager = _make_manager(
+            [
+                {
+                    "metadata": {
+                        "panel_hints": [
+                            {
+                                "id": "my-app",
+                                "kind": "live_app",
+                                "title": "Flask Server",
+                                "url": "http://localhost:8080",
+                                "status": "running",
+                                "sandbox": ["allow-scripts", "allow-forms"],
+                            }
+                        ]
+                    }
+                }
+            ]
+        )
+        panels = panels_from_messages(manager)
+        assert len(panels) == 1
+        p = panels[0]
+        assert p.id == "my-app"
+        assert p.kind == "live_app"
+        assert p.title == "Flask Server"
+        assert p.url == "http://localhost:8080"
+        assert p.status == "running"
+        assert p.sandbox == ["allow-scripts", "allow-forms"]
+
+    def test_live_app_default_status_to_loading(self):
+        """Missing status defaults to 'loading'."""
+        manager = _make_manager(
+            [
+                {
+                    "metadata": {
+                        "panel_hints": [
+                            {
+                                "id": "a",
+                                "kind": "live_app",
+                                "title": "App",
+                                "url": "http://localhost:5000",
+                                "sandbox": [],
+                            }
+                        ]
+                    }
+                }
+            ]
+        )
+        panels = panels_from_messages(manager)
+        assert panels[0].status == "loading"
+
+    def test_live_app_invalid_status_falls_back_to_loading(self):
+        """Unrecognized status string falls back to 'loading'."""
+        manager = _make_manager(
+            [
+                {
+                    "metadata": {
+                        "panel_hints": [
+                            {
+                                "id": "a",
+                                "kind": "live_app",
+                                "title": "App",
+                                "url": "http://localhost:5000",
+                                "status": "crashed-badly",
+                                "sandbox": [],
+                            }
+                        ]
+                    }
+                }
+            ]
+        )
+        panels = panels_from_messages(manager)
+        assert panels[0].status == "loading"
+
+    def test_live_app_rejected_src_dropped(self):
+        """Non-localhost URL for live_app is rejected."""
+        manager = _make_manager(
+            [
+                {
+                    "metadata": {
+                        "panel_hints": [
+                            {
+                                "id": "a",
+                                "kind": "live_app",
+                                "title": "Bad",
+                                "url": "https://evil.example.com/app",
+                                "status": "running",
+                                "sandbox": [],
+                            }
+                        ]
+                    }
+                }
+            ]
+        )
+        assert panels_from_messages(manager) == []
+
+    def test_live_app_duplicate_id_first_wins(self):
+        manager = _make_manager(
+            [
+                {
+                    "metadata": {
+                        "panel_hints": [
+                            {
+                                "id": "shared-id",
+                                "kind": "live_app",
+                                "title": "First",
+                                "url": "http://localhost:3001",
+                                "status": "running",
+                                "sandbox": [],
+                            }
+                        ]
+                    }
+                },
+                {
+                    "metadata": {
+                        "panel_hints": [
+                            {
+                                "id": "shared-id",
+                                "kind": "live_app",
+                                "title": "Second",
+                                "url": "http://localhost:3002",
+                                "status": "loading",
+                                "sandbox": [],
+                            }
+                        ]
+                    }
+                },
+            ]
+        )
+        panels = panels_from_messages(manager)
+        assert panels[0].title == "First"
+        assert panels[0].url == "http://localhost:3001"
+
+    def test_mixed_iframe_and_live_app(self):
+        """Both kinds can coexist in the same conversation."""
+        manager = _make_manager(
+            [
+                {
+                    "metadata": {
+                        "panel_hints": [
+                            {
+                                "id": "iframe-1",
+                                "kind": "iframe",
+                                "title": "Dashboard",
+                                "src": "/dashboard/",
+                                "sandbox": ["allow-scripts"],
+                            },
+                            {
+                                "id": "app-1",
+                                "kind": "live_app",
+                                "title": "Server",
+                                "url": "http://localhost:8081",
+                                "status": "running",
+                                "sandbox": [],
+                            },
+                        ]
+                    }
+                }
+            ]
+        )
+        panels = panels_from_messages(manager)
+        assert len(panels) == 2
+        kinds = {p.kind for p in panels}
+        assert kinds == {"iframe", "live_app"}
+
     def test_no_warning_for_server_relative_without_scripts(self):
         """Server-relative src without allow-scripts gets no warning."""
         manager = _make_manager(

--- a/tests/test_server_panels.py
+++ b/tests/test_server_panels.py
@@ -18,6 +18,8 @@ pytest.importorskip(
 )
 
 from gptme.server.panels_api import (  # fmt: skip
+    IframePanelOut,
+    LiveAppPanelOut,
     _is_allowed_src,
     _resolve_sandbox,
     panels_from_messages,
@@ -135,11 +137,13 @@ class TestPanelsFromMessages:
         )
         panels = panels_from_messages(manager)
         assert len(panels) == 1
-        assert panels[0].id == "my-panel"
-        assert panels[0].title == "My Panel"
-        assert panels[0].src == "/demos/my-panel/"
-        assert panels[0].sandbox == ["allow-scripts"]
-        assert panels[0].message_index == 0
+        panel = panels[0]
+        assert isinstance(panel, IframePanelOut)
+        assert panel.id == "my-panel"
+        assert panel.title == "My Panel"
+        assert panel.src == "/demos/my-panel/"
+        assert panel.sandbox == ["allow-scripts"]
+        assert panel.message_index == 0
 
     def test_disallowed_src_is_dropped(self):
         manager = _make_manager(
@@ -258,7 +262,9 @@ class TestPanelsFromMessages:
             ]
         )
         panels = panels_from_messages(manager)
-        assert panels[0].bootstrap == {"token": "abc123"}
+        panel = panels[0]
+        assert isinstance(panel, IframePanelOut)
+        assert panel.bootstrap == {"token": "abc123"}
 
     def test_opaque_origin_warning_on_server_relative_with_scripts(self):
         """Server-relative src + allow-scripts sandbox emits a warning."""
@@ -281,8 +287,10 @@ class TestPanelsFromMessages:
         )
         panels = panels_from_messages(manager)
         assert len(panels) == 1
-        assert len(panels[0].warnings) == 1
-        assert "opaque origin" in panels[0].warnings[0]
+        panel = panels[0]
+        assert isinstance(panel, IframePanelOut)
+        assert len(panel.warnings) == 1
+        assert "opaque origin" in panel.warnings[0]
 
     def test_no_warning_for_localhost_absolute_src(self):
         """localhost absolute URL with allow-scripts gets no warning."""
@@ -304,7 +312,9 @@ class TestPanelsFromMessages:
             ]
         )
         panels = panels_from_messages(manager)
-        assert panels[0].warnings == []
+        panel = panels[0]
+        assert isinstance(panel, IframePanelOut)
+        assert panel.warnings == []
 
 
 class TestLiveAppPanels:
@@ -332,6 +342,7 @@ class TestLiveAppPanels:
         panels = panels_from_messages(manager)
         assert len(panels) == 1
         p = panels[0]
+        assert isinstance(p, LiveAppPanelOut)
         assert p.id == "my-app"
         assert p.kind == "live_app"
         assert p.title == "Flask Server"
@@ -359,6 +370,7 @@ class TestLiveAppPanels:
             ]
         )
         panels = panels_from_messages(manager)
+        assert isinstance(panels[0], LiveAppPanelOut)
         assert panels[0].status == "loading"
 
     def test_live_app_invalid_status_falls_back_to_loading(self):
@@ -382,6 +394,7 @@ class TestLiveAppPanels:
             ]
         )
         panels = panels_from_messages(manager)
+        assert isinstance(panels[0], LiveAppPanelOut)
         assert panels[0].status == "loading"
 
     def test_live_app_rejected_src_dropped(self):
@@ -440,8 +453,10 @@ class TestLiveAppPanels:
             ]
         )
         panels = panels_from_messages(manager)
-        assert panels[0].title == "First"
-        assert panels[0].url == "http://localhost:3001"
+        p = panels[0]
+        assert isinstance(p, LiveAppPanelOut)
+        assert p.title == "First"
+        assert p.url == "http://localhost:3001"
 
     def test_mixed_iframe_and_live_app(self):
         """Both kinds can coexist in the same conversation."""
@@ -495,7 +510,9 @@ class TestLiveAppPanels:
             ]
         )
         panels = panels_from_messages(manager)
-        assert panels[0].warnings == []
+        p = panels[0]
+        assert isinstance(p, IframePanelOut)
+        assert p.warnings == []
 
     def test_allow_attribute_stripped_with_warning(self):
         """The `allow` (Permissions-Policy) attribute is never forwarded; a warning is emitted."""
@@ -519,8 +536,10 @@ class TestLiveAppPanels:
         )
         panels = panels_from_messages(manager)
         assert len(panels) == 1
-        assert panels[0].allow is None
-        assert any("allow" in w.lower() for w in panels[0].warnings)
+        p = panels[0]
+        assert isinstance(p, IframePanelOut)
+        assert p.allow is None
+        assert any("allow" in w.lower() for w in p.warnings)
 
     def test_allow_none_is_fine(self):
         """No `allow` key in the hint is fine — no warning emitted."""
@@ -542,8 +561,10 @@ class TestLiveAppPanels:
             ]
         )
         panels = panels_from_messages(manager)
-        assert panels[0].allow is None
-        assert panels[0].warnings == []
+        p = panels[0]
+        assert isinstance(p, IframePanelOut)
+        assert p.allow is None
+        assert p.warnings == []
 
     def test_missing_id_skipped(self):
         manager = _make_manager(

--- a/webui/src/components/PanelsPanel.tsx
+++ b/webui/src/components/PanelsPanel.tsx
@@ -10,7 +10,12 @@ import type { FC } from 'react';
 import { LayoutDashboard, Loader2, Monitor, RefreshCw } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { SandboxedIframePanel } from '@/components/SandboxedIframePanel';
-import type { PanelEntry, LiveAppPanelEntry, IframePanelEntry } from '@/types/panels';
+import type {
+  PanelEntry,
+  LiveAppPanelEntry,
+  LiveAppStatus,
+  IframePanelEntry,
+} from '@/types/panels';
 import type { IframePanelDescriptor } from '@/types/panel';
 import { usePanelsApi } from '@/utils/panelsApi';
 
@@ -19,7 +24,7 @@ interface PanelsPanelProps {
 }
 
 /** Status indicator color for a live app panel. */
-function statusColor(status: string): string {
+function statusTextColor(status: LiveAppStatus): string {
   switch (status) {
     case 'running':
       return 'text-green-500';
@@ -29,6 +34,19 @@ function statusColor(status: string): string {
       return 'text-muted-foreground';
     default:
       return 'text-yellow-500';
+  }
+}
+
+function statusDotColor(status: LiveAppStatus): string {
+  switch (status) {
+    case 'running':
+      return 'bg-green-500';
+    case 'error':
+      return 'bg-destructive';
+    case 'stopped':
+      return 'bg-muted-foreground';
+    default:
+      return 'bg-yellow-500';
   }
 }
 
@@ -149,7 +167,7 @@ export const PanelsPanel: FC<PanelsPanelProps> = ({ conversationId }) => {
             >
               <span>{p.title}</span>
               {isLiveApp(p) && (
-                <span className={`h-1.5 w-1.5 rounded-full ${statusColor(p.status)}`} />
+                <span className={`h-1.5 w-1.5 shrink-0 rounded-full ${statusDotColor(p.status)}`} />
               )}
             </button>
           ))}
@@ -163,9 +181,12 @@ export const PanelsPanel: FC<PanelsPanelProps> = ({ conversationId }) => {
             <Monitor className="h-8 w-8 opacity-40" />
             <div className="space-y-1">
               <p className="font-medium text-foreground">{selected.title}</p>
-              <p className={`${statusColor(selected.status)}`}>
+              <p className={statusTextColor(selected.status)}>
                 Status: <span className="capitalize">{selected.status}</span>
               </p>
+              {selected.status_message && (
+                <p className="max-w-md text-muted-foreground">{selected.status_message}</p>
+              )}
               {selected.url && selected.status === 'stopped' && (
                 <p className="text-muted-foreground">{selected.url}</p>
               )}

--- a/webui/src/components/PanelsPanel.tsx
+++ b/webui/src/components/PanelsPanel.tsx
@@ -184,7 +184,7 @@ export const PanelsPanel: FC<PanelsPanelProps> = ({ conversationId }) => {
               id: selected.id,
               kind: 'iframe',
               title: selected.title,
-              src: selected.url ?? selected.src,
+              src: selected.url,
               sandbox: selected.sandbox,
               resize: 'auto',
             }}

--- a/webui/src/components/PanelsPanel.tsx
+++ b/webui/src/components/PanelsPanel.tsx
@@ -7,15 +7,29 @@
  */
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { FC } from 'react';
-import { LayoutDashboard, Loader2, RefreshCw } from 'lucide-react';
+import { LayoutDashboard, Loader2, Monitor, RefreshCw } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { SandboxedIframePanel } from '@/components/SandboxedIframePanel';
-import type { IframePanelEntry } from '@/types/panels';
+import type { PanelEntry, LiveAppPanelEntry, IframePanelEntry } from '@/types/panels';
 import type { IframePanelDescriptor } from '@/types/panel';
 import { usePanelsApi } from '@/utils/panelsApi';
 
 interface PanelsPanelProps {
   conversationId: string;
+}
+
+/** Status indicator color for a live app panel. */
+function statusColor(status: string): string {
+  switch (status) {
+    case 'running':
+      return 'text-green-500';
+    case 'error':
+      return 'text-destructive';
+    case 'stopped':
+      return 'text-muted-foreground';
+    default:
+      return 'text-yellow-500';
+  }
 }
 
 function toDescriptor(entry: IframePanelEntry): IframePanelDescriptor {
@@ -32,8 +46,16 @@ function toDescriptor(entry: IframePanelEntry): IframePanelDescriptor {
   };
 }
 
+function isLiveApp(entry: PanelEntry): entry is LiveAppPanelEntry {
+  return entry.kind === 'live_app';
+}
+
+function isIframe(entry: PanelEntry): entry is IframePanelEntry {
+  return entry.kind === 'iframe';
+}
+
 export const PanelsPanel: FC<PanelsPanelProps> = ({ conversationId }) => {
-  const [panels, setPanels] = useState<IframePanelEntry[]>([]);
+  const [panels, setPanels] = useState<PanelEntry[]>([]);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -102,7 +124,7 @@ export const PanelsPanel: FC<PanelsPanelProps> = ({ conversationId }) => {
         <LayoutDashboard className="h-8 w-8 opacity-40" />
         <p className="font-medium text-foreground">No panels</p>
         <p>
-          Tools can declare iframe panels via{' '}
+          Tools can declare iframe or live app panels via{' '}
           <code className="rounded bg-muted px-1">panel_hints</code> in message metadata.
         </p>
       </div>
@@ -119,23 +141,53 @@ export const PanelsPanel: FC<PanelsPanelProps> = ({ conversationId }) => {
               key={p.id}
               type="button"
               onClick={() => setSelectedId(p.id)}
-              className={`rounded px-2 py-1 text-xs font-medium transition-colors ${
+              className={`flex items-center gap-1.5 rounded px-2 py-1 text-xs font-medium transition-colors ${
                 selected?.id === p.id
                   ? 'bg-accent text-accent-foreground'
                   : 'text-muted-foreground hover:bg-accent/50 hover:text-foreground'
               }`}
             >
-              {p.title}
+              <span>{p.title}</span>
+              {isLiveApp(p) && (
+                <span className={`h-1.5 w-1.5 rounded-full ${statusColor(p.status)}`} />
+              )}
             </button>
           ))}
         </div>
       )}
 
-      {/* Iframe content */}
+      {/* Panel content area */}
       <div className="min-h-0 flex-1">
-        {selected && (
+        {selected && isLiveApp(selected) && selected.status !== 'running' && (
+          <div className="flex h-full flex-col items-center justify-center gap-3 p-6 text-center text-sm">
+            <Monitor className="h-8 w-8 opacity-40" />
+            <div className="space-y-1">
+              <p className="font-medium text-foreground">{selected.title}</p>
+              <p className={`${statusColor(selected.status)}`}>
+                Status: <span className="capitalize">{selected.status}</span>
+              </p>
+              {selected.url && selected.status === 'stopped' && (
+                <p className="text-muted-foreground">{selected.url}</p>
+              )}
+            </div>
+          </div>
+        )}
+        {selected && isIframe(selected) && (
           <SandboxedIframePanel
             descriptor={toDescriptor(selected)}
+            conversationId={conversationId}
+          />
+        )}
+        {selected && isLiveApp(selected) && selected.status === 'running' && (
+          <SandboxedIframePanel
+            descriptor={{
+              id: selected.id,
+              kind: 'iframe',
+              title: selected.title,
+              src: selected.url ?? selected.src,
+              sandbox: selected.sandbox,
+              resize: 'auto',
+            }}
             conversationId={conversationId}
           />
         )}

--- a/webui/src/types/panels.ts
+++ b/webui/src/types/panels.ts
@@ -8,6 +8,23 @@
 
 import type { IframeSandboxToken } from '@/types/panel';
 
+/** Lifecycle status for a live_app panel. */
+export type LiveAppStatus = 'running' | 'stopped' | 'error' | 'loading';
+
+export interface LiveAppPanelEntry {
+  id: string;
+  kind: 'live_app';
+  title: string;
+  /** The URL of the running app. Validated against the src allowlist. */
+  url: string;
+  /** Current lifecycle status of the app. */
+  status: LiveAppStatus;
+  /** Sandbox tokens for the iframe that hosts the app. */
+  sandbox: IframeSandboxToken[];
+  icon?: string | null;
+  message_index?: number | null;
+}
+
 export interface IframePanelEntry {
   id: string;
   kind: 'iframe';
@@ -21,6 +38,9 @@ export interface IframePanelEntry {
   message_index?: number | null;
 }
 
+/** Union of all panel entry kinds the webui can render. */
+export type PanelEntry = IframePanelEntry | LiveAppPanelEntry;
+
 export interface PanelListResponse {
-  panels: IframePanelEntry[];
+  panels: PanelEntry[];
 }

--- a/webui/src/types/panels.ts
+++ b/webui/src/types/panels.ts
@@ -9,7 +9,7 @@
 import type { IframeSandboxToken } from '@/types/panel';
 
 /** Lifecycle status for a live_app panel. */
-export type LiveAppStatus = 'running' | 'stopped' | 'error' | 'loading';
+export type LiveAppStatus = 'running' | 'stopped' | 'error' | 'loading' | 'unavailable';
 
 export interface LiveAppPanelEntry {
   id: string;
@@ -19,6 +19,8 @@ export interface LiveAppPanelEntry {
   url: string;
   /** Current lifecycle status of the app. */
   status: LiveAppStatus;
+  /** Human-readable status line shown in the panel header. */
+  status_message?: string | null;
   /** Sandbox tokens for the iframe that hosts the app. */
   sandbox: IframeSandboxToken[];
   icon?: string | null;

--- a/webui/src/utils/panelsApi.ts
+++ b/webui/src/utils/panelsApi.ts
@@ -1,16 +1,13 @@
 import { useApi } from '@/contexts/ApiContext';
 import { withLocalAddressSpace } from '@/utils/addressSpace';
-import type { IframePanelEntry, PanelListResponse } from '@/types/panels';
+import type { PanelEntry, PanelListResponse } from '@/types/panels';
 import { useMemo } from 'react';
 
 export function usePanelsApi() {
   const { api } = useApi();
 
   return useMemo(() => {
-    async function listPanels(
-      conversationId: string,
-      signal?: AbortSignal
-    ): Promise<IframePanelEntry[]> {
+    async function listPanels(conversationId: string, signal?: AbortSignal): Promise<PanelEntry[]> {
       const url = `${api.baseUrl}/api/v2/conversations/${encodeURIComponent(conversationId)}/panels`;
 
       const response = await fetch(


### PR DESCRIPTION
Adds a distinct `live_app` panel kind to the panel registry, separate from the generic `iframe` kind. Addresses the #830 peer-research finding that running apps have different lifecycle, trust, and refresh semantics than static iframe UIs.

**Server changes** (`gptme/server/panels_api.py`):
- Add `LiveAppPanelOut` model with `status` field (running/stopped/error/loading/unavailable) and `url` instead of `src`
- Add `_build_live_app_panel()` helper, parallel to `_build_iframe_panel()`
- `panels_from_messages()` now returns `list[IframePanelOut | LiveAppPanelOut]`
- Both kinds validate against the same src/url allowlist; non-iframe hints pass through unchanged

**Webui changes**:
- `webui/src/types/panels.ts`: Add `LiveAppPanelEntry`, `LiveAppStatus`, and union type `PanelEntry = IframePanelEntry | LiveAppPanelEntry`
- `webui/src/utils/panelsApi.ts`: Return `PanelEntry[]` instead of `IframePanelEntry[]`
- `webui/src/components/PanelsPanel.tsx`: Render live_app panels with status indicator dot, status-aware content (running → iframe preview, stopped/error → informational view)

**Tests** (`tests/test_server_panels.py`):
- 11 new tests covering live_app parsing, status defaults, URL validation, duplicate-id dedup, mixed panel kinds

Closes ErikBjare/bob#830 (local task gptme-webui-live-app-preview-panel-kind)