### PR TITLE
feat(tools): introduce ToolFunction abstraction for structured callable metadata

### DIFF
--- a/gptme/cli/util.py
+++ b/gptme/cli/util.py
@@ -838,7 +838,7 @@ def tools_call(tool_name: str, function_name: str, arg: list[str]):
         sys.exit(1)
 
     function = (
-        [f for f in tool.functions if f.__name__ == function_name] or None
+        [f for f in tool.functions if f.name == function_name] or None
         if tool.functions
         else None
     )
@@ -861,7 +861,7 @@ def tools_call(tool_name: str, function_name: str, arg: list[str]):
         print(f"Function '{function_name}' not found in tool '{tool_name}'.")
         print("Available functions:")
         for f in tool.functions:
-            print(f"- {f.__name__}")
+            print(f"- {f.name}")
         sys.exit(1)
     else:
         # Parse arguments into a dictionary, ensuring proper typing
@@ -876,7 +876,7 @@ def tools_call(tool_name: str, function_name: str, arg: list[str]):
             key, value = arg_str.split("=", 1)
             kwargs[key] = value
         try:
-            return_val = function[0](**kwargs)
+            return_val = function[0].fn(**kwargs)
             print(return_val)
         except TypeError as e:
             click.echo(f"Error calling function: {e}", err=True)

--- a/gptme/tools/__init__.py
+++ b/gptme/tools/__init__.py
@@ -23,6 +23,7 @@ from ._allowlist import (
 from .base import (
     Parameter,
     ToolFormat,
+    ToolFunction,
     ToolSpec,
     ToolUse,
     get_tool_format,
@@ -43,6 +44,7 @@ __all__ = [
     "ToolSpec",
     "ToolUse",
     "ToolFormat",
+    "ToolFunction",
     "Parameter",
     # functions
     "get_tool_format",

--- a/gptme/tools/base.py
+++ b/gptme/tools/base.py
@@ -176,6 +176,41 @@ class Parameter:
     required: bool = False
 
 
+@dataclass(frozen=True)
+class ToolFunction:
+    """A structured callable exposed as a tool function, independent of execution runtime.
+
+    Replaces bare ``Callable`` entries in ``ToolSpec.functions`` with explicit
+    metadata so prompt rendering, IPython registration, and future runtimes all
+    consume the same description instead of introspecting raw Python objects.
+
+    Args:
+        name: Function name used in prompts and lookups.
+        fn: The actual callable to invoke.
+        description: Human-readable description shown in the tool prompt.
+        group: Logical grouping (e.g. "discord", "github") for allowlist patterns.
+        parameters: Explicit parameter schema; if empty, derived from fn's annotations.
+        hints: Capability tags (e.g. ``{"read-only"}``, ``{"destructive"}``).
+    """
+
+    name: str
+    fn: Callable
+    description: str = ""
+    group: str | None = None
+    parameters: list[Parameter] = field(default_factory=list)
+    hints: frozenset[str] = field(default_factory=frozenset)
+
+    @classmethod
+    def from_callable(cls, fn: Any, group: str | None = None) -> ToolFunction:
+        """Construct a ToolFunction from a plain callable, inferring metadata."""
+        return cls(
+            name=fn.__name__,
+            fn=fn,
+            description=fn.__doc__ or "",
+            group=group,
+        )
+
+
 def derive_type(t) -> str:
     """Convert a type annotation to a human-readable string for tool signatures.
 
@@ -266,7 +301,7 @@ class ToolSpec:
     instructions: str = ""
     instructions_format: dict[str, str] = field(default_factory=dict)
     examples: str | Callable[[str], str] = ""
-    functions: list[Callable] | None = None
+    functions: list[ToolFunction] | None = None
     init: InitFunc | None = None
     execute: ExecuteFunc | None = None
     block_types: list[str] = field(default_factory=list)
@@ -432,14 +467,12 @@ class ToolSpec:
         # return a prompt with a brief description of the available functions
         if self.functions:
             description = "The following Python functions are available using the `ipython` tool:\n\n```txt\n"
-            return (
-                description
-                + "\n".join(
-                    f"{callable_signature(func)}: {func.__doc__ or 'No description'}"
-                    for func in self.functions
-                )
-                + "\n```"
-            )
+            lines = []
+            for tf in self.functions:
+                sig = callable_signature(tf.fn)
+                doc = tf.description or "No description"
+                lines.append(f"{sig}: {doc}")
+            return description + "\n".join(lines) + "\n```"
         return "None"
 
 

--- a/gptme/tools/browser.py
+++ b/gptme/tools/browser.py
@@ -86,7 +86,7 @@ from ..util.gh import (
     parse_github_url,
     transform_github_url,
 )
-from .base import ToolSpec, ToolUse
+from .base import ToolFunction, ToolSpec, ToolUse
 
 try:
     import pypdf
@@ -1036,18 +1036,21 @@ services with APIs, prefer shell or Python over scraping.""",
     },
     examples=examples,
     functions=[
-        read_url,
-        search,
-        screenshot_url,
-        snapshot_url,
-        open_page,
-        close_page,
-        read_page_text,
-        click_element,
-        fill_element,
-        scroll_page,
-        read_logs,
-        pdf_to_images,
+        ToolFunction.from_callable(f)
+        for f in [
+            read_url,
+            search,
+            screenshot_url,
+            snapshot_url,
+            open_page,
+            close_page,
+            read_page_text,
+            click_element,
+            fill_element,
+            scroll_page,
+            read_logs,
+            pdf_to_images,
+        ]
     ],
     available=has_browser_tool,
     init=init,

--- a/gptme/tools/chats.py
+++ b/gptme/tools/chats.py
@@ -14,7 +14,7 @@ from typing import Literal
 
 from ..logmanager.conversations import _format_duration
 from ..message import Message
-from .base import ToolSpec, ToolUse
+from .base import ToolFunction, ToolSpec, ToolUse
 
 logger = logging.getLogger(__name__)
 
@@ -784,7 +784,9 @@ tool = ToolSpec(
         "or read a specific conversation by ID with read_chat().",
     },
     examples=examples,
-    functions=[list_chats, search_chats, read_chat],
+    functions=[
+        ToolFunction.from_callable(f) for f in [list_chats, search_chats, read_chat]
+    ],
 )
 
 __doc__ = tool.get_doc(__doc__)

--- a/gptme/tools/computer.py
+++ b/gptme/tools/computer.py
@@ -82,7 +82,7 @@ import subprocess
 from enum import Enum
 from typing import TYPE_CHECKING, Literal, TypedDict
 
-from .base import ToolSpec, ToolUse
+from .base import ToolFunction, ToolSpec, ToolUse
 from .computer_transport import get_transport
 from .screenshot import screenshot
 from .vision import view_image
@@ -1001,7 +1001,7 @@ tool = ToolSpec(
     desc="Control the computer through X11 (keyboard, mouse, screen)",
     instructions=instructions,
     examples=examples,
-    functions=[computer],
+    functions=[ToolFunction.from_callable(computer)],
     disabled_by_default=True,
 )
 

--- a/gptme/tools/python.py
+++ b/gptme/tools/python.py
@@ -334,7 +334,7 @@ def get_installed_python_libraries() -> list[str]:
 
 def get_functions():
     return "\n".join(
-        [f"- {callable_signature(func)}" for func in registered_functions.values()]
+        [f"- {callable_signature(fn)}" for fn in registered_functions.values()]
     )
 
 
@@ -399,8 +399,8 @@ def init() -> ToolSpec:
     # Register python functions from other tools
     for loaded_tool in get_tools():
         if loaded_tool.functions:
-            for func in loaded_tool.functions:
-                register_function(func)
+            for tf in loaded_tool.functions:
+                register_function(tf.fn)
 
     python_libraries = get_installed_python_libraries()
     python_libraries_str = (

--- a/gptme/tools/rag.py
+++ b/gptme/tools/rag.py
@@ -47,7 +47,7 @@ from ..config import RagConfig, get_project_config
 from ..dirs import get_project_gptme_dir
 from ..llm import _chat_complete
 from ..message import Message
-from .base import ToolSpec, ToolUse
+from .base import ToolFunction, ToolSpec, ToolUse
 
 logger = logging.getLogger(__name__)
 
@@ -281,7 +281,9 @@ tool = ToolSpec(
     desc="RAG (Retrieval-Augmented Generation) for context-aware assistance",
     instructions=instructions,
     examples=examples,
-    functions=[rag_index, rag_search, rag_status],
+    functions=[
+        ToolFunction.from_callable(f) for f in [rag_index, rag_search, rag_status]
+    ],
     available=_has_gptme_rag,
     init=init,
     hooks={

--- a/gptme/tools/screenshot.py
+++ b/gptme/tools/screenshot.py
@@ -9,7 +9,7 @@ import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
 
-from .base import ToolSpec, ToolUse
+from .base import ToolFunction, ToolSpec, ToolUse
 
 OUTPUT_DIR = Path("/tmp/outputs")
 IS_MACOS = platform.system() == "Darwin"
@@ -157,6 +157,6 @@ tool = ToolSpec(
     desc="Take a screenshot",
     available=_is_available,
     instructions=INSTRUCTIONS,
-    functions=[screenshot],
+    functions=[ToolFunction.from_callable(screenshot)],
     examples=examples,
 )

--- a/gptme/tools/subagent/__init__.py
+++ b/gptme/tools/subagent/__init__.py
@@ -12,7 +12,7 @@ Package structure:
 
 # Re-export public API for backward compatibility
 # Re-export ToolUse for examples()
-from ..base import ToolSpec, ToolUse
+from ..base import ToolFunction, ToolSpec, ToolUse
 from .api import subagent, subagent_read_log, subagent_status, subagent_wait
 from .batch import BatchJob, subagent_batch
 from .hooks import (
@@ -278,11 +278,14 @@ tool = ToolSpec(
     instructions=instructions,
     examples=examples,
     functions=[
-        subagent,
-        subagent_status,
-        subagent_wait,
-        subagent_read_log,
-        subagent_batch,
+        ToolFunction.from_callable(f)
+        for f in [
+            subagent,
+            subagent_status,
+            subagent_wait,
+            subagent_read_log,
+            subagent_batch,
+        ]
     ],
     disabled_by_default=True,
     hooks={

--- a/gptme/tools/vision.py
+++ b/gptme/tools/vision.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from PIL import Image
 
 from ..message import Message
-from .base import ToolSpec
+from .base import ToolFunction, ToolSpec
 
 # Track temp files for cleanup on exit
 _temp_files: list[Path] = []
@@ -118,5 +118,5 @@ tool = ToolSpec(
     name="vision",
     desc="Viewing images",
     instructions=instructions,
-    functions=[view_image],
+    functions=[ToolFunction.from_callable(view_image)],
 )

--- a/gptme/util/tool_format.py
+++ b/gptme/util/tool_format.py
@@ -51,7 +51,7 @@ def tool_to_dict(tool: "ToolSpec") -> dict[str, Any]:
         "disabled_by_default": tool.disabled_by_default,
         "block_types": tool.block_types,
         "has_execute": bool(tool.execute),
-        "functions": [f.__name__ for f in tool.functions] if tool.functions else [],
+        "functions": [f.name for f in tool.functions] if tool.functions else [],
         "commands": list(tool.commands.keys()) if tool.commands else [],
         "is_mcp": bool(tool.is_mcp),
     }

--- a/tests/test_tools_base.py
+++ b/tests/test_tools_base.py
@@ -15,6 +15,7 @@ from gptme.hooks import HookType
 from gptme.message import Message
 from gptme.tools.base import (
     Parameter,
+    ToolFunction,
     ToolSpec,
     ToolUse,
     _codeblock_char_ranges,
@@ -202,6 +203,90 @@ class TestCallableSignature:
         assert sig == "bare()"
 
 
+# ── ToolFunction ──────────────────────────────────────────────────
+
+
+class TestToolFunction:
+    def test_from_callable_infers_name(self):
+        def my_func(x: int) -> str:
+            """Does something."""
+            return ""
+
+        tf = ToolFunction.from_callable(my_func)
+        assert tf.name == "my_func"
+
+    def test_from_callable_infers_description(self):
+        def documented(x: int) -> str:
+            """This is a docstring."""
+            return ""
+
+        tf = ToolFunction.from_callable(documented)
+        assert tf.description == "This is a docstring."
+
+    def test_from_callable_no_docstring(self):
+        def nodoc():
+            pass
+
+        tf = ToolFunction.from_callable(nodoc)
+        assert tf.description == ""
+
+    def test_from_callable_group(self):
+        def fn():
+            pass
+
+        tf = ToolFunction.from_callable(fn, group="discord")
+        assert tf.group == "discord"
+
+    def test_default_hints_empty(self):
+        def fn():
+            pass
+
+        tf = ToolFunction.from_callable(fn)
+        assert tf.hints == frozenset()
+
+    def test_explicit_hints(self):
+        def fn():
+            pass
+
+        tf = ToolFunction(name="fn", fn=fn, hints=frozenset({"read-only"}))
+        assert "read-only" in tf.hints
+
+    def test_fn_is_callable(self):
+        def adder(a: int, b: int) -> int:
+            return a + b
+
+        tf = ToolFunction.from_callable(adder)
+        assert tf.fn(2, 3) == 5
+
+    def test_frozen(self):
+        def fn():
+            pass
+
+        tf = ToolFunction.from_callable(fn)
+        with pytest.raises((AttributeError, TypeError)):
+            tf.name = "new_name"  # type: ignore[misc]
+
+    def test_functions_description_uses_toolfunction_metadata(self):
+        def helper(name: str) -> bool:
+            """Checks a name."""
+            return True
+
+        tf = ToolFunction.from_callable(helper)
+        spec = ToolSpec(name="t", desc="", functions=[tf])
+        desc = spec.get_functions_description()
+        assert "helper" in desc
+        assert "Checks a name" in desc
+
+    def test_functions_description_explicit_description(self):
+        def helper(name: str) -> bool:
+            return True
+
+        tf = ToolFunction(name="helper", fn=helper, description="Custom description")
+        spec = ToolSpec(name="t", desc="", functions=[tf])
+        desc = spec.get_functions_description()
+        assert "Custom description" in desc
+
+
 # ── ToolSpec ───────────────────────────────────────────────────────
 
 
@@ -289,7 +374,9 @@ class TestToolSpec:
             """Does something."""
             return ""
 
-        tool = ToolSpec(name="t", desc="", functions=[my_func])
+        tool = ToolSpec(
+            name="t", desc="", functions=[ToolFunction.from_callable(my_func)]
+        )
         result = tool.get_instructions("markdown")
         assert "my_func" in result
         assert "Does something" in result
@@ -299,7 +386,9 @@ class TestToolSpec:
             """Checks a name."""
             return True
 
-        tool = ToolSpec(name="t", desc="", functions=[helper])
+        tool = ToolSpec(
+            name="t", desc="", functions=[ToolFunction.from_callable(helper)]
+        )
         desc = tool.get_functions_description()
         assert "helper" in desc
         assert "Checks a name" in desc

--- a/tests/test_tools_browser.py
+++ b/tests/test_tools_browser.py
@@ -918,7 +918,7 @@ class TestToolSpec:
 
     def test_tool_functions_include_core(self):
         assert tool.functions is not None
-        fn_names = [f.__name__ for f in tool.functions]
+        fn_names = [f.name for f in tool.functions]
         assert "read_url" in fn_names
         assert "search" in fn_names
         assert "screenshot_url" in fn_names

--- a/tests/test_util_tool_format.py
+++ b/tests/test_util_tool_format.py
@@ -11,7 +11,7 @@ Tests cover:
 from typing import Any
 from unittest.mock import patch
 
-from gptme.tools.base import ToolSpec
+from gptme.tools.base import ToolFunction, ToolSpec
 from gptme.util.tool_format import (
     format_langtags,
     format_tool_info,
@@ -80,7 +80,7 @@ class TestToolToDict:
         def my_func():
             pass
 
-        d = tool_to_dict(_tool(functions=[my_func]))
+        d = tool_to_dict(_tool(functions=[ToolFunction.from_callable(my_func)]))
         assert d["functions"] == ["my_func"]
 
     def test_no_functions(self):


### PR DESCRIPTION
## Summary

Implements Phase 1 of the refactor proposed in #607.

Adds a `ToolFunction` dataclass that replaces bare `Callable` entries in
`ToolSpec.functions`. This decouples function metadata from IPython-specific
concerns so future runtimes (or autonomous modes) can consume the same
structured info without introspecting raw Python objects.

### Changes

- **`gptme/tools/base.py`**: Add `ToolFunction` dataclass with fields:
  - `name`: function name for prompts and lookups
  - `fn`: the actual callable
  - `description`: shown in tool prompts (inferred from `__doc__` via `from_callable`)
  - `group`: logical grouping for allowlist patterns (e.g. `"discord"`)
  - `parameters`: explicit parameter schema (optional; introspected from annotations if empty)
  - `hints`: frozenset of capability tags (`"read-only"`, `"destructive"`, etc.)
  - `from_callable(fn)` classmethod for easy migration from raw callables
- **`ToolSpec.functions`**: type changed from `list[Callable] | None` to `list[ToolFunction] | None`
- **`get_functions_description()`**: uses `ToolFunction.name`/`description` instead of `__name__`/`__doc__`
- **`gptme/tools/python.py`**: registers `tf.fn` instead of the `ToolFunction` itself
- **Migrated 7 tools**: `browser`, `chats`, `computer`, `rag`, `screenshot`, `subagent`, `vision`
- **Fixed call sites**: `cli/util.py` and `util/tool_format.py` now use `.name`/`.fn`
- **Export**: `ToolFunction` exported from `gptme.tools`
- **Tests**: `TestToolFunction` class in `test_tools_base.py` (11 new tests)

### Phase 2 and 3 status

- **Phase 2** (allowlist wildcards `discord.*`): already implemented via `fnmatchcase` in `_allowlist.py` — no changes needed.
- **Phase 3** (safety hints propagation from MCP): future work. The `hints` field on `ToolFunction` is the hook for this.

## Test plan

- [x] `tests/test_tools_base.py` — all 99 tests pass (11 new `TestToolFunction` tests)
- [x] `tests/test_tools.py`, `tests/test_prompt_tools.py`, `tests/test_tools_python.py` — 84 tests pass
- [x] `mypy` passes (pre-commit)
- [x] `ruff` passes (pre-commit)

Closes #607 (Phase 1)