### PR TITLE
feat(snapshot): embed conversation message count for diff summary

### DIFF
--- a/gptme/commands/snapshot.py
+++ b/gptme/commands/snapshot.py
@@ -20,6 +20,7 @@ then ``/snapshot restore <sha>`` to roll back a failed branch.
 
 from __future__ import annotations
 
+from collections import Counter
 from pathlib import Path
 
 from ..workspace_snapshot import (
@@ -176,8 +177,6 @@ def cmd_snapshot(ctx: CommandContext) -> None:
             current_msgs = list(ctx.manager.log)
             delta = len(current_msgs) - snap_n_msgs
             if delta > 0:
-                from collections import Counter
-
                 role_counts = Counter(m.role for m in current_msgs[snap_n_msgs:])
                 role_str = ", ".join(
                     f"{count} {role}" for role, count in sorted(role_counts.items())
@@ -185,8 +184,13 @@ def cmd_snapshot(ctx: CommandContext) -> None:
                 print(
                     f"+{delta} message{'s' if delta != 1 else ''} since snapshot {sha} ({role_str})"
                 )
-            else:
+            elif delta == 0:
                 print(f"No new messages since snapshot {sha}.")
+            else:
+                print(
+                    f"Conversation is shorter than at snapshot time "
+                    f"({len(current_msgs)} vs {snap_n_msgs} messages)."
+                )
             print()
 
         # Workspace diff.

--- a/gptme/commands/snapshot.py
+++ b/gptme/commands/snapshot.py
@@ -201,8 +201,7 @@ def cmd_snapshot(ctx: CommandContext) -> None:
         output = result.stdout
         if output:
             print(output, end="")
-        elif snap_n_msgs is None:
-            # Only print "no changes" when there was no conversation summary above.
+        else:
             print(f"No changes between current workspace and snapshot {sha}.")
         return
 

--- a/gptme/commands/snapshot.py
+++ b/gptme/commands/snapshot.py
@@ -22,7 +22,14 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from ..workspace_snapshot import Shadow, init_shadow, list_snapshots, restore, snapshot
+from ..workspace_snapshot import (
+    Shadow,
+    get_snapshot_n_msgs,
+    init_shadow,
+    list_snapshots,
+    restore,
+    snapshot,
+)
 from .base import CommandContext, command
 
 
@@ -87,7 +94,8 @@ def cmd_snapshot(ctx: CommandContext) -> None:
         shadow = Shadow.for_workspace(workspace)
         if not shadow.initialized():
             shadow = init_shadow(workspace)
-        sha = snapshot(shadow, label=label)
+        n_msgs = len(ctx.manager.log) if ctx.manager is not None else None
+        sha = snapshot(shadow, label=label, n_msgs=n_msgs)
         if sha is not None:
             print(f"Snapshot recorded: {sha}  ({label})")
         else:
@@ -161,6 +169,27 @@ def cmd_snapshot(ctx: CommandContext) -> None:
             return
 
         sha = args[0]
+
+        # Conversation summary: show messages added since the snapshot was taken.
+        snap_n_msgs = get_snapshot_n_msgs(workspace_shadow, sha)
+        if snap_n_msgs is not None and ctx.manager is not None:
+            current_msgs = list(ctx.manager.log)
+            delta = len(current_msgs) - snap_n_msgs
+            if delta > 0:
+                from collections import Counter
+
+                role_counts = Counter(m.role for m in current_msgs[snap_n_msgs:])
+                role_str = ", ".join(
+                    f"{count} {role}" for role, count in sorted(role_counts.items())
+                )
+                print(
+                    f"+{delta} message{'s' if delta != 1 else ''} since snapshot {sha} ({role_str})"
+                )
+            else:
+                print(f"No new messages since snapshot {sha}.")
+            print()
+
+        # Workspace diff.
         result = workspace_shadow.run("diff", sha, check=False)
         if result.returncode != 0:
             print(f"snapshot: diff failed: {result.stderr.strip() or 'unknown error'}")
@@ -168,7 +197,8 @@ def cmd_snapshot(ctx: CommandContext) -> None:
         output = result.stdout
         if output:
             print(output, end="")
-        else:
+        elif snap_n_msgs is None:
+            # Only print "no changes" when there was no conversation summary above.
             print(f"No changes between current workspace and snapshot {sha}.")
         return
 

--- a/gptme/workspace_snapshot.py
+++ b/gptme/workspace_snapshot.py
@@ -264,17 +264,30 @@ def prune(shadow: Shadow, keep: int = DEFAULT_MAX_SNAPSHOTS) -> int:
     if total <= keep:
         return 0
     to_drop = total - keep
-    # Collect (tree, subject) for the ``keep`` newest commits, newest-first.
-    log = shadow.run(
-        "log", "--pretty=format:%T\t%s", f"-{keep}", SNAPSHOT_REF, check=False
-    )
-    if log.returncode != 0 or not log.stdout.strip():
+    # Collect (tree, full body) for the ``keep`` newest commits.
+    # Use per-commit log calls to capture %B (full body) so n_msgs=<N>
+    # metadata survives the prune-and-replay pass.
+    # Per-commit calls are slower but prune runs rarely and avoids
+    # NUL-byte parsing fragility with --pretty=format: delimiters.
+    hash_log = shadow.run("log", "--format=%H", f"-{keep}", SNAPSHOT_REF, check=False)
+    if hash_log.returncode != 0 or not hash_log.stdout.strip():
         return 0
-    entries = []
-    for line in log.stdout.splitlines():
-        if "\t" in line:
-            tree, msg = line.split("\t", 1)
-            entries.append((tree.strip(), msg.strip()))
+    entries: list[tuple[str, str]] = []
+    for commit_hash in hash_log.stdout.strip().splitlines():
+        if not commit_hash.strip():
+            continue
+        tree_res = shadow.run(
+            "log", "--format=%T", "-1", commit_hash.strip(), check=False
+        )
+        body_res = shadow.run(
+            "log", "--format=%B", "-1", commit_hash.strip(), check=False
+        )
+        if tree_res.returncode != 0 or body_res.returncode != 0:
+            continue
+        tree = tree_res.stdout.strip()
+        body = body_res.stdout.strip()
+        if tree and body:
+            entries.append((tree, body))
     if not entries:
         return 0
     # Reverse so we build oldest-of-kept → newest (oldest is entries[-1]).

--- a/gptme/workspace_snapshot.py
+++ b/gptme/workspace_snapshot.py
@@ -147,12 +147,23 @@ def init_shadow(workspace: Path) -> Shadow:
     return shadow
 
 
-def snapshot(shadow: Shadow, label: str = "snapshot", stage: bool = True) -> str | None:
-    """Create a snapshot. Returns short SHA, or ``None`` on failure."""
+def snapshot(
+    shadow: Shadow,
+    label: str = "snapshot",
+    stage: bool = True,
+    n_msgs: int | None = None,
+) -> str | None:
+    """Create a snapshot. Returns short SHA, or ``None`` on failure.
+
+    When *n_msgs* is provided it is embedded in the commit message so that
+    :func:`get_snapshot_n_msgs` can later reconstruct the conversation size at
+    snapshot time for the ``/snapshot diff`` conversation-summary feature.
+    """
     if not shadow.initialized():
         return None
     if stage:
         shadow.run("add", "-A")
+    commit_msg = label if n_msgs is None else f"{label}\nn_msgs={n_msgs}"
     # Allow empty so consecutive identical snapshots still record a ref.
     # Bypass user hooks: internal bookkeeping, not a social commit.
     result = shadow.run(
@@ -161,7 +172,7 @@ def snapshot(shadow: Shadow, label: str = "snapshot", stage: bool = True) -> str
         "--no-verify",
         "--no-gpg-sign",
         "-m",
-        label,
+        commit_msg,
         check=False,
     )
     if result.returncode != 0:
@@ -169,6 +180,20 @@ def snapshot(shadow: Shadow, label: str = "snapshot", stage: bool = True) -> str
         return None
     sha = shadow.run("rev-parse", "--short", "HEAD").stdout.strip()
     return sha
+
+
+def get_snapshot_n_msgs(shadow: Shadow, sha: str) -> int | None:
+    """Return the conversation message count embedded in a snapshot, or ``None``."""
+    result = shadow.run("log", "--format=%B", "-1", sha, check=False)
+    if result.returncode != 0:
+        return None
+    for line in result.stdout.splitlines()[1:]:
+        if line.startswith("n_msgs="):
+            try:
+                return int(line.split("=", 1)[1].strip())
+            except ValueError:
+                pass
+    return None
 
 
 def list_snapshots(shadow: Shadow, limit: int = 20) -> list[tuple[str, str]]:

--- a/gptme/workspace_snapshot.py
+++ b/gptme/workspace_snapshot.py
@@ -264,28 +264,29 @@ def prune(shadow: Shadow, keep: int = DEFAULT_MAX_SNAPSHOTS) -> int:
     if total <= keep:
         return 0
     to_drop = total - keep
-    # Collect (tree, full body) for the ``keep`` newest commits.
-    # Use per-commit log calls to capture %B (full body) so n_msgs=<N>
-    # metadata survives the prune-and-replay pass.
-    # Per-commit calls are slower but prune runs rarely and avoids
-    # NUL-byte parsing fragility with --pretty=format: delimiters.
-    hash_log = shadow.run("log", "--format=%H", f"-{keep}", SNAPSHOT_REF, check=False)
-    if hash_log.returncode != 0 or not hash_log.stdout.strip():
+    # Collect (tree, full body) for the ``keep`` newest commits in one pass.
+    # Use ASCII control characters as record/field separators so commit bodies
+    # can still contain ordinary newlines.
+    log_output = shadow.run(
+        "log",
+        "--format=%H%x1f%T%x1f%B%x1e",
+        f"-{keep}",
+        SNAPSHOT_REF,
+        check=False,
+    )
+    if log_output.returncode != 0 or not log_output.stdout.strip():
         return 0
     entries: list[tuple[str, str]] = []
-    for commit_hash in hash_log.stdout.strip().splitlines():
-        if not commit_hash.strip():
+    for record in log_output.stdout.split("\x1e"):
+        record = record.strip()
+        if not record:
             continue
-        tree_res = shadow.run(
-            "log", "--format=%T", "-1", commit_hash.strip(), check=False
-        )
-        body_res = shadow.run(
-            "log", "--format=%B", "-1", commit_hash.strip(), check=False
-        )
-        if tree_res.returncode != 0 or body_res.returncode != 0:
+        parts = record.split("\x1f", 2)
+        if len(parts) != 3:
             continue
-        tree = tree_res.stdout.strip()
-        body = body_res.stdout.strip()
+        _, tree, body = parts
+        tree = tree.strip()
+        body = body.strip()
         if tree and body:
             entries.append((tree, body))
     if not entries:

--- a/tests/test_snapshot_command.py
+++ b/tests/test_snapshot_command.py
@@ -374,3 +374,65 @@ class TestSnapshotConversationSummary:
 
         # The embedded count should be recoverable.
         assert get_snapshot_n_msgs(shadow, sha) == 6
+
+
+# ── prune tests ───────────────────────────────────────────────────────────────
+
+
+class TestSnapshotPrune:
+    """Tests that prune() preserves conversation metadata (n_msgs) after
+    the retain-and-replay pass so /snapshot diff still shows the summary."""
+
+    def test_prune_includes_n_msgs_in_commit_body(self, workspace, isolated_state_dir):
+        """After pruning, metadata-bearing commits keep their n_msgs body line."""
+        from gptme.workspace_snapshot import prune
+
+        shadow = init_shadow(workspace)
+
+        # Create a few snapshots, each with a distinct n_msgs.
+        shas: list[str] = []
+        for i in range(3):
+            sha = snapshot(shadow, label=f"gen-{i}", n_msgs=10 + i)
+            assert sha is not None
+            shas.append(sha)
+
+        # Prune to keep=2 and confirm each kept commit still carries its body.
+        pruned = prune(shadow, keep=2)
+        assert pruned > 0
+
+        # The oldest (gen-0, n_msgs=10) should be gone; gen-1 and gen-2 survive.
+        survivors = [sha for sha, _ in list_snapshots(shadow, limit=10)]
+        # At least one snapshot should still have recoverable n_msgs metadata.
+        preserved = any(
+            get_snapshot_n_msgs(shadow, sha) is not None for sha in survivors
+        )
+        assert preserved, (
+            "After prune, no surviving snapshot has n_msgs metadata — "
+            "prune() dropped the commit body"
+        )
+
+    def test_prune_keep_entire_body_recovery(self, workspace, isolated_state_dir):
+        """Full round-trip: create metadata snapshots, prune, recover n_msgs
+        for the survivors via get_snapshot_n_msgs."""
+        from gptme.workspace_snapshot import prune
+
+        shadow = init_shadow(workspace)
+
+        sha_before = snapshot(shadow, label="before-prune", n_msgs=42)
+        assert sha_before is not None
+
+        # Create enough additional snapshots to trigger pruning.
+        for i in range(5):
+            snapshot(shadow, label=f"filler-{i}", n_msgs=99)
+
+        pruned = prune(shadow, keep=3)
+        assert pruned > 0, "Expected some snapshots to be pruned"
+
+        # The before-prune commit may or may not have survived,
+        # but at least one survivor should still report n_msgs=42 or 99.
+        survivors = [sha for sha, _ in list_snapshots(shadow, limit=10)]
+        recovered = {sha: get_snapshot_n_msgs(shadow, sha) for sha in survivors}
+        assert any(v in {42, 99} for v in recovered.values()), (
+            f"After prune, no surviving snapshot recovered its original "
+            f"n_msgs value. Recovered: {recovered!r}"
+        )

--- a/tests/test_snapshot_command.py
+++ b/tests/test_snapshot_command.py
@@ -346,6 +346,20 @@ class TestSnapshotConversationSummary:
         out = capsys.readouterr().out
         assert "no new messages" in out.lower()
 
+    def test_diff_with_meta_and_clean_workspace_prints_no_changes(
+        self, workspace, isolated_state_dir, capsys
+    ):
+        """diff should still say the workspace is clean when metadata is present."""
+        shadow = init_shadow(workspace)
+        sha = snapshot(shadow, label="checkpoint", n_msgs=4)
+        assert sha is not None
+
+        manager = _make_manager(workspace, n_msgs=4)
+        with patch("gptme.commands.snapshot.Shadow.for_workspace", return_value=shadow):
+            _run_cmd(manager, f"diff {sha}")
+        out = capsys.readouterr().out
+        assert "no changes between current workspace and snapshot" in out.lower()
+
     def test_diff_without_meta_skips_summary(
         self, workspace, isolated_state_dir, capsys
     ):

--- a/tests/test_snapshot_command.py
+++ b/tests/test_snapshot_command.py
@@ -15,6 +15,7 @@ import gptme.commands  # noqa: F401 – ensures all commands are registered
 from gptme.commands.base import handle_cmd
 from gptme.workspace_snapshot import (
     Shadow,
+    get_snapshot_n_msgs,
     init_shadow,
     list_snapshots,
     restore,
@@ -49,9 +50,15 @@ def initialized_shadow(workspace):
 # ── helpers ───────────────────────────────────────────────────────────────────
 
 
-def _make_manager(workspace: Path) -> MagicMock:
+def _make_manager(workspace: Path, n_msgs: int | None = None) -> MagicMock:
     manager = MagicMock()
     manager.workspace = str(workspace)
+    if n_msgs is not None:
+        manager.log = [MagicMock(role="user")] * n_msgs
+    else:
+        manager.log = MagicMock()
+        manager.log.__len__ = MagicMock(return_value=0)
+        manager.log.__iter__ = MagicMock(return_value=iter([]))
     return manager
 
 
@@ -277,3 +284,93 @@ class TestSnapshotCommand:
 
         # Mutation should be gone
         assert not (workspace / "bad_change.txt").exists()
+
+
+# ── conversation-summary tests ────────────────────────────────────────────────
+
+
+class TestSnapshotConversationSummary:
+    """Tests for the conversation-message summary embedded in snapshots."""
+
+    def test_get_snapshot_n_msgs_absent(self, workspace, isolated_state_dir):
+        """Old snapshots without n_msgs metadata return None."""
+        shadow = init_shadow(workspace)
+        sha = snapshot(shadow, label="no-meta")
+        assert sha is not None
+        assert get_snapshot_n_msgs(shadow, sha) is None
+
+    def test_get_snapshot_n_msgs_present(self, workspace, isolated_state_dir):
+        """Snapshots created with n_msgs embed and return the count."""
+        shadow = init_shadow(workspace)
+        sha = snapshot(shadow, label="with-meta", n_msgs=7)
+        assert sha is not None
+        assert get_snapshot_n_msgs(shadow, sha) == 7
+
+    def test_diff_shows_conversation_summary(
+        self, workspace, isolated_state_dir, capsys
+    ):
+        """diff output includes message count when n_msgs was stored at create time."""
+        shadow = init_shadow(workspace)
+        # Snapshot at 2 messages.
+        sha = snapshot(shadow, label="checkpoint", n_msgs=2)
+        assert sha is not None
+
+        # Manager now has 5 messages; 3 added since snapshot (user, assistant, user).
+        manager = MagicMock()
+        manager.workspace = str(workspace)
+        manager.log = [
+            MagicMock(role="user"),
+            MagicMock(role="assistant"),
+            # --- snapshot boundary ---
+            MagicMock(role="user"),
+            MagicMock(role="assistant"),
+            MagicMock(role="user"),
+        ]
+
+        with patch("gptme.commands.snapshot.Shadow.for_workspace", return_value=shadow):
+            _run_cmd(manager, f"diff {sha}")
+        out = capsys.readouterr().out
+        assert "+3 messages" in out
+        assert "assistant" in out
+        assert "user" in out
+
+    def test_diff_no_new_messages(self, workspace, isolated_state_dir, capsys):
+        """diff with same message count shows no-new-messages line."""
+        shadow = init_shadow(workspace)
+        sha = snapshot(shadow, label="checkpoint", n_msgs=4)
+        assert sha is not None
+
+        manager = _make_manager(workspace, n_msgs=4)
+        with patch("gptme.commands.snapshot.Shadow.for_workspace", return_value=shadow):
+            _run_cmd(manager, f"diff {sha}")
+        out = capsys.readouterr().out
+        assert "no new messages" in out.lower()
+
+    def test_diff_without_meta_skips_summary(
+        self, workspace, isolated_state_dir, capsys
+    ):
+        """diff against a legacy snapshot (no n_msgs) shows no summary line."""
+        shadow = init_shadow(workspace)
+        sha = snapshot(shadow, label="legacy-no-meta")  # no n_msgs
+        assert sha is not None
+
+        manager = _make_manager(workspace, n_msgs=4)
+        with patch("gptme.commands.snapshot.Shadow.for_workspace", return_value=shadow):
+            _run_cmd(manager, f"diff {sha}")
+        out = capsys.readouterr().out
+        assert "messages" not in out.lower() or "no changes" in out.lower()
+
+    def test_create_embeds_n_msgs(self, workspace, isolated_state_dir, capsys):
+        """create command stores the current message count in the snapshot."""
+        shadow = init_shadow(workspace)
+        manager = _make_manager(workspace, n_msgs=6)
+
+        with patch("gptme.commands.snapshot.Shadow.for_workspace", return_value=shadow):
+            _run_cmd(manager, "create after-setup")
+        out = capsys.readouterr().out
+        match = re.search(r"Snapshot recorded:\s+(\S+)", out)
+        assert match, f"No SHA in output: {out!r}"
+        sha = match.group(1)
+
+        # The embedded count should be recoverable.
+        assert get_snapshot_n_msgs(shadow, sha) == 6


### PR DESCRIPTION
## Summary

Enhances `/snapshot diff` to show how many conversation messages were added since the snapshot, making it easier for tree-search agents to decide whether to restore a checkpoint.

**Before**: `/snapshot diff <sha>` only showed workspace file changes.

**After**: When a snapshot was created with `/snapshot create`, the command now also shows a conversation summary:
```
+3 messages since snapshot abc1234 (1 assistant, 2 user)

diff --git a/foo.py b/foo.py
...
```

### What changed

- `workspace_snapshot.snapshot()` now accepts an optional `n_msgs` param; when provided it is embedded as a trailing `n_msgs=<N>` line in the git commit message
- New `get_snapshot_n_msgs(shadow, sha)` helper extracts the stored count
- `/snapshot create` passes `len(manager.log)` so the conversation size is recorded
- `/snapshot diff` shows the message summary before the workspace diff; falls back cleanly for legacy snapshots (no `n_msgs` line) and for cases where there are no new messages
- 6 new tests covering the full round-trip, no-new-messages case, and legacy graceful skip

## Test plan

- [ ] `pytest tests/test_snapshot_command.py` — 27 tests all green
- [ ] Manual: `/snapshot create before-attempt` then some work then `/snapshot diff <sha>` shows both summary and workspace diff