### PR TITLE
feat(webui): add / keyboard shortcut to focus conversation search

### DIFF
--- a/webui/src/components/ConversationList.tsx
+++ b/webui/src/components/ConversationList.tsx
@@ -266,6 +266,29 @@ export const ConversationList: FC<Props> = ({
     return () => window.removeEventListener('keydown', handleFilterShortcut);
   }, []);
 
+  useEffect(() => {
+    const handleSlashShortcut = (e: KeyboardEvent) => {
+      if (e.key !== '/' || e.altKey || e.metaKey || e.ctrlKey || e.shiftKey) return;
+      if (!filterInputRef.current) return;
+      // Don't steal '/' from other focused inputs/textareas/contenteditable
+      const active = document.activeElement;
+      if (
+        active instanceof HTMLInputElement ||
+        active instanceof HTMLTextAreaElement ||
+        active instanceof HTMLSelectElement ||
+        (active instanceof HTMLElement && active.isContentEditable)
+      ) {
+        return;
+      }
+      e.preventDefault();
+      filterInputRef.current.focus();
+      filterInputRef.current.select();
+    };
+
+    window.addEventListener('keydown', handleSlashShortcut);
+    return () => window.removeEventListener('keydown', handleSlashShortcut);
+  }, []);
+
   if (!conversations) {
     return null;
   }

--- a/webui/src/components/__tests__/ConversationList.test.tsx
+++ b/webui/src/components/__tests__/ConversationList.test.tsx
@@ -212,19 +212,23 @@ describe('ConversationList', () => {
     expect(searchInput).toHaveFocus();
   });
 
-  it('does not focus search when / is pressed while an input is focused', () => {
+  it('does not focus search when / is pressed while a different input is focused', () => {
     renderWithProviders(<ConversationList {...defaultProps} />);
     const searchInput = screen.getByLabelText('Search conversations');
 
-    // Focus the search input itself (simulates already-focused input)
-    searchInput.focus();
-    const wasFocused = document.activeElement === searchInput;
+    // Simulate a message input (not the search box) being focused
+    const messageInput = document.createElement('input');
+    document.body.appendChild(messageInput);
+    messageInput.focus();
+    expect(document.activeElement).toBe(messageInput);
 
     fireEvent.keyDown(window, { key: '/' });
 
-    // Input is still focused (not blurred/refocused), and was already focused before
-    expect(wasFocused).toBe(true);
-    expect(searchInput).toHaveFocus();
+    // Guard must fire: search should not steal focus
+    expect(searchInput).not.toHaveFocus();
+    expect(messageInput).toHaveFocus();
+
+    document.body.removeChild(messageInput);
   });
 
   it('shows end-of-list message when no more pages', () => {

--- a/webui/src/components/__tests__/ConversationList.test.tsx
+++ b/webui/src/components/__tests__/ConversationList.test.tsx
@@ -203,6 +203,30 @@ describe('ConversationList', () => {
     expect(searchInput).toHaveFocus();
   });
 
+  it('focuses the conversation search with /', () => {
+    renderWithProviders(<ConversationList {...defaultProps} />);
+    const searchInput = screen.getByLabelText('Search conversations');
+
+    fireEvent.keyDown(window, { key: '/' });
+
+    expect(searchInput).toHaveFocus();
+  });
+
+  it('does not focus search when / is pressed while an input is focused', () => {
+    renderWithProviders(<ConversationList {...defaultProps} />);
+    const searchInput = screen.getByLabelText('Search conversations');
+
+    // Focus the search input itself (simulates already-focused input)
+    searchInput.focus();
+    const wasFocused = document.activeElement === searchInput;
+
+    fireEvent.keyDown(window, { key: '/' });
+
+    // Input is still focused (not blurred/refocused), and was already focused before
+    expect(wasFocused).toBe(true);
+    expect(searchInput).toHaveFocus();
+  });
+
   it('shows end-of-list message when no more pages', () => {
     renderWithProviders(<ConversationList {...defaultProps} hasNextPage={false} />);
     expect(screen.getByText("You've reached the end of your conversations.")).toBeInTheDocument();


### PR DESCRIPTION
## Summary

- Pressing `/` anywhere in the sidebar (outside any input) focuses the conversation search box — matching the GitHub/Discord/Slack convention
- The shortcut is suppressed when `document.activeElement` is an `<input>`, `<textarea>`, `<select>`, or `contenteditable` element, so typing `/` in the message input is unaffected
- Two new tests: one verifying the shortcut fires, one verifying it is suppressed when an input is already focused

Depends on #2827 (conversation list search/filter) which has already merged.

## Test plan

- [ ] Open the webui with conversations loaded
- [ ] Press `/` with no input focused — search box should receive focus and be selected
- [ ] Type some characters in the message input, then press `/` — it should type into the message input normally (not jump to search)
- [ ] Press `/` while the search box is already focused — it should not re-select or flicker
- [ ] `npm test -- --testPathPattern=ConversationList` passes (31 tests)