### PR TITLE
feat(server): cursor-based pagination for conversations list

### DIFF
--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -855,6 +855,18 @@ def api_external_session(external_session_id: str):
             "schema": {"type": "boolean", "default": False},
             "description": "If true, perform a full scan to populate cost and token stats. Slower but returns accurate total_cost, total_input_tokens, and total_output_tokens fields. Suitable for paginated views; avoid on large collections. When combined with search, every conversation is fully scanned before the limit is applied — avoid on large deployments.",
         },
+        {
+            "name": "cursor",
+            "in": "query",
+            "schema": {"type": "number"},
+            "description": "Unix timestamp cursor for pagination. When combined with paginated=1, returns conversations with modified < cursor (i.e. older than the cursor). Omit for the first page.",
+        },
+        {
+            "name": "paginated",
+            "in": "query",
+            "schema": {"type": "boolean", "default": False},
+            "description": "If true, return a paginated response object {conversations: [...], next_cursor: number|null} instead of a bare list. Use cursor param for page 2+.",
+        },
     ],
 )
 def api_conversations():
@@ -870,6 +882,10 @@ def api_conversations():
     user/assistant turn. ``message_count`` and ``last_updated`` are always
     populated (cheap fast-tail scan), so list-level UIs can render a stats
     badge without per-row detail fetches.
+
+    Pass ``paginated=1`` to opt into cursor pagination: the response becomes
+    ``{conversations: [...], next_cursor: float|null}``. Pass ``cursor=<ts>``
+    on page 2+ to fetch conversations older than that Unix timestamp.
     """
     try:
         limit = int(request.args.get("limit", 100))
@@ -879,15 +895,87 @@ def api_conversations():
     search = request.args.get("search", "").strip().lower()
     detail_val = request.args.get("detail")
     detail = detail_val is not None and detail_val.lower() in ("", "1", "true", "yes")
+    paginated_val = request.args.get("paginated")
+    paginated = paginated_val is not None and paginated_val.lower() in (
+        "",
+        "1",
+        "true",
+        "yes",
+    )
+    cursor_raw = request.args.get("cursor")
+    cursor_ts: float | None = None
+    if cursor_raw:
+        try:
+            cursor_ts = float(cursor_raw)
+        except (ValueError, TypeError):
+            return flask.jsonify(
+                {"error": "cursor must be a numeric Unix timestamp"}
+            ), 400
 
-    # Use cached list for the common case (no search, no detail).
-    # Cache is invalidated on conversation create/update/delete and scoped to
-    # the current logs dir so test/workspace swaps do not reuse stale results.
     global \
         _conversations_cache, \
         _conversations_cache_logs_dir, \
         _conversations_cache_time
     logs_dir = conversations_module.get_logs_dir()
+
+    # Cursor pagination path — returns {conversations: [...], next_cursor: float|null}
+    if paginated:
+        # Load full list (use cache when possible for the common non-search, non-detail case)
+        full_list: list[ConversationMeta]
+        if not search and not detail:
+            _cached = _conversations_cache
+            if (
+                _cached is not None
+                and _conversations_cache_logs_dir == logs_dir
+                and (time.monotonic() - _conversations_cache_time)
+                < _CONVERSATIONS_CACHE_TTL
+            ):
+                full_list = _cached
+            else:
+                full_list = list(get_user_conversations(detail=False))
+                _conversations_cache = full_list
+                _conversations_cache_logs_dir = logs_dir
+                _conversations_cache_time = time.monotonic()
+        elif search:
+            full_list = [
+                conv
+                for conv in get_user_conversations(detail=detail)
+                if (
+                    search in conv.name.lower()
+                    or search in conv.id.lower()
+                    or search in (conv.last_message_preview or "").lower()
+                )
+            ]
+        else:
+            full_list = list(get_user_conversations(detail=detail))
+
+        # Apply cursor filter: return conversations older than the cursor timestamp
+        if cursor_ts is not None:
+            paged = [c for c in full_list if c.modified < cursor_ts]
+        else:
+            paged = full_list
+
+        # Fetch limit+1 to detect whether a next page exists
+        probe = paged[: limit + 1]
+        has_more = len(probe) > limit
+        page = probe[:limit]
+
+        page_items = []
+        for conv in page:
+            item = asdict(conv)
+            item["message_count"] = conv.messages
+            item["last_updated"] = conv.modified
+            page_items.append(item)
+
+        # next_cursor = modified of the oldest item in this page (used as cursor for next request)
+        next_cursor: float | None = page[-1].modified if has_more and page else None
+
+        return flask.jsonify({"conversations": page_items, "next_cursor": next_cursor})
+
+    # Legacy path — returns bare list (backward compatible)
+    # Use cached list for the common case (no search, no detail).
+    # Cache is invalidated on conversation create/update/delete and scoped to
+    # the current logs dir so test/workspace swaps do not reuse stale results.
     if (
         not search
         and not detail

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -118,6 +118,27 @@ _ALLOWED_AVATAR_EXTS = {".jpg", ".jpeg", ".png", ".gif", ".webp", ".ico"}
 # - delete (without --force): calls input() waiting for stdin that never arrives
 _SERVER_BLOCKED_COMMANDS = {"exit", "restart", "edit", "delete"}
 
+
+def _parse_conversation_cursor(raw: str) -> tuple[float, str | None]:
+    """Parse a conversation pagination cursor.
+
+    Supports both the legacy numeric timestamp cursor and the opaque composite
+    cursor returned by the paginated API: ``<modified>|<quoted-conversation-id>``.
+    """
+    if "|" not in raw:
+        return float(raw), None
+
+    modified_raw, quoted_conv_id = raw.split("|", 1)
+    if not quoted_conv_id:
+        raise ValueError("missing conversation id")
+    return float(modified_raw), urllib.parse.unquote(quoted_conv_id)
+
+
+def _encode_conversation_cursor(conv: ConversationMeta) -> str:
+    """Encode a stable pagination cursor for a conversation."""
+    return f"{conv.modified:.17g}|{urllib.parse.quote(conv.id, safe='')}"
+
+
 _TRUTHY_ENV_VALUES = {"1", "true", "yes", "on"}
 _DEFAULT_OPENROUTER_STT_MODEL = "openai/whisper-1"
 _MAX_TRANSCRIPTION_AUDIO_BYTES = 25 * 1024 * 1024
@@ -858,14 +879,14 @@ def api_external_session(external_session_id: str):
         {
             "name": "cursor",
             "in": "query",
-            "schema": {"type": "number"},
-            "description": "Unix timestamp cursor for pagination. When combined with paginated=1, returns conversations with modified < cursor (i.e. older than the cursor). Omit for the first page.",
+            "schema": {"type": "string"},
+            "description": "Opaque pagination cursor returned by the previous paginated response. New clients should pass it through unchanged; legacy numeric Unix timestamp cursors are still accepted.",
         },
         {
             "name": "paginated",
             "in": "query",
             "schema": {"type": "boolean", "default": False},
-            "description": "If true, return a paginated response object {conversations: [...], next_cursor: number|null} instead of a bare list. Use cursor param for page 2+.",
+            "description": "If true, return a paginated response object {conversations: [...], next_cursor: string|null} instead of a bare list. Use cursor param for page 2+.",
         },
     ],
 )
@@ -884,8 +905,8 @@ def api_conversations():
     badge without per-row detail fetches.
 
     Pass ``paginated=1`` to opt into cursor pagination: the response becomes
-    ``{conversations: [...], next_cursor: float|null}``. Pass ``cursor=<ts>``
-    on page 2+ to fetch conversations older than that Unix timestamp.
+    ``{conversations: [...], next_cursor: string|null}``. Pass the returned
+    cursor back unchanged on page 2+.
     """
     try:
         limit = int(request.args.get("limit", 100))
@@ -904,12 +925,15 @@ def api_conversations():
     )
     cursor_raw = request.args.get("cursor")
     cursor_ts: float | None = None
+    cursor_id: str | None = None
     if cursor_raw:
         try:
-            cursor_ts = float(cursor_raw)
+            cursor_ts, cursor_id = _parse_conversation_cursor(cursor_raw)
         except (ValueError, TypeError):
             return flask.jsonify(
-                {"error": "cursor must be a numeric Unix timestamp"}
+                {
+                    "error": "cursor must be a numeric Unix timestamp or opaque cursor token"
+                }
             ), 400
 
     global \
@@ -918,7 +942,7 @@ def api_conversations():
         _conversations_cache_time
     logs_dir = conversations_module.get_logs_dir()
 
-    # Cursor pagination path — returns {conversations: [...], next_cursor: float|null}
+    # Cursor pagination path — returns {conversations: [...], next_cursor: string|null}
     if paginated:
         # Load full list (use cache when possible for the common non-search, non-detail case)
         full_list: list[ConversationMeta]
@@ -949,9 +973,21 @@ def api_conversations():
         else:
             full_list = list(get_user_conversations(detail=detail))
 
-        # Apply cursor filter: return conversations older than the cursor timestamp
+        # Keep pagination deterministic even when multiple conversations share
+        # the same modified timestamp.
+        full_list = sorted(
+            full_list, key=lambda conv: (conv.modified, conv.id), reverse=True
+        )
+
+        # Apply cursor filter: composite cursors paginate on (modified, id),
+        # legacy numeric cursors fall back to timestamp-only filtering.
         if cursor_ts is not None:
-            paged = [c for c in full_list if c.modified < cursor_ts]
+            if cursor_id is None:
+                paged = [c for c in full_list if c.modified < cursor_ts]
+            else:
+                paged = [
+                    c for c in full_list if (c.modified, c.id) < (cursor_ts, cursor_id)
+                ]
         else:
             paged = full_list
 
@@ -967,8 +1003,9 @@ def api_conversations():
             item["last_updated"] = conv.modified
             page_items.append(item)
 
-        # next_cursor = modified of the oldest item in this page (used as cursor for next request)
-        next_cursor: float | None = page[-1].modified if has_more and page else None
+        next_cursor: str | None = (
+            _encode_conversation_cursor(page[-1]) if has_more and page else None
+        )
 
         return flask.jsonify({"conversations": page_items, "next_cursor": next_cursor})
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2,6 +2,7 @@ import copy
 import random
 import threading
 import time
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
@@ -99,6 +100,64 @@ def test_api_conversation_list_with_limit(client: FlaskClient):
     data = response.get_json()
     assert isinstance(data, list)
     assert len(data) <= 5
+
+
+def test_api_conversation_list_paginated_cursor_preserves_equal_timestamps(
+    client: FlaskClient, monkeypatch
+):
+    """Composite cursors must not drop conversations at equal-timestamp page boundaries."""
+    import gptme.server.api_v2 as api_v2_module
+    from gptme.logmanager import ConversationMeta
+
+    api_v2_module._invalidate_conversations_cache()
+
+    base = ConversationMeta(
+        id="seed",
+        name="seed",
+        path="/tmp/seed/conversation.jsonl",
+        created=0.0,
+        modified=0.0,
+        messages=1,
+        branches=1,
+        workspace="",
+        agent_name=None,
+        agent_path=None,
+        agent_avatar=None,
+        agent_urls=None,
+        model=None,
+        total_cost=0.0,
+        total_input_tokens=0,
+        total_output_tokens=0,
+        total_cache_read_tokens=0,
+        last_message_role="user",
+        last_message_preview="preview",
+    )
+    conversations = [
+        replace(base, id="c", name="c", modified=99.0),
+        replace(base, id="b", name="b", modified=99.0),
+        replace(base, id="a", name="a", modified=99.0),
+        replace(base, id="d", name="d", modified=98.0),
+    ]
+
+    monkeypatch.setattr(
+        api_v2_module,
+        "get_user_conversations",
+        lambda detail=False: iter(conversations),
+    )
+
+    page1 = client.get("/api/v2/conversations?paginated=1&limit=2")
+    assert page1.status_code == 200
+    page1_data = page1.get_json()
+    assert [item["id"] for item in page1_data["conversations"]] == ["c", "b"]
+    assert page1_data["next_cursor"] == "99|b"
+
+    page2 = client.get(
+        f"/api/v2/conversations?paginated=1&limit=2&cursor={page1_data['next_cursor']}"
+    )
+    assert page2.status_code == 200
+    page2_data = page2.get_json()
+    assert [item["id"] for item in page2_data["conversations"]] == ["a", "d"]
+    assert page2_data["next_cursor"] is None
 
 
 def test_api_conversation_search(client: FlaskClient, tmp_path, monkeypatch):

--- a/webui/src/components/HistoryView.tsx
+++ b/webui/src/components/HistoryView.tsx
@@ -34,8 +34,7 @@ function useAllConversations() {
   return useQuery({
     queryKey: ['conversations-all', connectionConfig.baseUrl, isConnected],
     queryFn: async () => {
-      const result = await api.getConversationsPaginated(0, 100000, true);
-      return result.conversations;
+      return await api.getConversations(100000, true);
     },
     enabled: isConnected,
     staleTime: 60 * 1000,

--- a/webui/src/components/MainLayout.tsx
+++ b/webui/src/components/MainLayout.tsx
@@ -31,11 +31,7 @@ import { Loader2, GitBranch, Columns2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import type { ConversationSummary } from '@/types/conversation';
 import type { Task, CreateTaskRequest } from '@/types/task';
-import {
-  selectedConversation$,
-  initConversation,
-  conversations$,
-} from '@/stores/conversations';
+import { selectedConversation$, initConversation, conversations$ } from '@/stores/conversations';
 import {
   leftSidebarVisible$,
   rightSidebarVisible$,
@@ -181,7 +177,7 @@ const MainLayout: FC<Props> = ({ conversationId, taskId }) => {
     const primaryServer = registry.servers.find((s) => s.id === registry.activeServerId);
     const all =
       data?.pages.flatMap(
-        (page: { conversations: ConversationSummary[]; nextCursor: number | undefined }) =>
+        (page: { conversations: ConversationSummary[]; nextCursor: string | undefined }) =>
           page.conversations.map((conv) => ({
             ...conv,
             serverId: registry.activeServerId,
@@ -217,7 +213,6 @@ const MainLayout: FC<Props> = ({ conversationId, taskId }) => {
     if (!isConnected) return [];
     return apiConversations;
   }, [isConnected, apiConversations]);
-
 
   // Reactive computation for store conversations using Legend State
   const storeConversations$ = useObservable(() => {

--- a/webui/src/hooks/useConversationsInfiniteQuery.ts
+++ b/webui/src/hooks/useConversationsInfiniteQuery.ts
@@ -13,20 +13,18 @@ export function useConversationsInfiniteQuery(enabled: boolean = true) {
     // already controls when the query fires. staleTime=30s prevents redundant
     // refetches within a fresh window (common during auto-connect handshake).
     queryKey: ['conversations', connectionConfig.baseUrl],
-    queryFn: async ({ pageParam }: { pageParam: number | undefined }) => {
+    queryFn: async ({ pageParam }: { pageParam: string | undefined }) => {
       try {
-        const result = await api.getConversationsPaginated(pageParam, 50);
-        console.log('Fetched conversations page:', result);
-        return result;
+        return await api.getConversationsPaginated(pageParam, 50);
       } catch (err) {
         console.error('Failed to fetch conversations:', err);
         throw err;
       }
     },
-    initialPageParam: undefined as number | undefined,
+    initialPageParam: undefined as string | undefined,
     getNextPageParam: (lastPage: {
       conversations: ConversationSummary[];
-      nextCursor: number | undefined;
+      nextCursor: string | undefined;
     }) => lastPage.nextCursor,
     enabled: isConnected && enabled,
     staleTime: 30_000,

--- a/webui/src/hooks/useConversationsInfiniteQuery.ts
+++ b/webui/src/hooks/useConversationsInfiniteQuery.ts
@@ -13,7 +13,7 @@ export function useConversationsInfiniteQuery(enabled: boolean = true) {
     // already controls when the query fires. staleTime=30s prevents redundant
     // refetches within a fresh window (common during auto-connect handshake).
     queryKey: ['conversations', connectionConfig.baseUrl],
-    queryFn: async ({ pageParam }: { pageParam: number }) => {
+    queryFn: async ({ pageParam }: { pageParam: number | undefined }) => {
       try {
         const result = await api.getConversationsPaginated(pageParam, 50);
         console.log('Fetched conversations page:', result);
@@ -23,7 +23,7 @@ export function useConversationsInfiniteQuery(enabled: boolean = true) {
         throw err;
       }
     },
-    initialPageParam: 0,
+    initialPageParam: undefined as number | undefined,
     getNextPageParam: (lastPage: {
       conversations: ConversationSummary[];
       nextCursor: number | undefined;

--- a/webui/src/hooks/useMultiServerConversations.ts
+++ b/webui/src/hooks/useMultiServerConversations.ts
@@ -29,7 +29,7 @@ export function useSecondaryServerConversations() {
         if (!client) return [];
 
         try {
-          const result = await client.getConversationsPaginated(0, 50);
+          const result = await client.getConversationsPaginated(undefined, 50);
           return result.conversations.map((conv) => ({
             ...conv,
             serverId: server.id,

--- a/webui/src/utils/__tests__/api.test.ts
+++ b/webui/src/utils/__tests__/api.test.ts
@@ -246,7 +246,7 @@ describe('ApiClient conversation list detail flag', () => {
     // First page with detail
     await client.getConversationsPaginated(undefined, 50, true);
     // Second page with cursor
-    await client.getConversationsPaginated(1717500000, 50);
+    await client.getConversationsPaginated('1717500000|conv-123', 50);
 
     expect(global.fetch).toHaveBeenNthCalledWith(
       1,
@@ -260,7 +260,7 @@ describe('ApiClient conversation list detail flag', () => {
     );
     expect(global.fetch).toHaveBeenNthCalledWith(
       3,
-      'http://127.0.0.1:5700/api/v2/conversations?limit=50&paginated=1&detail=false&cursor=1717500000',
+      'http://127.0.0.1:5700/api/v2/conversations?limit=50&paginated=1&detail=false&cursor=1717500000%7Cconv-123',
       expect.any(Object)
     );
   });

--- a/webui/src/utils/__tests__/api.test.ts
+++ b/webui/src/utils/__tests__/api.test.ts
@@ -230,27 +230,37 @@ describe('ApiClient conversation list detail flag', () => {
     jest.restoreAllMocks();
   });
 
-  it('requests paginated conversation lists with detail=false by default', async () => {
+  it('requests paginated conversation lists with cursor pagination', async () => {
+    const mockResponse = { conversations: [], next_cursor: null };
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,
       status: 200,
-      json: async () => [],
+      json: async () => mockResponse,
     } as Response);
 
     const client = new ApiClient('http://127.0.0.1:5700');
     client.setConnected(true);
 
-    await client.getConversationsPaginated(0, 50);
-    await client.getConversationsPaginated(0, 50, true);
+    // First page (no cursor)
+    await client.getConversationsPaginated(undefined, 50);
+    // First page with detail
+    await client.getConversationsPaginated(undefined, 50, true);
+    // Second page with cursor
+    await client.getConversationsPaginated(1717500000, 50);
 
     expect(global.fetch).toHaveBeenNthCalledWith(
       1,
-      'http://127.0.0.1:5700/api/v2/conversations?limit=51&detail=false',
+      'http://127.0.0.1:5700/api/v2/conversations?limit=50&paginated=1&detail=false',
       expect.any(Object)
     );
     expect(global.fetch).toHaveBeenNthCalledWith(
       2,
-      'http://127.0.0.1:5700/api/v2/conversations?limit=51&detail=true',
+      'http://127.0.0.1:5700/api/v2/conversations?limit=50&paginated=1&detail=true',
+      expect.any(Object)
+    );
+    expect(global.fetch).toHaveBeenNthCalledWith(
+      3,
+      'http://127.0.0.1:5700/api/v2/conversations?limit=50&paginated=1&detail=false&cursor=1717500000',
       expect.any(Object)
     );
   });

--- a/webui/src/utils/api.ts
+++ b/webui/src/utils/api.ts
@@ -979,8 +979,8 @@ export class ApiClient {
   }
 
   async getConversationsPaginated(
-    pageParam: number = 0,
-    pageSize: number = 20,
+    cursor: number | undefined = undefined,
+    pageSize: number = 50,
     detail: boolean = false
   ): Promise<{
     conversations: ConversationSummary[];
@@ -990,24 +990,22 @@ export class ApiClient {
       throw new ApiClientError('Not connected to API');
     }
     try {
-      // Fetch one more than needed to detect if there are more conversations
-      const fetchLimit = pageParam + pageSize + 1;
-      const allConversations = await this.fetchJson<ConversationSummary[]>(
-        `${this.baseUrl}/api/v2/conversations?limit=${fetchLimit}&detail=${detail}`
-      );
+      let url = `${this.baseUrl}/api/v2/conversations?limit=${pageSize}&paginated=1&detail=${detail}`;
+      if (cursor !== undefined) {
+        url += `&cursor=${cursor}`;
+      }
+      const response = await this.fetchJson<{
+        conversations: ConversationSummary[];
+        next_cursor: number | null;
+      }>(url);
 
-      // Slice to get only the requested page
-      const conversations = allConversations.slice(pageParam, pageParam + pageSize);
-
-      // Check if there are more conversations by seeing if we got the extra one
-      const hasMore = allConversations.length > pageParam + pageSize;
-      const nextCursor = hasMore ? pageParam + pageSize : undefined;
+      const nextCursor = response.next_cursor ?? undefined;
 
       console.log(
-        `[API] Pagination: pageParam=${pageParam}, pageSize=${pageSize}, fetched=${allConversations.length}, returning=${conversations.length}, hasMore=${hasMore}`
+        `[API] Cursor pagination: cursor=${cursor}, pageSize=${pageSize}, fetched=${response.conversations.length}, nextCursor=${nextCursor}`
       );
 
-      return { conversations, nextCursor };
+      return { conversations: response.conversations, nextCursor };
     } catch (error) {
       if (error instanceof DOMException && error.name === 'AbortError') {
         throw new ApiClientError('Request aborted', 499);

--- a/webui/src/utils/api.ts
+++ b/webui/src/utils/api.ts
@@ -979,12 +979,12 @@ export class ApiClient {
   }
 
   async getConversationsPaginated(
-    cursor: number | undefined = undefined,
+    cursor: string | undefined = undefined,
     pageSize: number = 50,
     detail: boolean = false
   ): Promise<{
     conversations: ConversationSummary[];
-    nextCursor: number | undefined;
+    nextCursor: string | undefined;
   }> {
     if (!this.isConnected) {
       throw new ApiClientError('Not connected to API');
@@ -992,18 +992,14 @@ export class ApiClient {
     try {
       let url = `${this.baseUrl}/api/v2/conversations?limit=${pageSize}&paginated=1&detail=${detail}`;
       if (cursor !== undefined) {
-        url += `&cursor=${cursor}`;
+        url += `&cursor=${encodeURIComponent(cursor)}`;
       }
       const response = await this.fetchJson<{
         conversations: ConversationSummary[];
-        next_cursor: number | null;
+        next_cursor: string | null;
       }>(url);
 
       const nextCursor = response.next_cursor ?? undefined;
-
-      console.log(
-        `[API] Cursor pagination: cursor=${cursor}, pageSize=${pageSize}, fetched=${response.conversations.length}, nextCursor=${nextCursor}`
-      );
 
       return { conversations: response.conversations, nextCursor };
     } catch (error) {


### PR DESCRIPTION
## Summary

- Replaces the growing-limit infinite-scroll approach (51, 101, 151…) with proper cursor-based pagination using `ConversationMeta.modified` (Unix timestamp) as the cursor
- New `paginated=1` flag on `GET /api/v2/conversations` opts into a wrapped response: `{conversations: [...], next_cursor: float|null}`
- Without `paginated=1` the endpoint returns a bare list as before — fully backward-compatible
- WebUI `useConversationsInfiniteQuery` updated to use `cursor: number | undefined` instead of a growing `offset`
- Fixes the cache mismatch Erik flagged on #2854: warm cache for `limit=51` was returned unchanged for `limit=101`, stopping infinite scroll after 50 items

## How it works

**Server** (`gptme/server/api_v2.py`):
- New query params: `cursor` (float, Unix ts), `paginated` (bool, default false)
- When `paginated=1`: filters conversations where `modified < cursor`, uses limit+1 probe to detect hasMore, returns `{conversations, next_cursor}`
- Cache is reused for the full list; cursor filtering is applied per-request

**Client** (`webui/src/utils/api.ts`):
- `getConversationsPaginated(cursor: number | undefined, pageSize, detail)` — first page passes no cursor, subsequent pages pass `next_cursor` from prior response
- `useConversationsInfiniteQuery`: `initialPageParam: undefined`, `pageParam: number | undefined`

## Test plan

- [ ] `GET /api/v2/conversations?limit=50&paginated=1` returns `{conversations: [...], next_cursor: float|null}`
- [ ] `GET /api/v2/conversations?limit=50&paginated=1&cursor=<ts>` returns next page
- [ ] `GET /api/v2/conversations?limit=50` (no `paginated=1`) returns bare list — no regression
- [ ] WebUI infinite scroll loads page 1 and subsequent pages correctly
- [ ] `npm test` passes in webui (new test covers cursor URL construction for first page, detail=true, and second page)