### PR TITLE
feat(webui): show conversation stats in list using list-response data

### DIFF
--- a/webui/src/components/ConversationList.tsx
+++ b/webui/src/components/ConversationList.tsx
@@ -474,21 +474,54 @@ export const ConversationList: FC<Props> = ({
                   </Tooltip>
 
                   {/* Token estimate from list summary (available when detail=True) */}
-                  {(() => {
-                    const summaryTokens =
-                      (conv.total_input_tokens ?? 0) +
-                      (conv.total_output_tokens ?? 0) +
-                      (conv.total_cache_read_tokens ?? 0) +
-                      (conv.total_cache_creation_tokens ?? 0);
-                    if (summaryTokens === 0) return null;
-                    return (
-                      <span className="flex items-center text-muted-foreground">
-                        <span className="text-[10px] text-muted-foreground/60">
-                          {formatTokens(summaryTokens)} tok
-                        </span>
-                      </span>
-                    );
-                  })()}
+                  <Computed>
+                    {() => {
+                      const storeConv = conversations$.get(conv.id)?.get();
+                      const isLoaded = storeConv?.data?.log?.length > 0;
+                      // Hide when cost badge shows (it already includes token count)
+                      if (isLoaded) return null;
+                      const summaryTokens =
+                        (conv.total_input_tokens ?? 0) +
+                        (conv.total_output_tokens ?? 0) +
+                        (conv.total_cache_read_tokens ?? 0) +
+                        (conv.total_cache_creation_tokens ?? 0);
+                      if (summaryTokens === 0) return null;
+                      return (
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <span className="flex items-center text-muted-foreground">
+                              <span className="text-[10px] text-muted-foreground/60">
+                                {formatTokens(summaryTokens)} tok
+                              </span>
+                            </span>
+                          </TooltipTrigger>
+                          <TooltipContent>
+                            <div className="space-y-1 text-xs">
+                              <div className="font-medium">Token estimate</div>
+                              {(conv.total_input_tokens ?? 0) > 0 && (
+                                <div>Input: {formatTokens(conv.total_input_tokens!)} tokens</div>
+                              )}
+                              {(conv.total_output_tokens ?? 0) > 0 && (
+                                <div>Output: {formatTokens(conv.total_output_tokens!)} tokens</div>
+                              )}
+                              {(conv.total_cache_read_tokens ?? 0) > 0 && (
+                                <div>
+                                  Cache read: {formatTokens(conv.total_cache_read_tokens!)} tokens
+                                </div>
+                              )}
+                              {(conv.total_cache_creation_tokens ?? 0) > 0 && (
+                                <div>
+                                  Cache create: {formatTokens(conv.total_cache_creation_tokens!)}{' '}
+                                  tokens
+                                </div>
+                              )}
+                              <div>Total: {formatTokens(summaryTokens)} tokens</div>
+                            </div>
+                          </TooltipContent>
+                        </Tooltip>
+                      );
+                    }}
+                  </Computed>
 
                   {/* Cost badge: show per-conversation total cost from loaded data */}
                   <Computed>

--- a/webui/src/components/ConversationList.tsx
+++ b/webui/src/components/ConversationList.tsx
@@ -473,6 +473,23 @@ export const ConversationList: FC<Props> = ({
                     </TooltipContent>
                   </Tooltip>
 
+                  {/* Token estimate from list summary (available when detail=True) */}
+                  {(() => {
+                    const summaryTokens =
+                      (conv.total_input_tokens ?? 0) +
+                      (conv.total_output_tokens ?? 0) +
+                      (conv.total_cache_read_tokens ?? 0) +
+                      (conv.total_cache_creation_tokens ?? 0);
+                    if (summaryTokens === 0) return null;
+                    return (
+                      <span className="flex items-center text-muted-foreground">
+                        <span className="text-[10px] text-muted-foreground/60">
+                          {formatTokens(summaryTokens)} tok
+                        </span>
+                      </span>
+                    );
+                  })()}
+
                   {/* Cost badge: show per-conversation total cost from loaded data */}
                   <Computed>
                     {() => {

--- a/webui/src/components/ConversationList.tsx
+++ b/webui/src/components/ConversationList.tsx
@@ -478,8 +478,13 @@ export const ConversationList: FC<Props> = ({
                     {() => {
                       const storeConv = conversations$.get(conv.id)?.get();
                       const isLoaded = storeConv?.data?.log?.length > 0;
-                      // Hide when cost badge shows (it already includes token count)
-                      if (isLoaded) return null;
+                      // Hide only when cost badge will show (isLoaded AND has cost data).
+                      // Without the hasData check, loaded convs without per-message usage
+                      // metadata would silently show nothing.
+                      if (isLoaded) {
+                        const cost = computeConversationCost(storeConv!.data!.log);
+                        if (cost.hasData) return null;
+                      }
                       const summaryTokens =
                         (conv.total_input_tokens ?? 0) +
                         (conv.total_output_tokens ?? 0) +

--- a/webui/src/types/conversation.ts
+++ b/webui/src/types/conversation.ts
@@ -41,7 +41,9 @@ export interface ConversationSummary {
   name: string;
   created?: number; // Unix timestamp of first message
   modified: number; // Unix timestamp of last file modification
-  messages?: number; // Message count, present only when list requests opt into detail=true
+  messages?: number; // Message count. Always populated from list endpoint (fast path) since PR #2833.
+  message_count?: number; // Stable alias for `messages`, same value. Added in PR #2833.
+  last_updated?: number; // Stable alias for `modified`. Added in PR #2833.
   branch?: string;
   workspace?: string;
   readonly?: boolean; // For demo conversations


### PR DESCRIPTION
## Problem
The server now exposes `message_count` and token summary fields in the conversation list endpoint (PR #2833), but the WebUI wasn't showing token estimates from the list response — only from locally loaded message data.

## Scope
**In scope:**
- Update `ConversationSummary` type to document `message_count` and `last_updated` fields
- Add compact token estimate badge from list summary data when available
- All data comes from list response — no per-row detail fetches

**Out of scope:**
- Sorting by token count or other stats metrics
- Stats in the search results view

## Verification
- `npm test`: 458 passed, 52 suites
- `typecheck`: clean