### PR TITLE
fix(cli): reject malformed model paths

### DIFF
--- a/gptme/cli/cmd_batch.py
+++ b/gptme/cli/cmd_batch.py
@@ -43,8 +43,18 @@ def _validate_model_param(
     ctx: click.Context, param: click.Parameter, value: str | None
 ) -> str | None:
     """Reject empty --model before spawning child gptme sessions."""
-    if value is not None and not value.strip():
+    if value is None:
+        return value
+
+    model = value.strip()
+    if not model:
         raise click.BadParameter("Model name cannot be empty.", ctx=ctx, param=param)
+    if "/" in model and any(part == "" for part in model.split("/")):
+        raise click.BadParameter(
+            "Model path components cannot be empty. Use 'provider/model' or a bare provider name.",
+            ctx=ctx,
+            param=param,
+        )
     return value
 
 

--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -57,8 +57,18 @@ def _validate_model_param(
     ctx: click.Context, param: click.Parameter, value: str | None
 ) -> str | None:
     """Reject empty --model early so the CLI exits before heavy setup work."""
-    if value is not None and not value.strip():
+    if value is None:
+        return value
+
+    model = value.strip()
+    if not model:
         raise click.BadParameter("Model name cannot be empty.", ctx=ctx, param=param)
+    if "/" in model and any(part == "" for part in model.split("/")):
+        raise click.BadParameter(
+            "Model path components cannot be empty. Use 'provider/model' or a bare provider name.",
+            ctx=ctx,
+            param=param,
+        )
     return value
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -228,6 +228,25 @@ def test_name_empty_before_output_format(
     assert selected_logdirs == [logdir]
 
 
+@pytest.mark.parametrize("bad_model", ["openai/", "/gpt-4o", "/", "openrouter//gpt-4o"])
+def test_model_rejects_empty_path_components(bad_model: str, runner: CliRunner):
+    result = runner.invoke(cli.main, ["--model", bad_model, "--version"])
+
+    assert result.exit_code == 2
+    assert "Model path components cannot be empty" in result.output
+    assert "Traceback" not in result.output
+
+
+def test_model_allows_provider_owned_nested_model_path(runner: CliRunner):
+    result = runner.invoke(
+        cli.main,
+        ["--model", "openrouter/anthropic/claude-sonnet-4-6", "--version"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "gptme v" in result.output
+
+
 @pytest.mark.parametrize(
     ("bad_name", "expected_message"),
     [

--- a/tests/test_util_cli_batch.py
+++ b/tests/test_util_cli_batch.py
@@ -105,6 +105,25 @@ def test_batch_empty_model_rejected_before_child_spawn(monkeypatch, bad_model):
     assert "Model name cannot be empty." in result.output
 
 
+@pytest.mark.parametrize("bad_model", ["openai/", "/gpt-4o", "/", "openrouter//gpt-4o"])
+def test_batch_model_rejects_empty_path_components(monkeypatch, bad_model):
+    monkeypatch.setattr(
+        cmd_batch,
+        "_run_one_prompt",
+        lambda **_kwargs: (_ for _ in ()).throw(AssertionError("should not run")),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        util_main,
+        ["batch", "--model", bad_model],
+        input="hello\n",
+    )
+
+    assert result.exit_code != 0
+    assert "Model path components cannot be empty" in result.output
+
+
 def test_summarize_child_output_counts_tokens_and_max_turns():
     stdout = "\n".join(
         [


### PR DESCRIPTION
## What changed

Reject malformed `--model` values that contain empty slash components, such as `openai/`, `/gpt-4o`, `/`, or `openrouter//gpt-4o`.

The same validation now applies to both the top-level `gptme` CLI and `gptme-util batch`, which forwards model selectors into child `gptme` sessions.

## Why

Dogfooding the top-level CLI found that `gptme -n --tools none --model openai/ hello` passed Click validation, reached model initialization, printed `Using model: openai/`, and then failed on provider auth instead of telling the user the model selector itself was malformed.

This keeps bad input at the parser boundary while preserving valid provider-owned nested model IDs like `openrouter/anthropic/claude-sonnet-4-6`.

## Validation

- `uv run pytest tests/test_cli.py::test_model_rejects_empty_path_components tests/test_cli.py::test_model_allows_provider_owned_nested_model_path tests/test_util_cli_batch.py::test_batch_model_rejects_empty_path_components -q`
- `uv run pytest tests/test_cli.py tests/test_util_cli_batch.py -q`
- `uv run ruff check gptme/cli/main.py gptme/cli/cmd_batch.py tests/test_cli.py tests/test_util_cli_batch.py`
- `uv run ruff format --check gptme/cli/main.py gptme/cli/cmd_batch.py tests/test_cli.py tests/test_util_cli_batch.py`
- `uv run gptme --model openai/ --version` now exits with Click usage error: `Model path components cannot be empty.`