### PR TITLE
feat(artifacts): include workspace files created/modified by the conversation

### DIFF
--- a/gptme/server/artifacts_api.py
+++ b/gptme/server/artifacts_api.py
@@ -21,6 +21,7 @@ from typing import Any, Literal, cast, get_args
 import flask
 from pydantic import BaseModel, Field
 
+from ..codeblock import Codeblock
 from ..logmanager import LogManager
 from .api_v2_common import _validate_conversation_id
 from .auth import require_auth
@@ -311,6 +312,112 @@ def _artifacts_from_messages(
     return out
 
 
+# File-writing tools whose target becomes a conversation artifact, keyed by the
+# markdown codeblock langtag. "save" creates a file; the rest modify one.
+_FILE_WRITE_TOOLS = {"save", "append", "patch"}
+_CREATE_TOOLS = {"save"}
+
+
+def _normalize_workspace_path(raw: str, workspace: Path) -> str | None:
+    """Resolve a tool-written path to a workspace-relative path.
+
+    Returns None for empty paths or files outside the workspace (those can't be
+    previewed via the workspace root).
+    """
+    raw = (raw or "").strip()
+    if not raw:
+        return None
+    candidate = Path(raw) if Path(raw).is_absolute() else workspace / raw
+    try:
+        return str(candidate.resolve().relative_to(workspace))
+    except (ValueError, OSError):
+        return None
+
+
+def _artifacts_from_tool_writes(
+    manager: LogManager, target_id: str | None = None
+) -> list[Artifact]:
+    """Collect artifacts for workspace files created/modified by the conversation.
+
+    Parses file-writing codeblocks (save/append/patch) from assistant messages —
+    reliable and unaffected by parallel agents, unlike a workspace diff. Uses the
+    markdown codeblock parser (not the ToolUse registry) so it works even when
+    the server process hasn't initialized tools. Dedups by path: a file saved
+    then patched is reported once, marked as created.
+    """
+    workspace = manager.workspace
+    # relpath -> {tool, created, message_index, created_at}
+    by_path: dict[str, dict[str, Any]] = {}
+    for idx, msg in enumerate(manager.log):
+        if msg.role != "assistant":
+            continue
+        for cb in Codeblock.iter_from_markdown(msg.content):
+            # langtag is e.g. "save path/to/file"; first token is the tool.
+            parts = cb.lang.strip().split(None, 1)
+            if len(parts) != 2:
+                continue
+            tool, raw_path = parts[0], parts[1]
+            if tool not in _FILE_WRITE_TOOLS:
+                continue
+            relpath = _normalize_workspace_path(raw_path, workspace)
+            if not relpath:
+                continue
+            ts = msg.timestamp
+            if ts.tzinfo is None:
+                ts = ts.replace(tzinfo=timezone.utc)
+            created = tool in _CREATE_TOOLS
+            entry = by_path.get(relpath)
+            if entry is None:
+                by_path[relpath] = {
+                    "tool": tool,
+                    "created": created,
+                    "message_index": idx,  # first touch
+                    "created_at": ts.isoformat(),  # last touch (updated below)
+                }
+            else:
+                entry["created"] = entry["created"] or created
+                entry["tool"] = tool  # most recent operation
+                entry["created_at"] = ts.isoformat()
+
+    out: list[Artifact] = []
+    for relpath, info in by_path.items():
+        artifact_id = _artifact_id(f"workspace:{relpath}")
+        if target_id is not None and artifact_id != target_id:
+            continue
+        mime_type, _ = mimetypes.guess_type(relpath)
+        kind = classify_kind(Path(relpath), mime_type)
+        size: int | None = None
+        try:
+            size = (workspace / relpath).stat().st_size
+        except OSError:
+            pass
+        out.append(
+            Artifact(
+                id=artifact_id,
+                kind=kind,
+                title=Path(relpath).name,
+                source=ArtifactSource(type="workspace", path=relpath, url=None),
+                created_at=info["created_at"],
+                size=size,
+                mime_type=mime_type,
+                provenance=ArtifactProvenance(
+                    message_index=info["message_index"],
+                    # "save" => created; otherwise the most recent modifying tool.
+                    tool="save" if info["created"] else info["tool"],
+                ),
+                preview=ArtifactPreview(type=_PREVIEW_FOR_KIND.get(kind, "none")),
+                actions=[
+                    ArtifactAction(type="download", panel=None, artifact_id=None),
+                    ArtifactAction(type="open_workspace", panel=None, artifact_id=None),
+                    ArtifactAction(
+                        type="open_panel", panel="artifacts", artifact_id=artifact_id
+                    ),
+                ],
+            )
+        )
+    return out
+
+
 def derive_artifacts(
     manager: LogManager, target_id: str | None = None
 ) -> list[Artifact]:
@@ -378,6 +485,12 @@ def derive_artifacts(
                 preview=ArtifactPreview(type=_PREVIEW_FOR_KIND.get(kind, "none")),
                 actions=actions,
             )
+
+    # Phase 3: workspace files created/modified by file-writing tool uses.
+    # setdefault so an attachment with the same id (none, ids are namespaced)
+    # or a richer metadata descriptor (merged below) takes precedence.
+    for art in _artifacts_from_tool_writes(manager, target_id=target_id):
+        by_id.setdefault(art.id, art)
 
     # Merge in tool/plugin-declared artifacts; these win on id collision.
     for art in _artifacts_from_messages(manager, target_id=target_id):

--- a/gptme/server/artifacts_api.py
+++ b/gptme/server/artifacts_api.py
@@ -371,17 +371,19 @@ def _artifacts_from_tool_writes(
                 by_path[relpath] = {
                     "tool": tool,
                     "created": created,
-                    "message_index": idx,  # first touch
-                    "created_at": ts.isoformat(),  # last touch (updated below)
+                    "message_index": idx,  # first touch (kept across writes)
+                    "created_at": ts.isoformat(),  # touch time; updated on later writes
                 }
             else:
                 entry["created"] = entry["created"] or created
                 entry["tool"] = tool  # most recent operation
-                entry["created_at"] = ts.isoformat()
+                entry["created_at"] = ts.isoformat()  # most recent touch
 
     out: list[Artifact] = []
     for relpath, info in by_path.items():
-        artifact_id = _artifact_id(f"workspace:{relpath}")
+        # Key the id on the path (same scheme as workspace descriptors in Phase 2)
+        # so a metadata-declared artifact for the same file can override this one.
+        artifact_id = _artifact_id(relpath)
         if target_id is not None and artifact_id != target_id:
             continue
         mime_type, _ = mimetypes.guess_type(relpath)

--- a/tests/test_server_artifacts.py
+++ b/tests/test_server_artifacts.py
@@ -310,3 +310,54 @@ class TestArtifactsFromMessages:
         filtered = derive_artifacts(manager, target_id=target)
         assert len(filtered) == 1
         assert filtered[0].id == target
+
+
+class TestToolWriteArtifacts:
+    """Phase 3: workspace files created/modified by file-writing tool uses."""
+
+    def test_save_creates_workspace_artifact(self, tmp_path):
+        msg = Message(
+            "assistant",
+            "Saving:\n\n```save sub/factorial.py\ndef f():\n    return 1\n```\n",
+        )
+        arts = derive_artifacts(_manager_with_messages(tmp_path, [msg]))
+        assert len(arts) == 1
+        art = arts[0]
+        assert art.source.type == "workspace"
+        assert art.source.path == "sub/factorial.py"
+        assert art.title == "factorial.py"
+        assert art.provenance.tool == "save"  # created
+        assert art.provenance.message_index == 0
+
+    def test_patch_marks_modified(self, tmp_path):
+        msg = Message(
+            "assistant",
+            "```patch app.py\n<<<<<<< ORIGINAL\na\n=======\nb\n>>>>>>> UPDATED\n```\n",
+        )
+        arts = derive_artifacts(_manager_with_messages(tmp_path, [msg]))
+        assert len(arts) == 1
+        assert arts[0].provenance.tool == "patch"  # modified, not created
+
+    def test_save_then_patch_dedups_as_created(self, tmp_path):
+        msgs = [
+            Message("assistant", "```save app.py\nx = 1\n```\n"),
+            Message(
+                "assistant",
+                "```patch app.py\n<<<<<<< ORIGINAL\nx = 1\n=======\nx = 2\n>>>>>>> UPDATED\n```\n",
+            ),
+        ]
+        arts = derive_artifacts(_manager_with_messages(tmp_path, msgs))
+        assert len(arts) == 1
+        assert arts[0].provenance.tool == "save"  # created wins over later modify
+        assert arts[0].provenance.message_index == 0  # first touch
+
+    def test_path_outside_workspace_skipped(self, tmp_path):
+        msg = Message("assistant", "```save /etc/passwd\nhi\n```\n")
+        arts = derive_artifacts(_manager_with_messages(tmp_path, [msg]))
+        assert arts == []
+
+    def test_user_message_tool_blocks_ignored(self, tmp_path):
+        # Only assistant messages count (user examples shouldn't create artifacts).
+        msg = Message("user", "```save evil.py\nx\n```\n")
+        arts = derive_artifacts(_manager_with_messages(tmp_path, [msg]))
+        assert arts == []

--- a/tests/test_server_artifacts.py
+++ b/tests/test_server_artifacts.py
@@ -338,6 +338,29 @@ class TestToolWriteArtifacts:
         assert len(arts) == 1
         assert arts[0].provenance.tool == "patch"  # modified, not created
 
+    def test_append_marks_modified(self, tmp_path):
+        msg = Message("assistant", "```append notes.md\nmore text\n```\n")
+        arts = derive_artifacts(_manager_with_messages(tmp_path, [msg]))
+        assert len(arts) == 1
+        assert arts[0].title == "notes.md"
+        assert arts[0].provenance.tool == "append"  # modified, not created
+
+    def test_metadata_descriptor_overrides_tool_write(self, tmp_path):
+        # A metadata-declared workspace artifact for the same path wins (richer
+        # provenance), so the file isn't listed twice.
+        msg = Message(
+            "assistant",
+            "```save app.py\nx = 1\n```\n",
+            metadata={
+                "artifacts": [
+                    {"source_type": "workspace", "path": "app.py", "tool": "custom"}
+                ]
+            },
+        )
+        arts = derive_artifacts(_manager_with_messages(tmp_path, [msg]))
+        assert len(arts) == 1  # not duplicated
+        assert arts[0].provenance.tool == "custom"  # metadata wins
+
     def test_save_then_patch_dedups_as_created(self, tmp_path):
         msgs = [
             Message("assistant", "```save app.py\nx = 1\n```\n"),

--- a/webui/src/components/ArtifactsPanel.tsx
+++ b/webui/src/components/ArtifactsPanel.tsx
@@ -5,7 +5,7 @@ import { FilePreview } from '@/components/workspace/FilePreview';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { rightSidebarActiveTab$, rightSidebarVisible$ } from '@/stores/sidebar';
-import { workspaceNavigateTo$ } from '@/stores/workspaceExplorer';
+import { workspaceNavigateTo$, type WorkspaceRoot } from '@/stores/workspaceExplorer';
 import type { Artifact } from '@/types/artifact';
 import type { FileType } from '@/types/workspace';
 import { useArtifactsApi } from '@/utils/artifactsApi';
@@ -18,14 +18,28 @@ function getAttachmentRelativePath(sourcePath: string): string {
   return sourcePath.replace(/^attachments\/?/, '');
 }
 
+/** Which workspace root an artifact is previewed/downloaded under, or null if it isn't file-backed. */
+function previewRootFor(artifact: Artifact): WorkspaceRoot | null {
+  if (!artifact.source.path) return null;
+  if (artifact.source.type === 'attachment') return 'attachments';
+  if (artifact.source.type === 'workspace') return 'workspace';
+  return null;
+}
+
 function toPreviewFile(artifact: Artifact): FileType | null {
-  if (artifact.source.type !== 'attachment' || !artifact.source.path) {
+  const root = previewRootFor(artifact);
+  if (!root || !artifact.source.path) {
     return null;
   }
 
   return {
     name: artifact.title,
-    path: getAttachmentRelativePath(artifact.source.path),
+    // attachment paths are stored logdir-relative ("attachments/x"); workspace
+    // paths are already workspace-relative.
+    path:
+      root === 'attachments'
+        ? getAttachmentRelativePath(artifact.source.path)
+        : artifact.source.path,
     type: 'file',
     size: artifact.size ?? 0,
     modified: artifact.created_at,
@@ -103,19 +117,26 @@ export function ArtifactsPanel({ conversationId }: ArtifactsPanelProps) {
   const selectedArtifact = artifacts.find((artifact) => artifact.id === selectedArtifactId) ?? null;
   const selectedFile = selectedArtifact ? toPreviewFile(selectedArtifact) : null;
 
+  const openInWorkspaceRoot: WorkspaceRoot | null = selectedArtifact
+    ? previewRootFor(selectedArtifact)
+    : null;
+
   const handleOpenInWorkspace = () => {
-    if (selectedArtifact?.source.type !== 'attachment' || !selectedArtifact.source.path) {
+    if (!selectedArtifact?.source.path || !openInWorkspaceRoot) {
       return;
     }
 
-    const relativePath = getAttachmentRelativePath(selectedArtifact.source.path);
+    const relativePath =
+      openInWorkspaceRoot === 'attachments'
+        ? getAttachmentRelativePath(selectedArtifact.source.path)
+        : selectedArtifact.source.path;
     const directory = relativePath.includes('/')
       ? relativePath.slice(0, relativePath.lastIndexOf('/'))
       : '';
 
     workspaceNavigateTo$.set({
       path: directory,
-      root: 'attachments',
+      root: openInWorkspaceRoot,
     });
     rightSidebarVisible$.set(true);
     rightSidebarActiveTab$.set('workspace');
@@ -143,9 +164,7 @@ export function ArtifactsPanel({ conversationId }: ArtifactsPanelProps) {
             variant="outline"
             size="sm"
             onClick={handleOpenInWorkspace}
-            disabled={
-              selectedArtifact?.source.type !== 'attachment' || !selectedArtifact?.source.path
-            }
+            disabled={!openInWorkspaceRoot || !selectedArtifact?.source.path}
             title="Open in workspace viewer"
           >
             <FolderOpen className="mr-2 h-4 w-4" />
@@ -202,8 +221,12 @@ export function ArtifactsPanel({ conversationId }: ArtifactsPanelProps) {
         </div>
 
         <div className="min-h-0 w-full flex-1 overflow-hidden">
-          {selectedArtifact && selectedFile ? (
-            <FilePreview file={selectedFile} conversationId={conversationId} root="attachments" />
+          {selectedArtifact && selectedFile && openInWorkspaceRoot ? (
+            <FilePreview
+              file={selectedFile}
+              conversationId={conversationId}
+              root={openInWorkspaceRoot}
+            />
           ) : selectedArtifact ? (
             <div className="flex h-full flex-col items-center justify-center gap-2 p-4 text-center">
               <Package className="h-8 w-8 text-muted-foreground" />


### PR DESCRIPTION
## Summary
The Artifacts panel only listed `attachments/`, so conversations that created or edited workspace files showed "No artifacts yet". This adds those files (the approach you picked: parse file-writing tool uses, which is robust to parallel agents).

**Server** (`artifacts_api.py`): new Phase 3 in `derive_artifacts` that parses file-writing codeblocks (`save`/`append`/`patch`) from assistant messages and emits `workspace`-sourced artifacts — `save` ⇒ created, otherwise modified — deduped by path (created wins, earliest message index kept). Uses the markdown `Codeblock` parser instead of the `ToolUse` registry, so it works even before the server has initialized tools (the artifacts endpoint runs without a step having loaded tools).

**WebUI** (`ArtifactsPanel.tsx`): previews and "open in workspace" now support `workspace`-sourced artifacts (previously hardcoded to `attachments`), via the workspace file API with `root='workspace'`.

## Verification
- `pytest tests/test_server_artifacts.py` (34 passed); added tests for save→created, patch→modified, save+patch dedup, out-of-workspace skip, user-message ignore.
- End-to-end against a real conversation: the endpoint now returns the conversation's saved file as a `workspace` artifact, and the workspace preview endpoint serves its content (what the panel fetches).
- webui typecheck clean.

## Notes / follow-ups
- Covers markdown file-write codeblocks (the stored format for gptme file tools). `morph`/`patch_many` and XML-format tool uses aren't parsed yet.
- "diff for modified files" (from your spec) is not included — the preview shows current file content; diffs could be a follow-up.