### PR TITLE
fix(server): validate edited message file paths

### DIFF
--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -53,7 +53,7 @@ from ..logmanager import Log, LogManager, get_user_conversations
 from ..message import Message
 from ..tools import get_toolchain, get_tools, init_tools
 from ..util.content import is_message_command
-from ..util.uri import parse_file_reference
+from ..util.uri import FilePath, is_uri, parse_file_reference
 from .api_v2_agents import agents_api
 from .api_v2_common import (
     _abs_to_rel_workspace,
@@ -153,6 +153,31 @@ def _get_optional_string_list_field(
     if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
         return flask.jsonify({"error": f"{field} must be a list of strings"}), 400
     return value
+
+
+def _validate_message_file_references(
+    files: list[str], workspace: Path
+) -> list[FilePath] | tuple[flask.Response, int]:
+    """Validate local message attachments stay within the conversation workspace."""
+    file_paths: list[FilePath] = []
+    for f_str in files:
+        if is_uri(f_str):
+            file_paths.append(parse_file_reference(f_str))
+            continue
+
+        f = Path(f_str)
+        if f.is_absolute():
+            return (
+                flask.jsonify({"error": f"Absolute file paths are not supported: {f}"}),
+                400,
+            )
+
+        full = (workspace / f).resolve()
+        if not full.is_relative_to(workspace):
+            return flask.jsonify({"error": f"File path escapes workspace: {f}"}), 400
+
+        file_paths.append(full)
+    return file_paths
 
 
 def _persist_default_model(model: str) -> bool:
@@ -881,26 +906,12 @@ def api_conversation_post(conversation_id: str):
     files_result = _get_optional_string_list_field(req_json, "files")
     if isinstance(files_result, tuple):
         return files_result
-    file_paths: list[Path] = []
+    file_paths: list[FilePath] = []
     if files_result is not None:
-        workspace = log.workspace
-        for f_str in files_result:
-            f = Path(f_str)
-            # Reject absolute paths — they can't be relative to workspace
-            if f.is_absolute():
-                return flask.jsonify(
-                    {"error": f"Absolute file paths are not supported: {f}"}
-                ), 400
-            # Resolve relative to workspace and check it stays within
-            full = (workspace / f).resolve()
-            if not full.is_relative_to(workspace):
-                return flask.jsonify(
-                    {"error": f"File path escapes workspace: {f}"}
-                ), 400
-            # Store the resolved absolute path so the validated path is what
-            # downstream (embed_attached_file_content) actually reads, not a
-            # relative path that resolves differently depending on CWD.
-            file_paths.append(full)
+        validated_files = _validate_message_file_references(files_result, log.workspace)
+        if isinstance(validated_files, tuple):
+            return validated_files
+        file_paths = validated_files
     msg = Message(
         req_json["role"],
         req_json["content"],
@@ -1076,7 +1087,12 @@ def api_conversation_edit_message(conversation_id: str, index: int):
         if content_changed:
             replacements["content"] = content
         if files_changed and files is not None:
-            replacements["files"] = [parse_file_reference(f) for f in files]
+            validated_files = _validate_message_file_references(
+                files, manager.workspace
+            )
+            if isinstance(validated_files, tuple):
+                return validated_files
+            replacements["files"] = validated_files
         edited_msg = replace(msgs[index], **replacements)
         new_msgs = msgs[:index] + [edited_msg] + ([] if truncate else msgs[index + 1 :])
     elif truncate:

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -53,7 +53,7 @@ from ..logmanager import Log, LogManager, get_user_conversations
 from ..message import Message
 from ..tools import get_toolchain, get_tools, init_tools
 from ..util.content import is_message_command
-from ..util.uri import FilePath, is_uri, parse_file_reference
+from ..util.uri import URI, FilePath, is_uri, parse_file_reference
 from .api_v2_agents import agents_api
 from .api_v2_common import (
     _abs_to_rel_workspace,
@@ -162,7 +162,19 @@ def _validate_message_file_references(
     file_paths: list[FilePath] = []
     for f_str in files:
         if is_uri(f_str):
-            file_paths.append(parse_file_reference(f_str))
+            uri = parse_file_reference(f_str)
+            assert isinstance(uri, URI)
+            # file:// still points at local server paths and must not bypass workspace checks.
+            if uri.scheme == "file":
+                return (
+                    flask.jsonify(
+                        {
+                            "error": "file:// URIs are not supported for message attachments"
+                        }
+                    ),
+                    400,
+                )
+            file_paths.append(uri)
             continue
 
         f = Path(f_str)

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -1852,6 +1852,68 @@ def test_v2_edit_message_rejects_invalid_files_payload(
 
 
 @pytest.mark.parametrize(
+    ("files_payload", "expected_error"),
+    [
+        (["/etc/passwd"], "Absolute file paths are not supported"),
+        (["../outside.txt"], "File path escapes workspace"),
+    ],
+)
+def test_v2_edit_message_rejects_files_outside_workspace(
+    client: FlaskClient, files_payload: list[str], expected_error: str
+):
+    """Editing message files must reject local paths outside the workspace."""
+    conversation_id = create_conversation(client)["conversation_id"]
+    response = client.post(
+        f"/api/v2/conversations/{conversation_id}",
+        json={"role": "user", "content": "Original message"},
+    )
+    assert response.status_code == 200
+
+    conversation = client.get(f"/api/v2/conversations/{conversation_id}").get_json()
+    assert conversation is not None
+    user_index = len(conversation["log"]) - 1
+
+    response = client.patch(
+        f"/api/v2/conversations/{conversation_id}/messages/{user_index}",
+        json={"files": files_payload},
+    )
+
+    assert response.status_code == 400
+    assert expected_error in response.get_json()["error"]
+
+    conversation = client.get(f"/api/v2/conversations/{conversation_id}").get_json()
+    assert conversation is not None
+    assert "files" not in conversation["log"][user_index]
+
+
+def test_v2_edit_message_resolves_relative_files_against_workspace(
+    client: FlaskClient,
+):
+    """Relative edited files are stored under the conversation workspace."""
+    conversation_id = create_conversation(client)["conversation_id"]
+    response = client.post(
+        f"/api/v2/conversations/{conversation_id}",
+        json={"role": "user", "content": "Original message"},
+    )
+    assert response.status_code == 200
+
+    conversation = client.get(f"/api/v2/conversations/{conversation_id}").get_json()
+    assert conversation is not None
+    user_index = len(conversation["log"]) - 1
+
+    response = client.patch(
+        f"/api/v2/conversations/{conversation_id}/messages/{user_index}",
+        json={"files": ["attachments/ok.txt"]},
+    )
+
+    assert response.status_code == 200
+
+    conversation = client.get(f"/api/v2/conversations/{conversation_id}").get_json()
+    assert conversation is not None
+    assert conversation["log"][user_index]["files"] == ["attachments/ok.txt"]
+
+
+@pytest.mark.parametrize(
     "files_payload",
     [
         "attachments/image.png",

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -2015,6 +2015,53 @@ def test_v2_edit_message_preserves_uri_files(client: FlaskClient):
     assert conversation["log"][user_index]["files"] == [uri]
 
 
+@pytest.mark.parametrize(
+    "endpoint_builder",
+    [
+        lambda conversation_id, user_index: (
+            f"/api/v2/conversations/{conversation_id}",
+            {
+                "role": "user",
+                "content": "Test message",
+                "files": ["file:///etc/passwd"],
+            },
+            None,
+        ),
+        lambda conversation_id, user_index: (
+            f"/api/v2/conversations/{conversation_id}/messages/{user_index}",
+            {"files": ["file:///etc/passwd"]},
+            user_index,
+        ),
+    ],
+)
+def test_v2_message_file_uris_reject_file_scheme(client: FlaskClient, endpoint_builder):
+    """POST and PATCH message files must reject local file:// URIs."""
+    conversation_id = create_conversation(client)["conversation_id"]
+    response = client.post(
+        f"/api/v2/conversations/{conversation_id}",
+        json={"role": "user", "content": "Original message"},
+    )
+    assert response.status_code == 200
+
+    conversation = client.get(f"/api/v2/conversations/{conversation_id}").get_json()
+    assert conversation is not None
+    user_index = len(conversation["log"]) - 1
+
+    endpoint, payload, patched_index = endpoint_builder(conversation_id, user_index)
+    response = client.open(
+        endpoint, method="PATCH" if patched_index is not None else "POST", json=payload
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {
+        "error": "file:// URIs are not supported for message attachments"
+    }
+
+    conversation = client.get(f"/api/v2/conversations/{conversation_id}").get_json()
+    assert conversation is not None
+    assert conversation["log"][user_index].get("files") is None
+
+
 def test_v2_edit_message_rejects_non_string_content(client: FlaskClient):
     """Test that edit rejects non-string content with a 400."""
     conversation_id = create_conversation(client)["conversation_id"]


### PR DESCRIPTION
## Summary

- Add shared server-side validation for message file references.
- Apply it to edited message files so local paths must stay inside the conversation workspace.
- Preserve URI attachments and normalize accepted relative paths through the workspace.

## Root Cause

`POST /api/v2/conversations/<id>` validated local `files` entries against the conversation workspace, but `PATCH /api/v2/conversations/<id>/messages/<index>` parsed edited `files` with `parse_file_reference()` directly. That allowed absolute paths like `/etc/passwd` and traversal such as `../outside.txt` to be stored in conversation state.

## Validation

- `uv run --extra server --with requests --with pytest --with pytest-timeout python3 -m pytest tests/test_server_v2.py -q`
- `uv run --extra server --with requests --with pytest --with pytest-timeout python3 -m pytest tests/test_server_bad_input.py -q`
- `uv run --with ruff ruff check gptme/server/api_v2.py tests/test_server_v2.py`
- `git diff --check -- gptme/server/api_v2.py tests/test_server_v2.py`