### PR TITLE
fix(llm): invalidate gptme gateway client on reinit (#2876 follow-up)

### DIFF
--- a/gptme/llm/llm_anthropic.py
+++ b/gptme/llm/llm_anthropic.py
@@ -558,9 +558,18 @@ def _init_anthropic(
     proxy_url: str | None = None,
     proxy_key: str | None = None,
 ) -> None:
-    global _anthropic, _is_proxy
+    global _anthropic, _is_proxy, _anthropic_gptme, _anthropic_gptme_key
     proxy_key = proxy_key or None
     proxy_url = proxy_url or None
+
+    # Discard the lazily-built gptme gateway client so it rebuilds from current
+    # config on next use. _get_gptme_client only rebuilds when the device token
+    # CHANGES; a mid-session reinit() that switches proxy/timeout config while the
+    # device token stays the same would otherwise leave the gateway client pinned
+    # to the stale base_url/timeout. Resetting here keeps it symmetric with the
+    # primary _anthropic client this function rebuilds. (gptme#2876 follow-up.)
+    _anthropic_gptme = None
+    _anthropic_gptme_key = None
 
     from anthropic import NOT_GIVEN, Anthropic  # fmt: skip
 

--- a/tests/test_gptme_provider.py
+++ b/tests/test_gptme_provider.py
@@ -645,3 +645,31 @@ def _mock_config(env: dict[str, str] | None = None):
             raise KeyError(f"Missing environment variable: {key}")
 
     return MockConfig()
+
+
+def test_reinit_invalidates_gptme_gateway_client():
+    """reinit() must discard the lazily-built gptme gateway client so it rebuilds
+    from current config — symmetric with the primary _anthropic client.
+
+    Regression for gptme#2876 follow-up: _get_gptme_client only rebuilds on a
+    device-token CHANGE, so a mid-session reinit() that switches proxy/timeout
+    config (same device token) would otherwise leave the gateway client pinned to
+    the stale base_url/timeout.
+    """
+    from gptme.llm import llm_anthropic
+
+    sentinel = MagicMock(name="stale-gptme-client")
+    llm_anthropic._anthropic_gptme = sentinel
+    llm_anthropic._anthropic_gptme_key = "old-device-token"
+
+    # get_config and Anthropic are imported lazily *inside* _init_anthropic,
+    # so patch them at their source modules.
+    with (
+        patch("gptme.config.get_config", return_value=_mock_config()),
+        patch("anthropic.Anthropic", MagicMock()),
+    ):
+        llm_anthropic.reinit(api_key="new-real-key")
+
+    # The stale gateway client is discarded; next _get_gptme_client() rebuilds it.
+    assert llm_anthropic._anthropic_gptme is None
+    assert llm_anthropic._anthropic_gptme_key is None

--- a/tests/test_gptme_provider.py
+++ b/tests/test_gptme_provider.py
@@ -658,18 +658,26 @@ def test_reinit_invalidates_gptme_gateway_client():
     """
     from gptme.llm import llm_anthropic
 
+    orig_anthropic = llm_anthropic._anthropic
+    orig_gptme = llm_anthropic._anthropic_gptme
+    orig_gptme_key = llm_anthropic._anthropic_gptme_key
     sentinel = MagicMock(name="stale-gptme-client")
-    llm_anthropic._anthropic_gptme = sentinel
-    llm_anthropic._anthropic_gptme_key = "old-device-token"
+    try:
+        llm_anthropic._anthropic_gptme = sentinel
+        llm_anthropic._anthropic_gptme_key = "old-device-token"
 
-    # get_config and Anthropic are imported lazily *inside* _init_anthropic,
-    # so patch them at their source modules.
-    with (
-        patch("gptme.config.get_config", return_value=_mock_config()),
-        patch("anthropic.Anthropic", MagicMock()),
-    ):
-        llm_anthropic.reinit(api_key="new-real-key")
+        # get_config and Anthropic are imported lazily *inside* _init_anthropic,
+        # so patch them at their source modules.
+        with (
+            patch("gptme.config.get_config", return_value=_mock_config()),
+            patch("anthropic.Anthropic", MagicMock()),
+        ):
+            llm_anthropic.reinit(api_key="new-real-key")
 
-    # The stale gateway client is discarded; next _get_gptme_client() rebuilds it.
-    assert llm_anthropic._anthropic_gptme is None
-    assert llm_anthropic._anthropic_gptme_key is None
+        # The stale gateway client is discarded; next _get_gptme_client() rebuilds it.
+        assert llm_anthropic._anthropic_gptme is None
+        assert llm_anthropic._anthropic_gptme_key is None
+    finally:
+        llm_anthropic._anthropic = orig_anthropic
+        llm_anthropic._anthropic_gptme = orig_gptme
+        llm_anthropic._anthropic_gptme_key = orig_gptme_key


### PR DESCRIPTION
Follow-up to #2876 addressing the Greptile 4/5 reinit-asymmetry finding.

## Problem
The `_anthropic_gptme` gateway client added in #2876 is lazily built and only rebuilt by `_get_gptme_client()` when the **device token changes**. The primary `_anthropic` client, by contrast, is fully rebuilt by `reinit()`. So a mid-session `reinit(api_key, proxy_url, ...)` that switches proxy / timeout config while the **device token stays the same** leaves the gateway client pinned to the stale `base_url`/`timeout` — the asymmetry Greptile flagged.

## Fix
Reset `_anthropic_gptme` / `_anthropic_gptme_key` to `None` in `_init_anthropic` (called by both `init()` and `reinit()`). The gateway client is lazily rebuilt from current config on next `_get_gptme_client()` call — symmetric with the primary `_anthropic` client, no eager rebuild.

## Test
`test_reinit_invalidates_gptme_gateway_client`: sets a sentinel gateway client + token, calls `reinit()`, asserts both reset to `None`. Full `test_gptme_provider.py` suite green (35 passed); ruff clean.

## Note on the other 4/5 finding
Greptile also flagged `_max_tokens_param_name`'s "hardcoded prefix list" — but it's actually a regex (`^(?:o\d|gpt-(?:[5-9]|\d\d))`) that already covers future o-series and gpt-5→99 without code changes, so no change is needed there.