### PR TITLE
feat(util): add batch mode command

### DIFF
--- a/gptme/cli/cmd_batch.py
+++ b/gptme/cli/cmd_batch.py
@@ -81,7 +81,10 @@ def _summarize_child_output(
         content = event.get("content")
         if isinstance(content, str):
             tool_calls += _count_tool_calls(content)
-            if content.startswith("Stopped: reached max steps limit"):
+            # Detection uses substring match to tolerate message format changes.
+            # The canonical source is chat.py:
+            #   Message("system", f"Stopped: reached max steps limit ({...})")
+            if "reached max steps" in content:
                 exit_reason = "max_turns"
 
     record: dict[str, Any] = {
@@ -131,6 +134,7 @@ def _run_one_prompt(
             text=True,
             timeout=timeout,
             env=env,
+            stdin=subprocess.DEVNULL,
             check=False,
         )
     except subprocess.TimeoutExpired:

--- a/gptme/cli/cmd_batch.py
+++ b/gptme/cli/cmd_batch.py
@@ -124,7 +124,7 @@ def _run_one_prompt(
     ]
     if model:
         cmd.extend(["--model", model])
-    cmd.append(prompt)
+    cmd.extend(["--", prompt])
 
     start = time.monotonic()
     try:

--- a/gptme/cli/cmd_batch.py
+++ b/gptme/cli/cmd_batch.py
@@ -1,0 +1,204 @@
+"""Batch runner for gptme utility CLI."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from typing import TYPE_CHECKING, Any
+
+import click
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from typing import TextIO
+
+
+def _read_prompts(stdin: TextIO) -> list[str]:
+    return [prompt for line in stdin if (prompt := line.strip())]
+
+
+def _usage_tokens(metadata: dict[str, Any]) -> int:
+    usage = metadata.get("usage")
+    if not isinstance(usage, dict):
+        return 0
+
+    token_keys = (
+        "input_tokens",
+        "output_tokens",
+        "cache_read_tokens",
+        "cache_creation_tokens",
+    )
+    total = 0
+    for key in token_keys:
+        value = usage.get(key, 0)
+        if isinstance(value, int):
+            total += value
+    return total
+
+
+def _iter_json_events(stdout: str) -> Iterable[dict[str, Any]]:
+    for line in stdout.splitlines():
+        if not line.strip():
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(event, dict):
+            yield event
+
+
+def _count_tool_calls(content: str) -> int:
+    from ..tools import ToolUse  # fmt: skip
+
+    return sum(1 for _tooluse in ToolUse.iter_from_content(content))
+
+
+def _summarize_child_output(
+    *,
+    index: int,
+    prompt: str,
+    duration_s: float,
+    returncode: int,
+    stdout: str,
+    stderr: str,
+) -> dict[str, Any]:
+    tokens = 0
+    tool_calls = 0
+    exit_reason = "done" if returncode == 0 else "error"
+
+    for event in _iter_json_events(stdout):
+        metadata = event.get("metadata")
+        if isinstance(metadata, dict):
+            tokens += _usage_tokens(metadata)
+
+        if event.get("type") != "message":
+            continue
+
+        content = event.get("content")
+        if isinstance(content, str):
+            tool_calls += _count_tool_calls(content)
+            if content.startswith("Stopped: reached max steps limit"):
+                exit_reason = "max_turns"
+
+    record: dict[str, Any] = {
+        "index": index,
+        "prompt": prompt,
+        "exit_reason": exit_reason,
+        "tokens": tokens,
+        "duration_s": round(duration_s, 3),
+        "tool_calls": tool_calls,
+    }
+    if returncode != 0:
+        record["returncode"] = returncode
+        if stderr.strip():
+            record["error"] = stderr.strip().splitlines()[-1]
+    return record
+
+
+def _run_one_prompt(
+    *,
+    index: int,
+    prompt: str,
+    model: str | None,
+    max_turns: int,
+    timeout: float,
+) -> dict[str, Any]:
+    env = os.environ.copy()
+    env["GPTME_MAX_STEPS"] = str(max_turns)
+
+    cmd = [
+        sys.executable,
+        "-m",
+        "gptme",
+        "--non-interactive",
+        "--output-format",
+        "json",
+        "--no-stream",
+    ]
+    if model:
+        cmd.extend(["--model", model])
+    cmd.append(prompt)
+
+    start = time.monotonic()
+    try:
+        completed = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            env=env,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        duration_s = time.monotonic() - start
+        return {
+            "index": index,
+            "prompt": prompt,
+            "exit_reason": "timeout",
+            "tokens": 0,
+            "duration_s": round(duration_s, 3),
+            "tool_calls": 0,
+            "error": f"timed out after {timeout:g}s",
+            "returncode": None,
+        }
+
+    duration_s = time.monotonic() - start
+    return _summarize_child_output(
+        index=index,
+        prompt=prompt,
+        duration_s=duration_s,
+        returncode=completed.returncode,
+        stdout=completed.stdout,
+        stderr=completed.stderr,
+    )
+
+
+@click.command("batch")
+@click.option("--model", default=None, help="Model override for every prompt.")
+@click.option(
+    "--max-turns",
+    default=20,
+    show_default=True,
+    type=click.IntRange(min=1),
+    help="Maximum gptme response/tool steps per prompt.",
+)
+@click.option(
+    "--timeout",
+    default=120.0,
+    show_default=True,
+    type=click.FloatRange(min=0.1),
+    help="Per-prompt timeout in seconds.",
+)
+@click.option(
+    "--jsonl-only",
+    is_flag=True,
+    help="Suppress progress output on stderr.",
+)
+def batch_cmd(
+    model: str | None,
+    max_turns: int,
+    timeout: float,
+    jsonl_only: bool,
+) -> None:
+    """Run stdin prompts as fresh non-interactive gptme sessions."""
+    prompts = _read_prompts(sys.stdin)
+
+    for index, prompt in enumerate(prompts):
+        record = _run_one_prompt(
+            index=index,
+            prompt=prompt,
+            model=model,
+            max_turns=max_turns,
+            timeout=timeout,
+        )
+        click.echo(json.dumps(record, sort_keys=True))
+        if not jsonl_only:
+            click.echo(
+                f"[{index + 1}/{len(prompts)}] "
+                f"{record['exit_reason']} ({record['duration_s']:.1f}s)",
+                err=True,
+            )

--- a/gptme/cli/util.py
+++ b/gptme/cli/util.py
@@ -43,6 +43,7 @@ if TYPE_CHECKING:
 
 _LAZY_COMMANDS: dict[str, tuple[str, str]] = {
     "agents": (".cmd_agents", "agents"),
+    "batch": (".cmd_batch", "batch_cmd"),
     "chats": (".cmd_chats", "chats"),
     "hooks": (".cmd_hooks", "hooks"),
     "mcp": (".cmd_mcp", "mcp"),

--- a/gptme/cli/util.py
+++ b/gptme/cli/util.py
@@ -6,6 +6,7 @@ Command groups are split into separate modules for maintainability:
 - cmd_chats.py: Chat/conversation management (list, search, export, clean, stats)
 - cmd_hooks.py: Claude Code hook installation and execution
 - cmd_mcp.py: MCP server management (list, test, info, search)
+- cmd_batch.py: Batch runner for stdin prompts as fresh non-interactive sessions
 - cmd_skills.py: Skills and lessons (list, show, search, install, validate, etc.)
 
 Inline command groups (smaller, live in this file):

--- a/tests/test_util_cli_batch.py
+++ b/tests/test_util_cli_batch.py
@@ -311,6 +311,9 @@ def test_batch_without_jsonl_only_outputs_progress(monkeypatch):
     )
 
     assert result.exit_code == 0, result.output
-    assert "[1/1]" in result.stderr
-    assert "done" in result.stderr
-    assert "0.5s" in result.stderr
+    progress_output = (
+        result.stderr if result.stderr_bytes is not None else result.output
+    )
+    assert "[1/1]" in progress_output
+    assert "done" in progress_output
+    assert "0.5s" in progress_output

--- a/tests/test_util_cli_batch.py
+++ b/tests/test_util_cli_batch.py
@@ -1,0 +1,146 @@
+"""Tests for gptme-util batch command."""
+
+from __future__ import annotations
+
+import json
+
+from click.testing import CliRunner
+
+from gptme.cli import cmd_batch
+from gptme.cli.util import main as util_main
+
+
+def _jsonl(output: str) -> list[dict]:
+    return [json.loads(line) for line in output.splitlines() if line.strip()]
+
+
+def test_batch_skips_empty_stdin_lines(monkeypatch):
+    calls: list[dict] = []
+
+    def fake_run_one_prompt(**kwargs):
+        calls.append(kwargs)
+        return {
+            "index": kwargs["index"],
+            "prompt": kwargs["prompt"],
+            "exit_reason": "done",
+            "tokens": 0,
+            "duration_s": 0.0,
+            "tool_calls": 0,
+        }
+
+    monkeypatch.setattr(cmd_batch, "_run_one_prompt", fake_run_one_prompt)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        util_main,
+        [
+            "batch",
+            "--jsonl-only",
+            "--model",
+            "test/model",
+            "--max-turns",
+            "3",
+            "--timeout",
+            "7",
+        ],
+        input="first\n\n  \nsecond\n",
+    )
+
+    assert result.exit_code == 0, result.output
+    assert _jsonl(result.output) == [
+        {
+            "duration_s": 0.0,
+            "exit_reason": "done",
+            "index": 0,
+            "prompt": "first",
+            "tokens": 0,
+            "tool_calls": 0,
+        },
+        {
+            "duration_s": 0.0,
+            "exit_reason": "done",
+            "index": 1,
+            "prompt": "second",
+            "tokens": 0,
+            "tool_calls": 0,
+        },
+    ]
+    assert [call["model"] for call in calls] == ["test/model", "test/model"]
+    assert [call["max_turns"] for call in calls] == [3, 3]
+    assert [call["timeout"] for call in calls] == [7.0, 7.0]
+
+
+def test_batch_empty_input_outputs_no_records(monkeypatch):
+    monkeypatch.setattr(
+        cmd_batch,
+        "_run_one_prompt",
+        lambda **_kwargs: (_ for _ in ()).throw(AssertionError("should not run")),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(util_main, ["batch"], input="\n \n")
+
+    assert result.exit_code == 0, result.output
+    assert result.output == ""
+
+
+def test_summarize_child_output_counts_tokens_and_max_turns():
+    stdout = "\n".join(
+        [
+            json.dumps(
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": "hello",
+                    "metadata": {
+                        "usage": {
+                            "input_tokens": 10,
+                            "output_tokens": 5,
+                            "cache_read_tokens": 2,
+                            "cache_creation_tokens": 1,
+                        }
+                    },
+                }
+            ),
+            json.dumps(
+                {
+                    "type": "message",
+                    "role": "system",
+                    "content": "Stopped: reached max steps limit (1)",
+                }
+            ),
+        ]
+    )
+
+    record = cmd_batch._summarize_child_output(
+        index=4,
+        prompt="do it",
+        duration_s=1.23456,
+        returncode=0,
+        stdout=stdout,
+        stderr="",
+    )
+
+    assert record == {
+        "duration_s": 1.235,
+        "exit_reason": "max_turns",
+        "index": 4,
+        "prompt": "do it",
+        "tokens": 18,
+        "tool_calls": 0,
+    }
+
+
+def test_summarize_child_output_reports_error_tail():
+    record = cmd_batch._summarize_child_output(
+        index=0,
+        prompt="bad",
+        duration_s=0.5,
+        returncode=2,
+        stdout="not json\n",
+        stderr="first line\nlast line\n",
+    )
+
+    assert record["exit_reason"] == "error"
+    assert record["returncode"] == 2
+    assert record["error"] == "last line"

--- a/tests/test_util_cli_batch.py
+++ b/tests/test_util_cli_batch.py
@@ -225,7 +225,7 @@ def test_run_one_prompt_invokes_child_process(monkeypatch):
 
     record = cmd_batch._run_one_prompt(
         index=2,
-        prompt="say hello",
+        prompt="--help",
         model="test/model",
         max_turns=4,
         timeout=9.5,
@@ -235,7 +235,7 @@ def test_run_one_prompt_invokes_child_process(monkeypatch):
         "duration_s": 2.25,
         "exit_reason": "done",
         "index": 2,
-        "prompt": "say hello",
+        "prompt": "--help",
         "tokens": 0,
         "tool_calls": 0,
     }
@@ -251,7 +251,8 @@ def test_run_one_prompt_invokes_child_process(monkeypatch):
         "--no-stream",
         "--model",
         "test/model",
-        "say hello",
+        "--",
+        "--help",
     ]
     assert kwargs["capture_output"] is True
     assert kwargs["text"] is True

--- a/tests/test_util_cli_batch.py
+++ b/tests/test_util_cli_batch.py
@@ -144,3 +144,85 @@ def test_summarize_child_output_reports_error_tail():
     assert record["exit_reason"] == "error"
     assert record["returncode"] == 2
     assert record["error"] == "last line"
+
+
+def test_usage_tokens_handles_missing_usage():
+    """Usage key=None should return 0 tokens."""
+    assert cmd_batch._usage_tokens({"usage": None}) == 0  # type: ignore[arg-type]
+    assert cmd_batch._usage_tokens({}) == 0
+
+
+def test_usage_tokens_handles_non_int_values():
+    """Non-int token values should be skipped."""
+    record = {"usage": {"input_tokens": "10", "output_tokens": 5}}  # type: ignore[dict-item]
+    assert cmd_batch._usage_tokens(record) == 5
+
+
+def test_iter_json_events_skips_non_dict_and_invalid():
+    lines = [
+        json.dumps({"type": "message"}),
+        "not json at all",
+        json.dumps("just a string, not a dict"),
+        "",
+        json.dumps(["a list"]),
+        json.dumps({"type": "system"}),
+    ]
+    events = list(cmd_batch._iter_json_events("\n".join(lines)))
+    assert len(events) == 2
+    assert events[0]["type"] == "message"
+    assert events[1]["type"] == "system"
+
+
+def test_summarize_child_output_error_no_stderr():
+    """Non-zero exit but no stderr — still reports error, no error key."""
+    record = cmd_batch._summarize_child_output(
+        index=0,
+        prompt="crash",
+        duration_s=1.0,
+        returncode=1,
+        stdout="",
+        stderr="",
+    )
+    assert record["exit_reason"] == "error"
+    assert record["returncode"] == 1
+    assert "error" not in record
+
+
+def test_summarize_child_output_counts_tool_calls():
+    """_count_tool_calls should detect ToolUse blocks in content."""
+    # Simulate a message that contains tool-use markers
+    content_with_tools = (
+        "Let me check that.\n\n"
+        "```shell\nls\n```\n\n"
+        "Now I'll save.\n\n"
+        "```save test.txt\nhello\n```"
+    )
+    count = cmd_batch._count_tool_calls(content_with_tools)
+    # ToolUse.iter_from_content parses fenced code blocks as tool calls
+    assert count == 2
+
+
+def test_batch_without_jsonl_only_outputs_progress(monkeypatch):
+    """--jsonl-only off (default) emits stderr progress."""
+
+    def fake_run_one_prompt(**kwargs):
+        return {
+            "index": kwargs["index"],
+            "prompt": kwargs["prompt"],
+            "exit_reason": "done",
+            "tokens": 0,
+            "duration_s": 0.5,
+            "tool_calls": 0,
+        }
+
+    monkeypatch.setattr(cmd_batch, "_run_one_prompt", fake_run_one_prompt)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        util_main, ["batch", "--model", "test/model"], input="hello\n"
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "[1/1]" in result.stderr
+    assert "done" in result.stderr
+    assert "0.5s" in result.stderr

--- a/tests/test_util_cli_batch.py
+++ b/tests/test_util_cli_batch.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 
 from click.testing import CliRunner
 
@@ -104,6 +105,13 @@ def test_summarize_child_output_counts_tokens_and_max_turns():
             ),
             json.dumps(
                 {
+                    "type": "system",
+                    "content": "ignored content",
+                    "metadata": {"usage": {"input_tokens": 3}},
+                }
+            ),
+            json.dumps(
+                {
                     "type": "message",
                     "role": "system",
                     "content": "Stopped: reached max steps limit (1)",
@@ -126,7 +134,7 @@ def test_summarize_child_output_counts_tokens_and_max_turns():
         "exit_reason": "max_turns",
         "index": 4,
         "prompt": "do it",
-        "tokens": 18,
+        "tokens": 21,
         "tool_calls": 0,
     }
 
@@ -200,6 +208,86 @@ def test_summarize_child_output_counts_tool_calls():
     count = cmd_batch._count_tool_calls(content_with_tools)
     # ToolUse.iter_from_content parses fenced code blocks as tool calls
     assert count == 2
+
+
+def test_run_one_prompt_invokes_child_process(monkeypatch):
+    calls = []
+    times = iter([10.0, 12.25])
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        stdout = json.dumps({"type": "message", "content": "done"}) + "\n"
+        return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr(cmd_batch.subprocess, "run", fake_run)
+    monkeypatch.setattr(cmd_batch.sys, "executable", "/usr/bin/python-test")
+    monkeypatch.setattr(cmd_batch.time, "monotonic", lambda: next(times))
+
+    record = cmd_batch._run_one_prompt(
+        index=2,
+        prompt="say hello",
+        model="test/model",
+        max_turns=4,
+        timeout=9.5,
+    )
+
+    assert record == {
+        "duration_s": 2.25,
+        "exit_reason": "done",
+        "index": 2,
+        "prompt": "say hello",
+        "tokens": 0,
+        "tool_calls": 0,
+    }
+    assert len(calls) == 1
+    cmd, kwargs = calls[0]
+    assert cmd == [
+        "/usr/bin/python-test",
+        "-m",
+        "gptme",
+        "--non-interactive",
+        "--output-format",
+        "json",
+        "--no-stream",
+        "--model",
+        "test/model",
+        "say hello",
+    ]
+    assert kwargs["capture_output"] is True
+    assert kwargs["text"] is True
+    assert kwargs["timeout"] == 9.5
+    assert kwargs["stdin"] is subprocess.DEVNULL
+    assert kwargs["check"] is False
+    assert kwargs["env"]["GPTME_MAX_STEPS"] == "4"
+
+
+def test_run_one_prompt_reports_timeout(monkeypatch):
+    times = iter([1.0, 4.4567])
+
+    def fake_run(cmd, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=cmd, timeout=kwargs["timeout"])
+
+    monkeypatch.setattr(cmd_batch.subprocess, "run", fake_run)
+    monkeypatch.setattr(cmd_batch.time, "monotonic", lambda: next(times))
+
+    record = cmd_batch._run_one_prompt(
+        index=1,
+        prompt="slow",
+        model=None,
+        max_turns=2,
+        timeout=2.5,
+    )
+
+    assert record == {
+        "duration_s": 3.457,
+        "error": "timed out after 2.5s",
+        "exit_reason": "timeout",
+        "index": 1,
+        "prompt": "slow",
+        "returncode": None,
+        "tokens": 0,
+        "tool_calls": 0,
+    }
 
 
 def test_batch_without_jsonl_only_outputs_progress(monkeypatch):


### PR DESCRIPTION
## Summary
- Add `gptme-util batch` to read newline-delimited prompts from stdin.
- Run each prompt as a fresh `python -m gptme --non-interactive --output-format json --no-stream` child process with `GPTME_MAX_STEPS` and per-prompt timeout controls.
- Emit one JSONL summary per prompt with index, prompt, exit_reason, tokens, duration_s, tool_calls, and error details for failures/timeouts.
- Register the command lazily and add focused util CLI tests.

## Tests
- `poetry run pytest tests/test_util_cli_batch.py tests/test_cli_status.py -q`
- `poetry run ruff check gptme/cli/cmd_batch.py gptme/cli/util.py tests/test_util_cli_batch.py`
- `poetry run mypy gptme/cli/cmd_batch.py tests/test_util_cli_batch.py`
- `poetry run pre-commit run --files gptme/cli/cmd_batch.py gptme/cli/util.py tests/test_util_cli_batch.py`
- `poetry run gptme-util batch --help`

Context: Bob task `gptme-util-batch-mode` / internal idea row 467.