### PR TITLE
fix(tools): report unavailable tools accurately instead of 'invalid choice'

### DIFF
--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -858,7 +858,10 @@ def main(
     # We pass the tool_allowlist CLI argument. If it's not provided, init_tools
     # will load it from the environment variable TOOL_ALLOWLIST or the chat config.
     logger.debug(f"Using tools: {config.chat.tools}")
-    tools = init_tools(config.chat.tools)
+    try:
+        tools = init_tools(config.chat.tools)
+    except ValueError as e:
+        raise click.UsageError(str(e)) from e
 
     # Check if we're opening an existing conversation (via --resume, --name, or pick)
     # If so, skip generating initial messages (including expensive context_cmd)

--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -380,7 +380,11 @@ Run 'gptme-util --help' for all utility commands."""
     default=None,
     multiple=True,
     type=CommaSeparatedChoice(
-        _available_tools + ["none"],
+        # Accept all *known* tools, not just currently-available ones, so a tool
+        # that exists but is temporarily unavailable (e.g. 'tts' when its server
+        # isn't running) is reported as unavailable at load time rather than as a
+        # misleading "invalid choice" here.
+        _known_tool_names + ["none"],
         allow_prefixes=["+", "-"],
         extra_choices_for_prefix={"-": _known_tool_names},
         # Only '+' is lenient: plugin tools (added via '+tool') aren't known at

--- a/gptme/tools/__init__.py
+++ b/gptme/tools/__init__.py
@@ -218,7 +218,9 @@ def init_tools(
                         f"Tool '{tool_name}' matched available tools that should "
                         "have been loaded but were not found in loaded_tools"
                     )
-                logger.warning("%s", _unavailable_message(tool_name, matched_available))
+                logger.warning(
+                    "%s Skipping.", _unavailable_message(tool_name, matched_available)
+                )
                 continue
             raise ValueError(f"Tool '{tool_name}' not found")
 
@@ -230,6 +232,9 @@ def _unavailable_message(tool_name: str, matched_tools: list[ToolSpec]) -> str:
     hint = next((t.available_hint for t in matched_tools if t.available_hint), None)
     base = f"Tool '{tool_name}' is unavailable"
     if hint:
+        hint = hint.rstrip()
+        if hint[-1:] not in ".!?":
+            hint += "."
         return f"{base}: {hint}"
     return (
         f"{base} — it was discovered but its availability check failed "

--- a/gptme/tools/__init__.py
+++ b/gptme/tools/__init__.py
@@ -218,11 +218,24 @@ def init_tools(
                         f"Tool '{tool_name}' matched available tools that should "
                         "have been loaded but were not found in loaded_tools"
                     )
-                logger.warning("Tool %s found but is unavailable", tool_name)
+                logger.warning("%s", _unavailable_message(tool_name, matched_available))
                 continue
             raise ValueError(f"Tool '{tool_name}' not found")
 
         return loaded_tools
+
+
+def _unavailable_message(tool_name: str, matched_tools: list[ToolSpec]) -> str:
+    """Build an accurate 'unavailable' message, preferring a tool-provided hint."""
+    hint = next((t.available_hint for t in matched_tools if t.available_hint), None)
+    base = f"Tool '{tool_name}' is unavailable"
+    if hint:
+        return f"{base}: {hint}"
+    return (
+        f"{base} — it was discovered but its availability check failed "
+        "(a required service may not be running, or optional "
+        "dependencies/credentials are missing)."
+    )
 
 
 def get_toolchain(
@@ -247,14 +260,10 @@ def get_toolchain(
                 continue
 
             if not any(tool.is_available for tool in matched_tools):
+                msg = _unavailable_message(tool_name, matched_tools)
                 if strict:
-                    raise ValueError(
-                        f"Tool '{tool_name}' is unavailable (likely missing dependencies)"
-                    )
-                logger.warning(
-                    "Tool '%s' is unavailable (missing dependencies), skipping",
-                    tool_name,
-                )
+                    raise ValueError(msg)
+                logger.warning("%s Skipping.", msg)
                 continue
 
     tools = []
@@ -458,9 +467,7 @@ def load_tool(tool_name: str) -> ToolSpec:
 
         tool = available[tool_name]
         if not tool.is_available:
-            raise ValueError(
-                f"Tool '{tool_name}' is unavailable (likely missing dependencies)"
-            )
+            raise ValueError(_unavailable_message(tool_name, [tool]))
 
         # Initialize, register hooks/commands (shared logic)
         tool = _init_single_tool(tool)

--- a/gptme/tools/base.py
+++ b/gptme/tools/base.py
@@ -252,6 +252,8 @@ class ToolSpec:
         execute: An optional function that is called when the tool executes a block.
         block_types: A list of block types that the tool will execute.
         available: Whether the tool is available for use.
+        available_hint: Optional guidance shown when the tool is explicitly
+            requested but currently unavailable (e.g. "start the TTS server").
         parameters: Descriptor of parameters use by this tool.
         load_priority: Influence the loading order of this tool. The higher the later.
         disabled_by_default: Whether this tool should be disabled by default.
@@ -269,6 +271,7 @@ class ToolSpec:
     execute: ExecuteFunc | None = None
     block_types: list[str] = field(default_factory=list)
     available: bool | Callable[[], bool] = True
+    available_hint: str | None = None
     parameters: list[Parameter] = field(default_factory=list)
     load_priority: int = 0
     disabled_by_default: bool = False

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -422,6 +422,38 @@ def test_get_toolchain_strict_raises_on_unavailable():
         available.remove(unavailable_tool)
 
 
+def test_get_toolchain_unavailable_uses_available_hint():
+    """An unavailable tool's available_hint is surfaced in the error message."""
+    from gptme.tools.base import ToolSpec
+
+    available = get_available_tools()
+    unavailable_tool = ToolSpec(
+        name="fake_with_hint",
+        desc="A fake unavailable tool",
+        available=False,
+        available_hint="start the fake server (or set FAKE_BACKEND=cloud)",
+    )
+    available.append(unavailable_tool)
+    try:
+        with pytest.raises(
+            ValueError, match="start the fake server .or set FAKE_BACKEND=cloud."
+        ):
+            get_toolchain(["fake_with_hint"], strict=True)
+    finally:
+        available.remove(unavailable_tool)
+
+
+def test_unavailable_message_falls_back_to_generic():
+    """Without a hint, the message is accurate (not 'invalid choice'/'missing deps')."""
+    from gptme.tools import _unavailable_message
+    from gptme.tools.base import ToolSpec
+
+    spec = ToolSpec(name="foo", desc="x", available=False)
+    msg = _unavailable_message("foo", [spec])
+    assert msg.startswith("Tool 'foo' is unavailable")
+    assert "availability check failed" in msg
+
+
 def test_get_toolchain_nonstrict_skips_missing():
     """Test that get_toolchain skips unknown tools when strict=False."""
     # Should not raise, just warn and skip


### PR DESCRIPTION
## Summary

A tool that exists but is currently unavailable (its `is_available()` returns False — e.g. `tts` when its server isn't running, or a backend without optional deps) was dropped from the CLI's valid `--tools` choices. So a bare `-t tts` was rejected as **`invalid choice: tts`** — misleading, since the tool exists, it's just inactive.

- **CLI** (`cli/main.py`): build the `--tools` choice set from all *known* tools, not just currently-available ones. Bare unavailable tool names now pass parse-time validation and are reported at load time instead. (`+tool` was already lenient; `-tool` exclusions stay strict for typo protection.)
- **Message** (`tools/__init__.py`): replace the hardcoded "(likely missing dependencies)" with an accurate message via a shared `_unavailable_message()` helper, used at all three unavailable sites (`get_toolchain`, `init_tools`, `load_tool`).
- **Hint** (`tools/base.py`): add an optional `ToolSpec.available_hint` so a tool can give specific guidance (e.g. "start the TTS server, or set GPTME_TTS_BACKEND=openrouter"); the generic message is used when no hint is set.

Before: `Error: Invalid value for '-t' / '--tools': invalid choice: tts.`
After: `Tool 'tts' is unavailable — it was discovered but its availability check failed (a required service may not be running, or optional dependencies/credentials are missing).`

## Test plan

- [x] `tests/test_tools.py` — new tests: `available_hint` surfaced in the error; generic fallback message wording
- [x] Existing `get_toolchain` strict/non-strict unavailable tests still pass
- [x] Manually verified `-t tts` with the TTS server down now reports unavailability instead of "invalid choice"

Follow-up: the `gptme-tts` plugin will set `available_hint` for a TTS-specific message (separate gptme-contrib PR).