### PR TITLE
feat(webui): add staging deploy trigger

### DIFF
--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -569,8 +569,12 @@ def api_dev_deploy_staging_trigger():
     except ValueError as exc:
         return flask.jsonify({"error": str(exc)}), 500
 
+    owner, repo_name = repository.split("/", 1)
+    encoded_repository = (
+        f"{urllib.parse.quote(owner, safe='')}/{urllib.parse.quote(repo_name, safe='')}"
+    )
     workflow = urllib.parse.quote(workflow_name, safe="")
-    api_url = f"https://api.github.com/repos/{repository}/actions/workflows/{workflow}/dispatches"
+    api_url = f"https://api.github.com/repos/{encoded_repository}/actions/workflows/{workflow}/dispatches"
     request = urllib.request.Request(
         api_url,
         data=json.dumps(payload).encode("utf-8"),

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -5,9 +5,13 @@ This module contains the main conversation CRUD endpoints for the V2 API.
 Session management, tool execution, and agent creation are handled by separate modules.
 """
 
+import json
 import logging
 import os
 import shutil
+import urllib.error
+import urllib.parse
+import urllib.request
 from dataclasses import replace
 from datetime import datetime, timezone
 from itertools import islice
@@ -101,6 +105,57 @@ _ALLOWED_AVATAR_EXTS = {".jpg", ".jpeg", ".png", ".gif", ".webp", ".ico"}
 # - edit: launches an interactive $EDITOR subprocess, blocking the worker thread
 # - delete (without --force): calls input() waiting for stdin that never arrives
 _SERVER_BLOCKED_COMMANDS = {"exit", "restart", "edit", "delete"}
+
+_TRUTHY_ENV_VALUES = {"1", "true", "yes", "on"}
+
+
+def _env_truthy(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in _TRUTHY_ENV_VALUES
+
+
+def _get_webui_deploy_config() -> dict[str, object]:
+    """Return web UI deploy trigger config without exposing the GitHub token."""
+    repository = os.environ.get("GPTME_WEBUI_DEPLOY_REPOSITORY", "gptme/gptme").strip()
+    workflow = os.environ.get("GPTME_WEBUI_DEPLOY_WORKFLOW", "").strip()
+    ref = os.environ.get("GPTME_WEBUI_DEPLOY_REF", "master").strip()
+    token = os.environ.get("GPTME_WEBUI_GITHUB_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    enabled = _env_truthy("GPTME_WEBUI_ENABLE_DEV_DEPLOY")
+
+    actions_url = (
+        f"https://github.com/{repository}/actions/workflows/{workflow}"
+        if workflow
+        else f"https://github.com/{repository}/actions"
+    )
+
+    return {
+        "enabled": enabled,
+        "configured": enabled
+        and bool(token)
+        and "/" in repository
+        and bool(workflow)
+        and bool(ref),
+        "repository": repository,
+        "workflow": workflow,
+        "ref": ref,
+        "has_token": bool(token),
+        "actions_url": actions_url,
+    }
+
+
+def _get_webui_deploy_inputs() -> dict[str, object] | None:
+    raw_inputs = os.environ.get("GPTME_WEBUI_DEPLOY_INPUTS_JSON")
+    if not raw_inputs:
+        return None
+
+    try:
+        inputs = json.loads(raw_inputs)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid GPTME_WEBUI_DEPLOY_INPUTS_JSON: {exc}") from exc
+
+    if not isinstance(inputs, dict):
+        raise ValueError("GPTME_WEBUI_DEPLOY_INPUTS_JSON must be a JSON object")
+
+    return inputs
 
 
 def _is_valid_image_content(path: "Path") -> bool:
@@ -434,6 +489,149 @@ def api_config():
             agent_info["urls"] = agent.urls
 
     return flask.jsonify({"agent": agent_info})
+
+
+@v2_api.route("/api/v2/dev/deploy-staging", methods=["GET"])
+@require_auth
+def api_dev_deploy_staging_status():
+    """Return whether the web UI staging deploy trigger is configured."""
+    return flask.jsonify(_get_webui_deploy_config())
+
+
+@v2_api.route("/api/v2/dev/deploy-staging", methods=["POST"])
+@require_auth
+def api_dev_deploy_staging_trigger():
+    """Trigger the configured web UI staging deploy workflow."""
+    config = _get_webui_deploy_config()
+
+    if not config["enabled"]:
+        return (
+            flask.jsonify(
+                {
+                    "error": "Web UI deploy trigger is disabled",
+                    "detail": "Set GPTME_WEBUI_ENABLE_DEV_DEPLOY=true on the gptme server.",
+                }
+            ),
+            403,
+        )
+
+    token = os.environ.get("GPTME_WEBUI_GITHUB_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    if not token:
+        return (
+            flask.jsonify(
+                {
+                    "error": "Web UI deploy trigger is not configured",
+                    "detail": "Set GPTME_WEBUI_GITHUB_TOKEN with Actions workflow permissions.",
+                }
+            ),
+            503,
+        )
+
+    repository = str(config["repository"])
+    workflow_name = str(config["workflow"])
+    ref = str(config["ref"])
+    if "/" not in repository:
+        return (
+            flask.jsonify(
+                {
+                    "error": "Invalid GPTME_WEBUI_DEPLOY_REPOSITORY",
+                    "detail": "Expected owner/repo format.",
+                }
+            ),
+            500,
+        )
+    if not workflow_name:
+        return (
+            flask.jsonify(
+                {
+                    "error": "GPTME_WEBUI_DEPLOY_WORKFLOW is required",
+                    "detail": "Set it to a workflow file that supports workflow_dispatch.",
+                }
+            ),
+            503,
+        )
+    if not ref:
+        return (
+            flask.jsonify(
+                {
+                    "error": "GPTME_WEBUI_DEPLOY_REF is required",
+                    "detail": "Set it to the branch or tag to deploy.",
+                }
+            ),
+            503,
+        )
+
+    try:
+        payload: dict[str, object] = {"ref": ref}
+        inputs = _get_webui_deploy_inputs()
+        if inputs:
+            payload["inputs"] = inputs
+    except ValueError as exc:
+        return flask.jsonify({"error": str(exc)}), 500
+
+    workflow = urllib.parse.quote(workflow_name, safe="")
+    api_url = f"https://api.github.com/repos/{repository}/actions/workflows/{workflow}/dispatches"
+    request = urllib.request.Request(
+        api_url,
+        data=json.dumps(payload).encode("utf-8"),
+        method="POST",
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "User-Agent": "gptme-webui-dev-deploy",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+
+    try:
+        with urllib.request.urlopen(request, timeout=20) as response:
+            if response.status != 204:
+                return (
+                    flask.jsonify(
+                        {
+                            "error": "GitHub did not accept the deploy request",
+                            "detail": f"Unexpected status {response.status}",
+                        }
+                    ),
+                    502,
+                )
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        return (
+            flask.jsonify(
+                {
+                    "error": "GitHub rejected the deploy request",
+                    "github_status": exc.code,
+                    "detail": detail,
+                }
+            ),
+            502,
+        )
+    except urllib.error.URLError as exc:
+        return (
+            flask.jsonify(
+                {
+                    "error": "Could not reach GitHub",
+                    "detail": str(exc.reason),
+                }
+            ),
+            502,
+        )
+
+    return (
+        flask.jsonify(
+            {
+                "status": "queued",
+                "message": "Staging deploy workflow queued",
+                "repository": repository,
+                "workflow": workflow_name,
+                "ref": ref,
+                "actions_url": config["actions_url"],
+            }
+        ),
+        202,
+    )
 
 
 @v2_api.route("/api/v2/external-sessions")

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -1,3 +1,4 @@
+import json
 import random
 import time
 import unittest.mock
@@ -173,6 +174,89 @@ def test_v2_api_root_provider_configured(client: FlaskClient, monkeypatch):
     response = client.get("/api/v2")
     data = response.get_json()
     assert data["provider_configured"] is True
+
+
+def test_webui_deploy_status_disabled(client: FlaskClient, monkeypatch):
+    """The web UI deploy endpoint reports disabled state by default."""
+    monkeypatch.delenv("GPTME_WEBUI_ENABLE_DEV_DEPLOY", raising=False)
+    monkeypatch.delenv("GPTME_WEBUI_GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GPTME_WEBUI_DEPLOY_WORKFLOW", raising=False)
+
+    response = client.get("/api/v2/dev/deploy-staging")
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["enabled"] is False
+    assert data["configured"] is False
+    assert data["repository"] == "gptme/gptme"
+    assert data["workflow"] == ""
+
+
+def test_webui_deploy_trigger_disabled(client: FlaskClient, monkeypatch):
+    """The deploy trigger fails closed until explicitly enabled."""
+    monkeypatch.delenv("GPTME_WEBUI_ENABLE_DEV_DEPLOY", raising=False)
+
+    response = client.post("/api/v2/dev/deploy-staging", json={})
+
+    assert response.status_code == 403
+    data = response.get_json()
+    assert "disabled" in data["error"]
+
+
+def test_webui_deploy_trigger_requires_workflow(client: FlaskClient, monkeypatch):
+    """Enabled deploy trigger still requires an explicit workflow name."""
+    monkeypatch.setenv("GPTME_WEBUI_ENABLE_DEV_DEPLOY", "true")
+    monkeypatch.setenv("GPTME_WEBUI_GITHUB_TOKEN", "test-token")
+    monkeypatch.delenv("GPTME_WEBUI_DEPLOY_WORKFLOW", raising=False)
+
+    response = client.post("/api/v2/dev/deploy-staging", json={})
+
+    assert response.status_code == 503
+    data = response.get_json()
+    assert "WORKFLOW" in data["error"]
+
+
+def test_webui_deploy_trigger_dispatches_workflow(client: FlaskClient, monkeypatch):
+    """The deploy trigger posts workflow_dispatch to GitHub when configured."""
+    captured = {}
+
+    class FakeResponse:
+        status = 204
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    def fake_urlopen(request, timeout):
+        captured["url"] = request.full_url
+        captured["timeout"] = timeout
+        captured["payload"] = json.loads(request.data.decode("utf-8"))
+        captured["authorization"] = request.headers["Authorization"]
+        return FakeResponse()
+
+    monkeypatch.setenv("GPTME_WEBUI_ENABLE_DEV_DEPLOY", "true")
+    monkeypatch.setenv("GPTME_WEBUI_GITHUB_TOKEN", "test-token")
+    monkeypatch.setenv("GPTME_WEBUI_DEPLOY_REPOSITORY", "gptme/gptme")
+    monkeypatch.setenv("GPTME_WEBUI_DEPLOY_WORKFLOW", "webui-staging.yml")
+    monkeypatch.setenv("GPTME_WEBUI_DEPLOY_REF", "master")
+    monkeypatch.setenv("GPTME_WEBUI_DEPLOY_INPUTS_JSON", '{"environment":"staging"}')
+    monkeypatch.setattr("gptme.server.api_v2.urllib.request.urlopen", fake_urlopen)
+
+    response = client.post("/api/v2/dev/deploy-staging", json={})
+
+    assert response.status_code == 202
+    data = response.get_json()
+    assert data["status"] == "queued"
+    assert data["workflow"] == "webui-staging.yml"
+    assert captured == {
+        "url": "https://api.github.com/repos/gptme/gptme/actions/workflows/webui-staging.yml/dispatches",
+        "timeout": 20,
+        "payload": {"ref": "master", "inputs": {"environment": "staging"}},
+        "authorization": "Bearer test-token",
+    }
 
 
 def test_v2_user_api_key_persists_env_entry(client: FlaskClient, tmp_path, monkeypatch):

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -239,7 +239,7 @@ def test_webui_deploy_trigger_dispatches_workflow(client: FlaskClient, monkeypat
 
     monkeypatch.setenv("GPTME_WEBUI_ENABLE_DEV_DEPLOY", "true")
     monkeypatch.setenv("GPTME_WEBUI_GITHUB_TOKEN", "test-token")
-    monkeypatch.setenv("GPTME_WEBUI_DEPLOY_REPOSITORY", "gptme/gptme")
+    monkeypatch.setenv("GPTME_WEBUI_DEPLOY_REPOSITORY", "gptme/web ui#preview")
     monkeypatch.setenv("GPTME_WEBUI_DEPLOY_WORKFLOW", "webui-staging.yml")
     monkeypatch.setenv("GPTME_WEBUI_DEPLOY_REF", "master")
     monkeypatch.setenv("GPTME_WEBUI_DEPLOY_INPUTS_JSON", '{"environment":"staging"}')
@@ -252,7 +252,7 @@ def test_webui_deploy_trigger_dispatches_workflow(client: FlaskClient, monkeypat
     assert data["status"] == "queued"
     assert data["workflow"] == "webui-staging.yml"
     assert captured == {
-        "url": "https://api.github.com/repos/gptme/gptme/actions/workflows/webui-staging.yml/dispatches",
+        "url": "https://api.github.com/repos/gptme/web%20ui%23preview/actions/workflows/webui-staging.yml/dispatches",
         "timeout": 20,
         "payload": {"ref": "master", "inputs": {"environment": "staging"}},
         "authorization": "Bearer test-token",

--- a/webui/README.md
+++ b/webui/README.md
@@ -137,6 +137,23 @@ npm run typecheck       # type checking only
 npm run typecheck:watch # type checking in watch mode
 ```
 
+### Developer staging deploy trigger
+
+The Developer settings panel can trigger a GitHub Actions staging deployment through
+the connected gptme server when the trigger is explicitly configured:
+
+```sh
+GPTME_WEBUI_ENABLE_DEV_DEPLOY=true \
+GPTME_WEBUI_GITHUB_TOKEN=github_pat_with_actions_workflow_scope \
+GPTME_WEBUI_DEPLOY_REPOSITORY=gptme/gptme \
+GPTME_WEBUI_DEPLOY_WORKFLOW=webui-staging.yml \
+GPTME_WEBUI_DEPLOY_REF=master \
+gptme-server --cors-origin='http://localhost:5701'
+```
+
+Optional `GPTME_WEBUI_DEPLOY_INPUTS_JSON='{"environment":"staging"}'` adds
+workflow inputs for staging workflows that declare them.
+
 ## Testing
 
 ```sh

--- a/webui/src/components/SettingsModal.tsx
+++ b/webui/src/components/SettingsModal.tsx
@@ -12,11 +12,21 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
 import { Separator } from '@/components/ui/separator';
-import { Settings, Volume2, Palette, Info, FileText, ExternalLink, Server } from 'lucide-react';
+import {
+  Settings,
+  Volume2,
+  Palette,
+  Info,
+  FileText,
+  ExternalLink,
+  Server,
+  Rocket,
+} from 'lucide-react';
 import { useSettings } from '@/contexts/SettingsContext';
 import { useTheme } from 'next-themes';
 import { cn } from '@/lib/utils';
 import { ServerConfiguration } from '@/components/settings/ServerConfiguration';
+import { DeveloperDeploy } from '@/components/settings/DeveloperDeploy';
 import { use$ } from '@legendapp/state/react';
 import { settingsModal$, type SettingsCategory } from '@/stores/settingsModal';
 import { setupWizard$ } from '@/stores/setupWizard';
@@ -53,6 +63,16 @@ const categories = [
     icon: FileText,
     description: 'Message and code display options',
   },
+  ...(import.meta.env.DEV || import.meta.env.VITE_ENABLE_DEV_TOOLS === 'true'
+    ? [
+        {
+          id: 'developer' as const,
+          label: 'Developer',
+          icon: Rocket,
+          description: 'Deploy and debugging actions',
+        },
+      ]
+    : []),
   {
     id: 'about' as const,
     label: 'About',
@@ -297,6 +317,9 @@ export const SettingsModal = forwardRef<HTMLButtonElement, SettingsModalProps>(
               </div>
             </div>
           );
+
+        case 'developer':
+          return <DeveloperDeploy />;
 
         case 'about':
           return (

--- a/webui/src/components/settings/DeveloperDeploy.tsx
+++ b/webui/src/components/settings/DeveloperDeploy.tsx
@@ -96,7 +96,7 @@ export function DeveloperDeploy() {
           <Button
             type="button"
             onClick={handleDeploy}
-            disabled={isDeploying}
+            disabled={isDeploying || (status !== null && !status.configured)}
             className="w-full sm:w-auto"
           >
             {isDeploying ? (

--- a/webui/src/components/settings/DeveloperDeploy.tsx
+++ b/webui/src/components/settings/DeveloperDeploy.tsx
@@ -1,0 +1,146 @@
+import { useEffect, useState } from 'react';
+import { AlertCircle, CheckCircle2, Loader2, Rocket } from 'lucide-react';
+import { toast } from 'sonner';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { getPrimaryClient } from '@/stores/serverClients';
+import {
+  getStagingDeployStatus,
+  triggerStagingDeploy,
+  type DeployStatus,
+  type DeployTriggerResponse,
+} from '@/utils/deployApi';
+
+export function DeveloperDeploy() {
+  const [status, setStatus] = useState<DeployStatus | null>(null);
+  const [statusError, setStatusError] = useState<string | null>(null);
+  const [result, setResult] = useState<DeployTriggerResponse | null>(null);
+  const [deployError, setDeployError] = useState<string | null>(null);
+  const [isDeploying, setIsDeploying] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    try {
+      const api = getPrimaryClient();
+      getStagingDeployStatus(api)
+        .then((nextStatus) => {
+          if (!cancelled) {
+            setStatus(nextStatus);
+            setStatusError(null);
+          }
+        })
+        .catch((error) => {
+          if (!cancelled) {
+            setStatus(null);
+            setStatusError(error instanceof Error ? error.message : 'Deploy endpoint unavailable');
+          }
+        });
+    } catch (error) {
+      if (!cancelled) {
+        setStatus(null);
+        setStatusError(error instanceof Error ? error.message : 'No server configured');
+      }
+    }
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleDeploy = async () => {
+    setIsDeploying(true);
+    setDeployError(null);
+    setResult(null);
+
+    try {
+      const api = getPrimaryClient();
+      const response = await triggerStagingDeploy(api);
+      setResult(response);
+      toast.success('Staging deploy queued');
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to trigger staging deploy';
+      setDeployError(message);
+      toast.error(message);
+    } finally {
+      setIsDeploying(false);
+    }
+  };
+
+  const targetLabel = status
+    ? `${status.repository} / ${status.workflow || 'workflow unset'} @ ${status.ref}`
+    : 'primary gptme server';
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h3 className="mb-1 text-lg font-medium">Developer</h3>
+        <div className="flex flex-wrap items-center gap-2">
+          <p className="text-sm text-muted-foreground">Staging deploy controls</p>
+          {status && (
+            <Badge variant={status.configured ? 'secondary' : 'outline'}>
+              {status.configured ? 'Configured' : 'Not configured'}
+            </Badge>
+          )}
+          {statusError && <Badge variant="outline">Endpoint unavailable</Badge>}
+        </div>
+      </div>
+
+      <div className="space-y-3 rounded-md border p-4">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="space-y-1">
+            <h4 className="text-sm font-medium">Deploy to staging</h4>
+            <p className="text-xs text-muted-foreground">{targetLabel}</p>
+          </div>
+          <Button
+            type="button"
+            onClick={handleDeploy}
+            disabled={isDeploying}
+            className="w-full sm:w-auto"
+          >
+            {isDeploying ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : (
+              <Rocket className="mr-2 h-4 w-4" />
+            )}
+            {isDeploying ? 'Triggering' : 'Deploy'}
+          </Button>
+        </div>
+
+        {statusError && (
+          <Alert>
+            <AlertCircle className="h-4 w-4" />
+            <AlertTitle>Deploy endpoint unavailable</AlertTitle>
+            <AlertDescription>{statusError}</AlertDescription>
+          </Alert>
+        )}
+
+        {deployError && (
+          <Alert variant="destructive">
+            <AlertCircle className="h-4 w-4" />
+            <AlertTitle>Deploy failed</AlertTitle>
+            <AlertDescription>{deployError}</AlertDescription>
+          </Alert>
+        )}
+
+        {result && (
+          <Alert>
+            <CheckCircle2 className="h-4 w-4" />
+            <AlertTitle>{result.message}</AlertTitle>
+            <AlertDescription>
+              <a
+                href={result.actions_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline-offset-4 hover:underline"
+              >
+                Open GitHub Actions
+              </a>
+            </AlertDescription>
+          </Alert>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/webui/src/components/settings/__tests__/DeveloperDeploy.test.tsx
+++ b/webui/src/components/settings/__tests__/DeveloperDeploy.test.tsx
@@ -1,0 +1,50 @@
+import '@testing-library/jest-dom';
+import { render, screen, waitFor } from '@testing-library/react';
+import { DeveloperDeploy } from '../DeveloperDeploy';
+
+const mockGetPrimaryClient = jest.fn();
+const mockGetStagingDeployStatus = jest.fn();
+const mockTriggerStagingDeploy = jest.fn();
+
+jest.mock('@/stores/serverClients', () => ({
+  getPrimaryClient: () => mockGetPrimaryClient(),
+}));
+
+jest.mock('@/utils/deployApi', () => ({
+  getStagingDeployStatus: (...args: unknown[]) => mockGetStagingDeployStatus(...args),
+  triggerStagingDeploy: (...args: unknown[]) => mockTriggerStagingDeploy(...args),
+}));
+
+jest.mock('sonner', () => ({
+  toast: {
+    success: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+describe('DeveloperDeploy', () => {
+  beforeEach(() => {
+    mockGetPrimaryClient.mockReset();
+    mockGetStagingDeployStatus.mockReset();
+    mockTriggerStagingDeploy.mockReset();
+    mockGetPrimaryClient.mockReturnValue({ baseUrl: 'http://127.0.0.1:5700' });
+  });
+
+  it('disables deploy when the server reports the trigger is not configured', async () => {
+    mockGetStagingDeployStatus.mockResolvedValue({
+      enabled: true,
+      configured: false,
+      repository: 'gptme/gptme',
+      workflow: 'webui-staging.yml',
+      ref: 'master',
+      has_token: false,
+      actions_url: 'https://github.com/gptme/gptme/actions/workflows/webui-staging.yml',
+    });
+
+    render(<DeveloperDeploy />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Deploy' })).toBeDisabled();
+    });
+  });
+});

--- a/webui/src/stores/settingsModal.ts
+++ b/webui/src/stores/settingsModal.ts
@@ -1,6 +1,12 @@
 import { observable } from '@legendapp/state';
 
-export type SettingsCategory = 'servers' | 'appearance' | 'audio' | 'content' | 'about';
+export type SettingsCategory =
+  | 'servers'
+  | 'appearance'
+  | 'audio'
+  | 'content'
+  | 'developer'
+  | 'about';
 
 /** Observable to open the settings modal from outside (e.g. server dropdown, command palette). */
 export const settingsModal$ = observable({

--- a/webui/src/utils/deployApi.ts
+++ b/webui/src/utils/deployApi.ts
@@ -1,0 +1,109 @@
+import type { IApiClient } from '@/utils/api';
+import { withLocalAddressSpace } from '@/utils/addressSpace';
+
+export interface DeployStatus {
+  enabled: boolean;
+  configured: boolean;
+  repository: string;
+  workflow: string;
+  ref: string;
+  has_token: boolean;
+  actions_url: string;
+}
+
+export interface DeployTriggerResponse {
+  status: 'queued';
+  message: string;
+  repository: string;
+  workflow: string;
+  ref: string;
+  actions_url: string;
+}
+
+interface DeployErrorResponse {
+  error?: string;
+  detail?: string;
+  github_status?: number;
+}
+
+const DEPLOY_PATH = '/api/v2/dev/deploy-staging';
+
+function deployEndpoint(api: IApiClient): string {
+  return `${api.baseUrl.replace(/\/+$/, '')}${DEPLOY_PATH}`;
+}
+
+function deployHeaders(api: IApiClient): HeadersInit {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  };
+
+  if (api.authHeader) {
+    headers.Authorization = api.authHeader;
+  }
+
+  return headers;
+}
+
+async function parseJsonResponse<T>(response: Response): Promise<T> {
+  const text = await response.text();
+
+  if (!text) {
+    return {} as T;
+  }
+
+  try {
+    return JSON.parse(text) as T;
+  } catch {
+    return { error: text } as T;
+  }
+}
+
+function formatDeployError(response: Response, payload: DeployErrorResponse): string {
+  const parts = [payload.error || `Deploy request failed (${response.status})`];
+
+  if (payload.github_status) {
+    parts.push(`GitHub status ${payload.github_status}`);
+  }
+
+  if (payload.detail) {
+    parts.push(payload.detail);
+  }
+
+  return parts.join(': ');
+}
+
+export async function getStagingDeployStatus(api: IApiClient): Promise<DeployStatus> {
+  const url = deployEndpoint(api);
+  const response = await fetch(
+    url,
+    withLocalAddressSpace(url, {
+      headers: deployHeaders(api),
+    })
+  );
+  const payload = await parseJsonResponse<DeployStatus & DeployErrorResponse>(response);
+
+  if (!response.ok) {
+    throw new Error(formatDeployError(response, payload));
+  }
+
+  return payload;
+}
+
+export async function triggerStagingDeploy(api: IApiClient): Promise<DeployTriggerResponse> {
+  const url = deployEndpoint(api);
+  const response = await fetch(
+    url,
+    withLocalAddressSpace(url, {
+      method: 'POST',
+      headers: deployHeaders(api),
+      body: JSON.stringify({ source: 'gptme-webui-settings' }),
+    })
+  );
+  const payload = await parseJsonResponse<DeployTriggerResponse & DeployErrorResponse>(response);
+
+  if (!response.ok) {
+    throw new Error(formatDeployError(response, payload));
+  }
+
+  return payload;
+}


### PR DESCRIPTION
## Summary
- add authenticated `/api/v2/dev/deploy-staging` endpoints on gptme-server for deploy status and GitHub Actions `workflow_dispatch`
- add a dev-only Developer settings panel with a Deploy button, queued state, and error state
- document the server environment variables needed to enable a staging deploy workflow

## Verification
- `/tmp/gptme-dev-deploy-76d3/.venv/bin/python -m pytest tests/test_server_v2.py::test_webui_deploy_status_disabled tests/test_server_v2.py::test_webui_deploy_trigger_disabled tests/test_server_v2.py::test_webui_deploy_trigger_requires_workflow tests/test_server_v2.py::test_webui_deploy_trigger_dispatches_workflow -q`
- `uv run ruff check gptme/server/api_v2.py tests/test_server_v2.py`
- `npx prettier --check src/components/SettingsModal.tsx src/stores/settingsModal.ts src/components/settings/DeveloperDeploy.tsx src/utils/deployApi.ts`
- `npm run typecheck`
- `npm run build`
- pre-commit hooks passed via `prek` during commit

## Notes
The original local task targeted the archived `gptme/gptme-webui` repo. A branch was pushed there, but GitHub rejects PR creation because the repo is archived/read-only, so this PR ports the slice to the active monorepo web UI. The deploy trigger intentionally has no default workflow; staging remains disabled until a workflow with `workflow_dispatch`, ref, and token are configured.