### PR TITLE
perf(webui): split vendor chunks, memo ChatMessage

### DIFF
--- a/webui/src/components/ChatMessage.tsx
+++ b/webui/src/components/ChatMessage.tsx
@@ -1,4 +1,12 @@
-import { useCallback, useEffect, useRef, useState, useSyncExternalStore, type FC } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  useSyncExternalStore,
+  memo,
+  type FC,
+} from 'react';
 import type { Message, MessageMetadata, StreamingMessage } from '@/types/conversation';
 import { MessageAvatar } from './MessageAvatar';
 import { useMessageChainType } from '@/utils/messageUtils';
@@ -146,7 +154,7 @@ interface Props {
   messageIndex?: number;
 }
 
-export const ChatMessage: FC<Props> = ({
+const ChatMessageComponent: FC<Props> = ({
   message$,
   previousMessage$,
   nextMessage$,
@@ -753,3 +761,5 @@ export const ChatMessage: FC<Props> = ({
     </Memo>
   );
 };
+
+export const ChatMessage = memo(ChatMessageComponent);

--- a/webui/vite.config.ts
+++ b/webui/vite.config.ts
@@ -32,7 +32,20 @@ export default defineConfig(({ mode }) => ({
           },
       output: {
         manualChunks: {
-          vendor: ['react', 'react-dom', 'react-router-dom', '@tanstack/react-query'],
+          'vendor-react': ['react', 'react-dom', 'react-router-dom'],
+          'vendor-query': ['@tanstack/react-query'],
+          'vendor-legend': ['@legendapp/state'],
+          'vendor-radix': [
+            '@radix-ui/react-accordion',
+            '@radix-ui/react-dialog',
+            '@radix-ui/react-dropdown-menu',
+            '@radix-ui/react-popover',
+            '@radix-ui/react-select',
+            '@radix-ui/react-tabs',
+            '@radix-ui/react-tooltip',
+          ],
+          'vendor-icons': ['lucide-react'],
+          'vendor-recharts': ['recharts'],
         },
       },
     },


### PR DESCRIPTION
## Changes

- Split manualChunks into granular vendor buckets (react, query, legend, radix, icons, recharts) for better caching granularity
- Wrap ChatMessage with React.memo to prevent cascading re-renders on parent tree updates

Verified: `npm run build` passes cleanly.