### PR TITLE
feat(webui): add /settings route with full-page settings view

### DIFF
--- a/webui/public/_redirects
+++ b/webui/public/_redirects
@@ -14,4 +14,5 @@
 /external-sessions / 200
 /admin / 200
 /health / 200
+/settings / 200
 /workspace/* / 200

--- a/webui/src/App.tsx
+++ b/webui/src/App.tsx
@@ -24,6 +24,7 @@ const History = lazy(() => import('./pages/History'));
 const ExternalSessions = lazy(() => import('./pages/ExternalSessions'));
 const Admin = lazy(() => import('./pages/Admin'));
 const Health = lazy(() => import('./pages/Health'));
+const SettingsPage = lazy(() => import('./pages/SettingsPage'));
 const NotFound = lazy(() => import('./pages/NotFound'));
 
 const queryClient = new QueryClient({
@@ -90,6 +91,7 @@ const App: FC = () => {
                         <Route path={appRoutes.externalSessions} element={<ExternalSessions />} />
                         <Route path={appRoutes.admin} element={<Admin />} />
                         <Route path={appRoutes.health} element={<Health />} />
+                        <Route path={appRoutes.settings} element={<SettingsPage />} />
                         <Route path={appRoutes.workspace} element={<Workspace />} />
                         <Route path="*" element={<NotFound />} />
                       </Routes>

--- a/webui/src/appRoutes.ts
+++ b/webui/src/appRoutes.ts
@@ -11,6 +11,7 @@ export const appRoutes = {
   admin: '/admin',
   health: '/health',
   workspace: '/workspace/:id',
+  settings: '/settings',
 } as const;
 
 export const cloudflareSpaRedirectRules = [
@@ -24,5 +25,6 @@ export const cloudflareSpaRedirectRules = [
   `${appRoutes.externalSessions} / 200`,
   `${appRoutes.admin} / 200`,
   `${appRoutes.health} / 200`,
+  `${appRoutes.settings} / 200`,
   `${appRoutes.workspace.replace(/\/:[^/]+$/, '/*')} / 200`,
 ] as const;

--- a/webui/src/components/CommandPalette.tsx
+++ b/webui/src/components/CommandPalette.tsx
@@ -30,7 +30,6 @@ import {
 } from '@/utils/exportConversation';
 import { chatRoute } from '@/utils/routes';
 import { toast } from 'sonner';
-import { settingsModal$ } from '@/stores/settingsModal';
 
 interface CommandAction {
   id: string;
@@ -184,7 +183,7 @@ export function CommandPalette() {
         keywords: ['settings', 'preferences', 'config'],
         action: () => {
           setOpen(false);
-          settingsModal$.open.set(true);
+          navigate('/settings');
         },
         group: 'Navigation',
       },

--- a/webui/src/components/SettingsContent.tsx
+++ b/webui/src/components/SettingsContent.tsx
@@ -1,0 +1,486 @@
+import { useState, useEffect } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+import { Separator } from '@/components/ui/separator';
+import { Volume2, Palette, Info, FileText, ExternalLink, Server, Rocket } from 'lucide-react';
+import { useSettings } from '@/contexts/SettingsContext';
+import { useTheme } from 'next-themes';
+import { cn } from '@/lib/utils';
+import { ServerConfiguration } from '@/components/settings/ServerConfiguration';
+import { DeveloperDeploy } from '@/components/settings/DeveloperDeploy';
+import { type SettingsCategory } from '@/stores/settingsModal';
+import { setupWizard$ } from '@/stores/setupWizard';
+import { getPrimaryClient } from '@/stores/serverClients';
+import { isSpeechSupported } from '@/utils/tts';
+
+export interface SettingsContentProps {
+  activeCategory: SettingsCategory;
+  onCategoryChange: (category: SettingsCategory) => void;
+  /** Called when the settings view should close (no-op in full-page mode). */
+  onClose?: () => void;
+}
+
+const categories = [
+  {
+    id: 'servers' as const,
+    label: 'Servers',
+    icon: Server,
+    description: 'Manage server connections',
+  },
+  {
+    id: 'appearance' as const,
+    label: 'Appearance',
+    icon: Palette,
+    description: 'Theme and visual preferences',
+  },
+  {
+    id: 'audio' as const,
+    label: 'Audio',
+    icon: Volume2,
+    description: 'Sound and notification settings',
+  },
+  {
+    id: 'content' as const,
+    label: 'Content',
+    icon: FileText,
+    description: 'Message and code display options',
+  },
+  ...(import.meta.env.DEV || import.meta.env.VITE_ENABLE_DEV_TOOLS === 'true'
+    ? [
+        {
+          id: 'developer' as const,
+          label: 'Developer',
+          icon: Rocket,
+          description: 'Deploy and debugging actions',
+        },
+      ]
+    : []),
+  {
+    id: 'about' as const,
+    label: 'About',
+    icon: Info,
+    description: 'Version info and links',
+  },
+];
+
+export function SettingsContent({
+  activeCategory,
+  onCategoryChange,
+  onClose,
+}: SettingsContentProps) {
+  const { settings, updateSettings, resetSettings } = useSettings();
+  const { theme, setTheme } = useTheme();
+  const [serverVersion, setServerVersion] = useState<string | null>(null);
+
+  // Fetch server version when the 'about' tab becomes active
+  useEffect(() => {
+    if (activeCategory !== 'about') return;
+    const client = getPrimaryClient();
+    if (!client) return;
+    client
+      .getServerInfo()
+      .then((info) => setServerVersion(info.version ?? null))
+      .catch(() => setServerVersion(null));
+  }, [activeCategory]);
+
+  const renderCategoryContent = () => {
+    switch (activeCategory) {
+      case 'servers':
+        return <ServerConfiguration />;
+
+      case 'appearance':
+        return (
+          <div className="space-y-6">
+            <div>
+              <h3 className="mb-1 text-lg font-medium">Appearance</h3>
+              <p className="mb-4 text-sm text-muted-foreground">
+                Customize the visual appearance of the application
+              </p>
+            </div>
+
+            <div className="space-y-3">
+              <Label className="text-sm text-muted-foreground">Theme</Label>
+              <div className="flex items-center space-x-1 rounded-md bg-muted/50 p-1">
+                {[
+                  { value: 'light', label: 'Light' },
+                  { value: 'dark', label: 'Dark' },
+                  { value: 'system', label: 'System' },
+                ].map((option) => {
+                  const isActive = theme === option.value;
+                  return (
+                    <Button
+                      key={option.value}
+                      variant={isActive ? 'secondary' : 'ghost'}
+                      size="sm"
+                      className={`flex-1 text-sm ${
+                        isActive ? 'bg-background shadow-sm' : 'hover:bg-background/60'
+                      }`}
+                      onClick={() => setTheme(option.value as 'light' | 'dark' | 'system')}
+                    >
+                      {option.label}
+                    </Button>
+                  );
+                })}
+              </div>
+            </div>
+
+            <Separator />
+
+            <div className="space-y-3">
+              <Label className="text-sm text-muted-foreground">Welcome Background</Label>
+              <p className="text-xs text-muted-foreground">
+                Image URL or CSS gradient for the new-chat view. The card gets a frosted glass
+                effect when a background is set.
+              </p>
+              <input
+                type="text"
+                value={settings.welcomeBackground}
+                onChange={(e) => updateSettings({ welcomeBackground: e.target.value })}
+                placeholder="e.g. linear-gradient(135deg, #667eea 0%, #764ba2 100%)"
+                className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm placeholder:text-muted-foreground/50 focus:outline-none focus:ring-1 focus:ring-ring"
+              />
+              <div className="flex flex-wrap gap-2">
+                {[
+                  { label: 'Sunset', value: 'linear-gradient(135deg, #f093fb 0%, #f5576c 100%)' },
+                  {
+                    label: 'Ocean',
+                    value: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+                  },
+                  {
+                    label: 'Forest',
+                    value: 'linear-gradient(135deg, #11998e 0%, #38ef7d 100%)',
+                  },
+                  {
+                    label: 'Night',
+                    value: 'linear-gradient(135deg, #0c0c1d 0%, #1a1a3e 50%, #2d1b69 100%)',
+                  },
+                ].map((preset) => (
+                  <Button
+                    key={preset.label}
+                    variant="outline"
+                    size="sm"
+                    className="text-xs"
+                    onClick={() => updateSettings({ welcomeBackground: preset.value })}
+                  >
+                    {preset.label}
+                  </Button>
+                ))}
+                {settings.welcomeBackground && (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="text-xs text-muted-foreground"
+                    onClick={() => updateSettings({ welcomeBackground: '' })}
+                  >
+                    Clear
+                  </Button>
+                )}
+              </div>
+            </div>
+          </div>
+        );
+
+      case 'audio':
+        return (
+          <div className="space-y-6">
+            <div>
+              <h3 className="mb-1 text-lg font-medium">Audio</h3>
+              <p className="mb-4 text-sm text-muted-foreground">
+                Configure sound and notification preferences
+              </p>
+            </div>
+
+            <div className="flex items-center justify-between">
+              <div className="space-y-0.5">
+                <Label htmlFor="chime-toggle" className="text-sm">
+                  Completion chime
+                </Label>
+                <p className="text-xs text-muted-foreground">
+                  Play sound when agent completes tasks
+                </p>
+              </div>
+              <Switch
+                id="chime-toggle"
+                checked={settings.chimeEnabled}
+                onCheckedChange={(checked) => updateSettings({ chimeEnabled: checked })}
+              />
+            </div>
+
+            <div className="flex items-center justify-between">
+              <div className="space-y-0.5">
+                <Label htmlFor="tts-toggle" className="text-sm">
+                  Read responses aloud
+                </Label>
+                <p className="text-xs text-muted-foreground">
+                  Speak assistant messages aloud (uses gptme-tts server if configured, otherwise
+                  browser Web Speech API)
+                </p>
+              </div>
+              <Switch
+                id="tts-toggle"
+                checked={settings.ttsEnabled}
+                disabled={!isSpeechSupported()}
+                onCheckedChange={(checked) => updateSettings({ ttsEnabled: checked })}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="tts-server-url" className="text-sm">
+                TTS server URL
+              </Label>
+              <p className="text-xs text-muted-foreground">
+                HTTP base URL of a running <code className="rounded bg-muted px-1">gptme-tts</code>{' '}
+                server, e.g. <code className="rounded bg-muted px-1">http://localhost:5701</code>.
+                Leave empty to use browser TTS.
+              </p>
+              <Input
+                id="tts-server-url"
+                type="text"
+                placeholder="http://localhost:5701"
+                value={settings.ttsServerUrl}
+                onChange={(e) => updateSettings({ ttsServerUrl: e.target.value.trim() })}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="voice-server-url" className="text-sm">
+                Voice server URL
+              </Label>
+              <p className="text-xs text-muted-foreground">
+                WebSocket URL of a running gptme-voice-server instance, e.g.{' '}
+                <code className="rounded bg-muted px-1">ws://localhost:5700/voice</code>. Leave
+                empty to hide the voice button.
+              </p>
+              <Input
+                id="voice-server-url"
+                type="text"
+                placeholder="ws://localhost:5700/voice"
+                value={settings.voiceServerUrl}
+                onChange={(e) => updateSettings({ voiceServerUrl: e.target.value.trim() })}
+              />
+            </div>
+          </div>
+        );
+
+      case 'content':
+        return (
+          <div className="space-y-6">
+            <div>
+              <h3 className="mb-1 text-lg font-medium">Content</h3>
+              <p className="mb-4 text-sm text-muted-foreground">
+                Control how messages and code are displayed
+              </p>
+            </div>
+
+            <div className="flex items-center justify-between">
+              <div className="space-y-0.5">
+                <Label htmlFor="blocks-toggle" className="text-sm">
+                  Code blocks open by default
+                </Label>
+                <p className="text-xs text-muted-foreground">
+                  Whether code blocks are expanded when first shown
+                </p>
+              </div>
+              <Switch
+                id="blocks-toggle"
+                checked={settings.blocksDefaultOpen}
+                onCheckedChange={(checked) => updateSettings({ blocksDefaultOpen: checked })}
+              />
+            </div>
+
+            <Separator />
+
+            <div className="space-y-4">
+              <h4 className="text-sm font-medium">Developer Options</h4>
+
+              <div className="flex items-center justify-between">
+                <div className="space-y-0.5">
+                  <Label htmlFor="hidden-toggle" className="text-sm">
+                    Show hidden messages
+                  </Label>
+                  <p className="text-xs text-muted-foreground">
+                    Display messages marked as hidden (e.g., lessons, context)
+                  </p>
+                </div>
+                <Switch
+                  id="hidden-toggle"
+                  checked={settings.showHiddenMessages}
+                  onCheckedChange={(checked) => updateSettings({ showHiddenMessages: checked })}
+                />
+              </div>
+
+              <div className="flex items-center justify-between">
+                <div className="space-y-0.5">
+                  <Label htmlFor="initial-system-toggle" className="text-sm">
+                    Show initial system messages
+                  </Label>
+                  <p className="text-xs text-muted-foreground">
+                    Display the initial system prompt at the start of conversations
+                  </p>
+                </div>
+                <Switch
+                  id="initial-system-toggle"
+                  checked={settings.showInitialSystem}
+                  onCheckedChange={(checked) => updateSettings({ showInitialSystem: checked })}
+                />
+              </div>
+            </div>
+          </div>
+        );
+
+      case 'developer':
+        return <DeveloperDeploy />;
+
+      case 'about':
+        return (
+          <div className="space-y-6">
+            <div>
+              <h3 className="mb-1 text-lg font-medium">About</h3>
+              <p className="mb-4 text-sm text-muted-foreground">
+                Information about gptme and this web interface
+              </p>
+            </div>
+
+            <div className="space-y-4">
+              {serverVersion && (
+                <div className="space-y-1">
+                  <h4 className="text-sm font-medium">Version</h4>
+                  <p className="font-mono text-sm text-muted-foreground">gptme {serverVersion}</p>
+                </div>
+              )}
+
+              <div className="space-y-3">
+                <h4 className="text-sm font-medium">Related Projects</h4>
+                <div className="flex flex-col space-y-2">
+                  <a
+                    href="https://github.com/gptme/gptme"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex items-center text-sm text-muted-foreground transition-colors hover:text-foreground"
+                  >
+                    <ExternalLink className="mr-2 h-3 w-3" />
+                    gptme - AI agent framework
+                  </a>
+                  <a
+                    href="https://github.com/gptme/gptme/tree/master/webui"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex items-center text-sm text-muted-foreground transition-colors hover:text-foreground"
+                  >
+                    <ExternalLink className="mr-2 h-3 w-3" />
+                    gptme-webui - Web interface
+                  </a>
+                </div>
+              </div>
+
+              <Separator />
+
+              <div className="space-y-2">
+                <h4 className="text-sm font-medium">Setup Wizard</h4>
+                <div className="flex items-center justify-between">
+                  <p className="text-xs text-muted-foreground">
+                    Re-run the setup wizard to change server or sign in to gptme.ai
+                  </p>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => {
+                      onClose?.();
+                      setupWizard$.step.set('welcome');
+                      setupWizard$.open.set(true);
+                    }}
+                  >
+                    Re-run Setup
+                  </Button>
+                </div>
+              </div>
+
+              <Separator />
+
+              <div className="space-y-2">
+                <h4 className="text-sm font-medium">Reset Settings</h4>
+                <div className="flex items-center justify-between">
+                  <p className="text-xs text-muted-foreground">
+                    Restore all settings to their default values
+                  </p>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => {
+                      resetSettings();
+                      setTheme('system');
+                      onClose?.();
+                    }}
+                  >
+                    Reset All
+                  </Button>
+                </div>
+              </div>
+            </div>
+          </div>
+        );
+
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <div className="flex min-h-0 min-w-0 flex-1 flex-col sm:flex-row">
+      {/* Mobile: horizontal tab strip */}
+      <div className="flex overflow-x-auto border-b bg-muted/20 p-2 sm:hidden">
+        {categories.map((category) => {
+          const Icon = category.icon;
+          const isActive = activeCategory === category.id;
+          return (
+            <button
+              key={category.id}
+              onClick={() => onCategoryChange(category.id)}
+              className={cn(
+                'flex shrink-0 flex-col items-center gap-1 rounded-md px-3 py-2 text-xs transition-colors',
+                isActive ? 'border bg-background shadow-sm' : 'hover:bg-muted/60'
+              )}
+            >
+              <Icon className="h-4 w-4" />
+              <span className="font-medium">{category.label}</span>
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Desktop: vertical sidebar */}
+      <div className="hidden w-48 overflow-y-auto border-r bg-muted/20 p-4 sm:block">
+        <nav className="space-y-1">
+          {categories.map((category) => {
+            const Icon = category.icon;
+            const isActive = activeCategory === category.id;
+
+            return (
+              <button
+                key={category.id}
+                onClick={() => onCategoryChange(category.id)}
+                className={cn(
+                  'flex w-full items-start gap-3 rounded-md px-3 py-2 text-sm transition-colors',
+                  isActive ? 'border bg-background shadow-sm' : 'hover:bg-muted/60'
+                )}
+              >
+                <Icon className="mt-0.5 h-4 w-4 shrink-0" />
+                <div className="text-left">
+                  <div className="font-medium">{category.label}</div>
+                  <div className="text-xs text-muted-foreground">{category.description}</div>
+                </div>
+              </button>
+            );
+          })}
+        </nav>
+      </div>
+
+      {/* Content */}
+      <div className="min-h-0 min-w-0 flex-1 overflow-y-auto p-4 sm:p-6">
+        {renderCategoryContent()}
+      </div>
+    </div>
+  );
+}

--- a/webui/src/components/SettingsModal.tsx
+++ b/webui/src/components/SettingsModal.tsx
@@ -31,6 +31,9 @@ export const SettingsModal = forwardRef<HTMLButtonElement, SettingsModalProps>(
         if (externalRequest.category) {
           setActiveCategory(externalRequest.category);
         }
+        // Reset immediately to prevent auto-reopen on component remount
+        // when user navigates away while the modal is open
+        settingsModal$.open.set(false);
       }
     }, [externalRequest.open, externalRequest.category]);
 

--- a/webui/src/components/SettingsModal.tsx
+++ b/webui/src/components/SettingsModal.tsx
@@ -7,31 +7,10 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '@/components/ui/dialog';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { Switch } from '@/components/ui/switch';
-import { Separator } from '@/components/ui/separator';
-import {
-  Settings,
-  Volume2,
-  Palette,
-  Info,
-  FileText,
-  ExternalLink,
-  Server,
-  Rocket,
-} from 'lucide-react';
-import { useSettings } from '@/contexts/SettingsContext';
-import { useTheme } from 'next-themes';
-import { cn } from '@/lib/utils';
-import { ServerConfiguration } from '@/components/settings/ServerConfiguration';
-import { DeveloperDeploy } from '@/components/settings/DeveloperDeploy';
+import { Settings } from 'lucide-react';
 import { use$ } from '@legendapp/state/react';
 import { settingsModal$, type SettingsCategory } from '@/stores/settingsModal';
-import { setupWizard$ } from '@/stores/setupWizard';
-import { getPrimaryClient } from '@/stores/serverClients';
-import { isSpeechSupported } from '@/utils/tts';
+import { SettingsContent } from './SettingsContent';
 export type { SettingsCategory } from '@/stores/settingsModal';
 export { settingsModal$ } from '@/stores/settingsModal';
 
@@ -39,422 +18,31 @@ interface SettingsModalProps {
   children?: React.ReactNode;
 }
 
-const categories = [
-  {
-    id: 'servers' as const,
-    label: 'Servers',
-    icon: Server,
-    description: 'Manage server connections',
-  },
-  {
-    id: 'appearance' as const,
-    label: 'Appearance',
-    icon: Palette,
-    description: 'Theme and visual preferences',
-  },
-  {
-    id: 'audio' as const,
-    label: 'Audio',
-    icon: Volume2,
-    description: 'Sound and notification settings',
-  },
-  {
-    id: 'content' as const,
-    label: 'Content',
-    icon: FileText,
-    description: 'Message and code display options',
-  },
-  ...(import.meta.env.DEV || import.meta.env.VITE_ENABLE_DEV_TOOLS === 'true'
-    ? [
-        {
-          id: 'developer' as const,
-          label: 'Developer',
-          icon: Rocket,
-          description: 'Deploy and debugging actions',
-        },
-      ]
-    : []),
-  {
-    id: 'about' as const,
-    label: 'About',
-    icon: Info,
-    description: 'Version info and links',
-  },
-];
-
 export const SettingsModal = forwardRef<HTMLButtonElement, SettingsModalProps>(
-  ({ children }, _ref) => {
-    const { settings, updateSettings, resetSettings } = useSettings();
-    const { theme, setTheme } = useTheme();
+  function SettingsModal({ children }, _ref) {
     const [open, setOpen] = useState(false);
     const [activeCategory, setActiveCategory] = useState<SettingsCategory>('appearance');
-    const [serverVersion, setServerVersion] = useState<string | null>(null);
 
-    useEffect(() => {
-      if (activeCategory !== 'about') return;
-      const client = getPrimaryClient();
-      if (!client) return;
-      client
-        .getServerInfo()
-        .then((info) => setServerVersion(info.version ?? null))
-        .catch(() => setServerVersion(null));
-    }, [activeCategory]);
-
-    // Allow external code to open the modal to a specific category
+    // Sync open state with the observable (for external control, e.g. MenuBar search button, WelcomeView)
     const externalRequest = use$(settingsModal$);
     useEffect(() => {
       if (externalRequest.open) {
-        setActiveCategory(externalRequest.category);
         setOpen(true);
-        settingsModal$.open.set(false);
+        if (externalRequest.category) {
+          setActiveCategory(externalRequest.category);
+        }
       }
     }, [externalRequest.open, externalRequest.category]);
 
-    const renderCategoryContent = () => {
-      switch (activeCategory) {
-        case 'servers':
-          return <ServerConfiguration />;
-
-        case 'appearance':
-          return (
-            <div className="space-y-6">
-              <div>
-                <h3 className="mb-1 text-lg font-medium">Appearance</h3>
-                <p className="mb-4 text-sm text-muted-foreground">
-                  Customize the visual appearance of the application
-                </p>
-              </div>
-
-              <div className="space-y-3">
-                <Label className="text-sm text-muted-foreground">Theme</Label>
-                <div className="flex items-center space-x-1 rounded-md bg-muted/50 p-1">
-                  {[
-                    { value: 'light', label: 'Light' },
-                    { value: 'dark', label: 'Dark' },
-                    { value: 'system', label: 'System' },
-                  ].map((option) => {
-                    const isActive = theme === option.value;
-                    return (
-                      <Button
-                        key={option.value}
-                        variant={isActive ? 'secondary' : 'ghost'}
-                        size="sm"
-                        className={`flex-1 text-sm ${
-                          isActive ? 'bg-background shadow-sm' : 'hover:bg-background/60'
-                        }`}
-                        onClick={() => setTheme(option.value as 'light' | 'dark' | 'system')}
-                      >
-                        {option.label}
-                      </Button>
-                    );
-                  })}
-                </div>
-              </div>
-
-              <Separator />
-
-              <div className="space-y-3">
-                <Label className="text-sm text-muted-foreground">Welcome Background</Label>
-                <p className="text-xs text-muted-foreground">
-                  Image URL or CSS gradient for the new-chat view. The card gets a frosted glass
-                  effect when a background is set.
-                </p>
-                <input
-                  type="text"
-                  value={settings.welcomeBackground}
-                  onChange={(e) => updateSettings({ welcomeBackground: e.target.value })}
-                  placeholder="e.g. linear-gradient(135deg, #667eea 0%, #764ba2 100%)"
-                  className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm placeholder:text-muted-foreground/50 focus:outline-none focus:ring-1 focus:ring-ring"
-                />
-                <div className="flex flex-wrap gap-2">
-                  {[
-                    { label: 'Sunset', value: 'linear-gradient(135deg, #f093fb 0%, #f5576c 100%)' },
-                    {
-                      label: 'Ocean',
-                      value: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
-                    },
-                    {
-                      label: 'Forest',
-                      value: 'linear-gradient(135deg, #11998e 0%, #38ef7d 100%)',
-                    },
-                    {
-                      label: 'Night',
-                      value: 'linear-gradient(135deg, #0c0c1d 0%, #1a1a3e 50%, #2d1b69 100%)',
-                    },
-                  ].map((preset) => (
-                    <Button
-                      key={preset.label}
-                      variant="outline"
-                      size="sm"
-                      className="text-xs"
-                      onClick={() => updateSettings({ welcomeBackground: preset.value })}
-                    >
-                      {preset.label}
-                    </Button>
-                  ))}
-                  {settings.welcomeBackground && (
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      className="text-xs text-muted-foreground"
-                      onClick={() => updateSettings({ welcomeBackground: '' })}
-                    >
-                      Clear
-                    </Button>
-                  )}
-                </div>
-              </div>
-            </div>
-          );
-
-        case 'audio':
-          return (
-            <div className="space-y-6">
-              <div>
-                <h3 className="mb-1 text-lg font-medium">Audio</h3>
-                <p className="mb-4 text-sm text-muted-foreground">
-                  Configure sound and notification preferences
-                </p>
-              </div>
-
-              <div className="flex items-center justify-between">
-                <div className="space-y-0.5">
-                  <Label htmlFor="chime-toggle" className="text-sm">
-                    Completion chime
-                  </Label>
-                  <p className="text-xs text-muted-foreground">
-                    Play sound when agent completes tasks
-                  </p>
-                </div>
-                <Switch
-                  id="chime-toggle"
-                  checked={settings.chimeEnabled}
-                  onCheckedChange={(checked) => updateSettings({ chimeEnabled: checked })}
-                />
-              </div>
-
-              <div className="flex items-center justify-between">
-                <div className="space-y-0.5">
-                  <Label htmlFor="tts-toggle" className="text-sm">
-                    Read responses aloud
-                  </Label>
-                  <p className="text-xs text-muted-foreground">
-                    Speak assistant messages aloud (uses gptme-tts server if configured, otherwise
-                    browser Web Speech API)
-                  </p>
-                </div>
-                <Switch
-                  id="tts-toggle"
-                  checked={settings.ttsEnabled}
-                  disabled={!isSpeechSupported()}
-                  onCheckedChange={(checked) => updateSettings({ ttsEnabled: checked })}
-                />
-              </div>
-
-              <div className="space-y-2">
-                <Label htmlFor="tts-server-url" className="text-sm">
-                  TTS server URL
-                </Label>
-                <p className="text-xs text-muted-foreground">
-                  HTTP base URL of a running{' '}
-                  <code className="rounded bg-muted px-1">gptme-tts</code> server, e.g.{' '}
-                  <code className="rounded bg-muted px-1">http://localhost:5701</code>. Leave empty
-                  to use browser TTS.
-                </p>
-                <Input
-                  id="tts-server-url"
-                  type="text"
-                  placeholder="http://localhost:5701"
-                  value={settings.ttsServerUrl}
-                  onChange={(e) => updateSettings({ ttsServerUrl: e.target.value.trim() })}
-                />
-              </div>
-
-              <div className="space-y-2">
-                <Label htmlFor="voice-server-url" className="text-sm">
-                  Voice server URL
-                </Label>
-                <p className="text-xs text-muted-foreground">
-                  WebSocket URL of a running gptme-voice-server instance, e.g.{' '}
-                  <code className="rounded bg-muted px-1">ws://localhost:5700/voice</code>. Leave
-                  empty to hide the voice button.
-                </p>
-                <Input
-                  id="voice-server-url"
-                  type="text"
-                  placeholder="ws://localhost:5700/voice"
-                  value={settings.voiceServerUrl}
-                  onChange={(e) => updateSettings({ voiceServerUrl: e.target.value.trim() })}
-                />
-              </div>
-            </div>
-          );
-
-        case 'content':
-          return (
-            <div className="space-y-6">
-              <div>
-                <h3 className="mb-1 text-lg font-medium">Content</h3>
-                <p className="mb-4 text-sm text-muted-foreground">
-                  Control how messages and code are displayed
-                </p>
-              </div>
-
-              <div className="flex items-center justify-between">
-                <div className="space-y-0.5">
-                  <Label htmlFor="blocks-toggle" className="text-sm">
-                    Code blocks open by default
-                  </Label>
-                  <p className="text-xs text-muted-foreground">
-                    Whether code blocks are expanded when first shown
-                  </p>
-                </div>
-                <Switch
-                  id="blocks-toggle"
-                  checked={settings.blocksDefaultOpen}
-                  onCheckedChange={(checked) => updateSettings({ blocksDefaultOpen: checked })}
-                />
-              </div>
-
-              <Separator />
-
-              <div className="space-y-4">
-                <h4 className="text-sm font-medium">Developer Options</h4>
-
-                <div className="flex items-center justify-between">
-                  <div className="space-y-0.5">
-                    <Label htmlFor="hidden-toggle" className="text-sm">
-                      Show hidden messages
-                    </Label>
-                    <p className="text-xs text-muted-foreground">
-                      Display messages marked as hidden (e.g., lessons, context)
-                    </p>
-                  </div>
-                  <Switch
-                    id="hidden-toggle"
-                    checked={settings.showHiddenMessages}
-                    onCheckedChange={(checked) => updateSettings({ showHiddenMessages: checked })}
-                  />
-                </div>
-
-                <div className="flex items-center justify-between">
-                  <div className="space-y-0.5">
-                    <Label htmlFor="initial-system-toggle" className="text-sm">
-                      Show initial system messages
-                    </Label>
-                    <p className="text-xs text-muted-foreground">
-                      Display the initial system prompt at the start of conversations
-                    </p>
-                  </div>
-                  <Switch
-                    id="initial-system-toggle"
-                    checked={settings.showInitialSystem}
-                    onCheckedChange={(checked) => updateSettings({ showInitialSystem: checked })}
-                  />
-                </div>
-              </div>
-            </div>
-          );
-
-        case 'developer':
-          return <DeveloperDeploy />;
-
-        case 'about':
-          return (
-            <div className="space-y-6">
-              <div>
-                <h3 className="mb-1 text-lg font-medium">About</h3>
-                <p className="mb-4 text-sm text-muted-foreground">
-                  Information about gptme and this web interface
-                </p>
-              </div>
-
-              <div className="space-y-4">
-                {serverVersion && (
-                  <div className="space-y-1">
-                    <h4 className="text-sm font-medium">Version</h4>
-                    <p className="font-mono text-sm text-muted-foreground">gptme {serverVersion}</p>
-                  </div>
-                )}
-
-                <div className="space-y-3">
-                  <h4 className="text-sm font-medium">Related Projects</h4>
-                  <div className="flex flex-col space-y-2">
-                    <a
-                      href="https://github.com/gptme/gptme"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="flex items-center text-sm text-muted-foreground transition-colors hover:text-foreground"
-                    >
-                      <ExternalLink className="mr-2 h-3 w-3" />
-                      gptme - AI agent framework
-                    </a>
-                    <a
-                      href="https://github.com/gptme/gptme/tree/master/webui"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="flex items-center text-sm text-muted-foreground transition-colors hover:text-foreground"
-                    >
-                      <ExternalLink className="mr-2 h-3 w-3" />
-                      gptme-webui - Web interface
-                    </a>
-                  </div>
-                </div>
-
-                <Separator />
-
-                <div className="space-y-2">
-                  <h4 className="text-sm font-medium">Setup Wizard</h4>
-                  <div className="flex items-center justify-between">
-                    <p className="text-xs text-muted-foreground">
-                      Re-run the setup wizard to change server or sign in to gptme.ai
-                    </p>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={() => {
-                        setOpen(false);
-                        setupWizard$.step.set('welcome');
-                        setupWizard$.open.set(true);
-                      }}
-                    >
-                      Re-run Setup
-                    </Button>
-                  </div>
-                </div>
-
-                <Separator />
-
-                <div className="space-y-2">
-                  <h4 className="text-sm font-medium">Reset Settings</h4>
-                  <div className="flex items-center justify-between">
-                    <p className="text-xs text-muted-foreground">
-                      Restore all settings to their default values
-                    </p>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={() => {
-                        resetSettings();
-                        setTheme('system');
-                        setOpen(false);
-                      }}
-                    >
-                      Reset All
-                    </Button>
-                  </div>
-                </div>
-              </div>
-            </div>
-          );
-
-        default:
-          return null;
+    const handleOpenChange = (newOpen: boolean) => {
+      setOpen(newOpen);
+      if (!newOpen) {
+        settingsModal$.open.set(false);
       }
     };
 
     return (
-      <Dialog open={open} onOpenChange={setOpen}>
+      <Dialog open={open} onOpenChange={handleOpenChange}>
         {children !== undefined && <DialogTrigger asChild>{children}</DialogTrigger>}
         <DialogContent className="flex max-h-[90vh] w-[calc(100vw-2rem)] flex-col overflow-hidden p-0 sm:max-h-[80vh] sm:max-w-4xl">
           <DialogHeader className="border-b px-6 py-3">
@@ -465,60 +53,11 @@ export const SettingsModal = forwardRef<HTMLButtonElement, SettingsModalProps>(
             <DialogDescription>Customize your gptme experience</DialogDescription>
           </DialogHeader>
 
-          <div className="flex min-h-0 min-w-0 flex-1 flex-col sm:flex-row">
-            {/* Mobile: horizontal tab strip */}
-            <div className="flex overflow-x-auto border-b bg-muted/20 p-2 sm:hidden">
-              {categories.map((category) => {
-                const Icon = category.icon;
-                const isActive = activeCategory === category.id;
-                return (
-                  <button
-                    key={category.id}
-                    onClick={() => setActiveCategory(category.id)}
-                    className={cn(
-                      'flex shrink-0 flex-col items-center gap-1 rounded-md px-3 py-2 text-xs transition-colors',
-                      isActive ? 'border bg-background shadow-sm' : 'hover:bg-muted/60'
-                    )}
-                  >
-                    <Icon className="h-4 w-4" />
-                    <span className="font-medium">{category.label}</span>
-                  </button>
-                );
-              })}
-            </div>
-
-            {/* Desktop: vertical sidebar */}
-            <div className="hidden w-48 overflow-y-auto border-r bg-muted/20 p-4 sm:block">
-              <nav className="space-y-1">
-                {categories.map((category) => {
-                  const Icon = category.icon;
-                  const isActive = activeCategory === category.id;
-
-                  return (
-                    <button
-                      key={category.id}
-                      onClick={() => setActiveCategory(category.id)}
-                      className={cn(
-                        'flex w-full items-start gap-3 rounded-md px-3 py-2 text-sm transition-colors',
-                        isActive ? 'border bg-background shadow-sm' : 'hover:bg-muted/60'
-                      )}
-                    >
-                      <Icon className="mt-0.5 h-4 w-4 shrink-0" />
-                      <div className="text-left">
-                        <div className="font-medium">{category.label}</div>
-                        <div className="text-xs text-muted-foreground">{category.description}</div>
-                      </div>
-                    </button>
-                  );
-                })}
-              </nav>
-            </div>
-
-            {/* Content */}
-            <div className="min-h-0 min-w-0 flex-1 overflow-y-auto p-4 sm:p-6">
-              {renderCategoryContent()}
-            </div>
-          </div>
+          <SettingsContent
+            activeCategory={activeCategory}
+            onCategoryChange={setActiveCategory}
+            onClose={() => handleOpenChange(false)}
+          />
         </DialogContent>
       </Dialog>
     );

--- a/webui/src/components/SidebarIcons.tsx
+++ b/webui/src/components/SidebarIcons.tsx
@@ -89,7 +89,9 @@ export const SidebarIcons: FC<Props> = ({ tasks }) => {
             ? 'external-sessions'
             : location.pathname.startsWith('/admin')
               ? 'admin'
-              : 'chat';
+              : location.pathname.startsWith('/settings')
+                ? 'settings'
+                : 'chat';
 
   const handleNavigateToSection = (
     section: 'chat' | 'tasks' | 'history' | 'agents' | 'workspaces' | 'external-sessions' | 'admin'
@@ -212,11 +214,12 @@ export const SidebarIcons: FC<Props> = ({ tasks }) => {
         <TooltipProvider>
           <Tooltip>
             <TooltipTrigger asChild>
-              <SettingsModal>
+              {currentSection === 'settings' ? (
                 <Button
-                  variant="ghost"
+                  variant="secondary"
                   className="relative h-8 w-full min-w-0 justify-start gap-2 px-2"
-                  aria-label="Open settings"
+                  aria-label="Settings"
+                  onClick={() => navigate('/settings')}
                 >
                   <span className="relative flex-shrink-0">
                     <Settings className="h-4 w-4" />
@@ -232,7 +235,29 @@ export const SidebarIcons: FC<Props> = ({ tasks }) => {
                     Settings
                   </span>
                 </Button>
-              </SettingsModal>
+              ) : (
+                <SettingsModal>
+                  <Button
+                    variant="ghost"
+                    className="relative h-8 w-full min-w-0 justify-start gap-2 px-2"
+                    aria-label="Open settings"
+                  >
+                    <span className="relative flex-shrink-0">
+                      <Settings className="h-4 w-4" />
+                      {hasProviderError && (
+                        <span className="absolute -right-1 -top-1 h-2 w-2 rounded-full bg-red-500" />
+                      )}
+                    </span>
+                    <span
+                      className={`min-w-0 flex-1 truncate text-left text-sm transition-opacity duration-150 ${
+                        isExpanded ? 'opacity-100' : 'opacity-0'
+                      }`}
+                    >
+                      Settings
+                    </span>
+                  </Button>
+                </SettingsModal>
+              )}
             </TooltipTrigger>
             {!isExpanded && <TooltipContent side="right">Settings</TooltipContent>}
           </Tooltip>

--- a/webui/src/components/__tests__/CommandPalette.test.tsx
+++ b/webui/src/components/__tests__/CommandPalette.test.tsx
@@ -1,7 +1,6 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import { CommandPalette } from '../CommandPalette';
-import { settingsModal$ } from '@/stores/settingsModal';
 
 // Mock ApiContext with a stable `api` reference to avoid infinite re-render loop.
 // useEffect in CommandPalette has [search, api] as deps — if useApi() returns a
@@ -11,11 +10,6 @@ jest.mock('@/contexts/ApiContext', () => {
   const api = { searchConversations: jest.fn().mockResolvedValue([]) };
   return { useApi: () => ({ api }) };
 });
-
-// Mock settingsModal$ store - use inline jest.fn() to avoid hoisting issues
-jest.mock('@/stores/settingsModal', () => ({
-  settingsModal$: { open: { set: jest.fn() } },
-}));
 
 // Mock commandPalette$ store
 jest.mock('@/stores/commandPalette', () => ({
@@ -87,7 +81,6 @@ jest.mock('react-router-dom', () => {
 describe('CommandPalette', () => {
   beforeEach(() => {
     mockNavigate.mockClear();
-    (settingsModal$.open.set as jest.Mock).mockClear();
   });
 
   afterEach(() => {

--- a/webui/src/components/__tests__/CommandPalette.test.tsx
+++ b/webui/src/components/__tests__/CommandPalette.test.tsx
@@ -319,7 +319,7 @@ describe('CommandPalette', () => {
       expect(mockNavigate).toHaveBeenCalledWith('/');
     });
 
-    it('opens settings modal when selecting Settings', async () => {
+    it('navigates to settings when selecting Settings', async () => {
       renderCommandPalette();
 
       fireEvent.keyDown(document, { key: 'k', metaKey: true });
@@ -327,7 +327,7 @@ describe('CommandPalette', () => {
       const settings = await screen.findByText('Settings');
       fireEvent.click(settings);
 
-      expect(settingsModal$.open.set).toHaveBeenCalledWith(true);
+      expect(mockNavigate).toHaveBeenCalledWith('/settings');
     });
 
     it('closes after action execution', async () => {

--- a/webui/src/pages/SettingsPage.tsx
+++ b/webui/src/pages/SettingsPage.tsx
@@ -1,0 +1,36 @@
+import { useState, type FC } from 'react';
+import { Settings } from 'lucide-react';
+import { MenuBar } from '@/components/MenuBar';
+import { SidebarIcons } from '@/components/SidebarIcons';
+import { MobileBottomNav } from '@/components/MobileBottomNav';
+import { useTasksQuery } from '@/stores/tasks';
+import { SettingsContent } from '@/components/SettingsContent';
+import type { SettingsCategory } from '@/stores/settingsModal';
+
+/** Full-page settings view — replaces the modal when navigated via /settings route. */
+const SettingsPage: FC = () => {
+  const { data: tasks = [] } = useTasksQuery();
+  const [activeCategory, setActiveCategory] = useState<SettingsCategory>('appearance');
+
+  return (
+    <div className="flex h-screen flex-col">
+      <MenuBar />
+      <div className="flex min-h-0 flex-1">
+        <SidebarIcons tasks={tasks} />
+        <div className="flex flex-1 flex-col overflow-hidden">
+          {/* Page header */}
+          <div className="flex items-center gap-2 border-b px-6 py-3">
+            <Settings className="h-5 w-5" />
+            <h1 className="text-lg font-semibold">Settings</h1>
+            <p className="text-sm text-muted-foreground">Customize your gptme experience</p>
+          </div>
+
+          <SettingsContent activeCategory={activeCategory} onCategoryChange={setActiveCategory} />
+        </div>
+      </div>
+      <MobileBottomNav />
+    </div>
+  );
+};
+
+export default SettingsPage;

--- a/webui/src/pages/SettingsPage.tsx
+++ b/webui/src/pages/SettingsPage.tsx
@@ -1,4 +1,4 @@
-import { useState, type FC } from 'react';
+import { useState, useEffect, type FC } from 'react';
 import { Settings } from 'lucide-react';
 import { MenuBar } from '@/components/MenuBar';
 import { SidebarIcons } from '@/components/SidebarIcons';
@@ -6,11 +6,22 @@ import { MobileBottomNav } from '@/components/MobileBottomNav';
 import { useTasksQuery } from '@/stores/tasks';
 import { SettingsContent } from '@/components/SettingsContent';
 import type { SettingsCategory } from '@/stores/settingsModal';
+import { use$ } from '@legendapp/state/react';
+import { settingsModal$ } from '@/stores/settingsModal';
 
 /** Full-page settings view — replaces the modal when navigated via /settings route. */
 const SettingsPage: FC = () => {
   const { data: tasks = [] } = useTasksQuery();
   const [activeCategory, setActiveCategory] = useState<SettingsCategory>('appearance');
+
+  // Observe external requests (e.g. ServerSelector configure button) to switch category
+  const externalRequest = use$(settingsModal$);
+  useEffect(() => {
+    if (externalRequest.open && externalRequest.category) {
+      setActiveCategory(externalRequest.category);
+      settingsModal$.open.set(false);
+    }
+  }, [externalRequest.open, externalRequest.category]);
 
   return (
     <div className="flex h-screen flex-col">


### PR DESCRIPTION
## Summary

Adds a proper `/settings` route to the web UI, as requested by Erik in #2799. Instead of a 404 when navigating to settings, users now get a full-page settings view with the same category tabs as the modal.

## Changes

- **`SettingsContent`** — Shared component with category sidebar + content panels, extracted from SettingsModal
- **`SettingsPage`** — Full-page settings view with MenuBar/SidebarIcons/MobileBottomNav layout
- **`SettingsModal`** — Refactored to use the shared SettingsContent component
- **`CommandPalette`** — Settings action navigates to `/settings` instead of opening the modal
- **`appRoutes` + `_redirects`** — Added `/settings` route and Cloudflare SPA fallback

The modal remains available for the sidebar settings button (backward compatible).

## Testing

- TypeScript: `tsc --noEmit` — clean
- Tests: 435 passed, 51 suites
- Build: `vite build` — clean

Closes #2799