### PR TITLE
feat(snapshot): add --dry-run / -n flag to /snapshot prune

### DIFF
--- a/gptme/commands/snapshot.py
+++ b/gptme/commands/snapshot.py
@@ -24,6 +24,7 @@ from collections import Counter
 from pathlib import Path
 
 from ..workspace_snapshot import (
+    SNAPSHOT_REF,
     Shadow,
     get_snapshot_n_msgs,
     init_shadow,
@@ -36,6 +37,78 @@ from ..workspace_snapshot import (
 from .base import CommandContext, command
 
 DEFAULT_PRUNE_DAYS = 30
+
+
+def _print_prunable(
+    shadow: Shadow,
+    days: int | None,
+    max_entries: int | None,
+) -> None:
+    """Print snapshots that would be removed by a prune, without removing them."""
+    import time
+
+    would_drop = 0
+    listed: set[str] = set()
+
+    if days is not None:
+        cutoff = int(time.time()) - days * 86400
+        log = shadow.run(
+            "log",
+            f"--before=@{cutoff}",
+            "--format=%h\t%cr\t%s",
+            SNAPSHOT_REF,
+            check=False,
+        )
+        if log.returncode == 0 and log.stdout.strip():
+            lines = [ln for ln in log.stdout.strip().splitlines() if ln]
+            # Always keep the most recent snapshot even if it predates cutoff.
+            # The prune_by_age implementation uses keep_count or 1, so if ALL
+            # commits are older than cutoff we keep 1; reflect that here.
+            total_res = shadow.run("rev-list", "--count", SNAPSHOT_REF, check=False)
+            total = int(total_res.stdout.strip()) if total_res.returncode == 0 else 0
+            if total > 0 and len(lines) == total:
+                lines = lines[:-1]  # keep the oldest one (last in log order)
+            for ln in lines:
+                parts = ln.split("\t", 2)
+                if len(parts) == 3:
+                    sha, age, subject = parts
+                    if sha not in listed:
+                        print(f"  {sha}  {age:>15}  {subject}")
+                        listed.add(sha)
+                        would_drop += 1
+
+    if max_entries is not None:
+        total_res = shadow.run("rev-list", "--count", SNAPSHOT_REF, check=False)
+        if total_res.returncode == 0:
+            try:
+                total = int(total_res.stdout.strip())
+            except ValueError:
+                total = 0
+            to_skip = max_entries  # skip the newest max_entries; list the rest
+            if total > max_entries:
+                log = shadow.run(
+                    "log",
+                    f"--skip={to_skip}",
+                    "--format=%h\t%cr\t%s",
+                    SNAPSHOT_REF,
+                    check=False,
+                )
+                if log.returncode == 0 and log.stdout.strip():
+                    for ln in log.stdout.strip().splitlines():
+                        if not ln:
+                            continue
+                        parts = ln.split("\t", 2)
+                        if len(parts) == 3:
+                            sha, age, subject = parts
+                            if sha not in listed:
+                                print(f"  {sha}  {age:>15}  {subject}")
+                                listed.add(sha)
+                                would_drop += 1
+
+    if would_drop > 0:
+        print(f"Would prune {would_drop} snapshot(s).")
+    else:
+        print("No snapshots to prune.")
 
 
 def _print_usage() -> None:
@@ -51,7 +124,7 @@ def _print_usage() -> None:
         "  diff <sha>                  Show diff between current workspace and a snapshot."
     )
     print(
-        "  prune [--days N] [--max-entries K]  Remove old snapshots "
+        "  prune [--days N] [--max-entries K] [--dry-run|-n]  Remove old snapshots "
         f"(defaults to {DEFAULT_PRUNE_DAYS} days)."
     )
 
@@ -221,6 +294,7 @@ def cmd_snapshot(ctx: CommandContext) -> None:
     if subcommand == "prune":
         days: int | None = None
         max_entries: int | None = None
+        dry_run = False
         idx = 0
         while idx < len(args):
             arg = args[idx]
@@ -252,6 +326,8 @@ def cmd_snapshot(ctx: CommandContext) -> None:
                         f"snapshot: --max-entries must be an integer, got {args[idx]!r}"
                     )
                     return
+            elif arg in ("--dry-run", "-n"):
+                dry_run = True
             else:
                 print(f"snapshot: unknown argument {arg!r}")
                 _print_usage()
@@ -263,6 +339,10 @@ def cmd_snapshot(ctx: CommandContext) -> None:
 
         workspace_shadow = _workspace_shadow(ctx)
         if workspace_shadow is None:
+            return
+
+        if dry_run:
+            _print_prunable(workspace_shadow, days=days, max_entries=max_entries)
             return
 
         dropped = 0

--- a/gptme/commands/snapshot.py
+++ b/gptme/commands/snapshot.py
@@ -126,7 +126,7 @@ def _print_usage() -> None:
         "  diff <sha>                  Show diff between current workspace and a snapshot."
     )
     print(
-        "  prune [--days N] [--max-entries K] [--dry-run]  Remove old snapshots "
+        "  prune [--days N] [--max-entries K] [--dry-run|-n]  Remove old snapshots "
         f"(defaults to {DEFAULT_PRUNE_DAYS} days)."
     )
 
@@ -166,7 +166,7 @@ def cmd_snapshot(ctx: CommandContext) -> None:
       /snapshot list [--limit N]            Show recent snapshots
       /snapshot restore <sha>               Roll back to a snapshot
       /snapshot diff <sha>                  Show diff from current to snapshot
-      /snapshot prune [--days N] [--max-entries K]  Remove old snapshots
+      /snapshot prune [--days N] [--max-entries K] [--dry-run|-n]  Remove old snapshots
     """
     if not ctx.args or ctx.args[0] in {"help", "-h", "--help"}:
         _print_usage()
@@ -328,7 +328,7 @@ def cmd_snapshot(ctx: CommandContext) -> None:
                         f"snapshot: --max-entries must be an integer, got {args[idx]!r}"
                     )
                     return
-            elif arg == "--dry-run":
+            elif arg in ("--dry-run", "-n"):
                 dry_run = True
             else:
                 print(f"snapshot: unknown argument {arg!r}")

--- a/gptme/commands/snapshot.py
+++ b/gptme/commands/snapshot.py
@@ -67,7 +67,9 @@ def _print_prunable(
             total_res = shadow.run("rev-list", "--count", SNAPSHOT_REF, check=False)
             total = int(total_res.stdout.strip()) if total_res.returncode == 0 else 0
             if total > 0 and len(lines) == total:
-                lines = lines[:-1]  # keep the oldest one (last in log order)
+                lines = lines[
+                    1:
+                ]  # keep the newest one (first in log order, matching prune_by_age)
             for ln in lines:
                 parts = ln.split("\t", 2)
                 if len(parts) == 3:
@@ -124,7 +126,7 @@ def _print_usage() -> None:
         "  diff <sha>                  Show diff between current workspace and a snapshot."
     )
     print(
-        "  prune [--days N] [--max-entries K] [--dry-run|-n]  Remove old snapshots "
+        "  prune [--days N] [--max-entries K] [--dry-run]  Remove old snapshots "
         f"(defaults to {DEFAULT_PRUNE_DAYS} days)."
     )
 
@@ -326,7 +328,7 @@ def cmd_snapshot(ctx: CommandContext) -> None:
                         f"snapshot: --max-entries must be an integer, got {args[idx]!r}"
                     )
                     return
-            elif arg in ("--dry-run", "-n"):
+            elif arg == "--dry-run":
                 dry_run = True
             else:
                 print(f"snapshot: unknown argument {arg!r}")
@@ -334,7 +336,7 @@ def cmd_snapshot(ctx: CommandContext) -> None:
                 return
             idx += 1
 
-        if not args:
+        if days is None and max_entries is None:
             days = DEFAULT_PRUNE_DAYS
 
         workspace_shadow = _workspace_shadow(ctx)

--- a/gptme/workspace_snapshot.py
+++ b/gptme/workspace_snapshot.py
@@ -298,12 +298,17 @@ def restore(shadow: Shadow, snapshot_id: str) -> bool:
     return True
 
 
-def prune(shadow: Shadow, keep: int = DEFAULT_MAX_SNAPSHOTS) -> int:
+def prune(
+    shadow: Shadow, keep: int = DEFAULT_MAX_SNAPSHOTS, dry_run: bool = False
+) -> int:
     """Keep newest ``keep`` snapshots; drop the rest. Returns dropped count.
 
     Implementation: collect the ``keep`` newest (tree, message) pairs, replay
     them as a fresh orphan chain, and point SNAPSHOT_REF at the new tip.
     Older commits become unreachable and ``git gc`` can reclaim them.
+
+    When ``dry_run=True``, compute and return the would-be dropped count
+    without modifying the snapshot history.
     """
     if not shadow.initialized() or keep <= 0:
         return 0
@@ -317,6 +322,8 @@ def prune(shadow: Shadow, keep: int = DEFAULT_MAX_SNAPSHOTS) -> int:
     if total <= keep:
         return 0
     to_drop = total - keep
+    if dry_run:
+        return to_drop
     # Collect (tree, full body) for the ``keep`` newest commits in one pass.
     # Use ASCII control characters as record/field separators so commit bodies
     # can still contain ordinary newlines.
@@ -358,12 +365,15 @@ def prune(shadow: Shadow, keep: int = DEFAULT_MAX_SNAPSHOTS) -> int:
     return to_drop
 
 
-def prune_by_age(shadow: Shadow, days: int = 30) -> int:
+def prune_by_age(shadow: Shadow, days: int = 30, dry_run: bool = False) -> int:
     """Drop snapshots older than ``days`` days. Returns dropped count.
 
     Always keeps at least one snapshot (the most recent) regardless of age.
     Implementation mirrors :func:`prune`: collect entries to keep, replay as a
     fresh orphan chain, and point SNAPSHOT_REF at the new tip.
+
+    When ``dry_run=True``, compute and return the would-be dropped count
+    without modifying the snapshot history.
     """
     if not shadow.initialized() or days <= 0:
         return 0
@@ -392,6 +402,8 @@ def prune_by_age(shadow: Shadow, days: int = 30) -> int:
     to_drop = total_count - keep_count
     if to_drop <= 0:
         return 0
+    if dry_run:
+        return to_drop
     # Fetch only the survivors we need to replay.
     log_output = shadow.run(
         "log",

--- a/tests/test_snapshot_command.py
+++ b/tests/test_snapshot_command.py
@@ -601,10 +601,10 @@ class TestSnapshotPruneCommand:
         after = list_snapshots(shadow, limit=50)
         assert len(after) == len(before)
 
-    def test_prune_dry_run_short_flag_skips_deletion_by_age(
+    def test_prune_dry_run_default_age_applied(
         self, workspace, isolated_state_dir, capsys
     ):
-        """Short flag -n is equivalent to --dry-run; no snapshots removed."""
+        """--dry-run alone previews the default 30-day prune, not a no-op."""
         import time
 
         shadow = init_shadow(workspace)
@@ -619,7 +619,7 @@ class TestSnapshotPruneCommand:
             patch("gptme.commands.snapshot.Shadow.for_workspace", return_value=shadow),
             patch("gptme.workspace_snapshot.time.time", return_value=future),
         ):
-            _run_cmd(manager, "prune --days 30 -n")
+            _run_cmd(manager, "prune --dry-run")
         out = capsys.readouterr().out
         assert "would prune" in out.lower()
         after = list_snapshots(shadow, limit=50)

--- a/tests/test_snapshot_command.py
+++ b/tests/test_snapshot_command.py
@@ -624,3 +624,27 @@ class TestSnapshotPruneCommand:
         assert "would prune" in out.lower()
         after = list_snapshots(shadow, limit=50)
         assert len(after) == len(before)
+
+    def test_prune_dry_run_short_flag_skips_deletion_by_age(
+        self, workspace, isolated_state_dir, capsys
+    ):
+        """-n mirrors --dry-run for age-based prune previews."""
+        import time
+
+        shadow = init_shadow(workspace)
+        for i in range(3):
+            (workspace / f"f{i}.txt").write_text(str(i))
+            snapshot(shadow, label=f"snap-{i}")
+
+        future = time.time() + 31 * 86400
+        before = list_snapshots(shadow, limit=50)
+        manager = _make_manager(workspace)
+        with (
+            patch("gptme.commands.snapshot.Shadow.for_workspace", return_value=shadow),
+            patch("gptme.workspace_snapshot.time.time", return_value=future),
+        ):
+            _run_cmd(manager, "prune -n --days 30")
+        out = capsys.readouterr().out
+        assert "would prune" in out.lower()
+        after = list_snapshots(shadow, limit=50)
+        assert len(after) == len(before)

--- a/tests/test_snapshot_command.py
+++ b/tests/test_snapshot_command.py
@@ -581,3 +581,46 @@ class TestSnapshotPruneCommand:
         _run_cmd(manager, f"prune --max-entries {value}")
         out = capsys.readouterr().out
         assert "--max-entries must be a positive integer" in out.lower()
+
+    def test_prune_dry_run_skips_deletion_by_count(
+        self, workspace, isolated_state_dir, capsys
+    ):
+        """--dry-run reports what would be pruned without removing anything."""
+        shadow = init_shadow(workspace)
+        for i in range(5):
+            (workspace / f"f{i}.txt").write_text(str(i))
+            snapshot(shadow, label=f"snap-{i}")
+
+        before = list_snapshots(shadow, limit=50)
+        manager = _make_manager(workspace)
+        with patch("gptme.commands.snapshot.Shadow.for_workspace", return_value=shadow):
+            _run_cmd(manager, "prune --max-entries 3 --dry-run")
+        out = capsys.readouterr().out
+        assert "would prune" in out.lower()
+        # Nothing should have been deleted.
+        after = list_snapshots(shadow, limit=50)
+        assert len(after) == len(before)
+
+    def test_prune_dry_run_short_flag_skips_deletion_by_age(
+        self, workspace, isolated_state_dir, capsys
+    ):
+        """Short flag -n is equivalent to --dry-run; no snapshots removed."""
+        import time
+
+        shadow = init_shadow(workspace)
+        for i in range(3):
+            (workspace / f"f{i}.txt").write_text(str(i))
+            snapshot(shadow, label=f"snap-{i}")
+
+        future = time.time() + 31 * 86400
+        before = list_snapshots(shadow, limit=50)
+        manager = _make_manager(workspace)
+        with (
+            patch("gptme.commands.snapshot.Shadow.for_workspace", return_value=shadow),
+            patch("gptme.workspace_snapshot.time.time", return_value=future),
+        ):
+            _run_cmd(manager, "prune --days 30 -n")
+        out = capsys.readouterr().out
+        assert "would prune" in out.lower()
+        after = list_snapshots(shadow, limit=50)
+        assert len(after) == len(before)


### PR DESCRIPTION
## Summary

- Adds `--dry-run` / `-n` flag to `/snapshot prune` so users can preview what would be removed before committing to a destructive operation
- `prune()` and `prune_by_age()` in `workspace_snapshot.py` gain a `dry_run=False` parameter; when `True`, computation runs but no snapshot ref is modified
- New `_print_prunable()` helper in the command module lists each snapshot that would be removed (short sha, relative age, subject), then prints `"Would prune N snapshot(s)."`

Example output:
```
  a1b2c3d       13 days ago  Conversation snapshot: 45 messages
  e4f5g6h       20 days ago  Conversation snapshot: 30 messages
Would prune 2 snapshot(s).
```

Follows from #2887 (prune subcommand). Addresses the "preview before act" safety net flagged by Greptile.

## Test plan

- [ ] `test_prune_dry_run_skips_deletion_by_count` — `--dry-run` with `--max-entries` prints "would prune" and leaves all snapshots intact
- [ ] `test_prune_dry_run_short_flag_skips_deletion_by_age` — `-n` with `--days` and mocked future time prints "would prune" and leaves all snapshots intact
- [ ] All 126 existing snapshot tests still pass