### PR TITLE
fix: two startup hangs — skip OpenRouter fetch for bare model names, non-blocking piped stdin

### DIFF
--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -84,6 +84,12 @@ def _validate_model_param(
 script_path = Path(os.path.realpath(__file__))
 _STDIN_PIPE_GRACE_PERIOD = 1.0
 
+# Sub-timeout used by the inner read loop in `_read_stdin` to disambiguate
+# "data ready" from "pipe fd is readable but write end is open and idle".
+# Tuned to 100ms — generous enough to bridge small producer gaps without
+# being so long that an idle pipe stalls the prompt for a noticeable beat.
+_STDIN_PIPE_INTER_CHUNK_TIMEOUT = 0.1
+
 
 class CommaSeparatedChoice(click.ParamType):
     """Click type that validates comma-separated values against a set of choices."""
@@ -1335,8 +1341,6 @@ def _read_stdin() -> str:
     # Use os.read + select with sub-timeouts rather than sys.stdin.read() which
     # blocks until EOF on a pipe — "readable" from select on a pipe fd can
     # fire even when the write end is open but idle (e.g. under uv run).
-    import os  # fmt: skip
-
     try:
         fd = sys.stdin.fileno()
     except (OSError, ValueError, AttributeError):
@@ -1349,7 +1353,7 @@ def _read_stdin() -> str:
 
     try:
         while time.monotonic() < deadline:
-            r, _, _ = select.select([fd], [], [], 0.05)
+            r, _, _ = select.select([fd], [], [], _STDIN_PIPE_INTER_CHUNK_TIMEOUT)
             if not r:
                 # No data arrived within the sub-timeout — pipe is open but idle.
                 # Don't block on read; return what we have.

--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -10,6 +10,7 @@ import shutil
 import signal
 import sys
 import tempfile
+import time
 import traceback
 from datetime import datetime, timezone
 from itertools import islice
@@ -1330,13 +1331,34 @@ def _read_stdin() -> str:
     if not readable:
         return ""
 
-    chunk_size = 1024  # 1 KB
-    all_data = ""
+    # stdin is readable (data available or pipe open but idle).
+    # Use os.read + select with sub-timeouts rather than sys.stdin.read() which
+    # blocks until EOF on a pipe — "readable" from select on a pipe fd can
+    # fire even when the write end is open but idle (e.g. under uv run).
+    import os  # fmt: skip
 
-    while True:
-        chunk = sys.stdin.read(chunk_size)
-        if not chunk:
-            break
-        all_data += chunk
+    try:
+        fd = sys.stdin.fileno()
+    except (OSError, ValueError, AttributeError):
+        # No real fd (e.g. StringIO in tests or piped stdin where fileno fails).
+        # Use blocking read — safe because non-pipe fds return immediately.
+        return sys.stdin.read()
+
+    all_data = ""
+    deadline = time.monotonic() + _STDIN_PIPE_GRACE_PERIOD
+
+    try:
+        while time.monotonic() < deadline:
+            r, _, _ = select.select([fd], [], [], 0.05)
+            if not r:
+                # No data arrived within the sub-timeout — pipe is open but idle.
+                # Don't block on read; return what we have.
+                break
+            chunk = os.read(fd, 4096)
+            if not chunk:
+                break  # EOF
+            all_data += chunk.decode("utf-8", errors="replace")
+    except (OSError, ValueError):
+        pass
 
     return all_data

--- a/gptme/llm/models/resolution.py
+++ b/gptme/llm/models/resolution.py
@@ -307,30 +307,36 @@ def get_model(model: str) -> ModelMeta:
         if model in MODELS[provider]:
             return ModelMeta(provider, model, **MODELS[provider][model])
 
-    # For model name without provider, also try dynamic fetching for openrouter
-    try:
-        from .listing import _get_models_for_provider  # fmt: skip
+    # For model name without provider, also try dynamic fetching for openrouter.
+    # Skip if the model name has no "/" — OpenRouter models are always
+    # provider/model format, so a bare name cannot match. The API timeout
+    # makes this a ~10s hang for every nonexistent bare model name (bad UX).
+    if "/" in model:
+        try:
+            from .listing import _get_models_for_provider  # fmt: skip
 
-        openrouter_models = _get_models_for_provider("openrouter", dynamic_fetch=True)
-        # Strip @ suffix for comparison (e.g., "z-ai/glm-5@z-ai" -> "z-ai/glm-5")
-        base_model = model.split("@")[0] if "@" in model else model
-        for model_meta in openrouter_models:
-            if model_meta.model == model or model_meta.model == base_model:
-                return ModelMeta(
-                    provider=model_meta.provider,
-                    model=model,  # Preserve original name with suffix
-                    context=model_meta.context,
-                    max_output=model_meta.max_output,
-                    supports_streaming=model_meta.supports_streaming,
-                    supports_vision=model_meta.supports_vision,
-                    supports_reasoning=model_meta.supports_reasoning,
-                    supports_responses_api=model_meta.supports_responses_api,
-                    price_input=model_meta.price_input,
-                    price_output=model_meta.price_output,
-                    knowledge_cutoff=model_meta.knowledge_cutoff,
-                )
-    except Exception as e:
-        logger.debug("Failed to fetch OpenRouter models for %s: %s", model, e)
+            openrouter_models = _get_models_for_provider(
+                "openrouter", dynamic_fetch=True
+            )
+            # Strip @ suffix for comparison (e.g., "z-ai/glm-5@z-ai" -> "z-ai/glm-5")
+            base_model = model.split("@")[0] if "@" in model else model
+            for model_meta in openrouter_models:
+                if model_meta.model == model or model_meta.model == base_model:
+                    return ModelMeta(
+                        provider=model_meta.provider,
+                        model=model,  # Preserve original name with suffix
+                        context=model_meta.context,
+                        max_output=model_meta.max_output,
+                        supports_streaming=model_meta.supports_streaming,
+                        supports_vision=model_meta.supports_vision,
+                        supports_reasoning=model_meta.supports_reasoning,
+                        supports_responses_api=model_meta.supports_responses_api,
+                        price_input=model_meta.price_input,
+                        price_output=model_meta.price_output,
+                        knowledge_cutoff=model_meta.knowledge_cutoff,
+                    )
+        except Exception as e:
+            logger.debug("Failed to fetch OpenRouter models for %s: %s", model, e)
 
     log_warn_once(f"Unknown model {model}, using fallback metadata")
     return ModelMeta(provider="unknown", model=model, context=128_000)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -265,6 +265,35 @@ def test_read_stdin_waits_briefly_for_slow_pipe_writer(monkeypatch):
         read_file.close()
 
 
+def test_read_stdin_does_not_truncate_chunks_separated_by_subtimeout(monkeypatch):
+    """Multiple chunks arriving with inter-chunk gaps > 50ms must not be truncated.
+
+    Regression test for the Greptile-flagged concern: the previous 50ms inner
+    sub-timeout could silently drop chunks from pipelines that write in bursts
+    with inter-chunk gaps slightly above 50ms. The new sub-timeout (100ms via
+    `_STDIN_PIPE_INTER_CHUNK_TIMEOUT`) bridges typical small producer gaps.
+    """
+    read_fd, write_fd = os.pipe()
+    read_file = os.fdopen(read_fd)
+    monkeypatch.setattr(cli.sys, "stdin", read_file)
+
+    chunks = [b"first ", b"second ", b"third"]
+
+    def _writer():
+        for chunk in chunks:
+            time.sleep(0.08)  # > old 50ms, < new 100ms sub-timeout
+            os.write(write_fd, chunk)
+        os.close(write_fd)
+
+    writer = threading.Thread(target=_writer)
+    writer.start()
+    try:
+        assert cli._read_stdin() == "first second third"
+    finally:
+        writer.join()
+        read_file.close()
+
+
 @pytest.mark.parametrize("bad_name", ["../bad-name", ".", "..", "foo/bar", "foo\\bar"])
 def test_name_rejects_path_traversal(bad_name: str, runner: CliRunner):
     result = runner.invoke(

--- a/tests/test_llm_models.py
+++ b/tests/test_llm_models.py
@@ -132,17 +132,38 @@ def test_get_models_for_provider_gptme_dynamic_fetch(mock_get_available_models):
 
 
 @patch("gptme.llm.models.listing._get_models_for_provider")
+def test_get_model_name_only_dynamic_fetch_skipped_without_slash(mock_get_models):
+    """Test that OpenRouter dynamic fetch is skipped for bare model names without '/'.
+
+    OpenRouter models are always provider/model format, so a bare name without '/'
+    cannot match. The API timeout makes this a ~10s hang for nonexistent models.
+    """
+    model = get_model("test-model")
+    assert model.provider == "unknown"
+    assert model.model == "test-model"
+    assert model.context == 128_000
+
+    # Should NOT try OpenRouter dynamic fetch (no "/" in model name)
+    mock_get_models.assert_not_called()
+
+
+@patch("gptme.llm.models.listing._get_models_for_provider")
 def test_get_model_name_only_with_dynamic_fetch(mock_get_models):
-    """Test model lookup by name only with dynamic fetching from OpenRouter."""
-    # Mock OpenRouter dynamic model
+    """Test model lookup by name only with dynamic fetching from OpenRouter.
+
+    Dynamic fetch is only attempted when the model name contains '/' (OpenRouter
+    format: provider/model).
+    """
+    # Mock OpenRouter dynamic model — model name includes "/"
     dynamic_model = ModelMeta(
-        provider="openrouter", model="test-model", context=100_000
+        provider="openrouter", model="test-provider/test-model", context=100_000
     )
     mock_get_models.return_value = [dynamic_model]
 
-    model = get_model("test-model")
+    # The name includes "/" so it could be an OpenRouter model
+    model = get_model("test-provider/test-model")
     assert model.provider == "openrouter"
-    assert model.model == "test-model"
+    assert model.model == "test-provider/test-model"
     assert model.context == 100_000
 
     # Should have tried OpenRouter dynamic fetch


### PR DESCRIPTION
Two separate issues causing `gptme --model <nonexistent>` to hang for 10s+ 
before showing an error message:

**1. get_model() fetched OpenRouter API for bare model names**
`gptme/llm/models/resolution.py`: `get_model()` tried OpenRouter API dynamic
fetch for bare model names without '/' — but OpenRouter models are always
`provider/model` format, so a bare name can never match. The API timeout
caused a ~10s hang for every nonexistent bare model name.

**2. _read_stdin() blocked on idle pipe under uv run**
`gptme/cli/main.py`: `_read_stdin()` called `sys.stdin.read()` on a pipe
that `select.select()` marked as readable — but on a pipe with an open but
idle write end, 'readable' doesn't guarantee data is available; `read()`
then blocks indefinitely waiting for data or EOF. Fixed by using `os.read()`
with select sub-timeouts so an idle pipe returns quickly.

**Testing**: 128 tests pass, 2 pre-existing failures in resume tests (unrelated).

Fixes a common UX complaint for users running gptme in non-TTY environments.