### PR TITLE
feat(webui): add sort control to conversation list (Recent/Longest/A-Z)

### DIFF
--- a/webui/src/components/ConversationList.tsx
+++ b/webui/src/components/ConversationList.tsx
@@ -110,6 +110,7 @@ export const ConversationList: FC<Props> = ({
   const [showStarredOnly, setShowStarredOnly] = useState(false);
 
   const [sortBy, setSortBy] = useState<SortBy>(readSortPreference);
+  const useInfiniteScroll = sortBy === 'recent';
   const handleSortChange = (value: SortBy) => {
     setSortBy(value);
     writeSortPreference(value);
@@ -256,15 +257,15 @@ export const ConversationList: FC<Props> = ({
   const isFetchingRef = useRef(isFetching);
   isFetchingRef.current = isFetching;
 
-  // Set up intersection observer for infinite scrolling
+  // Keep infinite scroll for the date-grouped default view only.
+  // Flat sorts use an explicit pager so loaded pages do not reshuffle mid-scroll.
   useEffect(() => {
     if (observer.current) observer.current.disconnect();
 
-    // Only set up observer if we have content and can scroll
     const container = scrollContainerRef.current;
     const sentinel = loadMoreSentinelRef.current;
 
-    if (!container || !sentinel || !hasNextPage) {
+    if (!useInfiniteScroll || !container || !sentinel || !hasNextPage) {
       return;
     }
 
@@ -272,12 +273,10 @@ export const ConversationList: FC<Props> = ({
       (entries) => {
         const entry = entries[0];
         if (entry.isIntersecting && hasNextPage && !isFetchingRef.current) {
-          // Additional check: ensure we actually have scrollable content or are near the bottom
           const containerHeight = container.clientHeight;
           const scrollHeight = container.scrollHeight;
           const scrollTop = container.scrollTop;
 
-          // Load if we have scrollable content and are near the bottom, OR if content doesn't fill container yet
           const hasScrollableContent = scrollHeight > containerHeight;
           const nearBottom = scrollTop + containerHeight >= scrollHeight - 100;
 
@@ -299,7 +298,7 @@ export const ConversationList: FC<Props> = ({
     return () => {
       if (observer.current) observer.current.disconnect();
     };
-  }, [hasNextPage, fetchNextPage]); // isFetching accessed via ref to avoid observer recreation
+  }, [useInfiniteScroll, hasNextPage, fetchNextPage]); // isFetching accessed via ref to avoid observer recreation
 
   useEffect(() => {
     const handleFilterShortcut = (e: KeyboardEvent) => {
@@ -993,8 +992,30 @@ export const ConversationList: FC<Props> = ({
         </div>
       )}
 
+      {/* Keep flat sorts stable while still allowing more pages on demand. */}
+      {!isLoading && !isError && sortBy !== 'recent' && hasNextPage && (
+        <div className="px-2 pb-2">
+          <Button
+            variant="outline"
+            size="sm"
+            className="w-full"
+            onClick={() => fetchNextPage()}
+            disabled={isFetching}
+          >
+            {isFetching ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Loading more conversations...
+              </>
+            ) : (
+              'Load more conversations'
+            )}
+          </Button>
+        </div>
+      )}
+
       {/* Sentinel element for infinite loading */}
-      <div ref={loadMoreSentinelRef} style={{ height: '1px' }} />
+      {useInfiniteScroll && <div ref={loadMoreSentinelRef} style={{ height: '1px' }} />}
 
       {/* End message */}
       {!hasFilter && !hasNextPage && realConversations.length > 0 && (

--- a/webui/src/components/ConversationList.tsx
+++ b/webui/src/components/ConversationList.tsx
@@ -52,6 +52,27 @@ import { toast } from 'sonner';
 
 type MessageBreakdown = Partial<Record<MessageRole, number>>;
 
+type SortBy = 'recent' | 'longest' | 'alpha';
+const SORT_STORAGE_KEY = 'gptme:conv-sort';
+const SORT_VALUES: SortBy[] = ['recent', 'longest', 'alpha'];
+
+function readSortPreference(): SortBy {
+  try {
+    const raw = localStorage.getItem(SORT_STORAGE_KEY);
+    return (SORT_VALUES.includes(raw as SortBy) ? raw : 'recent') as SortBy;
+  } catch {
+    return 'recent';
+  }
+}
+
+function writeSortPreference(value: SortBy): void {
+  try {
+    localStorage.setItem(SORT_STORAGE_KEY, value);
+  } catch {
+    // Silently ignore storage errors (restricted environments, quota exceeded)
+  }
+}
+
 interface Props {
   conversations: ConversationSummary[];
   onSelect: (id: string, serverId?: string) => void;
@@ -88,14 +109,10 @@ export const ConversationList: FC<Props> = ({
   const queryClient = useQueryClient();
   const [showStarredOnly, setShowStarredOnly] = useState(false);
 
-  type SortBy = 'recent' | 'longest' | 'alpha';
-  const SORT_STORAGE_KEY = 'gptme:conv-sort';
-  const [sortBy, setSortBy] = useState<SortBy>(
-    () => (localStorage.getItem(SORT_STORAGE_KEY) as SortBy | null) ?? 'recent'
-  );
+  const [sortBy, setSortBy] = useState<SortBy>(readSortPreference);
   const handleSortChange = (value: SortBy) => {
     setSortBy(value);
-    localStorage.setItem(SORT_STORAGE_KEY, value);
+    writeSortPreference(value);
   };
 
   // Separately track local star state for optimistic UI updates.
@@ -878,7 +895,7 @@ export const ConversationList: FC<Props> = ({
                 {showStarredOnly ? 'Starred' : 'All'}
               </button>
               <button
-                aria-label="Sort conversations"
+                aria-label={`Sort conversations: ${sortBy === 'recent' ? 'Recent' : sortBy === 'longest' ? 'Longest' : 'A-Z'} (click to cycle)`}
                 className="flex items-center gap-1 rounded px-2 py-0.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
                 onClick={() => {
                   const next: SortBy =

--- a/webui/src/components/ConversationList.tsx
+++ b/webui/src/components/ConversationList.tsx
@@ -14,6 +14,7 @@ import {
   Columns2,
   X,
   Star,
+  ArrowUpDown,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -86,6 +87,16 @@ export const ConversationList: FC<Props> = ({
   const { toggleStar } = useConversationMetadata();
   const queryClient = useQueryClient();
   const [showStarredOnly, setShowStarredOnly] = useState(false);
+
+  type SortBy = 'recent' | 'longest' | 'alpha';
+  const SORT_STORAGE_KEY = 'gptme:conv-sort';
+  const [sortBy, setSortBy] = useState<SortBy>(
+    () => (localStorage.getItem(SORT_STORAGE_KEY) as SortBy | null) ?? 'recent'
+  );
+  const handleSortChange = (value: SortBy) => {
+    setSortBy(value);
+    localStorage.setItem(SORT_STORAGE_KEY, value);
+  };
 
   // Separately track local star state for optimistic UI updates.
   // Keyed by conversation ID, value is the optimistic starred value.
@@ -806,6 +817,16 @@ export const ConversationList: FC<Props> = ({
     filteredRealConversations.length === 0 &&
     filteredDemos.length === 0;
 
+  // Sort filtered conversations. 'recent' keeps server order (modified desc); others sort flat.
+  const sortedRealConversations =
+    sortBy === 'recent'
+      ? filteredRealConversations
+      : filteredRealConversations.slice().sort((a, b) => {
+          if (sortBy === 'longest') return (b.messages ?? 0) - (a.messages ?? 0);
+          // alpha
+          return getConversationName(a).localeCompare(getConversationName(b));
+        });
+
   return (
     <div
       ref={scrollContainerRef}
@@ -840,9 +861,9 @@ export const ConversationList: FC<Props> = ({
               </Button>
             )}
           </div>
-          {/* Star filter toggle */}
+          {/* Star filter toggle + sort control */}
           {realConversations.length > 0 && (
-            <div className="flex px-1 pt-1">
+            <div className="flex items-center justify-between px-1 pt-1">
               <button
                 aria-label={showStarredOnly ? 'Show all conversations' : 'Show starred only'}
                 aria-pressed={showStarredOnly}
@@ -855,6 +876,19 @@ export const ConversationList: FC<Props> = ({
               >
                 <Star className="h-3 w-3" fill={showStarredOnly ? 'currentColor' : 'none'} />
                 {showStarredOnly ? 'Starred' : 'All'}
+              </button>
+              <button
+                aria-label="Sort conversations"
+                className="flex items-center gap-1 rounded px-2 py-0.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
+                onClick={() => {
+                  const next: SortBy =
+                    sortBy === 'recent' ? 'longest' : sortBy === 'longest' ? 'alpha' : 'recent';
+                  handleSortChange(next);
+                }}
+                title={`Sort: ${sortBy === 'recent' ? 'Recent' : sortBy === 'longest' ? 'Longest' : 'A-Z'} (click to cycle)`}
+              >
+                <ArrowUpDown className="h-3 w-3" />
+                {sortBy === 'recent' ? 'Recent' : sortBy === 'longest' ? 'Longest' : 'A-Z'}
               </button>
             </div>
           )}
@@ -896,11 +930,12 @@ export const ConversationList: FC<Props> = ({
         </div>
       )}
 
-      {/* Render real conversations grouped by date */}
+      {/* Render real conversations: grouped by date for 'recent', flat list for other sorts */}
       {!isLoading &&
         !isError &&
+        sortBy === 'recent' &&
         groupByDate<ConversationSummary>(
-          filteredRealConversations,
+          sortedRealConversations,
           (c) => c.created ?? c.modified
         ).map(({ group, items }) => (
           <div key={group}>
@@ -921,6 +956,17 @@ export const ConversationList: FC<Props> = ({
             </div>
           </div>
         ))}
+      {!isLoading && !isError && sortBy !== 'recent' && (
+        <div className="space-y-2 px-2">
+          {sortedRealConversations.map((conv) => (
+            <ConversationItem
+              key={conv.serverId ? `${conv.serverId}:${conv.id}` : conv.id}
+              conv={conv}
+              showLabel={showServerLabels}
+            />
+          ))}
+        </div>
+      )}
 
       {/* Loading indicator for fetching more */}
       {isFetching && !isLoading && (


### PR DESCRIPTION
## Summary

- Adds a cycle button in the conversation list filter bar to switch between three sort modes
- **Recent** (default): preserves server order with sticky date-group headers (Today / Yesterday / etc.) — same as before
- **Longest**: flat list sorted by message count descending — surfaces the most active conversations
- **A-Z**: flat list sorted by conversation name ascending — for quick name lookup
- Non-date sorts drop date grouping and render a flat list; switching back to Recent restores grouping
- Sort selection persists to `localStorage` (`gptme:conv-sort`) — survives page refresh
- Works alongside the existing star filter and search filter

## Related

- ErikBjare/bob#863 (performance improvement sweeps — part of the UX improvements surface)
- PR #2833 (added `message_count` / `last_updated` fields that make this possible)

## Implementation

Single-file change to `webui/src/components/ConversationList.tsx`:
- `SortBy` type + `sortBy` state with localStorage init
- `sortedRealConversations` computed from `filteredRealConversations`
- Sort cycle button (Recent → Longest → A-Z → Recent) with `ArrowUpDown` icon
- Conditional render: `groupByDate` for `recent`, flat `div` for other sorts