### PR TITLE
fix(webui): sync model selector when switching conversations

### DIFF
--- a/webui/src/hooks/__tests__/useConversation.test.tsx
+++ b/webui/src/hooks/__tests__/useConversation.test.tsx
@@ -67,7 +67,7 @@ describe('useConversation', () => {
           step,
           closeEventStream,
           getConversation: jest.fn(),
-          getChatConfig: jest.fn(),
+          getChatConfig: jest.fn().mockResolvedValue(null),
         }) as any,
       isConnected$: observable(true),
     } as any);

--- a/webui/src/hooks/useConversation.ts
+++ b/webui/src/hooks/useConversation.ts
@@ -4,6 +4,7 @@ import { useToast } from '@/components/ui/use-toast';
 import type { Message, StreamingMessage } from '@/types/conversation';
 import type { ChatOptions } from '@/components/ChatInput';
 import { demoConversations, getDemoMessages } from '@/democonversations';
+import { isDemoMode } from '@/utils/connectionConfig';
 import { use$ } from '@legendapp/state/react';
 import {
   conversations$,
@@ -60,6 +61,32 @@ export function useConversation(conversationId: string, serverId?: string) {
       initConversation(conversationId);
     }
   }, [conversationId, conversation$]);
+
+  // Ensure the conversation's chat config is loaded whenever it's missing.
+  // The main load+connect effect below early-returns for already-connected
+  // conversations, so without this, switching to a previously-opened
+  // conversation leaves chatConfig (and thus the model selector) stale until
+  // the user opens Chat Settings.
+  useEffect(() => {
+    if (!isConnected || isDemoMode()) return;
+    if (demoConversations.some((c) => c.id === conversationId)) return;
+    if (conversation$?.chatConfig.peek()) return;
+    let cancelled = false;
+    api
+      .getChatConfig(conversationId)
+      .then((chatConfig) => {
+        if (!cancelled) updateConversation(conversationId, { chatConfig });
+      })
+      .catch((error) => {
+        console.warn(
+          `[useConversation] Failed to preload chat config for ${conversationId}:`,
+          error
+        );
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [conversationId, isConnected, api, conversation$]);
 
   // Load conversation data and connect to event stream
   useEffect(() => {

--- a/webui/src/hooks/useConversation.ts
+++ b/webui/src/hooks/useConversation.ts
@@ -70,6 +70,10 @@ export function useConversation(conversationId: string, serverId?: string) {
   useEffect(() => {
     if (!isConnected || isDemoMode()) return;
     if (demoConversations.some((c) => c.id === conversationId)) return;
+    // Only handle the already-connected case; the load+connect effect below
+    // fetches chatConfig for not-yet-connected conversations, so skipping here
+    // avoids a duplicate request on initial open.
+    if (!conversation$?.isConnected.peek()) return;
     if (conversation$?.chatConfig.peek()) return;
     let cancelled = false;
     api


### PR DESCRIPTION
## Summary
When switching to (or creating) a conversation whose model differs from the default, the chat input's model selector kept showing the default until you opened Chat Settings or refreshed.

**Root cause:** the selector reads `conversation$.chatConfig.chat.model`, but `useConversation`'s load+connect effect only fetched `chatConfig` for conversations that weren't already connected. Switching to an already-connected conversation skipped the fetch, leaving `chatConfig` (and the model) stale. Opening Chat Settings fetched it as a side effect, which is why that "fixed" it.

**Fix:** a small dedicated effect fetches `chatConfig` whenever it's missing for the selected conversation (independent of the connect guard), so the selector reflects the conversation's configured model immediately.

## Test plan
- [x] typecheck clean
- [ ] Create a conversation with a non-default model → selector shows that model without opening Chat Settings
- [ ] Switch between conversations with different models → selector updates each time