### PR TITLE
feat(llm): route gptme cloud models through their real backend SDK

### DIFF
--- a/gptme/llm/__init__.py
+++ b/gptme/llm/__init__.py
@@ -363,6 +363,28 @@ def _get_base_model(model: str) -> str:
     return model.split("/", 1)[1]
 
 
+def _gptme_backend(model: str) -> tuple[str, str] | None:
+    """For a gptme cloud model, return (backend_provider, bare_model).
+
+    gptme cloud models carry their real backend as a prefix in the resolved
+    ModelMeta.model (e.g. "anthropic/claude-sonnet-4-6", "openai/gpt-5",
+    "openrouter/openai/gpt-5.4"). This recovers that backend so a request can be
+    routed through the right SDK. Returns None for non-gptme models or when the
+    backend can't be determined (degraded/offline resolution).
+    """
+    from .models import get_model  # fmt: skip
+
+    if get_provider_from_model(model) != "gptme":
+        return None
+    meta = get_model(model)
+    if str(meta.provider) != "gptme" or "/" not in meta.model:
+        return None
+    backend, bare = meta.model.split("/", 1)
+    if backend not in ("anthropic", "openai", "openrouter"):
+        return None
+    return backend, bare
+
+
 @trace_function(name="llm.chat_complete", attributes={"component": "llm"})
 def _chat_complete(
     messages: list[Message],
@@ -377,6 +399,25 @@ def _chat_complete(
         raise ValueError(f"max_tokens must be a positive integer, got {max_tokens}")
     max_tokens = _resolve_max_tokens(model, max_tokens)
     provider = get_provider_from_model(model)
+
+    # Anthropic-backed gptme cloud models must use the Anthropic SDK (native
+    # format) — the gateway forwards the body verbatim to Anthropic, which
+    # rejects the OpenAI-only `stream_options`. openai/openrouter-backed gptme
+    # models stay on the OpenAI path below (the gateway forwards to those APIs,
+    # which accept the OpenAI request shape).
+    if (backend := _gptme_backend(model)) and backend[0] == "anthropic":
+        from .llm_anthropic import chat as chat_anthropic
+
+        return chat_anthropic(
+            messages,
+            backend[1],
+            tools,
+            output_schema=output_schema,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            top_p=top_p,
+            via_gptme=True,
+        )
 
     # Providers with native constrained decoding support
     # Custom providers and plugin providers are OpenAI-compatible, route through OpenAI path
@@ -482,6 +523,26 @@ def _stream(
         raise ValueError(f"max_tokens must be a positive integer, got {max_tokens}")
     max_tokens = _resolve_max_tokens(model, max_tokens)
     provider = get_provider_from_model(model)
+
+    # Anthropic-backed gptme cloud models use the Anthropic SDK (native format);
+    # see the matching note in _chat_complete.
+    if (backend := _gptme_backend(model)) and backend[0] == "anthropic":
+        from .llm_anthropic import stream as stream_anthropic
+
+        gptme_partial: dict = {}
+        gen = stream_anthropic(
+            messages,
+            backend[1],
+            tools,
+            output_schema=output_schema,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            top_p=top_p,
+            _partial=gptme_partial,
+            via_gptme=True,
+        )
+        return _StreamWithMetadata(gen, model, partial=gptme_partial)
+
     # Custom providers and plugin providers are OpenAI-compatible, route through OpenAI path
     if (
         provider in PROVIDERS_OPENAI

--- a/gptme/llm/llm_anthropic.py
+++ b/gptme/llm/llm_anthropic.py
@@ -590,6 +590,45 @@ def get_client() -> "Anthropic | None":
     return _anthropic
 
 
+# Separate Anthropic client for the gptme cloud gateway. Kept distinct from the
+# primary `_anthropic` client so a session can mix a real `anthropic/...` model
+# (real key) and a `gptme/anthropic/...` model (gateway + device token) without
+# the two clobbering each other (no reinit thrash on model switch).
+_anthropic_gptme: "Anthropic | None" = None
+
+
+def _get_gptme_client() -> "Anthropic":
+    """Lazily build the Anthropic client pointed at the gptme.ai gateway.
+
+    Uses the gptme device-token auth (sent as x-api-key) and the gateway base
+    URL. The Supabase messages function ignores the SDK's trailing path, so the
+    native Anthropic request lands on it and is forwarded verbatim to Anthropic.
+    """
+    global _anthropic_gptme
+    if _anthropic_gptme is None:
+        from anthropic import NOT_GIVEN, Anthropic  # fmt: skip
+
+        from ..config import get_config  # fmt: skip
+        from .llm_gptme import get_api_key, get_base_url  # fmt: skip
+
+        config = get_config()
+        timeout_str = config.get_env("LLM_API_TIMEOUT")
+        try:
+            timeout = float(timeout_str) if timeout_str else NOT_GIVEN
+        except ValueError as parse_err:
+            raise ValueError(
+                f"Invalid LLM_API_TIMEOUT value: {timeout_str!r}. Must be a valid number."
+            ) from parse_err
+
+        _anthropic_gptme = Anthropic(
+            api_key=get_api_key(config),
+            max_retries=5,
+            base_url=get_base_url(config),
+            timeout=timeout,
+        )
+    return _anthropic_gptme
+
+
 class CacheControl(TypedDict):
     type: Literal["ephemeral"]
 
@@ -625,10 +664,12 @@ def chat(
     max_tokens: int | None = None,
     temperature: float | None = None,
     top_p: float | None = None,
+    via_gptme: bool = False,
 ) -> tuple[str, MessageMetadata | None]:
     from anthropic import NOT_GIVEN  # fmt: skip
 
-    if not _anthropic:
+    client = _get_gptme_client() if via_gptme else _anthropic
+    if not client:
         raise RuntimeError("LLM not initialized")
     messages_dicts, system_messages, tools_dict = _prepare_messages_for_api(
         messages, tools
@@ -657,7 +698,7 @@ def chat(
         schema_name = output_schema.__name__
         messages_dicts = _inject_schema_instruction(messages_dicts, schema_name)
 
-    api_model = f"anthropic/{model}" if _is_proxy else model
+    api_model = f"anthropic/{model}" if (via_gptme or _is_proxy) else model
 
     model_meta = get_model(f"anthropic/{model}")
     use_thinking = _should_use_thinking(model_meta, tools)
@@ -677,7 +718,7 @@ def chat(
 
     _temperature = temperature if temperature is not None else TEMPERATURE
     _top_p = top_p if top_p is not None else TOP_P
-    response = _anthropic.messages.create(  # type: ignore[call-overload, misc]
+    response = client.messages.create(  # type: ignore[call-overload, misc]
         model=api_model,
         messages=messages_dicts,
         system=system_messages,
@@ -723,6 +764,7 @@ def stream(
     temperature: float | None = None,
     top_p: float | None = None,
     _partial: dict | None = None,
+    via_gptme: bool = False,
 ) -> Generator[str, None, MessageMetadata | None]:
     import anthropic.types  # fmt: skip
     from anthropic import NOT_GIVEN  # fmt: skip
@@ -733,7 +775,8 @@ def stream(
     # in the output before </think> for round-trip preservation.
     _current_block_signature: str | None = None
 
-    if not _anthropic:
+    client = _get_gptme_client() if via_gptme else _anthropic
+    if not client:
         raise RuntimeError("LLM not initialized")
     messages_dicts, system_messages, tools_dict = _prepare_messages_for_api(
         messages, tools, model=model
@@ -762,7 +805,7 @@ def stream(
         schema_name = output_schema.__name__
         messages_dicts = _inject_schema_instruction(messages_dicts, schema_name)
 
-    api_model = f"anthropic/{model}" if _is_proxy else model
+    api_model = f"anthropic/{model}" if (via_gptme or _is_proxy) else model
 
     model_meta = get_model(f"anthropic/{model}")
     use_thinking = _should_use_thinking(model_meta, tools)
@@ -779,7 +822,7 @@ def stream(
 
     _temperature = temperature if temperature is not None else TEMPERATURE
     _top_p = top_p if top_p is not None else TOP_P
-    with _anthropic.messages.stream(  # type: ignore[call-arg, misc]
+    with client.messages.stream(  # type: ignore[call-arg, misc]
         model=api_model,
         messages=messages_dicts,
         system=system_messages,

--- a/gptme/llm/llm_anthropic.py
+++ b/gptme/llm/llm_anthropic.py
@@ -595,6 +595,9 @@ def get_client() -> "Anthropic | None":
 # (real key) and a `gptme/anthropic/...` model (gateway + device token) without
 # the two clobbering each other (no reinit thrash on model switch).
 _anthropic_gptme: "Anthropic | None" = None
+# Device token the cached client was built with, so we rebuild after a token
+# refresh / re-login instead of holding a stale (eventually expired) credential.
+_anthropic_gptme_key: str | None = None
 
 
 def _get_gptme_client() -> "Anthropic":
@@ -603,15 +606,18 @@ def _get_gptme_client() -> "Anthropic":
     Uses the gptme device-token auth (sent as x-api-key) and the gateway base
     URL. The Supabase messages function ignores the SDK's trailing path, so the
     native Anthropic request lands on it and is forwarded verbatim to Anthropic.
+    Rebuilt when the device token changes (cheap: get_api_key reads the cached
+    token file) so a mid-session re-login takes effect.
     """
-    global _anthropic_gptme
-    if _anthropic_gptme is None:
-        from anthropic import NOT_GIVEN, Anthropic  # fmt: skip
+    global _anthropic_gptme, _anthropic_gptme_key
+    from anthropic import NOT_GIVEN, Anthropic  # fmt: skip
 
-        from ..config import get_config  # fmt: skip
-        from .llm_gptme import get_api_key, get_base_url  # fmt: skip
+    from ..config import get_config  # fmt: skip
+    from .llm_gptme import get_api_key, get_base_url  # fmt: skip
 
-        config = get_config()
+    config = get_config()
+    api_key = get_api_key(config)
+    if _anthropic_gptme is None or _anthropic_gptme_key != api_key:
         timeout_str = config.get_env("LLM_API_TIMEOUT")
         try:
             timeout = float(timeout_str) if timeout_str else NOT_GIVEN
@@ -621,11 +627,12 @@ def _get_gptme_client() -> "Anthropic":
             ) from parse_err
 
         _anthropic_gptme = Anthropic(
-            api_key=get_api_key(config),
+            api_key=api_key,
             max_retries=5,
             base_url=get_base_url(config),
             timeout=timeout,
         )
+        _anthropic_gptme_key = api_key
     return _anthropic_gptme
 
 

--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -801,21 +801,27 @@ def _gptme_api_model(
     return model if is_proxy else base_model
 
 
+# OpenAI's reasoning-era models reject `max_tokens` and require
+# `max_completion_tokens`: the o-series (o1, o3, o4, o5, ...) and gpt-5 and
+# later (gpt-5..gpt-9, gpt-10+). Matched by family so new releases in these
+# lines keep working without a code change; older models (gpt-4o, etc.) keep
+# `max_tokens`.
+_OPENAI_MAX_COMPLETION_RE = re.compile(r"^(?:o\d|gpt-(?:[5-9]|\d\d))")
+
+
 def _max_tokens_param_name(provider: Provider, api_model: str) -> str:
     """Choose between ``max_tokens`` and ``max_completion_tokens``.
 
-    OpenAI's gpt-5 / o-series reject ``max_tokens`` and require
-    ``max_completion_tokens``. This applies only when the request actually
-    targets OpenAI's API: the native ``openai`` provider, or a gptme cloud model
-    whose backend is openai. OpenRouter (including openrouter-backed gptme
-    models) keeps ``max_tokens``.
+    Applies only when the request actually targets OpenAI's API: the native
+    ``openai`` provider, or a gptme cloud model whose backend is openai.
+    OpenRouter (including openrouter-backed gptme models) keeps ``max_tokens``.
     """
     targets_openai = provider == "openai" or (
         provider == "gptme" and api_model.startswith("openai/")
     )
     if targets_openai:
         bare = api_model.rsplit("/", 1)[-1].split("@")[0].lower()
-        if bare.startswith(("gpt-5", "o1", "o3", "o4")):
+        if _OPENAI_MAX_COMPLETION_RE.match(bare):
             return "max_completion_tokens"
     return "max_tokens"
 

--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -128,12 +128,17 @@ def _record_usage(usage, model: str) -> MessageMetadata | None:
     # Determine the provider for telemetry
     # For OpenRouter models, detect the underlying provider from the model string
     # e.g., "openrouter/anthropic/claude-sonnet-4.5" -> "anthropic"
+    # gptme cloud models embed the real backend (gptme/openai/gpt-5,
+    # gptme/openrouter/...), so strip the gptme/ prefix before detecting.
     provider = "openai"
-    if model.startswith("openrouter/"):
-        parts = model.split("/")
+    detect = model.removeprefix("gptme/")
+    if detect.startswith("openrouter/"):
+        parts = detect.split("/")
         if len(parts) >= 2:
             # openrouter/anthropic/... -> anthropic
             provider = parts[1]
+    elif detect.startswith("anthropic/"):
+        provider = "anthropic"
 
     # Record the LLM request with token usage
     record_llm_request(
@@ -777,6 +782,44 @@ def _maybe_apply_verbosity(body: dict[str, Any], model_meta: ModelMeta) -> None:
     body["verbosity"] = OPENAI_VERBOSITY
 
 
+def _gptme_api_model(
+    provider: Provider,
+    model_meta: ModelMeta,
+    is_proxy: bool,
+    model: str,
+    base_model: str,
+) -> str:
+    """Model name to send on the wire.
+
+    For gptme cloud models, send the backend-prefixed id (e.g. "openai/gpt-5",
+    "openrouter/openai/gpt-5.4") so the gateway routes to the right backend.
+    Otherwise keep the existing behaviour: provider-prefixed under LLM_PROXY,
+    bare model name otherwise.
+    """
+    if provider == "gptme" and "/" in model_meta.model:
+        return model_meta.model
+    return model if is_proxy else base_model
+
+
+def _max_tokens_param_name(provider: Provider, api_model: str) -> str:
+    """Choose between ``max_tokens`` and ``max_completion_tokens``.
+
+    OpenAI's gpt-5 / o-series reject ``max_tokens`` and require
+    ``max_completion_tokens``. This applies only when the request actually
+    targets OpenAI's API: the native ``openai`` provider, or a gptme cloud model
+    whose backend is openai. OpenRouter (including openrouter-backed gptme
+    models) keeps ``max_tokens``.
+    """
+    targets_openai = provider == "openai" or (
+        provider == "gptme" and api_model.startswith("openai/")
+    )
+    if targets_openai:
+        bare = api_model.rsplit("/", 1)[-1].split("@")[0].lower()
+        if bare.startswith(("gpt-5", "o1", "o3", "o4")):
+            return "max_completion_tokens"
+    return "max_tokens"
+
+
 @retry_on_openai_error()
 def chat(
     messages: list[Message],
@@ -802,7 +845,7 @@ def chat(
     is_reasoner = model_meta.supports_reasoning
 
     # make the model name prefix with the provider if using LLM_PROXY, to make proxy aware of the provider
-    api_model = model if is_proxy else base_model
+    api_model = _gptme_api_model(provider, model_meta, is_proxy, model, base_model)
 
     if _should_use_responses_api(provider, model_meta, client):
         instructions, input_items, responses_tools = (
@@ -875,7 +918,7 @@ def chat(
     if response_format is not None:
         optional_kwargs["response_format"] = response_format
     if max_tokens is not None:
-        optional_kwargs["max_tokens"] = max_tokens
+        optional_kwargs[_max_tokens_param_name(provider, api_model)] = max_tokens
 
     response = client.chat.completions.create(
         model=api_model.split("@")[0],
@@ -1191,7 +1234,7 @@ def stream(
     is_reasoner = model_meta.supports_reasoning
 
     # make the model name prefix with the provider if using LLM_PROXY, to make proxy aware of the provider
-    api_model = model if is_proxy else base_model
+    api_model = _gptme_api_model(provider, model_meta, is_proxy, model, base_model)
 
     # Dispatch to Responses API streaming when enabled for GPT-5 class models
     if _should_use_responses_api(provider, model_meta, client):
@@ -1226,7 +1269,7 @@ def stream(
     if response_format is not None:
         optional_kwargs["response_format"] = response_format
     if max_tokens is not None:
-        optional_kwargs["max_tokens"] = max_tokens
+        optional_kwargs[_max_tokens_param_name(provider, api_model)] = max_tokens
 
     for chunk_raw in client.chat.completions.create(
         model=api_model.split("@")[0],

--- a/gptme/llm/models/resolution.py
+++ b/gptme/llm/models/resolution.py
@@ -1,6 +1,7 @@
 import logging
 import threading
 from contextvars import ContextVar
+from dataclasses import replace
 from datetime import datetime, timezone
 from typing import cast
 
@@ -269,6 +270,30 @@ def get_model(model: str) -> ModelMeta:
                                 price_output=model_meta.price_output,
                                 knowledge_cutoff=model_meta.knowledge_cutoff,
                             )
+
+                    # gptme cloud models carry their real backend as a prefix in
+                    # `.model` (e.g. "anthropic/claude-sonnet-4-6"). A 2-segment
+                    # request like "gptme/claude-sonnet-4-6" has no backend, so the
+                    # exact match above fails. Match on the bare (last) segment and
+                    # return the backend-prefixed model so downstream routing knows
+                    # which provider/SDK to use. Deterministic tie-break: fewest
+                    # path segments (prefer a direct backend over an openrouter
+                    # re-export), then anthropic-first, then name.
+                    if provider == "gptme" and "/" not in model_name:
+                        suffix_matches = [
+                            m
+                            for m in models
+                            if m.model.rsplit("/", 1)[-1] == model_name
+                        ]
+                        if suffix_matches:
+                            suffix_matches.sort(
+                                key=lambda m: (
+                                    m.model.count("/"),
+                                    not m.model.startswith("anthropic/"),
+                                    m.model,
+                                )
+                            )
+                            return replace(suffix_matches[0])
                 except Exception as e:
                     # Fall back to unknown model metadata
                     logger.debug(

--- a/tests/test_gptme_provider.py
+++ b/tests/test_gptme_provider.py
@@ -528,6 +528,9 @@ def test_max_tokens_param_name():
     assert _max_tokens_param_name("openai", "gpt-5") == "max_completion_tokens"
     assert _max_tokens_param_name("openai", "o3-mini") == "max_completion_tokens"
     assert _max_tokens_param_name("openai", "gpt-4o") == "max_tokens"
+    # Future families in the same lines keep working without a code change
+    assert _max_tokens_param_name("openai", "o5") == "max_completion_tokens"
+    assert _max_tokens_param_name("openai", "gpt-6") == "max_completion_tokens"
     assert _max_tokens_param_name("gptme", "openai/gpt-5") == "max_completion_tokens"
     assert _max_tokens_param_name("gptme", "openai/gpt-4o") == "max_tokens"
     # OpenRouter (incl. openrouter-backed gptme) keeps max_tokens

--- a/tests/test_gptme_provider.py
+++ b/tests/test_gptme_provider.py
@@ -445,6 +445,185 @@ def test_get_models_url_env_base_url_supabase_uses_default():
         assert get_models_url(config) == DEFAULT_MODELS_BASE_URL
 
 
+# --- Per-backend routing ---
+
+
+def _gptme_model_list():
+    """Fake gptme cloud model list: backend embedded as a prefix in `.model`."""
+    from gptme.llm.models import ModelMeta
+
+    return [
+        ModelMeta(
+            provider="gptme",
+            model="anthropic/claude-sonnet-4-6",
+            context=200_000,
+            max_output=64_000,
+            supports_reasoning=True,
+        ),
+        ModelMeta(
+            provider="gptme",
+            model="openai/gpt-5",
+            context=400_000,
+            max_output=64_000,
+            supports_reasoning=True,
+        ),
+        # Same bare name under a different backend — tie-break must prefer the
+        # direct backend (openai/gpt-5) over the openrouter re-export.
+        ModelMeta(provider="gptme", model="openrouter/openai/gpt-5", context=400_000),
+        ModelMeta(provider="gptme", model="openrouter/openai/gpt-5.4", context=400_000),
+    ]
+
+
+def _patch_model_list():
+    return patch(
+        "gptme.llm.models.listing._get_models_for_provider",
+        return_value=_gptme_model_list(),
+    )
+
+
+def test_gptme_two_segment_resolves_to_backend():
+    """gptme/<bare> resolves to the backend-prefixed model with real metadata."""
+    from gptme.llm.models.resolution import get_model
+
+    with _patch_model_list():
+        m = get_model("gptme/claude-sonnet-4-6")
+    assert m.model == "anthropic/claude-sonnet-4-6"
+    assert m.max_output == 64_000  # real metadata, not the degraded 128k fallback
+
+
+def test_gptme_two_segment_tiebreak_prefers_direct_backend():
+    """Ambiguous bare name prefers the direct backend over an openrouter re-export."""
+    from gptme.llm.models.resolution import get_model
+
+    with _patch_model_list():
+        m = get_model("gptme/gpt-5")
+    assert m.model == "openai/gpt-5"
+
+
+def test_gptme_backend_helper():
+    from gptme.llm import _gptme_backend
+
+    with _patch_model_list():
+        assert _gptme_backend("gptme/claude-sonnet-4-6") == (
+            "anthropic",
+            "claude-sonnet-4-6",
+        )
+        assert _gptme_backend("gptme/anthropic/claude-sonnet-4-6") == (
+            "anthropic",
+            "claude-sonnet-4-6",
+        )
+        assert _gptme_backend("gptme/gpt-5") == ("openai", "gpt-5")
+        assert _gptme_backend("gptme/openrouter/openai/gpt-5.4") == (
+            "openrouter",
+            "openai/gpt-5.4",
+        )
+    # A real (non-gptme) provider must not be treated as a gptme model
+    assert _gptme_backend("anthropic/claude-sonnet-4-6") is None
+
+
+def test_max_tokens_param_name():
+    """OpenAI gpt-5/o-series need max_completion_tokens; others keep max_tokens."""
+    from gptme.llm.llm_openai import _max_tokens_param_name
+
+    assert _max_tokens_param_name("openai", "gpt-5") == "max_completion_tokens"
+    assert _max_tokens_param_name("openai", "o3-mini") == "max_completion_tokens"
+    assert _max_tokens_param_name("openai", "gpt-4o") == "max_tokens"
+    assert _max_tokens_param_name("gptme", "openai/gpt-5") == "max_completion_tokens"
+    assert _max_tokens_param_name("gptme", "openai/gpt-4o") == "max_tokens"
+    # OpenRouter (incl. openrouter-backed gptme) keeps max_tokens
+    assert _max_tokens_param_name("gptme", "openrouter/openai/gpt-5.4") == "max_tokens"
+    assert (
+        _max_tokens_param_name("openrouter", "openrouter/openai/gpt-5") == "max_tokens"
+    )
+
+
+def test_gptme_api_model_wire_name():
+    """gptme provider sends the backend-prefixed wire model; others unchanged."""
+    from gptme.llm.llm_openai import _gptme_api_model
+    from gptme.llm.models import ModelMeta
+
+    mm = ModelMeta(provider="gptme", model="openai/gpt-5", context=1)
+    assert (
+        _gptme_api_model("gptme", mm, False, "gptme/gpt-5", "gpt-5") == "openai/gpt-5"
+    )
+
+    mm2 = ModelMeta(provider="openai", model="gpt-4o", context=1)
+    assert _gptme_api_model("openai", mm2, False, "openai/gpt-4o", "gpt-4o") == "gpt-4o"
+    assert (
+        _gptme_api_model("openai", mm2, True, "openai/gpt-4o", "gpt-4o")
+        == "openai/gpt-4o"
+    )
+
+
+def test_gptme_anthropic_uses_anthropic_sdk_no_stream_options():
+    """Anthropic-backed gptme models route via the Anthropic SDK (native, no
+    stream_options) and never touch the user's real anthropic client."""
+    from gptme.llm import _chat_complete
+    from gptme.message import Message
+
+    gateway = MagicMock()
+    block = MagicMock()
+    block.type = "text"
+    block.text = "hi"
+    resp = MagicMock()
+    resp.content = [block]
+    gateway.messages.create.return_value = resp
+
+    real_client = MagicMock()  # the user's real (direct) anthropic client
+
+    with (
+        _patch_model_list(),
+        patch("gptme.llm.llm_anthropic._get_gptme_client", return_value=gateway),
+        patch("gptme.llm.llm_anthropic._anthropic", real_client),
+        patch(
+            "gptme.llm.llm_anthropic._record_usage",
+            return_value={"model": "anthropic/claude-sonnet-4-6"},
+        ),
+    ):
+        content, _meta = _chat_complete(
+            [Message("system", "You are helpful."), Message("user", "hello")],
+            "gptme/claude-sonnet-4-6",
+            None,
+        )
+
+    assert content == "hi"
+    kwargs = gateway.messages.create.call_args.kwargs
+    assert kwargs["model"] == "anthropic/claude-sonnet-4-6"
+    assert "stream_options" not in kwargs
+    # No hijack: the real anthropic client must be untouched
+    real_client.messages.create.assert_not_called()
+
+
+def test_gptme_openai_chat_sends_max_completion_tokens():
+    """openai-backed gptme models stay on the OpenAI SDK path, send the
+    backend-prefixed wire model, and use max_completion_tokens for gpt-5."""
+    from gptme.llm import _chat_complete
+    from gptme.message import Message
+
+    client = MagicMock()
+    choice = MagicMock()
+    choice.message.content = "hi"
+    choice.message.tool_calls = None
+    choice.finish_reason = "stop"
+    resp = MagicMock()
+    resp.choices = [choice]
+    client.chat.completions.create.return_value = resp
+
+    with (
+        _patch_model_list(),
+        patch("gptme.llm.llm_openai.get_client", return_value=client),
+        patch(
+            "gptme.llm.llm_openai._record_usage", return_value={"model": "openai/gpt-5"}
+        ),
+    ):
+        _chat_complete([Message("user", "hi")], "gptme/openai/gpt-5", None)
+
+    kwargs = client.chat.completions.create.call_args.kwargs
+    assert kwargs["model"] == "openai/gpt-5"
+    assert "max_completion_tokens" in kwargs
+    assert "max_tokens" not in kwargs
+
+
 # --- Helpers ---
 
 


### PR DESCRIPTION
## Summary
The gptme.ai gateway (Supabase `messages` edge function) forwards request bodies **verbatim** to each backend's native endpoint, but every cloud model was bundled under `provider="gptme"` and forced through the **OpenAI SDK**. Two failures resulted:

- **anthropic-backed models** (e.g. `gptme/claude-sonnet-4-6`): the OpenAI SDK emits `stream_options`, which Anthropic's native `/v1/messages` rejects — `400 stream_options: Extra inputs are not permitted`.
- **openai gpt-5/o-series** (e.g. `gptme/gpt-5.4`): the chat path sends `max_tokens`, which those models reject — `400 ... use 'max_completion_tokens' instead`.

This routes each cloud model through its **real backend SDK**, keeping the `gptme/` namespace as the user-facing signal and single device-token credential. No global `LLM_PROXY` is set, so a user's real anthropic/openai keys are never hijacked.

### Changes
- **Anthropic-backed gptme models → Anthropic SDK.** New dedicated gateway client (`_get_gptme_client`) + `via_gptme` flag on `llm_anthropic.chat`/`stream`, kept **separate** from the user's direct anthropic client so mixing real and cloud models in one session doesn't thrash credentials. Native format never sends `stream_options`. (`gptme/llm/llm_anthropic.py`, dispatch in `gptme/llm/__init__.py`)
- **openai/openrouter-backed gptme models stay on the OpenAI SDK path** (the gateway forwards to those APIs, which accept the OpenAI shape) but now send the **backend-prefixed wire model** and use **`max_completion_tokens`** for OpenAI gpt-5/o-series. The token-arg fix is general (also correct for the native `openai` chat-completions path). OpenRouter keeps `max_tokens`. (`gptme/llm/llm_openai.py`)
- **2-segment resolution:** `gptme/claude-sonnet-4-6` now resolves to the backend-prefixed cloud model (`anthropic/claude-sonnet-4-6`) via a suffix match with a deterministic tie-break (prefer the direct backend over an openrouter re-export), recovering the real backend + metadata instead of a degraded fallback. (`gptme/llm/models/resolution.py`)
- Telemetry/cost provider detection now strips the `gptme/` prefix to attribute usage to the real backend.

**No `gptme-cloud` changes required** — the gateway already forwards native Anthropic bodies correctly (verified: Anthropic SDK with the gateway base URL lands on the `messages` function, which Supabase routes regardless of the trailing sub-path).

## Test plan
- [x] New tests in `tests/test_gptme_provider.py`:
  - anthropic-backed gptme model uses the Anthropic SDK, sends `model=anthropic/claude-sonnet-4-6`, **no `stream_options`**, and does **not** touch the user's real anthropic client
  - openai-backed gptme model sends `model=openai/gpt-5` + `max_completion_tokens` (not `max_tokens`)
  - 2-seg resolution maps to the right backend with real metadata; tie-break prefers the direct backend
  - `_max_tokens_param_name` / `_gptme_api_model` / `_gptme_backend` unit coverage
- [x] No regressions: `test_llm_openai`, `test_llm_anthropic`, `test_llm_models_resolution`, `test_llm_models`, `test_llm_openai_sampling` (332 passed)
- [x] ruff + mypy clean (pre-commit)
- [ ] Manual: `gptme -m gptme/claude-sonnet-4-6 'hi'` and `gptme -m gptme/gpt-5 'hi'` against a live login (needs auth; not runnable in CI)