### PR TITLE
feat(webui): add server-side TTS endpoint via OpenRouter

### DIFF
--- a/gptme/server/app.py
+++ b/gptme/server/app.py
@@ -85,6 +85,7 @@ def create_app(
     # noreorder
     from .api_v2 import v2_api  # fmt: skip
     from .artifacts_api import artifacts_api  # fmt: skip
+    from .tts_api import tts_api  # fmt: skip
     from .auth import auth_api  # fmt: skip
     from .panels_api import panels_api  # fmt: skip
     from .tasks_api import tasks_api  # fmt: skip
@@ -98,6 +99,7 @@ def create_app(
     app.register_blueprint(artifacts_api)
     app.register_blueprint(panels_api)
     app.register_blueprint(tools_api)
+    app.register_blueprint(tts_api)
 
     # Register OpenAPI documentation
     from .openapi_docs import docs_api  # fmt: skip

--- a/gptme/server/app.py
+++ b/gptme/server/app.py
@@ -85,11 +85,11 @@ def create_app(
     # noreorder
     from .api_v2 import v2_api  # fmt: skip
     from .artifacts_api import artifacts_api  # fmt: skip
-    from .tts_api import tts_api  # fmt: skip
     from .auth import auth_api  # fmt: skip
     from .panels_api import panels_api  # fmt: skip
     from .tasks_api import tasks_api  # fmt: skip
     from .tools_api import tools_api  # fmt: skip
+    from .tts_api import tts_api  # fmt: skip
     from .workspace_api import workspace_api  # fmt: skip
 
     app.register_blueprint(v2_api)

--- a/gptme/server/tts_api.py
+++ b/gptme/server/tts_api.py
@@ -42,7 +42,7 @@ def _optional_string(
     return value, None
 
 
-@tts_api.route("/api/v2/tts", methods=["POST"])
+@tts_api.route("/api/v2/audio/speech", methods=["POST"])
 @require_auth
 def synthesize_speech():
     """Synthesize speech from text via OpenRouter's speech API.

--- a/gptme/server/tts_api.py
+++ b/gptme/server/tts_api.py
@@ -8,7 +8,7 @@ that the browser can play natively.
 """
 
 import logging
-from typing import Any, TypedDict, cast
+from typing import Any, TypedDict
 
 import flask
 import requests
@@ -31,6 +31,17 @@ class TTSRequest(TypedDict, total=False):
     voice: str
 
 
+def _optional_string(
+    data: dict[str, Any], field: str, default: str
+) -> tuple[str | None, tuple[dict[str, str], int] | None]:
+    value = data.get(field)
+    if value is None or value == "":
+        return default, None
+    if not isinstance(value, str):
+        return None, ({"error": f"{field} must be a string"}, 400)
+    return value, None
+
+
 @tts_api.route("/api/v2/tts", methods=["POST"])
 @require_auth
 def synthesize_speech():
@@ -49,8 +60,12 @@ def synthesize_speech():
     Requires ``OPENROUTER_API_KEY`` to be configured (env or config file).
     """
     raw_data = flask.request.get_json(silent=True)
-    data = cast(TTSRequest, raw_data if isinstance(raw_data, dict) else {})
-    text = (data.get("text") or "").strip()
+    data: dict[str, Any] = raw_data if isinstance(raw_data, dict) else {}
+    raw_text = data.get("text")
+    if raw_text is not None and not isinstance(raw_text, str):
+        return {"error": "text must be a string"}, 400
+
+    text = (raw_text or "").strip()
     if not text:
         return {"error": "text is required"}, 400
     if len(text) > 1000:
@@ -65,8 +80,12 @@ def synthesize_speech():
             "error": "OPENROUTER_API_KEY not configured. Set the environment variable or add it to config."
         }, 400
 
-    model = data.get("model") or DEFAULT_MODEL
-    voice = data.get("voice") or DEFAULT_VOICE
+    model, error = _optional_string(data, "model", DEFAULT_MODEL)
+    if error is not None:
+        return error
+    voice, error = _optional_string(data, "voice", DEFAULT_VOICE)
+    if error is not None:
+        return error
 
     payload: dict[str, Any] = {
         "model": model,
@@ -99,7 +118,7 @@ def synthesize_speech():
             resp.status_code,
             resp.text[:500],
         )
-        return {"error": f"TTS provider error: {resp.status_code}"}, resp.status_code
+        return {"error": f"TTS provider error: {resp.status_code}"}, 502
 
     return flask.Response(
         resp.content,

--- a/gptme/server/tts_api.py
+++ b/gptme/server/tts_api.py
@@ -83,9 +83,11 @@ def synthesize_speech():
     model, error = _optional_string(data, "model", DEFAULT_MODEL)
     if error is not None:
         return error
+    assert model is not None
     voice, error = _optional_string(data, "voice", DEFAULT_VOICE)
     if error is not None:
         return error
+    assert voice is not None
 
     payload: dict[str, Any] = {
         "model": model,

--- a/gptme/server/tts_api.py
+++ b/gptme/server/tts_api.py
@@ -1,0 +1,107 @@
+"""
+TTS API endpoints for server-side text-to-speech via OpenRouter.
+
+Provides a server-native TTS endpoint so the webui can speak assistant
+messages without requiring a separate gptme-tts server. The endpoint
+proxies to OpenRouter's ``/api/v1/audio/speech`` and returns WAV audio
+that the browser can play natively.
+"""
+
+import logging
+from typing import TypedDict
+
+import flask
+import requests
+
+from .auth import require_auth
+
+logger = logging.getLogger(__name__)
+
+tts_api = flask.Blueprint("tts_api", __name__)
+
+OPENROUTER_SPEECH_URL = "https://openrouter.ai/api/v1/audio/speech"
+DEFAULT_MODEL = "x-ai/grok-voice-tts-1.0"
+DEFAULT_VOICE = "ara"
+REQUEST_TIMEOUT = 30
+
+
+class TTSRequest(TypedDict, total=False):
+    text: str
+    model: str
+    voice: str
+
+
+@tts_api.route("/api/v2/tts", methods=["POST"])
+@require_auth
+def synthesize_speech():
+    """Synthesize speech from text via OpenRouter's speech API.
+
+    Request body (JSON):
+        - ``text`` (required): Text to speak.
+        - ``model`` (optional): OpenRouter speech model ID.
+          Default: ``x-ai/grok-voice-tts-1.0``.
+        - ``voice`` (optional): Voice name for the model.
+          Default: ``ara``.
+
+    Returns:
+        WAV audio binary with ``Content-Type: audio/wav``.
+
+    Requires ``OPENROUTER_API_KEY`` to be configured (env or config file).
+    """
+    data: TTSRequest = flask.request.get_json(silent=True) or {}
+    text = (data.get("text") or "").strip()
+    if not text:
+        return {"error": "text is required"}, 400
+    if len(text) > 1000:
+        return {"error": "text too long (max 1000 characters)"}, 400
+
+    from ..config import get_config
+
+    config = get_config()
+    api_key = config.get_env("OPENROUTER_API_KEY")
+    if not api_key:
+        return {
+            "error": "OPENROUTER_API_KEY not configured. Set the environment variable or add it to config."
+        }, 400
+
+    model = data.get("model") or DEFAULT_MODEL
+    voice = data.get("voice") or DEFAULT_VOICE
+
+    payload = {
+        "model": model,
+        "input": text,
+        "voice": voice,
+        "response_format": "wav",
+        "speed": 1.0,
+    }
+
+    try:
+        resp = requests.post(
+            OPENROUTER_SPEECH_URL,
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+            },
+            json=payload,
+            timeout=REQUEST_TIMEOUT,
+        )
+    except requests.exceptions.Timeout:
+        logger.error("OpenRouter TTS request timed out after %ss", REQUEST_TIMEOUT)
+        return {"error": "TTS request timed out"}, 504
+    except requests.exceptions.ConnectionError as e:
+        logger.error("OpenRouter TTS connection error: %s", e)
+        return {"error": "TTS service unavailable"}, 502
+
+    if not resp.ok:
+        logger.error(
+            "OpenRouter TTS returned %s: %s",
+            resp.status_code,
+            resp.text[:500],
+        )
+        return {"error": f"TTS provider error: {resp.status_code}"}, resp.status_code
+
+    return flask.Response(
+        resp.content,
+        content_type="audio/wav",
+        headers={"X-OpenRouter-Model": model},
+    )

--- a/gptme/server/tts_api.py
+++ b/gptme/server/tts_api.py
@@ -8,7 +8,7 @@ that the browser can play natively.
 """
 
 import logging
-from typing import TypedDict
+from typing import Any, TypedDict, cast
 
 import flask
 import requests
@@ -48,7 +48,8 @@ def synthesize_speech():
 
     Requires ``OPENROUTER_API_KEY`` to be configured (env or config file).
     """
-    data: TTSRequest = flask.request.get_json(silent=True) or {}
+    raw_data = flask.request.get_json(silent=True)
+    data = cast(TTSRequest, raw_data if isinstance(raw_data, dict) else {})
     text = (data.get("text") or "").strip()
     if not text:
         return {"error": "text is required"}, 400
@@ -67,7 +68,7 @@ def synthesize_speech():
     model = data.get("model") or DEFAULT_MODEL
     voice = data.get("voice") or DEFAULT_VOICE
 
-    payload = {
+    payload: dict[str, Any] = {
         "model": model,
         "input": text,
         "voice": voice,

--- a/tests/test_server_tts_api.py
+++ b/tests/test_server_tts_api.py
@@ -21,7 +21,7 @@ def test_tts_endpoint_rejects_non_string_text(
 ):
     _set_openrouter_key(monkeypatch, "test-key")
 
-    response = client.post("/api/v2/tts", json={"text": 1})
+    response = client.post("/api/v2/audio/speech", json={"text": 1})
 
     assert response.status_code == 400
     assert response.get_json() == {"error": "text must be a string"}
@@ -33,7 +33,9 @@ def test_tts_endpoint_rejects_non_string_optional_fields(
 ):
     _set_openrouter_key(monkeypatch, "test-key")
 
-    response = client.post("/api/v2/tts", json={"text": "Hello", field: ["bad"]})
+    response = client.post(
+        "/api/v2/audio/speech", json={"text": "Hello", field: ["bad"]}
+    )
 
     assert response.status_code == 400
     assert response.get_json() == {"error": f"{field} must be a string"}
@@ -52,7 +54,7 @@ def test_tts_endpoint_maps_provider_errors_to_bad_gateway(
         ),
     )
 
-    response = client.post("/api/v2/tts", json={"text": "Hello"})
+    response = client.post("/api/v2/audio/speech", json={"text": "Hello"})
 
     assert response.status_code == 502
     assert response.get_json() == {"error": "TTS provider error: 400"}

--- a/tests/test_server_tts_api.py
+++ b/tests/test_server_tts_api.py
@@ -1,0 +1,58 @@
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip(
+    "flask", reason="flask not installed, install server extras (-E server)"
+)
+
+from flask.testing import FlaskClient  # fmt: skip
+
+
+def _set_openrouter_key(monkeypatch: pytest.MonkeyPatch, value: str | None) -> None:
+    monkeypatch.setattr(
+        "gptme.config.get_config",
+        lambda: SimpleNamespace(get_env=lambda key, default=None: value),
+    )
+
+
+def test_tts_endpoint_rejects_non_string_text(
+    client: FlaskClient, monkeypatch: pytest.MonkeyPatch
+):
+    _set_openrouter_key(monkeypatch, "test-key")
+
+    response = client.post("/api/v2/tts", json={"text": 1})
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "text must be a string"}
+
+
+@pytest.mark.parametrize("field", ["model", "voice"])
+def test_tts_endpoint_rejects_non_string_optional_fields(
+    field: str, client: FlaskClient, monkeypatch: pytest.MonkeyPatch
+):
+    _set_openrouter_key(monkeypatch, "test-key")
+
+    response = client.post("/api/v2/tts", json={"text": "Hello", field: ["bad"]})
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": f"{field} must be a string"}
+
+
+def test_tts_endpoint_maps_provider_errors_to_bad_gateway(
+    client: FlaskClient, monkeypatch: pytest.MonkeyPatch
+):
+    _set_openrouter_key(monkeypatch, "test-key")
+    monkeypatch.setattr(
+        "gptme.server.tts_api.requests.post",
+        lambda *args, **kwargs: SimpleNamespace(
+            ok=False,
+            status_code=400,
+            text="invalid voice",
+        ),
+    )
+
+    response = client.post("/api/v2/tts", json={"text": "Hello"})
+
+    assert response.status_code == 502
+    assert response.get_json() == {"error": "TTS provider error: 400"}

--- a/webui/src/utils/__tests__/tts.test.ts
+++ b/webui/src/utils/__tests__/tts.test.ts
@@ -1,0 +1,99 @@
+import { speakTextNow, stopSpeaking } from '../tts';
+
+describe('tts fallback chain', () => {
+  const originalFetch = global.fetch;
+  const originalAudio = global.Audio;
+  const originalCreateObjectURL = URL.createObjectURL;
+  const originalRevokeObjectURL = URL.revokeObjectURL;
+  const originalSpeechSynthesis = window.speechSynthesis;
+  const originalSpeechSynthesisUtterance = global.SpeechSynthesisUtterance;
+
+  const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+  beforeEach(() => {
+    localStorage.clear();
+    jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    URL.createObjectURL = jest.fn(() => 'blob:tts-audio');
+    URL.revokeObjectURL = jest.fn();
+    global.SpeechSynthesisUtterance = jest.fn().mockImplementation((text: string) => ({
+      text,
+      rate: 1,
+    })) as unknown as typeof SpeechSynthesisUtterance;
+  });
+
+  afterEach(() => {
+    stopSpeaking();
+    global.fetch = originalFetch;
+    global.Audio = originalAudio;
+    URL.createObjectURL = originalCreateObjectURL;
+    URL.revokeObjectURL = originalRevokeObjectURL;
+    Object.defineProperty(window, 'speechSynthesis', {
+      value: originalSpeechSynthesis,
+      configurable: true,
+    });
+    global.SpeechSynthesisUtterance = originalSpeechSynthesisUtterance;
+    jest.restoreAllMocks();
+  });
+
+  it('falls back to Web Speech silently when the local endpoint is not configured', async () => {
+    const speak = jest.fn();
+    const cancel = jest.fn();
+    Object.defineProperty(window, 'speechSynthesis', {
+      value: { speak, cancel },
+      configurable: true,
+    });
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+    } as Response);
+
+    speakTextNow('hello');
+    await flushPromises();
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      '/api/v2/tts',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ text: 'hello' }),
+      })
+    );
+    expect(console.warn).not.toHaveBeenCalled();
+    expect(speak).toHaveBeenCalledWith(expect.objectContaining({ text: 'hello' }));
+  });
+
+  it('falls back to the configured external TTS server after local endpoint errors', async () => {
+    localStorage.setItem(
+      'gptme-settings',
+      JSON.stringify({ ttsServerUrl: 'http://127.0.0.1:5000/' })
+    );
+    const play = jest.fn().mockResolvedValue(undefined);
+    global.Audio = jest.fn().mockImplementation((src: string) => ({
+      src,
+      play,
+      pause: jest.fn(),
+      onended: null,
+    })) as unknown as typeof Audio;
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 502,
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        blob: async () => new Blob(['audio'], { type: 'audio/wav' }),
+      } as Response);
+
+    speakTextNow('hello');
+    await flushPromises();
+    await flushPromises();
+
+    expect(global.fetch).toHaveBeenNthCalledWith(1, '/api/v2/tts', expect.any(Object));
+    expect(global.fetch).toHaveBeenNthCalledWith(
+      2,
+      'http://127.0.0.1:5000/tts?text=hello',
+      expect.any(Object)
+    );
+    expect(play).toHaveBeenCalled();
+  });
+});

--- a/webui/src/utils/__tests__/tts.test.ts
+++ b/webui/src/utils/__tests__/tts.test.ts
@@ -45,13 +45,19 @@ describe('tts fallback chain', () => {
     global.fetch = jest.fn().mockResolvedValue({
       ok: false,
       status: 400,
+      clone: () => ({
+        json: async () => ({
+          error:
+            'OPENROUTER_API_KEY not configured. Set the environment variable or add it to config.',
+        }),
+      }),
     } as Response);
 
     speakTextNow('hello');
     await flushPromises();
 
     expect(global.fetch).toHaveBeenCalledWith(
-      '/api/v2/tts',
+      '/api/v2/audio/speech',
       expect.objectContaining({
         method: 'POST',
         body: JSON.stringify({ text: 'hello' }),
@@ -88,7 +94,7 @@ describe('tts fallback chain', () => {
     await flushPromises();
     await flushPromises();
 
-    expect(global.fetch).toHaveBeenNthCalledWith(1, '/api/v2/tts', expect.any(Object));
+    expect(global.fetch).toHaveBeenNthCalledWith(1, '/api/v2/audio/speech', expect.any(Object));
     expect(global.fetch).toHaveBeenNthCalledWith(
       2,
       'http://127.0.0.1:5000/tts?text=hello',

--- a/webui/src/utils/tts.ts
+++ b/webui/src/utils/tts.ts
@@ -1,11 +1,13 @@
 /**
- * Text-to-speech via the browser's Web Speech API or a gptme-tts server.
+ * Text-to-speech via the browser's Web Speech API, the gptme server's
+ * built-in /api/v2/tts endpoint, or an external gptme-tts server.
  *
  * Priority:
- *   1. If `ttsServerUrl` is configured, GET {url}/tts?text=... and play the WAV.
- *   2. Otherwise fall back to the browser's built-in speechSynthesis API.
+ *   1. POST /api/v2/tts (same-origin, uses OpenRouter via gptme server config).
+ *   2. If `ttsServerUrl` is configured, GET {url}/tts?text=... and play the WAV.
+ *   3. Fall back to the browser's built-in speechSynthesis API.
  *
- * Both paths strip markdown before speaking so output sounds natural.
+ * All paths strip markdown before speaking so output sounds natural.
  */
 
 let currentAudio: HTMLAudioElement | null = null;
@@ -54,7 +56,49 @@ function isAbortError(error: unknown): boolean {
   return error instanceof DOMException && error.name === 'AbortError';
 }
 
-async function speakViaServer(text: string, serverUrl: string): Promise<void> {
+/** POST text to the gptme server's built-in /api/v2/tts endpoint. */
+async function speakViaLocalEndpoint(text: string): Promise<void> {
+  const controller = new AbortController();
+  currentFetchController = controller;
+  try {
+    const response = await fetch('/api/v2/tts', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text }),
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      // 400 = no API key configured locally; skip without warning
+      if (response.status === 400) return;
+      throw new Error(`TTS endpoint error: ${response.status}`);
+    }
+    const blob = await response.blob();
+    const objectUrl = URL.createObjectURL(blob);
+
+    if (controller.signal.aborted) {
+      URL.revokeObjectURL(objectUrl);
+      return;
+    }
+
+    if (currentAudio) {
+      currentAudio.pause();
+      URL.revokeObjectURL(currentAudio.src);
+    }
+    const audio = new Audio(objectUrl);
+    currentAudio = audio;
+    audio.onended = () => {
+      URL.revokeObjectURL(objectUrl);
+      if (currentAudio === audio) currentAudio = null;
+    };
+    await audio.play();
+  } finally {
+    if (currentFetchController === controller) {
+      currentFetchController = null;
+    }
+  }
+}
+
+async function speakViaExternalServer(text: string, serverUrl: string): Promise<void> {
   const url = `${serverUrl.replace(/\/$/, '')}/tts?${new URLSearchParams({ text })}`;
   const controller = new AbortController();
   currentFetchController = controller;
@@ -93,17 +137,28 @@ async function speak(rawText: string): Promise<void> {
 
   stopSpeaking();
 
+  // 1. Try the same-origin /api/v2/tts endpoint first.
+  try {
+    await speakViaLocalEndpoint(spoken);
+    return;
+  } catch (err) {
+    if (isAbortError(err)) return;
+    console.warn('Local /api/v2/tts unavailable, trying alternatives:', err);
+  }
+
+  // 2. Try an external gptme-tts server if configured.
   const { ttsServerUrl } = getSettings();
   if (ttsServerUrl) {
     try {
-      await speakViaServer(spoken, ttsServerUrl);
+      await speakViaExternalServer(spoken, ttsServerUrl);
       return;
     } catch (err) {
       if (isAbortError(err)) return;
-      console.warn('gptme-tts server unavailable, falling back to Web Speech API:', err);
+      console.warn('External TTS server unavailable, falling back to Web Speech API:', err);
     }
   }
 
+  // 3. Fall back to the browser's built-in speechSynthesis.
   if (!window.speechSynthesis) return;
   const utterance = new SpeechSynthesisUtterance(spoken);
   utterance.rate = 1.1;

--- a/webui/src/utils/tts.ts
+++ b/webui/src/utils/tts.ts
@@ -1,9 +1,9 @@
 /**
  * Text-to-speech via the browser's Web Speech API, the gptme server's
- * built-in /api/v2/tts endpoint, or an external gptme-tts server.
+ * built-in /api/v2/audio/speech endpoint, or an external gptme-tts server.
  *
  * Priority:
- *   1. POST /api/v2/tts (same-origin, uses OpenRouter via gptme server config).
+ *   1. POST /api/v2/audio/speech (same-origin, uses OpenRouter via gptme server config).
  *   2. If `ttsServerUrl` is configured, GET {url}/tts?text=... and play the WAV.
  *   3. Fall back to the browser's built-in speechSynthesis API.
  *
@@ -57,20 +57,33 @@ function isAbortError(error: unknown): boolean {
   return error instanceof DOMException && error.name === 'AbortError';
 }
 
-/** POST text to the gptme server's built-in /api/v2/tts endpoint. */
+async function isLocalTtsNotConfigured(response: Response): Promise<boolean> {
+  if (response.status !== 400) return false;
+  try {
+    const data = await response.clone().json();
+    return (
+      typeof data?.error === 'string' && data.error.includes('OPENROUTER_API_KEY not configured')
+    );
+  } catch {
+    return false;
+  }
+}
+
+/** POST text to the gptme server's built-in /api/v2/audio/speech endpoint. */
 async function speakViaLocalEndpoint(text: string): Promise<void> {
   const controller = new AbortController();
   currentFetchController = controller;
   try {
-    const response = await fetch('/api/v2/tts', {
+    const response = await fetch('/api/v2/audio/speech', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ text }),
       signal: controller.signal,
     });
     if (!response.ok) {
-      // 400 = no API key configured locally; signal speak() to fall through silently
-      if (response.status === 400) throw new Error(LOCAL_TTS_NOT_CONFIGURED);
+      if (await isLocalTtsNotConfigured(response)) {
+        throw new Error(LOCAL_TTS_NOT_CONFIGURED);
+      }
       throw new Error(`TTS endpoint error: ${response.status}`);
     }
     const blob = await response.blob();
@@ -138,14 +151,14 @@ async function speak(rawText: string): Promise<void> {
 
   stopSpeaking();
 
-  // 1. Try the same-origin /api/v2/tts endpoint first.
+  // 1. Try the same-origin /api/v2/audio/speech endpoint first.
   try {
     await speakViaLocalEndpoint(spoken);
     return;
   } catch (err) {
     if (isAbortError(err)) return;
     if ((err as Error)?.message !== LOCAL_TTS_NOT_CONFIGURED) {
-      console.warn('Local /api/v2/tts unavailable, trying alternatives:', err);
+      console.warn('Local /api/v2/audio/speech unavailable, trying alternatives:', err);
     }
   }
 

--- a/webui/src/utils/tts.ts
+++ b/webui/src/utils/tts.ts
@@ -12,6 +12,7 @@
 
 let currentAudio: HTMLAudioElement | null = null;
 let currentFetchController: AbortController | null = null;
+const LOCAL_TTS_NOT_CONFIGURED = 'tts-local-not-configured';
 
 function getSettings(): { ttsEnabled: boolean; ttsServerUrl: string } {
   try {
@@ -68,8 +69,8 @@ async function speakViaLocalEndpoint(text: string): Promise<void> {
       signal: controller.signal,
     });
     if (!response.ok) {
-      // 400 = no API key configured locally; skip without warning
-      if (response.status === 400) return;
+      // 400 = no API key configured locally; signal speak() to fall through silently
+      if (response.status === 400) throw new Error(LOCAL_TTS_NOT_CONFIGURED);
       throw new Error(`TTS endpoint error: ${response.status}`);
     }
     const blob = await response.blob();
@@ -143,7 +144,9 @@ async function speak(rawText: string): Promise<void> {
     return;
   } catch (err) {
     if (isAbortError(err)) return;
-    console.warn('Local /api/v2/tts unavailable, trying alternatives:', err);
+    if ((err as Error)?.message !== LOCAL_TTS_NOT_CONFIGURED) {
+      console.warn('Local /api/v2/tts unavailable, trying alternatives:', err);
+    }
   }
 
   // 2. Try an external gptme-tts server if configured.


### PR DESCRIPTION
## Summary

Adds a built-in `POST /api/v2/audio/speech` endpoint so the webui can speak assistant messages without requiring a separate gptme-tts server. The endpoint proxies to OpenRouter's `/api/v1/audio/speech` and returns WAV audio.

The webui's `tts.ts` now tries this same-origin endpoint first, then falls back to an external gptme-tts server (if configured), then browser `speechSynthesis`.

## New file

- `gptme/server/tts_api.py` — Flask blueprint with:
  - `POST /api/v2/audio/speech`: accepts `{text, model?, voice?}`, proxies to OpenRouter, returns `audio/wav`
  - Requires `OPENROUTER_API_KEY` to be configured
  - Length limit (1000 chars), timeout (30s), string-field validation, meaningful error responses

## Modified

- `gptme/server/app.py` — registers the `tts_api` blueprint
- `webui/src/utils/tts.ts` — prioritizes local `/api/v2/audio/speech` over external server and browser speechSynthesis; refactored `speakViaServer` -> `speakViaExternalServer`

## Verification

- `/home/bob/gptme/.venv/bin/python -m pytest tests/test_server_tts_api.py -q` — 4 passed
- `./node_modules/.bin/jest --runTestsByPath src/utils/__tests__/tts.test.ts` — 2 passed
- `/home/bob/gptme/.venv/bin/ruff check gptme/server/tts_api.py tests/test_server_tts_api.py` — clean
- `./node_modules/.bin/eslint src/utils/tts.ts src/utils/__tests__/tts.test.ts` — clean
- `./node_modules/.bin/tsc -p tsconfig.app.json --noEmit` — clean

Part of gptme-webui TTS surface (ErikBjare/bob#841).
