### PR TITLE
test(complete): cover cross-variant auto-reply exit counting

### DIFF
--- a/tests/test_complete.py
+++ b/tests/test_complete.py
@@ -165,6 +165,45 @@ class TestAutoReplyHook:
             )
             assert len(result) == 0
 
+    def test_two_auto_replies_mixed_variants_exits(self):
+        """Should exit after two no-tool replies even when the two auto-reply
+        messages are *different* variants.
+
+        Realistic production case: the first turn has incomplete todos, so the
+        reminder variant fires; the model then completes the todos but still
+        produces a tool-less response, so the confirm variant fires. Both
+        variants share the ``"No tool call detected in last message"`` marker,
+        so they must count toward the same exit threshold. This is the exact
+        cross-variant counting that gptme/gptme#2846 fixed — before that, the
+        two full-string markers were distinct and a mixed sequence undercounted
+        and never exited (infinite cycle).
+        """
+        messages = [
+            Message("assistant", "Working\n```shell\nls\n```"),
+            # First auto-reply: incomplete-todos (reminder) variant
+            Message(
+                "user",
+                "<system>No tool call detected in last message. You have incomplete todos:\n- Implement feature X (in_progress)\n\nPlease continue working on these tasks, or mark them complete/remove them before finishing.</system>",
+            ),
+            Message("assistant", "First response without tools"),
+            # Second auto-reply: confirm variant (todos now done, still no tools)
+            Message(
+                "user",
+                "<system>No tool call detected in last message. Did you mean to finish? If so, make sure you are completely done and then use the `complete` tool to end the session.</system>",
+            ),
+            Message("assistant", "Second response without tools"),
+        ]
+
+        manager = MagicMock()
+        manager.log = Log(messages)
+
+        # Should raise SessionCompleteException despite the two messages being
+        # different variants (regression guard for the shared marker).
+        with pytest.raises(SessionCompleteException) as exc_info:
+            list(auto_reply_hook(manager, interactive=False, prompt_queue=None))
+
+        assert "2 auto-reply confirmations" in str(exc_info.value)
+
 
 class TestTodoContinuationEnforcer:
     """Tests for todo-based continuation enforcement."""
@@ -239,45 +278,6 @@ class TestTodoContinuationEnforcer:
         manager.log = Log(messages)
 
         # Should raise SessionCompleteException (not cycle infinitely)
-        with pytest.raises(SessionCompleteException) as exc_info:
-            list(auto_reply_hook(manager, interactive=False, prompt_queue=None))
-
-        assert "2 auto-reply confirmations" in str(exc_info.value)
-
-    def test_two_auto_replies_mixed_variants_exits(self):
-        """Should exit after two no-tool replies even when the two auto-reply
-        messages are *different* variants.
-
-        Realistic production case: the first turn has incomplete todos, so the
-        reminder variant fires; the model then completes the todos but still
-        produces a tool-less response, so the confirm variant fires. Both
-        variants share the ``"No tool call detected in last message"`` marker,
-        so they must count toward the same exit threshold. This is the exact
-        cross-variant counting that gptme/gptme#2846 fixed — before that, the
-        two full-string markers were distinct and a mixed sequence undercounted
-        and never exited (infinite cycle).
-        """
-        messages = [
-            Message("assistant", "Working\n```shell\nls\n```"),
-            # First auto-reply: incomplete-todos (reminder) variant
-            Message(
-                "user",
-                "<system>No tool call detected in last message. You have incomplete todos:\n- Implement feature X (in_progress)\n\nPlease continue working on these tasks, or mark them complete/remove them before finishing.</system>",
-            ),
-            Message("assistant", "First response without tools"),
-            # Second auto-reply: confirm variant (todos now done, still no tools)
-            Message(
-                "user",
-                "<system>No tool call detected in last message. Did you mean to finish? If so, make sure you are completely done and then use the `complete` tool to end the session.</system>",
-            ),
-            Message("assistant", "Second response without tools"),
-        ]
-
-        manager = MagicMock()
-        manager.log = Log(messages)
-
-        # Should raise SessionCompleteException despite the two messages being
-        # different variants (regression guard for the shared marker).
         with pytest.raises(SessionCompleteException) as exc_info:
             list(auto_reply_hook(manager, interactive=False, prompt_queue=None))
 

--- a/tests/test_complete.py
+++ b/tests/test_complete.py
@@ -244,6 +244,45 @@ class TestTodoContinuationEnforcer:
 
         assert "2 auto-reply confirmations" in str(exc_info.value)
 
+    def test_two_auto_replies_mixed_variants_exits(self):
+        """Should exit after two no-tool replies even when the two auto-reply
+        messages are *different* variants.
+
+        Realistic production case: the first turn has incomplete todos, so the
+        reminder variant fires; the model then completes the todos but still
+        produces a tool-less response, so the confirm variant fires. Both
+        variants share the ``"No tool call detected in last message"`` marker,
+        so they must count toward the same exit threshold. This is the exact
+        cross-variant counting that gptme/gptme#2846 fixed — before that, the
+        two full-string markers were distinct and a mixed sequence undercounted
+        and never exited (infinite cycle).
+        """
+        messages = [
+            Message("assistant", "Working\n```shell\nls\n```"),
+            # First auto-reply: incomplete-todos (reminder) variant
+            Message(
+                "user",
+                "<system>No tool call detected in last message. You have incomplete todos:\n- Implement feature X (in_progress)\n\nPlease continue working on these tasks, or mark them complete/remove them before finishing.</system>",
+            ),
+            Message("assistant", "First response without tools"),
+            # Second auto-reply: confirm variant (todos now done, still no tools)
+            Message(
+                "user",
+                "<system>No tool call detected in last message. Did you mean to finish? If so, make sure you are completely done and then use the `complete` tool to end the session.</system>",
+            ),
+            Message("assistant", "Second response without tools"),
+        ]
+
+        manager = MagicMock()
+        manager.log = Log(messages)
+
+        # Should raise SessionCompleteException despite the two messages being
+        # different variants (regression guard for the shared marker).
+        with pytest.raises(SessionCompleteException) as exc_info:
+            list(auto_reply_hook(manager, interactive=False, prompt_queue=None))
+
+        assert "2 auto-reply confirmations" in str(exc_info.value)
+
     def test_auto_reply_without_incomplete_todos(self):
         """Should show normal message when no incomplete todos."""
         # Add only completed todos


### PR DESCRIPTION
## What

Adds a regression test for the auto-reply exit logic in `gptme/tools/complete.py`.

## Why

The two existing exit-after-2 tests (`test_two_auto_replies_exits`, `test_two_auto_replies_with_incomplete_todos_exits`) each use a **single** auto-reply variant twice. But the actual fix in #2846 was that both variants share the marker prefix `"No tool call detected in last message"` so they count toward the **same** exit threshold. No test exercises a *mixed* sequence — so a regression to per-variant markers (the pre-#2846 bug) would pass CI.

This is not hypothetical: a session that starts with incomplete todos (reminder variant) and then completes them while still producing a tool-less response (confirm variant) hits exactly this mixed path. Before #2846 it would undercount and never exit — an infinite auto-reply cycle until the budget/timeout.

## Test

`test_two_auto_replies_mixed_variants_exits`: first auto-reply is the reminder variant, second is the confirm variant; asserts `SessionCompleteException` still fires.

```
18 passed in 2.57s  (tests/test_complete.py)
```

No production code changes — test-only.