### PR TITLE
feat(server): add A2A JSON-RPC MVP

### DIFF
--- a/gptme/server/a2a_api.py
+++ b/gptme/server/a2a_api.py
@@ -1,0 +1,533 @@
+"""A2A JSON-RPC surface for gptme-server."""
+
+import logging
+import os
+import time
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import flask
+from flask import request
+
+from gptme.__version__ import __version__
+
+from ..config import ChatConfig, Config
+from ..dirs import get_logs_dir
+from ..llm.models import get_default_model
+from ..logmanager import LogManager
+from ..message import Message
+from ..prompts import get_prompt
+from ..tools import get_toolchain
+from .api_v2_common import _validate_conversation_id, msg2dict
+from .auth import require_auth
+from .session_models import ConversationSession, SessionManager
+from .session_step import _start_step_thread
+
+logger = logging.getLogger(__name__)
+
+A2A_PROTOCOL_VERSION = "1.0"
+A2A_RPC_PATH = "/api/a2a"
+A2A_CONTENT_TYPE = "application/json"
+
+JSONRPC_PARSE_ERROR = -32700
+JSONRPC_INVALID_REQUEST = -32600
+JSONRPC_METHOD_NOT_FOUND = -32601
+JSONRPC_INVALID_PARAMS = -32602
+JSONRPC_INTERNAL_ERROR = -32603
+
+A2A_TASK_NOT_FOUND = -32001
+A2A_CONTENT_TYPE_NOT_SUPPORTED = -32005
+
+
+class A2AError(Exception):
+    """JSON-RPC/A2A error with a protocol code."""
+
+    def __init__(
+        self,
+        code: int,
+        message: str,
+        *,
+        reason: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.reason = reason
+        self.metadata = metadata or {}
+
+
+a2a_api = flask.Blueprint("a2a_api", __name__)
+
+
+def _json_response(payload: dict[str, Any], status: int = 200) -> flask.Response:
+    response = flask.jsonify(payload)
+    response.status_code = status
+    response.content_type = A2A_CONTENT_TYPE
+    return response
+
+
+def _rpc_result(request_id: Any, result: dict[str, Any]) -> flask.Response:
+    return _json_response({"jsonrpc": "2.0", "id": request_id, "result": result})
+
+
+def _error_data(error: A2AError) -> list[dict[str, Any]] | None:
+    if not error.reason:
+        return None
+    return [
+        {
+            "@type": "type.googleapis.com/google.rpc.ErrorInfo",
+            "reason": error.reason,
+            "domain": "a2a-protocol.org",
+            "metadata": {
+                **error.metadata,
+                "timestamp": datetime.now(tz=timezone.utc).isoformat(),
+            },
+        }
+    ]
+
+
+def _rpc_error(request_id: Any, error: A2AError, status: int = 200) -> flask.Response:
+    error_payload: dict[str, Any] = {
+        "code": error.code,
+        "message": error.message,
+    }
+    if data := _error_data(error):
+        error_payload["data"] = data
+    return _json_response(
+        {"jsonrpc": "2.0", "id": request_id, "error": error_payload}, status=status
+    )
+
+
+def _a2a_endpoint_url() -> str:
+    return request.host_url.rstrip("/") + A2A_RPC_PATH
+
+
+def _agent_card() -> dict[str, Any]:
+    return {
+        "name": "gptme",
+        "description": (
+            "Local-first terminal AI agent exposed through the Agent2Agent protocol."
+        ),
+        "supportedInterfaces": [
+            {
+                "url": _a2a_endpoint_url(),
+                "protocolBinding": "JSONRPC",
+                "protocolVersion": A2A_PROTOCOL_VERSION,
+            }
+        ],
+        "provider": {
+            "organization": "gptme",
+            "url": "https://gptme.org",
+        },
+        "version": __version__,
+        "documentationUrl": "https://gptme.org/docs/server.html",
+        "capabilities": {
+            "streaming": False,
+            "pushNotifications": False,
+            "extendedAgentCard": False,
+        },
+        "securitySchemes": {
+            "bearerAuth": {
+                "httpAuthSecurityScheme": {
+                    "scheme": "Bearer",
+                    "bearerFormat": "gptme-server-token",
+                    "description": "Use the gptme-server bearer token.",
+                }
+            }
+        },
+        "securityRequirements": [{"bearerAuth": []}],
+        "defaultInputModes": ["text/plain"],
+        "defaultOutputModes": ["text/plain"],
+        "skills": [
+            {
+                "id": "gptme-terminal-agent",
+                "name": "gptme Terminal Agent",
+                "description": (
+                    "Answer questions, inspect workspaces, and perform "
+                    "software-development tasks through gptme."
+                ),
+                "tags": ["coding", "terminal", "software-development", "agent"],
+                "examples": [
+                    "Inspect this repository and summarize the failing tests.",
+                    "Implement the smallest fix for this bug and explain the change.",
+                ],
+                "inputModes": ["text/plain"],
+                "outputModes": ["text/plain"],
+            }
+        ],
+    }
+
+
+@a2a_api.route("/.well-known/agent-card.json")
+@a2a_api.route("/.well-known/agent.json")
+def agent_card() -> flask.Response:
+    """Return the public A2A Agent Card.
+
+    `agent-card.json` is the A2A 1.0 well-known URI. `agent.json` is kept as a
+    cheap legacy alias because early A2A docs and local planning notes used it.
+    """
+    return _json_response(_agent_card())
+
+
+def _request_jsonrpc() -> dict[str, Any] | A2AError:
+    req_json = request.get_json(silent=True)
+    if req_json is None:
+        if request.get_data(cache=True):
+            return A2AError(JSONRPC_PARSE_ERROR, "Invalid JSON payload")
+        return A2AError(JSONRPC_INVALID_REQUEST, "Request payload validation error")
+    if not isinstance(req_json, dict):
+        return A2AError(JSONRPC_INVALID_REQUEST, "Request payload validation error")
+    if req_json.get("jsonrpc") != "2.0":
+        return A2AError(JSONRPC_INVALID_REQUEST, "Request payload validation error")
+    if not isinstance(req_json.get("method"), str):
+        return A2AError(JSONRPC_INVALID_REQUEST, "Request payload validation error")
+    return req_json
+
+
+def _params_object(req_json: dict[str, Any]) -> dict[str, Any]:
+    params = req_json.get("params", {})
+    if not isinstance(params, dict):
+        raise A2AError(JSONRPC_INVALID_PARAMS, "Invalid parameters")
+    return params
+
+
+def _extract_message_text(message: dict[str, Any]) -> str:
+    role = message.get("role")
+    if role not in ("ROLE_USER", "user"):
+        raise A2AError(JSONRPC_INVALID_PARAMS, "Invalid parameters")
+    parts = message.get("parts")
+    if not isinstance(parts, list) or not parts:
+        raise A2AError(JSONRPC_INVALID_PARAMS, "Invalid parameters")
+
+    texts: list[str] = []
+    for part in parts:
+        if not isinstance(part, dict):
+            raise A2AError(JSONRPC_INVALID_PARAMS, "Invalid parameters")
+        keys = [key for key in ("text", "raw", "url", "data") if key in part]
+        if len(keys) != 1:
+            raise A2AError(JSONRPC_INVALID_PARAMS, "Invalid parameters")
+        if keys[0] != "text":
+            raise A2AError(
+                A2A_CONTENT_TYPE_NOT_SUPPORTED,
+                "Content type not supported",
+                reason="CONTENT_TYPE_NOT_SUPPORTED",
+            )
+        text = part["text"]
+        if not isinstance(text, str):
+            raise A2AError(JSONRPC_INVALID_PARAMS, "Invalid parameters")
+        texts.append(text)
+
+    content = "\n\n".join(texts).strip()
+    if not content:
+        raise A2AError(JSONRPC_INVALID_PARAMS, "Invalid parameters")
+    return content
+
+
+def _validate_task_id(task_id: str) -> None:
+    if _validate_conversation_id(task_id):
+        raise A2AError(JSONRPC_INVALID_PARAMS, "Invalid parameters")
+
+
+def _new_task_id() -> str:
+    return f"a2a-{uuid.uuid4().hex}"
+
+
+def _request_chat_config(logdir: Path) -> ChatConfig:
+    config_dict: dict[str, Any] = {
+        "_logdir": logdir,
+        "chat": {
+            "workspace": "@log",
+        },
+    }
+    return ChatConfig.from_dict(config_dict, create_workspace=False)
+
+
+def _create_task_conversation(task_id: str, user_text: str) -> ConversationSession:
+    logdir = get_logs_dir() / task_id
+    request_config = _request_chat_config(logdir)
+    logdir.mkdir(parents=True, exist_ok=False)
+    chat_config = ChatConfig.load_or_create(logdir, request_config)
+
+    msgs = get_prompt(
+        tools=list(get_toolchain(chat_config.tools, strict=False)),
+        interactive=chat_config.interactive,
+        tool_format=chat_config.tool_format or "markdown",
+        model=chat_config.model,
+        prompt="full",
+        workspace=chat_config.workspace,
+        agent_path=chat_config.agent,
+    )
+    msgs.append(Message("user", user_text))
+
+    manager = LogManager.load(logdir=logdir, initial_msgs=msgs, create=True)
+    manager.write()
+
+    if not chat_config.tools:
+        chat_config.tools = [
+            tool.name for tool in get_toolchain(None) if not tool.is_mcp
+        ]
+    if not chat_config.mcp:
+        config = Config.from_workspace(chat_config.workspace)
+        chat_config.mcp = config.mcp
+    chat_config.save()
+
+    session = SessionManager.create_session(task_id)
+    SessionManager.add_event(
+        task_id,
+        {
+            "type": "message_added",
+            "message": msg2dict(msgs[-1], manager.workspace, manager.logdir),
+        },
+    )
+    return session
+
+
+def _append_task_message(task_id: str, user_text: str) -> ConversationSession:
+    manager = LogManager.load(task_id, lock=False)
+    msg = Message("user", user_text)
+    manager.append(msg)
+
+    sessions = SessionManager.get_sessions_for_conversation(task_id)
+    session = max(sessions, key=lambda item: item.last_activity, default=None)
+    if session is None:
+        session = SessionManager.create_session(task_id)
+    SessionManager.add_event(
+        task_id,
+        {
+            "type": "message_added",
+            "message": msg2dict(msg, manager.workspace, manager.logdir),
+        },
+    )
+    return session
+
+
+def _resolve_model(chat_config: ChatConfig) -> str:
+    if chat_config.model:
+        return chat_config.model
+    if default_model := get_default_model():
+        return default_model.full
+    if model := Config.from_workspace(chat_config.workspace).get_env("MODEL"):
+        return model
+    raise A2AError(JSONRPC_INVALID_PARAMS, "No model specified")
+
+
+def _run_task_blocking(task_id: str, session: ConversationSession) -> None:
+    logdir = get_logs_dir() / task_id
+    chat_config = ChatConfig.load_or_create(logdir, ChatConfig())
+    model = _resolve_model(chat_config)
+    initial_event_count = session.events_count
+
+    _start_step_thread(
+        conversation_id=task_id,
+        session=session,
+        model=model,
+        workspace=chat_config.workspace,
+        branch="main",
+        auto_confirm=False,
+        stream=False,
+    )
+
+    timeout = float(os.environ.get("GPTME_A2A_BLOCKING_TIMEOUT", "120"))
+    deadline = time.monotonic() + timeout
+    event_index = initial_event_count
+
+    while time.monotonic() < deadline:
+        events = session.get_events_since(event_index)
+        event_index += len(events)
+        for event in events:
+            event_type = event.get("type") if isinstance(event, dict) else None
+            if event_type == "generation_complete":
+                return
+            if event_type == "error":
+                raise A2AError(
+                    JSONRPC_INTERNAL_ERROR,
+                    str(event.get("error") or "Internal error"),
+                )
+        if not session.generating:
+            return
+        session.event_flag.clear()
+        session.event_flag.wait(timeout=0.1)
+
+    logger.info("A2A SendMessage timed out waiting for task %s", task_id)
+
+
+def _a2a_message_from_log(
+    msg: Message,
+    task_id: str,
+    context_id: str,
+    index: int,
+) -> dict[str, Any]:
+    role = "ROLE_AGENT" if msg.role == "assistant" else "ROLE_USER"
+    return {
+        "messageId": f"{task_id}-{index}",
+        "taskId": task_id,
+        "contextId": context_id,
+        "role": role,
+        "parts": [{"text": msg.content, "mediaType": "text/plain"}],
+    }
+
+
+def _task_from_conversation(
+    task_id: str,
+    *,
+    history_length: int | None = None,
+) -> dict[str, Any]:
+    try:
+        manager = LogManager.load(task_id, lock=False)
+    except FileNotFoundError as exc:
+        raise A2AError(
+            A2A_TASK_NOT_FOUND,
+            "Task not found",
+            reason="TASK_NOT_FOUND",
+            metadata={"taskId": task_id},
+        ) from exc
+
+    context_id = task_id
+    messages = [
+        message
+        for message in manager.log.messages
+        if message.role in ("user", "assistant")
+    ]
+    sessions = SessionManager.get_sessions_for_conversation(task_id)
+    latest_session = max(sessions, key=lambda item: item.last_activity, default=None)
+    latest_assistant = next(
+        (message for message in reversed(messages) if message.role == "assistant"),
+        None,
+    )
+
+    if latest_session and latest_session.generating:
+        state = "TASK_STATE_WORKING"
+    elif latest_session and latest_session.last_error:
+        state = "TASK_STATE_FAILED"
+    elif latest_assistant:
+        state = "TASK_STATE_COMPLETED"
+    else:
+        state = "TASK_STATE_SUBMITTED"
+
+    timestamp_source = messages[-1] if messages else None
+    timestamp = (
+        timestamp_source.timestamp
+        if timestamp_source is not None
+        else datetime.now(tz=timezone.utc)
+    )
+
+    task: dict[str, Any] = {
+        "id": task_id,
+        "contextId": context_id,
+        "status": {
+            "state": state,
+            "timestamp": timestamp.isoformat(),
+        },
+        "metadata": {
+            "conversationId": task_id,
+            "provider": "gptme",
+        },
+    }
+
+    if latest_assistant is not None:
+        response_message = _a2a_message_from_log(
+            latest_assistant, task_id, context_id, len(messages) - 1
+        )
+        task["status"]["message"] = response_message
+        task["artifacts"] = [
+            {
+                "artifactId": "assistant-response",
+                "name": "Assistant response",
+                "parts": [
+                    {"text": latest_assistant.content, "mediaType": "text/plain"}
+                ],
+            }
+        ]
+
+    if history_length is None:
+        history_messages = messages
+    elif history_length <= 0:
+        history_messages = []
+    else:
+        history_messages = messages[-history_length:]
+    if history_messages:
+        start_index = len(messages) - len(history_messages)
+        task["history"] = [
+            _a2a_message_from_log(message, task_id, context_id, start_index + offset)
+            for offset, message in enumerate(history_messages)
+        ]
+
+    return task
+
+
+def _handle_send_message(params: dict[str, Any]) -> dict[str, Any]:
+    message = params.get("message")
+    if not isinstance(message, dict):
+        raise A2AError(JSONRPC_INVALID_PARAMS, "Invalid parameters")
+
+    user_text = _extract_message_text(message)
+    task_id = message.get("taskId")
+    context_id = message.get("contextId")
+    if task_id is not None and not isinstance(task_id, str):
+        raise A2AError(JSONRPC_INVALID_PARAMS, "Invalid parameters")
+    if context_id is not None and not isinstance(context_id, str):
+        raise A2AError(JSONRPC_INVALID_PARAMS, "Invalid parameters")
+    if task_id and context_id and task_id != context_id:
+        raise A2AError(JSONRPC_INVALID_PARAMS, "Invalid parameters")
+
+    if task_id:
+        _validate_task_id(task_id)
+        if not (get_logs_dir() / task_id).exists():
+            raise A2AError(
+                A2A_TASK_NOT_FOUND,
+                "Task not found",
+                reason="TASK_NOT_FOUND",
+                metadata={"taskId": task_id},
+            )
+        session = _append_task_message(task_id, user_text)
+    else:
+        task_id = _new_task_id()
+        session = _create_task_conversation(task_id, user_text)
+
+    _run_task_blocking(task_id, session)
+    return {"task": _task_from_conversation(task_id)}
+
+
+def _handle_get_task(params: dict[str, Any]) -> dict[str, Any]:
+    task_id = params.get("id")
+    if not isinstance(task_id, str) or not task_id.strip():
+        raise A2AError(JSONRPC_INVALID_PARAMS, "Invalid parameters")
+    _validate_task_id(task_id)
+
+    history_length = params.get("historyLength")
+    if history_length is not None and type(history_length) is not int:
+        raise A2AError(JSONRPC_INVALID_PARAMS, "Invalid parameters")
+    return {"task": _task_from_conversation(task_id, history_length=history_length)}
+
+
+@a2a_api.route(A2A_RPC_PATH, methods=["POST"])
+@require_auth
+def a2a_rpc() -> flask.Response:
+    req_json = _request_jsonrpc()
+    if isinstance(req_json, A2AError):
+        return _rpc_error(None, req_json)
+
+    request_id = req_json.get("id")
+    method = req_json["method"]
+
+    try:
+        params = _params_object(req_json)
+        if method == "SendMessage":
+            result = _handle_send_message(params)
+        elif method == "GetTask":
+            result = _handle_get_task(params)
+        else:
+            raise A2AError(JSONRPC_METHOD_NOT_FOUND, "Method not found")
+    except A2AError as exc:
+        return _rpc_error(request_id, exc)
+    except Exception:
+        logger.exception("Unhandled A2A RPC error")
+        return _rpc_error(
+            request_id,
+            A2AError(JSONRPC_INTERNAL_ERROR, "Internal error"),
+        )
+
+    return _rpc_result(request_id, result)

--- a/gptme/server/a2a_api.py
+++ b/gptme/server/a2a_api.py
@@ -1,5 +1,6 @@
 """A2A JSON-RPC surface for gptme-server."""
 
+import json
 import logging
 import os
 import time
@@ -39,6 +40,11 @@ JSONRPC_INTERNAL_ERROR = -32603
 
 A2A_TASK_NOT_FOUND = -32001
 A2A_CONTENT_TYPE_NOT_SUPPORTED = -32005
+
+# Sentinel file written to a task's logdir when its blocking run fails. It lets
+# GetTask report TASK_STATE_FAILED even after the in-memory session is GC'd
+# (the session holds last_error, which is lost once the session is collected).
+A2A_FAILURE_SENTINEL = "a2a_failed.json"
 
 
 class A2AError(Exception):
@@ -314,6 +320,49 @@ def _resolve_model(chat_config: ChatConfig) -> str:
     raise A2AError(JSONRPC_INVALID_PARAMS, "No model specified")
 
 
+def _failure_sentinel_path(task_id: str) -> Path:
+    return get_logs_dir() / task_id / A2A_FAILURE_SENTINEL
+
+
+def _write_failure_sentinel(task_id: str, error: BaseException) -> None:
+    """Persist a task failure so GetTask can report FAILED after session GC."""
+    path = _failure_sentinel_path(task_id)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(
+                {
+                    "error": str(error),
+                    "ts": datetime.now(tz=timezone.utc).isoformat(),
+                }
+            )
+        )
+    except OSError:
+        logger.exception("Failed to write A2A failure sentinel for %s", task_id)
+
+
+def _read_failure_sentinel(task_id: str) -> dict[str, Any] | None:
+    path = _failure_sentinel_path(task_id)
+    try:
+        data = json.loads(path.read_text())
+    except FileNotFoundError:
+        return None
+    except (OSError, json.JSONDecodeError):
+        logger.warning("Ignoring invalid A2A failure sentinel for %s", task_id)
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _clear_failure_sentinel(task_id: str) -> None:
+    """Remove a stale failure sentinel, e.g. when a task is resumed for retry."""
+    try:
+        _failure_sentinel_path(task_id).unlink()
+    except FileNotFoundError:
+        pass
+    except OSError:
+        logger.exception("Failed to clear A2A failure sentinel for %s", task_id)
+
+
 def _run_task_blocking(task_id: str, session: ConversationSession) -> None:
     logdir = get_logs_dir() / task_id
     chat_config = ChatConfig.load_or_create(logdir, ChatConfig())
@@ -338,31 +387,39 @@ def _run_task_blocking(task_id: str, session: ConversationSession) -> None:
     deadline = time.monotonic() + timeout
     event_index = initial_event_count
 
-    while time.monotonic() < deadline:
-        events = session.get_events_since(event_index)
-        event_index += len(events)
-        for event in events:
-            event_type = event.get("type") if isinstance(event, dict) else None
-            if event_type == "generation_complete":
-                # generation_complete fires BEFORE session.generating = False
-                # (the finally block runs after the event). Wait briefly for
-                # generating to settle so _task_from_conversation sees the
-                # correct state instead of TASK_STATE_WORKING.
-                for _ in range(10):  # ~1s max
-                    if not session.generating:
-                        break
-                    session.event_flag.clear()
-                    session.event_flag.wait(timeout=0.1)
+    try:
+        while time.monotonic() < deadline:
+            events = session.get_events_since(event_index)
+            event_index += len(events)
+            for event in events:
+                event_type = event.get("type") if isinstance(event, dict) else None
+                if event_type == "generation_complete":
+                    # generation_complete fires BEFORE session.generating = False
+                    # (the finally block runs after the event). Wait briefly for
+                    # generating to settle so _task_from_conversation sees the
+                    # correct state instead of TASK_STATE_WORKING.
+                    for _ in range(10):  # ~1s max
+                        if not session.generating:
+                            break
+                        session.event_flag.clear()
+                        session.event_flag.wait(timeout=0.1)
+                    return
+                if event_type == "error":
+                    raise A2AError(
+                        JSONRPC_INTERNAL_ERROR,
+                        str(event.get("error") or "Internal error"),
+                        reason="TASK_FAILED",
+                        metadata={"taskId": task_id},
+                    )
+            if not session.generating:
                 return
-            if event_type == "error":
-                raise A2AError(
-                    JSONRPC_INTERNAL_ERROR,
-                    str(event.get("error") or "Internal error"),
-                )
-        if not session.generating:
-            return
-        session.event_flag.clear()
-        session.event_flag.wait(timeout=0.1)
+            session.event_flag.clear()
+            session.event_flag.wait(timeout=0.1)
+    except Exception as exc:
+        # Persist the failure so a later GetTask (after the session is GC'd)
+        # can still report TASK_STATE_FAILED instead of WORKING/COMPLETED.
+        _write_failure_sentinel(task_id, exc)
+        raise
 
     logger.info("A2A SendMessage timed out waiting for task %s", task_id)
     # Return task in WORKING state so the client knows to poll with GetTask.
@@ -416,9 +473,14 @@ def _task_from_conversation(
         (-1, None),
     )
 
+    failure = _read_failure_sentinel(task_id)
     if latest_session and latest_session.generating:
         state = "TASK_STATE_WORKING"
     elif latest_session and latest_session.last_error:
+        state = "TASK_STATE_FAILED"
+    elif failure is not None:
+        # The session that ran this task has been GC'd, but a sentinel records
+        # that it failed — surface FAILED instead of COMPLETED/SUBMITTED.
         state = "TASK_STATE_FAILED"
     elif latest_assistant:
         state = "TASK_STATE_COMPLETED"
@@ -459,6 +521,16 @@ def _task_from_conversation(
                 ],
             }
         ]
+
+    if state == "TASK_STATE_FAILED" and failure is not None:
+        error_text = str(failure.get("error") or "Task failed")
+        task.setdefault("artifacts", []).append(
+            {
+                "artifactId": "error",
+                "name": "Task error",
+                "parts": [{"text": error_text, "mediaType": "text/plain"}],
+            }
+        )
 
     if history_length is None:
         history_messages = messages
@@ -501,6 +573,10 @@ def _handle_send_message(params: dict[str, Any]) -> dict[str, Any]:
                 metadata={"taskId": task_id},
             )
         session = _append_task_message(task_id, user_text)
+
+        # Resuming a task clears any prior failure sentinel: the new message
+        # triggers a fresh run, so the old failure no longer reflects state.
+        _clear_failure_sentinel(task_id)
 
         # Guard: don't spawn a second step thread if the session is already
         # generating — the new message is appended and the existing thread

--- a/gptme/server/a2a_api.py
+++ b/gptme/server/a2a_api.py
@@ -326,6 +326,10 @@ def _run_task_blocking(task_id: str, session: ConversationSession) -> None:
         model=model,
         workspace=chat_config.workspace,
         branch="main",
+        # MVP: tool execution is not auto-confirmed. Tasks that require tools
+        # return TASK_STATE_WORKING; clients should poll with GetTask.
+        # Full tool execution (auto_confirm=True + waiting for the agent loop)
+        # is deferred to a subsequent A2A phase.
         auto_confirm=False,
         stream=False,
     )
@@ -340,6 +344,15 @@ def _run_task_blocking(task_id: str, session: ConversationSession) -> None:
         for event in events:
             event_type = event.get("type") if isinstance(event, dict) else None
             if event_type == "generation_complete":
+                # generation_complete fires BEFORE session.generating = False
+                # (the finally block runs after the event). Wait briefly for
+                # generating to settle so _task_from_conversation sees the
+                # correct state instead of TASK_STATE_WORKING.
+                for _ in range(10):  # ~1s max
+                    if not session.generating:
+                        break
+                    session.event_flag.clear()
+                    session.event_flag.wait(timeout=0.1)
                 return
             if event_type == "error":
                 raise A2AError(

--- a/gptme/server/a2a_api.py
+++ b/gptme/server/a2a_api.py
@@ -488,6 +488,18 @@ def _handle_send_message(params: dict[str, Any]) -> dict[str, Any]:
                 metadata={"taskId": task_id},
             )
         session = _append_task_message(task_id, user_text)
+
+        # Guard: don't spawn a second step thread if the session is already
+        # generating — the new message is appended and the existing thread
+        # will process it or the client can poll with GetTask.
+        sessions = SessionManager.get_sessions_for_conversation(task_id)
+        latest_session = max(sessions, key=lambda s: s.last_activity, default=session)
+        if latest_session.generating:
+            logger.info(
+                "Task %s is already generating; returning current state",
+                task_id,
+            )
+            return {"task": _task_from_conversation(task_id)}
     else:
         task_id = _new_task_id()
         session = _create_task_conversation(task_id, user_text)

--- a/gptme/server/a2a_api.py
+++ b/gptme/server/a2a_api.py
@@ -46,6 +46,13 @@ A2A_CONTENT_TYPE_NOT_SUPPORTED = -32005
 # (the session holds last_error, which is lost once the session is collected).
 A2A_FAILURE_SENTINEL = "a2a_failed.json"
 
+# Marker file written to a task's logdir when the conversation is created via the
+# A2A endpoint. Task IDs are namespace-fenced to A2A-created conversations: a
+# missing marker means the conversation belongs to another surface (webui, CLI,
+# …) and must not be reachable as an A2A task, so GetTask/resume report it as
+# not found rather than leaking arbitrary user conversations.
+A2A_ORIGIN_MARKER = "a2a_origin.json"
+
 
 class A2AError(Exception):
     """JSON-RPC/A2A error with a protocol code."""
@@ -255,6 +262,7 @@ def _create_task_conversation(task_id: str, user_text: str) -> ConversationSessi
     logdir = get_logs_dir() / task_id
     request_config = _request_chat_config(logdir)
     logdir.mkdir(parents=True, exist_ok=False)
+    _write_origin_marker(task_id)
     chat_config = ChatConfig.load_or_create(logdir, request_config)
 
     msgs = get_prompt(
@@ -318,6 +326,43 @@ def _resolve_model(chat_config: ChatConfig) -> str:
     if model := Config.from_workspace(chat_config.workspace).get_env("MODEL"):
         return model
     raise A2AError(JSONRPC_INVALID_PARAMS, "No model specified")
+
+
+def _origin_marker_path(task_id: str) -> Path:
+    return get_logs_dir() / task_id / A2A_ORIGIN_MARKER
+
+
+def _write_origin_marker(task_id: str) -> None:
+    """Mark a conversation as A2A-created so its task ID is reachable via A2A."""
+    path = _origin_marker_path(task_id)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(
+                {
+                    "a2a_origin": True,
+                    "ts": datetime.now(tz=timezone.utc).isoformat(),
+                }
+            )
+        )
+    except OSError:
+        logger.exception("Failed to write A2A origin marker for %s", task_id)
+
+
+def _require_a2a_origin(task_id: str) -> None:
+    """Reject task IDs for conversations not created via the A2A endpoint.
+
+    Without this fence any valid gptme conversation ID would be readable and
+    resumable through ``/api/a2a``. A2A clients should only reach the tasks they
+    created, so a missing marker surfaces as TASK_NOT_FOUND.
+    """
+    if not _origin_marker_path(task_id).exists():
+        raise A2AError(
+            A2A_TASK_NOT_FOUND,
+            "Task not found",
+            reason="TASK_NOT_FOUND",
+            metadata={"taskId": task_id},
+        )
 
 
 def _failure_sentinel_path(task_id: str) -> Path:
@@ -446,6 +491,7 @@ def _task_from_conversation(
     *,
     history_length: int | None = None,
 ) -> dict[str, Any]:
+    _require_a2a_origin(task_id)
     try:
         manager = LogManager.load(task_id, lock=False)
     except FileNotFoundError as exc:
@@ -572,6 +618,9 @@ def _handle_send_message(params: dict[str, Any]) -> dict[str, Any]:
                 reason="TASK_NOT_FOUND",
                 metadata={"taskId": task_id},
             )
+        # Fence resume to A2A-created conversations: reject before appending so a
+        # non-A2A conversation is never mutated via the agent endpoint.
+        _require_a2a_origin(task_id)
         session = _append_task_message(task_id, user_text)
 
         # Resuming a task clears any prior failure sentinel: the new message

--- a/gptme/server/a2a_api.py
+++ b/gptme/server/a2a_api.py
@@ -352,6 +352,7 @@ def _run_task_blocking(task_id: str, session: ConversationSession) -> None:
         session.event_flag.wait(timeout=0.1)
 
     logger.info("A2A SendMessage timed out waiting for task %s", task_id)
+    # Return task in WORKING state so the client knows to poll with GetTask.
 
 
 def _a2a_message_from_log(
@@ -393,9 +394,13 @@ def _task_from_conversation(
     ]
     sessions = SessionManager.get_sessions_for_conversation(task_id)
     latest_session = max(sessions, key=lambda item: item.last_activity, default=None)
-    latest_assistant = next(
-        (message for message in reversed(messages) if message.role == "assistant"),
-        None,
+    latest_assistant_index, latest_assistant = next(
+        (
+            (len(messages) - 1 - i, m)
+            for i, m in enumerate(reversed(messages))
+            if m.role == "assistant"
+        ),
+        (-1, None),
     )
 
     if latest_session and latest_session.generating:
@@ -429,7 +434,7 @@ def _task_from_conversation(
 
     if latest_assistant is not None:
         response_message = _a2a_message_from_log(
-            latest_assistant, task_id, context_id, len(messages) - 1
+            latest_assistant, task_id, context_id, latest_assistant_index
         )
         task["status"]["message"] = response_message
         task["artifacts"] = [

--- a/gptme/server/app.py
+++ b/gptme/server/app.py
@@ -83,6 +83,7 @@ def create_app(
 
     # Register v2 API, workspace API, tasks API, and auth API
     # noreorder
+    from .a2a_api import a2a_api  # fmt: skip
     from .api_v2 import v2_api  # fmt: skip
     from .artifacts_api import artifacts_api  # fmt: skip
     from .auth import auth_api  # fmt: skip
@@ -92,6 +93,7 @@ def create_app(
     from .tts_api import tts_api  # fmt: skip
     from .workspace_api import workspace_api  # fmt: skip
 
+    app.register_blueprint(a2a_api)
     app.register_blueprint(v2_api)
     app.register_blueprint(auth_api)
     app.register_blueprint(workspace_api)

--- a/tests/test_server_a2a.py
+++ b/tests/test_server_a2a.py
@@ -231,6 +231,102 @@ def test_a2a_get_task_not_found_returns_a2a_error(client, monkeypatch, tmp_path)
     assert data["error"]["data"][0]["reason"] == "TASK_NOT_FOUND"
 
 
+def test_a2a_rejects_non_a2a_conversation(client, monkeypatch, tmp_path):
+    """Task IDs are namespace-fenced: a conversation not created via A2A (no
+    origin marker) must report TASK_NOT_FOUND for both GetTask and resume,
+    instead of leaking arbitrary user conversations through the agent endpoint.
+    """
+    monkeypatch.setenv("GPTME_LOGS_HOME", str(tmp_path))
+
+    # A conversation that exists on disk but was created by another surface
+    # (webui/CLI): no a2a_origin.json marker.
+    task_id = "a2a-foreign-conversation"
+    (tmp_path / task_id).mkdir(parents=True)
+
+    get_task_response = client.post(
+        "/api/a2a",
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "GetTask",
+            "params": {"id": task_id},
+        },
+    )
+    assert get_task_response.status_code == 200
+    get_error = get_task_response.get_json()["error"]
+    assert get_error["code"] == -32001
+    assert get_error["data"][0]["reason"] == "TASK_NOT_FOUND"
+
+    resume_response = client.post(
+        "/api/a2a",
+        json={
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "SendMessage",
+            "params": {
+                "message": {
+                    "role": "ROLE_USER",
+                    "parts": [{"text": "resume foreign conversation"}],
+                    "messageId": "client-message-1",
+                    "taskId": task_id,
+                }
+            },
+        },
+    )
+    assert resume_response.status_code == 200
+    resume_error = resume_response.get_json()["error"]
+    assert resume_error["code"] == -32001
+    assert resume_error["data"][0]["reason"] == "TASK_NOT_FOUND"
+
+
+def test_a2a_send_message_writes_origin_marker(client, monkeypatch, tmp_path):
+    """A2A-created conversations get an origin marker so their task IDs stay
+    reachable via GetTask/resume while foreign conversations do not."""
+    import gptme.server.a2a_api as a2a_api_module
+    import gptme.server.session_step as session_step_module
+    from gptme.logmanager import LogManager
+    from gptme.message import Message
+    from gptme.server.api_v2_common import EventType
+
+    monkeypatch.setenv("GPTME_LOGS_HOME", str(tmp_path))
+
+    def fake_prompt(**kwargs):
+        return [Message("system", "test prompt")]
+
+    def fake_start_step_thread(
+        conversation_id,
+        session,
+        model,
+        workspace,
+        branch="main",
+        auto_confirm=False,
+        stream=True,
+    ):
+        manager = LogManager.load(conversation_id, lock=False)
+        manager.append(Message("assistant", "A2A response"))
+        session_step_module.SessionManager.add_event(
+            conversation_id,
+            cast(
+                EventType,
+                {
+                    "type": "generation_complete",
+                    "message": {"role": "assistant", "content": "A2A response"},
+                },
+            ),
+        )
+        session.generating = False
+
+    monkeypatch.setattr(a2a_api_module, "get_prompt", fake_prompt)
+    monkeypatch.setattr(
+        a2a_api_module, "_resolve_model", lambda chat_config: "openai/gpt-4o-mini"
+    )
+    monkeypatch.setattr(a2a_api_module, "_start_step_thread", fake_start_step_thread)
+
+    response = client.post("/api/a2a", json=_send_message_request("hello"))
+    task_id = response.get_json()["result"]["task"]["id"]
+    assert (tmp_path / task_id / "a2a_origin.json").exists()
+
+
 def test_a2a_unknown_method_returns_jsonrpc_error(client):
     response = client.post(
         "/api/a2a",

--- a/tests/test_server_a2a.py
+++ b/tests/test_server_a2a.py
@@ -69,7 +69,8 @@ def test_a2a_send_message_and_get_task(client, monkeypatch, tmp_path):
         manager = LogManager.load(conversation_id, lock=False)
         msg = Message("assistant", "A2A response")
         manager.append(msg)
-        session.generating = False
+        # Emit generation_complete BEFORE clearing generating, matching production
+        # order in session_step.py (event fires, then finally block clears flag).
         session_step_module.SessionManager.add_event(
             conversation_id,
             cast(
@@ -80,6 +81,7 @@ def test_a2a_send_message_and_get_task(client, monkeypatch, tmp_path):
                 },
             ),
         )
+        session.generating = False
 
     monkeypatch.setattr(a2a_api_module, "get_prompt", fake_prompt)
     monkeypatch.setattr(

--- a/tests/test_server_a2a.py
+++ b/tests/test_server_a2a.py
@@ -117,6 +117,101 @@ def test_a2a_send_message_and_get_task(client, monkeypatch, tmp_path):
     assert fetched["history"][0]["role"] == "ROLE_AGENT"
 
 
+def test_a2a_failed_task_persists_after_session_gc(client, monkeypatch, tmp_path):
+    """A failed task must still report FAILED via GetTask after session GC.
+
+    The in-memory session holds ``last_error``; once it is garbage-collected,
+    GetTask falls back to a ``a2a_failed.json`` sentinel written at failure time
+    instead of inferring WORKING/COMPLETED.
+    """
+    import gptme.server.a2a_api as a2a_api_module
+    import gptme.server.session_step as session_step_module
+    from gptme.message import Message
+    from gptme.server.api_v2_common import EventType
+
+    monkeypatch.setenv("GPTME_LOGS_HOME", str(tmp_path))
+
+    def fake_prompt(**kwargs):
+        return [Message("system", "test prompt")]
+
+    def fake_start_step_thread(
+        conversation_id,
+        session,
+        model,
+        workspace,
+        branch="main",
+        auto_confirm=False,
+        stream=True,
+    ):
+        # Simulate a step-thread crash: emit an error event, then stop.
+        session_step_module.SessionManager.add_event(
+            conversation_id,
+            cast(EventType, {"type": "error", "error": "step thread crashed"}),
+        )
+        session.generating = False
+
+    monkeypatch.setattr(a2a_api_module, "get_prompt", fake_prompt)
+    monkeypatch.setattr(
+        a2a_api_module, "_resolve_model", lambda chat_config: "openai/gpt-4o-mini"
+    )
+    monkeypatch.setattr(a2a_api_module, "_start_step_thread", fake_start_step_thread)
+
+    response = client.post("/api/a2a", json=_send_message_request("trigger failure"))
+
+    assert response.status_code == 200
+    error = response.get_json()["error"]
+    assert error["code"] == -32603
+    assert error["data"][0]["reason"] == "TASK_FAILED"
+    task_id = error["data"][0]["metadata"]["taskId"]
+    assert task_id.startswith("a2a-")
+    assert (tmp_path / task_id / "a2a_failed.json").exists()
+
+    # Simulate session GC: no live session remains for the conversation.
+    monkeypatch.setattr(
+        a2a_api_module.SessionManager,
+        "get_sessions_for_conversation",
+        staticmethod(lambda conversation_id: []),
+    )
+
+    get_task_response = client.post(
+        "/api/a2a",
+        json={
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "GetTask",
+            "params": {"id": task_id},
+        },
+    )
+
+    assert get_task_response.status_code == 200
+    fetched = get_task_response.get_json()["result"]["task"]
+    assert fetched["status"]["state"] == "TASK_STATE_FAILED"
+    error_artifacts = [
+        a for a in fetched.get("artifacts", []) if a["artifactId"] == "error"
+    ]
+    assert error_artifacts
+    assert "step thread crashed" in error_artifacts[0]["parts"][0]["text"]
+
+
+def test_a2a_resume_clears_failure_sentinel(client, monkeypatch, tmp_path):
+    """Resuming a failed task (SendMessage with its id) clears the sentinel."""
+    import gptme.server.a2a_api as a2a_api_module
+
+    monkeypatch.setenv("GPTME_LOGS_HOME", str(tmp_path))
+
+    # Create a minimal task conversation with a failure sentinel in place.
+    task_id = "a2a-resume-test"
+    logdir = tmp_path / task_id
+    logdir.mkdir(parents=True)
+    a2a_api_module._write_failure_sentinel(task_id, RuntimeError("boom"))
+    assert a2a_api_module._read_failure_sentinel(task_id) is not None
+
+    a2a_api_module._clear_failure_sentinel(task_id)
+    assert a2a_api_module._read_failure_sentinel(task_id) is None
+    # Clearing a missing sentinel is a no-op, not an error.
+    a2a_api_module._clear_failure_sentinel(task_id)
+
+
 def test_a2a_get_task_not_found_returns_a2a_error(client, monkeypatch, tmp_path):
     monkeypatch.setenv("GPTME_LOGS_HOME", str(tmp_path))
 

--- a/tests/test_server_a2a.py
+++ b/tests/test_server_a2a.py
@@ -1,0 +1,174 @@
+from typing import cast
+
+import pytest
+
+flask = pytest.importorskip(
+    "flask", reason="flask not installed, install server extras (-E server)"
+)
+
+
+def _send_message_request(text: str, request_id: int = 1) -> dict:
+    return {
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "method": "SendMessage",
+        "params": {
+            "message": {
+                "role": "ROLE_USER",
+                "parts": [{"text": text}],
+                "messageId": "client-message-1",
+            }
+        },
+    }
+
+
+def test_a2a_agent_card(client):
+    response = client.get("/.well-known/agent-card.json")
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["name"] == "gptme"
+    assert data["supportedInterfaces"][0]["url"].endswith("/api/a2a")
+    assert data["supportedInterfaces"][0]["protocolBinding"] == "JSONRPC"
+    assert data["supportedInterfaces"][0]["protocolVersion"] == "1.0"
+    assert (
+        data["securitySchemes"]["bearerAuth"]["httpAuthSecurityScheme"]["scheme"]
+        == "Bearer"
+    )
+    assert data["skills"][0]["id"] == "gptme-terminal-agent"
+
+
+def test_a2a_legacy_agent_card_alias(client):
+    response = client.get("/.well-known/agent.json")
+
+    assert response.status_code == 200
+    assert response.get_json()["supportedInterfaces"][0]["url"].endswith("/api/a2a")
+
+
+def test_a2a_send_message_and_get_task(client, monkeypatch, tmp_path):
+    import gptme.server.a2a_api as a2a_api_module
+    import gptme.server.session_step as session_step_module
+    from gptme.logmanager import LogManager
+    from gptme.message import Message
+    from gptme.server.api_v2_common import EventType
+
+    monkeypatch.setenv("GPTME_LOGS_HOME", str(tmp_path))
+
+    def fake_prompt(**kwargs):
+        return [Message("system", "test prompt")]
+
+    def fake_start_step_thread(
+        conversation_id,
+        session,
+        model,
+        workspace,
+        branch="main",
+        auto_confirm=False,
+        stream=True,
+    ):
+        manager = LogManager.load(conversation_id, lock=False)
+        msg = Message("assistant", "A2A response")
+        manager.append(msg)
+        session.generating = False
+        session_step_module.SessionManager.add_event(
+            conversation_id,
+            cast(
+                EventType,
+                {
+                    "type": "generation_complete",
+                    "message": {"role": "assistant", "content": "A2A response"},
+                },
+            ),
+        )
+
+    monkeypatch.setattr(a2a_api_module, "get_prompt", fake_prompt)
+    monkeypatch.setattr(
+        a2a_api_module,
+        "_resolve_model",
+        lambda chat_config: "openai/gpt-4o-mini",
+    )
+    monkeypatch.setattr(a2a_api_module, "_start_step_thread", fake_start_step_thread)
+
+    response = client.post("/api/a2a", json=_send_message_request("hello from A2A"))
+
+    assert response.status_code == 200
+    data = response.get_json()
+    task = data["result"]["task"]
+    assert task["id"].startswith("a2a-")
+    assert task["status"]["state"] == "TASK_STATE_COMPLETED"
+    assert task["artifacts"][0]["parts"][0]["text"] == "A2A response"
+
+    get_task_response = client.post(
+        "/api/a2a",
+        json={
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "GetTask",
+            "params": {"id": task["id"], "historyLength": 1},
+        },
+    )
+
+    assert get_task_response.status_code == 200
+    fetched = get_task_response.get_json()["result"]["task"]
+    assert fetched["id"] == task["id"]
+    assert fetched["status"]["state"] == "TASK_STATE_COMPLETED"
+    assert fetched["history"][0]["role"] == "ROLE_AGENT"
+
+
+def test_a2a_get_task_not_found_returns_a2a_error(client, monkeypatch, tmp_path):
+    monkeypatch.setenv("GPTME_LOGS_HOME", str(tmp_path))
+
+    response = client.post(
+        "/api/a2a",
+        json={
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "GetTask",
+            "params": {"id": "a2a-missing-task"},
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["error"]["code"] == -32001
+    assert data["error"]["data"][0]["reason"] == "TASK_NOT_FOUND"
+
+
+def test_a2a_unknown_method_returns_jsonrpc_error(client):
+    response = client.post(
+        "/api/a2a",
+        json={"jsonrpc": "2.0", "id": 4, "method": "Nope", "params": {}},
+    )
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["error"]["code"] == -32601
+
+
+def test_a2a_malformed_json_returns_parse_error(client):
+    response = client.post("/api/a2a", data="{", content_type="application/json")
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["error"]["code"] == -32700
+
+
+def test_a2a_rpc_requires_auth_on_network_binding(monkeypatch):
+    from gptme.server.app import create_app
+    from gptme.server.auth import init_auth, set_server_token
+
+    app = create_app(host="0.0.0.0")
+    set_server_token("a2a-test-token")
+    init_auth(host="0.0.0.0", display=False)
+
+    with app.test_client() as test_client:
+        missing = test_client.post("/api/a2a", json=_send_message_request("hello"))
+        ok = test_client.post(
+            "/api/a2a",
+            json={"jsonrpc": "2.0", "id": 5, "method": "Nope", "params": {}},
+            headers={"Authorization": "Bearer a2a-test-token"},
+        )
+
+    assert missing.status_code == 401
+    assert ok.status_code == 200
+    assert ok.get_json()["error"]["code"] == -32601


### PR DESCRIPTION
## What

- Add a public A2A Agent Card at `/.well-known/agent-card.json`, with `/.well-known/agent.json` kept as a legacy alias.
- Add an authenticated JSON-RPC endpoint at `/api/a2a` with MVP `SendMessage` and `GetTask` methods.
- Map A2A task IDs onto existing gptme conversation logs so `GetTask` can recover task state from persisted history.
- Cover Agent Card discovery, RPC success, `TaskNotFoundError`, unknown methods, malformed JSON, and network-bound auth.

## Why

A2A 1.0 gives gptme a standard inbound agent-to-agent delegation surface. This is the smallest useful server slice: discovery plus blocking `SendMessage`/`GetTask`, without streaming, push notifications, or registry publishing.

Part of #2717.

## Validation

- `uv run ruff check gptme/server/a2a_api.py tests/test_server_a2a.py`
- `uv run ruff format --check gptme/server/a2a_api.py tests/test_server_a2a.py`
- `uv run pytest tests/test_server_a2a.py tests/test_server_auth.py -q` (11 passed)
- `uv run pytest tests/test_server.py tests/test_server_bad_input.py tests/test_server_cors.py tests/test_server_webui_dir.py -q` (65 passed)
- `git commit` / `prek` hooks passed