### PR TITLE
fix(webui): update ConversationList test to handle highlighted search terms

### DIFF
--- a/webui/src/components/__tests__/ConversationList.test.tsx
+++ b/webui/src/components/__tests__/ConversationList.test.tsx
@@ -251,7 +251,9 @@ describe('ConversationList', () => {
       });
 
       expect(screen.getByLabelText('Search conversations')).toHaveValue('alpha');
-      expect(screen.getByText('Alpha Project')).toBeInTheDocument();
+      // getByText fails when highlightText splits 'Alpha' into a <mark> element;
+      // toHaveTextContent checks the full textContent including child nodes.
+      expect(screen.getByTestId('conversation-title')).toHaveTextContent('Alpha Project');
       expect(screen.queryByText('Beta Notes')).not.toBeInTheDocument();
     });
 


### PR DESCRIPTION
## Problem

Master CI is failing on the WebUI job: `ConversationList.test.tsx` test
**"URL search state persistence › populates filter from ?search= URL param on mount"**
errors with:

```
TestingLibraryElementError: Unable to find an element with the text: Alpha Project
```

## Root Cause

Two recent features landed in sequence:
- #2832 added `highlightText()` which wraps matched search terms in `<mark>` elements
- #2834 added URL search persistence tests that used `getByText('Alpha Project')`

When the search query is `alpha`, the title renders as `<mark>Alpha</mark> Project` — two separate DOM nodes. `getByText('Alpha Project')` requires the exact string to exist in a single element, so it fails.

## Fix

Replace `getByText('Alpha Project')` with `getByTestId('conversation-title')` + `toHaveTextContent('Alpha Project')`. `toHaveTextContent` checks the combined `textContent` of the element including all child nodes, so it works correctly with the `<mark>` wrapping.

## Test

All 29 ConversationList tests pass locally with this fix.