### PR TITLE
fix(webui): trigger placeholder chat initial step

### DIFF
--- a/webui/src/components/MainLayout.tsx
+++ b/webui/src/components/MainLayout.tsx
@@ -326,6 +326,39 @@ const MainLayout: FC<Props> = ({ conversationId, taskId }) => {
     [createTaskMutation, selectedTaskId, navigate]
   );
 
+  const getSelectedConversationSummary = useCallback(
+    (selectedConversation: string): ConversationSummary => {
+      const conversation = allConversations.find((conv) => conv.id === selectedConversation);
+      if (conversation) return conversation;
+
+      const storeConversation = conversations$.get(selectedConversation)?.get();
+      if (storeConversation) {
+        // Create conversation summary even if no messages yet - let ConversationContent handle loading
+        return {
+          id: selectedConversation,
+          name: storeConversation.data.name || 'New conversation',
+          modified: storeConversation.lastMessage
+            ? new Date(storeConversation.lastMessage.timestamp || Date.now()).getTime()
+            : Date.now(),
+          messages: storeConversation.data.log?.length || 0,
+          workspace: storeConversation.data.workspace || '.',
+          readonly: false,
+        };
+      }
+
+      // Even if not in store yet, create a minimal conversation to trigger ConversationContent loading
+      return {
+        id: selectedConversation,
+        name: 'Loading...',
+        modified: Date.now(),
+        messages: 0,
+        workspace: '.',
+        readonly: false,
+      };
+    },
+    [allConversations]
+  );
+
   // Immediately clear conversation state when no conversationId is provided
   if (!conversationId && !taskId) {
     if (selectedConversation$.get() !== '' || conversation$.get() !== undefined) {
@@ -338,38 +371,7 @@ const MainLayout: FC<Props> = ({ conversationId, taskId }) => {
   // Update conversation$ when selected conversation changes
   useObserveEffect(selectedConversation$, ({ value: selectedConversation }) => {
     if (selectedConversation) {
-      let conversation = allConversations.find((conv) => conv.id === selectedConversation);
-
-      // If not found in allConversations, check the conversations store directly
-      if (!conversation) {
-        const storeConversation = conversations$.get(selectedConversation)?.get();
-
-        if (storeConversation) {
-          // Create conversation summary even if no messages yet - let ConversationContent handle loading
-          conversation = {
-            id: selectedConversation,
-            name: storeConversation.data.name || 'New conversation',
-            modified: storeConversation.lastMessage
-              ? new Date(storeConversation.lastMessage.timestamp || Date.now()).getTime()
-              : Date.now(),
-            messages: storeConversation.data.log?.length || 0,
-            workspace: storeConversation.data.workspace || '.',
-            readonly: false,
-          };
-        } else {
-          // Even if not in store yet, create a minimal conversation to trigger ConversationContent loading
-          conversation = {
-            id: selectedConversation,
-            name: 'Loading...',
-            modified: Date.now(),
-            messages: 0,
-            workspace: '.',
-            readonly: false,
-          };
-        }
-      }
-
-      conversation$.set(conversation);
+      conversation$.set(getSelectedConversationSummary(selectedConversation));
     } else {
       conversation$.set(undefined);
     }
@@ -378,14 +380,13 @@ const MainLayout: FC<Props> = ({ conversationId, taskId }) => {
   useEffect(() => {
     const selectedId = selectedConversation$.get();
     if (selectedId) {
-      const selectedConversation = allConversations.find((conv) => conv.id === selectedId);
-      conversation$.set(selectedConversation);
+      conversation$.set(getSelectedConversationSummary(selectedId));
     } else {
       // Ensure conversation is cleared when no conversation is selected
       conversation$.set(undefined);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [allConversations]); // conversation$ is an observable we're setting, not reading
+  }, [allConversations, getSelectedConversationSummary]); // conversation$ is an observable we're setting, not reading
 
   // Update document title
   useObserveEffect(conversation$, ({ value: conversation }) => {

--- a/webui/src/hooks/__tests__/useConversation.test.tsx
+++ b/webui/src/hooks/__tests__/useConversation.test.tsx
@@ -101,5 +101,11 @@ describe('useConversation', () => {
     );
     expect(conversations$.get('chat-placeholder')?.needsInitialStep.get()).toBe(false);
     expect(conversations$.get('chat-placeholder')?.initialStepStream.get()).toBeUndefined();
+    expect(
+      Object.prototype.hasOwnProperty.call(
+        conversations$.get('chat-placeholder')?.peek() ?? {},
+        'initialStepStream'
+      )
+    ).toBe(false);
   });
 });

--- a/webui/src/hooks/__tests__/useConversation.test.tsx
+++ b/webui/src/hooks/__tests__/useConversation.test.tsx
@@ -1,0 +1,105 @@
+import { observable } from '@legendapp/state';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { useApi } from '@/contexts/ApiContext';
+import { conversations$, initConversation } from '@/stores/conversations';
+import { useConversation } from '../useConversation';
+
+jest.mock('@/contexts/ApiContext', () => ({
+  useApi: jest.fn(),
+}));
+
+jest.mock('@/components/ui/use-toast', () => ({
+  useToast: () => ({ toast: jest.fn() }),
+}));
+
+jest.mock('@/utils/audio', () => ({
+  playChime: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('@/utils/notifications', () => ({
+  notifyGenerationComplete: jest.fn().mockResolvedValue(undefined),
+  notifyToolConfirmation: jest.fn().mockResolvedValue(undefined),
+}));
+
+describe('useConversation', () => {
+  const mockedUseApi = useApi as jest.MockedFunction<typeof useApi>;
+  const subscribeToEvents = jest.fn().mockResolvedValue(undefined);
+  const step = jest.fn().mockResolvedValue(undefined);
+  const closeEventStream = jest.fn();
+  let eventHandlers:
+    | {
+        onConnected?: () => void;
+      }
+    | undefined;
+
+  beforeEach(() => {
+    conversations$.set(new Map());
+    subscribeToEvents.mockImplementation((_conversationId, handlers) => {
+      eventHandlers = handlers;
+      return Promise.resolve();
+    });
+    step.mockClear();
+    closeEventStream.mockClear();
+
+    initConversation(
+      'chat-placeholder',
+      {
+        id: 'chat-placeholder',
+        name: 'New conversation',
+        log: [
+          {
+            role: 'user',
+            content: 'What is gptme?',
+            timestamp: '2026-06-07T00:00:00.000Z',
+          },
+        ],
+        logfile: 'chat-placeholder',
+        branches: {},
+        workspace: '.',
+      },
+      { needsInitialStep: true, initialStepStream: false }
+    );
+
+    mockedUseApi.mockReturnValue({
+      getClient: () =>
+        ({
+          subscribeToEvents,
+          step,
+          closeEventStream,
+          getConversation: jest.fn(),
+          getChatConfig: jest.fn(),
+        }) as any,
+      isConnected$: observable(true),
+    } as any);
+  });
+
+  afterEach(() => {
+    eventHandlers = undefined;
+    jest.clearAllMocks();
+  });
+
+  it('clears placeholder initial-step state after subscription connects', async () => {
+    renderHook(() => useConversation('chat-placeholder'));
+
+    await waitFor(() => {
+      expect(subscribeToEvents).toHaveBeenCalledTimes(1);
+    });
+
+    await act(async () => {
+      eventHandlers?.onConnected?.();
+      await Promise.resolve();
+    });
+
+    expect(step).toHaveBeenCalledWith(
+      'chat-placeholder',
+      undefined,
+      false,
+      'main',
+      undefined,
+      undefined,
+      undefined
+    );
+    expect(conversations$.get('chat-placeholder')?.needsInitialStep.get()).toBe(false);
+    expect(conversations$.get('chat-placeholder')?.initialStepStream.get()).toBeUndefined();
+  });
+});

--- a/webui/src/hooks/useConversation.ts
+++ b/webui/src/hooks/useConversation.ts
@@ -24,7 +24,6 @@ import {
   initConversation,
   selectedConversation$,
   updateConversationName,
-  setNeedsInitialStep,
   setMaxTokens,
   setTemperature,
   setTopP,
@@ -374,7 +373,10 @@ export function useConversation(conversationId: string, serverId?: string) {
               if (needsStep) {
                 console.log('[useConversation] Triggering initial step after subscription');
                 const initialStepStream = conversation$?.initialStepStream?.get();
-                setNeedsInitialStep(conversationId, false);
+                updateConversation(conversationId, {
+                  needsInitialStep: false,
+                  initialStepStream: undefined,
+                });
                 api
                   .step(
                     conversationId,

--- a/webui/src/hooks/useConversation.ts
+++ b/webui/src/hooks/useConversation.ts
@@ -373,9 +373,18 @@ export function useConversation(conversationId: string, serverId?: string) {
               const needsStep = conversation$?.needsInitialStep?.get();
               if (needsStep) {
                 console.log('[useConversation] Triggering initial step after subscription');
+                const initialStepStream = conversation$?.initialStepStream?.get();
                 setNeedsInitialStep(conversationId, false);
                 api
-                  .step(conversationId, undefined, true, 'main', maxTokens, temperature, topP)
+                  .step(
+                    conversationId,
+                    undefined,
+                    initialStepStream ?? true,
+                    'main',
+                    maxTokens,
+                    temperature,
+                    topP
+                  )
                   .catch((error) => {
                     console.error('[useConversation] Error triggering initial step:', error);
                     toastStepStartError(toast, error);

--- a/webui/src/hooks/useConversation.ts
+++ b/webui/src/hooks/useConversation.ts
@@ -24,6 +24,7 @@ import {
   initConversation,
   selectedConversation$,
   updateConversationName,
+  clearInitialStepState,
   setMaxTokens,
   setTemperature,
   setTopP,
@@ -373,10 +374,7 @@ export function useConversation(conversationId: string, serverId?: string) {
               if (needsStep) {
                 console.log('[useConversation] Triggering initial step after subscription');
                 const initialStepStream = conversation$?.initialStepStream?.get();
-                updateConversation(conversationId, {
-                  needsInitialStep: false,
-                  initialStepStream: undefined,
-                });
+                clearInitialStepState(conversationId);
                 api
                   .step(
                     conversationId,

--- a/webui/src/stores/conversations.ts
+++ b/webui/src/stores/conversations.ts
@@ -1,4 +1,4 @@
-import { mergeIntoObservable, observable } from '@legendapp/state';
+import { batch, mergeIntoObservable, observable } from '@legendapp/state';
 import type { ChatConfig, ConversationResponse } from '@/types/api';
 import type { Message, StreamingMessage, ToolUse } from '@/types/conversation';
 import { demoConversations, getDemoMessages } from '@/democonversations';
@@ -262,6 +262,16 @@ export function initConversation(
 
 export function setNeedsInitialStep(id: string, needsInitialStep: boolean) {
   updateConversation(id, { needsInitialStep });
+}
+
+export function clearInitialStepState(id: string) {
+  const conversation = conversations$.get(id);
+  if (!conversation) return;
+
+  batch(() => {
+    conversation.needsInitialStep.set(false);
+    conversation.initialStepStream.delete();
+  });
 }
 
 export function setMaxTokens(id: string, maxTokens: number | undefined) {

--- a/webui/src/stores/conversations.ts
+++ b/webui/src/stores/conversations.ts
@@ -54,6 +54,9 @@ export interface ConversationState {
   // Whether this conversation needs initial step after connecting
   // Used to fix race condition where step() was called before event subscription
   needsInitialStep: boolean;
+  // Stream setting captured when creating a placeholder conversation.
+  // The initial step starts before chatConfig is always loaded into the store.
+  initialStepStream?: boolean;
   // Currently displayed branch name
   currentBranch: string;
   // Max tokens setting for model responses, persisted across operations.
@@ -91,6 +94,7 @@ export function updateConversation(id: string, update: Partial<ConversationState
       showInitialSystem: false,
       chatConfig: null,
       needsInitialStep: false,
+      initialStepStream: undefined,
       currentBranch: 'main',
     });
   }
@@ -225,7 +229,7 @@ export function setToolComplete(
 export function initConversation(
   id: string,
   data?: ConversationResponse,
-  options?: { needsInitialStep?: boolean }
+  options?: { needsInitialStep?: boolean; initialStepStream?: boolean }
 ) {
   const initial: ConversationState = {
     data: data || {
@@ -250,6 +254,7 @@ export function initConversation(
     showInitialSystem: false,
     chatConfig: null,
     needsInitialStep: options?.needsInitialStep ?? false,
+    initialStepStream: options?.initialStepStream,
     currentBranch: 'main',
   };
   conversations$.set(id, initial);

--- a/webui/src/utils/__tests__/demoApiClient.test.ts
+++ b/webui/src/utils/__tests__/demoApiClient.test.ts
@@ -88,12 +88,15 @@ describe('createDemoApiClient', () => {
 
   it('createConversationWithPlaceholder returns a logfile and is retrievable', async () => {
     const client = createDemoApiClient();
-    const logfile = await client.createConversationWithPlaceholder('What is gptme?');
+    const logfile = await client.createConversationWithPlaceholder('What is gptme?', {
+      stream: false,
+    });
     expect(typeof logfile).toBe('string');
     expect(logfile.length).toBeGreaterThan(0);
     const conv = await client.getConversation(logfile);
     expect(conv.log[0].content).toBe('What is gptme?');
     expect(conversations$.get(logfile)?.needsInitialStep.get()).toBe(true);
+    expect(conversations$.get(logfile)?.initialStepStream.get()).toBe(false);
   });
 
   it('searches the demo conversation by name', async () => {

--- a/webui/src/utils/api.ts
+++ b/webui/src/utils/api.ts
@@ -1085,7 +1085,7 @@ export class ApiClient {
         branches: {},
         workspace: options?.workspace || '.',
       },
-      { needsInitialStep: true }
+      { needsInitialStep: true, initialStepStream: options?.stream }
     );
     if (options?.maxTokens !== undefined) {
       setMaxTokens(conversationId, options.maxTokens);

--- a/webui/src/utils/demoApiClient.ts
+++ b/webui/src/utils/demoApiClient.ts
@@ -320,7 +320,10 @@ export function createDemoApiClient(baseUrl: string = DEMO_BASE_URL): IApiClient
       };
       localConversations.set(logfile, conv);
       sessions$.set(logfile, `demo-session-${logfile}`);
-      initConversation(logfile, clone(conv), { needsInitialStep: true });
+      initConversation(logfile, clone(conv), {
+        needsInitialStep: true,
+        initialStepStream: opts?.stream,
+      });
       if (opts?.maxTokens !== undefined) {
         setMaxTokens(logfile, opts.maxTokens);
       }


### PR DESCRIPTION
## What
- Keeps placeholder conversations mounted while the server conversation list catches up after creating a new chat.
- Carries the placeholder stream preference into the delayed initial assistant step instead of always forcing streaming.
- Extends the demo placeholder test for the non-stream path.

## Verification
- npm test -- demoApiClient.test.ts --runInBand
- npm run typecheck
- npx prettier --check src/components/MainLayout.tsx src/hooks/useConversation.ts src/stores/conversations.ts src/utils/api.ts src/utils/demoApiClient.ts src/utils/__tests__/demoApiClient.test.ts
- git diff --check -- webui/src/components/MainLayout.tsx webui/src/hooks/useConversation.ts webui/src/stores/conversations.ts webui/src/utils/api.ts webui/src/utils/demoApiClient.ts webui/src/utils/__tests__/demoApiClient.test.ts
- Live smoke against local gptme-server + Vite: create conversation, send message, receive assistant response, no console errors/page errors/request failures.