### PR TITLE
feat(server): add ?q= filter param to conversations API with server-side webui search

### DIFF
--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -915,7 +915,9 @@ def api_conversations():
         return flask.jsonify({"error": "limit must be an integer"}), 400
     limit = max(1, min(limit, 1000))
     # ?q= is the primary filter param; ?search= is accepted as a backward-compat alias
-    search = (request.args.get("q") or request.args.get("search", "")).strip().lower()
+    # Use None-check so explicit ?q= (even empty) takes precedence over ?search=
+    q = request.args.get("q")
+    search = (q if q is not None else request.args.get("search", "")).strip().lower()
     detail_val = request.args.get("detail")
     detail = detail_val is not None and detail_val.lower() in ("", "1", "true", "yes")
     paginated_val = request.args.get("paginated")

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -866,10 +866,10 @@ def api_external_session(external_session_id: str):
             "description": "Maximum number of conversations to return",
         },
         {
-            "name": "search",
+            "name": "q",
             "in": "query",
             "schema": {"type": "string"},
-            "description": "Filter conversations by name, id, or last message preview (case-insensitive substring match)",
+            "description": "Filter conversations by name, id, or last message preview (case-insensitive substring match). Alias: search.",
         },
         {
             "name": "detail",
@@ -914,7 +914,8 @@ def api_conversations():
     except (ValueError, TypeError):
         return flask.jsonify({"error": "limit must be an integer"}), 400
     limit = max(1, min(limit, 1000))
-    search = request.args.get("search", "").strip().lower()
+    # ?q= is the primary filter param; ?search= is accepted as a backward-compat alias
+    search = (request.args.get("q") or request.args.get("search", "")).strip().lower()
     detail_val = request.args.get("detail")
     detail = detail_val is not None and detail_val.lower() in ("", "1", "true", "yes")
     paginated_val = request.args.get("paginated")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -226,6 +226,50 @@ def test_api_conversation_search_case_insensitive(
     assert data[0]["id"] == "MySearchConversation"
 
 
+def test_api_conversation_search_q_param(client: FlaskClient, tmp_path, monkeypatch):
+    """Test that the ?q= param filters conversations (primary alias for ?search=)."""
+    monkeypatch.setattr("gptme.logmanager.conversations.get_logs_dir", lambda: tmp_path)
+
+    conv_dir = tmp_path / "q-param-target"
+    conv_dir.mkdir()
+    (conv_dir / "conversation.jsonl").write_text(
+        '{"role": "system", "content": "hello", "timestamp": "2026-01-01T00:00:00"}\n'
+    )
+    other_dir = tmp_path / "other-conversation"
+    other_dir.mkdir()
+    (other_dir / "conversation.jsonl").write_text(
+        '{"role": "system", "content": "hello", "timestamp": "2026-01-01T00:00:00"}\n'
+    )
+
+    response = client.get("/api/v2/conversations?q=q-param-target")
+    assert response.status_code == 200
+    data = response.get_json()
+    assert isinstance(data, list)
+    assert len(data) == 1
+    assert data[0]["id"] == "q-param-target"
+
+
+def test_api_conversation_search_q_param_takes_precedence(
+    client: FlaskClient, tmp_path, monkeypatch
+):
+    """Test that ?q= takes precedence over ?search= when both are provided."""
+    monkeypatch.setattr("gptme.logmanager.conversations.get_logs_dir", lambda: tmp_path)
+
+    conv_dir = tmp_path / "q-wins"
+    conv_dir.mkdir()
+    (conv_dir / "conversation.jsonl").write_text(
+        '{"role": "system", "content": "hello", "timestamp": "2026-01-01T00:00:00"}\n'
+    )
+
+    # q= matches; search= does not — q= should win
+    response = client.get("/api/v2/conversations?q=q-wins&search=no-match-here")
+    assert response.status_code == 200
+    data = response.get_json()
+    assert isinstance(data, list)
+    assert len(data) == 1
+    assert data[0]["id"] == "q-wins"
+
+
 def test_api_conversation_list_detail_flag(client: FlaskClient, tmp_path, monkeypatch):
     """Test that detail=true returns cost/token stats while default (false) zeroes them."""
     import json
@@ -284,9 +328,9 @@ def test_api_conversation_list_detail_flag(client: FlaskClient, tmp_path, monkey
         }
     )
     conv_file.write_text("\n".join(json.dumps(m) for m in messages) + "\n")
-    assert conv_file.stat().st_size > 8192, (
-        "fixture must be > _TAIL_BYTES to trigger fast path"
-    )
+    assert (
+        conv_file.stat().st_size > 8192
+    ), "fixture must be > _TAIL_BYTES to trigger fast path"
 
     # Default (detail=false) should return zeroed cost/token stats but keep
     # the message count and `last_updated` (both come from the cheap tail scan).
@@ -390,9 +434,9 @@ def test_debug_errors_enabled(monkeypatch):
     # Test falsy values
     for value in ["0", "false", "no", ""]:
         monkeypatch.setenv("GPTME_DEBUG_ERRORS", value)
-        assert _is_debug_errors_enabled() is False, (
-            f"Should be False for value: {value}"
-        )
+        assert (
+            _is_debug_errors_enabled() is False
+        ), f"Should be False for value: {value}"
 
 
 def test_default_model_propagation():
@@ -747,9 +791,9 @@ def test_api_v2_conversation_post_tools_validation(conv, client: FlaskClient):
         json={"role": "user", "content": "hello", "tools": ["shell"]},
     )
     body = response.get_json()
-    assert response.status_code == 200, (
-        f"Expected 200 for valid tools list, got {response.status_code}: {body}"
-    )
+    assert (
+        response.status_code == 200
+    ), f"Expected 200 for valid tools list, got {response.status_code}: {body}"
 
 
 # --- Cookie-based authentication tests ---
@@ -924,9 +968,9 @@ def test_http_errors_return_json(client: FlaskClient):
     # 404: invalid message index type (-1 doesn't match <int:index> pattern)
     response = client.delete("/api/v2/conversations/any-conv/messages/-1")
     assert response.status_code in (404, 405)
-    assert response.content_type.startswith("application/json"), (
-        f"Expected JSON, got {response.content_type}: {response.data[:200]}"
-    )
+    assert response.content_type.startswith(
+        "application/json"
+    ), f"Expected JSON, got {response.content_type}: {response.data[:200]}"
     data = response.get_json()
     assert data is not None
     assert "error" in data

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -270,6 +270,27 @@ def test_api_conversation_search_q_param_takes_precedence(
     assert data[0]["id"] == "q-wins"
 
 
+def test_api_conversation_search_empty_q_overrides_search(
+    client: FlaskClient, tmp_path, monkeypatch
+):
+    """Test that explicit empty ?q= overrides ?search= (not a falsy-or fallthrough)."""
+    monkeypatch.setattr("gptme.logmanager.conversations.get_logs_dir", lambda: tmp_path)
+
+    conv_dir = tmp_path / "search-only"
+    conv_dir.mkdir()
+    (conv_dir / "conversation.jsonl").write_text(
+        '{"role": "system", "content": "hello", "timestamp": "2026-01-01T00:00:00"}\n'
+    )
+
+    # ?q= explicitly empty + ?search=search-only: empty q= should win → no filter → returns all
+    response = client.get("/api/v2/conversations?q=&search=search-only")
+    assert response.status_code == 200
+    data = response.get_json()
+    assert isinstance(data, list)
+    # empty q= means "no filter", so all conversations are returned (not just search-only match)
+    assert len(data) >= 1
+
+
 def test_api_conversation_list_detail_flag(client: FlaskClient, tmp_path, monkeypatch):
     """Test that detail=true returns cost/token stats while default (false) zeroes them."""
     import json
@@ -328,9 +349,9 @@ def test_api_conversation_list_detail_flag(client: FlaskClient, tmp_path, monkey
         }
     )
     conv_file.write_text("\n".join(json.dumps(m) for m in messages) + "\n")
-    assert (
-        conv_file.stat().st_size > 8192
-    ), "fixture must be > _TAIL_BYTES to trigger fast path"
+    assert conv_file.stat().st_size > 8192, (
+        "fixture must be > _TAIL_BYTES to trigger fast path"
+    )
 
     # Default (detail=false) should return zeroed cost/token stats but keep
     # the message count and `last_updated` (both come from the cheap tail scan).
@@ -434,9 +455,9 @@ def test_debug_errors_enabled(monkeypatch):
     # Test falsy values
     for value in ["0", "false", "no", ""]:
         monkeypatch.setenv("GPTME_DEBUG_ERRORS", value)
-        assert (
-            _is_debug_errors_enabled() is False
-        ), f"Should be False for value: {value}"
+        assert _is_debug_errors_enabled() is False, (
+            f"Should be False for value: {value}"
+        )
 
 
 def test_default_model_propagation():
@@ -791,9 +812,9 @@ def test_api_v2_conversation_post_tools_validation(conv, client: FlaskClient):
         json={"role": "user", "content": "hello", "tools": ["shell"]},
     )
     body = response.get_json()
-    assert (
-        response.status_code == 200
-    ), f"Expected 200 for valid tools list, got {response.status_code}: {body}"
+    assert response.status_code == 200, (
+        f"Expected 200 for valid tools list, got {response.status_code}: {body}"
+    )
 
 
 # --- Cookie-based authentication tests ---
@@ -968,9 +989,9 @@ def test_http_errors_return_json(client: FlaskClient):
     # 404: invalid message index type (-1 doesn't match <int:index> pattern)
     response = client.delete("/api/v2/conversations/any-conv/messages/-1")
     assert response.status_code in (404, 405)
-    assert response.content_type.startswith(
-        "application/json"
-    ), f"Expected JSON, got {response.content_type}: {response.data[:200]}"
+    assert response.content_type.startswith("application/json"), (
+        f"Expected JSON, got {response.content_type}: {response.data[:200]}"
+    )
     data = response.get_json()
     assert data is not None
     assert "error" in data

--- a/webui/src/components/HistoryView.tsx
+++ b/webui/src/components/HistoryView.tsx
@@ -26,6 +26,7 @@ import type { ConversationSummary } from '@/types/conversation';
 
 const PAGE_SIZE = 50;
 const MIN_SERVER_SEARCH_LEN = 3;
+const SERVER_SEARCH_LIMIT = 200;
 
 /** Fetch all conversation summaries for calendar/stats */
 function useAllConversations() {
@@ -50,7 +51,7 @@ function useServerSearch(query: string) {
 
   return useQuery({
     queryKey: ['conversations-search', connectionConfig.baseUrl, query],
-    queryFn: () => api.searchConversations(query, 200),
+    queryFn: () => api.searchConversations(query, SERVER_SEARCH_LIMIT),
     enabled: isConnected && query.length >= MIN_SERVER_SEARCH_LEN,
     staleTime: 30 * 1000,
     gcTime: 2 * 60 * 1000,
@@ -146,6 +147,10 @@ export const HistoryView: FC = () => {
 
   const { data: serverSearchResults, isFetching: isSearchFetching } =
     useServerSearch(debouncedSearch);
+  const useServerResults =
+    debouncedSearch.length >= MIN_SERVER_SEARCH_LEN && serverSearchResults !== undefined;
+  const showServerSearchLimitNotice =
+    useServerResults && serverSearchResults.length === SERVER_SEARCH_LIMIT;
 
   // Build activity map from conversations
   const activityData = useMemo(() => {
@@ -233,8 +238,6 @@ export const HistoryView: FC = () => {
   // they arrive; shorter queries (and while the server fetch is in-flight) fall
   // back to client-side filtering of the full list.
   const filteredConversations = useMemo(() => {
-    const useServerResults =
-      debouncedSearch.length >= MIN_SERVER_SEARCH_LEN && serverSearchResults !== undefined;
     const source: ConversationSummary[] = useServerResults ? serverSearchResults : conversations;
 
     let filtered: ConversationSummary[] = source;
@@ -260,7 +263,7 @@ export const HistoryView: FC = () => {
     const sorted = filtered === source ? [...filtered] : filtered;
     sorted.sort((a, b) => b.modified - a.modified);
     return sorted;
-  }, [conversations, serverSearchResults, selectedDate, searchQuery, debouncedSearch]);
+  }, [conversations, serverSearchResults, selectedDate, searchQuery, useServerResults]);
 
   // Reset visible count when filters change
   useEffect(() => {
@@ -461,6 +464,12 @@ export const HistoryView: FC = () => {
                 />
               </div>
             </div>
+            {showServerSearchLimitNotice && (
+              <div className="border-b bg-muted/30 px-4 py-2 text-xs text-muted-foreground">
+                Showing up to {SERVER_SEARCH_LIMIT.toLocaleString()} server search matches. Refine
+                your query if expected conversations are missing.
+              </div>
+            )}
 
             {/* List */}
             <div ref={scrollRef} className="max-h-[600px] overflow-y-auto">

--- a/webui/src/components/HistoryView.tsx
+++ b/webui/src/components/HistoryView.tsx
@@ -25,6 +25,7 @@ import { chatRoute } from '@/utils/routes';
 import type { ConversationSummary } from '@/types/conversation';
 
 const PAGE_SIZE = 50;
+const MIN_SERVER_SEARCH_LEN = 3;
 
 /** Fetch all conversation summaries for calendar/stats */
 function useAllConversations() {
@@ -39,6 +40,20 @@ function useAllConversations() {
     enabled: isConnected,
     staleTime: 60 * 1000,
     gcTime: 5 * 60 * 1000,
+  });
+}
+
+/** Server-side search for long-enough queries (>= MIN_SERVER_SEARCH_LEN chars). */
+function useServerSearch(query: string) {
+  const { api, connectionConfig } = useApi();
+  const isConnected = use$(api.isConnected$);
+
+  return useQuery({
+    queryKey: ['conversations-search', connectionConfig.baseUrl, query],
+    queryFn: () => api.searchConversations(query, 200),
+    enabled: isConnected && query.length >= MIN_SERVER_SEARCH_LEN,
+    staleTime: 30 * 1000,
+    gcTime: 2 * 60 * 1000,
   });
 }
 
@@ -112,10 +127,25 @@ export const HistoryView: FC = () => {
   const { data: conversations = [], isLoading } = useAllConversations();
   const [selectedDate, setSelectedDate] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
+  const [debouncedSearch, setDebouncedSearch] = useState('');
   const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
   const [selectedYear, setSelectedYear] = useState<number | null>(null); // null = current year view
   const sentinelRef = useRef<HTMLDivElement>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
+
+  // Debounce the search query for server-side requests
+  useEffect(() => {
+    const trimmed = searchQuery.trim();
+    if (trimmed.length < MIN_SERVER_SEARCH_LEN) {
+      setDebouncedSearch('');
+      return;
+    }
+    const id = setTimeout(() => setDebouncedSearch(trimmed), 300);
+    return () => clearTimeout(id);
+  }, [searchQuery]);
+
+  const { data: serverSearchResults, isFetching: isSearchFetching } =
+    useServerSearch(debouncedSearch);
 
   // Build activity map from conversations
   const activityData = useMemo(() => {
@@ -198,9 +228,16 @@ export const HistoryView: FC = () => {
     return count;
   }, [activityData, selectedYear]);
 
-  // Filter conversations
+  // Filter conversations.
+  // For queries >= MIN_SERVER_SEARCH_LEN chars we use server-side results once
+  // they arrive; shorter queries (and while the server fetch is in-flight) fall
+  // back to client-side filtering of the full list.
   const filteredConversations = useMemo(() => {
-    let filtered = conversations;
+    const useServerResults =
+      debouncedSearch.length >= MIN_SERVER_SEARCH_LEN && serverSearchResults !== undefined;
+    const source: ConversationSummary[] = useServerResults ? serverSearchResults : conversations;
+
+    let filtered: ConversationSummary[] = source;
 
     if (selectedDate) {
       filtered = filtered.filter((conv) => {
@@ -209,7 +246,8 @@ export const HistoryView: FC = () => {
       });
     }
 
-    if (searchQuery.trim()) {
+    // Client-side filter for short queries (< MIN_SERVER_SEARCH_LEN) or while server is fetching
+    if (!useServerResults && searchQuery.trim()) {
       const q = searchQuery.toLowerCase();
       filtered = filtered.filter(
         (conv) =>
@@ -219,10 +257,10 @@ export const HistoryView: FC = () => {
       );
     }
 
-    const sorted = filtered === conversations ? [...filtered] : filtered;
+    const sorted = filtered === source ? [...filtered] : filtered;
     sorted.sort((a, b) => b.modified - a.modified);
     return sorted;
-  }, [conversations, selectedDate, searchQuery]);
+  }, [conversations, serverSearchResults, selectedDate, searchQuery, debouncedSearch]);
 
   // Reset visible count when filters change
   useEffect(() => {
@@ -409,7 +447,11 @@ export const HistoryView: FC = () => {
             {/* Search */}
             <div className="border-b px-4 py-2">
               <div className="relative">
-                <Search className="absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                {isSearchFetching ? (
+                  <Loader2 className="absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 animate-spin text-muted-foreground" />
+                ) : (
+                  <Search className="absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                )}
                 <Input
                   placeholder="Search conversations..."
                   value={searchQuery}

--- a/webui/src/components/__tests__/HistoryView.test.tsx
+++ b/webui/src/components/__tests__/HistoryView.test.tsx
@@ -1,11 +1,52 @@
 import '@testing-library/jest-dom';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { render, screen } from '@testing-library/react';
 import { HistoryView } from '../HistoryView';
 import { TooltipProvider } from '@/components/ui/tooltip';
 
 const mockNavigate = jest.fn();
 const mockUseQuery = jest.fn();
+const mockIntersectionObserver = jest.fn(() => ({
+  observe: jest.fn(),
+  disconnect: jest.fn(),
+  unobserve: jest.fn(),
+}));
+const baseConversation = {
+  id: 'chat-1',
+  name: 'Accessible chat',
+  modified: Date.UTC(2026, 4, 31, 12, 0, 0) / 1000,
+  messages: 3,
+  last_message_preview: 'Latest preview',
+  last_message_role: 'user',
+  workspace: '.',
+};
+
+const setUseQueryResults = ({
+  allConversations = [baseConversation],
+  serverSearchResults = undefined,
+  isSearchFetching = false,
+}: {
+  allConversations?: (typeof baseConversation)[];
+  serverSearchResults?: (typeof baseConversation)[] | undefined;
+  isSearchFetching?: boolean;
+}) => {
+  mockUseQuery.mockImplementation(({ queryKey }: { queryKey: unknown[] }) => {
+    switch (queryKey[0]) {
+      case 'conversations-all':
+        return {
+          data: allConversations,
+          isLoading: false,
+        };
+      case 'conversations-search':
+        return {
+          data: serverSearchResults,
+          isFetching: isSearchFetching,
+        };
+      default:
+        throw new Error(`Unexpected query key: ${String(queryKey[0])}`);
+    }
+  });
+};
 
 jest.mock('react-router-dom', () => ({
   useNavigate: () => mockNavigate,
@@ -23,7 +64,8 @@ jest.mock('@/contexts/ApiContext', () => ({
   useApi: () => ({
     api: {
       isConnected$: {},
-      getConversationsPaginated: jest.fn(),
+      getConversations: jest.fn(),
+      searchConversations: jest.fn(),
     },
     connectionConfig: { baseUrl: 'http://localhost:5700' },
   }),
@@ -41,23 +83,24 @@ describe('HistoryView', () => {
       </TooltipProvider>
     );
 
+  beforeAll(() => {
+    Object.defineProperty(window, 'IntersectionObserver', {
+      writable: true,
+      configurable: true,
+      value: mockIntersectionObserver,
+    });
+    Object.defineProperty(global, 'IntersectionObserver', {
+      writable: true,
+      configurable: true,
+      value: mockIntersectionObserver,
+    });
+  });
+
   beforeEach(() => {
     mockNavigate.mockReset();
     mockUseQuery.mockReset();
-    mockUseQuery.mockReturnValue({
-      data: [
-        {
-          id: 'chat-1',
-          name: 'Accessible chat',
-          modified: Date.UTC(2026, 4, 31, 12, 0, 0) / 1000,
-          messages: 3,
-          last_message_preview: 'Latest preview',
-          last_message_role: 'user',
-          workspace: '.',
-        },
-      ],
-      isLoading: false,
-    });
+    mockIntersectionObserver.mockClear();
+    setUseQueryResults({});
   });
 
   it('labels history controls and exposes conversation rows as buttons', () => {
@@ -77,5 +120,34 @@ describe('HistoryView', () => {
     await user.click(screen.getByRole('button', { name: /Accessible chat/i }));
 
     expect(mockNavigate).toHaveBeenCalledWith('/chat/chat-1');
+  });
+
+  it('shows a notice when server-side search may be capped at 200 results', () => {
+    jest.useFakeTimers();
+    setUseQueryResults({
+      serverSearchResults: Array.from({ length: 200 }, (_, index) => ({
+        ...baseConversation,
+        id: `server-chat-${index}`,
+        name: `Server chat ${index}`,
+      })),
+    });
+
+    renderHistoryView();
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Search conversations' }), {
+      target: { value: 'server' },
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+
+    expect(
+      screen.getByText(
+        'Showing up to 200 server search matches. Refine your query if expected conversations are missing.'
+      )
+    ).toBeInTheDocument();
+
+    jest.useRealTimers();
   });
 });

--- a/webui/src/utils/api.ts
+++ b/webui/src/utils/api.ts
@@ -968,7 +968,7 @@ export class ApiClient {
     }
     try {
       return await this.fetchJson<ConversationSummary[]>(
-        `${this.baseUrl}/api/v2/conversations?search=${encodeURIComponent(query)}&limit=${limit}&detail=${detail}`
+        `${this.baseUrl}/api/v2/conversations?q=${encodeURIComponent(query)}&limit=${limit}&detail=${detail}`
       );
     } catch (error) {
       if (error instanceof DOMException && error.name === 'AbortError') {


### PR DESCRIPTION
## Summary

- **Server** (`api_v2.py`): Accept `?q=` as the primary filter parameter for `GET /api/v2/conversations`, with `?search=` kept as a backward-compatible alias. `?q=` takes precedence when both are provided. Filter applies before the `limit`/`cursor` slice so pagination works correctly with filtered results.
- **Webui** (`api.ts`): `searchConversations()` now sends `?q=` instead of `?search=`.
- **Webui** (`HistoryView.tsx`): Debounces search input (300ms) and uses server-side `?q=` filtering for queries ≥ 3 chars. Falls back to client-side filter for shorter queries. The full conversation list is still fetched separately for the activity calendar and stats.
- **Tests**: `test_api_conversation_search_q_param` + `test_api_conversation_search_q_param_takes_precedence` cover the new param and precedence behavior.

## Motivation

Users with large conversation histories (500+) previously had to download metadata for every conversation just to filter — client-side only. Server-side `?q=` reduces payload size and latency for search queries ≥ 3 chars.

## Test plan

- [x] `pytest tests/test_server.py -k search` — all 5 search tests pass (50/50 total)
- [x] `tsc --noEmit` — TypeScript typecheck clean
- [ ] Manual: open HistoryView, type ≥ 3 chars → spinner while fetching, results switch to server-filtered set
- [ ] Manual: type 1-2 chars → client-side filter (no extra API call)