### PR TITLE
feat(webui): add URL subroutes for settings category deep-linking

### DIFF
--- a/webui/extension/content/content.ts
+++ b/webui/extension/content/content.ts
@@ -6,14 +6,16 @@ document.addEventListener('mouseup', () => {
   const sel = window.getSelection()?.toString().trim() ?? '';
   if (sel && sel !== lastSelection) {
     lastSelection = sel;
-    chrome.runtime.sendMessage({
-      type: 'SELECTION',
-      // Truncate long selections to stay within reasonable token budgets
-      selection: sel.length > 2000 ? sel.slice(0, 2000) + '…' : sel,
-      url: location.href,
-      title: document.title,
-    }).catch(() => {
-      // Panel may not be open — ignore
-    });
+    chrome.runtime
+      .sendMessage({
+        type: 'SELECTION',
+        // Truncate long selections to stay within reasonable token budgets
+        selection: sel.length > 2000 ? sel.slice(0, 2000) + '…' : sel,
+        url: location.href,
+        title: document.title,
+      })
+      .catch(() => {
+        // Panel may not be open — ignore
+      });
   }
 });

--- a/webui/public/_redirects
+++ b/webui/public/_redirects
@@ -15,4 +15,5 @@
 /admin / 200
 /health / 200
 /settings / 200
+/settings/* / 200
 /workspace/* / 200

--- a/webui/src/App.tsx
+++ b/webui/src/App.tsx
@@ -92,6 +92,7 @@ const App: FC = () => {
                         <Route path={appRoutes.admin} element={<Admin />} />
                         <Route path={appRoutes.health} element={<Health />} />
                         <Route path={appRoutes.settings} element={<SettingsPage />} />
+                        <Route path={appRoutes.settingsCategory} element={<SettingsPage />} />
                         <Route path={appRoutes.workspace} element={<Workspace />} />
                         <Route path="*" element={<NotFound />} />
                       </Routes>

--- a/webui/src/appRoutes.ts
+++ b/webui/src/appRoutes.ts
@@ -12,6 +12,7 @@ export const appRoutes = {
   health: '/health',
   workspace: '/workspace/:id',
   settings: '/settings',
+  settingsCategory: '/settings/:category',
 } as const;
 
 export const cloudflareSpaRedirectRules = [
@@ -26,5 +27,6 @@ export const cloudflareSpaRedirectRules = [
   `${appRoutes.admin} / 200`,
   `${appRoutes.health} / 200`,
   `${appRoutes.settings} / 200`,
+  `${appRoutes.settings}/* / 200`,
   `${appRoutes.workspace.replace(/\/:[^/]+$/, '/*')} / 200`,
 ] as const;

--- a/webui/src/components/ui/badge.tsx
+++ b/webui/src/components/ui/badge.tsx
@@ -23,7 +23,8 @@ const badgeVariants = cva(
 );
 
 export interface BadgeProps
-  extends React.HTMLAttributes<HTMLDivElement>, VariantProps<typeof badgeVariants> {}
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
 
 function Badge({ className, variant, ...props }: BadgeProps) {
   return <div className={cn(badgeVariants({ variant }), className)} {...props} />;

--- a/webui/src/components/ui/button.tsx
+++ b/webui/src/components/ui/button.tsx
@@ -32,7 +32,8 @@ const buttonVariants = cva(
 );
 
 export interface ButtonProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement>, VariantProps<typeof buttonVariants> {
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
   asChild?: boolean;
 }
 

--- a/webui/src/components/ui/sheet.tsx
+++ b/webui/src/components/ui/sheet.tsx
@@ -48,8 +48,7 @@ const sheetVariants = cva(
 );
 
 interface SheetContentProps
-  extends
-    React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
+  extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
     VariantProps<typeof sheetVariants> {}
 
 const SheetContent = React.forwardRef<

--- a/webui/src/hooks/__tests__/useSpeechToText.test.tsx
+++ b/webui/src/hooks/__tests__/useSpeechToText.test.tsx
@@ -135,9 +135,7 @@ describe('useSpeechToText', () => {
       expect(result.current.state).toBe('idle');
     });
 
-    expect(transcribeAudio.mock.calls[0]?.[1]).toEqual(
-      expect.objectContaining({ language: 'en' })
-    );
+    expect(transcribeAudio.mock.calls[0]?.[1]).toEqual(expect.objectContaining({ language: 'en' }));
     expect(handler).toHaveBeenCalledWith('server transcript');
   });
 });

--- a/webui/src/pages/SettingsPage.tsx
+++ b/webui/src/pages/SettingsPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, type FC } from 'react';
+import { useState, useEffect, useCallback, type FC } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { Settings } from 'lucide-react';
 import { MenuBar } from '@/components/MenuBar';
@@ -30,6 +30,14 @@ const SettingsPage: FC = () => {
     setActiveCategory(toCategoryOrDefault(category));
   }, [category]);
 
+  const handleCategoryChange = useCallback(
+    (cat: SettingsCategory) => {
+      setActiveCategory(cat);
+      navigate(`/settings/${cat}`);
+    },
+    [navigate]
+  );
+
   // Observe external requests (e.g. ServerSelector configure button) to switch category
   const externalRequest = use$(settingsModal$);
   useEffect(() => {
@@ -37,13 +45,7 @@ const SettingsPage: FC = () => {
       handleCategoryChange(externalRequest.category);
       settingsModal$.open.set(false);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [externalRequest.open, externalRequest.category]);
-
-  function handleCategoryChange(cat: SettingsCategory) {
-    setActiveCategory(cat);
-    navigate(`/settings/${cat}`);
-  }
+  }, [externalRequest.open, externalRequest.category, handleCategoryChange]);
 
   return (
     <div className="flex h-screen flex-col">

--- a/webui/src/pages/SettingsPage.tsx
+++ b/webui/src/pages/SettingsPage.tsx
@@ -6,21 +6,14 @@ import { SidebarIcons } from '@/components/SidebarIcons';
 import { MobileBottomNav } from '@/components/MobileBottomNav';
 import { useTasksQuery } from '@/stores/tasks';
 import { SettingsContent } from '@/components/SettingsContent';
-import type { SettingsCategory } from '@/stores/settingsModal';
+import { SETTINGS_CATEGORIES, type SettingsCategory } from '@/stores/settingsModal';
 import { use$ } from '@legendapp/state/react';
 import { settingsModal$ } from '@/stores/settingsModal';
 
-const VALID_CATEGORIES: SettingsCategory[] = [
-  'servers',
-  'appearance',
-  'audio',
-  'content',
-  'developer',
-  'about',
-];
-
 function toCategoryOrDefault(raw: string | undefined): SettingsCategory {
-  return VALID_CATEGORIES.includes(raw as SettingsCategory) ? (raw as SettingsCategory) : 'servers';
+  return (SETTINGS_CATEGORIES as ReadonlyArray<string>).includes(raw ?? '')
+    ? (raw as SettingsCategory)
+    : 'servers';
 }
 
 /** Full-page settings view — replaces the modal when navigated via /settings route. */
@@ -49,7 +42,7 @@ const SettingsPage: FC = () => {
 
   function handleCategoryChange(cat: SettingsCategory) {
     setActiveCategory(cat);
-    navigate(`/settings/${cat}`, { replace: true });
+    navigate(`/settings/${cat}`);
   }
 
   return (

--- a/webui/src/pages/SettingsPage.tsx
+++ b/webui/src/pages/SettingsPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, type FC } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
 import { Settings } from 'lucide-react';
 import { MenuBar } from '@/components/MenuBar';
 import { SidebarIcons } from '@/components/SidebarIcons';
@@ -9,19 +10,47 @@ import type { SettingsCategory } from '@/stores/settingsModal';
 import { use$ } from '@legendapp/state/react';
 import { settingsModal$ } from '@/stores/settingsModal';
 
+const VALID_CATEGORIES: SettingsCategory[] = [
+  'servers',
+  'appearance',
+  'audio',
+  'content',
+  'developer',
+  'about',
+];
+
+function toCategoryOrDefault(raw: string | undefined): SettingsCategory {
+  return VALID_CATEGORIES.includes(raw as SettingsCategory) ? (raw as SettingsCategory) : 'servers';
+}
+
 /** Full-page settings view — replaces the modal when navigated via /settings route. */
 const SettingsPage: FC = () => {
+  const { category } = useParams<{ category?: string }>();
+  const navigate = useNavigate();
   const { data: tasks = [] } = useTasksQuery();
-  const [activeCategory, setActiveCategory] = useState<SettingsCategory>('appearance');
+  const [activeCategory, setActiveCategory] = useState<SettingsCategory>(
+    toCategoryOrDefault(category)
+  );
+
+  // Keep state in sync when URL param changes (e.g. browser back/forward)
+  useEffect(() => {
+    setActiveCategory(toCategoryOrDefault(category));
+  }, [category]);
 
   // Observe external requests (e.g. ServerSelector configure button) to switch category
   const externalRequest = use$(settingsModal$);
   useEffect(() => {
     if (externalRequest.open && externalRequest.category) {
-      setActiveCategory(externalRequest.category);
+      handleCategoryChange(externalRequest.category);
       settingsModal$.open.set(false);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [externalRequest.open, externalRequest.category]);
+
+  function handleCategoryChange(cat: SettingsCategory) {
+    setActiveCategory(cat);
+    navigate(`/settings/${cat}`, { replace: true });
+  }
 
   return (
     <div className="flex h-screen flex-col">
@@ -36,7 +65,10 @@ const SettingsPage: FC = () => {
             <p className="text-sm text-muted-foreground">Customize your gptme experience</p>
           </div>
 
-          <SettingsContent activeCategory={activeCategory} onCategoryChange={setActiveCategory} />
+          <SettingsContent
+            activeCategory={activeCategory}
+            onCategoryChange={handleCategoryChange}
+          />
         </div>
       </div>
       <MobileBottomNav />

--- a/webui/src/stores/settingsModal.ts
+++ b/webui/src/stores/settingsModal.ts
@@ -1,12 +1,15 @@
 import { observable } from '@legendapp/state';
 
-export type SettingsCategory =
-  | 'servers'
-  | 'appearance'
-  | 'audio'
-  | 'content'
-  | 'developer'
-  | 'about';
+export const SETTINGS_CATEGORIES = [
+  'servers',
+  'appearance',
+  'audio',
+  'content',
+  'developer',
+  'about',
+] as const;
+
+export type SettingsCategory = (typeof SETTINGS_CATEGORIES)[number];
 
 /** Observable to open the settings modal from outside (e.g. server dropdown, command palette). */
 export const settingsModal$ = observable({

--- a/webui/src/utils/logging.ts
+++ b/webui/src/utils/logging.ts
@@ -40,8 +40,9 @@ export async function setupLogging() {
 
   try {
     // Dynamically import Tauri logging to avoid module errors in browser
-    const { warn, debug, trace, info, error, attachConsole } =
-      await import('@tauri-apps/plugin-log');
+    const { warn, debug, trace, info, error, attachConsole } = await import(
+      '@tauri-apps/plugin-log'
+    );
 
     // Attach console first to see Rust logs in browser console
     detachConsole = await attachConsole();

--- a/webui/src/utils/tts.ts
+++ b/webui/src/utils/tts.ts
@@ -231,7 +231,9 @@ async function speak(rawText: string, key: string): Promise<void> {
         console.warn('External gptme-tts server unavailable, falling back to browser:', err);
       }
     } else {
-      console.warn('TTS engine "external" selected but no gptme-tts server URL set; using browser.');
+      console.warn(
+        'TTS engine "external" selected but no gptme-tts server URL set; using browser.'
+      );
     }
     if (!speakViaBrowser(spoken, key)) clearIfStill(key);
     return;


### PR DESCRIPTION
## Summary

- Add \`/settings/:category\` route so individual settings tabs have stable URLs (e.g. \`/settings/servers\`, \`/settings/appearance\`)
- Tab navigation pushes the new URL (each tab click adds a history entry — back-button steps through tabs)
- Browser back/forward sync via \`useEffect\` on the \`category\` param
- Unknown or missing category falls back to \`servers\`
- \`SETTINGS_CATEGORIES\` exported as a const array from \`settingsModal.ts\`; \`SettingsCategory\` type derived from it (single source of truth)
- Added \`/settings/*\` SPA fallback to \`_redirects\` (Cloudflare Pages) and \`cloudflareSpaRedirectRules\`

Builds on top of gptme/gptme#2806 (add /settings route, already merged).

## Test plan

- [ ] Navigate to \`/settings\` — lands on Servers tab
- [ ] Click Appearance tab → URL becomes \`/settings/appearance\`
- [ ] Browser back → returns to \`/settings/servers\`
- [ ] Navigate directly to \`/settings/developer\` → lands on Developer tab
- [ ] Navigate to \`/settings/nonsense\` → falls back to Servers tab
- [ ] \`tsc --noEmit\` passes
- [ ] Jest tests pass (\`cloudflareRedirects\`, \`CommandPalette\`)