### PR TITLE
fix(server): preserve messages field on cached conversation list responses

### DIFF
--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -899,7 +899,7 @@ def api_conversations():
             cached = _conversations_cache
             response_items = [asdict(c) for c in cached[:limit]]
             for item in response_items:
-                item["message_count"] = item.pop("messages")
+                item["message_count"] = item["messages"]
                 item["last_updated"] = item["modified"]
             return flask.jsonify(response_items)
 

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -95,7 +95,9 @@ def test_get_prompt_selective_components():
     assert len(full_mode) >= len(empty_selective)
 
 
-def test_get_prompt_stats_breaks_out_sections():
+def test_get_prompt_stats_breaks_out_sections(monkeypatch):
+    monkeypatch.chdir(Path(__file__).resolve().parents[1])
+
     stats = get_prompt_stats(
         get_tools(),
         prompt="full",

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -1337,6 +1337,13 @@ def test_v2_conversations_list_keeps_messages_on_cache_hit(client: FlaskClient):
     assert matching, f"created conversation {convname} not in cached list"
     item = matching[0]
     assert "messages" in item, "cached fast-mode response must keep `messages`"
+    assert "message_count" in item, (
+        "cached fast-mode response must include `message_count` alias"
+    )
+    assert "last_updated" in item, (
+        "cached fast-mode response must include `last_updated` alias"
+    )
+    assert "modified" in item, "cached fast-mode response must keep `modified`"
     assert item["messages"] == item["message_count"]
     assert item["modified"] == item["last_updated"]
 

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -1318,6 +1318,29 @@ def test_v2_conversations_list_keeps_messages_in_fast_mode(
     assert item["message_count"] >= 1  # at least the system prompt
 
 
+def test_v2_conversations_list_keeps_messages_on_cache_hit(client: FlaskClient):
+    """Regression: cached fast-mode responses must preserve ``messages``."""
+    convname = f"msglist-cache-hit-{random.randint(0, 1000000)}"
+    response = client.put(
+        f"/api/v2/conversations/{convname}",
+        json={"prompt": "You are an AI assistant for testing."},
+    )
+    assert response.status_code == 200
+
+    response = client.get("/api/v2/conversations")
+    assert response.status_code == 200
+
+    response = client.get("/api/v2/conversations")
+    assert response.status_code == 200
+    data = response.get_json()
+    matching = [c for c in data if c["id"] == convname]
+    assert matching, f"created conversation {convname} not in cached list"
+    item = matching[0]
+    assert "messages" in item, "cached fast-mode response must keep `messages`"
+    assert item["messages"] == item["message_count"]
+    assert item["modified"] == item["last_updated"]
+
+
 def test_v2_conversation_get(v2_conv, client: FlaskClient):
     """Test getting a V2 conversation."""
     conversation_id = v2_conv["conversation_id"]


### PR DESCRIPTION
## Summary
- preserve the legacy `messages` count field on cached `/api/v2/conversations` responses
- keep `message_count` as a stable alias instead of destructively popping `messages`
- add a regression test that performs two list requests so the warm-cache path is exercised

## Why
The conversations list cache introduced by #2857 returns a different response shape on cache hits than on cold requests. The second request drops `messages` because the cache-hit serializer does `item.pop("messages")`. The webui still reads `conv.messages` in multiple places, so warm-cache responses silently lose the badge/count data.

This is the follow-up fix for the last Greptile finding on superseded PR #2855. The bug exists on current `master` because the cache code landed through #2857.

## Testing
- `PYTHONPATH=/tmp/worktrees/gptme-master-cache-shape /home/bob/gptme/.venv/bin/pytest tests/test_server_v2.py::test_v2_conversations_list tests/test_server_v2.py::test_v2_conversations_list_exposes_message_count_and_last_updated tests/test_server_v2.py::test_v2_conversations_list_keeps_messages_in_fast_mode tests/test_server_v2.py::test_v2_conversations_list_keeps_messages_on_cache_hit -q`
