### PR TITLE
feat(cli): add --show-prompt-stats for per-section prompt token breakdown

### DIFF
--- a/docs/howto/index.md
+++ b/docs/howto/index.md
@@ -11,6 +11,7 @@ code-review
 debug-python
 automate-task
 refactor
+minimal-context
 ```
 
 ## File Editing
@@ -27,6 +28,9 @@ refactor
 
 ## Refactor Code
 [Refactor across files](refactor.md) — rename, extract, and reshape code across a codebase.
+
+## Minimal Context Mode
+[Use minimal context for token-efficient sessions](minimal-context.md) — trim the system prompt by scoping tools, switching to short mode, and using agent profiles. Includes per-section token measurement with `--show-prompt-stats`.
 
 ---
 

--- a/docs/howto/minimal-context.md
+++ b/docs/howto/minimal-context.md
@@ -1,0 +1,175 @@
+# Minimal context / token-efficient mode
+
+gptme's default system prompt is comprehensive — designed for general-purpose
+use with full tool access, workspace context, and detailed examples. For
+specialized single-task sessions (factory cells, evals, CI runs, batch
+processing), this full prompt is mostly waste — it loads tools and context the
+session never uses, and the per-tool examples inflate the prompt without
+improving output quality for capable models.
+
+This guide covers how to assemble a minimal-context configuration for
+token-efficient, task-focused sessions.
+
+## Quick reference
+
+| Lever | Effect | Typical saving |
+|---|---|---|
+| `--tools shell,read,patch` | Only load needed tools | -70-80% |
+| `--system short` | Drop per-tool examples | -42% |
+| `--non-interactive` (`-n`) | Skip user identity block | negligible base saving (*) |
+| `--context files` | Skip `context_cmd` output | workspace-dependent |
+| `--agent-profile isolated` | Hard-enforced tool subset + read-only guard | tool-scoping variant |
+
+(*) `-n` does not skip workspace context (AGENTS.md, context files). Its base
+prompt saving is small; the real non-interactive win is halting after the task
+completes rather than dropping into an interactive loop.
+
+## Measuring first: `--show-prompt-stats`
+
+Before trimming, instrument. Run gptme with `--show-prompt-stats` to see a
+per-section token breakdown:
+
+```console
+$ gptme -n --show-prompt-stats "count to 3"
+=== System prompt token breakdown ===
+  Section                     Tokens     Pct
+  ------------------------- --------  ------
+  Core (identity + tools)       8048   87.5%
+  Workspace files                163    1.8%
+  Chat history                   986   10.7%
+  ------------------------- --------  ------
+  Total                         9197
+```
+
+The example above (default, 20 tools, full prompt) shows 87.5% of the system
+prompt is core identity + tool descriptions. This is the largest lever — the
+more tools loaded, the larger the core block.
+
+Now with 4 tools and short mode:
+
+```console
+$ gptme -n --show-prompt-stats --system short -t shell,read,patch,save "count to 3"
+=== System prompt token breakdown ===
+  Section                     Tokens     Pct
+  ------------------------- --------  ------
+  Core (identity + tools)       1611   58.3%
+  Workspace files                163    5.9%
+  Chat history                   986   35.7%
+  ------------------------- --------  ------
+  Total                         2760
+```
+
+Total drops from 9197 to 2760 (-70%) by cutting 16 unused tools and switching
+to `--system short`.
+
+## Recommended patterns
+
+### Pattern 1: Isolated code cell (factory-style)
+
+For a task that only needs to read files and produce a patch:
+
+```bash
+gptme -n --system short \
+  --agent-profile isolated \
+  -t shell,read,patch \
+  "fix the bug in src/parser.py"
+```
+
+- `isolated` profile enforces tool scope and adds `read_only` + `no_network`
+- `--system short` drops per-tool examples
+- Only `shell`, `read`, and `patch` tools loaded
+
+### Pattern 2: Minimal eval run
+
+For benchmarks where every token counts:
+
+```bash
+gptme -n --system short \
+  --context files \
+  -t shell,save \
+  "run the benchmark and save results to output.json"
+```
+
+- `--context files` skips `context_cmd` (project-specific dynamic context)
+- Only `shell` and `save` tools loaded
+
+### Pattern 3: Full workspace, minimal cost
+
+When you need workspace context but want minimal prompt overhead:
+
+```bash
+gptme -n --system short \
+  -t shell,read,patch,save,gh \
+  "review PR #123 and post feedback"
+```
+
+- Still includes workspace files (AGENTS.md, README, pyproject.toml)
+- But only loads 5 tools instead of 20
+
+## Existing machinery
+
+gptme has three independent levers already — minimal-context mode is about
+combining them deliberately, not building new ones:
+
+### Tool scoping via `--tools`
+
+The `--tools` flag accepts an allowlist of tool names:
+
+```bash
+gptme -t shell,read,patch,save   # only these 4 tools
+gptme -t none                    # no tools at all (chat-only)
+```
+
+Tool descriptions dominate the system prompt. Loading only the tools a session
+needs is the single highest-impact lever — typically 70-80% reduction from
+the full 20-tool default.
+
+### System mode via `--system`
+
+`--system full` (default) includes per-tool examples. `--system short` drops them
+while keeping full tool *descriptions* — about 42% reduction with zero behavior
+change for capable models.
+
+### Agent profiles via `--agent-profile`
+
+8 built-in profiles in `gptme/profiles.py`:
+
+- `isolated` — read-only + no-network for sandboxed cells
+- `verifier` — similar, for factory verification cells
+- `developer` — full tool access, code-focused persona
+- `explorer` — read-heavy, network-allowed
+- `researcher` — broader tool access + network
+- `browser-use` — browser tools only
+- `computer-use` — desktop automation tools
+- `default` — normal operation
+
+Profiles enforce tool subsets and add behavior guards.
+
+## What's not yet trimable
+
+The base prompt is assembled from four sections: `prompt_gptme` (core identity),
+`prompt_user`, `prompt_tools`, and `prompt_workspace` (AGENTS.md, context files).
+
+Profiles only *append* to the base. Two things can't currently be trimmed:
+
+- **Core `prompt_gptme` block** — no "lean core" variant. The base identity
+  instructions are shared across all profiles.
+- **`prompt_workspace`** — no flag to skip AGENTS.md / workspace context
+  injection. `--context files` controls which components are included but
+  doesn't offer a "none" option.
+
+A `minimal` profile or `--skip-workspace` flag would close these gaps if
+measuring first shows worthwhile savings.
+
+## Claude Code comparison
+
+Claude Code's system prompt is larger in absolute terms but it's a fixed
+harness — it doesn't expose per-session tool/context scoping the way gptme
+can. gptme's advantage is that the levers already exist and are composable;
+the remaining work is making them ergonomic and documented.
+
+## Further reading
+
+- [CLI reference](../cli.rst) — full flag documentation
+- [Agent profiles](../agents.rst) — profile documentation
+- [#862: minimal context mode tracking issue](https://github.com/ErikBjare/bob/issues/862)

--- a/docs/howto/minimal-context.md
+++ b/docs/howto/minimal-context.md
@@ -145,7 +145,7 @@ change for capable models.
 
 Profiles enforce tool subsets and add behavior guards.
 
-## What's not yet trimable
+## What's not yet trimmable
 
 The base prompt is assembled from four sections: `prompt_gptme` (core identity),
 `prompt_user`, `prompt_tools`, and `prompt_workspace` (AGENTS.md, context files).

--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -899,6 +899,13 @@ def main(
         )
         sys.exit(1)
 
+    profile_msg = None
+    if selected_profile and selected_profile.system_prompt:
+        profile_msg = Message(
+            "system",
+            f"# Agent Profile: {selected_profile.name}\n\n{selected_profile.system_prompt}",
+        )
+
     if is_existing_conversation:
         logger.debug("Existing conversation found, skipping initial prompt generation")
         initial_msgs = []
@@ -921,16 +928,9 @@ def main(
             context_include=[item for val in context_include for item in val.split(",")]
             if context_include
             else None,
+            profile_prompt=profile_msg,
             show_prompt_stats=show_prompt_stats,
         )
-
-    # Append profile system prompt if using a profile
-    if selected_profile and selected_profile.system_prompt:
-        profile_msg = Message(
-            "system",
-            f"# Agent Profile: {selected_profile.name}\n\n{selected_profile.system_prompt}",
-        )
-        initial_msgs.append(profile_msg)
 
     # register a handler for Ctrl-C
     set_interruptible()  # prepare, user should be able to Ctrl+C until user prompt ready

--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -465,6 +465,13 @@ Run 'gptme-util --help' for all utility commands."""
     hidden=True,
 )
 @click.option(
+    "--show-prompt-stats",
+    "show_prompt_stats",
+    is_flag=True,
+    default=False,
+    help="Log per-section token counts for the assembled system prompt at startup.",
+)
+@click.option(
     "--architect",
     "architect_enabled",
     is_flag=True,
@@ -523,6 +530,7 @@ def main(
     auto_accept_architect: bool,
     context_include: tuple[str, ...],
     output_schema: str | None,
+    show_prompt_stats: bool = False,
 ):
     """Main entrypoint for the CLI."""
 
@@ -913,6 +921,7 @@ def main(
             context_include=[item for val in context_include for item in val.split(",")]
             if context_include
             else None,
+            show_prompt_stats=show_prompt_stats,
         )
 
     # Append profile system prompt if using a profile

--- a/gptme/prompts/__init__.py
+++ b/gptme/prompts/__init__.py
@@ -15,6 +15,7 @@ from ..llm.models import get_recommended_model
 from ..message import Message
 from ..tools import ToolFormat, ToolSpec, get_available_tools
 from ..util import document_prompt_function
+from ..util.tokens import len_tokens
 
 # Agent instruction files — always loaded (layered: user-level + project-level)
 # These are the standard filenames used across different AI coding tools.
@@ -120,6 +121,7 @@ def get_prompt(
     context_mode: ContextMode | None = None,
     context_include: list[str] | None = None,
     include_user_context: bool = True,
+    show_prompt_stats: bool = False,
 ) -> list[Message]:
     """
     Get the initial system prompt.
@@ -168,6 +170,10 @@ def get_prompt(
             agent instruction files from ~/.config/gptme
 
     Returns a list of messages: [core_system_prompt, workspace_prompt, ...].
+
+    If ``show_prompt_stats`` is True, per-section token counts are logged at
+    INFO level after assembly. Uses the configured model for accurate counting
+    when tiktoken is available, falling back to character-based approximation.
     """
     agent_config = get_project_config(agent_path)
     agent_name = (
@@ -333,13 +339,86 @@ def get_prompt(
     result.extend(dynamic_context_msgs)
 
     # Chat history (also dynamic)
-    result.extend(prompt_chat_history())
+    chat_history_msgs = list(prompt_chat_history())
+    result.extend(chat_history_msgs)
 
     # Set hide=True, pinned=True for all messages
     for i, msg in enumerate(result):
         result[i] = msg.replace(hide=True, pinned=True)
 
+    # Per-section token stats (must happen after hide/pinned so counts
+    # reflect the actual prompt the model sees)
+    if show_prompt_stats:
+        effective_model = model or get_recommended_model("openai")
+        _log_prompt_stats(
+            core_msgs=core_msgs,
+            agent_config_msgs=agent_config_msgs,
+            workspace_msgs=workspace_msgs,
+            dynamic_context_msgs=dynamic_context_msgs,
+            chat_history_msgs=chat_history_msgs,
+            static_dynamic_boundary=bool(dynamic_context_msgs and result),
+            model=effective_model,
+        )
+
     return result
+
+
+def _log_prompt_stats(
+    *,
+    core_msgs: list[Message],
+    agent_config_msgs: list[Message],
+    workspace_msgs: list[Message],
+    dynamic_context_msgs: list[Message],
+    chat_history_msgs: list[Message],
+    static_dynamic_boundary: bool,
+    model: str,
+) -> None:
+    """Log per-section token counts for the assembled system prompt."""
+    sections: list[tuple[str, list[Message]]] = [
+        ("Core (identity + tools)", core_msgs),
+    ]
+    if agent_config_msgs:
+        sections.append(("Agent config", agent_config_msgs))
+    if workspace_msgs:
+        sections.append(("Workspace files", workspace_msgs))
+    if static_dynamic_boundary:
+        # Boundary message itself is a single short Message in result
+        sections.append(
+            (
+                "Static/dynamic boundary",
+                [Message("system", SYSTEM_PROMPT_CACHE_BOUNDARY)],
+            )
+        )
+    if dynamic_context_msgs:
+        sections.append(("Dynamic context (context_cmd)", dynamic_context_msgs))
+    if chat_history_msgs:
+        sections.append(("Chat history", chat_history_msgs))
+
+    # Count per section
+    rows: list[tuple[str, int, float]] = []
+    total = 0
+    for name, msgs in sections:
+        tokens = len_tokens(msgs, model) if msgs else 0
+        total += tokens
+        rows.append((name, tokens, 0.0))
+
+    # Compute percentages
+    if total > 0:
+        rows = [(name, tokens, tokens / total * 100) for name, tokens, _pct in rows]
+
+    # Build table
+    lines = ["", "=== System prompt token breakdown ==="]
+    col_name = max(len(r[0]) for r in rows) + 2
+    lines.append(f"  {'Section':<{col_name}} {'Tokens':>8}  {'Pct':>6}")
+    lines.append(f"  {'-' * col_name} {'-' * 8}  {'-' * 6}")
+    for name, tokens, pct in rows:
+        lines.append(f"  {name:<{col_name}} {tokens:>8}  {pct:>5.1f}%")
+    lines.append(f"  {'-' * col_name} {'-' * 8}  {'-' * 6}")
+    lines.append(f"  {'Total':<{col_name}} {total:>8}")
+    lines.append("=====================================")
+
+    for line in lines:
+        logger.info(line)
 
 
 document_prompt_function(

--- a/gptme/prompts/__init__.py
+++ b/gptme/prompts/__init__.py
@@ -121,6 +121,7 @@ def get_prompt(
     context_mode: ContextMode | None = None,
     context_include: list[str] | None = None,
     include_user_context: bool = True,
+    profile_prompt: Message | None = None,
     show_prompt_stats: bool = False,
 ) -> list[Message]:
     """
@@ -168,6 +169,7 @@ def get_prompt(
         context_include: Components to include in selective mode
         include_user_context: Whether to include user-level prompt files and
             agent instruction files from ~/.config/gptme
+        profile_prompt: Optional profile system prompt appended after chat history
 
     Returns a list of messages: [core_system_prompt, workspace_prompt, ...].
 
@@ -345,6 +347,9 @@ def get_prompt(
     chat_history_msgs = list(prompt_chat_history())
     result.extend(chat_history_msgs)
 
+    if profile_prompt is not None:
+        result.append(profile_prompt)
+
     # Set hide=True, pinned=True for all messages
     for i, msg in enumerate(result):
         result[i] = msg.replace(hide=True, pinned=True)
@@ -358,6 +363,7 @@ def get_prompt(
             workspace_msgs=workspace_msgs,
             dynamic_context_msgs=dynamic_context_msgs,
             chat_history_msgs=chat_history_msgs,
+            profile_prompt=profile_prompt,
             static_dynamic_boundary=boundary_added,
             model=effective_model,
         )
@@ -372,6 +378,7 @@ def _log_prompt_stats(
     workspace_msgs: list[Message],
     dynamic_context_msgs: list[Message],
     chat_history_msgs: list[Message],
+    profile_prompt: Message | None,
     static_dynamic_boundary: bool,
     model: str,
 ) -> None:
@@ -395,6 +402,8 @@ def _log_prompt_stats(
         sections.append(("Dynamic context (context_cmd)", dynamic_context_msgs))
     if chat_history_msgs:
         sections.append(("Chat history", chat_history_msgs))
+    if profile_prompt is not None:
+        sections.append(("Agent profile", [profile_prompt]))
 
     # Count per section
     rows: list[tuple[str, int, float]] = []
@@ -403,6 +412,10 @@ def _log_prompt_stats(
         tokens = len_tokens(msgs, model) if msgs else 0
         total += tokens
         rows.append((name, tokens, 0.0))
+
+    if not rows:
+        logger.info("No prompt sections to report.")
+        return
 
     # Compute percentages
     if total > 0:

--- a/gptme/prompts/__init__.py
+++ b/gptme/prompts/__init__.py
@@ -317,6 +317,7 @@ def get_prompt(
 
     # Combine core messages into one system prompt
     result = []
+    core_prompt: Message | None = None
     if core_msgs:
         core_prompt = _join_messages(core_msgs)
         result.append(core_prompt)
@@ -332,8 +333,10 @@ def get_prompt(
     # Insert an explicit static/dynamic boundary before context_cmd output.
     # This keeps the prompt structure stable and makes the cacheable prefix
     # visible to both humans and providers with block-level prompt caching.
+    boundary_added = False
     if dynamic_context_msgs and result:
         result.append(Message("system", SYSTEM_PROMPT_CACHE_BOUNDARY))
+        boundary_added = True
 
     # Dynamic context last (changes every session, least cacheable)
     result.extend(dynamic_context_msgs)
@@ -346,17 +349,16 @@ def get_prompt(
     for i, msg in enumerate(result):
         result[i] = msg.replace(hide=True, pinned=True)
 
-    # Per-section token stats (must happen after hide/pinned so counts
-    # reflect the actual prompt the model sees)
+    # Per-section token stats run after every prompt section is populated.
     if show_prompt_stats:
         effective_model = model or get_recommended_model("openai")
         _log_prompt_stats(
-            core_msgs=core_msgs,
+            core_prompt=core_prompt,
             agent_config_msgs=agent_config_msgs,
             workspace_msgs=workspace_msgs,
             dynamic_context_msgs=dynamic_context_msgs,
             chat_history_msgs=chat_history_msgs,
-            static_dynamic_boundary=bool(dynamic_context_msgs and result),
+            static_dynamic_boundary=boundary_added,
             model=effective_model,
         )
 
@@ -365,7 +367,7 @@ def get_prompt(
 
 def _log_prompt_stats(
     *,
-    core_msgs: list[Message],
+    core_prompt: Message | None,
     agent_config_msgs: list[Message],
     workspace_msgs: list[Message],
     dynamic_context_msgs: list[Message],
@@ -374,9 +376,9 @@ def _log_prompt_stats(
     model: str,
 ) -> None:
     """Log per-section token counts for the assembled system prompt."""
-    sections: list[tuple[str, list[Message]]] = [
-        ("Core (identity + tools)", core_msgs),
-    ]
+    sections: list[tuple[str, list[Message]]] = []
+    if core_prompt is not None:
+        sections.append(("Core (identity + tools)", [core_prompt]))
     if agent_config_msgs:
         sections.append(("Agent config", agent_config_msgs))
     if workspace_msgs:

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1,11 +1,13 @@
+import logging
 import os
+import re
 from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 
-from gptme.message import len_tokens
-from gptme.prompts import get_prompt
+from gptme.message import Message, len_tokens
+from gptme.prompts import _join_messages, get_prompt
 from gptme.tools import get_tools, init_tools
 
 
@@ -354,6 +356,71 @@ def test_dynamic_context_has_explicit_cache_boundary(tmp_path):
     assert boundary_idx is not None, "Should include cache-boundary marker"
     assert dynamic_idx is not None, "Should include context_cmd output"
     assert file_idx < boundary_idx < dynamic_idx
+
+
+def test_show_prompt_stats_counts_joined_core_prompt(caplog, monkeypatch):
+    """Core prompt stats should include join separators inserted at assembly time."""
+    import gptme.prompts as prompts
+
+    core_msgs = [
+        Message("system", "aaaa"),
+        Message("system", "bbbb"),
+        Message("system", "cccc"),
+    ]
+
+    monkeypatch.setattr(
+        prompts,
+        "prompt_gptme",
+        lambda interactive, model, agent_name, tool_format: core_msgs,
+    )
+    monkeypatch.setattr(prompts, "prompt_chat_history", lambda: [])
+
+    with caplog.at_level(logging.INFO, logger="gptme.prompts"):
+        get_prompt([], prompt="short", show_prompt_stats=True, model="gpt-4")
+
+    joined_tokens = len_tokens(_join_messages(core_msgs), "gpt-4")
+    split_tokens = len_tokens(core_msgs, "gpt-4")
+    assert joined_tokens > split_tokens
+
+    match = re.search(
+        r"Core \(identity \+ tools\)\s+(\d+)\s+",
+        caplog.text,
+    )
+    assert match is not None
+    assert int(match.group(1)) == joined_tokens
+
+
+def test_show_prompt_stats_only_reports_boundary_when_inserted(
+    caplog, monkeypatch, tmp_path
+):
+    """Boundary stats should match the actual assembled prompt."""
+    import gptme.prompts as prompts
+
+    workspace = tmp_path / "agent"
+    workspace.mkdir()
+    (workspace / "gptme.toml").write_text(
+        '[prompt]\ncontext_cmd = "echo DYNAMIC_ONLY"\n'
+    )
+
+    monkeypatch.setattr(
+        prompts,
+        "prompt_gptme",
+        lambda interactive, model, agent_name, tool_format: [],
+    )
+    monkeypatch.setattr(prompts, "prompt_workspace", lambda *args, **kwargs: [])
+    monkeypatch.setattr(prompts, "prompt_chat_history", lambda: [])
+
+    with caplog.at_level(logging.INFO, logger="gptme.prompts"):
+        msgs = get_prompt(
+            [],
+            prompt="short",
+            agent_path=workspace,
+            show_prompt_stats=True,
+            model="gpt-4",
+        )
+
+    assert all("System Prompt Cache Boundary" not in msg.content for msg in msgs)
+    assert "Static/dynamic boundary" not in caplog.text
 
 
 def test_prompt_workspace_sorts_glob_matches_deterministically(tmp_path, monkeypatch):

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -423,6 +423,54 @@ def test_show_prompt_stats_only_reports_boundary_when_inserted(
     assert "Static/dynamic boundary" not in caplog.text
 
 
+def test_show_prompt_stats_handles_empty_prompt_sections(caplog, monkeypatch):
+    """Stats logging should not crash when every prompt section is empty."""
+    import gptme.prompts as prompts
+
+    monkeypatch.setattr(
+        prompts,
+        "prompt_gptme",
+        lambda interactive, model, agent_name, tool_format: [],
+    )
+    monkeypatch.setattr(prompts, "prompt_chat_history", lambda: [])
+
+    with caplog.at_level(logging.INFO, logger="gptme.prompts"):
+        msgs = get_prompt([], prompt="short", show_prompt_stats=True, model="gpt-4")
+
+    assert msgs == []
+    assert "No prompt sections to report." in caplog.text
+
+
+def test_show_prompt_stats_includes_profile_prompt(caplog, monkeypatch):
+    """Profile prompt stats should match the extra system message appended by the CLI."""
+    import gptme.prompts as prompts
+
+    monkeypatch.setattr(
+        prompts,
+        "prompt_gptme",
+        lambda interactive, model, agent_name, tool_format: [],
+    )
+    monkeypatch.setattr(prompts, "prompt_chat_history", lambda: [])
+
+    profile_msg = Message("system", "# Agent Profile: isolated\n\nProfile guidance")
+
+    with caplog.at_level(logging.INFO, logger="gptme.prompts"):
+        msgs = get_prompt(
+            [],
+            prompt="short",
+            profile_prompt=profile_msg,
+            show_prompt_stats=True,
+            model="gpt-4",
+        )
+
+    assert msgs == [profile_msg.replace(hide=True, pinned=True)]
+    assert "Agent profile" in caplog.text
+
+    match = re.search(r"Agent profile\s+(\d+)\s+", caplog.text)
+    assert match is not None
+    assert int(match.group(1)) == len_tokens([profile_msg], "gpt-4")
+
+
 def test_prompt_workspace_sorts_glob_matches_deterministically(tmp_path, monkeypatch):
     """Glob matches should not depend on filesystem traversal order."""
     from gptme.prompts import prompt_workspace


### PR DESCRIPTION
## What

Adds a `--show-prompt-stats` CLI flag that logs a per-section token-count table after the system prompt is assembled.

### Measured example (20 tools, full prompt)
```
=== System prompt token breakdown ===
  Section                     Tokens     Pct
  ------------------------- --------  ------
  Core (identity + tools)       8048   87.5%
  Workspace files                163    1.8%
  Chat history                   986   10.7%
  ------------------------- --------  ------
  Total                         9197
```

### Measured example (4 tools, short prompt)
```
=== System prompt token breakdown ===
  Section                     Tokens     Pct
  ------------------------- --------  ------
  Core (identity + tools)       1611   58.3%
  Workspace files                163    5.9%
  Chat history                   986   35.7%
  ------------------------- --------  ------
  Total                         2760
```

Total drops from 9197 → 2760 (−70%) by cutting unused tools + switching to `--system short`.

## Why

This is the measurement-first step for a "minimal context mode" exploration
(ErikBjare/bob#862). Before trimming the system prompt, we need to know where
the tokens actually go. The existing independent levers (`--tools`, `--system short`,
`--agent-profile`) already deliver 70-90% savings — this flag makes the savings
visible and measurable.

## Changes

- `gptme/prompts/__init__.py`: `show_prompt_stats` param in `get_prompt()`, new
  `_log_prompt_stats()` helper that uses existing `len_tokens()` utility
- `gptme/cli/main.py`: `--show-prompt-stats` flag wired through
- `docs/howto/minimal-context.md`: comprehensive how-to guide covering the
  three existing levers, measured savings, recommended patterns, and the
  not-yet-trimmable gaps

## Also ships

A `docs/howto/minimal-context.md` how-to guide covering:
- The three independent levers: `--tools`, `--system short`, `--agent-profile`
- Three recommended patterns (isolated cell, minimal eval, full-workspace-minimal-cost)
- `--show-prompt-stats` usage
- What's not yet trimmable (core prompt, workspace skip)
- Claude Code comparison

Ref: ErikBjare/bob#862
CC: @ErikBjare