### PR TITLE
feat(eval): surface per-task tool-call count (tool-efficiency metric)

### DIFF
--- a/gptme/eval/main.py
+++ b/gptme/eval/main.py
@@ -373,6 +373,7 @@ def print_model_results_table(model_results: dict[ModelConfig, list[EvalResult]]
                 else:
                     row.append(
                         f"{checkmark} {duration:.0f}s/{gen_tokens + run_tokens}tok"
+                        f"/{result.tool_calls}tc"
                     )
             except StopIteration:
                 row.append("❌ N/A")

--- a/gptme/eval/main.py
+++ b/gptme/eval/main.py
@@ -367,7 +367,7 @@ def print_model_results_table(model_results: dict[ModelConfig, list[EvalResult]]
                 duration = sum(result.timings.values())
                 gen_tokens = len_tokens(result.gen_stdout, "gpt-4")
                 run_tokens = len_tokens(result.run_stdout, "gpt-4")
-                reason = "timeout" if result.status == "timeout" else ""
+                reason = result.status if result.status in {"timeout", "error"} else ""
                 if reason:
                     row.append(f"{checkmark} {reason}")
                 else:
@@ -915,6 +915,7 @@ def read_results_from_csv(filename: str) -> dict[ModelConfig, list[EvalResult]]:
                 run_stderr=read_log_file(test_dir / "run_stderr.txt"),
                 log_dir=Path(row.get("Log Dir", str(test_dir))),
                 workspace_dir=Path(row.get("Workspace Dir", str(test_dir))),
+                tool_calls=int(row.get("Tool Calls", 0) or 0),
             )
             model_results[config].append(result)
     return dict(model_results)
@@ -1010,6 +1011,7 @@ def write_results(
             "Test",
             "Passed",
             "Score",
+            "Tool Calls",
             "Total Duration",
             "Generation Time",
             "Run Time",
@@ -1053,6 +1055,7 @@ def write_results(
                     "Test": result.name,
                     "Passed": "true" if passed else "false",
                     "Score": score,
+                    "Tool Calls": result.tool_calls,
                     "Total Duration": round(sum(result.timings.values()), 2),
                     "Generation Time": round(result.timings["gen"], 2),
                     "Run Time": round(result.timings["run"], 2),

--- a/gptme/eval/run.py
+++ b/gptme/eval/run.py
@@ -18,7 +18,7 @@ from concurrent.futures import (
 )
 from multiprocessing import Manager, Process
 from pathlib import Path
-from typing import TypedDict
+from typing import TYPE_CHECKING, TypedDict
 
 from tqdm import tqdm
 
@@ -37,7 +37,28 @@ from .types import (
     Status,
 )
 
+if TYPE_CHECKING:
+    from ..message import Message
+
 logger = logging.getLogger(__name__)
+
+
+def count_tool_calls(messages: list["Message"]) -> int:
+    """Count runnable tool calls in a conversation log.
+
+    Mirrors ``execute_msg`` semantics: only assistant messages can run tools,
+    and only runnable tool-uses are counted. This is the per-task tool-efficiency
+    signal — for equal completion, fewer tool calls is a cheaper, faster session.
+    """
+    from ..tools import ToolUse
+
+    return sum(
+        1
+        for msg in messages
+        if msg.role == "assistant"
+        for tu in ToolUse.iter_from_content(msg.content)
+        if tu.is_runnable
+    )
 
 
 class ProcessSuccess(TypedDict):
@@ -303,6 +324,7 @@ def execute(
     time_gen = 0.0
     time_run = 0.0
     time_eval = 0.0
+    tool_calls = 0
 
     prompt = test["prompt"]
     if adversarial:
@@ -455,13 +477,17 @@ def execute(
 
             _evaluate_checks(test["expect"], ctx)
 
+            # Load the parent conversation log once: used for the tool-efficiency
+            # metric (always) and any trajectory checks (when defined).
+            try:
+                messages = LogManager.load(log_dir, lock=False).log.messages
+            except Exception as e:
+                print(f"Error while loading conversation log: {e}")
+                messages = []
+            tool_calls = count_tool_calls(messages)
+
             check_log = test.get("check_log", {})
             if check_log:
-                try:
-                    messages = LogManager.load(log_dir, lock=False).log.messages
-                except Exception as e:
-                    print(f"Error while loading conversation log: {e}")
-                    messages = []
                 _evaluate_checks(check_log, messages)
             print("--- End of results ---")
 
@@ -482,6 +508,7 @@ def execute(
             log_dir=log_dir,
             workspace_dir=workspace_dir,
             cost=cost,
+            tool_calls=tool_calls,
         )
 
 

--- a/gptme/eval/types.py
+++ b/gptme/eval/types.py
@@ -91,6 +91,14 @@ class EvalResult:
     log_dir: Path
     workspace_dir: Path
     cost: "CostSummary | None" = field(default=None)
+    tool_calls: int = field(default=0)
+    """Number of runnable tool calls in the parent conversation log.
+
+    For equal completion, fewer tool calls indicate a more efficient (cheaper,
+    faster) session — a tool-efficiency signal that scales with the suite. Counts
+    runnable tool-uses in assistant messages only (matching ``execute_msg``
+    semantics); nested subagent tool-uses are not counted.
+    """
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize to a JSON-compatible dict."""
@@ -100,6 +108,7 @@ class EvalResult:
             "passed": all(c.passed for c in self.results) if self.results else False,
             "cases": [c.to_dict() for c in self.results],
             "timings": self.timings,
+            "tool_calls": self.tool_calls,
         }
         if self.cost is not None:
             d["cost"] = self.cost.to_dict()

--- a/tests/test_eval_tool_efficiency.py
+++ b/tests/test_eval_tool_efficiency.py
@@ -1,0 +1,58 @@
+"""Tests for the gptme-eval tool-efficiency (tool-call count) metric."""
+
+from pathlib import Path
+
+from gptme.eval.run import count_tool_calls
+from gptme.eval.types import EvalResult
+from gptme.message import Message
+from gptme.tools import init_tools
+
+
+def test_count_tool_calls_counts_runnable_assistant_tooluses():
+    """count_tool_calls counts runnable tool-uses in assistant messages only."""
+    init_tools()
+
+    messages = [
+        Message("system", "You are a helpful assistant."),
+        Message("user", "List the files and then read main.py."),
+        # assistant turn with one runnable shell tool-use
+        Message("assistant", "Sure, listing files:\n\n```shell\nls -la\n```"),
+        # tool output is a system message — not an assistant turn, not counted
+        Message("system", "```stdout\nmain.py\n```"),
+        # assistant turn with another runnable tool-use
+        Message("assistant", "Now reading it:\n\n```shell\ncat main.py\n```"),
+        # assistant turn with prose only — no tool-use
+        Message("assistant", "The file defines a single function."),
+    ]
+
+    assert count_tool_calls(messages) == 2
+
+
+def test_count_tool_calls_empty():
+    """No messages (e.g. a log that failed to load) yields zero."""
+    assert count_tool_calls([]) == 0
+
+
+def _make_result(tool_calls: int | None = None) -> EvalResult:
+    kwargs: dict = {}
+    if tool_calls is not None:
+        kwargs["tool_calls"] = tool_calls
+    return EvalResult(
+        name="hello",
+        status="success",
+        results=[],
+        timings={"gen": 1.0, "run": 0.5, "eval": 0.1},
+        gen_stdout="",
+        gen_stderr="",
+        run_stdout="",
+        run_stderr="",
+        log_dir=Path("/tmp/log"),
+        workspace_dir=Path("/tmp/ws"),
+        **kwargs,
+    )
+
+
+def test_evalresult_to_dict_includes_tool_calls():
+    """EvalResult serializes the tool_calls field; default is 0."""
+    assert _make_result().to_dict()["tool_calls"] == 0
+    assert _make_result(tool_calls=4).to_dict()["tool_calls"] == 4

--- a/tests/test_eval_tool_efficiency.py
+++ b/tests/test_eval_tool_efficiency.py
@@ -1,9 +1,16 @@
 """Tests for the gptme-eval tool-efficiency (tool-call count) metric."""
 
+import csv
 from pathlib import Path
+from typing import Literal
 
+from gptme.eval.main import (
+    print_model_results_table,
+    read_results_from_csv,
+    write_results,
+)
 from gptme.eval.run import count_tool_calls
-from gptme.eval.types import EvalResult
+from gptme.eval.types import EvalResult, ModelConfig
 from gptme.message import Message
 from gptme.tools import init_tools
 
@@ -33,13 +40,17 @@ def test_count_tool_calls_empty():
     assert count_tool_calls([]) == 0
 
 
-def _make_result(tool_calls: int | None = None) -> EvalResult:
+def _make_result(
+    tool_calls: int | None = None,
+    *,
+    status: Literal["success", "error", "timeout"] = "success",
+) -> EvalResult:
     kwargs: dict = {}
     if tool_calls is not None:
         kwargs["tool_calls"] = tool_calls
     return EvalResult(
         name="hello",
-        status="success",
+        status=status,
         results=[],
         timings={"gen": 1.0, "run": 0.5, "eval": 0.1},
         gen_stdout="",
@@ -56,3 +67,29 @@ def test_evalresult_to_dict_includes_tool_calls():
     """EvalResult serializes the tool_calls field; default is 0."""
     assert _make_result().to_dict()["tool_calls"] == 0
     assert _make_result(tool_calls=4).to_dict()["tool_calls"] == 4
+
+
+def test_write_results_persists_tool_calls_roundtrip(tmp_path, monkeypatch):
+    """CSV persistence should preserve tool_calls for replayed results."""
+    monkeypatch.setenv("EVAL_RESULTS_DIR", str(tmp_path))
+
+    config = ModelConfig(model="test-model", tool_format="tool")
+    write_results({config: [_make_result(tool_calls=4)]})
+
+    csv_path = next(tmp_path.glob("*/eval_results.csv"))
+    with open(csv_path, newline="") as f:
+        row = next(csv.DictReader(f))
+    assert row["Tool Calls"] == "4"
+
+    model_results = read_results_from_csv(str(csv_path))
+    assert model_results[config][0].tool_calls == 4
+
+
+def test_print_model_results_table_hides_tool_calls_for_error_rows(capsys):
+    """Error rows should show the status marker instead of a fake 0tc metric."""
+    config = ModelConfig(model="test-model", tool_format="tool")
+    print_model_results_table({config: [_make_result(tool_calls=4, status="error")]})
+
+    output = capsys.readouterr().out
+    assert "error" in output
+    assert "/4tc" not in output


### PR DESCRIPTION
## What

`gptme-eval` already measures completion rate, cost, and wall time, but not **tool efficiency** — how many tool calls a task took. For equal completion, fewer tool calls means a cheaper, faster session. It's a bitter-lesson-aligned signal that scales with the existing benchmark suite, with no hand-coded rubric.

## Changes

- **`count_tool_calls(messages)`** (`gptme/eval/run.py`): counts runnable tool-uses in **assistant** messages only, mirroring `execute_msg` semantics. Nested subagent tool-uses are not counted (matches `check_log` semantics).
- **`EvalResult.tool_calls`** field (`gptme/eval/types.py`), emitted in `to_dict()` → flows automatically to JSON output and `results_to_json`.
- The conversation log is now loaded **once** in the success branch (reused for both the metric and any `check_log` trajectory checks), instead of only when `check_log` is defined.
- Per-run results table (`print_model_results_table`) appends `/<n>tc` alongside duration/tokens.
- 3 unit tests (`tests/test_eval_tool_efficiency.py`).

## Verification

- `tests/test_eval_tool_efficiency.py`: 3 passed
- `tests/test_eval.py` + `tests/test_eval_leaderboard.py`: 62 passed, 2 skipped (no regression)
- mypy + ruff clean on all changed files

## Scope

Surgical, additive. No new CLI/harness (gptme-eval already exists), no new suites, no changes to the cost/time/completion metrics. Default `tool_calls=0` keeps `read_results_from_csv` and all existing constructors working unchanged.

Ref: ErikBjare/bob#745 ("CLIs or tooling for better sessions, bitter lesson proof")