### PR TITLE
feat(webui): add 'Try the offline demo' CTA to disconnected state

### DIFF
--- a/webui/src/components/WelcomeView.tsx
+++ b/webui/src/components/WelcomeView.tsx
@@ -433,6 +433,25 @@ export const WelcomeView = () => {
                       for a managed option — no install required.
                     </p>
                   )}
+                  {isHostedOrigin && !demoMode && (
+                    <p className="text-sm text-muted-foreground">
+                      Just want to see what gptme can do?{' '}
+                      <Button
+                        type="button"
+                        variant="link"
+                        size="sm"
+                        className="h-auto p-0 text-sm"
+                        onClick={() => {
+                          const url = new URL(window.location.href);
+                          url.searchParams.set('demo', '1');
+                          window.location.href = url.toString();
+                        }}
+                      >
+                        Try the offline demo
+                      </Button>{' '}
+                      — no install or account required.
+                    </p>
+                  )}
                   <p className="text-xs text-muted-foreground">
                     Need help connecting?{' '}
                     <a

--- a/webui/src/components/__tests__/WelcomeView.test.tsx
+++ b/webui/src/components/__tests__/WelcomeView.test.tsx
@@ -521,4 +521,73 @@ describe('WelcomeView', () => {
     expect(screen.getByText(/connection timed out/i)).toBeInTheDocument();
     expect(screen.queryByText(/Start a local gptme server/i)).not.toBeInTheDocument();
   });
+
+  describe('demo CTA', () => {
+    beforeEach(() => {
+      seedReturningUser();
+      isConnected$.set(false);
+    });
+
+    it('shows "Try the offline demo" CTA on hosted origin when disconnected', () => {
+      setLocation('https://chat.gptme.org/');
+
+      render(
+        <SettingsProvider>
+          <WelcomeView />
+        </SettingsProvider>
+      );
+
+      expect(screen.getByText(/just want to see what gptme can do/i)).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /try the offline demo/i })).toBeInTheDocument();
+      expect(screen.getByText(/no install or account required/i)).toBeInTheDocument();
+    });
+
+    it('suppresses demo CTA when already in demo mode', () => {
+      setLocation('https://chat.gptme.org/?demo=1');
+      mockIsDemoMode.mockReturnValue(true);
+
+      render(
+        <SettingsProvider>
+          <WelcomeView />
+        </SettingsProvider>
+      );
+
+      expect(screen.queryByText(/just want to see what gptme can do/i)).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: /try the offline demo/i })
+      ).not.toBeInTheDocument();
+    });
+
+    it('suppresses demo CTA on localhost origin', () => {
+      setLocation('http://localhost/');
+
+      render(
+        <SettingsProvider>
+          <WelcomeView />
+        </SettingsProvider>
+      );
+
+      expect(screen.queryByText(/just want to see what gptme can do/i)).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: /try the offline demo/i })
+      ).not.toBeInTheDocument();
+    });
+
+    it('navigates to ?demo=1 when clicking the demo CTA', () => {
+      setLocation('https://chat.gptme.org/');
+
+      render(
+        <SettingsProvider>
+          <WelcomeView />
+        </SettingsProvider>
+      );
+
+      const btn = screen.getByRole('button', { name: /try the offline demo/i });
+      fireEvent.click(btn);
+
+      // jsdom sets window.location.href on assignment, constructing
+      // a URL with ?demo=1 appended.
+      expect(window.location.href).toContain('demo=1');
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Adds a **"Try the offline demo"** link to the disconnected welcome screen in gptme-webui
- Shown only when `isHostedOrigin && !demoMode` — i.e. on chat.gptme.org when not already in demo mode
- Clicking it navigates to `?demo=1`, which activates the fully-offline `createDemoApiClient` fixture client (no install, no account, no backend required)

## Context

The offline demo client (`createDemoApiClient` in `demoApiClient.ts`) is fully implemented — it handles all three demo slices (seam, fixtures, event replay). The `?demo=1` URL flag activates it. But there was no entry-point CTA: anonymous visitors on chat.gptme.org landed on the disconnected screen with no way to discover the demo existed.

This PR closes that last mile. The anonymous visitor flow now works end-to-end:
1. Visit chat.gptme.org
2. See "Try the offline demo" link
3. Click → navigate to `?demo=1`
4. Chat with the Fibonacci fixture, zero setup

## Test plan

- [ ] Visit chat.gptme.org (or a local dev server with `VITE_IS_HOSTED_ORIGIN=true`) while disconnected — CTA appears
- [ ] Click "Try the offline demo" → URL updates to `?demo=1`, demo loads
- [ ] CTA hidden when already in `?demo=1` mode (demoMode=true)
- [ ] CTA hidden on localhost (isHostedOrigin=false)
- [ ] No layout regressions in the disconnected state for returning vs first-time visitors