### PR TITLE
fix(ci): pin self-heal logs to triggering attempt

### DIFF
--- a/.github/workflows/self-heal.yml
+++ b/.github/workflows/self-heal.yml
@@ -66,8 +66,11 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -o pipefail
+          # workflow_run id is stable across reruns; pin to the triggering attempt
+          # so a newer rerun doesn't replace the failed logs we're analyzing.
           gh run view ${{ github.event.workflow_run.id }} \
             --repo ${{ github.repository }} \
+            --attempt ${{ github.event.workflow_run.run_attempt }} \
             --log-failed 2>&1 | tail -c 15000 > /tmp/failure.log
           echo "Failure log size: $(wc -c < /tmp/failure.log) bytes"
 


### PR DESCRIPTION
## Summary
- pin `self-heal` log downloads to the triggering `workflow_run` attempt
- prevent reruns of the same workflow run from replacing the failed logs being analyzed

## Root cause
`workflow_run.id` stays the same across reruns, but `gh run view <id>` defaults to the latest attempt.
The failing `self-heal` run 27144617434 was triggered by failed attempt 1 of `Test` run 27143868772, but by the time `self-heal` fetched logs, attempt 2 was already in progress.
That made `gh run view --log-failed` read the rerun and exit with:

```txt
run 27143868772 is still in progress; logs will be available when it is complete
```

Using `--attempt ${{ github.event.workflow_run.run_attempt }}` makes the workflow inspect the exact failed attempt that triggered the event.

## Verification
- reproduced the failure locally with `gh run view 27143868772 --repo gptme/gptme --log-failed`
- verified the fix path with `gh run view 27143868772 --repo gptme/gptme --attempt 1 --log-failed`
- `prek` passed during commit
