### PR TITLE
feat(webui): add split-pane conversation view (Slice 1 — layout skeleton)

### DIFF
--- a/webui/e2e/conversation.spec.ts
+++ b/webui/e2e/conversation.spec.ts
@@ -104,3 +104,31 @@ test.describe('Conversation Flow', () => {
     await expect(page.getByText('Introduction to gptme')).toBeVisible();
   });
 });
+
+test.describe('Split View', () => {
+  test('should render split panes when ?split= param is present', async ({ page }) => {
+    // Navigate with the split parameter using two demo conversation IDs
+    await page.goto('/chat/introduction%20to%20gptme?split=introduction%20to%20gptme,introduction%20to%20gptme');
+    await page.waitForLoadState('networkidle');
+
+    // Split view header should appear
+    await expect(page.getByText('Split view')).toBeVisible({ timeout: 10000 });
+
+    // Close button should be present
+    await expect(page.getByTitle('Close split view')).toBeVisible({ timeout: 10000 });
+  });
+
+  test('should return to single-pane view when split is closed', async ({ page }) => {
+    await page.goto('/chat/introduction%20to%20gptme?split=introduction%20to%20gptme,introduction%20to%20gptme');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByText('Split view')).toBeVisible({ timeout: 10000 });
+
+    // Click the close button
+    await page.getByTitle('Close split view').click();
+    await page.waitForLoadState('networkidle');
+
+    // Split view header should be gone
+    await expect(page.getByText('Split view')).not.toBeVisible();
+  });
+});

--- a/webui/e2e/conversation.spec.ts
+++ b/webui/e2e/conversation.spec.ts
@@ -108,7 +108,7 @@ test.describe('Conversation Flow', () => {
 test.describe('Split View', () => {
   test('should render split panes when ?split= param is present', async ({ page }) => {
     // Navigate with the split parameter using two demo conversation IDs
-    await page.goto('/chat/introduction%20to%20gptme?split=introduction%20to%20gptme,introduction%20to%20gptme');
+    await page.goto('/chat/introduction?split=introduction,introduction');
     await page.waitForLoadState('networkidle');
 
     // Split view header should appear
@@ -119,7 +119,7 @@ test.describe('Split View', () => {
   });
 
   test('should return to single-pane view when split is closed', async ({ page }) => {
-    await page.goto('/chat/introduction%20to%20gptme?split=introduction%20to%20gptme,introduction%20to%20gptme');
+    await page.goto('/chat/introduction?split=introduction,introduction');
     await page.waitForLoadState('networkidle');
 
     await expect(page.getByText('Split view')).toBeVisible({ timeout: 10000 });

--- a/webui/src/components/ConversationContent.tsx
+++ b/webui/src/components/ConversationContent.tsx
@@ -1,5 +1,5 @@
 import type { FC } from 'react';
-import { useRef, useEffect, useCallback, useState, useId } from 'react';
+import { useRef, useEffect, useCallback, useState } from 'react';
 import { ChatMessage } from './ChatMessage';
 import { ChatInput, type ChatOptions } from './ChatInput';
 import { CollapsedStepGroup } from './CollapsedStepGroup';
@@ -25,8 +25,6 @@ interface Props {
   isReadOnly?: boolean;
 }
 
-let activeConversationPaneId: string | null = null;
-
 export const ConversationContent: FC<Props> = ({ conversationId, serverId, isReadOnly }) => {
   const {
     conversation$,
@@ -49,7 +47,6 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
   const shouldFocus$ = useObservable(false);
   // Store the previous conversation ID to detect changes
   const prevConversationIdRef = useRef<string | null>(null);
-  const paneId = useId();
   const paneRef = useRef<HTMLElement>(null);
 
   const { api, connectionConfig } = useApi();
@@ -61,6 +58,34 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
   const searchQuery$ = useObservable('');
   const searchMatchIndices$ = useObservable<number[]>([]);
   const searchCurrentMatch$ = useObservable(0);
+
+  const activatePane = useCallback(() => {
+    const pane = paneRef.current;
+    if (!pane) return;
+
+    document
+      .querySelectorAll<HTMLElement>('[data-conversation-pane-active="true"]')
+      .forEach((activePane) => {
+        if (activePane !== pane) {
+          activePane.removeAttribute('data-conversation-pane-active');
+        }
+      });
+    pane.dataset.conversationPaneActive = 'true';
+  }, []);
+
+  const isActivePane = useCallback(() => {
+    const pane = paneRef.current;
+    if (!pane) return false;
+
+    const activePane = document.querySelector<HTMLElement>(
+      '[data-conversation-pane-active="true"]'
+    );
+    if (activePane) {
+      return activePane === pane;
+    }
+
+    return document.querySelectorAll('[data-conversation-pane]').length <= 1;
+  }, []);
 
   // Fetch user info once (cached in ApiClient)
   useEffect(() => {
@@ -88,7 +113,7 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
   // Add keyboard shortcut for focusing the input
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (activeConversationPaneId !== paneId) {
+      if (!isActivePane()) {
         return;
       }
 
@@ -109,12 +134,12 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [isReadOnly, hasSession$, paneId, shouldFocus$]);
+  }, [isReadOnly, hasSession$, isActivePane, shouldFocus$]);
 
   // Ctrl+F / Cmd+F to open message search (or re-focus if already open)
   useEffect(() => {
     const handleSearchKeyDown = (e: KeyboardEvent) => {
-      if (activeConversationPaneId !== paneId) {
+      if (!isActivePane()) {
         return;
       }
 
@@ -129,23 +154,22 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
     };
     window.addEventListener('keydown', handleSearchKeyDown);
     return () => window.removeEventListener('keydown', handleSearchKeyDown);
-  }, [paneId, searchVisible$]);
+  }, [isActivePane, searchVisible$]);
 
   useEffect(() => {
-    if (!activeConversationPaneId) {
-      activeConversationPaneId = paneId;
+    const pane = paneRef.current;
+    if (!pane) return;
+
+    if (!document.querySelector('[data-conversation-pane-active="true"]')) {
+      activatePane();
     }
 
     return () => {
-      if (activeConversationPaneId === paneId) {
-        activeConversationPaneId = null;
+      if (pane.dataset.conversationPaneActive === 'true') {
+        pane.removeAttribute('data-conversation-pane-active');
       }
     };
-  }, [paneId]);
-
-  const activatePane = useCallback(() => {
-    activeConversationPaneId = paneId;
-  }, [paneId]);
+  }, [activatePane]);
 
   const firstNonSystemIndex$ = useObservable(() => {
     return conversation$?.get()?.data.log.findIndex((msg) => msg.role !== 'system') || 0;
@@ -479,6 +503,7 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
   return (
     <main
       ref={paneRef}
+      data-conversation-pane
       className="relative flex h-full flex-col"
       onFocus={activatePane}
       onPointerDown={activatePane}

--- a/webui/src/components/ConversationContent.tsx
+++ b/webui/src/components/ConversationContent.tsx
@@ -172,13 +172,13 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
   }, [activatePane]);
 
   const firstNonSystemIndex$ = useObservable(() => {
-    return conversation$?.get()?.data.log.findIndex((msg) => msg.role !== 'system') || 0;
+    return conversation$?.get()?.data?.log?.findIndex((msg) => msg.role !== 'system') ?? 0;
   });
 
   // Update the firstNonSystemIndex$ when the conversationId changes
   useEffect(() => {
     firstNonSystemIndex$.set(
-      conversation$?.get()?.data.log.findIndex((msg) => msg.role !== 'system') || 0
+      conversation$?.get()?.data?.log?.findIndex((msg) => msg.role !== 'system') ?? 0
     );
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [conversationId]);

--- a/webui/src/components/ConversationContent.tsx
+++ b/webui/src/components/ConversationContent.tsx
@@ -1,5 +1,5 @@
 import type { FC } from 'react';
-import { useRef, useEffect, useCallback, useState } from 'react';
+import { useRef, useEffect, useCallback, useState, useId } from 'react';
 import { ChatMessage } from './ChatMessage';
 import { ChatInput, type ChatOptions } from './ChatInput';
 import { CollapsedStepGroup } from './CollapsedStepGroup';
@@ -25,6 +25,8 @@ interface Props {
   isReadOnly?: boolean;
 }
 
+let activeConversationPaneId: string | null = null;
+
 export const ConversationContent: FC<Props> = ({ conversationId, serverId, isReadOnly }) => {
   const {
     conversation$,
@@ -47,6 +49,8 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
   const shouldFocus$ = useObservable(false);
   // Store the previous conversation ID to detect changes
   const prevConversationIdRef = useRef<string | null>(null);
+  const paneId = useId();
+  const paneRef = useRef<HTMLElement>(null);
 
   const { api, connectionConfig } = useApi();
   const hasSession$ = useObservable<boolean>(false);
@@ -84,6 +88,10 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
   // Add keyboard shortcut for focusing the input
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
+      if (activeConversationPaneId !== paneId) {
+        return;
+      }
+
       // Only handle 'i' key when:
       // - Not in an input/textarea
       // - Not in read-only mode
@@ -101,15 +109,19 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [isReadOnly, hasSession$, shouldFocus$]);
+  }, [isReadOnly, hasSession$, paneId, shouldFocus$]);
 
   // Ctrl+F / Cmd+F to open message search (or re-focus if already open)
   useEffect(() => {
     const handleSearchKeyDown = (e: KeyboardEvent) => {
+      if (activeConversationPaneId !== paneId) {
+        return;
+      }
+
       if ((e.ctrlKey || e.metaKey) && e.key === 'f') {
         e.preventDefault();
         if (searchVisible$.get()) {
-          document.querySelector<HTMLInputElement>('[data-search-input]')?.focus();
+          paneRef.current?.querySelector<HTMLInputElement>('[data-search-input]')?.focus();
         } else {
           searchVisible$.set(true);
         }
@@ -117,7 +129,23 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
     };
     window.addEventListener('keydown', handleSearchKeyDown);
     return () => window.removeEventListener('keydown', handleSearchKeyDown);
-  }, [searchVisible$]);
+  }, [paneId, searchVisible$]);
+
+  useEffect(() => {
+    if (!activeConversationPaneId) {
+      activeConversationPaneId = paneId;
+    }
+
+    return () => {
+      if (activeConversationPaneId === paneId) {
+        activeConversationPaneId = null;
+      }
+    };
+  }, [paneId]);
+
+  const activatePane = useCallback(() => {
+    activeConversationPaneId = paneId;
+  }, [paneId]);
 
   const firstNonSystemIndex$ = useObservable(() => {
     return conversation$.get()?.data.log.findIndex((msg) => msg.role !== 'system') || 0;
@@ -449,7 +477,12 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
   }
 
   return (
-    <main className="relative flex h-full flex-col">
+    <main
+      ref={paneRef}
+      className="relative flex h-full flex-col"
+      onFocus={activatePane}
+      onPointerDown={activatePane}
+    >
       <Memo>
         {() =>
           searchVisible$.get() ? (

--- a/webui/src/components/ConversationContent.tsx
+++ b/webui/src/components/ConversationContent.tsx
@@ -148,13 +148,13 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
   }, [paneId]);
 
   const firstNonSystemIndex$ = useObservable(() => {
-    return conversation$.get()?.data.log.findIndex((msg) => msg.role !== 'system') || 0;
+    return conversation$?.get()?.data.log.findIndex((msg) => msg.role !== 'system') || 0;
   });
 
   // Update the firstNonSystemIndex$ when the conversationId changes
   useEffect(() => {
     firstNonSystemIndex$.set(
-      conversation$.get()?.data.log.findIndex((msg) => msg.role !== 'system') || 0
+      conversation$?.get()?.data.log.findIndex((msg) => msg.role !== 'system') || 0
     );
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [conversationId]);
@@ -201,7 +201,7 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
   // All .get() calls inside are auto-tracked, so this re-runs when any of
   // conversation log, showHiddenMessages, showInitialSystem, or firstNonSystemIndex changes.
   useObserveEffect(() => {
-    const messages = conversation$.data.log.get();
+    const messages = conversation$?.data.log.get();
     if (!messages?.length) {
       stepRoles$.set(new Map());
       return;
@@ -238,8 +238,8 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
 
   // Compute fork points once (reactive: recomputes when branches/currentBranch change)
   const forkPoints$ = useObservable(() => {
-    const branches = conversation$.data.branches?.get();
-    const currentBranch = conversation$.currentBranch?.get() || 'main';
+    const branches = conversation$?.data.branches?.get();
+    const currentBranch = conversation$?.currentBranch?.get() || 'main';
     if (!branches || Object.keys(branches).length <= 1) return new Map();
     return computeForkPoints(currentBranch, branches);
   });
@@ -260,7 +260,7 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
   }, [isAutoScrolling$]);
 
   // Auto-scroll when the conversation is updated (e.g., streaming response)
-  useObserveEffect(conversation$.data.log, () => {
+  useObserveEffect(conversation$?.data.log, () => {
     if (!autoScrollAborted$.get()) {
       requestAnimationFrame(scrollToBottom);
     }

--- a/webui/src/components/ConversationContent.tsx
+++ b/webui/src/components/ConversationContent.tsx
@@ -526,7 +526,7 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
           )}
         </Memo>
 
-        <For each={conversation$.data.log}>
+        <For each={conversation$?.data.log ?? []}>
           {(msg$) => {
             const index = getObservableIndex(msg$);
             // Hide all system messages before the first non-system message by default

--- a/webui/src/components/MainLayout.tsx
+++ b/webui/src/components/MainLayout.tsx
@@ -467,11 +467,6 @@ const MainLayout: FC<Props> = ({ conversationId, taskId }) => {
 
     // Chat section — split view
     if (splitIds) {
-      // Wait for conversations to be initialized before rendering split view
-      const leftState = conversations$.get(splitIds[0])?.get();
-      const rightState = conversations$.get(splitIds[1])?.get();
-      const isSplitLoading = !leftState || !rightState;
-
       const leftConversation = getSelectedConversationSummary(splitIds[0]);
       const rightConversation = getSelectedConversationSummary(splitIds[1]);
 
@@ -482,7 +477,6 @@ const MainLayout: FC<Props> = ({ conversationId, taskId }) => {
           serverId={serverParam || undefined}
           leftIsReadOnly={leftConversation.readonly}
           rightIsReadOnly={rightConversation.readonly}
-          isLoading={isSplitLoading}
           vertical={isMobile}
           onClose={() => {
             const params = new URLSearchParams(searchParams);

--- a/webui/src/components/MainLayout.tsx
+++ b/webui/src/components/MainLayout.tsx
@@ -4,6 +4,7 @@ import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from '@/componen
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet';
 import { WelcomeView } from '@/components/WelcomeView';
 import { ConversationContent } from '@/components/ConversationContent';
+import { SplitConversationView } from '@/components/SplitConversationView';
 import { TaskDetails } from '@/components/TaskDetails';
 import { RightSidebar } from '@/components/RightSidebar';
 import { RightSidebarContent } from '@/components/RightSidebarContent';
@@ -26,7 +27,8 @@ import { serverRegistry$ } from '@/stores/servers';
 import { demoConversations, getDemoMessages } from '@/democonversations';
 import { useSearchParams, useNavigate, useLocation } from 'react-router-dom';
 import { Memo, use$, useObservable, useObserveEffect } from '@legendapp/state/react';
-import { Loader2, GitBranch } from 'lucide-react';
+import { Loader2, GitBranch, Columns2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
 import type { ConversationSummary } from '@/types/conversation';
 import type { Task, CreateTaskRequest } from '@/types/task';
 import {
@@ -56,6 +58,12 @@ const MainLayout: FC<Props> = ({ conversationId, taskId }) => {
   const location = useLocation();
   const stepParam = searchParams.get('step');
   const serverParam = searchParams.get('server');
+  const splitParam = searchParams.get('split');
+  const splitIds = useMemo((): [string, string] | null => {
+    if (!splitParam) return null;
+    const ids = splitParam.split(',').filter(Boolean).slice(0, 2);
+    return ids.length === 2 ? (ids as [string, string]) : null;
+  }, [splitParam]);
   const { api, isConnected$ } = useApi();
   const { toast } = useToast();
   const queryClient = useQueryClient();
@@ -456,17 +464,53 @@ const MainLayout: FC<Props> = ({ conversationId, taskId }) => {
       );
     }
 
-    // Chat section
+    // Chat section — split view
+    if (splitIds) {
+      return (
+        <SplitConversationView
+          leftId={splitIds[0]}
+          rightId={splitIds[1]}
+          serverId={serverParam || undefined}
+          vertical={isMobile}
+          onClose={() => {
+            const params = new URLSearchParams(searchParams);
+            params.delete('split');
+            const qs = params.toString();
+            navigate(`/chat/${encodeURIComponent(splitIds[0])}${qs ? `?${qs}` : ''}`);
+          }}
+        />
+      );
+    }
+
+    // Chat section — single conversation
     const conversation = conversation$.get();
     if (conversation) {
       return (
-        <div className="h-full overflow-auto">
-          <ConversationContent
-            key={conversation.id}
-            conversationId={conversation.id}
-            serverId={serverParam || conversation.serverId}
-            isReadOnly={conversation.readonly}
-          />
+        <div className="flex h-full flex-col overflow-hidden">
+          <div className="flex flex-shrink-0 items-center justify-end border-b px-2 py-0.5">
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-6 gap-1 px-2 text-xs text-muted-foreground hover:text-foreground"
+              onClick={() => {
+                const params = new URLSearchParams(searchParams);
+                params.set('split', `${conversation.id},${conversation.id}`);
+                navigate(`?${params.toString()}`);
+              }}
+              title="Open in split view"
+            >
+              <Columns2 className="h-3 w-3" />
+              Split
+            </Button>
+          </div>
+          <div className="min-h-0 flex-1">
+            <ConversationContent
+              key={conversation.id}
+              conversationId={conversation.id}
+              serverId={serverParam || conversation.serverId}
+              isReadOnly={conversation.readonly}
+            />
+          </div>
         </div>
       );
     }

--- a/webui/src/components/MainLayout.tsx
+++ b/webui/src/components/MainLayout.tsx
@@ -299,6 +299,7 @@ const MainLayout: FC<Props> = ({ conversationId, taskId }) => {
       selectedConversation$.set(id);
 
       const newParams = new URLSearchParams(searchParams);
+      newParams.delete('split');
       if (serverId) {
         newParams.set('server', serverId);
       } else {
@@ -466,17 +467,22 @@ const MainLayout: FC<Props> = ({ conversationId, taskId }) => {
 
     // Chat section — split view
     if (splitIds) {
+      const leftConversation = getSelectedConversationSummary(splitIds[0]);
+      const rightConversation = getSelectedConversationSummary(splitIds[1]);
+
       return (
         <SplitConversationView
           leftId={splitIds[0]}
           rightId={splitIds[1]}
           serverId={serverParam || undefined}
+          leftIsReadOnly={leftConversation.readonly}
+          rightIsReadOnly={rightConversation.readonly}
           vertical={isMobile}
           onClose={() => {
             const params = new URLSearchParams(searchParams);
             params.delete('split');
             const qs = params.toString();
-            navigate(`/chat/${encodeURIComponent(splitIds[0])}${qs ? `?${qs}` : ''}`);
+            navigate(chatRoute(splitIds[0], qs));
           }}
         />
       );

--- a/webui/src/components/MainLayout.tsx
+++ b/webui/src/components/MainLayout.tsx
@@ -467,6 +467,20 @@ const MainLayout: FC<Props> = ({ conversationId, taskId }) => {
 
     // Chat section — split view
     if (splitIds) {
+      // Wait for conversations to be initialized before rendering split view
+      const leftState = conversations$.get(splitIds[0])?.get();
+      const rightState = conversations$.get(splitIds[1])?.get();
+      if (!leftState || !rightState) {
+        return (
+          <div className="flex h-full items-center justify-center">
+            <div className="text-center">
+              <div className="mx-auto mb-4 h-8 w-8 animate-spin rounded-full border-b-2 border-primary" />
+              <p className="text-sm text-muted-foreground">Loading split view...</p>
+            </div>
+          </div>
+        );
+      }
+
       const leftConversation = getSelectedConversationSummary(splitIds[0]);
       const rightConversation = getSelectedConversationSummary(splitIds[1]);
 

--- a/webui/src/components/MainLayout.tsx
+++ b/webui/src/components/MainLayout.tsx
@@ -470,16 +470,7 @@ const MainLayout: FC<Props> = ({ conversationId, taskId }) => {
       // Wait for conversations to be initialized before rendering split view
       const leftState = conversations$.get(splitIds[0])?.get();
       const rightState = conversations$.get(splitIds[1])?.get();
-      if (!leftState || !rightState) {
-        return (
-          <div className="flex h-full items-center justify-center">
-            <div className="text-center">
-              <div className="mx-auto mb-4 h-8 w-8 animate-spin rounded-full border-b-2 border-primary" />
-              <p className="text-sm text-muted-foreground">Loading split view...</p>
-            </div>
-          </div>
-        );
-      }
+      const isSplitLoading = !leftState || !rightState;
 
       const leftConversation = getSelectedConversationSummary(splitIds[0]);
       const rightConversation = getSelectedConversationSummary(splitIds[1]);
@@ -491,6 +482,7 @@ const MainLayout: FC<Props> = ({ conversationId, taskId }) => {
           serverId={serverParam || undefined}
           leftIsReadOnly={leftConversation.readonly}
           rightIsReadOnly={rightConversation.readonly}
+          isLoading={isSplitLoading}
           vertical={isMobile}
           onClose={() => {
             const params = new URLSearchParams(searchParams);

--- a/webui/src/components/SplitConversationView.tsx
+++ b/webui/src/components/SplitConversationView.tsx
@@ -8,6 +8,8 @@ interface Props {
   leftId: string;
   rightId: string;
   serverId?: string;
+  leftIsReadOnly?: boolean;
+  rightIsReadOnly?: boolean;
   /** Stack panes vertically instead of side-by-side (for narrow screens). */
   vertical?: boolean;
   onClose: () => void;
@@ -17,6 +19,8 @@ export const SplitConversationView: FC<Props> = ({
   leftId,
   rightId,
   serverId,
+  leftIsReadOnly,
+  rightIsReadOnly,
   vertical = false,
   onClose,
 }) => {
@@ -39,11 +43,21 @@ export const SplitConversationView: FC<Props> = ({
         className="min-h-0 flex-1"
       >
         <ResizablePanel defaultSize={50} minSize={20}>
-          <ConversationContent key={leftId} conversationId={leftId} serverId={serverId} />
+          <ConversationContent
+            key={leftId}
+            conversationId={leftId}
+            serverId={serverId}
+            isReadOnly={leftIsReadOnly}
+          />
         </ResizablePanel>
         <ResizableHandle withHandle />
         <ResizablePanel defaultSize={50} minSize={20}>
-          <ConversationContent key={rightId} conversationId={rightId} serverId={serverId} />
+          <ConversationContent
+            key={rightId}
+            conversationId={rightId}
+            serverId={serverId}
+            isReadOnly={rightIsReadOnly}
+          />
         </ResizablePanel>
       </ResizablePanelGroup>
     </div>

--- a/webui/src/components/SplitConversationView.tsx
+++ b/webui/src/components/SplitConversationView.tsx
@@ -1,0 +1,51 @@
+import { type FC } from 'react';
+import { X } from 'lucide-react';
+import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from '@/components/ui/resizable';
+import { ConversationContent } from './ConversationContent';
+import { Button } from '@/components/ui/button';
+
+interface Props {
+  leftId: string;
+  rightId: string;
+  serverId?: string;
+  /** Stack panes vertically instead of side-by-side (for narrow screens). */
+  vertical?: boolean;
+  onClose: () => void;
+}
+
+export const SplitConversationView: FC<Props> = ({
+  leftId,
+  rightId,
+  serverId,
+  vertical = false,
+  onClose,
+}) => {
+  return (
+    <div className="flex h-full flex-col overflow-hidden">
+      <div className="flex flex-shrink-0 items-center justify-between border-b px-3 py-1">
+        <span className="text-xs text-muted-foreground">Split view</span>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-6 w-6"
+          onClick={onClose}
+          title="Close split view"
+        >
+          <X className="h-3 w-3" />
+        </Button>
+      </div>
+      <ResizablePanelGroup
+        direction={vertical ? 'vertical' : 'horizontal'}
+        className="min-h-0 flex-1"
+      >
+        <ResizablePanel defaultSize={50} minSize={20}>
+          <ConversationContent key={leftId} conversationId={leftId} serverId={serverId} />
+        </ResizablePanel>
+        <ResizableHandle withHandle />
+        <ResizablePanel defaultSize={50} minSize={20}>
+          <ConversationContent key={rightId} conversationId={rightId} serverId={serverId} />
+        </ResizablePanel>
+      </ResizablePanelGroup>
+    </div>
+  );
+};

--- a/webui/src/components/SplitConversationView.tsx
+++ b/webui/src/components/SplitConversationView.tsx
@@ -10,6 +10,7 @@ interface Props {
   serverId?: string;
   leftIsReadOnly?: boolean;
   rightIsReadOnly?: boolean;
+  isLoading?: boolean;
   /** Stack panes vertically instead of side-by-side (for narrow screens). */
   vertical?: boolean;
   onClose: () => void;
@@ -21,6 +22,7 @@ export const SplitConversationView: FC<Props> = ({
   serverId,
   leftIsReadOnly,
   rightIsReadOnly,
+  isLoading = false,
   vertical = false,
   onClose,
 }) => {
@@ -38,28 +40,37 @@ export const SplitConversationView: FC<Props> = ({
           <X className="h-3 w-3" />
         </Button>
       </div>
-      <ResizablePanelGroup
-        direction={vertical ? 'vertical' : 'horizontal'}
-        className="min-h-0 flex-1"
-      >
-        <ResizablePanel defaultSize={50} minSize={20}>
-          <ConversationContent
-            key={leftId}
-            conversationId={leftId}
-            serverId={serverId}
-            isReadOnly={leftIsReadOnly}
-          />
-        </ResizablePanel>
-        <ResizableHandle withHandle />
-        <ResizablePanel defaultSize={50} minSize={20}>
-          <ConversationContent
-            key={rightId}
-            conversationId={rightId}
-            serverId={serverId}
-            isReadOnly={rightIsReadOnly}
-          />
-        </ResizablePanel>
-      </ResizablePanelGroup>
+      {isLoading ? (
+        <div className="flex min-h-0 flex-1 items-center justify-center">
+          <div className="text-center">
+            <div className="mx-auto mb-4 h-8 w-8 animate-spin rounded-full border-b-2 border-primary" />
+            <p className="text-sm text-muted-foreground">Loading split view...</p>
+          </div>
+        </div>
+      ) : (
+        <ResizablePanelGroup
+          direction={vertical ? 'vertical' : 'horizontal'}
+          className="min-h-0 flex-1"
+        >
+          <ResizablePanel defaultSize={50} minSize={20}>
+            <ConversationContent
+              key={leftId}
+              conversationId={leftId}
+              serverId={serverId}
+              isReadOnly={leftIsReadOnly}
+            />
+          </ResizablePanel>
+          <ResizableHandle withHandle />
+          <ResizablePanel defaultSize={50} minSize={20}>
+            <ConversationContent
+              key={rightId}
+              conversationId={rightId}
+              serverId={serverId}
+              isReadOnly={rightIsReadOnly}
+            />
+          </ResizablePanel>
+        </ResizablePanelGroup>
+      )}
     </div>
   );
 };

--- a/webui/src/components/__tests__/SplitConversationView.test.tsx
+++ b/webui/src/components/__tests__/SplitConversationView.test.tsx
@@ -4,15 +4,31 @@ import { SplitConversationView } from '../SplitConversationView';
 
 // Stub ConversationContent so tests don't need full API context
 jest.mock('../ConversationContent', () => ({
-  ConversationContent: ({ conversationId }: { conversationId: string }) => (
-    <div data-testid={`conversation-${conversationId}`}>{conversationId}</div>
+  ConversationContent: ({
+    conversationId,
+    isReadOnly,
+  }: {
+    conversationId: string;
+    isReadOnly?: boolean;
+  }) => (
+    <div data-testid={`conversation-${conversationId}`} data-readonly={String(!!isReadOnly)}>
+      {conversationId}
+    </div>
   ),
 }));
 
 // Stub resizable panels to simple divs
 jest.mock('@/components/ui/resizable', () => ({
-  ResizablePanelGroup: ({ children, className }: { children: React.ReactNode; className?: string }) => (
-    <div data-testid="resizable-group" className={className}>{children}</div>
+  ResizablePanelGroup: ({
+    children,
+    className,
+  }: {
+    children: React.ReactNode;
+    className?: string;
+  }) => (
+    <div data-testid="resizable-group" className={className}>
+      {children}
+    </div>
   ),
   ResizablePanel: ({ children }: { children: React.ReactNode }) => (
     <div data-testid="resizable-panel">{children}</div>
@@ -28,35 +44,42 @@ describe('SplitConversationView', () => {
   });
 
   it('renders both conversation panes', () => {
-    render(
-      <SplitConversationView leftId="conv-a" rightId="conv-b" onClose={onClose} />
-    );
+    render(<SplitConversationView leftId="conv-a" rightId="conv-b" onClose={onClose} />);
 
     expect(screen.getByTestId('conversation-conv-a')).toBeInTheDocument();
     expect(screen.getByTestId('conversation-conv-b')).toBeInTheDocument();
   });
 
   it('shows "Split view" label', () => {
-    render(
-      <SplitConversationView leftId="conv-a" rightId="conv-b" onClose={onClose} />
-    );
+    render(<SplitConversationView leftId="conv-a" rightId="conv-b" onClose={onClose} />);
 
     expect(screen.getByText('Split view')).toBeInTheDocument();
   });
 
-  it('calls onClose when close button is clicked', () => {
+  it('forwards readonly state to each conversation pane', () => {
     render(
-      <SplitConversationView leftId="conv-a" rightId="conv-b" onClose={onClose} />
+      <SplitConversationView
+        leftId="conv-a"
+        rightId="conv-b"
+        leftIsReadOnly
+        rightIsReadOnly={false}
+        onClose={onClose}
+      />
     );
+
+    expect(screen.getByTestId('conversation-conv-a')).toHaveAttribute('data-readonly', 'true');
+    expect(screen.getByTestId('conversation-conv-b')).toHaveAttribute('data-readonly', 'false');
+  });
+
+  it('calls onClose when close button is clicked', () => {
+    render(<SplitConversationView leftId="conv-a" rightId="conv-b" onClose={onClose} />);
 
     fireEvent.click(screen.getByTitle('Close split view'));
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
   it('uses vertical layout on mobile', () => {
-    render(
-      <SplitConversationView leftId="a" rightId="b" vertical onClose={onClose} />
-    );
+    render(<SplitConversationView leftId="a" rightId="b" vertical onClose={onClose} />);
 
     // Both panes still rendered
     expect(screen.getByTestId('conversation-a')).toBeInTheDocument();

--- a/webui/src/components/__tests__/SplitConversationView.test.tsx
+++ b/webui/src/components/__tests__/SplitConversationView.test.tsx
@@ -1,0 +1,65 @@
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { SplitConversationView } from '../SplitConversationView';
+
+// Stub ConversationContent so tests don't need full API context
+jest.mock('../ConversationContent', () => ({
+  ConversationContent: ({ conversationId }: { conversationId: string }) => (
+    <div data-testid={`conversation-${conversationId}`}>{conversationId}</div>
+  ),
+}));
+
+// Stub resizable panels to simple divs
+jest.mock('@/components/ui/resizable', () => ({
+  ResizablePanelGroup: ({ children, className }: { children: React.ReactNode; className?: string }) => (
+    <div data-testid="resizable-group" className={className}>{children}</div>
+  ),
+  ResizablePanel: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="resizable-panel">{children}</div>
+  ),
+  ResizableHandle: () => <div data-testid="resizable-handle" />,
+}));
+
+describe('SplitConversationView', () => {
+  const onClose = jest.fn();
+
+  beforeEach(() => {
+    onClose.mockClear();
+  });
+
+  it('renders both conversation panes', () => {
+    render(
+      <SplitConversationView leftId="conv-a" rightId="conv-b" onClose={onClose} />
+    );
+
+    expect(screen.getByTestId('conversation-conv-a')).toBeInTheDocument();
+    expect(screen.getByTestId('conversation-conv-b')).toBeInTheDocument();
+  });
+
+  it('shows "Split view" label', () => {
+    render(
+      <SplitConversationView leftId="conv-a" rightId="conv-b" onClose={onClose} />
+    );
+
+    expect(screen.getByText('Split view')).toBeInTheDocument();
+  });
+
+  it('calls onClose when close button is clicked', () => {
+    render(
+      <SplitConversationView leftId="conv-a" rightId="conv-b" onClose={onClose} />
+    );
+
+    fireEvent.click(screen.getByTitle('Close split view'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses vertical layout on mobile', () => {
+    render(
+      <SplitConversationView leftId="a" rightId="b" vertical onClose={onClose} />
+    );
+
+    // Both panes still rendered
+    expect(screen.getByTestId('conversation-a')).toBeInTheDocument();
+    expect(screen.getByTestId('conversation-b')).toBeInTheDocument();
+  });
+});

--- a/webui/src/components/__tests__/SplitConversationView.test.tsx
+++ b/webui/src/components/__tests__/SplitConversationView.test.tsx
@@ -78,6 +78,16 @@ describe('SplitConversationView', () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
+  it('keeps close button available while loading conversations', () => {
+    render(<SplitConversationView leftId="conv-a" rightId="conv-b" isLoading onClose={onClose} />);
+
+    expect(screen.getByText('Loading split view...')).toBeInTheDocument();
+    expect(screen.queryByTestId('conversation-conv-a')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTitle('Close split view'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
   it('uses vertical layout on mobile', () => {
     render(<SplitConversationView leftId="a" rightId="b" vertical onClose={onClose} />);
 


### PR DESCRIPTION
## Summary

Adds a side-by-side split-pane layout to the gptme webui, activated by the `?split=<id1>,<id2>` URL parameter.

- **New component** `SplitConversationView`: renders two `ConversationContent` panels in a horizontal `ResizablePanelGroup`; stacks vertically on mobile (`vertical` prop)
- **`MainLayout` update**: parses the `split` query param and renders the split view when two conversation IDs are present; single-pane behavior is unchanged
- **Split button**: small "Split" button (Columns2 icon) added to the single-pane conversation toolbar — clicking it sets `?split=<id>,<id>` as a quick entry point
- **Tests**: unit tests for `SplitConversationView` (4 cases); e2e routing tests for the split URL parameter

## How to test

```
# Navigate to split view manually:
http://localhost:5700/chat/<conv-id>?split=<id1>,<id2>

# Use the "Split" button in the conversation toolbar when a conversation is open
```

Slice 2 (independent navigation per pane, conversation picker) is tracked separately.

Closes #1206 (Slice 1)

## Test plan

- [ ] Navigate to `/?split=<id1>,<id2>` — two conversations render side by side
- [ ] Single-pane URLs (`/chat/<id>`) render unchanged
- [ ] "Split" button in toolbar creates split URL
- [ ] "Close split view" button returns to single-pane
- [ ] Mobile: panes stack vertically
- [ ] Unit tests pass: `npm test -- --testPathPatterns SplitConversation`