### PR TITLE
feat(cli): add --format table option to gptme-util status

### DIFF
--- a/gptme/cli/cmd_status.py
+++ b/gptme/cli/cmd_status.py
@@ -13,6 +13,7 @@ import json
 import logging
 import os
 import re
+import shutil
 import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
@@ -170,6 +171,56 @@ def _ready_tasks(limit: int = 3) -> list[dict]:
     return tasks[:limit]
 
 
+def _session_id() -> str:
+    """Return the current session ID from environment variables."""
+    for key in (
+        "GPTME_SESSION_ID",
+        "BOB_SESSION_ID",
+        "SESSION_ID",
+        "GIT_COMMITTER_SESSION_ID",
+    ):
+        val = os.environ.get(key)
+        if val:
+            return val
+    return "none"
+
+
+def _disk_usage(path: Path | None = None) -> str:
+    """Return human-readable disk usage for the given path."""
+    target = path or Path.cwd()
+    try:
+        usage = shutil.disk_usage(target)
+        total_gb = usage.total / (1024**3)
+        used_gb = usage.used / (1024**3)
+        percent = (usage.used / usage.total) * 100
+        return f"{used_gb:.1f}G / {total_gb:.1f}G ({percent:.0f}%)"
+    except Exception:
+        return "unknown"
+
+
+def _journal_entries(limit: int = 5) -> list[str]:
+    """Return the last N journal entry filenames (Bob workspace)."""
+    root = _git_root()
+    if not root:
+        return []
+    journal_dir = root / "journal"
+    if not journal_dir.is_dir():
+        return []
+    entries: list[Path] = []
+    for day_dir in sorted(journal_dir.iterdir(), reverse=True):
+        if not day_dir.is_dir():
+            continue
+        day_entries = [
+            entry.relative_to(root)
+            for entry in sorted(day_dir.iterdir(), reverse=True)
+            if entry.is_file() and entry.suffix == ".md"
+        ]
+        entries.extend(day_entries)
+        if len(entries) >= limit:
+            break
+    return [str(e) for e in entries[:limit]]
+
+
 def _strip_markdown(doc: str) -> str:
     """Strip Markdown formatting for plain-text output."""
     lines = []
@@ -268,6 +319,69 @@ def section_ready_next() -> str:
 # ── build ─────────────────────────────────────────────────────────────
 
 
+def build_table_document() -> str:
+    """Build a machine-readable markdown table of session state."""
+    is_bob = _is_bob_workspace()
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    session_id = _session_id()
+    root = _git_root()
+
+    # active_task
+    active = _active_tasks(1)
+    active_task = active[0].get("_id", "none") if active else "none"
+
+    # last_commit
+    commits = _recent_commits(1)
+    last_commit = commits[0] if commits else "none"
+
+    # pending_prs
+    tracked = [
+        ("gptme/gptme", 10),
+        ("gptme/gptme-cloud", 3),
+        ("ErikBjare/bob", None),
+        ("gptme/gptme-contrib", None),
+    ]
+    pr_rows = _pr_queue(tracked)
+    pending_prs = (
+        ", ".join(f"{r['repo']}:{r['count']}" for r in pr_rows) if pr_rows else "none"
+    )
+
+    # waiting_for
+    blockers = _blockers(1)
+    waiting_for = blockers[0].get("waiting_for", "none") if blockers else "none"
+
+    # disk_usage
+    disk = _disk_usage(root)
+
+    # journal_entries
+    journals = _journal_entries(5)
+    journal_str = ", ".join(journals) if journals else "none"
+
+    lines = [
+        f"# gptme Status — {now}",
+        "",
+        "| Field | Value |",
+        "|-------|-------|",
+        f"| session_id | `{session_id}` |",
+        f"| active_task | `{active_task}` |",
+        f"| last_commit | `{last_commit}` |",
+        f"| pending_prs | {pending_prs} |",
+        f"| waiting_for | {waiting_for} |",
+        f"| disk_usage | {disk} |",
+        f"| journal_entries | {journal_str} |",
+    ]
+
+    if is_bob:
+        services = _service_status()
+        svc_str = ", ".join(f"{s['label']}={s['status']}" for s in services)
+        lines.append(f"| services | {svc_str} |")
+        dead = _dead_timers()
+        if dead:
+            lines.append(f"| dead_timers | {dead} |")
+
+    return "\n".join(lines)
+
+
 def build_document() -> str:
     is_bob = _is_bob_workspace()
     sections: list[str] = [
@@ -311,7 +425,14 @@ def build_document() -> str:
     default=True,
     help="Output as Markdown (default: enabled). Use --no-markdown for plain text.",
 )
-def status(write: bool, output: str | None, markdown: bool):
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["narrative", "table"], case_sensitive=False),
+    default="narrative",
+    help="Output format: narrative (default) or table.",
+)
+def status(write: bool, output: str | None, markdown: bool, output_format: str):
     """Generate a portable operator handoff / session-status document.
 
     Produces a compact briefing: active work, PR queue, service health,
@@ -327,8 +448,13 @@ def status(write: bool, output: str | None, markdown: bool):
         gptme-util status -o /tmp/handoff.md    # write to custom path
 
         gptme-util status --no-markdown         # plain-text output
+
+        gptme-util status --format table        # machine-readable table
     """
-    doc = build_document()
+    if output_format == "table":
+        doc = build_table_document()
+    else:
+        doc = build_document()
     if not markdown:
         doc = _strip_markdown(doc)
     out_path: Path | None = None

--- a/gptme/cli/cmd_status.py
+++ b/gptme/cli/cmd_status.py
@@ -186,7 +186,7 @@ def _session_id() -> str:
 
 
 def _disk_usage(path: Path | None = None) -> str:
-    """Return human-readable disk usage for the given path."""
+    """Return human-readable usage for the filesystem containing the path."""
     target = path or Path.cwd()
     try:
         usage = shutil.disk_usage(target)
@@ -196,6 +196,14 @@ def _disk_usage(path: Path | None = None) -> str:
         return f"{used_gb:.1f}G / {total_gb:.1f}G ({percent:.0f}%)"
     except Exception:
         return "unknown"
+
+
+def _markdown_table_cell(value: object) -> str:
+    """Escape dynamic values for a single markdown table cell."""
+    text = " ".join(str(value).splitlines()).strip()
+    if not text:
+        return "none"
+    return text.replace("|", r"\|")
 
 
 def _journal_entries(limit: int = 5) -> list[str]:
@@ -348,24 +356,28 @@ def build_table_document() -> str:
 
     # waiting_for
     blockers = _blockers(1)
-    waiting_for = blockers[0].get("waiting_for", "none") if blockers else "none"
+    waiting_for = (
+        _markdown_table_cell(blockers[0].get("waiting_for", "none"))
+        if blockers
+        else "none"
+    )
 
     # disk_usage
-    disk = _disk_usage(root)
+    disk = _markdown_table_cell(_disk_usage(root))
 
     # journal_entries
     journals = _journal_entries(5)
-    journal_str = ", ".join(journals) if journals else "none"
+    journal_str = _markdown_table_cell(", ".join(journals) if journals else "none")
 
     lines = [
         f"# gptme Status — {now}",
         "",
         "| Field | Value |",
         "|-------|-------|",
-        f"| session_id | `{session_id}` |",
-        f"| active_task | `{active_task}` |",
-        f"| last_commit | `{last_commit}` |",
-        f"| pending_prs | {pending_prs} |",
+        f"| session_id | `{_markdown_table_cell(session_id)}` |",
+        f"| active_task | `{_markdown_table_cell(active_task)}` |",
+        f"| last_commit | `{_markdown_table_cell(last_commit)}` |",
+        f"| pending_prs | {_markdown_table_cell(pending_prs)} |",
         f"| waiting_for | {waiting_for} |",
         f"| disk_usage | {disk} |",
         f"| journal_entries | {journal_str} |",
@@ -373,7 +385,9 @@ def build_table_document() -> str:
 
     if is_bob:
         services = _service_status()
-        svc_str = ", ".join(f"{s['label']}={s['status']}" for s in services)
+        svc_str = _markdown_table_cell(
+            ", ".join(f"{s['label']}={s['status']}" for s in services)
+        )
         lines.append(f"| services | {svc_str} |")
         dead = _dead_timers()
         if dead:

--- a/tests/test_cli_status.py
+++ b/tests/test_cli_status.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 
 from click.testing import CliRunner
 
-from gptme.cli.cmd_status import _strip_markdown, status
+from gptme.cli.cmd_status import (
+    _session_id,
+    _strip_markdown,
+    build_table_document,
+    status,
+)
 from gptme.cli.util import main as util_main
 
 
@@ -70,3 +75,61 @@ def test_strip_markdown_removes_headings():
     assert "bold" in plain
     assert "`code`" not in plain
     assert "code" in plain
+
+
+def test_status_format_table():
+    """Verify --format table outputs a markdown table with expected fields."""
+    runner = CliRunner()
+    result = runner.invoke(status, ["--format", "table"])
+    assert result.exit_code == 0
+    assert "| Field | Value |" in result.output
+    assert "| session_id |" in result.output
+    assert "| active_task |" in result.output
+    assert "| last_commit |" in result.output
+    assert "| pending_prs |" in result.output
+    assert "| waiting_for |" in result.output
+    assert "| disk_usage |" in result.output
+    assert "| journal_entries |" in result.output
+
+
+def test_status_format_table_via_util():
+    """Verify gptme-util status --format table dispatches correctly."""
+    runner = CliRunner()
+    result = runner.invoke(util_main, ["status", "--format", "table"])
+    assert result.exit_code == 0
+    assert "| Field | Value |" in result.output
+    assert "| session_id |" in result.output
+
+
+def test_status_format_narrative_is_default():
+    """Verify default format is narrative (not table)."""
+    runner = CliRunner()
+    result = runner.invoke(status)
+    assert result.exit_code == 0
+    assert "## Active Work" in result.output
+    assert "| Field | Value |" not in result.output
+
+
+def test_session_id_from_env(monkeypatch):
+    """Verify _session_id reads from environment variables."""
+    monkeypatch.setenv("GPTME_SESSION_ID", "abc123")
+    assert _session_id() == "abc123"
+    monkeypatch.delenv("GPTME_SESSION_ID")
+    monkeypatch.setenv("BOB_SESSION_ID", "def456")
+    assert _session_id() == "def456"
+
+
+def test_session_id_fallback():
+    """Verify _session_id returns 'none' when no env var is set."""
+    # This test may be brittle if the test runner sets session env vars;
+    # we verify at least the fallback path exists by inspecting the function.
+    assert _session_id() is not None
+
+
+def test_build_table_document_structure():
+    """Verify build_table_document produces a markdown table."""
+    doc = build_table_document()
+    lines = doc.splitlines()
+    assert any("| Field | Value |" in line for line in lines)
+    assert any("| session_id |" in line for line in lines)
+    assert any("| last_commit |" in line for line in lines)

--- a/tests/test_cli_status.py
+++ b/tests/test_cli_status.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from click.testing import CliRunner
 
+import gptme.cli.cmd_status as cmd_status
 from gptme.cli.cmd_status import (
     _session_id,
     _strip_markdown,
@@ -119,11 +120,16 @@ def test_session_id_from_env(monkeypatch):
     assert _session_id() == "def456"
 
 
-def test_session_id_fallback():
+def test_session_id_fallback(monkeypatch):
     """Verify _session_id returns 'none' when no env var is set."""
-    # This test may be brittle if the test runner sets session env vars;
-    # we verify at least the fallback path exists by inspecting the function.
-    assert _session_id() is not None
+    for key in (
+        "GPTME_SESSION_ID",
+        "BOB_SESSION_ID",
+        "SESSION_ID",
+        "GIT_COMMITTER_SESSION_ID",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    assert _session_id() == "none"
 
 
 def test_build_table_document_structure():
@@ -133,3 +139,24 @@ def test_build_table_document_structure():
     assert any("| Field | Value |" in line for line in lines)
     assert any("| session_id |" in line for line in lines)
     assert any("| last_commit |" in line for line in lines)
+
+
+def test_build_table_document_escapes_multiline_waiting_for(monkeypatch):
+    """Verify multiline blockers stay inside a single markdown table row."""
+    monkeypatch.setattr(cmd_status, "_is_bob_workspace", lambda: False)
+    monkeypatch.setattr(cmd_status, "_active_tasks", lambda _limit=1: [])
+    monkeypatch.setattr(cmd_status, "_recent_commits", lambda _limit=1: [])
+    monkeypatch.setattr(cmd_status, "_pr_queue", lambda _tracked: [])
+    monkeypatch.setattr(cmd_status, "_git_root", lambda: None)
+    monkeypatch.setattr(cmd_status, "_disk_usage", lambda _root=None: "1G / 2G (50%)")
+    monkeypatch.setattr(cmd_status, "_journal_entries", lambda _limit=5: [])
+    monkeypatch.setattr(
+        cmd_status,
+        "_blockers",
+        lambda _limit=1: [{"waiting_for": "first line\nsecond | line"}],
+    )
+
+    doc = build_table_document()
+
+    assert "| waiting_for | first line second \\| line |" in doc
+    assert "second | line" not in doc


### PR DESCRIPTION
Adds a machine-readable markdown table format to `gptme-util status` via `--format table`.

### Changes
- New `--format table` flag outputs a markdown table with session metadata
- Table includes: session_id, active_task, last_commit, pending_prs, waiting_for, disk_usage, journal_entries
- New helpers: `_session_id()`, `_disk_usage()`, `_journal_entries()`
- Backward compatible: default `--format narrative` preserves existing output
- Added tests for table format, session ID helper, and table document structure

### Verification
- `make test` passes (tests/test_cli_status.py: 12 passed)
- `make typecheck` passes
- `make lint` passes

Closes the `gptme-status-markdown` task.