### PR TITLE
test(tauri): add E2E chat interaction flow tests (Slice 2)

### DIFF
--- a/.github/workflows/tauri.yml
+++ b/.github/workflows/tauri.yml
@@ -246,6 +246,13 @@ jobs:
       - name: Verify tauri-driver installation
         run: command -v tauri-driver
 
+      - name: Serve webui mock on devUrl port (5701)
+        run: |
+          python3 -m http.server 5701 --directory webui/dist &
+          echo $! > /tmp/webui-server.pid
+          timeout 15 bash -c 'until curl -sf http://localhost:5701 > /dev/null; do sleep 0.5; done'
+          echo "webui mock server ready on port 5701"
+
       - name: Install E2E test dependencies
         run: cd tauri/e2e && npm ci
 

--- a/.github/workflows/tauri.yml
+++ b/.github/workflows/tauri.yml
@@ -110,7 +110,7 @@ jobs:
         run: cd tauri/src-tauri && cargo test
 
   e2e:
-    name: E2E smoke test (tauri-driver, Linux)
+    name: E2E tests (tauri-driver, Linux)
     runs-on: ubuntu-latest
     needs: [lint, test]
     env:
@@ -166,16 +166,72 @@ jobs:
           touch tauri/src-tauri/icons/icon.icns
           touch tauri/src-tauri/icons/icon.ico
 
-      - name: Create minimal webui placeholder for E2E
+      - name: Create webui placeholder for E2E (chat mock)
         run: |
           mkdir -p webui/dist
-          cat > webui/dist/index.html << 'EOF'
+          cat > webui/dist/index.html << 'HTMLEOF'
           <!DOCTYPE html>
           <html lang="en">
-          <head><meta charset="UTF-8"><title>gptme</title></head>
-          <body><div id="app">gptme loading...</div></body>
+          <head>
+            <meta charset="UTF-8">
+            <title>gptme</title>
+            <style>
+              body { font-family: sans-serif; max-width: 800px; margin: 0 auto; padding: 20px; }
+              #messages { list-style: none; padding: 0; min-height: 100px; }
+              .message { padding: 8px 12px; margin: 4px 0; border-radius: 8px; }
+              .message.user { background: #e3f2fd; }
+              .message.assistant { background: #f1f8e9; }
+              #input-area { display: flex; gap: 8px; margin-top: 16px; }
+              #message-input { flex: 1; padding: 8px; border: 1px solid #ccc; border-radius: 4px; }
+              #send-btn { padding: 8px 16px; background: #1976d2; color: white; border: none; border-radius: 4px; cursor: pointer; }
+              #send-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+            </style>
+          </head>
+          <body>
+            <div id="app">
+              <div id="conversation-title" data-testid="conversation-title">New Conversation</div>
+              <ul id="messages" data-testid="message-list"></ul>
+              <div id="input-area">
+                <input id="message-input" data-testid="message-input" type="text" placeholder="Type a message..." />
+                <button id="send-btn" data-testid="send-button">Send</button>
+              </div>
+            </div>
+            <script>
+              var msgCount = 0;
+              function addMessage(text, role) {
+                var li = document.createElement('li');
+                li.className = 'message ' + role;
+                li.setAttribute('data-testid', 'message-' + role + '-' + msgCount);
+                li.textContent = text;
+                document.getElementById('messages').appendChild(li);
+                msgCount++;
+              }
+              function sendMessage() {
+                var input = document.getElementById('message-input');
+                var btn = document.getElementById('send-btn');
+                var text = input.value.trim();
+                if (!text) return;
+                var title = document.getElementById('conversation-title');
+                if (title.textContent === 'New Conversation') {
+                  title.textContent = text.slice(0, 40) + (text.length > 40 ? '...' : '');
+                }
+                addMessage(text, 'user');
+                input.value = '';
+                btn.disabled = true;
+                setTimeout(function() {
+                  addMessage('Mock response to: ' + text, 'assistant');
+                  btn.disabled = false;
+                }, 400);
+              }
+              document.getElementById('send-btn').addEventListener('click', sendMessage);
+              document.getElementById('message-input').addEventListener('keydown', function(e) {
+                if (e.key === 'Enter') sendMessage();
+              });
+              document.getElementById('app').setAttribute('data-ready', 'true');
+            </script>
+          </body>
           </html>
-          EOF
+          HTMLEOF
 
       - name: Build Tauri debug binary
         run: cd tauri/src-tauri && cargo build
@@ -193,7 +249,7 @@ jobs:
       - name: Install E2E test dependencies
         run: cd tauri/e2e && npm ci
 
-      - name: Run E2E smoke tests
+      - name: Run E2E tests (smoke + chat flow)
         run: xvfb-run --auto-servernum npm --prefix tauri/e2e test
 
   build:

--- a/tauri/e2e/test/specs/chat_flow.test.js
+++ b/tauri/e2e/test/specs/chat_flow.test.js
@@ -1,0 +1,113 @@
+/**
+ * Chat interaction flow — Slice 2 E2E tests.
+ *
+ * These tests run against the chat-mock.html fixture (configured in CI via
+ * the "Create webui placeholder" step in tauri.yml, or locally by pointing
+ * the built app at tauri/e2e/fixtures/chat-mock.html).
+ *
+ * Covers:
+ * - Chat input and send button are present
+ * - Sending a message adds it to the message list
+ * - An assistant response appears after the user message
+ * - The conversation title updates from the first user message
+ */
+describe("Chat interaction flow", () => {
+  before(async () => {
+    await browser.waitUntil(
+      async () => {
+        try {
+          const app = await $("#app");
+          const ready = await app.getAttribute("data-ready");
+          return ready === "true";
+        } catch (_e) {
+          return false;
+        }
+      },
+      {
+        timeout: 30000,
+        timeoutMsg: "App did not reach ready state (data-ready=true) within 30s",
+      }
+    );
+  });
+
+  it("chat input element is present and editable", async () => {
+    const input = await $('[data-testid="message-input"]');
+    await expect(input).toExist();
+    await expect(input).toBeEnabled();
+  });
+
+  it("send button is present", async () => {
+    const btn = await $('[data-testid="send-button"]');
+    await expect(btn).toExist();
+    await expect(btn).toBeEnabled();
+  });
+
+  it("message list container is present", async () => {
+    const list = await $('[data-testid="message-list"]');
+    await expect(list).toExist();
+  });
+
+  it("sending a message appends it to the chat as a user message", async () => {
+    const input = await $('[data-testid="message-input"]');
+    await input.setValue("Hello, gptme!");
+
+    const sendBtn = await $('[data-testid="send-button"]');
+    await sendBtn.click();
+
+    const userMsg = await $('[data-testid="message-user-0"]');
+    await expect(userMsg).toExist();
+    await expect(userMsg).toHaveText("Hello, gptme!");
+  });
+
+  it("input field is cleared after sending", async () => {
+    const input = await $('[data-testid="message-input"]');
+    const value = await input.getValue();
+    expect(value).toBe("");
+  });
+
+  it("assistant response appears after user message", async () => {
+    await browser.waitUntil(
+      async () => {
+        const responses = await $$('[data-testid^="message-assistant-"]');
+        return responses.length > 0;
+      },
+      {
+        timeout: 10000,
+        timeoutMsg: "No assistant response appeared within 10s",
+      }
+    );
+
+    const response = await $('[data-testid^="message-assistant-"]');
+    await expect(response).toExist();
+    const text = await response.getText();
+    expect(text.length).toBeGreaterThan(0);
+  });
+
+  it("conversation title updates from the first user message", async () => {
+    const title = await $('[data-testid="conversation-title"]');
+    await expect(title).toExist();
+    const text = await title.getText();
+    expect(text).not.toBe("New Conversation");
+    expect(text.length).toBeGreaterThan(0);
+  });
+
+  it("Enter key sends a message", async () => {
+    const input = await $('[data-testid="message-input"]');
+    await input.setValue("Second message via Enter");
+    await browser.keys("Enter");
+
+    await browser.waitUntil(
+      async () => {
+        const msgs = await $$('[data-testid^="message-user-"]');
+        return msgs.length >= 2;
+      },
+      {
+        timeout: 5000,
+        timeoutMsg: "Second user message did not appear after pressing Enter",
+      }
+    );
+
+    const msgs = await $$('[data-testid^="message-user-"]');
+    expect(msgs.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/tauri/e2e/test/specs/chat_flow.test.js
+++ b/tauri/e2e/test/specs/chat_flow.test.js
@@ -49,13 +49,26 @@ describe("Chat interaction flow", () => {
   });
 
   it("sending a message appends it to the chat as a user message", async () => {
+    const beforeMessages = await $$('[data-testid^="message-user-"]');
     const input = await $('[data-testid="message-input"]');
     await input.setValue("Hello, gptme!");
 
     const sendBtn = await $('[data-testid="send-button"]');
     await sendBtn.click();
 
-    const userMsg = await $('[data-testid="message-user-0"]');
+    await browser.waitUntil(
+      async () => {
+        const afterMessages = await $$('[data-testid^="message-user-"]');
+        return afterMessages.length === beforeMessages.length + 1;
+      },
+      {
+        timeout: 5000,
+        timeoutMsg: "User message did not appear after sending",
+      }
+    );
+
+    const userMessages = await $$('[data-testid^="message-user-"]');
+    const userMsg = userMessages[userMessages.length - 1];
     await expect(userMsg).toExist();
     await expect(userMsg).toHaveText("Hello, gptme!");
   });

--- a/tauri/e2e/test/specs/chat_flow.test.js
+++ b/tauri/e2e/test/specs/chat_flow.test.js
@@ -1,9 +1,10 @@
 /**
  * Chat interaction flow — Slice 2 E2E tests.
  *
- * These tests run against the chat-mock.html fixture (configured in CI via
- * the "Create webui placeholder" step in tauri.yml, or locally by pointing
- * the built app at tauri/e2e/fixtures/chat-mock.html).
+ * These tests run against the webui mock served on devUrl (port 5701).
+ * In CI, the "Create webui placeholder for E2E" step writes webui/dist/index.html
+ * and "Serve webui mock on devUrl port" starts python3 http.server on 5701.
+ * Locally: run `python3 -m http.server 5701 --directory webui/dist` first.
  *
  * Covers:
  * - Chat input and send button are present
@@ -94,7 +95,8 @@ describe("Chat interaction flow", () => {
   it("Enter key sends a message", async () => {
     const input = await $('[data-testid="message-input"]');
     await input.setValue("Second message via Enter");
-    await browser.keys("Enter");
+    await input.click(); // ensure input has focus before sending keystroke
+    await browser.keys(["Enter"]);
 
     await browser.waitUntil(
       async () => {


### PR DESCRIPTION
## Summary

- Adds `tauri/e2e/test/specs/chat_flow.test.js` — 7 E2E tests covering the chat interaction flow built on the tauri-driver harness from #2772/#2773
- Updates the CI webui placeholder to a functional chat mock with `data-testid` attributes and a simulated async response loop, so these tests can run without a real gptme server or LLM API keys
- Renames the CI E2E job to "E2E tests (tauri-driver, Linux)" to reflect the expanded scope

## What's tested

| Test | What it verifies |
|------|-----------------|
| chat input present & enabled | UI element exists after app loads |
| send button present | UI element exists |
| message list container present | Container renders |
| send message → user message appears | Message stored with `data-testid="message-user-0"` |
| input cleared after send | State management |
| assistant response appears | Mock response renders within 10s |
| title updates from first message | Conversation title derives from first user message |
| Enter key sends message | Keyboard shortcut works |

## Design

The CI placeholder is a self-contained HTML file with inline JS that:
- Responds to send with a deterministic mock reply after 400ms
- Sets `data-ready="true"` on `#app` when the DOM is ready (used by the `before()` hook to wait for full load)
- Exposes all interactive elements via `data-testid` attributes for stable WebDriver selectors

The smoke tests (#2773) continue to pass unchanged — they only check `document.readyState === "complete"` and `body` existence.

## Test plan

- [ ] CI E2E job passes (smoke + chat flow)
- [ ] `tauri/e2e/test/specs/chat_flow.test.js` shows 7 passing tests in CI output
- [ ] `tauri/e2e/test/specs/smoke.test.js` still shows 2 passing tests

Closes part of gptme#1591.