### PR TITLE
test(webui): honor Playwright port setting

### DIFF
--- a/webui/playwright.config.ts
+++ b/webui/playwright.config.ts
@@ -39,7 +39,7 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: 'npm run dev',
+    command: `npm run dev -- --host 127.0.0.1 --port ${port}`,
     url: 'http://localhost:' + port,
     reuseExistingServer: !process.env.CI,
   },

--- a/webui/playwright.config.ts
+++ b/webui/playwright.config.ts
@@ -40,7 +40,7 @@ export default defineConfig({
   ],
   webServer: {
     command: `npm run dev -- --host 127.0.0.1 --port ${port}`,
-    url: 'http://localhost:' + port,
+    url: 'http://127.0.0.1:' + port,
     reuseExistingServer: !process.env.CI,
   },
 });

--- a/webui/playwright.config.ts
+++ b/webui/playwright.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
   workers: process.env.CI ? 1 : undefined,
   reporter: 'html',
   use: {
-    baseURL: 'http://localhost:' + port,
+    baseURL: 'http://127.0.0.1:' + port,
     trace: 'on-first-retry',
     // Skip the first-run setup wizard in all E2E tests by default.
     // Tests that need to verify the wizard itself must override storageState
@@ -21,7 +21,7 @@ export default defineConfig({
       cookies: [],
       origins: [
         {
-          origin: 'http://localhost:' + port,
+          origin: 'http://127.0.0.1:' + port,
           localStorage: [
             {
               name: 'gptme-settings',


### PR DESCRIPTION
## Summary
- pass Playwright's configured `PORT` through to Vite's dev server command
- bind Vite to `127.0.0.1` so the `webServer.url` and startup command use the same endpoint

## Context
Found while retesting the setup wizard flow from #2193. `playwright.config.ts` reads `process.env.PORT` and waits on that URL, but `npm run dev` ignored the same port. A non-default-port smoke (`PORT=5711 ...`) started Vite without a matching listener, so Playwright waited on the wrong endpoint.

This does not close #2193; it removes a harness footgun for the desktop/webui onboarding smoke tests.

## Verification
- `npm test -- --runInBand src/components/__tests__/SetupWizard.test.tsx src/components/__tests__/WelcomeView.test.tsx src/components/settings/__tests__/ServerApiKeySettings.test.tsx src/components/settings/__tests__/ServerDefaultModelSettings.test.tsx` (43 passed)
- `npm run typecheck`
- `PORT=5711 npm run test:e2e -- e2e/setup-wizard.spec.ts --project=chromium` (2 passed)
- `git diff --check -- webui/playwright.config.ts`