### PR TITLE
feat(cli): add startup prompt stats report

### DIFF
--- a/docs/howto/index.md
+++ b/docs/howto/index.md
@@ -6,12 +6,16 @@ Each guide gives you a copy-pasteable pattern you can adapt immediately.
 ```{toctree}
 :maxdepth: 1
 
+minimal-context
 edit-files
 code-review
 debug-python
 automate-task
 refactor
 ```
+
+## Minimal Context
+[Run gptme with minimal context](minimal-context.md) — measure and trim prompt sections for cheaper, tighter specialized runs.
 
 ## File Editing
 [Edit files surgically](edit-files.md) — patch, save, and inspect without rewriting whole files.

--- a/docs/howto/minimal-context.md
+++ b/docs/howto/minimal-context.md
@@ -1,0 +1,105 @@
+# Run gptme with minimal context
+
+Use this pattern when you want a cheaper, tighter startup prompt for a
+specialized task or an isolated automation run.
+
+## Measure first
+
+Start by checking where the prompt tokens actually go for your current setup:
+
+```bash
+gptme --show-prompt-stats
+```
+
+That prints per-section counts for the startup system prompt, including:
+
+- `prompt_gptme` for the core assistant instructions
+- `prompt_tools` for tool documentation
+- `prompt_user` for user profile text
+- `prompt_workspace` for AGENTS/CLAUDE files and configured prompt files
+- `prompt_context_cmd_*` for dynamic `context_cmd` output
+
+For most code tasks, `prompt_tools` is the biggest section by far. That means
+the highest-leverage trim is usually tool scoping, not rewriting the base prompt.
+
+## Use the three practical levers
+
+### 1. Restrict tools
+
+Only load the tools the task actually needs:
+
+```bash
+gptme --tools shell,read,patch,save "rename the public API and update tests"
+```
+
+If you only need a couple of extras on top of defaults, use additive syntax:
+
+```bash
+gptme --tools +browser "open the docs site and summarize the API changes"
+```
+
+### 2. Use the short system prompt
+
+`--system short` keeps the same broad behavior but drops the longer wording and
+tool examples:
+
+```bash
+gptme --system short --tools shell,read,patch,save "fix the failing test"
+```
+
+### 3. Trim workspace context when it is not helping
+
+Use `--context` to control whether prompt files and `context_cmd` output are
+included:
+
+```bash
+# Keep static prompt files, skip dynamic context_cmd output
+gptme --context files "review this module"
+
+# Keep dynamic context_cmd output, skip prompt files
+gptme --context cmd "summarize the current repo status"
+```
+
+This does **not** yet provide a full `--no-workspace` mode. If you want to skip
+project instructions entirely today, run gptme from a smaller workspace or a
+separate agent path.
+
+## Good defaults for specialized sessions
+
+For a focused coding run:
+
+```bash
+gptme \
+  --system short \
+  --tools shell,read,patch,save \
+  --context files \
+  "update the parser and make the tests pass"
+```
+
+For a constrained automation or factory-style cell:
+
+```bash
+gptme \
+  --agent-profile isolated \
+  --system short \
+  --tools shell,read,patch,save,complete \
+  --non-interactive \
+  "apply the requested refactor and finish when tests pass"
+```
+
+`--agent-profile isolated` is useful when you want stricter behavior and a
+hard tool subset, but remember that profiles currently **add** instructions.
+They do not subtract the base `prompt_gptme` or workspace prompt.
+
+## Iterate with stats
+
+Compare the before/after prompt surface instead of guessing:
+
+```bash
+gptme --show-prompt-stats
+gptme --show-prompt-stats --system short --tools shell,read,patch,save --context files
+```
+
+If `prompt_workspace` or `prompt_context_cmd_project` still dominates, the next
+improvement is likely in your workspace prompt files or `gptme.toml`, not in the
+core assistant prompt.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -177,6 +177,28 @@ See available profiles with:
 
     gptme-util profile list
 
+Minimal context mode
+^^^^^^^^^^^^^^^^^^^^
+
+When you want a tighter startup prompt for a specialized task, combine a short
+system prompt, a narrow tool set, and selective context:
+
+.. code-block:: bash
+
+    gptme --system short --tools shell,read,patch,save --context files "fix the failing test"
+
+Measure the prompt before and after with:
+
+.. code-block:: bash
+
+    gptme --show-prompt-stats
+
+That prints per-section token counts for the startup system prompt so you can
+see whether the cost is coming from tool docs, user profile text, workspace
+prompt files, or dynamic ``context_cmd`` output.
+
+For a deeper recipe, see :doc:`howto/minimal-context`.
+
 Skip confirmation prompts
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -9,6 +9,7 @@ import shlex
 import shutil
 import signal
 import sys
+import tempfile
 import traceback
 from datetime import datetime, timezone
 from itertools import islice
@@ -41,7 +42,13 @@ from ..logmanager import (
 )
 from ..message import Message
 from ..profiles import get_profile
-from ..prompts import ContextMode, get_prompt
+from ..prompts import (
+    ContextMode,
+    PromptSectionStat,
+    format_prompt_stats,
+    get_prompt,
+    get_prompt_stats,
+)
 from ..telemetry import init_telemetry, shutdown_telemetry
 from ..tools import ToolFormat, get_available_tools, init_tools
 from ..util import epoch_to_age
@@ -49,6 +56,7 @@ from ..util.auto_naming import generate_conversation_id
 from ..util.context import md_codeblock
 from ..util.interrupt import handle_keyboard_interrupt, set_interruptible
 from ..util.prompt import add_history
+from ..util.tokens import len_tokens
 
 logger = logging.getLogger(__name__)
 
@@ -420,6 +428,11 @@ Run 'gptme-util --help' for all utility commands."""
     help="Show hidden system messages.",
 )
 @click.option(
+    "--show-prompt-stats",
+    is_flag=True,
+    help="Show startup system-prompt token stats for the current configuration and exit.",
+)
+@click.option(
     "-v",
     "--verbose",
     is_flag=True,
@@ -510,6 +523,7 @@ def main(
     non_interactive: bool,
     output_format: str,
     show_hidden: bool,
+    show_prompt_stats: bool,
     version: bool,
     version_json: bool,
     resume: bool,
@@ -774,6 +788,81 @@ def main(
             )
         return prompt_msgs
 
+    if show_prompt_stats:
+        stats_root = Path(tempfile.mkdtemp(prefix="gptme-prompt-stats-"))
+        try:
+            stats_logdir = stats_root / "log"
+            if workspace == "@log":
+                stats_workspace_path = stats_logdir / "workspace"
+                stats_workspace_path.mkdir(parents=True, exist_ok=True)
+            else:
+                stats_workspace_path = Path(workspace) if workspace else Path.cwd()
+
+            try:
+                config = setup_config_from_cli(
+                    workspace=stats_workspace_path,
+                    logdir=stats_logdir,
+                    model=model,
+                    tool_allowlist=tool_allowlist_str,
+                    tool_format=tool_format,
+                    stream=stream,
+                    interactive=interactive,
+                    agent_path=Path(agent_path) if agent_path else None,
+                )
+            except ValueError as e:
+                raise click.UsageError(str(e)) from e
+            assert config.chat and config.chat.tool_format
+
+            logger.debug(f"Using tools: {config.chat.tools}")
+            try:
+                tools = init_tools(config.chat.tools)
+            except ValueError as e:
+                raise click.UsageError(str(e)) from e
+
+            stats_context_mode: ContextMode | None = (
+                "selective" if context_include else None
+            )
+            stats = get_prompt_stats(
+                tools=tools,
+                prompt=prompt_system,
+                interactive=config.chat.interactive,
+                tool_format=config.chat.tool_format,
+                model=config.chat.model,
+                workspace=stats_workspace_path,
+                agent_path=config.chat.agent,
+                context_mode=stats_context_mode,
+                context_include=[
+                    item for val in context_include for item in val.split(",")
+                ]
+                if context_include
+                else None,
+            )
+            extra_sections: list[PromptSectionStat] = []
+            if selected_profile and selected_profile.system_prompt:
+                profile_msg = Message(
+                    "system",
+                    f"# Agent Profile: {selected_profile.name}\n\n{selected_profile.system_prompt}",
+                )
+                extra_sections.append(
+                    PromptSectionStat(
+                        name="agent_profile",
+                        messages=1,
+                        chars=len(profile_msg.content),
+                        tokens=len_tokens(profile_msg, config.chat.model or "gpt-4"),
+                    )
+                )
+            header = (
+                "System prompt stats"
+                f" (prompt={prompt_system}, tool_format={config.chat.tool_format}, "
+                f"tools={len(tools)}, interactive={config.chat.interactive})"
+            )
+            click.echo(
+                format_prompt_stats(stats, header=header, extra_sections=extra_sections)
+            )
+            return
+        finally:
+            shutil.rmtree(stats_root, ignore_errors=True)
+
     logdir_preexisting = True
 
     if resume:
@@ -823,7 +912,7 @@ def main(
             )
 
     if workspace == "@log":
-        workspace_path: Path | None = logdir / "workspace"
+        workspace_path = logdir / "workspace"
         assert workspace_path  # mypy not smart enough to see its not None
         workspace_path.mkdir(parents=True, exist_ok=True)
     else:
@@ -845,15 +934,6 @@ def main(
         raise click.UsageError(str(e)) from e
     assert config.chat and config.chat.tool_format
 
-    # init telemetry with agent name and interactive mode
-    agent_config = config.chat.agent_config
-    agent_name = agent_config.name if agent_config else None
-    init_telemetry(
-        service_name="gptme-cli",
-        agent_name=agent_name,
-        interactive=interactive,
-    )
-
     # early init tools to generate system prompt
     # We pass the tool_allowlist CLI argument. If it's not provided, init_tools
     # will load it from the environment variable TOOL_ALLOWLIST or the chat config.
@@ -862,6 +942,15 @@ def main(
         tools = init_tools(config.chat.tools)
     except ValueError as e:
         raise click.UsageError(str(e)) from e
+
+    # init telemetry with agent name and interactive mode
+    agent_config = config.chat.agent_config
+    agent_name = agent_config.name if agent_config else None
+    init_telemetry(
+        service_name="gptme-cli",
+        agent_name=agent_name,
+        interactive=interactive,
+    )
 
     # Check if we're opening an existing conversation (via --resume, --name, or pick)
     # If so, skip generating initial messages (including expensive context_cmd)

--- a/gptme/prompts/__init__.py
+++ b/gptme/prompts/__init__.py
@@ -77,7 +77,7 @@ class PromptSectionStat:
 
 @dataclass(frozen=True)
 class PromptStats:
-    sections: list[PromptSectionStat]
+    sections: tuple[PromptSectionStat, ...]
     total_messages: int
     total_chars: int
     total_tokens: int
@@ -360,10 +360,10 @@ def get_prompt_stats(
         include_user_context=include_user_context,
     )
 
-    stats = [
+    stats = tuple(
         _section_stat(name, msgs, model)
         for name, msgs in (*core_sections, *cacheable_sections, *dynamic_sections)
-    ]
+    )
     cacheable_section_count = len(core_sections) + len(cacheable_sections)
     total_messages = sum(stat.messages for stat in stats)
     total_chars = sum(stat.chars for stat in stats)

--- a/gptme/prompts/__init__.py
+++ b/gptme/prompts/__init__.py
@@ -7,6 +7,7 @@ When prompting, it is important to provide clear instructions and avoid any ambi
 
 import logging
 from contextvars import ContextVar
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
 
@@ -15,6 +16,7 @@ from ..llm.models import get_recommended_model
 from ..message import Message
 from ..tools import ToolFormat, ToolSpec, get_available_tools
 from ..util import document_prompt_function
+from ..util.tokens import len_tokens
 
 # Agent instruction files — always loaded (layered: user-level + project-level)
 # These are the standard filenames used across different AI coding tools.
@@ -65,6 +67,24 @@ Static bootstrap content ends above. Session-volatile context starts below.
 ContextMode = Literal["full", "selective"]
 
 
+@dataclass(frozen=True)
+class PromptSectionStat:
+    name: str
+    messages: int
+    chars: int
+    tokens: int
+
+
+@dataclass(frozen=True)
+class PromptStats:
+    sections: list[PromptSectionStat]
+    total_messages: int
+    total_chars: int
+    total_tokens: int
+    cacheable_tokens: int
+    dynamic_tokens: int
+
+
 def _join_messages(msgs: list[Message]) -> Message:
     """Combine several system prompt messages into one."""
     role = msgs[0].role if msgs else "system"
@@ -84,6 +104,323 @@ def _xml_section(tag: str, content: str) -> str:
     Only use xml_escape() on leaf text that should not contain markup.
     """
     return f"<{tag}>\n{content.strip()}\n</{tag}>"
+
+
+def _build_core_prompt_sections(
+    *,
+    prompt: PromptType | str,
+    interactive: bool,
+    model: str | None,
+    agent_name: str | None,
+    tool_format: ToolFormat,
+    tools: list[ToolSpec],
+    workspace: Path | None,
+    include_tools: bool,
+    is_selective: bool,
+) -> list[tuple[str, list[Message]]]:
+    """Build named core prompt sections in display order."""
+    sections: list[tuple[str, list[Message]]] = []
+
+    def add(name: str, msgs: list[Message]) -> None:
+        if msgs:
+            sections.append((name, msgs))
+
+    if is_selective and not include_tools:
+        add(
+            "prompt_gptme",
+            list(prompt_gptme(interactive, model, agent_name, tool_format=tool_format)),
+        )
+        return sections
+
+    if prompt == "full":
+        add(
+            "prompt_gptme",
+            list(prompt_gptme(interactive, model, agent_name, tool_format=tool_format)),
+        )
+        if include_tools:
+            add(
+                "prompt_tools",
+                list(prompt_tools(tools=tools, tool_format=tool_format, model=model)),
+            )
+        if interactive:
+            add("prompt_user", list(prompt_user(tool_format=tool_format)))
+        add("prompt_project", list(prompt_project(tool_format=tool_format)))
+        add(
+            "prompt_systeminfo",
+            list(prompt_systeminfo(workspace, tool_format=tool_format)),
+        )
+        add("prompt_timeinfo", list(prompt_timeinfo(tool_format=tool_format)))
+        if include_tools:
+            add(
+                "prompt_skills_summary",
+                list(prompt_skills_summary(tool_format=tool_format)),
+            )
+        return sections
+
+    if prompt == "short":
+        add(
+            "prompt_gptme",
+            list(
+                prompt_gptme(
+                    interactive,
+                    model,
+                    agent_name=agent_name,
+                    tool_format=tool_format,
+                    compact=True,
+                )
+            ),
+        )
+        if include_tools:
+            add(
+                "prompt_tools",
+                list(
+                    prompt_tools(
+                        examples=False,
+                        tools=tools,
+                        tool_format=tool_format,
+                        model=model,
+                    )
+                ),
+            )
+        if interactive:
+            add("prompt_user", list(prompt_user(tool_format=tool_format)))
+        add("prompt_project", list(prompt_project(tool_format=tool_format)))
+        return sections
+
+    add("custom_prompt", [Message("system", prompt)])
+    if include_tools:
+        add(
+            "prompt_tools",
+            list(prompt_tools(tools=tools, tool_format=tool_format, model=model)),
+        )
+    return sections
+
+
+def _build_prompt_sections(
+    *,
+    tools: list[ToolSpec],
+    tool_format: ToolFormat,
+    prompt: PromptType | str,
+    interactive: bool,
+    model: str | None,
+    workspace: Path | None,
+    agent_path: Path | None,
+    context_mode: ContextMode | None,
+    context_include: list[str] | None,
+    include_user_context: bool,
+) -> tuple[
+    list[tuple[str, list[Message]]],
+    list[tuple[str, list[Message]]],
+    list[tuple[str, list[Message]]],
+]:
+    """Build named prompt sections for core, cacheable workspace, and dynamic parts."""
+    agent_config = get_project_config(agent_path)
+    agent_name = (
+        agent_config.agent.name if agent_config and agent_config.agent else None
+    )
+
+    effective_mode = context_mode or "full"
+    include_set = set(context_include or [])
+    if "all" in include_set:
+        include_set.update(("files", "cmd"))
+    include_set.discard("agent")
+    include_set.discard("agent-config")
+    is_selective = effective_mode == "selective"
+    include_tools = bool(tools)
+    include_workspace = effective_mode == "full" or (
+        is_selective and "files" in include_set
+    )
+    include_agent_config = bool(agent_path)
+    include_context_cmd = effective_mode == "full" or (
+        is_selective and "cmd" in include_set
+    )
+
+    core_sections = _build_core_prompt_sections(
+        prompt=prompt,
+        interactive=interactive,
+        model=model,
+        agent_name=agent_name,
+        tool_format=tool_format,
+        tools=tools,
+        workspace=workspace,
+        include_tools=include_tools,
+        is_selective=is_selective,
+    )
+
+    cacheable_sections: list[tuple[str, list[Message]]] = []
+    if include_agent_config:
+        cacheable_sections.append(
+            (
+                "prompt_agent_workspace",
+                list(
+                    prompt_workspace(
+                        agent_path,
+                        title="Agent Config",
+                        include_path=True,
+                        include_context_cmd=False,
+                        include_user_context=include_user_context,
+                    )
+                ),
+            )
+        )
+    if include_workspace and workspace and workspace != agent_path:
+        cacheable_sections.append(
+            (
+                "prompt_workspace",
+                list(
+                    prompt_workspace(
+                        workspace,
+                        include_context_cmd=False,
+                        include_user_context=include_user_context,
+                    )
+                ),
+            )
+        )
+
+    dynamic_sections: list[tuple[str, list[Message]]] = []
+    if include_context_cmd:
+        for ws, title, section_name in [
+            (
+                agent_path if include_agent_config else None,
+                "Agent",
+                "prompt_context_cmd_agent",
+            ),
+            (
+                workspace if include_workspace and workspace != agent_path else None,
+                "Project",
+                "prompt_context_cmd_project",
+            ),
+        ]:
+            if ws is None:
+                continue
+            ws_project = get_project_config(ws)
+            if (
+                ws_project
+                and ws_project.context_cmd
+                and (
+                    cmd_output := get_project_context_cmd_output(
+                        ws_project.context_cmd, ws
+                    )
+                )
+            ):
+                dynamic_sections.append(
+                    (
+                        section_name,
+                        [
+                            Message(
+                                "system",
+                                f"## {title} computed context\n\n" + cmd_output,
+                            )
+                        ],
+                    )
+                )
+
+    chat_history_msgs = list(prompt_chat_history())
+    if chat_history_msgs:
+        dynamic_sections.append(("prompt_chat_history", chat_history_msgs))
+
+    return core_sections, cacheable_sections, dynamic_sections
+
+
+def _section_stat(
+    name: str, msgs: list[Message], model: str | None
+) -> PromptSectionStat:
+    token_model = model or "gpt-4"
+    return PromptSectionStat(
+        name=name,
+        messages=len(msgs),
+        chars=sum(len(msg.content) for msg in msgs),
+        tokens=len_tokens(msgs, token_model),
+    )
+
+
+def get_prompt_stats(
+    tools: list[ToolSpec],
+    tool_format: ToolFormat = "markdown",
+    prompt: PromptType | str = "full",
+    interactive: bool = True,
+    model: str | None = None,
+    workspace: Path | None = None,
+    agent_path: Path | None = None,
+    context_mode: ContextMode | None = None,
+    context_include: list[str] | None = None,
+    include_user_context: bool = True,
+) -> PromptStats:
+    """Return token statistics for each startup prompt section."""
+    core_sections, cacheable_sections, dynamic_sections = _build_prompt_sections(
+        tools=tools,
+        tool_format=tool_format,
+        prompt=prompt,
+        interactive=interactive,
+        model=model,
+        workspace=workspace,
+        agent_path=agent_path,
+        context_mode=context_mode,
+        context_include=context_include,
+        include_user_context=include_user_context,
+    )
+
+    stats = [
+        _section_stat(name, msgs, model)
+        for name, msgs in (*core_sections, *cacheable_sections, *dynamic_sections)
+    ]
+    total_messages = sum(stat.messages for stat in stats)
+    total_chars = sum(stat.chars for stat in stats)
+    total_tokens = sum(stat.tokens for stat in stats)
+    cacheable_tokens = sum(
+        _section_stat(name, msgs, model).tokens
+        for name, msgs in (*core_sections, *cacheable_sections)
+    )
+    dynamic_tokens = sum(
+        _section_stat(name, msgs, model).tokens for name, msgs in dynamic_sections
+    )
+    return PromptStats(
+        sections=stats,
+        total_messages=total_messages,
+        total_chars=total_chars,
+        total_tokens=total_tokens,
+        cacheable_tokens=cacheable_tokens,
+        dynamic_tokens=dynamic_tokens,
+    )
+
+
+def format_prompt_stats(
+    stats: PromptStats,
+    *,
+    header: str | None = None,
+    extra_sections: list[PromptSectionStat] | None = None,
+) -> str:
+    """Format prompt stats as a compact plain-text table."""
+    sections = list(stats.sections)
+    if extra_sections:
+        sections.extend(extra_sections)
+
+    total_messages = sum(section.messages for section in sections)
+    total_chars = sum(section.chars for section in sections)
+    total_tokens = sum(section.tokens for section in sections)
+    cacheable_tokens = stats.cacheable_tokens + sum(
+        section.tokens for section in (extra_sections or [])
+    )
+
+    name_width = max(
+        len("section"), *(len(section.name) for section in sections), len("total")
+    )
+    lines = []
+    if header:
+        lines.append(header)
+    lines.append(f"{'section':<{name_width}}  {'msgs':>4}  {'chars':>8}  {'tokens':>8}")
+    lines.extend(
+        [
+            f"{section.name:<{name_width}}  {section.messages:>4}  {section.chars:>8}  {section.tokens:>8}"
+            for section in sections
+        ]
+    )
+    lines.append(
+        f"{'total':<{name_width}}  {total_messages:>4}  {total_chars:>8}  {total_tokens:>8}"
+    )
+    lines.append(f"cacheable_tokens: {cacheable_tokens}")
+    lines.append(f"dynamic_tokens:   {total_tokens - cacheable_tokens}")
+    return "\n".join(lines)
 
 
 # Sub-module imports for orchestration
@@ -169,171 +506,37 @@ def get_prompt(
 
     Returns a list of messages: [core_system_prompt, workspace_prompt, ...].
     """
-    agent_config = get_project_config(agent_path)
-    agent_name = (
-        agent_config.agent.name if agent_config and agent_config.agent else None
+    core_sections, cacheable_sections, dynamic_sections = _build_prompt_sections(
+        tools=tools,
+        tool_format=tool_format,
+        prompt=prompt,
+        interactive=interactive,
+        model=model,
+        workspace=workspace,
+        agent_path=agent_path,
+        context_mode=context_mode,
+        context_include=context_include,
+        include_user_context=include_user_context,
     )
 
-    # Default context_mode to "full" if not specified
-    effective_mode = context_mode or "full"
-    include_set = set(context_include or [])
-
-    # Determine what to include based on context_mode
-    # Expand aliases
-    if "all" in include_set:
-        include_set.update(("files", "cmd"))
-    # Legacy: "agent" in context_include is ignored (agent-path is now always loaded)
-    include_set.discard("agent")
-    include_set.discard("agent-config")
-    is_selective = effective_mode == "selective"
-    # Tools are always included when they're loaded — no need to opt-in via --context-include
-    include_tools = bool(tools)
-    include_workspace = effective_mode == "full" or (
-        is_selective and "files" in include_set
-    )
-    # Agent workspace is always loaded when --agent-path is provided
-    include_agent_config = bool(agent_path)
-    include_context_cmd = effective_mode == "full" or (
-        is_selective and "cmd" in include_set
-    )
-
-    # Generate core system messages (without workspace context)
-    core_msgs: list[Message]
-    if is_selective and not include_tools:
-        # Selective mode with no tools loaded: base prompt only
-        core_msgs = list(
-            prompt_gptme(interactive, model, agent_name, tool_format=tool_format)
-        )
-    elif prompt == "full":
-        if include_tools:
-            core_msgs = list(
-                prompt_full(
-                    interactive,
-                    tools,
-                    tool_format,
-                    model,
-                    agent_name=agent_name,
-                    workspace=workspace,
-                )
-            )
-        else:
-            # Full mode without tools
-            # Note: skills summary is intentionally excluded here since skills
-            # require tool access (e.g., `cat <path>`) to load on-demand
-            core_msgs = list(
-                prompt_gptme(interactive, model, agent_name, tool_format=tool_format)
-            )
-            if interactive:
-                core_msgs.extend(prompt_user(tool_format=tool_format))
-            core_msgs.extend(prompt_project(tool_format=tool_format))
-            core_msgs.extend(prompt_systeminfo(workspace, tool_format=tool_format))
-            core_msgs.extend(prompt_timeinfo(tool_format=tool_format))
-    elif prompt == "short":
-        if include_tools:
-            core_msgs = list(
-                prompt_short(
-                    interactive,
-                    tools,
-                    tool_format,
-                    model=model,
-                    agent_name=agent_name,
-                )
-            )
-        else:
-            core_msgs = list(
-                prompt_gptme(interactive, model, agent_name, tool_format=tool_format)
-            )
-    else:
-        core_msgs = [Message("system", prompt)]
-        if tools and include_tools:
-            core_msgs.extend(
-                prompt_tools(tools=tools, tool_format=tool_format, model=model)
-            )
-
-    # Generate workspace messages separately (if included)
-    # Always exclude context_cmd here — it's collected separately below
-    # for better prompt caching (static/semi-static content first, dynamic last).
-    workspace_msgs = (
-        list(
-            prompt_workspace(
-                workspace,
-                include_context_cmd=False,
-                include_user_context=include_user_context,
-            )
-        )
-        if include_workspace and workspace and workspace != agent_path
-        else []
-    )
-
-    # Agent config workspace (separate from project, only with --agent-path)
-    agent_config_msgs = (
-        list(
-            prompt_workspace(
-                agent_path,
-                title="Agent Config",
-                include_path=True,
-                include_context_cmd=False,
-                include_user_context=include_user_context,
-            )
-        )
-        if include_agent_config
-        else []
-    )
-
-    # Collect dynamic context_cmd outputs separately.
-    # By placing these after all static/semi-static content, we maximize the
-    # prompt prefix that can be cached across conversation starts (core prompt,
-    # workspace files, agent config rarely change; context_cmd changes every session).
-    dynamic_context_msgs: list[Message] = []
-    if include_context_cmd:
-        for ws, title in [
-            (agent_path if include_agent_config else None, "Agent"),
-            (
-                workspace if include_workspace and workspace != agent_path else None,
-                "Project",
-            ),
-        ]:
-            if ws is None:
-                continue
-            ws_project = get_project_config(ws)
-            if (
-                ws_project
-                and ws_project.context_cmd
-                and (
-                    cmd_output := get_project_context_cmd_output(
-                        ws_project.context_cmd, ws
-                    )
-                )
-            ):
-                dynamic_context_msgs.append(
-                    Message("system", f"## {title} computed context\n\n" + cmd_output)
-                )
-
-    # Combine core messages into one system prompt
+    core_msgs = [msg for _, msgs in core_sections for msg in msgs]
     result = []
     if core_msgs:
         core_prompt = _join_messages(core_msgs)
         result.append(core_prompt)
 
-    # Add agent config messages separately (if included)
-    if include_agent_config:
-        result.extend(agent_config_msgs)
-
-    # Add workspace messages separately (if included)
-    if include_workspace:
-        result.extend(workspace_msgs)
+    for _, msgs in cacheable_sections:
+        result.extend(msgs)
 
     # Insert an explicit static/dynamic boundary before context_cmd output.
     # This keeps the prompt structure stable and makes the cacheable prefix
     # visible to both humans and providers with block-level prompt caching.
-    if dynamic_context_msgs and result:
+    if dynamic_sections and result:
         result.append(Message("system", SYSTEM_PROMPT_CACHE_BOUNDARY))
 
     # Dynamic context last (changes every session, least cacheable)
-    result.extend(dynamic_context_msgs)
-
-    # Chat history (also dynamic)
-    result.extend(prompt_chat_history())
+    for _, msgs in dynamic_sections:
+        result.extend(msgs)
 
     # Set hide=True, pinned=True for all messages
     for i, msg in enumerate(result):
@@ -366,12 +569,16 @@ __all__ = [
     "ContextMode",
     "DEFAULT_CONTEXT_FILES",
     "PromptType",
+    "PromptSectionStat",
+    "PromptStats",
     "_loaded_agent_files_var",
     "_truncate_context_output",
     "_xml_section",
     "find_agent_files_in_tree",
+    "format_prompt_stats",
     "get_project_context_cmd_output",
     "get_prompt",
+    "get_prompt_stats",
     "prompt_chat_history",
     "prompt_full",
     "prompt_gptme",

--- a/gptme/prompts/__init__.py
+++ b/gptme/prompts/__init__.py
@@ -182,9 +182,9 @@ def _build_core_prompt_sections(
                     )
                 ),
             )
-        if interactive:
-            add("prompt_user", list(prompt_user(tool_format=tool_format)))
-        add("prompt_project", list(prompt_project(tool_format=tool_format)))
+            if interactive:
+                add("prompt_user", list(prompt_user(tool_format=tool_format)))
+            add("prompt_project", list(prompt_project(tool_format=tool_format)))
         return sections
 
     add("custom_prompt", [Message("system", prompt)])
@@ -364,16 +364,12 @@ def get_prompt_stats(
         _section_stat(name, msgs, model)
         for name, msgs in (*core_sections, *cacheable_sections, *dynamic_sections)
     ]
+    cacheable_section_count = len(core_sections) + len(cacheable_sections)
     total_messages = sum(stat.messages for stat in stats)
     total_chars = sum(stat.chars for stat in stats)
     total_tokens = sum(stat.tokens for stat in stats)
-    cacheable_tokens = sum(
-        _section_stat(name, msgs, model).tokens
-        for name, msgs in (*core_sections, *cacheable_sections)
-    )
-    dynamic_tokens = sum(
-        _section_stat(name, msgs, model).tokens for name, msgs in dynamic_sections
-    )
+    cacheable_tokens = sum(stat.tokens for stat in stats[:cacheable_section_count])
+    dynamic_tokens = sum(stat.tokens for stat in stats[cacheable_section_count:])
     return PromptStats(
         sections=stats,
         total_messages=total_messages,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,6 +6,8 @@ import threading
 import time
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from types import SimpleNamespace
+from typing import Any
 
 import click
 import pytest
@@ -87,6 +89,63 @@ def test_version(runner: CliRunner):
     result = runner.invoke(cli.main, ["--version"])
     assert result.exit_code == 0
     assert "gptme" in result.output
+
+
+def test_show_prompt_stats_exits_before_chat(monkeypatch, tmp_path: Path, runner):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "state"))
+
+    fake_config = SimpleNamespace(
+        chat=SimpleNamespace(
+            agent_config=None,
+            tools=["shell", "read"],
+            interactive=False,
+            tool_format="markdown",
+            model="local/test",
+            workspace=tmp_path,
+            stream=False,
+            agent=None,
+        ),
+        project=None,
+    )
+    seen: dict[str, Any] = {}
+
+    monkeypatch.setattr(cli, "setup_config_from_cli", lambda **_: fake_config)
+    monkeypatch.setattr(cli, "init_tools", lambda _: [])
+    monkeypatch.setattr(
+        cli,
+        "get_prompt_stats",
+        lambda **kwargs: (
+            seen.update(kwargs=kwargs)
+            or SimpleNamespace(
+                sections=[],
+                total_messages=0,
+                total_chars=0,
+                total_tokens=0,
+                cacheable_tokens=0,
+                dynamic_tokens=0,
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        cli,
+        "format_prompt_stats",
+        lambda stats, header=None, extra_sections=None: "prompt-stats-output",
+    )
+    monkeypatch.setattr(cli, "chat", lambda *args, **kwargs: pytest.fail("chat ran"))
+    monkeypatch.setattr(
+        cli,
+        "init_telemetry",
+        lambda **kwargs: pytest.fail("telemetry should not start for prompt stats"),
+    )
+
+    result = runner.invoke(cli.main, ["--show-prompt-stats"], input="")
+
+    assert result.exit_code == 0
+    assert "prompt-stats-output" in result.output
+    assert seen["kwargs"]["workspace"] is not None
+    assert seen["kwargs"]["model"] == "local/test"
 
 
 @pytest.mark.skipif(os.name == "nt", reason="SIGALRM-based pipe guard is POSIX-only")

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -111,6 +111,17 @@ def test_get_prompt_stats_breaks_out_sections():
     assert stats.cacheable_tokens >= stats.dynamic_tokens
 
 
+def test_get_prompt_stats_short_without_tools_keeps_minimal_core():
+    stats = get_prompt_stats(
+        [],
+        prompt="short",
+        context_mode="selective",
+        context_include=[],
+    )
+
+    assert [section.name for section in stats.sections] == ["prompt_gptme"]
+
+
 def test_get_prompt_stats_includes_workspace_and_dynamic_context(tmp_path):
     workspace = tmp_path / "project"
     workspace.mkdir()

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -5,7 +5,7 @@ from types import SimpleNamespace
 import pytest
 
 from gptme.message import len_tokens
-from gptme.prompts import get_prompt
+from gptme.prompts import format_prompt_stats, get_prompt, get_prompt_stats
 from gptme.tools import get_tools, init_tools
 
 
@@ -93,6 +93,57 @@ def test_get_prompt_selective_components():
     # Full mode should have more content
     full_mode = get_prompt(get_tools(), prompt="full", context_mode="full")
     assert len(full_mode) >= len(empty_selective)
+
+
+def test_get_prompt_stats_breaks_out_sections():
+    stats = get_prompt_stats(
+        get_tools(),
+        prompt="full",
+        context_mode="selective",
+        context_include=[],
+    )
+
+    names = [section.name for section in stats.sections]
+    assert "prompt_gptme" in names
+    assert "prompt_tools" in names
+    assert "prompt_project" in names
+    assert stats.total_tokens == sum(section.tokens for section in stats.sections)
+    assert stats.cacheable_tokens >= stats.dynamic_tokens
+
+
+def test_get_prompt_stats_includes_workspace_and_dynamic_context(tmp_path):
+    workspace = tmp_path / "project"
+    workspace.mkdir()
+    (workspace / "README.md").write_text("# Prompt Stats")
+    (workspace / "gptme.toml").write_text(
+        '[prompt]\nfiles = ["README.md"]\ncontext_cmd = "echo DYNAMIC_STATS_MARKER"\n'
+    )
+
+    stats = get_prompt_stats(
+        get_tools(),
+        prompt="full",
+        workspace=workspace,
+    )
+
+    by_name = {section.name: section for section in stats.sections}
+    assert by_name["prompt_workspace"].tokens > 0
+    assert by_name["prompt_context_cmd_project"].tokens > 0
+    assert stats.dynamic_tokens >= by_name["prompt_context_cmd_project"].tokens
+
+
+def test_format_prompt_stats_outputs_summary_table():
+    stats = get_prompt_stats(
+        get_tools(),
+        prompt="short",
+        context_mode="selective",
+        context_include=[],
+    )
+
+    rendered = format_prompt_stats(stats, header="Prompt stats")
+    assert "Prompt stats" in rendered
+    assert "section" in rendered
+    assert "prompt_gptme" in rendered
+    assert "total" in rendered
 
 
 def test_prompt_systeminfo_uses_workspace(tmp_path):

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -103,6 +103,7 @@ def test_get_prompt_stats_breaks_out_sections():
         context_include=[],
     )
 
+    assert isinstance(stats.sections, tuple)
     names = [section.name for section in stats.sections]
     assert "prompt_gptme" in names
     assert "prompt_tools" in names


### PR DESCRIPTION
## Summary
- add named startup prompt section accounting in `gptme.prompts`
- add `gptme --show-prompt-stats` to inspect prompt token cost without starting a conversation
- document a practical minimal-context recipe in the docs

## Testing
- PYTHONPATH=/tmp/worktrees/gptme-minctx-9c53 /home/bob/projects/gptme/.venv/bin/pytest /tmp/worktrees/gptme-minctx-9c53/tests/test_prompts.py /tmp/worktrees/gptme-minctx-9c53/tests/test_cli.py -q
- PYTHONPATH=/tmp/worktrees/gptme-minctx-9c53 /home/bob/projects/gptme/.venv/bin/gptme --show-prompt-stats --system short --tools shell,read --context files