### PR TITLE
feat(webui): show active model in conversation header

### DIFF
--- a/webui/src/components/ConversationContent.tsx
+++ b/webui/src/components/ConversationContent.tsx
@@ -505,12 +505,26 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
         }}
       >
         <Memo>
-          {() => (
-            <OpenConversationPathButton
-              logdir={conversation$.data.logdir.get()}
-              baseUrl={connectionConfig.baseUrl}
-            />
-          )}
+          {() => {
+            const log = conversation$.data.log.get();
+            let activeModel: string | undefined;
+            if (log) {
+              for (let i = log.length - 1; i >= 0; i--) {
+                const msg = log[i];
+                if (msg.role === 'assistant' && msg.metadata?.model) {
+                  activeModel = msg.metadata.model;
+                  break;
+                }
+              }
+            }
+            return (
+              <OpenConversationPathButton
+                logdir={conversation$.data.logdir.get()}
+                baseUrl={connectionConfig.baseUrl}
+                activeModel={activeModel}
+              />
+            );
+          }}
         </Memo>
 
         <For each={conversation$.data.log}>

--- a/webui/src/components/OpenConversationPathButton.tsx
+++ b/webui/src/components/OpenConversationPathButton.tsx
@@ -15,19 +15,27 @@ import { isTauriEnvironment } from '@/utils/tauri';
 interface OpenConversationPathButtonProps {
   logdir?: string;
   baseUrl: string;
+  activeModel?: string;
 }
 
-export function OpenConversationPathButton({ logdir, baseUrl }: OpenConversationPathButtonProps) {
-  if (!logdir || !isLocalApiBaseUrl(baseUrl)) {
+export function OpenConversationPathButton({
+  logdir,
+  baseUrl,
+  activeModel,
+}: OpenConversationPathButtonProps) {
+  const showFolderButton = !!(logdir && isLocalApiBaseUrl(baseUrl));
+  const shortModelName = activeModel ? (activeModel.split('/').pop() ?? activeModel) : undefined;
+
+  if (!showFolderButton && !shortModelName) {
     return null;
   }
 
   const copyPath = async () => {
+    if (!logdir) return;
     if (!navigator.clipboard?.writeText) {
       toast.error('Clipboard unavailable');
       return;
     }
-
     try {
       await navigator.clipboard.writeText(logdir);
       toast.success('Conversation path copied');
@@ -38,6 +46,7 @@ export function OpenConversationPathButton({ logdir, baseUrl }: OpenConversation
   };
 
   const openDirectory = async () => {
+    if (!logdir) return;
     // Browsers block navigating to file:// from page scripts (throws a security
     // error), so only attempt a real open in the Tauri desktop app. In a plain
     // browser, fall back to copying the path.
@@ -56,37 +65,51 @@ export function OpenConversationPathButton({ logdir, baseUrl }: OpenConversation
   };
 
   return (
-    <div className="sticky top-0 z-20 mx-auto flex max-w-3xl justify-end px-3 pt-3">
-      <DropdownMenu>
+    <div className="sticky top-0 z-20 mx-auto flex max-w-3xl items-center justify-end gap-2 px-3 pt-3">
+      {shortModelName && (
         <TooltipProvider>
           <Tooltip>
             <TooltipTrigger asChild>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="icon"
-                  className="h-8 w-8 bg-background/90 shadow-sm backdrop-blur"
-                  aria-label="Open conversation directory"
-                >
-                  <FolderOpen className="h-4 w-4" />
-                </Button>
-              </DropdownMenuTrigger>
+              <span className="h-8 cursor-default select-none rounded-md border bg-background/90 px-2 py-1 text-xs font-medium text-muted-foreground shadow-sm backdrop-blur">
+                {shortModelName}
+              </span>
             </TooltipTrigger>
-            <TooltipContent>Open conversation directory</TooltipContent>
+            <TooltipContent>{activeModel}</TooltipContent>
           </Tooltip>
         </TooltipProvider>
-        <DropdownMenuContent align="end" className="w-48">
-          <DropdownMenuItem onClick={() => void openDirectory()}>
-            <ExternalLink className="mr-2 h-4 w-4" />
-            Open directory
-          </DropdownMenuItem>
-          <DropdownMenuItem onClick={() => void copyPath()}>
-            <Copy className="mr-2 h-4 w-4" />
-            Copy path
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
+      )}
+      {showFolderButton && (
+        <DropdownMenu>
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="icon"
+                    className="h-8 w-8 bg-background/90 shadow-sm backdrop-blur"
+                    aria-label="Open conversation directory"
+                  >
+                    <FolderOpen className="h-4 w-4" />
+                  </Button>
+                </DropdownMenuTrigger>
+              </TooltipTrigger>
+              <TooltipContent>Open conversation directory</TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+          <DropdownMenuContent align="end" className="w-48">
+            <DropdownMenuItem onClick={() => void openDirectory()}>
+              <ExternalLink className="mr-2 h-4 w-4" />
+              Open directory
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={() => void copyPath()}>
+              <Copy className="mr-2 h-4 w-4" />
+              Copy path
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Adds a small badge showing the active model name (e.g. `claude-sonnet-4-6`) in the sticky conversation header, next to the folder-open button
- Provider prefix is stripped for readability (`anthropic/claude-sonnet-4-6` → `claude-sonnet-4-6`); tooltip shows full model ID on hover
- Model is derived from the last assistant message that has `metadata.model` set — no backend changes needed
- Badge is hidden until the first assistant message with model metadata arrives (graceful fallback)
- The folder-open button continues to work independently

Closes gptme/gptme#2799 (the settings route bug is separate — see that issue)

## Changes

**`webui/src/components/OpenConversationPathButton.tsx`**:
- Added `activeModel?: string` prop
- Refactored early-return to support badge + folder-button independently
- Badge styled to match existing UI: `h-8 rounded-md border bg-background/90 px-2 py-1 text-xs font-medium text-muted-foreground shadow-sm backdrop-blur`

**`webui/src/components/ConversationContent.tsx`**:
- Derives `activeModel` from the last assistant message with `metadata.model` set (scans backwards through log)
- Passes `activeModel` to `OpenConversationPathButton`

## Test plan

- [ ] TypeScript typecheck passes (`tsc --noEmit`)
- [ ] Existing `OpenConversationPath` Jest tests pass (10/10)
- [ ] In a live conversation: badge shows `claude-sonnet-4-6` (or similar) after the first assistant message
- [ ] Hovering badge shows full model ID tooltip
- [ ] Folder-open button still works independently
- [ ] Badge hidden on a conversation with no assistant messages yet