### PR TITLE
feat(cli): add --no-workspace flag to skip all workspace context

### DIFF
--- a/docs/howto/minimal-context.md
+++ b/docs/howto/minimal-context.md
@@ -60,9 +60,33 @@ gptme --context files "review this module"
 gptme --context cmd "summarize the current repo status"
 ```
 
-This does **not** yet provide a full `--no-workspace` mode. If you want to skip
-project instructions entirely today, run gptme from a smaller workspace or a
-separate agent path.
+### 4. Skip workspace context entirely with `--no-workspace`
+
+Use `--no-workspace` to skip all project-specific context (prompt files **and**
+`context_cmd` output) in a single flag. Tools and the core assistant prompt are
+still included — only the workspace layer is stripped:
+
+```bash
+gptme --no-workspace "summarize this file: src/parser.py"
+```
+
+This is equivalent to `--context` with no items specified, and it is the right
+choice when:
+
+- You are running a specialized one-shot command that should not load project
+  instructions or dynamic context at all.
+- You want to compare baseline model behavior without workspace prompt influence.
+- You are inside a project with a heavy `context_cmd` and only need basic tools.
+
+Combine it with other levers for the minimal possible prompt:
+
+```bash
+gptme \
+  --no-workspace \
+  --system short \
+  --tools shell,read,patch,save \
+  "apply this patch and run the tests"
+```
 
 ## Good defaults for specialized sessions
 
@@ -98,6 +122,7 @@ Compare the before/after prompt surface instead of guessing:
 ```bash
 gptme --show-prompt-stats
 gptme --show-prompt-stats --system short --tools shell,read,patch,save --context files
+gptme --show-prompt-stats --no-workspace --system short --tools shell,read,patch,save
 ```
 
 If `prompt_workspace` or `prompt_context_cmd_project` still dominates, the next

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -187,6 +187,14 @@ system prompt, a narrow tool set, and selective context:
 
     gptme --system short --tools shell,read,patch,save --context files "fix the failing test"
 
+Use ``--no-workspace`` to skip all project-specific context (prompt files and
+``context_cmd`` output) in one flag — tools and the core prompt are still
+included:
+
+.. code-block:: bash
+
+    gptme --no-workspace --system short --tools shell,read,patch,save "apply this patch"
+
 Measure the prompt before and after with:
 
 .. code-block:: bash

--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -478,6 +478,12 @@ Run 'gptme-util --help' for all utility commands."""
     hidden=True,
 )
 @click.option(
+    "--no-workspace",
+    "no_workspace",
+    is_flag=True,
+    help="Skip all workspace context (prompt files and context_cmd). Tools and agent config are still included.",
+)
+@click.option(
     "--architect",
     "architect_enabled",
     is_flag=True,
@@ -536,6 +542,7 @@ def main(
     editor_model: str | None,
     auto_accept_architect: bool,
     context_include: tuple[str, ...],
+    no_workspace: bool,
     output_schema: str | None,
 ):
     """Main entrypoint for the CLI."""
@@ -820,7 +827,16 @@ def main(
                 raise click.UsageError(str(e)) from e
 
             stats_context_mode: ContextMode | None = (
-                "selective" if context_include else None
+                "selective" if (context_include or no_workspace) else None
+            )
+            stats_context_include: list[str] | None = (
+                []
+                if no_workspace
+                else (
+                    [item for val in context_include for item in val.split(",")]
+                    if context_include
+                    else None
+                )
             )
             stats = get_prompt_stats(
                 tools=tools,
@@ -831,11 +847,7 @@ def main(
                 workspace=stats_workspace_path,
                 agent_path=config.chat.agent,
                 context_mode=stats_context_mode,
-                context_include=[
-                    item for val in context_include for item in val.split(",")
-                ]
-                if context_include
-                else None,
+                context_include=stats_context_include,
             )
             extra_sections: list[PromptSectionStat] = []
             if selected_profile and selected_profile.system_prompt:
@@ -984,9 +996,18 @@ def main(
         logger.debug("Existing conversation found, skipping initial prompt generation")
         initial_msgs = []
     else:
-        # Infer context mode: --context-include implies selective mode
+        # Infer context mode: --context-include / --no-workspace both imply selective mode
         effective_context_mode: ContextMode | None = (
-            "selective" if context_include else None
+            "selective" if (context_include or no_workspace) else None
+        )
+        effective_context_include: list[str] | None = (
+            []
+            if no_workspace
+            else (
+                [item for val in context_include for item in val.split(",")]
+                if context_include
+                else None
+            )
         )
 
         # get initial system prompt
@@ -999,9 +1020,7 @@ def main(
             workspace=workspace_path,
             agent_path=config.chat.agent,
             context_mode=effective_context_mode,
-            context_include=[item for val in context_include for item in val.split(",")]
-            if context_include
-            else None,
+            context_include=effective_context_include,
         )
 
     # Append profile system prompt if using a profile

--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -552,6 +552,12 @@ def main(
     if not name or not name.strip():
         name = "random"
 
+    if no_workspace and context_include:
+        raise click.UsageError(
+            "--no-workspace and --context are mutually exclusive: "
+            "--no-workspace strips all workspace context, so --context values would be silently ignored."
+        )
+
     # Apply agent profile if specified
     selected_profile = None
     if agent_profile:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -148,6 +148,68 @@ def test_show_prompt_stats_exits_before_chat(monkeypatch, tmp_path: Path, runner
     assert seen["kwargs"]["model"] == "local/test"
 
 
+def test_no_workspace_flag_wires_correctly(monkeypatch, tmp_path: Path, runner):
+    """--no-workspace should pass context_mode=selective, context_include=[] to get_prompt_stats."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "state"))
+
+    fake_config = SimpleNamespace(
+        chat=SimpleNamespace(
+            agent_config=None,
+            tools=["shell", "read"],
+            interactive=False,
+            tool_format="markdown",
+            model="local/test",
+            workspace=tmp_path,
+            stream=False,
+            agent=None,
+        ),
+        project=None,
+    )
+    seen: dict[str, Any] = {}
+
+    monkeypatch.setattr(cli, "setup_config_from_cli", lambda **_: fake_config)
+    monkeypatch.setattr(cli, "init_tools", lambda _: [])
+    monkeypatch.setattr(
+        cli,
+        "get_prompt_stats",
+        lambda **kwargs: (
+            seen.update(kwargs=kwargs)
+            or SimpleNamespace(
+                sections=[],
+                total_messages=0,
+                total_chars=0,
+                total_tokens=0,
+                cacheable_tokens=0,
+                dynamic_tokens=0,
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        cli,
+        "format_prompt_stats",
+        lambda stats, header=None, extra_sections=None: "prompt-stats-output",
+    )
+    monkeypatch.setattr(cli, "chat", lambda *args, **kwargs: pytest.fail("chat ran"))
+    monkeypatch.setattr(cli, "init_telemetry", lambda **kwargs: None)
+
+    result = runner.invoke(
+        cli.main, ["--no-workspace", "--show-prompt-stats"], input=""
+    )
+
+    assert result.exit_code == 0, result.output
+    assert seen["kwargs"]["context_mode"] == "selective"
+    assert seen["kwargs"]["context_include"] == []
+
+
+def test_no_workspace_and_context_mutually_exclusive(runner):
+    """--no-workspace and --context together should produce a UsageError."""
+    result = runner.invoke(cli.main, ["--no-workspace", "--context", "files", "hello"])
+    assert result.exit_code != 0
+    assert "mutually exclusive" in result.output
+
+
 @pytest.mark.skipif(os.name == "nt", reason="SIGALRM-based pipe guard is POSIX-only")
 def test_read_stdin_open_pipe_without_data_returns_empty(monkeypatch):
     """An idle pipe should not block forever waiting for stdin bytes."""

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -143,6 +143,35 @@ def test_get_prompt_stats_includes_workspace_and_dynamic_context(tmp_path):
     assert stats.dynamic_tokens >= by_name["prompt_context_cmd_project"].tokens
 
 
+def test_no_workspace_excludes_workspace_context(tmp_path):
+    """Test that --no-workspace (selective mode, empty include) skips files and context_cmd."""
+    workspace = tmp_path / "project"
+    workspace.mkdir()
+    (workspace / "README.md").write_text("# No-Workspace Test")
+    (workspace / "gptme.toml").write_text(
+        '[prompt]\nfiles = ["README.md"]\ncontext_cmd = "echo NO_WORKSPACE_MARKER"\n'
+    )
+
+    # Simulate --no-workspace: selective mode with empty include list
+    stats = get_prompt_stats(
+        get_tools(),
+        prompt="full",
+        workspace=workspace,
+        context_mode="selective",
+        context_include=[],
+    )
+
+    by_name = {section.name: section for section in stats.sections}
+    assert "prompt_workspace" not in by_name, (
+        "workspace files should be absent with --no-workspace"
+    )
+    assert "prompt_context_cmd_project" not in by_name, (
+        "context_cmd should be absent with --no-workspace"
+    )
+    assert "prompt_tools" in by_name, "tools should still be included"
+    assert "prompt_gptme" in by_name, "core gptme prompt should still be included"
+
+
 def test_format_prompt_stats_outputs_summary_table():
     stats = get_prompt_stats(
         get_tools(),


### PR DESCRIPTION
## Summary

- Adds `--no-workspace` as a first-class CLI flag to skip prompt files and `context_cmd` output in one flag, without manual workspace juggling
- Equivalent to selective mode with an empty include set: tools and the core gptme prompt are still included, only the workspace layer is stripped
- Updates `docs/howto/minimal-context.md` to document `--no-workspace` and remove the stale "not yet available" note
- Adds test in `tests/test_prompts.py` verifying workspace/context_cmd sections are absent with the flag

## Motivation

The minimal-context howto shipped in #2843 explicitly called out `--no-workspace` as missing. This PR closes that gap. Use cases:
- Specialized one-shot commands that should ignore project instructions
- Baseline comparisons without workspace prompt influence
- Projects with heavy `context_cmd` when you only need basic tools

## Usage

```bash
# Skip all workspace context in one flag
gptme --no-workspace "summarize this file: src/parser.py"

# Combine with other minimal-context levers
gptme --no-workspace --system short --tools shell,read,patch,save "apply this patch"
```

## Test plan

- [x] `uv run pytest tests/test_prompts.py tests/test_cli.py` — 106 passed, 8 skipped
- [x] `test_no_workspace_excludes_workspace_context` verifies workspace + context_cmd sections absent, tools + core still present