### PR TITLE
feat(server): add provider health endpoint and webui panel

### DIFF
--- a/gptme/llm/llm_openai_subscription.py
+++ b/gptme/llm/llm_openai_subscription.py
@@ -365,7 +365,9 @@ def oauth_authenticate() -> SubscriptionAuth:
     return auth
 
 
-def _refresh_access_token(refresh_token: str) -> SubscriptionAuth:
+def _refresh_access_token(
+    refresh_token: str, timeout: float | tuple[float, float] = 30
+) -> SubscriptionAuth:
     """Refresh access token using refresh token."""
     response = requests.post(
         OAUTH_TOKEN_URL,
@@ -375,7 +377,7 @@ def _refresh_access_token(refresh_token: str) -> SubscriptionAuth:
             "refresh_token": refresh_token,
         },
         headers={"Content-Type": "application/x-www-form-urlencoded"},
-        timeout=30,
+        timeout=timeout,
     )
 
     if response.status_code != 200:
@@ -403,7 +405,7 @@ def _refresh_access_token(refresh_token: str) -> SubscriptionAuth:
     return auth
 
 
-def get_auth() -> SubscriptionAuth:
+def get_auth(timeout: float | tuple[float, float] = 30) -> SubscriptionAuth:
     """Get current auth, refreshing or prompting login if needed."""
     global _auth
     last_refresh_error: Exception | None = None
@@ -414,7 +416,7 @@ def get_auth() -> SubscriptionAuth:
 
         if _auth.refresh_token:
             try:
-                _auth = _refresh_access_token(_auth.refresh_token)
+                _auth = _refresh_access_token(_auth.refresh_token, timeout=timeout)
                 return _auth
             except Exception as e:
                 logger.warning(f"Token refresh failed: {e}")
@@ -428,7 +430,9 @@ def get_auth() -> SubscriptionAuth:
 
         if stored_auth.refresh_token:
             try:
-                _auth = _refresh_access_token(stored_auth.refresh_token)
+                _auth = _refresh_access_token(
+                    stored_auth.refresh_token, timeout=timeout
+                )
                 return _auth
             except Exception as e:
                 logger.warning(f"Token refresh failed: {e}")

--- a/gptme/llm/models/resolution.py
+++ b/gptme/llm/models/resolution.py
@@ -1,4 +1,5 @@
 import logging
+import threading
 from contextvars import ContextVar
 from datetime import datetime, timezone
 from typing import cast
@@ -52,13 +53,16 @@ def set_default_model(model: str | ModelMeta) -> None:
     _default_model_var.set(modelmeta)
 
 
-_logged_warnings = set()
+_logged_warnings: set[str] = set()
+_logged_warnings_lock = threading.Lock()
 
 
 def log_warn_once(msg: str):
-    if msg not in _logged_warnings:
-        logger.warning(msg)
+    with _logged_warnings_lock:
+        if msg in _logged_warnings:
+            return
         _logged_warnings.add(msg)
+    logger.warning(msg)
 
 
 def _get_custom_provider_config(provider_name: str):

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -1701,6 +1701,13 @@ def _probe_provider(provider_name: str) -> dict:
             health_client = openai_client.with_options(timeout=_PROVIDER_HEALTH_TIMEOUT)
             next(iter(health_client.models.list()), None)
 
+        elif provider_name == "openai-subscription":
+            from ..llm.llm_openai_subscription import (
+                get_auth as get_subscription_auth,
+            )
+
+            get_subscription_auth(timeout=_PROVIDER_HEALTH_TIMEOUT)
+
         else:
             # Plugin or unknown provider — key is configured but no live check
             return {"status": "configured", "latency_ms": elapsed_ms(), "error": None}

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -9,6 +9,7 @@ import json
 import logging
 import os
 import shutil
+import threading
 import time
 import urllib.error
 import urllib.parse
@@ -1634,6 +1635,7 @@ def api_models():
 # Cache for provider health results
 _provider_health_cache: dict[str, object] = {}
 _provider_health_cache_time: float = 0.0
+_provider_health_lock = threading.Lock()
 _PROVIDER_HEALTH_TTL = 60.0  # seconds
 _PROVIDER_HEALTH_TIMEOUT = 5.0  # seconds per provider
 
@@ -1683,6 +1685,7 @@ def _probe_provider(provider_name: str) -> dict:
             "groq",
             "deepseek",
             "nvidia",
+            "moonshot",
         ):
             from ..llm.llm_openai import get_client as get_openai_client  # fmt: skip
             from ..llm.llm_openai import has_client  # fmt: skip
@@ -1761,17 +1764,26 @@ def api_providers_health():
     force = request.args.get("force", "").lower() in ("1", "true", "yes")
     now = time.monotonic()
 
+    # Fast path: read cache without lock
     if not force and (now - _provider_health_cache_time) < _PROVIDER_HEALTH_TTL:
         return flask.jsonify(_provider_health_cache)
 
-    available = list_available_providers()
-    provider_names = [str(p) for p, _ in available]
+    with _provider_health_lock:
+        # Double-check after acquiring lock (prevents thundering herd)
+        if not force and (now - _provider_health_cache_time) < _PROVIDER_HEALTH_TTL:
+            return flask.jsonify(_provider_health_cache)
 
+        available = list_available_providers()
+        provider_names = [str(p) for p, _ in available]
+
+    # Probe outside lock (call may block on ThreadPoolExecutor)
     response: dict[str, object] = {
         "providers": _collect_provider_health(provider_names)
     }
-    _provider_health_cache = response
-    _provider_health_cache_time = now
+
+    with _provider_health_lock:
+        _provider_health_cache = response
+        _provider_health_cache_time = now
 
     return flask.jsonify(response)
 

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -9,10 +9,13 @@ import json
 import logging
 import os
 import shutil
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
 from base64 import b64encode
+from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import wait as futures_wait
 from dataclasses import asdict, replace
 from datetime import datetime, timezone
 from itertools import islice
@@ -46,6 +49,7 @@ from gptme.llm.models import (
     get_recommended_model,
     set_default_model,
 )
+from gptme.llm.models.types import is_custom_provider
 from gptme.prompts import get_prompt
 
 from ..commands import handle_cmd
@@ -1625,6 +1629,149 @@ def api_models():
             "recommended": recommended,
         }
     )
+
+
+# Cache for provider health results
+_provider_health_cache: dict[str, object] = {}
+_provider_health_cache_time: float = 0.0
+_PROVIDER_HEALTH_TTL = 60.0  # seconds
+_PROVIDER_HEALTH_TIMEOUT = 5.0  # seconds per provider
+
+
+def _probe_provider(provider_name: str) -> dict:
+    """Probe a single provider and return {status, latency_ms, error}."""
+    start = time.monotonic()
+
+    def elapsed_ms() -> int:
+        return round((time.monotonic() - start) * 1000)
+
+    try:
+        provider = cast(Provider, provider_name)
+
+        if provider_name in ("openrouter", "local", "gptme") or is_custom_provider(
+            provider
+        ):
+            # These support dynamic model listing via an HTTP call
+            from ..llm import get_available_models  # fmt: skip
+
+            get_available_models(provider)
+
+        elif provider_name == "anthropic":
+            from ..llm.llm_anthropic import (
+                get_client as get_anthropic_client,  # fmt: skip
+            )
+            from ..llm.llm_anthropic import init as init_anthropic  # fmt: skip
+
+            anthropic_client = get_anthropic_client()
+            if anthropic_client is None:
+                init_anthropic(get_config())
+                anthropic_client = get_anthropic_client()
+            if anthropic_client is None:
+                return {
+                    "status": "error",
+                    "latency_ms": elapsed_ms(),
+                    "error": "Client not initialized",
+                }
+            # Lightweight list call to verify connectivity and auth
+            next(iter(anthropic_client.models.list(limit=1)), None)
+
+        elif provider_name in (
+            "openai",
+            "azure",
+            "gemini",
+            "xai",
+            "groq",
+            "deepseek",
+            "nvidia",
+        ):
+            from ..llm.llm_openai import get_client as get_openai_client  # fmt: skip
+            from ..llm.llm_openai import has_client  # fmt: skip
+            from ..llm.llm_openai import init as init_openai  # fmt: skip
+
+            if not has_client(provider):
+                init_openai(provider, get_config())
+            openai_client = get_openai_client(provider)
+            next(iter(openai_client.models.list()), None)
+
+        else:
+            # Plugin or unknown provider — key is configured but no live check
+            return {"status": "configured", "latency_ms": elapsed_ms(), "error": None}
+
+        return {"status": "ok", "latency_ms": elapsed_ms(), "error": None}
+
+    except Exception as e:
+        return {"status": "error", "latency_ms": elapsed_ms(), "error": str(e)}
+
+
+def _timeout_health_result() -> dict[str, object]:
+    return {
+        "status": "error",
+        "latency_ms": round(_PROVIDER_HEALTH_TIMEOUT * 1000),
+        "error": "Timeout",
+    }
+
+
+def _collect_provider_health(provider_names: list[str]) -> dict[str, dict]:
+    if not provider_names:
+        return {}
+
+    executor = ThreadPoolExecutor(max_workers=len(provider_names))
+    future_to_name = {
+        executor.submit(_probe_provider, name): name for name in provider_names
+    }
+
+    try:
+        done, not_done = futures_wait(future_to_name, timeout=_PROVIDER_HEALTH_TIMEOUT)
+        results: dict[str, dict] = {}
+
+        for future in done:
+            name = future_to_name[future]
+            try:
+                results[name] = future.result()
+            except Exception as e:
+                results[name] = {
+                    "status": "error",
+                    "latency_ms": None,
+                    "error": str(e),
+                }
+
+        for future in not_done:
+            name = future_to_name[future]
+            future.cancel()
+            results[name] = _timeout_health_result()
+
+        return results
+    finally:
+        # Avoid blocking the request thread on providers that ignore client-side timeouts.
+        executor.shutdown(wait=False, cancel_futures=True)
+
+
+@v2_api.route("/api/v2/providers/health")
+@require_auth
+@api_doc_simple(tags=["models"])
+def api_providers_health():
+    """Check health of all configured providers.
+
+    Probes each configured provider with a lightweight API call (model listing)
+    and returns status, latency, and any error message. Results are cached for
+    60 seconds. Pass ``?force=1`` to bypass the cache.
+    """
+    global _provider_health_cache, _provider_health_cache_time
+
+    force = request.args.get("force", "").lower() in ("1", "true", "yes")
+    now = time.monotonic()
+
+    if not force and (now - _provider_health_cache_time) < _PROVIDER_HEALTH_TTL:
+        return flask.jsonify(_provider_health_cache)
+
+    available = list_available_providers()
+    provider_names = [str(p) for p, _ in available]
+
+    response: dict[str, object] = {"providers": _collect_provider_health(provider_names)}
+    _provider_health_cache = response
+    _provider_health_cache_time = now
+
+    return flask.jsonify(response)
 
 
 @v2_api.route("/api/v2/commands")

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -1635,7 +1635,8 @@ def api_models():
 # Cache for provider health results
 _provider_health_cache: dict[str, object] = {}
 _provider_health_cache_time: float = 0.0
-_provider_health_lock = threading.Lock()
+_provider_health_condition = threading.Condition()
+_provider_health_refreshing = False
 _PROVIDER_HEALTH_TTL = 60.0  # seconds
 _PROVIDER_HEALTH_TIMEOUT = 5.0  # seconds per provider
 
@@ -1675,7 +1676,10 @@ def _probe_provider(provider_name: str) -> dict:
                     "error": "Client not initialized",
                 }
             # Lightweight list call to verify connectivity and auth
-            next(iter(anthropic_client.models.list(limit=1)), None)
+            health_client = anthropic_client.with_options(
+                timeout=_PROVIDER_HEALTH_TIMEOUT
+            )
+            next(iter(health_client.models.list(limit=1)), None)
 
         elif provider_name in (
             "openai",
@@ -1694,7 +1698,8 @@ def _probe_provider(provider_name: str) -> dict:
             if not has_client(provider):
                 init_openai(provider, get_config())
             openai_client = get_openai_client(provider)
-            next(iter(openai_client.models.list()), None)
+            health_client = openai_client.with_options(timeout=_PROVIDER_HEALTH_TIMEOUT)
+            next(iter(health_client.models.list()), None)
 
         else:
             # Plugin or unknown provider — key is configured but no live check
@@ -1759,33 +1764,41 @@ def api_providers_health():
     and returns status, latency, and any error message. Results are cached for
     60 seconds. Pass ``?force=1`` to bypass the cache.
     """
-    global _provider_health_cache, _provider_health_cache_time
-
     force = request.args.get("force", "").lower() in ("1", "true", "yes")
-    now = time.monotonic()
+    return flask.jsonify(_get_provider_health_response(force))
 
-    # Fast path: read cache without lock
-    if not force and (now - _provider_health_cache_time) < _PROVIDER_HEALTH_TTL:
-        return flask.jsonify(_provider_health_cache)
 
-    with _provider_health_lock:
-        # Double-check after acquiring lock (prevents thundering herd)
-        if not force and (now - _provider_health_cache_time) < _PROVIDER_HEALTH_TTL:
-            return flask.jsonify(_provider_health_cache)
+def _get_provider_health_response(force: bool) -> dict[str, object]:
+    global _provider_health_cache, _provider_health_cache_time
+    global _provider_health_refreshing
 
+    with _provider_health_condition:
+        while True:
+            now = time.monotonic()
+            cache_fresh = (now - _provider_health_cache_time) < _PROVIDER_HEALTH_TTL
+            if not force and cache_fresh:
+                return _provider_health_cache
+            if not _provider_health_refreshing:
+                _provider_health_refreshing = True
+                break
+            _provider_health_condition.wait()
+            force = False
+
+    try:
         available = list_available_providers()
         provider_names = [str(p) for p, _ in available]
+        response: dict[str, object] = {
+            "providers": _collect_provider_health(provider_names)
+        }
+    finally:
+        with _provider_health_condition:
+            if "response" in locals():
+                _provider_health_cache = response
+                _provider_health_cache_time = time.monotonic()
+            _provider_health_refreshing = False
+            _provider_health_condition.notify_all()
 
-    # Probe outside lock (call may block on ThreadPoolExecutor)
-    response: dict[str, object] = {
-        "providers": _collect_provider_health(provider_names)
-    }
-
-    with _provider_health_lock:
-        _provider_health_cache = response
-        _provider_health_cache_time = now
-
-    return flask.jsonify(response)
+    return response
 
 
 @v2_api.route("/api/v2/commands")

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -1767,7 +1767,9 @@ def api_providers_health():
     available = list_available_providers()
     provider_names = [str(p) for p, _ in available]
 
-    response: dict[str, object] = {"providers": _collect_provider_health(provider_names)}
+    response: dict[str, object] = {
+        "providers": _collect_provider_health(provider_names)
+    }
     _provider_health_cache = response
     _provider_health_cache_time = now
 

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -1657,7 +1657,9 @@ def _probe_provider(provider_name: str) -> dict:
             # These support dynamic model listing via an HTTP call
             from ..llm import get_available_models  # fmt: skip
 
-            get_available_models(provider)
+            models = get_available_models(provider)
+            if not models:
+                raise RuntimeError(f"No models returned from {provider_name}")
 
         elif provider_name == "anthropic":
             from ..llm.llm_anthropic import (
@@ -1676,10 +1678,10 @@ def _probe_provider(provider_name: str) -> dict:
                     "error": "Client not initialized",
                 }
             # Lightweight list call to verify connectivity and auth
-            health_client = anthropic_client.with_options(
+            anthropic_health_client = anthropic_client.with_options(
                 timeout=_PROVIDER_HEALTH_TIMEOUT
             )
-            next(iter(health_client.models.list(limit=1)), None)
+            next(iter(anthropic_health_client.models.list(limit=1)), None)
 
         elif provider_name in (
             "openai",
@@ -1698,8 +1700,10 @@ def _probe_provider(provider_name: str) -> dict:
             if not has_client(provider):
                 init_openai(provider, get_config())
             openai_client = get_openai_client(provider)
-            health_client = openai_client.with_options(timeout=_PROVIDER_HEALTH_TIMEOUT)
-            next(iter(health_client.models.list()), None)
+            openai_health_client = openai_client.with_options(
+                timeout=_PROVIDER_HEALTH_TIMEOUT
+            )
+            next(iter(openai_health_client.models.list()), None)
 
         elif provider_name == "openai-subscription":
             from ..llm.llm_openai_subscription import (

--- a/tests/test_llm_models_resolution.py
+++ b/tests/test_llm_models_resolution.py
@@ -367,6 +367,21 @@ class TestLogWarnOnce:
             log_warn_once(test_msg)  # second call — should be suppressed
         assert test_msg not in caplog.text
 
+    def test_threaded_warn_once(self, caplog):
+        """Concurrent callers should not race the warning de-dup cache."""
+        import logging
+        from concurrent.futures import ThreadPoolExecutor
+
+        test_msg = f"threaded-dedup-test-message-{id(self)}"
+        with (
+            caplog.at_level(logging.WARNING),
+            ThreadPoolExecutor(max_workers=8) as executor,
+        ):
+            list(executor.map(log_warn_once, [test_msg] * 32))
+
+        warnings = [r for r in caplog.records if test_msg in r.getMessage()]
+        assert len(warnings) == 1
+
     def test_get_model_unknown_warns_once(self, caplog):
         """get_model on an unknown model should warn once across repeated calls.
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -424,6 +424,21 @@ def test_probe_provider_checks_openai_subscription_auth(
     assert calls == [api_module._PROVIDER_HEALTH_TIMEOUT]
 
 
+def test_probe_provider_empty_dynamic_models_is_unhealthy(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """local/gptme/custom probes should not report ok when model listing is empty."""
+    from gptme import llm
+    from gptme.server import api_v2 as api_module
+
+    monkeypatch.setattr(llm, "get_available_models", lambda provider: [])
+
+    result = api_module._probe_provider("local")
+
+    assert result["status"] == "error"
+    assert result["error"] == "No models returned from local"
+
+
 def test_api_providers_health_force_shares_inflight_refresh(
     monkeypatch: pytest.MonkeyPatch,
 ):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,5 +1,6 @@
 import copy
 import random
+import time
 from pathlib import Path
 
 import pytest
@@ -308,6 +309,130 @@ def test_default_model_propagation():
         from gptme.llm.models import _default_model_var
 
         _default_model_var.set(None)
+
+
+def _reset_provider_health_cache(monkeypatch: pytest.MonkeyPatch):
+    import gptme.server.api_v2 as api_module
+
+    monkeypatch.setattr(api_module, "_provider_health_cache", {})
+    monkeypatch.setattr(api_module, "_provider_health_cache_time", 0.0)
+    return api_module
+
+
+def test_api_providers_health_structure(
+    client: FlaskClient, monkeypatch: pytest.MonkeyPatch
+):
+    """Test that /api/v2/providers/health returns the expected response shape."""
+    api_module = _reset_provider_health_cache(monkeypatch)
+    monkeypatch.setattr(
+        api_module,
+        "list_available_providers",
+        lambda: [("anthropic", "ANTHROPIC_API_KEY"), ("openai", "OPENAI_API_KEY")],
+    )
+    monkeypatch.setattr(
+        api_module,
+        "_probe_provider",
+        lambda provider_name: {
+            "status": "ok" if provider_name == "anthropic" else "error",
+            "latency_ms": 42 if provider_name == "anthropic" else 17,
+            "error": None if provider_name == "anthropic" else "bad key",
+        },
+    )
+
+    response = client.get("/api/v2/providers/health")
+    assert response.status_code == 200
+    assert response.get_json() == {
+        "providers": {
+            "anthropic": {"status": "ok", "latency_ms": 42, "error": None},
+            "openai": {"status": "error", "latency_ms": 17, "error": "bad key"},
+        }
+    }
+
+
+def test_api_providers_health_cached(
+    client: FlaskClient, monkeypatch: pytest.MonkeyPatch
+):
+    """Test that repeated calls use the cache instead of probing again."""
+    api_module = _reset_provider_health_cache(monkeypatch)
+    monkeypatch.setattr(
+        api_module,
+        "list_available_providers",
+        lambda: [("anthropic", "ANTHROPIC_API_KEY")],
+    )
+    calls: list[str] = []
+
+    def fake_probe(provider_name: str) -> dict[str, object]:
+        calls.append(provider_name)
+        return {"status": "ok", "latency_ms": 5, "error": None}
+
+    monkeypatch.setattr(api_module, "_probe_provider", fake_probe)
+
+    r1 = client.get("/api/v2/providers/health")
+    r2 = client.get("/api/v2/providers/health")
+    assert r1.status_code == 200
+    assert r2.status_code == 200
+    assert calls == ["anthropic"]
+    assert r1.get_json() == r2.get_json()
+
+
+def test_api_providers_health_force(
+    client: FlaskClient, monkeypatch: pytest.MonkeyPatch
+):
+    """Test that ?force=1 bypasses the cache."""
+    api_module = _reset_provider_health_cache(monkeypatch)
+    monkeypatch.setattr(
+        api_module,
+        "list_available_providers",
+        lambda: [("anthropic", "ANTHROPIC_API_KEY")],
+    )
+    calls: list[str] = []
+
+    def fake_probe(provider_name: str) -> dict[str, object]:
+        calls.append(provider_name)
+        return {"status": "ok", "latency_ms": 7, "error": None}
+
+    monkeypatch.setattr(api_module, "_probe_provider", fake_probe)
+
+    response = client.get("/api/v2/providers/health")
+    forced = client.get("/api/v2/providers/health?force=1")
+    assert response.status_code == 200
+    assert forced.status_code == 200
+    assert calls == ["anthropic", "anthropic"]
+
+
+def test_api_providers_health_timeout_returns_quickly(
+    client: FlaskClient, monkeypatch: pytest.MonkeyPatch
+):
+    """Slow probes should surface as timeouts without blocking the response."""
+    api_module = _reset_provider_health_cache(monkeypatch)
+    monkeypatch.setattr(
+        api_module,
+        "list_available_providers",
+        lambda: [("anthropic", "ANTHROPIC_API_KEY")],
+    )
+    monkeypatch.setattr(api_module, "_PROVIDER_HEALTH_TIMEOUT", 0.01)
+
+    def slow_probe(_provider_name: str) -> dict[str, object]:
+        time.sleep(0.2)
+        return {"status": "ok", "latency_ms": 200, "error": None}
+
+    monkeypatch.setattr(api_module, "_probe_provider", slow_probe)
+
+    start = time.monotonic()
+    response = client.get("/api/v2/providers/health?force=1")
+    elapsed = time.monotonic() - start
+
+    assert response.status_code == 200
+    assert elapsed < 0.12
+    assert response.get_json() == {
+        "providers": {
+            "anthropic": {
+                "status": "error",
+                "latency_ms": 10,
+                "error": "Timeout",
+            }
+        }
+    }
 
 
 def test_api_v2_commands(client: FlaskClient):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,5 +1,6 @@
 import copy
 import random
+import threading
 import time
 from pathlib import Path
 
@@ -316,6 +317,7 @@ def _reset_provider_health_cache(monkeypatch: pytest.MonkeyPatch):
 
     monkeypatch.setattr(api_module, "_provider_health_cache", {})
     monkeypatch.setattr(api_module, "_provider_health_cache_time", 0.0)
+    monkeypatch.setattr(api_module, "_provider_health_refreshing", False)
     return api_module
 
 
@@ -398,6 +400,55 @@ def test_api_providers_health_force(
     assert response.status_code == 200
     assert forced.status_code == 200
     assert calls == ["anthropic", "anthropic"]
+
+
+def test_api_providers_health_force_shares_inflight_refresh(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Concurrent forced refreshes should share one probe instead of stampeding."""
+    api_module = _reset_provider_health_cache(monkeypatch)
+    monkeypatch.setattr(
+        api_module,
+        "list_available_providers",
+        lambda: [("anthropic", "ANTHROPIC_API_KEY")],
+    )
+    probe_started = threading.Event()
+    release_probe = threading.Event()
+    calls: list[str] = []
+
+    def fake_probe(provider_name: str) -> dict[str, object]:
+        calls.append(provider_name)
+        probe_started.set()
+        assert release_probe.wait(timeout=1)
+        return {"status": "ok", "latency_ms": 9, "error": None}
+
+    monkeypatch.setattr(api_module, "_probe_provider", fake_probe)
+
+    results: list[dict[str, object]] = []
+
+    def load_health() -> None:
+        results.append(api_module._get_provider_health_response(force=True))
+
+    first = threading.Thread(target=load_health)
+    second = threading.Thread(target=load_health)
+
+    first.start()
+    assert probe_started.wait(timeout=1)
+    second.start()
+    time.sleep(0.01)
+    assert calls == ["anthropic"]
+
+    release_probe.set()
+    first.join(timeout=1)
+    second.join(timeout=1)
+
+    assert not first.is_alive()
+    assert not second.is_alive()
+    assert calls == ["anthropic"]
+    assert results == [
+        {"providers": {"anthropic": {"status": "ok", "latency_ms": 9, "error": None}}},
+        {"providers": {"anthropic": {"status": "ok", "latency_ms": 9, "error": None}}},
+    ]
 
 
 def test_api_providers_health_timeout_returns_quickly(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -402,6 +402,28 @@ def test_api_providers_health_force(
     assert calls == ["anthropic", "anthropic"]
 
 
+def test_probe_provider_checks_openai_subscription_auth(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """openai-subscription should get a real auth check, not configured fallback."""
+    from gptme.llm import llm_openai_subscription
+    from gptme.server import api_v2 as api_module
+
+    calls: list[float] = []
+
+    def fake_get_auth(timeout: float) -> object:
+        calls.append(timeout)
+        return object()
+
+    monkeypatch.setattr(llm_openai_subscription, "get_auth", fake_get_auth)
+
+    result = api_module._probe_provider("openai-subscription")
+
+    assert result["status"] == "ok"
+    assert result["error"] is None
+    assert calls == [api_module._PROVIDER_HEALTH_TIMEOUT]
+
+
 def test_api_providers_health_force_shares_inflight_refresh(
     monkeypatch: pytest.MonkeyPatch,
 ):

--- a/webui/src/components/settings/ServerConfiguration.tsx
+++ b/webui/src/components/settings/ServerConfiguration.tsx
@@ -31,6 +31,7 @@ import { cn } from '@/lib/utils';
 import { ConfigFileEditor } from './ConfigFileEditor';
 import { ServerDefaultModelSettings } from './ServerDefaultModelSettings';
 import { ServerApiKeySettings } from './ServerApiKeySettings';
+import { ServerProviderHealthSettings } from './ServerProviderHealthSettings';
 
 interface ServerFormState {
   name: string;
@@ -382,6 +383,7 @@ export const ServerConfiguration: FC = () => {
       <ConfigFileEditor />
       <ServerApiKeySettings />
       <ServerDefaultModelSettings />
+      <ServerProviderHealthSettings />
 
       <Button variant="outline" onClick={handleOpenAdd}>
         <Plus className="mr-2 h-4 w-4" />

--- a/webui/src/components/settings/ServerProviderHealthSettings.tsx
+++ b/webui/src/components/settings/ServerProviderHealthSettings.tsx
@@ -108,7 +108,11 @@ export function ServerProviderHealthSettings() {
       {providerEntries.length > 0 ? (
         <div className="space-y-2">
           {providerEntries.map(([provider, info]) => {
-            const styles = STATUS_STYLES[info.status];
+            const styles = STATUS_STYLES[info.status] ?? {
+              label: info.status,
+              dotClassName: 'bg-gray-500',
+              textClassName: 'text-gray-500',
+            };
             return (
               <div
                 key={provider}

--- a/webui/src/components/settings/ServerProviderHealthSettings.tsx
+++ b/webui/src/components/settings/ServerProviderHealthSettings.tsx
@@ -1,0 +1,140 @@
+import { useCallback, useEffect, useState } from 'react';
+import { RefreshCw } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { useApi } from '@/contexts/ApiContext';
+
+type ProviderHealthStatus = 'ok' | 'configured' | 'error';
+
+type ProviderHealthEntry = {
+  status: ProviderHealthStatus;
+  latency_ms: number | null;
+  error: string | null;
+};
+
+type ProviderHealthResponse = {
+  providers: Record<string, ProviderHealthEntry>;
+};
+
+const STATUS_STYLES: Record<
+  ProviderHealthStatus,
+  { label: string; dotClassName: string; textClassName: string }
+> = {
+  ok: {
+    label: 'Reachable',
+    dotClassName: 'bg-emerald-500',
+    textClassName: 'text-emerald-700 dark:text-emerald-400',
+  },
+  configured: {
+    label: 'Configured',
+    dotClassName: 'bg-sky-500',
+    textClassName: 'text-sky-700 dark:text-sky-400',
+  },
+  error: {
+    label: 'Error',
+    dotClassName: 'bg-red-500',
+    textClassName: 'text-red-700 dark:text-red-400',
+  },
+};
+
+export function ServerProviderHealthSettings() {
+  const { api } = useApi();
+  const [health, setHealth] = useState<ProviderHealthResponse | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadHealth = useCallback(
+    async (force = false) => {
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const headers: Record<string, string> = {};
+        if (api.authHeader) {
+          headers.Authorization = api.authHeader;
+        }
+
+        const suffix = force ? '?force=1' : '';
+        const response = await fetch(`${api.baseUrl}/api/v2/providers/health${suffix}`, {
+          headers,
+        });
+
+        if (!response.ok) {
+          throw new Error(`Failed to fetch provider health: ${response.statusText}`);
+        }
+
+        const data = (await response.json()) as ProviderHealthResponse;
+        setHealth(data);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to fetch provider health');
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [api.authHeader, api.baseUrl]
+  );
+
+  useEffect(() => {
+    void loadHealth();
+  }, [loadHealth]);
+
+  const providerEntries = Object.entries(health?.providers ?? {});
+
+  return (
+    <div className="space-y-3 rounded-lg border p-4">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h4 className="text-sm font-medium">Provider health</h4>
+          <p className="text-sm text-muted-foreground">
+            Check which configured providers are actually reachable from this server.
+          </p>
+        </div>
+
+        <Button type="button" variant="outline" size="sm" onClick={() => void loadHealth(true)}>
+          <RefreshCw className={`mr-2 h-3.5 w-3.5 ${isLoading ? 'animate-spin' : ''}`} />
+          {isLoading ? 'Refreshing…' : 'Refresh'}
+        </Button>
+      </div>
+
+      {error ? <p className="text-sm text-destructive">{error}</p> : null}
+
+      {!error && isLoading && !health ? (
+        <p className="text-sm text-muted-foreground">Loading provider health…</p>
+      ) : null}
+
+      {!error && !isLoading && providerEntries.length == 0 ? (
+        <p className="text-sm text-muted-foreground">No configured providers detected.</p>
+      ) : null}
+
+      {providerEntries.length > 0 ? (
+        <div className="space-y-2">
+          {providerEntries.map(([provider, info]) => {
+            const styles = STATUS_STYLES[info.status];
+            return (
+              <div
+                key={provider}
+                className="flex flex-wrap items-center justify-between gap-3 rounded-md bg-muted/30 px-3 py-2"
+              >
+                <div className="min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className={`h-2.5 w-2.5 rounded-full ${styles.dotClassName}`} />
+                    <span className="font-medium">{provider}</span>
+                    <span className={`text-xs font-medium ${styles.textClassName}`}>
+                      {styles.label}
+                    </span>
+                  </div>
+                  {info.error ? (
+                    <p className="mt-1 text-xs text-muted-foreground">{info.error}</p>
+                  ) : null}
+                </div>
+
+                <div className="text-xs text-muted-foreground">
+                  {info.latency_ms == null ? 'No latency' : `${info.latency_ms} ms`}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/webui/src/components/settings/ServerProviderHealthSettings.tsx
+++ b/webui/src/components/settings/ServerProviderHealthSettings.tsx
@@ -101,7 +101,13 @@ export function ServerProviderHealthSettings() {
           </p>
         </div>
 
-        <Button type="button" variant="outline" size="sm" onClick={() => void loadHealth(true)}>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => void loadHealth(true)}
+          disabled={isLoading}
+        >
           <RefreshCw className={`mr-2 h-3.5 w-3.5 ${isLoading ? 'animate-spin' : ''}`} />
           {isLoading ? 'Refreshing…' : 'Refresh'}
         </Button>
@@ -144,7 +150,7 @@ export function ServerProviderHealthSettings() {
                 </div>
 
                 <div className="text-xs text-muted-foreground">
-                  {info.latency_ms == null ? 'No latency' : `${info.latency_ms} ms`}
+                  {info.latency_ms === null ? 'No latency' : `${info.latency_ms} ms`}
                 </div>
               </div>
             );

--- a/webui/src/components/settings/ServerProviderHealthSettings.tsx
+++ b/webui/src/components/settings/ServerProviderHealthSettings.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { RefreshCw } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useApi } from '@/contexts/ApiContext';
@@ -41,9 +41,13 @@ export function ServerProviderHealthSettings() {
   const [health, setHealth] = useState<ProviderHealthResponse | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const latestRequestId = useRef(0);
 
   const loadHealth = useCallback(
     async (force = false) => {
+      const requestId = latestRequestId.current + 1;
+      latestRequestId.current = requestId;
+
       setIsLoading(true);
       setError(null);
 
@@ -63,11 +67,19 @@ export function ServerProviderHealthSettings() {
         }
 
         const data = (await response.json()) as ProviderHealthResponse;
+        if (requestId !== latestRequestId.current) {
+          return;
+        }
         setHealth(data);
       } catch (err) {
+        if (requestId !== latestRequestId.current) {
+          return;
+        }
         setError(err instanceof Error ? err.message : 'Failed to fetch provider health');
       } finally {
-        setIsLoading(false);
+        if (requestId === latestRequestId.current) {
+          setIsLoading(false);
+        }
       }
     },
     [api.authHeader, api.baseUrl]
@@ -101,7 +113,7 @@ export function ServerProviderHealthSettings() {
         <p className="text-sm text-muted-foreground">Loading provider health…</p>
       ) : null}
 
-      {!error && !isLoading && providerEntries.length == 0 ? (
+      {!error && !isLoading && providerEntries.length === 0 ? (
         <p className="text-sm text-muted-foreground">No configured providers detected.</p>
       ) : null}
 

--- a/webui/src/components/settings/__tests__/ServerProviderHealthSettings.test.tsx
+++ b/webui/src/components/settings/__tests__/ServerProviderHealthSettings.test.tsx
@@ -1,8 +1,24 @@
 import '@testing-library/jest-dom';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { ServerProviderHealthSettings } from '../ServerProviderHealthSettings';
 
 const mockFetch = jest.fn();
+
+type MockResponse = {
+  ok: boolean;
+  json: () => Promise<{
+    providers: Record<string, { status: string; latency_ms: number | null; error: string | null }>;
+  }>;
+};
+
+function deferred<T>() {
+  let resolve: (value: T) => void = () => {};
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+
+  return { promise, resolve };
+}
 
 jest.mock('@/contexts/ApiContext', () => ({
   useApi: () => ({
@@ -96,5 +112,57 @@ describe('ServerProviderHealthSettings', () => {
         }
       );
     });
+  });
+
+  it('ignores stale responses when refresh finishes before initial load', async () => {
+    const initialResponse = deferred<MockResponse>();
+    const refreshResponse = deferred<MockResponse>();
+
+    mockFetch
+      .mockReturnValueOnce(initialResponse.promise)
+      .mockReturnValueOnce(refreshResponse.promise);
+
+    render(<ServerProviderHealthSettings />);
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /refresh/i }));
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    await act(async () => {
+      refreshResponse.resolve({
+        ok: true,
+        json: async () => ({
+          providers: {
+            anthropic: { status: 'ok', latency_ms: 12, error: null },
+          },
+        }),
+      });
+      await refreshResponse.promise;
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('12 ms')).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      initialResponse.resolve({
+        ok: true,
+        json: async () => ({
+          providers: {
+            anthropic: { status: 'ok', latency_ms: 10, error: null },
+          },
+        }),
+      });
+      await initialResponse.promise;
+    });
+
+    expect(screen.getByText('12 ms')).toBeInTheDocument();
+    expect(screen.queryByText('10 ms')).not.toBeInTheDocument();
   });
 });

--- a/webui/src/components/settings/__tests__/ServerProviderHealthSettings.test.tsx
+++ b/webui/src/components/settings/__tests__/ServerProviderHealthSettings.test.tsx
@@ -1,0 +1,100 @@
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { ServerProviderHealthSettings } from '../ServerProviderHealthSettings';
+
+const mockFetch = jest.fn();
+
+jest.mock('@/contexts/ApiContext', () => ({
+  useApi: () => ({
+    api: {
+      baseUrl: 'http://127.0.0.1:5700',
+      authHeader: 'Bearer test-token',
+    },
+  }),
+}));
+
+jest.mock('@/components/ui/button', () => ({
+  Button: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button {...props}>{children}</button>
+  ),
+}));
+
+describe('ServerProviderHealthSettings', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    Object.defineProperty(window, 'fetch', {
+      writable: true,
+      value: mockFetch,
+    });
+  });
+
+  it('loads and renders provider health from the server API', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        providers: {
+          anthropic: { status: 'ok', latency_ms: 42, error: null },
+          openai: { status: 'error', latency_ms: 17, error: 'bad key' },
+        },
+      }),
+    });
+
+    render(<ServerProviderHealthSettings />);
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith('http://127.0.0.1:5700/api/v2/providers/health', {
+        headers: {
+          Authorization: 'Bearer test-token',
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('anthropic')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Reachable')).toBeInTheDocument();
+    expect(screen.getByText('42 ms')).toBeInTheDocument();
+    expect(screen.getByText('openai')).toBeInTheDocument();
+    expect(screen.getByText('Error')).toBeInTheDocument();
+    expect(screen.getByText('bad key')).toBeInTheDocument();
+  });
+
+  it('forces a refresh when the button is clicked', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          providers: {
+            anthropic: { status: 'ok', latency_ms: 10, error: null },
+          },
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          providers: {
+            anthropic: { status: 'ok', latency_ms: 12, error: null },
+          },
+        }),
+      });
+
+    render(<ServerProviderHealthSettings />);
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /refresh/i }));
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenLastCalledWith(
+        'http://127.0.0.1:5700/api/v2/providers/health?force=1',
+        {
+          headers: {
+            Authorization: 'Bearer test-token',
+          },
+        }
+      );
+    });
+  });
+});

--- a/webui/src/components/settings/__tests__/ServerProviderHealthSettings.test.tsx
+++ b/webui/src/components/settings/__tests__/ServerProviderHealthSettings.test.tsx
@@ -97,10 +97,13 @@ describe('ServerProviderHealthSettings', () => {
     render(<ServerProviderHealthSettings />);
 
     await waitFor(() => {
-      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(screen.getByText('10 ms')).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getByRole('button', { name: /refresh/i }));
+    const refreshButton = screen.getByRole('button', { name: /refresh/i });
+    expect(refreshButton).not.toBeDisabled();
+
+    fireEvent.click(refreshButton);
 
     await waitFor(() => {
       expect(mockFetch).toHaveBeenLastCalledWith(
@@ -114,25 +117,36 @@ describe('ServerProviderHealthSettings', () => {
     });
   });
 
-  it('ignores stale responses when refresh finishes before initial load', async () => {
-    const initialResponse = deferred<MockResponse>();
+  it('prevents duplicate forced refreshes while loading', async () => {
     const refreshResponse = deferred<MockResponse>();
 
     mockFetch
-      .mockReturnValueOnce(initialResponse.promise)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          providers: {
+            anthropic: { status: 'ok', latency_ms: 10, error: null },
+          },
+        }),
+      })
       .mockReturnValueOnce(refreshResponse.promise);
 
     render(<ServerProviderHealthSettings />);
 
     await waitFor(() => {
-      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(screen.getByText('10 ms')).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getByRole('button', { name: /refresh/i }));
+    const refreshButton = screen.getByRole('button', { name: /refresh/i });
+    fireEvent.click(refreshButton);
 
     await waitFor(() => {
       expect(mockFetch).toHaveBeenCalledTimes(2);
     });
+
+    expect(refreshButton).toBeDisabled();
+    fireEvent.click(refreshButton);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
 
     await act(async () => {
       refreshResponse.resolve({
@@ -149,20 +163,5 @@ describe('ServerProviderHealthSettings', () => {
     await waitFor(() => {
       expect(screen.getByText('12 ms')).toBeInTheDocument();
     });
-
-    await act(async () => {
-      initialResponse.resolve({
-        ok: true,
-        json: async () => ({
-          providers: {
-            anthropic: { status: 'ok', latency_ms: 10, error: null },
-          },
-        }),
-      });
-      await initialResponse.promise;
-    });
-
-    expect(screen.getByText('12 ms')).toBeInTheDocument();
-    expect(screen.queryByText('10 ms')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

- Adds `GET /api/v2/providers/health` — returns per-provider `{status, latency_ms, error}` by probing each configured provider with a `list_models()` call (5 s timeout, 60 s TTL cache, non-blocking `ThreadPoolExecutor`)
- Adds **Provider Health** settings panel in the webui (`ServerProviderHealthSettings.tsx`) mounted in `ServerConfiguration`; shows status badges + refresh button
- Adds deterministic server tests: shape, cache reuse, `force=1`, timeout behavior
- Adds Jest tests for the UI component (`ServerProviderHealthSettings.test.tsx`)

## Motivation

When the gptme server starts or the webui connects there's no way to quickly tell which providers are reachable vs. just configured. Users see confusing errors only when they try to start a chat. This endpoint gives the webui (and any tooling) an on-demand health snapshot.

## Test plan

- [ ] `uv run pytest tests/test_server.py -q` — backend tests pass
- [ ] `npm exec -- jest --runInBand ServerProviderHealthSettings.test.tsx` — UI tests pass
- [ ] Manual: start server, open Settings → Server → check Provider Health section shows badges
- [ ] Manual: hit `GET /api/v2/providers/health` and confirm JSON shape