### PR TITLE
feat(config): add context_exclude glob patterns to [prompt] in gptme.toml

### DIFF
--- a/gptme/config/models.py
+++ b/gptme/config/models.py
@@ -263,6 +263,7 @@ class ProjectConfig:
     base_prompt: str | None = None
     prompt: str | None = None
     files: list[str] | None = None
+    exclude: list[str] = field(default_factory=list)
     context_cmd: str | None = None
     rag: RagConfig = field(default_factory=RagConfig)
     agent: AgentConfig | None = None
@@ -294,12 +295,14 @@ class ProjectConfig:
             prompt = prompt_data.pop("prompt", None)
             base_prompt = prompt_data.pop("base_prompt", None)
             files = prompt_data.pop("files", None)
+            exclude = prompt_data.pop("exclude", [])
             context_cmd = prompt_data.pop("context_cmd", None)
         else:
             # Old format: flat structure, prompt_data contains the prompt string
             prompt = prompt_data
             base_prompt = config_data.pop("base_prompt", None)
             files = config_data.pop("files", None)
+            exclude = []
             context_cmd = config_data.pop("context_cmd", None)
 
         rag = _build_section("rag", RagConfig, _pop_object_section(config_data, "rag"))
@@ -380,6 +383,7 @@ class ProjectConfig:
             prompt=prompt,
             base_prompt=base_prompt,
             files=files,
+            exclude=exclude,
             context_cmd=context_cmd,
             rag=rag,
             agent=agent,

--- a/gptme/prompts/workspace.py
+++ b/gptme/prompts/workspace.py
@@ -331,13 +331,22 @@ def prompt_workspace(
     # Apply exclude patterns from project config (glob-matched against file names and paths)
     if project and project.exclude:
         before_count = len(context_files)
+
+        def _is_excluded(f: Path, patterns: list[str]) -> bool:
+            rel = None
+            try:
+                rel = f.relative_to(workspace_resolved)
+            except ValueError:
+                pass
+            for pat in patterns:
+                if fnmatch.fnmatch(f.name, pat):
+                    return True
+                if rel is not None and fnmatch.fnmatch(str(rel), pat):
+                    return True
+            return False
+
         context_files = [
-            f
-            for f in context_files
-            if not any(
-                fnmatch.fnmatch(f.name, pat) or fnmatch.fnmatch(str(f), pat)
-                for pat in project.exclude
-            )
+            f for f in context_files if not _is_excluded(f, project.exclude)
         ]
         excluded_count = before_count - len(context_files)
         if excluded_count:

--- a/gptme/prompts/workspace.py
+++ b/gptme/prompts/workspace.py
@@ -1,3 +1,4 @@
+import fnmatch
 import logging
 import subprocess
 from collections.abc import Generator
@@ -326,6 +327,23 @@ def prompt_workspace(
                         seen_paths.add(rp)
                 else:
                     logger.debug(f"User-configured file not found: {p}")
+
+    # Apply exclude patterns from project config (glob-matched against file names and paths)
+    if project and project.exclude:
+        before_count = len(context_files)
+        context_files = [
+            f
+            for f in context_files
+            if not any(
+                fnmatch.fnmatch(f.name, pat) or fnmatch.fnmatch(str(f), pat)
+                for pat in project.exclude
+            )
+        ]
+        excluded_count = before_count - len(context_files)
+        if excluded_count:
+            logger.debug(
+                f"Excluded {excluded_count} file(s) via project config exclude patterns"
+            )
 
     # Get tree output if enabled
     if tree_output := get_tree_output(workspace):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -235,6 +235,34 @@ def test_get_config():
     assert config
 
 
+def test_project_config_exclude_field():
+    """Test that [prompt] exclude list is parsed correctly from gptme.toml."""
+    import tomlkit
+
+    toml_str = """
+[prompt]
+files = ["README.md", "*.lock"]
+exclude = ["*.lock", "*.jsonl"]
+"""
+    config_data = dict(tomlkit.loads(toml_str))
+    project_config = ProjectConfig.from_dict(config_data)
+    assert project_config.files == ["README.md", "*.lock"]
+    assert project_config.exclude == ["*.lock", "*.jsonl"]
+
+
+def test_project_config_exclude_field_default():
+    """Test that [prompt] exclude defaults to an empty list."""
+    import tomlkit
+
+    toml_str = """
+[prompt]
+files = ["README.md"]
+"""
+    config_data = dict(tomlkit.loads(toml_str))
+    project_config = ProjectConfig.from_dict(config_data)
+    assert project_config.exclude == []
+
+
 def test_env_vars_loaded_in_correct_priority(monkeypatch, tmp_path):
     temp_user_config = str(tmp_path / "config.toml")
     temp_project_config = str(tmp_path / "gptme.toml")

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -149,6 +149,46 @@ files = ["../outside/secret.txt", "README.md"]
     assert "../outside/secret.txt" not in content, "Path traversal should be blocked"
 
 
+def test_prompt_workspace_exclude_patterns(tmp_path):
+    """Test that [prompt] exclude patterns filter context files."""
+    from gptme.prompts import prompt_workspace
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    # Files that should be included
+    (workspace / "README.md").write_text("# Project")
+    (workspace / "pyproject.toml").write_text("[project]\nname = 'test'")
+
+    # Files that should be excluded by pattern
+    (workspace / "uv.lock").write_text("lock file content")
+    (workspace / "session.jsonl").write_text('{"role": "user"}')
+
+    (workspace / "gptme.toml").write_text(
+        """
+[prompt]
+files = ["README.md", "pyproject.toml", "*.lock", "*.jsonl"]
+exclude = ["*.lock", "*.jsonl"]
+"""
+    )
+
+    msgs = list(prompt_workspace(workspace, include_user_context=False))
+    attached_files: list[str] = []
+    for msg in msgs:
+        attached_files.extend(str(f) for f in msg.files)
+
+    assert any("README.md" in f for f in attached_files), "README.md should be included"
+    assert any("pyproject.toml" in f for f in attached_files), (
+        "pyproject.toml should be included"
+    )
+    assert not any("uv.lock" in f for f in attached_files), (
+        "*.lock files should be excluded"
+    )
+    assert not any("session.jsonl" in f for f in attached_files), (
+        "*.jsonl files should be excluded"
+    )
+
+
 def test_workspace_git_status_in_git_repo(tmp_path):
     """Test that git status is included in workspace prompt for git repos."""
     import subprocess

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -189,6 +189,44 @@ exclude = ["*.lock", "*.jsonl"]
     )
 
 
+def test_prompt_workspace_exclude_dir_patterns(tmp_path):
+    """Test that [prompt] exclude patterns work for directory-relative paths."""
+    from gptme.prompts import prompt_workspace
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    # Files at root level
+    (workspace / "README.md").write_text("# Project")
+
+    # Files in subdirectory that should be excluded
+    dist = workspace / "dist"
+    dist.mkdir()
+    (dist / "bundle.js").write_text("// bundled")
+    (dist / "bundle.css").write_text("/* styles */")
+
+    (workspace / "gptme.toml").write_text(
+        """
+[prompt]
+files = ["README.md", "dist/*.js", "dist/*.css"]
+exclude = ["dist/*.js"]
+"""
+    )
+
+    msgs = list(prompt_workspace(workspace, include_user_context=False))
+    attached_files: list[str] = []
+    for msg in msgs:
+        attached_files.extend(str(f) for f in msg.files)
+
+    assert any("README.md" in f for f in attached_files), "README.md should be included"
+    assert any("bundle.css" in f for f in attached_files), (
+        "dist/*.css should be included"
+    )
+    assert not any("bundle.js" in f for f in attached_files), (
+        "dist/*.js should be excluded"
+    )
+
+
 def test_workspace_git_status_in_git_repo(tmp_path):
     """Test that git status is included in workspace prompt for git repos."""
     import subprocess


### PR DESCRIPTION
## Summary

- Adds an `exclude` list to the `[prompt]` section of `gptme.toml` that filters out matched files from automatic context inclusion
- Patterns are glob-matched against both the filename and full path using `fnmatch`
- Agent instruction files (AGENTS.md, CLAUDE.md etc.) are intentionally unaffected — only context files are filtered

## Usage

```toml
[prompt]
files = ["README.md", "*.lock", "*.jsonl"]
exclude = ["*.lock", "*.jsonl"]
```

This lets users include broad globs but exclude large/noisy files (lockfiles, generated JSONL, binary outputs) without having to enumerate every include precisely.

## Test plan

- [x] `test_project_config_exclude_field` — verifies `ProjectConfig.from_dict` parses `exclude` from `[prompt]` section
- [x] `test_project_config_exclude_field_default` — verifies `exclude` defaults to `[]` when not set
- [x] `test_prompt_workspace_exclude_patterns` — end-to-end: workspace with `*.lock`/`*.jsonl` files, verified they are absent from context messages after exclusion
- [x] All existing `test_prompts.py` and `test_config.py` tests still pass (80 tests)