### PR TITLE
feat(webui): persist conversation search query in URL ?search= param

### DIFF
--- a/webui/src/components/ConversationList.tsx
+++ b/webui/src/components/ConversationList.tsx
@@ -40,6 +40,7 @@ import { DeleteConversationConfirmationDialog } from './DeleteConversationConfir
 
 import type { MessageRole, ConversationSummary } from '@/types/conversation';
 import { type FC, useRef, useEffect, useState, useCallback } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { Computed, use$ } from '@legendapp/state/react';
 import { type Observable } from '@legendapp/state';
 import { conversations$ } from '@/stores/conversations';
@@ -83,10 +84,18 @@ export const ConversationList: FC<Props> = ({
   const [deleteTarget, setDeleteTarget] = useState<{ id: string; name: string } | null>(null);
   const [renamingId, setRenamingId] = useState<string | null>(null);
   const [renameValue, setRenameValue] = useState('');
-  const [filterQuery, setFilterQuery] = useState('');
   // Guard against double-submit: onKeyDown(Enter) sets this before onBlur fires
   const renameCommittedRef = useRef(false);
   const filterInputRef = useRef<HTMLInputElement>(null);
+
+  // URL-synced search state: local state for immediate input responsiveness,
+  // with debounced writes to ?search= URL param.
+  const [searchParams, setSearchParams] = useSearchParams();
+  const urlSearch = searchParams.get('search') ?? '';
+  const [filterQuery, setFilterQuery] = useState(urlSearch);
+  const filterDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Track our own URL writes to avoid echo-syncing back to local state.
+  const prevUrlSearchRef = useRef(urlSearch);
 
   const handleExportMarkdown = useCallback((conv: ConversationSummary) => {
     const storeConv = conversations$.get(conv.id)?.get();
@@ -153,6 +162,41 @@ export const ConversationList: FC<Props> = ({
       setRenamingId(null);
     },
     [api, renameValue]
+  );
+
+  // Sync URL → local state on browser back/forward (skip our own debounced writes).
+  useEffect(() => {
+    if (prevUrlSearchRef.current !== urlSearch) {
+      prevUrlSearchRef.current = urlSearch;
+      setFilterQuery(urlSearch);
+    }
+  }, [urlSearch]);
+
+  // Flush debounce timer on unmount.
+  useEffect(() => {
+    return () => {
+      if (filterDebounceRef.current) clearTimeout(filterDebounceRef.current);
+    };
+  }, []);
+
+  const handleFilterChange = useCallback(
+    (value: string) => {
+      setFilterQuery(value);
+      if (filterDebounceRef.current) clearTimeout(filterDebounceRef.current);
+      filterDebounceRef.current = setTimeout(() => {
+        prevUrlSearchRef.current = value;
+        setSearchParams(
+          (prev) => {
+            const next = new URLSearchParams(prev);
+            if (value) next.set('search', value);
+            else next.delete('search');
+            return next;
+          },
+          { replace: true }
+        );
+      }, 300);
+    },
+    [setSearchParams]
   );
 
   // Refs for infinite scrolling
@@ -579,7 +623,7 @@ export const ConversationList: FC<Props> = ({
             <Input
               ref={filterInputRef}
               value={filterQuery}
-              onChange={(e) => setFilterQuery(e.target.value)}
+              onChange={(e) => handleFilterChange(e.target.value)}
               placeholder="Search conversations"
               aria-label="Search conversations"
               className="h-8 pl-8 pr-8 text-sm"
@@ -592,7 +636,7 @@ export const ConversationList: FC<Props> = ({
                 aria-label="Clear conversation search"
                 className="absolute right-1 top-1/2 h-6 w-6 -translate-y-1/2"
                 onClick={() => {
-                  setFilterQuery('');
+                  handleFilterChange('');
                   filterInputRef.current?.focus();
                 }}
               >

--- a/webui/src/components/ConversationList.tsx
+++ b/webui/src/components/ConversationList.tsx
@@ -165,8 +165,10 @@ export const ConversationList: FC<Props> = ({
   );
 
   // Sync URL → local state on browser back/forward (skip our own debounced writes).
+  // Cancel any pending debounced write so a navigation event can't overwrite the new URL.
   useEffect(() => {
     if (prevUrlSearchRef.current !== urlSearch) {
+      if (filterDebounceRef.current) clearTimeout(filterDebounceRef.current);
       prevUrlSearchRef.current = urlSearch;
       setFilterQuery(urlSearch);
     }

--- a/webui/src/components/__tests__/ConversationList.test.tsx
+++ b/webui/src/components/__tests__/ConversationList.test.tsx
@@ -4,6 +4,7 @@ import '@testing-library/jest-dom';
 import { observable } from '@legendapp/state';
 import type { ConversationSummary } from '@/types/conversation';
 import { TooltipProvider } from '@/components/ui/tooltip';
+import { MemoryRouter } from 'react-router-dom';
 
 // Mock the ApiContext
 const mockDeleteConversation = jest.fn().mockResolvedValue(undefined);
@@ -76,8 +77,13 @@ const createConversation = (overrides: Partial<ConversationSummary> = {}): Conve
 });
 
 // Helper to render with required providers
-const renderWithProviders = (ui: React.ReactElement) => {
-  return render(<TooltipProvider>{ui}</TooltipProvider>);
+const renderWithProviders = (ui: React.ReactElement, { initialSearch = '' } = {}) => {
+  const initialEntries = initialSearch ? [`/?search=${encodeURIComponent(initialSearch)}`] : ['/'];
+  return render(
+    <MemoryRouter initialEntries={initialEntries}>
+      <TooltipProvider>{ui}</TooltipProvider>
+    </MemoryRouter>
+  );
 };
 
 describe('ConversationList', () => {
@@ -229,6 +235,44 @@ describe('ConversationList', () => {
       <ConversationList {...defaultProps} conversations={[conv]} showServerLabels={true} />
     );
     expect(screen.getByText('server-1')).toBeInTheDocument();
+  });
+
+  describe('URL search state persistence', () => {
+    it('populates filter from ?search= URL param on mount', () => {
+      const convs = [
+        createConversation({ id: 'conv-1', name: 'Alpha Project' }),
+        createConversation({ id: 'conv-2', name: 'Beta Notes' }),
+      ];
+      renderWithProviders(<ConversationList {...defaultProps} conversations={convs} />, {
+        initialSearch: 'alpha',
+      });
+
+      expect(screen.getByLabelText('Search conversations')).toHaveValue('alpha');
+      expect(screen.getByText('Alpha Project')).toBeInTheDocument();
+      expect(screen.queryByText('Beta Notes')).not.toBeInTheDocument();
+    });
+
+    it('clears URL search when clear button is clicked', async () => {
+      jest.useFakeTimers();
+      const convs = [
+        createConversation({ id: 'conv-1', name: 'Alpha Project' }),
+        createConversation({ id: 'conv-2', name: 'Beta Notes' }),
+      ];
+      renderWithProviders(<ConversationList {...defaultProps} conversations={convs} />, {
+        initialSearch: 'alpha',
+      });
+
+      // Verify initial filter active
+      expect(screen.queryByText('Beta Notes')).not.toBeInTheDocument();
+
+      fireEvent.click(screen.getByLabelText('Clear conversation search'));
+
+      // Local state clears immediately
+      expect(screen.getByLabelText('Search conversations')).toHaveValue('');
+      expect(screen.getByText('Beta Notes')).toBeInTheDocument();
+
+      jest.useRealTimers();
+    });
   });
 
   // Note: Radix UI ContextMenu requires pointer events that JSDOM doesn't fully support.

--- a/webui/src/components/__tests__/ConversationList.test.tsx
+++ b/webui/src/components/__tests__/ConversationList.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import { ConversationList } from '../ConversationList';
 import '@testing-library/jest-dom';
 import { observable } from '@legendapp/state';
@@ -268,6 +268,11 @@ describe('ConversationList', () => {
       fireEvent.click(screen.getByLabelText('Clear conversation search'));
 
       // Local state clears immediately
+      expect(screen.getByLabelText('Search conversations')).toHaveValue('');
+      expect(screen.getByText('Beta Notes')).toBeInTheDocument();
+
+      // Flush the 300ms debounce — verifies the URL param write fires and doesn't corrupt state
+      act(() => jest.runAllTimers());
       expect(screen.getByLabelText('Search conversations')).toHaveValue('');
       expect(screen.getByText('Beta Notes')).toBeInTheDocument();
 


### PR DESCRIPTION
Follow-on to #2827 (conversation list search/filter). The search input cleared on page reload. This PR persists the filter in the URL so navigation and reload preserve the user's filter state.

## Changes

- **`ConversationList.tsx`**: Replace `useState('')` filter with `useSearchParams`-backed pattern
  - Local `useState` for immediate input responsiveness (no typing lag)
  - Debounced `setSearchParams(..., { replace: true })` at 300ms — avoids history spam on fast typing
  - Ref-based echo guard prevents URL→state→URL feedback cycle on our own writes
  - `useEffect` syncs URL → local state on browser back/forward navigation
- **`ConversationList.test.tsx`**: Wrap `renderWithProviders` in `MemoryRouter`; add `initialSearch` option; 2 new URL persistence tests

## Behavior

```
# Before: filter clears on reload
User types "gptme" → filters list → reloads → filter gone

# After: filter persists in URL
User types "gptme" → URL becomes ?search=gptme → reloads → filter restored
Browser back → URL loses ?search= → filter clears automatically
```

## Test plan

- [x] TypeScript typecheck clean
- [x] All 452 webui tests pass (23/23 ConversationList tests, 2 new URL tests)
- [ ] Manual: type in filter, reload page — filter should be restored
- [ ] Manual: type in filter, clear with X button — URL param should be removed
- [ ] Manual: type in filter, use browser back — filter should clear