### PR TITLE
feat(webui): model favorites, set-as-default, and picker scroll fix

### DIFF
--- a/gptme/config/models.py
+++ b/gptme/config/models.py
@@ -149,6 +149,25 @@ class UserIdentityConfig:
 
 
 @dataclass
+class ModelsConfig:
+    """Model-related user preferences, stored under a ``[models]`` section.
+
+    Scope: these refer to the primary chat/LLM model (the same notion as the
+    ``MODEL`` env var). Other modalities (TTS/STT/image) are configured
+    separately; if they ever need formal model selection they should get their
+    own scoped keys (e.g. ``[models.tts]``) rather than overloading these.
+    """
+
+    # Default chat model (fully-qualified id). Formal alternative to the MODEL
+    # env var; takes precedence over MODEL but below an explicit per-chat model.
+    default: str | None = None
+
+    # User-curated favorite models (fully-qualified ids, e.g.
+    # "anthropic/claude-opus-4-8"). Surfaced prominently in model pickers.
+    favorites: list[str] = field(default_factory=list)
+
+
+@dataclass
 class UserConfig:
     """User-level configuration, such as user-specific prompts and environment variables."""
 
@@ -160,9 +179,8 @@ class UserConfig:
     providers: list[ProviderConfig] = field(default_factory=list)
     lessons: "LessonsConfig | None" = None
 
-    # User-curated favorite models (fully-qualified ids, e.g. "anthropic/claude-opus-4-8").
-    # Surfaced prominently in model pickers across clients.
-    favorites: list[str] = field(default_factory=list)
+    # Model-related preferences (favorites, ...), under a [models] section.
+    models: "ModelsConfig" = field(default_factory=lambda: ModelsConfig())
 
     # Plugin system configuration (search paths + enabled allowlist).
     # Layered with project-level [plugins] (see Config.get_plugin_config).

--- a/gptme/config/models.py
+++ b/gptme/config/models.py
@@ -160,6 +160,10 @@ class UserConfig:
     providers: list[ProviderConfig] = field(default_factory=list)
     lessons: "LessonsConfig | None" = None
 
+    # User-curated favorite models (fully-qualified ids, e.g. "anthropic/claude-opus-4-8").
+    # Surfaced prominently in model pickers across clients.
+    favorites: list[str] = field(default_factory=list)
+
     # Plugin system configuration (search paths + enabled allowlist).
     # Layered with project-level [plugins] (see Config.get_plugin_config).
     plugins: PluginsConfig = field(default_factory=PluginsConfig)

--- a/gptme/config/user.py
+++ b/gptme/config/user.py
@@ -204,6 +204,15 @@ def load_user_config(path: str | None = None) -> UserConfig:
     providers_config = config.pop("providers", [])
     providers = [ProviderConfig(**provider) for provider in providers_config]
 
+    # Parse favorite models (list of fully-qualified model ids)
+    favorites_data = config.pop("favorites", [])
+    if not isinstance(favorites_data, list):
+        logger.warning(
+            f"[favorites] should be a list, got {type(favorites_data).__name__}"
+        )
+        favorites_data = []
+    favorites = [str(m) for m in favorites_data if isinstance(m, str)]
+
     # Parse lessons config
     lessons_data = config.pop("lessons", None)
     lessons = (
@@ -238,6 +247,7 @@ def load_user_config(path: str | None = None) -> UserConfig:
         mcp=mcp,
         providers=providers,
         lessons=lessons,
+        favorites=favorites,
         plugins=plugins,
         plugin=plugin_config,
     )

--- a/gptme/config/user.py
+++ b/gptme/config/user.py
@@ -21,6 +21,7 @@ from ..util import path_with_tilde
 from .models import (
     LessonsConfig,
     MCPConfig,
+    ModelsConfig,
     PluginsConfig,
     ProviderConfig,
     UserConfig,
@@ -125,6 +126,24 @@ def get_user_config_env_source(key: str, path: str | None = None) -> str | None:
     return None
 
 
+def get_default_model_source(path: str | None = None) -> str | None:
+    """Return where the default model comes from.
+
+    Precedence mirrors model resolution: ``[models].default`` (local then main
+    config) takes priority, then the ``MODEL`` env var / ``[env]`` source.
+    """
+    config_file, local_path = get_user_config_paths(path)
+    if local_path.exists():
+        with open(local_path) as f:
+            local_doc = tomlkit.load(f)
+        if _get_nested_config_value(local_doc, "models", "default") is not None:
+            return USER_CONFIG_SOURCE_LOCAL
+    main_doc = _load_config_doc(str(config_file))
+    if _get_nested_config_value(main_doc, "models", "default") is not None:
+        return USER_CONFIG_SOURCE_MAIN
+    return get_user_config_env_source("MODEL", path)
+
+
 def get_user_config_runtime_info(path: str | None = None) -> dict[str, str | bool]:
     """Return read/write path details for the user config UI."""
     config_file, local_path = get_user_config_paths(path)
@@ -204,14 +223,25 @@ def load_user_config(path: str | None = None) -> UserConfig:
     providers_config = config.pop("providers", [])
     providers = [ProviderConfig(**provider) for provider in providers_config]
 
-    # Parse favorite models (list of fully-qualified model ids)
-    favorites_data = config.pop("favorites", [])
+    # Parse [models] section (model-related preferences like favorites)
+    models_data = config.pop("models", {})
+    if not isinstance(models_data, dict):
+        logger.warning(f"[models] should be a table, got {type(models_data).__name__}")
+        models_data = {}
+    favorites_data = models_data.get("favorites", [])
     if not isinstance(favorites_data, list):
         logger.warning(
-            f"[favorites] should be a list, got {type(favorites_data).__name__}"
+            f"[models].favorites should be a list, got {type(favorites_data).__name__}"
         )
         favorites_data = []
-    favorites = [str(m) for m in favorites_data if isinstance(m, str)]
+    default_model = models_data.get("default")
+    if default_model is not None and not isinstance(default_model, str):
+        logger.warning("[models].default should be a string")
+        default_model = None
+    models_config = ModelsConfig(
+        default=default_model,
+        favorites=[str(m) for m in favorites_data if isinstance(m, str)],
+    )
 
     # Parse lessons config
     lessons_data = config.pop("lessons", None)
@@ -247,7 +277,7 @@ def load_user_config(path: str | None = None) -> UserConfig:
         mcp=mcp,
         providers=providers,
         lessons=lessons,
-        favorites=favorites,
+        models=models_config,
         plugins=plugins,
         plugin=plugin_config,
     )

--- a/gptme/init.py
+++ b/gptme/init.py
@@ -103,8 +103,13 @@ def init_model(
     config = get_config()
 
     # get from config
+    # Precedence: explicit per-chat model > [models].default > MODEL env var.
     if not model:
-        model = (config.chat.model if config.chat else None) or config.get_env("MODEL")
+        model = (
+            (config.chat.model if config.chat else None)
+            or config.user.models.default
+            or config.get_env("MODEL")
+        )
 
     if not model:  # pragma: no cover
         # auto-detect depending on if OPENAI_API_KEY or ANTHROPIC_API_KEY is set

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -56,6 +56,7 @@ from gptme.prompts import get_prompt
 from ..commands import handle_cmd
 from ..config import get_project_config
 from ..config.user import (
+    get_default_model_source,
     get_user_config_env_source,
     get_user_config_paths,
     get_user_config_runtime_info,
@@ -292,11 +293,11 @@ def _get_optional_string_list_field(
 
 
 def _persist_default_model(model: str) -> bool:
-    """Persist env.MODEL and try to apply it in-process.
+    """Persist the default model to [models].default and try to apply in-process.
 
     Returns True if a restart is still required to guarantee the change takes effect.
     """
-    set_config_value("env.MODEL", model, reload=False)
+    set_config_value("models.default", model, reload=False)
 
     model_meta = get_model(model)
     try:
@@ -1627,7 +1628,7 @@ def api_models():
 
     # User-curated favorites (only those still available in the model list)
     available_ids = {m["id"] for m in models_data}
-    favorites = [m for m in config.user.favorites if m in available_ids]
+    favorites = [m for m in config.user.models.favorites if m in available_ids]
 
     return flask.jsonify(
         {
@@ -2298,16 +2299,26 @@ def api_user_favorites():
     ):
         return flask.jsonify({"error": "favorites must be a list of strings"}), 400
 
-    # De-duplicate while preserving order; trim and drop empties
+    # Validate, de-duplicate (preserving order), and drop malformed entries so
+    # junk doesn't accumulate in config.toml. Favorites may reference custom
+    # providers, so we don't require a known built-in provider — just a
+    # plausible "provider/model" shape within a sane length.
     seen: set[str] = set()
     cleaned: list[str] = []
     for m in favorites:
         trimmed = m.strip()
-        if trimmed and trimmed not in seen:
-            seen.add(trimmed)
-            cleaned.append(trimmed)
+        if not trimmed or trimmed in seen:
+            continue
+        if "/" not in trimmed or len(trimmed) > 256:
+            logger.warning("Dropping invalid favorite model id: %r", m)
+            continue
+        if any(ord(ch) < 32 or ord(ch) == 127 for ch in trimmed):
+            logger.warning("Dropping favorite model id with control chars: %r", m)
+            continue
+        seen.add(trimmed)
+        cleaned.append(trimmed)
 
-    set_config_value("favorites", cleaned, reload=True)
+    set_config_value("models.favorites", cleaned, reload=True)
     logger.info("Saved %d favorite model(s) via /api/v2/user/favorites", len(cleaned))
     return flask.jsonify({"status": "ok", "favorites": cleaned})
 
@@ -2591,7 +2602,7 @@ def api_user_settings():
             "providers_configured": providers,
             "provider_sources": provider_sources,
             "default_model": default_model.full if default_model else None,
-            "default_model_source": get_user_config_env_source("MODEL"),
+            "default_model_source": get_default_model_source(),
             "config_files": get_user_config_runtime_info(),
         }
     )

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -98,6 +98,8 @@ from .openapi_docs import (
     UserConfigFileSaveResponse,
     UserDefaultModelSaveRequest,
     UserDefaultModelSaveResponse,
+    UserFavoritesSaveRequest,
+    UserFavoritesSaveResponse,
     UserSettingsResponse,
     api_doc,
     api_doc_simple,
@@ -1623,11 +1625,16 @@ def api_models():
         except ValueError:
             pass
 
+    # User-curated favorites (only those still available in the model list)
+    available_ids = {m["id"] for m in models_data}
+    favorites = [m for m in config.user.favorites if m in available_ids]
+
     return flask.jsonify(
         {
             "models": models_data,
             "default": default_model.full if default_model else None,
             "recommended": recommended,
+            "favorites": favorites,
         }
     )
 
@@ -2266,6 +2273,43 @@ def api_user_default_model():
             "restart_required": restart_required,
         }
     )
+
+
+@v2_api.route("/api/v2/user/favorites", methods=["POST"])
+@require_auth
+@api_doc(
+    summary="Save favorite models",
+    description="Persist the user's favorite models into the global gptme config.",
+    request_body=UserFavoritesSaveRequest,
+    responses={200: UserFavoritesSaveResponse, 400: ErrorResponse},
+    tags=["user"],
+)
+def api_user_favorites():
+    """Persist favorite models into user config."""
+    req_json = request.get_json(silent=True)
+    if req_json is None:
+        return flask.jsonify({"error": "No JSON data provided"}), 400
+    if not isinstance(req_json, dict):
+        return flask.jsonify({"error": "JSON body must be an object"}), 400
+
+    favorites = req_json.get("favorites")
+    if not isinstance(favorites, list) or not all(
+        isinstance(m, str) for m in favorites
+    ):
+        return flask.jsonify({"error": "favorites must be a list of strings"}), 400
+
+    # De-duplicate while preserving order; trim and drop empties
+    seen: set[str] = set()
+    cleaned: list[str] = []
+    for m in favorites:
+        trimmed = m.strip()
+        if trimmed and trimmed not in seen:
+            seen.add(trimmed)
+            cleaned.append(trimmed)
+
+    set_config_value("favorites", cleaned, reload=True)
+    logger.info("Saved %d favorite model(s) via /api/v2/user/favorites", len(cleaned))
+    return flask.jsonify({"status": "ok", "favorites": cleaned})
 
 
 @v2_api.route("/api/v2/user/avatar", methods=["GET"])

--- a/gptme/server/openapi_docs.py
+++ b/gptme/server/openapi_docs.py
@@ -208,6 +208,22 @@ class UserDefaultModelSaveResponse(BaseModel):
     )
 
 
+class UserFavoritesSaveRequest(BaseModel):
+    """Request to save the user's favorite models."""
+
+    favorites: list[str] = Field(
+        ...,
+        description="Fully-qualified model ids to store as favorites",
+    )
+
+
+class UserFavoritesSaveResponse(BaseModel):
+    """Response after persisting favorite models."""
+
+    status: str = Field(..., description="Operation status")
+    favorites: list[str] = Field(..., description="Favorite model ids that were saved")
+
+
 class UserConfigFileResponse(BaseModel):
     """Raw user config file contents plus path metadata."""
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -36,6 +36,7 @@ def mock_config():
     config = MagicMock()
     config.chat = MagicMock()
     config.chat.model = None
+    config.user.models.default = None
     config.get_env.return_value = None
     return config
 
@@ -411,7 +412,9 @@ class TestInitModelParsing:
         from gptme.init import init_model
 
         mock_config_fn.return_value = MagicMock(
-            chat=MagicMock(model=None), get_env=MagicMock(return_value=None)
+            chat=MagicMock(model=None),
+            user=MagicMock(models=MagicMock(default=None)),
+            get_env=MagicMock(return_value=None),
         )
         mock_get_model.return_value = dummy_model_meta
 
@@ -443,7 +446,9 @@ class TestInitModelParsing:
         from gptme.init import init_model
 
         mock_config_fn.return_value = MagicMock(
-            chat=MagicMock(model=None), get_env=MagicMock(return_value=None)
+            chat=MagicMock(model=None),
+            user=MagicMock(models=MagicMock(default=None)),
+            get_env=MagicMock(return_value=None),
         )
         mock_get_model.return_value = dummy_model_meta
 
@@ -475,7 +480,9 @@ class TestInitModelParsing:
         from gptme.init import init_model
 
         mock_config_fn.return_value = MagicMock(
-            chat=MagicMock(model=None), get_env=MagicMock(return_value=None)
+            chat=MagicMock(model=None),
+            user=MagicMock(models=MagicMock(default=None)),
+            get_env=MagicMock(return_value=None),
         )
         mock_get_model.return_value = dummy_model_meta
 
@@ -504,7 +511,9 @@ class TestInitModelParsing:
         from gptme.init import init_model
 
         mock_config_fn.return_value = MagicMock(
-            chat=MagicMock(model=None), get_env=MagicMock(return_value=None)
+            chat=MagicMock(model=None),
+            user=MagicMock(models=MagicMock(default=None)),
+            get_env=MagicMock(return_value=None),
         )
         mock_get_model.return_value = dummy_model_meta
 
@@ -539,7 +548,9 @@ class TestInitModelParsing:
         from gptme.init import init_model
 
         mock_config_fn.return_value = MagicMock(
-            chat=MagicMock(model=None), get_env=MagicMock(return_value=None)
+            chat=MagicMock(model=None),
+            user=MagicMock(models=MagicMock(default=None)),
+            get_env=MagicMock(return_value=None),
         )
 
         resolved_meta = ModelMeta(
@@ -585,7 +596,9 @@ class TestInitModelParsing:
         from gptme.init import init_model
 
         mock_config_fn.return_value = MagicMock(
-            chat=MagicMock(model=None), get_env=MagicMock(return_value=None)
+            chat=MagicMock(model=None),
+            user=MagicMock(models=MagicMock(default=None)),
+            get_env=MagicMock(return_value=None),
         )
         # get_model resolves the bare OpenRouter-style name to provider=openrouter
         mock_get_model.return_value = ModelMeta(
@@ -625,7 +638,9 @@ class TestInitModelParsing:
         from gptme.init import init_model
 
         mock_config_fn.return_value = MagicMock(
-            chat=MagicMock(model=None), get_env=MagicMock(return_value=None)
+            chat=MagicMock(model=None),
+            user=MagicMock(models=MagicMock(default=None)),
+            get_env=MagicMock(return_value=None),
         )
         mock_get_model.return_value = ModelMeta(
             provider="unknown",
@@ -662,7 +677,9 @@ class TestInitModelParsing:
         from gptme.init import init_model
 
         mock_config_fn.return_value = MagicMock(
-            chat=MagicMock(model=None), get_env=MagicMock(return_value=None)
+            chat=MagicMock(model=None),
+            user=MagicMock(models=MagicMock(default=None)),
+            get_env=MagicMock(return_value=None),
         )
         mock_get_model.return_value = ModelMeta(
             provider="openai",
@@ -702,7 +719,9 @@ class TestInitModelParsing:
         from gptme.init import init_model
 
         mock_config_fn.return_value = MagicMock(
-            chat=MagicMock(model=None), get_env=MagicMock(return_value=None)
+            chat=MagicMock(model=None),
+            user=MagicMock(models=MagicMock(default=None)),
+            get_env=MagicMock(return_value=None),
         )
         mock_get_model.return_value = ModelMeta(
             provider="unknown",
@@ -735,7 +754,9 @@ class TestInitModelParsing:
         from gptme.init import init_model
 
         mock_config_fn.return_value = MagicMock(
-            chat=MagicMock(model=None), get_env=MagicMock(return_value=None)
+            chat=MagicMock(model=None),
+            user=MagicMock(models=MagicMock(default=None)),
+            get_env=MagicMock(return_value=None),
         )
         mock_get_model.return_value = dummy_model_meta
 
@@ -765,7 +786,9 @@ class TestInitModelParsing:
         from gptme.init import init_model
 
         mock_config_fn.return_value = MagicMock(
-            chat=MagicMock(model=None), get_env=MagicMock(return_value=None)
+            chat=MagicMock(model=None),
+            user=MagicMock(models=MagicMock(default=None)),
+            get_env=MagicMock(return_value=None),
         )
         mock_get_model.return_value = dummy_model_meta
 
@@ -807,6 +830,7 @@ class TestInitModelConfig:
         from gptme.init import init_model
 
         config = MagicMock()
+        config.user.models.default = None
         config.chat.model = "anthropic/claude-sonnet-4-6"
         config.get_env.return_value = None
         mock_config_fn.return_value = config
@@ -839,6 +863,7 @@ class TestInitModelConfig:
         from gptme.init import init_model
 
         config = MagicMock()
+        config.user.models.default = None
         config.chat.model = None
         config.get_env.return_value = "openai/gpt-5"
         mock_config_fn.return_value = config
@@ -871,6 +896,7 @@ class TestInitModelConfig:
         from gptme.init import init_model
 
         config = MagicMock()
+        config.user.models.default = None
         config.chat = None
         config.get_env.return_value = "anthropic/claude-haiku-4-5"
         mock_config_fn.return_value = config
@@ -903,6 +929,7 @@ class TestInitModelConfig:
         from gptme.init import init_model
 
         config = MagicMock()
+        config.user.models.default = None
         config.chat = MagicMock(model=None)
         config.get_env.return_value = None
         mock_config_fn.return_value = config
@@ -934,6 +961,7 @@ class TestInitModelConfig:
         from gptme.init import init_model
 
         config = MagicMock()
+        config.user.models.default = None
         config.chat = MagicMock(model="anthropic/claude-sonnet-4-6")
         mock_config_fn.return_value = config
         mock_get_model.return_value = dummy_model_meta
@@ -978,7 +1006,9 @@ class TestInitModelContextOverride:
             context=200000,
         )
         mock_config_fn.return_value = MagicMock(
-            chat=MagicMock(model=None), get_env=MagicMock(return_value=None)
+            chat=MagicMock(model=None),
+            user=MagicMock(models=MagicMock(default=None)),
+            get_env=MagicMock(return_value=None),
         )
         mock_get_model.return_value = original_meta
 
@@ -1018,7 +1048,9 @@ class TestInitModelContextOverride:
             context=200000,
         )
         mock_config_fn.return_value = MagicMock(
-            chat=MagicMock(model=None), get_env=MagicMock(return_value=None)
+            chat=MagicMock(model=None),
+            user=MagicMock(models=MagicMock(default=None)),
+            get_env=MagicMock(return_value=None),
         )
         mock_get_model.return_value = original_meta
 
@@ -1055,7 +1087,9 @@ class TestInitModelContextOverride:
             context=128000,
         )
         mock_config_fn.return_value = MagicMock(
-            chat=MagicMock(model=None), get_env=MagicMock(return_value=None)
+            chat=MagicMock(model=None),
+            user=MagicMock(models=MagicMock(default=None)),
+            get_env=MagicMock(return_value=None),
         )
         mock_get_model.return_value = original_meta
 
@@ -1093,7 +1127,9 @@ class TestInitModelContextOverride:
             context=8192,
         )
         mock_config_fn.return_value = MagicMock(
-            chat=MagicMock(model=None), get_env=MagicMock(return_value=None)
+            chat=MagicMock(model=None),
+            user=MagicMock(models=MagicMock(default=None)),
+            get_env=MagicMock(return_value=None),
         )
         mock_get_model.return_value = original_meta
 
@@ -1129,7 +1165,9 @@ class TestInitModelContextOverride:
             context=200000,
         )
         mock_config_fn.return_value = MagicMock(
-            chat=MagicMock(model=None), get_env=MagicMock(return_value=None)
+            chat=MagicMock(model=None),
+            user=MagicMock(models=MagicMock(default=None)),
+            get_env=MagicMock(return_value=None),
         )
         mock_get_model.return_value = original_meta
 
@@ -1171,7 +1209,9 @@ class TestInitModelContextOverride:
             price_output=75.0,
         )
         mock_config_fn.return_value = MagicMock(
-            chat=MagicMock(model=None), get_env=MagicMock(return_value=None)
+            chat=MagicMock(model=None),
+            user=MagicMock(models=MagicMock(default=None)),
+            get_env=MagicMock(return_value=None),
         )
         mock_get_model.return_value = original_meta
 
@@ -1218,7 +1258,9 @@ class TestInitModelConsole:
         from gptme.init import init_model
 
         mock_config_fn.return_value = MagicMock(
-            chat=MagicMock(model=None), get_env=MagicMock(return_value=None)
+            chat=MagicMock(model=None),
+            user=MagicMock(models=MagicMock(default=None)),
+            get_env=MagicMock(return_value=None),
         )
         mock_get_model.return_value = dummy_model_meta
 
@@ -1250,7 +1292,9 @@ class TestInitModelConsole:
         from gptme.init import init_model
 
         mock_config_fn.return_value = MagicMock(
-            chat=MagicMock(model=None), get_env=MagicMock(return_value=None)
+            chat=MagicMock(model=None),
+            user=MagicMock(models=MagicMock(default=None)),
+            get_env=MagicMock(return_value=None),
         )
         mock_get_model.return_value = dummy_model_meta
 
@@ -1294,6 +1338,7 @@ class TestInitModelInteractive:
         from gptme.init import init_model
 
         config = MagicMock()
+        config.user.models.default = None
         config.chat = MagicMock(model=None)
         config.get_env.return_value = None
         mock_config_fn.return_value = config
@@ -1328,6 +1373,7 @@ class TestInitModelInteractive:
         from gptme.init import init_model
 
         config = MagicMock()
+        config.user.models.default = None
         config.chat = MagicMock(model=None)
         config.get_env.return_value = None
         mock_config_fn.return_value = config
@@ -1359,6 +1405,7 @@ class TestInitModelInteractive:
         from gptme.init import init_model
 
         config = MagicMock()
+        config.user.models.default = None
         config.chat = MagicMock(model=None)
         config.get_env.return_value = None
         mock_config_fn.return_value = config
@@ -1397,6 +1444,7 @@ class TestInitModelInteractive:
         from gptme.init import init_model
 
         config = MagicMock()
+        config.user.models.default = None
         config.chat = MagicMock(model=None)
         config.get_env.return_value = None
         mock_config_fn.return_value = config
@@ -1437,6 +1485,7 @@ class TestInitModelInteractive:
         from gptme.init import init_model
 
         config = MagicMock()
+        config.user.models.default = None
         config.chat = MagicMock(model=None)
         config.get_env.return_value = None
         mock_config_fn.return_value = config
@@ -1503,7 +1552,9 @@ class TestInitModelBuiltinProviders:
         from gptme.init import init_model
 
         mock_config_fn.return_value = MagicMock(
-            chat=MagicMock(model=None), get_env=MagicMock(return_value=None)
+            chat=MagicMock(model=None),
+            user=MagicMock(models=MagicMock(default=None)),
+            get_env=MagicMock(return_value=None),
         )
         mock_get_model.return_value = dummy_model_meta
 
@@ -1551,7 +1602,9 @@ class TestInitModelBuiltinProviders:
         from gptme.init import init_model
 
         mock_config_fn.return_value = MagicMock(
-            chat=MagicMock(model=None), get_env=MagicMock(return_value=None)
+            chat=MagicMock(model=None),
+            user=MagicMock(models=MagicMock(default=None)),
+            get_env=MagicMock(return_value=None),
         )
         mock_get_model.return_value = dummy_model_meta
 
@@ -1803,7 +1856,9 @@ class TestInitEdgeCases:
         from gptme.init import init_model
 
         mock_config_fn.return_value = MagicMock(
-            chat=MagicMock(model=None), get_env=MagicMock(return_value=None)
+            chat=MagicMock(model=None),
+            user=MagicMock(models=MagicMock(default=None)),
+            get_env=MagicMock(return_value=None),
         )
         mock_get_model.return_value = dummy_model_meta
 

--- a/tests/test_json_output.py
+++ b/tests/test_json_output.py
@@ -377,7 +377,11 @@ class TestJSONRuntimeSuppression:
         """Init model path where no API keys are set must NOT leak the
         'No API keys set' warning to stdout when --output-format json."""
         set_output_format("json")
-        mock_config = SimpleNamespace(chat=None, get_env=lambda key, default=None: None)
+        mock_config = SimpleNamespace(
+            chat=None,
+            user=SimpleNamespace(models=SimpleNamespace(default=None)),
+            get_env=lambda key, default=None: None,
+        )
         monkeypatch.setattr(gptme_init, "get_config", lambda: mock_config)
         # Must patch on gptme_init, not llm — init.py imports via `from .llm import ...`,
         # which creates a module-level global that LOAD_GLOBAL resolves from gptme_init.

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -368,7 +368,7 @@ def test_v2_user_api_key_rejects_unknown_provider(client: FlaskClient):
 def test_v2_user_default_model_persists_and_applies(
     client: FlaskClient, tmp_path, monkeypatch
 ):
-    """Saving a default model should write env.MODEL and update runtime state."""
+    """Saving a default model should write [models].default and update runtime state."""
     import gptme.config.user as user_mod
 
     config_file = tmp_path / "config.toml"
@@ -395,7 +395,7 @@ def test_v2_user_default_model_persists_and_applies(
     }
 
     saved = tomlkit.loads(config_file.read_text()).unwrap()
-    assert saved["env"]["MODEL"] == "anthropic/claude-sonnet-4-7"
+    assert saved["models"]["default"] == "anthropic/claude-sonnet-4-7"
     assert applied["model"].full == "anthropic/claude-sonnet-4-7"
 
 
@@ -2538,13 +2538,11 @@ def test_v2_user_settings_returns_providers_and_model(client: FlaskClient, monke
     )
     monkeypatch.setattr(
         "gptme.server.api_v2.get_user_config_env_source",
-        lambda key: (
-            "config.local.toml"
-            if key == "ANTHROPIC_API_KEY"
-            else "config.toml"
-            if key == "MODEL"
-            else None
-        ),
+        lambda key: "config.local.toml" if key == "ANTHROPIC_API_KEY" else None,
+    )
+    monkeypatch.setattr(
+        "gptme.server.api_v2.get_default_model_source",
+        lambda: "config.toml",
     )
     monkeypatch.setattr(
         "gptme.server.api_v2.get_user_config_runtime_info",
@@ -2582,6 +2580,7 @@ def test_v2_user_settings_no_providers_no_model(client: FlaskClient, monkeypatch
     monkeypatch.setattr(
         "gptme.server.api_v2.get_user_config_env_source", lambda _key: None
     )
+    monkeypatch.setattr("gptme.server.api_v2.get_default_model_source", lambda: None)
     monkeypatch.setattr(
         "gptme.server.api_v2.get_user_config_runtime_info",
         lambda: {

--- a/webui/src/components/ChatInput.tsx
+++ b/webui/src/components/ChatInput.tsx
@@ -10,6 +10,7 @@ import {
   File,
   ChevronDown,
   SlidersHorizontal,
+  Star,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
@@ -52,6 +53,7 @@ import { useWorkspaces } from '@/hooks/useWorkspaces';
 import { WorkspaceSelector } from '@/components/WorkspaceSelector';
 import type { WorkspaceProject, Agent } from '@/utils/workspaceUtils';
 import { useModels } from '@/hooks/useModels';
+import { useToast } from '@/components/ui/use-toast';
 import { useAgents } from '@/hooks/useAgents';
 import { useFileAutocomplete } from '@/hooks/useFileAutocomplete';
 import { FileAutocomplete } from '@/components/FileAutocomplete';
@@ -352,8 +354,51 @@ const ModelBadge: FC<{
             setOpen(false);
           }}
         />
+        <SetDefaultModelFooter model={model} />
       </PopoverContent>
     </Popover>
+  );
+};
+
+/** Footer in the model dropdown to make the current model the default for new chats. */
+const SetDefaultModelFooter: FC<{ model: string }> = ({ model }) => {
+  const { defaultModel, saveDefaultModel } = useModels();
+  const { toast } = useToast();
+  const [saving, setSaving] = useState(false);
+  const isDefault = defaultModel === model;
+
+  const handleSetDefault = async () => {
+    setSaving(true);
+    const { ok, restartRequired } = await saveDefaultModel(model);
+    setSaving(false);
+    if (ok) {
+      toast({
+        title: 'Default model updated',
+        description: restartRequired
+          ? 'Restart the gptme server for it to take full effect.'
+          : 'New chats will use this model.',
+      });
+    } else {
+      toast({ variant: 'destructive', title: 'Failed to set default model' });
+    }
+  };
+
+  return (
+    <div className="border-t p-1">
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        className="h-7 w-full justify-start text-xs font-normal"
+        disabled={isDefault || saving}
+        onClick={() => void handleSetDefault()}
+      >
+        <Star
+          className={`mr-2 h-3.5 w-3.5 ${isDefault ? 'fill-yellow-400 text-yellow-400' : ''}`}
+        />
+        {isDefault ? 'Default for new chats' : 'Set as default for new chats'}
+      </Button>
+    </div>
   );
 };
 

--- a/webui/src/components/ModelPicker.tsx
+++ b/webui/src/components/ModelPicker.tsx
@@ -27,9 +27,10 @@ import type { Control, FieldPath, FieldValues } from 'react-hook-form';
 const ModelItem: FC<{
   model: ModelInfo;
   isSelected: boolean;
-  isRecommended: boolean;
+  isFavorite: boolean;
   showProvider: boolean;
-}> = ({ model, isSelected, isRecommended, showProvider }) => (
+  onToggleFavorite: () => void;
+}> = ({ model, isSelected, isFavorite, showProvider, onToggleFavorite }) => (
   <div className="flex w-full items-center justify-between gap-2">
     <div className="flex min-w-0 flex-col">
       <div className="flex items-center gap-2">
@@ -41,9 +42,6 @@ const ModelItem: FC<{
             ? `${model.provider}/${model.model}`
             : model.model}
         </span>
-        {isRecommended && (
-          <Star className="h-3 w-3 flex-shrink-0 fill-yellow-400 text-yellow-400" />
-        )}
       </div>
       <div className="flex items-center gap-2 text-xs text-muted-foreground">
         {model.context > 0 && <span>{Math.round(model.context / 1000)}k ctx</span>}
@@ -51,44 +49,79 @@ const ModelItem: FC<{
         {model.supports_reasoning && <span>reasoning</span>}
       </div>
     </div>
-    {isSelected && <Check className="h-4 w-4 flex-shrink-0" />}
+    <div className="flex flex-shrink-0 items-center gap-1">
+      {isSelected && <Check className="h-4 w-4" />}
+      <button
+        type="button"
+        aria-label={isFavorite ? 'Remove from favorites' : 'Add to favorites'}
+        title={isFavorite ? 'Remove from favorites' : 'Add to favorites'}
+        className="rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
+        onClick={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          onToggleFavorite();
+        }}
+        onPointerDown={(e) => e.stopPropagation()}
+      >
+        <Star className={`h-3.5 w-3.5 ${isFavorite ? 'fill-yellow-400 text-yellow-400' : ''}`} />
+      </button>
+    </div>
   </div>
 );
 
 function useModelGroups() {
-  const { models, availableModels, recommendedModels } = useModels();
+  const { models, availableModels, recommendedModels, favorites, toggleFavorite } = useModels();
 
   const recommendedSet = useMemo(() => new Set(recommendedModels), [recommendedModels]);
+  const favoriteSet = useMemo(() => new Set(favorites), [favorites]);
 
-  const availableRecommended = useMemo(
+  const availableFavorites = useMemo(
     () =>
-      recommendedModels
+      favorites
         .filter((id) => availableModels.includes(id))
         .map((id) => models.find((m) => m.id === id)!)
         .filter(Boolean),
-    [recommendedModels, availableModels, models]
+    [favorites, availableModels, models]
+  );
+
+  // Favorites take precedence over the Recommended group to avoid duplicates.
+  const availableRecommended = useMemo(
+    () =>
+      recommendedModels
+        .filter((id) => availableModels.includes(id) && !favoriteSet.has(id))
+        .map((id) => models.find((m) => m.id === id)!)
+        .filter(Boolean),
+    [recommendedModels, availableModels, models, favoriteSet]
   );
 
   const providerGroups = useMemo(() => {
     const groups: Record<string, ModelInfo[]> = {};
     for (const model of models) {
-      if (recommendedSet.has(model.id)) continue;
+      if (recommendedSet.has(model.id) || favoriteSet.has(model.id)) continue;
       if (!groups[model.provider]) {
         groups[model.provider] = [];
       }
       groups[model.provider].push(model);
     }
     return Object.entries(groups).sort(([a], [b]) => a.localeCompare(b));
-  }, [models, recommendedSet]);
+  }, [models, recommendedSet, favoriteSet]);
 
-  return { models, availableRecommended, providerGroups, recommendedSet };
+  return {
+    models,
+    availableFavorites,
+    availableRecommended,
+    providerGroups,
+    favoriteSet,
+    toggleFavorite,
+  };
 }
 
 const ModelCommandList: FC<{
   value?: string;
   onSelect: (modelId: string) => void;
 }> = ({ value, onSelect }) => {
-  const { availableRecommended, providerGroups, recommendedSet } = useModelGroups();
+  const { availableFavorites, availableRecommended, providerGroups, favoriteSet, toggleFavorite } =
+    useModelGroups();
 
   // Substring filter instead of cmdk's default fuzzy match
   const filter = (value: string, search: string, keywords?: string[]) => {
@@ -97,29 +130,41 @@ const ModelCommandList: FC<{
     return terms.every((term) => haystack.includes(term)) ? 1 : 0;
   };
 
+  const renderItem = (model: ModelInfo, showProvider: boolean) => (
+    <CommandItem
+      key={model.id}
+      value={model.id}
+      keywords={[model.provider, model.model]}
+      onSelect={() => onSelect(model.id)}
+    >
+      <ModelItem
+        model={model}
+        isSelected={model.id === value}
+        isFavorite={favoriteSet.has(model.id)}
+        showProvider={showProvider}
+        onToggleFavorite={() => void toggleFavorite(model.id)}
+      />
+    </CommandItem>
+  );
+
   return (
     <Command className="rounded-lg" filter={filter}>
       <CommandInput placeholder="Search models..." />
-      <CommandList className="max-h-[350px]">
+      {/* stopPropagation lets the wheel scroll this list even when rendered
+          inside a Radix Dialog, whose react-remove-scroll otherwise eats the
+          wheel event on document. Harmless outside a dialog. */}
+      <CommandList className="max-h-[350px]" onWheel={(e) => e.stopPropagation()}>
         <CommandEmpty>No models found.</CommandEmpty>
+
+        {availableFavorites.length > 0 && (
+          <CommandGroup heading="Favorites">
+            {availableFavorites.map((model) => renderItem(model, true))}
+          </CommandGroup>
+        )}
 
         {availableRecommended.length > 0 && (
           <CommandGroup heading="Recommended">
-            {availableRecommended.map((model) => (
-              <CommandItem
-                key={model.id}
-                value={model.id}
-                keywords={[model.provider, model.model]}
-                onSelect={() => onSelect(model.id)}
-              >
-                <ModelItem
-                  model={model}
-                  isSelected={model.id === value}
-                  isRecommended
-                  showProvider
-                />
-              </CommandItem>
-            ))}
+            {availableRecommended.map((model) => renderItem(model, true))}
           </CommandGroup>
         )}
 
@@ -133,21 +178,7 @@ const ModelCommandList: FC<{
               </span>
             }
           >
-            {providerModels.map((model) => (
-              <CommandItem
-                key={model.id}
-                value={model.id}
-                keywords={[model.provider, model.model]}
-                onSelect={() => onSelect(model.id)}
-              >
-                <ModelItem
-                  model={model}
-                  isSelected={model.id === value}
-                  isRecommended={recommendedSet.has(model.id)}
-                  showProvider={false}
-                />
-              </CommandItem>
-            ))}
+            {providerModels.map((model) => renderItem(model, false))}
           </CommandGroup>
         ))}
       </CommandList>

--- a/webui/src/hooks/useModels.ts
+++ b/webui/src/hooks/useModels.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { use$ } from '@legendapp/state/react';
 import { useApi } from '@/contexts/ApiContext';
 import { buildModelsFetchError } from '@/utils/modelsError';
@@ -33,6 +33,17 @@ export function useModels() {
   const [favorites, setFavoritesState] = useState<string[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+
+  // Mirror favorites in a ref so rapid toggles read the latest list instead of
+  // a stale closure value (which could drop a favorite under quick clicks).
+  const favoritesRef = useRef<string[]>([]);
+  useEffect(() => {
+    favoritesRef.current = favorites;
+  }, [favorites]);
+  const applyFavorites = useCallback((next: string[]) => {
+    favoritesRef.current = next;
+    setFavoritesState(next);
+  }, []);
 
   useEffect(() => {
     if (!isConnected || isDemoMode()) {
@@ -91,8 +102,8 @@ export function useModels() {
   // Persist the favorites list. Optimistically updates local state and reverts on failure.
   const saveFavorites = useCallback(
     async (next: string[]): Promise<boolean> => {
-      const prev = favorites;
-      setFavoritesState(next);
+      const prev = favoritesRef.current;
+      applyFavorites(next);
       try {
         const response = await fetch(`${api.baseUrl}/api/v2/user/favorites`, {
           method: 'POST',
@@ -101,25 +112,25 @@ export function useModels() {
         });
         if (!response.ok) throw new Error(`HTTP ${response.status}`);
         const data = (await response.json()) as { favorites?: string[] };
-        if (data.favorites) setFavoritesState(data.favorites);
+        if (data.favorites) applyFavorites(data.favorites);
         return true;
       } catch (err) {
         console.error('Failed to save favorites:', err);
-        setFavoritesState(prev);
+        applyFavorites(prev);
         return false;
       }
     },
-    [api.baseUrl, authedHeaders, favorites]
+    [api.baseUrl, authedHeaders, applyFavorites]
   );
 
   const toggleFavorite = useCallback(
-    (modelId: string): Promise<boolean> =>
-      saveFavorites(
-        favorites.includes(modelId)
-          ? favorites.filter((id) => id !== modelId)
-          : [...favorites, modelId]
-      ),
-    [favorites, saveFavorites]
+    (modelId: string): Promise<boolean> => {
+      const current = favoritesRef.current;
+      return saveFavorites(
+        current.includes(modelId) ? current.filter((id) => id !== modelId) : [...current, modelId]
+      );
+    },
+    [saveFavorites]
   );
 
   // Persist the default model for new chats. Returns whether a server restart is required.

--- a/webui/src/hooks/useModels.ts
+++ b/webui/src/hooks/useModels.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { use$ } from '@legendapp/state/react';
 import { useApi } from '@/contexts/ApiContext';
 import { buildModelsFetchError } from '@/utils/modelsError';
@@ -21,6 +21,7 @@ export interface ModelsResponse {
   models: ModelInfo[];
   default: string | null;
   recommended: string[];
+  favorites?: string[];
 }
 
 export function useModels() {
@@ -29,6 +30,7 @@ export function useModels() {
   const [models, setModels] = useState<ModelInfo[]>([]);
   const [defaultModel, setDefaultModel] = useState<string | null>(null);
   const [recommendedModels, setRecommendedModels] = useState<string[]>([]);
+  const [favorites, setFavoritesState] = useState<string[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -64,12 +66,14 @@ export function useModels() {
         setModels(data.models);
         setDefaultModel(data.default || null);
         setRecommendedModels(data.recommended || []);
+        setFavoritesState(data.favorites || []);
       } catch (err) {
         console.error('Failed to fetch models:', err);
         setError(err instanceof Error ? err.message : 'Failed to fetch models');
         setModels([]);
         setDefaultModel(null);
         setRecommendedModels([]);
+        setFavoritesState([]);
       } finally {
         setIsLoading(false);
       }
@@ -77,6 +81,67 @@ export function useModels() {
 
     fetchModels();
   }, [api.baseUrl, api.authHeader, isConnected]);
+
+  const authedHeaders = useCallback(() => {
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    if (api.authHeader) headers.Authorization = api.authHeader;
+    return headers;
+  }, [api.authHeader]);
+
+  // Persist the favorites list. Optimistically updates local state and reverts on failure.
+  const saveFavorites = useCallback(
+    async (next: string[]): Promise<boolean> => {
+      const prev = favorites;
+      setFavoritesState(next);
+      try {
+        const response = await fetch(`${api.baseUrl}/api/v2/user/favorites`, {
+          method: 'POST',
+          headers: authedHeaders(),
+          body: JSON.stringify({ favorites: next }),
+        });
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        const data = (await response.json()) as { favorites?: string[] };
+        if (data.favorites) setFavoritesState(data.favorites);
+        return true;
+      } catch (err) {
+        console.error('Failed to save favorites:', err);
+        setFavoritesState(prev);
+        return false;
+      }
+    },
+    [api.baseUrl, authedHeaders, favorites]
+  );
+
+  const toggleFavorite = useCallback(
+    (modelId: string): Promise<boolean> =>
+      saveFavorites(
+        favorites.includes(modelId)
+          ? favorites.filter((id) => id !== modelId)
+          : [...favorites, modelId]
+      ),
+    [favorites, saveFavorites]
+  );
+
+  // Persist the default model for new chats. Returns whether a server restart is required.
+  const saveDefaultModel = useCallback(
+    async (modelId: string): Promise<{ ok: boolean; restartRequired: boolean }> => {
+      try {
+        const response = await fetch(`${api.baseUrl}/api/v2/user/default-model`, {
+          method: 'POST',
+          headers: authedHeaders(),
+          body: JSON.stringify({ model: modelId }),
+        });
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        const data = (await response.json()) as { restart_required?: boolean };
+        setDefaultModel(modelId);
+        return { ok: true, restartRequired: !!data.restart_required };
+      } catch (err) {
+        console.error('Failed to save default model:', err);
+        return { ok: false, restartRequired: false };
+      }
+    },
+    [api.baseUrl, authedHeaders]
+  );
 
   const availableModels = models.map((model) => model.id);
 
@@ -87,5 +152,9 @@ export function useModels() {
     isLoading,
     error,
     recommendedModels,
+    favorites,
+    saveFavorites,
+    toggleFavorite,
+    saveDefaultModel,
   };
 }


### PR DESCRIPTION
## Summary
Makes model selection in the webui less reliant on the static "Recommended" list and removes the need to hand-edit `config.toml` to change your default model.

- **`[models]` config section**: model preferences now live under `[models]` in the user config:
  - `[models].default` — a formal, discoverable alternative to the `MODEL` env var. Precedence: explicit per-chat model > `[models].default` > `MODEL` env (so existing setups keep working).
  - `[models].favorites` — user-curated favorite model ids. Validated server-side (provider/model shape, length, no control chars); invalid entries dropped.
  - Scoped to chat/LLM models (mirrors `MODEL`); other modalities would get their own scoped keys later.
- **Endpoints**: `GET /api/v2/models` returns `favorites` (filtered to available); `POST /api/v2/user/favorites` persists them; `POST /api/v2/user/default-model` now writes `[models].default`.
- **Model picker**: a "Favorites" group at the top plus an interactive ⭐ toggle on every row (favorites take precedence over Recommended, no dupes).
- **Set as default for new chats**: footer in the chat model dropdown.
- **Scroll-wheel fix**: model picker inside the Settings dialog (Radix Dialog's react-remove-scroll ate wheel events).

## Verification
- Backend exercised live: default + favorites persist to `[models]`, invalid favorites dropped, `GET /api/v2/models` filters to available, model-source reporting works.
- Config roundtrip + `pytest tests/test_config.py` (62) pass against the branch; OpenAPI generates + validates.
- Frontend typecheck clean; favorites/star-toggle/set-default verified in-browser end-to-end.

## Follow-ups (not in this PR)
- Restructure Settings → Servers into a cleaner subview.