### PR TITLE
feat(tools): add view_anchored and patch_anchored tools (Gate G2)

### DIFF
--- a/gptme/tools/patch_anchored.py
+++ b/gptme/tools/patch_anchored.py
@@ -38,6 +38,7 @@ if TYPE_CHECKING:
 # ---------------------------------------------------------------------------
 
 _SEPARATOR = "│"
+_VALID_OPERATIONS = {"replace", "delete", "insert_before", "insert_after"}
 
 
 def _render_anchored(path: Path, text: str) -> str:
@@ -216,6 +217,11 @@ def _parse_ops(ops_json: str) -> list[EditOperation]:
             raise ValueError(f"Operation {i} missing required field 'anchor'")
         if not op:
             raise ValueError(f"Operation {i} missing required field 'op'")
+        if op not in _VALID_OPERATIONS:
+            allowed = ", ".join(sorted(_VALID_OPERATIONS))
+            raise ValueError(
+                f"Operation {i} has invalid field 'op': {op!r}. Expected one of: {allowed}"
+            )
         ops.append(
             EditOperation(
                 anchor=anchor,

--- a/gptme/tools/patch_anchored.py
+++ b/gptme/tools/patch_anchored.py
@@ -1,0 +1,299 @@
+"""
+Hash-anchored file viewing and editing.
+
+Provides ``view_anchored`` and ``patch_anchored`` tools that implement a
+two-call editing cycle resistant to line-number drift:
+
+1. ``view_anchored <path>`` — renders the file with a content-addressed
+   anchor token on every line.
+2. ``patch_anchored <path>`` — accepts a JSON array of edit operations
+   (``{anchor, op, text, expected}``), resolves all anchors against the
+   *current* file, then applies the batch atomically.  Any unresolved
+   anchor or failing ``expected`` guard rejects the whole batch and
+   re-renders the file so the model can retry.
+
+Both tools are disabled by default (enable via allowlist or
+``TOOL_ALLOWLIST`` env var).
+
+Design: ``knowledge/technical-designs/2026-05-31-hash-anchored-editing-gptme-integration.md``
+Engine: :mod:`gptme.tools._anchored`
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from ..message import Message
+from ..util.context import md_codeblock
+from ._anchored import EditOperation, apply_operations, snapshot_text
+from .base import Parameter, ToolSpec, ToolUse
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+_SEPARATOR = "│"
+
+
+def _render_anchored(path: Path, text: str) -> str:
+    """Format file content with one anchor token per line."""
+    anchors = snapshot_text(text)
+    if not anchors:
+        return md_codeblock(str(path), "(empty file)")
+    body = "\n".join(f"{a.anchor}{_SEPARATOR} {a.text}" for a in anchors)
+    return md_codeblock(str(path), body)
+
+
+def _path_from_args(
+    args: list[str] | None,
+    kwargs: dict[str, str] | None,
+) -> Path | None:
+    if args:
+        return Path(" ".join(args)).expanduser()
+    if kwargs and kwargs.get("path"):
+        return Path(kwargs["path"]).expanduser()
+    return None
+
+
+def _read_file(path: Path) -> tuple[str, str | None]:
+    """Read a file; return (content, error_message).  error_message is None on success."""
+    path = path.expanduser().resolve()
+    if not path.exists():
+        return "", f"File not found: {path}"
+    if not path.is_file():
+        return "", f"Not a file: {path}"
+    try:
+        return path.read_text(encoding="utf-8"), None
+    except UnicodeDecodeError:
+        return "", f"Cannot read binary file: {path}"
+    except PermissionError:
+        return "", f"Permission denied: {path}"
+
+
+# ---------------------------------------------------------------------------
+# view_anchored
+# ---------------------------------------------------------------------------
+
+_VIEW_INSTRUCTIONS = """
+Render a file with content-addressed anchor tokens so that specific lines can
+be referenced in a subsequent ``patch_anchored`` call.
+
+Each output line is formatted as::
+
+    <anchor>│ <line content>
+
+where ``<anchor>`` is a stable context-triple hash.  Adjacent-line edits
+invalidate the surrounding anchors by design, so always call ``view_anchored``
+immediately before ``patch_anchored`` — never reuse stale anchors.
+""".strip()
+
+
+def _view_examples(tool_format) -> str:  # type: ignore[no-untyped-def]
+    return f"""
+> User: show me hello.py with anchors so I can edit it
+> Assistant:
+{ToolUse("view_anchored", ["hello.py"], "").to_output(tool_format)}
+> System: ````hello.py
+> a3f1c8d2e9b5a70f:1│ def hello():
+> 9c2eb1d4f7a36e52:1│     print("Hello world")
+> ````
+""".strip()
+
+
+def execute_view_anchored(
+    code: str | None,
+    args: list[str] | None,
+    kwargs: dict[str, str] | None,
+) -> Generator[Message, None, None]:
+    path = _path_from_args(args, kwargs)
+    if path is None:
+        yield Message("system", "Error: no path provided to view_anchored")
+        return
+
+    content, err = _read_file(path)
+    if err:
+        yield Message("system", err)
+        return
+
+    yield Message("system", _render_anchored(path.expanduser().resolve(), content))
+
+
+tool_view_anchored = ToolSpec(
+    name="view_anchored",
+    desc="Render a file with content-addressed anchor tokens for use with patch_anchored",
+    instructions=_VIEW_INSTRUCTIONS,
+    examples=_view_examples,
+    execute=execute_view_anchored,
+    block_types=["view_anchored"],
+    disabled_by_default=True,
+    parameters=[
+        Parameter(
+            name="path",
+            type="string",
+            description="Path to the file to render.",
+            required=True,
+        ),
+    ],
+)
+
+# ---------------------------------------------------------------------------
+# patch_anchored
+# ---------------------------------------------------------------------------
+
+_PATCH_INSTRUCTIONS = """
+Apply anchored edits to a file using anchor tokens produced by ``view_anchored``.
+
+The code block body must be a JSON array of operation objects::
+
+    [
+      {"anchor": "<token>", "op": "replace",       "text": "<new text>"},
+      {"anchor": "<token>", "op": "delete"},
+      {"anchor": "<token>", "op": "insert_before", "text": "<new text>"},
+      {"anchor": "<token>", "op": "insert_after",  "text": "<new text>",
+       "expected": "<guard text>"}
+    ]
+
+Fields:
+
+- ``anchor``   (string, required) — token from ``view_anchored``
+- ``op``       (string, required) — one of ``replace`` / ``delete`` /
+  ``insert_before`` / ``insert_after``
+- ``text``     (string, optional) — new content for replace/insert ops
+- ``expected`` (string, optional) — guard: if the anchored line no longer
+  matches this exact text the whole batch is rejected before any mutation
+
+All anchors are resolved against the *current* file before any write.
+On any failure the batch is rejected atomically and the file is re-rendered
+so the model can retry with fresh anchors.
+
+### Two-call cycle
+
+1. Call ``view_anchored`` to get fresh anchors.
+2. Call ``patch_anchored`` with those anchors.
+
+Never reuse anchors from a previous ``view_anchored`` call.
+""".strip()
+
+
+def _patch_examples(tool_format) -> str:  # type: ignore[no-untyped-def]
+    ops = '[{"anchor": "9c2eb1d4f7a36e52:1", "op": "replace", "text": "    print(\\"Hello, world!\\")", "expected": "    print(\\"Hello world\\")"}]'
+    return f"""
+> User: update the greeting in hello.py
+> Assistant: First, I'll view the file to get anchor tokens:
+{ToolUse("view_anchored", ["hello.py"], "").to_output(tool_format)}
+> System: ````hello.py
+> a3f1c8d2e9b5a70f:1│ def hello():
+> 9c2eb1d4f7a36e52:1│     print("Hello world")
+> ````
+> Assistant: Now I'll apply the anchored patch:
+{ToolUse("patch_anchored", ["hello.py"], ops).to_output(tool_format)}
+> System: Anchored patch applied to `hello.py` (1 operation(s))
+""".strip()
+
+
+def _parse_ops(ops_json: str) -> list[EditOperation]:
+    """Parse a JSON array of operations into :class:`EditOperation` objects."""
+    try:
+        raw = json.loads(ops_json)
+    except json.JSONDecodeError as e:
+        raise ValueError(f"Invalid JSON: {e}") from e
+    if not isinstance(raw, list):
+        raise ValueError("Expected a JSON array of operations")
+    ops: list[EditOperation] = []
+    for i, item in enumerate(raw):
+        if not isinstance(item, dict):
+            raise ValueError(
+                f"Operation {i} must be a JSON object, got {type(item).__name__}"
+            )
+        anchor = item.get("anchor")
+        op = item.get("op")
+        if not anchor:
+            raise ValueError(f"Operation {i} missing required field 'anchor'")
+        if not op:
+            raise ValueError(f"Operation {i} missing required field 'op'")
+        ops.append(
+            EditOperation(
+                anchor=anchor,
+                op=op,
+                text=item.get("text"),
+                expected=item.get("expected"),
+            )
+        )
+    return ops
+
+
+def execute_patch_anchored(
+    code: str | None,
+    args: list[str] | None,
+    kwargs: dict[str, str] | None,
+) -> Generator[Message, None, None]:
+    path = _path_from_args(args, kwargs)
+    if path is None:
+        yield Message("system", "Error: no path provided to patch_anchored")
+        return
+
+    ops_json = code or (kwargs or {}).get("ops") or ""
+    if not ops_json.strip():
+        yield Message("system", "Error: no operations provided to patch_anchored")
+        return
+
+    try:
+        ops = _parse_ops(ops_json.strip())
+    except ValueError as e:
+        yield Message("system", f"patch_anchored: {e}")
+        return
+
+    content, err = _read_file(path)
+    if err:
+        yield Message("system", err)
+        return
+
+    resolved_path = path.expanduser().resolve()
+    try:
+        updated = apply_operations(content, ops)
+    except ValueError as e:
+        rerender = _render_anchored(resolved_path, content)
+        yield Message(
+            "system",
+            f"patch_anchored failed (batch rejected, no changes written): {e}\n\n"
+            f"Re-rendered file with current anchors:\n{rerender}",
+        )
+        return
+
+    resolved_path.write_text(updated, encoding="utf-8")
+    yield Message(
+        "system",
+        f"Anchored patch applied to `{resolved_path}` ({len(ops)} operation(s))",
+    )
+
+
+tool_patch_anchored = ToolSpec(
+    name="patch_anchored",
+    desc="Apply hash-anchored edits to a file using anchor tokens from view_anchored",
+    instructions=_PATCH_INSTRUCTIONS,
+    examples=_patch_examples,
+    execute=execute_patch_anchored,
+    block_types=["patch_anchored"],
+    disabled_by_default=True,
+    parameters=[
+        Parameter(
+            name="path",
+            type="string",
+            description="Path to the file to patch.",
+            required=True,
+        ),
+        Parameter(
+            name="ops",
+            type="string",
+            description='JSON array of edit operations. Each: {"anchor": "...", "op": "replace|delete|insert_before|insert_after", "text": "...", "expected": "..."}',
+            required=True,
+        ),
+    ],
+)
+
+__doc__ = tool_view_anchored.get_doc(__doc__)

--- a/tests/test_tools_patch_anchored.py
+++ b/tests/test_tools_patch_anchored.py
@@ -1,0 +1,357 @@
+"""Tests for the view_anchored and patch_anchored tools."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from gptme.tools._anchored import snapshot_text
+from gptme.tools.patch_anchored import (
+    _parse_ops,
+    _render_anchored,
+    execute_patch_anchored,
+    execute_view_anchored,
+    tool_patch_anchored,
+    tool_view_anchored,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _collect(gen) -> list[str]:
+    """Collect message content strings from a generator."""
+    return [msg.content for msg in gen]
+
+
+# ---------------------------------------------------------------------------
+# _render_anchored
+# ---------------------------------------------------------------------------
+
+
+class TestRenderAnchored:
+    def test_each_line_has_anchor_prefix(self, tmp_path: Path) -> None:
+        f = tmp_path / "hello.py"
+        f.write_text("def hello():\n    pass\n")
+        content = f.read_text()
+        rendered = _render_anchored(f, content)
+        anchors = snapshot_text(content)
+
+        for a in anchors:
+            assert a.anchor in rendered
+            assert a.text in rendered
+
+    def test_separator_present(self, tmp_path: Path) -> None:
+        f = tmp_path / "a.txt"
+        f.write_text("line one\nline two\n")
+        rendered = _render_anchored(f, f.read_text())
+        assert "│" in rendered
+
+    def test_empty_file(self, tmp_path: Path) -> None:
+        f = tmp_path / "empty.txt"
+        f.write_text("")
+        rendered = _render_anchored(f, "")
+        assert "empty file" in rendered
+
+    def test_anchor_format_in_output(self, tmp_path: Path) -> None:
+        f = tmp_path / "a.txt"
+        f.write_text("alpha\nbeta\n")
+        rendered = _render_anchored(f, f.read_text())
+        # Every anchor is <16-hex>:<ordinal> — check colon presence per line
+        body_lines = [ln for ln in rendered.splitlines() if "│" in ln]
+        assert len(body_lines) == 2
+        for line in body_lines:
+            anchor_part = line.split("│")[0].strip()
+            digest, ordinal = anchor_part.split(":")
+            assert len(digest) == 16
+            assert ordinal.isdigit()
+
+
+# ---------------------------------------------------------------------------
+# _parse_ops
+# ---------------------------------------------------------------------------
+
+
+class TestParseOps:
+    def test_valid_replace(self) -> None:
+        ops = _parse_ops('[{"anchor": "abc:1", "op": "replace", "text": "new"}]')
+        assert len(ops) == 1
+        assert ops[0].op == "replace"
+        assert ops[0].text == "new"
+
+    def test_valid_delete(self) -> None:
+        ops = _parse_ops('[{"anchor": "abc:1", "op": "delete"}]')
+        assert ops[0].op == "delete"
+        assert ops[0].text is None
+
+    def test_valid_with_expected(self) -> None:
+        ops = _parse_ops(
+            '[{"anchor": "abc:1", "op": "replace", "text": "X", "expected": "old"}]'
+        )
+        assert ops[0].expected == "old"
+
+    def test_multiple_ops(self) -> None:
+        raw = json.dumps(
+            [
+                {"anchor": "a:1", "op": "replace", "text": "X"},
+                {"anchor": "b:1", "op": "delete"},
+            ]
+        )
+        ops = _parse_ops(raw)
+        assert len(ops) == 2
+
+    def test_invalid_json(self) -> None:
+        with pytest.raises(ValueError, match="Invalid JSON"):
+            _parse_ops("not json")
+
+    def test_not_an_array(self) -> None:
+        with pytest.raises(ValueError, match="JSON array"):
+            _parse_ops('{"anchor": "a:1", "op": "replace"}')
+
+    def test_missing_anchor(self) -> None:
+        with pytest.raises(ValueError, match="anchor"):
+            _parse_ops('[{"op": "replace", "text": "x"}]')
+
+    def test_missing_op(self) -> None:
+        with pytest.raises(ValueError, match="op"):
+            _parse_ops('[{"anchor": "a:1", "text": "x"}]')
+
+
+# ---------------------------------------------------------------------------
+# execute_view_anchored
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteViewAnchored:
+    def test_renders_file_with_anchors(self, tmp_path: Path) -> None:
+        f = tmp_path / "sample.py"
+        f.write_text("alpha\nbeta\ngamma\n")
+        msgs = _collect(execute_view_anchored("", ["str(f)"], None))
+        # Use kwargs interface for reliability
+        msgs = _collect(execute_view_anchored("", None, {"path": str(f)}))
+        assert len(msgs) == 1
+        rendered = msgs[0]
+        assert "alpha" in rendered
+        assert "beta" in rendered
+        assert "│" in rendered
+
+    def test_missing_path(self) -> None:
+        msgs = _collect(execute_view_anchored("", None, None))
+        assert "no path" in msgs[0].lower()
+
+    def test_nonexistent_file(self, tmp_path: Path) -> None:
+        msgs = _collect(
+            execute_view_anchored("", None, {"path": str(tmp_path / "nope.txt")})
+        )
+        assert "not found" in msgs[0].lower()
+
+    def test_directory_rejected(self, tmp_path: Path) -> None:
+        msgs = _collect(execute_view_anchored("", None, {"path": str(tmp_path)}))
+        assert "not a file" in msgs[0].lower()
+
+    def test_anchor_count_matches_line_count(self, tmp_path: Path) -> None:
+        f = tmp_path / "three.txt"
+        f.write_text("one\ntwo\nthree\n")
+        msgs = _collect(execute_view_anchored("", None, {"path": str(f)}))
+        # three lines → three anchor│ lines in the output
+        anchor_lines = [ln for ln in msgs[0].splitlines() if "│" in ln]
+        assert len(anchor_lines) == 3
+
+    def test_args_path(self, tmp_path: Path) -> None:
+        f = tmp_path / "a.txt"
+        f.write_text("hello\n")
+        msgs = _collect(execute_view_anchored("", [str(f)], None))
+        assert "hello" in msgs[0]
+
+
+# ---------------------------------------------------------------------------
+# execute_patch_anchored
+# ---------------------------------------------------------------------------
+
+
+class TestExecutePatchAnchored:
+    def _anchors_for(self, text: str) -> list:
+        return snapshot_text(text)
+
+    def test_replace_operation(self, tmp_path: Path) -> None:
+        f = tmp_path / "file.txt"
+        f.write_text("alpha\nbeta\ngamma\n")
+        anchors = self._anchors_for(f.read_text())
+        ops = json.dumps(
+            [{"anchor": anchors[1].anchor, "op": "replace", "text": "BETA"}]
+        )
+        msgs = _collect(execute_patch_anchored(ops, None, {"path": str(f)}))
+        assert "applied" in msgs[0].lower()
+        assert f.read_text() == "alpha\nBETA\ngamma\n"
+
+    def test_delete_operation(self, tmp_path: Path) -> None:
+        f = tmp_path / "file.txt"
+        f.write_text("alpha\nbeta\ngamma\n")
+        anchors = self._anchors_for(f.read_text())
+        ops = json.dumps([{"anchor": anchors[1].anchor, "op": "delete"}])
+        msgs = _collect(execute_patch_anchored(ops, None, {"path": str(f)}))
+        assert "applied" in msgs[0].lower()
+        assert f.read_text() == "alpha\ngamma\n"
+
+    def test_insert_before(self, tmp_path: Path) -> None:
+        f = tmp_path / "file.txt"
+        f.write_text("alpha\nbeta\n")
+        anchors = self._anchors_for(f.read_text())
+        ops = json.dumps(
+            [{"anchor": anchors[0].anchor, "op": "insert_before", "text": "zero"}]
+        )
+        msgs = _collect(execute_patch_anchored(ops, None, {"path": str(f)}))
+        assert "applied" in msgs[0].lower()
+        assert f.read_text() == "zero\nalpha\nbeta\n"
+
+    def test_insert_after(self, tmp_path: Path) -> None:
+        f = tmp_path / "file.txt"
+        f.write_text("alpha\nbeta\n")
+        anchors = self._anchors_for(f.read_text())
+        ops = json.dumps(
+            [{"anchor": anchors[0].anchor, "op": "insert_after", "text": "one-half"}]
+        )
+        _collect(execute_patch_anchored(ops, None, {"path": str(f)}))
+        assert f.read_text() == "alpha\none-half\nbeta\n"
+
+    def test_atomic_reject_on_unknown_anchor(self, tmp_path: Path) -> None:
+        """Stale anchor rejects the whole batch and leaves the file unchanged."""
+        f = tmp_path / "file.txt"
+        original = "alpha\nbeta\ngamma\n"
+        f.write_text(original)
+        # Use an anchor computed from a different file state
+        other_text = "alpha\ninserted\nbeta\ngamma\n"
+        stale_anchor = snapshot_text(other_text)[2].anchor  # "beta" in modified file
+        ops = json.dumps([{"anchor": stale_anchor, "op": "replace", "text": "X"}])
+        msgs = _collect(execute_patch_anchored(ops, None, {"path": str(f)}))
+        assert "failed" in msgs[0].lower() or "rejected" in msgs[0].lower()
+        assert f.read_text() == original  # unchanged
+
+    def test_failure_message_includes_rerender(self, tmp_path: Path) -> None:
+        """On failure the response includes a re-rendered view for retry."""
+        f = tmp_path / "file.txt"
+        f.write_text("alpha\nbeta\n")
+        ops = json.dumps(
+            [{"anchor": "0000000000000000:1", "op": "replace", "text": "X"}]
+        )
+        msgs = _collect(execute_patch_anchored(ops, None, {"path": str(f)}))
+        assert "│" in msgs[0]  # re-render present
+
+    def test_expected_guard_success(self, tmp_path: Path) -> None:
+        f = tmp_path / "file.txt"
+        f.write_text("alpha\nbeta\n")
+        anchors = self._anchors_for(f.read_text())
+        ops = json.dumps(
+            [
+                {
+                    "anchor": anchors[0].anchor,
+                    "op": "replace",
+                    "text": "ALPHA",
+                    "expected": "alpha",
+                }
+            ]
+        )
+        msgs = _collect(execute_patch_anchored(ops, None, {"path": str(f)}))
+        assert "applied" in msgs[0].lower()
+        assert f.read_text() == "ALPHA\nbeta\n"
+
+    def test_expected_guard_failure_rejects_batch(self, tmp_path: Path) -> None:
+        f = tmp_path / "file.txt"
+        original = "alpha\nbeta\n"
+        f.write_text(original)
+        anchors = self._anchors_for(original)
+        ops = json.dumps(
+            [
+                {
+                    "anchor": anchors[0].anchor,
+                    "op": "replace",
+                    "text": "ALPHA",
+                    "expected": "wrong_text",
+                }
+            ]
+        )
+        msgs = _collect(execute_patch_anchored(ops, None, {"path": str(f)}))
+        assert "failed" in msgs[0].lower() or "rejected" in msgs[0].lower()
+        assert f.read_text() == original
+
+    def test_missing_path(self) -> None:
+        msgs = _collect(
+            execute_patch_anchored('[{"anchor":"a:1","op":"delete"}]', None, None)
+        )
+        assert "no path" in msgs[0].lower()
+
+    def test_missing_ops(self, tmp_path: Path) -> None:
+        f = tmp_path / "file.txt"
+        f.write_text("hello\n")
+        msgs = _collect(execute_patch_anchored("", None, {"path": str(f)}))
+        assert "no operations" in msgs[0].lower()
+
+    def test_invalid_json_ops(self, tmp_path: Path) -> None:
+        f = tmp_path / "file.txt"
+        f.write_text("hello\n")
+        msgs = _collect(execute_patch_anchored("not json!", None, {"path": str(f)}))
+        assert "invalid json" in msgs[0].lower() or "patch_anchored" in msgs[0].lower()
+
+    def test_nonexistent_file(self, tmp_path: Path) -> None:
+        ops = '[{"anchor": "a:1", "op": "delete"}]'
+        msgs = _collect(
+            execute_patch_anchored(ops, None, {"path": str(tmp_path / "nope.txt")})
+        )
+        assert "not found" in msgs[0].lower()
+
+    def test_multi_op_batch(self, tmp_path: Path) -> None:
+        """Multiple operations in one batch are applied atomically."""
+        f = tmp_path / "file.txt"
+        f.write_text("alpha\nbeta\ngamma\ndelta\n")
+        anchors = self._anchors_for(f.read_text())
+        ops = json.dumps(
+            [
+                {"anchor": anchors[0].anchor, "op": "replace", "text": "ALPHA"},
+                {"anchor": anchors[2].anchor, "op": "delete"},
+            ]
+        )
+        _collect(execute_patch_anchored(ops, None, {"path": str(f)}))
+        assert f.read_text() == "ALPHA\nbeta\ndelta\n"
+
+    def test_args_path(self, tmp_path: Path) -> None:
+        f = tmp_path / "file.txt"
+        f.write_text("hello\n")
+        anchors = self._anchors_for(f.read_text())
+        ops = json.dumps(
+            [{"anchor": anchors[0].anchor, "op": "replace", "text": "world"}]
+        )
+        msgs = _collect(execute_patch_anchored(ops, [str(f)], None))
+        assert "applied" in msgs[0].lower()
+
+
+# ---------------------------------------------------------------------------
+# ToolSpec metadata
+# ---------------------------------------------------------------------------
+
+
+class TestToolSpecs:
+    def test_view_anchored_disabled_by_default(self) -> None:
+        assert tool_view_anchored.disabled_by_default is True
+
+    def test_patch_anchored_disabled_by_default(self) -> None:
+        assert tool_patch_anchored.disabled_by_default is True
+
+    def test_view_anchored_block_type(self) -> None:
+        assert "view_anchored" in tool_view_anchored.block_types
+
+    def test_patch_anchored_block_type(self) -> None:
+        assert "patch_anchored" in tool_patch_anchored.block_types
+
+    def test_view_anchored_has_parameters(self) -> None:
+        assert any(p.name == "path" for p in tool_view_anchored.parameters)
+
+    def test_patch_anchored_has_parameters(self) -> None:
+        names = {p.name for p in tool_patch_anchored.parameters}
+        assert "path" in names
+        assert "ops" in names

--- a/tests/test_tools_patch_anchored.py
+++ b/tests/test_tools_patch_anchored.py
@@ -300,6 +300,16 @@ class TestExecutePatchAnchored:
         msgs = _collect(execute_patch_anchored("not json!", None, {"path": str(f)}))
         assert "invalid json" in msgs[0].lower() or "patch_anchored" in msgs[0].lower()
 
+    def test_invalid_op_rejected(self, tmp_path: Path) -> None:
+        f = tmp_path / "file.txt"
+        f.write_text("hello\n")
+        anchors = self._anchors_for(f.read_text())
+        ops = json.dumps([{"anchor": anchors[0].anchor, "op": "append"}])
+        msgs = _collect(execute_patch_anchored(ops, None, {"path": str(f)}))
+        assert "invalid field 'op'" in msgs[0].lower()
+        assert "append" in msgs[0]
+        assert f.read_text() == "hello\n"
+
     def test_nonexistent_file(self, tmp_path: Path) -> None:
         ops = '[{"anchor": "a:1", "op": "delete"}]'
         msgs = _collect(

--- a/tests/test_tools_patch_anchored.py
+++ b/tests/test_tools_patch_anchored.py
@@ -122,6 +122,10 @@ class TestParseOps:
         with pytest.raises(ValueError, match="op"):
             _parse_ops('[{"anchor": "a:1", "text": "x"}]')
 
+    def test_invalid_op(self) -> None:
+        with pytest.raises(ValueError, match="invalid field 'op'"):
+            _parse_ops('[{"anchor": "a:1", "op": "append", "text": "x"}]')
+
 
 # ---------------------------------------------------------------------------
 # execute_view_anchored
@@ -132,8 +136,6 @@ class TestExecuteViewAnchored:
     def test_renders_file_with_anchors(self, tmp_path: Path) -> None:
         f = tmp_path / "sample.py"
         f.write_text("alpha\nbeta\ngamma\n")
-        msgs = _collect(execute_view_anchored("", ["str(f)"], None))
-        # Use kwargs interface for reliability
         msgs = _collect(execute_view_anchored("", None, {"path": str(f)}))
         assert len(msgs) == 1
         rendered = msgs[0]


### PR DESCRIPTION
## Summary

Implements the two-call hash-anchored editing surface on top of the existing `_anchored.py` engine (Gate G1, shipped in v0.31.0).

### Differentiator vs `patch`

The existing `patch` tool re-matches ORIGINAL blocks against an already-mutated buffer: sequential edits in the same file drift silently when adjacent lines change. `patch_anchored` resolves **all** anchors against the pre-mutation snapshot first, then writes all-or-nothing. A stale anchor (from an adjacent-line change) fails the whole batch loudly and re-renders the file for retry, rather than silently resolving to the wrong place.

### Two-call cycle

1. **`view_anchored <path>`** — renders the file with `<digest>:<ordinal>│ <line>` so the model can capture anchor tokens:
   ```
   a3f1c8d2e9b5a70f:1│ def process_request(data):
   9c2eb1d4f7a36e52:1│     return handle(data)
   ```
2. **`patch_anchored <path>`** — accepts a JSON array of `{anchor, op, text, expected}` objects, resolves all anchors against the *current* file, applies bottom-up. Any unknown/mismatched anchor rejects the entire batch atomically and re-renders for retry.

### Design decisions (per issue #2667)

- **D1: new tools, not retrofit of `patch`** — keeps `patch`'s stable contract intact; lets us A/B before deprecating anything
- **D4: `disabled_by_default=True`** — opt-in via allowlist or `TOOL_ALLOWLIST`; zero behaviour change for existing users

### What's included

- `gptme/tools/patch_anchored.py` — `tool_view_anchored` and `tool_patch_anchored` ToolSpec definitions, wired to the `_anchored.py` engine
- `tests/test_tools_patch_anchored.py` — 38 tests covering render format, JSON parsing, all four ops, atomic rejection, expected guards, error paths, and ToolSpec metadata

### Gates

| Gate | Status |
|------|--------|
| G1 — `_anchored.py` engine | ✅ shipped (v0.31.0) |
| G2 — `view_anchored` + `patch_anchored` tools | ✅ this PR |
| G3 — dogfood ≥20 real sessions, measure failure rate | ⏳ open |
| G4 — flip default if G3 shows net improvement | ⏳ open |

Closes #2667