### PR TITLE
fix(hooks): hide injected agent-instructions from conversation view

### DIFF
--- a/gptme/hooks/agents_md_inject.py
+++ b/gptme/hooks/agents_md_inject.py
@@ -189,6 +189,11 @@ def inject_agent_instruction_files(
             f"{content}\n"
             f"</agent-instructions>",
             files=[agent_file],
+            # Display-only hide: the instructions still reach the LLM, but this
+            # injected context message shouldn't clutter the conversation view
+            # (it's transient/not persisted, so it otherwise only appeared live
+            # via the message_added stream event and vanished on reload).
+            hide=True,
         )
 
 

--- a/gptme/hooks/tests/test_agents_md_inject.py
+++ b/gptme/hooks/tests/test_agents_md_inject.py
@@ -173,6 +173,9 @@ class TestOnCwdChanged:
             assert "My Agent Instructions" in injected
             assert "Do good things" in injected
             assert "agent-instructions" in injected
+            # Injected instructions are display-hidden: they reach the LLM but
+            # shouldn't clutter the conversation view (consistent on stream/reload).
+            assert agent_msgs[0].hide is True
         finally:
             os.chdir(original)
 


### PR DESCRIPTION
## Summary
Fixes `<agent-instructions source="...">` cluttering the conversation mid-stream (reported in the webui: it appeared only via the live `message_added` event and was gone on reload).

The `agents_md_inject` hook injects agent instructions as a **transient** `system` message each step — not persisted to the log. So the webui showed it live (from the stream event) but not on reload, which was confusing and noisy.

Mark the injected message `hide=True`. `hide` is **display-only** (the `gptme/llm/` path doesn't filter on it), so the instructions still reach the model, but the message no longer shows in the webui/CLI conversation view — consistent on both stream and reload.

## Test plan
- [x] `pytest gptme/hooks/tests/test_agents_md_inject.py` (17 passed); added an assertion that the injected message is `hide=True`