### PR TITLE
feat(openai): enable Responses API by default for gpt-5/o-series models

### DIFF
--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -115,31 +115,32 @@ Use the direct OpenAI Platform provider with ``openai/<model>``:
     gptme "fix this bug" -m openai/gpt-5.5
 
 GPT-5-class ``openai/*`` models (``gpt-5``, ``gpt-5.5``, ``gpt-5-mini``, and
-``gpt-5-nano``) support the OpenAI Responses API, but the direct OpenAI
-provider still keeps that path behind a feature gate for now.
-
-To enable the Responses API path for direct OpenAI GPT-5-class models, set
-``GPTME_OPENAI_RESPONSES_API=1``:
+``gpt-5-nano``) and o-series models automatically use the OpenAI Responses API.
+gptme routes these models through ``/v1/responses`` by default:
 
 .. code-block:: sh
 
     export OPENAI_API_KEY="your-api-key"
-    export GPTME_OPENAI_RESPONSES_API=1
     gptme "solve this problem" -m openai/gpt-5
 
-When that flag is enabled, gptme routes supported direct ``openai/*`` GPT-5
-models through ``/v1/responses``. Non-GPT-5 models, proxy providers such as
-OpenRouter, and other OpenAI-compatible backends continue using the legacy
-chat-completions path.
+Non-GPT-5 models, proxy providers such as OpenRouter, and other
+OpenAI-compatible backends continue using the chat-completions path.
 
-Set ``GPTME_OPENAI_RESPONSES_API=0`` (or unset it) to force the legacy path
-again while debugging or comparing behavior. In addition to ``1``, the flag
-also accepts ``true``, ``yes``, and ``on`` as truthy values.
+To force the legacy chat-completions path for debugging or comparison, set
+``GPTME_OPENAI_RESPONSES_API=0``:
+
+.. code-block:: sh
+
+    export GPTME_OPENAI_RESPONSES_API=0
+    gptme "solve this problem" -m openai/gpt-5
+
+In addition to ``0``, the flag also accepts ``false``, ``no``, and ``off`` as
+falsy values.
 
 .. note::
 
     This flag only affects the direct ``openai`` provider. The
-    ``openai-subscription`` provider already uses its own Responses API path by
+    ``openai-subscription`` provider uses its own Responses API path by
     default.
 
 .. rubric:: OpenRouter

--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -207,10 +207,15 @@ def _make_response_format(output_schema):
 
 
 def _responses_api_enabled() -> bool:
+    """Check whether the Responses API is enabled.
+
+    Enabled by default for models that support it (gpt-5 class, o-series).
+    Set GPTME_OPENAI_RESPONSES_API=0 to force Chat Completions for debugging.
+    """
     value = os.environ.get("GPTME_OPENAI_RESPONSES_API")
     if value is None:
-        return False
-    return value.strip().lower() in {"1", "true", "yes", "on"}
+        return True  # default-on for supported models
+    return value.strip().lower() not in {"0", "false", "no", "off"}
 
 
 def _should_use_responses_api(

--- a/tests/test_llm_openai.py
+++ b/tests/test_llm_openai.py
@@ -644,10 +644,8 @@ def test_message_conversion_gpt5_with_tool_results():
     assert first_part_3["text"] == "Saved to file.txt"
 
 
-def test_chat_uses_responses_api_for_gpt5_when_enabled(monkeypatch):
+def test_chat_uses_responses_api_for_gpt5_by_default(monkeypatch):
     from openai.types.responses.response_usage import ResponseUsage
-
-    monkeypatch.setenv("GPTME_OPENAI_RESPONSES_API", "1")
 
     fake_response = SimpleNamespace(
         output=[
@@ -705,8 +703,6 @@ def test_chat_uses_responses_api_for_gpt5_when_enabled(monkeypatch):
 
 
 def test_chat_responses_api_formats_function_calls(monkeypatch):
-    monkeypatch.setenv("GPTME_OPENAI_RESPONSES_API", "1")
-
     fake_response = SimpleNamespace(
         output=[
             SimpleNamespace(
@@ -825,23 +821,38 @@ def test_llm_openai_all_excludes_private_responses_helpers():
     assert "_messages_dicts_to_responses_input" not in llm_openai.__all__
 
 
-def test_should_use_responses_api_requires_direct_openai(monkeypatch):
-    monkeypatch.setenv("GPTME_OPENAI_RESPONSES_API", "1")
+def test_should_use_responses_api_enabled_by_default(monkeypatch):
+    """Responses API is on by default for supported models; off for unsupported or proxy."""
     monkeypatch.setattr(llm_openai, "_is_proxy", lambda client: False)
 
     client = cast(Any, SimpleNamespace())
+    # gpt-5 supports Responses API → enabled by default
     assert (
         _should_use_responses_api("openai", get_model("openai/gpt-5"), client) is True
     )
+    # gpt-4o does not have supports_responses_api=True → Chat Completions
     assert (
         _should_use_responses_api("openai", get_model("openai/gpt-4o"), client) is False
     )
+    # Non-openai provider → Chat Completions
     assert (
         _should_use_responses_api("openrouter", get_model("openai/gpt-5"), client)
         is False
     )
 
+    # Proxy → Chat Completions (proxy may not support Responses API format)
     monkeypatch.setattr(llm_openai, "_is_proxy", lambda client: True)
+    assert (
+        _should_use_responses_api("openai", get_model("openai/gpt-5"), client) is False
+    )
+
+
+def test_should_use_responses_api_can_be_disabled(monkeypatch):
+    """GPTME_OPENAI_RESPONSES_API=0 forces Chat Completions even for supported models."""
+    monkeypatch.setenv("GPTME_OPENAI_RESPONSES_API", "0")
+    monkeypatch.setattr(llm_openai, "_is_proxy", lambda client: False)
+
+    client = cast(Any, SimpleNamespace())
     assert (
         _should_use_responses_api("openai", get_model("openai/gpt-5"), client) is False
     )


### PR DESCRIPTION
## Summary

- `_responses_api_enabled()` now returns `True` by default instead of requiring `GPTME_OPENAI_RESPONSES_API=1`
- The Responses API path was added in #2397 as an opt-in experiment; the code is now mature and well-tested
- gpt-5 class models and o-series models (`supports_responses_api=True`) will automatically use the Responses API
- Opt out: set `GPTME_OPENAI_RESPONSES_API=0` to force Chat Completions for debugging

## Why now

The env-var gate was protective scaffolding for a new feature. The Responses API implementation is now complete with full streaming, tool-call, and reasoning support. The TODO in `llm_openai_subscription.py` explicitly calls out that both providers should use the same path.

## Changes

- `gptme/llm/llm_openai.py`: flip `_responses_api_enabled()` default from `False` to `True`; make `GPTME_OPENAI_RESPONSES_API=0` the opt-out
- `tests/test_llm_openai.py`: remove redundant `setenv("GPTME_OPENAI_RESPONSES_API", "1")` from tests, rename tests to reflect default-on semantics, add `test_should_use_responses_api_can_be_disabled` for the opt-out path

## Test plan

- [x] All 100 tests in `test_llm_openai.py` pass
- [x] 15 Responses API-specific tests pass without the env var
- [x] Opt-out test confirms `GPTME_OPENAI_RESPONSES_API=0` disables Responses API
- [ ] CI green