### PR TITLE
feat(webui): add TTS engine selector (browser / gptme-server / gptme-tts)

### DIFF
--- a/webui/src/components/SettingsContent.tsx
+++ b/webui/src/components/SettingsContent.tsx
@@ -4,6 +4,13 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
 import { Separator } from '@/components/ui/separator';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import { Volume2, Palette, Info, FileText, ExternalLink, Server, Rocket } from 'lucide-react';
 import { useSettings } from '@/contexts/SettingsContext';
 import { useTheme } from 'next-themes';
@@ -214,8 +221,7 @@ export function SettingsContent({
                   Read responses aloud
                 </Label>
                 <p className="text-xs text-muted-foreground">
-                  Speak assistant messages aloud (uses gptme-tts server if configured, otherwise
-                  browser Web Speech API)
+                  Auto-play assistant messages aloud using the TTS engine selected below
                 </p>
               </div>
               <Switch
@@ -227,22 +233,58 @@ export function SettingsContent({
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="tts-server-url" className="text-sm">
-                TTS server URL
+              <Label htmlFor="tts-engine" className="text-sm">
+                TTS engine
               </Label>
+              <p className="text-xs text-muted-foreground">Which engine synthesizes speech.</p>
+              <Select
+                value={settings.ttsProvider}
+                onValueChange={(value) =>
+                  updateSettings({ ttsProvider: value as typeof settings.ttsProvider })
+                }
+              >
+                <SelectTrigger id="tts-engine">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="auto">Automatic (server → gptme-tts → browser)</SelectItem>
+                  <SelectItem value="server">gptme-server (provider-backed)</SelectItem>
+                  <SelectItem value="external">gptme-tts server</SelectItem>
+                  <SelectItem value="browser">Browser (Web Speech API)</SelectItem>
+                </SelectContent>
+              </Select>
               <p className="text-xs text-muted-foreground">
-                HTTP base URL of a running <code className="rounded bg-muted px-1">gptme-tts</code>{' '}
-                server, e.g. <code className="rounded bg-muted px-1">http://localhost:5701</code>.
-                Leave empty to use browser TTS.
+                {settings.ttsProvider === 'server' &&
+                  'Uses the connected gptme-server /api/v2/audio/speech endpoint (provider-backed, e.g. OpenRouter — higher quality). Requires the server to have a TTS provider configured.'}
+                {settings.ttsProvider === 'external' &&
+                  'Uses a standalone gptme-tts server (set the URL below).'}
+                {settings.ttsProvider === 'browser' &&
+                  "Uses the browser's built-in speech synthesis."}
+                {settings.ttsProvider === 'auto' &&
+                  'Tries the gptme-server endpoint, then a gptme-tts server (if set), then the browser.'}
               </p>
-              <Input
-                id="tts-server-url"
-                type="text"
-                placeholder="http://localhost:5701"
-                value={settings.ttsServerUrl}
-                onChange={(e) => updateSettings({ ttsServerUrl: e.target.value.trim() })}
-              />
             </div>
+
+            {(settings.ttsProvider === 'external' || settings.ttsProvider === 'auto') && (
+              <div className="space-y-2">
+                <Label htmlFor="tts-server-url" className="text-sm">
+                  gptme-tts server URL
+                </Label>
+                <p className="text-xs text-muted-foreground">
+                  HTTP base URL of a running{' '}
+                  <code className="rounded bg-muted px-1">gptme-tts</code> server, e.g.{' '}
+                  <code className="rounded bg-muted px-1">http://localhost:5001</code>.
+                  {settings.ttsProvider === 'auto' && ' Leave empty to skip this engine.'}
+                </p>
+                <Input
+                  id="tts-server-url"
+                  type="text"
+                  placeholder="http://localhost:5001"
+                  value={settings.ttsServerUrl}
+                  onChange={(e) => updateSettings({ ttsServerUrl: e.target.value.trim() })}
+                />
+              </div>
+            )}
 
             <div className="space-y-2">
               <Label htmlFor="voice-server-url" className="text-sm">

--- a/webui/src/contexts/SettingsContext.tsx
+++ b/webui/src/contexts/SettingsContext.tsx
@@ -4,6 +4,14 @@ import { stopSpeaking } from '../utils/tts';
 export interface Settings {
   chimeEnabled: boolean;
   ttsEnabled: boolean;
+  /**
+   * Which TTS engine to use:
+   * - 'auto': try the gptme-server endpoint, then an external gptme-tts server, then browser
+   * - 'browser': the browser's built-in speechSynthesis
+   * - 'server': the connected gptme-server's /api/v2/audio/speech (provider-backed, e.g. OpenRouter)
+   * - 'external': a standalone gptme-tts server at `ttsServerUrl`
+   */
+  ttsProvider: 'auto' | 'browser' | 'server' | 'external';
   blocksDefaultOpen: boolean;
   showHiddenMessages: boolean;
   showInitialSystem: boolean;
@@ -32,6 +40,7 @@ interface SettingsContextType {
 const defaultSettings: Settings = {
   chimeEnabled: true,
   ttsEnabled: false,
+  ttsProvider: 'auto',
   blocksDefaultOpen: true,
   showHiddenMessages: false,
   showInitialSystem: false,

--- a/webui/src/contexts/SettingsContext.tsx
+++ b/webui/src/contexts/SettingsContext.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useContext, useState } from 'react';
-import { stopSpeaking } from '../utils/tts';
+import { stopSpeaking, type TtsProvider } from '../utils/tts';
 
 export interface Settings {
   chimeEnabled: boolean;
@@ -11,7 +11,7 @@ export interface Settings {
    * - 'server': the connected gptme-server's /api/v2/audio/speech (provider-backed, e.g. OpenRouter)
    * - 'external': a standalone gptme-tts server at `ttsServerUrl`
    */
-  ttsProvider: 'auto' | 'browser' | 'server' | 'external';
+  ttsProvider: TtsProvider;
   blocksDefaultOpen: boolean;
   showHiddenMessages: boolean;
   showInitialSystem: boolean;

--- a/webui/src/utils/tts.ts
+++ b/webui/src/utils/tts.ts
@@ -36,7 +36,7 @@ export function getSpeakingKey(): string | null {
   return speakingKey;
 }
 
-type TtsProvider = 'auto' | 'browser' | 'server' | 'external';
+export type TtsProvider = 'auto' | 'browser' | 'server' | 'external';
 
 function getSettings(): {
   ttsEnabled: boolean;
@@ -230,6 +230,8 @@ async function speak(rawText: string, key: string): Promise<void> {
         if (isAbortError(err)) return;
         console.warn('External gptme-tts server unavailable, falling back to browser:', err);
       }
+    } else {
+      console.warn('TTS engine "external" selected but no gptme-tts server URL set; using browser.');
     }
     if (!speakViaBrowser(spoken, key)) clearIfStill(key);
     return;

--- a/webui/src/utils/tts.ts
+++ b/webui/src/utils/tts.ts
@@ -36,20 +36,32 @@ export function getSpeakingKey(): string | null {
   return speakingKey;
 }
 
-function getSettings(): { ttsEnabled: boolean; ttsServerUrl: string } {
+type TtsProvider = 'auto' | 'browser' | 'server' | 'external';
+
+function getSettings(): {
+  ttsEnabled: boolean;
+  ttsServerUrl: string;
+  ttsProvider: TtsProvider;
+} {
   try {
     const saved = localStorage.getItem('gptme-settings');
     if (saved) {
       const s = JSON.parse(saved);
+      const provider: TtsProvider = ['auto', 'browser', 'server', 'external'].includes(
+        s.ttsProvider
+      )
+        ? s.ttsProvider
+        : 'auto';
       return {
         ttsEnabled: s.ttsEnabled === true,
         ttsServerUrl: typeof s.ttsServerUrl === 'string' ? s.ttsServerUrl.trim() : '',
+        ttsProvider: provider,
       };
     }
   } catch {
     // ignore
   }
-  return { ttsEnabled: false, ttsServerUrl: '' };
+  return { ttsEnabled: false, ttsServerUrl: '', ttsProvider: 'auto' };
 }
 
 /** Strip markdown so the spoken text sounds natural. */
@@ -159,44 +171,9 @@ async function speakViaExternalServer(text: string, serverUrl: string, key: stri
 
 const DEFAULT_SPEAK_KEY = '__tts__';
 
-async function speak(rawText: string, key: string): Promise<void> {
-  const spoken = toSpokenText(rawText);
-  if (!spoken) return;
-
-  stopSpeaking();
-  // Mark as playing immediately so the button shows a stop/loading state during
-  // the network round-trip (playBlob/utterance re-affirm the same key on start).
-  setSpeakingKey(key);
-
-  // 1. Try the same-origin /api/v2/audio/speech endpoint first.
-  try {
-    await speakViaLocalEndpoint(spoken, key);
-    return;
-  } catch (err) {
-    if (isAbortError(err)) return;
-    if ((err as Error)?.message !== LOCAL_TTS_NOT_CONFIGURED) {
-      console.warn('Local /api/v2/audio/speech unavailable, trying alternatives:', err);
-    }
-  }
-
-  // 2. Try an external gptme-tts server if configured.
-  const { ttsServerUrl } = getSettings();
-  if (ttsServerUrl) {
-    try {
-      await speakViaExternalServer(spoken, ttsServerUrl, key);
-      return;
-    } catch (err) {
-      if (isAbortError(err)) return;
-      console.warn('External TTS server unavailable, falling back to Web Speech API:', err);
-    }
-  }
-
-  // 3. Fall back to the browser's built-in speechSynthesis.
-  if (!window.speechSynthesis) {
-    // Nothing could play — clear the provisional speaking state.
-    if (getSpeakingKey() === key) setSpeakingKey(null);
-    return;
-  }
+/** Start browser speechSynthesis. Returns false if unavailable. */
+function speakViaBrowser(spoken: string, key: string): boolean {
+  if (!window.speechSynthesis) return false;
   const utterance = new SpeechSynthesisUtterance(spoken);
   utterance.rate = 1.1;
   // Guard against a previous utterance's late onend/onerror (fired after a new
@@ -207,7 +184,77 @@ async function speak(rawText: string, key: string): Promise<void> {
   utterance.onerror = () => {
     if (getSpeakingKey() === key) setSpeakingKey(null);
   };
+  setSpeakingKey(key);
   window.speechSynthesis.speak(utterance);
+  return true;
+}
+
+function clearIfStill(key: string): void {
+  if (getSpeakingKey() === key) setSpeakingKey(null);
+}
+
+async function speak(rawText: string, key: string): Promise<void> {
+  const spoken = toSpokenText(rawText);
+  if (!spoken) return;
+
+  stopSpeaking();
+  // Mark as playing immediately so the button shows a stop/loading state during
+  // the network round-trip (playBlob/utterance re-affirm the same key on start).
+  setSpeakingKey(key);
+
+  const { ttsServerUrl, ttsProvider } = getSettings();
+
+  // Explicit engine selection. Each falls back to the browser if its engine
+  // fails, so TTS still works (and aborts — from a newer call — bail silently).
+  if (ttsProvider === 'browser') {
+    if (!speakViaBrowser(spoken, key)) clearIfStill(key);
+    return;
+  }
+  if (ttsProvider === 'server') {
+    try {
+      await speakViaLocalEndpoint(spoken, key);
+      return;
+    } catch (err) {
+      if (isAbortError(err)) return;
+      console.warn('gptme-server TTS unavailable, falling back to browser:', err);
+    }
+    if (!speakViaBrowser(spoken, key)) clearIfStill(key);
+    return;
+  }
+  if (ttsProvider === 'external') {
+    if (ttsServerUrl) {
+      try {
+        await speakViaExternalServer(spoken, ttsServerUrl, key);
+        return;
+      } catch (err) {
+        if (isAbortError(err)) return;
+        console.warn('External gptme-tts server unavailable, falling back to browser:', err);
+      }
+    }
+    if (!speakViaBrowser(spoken, key)) clearIfStill(key);
+    return;
+  }
+
+  // 'auto': gptme-server endpoint -> external gptme-tts server -> browser.
+  try {
+    await speakViaLocalEndpoint(spoken, key);
+    return;
+  } catch (err) {
+    if (isAbortError(err)) return;
+    if ((err as Error)?.message !== LOCAL_TTS_NOT_CONFIGURED) {
+      console.warn('Local /api/v2/audio/speech unavailable, trying alternatives:', err);
+    }
+  }
+  if (ttsServerUrl) {
+    try {
+      await speakViaExternalServer(spoken, ttsServerUrl, key);
+      return;
+    } catch (err) {
+      if (isAbortError(err)) return;
+      console.warn('External TTS server unavailable, falling back to Web Speech API:', err);
+    }
+  }
+  if (!speakViaBrowser(spoken, key)) clearIfStill(key);
 }
 
 /** Speak text if the global TTS toggle is enabled (auto-play on new messages). */


### PR DESCRIPTION
## Summary
The Audio settings only exposed an external **gptme-tts server** URL + browser TTS, with no mention of the **gptme-server's** provider-backed `/api/v2/audio/speech` endpoint — even though `tts.ts` was silently trying it first. As you noted, gptme-tts (standalone) ≠ gptme-server with a TTS endpoint.

Adds an explicit **TTS engine** setting (`ttsProvider`) with the three engines + an auto default:
- **Automatic** (default): gptme-server endpoint → gptme-tts server → browser (prior behavior, no surprise for existing users)
- **gptme-server (provider-backed)**: the connected server's `/api/v2/audio/speech` (e.g. OpenRouter — higher quality)
- **gptme-tts server**: a standalone gptme-tts instance (URL field shown for this + auto)
- **Browser**: Web Speech API

`speak()` now honors the selection and falls back to the browser if the chosen engine fails, so playback always works. The engine descriptions clarify each option, and the server-URL field is relabeled "gptme-tts server URL" and only shown when relevant.

## Test plan
- [x] typecheck clean; `jest tts.test.ts` passes
- [ ] Settings → Audio: engine dropdown shows 4 options; selecting "gptme-tts server" reveals the URL field; "gptme-server" uses the provider endpoint; "browser" uses Web Speech
- [ ] Read-aloud honors the selected engine