### PR TITLE
feat(webui/tts): add ttsAuthToken setting for cloud-authenticated TTS

### DIFF
--- a/webui/src/contexts/SettingsContext.tsx
+++ b/webui/src/contexts/SettingsContext.tsx
@@ -34,6 +34,11 @@ export interface Settings {
    * Bearer token sent with /api/v2/audio/speech requests.
    * Set by cloud hosts (e.g. gptme.ai) so TTS can be billed to the user's account.
    * Leave empty for self-hosted / unauthenticated endpoints.
+   *
+   * Token lifecycle: cloud hosts MUST call `updateSettings({ ttsAuthToken: '' })` on
+   * logout to clear this from localStorage. The token persists across page reloads
+   * intentionally (to avoid re-authentication overhead), so explicit logout cleanup is
+   * required.
    */
   ttsAuthToken: string;
   /**

--- a/webui/src/contexts/SettingsContext.tsx
+++ b/webui/src/contexts/SettingsContext.tsx
@@ -31,6 +31,12 @@ export interface Settings {
    */
   ttsServerUrl: string;
   /**
+   * Bearer token sent with /api/v2/audio/speech requests.
+   * Set by cloud hosts (e.g. gptme.ai) so TTS can be billed to the user's account.
+   * Leave empty for self-hosted / unauthenticated endpoints.
+   */
+  ttsAuthToken: string;
+  /**
    * WebSocket URL for the gptme-voice-server /voice endpoint, e.g. ws://localhost:5700/voice.
    * Leave empty to hide the VoiceButton.
    */
@@ -59,6 +65,7 @@ const defaultSettings: Settings = {
   hasCompletedSetup: false,
   welcomeBackground: '',
   ttsServerUrl: '',
+  ttsAuthToken: '',
   voiceServerUrl: '',
   noConfirmMode: false,
 };

--- a/webui/src/utils/tts.ts
+++ b/webui/src/utils/tts.ts
@@ -42,6 +42,7 @@ function getSettings(): {
   ttsEnabled: boolean;
   ttsServerUrl: string;
   ttsProvider: TtsProvider;
+  ttsAuthToken: string;
 } {
   try {
     const saved = localStorage.getItem('gptme-settings');
@@ -56,12 +57,13 @@ function getSettings(): {
         ttsEnabled: s.ttsEnabled === true,
         ttsServerUrl: typeof s.ttsServerUrl === 'string' ? s.ttsServerUrl.trim() : '',
         ttsProvider: provider,
+        ttsAuthToken: typeof s.ttsAuthToken === 'string' ? s.ttsAuthToken : '',
       };
     }
   } catch {
     // ignore
   }
-  return { ttsEnabled: false, ttsServerUrl: '', ttsProvider: 'auto' };
+  return { ttsEnabled: false, ttsServerUrl: '', ttsProvider: 'auto', ttsAuthToken: '' };
 }
 
 /** Strip markdown so the spoken text sounds natural. */
@@ -130,9 +132,14 @@ async function speakViaLocalEndpoint(text: string, key: string): Promise<void> {
   const controller = new AbortController();
   currentFetchController = controller;
   try {
+    const { ttsAuthToken } = getSettings();
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    if (ttsAuthToken) {
+      headers['Authorization'] = `Bearer ${ttsAuthToken}`;
+    }
     const response = await fetch('/api/v2/audio/speech', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers,
       body: JSON.stringify({ text }),
       signal: controller.signal,
     });

--- a/webui/src/utils/tts.ts
+++ b/webui/src/utils/tts.ts
@@ -57,7 +57,7 @@ function getSettings(): {
         ttsEnabled: s.ttsEnabled === true,
         ttsServerUrl: typeof s.ttsServerUrl === 'string' ? s.ttsServerUrl.trim() : '',
         ttsProvider: provider,
-        ttsAuthToken: typeof s.ttsAuthToken === 'string' ? s.ttsAuthToken : '',
+        ttsAuthToken: typeof s.ttsAuthToken === 'string' ? s.ttsAuthToken.trim() : '',
       };
     }
   } catch {


### PR DESCRIPTION
## Summary

Adds `ttsAuthToken` to the webui `Settings` interface and passes it as an
`Authorization: Bearer` header when calling `/api/v2/audio/speech`.

This enables cloud hosts (e.g. gptme.ai) to inject a user auth token so TTS
calls can be billed to the user's account, without changing the self-hosted
behaviour (token defaults to empty string → no header sent).

### Changes

- **`src/contexts/SettingsContext.tsx`** — adds `ttsAuthToken: string` to
  `Settings` interface (default `''`) with a JSDoc comment explaining its
  purpose
- **`src/utils/tts.ts`** — reads `ttsAuthToken` from settings in
  `speakViaLocalEndpoint`; when non-empty, attaches `Authorization: Bearer
  <token>` to the fetch request

### Self-hosted behaviour

No change. `ttsAuthToken` defaults to `''` — the header is not sent, and
the existing endpoint/fallback logic is unchanged.

### Cloud usage

The host page calls `updateSettings({ ttsAuthToken: session.access_token })`
after Supabase login. See companion PR: gptme/gptme-cloud#388

## Test plan

- [ ] Self-hosted: TTS still works without any auth header
- [ ] Cloud: `ttsAuthToken` gets set and Bearer header appears in `/api/v2/audio/speech` request (devtools Network tab)