### PR TITLE
test(webui): add Playwright e2e keyboard navigation tests

### DIFF
--- a/webui/e2e/keyboard.spec.ts
+++ b/webui/e2e/keyboard.spec.ts
@@ -27,7 +27,7 @@ test.describe('Keyboard Navigation', () => {
 
     await page.keyboard.press('?');
     await expect(dialog).toBeVisible({ timeout: 3000 });
-    await expect(dialog.getByText(/command palette/i)).toBeVisible();
+    await expect(dialog.getByText('Open command palette')).toBeVisible();
 
     await page.keyboard.press('Escape');
     await expect(dialog).not.toBeVisible({ timeout: 3000 });
@@ -39,10 +39,6 @@ test.describe('Keyboard Navigation', () => {
       .locator('[role="button"][tabindex="0"]')
       .first();
     await expect(firstRow).toBeVisible({ timeout: 5000 });
-
-    // The row must be in the tab order
-    expect(await firstRow.getAttribute('tabindex')).toBe('0');
-    expect(await firstRow.getAttribute('role')).toBe('button');
 
     // Focus and activate via keyboard
     await firstRow.focus();
@@ -67,7 +63,7 @@ test.describe('Keyboard Navigation', () => {
       const outsideFocus = await page.evaluate(() => {
         const active = document.activeElement;
         const dlg = document.querySelector('[role="dialog"]');
-        return dlg ? !dlg.contains(active) : false;
+        return dlg ? !dlg.contains(active) : true;
       });
       expect(outsideFocus).toBe(false);
     }

--- a/webui/e2e/keyboard.spec.ts
+++ b/webui/e2e/keyboard.spec.ts
@@ -1,0 +1,78 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Keyboard Navigation', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+    await expect(page.getByTestId('conversation-list')).toBeVisible({ timeout: 10000 });
+  });
+
+  test('command palette: Ctrl+K opens, Esc closes', async ({ page }) => {
+    const input = page.getByPlaceholder('Type a command or search conversations...');
+    await expect(input).not.toBeVisible();
+
+    await page.keyboard.press('Control+k');
+    await expect(input).toBeVisible({ timeout: 3000 });
+
+    await page.keyboard.press('Escape');
+    await expect(input).not.toBeVisible({ timeout: 3000 });
+  });
+
+  test('shortcuts dialog: ? opens, Esc closes', async ({ page }) => {
+    // Click body to ensure focus is not in an input before pressing ?
+    await page.locator('body').click();
+
+    const dialog = page.getByRole('dialog', { name: /keyboard shortcuts/i });
+    await expect(dialog).not.toBeVisible();
+
+    await page.keyboard.press('?');
+    await expect(dialog).toBeVisible({ timeout: 3000 });
+    await expect(dialog.getByText(/command palette/i)).toBeVisible();
+
+    await page.keyboard.press('Escape');
+    await expect(dialog).not.toBeVisible({ timeout: 3000 });
+  });
+
+  test('conversation rows: Tab-focusable and Enter selects', async ({ page }) => {
+    const firstRow = page
+      .getByTestId('conversation-list')
+      .locator('[role="button"][tabindex="0"]')
+      .first();
+    await expect(firstRow).toBeVisible({ timeout: 5000 });
+
+    // The row must be in the tab order
+    expect(await firstRow.getAttribute('tabindex')).toBe('0');
+    expect(await firstRow.getAttribute('role')).toBe('button');
+
+    // Focus and activate via keyboard
+    await firstRow.focus();
+    await expect(firstRow).toBeFocused();
+    await page.keyboard.press('Enter');
+
+    // After selection, aria-pressed flips to true
+    await expect(firstRow).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  test('focus trap: Tab stays inside an open dialog', async ({ page }) => {
+    // Open the shortcuts dialog (Radix UI Dialog traps focus)
+    await page.locator('body').click();
+    await page.keyboard.press('?');
+
+    const dialog = page.getByRole('dialog', { name: /keyboard shortcuts/i });
+    await expect(dialog).toBeVisible({ timeout: 3000 });
+
+    // Tab through several cycles; focus must always stay inside the dialog
+    for (let i = 0; i < 6; i++) {
+      await page.keyboard.press('Tab');
+      const outsideFocus = await page.evaluate(() => {
+        const active = document.activeElement;
+        const dlg = document.querySelector('[role="dialog"]');
+        return dlg ? !dlg.contains(active) : false;
+      });
+      expect(outsideFocus).toBe(false);
+    }
+
+    await page.keyboard.press('Escape');
+    await expect(dialog).not.toBeVisible({ timeout: 3000 });
+  });
+});

--- a/webui/src/components/CommandPalette.tsx
+++ b/webui/src/components/CommandPalette.tsx
@@ -62,7 +62,9 @@ export function CommandPalette() {
     });
   }, []);
 
-  // Toggle command palette with Cmd+K or Ctrl+K
+  // Toggle command palette with Cmd+K or Ctrl+K; close on Escape.
+  // The Escape handler is explicit because cmdk v1 intercepts the key at the
+  // element level before Radix UI Dialog's DismissableLayer sees it.
   useEffect(() => {
     const down = (e: KeyboardEvent) => {
       if (e.key === 'k' && (e.metaKey || e.ctrlKey)) {
@@ -72,12 +74,14 @@ export function CommandPalette() {
           commandPaletteOpen$.set(next);
           return next;
         });
+      } else if (e.key === 'Escape') {
+        setOpen(false);
       }
     };
 
     document.addEventListener('keydown', down);
     return () => document.removeEventListener('keydown', down);
-  }, []);
+  }, [setOpen]);
 
   // Alt+N — new conversation (skip when typing in an input)
   useEffect(() => {


### PR DESCRIPTION
## Summary

- Adds `webui/e2e/keyboard.spec.ts` with four keyboard navigation e2e tests:
  - **Ctrl+K** opens the command palette; **Esc** closes it
  - **?** opens the shortcuts dialog (with input-focus guard); **Esc** closes it
  - Conversation rows are Tab-focusable (`role=button`, `tabindex=0`) and Enter triggers selection (`aria-pressed` flips to `true`)
  - **Focus trap**: Tab cannot escape an open Radix UI Dialog (6 Tab presses, all stay inside)

Complements the existing unit tests added in #2829 (keyboard-accessible conversation rows) and the existing e2e split-view shortcut test in `conversation.spec.ts`.

## Test plan
- [ ] CI WebUI check passes (jest unit tests + Playwright e2e)
- [ ] All four new tests pass against the dev server