### PR TITLE
feat(chats): add per-conversation session stats

### DIFF
--- a/gptme/cli/cmd_chats.py
+++ b/gptme/cli/cmd_chats.py
@@ -432,21 +432,28 @@ def chats_clean(max_messages: int, include_test: bool, delete: bool, json_output
 
 
 @chats.command("stats")
+@click.argument("id", required=False)
 @click.option(
     "--since",
     default=None,
     help="Only include conversations since this date (YYYY-MM-DD or Nd for N days ago).",
 )
 @click.option("--json", "as_json", is_flag=True, help="Output as JSON.")
-def chats_stats(since: str | None, as_json: bool):
+def chats_stats(id: str | None, since: str | None, as_json: bool):
     """Show conversation statistics.
 
-    Displays overview of conversation history including counts,
+    Without an ID, displays overview of conversation history including counts,
     date ranges, message totals, and activity breakdown.
+
+    With an ID, shows detailed stats for one conversation including role counts,
+    tool calls, token usage, and duration.
     """
     from ..tools.chats import conversation_stats  # fmt: skip
 
+    if id and since:
+        raise click.UsageError("Cannot use --since when inspecting a specific chat.")
+
     try:
-        conversation_stats(since=since, as_json=as_json)
+        conversation_stats(since=since, as_json=as_json, conversation_id=id)
     except ValueError as e:
         raise click.UsageError(str(e)) from e

--- a/gptme/logmanager/conversations.py
+++ b/gptme/logmanager/conversations.py
@@ -24,6 +24,31 @@ from .manager import Log
 logger = logging.getLogger(__name__)
 
 
+def _format_token_count(n: int) -> str:
+    """Format token count with K/M suffix."""
+    if n >= 1_000_000:
+        return f"{n / 1_000_000:.1f}M"
+    if n >= 1_000:
+        return f"{n / 1_000:.1f}K"
+    return str(n)
+
+
+def _format_duration(seconds: float) -> str:
+    """Format duration seconds into a compact human-readable string."""
+    total_seconds = max(0, int(seconds))
+    days, rem = divmod(total_seconds, 86_400)
+    hours, rem = divmod(rem, 3_600)
+    minutes, secs = divmod(rem, 60)
+
+    if days:
+        return f"{days}d {hours}h"
+    if hours:
+        return f"{hours}h {minutes}m"
+    if minutes:
+        return f"{minutes}m {secs}s"
+    return f"{secs}s"
+
+
 def _conversation_files() -> list[Path]:
     # NOTE: only returns the main conversation, not branches (to avoid duplicates)
     # returns the conversation files sorted by modified time (newest first)
@@ -73,8 +98,29 @@ class ConversationMeta:
             output += (
                 f"\nModified: {datetime.fromtimestamp(self.modified, tz=timezone.utc)}"
             )
+            output += f"\nDuration: {_format_duration(self.modified - self.created)}"
             if self.branches > 1:
                 output += f"\n({self.branches} branches)"
+            if self.model:
+                output += f"\nModel:    {self.model}"
+            total_tokens = self.total_input_tokens + self.total_output_tokens
+            if total_tokens:
+                output += (
+                    "\nTokens:   "
+                    f"{_format_token_count(total_tokens)} total "
+                    f"({_format_token_count(self.total_input_tokens)} in / "
+                    f"{_format_token_count(self.total_output_tokens)} out)"
+                )
+            if self.total_cost:
+                cost_str = (
+                    f"${self.total_cost:.2f}"
+                    if self.total_cost >= 0.01
+                    else f"${self.total_cost:.4f}"
+                )
+                output += f"\nCost:     {cost_str}"
+            if self.last_message_preview:
+                role = self.last_message_role or "last"
+                output += f"\nLast:     {role}: {self.last_message_preview}"
         return output
 
 

--- a/gptme/tools/chats.py
+++ b/gptme/tools/chats.py
@@ -339,6 +339,108 @@ def _format_tokens(n: int) -> str:
     return str(n)
 
 
+def _format_duration(seconds: float) -> str:
+    """Format duration seconds into a compact human-readable string."""
+    total_seconds = max(0, int(seconds))
+    days, rem = divmod(total_seconds, 86_400)
+    hours, rem = divmod(rem, 3_600)
+    minutes, secs = divmod(rem, 60)
+
+    if days:
+        return f"{days}d {hours}h"
+    if hours:
+        return f"{hours}h {minutes}m"
+    if minutes:
+        return f"{minutes}m {secs}s"
+    return f"{secs}s"
+
+
+def _normalize_timestamp(ts: datetime) -> datetime:
+    """Normalize datetimes to timezone-aware UTC."""
+    if ts.tzinfo is None:
+        return ts.replace(tzinfo=timezone.utc)
+    return ts.astimezone(timezone.utc)
+
+
+def _conversation_detail(conversation_id: str) -> dict:
+    """Collect detailed stats for a single conversation."""
+    from ..logmanager import LogManager, get_conversation_by_id  # fmt: skip
+
+    conv = get_conversation_by_id(conversation_id)
+    if conv is None:
+        raise ValueError(f"Conversation '{conversation_id}' not found.")
+
+    log_manager = LogManager.load(Path(conv.path), lock=False)
+    messages = list(log_manager.log)
+
+    role_counts: Counter[str] = Counter()
+    tool_counts: Counter[str] = Counter()
+    timestamps: list[datetime] = []
+
+    for msg in messages:
+        role_counts[msg.role] += 1
+        timestamps.append(_normalize_timestamp(msg.timestamp))
+        if msg.role != "assistant":
+            continue
+        tool_uses = list(
+            ToolUse.iter_from_content(msg.content, tool_format_override="tool")
+        )
+        if not tool_uses and "<tool-use>" in msg.content:
+            tool_uses = list(
+                ToolUse.iter_from_content(msg.content, tool_format_override="xml")
+            )
+        for tool_use in tool_uses:
+            tool_counts[tool_use.tool] += 1
+
+    started = (
+        timestamps[0]
+        if timestamps
+        else datetime.fromtimestamp(conv.created, tz=timezone.utc)
+    )
+    ended = (
+        timestamps[-1]
+        if timestamps
+        else datetime.fromtimestamp(conv.modified, tz=timezone.utc)
+    )
+    duration_seconds = max(0.0, (ended - started).total_seconds())
+    total_tokens = conv.total_input_tokens + conv.total_output_tokens
+
+    data = {
+        "id": conv.id,
+        "name": conv.name,
+        "workspace": conv.workspace,
+        "agent_name": conv.agent_name,
+        "model": conv.model,
+        "started": started.isoformat(),
+        "ended": ended.isoformat(),
+        "duration_seconds": int(duration_seconds),
+        "messages": {
+            "total": len(messages),
+            "by_role": dict(sorted(role_counts.items())),
+        },
+        "tool_calls": {
+            "total": sum(tool_counts.values()),
+            "by_tool": dict(tool_counts.most_common()),
+        },
+        "usage": {
+            "input_tokens": conv.total_input_tokens,
+            "output_tokens": conv.total_output_tokens,
+            "cache_read_tokens": conv.total_cache_read_tokens,
+            "total_tokens": total_tokens,
+            "cost": round(conv.total_cost, 4),
+        },
+        "last_message": (
+            {
+                "role": conv.last_message_role,
+                "preview": conv.last_message_preview,
+            }
+            if conv.last_message_preview
+            else None
+        ),
+    }
+    return data
+
+
 def _parse_since(since: str | None) -> float | None:
     """Parse a --since argument into a timestamp.
 
@@ -369,13 +471,77 @@ def _parse_since(since: str | None) -> float | None:
     )
 
 
-def conversation_stats(since: str | None = None, as_json: bool = False) -> None:
+def conversation_stats(
+    since: str | None = None,
+    as_json: bool = False,
+    conversation_id: str | None = None,
+) -> None:
     """Show statistics about conversation history.
 
     Args:
         since: Only include conversations since this date (YYYY-MM-DD or Nd).
         as_json: Output as JSON instead of formatted text.
+        conversation_id: Optional conversation ID to inspect in detail.
     """
+    if conversation_id is not None:
+        conv_data = _conversation_detail(conversation_id)
+
+        if as_json:
+            print(json_mod.dumps(conv_data, indent=2))
+            return
+
+        print(f"Conversation Stats: {conv_data['name']}")
+        print("=" * 40)
+        print(f"  ID:                   {conv_data['id']}")
+        if conv_data["agent_name"]:
+            print(f"  Agent:                {conv_data['agent_name']}")
+        if conv_data["model"]:
+            print(f"  Model:                {conv_data['model']}")
+        print(f"  Messages:             {conv_data['messages']['total']}")
+        role_breakdown = ", ".join(
+            f"{role}={count}"
+            for role, count in conv_data["messages"]["by_role"].items()
+        )
+        print(f"  By role:              {role_breakdown}")
+        print(f"  Tool calls:           {conv_data['tool_calls']['total']}")
+        if conv_data["tool_calls"]["by_tool"]:
+            tool_breakdown = ", ".join(
+                f"{tool}={count}"
+                for tool, count in conv_data["tool_calls"]["by_tool"].items()
+            )
+            print(f"  By tool:              {tool_breakdown}")
+        print(f"  Started:              {conv_data['started']}")
+        print(f"  Ended:                {conv_data['ended']}")
+        print(
+            f"  Duration:             {_format_duration(conv_data['duration_seconds'])}"
+        )
+        print(f"  Workspace:            {conv_data['workspace']}")
+
+        usage = conv_data["usage"]
+        if usage["total_tokens"] or usage["cost"]:
+            cache_pct = (
+                usage["cache_read_tokens"] / usage["input_tokens"] * 100
+                if usage["input_tokens"]
+                else 0
+            )
+            print("\nToken Usage & Cost")
+            print(
+                f"  Input tokens:         {_format_tokens(usage['input_tokens']):>8s}  ({cache_pct:.0f}% cached)"
+            )
+            print(
+                f"  Output tokens:        {_format_tokens(usage['output_tokens']):>8s}"
+            )
+            print(
+                f"  Total tokens:         {_format_tokens(usage['total_tokens']):>8s}"
+            )
+            print(f"  Total cost:           ${usage['cost']:>8.4f}")
+
+        if conv_data["last_message"]:
+            last = conv_data["last_message"]
+            print("\nLast Message")
+            print(f"  {last['role']}: {last['preview']}")
+        return
+
     from ..logmanager import get_user_conversations  # fmt: skip
 
     since_ts = _parse_since(since)

--- a/gptme/tools/chats.py
+++ b/gptme/tools/chats.py
@@ -12,6 +12,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Literal
 
+from ..logmanager.conversations import _format_duration
 from ..message import Message
 from .base import ToolSpec, ToolUse
 
@@ -339,22 +340,6 @@ def _format_tokens(n: int) -> str:
     return str(n)
 
 
-def _format_duration(seconds: float) -> str:
-    """Format duration seconds into a compact human-readable string."""
-    total_seconds = max(0, int(seconds))
-    days, rem = divmod(total_seconds, 86_400)
-    hours, rem = divmod(rem, 3_600)
-    minutes, secs = divmod(rem, 60)
-
-    if days:
-        return f"{days}d {hours}h"
-    if hours:
-        return f"{hours}h {minutes}m"
-    if minutes:
-        return f"{minutes}m {secs}s"
-    return f"{secs}s"
-
-
 def _normalize_timestamp(ts: datetime) -> datetime:
     """Normalize datetimes to timezone-aware UTC."""
     if ts.tzinfo is None:
@@ -388,6 +373,10 @@ def _conversation_detail(conversation_id: str) -> dict:
         if not tool_uses and "<tool-use>" in msg.content:
             tool_uses = list(
                 ToolUse.iter_from_content(msg.content, tool_format_override="xml")
+            )
+        if not tool_uses and "```" in msg.content:
+            tool_uses = list(
+                ToolUse.iter_from_content(msg.content, tool_format_override="markdown")
             )
         for tool_use in tool_uses:
             tool_counts[tool_use.tool] += 1

--- a/tests/test_chats_json.py
+++ b/tests/test_chats_json.py
@@ -79,6 +79,31 @@ class TestConvToDict:
         # Must not raise
         json.dumps(d)
 
+    def test_metadata_format_includes_usage_fields(self):
+        conv = ConversationMeta(
+            id="test-6",
+            name="conv-test-6",
+            path="/tmp/fake/test-6/conversation.jsonl",
+            created=datetime(2026, 1, 1, tzinfo=timezone.utc).timestamp(),
+            modified=datetime(2026, 1, 1, 0, 5, tzinfo=timezone.utc).timestamp(),
+            messages=8,
+            branches=1,
+            workspace="/tmp",
+            model="openai/gpt-5",
+            total_cost=0.1234,
+            total_input_tokens=3200,
+            total_output_tokens=800,
+            last_message_role="assistant",
+            last_message_preview="Wrapped up the task.",
+        )
+
+        output = conv.format(metadata=True)
+        assert "Model:    openai/gpt-5" in output
+        assert "Tokens:   4.0K total (3.2K in / 800 out)" in output
+        assert "Cost:     $0.12" in output
+        assert "Duration: 5m 0s" in output
+        assert "Last:     assistant: Wrapped up the task." in output
+
 
 # --- chats list --json tests ---
 

--- a/tests/test_chats_stats.py
+++ b/tests/test_chats_stats.py
@@ -2,6 +2,7 @@
 
 import json
 from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -9,6 +10,7 @@ from click.testing import CliRunner
 
 from gptme.cli.util import main
 from gptme.logmanager import ConversationMeta
+from gptme.message import Message
 from gptme.tools.chats import _parse_since, conversation_stats
 
 # --- _parse_since tests ---
@@ -52,6 +54,13 @@ def _make_conv(
     messages: int = 10,
     days_ago: int = 0,
     agent_name: str | None = None,
+    model: str | None = None,
+    cost: float = 0.0,
+    input_tokens: int = 0,
+    output_tokens: int = 0,
+    cache_read_tokens: int = 0,
+    last_message_role: str | None = None,
+    last_message_preview: str | None = None,
 ) -> ConversationMeta:
     """Helper to create test ConversationMeta objects."""
     now = datetime.now(tz=timezone.utc)
@@ -66,6 +75,13 @@ def _make_conv(
         branches=1,
         workspace="/tmp",
         agent_name=agent_name,
+        model=model,
+        total_cost=cost,
+        total_input_tokens=input_tokens,
+        total_output_tokens=output_tokens,
+        total_cache_read_tokens=cache_read_tokens,
+        last_message_role=last_message_role,
+        last_message_preview=last_message_preview,
     )
 
 
@@ -272,3 +288,106 @@ def test_stats_hist_days_capped_at_365(mock_get_convs):
     data = json.loads(buf.getvalue())
     # by_day must be capped at 365, not ~2200+ days
     assert len(data["by_day"]) == 365
+
+
+@patch("gptme.logmanager.LogManager")
+@patch("gptme.logmanager.get_conversation_by_id")
+def test_session_stats_json(mock_get_conv, mock_log_manager, capsys):
+    """Detailed stats for one conversation should include tools, usage, and duration."""
+    mock_get_conv.return_value = _make_conv(
+        "demo-chat",
+        messages=4,
+        agent_name="Bob",
+        model="openai/gpt-5",
+        cost=0.1234,
+        input_tokens=1200,
+        output_tokens=345,
+        cache_read_tokens=600,
+        last_message_role="assistant",
+        last_message_preview="Done.",
+    )
+    mock_log_manager.load.return_value = SimpleNamespace(
+        log=[
+            Message(
+                "system",
+                "system prompt",
+                timestamp=datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc),
+            ),
+            Message(
+                "user",
+                "hello",
+                timestamp=datetime(2026, 1, 1, 12, 1, tzinfo=timezone.utc),
+            ),
+            Message(
+                "assistant",
+                '@shell(call-1): {"command": "pwd"}\n@read(call-2): {"path": "/tmp/demo"}',
+                timestamp=datetime(2026, 1, 1, 12, 3, tzinfo=timezone.utc),
+            ),
+            Message(
+                "assistant",
+                "Done.",
+                timestamp=datetime(2026, 1, 1, 12, 4, tzinfo=timezone.utc),
+            ),
+        ]
+    )
+
+    conversation_stats(conversation_id="demo-chat", as_json=True)
+
+    data = json.loads(capsys.readouterr().out)
+    assert data["id"] == "demo-chat"
+    assert data["messages"]["total"] == 4
+    assert data["messages"]["by_role"]["assistant"] == 2
+    assert data["tool_calls"]["total"] == 2
+    assert data["tool_calls"]["by_tool"] == {"shell": 1, "read": 1}
+    assert data["usage"]["total_tokens"] == 1545
+    assert data["usage"]["cost"] == 0.1234
+    assert data["duration_seconds"] == 240
+    assert data["last_message"]["preview"] == "Done."
+
+
+@patch("gptme.logmanager.LogManager")
+@patch("gptme.logmanager.get_conversation_by_id")
+def test_cli_chats_stats_single_conversation(mock_get_conv, mock_log_manager):
+    """CLI should support inspecting a single conversation by ID."""
+    mock_get_conv.return_value = _make_conv(
+        "demo-chat",
+        messages=3,
+        model="anthropic/claude-sonnet-4-6",
+        input_tokens=800,
+        output_tokens=200,
+    )
+    mock_log_manager.load.return_value = SimpleNamespace(
+        log=[
+            Message(
+                "user",
+                "hello",
+                timestamp=datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc),
+            ),
+            Message(
+                "assistant",
+                '@shell(call-1): {"command": "pwd"}',
+                timestamp=datetime(2026, 1, 1, 12, 2, tzinfo=timezone.utc),
+            ),
+            Message(
+                "system",
+                "Ran command",
+                timestamp=datetime(2026, 1, 1, 12, 3, tzinfo=timezone.utc),
+            ),
+        ]
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["chats", "stats", "demo-chat"])
+    assert result.exit_code == 0, result.output
+    assert "Conversation Stats: conv-demo-chat" in result.output
+    assert "Tool calls:           1" in result.output
+    assert "shell=1" in result.output
+    assert "anthropic/claude-sonnet-4-6" in result.output
+
+
+def test_cli_chats_stats_rejects_since_with_id():
+    """Per-conversation stats should not accept aggregate-only filters."""
+    runner = CliRunner()
+    result = runner.invoke(main, ["chats", "stats", "demo-chat", "--since", "7d"])
+    assert result.exit_code != 0
+    assert "Cannot use --since" in result.output


### PR DESCRIPTION
## Summary
- add detailed `gptme-util chats stats [ID]` output for a single conversation
- count assistant tool calls and expose duration, tokens, cost, and role breakdown
- make `gptme-util chats list --metadata` show model, tokens, cost, duration, and last-message preview

## Testing
- env PYTHONPATH=/tmp/gptme-b90a /home/bob/gptme/.venv/bin/pytest /tmp/gptme-b90a/tests/test_chats_stats.py /tmp/gptme-b90a/tests/test_chats_json.py -q
- env PYTHONPATH=/tmp/gptme-b90a /home/bob/gptme/.venv/bin/pytest /tmp/gptme-b90a/tests/test_util_cli.py -q -k "chats"
- env PYTHONPATH=/tmp/gptme-b90a /home/bob/gptme/.venv/bin/python -m mypy /tmp/gptme-b90a/gptme/cli/cmd_chats.py /tmp/gptme-b90a/gptme/tools/chats.py /tmp/gptme-b90a/gptme/logmanager/conversations.py
- env PYTHONPATH=/tmp/gptme-b90a /home/bob/gptme/.venv/bin/python -m ruff check /tmp/gptme-b90a/gptme/cli/cmd_chats.py /tmp/gptme-b90a/gptme/tools/chats.py /tmp/gptme-b90a/gptme/logmanager/conversations.py /tmp/gptme-b90a/tests/test_chats_stats.py /tmp/gptme-b90a/tests/test_chats_json.py