### PR TITLE
docs: add model-routing guide — pick your model per task

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ You can find more [Demos][docs-demos] and [Examples][docs-examples] in the [docu
 - 🤖 **Support for many LLM [providers][docs-providers]**
   - Anthropic (Claude), OpenAI (GPT), Google (Gemini), xAI (Grok), DeepSeek, and more.
   - Use OpenRouter for access to 100+ models, or serve locally with `llama.cpp`.
+  - [Pick the right model per task][docs-model-routing] — fast/cheap for triage, powerful for coding.
 - 🌐 **Web UI and REST API**
   - Modern web interface at [chat.gptme.org](https://chat.gptme.org) ([gptme-webui])
   - Simple built-in web UI included in the Python package.
@@ -642,6 +643,7 @@ Contributions welcome! See the [contributing guide](https://gptme.org/docs/contr
 [docs-examples]: https://gptme.org/docs/examples.html
 [docs-demos]: https://gptme.org/docs/demos.html
 [docs-providers]: https://gptme.org/docs/providers.html
+[docs-model-routing]: https://gptme.org/docs/model-routing.html
 [docs-tools]: https://gptme.org/docs/tools.html
 [docs-tools-python]: https://gptme.org/docs/tools.html#python
 [docs-tools-shell]: https://gptme.org/docs/tools.html#shell

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,6 +35,7 @@ See the `README <https://github.com/gptme/gptme/blob/master/README.md>`_ file fo
    cli
    config
    providers
+   model-routing
    security
 
 .. toctree::

--- a/docs/model-routing.md
+++ b/docs/model-routing.md
@@ -76,7 +76,7 @@ without per-call flags:
 
 ```toml
 # router-agent/gptme.toml — cheap, fast, handles triage and dispatch
-model = "openrouter/qwen/qwen3.7-max"
+model = "openrouter/qwen/qwen3-max"
 ```
 
 ```toml

--- a/docs/model-routing.md
+++ b/docs/model-routing.md
@@ -15,7 +15,7 @@ Pass `--model` (`-m`) as `<provider>/<model>` to choose the model for a single r
 
 ```sh
 # Quick question — small, cheap, fast
-gptme "what does this regex match?" -m openrouter/qwen/qwen3.7-max
+gptme "what does this regex match?" -m openrouter/qwen/qwen3-max
 
 # Complex coding — powerful reasoning model
 gptme "refactor this module for testability" -m anthropic/claude-sonnet-4-6
@@ -59,7 +59,7 @@ If you mostly use one model, set it once in `gptme.toml` (project) or
 
 ```toml
 # gptme.toml or ~/.config/gptme/config.toml
-model = "openrouter/qwen/qwen3.7-max"
+model = "openrouter/qwen/qwen3-max"
 ```
 
 With a default configured, `gptme "query"` uses that model, and `--model` still

--- a/docs/model-routing.md
+++ b/docs/model-routing.md
@@ -71,11 +71,16 @@ See {doc}`config` for the full config reference.
 
 When you run multiple agents — for example a team of agents each handling a
 different role — each can have its own model. Set the model in the agent's own
-config so a fast agent and a reasoning-heavy agent can coexist without per-call
-flags:
+config so a fast routing agent and a reasoning-heavy coding agent can coexist
+without per-call flags:
 
 ```toml
-# Each agent's gptme.toml
+# router-agent/gptme.toml — cheap, fast, handles triage and dispatch
+model = "openrouter/qwen/qwen3.7-max"
+```
+
+```toml
+# coder-agent/gptme.toml — frontier model for complex implementation
 model = "anthropic/claude-sonnet-4-6"
 ```
 

--- a/docs/model-routing.md
+++ b/docs/model-routing.md
@@ -1,0 +1,92 @@
+# Choosing your model
+
+gptme is model-agnostic: it works with any LLM through a single `--model` flag, and
+you can pick a different model for every task. Use a small, fast model for quick
+questions and a powerful reasoning model for complex code — without changing tools,
+formats, or workflow.
+
+This page is a task-oriented guide to *picking* a model. For the full provider
+reference (credentials, OAuth onboarding, OpenAI-compatible servers), see
+{doc}`providers`.
+
+## Pick a model per session
+
+Pass `--model` (`-m`) as `<provider>/<model>` to choose the model for a single run:
+
+```sh
+# Quick question — small, cheap, fast
+gptme "what does this regex match?" -m openrouter/qwen/qwen3.7-max
+
+# Complex coding — powerful reasoning model
+gptme "refactor this module for testability" -m anthropic/claude-sonnet-4-6
+
+# Use a provider default (no model specified)
+gptme "hello" -m anthropic
+```
+
+List the models gptme knows about at any time:
+
+```sh
+gptme '/models' - '/exit'
+```
+
+The rule of thumb: **match the model to the job.** Triage, summarization, and
+quick lookups run fine on small models; multi-step coding and reasoning benefit
+from a frontier model. Picking per task keeps cost down without capping capability.
+
+## One key, many models: OpenRouter
+
+[OpenRouter](https://openrouter.ai/) is the easiest way to reach many models
+without managing a separate API key for each provider. With one
+`OPENROUTER_API_KEY` you can route to 100+ models from Anthropic, OpenAI, Google,
+DeepSeek, xAI, and more:
+
+```sh
+gptme "hello" -m openrouter/anthropic/claude-sonnet-4-6
+gptme "hello" -m openrouter/deepseek/deepseek-v4-pro
+gptme "hello" -m openrouter/x-ai/grok-4
+```
+
+gptme applies privacy-first defaults for OpenRouter (data collection denied,
+provider routing requires full parameter support). See the OpenRouter section of
+the {doc}`providers` page for configuration details, quantization controls, and
+provider pinning.
+
+## Set a default model
+
+If you mostly use one model, set it once in `gptme.toml` (project) or
+`~/.config/gptme/config.toml` (global) instead of passing `--model` every time:
+
+```toml
+# gptme.toml or ~/.config/gptme/config.toml
+model = "openrouter/qwen/qwen3.7-max"
+```
+
+With a default configured, `gptme "query"` uses that model, and `--model` still
+overrides it per run when you need something stronger or cheaper.
+
+See {doc}`config` for the full config reference.
+
+## Per-agent models
+
+When you run multiple agents — for example a team of agents each handling a
+different role — each can have its own model. Set the model in the agent's own
+config so a fast agent and a reasoning-heavy agent can coexist without per-call
+flags:
+
+```toml
+# Each agent's gptme.toml
+model = "anthropic/claude-sonnet-4-6"
+```
+
+This is how an agent "brain" pins its default model: configure it once in the
+agent's config, override per session only when a specific task needs a different
+model. No vendor lock-in, no format changes.
+
+## See also
+
+- {doc}`providers` — full provider reference: credentials, OAuth,
+  OpenAI-compatible servers, local models
+- {doc}`custom-providers` — add your own OpenAI-compatible provider
+- {doc}`config` — `gptme.toml` and global config reference
+- {doc}`evals` — how different models perform on gptme's benchmark suite


### PR DESCRIPTION
## What

Adds `docs/model-routing.md`, a task-oriented guide to picking the right gptme model per task. gptme already has all the plumbing for per-task model routing — this page surfaces it as a first-class user-facing story (the gap was docs/UX, not code).

## Sections

- **Pick a model per session** — `--model` / `-m` for one-off selection, `/models` to list
- **One key, many models: OpenRouter** — 100+ models through a single API key
- **Set a default model** — `gptme.toml` / global config
- **Per-agent models** — each agent pins its own default

Cross-links to `providers`, `config`, `custom-providers`, and `evals` (uses `{doc}` roles so Sphinx resolves them). Reference detail stays on the Providers page; this page is the *decision* guide, complementary not duplicative.

## Changes

- New `docs/model-routing.md`
- Added to the User Guide toctree in `docs/index.rst` (after `providers`)
- Linked from the README providers feature bullet

Docs-only, no code changes — no CI risk.

🤖 Authored by Bob