### PR TITLE
refactor(llm): extract shared Responses API event loop into openai_responses.py

### DIFF
--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -31,10 +31,9 @@ from .openai_responses import (
     ToolCallFunction,
     _content_to_responses_input,  # noqa: F401
     _extract_usage_token_counts,
-    _filter_duplicate_thinking_text,
-    _longest_suffix_prefix,
     _messages_dicts_to_responses_input,
     _obj_get,
+    _stream_responses_events,
     _tool_spec_to_responses_tool,
 )
 from .utils import (
@@ -1068,100 +1067,14 @@ def _stream_responses(
         if top_p_value is not None:
             kwargs["top_p"] = top_p_value
 
-    # Track function-call items: output_index -> (item_id, name, call_id)
-    func_call_items: dict[int, tuple[str, str, str]] = {}
-    header_emitted: set[int] = set()
-    # Guard against double-wrapping: some models emit BOTH structured
-    # reasoning deltas AND raw <thinking> tags in output_text.delta.
-    # If structured reasoning was seen, skip text-tag conversion so
-    # the output doesn't become <think><think>...</think></think>.
-    seen_reasoning_delta = False
-    in_reasoning_block = False
-    in_duplicate_thinking_block = False
-    # Buffer for detecting <thinking> / </thinking> tags split across
-    # SSE chunks (max tag length is ~11 characters).
-    pending = ""
     captured_metadata: MessageMetadata | None = None
 
+    def _capture_usage(usage: Any) -> None:
+        nonlocal captured_metadata
+        captured_metadata = _record_usage(usage, model)
+
     stream = client.responses.create(**kwargs)
-
-    for event in stream:
-        if event.type == "response.output_item.added":
-            item = event.item
-            if _obj_get(item, "type") == "function_call":
-                func_call_items[event.output_index] = (
-                    _obj_get(item, "id") or _obj_get(item, "call_id") or "",
-                    _obj_get(item, "name", ""),
-                    _obj_get(item, "call_id", ""),
-                )
-
-        elif event.type == "response.reasoning_text.delta":
-            if not in_reasoning_block:
-                # Flush any partial-tag buffer before opening think block
-                if pending:
-                    yield pending.replace("<thinking>", "<think>").replace(
-                        "</thinking>", "</think>"
-                    )
-                    pending = ""
-                yield "<think>\n"
-                in_reasoning_block = True
-                seen_reasoning_delta = True
-            yield event.delta
-
-        elif event.type == "response.output_text.delta":
-            if in_reasoning_block:
-                yield "\n</think>\n"
-                in_reasoning_block = False
-
-            delta_text = event.delta
-            if delta_text:
-                # Combine with any previous partial-tag buffer
-                text = pending + delta_text
-                pending = ""
-
-                if seen_reasoning_delta:
-                    text, pending, in_duplicate_thinking_block = (
-                        _filter_duplicate_thinking_text(
-                            text, in_thinking_block=in_duplicate_thinking_block
-                        )
-                    )
-                else:
-                    # Hold back potential partial tag suffix to check in
-                    # next chunk. A trailing `<` is buffered because it
-                    # could be the start of either <thinking> or
-                    # </thinking>.
-                    for tag in ("<thinking>", "</thinking>"):
-                        pending = _longest_suffix_prefix(text, tag)
-                        if pending:
-                            text = text[: -len(pending)]
-                            break
-
-                    # Convert <thinking>/</thinking> to <think>/</think>
-                    text = text.replace("<thinking>", "<think>").replace(
-                        "</thinking>", "</think>"
-                    )
-                if text:
-                    yield text
-
-        elif event.type == "response.function_call_arguments.delta":
-            output_index = event.output_index
-            if output_index not in header_emitted:
-                _, name, call_id = func_call_items.get(output_index, ("", "", ""))
-                yield f"\n@{name}({call_id}): "
-                header_emitted.add(output_index)
-            yield event.delta
-
-        elif event.type == "response.completed":
-            if event.response.usage:
-                captured_metadata = _record_usage(event.response.usage, model)
-
-    # Flush any remaining state.
-    if in_reasoning_block:
-        yield "\n</think>\n"
-    if pending and not in_duplicate_thinking_block:
-        yield pending.replace("<thinking>", "<think>").replace(
-            "</thinking>", "</think>"
-        )
+    yield from _stream_responses_events(stream, usage_callback=_capture_usage)
 
     return captured_metadata
 

--- a/gptme/llm/llm_openai_subscription.py
+++ b/gptme/llm/llm_openai_subscription.py
@@ -51,9 +51,8 @@ import requests
 
 from ..message import Message
 from .openai_responses import (
-    _filter_duplicate_thinking_text,
-    _longest_suffix_prefix,
     _messages_to_responses_input,
+    _stream_responses_events,
     _tool_spec_to_responses_tool,
 )
 
@@ -545,115 +544,18 @@ def stream(
         error_text = response.text[:500]
         raise ValueError(f"Codex API error {response.status_code}: {error_text}")
 
-    in_reasoning_block = False
-    # Track whether this stream uses structured reasoning.delta events.
-    # When true, skip <thinking>→<think> text conversion to avoid double-wrapping:
-    # gpt-5.4 can emit BOTH response.reasoning.delta AND raw <thinking> tags in
-    # output_text.delta for the same content, causing <think><think>...</think></think>.
-    seen_reasoning_delta = False
-    # Buffer to detect tags split across SSE chunks (max tag length is ~11 chars)
-    pending = ""
-    in_duplicate_thinking_block = False
+    def _sse_events():
+        for line in response.iter_lines():
+            if not line:
+                continue
+            data = _parse_sse_response(line)
+            if data is None:
+                continue
+            if data.get("done"):
+                return
+            yield data
 
-    for line in response.iter_lines():
-        if not line:
-            continue
-
-        data = _parse_sse_response(line)
-        if data is None:
-            continue
-
-        if data.get("done"):
-            break
-
-        # Handle Responses API SSE events
-        event_type = data.get("type", "")
-
-        if event_type == "response.reasoning.delta":
-            # Structured reasoning content — wrap in <think> blocks
-            delta_text = data.get("delta", "")
-            if delta_text:
-                seen_reasoning_delta = True
-                if not in_reasoning_block:
-                    # Flush any pending partial-tag buffer before opening think block
-                    if pending:
-                        yield pending.replace("<thinking>", "<think>").replace(
-                            "</thinking>", "</think>"
-                        )
-                        pending = ""
-                    yield "<think>\n"
-                    in_reasoning_block = True
-                yield delta_text
-
-        elif event_type == "response.output_text.delta":
-            # Text output — close any open reasoning block first, then handle
-            # <thinking> tags that some models emit as plain text.
-            # Only convert <thinking> tags when no structured reasoning.delta was seen —
-            # if both mechanisms fire (gpt-5.4 emits both), skip text conversion to
-            # avoid double-wrapping <think><think>...</think></think>.
-            if in_reasoning_block:
-                yield "\n</think>\n"
-                in_reasoning_block = False
-
-            delta_text = data.get("delta", "")
-            if delta_text:
-                # Combine with any pending partial-tag buffer
-                text = pending + delta_text
-                pending = ""
-
-                if seen_reasoning_delta:
-                    text, pending, in_duplicate_thinking_block = (
-                        _filter_duplicate_thinking_text(
-                            text, in_thinking_block=in_duplicate_thinking_block
-                        )
-                    )
-                else:
-                    for tag in ("<thinking>", "</thinking>"):
-                        pending = _longest_suffix_prefix(text, tag)
-                        if pending:
-                            text = text[: -len(pending)]
-                            break
-                    text = text.replace("<thinking>", "<think>").replace(
-                        "</thinking>", "</think>"
-                    )
-                if text:
-                    yield text
-
-        elif event_type == "response.output_item.added":
-            # Function call start: emit @name(call_id): prefix
-            if in_reasoning_block:
-                yield "\n</think>\n"
-                in_reasoning_block = False
-            if pending and not in_duplicate_thinking_block:
-                yield pending.replace("<thinking>", "<think>").replace(
-                    "</thinking>", "</think>"
-                )
-            pending = ""
-            item = data.get("item", {})
-            if item.get("type") == "function_call":
-                name = item.get("name", "")
-                call_id = item.get("call_id", "")
-                yield f"\n@{name}({call_id}): "
-
-        elif event_type == "response.function_call_arguments.delta":
-            # Function call argument chunks
-            delta_text = data.get("delta", "")
-            if delta_text:
-                yield delta_text
-
-        elif event_type == "response.done":
-            break
-
-    # Flush any remaining state.
-    # Invariant: pending and in_reasoning_block are mutually exclusive —
-    # reasoning.delta always flushes pending before setting in_reasoning_block.
-    # Close the reasoning block first so any pending text lands outside it.
-    if in_reasoning_block:
-        yield "\n</think>\n"
-    if pending and not in_duplicate_thinking_block:
-        yield pending.replace("<thinking>", "<think>").replace(
-            "</thinking>", "</think>"
-        )
+    yield from _stream_responses_events(_sse_events())
 
 
 def chat(

--- a/gptme/llm/openai_responses.py
+++ b/gptme/llm/openai_responses.py
@@ -12,6 +12,8 @@ from typing_extensions import NotRequired
 from .utils import extract_tool_uses_from_assistant_message, parameters2dict
 
 if TYPE_CHECKING:
+    from collections.abc import Callable, Generator, Iterable
+
     from ..message import Message
     from ..tools import ToolSpec
 
@@ -306,6 +308,119 @@ def _messages_to_responses_input(
 
     instructions = "\n\n".join(instructions_parts).strip() or None
     return instructions, items
+
+
+def _stream_responses_events(
+    event_iter: Iterable[Any],
+    *,
+    usage_callback: Callable[[Any], None] | None = None,
+) -> Generator[str, None, None]:
+    """Process a Responses API event stream, yielding formatted text chunks.
+
+    Works with both OpenAI SDK event objects and raw SSE dicts from the
+    subscription provider — ``_obj_get()`` handles both dict and attribute access.
+    Accepts ``response.reasoning_text.delta`` (SDK) or ``response.reasoning.delta``
+    (chatgpt.com backend) interchangeably.
+
+    ``usage_callback`` is called with the usage object from ``response.completed``
+    events; subscription streams (which use ``response.done``) never trigger it.
+    """
+    in_reasoning_block = False
+    seen_reasoning_delta = False
+    in_duplicate_thinking_block = False
+    pending = ""
+    func_call_items: dict[int, tuple[str, str]] = {}  # output_index -> (name, call_id)
+    header_emitted: set[int] = set()
+
+    for event in event_iter:
+        event_type = _obj_get(event, "type", "")
+
+        if event_type in ("response.reasoning_text.delta", "response.reasoning.delta"):
+            delta = _obj_get(event, "delta", "")
+            if delta:
+                if not in_reasoning_block:
+                    if pending:
+                        yield pending.replace("<thinking>", "<think>").replace(
+                            "</thinking>", "</think>"
+                        )
+                        pending = ""
+                    yield "<think>\n"
+                    in_reasoning_block = True
+                    seen_reasoning_delta = True
+                yield delta
+
+        elif event_type == "response.output_text.delta":
+            if in_reasoning_block:
+                yield "\n</think>\n"
+                in_reasoning_block = False
+
+            delta = _obj_get(event, "delta", "")
+            if delta:
+                text = pending + delta
+                pending = ""
+
+                if seen_reasoning_delta:
+                    text, pending, in_duplicate_thinking_block = (
+                        _filter_duplicate_thinking_text(
+                            text, in_thinking_block=in_duplicate_thinking_block
+                        )
+                    )
+                else:
+                    for tag in ("<thinking>", "</thinking>"):
+                        pending = _longest_suffix_prefix(text, tag)
+                        if pending:
+                            text = text[: -len(pending)]
+                            break
+                    text = text.replace("<thinking>", "<think>").replace(
+                        "</thinking>", "</think>"
+                    )
+
+                if text:
+                    yield text
+
+        elif event_type == "response.output_item.added":
+            if in_reasoning_block:
+                yield "\n</think>\n"
+                in_reasoning_block = False
+            if pending and not in_duplicate_thinking_block:
+                yield pending.replace("<thinking>", "<think>").replace(
+                    "</thinking>", "</think>"
+                )
+            pending = ""
+
+            item = _obj_get(event, "item", None)
+            if item is not None and _obj_get(item, "type") == "function_call":
+                output_index = _obj_get(event, "output_index", 0)
+                func_call_items[output_index] = (
+                    _obj_get(item, "name", ""),
+                    _obj_get(item, "call_id", "") or _obj_get(item, "id", ""),
+                )
+
+        elif event_type == "response.function_call_arguments.delta":
+            output_index = _obj_get(event, "output_index", 0)
+            if output_index not in header_emitted:
+                name, call_id = func_call_items.get(output_index, ("", ""))
+                yield f"\n@{name}({call_id}): "
+                header_emitted.add(output_index)
+            delta = _obj_get(event, "delta", "")
+            if delta:
+                yield delta
+
+        elif event_type in ("response.completed", "response.done"):
+            if usage_callback is not None and event_type == "response.completed":
+                response_obj = _obj_get(event, "response", None)
+                if response_obj is not None:
+                    usage = _obj_get(response_obj, "usage", None)
+                    if usage is not None:
+                        usage_callback(usage)
+            break
+
+    if in_reasoning_block:
+        yield "\n</think>\n"
+    if pending and not in_duplicate_thinking_block:
+        yield pending.replace("<thinking>", "<think>").replace(
+            "</thinking>", "</think>"
+        )
 
 
 def _extract_usage_token_counts(usage: Any) -> UsageTokenCounts:


### PR DESCRIPTION
## Summary

- Extracts the duplicated ~100-line Responses API SSE event-handling loop from both `llm_openai.py` and `llm_openai_subscription.py` into a new shared `_stream_responses_events()` helper in `openai_responses.py`
- Net -70 LOC across the three files (134 inserted, 204 deleted)
- The code comment in `llm_openai.py` already called for this exact merge

## What the shared helper does

`_stream_responses_events(event_iter, *, usage_callback=None)` handles the full event loop using `_obj_get()` throughout — so it works with both OpenAI SDK event objects (attribute access) and raw SSE dicts from the subscription provider (dict access). Accepts both `response.reasoning_text.delta` (SDK) and `response.reasoning.delta` (chatgpt.com backend) interchangeably.

**Callers after this change:**
- `_stream_responses()` — wraps `client.responses.create()` stream; passes a `usage_callback` closure to capture metadata from `response.completed`
- `subscription.stream()` — wraps `response.iter_lines()` in a `_sse_events()` generator and passes it to the shared helper

## Test plan

- [x] All 106 existing `test_llm_openai` + `test_llm_openai_sampling` tests pass
- [x] `mypy` clean on all 3 modified files
- [x] `ruff check` + `ruff format` clean