### PR TITLE
feat(webui): show relative timestamps on messages with auto-refresh

### DIFF
--- a/webui/src/components/ChatMessage.tsx
+++ b/webui/src/components/ChatMessage.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useRef, useState, useSyncExternalStore, type FC } from 'react';
-import type { Message, StreamingMessage } from '@/types/conversation';
+import { useCallback, useEffect, useRef, useState, useSyncExternalStore, type FC } from 'react';
+import type { Message, MessageMetadata, StreamingMessage } from '@/types/conversation';
 import { MessageAvatar } from './MessageAvatar';
 import { useMessageChainType } from '@/utils/messageUtils';
 import { useApi } from '@/contexts/ApiContext';
@@ -38,33 +38,83 @@ import {
   stopSpeaking,
 } from '@/utils/tts';
 import { rightSidebarActiveTab$, rightSidebarVisible$ } from '@/stores/sidebar';
+import { getRelativeTimeString } from '@/utils/time';
 
-function formatTimestamp(timestamp: string): { short: string; full: string } {
-  const date = new Date(timestamp);
-  if (isNaN(date.getTime())) return { short: '', full: '' };
-  const now = new Date();
-  const isToday = date.toDateString() === now.toDateString();
-  const isThisYear = date.getFullYear() === now.getFullYear();
+function MessageMetaLabel({
+  timestamp,
+  metadata,
+}: {
+  timestamp?: string;
+  metadata?: MessageMetadata;
+}) {
+  const [, setTick] = useState(0);
 
-  const timeStr = date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
-  const full = date.toLocaleString([], {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-    second: '2-digit',
-  });
+  useEffect(() => {
+    if (!timestamp) return;
+    const id = setInterval(() => setTick((t) => t + 1), 60_000);
+    return () => clearInterval(id);
+  }, [timestamp]);
 
-  if (isToday) {
-    return { short: timeStr, full };
+  if (!timestamp && !metadata) return null;
+
+  const date = timestamp ? new Date(timestamp) : null;
+  const isValidDate = date && !isNaN(date.getTime());
+
+  const relTime = isValidDate ? getRelativeTimeString(date) : null;
+  const fullTime = isValidDate
+    ? date.toLocaleString([], {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+      })
+    : null;
+
+  const model = metadata?.model;
+  const cost = metadata?.cost;
+  const usage = metadata?.usage;
+
+  const parts: string[] = [];
+  if (model) parts.push(model);
+  if (relTime) parts.push(relTime);
+  const shortLabel = parts.join(' · ');
+  if (!shortLabel) return null;
+
+  const tooltipLines: string[] = [];
+  if (fullTime) tooltipLines.push(fullTime);
+  if (model) tooltipLines.push(`Model: ${model}`);
+  if (cost != null) tooltipLines.push(`Cost: $${cost.toFixed(4)}`);
+  if (usage) {
+    if (usage.input_tokens)
+      tooltipLines.push(`Input: ${usage.input_tokens.toLocaleString()} tokens`);
+    if (usage.output_tokens)
+      tooltipLines.push(`Output: ${usage.output_tokens.toLocaleString()} tokens`);
+    if (usage.cache_read_tokens)
+      tooltipLines.push(`Cache read: ${usage.cache_read_tokens.toLocaleString()} tokens`);
+    if (usage.cache_creation_tokens)
+      tooltipLines.push(`Cache write: ${usage.cache_creation_tokens.toLocaleString()} tokens`);
   }
-  const dateStr = date.toLocaleDateString([], {
-    month: 'short',
-    day: 'numeric',
-    ...(isThisYear ? {} : { year: 'numeric' }),
-  });
-  return { short: `${dateStr}, ${timeStr}`, full };
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div className="h-0 select-none overflow-visible px-3 text-right text-[10px] leading-4 text-muted-foreground/50 opacity-0 transition-opacity group-hover/message:opacity-100">
+            {shortLabel}
+          </div>
+        </TooltipTrigger>
+        <TooltipContent side="bottom" className="max-w-xs">
+          <div className="space-y-0.5 text-xs">
+            {tooltipLines.map((line, i) => (
+              <div key={i}>{line}</div>
+            ))}
+          </div>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
 }
 
 interface Props {
@@ -680,63 +730,8 @@ export const ChatMessage: FC<Props> = ({
                     <Memo>
                       {() => {
                         const msg = message$.get() as Message;
-                        const timestamp = msg?.timestamp;
-                        const metadata = msg?.metadata;
-                        if (!timestamp && !metadata) return null;
-
-                        const time = timestamp ? formatTimestamp(timestamp) : null;
-                        const model = metadata?.model;
-                        const cost = metadata?.cost;
-                        const usage = metadata?.usage;
-
-                        // Build the short inline label: "model · time"
-                        const parts: string[] = [];
-                        if (model) parts.push(model);
-                        if (time?.short) parts.push(time.short);
-                        const shortLabel = parts.join(' · ');
-                        if (!shortLabel) return null;
-
-                        // Build rich tooltip content
-                        const tooltipLines: string[] = [];
-                        if (time?.full) tooltipLines.push(time.full);
-                        if (model) tooltipLines.push(`Model: ${model}`);
-                        if (cost != null) tooltipLines.push(`Cost: $${cost.toFixed(4)}`);
-                        if (usage) {
-                          if (usage.input_tokens)
-                            tooltipLines.push(
-                              `Input: ${usage.input_tokens.toLocaleString()} tokens`
-                            );
-                          if (usage.output_tokens)
-                            tooltipLines.push(
-                              `Output: ${usage.output_tokens.toLocaleString()} tokens`
-                            );
-                          if (usage.cache_read_tokens)
-                            tooltipLines.push(
-                              `Cache read: ${usage.cache_read_tokens.toLocaleString()} tokens`
-                            );
-                          if (usage.cache_creation_tokens)
-                            tooltipLines.push(
-                              `Cache write: ${usage.cache_creation_tokens.toLocaleString()} tokens`
-                            );
-                        }
-
                         return (
-                          <TooltipProvider>
-                            <Tooltip>
-                              <TooltipTrigger asChild>
-                                <div className="h-0 select-none overflow-visible px-3 text-right text-[10px] leading-4 text-muted-foreground/50 opacity-0 transition-opacity group-hover/message:opacity-100">
-                                  {shortLabel}
-                                </div>
-                              </TooltipTrigger>
-                              <TooltipContent side="bottom" className="max-w-xs">
-                                <div className="space-y-0.5 text-xs">
-                                  {tooltipLines.map((line, i) => (
-                                    <div key={i}>{line}</div>
-                                  ))}
-                                </div>
-                              </TooltipContent>
-                            </Tooltip>
-                          </TooltipProvider>
+                          <MessageMetaLabel timestamp={msg?.timestamp} metadata={msg?.metadata} />
                         );
                       }}
                     </Memo>

--- a/webui/src/components/ChatMessage.tsx
+++ b/webui/src/components/ChatMessage.tsx
@@ -51,6 +51,14 @@ function MessageMetaLabel({
 
   useEffect(() => {
     if (!timestamp) return;
+    const date = new Date(timestamp);
+    if (isNaN(date.getTime())) return;
+
+    // Only auto-refresh for recent messages (<1h old). Older messages change
+    // so slowly (hours → days) that per-minute updates are wasteful.
+    const ageMs = Date.now() - date.getTime();
+    if (ageMs > 60 * 60 * 1000) return;
+
     const id = setInterval(() => setTick((t) => t + 1), 60_000);
     return () => clearInterval(id);
   }, [timestamp]);


### PR DESCRIPTION
## Summary

- Replaces the existing `formatTimestamp` helper (which showed absolute HH:MM time) with a new `MessageMetaLabel` component that displays relative timestamps ("3 min ago", "2h ago", "Jun 8") in the per-message hover label
- Tooltip on hover still shows the full exact datetime (e.g. "Jun 10, 2026, 23:26:00")
- Relative time auto-refreshes every 60 seconds via `setInterval` in `useEffect`
- Messages without a `timestamp` field gracefully show nothing (no regression for old conversations)

**Before**: "model · 14:30" (absolute HH:MM)
**After**: "model · 3 min ago" (relative, auto-updating)

## Design notes

The key refactor is extracting the tooltip+label block from inside `<Memo>` into a proper React FC (`MessageMetaLabel`). This is required because `useState`/`useEffect` hooks must live in a real component — putting them inside a `Memo` render callback doesn't give them a stable component identity. `Memo` now just reads observables and passes props through.

## Test plan

- [ ] Open a conversation with recent messages — hover a message and confirm it shows "X min ago"
- [ ] Hover the label — tooltip should show full datetime
- [ ] Wait 60s — relative time should update automatically
- [ ] Open a conversation with old messages (e.g. from yesterday) — should show "Nh ago" or "yesterday"
- [ ] Check a conversation imported from before timestamps were added — no timestamp should show nothing (no regression)