### PR TITLE
feat(server): add `detail` query param to conversation list endpoint

### DIFF
--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -738,6 +738,12 @@ def api_external_session(external_session_id: str):
             "schema": {"type": "string"},
             "description": "Filter conversations by name, id, or last message preview (case-insensitive substring match)",
         },
+        {
+            "name": "detail",
+            "in": "query",
+            "schema": {"type": "boolean", "default": False},
+            "description": "If true, perform a full scan to populate cost and token stats. Slower but returns accurate total_cost, total_input_tokens, and total_output_tokens fields. Suitable for paginated views; avoid on large collections.",
+        },
     ],
 )
 def api_conversations():
@@ -745,6 +751,7 @@ def api_conversations():
 
     Get a list of user conversations with metadata using the V2 API.
     Supports optional search filtering by conversation name, id, or last message preview.
+    Pass ``detail=true`` to include cost/token stats (slower full scan).
     """
     try:
         limit = int(request.args.get("limit", 100))
@@ -752,13 +759,14 @@ def api_conversations():
         return flask.jsonify({"error": "limit must be an integer"}), 400
     limit = max(1, min(limit, 1000))
     search = request.args.get("search", "").strip().lower()
+    detail = request.args.get("detail", "").lower() in ("1", "true", "yes")
 
-    # Use fast tail-only scan for list/search — reads last 8KB for
+    # Use fast tail-only scan for list/search by default — reads last 8KB for
     # preview/model, skips json.loads() on every metadata line.
-    # Full file is still read for line count, but without JSON parsing.
+    # Pass detail=true to opt in to full cost/token stats (slower).
     if search:
         conversations = []
-        for conv in get_user_conversations(detail=False):
+        for conv in get_user_conversations(detail=detail):
             if (
                 search in conv.name.lower()
                 or search in conv.id.lower()
@@ -768,7 +776,7 @@ def api_conversations():
                 if len(conversations) >= limit:
                     break
     else:
-        conversations = list(islice(get_user_conversations(detail=False), limit))
+        conversations = list(islice(get_user_conversations(detail=detail), limit))
     return flask.jsonify(conversations)
 
 

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -742,7 +742,7 @@ def api_external_session(external_session_id: str):
             "name": "detail",
             "in": "query",
             "schema": {"type": "boolean", "default": False},
-            "description": "If true, perform a full scan to populate cost and token stats. Slower but returns accurate total_cost, total_input_tokens, and total_output_tokens fields. Suitable for paginated views; avoid on large collections.",
+            "description": "If true, perform a full scan to populate cost and token stats. Slower but returns accurate total_cost, total_input_tokens, and total_output_tokens fields. Suitable for paginated views; avoid on large collections. When combined with search, every conversation is fully scanned before the limit is applied — avoid on large deployments.",
         },
     ],
 )
@@ -759,7 +759,8 @@ def api_conversations():
         return flask.jsonify({"error": "limit must be an integer"}), 400
     limit = max(1, min(limit, 1000))
     search = request.args.get("search", "").strip().lower()
-    detail = request.args.get("detail", "").lower() in ("1", "true", "yes")
+    detail_val = request.args.get("detail")
+    detail = detail_val is not None and detail_val.lower() in ("", "1", "true", "yes")
 
     # Use fast tail-only scan for list/search by default — reads last 8KB for
     # preview/model, skips json.loads() on every metadata line.

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -165,6 +165,66 @@ def test_api_conversation_search_case_insensitive(
     assert data[0]["id"] == "MySearchConversation"
 
 
+def test_api_conversation_list_detail_flag(client: FlaskClient, tmp_path, monkeypatch):
+    """Test that detail=true returns cost/token stats while default (false) zeroes them."""
+    import json
+
+    monkeypatch.setattr("gptme.logmanager.conversations.get_logs_dir", lambda: tmp_path)
+
+    # Create a conversation with an assistant message that carries usage info
+    conv_dir = tmp_path / "stats-conversation"
+    conv_dir.mkdir()
+    conv_file = conv_dir / "conversation.jsonl"
+    # Build a conversation > _TAIL_BYTES (8192) so the fast path actually activates
+    # for large files when detail=False. Pad with many user turns first.
+    messages: list[dict[str, object]] = [
+        {"role": "system", "content": "hello", "timestamp": "2026-01-01T00:00:00"},
+    ]
+    messages.extend(
+        {
+            "role": "user",
+            "content": "x" * 200,
+            "timestamp": f"2026-01-01T00:01:{i:02d}",
+        }
+        for i in range(40)
+    )
+    # The metadata-bearing assistant message (carries cost/token stats)
+    messages.append(
+        {
+            "role": "assistant",
+            "content": "reply",
+            "timestamp": "2026-01-02T00:00:00",
+            "metadata": {
+                "model": "claude-3-5-haiku",
+                "cost": 0.0001,
+                "usage": {"input_tokens": 10, "output_tokens": 5},
+            },
+        }
+    )
+    conv_file.write_text("\n".join(json.dumps(m) for m in messages) + "\n")
+    assert conv_file.stat().st_size > 8192, (
+        "fixture must be > _TAIL_BYTES to trigger fast path"
+    )
+
+    # Default (detail=false) should return zeroed stats
+    response = client.get("/api/v2/conversations")
+    assert response.status_code == 200
+    data = response.get_json()
+    assert isinstance(data, list)
+    assert len(data) == 1
+    assert data[0]["total_cost"] == 0.0
+    assert data[0]["total_input_tokens"] == 0
+
+    # detail=true should return actual stats
+    response = client.get("/api/v2/conversations?detail=true")
+    assert response.status_code == 200
+    data = response.get_json()
+    assert isinstance(data, list)
+    assert len(data) == 1
+    assert data[0]["total_cost"] > 0
+    assert data[0]["total_input_tokens"] > 0
+
+
 def test_api_conversation_get(conv, client: FlaskClient):
     response = client.get(f"/api/v2/conversations/{conv}")
     assert response.status_code == 200

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -223,6 +223,7 @@ def test_api_conversation_list_detail_flag(client: FlaskClient, tmp_path, monkey
     assert len(data) == 1
     assert data[0]["total_cost"] > 0
     assert data[0]["total_input_tokens"] > 0
+    assert data[0]["total_output_tokens"] > 0
 
 
 def test_api_conversation_get(conv, client: FlaskClient):


### PR DESCRIPTION
## Summary

The conversation list endpoint (`GET /api/v2/conversations`) currently always uses the fast tail-only scan, zeroing `total_cost` and token fields. This makes it impossible for the webui to display cost/token stats in the conversation list without opening each conversation.

This PR exposes the existing fast/full scan toggle as a query parameter:

- **Default** (`detail=false`): fast tail-only scan — unchanged behavior, suitable for large collections
- **`?detail=true`**: full JSONL scan — returns accurate `total_cost`, `total_input_tokens`, `total_output_tokens` fields

The `detail` parameter is documented in the OpenAPI `@api_doc_simple` decorator and works with both the regular and search list paths.

## Test plan

- `test_api_conversation_list_detail_flag` — verifies that:
  - Default returns zeroed stats on a large (>8KB) conversation file
  - `?detail=true` returns non-zero stats on the same file
- All existing `test_api_conversation_list*` tests pass

## Related

- Enables `tasks/gptme-webui-conversation-stats-in-list.md` (webui badge rendering slice)
- See `tasks/gptme-conversation-list-summary-stats-api.md` for context