### PR TITLE
feat(snapshot): add /snapshot prune subcommand

### DIFF
--- a/gptme/commands/snapshot.py
+++ b/gptme/commands/snapshot.py
@@ -239,6 +239,9 @@ def cmd_snapshot(ctx: CommandContext) -> None:
                     return
                 try:
                     max_entries = int(args[idx])
+                    if max_entries <= 0:
+                        print("snapshot: --max-entries must be a positive integer")
+                        return
                 except ValueError:
                     print(
                         f"snapshot: --max-entries must be an integer, got {args[idx]!r}"

--- a/gptme/commands/snapshot.py
+++ b/gptme/commands/snapshot.py
@@ -28,6 +28,8 @@ from ..workspace_snapshot import (
     get_snapshot_n_msgs,
     init_shadow,
     list_snapshots,
+    prune,
+    prune_by_age,
     restore,
     snapshot,
 )
@@ -35,13 +37,18 @@ from .base import CommandContext, command
 
 
 def _print_usage() -> None:
-    print("Usage: /snapshot <create|list|restore|diff> ...")
+    print("Usage: /snapshot <create|list|restore|diff|prune> ...")
     print()
     print("Subcommands:")
-    print("  create [label]       Record the current workspace state as a snapshot.")
-    print("  list [--limit N]     List recent snapshots (newest first).")
-    print("  restore <sha>        Restore workspace to a snapshot.")
-    print("  diff <sha>           Show diff between current workspace and a snapshot.")
+    print(
+        "  create [label]              Record the current workspace state as a snapshot."
+    )
+    print("  list [--limit N]            List recent snapshots (newest first).")
+    print("  restore <sha>               Restore workspace to a snapshot.")
+    print(
+        "  diff <sha>                  Show diff between current workspace and a snapshot."
+    )
+    print("  prune [--days N] [--max-entries K]  Remove old snapshots.")
 
 
 def _workspace_path(ctx: CommandContext) -> Path | None:
@@ -68,17 +75,18 @@ def _workspace_shadow(ctx: CommandContext) -> Shadow | None:
 
 @command("snapshot")
 def cmd_snapshot(ctx: CommandContext) -> None:
-    """List, diff, or restore workspace auto-snapshots.
+    """List, diff, restore, or prune workspace auto-snapshots.
 
     Snapshots are created automatically by the auto_snapshots hook before and
     after each mutating tool call.  Use this command to inspect the history,
-    restore a prior state, or explicitly record a named snapshot.
+    restore a prior state, explicitly record a named snapshot, or prune old ones.
 
     Usage:
-      /snapshot create [label]     Record current workspace state
-      /snapshot list [--limit N]   Show recent snapshots
-      /snapshot restore <sha>      Roll back to a snapshot
-      /snapshot diff <sha>         Show diff from current to snapshot
+      /snapshot create [label]              Record current workspace state
+      /snapshot list [--limit N]            Show recent snapshots
+      /snapshot restore <sha>               Roll back to a snapshot
+      /snapshot diff <sha>                  Show diff from current to snapshot
+      /snapshot prune [--days N] [--max-entries K]  Remove old snapshots
     """
     if not ctx.args or ctx.args[0] in {"help", "-h", "--help"}:
         _print_usage()
@@ -203,6 +211,53 @@ def cmd_snapshot(ctx: CommandContext) -> None:
             print(output, end="")
         else:
             print(f"No changes between current workspace and snapshot {sha}.")
+        return
+
+    if subcommand == "prune":
+        days = 30
+        max_entries: int | None = None
+        idx = 0
+        while idx < len(args):
+            arg = args[idx]
+            if arg in ("--days", "-d"):
+                idx += 1
+                if idx >= len(args):
+                    print("snapshot: --days requires a value")
+                    return
+                try:
+                    days = int(args[idx])
+                except ValueError:
+                    print(f"snapshot: --days must be an integer, got {args[idx]!r}")
+                    return
+            elif arg == "--max-entries":
+                idx += 1
+                if idx >= len(args):
+                    print("snapshot: --max-entries requires a value")
+                    return
+                try:
+                    max_entries = int(args[idx])
+                except ValueError:
+                    print(
+                        f"snapshot: --max-entries must be an integer, got {args[idx]!r}"
+                    )
+                    return
+            else:
+                print(f"snapshot: unknown argument {arg!r}")
+                _print_usage()
+                return
+            idx += 1
+
+        workspace_shadow = _workspace_shadow(ctx)
+        if workspace_shadow is None:
+            return
+
+        dropped = prune_by_age(workspace_shadow, days=days)
+        if max_entries is not None:
+            dropped += prune(workspace_shadow, keep=max_entries)
+        if dropped > 0:
+            print(f"Pruned {dropped} snapshot(s).")
+        else:
+            print("No snapshots to prune.")
         return
 
     print(f"snapshot: unknown subcommand {subcommand!r}")

--- a/gptme/commands/snapshot.py
+++ b/gptme/commands/snapshot.py
@@ -35,6 +35,8 @@ from ..workspace_snapshot import (
 )
 from .base import CommandContext, command
 
+DEFAULT_PRUNE_DAYS = 30
+
 
 def _print_usage() -> None:
     print("Usage: /snapshot <create|list|restore|diff|prune> ...")
@@ -48,7 +50,10 @@ def _print_usage() -> None:
     print(
         "  diff <sha>                  Show diff between current workspace and a snapshot."
     )
-    print("  prune [--days N] [--max-entries K]  Remove old snapshots.")
+    print(
+        "  prune [--days N] [--max-entries K]  Remove old snapshots "
+        f"(defaults to {DEFAULT_PRUNE_DAYS} days)."
+    )
 
 
 def _workspace_path(ctx: CommandContext) -> Path | None:
@@ -252,6 +257,9 @@ def cmd_snapshot(ctx: CommandContext) -> None:
                 _print_usage()
                 return
             idx += 1
+
+        if not args:
+            days = DEFAULT_PRUNE_DAYS
 
         workspace_shadow = _workspace_shadow(ctx)
         if workspace_shadow is None:

--- a/gptme/commands/snapshot.py
+++ b/gptme/commands/snapshot.py
@@ -214,7 +214,7 @@ def cmd_snapshot(ctx: CommandContext) -> None:
         return
 
     if subcommand == "prune":
-        days = 30
+        days: int | None = None
         max_entries: int | None = None
         idx = 0
         while idx < len(args):
@@ -226,6 +226,9 @@ def cmd_snapshot(ctx: CommandContext) -> None:
                     return
                 try:
                     days = int(args[idx])
+                    if days <= 0:
+                        print("snapshot: --days must be a positive integer")
+                        return
                 except ValueError:
                     print(f"snapshot: --days must be an integer, got {args[idx]!r}")
                     return
@@ -251,7 +254,9 @@ def cmd_snapshot(ctx: CommandContext) -> None:
         if workspace_shadow is None:
             return
 
-        dropped = prune_by_age(workspace_shadow, days=days)
+        dropped = 0
+        if days is not None:
+            dropped += prune_by_age(workspace_shadow, days=days)
         if max_entries is not None:
             dropped += prune(workspace_shadow, keep=max_entries)
         if dropped > 0:

--- a/gptme/workspace_snapshot.py
+++ b/gptme/workspace_snapshot.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import logging
 import os
 import subprocess
+import time
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -306,6 +307,69 @@ def prune(shadow: Shadow, keep: int = DEFAULT_MAX_SNAPSHOTS) -> int:
             return 0
         parent = res.stdout.strip()
     # Point the ref at the new tip.
+    reset = shadow.run("update-ref", SNAPSHOT_REF, parent, check=False)
+    if reset.returncode != 0:
+        return 0
+    return to_drop
+
+
+def prune_by_age(shadow: Shadow, days: int = 30) -> int:
+    """Drop snapshots older than ``days`` days. Returns dropped count.
+
+    Always keeps at least one snapshot (the most recent) regardless of age.
+    Implementation mirrors :func:`prune`: collect entries to keep, replay as a
+    fresh orphan chain, and point SNAPSHOT_REF at the new tip.
+    """
+    if not shadow.initialized() or days <= 0:
+        return 0
+    cutoff = int(time.time()) - days * 86400
+    # Fetch all commits: hash, tree, commit-timestamp, full body.
+    log_output = shadow.run(
+        "log",
+        "--format=%H%x1f%T%x1f%ct%x1f%B%x1e",
+        SNAPSHOT_REF,
+        check=False,
+    )
+    if log_output.returncode != 0 or not log_output.stdout.strip():
+        return 0
+    all_entries: list[tuple[str, str, int]] = []  # (tree, body, timestamp)
+    for record in log_output.stdout.split("\x1e"):
+        record = record.strip()
+        if not record:
+            continue
+        parts = record.split("\x1f", 3)
+        if len(parts) != 4:
+            continue
+        _, tree, ts_str, body = parts
+        tree = tree.strip()
+        body = body.strip()
+        try:
+            ts = int(ts_str.strip())
+        except ValueError:
+            continue
+        if tree and body:
+            all_entries.append((tree, body, ts))
+    if not all_entries:
+        return 0
+    # Keep entries within the age window; always retain the newest one.
+    keep = [(t, b, ts) for t, b, ts in all_entries if ts >= cutoff]
+    if not keep:
+        keep = [all_entries[0]]  # always retain the most recent
+    to_drop = len(all_entries) - len(keep)
+    if to_drop == 0:
+        return 0
+    # Rebuild orphan chain oldest-first (entries arrive newest-first from log).
+    keep.reverse()
+    first_tree, first_msg, _ = keep[0]
+    res = shadow.run("commit-tree", first_tree, "-m", first_msg, check=False)
+    if res.returncode != 0:
+        return 0
+    parent = res.stdout.strip()
+    for tree, msg, _ in keep[1:]:
+        res = shadow.run("commit-tree", tree, "-p", parent, "-m", msg, check=False)
+        if res.returncode != 0:
+            return 0
+        parent = res.stdout.strip()
     reset = shadow.run("update-ref", SNAPSHOT_REF, parent, check=False)
     if reset.returncode != 0:
         return 0

--- a/gptme/workspace_snapshot.py
+++ b/gptme/workspace_snapshot.py
@@ -323,9 +323,34 @@ def prune_by_age(shadow: Shadow, days: int = 30) -> int:
     if not shadow.initialized() or days <= 0:
         return 0
     cutoff = int(time.time()) - days * 86400
-    # Fetch all commits: hash, tree, commit-timestamp, full body.
+    total = shadow.run("rev-list", "--count", SNAPSHOT_REF, check=False)
+    if total.returncode != 0:
+        return 0
+    try:
+        total_count = int(total.stdout.strip())
+    except ValueError:
+        return 0
+    recent = shadow.run(
+        "rev-list",
+        "--count",
+        f"--since=@{cutoff}",
+        SNAPSHOT_REF,
+        check=False,
+    )
+    if recent.returncode != 0:
+        return 0
+    try:
+        keep_count = int(recent.stdout.strip())
+    except ValueError:
+        return 0
+    keep_count = keep_count or 1
+    to_drop = total_count - keep_count
+    if to_drop <= 0:
+        return 0
+    # Fetch only the survivors we need to replay.
     log_output = shadow.run(
         "log",
+        f"-{keep_count}",
         "--format=%H%x1f%T%x1f%ct%x1f%B%x1e",
         SNAPSHOT_REF,
         check=False,
@@ -349,23 +374,16 @@ def prune_by_age(shadow: Shadow, days: int = 30) -> int:
             continue
         if tree and body:
             all_entries.append((tree, body, ts))
-    if not all_entries:
-        return 0
-    # Keep entries within the age window; always retain the newest one.
-    keep = [(t, b, ts) for t, b, ts in all_entries if ts >= cutoff]
-    if not keep:
-        keep = [all_entries[0]]  # always retain the most recent
-    to_drop = len(all_entries) - len(keep)
-    if to_drop == 0:
+    if len(all_entries) != keep_count:
         return 0
     # Rebuild orphan chain oldest-first (entries arrive newest-first from log).
-    keep.reverse()
-    first_tree, first_msg, _ = keep[0]
+    all_entries.reverse()
+    first_tree, first_msg, _ = all_entries[0]
     res = shadow.run("commit-tree", first_tree, "-m", first_msg, check=False)
     if res.returncode != 0:
         return 0
     parent = res.stdout.strip()
-    for tree, msg, _ in keep[1:]:
+    for tree, msg, _ in all_entries[1:]:
         res = shadow.run("commit-tree", tree, "-p", parent, "-m", msg, check=False)
         if res.returncode != 0:
             return 0

--- a/gptme/workspace_snapshot.py
+++ b/gptme/workspace_snapshot.py
@@ -54,11 +54,18 @@ class Shadow:
         return e
 
     def run(
-        self, *args: str, check: bool = True, capture: bool = True
+        self,
+        *args: str,
+        check: bool = True,
+        capture: bool = True,
+        env: dict[str, str] | None = None,
     ) -> subprocess.CompletedProcess:
+        run_env = self.env()
+        if env:
+            run_env.update(env)
         return subprocess.run(
             ["git", *args],
-            env=self.env(),
+            env=run_env,
             cwd=self.workspace,
             check=check,
             text=True,
@@ -218,6 +225,51 @@ def list_snapshots(shadow: Shadow, limit: int = 20) -> list[tuple[str, str]]:
     return out
 
 
+def _git_date_env(timestamp: int) -> dict[str, str]:
+    git_date = f"{timestamp} +0000"
+    return {
+        "GIT_AUTHOR_DATE": git_date,
+        "GIT_COMMITTER_DATE": git_date,
+    }
+
+
+def _rebuild_snapshot_chain(
+    shadow: Shadow, entries: list[tuple[str, str, int]]
+) -> str | None:
+    """Replay kept snapshot commits while preserving their original timestamps."""
+    if not entries:
+        return None
+
+    entries.reverse()
+    first_tree, first_msg, first_ts = entries[0]
+    res = shadow.run(
+        "commit-tree",
+        first_tree,
+        "-m",
+        first_msg,
+        check=False,
+        env=_git_date_env(first_ts),
+    )
+    if res.returncode != 0:
+        return None
+    parent = res.stdout.strip()
+    for tree, msg, ts in entries[1:]:
+        res = shadow.run(
+            "commit-tree",
+            tree,
+            "-p",
+            parent,
+            "-m",
+            msg,
+            check=False,
+            env=_git_date_env(ts),
+        )
+        if res.returncode != 0:
+            return None
+        parent = res.stdout.strip()
+    return parent
+
+
 def restore(shadow: Shadow, snapshot_id: str) -> bool:
     """Restore the workspace tree from ``snapshot_id``.
 
@@ -270,42 +322,35 @@ def prune(shadow: Shadow, keep: int = DEFAULT_MAX_SNAPSHOTS) -> int:
     # can still contain ordinary newlines.
     log_output = shadow.run(
         "log",
-        "--format=%H%x1f%T%x1f%B%x1e",
+        "--format=%H%x1f%T%x1f%ct%x1f%B%x1e",
         f"-{keep}",
         SNAPSHOT_REF,
         check=False,
     )
     if log_output.returncode != 0 or not log_output.stdout.strip():
         return 0
-    entries: list[tuple[str, str]] = []
+    entries: list[tuple[str, str, int]] = []
     for record in log_output.stdout.split("\x1e"):
         record = record.strip()
         if not record:
             continue
-        parts = record.split("\x1f", 2)
-        if len(parts) != 3:
+        parts = record.split("\x1f", 3)
+        if len(parts) != 4:
             continue
-        _, tree, body = parts
+        _, tree, ts_str, body = parts
         tree = tree.strip()
         body = body.strip()
+        try:
+            ts = int(ts_str.strip())
+        except ValueError:
+            continue
         if tree and body:
-            entries.append((tree, body))
+            entries.append((tree, body, ts))
     if not entries:
         return 0
-    # Reverse so we build oldest-of-kept → newest (oldest is entries[-1]).
-    entries.reverse()
-    # Create an orphan root from the oldest kept commit.
-    first_tree, first_msg = entries[0]
-    res = shadow.run("commit-tree", first_tree, "-m", first_msg, check=False)
-    if res.returncode != 0:
+    parent = _rebuild_snapshot_chain(shadow, entries)
+    if parent is None:
         return 0
-    parent = res.stdout.strip()
-    # Chain remaining commits onto the orphan root.
-    for tree, msg in entries[1:]:
-        res = shadow.run("commit-tree", tree, "-p", parent, "-m", msg, check=False)
-        if res.returncode != 0:
-            return 0
-        parent = res.stdout.strip()
     # Point the ref at the new tip.
     reset = shadow.run("update-ref", SNAPSHOT_REF, parent, check=False)
     if reset.returncode != 0:
@@ -376,18 +421,9 @@ def prune_by_age(shadow: Shadow, days: int = 30) -> int:
             all_entries.append((tree, body, ts))
     if len(all_entries) != keep_count:
         return 0
-    # Rebuild orphan chain oldest-first (entries arrive newest-first from log).
-    all_entries.reverse()
-    first_tree, first_msg, _ = all_entries[0]
-    res = shadow.run("commit-tree", first_tree, "-m", first_msg, check=False)
-    if res.returncode != 0:
+    parent = _rebuild_snapshot_chain(shadow, all_entries)
+    if parent is None:
         return 0
-    parent = res.stdout.strip()
-    for tree, msg, _ in all_entries[1:]:
-        res = shadow.run("commit-tree", tree, "-p", parent, "-m", msg, check=False)
-        if res.returncode != 0:
-            return 0
-        parent = res.stdout.strip()
     reset = shadow.run("update-ref", SNAPSHOT_REF, parent, check=False)
     if reset.returncode != 0:
         return 0

--- a/tests/test_snapshot_command.py
+++ b/tests/test_snapshot_command.py
@@ -453,6 +453,29 @@ class TestSnapshotPrune:
 
 
 class TestSnapshotPruneCommand:
+    def test_prune_no_args_defaults_to_30_days(
+        self, workspace, isolated_state_dir, capsys
+    ):
+        """Bare prune should apply the documented 30-day age window."""
+        import time
+
+        shadow = init_shadow(workspace)
+        for i in range(4):
+            (workspace / f"f{i}.txt").write_text(str(i))
+            snapshot(shadow, label=f"snap-{i}")
+
+        future = time.time() + 31 * 86400
+        manager = _make_manager(workspace)
+        with (
+            patch("gptme.commands.snapshot.Shadow.for_workspace", return_value=shadow),
+            patch("gptme.workspace_snapshot.time.time", return_value=future),
+        ):
+            _run_cmd(manager, "prune")
+        out = capsys.readouterr().out
+        assert "pruned" in out.lower()
+        remaining = list_snapshots(shadow, limit=50)
+        assert len(remaining) == 1
+
     def test_prune_no_op_when_all_recent(self, workspace, isolated_state_dir, capsys):
         """All snapshots are fresh — nothing pruned, reports 0."""
         shadow = init_shadow(workspace)

--- a/tests/test_snapshot_command.py
+++ b/tests/test_snapshot_command.py
@@ -450,3 +450,69 @@ class TestSnapshotPrune:
             f"After prune, no surviving snapshot recovered its original "
             f"n_msgs value. Recovered: {recovered!r}"
         )
+
+
+class TestSnapshotPruneCommand:
+    def test_prune_no_op_when_all_recent(self, workspace, isolated_state_dir, capsys):
+        """All snapshots are fresh — nothing pruned, reports 0."""
+        shadow = init_shadow(workspace)
+        snapshot(shadow, label="fresh")
+        manager = _make_manager(workspace)
+        with patch("gptme.commands.snapshot.Shadow.for_workspace", return_value=shadow):
+            _run_cmd(manager, "prune --days 30")
+        out = capsys.readouterr().out
+        assert "no snapshots to prune" in out.lower()
+
+    def test_prune_drops_old_snapshots(self, workspace, isolated_state_dir, capsys):
+        """With mocked future time, old snapshots are removed."""
+        import time
+
+        shadow = init_shadow(workspace)
+        for i in range(4):
+            (workspace / f"f{i}.txt").write_text(str(i))
+            snapshot(shadow, label=f"snap-{i}")
+
+        future = time.time() + 31 * 86400
+        manager = _make_manager(workspace)
+        with (
+            patch("gptme.commands.snapshot.Shadow.for_workspace", return_value=shadow),
+            patch("gptme.workspace_snapshot.time.time", return_value=future),
+        ):
+            _run_cmd(manager, "prune --days 30")
+        out = capsys.readouterr().out
+        assert "pruned" in out.lower()
+        remaining = list_snapshots(shadow, limit=50)
+        assert len(remaining) == 1
+
+    def test_prune_max_entries_flag(self, workspace, isolated_state_dir, capsys):
+        """--max-entries keeps only K newest snapshots."""
+        shadow = init_shadow(workspace)
+        for i in range(8):
+            (workspace / f"f{i}.txt").write_text(str(i))
+            snapshot(shadow, label=f"snap-{i}")
+
+        manager = _make_manager(workspace)
+        with patch("gptme.commands.snapshot.Shadow.for_workspace", return_value=shadow):
+            _run_cmd(manager, "prune --days 3650 --max-entries 3")
+        out = capsys.readouterr().out
+        assert "pruned" in out.lower()
+        remaining = list_snapshots(shadow, limit=50)
+        assert len(remaining) == 3
+
+    def test_prune_unknown_arg(self, workspace, isolated_state_dir, capsys):
+        manager = _make_manager(workspace)
+        _run_cmd(manager, "prune --invalid-flag")
+        out = capsys.readouterr().out
+        assert "unknown argument" in out.lower()
+
+    def test_prune_days_missing_value(self, workspace, isolated_state_dir, capsys):
+        manager = _make_manager(workspace)
+        _run_cmd(manager, "prune --days")
+        out = capsys.readouterr().out
+        assert "--days requires a value" in out.lower()
+
+    def test_prune_days_non_integer(self, workspace, isolated_state_dir, capsys):
+        manager = _make_manager(workspace)
+        _run_cmd(manager, "prune --days abc")
+        out = capsys.readouterr().out
+        assert "--days must be an integer" in out.lower()

--- a/tests/test_snapshot_command.py
+++ b/tests/test_snapshot_command.py
@@ -549,3 +549,12 @@ class TestSnapshotPruneCommand:
         _run_cmd(manager, f"prune --days {value}")
         out = capsys.readouterr().out
         assert "--days must be a positive integer" in out.lower()
+
+    @pytest.mark.parametrize("value", ["0", "-1"])
+    def test_prune_max_entries_requires_positive_integer(
+        self, workspace, isolated_state_dir, capsys, value
+    ):
+        manager = _make_manager(workspace)
+        _run_cmd(manager, f"prune --max-entries {value}")
+        out = capsys.readouterr().out
+        assert "--max-entries must be a positive integer" in out.lower()

--- a/tests/test_snapshot_command.py
+++ b/tests/test_snapshot_command.py
@@ -499,6 +499,30 @@ class TestSnapshotPruneCommand:
         remaining = list_snapshots(shadow, limit=50)
         assert len(remaining) == 3
 
+    def test_prune_max_entries_without_days_skips_age_prune(
+        self, workspace, isolated_state_dir, capsys
+    ):
+        """--max-entries alone should not implicitly trigger age pruning."""
+        import time
+
+        shadow = init_shadow(workspace)
+        for i in range(8):
+            (workspace / f"f{i}.txt").write_text(str(i))
+            snapshot(shadow, label=f"snap-{i}")
+
+        future = time.time() + 31 * 86400
+        manager = _make_manager(workspace)
+        with (
+            patch("gptme.commands.snapshot.Shadow.for_workspace", return_value=shadow),
+            patch("gptme.workspace_snapshot.time.time", return_value=future),
+        ):
+            _run_cmd(manager, "prune --max-entries 3")
+        out = capsys.readouterr().out
+        assert "pruned" in out.lower()
+        remaining = list_snapshots(shadow, limit=50)
+        assert len(remaining) == 3
+        assert [label for _, label in remaining] == ["snap-7", "snap-6", "snap-5"]
+
     def test_prune_unknown_arg(self, workspace, isolated_state_dir, capsys):
         manager = _make_manager(workspace)
         _run_cmd(manager, "prune --invalid-flag")
@@ -516,3 +540,12 @@ class TestSnapshotPruneCommand:
         _run_cmd(manager, "prune --days abc")
         out = capsys.readouterr().out
         assert "--days must be an integer" in out.lower()
+
+    @pytest.mark.parametrize("value", ["0", "-1"])
+    def test_prune_days_requires_positive_integer(
+        self, workspace, isolated_state_dir, capsys, value
+    ):
+        manager = _make_manager(workspace)
+        _run_cmd(manager, f"prune --days {value}")
+        out = capsys.readouterr().out
+        assert "--days must be a positive integer" in out.lower()

--- a/tests/test_workspace_snapshot.py
+++ b/tests/test_workspace_snapshot.py
@@ -335,6 +335,40 @@ def test_prune_by_age_always_keeps_at_least_one(
     assert remaining[0][1] in {"only-snap", "initial"}
 
 
+def test_prune_by_age_preserves_survivor_timestamps(
+    isolated_state_dir, workspace, monkeypatch
+):
+    """A second age-prune should still see survivors as old based on original dates."""
+    base = 1_700_000_000
+
+    def set_git_dates(timestamp: int) -> None:
+        git_date = f"{timestamp} +0000"
+        monkeypatch.setenv("GIT_AUTHOR_DATE", git_date)
+        monkeypatch.setenv("GIT_COMMITTER_DATE", git_date)
+
+    set_git_dates(base)
+    shadow = init_shadow(workspace)
+    for label, days_after_base in (
+        ("snap-5", 5),
+        ("snap-20", 20),
+        ("snap-29", 29),
+    ):
+        set_git_dates(base + days_after_base * 86400)
+        (workspace / f"{label}.txt").write_text(label)
+        snapshot(shadow, label=label)
+
+    monkeypatch.setattr("gptme.workspace_snapshot.time.time", lambda: base + 40 * 86400)
+    assert prune_by_age(shadow, days=30) == 2
+    assert [label for _, label in list_snapshots(shadow, limit=50)] == [
+        "snap-29",
+        "snap-20",
+    ]
+
+    monkeypatch.setattr("gptme.workspace_snapshot.time.time", lambda: base + 60 * 86400)
+    assert prune_by_age(shadow, days=30) == 1
+    assert [label for _, label in list_snapshots(shadow, limit=50)] == ["snap-29"]
+
+
 # --- hook activation gate ---------------------------------------------------
 
 

--- a/tests/test_workspace_snapshot.py
+++ b/tests/test_workspace_snapshot.py
@@ -11,6 +11,7 @@ Covers:
 
 from __future__ import annotations
 
+import time
 from unittest.mock import MagicMock
 
 import pytest
@@ -31,6 +32,7 @@ from gptme.workspace_snapshot import (
     init_shadow,
     list_snapshots,
     prune,
+    prune_by_age,
     restore,
     snapshot,
     tree_hash,
@@ -279,6 +281,58 @@ def test_prune_noop_when_under_limit(isolated_state_dir, workspace):
     snapshot(shadow, label="one")
     dropped = prune(shadow, keep=50)
     assert dropped == 0
+
+
+# --- prune_by_age -----------------------------------------------------------
+
+
+def test_prune_by_age_drops_old_snapshots(isolated_state_dir, workspace, monkeypatch):
+    """Mock time far into the future so existing commits appear older than 30 days."""
+    shadow = init_shadow(workspace)
+    for i in range(5):
+        (workspace / f"f{i}.txt").write_text(str(i))
+        snapshot(shadow, label=f"snap-{i}")
+
+    # Advance the clock 31 days so all commits look older than the default 30-day window.
+    future = time.time() + 31 * 86400
+    monkeypatch.setattr("gptme.workspace_snapshot.time.time", lambda: future)
+
+    n_dropped = prune_by_age(shadow, days=30)
+    # All commits were "made 31 days ago" — only the newest is preserved.
+    assert n_dropped > 0
+    remaining = list_snapshots(shadow, limit=50)
+    assert len(remaining) == 1
+    assert remaining[0][1] == "snap-4"
+
+
+def test_prune_by_age_noop_when_all_recent(isolated_state_dir, workspace):
+    """No snapshots dropped when all are within the age window."""
+    shadow = init_shadow(workspace)
+    for i in range(3):
+        (workspace / f"f{i}.txt").write_text(str(i))
+        snapshot(shadow, label=f"snap-{i}")
+
+    dropped = prune_by_age(shadow, days=30)
+    assert dropped == 0
+    remaining = list_snapshots(shadow, limit=50)
+    assert len(remaining) == 4  # init + 3 snapshots
+
+
+def test_prune_by_age_always_keeps_at_least_one(
+    isolated_state_dir, workspace, monkeypatch
+):
+    """Even when all snapshots are ancient, the newest is always preserved."""
+    shadow = init_shadow(workspace)
+    snapshot(shadow, label="only-snap")
+
+    future = time.time() + 365 * 86400  # 1 year in the future
+    monkeypatch.setattr("gptme.workspace_snapshot.time.time", lambda: future)
+
+    prune_by_age(shadow, days=30)
+    remaining = list_snapshots(shadow, limit=50)
+    assert len(remaining) == 1
+    # The newest commit was "initial" (from init_shadow) or "only-snap".
+    assert remaining[0][1] in {"only-snap", "initial"}
 
 
 # --- hook activation gate ---------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `prune_by_age(shadow, days=30)` to `workspace_snapshot.py` — drops snapshots with commit timestamps older than N days, always preserving at least one (the most recent)
- Exposes it as `/snapshot prune [--days N] [--max-entries K]` in the command layer
- Both flags can be combined: age-prune runs first, count-prune caps the remainder

The existing count-based `prune()` function is unchanged; `prune_by_age` follows the same orphan-chain-replay approach.

## Usage

```
/snapshot prune              # drop snapshots older than 30 days (default)
/snapshot prune --days 7     # drop snapshots older than 7 days
/snapshot prune --max-entries 100     # keep at most 100 newest snapshots
/snapshot prune --days 30 --max-entries 50  # age prune then count cap
```

## Test plan

- [x] `test_prune_by_age_drops_old_snapshots` — time-mocked future; all commits appear old; only newest survives
- [x] `test_prune_by_age_noop_when_all_recent` — all snapshots fresh; dropped == 0
- [x] `test_prune_by_age_always_keeps_at_least_one` — even with 1-year future clock, at least 1 snapshot remains
- [x] `/snapshot prune` command: no-op when all recent, drops old, max-entries flag, error paths
- [x] Full snapshot test suites (117 tests) pass with no regressions