### PR TITLE
feat(webui): thread log_offset through conversation state for windowed pagination (Slice 1)

### DIFF
--- a/webui/src/components/ConversationContent.tsx
+++ b/webui/src/components/ConversationContent.tsx
@@ -7,6 +7,7 @@ import { useConversation } from '@/hooks/useConversation';
 import { BranchIndicator } from './BranchIndicator';
 import { computeForkPoints } from '@/utils/branchUtils';
 import { buildStepRoles, type StepRole } from '@/utils/stepGrouping';
+import type { Message } from '@/types/conversation';
 
 import { InlineToolConfirmation } from './InlineToolConfirmation';
 import { MessageSearchBar } from './MessageSearchBar';
@@ -227,7 +228,8 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
 
   // Recompute step roles when messages or visibility settings change.
   // All .get() calls inside are auto-tracked, so this re-runs when any of
-  // conversation log, showHiddenMessages, showInitialSystem, or firstNonSystemIndex changes.
+  // conversation log, showHiddenMessages, showInitialSystem, firstNonSystemIndex,
+  // or logOffset changes.
   useObserveEffect(() => {
     const messages = conversation$?.data.log.get();
     if (!messages?.length) {
@@ -235,10 +237,12 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
       return;
     }
 
+    const logOffset = conversation$?.logOffset?.get() ?? 0;
     const firstNonSystem = firstNonSystemIndex$.get();
     const showInitial = showInitialSystem$.get();
     const showHidden = showHiddenMessages$.get();
 
+    // isHidden receives LOCAL indices (array positions in messages[]).
     const isHidden = (idx: number) => {
       const msg = messages[idx];
       if (!msg) return false;
@@ -248,7 +252,8 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
       return false;
     };
 
-    stepRoles$.set(buildStepRoles(messages, isHidden));
+    // buildStepRoles emits absolute-indexed keys (localIdx + logOffset).
+    stepRoles$.set(buildStepRoles(messages as Message[], isHidden, logOffset));
   });
 
   // Create a ref for the scroll container
@@ -314,6 +319,7 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
 
   const isMessageHidden = useCallback(
     (idx: number) => {
+      // idx is a LOCAL index (array position in the current log window).
       const messages = conversation$.data.log.get();
       const msg = messages?.[idx];
       if (!msg) return false;
@@ -324,7 +330,9 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
       if (isInitialSystem && !showInitialSystem$.get()) return true;
       if (msg.hide && !showHiddenMessages$.get()) return true;
 
-      const stepRole = stepRoles$.get().get(idx);
+      // stepRoles$ is keyed by ABSOLUTE index.
+      const logOffset = conversation$?.logOffset?.get() ?? 0;
+      const stepRole = stepRoles$.get().get(logOffset + idx);
       if (
         (stepRole?.type === 'group-start' || stepRole?.type === 'grouped') &&
         !expandedGroups$.get().has(stepRole.groupId)
@@ -366,10 +374,13 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
       const q = query.toLowerCase();
       const messages = conversation$.data.log.get();
       if (!messages) return [];
+      // Read logOffset inside the callback so it's always fresh.
+      const logOffset = conversation$?.logOffset?.get() ?? 0;
       return messages
         .map((msg, i) => {
           const content = typeof msg.content === 'string' ? msg.content.toLowerCase() : '';
-          return !isMessageHidden(i) && content.includes(q) ? i : -1;
+          // Return ABSOLUTE index so highlightSearchMatch finds the right data-message-index.
+          return !isMessageHidden(i) && content.includes(q) ? logOffset + i : -1;
         })
         .filter((i) => i >= 0);
     },
@@ -599,23 +610,30 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
 
         <For each={conversation$?.data.log ?? []}>
           {(msg$) => {
+            // index is the LOCAL array position in the current log window.
             const index = getObservableIndex(msg$);
+            // absoluteIndex is the position in the full conversation (server-space).
+            // All server-bound operations and index-keyed maps use absoluteIndex.
+            const logOffset = conversation$?.logOffset?.get() ?? 0;
+            const absoluteIndex = logOffset + index;
+
             // Hide all system messages before the first non-system message by default
             const firstNonSystemIndex = firstNonSystemIndex$.get();
             const isInitialSystem =
               msg$.role.get() === 'system' &&
               (firstNonSystemIndex === -1 || index < firstNonSystemIndex);
             if (isInitialSystem && !showInitialSystem$.get()) {
-              return <div key={`${index}-${msg$.timestamp.get()}`} />;
+              return <div key={`${absoluteIndex}-${msg$.timestamp.get()}`} />;
             }
 
             // Hide messages with hide=true (e.g., auto-included lessons)
             if (msg$.hide?.get() && !showHiddenMessages$.get()) {
-              return <div key={`${index}-${msg$.timestamp.get()}`} />;
+              return <div key={`${absoluteIndex}-${msg$.timestamp.get()}`} />;
             }
 
             // Get the previous and next *visible* messages for chain context
             // (skip hidden messages so they don't break chain grouping)
+            // prevIdx/nextIdx are LOCAL for array traversal.
             let prevIdx = index - 1;
             while (prevIdx >= 0 && isMessageHidden(prevIdx)) prevIdx--;
             const previousMessage$ = prevIdx >= 0 ? conversation$.data.log[prevIdx] : undefined;
@@ -626,12 +644,12 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
               ? conversation$.data.log[nextIdx]
               : undefined;
 
-            // Step grouping: check if this message should be collapsed
-            const stepRole = stepRoles$.get().get(index);
+            // Step grouping: stepRoles$ is keyed by ABSOLUTE index.
+            const stepRole = stepRoles$.get().get(absoluteIndex);
 
             // If this is a grouped message and the group is collapsed, hide it
             if (stepRole?.type === 'grouped' && !expandedGroups$.get().has(stepRole.groupId)) {
-              return <div key={`${index}-${msg$.timestamp.get()}`} />;
+              return <div key={`${absoluteIndex}-${msg$.timestamp.get()}`} />;
             }
 
             // If this is a group-start, render the summary bar
@@ -649,7 +667,7 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
 
             // When group is collapsed and this is group-start, show only the summary bar
             if (stepRole?.type === 'group-start' && !expandedGroups$.get().has(stepRole.groupId)) {
-              return <div key={`${index}-${msg$.timestamp.get()}`}>{groupSummary}</div>;
+              return <div key={`${absoluteIndex}-${msg$.timestamp.get()}`}>{groupSummary}</div>;
             }
 
             // Construct agent avatar URL if agent has avatar configured
@@ -661,7 +679,10 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
             const agentName = conversation$.data.agent?.name?.get();
 
             return (
-              <div key={`${index}-${msg$.timestamp.get()}`} data-message-index={index}>
+              <div
+                key={`${absoluteIndex}-${msg$.timestamp.get()}`}
+                data-message-index={absoluteIndex}
+              >
                 {/* Show summary bar above first message when group is expanded */}
                 {groupSummary}
                 <ChatMessage
@@ -676,12 +697,13 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
                   onDelete={isReadOnly ? undefined : deleteMessage}
                   onRerun={isReadOnly ? undefined : rerunFromMessage}
                   onRegenerate={isReadOnly ? undefined : regenerateMessage}
-                  messageIndex={index}
+                  messageIndex={absoluteIndex}
                 />
                 {/* Branch indicator at fork points */}
                 <Memo>
                   {() => {
-                    const forkInfo = forkPoints$.get().get(index);
+                    // forkPoints$ is computed from branches and keyed by absolute index.
+                    const forkInfo = forkPoints$.get().get(absoluteIndex);
                     if (!forkInfo) return null;
                     return (
                       <div className="mx-auto max-w-3xl">

--- a/webui/src/hooks/useConversation.ts
+++ b/webui/src/hooks/useConversation.ts
@@ -9,6 +9,7 @@ import { use$ } from '@legendapp/state/react';
 import {
   conversations$,
   updateConversation,
+  updateConversationData,
   setGenerating,
   setConnected,
   setConnectionStatus,
@@ -136,7 +137,8 @@ export function useConversation(conversationId: string, serverId?: string) {
             // Also load the chat config
             try {
               const chatConfig = await api.getChatConfig(conversationId);
-              updateConversation(conversationId, { data, chatConfig, loadError: null });
+              updateConversationData(conversationId, data);
+              updateConversation(conversationId, { chatConfig, loadError: null });
               console.log(`[useConversation] Loaded conversation and config for ${conversationId}`);
             } catch (error) {
               console.warn(
@@ -144,7 +146,8 @@ export function useConversation(conversationId: string, serverId?: string) {
                 error
               );
               // Still update with conversation data even if config fails
-              updateConversation(conversationId, { data, loadError: null });
+              updateConversationData(conversationId, data);
+              updateConversation(conversationId, { loadError: null });
             }
           } catch (error) {
             console.warn(
@@ -733,7 +736,8 @@ export function useConversation(conversationId: string, serverId?: string) {
   const rerunFromMessage = async (index: number) => {
     if (!conversation$) return;
     const log = conversation$.data.log.get();
-    const isLastMessage = index === log.length - 1;
+    const localIndex = index - conversation$.logOffset.get();
+    const isLastMessage = localIndex === log.length - 1;
 
     try {
       if (!isLastMessage) {

--- a/webui/src/hooks/useConversation.ts
+++ b/webui/src/hooks/useConversation.ts
@@ -118,13 +118,17 @@ export function useConversation(conversationId: string, serverId?: string) {
           return;
         }
 
-        // Check if conversation already has data (e.g., from placeholder)
-        const hasExistingMessages = conversation$?.data.log.peek()?.length > 0;
+        // Only fetch from API when the window has not been properly hydrated.
+        // A non-zero log.length is not sufficient: a windowed prefetch or
+        // a placeholder conversation with injected messages would bypass the
+        // real API load and leave indices wrong. isWindowHydrated is set by
+        // updateConversationData() and initConversation(data).
+        const isWindowHydrated = conversation$?.isWindowHydrated?.peek() === true;
         console.log('[useConversation] Loading conversation', {
           conversationId,
-          hasExistingMessages,
+          isWindowHydrated,
         });
-        if (!hasExistingMessages) {
+        if (!isWindowHydrated) {
           // Only load from API if we don't already have conversation data
           try {
             const data = await api.getConversation(conversationId);

--- a/webui/src/stores/__tests__/conversations.test.ts
+++ b/webui/src/stores/__tests__/conversations.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, beforeEach } from '@jest/globals';
+import {
+  conversations$,
+  initConversation,
+  updateConversationData,
+  replaceLog,
+  prependLogPage,
+  toAbsoluteIndex,
+  toLocalIndex,
+} from '../conversations';
+import type { ConversationResponse } from '@/types/api';
+import type { Message } from '@/types/conversation';
+
+function makeResponse(overrides: Partial<ConversationResponse> = {}): ConversationResponse {
+  return {
+    id: 'test-conv',
+    name: 'Test',
+    log: [],
+    logfile: 'test-conv',
+    branches: {},
+    workspace: '/workspace',
+    ...overrides,
+  };
+}
+
+function msg(role: Message['role'], content = ''): Message {
+  return { role, content };
+}
+
+describe('index translation helpers', () => {
+  it('toAbsoluteIndex adds offset to local index', () => {
+    expect(toAbsoluteIndex(150, 0)).toBe(150);
+    expect(toAbsoluteIndex(150, 5)).toBe(155);
+    expect(toAbsoluteIndex(0, 3)).toBe(3);
+  });
+
+  it('toLocalIndex subtracts offset from absolute index', () => {
+    expect(toLocalIndex(150, 150)).toBe(0);
+    expect(toLocalIndex(150, 155)).toBe(5);
+    expect(toLocalIndex(0, 3)).toBe(3);
+  });
+
+  it('round-trips: toLocalIndex(offset, toAbsoluteIndex(offset, local)) === local', () => {
+    const offset = 42;
+    for (const local of [0, 1, 10, 99]) {
+      expect(toLocalIndex(offset, toAbsoluteIndex(offset, local))).toBe(local);
+    }
+  });
+});
+
+describe('updateConversationData window metadata', () => {
+  const id = 'test-conv';
+
+  beforeEach(() => {
+    initConversation(id);
+  });
+
+  it('sets logOffset=0 and hasMoreBefore=false for full-log response', () => {
+    const data = makeResponse({ log: [msg('user', 'hi'), msg('assistant', 'hello')] });
+    updateConversationData(id, data);
+
+    const conv = conversations$.get(id);
+    expect(conv?.logOffset.get()).toBe(0);
+    expect(conv?.hasMoreBefore.get()).toBe(false);
+    expect(conv?.isWindowHydrated.get()).toBe(true);
+  });
+
+  it('extracts logOffset from "before" cursor when has_more=true', () => {
+    // Server returns has_more=true, before=150 (start of the window).
+    // log[0] is at absolute index 150.
+    const data = makeResponse({
+      log: [msg('user', 'page start')],
+      has_more: true,
+      before: 150,
+      total_messages: 200,
+    });
+    updateConversationData(id, data);
+
+    const conv = conversations$.get(id);
+    expect(conv?.logOffset.get()).toBe(150);
+    expect(conv?.hasMoreBefore.get()).toBe(true);
+    expect(conv?.isWindowHydrated.get()).toBe(true);
+  });
+
+  it('sets logOffset=0 when has_more=false (no cursor needed)', () => {
+    const data = makeResponse({
+      log: [msg('user', 'first message')],
+      has_more: false,
+      total_messages: 1,
+    });
+    updateConversationData(id, data);
+
+    const conv = conversations$.get(id);
+    expect(conv?.logOffset.get()).toBe(0);
+    expect(conv?.hasMoreBefore.get()).toBe(false);
+  });
+
+  it('marks conversation as hydrated after update', () => {
+    initConversation(id); // isWindowHydrated starts false for placeholder
+    expect(conversations$.get(id)?.isWindowHydrated.get()).toBe(false);
+
+    updateConversationData(id, makeResponse());
+    expect(conversations$.get(id)?.isWindowHydrated.get()).toBe(true);
+  });
+});
+
+describe('replaceLog window metadata reset', () => {
+  const id = 'test-conv-2';
+
+  beforeEach(() => {
+    initConversation(id);
+    // Simulate a windowed state (e.g., after paginated open)
+    updateConversationData(id, makeResponse({ has_more: true, before: 100, total_messages: 200 }));
+  });
+
+  it('resets logOffset and hasMoreBefore to full-log defaults after server mutation', () => {
+    const fullLog = [msg('user', 'hi'), msg('assistant', 'hello')];
+    replaceLog(id, fullLog);
+
+    const conv = conversations$.get(id);
+    expect(conv?.logOffset.get()).toBe(0);
+    expect(conv?.hasMoreBefore.get()).toBe(false);
+    expect(conv?.isWindowHydrated.get()).toBe(true);
+  });
+});
+
+describe('prependLogPage', () => {
+  const id = 'test-conv-3';
+
+  beforeEach(() => {
+    initConversation(id);
+    // Start with last 50 messages loaded (logOffset=150, total=200)
+    const currentPage = [msg('user', 'page 2')];
+    updateConversationData(
+      id,
+      makeResponse({ log: currentPage, has_more: true, before: 150, total_messages: 200 })
+    );
+  });
+
+  it('prepends older messages and updates logOffset', () => {
+    const olderPage = [msg('system', 'old message')];
+    const olderOffset = 100; // absolute index of olderPage[0]
+    prependLogPage(id, olderPage, olderOffset, true);
+
+    const conv = conversations$.get(id);
+    const log = conv?.data.log.get();
+    expect(log?.length).toBe(2); // 1 older + 1 current
+    expect(log?.[0].role).toBe('system'); // older first
+    expect(log?.[1].role).toBe('user'); // current second
+    expect(conv?.logOffset.get()).toBe(100);
+    expect(conv?.hasMoreBefore.get()).toBe(true);
+  });
+
+  it('sets hasMoreBefore=false when prepending the first page', () => {
+    const firstPage = [msg('system', 'very first message')];
+    prependLogPage(id, firstPage, 0, false);
+
+    const conv = conversations$.get(id);
+    expect(conv?.logOffset.get()).toBe(0);
+    expect(conv?.hasMoreBefore.get()).toBe(false);
+  });
+});

--- a/webui/src/stores/__tests__/conversations.test.ts
+++ b/webui/src/stores/__tests__/conversations.test.ts
@@ -5,6 +5,7 @@ import {
   updateConversationData,
   replaceLog,
   prependLogPage,
+  setCurrentBranch,
   toAbsoluteIndex,
   toLocalIndex,
 } from '../conversations';
@@ -158,5 +159,46 @@ describe('prependLogPage', () => {
     const conv = conversations$.get(id);
     expect(conv?.logOffset.get()).toBe(0);
     expect(conv?.hasMoreBefore.get()).toBe(false);
+  });
+});
+
+describe('setCurrentBranch window metadata reset', () => {
+  const id = 'test-conv-4';
+
+  beforeEach(() => {
+    // Initialize with windowed state and a branch available
+    const mainLog = [msg('user', 'hi'), msg('assistant', 'hello')];
+    const altLog = [msg('user', 'alt start'), msg('assistant', 'alt reply')];
+    initConversation(id, {
+      id,
+      name: 'Test',
+      log: mainLog,
+      logfile: id,
+      branches: { main: mainLog, alt: altLog },
+      workspace: '/workspace',
+    });
+    // Simulate windowed state: logOffset=100, hasMoreBefore=true
+    conversations$.get(id)?.logOffset.set(100);
+    conversations$.get(id)?.hasMoreBefore.set(true);
+  });
+
+  it('resets window metadata when switching branches', () => {
+    setCurrentBranch(id, 'alt');
+
+    const conv = conversations$.get(id);
+    expect(conv?.currentBranch.get()).toBe('alt');
+    // Branch logs are always full logs — window must be reset to avoid stale offset
+    expect(conv?.logOffset.get()).toBe(0);
+    expect(conv?.hasMoreBefore.get()).toBe(false);
+    expect(conv?.isWindowHydrated.get()).toBe(true);
+  });
+
+  it('does not switch to a non-existent branch', () => {
+    setCurrentBranch(id, 'nonexistent');
+
+    const conv = conversations$.get(id);
+    // Branch unchanged, window metadata unchanged
+    expect(conv?.currentBranch.get()).toBe('main');
+    expect(conv?.logOffset.get()).toBe(100); // still the windowed offset
   });
 });

--- a/webui/src/stores/conversations.ts
+++ b/webui/src/stores/conversations.ts
@@ -332,10 +332,12 @@ export function updateConversationData(id: string, data: ConversationResponse) {
   if (!conv) return;
   // Derive offset: server sets 'before = start' only when has_more (start > 0).
   const logOffset = data.has_more ? (data.before ?? 0) : 0;
-  conv.data.set(data);
-  conv.logOffset.set(logOffset);
-  conv.hasMoreBefore.set(data.has_more ?? false);
-  conv.isWindowHydrated.set(true);
+  batch(() => {
+    conv.data.set(data);
+    conv.logOffset.set(logOffset);
+    conv.hasMoreBefore.set(data.has_more ?? false);
+    conv.isWindowHydrated.set(true);
+  });
 }
 
 /** Switch to a different branch, updating the displayed log */
@@ -344,8 +346,14 @@ export function setCurrentBranch(id: string, branch: string) {
   if (!conv) return;
   const branches = conv.data.branches?.get();
   if (!branches || !branches[branch]) return;
-  conv.currentBranch.set(branch);
-  conv.data.log.set(branches[branch]);
+  // Reset window metadata: branch logs are always full logs, never windowed.
+  batch(() => {
+    conv.currentBranch.set(branch);
+    conv.data.log.set(branches[branch]);
+    conv.logOffset.set(0);
+    conv.hasMoreBefore.set(false);
+    conv.isWindowHydrated.set(true);
+  });
 }
 
 /** Replace the entire log (used after server-side edit).
@@ -354,10 +362,12 @@ export function setCurrentBranch(id: string, branch: string) {
 export function replaceLog(id: string, log: Message[]) {
   const conv = conversations$.get(id);
   if (!conv) return;
-  conv.data.log.set(log);
-  conv.logOffset.set(0);
-  conv.hasMoreBefore.set(false);
-  conv.isWindowHydrated.set(true);
+  batch(() => {
+    conv.data.log.set(log);
+    conv.logOffset.set(0);
+    conv.hasMoreBefore.set(false);
+    conv.isWindowHydrated.set(true);
+  });
 }
 
 /** Prepend an older page of messages (for "load older" UX in Slice 2).
@@ -371,9 +381,11 @@ export function prependLogPage(
   const conv = conversations$.get(id);
   if (!conv) return;
   const currentLog = conv.data.log.get() as Message[];
-  conv.data.log.set([...olderLog, ...currentLog]);
-  conv.logOffset.set(olderOffset);
-  conv.hasMoreBefore.set(hasMoreBefore);
+  batch(() => {
+    conv.data.log.set([...olderLog, ...currentLog]);
+    conv.logOffset.set(olderOffset);
+    conv.hasMoreBefore.set(hasMoreBefore);
+  });
 }
 
 /** Update branch data */

--- a/webui/src/stores/conversations.ts
+++ b/webui/src/stores/conversations.ts
@@ -68,6 +68,14 @@ export interface ConversationState {
   temperature?: number;
   // Nucleus sampling top_p, persisted across operations. Undefined = provider default.
   topP?: number;
+  // Window metadata: tracks which slice of the full conversation is loaded.
+  // Absolute index of log[0] in the full conversation; 0 = full log from start.
+  logOffset: number;
+  // True when there are older messages that exist before logOffset.
+  hasMoreBefore: boolean;
+  // False for placeholder/prefetch entries that have not been properly hydrated
+  // from the API. Replaces the fragile hasExistingMessages check.
+  isWindowHydrated: boolean;
 }
 
 // Central store for all conversations
@@ -101,6 +109,9 @@ export function updateConversation(id: string, update: Partial<ConversationState
       needsInitialStep: false,
       initialStepStream: undefined,
       currentBranch: 'main',
+      logOffset: 0,
+      hasMoreBefore: false,
+      isWindowHydrated: false,
     });
   }
   // mergeIntoObservable treats an undefined value as "delete this key". `data`
@@ -271,6 +282,11 @@ export function initConversation(
     needsInitialStep: options?.needsInitialStep ?? false,
     initialStepStream: options?.initialStepStream,
     currentBranch: 'main',
+    logOffset: 0,
+    hasMoreBefore: false,
+    // Treat pre-supplied data (e.g. demo conversations) as hydrated;
+    // placeholder conversations created without data are NOT hydrated.
+    isWindowHydrated: data !== undefined,
   };
   conversations$.set(id, initial);
 }
@@ -301,9 +317,25 @@ export function setTopP(id: string, topP: number | undefined) {
   updateConversation(id, { topP });
 }
 
-// Update conversation data in the store
+// Index translation helpers — all server-bound ops and index-keyed maps use absolute indices.
+export function toAbsoluteIndex(logOffset: number, localIndex: number): number {
+  return logOffset + localIndex;
+}
+export function toLocalIndex(logOffset: number, absoluteIndex: number): number {
+  return absoluteIndex - logOffset;
+}
+
+// Update conversation data in the store, extracting window metadata from the response.
+// 'before' in a paged response = absolute index of log[0] when has_more=true.
 export function updateConversationData(id: string, data: ConversationResponse) {
-  conversations$.get(id)?.data.set(data);
+  const conv = conversations$.get(id);
+  if (!conv) return;
+  // Derive offset: server sets 'before = start' only when has_more (start > 0).
+  const logOffset = data.has_more ? (data.before ?? 0) : 0;
+  conv.data.set(data);
+  conv.logOffset.set(logOffset);
+  conv.hasMoreBefore.set(data.has_more ?? false);
+  conv.isWindowHydrated.set(true);
 }
 
 /** Switch to a different branch, updating the displayed log */
@@ -316,11 +348,32 @@ export function setCurrentBranch(id: string, branch: string) {
   conv.data.log.set(branches[branch]);
 }
 
-/** Replace the entire log (used after server-side edit) */
+/** Replace the entire log (used after server-side edit).
+ *  Server mutations (edit/delete/rerun) return the full log, so window metadata
+ *  is reset to a full-log state (offset=0, no older messages). */
 export function replaceLog(id: string, log: Message[]) {
   const conv = conversations$.get(id);
   if (!conv) return;
   conv.data.log.set(log);
+  conv.logOffset.set(0);
+  conv.hasMoreBefore.set(false);
+  conv.isWindowHydrated.set(true);
+}
+
+/** Prepend an older page of messages (for "load older" UX in Slice 2).
+ *  Updates logOffset and hasMoreBefore to reflect the newly extended window. */
+export function prependLogPage(
+  id: string,
+  olderLog: Message[],
+  olderOffset: number,
+  hasMoreBefore: boolean
+) {
+  const conv = conversations$.get(id);
+  if (!conv) return;
+  const currentLog = conv.data.log.get() as Message[];
+  conv.data.log.set([...olderLog, ...currentLog]);
+  conv.logOffset.set(olderOffset);
+  conv.hasMoreBefore.set(hasMoreBefore);
 }
 
 /** Update branch data */

--- a/webui/src/types/api.ts
+++ b/webui/src/types/api.ts
@@ -100,6 +100,11 @@ export interface ConversationResponse {
   branches: Record<string, Message[]>;
   workspace: string;
   agent?: AgentInfo;
+  // Pagination metadata (only present when limit param was used)
+  total_messages?: number;
+  has_more?: boolean;
+  // Cursor for the next older page = absolute index of log[0] (present when has_more=true)
+  before?: number;
 }
 
 export enum ToolFormat {

--- a/webui/src/utils/__tests__/stepGrouping.test.ts
+++ b/webui/src/utils/__tests__/stepGrouping.test.ts
@@ -313,4 +313,94 @@ describe('buildStepRoles', () => {
       ]);
     }
   });
+
+  describe('logOffset', () => {
+    // These tests verify Slice 1 of windowed pagination:
+    // buildStepRoles emits absolute indices (logOffset + localIndex) so that
+    // edit/delete/rerun targeting the correct server-side message position.
+
+    it('defaults to logOffset=0, producing local indices (backward-compat)', () => {
+      const messages = [
+        msg('user', 'do something'), // local 0
+        msg('assistant', 'using tool'), // local 1 - step
+        msg('system', 'saved file'), // local 2 - step
+        msg('assistant', 'done'), // local 3 - response
+      ];
+      const roles = buildStepRoles(messages, neverHidden);
+      // With logOffset=0, absolute == local
+      expect(roles.get(1)?.type).toBe('group-start');
+      expect(roles.get(2)?.type).toBe('grouped');
+      expect(roles.get(3)?.type).toBe('response');
+      // Local indices 0..3 should NOT appear under different keys
+      expect(roles.has(0)).toBe(false);
+    });
+
+    it('offsets all map keys by logOffset', () => {
+      const messages = [
+        msg('user', 'do something'), // local 0, absolute 150
+        msg('assistant', 'using tool'), // local 1, absolute 151 - step
+        msg('system', 'saved file'), // local 2, absolute 152 - step
+        msg('assistant', 'done'), // local 3, absolute 153 - response
+      ];
+      const logOffset = 150;
+      const roles = buildStepRoles(messages, neverHidden, logOffset);
+
+      // Local indices must NOT appear as keys
+      expect(roles.has(1)).toBe(false);
+      expect(roles.has(2)).toBe(false);
+      expect(roles.has(3)).toBe(false);
+
+      // Absolute indices must be present
+      expect(roles.get(151)?.type).toBe('group-start');
+      expect(roles.get(152)?.type).toBe('grouped');
+      expect(roles.get(153)?.type).toBe('response');
+    });
+
+    it('uses absolute index as groupId for stable expansion tracking', () => {
+      const messages = [
+        msg('user', 'do something'), // local 0, absolute 50
+        msg('assistant', 'using tool'), // local 1, absolute 51 - step
+        msg('system', 'saved file'), // local 2, absolute 52 - step
+        msg('assistant', 'done'), // local 3, absolute 53 - response
+      ];
+      const roles = buildStepRoles(messages, neverHidden, 50);
+
+      const start = roles.get(51);
+      expect(start?.type).toBe('group-start');
+      if (start?.type === 'group-start') {
+        // groupId = absolute index of first step (51)
+        expect(start.groupId).toBe(51);
+      }
+
+      const grouped = roles.get(52);
+      expect(grouped?.type).toBe('grouped');
+      if (grouped?.type === 'grouped') {
+        // grouped also references the same absolute groupId
+        expect(grouped.groupId).toBe(51);
+      }
+    });
+
+    it('isHidden receives local indices regardless of logOffset', () => {
+      // isHidden must still work with local array indices (0-based in messages[])
+      const hiddenLocalIdx = new Set([1]); // hide local index 1
+      const isHidden = (idx: number) => hiddenLocalIdx.has(idx);
+
+      const messages = [
+        msg('user', 'do something'), // local 0, absolute 100
+        msg('assistant', 'using tool'), // local 1 — HIDDEN, absolute 101
+        msg('system', 'saved file'), // local 2, absolute 102 - step
+        msg('assistant', 'step 2'), // local 3, absolute 103 - step
+        msg('assistant', 'done'), // local 4, absolute 104 - response
+      ];
+      const roles = buildStepRoles(messages, isHidden, 100);
+
+      // With local idx 1 hidden, only 2 visible intermediate steps remain
+      // (local 2 and 3), so grouping triggers — group-start at absolute 102
+      expect(roles.get(102)?.type).toBe('group-start');
+      expect(roles.get(103)?.type).toBe('grouped');
+      expect(roles.get(104)?.type).toBe('response');
+      // The hidden message at absolute 101 should not appear in the map
+      expect(roles.has(101)).toBe(false);
+    });
+  });
 });

--- a/webui/src/utils/stepGrouping.ts
+++ b/webui/src/utils/stepGrouping.ts
@@ -104,10 +104,15 @@ function extractToolSteps(content: string): ToolStepDetail[] {
  * Groups intermediate messages in each turn (between user messages),
  * keeping the last assistant message visible as the "response".
  * A "step" = one tool-use cycle (assistant action + system result).
+ *
+ * @param logOffset Absolute index of messages[0] in the full conversation.
+ *   All map keys are emitted as absolute indices (logOffset + localIndex).
+ *   isHidden is always called with LOCAL indices (array positions).
  */
 export function buildStepRoles(
   messages: Message[],
-  isHidden: (idx: number) => boolean
+  isHidden: (idx: number) => boolean,
+  logOffset: number = 0
 ): Map<number, StepRole> {
   const roles = new Map<number, StepRole>();
 
@@ -183,10 +188,11 @@ export function buildStepRoles(
         }
       }
 
-      // Use message index of first step as stable group ID
+      // Use absolute index of first step as stable group ID.
       // (incrementing counters shift when messages change, breaking expanded state)
       const firstIdx = stepIndices[0];
-      const stableGroupId = firstIdx;
+      const absFirstIdx = logOffset + firstIdx;
+      const stableGroupId = absFirstIdx; // absolute for stable identity across prepends
 
       // count = tool-call steps (not raw messages); fall back to message count if no system msgs
       const groupStart: Extract<StepRole, { type: 'group-start' }> = {
@@ -201,16 +207,16 @@ export function buildStepRoles(
         groupStart.steps = allSteps;
       }
 
-      roles.set(firstIdx, groupStart);
+      roles.set(absFirstIdx, groupStart);
 
       // Mark the rest as grouped (hidden when collapsed)
       for (let k = 1; k < stepIndices.length; k++) {
-        roles.set(stepIndices[k], { type: 'grouped', groupId: stableGroupId });
+        roles.set(logOffset + stepIndices[k], { type: 'grouped', groupId: stableGroupId });
       }
 
       // Mark response
       if (responseIdx >= 0) {
-        roles.set(responseIdx, { type: 'response' });
+        roles.set(logOffset + responseIdx, { type: 'response' });
       }
     }
 


### PR DESCRIPTION
## Summary

Prerequisite for Slice 2 (windowed open + "Load older" UX — `?limit=50` on open, older-page prepend). Without offset threading, a windowed fetch would corrupt edit/delete/rerun/fork/branch operations that pass the rendered array index directly to the server, which treats it as an absolute conversation index.

- Add `logOffset`, `hasMoreBefore`, `isWindowHydrated` to `ConversationState`
- Add `toAbsoluteIndex` / `toLocalIndex` helpers and `prependLogPage` store function
- `updateConversationData` extracts `logOffset` from the server's `before` cursor
- `replaceLog` resets window metadata (server mutations always return the full log)
- `buildStepRoles` accepts `logOffset` and emits absolute-indexed map keys (stable group IDs across prepends)
- `ConversationContent` computes `absoluteIndex = logOffset + localIndex` for all server-bound operations and index-keyed map lookups
- `computeSearchMatches` returns absolute indices, consistent with `data-message-index` DOM attributes
- Replaces fragile `hasExistingMessages` hydration gate with `isWindowHydrated`
- Adds pagination fields to `ConversationResponse` type (`total_messages`, `has_more`, `before`)

**No behavior change for `logOffset=0`** — all current full-log responses keep `logOffset=0`, so this PR is a pure plumbing change.

Related server-side PR: #2861 (adds `?limit` / `?before` pagination to conversation GET)
Design doc: `knowledge/technical-designs/gptme-webui-windowed-log-offset-design.md`

## Test plan
- [x] TypeScript: `npm run typecheck` passes (clean)
- [x] Jest: `npm test` passes — 31 tests (17 existing stepGrouping + 4 new offset tests + 10 new store tests)
- [ ] Manual: open a long conversation, verify edit/delete/rerun work on any message
- [ ] Manual: no behavioral difference for short conversations (`logOffset=0` for all current fetches)