### PR TITLE
feat(tools): as_function_subtoolspecs() — invoke tool functions without IPython

### DIFF
--- a/gptme/tools/base.py
+++ b/gptme/tools/base.py
@@ -516,8 +516,8 @@ class ToolSpec:
         Example::
 
             for sub in browser_tool.as_function_subtoolspecs():
-                # sub.name == "browser.view_image" etc.
-                init_tools([sub])
+                if sub.name == "browser.view_image":
+                    list(sub.execute(None, None, {"path": "screenshot.png"}))
         """
         if not self.functions:
             return []

--- a/gptme/tools/base.py
+++ b/gptme/tools/base.py
@@ -531,6 +531,7 @@ class ToolSpec:
                     hints=tf.hints,
                     desc=tf.description or sub.desc,
                     parameters=list(tf.parameters) if tf.parameters else sub.parameters,
+                    available=self.available,
                 )
             )
         return specs

--- a/gptme/tools/base.py
+++ b/gptme/tools/base.py
@@ -527,6 +527,8 @@ class ToolSpec:
                     sub,
                     name=f"{self.name}.{tf.name}",
                     hints=tf.hints,
+                    desc=tf.description or sub.desc,
+                    parameters=list(tf.parameters) if tf.parameters else sub.parameters,
                 )
             )
         return specs

--- a/gptme/tools/base.py
+++ b/gptme/tools/base.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import dataclasses
 import importlib
 import importlib.util
 import inspect
@@ -490,7 +491,7 @@ class ToolSpec:
     def get_functions_description(self) -> str:
         # return a prompt with a brief description of the available functions
         if self.functions:
-            description = "The following Python functions are available using the `ipython` tool:\n\n```txt\n"
+            description = "The following Python functions are available:\n\n```txt\n"
             lines = []
             for tf in self.functions:
                 sig = callable_signature(tf.fn)
@@ -498,6 +499,37 @@ class ToolSpec:
                 lines.append(f"{sig}: {doc}")
             return description + "\n".join(lines) + "\n```"
         return "None"
+
+    def as_function_subtoolspecs(self) -> list[ToolSpec]:
+        """Expand each ToolFunction into its own independently invocable ToolSpec.
+
+        Returns one ToolSpec per ToolFunction, each with a direct ``execute``
+        handler that calls ``fn(**kwargs)`` without requiring IPython.
+        Sub-spec names follow the ``<parent>.<function_name>`` pattern, which
+        mirrors the MCP tool naming convention (e.g. ``discord.send_message``).
+
+        This allows agents to invoke helper functions even when the IPython
+        tool is not loaded.
+
+        Example::
+
+            for sub in browser_tool.as_function_subtoolspecs():
+                # sub.name == "browser.view_image" etc.
+                init_tools([sub])
+        """
+        if not self.functions:
+            return []
+        specs = []
+        for tf in self.functions:
+            sub = ToolSpec.from_function(tf.fn)
+            specs.append(
+                dataclasses.replace(
+                    sub,
+                    name=f"{self.name}.{tf.name}",
+                    hints=tf.hints,
+                )
+            )
+        return specs
 
     @classmethod
     def from_function(cls, fn: Callable) -> ToolSpec:

--- a/gptme/tools/base.py
+++ b/gptme/tools/base.py
@@ -48,7 +48,9 @@ ToolFormat: TypeAlias = Literal["markdown", "xml", "tool"]
 tool_format: ToolFormat = "markdown"
 
 # Match tool name and start of JSON
-toolcall_re = re.compile(r"^@(\w+)\(([\w\-:\.]+)\):\s*({.*)", re.MULTILINE | re.DOTALL)
+toolcall_re = re.compile(
+    r"^@([\w.]+)\(([\w\-:\.]+)\):\s*({.*)", re.MULTILINE | re.DOTALL
+)
 
 
 def find_json_end(s: str, start: int) -> int | None:

--- a/tests/test_tools_base.py
+++ b/tests/test_tools_base.py
@@ -737,6 +737,23 @@ class TestAsFunctionSubtoolspecs:
         assert len(sub.parameters) == 1
         assert sub.parameters[0].description == "The input value"
 
+    def test_subtool_inherits_parent_availability_guard(self):
+        def read_channel() -> str:
+            """Read a channel."""
+            return ""
+
+        tool = ToolSpec(
+            name="discord",
+            desc="",
+            available=lambda: False,
+            functions=[ToolFunction.from_callable(read_channel)],
+        )
+
+        subs = tool.as_function_subtoolspecs()
+
+        assert subs[0].available is tool.available
+        assert subs[0].is_available is False
+
 
 # ── Hint-based allowlist ───────────────────────────────────────────
 

--- a/tests/test_tools_base.py
+++ b/tests/test_tools_base.py
@@ -1032,6 +1032,15 @@ class TestToolUseToolFormat:
         assert tool_calls[0].call_id == "call-1"
         assert tool_calls[0].kwargs == {"command": "echo hi"}
 
+    def test_tool_call_parsing_allows_dotted_tool_names(self):
+        content = '@browser.view(call-1): {"url": "https://example.com"}'
+        uses = list(ToolUse.iter_from_content(content, tool_format_override="tool"))
+        tool_calls = [u for u in uses if u._format == "tool"]
+        assert len(tool_calls) == 1
+        assert tool_calls[0].tool == "browser.view"
+        assert tool_calls[0].call_id == "call-1"
+        assert tool_calls[0].kwargs == {"url": "https://example.com"}
+
     def test_tool_call_inside_codeblock_skipped(self):
         content = '```example\n@shell(id-1): {"cmd": "test"}\n```'
         uses = list(ToolUse.iter_from_content(content, tool_format_override="tool"))

--- a/tests/test_tools_base.py
+++ b/tests/test_tools_base.py
@@ -609,6 +609,114 @@ class TestToolSpecFromFunction:
         assert any("got:world" in m.content for m in msgs)
 
 
+# ── ToolSpec.as_function_subtoolspecs ─────────────────────────────
+
+
+class TestAsFunctionSubtoolspecs:
+    def test_empty_when_no_functions(self):
+        tool = ToolSpec(name="browser", desc="")
+        assert tool.as_function_subtoolspecs() == []
+
+    def test_one_subtool_per_function(self):
+        def view(url: str) -> str:
+            """View a URL."""
+            return url
+
+        def screenshot() -> str:
+            """Take a screenshot."""
+            return "ok"
+
+        tool = ToolSpec(
+            name="browser",
+            desc="",
+            functions=[
+                ToolFunction.from_callable(view),
+                ToolFunction.from_callable(screenshot),
+            ],
+        )
+        subs = tool.as_function_subtoolspecs()
+        assert len(subs) == 2
+
+    def test_subtool_names_are_qualified(self):
+        def view(url: str) -> str:
+            """View a URL."""
+            return url
+
+        tool = ToolSpec(
+            name="browser",
+            desc="",
+            functions=[ToolFunction.from_callable(view)],
+        )
+        subs = tool.as_function_subtoolspecs()
+        assert subs[0].name == "browser.view"
+
+    def test_subtool_is_runnable(self):
+        def greet(name: str) -> str:
+            """Greet someone."""
+            return f"hi {name}"
+
+        tool = ToolSpec(
+            name="chat",
+            desc="",
+            functions=[ToolFunction.from_callable(greet)],
+        )
+        subs = tool.as_function_subtoolspecs()
+        assert subs[0].is_runnable
+
+    def test_subtool_executes_without_ipython(self):
+        """Functions in sub-toolspecs must run without importing IPython."""
+        import sys
+
+        def double(n: str) -> str:
+            """Double a number string."""
+            return str(int(n) * 2)
+
+        tool = ToolSpec(
+            name="math",
+            desc="",
+            functions=[ToolFunction.from_callable(double)],
+        )
+        before = "IPython" in sys.modules
+        subs = tool.as_function_subtoolspecs()
+        after = "IPython" in sys.modules
+        assert before == after, "IPython must not be imported during subtool expansion"
+
+        sub = subs[0]
+        assert sub.execute is not None
+        msgs = list(sub.execute(None, None, {"n": "6"}))  # type: ignore[arg-type]
+        assert any("12" in m.content for m in msgs)
+
+    def test_subtool_inherits_hints(self):
+        def read_channel() -> str:
+            """Read a channel."""
+            return ""
+
+        tf = ToolFunction(
+            name="read_channel",
+            fn=read_channel,
+            hints=frozenset({"read-only"}),
+        )
+        tool = ToolSpec(name="discord", desc="", functions=[tf])
+        subs = tool.as_function_subtoolspecs()
+        assert "read-only" in subs[0].hints
+
+    def test_subtool_name_allows_glob_allowlist(self):
+        """Sub-tool names like discord.read_channel match 'discord.*' patterns."""
+        from gptme.tools._allowlist import tool_matches_allowlist
+
+        def read_channel() -> str:
+            """Read a channel."""
+            return ""
+
+        tool = ToolSpec(
+            name="discord",
+            desc="",
+            functions=[ToolFunction.from_callable(read_channel)],
+        )
+        subs = tool.as_function_subtoolspecs()
+        assert tool_matches_allowlist(subs[0].name, ["discord.*"])
+
+
 # ── Hint-based allowlist ───────────────────────────────────────────
 
 

--- a/tests/test_tools_base.py
+++ b/tests/test_tools_base.py
@@ -716,6 +716,27 @@ class TestAsFunctionSubtoolspecs:
         subs = tool.as_function_subtoolspecs()
         assert tool_matches_allowlist(subs[0].name, ["discord.*"])
 
+    def test_subtool_honours_custom_description_and_parameters(self):
+        """Custom description/parameters on ToolFunction must not be discarded."""
+
+        def fn(x: str) -> str:
+            """Auto-derived description (should be overridden)."""
+            return x
+
+        custom_param = Parameter(name="x", type="string", description="The input value")
+        tf = ToolFunction(
+            name="fn",
+            fn=fn,
+            description="Richer prose description",
+            parameters=[custom_param],
+        )
+        tool = ToolSpec(name="mytool", desc="", functions=[tf])
+        subs = tool.as_function_subtoolspecs()
+        sub = subs[0]
+        assert sub.desc == "Richer prose description"
+        assert len(sub.parameters) == 1
+        assert sub.parameters[0].description == "The input value"
+
 
 # ── Hint-based allowlist ───────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Adds `ToolSpec.as_function_subtoolspecs()` — a method that expands each `ToolFunction` in a tool's `functions=` list into its own independently executable `ToolSpec`. Each sub-spec can be invoked directly via its own `execute` handler, with no IPython dependency.

This closes the key remaining gap from issue #607: tools whose helper functions are currently only accessible through the IPython REPL can now be exposed directly to agents that don't load the IPython tool.

Key changes:

- **`ToolSpec.as_function_subtoolspecs() -> list[ToolSpec]`**: creates one ToolSpec per ToolFunction; sub-spec names follow `parent.function_name` (e.g. `browser.view_image`), mirroring the MCP tool naming convention that already supports `discord.*` glob allowlists.
- **Sub-specs inherit `hints`** from their `ToolFunction`, enabling `hint:read-only` allowlist filtering.
- **`get_functions_description()` no longer mentions "the `ipython` tool"** — the description is now runtime-neutral since functions can run without IPython via `from_function()` / subtoolspecs.
- 7 new unit tests: empty functions list, count, qualified names, `is_runnable`, no-IPython-import, hints inheritance, and glob allowlist matching.

## Relationship to prior work

- PR #2893 added `ToolSpec.from_function()` and `ToolFunction.from_callable()` (already merged)
- PR #2890 added `_allowlist.py` with glob + `hint:` patterns (already merged)
- This PR completes the follow-on mentioned in #2893: making functions runtime-independent

Closes #607 (partial — function listing decoupled from IPython; each function now independently invocable via `as_function_subtoolspecs()`)

## Test plan

- [x] 7 new `TestAsFunctionSubtoolspecs` tests pass
- [x] All 142 `test_tools_base.py` tests pass
- [x] ruff check + format clean
- [x] mypy clean on `gptme/tools/base.py`