### PR TITLE
docs(howto): remove inaccurate --no-workspace equivalence claim

### DIFF
--- a/docs/howto/minimal-context.md
+++ b/docs/howto/minimal-context.md
@@ -70,8 +70,7 @@ still included — only the workspace layer is stripped:
 gptme --no-workspace "summarize this file: src/parser.py"
 ```
 
-This is equivalent to `--context` with no items specified, and it is the right
-choice when:
+It is the right choice when:
 
 - You are running a specialized one-shot command that should not load project
   instructions or dynamic context at all.


### PR DESCRIPTION
## Summary

- Removes the claim that `--no-workspace` is "equivalent to `--context` with no items specified"

The `--context` flag accepts explicit choices (`files`, `cmd`, `all`). "No items specified" means not passing `--context` at all, which defaults to full workspace context. `--no-workspace` is the *opposite* — it strips all workspace context. The claim was inaccurate.

The preceding sentence already accurately describes `--no-workspace` behavior, so the equivalence clause was both wrong and redundant.

Flagged by Greptile on #2853 before merge (Erik merged with 5/5 score, but the doc fix is still worth doing).

## Test plan

- [ ] Verify the docs render cleanly (`cd docs && make html` or similar)
- [ ] No behavior changes — docs only