### PR TITLE
fix(server): graceful shutdown on SIGTERM

### DIFF
--- a/gptme/server/cli.py
+++ b/gptme/server/cli.py
@@ -100,6 +100,7 @@ def _install_sigterm_handler() -> None:
     """
 
     def _handle_sigterm(signum, frame):
+        logger.info("Received SIGTERM, shutting down gracefully")
         raise KeyboardInterrupt
 
     signal.signal(signal.SIGTERM, _handle_sigterm)

--- a/gptme/server/cli.py
+++ b/gptme/server/cli.py
@@ -79,6 +79,32 @@ def _start_parent_death_watcher(
     thread.start()
 
 
+def _install_sigterm_handler() -> None:
+    """Make SIGTERM trigger the same graceful shutdown path as Ctrl+C (SIGINT).
+
+    Werkzeug's dev server (`app.run()`) catches `KeyboardInterrupt` in its
+    serve loop and exits cleanly, which lets the `finally: shutdown_telemetry()`
+    block run. Python only raises `KeyboardInterrupt` for SIGINT, though — the
+    default SIGTERM handler terminates the process immediately without unwinding
+    the stack, so on `systemctl stop`, container scale-down, or a rolling
+    restart the cleanup block never runs and any in-flight SSE stream is cut
+    mid-token.
+
+    Re-raising SIGTERM as `KeyboardInterrupt` routes it through the existing
+    clean-shutdown path. This also makes the parent-death watcher's self-SIGTERM
+    (see `_start_parent_death_watcher`) actually shut the server down gracefully,
+    as its comment already assumes.
+
+    Signal handlers can only be installed from the main thread; this is called
+    from the `serve` command before `app.run()`, which runs there.
+    """
+
+    def _handle_sigterm(signum, frame):
+        raise KeyboardInterrupt
+
+    signal.signal(signal.SIGTERM, _handle_sigterm)
+
+
 @click.group(cls=DefaultGroup, default="serve", default_if_no_args=True)
 def main():
     """gptme server commands."""
@@ -234,6 +260,10 @@ def serve(
     init_auth(host=host, display=True)
 
     app = create_app(cors_origin=cors_origin, host=host, webui_dir=webui_dir)
+
+    # Route SIGTERM through the same clean-shutdown path as Ctrl+C so the
+    # `finally` block below runs on `systemctl stop` / container scale-down.
+    _install_sigterm_handler()
 
     try:
         app.run(debug=debug, host=host, port=port)

--- a/tests/test_server_parent_death_watcher.py
+++ b/tests/test_server_parent_death_watcher.py
@@ -12,7 +12,11 @@ pytest.importorskip(
     "flask", reason="flask not installed, install server extras (-E server)"
 )
 
-from gptme.server.cli import _pid_alive, _start_parent_death_watcher
+from gptme.server.cli import (
+    _install_sigterm_handler,
+    _pid_alive,
+    _start_parent_death_watcher,
+)
 
 
 def test_pid_alive_for_self():
@@ -55,5 +59,22 @@ def test_watcher_sends_sigterm_when_watched_pid_disappears():
                     break
                 time.sleep(0.01)
         assert received == [signal.SIGTERM]
+    finally:
+        signal.signal(signal.SIGTERM, original)
+
+
+def test_install_sigterm_handler_raises_keyboardinterrupt():
+    """SIGTERM should re-raise as KeyboardInterrupt so the server's graceful
+    shutdown path (Werkzeug catches KeyboardInterrupt → `finally` cleanup runs)
+    fires on `systemctl stop` / container scale-down, not just on Ctrl+C."""
+    original = signal.getsignal(signal.SIGTERM)
+    try:
+        _install_sigterm_handler()
+        handler = signal.getsignal(signal.SIGTERM)
+        assert callable(handler)
+        # Invoking the handler directly must raise KeyboardInterrupt, which is
+        # what routes SIGTERM into Werkzeug's clean-shutdown path.
+        with pytest.raises(KeyboardInterrupt):
+            handler(signal.SIGTERM, None)
     finally:
         signal.signal(signal.SIGTERM, original)


### PR DESCRIPTION
## Problem

When `gptme-server` receives **SIGTERM** (`systemctl stop`, container scale-down, Kubernetes rolling restart), the process exits immediately. The `finally: shutdown_telemetry()` block never runs and any in-flight SSE stream is cut mid-token — the client sees an abrupt stream cut with no error, which looks like a bug.

## Root cause

The server runs Flask's dev server via `app.run()`. Werkzeug catches `KeyboardInterrupt` in its serve loop and exits cleanly, so **SIGINT (Ctrl+C)** already triggers the clean-shutdown path. But Python's *default* SIGTERM handler terminates the process immediately without unwinding the stack — no `KeyboardInterrupt`, no `finally`. Werkzeug installs no SIGTERM handler of its own (verified: `werkzeug.serving` has zero `signal`/`SIGTERM` references).

This also meant the parent-death watcher (#2260), whose comment says *"Send SIGTERM to ourselves so Flask's signal handlers run and the finally block fires"*, did **not** actually shut down gracefully — there was no such handler.

## Fix

Install a SIGTERM handler that re-raises as `KeyboardInterrupt`, routing SIGTERM through the exact same clean-shutdown path as Ctrl+C. ~8 LOC, installed from the main thread before `app.run()`.

## Reproduction (behavior, isolated)

```
default (no handler): SIGTERM → finally did NOT run   ✗
fixed (SIGTERM→KeyboardInterrupt): finally RAN        ✓
```

## Test

Adds `test_install_sigterm_handler_raises_keyboardinterrupt` to `tests/test_server_parent_death_watcher.py` (the natural home — it completes the #2260 watcher story). All 5 tests in that file pass.

Surfaced by the fleet.gptme.ai pod-lifecycle investigation (ErikBjare/bob#845).