### PR TITLE
fix(server): tolerate pre-existing workspace symlink in ChatConfig.from_logdir

### DIFF
--- a/gptme/chat.py
+++ b/gptme/chat.py
@@ -6,7 +6,7 @@ from collections.abc import Callable, Generator
 from pathlib import Path
 
 from .commands import execute_cmd
-from .config import ChatConfig, get_config
+from .config import ChatConfig, get_config, require_workspace_exists
 from .constants import (
     DECLINED_CONTENT,
     INTERRUPT_CONTENT,
@@ -130,6 +130,7 @@ def chat(
         # Initialize workspace
         if not is_output_json():
             console.log(f"Using workspace: {path_with_tilde(workspace)}")
+        require_workspace_exists(workspace)
         os.chdir(workspace)
 
         # print log (suppressed in JSON output mode)

--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -29,7 +29,7 @@ import gptme
 
 from ..chat import chat
 from ..commands import _gen_help
-from ..config import setup_config_from_cli
+from ..config import ensure_workspace_dir, setup_config_from_cli
 from ..constants import MULTIPROMPT_SEPARATOR
 from ..dirs import get_logs_dir
 from ..init import init_logging
@@ -939,7 +939,7 @@ def main(
     if workspace == "@log":
         workspace_path = logdir / "workspace"
         assert workspace_path  # mypy not smart enough to see its not None
-        workspace_path.mkdir(parents=True, exist_ok=True)
+        ensure_workspace_dir(workspace_path)
     else:
         workspace_path = Path(workspace) if workspace else Path.cwd()
 

--- a/gptme/config/__init__.py
+++ b/gptme/config/__init__.py
@@ -12,7 +12,7 @@ Split into sub-modules for maintainability:
 # Re-export everything for backward compatibility.
 # All existing ``from gptme.config import X`` statements continue to work.
 
-from .chat import ChatConfig
+from .chat import ChatConfig, ensure_workspace_dir, require_workspace_exists
 from .cli_setup import setup_config_from_cli
 from .core import (
     Config,
@@ -64,7 +64,9 @@ __all__ = [
     "UserPromptConfig",
     # Core functions
     "_config_var",
+    "ensure_workspace_dir",
     "get_config",
+    "require_workspace_exists",
     "set_config",
     "set_config_from_workspace",
     "reload_config",

--- a/gptme/config/chat.py
+++ b/gptme/config/chat.py
@@ -166,7 +166,13 @@ class ChatConfig:
             # This ensures server sessions get isolated workspaces
             # instead of sharing the server process's cwd.
             workspace = path / "workspace"
-            workspace.mkdir(parents=True, exist_ok=True)
+            # mkdir(exist_ok=True) only tolerates a pre-existing *directory*;
+            # it still raises FileExistsError when the path is a symlink or
+            # file (e.g. a manually-linked workspace). Skip creation if the
+            # path already exists in any form (is_symlink() also catches
+            # broken symlinks, which exists() does not).
+            if not (workspace.is_symlink() or workspace.exists()):
+                workspace.mkdir(parents=True, exist_ok=True)
             return cls(_logdir=path, workspace=workspace.resolve())
         try:
             if tomllib is not None:

--- a/gptme/config/chat.py
+++ b/gptme/config/chat.py
@@ -42,6 +42,34 @@ def _coerce_config_path(value: object, field_name: str) -> Path:
     return Path(value).expanduser().resolve()
 
 
+def ensure_workspace_dir(workspace: Path) -> None:
+    """Create the workspace directory unless it already exists in some form.
+
+    mkdir(parents=True, exist_ok=True) only tolerates a pre-existing
+    *directory*; it still raises FileExistsError when the path is a symlink or
+    file (e.g. a manually-linked workspace). Skip creation when the path
+    already exists in any form. is_symlink() also catches broken symlinks,
+    which exists() reports as absent.
+    """
+    if not (workspace.is_symlink() or workspace.exists()):
+        workspace.mkdir(parents=True, exist_ok=True)
+
+
+def require_workspace_exists(workspace: Path) -> None:
+    """Raise an actionable error if a configured workspace is missing.
+
+    Workspaces may be symlinks to external directories that later get moved or
+    deleted. We surface a clear message instead of a bare FileNotFoundError
+    (CLI) or a silently-dying step thread (server) when about to chdir into it.
+    """
+    if not workspace.exists():
+        raise FileNotFoundError(
+            f"Configured workspace does not exist: {workspace}\n"
+            "It may have been moved or deleted. Restore the directory, or update "
+            "the conversation's workspace (chat.workspace in its config.toml)."
+        )
+
+
 @dataclass
 class ChatConfig:
     """Configuration for a chat session."""
@@ -99,7 +127,7 @@ class ChatConfig:
                     raise ValueError("Cannot use '@log' workspace without logdir")
                 chat_data["workspace"] = (_logdir / "workspace").resolve()
                 if create_workspace:
-                    chat_data["workspace"].mkdir(parents=True, exist_ok=True)
+                    ensure_workspace_dir(chat_data["workspace"])
             else:
                 chat_data["workspace"] = _coerce_config_path(
                     workspace_value, "workspace"
@@ -166,13 +194,7 @@ class ChatConfig:
             # This ensures server sessions get isolated workspaces
             # instead of sharing the server process's cwd.
             workspace = path / "workspace"
-            # mkdir(exist_ok=True) only tolerates a pre-existing *directory*;
-            # it still raises FileExistsError when the path is a symlink or
-            # file (e.g. a manually-linked workspace). Skip creation if the
-            # path already exists in any form (is_symlink() also catches
-            # broken symlinks, which exists() does not).
-            if not (workspace.is_symlink() or workspace.exists()):
-                workspace.mkdir(parents=True, exist_ok=True)
+            ensure_workspace_dir(workspace)
             return cls(_logdir=path, workspace=workspace.resolve())
         try:
             if tomllib is not None:
@@ -276,7 +298,7 @@ class ChatConfig:
             # Workspace IS the log workspace — ensure the directory exists
             # (from_logdir creates it for new conversations, but callers
             # constructing ChatConfig directly may not have)
-            self.workspace.mkdir(parents=True, exist_ok=True)
+            ensure_workspace_dir(self.workspace)
 
         return self
 

--- a/gptme/server/session_step.py
+++ b/gptme/server/session_step.py
@@ -20,7 +20,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from ..config import ChatConfig
+from ..config import ChatConfig, require_workspace_exists
 from ..dirs import get_logs_dir
 from ..executor import prepare_execution_environment
 from ..hooks import HookType, trigger_hook
@@ -578,6 +578,22 @@ def step(
         branch=branch,
         lock=False,
     )
+
+    # Fail cleanly if the configured workspace is missing (e.g. an external
+    # symlinked workspace that was moved/deleted). step() runs in a daemon
+    # thread, so an uncaught error here would silently leave the session stuck
+    # in "generating"; emit a visible error event and stop instead of letting
+    # the later os.chdir(workspace) crash the thread.
+    try:
+        require_workspace_exists(workspace)
+    except FileNotFoundError as e:
+        ws_error_event: ErrorEvent = {"type": "error", "error": str(e)}
+        _persist_generation_error(manager, session, str(e))
+        SessionManager.add_event(conversation_id, ws_error_event)
+        session.last_error = str(e)
+        session.generating = False
+        session.generating_since = None
+        return
 
     # Set the model as default before triggering hooks
     # This ensures hooks like token_awareness can access the model

--- a/tests/test_chat_config.py
+++ b/tests/test_chat_config.py
@@ -15,6 +15,22 @@ def test_chat_config_from_logdir(tmp_path: Path):
     assert loaded.model == "test-model"
 
 
+def test_chat_config_from_logdir_workspace_symlink(tmp_path: Path):
+    """from_logdir must not crash when 'workspace' is a pre-existing symlink.
+
+    Some older conversations have a manually-created 'workspace' symlink
+    instead of a directory. mkdir(exist_ok=True) raises FileExistsError on a
+    symlink/non-dir, which previously 500'd the conversations list endpoint.
+    """
+    logdir = tmp_path / "conv"
+    logdir.mkdir()
+    target = tmp_path / "linked-workspace"
+    (logdir / "workspace").symlink_to(target)  # broken symlink (target absent)
+
+    loaded = ChatConfig.from_logdir(logdir)
+    assert loaded.workspace == target
+
+
 def test_chat_config_load_or_create(tmp_path: Path):
     """Test loading or creating ChatConfig with CLI overrides."""
     # Test with no existing config

--- a/tests/test_chat_config.py
+++ b/tests/test_chat_config.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pytest
 import tomlkit
 
-from gptme.config import ChatConfig
+from gptme.config import ChatConfig, ensure_workspace_dir, require_workspace_exists
 
 
 def test_chat_config_from_logdir(tmp_path: Path):
@@ -29,6 +29,41 @@ def test_chat_config_from_logdir_workspace_symlink(tmp_path: Path):
 
     loaded = ChatConfig.from_logdir(logdir)
     assert loaded.workspace == target
+
+
+def test_ensure_workspace_dir(tmp_path: Path):
+    """ensure_workspace_dir creates a missing dir but tolerates symlinks."""
+    # Missing → created
+    ws = tmp_path / "ws"
+    ensure_workspace_dir(ws)
+    assert ws.is_dir()
+
+    # Pre-existing dir → no-op, no error
+    ensure_workspace_dir(ws)
+
+    # Broken symlink → left as-is, no FileExistsError
+    link = tmp_path / "link"
+    link.symlink_to(tmp_path / "absent")
+    ensure_workspace_dir(link)
+    assert link.is_symlink()
+    assert not link.exists()  # target still absent — not created
+
+
+def test_require_workspace_exists(tmp_path: Path):
+    """require_workspace_exists raises an actionable error only when missing."""
+    existing = tmp_path / "here"
+    existing.mkdir()
+    require_workspace_exists(existing)  # no raise
+
+    missing = tmp_path / "gone"
+    with pytest.raises(FileNotFoundError, match="workspace does not exist"):
+        require_workspace_exists(missing)
+
+    # Broken symlink counts as missing (target absent)
+    link = tmp_path / "link"
+    link.symlink_to(tmp_path / "absent")
+    with pytest.raises(FileNotFoundError, match="workspace does not exist"):
+        require_workspace_exists(link)
 
 
 def test_chat_config_load_or_create(tmp_path: Path):


### PR DESCRIPTION
## Summary
A conversation whose `workspace` is a **symlink to a now-missing directory** (e.g. an external workspace that was moved/deleted) broke gptme in several places. This PR makes the read path tolerant and the run path fail *cleanly* instead of crashing.

### Read path (list/load) — no longer crashes
- `GET /api/v2/conversations` 500'd because `ChatConfig.from_logdir` calls `workspace.mkdir(parents=True, exist_ok=True)`, and `exist_ok=True` only tolerates a pre-existing *directory* — a symlink (even broken) raises `FileExistsError`, taking down the whole list.
- Extracted `ensure_workspace_dir()` (symlink-tolerant mkdir) and reused it across `from_logdir` / `from_dict` (`@log`) / `save()` and the CLI `@log` path, so no workspace-creation site `FileExistsError`s on a pre-existing symlink.

### Run path (CLI + server step) — fails with an actionable message
Listing/loading was fixed, but *running* such a conversation still crashed at `os.chdir(workspace)`:
- **CLI** (`chat.py`): bare `FileNotFoundError`.
- **Server** (`session_step.py`): `step()` runs in a **daemon thread**, so the crash left the session stuck in `generating` forever with no error surfaced to the webui.

Added `require_workspace_exists()` (raises an actionable message) and validated before the chdir in both paths. The CLI surfaces it via the existing fatal-error handler; the server emits a visible error event and resets the generating flags.

**Policy:** a moved/deleted workspace fails until manually corrected (restore the dir, or update `chat.workspace`) rather than being silently recreated or relocated.

Observed in the wild:
```
FileExistsError: [Errno 17] File exists: '.../logs/2025-03-21-skipping-purple-octopus/workspace'
  at gptme/config/chat.py:169 in from_logdir
```
where `workspace -> /Users/.../server-refactor` (symlink to a since-removed dir).

## Test plan
- [x] New unit tests: `ensure_workspace_dir` (creates/tolerates symlink), `require_workspace_exists` (raises only when missing), `from_logdir` broken-symlink workspace
- [x] `tests/test_chat_config.py` passes (11 passed)
- [x] Reproduced the original 500 against the real logdir; gone after the fix
- [x] ruff + mypy clean (pre-commit)