### PR TITLE
feat(webui): add starred/pinned conversations with localStorage persistence

### DIFF
--- a/webui/src/components/ConversationList.tsx
+++ b/webui/src/components/ConversationList.tsx
@@ -294,13 +294,9 @@ export const ConversationList: FC<Props> = ({
     return () => window.removeEventListener('keydown', handleSlashShortcut);
   }, []);
 
-  if (!conversations) {
-    return null;
-  }
-  // Separate demo conversations from real ones
+  // Separate demo conversations from real ones (computed before early return to satisfy Rules of Hooks)
   const demoIds = new Set(demoConversations.map((d) => d.id));
-  const allRealConversations = conversations.filter((c) => !demoIds.has(c.id));
-  const demos = conversations.filter((c) => demoIds.has(c.id));
+  const allRealConversations = conversations ? conversations.filter((c) => !demoIds.has(c.id)) : [];
 
   // Apply filter, then sort starred to top
   const realConversations = useMemo(() => {
@@ -309,6 +305,11 @@ export const ConversationList: FC<Props> = ({
       : allRealConversations;
     return [...filtered].sort((a, b) => (isStarred(b.id) ? 1 : 0) - (isStarred(a.id) ? 1 : 0));
   }, [allRealConversations, showStarredOnly, isStarred]);
+
+  if (!conversations) {
+    return null;
+  }
+  const demos = conversations.filter((c) => demoIds.has(c.id));
 
   // strip leading YYYY-MM-DD from name if present
   function stripDate(name: string) {

--- a/webui/src/components/ConversationList.tsx
+++ b/webui/src/components/ConversationList.tsx
@@ -438,7 +438,7 @@ export const ConversationList: FC<Props> = ({
                   <div className="mb-1 flex items-center gap-2">
                     {!isDemo && (
                       <button
-                        className={`shrink-0 rounded p-0.5 transition-colors hover:text-yellow-500 focus:outline-none ${
+                        className={`shrink-0 rounded p-0.5 transition-colors hover:text-yellow-500 focus:outline-none focus-visible:text-yellow-500 focus-visible:opacity-100 ${
                           isStarred(conv.id)
                             ? 'text-yellow-500 opacity-100'
                             : 'text-muted-foreground opacity-0 group-hover:opacity-100'
@@ -448,6 +448,9 @@ export const ConversationList: FC<Props> = ({
                           toggleStar(conv.id);
                         }}
                         title={isStarred(conv.id) ? 'Unstar conversation' : 'Star conversation'}
+                        aria-label={
+                          isStarred(conv.id) ? 'Unstar conversation' : 'Star conversation'
+                        }
                       >
                         <Star
                           className="h-3 w-3"

--- a/webui/src/components/ConversationList.tsx
+++ b/webui/src/components/ConversationList.tsx
@@ -41,7 +41,7 @@ import { DeleteConversationConfirmationDialog } from './DeleteConversationConfir
 import { useStarredConversations } from '@/hooks/useStarredConversations';
 
 import type { MessageRole, ConversationSummary } from '@/types/conversation';
-import { type FC, useRef, useEffect, useState, useCallback } from 'react';
+import { type FC, useRef, useEffect, useState, useCallback, useMemo } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { Computed, use$ } from '@legendapp/state/react';
 import { type Observable } from '@legendapp/state';
@@ -297,21 +297,18 @@ export const ConversationList: FC<Props> = ({
   if (!conversations) {
     return null;
   }
-
   // Separate demo conversations from real ones
   const demoIds = new Set(demoConversations.map((d) => d.id));
   const allRealConversations = conversations.filter((c) => !demoIds.has(c.id));
   const demos = conversations.filter((c) => demoIds.has(c.id));
 
   // Apply filter, then sort starred to top
-  const filteredConversations = showStarredOnly
-    ? allRealConversations.filter((c) => isStarred(c.id))
-    : allRealConversations;
-  const realConversations = [...filteredConversations].sort((a, b) => {
-    const aStarred = isStarred(a.id) ? 1 : 0;
-    const bStarred = isStarred(b.id) ? 1 : 0;
-    return bStarred - aStarred; // starred first
-  });
+  const realConversations = useMemo(() => {
+    const filtered = showStarredOnly
+      ? allRealConversations.filter((c) => isStarred(c.id))
+      : allRealConversations;
+    return [...filtered].sort((a, b) => (isStarred(b.id) ? 1 : 0) - (isStarred(a.id) ? 1 : 0));
+  }, [allRealConversations, showStarredOnly, isStarred]);
 
   // strip leading YYYY-MM-DD from name if present
   function stripDate(name: string) {
@@ -441,7 +438,7 @@ export const ConversationList: FC<Props> = ({
                         className={`shrink-0 rounded p-0.5 transition-colors hover:text-yellow-500 focus:outline-none focus-visible:text-yellow-500 focus-visible:opacity-100 ${
                           isStarred(conv.id)
                             ? 'text-yellow-500 opacity-100'
-                            : 'text-muted-foreground opacity-0 group-hover:opacity-100'
+                            : 'text-muted-foreground opacity-0 focus-visible:opacity-100 group-hover:opacity-100'
                         }`}
                         onClick={(e) => {
                           e.stopPropagation();
@@ -840,13 +837,14 @@ export const ConversationList: FC<Props> = ({
       {!isLoading && !isError && allRealConversations.length > 0 && (
         <div className="flex px-2 pb-1">
           <button
+            aria-label={showStarredOnly ? 'Show all conversations' : 'Show starred only'}
+            aria-pressed={showStarredOnly}
             className={`flex items-center gap-1 rounded px-2 py-0.5 text-xs transition-colors ${
               showStarredOnly
                 ? 'bg-yellow-500/20 text-yellow-600 dark:text-yellow-400'
                 : 'text-muted-foreground hover:text-foreground'
             }`}
             onClick={() => setShowStarredOnly((v) => !v)}
-            title={showStarredOnly ? 'Show all conversations' : 'Show starred only'}
           >
             <Star className="h-3 w-3" fill={showStarredOnly ? 'currentColor' : 'none'} />
             {showStarredOnly ? 'Starred' : 'All'}

--- a/webui/src/components/ConversationList.tsx
+++ b/webui/src/components/ConversationList.tsx
@@ -13,6 +13,7 @@ import {
   BookOpen,
   Columns2,
   X,
+  Star,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -37,6 +38,7 @@ import {
   getExportableMessages,
 } from '@/utils/exportConversation';
 import { DeleteConversationConfirmationDialog } from './DeleteConversationConfirmationDialog';
+import { useStarredConversations } from '@/hooks/useStarredConversations';
 
 import type { MessageRole, ConversationSummary } from '@/types/conversation';
 import { type FC, useRef, useEffect, useState, useCallback } from 'react';
@@ -79,6 +81,9 @@ export const ConversationList: FC<Props> = ({
 }) => {
   const { api, isConnected$ } = useApi();
   const isConnected = use$(isConnected$);
+
+  const { isStarred, toggleStar } = useStarredConversations();
+  const [showStarredOnly, setShowStarredOnly] = useState(false);
 
   // Context menu state
   const [deleteTarget, setDeleteTarget] = useState<{ id: string; name: string } | null>(null);
@@ -295,8 +300,18 @@ export const ConversationList: FC<Props> = ({
 
   // Separate demo conversations from real ones
   const demoIds = new Set(demoConversations.map((d) => d.id));
-  const realConversations = conversations.filter((c) => !demoIds.has(c.id));
+  const allRealConversations = conversations.filter((c) => !demoIds.has(c.id));
   const demos = conversations.filter((c) => demoIds.has(c.id));
+
+  // Apply filter, then sort starred to top
+  const filteredConversations = showStarredOnly
+    ? allRealConversations.filter((c) => isStarred(c.id))
+    : allRealConversations;
+  const realConversations = [...filteredConversations].sort((a, b) => {
+    const aStarred = isStarred(a.id) ? 1 : 0;
+    const bStarred = isStarred(b.id) ? 1 : 0;
+    return bStarred - aStarred; // starred first
+  });
 
   // strip leading YYYY-MM-DD from name if present
   function stripDate(name: string) {
@@ -387,7 +402,7 @@ export const ConversationList: FC<Props> = ({
               role="button"
               tabIndex={0}
               aria-pressed={isSelected}
-              className={`cursor-pointer rounded-lg py-2 pl-2 transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring ${
+              className={`group cursor-pointer rounded-lg py-2 pl-2 transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring ${
                 isSelected ? 'bg-accent' : ''
               }`}
               onClick={() => onSelect(conv.id, conv.serverId)}
@@ -421,6 +436,25 @@ export const ConversationList: FC<Props> = ({
                   />
                 ) : (
                   <div className="mb-1 flex items-center gap-2">
+                    {!isDemo && (
+                      <button
+                        className={`shrink-0 rounded p-0.5 transition-colors hover:text-yellow-500 focus:outline-none ${
+                          isStarred(conv.id)
+                            ? 'text-yellow-500 opacity-100'
+                            : 'text-muted-foreground opacity-0 group-hover:opacity-100'
+                        }`}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          toggleStar(conv.id);
+                        }}
+                        title={isStarred(conv.id) ? 'Unstar conversation' : 'Star conversation'}
+                      >
+                        <Star
+                          className="h-3 w-3"
+                          fill={isStarred(conv.id) ? 'currentColor' : 'none'}
+                        />
+                      </button>
+                    )}
                     <div
                       data-testid="conversation-title"
                       className="font-small min-w-0 flex-1 whitespace-nowrap"
@@ -662,6 +696,16 @@ export const ConversationList: FC<Props> = ({
           <ContextMenuItem
             onClick={(e) => {
               e.stopPropagation();
+              toggleStar(conv.id);
+            }}
+          >
+            <Star className="mr-2 h-4 w-4" fill={isStarred(conv.id) ? 'currentColor' : 'none'} />
+            {isStarred(conv.id) ? 'Unstar' : 'Star'}
+          </ContextMenuItem>
+          <ContextMenuSeparator />
+          <ContextMenuItem
+            onClick={(e) => {
+              e.stopPropagation();
               handleStartRename(conv);
             }}
           >
@@ -786,6 +830,24 @@ export const ConversationList: FC<Props> = ({
       {!isLoading && !isError && hasNoFilteredMatches && (
         <div className="px-2 py-4 text-sm text-muted-foreground">
           No conversations match your search.
+        </div>
+      )}
+
+      {/* Star filter toggle */}
+      {!isLoading && !isError && allRealConversations.length > 0 && (
+        <div className="flex px-2 pb-1">
+          <button
+            className={`flex items-center gap-1 rounded px-2 py-0.5 text-xs transition-colors ${
+              showStarredOnly
+                ? 'bg-yellow-500/20 text-yellow-600 dark:text-yellow-400'
+                : 'text-muted-foreground hover:text-foreground'
+            }`}
+            onClick={() => setShowStarredOnly((v) => !v)}
+            title={showStarredOnly ? 'Show all conversations' : 'Show starred only'}
+          >
+            <Star className="h-3 w-3" fill={showStarredOnly ? 'currentColor' : 'none'} />
+            {showStarredOnly ? 'Starred' : 'All'}
+          </button>
         </div>
       )}
 

--- a/webui/src/hooks/useStarredConversations.ts
+++ b/webui/src/hooks/useStarredConversations.ts
@@ -32,6 +32,11 @@ export function useStarredConversations() {
     return () => window.removeEventListener('storage', handler);
   }, []);
 
+  // Sync to localStorage whenever starred changes
+  useEffect(() => {
+    saveStarred(starred);
+  }, [starred]);
+
   const toggleStar = useCallback((id: string) => {
     setStarred((prev) => {
       const next = new Set(prev);
@@ -40,7 +45,6 @@ export function useStarredConversations() {
       } else {
         next.add(id);
       }
-      saveStarred(next);
       return next;
     });
   }, []);

--- a/webui/src/hooks/useStarredConversations.ts
+++ b/webui/src/hooks/useStarredConversations.ts
@@ -1,0 +1,51 @@
+import { useState, useCallback, useEffect } from 'react';
+
+const STORAGE_KEY = 'gptme:starred-conversations';
+
+function loadStarred(): Set<string> {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return new Set();
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) return new Set<string>(parsed);
+  } catch {
+    // ignore parse errors
+  }
+  return new Set();
+}
+
+function saveStarred(ids: Set<string>) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify([...ids]));
+}
+
+export function useStarredConversations() {
+  const [starred, setStarred] = useState<Set<string>>(() => loadStarred());
+
+  // Sync across tabs
+  useEffect(() => {
+    const handler = (e: StorageEvent) => {
+      if (e.key === STORAGE_KEY) {
+        setStarred(loadStarred());
+      }
+    };
+    window.addEventListener('storage', handler);
+    return () => window.removeEventListener('storage', handler);
+  }, []);
+
+  const toggleStar = useCallback((id: string) => {
+    setStarred((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      saveStarred(next);
+      return next;
+    });
+  }, []);
+
+  const isStarred = useCallback((id: string) => starred.has(id), [starred]);
+
+  return { starred, isStarred, toggleStar };
+}

--- a/webui/src/hooks/useStarredConversations.ts
+++ b/webui/src/hooks/useStarredConversations.ts
@@ -45,11 +45,6 @@ export function useStarredConversations() {
     return () => window.removeEventListener('storage', handler);
   }, []);
 
-  // Sync to localStorage whenever starred changes
-  useEffect(() => {
-    saveStarred(starred);
-  }, [starred]);
-
   const toggleStar = useCallback((id: string) => {
     setStarred((prev) => {
       const next = new Set(prev);

--- a/webui/src/hooks/useStarredConversations.ts
+++ b/webui/src/hooks/useStarredConversations.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 
 const STORAGE_KEY = 'gptme:starred-conversations';
 
@@ -20,11 +20,24 @@ function saveStarred(ids: Set<string>) {
 
 export function useStarredConversations() {
   const [starred, setStarred] = useState<Set<string>>(() => loadStarred());
+  const skipNextSave = useRef(false);
+
+  // Persist to localStorage, but skip when the change originated from another tab
+  // to avoid a cross-tab echo loop (tab B updates state → saves → triggers storage
+  // event in tab A → tab A updates state → saves → …).
+  useEffect(() => {
+    if (skipNextSave.current) {
+      skipNextSave.current = false;
+      return;
+    }
+    saveStarred(starred);
+  }, [starred]);
 
   // Sync across tabs
   useEffect(() => {
     const handler = (e: StorageEvent) => {
       if (e.key === STORAGE_KEY) {
+        skipNextSave.current = true;
         setStarred(loadStarred());
       }
     };


### PR DESCRIPTION
## Summary

Adds the ability to star/pin conversations in the WebUI, with localStorage persistence and cross-tab sync.

- New `useStarredConversations` hook (localStorage-backed, syncs across tabs via the `storage` event)
- Star button appears on hover for unstarred conversations, always visible for starred ones
- Star/Unstar option added to the right-click context menu
- Starred conversations sort to the top of the list
- Filter toggle (All / Starred) in the conversation list header

## Implementation notes

- Pure client-side feature — no server changes. Starred state lives in `localStorage` keyed per-origin.
- Merged cleanly with the recently-landed accessibility attributes (`role="button"`, `aria-pressed`) and the `group` hover class on conversation rows.

## Verification

- `npx tsc -p tsconfig.app.json --noEmit` — clean
- `npx eslint` on changed files — clean
- `npx prettier --check` — clean
- `npx jest ConversationList.test.tsx` — **28/29 pass**

The single failing test (`filters conversations by search query` → `getByText('Alpha Project')`) is **pre-existing on master**, not introduced here. It is the known search-highlight text-node split issue (matched terms wrapped in `<mark>` spans by the merged #2832 highlight feature) that open PR #2835 fixes. CI on this branch will go green once #2835 lands and this branch is rebased.

🤖 Authored by Bob