### PR TITLE
feat(webui): add browser TTS for assistant messages (Slice 1 — Web Speech API)

### DIFF
--- a/webui/src/components/ChatMessage.tsx
+++ b/webui/src/components/ChatMessage.tsx
@@ -22,12 +22,14 @@ import {
   ExternalLink,
   FileText,
   FolderOpen,
+  Volume2,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
 import { ChatInput } from '@/components/ChatInput';
 import { workspaceNavigateTo$ } from '@/stores/workspaceExplorer';
+import { speakTextNow, isSpeechSupported } from '@/utils/tts';
 import { rightSidebarActiveTab$, rightSidebarVisible$ } from '@/stores/sidebar';
 
 function formatTimestamp(timestamp: string): { short: string; full: string } {
@@ -549,6 +551,18 @@ export const ChatMessage: FC<Props> = ({
                             </Button>
                           )}
                         </>
+                      )}
+                      {message$.role.get() === 'assistant' && isSpeechSupported() && (
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => speakTextNow(message$.content.get() ?? '')}
+                          className="h-7 w-7 p-0"
+                          aria-label="Read aloud"
+                          title="Read aloud"
+                        >
+                          <Volume2 size={14} />
+                        </Button>
                       )}
                       <Button
                         variant="ghost"

--- a/webui/src/components/SettingsModal.tsx
+++ b/webui/src/components/SettingsModal.tsx
@@ -232,6 +232,22 @@ export const SettingsModal = forwardRef<HTMLButtonElement, SettingsModalProps>(
                 />
               </div>
 
+              <div className="flex items-center justify-between">
+                <div className="space-y-0.5">
+                  <Label htmlFor="tts-toggle" className="text-sm">
+                    Read responses aloud
+                  </Label>
+                  <p className="text-xs text-muted-foreground">
+                    Speak assistant messages using browser TTS (Web Speech API)
+                  </p>
+                </div>
+                <Switch
+                  id="tts-toggle"
+                  checked={settings.ttsEnabled}
+                  onCheckedChange={(checked) => updateSettings({ ttsEnabled: checked })}
+                />
+              </div>
+
               <div className="space-y-2">
                 <Label htmlFor="voice-server-url" className="text-sm">
                   Voice server URL

--- a/webui/src/components/SettingsModal.tsx
+++ b/webui/src/components/SettingsModal.tsx
@@ -239,7 +239,8 @@ export const SettingsModal = forwardRef<HTMLButtonElement, SettingsModalProps>(
                     Read responses aloud
                   </Label>
                   <p className="text-xs text-muted-foreground">
-                    Speak assistant messages using browser TTS (Web Speech API)
+                    Speak assistant messages aloud (uses gptme-tts server if configured, otherwise
+                    browser Web Speech API)
                   </p>
                 </div>
                 <Switch
@@ -247,6 +248,25 @@ export const SettingsModal = forwardRef<HTMLButtonElement, SettingsModalProps>(
                   checked={settings.ttsEnabled}
                   disabled={!isSpeechSupported()}
                   onCheckedChange={(checked) => updateSettings({ ttsEnabled: checked })}
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="tts-server-url" className="text-sm">
+                  TTS server URL
+                </Label>
+                <p className="text-xs text-muted-foreground">
+                  HTTP base URL of a running{' '}
+                  <code className="rounded bg-muted px-1">gptme-tts</code> server, e.g.{' '}
+                  <code className="rounded bg-muted px-1">http://localhost:5701</code>. Leave empty
+                  to use browser TTS.
+                </p>
+                <Input
+                  id="tts-server-url"
+                  type="text"
+                  placeholder="http://localhost:5701"
+                  value={settings.ttsServerUrl}
+                  onChange={(e) => updateSettings({ ttsServerUrl: e.target.value.trim() })}
                 />
               </div>
 

--- a/webui/src/components/SettingsModal.tsx
+++ b/webui/src/components/SettingsModal.tsx
@@ -31,6 +31,7 @@ import { use$ } from '@legendapp/state/react';
 import { settingsModal$, type SettingsCategory } from '@/stores/settingsModal';
 import { setupWizard$ } from '@/stores/setupWizard';
 import { getPrimaryClient } from '@/stores/serverClients';
+import { isSpeechSupported } from '@/utils/tts';
 export type { SettingsCategory } from '@/stores/settingsModal';
 export { settingsModal$ } from '@/stores/settingsModal';
 
@@ -244,6 +245,7 @@ export const SettingsModal = forwardRef<HTMLButtonElement, SettingsModalProps>(
                 <Switch
                   id="tts-toggle"
                   checked={settings.ttsEnabled}
+                  disabled={!isSpeechSupported()}
                   onCheckedChange={(checked) => updateSettings({ ttsEnabled: checked })}
                 />
               </div>

--- a/webui/src/contexts/SettingsContext.tsx
+++ b/webui/src/contexts/SettingsContext.tsx
@@ -1,4 +1,5 @@
 import React, { createContext, useContext, useState } from 'react';
+import { stopSpeaking } from '../utils/tts';
 
 export interface Settings {
   chimeEnabled: boolean;
@@ -63,6 +64,9 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
   const [settings, setSettings] = useState<Settings>(loadSettingsFromStorage);
 
   const updateSettings = (updates: Partial<Settings>) => {
+    if (updates.ttsEnabled === false) {
+      stopSpeaking();
+    }
     // Use functional updater to avoid stale closure if called in rapid succession.
     setSettings((current) => {
       const newSettings = { ...current, ...updates };

--- a/webui/src/contexts/SettingsContext.tsx
+++ b/webui/src/contexts/SettingsContext.tsx
@@ -2,6 +2,7 @@ import React, { createContext, useContext, useState } from 'react';
 
 export interface Settings {
   chimeEnabled: boolean;
+  ttsEnabled: boolean;
   blocksDefaultOpen: boolean;
   showHiddenMessages: boolean;
   showInitialSystem: boolean;
@@ -23,6 +24,7 @@ interface SettingsContextType {
 
 const defaultSettings: Settings = {
   chimeEnabled: true,
+  ttsEnabled: false,
   blocksDefaultOpen: true,
   showHiddenMessages: false,
   showInitialSystem: false,

--- a/webui/src/contexts/SettingsContext.tsx
+++ b/webui/src/contexts/SettingsContext.tsx
@@ -11,6 +11,12 @@ export interface Settings {
   /** CSS background for the welcome/new-chat view (image URL or gradient) */
   welcomeBackground: string;
   /**
+   * HTTP base URL of a running gptme-tts server, e.g. http://localhost:5701.
+   * When set, TTS uses this server instead of the browser's speechSynthesis API.
+   * Leave empty to use browser TTS.
+   */
+  ttsServerUrl: string;
+  /**
    * WebSocket URL for the gptme-voice-server /voice endpoint, e.g. ws://localhost:5700/voice.
    * Leave empty to hide the VoiceButton.
    */
@@ -31,6 +37,7 @@ const defaultSettings: Settings = {
   showInitialSystem: false,
   hasCompletedSetup: false,
   welcomeBackground: '',
+  ttsServerUrl: '',
   voiceServerUrl: '',
 };
 
@@ -80,6 +87,7 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
   };
 
   const resetSettings = () => {
+    stopSpeaking();
     // Use functional updater to avoid stale closure on hasCompletedSetup.
     // Preserve hasCompletedSetup so a settings reset doesn't re-trigger the wizard.
     setSettings((current) => {

--- a/webui/src/hooks/useConversation.ts
+++ b/webui/src/hooks/useConversation.ts
@@ -30,6 +30,7 @@ import {
   setTopP,
 } from '@/stores/conversations';
 import { playChime } from '@/utils/audio';
+import { speakText } from '@/utils/tts';
 import { findLatestAssistantIndexForError } from '@/utils/conversationErrorHandling';
 import { notifyGenerationComplete, notifyToolConfirmation } from '@/utils/notifications';
 import { ApiClientError, getApiErrorPresentation } from '@/utils/api';
@@ -218,6 +219,7 @@ export function useConversation(conversationId: string, serverId?: string) {
                   playChime().catch((error) => {
                     console.warn('Failed to play completion chime:', error);
                   });
+                  speakText(message.content);
                   notifyGenerationComplete(conversation$?.data.name.get()).catch((error) => {
                     console.warn('Failed to show completion notification:', error);
                   });

--- a/webui/src/utils/tts.ts
+++ b/webui/src/utils/tts.ts
@@ -1,24 +1,29 @@
 /**
- * Text-to-speech using the browser's Web Speech API.
+ * Text-to-speech via the browser's Web Speech API or a gptme-tts server.
  *
- * Speaks assistant messages aloud when ttsEnabled is set in localStorage.
- * Strips markdown formatting and code blocks before speaking so output
- * sounds natural. Long messages are truncated to avoid endless monologues.
+ * Priority:
+ *   1. If `ttsServerUrl` is configured, POST to {url}/tts and play the WAV.
+ *   2. Otherwise fall back to the browser's built-in speechSynthesis API.
+ *
+ * Both paths strip markdown before speaking so output sounds natural.
  */
 
-const MAX_CHARS = 500;
+let currentAudio: HTMLAudioElement | null = null;
 
-function isEnabled(): boolean {
+function getSettings(): { ttsEnabled: boolean; ttsServerUrl: string } {
   try {
     const saved = localStorage.getItem('gptme-settings');
     if (saved) {
-      const settings = JSON.parse(saved);
-      return settings.ttsEnabled === true;
+      const s = JSON.parse(saved);
+      return {
+        ttsEnabled: s.ttsEnabled === true,
+        ttsServerUrl: typeof s.ttsServerUrl === 'string' ? s.ttsServerUrl.trim() : '',
+      };
     }
   } catch {
     // ignore
   }
-  return false;
+  return { ttsEnabled: false, ttsServerUrl: '' };
 }
 
 /** Strip markdown so the spoken text sounds natural. */
@@ -44,39 +49,71 @@ function toSpokenText(markdown: string): string {
   );
 }
 
-function speak(rawText: string): void {
-  if (!window.speechSynthesis) return;
+async function speakViaServer(text: string, serverUrl: string): Promise<void> {
+  const url = `${serverUrl.replace(/\/$/, '')}/tts?${new URLSearchParams({ text })}`;
+  const response = await fetch(url);
+  if (!response.ok) throw new Error(`TTS server error: ${response.status}`);
+  const blob = await response.blob();
+  const objectUrl = URL.createObjectURL(blob);
 
+  if (currentAudio) {
+    currentAudio.pause();
+    URL.revokeObjectURL(currentAudio.src);
+  }
+  const audio = new Audio(objectUrl);
+  currentAudio = audio;
+  audio.onended = () => {
+    URL.revokeObjectURL(objectUrl);
+    if (currentAudio === audio) currentAudio = null;
+  };
+  await audio.play();
+}
+
+async function speak(rawText: string): Promise<void> {
   const spoken = toSpokenText(rawText);
   if (!spoken) return;
 
-  const truncated = spoken.length > MAX_CHARS ? spoken.slice(0, MAX_CHARS) + '…' : spoken;
+  const { ttsServerUrl } = getSettings();
+  if (ttsServerUrl) {
+    try {
+      await speakViaServer(spoken, ttsServerUrl);
+      return;
+    } catch (err) {
+      console.warn('gptme-tts server unavailable, falling back to Web Speech API:', err);
+    }
+  }
 
+  if (!window.speechSynthesis) return;
   // Cancel any previous utterance so a new message interrupts the old one.
   window.speechSynthesis.cancel();
-
-  const utterance = new SpeechSynthesisUtterance(truncated);
+  const utterance = new SpeechSynthesisUtterance(spoken);
   utterance.rate = 1.1;
   window.speechSynthesis.speak(utterance);
 }
 
 /** Speak text if the global TTS toggle is enabled (auto-play on new messages). */
 export function speakText(rawText: string): void {
-  if (!isEnabled()) return;
-  speak(rawText);
+  const { ttsEnabled } = getSettings();
+  if (!ttsEnabled) return;
+  void speak(rawText);
 }
 
 /** Speak text immediately, regardless of the global TTS toggle (per-message button). */
 export function speakTextNow(rawText: string): void {
-  speak(rawText);
+  void speak(rawText);
 }
 
 export function stopSpeaking(): void {
+  if (currentAudio) {
+    currentAudio.pause();
+    URL.revokeObjectURL(currentAudio.src);
+    currentAudio = null;
+  }
   if (window.speechSynthesis) {
     window.speechSynthesis.cancel();
   }
 }
 
 export function isSpeechSupported(): boolean {
-  return 'speechSynthesis' in window;
+  return 'speechSynthesis' in window || typeof Audio !== 'undefined';
 }

--- a/webui/src/utils/tts.ts
+++ b/webui/src/utils/tts.ts
@@ -44,8 +44,7 @@ function toSpokenText(markdown: string): string {
   );
 }
 
-export function speakText(rawText: string): void {
-  if (!isEnabled()) return;
+function speak(rawText: string): void {
   if (!window.speechSynthesis) return;
 
   const spoken = toSpokenText(rawText);
@@ -59,6 +58,17 @@ export function speakText(rawText: string): void {
   const utterance = new SpeechSynthesisUtterance(truncated);
   utterance.rate = 1.1;
   window.speechSynthesis.speak(utterance);
+}
+
+/** Speak text if the global TTS toggle is enabled (auto-play on new messages). */
+export function speakText(rawText: string): void {
+  if (!isEnabled()) return;
+  speak(rawText);
+}
+
+/** Speak text immediately, regardless of the global TTS toggle (per-message button). */
+export function speakTextNow(rawText: string): void {
+  speak(rawText);
 }
 
 export function stopSpeaking(): void {

--- a/webui/src/utils/tts.ts
+++ b/webui/src/utils/tts.ts
@@ -9,6 +9,7 @@
  */
 
 let currentAudio: HTMLAudioElement | null = null;
+let currentFetchController: AbortController | null = null;
 
 function getSettings(): { ttsEnabled: boolean; ttsServerUrl: string } {
   try {
@@ -49,29 +50,48 @@ function toSpokenText(markdown: string): string {
   );
 }
 
+function isAbortError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === 'AbortError';
+}
+
 async function speakViaServer(text: string, serverUrl: string): Promise<void> {
   const url = `${serverUrl.replace(/\/$/, '')}/tts?${new URLSearchParams({ text })}`;
-  const response = await fetch(url);
-  if (!response.ok) throw new Error(`TTS server error: ${response.status}`);
-  const blob = await response.blob();
-  const objectUrl = URL.createObjectURL(blob);
+  const controller = new AbortController();
+  currentFetchController = controller;
+  try {
+    const response = await fetch(url, { signal: controller.signal });
+    if (!response.ok) throw new Error(`TTS server error: ${response.status}`);
+    const blob = await response.blob();
+    const objectUrl = URL.createObjectURL(blob);
 
-  if (currentAudio) {
-    currentAudio.pause();
-    URL.revokeObjectURL(currentAudio.src);
+    if (controller.signal.aborted) {
+      URL.revokeObjectURL(objectUrl);
+      return;
+    }
+
+    if (currentAudio) {
+      currentAudio.pause();
+      URL.revokeObjectURL(currentAudio.src);
+    }
+    const audio = new Audio(objectUrl);
+    currentAudio = audio;
+    audio.onended = () => {
+      URL.revokeObjectURL(objectUrl);
+      if (currentAudio === audio) currentAudio = null;
+    };
+    await audio.play();
+  } finally {
+    if (currentFetchController === controller) {
+      currentFetchController = null;
+    }
   }
-  const audio = new Audio(objectUrl);
-  currentAudio = audio;
-  audio.onended = () => {
-    URL.revokeObjectURL(objectUrl);
-    if (currentAudio === audio) currentAudio = null;
-  };
-  await audio.play();
 }
 
 async function speak(rawText: string): Promise<void> {
   const spoken = toSpokenText(rawText);
   if (!spoken) return;
+
+  stopSpeaking();
 
   const { ttsServerUrl } = getSettings();
   if (ttsServerUrl) {
@@ -79,13 +99,12 @@ async function speak(rawText: string): Promise<void> {
       await speakViaServer(spoken, ttsServerUrl);
       return;
     } catch (err) {
+      if (isAbortError(err)) return;
       console.warn('gptme-tts server unavailable, falling back to Web Speech API:', err);
     }
   }
 
   if (!window.speechSynthesis) return;
-  // Cancel any previous utterance so a new message interrupts the old one.
-  window.speechSynthesis.cancel();
   const utterance = new SpeechSynthesisUtterance(spoken);
   utterance.rate = 1.1;
   window.speechSynthesis.speak(utterance);
@@ -104,6 +123,10 @@ export function speakTextNow(rawText: string): void {
 }
 
 export function stopSpeaking(): void {
+  if (currentFetchController) {
+    currentFetchController.abort();
+    currentFetchController = null;
+  }
   if (currentAudio) {
     currentAudio.pause();
     URL.revokeObjectURL(currentAudio.src);

--- a/webui/src/utils/tts.ts
+++ b/webui/src/utils/tts.ts
@@ -28,7 +28,7 @@ function toSpokenText(markdown: string): string {
       // Remove fenced code blocks entirely
       .replace(/```[\s\S]*?```/g, '[code block]')
       // Remove inline code
-      .replace(/`[^`]+`/g, '')
+      .replace(/`[^`]+`/g, '[code]')
       // Remove bold/italic markers
       .replace(/\*{1,3}([^*]+)\*{1,3}/g, '$1')
       .replace(/_{1,3}([^_]+)_{1,3}/g, '$1')

--- a/webui/src/utils/tts.ts
+++ b/webui/src/utils/tts.ts
@@ -2,7 +2,7 @@
  * Text-to-speech via the browser's Web Speech API or a gptme-tts server.
  *
  * Priority:
- *   1. If `ttsServerUrl` is configured, POST to {url}/tts and play the WAV.
+ *   1. If `ttsServerUrl` is configured, GET {url}/tts?text=... and play the WAV.
  *   2. Otherwise fall back to the browser's built-in speechSynthesis API.
  *
  * Both paths strip markdown before speaking so output sounds natural.

--- a/webui/src/utils/tts.ts
+++ b/webui/src/utils/tts.ts
@@ -1,0 +1,72 @@
+/**
+ * Text-to-speech using the browser's Web Speech API.
+ *
+ * Speaks assistant messages aloud when ttsEnabled is set in localStorage.
+ * Strips markdown formatting and code blocks before speaking so output
+ * sounds natural. Long messages are truncated to avoid endless monologues.
+ */
+
+const MAX_CHARS = 500;
+
+function isEnabled(): boolean {
+  try {
+    const saved = localStorage.getItem('gptme-settings');
+    if (saved) {
+      const settings = JSON.parse(saved);
+      return settings.ttsEnabled === true;
+    }
+  } catch {
+    // ignore
+  }
+  return false;
+}
+
+/** Strip markdown so the spoken text sounds natural. */
+function toSpokenText(markdown: string): string {
+  return (
+    markdown
+      // Remove fenced code blocks entirely
+      .replace(/```[\s\S]*?```/g, '[code block]')
+      // Remove inline code
+      .replace(/`[^`]+`/g, '')
+      // Remove bold/italic markers
+      .replace(/\*{1,3}([^*]+)\*{1,3}/g, '$1')
+      .replace(/_{1,3}([^_]+)_{1,3}/g, '$1')
+      // Remove markdown links — keep label text
+      .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+      // Remove raw URLs
+      .replace(/https?:\/\/\S+/g, '')
+      // Remove heading markers
+      .replace(/^#{1,6}\s+/gm, '')
+      // Collapse whitespace
+      .replace(/\s+/g, ' ')
+      .trim()
+  );
+}
+
+export function speakText(rawText: string): void {
+  if (!isEnabled()) return;
+  if (!window.speechSynthesis) return;
+
+  const spoken = toSpokenText(rawText);
+  if (!spoken) return;
+
+  const truncated = spoken.length > MAX_CHARS ? spoken.slice(0, MAX_CHARS) + '…' : spoken;
+
+  // Cancel any previous utterance so a new message interrupts the old one.
+  window.speechSynthesis.cancel();
+
+  const utterance = new SpeechSynthesisUtterance(truncated);
+  utterance.rate = 1.1;
+  window.speechSynthesis.speak(utterance);
+}
+
+export function stopSpeaking(): void {
+  if (window.speechSynthesis) {
+    window.speechSynthesis.cancel();
+  }
+}
+
+export function isSpeechSupported(): boolean {
+  return 'speechSynthesis' in window;
+}


### PR DESCRIPTION
## Summary

- Adds a **"Read responses aloud"** toggle in Settings (Voice section), off by default
- **gptme-tts server support**: set a server URL in Settings → Voice (e.g. `http://localhost:8765`); falls back to browser Web Speech API if unset or unreachable
- Per-message **"Speak aloud"** button on assistant messages (speaks regardless of global toggle)
- Strips markdown before speaking (code blocks → `[code]`, removes bold/italic/links)
- No length truncation — full messages are spoken
- Cancels current speech when new message arrives or stop is requested; aborts in-flight server fetches

## Files changed

- **`webui/src/utils/tts.ts`** (new) — `speakText`, `speakTextNow`, `stopSpeaking`, `isSpeechSupported`; gptme-tts server path with Web Speech API fallback
- **`SettingsContext.tsx`** — adds `ttsEnabled: boolean` and `ttsServerUrl: string`
- **`SettingsModal.tsx`** — "Read responses aloud" toggle + TTS server URL input in Voice section
- **`ChatMessage.tsx`** — per-message speak button (Volume2 icon) on assistant messages
- **`useConversation.ts`** — calls `speakText` alongside the completion chime

## Test plan

- [ ] Enable "Read responses aloud" in Settings; send a message and confirm speech
- [ ] Verify markdown is stripped (code blocks, bold, links)
- [ ] Verify new message cancels current speech
- [ ] Verify setting defaults to off (no autoplay on load)
- [ ] Set TTS server URL (e.g. `http://localhost:8765`) — verify server path is used for audio
- [ ] Per-message speak button triggers speech even when toggle is off
- [ ] TypeScript: `npm run typecheck` passes

## Notes

Slice 1: Web Speech API primary path, optional [gptme-tts](https://github.com/gptme/gptme-contrib/tree/master/plugins/gptme-tts) server for local higher-quality audio — no gptme server changes required.

Follow-up (not in this PR): `/api/tts` endpoint on the gptme server for cloud TTS via OpenRouter/similar — would eliminate the separate local server requirement for quality audio.
Tracking: ErikBjare/bob#841