### PR TITLE
feat(plugins): discover src-layout plugins, layer user [plugins], lenient +tool

### DIFF
--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -373,7 +373,10 @@ Run 'gptme-util --help' for all utility commands."""
         _available_tools + ["none"],
         allow_prefixes=["+", "-"],
         extra_choices_for_prefix={"-": _known_tool_names},
-        lenient_prefixes=["+", "-"],
+        # Only '+' is lenient: plugin tools (added via '+tool') aren't known at
+        # parse time. '-tool' exclusions stay strict against known tools so typos
+        # like '-shel' are caught early instead of being silently ignored.
+        lenient_prefixes=["+"],
         metavar="TOOL",
     ),
     help=f"Tools to allow. Comma-separated or repeated. Use '+tool' to add to defaults (e.g., '-t +subagent'). Use '-tool' to exclude from defaults (e.g., '-t=-browser'). Use 'none' to disable all tools. Supports .py file paths for custom tools (e.g., '-t path/to/tool.py'). Available: {available_tool_names}.",

--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -77,6 +77,7 @@ class CommaSeparatedChoice(click.ParamType):
         allow_prefix: str | None = None,
         allow_prefixes: list[str] | None = None,
         extra_choices_for_prefix: dict[str, list[str]] | None = None,
+        lenient_prefixes: list[str] | None = None,
         metavar: str | None = None,
     ):
         self.choices = choices
@@ -92,6 +93,11 @@ class CommaSeparatedChoice(click.ParamType):
             prefix: set(prefix_choices)
             for prefix, prefix_choices in (extra_choices_for_prefix or {}).items()
         }
+        # Prefixes for which unknown names are accepted at parse time. Plugin
+        # tools aren't known when the CLI is built (plugins load later), so a
+        # prefixed name like "+tts" must pass; it's resolved against the loaded
+        # toolset later, which warns if it's genuinely missing.
+        self.lenient_prefixes = set(lenient_prefixes or [])
         self._metavar = metavar
 
     def convert(self, value, param, ctx):
@@ -111,6 +117,9 @@ class CommaSeparatedChoice(click.ParamType):
                     break
             # Allow file paths (e.g. path/to/tool.py) to pass through
             if check.endswith(".py") or "/" in check or "\\" in check:
+                continue
+            # Defer validation for lenient prefixes (e.g. "+tts" plugin tools)
+            if matched_prefix in self.lenient_prefixes:
                 continue
             extra_choices = (
                 self.extra_choices_for_prefix.get(matched_prefix, set())
@@ -364,6 +373,7 @@ Run 'gptme-util --help' for all utility commands."""
         _available_tools + ["none"],
         allow_prefixes=["+", "-"],
         extra_choices_for_prefix={"-": _known_tool_names},
+        lenient_prefixes=["+", "-"],
         metavar="TOOL",
     ),
     help=f"Tools to allow. Comma-separated or repeated. Use '+tool' to add to defaults (e.g., '-t +subagent'). Use '-tool' to exclude from defaults (e.g., '-t=-browser'). Use 'none' to disable all tools. Supports .py file paths for custom tools (e.g., '-t path/to/tool.py'). Available: {available_tool_names}.",

--- a/gptme/config/core.py
+++ b/gptme/config/core.py
@@ -103,6 +103,47 @@ class Config:
 
         return mcp
 
+    def get_plugin_config(self) -> tuple[list[Path], list[str] | None]:
+        """Resolve plugin search paths and the enabled allowlist.
+
+        Layers user-level ``[plugins]`` (from ~/.config/gptme/config.toml) with
+        project-level ``[plugins]`` (from gptme.toml). User paths resolve against
+        the user config directory; project paths against the workspace. Returns
+        ``(paths, enabled)`` where ``enabled`` is ``None`` when no allowlist is
+        set (meaning all discovered plugins are enabled).
+        """
+        from .user import config_path as user_config_path
+
+        paths: list[Path] = []
+        enabled: list[str] = []
+
+        def _add_path(path: Path) -> None:
+            resolved = path.resolve()
+            if resolved not in {p.resolve() for p in paths}:
+                paths.append(path)
+
+        # User-level plugins (relative paths resolve against the config dir)
+        user_config_dir = Path(user_config_path).expanduser().parent
+        for path_str in self.user.plugins.paths:
+            path = Path(path_str).expanduser()
+            if not path.is_absolute():
+                path = user_config_dir / path
+            _add_path(path)
+        enabled.extend(self.user.plugins.enabled)
+
+        # Project-level plugins (relative paths resolve against the workspace)
+        if self.project and self.project.plugins:
+            for path_str in self.project.plugins.paths:
+                path = Path(path_str).expanduser()
+                if not path.is_absolute() and self.project._workspace:
+                    path = self.project._workspace / path
+                _add_path(path)
+            enabled.extend(self.project.plugins.enabled)
+
+        # Dedupe enabled, preserving order. Empty => None (all plugins enabled).
+        deduped_enabled = list(dict.fromkeys(enabled))
+        return paths, (deduped_enabled or None)
+
     def get_env(self, key: str, default: str | None = None) -> str | None:
         """Gets an environment variable, checks the config file if it's not set in the environment.
 

--- a/gptme/config/core.py
+++ b/gptme/config/core.py
@@ -107,13 +107,17 @@ class Config:
         """Resolve plugin search paths and the enabled allowlist.
 
         Layers user-level ``[plugins]`` (from ~/.config/gptme/config.toml) with
-        project-level ``[plugins]`` (from gptme.toml). User paths resolve against
-        the user config directory; project paths against the workspace. Returns
-        ``(paths, enabled)`` where ``enabled`` is ``None`` when no allowlist is
-        set (meaning all discovered plugins are enabled).
-        """
-        from .user import config_path as user_config_path
+        project-level ``[plugins]`` (from gptme.toml). User paths are
+        ``~``/absolute (or expanduser-resolved); project paths resolve against
+        the workspace when relative. Returns ``(paths, enabled)``.
 
+        The ``enabled`` allowlist is the **union** of the user and project lists
+        (empty => ``None``, meaning all discovered plugins are enabled). The
+        union is intentionally restrictive: a global allowlist set by the user
+        also constrains plugins discovered from project paths, so a project
+        cannot silently load plugins the user hasn't opted into. To allow a
+        project's plugins under a user allowlist, add them to either list.
+        """
         paths: list[Path] = []
         enabled: list[str] = []
 
@@ -122,13 +126,11 @@ class Config:
             if resolved not in {p.resolve() for p in paths}:
                 paths.append(path)
 
-        # User-level plugins (relative paths resolve against the config dir)
-        user_config_dir = Path(user_config_path).expanduser().parent
+        # User-level plugins. Paths are expanduser-resolved; use absolute or
+        # ``~``-prefixed paths (resolution is independent of the config file
+        # location, which may differ from the default in tests/multi-profile).
         for path_str in self.user.plugins.paths:
-            path = Path(path_str).expanduser()
-            if not path.is_absolute():
-                path = user_config_dir / path
-            _add_path(path)
+            _add_path(Path(path_str).expanduser())
         enabled.extend(self.user.plugins.enabled)
 
         # Project-level plugins (relative paths resolve against the workspace)

--- a/gptme/config/models.py
+++ b/gptme/config/models.py
@@ -160,6 +160,10 @@ class UserConfig:
     providers: list[ProviderConfig] = field(default_factory=list)
     lessons: "LessonsConfig | None" = None
 
+    # Plugin system configuration (search paths + enabled allowlist).
+    # Layered with project-level [plugins] (see Config.get_plugin_config).
+    plugins: PluginsConfig = field(default_factory=PluginsConfig)
+
     # Plugin-specific configuration namespace (user-level)
     # Allows plugins to have their own config sections like [plugin.retrieval]
     plugin: dict[str, dict] = field(default_factory=dict)

--- a/gptme/config/user.py
+++ b/gptme/config/user.py
@@ -21,6 +21,7 @@ from ..util import path_with_tilde
 from .models import (
     LessonsConfig,
     MCPConfig,
+    PluginsConfig,
     ProviderConfig,
     UserConfig,
     UserIdentityConfig,
@@ -211,6 +212,15 @@ def load_user_config(path: str | None = None) -> UserConfig:
         else None
     )
 
+    # Parse [plugins] section (search paths + enabled allowlist)
+    plugins_data = config.pop("plugins", {})
+    if not isinstance(plugins_data, dict):
+        raise ValueError("plugins must be an object")
+    plugins = PluginsConfig(
+        paths=plugins_data.get("paths", []),
+        enabled=plugins_data.get("enabled", []),
+    )
+
     # Extract plugin-prefixed keys (e.g., [plugin.retrieval] -> plugin["retrieval"])
     # This allows plugins to have their own config sections without triggering warnings
     plugin_config: dict[str, dict] = {}
@@ -228,6 +238,7 @@ def load_user_config(path: str | None = None) -> UserConfig:
         mcp=mcp,
         providers=providers,
         lessons=lessons,
+        plugins=plugins,
         plugin=plugin_config,
     )
 

--- a/gptme/hooks/registry.py
+++ b/gptme/hooks/registry.py
@@ -26,6 +26,7 @@ from .types import (
     CwdChangedHook,
     FilePostSaveHook,
     FilePreSaveHook,
+    GenerationChunkHook,
     GenerationPostHook,
     GenerationPreHook,
     Hook,
@@ -543,6 +544,17 @@ def register_hook(
     name: str,
     hook_type: Literal[HookType.GENERATION_POST],
     func: GenerationPostHook,
+    priority: int = 0,
+    enabled: bool = True,
+    async_mode: bool = False,
+) -> None: ...
+
+
+@overload
+def register_hook(
+    name: str,
+    hook_type: Literal[HookType.GENERATION_CHUNK],
+    func: GenerationChunkHook,
     priority: int = 0,
     enabled: bool = True,
     async_mode: bool = False,

--- a/gptme/hooks/types.py
+++ b/gptme/hooks/types.py
@@ -117,6 +117,7 @@ class HookType(str, Enum):
     # Generation
     GENERATION_PRE = "generation.pre"  # Before generating response
     GENERATION_POST = "generation.post"  # After generating response
+    GENERATION_CHUNK = "generation.chunk"  # On each streamed response line
     GENERATION_INTERRUPT = "generation.interrupt"  # Interrupt generation
 
     # Loop control
@@ -254,6 +255,26 @@ class GenerationPostHook(Protocol):
     ) -> Generator[Message | StopPropagation, None, None]: ...
 
 
+class GenerationChunkHook(Protocol):
+    """Hook called for each line of a streaming response, as it streams.
+
+    Fires only during streamed generation, once per response line (thinking
+    content is already filtered out). Lets plugins react incrementally, e.g.
+    speaking sentences as they arrive instead of waiting for generation.post.
+
+    Args:
+        chunk: The streamed text chunk (typically one line, may include a
+            trailing newline).
+        workspace: Workspace directory path (optional).
+    """
+
+    def __call__(
+        self,
+        chunk: str,
+        **kwargs: Any,
+    ) -> Generator[Message | StopPropagation, None, None]: ...
+
+
 class CacheInvalidatedHook(Protocol):
     """Hook called when prompt cache is invalidated.
 
@@ -349,6 +370,7 @@ HookFunc = (
     | LoopContinueHook
     | GenerationPreHook
     | GenerationPostHook
+    | GenerationChunkHook
     | FilePreSaveHook
     | FilePostSaveHook
     | CacheInvalidatedHook

--- a/gptme/init.py
+++ b/gptme/init.py
@@ -89,22 +89,10 @@ def init(
 
 def _init_plugins():
     """Discover and initialize all plugins (folder-based + entry-point)."""
-    from pathlib import Path
-
     from .plugins import discover_all_plugins
 
     config = get_config()
-    folder_paths: list[Path] = []
-    enabled: list[str] | None = None
-
-    if config.project and config.project.plugins:
-        for path_str in config.project.plugins.paths:
-            path = Path(path_str).expanduser()
-            if not path.is_absolute() and config.project._workspace:
-                path = config.project._workspace / path
-            folder_paths.append(path)
-        enabled = config.project.plugins.enabled or None
-
+    folder_paths, enabled = config.get_plugin_config()
     discover_all_plugins(folder_paths=folder_paths or None, enabled_plugins=enabled)
 
 

--- a/gptme/llm/__init__.py
+++ b/gptme/llm/__init__.py
@@ -544,6 +544,21 @@ def _reply_stream(
         length = length or shutil.get_terminal_size().columns
         rprint("\r" + " " * length, end="\r")
 
+    # Combine the on_token callback (ACP/display) with generation.chunk hooks
+    # (e.g. streaming TTS) into a single emitter, so the per-line buffering below
+    # runs whenever either consumer is interested — not just when on_token is set.
+    from ..hooks import HookType, get_hooks, trigger_hook
+
+    _chunk_hooks_active = bool(get_hooks(HookType.GENERATION_CHUNK))
+    emit_active = on_token is not None or _chunk_hooks_active
+
+    def _emit_chunk(text: str) -> None:
+        if _chunk_hooks_active:
+            for _ in trigger_hook(HookType.GENERATION_CHUNK, chunk=text):
+                pass
+        if on_token is not None:
+            on_token(text)
+
     output = ""
     start_time = time.time()
     first_token_time = None
@@ -693,7 +708,7 @@ def _reply_stream(
             # line is not a thinking-tag delimiter.  This prevents the opening
             # <think> tag characters from leaking to callers before are_thinking
             # flips at the trailing '\n'.
-            if on_token:
+            if emit_active:
                 if char == "\n":
                     # A thinking-tag transition happened on this newline when
                     # are_thinking != prev_thinking.  In that case discard the
@@ -701,7 +716,7 @@ def _reply_stream(
                     if not are_thinking and not prev_thinking:
                         if line_buffer:
                             # Normal line — emit the whole line as one chunk.
-                            on_token("".join(line_buffer) + "\n")
+                            _emit_chunk("".join(line_buffer) + "\n")
                         elif just_closed_thinking:
                             # Suppress the one blank "\n" that Anthropic always
                             # emits after "\n</think>\n\n".  Without this guard
@@ -710,7 +725,7 @@ def _reply_stream(
                             pass
                         else:
                             # Intentional blank line in response content.
-                            on_token("\n")
+                            _emit_chunk("\n")
                         # Only reset here (inside the normal-line branch), NOT on
                         # the "\n" that triggered the </think> detection — that "\n"
                         # has prev_thinking=True so it skips this block entirely,
@@ -762,8 +777,8 @@ def _reply_stream(
         if not json_mode and think_display_buffer:
             rprint(f"[dim]{''.join(think_display_buffer)}[/dim]", end="")
             think_display_buffer.clear()
-        if on_token and line_buffer and not are_thinking:
-            on_token("".join(line_buffer))
+        if emit_active and line_buffer and not are_thinking:
+            _emit_chunk("".join(line_buffer))
             line_buffer.clear()
 
     except KeyboardInterrupt:
@@ -774,12 +789,13 @@ def _reply_stream(
             normal_display_buffer.clear()
         # Flush partial line before the interrupt suffix so callers see the
         # content that was streamed up to the interrupt point.
-        if on_token and line_buffer:
-            on_token("".join(line_buffer))
+        if emit_active and line_buffer:
+            _emit_chunk("".join(line_buffer))
             line_buffer.clear()
         suffix = "... ^C Interrupted"
         if on_token:
             # Emit as one chunk; ACP batching callback handles downstream chunking.
+            # Display/ACP only — not a chunk hook event (don't speak the suffix).
             on_token(suffix)
         return Message("assistant", output + suffix, metadata=stream.metadata)
     finally:

--- a/gptme/plugins/__init__.py
+++ b/gptme/plugins/__init__.py
@@ -130,11 +130,15 @@ def discover_plugins(plugin_paths: list[Path]) -> list[Plugin]:
         for plugin_dir in search_path.iterdir():
             if not plugin_dir.is_dir():
                 continue
+            plugin = None
             if _is_plugin_dir(plugin_dir):
                 plugin = _load_plugin(plugin_dir)
-                if plugin:
-                    plugins.append(plugin)
-                    logger.debug(f"Discovered plugin: {plugin.name}")
+            elif _is_src_layout_plugin(plugin_dir):
+                # src-layout pip package (e.g. gptme-tts with src/gptme_tts/)
+                plugin = _load_src_layout_plugin(plugin_dir)
+            if plugin:
+                plugins.append(plugin)
+                logger.debug(f"Discovered plugin: {plugin.name}")
 
     # Cache for subsequent calls
     _plugin_cache[cache_key] = plugins
@@ -149,6 +153,50 @@ def _is_plugin_dir(path: Path) -> bool:
     Component directories (tools/, hooks/, commands/) are optional.
     """
     return (path / "__init__.py").exists()
+
+
+def _src_layout_packages(path: Path) -> list[Path]:
+    """Return importable packages under a ``src/`` directory, if any.
+
+    Supports the standard src-layout used by pip-installable plugins
+    (``pyproject.toml`` + ``src/<package>/__init__.py``).
+    """
+    src_dir = path / "src"
+    if not (path / "pyproject.toml").exists() or not src_dir.is_dir():
+        return []
+    return [
+        child
+        for child in sorted(src_dir.iterdir())
+        if child.is_dir() and (child / "__init__.py").exists()
+    ]
+
+
+def _is_src_layout_plugin(path: Path) -> bool:
+    """Check if a directory is a src-layout pip package containing packages."""
+    return bool(_src_layout_packages(path))
+
+
+def _load_src_layout_plugin(plugin_path: Path) -> Plugin | None:
+    """Load a src-layout plugin (``pyproject.toml`` + ``src/<package>/``).
+
+    Each inner package is registered as a tool module so its top-level
+    :class:`~gptme.tools.base.ToolSpec` instances are discovered. The plugin
+    keeps the *directory* name (e.g. ``gptme-tts``) so allowlists match, while
+    the tool modules use the *package* name (e.g. ``gptme_tts``).
+    """
+    packages = _src_layout_packages(plugin_path)
+    if not packages:
+        return None
+
+    src_dir = plugin_path / "src"
+    if str(src_dir) not in sys.path:
+        sys.path.insert(0, str(src_dir))
+
+    plugin = Plugin(name=plugin_path.name, path=plugin_path)
+    for package in packages:
+        plugin.tool_modules.append(package.name)
+        logger.debug(f"  Found src-layout package: {package.name}")
+    return plugin
 
 
 def _load_plugin(plugin_path: Path) -> Plugin | None:

--- a/gptme/plugins/entrypoints.py
+++ b/gptme/plugins/entrypoints.py
@@ -63,7 +63,7 @@ def _coerce_to_plugin(name: str, obj: object, _from_factory: bool = False):
     if isinstance(obj, ToolSpec):
         return GptmePlugin(name=name, tools=[obj])
     if (
-        isinstance(obj, (list, tuple))
+        isinstance(obj, list | tuple)
         and obj
         and all(isinstance(o, ToolSpec) for o in obj)
     ):

--- a/gptme/plugins/entrypoints.py
+++ b/gptme/plugins/entrypoints.py
@@ -37,32 +37,50 @@ def discover_entrypoint_plugins() -> tuple[GptmePlugin, ...]:
             logger.warning("Failed to load plugin %r: %s", ep.name, exc)
             continue
 
-        if isinstance(obj, GptmePlugin):
-            plugins.append(obj)
-            logger.debug("Loaded entry-point plugin: %s", obj.name)
-        elif callable(obj):
-            # Support factory functions that return GptmePlugin
-            try:
-                result = obj()
-                if isinstance(result, GptmePlugin):
-                    plugins.append(result)
-                    logger.debug("Loaded entry-point plugin: %s", result.name)
-                else:
-                    logger.warning(
-                        "Plugin factory %r returned %r instead of GptmePlugin; skipping",
-                        ep.name,
-                        type(result).__name__,
-                    )
-            except Exception as exc:
-                logger.warning("Plugin factory %r raised: %s", ep.name, exc)
-        else:
-            logger.warning(
-                "Plugin %r exported %r instead of GptmePlugin; skipping",
-                ep.name,
-                type(obj).__name__,
-            )
+        plugin = _coerce_to_plugin(ep.name, obj)
+        if plugin is not None:
+            plugins.append(plugin)
+            logger.debug("Loaded entry-point plugin: %s", plugin.name)
 
     return tuple(plugins)
+
+
+def _coerce_to_plugin(name: str, obj: object, _from_factory: bool = False):
+    """Normalize an entry-point export into a :class:`GptmePlugin`.
+
+    Accepts a ``GptmePlugin``, a bare ``ToolSpec``, a list/tuple of ``ToolSpec``
+    (wrapped into a plugin named after the entry point), or a zero-arg factory
+    returning any of those. Returns ``None`` (with a warning) for anything else.
+
+    Many existing plugins export a ``ToolSpec`` directly (``pkg:tool``) rather
+    than a manifest, so accepting that form keeps them working instead of being
+    silently skipped.
+    """
+    from ..tools.base import ToolSpec
+
+    if isinstance(obj, GptmePlugin):
+        return obj
+    if isinstance(obj, ToolSpec):
+        return GptmePlugin(name=name, tools=[obj])
+    if (
+        isinstance(obj, (list, tuple))
+        and obj
+        and all(isinstance(o, ToolSpec) for o in obj)
+    ):
+        return GptmePlugin(name=name, tools=list(obj))
+    # A factory callable (but only resolve one level to avoid recursion loops)
+    if callable(obj) and not _from_factory:
+        try:
+            return _coerce_to_plugin(name, obj(), _from_factory=True)
+        except Exception as exc:
+            logger.warning("Plugin factory %r raised: %s", name, exc)
+            return None
+    logger.warning(
+        "Plugin %r exported %r instead of GptmePlugin or ToolSpec; skipping",
+        name,
+        type(obj).__name__,
+    )
+    return None
 
 
 def clear_entrypoint_cache() -> None:

--- a/gptme/tools/__init__.py
+++ b/gptme/tools/__init__.py
@@ -343,23 +343,12 @@ def get_available_tools(include_mcp: bool = True) -> list[ToolSpec]:
         if env_tool_modules:
             tool_modules = env_tool_modules.split(",")
 
-        # Add plugin tool modules
-        if config.project and config.project.plugins.paths:
-            # Resolve plugin paths (support ~ and relative paths)
-            plugin_paths = []
-            for path_str in config.project.plugins.paths:
-                path = Path(path_str).expanduser()
-                if not path.is_absolute() and config.project._workspace:
-                    # Relative to workspace
-                    path = config.project._workspace / path
-                plugin_paths.append(path)
-
-            # Get tool modules from plugins
+        # Add plugin tool modules (user + project [plugins], layered)
+        plugin_paths, enabled_plugins = config.get_plugin_config()
+        if plugin_paths:
             plugin_tool_modules = get_plugin_tool_modules(
                 plugin_paths,
-                enabled_plugins=config.project.plugins.enabled
-                if config.project.plugins.enabled is not None
-                else None,
+                enabled_plugins=enabled_plugins,
             )
             tool_modules.extend(plugin_tool_modules)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1164,25 +1164,30 @@ def test_comma_separated_choice_minus_prefix():
 
 
 def test_comma_separated_choice_lenient_prefixes_allow_plugin_tools():
-    """With lenient_prefixes, prefixed unknown names pass (e.g. '+tts' plugin tool).
+    """Only '+'-prefixed unknown names pass (plugin tools); '-' stays strict.
 
-    Plugin tools aren't known when the CLI is built, so a prefixed name must
-    pass parse-time validation; it's resolved against the loaded toolset later.
+    Plugin tools aren't known when the CLI is built, so '+tool' must pass
+    parse-time validation (resolved against the loaded toolset later). '-tool'
+    exclusions stay strict so typos are caught early.
     """
     from gptme.cli.main import CommaSeparatedChoice
 
     csc = CommaSeparatedChoice(
         ["shell", "save", "read"],
         allow_prefixes=["+", "-"],
-        lenient_prefixes=["+", "-"],
+        extra_choices_for_prefix={"-": ["browser"]},
+        lenient_prefixes=["+"],
     )
 
     # Unknown plugin tool with '+' passes
     assert csc.convert("+tts", None, None) == "+tts"
-    # Unknown tool with '-' passes too
-    assert csc.convert("-tts", None, None) == "-tts"
-    # Known tools still pass
+    # Known tools still pass with either prefix
     assert csc.convert("+shell", None, None) == "+shell"
+    assert csc.convert("-browser", None, None) == "-browser"
+
+    # Unknown '-' exclusion is rejected (typo protection retained)
+    with pytest.raises(click.exceptions.BadParameter):
+        csc.convert("-tts", None, None)
 
     # Bare (unprefixed) unknown names are still rejected
     with pytest.raises(click.exceptions.BadParameter):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1163,6 +1163,32 @@ def test_comma_separated_choice_minus_prefix():
         csc.convert("-nonexistent", None, None)
 
 
+def test_comma_separated_choice_lenient_prefixes_allow_plugin_tools():
+    """With lenient_prefixes, prefixed unknown names pass (e.g. '+tts' plugin tool).
+
+    Plugin tools aren't known when the CLI is built, so a prefixed name must
+    pass parse-time validation; it's resolved against the loaded toolset later.
+    """
+    from gptme.cli.main import CommaSeparatedChoice
+
+    csc = CommaSeparatedChoice(
+        ["shell", "save", "read"],
+        allow_prefixes=["+", "-"],
+        lenient_prefixes=["+", "-"],
+    )
+
+    # Unknown plugin tool with '+' passes
+    assert csc.convert("+tts", None, None) == "+tts"
+    # Unknown tool with '-' passes too
+    assert csc.convert("-tts", None, None) == "-tts"
+    # Known tools still pass
+    assert csc.convert("+shell", None, None) == "+shell"
+
+    # Bare (unprefixed) unknown names are still rejected
+    with pytest.raises(click.exceptions.BadParameter):
+        csc.convert("tts", None, None)
+
+
 def test_comma_separated_choice_strips_short_option_equals_prefix():
     """Accept Click's `-x=value` short-option form for comma-separated choices."""
     from gptme.cli.main import CommaSeparatedChoice

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1414,3 +1414,54 @@ def test_chat_config_load_or_create_server_explicit_log_workspace(
 
     expected_workspace = (logdir / "workspace").resolve()
     assert config.workspace.resolve() == expected_workspace
+
+
+def test_user_config_plugins_parsed(tmp_path):
+    """[plugins] in the user config is parsed (not an 'unknown key')."""
+    temp_user_config = str(tmp_path / "config.toml")
+    with open(temp_user_config, "w") as f:
+        f.write(default_user_config)
+        f.write('\n[plugins]\npaths = ["~/plugins"]\nenabled = ["gptme-tts"]\n')
+    user = load_user_config(temp_user_config)
+    assert user.plugins.paths == ["~/plugins"]
+    assert user.plugins.enabled == ["gptme-tts"]
+
+
+def test_get_plugin_config_layers_user_and_project(tmp_path):
+    """get_plugin_config merges user-level and project-level [plugins]."""
+    user_plugins = tmp_path / "user_plugins"
+    project_plugins = tmp_path / "project_plugins"
+    user_plugins.mkdir()
+    project_plugins.mkdir()
+
+    temp_user_config = str(tmp_path / "config.toml")
+    with open(temp_user_config, "w") as f:
+        f.write(default_user_config)
+        f.write(f'\n[plugins]\npaths = ["{user_plugins}"]\nenabled = ["user-plugin"]\n')
+
+    with open(tmp_path / "gptme.toml", "w") as f:
+        f.write(
+            f'[plugins]\npaths = ["{project_plugins}"]\nenabled = ["project-plugin"]\n'
+        )
+
+    config = Config.from_workspace(tmp_path)
+    config = replace(config, user=load_user_config(temp_user_config))
+
+    paths, enabled = config.get_plugin_config()
+    resolved = {p.resolve() for p in paths}
+    assert user_plugins.resolve() in resolved
+    assert project_plugins.resolve() in resolved
+    assert enabled is not None
+    assert set(enabled) == {"user-plugin", "project-plugin"}
+
+
+def test_get_plugin_config_empty_enabled_is_none(tmp_path):
+    """No enabled allowlist anywhere => None (all plugins enabled)."""
+    temp_user_config = str(tmp_path / "config.toml")
+    with open(temp_user_config, "w") as f:
+        f.write(default_user_config)
+
+    config = Config.from_workspace(tmp_path)
+    config = replace(config, user=load_user_config(temp_user_config))
+    _paths, enabled = config.get_plugin_config()
+    assert enabled is None

--- a/tests/test_llm_utils.py
+++ b/tests/test_llm_utils.py
@@ -449,6 +449,54 @@ def test_reply_stream_on_token_callback(monkeypatch):
     assert len(collected) < len(expected_text)
 
 
+def test_reply_stream_generation_chunk_hook(monkeypatch):
+    """generation.chunk hooks receive streamed lines even without an on_token callback."""
+    from gptme.hooks import HookType, clear_hooks, register_hook
+    from gptme.llm import _reply_stream
+    from gptme.message import Message
+
+    chunks_to_yield = ["Hello world.\n", "How are you?"]
+
+    def _fake_gen(chunks):
+        yield from chunks
+
+    class _FakeStream:
+        def __init__(self, chunks):
+            self.gen = _fake_gen(chunks)
+            self.metadata = {"model": "test/model"}
+
+        def __iter__(self):
+            yield from self.gen
+
+    monkeypatch.setattr(
+        "gptme.llm._stream",
+        lambda *args, **kwargs: _FakeStream(chunks_to_yield),
+    )
+
+    received: list[str] = []
+
+    def chunk_hook(chunk, **kwargs):
+        received.append(chunk)
+        return
+        yield  # make it a generator
+
+    clear_hooks(HookType.GENERATION_CHUNK)
+    register_hook("test.chunk", HookType.GENERATION_CHUNK, chunk_hook)
+    try:
+        # Note: no on_token — the hook alone drives chunk emission.
+        result = _reply_stream(
+            messages=[Message("user", "hi")],
+            model="test/model",
+            tools=None,
+        )
+    finally:
+        clear_hooks(HookType.GENERATION_CHUNK)
+
+    assert result.content == "Hello world.\nHow are you?"
+    # Hook receives whole lines (newline-terminated) plus the final partial line.
+    assert received == ["Hello world.\n", "How are you?"]
+
+
 def test_reply_stream_on_token_break_on_tooluse(monkeypatch):
     """on_token receives only content up to the break_on_tooluse breakpoint."""
     from gptme.llm import _reply_stream

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -364,6 +364,38 @@ def test_get_plugin_tool_modules_src_layout_allowlist():
         assert tool_modules == ["gptme_tts"]
 
 
+def test_coerce_entrypoint_export_to_plugin():
+    """Entry-point exports of ToolSpec / list / factory normalize to a plugin."""
+    from gptme.plugins.entrypoints import _coerce_to_plugin
+    from gptme.plugins.plugin import GptmePlugin
+    from gptme.tools.base import ToolSpec
+
+    tool = ToolSpec(name="demo", desc="demo tool")
+
+    # GptmePlugin passes through unchanged
+    manifest = GptmePlugin(name="p", tools=[tool])
+    assert _coerce_to_plugin("p", manifest) is manifest
+
+    # Bare ToolSpec is wrapped, named after the entry point
+    wrapped = _coerce_to_plugin("demo-ep", tool)
+    assert isinstance(wrapped, GptmePlugin)
+    assert wrapped.name == "demo-ep"
+    assert wrapped.tools == [tool]
+
+    # List of ToolSpec is wrapped
+    listed = _coerce_to_plugin("multi", [tool])
+    assert isinstance(listed, GptmePlugin)
+    assert listed.tools == [tool]
+
+    # Factory callable returning a ToolSpec is resolved
+    from_factory = _coerce_to_plugin("fac", lambda: tool)
+    assert isinstance(from_factory, GptmePlugin)
+    assert from_factory.tools == [tool]
+
+    # Anything else is rejected
+    assert _coerce_to_plugin("bad", object()) is None
+
+
 def test_register_plugin_hooks():
     """Test plugin hook registration."""
     from gptme.hooks import HookType, clear_hooks, get_hooks

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -309,6 +309,61 @@ def test_discover_plugins_with_individual_hook_modules():
         assert "my_plugin.hooks.another_hook" in plugins[0].hook_modules
 
 
+def _make_src_layout_plugin(parent: Path, dir_name: str, pkg_name: str) -> Path:
+    """Create a src-layout pip-package plugin (pyproject.toml + src/<pkg>/)."""
+    plugin_dir = parent / dir_name
+    pkg_dir = plugin_dir / "src" / pkg_name
+    pkg_dir.mkdir(parents=True)
+    (plugin_dir / "pyproject.toml").write_text(
+        f'[project]\nname = "{dir_name}"\nversion = "0.1.0"\n'
+    )
+    (pkg_dir / "__init__.py").write_text("")
+    return pkg_dir
+
+
+def test_discover_plugins_src_layout():
+    """Discover a src-layout plugin (e.g. gptme-tts) under a search path.
+
+    The plugin keeps its directory name while the tool module uses the inner
+    package name.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        _make_src_layout_plugin(Path(tmpdir), "gptme-tts", "gptme_tts")
+
+        plugins = discover_plugins([Path(tmpdir)])
+
+        assert len(plugins) == 1
+        assert plugins[0].name == "gptme-tts"
+        assert plugins[0].tool_modules == ["gptme_tts"]
+
+
+def test_discover_plugins_src_layout_requires_pyproject():
+    """A src/ dir without pyproject.toml is not treated as a plugin."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        plugin_dir = Path(tmpdir) / "not-a-plugin"
+        pkg_dir = plugin_dir / "src" / "somepkg"
+        pkg_dir.mkdir(parents=True)
+        (pkg_dir / "__init__.py").write_text("")
+        # No pyproject.toml
+
+        plugins = discover_plugins([Path(tmpdir)])
+        assert plugins == []
+
+
+def test_get_plugin_tool_modules_src_layout_allowlist():
+    """The enabled allowlist matches a src-layout plugin by its directory name."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        _make_src_layout_plugin(Path(tmpdir), "gptme-tts", "gptme_tts")
+        _make_src_layout_plugin(Path(tmpdir), "gptme-other", "gptme_other")
+
+        tool_modules = get_plugin_tool_modules(
+            [Path(tmpdir)],
+            enabled_plugins=["gptme-tts"],
+        )
+
+        assert tool_modules == ["gptme_tts"]
+
+
 def test_register_plugin_hooks():
     """Test plugin hook registration."""
     from gptme.hooks import HookType, clear_hooks, get_hooks

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -84,6 +84,8 @@ def test_init_tools_allowlist_from_env():
         mock_config = mock_get_config.return_value
         # Mock the get_env method to return the custom_env_value
         mock_config.get_env.side_effect = mock_get_env
+        # No plugin search paths / allowlist for this test
+        mock_config.get_plugin_config.return_value = ([], None)
 
         init_tools()
 
@@ -121,6 +123,11 @@ def test_tool_loading_with_missing_package():
 def test_get_available_tools():
     # Clear cache to ensure test uses mocked config
     clear_tools()
+    # Also clear the plugin registry so globally-discovered plugins (e.g. an
+    # installed gptme-tts) don't leak extra tools into this exact-set assertion.
+    from gptme.plugins.registry import clear_registry
+
+    clear_registry()
     custom_env_value = "gptme.tools.save,gptme.tools.patch"
 
     with patch("gptme.config.get_config") as mock_get_config:
@@ -128,6 +135,8 @@ def test_get_available_tools():
         mock_config = mock_get_config.return_value
         # Mock the get_env method to return the custom_env_value
         mock_config.get_env.return_value = custom_env_value
+        # No plugin search paths / allowlist for this test
+        mock_config.get_plugin_config.return_value = ([], None)
 
         tools = get_available_tools()
 


### PR DESCRIPTION
## Summary

Dogfoods the plugin system so a pip-package plugin like `gptme-tts` works with `gptme -t +tts`, and restores streaming TTS. Changes:

1. **Discover `src/`-layout plugins.** `discover_plugins` only recognized the `tools/`-subdir convention, so every `src/<pkg>/` pip-package plugin in `gptme-contrib` was found as *zero* plugins. Now it also detects `pyproject.toml` + `src/` children, adds `src/` to `sys.path`, and registers the inner package as a tool module (plugin keeps its directory name for the `enabled` allowlist).

2. **Lenient `+tool` CLI validation.** The `--tools` choice list is frozen at import, before plugins load, so `+tts` was rejected as an invalid choice. `CommaSeparatedChoice` gains `lenient_prefixes` so `+`/`-` names pass parse-time validation; they're resolved against the loaded toolset later (which already warns on genuinely-missing tools).

3. **User-level `[plugins]` layering.** The section only worked in project `gptme.toml`; in the user config it was an `Unknown keys` warning. Add `plugins` to `UserConfig` and `Config.get_plugin_config()` to merge user + project search paths/allowlist (used by `init` and `get_available_tools`).

4. **Accept `ToolSpec` entry-point exports.** Many plugins register `pkg:tool` (a `ToolSpec`) rather than `pkg:plugin` (a `GptmePlugin`), so the entry-point loader skipped them with a warning. Coerce a bare `ToolSpec` / list of `ToolSpec` / factory into a `GptmePlugin`.

5. **`generation.chunk` hook (streaming).** New hook fired once per streamed response line (thinking filtered out), via the existing `on_token` line-buffering. Lets plugins react incrementally — restoring streaming TTS (speak sentences as they arrive), which was lost when TTS moved to `generation.post`.

## Test plan

- [x] `tests/test_plugins.py` — src-layout discovery + `ToolSpec` entry-point coercion
- [x] `tests/test_config.py` — user `[plugins]` parsing and user+project layering
- [x] `tests/test_cli.py` — lenient `+`/`-` prefixes (bare unknown names still rejected)
- [x] `tests/test_llm_utils.py` — `generation.chunk` hook fires per streamed line without `on_token`
- [x] Full plugins/config/init/hooks suites pass; ruff + mypy clean
- [x] Manually verified `gptme -t +tts` loads the tool, replies, and speaks — incrementally on multi-line responses

Companion: gptme/gptme-contrib#1062 (gptme-tts entry-point manifest, hook-name fix, streaming subscriber, server resolution fix).