### PR TITLE
fix(webui): add Escape-to-navigate-back for full-page settings view

### DIFF
--- a/webui/e2e/keyboard.spec.ts
+++ b/webui/e2e/keyboard.spec.ts
@@ -72,3 +72,31 @@ test.describe('Keyboard Navigation', () => {
     await expect(dialog).not.toBeVisible({ timeout: 3000 });
   });
 });
+
+test.describe('Keyboard Navigation — Settings Page', () => {
+  test('Escape navigates back to /chat (with history)', async ({ page }) => {
+    // Navigate to /chat first to establish history
+    await page.goto('/chat');
+    await page.waitForLoadState('networkidle');
+
+    // Navigate to /settings
+    await page.goto('/settings');
+    await page.waitForLoadState('networkidle');
+    await expect(page.locator('h1', { hasText: 'Settings' })).toBeVisible({ timeout: 5000 });
+
+    // Press Escape — should navigate back to /chat
+    await page.keyboard.press('Escape');
+    await expect(page).toHaveURL(/\/chat$/, { timeout: 5000 });
+  });
+
+  test('Escape falls back to /chat (no history)', async ({ page }) => {
+    // Navigate directly to /settings (no prior history)
+    await page.goto('/settings');
+    await page.waitForLoadState('networkidle');
+    await expect(page.locator('h1', { hasText: 'Settings' })).toBeVisible({ timeout: 5000 });
+
+    // Press Escape — should fall back to /chat since there's no history
+    await page.keyboard.press('Escape');
+    await expect(page).toHaveURL(/\/chat$/, { timeout: 5000 });
+  });
+});

--- a/webui/src/pages/SettingsPage.tsx
+++ b/webui/src/pages/SettingsPage.tsx
@@ -62,9 +62,15 @@ const SettingsPage: FC = () => {
       onKeyDown={(e) => {
         if (e.key === 'Escape') {
           e.stopPropagation();
-          // Navigate back if there is prior history,
-          // otherwise fall back to /chat (e.g. direct link or new tab).
-          if (window.history.length > 1) {
+          // A fresh tab always has at least one `about:blank` entry in
+          // its history, so a direct URL load on /settings leaves
+          // window.history.length at 2 (about:blank + /settings). Using
+          // `> 2` as the threshold excludes that case: navigate(-1) on a
+          // 2-entry history would land on about:blank, so we fall back
+          // to /chat instead. Any value >= 3 means the user reached
+          // /settings from at least one in-app page and going back is
+          // safe.
+          if (window.history.length > 2) {
             navigate(-1);
           } else {
             navigate('/chat');

--- a/webui/src/pages/SettingsPage.tsx
+++ b/webui/src/pages/SettingsPage.tsx
@@ -48,7 +48,16 @@ const SettingsPage: FC = () => {
   }, [externalRequest.open, externalRequest.category, handleCategoryChange]);
 
   return (
-    <div className="flex h-screen flex-col">
+    <div
+      className="flex h-screen flex-col"
+      tabIndex={-1}
+      onKeyDown={(e) => {
+        if (e.key === 'Escape') {
+          e.stopPropagation();
+          navigate(-1);
+        }
+      }}
+    >
       <MenuBar />
       <div className="flex min-h-0 flex-1">
         <SidebarIcons tasks={tasks} />

--- a/webui/src/pages/SettingsPage.tsx
+++ b/webui/src/pages/SettingsPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, type FC } from 'react';
+import { useState, useEffect, useCallback, useRef, type FC } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { Settings } from 'lucide-react';
 import { MenuBar } from '@/components/MenuBar';
@@ -21,9 +21,16 @@ const SettingsPage: FC = () => {
   const { category } = useParams<{ category?: string }>();
   const navigate = useNavigate();
   const { data: tasks = [] } = useTasksQuery();
+  const containerRef = useRef<HTMLDivElement>(null);
   const [activeCategory, setActiveCategory] = useState<SettingsCategory>(
     toCategoryOrDefault(category)
   );
+
+  // Auto-focus the container so the Escape key handler works immediately on mount,
+  // without requiring the user to click inside the page first.
+  useEffect(() => {
+    containerRef.current?.focus();
+  }, []);
 
   // Keep state in sync when URL param changes (e.g. browser back/forward)
   useEffect(() => {
@@ -49,12 +56,19 @@ const SettingsPage: FC = () => {
 
   return (
     <div
+      ref={containerRef}
       className="flex h-screen flex-col"
       tabIndex={-1}
       onKeyDown={(e) => {
         if (e.key === 'Escape') {
           e.stopPropagation();
-          navigate(-1);
+          // Navigate back if there is prior history,
+          // otherwise fall back to /chat (e.g. direct link or new tab).
+          if (window.history.length > 1) {
+            navigate(-1);
+          } else {
+            navigate('/chat');
+          }
         }
       }}
     >


### PR DESCRIPTION
The full-page SettingsPage at `/settings` had no keyboard handler for Escape. Pressing Escape now navigates back to the previous route, matching the behavior users expect from the modal version (which already handles Escape via Radix Dialog).

Part of the ongoing keyboard navigation audit (task `gptme-webui-keyboard-navigation`).