### PR TITLE
feat(artifacts): format-independent file-write parsing + diffs

### DIFF
--- a/gptme/server/artifacts_api.py
+++ b/gptme/server/artifacts_api.py
@@ -433,17 +433,36 @@ def _iter_xml_writes(content: str) -> Iterator[_FileWrite]:
             paths = [tok for a in args for tok in a.split()]
             yield from _split_patch_many_body(paths, body)
         elif args:
-            # args[0] is the path; tolerate a stray leading tool-name token.
+            # args[0] is the path; tolerate a stray leading tool-name token. A
+            # bare tool name with no path (e.g. args="save") yields nothing.
             tokens = args[0].split()
-            raw_path = tokens[1] if tokens and tokens[0] == tool else args[0]
-            yield _FileWrite(tool, raw_path.strip(), body)
+            if tokens and tokens[0] == tool:
+                raw_path = tokens[1] if len(tokens) >= 2 else None
+            else:
+                raw_path = args[0]
+            if raw_path and raw_path.strip():
+                yield _FileWrite(tool, raw_path.strip(), body)
 
 
 def _iter_toolcall_writes(content: str) -> Iterator[_FileWrite]:
-    from ..tools.base import find_json_end, toolcall_re  # local import
+    from ..tools.base import (  # local import: avoids tools import at load
+        _codeblock_char_ranges,
+        find_json_end,
+        toolcall_re,
+    )
 
+    # Skip `@tool(...): {...}` matches inside fenced code blocks so tool-call
+    # syntax shown in examples/docs doesn't register as a real file write.
+    codeblock_ranges = _codeblock_char_ranges(content)
     search_from = 0
     while match := toolcall_re.search(content, search_from):
+        block_end = next(
+            (end for start, end in codeblock_ranges if start <= match.start() < end),
+            None,
+        )
+        if block_end is not None:
+            search_from = block_end
+            continue
         tool = match.group(1)
         json_start = match.start(3)
         json_end = find_json_end(content, json_start)

--- a/gptme/server/artifacts_api.py
+++ b/gptme/server/artifacts_api.py
@@ -14,11 +14,14 @@ filename heuristics.
 import hashlib
 import logging
 import mimetypes
+import re
+from collections.abc import Iterator
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Literal, cast, get_args
+from typing import Any, Literal, NamedTuple, cast, get_args
 
 import flask
+import json_repair
 from pydantic import BaseModel, Field
 
 from ..codeblock import Codeblock
@@ -111,6 +114,10 @@ class Artifact(BaseModel):
     )
     preview: ArtifactPreview = Field(..., description="Preview/renderer hint")
     actions: list[ArtifactAction] = Field(..., description="Available user actions")
+    diff: str | None = Field(
+        None,
+        description="Unified diff of the change, for files modified by the conversation",
+    )
 
 
 class ArtifactListResponse(BaseModel):
@@ -285,6 +292,7 @@ def _artifact_from_descriptor(
         ),
         preview=ArtifactPreview(type=_PREVIEW_FOR_KIND.get(kind, "none")),
         actions=actions,
+        diff=desc["diff"] if isinstance(desc.get("diff"), str) else None,
     )
 
 
@@ -312,10 +320,164 @@ def _artifacts_from_messages(
     return out
 
 
-# File-writing tools whose target becomes a conversation artifact, keyed by the
-# markdown codeblock langtag. "save" creates a file; the rest modify one.
-_FILE_WRITE_TOOLS = {"save", "append", "patch"}
+# File-writing tools whose target becomes a conversation artifact. "save"
+# creates a file; the rest modify an existing one. patch_many writes several
+# files in a single tool use.
+_FILE_WRITE_TOOLS = {"save", "append", "patch", "morph", "patch_many"}
 _CREATE_TOOLS = {"save"}
+_MULTI_PATH_TOOLS = {"patch_many"}
+
+# Matches the per-file header of multi-hunk patch_many bodies (mirrors
+# gptme.tools.patch_many._CONFIRM_HEADER_RE), used to recover paths embedded in
+# the codeblock body rather than the langtag/args.
+_PATCH_MANY_PATH_RE = re.compile(r"(?m)^=== PATH: (?P<path>.+?) ===\s*$")
+
+
+class _FileWrite(NamedTuple):
+    """One file-writing operation recovered from a message, format-agnostic."""
+
+    tool: str
+    raw_path: str
+    # Edit payload for diff generation (patch body, appended text, ...). None
+    # when the tool's change can't be turned into a diff (e.g. morph).
+    payload: str | None
+
+
+def _diff_for_write(tool: str, payload: str | None) -> str | None:
+    """Build a unified-diff string for a modifying write, or None if not derivable.
+
+    ``patch``/``patch_many`` payloads carry ORIGINAL/UPDATED blocks we can diff
+    directly. ``append`` is pure additions. ``morph`` edits use ``... existing
+    code ...`` placeholders with no recoverable original, so they get no diff.
+    """
+    if not payload:
+        return None
+    if tool in ("patch", "patch_many"):
+        from ..tools.patch import Patch  # local import: avoids tools import at load
+
+        try:
+            diffs = [p.diff_minimal() for p in Patch._from_codeblock(payload)]
+        except Exception:
+            return None
+        body = "\n".join(d for d in diffs if d)
+        return body or None
+    if tool == "append":
+        added = "\n".join("+" + line for line in payload.splitlines())
+        return added or None
+    return None
+
+
+def _iter_file_writes(content: str) -> Iterator[_FileWrite]:
+    """Yield file-writing operations in a message across all tool formats.
+
+    Handles markdown codeblocks, XML tool-use, and native tool-call JSON without
+    requiring the tool registry to be initialized (the artifact read path runs in
+    a server process that hasn't loaded tools). patch_many yields one entry per
+    target file.
+    """
+    yield from _iter_markdown_writes(content)
+    yield from _iter_xml_writes(content)
+    yield from _iter_toolcall_writes(content)
+
+
+def _split_patch_many_body(paths: list[str], body: str) -> Iterator[_FileWrite]:
+    """Pair patch_many paths with their patch bodies (header- or embedded-form)."""
+    embedded = list(_PATCH_MANY_PATH_RE.finditer(body))
+    if embedded:
+        # Multi-hunk form: `=== PATH: x ===` headers delimit per-file patches.
+        for i, m in enumerate(embedded):
+            start = m.end()
+            end = embedded[i + 1].start() if i + 1 < len(embedded) else len(body)
+            yield _FileWrite("patch_many", m.group("path"), body[start:end].strip())
+        return
+    # Simple form: paths in the header, one conflict-marker patch each (in order).
+    from ..tools.patch import DIVIDER, ORIGINAL, UPDATED, Patch  # local import
+
+    try:
+        patches = list(Patch._from_codeblock(body))
+    except Exception:
+        patches = []
+    for i, raw_path in enumerate(paths):
+        payload = (
+            f"{ORIGINAL}{patches[i].original}{DIVIDER}{patches[i].updated}{UPDATED}"
+            if i < len(patches)
+            else None
+        )
+        yield _FileWrite("patch_many", raw_path, payload)
+
+
+def _iter_markdown_writes(content: str) -> Iterator[_FileWrite]:
+    for cb in Codeblock.iter_from_markdown(content):
+        parts = cb.lang.strip().split()
+        if not parts or parts[0] not in _FILE_WRITE_TOOLS:
+            continue
+        tool = parts[0]
+        if tool in _MULTI_PATH_TOOLS:
+            yield from _split_patch_many_body(parts[1:], cb.content)
+        elif len(parts) >= 2:
+            # Keep the path intact even if it contains spaces.
+            raw_path = cb.lang.strip().split(None, 1)[1]
+            yield _FileWrite(tool, raw_path, cb.content)
+
+
+def _iter_xml_writes(content: str) -> Iterator[_FileWrite]:
+    from ..tools.base import ToolUse  # local import: avoids tools import at load
+
+    for tu in ToolUse._iter_from_xml(content):
+        tool = tu.tool
+        if tool not in _FILE_WRITE_TOOLS:
+            continue
+        args = [str(a) for a in (tu.args or [])]
+        body = tu.content or ""
+        if tool in _MULTI_PATH_TOOLS:
+            paths = [tok for a in args for tok in a.split()]
+            yield from _split_patch_many_body(paths, body)
+        elif args:
+            # args[0] is the path; tolerate a stray leading tool-name token.
+            tokens = args[0].split()
+            raw_path = tokens[1] if tokens and tokens[0] == tool else args[0]
+            yield _FileWrite(tool, raw_path.strip(), body)
+
+
+def _iter_toolcall_writes(content: str) -> Iterator[_FileWrite]:
+    from ..tools.base import find_json_end, toolcall_re  # local import
+
+    search_from = 0
+    while match := toolcall_re.search(content, search_from):
+        tool = match.group(1)
+        json_start = match.start(3)
+        json_end = find_json_end(content, json_start)
+        if json_end is None:
+            break
+        search_from = json_end
+        if tool not in _FILE_WRITE_TOOLS:
+            continue
+        try:
+            kwargs = json_repair.loads(content[json_start:json_end])
+        except Exception:
+            continue
+        if not isinstance(kwargs, dict):
+            continue
+        if tool in _MULTI_PATH_TOOLS:
+            raw = kwargs.get("patches")
+            if isinstance(raw, str):
+                try:
+                    raw = json_repair.loads(raw)
+                except Exception:
+                    raw = None
+            if isinstance(raw, list):
+                for entry in raw:
+                    if isinstance(entry, dict) and entry.get("path"):
+                        yield _FileWrite(
+                            "patch_many",
+                            str(entry["path"]),
+                            entry.get("patch"),
+                        )
+        else:
+            path = kwargs.get("path")
+            if path:
+                payload = kwargs.get("patch") or kwargs.get("content")
+                yield _FileWrite(tool, str(path), payload)
 
 
 def _normalize_workspace_path(raw: str, workspace: Path) -> str | None:
@@ -339,45 +501,44 @@ def _artifacts_from_tool_writes(
 ) -> list[Artifact]:
     """Collect artifacts for workspace files created/modified by the conversation.
 
-    Parses file-writing codeblocks (save/append/patch) from assistant messages —
-    reliable and unaffected by parallel agents, unlike a workspace diff. Uses the
-    markdown codeblock parser (not the ToolUse registry) so it works even when
-    the server process hasn't initialized tools. Dedups by path: a file saved
-    then patched is reported once, marked as created.
+    Parses file-writing tool uses (save/append/patch/morph/patch_many) from
+    assistant messages — reliable and unaffected by parallel agents, unlike a
+    workspace diff. Handles markdown, XML, and native tool-call formats without
+    requiring the tool registry (the read path runs in a server process that
+    hasn't loaded tools). Dedups by path: a file saved then patched is reported
+    once, marked as created. Modified files carry a unified ``diff`` when one can
+    be derived from the edit.
     """
     workspace = manager.workspace
-    # relpath -> {tool, created, message_index, created_at}
+    # relpath -> {tool, created, message_index, created_at, diff}
     by_path: dict[str, dict[str, Any]] = {}
     for idx, msg in enumerate(manager.log):
         if msg.role != "assistant":
             continue
-        for cb in Codeblock.iter_from_markdown(msg.content):
-            # langtag is e.g. "save path/to/file"; first token is the tool.
-            parts = cb.lang.strip().split(None, 1)
-            if len(parts) != 2:
-                continue
-            tool, raw_path = parts[0], parts[1]
-            if tool not in _FILE_WRITE_TOOLS:
-                continue
-            relpath = _normalize_workspace_path(raw_path, workspace)
+        for write in _iter_file_writes(msg.content):
+            relpath = _normalize_workspace_path(write.raw_path, workspace)
             if not relpath:
                 continue
             ts = msg.timestamp
             if ts.tzinfo is None:
                 ts = ts.replace(tzinfo=timezone.utc)
-            created = tool in _CREATE_TOOLS
+            created = write.tool in _CREATE_TOOLS
+            diff = _diff_for_write(write.tool, write.payload)
             entry = by_path.get(relpath)
             if entry is None:
                 by_path[relpath] = {
-                    "tool": tool,
+                    "tool": write.tool,
                     "created": created,
                     "message_index": idx,  # first touch (kept across writes)
                     "created_at": ts.isoformat(),  # touch time; updated on later writes
+                    "diff": diff,
                 }
             else:
                 entry["created"] = entry["created"] or created
-                entry["tool"] = tool  # most recent operation
+                entry["tool"] = write.tool  # most recent operation
                 entry["created_at"] = ts.isoformat()  # most recent touch
+                if diff is not None:
+                    entry["diff"] = diff  # keep most recent derivable diff
 
     out: list[Artifact] = []
     for relpath, info in by_path.items():
@@ -415,6 +576,8 @@ def _artifacts_from_tool_writes(
                         type="open_panel", panel="artifacts", artifact_id=artifact_id
                     ),
                 ],
+                # Only modified files carry a diff; created files show full content.
+                diff=None if info["created"] else info.get("diff"),
             )
         )
     return out
@@ -486,6 +649,7 @@ def derive_artifacts(
                 ),
                 preview=ArtifactPreview(type=_PREVIEW_FOR_KIND.get(kind, "none")),
                 actions=actions,
+                diff=None,  # uploaded/attachment files have no conversation diff
             )
 
     # Phase 3: workspace files created/modified by file-writing tool uses.

--- a/tests/test_server_artifacts.py
+++ b/tests/test_server_artifacts.py
@@ -384,3 +384,111 @@ class TestToolWriteArtifacts:
         msg = Message("user", "```save evil.py\nx\n```\n")
         arts = derive_artifacts(_manager_with_messages(tmp_path, [msg]))
         assert arts == []
+
+    def test_morph_marks_modified(self, tmp_path):
+        msg = Message(
+            "assistant",
+            "```morph app.py\n// ... existing code ...\nFOO\n```\n",
+        )
+        arts = derive_artifacts(_manager_with_messages(tmp_path, [msg]))
+        assert len(arts) == 1
+        assert arts[0].title == "app.py"
+        assert arts[0].provenance.tool == "morph"  # modified, not created
+        assert arts[0].diff is None  # morph edits aren't diffable
+
+    def test_patch_many_simple_form(self, tmp_path):
+        msg = Message(
+            "assistant",
+            "```patch_many a.py b.py\n"
+            "<<<<<<< ORIGINAL\n1\n=======\n2\n>>>>>>> UPDATED\n"
+            "<<<<<<< ORIGINAL\n3\n=======\n4\n>>>>>>> UPDATED\n```\n",
+        )
+        arts = {
+            a.title: a
+            for a in derive_artifacts(_manager_with_messages(tmp_path, [msg]))
+        }
+        assert set(arts) == {"a.py", "b.py"}
+        assert arts["a.py"].provenance.tool == "patch_many"
+        assert arts["a.py"].diff == "-1\n+2"
+        assert arts["b.py"].diff == "-3\n+4"
+
+    def test_patch_many_embedded_paths(self, tmp_path):
+        msg = Message(
+            "assistant",
+            "```patch_many\n"
+            "=== PATH: p.py ===\n"
+            "<<<<<<< ORIGINAL\na\n=======\nb\n>>>>>>> UPDATED\n"
+            "=== PATH: q.py ===\n"
+            "<<<<<<< ORIGINAL\nc\n=======\nd\n>>>>>>> UPDATED\n```\n",
+        )
+        arts = {
+            a.title: a
+            for a in derive_artifacts(_manager_with_messages(tmp_path, [msg]))
+        }
+        assert set(arts) == {"p.py", "q.py"}
+        assert arts["p.py"].diff == "-a\n+b"
+        assert arts["q.py"].diff == "-c\n+d"
+
+    def test_xml_format_save(self, tmp_path):
+        msg = Message(
+            "assistant",
+            '<tool-use>\n<save args="x.py">\nx = 1\n</save>\n</tool-use>',
+        )
+        arts = derive_artifacts(_manager_with_messages(tmp_path, [msg]))
+        assert len(arts) == 1
+        assert arts[0].title == "x.py"
+        assert arts[0].provenance.tool == "save"
+
+    def test_xml_format_patch_has_diff(self, tmp_path):
+        msg = Message(
+            "assistant",
+            '<tool-use>\n<patch args="app.py">\n'
+            "<<<<<<< ORIGINAL\na\n=======\nb\n>>>>>>> UPDATED\n"
+            "</patch>\n</tool-use>",
+        )
+        arts = derive_artifacts(_manager_with_messages(tmp_path, [msg]))
+        assert len(arts) == 1
+        assert arts[0].provenance.tool == "patch"
+        assert arts[0].diff == "-a\n+b"
+
+    def test_toolcall_format_save(self, tmp_path):
+        msg = Message(
+            "assistant",
+            '@save(toolu_01): {"path": "t.py", "content": "x = 1"}',
+        )
+        arts = derive_artifacts(_manager_with_messages(tmp_path, [msg]))
+        assert len(arts) == 1
+        assert arts[0].title == "t.py"
+        assert arts[0].provenance.tool == "save"
+
+    def test_toolcall_format_patch_many_has_diff(self, tmp_path):
+        msg = Message(
+            "assistant",
+            '@patch_many(toolu_02): {"patches": [{"path": "a.py", '
+            '"patch": "<<<<<<< ORIGINAL\\nx\\n=======\\ny\\n>>>>>>> UPDATED"}]}',
+        )
+        arts = derive_artifacts(_manager_with_messages(tmp_path, [msg]))
+        assert len(arts) == 1
+        assert arts[0].title == "a.py"
+        assert arts[0].provenance.tool == "patch_many"
+        assert arts[0].diff == "-x\n+y"
+
+    def test_append_diff_is_additions(self, tmp_path):
+        msg = Message("assistant", "```append notes.md\nline one\nline two\n```\n")
+        arts = derive_artifacts(_manager_with_messages(tmp_path, [msg]))
+        assert len(arts) == 1
+        assert arts[0].diff == "+line one\n+line two"
+
+    def test_created_file_has_no_diff(self, tmp_path):
+        # save-then-patch stays "created"; created files show full content, no diff.
+        msgs = [
+            Message("assistant", "```save app.py\nx = 1\n```\n"),
+            Message(
+                "assistant",
+                "```patch app.py\n<<<<<<< ORIGINAL\nx = 1\n=======\nx = 2\n>>>>>>> UPDATED\n```\n",
+            ),
+        ]
+        arts = derive_artifacts(_manager_with_messages(tmp_path, msgs))
+        assert len(arts) == 1
+        assert arts[0].provenance.tool == "save"
+        assert arts[0].diff is None

--- a/tests/test_server_artifacts.py
+++ b/tests/test_server_artifacts.py
@@ -479,6 +479,25 @@ class TestToolWriteArtifacts:
         assert len(arts) == 1
         assert arts[0].diff == "+line one\n+line two"
 
+    def test_toolcall_in_codeblock_ignored(self, tmp_path):
+        # Tool-call syntax shown as an example inside a fenced block is not a
+        # real write and must not produce a phantom artifact.
+        msg = Message(
+            "assistant",
+            'Here is how to use save:\n\n```\n@save(toolu_01): {"path": "x.py", '
+            '"content": "hi"}\n```\n',
+        )
+        arts = derive_artifacts(_manager_with_messages(tmp_path, [msg]))
+        assert arts == []
+
+    def test_xml_bare_tool_name_arg_no_crash(self, tmp_path):
+        # args="save" with no path must not raise; it's just skipped.
+        msg = Message(
+            "assistant", '<tool-use>\n<save args="save">\nx\n</save>\n</tool-use>'
+        )
+        arts = derive_artifacts(_manager_with_messages(tmp_path, [msg]))
+        assert arts == []
+
     def test_created_file_has_no_diff(self, tmp_path):
         # save-then-patch stays "created"; created files show full content, no diff.
         msgs = [

--- a/webui/src/components/ArtifactsPanel.tsx
+++ b/webui/src/components/ArtifactsPanel.tsx
@@ -47,6 +47,25 @@ function toPreviewFile(artifact: Artifact): FileType | null {
   };
 }
 
+function DiffBlock({ diff }: { diff: string }) {
+  return (
+    <pre className="h-full overflow-auto bg-muted/30 p-3 font-mono text-xs leading-relaxed">
+      {diff.split('\n').map((line, i) => {
+        const cls = line.startsWith('+')
+          ? 'text-green-600 dark:text-green-400'
+          : line.startsWith('-')
+            ? 'text-red-600 dark:text-red-400'
+            : 'text-muted-foreground';
+        return (
+          <div key={i} className={cls}>
+            {line || ' '}
+          </div>
+        );
+      })}
+    </pre>
+  );
+}
+
 function formatFileSize(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
@@ -65,6 +84,7 @@ function formatCreatedAt(createdAt: string): string {
 export function ArtifactsPanel({ conversationId }: ArtifactsPanelProps) {
   const [artifacts, setArtifacts] = useState<Artifact[]>([]);
   const [selectedArtifactId, setSelectedArtifactId] = useState<string | null>(null);
+  const [showDiff, setShowDiff] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -116,6 +136,12 @@ export function ArtifactsPanel({ conversationId }: ArtifactsPanelProps) {
 
   const selectedArtifact = artifacts.find((artifact) => artifact.id === selectedArtifactId) ?? null;
   const selectedFile = selectedArtifact ? toPreviewFile(selectedArtifact) : null;
+  const selectedDiff = selectedArtifact?.diff ?? null;
+
+  // Default to the diff view when a selection has changes to show.
+  useEffect(() => {
+    setShowDiff(!!selectedDiff);
+  }, [selectedArtifactId, selectedDiff]);
 
   const openInWorkspaceRoot: WorkspaceRoot | null = selectedArtifact
     ? previewRootFor(selectedArtifact)
@@ -220,8 +246,32 @@ export function ArtifactsPanel({ conversationId }: ArtifactsPanelProps) {
           )}
         </div>
 
+        {selectedDiff && (
+          <div className="flex shrink-0 items-center gap-1 border-b px-3 py-1.5">
+            <Button
+              variant={showDiff ? 'secondary' : 'ghost'}
+              size="sm"
+              className="h-6 px-2 text-xs"
+              onClick={() => setShowDiff(true)}
+            >
+              Diff
+            </Button>
+            <Button
+              variant={!showDiff ? 'secondary' : 'ghost'}
+              size="sm"
+              className="h-6 px-2 text-xs"
+              onClick={() => setShowDiff(false)}
+              disabled={!selectedFile || !openInWorkspaceRoot}
+            >
+              Preview
+            </Button>
+          </div>
+        )}
+
         <div className="min-h-0 w-full flex-1 overflow-hidden">
-          {selectedArtifact && selectedFile && openInWorkspaceRoot ? (
+          {selectedDiff && showDiff ? (
+            <DiffBlock diff={selectedDiff} />
+          ) : selectedArtifact && selectedFile && openInWorkspaceRoot ? (
             <FilePreview
               file={selectedFile}
               conversationId={conversationId}

--- a/webui/src/components/__tests__/ArtifactsPanel.test.tsx
+++ b/webui/src/components/__tests__/ArtifactsPanel.test.tsx
@@ -59,6 +59,7 @@ describe('ArtifactsPanel', () => {
       type: 'image',
     },
     actions: [],
+    diff: null,
   };
 
   beforeEach(() => {
@@ -102,6 +103,31 @@ describe('ArtifactsPanel', () => {
     });
     expect(mockSetters.rightSidebarVisible).toHaveBeenCalledWith(true);
     expect(mockSetters.rightSidebarActiveTab).toHaveBeenCalledWith('workspace');
+  });
+
+  it('renders the diff for a modified artifact and toggles to preview', async () => {
+    const modified: Artifact = {
+      ...artifact,
+      id: 'art_app',
+      kind: 'other',
+      title: 'app.py',
+      source: { type: 'workspace', path: 'app.py', url: null },
+      preview: { type: 'text' },
+      provenance: { message_index: 1, tool: 'patch' },
+      diff: '-old line\n+new line',
+    };
+    mockListArtifacts.mockResolvedValue([modified]);
+
+    render(<ArtifactsPanel conversationId="conv-diff" />);
+
+    await waitFor(() => {
+      expect(screen.getByText('-old line')).toBeInTheDocument();
+    });
+    expect(screen.getByText('+new line')).toBeInTheDocument();
+
+    // Toggle to the file preview.
+    fireEvent.click(screen.getByRole('button', { name: 'Preview' }));
+    expect(screen.getByTestId('file-preview')).toHaveTextContent('app.py:app.py');
   });
 
   it('shows an error when artifact loading fails', async () => {

--- a/webui/src/types/artifact.ts
+++ b/webui/src/types/artifact.ts
@@ -45,6 +45,8 @@ export interface Artifact {
   provenance: ArtifactProvenance;
   preview: ArtifactPreview;
   actions: ArtifactAction[];
+  /** Unified diff of the change, for files modified by the conversation. */
+  diff: string | null;
 }
 
 export interface ArtifactListResponse {


### PR DESCRIPTION
## Summary

Follow-up to #2814. Extends conversation artifact detection so it works regardless of the tool format the assistant used, adds the `morph` and `patch_many` tools, and surfaces diffs for modified files.

- **Format-independent parsing**: file writes are now recovered from markdown codeblocks, XML tool-use, **and** native tool-call JSON. All parsing stays registry-independent (the artifact read path runs in a server process that hasn't initialized tools).
- **morph + patch_many**: `morph` is treated as a modify; `patch_many` expands into one artifact per target file, handling both the header-paths form (` ```patch_many a.py b.py `) and the embedded `=== PATH: ... ===` multi-hunk form, plus the kwargs `patches` array in tool-call format.
- **Diffs for modified files**: each modified artifact carries a unified `diff` derived from the edit — ORIGINAL/UPDATED blocks for `patch`/`patch_many`, additions for `append`. `morph` (no recoverable original) and created files (full content shown instead) get no diff.
- **webui**: new `diff` field on the `Artifact` type; the Artifacts panel shows a Diff/Preview toggle and a color-coded diff view, defaulting to the diff when a change is present.

## Test plan

- [x] `pytest tests/test_server_artifacts.py` — 45 passed (10 new cases: morph, patch_many simple/embedded, XML save/patch, tool-call save/patch_many, append diff, created-no-diff)
- [x] `npx jest ArtifactsPanel` — 4 passed (new diff render + toggle test)
- [x] webui `typecheck` + `eslint` clean on changed files
- [x] `ruff` + `mypy` pass (pre-commit)