### PR TITLE
fix(cloud): route LLM API calls to Supabase edge functions, not fleet.gptme.ai

### DIFF
--- a/gptme/cli/auth.py
+++ b/gptme/cli/auth.py
@@ -236,10 +236,15 @@ def auth_logout(url: str):
 )
 def auth_status(url: str):
     """Show current login status for gptme cloud."""
-    from ..llm.llm_gptme import _load_token
+    from ..llm.llm_gptme import DEFAULT_SERVICE_URL, _load_token
 
     base_url = url.rstrip("/")
     token_data = _load_token(base_url)
+    # Migration fallback: when checking the default Supabase URL and no new
+    # token exists, _load_token() (no args) also searches legacy paths like
+    # fleet.gptme.ai tokens saved before the Supabase URL migration.
+    if not token_data and base_url == DEFAULT_SERVICE_URL:
+        token_data = _load_token()
 
     if not token_data:
         console.print(f"[yellow]Not logged in to {base_url}[/yellow]")

--- a/gptme/cli/auth.py
+++ b/gptme/cli/auth.py
@@ -64,7 +64,11 @@ def auth_login(url: str, auth_url: str | None, no_browser: bool):
 
     Works great for SSH sessions and headless environments.
     """
-    from ..llm.llm_gptme import DEFAULT_BASE_URL, DEFAULT_DEVICE_AUTH_URL
+    from ..llm.llm_gptme import (
+        DEFAULT_BASE_URL,
+        DEFAULT_DEVICE_AUTH_URL,
+        DEFAULT_SERVICE_URL,
+    )
 
     base_url = url.rstrip("/")
     auth_base = (auth_url or DEFAULT_DEVICE_AUTH_URL).rstrip("/")
@@ -150,16 +154,17 @@ def auth_login(url: str, auth_url: str | None, no_browser: bool):
 
             from ..llm.llm_gptme import _save_token
 
-            _save_token(
-                {
-                    "access_token": access_token,
-                    "expires_at": time.time() + token_data.get("expires_in", 86400),
-                    "server_url": base_url,
-                    "base_url": DEFAULT_BASE_URL,
-                    "sub": sub,
-                },
-                base_url,
-            )
+            token_entry: dict = {
+                "access_token": access_token,
+                "expires_at": time.time() + token_data.get("expires_in", 86400),
+                "server_url": base_url,
+                "sub": sub,
+            }
+            # Only store base_url for the default Supabase service.
+            # Custom server tokens rely on the server_url+/v1 fallback in get_base_url().
+            if base_url == DEFAULT_SERVICE_URL.rstrip("/"):
+                token_entry["base_url"] = DEFAULT_BASE_URL
+            _save_token(token_entry, base_url)
 
             console.print("\n")
             console.print("[green bold]✓ Authorization successful![/green bold]")

--- a/gptme/cli/auth.py
+++ b/gptme/cli/auth.py
@@ -216,13 +216,29 @@ def auth_login(url: str, auth_url: str | None, no_browser: bool):
 )
 def auth_logout(url: str):
     """Remove stored credentials for gptme cloud."""
-    from ..llm.llm_gptme import _get_token_path
+    from ..llm.llm_gptme import (
+        _LEGACY_SERVICE_URLS,
+        DEFAULT_SERVICE_URL,
+        _get_token_path,
+    )
 
     base_url = url.rstrip("/")
     token_path = _get_token_path(base_url)
     if token_path.exists():
         token_path.unlink()
         console.print(f"[green]✓ Logged out from {base_url}[/green]")
+    elif base_url == DEFAULT_SERVICE_URL:
+        # Migration fallback: check legacy service URL paths so users authenticated
+        # before the Supabase migration can actually log out.
+        for legacy_url in _LEGACY_SERVICE_URLS:
+            legacy_path = _get_token_path(legacy_url)
+            if legacy_path.exists():
+                legacy_path.unlink()
+                console.print(
+                    f"[green]✓ Logged out (removed legacy token from {legacy_url})[/green]"
+                )
+                return
+        console.print(f"[yellow]No credentials stored for {base_url}[/yellow]")
     else:
         console.print(f"[yellow]No credentials stored for {base_url}[/yellow]")
 

--- a/gptme/cli/auth.py
+++ b/gptme/cli/auth.py
@@ -32,7 +32,7 @@ def main():
 @main.command("login")
 @click.option(
     "--url",
-    default="https://fleet.gptme.ai",
+    default="https://kpkxgnfpyntahyhckhgm.supabase.co",
     show_default=True,
     help="gptme service URL (used for LLM API and token storage).",
 )
@@ -204,7 +204,7 @@ def auth_login(url: str, auth_url: str | None, no_browser: bool):
 @main.command("logout")
 @click.option(
     "--url",
-    default="https://fleet.gptme.ai",
+    default="https://kpkxgnfpyntahyhckhgm.supabase.co",
     show_default=True,
     help="gptme service URL to log out from.",
 )
@@ -224,7 +224,7 @@ def auth_logout(url: str):
 @main.command("status")
 @click.option(
     "--url",
-    default="https://fleet.gptme.ai",
+    default="https://kpkxgnfpyntahyhckhgm.supabase.co",
     show_default=True,
     help="gptme service URL to check.",
 )

--- a/gptme/cli/auth.py
+++ b/gptme/cli/auth.py
@@ -64,7 +64,7 @@ def auth_login(url: str, auth_url: str | None, no_browser: bool):
 
     Works great for SSH sessions and headless environments.
     """
-    from ..llm.llm_gptme import DEFAULT_DEVICE_AUTH_URL
+    from ..llm.llm_gptme import DEFAULT_BASE_URL, DEFAULT_DEVICE_AUTH_URL
 
     base_url = url.rstrip("/")
     auth_base = (auth_url or DEFAULT_DEVICE_AUTH_URL).rstrip("/")
@@ -155,6 +155,7 @@ def auth_login(url: str, auth_url: str | None, no_browser: bool):
                     "access_token": access_token,
                     "expires_at": time.time() + token_data.get("expires_in", 86400),
                     "server_url": base_url,
+                    "base_url": DEFAULT_BASE_URL,
                     "sub": sub,
                 },
                 base_url,

--- a/gptme/llm/llm_gptme.py
+++ b/gptme/llm/llm_gptme.py
@@ -265,13 +265,16 @@ def device_flow_authenticate(
             except (json.JSONDecodeError, KeyError) as e:
                 raise RuntimeError(f"Invalid token response: {e}") from e
 
-            # Save token; keyed by service URL, includes explicit base_url for API calls
-            result = {
+            # Save token; keyed by service URL.
+            # base_url is only set for the default Supabase service — custom servers
+            # use the server_url+/v1 fallback in get_base_url() instead.
+            result: dict = {
                 "access_token": access_token,
                 "expires_at": time.time() + token_data.get("expires_in", 86400),
                 "server_url": service_base,
-                "base_url": DEFAULT_BASE_URL,
             }
+            if service_base == DEFAULT_SERVICE_URL:
+                result["base_url"] = DEFAULT_BASE_URL
             _save_token(result, service_base)
             return result
 

--- a/gptme/llm/llm_gptme.py
+++ b/gptme/llm/llm_gptme.py
@@ -14,9 +14,18 @@ Token priority:
     3. Error with instructions
 
 Base URL priority:
-    1. Token's ``server_url`` field
+    1. Token's ``base_url`` field (explicit, Supabase-aware)
     2. ``GPTME_CLOUD_BASE_URL`` environment variable
-    3. Default: ``https://fleet.gptme.ai/v1``
+    3. Default: Supabase messages edge function
+
+URL architecture:
+    - LLM API calls go to Supabase edge functions, NOT fleet.gptme.ai.
+    - fleet.gptme.ai only routes /api/v1/instances/ (traefik) and
+      /api/v1/operator/ (fleet-operator). It has no /v1/chat/completions or
+      /v1/models routes.
+    - Chat completions: DEFAULT_BASE_URL (messages edge function)
+    - Model listing:    DEFAULT_MODELS_BASE_URL (functions/v1 base)
+    - Device auth:      DEFAULT_DEVICE_AUTH_URL (device-auth edge function)
 """
 
 import hashlib
@@ -35,16 +44,23 @@ class GptmeAuthError(KeyError):
     """Raised when no valid gptme.ai credentials are found."""
 
 
-# Default base URL for the gptme cloud API proxy
-DEFAULT_BASE_URL = "https://fleet.gptme.ai/v1"
-
-# Default service URL (for auth endpoints, without /v1)
-DEFAULT_SERVICE_URL = "https://fleet.gptme.ai"
-
-# Device auth has moved off fleet-operator and onto Supabase edge functions.
-# The CLI polls these two endpoints during the RFC 8628 device authorization flow.
+# All gptme cloud API traffic goes through Supabase edge functions.
+# fleet.gptme.ai is for user instance routing only (/api/v1/instances/, /api/v1/operator/).
 _SUPABASE_URL = "https://kpkxgnfpyntahyhckhgm.supabase.co"
-DEFAULT_DEVICE_AUTH_URL = f"{_SUPABASE_URL}/functions/v1/device-auth"
+_SUPABASE_FUNCTIONS_V1 = f"{_SUPABASE_URL}/functions/v1"
+
+# Chat completions endpoint — the messages function ignores sub-path, so the
+# OpenAI SDK's /chat/completions suffix lands here without issue.
+DEFAULT_BASE_URL = f"{_SUPABASE_FUNCTIONS_V1}/messages"
+
+# Base for model listing — OpenAI SDK appends /models → /functions/v1/models ✓
+DEFAULT_MODELS_BASE_URL = _SUPABASE_FUNCTIONS_V1
+
+# Service URL used for token storage keying (not for API calls).
+DEFAULT_SERVICE_URL = _SUPABASE_URL
+
+# Device auth edge function.
+DEFAULT_DEVICE_AUTH_URL = f"{_SUPABASE_FUNCTIONS_V1}/device-auth"
 
 # Token storage directory
 _TOKEN_DIR = (
@@ -116,30 +132,50 @@ def get_api_key(config: Config) -> str:
 
 
 def get_base_url(config: Config) -> str:
-    """Get the base URL for the gptme cloud API.
+    """Get the base URL for gptme cloud chat completions.
 
     Checks (in order):
-    1. Token file's ``server_url`` field
+    1. Token file's ``base_url`` field (explicit, set by device_flow_authenticate)
     2. ``GPTME_CLOUD_BASE_URL`` environment variable
-    3. Default: https://fleet.gptme.ai/v1
-    """
-    # Check token file for server URL
-    token_data = _load_token()
-    if token_data and token_data.get("server_url"):
-        server_url = token_data["server_url"].rstrip("/")
-        if not server_url.endswith("/v1"):
-            server_url += "/v1"
-        return server_url
+    3. Default: Supabase messages edge function
 
-    # Check env var (normalize /v1 suffix)
+    The returned URL is used as the OpenAI SDK base_url. For chat completions,
+    this points at the Supabase messages function. For model listing, use
+    get_models_url() instead.
+    """
+    token_data = _load_token()
+    if token_data:
+        # New explicit base_url field (Supabase-aware, set by device_flow_authenticate)
+        if token_data.get("base_url"):
+            return token_data["base_url"].rstrip("/")
+        # Legacy: token has server_url but no base_url — reconstruct old-style
+        # (e.g. tokens saved before this fix, pointing at fleet.gptme.ai)
+        if token_data.get("server_url"):
+            server_url = token_data["server_url"].rstrip("/")
+            if not server_url.endswith("/v1"):
+                server_url += "/v1"
+            return server_url
+
     env_url = config.get_env("GPTME_CLOUD_BASE_URL")
     if env_url:
-        env_url = env_url.rstrip("/")
-        if not env_url.endswith("/v1"):
-            env_url += "/v1"
-        return env_url
+        return env_url.rstrip("/")
 
     return DEFAULT_BASE_URL
+
+
+def get_models_url(config: Config) -> str:
+    """Get the base URL for gptme cloud model listing.
+
+    Returns the Supabase functions/v1 base so the OpenAI SDK can append
+    /models and reach the models edge function.
+    Checks (in order):
+    1. ``GPTME_CLOUD_MODELS_URL`` environment variable
+    2. Default: Supabase functions/v1 base
+    """
+    env_url = config.get_env("GPTME_CLOUD_MODELS_URL")
+    if env_url:
+        return env_url.rstrip("/")
+    return DEFAULT_MODELS_BASE_URL
 
 
 def device_flow_authenticate(
@@ -210,11 +246,12 @@ def device_flow_authenticate(
             except (json.JSONDecodeError, KeyError) as e:
                 raise RuntimeError(f"Invalid token response: {e}") from e
 
-            # Save token; keyed by service URL (fleet), not auth URL (supabase)
+            # Save token; keyed by service URL, includes explicit base_url for API calls
             result = {
                 "access_token": access_token,
                 "expires_at": time.time() + token_data.get("expires_in", 86400),
                 "server_url": service_base,
+                "base_url": DEFAULT_BASE_URL,
             }
             _save_token(result, service_base)
             return result

--- a/gptme/llm/llm_gptme.py
+++ b/gptme/llm/llm_gptme.py
@@ -185,12 +185,29 @@ def get_base_url(config: Config) -> str:
 def get_models_url(config: Config) -> str:
     """Get the base URL for gptme cloud model listing.
 
-    Returns the Supabase functions/v1 base so the OpenAI SDK can append
-    /models and reach the models edge function.
+    The OpenAI SDK appends /models to the returned URL.
     Checks (in order):
-    1. ``GPTME_CLOUD_MODELS_URL`` environment variable
-    2. Default: Supabase functions/v1 base
+    1. Token file's ``server_url`` field (custom-server token)
+       → uses server_url + /v1 as the models base
+    2. ``GPTME_CLOUD_MODELS_URL`` environment variable
+    3. Default: Supabase functions/v1 base
+
+    For the default Supabase service, models are listed via the
+    functions/v1/models edge function. For custom servers (tokens
+    with server_url but no base_url), the models endpoint lives
+    at {server_url}/v1/models — matching the chat-completions base.
     """
+    token_data = _load_token()
+    if token_data:
+        # Custom-server token (server_url without explicit base_url)
+        if not token_data.get("base_url") and token_data.get("server_url"):
+            server_url = token_data["server_url"].rstrip("/")
+            if not server_url.endswith("/v1"):
+                server_url += "/v1"
+            return server_url
+        # Default (Supabase) token with base_url — use the default models URL
+        # which is the functions/v1 base the SDK needs for /models.
+
     env_url = config.get_env("GPTME_CLOUD_MODELS_URL")
     if env_url:
         return env_url.rstrip("/")

--- a/gptme/llm/llm_gptme.py
+++ b/gptme/llm/llm_gptme.py
@@ -67,6 +67,12 @@ _TOKEN_DIR = (
     Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config")) / "gptme" / "auth"
 )
 
+# Legacy service URLs whose token files should be checked as a migration fallback
+# when no token exists at the current DEFAULT_SERVICE_URL path.
+_LEGACY_SERVICE_URLS = [
+    "https://fleet.gptme.ai",
+]
+
 
 def _get_token_path(service_url: str | None = None) -> Path:
     """Get path to the Device Flow token file.
@@ -85,7 +91,20 @@ def _load_token(service_url: str | None = None) -> dict | None:
     """
     token_path = _get_token_path(service_url)
     if not token_path.exists():
-        return None
+        # Migration: if using the default URL and no new token exists, check
+        # legacy service URL paths so users authenticated before the Supabase
+        # migration can still be found (their token has a server_url field
+        # that get_base_url() uses to reconstruct the old-style URL).
+        if service_url is None:
+            for legacy_url in _LEGACY_SERVICE_URLS:
+                legacy_path = _get_token_path(legacy_url)
+                if legacy_path.exists():
+                    token_path = legacy_path
+                    break
+            else:
+                return None
+        else:
+            return None
 
     try:
         data = json.loads(token_path.read_text())

--- a/gptme/llm/llm_gptme.py
+++ b/gptme/llm/llm_gptme.py
@@ -13,10 +13,16 @@ Token priority:
     2. ``GPTME_CLOUD_API_KEY`` environment variable
     3. Error with instructions
 
-Base URL priority:
+Base URL priority (chat completions):
     1. Token's ``base_url`` field (explicit, Supabase-aware)
     2. ``GPTME_CLOUD_BASE_URL`` environment variable
     3. Default: Supabase messages edge function
+
+Models URL priority:
+    1. Token's ``server_url`` field for custom-server tokens (no base_url)
+    2. ``GPTME_CLOUD_MODELS_URL`` environment variable
+    3. ``GPTME_CLOUD_BASE_URL`` for non-Supabase custom servers (env-var-only)
+    4. Default: Supabase functions/v1 base
 
 URL architecture:
     - LLM API calls go to Supabase edge functions, NOT fleet.gptme.ai.
@@ -187,15 +193,12 @@ def get_models_url(config: Config) -> str:
 
     The OpenAI SDK appends /models to the returned URL.
     Checks (in order):
-    1. Token file's ``server_url`` field (custom-server token)
+    1. Token file's ``server_url`` field (custom-server token without base_url)
        → uses server_url + /v1 as the models base
     2. ``GPTME_CLOUD_MODELS_URL`` environment variable
-    3. Default: Supabase functions/v1 base
-
-    For the default Supabase service, models are listed via the
-    functions/v1/models edge function. For custom servers (tokens
-    with server_url but no base_url), the models endpoint lives
-    at {server_url}/v1/models — matching the chat-completions base.
+    3. ``GPTME_CLOUD_BASE_URL`` env var when pointing at a non-Supabase server
+       → env-var-only users with custom OpenAI-compatible APIs
+    4. Default: Supabase functions/v1 base
     """
     token_data = _load_token()
     if token_data:
@@ -211,6 +214,14 @@ def get_models_url(config: Config) -> str:
     env_url = config.get_env("GPTME_CLOUD_MODELS_URL")
     if env_url:
         return env_url.rstrip("/")
+
+    # For env-var-only users with a custom server (GPTME_CLOUD_BASE_URL not pointing
+    # at Supabase), use the same base URL for model listing — standard OpenAI-compatible
+    # APIs serve both /chat/completions and /models from the same base.
+    base_url = config.get_env("GPTME_CLOUD_BASE_URL")
+    if base_url and DEFAULT_SERVICE_URL not in base_url:
+        return base_url.rstrip("/")
+
     return DEFAULT_MODELS_BASE_URL
 
 

--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -1693,12 +1693,12 @@ def get_available_models(provider: Provider) -> list[ModelMeta]:
         return _get_openai_compatible_models(config, provider)
 
     if provider == "gptme":
-        from .llm_gptme import get_api_key, get_base_url
+        from .llm_gptme import get_api_key, get_models_url
 
         return _get_openai_compatible_models(
             config,
             provider,
-            base_url=get_base_url(config),
+            base_url=get_models_url(config),
             api_key=get_api_key(config),
         )
 

--- a/tests/test_gptme_provider.py
+++ b/tests/test_gptme_provider.py
@@ -297,6 +297,47 @@ def test_auth_status_shows_logged_in_for_legacy_fleet_token(tmp_path: Path):
     assert "Not logged in" not in result.output
 
 
+def test_auth_logout_removes_legacy_fleet_token(tmp_path: Path):
+    """auth_logout should remove legacy fleet.gptme.ai token when run against default URL.
+
+    Regression guard: auth_logout was looking up the Supabase-URL-hashed path
+    and reporting "No credentials stored" even though the legacy fleet token was
+    still valid on disk (and still found by get_api_key via _load_token fallback).
+    """
+    import hashlib
+
+    from click.testing import CliRunner
+
+    from gptme.cli.auth import main as auth_main
+
+    legacy_url = "https://fleet.gptme.ai"
+    url_hash = hashlib.sha256(legacy_url.encode()).hexdigest()[:12]
+    legacy_token_path = tmp_path / f"gptme-cloud-{url_hash}.json"
+    legacy_token_path.write_text(
+        json.dumps(
+            {
+                "access_token": "legacy-token",
+                "expires_at": time.time() + 3600,
+                "server_url": legacy_url,
+                "sub": "user-legacy",
+            }
+        )
+    )
+
+    runner = CliRunner()
+    with patch("gptme.llm.llm_gptme._TOKEN_DIR", tmp_path):
+        result = runner.invoke(auth_main, ["logout"])
+
+    assert result.exit_code == 0, result.output
+    assert "Logged out" in result.output, (
+        "auth_logout must remove legacy fleet token via migration fallback; "
+        f"got: {result.output!r}"
+    )
+    assert not legacy_token_path.exists(), (
+        "Legacy token file should be deleted after logout"
+    )
+
+
 def _mock_device_flow_responses(auth_uri: str = "https://gptme.ai/activate"):
     """Return (authorize_resp, token_resp) mocks for device_flow_authenticate."""
     auth_resp = MagicMock()

--- a/tests/test_gptme_provider.py
+++ b/tests/test_gptme_provider.py
@@ -314,6 +314,57 @@ def test_device_flow_authenticate_default_server_has_base_url():
     assert result["server_url"] == DEFAULT_SERVICE_URL
 
 
+def test_get_models_url_custom_token():
+    """Custom-server tokens (no base_url) should use server_url + /v1 for model listing."""
+    from gptme.llm.llm_gptme import get_models_url
+
+    token_data = {
+        "access_token": "test",
+        "server_url": "https://custom.example.com",
+        "expires_at": 9999999999,
+    }
+    config = _mock_config()
+    with patch("gptme.llm.llm_gptme._load_token", return_value=token_data):
+        assert get_models_url(config) == "https://custom.example.com/v1"
+
+
+def test_get_models_url_env_models_url():
+    """GPTME_CLOUD_MODELS_URL should take precedence over GPTME_CLOUD_BASE_URL."""
+    from gptme.llm.llm_gptme import get_models_url
+
+    config = _mock_config(
+        env={
+            "GPTME_CLOUD_MODELS_URL": "https://custom.example.com/v1",
+            "GPTME_CLOUD_BASE_URL": "https://other.example.com/v1",
+        }
+    )
+    with patch("gptme.llm.llm_gptme._load_token", return_value=None):
+        assert get_models_url(config) == "https://custom.example.com/v1"
+
+
+def test_get_models_url_env_base_url_custom_server():
+    """GPTME_CLOUD_BASE_URL for a custom (non-Supabase) server should be used for models."""
+    from gptme.llm.llm_gptme import get_models_url
+
+    config = _mock_config(env={"GPTME_CLOUD_BASE_URL": "https://custom.example.com/v1"})
+    with patch("gptme.llm.llm_gptme._load_token", return_value=None):
+        assert get_models_url(config) == "https://custom.example.com/v1"
+
+
+def test_get_models_url_env_base_url_supabase_uses_default():
+    """GPTME_CLOUD_BASE_URL pointing at Supabase should NOT be used for models (wrong path)."""
+    from gptme.llm.llm_gptme import (
+        _SUPABASE_FUNCTIONS_V1,
+        DEFAULT_MODELS_BASE_URL,
+        get_models_url,
+    )
+
+    supabase_url = f"{_SUPABASE_FUNCTIONS_V1}/messages"
+    config = _mock_config(env={"GPTME_CLOUD_BASE_URL": supabase_url})
+    with patch("gptme.llm.llm_gptme._load_token", return_value=None):
+        assert get_models_url(config) == DEFAULT_MODELS_BASE_URL
+
+
 # --- Helpers ---
 
 

--- a/tests/test_gptme_provider.py
+++ b/tests/test_gptme_provider.py
@@ -154,16 +154,7 @@ def test_get_base_url_from_token():
 
 
 def test_get_base_url_from_env():
-    """Should use GPTME_CLOUD_BASE_URL env var (with /v1 normalization)."""
-    from gptme.llm.llm_gptme import get_base_url
-
-    config = _mock_config(env={"GPTME_CLOUD_BASE_URL": "https://my-server.example.com"})
-    with patch("gptme.llm.llm_gptme._load_token", return_value=None):
-        assert get_base_url(config) == "https://my-server.example.com/v1"
-
-
-def test_get_base_url_from_env_with_v1():
-    """Should preserve /v1 suffix in env var."""
+    """Should return GPTME_CLOUD_BASE_URL env var as-is (no /v1 normalization)."""
     from gptme.llm.llm_gptme import get_base_url
 
     config = _mock_config(
@@ -171,6 +162,16 @@ def test_get_base_url_from_env_with_v1():
     )
     with patch("gptme.llm.llm_gptme._load_token", return_value=None):
         assert get_base_url(config) == "https://my-server.example.com/v1"
+
+
+def test_get_base_url_from_env_supabase():
+    """Should return Supabase function URL as-is from env var."""
+    from gptme.llm.llm_gptme import _SUPABASE_FUNCTIONS_V1, get_base_url
+
+    supabase_url = f"{_SUPABASE_FUNCTIONS_V1}/messages"
+    config = _mock_config(env={"GPTME_CLOUD_BASE_URL": supabase_url})
+    with patch("gptme.llm.llm_gptme._load_token", return_value=None):
+        assert get_base_url(config) == supabase_url
 
 
 def test_save_token(tmp_path: Path):

--- a/tests/test_gptme_provider.py
+++ b/tests/test_gptme_provider.py
@@ -258,6 +258,45 @@ def test_load_token_legacy_fleet_migration(tmp_path: Path):
     assert result["server_url"] == legacy_url
 
 
+def test_auth_status_shows_logged_in_for_legacy_fleet_token(tmp_path: Path):
+    """auth_status should show 'Logged in' even for legacy fleet.gptme.ai tokens.
+
+    Regression guard: auth_status was passing explicit Supabase URL to
+    _load_token(), bypassing the migration fallback that finds old fleet.gptme.ai
+    tokens during the URL-migration upgrade window.
+    """
+    import hashlib
+
+    from click.testing import CliRunner
+
+    from gptme.cli.auth import main as auth_main
+
+    legacy_url = "https://fleet.gptme.ai"
+    url_hash = hashlib.sha256(legacy_url.encode()).hexdigest()[:12]
+    legacy_token_path = tmp_path / f"gptme-cloud-{url_hash}.json"
+    legacy_token_path.write_text(
+        json.dumps(
+            {
+                "access_token": "legacy-token",
+                "expires_at": time.time() + 3600,
+                "server_url": legacy_url,
+                "sub": "user-legacy",
+            }
+        )
+    )
+
+    runner = CliRunner()
+    with patch("gptme.llm.llm_gptme._TOKEN_DIR", tmp_path):
+        result = runner.invoke(auth_main, ["status"])
+
+    assert result.exit_code == 0, result.output
+    assert "Logged in" in result.output, (
+        "auth_status must find legacy fleet token via migration fallback; "
+        f"got: {result.output!r}"
+    )
+    assert "Not logged in" not in result.output
+
+
 def _mock_device_flow_responses(auth_uri: str = "https://gptme.ai/activate"):
     """Return (authorize_resp, token_resp) mocks for device_flow_authenticate."""
     auth_resp = MagicMock()

--- a/tests/test_gptme_provider.py
+++ b/tests/test_gptme_provider.py
@@ -3,7 +3,7 @@
 import json
 import time
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -256,6 +256,62 @@ def test_load_token_legacy_fleet_migration(tmp_path: Path):
     )
     assert result["access_token"] == "legacy-token"
     assert result["server_url"] == legacy_url
+
+
+def _mock_device_flow_responses(auth_uri: str = "https://gptme.ai/activate"):
+    """Return (authorize_resp, token_resp) mocks for device_flow_authenticate."""
+    auth_resp = MagicMock()
+    auth_resp.status_code = 200
+    auth_resp.json.return_value = {
+        "device_code": "dc123",
+        "user_code": "UC-123",
+        "verification_uri": auth_uri,
+        "interval": 1,
+        "expires_in": 300,
+    }
+    tok_resp = MagicMock()
+    tok_resp.status_code = 200
+    tok_resp.json.return_value = {"access_token": "test-token", "expires_in": 3600}
+    return auth_resp, tok_resp
+
+
+def test_device_flow_authenticate_custom_server_no_base_url():
+    """Custom server tokens must NOT store base_url; routing relies on server_url+/v1."""
+    from gptme.llm.llm_gptme import device_flow_authenticate
+
+    auth_resp, tok_resp = _mock_device_flow_responses()
+    custom_url = "https://custom.example.com"
+
+    with (
+        patch("requests.post", side_effect=[auth_resp, tok_resp]),
+        patch("gptme.llm.llm_gptme._save_token"),
+    ):
+        result = device_flow_authenticate(server_url=custom_url)
+
+    assert "base_url" not in result, (
+        "Custom server token must not hardcode Supabase base_url"
+    )
+    assert result["server_url"] == custom_url
+
+
+def test_device_flow_authenticate_default_server_has_base_url():
+    """Default Supabase tokens SHOULD store explicit base_url for edge fn routing."""
+    from gptme.llm.llm_gptme import (
+        DEFAULT_BASE_URL,
+        DEFAULT_SERVICE_URL,
+        device_flow_authenticate,
+    )
+
+    auth_resp, tok_resp = _mock_device_flow_responses()
+
+    with (
+        patch("requests.post", side_effect=[auth_resp, tok_resp]),
+        patch("gptme.llm.llm_gptme._save_token"),
+    ):
+        result = device_flow_authenticate()  # uses DEFAULT_SERVICE_URL
+
+    assert result.get("base_url") == DEFAULT_BASE_URL
+    assert result["server_url"] == DEFAULT_SERVICE_URL
 
 
 # --- Helpers ---

--- a/tests/test_gptme_provider.py
+++ b/tests/test_gptme_provider.py
@@ -226,6 +226,38 @@ def test_token_path_uses_url_hash():
     assert "gptme-cloud-" in path2.name
 
 
+def test_load_token_legacy_fleet_migration(tmp_path: Path):
+    """Should find old fleet.gptme.ai token when no new Supabase token exists.
+
+    Covers the upgrade path: user authenticated before the Supabase URL migration.
+    Their token is stored at the fleet.gptme.ai hash path; _load_token() must
+    find it so get_base_url() can reconstruct the old-style URL via server_url.
+    """
+    import hashlib
+
+    from gptme.llm.llm_gptme import _load_token
+
+    legacy_url = "https://fleet.gptme.ai"
+    url_hash = hashlib.sha256(legacy_url.encode()).hexdigest()[:12]
+    legacy_token_path = tmp_path / f"gptme-cloud-{url_hash}.json"
+    token_data = {
+        "access_token": "legacy-token",
+        "expires_at": time.time() + 3600,
+        "server_url": legacy_url,
+    }
+    legacy_token_path.write_text(json.dumps(token_data))
+
+    # Patch _TOKEN_DIR so _get_token_path resolves into tmp_path
+    with patch("gptme.llm.llm_gptme._TOKEN_DIR", tmp_path):
+        result = _load_token()  # no service_url → default path (Supabase) won't exist
+
+    assert result is not None, (
+        "Legacy fleet token should be found via migration fallback"
+    )
+    assert result["access_token"] == "legacy-token"
+    assert result["server_url"] == legacy_url
+
+
 # --- Helpers ---
 
 

--- a/tests/test_gptme_provider.py
+++ b/tests/test_gptme_provider.py
@@ -153,6 +153,22 @@ def test_get_base_url_from_token():
         assert get_base_url(config) == "https://custom.gptme.ai/v1"
 
 
+def test_get_base_url_from_token_explicit():
+    """Should prefer explicit base_url field over server_url fallback."""
+    from gptme.llm.llm_gptme import get_base_url
+
+    token_data = {
+        "access_token": "test",
+        "server_url": "https://fleet.gptme.ai",
+        "base_url": "https://kpkxgnfpyntahyhckhgm.supabase.co/functions/v1/messages",
+    }
+    config = _mock_config()
+    with patch("gptme.llm.llm_gptme._load_token", return_value=token_data):
+        assert get_base_url(config) == (
+            "https://kpkxgnfpyntahyhckhgm.supabase.co/functions/v1/messages"
+        )
+
+
 def test_get_base_url_from_env():
     """Should return GPTME_CLOUD_BASE_URL env var as-is (no /v1 normalization)."""
     from gptme.llm.llm_gptme import get_base_url

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1419,7 +1419,9 @@ class TestInitModelInteractive:
         init_model(model="gptme/claude-sonnet-4-6", interactive=True)
 
         mock_console.input.assert_called_once()
-        mock_device_flow.assert_called_once_with(server_url="https://fleet.gptme.ai")
+        mock_device_flow.assert_called_once_with(
+            server_url="https://kpkxgnfpyntahyhckhgm.supabase.co"
+        )
         assert mock_init_llm.call_args_list == [call("gptme"), call("gptme")]
 
     @patch("gptme.init.set_default_model")

--- a/tests/test_llm_openai.py
+++ b/tests/test_llm_openai.py
@@ -2576,12 +2576,12 @@ class TestGetAvailableModels:
 
     @patch("gptme.llm.llm_openai.requests.get")
     @patch("gptme.llm.llm_openai.get_config")
-    @patch("gptme.llm.llm_gptme.get_base_url")
+    @patch("gptme.llm.llm_gptme.get_models_url")
     @patch("gptme.llm.llm_gptme.get_api_key")
     def test_gptme_provider_uses_authenticated_models_endpoint(
         self,
         mock_get_api_key,
-        mock_get_base_url,
+        mock_get_models_url,
         mock_get_config,
         mock_requests_get,
     ):
@@ -2591,7 +2591,9 @@ class TestGetAvailableModels:
         get_available_models.cache_clear()
         mock_get_config.return_value = MagicMock()
         mock_get_api_key.return_value = "gptme-token"
-        mock_get_base_url.return_value = "https://fleet.gptme.ai/v1"
+        mock_get_models_url.return_value = (
+            "https://kpkxgnfpyntahyhckhgm.supabase.co/functions/v1"
+        )
         mock_response = MagicMock()
         mock_response.json.return_value = {
             "data": [{"id": "openai/gpt-5", "context_length": 256000}]
@@ -2601,7 +2603,7 @@ class TestGetAvailableModels:
         models = get_available_models("gptme")
 
         mock_requests_get.assert_called_once_with(
-            "https://fleet.gptme.ai/v1/models",
+            "https://kpkxgnfpyntahyhckhgm.supabase.co/functions/v1/models",
             headers={"Authorization": "Bearer gptme-token"},
             timeout=10,
         )


### PR DESCRIPTION
## Summary

- `fleet.gptme.ai` only routes `/api/v1/instances/` (traefik) and `/api/v1/operator/` (fleet-operator) — it has **no** `/v1/chat/completions` or `/v1/models` routes
- All LLM API traffic should go to Supabase edge functions
- Fixes the stale default URLs that caused repeated confusion (ErikBjare/bob#845)

**URL architecture:**
- Chat completions → Supabase `messages` edge function (ignores sub-path, processes JSON body)
- Model listing → Supabase `functions/v1` base (SDK appends `/models` → `/functions/v1/models` ✓)
- Device auth → Supabase `device-auth` edge function (unchanged)
- Token storage keying → Supabase root URL

**Changes:**
- `DEFAULT_BASE_URL`: `fleet.gptme.ai/v1` → `supabase.co/functions/v1/messages`
- `DEFAULT_MODELS_BASE_URL`: new constant for model listing  
- `DEFAULT_SERVICE_URL`: `fleet.gptme.ai` → `supabase.co`
- `auth.py` `--url` default: updated to Supabase URL
- `get_base_url()`: reads explicit `base_url` field from token (new), falls back to legacy `server_url+/v1` for old tokens
- `get_models_url()`: new function for the models-specific base URL
- `llm_openai.py`: gptme provider model listing uses `get_models_url()` 
- `device_flow_authenticate()`: saves `base_url` in token for explicit lookups
- Removes `/v1` auto-normalization from env var (callers provide the exact URL)

**Note:** Existing tokens saved under `fleet.gptme.ai` will fall back to the legacy `server_url+/v1` path and continue working until users re-login with `gptme-auth login`.

## Test plan
- [ ] All 17 `tests/test_gptme_provider.py` tests pass
- [ ] `gptme-auth login` completes and saves token with correct `base_url`
- [ ] `gptme -m gptme/claude-sonnet-4-6` resolves models from Supabase
- [ ] Chat completions reach `messages` edge function, not `fleet.gptme.ai`