### PR TITLE
fix(server): scope conversations cache to active logs dir

### DIFF
--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -62,6 +62,7 @@ from ..config.user import (
 )
 from ..dirs import get_logs_dir
 from ..logmanager import ConversationMeta, Log, LogManager, get_user_conversations
+from ..logmanager import conversations as conversations_module
 from ..message import Message
 from ..tools import get_toolchain, get_tools, init_tools
 from ..util.content import is_message_command
@@ -880,9 +881,19 @@ def api_conversations():
     detail = detail_val is not None and detail_val.lower() in ("", "1", "true", "yes")
 
     # Use cached list for the common case (no search, no detail).
-    # Cache is invalidated on conversation create/update/delete.
-    global _conversations_cache, _conversations_cache_time
-    if not search and not detail and _conversations_cache is not None:
+    # Cache is invalidated on conversation create/update/delete and scoped to
+    # the current logs dir so test/workspace swaps do not reuse stale results.
+    global \
+        _conversations_cache, \
+        _conversations_cache_logs_dir, \
+        _conversations_cache_time
+    logs_dir = conversations_module.get_logs_dir()
+    if (
+        not search
+        and not detail
+        and _conversations_cache is not None
+        and _conversations_cache_logs_dir == logs_dir
+    ):
         elapsed = time.monotonic() - _conversations_cache_time
         if elapsed < _CONVERSATIONS_CACHE_TTL:
             cached = _conversations_cache
@@ -925,6 +936,7 @@ def api_conversations():
     # a higher limit return the correct number of items (not truncated).
     if not search and not detail:
         _conversations_cache = all_conversations
+        _conversations_cache_logs_dir = logs_dir
         _conversations_cache_time = time.monotonic()
 
     return flask.jsonify(response_items)
@@ -2681,11 +2693,16 @@ _CONVERSATIONS_CACHE_TTL = (
     30.0  # seconds — covers page navigation refresh within a session
 )
 _conversations_cache: list[ConversationMeta] | None = None
+_conversations_cache_logs_dir: Path | None = None
 _conversations_cache_time: float = 0.0
 
 
 def _invalidate_conversations_cache() -> None:
     """Invalidate the conversations list cache."""
-    global _conversations_cache, _conversations_cache_time
+    global \
+        _conversations_cache, \
+        _conversations_cache_logs_dir, \
+        _conversations_cache_time
     _conversations_cache = None
+    _conversations_cache_logs_dir = None
     _conversations_cache_time = 0.0

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -171,6 +171,23 @@ def test_api_conversation_list_detail_flag(client: FlaskClient, tmp_path, monkey
     """Test that detail=true returns cost/token stats while default (false) zeroes them."""
     import json
 
+    import gptme.server.api_v2 as api_v2_module
+
+    api_v2_module._invalidate_conversations_cache()
+
+    empty_logs_dir = tmp_path / "empty-logs"
+    empty_logs_dir.mkdir()
+
+    # Prime the list cache against a different logs dir first. Without scoping
+    # the cache to the active logs dir, the second request below reuses the
+    # stale empty result instead of scanning the populated tmp_path.
+    monkeypatch.setattr(
+        "gptme.logmanager.conversations.get_logs_dir", lambda: empty_logs_dir
+    )
+    response = client.get("/api/v2/conversations")
+    assert response.status_code == 200
+    assert response.get_json() == []
+
     monkeypatch.setattr("gptme.logmanager.conversations.get_logs_dir", lambda: tmp_path)
 
     # Create a conversation with an assistant message that carries usage info


### PR DESCRIPTION
## Summary

The original webui page-load request reduction work from this branch was superseded by `#2857`, so this PR has been rebased onto current `master` and narrowed to the remaining real issue exposed by CI.

The server-side conversations list cache was process-global but not scoped to the active logs directory. If the logs root changes within the same process, cached results from the previous directory can be reused incorrectly.

This PR now:
- scopes the `/api/v2/conversations` cache to the active logs dir
- clears the logs-dir marker when invalidating the cache
- adds a regression test that primes the cache on one logs dir and verifies a second logs dir does not reuse the stale result

## Verification

- `python -m ruff check gptme/server/api_v2.py tests/test_server.py`
- `python -m pytest -q tests/test_server.py`

## Context

- `#2857` already landed the broader webui request-reduction changes that originally motivated this branch
- this PR keeps the remaining cache-scope fix instead of carrying stale overlap