### PR TITLE
fix(server): return 400 for non-positive limit in conversations API

### DIFF
--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -865,15 +865,17 @@ def api_external_sessions():
 )
 def api_external_session(external_session_id: str):
     """Get a normalized read-only external session transcript."""
-    provider = get_external_session_provider()
-    if provider is None:
-        return flask.jsonify({"error": "external session provider unavailable"}), 503
-
     try:
         days = int(request.args.get("days", 30))
     except (ValueError, TypeError):
         return flask.jsonify({"error": "days must be an integer"}), 400
-    days = max(1, min(days, 3650))
+    if days <= 0:
+        return flask.jsonify({"error": "days must be a positive integer"}), 400
+    days = min(days, 3650)
+
+    provider = get_external_session_provider()
+    if provider is None:
+        return flask.jsonify({"error": "external session provider unavailable"}), 503
 
     session = provider.get_session(external_session_id, days=days)
     if session is None:

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -829,8 +829,12 @@ def api_external_sessions():
     except (ValueError, TypeError):
         return flask.jsonify({"error": "limit and days must be integers"}), 400
 
-    limit = max(1, min(limit, 1000))
-    days = max(1, min(days, 3650))
+    if limit <= 0:
+        return flask.jsonify({"error": "limit must be a positive integer"}), 400
+    limit = min(limit, 1000)
+    if days <= 0:
+        return flask.jsonify({"error": "days must be a positive integer"}), 400
+    days = min(days, 3650)
 
     sessions = [
         item.to_dict() for item in provider.list_sessions(limit=limit, days=days)
@@ -939,7 +943,9 @@ def api_conversations():
         limit = int(request.args.get("limit", 100))
     except (ValueError, TypeError):
         return flask.jsonify({"error": "limit must be an integer"}), 400
-    limit = max(1, min(limit, 1000))
+    if limit <= 0:
+        return flask.jsonify({"error": "limit must be a positive integer"}), 400
+    limit = min(limit, 1000)
     # ?q= is the primary filter param; ?search= is accepted as a backward-compat alias
     # Use None-check so explicit ?q= (even empty) takes precedence over ?search=
     q = request.args.get("q")

--- a/tests/test_server_bad_input.py
+++ b/tests/test_server_bad_input.py
@@ -173,6 +173,17 @@ def test_conversations_limit_capped():
     print("  PASS: conversations limit=9999 accepted (capped)")
 
 
+def test_external_session_invalid_days():
+    """Non-positive days values should return 400 before the provider check."""
+    for bad_days in ("-1", "0", "-100"):
+        status, data = _req("GET", f"/api/v2/external-sessions/some-id?days={bad_days}")
+        assert status == 400, f"expected 400 for days={bad_days}, got {status}: {data}"
+        assert isinstance(data, dict) and "error" in data, (
+            f"expected error dict for days={bad_days}, got {data}"
+        )
+        print(f"  PASS: external-session days={bad_days} rejected")
+
+
 def test_get_session_nonexistent():
     """Getting a non-existent session should return 404."""
     cid, _session_id, _ = _create_conversation()

--- a/tests/test_server_bad_input.py
+++ b/tests/test_server_bad_input.py
@@ -145,6 +145,34 @@ def test_get_conversation_bad_id():
     print("  PASS: 404 on nonexistent conversation")
 
 
+def test_conversations_invalid_limit():
+    """Non-positive limit values should return 400, not silently clamp."""
+    for bad_limit in ("-1", "0", "-100"):
+        status, data = _req("GET", f"/api/v2/conversations?limit={bad_limit}")
+        assert status == 400, (
+            f"expected 400 for limit={bad_limit}, got {status}: {data}"
+        )
+        assert isinstance(data, dict) and "error" in data, (
+            f"expected error dict for limit={bad_limit}, got {data}"
+        )
+        print(f"  PASS: conversations limit={bad_limit} rejected")
+
+
+def test_conversations_valid_limits():
+    """Valid limit values should work (1, positive integers, up to 1000)."""
+    for good_limit in ("1", "10", "100", "1000"):
+        status, _data = _req("GET", f"/api/v2/conversations?limit={good_limit}")
+        assert status == 200, f"expected 200 for limit={good_limit}, got {status}"
+    print("  PASS: conversations valid limits accepted")
+
+
+def test_conversations_limit_capped():
+    """limit > 1000 should be silently capped to 1000 (not rejected)."""
+    status, _data = _req("GET", "/api/v2/conversations?limit=9999")
+    assert status == 200, f"expected 200 for limit=9999 (capped), got {status}"
+    print("  PASS: conversations limit=9999 accepted (capped)")
+
+
 def test_get_session_nonexistent():
     """Getting a non-existent session should return 404."""
     cid, _session_id, _ = _create_conversation()
@@ -354,6 +382,9 @@ def main():
     test_get_conversation_bad_id()
     test_create_existing_conversation_duplicate()
     test_get_conversation_traversal_attempt()
+    test_conversations_invalid_limit()
+    test_conversations_valid_limits()
+    test_conversations_limit_capped()
 
     print("\n=== Session / step edge cases ===")
     test_step_no_session()
@@ -424,11 +455,12 @@ def main():
     print(f"  V2 root: {s}" if s == 200 else f"  V2 root: {s}")
 
     # Probe: list conversations with invalid limit
-    s, d = _req("GET", "/api/v2/conversations?limit=-1")
-    if s == 200:
-        print("  List conversations with limit=-1: OK (clamped)")
-    else:
-        print(f"  List conversations with limit=-1: {s}")
+    _expect_error(
+        "GET", "/api/v2/conversations?limit=-1", None, 400, "conversations limit=-1"
+    )
+    _expect_error(
+        "GET", "/api/v2/conversations?limit=0", None, 400, "conversations limit=0"
+    )
 
     print("\n=== Session / step interactive endpoints ===")
     cid, sid, _ = _create_conversation()


### PR DESCRIPTION
## Summary

- `GET /api/v2/conversations?limit=-1` and `?limit=0` previously returned HTTP 200 with data, silently clamping the value to 1 via `max(1, min(limit, 1000))`.
- The message pagination endpoint (`GET /api/v2/conversations/{id}`) already correctly returns 400 for `limit <= 0`. This PR aligns the conversations list and external sessions endpoints to match.
- Adds three regression tests: invalid limits rejected (0, -1, -100), valid limits accepted (1-1000), overlimit capped to 1000.

## Reproduction

```bash
# Before fix (returns 200 with one conversation):
curl http://127.0.0.1:5700/api/v2/conversations?limit=-1
curl http://127.0.0.1:5700/api/v2/conversations?limit=0

# After fix (returns 400):
# {"error": "limit must be a positive integer"}
```

## Test plan

- [x] `test_conversations_invalid_limit` — verifies -1, 0, -100 return 400
- [x] `test_conversations_valid_limits` — verifies 1, 10, 100, 1000 return 200
- [x] `test_conversations_limit_capped` — verifies 9999 returns 200 (silently capped)