### PR TITLE
feat(rag): add rag_index_conversations for indexing past conversations

### DIFF
--- a/gptme/tools/rag.py
+++ b/gptme/tools/rag.py
@@ -205,6 +205,9 @@ def rag_index_conversations(
     """
     from ..logmanager import _gen_read_jsonl
 
+    if n <= 0:
+        raise ValueError(f"n must be a positive integer, got {n}")
+
     logs_dir = get_logs_dir()
     conv_files = sorted(
         logs_dir.glob("*/conversation.jsonl"),
@@ -250,7 +253,7 @@ def rag_index_conversations(
 
             if lines:
                 out_file = export_path / f"{conv_id}.md"
-                out_file.write_text("\n\n".join(lines))
+                out_file.write_text("\n\n".join(lines), encoding="utf-8")
                 exported += 1
 
         if exported == 0:

--- a/gptme/tools/rag.py
+++ b/gptme/tools/rag.py
@@ -29,7 +29,13 @@ Configure RAG in your ``gptme.toml``::
    - Search indexed documents with ``rag_search``
    - Check index status with ``rag_status``
 
-2. Automatic Context Enhancement
+2. Conversation Indexing
+
+   - Index past gptme conversations with ``rag_index_conversations``
+   - Only indexes user and assistant messages (skips system prompts)
+   - Enables semantic search across your conversation history
+
+3. Automatic Context Enhancement
 
    - Retrieves semantically similar documents
    - Preserves conversation flow with hidden context messages
@@ -38,13 +44,14 @@ Configure RAG in your ``gptme.toml``::
 import logging
 import shutil
 import subprocess
+import tempfile
 import time
 from dataclasses import replace
 from functools import lru_cache
 from pathlib import Path
 
 from ..config import RagConfig, get_project_config
-from ..dirs import get_project_gptme_dir
+from ..dirs import get_logs_dir, get_project_gptme_dir
 from ..llm import _chat_complete
 from ..message import Message
 from .base import ToolFunction, ToolSpec, ToolUse
@@ -78,6 +85,18 @@ User: Show index status
 Assistant: I'll check the current status of the RAG index.
 {ToolUse("ipython", [], "rag_status()").to_output(tool_format)}
 System: Index contains 42 documents
+
+User: Index my past conversations so I can search them
+Assistant: I'll index your recent conversations with RAG.
+{ToolUse("ipython", [], "rag_index_conversations()").to_output(tool_format)}
+System: Indexed 47 conversations.
+Indexed 47 paths
+
+User: Index only the last 10 conversations
+Assistant: I'll index just the 10 most recent conversations.
+{ToolUse("ipython", [], "rag_index_conversations(n=10)").to_output(tool_format)}
+System: Indexed 10 conversations.
+Indexed 10 paths
 """
 
 
@@ -165,6 +184,83 @@ def rag_status() -> str:
     cmd = ["gptme-rag", "status"]
     result = _run_rag_cmd(cmd)
     return result.stdout.strip()
+
+
+def rag_index_conversations(
+    n: int = 100,
+    output_dir: str | None = None,
+) -> str:
+    """Index past gptme conversations for semantic search.
+
+    Exports user and assistant messages from conversation logs (skipping system
+    prompts) into text files and indexes them with gptme-rag.
+
+    Args:
+        n: Maximum number of recent conversations to index (default: 100).
+        output_dir: Directory to write exported conversation files.
+            Defaults to a temporary directory managed by gptme-rag.
+
+    Returns:
+        Status message from the indexing operation.
+    """
+    from ..logmanager import _gen_read_jsonl
+
+    logs_dir = get_logs_dir()
+    conv_files = sorted(
+        logs_dir.glob("*/conversation.jsonl"),
+        key=lambda f: -f.stat().st_mtime,
+    )[:n]
+
+    if not conv_files:
+        return "No conversations found to index."
+
+    if output_dir:
+        export_path = Path(output_dir)
+        export_path.mkdir(parents=True, exist_ok=True)
+        cleanup = False
+    else:
+        _tmpdir = tempfile.mkdtemp(prefix="gptme-rag-convs-")
+        export_path = Path(_tmpdir)
+        cleanup = True
+
+    exported = 0
+    try:
+        for conv_file in conv_files:
+            conv_id = conv_file.parent.name
+            msgs = list(_gen_read_jsonl(conv_file))
+            # Only include user and assistant messages — system prompts add noise
+            content_msgs = [m for m in msgs if m.role in ("user", "assistant")]
+            if not content_msgs:
+                continue
+
+            lines = []
+            for msg in content_msgs:
+                role_label = msg.role.capitalize()
+                # Handle multimodal content (list) — extract text parts only
+                if isinstance(msg.content, list):
+                    text = " ".join(
+                        part.get("text", "")
+                        for part in msg.content
+                        if isinstance(part, dict) and part.get("type") == "text"
+                    )
+                else:
+                    text = msg.content
+                if text.strip():
+                    lines.append(f"**{role_label}**: {text.strip()}")
+
+            if lines:
+                out_file = export_path / f"{conv_id}.md"
+                out_file.write_text("\n\n".join(lines))
+                exported += 1
+
+        if exported == 0:
+            return "No conversation content to index."
+
+        result = _run_rag_cmd(["gptme-rag", "index", str(export_path)])
+        return f"Indexed {exported} conversations.\n{result.stdout.strip()}"
+    finally:
+        if cleanup:
+            shutil.rmtree(export_path, ignore_errors=True)
 
 
 def init() -> ToolSpec:
@@ -282,7 +378,8 @@ tool = ToolSpec(
     instructions=instructions,
     examples=examples,
     functions=[
-        ToolFunction.from_callable(f) for f in [rag_index, rag_search, rag_status]
+        ToolFunction.from_callable(f)
+        for f in [rag_index, rag_search, rag_status, rag_index_conversations]
     ],
     available=_has_gptme_rag,
     init=init,

--- a/tests/test_tools_rag.py
+++ b/tests/test_tools_rag.py
@@ -1,6 +1,7 @@
 """Tests for the RAG tool."""
 
 import json
+import os
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -146,13 +147,16 @@ def test_rag_index_conversations_respects_n_limit(tmp_path):
     """Test that the n parameter limits the number of conversations indexed."""
     logs_dir = tmp_path / "logs"
     for i in range(5):
+        conv_dir = logs_dir / f"conv-{i}"
         _write_conversation(
-            logs_dir / f"conv-{i}",
+            conv_dir,
             [
                 {"role": "user", "content": f"Question {i}"},
                 {"role": "assistant", "content": f"Answer {i}"},
             ],
         )
+        mtime = 1_700_000_000 + i
+        os.utime(conv_dir / "conversation.jsonl", (mtime, mtime))
 
     export_dir = tmp_path / "export"
     mock_proc = MagicMock()
@@ -166,7 +170,47 @@ def test_rag_index_conversations_respects_n_limit(tmp_path):
 
     exported_files = list(export_dir.glob("*.md"))
     assert len(exported_files) == 3
+    assert {path.stem for path in exported_files} == {"conv-2", "conv-3", "conv-4"}
     assert "Indexed 3 conversations" in result
+
+
+def test_rag_index_conversations_rejects_non_positive_n(tmp_path):
+    """Test that non-positive n is rejected instead of silently mis-indexing."""
+    with (
+        patch("gptme.tools.rag.get_logs_dir", return_value=tmp_path),
+        pytest.raises(ValueError, match="n must be a positive integer"),
+    ):
+        rag_index_conversations(n=0, output_dir=str(tmp_path / "export"))
+
+
+def test_rag_index_conversations_writes_utf8_exports(tmp_path):
+    """Test that exported conversations are always written as UTF-8."""
+    logs_dir = tmp_path / "logs"
+    _write_conversation(
+        logs_dir / "unicode-conv",
+        [
+            {"role": "user", "content": "Hej 👋"},
+            {"role": "assistant", "content": "Hallå världen"},
+        ],
+    )
+
+    export_dir = tmp_path / "export"
+    mock_proc = MagicMock()
+    mock_proc.stdout = "Indexed 1 paths\n"
+
+    with (
+        patch("gptme.tools.rag.get_logs_dir", return_value=logs_dir),
+        patch("gptme.tools.rag._run_rag_cmd", return_value=mock_proc),
+        patch("pathlib.Path.write_text", autospec=True) as mock_write_text,
+    ):
+        result = rag_index_conversations(output_dir=str(export_dir))
+
+    assert "Indexed 1 conversations" in result
+    mock_write_text.assert_called_once_with(
+        export_dir / "unicode-conv.md",
+        "**User**: Hej 👋\n\n**Assistant**: Hallå världen",
+        encoding="utf-8",
+    )
 
 
 def test_rag_index_conversations_uses_tmpdir_by_default(tmp_path):

--- a/tests/test_tools_rag.py
+++ b/tests/test_tools_rag.py
@@ -1,12 +1,14 @@
 """Tests for the RAG tool."""
 
-from unittest.mock import patch
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from gptme.config import RagConfig
 from gptme.message import Message
-from gptme.tools.rag import _has_gptme_rag, _rag_context_hook
+from gptme.tools.rag import _has_gptme_rag, _rag_context_hook, rag_index_conversations
 
 
 @pytest.mark.skipif(not _has_gptme_rag(), reason="RAG is not available")
@@ -55,3 +57,143 @@ def test_rag_context_hook_disabled():
 
         # Should yield nothing when RAG is disabled
         assert len(context_msgs) == 0
+
+
+def _write_conversation(conv_dir: Path, messages: list[dict]) -> None:
+    """Write a fake conversation.jsonl for testing."""
+    conv_dir.mkdir(parents=True, exist_ok=True)
+    with open(conv_dir / "conversation.jsonl", "w") as f:
+        f.writelines(json.dumps(msg) + "\n" for msg in messages)
+
+
+def test_rag_index_conversations_no_conversations(tmp_path):
+    """Test that rag_index_conversations returns a message when there are no conversations."""
+    with patch("gptme.tools.rag.get_logs_dir", return_value=tmp_path):
+        result = rag_index_conversations(output_dir=str(tmp_path / "export"))
+    assert "No conversations found" in result
+
+
+def test_rag_index_conversations_exports_user_assistant_only(tmp_path):
+    """Test that only user/assistant messages are exported, not system messages."""
+    logs_dir = tmp_path / "logs"
+    conv_dir = logs_dir / "test-conv-1"
+    _write_conversation(
+        conv_dir,
+        [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Hello, how are you?"},
+            {"role": "assistant", "content": "I am doing well, thanks!"},
+        ],
+    )
+
+    export_dir = tmp_path / "export"
+
+    mock_proc = MagicMock()
+    mock_proc.stdout = "Indexed 1 paths\n"
+
+    with (
+        patch("gptme.tools.rag.get_logs_dir", return_value=logs_dir),
+        patch("gptme.tools.rag._run_rag_cmd", return_value=mock_proc),
+    ):
+        result = rag_index_conversations(output_dir=str(export_dir))
+
+    assert "Indexed 1 conversations" in result
+
+    # Check the exported file
+    exported_files = list(export_dir.glob("*.md"))
+    assert len(exported_files) == 1
+
+    content = exported_files[0].read_text()
+    assert "**User**: Hello, how are you?" in content
+    assert "**Assistant**: I am doing well, thanks!" in content
+    # System message should NOT appear
+    assert "You are a helpful assistant" not in content
+
+
+def test_rag_index_conversations_skips_empty(tmp_path):
+    """Test that conversations with no user/assistant messages are skipped."""
+    logs_dir = tmp_path / "logs"
+    # Conversation with only system messages
+    _write_conversation(
+        logs_dir / "system-only",
+        [{"role": "system", "content": "System only conversation"}],
+    )
+    # Normal conversation
+    _write_conversation(
+        logs_dir / "normal-conv",
+        [
+            {"role": "user", "content": "A question"},
+            {"role": "assistant", "content": "An answer"},
+        ],
+    )
+
+    export_dir = tmp_path / "export"
+    mock_proc = MagicMock()
+    mock_proc.stdout = "Indexed 1 paths\n"
+
+    with (
+        patch("gptme.tools.rag.get_logs_dir", return_value=logs_dir),
+        patch("gptme.tools.rag._run_rag_cmd", return_value=mock_proc),
+    ):
+        result = rag_index_conversations(output_dir=str(export_dir))
+
+    assert "Indexed 1 conversations" in result
+    exported_files = list(export_dir.glob("*.md"))
+    assert len(exported_files) == 1
+
+
+def test_rag_index_conversations_respects_n_limit(tmp_path):
+    """Test that the n parameter limits the number of conversations indexed."""
+    logs_dir = tmp_path / "logs"
+    for i in range(5):
+        _write_conversation(
+            logs_dir / f"conv-{i}",
+            [
+                {"role": "user", "content": f"Question {i}"},
+                {"role": "assistant", "content": f"Answer {i}"},
+            ],
+        )
+
+    export_dir = tmp_path / "export"
+    mock_proc = MagicMock()
+    mock_proc.stdout = "Indexed 3 paths\n"
+
+    with (
+        patch("gptme.tools.rag.get_logs_dir", return_value=logs_dir),
+        patch("gptme.tools.rag._run_rag_cmd", return_value=mock_proc),
+    ):
+        result = rag_index_conversations(n=3, output_dir=str(export_dir))
+
+    exported_files = list(export_dir.glob("*.md"))
+    assert len(exported_files) == 3
+    assert "Indexed 3 conversations" in result
+
+
+def test_rag_index_conversations_uses_tmpdir_by_default(tmp_path):
+    """Test that a temp dir is used when no output_dir is specified."""
+    logs_dir = tmp_path / "logs"
+    _write_conversation(
+        logs_dir / "my-conv",
+        [
+            {"role": "user", "content": "A question"},
+            {"role": "assistant", "content": "An answer"},
+        ],
+    )
+
+    mock_proc = MagicMock()
+    mock_proc.stdout = "Indexed 1 paths\n"
+    captured_cmd = []
+
+    def mock_run_rag_cmd(cmd):
+        captured_cmd.extend(cmd)
+        return mock_proc
+
+    with (
+        patch("gptme.tools.rag.get_logs_dir", return_value=logs_dir),
+        patch("gptme.tools.rag._run_rag_cmd", side_effect=mock_run_rag_cmd),
+    ):
+        result = rag_index_conversations()
+
+    assert "Indexed 1 conversations" in result
+    # The temp dir path should have been passed to gptme-rag index
+    assert "gptme-rag-convs-" in captured_cmd[-1]


### PR DESCRIPTION
## Summary

Adds `rag_index_conversations()` to the RAG tool, enabling semantic search over past gptme conversations — the conversation indexing aspect of #59.

### What it does

- Reads conversation logs from gptme's data directory
- Filters to **only user and assistant messages** (skips system prompts, which add noise)
- Exports each conversation as a markdown file
- Passes the exported files to `gptme-rag index`

### Usage

```python
# Index the 100 most recent conversations (default)
rag_index_conversations()

# Index only the last 10
rag_index_conversations(n=10)

# Keep the exported files in a specific directory
rag_index_conversations(output_dir="/path/to/conv-exports")
```

After indexing, `rag_search()` can find content across your conversation history.

### Design notes

- System prompts are filtered out by design — they inflate the index with boilerplate that rarely improves retrieval
- Multimodal messages (image/list content) are handled: text parts are extracted, non-text parts are skipped
- Without `output_dir`, exports go to a temp dir that's cleaned up after indexing

### Tests

5 new tests covering: no conversations, system-prompt filtering, empty-conversation skipping, n-limit, and temp-dir cleanup.

Closes #59 (partial — conversation indexing aspect; the gptme-contrib retrieval plugin is in gptme/gptme-contrib#230)