### PR TITLE
fix(models): validate provider default model entries + update groq default

### DIFF
--- a/gptme/llm/__init__.py
+++ b/gptme/llm/__init__.py
@@ -91,7 +91,7 @@ PROVIDER_DEFAULT_MODELS: dict[str, str] = {
     "openai": "openai/gpt-4o-mini",
     "openrouter": "openrouter/anthropic/claude-haiku-4-5",
     "gemini": "gemini/gemini-2.0-flash",
-    "groq": "groq/llama-3.1-8b-instant",
+    "groq": "groq/llama-3.3-70b-versatile",
     "xai": "xai/grok-3-mini",
     "deepseek": "deepseek/deepseek-chat",
     "moonshot": "moonshot/kimi-k2.6",

--- a/tests/test_llm_models.py
+++ b/tests/test_llm_models.py
@@ -47,6 +47,10 @@ def test_provider_default_models_resolve_without_unknown_fallback(
     assert model.provider_key == provider
     assert not any("Unknown model" in record.message for record in caplog.records)
 
+    # openrouter models are dynamic (fetched from the API at runtime) and are not
+    # in the static MODELS registry. _find_closest_model_properties also suppresses
+    # log_warn_once for openrouter, so the caplog assertion above is the only live
+    # check for that provider — the MODELS[provider] lookup would always be skipped.
     if provider != "openrouter":
         _, model_name = full_model.split("/", 1)
         model_name = MODEL_ALIASES.get(provider, {}).get(model_name, model_name)

--- a/tests/test_llm_models.py
+++ b/tests/test_llm_models.py
@@ -1,9 +1,12 @@
 import json
+import logging
 from unittest.mock import patch
 
 import pytest
 
+from gptme.llm import PROVIDER_DEFAULT_MODELS
 from gptme.llm.models import (
+    MODEL_ALIASES,
     MODELS,
     ModelMeta,
     _find_closest_model_properties,
@@ -27,6 +30,27 @@ def test_get_model_provider_only():
     model = get_model("openai")
     assert model.provider == "openai"
     assert model.model == "gpt-5"  # current recommended model
+
+
+@pytest.mark.parametrize(
+    ("provider", "full_model"),
+    sorted(PROVIDER_DEFAULT_MODELS.items()),
+)
+def test_provider_default_models_resolve_without_unknown_fallback(
+    provider, full_model, caplog
+):
+    """Provider default models should stay synced with the model registry."""
+    with caplog.at_level(logging.WARNING):
+        model = get_model(full_model)
+
+    assert model.full == full_model
+    assert model.provider_key == provider
+    assert not any("Unknown model" in record.message for record in caplog.records)
+
+    if provider != "openrouter":
+        _, model_name = full_model.split("/", 1)
+        model_name = MODEL_ALIASES.get(provider, {}).get(model_name, model_name)
+        assert model_name in MODELS[provider]
 
 
 def test_get_model_unknown_provider_model():


### PR DESCRIPTION
## Summary

- Updates groq provider default from `llama-3.1-8b-instant` to `llama-3.3-70b-versatile` (the current recommended model)
- Adds `test_provider_default_models_resolve_without_unknown_fallback` — a parametrized test that verifies every entry in `PROVIDER_DEFAULT_MODELS` resolves without triggering the "Unknown model" warning

## Motivation

When `minimax-m2.7 → minimax-m3` was retired, the provider-default mapping in `PROVIDER_DEFAULT_MODELS` was not updated. This was only caught by CI after the fact (`cbf958b681`). The new parametrized test catches this class of drift before it reaches master CI.

## Test plan

- [ ] `pytest tests/test_llm_models.py -v` — all parametrized cases pass (no "Unknown model" warnings)
- [ ] Existing model resolution tests unaffected