### PR TITLE
fix(server): validate model type in config PATCH to prevent 500

### DIFF
--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -2140,7 +2140,7 @@ def api_conversation_config_patch(conversation_id: str):
                 return raw_allowlist  # 400: bad type, no side effects
             tool_allowlist = raw_allowlist  # narrowed to list[str] | None
         if "model" in chat_patch and not isinstance(
-            chat_patch["model"], (str, type(None))
+            chat_patch["model"], str | type(None)
         ):
             return flask.jsonify({"error": "model must be a string"}), 400
 

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -2128,16 +2128,21 @@ def api_conversation_config_patch(conversation_id: str):
     if not isinstance(req_json, dict):
         return flask.jsonify({"error": "JSON body must be an object"}), 400
 
-    # Extract tool allowlist early for type-checking (no side effects).
+    # Extract and type-check fields early (no side effects).
     # init_tools validation is deferred to after the 404/409 guards because it
     # mutates process-wide state (loaded_tools, _tools_init_lock).
     tool_allowlist: list[str] | None = None
     chat_patch = req_json.get("chat")
-    if isinstance(chat_patch, dict) and "tools" in chat_patch:
-        raw_allowlist = _get_optional_string_list_field(chat_patch, "tools")
-        if isinstance(raw_allowlist, tuple):
-            return raw_allowlist  # 400: bad type, no side effects
-        tool_allowlist = raw_allowlist  # narrowed to list[str] | None
+    if isinstance(chat_patch, dict):
+        if "tools" in chat_patch:
+            raw_allowlist = _get_optional_string_list_field(chat_patch, "tools")
+            if isinstance(raw_allowlist, tuple):
+                return raw_allowlist  # 400: bad type, no side effects
+            tool_allowlist = raw_allowlist  # narrowed to list[str] | None
+        if "model" in chat_patch and not isinstance(
+            chat_patch["model"], (str, type(None))
+        ):
+            return flask.jsonify({"error": "model must be a string"}), 400
 
     logdir = get_logs_dir() / conversation_id
 

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -2030,6 +2030,26 @@ def test_v2_chat_config_patch_validates_tools_before_init(
     assert expected_error in data["error"]
 
 
+@pytest.mark.parametrize(
+    "bad_model",
+    [12345, 3.14, True, ["gpt-4"], {"name": "gpt-4"}],
+)
+def test_v2_chat_config_patch_rejects_non_string_model(
+    client: FlaskClient, bad_model: object
+):
+    """Config PATCH should reject non-string model values with 400 not 500."""
+    conv = create_conversation(client)
+    conversation_id = conv["conversation_id"]
+
+    response = client.patch(
+        f"/api/v2/conversations/{conversation_id}/config",
+        json={"chat": {"model": bad_model}},
+    )
+
+    assert response.status_code == 400
+    assert "model must be a string" in response.get_json()["error"]
+
+
 def test_v2_chat_config_patch_rejected_during_generation(client: FlaskClient):
     """Config PATCH should return 409 when a session is actively generating."""
     conv = create_conversation(client)


### PR DESCRIPTION
## Summary

- `PATCH /api/v2/conversations/{id}/config` with a non-string `chat.model` value (e.g. `{"chat": {"model": 12345}}`) crashed with a 500 (`TypeError: argument of type 'int' is not iterable`) deep inside `get_model()` instead of returning a clean 400
- Add early type validation mirroring the existing `tools` allowlist check: if `chat.model` is present but not a string or null, return 400 before any side-effecting operations
- Add parametrized regression test covering int, float, bool, list, and dict as bad model values (5 cases, all now return 400)

Found during dogfood sweep of the config PATCH surface.

## Test plan

- [x] `pytest tests/test_server_v2.py -k config_patch` — 15/15 passed locally
- [x] New test: `test_v2_chat_config_patch_rejects_non_string_model` (5 parametrized cases)
- [x] Pre-commit hooks clean