### PR TITLE
feat(tools): ToolSpec.from_function() + parameter extraction in from_callable

### DIFF
--- a/gptme/tools/base.py
+++ b/gptme/tools/base.py
@@ -505,7 +505,7 @@ class ToolSpec:
 
         Auto-generates name, description, and parameters from the function
         signature and docstring. The returned ToolSpec has an execute handler
-        that calls fn(**kwargs) directly — no IPython required.
+        that calls ``fn(**kwargs)`` directly — no IPython required.
 
         Note: All values received via the ``kwargs`` channel are strings
         (``dict[str, str]``). Functions whose parameters require non-string

--- a/gptme/tools/base.py
+++ b/gptme/tools/base.py
@@ -211,8 +211,11 @@ class ToolFunction:
         doc = inspect.getdoc(fn) or ""
         description = doc.split("\n\n")[0] if doc else ""
 
+        _SKIP_KINDS = {inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD}
         params: list[Parameter] = []
         for param_name, param in sig.parameters.items():
+            if param.kind in _SKIP_KINDS:
+                continue
             annotation = param.annotation
             type_str = (
                 "any"
@@ -503,9 +506,20 @@ class ToolSpec:
         Auto-generates name, description, and parameters from the function
         signature and docstring. The returned ToolSpec has an execute handler
         that calls fn(**kwargs) directly — no IPython required.
+
+        Note: All values received via the ``kwargs`` channel are strings
+        (``dict[str, str]``). Functions whose parameters require non-string
+        types (``int``, ``float``, ``bool``, etc.) must perform their own
+        coercion inside the function body.
         """
         tf = ToolFunction.from_callable(fn)
         captured_params = tf.parameters
+        sig = inspect.signature(fn)
+        pos_only_names = [
+            name
+            for name, p in sig.parameters.items()
+            if p.kind == inspect.Parameter.POSITIONAL_ONLY
+        ]
 
         def execute(
             code: str | None,
@@ -519,7 +533,15 @@ class ToolSpec:
                 for i, param in enumerate(captured_params):
                     if i < len(args):
                         call_kwargs[param.name] = args[i]
-            result = fn(**call_kwargs)
+            if pos_only_names:
+                pos_vals = [
+                    call_kwargs.pop(name)
+                    for name in pos_only_names
+                    if name in call_kwargs
+                ]
+                result = fn(*pos_vals, **call_kwargs)
+            else:
+                result = fn(**call_kwargs)
             if result is not None:
                 yield Message("system", str(result))
 

--- a/gptme/tools/base.py
+++ b/gptme/tools/base.py
@@ -202,12 +202,32 @@ class ToolFunction:
 
     @classmethod
     def from_callable(cls, fn: Any, group: str | None = None) -> ToolFunction:
-        """Construct a ToolFunction from a plain callable, inferring metadata."""
+        """Construct a ToolFunction from a plain callable, inferring metadata.
+
+        Populates name, description (first docstring paragraph), and parameters
+        (from type annotations + inspect.signature). No IPython import required.
+        """
+        sig = inspect.signature(fn)
+        doc = inspect.getdoc(fn) or ""
+        description = doc.split("\n\n")[0] if doc else ""
+
+        params: list[Parameter] = []
+        for param_name, param in sig.parameters.items():
+            annotation = param.annotation
+            type_str = (
+                "any"
+                if annotation is inspect.Parameter.empty
+                else derive_type(annotation)
+            )
+            required = param.default is inspect.Parameter.empty
+            params.append(Parameter(name=param_name, type=type_str, required=required))
+
         return cls(
             name=fn.__name__,
             fn=fn,
-            description=fn.__doc__ or "",
+            description=description,
             group=group,
+            parameters=params,
         )
 
 
@@ -475,6 +495,40 @@ class ToolSpec:
                 lines.append(f"{sig}: {doc}")
             return description + "\n".join(lines) + "\n```"
         return "None"
+
+    @classmethod
+    def from_function(cls, fn: Callable) -> ToolSpec:
+        """Create a ToolSpec from a plain Python function.
+
+        Auto-generates name, description, and parameters from the function
+        signature and docstring. The returned ToolSpec has an execute handler
+        that calls fn(**kwargs) directly — no IPython required.
+        """
+        tf = ToolFunction.from_callable(fn)
+        captured_params = tf.parameters
+
+        def execute(
+            code: str | None,
+            args: list[str] | None,
+            kwargs: dict[str, str] | None,
+        ) -> Generator[Message, None, None]:
+            call_kwargs: dict[str, Any] = {}
+            if kwargs:
+                call_kwargs = dict(kwargs)
+            elif args:
+                for i, param in enumerate(captured_params):
+                    if i < len(args):
+                        call_kwargs[param.name] = args[i]
+            result = fn(**call_kwargs)
+            if result is not None:
+                yield Message("system", str(result))
+
+        return cls(
+            name=tf.name,
+            desc=tf.description,
+            parameters=list(captured_params),
+            execute=execute,
+        )
 
 
 @dataclass(frozen=True)

--- a/tests/test_tools_base.py
+++ b/tests/test_tools_base.py
@@ -338,6 +338,24 @@ class TestToolFunction:
         tf = ToolFunction.from_callable(fn)
         assert tf.parameters == []
 
+    def test_from_callable_skips_variadic(self):
+        def fn(*args: str, **kwargs: str) -> None:
+            pass
+
+        tf = ToolFunction.from_callable(fn)
+        assert tf.parameters == []
+
+    def test_from_callable_skips_variadic_mixed(self):
+        def fn(name: str, *args: str, flag: bool = False, **kwargs: str) -> None:
+            pass
+
+        tf = ToolFunction.from_callable(fn)
+        names = [p.name for p in tf.parameters]
+        assert "name" in names
+        assert "flag" in names
+        assert "args" not in names
+        assert "kwargs" not in names
+
 
 # ── ToolSpec ───────────────────────────────────────────────────────
 
@@ -567,6 +585,28 @@ class TestToolSpecFromFunction:
 
         spec = ToolSpec.from_function(fn)
         assert spec.is_runnable
+
+    def test_execute_positional_only_via_kwargs(self):
+        """Positional-only params must not cause TypeError when called via kwargs."""
+
+        def fn(x: str, /) -> str:
+            return f"got:{x}"
+
+        spec = ToolSpec.from_function(fn)
+        assert spec.execute is not None
+        msgs = list(spec.execute(None, None, {"x": "hello"}))  # type: ignore[arg-type]
+        assert any("got:hello" in m.content for m in msgs)
+
+    def test_execute_positional_only_via_args(self):
+        """Positional-only params work via the positional-args path too."""
+
+        def fn(x: str, /) -> str:
+            return f"got:{x}"
+
+        spec = ToolSpec.from_function(fn)
+        assert spec.execute is not None
+        msgs = list(spec.execute(None, ["world"], None))  # type: ignore[arg-type]
+        assert any("got:world" in m.content for m in msgs)
 
 
 # ── Hint-based allowlist ───────────────────────────────────────────

--- a/tests/test_tools_base.py
+++ b/tests/test_tools_base.py
@@ -292,6 +292,52 @@ class TestToolFunction:
         desc = spec.get_functions_description()
         assert "Custom description" in desc
 
+    def test_from_callable_extracts_parameters(self):
+        def greet(name: str, repeat: int) -> str:
+            """Say hello."""
+            return f"hello {name}" * repeat
+
+        tf = ToolFunction.from_callable(greet)
+        assert len(tf.parameters) == 2
+        assert tf.parameters[0].name == "name"
+        assert tf.parameters[0].type == "str"
+        assert tf.parameters[0].required is True
+        assert tf.parameters[1].name == "repeat"
+        assert tf.parameters[1].type == "int"
+
+    def test_from_callable_optional_parameter(self):
+        def fn(path: str, encoding: str = "utf-8") -> str:
+            return ""
+
+        tf = ToolFunction.from_callable(fn)
+        assert tf.parameters[0].required is True
+        assert tf.parameters[1].required is False
+
+    def test_from_callable_unannotated_parameter(self):
+        def fn(x) -> None:
+            pass
+
+        tf = ToolFunction.from_callable(fn)
+        assert tf.parameters[0].type == "any"
+
+    def test_from_callable_description_first_paragraph_only(self):
+        def fn() -> None:
+            """First paragraph.
+
+            Second paragraph with details.
+            """
+
+        tf = ToolFunction.from_callable(fn)
+        assert tf.description == "First paragraph."
+        assert "Second paragraph" not in tf.description
+
+    def test_from_callable_no_params(self):
+        def fn() -> str:
+            return "ok"
+
+        tf = ToolFunction.from_callable(fn)
+        assert tf.parameters == []
+
 
 # ── ToolSpec ───────────────────────────────────────────────────────
 
@@ -445,6 +491,82 @@ class TestToolSpec:
         tool = ToolSpec(name="t", desc="", hints=frozenset({"read-only", "idempotent"}))
         assert "read-only" in tool.hints
         assert "idempotent" in tool.hints
+
+
+# ── ToolSpec.from_function ─────────────────────────────────────────
+
+
+class TestToolSpecFromFunction:
+    def test_basic_metadata(self):
+        def greet(name: str) -> str:
+            """Greet someone by name."""
+            return f"Hello, {name}!"
+
+        spec = ToolSpec.from_function(greet)
+        assert spec.name == "greet"
+        assert spec.desc == "Greet someone by name."
+
+    def test_parameters_extracted(self):
+        def add(a: int, b: int) -> int:
+            """Add two numbers."""
+            return a + b
+
+        spec = ToolSpec.from_function(add)
+        assert len(spec.parameters) == 2
+        assert spec.parameters[0].name == "a"
+        assert spec.parameters[0].type == "int"
+        assert spec.parameters[0].required is True
+        assert spec.parameters[1].name == "b"
+
+    def test_execute_via_kwargs(self):
+        def add(a: int, b: int) -> int:
+            """Add two numbers."""
+            return int(a) + int(b)
+
+        spec = ToolSpec.from_function(add)
+        assert spec.execute is not None
+        msgs = list(spec.execute(None, None, {"a": "3", "b": "4"}))  # type: ignore[arg-type]
+        assert any("7" in m.content for m in msgs)
+
+    def test_execute_via_positional_args(self):
+        def echo(text: str) -> str:
+            """Echo text back."""
+            return text
+
+        spec = ToolSpec.from_function(echo)
+        assert spec.execute is not None
+        msgs = list(spec.execute(None, ["hello"], None))  # type: ignore[arg-type]
+        assert any("hello" in m.content for m in msgs)
+
+    def test_execute_returns_none_produces_no_message(self):
+        def noop() -> None:
+            pass
+
+        spec = ToolSpec.from_function(noop)
+        assert spec.execute is not None
+        msgs = list(spec.execute(None, None, None))  # type: ignore[arg-type]
+        assert msgs == []
+
+    def test_no_ipython_import(self):
+        """from_function path must not trigger an IPython import."""
+        import sys
+
+        def fn(x: str) -> str:
+            """Returns x."""
+            return x
+
+        before = "IPython" in sys.modules
+        ToolSpec.from_function(fn)
+        after = "IPython" in sys.modules
+        # IPython should not have been newly imported by from_function
+        assert before == after
+
+    def test_is_runnable(self):
+        def fn(x: str) -> str:
+            return x
+
+        spec = ToolSpec.from_function(fn)
+        assert spec.is_runnable
 
 
 # ── Hint-based allowlist ───────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `ToolFunction.from_callable` now auto-populates `parameters` from `inspect.signature` + type annotations. Each parameter gets `name`, `type` (via `derive_type`), and `required` (True when no default). Description is extracted as the first paragraph of the docstring only.
- New `ToolSpec.from_function(fn)` classmethod: wraps any Python function as a `ToolSpec` with auto-generated name/desc/parameters and a direct `execute` handler that calls `fn(**kwargs)` — no IPython import required.
- 13 new unit tests covering parameter extraction, optional/unannotated params, first-paragraph doc, and all `from_function` paths (kwargs, positional args, None return, no-IPython-import, is_runnable).

Closes #607 (partial — `from_function` classmethod as requested; IPython-tool function listing is a separate follow-on).

## Test plan

- [x] All 25 relevant `TestToolFunction` + `TestToolSpecFromFunction` + `TestParameter` tests pass
- [x] Existing `TestToolFunction` tests (10) still pass — no regressions
- [x] mypy clean on `gptme/tools/base.py` and `tests/test_tools_base.py`
- [x] ruff format/lint clean (auto-fixed + re-ran cleanly)

Co-authored-by: Bob <bob@superuserlabs.org>