### PR TITLE
feat(webui): add OpenRouter STT fallback for unsupported browsers

### DIFF
--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -12,6 +12,7 @@ import shutil
 import urllib.error
 import urllib.parse
 import urllib.request
+from base64 import b64encode
 from dataclasses import replace
 from datetime import datetime, timezone
 from itertools import islice
@@ -32,7 +33,9 @@ from gptme.config import (
     set_config,
     set_config_value,
 )
+from gptme.credentials import get_stored_api_key
 from gptme.llm import PROVIDER_API_KEYS, list_available_providers
+from gptme.llm.constants import OPENROUTER_APP_HEADERS
 from gptme.llm.models import (
     PROVIDERS,
     Provider,
@@ -71,6 +74,7 @@ from .external_sessions import get_external_session_provider
 from .openapi_docs import (
     CONVERSATION_ID_PARAM,
     ApiRootResponse,
+    AudioTranscriptionResponse,
     ConversationCreateRequest,
     ConversationListResponse,
     ConversationResponse,
@@ -107,10 +111,72 @@ _ALLOWED_AVATAR_EXTS = {".jpg", ".jpeg", ".png", ".gif", ".webp", ".ico"}
 _SERVER_BLOCKED_COMMANDS = {"exit", "restart", "edit", "delete"}
 
 _TRUTHY_ENV_VALUES = {"1", "true", "yes", "on"}
+_DEFAULT_OPENROUTER_STT_MODEL = "openai/whisper-1"
+_MAX_TRANSCRIPTION_AUDIO_BYTES = 25 * 1024 * 1024
+_SUPPORTED_TRANSCRIPTION_FORMATS = {"wav", "mp3", "flac", "m4a", "ogg", "webm", "aac"}
 
 
 def _env_truthy(name: str) -> bool:
     return os.environ.get(name, "").strip().lower() in _TRUTHY_ENV_VALUES
+
+
+def _guess_audio_format(filename: str | None, mimetype: str | None) -> str | None:
+    """Infer an OpenRouter STT audio format from filename or MIME type."""
+    if mimetype:
+        mime_key = mimetype.split(";", 1)[0].strip().lower()
+        mime_map = {
+            "audio/aac": "aac",
+            "audio/flac": "flac",
+            "audio/m4a": "m4a",
+            "audio/mp3": "mp3",
+            "audio/mp4": "m4a",
+            "audio/mpeg": "mp3",
+            "audio/ogg": "ogg",
+            "audio/wav": "wav",
+            "audio/webm": "webm",
+            "audio/x-wav": "wav",
+        }
+        if mime_key in mime_map:
+            return mime_map[mime_key]
+
+    if filename:
+        suffix = Path(filename).suffix.lower().lstrip(".")
+        if suffix in _SUPPORTED_TRANSCRIPTION_FORMATS:
+            return suffix
+    return None
+
+
+def _transcribe_audio_with_openrouter(
+    audio_bytes: bytes, audio_format: str, model: str, language: str | None = None
+) -> dict:
+    """Call OpenRouter's STT endpoint and return the decoded JSON response."""
+    config = get_config()
+    api_key = config.get_env("OPENROUTER_API_KEY") or get_stored_api_key("openrouter")
+    if not api_key:
+        raise ValueError("OpenRouter is not configured on this server")
+
+    payload: dict[str, object] = {
+        "model": model,
+        "input_audio": {
+            "data": b64encode(audio_bytes).decode("ascii"),
+            "format": audio_format,
+        },
+    }
+    if language:
+        payload["language"] = language
+
+    req = urllib.request.Request(
+        "https://openrouter.ai/api/v1/audio/transcriptions",
+        data=json.dumps(payload).encode("utf-8"),
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+            **OPENROUTER_APP_HEADERS,
+        },
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=60) as response:
+        return cast(dict, json.loads(response.read().decode("utf-8")))
 
 
 def _get_webui_deploy_config() -> dict[str, object]:
@@ -2150,6 +2216,110 @@ def api_user_config_file_patch():
     response["status"] = "ok"
     response["key"] = key
     return flask.jsonify(response)
+
+
+@v2_api.route("/api/v2/audio/transcriptions", methods=["POST"])
+@require_auth
+@api_doc(
+    summary="Transcribe uploaded audio with OpenRouter STT",
+    description=(
+        "Accept a short audio recording as multipart/form-data, forward it to "
+        "OpenRouter's `/api/v1/audio/transcriptions` endpoint, and return the "
+        "transcribed text."
+    ),
+    responses={
+        200: AudioTranscriptionResponse,
+        400: ErrorResponse,
+        413: ErrorResponse,
+        502: ErrorResponse,
+        503: ErrorResponse,
+    },
+    tags=["audio"],
+)
+def api_audio_transcriptions():
+    """Transcribe uploaded audio via OpenRouter."""
+    audio_file = request.files.get("file")
+    if audio_file is None or not audio_file.filename:
+        return flask.jsonify({"error": "No audio file provided"}), 400
+
+    audio_bytes = audio_file.read()
+    if not audio_bytes:
+        return flask.jsonify({"error": "Audio file is empty"}), 400
+    if len(audio_bytes) > _MAX_TRANSCRIPTION_AUDIO_BYTES:
+        size_mb = len(audio_bytes) / 1024 / 1024
+        return (
+            flask.jsonify(
+                {"error": (f"Audio file exceeds 25MB limit ({size_mb:.1f}MB)")}
+            ),
+            413,
+        )
+
+    requested_format = request.form.get("format")
+    audio_format = (requested_format or "").strip().lower() or _guess_audio_format(
+        audio_file.filename, audio_file.mimetype
+    )
+    if audio_format not in _SUPPORTED_TRANSCRIPTION_FORMATS:
+        supported_formats = ", ".join(sorted(_SUPPORTED_TRANSCRIPTION_FORMATS))
+        return (
+            flask.jsonify(
+                {
+                    "error": (
+                        "Unsupported audio format. "
+                        f"Supported formats: {supported_formats}"
+                    )
+                }
+            ),
+            400,
+        )
+
+    requested_model = request.form.get("model")
+    model = (requested_model or "").strip() or _DEFAULT_OPENROUTER_STT_MODEL
+
+    language = (request.form.get("language") or "").strip().lower() or None
+    if language and len(language) > 8:
+        return flask.jsonify({"error": "language must be a short ISO code"}), 400
+
+    try:
+        result = _transcribe_audio_with_openrouter(
+            audio_bytes=audio_bytes,
+            audio_format=audio_format,
+            model=model,
+            language=language,
+        )
+    except ValueError as exc:
+        return flask.jsonify({"error": str(exc)}), 503
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        logger.warning("OpenRouter STT request failed: %s %s", exc.code, detail)
+        return (
+            flask.jsonify(
+                {
+                    "error": (
+                        f"OpenRouter STT request failed ({exc.code}): "
+                        f"{detail or exc.reason}"
+                    )
+                }
+            ),
+            502,
+        )
+    except urllib.error.URLError as exc:
+        logger.warning("OpenRouter STT network failure: %s", exc)
+        return flask.jsonify(
+            {"error": f"OpenRouter STT request failed: {exc.reason}"}
+        ), 502
+
+    text = result.get("text")
+    if not isinstance(text, str):
+        return flask.jsonify({"error": "OpenRouter STT response missing text"}), 502
+
+    usage = result.get("usage")
+    return flask.jsonify(
+        {
+            "text": text,
+            "model": model,
+            "usage": usage if isinstance(usage, dict) else None,
+        }
+    )
 
 
 @v2_api.route("/api/v2/user/settings", methods=["GET"])

--- a/gptme/server/openapi_docs.py
+++ b/gptme/server/openapi_docs.py
@@ -293,6 +293,22 @@ class UserSettingsResponse(BaseModel):
     )
 
 
+class AudioTranscriptionResponse(BaseModel):
+    """Response from the speech-to-text transcription endpoint."""
+
+    text: str = Field(..., description="Transcribed text")
+    model: str = Field(
+        ..., description="Fully qualified OpenRouter model used for transcription"
+    )
+    usage: dict[str, int | float] | None = Field(
+        None,
+        description=(
+            "Optional usage/cost metadata returned by OpenRouter, such as "
+            "seconds, tokens, and cost."
+        ),
+    )
+
+
 class ExternalSessionListItem(BaseModel):
     """A read-only external session catalog item."""
 

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -1,3 +1,4 @@
+import io
 import json
 import random
 import time
@@ -2600,6 +2601,102 @@ def test_v2_user_settings_no_providers_no_model(client: FlaskClient, monkeypatch
     assert data["default_model"] is None
     assert data["default_model_source"] is None
     assert data["config_files"]["local_config_exists"] is False
+
+
+def test_v2_audio_transcriptions_success(client: FlaskClient, monkeypatch):
+    """POST /api/v2/audio/transcriptions proxies a short recording to OpenRouter."""
+
+    class FakeConfig:
+        def get_env(self, key: str, default: str | None = None):
+            if key == "OPENROUTER_API_KEY":
+                return "sk-or-test"
+            return default
+
+    captured: dict[str, Any] = {}
+
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self):
+            return json.dumps(
+                {
+                    "text": "hello from openrouter",
+                    "usage": {"seconds": 1.2, "total_tokens": 12},
+                }
+            ).encode("utf-8")
+
+    def fake_urlopen(req, timeout=0):
+        captured["url"] = req.full_url
+        captured["timeout"] = timeout
+        captured["body"] = json.loads(req.data.decode("utf-8"))
+        return FakeResponse()
+
+    monkeypatch.setattr("gptme.server.api_v2.get_config", lambda: FakeConfig())
+    monkeypatch.setattr("gptme.server.api_v2.urllib.request.urlopen", fake_urlopen)
+
+    response = client.post(
+        "/api/v2/audio/transcriptions",
+        data={
+            "file": (io.BytesIO(b"audio-bytes"), "speech.webm"),
+            "format": "webm",
+            "language": "en",
+        },
+        content_type="multipart/form-data",
+    )
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data == {
+        "text": "hello from openrouter",
+        "model": "openai/whisper-1",
+        "usage": {"seconds": 1.2, "total_tokens": 12},
+    }
+    assert captured["url"] == "https://openrouter.ai/api/v1/audio/transcriptions"
+    assert captured["timeout"] == 60
+    assert captured["body"]["model"] == "openai/whisper-1"
+    assert captured["body"]["language"] == "en"
+    assert captured["body"]["input_audio"]["format"] == "webm"
+    assert isinstance(captured["body"]["input_audio"]["data"], str)
+
+
+def test_v2_audio_transcriptions_requires_file(client: FlaskClient):
+    """POST /api/v2/audio/transcriptions rejects empty multipart uploads."""
+    response = client.post(
+        "/api/v2/audio/transcriptions",
+        data={},
+        content_type="multipart/form-data",
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "No audio file provided"}
+
+
+def test_v2_audio_transcriptions_requires_openrouter(client: FlaskClient, monkeypatch):
+    """POST /api/v2/audio/transcriptions fails cleanly without OpenRouter config."""
+
+    class FakeConfig:
+        def get_env(self, _key: str, default: str | None = None):
+            return default
+
+    monkeypatch.setattr("gptme.server.api_v2.get_config", lambda: FakeConfig())
+    monkeypatch.setattr(
+        "gptme.server.api_v2.get_stored_api_key", lambda _provider: None
+    )
+
+    response = client.post(
+        "/api/v2/audio/transcriptions",
+        data={"file": (io.BytesIO(b"audio-bytes"), "speech.webm"), "format": "webm"},
+        content_type="multipart/form-data",
+    )
+
+    assert response.status_code == 503
+    assert response.get_json() == {
+        "error": "OpenRouter is not configured on this server"
+    }
 
 
 def test_v2_conversation_transcript_append(

--- a/webui/src/components/SpeechInputButton.tsx
+++ b/webui/src/components/SpeechInputButton.tsx
@@ -17,6 +17,7 @@ export function SpeechInputButton({ onTranscript, onInterimTranscript, disabled 
     useSpeechToText();
 
   const isListening = state === 'listening';
+  const isTranscribing = state === 'transcribing';
 
   useEffect(() => {
     onFinalResult(onTranscript);
@@ -35,15 +36,18 @@ export function SpeechInputButton({ onTranscript, onInterimTranscript, disabled 
   const isError = state === 'error';
 
   const handleClick = () => {
+    if (isTranscribing) return;
     if (isListening) stopListening();
     else startListening();
   };
 
   const label = isError
     ? 'Mic error — click to retry'
-    : isListening
-      ? 'Listening… click to stop'
-      : 'Dictate message (speech-to-text)';
+    : isTranscribing
+      ? 'Transcribing…'
+      : isListening
+        ? 'Listening… click to stop'
+        : 'Dictate message (speech-to-text)';
 
   return (
     <Tooltip>
@@ -53,12 +57,12 @@ export function SpeechInputButton({ onTranscript, onInterimTranscript, disabled 
           variant="ghost"
           size="icon"
           onClick={handleClick}
-          disabled={disabled}
+          disabled={disabled || isTranscribing}
           className={[
             'relative h-8 w-8 shrink-0 rounded-full transition-colors',
             isError
               ? 'text-destructive'
-              : isListening
+              : isListening || isTranscribing
                 ? 'text-blue-500 hover:text-blue-600'
                 : 'text-muted-foreground',
           ].join(' ')}
@@ -71,7 +75,7 @@ export function SpeechInputButton({ onTranscript, onInterimTranscript, disabled 
           )}
           {state === 'error' ? (
             <MicOff className="h-4 w-4" />
-          ) : isListening ? (
+          ) : isListening || isTranscribing ? (
             <Loader2 className="relative h-4 w-4 animate-spin" />
           ) : (
             <Mic className="h-4 w-4" />

--- a/webui/src/hooks/__tests__/useSpeechToText.test.tsx
+++ b/webui/src/hooks/__tests__/useSpeechToText.test.tsx
@@ -1,0 +1,141 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { useSpeechToText } from '../useSpeechToText';
+
+const transcribeAudio = jest.fn();
+const useUserSettingsMock = jest.fn();
+
+jest.mock('@/contexts/ApiContext', () => ({
+  useApi: () => ({
+    api: {
+      transcribeAudio,
+    },
+  }),
+}));
+
+jest.mock('@/hooks/useUserSettings', () => ({
+  useUserSettings: () => useUserSettingsMock(),
+}));
+
+class MockMediaStream {
+  private tracks = [{ stop: jest.fn() }];
+
+  getTracks(): MediaStreamTrack[] {
+    return this.tracks as unknown as MediaStreamTrack[];
+  }
+}
+
+class MockMediaRecorder {
+  static isTypeSupported(type: string) {
+    return type.startsWith('audio/webm');
+  }
+
+  mimeType: string;
+  ondataavailable: ((event: { data: Blob }) => void) | null = null;
+  onerror: (() => void) | null = null;
+  onstop: (() => void) | null = null;
+  state: 'inactive' | 'recording' = 'inactive';
+
+  constructor(
+    _stream: MediaStream,
+    options?: {
+      mimeType?: string;
+    }
+  ) {
+    this.mimeType = options?.mimeType ?? 'audio/webm';
+  }
+
+  start() {
+    this.state = 'recording';
+  }
+
+  stop() {
+    this.state = 'inactive';
+    this.ondataavailable?.({
+      data: new Blob(['audio'], { type: this.mimeType }),
+    });
+    this.onstop?.();
+  }
+}
+
+beforeEach(() => {
+  transcribeAudio.mockReset();
+  useUserSettingsMock.mockReset();
+  useUserSettingsMock.mockReturnValue({
+    settings: { providers_configured: ['openrouter'] },
+    isLoading: false,
+    error: null,
+    refetch: jest.fn(),
+  });
+  transcribeAudio.mockResolvedValue({
+    text: 'server transcript',
+    model: 'openai/whisper-1',
+  });
+
+  Object.defineProperty(window, 'MediaRecorder', {
+    configurable: true,
+    writable: true,
+    value: MockMediaRecorder,
+  });
+  Object.defineProperty(navigator, 'mediaDevices', {
+    configurable: true,
+    writable: true,
+    value: {
+      getUserMedia: jest.fn().mockResolvedValue(new MockMediaStream()),
+    },
+  });
+  Object.defineProperty(navigator, 'language', {
+    configurable: true,
+    value: 'en-US',
+  });
+  delete (window as Window & { SpeechRecognition?: unknown }).SpeechRecognition;
+  delete (window as Window & { webkitSpeechRecognition?: unknown }).webkitSpeechRecognition;
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('useSpeechToText', () => {
+  it('reports unsupported when neither browser STT nor server fallback is available', () => {
+    useUserSettingsMock.mockReturnValue({
+      settings: { providers_configured: [] },
+      isLoading: false,
+      error: null,
+      refetch: jest.fn(),
+    });
+
+    const { result } = renderHook(() => useSpeechToText());
+
+    expect(result.current.isSupported).toBe(false);
+  });
+
+  it('records and transcribes through the server fallback when browser STT is unavailable', async () => {
+    const handler = jest.fn();
+    const { result } = renderHook(() => useSpeechToText());
+
+    act(() => {
+      result.current.onFinalResult(handler);
+      result.current.startListening();
+    });
+
+    expect(result.current.state).toBe('listening');
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    act(() => {
+      result.current.stopListening();
+    });
+
+    await waitFor(() => {
+      expect(transcribeAudio).toHaveBeenCalledTimes(1);
+    });
+    await waitFor(() => {
+      expect(result.current.state).toBe('idle');
+    });
+
+    expect(transcribeAudio.mock.calls[0]?.[1]).toEqual({ language: 'en' });
+    expect(handler).toHaveBeenCalledWith('server transcript');
+  });
+});

--- a/webui/src/hooks/__tests__/useSpeechToText.test.tsx
+++ b/webui/src/hooks/__tests__/useSpeechToText.test.tsx
@@ -135,7 +135,9 @@ describe('useSpeechToText', () => {
       expect(result.current.state).toBe('idle');
     });
 
-    expect(transcribeAudio.mock.calls[0]?.[1]).toEqual({ language: 'en' });
+    expect(transcribeAudio.mock.calls[0]?.[1]).toEqual(
+      expect.objectContaining({ language: 'en' })
+    );
     expect(handler).toHaveBeenCalledWith('server transcript');
   });
 });

--- a/webui/src/hooks/useSpeechToText.ts
+++ b/webui/src/hooks/useSpeechToText.ts
@@ -90,6 +90,7 @@ export function useSpeechToText(): UseSpeechToTextReturn {
   const recordingRef = useRef<RecordingSession | null>(null);
   const fallbackSetupGenRef = useRef(0);
   const finalHandlerRef = useRef<((text: string) => void) | null>(null);
+  const abortControllerRef = useRef<AbortController | null>(null);
   const SpeechRecognitionClass = getSpeechRecognitionClass();
   const browserSupported = SpeechRecognitionClass !== null;
   const serverFallbackSupported =
@@ -204,6 +205,7 @@ export function useSpeechToText(): UseSpeechToTextReturn {
           setInterimTranscript('');
 
           if (session.skipTranscription) {
+            abortControllerRef.current?.abort();
             setState('idle');
             return;
           }
@@ -216,9 +218,14 @@ export function useSpeechToText(): UseSpeechToTextReturn {
             return;
           }
 
+          // Cancel any previous in-flight transcription before starting a new one
+          abortControllerRef.current?.abort();
+          const controller = new AbortController();
+          abortControllerRef.current = controller;
+
           setState('transcribing');
           void api
-            .transcribeAudio(audio, { language: getLanguageCode() })
+            .transcribeAudio(audio, { language: getLanguageCode(), signal: controller.signal })
             .then((result) => {
               const text = result.text.trim();
               if (text && finalHandlerRef.current) {
@@ -227,6 +234,7 @@ export function useSpeechToText(): UseSpeechToTextReturn {
               setState('idle');
             })
             .catch((error: unknown) => {
+              if (error instanceof DOMException && error.name === 'AbortError') return;
               console.warn('Server transcription failed:', error);
               setState('error');
             });
@@ -277,6 +285,8 @@ export function useSpeechToText(): UseSpeechToTextReturn {
   // Cleanup on unmount
   useEffect(
     () => () => {
+      abortControllerRef.current?.abort();
+
       if (recognitionRef.current) {
         recognitionRef.current.abort();
         recognitionRef.current = null;

--- a/webui/src/hooks/useSpeechToText.ts
+++ b/webui/src/hooks/useSpeechToText.ts
@@ -1,6 +1,8 @@
 import { useState, useRef, useCallback, useEffect } from 'react';
+import { useApi } from '@/contexts/ApiContext';
+import { useUserSettings } from '@/hooks/useUserSettings';
 
-export type STTState = 'idle' | 'listening' | 'error';
+export type STTState = 'idle' | 'listening' | 'transcribing' | 'error';
 
 export interface UseSpeechToTextReturn {
   state: STTState;
@@ -14,6 +16,14 @@ export interface UseSpeechToTextReturn {
 // SpeechRecognition is not in TypeScript's standard DOM lib on all targets.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnyWindow = Window & { SpeechRecognition?: any; webkitSpeechRecognition?: any };
+
+interface RecordingSession {
+  chunks: Blob[];
+  mediaRecorder: MediaRecorder;
+  mimeType: string;
+  skipTranscription: boolean;
+  stream: MediaStream;
+}
 
 const getSpeechRecognitionClass = ():
   | (new () => {
@@ -37,74 +47,218 @@ const getSpeechRecognitionClass = ():
   return w.SpeechRecognition ?? w.webkitSpeechRecognition ?? null;
 };
 
+function canUseRecordedFallback(): boolean {
+  return (
+    typeof MediaRecorder !== 'undefined' &&
+    typeof navigator !== 'undefined' &&
+    typeof navigator.mediaDevices?.getUserMedia === 'function'
+  );
+}
+
+function getPreferredRecorderMimeType(): string {
+  const candidates = [
+    'audio/webm;codecs=opus',
+    'audio/webm',
+    'audio/ogg;codecs=opus',
+    'audio/ogg',
+    'audio/mp4',
+  ];
+  for (const candidate of candidates) {
+    if (
+      typeof MediaRecorder.isTypeSupported === 'function' &&
+      MediaRecorder.isTypeSupported(candidate)
+    ) {
+      return candidate;
+    }
+  }
+  return 'audio/webm';
+}
+
+function getLanguageCode(): string | undefined {
+  const locale = navigator.language?.trim();
+  if (!locale) return undefined;
+  return locale.split('-', 1)[0]?.toLowerCase() || undefined;
+}
+
 export function useSpeechToText(): UseSpeechToTextReturn {
+  const { api } = useApi();
+  const { settings } = useUserSettings();
   const [state, setState] = useState<STTState>('idle');
   const [interimTranscript, setInterimTranscript] = useState('');
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const recognitionRef = useRef<any>(null);
+  const recordingRef = useRef<RecordingSession | null>(null);
+  const fallbackSetupGenRef = useRef(0);
   const finalHandlerRef = useRef<((text: string) => void) | null>(null);
   const SpeechRecognitionClass = getSpeechRecognitionClass();
-  const isSupported = SpeechRecognitionClass !== null;
+  const browserSupported = SpeechRecognitionClass !== null;
+  const serverFallbackSupported =
+    !browserSupported &&
+    settings?.providers_configured.includes('openrouter') === true &&
+    canUseRecordedFallback();
+  const isSupported = browserSupported || serverFallbackSupported;
+
+  const releaseRecordingSession = useCallback((session: RecordingSession | null) => {
+    session?.stream.getTracks().forEach((track) => track.stop());
+  }, []);
 
   const startListening = useCallback(() => {
-    if (!SpeechRecognitionClass) return;
-    if (recognitionRef.current) return;
+    if (SpeechRecognitionClass) {
+      if (recognitionRef.current) return;
 
-    const recognition = new SpeechRecognitionClass();
-    recognition.continuous = true;
-    recognition.interimResults = true;
-    recognition.lang = navigator.language || 'en-US';
+      const recognition = new SpeechRecognitionClass();
+      recognition.continuous = true;
+      recognition.interimResults = true;
+      recognition.lang = navigator.language || 'en-US';
 
-    recognition.onstart = () => setState('listening');
+      recognition.onstart = () => setState('listening');
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    recognition.onresult = (event: any) => {
-      let interim = '';
-      let final = '';
-      for (let i = event.resultIndex; i < event.results.length; i++) {
-        const result = event.results[i];
-        if (result.isFinal) {
-          final += result[0].transcript;
-        } else {
-          interim += result[0].transcript;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      recognition.onresult = (event: any) => {
+        let interim = '';
+        let final = '';
+        for (let i = event.resultIndex; i < event.results.length; i++) {
+          const result = event.results[i];
+          if (result.isFinal) {
+            final += result[0].transcript;
+          } else {
+            interim += result[0].transcript;
+          }
+        }
+        setInterimTranscript(interim);
+        if (final && finalHandlerRef.current) {
+          finalHandlerRef.current(final);
+        }
+      };
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      recognition.onerror = (event: any) => {
+        console.warn('SpeechRecognition error:', event.error);
+        if (recognitionRef.current !== recognition) return;
+        setState('error');
+        recognitionRef.current = null;
+        setInterimTranscript('');
+      };
+
+      recognition.onend = () => {
+        if (recognitionRef.current !== recognition) return;
+        recognitionRef.current = null;
+        setState('idle');
+        setInterimTranscript('');
+      };
+
+      recognitionRef.current = recognition;
+      try {
+        recognition.start();
+      } catch {
+        recognitionRef.current = null;
+        setState('error');
+      }
+      return;
+    }
+
+    if (!serverFallbackSupported || recordingRef.current) return;
+
+    setInterimTranscript('');
+    setState('listening');
+    const gen = ++fallbackSetupGenRef.current;
+
+    void (async () => {
+      try {
+        const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+        if (fallbackSetupGenRef.current !== gen) {
+          stream.getTracks().forEach((track) => track.stop());
+          return;
+        }
+
+        const mimeType = getPreferredRecorderMimeType();
+        const mediaRecorder = new MediaRecorder(stream, { mimeType });
+        const session: RecordingSession = {
+          chunks: [],
+          mediaRecorder,
+          mimeType,
+          skipTranscription: false,
+          stream,
+        };
+        recordingRef.current = session;
+
+        mediaRecorder.ondataavailable = (event: BlobEvent) => {
+          if (event.data.size > 0) {
+            session.chunks.push(event.data);
+          }
+        };
+
+        mediaRecorder.onerror = () => {
+          if (recordingRef.current !== session) return;
+          recordingRef.current = null;
+          releaseRecordingSession(session);
+          setInterimTranscript('');
+          setState('error');
+        };
+
+        mediaRecorder.onstop = () => {
+          if (recordingRef.current !== session) return;
+
+          recordingRef.current = null;
+          releaseRecordingSession(session);
+          setInterimTranscript('');
+
+          if (session.skipTranscription) {
+            setState('idle');
+            return;
+          }
+
+          const audio = new Blob(session.chunks, {
+            type: mediaRecorder.mimeType || session.mimeType || 'audio/webm',
+          });
+          if (audio.size === 0) {
+            setState('error');
+            return;
+          }
+
+          setState('transcribing');
+          void api
+            .transcribeAudio(audio, { language: getLanguageCode() })
+            .then((result) => {
+              const text = result.text.trim();
+              if (text && finalHandlerRef.current) {
+                finalHandlerRef.current(text);
+              }
+              setState('idle');
+            })
+            .catch((error: unknown) => {
+              console.warn('Server transcription failed:', error);
+              setState('error');
+            });
+        };
+
+        mediaRecorder.start();
+      } catch (error) {
+        console.warn('Recorded speech-to-text setup failed:', error);
+        if (fallbackSetupGenRef.current === gen) {
+          recordingRef.current = null;
+          setInterimTranscript('');
+          setState('error');
         }
       }
-      setInterimTranscript(interim);
-      if (final && finalHandlerRef.current) {
-        finalHandlerRef.current(final);
-      }
-    };
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    recognition.onerror = (event: any) => {
-      console.warn('SpeechRecognition error:', event.error);
-      if (recognitionRef.current !== recognition) return; // stale closure guard
-      setState('error');
-      recognitionRef.current = null;
-      setInterimTranscript('');
-    };
-
-    recognition.onend = () => {
-      if (recognitionRef.current !== recognition) return; // stale closure guard
-      recognitionRef.current = null;
-      setState('idle');
-      setInterimTranscript('');
-    };
-
-    recognitionRef.current = recognition;
-    try {
-      recognition.start();
-    } catch {
-      recognitionRef.current = null;
-      setState('error');
-    }
-  }, [SpeechRecognitionClass]);
+    })();
+  }, [SpeechRecognitionClass, api, releaseRecordingSession, serverFallbackSupported]);
 
   const stopListening = useCallback(() => {
     if (recognitionRef.current) {
       recognitionRef.current.stop();
       recognitionRef.current = null;
+      setState('idle');
+      setInterimTranscript('');
+      return;
     }
+
+    if (recordingRef.current) {
+      recordingRef.current.mediaRecorder.stop();
+      return;
+    }
+
+    fallbackSetupGenRef.current++;
     setState('idle');
     setInterimTranscript('');
   }, []);
@@ -127,8 +281,18 @@ export function useSpeechToText(): UseSpeechToTextReturn {
         recognitionRef.current.abort();
         recognitionRef.current = null;
       }
+
+      fallbackSetupGenRef.current++;
+      if (recordingRef.current) {
+        recordingRef.current.skipTranscription = true;
+        if (recordingRef.current.mediaRecorder.state !== 'inactive') {
+          recordingRef.current.mediaRecorder.stop();
+        }
+        releaseRecordingSession(recordingRef.current);
+        recordingRef.current = null;
+      }
     },
-    []
+    [releaseRecordingSession]
   );
 
   return { state, isSupported, interimTranscript, startListening, stopListening, onFinalResult };

--- a/webui/src/utils/api.ts
+++ b/webui/src/utils/api.ts
@@ -1276,7 +1276,7 @@ export class ApiClient {
 
   async transcribeAudio(
     audio: Blob,
-    options?: { language?: string; model?: string }
+    options?: { language?: string; model?: string; signal?: AbortSignal }
   ): Promise<AudioTranscriptionResponse> {
     if (!this.isConnected) {
       throw new ApiClientError('Not connected to API');
@@ -1301,7 +1301,7 @@ export class ApiClient {
     const url = `${this.baseUrl}/api/v2/audio/transcriptions`;
     const response = await fetch(
       url,
-      withLocalAddressSpace(url, { method: 'POST', headers, body: formData })
+      withLocalAddressSpace(url, { method: 'POST', headers, body: formData, signal: options?.signal })
     );
     const data = await response.json();
     if (!response.ok) {

--- a/webui/src/utils/api.ts
+++ b/webui/src/utils/api.ts
@@ -24,6 +24,12 @@ type RequestInit = globalThis.RequestInit;
 type Response = globalThis.Response;
 type HeadersInit = globalThis.HeadersInit;
 
+export interface AudioTranscriptionResponse {
+  text: string;
+  model: string;
+  usage?: Record<string, number> | null;
+}
+
 // Error type for API client
 export class ApiClientError extends Error {
   status?: number;
@@ -164,6 +170,30 @@ export function isLikelyChromeCorsPna(targetUrl: string): boolean {
     return isLocalUrl(targetUrl) && isPublicOrigin;
   } catch {
     return false;
+  }
+}
+
+function inferTranscriptionFormat(blobType: string | undefined): string {
+  const mimeType = (blobType ?? '').split(';', 1)[0].trim().toLowerCase();
+  switch (mimeType) {
+    case 'audio/aac':
+      return 'aac';
+    case 'audio/flac':
+      return 'flac';
+    case 'audio/m4a':
+    case 'audio/mp4':
+      return 'm4a';
+    case 'audio/mp3':
+    case 'audio/mpeg':
+      return 'mp3';
+    case 'audio/ogg':
+      return 'ogg';
+    case 'audio/wav':
+    case 'audio/x-wav':
+      return 'wav';
+    case 'audio/webm':
+    default:
+      return 'webm';
   }
 }
 
@@ -1242,6 +1272,47 @@ export class ApiClient {
       throw new ApiClientError(`Upload failed: ${response.status}`, response.status);
     }
     return data;
+  }
+
+  async transcribeAudio(
+    audio: Blob,
+    options?: { language?: string; model?: string }
+  ): Promise<AudioTranscriptionResponse> {
+    if (!this.isConnected) {
+      throw new ApiClientError('Not connected to API');
+    }
+
+    const format = inferTranscriptionFormat(audio.type);
+    const formData = new FormData();
+    formData.append('file', audio, `speech.${format}`);
+    formData.append('format', format);
+    if (options?.language) {
+      formData.append('language', options.language);
+    }
+    if (options?.model) {
+      formData.append('model', options.model);
+    }
+
+    const headers: Record<string, string> = {};
+    if (this.authHeader) {
+      headers.Authorization = this.authHeader;
+    }
+
+    const url = `${this.baseUrl}/api/v2/audio/transcriptions`;
+    const response = await fetch(
+      url,
+      withLocalAddressSpace(url, { method: 'POST', headers, body: formData })
+    );
+    const data = await response.json();
+    if (!response.ok) {
+      if (isApiErrorResponse(data)) {
+        const apiError = normalizeApiError(data, response.status);
+        throw new ApiClientError(apiError.message, apiError.status, apiError);
+      }
+      throw new ApiClientError(`Transcription failed: ${response.status}`, response.status);
+    }
+
+    return data as AudioTranscriptionResponse;
   }
 
   async step(

--- a/webui/src/utils/demoApiClient.ts
+++ b/webui/src/utils/demoApiClient.ts
@@ -344,6 +344,7 @@ export function createDemoApiClient(baseUrl: string = DEMO_BASE_URL): IApiClient
     deleteMessage: async () => notImpl('deleteMessage'),
     rerunTools: async () => notImpl('rerunTools'),
     uploadFiles: async () => notImpl('uploadFiles'),
+    transcribeAudio: async () => notImpl('transcribeAudio'),
     step: async (logfile) => {
       const callbacks = eventCallbacks.get(logfile);
       const intro = makeDemoAssistantMessage(


### PR DESCRIPTION
## Summary
- add an authenticated `/api/v2/audio/transcriptions` endpoint that proxies short recordings to OpenRouter STT
- extend the webui speech input hook to fall back to `MediaRecorder` + server transcription when browser `SpeechRecognition` is unavailable
- keep the speech button responsive with a transcribing state and cover the new path with API + hook tests

## Verification
- `/home/bob/gptme/.venv/bin/python -m pytest tests/test_server_v2.py -k audio_transcriptions -q`
- `./node_modules/.bin/jest --runTestsByPath src/hooks/__tests__/useSpeechToText.test.tsx`
- `./node_modules/.bin/eslint src/components/SpeechInputButton.tsx src/hooks/useSpeechToText.ts src/hooks/__tests__/useSpeechToText.test.tsx src/utils/api.ts src/utils/demoApiClient.ts`
- `./node_modules/.bin/tsc -p tsconfig.app.json --noEmit`