### PR TITLE
feat(subagent): configurable max_concurrent cap with semaphore gating

### DIFF
--- a/gptme/config/models.py
+++ b/gptme/config/models.py
@@ -252,6 +252,24 @@ class ArchitectConfig:
 
 
 @dataclass
+class SubagentConfig:
+    """Configuration for subagent execution."""
+
+    max_concurrent: int | None = None
+    """Maximum number of concurrently running subagents.
+
+    Controls how many subagents can run simultaneously. Excess subagents queue
+    and start as slots free up. Resolution order: ``GPTME_SUBAGENT_MAX_CONCURRENT``
+    env var > this field > ``min(8, cpu_count)`` default.
+
+    Example ``gptme.toml``::
+
+        [subagent]
+        max_concurrent = 4
+    """
+
+
+@dataclass
 class ProjectConfig:
     """Project-level configuration, such as which files to include in the context by default.
 
@@ -275,6 +293,8 @@ class ProjectConfig:
     plugins: PluginsConfig = field(default_factory=PluginsConfig)
 
     architect: ArchitectConfig = field(default_factory=ArchitectConfig)
+
+    subagent: SubagentConfig = field(default_factory=SubagentConfig)
 
     # Plugin-specific configuration namespace
     # Allows plugins to have their own config sections like [plugin.retrieval]
@@ -371,6 +391,10 @@ class ProjectConfig:
                 **{k: v for k, v in architect_data.items() if k in known_keys}
             )
 
+        subagent = _build_section(
+            "subagent", SubagentConfig, _pop_object_section(config_data, "subagent")
+        )
+
         # Warn about unknown keys and drop them instead of passing them through
         # as kwargs (which would crash with "unexpected keyword argument").
         if config_data:
@@ -394,6 +418,7 @@ class ProjectConfig:
             plugin=plugin_config,
             env=env,
             mcp=mcp,
+            subagent=subagent,
         )
 
     def merge(self, other: Self) -> Self:

--- a/gptme/tools/subagent/api.py
+++ b/gptme/tools/subagent/api.py
@@ -22,6 +22,8 @@ from .types import (
     Role,
     Subagent,
     SubtaskDef,
+    _subagent_results,
+    _subagent_results_lock,
     _subagents,
     _subagents_lock,
     resolve_role_defaults,
@@ -397,6 +399,13 @@ def subagent(
             _sem = get_slot_sem()
             _sem.acquire()
             try:
+                with _subagent_results_lock:
+                    if agent_id in _subagent_results:
+                        logger.info(
+                            f"Skipping cancelled queued subprocess subagent {agent_id}"
+                        )
+                        _exec._cleanup_isolation(sa)
+                        return
                 process = _exec._run_subagent_subprocess(
                     prompt=prompt,
                     logdir=logdir,

--- a/gptme/tools/subagent/api.py
+++ b/gptme/tools/subagent/api.py
@@ -417,7 +417,9 @@ def subagent(
                 logger.error(
                     f"Subagent {agent_id} subprocess failed: {e}", exc_info=True
                 )
-                if set_subagent_result_if_absent(agent_id, ReturnType("failure", str(e))):
+                if set_subagent_result_if_absent(
+                    agent_id, ReturnType("failure", str(e))
+                ):
                     notify_completion(agent_id, "failure", f"Subprocess failed: {e}")
                 _exec._cleanup_isolation(sa)
             finally:

--- a/gptme/tools/subagent/api.py
+++ b/gptme/tools/subagent/api.py
@@ -463,6 +463,18 @@ def subagent(
             _sem = get_slot_sem()
             _sem.acquire()
             try:
+                with _subagent_results_lock:
+                    if agent_id in _subagent_results:
+                        logger.info(
+                            f"Skipping cancelled queued thread subagent {agent_id}"
+                        )
+                        with _subagents_lock:
+                            sa = next(
+                                (s for s in _subagents if s.agent_id == agent_id), None
+                            )
+                        if sa:
+                            _exec._cleanup_isolation(sa)
+                        return
                 try:
                     _exec._create_subagent_thread(
                         prompt=prompt,

--- a/gptme/tools/subagent/api.py
+++ b/gptme/tools/subagent/api.py
@@ -279,69 +279,78 @@ def subagent(
             )
 
         def run_acp_subagent():
-            import asyncio
-
-            async def _acp_run():
-                from ...acp.client import GptmeAcpClient
-
-                collected_text: list[str] = []
-
-                def on_update(session_id: str, update) -> None:
-                    """Collect text from session updates."""
-                    # Extract text from agent_message_chunk updates
-                    update_type = getattr(update, "type", None)
-                    if update_type == "agent_message_chunk":
-                        chunk = getattr(update, "chunk", None)
-                        if chunk:
-                            text = getattr(chunk, "text", None) or (
-                                chunk.get("text") if isinstance(chunk, dict) else None
-                            )
-                            if text:
-                                collected_text.append(text)
-
-                async with GptmeAcpClient(
-                    workspace=workspace,
-                    command=acp_command,
-                    auto_confirm=True,
-                    on_update=on_update,
-                ) as client:
-                    result = await client.run(prompt, cwd=workspace)
-                    stop_reason = getattr(result, "stop_reason", "unknown")
-                    result_text = "".join(collected_text) if collected_text else None
-
-                    status = "success" if stop_reason == "end_turn" else "failure"
-                    summary = (
-                        result_text[:500]
-                        if result_text
-                        else f"ACP stop_reason={stop_reason}"
-                    )
-                    return status, summary
-
+            _sem = get_slot_sem()
+            _sem.acquire()
             try:
-                status, summary = asyncio.run(_acp_run())
+                import asyncio
 
-                result = ReturnType(status, summary)
-                if not set_subagent_result_if_absent(agent_id, result):
-                    return
-                notify_completion(
-                    agent_id,
-                    status,
-                    _exec._summarize_result(result, max_chars=200),
-                )
-            except Exception as e:
-                logger.error(f"ACP subagent {agent_id} failed: {e}", exc_info=True)
-                if not set_subagent_result_if_absent(
-                    agent_id, ReturnType("failure", str(e))
-                ):
-                    return
-                notify_completion(agent_id, "failure", f"ACP error: {e}")
-            finally:
-                with _subagents_lock:
-                    sa_ref = next(
-                        (s for s in _subagents if s.agent_id == agent_id), None
+                async def _acp_run():
+                    from ...acp.client import GptmeAcpClient
+
+                    collected_text: list[str] = []
+
+                    def on_update(session_id: str, update) -> None:
+                        """Collect text from session updates."""
+                        # Extract text from agent_message_chunk updates
+                        update_type = getattr(update, "type", None)
+                        if update_type == "agent_message_chunk":
+                            chunk = getattr(update, "chunk", None)
+                            if chunk:
+                                text = getattr(chunk, "text", None) or (
+                                    chunk.get("text")
+                                    if isinstance(chunk, dict)
+                                    else None
+                                )
+                                if text:
+                                    collected_text.append(text)
+
+                    async with GptmeAcpClient(
+                        workspace=workspace,
+                        command=acp_command,
+                        auto_confirm=True,
+                        on_update=on_update,
+                    ) as client:
+                        result = await client.run(prompt, cwd=workspace)
+                        stop_reason = getattr(result, "stop_reason", "unknown")
+                        result_text = (
+                            "".join(collected_text) if collected_text else None
+                        )
+
+                        status = "success" if stop_reason == "end_turn" else "failure"
+                        summary = (
+                            result_text[:500]
+                            if result_text
+                            else f"ACP stop_reason={stop_reason}"
+                        )
+                        return status, summary
+
+                try:
+                    status, summary = asyncio.run(_acp_run())
+
+                    result = ReturnType(status, summary)
+                    if not set_subagent_result_if_absent(agent_id, result):
+                        return
+                    notify_completion(
+                        agent_id,
+                        status,
+                        _exec._summarize_result(result, max_chars=200),
                     )
-                if sa_ref:
-                    _exec._cleanup_isolation(sa_ref)
+                except Exception as e:
+                    logger.error(f"ACP subagent {agent_id} failed: {e}", exc_info=True)
+                    if not set_subagent_result_if_absent(
+                        agent_id, ReturnType("failure", str(e))
+                    ):
+                        return
+                    notify_completion(agent_id, "failure", f"ACP error: {e}")
+                finally:
+                    with _subagents_lock:
+                        sa_ref = next(
+                            (s for s in _subagents if s.agent_id == agent_id), None
+                        )
+                    if sa_ref:
+                        _exec._cleanup_isolation(sa_ref)
+            finally:
+                _sem.release()
 
         t = threading.Thread(target=run_acp_subagent, daemon=True)
 
@@ -398,7 +407,10 @@ def subagent(
                     output_schema=output_schema_str,
                     profile=profile,
                 )
-                sa = Subagent(
+                # Create a local Subagent view with the real process for monitoring.
+                # The registered sa (in _subagents) has process=None / thread=launcher;
+                # we don't re-register to avoid a duplicate agent_id entry.
+                _sa_proc = Subagent(
                     agent_id=agent_id,
                     prompt=prompt,
                     thread=None,
@@ -412,18 +424,37 @@ def subagent(
                     repo_path=repo_path,
                     timeout=timeout,
                 )
-                with _subagents_lock:
-                    _subagents.append(sa)
                 # Monitor blocks until the process finishes (slot stays acquired)
-                _exec._monitor_subprocess(sa)
+                _exec._monitor_subprocess(_sa_proc)
             except Exception as e:
                 logger.error(
                     f"Subagent {agent_id} subprocess failed: {e}", exc_info=True
                 )
+                set_subagent_result_if_absent(agent_id, ReturnType("failure", str(e)))
+                notify_completion(agent_id, "failure", f"Subprocess failed: {e}")
             finally:
                 _sem.release()
 
         launcher = threading.Thread(target=_launch_subprocess, daemon=True)
+
+        # Pre-register with launcher thread so status/wait/cancel work while queued.
+        # process=None here; is_running() falls through to thread.is_alive().
+        sa = Subagent(
+            agent_id=agent_id,
+            prompt=prompt,
+            thread=launcher,
+            logdir=logdir,
+            model=model_name,
+            output_schema=output_schema,
+            process=None,
+            execution_mode="subprocess",
+            isolated=isolated,
+            worktree_path=worktree_path,
+            repo_path=repo_path,
+            timeout=timeout,
+        )
+        with _subagents_lock:
+            _subagents.append(sa)
         launcher.start()
     else:
         # Thread mode: original behavior, gated by the concurrency semaphore.

--- a/gptme/tools/subagent/api.py
+++ b/gptme/tools/subagent/api.py
@@ -284,6 +284,19 @@ def subagent(
             _sem = get_slot_sem()
             _sem.acquire()
             try:
+                with _subagent_results_lock:
+                    if agent_id in _subagent_results:
+                        logger.info(
+                            f"Skipping cancelled queued ACP subagent {agent_id}"
+                        )
+                        with _subagents_lock:
+                            sa = next(
+                                (s for s in _subagents if s.agent_id == agent_id), None
+                            )
+                        if sa:
+                            _exec._cleanup_isolation(sa)
+                        return
+
                 import asyncio
 
                 async def _acp_run():

--- a/gptme/tools/subagent/api.py
+++ b/gptme/tools/subagent/api.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import Literal
 
 from . import execution as _exec
+from .concurrency import get_slot_sem
 from .hooks import notify_completion
 from .types import (
     ReturnType,
@@ -365,7 +366,9 @@ def subagent(
         t.start()
 
     elif use_subprocess:
-        # Subprocess mode: better output isolation
+        # Subprocess mode: better output isolation, gated by the concurrency semaphore.
+        # A launcher thread acquires the slot before starting the OS process so that
+        # excess agents queue (rather than all starting at once).
         logger.info(f"Starting subagent {agent_id} in subprocess mode")
         if profile:
             logger.info(f"  with profile: {profile}")
@@ -381,63 +384,85 @@ def subagent(
                 # TypedDict or dataclass - create simple schema
                 output_schema_str = json.dumps({"type": "object"})
 
-        process = _exec._run_subagent_subprocess(
-            prompt=prompt,
-            logdir=logdir,
-            model=model_name,
-            workspace=workspace,
-            context_mode=context_mode,
-            context_include=context_include,
-            output_schema=output_schema_str,
-            profile=profile,
-        )
-
-        # Create Subagent with subprocess reference
-        sa = Subagent(
-            agent_id=agent_id,
-            prompt=prompt,
-            thread=None,
-            logdir=logdir,
-            model=model_name,
-            output_schema=output_schema,
-            process=process,
-            execution_mode="subprocess",
-            isolated=isolated,
-            worktree_path=worktree_path,
-            repo_path=repo_path,
-            timeout=timeout,
-        )
-        with _subagents_lock:
-            _subagents.append(sa)
-
-        # Start monitor thread for hook-based completion notification
-        monitor_thread = threading.Thread(
-            target=_exec._monitor_subprocess,
-            args=(sa,),
-            daemon=True,
-        )
-        monitor_thread.start()
-    else:
-        # Thread mode: original behavior
-        def run_subagent():
+        def _launch_subprocess():
+            _sem = get_slot_sem()
+            _sem.acquire()
             try:
-                _exec._create_subagent_thread(
+                process = _exec._run_subagent_subprocess(
                     prompt=prompt,
                     logdir=logdir,
                     model=model_name,
+                    workspace=workspace,
                     context_mode=context_mode,
                     context_include=context_include,
-                    workspace=workspace,
-                    target="parent",
-                    output_schema=output_schema,
-                    profile_name=profile,
+                    output_schema=output_schema_str,
+                    profile=profile,
                 )
+                sa = Subagent(
+                    agent_id=agent_id,
+                    prompt=prompt,
+                    thread=None,
+                    logdir=logdir,
+                    model=model_name,
+                    output_schema=output_schema,
+                    process=process,
+                    execution_mode="subprocess",
+                    isolated=isolated,
+                    worktree_path=worktree_path,
+                    repo_path=repo_path,
+                    timeout=timeout,
+                )
+                with _subagents_lock:
+                    _subagents.append(sa)
+                # Monitor blocks until the process finishes (slot stays acquired)
+                _exec._monitor_subprocess(sa)
             except Exception as e:
-                # If subagent creation fails, notify with error status
-                logger.error(f"Subagent {agent_id} failed during execution: {e}")
-                if not set_subagent_result_if_absent(
-                    agent_id, ReturnType("failure", str(e))
-                ):
+                logger.error(
+                    f"Subagent {agent_id} subprocess failed: {e}", exc_info=True
+                )
+            finally:
+                _sem.release()
+
+        launcher = threading.Thread(target=_launch_subprocess, daemon=True)
+        launcher.start()
+    else:
+        # Thread mode: original behavior, gated by the concurrency semaphore.
+        # The semaphore is acquired before starting LLM work and released in
+        # finally so excess agents queue until a slot opens.
+        def run_subagent():
+            _sem = get_slot_sem()
+            _sem.acquire()
+            try:
+                try:
+                    _exec._create_subagent_thread(
+                        prompt=prompt,
+                        logdir=logdir,
+                        model=model_name,
+                        context_mode=context_mode,
+                        context_include=context_include,
+                        workspace=workspace,
+                        target="parent",
+                        output_schema=output_schema,
+                        profile_name=profile,
+                    )
+                except Exception as e:
+                    # If subagent creation fails, notify with error status
+                    logger.error(f"Subagent {agent_id} failed during execution: {e}")
+                    if not set_subagent_result_if_absent(
+                        agent_id, ReturnType("failure", str(e))
+                    ):
+                        with _subagents_lock:
+                            sa = next(
+                                (s for s in _subagents if s.agent_id == agent_id), None
+                            )
+                        if sa:
+                            _exec._cleanup_isolation(sa)
+                        return
+                    try:
+                        notify_completion(agent_id, "failure", f"Execution failed: {e}")
+                    except Exception as notify_err:
+                        logger.warning(f"Failed to notify subagent error: {notify_err}")
+                    # Clean up worktree isolation even on failure
                     with _subagents_lock:
                         sa = next(
                             (s for s in _subagents if s.agent_id == agent_id), None
@@ -445,34 +470,26 @@ def subagent(
                     if sa:
                         _exec._cleanup_isolation(sa)
                     return
-                try:
-                    notify_completion(agent_id, "failure", f"Execution failed: {e}")
-                except Exception as notify_err:
-                    logger.warning(f"Failed to notify subagent error: {notify_err}")
-                # Clean up worktree isolation even on failure
+
+                # Notify via hook system when complete (only if successful)
                 with _subagents_lock:
                     sa = next((s for s in _subagents if s.agent_id == agent_id), None)
                 if sa:
+                    # Use _read_log() instead of status(): the thread is still alive here,
+                    # so status() would return "running" and poison the result cache.
+                    result = sa._read_log()
+                    if not set_subagent_result_if_absent(agent_id, result):
+                        _exec._cleanup_isolation(sa)
+                        return
+                    try:
+                        summary = _exec._summarize_result(result, max_chars=200)
+                        notify_completion(agent_id, result.status, summary)
+                    except Exception as e:
+                        logger.warning(f"Failed to notify subagent completion: {e}")
+                    # Clean up worktree isolation
                     _exec._cleanup_isolation(sa)
-                return
-
-            # Notify via hook system when complete (only if successful)
-            with _subagents_lock:
-                sa = next((s for s in _subagents if s.agent_id == agent_id), None)
-            if sa:
-                # Use _read_log() instead of status(): the thread is still alive here,
-                # so status() would return "running" and poison the result cache.
-                result = sa._read_log()
-                if not set_subagent_result_if_absent(agent_id, result):
-                    _exec._cleanup_isolation(sa)
-                    return
-                try:
-                    summary = _exec._summarize_result(result, max_chars=200)
-                    notify_completion(agent_id, result.status, summary)
-                except Exception as e:
-                    logger.warning(f"Failed to notify subagent completion: {e}")
-                # Clean up worktree isolation
-                _exec._cleanup_isolation(sa)
+            finally:
+                _sem.release()
 
         # Create thread (don't start yet)
         t = threading.Thread(

--- a/gptme/tools/subagent/api.py
+++ b/gptme/tools/subagent/api.py
@@ -407,31 +407,19 @@ def subagent(
                     output_schema=output_schema_str,
                     profile=profile,
                 )
-                # Create a local Subagent view with the real process for monitoring.
-                # The registered sa (in _subagents) has process=None / thread=launcher;
-                # we don't re-register to avoid a duplicate agent_id entry.
-                _sa_proc = Subagent(
-                    agent_id=agent_id,
-                    prompt=prompt,
-                    thread=None,
-                    logdir=logdir,
-                    model=model_name,
-                    output_schema=output_schema,
-                    process=process,
-                    execution_mode="subprocess",
-                    isolated=isolated,
-                    worktree_path=worktree_path,
-                    repo_path=repo_path,
-                    timeout=timeout,
-                )
+                # Subagent is a frozen dataclass; install the live process on the
+                # pre-registered object so queued agents become inspectable once
+                # they leave the semaphore.
+                object.__setattr__(sa, "process", process)
                 # Monitor blocks until the process finishes (slot stays acquired)
-                _exec._monitor_subprocess(_sa_proc)
+                _exec._monitor_subprocess(sa)
             except Exception as e:
                 logger.error(
                     f"Subagent {agent_id} subprocess failed: {e}", exc_info=True
                 )
-                set_subagent_result_if_absent(agent_id, ReturnType("failure", str(e)))
-                notify_completion(agent_id, "failure", f"Subprocess failed: {e}")
+                if set_subagent_result_if_absent(agent_id, ReturnType("failure", str(e))):
+                    notify_completion(agent_id, "failure", f"Subprocess failed: {e}")
+                _exec._cleanup_isolation(sa)
             finally:
                 _sem.release()
 

--- a/gptme/tools/subagent/concurrency.py
+++ b/gptme/tools/subagent/concurrency.py
@@ -1,0 +1,53 @@
+"""Concurrency limiter for parallel subagents.
+
+Provides a module-level semaphore that caps the number of concurrently running
+subagents. The limit is resolved at first use from (highest to lowest priority):
+
+1. ``GPTME_SUBAGENT_MAX_CONCURRENT`` environment variable
+2. ``[subagent] max_concurrent`` in ``gptme.toml``
+3. ``min(8, os.cpu_count() or 2)`` safe default (mirrors Claude Code's ``min(16, cores-2)``)
+"""
+
+import os
+import threading
+
+_slot_sem: threading.BoundedSemaphore | None = None
+_slot_sem_lock = threading.Lock()
+
+
+def _max_concurrent() -> int:
+    """Resolve max concurrent subagents from env > config > cpu-based default."""
+    env_val = os.environ.get("GPTME_SUBAGENT_MAX_CONCURRENT")
+    if env_val:
+        return int(env_val)
+    try:
+        from gptme.config import get_config
+
+        project = get_config().project
+        if project is not None:
+            mc = project.subagent.max_concurrent
+            if mc is not None:
+                return mc
+    except Exception:
+        pass
+    return min(8, os.cpu_count() or 2)
+
+
+def get_slot_sem() -> threading.BoundedSemaphore:
+    """Return the global concurrency semaphore, initializing lazily on first call."""
+    global _slot_sem
+    with _slot_sem_lock:
+        if _slot_sem is None:
+            _slot_sem = threading.BoundedSemaphore(_max_concurrent())
+        return _slot_sem
+
+
+def _reset_slot_sem(max_concurrent: int | None = None) -> None:
+    """Reset the semaphore (for testing only)."""
+    global _slot_sem
+    with _slot_sem_lock:
+        _slot_sem = (
+            threading.BoundedSemaphore(max_concurrent)
+            if max_concurrent is not None
+            else None
+        )

--- a/gptme/tools/subagent/concurrency.py
+++ b/gptme/tools/subagent/concurrency.py
@@ -8,8 +8,11 @@ subagents. The limit is resolved at first use from (highest to lowest priority):
 3. ``min(8, os.cpu_count() or 2)`` safe default (mirrors Claude Code's ``min(16, cores-2)``)
 """
 
+import logging
 import os
 import threading
+
+logger = logging.getLogger(__name__)
 
 _slot_sem: threading.BoundedSemaphore | None = None
 _slot_sem_lock = threading.Lock()
@@ -19,7 +22,15 @@ def _max_concurrent() -> int:
     """Resolve max concurrent subagents from env > config > cpu-based default."""
     env_val = os.environ.get("GPTME_SUBAGENT_MAX_CONCURRENT")
     if env_val:
-        return int(env_val)
+        try:
+            val = int(env_val)
+            if val < 1:
+                raise ValueError(f"must be >= 1, got {val}")
+            return val
+        except ValueError as e:
+            logger.warning(
+                f"Ignoring invalid GPTME_SUBAGENT_MAX_CONCURRENT={env_val!r}: {e}"
+            )
     try:
         from gptme.config import get_config
 

--- a/gptme/tools/subagent/concurrency.py
+++ b/gptme/tools/subagent/concurrency.py
@@ -31,21 +31,21 @@ def _max_concurrent() -> int:
             logger.warning(
                 f"Ignoring invalid GPTME_SUBAGENT_MAX_CONCURRENT={env_val!r}: {e}"
             )
-    config_mc: int | None = None
     try:
         from gptme.config import get_config
 
         project = get_config().project
         if project is not None:
-            config_mc = project.subagent.max_concurrent
+            mc = project.subagent.max_concurrent
+            if mc is not None:
+                if mc < 1:
+                    logger.warning(
+                        f"Ignoring invalid [subagent] max_concurrent={mc!r}: must be >= 1"
+                    )
+                else:
+                    return mc
     except Exception:
         pass
-    if config_mc is not None:
-        if config_mc < 1:
-            raise ValueError(
-                f"[subagent] max_concurrent in gptme.toml must be >= 1, got {config_mc}"
-            )
-        return config_mc
     return min(8, os.cpu_count() or 2)
 
 
@@ -61,6 +61,8 @@ def get_slot_sem() -> threading.BoundedSemaphore:
 def _reset_slot_sem(max_concurrent: int | None = None) -> None:
     """Reset the semaphore (for testing only)."""
     global _slot_sem
+    if max_concurrent is not None and max_concurrent < 1:
+        raise ValueError(f"max_concurrent must be >= 1, got {max_concurrent}")
     with _slot_sem_lock:
         _slot_sem = (
             threading.BoundedSemaphore(max_concurrent)

--- a/gptme/tools/subagent/concurrency.py
+++ b/gptme/tools/subagent/concurrency.py
@@ -31,16 +31,21 @@ def _max_concurrent() -> int:
             logger.warning(
                 f"Ignoring invalid GPTME_SUBAGENT_MAX_CONCURRENT={env_val!r}: {e}"
             )
+    config_mc: int | None = None
     try:
         from gptme.config import get_config
 
         project = get_config().project
         if project is not None:
-            mc = project.subagent.max_concurrent
-            if mc is not None:
-                return mc
+            config_mc = project.subagent.max_concurrent
     except Exception:
         pass
+    if config_mc is not None:
+        if config_mc < 1:
+            raise ValueError(
+                f"[subagent] max_concurrent in gptme.toml must be >= 1, got {config_mc}"
+            )
+        return config_mc
     return min(8, os.cpu_count() or 2)
 
 

--- a/gptme/tools/subagent/execution.py
+++ b/gptme/tools/subagent/execution.py
@@ -613,6 +613,17 @@ def _run_planner(
                             f"Executor {_sa.agent_id} subprocess failed: {e}",
                             exc_info=True,
                         )
+                        from .hooks import notify_completion
+                        from .types import ReturnType, set_subagent_result_if_absent
+
+                        if set_subagent_result_if_absent(
+                            _sa.agent_id, ReturnType("failure", str(e))
+                        ):
+                            notify_completion(
+                                _sa.agent_id,
+                                "failure",
+                                f"Executor subprocess failed: {e}",
+                            )
                         _cleanup_isolation(_sa)
                         return
                     object.__setattr__(_sa, "process", process)

--- a/gptme/tools/subagent/execution.py
+++ b/gptme/tools/subagent/execution.py
@@ -25,6 +25,7 @@ from .._allowlist import (
     matching_allowlist_tools,
     tool_matches_allowlist,
 )
+from .concurrency import get_slot_sem
 
 if TYPE_CHECKING:
     from .types import ReturnType, Status, Subagent, SubtaskDef
@@ -573,55 +574,67 @@ def _run_planner(
                 )
 
         if resolved_use_subprocess:
-            # Subprocess mode: better output isolation for verify/sensitive roles
-            cleanup_sa = Subagent(
-                executor_id,
-                executor_prompt,
-                None,
-                logdir,
-                model,
-                execution_mode="subprocess",
-                isolated=resolved_isolated,
-                worktree_path=worktree_path,
-                repo_path=repo_path,
-            )
+            # Subprocess mode: a combined thread acquires the concurrency slot before
+            # Popen, monitors to completion, and releases in finally — same pattern as
+            # api.py _launch_subprocess. Captures all loop vars via default args.
+            def _run_executor_subprocess(
+                _prompt=executor_prompt,
+                _logdir=logdir,
+                _model=model,
+                _workspace=workspace,
+                _profile=resolved_profile,
+                _executor_id=executor_id,
+                _isolated=resolved_isolated,
+                _worktree_path=worktree_path,
+                _repo_path=repo_path,
+            ):
+                _sem = get_slot_sem()
+                _sem.acquire()
+                try:
+                    try:
+                        process = _run_subagent_subprocess(
+                            prompt=_prompt,
+                            logdir=_logdir,
+                            model=_model,
+                            workspace=_workspace,
+                            context_mode=context_mode,
+                            context_include=context_include,
+                            profile=_profile,
+                        )
+                    except Exception:
+                        _cleanup_isolation(
+                            Subagent(
+                                _executor_id,
+                                _prompt,
+                                None,
+                                _logdir,
+                                _model,
+                                execution_mode="subprocess",
+                                isolated=_isolated,
+                                worktree_path=_worktree_path,
+                                repo_path=_repo_path,
+                            )
+                        )
+                        raise
+                    sa = Subagent(
+                        _executor_id,
+                        _prompt,
+                        None,
+                        _logdir,
+                        _model,
+                        process=process,
+                        execution_mode="subprocess",
+                        isolated=_isolated,
+                        worktree_path=_worktree_path,
+                        repo_path=_repo_path,
+                    )
+                    with _subagents_lock:
+                        _subagents.append(sa)
+                    _monitor_subprocess(sa)
+                finally:
+                    _sem.release()
 
-            try:
-                process = _run_subagent_subprocess(
-                    prompt=executor_prompt,
-                    logdir=logdir,
-                    model=model,
-                    workspace=workspace,
-                    context_mode=context_mode,
-                    context_include=context_include,
-                    profile=resolved_profile,
-                )
-            except Exception:
-                _cleanup_isolation(cleanup_sa)
-                raise
-
-            sa = Subagent(
-                executor_id,
-                executor_prompt,
-                None,
-                logdir,
-                model,
-                process=process,
-                execution_mode="subprocess",
-                isolated=resolved_isolated,
-                worktree_path=worktree_path,
-                repo_path=repo_path,
-            )
-
-            with _subagents_lock:
-                _subagents.append(sa)
-
-            # Monitor thread handles completion notification and cleanup
-            monitor_t = threading.Thread(
-                target=_monitor_subprocess,
-                args=(sa,),
-                daemon=True,
-            )
+            monitor_t = threading.Thread(target=_run_executor_subprocess, daemon=True)
             monitor_t.start()
 
             # Sequential mode: wait for this executor before starting the next
@@ -651,6 +664,8 @@ def _run_planner(
                 subtask_profile=resolved_profile,
                 cleanup_subagent=cleanup_sa,
             ):
+                _sem = get_slot_sem()
+                _sem.acquire()
                 try:
                     _create_subagent_thread(
                         prompt=prompt,
@@ -664,6 +679,7 @@ def _run_planner(
                     )
                 finally:
                     _cleanup_isolation(cleanup_subagent)
+                    _sem.release()
 
             t = threading.Thread(target=run_executor, daemon=True)
             sa = Subagent(

--- a/gptme/tools/subagent/execution.py
+++ b/gptme/tools/subagent/execution.py
@@ -574,67 +574,55 @@ def _run_planner(
                 )
 
         if resolved_use_subprocess:
+            sa = Subagent(
+                executor_id,
+                executor_prompt,
+                None,
+                logdir,
+                model,
+                process=None,
+                execution_mode="subprocess",
+                isolated=resolved_isolated,
+                worktree_path=worktree_path,
+                repo_path=repo_path,
+            )
             # Subprocess mode: a combined thread acquires the concurrency slot before
             # Popen, monitors to completion, and releases in finally — same pattern as
             # api.py _launch_subprocess. Captures all loop vars via default args.
             def _run_executor_subprocess(
-                _prompt=executor_prompt,
-                _logdir=logdir,
-                _model=model,
+                _sa: "Subagent" = sa,
                 _workspace=workspace,
                 _profile=resolved_profile,
-                _executor_id=executor_id,
-                _isolated=resolved_isolated,
-                _worktree_path=worktree_path,
-                _repo_path=repo_path,
             ):
                 _sem = get_slot_sem()
                 _sem.acquire()
                 try:
                     try:
                         process = _run_subagent_subprocess(
-                            prompt=_prompt,
-                            logdir=_logdir,
-                            model=_model,
+                            prompt=_sa.prompt,
+                            logdir=_sa.logdir,
+                            model=_sa.model,
                             workspace=_workspace,
                             context_mode=context_mode,
                             context_include=context_include,
                             profile=_profile,
                         )
-                    except Exception:
-                        _cleanup_isolation(
-                            Subagent(
-                                _executor_id,
-                                _prompt,
-                                None,
-                                _logdir,
-                                _model,
-                                execution_mode="subprocess",
-                                isolated=_isolated,
-                                worktree_path=_worktree_path,
-                                repo_path=_repo_path,
-                            )
+                    except Exception as e:
+                        logger.error(
+                            f"Executor {_sa.agent_id} subprocess failed: {e}",
+                            exc_info=True,
                         )
-                        raise
-                    sa = Subagent(
-                        _executor_id,
-                        _prompt,
-                        None,
-                        _logdir,
-                        _model,
-                        process=process,
-                        execution_mode="subprocess",
-                        isolated=_isolated,
-                        worktree_path=_worktree_path,
-                        repo_path=_repo_path,
-                    )
-                    with _subagents_lock:
-                        _subagents.append(sa)
-                    _monitor_subprocess(sa)
+                        _cleanup_isolation(_sa)
+                        return
+                    object.__setattr__(_sa, "process", process)
+                    _monitor_subprocess(_sa)
                 finally:
                     _sem.release()
 
             monitor_t = threading.Thread(target=_run_executor_subprocess, daemon=True)
+            object.__setattr__(sa, "thread", monitor_t)
+            with _subagents_lock:
+                _subagents.append(sa)
             monitor_t.start()
 
             # Sequential mode: wait for this executor before starting the next

--- a/gptme/tools/subagent/execution.py
+++ b/gptme/tools/subagent/execution.py
@@ -491,7 +491,14 @@ def _run_planner(
     """
     from gptme.cli.main import get_logdir
 
-    from .types import Subagent, _subagents, _subagents_lock, resolve_role_defaults
+    from .types import (
+        Subagent,
+        _subagent_results,
+        _subagent_results_lock,
+        _subagents,
+        _subagents_lock,
+        resolve_role_defaults,
+    )
 
     logger.info(
         f"Starting planner {agent_id} with {len(subtasks)} subtasks "
@@ -598,6 +605,14 @@ def _run_planner(
                 _sem = get_slot_sem()
                 _sem.acquire()
                 try:
+                    with _subagent_results_lock:
+                        if _sa.agent_id in _subagent_results:
+                            logger.info(
+                                "Skipping cancelled queued planner subprocess "
+                                f"executor {_sa.agent_id}"
+                            )
+                            _cleanup_isolation(_sa)
+                            return
                     try:
                         process = _run_subagent_subprocess(
                             prompt=_sa.prompt,

--- a/gptme/tools/subagent/execution.py
+++ b/gptme/tools/subagent/execution.py
@@ -701,8 +701,15 @@ def _run_planner(
                         profile_name=subtask_profile,
                     )
                 finally:
-                    _cleanup_isolation(cleanup_subagent)
-                    _sem.release()
+                    try:
+                        _cleanup_isolation(cleanup_subagent)
+                    except Exception:
+                        logger.exception(
+                            "Failed to clean up isolated planner thread executor "
+                            f"{executor_agent_id}"
+                        )
+                    finally:
+                        _sem.release()
 
             t = threading.Thread(target=run_executor, daemon=True)
             sa = Subagent(

--- a/gptme/tools/subagent/execution.py
+++ b/gptme/tools/subagent/execution.py
@@ -586,6 +586,7 @@ def _run_planner(
                 worktree_path=worktree_path,
                 repo_path=repo_path,
             )
+
             # Subprocess mode: a combined thread acquires the concurrency slot before
             # Popen, monitors to completion, and releases in finally — same pattern as
             # api.py _launch_subprocess. Captures all loop vars via default args.

--- a/gptme/tools/subagent/execution.py
+++ b/gptme/tools/subagent/execution.py
@@ -673,6 +673,7 @@ def _run_planner(
             )
 
             def run_executor(
+                executor_agent_id=executor_id,
                 prompt=executor_prompt,
                 log_dir=logdir,
                 ws=workspace,
@@ -682,6 +683,13 @@ def _run_planner(
                 _sem = get_slot_sem()
                 _sem.acquire()
                 try:
+                    with _subagent_results_lock:
+                        if executor_agent_id in _subagent_results:
+                            logger.info(
+                                "Skipping cancelled queued planner thread "
+                                f"executor {executor_agent_id}"
+                            )
+                            return
                     _create_subagent_thread(
                         prompt=prompt,
                         logdir=log_dir,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,7 @@ from gptme.init import init
 from gptme.tools import clear_tools
 from gptme.tools import shell as shell_module
 from gptme.tools.rag import _has_gptme_rag
-from gptme.tools.subagent import _subagents
+from gptme.tools.subagent import _subagent_results, _subagent_results_lock, _subagents
 from gptme.tools.subagent.concurrency import _reset_slot_sem
 
 logger = logging.getLogger(__name__)
@@ -264,6 +264,11 @@ def cleanup_subagents_after():
                 subagent.process.kill()
     # Clear the subagents list
     _subagents.clear()
+    # Clear cached terminal results too; many tests intentionally reuse agent IDs
+    # like "explorer"/"checker", and the queued-cancel guards now treat a stale
+    # cached result as "already completed" and skip the new launch.
+    with _subagent_results_lock:
+        _subagent_results.clear()
     # Reset the concurrency semaphore so monitor threads from this test
     # don't starve the next test when running under xdist.  Monitor threads
     # capture the old semaphore object in their closure, so they release the

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,7 @@ from gptme.tools import clear_tools
 from gptme.tools import shell as shell_module
 from gptme.tools.rag import _has_gptme_rag
 from gptme.tools.subagent import _subagents
+from gptme.tools.subagent.concurrency import _reset_slot_sem
 
 logger = logging.getLogger(__name__)
 
@@ -263,6 +264,11 @@ def cleanup_subagents_after():
                 subagent.process.kill()
     # Clear the subagents list
     _subagents.clear()
+    # Reset the concurrency semaphore so monitor threads from this test
+    # don't starve the next test when running under xdist.  Monitor threads
+    # capture the old semaphore object in their closure, so they release the
+    # old sem (harmless) while the next test gets a fresh one.
+    _reset_slot_sem()
 
 
 @pytest.fixture

--- a/tests/test_hooks_cache_awareness.py
+++ b/tests/test_hooks_cache_awareness.py
@@ -578,7 +578,6 @@ class TestCacheColdHeuristic:
         assert is_cache_likely_cold() is False
 
     def test_get_elapsed_returns_none_before_first_call(self):
-
         assert get_elapsed_since_last_call() is None
 
     def test_recent_call_not_cold(self):

--- a/tests/test_subagent_concurrency.py
+++ b/tests/test_subagent_concurrency.py
@@ -39,6 +39,21 @@ class TestMaxConcurrent:
         monkeypatch.setenv("GPTME_SUBAGENT_MAX_CONCURRENT", "7")
         assert _max_concurrent() == 7
 
+    def test_env_var_invalid_string_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv("GPTME_SUBAGENT_MAX_CONCURRENT", "not-a-number")
+        val = _max_concurrent()
+        assert 1 <= val <= 16, f"fallback {val} not in reasonable range"
+
+    def test_env_var_zero_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv("GPTME_SUBAGENT_MAX_CONCURRENT", "0")
+        val = _max_concurrent()
+        assert val >= 1, "zero env var must not produce a deadlocking semaphore"
+
+    def test_env_var_negative_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv("GPTME_SUBAGENT_MAX_CONCURRENT", "-1")
+        val = _max_concurrent()
+        assert val >= 1, "negative env var must not produce a deadlocking semaphore"
+
 
 class TestGetSlotSem:
     def test_returns_bounded_semaphore(self):

--- a/tests/test_subagent_concurrency.py
+++ b/tests/test_subagent_concurrency.py
@@ -118,3 +118,40 @@ class TestConcurrencyEnforcement:
             t.join(timeout=5)
 
         assert peak[0] <= CAP, f"peak concurrency {peak[0]} exceeded cap {CAP}"
+
+    def test_planner_path_respects_semaphore(self, monkeypatch):
+        """Planner-spawned executors must go through the same semaphore as direct calls.
+
+        Simulate what _run_planner does: spawn N threads each calling get_slot_sem()
+        and confirm peak concurrency never exceeds the cap.
+        """
+        CAP = 2
+        N = 6
+        _reset_slot_sem(max_concurrent=CAP)
+
+        peak = [0]
+        current = [0]
+        lock = threading.Lock()
+
+        def executor_thread():
+            # Mimics what run_executor() in _run_planner does
+            _sem = get_slot_sem()
+            _sem.acquire()
+            try:
+                with lock:
+                    current[0] += 1
+                    if current[0] > peak[0]:
+                        peak[0] = current[0]
+                time.sleep(0.02)  # simulate LLM work
+                with lock:
+                    current[0] -= 1
+            finally:
+                _sem.release()
+
+        threads = [threading.Thread(target=executor_thread) for _ in range(N)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+
+        assert peak[0] <= CAP, f"planner executor peak {peak[0]} exceeded cap {CAP}"

--- a/tests/test_subagent_concurrency.py
+++ b/tests/test_subagent_concurrency.py
@@ -54,6 +54,36 @@ class TestMaxConcurrent:
         val = _max_concurrent()
         assert val >= 1, "negative env var must not produce a deadlocking semaphore"
 
+    def test_config_zero_falls_back_to_default(self, monkeypatch):
+        """Config max_concurrent=0 must warn and fall back to default, not deadlock."""
+        monkeypatch.delenv("GPTME_SUBAGENT_MAX_CONCURRENT", raising=False)
+        from unittest.mock import MagicMock, patch
+
+        mock_project = MagicMock()
+        mock_project.subagent.max_concurrent = 0
+        mock_config = MagicMock()
+        mock_config.project = mock_project
+        with patch("gptme.config.get_config", return_value=mock_config):
+            val = _max_concurrent()
+        assert val >= 1, (
+            "config max_concurrent=0 must not produce a deadlocking semaphore"
+        )
+
+    def test_config_negative_falls_back_to_default(self, monkeypatch):
+        """Config max_concurrent=-1 must warn and fall back to default."""
+        monkeypatch.delenv("GPTME_SUBAGENT_MAX_CONCURRENT", raising=False)
+        from unittest.mock import MagicMock, patch
+
+        mock_project = MagicMock()
+        mock_project.subagent.max_concurrent = -1
+        mock_config = MagicMock()
+        mock_config.project = mock_project
+        with patch("gptme.config.get_config", return_value=mock_config):
+            val = _max_concurrent()
+        assert val >= 1, (
+            "config max_concurrent=-1 must not raise into background threads"
+        )
+
 
 class TestGetSlotSem:
     def test_returns_bounded_semaphore(self):
@@ -70,6 +100,16 @@ class TestGetSlotSem:
         _reset_slot_sem()
         sem2 = get_slot_sem()
         assert sem1 is not sem2
+
+    def test_reset_zero_raises(self):
+        """_reset_slot_sem(0) must raise to prevent creating a deadlocking semaphore."""
+        with pytest.raises(ValueError, match="must be >= 1"):
+            _reset_slot_sem(0)
+
+    def test_reset_negative_raises(self):
+        """_reset_slot_sem(-1) must raise."""
+        with pytest.raises(ValueError, match="must be >= 1"):
+            _reset_slot_sem(-1)
 
     def test_reset_with_explicit_count(self, monkeypatch):
         monkeypatch.delenv("GPTME_SUBAGENT_MAX_CONCURRENT", raising=False)

--- a/tests/test_subagent_concurrency.py
+++ b/tests/test_subagent_concurrency.py
@@ -1,0 +1,105 @@
+"""Unit tests for subagent concurrency limiter."""
+
+import threading
+import time
+
+import pytest
+
+from gptme.tools.subagent.concurrency import (
+    _max_concurrent,
+    _reset_slot_sem,
+    get_slot_sem,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_semaphore():
+    """Reset the global semaphore before and after each test."""
+    _reset_slot_sem()
+    yield
+    _reset_slot_sem()
+
+
+class TestMaxConcurrent:
+    def test_env_var_takes_priority(self, monkeypatch):
+        monkeypatch.setenv("GPTME_SUBAGENT_MAX_CONCURRENT", "3")
+        assert _max_concurrent() == 3
+
+    def test_env_var_overrides_config(self, monkeypatch):
+        monkeypatch.setenv("GPTME_SUBAGENT_MAX_CONCURRENT", "2")
+        # Even if config would return something else, env wins
+        assert _max_concurrent() == 2
+
+    def test_default_is_reasonable(self, monkeypatch):
+        monkeypatch.delenv("GPTME_SUBAGENT_MAX_CONCURRENT", raising=False)
+        val = _max_concurrent()
+        assert 1 <= val <= 16, f"default {val} not in reasonable range [1, 16]"
+
+    def test_env_var_is_integer(self, monkeypatch):
+        monkeypatch.setenv("GPTME_SUBAGENT_MAX_CONCURRENT", "7")
+        assert _max_concurrent() == 7
+
+
+class TestGetSlotSem:
+    def test_returns_bounded_semaphore(self):
+        sem = get_slot_sem()
+        assert isinstance(sem, type(threading.BoundedSemaphore()))
+
+    def test_same_instance_on_repeated_calls(self):
+        sem1 = get_slot_sem()
+        sem2 = get_slot_sem()
+        assert sem1 is sem2
+
+    def test_reset_creates_new_instance(self):
+        sem1 = get_slot_sem()
+        _reset_slot_sem()
+        sem2 = get_slot_sem()
+        assert sem1 is not sem2
+
+    def test_reset_with_explicit_count(self, monkeypatch):
+        monkeypatch.delenv("GPTME_SUBAGENT_MAX_CONCURRENT", raising=False)
+        _reset_slot_sem(max_concurrent=4)
+        sem = get_slot_sem()
+        # Acquire 4 times — 5th should block (non-blocking acquire returns False)
+        acquired = [sem.acquire(blocking=False) for _ in range(4)]
+        assert all(acquired), "should acquire 4 times with cap=4"
+        assert not sem.acquire(blocking=False), "5th acquire should fail with cap=4"
+        # Release all
+        for _ in range(4):
+            sem.release()
+
+
+class TestConcurrencyEnforcement:
+    """Verify the semaphore actually caps concurrent executions."""
+
+    def test_cap_enforced_with_mock_workers(self, monkeypatch):
+        """N workers with cap=3: peak concurrency must not exceed 3."""
+        CAP = 3
+        N = 10
+        _reset_slot_sem(max_concurrent=CAP)
+        sem = get_slot_sem()
+
+        peak = [0]
+        current = [0]
+        lock = threading.Lock()
+
+        def worker():
+            sem.acquire()
+            try:
+                with lock:
+                    current[0] += 1
+                    if current[0] > peak[0]:
+                        peak[0] = current[0]
+                time.sleep(0.01)  # simulate work
+                with lock:
+                    current[0] -= 1
+            finally:
+                sem.release()
+
+        threads = [threading.Thread(target=worker) for _ in range(N)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=5)
+
+        assert peak[0] <= CAP, f"peak concurrency {peak[0]} exceeded cap {CAP}"

--- a/tests/test_subagent_integration.py
+++ b/tests/test_subagent_integration.py
@@ -1,0 +1,220 @@
+"""Integration tests for subagent cancel + max_concurrent lifecycle.
+
+Uses real threading with mocked LLM calls to exercise the semaphore-gating and
+cancel-lifecycle paths without requiring API keys.
+"""
+
+import queue
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+import gptme.tools.subagent.api as subagent_api
+from gptme.tools.subagent.api import subagent, subagent_cancel
+from gptme.tools.subagent.concurrency import _reset_slot_sem
+from gptme.tools.subagent.types import (
+    _completion_queue,
+    _subagent_results,
+    _subagent_results_lock,
+    _subagents,
+    _subagents_lock,
+)
+
+
+@pytest.fixture(autouse=True)
+def clean_subagent_state():
+    """Clear global subagent state BEFORE each test for a clean slate.
+
+    Post-test cleanup (thread join, process terminate, semaphore reset) is
+    handled by conftest.py's autouse ``cleanup_subagents_after`` fixture.
+    """
+    with _subagents_lock:
+        _subagents.clear()
+    with _subagent_results_lock:
+        _subagent_results.clear()
+    while not _completion_queue.empty():
+        try:
+            _completion_queue.get_nowait()
+        except queue.Empty:
+            break
+    _reset_slot_sem()
+    return
+
+
+class TestCancelLifecycle:
+    """Integration tests: cancel completes within deadline and marks result as failure."""
+
+    def _spawn_blocking_subagent(
+        self,
+        agent_id: str,
+        hold_event: threading.Event,
+        monkeypatch,
+        tmp_path: Path,
+    ) -> None:
+        """Spawn a subagent whose LLM call blocks until hold_event is set."""
+        import gptme.cli.main as cli_main
+        import gptme.llm.models as llm_models
+        import gptme.profiles as profiles
+
+        monkeypatch.setattr(cli_main, "get_logdir", lambda name: tmp_path / name)
+        monkeypatch.setattr(llm_models, "get_default_model", lambda: None)
+        monkeypatch.setattr(profiles, "get_profile", lambda _: None)
+
+        def blocking_thread(**kwargs):
+            hold_event.wait(timeout=30)
+
+        monkeypatch.setattr(
+            subagent_api._exec, "_create_subagent_thread", blocking_thread
+        )
+        monkeypatch.setattr(subagent_api._exec, "_cleanup_isolation", lambda sa: None)
+
+        subagent(agent_id, "do a thing")
+
+    def test_cancel_marks_result_as_failure(self, monkeypatch, tmp_path):
+        """Cancelled subagent result is failure/cancelled within 5 seconds."""
+        hold = threading.Event()
+
+        self._spawn_blocking_subagent("agent-a", hold, monkeypatch, tmp_path)
+
+        # Let the thread start and acquire the semaphore.
+        with _subagents_lock:
+            sa = next(s for s in _subagents if s.agent_id == "agent-a")
+        assert sa.thread is not None
+        time.sleep(0.1)
+
+        result_msg = subagent_cancel("agent-a")
+        assert "cancelled" in result_msg.lower()
+
+        with _subagent_results_lock:
+            result = _subagent_results.get("agent-a")
+        assert result is not None
+        assert result.status == "failure"
+        assert result.result is not None
+        assert "cancelled" in result.result.lower()
+
+        # Unblock the thread so it can exit cleanly.
+        hold.set()
+        sa.thread.join(timeout=5)
+        assert not sa.thread.is_alive(), "thread must exit within 5 s after unblock"
+
+    def test_cancel_of_finished_subagent_reports_not_running(
+        self, monkeypatch, tmp_path
+    ):
+        """Cancelling an already-completed subagent returns 'not running' message."""
+        hold = threading.Event()
+        hold.set()  # unblocked immediately → subagent completes right away
+
+        self._spawn_blocking_subagent("agent-done", hold, monkeypatch, tmp_path)
+
+        with _subagents_lock:
+            sa = next(s for s in _subagents if s.agent_id == "agent-done")
+        assert sa.thread is not None
+        sa.thread.join(timeout=5)
+        assert not sa.thread.is_alive()
+
+        result = subagent_cancel("agent-done")
+        assert "not running" in result.lower()
+
+
+class TestMaxConcurrentGating:
+    """Integration tests: slot freed by cancel allows a queued subagent to proceed."""
+
+    def test_cancel_releases_slot_for_second_subagent(self, monkeypatch, tmp_path):
+        """With max_concurrent=1, cancelling subagent-1 lets subagent-2 acquire the slot."""
+        import gptme.cli.main as cli_main
+        import gptme.llm.models as llm_models
+        import gptme.profiles as profiles
+
+        monkeypatch.setattr(cli_main, "get_logdir", lambda name: tmp_path / name)
+        monkeypatch.setattr(llm_models, "get_default_model", lambda: None)
+        monkeypatch.setattr(profiles, "get_profile", lambda _: None)
+
+        agent1_hold = threading.Event()
+        agent2_started = threading.Event()
+        agent2_hold = threading.Event()
+
+        call_count = [0]
+
+        def patched_create_thread(**kwargs):
+            idx = call_count[0]
+            call_count[0] += 1
+            if idx == 0:
+                agent1_hold.wait(timeout=30)
+            else:
+                agent2_started.set()
+                agent2_hold.wait(timeout=30)
+
+        monkeypatch.setattr(
+            subagent_api._exec, "_create_subagent_thread", patched_create_thread
+        )
+        monkeypatch.setattr(subagent_api._exec, "_cleanup_isolation", lambda sa: None)
+
+        _reset_slot_sem(max_concurrent=1)
+
+        subagent("agent-1", "task one")
+        subagent("agent-2", "task two")
+
+        # Give threads time to start; agent-1 holds the slot, agent-2 should block.
+        time.sleep(0.2)
+        assert not agent2_started.is_set(), (
+            "agent-2 must not enter LLM work while agent-1 holds the only slot"
+        )
+
+        # Cancel agent-1 (marks result as failure) then unblock its thread.
+        result_msg = subagent_cancel("agent-1")
+        assert "cancelled" in result_msg.lower()
+        agent1_hold.set()
+
+        # agent-1's thread releases the semaphore → agent-2 should acquire it.
+        assert agent2_started.wait(timeout=5), (
+            "agent-2 must acquire the slot within 5 s after agent-1 is cancelled+unblocked"
+        )
+
+        # Clean up agent-2.
+        agent2_hold.set()
+        with _subagents_lock:
+            sa2 = next(s for s in _subagents if s.agent_id == "agent-2")
+        assert sa2.thread is not None
+        sa2.thread.join(timeout=5)
+
+    def test_slot_available_after_natural_completion(self, monkeypatch, tmp_path):
+        """Slot freed by normal completion allows a queued subagent to run."""
+        import gptme.cli.main as cli_main
+        import gptme.llm.models as llm_models
+        import gptme.profiles as profiles
+
+        monkeypatch.setattr(cli_main, "get_logdir", lambda name: tmp_path / name)
+        monkeypatch.setattr(llm_models, "get_default_model", lambda: None)
+        monkeypatch.setattr(profiles, "get_profile", lambda _: None)
+
+        agent2_started = threading.Event()
+
+        call_count = [0]
+
+        def patched_create_thread(**kwargs):
+            idx = call_count[0]
+            call_count[0] += 1
+            if idx == 0:
+                return  # agent-1 completes immediately
+            agent2_started.set()
+
+        monkeypatch.setattr(
+            subagent_api._exec, "_create_subagent_thread", patched_create_thread
+        )
+        monkeypatch.setattr(subagent_api._exec, "_cleanup_isolation", lambda sa: None)
+
+        _reset_slot_sem(max_concurrent=1)
+
+        subagent("agent-x", "quick task")
+        subagent("agent-y", "queued task")
+
+        assert agent2_started.wait(timeout=5), (
+            "agent-y must start after agent-x completes naturally"
+        )
+
+        with _subagents_lock:
+            sa_y = next(s for s in _subagents if s.agent_id == "agent-y")
+        assert sa_y.thread is not None
+        sa_y.thread.join(timeout=5)

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -14,6 +14,7 @@ from unittest.mock import MagicMock
 import pytest
 
 import gptme.tools.subagent.api as subagent_api
+import gptme.tools.subagent.execution as subagent_execution
 from gptme.tools.subagent.api import subagent, subagent_cancel
 from gptme.tools.subagent.batch import BatchJob
 from gptme.tools.subagent.execution import _monitor_subprocess
@@ -644,5 +645,104 @@ class TestSubagentCancel:
         assert notify_calls == []
         with _subagent_results_lock:
             assert _subagent_results["proc-agent"] == ReturnType(
+                "failure", "Cancelled by orchestrator"
+            )
+
+    def test_cancelled_queued_subprocess_does_not_launch_after_slot_frees(
+        self, monkeypatch, tmp_path
+    ):
+        cli_main = importlib.import_module("gptme.cli.main")
+        llm_models = importlib.import_module("gptme.llm.models")
+        profiles = importlib.import_module("gptme.profiles")
+        git_worktree = importlib.import_module("gptme.util.git_worktree")
+        monkeypatch.setattr(cli_main, "get_logdir", lambda name: tmp_path / name)
+        monkeypatch.setattr(llm_models, "get_default_model", lambda: None)
+        monkeypatch.setattr(profiles, "get_profile", lambda _: None)
+        monkeypatch.setattr(git_worktree, "get_git_root", lambda _: None)
+
+        sem = threading.BoundedSemaphore(1)
+        assert sem.acquire(timeout=0)
+        monkeypatch.setattr(subagent_api, "get_slot_sem", lambda: sem)
+
+        launch_mock = MagicMock(return_value=MagicMock())
+        cleanup_calls: list[str] = []
+
+        monkeypatch.setattr(subagent_api._exec, "_run_subagent_subprocess", launch_mock)
+        monkeypatch.setattr(subagent_api._exec, "_monitor_subprocess", lambda sa: None)
+        monkeypatch.setattr(
+            subagent_api._exec,
+            "_cleanup_isolation",
+            lambda sa: cleanup_calls.append(sa.agent_id),
+        )
+
+        subagent("proc-agent", "do the thing", use_subprocess=True, isolated=True)
+
+        with _subagents_lock:
+            sa = next(s for s in _subagents if s.agent_id == "proc-agent")
+        assert sa.thread is not None
+
+        result = subagent_cancel("proc-agent")
+        assert "marked as cancelled" in result.lower()
+
+        sem.release()
+        sa.thread.join(timeout=1)
+        assert not sa.thread.is_alive()
+
+        launch_mock.assert_not_called()
+        assert cleanup_calls == ["proc-agent"]
+        with _subagent_results_lock:
+            assert _subagent_results["proc-agent"] == ReturnType(
+                "failure", "Cancelled by orchestrator"
+            )
+
+    def test_cancelled_queued_planner_subprocess_does_not_launch_after_slot_frees(
+        self, monkeypatch, tmp_path
+    ):
+        cli_main = importlib.import_module("gptme.cli.main")
+        llm_models = importlib.import_module("gptme.llm.models")
+        profiles = importlib.import_module("gptme.profiles")
+        git_worktree = importlib.import_module("gptme.util.git_worktree")
+        monkeypatch.setattr(cli_main, "get_logdir", lambda name: tmp_path / name)
+        monkeypatch.setattr(llm_models, "get_default_model", lambda: None)
+        monkeypatch.setattr(profiles, "get_profile", lambda _: None)
+        monkeypatch.setattr(git_worktree, "get_git_root", lambda _: None)
+
+        sem = threading.BoundedSemaphore(1)
+        assert sem.acquire(timeout=0)
+        monkeypatch.setattr(subagent_execution, "get_slot_sem", lambda: sem)
+
+        launch_mock = MagicMock(return_value=MagicMock())
+        cleanup_calls: list[str] = []
+
+        monkeypatch.setattr(subagent_execution, "_run_subagent_subprocess", launch_mock)
+        monkeypatch.setattr(subagent_execution, "_monitor_subprocess", lambda sa: None)
+        monkeypatch.setattr(
+            subagent_execution,
+            "_cleanup_isolation",
+            lambda sa: cleanup_calls.append(sa.agent_id),
+        )
+
+        subagent(
+            "planner-agent",
+            "context",
+            mode="planner",
+            subtasks=[{"id": "verify", "description": "Verify it", "role": "verify"}],
+        )
+
+        with _subagents_lock:
+            sa = next(s for s in _subagents if s.agent_id == "planner-agent-verify")
+        assert sa.thread is not None
+
+        result = subagent_cancel("planner-agent-verify")
+        assert "marked as cancelled" in result.lower()
+
+        sem.release()
+        sa.thread.join(timeout=1)
+        assert not sa.thread.is_alive()
+
+        launch_mock.assert_not_called()
+        assert cleanup_calls == ["planner-agent-verify"]
+        with _subagent_results_lock:
+            assert _subagent_results["planner-agent-verify"] == ReturnType(
                 "failure", "Cancelled by orchestrator"
             )

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -841,3 +841,46 @@ class TestSubagentCancel:
             assert _subagent_results["planner-agent-implement"] == ReturnType(
                 "failure", "Cancelled by orchestrator"
             )
+
+    def test_planner_thread_cleanup_failure_still_releases_semaphore(
+        self, monkeypatch, tmp_path
+    ):
+        cli_main = importlib.import_module("gptme.cli.main")
+        llm_models = importlib.import_module("gptme.llm.models")
+        profiles = importlib.import_module("gptme.profiles")
+        monkeypatch.setattr(cli_main, "get_logdir", lambda name: tmp_path / name)
+        monkeypatch.setattr(llm_models, "get_default_model", lambda: None)
+        monkeypatch.setattr(profiles, "get_profile", lambda _: None)
+
+        sem = threading.BoundedSemaphore(1)
+        monkeypatch.setattr(subagent_execution, "get_slot_sem", lambda: sem)
+        monkeypatch.setattr(
+            subagent_execution, "_create_subagent_thread", lambda **kwargs: None
+        )
+
+        cleanup_calls: list[str] = []
+
+        def fail_cleanup(sa):
+            cleanup_calls.append(sa.agent_id)
+            raise RuntimeError("cleanup boom")
+
+        monkeypatch.setattr(subagent_execution, "_cleanup_isolation", fail_cleanup)
+
+        subagent(
+            "planner-agent",
+            "context",
+            mode="planner",
+            subtasks=[
+                {"id": "implement", "description": "Implement it", "role": "implement"}
+            ],
+        )
+
+        with _subagents_lock:
+            sa = next(s for s in _subagents if s.agent_id == "planner-agent-implement")
+        assert sa.thread is not None
+
+        sa.thread.join(timeout=1)
+        assert not sa.thread.is_alive()
+        assert cleanup_calls == ["planner-agent-implement"]
+        assert sem.acquire(timeout=0.1)
+        sem.release()

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -589,3 +589,60 @@ class TestSubagentCancel:
             assert _subagent_results["thread-agent"] == ReturnType(
                 "failure", "Cancelled by orchestrator"
             )
+
+    def test_subprocess_launch_failure_cleans_isolation_when_cancel_wins_race(
+        self, monkeypatch, tmp_path
+    ):
+        cli_main = importlib.import_module("gptme.cli.main")
+        llm_models = importlib.import_module("gptme.llm.models")
+        profiles = importlib.import_module("gptme.profiles")
+        git_worktree = importlib.import_module("gptme.util.git_worktree")
+        monkeypatch.setattr(cli_main, "get_logdir", lambda name: tmp_path / name)
+        monkeypatch.setattr(llm_models, "get_default_model", lambda: None)
+        monkeypatch.setattr(profiles, "get_profile", lambda _: None)
+        monkeypatch.setattr(git_worktree, "get_git_root", lambda _: None)
+
+        def boom(**kwargs):
+            raise OSError("boom")
+
+        monkeypatch.setattr(subagent_api._exec, "_run_subagent_subprocess", boom)
+
+        cleanup_calls: list[str] = []
+        notify_calls: list[tuple[str, str, str]] = []
+
+        def fake_cleanup(sa: Subagent) -> None:
+            cleanup_calls.append(sa.agent_id)
+
+        def fake_notify_completion(agent_id: str, status: str, summary: str) -> None:
+            notify_calls.append((agent_id, status, summary))
+
+        def fake_set_subagent_result_if_absent(
+            agent_id: str, result: ReturnType
+        ) -> bool:
+            with _subagent_results_lock:
+                _subagent_results[agent_id] = ReturnType(
+                    "failure", "Cancelled by orchestrator"
+                )
+            return False
+
+        monkeypatch.setattr(subagent_api._exec, "_cleanup_isolation", fake_cleanup)
+        monkeypatch.setattr(subagent_api, "notify_completion", fake_notify_completion)
+        monkeypatch.setattr(
+            subagent_api,
+            "set_subagent_result_if_absent",
+            fake_set_subagent_result_if_absent,
+        )
+
+        subagent("proc-agent", "do the thing", use_subprocess=True, isolated=True)
+
+        with _subagents_lock:
+            sa = next(s for s in _subagents if s.agent_id == "proc-agent")
+        assert sa.thread is not None
+        sa.thread.join(timeout=1)
+        assert not sa.thread.is_alive()
+        assert cleanup_calls == ["proc-agent"]
+        assert notify_calls == []
+        with _subagent_results_lock:
+            assert _subagent_results["proc-agent"] == ReturnType(
+                "failure", "Cancelled by orchestrator"
+            )

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -695,6 +695,50 @@ class TestSubagentCancel:
                 "failure", "Cancelled by orchestrator"
             )
 
+    def test_cancelled_queued_thread_does_not_launch_after_slot_frees(
+        self, monkeypatch, tmp_path
+    ):
+        cli_main = importlib.import_module("gptme.cli.main")
+        llm_models = importlib.import_module("gptme.llm.models")
+        profiles = importlib.import_module("gptme.profiles")
+        monkeypatch.setattr(cli_main, "get_logdir", lambda name: tmp_path / name)
+        monkeypatch.setattr(llm_models, "get_default_model", lambda: None)
+        monkeypatch.setattr(profiles, "get_profile", lambda _: None)
+
+        sem = threading.BoundedSemaphore(1)
+        assert sem.acquire(timeout=0)
+        monkeypatch.setattr(subagent_api, "get_slot_sem", lambda: sem)
+
+        launch_mock = MagicMock()
+        cleanup_calls: list[str] = []
+
+        monkeypatch.setattr(subagent_api._exec, "_create_subagent_thread", launch_mock)
+        monkeypatch.setattr(
+            subagent_api._exec,
+            "_cleanup_isolation",
+            lambda sa: cleanup_calls.append(sa.agent_id),
+        )
+
+        subagent("thread-agent", "do the thing", isolated=True)
+
+        with _subagents_lock:
+            sa = next(s for s in _subagents if s.agent_id == "thread-agent")
+        assert sa.thread is not None
+
+        result = subagent_cancel("thread-agent")
+        assert "marked as cancelled" in result.lower()
+
+        sem.release()
+        sa.thread.join(timeout=1)
+        assert not sa.thread.is_alive()
+
+        launch_mock.assert_not_called()
+        assert cleanup_calls == ["thread-agent"]
+        with _subagent_results_lock:
+            assert _subagent_results["thread-agent"] == ReturnType(
+                "failure", "Cancelled by orchestrator"
+            )
+
     def test_cancelled_queued_planner_subprocess_does_not_launch_after_slot_frees(
         self, monkeypatch, tmp_path
     ):
@@ -744,5 +788,56 @@ class TestSubagentCancel:
         assert cleanup_calls == ["planner-agent-verify"]
         with _subagent_results_lock:
             assert _subagent_results["planner-agent-verify"] == ReturnType(
+                "failure", "Cancelled by orchestrator"
+            )
+
+    def test_cancelled_queued_planner_thread_does_not_launch_after_slot_frees(
+        self, monkeypatch, tmp_path
+    ):
+        cli_main = importlib.import_module("gptme.cli.main")
+        llm_models = importlib.import_module("gptme.llm.models")
+        profiles = importlib.import_module("gptme.profiles")
+        monkeypatch.setattr(cli_main, "get_logdir", lambda name: tmp_path / name)
+        monkeypatch.setattr(llm_models, "get_default_model", lambda: None)
+        monkeypatch.setattr(profiles, "get_profile", lambda _: None)
+
+        sem = threading.BoundedSemaphore(1)
+        assert sem.acquire(timeout=0)
+        monkeypatch.setattr(subagent_execution, "get_slot_sem", lambda: sem)
+
+        launch_mock = MagicMock()
+        cleanup_calls: list[str] = []
+
+        monkeypatch.setattr(subagent_execution, "_create_subagent_thread", launch_mock)
+        monkeypatch.setattr(
+            subagent_execution,
+            "_cleanup_isolation",
+            lambda sa: cleanup_calls.append(sa.agent_id),
+        )
+
+        subagent(
+            "planner-agent",
+            "context",
+            mode="planner",
+            subtasks=[
+                {"id": "implement", "description": "Implement it", "role": "implement"}
+            ],
+        )
+
+        with _subagents_lock:
+            sa = next(s for s in _subagents if s.agent_id == "planner-agent-implement")
+        assert sa.thread is not None
+
+        result = subagent_cancel("planner-agent-implement")
+        assert "marked as cancelled" in result.lower()
+
+        sem.release()
+        sa.thread.join(timeout=1)
+        assert not sa.thread.is_alive()
+
+        launch_mock.assert_not_called()
+        assert cleanup_calls == ["planner-agent-implement"]
+        with _subagent_results_lock:
+            assert _subagent_results["planner-agent-implement"] == ReturnType(
                 "failure", "Cancelled by orchestrator"
             )

--- a/tests/test_tools_subagent.py
+++ b/tests/test_tools_subagent.py
@@ -717,8 +717,8 @@ def test_subprocess_working_directory():
 @pytest.mark.slow
 def test_subprocess_full_flow_with_subagent_function():
     """Test the full subprocess flow using the subagent() function."""
-    import time
     import tempfile
+    import time
     from pathlib import Path
     from unittest.mock import patch
 

--- a/tests/test_tools_subagent.py
+++ b/tests/test_tools_subagent.py
@@ -493,20 +493,24 @@ def test_subprocess_mode_creates_process():
     mock_process.poll.return_value = None  # Process still running
 
     with patch(
-        "gptme.tools.subagent.execution.subprocess.Popen", return_value=mock_process
+        "gptme.tools.subagent.execution._run_subagent_subprocess",
+        return_value=mock_process,
     ):
         subagent(
             agent_id="test-subprocess",
             prompt="Simple test task",
             use_subprocess=True,
         )
+        # Wait while the patch is still active; otherwise the launcher thread can
+        # race past the context manager and call the real Popen.
+        _wait_for_new_subagent_threads(0)
 
-        # Verify subprocess was created
-        assert len(_subagents) >= 1
-        sa = next((s for s in _subagents if s.agent_id == "test-subprocess"), None)
-        assert sa is not None
-        assert sa.execution_mode == "subprocess"
-        assert sa.process is mock_process
+    # Verify subprocess was created
+    assert len(_subagents) >= 1
+    sa = next((s for s in _subagents if s.agent_id == "test-subprocess"), None)
+    assert sa is not None
+    assert sa.execution_mode == "subprocess"
+    assert sa.process is mock_process
 
 
 def test_subprocess_mode_command_construction():
@@ -527,22 +531,23 @@ def test_subprocess_mode_command_construction():
     _subagents.clear()
 
     with patch(
-        "gptme.tools.subagent.execution.subprocess.Popen", side_effect=capture_popen
+        "gptme.tools.subagent.execution._run_subagent_subprocess",
+        return_value=MagicMock(),
     ):
         subagent(
             agent_id="test-cmd",
             prompt="Test prompt for command",
             use_subprocess=True,
         )
+        # Keep the patch active until the launcher thread has built the command.
+        _wait_for_new_subagent_threads(0)
 
-    # Verify command structure
-    assert "-m" in captured_cmd
-    assert "gptme" in captured_cmd
-    assert "-n" in captured_cmd  # Non-interactive
-    assert "--no-confirm" in captured_cmd
-    assert (
-        "Test prompt for command" not in captured_cmd
-    )  # Prompt passed via stdin, not argv
+    # Command construction is now tested at the unit level; the async subprocess
+    # path delegates to _run_subagent_subprocess which is tested separately.
+    # Here we verify the subagent was created with correct mode.
+    sa = next((s for s in _subagents if s.agent_id == "test-cmd"), None)
+    assert sa is not None
+    assert sa.execution_mode == "subprocess"
 
 
 def test_subprocess_mode_completion_stored():
@@ -565,18 +570,16 @@ def test_subprocess_mode_completion_stored():
     mock_process.communicate.return_value = ("Success output", "")
 
     with patch(
-        "gptme.tools.subagent.execution.subprocess.Popen", return_value=mock_process
+        "gptme.tools.subagent.execution._run_subagent_subprocess",
+        return_value=mock_process,
     ):
         subagent(
             agent_id="test-complete",
             prompt="Task to complete",
             use_subprocess=True,
         )
-
-    # Give monitor thread time to process (it runs in daemon thread)
-    import time
-
-    time.sleep(0.5)
+        # Wait for launcher thread to complete while patch is active
+        _wait_for_new_subagent_threads(0)
 
     # Verify status can be retrieved
     status = subagent_status("test-complete")
@@ -714,6 +717,7 @@ def test_subprocess_working_directory():
 @pytest.mark.slow
 def test_subprocess_full_flow_with_subagent_function():
     """Test the full subprocess flow using the subagent() function."""
+    import time
     import tempfile
     from pathlib import Path
     from unittest.mock import patch
@@ -744,6 +748,12 @@ def test_subprocess_full_flow_with_subagent_function():
             sa = next((s for s in _subagents if s.agent_id == "subprocess-test"), None)
             assert sa is not None
             assert sa.execution_mode == "subprocess"
+
+            # The monitor thread stays alive while the subprocess runs; wait only
+            # for the process reference to appear on the pre-registered Subagent.
+            deadline = time.time() + 2.0
+            while sa.process is None and time.time() < deadline:
+                time.sleep(0.05)
             assert sa.process is not None
 
             # The process should have started
@@ -1282,19 +1292,22 @@ def test_subprocess_mode_with_profile():
     _subagents.clear()
 
     with patch(
-        "gptme.tools.subagent.execution.subprocess.Popen", side_effect=capture_popen
-    ):
+        "gptme.tools.subagent.execution._run_subagent_subprocess",
+        return_value=MagicMock(),
+    ) as mock_run:
         subagent(
             agent_id="test-subprocess-profile",
             prompt="Explore task",
             use_subprocess=True,
             profile="explorer",
         )
+        # Keep the patch active until the launcher thread has built the command.
+        _wait_for_new_subagent_threads(0)
 
-    # Verify --agent-profile flag is in the command
-    assert "--agent-profile" in captured_cmd
-    profile_idx = captured_cmd.index("--agent-profile")
-    assert captured_cmd[profile_idx + 1] == "explorer"
+    # Verify profile was passed to _run_subagent_subprocess
+    mock_run.assert_called_once()
+    sub_kwargs = mock_run.call_args[1]
+    assert sub_kwargs.get("profile") == "explorer"
 
 
 def test_create_subagent_thread_warns_on_unknown_profile_tools(tmp_path):
@@ -1663,6 +1676,9 @@ def test_role_verify_defaults_subprocess_and_isolated(
         role="verify",
     )
 
+    # Wait for launcher thread to execute (subprocess mode is now async)
+    _wait_for_new_subagent_threads(0)
+
     assert len(_subagents) == 1
     sa = _subagents[-1]
     # The subagent should be created in subprocess mode (not thread mode)
@@ -1798,10 +1814,15 @@ def test_role_verify_explicit_false_subprocess_opts_out(
     )
 
 
+@patch("gptme.tools.subagent.execution._run_subagent_subprocess")
 @patch("gptme.tools.subagent.execution._create_subagent_thread")
-def test_planner_subtask_role_passthrough(mock_create_thread: MagicMock):
+def test_planner_subtask_role_passthrough(
+    mock_create_thread: MagicMock, mock_run_subprocess: MagicMock
+):
     """Test that planner subtasks with role pass role through to spawned executor."""
     from gptme.tools.subagent import SubtaskDef, _subagents, subagent
+
+    mock_run_subprocess.return_value = MagicMock()  # fake Popen
 
     initial_count = len(_subagents)
 
@@ -1821,6 +1842,11 @@ def test_planner_subtask_role_passthrough(mock_create_thread: MagicMock):
     # Wait for threads to execute while the patch is still active; without this
     # the OS may schedule them after @patch exits and they call the real function.
     _wait_for_new_subagent_threads(initial_count, timeout=5.0)
+    # Additional wait for the verify subtask's closure thread (subprocess SA has
+    # thread=None so _wait_for_new_subagent_threads can't join it)
+    import time
+
+    time.sleep(0.3)
 
     # Should have spawned 3 executors
     assert len(_subagents) == initial_count + 3
@@ -1951,6 +1977,8 @@ def test_planner_subtask_role_overrides_planner_profile(
         subtasks=subtasks,
     )
 
+    _wait_for_new_subagent_threads(initial_count, timeout=1.0)
+
     # role=verify routes to subprocess backend (not thread mode)
     mock_run_subprocess.assert_called_once()
     sub_kwargs = mock_run_subprocess.call_args[1]
@@ -1996,6 +2024,8 @@ def test_planner_subtask_role_verify_uses_subprocess(
         subtasks=subtasks,
     )
 
+    _wait_for_new_subagent_threads(initial_count, timeout=1.0)
+
     # Subprocess backend should have been called for the verify subtask
     mock_run_subprocess.assert_called_once()
     call_kwargs = mock_run_subprocess.call_args[1]
@@ -2038,6 +2068,8 @@ def test_planner_subtask_role_verify_sets_isolated(
         subtasks=subtasks,
     )
 
+    _wait_for_new_subagent_threads(initial_count, timeout=1.0)
+
     new_agents = _subagents[initial_count:]
     assert len(new_agents) == 1
     sa = new_agents[0]
@@ -2065,18 +2097,21 @@ def test_planner_subtask_role_verify_cleans_isolation_on_launch_failure(
         {"id": "check3", "description": "Verify output", "role": "verify"},
     ]
 
-    with pytest.raises(OSError, match="boom"):
-        subagent(
-            agent_id="test-verify-launch-failure",
-            prompt="context",
-            mode="planner",
-            subtasks=subtasks,
-        )
+    subagent(
+        agent_id="test-verify-launch-failure",
+        prompt="context",
+        mode="planner",
+        subtasks=subtasks,
+    )
+
+    _wait_for_new_subagent_threads(initial_count, timeout=1.0)
 
     mock_run_subprocess.assert_called_once()
     mock_monitor.assert_not_called()
     mock_cleanup_isolation.assert_called_once()
-    assert len(_subagents) == initial_count
+    new_agents = _subagents[initial_count:]
+    assert len(new_agents) == 1
+    assert new_agents[0].execution_mode == "subprocess"
 
 
 @patch("gptme.tools.subagent.execution._create_subagent_thread")

--- a/tests/test_tools_subagent.py
+++ b/tests/test_tools_subagent.py
@@ -8,7 +8,7 @@ from gptme.tools.subagent import SubtaskDef, _subagents, subagent
 
 
 def _wait_for_new_subagent_threads(initial_count: int, timeout: float = 1.0) -> None:
-    """Join threads started by this test before asserting on mock call metadata."""
+    """Join spawned threads before a thread-mocking patch context can unwind."""
     for sa in _subagents[initial_count:]:
         if sa.thread is not None:
             sa.thread.join(timeout=timeout)
@@ -37,6 +37,7 @@ def test_planner_mode_spawns_executors(mock_create_thread: MagicMock):
         mode="planner",
         subtasks=subtasks,
     )
+    _wait_for_new_subagent_threads(initial_count)
 
     # Should have spawned 2 executor subagents
     assert len(_subagents) == initial_count + 2
@@ -50,6 +51,7 @@ def test_planner_mode_spawns_executors(mock_create_thread: MagicMock):
 @patch("gptme.tools.subagent.execution._create_subagent_thread")
 def test_planner_mode_executor_prompts(mock_create_thread: MagicMock):
     """Test that executor prompts include context and subtask description."""
+    initial_count = len(_subagents)
     subtasks: list[SubtaskDef] = [
         {"id": "task1", "description": "Do something specific"}
     ]
@@ -60,6 +62,7 @@ def test_planner_mode_executor_prompts(mock_create_thread: MagicMock):
         mode="planner",
         subtasks=subtasks,
     )
+    _wait_for_new_subagent_threads(initial_count)
 
     # Check the spawned executor has correct prompt
     executor = _subagents[-1]
@@ -73,6 +76,7 @@ def test_executor_mode_still_works(mock_create_thread: MagicMock):
     initial_count = len(_subagents)
 
     subagent(agent_id="test-executor", prompt="Simple task")
+    _wait_for_new_subagent_threads(initial_count)
 
     # Should spawn 1 executor
     assert len(_subagents) == initial_count + 1
@@ -101,6 +105,7 @@ def test_planner_parallel_mode(mock_create_thread: MagicMock):
         subtasks=subtasks,
         execution_mode="parallel",
     )
+    _wait_for_new_subagent_threads(initial_count)
 
     # All 3 executors should be spawned
     assert len(_subagents) == initial_count + 3
@@ -129,6 +134,7 @@ def test_planner_sequential_mode():
             subtasks=subtasks,
             execution_mode="sequential",
         )
+        _wait_for_new_subagent_threads(initial_count)
 
     # Should spawn 2 executors
     assert len(_subagents) == initial_count + 2
@@ -155,6 +161,7 @@ def test_planner_default_is_parallel(mock_create_thread: MagicMock):
         mode="planner",
         subtasks=subtasks,
     )
+    _wait_for_new_subagent_threads(initial_count)
 
     # Should spawn 1 executor (parallel is default)
     assert len(_subagents) == initial_count + 1
@@ -166,6 +173,7 @@ def test_context_mode_default_is_full(mock_create_thread: MagicMock):
     initial_count = len(_subagents)
 
     subagent(agent_id="test-full", prompt="Test with full context")
+    _wait_for_new_subagent_threads(initial_count)
 
     # Should spawn 1 executor with full context
     assert len(_subagents) == initial_count + 1
@@ -192,6 +200,7 @@ def test_context_mode_selective_with_tools(mock_create_thread: MagicMock):
         context_mode="selective",
         context_include=["tools"],
     )
+    _wait_for_new_subagent_threads(initial_count)
 
     # Should spawn 1 executor
     assert len(_subagents) == initial_count + 1
@@ -211,6 +220,7 @@ def test_context_mode_selective_with_agent(mock_create_thread: MagicMock):
         context_mode="selective",
         context_include=["agent"],
     )
+    _wait_for_new_subagent_threads(initial_count)
 
     # Should spawn 1 executor
     assert len(_subagents) == initial_count + 1
@@ -227,6 +237,7 @@ def test_context_mode_selective_with_workspace(mock_create_thread: MagicMock):
         context_mode="selective",
         context_include=["workspace"],
     )
+    _wait_for_new_subagent_threads(initial_count)
 
     # Should spawn 1 executor
     assert len(_subagents) == initial_count + 1
@@ -243,6 +254,7 @@ def test_context_mode_selective_multiple_components(mock_create_thread: MagicMoc
         context_mode="selective",
         context_include=["agent", "tools", "workspace"],
     )
+    _wait_for_new_subagent_threads(initial_count)
 
     # Should spawn 1 executor
     assert len(_subagents) == initial_count + 1
@@ -265,6 +277,7 @@ def test_planner_mode_with_context_modes(mock_create_thread: MagicMock):
         mode="planner",
         subtasks=subtasks,
     )
+    _wait_for_new_subagent_threads(initial_count)
 
     # Should spawn 2 executors
     assert len(_subagents) == initial_count + 2

--- a/tests/test_tools_subagent.py
+++ b/tests/test_tools_subagent.py
@@ -941,7 +941,9 @@ def test_subprocess_mode_execution_basic():
     sa = next((s for s in _subagents if s.agent_id == "test-subprocess-exec"), None)
     assert sa is not None
     assert sa.execution_mode == "subprocess"
-    assert sa.process is not None
+    # Launch now happens asynchronously behind the semaphore, so queued
+    # subprocess agents are visible before the child process exists.
+    assert sa.thread is not None
 
     # Wait for completion with a reasonable timeout
     result = subagent_wait("test-subprocess-exec", timeout=60)

--- a/tests/test_tools_subagent.py
+++ b/tests/test_tools_subagent.py
@@ -1577,6 +1577,71 @@ def test_acp_mode_handles_failure():
             assert result.status == "failure"
 
 
+def test_cancelled_queued_acp_does_not_launch_after_slot_frees():
+    """ACP subagents cancelled while queued must not start once a slot opens."""
+    import threading
+    from unittest.mock import AsyncMock, patch
+
+    from gptme.tools.subagent import (
+        _subagent_results,
+        _subagent_results_lock,
+        _subagents,
+        subagent,
+        subagent_cancel,
+    )
+
+    _subagents.clear()
+    with _subagent_results_lock:
+        _subagent_results.clear()
+
+    sem = threading.BoundedSemaphore(1)
+    assert sem.acquire(timeout=0)
+
+    mock_client = AsyncMock()
+    mock_client.run = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+    cleanup_calls: list[str] = []
+
+    with (
+        patch("gptme.acp.client.GptmeAcpClient", return_value=mock_client),
+        patch("gptme.tools.subagent.notify_completion") as mock_notify,
+        patch("gptme.tools.subagent.api.get_slot_sem", return_value=sem),
+        patch(
+            "gptme.tools.subagent.api._exec._cleanup_isolation",
+            side_effect=lambda sa: cleanup_calls.append(sa.agent_id),
+        ),
+    ):
+        subagent(
+            agent_id="test-acp-cancelled",
+            prompt="Do not run",
+            use_acp=True,
+            acp_command="fake-acp",
+        )
+
+        sa = next(s for s in _subagents if s.agent_id == "test-acp-cancelled")
+        assert sa.thread is not None
+
+        result = subagent_cancel("test-acp-cancelled")
+        assert "marked as cancelled" in result.lower()
+
+        sem.release()
+        sa.thread.join(timeout=10)
+        assert not sa.thread.is_alive()
+
+        mock_client.__aenter__.assert_not_awaited()
+        mock_client.run.assert_not_awaited()
+        mock_notify.assert_not_called()
+        assert cleanup_calls == ["test-acp-cancelled"]
+
+    with _subagent_results_lock:
+        assert _subagent_results["test-acp-cancelled"].status == "failure"
+        assert (
+            _subagent_results["test-acp-cancelled"].result
+            == "Cancelled by orchestrator"
+        )
+
+
 def test_acp_mode_subagent_batch():
     """Test that subagent_batch forwards use_acp and acp_command to subagent()."""
     from unittest.mock import AsyncMock, MagicMock, patch

--- a/webui/server.py
+++ b/webui/server.py
@@ -18,7 +18,7 @@ class SPAHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
     def list_directory(self, path):
         """Disable directory listing."""
         self.send_error(403, "Directory listing not allowed")
-        return None
+        return
 
     def do_GET(self):
         """Handle GET requests with SPA fallback."""


### PR DESCRIPTION
## Summary

- Adds `gptme/tools/subagent/concurrency.py`: module-level `BoundedSemaphore` that caps how many subagents run simultaneously. Excess agents queue and start as slots free — same pattern as Claude Code's `min(16, cpu_cores-2)` cap.
- Thread mode: semaphore acquired before LLM work starts, released in `finally` (held for full agent lifetime).
- Subprocess mode: launcher thread acquires slot before `Popen`, holds through `_monitor_subprocess`, releases in `finally`.
- New `SubagentConfig` dataclass + `[subagent]` section in `ProjectConfig` for `gptme.toml` support.
- 9 new unit tests in `tests/test_subagent_concurrency.py` (env var resolution, semaphore singleton, peak-concurrency enforcement).

**Configuration (priority order):**
1. `GPTME_SUBAGENT_MAX_CONCURRENT` env var
2. `[subagent] max_concurrent` in `gptme.toml`
3. `min(8, cpu_count)` default

Example config:
```toml
[subagent]
max_concurrent = 4
```

## Test plan

- [x] `pytest tests/test_subagent_concurrency.py` — 9/9 pass
- [x] `pytest tests/test_subagent_unit.py` — 45/45 pass (no regressions)
- [x] Config round-trip: `ProjectConfig.from_dict({'subagent': {'max_concurrent': 5}}).subagent.max_concurrent == 5`
- [x] All pre-commit hooks pass (ruff, mypy, format)
- [ ] Run CI

Closes #554 (partial — concurrent cap is one piece of the better-subagents initiative)