### PR TITLE
feat(util): add --max-tokens and --temperature to llm generate

### DIFF
--- a/gptme/cli/util.py
+++ b/gptme/cli/util.py
@@ -604,7 +604,7 @@ def llm():
     "--temperature",
     type=float,
     default=None,
-    help="Sampling temperature (0.0=deterministic, higher=more creative).",
+    help="Sampling temperature (0.0=deterministic, higher=more creative). Range: 0.0–2.0.",
 )
 def llm_generate(
     prompt: str | None,

--- a/gptme/cli/util.py
+++ b/gptme/cli/util.py
@@ -594,8 +594,25 @@ def llm():
     show_default=True,
     help="System message to prepend.",
 )
+@click.option(
+    "--max-tokens",
+    type=int,
+    default=None,
+    help="Maximum number of tokens to generate.",
+)
+@click.option(
+    "--temperature",
+    type=float,
+    default=None,
+    help="Sampling temperature (0.0=deterministic, higher=more creative).",
+)
 def llm_generate(
-    prompt: str | None, model: str | None, stream: bool, system_prompt: str
+    prompt: str | None,
+    model: str | None,
+    stream: bool,
+    system_prompt: str,
+    max_tokens: int | None,
+    temperature: float | None,
 ):
     """Generate a response from an LLM without any formatting."""
 
@@ -616,10 +633,14 @@ def llm_generate(
         print("Error: Empty prompt provided.", file=sys.stderr)
         sys.exit(1)
 
-    # Validate empty model before initialization (before redirect_stderr
-    # so Click can print the UsageError to real stderr, not the captured sink)
+    # Validate parameters before initialization (before redirect_stderr
+    # so Click can print errors to real stderr, not the captured sink)
     if model is not None and not model.strip():
         raise click.UsageError("Model name cannot be empty.")
+    if max_tokens is not None and max_tokens <= 0:
+        raise click.UsageError("--max-tokens must be a positive integer.")
+    if temperature is not None and not (0.0 <= temperature <= 2.0):
+        raise click.UsageError("--temperature must be between 0.0 and 2.0.")
 
     # Capture stderr to suppress console output during initialization
     stderr_capture = io.StringIO()
@@ -667,12 +688,16 @@ def llm_generate(
     try:
         if stream:
             # Stream response directly to stdout
-            for chunk in _stream(messages, model, None):
+            for chunk in _stream(
+                messages, model, None, max_tokens=max_tokens, temperature=temperature
+            ):
                 print(chunk, end="", flush=True)
             print()  # Final newline
         else:
             # Get complete response and print it
-            response, _ = _chat_complete(messages, model, None)
+            response, _ = _chat_complete(
+                messages, model, None, max_tokens=max_tokens, temperature=temperature
+            )
             print(response)
     except Exception as e:
         print(f"Error generating response: {e}", file=sys.stderr)

--- a/tests/test_util_cli.py
+++ b/tests/test_util_cli.py
@@ -891,7 +891,7 @@ def test_llm_generate_prepends_system_message(monkeypatch):
 
     captured: list = []
 
-    def fake_chat_complete(messages, model, tools):
+    def fake_chat_complete(messages, model, tools, **kwargs):
         captured.extend(messages)
         return ("ok", None)
 
@@ -922,7 +922,7 @@ def test_llm_generate_prepends_system_message_stream(monkeypatch):
 
     captured: list = []
 
-    def fake_stream(messages, model, tools):
+    def fake_stream(messages, model, tools, **kwargs):
         captured.extend(messages)
         yield "ok"
 

--- a/tests/test_util_cli_generate.py
+++ b/tests/test_util_cli_generate.py
@@ -8,34 +8,6 @@ from click.testing import CliRunner
 from gptme.cli.util import main
 
 
-def _mock_init_generate(mock_init, mock_provider, mock_init_llm, mock_default_model):
-    """Return a context-manager stack mocking the llm generate setup path."""
-    from contextlib import ExitStack
-
-    stack = ExitStack()
-    stack.enter_context(patch("gptme.cli.util.main"))  # dummy; replaced below
-    return stack
-
-
-def _generate_patches(response="test response"):
-    """Return a list of patch() objects covering the llm generate init path."""
-    from unittest.mock import MagicMock, patch
-
-    mock_model = MagicMock()
-    mock_model.full = "anthropic/claude-haiku-4-5"
-
-    return [
-        patch("gptme.init.init"),
-        patch("gptme.llm.get_provider_from_model", return_value="anthropic"),
-        patch("gptme.llm.init_llm"),
-        patch("gptme.llm.models.get_default_model", return_value=mock_model),
-        patch(
-            "gptme.llm._chat_complete",
-            return_value=(response, None),
-        ),
-    ]
-
-
 class TestLlmGenerateHelp:
     def test_help_shows_new_flags(self):
         runner = CliRunner()
@@ -86,7 +58,7 @@ class TestLlmGenerateValidation:
 class TestLlmGenerateParams:
     def test_max_tokens_passed_to_chat_complete(self):
         """--max-tokens is forwarded to _chat_complete."""
-        from unittest.mock import MagicMock, patch
+        from unittest.mock import MagicMock
 
         mock_model = MagicMock()
         mock_model.full = "anthropic/claude-haiku-4-5"
@@ -111,7 +83,7 @@ class TestLlmGenerateParams:
 
     def test_temperature_passed_to_chat_complete(self):
         """--temperature is forwarded to _chat_complete."""
-        from unittest.mock import MagicMock, patch
+        from unittest.mock import MagicMock
 
         mock_model = MagicMock()
         mock_model.full = "anthropic/claude-haiku-4-5"
@@ -136,7 +108,7 @@ class TestLlmGenerateParams:
 
     def test_both_params_passed_together(self):
         """Both --max-tokens and --temperature can be combined."""
-        from unittest.mock import MagicMock, patch
+        from unittest.mock import MagicMock
 
         mock_model = MagicMock()
         mock_model.full = "anthropic/claude-haiku-4-5"
@@ -170,7 +142,7 @@ class TestLlmGenerateParams:
 
     def test_no_params_defaults_to_none(self):
         """Without flags, max_tokens and temperature default to None."""
-        from unittest.mock import MagicMock, patch
+        from unittest.mock import MagicMock
 
         mock_model = MagicMock()
         mock_model.full = "anthropic/claude-haiku-4-5"
@@ -193,7 +165,7 @@ class TestLlmGenerateParams:
 
     def test_max_tokens_passed_to_stream(self):
         """--max-tokens is forwarded to _stream when --stream is set."""
-        from unittest.mock import MagicMock, patch
+        from unittest.mock import MagicMock
 
         mock_model = MagicMock()
         mock_model.full = "anthropic/claude-haiku-4-5"
@@ -218,7 +190,7 @@ class TestLlmGenerateParams:
 
     def test_temperature_boundary_values_accepted(self):
         """0.0 and 2.0 are valid temperature boundaries."""
-        from unittest.mock import MagicMock, patch
+        from unittest.mock import MagicMock
 
         mock_model = MagicMock()
         mock_model.full = "anthropic/claude-haiku-4-5"

--- a/tests/test_util_cli_generate.py
+++ b/tests/test_util_cli_generate.py
@@ -1,0 +1,242 @@
+"""Tests for gptme-util llm generate --max-tokens and --temperature flags."""
+
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from gptme.cli.util import main
+
+
+def _mock_init_generate(mock_init, mock_provider, mock_init_llm, mock_default_model):
+    """Return a context-manager stack mocking the llm generate setup path."""
+    from contextlib import ExitStack
+
+    stack = ExitStack()
+    stack.enter_context(patch("gptme.cli.util.main"))  # dummy; replaced below
+    return stack
+
+
+def _generate_patches(response="test response"):
+    """Return a list of patch() objects covering the llm generate init path."""
+    from unittest.mock import MagicMock, patch
+
+    mock_model = MagicMock()
+    mock_model.full = "anthropic/claude-haiku-4-5"
+
+    return [
+        patch("gptme.init.init"),
+        patch("gptme.llm.get_provider_from_model", return_value="anthropic"),
+        patch("gptme.llm.init_llm"),
+        patch("gptme.llm.models.get_default_model", return_value=mock_model),
+        patch(
+            "gptme.llm._chat_complete",
+            return_value=(response, None),
+        ),
+    ]
+
+
+class TestLlmGenerateHelp:
+    def test_help_shows_new_flags(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ["llm", "generate", "--help"])
+        assert result.exit_code == 0
+        assert "--max-tokens" in result.output
+        assert "--temperature" in result.output
+
+
+class TestLlmGenerateValidation:
+    def test_max_tokens_zero_rejected(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ["llm", "generate", "--max-tokens", "0", "hello"])
+        assert result.exit_code != 0
+        assert (
+            "max-tokens" in result.output.lower()
+            or "max_tokens" in result.output.lower()
+        )
+
+    def test_max_tokens_negative_rejected(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ["llm", "generate", "--max-tokens", "-1", "hello"])
+        assert result.exit_code != 0
+
+    def test_temperature_above_range_rejected(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            main, ["llm", "generate", "--temperature", "2.1", "hello"]
+        )
+        assert result.exit_code != 0
+        assert "temperature" in result.output.lower()
+
+    def test_temperature_negative_rejected(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            main, ["llm", "generate", "--temperature", "-0.1", "hello"]
+        )
+        assert result.exit_code != 0
+
+    def test_max_tokens_non_integer_rejected(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            main, ["llm", "generate", "--max-tokens", "abc", "hello"]
+        )
+        assert result.exit_code != 0
+
+
+class TestLlmGenerateParams:
+    def test_max_tokens_passed_to_chat_complete(self):
+        """--max-tokens is forwarded to _chat_complete."""
+        from unittest.mock import MagicMock, patch
+
+        mock_model = MagicMock()
+        mock_model.full = "anthropic/claude-haiku-4-5"
+        mock_complete = MagicMock(return_value=("hello", None))
+
+        with (
+            patch("gptme.init.init"),
+            patch("gptme.llm.get_provider_from_model", return_value="anthropic"),
+            patch("gptme.llm.init_llm"),
+            patch("gptme.llm.models.get_default_model", return_value=mock_model),
+            patch("gptme.llm._chat_complete", mock_complete),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(
+                main,
+                ["llm", "generate", "--max-tokens", "50", "say hello"],
+            )
+
+        assert result.exit_code == 0, result.output
+        call_kwargs = mock_complete.call_args[1]
+        assert call_kwargs["max_tokens"] == 50
+
+    def test_temperature_passed_to_chat_complete(self):
+        """--temperature is forwarded to _chat_complete."""
+        from unittest.mock import MagicMock, patch
+
+        mock_model = MagicMock()
+        mock_model.full = "anthropic/claude-haiku-4-5"
+        mock_complete = MagicMock(return_value=("hello", None))
+
+        with (
+            patch("gptme.init.init"),
+            patch("gptme.llm.get_provider_from_model", return_value="anthropic"),
+            patch("gptme.llm.init_llm"),
+            patch("gptme.llm.models.get_default_model", return_value=mock_model),
+            patch("gptme.llm._chat_complete", mock_complete),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(
+                main,
+                ["llm", "generate", "--temperature", "0.0", "say hello"],
+            )
+
+        assert result.exit_code == 0, result.output
+        call_kwargs = mock_complete.call_args[1]
+        assert call_kwargs["temperature"] == 0.0
+
+    def test_both_params_passed_together(self):
+        """Both --max-tokens and --temperature can be combined."""
+        from unittest.mock import MagicMock, patch
+
+        mock_model = MagicMock()
+        mock_model.full = "anthropic/claude-haiku-4-5"
+        mock_complete = MagicMock(return_value=("hello", None))
+
+        with (
+            patch("gptme.init.init"),
+            patch("gptme.llm.get_provider_from_model", return_value="anthropic"),
+            patch("gptme.llm.init_llm"),
+            patch("gptme.llm.models.get_default_model", return_value=mock_model),
+            patch("gptme.llm._chat_complete", mock_complete),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(
+                main,
+                [
+                    "llm",
+                    "generate",
+                    "--max-tokens",
+                    "100",
+                    "--temperature",
+                    "0.7",
+                    "say hello",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        call_kwargs = mock_complete.call_args[1]
+        assert call_kwargs["max_tokens"] == 100
+        assert call_kwargs["temperature"] == pytest.approx(0.7)
+
+    def test_no_params_defaults_to_none(self):
+        """Without flags, max_tokens and temperature default to None."""
+        from unittest.mock import MagicMock, patch
+
+        mock_model = MagicMock()
+        mock_model.full = "anthropic/claude-haiku-4-5"
+        mock_complete = MagicMock(return_value=("hello", None))
+
+        with (
+            patch("gptme.init.init"),
+            patch("gptme.llm.get_provider_from_model", return_value="anthropic"),
+            patch("gptme.llm.init_llm"),
+            patch("gptme.llm.models.get_default_model", return_value=mock_model),
+            patch("gptme.llm._chat_complete", mock_complete),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(main, ["llm", "generate", "say hello"])
+
+        assert result.exit_code == 0, result.output
+        call_kwargs = mock_complete.call_args[1]
+        assert call_kwargs["max_tokens"] is None
+        assert call_kwargs["temperature"] is None
+
+    def test_max_tokens_passed_to_stream(self):
+        """--max-tokens is forwarded to _stream when --stream is set."""
+        from unittest.mock import MagicMock, patch
+
+        mock_model = MagicMock()
+        mock_model.full = "anthropic/claude-haiku-4-5"
+        mock_stream = MagicMock(return_value=iter(["hello", " world"]))
+
+        with (
+            patch("gptme.init.init"),
+            patch("gptme.llm.get_provider_from_model", return_value="anthropic"),
+            patch("gptme.llm.init_llm"),
+            patch("gptme.llm.models.get_default_model", return_value=mock_model),
+            patch("gptme.llm._stream", mock_stream),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(
+                main,
+                ["llm", "generate", "--stream", "--max-tokens", "50", "say hello"],
+            )
+
+        assert result.exit_code == 0, result.output
+        call_kwargs = mock_stream.call_args[1]
+        assert call_kwargs["max_tokens"] == 50
+
+    def test_temperature_boundary_values_accepted(self):
+        """0.0 and 2.0 are valid temperature boundaries."""
+        from unittest.mock import MagicMock, patch
+
+        mock_model = MagicMock()
+        mock_model.full = "anthropic/claude-haiku-4-5"
+
+        for temp in ["0.0", "2.0"]:
+            mock_complete = MagicMock(return_value=("hello", None))
+            with (
+                patch("gptme.init.init"),
+                patch("gptme.llm.get_provider_from_model", return_value="anthropic"),
+                patch("gptme.llm.init_llm"),
+                patch("gptme.llm.models.get_default_model", return_value=mock_model),
+                patch("gptme.llm._chat_complete", mock_complete),
+            ):
+                runner = CliRunner()
+                result = runner.invoke(
+                    main,
+                    ["llm", "generate", "--temperature", temp, "hello"],
+                )
+            assert result.exit_code == 0, (
+                f"temperature={temp} should be valid, got: {result.output}"
+            )


### PR DESCRIPTION
## Summary

Adds two missing generation control options to `gptme-util llm generate`:

- `--max-tokens INT` — cap response length (default: None = model default)
- `--temperature FLOAT` — control creativity/determinism, 0.0–2.0 (default: None = model default)

Both `_chat_complete` and `_stream` already accepted these as keyword args; this change wires them up from the CLI surface.

## Changes

- `gptme/cli/util.py`: added two Click options with validation (`max_tokens > 0`, `temperature in [0.0, 2.0]`)
- `tests/test_util_cli_generate.py`: 12 new unit tests — help output, validation errors, parameter forwarding for both non-stream and stream paths

## Test plan

- [ ] `pytest tests/test_util_cli_generate.py` — 12 tests pass
- [ ] `gptme-util llm generate --help` shows `--max-tokens` and `--temperature`
- [ ] `gptme-util llm generate --max-tokens 0 hello` exits non-zero with clear error
- [ ] `gptme-util llm generate --temperature 2.1 hello` exits non-zero with clear error