### PR TITLE
feat(webui/stt): add sttAuthToken setting for cloud-authenticated STT

### DIFF
--- a/webui/src/contexts/SettingsContext.tsx
+++ b/webui/src/contexts/SettingsContext.tsx
@@ -42,6 +42,17 @@ export interface Settings {
    */
   ttsAuthToken: string;
   /**
+   * Bearer token sent with /api/v2/audio/transcriptions requests.
+   * Set by cloud hosts (e.g. gptme.ai) so STT can be billed to the user's account.
+   * When set, STT uses the same-origin /api/v2/audio/transcriptions endpoint
+   * (e.g. a Cloudflare Pages Function proxy) instead of the connected gptme server.
+   * Leave empty for self-hosted / unauthenticated endpoints.
+   *
+   * Token lifecycle: cloud hosts MUST call `updateSettings({ sttAuthToken: '' })` on
+   * logout to clear this from localStorage.
+   */
+  sttAuthToken: string;
+  /**
    * WebSocket URL for the gptme-voice-server /voice endpoint, e.g. ws://localhost:5700/voice.
    * Leave empty to hide the VoiceButton.
    */
@@ -71,6 +82,7 @@ const defaultSettings: Settings = {
   welcomeBackground: '',
   ttsServerUrl: '',
   ttsAuthToken: '',
+  sttAuthToken: '',
   voiceServerUrl: '',
   noConfirmMode: false,
 };

--- a/webui/src/hooks/__tests__/useSpeechToText.test.tsx
+++ b/webui/src/hooks/__tests__/useSpeechToText.test.tsx
@@ -4,6 +4,7 @@ import { useSpeechToText } from '../useSpeechToText';
 const transcribeAudio = jest.fn();
 const useUserSettingsMock = jest.fn();
 const useSettingsMock = jest.fn();
+const fetchMock = jest.fn();
 
 jest.mock('@/contexts/ApiContext', () => ({
   useApi: () => ({
@@ -80,6 +81,16 @@ beforeEach(() => {
   transcribeAudio.mockResolvedValue({
     text: 'server transcript',
     model: 'openai/whisper-1',
+  });
+  fetchMock.mockReset();
+  fetchMock.mockResolvedValue({
+    ok: true,
+    json: jest.fn().mockResolvedValue({ text: 'cloud transcript' }),
+  });
+  Object.defineProperty(globalThis, 'fetch', {
+    configurable: true,
+    writable: true,
+    value: fetchMock,
   });
 
   Object.defineProperty(window, 'MediaRecorder', {
@@ -264,5 +275,55 @@ describe('useSpeechToText', () => {
 
     expect(transcribeAudio.mock.calls[0]?.[1]).toEqual(expect.objectContaining({ language: 'en' }));
     expect(handler).toHaveBeenCalledWith('server transcript');
+  });
+
+  it('uses the refreshed sttAuthToken for cloud transcription without recreating the callback', async () => {
+    const handler = jest.fn();
+    useUserSettingsMock.mockReturnValue({
+      settings: { providers_configured: [] },
+      isLoading: false,
+      error: null,
+      refetch: jest.fn(),
+    });
+
+    let settings = { sttProvider: 'server', sttAuthToken: 'token-1' };
+    useSettingsMock.mockImplementation(() => ({
+      settings,
+      updateSettings: jest.fn(),
+      resetSettings: jest.fn(),
+    }));
+
+    const { result, rerender } = renderHook(() => useSpeechToText());
+
+    settings = { ...settings, sttAuthToken: 'token-2' };
+    rerender();
+
+    act(() => {
+      result.current.onFinalResult(handler);
+      result.current.startListening();
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    act(() => {
+      result.current.stopListening();
+    });
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+    await waitFor(() => {
+      expect(result.current.state).toBe('idle');
+    });
+
+    expect(fetchMock.mock.calls[0]?.[1]).toEqual(
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: 'Bearer token-2' }),
+      })
+    );
+    expect(handler).toHaveBeenCalledWith('cloud transcript');
+    expect(transcribeAudio).not.toHaveBeenCalled();
   });
 });

--- a/webui/src/hooks/useSpeechToText.ts
+++ b/webui/src/hooks/useSpeechToText.ts
@@ -81,6 +81,40 @@ function getLanguageCode(): string | undefined {
   return locale.split('-', 1)[0]?.toLowerCase() || undefined;
 }
 
+/**
+ * Transcribe audio via a same-origin cloud endpoint (e.g. a Cloudflare Pages
+ * Function proxy to the billing-aware llm-proxy). Used when `sttAuthToken` is
+ * set by a cloud host (e.g. gptme.ai) so STT is billed to the user's account.
+ */
+async function transcribeViaCloudEndpoint(
+  audio: Blob,
+  authToken: string,
+  options?: { language?: string; signal?: AbortSignal }
+): Promise<string> {
+  const format = audio.type.split(';', 1)[0].split('/')[1] || 'webm';
+  const formData = new FormData();
+  formData.append('file', audio, `speech.${format}`);
+  formData.append('format', format);
+  if (options?.language) {
+    formData.append('language', options.language);
+  }
+  const response = await fetch('/api/v2/audio/transcriptions', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${authToken}` },
+    body: formData,
+    signal: options?.signal,
+  });
+  if (!response.ok) {
+    const err = await response.json().catch(() => ({}));
+    throw new Error(
+      (err as { error?: { message?: string } }).error?.message ??
+        `Transcription failed: ${response.status}`
+    );
+  }
+  const data = (await response.json()) as { text: string };
+  return data.text;
+}
+
 export function useSpeechToText(): UseSpeechToTextReturn {
   const { api } = useApi();
   const { settings: userSettings } = useUserSettings();
@@ -95,8 +129,12 @@ export function useSpeechToText(): UseSpeechToTextReturn {
   const abortControllerRef = useRef<AbortController | null>(null);
   const SpeechRecognitionClass = getSpeechRecognitionClass();
   const browserSupported = SpeechRecognitionClass !== null;
+  // Cloud hosts set sttAuthToken so the same-origin /api/v2/audio/transcriptions
+  // proxy (e.g. Cloudflare Pages Function) handles billing — no OpenRouter key needed.
+  const cloudSttConfigured = !!clientSettings.sttAuthToken && canUseRecordedFallback();
   const serverConfigured =
-    userSettings?.providers_configured.includes('openrouter') === true && canUseRecordedFallback();
+    (userSettings?.providers_configured.includes('openrouter') === true || cloudSttConfigured) &&
+    canUseRecordedFallback();
   const prefersServerStt = clientSettings.sttProvider === 'server';
   const serverFallbackSupported = !browserSupported && serverConfigured;
   // When user explicitly chooses server mode, use server STT even if browser supports it
@@ -234,12 +272,23 @@ export function useSpeechToText(): UseSpeechToTextReturn {
           abortControllerRef.current = controller;
 
           setState('transcribing');
-          void api
-            .transcribeAudio(audio, { language: getLanguageCode(), signal: controller.signal })
-            .then((result) => {
-              const text = result.text.trim();
-              if (text && finalHandlerRef.current) {
-                finalHandlerRef.current(text);
+          const sttAuthToken = clientSettings.sttAuthToken;
+          const transcribePromise: Promise<string> = sttAuthToken
+            ? transcribeViaCloudEndpoint(audio, sttAuthToken, {
+                language: getLanguageCode() ?? undefined,
+                signal: controller.signal,
+              })
+            : api
+                .transcribeAudio(audio, {
+                  language: getLanguageCode(),
+                  signal: controller.signal,
+                })
+                .then((r) => r.text);
+          void transcribePromise
+            .then((text) => {
+              const trimmed = text.trim();
+              if (trimmed && finalHandlerRef.current) {
+                finalHandlerRef.current(trimmed);
               }
               setState('idle');
             })

--- a/webui/src/hooks/useSpeechToText.ts
+++ b/webui/src/hooks/useSpeechToText.ts
@@ -127,6 +127,7 @@ export function useSpeechToText(): UseSpeechToTextReturn {
   const fallbackSetupGenRef = useRef(0);
   const finalHandlerRef = useRef<((text: string) => void) | null>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
+  const sttAuthTokenRef = useRef(clientSettings.sttAuthToken);
   const SpeechRecognitionClass = getSpeechRecognitionClass();
   const browserSupported = SpeechRecognitionClass !== null;
   // Cloud hosts set sttAuthToken so the same-origin /api/v2/audio/transcriptions
@@ -140,6 +141,10 @@ export function useSpeechToText(): UseSpeechToTextReturn {
   // When user explicitly chooses server mode, use server STT even if browser supports it
   const serverEnabled = serverConfigured && (prefersServerStt || serverFallbackSupported);
   const isSupported = browserSupported || serverConfigured;
+
+  useEffect(() => {
+    sttAuthTokenRef.current = clientSettings.sttAuthToken;
+  }, [clientSettings.sttAuthToken]);
 
   const releaseRecordingSession = useCallback((session: RecordingSession | null) => {
     session?.stream.getTracks().forEach((track) => track.stop());
@@ -272,7 +277,7 @@ export function useSpeechToText(): UseSpeechToTextReturn {
           abortControllerRef.current = controller;
 
           setState('transcribing');
-          const sttAuthToken = clientSettings.sttAuthToken;
+          const sttAuthToken = sttAuthTokenRef.current;
           const transcribePromise: Promise<string> = sttAuthToken
             ? transcribeViaCloudEndpoint(audio, sttAuthToken, {
                 language: getLanguageCode() ?? undefined,


### PR DESCRIPTION
## Summary

- Adds `sttAuthToken: string` to `Settings` in `SettingsContext.tsx` (parallel to `ttsAuthToken`)
- When `sttAuthToken` is set, server STT is considered available regardless of `providers_configured` (so cloud fleet instances without a direct OpenRouter key still show the mic button)
- Transcription uses `fetch('/api/v2/audio/transcriptions')` with the token (same-origin) instead of `api.transcribeAudio()` (which goes to the connected gptme server URL)

## Context

Cloud hosts (e.g. gptme.ai) route TTS through a same-origin Cloudflare Pages Function using `ttsAuthToken`. STT needs the same treatment: fleet instances use `LLM_PROXY_URL`/`LLM_PROXY_API_KEY` rather than a direct `OPENROUTER_API_KEY`, so `providers_configured` never includes `openrouter` → the server STT path was never activated for cloud users.

The cloud-side wiring (Pages Function + Supabase edge function + `Chat.tsx` update) is in gptme/gptme-cloud#27.

## Test plan
- [ ] Browser STT (SpeechRecognition API) continues to work unchanged when `sttAuthToken` is empty
- [ ] Server STT via `api.transcribeAudio()` continues to work for self-hosted instances
- [ ] When `sttAuthToken` is set, mic button appears even if `providers_configured` lacks `openrouter`
- [ ] When `sttAuthToken` is set, transcription goes to relative `/api/v2/audio/transcriptions` with Bearer token