### PR TITLE
feat(subagent): add subagent_cancel() + tests for resolve_role_defaults

### DIFF
--- a/gptme/tools/subagent/__init__.py
+++ b/gptme/tools/subagent/__init__.py
@@ -13,7 +13,13 @@ Package structure:
 # Re-export public API for backward compatibility
 # Re-export ToolUse for examples()
 from ..base import ToolFunction, ToolSpec, ToolUse
-from .api import subagent, subagent_read_log, subagent_status, subagent_wait
+from .api import (
+    subagent,
+    subagent_cancel,
+    subagent_read_log,
+    subagent_status,
+    subagent_wait,
+)
 from .batch import BatchJob, subagent_batch
 from .hooks import (
     _get_complete_instruction,
@@ -227,6 +233,7 @@ Key features:
 - acp_command="claude-code-acp": Use a different ACP agent (default: gptme-acp)
 - isolated=True: Run subagent in a git worktree for filesystem isolation
 - subagent_batch(): Start multiple subagents in parallel
+- subagent_cancel(): Cancel a running subagent (SIGTERM for subprocess, marks result for threads)
 - Hook-based notifications: Completions delivered as system messages
 
 ## Agent Profiles for Subagents
@@ -281,6 +288,7 @@ tool = ToolSpec(
         ToolFunction.from_callable(f)
         for f in [
             subagent,
+            subagent_cancel,
             subagent_status,
             subagent_wait,
             subagent_read_log,
@@ -301,6 +309,7 @@ __doc__ = tool.get_doc(__doc__)
 __all__ = [
     # Public API
     "subagent",
+    "subagent_cancel",
     "subagent_status",
     "subagent_wait",
     "subagent_read_log",

--- a/gptme/tools/subagent/api.py
+++ b/gptme/tools/subagent/api.py
@@ -486,6 +486,55 @@ def subagent(
         t.start()
 
 
+def subagent_cancel(agent_id: str) -> str:
+    """Cancel a running subagent.
+
+    For subprocess-mode subagents, sends SIGTERM (then SIGKILL after 5s) to the
+    process. For thread-mode subagents, marks the result as cancelled — the thread
+    continues until its next natural checkpoint but the result is already recorded
+    as failure so callers won't block waiting for it.
+
+    Args:
+        agent_id: The subagent to cancel
+
+    Returns:
+        A human-readable status message
+    """
+    with _subagents_lock:
+        sa = next((s for s in _subagents if s.agent_id == agent_id), None)
+
+    if sa is None:
+        raise ValueError(f"Subagent with ID {agent_id} not found.")
+
+    if not sa.is_running():
+        return f"Subagent '{agent_id}' is not running (already finished)."
+
+    if sa.execution_mode == "subprocess" and sa.process:
+        sa.process.terminate()
+        try:
+            sa.process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            sa.process.kill()
+            sa.process.wait()
+        with _subagent_results_lock:
+            _subagent_results[agent_id] = ReturnType(
+                "failure", "Cancelled by orchestrator"
+            )
+        logger.info(f"Subagent '{agent_id}' subprocess terminated.")
+        return f"Subagent '{agent_id}' cancelled."
+    # Thread/ACP mode: threads cannot be forcefully stopped in Python.
+    # Mark the result so the orchestrator sees it as cancelled immediately.
+    with _subagent_results_lock:
+        _subagent_results[agent_id] = ReturnType("failure", "Cancelled by orchestrator")
+    logger.info(
+        f"Subagent '{agent_id}' marked cancelled (thread will stop at next checkpoint)."
+    )
+    return (
+        f"Subagent '{agent_id}' marked as cancelled. "
+        "The background thread will stop at its next natural checkpoint."
+    )
+
+
 def subagent_status(agent_id: str) -> dict:
     """Returns the status of a subagent."""
     with _subagents_lock:

--- a/gptme/tools/subagent/api.py
+++ b/gptme/tools/subagent/api.py
@@ -438,6 +438,12 @@ def subagent(
                 if not set_subagent_result_if_absent(
                     agent_id, ReturnType("failure", str(e))
                 ):
+                    with _subagents_lock:
+                        sa = next(
+                            (s for s in _subagents if s.agent_id == agent_id), None
+                        )
+                    if sa:
+                        _exec._cleanup_isolation(sa)
                     return
                 try:
                     notify_completion(agent_id, "failure", f"Execution failed: {e}")

--- a/gptme/tools/subagent/api.py
+++ b/gptme/tools/subagent/api.py
@@ -460,7 +460,9 @@ def subagent(
             with _subagents_lock:
                 sa = next((s for s in _subagents if s.agent_id == agent_id), None)
             if sa:
-                result = sa.status()
+                # Use _read_log() instead of status(): the thread is still alive here,
+                # so status() would return "running" and poison the result cache.
+                result = sa._read_log()
                 if not set_subagent_result_if_absent(agent_id, result):
                     _exec._cleanup_isolation(sa)
                     return

--- a/gptme/tools/subagent/api.py
+++ b/gptme/tools/subagent/api.py
@@ -26,6 +26,7 @@ from .types import (
     _subagents,
     _subagents_lock,
     resolve_role_defaults,
+    set_subagent_result_if_absent,
 )
 
 logger = logging.getLogger(__name__)
@@ -320,17 +321,20 @@ def subagent(
             try:
                 status, summary = asyncio.run(_acp_run())
 
-                with _subagent_results_lock:
-                    _subagent_results[agent_id] = ReturnType(status, summary)
+                result = ReturnType(status, summary)
+                if not set_subagent_result_if_absent(agent_id, result):
+                    return
                 notify_completion(
                     agent_id,
                     status,
-                    _exec._summarize_result(ReturnType(status, summary), max_chars=200),
+                    _exec._summarize_result(result, max_chars=200),
                 )
             except Exception as e:
                 logger.error(f"ACP subagent {agent_id} failed: {e}", exc_info=True)
-                with _subagent_results_lock:
-                    _subagent_results[agent_id] = ReturnType("failure", str(e))
+                if not set_subagent_result_if_absent(
+                    agent_id, ReturnType("failure", str(e))
+                ):
+                    return
                 notify_completion(agent_id, "failure", f"ACP error: {e}")
             finally:
                 with _subagents_lock:
@@ -451,9 +455,12 @@ def subagent(
                 sa = next((s for s in _subagents if s.agent_id == agent_id), None)
             if sa:
                 result = sa.status()
+                with _subagent_results_lock:
+                    result_was_already_recorded = agent_id in _subagent_results
                 try:
-                    summary = _exec._summarize_result(result, max_chars=200)
-                    notify_completion(agent_id, result.status, summary)
+                    if not result_was_already_recorded:
+                        summary = _exec._summarize_result(result, max_chars=200)
+                        notify_completion(agent_id, result.status, summary)
                 except Exception as e:
                     logger.warning(f"Failed to notify subagent completion: {e}")
                 # Clean up worktree isolation
@@ -510,16 +517,16 @@ def subagent_cancel(agent_id: str) -> str:
         return f"Subagent '{agent_id}' is not running (already finished)."
 
     if sa.execution_mode == "subprocess" and sa.process:
+        with _subagent_results_lock:
+            _subagent_results[agent_id] = ReturnType(
+                "failure", "Cancelled by orchestrator"
+            )
         sa.process.terminate()
         try:
             sa.process.wait(timeout=5)
         except subprocess.TimeoutExpired:
             sa.process.kill()
             sa.process.wait()
-        with _subagent_results_lock:
-            _subagent_results[agent_id] = ReturnType(
-                "failure", "Cancelled by orchestrator"
-            )
         logger.info(f"Subagent '{agent_id}' subprocess terminated.")
         return f"Subagent '{agent_id}' cancelled."
     # Thread/ACP mode: threads cannot be forcefully stopped in Python.

--- a/gptme/tools/subagent/api.py
+++ b/gptme/tools/subagent/api.py
@@ -21,8 +21,6 @@ from .types import (
     Role,
     Subagent,
     SubtaskDef,
-    _subagent_results,
-    _subagent_results_lock,
     _subagents,
     _subagents_lock,
     resolve_role_defaults,
@@ -437,8 +435,10 @@ def subagent(
             except Exception as e:
                 # If subagent creation fails, notify with error status
                 logger.error(f"Subagent {agent_id} failed during execution: {e}")
-                with _subagent_results_lock:
-                    _subagent_results[agent_id] = ReturnType("failure", str(e))
+                if not set_subagent_result_if_absent(
+                    agent_id, ReturnType("failure", str(e))
+                ):
+                    return
                 try:
                     notify_completion(agent_id, "failure", f"Execution failed: {e}")
                 except Exception as notify_err:
@@ -455,12 +455,12 @@ def subagent(
                 sa = next((s for s in _subagents if s.agent_id == agent_id), None)
             if sa:
                 result = sa.status()
-                with _subagent_results_lock:
-                    result_was_already_recorded = agent_id in _subagent_results
+                if not set_subagent_result_if_absent(agent_id, result):
+                    _exec._cleanup_isolation(sa)
+                    return
                 try:
-                    if not result_was_already_recorded:
-                        summary = _exec._summarize_result(result, max_chars=200)
-                        notify_completion(agent_id, result.status, summary)
+                    summary = _exec._summarize_result(result, max_chars=200)
+                    notify_completion(agent_id, result.status, summary)
                 except Exception as e:
                     logger.warning(f"Failed to notify subagent completion: {e}")
                 # Clean up worktree isolation
@@ -516,11 +516,11 @@ def subagent_cancel(agent_id: str) -> str:
     if not sa.is_running():
         return f"Subagent '{agent_id}' is not running (already finished)."
 
+    cancelled_result = ReturnType("failure", "Cancelled by orchestrator")
+
     if sa.execution_mode == "subprocess" and sa.process:
-        with _subagent_results_lock:
-            _subagent_results[agent_id] = ReturnType(
-                "failure", "Cancelled by orchestrator"
-            )
+        if not set_subagent_result_if_absent(agent_id, cancelled_result):
+            return f"Subagent '{agent_id}' already finished before cancellation."
         sa.process.terminate()
         try:
             sa.process.wait(timeout=5)
@@ -531,8 +531,8 @@ def subagent_cancel(agent_id: str) -> str:
         return f"Subagent '{agent_id}' cancelled."
     # Thread/ACP mode: threads cannot be forcefully stopped in Python.
     # Mark the result so the orchestrator sees it as cancelled immediately.
-    with _subagent_results_lock:
-        _subagent_results[agent_id] = ReturnType("failure", "Cancelled by orchestrator")
+    if not set_subagent_result_if_absent(agent_id, cancelled_result):
+        return f"Subagent '{agent_id}' already finished before cancellation."
     logger.info(
         f"Subagent '{agent_id}' marked cancelled (thread will stop at next checkpoint)."
     )

--- a/gptme/tools/subagent/execution.py
+++ b/gptme/tools/subagent/execution.py
@@ -406,8 +406,7 @@ def _monitor_subprocess(
     from .hooks import notify_completion
     from .types import (
         ReturnType,
-        _subagent_results,
-        _subagent_results_lock,
+        set_subagent_result_if_absent,
     )
 
     if not subagent.process:
@@ -445,10 +444,10 @@ def _monitor_subprocess(
         result = f"Process exited with code {subagent.process.returncode}"
 
     # Cache the result in module-level dict (Subagent is frozen)
-    # Use lock for thread-safe access when multiple subagents run in parallel
     final_result = ReturnType(status, result)
-    with _subagent_results_lock:
-        _subagent_results[subagent.agent_id] = final_result
+    if not set_subagent_result_if_absent(subagent.agent_id, final_result):
+        _cleanup_isolation(subagent)
+        return
 
     # Notify via hook system (fire-and-forget-then-get-alerted pattern)
     try:

--- a/gptme/tools/subagent/types.py
+++ b/gptme/tools/subagent/types.py
@@ -114,6 +114,15 @@ _subagent_results_lock = threading.Lock()
 _completion_queue: queue.Queue[tuple[str, Status, str]] = queue.Queue()
 
 
+def set_subagent_result_if_absent(agent_id: str, result: "ReturnType") -> bool:
+    """Cache a subagent result unless another terminal result already exists."""
+    with _subagent_results_lock:
+        if agent_id in _subagent_results:
+            return False
+        _subagent_results[agent_id] = result
+        return True
+
+
 # ---------------------------------------------------------------------------
 # Data classes
 # ---------------------------------------------------------------------------

--- a/gptme/tools/subagent/types.py
+++ b/gptme/tools/subagent/types.py
@@ -188,13 +188,20 @@ class Subagent:
         return False
 
     def status(self) -> ReturnType:
-        # Return cached result if available (subprocess mode)
+        if self.is_running():
+            return ReturnType("running")
+        return self._read_log()
+
+    def _read_log(self) -> ReturnType:
+        """Read result from cache or conversation log, bypassing thread-liveness check.
+
+        Safe to call from within a completion handler (e.g. the run_subagent thread),
+        where status() would incorrectly return "running" because the thread is alive.
+        """
+        # Return cached result if available (set by cancel or subprocess completion)
         with _subagent_results_lock:
             if self.agent_id in _subagent_results:
                 return _subagent_results[self.agent_id]
-
-        if self.is_running():
-            return ReturnType("running")
 
         # Check if executor used the complete tool
         try:

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -13,6 +13,7 @@ import pytest
 
 from gptme.tools.subagent.api import subagent_cancel
 from gptme.tools.subagent.batch import BatchJob
+from gptme.tools.subagent.execution import _monitor_subprocess
 from gptme.tools.subagent.hooks import (
     _get_complete_instruction,
     _subagent_completion_hook,
@@ -350,6 +351,11 @@ class TestSubagentCancel:
             _subagents.clear()
         with _subagent_results_lock:
             _subagent_results.clear()
+        while not _completion_queue.empty():
+            try:
+                _completion_queue.get_nowait()
+            except queue.Empty:
+                break
 
     def _register(self, agent_id: str, **kwargs) -> Subagent:
         sa = Subagent(
@@ -400,6 +406,27 @@ class TestSubagentCancel:
         self._register("slow-proc", process=mock_proc, execution_mode="subprocess")
         subagent_cancel("slow-proc")
         mock_proc.kill.assert_called_once()
+
+    def test_subprocess_monitor_preserves_cancelled_result(self):
+        mock_proc = MagicMock()
+        mock_proc.wait.return_value = 0
+        mock_proc.returncode = -15
+        sa = self._register(
+            "proc-agent",
+            process=mock_proc,
+            execution_mode="subprocess",
+        )
+        with _subagent_results_lock:
+            _subagent_results["proc-agent"] = ReturnType(
+                "failure", "Cancelled by orchestrator"
+            )
+
+        _monitor_subprocess(sa)
+
+        with _subagent_results_lock:
+            assert _subagent_results["proc-agent"].status == "failure"
+            assert _subagent_results["proc-agent"].result == "Cancelled by orchestrator"
+        assert _completion_queue.empty()
 
     def test_cancel_thread_marks_result(self):
         mock_thread = MagicMock(spec=threading.Thread)

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -11,6 +11,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from gptme.tools.subagent.api import subagent_cancel
 from gptme.tools.subagent.batch import BatchJob
 from gptme.tools.subagent.hooks import (
     _get_complete_instruction,
@@ -21,6 +22,11 @@ from gptme.tools.subagent.types import (
     ReturnType,
     Subagent,
     _completion_queue,
+    _subagent_results,
+    _subagent_results_lock,
+    _subagents,
+    _subagents_lock,
+    resolve_role_defaults,
 )
 
 # ---------------------------------------------------------------------------
@@ -262,3 +268,144 @@ class TestBatchJob:
     def test_get_completed_empty(self):
         job = BatchJob(agent_ids=["x"])
         assert job.get_completed() == {}
+
+
+# ---------------------------------------------------------------------------
+# resolve_role_defaults tests
+# ---------------------------------------------------------------------------
+
+
+class TestResolveRoleDefaults:
+    def test_none_role_returns_false_defaults(self):
+        use_sub, use_iso, profile = resolve_role_defaults(None)
+        assert use_sub is False
+        assert use_iso is False
+        assert profile is None
+
+    def test_none_role_respects_explicit_subprocess(self):
+        use_sub, use_iso, profile = resolve_role_defaults(
+            None, explicit_use_subprocess=True
+        )
+        assert use_sub is True
+        assert profile is None
+
+    def test_none_role_respects_explicit_isolated(self):
+        use_sub, use_iso, profile = resolve_role_defaults(None, explicit_isolated=True)
+        assert use_iso is True
+
+    def test_explore_role_sets_explorer_profile(self):
+        use_sub, use_iso, profile = resolve_role_defaults("explore")
+        assert profile == "explorer"
+        assert use_sub is False
+        assert use_iso is False
+
+    def test_implement_role_sets_developer_profile(self):
+        use_sub, use_iso, profile = resolve_role_defaults("implement")
+        assert profile == "developer"
+        assert use_sub is False
+        assert use_iso is False
+
+    def test_general_role_sets_default_profile(self):
+        _, _, profile = resolve_role_defaults("general")
+        assert profile == "default"
+
+    def test_verify_role_enables_subprocess_and_isolated(self):
+        use_sub, use_iso, profile = resolve_role_defaults("verify")
+        assert use_sub is True
+        assert use_iso is True
+        assert profile == "verifier"
+
+    def test_explicit_args_override_verify_role_defaults(self):
+        use_sub, use_iso, profile = resolve_role_defaults(
+            "verify",
+            explicit_use_subprocess=False,
+            explicit_isolated=False,
+        )
+        assert use_sub is False
+        assert use_iso is False
+        assert profile == "verifier"
+
+    def test_explicit_subprocess_true_overrides_explore_default(self):
+        use_sub, use_iso, _ = resolve_role_defaults(
+            "explore", explicit_use_subprocess=True
+        )
+        assert use_sub is True
+
+    def test_explicit_isolated_true_overrides_implement_default(self):
+        _, use_iso, _ = resolve_role_defaults("implement", explicit_isolated=True)
+        assert use_iso is True
+
+
+# ---------------------------------------------------------------------------
+# subagent_cancel tests
+# ---------------------------------------------------------------------------
+
+
+class TestSubagentCancel:
+    _logdir = Path("/tmp/test-log")
+
+    def setup_method(self):
+        """Clear global subagent registry before each test."""
+        with _subagents_lock:
+            _subagents.clear()
+        with _subagent_results_lock:
+            _subagent_results.clear()
+
+    def _register(self, agent_id: str, **kwargs) -> Subagent:
+        sa = Subagent(
+            agent_id=agent_id,
+            prompt="test",
+            thread=kwargs.get("thread"),
+            logdir=self._logdir,
+            model=None,
+            process=kwargs.get("process"),
+            execution_mode=kwargs.get("execution_mode", "thread"),
+        )
+        with _subagents_lock:
+            _subagents.append(sa)
+        return sa
+
+    def test_cancel_unknown_raises(self):
+        with pytest.raises(ValueError, match="not found"):
+            subagent_cancel("nonexistent")
+
+    def test_cancel_finished_subagent(self):
+        mock_thread = MagicMock(spec=threading.Thread)
+        mock_thread.is_alive.return_value = False
+        self._register("done-agent", thread=mock_thread)
+        result = subagent_cancel("done-agent")
+        assert "not running" in result
+
+    def test_cancel_subprocess_terminates_process(self):
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = None  # still running
+        mock_proc.wait.return_value = 0
+        self._register("proc-agent", process=mock_proc, execution_mode="subprocess")
+        result = subagent_cancel("proc-agent")
+        mock_proc.terminate.assert_called_once()
+        assert "cancelled" in result.lower()
+        with _subagent_results_lock:
+            assert _subagent_results["proc-agent"].status == "failure"
+            assert "Cancelled" in (_subagent_results["proc-agent"].result or "")
+
+    def test_cancel_subprocess_kills_on_timeout(self):
+        import subprocess as _subprocess
+
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = None
+        mock_proc.wait.side_effect = [
+            _subprocess.TimeoutExpired(cmd="gptme", timeout=5),
+            0,
+        ]
+        self._register("slow-proc", process=mock_proc, execution_mode="subprocess")
+        subagent_cancel("slow-proc")
+        mock_proc.kill.assert_called_once()
+
+    def test_cancel_thread_marks_result(self):
+        mock_thread = MagicMock(spec=threading.Thread)
+        mock_thread.is_alive.return_value = True
+        self._register("thread-agent", thread=mock_thread)
+        result = subagent_cancel("thread-agent")
+        assert "cancelled" in result.lower()
+        with _subagent_results_lock:
+            assert _subagent_results["thread-agent"].status == "failure"

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -5,6 +5,7 @@ requiring API keys or running actual LLM calls.
 """
 
 import importlib
+import json
 import queue
 import threading
 from pathlib import Path
@@ -232,6 +233,45 @@ class TestSubagentIsRunning:
             execution_mode="acp",
         )
         assert sa.is_running() is False
+
+    def test_read_log_bypasses_thread_liveness(self, tmp_path):
+        """Regression: _read_log() must read from log even when thread is alive.
+
+        run_subagent calls _read_log() (not status()) for exactly this reason:
+        status() returns 'running' while the thread is alive, which would poison
+        the _subagent_results cache with a wrong 'running' entry.
+        """
+        logdir = tmp_path / "subagent-log"
+        logdir.mkdir()
+        (logdir / "conversation.jsonl").write_text(
+            json.dumps(
+                {
+                    "role": "assistant",
+                    "content": "```complete\ntask done\n```",
+                    "timestamp": "2025-01-01T00:00:00+00:00",
+                }
+            )
+            + "\n"
+        )
+
+        mock_thread = MagicMock(spec=threading.Thread)
+        mock_thread.is_alive.return_value = True  # thread still "alive"
+
+        sa = Subagent(
+            agent_id="read-log-test",
+            prompt="do thing",
+            thread=mock_thread,
+            logdir=logdir,
+            model=None,
+        )
+
+        # status() returns "running" while thread is alive — old bug path
+        assert sa.status().status == "running"
+
+        # _read_log() bypasses liveness and reads from log — fixed path
+        result = sa._read_log()
+        assert result.status == "success"
+        assert "task done" in (result.result or "")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -4,6 +4,7 @@ Tests the refactored subagent package (hooks, types, batch) without
 requiring API keys or running actual LLM calls.
 """
 
+import importlib
 import queue
 import threading
 from pathlib import Path
@@ -11,7 +12,8 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from gptme.tools.subagent.api import subagent_cancel
+import gptme.tools.subagent.api as subagent_api
+from gptme.tools.subagent.api import subagent, subagent_cancel
 from gptme.tools.subagent.batch import BatchJob
 from gptme.tools.subagent.execution import _monitor_subprocess
 from gptme.tools.subagent.hooks import (
@@ -407,6 +409,20 @@ class TestSubagentCancel:
         subagent_cancel("slow-proc")
         mock_proc.kill.assert_called_once()
 
+    def test_cancel_subprocess_preserves_completed_result(self):
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = None
+        self._register("proc-agent", process=mock_proc, execution_mode="subprocess")
+        with _subagent_results_lock:
+            _subagent_results["proc-agent"] = ReturnType("success", "done")
+
+        result = subagent_cancel("proc-agent")
+
+        assert "already finished" in result.lower()
+        mock_proc.terminate.assert_not_called()
+        with _subagent_results_lock:
+            assert _subagent_results["proc-agent"] == ReturnType("success", "done")
+
     def test_subprocess_monitor_preserves_cancelled_result(self):
         mock_proc = MagicMock()
         mock_proc.wait.return_value = 0
@@ -436,3 +452,51 @@ class TestSubagentCancel:
         assert "cancelled" in result.lower()
         with _subagent_results_lock:
             assert _subagent_results["thread-agent"].status == "failure"
+
+    def test_thread_completion_skips_notify_when_cancel_wins_race(
+        self, monkeypatch, tmp_path
+    ):
+        cli_main = importlib.import_module("gptme.cli.main")
+        llm_models = importlib.import_module("gptme.llm.models")
+        profiles = importlib.import_module("gptme.profiles")
+        monkeypatch.setattr(cli_main, "get_logdir", lambda name: tmp_path / name)
+        monkeypatch.setattr(llm_models, "get_default_model", lambda: None)
+        monkeypatch.setattr(profiles, "get_profile", lambda _: None)
+        monkeypatch.setattr(
+            subagent_api._exec, "_create_subagent_thread", lambda **kwargs: None
+        )
+        monkeypatch.setattr(subagent_api._exec, "_cleanup_isolation", lambda sa: None)
+
+        notify_calls: list[tuple[str, str, str]] = []
+
+        def fake_notify_completion(agent_id: str, status: str, summary: str) -> None:
+            notify_calls.append((agent_id, status, summary))
+
+        def fake_set_subagent_result_if_absent(
+            agent_id: str, result: ReturnType
+        ) -> bool:
+            with _subagent_results_lock:
+                _subagent_results[agent_id] = ReturnType(
+                    "failure", "Cancelled by orchestrator"
+                )
+            return False
+
+        monkeypatch.setattr(subagent_api, "notify_completion", fake_notify_completion)
+        monkeypatch.setattr(
+            subagent_api,
+            "set_subagent_result_if_absent",
+            fake_set_subagent_result_if_absent,
+        )
+
+        subagent("thread-agent", "do the thing")
+
+        with _subagents_lock:
+            sa = next(s for s in _subagents if s.agent_id == "thread-agent")
+        assert sa.thread is not None
+        sa.thread.join(timeout=1)
+        assert not sa.thread.is_alive()
+        assert notify_calls == []
+        with _subagent_results_lock:
+            assert _subagent_results["thread-agent"] == ReturnType(
+                "failure", "Cancelled by orchestrator"
+            )

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -500,3 +500,52 @@ class TestSubagentCancel:
             assert _subagent_results["thread-agent"] == ReturnType(
                 "failure", "Cancelled by orchestrator"
             )
+
+    def test_thread_exception_cleans_isolation_when_cancel_wins_race(
+        self, monkeypatch, tmp_path
+    ):
+        cli_main = importlib.import_module("gptme.cli.main")
+        llm_models = importlib.import_module("gptme.llm.models")
+        profiles = importlib.import_module("gptme.profiles")
+        monkeypatch.setattr(cli_main, "get_logdir", lambda name: tmp_path / name)
+        monkeypatch.setattr(llm_models, "get_default_model", lambda: None)
+        monkeypatch.setattr(profiles, "get_profile", lambda _: None)
+
+        def boom(**kwargs):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(subagent_api._exec, "_create_subagent_thread", boom)
+
+        cleanup_calls: list[str] = []
+
+        def fake_cleanup(sa: Subagent) -> None:
+            cleanup_calls.append(sa.agent_id)
+
+        def fake_set_subagent_result_if_absent(
+            agent_id: str, result: ReturnType
+        ) -> bool:
+            with _subagent_results_lock:
+                _subagent_results[agent_id] = ReturnType(
+                    "failure", "Cancelled by orchestrator"
+                )
+            return False
+
+        monkeypatch.setattr(subagent_api._exec, "_cleanup_isolation", fake_cleanup)
+        monkeypatch.setattr(
+            subagent_api,
+            "set_subagent_result_if_absent",
+            fake_set_subagent_result_if_absent,
+        )
+
+        subagent("thread-agent", "do the thing", isolated=True)
+
+        with _subagents_lock:
+            sa = next(s for s in _subagents if s.agent_id == "thread-agent")
+        assert sa.thread is not None
+        sa.thread.join(timeout=1)
+        assert not sa.thread.is_alive()
+        assert cleanup_calls == ["thread-agent"]
+        with _subagent_results_lock:
+            assert _subagent_results["thread-agent"] == ReturnType(
+                "failure", "Cancelled by orchestrator"
+            )


### PR DESCRIPTION
## Summary

Addresses #554 by adding a missing capability to the subagent API and filling a test coverage gap.

### Changes

- **`subagent_cancel(agent_id)`** — new public API function to cancel a running subagent mid-flight:
  - Subprocess mode: sends SIGTERM, then SIGKILL after 5s if the process doesn't exit
  - Thread/ACP mode: immediately marks the result as `failure/Cancelled by orchestrator` in the results registry so callers don't block waiting — the background thread continues until its next natural checkpoint
  - Raises `ValueError` if the agent_id isn't found; returns a no-op message if the subagent already finished
  - Exported from the tool spec so the orchestrating agent can call it via `ipython`

- **Tests for `resolve_role_defaults`** — this function was previously untested despite being used to wire role-based profile/subprocess/isolated defaults throughout the subagent planner. Adds 10 cases covering: None role pass-through, explore/implement/general/verify role defaults, and explicit-arg overrides of role defaults.

- **Tests for `subagent_cancel`** — 5 unit tests covering: unknown agent raises, already-finished no-op, subprocess termination, SIGKILL fallback on timeout, and thread-mode result marking.

Test count: 25 → 40 (all passing).

## Test plan

- [x] `uv run python -m pytest tests/test_subagent_unit.py -v` — 40/40 pass
- [ ] Orchestrator can now cancel a stuck/wrong subagent without restarting the session