### PR TITLE
feat(webui): server-backed star/unstar for conversations via metadata sidecar

### DIFF
--- a/tests/test_complete.py
+++ b/tests/test_complete.py
@@ -165,6 +165,45 @@ class TestAutoReplyHook:
             )
             assert len(result) == 0
 
+    def test_two_auto_replies_mixed_variants_exits(self):
+        """Should exit after two no-tool replies even when the two auto-reply
+        messages are *different* variants.
+
+        Realistic production case: the first turn has incomplete todos, so the
+        reminder variant fires; the model then completes the todos but still
+        produces a tool-less response, so the confirm variant fires. Both
+        variants share the ``"No tool call detected in last message"`` marker,
+        so they must count toward the same exit threshold. This is the exact
+        cross-variant counting that gptme/gptme#2846 fixed — before that, the
+        two full-string markers were distinct and a mixed sequence undercounted
+        and never exited (infinite cycle).
+        """
+        messages = [
+            Message("assistant", "Working\n```shell\nls\n```"),
+            # First auto-reply: incomplete-todos (reminder) variant
+            Message(
+                "user",
+                "<system>No tool call detected in last message. You have incomplete todos:\n- Implement feature X (in_progress)\n\nPlease continue working on these tasks, or mark them complete/remove them before finishing.</system>",
+            ),
+            Message("assistant", "First response without tools"),
+            # Second auto-reply: confirm variant (todos now done, still no tools)
+            Message(
+                "user",
+                "<system>No tool call detected in last message. Did you mean to finish? If so, make sure you are completely done and then use the `complete` tool to end the session.</system>",
+            ),
+            Message("assistant", "Second response without tools"),
+        ]
+
+        manager = MagicMock()
+        manager.log = Log(messages)
+
+        # Should raise SessionCompleteException despite the two messages being
+        # different variants (regression guard for the shared marker).
+        with pytest.raises(SessionCompleteException) as exc_info:
+            list(auto_reply_hook(manager, interactive=False, prompt_queue=None))
+
+        assert "2 auto-reply confirmations" in str(exc_info.value)
+
 
 class TestTodoContinuationEnforcer:
     """Tests for todo-based continuation enforcement."""
@@ -239,45 +278,6 @@ class TestTodoContinuationEnforcer:
         manager.log = Log(messages)
 
         # Should raise SessionCompleteException (not cycle infinitely)
-        with pytest.raises(SessionCompleteException) as exc_info:
-            list(auto_reply_hook(manager, interactive=False, prompt_queue=None))
-
-        assert "2 auto-reply confirmations" in str(exc_info.value)
-
-    def test_two_auto_replies_mixed_variants_exits(self):
-        """Should exit after two no-tool replies even when the two auto-reply
-        messages are *different* variants.
-
-        Realistic production case: the first turn has incomplete todos, so the
-        reminder variant fires; the model then completes the todos but still
-        produces a tool-less response, so the confirm variant fires. Both
-        variants share the ``"No tool call detected in last message"`` marker,
-        so they must count toward the same exit threshold. This is the exact
-        cross-variant counting that gptme/gptme#2846 fixed — before that, the
-        two full-string markers were distinct and a mixed sequence undercounted
-        and never exited (infinite cycle).
-        """
-        messages = [
-            Message("assistant", "Working\n```shell\nls\n```"),
-            # First auto-reply: incomplete-todos (reminder) variant
-            Message(
-                "user",
-                "<system>No tool call detected in last message. You have incomplete todos:\n- Implement feature X (in_progress)\n\nPlease continue working on these tasks, or mark them complete/remove them before finishing.</system>",
-            ),
-            Message("assistant", "First response without tools"),
-            # Second auto-reply: confirm variant (todos now done, still no tools)
-            Message(
-                "user",
-                "<system>No tool call detected in last message. Did you mean to finish? If so, make sure you are completely done and then use the `complete` tool to end the session.</system>",
-            ),
-            Message("assistant", "Second response without tools"),
-        ]
-
-        manager = MagicMock()
-        manager.log = Log(messages)
-
-        # Should raise SessionCompleteException despite the two messages being
-        # different variants (regression guard for the shared marker).
         with pytest.raises(SessionCompleteException) as exc_info:
             list(auto_reply_hook(manager, interactive=False, prompt_queue=None))
 

--- a/tests/test_complete.py
+++ b/tests/test_complete.py
@@ -244,6 +244,45 @@ class TestTodoContinuationEnforcer:
 
         assert "2 auto-reply confirmations" in str(exc_info.value)
 
+    def test_two_auto_replies_mixed_variants_exits(self):
+        """Should exit after two no-tool replies even when the two auto-reply
+        messages are *different* variants.
+
+        Realistic production case: the first turn has incomplete todos, so the
+        reminder variant fires; the model then completes the todos but still
+        produces a tool-less response, so the confirm variant fires. Both
+        variants share the ``"No tool call detected in last message"`` marker,
+        so they must count toward the same exit threshold. This is the exact
+        cross-variant counting that gptme/gptme#2846 fixed — before that, the
+        two full-string markers were distinct and a mixed sequence undercounted
+        and never exited (infinite cycle).
+        """
+        messages = [
+            Message("assistant", "Working\n```shell\nls\n```"),
+            # First auto-reply: incomplete-todos (reminder) variant
+            Message(
+                "user",
+                "<system>No tool call detected in last message. You have incomplete todos:\n- Implement feature X (in_progress)\n\nPlease continue working on these tasks, or mark them complete/remove them before finishing.</system>",
+            ),
+            Message("assistant", "First response without tools"),
+            # Second auto-reply: confirm variant (todos now done, still no tools)
+            Message(
+                "user",
+                "<system>No tool call detected in last message. Did you mean to finish? If so, make sure you are completely done and then use the `complete` tool to end the session.</system>",
+            ),
+            Message("assistant", "Second response without tools"),
+        ]
+
+        manager = MagicMock()
+        manager.log = Log(messages)
+
+        # Should raise SessionCompleteException despite the two messages being
+        # different variants (regression guard for the shared marker).
+        with pytest.raises(SessionCompleteException) as exc_info:
+            list(auto_reply_hook(manager, interactive=False, prompt_queue=None))
+
+        assert "2 auto-reply confirmations" in str(exc_info.value)
+
     def test_auto_reply_without_incomplete_todos(self):
         """Should show normal message when no incomplete todos."""
         # Add only completed todos

--- a/webui/src/components/ConversationList.tsx
+++ b/webui/src/components/ConversationList.tsx
@@ -13,6 +13,7 @@ import {
   BookOpen,
   Columns2,
   X,
+  Star,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -38,6 +39,7 @@ import {
 } from '@/utils/exportConversation';
 import { DeleteConversationConfirmationDialog } from './DeleteConversationConfirmationDialog';
 
+import { useConversationMetadata } from '@/hooks/useConversationMetadata';
 import type { MessageRole, ConversationSummary } from '@/types/conversation';
 import { type FC, useRef, useEffect, useState, useCallback } from 'react';
 import { useSearchParams } from 'react-router-dom';
@@ -79,6 +81,22 @@ export const ConversationList: FC<Props> = ({
 }) => {
   const { api, isConnected$ } = useApi();
   const isConnected = use$(isConnected$);
+
+  const { toggleStar } = useConversationMetadata();
+  const [showStarredOnly, setShowStarredOnly] = useState(false);
+
+  // Separately track local star state for optimistic UI updates.
+  // Keyed by conversation ID, value is the optimistic starred value.
+  const [optimisticStars, setOptimisticStars] = useState<Record<string, boolean>>({});
+
+  // Determine effective starred state: optimistic (if set) > server state
+  const getIsStarred = useCallback(
+    (conv: ConversationSummary) => {
+      if (conv.id in optimisticStars) return optimisticStars[conv.id];
+      return conv.starred ?? false;
+    },
+    [optimisticStars]
+  );
 
   // Context menu state
   const [deleteTarget, setDeleteTarget] = useState<{ id: string; name: string } | null>(null);
@@ -421,6 +439,37 @@ export const ConversationList: FC<Props> = ({
                   />
                 ) : (
                   <div className="mb-1 flex items-center gap-2">
+                    {!demoIds.has(conv.id) && (
+                      <button
+                        className={`shrink-0 rounded p-0.5 transition-colors hover:text-yellow-500 focus:outline-none focus-visible:text-yellow-500 focus-visible:opacity-100 ${
+                          getIsStarred(conv)
+                            ? 'text-yellow-500 opacity-100'
+                            : 'text-muted-foreground opacity-0 focus-visible:opacity-100 group-hover:opacity-100'
+                        }`}
+                        onClick={async (e) => {
+                          e.stopPropagation();
+                          const newVal = !getIsStarred(conv);
+                          // Optimistic update
+                          setOptimisticStars((prev) => ({ ...prev, [conv.id]: newVal }));
+                          await toggleStar(conv.id, getIsStarred(conv));
+                          // Clear optimistic state on success (server state takes over)
+                          setOptimisticStars((prev) => {
+                            const next = { ...prev };
+                            delete next[conv.id];
+                            return next;
+                          });
+                        }}
+                        title={getIsStarred(conv) ? 'Unstar conversation' : 'Star conversation'}
+                        aria-label={
+                          getIsStarred(conv) ? 'Unstar conversation' : 'Star conversation'
+                        }
+                      >
+                        <Star
+                          className="h-3 w-3"
+                          fill={getIsStarred(conv) ? 'currentColor' : 'none'}
+                        />
+                      </button>
+                    )}
                     <div
                       data-testid="conversation-title"
                       className="font-small min-w-0 flex-1 whitespace-nowrap"
@@ -695,6 +744,25 @@ export const ConversationList: FC<Props> = ({
               Open in split view
             </ContextMenuItem>
           )}
+          {!demoIds.has(conv.id) && (
+            <ContextMenuItem
+              onClick={(e) => {
+                e.stopPropagation();
+                const newVal = !getIsStarred(conv);
+                setOptimisticStars((prev) => ({ ...prev, [conv.id]: newVal }));
+                toggleStar(conv.id, getIsStarred(conv)).then(() => {
+                  setOptimisticStars((prev) => {
+                    const next = { ...prev };
+                    delete next[conv.id];
+                    return next;
+                  });
+                });
+              }}
+            >
+              <Star className="mr-2 h-4 w-4" fill={getIsStarred(conv) ? 'currentColor' : 'none'} />
+              {getIsStarred(conv) ? 'Unstar' : 'Star'}
+            </ContextMenuItem>
+          )}
           <ContextMenuSeparator />
           <ContextMenuItem
             className="text-destructive focus:text-destructive"
@@ -713,7 +781,10 @@ export const ConversationList: FC<Props> = ({
     );
   };
 
-  const filteredRealConversations = realConversations.filter(matchesFilter);
+  // Filter by search query AND star state (when showStarredOnly is active)
+  const filteredRealConversations = realConversations.filter(
+    (c) => matchesFilter(c) && (!showStarredOnly || getIsStarred(c))
+  );
   const filteredDemos = demos.filter(matchesFilter);
   const hasFilter = normalizedFilter.length > 0;
   const hasNoFilteredMatches =
@@ -753,6 +824,24 @@ export const ConversationList: FC<Props> = ({
               </Button>
             )}
           </div>
+          {/* Star filter toggle */}
+          {realConversations.length > 0 && (
+            <div className="flex px-1 pt-1">
+              <button
+                aria-label={showStarredOnly ? 'Show all conversations' : 'Show starred only'}
+                aria-pressed={showStarredOnly}
+                className={`flex items-center gap-1 rounded px-2 py-0.5 text-xs transition-colors ${
+                  showStarredOnly
+                    ? 'bg-yellow-500/20 text-yellow-600 dark:text-yellow-400'
+                    : 'text-muted-foreground hover:text-foreground'
+                }`}
+                onClick={() => setShowStarredOnly((v) => !v)}
+              >
+                <Star className="h-3 w-3" fill={showStarredOnly ? 'currentColor' : 'none'} />
+                {showStarredOnly ? 'Starred' : 'All'}
+              </button>
+            </div>
+          )}
         </div>
       )}
       {isLoading && (

--- a/webui/src/components/ConversationList.tsx
+++ b/webui/src/components/ConversationList.tsx
@@ -405,7 +405,7 @@ export const ConversationList: FC<Props> = ({
               role="button"
               tabIndex={0}
               aria-pressed={isSelected}
-              className={`cursor-pointer rounded-lg py-2 pl-2 transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring ${
+              className={`group cursor-pointer rounded-lg py-2 pl-2 transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring ${
                 isSelected ? 'bg-accent' : ''
               }`}
               onClick={() => onSelect(conv.id, conv.serverId)}
@@ -788,7 +788,9 @@ export const ConversationList: FC<Props> = ({
   const filteredDemos = demos.filter(matchesFilter);
   const hasFilter = normalizedFilter.length > 0;
   const hasNoFilteredMatches =
-    hasFilter && filteredRealConversations.length === 0 && filteredDemos.length === 0;
+    (hasFilter || showStarredOnly) &&
+    filteredRealConversations.length === 0 &&
+    filteredDemos.length === 0;
 
   return (
     <div
@@ -874,7 +876,9 @@ export const ConversationList: FC<Props> = ({
       )}
       {!isLoading && !isError && hasNoFilteredMatches && (
         <div className="px-2 py-4 text-sm text-muted-foreground">
-          No conversations match your search.
+          {showStarredOnly && !hasFilter
+            ? 'No starred conversations.'
+            : 'No conversations match your search.'}
         </div>
       )}
 

--- a/webui/src/components/ConversationList.tsx
+++ b/webui/src/components/ConversationList.tsx
@@ -756,6 +756,13 @@ export const ConversationList: FC<Props> = ({
                     delete next[conv.id];
                     return next;
                   });
+                }).catch((err) => {
+                  console.error('Failed to toggle star from context menu:', err);
+                  setOptimisticStars((prev) => {
+                    const next = { ...prev };
+                    delete next[conv.id];
+                    return next;
+                  });
                 });
               }}
             >

--- a/webui/src/components/ConversationList.tsx
+++ b/webui/src/components/ConversationList.tsx
@@ -42,6 +42,7 @@ import { DeleteConversationConfirmationDialog } from './DeleteConversationConfir
 import { useConversationMetadata } from '@/hooks/useConversationMetadata';
 import type { MessageRole, ConversationSummary } from '@/types/conversation';
 import { type FC, useRef, useEffect, useState, useCallback } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import { useSearchParams } from 'react-router-dom';
 import { Computed, use$ } from '@legendapp/state/react';
 import { type Observable } from '@legendapp/state';
@@ -83,6 +84,7 @@ export const ConversationList: FC<Props> = ({
   const isConnected = use$(isConnected$);
 
   const { toggleStar } = useConversationMetadata();
+  const queryClient = useQueryClient();
   const [showStarredOnly, setShowStarredOnly] = useState(false);
 
   // Separately track local star state for optimistic UI updates.
@@ -452,7 +454,9 @@ export const ConversationList: FC<Props> = ({
                           // Optimistic update
                           setOptimisticStars((prev) => ({ ...prev, [conv.id]: newVal }));
                           await toggleStar(conv.id, getIsStarred(conv));
-                          // Clear optimistic state on success (server state takes over)
+                          // Invalidate cache so server state reflects the toggle before
+                          // the optimistic entry is cleared.
+                          await queryClient.invalidateQueries({ queryKey: ['conversations'] });
                           setOptimisticStars((prev) => {
                             const next = { ...prev };
                             delete next[conv.id];
@@ -750,20 +754,23 @@ export const ConversationList: FC<Props> = ({
                 e.stopPropagation();
                 const newVal = !getIsStarred(conv);
                 setOptimisticStars((prev) => ({ ...prev, [conv.id]: newVal }));
-                toggleStar(conv.id, getIsStarred(conv)).then(() => {
-                  setOptimisticStars((prev) => {
-                    const next = { ...prev };
-                    delete next[conv.id];
-                    return next;
+                toggleStar(conv.id, getIsStarred(conv))
+                  .then(async () => {
+                    await queryClient.invalidateQueries({ queryKey: ['conversations'] });
+                    setOptimisticStars((prev) => {
+                      const next = { ...prev };
+                      delete next[conv.id];
+                      return next;
+                    });
+                  })
+                  .catch((err) => {
+                    console.error('Failed to toggle star from context menu:', err);
+                    setOptimisticStars((prev) => {
+                      const next = { ...prev };
+                      delete next[conv.id];
+                      return next;
+                    });
                   });
-                }).catch((err) => {
-                  console.error('Failed to toggle star from context menu:', err);
-                  setOptimisticStars((prev) => {
-                    const next = { ...prev };
-                    delete next[conv.id];
-                    return next;
-                  });
-                });
               }}
             >
               <Star className="mr-2 h-4 w-4" fill={getIsStarred(conv) ? 'currentColor' : 'none'} />

--- a/webui/src/hooks/useConversationMetadata.ts
+++ b/webui/src/hooks/useConversationMetadata.ts
@@ -1,0 +1,52 @@
+import { useCallback } from 'react';
+import { useApi } from '@/contexts/ApiContext';
+
+/**
+ * Hook for managing conversation metadata (starred, description, tags) via
+ * the server-side metadata.toml sidecar API.
+ *
+ * Unlike the old localStorage approach, metadata persists across devices,
+ * browsers, and conversation file migration.
+ */
+export function useConversationMetadata() {
+  const { api } = useApi();
+
+  const toggleStar = useCallback(
+    async (conversationId: string, currentlyStarred: boolean): Promise<boolean> => {
+      try {
+        await api.patchConversationMetadata(conversationId, {
+          starred: !currentlyStarred,
+        });
+        return !currentlyStarred;
+      } catch (err) {
+        console.error('Failed to toggle star:', err);
+        return currentlyStarred; // revert on error
+      }
+    },
+    [api]
+  );
+
+  const updateDescription = useCallback(
+    async (conversationId: string, description: string | null): Promise<void> => {
+      try {
+        await api.patchConversationMetadata(conversationId, { description });
+      } catch (err) {
+        console.error('Failed to update description:', err);
+      }
+    },
+    [api]
+  );
+
+  const updateTags = useCallback(
+    async (conversationId: string, tags: string[] | null): Promise<void> => {
+      try {
+        await api.patchConversationMetadata(conversationId, { tags });
+      } catch (err) {
+        console.error('Failed to update tags:', err);
+      }
+    },
+    [api]
+  );
+
+  return { toggleStar, updateDescription, updateTags };
+}

--- a/webui/src/types/conversation.ts
+++ b/webui/src/types/conversation.ts
@@ -61,6 +61,11 @@ export interface ConversationSummary {
   total_output_tokens?: number;
   total_cache_read_tokens?: number;
   total_cache_creation_tokens?: number;
+  // Metadata sidecar fields (populated by server from metadata.toml)
+  starred?: boolean;
+  description?: string | null;
+  tags?: string[];
+  pinned_order?: number | null;
 }
 
 export interface GenerateCallbacks {

--- a/webui/src/utils/api.ts
+++ b/webui/src/utils/api.ts
@@ -1513,6 +1513,37 @@ export class ApiClient {
     );
   }
 
+  async patchConversationMetadata(
+    conversationId: string,
+    metadata: { starred?: boolean; description?: string | null; tags?: string[] | null }
+  ): Promise<void> {
+    if (!this.isConnected) {
+      throw new ApiClientError('Not connected to API');
+    }
+
+    await this.fetchJson<{ starred: boolean; description?: string | null; tags?: string[] }>(
+      `${this.baseUrl}/api/v2/conversations/${conversationId}/metadata`,
+      {
+        method: 'PATCH',
+        body: JSON.stringify(metadata),
+        signal: this.controller?.signal,
+      }
+    );
+  }
+
+  async getConversationMetadata(conversationId: string): Promise<{
+    starred: boolean;
+    description?: string | null;
+    tags?: string[];
+    pinned_order?: number | null;
+  }> {
+    if (!this.isConnected) {
+      throw new ApiClientError('Not connected to API');
+    }
+
+    return this.fetchJson(`${this.baseUrl}/api/v2/conversations/${conversationId}/metadata`);
+  }
+
   async deleteConversation(logfile: string): Promise<void> {
     if (!this.isConnected) {
       throw new ApiClientError('Not connected to API');

--- a/webui/src/utils/demoApiClient.ts
+++ b/webui/src/utils/demoApiClient.ts
@@ -369,6 +369,8 @@ export function createDemoApiClient(baseUrl: string = DEMO_BASE_URL): IApiClient
     },
     confirmTool: async () => {},
     deleteConversation: async () => {},
+    patchConversationMetadata: async () => {},
+    getConversationMetadata: async () => ({ starred: false }),
     createAgent: async () => notImpl('createAgent'),
     deleteSession: async () => {},
     getExternalSession: async () => notImpl('getExternalSession'),


### PR DESCRIPTION
## Problem

The starred/pinned conversations feature (PR #2836) was closed because localStorage-only persistence is not durable — it doesn't survive browser switches, device changes, or conversation file migrations.

## Solution

Replaces the old localStorage approach with proper server-side persistence through the metadata.toml sidecar API that was already built (Phase 1, see gptme/logmanager/metadata.py and the GET/PATCH /api/v2/conversations/{id}/metadata endpoints).

### Changes

- **ConversationSummary type**: Added starred, description, tags, pinned_order fields
- **ApiClient**: Added patchConversationMetadata() and getConversationMetadata() methods
- **useConversationMetadata hook**: New hook with toggleStar(), updateDescription(), updateTags() — all via PATCH API
- **ConversationList**: Star button on each conversation row (with optimistic UI), All/Starred filter toggle, Star/Unstar in context menu
- **DemoApiClient**: Stubbed the new methods

## Verification

- [x] TypeScript typecheck passes
- [x] All 463 unit tests pass (52 suites)
- [x] Pre-commit hooks pass

## Related

- gptme/gptme#2836 — original localStorage-only PR (closed)
- Server-side metadata API already on master (Phase 1)
