### PR TITLE
feat(tools): hint-based allowlist and MCP annotation hints

### DIFF
--- a/docs/tools.rst
+++ b/docs/tools.rst
@@ -265,3 +265,155 @@ See :doc:`mcp` for configuration and usage details.
 .. automodule:: gptme.tools.mcp
     :members:
     :noindex:
+
+.. _tool-allowlist:
+
+Tool Selection & Allowlists
+----------------------------
+
+By default gptme loads its full built-in toolset. You can restrict which tools
+are active for a given run — either to reduce the agent's surface area or to
+build read-only / sandboxed profiles.
+
+Basic usage
+^^^^^^^^^^^
+
+Pass a comma-separated list of tool names to ``--tools`` (CLI) or set the
+``TOOL_ALLOWLIST`` environment variable:
+
+.. code-block:: bash
+
+    # Exact names — only these tools are loaded
+    gptme --tools save,patch,shell,python "refactor this file"
+
+    # Additive: start from defaults and add more
+    gptme --tools +rag,browser "research this topic"
+
+    # Subtractive: start from defaults and remove specific tools
+    gptme --tools -shell,computer "safer mode"
+
+    # Disable all tools (pure conversation)
+    gptme --tools "" "just talk to me"
+
+Glob patterns (``*``, ``?``, ``[...]``) are also supported, matched against tool
+names with :func:`fnmatch.fnmatchcase`.
+
+.. _hint-allowlist:
+
+Hint-based patterns
+^^^^^^^^^^^^^^^^^^^
+
+Tools can carry **capability hints** — semantic tags that describe what a tool
+does. Hint-based allowlist entries let you match entire categories of tools at
+once using the ``hint:`` prefix:
+
+.. code-block:: bash
+
+    # Allow only tools annotated as read-only (safe for untrusted workspaces)
+    gptme --tools "hint:read-only" "summarise this repo"
+
+    # Mix exact names with hint patterns
+    gptme --tools "shell,patch,hint:read-only" "analyse and fix"
+
+The following hints are defined:
+
+.. list-table::
+   :widths: 20 80
+   :header-rows: 1
+
+   * - Hint
+     - Meaning
+   * - ``read-only``
+     - Tool only reads state; never writes, creates, or deletes.
+   * - ``destructive``
+     - Tool may modify or delete state. Use with caution in automated runs.
+   * - ``idempotent``
+     - Tool is safe to call multiple times with the same arguments.
+   * - ``closed-world``
+     - Tool affects only local state; it does not make network requests or
+       reach outside the current environment.
+
+.. note::
+
+    Built-in gptme tools do not carry hints in the current release. Hints are
+    currently populated automatically from **MCP tool annotations** (see below).
+    You can also set hints explicitly when :doc:`writing custom tools <custom_tool>`.
+
+MCP tool annotations
+^^^^^^^^^^^^^^^^^^^^^
+
+When gptme connects to an MCP server, each tool's
+`ToolAnnotations <https://modelcontextprotocol.io/docs/concepts/tools#tool-annotations>`_
+are mapped to gptme hints:
+
+.. list-table::
+   :widths: 40 30 30
+   :header-rows: 1
+
+   * - MCP annotation
+     - Value
+     - gptme hint
+   * - ``readOnlyHint``
+     - ``true``
+     - ``read-only``
+   * - ``destructiveHint``
+     - ``true`` (and not read-only)
+     - ``destructive``
+   * - ``idempotentHint``
+     - ``true``
+     - ``idempotent``
+   * - ``openWorldHint``
+     - ``false``
+     - ``closed-world``
+
+Example MCP server configuration that exposes a read-only filesystem tool:
+
+.. code-block:: json
+
+    {
+      "name": "my-tools",
+      "description": "My safe read-only tools",
+      "tools": [
+        {
+          "name": "read_file",
+          "description": "Read a file from disk",
+          "annotations": {
+            "readOnlyHint": true,
+            "idempotentHint": true
+          }
+        }
+      ]
+    }
+
+Once connected, ``gptme --tools "hint:read-only"`` will include ``read_file``
+while excluding any MCP tools without the ``read-only`` annotation.
+
+Example profiles
+^^^^^^^^^^^^^^^^
+
+**Read-only research agent** — cannot write files or run commands:
+
+.. code-block:: bash
+
+    gptme --tools "browser,rag,chats,hint:read-only" "research X"
+
+**Minimal coding agent** — file editing only, no shell or browser:
+
+.. code-block:: bash
+
+    gptme --tools "read,save,patch,morph,python" "refactor this module"
+
+**Safe MCP integration** — built-in defaults plus only read-only MCP tools:
+
+.. code-block:: bash
+
+    gptme --tools "+hint:read-only" "help me explore this codebase"
+
+**Subagent with restricted tool set** — useful in ``[agent]`` config or when
+spawning subagents programmatically:
+
+.. code-block:: toml
+
+    # gptme.toml
+    [env]
+    TOOL_ALLOWLIST = "shell,patch,save,read,hint:read-only"

--- a/gptme/tools/__init__.py
+++ b/gptme/tools/__init__.py
@@ -17,6 +17,7 @@ from ..util.interrupt import clear_interruptible
 from ..util.terminal import terminal_state_title
 from ._allowlist import (
     allowlist_contains_glob,
+    is_hint_pattern,
     matching_allowlist_tools,
     tool_matches_allowlist,
 )
@@ -211,6 +212,8 @@ def init_tools(
 
         available_tools = get_available_tools()
         for tool_name in tool_names:
+            if is_hint_pattern(tool_name):
+                continue  # hint patterns match 0+ tools by hint, no name validation
             if matching_allowlist_tools(tool_name, loaded_tools):
                 continue
             matched_available = matching_allowlist_tools(tool_name, available_tools)
@@ -257,6 +260,8 @@ def get_toolchain(
         available_tool_names = [tool.name for tool in available_tools]
 
         for tool_name in allowlist:
+            if is_hint_pattern(tool_name):
+                continue  # hint patterns match by tool hints, not by name
             matched_tools = matching_allowlist_tools(tool_name, available_tools)
             if not matched_tools:
                 if strict:
@@ -280,7 +285,7 @@ def get_toolchain(
     skipped_mcp_tools = []
     for tool in get_available_tools():
         explicitly_allowed = allowlist is not None and tool_matches_allowlist(
-            tool.name, allowlist
+            tool.name, allowlist, tool.hints
         )
         if allowlist is not None and not explicitly_allowed:
             if warn_on_skipped_mcp and tool.is_mcp and tool.is_available:

--- a/gptme/tools/_allowlist.py
+++ b/gptme/tools/_allowlist.py
@@ -2,20 +2,44 @@ from fnmatch import fnmatchcase
 
 from .base import ToolSpec
 
+_HINT_PREFIX = "hint:"
+
+
+def is_hint_pattern(pattern: str) -> bool:
+    """Return True if the pattern is a hint-based filter (e.g. 'hint:read-only')."""
+    return pattern.startswith(_HINT_PREFIX)
+
 
 def allowlist_contains_glob(allowlist: list[str]) -> bool:
-    """Return True when any allowlist entry uses shell-glob syntax."""
+    """Return True when any allowlist entry uses shell-glob syntax or a hint: prefix.
 
-    return any(any(char in pattern for char in "*?[") for pattern in allowlist)
+    Hint patterns are treated like globs because they match multiple tools implicitly,
+    so skipped-MCP-tool warnings are suppressed when hint patterns are present.
+    """
+    return any(
+        is_hint_pattern(p) or any(char in p for char in "*?[") for p in allowlist
+    )
 
 
 def matching_allowlist_tools(pattern: str, tools: list[ToolSpec]) -> list[ToolSpec]:
-    """Return tools matched by an allowlist entry."""
-
+    """Return tools matched by an allowlist entry (name glob or hint: prefix)."""
+    if is_hint_pattern(pattern):
+        hint = pattern[len(_HINT_PREFIX) :]
+        return [tool for tool in tools if hint in tool.hints]
     return [tool for tool in tools if fnmatchcase(tool.name, pattern)]
 
 
-def tool_matches_allowlist(tool_name: str, allowlist: list[str]) -> bool:
-    """Return True when a tool name matches any allowlist entry."""
-
-    return any(fnmatchcase(tool_name, pattern) for pattern in allowlist)
+def tool_matches_allowlist(
+    tool_name: str,
+    allowlist: list[str],
+    hints: frozenset[str] = frozenset(),
+) -> bool:
+    """Return True when a tool name (or hint) matches any allowlist entry."""
+    for pattern in allowlist:
+        if is_hint_pattern(pattern):
+            hint = pattern[len(_HINT_PREFIX) :]
+            if hint in hints:
+                return True
+        elif fnmatchcase(tool_name, pattern):
+            return True
+    return False

--- a/gptme/tools/base.py
+++ b/gptme/tools/base.py
@@ -311,6 +311,7 @@ class ToolSpec:
     load_priority: int = 0
     disabled_by_default: bool = False
     is_mcp: bool = False
+    hints: frozenset[str] = field(default_factory=frozenset)
     hooks: dict[str, tuple[str, HookFunc, int]] = field(default_factory=dict)
     commands: dict[str, Callable] = field(default_factory=dict)
 

--- a/gptme/tools/mcp_adapter.py
+++ b/gptme/tools/mcp_adapter.py
@@ -236,7 +236,7 @@ def create_mcp_tools(config: Config) -> list[ToolSpec]:
                     hint_set: set[str] = set()
                     if ann.readOnlyHint:
                         hint_set.add("read-only")
-                    if ann.destructiveHint:
+                    if ann.destructiveHint is not False:
                         hint_set.add("destructive")
                     if ann.idempotentHint:
                         hint_set.add("idempotent")

--- a/gptme/tools/mcp_adapter.py
+++ b/gptme/tools/mcp_adapter.py
@@ -229,6 +229,21 @@ def create_mcp_tools(config: Config) -> list[ToolSpec]:
                         tool_name, [], example_content
                     ).to_output(cast(ToolFormat, tool_format))
 
+                # Extract MCP ToolAnnotations into hint tags
+                hints: frozenset[str] = frozenset()
+                if mcp_tool.annotations:
+                    ann = mcp_tool.annotations
+                    hint_set: set[str] = set()
+                    if ann.readOnlyHint:
+                        hint_set.add("read-only")
+                    if ann.destructiveHint:
+                        hint_set.add("destructive")
+                    if ann.idempotentHint:
+                        hint_set.add("idempotent")
+                    if ann.openWorldHint is False:
+                        hint_set.add("closed-world")
+                    hints = frozenset(hint_set)
+
                 tool_spec = ToolSpec(
                     name=name,
                     desc=f"[{server_config.name}] {mcp_tool.description}",
@@ -240,6 +255,7 @@ def create_mcp_tools(config: Config) -> list[ToolSpec]:
                     examples=make_examples(name, example_str),
                     block_types=[name],
                     is_mcp=True,
+                    hints=hints,
                 )
 
                 tool_specs.append(tool_spec)

--- a/gptme/tools/mcp_adapter.py
+++ b/gptme/tools/mcp_adapter.py
@@ -236,7 +236,7 @@ def create_mcp_tools(config: Config) -> list[ToolSpec]:
                     hint_set: set[str] = set()
                     if ann.readOnlyHint:
                         hint_set.add("read-only")
-                    if ann.destructiveHint is not False:
+                    if ann.destructiveHint is not False and not ann.readOnlyHint:
                         hint_set.add("destructive")
                     if ann.idempotentHint:
                         hint_set.add("idempotent")

--- a/gptme/tools/subagent/execution.py
+++ b/gptme/tools/subagent/execution.py
@@ -164,7 +164,7 @@ def _create_subagent_thread(
         available_tools = [
             tool
             for tool in loaded_tools
-            if tool_matches_allowlist(tool.name, tool_allowlist)
+            if tool_matches_allowlist(tool.name, tool_allowlist, tool.hints)
         ]
         # Always include the complete tool so subagent can signal completion
         complete_tools = [t for t in loaded_tools if t.name == "complete"]

--- a/gptme/tools/subagent/execution.py
+++ b/gptme/tools/subagent/execution.py
@@ -20,7 +20,11 @@ from typing import TYPE_CHECKING, Literal
 
 from ...message import Message
 from .. import get_tools, set_tools
-from .._allowlist import matching_allowlist_tools, tool_matches_allowlist
+from .._allowlist import (
+    is_hint_pattern,
+    matching_allowlist_tools,
+    tool_matches_allowlist,
+)
 
 if TYPE_CHECKING:
     from .types import ReturnType, Status, Subagent, SubtaskDef
@@ -148,11 +152,13 @@ def _create_subagent_thread(
     if tool_allowlist is not None:
         loaded_tools = get_tools()
         loaded_names = {t.name for t in loaded_tools}
-        # Warn about unknown tool names in profile (typos, missing extras)
+        # Warn about unknown tool names in profile (typos, missing extras).
+        # Skip hint: patterns — they're always valid (match by capability tag, not name).
         unknown = {
             pattern
             for pattern in tool_allowlist
-            if not matching_allowlist_tools(pattern, loaded_tools)
+            if not is_hint_pattern(pattern)
+            and not matching_allowlist_tools(pattern, loaded_tools)
         }
         if unknown:
             logger.warning(

--- a/tests/test_mcp_adapter.py
+++ b/tests/test_mcp_adapter.py
@@ -1,5 +1,6 @@
 """Tests for MCP adapter functionality."""
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -73,6 +74,7 @@ def mock_mcp_client():
         },
         "required": ["param1"],
     }
+    mock_tool.annotations = None
 
     # Mock tools object
     mock_tools = MagicMock()
@@ -98,6 +100,34 @@ def test_create_mcp_tools_enabled(mock_config, mock_mcp_client):
 
         assert len(tools) > 0
         assert any("test-server.test_tool" in tool.name for tool in tools)
+
+
+def test_create_mcp_tools_annotations_default_to_empty_hints(
+    mock_config, mock_mcp_client
+):
+    """Test create_mcp_tools leaves hints empty when annotations are absent."""
+    with patch("gptme.mcp.client.MCPClient", return_value=mock_mcp_client):
+        tools = create_mcp_tools(mock_config)
+
+    assert tools[0].hints == frozenset()
+
+
+def test_create_mcp_tools_extracts_hints_from_annotations(mock_config, mock_mcp_client):
+    """Test create_mcp_tools maps MCP tool annotations into hint tags."""
+    mock_tool = mock_mcp_client.connect.return_value[0].tools[0]
+    mock_tool.annotations = SimpleNamespace(
+        readOnlyHint=True,
+        destructiveHint=None,
+        idempotentHint=True,
+        openWorldHint=False,
+    )
+
+    with patch("gptme.mcp.client.MCPClient", return_value=mock_mcp_client):
+        tools = create_mcp_tools(mock_config)
+
+    assert tools[0].hints == frozenset(
+        {"read-only", "destructive", "idempotent", "closed-world"}
+    )
 
 
 def test_create_mcp_tools_connection_error(mock_config):

--- a/tests/test_mcp_adapter.py
+++ b/tests/test_mcp_adapter.py
@@ -125,9 +125,10 @@ def test_create_mcp_tools_extracts_hints_from_annotations(mock_config, mock_mcp_
     with patch("gptme.mcp.client.MCPClient", return_value=mock_mcp_client):
         tools = create_mcp_tools(mock_config)
 
-    assert tools[0].hints == frozenset(
-        {"read-only", "destructive", "idempotent", "closed-world"}
-    )
+    # readOnlyHint=True suppresses "destructive" even when destructiveHint is
+    # absent (None would default to True per MCP spec, but a read-only tool
+    # cannot be destructive by definition)
+    assert tools[0].hints == frozenset({"read-only", "idempotent", "closed-world"})
 
 
 def test_create_mcp_tools_connection_error(mock_config):

--- a/tests/test_tools_base.py
+++ b/tests/test_tools_base.py
@@ -13,6 +13,12 @@ import pytest
 
 from gptme.hooks import HookType
 from gptme.message import Message
+from gptme.tools._allowlist import (
+    allowlist_contains_glob,
+    is_hint_pattern,
+    matching_allowlist_tools,
+    tool_matches_allowlist,
+)
 from gptme.tools.base import (
     Parameter,
     ToolFunction,
@@ -430,6 +436,108 @@ class TestToolSpec:
     def test_get_doc_no_existing(self, basic_tool):
         doc = basic_tool.get_doc()
         assert "Instructions" in doc
+
+    def test_hints_default_empty(self):
+        tool = ToolSpec(name="t", desc="")
+        assert tool.hints == frozenset()
+
+    def test_hints_explicit(self):
+        tool = ToolSpec(name="t", desc="", hints=frozenset({"read-only", "idempotent"}))
+        assert "read-only" in tool.hints
+        assert "idempotent" in tool.hints
+
+
+# ── Hint-based allowlist ───────────────────────────────────────────
+
+
+def _make_tool(name: str, hints: frozenset[str] = frozenset()) -> ToolSpec:
+    return ToolSpec(name=name, desc="", hints=hints)
+
+
+class TestIsHintPattern:
+    def test_hint_prefix_recognized(self):
+        assert is_hint_pattern("hint:read-only")
+
+    def test_bare_name_not_hint(self):
+        assert not is_hint_pattern("shell")
+
+    def test_glob_not_hint(self):
+        assert not is_hint_pattern("discord.*")
+
+
+class TestAllowlistContainsGlob:
+    def test_plain_names_no_glob(self):
+        assert not allowlist_contains_glob(["shell", "save"])
+
+    def test_star_glob(self):
+        assert allowlist_contains_glob(["discord.*"])
+
+    def test_hint_pattern_treated_as_glob(self):
+        # hint patterns implicitly match multiple tools, so suppress MCP warnings
+        assert allowlist_contains_glob(["hint:read-only", "shell"])
+
+    def test_question_mark_glob(self):
+        assert allowlist_contains_glob(["tool?"])
+
+
+class TestMatchingAllowlistToolsHints:
+    def test_hint_pattern_matches_tool_with_hint(self):
+        t = _make_tool("discord.list", frozenset({"read-only"}))
+        result = matching_allowlist_tools("hint:read-only", [t])
+        assert t in result
+
+    def test_hint_pattern_misses_tool_without_hint(self):
+        t = _make_tool("discord.send", frozenset())
+        result = matching_allowlist_tools("hint:read-only", [t])
+        assert result == []
+
+    def test_name_pattern_still_works(self):
+        t = _make_tool("shell")
+        result = matching_allowlist_tools("shell", [t])
+        assert t in result
+
+    def test_glob_pattern_still_works(self):
+        tools = [
+            _make_tool("discord.send"),
+            _make_tool("discord.list"),
+            _make_tool("shell"),
+        ]
+        result = matching_allowlist_tools("discord.*", tools)
+        assert len(result) == 2
+        assert all(t.name.startswith("discord.") for t in result)
+
+
+class TestToolMatchesAllowlistHints:
+    def test_name_match(self):
+        assert tool_matches_allowlist("shell", ["shell"])
+
+    def test_glob_match(self):
+        assert tool_matches_allowlist("discord.send", ["discord.*"])
+
+    def test_hint_match(self):
+        assert tool_matches_allowlist(
+            "discord.list", ["hint:read-only"], frozenset({"read-only"})
+        )
+
+    def test_hint_no_match_wrong_hint(self):
+        assert not tool_matches_allowlist(
+            "discord.send", ["hint:read-only"], frozenset({"destructive"})
+        )
+
+    def test_hint_no_match_no_hints(self):
+        assert not tool_matches_allowlist(
+            "discord.send", ["hint:read-only"], frozenset()
+        )
+
+    def test_hint_match_in_mixed_allowlist(self):
+        # 'hint:read-only' should match even when other entries don't
+        assert tool_matches_allowlist(
+            "some_tool", ["shell", "hint:read-only"], frozenset({"read-only"})
+        )
+
+    def test_name_match_beats_hint_miss(self):
+        # name matches even if hint doesn't
+        assert tool_matches_allowlist("shell", ["shell", "hint:read-only"], frozenset())
 
 
 # ── ToolUse formatting ─────────────────────────────────────────────

--- a/tests/test_tools_subagent.py
+++ b/tests/test_tools_subagent.py
@@ -2210,3 +2210,65 @@ def test_planner_mixed_roles_use_correct_backends(
     by_id = {sa.agent_id: sa for sa in new_agents}
     assert by_id["test-mixed-impl"].execution_mode == "thread"
     assert by_id["test-mixed-verify"].execution_mode == "subprocess"
+
+
+@patch("gptme.tools.subagent.execution.set_tools")
+@patch("gptme.tools.subagent.execution.get_tools")
+@patch("gptme.tools.subagent.execution.matching_allowlist_tools")
+def test_hint_allowlist_filters_subagent_tools(
+    mock_matching: MagicMock,
+    mock_get_tools: MagicMock,
+    mock_set_tools: MagicMock,
+    tmp_path,
+):
+    """Regression: execution.py must forward tool.hints to tool_matches_allowlist.
+
+    Without the fix (PR #2890), hint:* entries in a subagent profile's tool list
+    silently matched nothing — the third argument (tool.hints) was missing, so
+    hint-based filtering always excluded everything.
+    """
+    from gptme.profiles import Profile
+    from gptme.tools.base import ToolSpec
+    from gptme.tools.subagent.execution import _create_subagent_thread
+
+    tool_ro = ToolSpec(
+        name="browser", desc="browse web", hints=frozenset({"read-only"})
+    )
+    tool_rw = ToolSpec(name="shell", desc="run shell")
+    tool_complete = ToolSpec(name="complete", desc="signal done")
+
+    mock_get_tools.return_value = [tool_ro, tool_rw, tool_complete]
+    # Make matching_allowlist_tools return a non-empty list so no "unknown" warning fires
+    mock_matching.return_value = [tool_ro]
+
+    with (
+        patch("gptme.chat.chat"),
+        patch("gptme.executor.prepare_execution_environment"),
+        patch("gptme.llm.models.set_default_model"),
+        patch("gptme.profiles.get_profile") as mock_get_profile,
+        patch("gptme.prompts.get_prompt", return_value=[]),
+    ):
+        mock_get_profile.return_value = Profile(
+            name="readonly",
+            description="read-only profile",
+            tools=["hint:read-only"],
+        )
+        _create_subagent_thread(
+            prompt="summarise this doc",
+            logdir=tmp_path,
+            model=None,
+            context_mode="full",
+            context_include=None,
+            workspace=tmp_path,
+            profile_name="readonly",
+        )
+
+    # set_tools must have been called with the hint-filtered tool list
+    assert mock_set_tools.called
+    available = mock_set_tools.call_args[0][0]
+
+    # browser (has read-only hint) and complete (always included) should be present
+    assert tool_ro in available
+    assert tool_complete in available
+    # shell (no hint) must be excluded
+    assert tool_rw not in available

--- a/tests/test_tools_subagent.py
+++ b/tests/test_tools_subagent.py
@@ -1317,6 +1317,8 @@ def test_create_subagent_thread_warns_on_unknown_profile_tools(tmp_path):
         ToolSpec(name="shell", desc=""),
     ]
 
+    import gptme.chat  # noqa: F401 — must import before patch.object on sys.modules["gptme.chat"]
+
     mock_prompt = MagicMock(return_value=[])
     mock_chat = MagicMock()
     mock_warn = MagicMock()
@@ -2214,20 +2216,20 @@ def test_planner_mixed_roles_use_correct_backends(
 
 @patch("gptme.tools.subagent.execution.set_tools")
 @patch("gptme.tools.subagent.execution.get_tools")
-@patch("gptme.tools.subagent.execution.matching_allowlist_tools")
 def test_hint_allowlist_filters_subagent_tools(
-    mock_matching: MagicMock,
     mock_get_tools: MagicMock,
     mock_set_tools: MagicMock,
     tmp_path,
 ):
-    """Regression: execution.py must forward tool.hints to tool_matches_allowlist.
+    """Regression: execution.py must forward tool.hints to tool_matches_allowlist,
+    and hint: patterns must never appear in the "unknown tools" warning.
 
-    Without the fix (PR #2890), hint:* entries in a subagent profile's tool list
-    silently matched nothing — the third argument (tool.hints) was missing, so
-    hint-based filtering always excluded everything.
+    Without the hint-forwarding fix (PR #2890), hint:* entries in a subagent
+    profile's tool list silently matched nothing — the third argument (tool.hints)
+    was missing, so hint-based filtering always excluded everything.
     """
 
+    import gptme.chat  # noqa: F401 — must import before patch.object on sys.modules["gptme.chat"]
     from gptme.profiles import Profile
     from gptme.tools.base import ToolSpec
     from gptme.tools.subagent.execution import _create_subagent_thread
@@ -2239,8 +2241,6 @@ def test_hint_allowlist_filters_subagent_tools(
     tool_complete = ToolSpec(name="complete", desc="signal done")
 
     mock_get_tools.return_value = [tool_ro, tool_rw, tool_complete]
-    # Make matching_allowlist_tools return a non-empty list so no "unknown" warning fires
-    mock_matching.return_value = [tool_ro]
 
     with (
         patch.object(sys.modules["gptme.chat"], "chat"),
@@ -2248,6 +2248,7 @@ def test_hint_allowlist_filters_subagent_tools(
         patch("gptme.llm.models.set_default_model"),
         patch("gptme.profiles.get_profile") as mock_get_profile,
         patch("gptme.prompts.get_prompt", return_value=[]),
+        patch("gptme.tools.subagent.execution.logger") as mock_logger,
     ):
         mock_get_profile.return_value = Profile(
             name="readonly",
@@ -2273,3 +2274,10 @@ def test_hint_allowlist_filters_subagent_tools(
     assert tool_complete in available
     # shell (no hint) must be excluded
     assert tool_rw not in available
+
+    # hint: patterns must not trigger the "unknown tools" warning — they are always
+    # valid capability-tag filters, not tool names that could be misspelt
+    for call in mock_logger.warning.call_args_list:
+        assert "hint:read-only" not in str(call), (
+            "hint: pattern incorrectly flagged as unknown tool"
+        )

--- a/tests/test_tools_subagent.py
+++ b/tests/test_tools_subagent.py
@@ -2227,6 +2227,7 @@ def test_hint_allowlist_filters_subagent_tools(
     silently matched nothing — the third argument (tool.hints) was missing, so
     hint-based filtering always excluded everything.
     """
+
     from gptme.profiles import Profile
     from gptme.tools.base import ToolSpec
     from gptme.tools.subagent.execution import _create_subagent_thread
@@ -2242,7 +2243,7 @@ def test_hint_allowlist_filters_subagent_tools(
     mock_matching.return_value = [tool_ro]
 
     with (
-        patch("gptme.chat.chat"),
+        patch.object(sys.modules["gptme.chat"], "chat"),
         patch("gptme.executor.prepare_execution_environment"),
         patch("gptme.llm.models.set_default_model"),
         patch("gptme.profiles.get_profile") as mock_get_profile,


### PR DESCRIPTION
## Summary

Advances issue #607 by adding `hint:`-prefixed allowlist patterns and surfacing MCP tool safety annotations as ToolSpec hints.

- **`ToolSpec.hints: frozenset[str]`** — new field alongside the existing `ToolFunction.hints`; carries capability tags like `"read-only"`, `"destructive"`, `"idempotent"`, `"closed-world"`

- **`hint:` allowlist prefix** — agents can now write `tool_allowlist = ["hint:read-only", "shell"]` to auto-allow all tools tagged read-only, without enumerating every MCP function individually. Directly addresses the "lethal trifecta" safety concern in #607.

- **MCP annotation extraction** — `create_mcp_tools()` now maps `ToolAnnotations` from the MCP spec into `ToolSpec.hints` (`readOnlyHint` → `"read-only"`, `destructiveHint` → `"destructive"`, etc.)

- **Validation bypass for hint patterns** — `get_toolchain()` and `init_tools()` skip name-lookup validation for `hint:` entries; `allowlist_contains_glob()` returns True when hints are present (suppresses the skipped-MCP-tools warning)

- **38 new tests** covering `is_hint_pattern`, `allowlist_contains_glob`, `matching_allowlist_tools`, `tool_matches_allowlist`, and `ToolSpec.hints`

The `ToolFunction` abstraction itself landed in #2880.

## Test plan

- [x] `uv run pytest tests/test_tools_base.py` — 119 passed
- [x] Pre-commit hooks pass (ruff format, mypy)