### PR TITLE
feat(subagent): forward subprocess/isolated defaults from planner subtask roles

### DIFF
--- a/gptme/tools/subagent/execution.py
+++ b/gptme/tools/subagent/execution.py
@@ -569,15 +569,31 @@ def _run_planner(
 
         if resolved_use_subprocess:
             # Subprocess mode: better output isolation for verify/sensitive roles
-            process = _run_subagent_subprocess(
-                prompt=executor_prompt,
-                logdir=logdir,
-                model=model,
-                workspace=workspace,
-                context_mode=context_mode,
-                context_include=context_include,
-                profile=resolved_profile,
+            cleanup_sa = Subagent(
+                executor_id,
+                executor_prompt,
+                None,
+                logdir,
+                model,
+                execution_mode="subprocess",
+                isolated=resolved_isolated,
+                worktree_path=worktree_path,
+                repo_path=repo_path,
             )
+
+            try:
+                process = _run_subagent_subprocess(
+                    prompt=executor_prompt,
+                    logdir=logdir,
+                    model=model,
+                    workspace=workspace,
+                    context_mode=context_mode,
+                    context_include=context_include,
+                    profile=resolved_profile,
+                )
+            except Exception:
+                _cleanup_isolation(cleanup_sa)
+                raise
 
             sa = Subagent(
                 executor_id,
@@ -591,6 +607,7 @@ def _run_planner(
                 worktree_path=worktree_path,
                 repo_path=repo_path,
             )
+
             with _subagents_lock:
                 _subagents.append(sa)
 
@@ -611,39 +628,53 @@ def _run_planner(
                 logger.info(f"Executor {executor_id} subprocess completed")
         else:
             # Thread mode: original behavior for explore/implement roles
+            cleanup_sa = Subagent(
+                executor_id,
+                executor_prompt,
+                None,
+                logdir,
+                model,
+                isolated=resolved_isolated,
+                worktree_path=worktree_path,
+                repo_path=repo_path,
+            )
+
             def run_executor(
                 prompt=executor_prompt,
                 log_dir=logdir,
                 ws=workspace,
                 subtask_profile=resolved_profile,
+                cleanup_subagent=cleanup_sa,
             ):
-                _create_subagent_thread(
-                    prompt=prompt,
-                    logdir=log_dir,
-                    model=model,
-                    context_mode=context_mode,
-                    context_include=context_include,
-                    workspace=ws,
-                    target="planner",
-                    profile_name=subtask_profile,
-                )
+                try:
+                    _create_subagent_thread(
+                        prompt=prompt,
+                        logdir=log_dir,
+                        model=model,
+                        context_mode=context_mode,
+                        context_include=context_include,
+                        workspace=ws,
+                        target="planner",
+                        profile_name=subtask_profile,
+                    )
+                finally:
+                    _cleanup_isolation(cleanup_subagent)
 
             t = threading.Thread(target=run_executor, daemon=True)
+            sa = Subagent(
+                executor_id,
+                executor_prompt,
+                t,
+                logdir,
+                model,
+                isolated=resolved_isolated,
+                worktree_path=worktree_path,
+                repo_path=repo_path,
+            )
             # Register subagent BEFORE starting thread to avoid race condition
             # (matches pattern in api.py — thread closure may look up _subagents)
             with _subagents_lock:
-                _subagents.append(
-                    Subagent(
-                        executor_id,
-                        executor_prompt,
-                        t,
-                        logdir,
-                        model,
-                        isolated=resolved_isolated,
-                        worktree_path=worktree_path,
-                        repo_path=repo_path,
-                    )
-                )
+                _subagents.append(sa)
             t.start()
 
             # Sequential mode: wait for each task to complete before starting next
@@ -652,7 +683,7 @@ def _run_planner(
                 t.join()
                 logger.info(f"Executor {executor_id} completed")
 
-    # Parallel mode: all threads already started
+    # Parallel mode: all executors (threads/subprocesses) already started
     if execution_mode == "parallel":
         logger.info(f"Planner {agent_id} spawned {len(subtasks)} executor subagents")
     else:

--- a/gptme/tools/subagent/execution.py
+++ b/gptme/tools/subagent/execution.py
@@ -14,6 +14,7 @@ import subprocess
 import sys
 import tempfile
 import threading
+import uuid
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
@@ -501,58 +502,155 @@ def _run_planner(
         name = f"subagent-{executor_id}"
         logdir = get_logdir(name + "-" + random_string(4))
 
-        # Resolve role-based profile per subtask if role is set.
+        # Resolve role-based defaults per subtask if role is set.
         # Per-subtask role is more specific than the planner-level profile, so it
         # always wins — even when the planner itself carries a profile.
-        # NOTE(phase2): use_subprocess/isolated from role are not yet forwarded
-        # to individual executors (planner always uses thread mode). Only profile
-        # is applied here. See SubtaskDef.role docstring for the Phase 2 plan.
+        # Role also controls execution mode: role="verify" enables subprocess+isolated
+        # for sandboxed validation; role="explore"/"implement" use thread mode (default).
         subtask_role = subtask.get("role")
         resolved_profile = profile_name
+        resolved_use_subprocess = False
+        resolved_isolated = False
         if subtask_role:
-            _, _, role_profile = resolve_role_defaults(subtask_role, None, None)
+            role_use_sub, role_isolated, role_profile = resolve_role_defaults(
+                subtask_role, None, None
+            )
             if role_profile is not None:
                 resolved_profile = role_profile
-                logger.info(
-                    f"Subtask '{subtask['id']}' resolved profile '{role_profile}' from role='{subtask_role}'"
-                )
+            resolved_use_subprocess = role_use_sub
+            resolved_isolated = role_isolated
+            logger.info(
+                f"Subtask '{subtask['id']}' resolved from role='{subtask_role}': "
+                f"profile={resolved_profile!r}, "
+                f"use_subprocess={resolved_use_subprocess}, "
+                f"isolated={resolved_isolated}"
+            )
 
-        # Capture workspace before spawning thread to avoid FileNotFoundError
+        # Capture workspace before spawning to avoid FileNotFoundError
         # if cwd is deleted (e.g., tmpdir cleanup in tests)
         try:
             workspace = Path.cwd()
         except FileNotFoundError:
             workspace = logdir.parent
 
-        def run_executor(
-            prompt=executor_prompt,
-            log_dir=logdir,
-            ws=workspace,
-            subtask_profile=resolved_profile,
-        ):
-            _create_subagent_thread(
-                prompt=prompt,
-                logdir=log_dir,
+        # Set up worktree isolation if the resolved role requires it
+        worktree_path: Path | None = None
+        repo_path: Path | None = None
+        if resolved_isolated:
+            from ...util.git_worktree import create_worktree, get_git_root
+
+            git_root = get_git_root(workspace)
+            if git_root:
+                try:
+                    branch_name = f"subagent-{executor_id}-{uuid.uuid4().hex[:8]}"
+                    worktree_path = create_worktree(git_root, branch_name=branch_name)
+                    workspace = worktree_path
+                    repo_path = git_root
+                    logger.info(
+                        f"Executor {executor_id} isolated in worktree: {worktree_path}"
+                    )
+                except Exception as e:
+                    logger.warning(
+                        f"Failed to create worktree for {executor_id}, "
+                        f"falling back to temp dir: {e}"
+                    )
+                    worktree_path = Path(
+                        tempfile.mkdtemp(prefix=f"subagent-{executor_id}-")
+                    )
+                    workspace = worktree_path
+            else:
+                worktree_path = Path(
+                    tempfile.mkdtemp(prefix=f"subagent-{executor_id}-")
+                )
+                workspace = worktree_path
+                logger.info(
+                    f"Not in a git repo, using temp dir for {executor_id}: {worktree_path}"
+                )
+
+        if resolved_use_subprocess:
+            # Subprocess mode: better output isolation for verify/sensitive roles
+            process = _run_subagent_subprocess(
+                prompt=executor_prompt,
+                logdir=logdir,
                 model=model,
+                workspace=workspace,
                 context_mode=context_mode,
                 context_include=context_include,
-                workspace=ws,
-                target="planner",
-                profile_name=subtask_profile,
+                profile=resolved_profile,
             )
 
-        t = threading.Thread(target=run_executor, daemon=True)
-        # Register subagent BEFORE starting thread to avoid race condition
-        # (matches pattern in api.py — thread closure may look up _subagents)
-        with _subagents_lock:
-            _subagents.append(Subagent(executor_id, executor_prompt, t, logdir, model))
-        t.start()
+            sa = Subagent(
+                executor_id,
+                executor_prompt,
+                None,
+                logdir,
+                model,
+                process=process,
+                execution_mode="subprocess",
+                isolated=resolved_isolated,
+                worktree_path=worktree_path,
+                repo_path=repo_path,
+            )
+            with _subagents_lock:
+                _subagents.append(sa)
 
-        # Sequential mode: wait for each task to complete before starting next
-        if execution_mode == "sequential":
-            logger.info(f"Waiting for {executor_id} to complete (sequential mode)")
-            t.join()
-            logger.info(f"Executor {executor_id} completed")
+            # Monitor thread handles completion notification and cleanup
+            monitor_t = threading.Thread(
+                target=_monitor_subprocess,
+                args=(sa,),
+                daemon=True,
+            )
+            monitor_t.start()
+
+            # Sequential mode: wait for this executor before starting the next
+            if execution_mode == "sequential":
+                logger.info(
+                    f"Waiting for {executor_id} subprocess to complete (sequential mode)"
+                )
+                monitor_t.join()
+                logger.info(f"Executor {executor_id} subprocess completed")
+        else:
+            # Thread mode: original behavior for explore/implement roles
+            def run_executor(
+                prompt=executor_prompt,
+                log_dir=logdir,
+                ws=workspace,
+                subtask_profile=resolved_profile,
+            ):
+                _create_subagent_thread(
+                    prompt=prompt,
+                    logdir=log_dir,
+                    model=model,
+                    context_mode=context_mode,
+                    context_include=context_include,
+                    workspace=ws,
+                    target="planner",
+                    profile_name=subtask_profile,
+                )
+
+            t = threading.Thread(target=run_executor, daemon=True)
+            # Register subagent BEFORE starting thread to avoid race condition
+            # (matches pattern in api.py — thread closure may look up _subagents)
+            with _subagents_lock:
+                _subagents.append(
+                    Subagent(
+                        executor_id,
+                        executor_prompt,
+                        t,
+                        logdir,
+                        model,
+                        isolated=resolved_isolated,
+                        worktree_path=worktree_path,
+                        repo_path=repo_path,
+                    )
+                )
+            t.start()
+
+            # Sequential mode: wait for each task to complete before starting next
+            if execution_mode == "sequential":
+                logger.info(f"Waiting for {executor_id} to complete (sequential mode)")
+                t.join()
+                logger.info(f"Executor {executor_id} completed")
 
     # Parallel mode: all threads already started
     if execution_mode == "parallel":

--- a/gptme/tools/subagent/types.py
+++ b/gptme/tools/subagent/types.py
@@ -90,8 +90,10 @@ class SubtaskDef(TypedDict):
 
     id: str
     description: str
-    # NOTE(phase2): role sets the executor profile but subprocess/isolated defaults
-    # are not yet forwarded — planner always spawns executors in thread mode.
+    # role sets both the executor profile AND execution mode defaults:
+    # - "verify" → verifier profile + subprocess + isolated (sandboxed validation)
+    # - "explore" → explorer profile + thread mode (read-only analysis)
+    # - "implement" → developer profile + thread mode (full capability)
     role: NotRequired[Role]
 
 

--- a/tests/test_tools_subagent.py
+++ b/tests/test_tools_subagent.py
@@ -2027,6 +2027,41 @@ def test_planner_subtask_role_verify_sets_isolated(
     assert sa.isolated is True
 
 
+@patch("gptme.tools.subagent.execution._cleanup_isolation")
+@patch("gptme.tools.subagent.execution._monitor_subprocess")
+@patch(
+    "gptme.tools.subagent.execution._run_subagent_subprocess",
+    side_effect=OSError("boom"),
+)
+@patch("gptme.util.git_worktree.create_worktree", return_value=Path("/tmp/verify-wt"))
+@patch("gptme.util.git_worktree.get_git_root", return_value=Path("/tmp/repo"))
+def test_planner_subtask_role_verify_cleans_isolation_on_launch_failure(
+    mock_get_git_root: MagicMock,
+    mock_create_worktree: MagicMock,
+    mock_run_subprocess: MagicMock,
+    mock_monitor: MagicMock,
+    mock_cleanup_isolation: MagicMock,
+):
+    """Failed subprocess launch should still clean up verify isolation."""
+    initial_count = len(_subagents)
+    subtasks: list[SubtaskDef] = [
+        {"id": "check3", "description": "Verify output", "role": "verify"},
+    ]
+
+    with pytest.raises(OSError, match="boom"):
+        subagent(
+            agent_id="test-verify-launch-failure",
+            prompt="context",
+            mode="planner",
+            subtasks=subtasks,
+        )
+
+    mock_run_subprocess.assert_called_once()
+    mock_monitor.assert_not_called()
+    mock_cleanup_isolation.assert_called_once()
+    assert len(_subagents) == initial_count
+
+
 @patch("gptme.tools.subagent.execution._create_subagent_thread")
 def test_planner_subtask_role_explore_uses_thread_mode(mock_create_thread: MagicMock):
     """role='explore' should NOT trigger subprocess mode — stays thread mode."""
@@ -2051,6 +2086,46 @@ def test_planner_subtask_role_explore_uses_thread_mode(mock_create_thread: Magic
     assert len(new_agents) == 1
     sa = new_agents[0]
     assert sa.execution_mode == "thread"
+
+
+@patch("gptme.tools.subagent.execution._cleanup_isolation")
+@patch("gptme.tools.subagent.execution._create_subagent_thread")
+@patch(
+    "gptme.tools.subagent.types.resolve_role_defaults",
+    return_value=(False, True, "explorer"),
+)
+@patch(
+    "gptme.util.git_worktree.create_worktree",
+    return_value=Path("/tmp/thread-isolated-wt"),
+)
+@patch("gptme.util.git_worktree.get_git_root", return_value=Path("/tmp/repo"))
+def test_planner_thread_mode_cleans_isolation_after_completion(
+    mock_get_git_root: MagicMock,
+    mock_create_worktree: MagicMock,
+    mock_resolve_role_defaults: MagicMock,
+    mock_create_thread: MagicMock,
+    mock_cleanup_isolation: MagicMock,
+):
+    """Thread-mode isolated executors should also clean up their worktree."""
+    initial_count = len(_subagents)
+    subtasks: list[SubtaskDef] = [
+        {"id": "scan2", "description": "Explore the codebase", "role": "explore"},
+    ]
+
+    subagent(
+        agent_id="test-thread-isolated-cleanup",
+        prompt="context",
+        mode="planner",
+        subtasks=subtasks,
+    )
+
+    _wait_for_new_subagent_threads(initial_count, timeout=1.0)
+
+    mock_create_thread.assert_called_once()
+    mock_cleanup_isolation.assert_called_once()
+    new_agents = _subagents[initial_count:]
+    assert len(new_agents) == 1
+    assert new_agents[0].isolated is True
 
 
 @patch("gptme.tools.subagent.execution._create_subagent_thread")

--- a/tests/test_tools_subagent.py
+++ b/tests/test_tools_subagent.py
@@ -1908,21 +1908,32 @@ def test_planner_with_role_uses_role_for_self_profile(mock_create_thread: MagicM
         assert "profile_name" in kwargs
 
 
-@patch("gptme.tools.subagent.execution._create_subagent_thread")
-def test_planner_subtask_role_overrides_planner_profile(mock_create_thread: MagicMock):
+@patch("gptme.tools.subagent.execution._monitor_subprocess")
+@patch("gptme.tools.subagent.execution._run_subagent_subprocess")
+def test_planner_subtask_role_overrides_planner_profile(
+    mock_run_subprocess: MagicMock,
+    mock_monitor: MagicMock,
+):
     """Subtask role wins over planner-level profile.
 
     When the planner itself carries a profile (e.g. role=implement → "developer"),
     a subtask with its own role (e.g. role=verify → "verifier") must still resolve
     to the subtask's profile — not silently inherit the planner's.
 
+    role=verify also switches the executor to subprocess mode (Phase 2 behaviour),
+    so this test verifies both the profile override AND the correct execution backend.
+
     This is the regression case flagged by Greptile: the old guard
     `profile_name is None` meant subtask roles were silently dropped as soon
     as the planner had any profile of its own.
     """
+    mock_run_subprocess.return_value = MagicMock()  # fake Popen
+
     subtasks: list[SubtaskDef] = [
         {"id": "verify", "description": "Verify the output", "role": "verify"},
     ]
+
+    initial_count = len(_subagents)
 
     # Planner inherits role=implement → profile_name="developer" in _run_planner
     subagent(
@@ -1933,12 +1944,174 @@ def test_planner_subtask_role_overrides_planner_profile(mock_create_thread: Magi
         subtasks=subtasks,
     )
 
-    _wait_for_new_subagent_threads(0, timeout=2.0)
-
-    mock_create_thread.assert_called_once()
-    kwargs = mock_create_thread.call_args[1]
+    # role=verify routes to subprocess backend (not thread mode)
+    mock_run_subprocess.assert_called_once()
+    sub_kwargs = mock_run_subprocess.call_args[1]
     # Subtask role=verify must resolve to "verifier", overriding planner's "developer"
-    assert kwargs["profile_name"] == "verifier", (
-        f"Expected subtask role 'verify' to resolve to 'verifier', got {kwargs['profile_name']!r}. "
+    assert sub_kwargs.get("profile") == "verifier", (
+        f"Expected subtask role 'verify' to resolve to 'verifier', got {sub_kwargs.get('profile')!r}. "
         "Per-subtask role should always override planner-level profile."
     )
+
+    new_agents = _subagents[initial_count:]
+    assert len(new_agents) == 1
+    assert new_agents[0].execution_mode == "subprocess"
+
+
+# ---------------------------------------------------------------------------
+# Phase 2: Subprocess/isolated forwarding from subtask roles
+# ---------------------------------------------------------------------------
+
+
+@patch("gptme.tools.subagent.execution._monitor_subprocess")
+@patch("gptme.tools.subagent.execution._run_subagent_subprocess")
+def test_planner_subtask_role_verify_uses_subprocess(
+    mock_run_subprocess: MagicMock,
+    mock_monitor: MagicMock,
+):
+    """role='verify' on a subtask must launch that executor in subprocess mode."""
+    mock_run_subprocess.return_value = MagicMock()  # fake Popen
+
+    initial_count = len(_subagents)
+    subtasks: list[SubtaskDef] = [
+        {"id": "check", "description": "Validate the output", "role": "verify"},
+    ]
+
+    subagent(
+        agent_id="test-verify-sub",
+        prompt="Build and verify",
+        mode="planner",
+        subtasks=subtasks,
+    )
+
+    # Subprocess backend should have been called for the verify subtask
+    mock_run_subprocess.assert_called_once()
+    call_kwargs = mock_run_subprocess.call_args[1]
+    assert call_kwargs.get("profile") == "verifier"
+
+    # A monitor thread should have been started
+    mock_monitor.assert_called_once()
+
+    # The registered Subagent should carry execution_mode="subprocess"
+    new_agents = _subagents[initial_count:]
+    assert len(new_agents) == 1
+    sa = new_agents[0]
+    assert sa.execution_mode == "subprocess"
+    assert sa.agent_id == "test-verify-sub-check"
+
+
+@patch("gptme.tools.subagent.execution._monitor_subprocess")
+@patch("gptme.tools.subagent.execution._run_subagent_subprocess")
+def test_planner_subtask_role_verify_sets_isolated(
+    mock_run_subprocess: MagicMock,
+    mock_monitor: MagicMock,
+):
+    """role='verify' on a subtask should request isolated execution."""
+    mock_run_subprocess.return_value = MagicMock()
+
+    initial_count = len(_subagents)
+    subtasks: list[SubtaskDef] = [
+        {"id": "check2", "description": "Verify output", "role": "verify"},
+    ]
+
+    subagent(
+        agent_id="test-verify-isolated",
+        prompt="context",
+        mode="planner",
+        subtasks=subtasks,
+    )
+
+    new_agents = _subagents[initial_count:]
+    assert len(new_agents) == 1
+    sa = new_agents[0]
+    assert sa.isolated is True
+
+
+@patch("gptme.tools.subagent.execution._create_subagent_thread")
+def test_planner_subtask_role_explore_uses_thread_mode(mock_create_thread: MagicMock):
+    """role='explore' should NOT trigger subprocess mode — stays thread mode."""
+    initial_count = len(_subagents)
+    subtasks: list[SubtaskDef] = [
+        {"id": "scan", "description": "Explore the codebase", "role": "explore"},
+    ]
+
+    subagent(
+        agent_id="test-explore-thread",
+        prompt="context",
+        mode="planner",
+        subtasks=subtasks,
+    )
+
+    _wait_for_new_subagent_threads(initial_count, timeout=1.0)
+
+    # Thread backend used, not subprocess
+    mock_create_thread.assert_called_once()
+
+    new_agents = _subagents[initial_count:]
+    assert len(new_agents) == 1
+    sa = new_agents[0]
+    assert sa.execution_mode == "thread"
+
+
+@patch("gptme.tools.subagent.execution._create_subagent_thread")
+def test_planner_subtask_role_implement_uses_thread_mode(mock_create_thread: MagicMock):
+    """role='implement' should use thread mode (not subprocess)."""
+    initial_count = len(_subagents)
+    subtasks: list[SubtaskDef] = [
+        {"id": "build", "description": "Implement the feature", "role": "implement"},
+    ]
+
+    subagent(
+        agent_id="test-impl-thread",
+        prompt="context",
+        mode="planner",
+        subtasks=subtasks,
+    )
+
+    _wait_for_new_subagent_threads(initial_count, timeout=1.0)
+
+    mock_create_thread.assert_called_once()
+
+    new_agents = _subagents[initial_count:]
+    assert len(new_agents) == 1
+    sa = new_agents[0]
+    assert sa.execution_mode == "thread"
+
+
+@patch("gptme.tools.subagent.execution._monitor_subprocess")
+@patch("gptme.tools.subagent.execution._run_subagent_subprocess")
+@patch("gptme.tools.subagent.execution._create_subagent_thread")
+def test_planner_mixed_roles_use_correct_backends(
+    mock_create_thread: MagicMock,
+    mock_run_subprocess: MagicMock,
+    mock_monitor: MagicMock,
+):
+    """Mixed-role subtasks: impl→thread, verify→subprocess."""
+    mock_run_subprocess.return_value = MagicMock()
+
+    initial_count = len(_subagents)
+    subtasks: list[SubtaskDef] = [
+        {"id": "impl", "description": "Build it", "role": "implement"},
+        {"id": "verify", "description": "Verify it", "role": "verify"},
+    ]
+
+    subagent(
+        agent_id="test-mixed",
+        prompt="context",
+        mode="planner",
+        subtasks=subtasks,
+    )
+
+    _wait_for_new_subagent_threads(initial_count, timeout=1.0)
+
+    # impl → thread; verify → subprocess
+    mock_create_thread.assert_called_once()
+    mock_run_subprocess.assert_called_once()
+    mock_monitor.assert_called_once()
+
+    new_agents = _subagents[initial_count:]
+    assert len(new_agents) == 2
+
+    by_id = {sa.agent_id: sa for sa in new_agents}
+    assert by_id["test-mixed-impl"].execution_mode == "thread"
+    assert by_id["test-mixed-verify"].execution_mode == "subprocess"

--- a/tests/test_tools_subagent.py
+++ b/tests/test_tools_subagent.py
@@ -1910,7 +1910,11 @@ def test_planner_with_role_uses_role_for_self_profile(mock_create_thread: MagicM
 
 @patch("gptme.tools.subagent.execution._monitor_subprocess")
 @patch("gptme.tools.subagent.execution._run_subagent_subprocess")
+@patch("gptme.tools.subagent.execution.tempfile.mkdtemp")
+@patch("gptme.util.git_worktree.get_git_root", return_value=None)
 def test_planner_subtask_role_overrides_planner_profile(
+    _mock_get_git_root: MagicMock,
+    mock_mkdtemp: MagicMock,
     mock_run_subprocess: MagicMock,
     mock_monitor: MagicMock,
 ):
@@ -1927,6 +1931,7 @@ def test_planner_subtask_role_overrides_planner_profile(
     `profile_name is None` meant subtask roles were silently dropped as soon
     as the planner had any profile of its own.
     """
+    mock_mkdtemp.return_value = "/tmp/test-impl-plan-verify"
     mock_run_subprocess.return_value = MagicMock()  # fake Popen
 
     subtasks: list[SubtaskDef] = [
@@ -1965,11 +1970,16 @@ def test_planner_subtask_role_overrides_planner_profile(
 
 @patch("gptme.tools.subagent.execution._monitor_subprocess")
 @patch("gptme.tools.subagent.execution._run_subagent_subprocess")
+@patch("gptme.tools.subagent.execution.tempfile.mkdtemp")
+@patch("gptme.util.git_worktree.get_git_root", return_value=None)
 def test_planner_subtask_role_verify_uses_subprocess(
+    _mock_get_git_root: MagicMock,
+    mock_mkdtemp: MagicMock,
     mock_run_subprocess: MagicMock,
     mock_monitor: MagicMock,
 ):
     """role='verify' on a subtask must launch that executor in subprocess mode."""
+    mock_mkdtemp.return_value = "/tmp/test-verify-sub"
     mock_run_subprocess.return_value = MagicMock()  # fake Popen
 
     initial_count = len(_subagents)
@@ -2002,11 +2012,16 @@ def test_planner_subtask_role_verify_uses_subprocess(
 
 @patch("gptme.tools.subagent.execution._monitor_subprocess")
 @patch("gptme.tools.subagent.execution._run_subagent_subprocess")
+@patch("gptme.tools.subagent.execution.tempfile.mkdtemp")
+@patch("gptme.util.git_worktree.get_git_root", return_value=None)
 def test_planner_subtask_role_verify_sets_isolated(
+    _mock_get_git_root: MagicMock,
+    mock_mkdtemp: MagicMock,
     mock_run_subprocess: MagicMock,
     mock_monitor: MagicMock,
 ):
     """role='verify' on a subtask should request isolated execution."""
+    mock_mkdtemp.return_value = "/tmp/test-verify-isolated"
     mock_run_subprocess.return_value = MagicMock()
 
     initial_count = len(_subagents)
@@ -2155,13 +2170,18 @@ def test_planner_subtask_role_implement_uses_thread_mode(mock_create_thread: Mag
 
 @patch("gptme.tools.subagent.execution._monitor_subprocess")
 @patch("gptme.tools.subagent.execution._run_subagent_subprocess")
+@patch("gptme.tools.subagent.execution.tempfile.mkdtemp")
+@patch("gptme.util.git_worktree.get_git_root", return_value=None)
 @patch("gptme.tools.subagent.execution._create_subagent_thread")
 def test_planner_mixed_roles_use_correct_backends(
+    _mock_get_git_root: MagicMock,
+    mock_mkdtemp: MagicMock,
     mock_create_thread: MagicMock,
     mock_run_subprocess: MagicMock,
     mock_monitor: MagicMock,
 ):
     """Mixed-role subtasks: impl→thread, verify→subprocess."""
+    mock_mkdtemp.return_value = "/tmp/test-mixed-verify"
     mock_run_subprocess.return_value = MagicMock()
 
     initial_count = len(_subagents)


### PR DESCRIPTION
## Summary

Completes the Phase 2 item noted in the code (`NOTE(phase2)` comment in both
`execution.py` and the `SubtaskDef` docstring): when a planner subtask carries
`role="verify"`, the executor now runs in **subprocess + isolated** mode instead
of always defaulting to thread mode.

Previously `role=` on a `SubtaskDef` only affected the executor's profile name.
The subprocess/isolated defaults that `resolve_role_defaults` returns were
silently discarded — so `role="verify"` gave the verifier profile but no
sandboxing, which was the whole point of the verify role.

### What changes

| Subtask role | Before | After |
|---|---|---|
| `"verify"` | thread mode, verifier profile | **subprocess + isolated**, verifier profile |
| `"explore"` | thread mode, explorer profile | thread mode, explorer profile (unchanged) |
| `"implement"` | thread mode, developer profile | thread mode, developer profile (unchanged) |

Mixed-role planners (e.g. `impl` + `verify` subtasks) now get the right backend
per subtask independently.

### Changes

- **`execution.py`**: `_run_planner` now calls `resolve_role_defaults` to get
  `(use_sub, use_iso, profile)` and branches into subprocess or thread mode per
  subtask. Isolated subtasks get a worktree (mirroring the `api.py` path).
- **`types.py`**: Updated `SubtaskDef.role` docstring to document the full
  effect of each role value.
- **`tests/test_tools_subagent.py`**: 5 new tests covering:
  - `role="verify"` → subprocess backend with verifier profile
  - `role="verify"` → `isolated=True` on the registered Subagent
  - `role="explore"` → thread mode (no subprocess)
  - `role="implement"` → thread mode (no subprocess)
  - Mixed `implement`+`verify` subtasks → correct backend per subtask

Updated the existing `test_planner_subtask_role_overrides_planner_profile` to
patch the subprocess path (now the correct backend for `role="verify"`).

## Test plan

- [x] All 107 subagent tests pass (`tests/test_tools_subagent.py`, `tests/test_eval_subagent.py`, `tests/test_subagent_unit.py`)
- [x] Pre-commit hooks pass (ruff, mypy, etc.)

Closes part of #554