### PR TITLE
fix(cloud): parse max_completion_tokens for gptme provider models

### DIFF
--- a/gptme/llm/__init__.py
+++ b/gptme/llm/__init__.py
@@ -202,12 +202,15 @@ _OPENROUTER_DEFAULT_MAX_TOKENS = 16000
 
 
 def _resolve_max_tokens(model: str, max_tokens: int | None) -> int | None:
-    """Apply the GPTME_MAX_TOKENS env override or a sane default for OpenRouter models.
+    """Apply the GPTME_MAX_TOKENS env override or a sane default for providers that require it.
 
     When max_tokens is omitted, OpenRouter reserves model.max_output +
     reasoning_budget credits per request. For large models like Sonnet 4.6
     that is ~65k tokens. A partially-spent daily-budget key rejects this
     with HTTP 402 even when the actual response would fit comfortably.
+
+    The gptme cloud provider (Supabase messages function) requires max_tokens
+    explicitly — omitting it returns HTTP 400 Field required.
 
     Setting a default max_tokens reduces the reservation so partial-budget
     keys still work.
@@ -216,7 +219,10 @@ def _resolve_max_tokens(model: str, max_tokens: int | None) -> int | None:
     if max_tokens is not None:
         return max_tokens
 
-    if get_provider_from_model(model) != "openrouter":
+    provider = get_provider_from_model(model)
+
+    # Only apply defaults for providers that need them
+    if provider not in ("openrouter", "gptme"):
         return None
 
     raw = get_config().get_env("GPTME_MAX_TOKENS")
@@ -238,7 +244,14 @@ def _resolve_max_tokens(model: str, max_tokens: int | None) -> int | None:
                 )
                 _max_tokens_env_warned = True
 
-    return _OPENROUTER_DEFAULT_MAX_TOKENS
+    if provider == "openrouter":
+        return _OPENROUTER_DEFAULT_MAX_TOKENS
+
+    # provider == "gptme": use max_output from model metadata, with 4096 fallback
+    from .models import get_model  # fmt: skip
+
+    model_meta = get_model(model)
+    return model_meta.max_output or 4096
 
 
 @trace_function(name="llm.reply", attributes={"component": "llm"})

--- a/gptme/llm/llm_gptme.py
+++ b/gptme/llm/llm_gptme.py
@@ -6,7 +6,12 @@ or falls back to a ``GPTME_CLOUD_API_KEY`` environment variable.
 
 Usage:
     1. Authenticate: ``gptme-auth login``
-    2. Use models:   ``gptme -m gptme/claude-sonnet-4-6``
+    2. List models:  ``gptme --list-models`` (shows ``gptme/anthropic/MODEL`` etc.)
+    3. Use models:   ``gptme -m gptme/anthropic/claude-sonnet-4-6``
+
+    Model IDs from the gptme cloud service include a provider prefix (e.g.
+    ``anthropic/``, ``openai/``). The full model spec for gptme is therefore
+    ``gptme/<provider>/<model>`` — e.g. ``gptme/anthropic/claude-sonnet-4-6``.
 
 Token priority:
     1. Device Flow token from ``~/.config/gptme/auth/gptme-cloud-<hash>.json``

--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -1812,14 +1812,16 @@ def _openai_compatible_model_to_modelmeta(
         input_side = modality.split("->")[0] if "->" in modality else ""
         supports_vision = "image" in input_side
 
+    max_output = model_data.get("max_completion_tokens")
+
     return ModelMeta(
         provider=provider,
         model=model_id,
         context=context,
-        max_output=None,
-        supports_streaming=True,
+        max_output=max_output,
+        supports_streaming=model_data.get("supports_streaming", True),
         supports_vision=supports_vision,
-        supports_reasoning=False,
+        supports_reasoning=model_data.get("supports_reasoning", False),
         price_input=0,  # pricing unknown for dynamically discovered models
         price_output=0,
     )


### PR DESCRIPTION
## Problem

Dogfooding `gptme-auth login` (ErikBjare/bob#845) hit two bugs after PR #2820 fixed the URL routing:

1. **`max_tokens: Field required`** — Every gptme cloud API call fails with HTTP 400 because gptme never sends `max_tokens`. The Supabase messages function passes requests to Anthropic, which requires `max_tokens`. The root cause: `_openai_compatible_model_to_modelmeta` set `max_output=None` for all dynamically-fetched models, so gptme omitted the parameter.

2. **Model ID format confusion** — The existing docstring showed `gptme -m gptme/claude-sonnet-4-6`, but the Supabase models endpoint returns IDs like `anthropic/claude-sonnet-4-6`. The correct model spec is `gptme/anthropic/claude-sonnet-4-6` (provider prefix preserved). Using `gptme/claude-sonnet-4-6` strips to bare `claude-sonnet-4-6` which the Supabase function rejects.

## Fix

- **`_openai_compatible_model_to_modelmeta`**: parse `max_completion_tokens` from the models list response (present for every model in the Supabase endpoint) and set it as `max_output`. Also forward `supports_streaming` and `supports_reasoning` from the response instead of hardcoding defaults.

- **`llm_gptme.py` docstring**: document the correct model ID format (`gptme/anthropic/MODEL`, `gptme/openai/MODEL`) and that `gptme --list-models` is the right way to discover available models.

## Verification

```bash
# Direct Supabase endpoint — confirmed working
curl -s -X POST "https://kpkxgnfpyntahyhckhgm.supabase.co/functions/v1/messages" \
  -H "Authorization: Bearer $GPTME_CLOUD_API_KEY" \
  -H "Content-Type: application/json" \
  -d '{"model":"anthropic/claude-haiku-4-5-20251001","messages":[{"role":"user","content":"say hello"}],"max_tokens":50,"stream":false}'
# → {"content":[{"type":"text","text":"Hello! ..."}], ...}
```

After this fix, gptme should correctly send `max_tokens` (from `max_output`) to the Supabase messages function.

## Note on model naming

The server-side `messages` function requires the `anthropic/` prefix — it returns "Unsupported provider prefix: claude-sonnet-4-6" for bare names. A follow-up could add bare-name fallback in the edge function (e.g. auto-prefix with `anthropic/` when no recognized prefix found), but for now the client-side doc fix documents the correct format.