### PR TITLE
fix(server): reject whitespace elicitation ids

### DIFF
--- a/gptme/server/api_v2_sessions.py
+++ b/gptme/server/api_v2_sessions.py
@@ -886,9 +886,17 @@ def api_conversation_elicit_respond(conversation_id: str):
         )
     if not isinstance(elicit_id, str):
         return flask.jsonify({"error": "elicit_id must be a string"}), 400
-    if not elicit_id:
+    stripped_elicit_id = elicit_id.strip()
+    if not stripped_elicit_id:
         return (
-            flask.jsonify({"error": "elicit_id and action are required"}),
+            flask.jsonify({"error": "elicit_id must not be blank"}),
+            400,
+        )
+    if stripped_elicit_id != elicit_id:
+        return (
+            flask.jsonify(
+                {"error": "elicit_id must not contain leading or trailing whitespace"}
+            ),
             400,
         )
 

--- a/tests/test_server_bad_input.py
+++ b/tests/test_server_bad_input.py
@@ -541,6 +541,15 @@ def main():
         "elicit respond bad elicit_id type",
     )
 
+    # Probe: elicit/respond with whitespace-only elicit_id
+    _expect_error(
+        "POST",
+        f"/api/v2/conversations/{cid}/elicit/respond",
+        {"elicit_id": "   ", "action": "accept"},
+        400,
+        "elicit respond whitespace elicit_id",
+    )
+
     # Probe: elicit/respond with unknown action
     _expect_error(
         "POST",

--- a/tests/test_server_v2_sessions.py
+++ b/tests/test_server_v2_sessions.py
@@ -1019,6 +1019,36 @@ class TestElicitRespondEndpoint:
         assert data is not None
         assert data["error"] == "elicit_id must be a string"
 
+    @patch("gptme.server.api_v2_sessions.resolve_hook_elicitation")
+    def test_whitespace_only_elicit_id_rejected(
+        self, mock_resolve, conv, client: FlaskClient
+    ):
+        """Whitespace-only elicit_id values return 400 instead of a false success."""
+        response = client.post(
+            f"/api/v2/conversations/{conv['conversation_id']}/elicit/respond",
+            json={"elicit_id": "   ", "action": "accept"},
+        )
+        assert response.status_code == 400
+        data = response.get_json()
+        assert data is not None
+        assert data["error"] == "elicit_id must not be blank"
+        mock_resolve.assert_not_called()
+
+    @patch("gptme.server.api_v2_sessions.resolve_hook_elicitation")
+    def test_padded_elicit_id_rejected(self, mock_resolve, conv, client: FlaskClient):
+        """Padded elicit_id values are rejected instead of silently normalized."""
+        response = client.post(
+            f"/api/v2/conversations/{conv['conversation_id']}/elicit/respond",
+            json={"elicit_id": " test-elicit-id ", "action": "accept"},
+        )
+        assert response.status_code == 400
+        data = response.get_json()
+        assert data is not None
+        assert data["error"] == (
+            "elicit_id must not contain leading or trailing whitespace"
+        )
+        mock_resolve.assert_not_called()
+
     @pytest.mark.parametrize("elicit_id", [0, False, []])
     def test_falsy_non_string_elicit_id(self, conv, client: FlaskClient, elicit_id):
         """Falsy non-string elicit_id values must return the type error, not the required-fields error."""


### PR DESCRIPTION
## Summary
- Reject whitespace-only `elicit_id` values on `/api/v2/conversations/<id>/elicit/respond`
- Keep the route from returning false-success 200s for malformed elicitation responses
- Add route-level and bad-input sweep regression coverage

## Repro
Before this patch, posting `{"elicit_id": "   ", "action": "accept"}` to `/elicit/respond` logged `Pending elicitation not found` but still returned `200 {"status": "ok"}`.

## Tests
- `XDG_DATA_HOME=/tmp/gptme-server-api-dogfood-f5ad-test-data3 XDG_CONFIG_HOME=/tmp/gptme-server-api-dogfood-f5ad-test-config3 /tmp/gptme-server-api-dogfood-f5ad/.venv/bin/python3 -m pytest tests/test_server_v2_sessions.py::TestElicitRespondEndpoint -q`
- `GPTME_TEST_SERVER_URL=http://127.0.0.1:5019 XDG_DATA_HOME=/tmp/gptme-server-api-dogfood-f5ad-live-data XDG_CONFIG_HOME=/tmp/gptme-server-api-dogfood-f5ad-live-config /tmp/gptme-server-api-dogfood-f5ad/.venv/bin/python3 tests/test_server_bad_input.py`
- Ad-hoc malformed endpoint probe: `5xx_count 0`; whitespace `elicit_id` now returns 400
