### PR TITLE
feat(util): add --output-format json to gptme-util llm generate

### DIFF
--- a/gptme/cli/util.py
+++ b/gptme/cli/util.py
@@ -606,6 +606,13 @@ def llm():
     default=None,
     help="Sampling temperature (0.0=deterministic, higher=more creative). Range: 0.0–2.0.",
 )
+@click.option(
+    "--output-format",
+    type=click.Choice(["text", "json"], case_sensitive=False),
+    default="text",
+    show_default=True,
+    help="Output format: 'text' (default) or 'json' (includes model and usage metadata). Incompatible with --stream.",
+)
 def llm_generate(
     prompt: str | None,
     model: str | None,
@@ -613,6 +620,7 @@ def llm_generate(
     system_prompt: str,
     max_tokens: int | None,
     temperature: float | None,
+    output_format: str,
 ):
     """Generate a response from an LLM without any formatting."""
 
@@ -641,6 +649,8 @@ def llm_generate(
         raise click.UsageError("--max-tokens must be a positive integer.")
     if temperature is not None and not (0.0 <= temperature <= 2.0):
         raise click.UsageError("--temperature must be between 0.0 and 2.0.")
+    if output_format == "json" and stream:
+        raise click.UsageError("--output-format json is incompatible with --stream.")
 
     # Capture stderr to suppress console output during initialization
     stderr_capture = io.StringIO()
@@ -693,8 +703,17 @@ def llm_generate(
             ):
                 print(chunk, end="", flush=True)
             print()  # Final newline
+        elif output_format == "json":
+            # Return structured JSON with content and metadata
+            response, metadata = _chat_complete(
+                messages, model, None, max_tokens=max_tokens, temperature=temperature
+            )
+            result: dict = {"content": response, "model": model}
+            if metadata and "usage" in metadata:
+                result["usage"] = dict(metadata["usage"])
+            print(json.dumps(result))
         else:
-            # Get complete response and print it
+            # Get complete response and print it (plain text)
             response, _ = _chat_complete(
                 messages, model, None, max_tokens=max_tokens, temperature=temperature
             )

--- a/gptme/cli/util.py
+++ b/gptme/cli/util.py
@@ -708,9 +708,13 @@ def llm_generate(
             response, metadata = _chat_complete(
                 messages, model, None, max_tokens=max_tokens, temperature=temperature
             )
-            result: dict = {"content": response, "model": model}
-            if metadata and "usage" in metadata:
-                result["usage"] = dict(metadata["usage"])
+            result: dict = {
+                "content": response,
+                "model": (metadata.get("model") if metadata else None) or model,
+                "usage": dict(metadata["usage"])
+                if metadata and "usage" in metadata
+                else None,
+            }
             print(json.dumps(result))
         else:
             # Get complete response and print it (plain text)

--- a/tests/test_cli_llm_generate.py
+++ b/tests/test_cli_llm_generate.py
@@ -15,6 +15,10 @@ def _fake_chat_complete(messages, model, tools, **kwargs):
     return "hello world", meta
 
 
+def _fake_chat_complete_no_usage(messages, model, tools, **kwargs):
+    return "hello world", {"model": model}
+
+
 @pytest.fixture()
 def mock_llm_env():
     """Patch LLM initialisation so tests run without real credentials or API calls."""
@@ -59,6 +63,29 @@ def test_llm_generate_json_incompatible_with_stream():
     )
     assert result.exit_code != 0
     assert "incompatible" in result.output.lower()
+
+
+def test_llm_generate_json_no_usage_returns_null():
+    """When the provider returns no usage data, 'usage' key is present but null."""
+    with (
+        patch("gptme.init.init"),
+        patch("gptme.llm.get_provider_from_model", return_value="anthropic"),
+        patch("gptme.llm.init_llm"),
+        patch(
+            "gptme.llm.models.get_default_model",
+            return_value=MagicMock(full="anthropic/claude-test"),
+        ),
+        patch("gptme.llm._chat_complete", side_effect=_fake_chat_complete_no_usage),
+    ):
+        runner = CliRunner()
+        result = runner.invoke(
+            llm_generate,
+            ["--output-format", "json", "--model", "anthropic/claude-test", "say hi"],
+        )
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert "usage" in data, "usage key must always be present in JSON output"
+    assert data["usage"] is None
 
 
 def test_llm_generate_text_output_unchanged(mock_llm_env):

--- a/tests/test_cli_llm_generate.py
+++ b/tests/test_cli_llm_generate.py
@@ -1,0 +1,75 @@
+"""Tests for `gptme-util llm generate` command, specifically --output-format."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from gptme.cli.util import llm_generate
+
+
+def _fake_chat_complete(messages, model, tools, **kwargs):
+    usage = {"input_tokens": 10, "output_tokens": 5}
+    meta = {"model": model, "usage": usage}
+    return "hello world", meta
+
+
+@pytest.fixture()
+def mock_llm_env():
+    """Patch LLM initialisation so tests run without real credentials or API calls."""
+    with (
+        # redirect_stderr is used inside the function to suppress console output;
+        # keep it functional but mock everything it imports
+        patch("gptme.init.init"),
+        patch("gptme.llm.get_provider_from_model", return_value="anthropic"),
+        patch("gptme.llm.init_llm"),
+        patch(
+            "gptme.llm.models.get_default_model",
+            return_value=MagicMock(full="anthropic/claude-test"),
+        ),
+        # Patch at the source so the local import inside the function body gets the mock
+        patch("gptme.llm._chat_complete", side_effect=_fake_chat_complete),
+    ):
+        yield
+
+
+def test_llm_generate_json_output(mock_llm_env):
+    """--output-format json returns a valid JSON object with content and usage."""
+    runner = CliRunner()
+    result = runner.invoke(
+        llm_generate,
+        ["--output-format", "json", "--model", "anthropic/claude-test", "say hi"],
+    )
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert data["content"] == "hello world"
+    assert data["model"] == "anthropic/claude-test"
+    assert "usage" in data
+    assert data["usage"]["input_tokens"] == 10
+    assert data["usage"]["output_tokens"] == 5
+
+
+def test_llm_generate_json_incompatible_with_stream():
+    """--output-format json raises UsageError when combined with --stream."""
+    runner = CliRunner()
+    result = runner.invoke(
+        llm_generate,
+        ["--output-format", "json", "--stream", "say hi"],
+    )
+    assert result.exit_code != 0
+    assert "incompatible" in result.output.lower()
+
+
+def test_llm_generate_text_output_unchanged(mock_llm_env):
+    """Default (text) output is the raw response string, not JSON."""
+    runner = CliRunner()
+    result = runner.invoke(
+        llm_generate,
+        ["--model", "anthropic/claude-test", "say hi"],
+    )
+    assert result.exit_code == 0, result.output
+    assert result.output.strip() == "hello world"
+    # Must NOT be a JSON object
+    with pytest.raises(json.JSONDecodeError):
+        json.loads(result.output)


### PR DESCRIPTION
## Summary

Adds `--output-format {text,json}` flag to `gptme-util llm generate`.

- When `--output-format json` is set, outputs a structured JSON object with `content`, `model`, and `usage` (input/output token counts)
- Default (`text`) output is unchanged — raw string, backward-compatible
- `--output-format json` is incompatible with `--stream` (raises `UsageError`)
- 3 new unit tests covering JSON output shape, the stream incompatibility, and text output unchanged

## Motivation

Scripting consumers of `gptme-util llm generate` often need token counts or the resolved model name alongside the content. This follows up on #2894 (which added `--max-tokens` and `--temperature`).

Example:
```bash
$ gptme-util llm generate --output-format json "say hi" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['usage'])"
{'input_tokens': 42, 'output_tokens': 7}
```

## Test plan

- [x] `test_llm_generate_json_output` — verifies JSON shape, content, model, usage
- [x] `test_llm_generate_json_incompatible_with_stream` — verifies the usage error
- [x] `test_llm_generate_text_output_unchanged` — verifies backward compatibility
- [x] All 507 existing llm-related tests pass (no regressions)