### PR TITLE
fix(util): reject empty batch model override

### DIFF
--- a/gptme/cli/cmd_batch.py
+++ b/gptme/cli/cmd_batch.py
@@ -39,6 +39,15 @@ def _usage_tokens(metadata: dict[str, Any]) -> int:
     return total
 
 
+def _validate_model_param(
+    ctx: click.Context, param: click.Parameter, value: str | None
+) -> str | None:
+    """Reject empty --model before spawning child gptme sessions."""
+    if value is not None and not value.strip():
+        raise click.BadParameter("Model name cannot be empty.", ctx=ctx, param=param)
+    return value
+
+
 def _iter_json_events(stdout: str) -> Iterable[dict[str, Any]]:
     for line in stdout.splitlines():
         if not line.strip():
@@ -122,7 +131,7 @@ def _run_one_prompt(
         "json",
         "--no-stream",
     ]
-    if model:
+    if model is not None:
         cmd.extend(["--model", model])
     cmd.extend(["--", prompt])
 
@@ -162,7 +171,12 @@ def _run_one_prompt(
 
 
 @click.command("batch")
-@click.option("--model", default=None, help="Model override for every prompt.")
+@click.option(
+    "--model",
+    default=None,
+    callback=_validate_model_param,
+    help="Model override for every prompt.",
+)
 @click.option(
     "--max-turns",
     default=20,

--- a/tests/test_util_cli_batch.py
+++ b/tests/test_util_cli_batch.py
@@ -85,6 +85,24 @@ def test_batch_empty_input_outputs_no_records(monkeypatch):
     assert result.output == ""
 
 
+def test_batch_empty_model_rejected_before_child_spawn(monkeypatch):
+    monkeypatch.setattr(
+        cmd_batch,
+        "_run_one_prompt",
+        lambda **_kwargs: (_ for _ in ()).throw(AssertionError("should not run")),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        util_main,
+        ["batch", "--model", ""],
+        input="hello\n",
+    )
+
+    assert result.exit_code != 0
+    assert "Model name cannot be empty." in result.output
+
+
 def test_summarize_child_output_counts_tokens_and_max_turns():
     stdout = "\n".join(
         [


### PR DESCRIPTION
## What

Reject explicit empty `gptme-util batch --model` values at the Click boundary before spawning child `gptme` sessions.

## Why

Dogfooding the fresh batch CLI surface found that `--model ''` was treated as no override because `_run_one_prompt()` checked `if model:`. That silently fell back to the configured default model and could start real child sessions instead of reporting a usage error.

## Validation

- `uv run --with pytest --with requests pytest tests/test_util_cli_batch.py -q` (`13 passed`)
- `uv run --with ruff ruff check gptme/cli/cmd_batch.py tests/test_util_cli_batch.py`
- `uv run --with ruff ruff format --check gptme/cli/cmd_batch.py tests/test_util_cli_batch.py`
- `git diff --check -- gptme/cli/cmd_batch.py tests/test_util_cli_batch.py`
- Replayed `gptme-util batch --model ''` and whitespace-only model repros; both now exit with `Invalid value for '--model': Model name cannot be empty.`