### PR TITLE
feat(computer): add wait_for_change action for context-efficient UI loops

### DIFF
--- a/gptme/tools/computer.py
+++ b/gptme/tools/computer.py
@@ -54,6 +54,7 @@ Mouse:
 Screen:
     - screenshot: Take and view a screenshot
     - cursor_position: Get current mouse position
+    - wait_for_change: Poll until screen changes, then return one screenshot
 
 The tool automatically handles screen resolution scaling to ensure optimal performance
 with LLM vision capabilities.
@@ -79,6 +80,7 @@ import platform
 import shlex
 import shutil
 import subprocess
+import time
 from enum import Enum
 from typing import TYPE_CHECKING, Literal, TypedDict
 
@@ -119,6 +121,30 @@ def _make_screenshot_msg(path: Path, tool: str = "computer") -> Message | None:
     return dataclasses.replace(msg, metadata=existing)
 
 
+def _compute_change_ratio(path1: Path, path2: Path) -> float:
+    """Return fraction of pixels that differ between two screenshots (0.0–1.0).
+
+    Uses Pillow's pixel-level comparison after converting to a consistent mode.
+    Returns 0.0 if images can't be compared (mismatched sizes, load errors).
+    """
+    try:
+        from PIL import Image, ImageChops
+
+        img1 = Image.open(path1).convert("RGB")
+        img2 = Image.open(path2).convert("RGB")
+        if img1.size != img2.size:
+            return 0.0
+        diff = ImageChops.difference(img1, img2)
+        total_pixels = img1.width * img1.height
+        raw = diff.tobytes()  # 3 bytes per pixel for RGB
+        nonzero = sum(
+            1 for i in range(0, len(raw), 3) if raw[i] or raw[i + 1] or raw[i + 2]
+        )
+        return nonzero / total_pixels
+    except Exception:
+        return 0.0
+
+
 # Constants from Anthropic's implementation
 TYPING_DELAY_MS = 12
 TYPING_GROUP_SIZE = 50
@@ -135,6 +161,7 @@ Action = Literal[
     "scroll",
     "screenshot",
     "cursor_position",
+    "wait_for_change",
 ]
 
 ScrollDirection = Literal["up", "down", "left", "right"]
@@ -666,6 +693,24 @@ def _dispatch_transport(
         print(f"Cursor position: X={x},Y={y}")
         return None
 
+    if action == "wait_for_change":
+        timeout = float(text) if text else 10.0
+        poll_interval = 0.5
+        change_threshold = 0.01
+        baseline = transport.screenshot()
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            time.sleep(poll_interval)
+            current = transport.screenshot()
+            ratio = _compute_change_ratio(baseline, current)
+            if ratio >= change_threshold:
+                print(f"Screen changed ({ratio:.1%} pixels differ)")
+                return _make_screenshot_msg(current)
+        print(
+            f"No screen change detected after {timeout:.0f}s — returning current screenshot"
+        )
+        return _make_screenshot_msg(transport.screenshot())
+
     raise ValueError(f"Invalid action: {action}")
 
 
@@ -887,6 +932,62 @@ def computer(
         x, y = _scale_coordinates(_ScalingSource.COMPUTER, x, y, width, height)
         print(f"Cursor position: X={x},Y={y}")
         return None
+    if action == "wait_for_change":
+        # text holds the optional timeout (seconds) as a string; default 10s
+        timeout = float(text) if text else 10.0
+        poll_interval = 0.5
+        change_threshold = 0.01  # 1% of pixels must differ
+        baseline = screenshot()
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            time.sleep(poll_interval)
+            current = screenshot()
+            ratio = _compute_change_ratio(baseline, current)
+            if ratio >= change_threshold:
+                print(f"Screen changed ({ratio:.1%} pixels differ)")
+                path = current
+                if path.exists():
+                    try:
+                        subprocess.run(
+                            [
+                                "convert",
+                                str(path),
+                                "-resize",
+                                f"{width}x{height}!",
+                                str(path),
+                            ],
+                            check=True,
+                            capture_output=True,
+                            text=True,
+                            timeout=30,
+                        )
+                    except (
+                        subprocess.CalledProcessError,
+                        subprocess.TimeoutExpired,
+                        FileNotFoundError,
+                    ):
+                        pass
+                return _make_screenshot_msg(path)
+        print(
+            f"No screen change detected after {timeout:.0f}s — returning current screenshot"
+        )
+        path = screenshot()
+        if path.exists():
+            try:
+                subprocess.run(
+                    ["convert", str(path), "-resize", f"{width}x{height}!", str(path)],
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                    timeout=30,
+                )
+            except (
+                subprocess.CalledProcessError,
+                subprocess.TimeoutExpired,
+                FileNotFoundError,
+            ):
+                pass
+        return _make_screenshot_msg(path)
     raise ValueError(f"Invalid action: {action}")
 
 
@@ -1027,6 +1128,23 @@ Available actions:
 - scroll: Scroll the mouse wheel at coordinates (text="up"/"down"/"left"/"right")
 - screenshot: Take and view a screenshot
 - cursor_position: Get current mouse position
+- wait_for_change: Wait until the screen changes, then return a single screenshot.
+  Loops internally until ≥1% of pixels differ from the initial capture, or the
+  timeout (text="<seconds>", default 10) elapses. Returns one screenshot regardless
+  of how many internal polls were needed — avoids stacking redundant screenshots in
+  the conversation context. Use after triggering an action that produces a visual
+  response (page load, dialog open, animation finish).
+
+### Efficient action-verify loops
+
+Prefer wait_for_change over immediate screenshot after triggering UI changes:
+
+  computer("left_click", coordinate=(760, 540))  # trigger action
+  computer("wait_for_change", text="5")           # wait for response, see result once
+
+This prevents the conversation from accumulating multiple nearly-identical
+screenshots during transitions. Only call screenshot() directly when you need
+the current state without waiting.
 
 Note: Key names are automatically mapped between platforms.
 Common modifiers (ctrl, alt, cmd/super, shift) work consistently across platforms.
@@ -1070,6 +1188,14 @@ User: Scroll down in the page at (512, 400)
 Assistant: I'll scroll down at those coordinates.
 {ToolUse("ipython", [], 'computer("scroll", coordinate=(512, 400), text="down")').to_output(tool_format)}
 System: Scrolled down at 512,400
+
+User: Click the Submit button then wait for the result page to load
+Assistant: I'll click Submit and wait for the screen to change before returning a screenshot.
+{ToolUse("ipython", [], 'computer("left_click", coordinate=(760, 540))').to_output(tool_format)}
+System: Performed left_click
+{ToolUse("ipython", [], 'computer("wait_for_change", text="10")').to_output(tool_format)}
+System: Screen changed (23.4% pixels differ)
+Viewing image...
 """
 
     # Platform-specific keyboard shortcut examples

--- a/tests/test_tools_computer.py
+++ b/tests/test_tools_computer.py
@@ -998,3 +998,159 @@ def test_computer_scroll_invalid_direction(mock_res):
     """computer('scroll') raises ValueError for an invalid direction string."""
     with pytest.raises(ValueError, match="Invalid scroll direction"):
         computer("scroll", text="sideways", coordinate=(512, 400))
+
+
+# ============================================================
+# _compute_change_ratio tests
+# ============================================================
+
+import tempfile
+from pathlib import Path
+
+from gptme.tools.computer import _compute_change_ratio
+
+
+def _make_png(color: tuple[int, int, int], size: tuple[int, int] = (100, 100)) -> Path:
+    """Create a temporary solid-colour PNG and return its path."""
+    from PIL import Image
+
+    img = Image.new("RGB", size, color)
+    f = tempfile.NamedTemporaryFile(suffix=".png", delete=False)
+    img.save(f.name)
+    f.close()
+    return Path(f.name)
+
+
+def test_compute_change_ratio_identical():
+    """Two identical images → 0% change."""
+    p = _make_png((100, 150, 200))
+    try:
+        assert _compute_change_ratio(p, p) == 0.0
+    finally:
+        p.unlink(missing_ok=True)
+
+
+def test_compute_change_ratio_totally_different():
+    """Completely different colours → 100% change."""
+    p1 = _make_png((0, 0, 0))
+    p2 = _make_png((255, 255, 255))
+    try:
+        ratio = _compute_change_ratio(p1, p2)
+        assert ratio == pytest.approx(1.0)
+    finally:
+        p1.unlink(missing_ok=True)
+        p2.unlink(missing_ok=True)
+
+
+def test_compute_change_ratio_partial():
+    """Half-black / half-white images → ~50% change."""
+    from PIL import Image
+
+    size = (100, 100)
+    img1 = Image.new("RGB", size, (0, 0, 0))
+    img2 = Image.new("RGB", size, (0, 0, 0))
+    # Paint the right half of img2 white
+    for x in range(50, 100):
+        for y in range(100):
+            img2.putpixel((x, y), (255, 255, 255))
+
+    f1 = tempfile.NamedTemporaryFile(suffix=".png", delete=False)
+    f2 = tempfile.NamedTemporaryFile(suffix=".png", delete=False)
+    img1.save(f1.name)
+    img2.save(f2.name)
+    f1.close()
+    f2.close()
+    p1, p2 = Path(f1.name), Path(f2.name)
+    try:
+        ratio = _compute_change_ratio(p1, p2)
+        assert 0.45 < ratio < 0.55
+    finally:
+        p1.unlink(missing_ok=True)
+        p2.unlink(missing_ok=True)
+
+
+def test_compute_change_ratio_missing_file():
+    """A missing file path returns 0.0 (no crash)."""
+    p = Path("/nonexistent/path.png")
+    assert _compute_change_ratio(p, p) == 0.0
+
+
+def test_compute_change_ratio_mismatched_sizes():
+    """Images with different sizes return 0.0 (uncomparable)."""
+    p1 = _make_png((0, 0, 0), size=(100, 100))
+    p2 = _make_png((255, 0, 0), size=(200, 200))
+    try:
+        assert _compute_change_ratio(p1, p2) == 0.0
+    finally:
+        p1.unlink(missing_ok=True)
+        p2.unlink(missing_ok=True)
+
+
+# ============================================================
+# wait_for_change action tests (unit — mocks screenshot/time)
+# ============================================================
+
+_MOCK_LINUX_RES_WFC = (1920, 1080)
+
+
+@mock.patch("gptme.tools.computer.IS_MACOS", False)
+@mock.patch(
+    "gptme.tools.computer._get_display_resolution", return_value=_MOCK_LINUX_RES_WFC
+)
+@mock.patch("gptme.tools.computer.get_transport", return_value=None)
+def test_wait_for_change_detects_change(mock_transport, mock_res, tmp_path):
+    """wait_for_change returns a message when the screen changes."""
+    from PIL import Image
+
+    def _solid(color):
+        p = tmp_path / f"{color}.png"
+        Image.new("RGB", (100, 100), color).save(p)
+        return p
+
+    baseline = _solid((0, 0, 0))
+    changed = _solid((255, 255, 255))
+
+    call_count = {"n": 0}
+
+    def _fake_screenshot():
+        call_count["n"] += 1
+        return baseline if call_count["n"] == 1 else changed
+
+    with (
+        mock.patch("gptme.tools.computer.screenshot", side_effect=_fake_screenshot),
+        mock.patch("gptme.tools.computer.time.sleep"),
+        mock.patch(
+            "gptme.tools.computer._make_screenshot_msg", return_value=mock.sentinel.msg
+        ),
+    ):
+        result = computer("wait_for_change", text="5")
+
+    assert result is mock.sentinel.msg
+
+
+@mock.patch("gptme.tools.computer.IS_MACOS", False)
+@mock.patch(
+    "gptme.tools.computer._get_display_resolution", return_value=_MOCK_LINUX_RES_WFC
+)
+@mock.patch("gptme.tools.computer.get_transport", return_value=None)
+def test_wait_for_change_timeout_returns_screenshot(mock_transport, mock_res, tmp_path):
+    """wait_for_change returns a screenshot even when timeout is reached without change."""
+    from PIL import Image
+
+    static = tmp_path / "static.png"
+    Image.new("RGB", (100, 100), (42, 42, 42)).save(static)
+
+    with (
+        mock.patch("gptme.tools.computer.screenshot", return_value=static),
+        mock.patch("gptme.tools.computer.time.sleep"),
+        mock.patch(
+            "gptme.tools.computer.time.monotonic", side_effect=[0.0, 0.0, 100.0]
+        ),
+        mock.patch(
+            "gptme.tools.computer._make_screenshot_msg",
+            return_value=mock.sentinel.timeout_msg,
+        ),
+    ):
+        result = computer("wait_for_change", text="1")
+
+    assert result is mock.sentinel.timeout_msg


### PR DESCRIPTION
## What

Adds `wait_for_change` to the computer tool's action set.

## Why this PR vs the existing primitives

Currently, implementing a "click → wait → verify" loop requires the agent to
repeatedly call `computer("screenshot")` and inspect each frame manually:

```python
computer("left_click", coordinate=(760, 540))   # trigger
computer("screenshot")                           # check — nothing yet
computer("screenshot")                           # check — still nothing
computer("screenshot")                           # check — now it loaded
```

Every intermediate screenshot accumulates in the conversation context and consumes
vision tokens on nearly-identical frames. `wait_for_change` internalizes the
polling loop and returns **exactly one screenshot** — the first frame where ≥1%
of pixels changed — regardless of how many polls were needed:

```python
computer("left_click", coordinate=(760, 540))   # trigger
computer("wait_for_change", text="10")           # one call, one screenshot returned
```

This directly addresses the efficiency concern in issue #216:
> "put it in a loop where it doesn't stack tons view/interact steps, maybe use a
> looping subagent or some kind of context-efficient tool-use loop"

## Changes

- `gptme/tools/computer.py`:
  - `_compute_change_ratio(path1, path2)` — pixel-diff helper (Pillow, no extra deps)
  - `Action` literal extended with `"wait_for_change"`
  - Native code path: polls with `screenshot()` at 0.5s intervals; threshold 1%
  - Transport code path: polls with `transport.screenshot()`; same logic
  - Updated module docstring, `instructions`, and `examples`

- `tests/test_tools_computer.py`:
  - 5 tests for `_compute_change_ratio` (identical, totally different, partial, missing file, size mismatch)
  - 2 tests for `wait_for_change` via mocks (change detected, timeout path)

All 7 new tests pass.

Closes #216