### PR TITLE
feat(server): expose message_count and last_updated in conversation list

### DIFF
--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -863,6 +863,13 @@ def api_conversations():
     Get a list of user conversations with metadata using the V2 API.
     Supports optional search filtering by conversation name, id, or last message preview.
     Pass ``detail=true`` to include cost/token stats (slower full scan).
+
+    Each item exposes ``id``, ``name``, ``created``, ``modified``,
+    ``message_count`` (alias of ``messages``), ``last_updated`` (alias of
+    ``modified``), and a ``last_message_preview`` for the most recent
+    user/assistant turn. ``message_count`` and ``last_updated`` are always
+    populated (cheap fast-tail scan), so list-level UIs can render a stats
+    badge without per-row detail fetches.
     """
     try:
         limit = int(request.args.get("limit", 100))
@@ -892,8 +899,12 @@ def api_conversations():
     response_items = []
     for conv in conversations:
         item = asdict(conv)
-        if not detail:
-            item.pop("messages", None)
+        # `messages` is the message count (int), not message content — both
+        # the fast tail-scan and full scan populate it, so it is safe to keep
+        # in the response regardless of `detail`.
+        # Add stable webui-facing aliases: `message_count` and `last_updated`.
+        item["message_count"] = conv.messages
+        item["last_updated"] = conv.modified
         response_items.append(item)
     return flask.jsonify(response_items)
 

--- a/gptme/server/openapi_docs.py
+++ b/gptme/server/openapi_docs.py
@@ -48,10 +48,15 @@ class ConversationListItem(BaseModel):
     workspace: str = Field(..., description="Workspace path")
     agent_name: str | None = Field(None, description="Agent name")
     agent_path: str | None = Field(None, description="Agent config path")
+    agent_avatar: str | None = Field(None, description="Agent avatar filename")
+    agent_urls: dict[str, str] | None = Field(
+        None, description="Agent URLs (e.g. web, api)"
+    )
     model: str | None = Field(None, description="Model name")
     total_cost: float = Field(0.0, description="Total cost")
     total_input_tokens: int = Field(0, description="Total input tokens")
     total_output_tokens: int = Field(0, description="Total output tokens")
+    total_cache_read_tokens: int = Field(0, description="Total cache read tokens")
     last_message_role: str | None = Field(
         None, description="Last message role (user/assistant/system)"
     )

--- a/gptme/server/openapi_docs.py
+++ b/gptme/server/openapi_docs.py
@@ -30,10 +30,34 @@ logger = logging.getLogger(__name__)
 class ConversationListItem(BaseModel):
     """A conversation list item."""
 
+    id: str = Field(..., description="Conversation ID")
     name: str = Field(..., description="Conversation name")
     path: str = Field(..., description="Conversation path")
-    created: str = Field(..., description="Creation timestamp")
-    modified: str = Field(..., description="Last modified timestamp")
+    created: float = Field(..., description="Creation timestamp (Unix epoch)")
+    modified: float = Field(..., description="Last-modified timestamp (Unix epoch)")
+    last_updated: float = Field(
+        ...,
+        description="Alias for `modified` — last-updated timestamp (Unix epoch). Stable, webui-facing alias.",
+    )
+    messages: int = Field(..., description="Message count (legacy alias)")
+    message_count: int = Field(
+        ...,
+        description="Message count — stable, webui-facing alias for `messages`.",
+    )
+    branches: int = Field(..., description="Branch count")
+    workspace: str = Field(..., description="Workspace path")
+    agent_name: str | None = Field(None, description="Agent name")
+    agent_path: str | None = Field(None, description="Agent config path")
+    model: str | None = Field(None, description="Model name")
+    total_cost: float = Field(0.0, description="Total cost")
+    total_input_tokens: int = Field(0, description="Total input tokens")
+    total_output_tokens: int = Field(0, description="Total output tokens")
+    last_message_role: str | None = Field(
+        None, description="Last message role (user/assistant/system)"
+    )
+    last_message_preview: str | None = Field(
+        None, description="Preview of the last message"
+    )
 
 
 class Message(BaseModel):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -208,23 +208,32 @@ def test_api_conversation_list_detail_flag(client: FlaskClient, tmp_path, monkey
         "fixture must be > _TAIL_BYTES to trigger fast path"
     )
 
-    # Default (detail=false) should return zeroed stats and omit the message count
+    # Default (detail=false) should return zeroed cost/token stats but keep
+    # the message count and `last_updated` (both come from the cheap tail scan).
     response = client.get("/api/v2/conversations")
     assert response.status_code == 200
     data = response.get_json()
     assert isinstance(data, list)
     assert len(data) == 1
-    assert "messages" not in data[0]
+    # `messages` and `message_count` are stable aliases for the count and are
+    # always populated by the tail scan, regardless of `detail`.
+    assert data[0]["messages"] == len(messages)
+    assert data[0]["message_count"] == len(messages)
+    # `last_updated` is the stable alias for `modified`.
+    assert data[0]["last_updated"] == data[0]["modified"]
+    # Cost/token stats are zeroed in fast mode.
     assert data[0]["total_cost"] == 0.0
     assert data[0]["total_input_tokens"] == 0
+    assert data[0]["total_output_tokens"] == 0
 
-    # detail=true should return actual stats and include the message count
+    # detail=true should return actual cost/token stats alongside the count.
     response = client.get("/api/v2/conversations?detail=true")
     assert response.status_code == 200
     data = response.get_json()
     assert isinstance(data, list)
     assert len(data) == 1
     assert data[0]["messages"] == len(messages)
+    assert data[0]["message_count"] == len(messages)
     assert data[0]["total_cost"] > 0
     assert data[0]["total_input_tokens"] > 0
     assert data[0]["total_output_tokens"] > 0

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -1267,7 +1267,7 @@ def test_v2_conversations_list_exposes_message_count_and_last_updated(
         assert "message_count" in item
         assert "last_updated" in item
         assert isinstance(item["message_count"], int)
-        assert isinstance(item["last_updated"], (int, float))
+        assert isinstance(item["last_updated"], int | float)
         # Stable aliases mirror the legacy fields.
         assert item["message_count"] == item["messages"]
         assert item["last_updated"] == item["modified"]

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -1248,6 +1248,68 @@ def test_v2_conversations_list(client: FlaskClient):
     assert isinstance(data, list)
 
 
+def test_v2_conversations_list_exposes_message_count_and_last_updated(
+    client: FlaskClient,
+):
+    """Fast-mode (default) list response must include ``message_count`` and
+    ``last_updated`` aliases for the webui stats badge. Both come from the
+    cheap tail-only scan and are stable aliases for the legacy ``messages``
+    and ``modified`` fields.
+    """
+    response = client.get("/api/v2/conversations")
+    assert response.status_code == 200
+    data = response.get_json()
+    assert isinstance(data, list)
+    # No conversations in this isolated test client: shape still validated.
+    # With conversations: each item carries the new aliases and the legacy
+    # fields stay in sync.
+    for item in data:
+        assert "message_count" in item
+        assert "last_updated" in item
+        assert isinstance(item["message_count"], int)
+        assert isinstance(item["last_updated"], (int, float))
+        # Stable aliases mirror the legacy fields.
+        assert item["message_count"] == item["messages"]
+        assert item["last_updated"] == item["modified"]
+
+
+def test_v2_conversations_list_keeps_messages_in_fast_mode(
+    client: FlaskClient, tmp_path, monkeypatch
+):
+    """Regression: ``messages`` (the count) must remain in the fast-mode
+    response. A previous bug stripped it via ``item.pop("messages", None)``,
+    which broke webui stats that read either ``messages`` or the new
+    ``message_count`` alias.
+    """
+    # Create a real conversation with a non-test prefix so it isn't filtered
+    # out by ``_is_test_conversation_id`` (``test-`` and ``tmp`` prefixes are
+    # skipped by the user-facing list endpoint).
+    convname = f"msglist-{random.randint(0, 1000000)}"
+    response = client.put(
+        f"/api/v2/conversations/{convname}",
+        json={"prompt": "You are an AI assistant for testing."},
+    )
+    assert response.status_code == 200
+
+    response = client.get("/api/v2/conversations")
+    assert response.status_code == 200
+    data = response.get_json()
+    matching = [c for c in data if c["id"] == convname]
+    assert matching, f"created conversation {convname} not in list"
+    item = matching[0]
+    assert "messages" in item, "fast-mode response must keep `messages` (count)"
+    assert "message_count" in item, (
+        "fast-mode response must include `message_count` alias"
+    )
+    assert "last_updated" in item, (
+        "fast-mode response must include `last_updated` alias"
+    )
+    assert "modified" in item, "fast-mode response must keep `modified`"
+    assert item["messages"] == item["message_count"]
+    assert item["modified"] == item["last_updated"]
+    assert item["message_count"] >= 1  # at least the system prompt
+
+
 def test_v2_conversation_get(v2_conv, client: FlaskClient):
     """Test getting a V2 conversation."""
     conversation_id = v2_conv["conversation_id"]

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -1256,14 +1256,22 @@ def test_v2_conversations_list_exposes_message_count_and_last_updated(
     cheap tail-only scan and are stable aliases for the legacy ``messages``
     and ``modified`` fields.
     """
+    # Create a conversation with a non-test prefix so it isn't filtered out
+    # by the user-facing list endpoint (which skips ``test-`` and ``tmp`` prefixes).
+    convname = f"msglist-shape-{random.randint(0, 1000000)}"
+    put_response = client.put(
+        f"/api/v2/conversations/{convname}",
+        json={"prompt": "You are an AI assistant for testing."},
+    )
+    assert put_response.status_code == 200
+
     response = client.get("/api/v2/conversations")
     assert response.status_code == 200
     data = response.get_json()
     assert isinstance(data, list)
-    # No conversations in this isolated test client: shape still validated.
-    # With conversations: each item carries the new aliases and the legacy
-    # fields stay in sync.
-    for item in data:
+    matching = [c for c in data if c["id"] == convname]
+    assert matching, f"created conversation {convname} not in list"
+    for item in matching:
         assert "message_count" in item
         assert "last_updated" in item
         assert isinstance(item["message_count"], int)


### PR DESCRIPTION
## Summary

Conversation list endpoint already populates message count and mtime via the cheap tail-only scan, but the response handler stripped the count with `item.pop("messages", None)` and exposed no stable alias for the timestamp. The webui needed both fields to render a list-level stats badge (PR #2774 wired per-conversation stats; the list path was missing).

## Changes

- **api_v2.py** — `api_conversations`: stop stripping `messages` (it's the count, not content); add `message_count` and `last_updated` as stable webui-facing aliases; expand the docstring to document the new fields.
- **openapi_docs.py** — `ConversationListItem`: document every field actually returned by the endpoint (`id`, full timestamps, `branches`, `workspace`, agent + model + cost/token + `last_message_*` fields), with the new aliases noted. Was previously a 4-field stub.
- **test_server_v2.py** — two new tests:
  - `test_v2_conversations_list_exposes_message_count_and_last_updated`: shape contract for the new fields.
  - `test_v2_conversations_list_keeps_messages_in_fast_mode`: regression for the pop() bug, with a non-`test-` conversation prefix to dodge the user-list filter.
- **test_server.py** — `test_api_conversation_list_detail_flag`: updated to reflect the correct shape (count + last_updated in both modes; cost/token zeroed only in fast mode). The previous `assert "messages" not in data[0]` was locking in the bug.

## Verification

- `pytest tests/test_chats_json.py tests/test_conversations.py tests/test_server.py tests/test_server_v2.py` — 252 passed, 4 skipped
- `ruff format` + `ruff check` — clean
- `mypy gptme/server/api_v2.py gptme/server/openapi_docs.py` — no issues
- `prek` (pre-commit) — passed

## Unblocks

- `gptme-webui-conversation-stats-in-list` — list-level stats badge can now use either `message_count` (new) or `messages` (existing) without per-row detail fetches.

Refs: `gptme-server-conversation-list-message-count` (Bob-local task)