### PR TITLE
perf(server): add ETag conditional request support for conversations endpoints

### DIFF
--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -427,13 +427,19 @@ def _etag_conversations(conversations: "list[ConversationMeta]") -> str:
 
 
 def _etag_conversation(logdir: "Path") -> str:
-    """Compute ETag from the conversation log file's mtime."""
+    """Compute ETag from the conversation log file's mtime and size.
+
+    Including size prevents stale 304s on filesystems with 1-second mtime
+    granularity where two writes within the same tick leave mtime unchanged.
+    """
     logfile = logdir / "conversation.jsonl"
     try:
-        mtime = logfile.stat().st_mtime
+        stat = logfile.stat()
+        mtime = stat.st_mtime
+        size = stat.st_size
     except OSError:
         return ""
-    return hashlib.md5(str(mtime).encode()).hexdigest()[:16]
+    return hashlib.md5(f"{mtime}:{size}".encode()).hexdigest()[:16]
 
 
 v2_api = flask.Blueprint("v2_api", __name__)

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -1043,14 +1043,18 @@ def api_conversations():
         if elapsed < _CONVERSATIONS_CACHE_TTL:
             cached = _conversations_cache
             etag = _etag_conversations(cached[:limit])
-            if request.if_none_match.contains(etag):
-                return flask.make_response("", 304)
+            if request.if_none_match.contains_weak(etag):
+                resp = flask.make_response("", 304)
+                resp.set_etag(etag, weak=True)
+                resp.cache_control.no_cache = True
+                return resp
             response_items = [asdict(c) for c in cached[:limit]]
             for item in response_items:
                 item["message_count"] = item["messages"]
                 item["last_updated"] = item["modified"]
             resp = flask.make_response(flask.jsonify(response_items))
-            resp.set_etag(etag)
+            resp.set_etag(etag, weak=True)
+            resp.cache_control.no_cache = True
             return resp
 
     # Use fast tail-only scan for list/search by default — reads last 8KB for
@@ -1088,10 +1092,14 @@ def api_conversations():
         _conversations_cache_logs_dir = logs_dir
         _conversations_cache_time = time.monotonic()
         etag = _etag_conversations(conversations)
-        if request.if_none_match.contains(etag):
-            return flask.make_response("", 304)
+        if request.if_none_match.contains_weak(etag):
+            resp = flask.make_response("", 304)
+            resp.set_etag(etag, weak=True)
+            resp.cache_control.no_cache = True
+            return resp
         resp = flask.make_response(flask.jsonify(response_items))
-        resp.set_etag(etag)
+        resp.set_etag(etag, weak=True)
+        resp.cache_control.no_cache = True
         return resp
 
     return flask.jsonify(response_items)
@@ -1113,8 +1121,11 @@ def api_conversation(conversation_id: str):
 
     logdir = get_logs_dir() / conversation_id
     etag = _etag_conversation(logdir)
-    if etag and request.if_none_match.contains(etag):
-        return flask.make_response("", 304)
+    if etag and request.if_none_match.contains_weak(etag):
+        resp = flask.make_response("", 304)
+        resp.set_etag(etag, weak=True)
+        resp.cache_control.no_cache = True
+        return resp
 
     try:
         manager = LogManager.load(conversation_id, lock=False)
@@ -1165,7 +1176,8 @@ def api_conversation(conversation_id: str):
 
     resp = flask.make_response(flask.jsonify(log_dict))
     if etag:
-        resp.set_etag(etag)
+        resp.set_etag(etag, weak=True)
+        resp.cache_control.no_cache = True
     return resp
 
 

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -5,6 +5,7 @@ This module contains the main conversation CRUD endpoints for the V2 API.
 Session management, tool execution, and agent creation are handled by separate modules.
 """
 
+import hashlib
 import json
 import logging
 import os
@@ -415,6 +416,24 @@ def _validate_config_key_path(key: str) -> str:
     if any(not segment.strip() for segment in trimmed.split(".")):
         raise ValueError("key must be a dotted path with non-empty segments")
     return trimmed
+
+
+def _etag_conversations(conversations: "list[ConversationMeta]") -> str:
+    """Compute a stable ETag from conversation IDs and modification times."""
+    h = hashlib.md5()
+    for c in conversations:
+        h.update(f"{c.id}:{c.modified}\n".encode())
+    return h.hexdigest()[:16]
+
+
+def _etag_conversation(logdir: "Path") -> str:
+    """Compute ETag from the conversation log file's mtime."""
+    logfile = logdir / "conversation.jsonl"
+    try:
+        mtime = logfile.stat().st_mtime
+    except OSError:
+        return ""
+    return hashlib.md5(str(mtime).encode()).hexdigest()[:16]
 
 
 v2_api = flask.Blueprint("v2_api", __name__)
@@ -1023,11 +1042,16 @@ def api_conversations():
         elapsed = time.monotonic() - _conversations_cache_time
         if elapsed < _CONVERSATIONS_CACHE_TTL:
             cached = _conversations_cache
+            etag = _etag_conversations(cached[:limit])
+            if request.if_none_match.contains(etag):
+                return flask.make_response("", 304)
             response_items = [asdict(c) for c in cached[:limit]]
             for item in response_items:
                 item["message_count"] = item["messages"]
                 item["last_updated"] = item["modified"]
-            return flask.jsonify(response_items)
+            resp = flask.make_response(flask.jsonify(response_items))
+            resp.set_etag(etag)
+            return resp
 
     # Use fast tail-only scan for list/search by default — reads last 8KB for
     # preview/model, skips json.loads() on every metadata line.
@@ -1063,6 +1087,12 @@ def api_conversations():
         _conversations_cache = all_conversations
         _conversations_cache_logs_dir = logs_dir
         _conversations_cache_time = time.monotonic()
+        etag = _etag_conversations(conversations)
+        if request.if_none_match.contains(etag):
+            return flask.make_response("", 304)
+        resp = flask.make_response(flask.jsonify(response_items))
+        resp.set_etag(etag)
+        return resp
 
     return flask.jsonify(response_items)
 
@@ -1081,6 +1111,11 @@ def api_conversation(conversation_id: str):
     if error := _validate_conversation_id(conversation_id):
         return error
 
+    logdir = get_logs_dir() / conversation_id
+    etag = _etag_conversation(logdir)
+    if etag and request.if_none_match.contains(etag):
+        return flask.make_response("", 304)
+
     try:
         manager = LogManager.load(conversation_id, lock=False)
     except FileNotFoundError:
@@ -1089,7 +1124,6 @@ def api_conversation(conversation_id: str):
         ), 404
 
     # Create and set config
-    logdir = get_logs_dir() / conversation_id
     chat_config = ChatConfig.load_or_create(logdir, ChatConfig()).save()
     log_dict = manager.to_dict(branches=True)
     log_dict["logdir"] = str(logdir)
@@ -1129,7 +1163,10 @@ def api_conversation(conversation_id: str):
             "last_error": latest.last_error,
         }
 
-    return flask.jsonify(log_dict)
+    resp = flask.make_response(flask.jsonify(log_dict))
+    if etag:
+        resp.set_etag(etag)
+    return resp
 
 
 @v2_api.route("/api/v2/conversations/<string:conversation_id>", methods=["PUT"])

--- a/tests/test_server_etag.py
+++ b/tests/test_server_etag.py
@@ -1,0 +1,118 @@
+"""Tests for ETag conditional request support on conversations endpoints."""
+
+import pytest
+
+flask = pytest.importorskip(
+    "flask", reason="flask not installed, install server extras (-E server)"
+)
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+def app(tmp_path, monkeypatch):
+    from gptme.server.app import create_app
+
+    monkeypatch.setenv("GPTME_LOGS_DIR", str(tmp_path / "logs"))
+    app = create_app()
+    app.config["TESTING"] = True
+    app.config["AUTH_DISABLED"] = True
+    return app
+
+
+def _create_conversation(client, conv_id: str) -> None:
+    resp = client.put(
+        f"/api/v2/conversations/{conv_id}",
+        json={"messages": [{"role": "user", "content": "hello"}], "prompt": "none"},
+    )
+    assert resp.status_code == 200, resp.get_json()
+
+
+class TestConversationsListETag:
+    def test_returns_etag_header(self, app):
+        with app.test_client() as client:
+            _create_conversation(client, "test-conv-1")
+            resp = client.get("/api/v2/conversations")
+            assert resp.status_code == 200
+            assert resp.headers.get("ETag") is not None
+
+    def test_304_on_matching_etag(self, app):
+        with app.test_client() as client:
+            _create_conversation(client, "test-conv-2")
+            resp1 = client.get("/api/v2/conversations")
+            assert resp1.status_code == 200
+            etag = resp1.headers["ETag"]
+
+            resp2 = client.get("/api/v2/conversations", headers={"If-None-Match": etag})
+            assert resp2.status_code == 304
+            assert resp2.data == b""
+
+    def test_200_on_mismatched_etag(self, app):
+        with app.test_client() as client:
+            _create_conversation(client, "test-conv-3")
+            resp = client.get(
+                "/api/v2/conversations",
+                headers={"If-None-Match": '"deadbeefdeadbeef"'},
+            )
+            assert resp.status_code == 200
+            assert resp.headers.get("ETag") is not None
+
+    def test_no_etag_on_search(self, app):
+        """Search responses don't carry ETags (content varies by query param)."""
+        with app.test_client() as client:
+            _create_conversation(client, "test-conv-4")
+            resp = client.get("/api/v2/conversations?search=hello")
+            assert resp.status_code == 200
+            # No ETag for search results (correct — skip assertion if absent)
+            # We just check it doesn't 304 inadvertently
+            assert resp.get_json() is not None
+
+
+class TestConversationETag:
+    def test_returns_etag_header(self, app):
+        with app.test_client() as client:
+            _create_conversation(client, "test-single-1")
+            resp = client.get("/api/v2/conversations/test-single-1")
+            assert resp.status_code == 200
+            assert resp.headers.get("ETag") is not None
+
+    def test_304_on_matching_etag(self, app):
+        with app.test_client() as client:
+            _create_conversation(client, "test-single-2")
+            resp1 = client.get("/api/v2/conversations/test-single-2")
+            assert resp1.status_code == 200
+            etag = resp1.headers["ETag"]
+
+            resp2 = client.get(
+                "/api/v2/conversations/test-single-2",
+                headers={"If-None-Match": etag},
+            )
+            assert resp2.status_code == 304
+            assert resp2.data == b""
+
+    def test_200_on_mismatched_etag(self, app):
+        with app.test_client() as client:
+            _create_conversation(client, "test-single-3")
+            resp = client.get(
+                "/api/v2/conversations/test-single-3",
+                headers={"If-None-Match": '"deadbeefdeadbeef"'},
+            )
+            assert resp.status_code == 200
+            assert resp.headers.get("ETag") is not None
+
+    def test_etag_changes_after_message_added(self, app):
+        with app.test_client() as client:
+            _create_conversation(client, "test-single-4")
+            resp1 = client.get("/api/v2/conversations/test-single-4")
+            etag1 = resp1.headers["ETag"]
+
+            # Add a new message — mtime changes
+            add = client.post(
+                "/api/v2/conversations/test-single-4",
+                json={"role": "user", "content": "follow-up"},
+            )
+            assert add.status_code == 200
+
+            resp2 = client.get("/api/v2/conversations/test-single-4")
+            etag2 = resp2.headers["ETag"]
+            assert etag1 != etag2, "ETag must change after message is appended"

--- a/tests/test_server_etag.py
+++ b/tests/test_server_etag.py
@@ -13,7 +13,7 @@ pytestmark = pytest.mark.integration
 def app(tmp_path, monkeypatch):
     from gptme.server.app import create_app
 
-    monkeypatch.setenv("GPTME_LOGS_DIR", str(tmp_path / "logs"))
+    monkeypatch.setenv("GPTME_LOGS_HOME", str(tmp_path / "logs"))
     app = create_app()
     app.config["TESTING"] = True
     app.config["AUTH_DISABLED"] = True


### PR DESCRIPTION
## Summary

- Adds `ETag` response headers to `GET /api/v2/conversations` and `GET /api/v2/conversations/:id`
- Validates `If-None-Match` request headers and returns `304 Not Modified` when data is unchanged
- 8 new integration tests covering 200/304/mismatch cases and ETag invalidation after message append

## How it works

**Conversations list** (`GET /api/v2/conversations`): ETag derived from MD5 of conversation IDs + modification times. Only applied on the no-search, no-detail fast path (the common polling case). Works on both the cache-hit and fresh-fetch paths.

**Single conversation** (`GET /api/v2/conversations/:id`): ETag from MD5 of `conversation.jsonl` mtime. The 304 check happens *before* loading the full log manager, so cache hits avoid the file read entirely.

## Motivation

The webui polls conversations on page load and navigation. After cursor pagination (#2860) and server-side caching (#2856/#2859), data is cheap to generate — but the response is still serialized and transmitted even when nothing changed. For users with 500+ conversations, each list response is several KB. ETags turn repeat polls into free 304s with ~0 bytes transferred.

Browsers handle `If-None-Match` automatically when using `fetch` cache mode; the webui client can opt in with a single header addition.

## Test plan

- [x] `test_returns_etag_header` — 200 responses carry ETag
- [x] `test_304_on_matching_etag` — identical ETag → 304 with empty body
- [x] `test_200_on_mismatched_etag` — wrong ETag → 200 with fresh data
- [x] `test_no_etag_on_search` — search responses don't 304 inadvertently
- [x] `test_etag_changes_after_message_added` — mtime-based ETag invalidates correctly
- [x] Existing `test_server_bad_input` and `test_server_cors` tests still pass (24/24)