### PR TITLE
feat(webui): add persistent no-confirm (YOLO) mode setting

### DIFF
--- a/webui/src/components/ConversationContent.tsx
+++ b/webui/src/components/ConversationContent.tsx
@@ -451,12 +451,14 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
   };
 
   // When no-confirm mode is on, silently auto-confirm any pending tool without showing the dialog.
+  const AUTO_CONFIRM_ALL = 999999;
   const pendingToolId = use$(() => conversation$?.pendingTool.get()?.id ?? null);
   useEffect(() => {
     if (pendingToolId && settings.noConfirmMode) {
-      void handleAutoConfirmTool(999999);
+      void handleAutoConfirmTool(AUTO_CONFIRM_ALL);
     }
-    // handleAutoConfirmTool is stable (calls confirmTool from the hook)
+    // Safe to omit handleAutoConfirmTool: confirmTool reads pendingTool fresh from the
+    // observable store on each call, so a stale closure does not cause incorrect behaviour.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pendingToolId, settings.noConfirmMode]);
 
@@ -695,14 +697,16 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
           }}
         </For>
 
-        {/* Inline Tool Confirmation */}
-        <InlineToolConfirmation
-          pendingTool$={conversation$?.pendingTool}
-          onConfirm={handleConfirmTool}
-          onEdit={handleEditTool}
-          onSkip={handleSkipTool}
-          onAuto={handleAutoConfirmTool}
-        />
+        {/* Inline Tool Confirmation — hidden when no-confirm mode is active */}
+        {!settings.noConfirmMode && (
+          <InlineToolConfirmation
+            pendingTool$={conversation$?.pendingTool}
+            onConfirm={handleConfirmTool}
+            onEdit={handleEditTool}
+            onSkip={handleSkipTool}
+            onAuto={handleAutoConfirmTool}
+          />
+        )}
 
         {/* Inline Tool Execution */}
         <InlineToolExecution executingTool$={conversation$?.executingTool} />

--- a/webui/src/components/ConversationContent.tsx
+++ b/webui/src/components/ConversationContent.tsx
@@ -450,6 +450,16 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
     await confirmTool('auto', { count });
   };
 
+  // When no-confirm mode is on, silently auto-confirm any pending tool without showing the dialog.
+  const pendingToolId = use$(() => conversation$?.pendingTool.get()?.id ?? null);
+  useEffect(() => {
+    if (pendingToolId && settings.noConfirmMode) {
+      void handleAutoConfirmTool(999999);
+    }
+    // handleAutoConfirmTool is stable (calls confirmTool from the hook)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pendingToolId, settings.noConfirmMode]);
+
   const handleScrollToBottom = () => {
     const container = scrollContainerRef.current;
     if (container) {

--- a/webui/src/components/SettingsContent.tsx
+++ b/webui/src/components/SettingsContent.tsx
@@ -335,6 +335,29 @@ export function SettingsContent({
             <Separator />
 
             <div className="space-y-4">
+              <h4 className="text-sm font-medium">Tool Execution</h4>
+
+              <div className="flex items-center justify-between">
+                <div className="space-y-0.5">
+                  <Label htmlFor="no-confirm-toggle" className="text-sm">
+                    No-confirm mode
+                  </Label>
+                  <p className="text-xs text-muted-foreground">
+                    Auto-confirm all tool execution prompts without asking (equivalent to{' '}
+                    <code className="font-mono">--no-confirm</code> in the CLI)
+                  </p>
+                </div>
+                <Switch
+                  id="no-confirm-toggle"
+                  checked={settings.noConfirmMode}
+                  onCheckedChange={(checked) => updateSettings({ noConfirmMode: checked })}
+                />
+              </div>
+            </div>
+
+            <Separator />
+
+            <div className="space-y-4">
               <h4 className="text-sm font-medium">Developer Options</h4>
 
               <div className="flex items-center justify-between">

--- a/webui/src/contexts/SettingsContext.tsx
+++ b/webui/src/contexts/SettingsContext.tsx
@@ -29,6 +29,11 @@ export interface Settings {
    * Leave empty to hide the VoiceButton.
    */
   voiceServerUrl: string;
+  /**
+   * When true, tool execution prompts are skipped and all tools are auto-confirmed.
+   * Equivalent to --no-confirm in the CLI (also known as "YOLO mode").
+   */
+  noConfirmMode: boolean;
 }
 
 interface SettingsContextType {
@@ -48,6 +53,7 @@ const defaultSettings: Settings = {
   welcomeBackground: '',
   ttsServerUrl: '',
   voiceServerUrl: '',
+  noConfirmMode: false,
 };
 
 function loadSettingsFromStorage(): Settings {


### PR DESCRIPTION
## Summary

- Adds a **No-confirm mode** toggle to Settings → Content → Tool Execution
- When enabled, all tool execution prompts are silently auto-confirmed (equivalent to `--no-confirm` / YOLO mode in the CLI)
- Setting persists in `localStorage` across sessions via `SettingsContext`

## Motivation

Power users frequently click "Auto-accept all" on every new conversation. This makes it a one-time persistent toggle instead.

Closes ErikBjare/bob#848.

## Implementation

Three small changes:
1. **`SettingsContext.tsx`** — add `noConfirmMode: boolean` (default `false`) to the `Settings` interface and `defaultSettings`
2. **`SettingsContent.tsx`** — add a Switch toggle in the Content tab under a new "Tool Execution" section
3. **`ConversationContent.tsx`** — add a `useEffect` that watches `pendingTool` and calls `confirmTool('auto', {count: 999999})` immediately when `noConfirmMode` is on, bypassing the `InlineToolConfirmation` dialog entirely

## Test plan

- [ ] Toggle the setting on in Settings → Content → Tool Execution
- [ ] Start a conversation that triggers tool execution — confirm the dialog is skipped and tools run automatically
- [ ] Toggle off — confirm the confirmation dialog reappears
- [ ] Reload the page — confirm the setting persists (stored in localStorage)