### PR TITLE
feat(computer): add scroll action for mouse wheel support

### DIFF
--- a/gptme/tools/computer.py
+++ b/gptme/tools/computer.py
@@ -132,9 +132,12 @@ Action = Literal[
     "right_click",
     "middle_click",
     "double_click",
+    "scroll",
     "screenshot",
     "cursor_position",
 ]
+
+ScrollDirection = Literal["up", "down", "left", "right"]
 
 
 class _Resolution(TypedDict):
@@ -466,6 +469,61 @@ def _linux_type(text: str, display: str) -> None:
         )
 
 
+def _linux_scroll(
+    x: int, y: int, direction: str, display: str, amount: int = 3
+) -> None:
+    """Scroll in a direction at (x, y) using xdotool on Linux/X11.
+
+    Button mapping: 4=up, 5=down, 6=left, 7=right.
+    """
+    button_map = {"up": "4", "down": "5", "left": "6", "right": "7"}
+    button = button_map.get(direction)
+    if button is None:
+        raise ValueError(f"Invalid scroll direction: {direction!r}")
+    _run_xdotool(f"mousemove --sync {x} {y}", display)
+    for _ in range(amount):
+        _run_xdotool(f"click {button}", display)
+
+
+def _macos_scroll(x: int, y: int, direction: str, amount: int = 3) -> None:
+    """Scroll in a direction at (x, y) on macOS using Quartz scroll wheel events."""
+    try:
+        from Quartz import (  # type: ignore[import-not-found]
+            CGEventCreateScrollWheelEvent,
+            CGEventPost,
+            CGEventSetLocation,
+            kCGHIDEventTap,
+            kCGScrollEventUnitLine,
+        )
+        from Quartz.CoreGraphics import CGPoint  # type: ignore[import-not-found]
+    except ImportError:
+        raise RuntimeError(
+            "pyobjc-framework-Quartz is required for scroll on macOS. "
+            "Install with: pip install pyobjc-framework-Quartz"
+        ) from None
+
+    _macos_mouse_move(x, y)
+
+    delta_y = 0
+    delta_x = 0
+    if direction == "up":
+        delta_y = amount
+    elif direction == "down":
+        delta_y = -amount
+    elif direction == "left":
+        delta_x = amount
+    elif direction == "right":
+        delta_x = -amount
+    else:
+        raise ValueError(f"Invalid scroll direction: {direction!r}")
+
+    event = CGEventCreateScrollWheelEvent(
+        None, kCGScrollEventUnitLine, 2, delta_y, delta_x
+    )
+    CGEventSetLocation(event, CGPoint(x, y))
+    CGEventPost(kCGHIDEventTap, event)
+
+
 def _macos_click(button: int) -> None:
     """
     Click mouse button using cliclick on macOS.
@@ -581,6 +639,18 @@ def _dispatch_transport(
         }[action]
         click_fn()
         print(f"Performed {action}")
+        return None
+
+    if action == "scroll":
+        if not coordinate:
+            raise ValueError("coordinate is required for scroll")
+        if not text:
+            raise ValueError(
+                "text (direction: up/down/left/right) is required for scroll"
+            )
+        x, y = coordinate
+        transport.scroll(x, y, text)
+        print(f"Scrolled {text} at {x},{y}")
         return None
 
     if action == "screenshot":
@@ -743,6 +813,27 @@ def computer(
             _run_xdotool(f"click {click_arg}", display)
 
         print(f"Performed {action}")
+        return None
+    if action == "scroll":
+        if not coordinate:
+            raise ValueError("coordinate is required for scroll")
+        if not text:
+            raise ValueError(
+                "text (direction: up/down/left/right) is required for scroll"
+            )
+        direction = text.lower()
+        if direction not in ("up", "down", "left", "right"):
+            raise ValueError(
+                f"Invalid scroll direction: {direction!r}. Must be up/down/left/right"
+            )
+        sx, sy = _scale_coordinates(
+            _ScalingSource.API, coordinate[0], coordinate[1], width, height
+        )
+        if IS_MACOS:
+            _macos_scroll(sx, sy, direction)
+        else:
+            _linux_scroll(sx, sy, direction, display)
+        print(f"Scrolled {direction} at {coordinate[0]},{coordinate[1]}")
         return None
     if action == "screenshot":
         path = screenshot()  # Use existing screenshot function
@@ -929,6 +1020,7 @@ Available actions:
 - mouse_move: Move mouse to coordinates
 - left_click, right_click, middle_click, double_click: Mouse clicks
 - left_click_drag: Click and drag to coordinates
+- scroll: Scroll the mouse wheel at coordinates (text="up"/"down"/"left"/"right")
 - screenshot: Take and view a screenshot
 - cursor_position: Get current mouse position
 
@@ -969,6 +1061,11 @@ User: Double-click at current position
 Assistant: I'll perform a double-click.
 {ToolUse("ipython", [], 'computer("double_click")').to_output(tool_format)}
 System: Performed double_click
+
+User: Scroll down in the page at (512, 400)
+Assistant: I'll scroll down at those coordinates.
+{ToolUse("ipython", [], 'computer("scroll", coordinate=(512, 400), text="down")').to_output(tool_format)}
+System: Scrolled down at 512,400
 """
 
     # Platform-specific keyboard shortcut examples

--- a/gptme/tools/computer.py
+++ b/gptme/tools/computer.py
@@ -481,8 +481,7 @@ def _linux_scroll(
     if button is None:
         raise ValueError(f"Invalid scroll direction: {direction!r}")
     _run_xdotool(f"mousemove --sync {x} {y}", display)
-    for _ in range(amount):
-        _run_xdotool(f"click {button}", display)
+    _run_xdotool(f"click --repeat {amount} {button}", display)
 
 
 def _macos_scroll(x: int, y: int, direction: str, amount: int = 3) -> None:
@@ -649,8 +648,9 @@ def _dispatch_transport(
                 "text (direction: up/down/left/right) is required for scroll"
             )
         x, y = coordinate
-        transport.scroll(x, y, text)
-        print(f"Scrolled {text} at {x},{y}")
+        direction = text.lower()
+        transport.scroll(x, y, direction)
+        print(f"Scrolled {direction} at {x},{y}")
         return None
 
     if action == "screenshot":

--- a/gptme/tools/computer.py
+++ b/gptme/tools/computer.py
@@ -649,6 +649,10 @@ def _dispatch_transport(
             )
         x, y = coordinate
         direction = text.lower()
+        if direction not in ("up", "down", "left", "right"):
+            raise ValueError(
+                f"Invalid scroll direction: {direction!r}. Must be up/down/left/right"
+            )
         transport.scroll(x, y, direction)
         print(f"Scrolled {direction} at {x},{y}")
         return None

--- a/gptme/tools/computer_transport.py
+++ b/gptme/tools/computer_transport.py
@@ -82,6 +82,11 @@ class ComputerTransport(abc.ABC):
         ...
 
     @abc.abstractmethod
+    def scroll(self, x: int, y: int, direction: str, amount: int = 3) -> None:
+        """Scroll at (x, y) in the given direction ('up'/'down'/'left'/'right')."""
+        ...
+
+    @abc.abstractmethod
     def screenshot(self, width: int = 0, height: int = 0) -> Path:
         """Capture and save a screenshot. Returns path to the image file."""
         ...
@@ -258,6 +263,26 @@ class NativeComputerTransport(ComputerTransport):
 
             display = os.getenv("DISPLAY", ":1")
             _run_xdotool(f"mousedown 1 mousemove --sync {x} {y} mouseup 1", display)
+
+    def scroll(self, x: int, y: int, direction: str, amount: int = 3) -> None:
+        from .computer import (
+            IS_MACOS,
+            _get_api_resolution,
+            _linux_scroll,
+            _macos_scroll,
+            _scale_coordinates,
+            _ScalingSource,
+        )
+
+        api_w, api_h = _get_api_resolution()
+        sx, sy = _scale_coordinates(_ScalingSource.API, x, y, api_w, api_h)
+        if IS_MACOS:
+            _macos_scroll(sx, sy, direction, amount)
+        else:
+            import os
+
+            display = os.getenv("DISPLAY", ":1")
+            _linux_scroll(sx, sy, direction, display, amount)
 
     def screenshot(self, width: int = 0, height: int = 0) -> Path:
         from .screenshot import screenshot as take_screenshot
@@ -545,6 +570,11 @@ class CuaComputerTransport(ComputerTransport):
         start_x, start_y = self._require_cursor_position()
         self._run_async(self._sandbox.mouse.drag(start_x, start_y, x, y))  # type: ignore[attr-defined, union-attr]
         self._cursor_position = (x, y)
+
+    def scroll(self, x: int, y: int, direction: str, amount: int = 3) -> None:
+        self._ensure_sandbox()
+        assert self._sandbox is not None
+        self._run_async(self._sandbox.mouse.scroll(x, y, direction, amount))  # type: ignore[attr-defined, union-attr]
 
     def screenshot(self, width: int = 0, height: int = 0) -> Path:
         self._ensure_sandbox()

--- a/tests/test_computer_transport.py
+++ b/tests/test_computer_transport.py
@@ -54,6 +54,9 @@ class StubTransport(ComputerTransport):
     def left_click_drag(self, x: int, y: int) -> None:
         pass
 
+    def scroll(self, x: int, y: int, direction: str, amount: int = 3) -> None:
+        pass
+
     def screenshot(self, width: int = 0, height: int = 0) -> Path:
         return Path("/tmp/stub.png")
 
@@ -81,7 +84,7 @@ class TestComputerTransportABC(unittest.TestCase):
             IncompleteTransport()  # type: ignore[abstract]
 
     def test_abstract_method_surface_matches_expected(self):
-        """The 11 abstract methods match gptme's computer() action set."""
+        """The 12 abstract methods match gptme's computer() action set."""
         abstract = {
             name
             for name in dir(ComputerTransport)
@@ -101,6 +104,7 @@ class TestComputerTransportABC(unittest.TestCase):
             "middle_click",
             "double_click",
             "left_click_drag",
+            "scroll",
             "screenshot",
             "cursor_position",
         }
@@ -723,6 +727,91 @@ class TestResizeImage(unittest.TestCase):
         ):
             _resize_image(Path("/tmp/shot.png"), 100, 100)
         self.assertIn("bad image", str(ctx.exception))
+
+
+class TestNativeTransportScroll(unittest.TestCase):
+    """Scroll dispatches to the correct platform helper."""
+
+    def test_linux_scroll_down_calls_xdotool(self):
+        """scroll() on Linux must call _linux_scroll with the right args."""
+        transport = NativeComputerTransport()
+        calls: list[tuple] = []
+
+        def fake_scroll(x, y, direction, display, amount=3):
+            calls.append((x, y, direction, display, amount))
+
+        with (
+            patch("gptme.tools.computer.IS_MACOS", False),
+            patch("gptme.tools.computer._linux_scroll", side_effect=fake_scroll),
+            patch("gptme.tools.computer._get_api_resolution", return_value=(1366, 768)),
+            patch(
+                "gptme.tools.computer._get_display_resolution",
+                return_value=(1366, 768),
+            ),
+            patch.dict(os.environ, {"DISPLAY": ":1"}),
+        ):
+            transport.scroll(100, 200, "down")
+
+        self.assertEqual(len(calls), 1)
+        _, _, direction, _, amount = calls[0]
+        self.assertEqual(direction, "down")
+        self.assertEqual(amount, 3)
+
+    def test_linux_scroll_up_custom_amount(self):
+        """scroll() passes the amount parameter through to _linux_scroll."""
+        transport = NativeComputerTransport()
+        calls: list[tuple] = []
+
+        def fake_scroll(x, y, direction, display, amount=3):
+            calls.append((x, y, direction, display, amount))
+
+        with (
+            patch("gptme.tools.computer.IS_MACOS", False),
+            patch("gptme.tools.computer._linux_scroll", side_effect=fake_scroll),
+            patch("gptme.tools.computer._get_api_resolution", return_value=(1366, 768)),
+            patch(
+                "gptme.tools.computer._get_display_resolution",
+                return_value=(1366, 768),
+            ),
+            patch.dict(os.environ, {"DISPLAY": ":1"}),
+        ):
+            transport.scroll(512, 400, "up", amount=5)
+
+        self.assertEqual(calls[0][2], "up")
+        self.assertEqual(calls[0][4], 5)
+
+
+class TestDispatchTransportScroll(unittest.TestCase):
+    """_dispatch_transport routes scroll actions correctly."""
+
+    def test_scroll_dispatched_with_coordinate_and_direction(self):
+        """scroll with coordinate and text=direction must call transport.scroll()."""
+        stub = StubTransport()
+        stub.scroll = MagicMock()  # type: ignore[method-assign]
+
+        from gptme.tools.computer import _dispatch_transport
+
+        _dispatch_transport(stub, "scroll", text="down", coordinate=(100, 200))
+
+        stub.scroll.assert_called_once_with(100, 200, "down")
+
+    def test_scroll_missing_coordinate_raises(self):
+        """scroll without coordinate must raise ValueError."""
+        stub = StubTransport()
+
+        from gptme.tools.computer import _dispatch_transport
+
+        with self.assertRaises(ValueError, msg="coordinate is required for scroll"):
+            _dispatch_transport(stub, "scroll", text="up")
+
+    def test_scroll_missing_direction_raises(self):
+        """scroll without text (direction) must raise ValueError."""
+        stub = StubTransport()
+
+        from gptme.tools.computer import _dispatch_transport
+
+        with self.assertRaises(ValueError, msg="text.*direction.*required"):
+            _dispatch_transport(stub, "scroll", coordinate=(100, 200))
 
 
 if __name__ == "__main__":

--- a/tests/test_computer_transport.py
+++ b/tests/test_computer_transport.py
@@ -813,6 +813,29 @@ class TestDispatchTransportScroll(unittest.TestCase):
         with self.assertRaises(ValueError, msg="text.*direction.*required"):
             _dispatch_transport(stub, "scroll", coordinate=(100, 200))
 
+    def test_scroll_invalid_direction_raises(self):
+        """scroll with an invalid direction must raise ValueError, not silently forward."""
+        stub = StubTransport()
+        stub.scroll = MagicMock()  # type: ignore[method-assign]
+
+        from gptme.tools.computer import _dispatch_transport
+
+        with self.assertRaisesRegex(ValueError, "Invalid scroll direction"):
+            _dispatch_transport(stub, "scroll", text="diagonal", coordinate=(100, 200))
+
+        stub.scroll.assert_not_called()
+
+    def test_scroll_direction_case_insensitive(self):
+        """scroll direction must be normalised to lowercase before reaching transport."""
+        stub = StubTransport()
+        stub.scroll = MagicMock()  # type: ignore[method-assign]
+
+        from gptme.tools.computer import _dispatch_transport
+
+        _dispatch_transport(stub, "scroll", text="Down", coordinate=(100, 200))
+
+        stub.scroll.assert_called_once_with(100, 200, "down")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_tools_computer.py
+++ b/tests/test_tools_computer.py
@@ -13,6 +13,7 @@ from gptme.tools.computer import (
     MODIFIER_KEYS,
     _chunks,
     _get_display_resolution,
+    _linux_scroll,
     _parse_key_sequence,
     _run_xdotool,
     _scale_coordinates,
@@ -900,3 +901,102 @@ def test_computer_cursor_position_macos_bad_output(mock_run, mock_res):
     mock_run.return_value = mock.MagicMock(stdout="not,valid,output\n")
     with pytest.raises(RuntimeError, match="Failed to get cursor position"):
         computer("cursor_position")
+
+
+# === scroll action tests ===
+
+_MOCK_LINUX_RES = (1366, 768)
+
+
+def test_linux_scroll_down_calls_xdotool():
+    """_linux_scroll down issues xdotool click 5 (scroll-down button)."""
+    calls = []
+
+    def fake_xdotool(cmd: str, display: str) -> str:
+        calls.append(cmd)
+        return ""
+
+    with mock.patch("gptme.tools.computer._run_xdotool", side_effect=fake_xdotool):
+        _linux_scroll(100, 200, "down", ":1", amount=3)
+
+    # First call should be mousemove, then 3 click 5 calls
+    assert calls[0].startswith("mousemove")
+    click_calls = [c for c in calls if c.startswith("click")]
+    assert all("5" in c for c in click_calls), (
+        f"Expected button 5 (scroll down), got: {click_calls}"
+    )
+    assert len(click_calls) == 3
+
+
+def test_linux_scroll_up_calls_xdotool():
+    """_linux_scroll up issues xdotool click 4 (scroll-up button)."""
+    calls = []
+
+    def fake_xdotool(cmd: str, display: str) -> str:
+        calls.append(cmd)
+        return ""
+
+    with mock.patch("gptme.tools.computer._run_xdotool", side_effect=fake_xdotool):
+        _linux_scroll(100, 200, "up", ":1", amount=2)
+
+    click_calls = [c for c in calls if c.startswith("click")]
+    assert all("4" in c for c in click_calls), (
+        f"Expected button 4 (scroll up), got: {click_calls}"
+    )
+    assert len(click_calls) == 2
+
+
+def test_linux_scroll_invalid_direction():
+    """_linux_scroll raises ValueError for unknown direction."""
+    with pytest.raises(ValueError, match="Invalid scroll direction"):
+        _linux_scroll(100, 200, "diagonal", ":1")
+
+
+@mock.patch("gptme.tools.computer.IS_MACOS", False)
+@mock.patch(
+    "gptme.tools.computer._get_display_resolution", return_value=_MOCK_LINUX_RES
+)
+def test_computer_scroll_linux(mock_res):
+    """computer('scroll') on Linux calls _linux_scroll with correct args."""
+    scroll_calls = []
+
+    def fake_scroll(x, y, direction, display, amount=3):
+        scroll_calls.append((x, y, direction, display, amount))
+
+    with mock.patch("gptme.tools.computer._linux_scroll", side_effect=fake_scroll):
+        result = computer("scroll", text="down", coordinate=(512, 400))
+
+    assert result is None
+    assert len(scroll_calls) == 1
+    _, _, direction, _, _ = scroll_calls[0]
+    assert direction == "down"
+
+
+@mock.patch("gptme.tools.computer.IS_MACOS", False)
+@mock.patch(
+    "gptme.tools.computer._get_display_resolution", return_value=_MOCK_LINUX_RES
+)
+def test_computer_scroll_missing_coordinate(mock_res):
+    """computer('scroll') raises ValueError when coordinate is missing."""
+    with pytest.raises(ValueError, match="coordinate is required"):
+        computer("scroll", text="down")
+
+
+@mock.patch("gptme.tools.computer.IS_MACOS", False)
+@mock.patch(
+    "gptme.tools.computer._get_display_resolution", return_value=_MOCK_LINUX_RES
+)
+def test_computer_scroll_missing_direction(mock_res):
+    """computer('scroll') raises ValueError when direction text is missing."""
+    with pytest.raises(ValueError, match="text.*direction.*required"):
+        computer("scroll", coordinate=(512, 400))
+
+
+@mock.patch("gptme.tools.computer.IS_MACOS", False)
+@mock.patch(
+    "gptme.tools.computer._get_display_resolution", return_value=_MOCK_LINUX_RES
+)
+def test_computer_scroll_invalid_direction(mock_res):
+    """computer('scroll') raises ValueError for an invalid direction string."""
+    with pytest.raises(ValueError, match="Invalid scroll direction"):
+        computer("scroll", text="sideways", coordinate=(512, 400))

--- a/tests/test_tools_computer.py
+++ b/tests/test_tools_computer.py
@@ -919,13 +919,12 @@ def test_linux_scroll_down_calls_xdotool():
     with mock.patch("gptme.tools.computer._run_xdotool", side_effect=fake_xdotool):
         _linux_scroll(100, 200, "down", ":1", amount=3)
 
-    # First call should be mousemove, then 3 click 5 calls
+    # First call should be mousemove, then a single click --repeat 3 5
     assert calls[0].startswith("mousemove")
     click_calls = [c for c in calls if c.startswith("click")]
-    assert all("5" in c for c in click_calls), (
-        f"Expected button 5 (scroll down), got: {click_calls}"
-    )
-    assert len(click_calls) == 3
+    assert len(click_calls) == 1
+    assert "--repeat 3" in click_calls[0], f"Expected --repeat 3, got: {click_calls}"
+    assert "5" in click_calls[0], f"Expected button 5 (scroll down), got: {click_calls}"
 
 
 def test_linux_scroll_up_calls_xdotool():
@@ -940,10 +939,9 @@ def test_linux_scroll_up_calls_xdotool():
         _linux_scroll(100, 200, "up", ":1", amount=2)
 
     click_calls = [c for c in calls if c.startswith("click")]
-    assert all("4" in c for c in click_calls), (
-        f"Expected button 4 (scroll up), got: {click_calls}"
-    )
-    assert len(click_calls) == 2
+    assert len(click_calls) == 1
+    assert "--repeat 2" in click_calls[0], f"Expected --repeat 2, got: {click_calls}"
+    assert "4" in click_calls[0], f"Expected button 4 (scroll up), got: {click_calls}"
 
 
 def test_linux_scroll_invalid_direction():


### PR DESCRIPTION
## Summary

Adds a `scroll` action to the computer tool, bringing it closer to feature parity with Anthropic's computer use API. Scrolling is a fundamental interaction needed for realistic computer use sessions (web browsing, document navigation, list-heavy UIs).

- **Linux (X11)**: uses `xdotool click 4/5/6/7` (up/down/left/right mouse wheel buttons)
- **macOS**: uses `Quartz.CGEventCreateScrollWheelEvent` scroll wheel events (requires `pyobjc-framework-Quartz`)
- **CUA sandbox transport**: delegates to `sandbox.mouse.scroll()`

### Changes

- `gptme/tools/computer.py` — add `scroll` to `Action` type, `ScrollDirection` alias, `_linux_scroll()`, `_macos_scroll()`, scroll handling in `computer()` and `_dispatch_transport()`, updated instructions + example
- `gptme/tools/computer_transport.py` — add `scroll()` to `ComputerTransport` ABC and implement in `NativeComputerTransport` and `CuaComputerTransport`
- Tests covering Linux dispatch, direction/amount params, invalid-input errors, and transport-layer routing

### Usage

```python
computer("scroll", coordinate=(512, 400), text="down")   # scroll down 3 clicks
computer("scroll", coordinate=(512, 400), text="up")     # scroll up
```

Closes #216 (partial — this is the most actionable missing primitive; the higher-level "look→act→look" orchestration loop remains as future work)

## Test plan

- [x] `pytest tests/test_tools_computer.py tests/test_computer_transport.py` — all 112 tests pass
- [x] `ruff`/`mypy` clean (verified by pre-commit)
- [ ] Manual scroll test in a running X11/Xvfb environment (requires display)