### PR TITLE
fix(webui): make Escape key and interrupt logs consistent with isBusy

### DIFF
--- a/webui/src/components/ChatInput.tsx
+++ b/webui/src/components/ChatInput.tsx
@@ -971,11 +971,11 @@ export const ChatInput: FC<Props> = ({
           textareaRef.current.style.height = '';
         }
       } else if (onInterrupt) {
-        // No message text, so interrupt
-        console.log('[ChatInput] Interrupting generation...', { isGenerating });
+        // No message text, so interrupt (covers both isGenerating and pendingTool states)
+        console.log('[ChatInput] Interrupting generation...', { isBusy });
         try {
           await onInterrupt();
-          console.log('[ChatInput] Generation interrupted successfully', { isGenerating });
+          console.log('[ChatInput] Generation interrupted successfully', { isBusy });
         } catch (error) {
           console.error('[ChatInput] Error interrupting generation:', error);
         }
@@ -1038,8 +1038,8 @@ export const ChatInput: FC<Props> = ({
         return;
       }
 
-      // If generating, interrupt
-      if (isGenerating && onInterrupt) {
+      // If busy (generating or pending tool confirmation), interrupt
+      if (isBusy && onInterrupt) {
         console.log('[ChatInput] Escape pressed, interrupting generation...');
         onInterrupt();
       }


### PR DESCRIPTION
## Summary

Follow-up to #2808 — addresses two Greptile P2 findings Erik asked about.

After #2808 introduced `isBusy = isGenerating || !!pendingTool`, two inconsistencies remained:

**1. Escape key was a no-op during tool confirmation (`pendingTool` state)**

The Escape handler still gated on `isGenerating`:
```ts
if (isGenerating && onInterrupt)  // misses pendingTool state
```
When a tool confirmation is pending (`isBusy=true`, `isGenerating=false`), pressing Escape silently did nothing. The Stop button would show (using `isBusy`) but Escape would not trigger `onInterrupt`. Fixed to use `isBusy`.

**2. Interrupt logs showed stale `isGenerating` value**

The Stop-button interrupt path logged `{ isGenerating }`, which prints `false` when the interrupt is triggered via `pendingTool` state. Now logs `{ isBusy }` for accurate trace context.

## Test plan

- [ ] Trigger a tool confirmation dialog (any tool requiring confirmation)
- [ ] Press Escape — should now call `onInterrupt()` and abort the pending step
- [ ] Verify Stop button still works as before
- [ ] Check browser console shows `{ isBusy: true }` during a pendingTool interrupt

Greptile P2 comments from #2808: `ChatInput.tsx` lines 975-978 and 1040-1044.