### PR TITLE
feat(webui): add Alt+N global shortcut for new conversation

### DIFF
--- a/webui/src/components/CommandPalette.tsx
+++ b/webui/src/components/CommandPalette.tsx
@@ -83,7 +83,7 @@ export function CommandPalette() {
   // Alt+N — new conversation (skip when typing in an input)
   useEffect(() => {
     const down = (e: KeyboardEvent) => {
-      if (e.key.toLowerCase() !== 'n' || !e.altKey || e.metaKey || e.ctrlKey) return;
+      if (e.code !== 'KeyN' || !e.altKey || e.metaKey || e.ctrlKey) return;
       const target = e.target as HTMLElement | null;
       if (
         target instanceof HTMLInputElement ||

--- a/webui/src/components/CommandPalette.tsx
+++ b/webui/src/components/CommandPalette.tsx
@@ -80,6 +80,26 @@ export function CommandPalette() {
     return () => document.removeEventListener('keydown', down);
   }, []);
 
+  // Cmd+N / Ctrl+N — new conversation (skip when typing in an input)
+  useEffect(() => {
+    const down = (e: KeyboardEvent) => {
+      if (e.key !== 'n' || !(e.metaKey || e.ctrlKey)) return;
+      const target = e.target as HTMLElement | null;
+      if (
+        target instanceof HTMLInputElement ||
+        target instanceof HTMLTextAreaElement ||
+        target?.isContentEditable
+      ) {
+        return;
+      }
+      e.preventDefault();
+      navigate('/');
+      setOpen(false);
+    };
+    document.addEventListener('keydown', down);
+    return () => document.removeEventListener('keydown', down);
+  }, [navigate, setOpen]);
+
   // Reset search when closing
   useEffect(() => {
     if (!open) {

--- a/webui/src/components/CommandPalette.tsx
+++ b/webui/src/components/CommandPalette.tsx
@@ -80,10 +80,10 @@ export function CommandPalette() {
     return () => document.removeEventListener('keydown', down);
   }, []);
 
-  // Cmd+N / Ctrl+N — new conversation (skip when typing in an input)
+  // Alt+N — new conversation (skip when typing in an input)
   useEffect(() => {
     const down = (e: KeyboardEvent) => {
-      if (e.key !== 'n' || !(e.metaKey || e.ctrlKey)) return;
+      if (e.key.toLowerCase() !== 'n' || !e.altKey || e.metaKey || e.ctrlKey) return;
       const target = e.target as HTMLElement | null;
       if (
         target instanceof HTMLInputElement ||

--- a/webui/src/components/ShortcutsDialog.tsx
+++ b/webui/src/components/ShortcutsDialog.tsx
@@ -20,13 +20,14 @@ interface ShortcutGroup {
 
 const isMac = typeof navigator !== 'undefined' && /Mac|iPhone|iPad/.test(navigator.platform ?? '');
 const MOD = isMac ? '⌘' : 'Ctrl';
+const ALT = isMac ? '⌥' : 'Alt';
 
 const SHORTCUT_GROUPS: ShortcutGroup[] = [
   {
     title: 'General',
     shortcuts: [
       { keys: [MOD, 'K'], description: 'Open command palette' },
-      { keys: [MOD, 'N'], description: 'New conversation' },
+      { keys: [ALT, 'N'], description: 'New conversation' },
       { keys: [MOD, 'F'], description: 'Search messages in conversation' },
       { keys: ['?'], description: 'Show this shortcuts reference' },
       { keys: ['i'], description: 'Focus the message input' },

--- a/webui/src/components/ShortcutsDialog.tsx
+++ b/webui/src/components/ShortcutsDialog.tsx
@@ -26,6 +26,7 @@ const SHORTCUT_GROUPS: ShortcutGroup[] = [
     title: 'General',
     shortcuts: [
       { keys: [MOD, 'K'], description: 'Open command palette' },
+      { keys: [MOD, 'N'], description: 'New conversation' },
       { keys: [MOD, 'F'], description: 'Search messages in conversation' },
       { keys: ['?'], description: 'Show this shortcuts reference' },
       { keys: ['i'], description: 'Focus the message input' },

--- a/webui/src/components/__tests__/CommandPalette.test.tsx
+++ b/webui/src/components/__tests__/CommandPalette.test.tsx
@@ -163,7 +163,7 @@ describe('CommandPalette', () => {
 
     it('navigates to home with Alt+N', () => {
       renderCommandPalette();
-      fireEvent.keyDown(document, { key: 'n', altKey: true });
+      fireEvent.keyDown(document, { key: 'n', code: 'KeyN', altKey: true });
       expect(mockNavigate).toHaveBeenCalledWith('/');
     });
 
@@ -171,6 +171,7 @@ describe('CommandPalette', () => {
       renderCommandPalette();
       const event = new KeyboardEvent('keydown', {
         key: 'n',
+        code: 'KeyN',
         altKey: true,
         cancelable: true,
       });
@@ -191,7 +192,7 @@ describe('CommandPalette', () => {
         </BrowserRouter>
       );
       const input = screen.getByTestId('text-field');
-      fireEvent.keyDown(input, { key: 'n', altKey: true });
+      fireEvent.keyDown(input, { key: 'n', code: 'KeyN', altKey: true });
       expect(mockNavigate).not.toHaveBeenCalled();
     });
   });

--- a/webui/src/components/__tests__/CommandPalette.test.tsx
+++ b/webui/src/components/__tests__/CommandPalette.test.tsx
@@ -161,19 +161,27 @@ describe('CommandPalette', () => {
       expect(preventDefaultSpy).toHaveBeenCalled();
     });
 
-    it('navigates to home with Ctrl+N', () => {
+    it('navigates to home with Alt+N', () => {
       renderCommandPalette();
-      fireEvent.keyDown(document, { key: 'n', ctrlKey: true });
+      fireEvent.keyDown(document, { key: 'n', altKey: true });
       expect(mockNavigate).toHaveBeenCalledWith('/');
     });
 
-    it('navigates to home with Cmd+N (Mac)', () => {
+    it('prevents default browser behavior for Alt+N', () => {
       renderCommandPalette();
-      fireEvent.keyDown(document, { key: 'n', metaKey: true });
-      expect(mockNavigate).toHaveBeenCalledWith('/');
+      const event = new KeyboardEvent('keydown', {
+        key: 'n',
+        altKey: true,
+        cancelable: true,
+      });
+      const preventDefaultSpy = jest.spyOn(event, 'preventDefault');
+
+      document.dispatchEvent(event);
+
+      expect(preventDefaultSpy).toHaveBeenCalled();
     });
 
-    it('does not navigate with Ctrl+N when typing in an input', () => {
+    it('does not navigate with Alt+N when typing in an input', () => {
       render(
         <BrowserRouter>
           <>
@@ -183,7 +191,7 @@ describe('CommandPalette', () => {
         </BrowserRouter>
       );
       const input = screen.getByTestId('text-field');
-      fireEvent.keyDown(input, { key: 'n', ctrlKey: true });
+      fireEvent.keyDown(input, { key: 'n', altKey: true });
       expect(mockNavigate).not.toHaveBeenCalled();
     });
   });

--- a/webui/src/components/__tests__/CommandPalette.test.tsx
+++ b/webui/src/components/__tests__/CommandPalette.test.tsx
@@ -160,6 +160,32 @@ describe('CommandPalette', () => {
 
       expect(preventDefaultSpy).toHaveBeenCalled();
     });
+
+    it('navigates to home with Ctrl+N', () => {
+      renderCommandPalette();
+      fireEvent.keyDown(document, { key: 'n', ctrlKey: true });
+      expect(mockNavigate).toHaveBeenCalledWith('/');
+    });
+
+    it('navigates to home with Cmd+N (Mac)', () => {
+      renderCommandPalette();
+      fireEvent.keyDown(document, { key: 'n', metaKey: true });
+      expect(mockNavigate).toHaveBeenCalledWith('/');
+    });
+
+    it('does not navigate with Ctrl+N when typing in an input', () => {
+      render(
+        <BrowserRouter>
+          <>
+            <input data-testid="text-field" />
+            <CommandPalette />
+          </>
+        </BrowserRouter>
+      );
+      const input = screen.getByTestId('text-field');
+      fireEvent.keyDown(input, { key: 'n', ctrlKey: true });
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
   });
 
   describe('Search Functionality', () => {

--- a/webui/src/components/__tests__/ShortcutsDialog.test.tsx
+++ b/webui/src/components/__tests__/ShortcutsDialog.test.tsx
@@ -56,6 +56,7 @@ describe('ShortcutsDialog', () => {
     fireEvent.keyDown(document, { key: '?' });
     expect(screen.getByText('General')).toBeInTheDocument();
     expect(screen.getByText('Open command palette')).toBeInTheDocument();
+    expect(screen.getByText('New conversation')).toBeInTheDocument();
     expect(screen.getByText('Focus the message input')).toBeInTheDocument();
     expect(screen.getByText('Send message')).toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary

- Adds `Alt+N` / `⌥N` as a global keyboard shortcut to navigate directly to a new conversation
- Guard prevents activation when the user is typing in an `<input>`, `<textarea>`, or contentEditable element
- Updates `ShortcutsDialog` to list the new shortcut in the General section (`?` help overlay)
- Adds tests for the new handler: Alt+N and the input-guard path

## Context

`?` (shortcuts help), `Ctrl+K` (command palette), `Ctrl+F` (message search), and `i` (focus input) were already implemented. A direct "new conversation" shortcut was the missing piece — previously you had to open the command palette first.

`Alt+N` was chosen over `Ctrl+N` / `Cmd+N` to avoid the browser/OS-level conflict: those keys open a new window in Chrome, Firefox, Edge, and Safari, and `e.preventDefault()` cannot suppress them. `Alt+N` has no such conflict and works cleanly in both the Tauri desktop app and the browser.

## Test plan

- [ ] Tests pass: `npm test -- --testPathPattern="CommandPalette|ShortcutsDialog"`
- [ ] Press `Alt+N` anywhere outside an input — navigates to new conversation
- [ ] Press `Alt+N` while typing in the message input — shortcut does not fire
- [ ] Press `?` — shortcuts dialog shows "New conversation" with `Alt+N` / `⌥N`