### PR TITLE
fix(webui): improve chat composer mobile ergonomics

### DIFF
--- a/webui/src/components/ChatInput.tsx
+++ b/webui/src/components/ChatInput.tsx
@@ -1040,8 +1040,8 @@ export const ChatInput: FC<Props> = ({
   return (
     <form onSubmit={handleSubmit} className="p-2 sm:p-4">
       <p id={inputHelpId} className="sr-only">
-        Press Enter to send, Shift Enter for a new line, and Escape to stop generation or leave the
-        message field.
+        Press Enter to send, Shift Enter for a new line, and Escape to cancel, stop generation, or
+        leave the message field.
       </p>
       {/* Hidden file input */}
       <input
@@ -1185,7 +1185,7 @@ export const ChatInput: FC<Props> = ({
                 ) : (
                   /* Normal mode: full toolbar */
                   <>
-                    <div className="absolute bottom-1.5 left-1.5 right-12 flex max-h-14 flex-wrap items-center gap-1.5 overflow-hidden sm:gap-2">
+                    <div className="absolute bottom-1.5 left-1.5 right-12 flex min-w-0 flex-nowrap items-center gap-1.5 overflow-x-auto overflow-y-hidden pr-1 sm:gap-2">
                       <ModelBadge
                         model={effectiveModel}
                         models={modelInfos}

--- a/webui/src/components/ChatInput.tsx
+++ b/webui/src/components/ChatInput.tsx
@@ -17,6 +17,7 @@ import {
   useState,
   useEffect,
   useRef,
+  useId,
   useCallback,
   type FC,
   type Dispatch,
@@ -367,9 +368,10 @@ const OptionsButton: FC<{ isDisabled: boolean; children: React.ReactNode }> = ({
         size="sm"
         className="h-5 rounded-sm px-1.5 text-[10px] text-muted-foreground transition-all hover:bg-accent hover:text-muted-foreground hover:opacity-100"
         disabled={isDisabled}
+        aria-label="More chat options"
       >
         <Settings className="mr-0.5 h-2.5 w-2.5" />
-        Options
+        <span className="hidden sm:inline">Options</span>
       </Button>
     </PopoverTrigger>
     <PopoverContent className="w-80" align="start">
@@ -387,6 +389,7 @@ const SubmitButton: FC<{ isGenerating: boolean; isDisabled: boolean; hasText: bo
   // When not generating: show "Send"
   const showQueue = isGenerating && hasText;
   const showStop = isGenerating && !hasText;
+  const canSubmit = !isDisabled && (isGenerating || hasText);
 
   return (
     <Button
@@ -398,7 +401,7 @@ const SubmitButton: FC<{ isGenerating: boolean; isDisabled: boolean; hasText: bo
             ? 'bg-blue-600 p-3 text-white hover:bg-blue-700'
             : 'h-8 w-8 bg-green-600 text-green-100'
       }`}
-      disabled={isDisabled}
+      disabled={!canSubmit}
       aria-label={showStop ? 'Stop generation' : showQueue ? 'Queue message' : 'Send message'}
     >
       {showStop ? (
@@ -668,6 +671,7 @@ export const ChatInput: FC<Props> = ({
   );
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const inputHelpId = useId();
   // Stable string key derived from editFiles — prevents the useEffect below from
   // firing on every render due to new array references from the parent.
   const editFileKey = editFiles?.join('\0') ?? '';
@@ -1034,7 +1038,11 @@ export const ChatInput: FC<Props> = ({
   };
 
   return (
-    <form onSubmit={handleSubmit} className="p-4">
+    <form onSubmit={handleSubmit} className="p-2 sm:p-4">
+      <p id={inputHelpId} className="sr-only">
+        Press Enter to send, Shift Enter for a new line, and Escape to stop generation or leave the
+        message field.
+      </p>
       {/* Hidden file input */}
       <input
         ref={fileInputRef}
@@ -1117,10 +1125,12 @@ export const ChatInput: FC<Props> = ({
                   onKeyDown={handleKeyDown}
                   onPaste={handlePaste}
                   placeholder={editMode ? 'Edit message...' : placeholder}
+                  aria-label={editMode ? 'Edit message' : 'Chat message'}
+                  aria-describedby={inputHelpId}
                   className={
                     editMode
-                      ? 'max-h-[300px] min-h-[60px] resize-none overflow-y-auto pb-8'
-                      : 'max-h-[400px] min-h-[60px] resize-none overflow-y-auto pb-8 pr-16'
+                      ? 'max-h-[min(42vh,300px)] min-h-[60px] resize-none overflow-y-auto pb-12 sm:pb-8'
+                      : 'max-h-[min(42vh,400px)] min-h-[60px] resize-none overflow-y-auto pb-16 pr-14 sm:pb-8 sm:pr-16'
                   }
                   disabled={isDisabled}
                   autoFocus={editMode}
@@ -1175,7 +1185,7 @@ export const ChatInput: FC<Props> = ({
                 ) : (
                   /* Normal mode: full toolbar */
                   <>
-                    <div className="absolute bottom-1.5 left-1.5 flex items-center gap-2">
+                    <div className="absolute bottom-1.5 left-1.5 right-12 flex max-h-14 flex-wrap items-center gap-1.5 overflow-hidden sm:gap-2">
                       <ModelBadge
                         model={effectiveModel}
                         models={modelInfos}
@@ -1194,9 +1204,10 @@ export const ChatInput: FC<Props> = ({
                         disabled={isDisabled}
                         onClick={() => fileInputRef.current?.click()}
                         title="Attach files"
+                        aria-label="Attach files"
                       >
                         <Paperclip className="mr-0.5 h-2.5 w-2.5" />
-                        Attach
+                        <span className="hidden sm:inline">Attach</span>
                       </Button>
 
                       <OptionsButton isDisabled={isDisabled}>

--- a/webui/src/components/__tests__/ChatInput.test.tsx
+++ b/webui/src/components/__tests__/ChatInput.test.tsx
@@ -151,6 +151,31 @@ describe('ChatInput', () => {
     await waitFor(() => expect(screen.queryByText('test.txt')).not.toBeInTheDocument());
   });
 
+  it('labels the composer and disables empty sends', async () => {
+    const autoFocus$ = observable(false);
+    const onSend = jest.fn();
+
+    render(<ChatInput conversationId="conv-a" onSend={onSend} autoFocus$={autoFocus$} />);
+
+    const input = screen.getByRole('textbox', { name: 'Chat message' });
+    expect(input).toHaveAccessibleDescription(/Press Enter to send/);
+
+    const sendButton = screen.getByRole('button', { name: 'Send message' });
+    expect(sendButton).toBeDisabled();
+
+    fireEvent.change(input, { target: { value: 'ship the refresh' } });
+    expect(sendButton).toBeEnabled();
+
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    await waitFor(() => {
+      expect(onSend).toHaveBeenCalledWith(
+        'ship the refresh',
+        expect.objectContaining({ stream: true, workspace: '.' })
+      );
+    });
+  });
+
   it('preserves existing attachments in edit mode', async () => {
     const autoFocus$ = observable(false);
     const onEditSave = jest.fn();

--- a/webui/src/components/__tests__/ChatInput.test.tsx
+++ b/webui/src/components/__tests__/ChatInput.test.tsx
@@ -4,6 +4,11 @@ import { observable } from '@legendapp/state';
 import { ChatInput } from '../ChatInput';
 
 const mockUploadFiles = jest.fn();
+const mockConversation$ = observable({
+  isGenerating: false,
+  executingTool: null,
+  chatConfig: { chat: {} },
+});
 
 jest.mock('@/contexts/SettingsContext', () => ({
   useSettings: () => ({
@@ -45,16 +50,9 @@ jest.mock('@/stores/sidebar', () => {
 });
 
 jest.mock('@/stores/conversations', () => {
-  const { observable } = jest.requireActual('@legendapp/state');
   return {
     conversations$: {
-      get: jest.fn(() =>
-        observable({
-          isGenerating: false,
-          executingTool: null,
-          chatConfig: { chat: {} },
-        })
-      ),
+      get: jest.fn(() => mockConversation$),
     },
     setMaxTokens: jest.fn(),
     setTemperature: jest.fn(),
@@ -127,6 +125,11 @@ describe('ChatInput', () => {
       ],
     });
     window.localStorage.clear();
+    mockConversation$.set({
+      isGenerating: false,
+      executingTool: null,
+      chatConfig: { chat: {} },
+    });
   });
 
   it('clears attached files when the conversation changes', async () => {
@@ -174,6 +177,28 @@ describe('ChatInput', () => {
         expect.objectContaining({ stream: true, workspace: '.' })
       );
     });
+  });
+
+  it('keeps the stop action enabled while generating without text', () => {
+    const autoFocus$ = observable(false);
+    mockConversation$.set({
+      isGenerating: true,
+      executingTool: null,
+      chatConfig: { chat: {} },
+    });
+
+    render(
+      <ChatInput
+        conversationId="conv-a"
+        onSend={jest.fn()}
+        onInterrupt={jest.fn().mockResolvedValue(undefined)}
+        autoFocus$={autoFocus$}
+      />
+    );
+
+    const stopButton = screen.getByRole('button', { name: 'Stop generation' });
+    expect(stopButton).toBeEnabled();
+    expect(stopButton).toHaveTextContent('Stop');
   });
 
   it('preserves existing attachments in edit mode', async () => {


### PR DESCRIPTION
## What changed

Phase 1 audit found three high-impact chat composer pain points:

1. The mobile composer toolbar could collide with the send control or overflow at narrow widths.
2. The message textarea depended on placeholder text instead of a stable accessible name and shortcut description.
3. The send button stayed enabled for an empty, idle composer, which created a dead primary action for keyboard and screen-reader users.

This PR fixes two of those directly and improves the third:

- gives the composer textarea an explicit accessible name and screen-reader shortcut help
- disables the idle send button until text or attachments exist, while preserving the generating-state Stop action
- reduces mobile composer padding, caps textarea height by viewport, lets toolbar controls wrap within the send-button boundary, and switches secondary toolbar labels to icon-first on small screens
- adds a focused ChatInput regression test for the accessible composer and empty-send behavior

## Validation

- `npm ci`
- `npm test -- ChatInput.test.tsx --runInBand`
- `npm run typecheck`
- `npm run build`
- `npx prettier --check src/components/ChatInput.tsx src/components/__tests__/ChatInput.test.tsx`
- `git diff --check -- webui/src/components/ChatInput.tsx webui/src/components/__tests__/ChatInput.test.tsx`
- Playwright mobile smoke at 375x812 against local Vite `/chat`: page rendered with the disabled composer visible and toolbar/bottom-nav controls fitting. Console errors were limited to expected `127.0.0.1:5700` connection/CORS failures because no local gptme server was running.

`npm run build` completed with existing Browserslist staleness and large chunk warnings.
