### PR TITLE
docs: add gptme-howto link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,7 +475,7 @@ gptme -n 'run the test suite and fix any failing tests'
 gptme --non-interactive --output-format json 'summarize the current git diff'
 ```
 
-For more, see the [Getting Started][docs-getting-started] guide and the [Examples][docs-examples] in the [documentation][docs].
+For more, see the [Getting Started][docs-getting-started] guide and the [Examples][docs-examples] in the [documentation][docs]. For copy-paste task recipes, see [gptme-howto](https://github.com/gptme/gptme-howto).
 
 ### ⚙️ Configuration
 
@@ -855,6 +855,7 @@ gptme is **self-correcting**:
 - **Website**: [gptme.org](https://gptme.org)
 - **Documentation**: [docs.gptme.org](https://gptme.org/docs/)
 - **Examples**: [Examples](https://gptme.org/docs/examples.html)
+- **How-To Recipes**: [gptme-howto](https://github.com/gptme/gptme-howto)
 - **Downloads**: [Downloads](https://gptme.org/downloads/)
 - **Discord**: [Discord Community](https://discord.gg/NMaCmmkxWv)
 - **Twitter**: [@gptmeorg](https://x.com/gptmeorg)


### PR DESCRIPTION
Links to the new [gptme-howto](https://github.com/gptme/gptme-howto) repo — copy-paste task recipes for gptme's most common workflows.

Added in two places:
1. After the "getting started / examples" line in the quickstart section
2. In the "Where can I find more resources?" FAQ list

Companion to gptme/gptme-howto (just created, 5 recipes: file editing, code review, debugging, automating workflows, cross-file refactoring).