### PR TITLE
fix(complete): auto-reply kill-switch now detects incomplete-todos variant

### DIFF
--- a/gptme/tools/complete.py
+++ b/gptme/tools/complete.py
@@ -193,9 +193,14 @@ def auto_reply_hook(
         return  # Has tools, no need to prompt
 
     # Count consecutive auto-replies
+    # Both auto-reply variants share this prefix:
+    # "No tool call detected in last message. You have incomplete todos:\n..."
+    # "No tool call detected in last message. Did you mean to finish? ..."
+    _AUTO_REPLY_MARKER = "No tool call detected in last message"
+
     auto_reply_count = 0
     for msg in reversed(manager.log.messages):
-        if msg.role == "user" and "use the `complete` tool" in msg.content:
+        if msg.role == "user" and _AUTO_REPLY_MARKER in msg.content:
             auto_reply_count += 1
         elif msg.role == "assistant":
             # Stop counting when we hit an assistant message with tools

--- a/tests/test_complete.py
+++ b/tests/test_complete.py
@@ -210,6 +210,40 @@ class TestTodoContinuationEnforcer:
         assert "Implement feature X" in result[0].content
         assert "Write tests" in result[0].content
 
+    def test_two_auto_replies_with_incomplete_todos_exits(self):
+        """Should exit after 2 consecutive no-tool replies even with incomplete todos."""
+        # Add incomplete todos
+        todo._current_todos["1"] = {
+            "id": "1",
+            "text": "Implement feature X",
+            "state": "in_progress",
+            "created": "2025-01-01T00:00:00",
+            "updated": "2025-01-01T00:00:00",
+        }
+
+        messages = [
+            Message("assistant", "Working\n```shell\nls\n```"),
+            Message(
+                "user",
+                "<system>No tool call detected in last message. You have incomplete todos:\n- Implement feature X (in_progress)\n\nPlease continue working on these tasks, or mark them complete/remove them before finishing.</system>",
+            ),
+            Message("assistant", "First response without tools"),
+            Message(
+                "user",
+                "<system>No tool call detected in last message. You have incomplete todos:\n- Implement feature X (in_progress)\n\nPlease continue working on these tasks, or mark them complete/remove them before finishing.</system>",
+            ),
+            Message("assistant", "Second response without tools"),
+        ]
+
+        manager = MagicMock()
+        manager.log = Log(messages)
+
+        # Should raise SessionCompleteException (not cycle infinitely)
+        with pytest.raises(SessionCompleteException) as exc_info:
+            list(auto_reply_hook(manager, interactive=False, prompt_queue=None))
+
+        assert "2 auto-reply confirmations" in str(exc_info.value)
+
     def test_auto_reply_without_incomplete_todos(self):
         """Should show normal message when no incomplete todos."""
         # Add only completed todos


### PR DESCRIPTION
## Problem

The consecutive auto-reply kill-switch in `auto_reply_hook` only matched `"use the \`complete\` tool"` in auto-reply messages to count no-tool cycles. The incomplete-todos auto-reply variant uses completely different wording ("Please continue working on these tasks..."), so it was invisible to the counting loop.

This meant sessions with incomplete todos could cycle indefinitely through no-tool auto-replies — the model generates prose, auto-reply nudges "continue working", model generates more prose, repeat — without ever hitting the 2-consecutive kill-switch.

Observed in production: 184 "Auto-reply: Assistant message had no tools" warnings in 6 hours across 4 autonomous sessions, with deepseek-based sessions generating 203 warnings each from the same repeating cycle.

## Fix

Replace the narrow counting pattern `"use the \`complete\` tool"` with the shared prefix `"No tool call detected in last message"` that appears in both auto-reply variants.

This ensures the 2-consecutive-no-tool kill-switch fires correctly regardless of whether incomplete todos exist.

## Test

Added `test_two_auto_replies_with_incomplete_todos_exits` — verifies that 2 consecutive no-tool replies with incomplete todos trigger `SessionCompleteException` instead of cycling infinitely.

## Verification

- `tests/test_complete.py`: 17/17 passed (16 existing + 1 new)
- Pre-commit: all checks passed
- No other tests affected