### PR TITLE
feat(webui): highlight matched search terms in conversation list titles

### DIFF
--- a/webui/src/components/ConversationList.tsx
+++ b/webui/src/components/ConversationList.tsx
@@ -244,6 +244,21 @@ export const ConversationList: FC<Props> = ({
   const matchesFilter = (conv: ConversationSummary) =>
     !normalizedFilter || getConversationName(conv).toLowerCase().includes(normalizedFilter);
 
+  function highlightText(text: string, query: string) {
+    if (!query) return text;
+    const idx = text.toLowerCase().indexOf(query.toLowerCase());
+    if (idx === -1) return text;
+    return (
+      <>
+        {text.slice(0, idx)}
+        <mark className="rounded-sm bg-yellow-200 px-0 text-yellow-900 dark:bg-yellow-700 dark:text-yellow-100">
+          {text.slice(idx, idx + query.length)}
+        </mark>
+        {text.slice(idx + query.length)}
+      </>
+    );
+  }
+
   const ConversationItem: FC<{ conv: ConversationSummary; showLabel?: boolean }> = ({
     conv,
     showLabel,
@@ -336,7 +351,10 @@ export const ConversationList: FC<Props> = ({
                           'linear-gradient(to right, black 0%, black calc(100% - 2rem), transparent 100%)',
                       }}
                     >
-                      {convState?.data?.name || conv.name || stripDate(conv.id)}
+                      {highlightText(
+                        convState?.data?.name || conv.name || stripDate(conv.id),
+                        normalizedFilter
+                      )}
                     </div>
                     <Computed>
                       {() => {

--- a/webui/src/components/ConversationList.tsx
+++ b/webui/src/components/ConversationList.tsx
@@ -246,7 +246,7 @@ export const ConversationList: FC<Props> = ({
 
   function highlightText(text: string, query: string) {
     if (!query) return text;
-    const idx = text.toLowerCase().indexOf(query.toLowerCase());
+    const idx = text.toLowerCase().indexOf(query);
     if (idx === -1) return text;
     return (
       <>

--- a/webui/src/components/__tests__/ConversationList.test.tsx
+++ b/webui/src/components/__tests__/ConversationList.test.tsx
@@ -155,7 +155,10 @@ describe('ConversationList', () => {
       target: { value: 'alpha' },
     });
 
-    expect(screen.getByText('Alpha Project')).toBeInTheDocument();
+    // getByText can't find text split across <mark> nodes; use testid + textContent instead
+    const titles = screen.getAllByTestId('conversation-title');
+    expect(titles).toHaveLength(1);
+    expect(titles[0]).toHaveTextContent('Alpha Project');
     expect(screen.queryByText('Beta Notes')).not.toBeInTheDocument();
   });
 


### PR DESCRIPTION
## Summary

- When a conversation search filter is active (⌥+F / Alt+F), matched characters in conversation titles are visually highlighted
- Uses a yellow background `<mark>` element (`bg-yellow-200` / `dark:bg-yellow-700`) consistent with standard search-highlight conventions
- Case-insensitive matching, consistent with the existing filter predicate in `normalizedFilter`
- Frontend-only change (~20 LoC), no API or server changes

## Test plan

- [ ] Type a search query in the conversation list filter (⌥+F / Alt+F to open)
- [ ] Matched substring in conversation titles shows a yellow highlight
- [ ] Highlight disappears when the query is cleared
- [ ] Dark mode: highlight uses `dark:bg-yellow-700` with `dark:text-yellow-100` for readability
- [ ] Conversations not matching the query remain hidden (existing filter behavior unchanged)
- [ ] TypeScript: `npx tsc --noEmit` passes

Follows up on #2827 (feat: add conversation list search/filter).