### PR TITLE
feat(webui): toggle/stop TTS playback from the message button

### DIFF
--- a/webui/src/components/ChatMessage.tsx
+++ b/webui/src/components/ChatMessage.tsx
@@ -105,9 +105,9 @@ export const ChatMessage: FC<Props> = ({
   const { api, connectionConfig } = useApi();
   const { settings } = useSettings();
   // TTS playback state: which message is currently being spoken (if any).
-  const ttsKey = `${conversationId}:${messageIndex}`;
+  const ttsKey = messageIndex !== undefined ? `${conversationId}:${messageIndex}` : null;
   const speakingKey = useSyncExternalStore(subscribeSpeaking, getSpeakingKey);
-  const isSpeakingThis = speakingKey === ttsKey;
+  const isSpeakingThis = ttsKey !== null && speakingKey === ttsKey;
   // Use observables (not useState) because these are read inside <Memo>
   const isEditing$ = useObservable(false);
   const editContent$ = useObservable('');
@@ -570,7 +570,7 @@ export const ChatMessage: FC<Props> = ({
                           onClick={() =>
                             isSpeakingThis
                               ? stopSpeaking()
-                              : speakTextNow(message$.content.get() ?? '', ttsKey)
+                              : speakTextNow(message$.content.get() ?? '', ttsKey ?? undefined)
                           }
                           className="h-7 w-7 p-0"
                           aria-label={isSpeakingThis ? 'Stop reading' : 'Read aloud'}

--- a/webui/src/components/ChatMessage.tsx
+++ b/webui/src/components/ChatMessage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState, type FC } from 'react';
+import { useCallback, useRef, useState, useSyncExternalStore, type FC } from 'react';
 import type { Message, StreamingMessage } from '@/types/conversation';
 import { MessageAvatar } from './MessageAvatar';
 import { useMessageChainType } from '@/utils/messageUtils';
@@ -23,13 +23,20 @@ import {
   FileText,
   FolderOpen,
   Volume2,
+  Square,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
 import { ChatInput } from '@/components/ChatInput';
 import { workspaceNavigateTo$ } from '@/stores/workspaceExplorer';
-import { speakTextNow, isSpeechSupported } from '@/utils/tts';
+import {
+  speakTextNow,
+  isSpeechSupported,
+  subscribeSpeaking,
+  getSpeakingKey,
+  stopSpeaking,
+} from '@/utils/tts';
 import { rightSidebarActiveTab$, rightSidebarVisible$ } from '@/stores/sidebar';
 
 function formatTimestamp(timestamp: string): { short: string; full: string } {
@@ -97,6 +104,10 @@ export const ChatMessage: FC<Props> = ({
 }) => {
   const { api, connectionConfig } = useApi();
   const { settings } = useSettings();
+  // TTS playback state: which message is currently being spoken (if any).
+  const ttsKey = `${conversationId}:${messageIndex}`;
+  const speakingKey = useSyncExternalStore(subscribeSpeaking, getSpeakingKey);
+  const isSpeakingThis = speakingKey === ttsKey;
   // Use observables (not useState) because these are read inside <Memo>
   const isEditing$ = useObservable(false);
   const editContent$ = useObservable('');
@@ -556,12 +567,16 @@ export const ChatMessage: FC<Props> = ({
                         <Button
                           variant="ghost"
                           size="sm"
-                          onClick={() => speakTextNow(message$.content.get() ?? '')}
+                          onClick={() =>
+                            isSpeakingThis
+                              ? stopSpeaking()
+                              : speakTextNow(message$.content.get() ?? '', ttsKey)
+                          }
                           className="h-7 w-7 p-0"
-                          aria-label="Read aloud"
-                          title="Read aloud"
+                          aria-label={isSpeakingThis ? 'Stop reading' : 'Read aloud'}
+                          title={isSpeakingThis ? 'Stop reading' : 'Read aloud'}
                         >
-                          <Volume2 size={14} />
+                          {isSpeakingThis ? <Square size={14} /> : <Volume2 size={14} />}
                         </Button>
                       )}
                       <Button

--- a/webui/src/utils/tts.ts
+++ b/webui/src/utils/tts.ts
@@ -164,6 +164,9 @@ async function speak(rawText: string, key: string): Promise<void> {
   if (!spoken) return;
 
   stopSpeaking();
+  // Mark as playing immediately so the button shows a stop/loading state during
+  // the network round-trip (playBlob/utterance re-affirm the same key on start).
+  setSpeakingKey(key);
 
   // 1. Try the same-origin /api/v2/audio/speech endpoint first.
   try {
@@ -189,12 +192,21 @@ async function speak(rawText: string, key: string): Promise<void> {
   }
 
   // 3. Fall back to the browser's built-in speechSynthesis.
-  if (!window.speechSynthesis) return;
+  if (!window.speechSynthesis) {
+    // Nothing could play — clear the provisional speaking state.
+    if (getSpeakingKey() === key) setSpeakingKey(null);
+    return;
+  }
   const utterance = new SpeechSynthesisUtterance(spoken);
   utterance.rate = 1.1;
-  utterance.onend = () => setSpeakingKey(null);
-  utterance.onerror = () => setSpeakingKey(null);
-  setSpeakingKey(key);
+  // Guard against a previous utterance's late onend/onerror (fired after a new
+  // speak() already set its key) wiping the newer speaking state.
+  utterance.onend = () => {
+    if (getSpeakingKey() === key) setSpeakingKey(null);
+  };
+  utterance.onerror = () => {
+    if (getSpeakingKey() === key) setSpeakingKey(null);
+  };
   window.speechSynthesis.speak(utterance);
 }
 

--- a/webui/src/utils/tts.ts
+++ b/webui/src/utils/tts.ts
@@ -14,6 +14,28 @@ let currentAudio: HTMLAudioElement | null = null;
 let currentFetchController: AbortController | null = null;
 const LOCAL_TTS_NOT_CONFIGURED = 'tts-local-not-configured';
 
+// Which logical item (e.g. a message key) is currently being spoken, so the UI
+// can show a stop/playing state. null = nothing playing.
+let speakingKey: string | null = null;
+const speakingListeners = new Set<() => void>();
+
+function setSpeakingKey(key: string | null): void {
+  if (speakingKey === key) return;
+  speakingKey = key;
+  for (const listener of speakingListeners) listener();
+}
+
+/** Subscribe to speaking-state changes (for useSyncExternalStore). */
+export function subscribeSpeaking(listener: () => void): () => void {
+  speakingListeners.add(listener);
+  return () => speakingListeners.delete(listener);
+}
+
+/** Key of the item currently being spoken, or null. */
+export function getSpeakingKey(): string | null {
+  return speakingKey;
+}
+
 function getSettings(): { ttsEnabled: boolean; ttsServerUrl: string } {
   try {
     const saved = localStorage.getItem('gptme-settings');
@@ -69,8 +91,30 @@ async function isLocalTtsNotConfigured(response: Response): Promise<boolean> {
   }
 }
 
+/** Play an audio blob, wiring up cleanup + speaking-state clearing. */
+function playBlob(blob: Blob, key: string): void {
+  const objectUrl = URL.createObjectURL(blob);
+  if (currentAudio) {
+    currentAudio.pause();
+    URL.revokeObjectURL(currentAudio.src);
+  }
+  const audio = new Audio(objectUrl);
+  currentAudio = audio;
+  const cleanup = () => {
+    URL.revokeObjectURL(objectUrl);
+    if (currentAudio === audio) {
+      currentAudio = null;
+      setSpeakingKey(null);
+    }
+  };
+  audio.onended = cleanup;
+  audio.onerror = cleanup;
+  setSpeakingKey(key);
+  void audio.play().catch(cleanup);
+}
+
 /** POST text to the gptme server's built-in /api/v2/audio/speech endpoint. */
-async function speakViaLocalEndpoint(text: string): Promise<void> {
+async function speakViaLocalEndpoint(text: string, key: string): Promise<void> {
   const controller = new AbortController();
   currentFetchController = controller;
   try {
@@ -87,24 +131,8 @@ async function speakViaLocalEndpoint(text: string): Promise<void> {
       throw new Error(`TTS endpoint error: ${response.status}`);
     }
     const blob = await response.blob();
-    const objectUrl = URL.createObjectURL(blob);
-
-    if (controller.signal.aborted) {
-      URL.revokeObjectURL(objectUrl);
-      return;
-    }
-
-    if (currentAudio) {
-      currentAudio.pause();
-      URL.revokeObjectURL(currentAudio.src);
-    }
-    const audio = new Audio(objectUrl);
-    currentAudio = audio;
-    audio.onended = () => {
-      URL.revokeObjectURL(objectUrl);
-      if (currentAudio === audio) currentAudio = null;
-    };
-    await audio.play();
+    if (controller.signal.aborted) return;
+    playBlob(blob, key);
   } finally {
     if (currentFetchController === controller) {
       currentFetchController = null;
@@ -112,7 +140,7 @@ async function speakViaLocalEndpoint(text: string): Promise<void> {
   }
 }
 
-async function speakViaExternalServer(text: string, serverUrl: string): Promise<void> {
+async function speakViaExternalServer(text: string, serverUrl: string, key: string): Promise<void> {
   const url = `${serverUrl.replace(/\/$/, '')}/tts?${new URLSearchParams({ text })}`;
   const controller = new AbortController();
   currentFetchController = controller;
@@ -120,24 +148,8 @@ async function speakViaExternalServer(text: string, serverUrl: string): Promise<
     const response = await fetch(url, { signal: controller.signal });
     if (!response.ok) throw new Error(`TTS server error: ${response.status}`);
     const blob = await response.blob();
-    const objectUrl = URL.createObjectURL(blob);
-
-    if (controller.signal.aborted) {
-      URL.revokeObjectURL(objectUrl);
-      return;
-    }
-
-    if (currentAudio) {
-      currentAudio.pause();
-      URL.revokeObjectURL(currentAudio.src);
-    }
-    const audio = new Audio(objectUrl);
-    currentAudio = audio;
-    audio.onended = () => {
-      URL.revokeObjectURL(objectUrl);
-      if (currentAudio === audio) currentAudio = null;
-    };
-    await audio.play();
+    if (controller.signal.aborted) return;
+    playBlob(blob, key);
   } finally {
     if (currentFetchController === controller) {
       currentFetchController = null;
@@ -145,7 +157,9 @@ async function speakViaExternalServer(text: string, serverUrl: string): Promise<
   }
 }
 
-async function speak(rawText: string): Promise<void> {
+const DEFAULT_SPEAK_KEY = '__tts__';
+
+async function speak(rawText: string, key: string): Promise<void> {
   const spoken = toSpokenText(rawText);
   if (!spoken) return;
 
@@ -153,7 +167,7 @@ async function speak(rawText: string): Promise<void> {
 
   // 1. Try the same-origin /api/v2/audio/speech endpoint first.
   try {
-    await speakViaLocalEndpoint(spoken);
+    await speakViaLocalEndpoint(spoken, key);
     return;
   } catch (err) {
     if (isAbortError(err)) return;
@@ -166,7 +180,7 @@ async function speak(rawText: string): Promise<void> {
   const { ttsServerUrl } = getSettings();
   if (ttsServerUrl) {
     try {
-      await speakViaExternalServer(spoken, ttsServerUrl);
+      await speakViaExternalServer(spoken, ttsServerUrl, key);
       return;
     } catch (err) {
       if (isAbortError(err)) return;
@@ -178,19 +192,22 @@ async function speak(rawText: string): Promise<void> {
   if (!window.speechSynthesis) return;
   const utterance = new SpeechSynthesisUtterance(spoken);
   utterance.rate = 1.1;
+  utterance.onend = () => setSpeakingKey(null);
+  utterance.onerror = () => setSpeakingKey(null);
+  setSpeakingKey(key);
   window.speechSynthesis.speak(utterance);
 }
 
 /** Speak text if the global TTS toggle is enabled (auto-play on new messages). */
-export function speakText(rawText: string): void {
+export function speakText(rawText: string, key: string = DEFAULT_SPEAK_KEY): void {
   const { ttsEnabled } = getSettings();
   if (!ttsEnabled) return;
-  void speak(rawText);
+  void speak(rawText, key);
 }
 
 /** Speak text immediately, regardless of the global TTS toggle (per-message button). */
-export function speakTextNow(rawText: string): void {
-  void speak(rawText);
+export function speakTextNow(rawText: string, key: string = DEFAULT_SPEAK_KEY): void {
+  void speak(rawText, key);
 }
 
 export function stopSpeaking(): void {
@@ -206,6 +223,7 @@ export function stopSpeaking(): void {
   if (window.speechSynthesis) {
     window.speechSynthesis.cancel();
   }
+  setSpeakingKey(null);
 }
 
 export function isSpeechSupported(): boolean {


### PR DESCRIPTION
## Summary
The per-message "Read aloud" button always restarted playback — there was no way to stop/pause. Now it toggles.

- `tts.ts` exposes a subscribable "speaking key" (`subscribeSpeaking`/`getSpeakingKey`) tracking which item is currently being spoken; cleared on end/error/stop. Refactored the two audio paths through a shared `playBlob` helper.
- The ChatMessage button toggles: click to play (passing the message key), click again to `stopSpeaking()`. Icon reflects state (Volume2 ↔ Square) and aria-label/title update accordingly.

## Test plan
- [x] typecheck clean; `jest tts.test.ts` passes
- [ ] Click read-aloud on an assistant message → plays; icon becomes a stop square
- [ ] Click again → stops immediately
- [ ] Starting playback on another message stops the first