### PR TITLE
fix(auth): change default API URL from fleet.gptme.ai to Supabase

### DIFF
--- a/gptme/cli/auth.py
+++ b/gptme/cli/auth.py
@@ -20,6 +20,8 @@ import requests
 import requests.exceptions
 from rich.console import Console
 
+from ..llm.llm_gptme import DEFAULT_SERVICE_URL
+
 logger = logging.getLogger(__name__)
 console = Console()
 
@@ -32,7 +34,7 @@ def main():
 @main.command("login")
 @click.option(
     "--url",
-    default="https://fleet.gptme.ai",
+    default=DEFAULT_SERVICE_URL,
     show_default=True,
     help="gptme service URL (used for LLM API and token storage).",
 )
@@ -204,7 +206,7 @@ def auth_login(url: str, auth_url: str | None, no_browser: bool):
 @main.command("logout")
 @click.option(
     "--url",
-    default="https://fleet.gptme.ai",
+    default=DEFAULT_SERVICE_URL,
     show_default=True,
     help="gptme service URL to log out from.",
 )
@@ -224,7 +226,7 @@ def auth_logout(url: str):
 @main.command("status")
 @click.option(
     "--url",
-    default="https://fleet.gptme.ai",
+    default=DEFAULT_SERVICE_URL,
     show_default=True,
     help="gptme service URL to check.",
 )

--- a/gptme/llm/llm_gptme.py
+++ b/gptme/llm/llm_gptme.py
@@ -14,9 +14,15 @@ Token priority:
     3. Error with instructions
 
 Base URL priority:
-    1. Token's ``server_url`` field
+    1. Token's ``server_url`` field (Supabase URL → resolved to messages endpoint)
     2. ``GPTME_CLOUD_BASE_URL`` environment variable
-    3. Default: ``https://fleet.gptme.ai/v1``
+    3. Default: Supabase messages edge function endpoint
+
+Architecture note:
+    The gptme.ai API lives on Supabase Edge Functions, NOT on fleet.gptme.ai.
+    fleet.gptme.ai is only for user instance management (fleet-operator).
+    - LLM completions: ``https://<project>.supabase.co/functions/v1/messages``
+    - Model listing:   ``https://<project>.supabase.co/functions/v1/models``
 """
 
 import hashlib
@@ -35,15 +41,22 @@ class GptmeAuthError(KeyError):
     """Raised when no valid gptme.ai credentials are found."""
 
 
-# Default base URL for the gptme cloud API proxy
-DEFAULT_BASE_URL = "https://fleet.gptme.ai/v1"
-
-# Default service URL (for auth endpoints, without /v1)
-DEFAULT_SERVICE_URL = "https://fleet.gptme.ai"
-
-# Device auth has moved off fleet-operator and onto Supabase edge functions.
-# The CLI polls these two endpoints during the RFC 8628 device authorization flow.
+# Supabase project URL — all gptme.ai API functions live here
 _SUPABASE_URL = "https://kpkxgnfpyntahyhckhgm.supabase.co"
+
+# Default base URL for LLM completions (OpenAI-compatible endpoint).
+# Supabase routes /functions/v1/messages/* to the messages edge function,
+# so the OpenAI client calling POST /chat/completions lands at the right place.
+DEFAULT_BASE_URL = f"{_SUPABASE_URL}/functions/v1/messages"
+
+# Default service URL (Supabase project root, used for token storage keying).
+# fleet.gptme.ai is NOT used for API calls — only for user instance management.
+DEFAULT_SERVICE_URL = _SUPABASE_URL
+
+# Functions root URL — used for model listing (GET /functions/v1/models).
+DEFAULT_MODELS_BASE_URL = f"{_SUPABASE_URL}/functions/v1"
+
+# Device auth edge function endpoint (RFC 8628 device authorization flow).
 DEFAULT_DEVICE_AUTH_URL = f"{_SUPABASE_URL}/functions/v1/device-auth"
 
 # Token storage directory
@@ -116,22 +129,30 @@ def get_api_key(config: Config) -> str:
 
 
 def get_base_url(config: Config) -> str:
-    """Get the base URL for the gptme cloud API.
+    """Get the base URL for the gptme cloud LLM completions endpoint.
 
     Checks (in order):
     1. Token file's ``server_url`` field
     2. ``GPTME_CLOUD_BASE_URL`` environment variable
-    3. Default: https://fleet.gptme.ai/v1
+    3. Default: Supabase messages edge function
+
+    The returned URL is used as the OpenAI client ``base_url``.  The OpenAI
+    client appends ``/chat/completions`` to it — Supabase routes all
+    ``/functions/v1/messages/*`` sub-paths to the messages edge function.
     """
     # Check token file for server URL
     token_data = _load_token()
     if token_data and token_data.get("server_url"):
         server_url = token_data["server_url"].rstrip("/")
+        # Supabase token (new default): resolve to messages endpoint
+        if server_url == _SUPABASE_URL:
+            return DEFAULT_BASE_URL
+        # Legacy fleet token or custom URL: append /v1 if not already present
         if not server_url.endswith("/v1"):
             server_url += "/v1"
         return server_url
 
-    # Check env var (normalize /v1 suffix)
+    # Check env var
     env_url = config.get_env("GPTME_CLOUD_BASE_URL")
     if env_url:
         env_url = env_url.rstrip("/")
@@ -140,6 +161,20 @@ def get_base_url(config: Config) -> str:
         return env_url
 
     return DEFAULT_BASE_URL
+
+
+def get_models_base_url(config: Config) -> str:
+    """Get the base URL for gptme cloud model listing.
+
+    Returns a URL where appending ``/models`` reaches the models endpoint.
+    For Supabase this is ``/functions/v1``; for legacy fleet/custom URLs
+    the base URL already ends in ``/v1``.
+    """
+    base_url = get_base_url(config)
+    # Strip the messages function name to get the functions root
+    if base_url.endswith("/messages"):
+        return base_url.rsplit("/messages", 1)[0]
+    return base_url
 
 
 def device_flow_authenticate(

--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -1693,12 +1693,12 @@ def get_available_models(provider: Provider) -> list[ModelMeta]:
         return _get_openai_compatible_models(config, provider)
 
     if provider == "gptme":
-        from .llm_gptme import get_api_key, get_base_url
+        from .llm_gptme import get_api_key, get_models_base_url
 
         return _get_openai_compatible_models(
             config,
             provider,
-            base_url=get_base_url(config),
+            base_url=get_models_base_url(config),
             api_key=get_api_key(config),
         )
 

--- a/webui/e2e/conversation.spec.ts
+++ b/webui/e2e/conversation.spec.ts
@@ -131,4 +131,27 @@ test.describe('Split View', () => {
     // Split view header should be gone
     await expect(page.getByText('Split view')).not.toBeVisible();
   });
+
+  test('should toggle split view with keyboard shortcut', async ({ page }) => {
+    // Navigate to a single conversation
+    await page.goto('/chat/introduction');
+    await page.waitForLoadState('networkidle');
+
+    // Should see the conversation content
+    await expect(page.getByText(/Hello! I'm gptme/)).toBeVisible({ timeout: 10000 });
+
+    // Press keyboard shortcut (Ctrl+Shift+\) to open split view
+    await page.keyboard.press('Control+Shift+\\');
+    await page.waitForLoadState('networkidle');
+
+    // Split view header should appear
+    await expect(page.getByText('Split view')).toBeVisible({ timeout: 10000 });
+
+    // Press keyboard shortcut again to close split view
+    await page.keyboard.press('Control+Shift+\\');
+    await page.waitForLoadState('networkidle');
+
+    // Split view header should be gone
+    await expect(page.getByText('Split view')).not.toBeVisible();
+  });
 });

--- a/webui/src/components/ConversationList.tsx
+++ b/webui/src/components/ConversationList.tsx
@@ -10,6 +10,7 @@ import {
   FileJson,
   Trash2,
   BookOpen,
+  Columns2,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
@@ -55,6 +56,7 @@ interface Props {
   hasNextPage?: boolean;
   selectedId$?: Observable<string | null>;
   showServerLabels?: boolean;
+  onOpenInSplitView?: (conversationId: string) => void;
 }
 
 export const ConversationList: FC<Props> = ({
@@ -69,6 +71,7 @@ export const ConversationList: FC<Props> = ({
   hasNextPage = false,
   selectedId$,
   showServerLabels = false,
+  onOpenInSplitView,
 }) => {
   const { api, isConnected$ } = useApi();
   const isConnected = use$(isConnected$);
@@ -499,6 +502,17 @@ export const ConversationList: FC<Props> = ({
               </ContextMenuItem>
             </ContextMenuSubContent>
           </ContextMenuSub>
+          {onOpenInSplitView && (
+            <ContextMenuItem
+              onClick={(e) => {
+                e.stopPropagation();
+                onOpenInSplitView(conv.id);
+              }}
+            >
+              <Columns2 className="mr-2 h-4 w-4" />
+              Open in split view
+            </ContextMenuItem>
+          )}
           <ContextMenuSeparator />
           <ContextMenuItem
             className="text-destructive focus:text-destructive"

--- a/webui/src/components/MainLayout.tsx
+++ b/webui/src/components/MainLayout.tsx
@@ -430,6 +430,34 @@ const MainLayout: FC<Props> = ({ conversationId, taskId }) => {
     }
   }, [isMobile]);
 
+  // Handle navigating a split pane to a different conversation
+  const handleNavigatePane = useCallback(
+    (paneIndex: 0 | 1, newId: string) => {
+      if (!splitIds) return;
+      const ids = [...splitIds];
+      ids[paneIndex] = newId;
+      const params = new URLSearchParams(searchParams);
+      params.set("split", `${ids[0]},${ids[1]}`);
+      navigate(`?${params.toString()}`);
+    },
+    [splitIds, searchParams, navigate]
+  );
+
+  // Handle "Open in split view" from a conversation list context menu
+  const handleOpenInSplitView = useCallback(
+    (conversationId: string) => {
+      const currentId = selectedConversation$.get();
+      const params = new URLSearchParams(searchParams);
+      if (currentId) {
+        params.set("split", `${currentId},${conversationId}`);
+      } else {
+        params.set("split", `${conversationId},${conversationId}`);
+      }
+      navigate(`?${params.toString()}`);
+    },
+    [searchParams, navigate]
+  );
+
   // Keyboard shortcut: Ctrl+Shift+\ (Cmd+Shift+\ on Mac) to toggle split view
   useEffect(() => {
     const toggleSplit = (e: KeyboardEvent) => {
@@ -508,10 +536,13 @@ const MainLayout: FC<Props> = ({ conversationId, taskId }) => {
         <SplitConversationView
           leftId={splitIds[0]}
           rightId={splitIds[1]}
+          allConversations={allConversations}
           serverId={serverParam || undefined}
           leftIsReadOnly={leftConversation.readonly}
           rightIsReadOnly={rightConversation.readonly}
           vertical={isMobile}
+          onNavigateLeft={(id: string) => handleNavigatePane(0, id)}
+          onNavigateRight={(id: string) => handleNavigatePane(1, id)}
           onClose={() => {
             const params = new URLSearchParams(searchParams);
             params.delete('split');
@@ -607,6 +638,7 @@ const MainLayout: FC<Props> = ({ conversationId, taskId }) => {
                 tasksLoading={tasksLoading}
                 tasksError={!!tasksError}
                 onTasksRetry={() => refetchTasks()}
+                onOpenInSplitView={handleOpenInSplitView}
               />
             </div>
           </SheetContent>
@@ -717,6 +749,7 @@ const MainLayout: FC<Props> = ({ conversationId, taskId }) => {
             tasksLoading={tasksLoading}
             tasksError={!!tasksError}
             onTasksRetry={() => refetchTasks()}
+            onOpenInSplitView={handleOpenInSplitView}
           />
         </ResizablePanel>
 

--- a/webui/src/components/MainLayout.tsx
+++ b/webui/src/components/MainLayout.tsx
@@ -437,7 +437,7 @@ const MainLayout: FC<Props> = ({ conversationId, taskId }) => {
       const ids = [...splitIds];
       ids[paneIndex] = newId;
       const params = new URLSearchParams(searchParams);
-      params.set("split", `${ids[0]},${ids[1]}`);
+      params.set('split', `${ids[0]},${ids[1]}`);
       navigate(`?${params.toString()}`);
     },
     [splitIds, searchParams, navigate]
@@ -446,16 +446,21 @@ const MainLayout: FC<Props> = ({ conversationId, taskId }) => {
   // Handle "Open in split view" from a conversation list context menu
   const handleOpenInSplitView = useCallback(
     (conversationId: string) => {
-      const currentId = selectedConversation$.get();
       const params = new URLSearchParams(searchParams);
-      if (currentId) {
-        params.set("split", `${currentId},${conversationId}`);
+      if (splitIds) {
+        // Already in split view: put clicked conversation in right pane, keep left
+        params.set('split', `${splitIds[0]},${conversationId}`);
       } else {
-        params.set("split", `${conversationId},${conversationId}`);
+        const currentId = selectedConversation$.get();
+        if (currentId) {
+          params.set('split', `${currentId},${conversationId}`);
+        } else {
+          params.set('split', `${conversationId},${conversationId}`);
+        }
       }
       navigate(`?${params.toString()}`);
     },
-    [searchParams, navigate]
+    [splitIds, searchParams, navigate]
   );
 
   // Keyboard shortcut: Ctrl+Shift+\ (Cmd+Shift+\ on Mac) to toggle split view

--- a/webui/src/components/MainLayout.tsx
+++ b/webui/src/components/MainLayout.tsx
@@ -430,6 +430,40 @@ const MainLayout: FC<Props> = ({ conversationId, taskId }) => {
     }
   }, [isMobile]);
 
+  // Keyboard shortcut: Ctrl+Shift+\ (Cmd+Shift+\ on Mac) to toggle split view
+  useEffect(() => {
+    const toggleSplit = (e: KeyboardEvent) => {
+      if (e.code !== 'Backslash' || !e.shiftKey || !(e.ctrlKey || e.metaKey)) return;
+      const target = e.target as HTMLElement | null;
+      if (
+        target instanceof HTMLInputElement ||
+        target instanceof HTMLTextAreaElement ||
+        target?.isContentEditable
+      ) {
+        return;
+      }
+      e.preventDefault();
+
+      if (splitIds) {
+        // Close split view
+        const params = new URLSearchParams(searchParams);
+        params.delete('split');
+        const qs = params.toString();
+        navigate(chatRoute(splitIds[0], qs));
+      } else {
+        // Open split view
+        const conversation = conversation$.get();
+        if (!conversation) return;
+        const params = new URLSearchParams(searchParams);
+        params.set('split', `${conversation.id},${conversation.id}`);
+        navigate(`?${params.toString()}`);
+      }
+    };
+
+    document.addEventListener('keydown', toggleSplit);
+    return () => document.removeEventListener('keydown', toggleSplit);
+  }, [splitIds, navigate, searchParams, conversation$]);
+
   // Render main content based on current section
   const renderMainContent = () => {
     if (currentSection === 'agents') {

--- a/webui/src/components/ShortcutsDialog.tsx
+++ b/webui/src/components/ShortcutsDialog.tsx
@@ -29,6 +29,7 @@ const SHORTCUT_GROUPS: ShortcutGroup[] = [
       { keys: [MOD, 'K'], description: 'Open command palette' },
       { keys: [ALT, 'N'], description: 'New conversation' },
       { keys: [MOD, 'F'], description: 'Search messages in conversation' },
+      { keys: [MOD, 'Shift', '\\'], description: 'Toggle split view' },
       { keys: ['?'], description: 'Show this shortcuts reference' },
       { keys: ['i'], description: 'Focus the message input' },
     ],

--- a/webui/src/components/SplitConversationView.tsx
+++ b/webui/src/components/SplitConversationView.tsx
@@ -3,11 +3,7 @@ import { X, ChevronDown } from 'lucide-react';
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from '@/components/ui/resizable';
 import { ConversationContent } from './ConversationContent';
 import { Button } from '@/components/ui/button';
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from '@/components/ui/popover';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import {
   Command,
   CommandEmpty,
@@ -69,7 +65,7 @@ function ConversationSelector({
               {allConversations.map((conv) => (
                 <CommandItem
                   key={conv.serverId ? `${conv.serverId}:${conv.id}` : conv.id}
-                  value={conv.id}
+                  value={conv.serverId ? `${conv.serverId}:${conv.id}` : conv.id}
                   keywords={[conv.name || '', conv.id]}
                   onSelect={() => {
                     onSelect(conv.id);

--- a/webui/src/components/SplitConversationView.tsx
+++ b/webui/src/components/SplitConversationView.tsx
@@ -1,8 +1,22 @@
-import { type FC } from 'react';
-import { X } from 'lucide-react';
+import { type FC, useState } from 'react';
+import { X, ChevronDown } from 'lucide-react';
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from '@/components/ui/resizable';
 import { ConversationContent } from './ConversationContent';
 import { Button } from '@/components/ui/button';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command';
+import type { ConversationSummary } from '@/types/conversation';
 
 interface Props {
   leftId: string;
@@ -14,6 +28,63 @@ interface Props {
   /** Stack panes vertically instead of side-by-side (for narrow screens). */
   vertical?: boolean;
   onClose: () => void;
+  /** Full conversation list for the pane selector dropdowns. */
+  allConversations?: ConversationSummary[];
+  /** Called when the left pane switches to a different conversation. */
+  onNavigateLeft?: (id: string) => void;
+  /** Called when the right pane switches to a different conversation. */
+  onNavigateRight?: (id: string) => void;
+}
+
+function ConversationSelector({
+  currentId,
+  allConversations,
+  onSelect,
+}: {
+  currentId: string;
+  allConversations: ConversationSummary[];
+  onSelect: (id: string) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const current = allConversations.find((c) => c.id === currentId);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-6 max-w-[180px] gap-1 truncate px-1 text-xs font-normal text-muted-foreground hover:text-foreground"
+        >
+          <span className="truncate">{current?.name || currentId}</span>
+          <ChevronDown className="h-3 w-3 flex-shrink-0" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-[250px] p-0" align="start">
+        <Command>
+          <CommandInput placeholder="Search conversations..." />
+          <CommandList>
+            <CommandEmpty>No conversations found.</CommandEmpty>
+            <CommandGroup>
+              {allConversations.map((conv) => (
+                <CommandItem
+                  key={conv.serverId ? `${conv.serverId}:${conv.id}` : conv.id}
+                  value={conv.id}
+                  keywords={[conv.name || '', conv.id]}
+                  onSelect={() => {
+                    onSelect(conv.id);
+                    setOpen(false);
+                  }}
+                >
+                  <span className="truncate">{conv.name || conv.id}</span>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
 }
 
 export const SplitConversationView: FC<Props> = ({
@@ -25,6 +96,9 @@ export const SplitConversationView: FC<Props> = ({
   isLoading = false,
   vertical = false,
   onClose,
+  allConversations = [],
+  onNavigateLeft,
+  onNavigateRight,
 }) => {
   return (
     <div className="flex h-full flex-col overflow-hidden">
@@ -53,21 +127,43 @@ export const SplitConversationView: FC<Props> = ({
           className="min-h-0 flex-1"
         >
           <ResizablePanel defaultSize={50} minSize={20}>
-            <ConversationContent
-              key={leftId}
-              conversationId={leftId}
-              serverId={serverId}
-              isReadOnly={leftIsReadOnly}
-            />
+            <div className="flex h-full flex-col">
+              <div className="flex flex-shrink-0 items-center border-b px-2 py-0.5">
+                <ConversationSelector
+                  currentId={leftId}
+                  allConversations={allConversations}
+                  onSelect={onNavigateLeft || (() => {})}
+                />
+              </div>
+              <div className="min-h-0 flex-1">
+                <ConversationContent
+                  key={leftId}
+                  conversationId={leftId}
+                  serverId={serverId}
+                  isReadOnly={leftIsReadOnly}
+                />
+              </div>
+            </div>
           </ResizablePanel>
           <ResizableHandle withHandle />
           <ResizablePanel defaultSize={50} minSize={20}>
-            <ConversationContent
-              key={rightId}
-              conversationId={rightId}
-              serverId={serverId}
-              isReadOnly={rightIsReadOnly}
-            />
+            <div className="flex h-full flex-col">
+              <div className="flex flex-shrink-0 items-center border-b px-2 py-0.5">
+                <ConversationSelector
+                  currentId={rightId}
+                  allConversations={allConversations}
+                  onSelect={onNavigateRight || (() => {})}
+                />
+              </div>
+              <div className="min-h-0 flex-1">
+                <ConversationContent
+                  key={rightId}
+                  conversationId={rightId}
+                  serverId={serverId}
+                  isReadOnly={rightIsReadOnly}
+                />
+              </div>
+            </div>
           </ResizablePanel>
         </ResizablePanelGroup>
       )}

--- a/webui/src/components/UnifiedSidebar.tsx
+++ b/webui/src/components/UnifiedSidebar.tsx
@@ -83,6 +83,9 @@ interface Props {
   // Multi-backend
   showServerLabels?: boolean;
 
+  // Split view
+  onOpenInSplitView?: (conversationId: string) => void;
+
   // Task props
   tasks: Task[];
   selectedTaskId?: string;
@@ -112,6 +115,7 @@ export const UnifiedSidebar: FC<Props> = ({
   tasksLoading = false,
   tasksError = false,
   onTasksRetry,
+  onOpenInSplitView,
 }) => {
   const selectedWorkspace = use$(selectedWorkspace$);
   const selectedAgent = use$(selectedAgent$);
@@ -391,6 +395,7 @@ export const UnifiedSidebar: FC<Props> = ({
               fetchNextPage={fetchNextPage}
               hasNextPage={hasNextPage}
               showServerLabels={showServerLabels}
+              onOpenInSplitView={onOpenInSplitView}
             />
           )}
 

--- a/webui/src/components/__tests__/SplitConversationView.test.tsx
+++ b/webui/src/components/__tests__/SplitConversationView.test.tsx
@@ -59,16 +59,8 @@ jest.mock('@/components/ui/command', () => ({
   CommandGroup: ({ children }: { children: React.ReactNode }) => (
     <div data-testid="command-group">{children}</div>
   ),
-  CommandInput: () => (
-    <div data-testid="command-input" />
-  ),
-  CommandItem: ({
-    children,
-    onSelect,
-  }: {
-    children: React.ReactNode;
-    onSelect?: () => void;
-  }) => (
+  CommandInput: () => <div data-testid="command-input" />,
+  CommandItem: ({ children, onSelect }: { children: React.ReactNode; onSelect?: () => void }) => (
     <div data-testid="command-item" onClick={onSelect}>
       {children}
     </div>
@@ -191,12 +183,14 @@ describe('SplitConversationView', () => {
     // Click one item from left selector (first 3 items)
     fireEvent.click(items[0]);
     expect(onNavigateLeft).toHaveBeenCalledTimes(1);
+    expect(onNavigateLeft).toHaveBeenCalledWith('conv-a');
     expect(onNavigateRight).not.toHaveBeenCalled();
 
     // Click one item from right selector (last 3 items)
     onNavigateLeft.mockClear();
     fireEvent.click(items[3]);
     expect(onNavigateRight).toHaveBeenCalledTimes(1);
+    expect(onNavigateRight).toHaveBeenCalledWith('conv-a');
     expect(onNavigateLeft).not.toHaveBeenCalled();
   });
 });

--- a/webui/src/components/__tests__/SplitConversationView.test.tsx
+++ b/webui/src/components/__tests__/SplitConversationView.test.tsx
@@ -36,11 +36,62 @@ jest.mock('@/components/ui/resizable', () => ({
   ResizableHandle: () => <div data-testid="resizable-handle" />,
 }));
 
+// Stub Popover + Command so the conversation selector renders in tests
+jest.mock('@/components/ui/popover', () => ({
+  Popover: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="popover">{children}</div>
+  ),
+  PopoverTrigger: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="popover-trigger">{children}</div>
+  ),
+  PopoverContent: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="popover-content">{children}</div>
+  ),
+}));
+
+jest.mock('@/components/ui/command', () => ({
+  Command: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="command">{children}</div>
+  ),
+  CommandEmpty: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="command-empty">{children}</div>
+  ),
+  CommandGroup: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="command-group">{children}</div>
+  ),
+  CommandInput: () => (
+    <div data-testid="command-input" />
+  ),
+  CommandItem: ({
+    children,
+    onSelect,
+  }: {
+    children: React.ReactNode;
+    onSelect?: () => void;
+  }) => (
+    <div data-testid="command-item" onClick={onSelect}>
+      {children}
+    </div>
+  ),
+  CommandList: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="command-list">{children}</div>
+  ),
+}));
+
 describe('SplitConversationView', () => {
   const onClose = jest.fn();
+  const onNavigateLeft = jest.fn();
+  const onNavigateRight = jest.fn();
+  const mockConversations = [
+    { id: 'conv-a', name: 'Conversation A', modified: 1000, messages: 5, workspace: '.' },
+    { id: 'conv-b', name: 'Conversation B', modified: 2000, messages: 3, workspace: '.' },
+    { id: 'conv-c', name: 'Conversation C', modified: 3000, messages: 8, workspace: '.' },
+  ];
 
   beforeEach(() => {
     onClose.mockClear();
+    onNavigateLeft.mockClear();
+    onNavigateRight.mockClear();
   });
 
   it('renders both conversation panes', () => {
@@ -91,8 +142,61 @@ describe('SplitConversationView', () => {
   it('uses vertical layout on mobile', () => {
     render(<SplitConversationView leftId="a" rightId="b" vertical onClose={onClose} />);
 
-    // Both panes still rendered
     expect(screen.getByTestId('conversation-a')).toBeInTheDocument();
     expect(screen.getByTestId('conversation-b')).toBeInTheDocument();
+  });
+
+  it('renders conversation selectors for both panes', () => {
+    render(
+      <SplitConversationView
+        leftId="conv-a"
+        rightId="conv-b"
+        allConversations={mockConversations}
+        onClose={onClose}
+      />
+    );
+
+    const triggers = screen.getAllByTestId('popover-trigger');
+    expect(triggers).toHaveLength(2);
+  });
+
+  it('renders all conversations in the selector lists', () => {
+    render(
+      <SplitConversationView
+        leftId="conv-a"
+        rightId="conv-b"
+        allConversations={mockConversations}
+        onClose={onClose}
+      />
+    );
+
+    const items = screen.getAllByTestId('command-item');
+    // Both selectors render all 3 conversations, so 6 items total
+    expect(items).toHaveLength(6);
+  });
+
+  it('calls navigation callbacks when selecting from conversation selectors', () => {
+    render(
+      <SplitConversationView
+        leftId="conv-a"
+        rightId="conv-b"
+        allConversations={mockConversations}
+        onClose={onClose}
+        onNavigateLeft={onNavigateLeft}
+        onNavigateRight={onNavigateRight}
+      />
+    );
+
+    const items = screen.getAllByTestId('command-item');
+    // Click one item from left selector (first 3 items)
+    fireEvent.click(items[0]);
+    expect(onNavigateLeft).toHaveBeenCalledTimes(1);
+    expect(onNavigateRight).not.toHaveBeenCalled();
+
+    // Click one item from right selector (last 3 items)
+    onNavigateLeft.mockClear();
+    fireEvent.click(items[3]);
+    expect(onNavigateRight).toHaveBeenCalledTimes(1);
+    expect(onNavigateLeft).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

Fixes the recurring confusion about gptme-cloud URL routing (ErikBjare/bob#845).

**Root cause**: `gptme-auth login` defaulted to `fleet.gptme.ai` for token storage and LLM API calls, but that host only handles user instance management — the actual LLM API (completions, model listing) lives on Supabase Edge Functions.

**Changes**:
- `DEFAULT_BASE_URL` → `https://kpkxgnfpyntahyhckhgm.supabase.co/functions/v1/messages` (completions endpoint)
- `DEFAULT_SERVICE_URL` → Supabase project root (used as token storage key)
- Added `DEFAULT_MODELS_BASE_URL` for model listing (`functions/v1` root)
- Added `get_models_base_url()` — strips `/messages` to get the functions root for `GET /models`
- Updated `get_base_url()` to resolve Supabase tokens to the messages endpoint (instead of blindly appending `/v1`)
- Updated all `gptme-auth` CLI `--url` defaults
- Updated `get_available_models()` for `gptme` provider to use `get_models_base_url()`

**Backward compat**: existing tokens with `server_url = "https://fleet.gptme.ai"` still get `/v1` appended (legacy path preserved). Users will need to re-login to pick up the new default.

**Architecture clarification** (documented in module docstring):
- fleet.gptme.ai → user instance management only (fleet-operator)
- Supabase `/functions/v1/messages` → LLM completions
- Supabase `/functions/v1/models` → model listing

## Test plan
- [ ] `gptme-auth login` now authenticates against the Supabase URL by default
- [ ] `gptme -m gptme/claude-sonnet-4-6 "hello"` routes to Supabase messages function
- [ ] `gptme --list-models gptme` uses the Supabase models function
- [ ] Existing fleet.gptme.ai tokens continue to work (backward compat path)