### PR TITLE
fix(plugins): recurse nested src-layout tool packages

### DIFF
--- a/gptme/tools/__init__.py
+++ b/gptme/tools/__init__.py
@@ -31,6 +31,7 @@ from .base import (
 
 if TYPE_CHECKING:
     from collections.abc import Generator
+    from types import ModuleType
 
     from ..logmanager import Log
 
@@ -78,9 +79,37 @@ def _set_available_tools_cache(tools: list[ToolSpec] | None) -> None:
     _available_tools_var.set(tools)
 
 
+def _collect_tool_modules(
+    module_name: str,
+    module: ModuleType,
+) -> list[ModuleType]:
+    """Recursively collect a package/module and its public descendants."""
+    modules = [module]
+    if not hasattr(module, "__path__"):
+        return modules
+
+    for _, submodule_name, _ in pkgutil.iter_modules(module.__path__):
+        if submodule_name.startswith("_"):
+            continue
+        full_submodule_name = f"{module_name}.{submodule_name}"
+        try:
+            submodule = importlib.import_module(full_submodule_name)
+        except ModuleNotFoundError as e:
+            logger.warning(
+                "Missing dependency '%s' for module %s",
+                e.name,
+                full_submodule_name,
+            )
+            continue
+        modules.extend(_collect_tool_modules(full_submodule_name, submodule))
+
+    return modules
+
+
 def _discover_tools(module_names: list[str]) -> list[ToolSpec]:
     """Discover tools in a package or module, given the module/package name as a string."""
     tools = []
+    seen_specs: set[int] = set()
     for module_name in module_names:
         try:
             # Dynamically import the package or module
@@ -89,30 +118,15 @@ def _discover_tools(module_names: list[str]) -> list[ToolSpec]:
             logger.warning("Module or package %s not found", module_name)
             continue
 
-        modules = []
-        # Check if it's a package or a module
-        if hasattr(module, "__path__"):  # It's a package
-            # Iterate over modules in the package
-            for _, submodule_name, _ in pkgutil.iter_modules(module.__path__):
-                # Skip private modules
-                if submodule_name.startswith("_"):
-                    continue
-                full_submodule_name = f"{module_name}.{submodule_name}"
-                try:
-                    modules.append(importlib.import_module(full_submodule_name))
-                except ModuleNotFoundError as e:
-                    logger.warning(
-                        "Missing dependency '%s' for module %s",
-                        e.name,
-                        full_submodule_name,
-                    )
-                    continue
-        else:  # It's a single module
-            modules.append(module)
+        modules = _collect_tool_modules(module_name, module)
 
         # Find instances of ToolSpec in the modules
         for module in modules:
             for _, obj in inspect.getmembers(module, lambda c: isinstance(c, ToolSpec)):
+                spec_id = id(obj)
+                if spec_id in seen_specs:
+                    continue
+                seen_specs.add(spec_id)
                 tools.append(obj)
 
     return tools

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -11,6 +11,7 @@ from gptme.plugins import (
     get_plugin_tool_modules,
     register_plugin_commands,
 )
+from gptme.tools import _discover_tools
 
 
 def test_plugin_dataclass():
@@ -362,6 +363,33 @@ def test_get_plugin_tool_modules_src_layout_allowlist():
         )
 
         assert tool_modules == ["gptme_tts"]
+
+
+def test_discover_tools_recurses_nested_src_layout_packages():
+    """Nested tool packages under src-layout plugins still expose ToolSpecs."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        plugin_dir = Path(tmpdir) / "gptme-imagen"
+        pkg_dir = plugin_dir / "src" / "gptme_imagen"
+        tools_dir = pkg_dir / "tools"
+        tools_dir.mkdir(parents=True)
+
+        (plugin_dir / "pyproject.toml").write_text(
+            '[project]\nname = "gptme-imagen"\nversion = "0.1.0"\n'
+        )
+        (pkg_dir / "__init__.py").write_text("")
+        (tools_dir / "__init__.py").write_text("")
+        (tools_dir / "image_gen.py").write_text(
+            "from gptme.tools.base import ToolSpec\n"
+            'image_gen_tool = ToolSpec(name="image_gen", desc="demo")\n'
+        )
+
+        tool_modules = get_plugin_tool_modules(
+            [Path(tmpdir)],
+            enabled_plugins=["gptme-imagen"],
+        )
+
+        tools = _discover_tools(tool_modules)
+        assert [tool.name for tool in tools] == ["image_gen"]
 
 
 def test_coerce_entrypoint_export_to_plugin():

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,5 +1,6 @@
 """Tests for the plugin system."""
 
+import sys
 import tempfile
 from pathlib import Path
 
@@ -367,29 +368,45 @@ def test_get_plugin_tool_modules_src_layout_allowlist():
 
 def test_discover_tools_recurses_nested_src_layout_packages():
     """Nested tool packages under src-layout plugins still expose ToolSpecs."""
-    with tempfile.TemporaryDirectory() as tmpdir:
-        plugin_dir = Path(tmpdir) / "gptme-imagen"
-        pkg_dir = plugin_dir / "src" / "gptme_imagen"
-        tools_dir = pkg_dir / "tools"
-        tools_dir.mkdir(parents=True)
+    package_name = "gptme_imagen"
+    module_prefix = f"{package_name}."
 
-        (plugin_dir / "pyproject.toml").write_text(
-            '[project]\nname = "gptme-imagen"\nversion = "0.1.0"\n'
-        )
-        (pkg_dir / "__init__.py").write_text("")
-        (tools_dir / "__init__.py").write_text("")
-        (tools_dir / "image_gen.py").write_text(
-            "from gptme.tools.base import ToolSpec\n"
-            'image_gen_tool = ToolSpec(name="image_gen", desc="demo")\n'
-        )
+    for _ in range(2):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            plugin_dir = Path(tmpdir) / "gptme-imagen"
+            src_dir = plugin_dir / "src"
+            pkg_dir = src_dir / package_name
+            tools_dir = pkg_dir / "tools"
+            tools_dir.mkdir(parents=True)
 
-        tool_modules = get_plugin_tool_modules(
-            [Path(tmpdir)],
-            enabled_plugins=["gptme-imagen"],
-        )
+            try:
+                (plugin_dir / "pyproject.toml").write_text(
+                    '[project]\nname = "gptme-imagen"\nversion = "0.1.0"\n'
+                )
+                (pkg_dir / "__init__.py").write_text("")
+                (tools_dir / "__init__.py").write_text(
+                    "from .image_gen import image_gen_tool\n"
+                )
+                (tools_dir / "image_gen.py").write_text(
+                    "from gptme.tools.base import ToolSpec\n"
+                    'image_gen_tool = ToolSpec(name="image_gen", desc="demo")\n'
+                )
 
-        tools = _discover_tools(tool_modules)
-        assert [tool.name for tool in tools] == ["image_gen"]
+                tool_modules = get_plugin_tool_modules(
+                    [Path(tmpdir)],
+                    enabled_plugins=["gptme-imagen"],
+                )
+
+                tools = _discover_tools(tool_modules)
+                assert [tool.name for tool in tools] == ["image_gen"]
+            finally:
+                for module_name in list(sys.modules):
+                    if module_name == package_name or module_name.startswith(
+                        module_prefix
+                    ):
+                        sys.modules.pop(module_name, None)
+                if str(src_dir) in sys.path:
+                    sys.path.remove(str(src_dir))
 
 
 def test_coerce_entrypoint_export_to_plugin():


### PR DESCRIPTION
## Summary
- recurse tool discovery through nested public subpackages instead of stopping at one level
- dedupe re-exported ToolSpecs so plugins like gptme-tts do not surface duplicate tools
- add a regression test covering a gptme-imagen-style src-layout plugin with a nested tools package

## Why
`gptme-imagen` exposes its `ToolSpec` from `gptme_imagen.tools.image_gen`, but gptme only scanned one package level for src-layout plugins. That meant the plugin was discoverable by name while its `image_gen` tool stayed invisible, blocking the image-generation slice under ErikBjare/bob#841.

## Testing
- `uv run pytest tests/test_plugins.py -q`
- `uv run ruff check gptme/tools/__init__.py tests/test_plugins.py`
