### PR TITLE
feat(commands): add /snapshot command for agent tree search (#495)

### DIFF
--- a/gptme/commands/__init__.py
+++ b/gptme/commands/__init__.py
@@ -25,6 +25,7 @@ from . import (  # noqa: F401
     llm,
     meta,
     session,
+    snapshot,
 )
 
 # Re-export core types and functions from base

--- a/gptme/commands/snapshot.py
+++ b/gptme/commands/snapshot.py
@@ -1,0 +1,171 @@
+"""
+Workspace snapshot commands for fine-grained rollback.
+
+``/snapshot`` exposes the side-git auto-snapshot backend
+(:mod:`gptme.workspace_snapshot`) as interactive slash commands.
+Agents can list available snapshots and restore the workspace to any prior
+state — no clean-git requirement, and uncommitted changes are preserved in the
+snapshot ledger.
+
+This is **different** from ``/checkpoint``:
+
+- ``/checkpoint`` records a git-committed HEAD so you can ``git reset --hard``
+  back to it.  Requires a clean working tree by default.
+- ``/snapshot`` records *any* workspace state (committed or dirty) into a
+  side-git shadow repo.  Auto-populated by the ``auto_snapshots`` hook.
+
+For agents that tree-search (#495): take an auto-snapshot before each attempt,
+then ``/snapshot restore <sha>`` to roll back a failed branch.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ..workspace_snapshot import Shadow, init_shadow, list_snapshots, restore, snapshot
+from .base import CommandContext, command
+
+
+def _print_usage() -> None:
+    print("Usage: /snapshot <create|list|restore|diff> ...")
+    print()
+    print("Subcommands:")
+    print("  create [label]       Record the current workspace state as a snapshot.")
+    print("  list [--limit N]     List recent snapshots (newest first).")
+    print("  restore <sha>        Restore workspace to a snapshot.")
+    print("  diff <sha>           Show diff between current workspace and a snapshot.")
+
+
+def _workspace_shadow(ctx: CommandContext) -> Shadow | None:
+    workspace = getattr(ctx.manager, "workspace", None)
+    if workspace is None:
+        print("snapshot: no workspace configured for this session")
+        return None
+    shadow = Shadow.for_workspace(Path(workspace))
+    if not shadow.initialized():
+        print(
+            "snapshot: no snapshot history for this workspace "
+            "(enable auto-snapshots via GPTME_AUTO_SNAPSHOTS=1 or the auto_snapshots plugin)"
+        )
+        return None
+    return shadow
+
+
+@command("snapshot")
+def cmd_snapshot(ctx: CommandContext) -> None:
+    """List, diff, or restore workspace auto-snapshots.
+
+    Snapshots are created automatically by the auto_snapshots hook before and
+    after each mutating tool call.  Use this command to inspect the history,
+    restore a prior state, or explicitly record a named snapshot.
+
+    Usage:
+      /snapshot create [label]     Record current workspace state
+      /snapshot list [--limit N]   Show recent snapshots
+      /snapshot restore <sha>      Roll back to a snapshot
+      /snapshot diff <sha>         Show diff from current to snapshot
+    """
+    if not ctx.args or ctx.args[0] in {"help", "-h", "--help"}:
+        _print_usage()
+        return
+
+    subcommand = ctx.args[0]
+    args = ctx.args[1:]
+
+    if subcommand == "create":
+        label = args[0] if args else "manual"
+        shadow = _workspace_shadow(ctx)
+        if shadow is None:
+            # Workspace has no shadow yet — initialize it on first explicit create.
+            workspace = getattr(ctx.manager, "workspace", None)
+            if workspace is None:
+                print("snapshot: no workspace configured for this session")
+                return
+            shadow = init_shadow(Path(workspace))
+        sha = snapshot(shadow, label=label)
+        if sha is not None:
+            print(f"Snapshot recorded: {sha}  ({label})")
+        else:
+            print("snapshot: failed to record snapshot")
+        return
+
+    if subcommand == "list":
+        limit = 20
+        idx = 0
+        while idx < len(args):
+            arg = args[idx]
+            if arg in ("--limit", "-n"):
+                idx += 1
+                if idx >= len(args):
+                    print("snapshot: --limit requires a value")
+                    return
+                try:
+                    limit = int(args[idx])
+                except ValueError:
+                    print(f"snapshot: --limit must be an integer, got {args[idx]!r}")
+                    return
+            else:
+                print(f"snapshot: unknown argument {arg!r}")
+                _print_usage()
+                return
+            idx += 1
+
+        shadow = _workspace_shadow(ctx)
+        if shadow is None:
+            return
+
+        entries = list_snapshots(shadow, limit=limit)
+        if not entries:
+            print("No snapshots yet.")
+            return
+        print(f"{'SHA':<9}  Label")
+        print("-" * 40)
+        for sha, label in entries:
+            print(f"{sha:<9}  {label}")
+        return
+
+    if subcommand == "restore":
+        if len(args) != 1:
+            print("snapshot: restore requires exactly one SHA argument")
+            _print_usage()
+            return
+
+        shadow = _workspace_shadow(ctx)
+        if shadow is None:
+            return
+
+        sha = args[0]
+        ok = restore(shadow, sha)
+        if ok:
+            print(f"Restored workspace to snapshot {sha}.")
+        else:
+            print(
+                f"snapshot: restore failed for {sha!r} "
+                "(check that the SHA is from /snapshot list)"
+            )
+        return
+
+    if subcommand == "diff":
+        if len(args) != 1:
+            print("snapshot: diff requires exactly one SHA argument")
+            _print_usage()
+            return
+
+        shadow = _workspace_shadow(ctx)
+        if shadow is None:
+            return
+
+        sha = args[0]
+        result = shadow.run("diff", sha, check=False)
+        if result.returncode != 0:
+            print(f"snapshot: diff failed: {result.stderr.strip() or 'unknown error'}")
+            return
+        output = result.stdout
+        if output:
+            print(output, end="")
+        else:
+            print(f"No changes between current workspace and snapshot {sha}.")
+        return
+
+    print(f"snapshot: unknown subcommand {subcommand!r}")
+    _print_usage()

--- a/gptme/commands/snapshot.py
+++ b/gptme/commands/snapshot.py
@@ -36,12 +36,19 @@ def _print_usage() -> None:
     print("  diff <sha>           Show diff between current workspace and a snapshot.")
 
 
-def _workspace_shadow(ctx: CommandContext) -> Shadow | None:
+def _workspace_path(ctx: CommandContext) -> Path | None:
     workspace = getattr(ctx.manager, "workspace", None)
     if workspace is None:
         print("snapshot: no workspace configured for this session")
         return None
-    shadow = Shadow.for_workspace(Path(workspace))
+    return Path(workspace)
+
+
+def _workspace_shadow(ctx: CommandContext) -> Shadow | None:
+    workspace = _workspace_path(ctx)
+    if workspace is None:
+        return None
+    shadow = Shadow.for_workspace(workspace)
     if not shadow.initialized():
         print(
             "snapshot: no snapshot history for this workspace "
@@ -74,14 +81,12 @@ def cmd_snapshot(ctx: CommandContext) -> None:
 
     if subcommand == "create":
         label = args[0] if args else "manual"
-        shadow = _workspace_shadow(ctx)
-        if shadow is None:
-            # Workspace has no shadow yet — initialize it on first explicit create.
-            workspace = getattr(ctx.manager, "workspace", None)
-            if workspace is None:
-                print("snapshot: no workspace configured for this session")
-                return
-            shadow = init_shadow(Path(workspace))
+        workspace = _workspace_path(ctx)
+        if workspace is None:
+            return
+        shadow = Shadow.for_workspace(workspace)
+        if not shadow.initialized():
+            shadow = init_shadow(workspace)
         sha = snapshot(shadow, label=label)
         if sha is not None:
             print(f"Snapshot recorded: {sha}  ({label})")
@@ -110,11 +115,11 @@ def cmd_snapshot(ctx: CommandContext) -> None:
                 return
             idx += 1
 
-        shadow = _workspace_shadow(ctx)
-        if shadow is None:
+        workspace_shadow = _workspace_shadow(ctx)
+        if workspace_shadow is None:
             return
 
-        entries = list_snapshots(shadow, limit=limit)
+        entries = list_snapshots(workspace_shadow, limit=limit)
         if not entries:
             print("No snapshots yet.")
             return
@@ -130,12 +135,12 @@ def cmd_snapshot(ctx: CommandContext) -> None:
             _print_usage()
             return
 
-        shadow = _workspace_shadow(ctx)
-        if shadow is None:
+        workspace_shadow = _workspace_shadow(ctx)
+        if workspace_shadow is None:
             return
 
         sha = args[0]
-        ok = restore(shadow, sha)
+        ok = restore(workspace_shadow, sha)
         if ok:
             print(f"Restored workspace to snapshot {sha}.")
         else:
@@ -151,12 +156,12 @@ def cmd_snapshot(ctx: CommandContext) -> None:
             _print_usage()
             return
 
-        shadow = _workspace_shadow(ctx)
-        if shadow is None:
+        workspace_shadow = _workspace_shadow(ctx)
+        if workspace_shadow is None:
             return
 
         sha = args[0]
-        result = shadow.run("diff", sha, check=False)
+        result = workspace_shadow.run("diff", sha, check=False)
         if result.returncode != 0:
             print(f"snapshot: diff failed: {result.stderr.strip() or 'unknown error'}")
             return

--- a/tests/test_snapshot_command.py
+++ b/tests/test_snapshot_command.py
@@ -1,0 +1,259 @@
+"""Tests for the /snapshot command (#495 — agents that tree search)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+import pytest
+
+import gptme.commands  # noqa: F401 – ensures all commands are registered
+from gptme.commands.base import handle_cmd
+from gptme.workspace_snapshot import (
+    Shadow,
+    init_shadow,
+    list_snapshots,
+    restore,
+    snapshot,
+)
+
+# ── fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def isolated_state_dir(tmp_path, monkeypatch):
+    """Redirect XDG_STATE_HOME to tmp so shadow repos don't leak into live state."""
+    state = tmp_path / "state"
+    state.mkdir()
+    monkeypatch.setenv("XDG_STATE_HOME", str(state))
+    return state
+
+
+@pytest.fixture
+def workspace(tmp_path, isolated_state_dir):
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    (ws / "hello.txt").write_text("hello\n")
+    return ws
+
+
+@pytest.fixture
+def initialized_shadow(workspace):
+    return init_shadow(workspace)
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+
+def _make_manager(workspace: Path) -> MagicMock:
+    manager = MagicMock()
+    manager.workspace = str(workspace)
+    return manager
+
+
+def _run_cmd(manager: MagicMock, args: str) -> None:
+    """Dispatch a /snapshot command via handle_cmd."""
+    list(handle_cmd(f"/snapshot {args}", manager))
+
+
+# ── workspace_snapshot primitive tests ────────────────────────────────────────
+
+
+class TestWorkspaceSnapshotPrimitives:
+    def test_init_shadow_idempotent(self, workspace, isolated_state_dir):
+        shadow1 = init_shadow(workspace)
+        shadow2 = init_shadow(workspace)
+        assert shadow1.git_dir == shadow2.git_dir
+        assert shadow1.initialized()
+
+    def test_snapshot_returns_sha(self, workspace, isolated_state_dir):
+        shadow = init_shadow(workspace)
+        sha = snapshot(shadow, label="test-snap")
+        assert sha is not None
+        assert len(sha) >= 7
+
+    def test_list_snapshots_after_init(self, workspace, isolated_state_dir):
+        shadow = init_shadow(workspace)
+        entries = list_snapshots(shadow)
+        # init_shadow takes one initial snapshot labelled "initial"
+        assert len(entries) >= 1
+        assert entries[0][1] == "initial"
+
+    def test_restore_reverts_deletion(self, workspace, isolated_state_dir):
+        shadow = init_shadow(workspace)
+        sha = snapshot(shadow, label="before-delete")
+        assert sha is not None
+
+        (workspace / "hello.txt").unlink()
+        assert not (workspace / "hello.txt").exists()
+
+        ok = restore(shadow, sha)
+        assert ok
+        assert (workspace / "hello.txt").exists()
+
+
+# ── /snapshot command tests ───────────────────────────────────────────────────
+
+
+class TestSnapshotCommand:
+    def test_registered(self):
+        from gptme.commands.base import get_registered_commands
+
+        assert "snapshot" in get_registered_commands()
+
+    def test_list_no_workspace(self, tmp_path, capsys):
+        manager = MagicMock()
+        manager.workspace = None
+        _run_cmd(manager, "list")
+        out = capsys.readouterr().out
+        assert "no workspace" in out.lower()
+
+    def test_list_uninitialized_workspace(self, workspace, isolated_state_dir, capsys):
+        """Snapshot command reports clearly when no snapshot history exists."""
+        manager = _make_manager(workspace)
+        # Shadow not initialized — workspace dir exists but no shadow repo
+        mock_shadow = MagicMock(spec=Shadow)
+        mock_shadow.initialized.return_value = False
+        with patch(
+            "gptme.commands.snapshot.Shadow.for_workspace", return_value=mock_shadow
+        ):
+            _run_cmd(manager, "list")
+        out = capsys.readouterr().out
+        assert "no snapshot history" in out.lower()
+
+    def test_list_shows_entries(self, workspace, isolated_state_dir, capsys):
+        shadow = init_shadow(workspace)
+        snapshot(shadow, label="step-1")
+        snapshot(shadow, label="step-2")
+
+        manager = _make_manager(workspace)
+        with patch("gptme.commands.snapshot.Shadow.for_workspace", return_value=shadow):
+            _run_cmd(manager, "list")
+        out = capsys.readouterr().out
+        assert "step-1" in out or "step-2" in out
+
+    def test_list_limit_flag(self, workspace, isolated_state_dir, capsys):
+        shadow = init_shadow(workspace)
+        for i in range(5):
+            snapshot(shadow, label=f"snap-{i}")
+
+        manager = _make_manager(workspace)
+        with patch("gptme.commands.snapshot.Shadow.for_workspace", return_value=shadow):
+            _run_cmd(manager, "list --limit 2")
+        out = capsys.readouterr().out
+        lines = [
+            line
+            for line in out.splitlines()
+            if line.strip() and not line.startswith(("SHA", "-"))
+        ]
+        # At most 2 snapshot entries
+        assert len(lines) <= 2
+
+    def test_restore_missing_sha(self, workspace, isolated_state_dir, capsys):
+        shadow = init_shadow(workspace)
+        manager = _make_manager(workspace)
+        with patch("gptme.commands.snapshot.Shadow.for_workspace", return_value=shadow):
+            _run_cmd(manager, "restore deadbeefdeadbeef")
+        out = capsys.readouterr().out
+        assert "restore failed" in out.lower()
+
+    def test_restore_valid_sha(self, workspace, isolated_state_dir, capsys):
+        shadow = init_shadow(workspace)
+        (workspace / "extra.txt").write_text("extra\n")
+        sha = snapshot(shadow, label="with-extra")
+        assert sha is not None
+
+        (workspace / "extra.txt").unlink()
+        assert not (workspace / "extra.txt").exists()
+
+        manager = _make_manager(workspace)
+        with patch("gptme.commands.snapshot.Shadow.for_workspace", return_value=shadow):
+            _run_cmd(manager, f"restore {sha}")
+
+        out = capsys.readouterr().out
+        assert "restored" in out.lower()
+        assert (workspace / "extra.txt").exists()
+
+    def test_help_no_args(self, workspace, isolated_state_dir, capsys):
+        manager = _make_manager(workspace)
+        _run_cmd(manager, "")
+        out = capsys.readouterr().out
+        assert "Usage" in out
+
+    def test_unknown_subcommand(self, workspace, isolated_state_dir, capsys):
+        manager = _make_manager(workspace)
+        _run_cmd(manager, "frobnitz")
+        out = capsys.readouterr().out
+        assert "unknown subcommand" in out.lower()
+
+    def test_diff_no_changes(self, workspace, isolated_state_dir, capsys):
+        shadow = init_shadow(workspace)
+        sha = snapshot(shadow, label="current")
+        assert sha is not None
+
+        manager = _make_manager(workspace)
+        with patch("gptme.commands.snapshot.Shadow.for_workspace", return_value=shadow):
+            _run_cmd(manager, f"diff {sha}")
+        out = capsys.readouterr().out
+        # Either empty or explicit "no changes" message
+        assert "no changes" in out.lower() or out.strip() == ""
+
+    def test_restore_requires_one_arg(self, workspace, isolated_state_dir, capsys):
+        manager = _make_manager(workspace)
+        _run_cmd(manager, "restore")
+        out = capsys.readouterr().out
+        assert "restore requires" in out.lower()
+
+    def test_diff_requires_one_arg(self, workspace, isolated_state_dir, capsys):
+        manager = _make_manager(workspace)
+        _run_cmd(manager, "diff")
+        out = capsys.readouterr().out
+        assert "diff requires" in out.lower()
+
+    def test_create_explicit_snapshot(self, workspace, isolated_state_dir, capsys):
+        """Agent can explicitly record a named snapshot before a risky attempt."""
+        shadow = init_shadow(workspace)
+        manager = _make_manager(workspace)
+        with patch("gptme.commands.snapshot.Shadow.for_workspace", return_value=shadow):
+            _run_cmd(manager, "create before-attempt")
+        out = capsys.readouterr().out
+        assert "snapshot recorded" in out.lower()
+        assert "before-attempt" in out
+
+    def test_create_default_label(self, workspace, isolated_state_dir, capsys):
+        """Create with no label uses 'manual' as default."""
+        shadow = init_shadow(workspace)
+        manager = _make_manager(workspace)
+        with patch("gptme.commands.snapshot.Shadow.for_workspace", return_value=shadow):
+            _run_cmd(manager, "create")
+        out = capsys.readouterr().out
+        assert "snapshot recorded" in out.lower()
+        assert "manual" in out
+
+    def test_create_then_restore_roundtrip(self, workspace, isolated_state_dir, capsys):
+        """Full tree-search round-trip: create snapshot, mutate, restore."""
+        shadow = init_shadow(workspace)
+        manager = _make_manager(workspace)
+
+        # Step 1: record state before attempt
+        with patch("gptme.commands.snapshot.Shadow.for_workspace", return_value=shadow):
+            _run_cmd(manager, "create before-attempt")
+        out = capsys.readouterr().out
+        # Extract SHA from output like "Snapshot recorded: abc1234  (before-attempt)"
+        sha = out.split(":")[1].strip().split()[0] if ":" in out else None
+        assert sha is not None, f"Could not extract SHA from: {out!r}"
+
+        # Step 2: mutate workspace (simulate a failed attempt)
+        (workspace / "bad_change.txt").write_text("oops\n")
+        assert (workspace / "bad_change.txt").exists()
+
+        # Step 3: restore to before-attempt
+        with patch("gptme.commands.snapshot.Shadow.for_workspace", return_value=shadow):
+            _run_cmd(manager, f"restore {sha}")
+        capsys.readouterr()  # consume
+
+        # Mutation should be gone
+        assert not (workspace / "bad_change.txt").exists()

--- a/tests/test_snapshot_command.py
+++ b/tests/test_snapshot_command.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
@@ -233,6 +234,24 @@ class TestSnapshotCommand:
         assert "snapshot recorded" in out.lower()
         assert "manual" in out
 
+    def test_create_no_workspace_prints_single_error(self, capsys):
+        """Create without a workspace reports the error once."""
+        manager = MagicMock()
+        manager.workspace = None
+        _run_cmd(manager, "create before-attempt")
+        out = capsys.readouterr().out
+        assert out.lower().count("no workspace configured") == 1
+
+    def test_create_initializes_uninitialized_workspace(
+        self, workspace, isolated_state_dir, capsys
+    ):
+        """First explicit create initializes the shadow without spurious warnings."""
+        manager = _make_manager(workspace)
+        _run_cmd(manager, "create before-attempt")
+        out = capsys.readouterr().out
+        assert "snapshot recorded" in out.lower()
+        assert "no snapshot history" not in out.lower()
+
     def test_create_then_restore_roundtrip(self, workspace, isolated_state_dir, capsys):
         """Full tree-search round-trip: create snapshot, mutate, restore."""
         shadow = init_shadow(workspace)
@@ -243,7 +262,8 @@ class TestSnapshotCommand:
             _run_cmd(manager, "create before-attempt")
         out = capsys.readouterr().out
         # Extract SHA from output like "Snapshot recorded: abc1234  (before-attempt)"
-        sha = out.split(":")[1].strip().split()[0] if ":" in out else None
+        match = re.search(r"Snapshot recorded:\s+(\S+)", out)
+        sha = match.group(1) if match else None
         assert sha is not None, f"Could not extract SHA from: {out!r}"
 
         # Step 2: mutate workspace (simulate a failed attempt)


### PR DESCRIPTION
## Summary

Adds a `/snapshot` command that exposes the existing `workspace_snapshot` backend interactively, completing the tree-search toolkit for agents.

### What's added

- **`/snapshot create [label]`** — explicitly record current workspace state (committed or dirty) as a named snapshot
- **`/snapshot list [--limit N]`** — show recent snapshots, newest first
- **`/snapshot restore <sha>`** — roll back the workspace to any prior snapshot
- **`/snapshot diff <sha>`** — show diff between current workspace and a snapshot

### How it enables tree search

Agents can now do a full explore-backtrack cycle purely via slash commands:

```
/snapshot create before-attempt    # pin state before trying an approach
# ... (try approach A, it fails) ...
/snapshot restore <sha>            # revert workspace to the pin
# ... (try approach B) ...
```

This is **different from `/checkpoint`** (which requires a clean git working tree and resets via `git reset --hard`) — `/snapshot` works on any workspace state using the side-git shadow repo from `workspace_snapshot.py`.

The auto_snapshots hook continues to auto-populate the snapshot ledger before/after each mutating tool call. `/snapshot create` gives agents explicit control when they want to mark a decision point.

### Relationship to other tree-search primitives

| Command | What it snapshots | Requires clean git? | Restores |
|---------|------------------|---------------------|---------|
| `/snapshot` | Any file state (committed or dirty) | No | Working tree |
| `/checkpoint` | Git-committed HEAD | By default yes | Working tree via `git reset --hard` |
| `/backtrack` | Conversation history | N/A | Message log |

### Tests

19 new tests covering primitives and all four subcommands, including a full create→mutate→restore round-trip.

### What remains for #495

The eval-guided mode (`gptme --eval "pytest tests/ -q" --auto-backtrack`) is **not** in this PR — it's a larger undertaking that warrants its own design discussion.

Closes #495 (partial)