### PR TITLE
feat(webui): show message count as badge on conversation title line

### DIFF
--- a/webui/src/components/ConversationList.tsx
+++ b/webui/src/components/ConversationList.tsx
@@ -321,7 +321,7 @@ export const ConversationList: FC<Props> = ({
                           ? Object.values(breakdown).reduce((a, b) => a + b, 0)
                           : conv.messages;
 
-                        if (count === undefined) {
+                        if (!count) {
                           return null;
                         }
 

--- a/webui/src/components/ConversationList.tsx
+++ b/webui/src/components/ConversationList.tsx
@@ -298,17 +298,52 @@ export const ConversationList: FC<Props> = ({
                     autoFocus
                   />
                 ) : (
-                  <div
-                    data-testid="conversation-title"
-                    className="font-small mb-1 whitespace-nowrap"
-                    style={{
-                      maskImage:
-                        'linear-gradient(to right, black 0%, black calc(100% - 2rem), transparent 100%)',
-                      WebkitMaskImage:
-                        'linear-gradient(to right, black 0%, black calc(100% - 2rem), transparent 100%)',
-                    }}
-                  >
-                    {convState?.data?.name || conv.name || stripDate(conv.id)}
+                  <div className="mb-1 flex items-center gap-2">
+                    <div
+                      data-testid="conversation-title"
+                      className="font-small min-w-0 flex-1 whitespace-nowrap"
+                      style={{
+                        maskImage:
+                          'linear-gradient(to right, black 0%, black calc(100% - 2rem), transparent 100%)',
+                        WebkitMaskImage:
+                          'linear-gradient(to right, black 0%, black calc(100% - 2rem), transparent 100%)',
+                      }}
+                    >
+                      {convState?.data?.name || conv.name || stripDate(conv.id)}
+                    </div>
+                    <Computed>
+                      {() => {
+                        const storeConv = conversations$.get(conv.id)?.get();
+                        const isLoaded = storeConv?.data?.log?.length > 0;
+
+                        const breakdown = isLoaded ? getMessageBreakdown() : {};
+                        const count = isLoaded
+                          ? Object.values(breakdown).reduce((a, b) => a + b, 0)
+                          : conv.messages;
+
+                        if (count === undefined) {
+                          return null;
+                        }
+
+                        const badge = (
+                          <span className="inline-flex shrink-0 items-center whitespace-nowrap rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
+                            <MessageSquare className="mr-1 h-3 w-3" />
+                            {count}
+                          </span>
+                        );
+
+                        return isLoaded ? (
+                          <Tooltip>
+                            <TooltipTrigger asChild>{badge}</TooltipTrigger>
+                            <TooltipContent>
+                              <div className="whitespace-pre">{formatBreakdown(breakdown)}</div>
+                            </TooltipContent>
+                          </Tooltip>
+                        ) : (
+                          badge
+                        );
+                      }}
+                    </Computed>
                   </div>
                 )}
                 {conv.last_message_preview && (
@@ -335,39 +370,6 @@ export const ConversationList: FC<Props> = ({
                       {new Date(conv.modified * 1000).toLocaleString()}
                     </TooltipContent>
                   </Tooltip>
-                  <Computed>
-                    {() => {
-                      const storeConv = conversations$.get(conv.id)?.get();
-                      const isLoaded = storeConv?.data?.log?.length > 0;
-
-                      const breakdown = isLoaded ? getMessageBreakdown() : {};
-                      const count = isLoaded
-                        ? Object.values(breakdown).reduce((a, b) => a + b, 0)
-                        : conv.messages;
-
-                      if (count === undefined) {
-                        return null;
-                      }
-
-                      const messageCountElement = (
-                        <span className="flex items-center">
-                          <MessageSquare className="mr-1 h-3 w-3" />
-                          {count}
-                        </span>
-                      );
-
-                      return isLoaded ? (
-                        <Tooltip>
-                          <TooltipTrigger asChild>{messageCountElement}</TooltipTrigger>
-                          <TooltipContent>
-                            <div className="whitespace-pre">{formatBreakdown(breakdown)}</div>
-                          </TooltipContent>
-                        </Tooltip>
-                      ) : (
-                        messageCountElement
-                      );
-                    }}
-                  </Computed>
 
                   {/* Cost badge: show per-conversation total cost from loaded data */}
                   <Computed>


### PR DESCRIPTION
## Problem

The conversation list in the sidebar shows only the conversation title. Users cannot tell at a glance how long a conversation is — whether it is a 2-message quick lookup or a 200-message deep session.

The message count was already shown inline in the metadata row (alongside the timestamp), but not in a glanceable position.

## Solution

Moved the message count from the metadata row to the title line as a right-aligned rounded badge:

- **Before**: Title line → metadata row with timestamp + icon + count + state indicators
- **After**: Title line with right-aligned count badge → metadata row with timestamp + state indicators

The count badge uses `rounded-full bg-muted px-2 py-0.5 text-xs font-medium` styling for a clean, glanceable pill appearance. The format-breakdown tooltip (showing user/assistant/tool/system counts) is preserved on hover when store data is loaded.

No backend changes needed — the count is already available from `ConversationSummary.messages`.

## Verification
- TypeScript typecheck: clean
- Build: clean