### PR TITLE
fix(webui): request fast conversation list detail

### DIFF
--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -13,7 +13,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from base64 import b64encode
-from dataclasses import replace
+from dataclasses import asdict, replace
 from datetime import datetime, timezone
 from itertools import islice
 from pathlib import Path
@@ -844,7 +844,13 @@ def api_conversations():
                     break
     else:
         conversations = list(islice(get_user_conversations(detail=detail), limit))
-    return flask.jsonify(conversations)
+    response_items = []
+    for conv in conversations:
+        item = asdict(conv)
+        if not detail:
+            item.pop("messages", None)
+        response_items.append(item)
+    return flask.jsonify(response_items)
 
 
 @v2_api.route("/api/v2/conversations/<string:conversation_id>")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -206,21 +206,23 @@ def test_api_conversation_list_detail_flag(client: FlaskClient, tmp_path, monkey
         "fixture must be > _TAIL_BYTES to trigger fast path"
     )
 
-    # Default (detail=false) should return zeroed stats
+    # Default (detail=false) should return zeroed stats and omit the message count
     response = client.get("/api/v2/conversations")
     assert response.status_code == 200
     data = response.get_json()
     assert isinstance(data, list)
     assert len(data) == 1
+    assert "messages" not in data[0]
     assert data[0]["total_cost"] == 0.0
     assert data[0]["total_input_tokens"] == 0
 
-    # detail=true should return actual stats
+    # detail=true should return actual stats and include the message count
     response = client.get("/api/v2/conversations?detail=true")
     assert response.status_code == 200
     data = response.get_json()
     assert isinstance(data, list)
     assert len(data) == 1
+    assert data[0]["messages"] == len(messages)
     assert data[0]["total_cost"] > 0
     assert data[0]["total_input_tokens"] > 0
     assert data[0]["total_output_tokens"] > 0

--- a/webui/src/components/CommandPalette.tsx
+++ b/webui/src/components/CommandPalette.tsx
@@ -106,7 +106,7 @@ export function CommandPalette() {
     const currentSearch = search;
     searchTimerRef.current = setTimeout(async () => {
       try {
-        const results = await api.searchConversations(currentSearch, 10);
+        const results = await api.searchConversations(currentSearch, 10, true);
         if (!cancelled) {
           setConversationResults(results);
         }
@@ -331,7 +331,7 @@ export function CommandPalette() {
                   <div className="flex flex-1 flex-col overflow-hidden">
                     <span className="truncate">{stripDatePrefix(conv.name)}</span>
                     <span className="text-xs text-muted-foreground">
-                      {conv.messages} messages · {formatRelativeTime(conv.modified)}
+                      {conv.messages ?? 0} messages · {formatRelativeTime(conv.modified)}
                     </span>
                   </div>
                 </CommandItem>

--- a/webui/src/components/ConversationList.tsx
+++ b/webui/src/components/ConversationList.tsx
@@ -342,6 +342,10 @@ export const ConversationList: FC<Props> = ({
                         ? Object.values(breakdown).reduce((a, b) => a + b, 0)
                         : conv.messages;
 
+                      if (count === undefined) {
+                        return null;
+                      }
+
                       const messageCountElement = (
                         <span className="flex items-center">
                           <MessageSquare className="mr-1 h-3 w-3" />

--- a/webui/src/components/HistoryView.tsx
+++ b/webui/src/components/HistoryView.tsx
@@ -34,7 +34,7 @@ function useAllConversations() {
   return useQuery({
     queryKey: ['conversations-all', connectionConfig.baseUrl, isConnected],
     queryFn: async () => {
-      const result = await api.getConversationsPaginated(0, 100000);
+      const result = await api.getConversationsPaginated(0, 100000, true);
       return result.conversations;
     },
     enabled: isConnected,
@@ -95,7 +95,7 @@ const ConversationRow: FC<{
       <div className="mt-1 flex items-center gap-3 text-xs text-muted-foreground">
         <span className="flex items-center gap-1">
           <MessageSquare className="h-3 w-3" />
-          {conv.messages} messages
+          {conv.messages ?? 0} messages
         </span>
         {conv.workspace && conv.workspace !== '.' && (
           <span className="truncate">{conv.workspace}</span>
@@ -157,7 +157,7 @@ export const HistoryView: FC = () => {
   // Compute stats (scoped to selected year if not current)
   const stats = useMemo(() => {
     const totalConversations = conversations.length;
-    const totalMessages = conversations.reduce((sum, c) => sum + c.messages, 0);
+    const totalMessages = conversations.reduce((sum, c) => sum + (c.messages ?? 0), 0);
     const activeDays = activityData.size;
 
     // Current streak

--- a/webui/src/types/conversation.ts
+++ b/webui/src/types/conversation.ts
@@ -41,7 +41,7 @@ export interface ConversationSummary {
   name: string;
   created?: number; // Unix timestamp of first message
   modified: number; // Unix timestamp of last file modification
-  messages: number; // Message count
+  messages?: number; // Message count, present only when list requests opt into detail=true
   branch?: string;
   workspace?: string;
   readonly?: boolean; // For demo conversations

--- a/webui/src/utils/__tests__/api.test.ts
+++ b/webui/src/utils/__tests__/api.test.ts
@@ -207,6 +207,55 @@ describe('ApiClient error parsing', () => {
   });
 });
 
+describe('ApiClient conversation list detail flag', () => {
+  const originalFetch = global.fetch;
+  const originalCrypto = global.crypto;
+
+  beforeEach(() => {
+    Object.defineProperty(global, 'crypto', {
+      value: {
+        ...originalCrypto,
+        randomUUID: jest.fn(() => 'test-client-id'),
+      },
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    Object.defineProperty(global, 'crypto', {
+      value: originalCrypto,
+      configurable: true,
+    });
+    jest.restoreAllMocks();
+  });
+
+  it('requests paginated conversation lists with detail=false by default', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => [],
+    } as Response);
+
+    const client = new ApiClient('http://127.0.0.1:5700');
+    client.setConnected(true);
+
+    await client.getConversationsPaginated(0, 50);
+    await client.getConversationsPaginated(0, 50, true);
+
+    expect(global.fetch).toHaveBeenNthCalledWith(
+      1,
+      'http://127.0.0.1:5700/api/v2/conversations?limit=51&detail=false',
+      expect.any(Object)
+    );
+    expect(global.fetch).toHaveBeenNthCalledWith(
+      2,
+      'http://127.0.0.1:5700/api/v2/conversations?limit=51&detail=true',
+      expect.any(Object)
+    );
+  });
+});
+
 describe('ApiClient event stream reconnection', () => {
   const originalEventSource = global.EventSource;
   const originalCrypto = global.crypto;

--- a/webui/src/utils/api.ts
+++ b/webui/src/utils/api.ts
@@ -939,13 +939,16 @@ export class ApiClient {
     return data;
   }
 
-  async getConversations(limit: number = 100): Promise<ConversationSummary[]> {
+  async getConversations(
+    limit: number = 100,
+    detail: boolean = false
+  ): Promise<ConversationSummary[]> {
     if (!this.isConnected) {
       throw new ApiClientError('Not connected to API');
     }
     try {
       return await this.fetchJson<ConversationSummary[]>(
-        `${this.baseUrl}/api/v2/conversations?limit=${limit}`
+        `${this.baseUrl}/api/v2/conversations?limit=${limit}&detail=${detail}`
       );
     } catch (error) {
       if (error instanceof DOMException && error.name === 'AbortError') {
@@ -955,13 +958,17 @@ export class ApiClient {
     }
   }
 
-  async searchConversations(query: string, limit: number = 20): Promise<ConversationSummary[]> {
+  async searchConversations(
+    query: string,
+    limit: number = 20,
+    detail: boolean = false
+  ): Promise<ConversationSummary[]> {
     if (!this.isConnected) {
       throw new ApiClientError('Not connected to API');
     }
     try {
       return await this.fetchJson<ConversationSummary[]>(
-        `${this.baseUrl}/api/v2/conversations?search=${encodeURIComponent(query)}&limit=${limit}`
+        `${this.baseUrl}/api/v2/conversations?search=${encodeURIComponent(query)}&limit=${limit}&detail=${detail}`
       );
     } catch (error) {
       if (error instanceof DOMException && error.name === 'AbortError') {
@@ -973,7 +980,8 @@ export class ApiClient {
 
   async getConversationsPaginated(
     pageParam: number = 0,
-    pageSize: number = 20
+    pageSize: number = 20,
+    detail: boolean = false
   ): Promise<{
     conversations: ConversationSummary[];
     nextCursor: number | undefined;
@@ -985,7 +993,7 @@ export class ApiClient {
       // Fetch one more than needed to detect if there are more conversations
       const fetchLimit = pageParam + pageSize + 1;
       const allConversations = await this.fetchJson<ConversationSummary[]>(
-        `${this.baseUrl}/api/v2/conversations?limit=${fetchLimit}`
+        `${this.baseUrl}/api/v2/conversations?limit=${fetchLimit}&detail=${detail}`
       );
 
       // Slice to get only the requested page
@@ -1301,7 +1309,12 @@ export class ApiClient {
     const url = `${this.baseUrl}/api/v2/audio/transcriptions`;
     const response = await fetch(
       url,
-      withLocalAddressSpace(url, { method: 'POST', headers, body: formData, signal: options?.signal })
+      withLocalAddressSpace(url, {
+        method: 'POST',
+        headers,
+        body: formData,
+        signal: options?.signal,
+      })
     );
     const data = await response.json();
     if (!response.ok) {


### PR DESCRIPTION
## Summary
- omit `messages` from `/api/v2/conversations` responses unless `detail=true` is requested
- make webui conversation summaries tolerate missing message counts
- request `detail=false` for the sidebar infinite query while opting into detail for count-heavy views/search

## Verification
- `uv run --with pytest --with requests python -m pytest tests/test_server.py -k conversation_list -v`
- `npm run typecheck -- --pretty false`
- `npx eslint src/components/CommandPalette.tsx src/components/ConversationList.tsx src/components/HistoryView.tsx src/utils/api.ts src/types/conversation.ts src/utils/__tests__/api.test.ts`
- `npm test -- --runInBand src/utils/__tests__/api.test.ts src/components/__tests__/HistoryView.test.tsx src/components/__tests__/ConversationList.test.tsx src/utils/__tests__/demoApiClient.test.ts`