### PR TITLE
feat(commands): add /backtrack for in-session conversation recovery

### DIFF
--- a/gptme/commands/__init__.py
+++ b/gptme/commands/__init__.py
@@ -19,6 +19,7 @@ from .. import llm as _llm  # noqa: F401
 # Import command modules to register their commands
 from . import (  # noqa: F401
     account,
+    backtrack,
     checkpoint,
     export,
     llm,

--- a/gptme/commands/backtrack.py
+++ b/gptme/commands/backtrack.py
@@ -1,0 +1,163 @@
+"""
+Conversation backtracking: /backtrack mark|list|<target> [--reason <text>]
+
+Lets the user save named checkpoints in the conversation log and rewind to them
+after a failed tool run or bad exchange.  The rollback injects a short system
+message that tells the model *why* we rewound so retries are more informed.
+
+This implements Phase 1 of gptme/gptme#523 (manual conversation backtracking).
+Filesystem state is NOT rolled back — use /checkpoint for that.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from ..message import Message
+
+from ..logmanager.conv_checkpoints import (
+    list_conv_checkpoints,
+    resolve_conv_checkpoint,
+    save_conv_checkpoint,
+)
+from .base import CommandContext, command
+
+# Separator used in /backtrack help output
+_SEP = "  "
+
+
+def _print_usage() -> None:
+    print("Usage: /backtrack <mark [label] | list | <target> [--reason <text>]>")
+    print()
+    print("Subcommands:")
+    print(f"  mark [label]{_SEP}Save the current message index as a named checkpoint.")
+    print(f"  list{_SEP * 4}List saved checkpoints for this conversation.")
+    print(f"  <label|N>{_SEP * 3}Rewind to a checkpoint label or message index N.")
+    print()
+    print("Options for rewind:")
+    print(f"  --reason <text>{_SEP}Inject a corrective summary explaining the rewind.")
+
+
+def _auto_label(records_count: int) -> str:
+    return f"cp{records_count + 1}"
+
+
+def _complete_backtrack(partial: str, _prev: list[str]) -> list[tuple[str, str]]:
+    completions: list[tuple[str, str]] = [
+        ("mark", "Save current position as a checkpoint"),
+        ("list", "List saved checkpoints"),
+    ]
+    # filter by partial
+    return [(c, d) for c, d in completions if c.startswith(partial)]
+
+
+@command("backtrack", completer=_complete_backtrack)
+def cmd_backtrack(ctx: CommandContext) -> Generator[Message, None, None]:
+    """Rewind the conversation to a checkpoint or message index.
+
+    Usage:
+      /backtrack mark [label]          Save a named checkpoint
+      /backtrack list                  List checkpoints
+      /backtrack <label|N> [--reason]  Rewind to checkpoint/index
+    """
+    from ..message import Message  # fmt: skip
+
+    args = list(ctx.args)
+    if not args or args[0] in {"help", "-h", "--help"}:
+        _print_usage()
+        return
+
+    subcommand = args[0]
+
+    # ── mark ─────────────────────────────────────────────────────────────────
+    if subcommand == "mark":
+        label = args[1] if len(args) > 1 else None
+        index = len(ctx.manager.log.messages)
+        existing = list_conv_checkpoints(ctx.manager.logdir)
+        if label is None:
+            label = _auto_label(len(existing))
+        record = save_conv_checkpoint(ctx.manager.logdir, index, label)
+        print(f"Checkpoint '{record.label}' saved at message index {record.index}.")
+        return
+
+    # ── list ─────────────────────────────────────────────────────────────────
+    if subcommand == "list":
+        records = list_conv_checkpoints(ctx.manager.logdir)
+        if not records:
+            print("No checkpoints yet.  Use /backtrack mark [label] to save one.")
+            return
+        print(f"{'#':>3}  {'Label':<16}  {'Index':>5}  Timestamp")
+        for i, r in enumerate(records, start=1):
+            ts = r.timestamp[:19].replace("T", " ")
+            print(f"{i:>3}  {r.label:<16}  {r.index:>5}  {ts}")
+        return
+
+    # ── rewind ───────────────────────────────────────────────────────────────
+    target = subcommand  # label or bare integer
+
+    # Parse --reason
+    reason: str | None = None
+    remaining_args = args[1:]
+    reason_idx = next(
+        (i for i, a in enumerate(remaining_args) if a == "--reason"),
+        None,
+    )
+    if reason_idx is not None:
+        if reason_idx + 1 < len(remaining_args):
+            reason = " ".join(remaining_args[reason_idx + 1 :])
+        else:
+            print("backtrack: --reason requires a value")
+            return
+    elif remaining_args and not remaining_args[0].startswith("--"):
+        # Allow: /backtrack 5 optional reason without --reason flag
+        reason = " ".join(remaining_args)
+
+    # Resolve target → checkpoint record
+    try:
+        record = resolve_conv_checkpoint(ctx.manager.logdir, target)
+    except KeyError as exc:
+        print(f"backtrack: {exc}")
+        return
+
+    current_len = len(ctx.manager.log.messages)
+    rewind_to = record.index
+
+    if rewind_to < 0:
+        print(f"backtrack: invalid index {rewind_to}")
+        return
+    if rewind_to > current_len:
+        print(
+            f"backtrack: checkpoint index {rewind_to} is beyond current "
+            f"conversation length ({current_len} messages)"
+        )
+        return
+    if rewind_to == current_len:
+        print(f"backtrack: already at message index {current_len} — nothing to rewind.")
+        return
+
+    removed = current_len - rewind_to
+
+    # Truncate the log (edit() saves a backup branch automatically)
+    new_messages = list(ctx.manager.log.messages[:rewind_to])
+    ctx.manager.edit(new_messages)
+
+    # Build the corrective summary message
+    if reason:
+        # strip surrounding quotes that some shells add
+        reason = re.sub(r'^["\']|["\']$', "", reason).strip()
+
+    summary_parts = [
+        f"[Backtracked {removed} message(s) to index {rewind_to}",
+        f" (checkpoint: '{record.label}')" if not record.label.startswith("@") else "",
+        "]",
+    ]
+    if reason:
+        summary_parts.append(f"\n{reason}")
+    summary = "".join(summary_parts)
+
+    summary_msg = Message("system", summary, hide=True)
+    yield summary_msg

--- a/gptme/commands/backtrack.py
+++ b/gptme/commands/backtrack.py
@@ -40,6 +40,9 @@ def _print_usage() -> None:
     print()
     print("Options for rewind:")
     print(f"  --reason <text>{_SEP}Inject a corrective summary explaining the rewind.")
+    print(
+        f"  <label> <text> {_SEP}Shorthand: extra words after the label become the reason."
+    )
 
 
 def _auto_label(records_count: int) -> str:
@@ -47,6 +50,9 @@ def _auto_label(records_count: int) -> str:
 
 
 def _complete_backtrack(partial: str, _prev: list[str]) -> list[tuple[str, str]]:
+    # Checkpoint labels are not included here because the completer runs without
+    # access to the LogManager (and thus the sidecar file). Use /backtrack list
+    # to see available labels; a closure-based completer could surface them in future.
     completions: list[tuple[str, str]] = [
         ("mark", "Save current position as a checkpoint"),
         ("list", "List saved checkpoints"),
@@ -80,6 +86,14 @@ def cmd_backtrack(ctx: CommandContext) -> Generator[Message, None, None]:
         existing = list_conv_checkpoints(ctx.manager.logdir)
         if label is None:
             label = _auto_label(len(existing))
+        # Warn if a checkpoint with this label already exists
+        existing_labels = [r for r in existing if r.label == label]
+        if existing_labels:
+            prev = existing_labels[-1]
+            print(
+                f"Warning: checkpoint '{label}' already exists at index {prev.index}; "
+                f"creating a new one at index {index}."
+            )
         record = save_conv_checkpoint(ctx.manager.logdir, index, label)
         print(f"Checkpoint '{record.label}' saved at message index {record.index}.")
         return

--- a/gptme/commands/meta.py
+++ b/gptme/commands/meta.py
@@ -13,6 +13,7 @@ from .base import CommandContext, command
 
 Actions = Literal[
     "log",
+    "backtrack",
     "checkpoint",
     "undo",
     "edit",
@@ -41,6 +42,7 @@ Actions = Literal[
 
 action_descriptions: dict[Actions, str] = {
     "undo": "Undo the last action",
+    "backtrack": "Rewind conversation to a checkpoint or message index",
     "log": "Show the conversation log",
     "checkpoint": "Manage workspace checkpoints",
     "edit": "Edit the conversation in your editor",

--- a/gptme/logmanager/conv_checkpoints.py
+++ b/gptme/logmanager/conv_checkpoints.py
@@ -78,13 +78,11 @@ def resolve_conv_checkpoint(
     logdir: Path,
     identifier: str,
 ) -> ConvCheckpoint:
-    """Resolve a label, 1-based index, or bare integer to a checkpoint.
+    """Resolve a label or bare integer to a checkpoint.
 
     Priority:
     1. Pure decimal integer → treat as **message index** (not checkpoint #).
     2. Otherwise → match against checkpoint labels (most-recent match wins).
-    3. Decimal integer that matches no message-index check → try as 1-based
-       checkpoint list index.
     """
     records = list_conv_checkpoints(logdir)
 

--- a/gptme/logmanager/conv_checkpoints.py
+++ b/gptme/logmanager/conv_checkpoints.py
@@ -1,0 +1,107 @@
+"""Conversation-level checkpoint primitives for ``/backtrack``.
+
+Lightweight, per-conversation recovery markers that record a message index
+(and optional label) so the user can rewind the conversation to a known-good
+point after a failed tool run or bad exchange.
+
+This is the *conversation* layer of backtracking (issue #523).  It does NOT
+snapshot filesystem state — use workspace checkpoints (``gptme/checkpoint.py``)
+for that.
+
+Storage lives in ``<logdir>/conv-checkpoints.jsonl`` alongside the conversation
+log.  Records are append-only; the sidecar file is never mutated after writing.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@dataclasses.dataclass(frozen=True)
+class ConvCheckpoint:
+    """A single conversation checkpoint."""
+
+    index: int  # message count at the time of the checkpoint
+    label: str  # user-supplied label or auto-generated
+    timestamp: str  # ISO 8601
+
+
+def _sidecar_path(logdir: Path) -> Path:
+    return logdir / "conv-checkpoints.jsonl"
+
+
+def save_conv_checkpoint(logdir: Path, index: int, label: str) -> ConvCheckpoint:
+    """Append a checkpoint to the sidecar.  Returns the new record."""
+    record = ConvCheckpoint(
+        index=index,
+        label=label,
+        timestamp=datetime.now(timezone.utc).isoformat(),
+    )
+    path = _sidecar_path(logdir)
+    with open(path, "a", encoding="utf-8") as f:
+        f.write(json.dumps(dataclasses.asdict(record)) + "\n")
+    return record
+
+
+def list_conv_checkpoints(logdir: Path) -> list[ConvCheckpoint]:
+    """Return all checkpoints for this conversation, oldest first."""
+    path = _sidecar_path(logdir)
+    if not path.exists():
+        return []
+    records: list[ConvCheckpoint] = []
+    with open(path, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                data = json.loads(line)
+                records.append(
+                    ConvCheckpoint(
+                        index=data["index"],
+                        label=data["label"],
+                        timestamp=data["timestamp"],
+                    )
+                )
+            except (json.JSONDecodeError, KeyError):
+                continue
+    return records
+
+
+def resolve_conv_checkpoint(
+    logdir: Path,
+    identifier: str,
+) -> ConvCheckpoint:
+    """Resolve a label, 1-based index, or bare integer to a checkpoint.
+
+    Priority:
+    1. Pure decimal integer → treat as **message index** (not checkpoint #).
+    2. Otherwise → match against checkpoint labels (most-recent match wins).
+    3. Decimal integer that matches no message-index check → try as 1-based
+       checkpoint list index.
+    """
+    records = list_conv_checkpoints(logdir)
+
+    if identifier.lstrip("-").isdigit():
+        msg_idx = int(identifier)
+        return ConvCheckpoint(
+            index=msg_idx,
+            label=f"@{msg_idx}",
+            timestamp=datetime.now(timezone.utc).isoformat(),
+        )
+
+    # Label match (last one wins so the most-recent label takes precedence)
+    matches = [r for r in records if r.label == identifier]
+    if matches:
+        return matches[-1]
+
+    raise KeyError(
+        f"no checkpoint named {identifier!r} found "
+        f"(use a label, message index, or /backtrack list)"
+    )

--- a/tests/test_backtrack.py
+++ b/tests/test_backtrack.py
@@ -1,0 +1,194 @@
+"""Tests for /backtrack conversation checkpointing (issue #523)."""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+import gptme.commands  # noqa: F401 – ensures all commands are registered
+from gptme.commands.base import handle_cmd
+from gptme.logmanager.conv_checkpoints import (
+    list_conv_checkpoints,
+    resolve_conv_checkpoint,
+    save_conv_checkpoint,
+)
+from gptme.message import Message
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+
+def _make_log(n: int) -> list[Message]:
+    """Build a simple log of n alternating user/assistant messages."""
+    from typing import Literal, cast  # fmt: skip
+
+    Role = Literal["user", "assistant"]
+    msgs = []
+    for i in range(n):
+        role = cast(Role, "user" if i % 2 == 0 else "assistant")
+        msgs.append(Message(role, f"msg {i}"))
+    return msgs
+
+
+def _make_manager(tmp_path: Path, n_messages: int = 6) -> MagicMock:
+    manager = MagicMock()
+    manager.logdir = tmp_path
+    messages = _make_log(n_messages)
+    manager.log = MagicMock()
+    manager.log.messages = messages
+
+    # edit() replaces the log in place (simplified)
+    def _edit(new_msgs):
+        if isinstance(new_msgs, list):
+            manager.log.messages = new_msgs
+        else:
+            manager.log.messages = list(new_msgs)
+
+    manager.edit.side_effect = _edit
+    return manager
+
+
+# ── ConvCheckpoint primitives ─────────────────────────────────────────────────
+
+
+class TestConvCheckpointPrimitives:
+    def test_save_and_list(self, tmp_path):
+        r = save_conv_checkpoint(tmp_path, index=4, label="before-patch")
+        assert r.index == 4
+        assert r.label == "before-patch"
+
+        records = list_conv_checkpoints(tmp_path)
+        assert len(records) == 1
+        assert records[0] == r
+
+    def test_multiple_checkpoints(self, tmp_path):
+        save_conv_checkpoint(tmp_path, 2, "start")
+        save_conv_checkpoint(tmp_path, 6, "mid")
+        records = list_conv_checkpoints(tmp_path)
+        assert [r.label for r in records] == ["start", "mid"]
+
+    def test_empty_list(self, tmp_path):
+        assert list_conv_checkpoints(tmp_path) == []
+
+    def test_sidecar_appends(self, tmp_path):
+        save_conv_checkpoint(tmp_path, 1, "a")
+        save_conv_checkpoint(tmp_path, 2, "b")
+        lines = (tmp_path / "conv-checkpoints.jsonl").read_text().strip().splitlines()
+        assert len(lines) == 2
+
+    def test_resolve_by_label(self, tmp_path):
+        save_conv_checkpoint(tmp_path, 4, "mymark")
+        r = resolve_conv_checkpoint(tmp_path, "mymark")
+        assert r.index == 4
+        assert r.label == "mymark"
+
+    def test_resolve_by_integer(self, tmp_path):
+        r = resolve_conv_checkpoint(tmp_path, "3")
+        assert r.index == 3
+        assert r.label == "@3"
+
+    def test_resolve_missing_label(self, tmp_path):
+        with pytest.raises(KeyError, match="no checkpoint named"):
+            resolve_conv_checkpoint(tmp_path, "nonexistent")
+
+    def test_resolve_last_label_wins(self, tmp_path):
+        save_conv_checkpoint(tmp_path, 2, "foo")
+        save_conv_checkpoint(tmp_path, 8, "foo")  # same label, updated position
+        r = resolve_conv_checkpoint(tmp_path, "foo")
+        assert r.index == 8
+
+
+# ── /backtrack command ────────────────────────────────────────────────────────
+
+
+class TestBacktrackCommand:
+    def test_mark_no_label(self, tmp_path, capsys):
+        manager = _make_manager(tmp_path, n_messages=6)
+        list(handle_cmd("/backtrack mark", manager))
+        out = capsys.readouterr().out
+        assert "cp1" in out
+        assert "index 6" in out
+        records = list_conv_checkpoints(tmp_path)
+        assert len(records) == 1
+        assert records[0].index == 6
+
+    def test_mark_with_label(self, tmp_path, capsys):
+        manager = _make_manager(tmp_path, n_messages=4)
+        list(handle_cmd("/backtrack mark my-label", manager))
+        out = capsys.readouterr().out
+        assert "my-label" in out
+        records = list_conv_checkpoints(tmp_path)
+        assert records[0].label == "my-label"
+        assert records[0].index == 4
+
+    def test_list_empty(self, tmp_path, capsys):
+        manager = _make_manager(tmp_path)
+        list(handle_cmd("/backtrack list", manager))
+        out = capsys.readouterr().out
+        assert "No checkpoints" in out
+
+    def test_list_shows_records(self, tmp_path, capsys):
+        save_conv_checkpoint(tmp_path, 4, "start")
+        manager = _make_manager(tmp_path)
+        list(handle_cmd("/backtrack list", manager))
+        out = capsys.readouterr().out
+        assert "start" in out
+        assert "4" in out
+
+    def test_rewind_by_index(self, tmp_path):
+        manager = _make_manager(tmp_path, n_messages=6)
+        msgs = list(handle_cmd("/backtrack 3", manager))
+        # Log should be truncated to 3 messages
+        assert len(manager.log.messages) == 3
+        # A summary system message should be yielded
+        assert any(m.role == "system" for m in msgs)
+
+    def test_rewind_by_label(self, tmp_path):
+        save_conv_checkpoint(tmp_path, 2, "before-patch")
+        manager = _make_manager(tmp_path, n_messages=6)
+        msgs = list(handle_cmd("/backtrack before-patch", manager))
+        assert len(manager.log.messages) == 2
+        assert any("before-patch" in m.content for m in msgs if m.role == "system")
+
+    def test_rewind_injects_reason(self, tmp_path):
+        manager = _make_manager(tmp_path, n_messages=6)
+        msgs = list(
+            handle_cmd(
+                '/backtrack 2 --reason "Patch hunk not found; re-read the file."',
+                manager,
+            )
+        )
+        system_msgs = [m for m in msgs if m.role == "system"]
+        assert system_msgs
+        assert "Patch hunk not found" in system_msgs[0].content
+
+    def test_rewind_saves_backup_branch(self, tmp_path):
+        manager = _make_manager(tmp_path, n_messages=6)
+        list(handle_cmd("/backtrack 2", manager))
+        # edit() should have been called once
+        assert manager.edit.called
+
+    def test_rewind_to_same_index_is_noop(self, tmp_path, capsys):
+        manager = _make_manager(tmp_path, n_messages=4)
+        list(handle_cmd("/backtrack 4", manager))
+        out = capsys.readouterr().out
+        assert "nothing to rewind" in out
+        # Log unchanged
+        assert len(manager.log.messages) == 4
+
+    def test_rewind_beyond_length_errors(self, tmp_path, capsys):
+        manager = _make_manager(tmp_path, n_messages=4)
+        list(handle_cmd("/backtrack 99", manager))
+        out = capsys.readouterr().out
+        assert "beyond current" in out
+
+    def test_help_subcommand(self, tmp_path, capsys):
+        manager = _make_manager(tmp_path)
+        list(handle_cmd("/backtrack help", manager))
+        out = capsys.readouterr().out
+        assert "Usage" in out
+
+    def test_no_args_prints_usage(self, tmp_path, capsys):
+        manager = _make_manager(tmp_path)
+        list(handle_cmd("/backtrack", manager))
+        out = capsys.readouterr().out
+        assert "Usage" in out

--- a/tests/test_backtrack.py
+++ b/tests/test_backtrack.py
@@ -120,6 +120,19 @@ class TestBacktrackCommand:
         assert records[0].label == "my-label"
         assert records[0].index == 4
 
+    def test_mark_duplicate_label_warns(self, tmp_path, capsys):
+        manager = _make_manager(tmp_path, n_messages=4)
+        list(handle_cmd("/backtrack mark dup", manager))
+        capsys.readouterr()  # clear first mark output
+        manager = _make_manager(tmp_path, n_messages=6)
+        list(handle_cmd("/backtrack mark dup", manager))
+        out = capsys.readouterr().out
+        assert "Warning" in out
+        assert "dup" in out
+        # Both records should be saved
+        records = list_conv_checkpoints(tmp_path)
+        assert len(records) == 2
+
     def test_list_empty(self, tmp_path, capsys):
         manager = _make_manager(tmp_path)
         list(handle_cmd("/backtrack list", manager))


### PR DESCRIPTION
Closes #523

## Summary

Implements Phase 1 of conversation backtracking: named conversation checkpoints + a `/backtrack` command to rewind the log and inject a corrective summary.

**Differentiator vs `/undo`**: `/undo N` removes N messages blindly. `/backtrack` marks a *named* position up front, then rewinds to it later and injects a compact system message explaining *why* the rewind happened — so the model retries more intelligently, not just repeatedly.

## What's added

**`gptme/logmanager/conv_checkpoints.py`** — lightweight sidecar  
Append-only JSONL at `<logdir>/conv-checkpoints.jsonl`. Stores message index, label, and timestamp. No mutation of the conversation log itself.

**`gptme/commands/backtrack.py`** — `/backtrack` command
```
/backtrack mark [label]             Save current position as a named checkpoint
/backtrack list                     Show saved checkpoints for this conversation
/backtrack <label|N> [--reason X]   Rewind log to checkpoint + inject corrective summary
```

The rewind delegates to the existing `LogManager.edit()` path, which saves a backup branch automatically before truncating — full rollback is always possible.

**Example usage:**
```
# Before a risky patch
/backtrack mark before-patch

# …patch fails, context is now wrong…

/backtrack before-patch --reason "Patch hunk not found; re-read the file before editing."
# → truncates to saved index, injects:
# [Backtracked 3 message(s) to index 8 (checkpoint: 'before-patch')]
# Patch hunk not found; re-read the file before editing.
```

## Scope

- Does **not** rollback filesystem state — use `/checkpoint` for that (#2221)
- Phase 2 (auto-backtrack on retryable tool failures) is intentionally out of scope
- 20 tests added, all passing; existing `test_commands` and `test_logmanager` suites unaffected