### PR TITLE
fix(webui): add semantic landmark roles and aria-current to navigation

### DIFF
--- a/webui/src/components/MainLayout.tsx
+++ b/webui/src/components/MainLayout.tsx
@@ -653,7 +653,7 @@ const MainLayout: FC<Props> = ({ conversationId, taskId }) => {
         </Sheet>
 
         {/* Main Content */}
-        <div className="flex-1 overflow-hidden">{renderMainContent()}</div>
+        <main className="flex-1 overflow-hidden" aria-label="Main content">{renderMainContent()}</main>
 
         {/* Right Sidebar - Sheet for mobile */}
         {currentSection === 'chat' && (
@@ -764,7 +764,7 @@ const MainLayout: FC<Props> = ({ conversationId, taskId }) => {
         <ResizableHandle />
 
         <ResizablePanel defaultSize={60} minSize={30} className="overflow-hidden">
-          {renderMainContent()}
+          <main className="h-full" aria-label="Main content">{renderMainContent()}</main>
         </ResizablePanel>
 
         {/* Conditional right sidebar for chat */}

--- a/webui/src/components/SidebarIcons.tsx
+++ b/webui/src/components/SidebarIcons.tsx
@@ -114,12 +114,13 @@ export const SidebarIcons: FC<Props> = ({ tasks }) => {
   ];
 
   return (
-    <div
+    <nav
       className={`hidden h-full flex-col overflow-hidden border-r bg-background transition-[width] duration-200 ease-in-out md:flex ${
         isExpanded ? 'w-44' : 'w-11'
       }`}
       data-testid="nav-sidebar"
       data-expanded={isExpanded}
+      aria-label="Main navigation"
     >
       {/* Navigation Items */}
       <div className="flex-shrink-0 space-y-1 p-1">
@@ -136,6 +137,7 @@ export const SidebarIcons: FC<Props> = ({ tasks }) => {
                     className="relative h-8 w-full min-w-0 justify-start gap-2 px-2"
                     onClick={() => handleNavigateToSection(section)}
                     aria-label={label}
+                    aria-current={isActive ? 'page' : undefined}
                   >
                     <Icon className="h-4 w-4 flex-shrink-0" />
                     <span
@@ -329,6 +331,6 @@ export const SidebarIcons: FC<Props> = ({ tasks }) => {
           </Tooltip>
         </TooltipProvider>
       </div>
-    </div>
+    </nav>
   );
 };


### PR DESCRIPTION
## Problem

gptme-webui lacks proper ARIA landmark roles, making screen reader navigation harder than necessary. The main content area has no `role="main"` and the navigation sidebar has no `role="navigation"` or `aria-label`. Active navigation items don't indicate their state to assistive technology.

## Solution

Three targeted changes based on a keyboard navigation audit:

1. **Nav sidebar**: Convert `<div>` to semantic `<nav>` with `aria-label="Main navigation"`
2. **Active nav items**: Add `aria-current="page"` to the currently active navigation button
3. **Main content**: Wrap in `<main>` element with `aria-label="Main content"` (both mobile and desktop layouts)

## Verification
- [x] TypeScript typecheck passes
- [x] All 463 unit tests pass (52 suites)
- [x] No visual regressions (structure-only changes)

## Related
- Keyboard navigation audit: ErikBjare/bob#862