### PR TITLE
feat(computer): add window_focus action for reliable new-window targeting

### DIFF
--- a/gptme/tools/computer.py
+++ b/gptme/tools/computer.py
@@ -597,41 +597,60 @@ def _linux_window_focus(pattern: str, display: str, timeout: float = 10.0) -> No
         ) from e
 
 
-def _macos_window_focus(pattern: str) -> None:
+def _macos_window_focus(pattern: str, timeout: float = 10.0) -> None:
     """Focus the frontmost application whose name contains pattern on macOS.
 
-    Uses AppleScript via ``osascript``.  The pattern is matched case-sensitively
-    against the process name (not the window title).
+    Uses AppleScript via ``osascript`` with a Python-level retry loop so the
+    call blocks until a matching window appears or the timeout expires — matching
+    the blocking semantics of the Linux xdotool path.
 
     Args:
         pattern: Substring matched against application/process name.
+        timeout: Seconds to wait for the window to appear (default 10).
     """
     # Escape for embedding inside an AppleScript string literal
     safe = pattern.replace("\\", "\\\\").replace('"', '\\"')
     script = (
         'tell application "System Events"\n'
+        "  set found to false\n"
         "  repeat with p in (every process whose background only is false)\n"
         f'    if name of p contains "{safe}" then\n'
         "      set frontmost of p to true\n"
-        "      return\n"
+        "      set found to true\n"
+        "      exit repeat\n"
         "    end if\n"
         "  end repeat\n"
+        "  if found then\n"
+        '    return "found"\n'
+        "  else\n"
+        '    return "not_found"\n'
+        "  end if\n"
         "end tell"
     )
-    try:
-        subprocess.run(
-            ["osascript", "-e", script],
-            check=True,
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except subprocess.TimeoutExpired as e:
-        raise RuntimeError(f"window_focus timed out for pattern {pattern!r}") from e
-    except subprocess.CalledProcessError as e:
-        raise RuntimeError(
-            f"Failed to focus window matching {pattern!r}: {e.stderr}"
-        ) from e
+    deadline = time.monotonic() + timeout
+    while True:
+        try:
+            result = subprocess.run(
+                ["osascript", "-e", script],
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+        except subprocess.TimeoutExpired as e:
+            raise RuntimeError(f"window_focus timed out for pattern {pattern!r}") from e
+        except subprocess.CalledProcessError as e:
+            raise RuntimeError(
+                f"Failed to focus window matching {pattern!r}: {e.stderr}"
+            ) from e
+
+        if result.stdout.strip() == "found":
+            return
+        if time.monotonic() >= deadline:
+            raise RuntimeError(
+                f"No window matching {pattern!r} appeared within {timeout:.0f}s"
+            )
+        time.sleep(0.5)
 
 
 def _macos_click(button: int) -> None:

--- a/gptme/tools/computer.py
+++ b/gptme/tools/computer.py
@@ -608,30 +608,31 @@ def _macos_window_focus(pattern: str, timeout: float = 10.0) -> None:
         pattern: Substring matched against application/process name.
         timeout: Seconds to wait for the window to appear (default 10).
     """
-    # Escape for embedding inside an AppleScript string literal
-    safe = pattern.replace("\\", "\\\\").replace('"', '\\"')
     script = (
-        'tell application "System Events"\n'
-        "  set found to false\n"
-        "  repeat with p in (every process whose background only is false)\n"
-        f'    if name of p contains "{safe}" then\n'
-        "      set frontmost of p to true\n"
-        "      set found to true\n"
-        "      exit repeat\n"
+        "on run argv\n"
+        "  set needle to item 1 of argv\n"
+        '  tell application "System Events"\n'
+        "    set found to false\n"
+        "    repeat with p in (every process whose background only is false)\n"
+        "      if name of p contains needle then\n"
+        "        set frontmost of p to true\n"
+        "        set found to true\n"
+        "        exit repeat\n"
+        "      end if\n"
+        "    end repeat\n"
+        "    if found then\n"
+        '      return "found"\n'
+        "    else\n"
+        '      return "not_found"\n'
         "    end if\n"
-        "  end repeat\n"
-        "  if found then\n"
-        '    return "found"\n'
-        "  else\n"
-        '    return "not_found"\n'
-        "  end if\n"
-        "end tell"
+        "  end tell\n"
+        "end run"
     )
     deadline = time.monotonic() + timeout
     while True:
         try:
             result = subprocess.run(
-                ["osascript", "-e", script],
+                ["osascript", "-e", script, pattern],
                 check=True,
                 capture_output=True,
                 text=True,

--- a/gptme/tools/computer.py
+++ b/gptme/tools/computer.py
@@ -56,6 +56,9 @@ Screen:
     - cursor_position: Get current mouse position
     - wait_for_change: Poll until screen changes, then return one screenshot
 
+Window management:
+    - window_focus: Wait for a window matching a name pattern to appear and focus it
+
 The tool automatically handles screen resolution scaling to ensure optimal performance
 with LLM vision capabilities.
 
@@ -162,6 +165,7 @@ Action = Literal[
     "screenshot",
     "cursor_position",
     "wait_for_change",
+    "window_focus",
 ]
 
 ScrollDirection = Literal["up", "down", "left", "right"]
@@ -550,6 +554,86 @@ def _macos_scroll(x: int, y: int, direction: str, amount: int = 3) -> None:
     CGEventPost(kCGHIDEventTap, event)
 
 
+def _linux_window_focus(pattern: str, display: str, timeout: float = 10.0) -> None:
+    """Wait for a window matching the name pattern to appear and focus it.
+
+    Uses xdotool's ``--sync`` flag so the call blocks until the window exists,
+    then focuses it.  This avoids the screenshot-polling workaround previously
+    needed when opening new terminal windows in X11 environments.
+
+    Args:
+        pattern: Substring matched against WM_NAME (window title).
+        display: X11 display string (e.g. ":1").
+        timeout: Seconds to wait for the window to appear (default 10).
+    """
+    env = os.environ.copy()
+    env["DISPLAY"] = display
+    try:
+        subprocess.run(
+            [
+                "xdotool",
+                "search",
+                "--sync",
+                "--limit",
+                "1",
+                "--name",
+                pattern,
+                "windowfocus",
+                "--sync",
+            ],
+            env=env,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=timeout + 2,  # extra headroom beyond the xdotool sync wait
+        )
+    except subprocess.TimeoutExpired as e:
+        raise RuntimeError(
+            f"No window matching {pattern!r} appeared within {timeout:.0f}s"
+        ) from e
+    except subprocess.CalledProcessError as e:
+        raise RuntimeError(
+            f"xdotool search/focus failed for pattern {pattern!r}: {e.stderr}"
+        ) from e
+
+
+def _macos_window_focus(pattern: str) -> None:
+    """Focus the frontmost application whose name contains pattern on macOS.
+
+    Uses AppleScript via ``osascript``.  The pattern is matched case-sensitively
+    against the process name (not the window title).
+
+    Args:
+        pattern: Substring matched against application/process name.
+    """
+    # Escape for embedding inside an AppleScript string literal
+    safe = pattern.replace("\\", "\\\\").replace('"', '\\"')
+    script = (
+        'tell application "System Events"\n'
+        "  repeat with p in (every process whose background only is false)\n"
+        f'    if name of p contains "{safe}" then\n'
+        "      set frontmost of p to true\n"
+        "      return\n"
+        "    end if\n"
+        "  end repeat\n"
+        "end tell"
+    )
+    try:
+        subprocess.run(
+            ["osascript", "-e", script],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except subprocess.TimeoutExpired as e:
+        raise RuntimeError(f"window_focus timed out for pattern {pattern!r}") from e
+    except subprocess.CalledProcessError as e:
+        raise RuntimeError(
+            f"Failed to focus window matching {pattern!r}: {e.stderr}"
+        ) from e
+
+
 def _macos_click(button: int) -> None:
     """
     Click mouse button using cliclick on macOS.
@@ -710,6 +794,13 @@ def _dispatch_transport(
             f"No screen change detected after {timeout:.0f}s — returning current screenshot"
         )
         return _make_screenshot_msg(transport.screenshot())
+
+    if action == "window_focus":
+        if not text:
+            raise ValueError("text (window name pattern) is required for window_focus")
+        transport.window_focus(text)
+        print(f"Focused window matching: {text!r}")
+        return None
 
     raise ValueError(f"Invalid action: {action}")
 
@@ -988,6 +1079,15 @@ def computer(
             ):
                 pass
         return _make_screenshot_msg(path)
+    if action == "window_focus":
+        if not text:
+            raise ValueError("text (window name pattern) is required for window_focus")
+        if IS_MACOS:
+            _macos_window_focus(text)
+        else:
+            _linux_window_focus(text, display)
+        print(f"Focused window matching: {text!r}")
+        return None
     raise ValueError(f"Invalid action: {action}")
 
 
@@ -1134,6 +1234,9 @@ Available actions:
   of how many internal polls were needed — avoids stacking redundant screenshots in
   the conversation context. Use after triggering an action that produces a visual
   response (page load, dialog open, animation finish).
+- window_focus: Wait for a window whose title contains text=<pattern> to appear,
+  then focus it. On Linux/X11 this uses xdotool --sync so no screenshot polling
+  is needed. Use after opening a new application to avoid guessing where to click.
 
 ### Efficient action-verify loops
 
@@ -1145,6 +1248,17 @@ Prefer wait_for_change over immediate screenshot after triggering UI changes:
 This prevents the conversation from accumulating multiple nearly-identical
 screenshots during transitions. Only call screenshot() directly when you need
 the current state without waiting.
+
+### Opening new windows without guessing their position
+
+Prefer window_focus over clicking at a guessed coordinate after launching a window:
+
+  computer("key", text="ctrl+alt+t")         # open terminal
+  computer("window_focus", text="Terminal")   # wait for it, then focus it
+  computer("type", text="echo hello")         # type into the now-focused window
+
+This avoids the delay/click-at-random pattern that fails when window position
+varies across sessions or virtual displays.
 
 Note: Key names are automatically mapped between platforms.
 Common modifiers (ctrl, alt, cmd/super, shift) work consistently across platforms.
@@ -1196,6 +1310,17 @@ System: Performed left_click
 {ToolUse("ipython", [], 'computer("wait_for_change", text="10")').to_output(tool_format)}
 System: Screen changed (23.4% pixels differ)
 Viewing image...
+
+User: Open a terminal and run a command
+Assistant: I'll open a terminal with a keyboard shortcut, wait for it to appear and focus it, then type the command.
+{ToolUse("ipython", [], 'computer("key", text="ctrl+alt+t")').to_output(tool_format)}
+System: Sent key sequence: ctrl+alt+t
+{ToolUse("ipython", [], 'computer("window_focus", text="Terminal")').to_output(tool_format)}
+System: Focused window matching: 'Terminal'
+{ToolUse("ipython", [], 'computer("type", text="ls -la")').to_output(tool_format)}
+System: Typed text: ls -la
+{ToolUse("ipython", [], 'computer("key", text="return")').to_output(tool_format)}
+System: Sent key sequence: return
 """
 
     # Platform-specific keyboard shortcut examples

--- a/gptme/tools/computer_transport.py
+++ b/gptme/tools/computer_transport.py
@@ -96,6 +96,18 @@ class ComputerTransport(abc.ABC):
         """Return current cursor position as (x, y) in API-space."""
         ...
 
+    def window_focus(self, pattern: str) -> None:
+        """Wait for a window whose title matches pattern and focus it.
+
+        Not all transports support window management.  The default raises
+        ``NotImplementedError``; native transport overrides this with an
+        xdotool/osascript implementation.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} does not support window_focus. "
+            "Use native transport (unset GPTME_COMPUTER_TRANSPORT)."
+        )
+
     @abc.abstractmethod
     def close(self) -> None:
         """Release any resources held by this transport."""
@@ -340,6 +352,17 @@ class NativeComputerTransport(ComputerTransport):
         api_w, api_h = _get_api_resolution()
         x, y = _scale_coordinates(_ScalingSource.COMPUTER, x, y, api_w, api_h)
         return x, y
+
+    def window_focus(self, pattern: str) -> None:
+        from .computer import IS_MACOS, _linux_window_focus, _macos_window_focus
+
+        if IS_MACOS:
+            _macos_window_focus(pattern)
+        else:
+            import os
+
+            display = os.getenv("DISPLAY", ":1")
+            _linux_window_focus(pattern, display)
 
     def close(self) -> None:
         pass  # No resources to release for native transport

--- a/gptme/tools/computer_transport.py
+++ b/gptme/tools/computer_transport.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import abc
 import asyncio
+import os
 import threading
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -359,8 +360,6 @@ class NativeComputerTransport(ComputerTransport):
         if IS_MACOS:
             _macos_window_focus(pattern)
         else:
-            import os
-
             display = os.getenv("DISPLAY", ":1")
             _linux_window_focus(pattern, display)
 

--- a/tests/test_tools_computer.py
+++ b/tests/test_tools_computer.py
@@ -1270,6 +1270,7 @@ def test_macos_window_focus_success():
     call_args = mock_run.call_args
     cmd = call_args[0][0]
     assert cmd[0] == "osascript"
+    assert cmd[-1] == "Terminal"
 
 
 def test_macos_window_focus_no_match_raises():
@@ -1318,3 +1319,18 @@ def test_macos_window_focus_osascript_failure_raises():
         pytest.raises(RuntimeError, match="Failed to focus window matching.*'MyApp'"),
     ):
         _macos_window_focus("MyApp", timeout=5.0)
+
+
+def test_macos_window_focus_accepts_double_quotes_in_pattern():
+    """Quoted titles should be passed as argv, not interpolated into AppleScript."""
+    pattern = '"My App"'
+    with mock.patch("gptme.tools.computer.subprocess.run") as mock_run:
+        mock_run.return_value = mock.MagicMock(
+            returncode=0, stdout="found\n", stderr=""
+        )
+        _macos_window_focus(pattern, timeout=5.0)
+
+    cmd = mock_run.call_args[0][0]
+    assert cmd[0] == "osascript"
+    assert cmd[-1] == pattern
+    assert pattern not in cmd[2]

--- a/tests/test_tools_computer.py
+++ b/tests/test_tools_computer.py
@@ -14,6 +14,7 @@ from gptme.tools.computer import (
     _chunks,
     _get_display_resolution,
     _linux_scroll,
+    _linux_window_focus,
     _parse_key_sequence,
     _run_xdotool,
     _scale_coordinates,
@@ -1154,3 +1155,99 @@ def test_wait_for_change_timeout_returns_screenshot(mock_transport, mock_res, tm
         result = computer("wait_for_change", text="1")
 
     assert result is mock.sentinel.timeout_msg
+
+
+# ============================================================
+# window_focus action tests
+# ============================================================
+
+_MOCK_LINUX_RES_WF = (1920, 1080)
+
+
+@pytest.mark.skipif(IS_MACOS, reason="Linux-only: xdotool window focus")
+@mock.patch("gptme.tools.computer.IS_MACOS", False)
+@mock.patch(
+    "gptme.tools.computer._get_display_resolution", return_value=_MOCK_LINUX_RES_WF
+)
+@mock.patch("gptme.tools.computer.get_transport", return_value=None)
+def test_window_focus_linux_success(mock_transport, mock_res, capsys):
+    """window_focus on Linux calls xdotool search --sync with the given pattern."""
+    with mock.patch("gptme.tools.computer.subprocess.run") as mock_run:
+        mock_run.return_value = mock.MagicMock(
+            returncode=0, stdout="12345\n", stderr=""
+        )
+        result = computer("window_focus", text="Terminal")
+
+    assert result is None
+    out = capsys.readouterr().out
+    assert "Terminal" in out
+    # Verify xdotool was called with --sync and the pattern
+    call_args = mock_run.call_args
+    cmd = call_args[0][0]
+    assert cmd[0] == "xdotool"
+    assert "search" in cmd
+    assert "--sync" in cmd
+    assert "Terminal" in cmd
+    assert "windowfocus" in cmd
+
+
+@pytest.mark.skipif(IS_MACOS, reason="Linux-only: xdotool window focus")
+@mock.patch("gptme.tools.computer.IS_MACOS", False)
+@mock.patch(
+    "gptme.tools.computer._get_display_resolution", return_value=_MOCK_LINUX_RES_WF
+)
+@mock.patch("gptme.tools.computer.get_transport", return_value=None)
+def test_window_focus_timeout_raises(mock_transport, mock_res):
+    """window_focus raises RuntimeError when the window doesn't appear within timeout."""
+    with (
+        mock.patch(
+            "gptme.tools.computer.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(["xdotool"], 10.0),
+        ),
+        pytest.raises(RuntimeError, match="No window matching.*'nonexistent'"),
+    ):
+        computer("window_focus", text="nonexistent")
+
+
+@mock.patch("gptme.tools.computer.IS_MACOS", False)
+@mock.patch(
+    "gptme.tools.computer._get_display_resolution", return_value=_MOCK_LINUX_RES_WF
+)
+@mock.patch("gptme.tools.computer.get_transport", return_value=None)
+def test_window_focus_requires_text(mock_transport, mock_res):
+    """window_focus raises ValueError when text is not provided."""
+    with pytest.raises(ValueError, match="text.*required for window_focus"):
+        computer("window_focus", text=None)
+
+
+@pytest.mark.skipif(IS_MACOS, reason="Linux-only: xdotool window focus")
+@mock.patch("gptme.tools.computer.IS_MACOS", False)
+@mock.patch(
+    "gptme.tools.computer._get_display_resolution", return_value=_MOCK_LINUX_RES_WF
+)
+@mock.patch("gptme.tools.computer.get_transport", return_value=None)
+def test_window_focus_xdotool_failure_raises(mock_transport, mock_res):
+    """window_focus raises RuntimeError when xdotool returns non-zero."""
+    err = subprocess.CalledProcessError(1, ["xdotool"], stderr="no window found")
+    with (
+        mock.patch("gptme.tools.computer.subprocess.run", side_effect=err),
+        pytest.raises(RuntimeError, match="xdotool search/focus failed"),
+    ):
+        computer("window_focus", text="NoSuchWindow")
+
+
+def test_linux_window_focus_unit():
+    """_linux_window_focus passes --sync, --limit, pattern, and windowfocus to xdotool."""
+    with mock.patch("gptme.tools.computer.subprocess.run") as mock_run:
+        mock_run.return_value = mock.MagicMock(returncode=0, stdout="999\n", stderr="")
+        _linux_window_focus("MyApp", display=":1", timeout=5.0)
+
+    call_args = mock_run.call_args
+    cmd = call_args[0][0]
+    assert cmd[0] == "xdotool"
+    assert "--sync" in cmd
+    assert "--limit" in cmd
+    assert "MyApp" in cmd
+    assert "windowfocus" in cmd
+    # timeout + 2 headroom
+    assert call_args[1]["timeout"] == pytest.approx(7.0)

--- a/tests/test_tools_computer.py
+++ b/tests/test_tools_computer.py
@@ -15,6 +15,7 @@ from gptme.tools.computer import (
     _get_display_resolution,
     _linux_scroll,
     _linux_window_focus,
+    _macos_window_focus,
     _parse_key_sequence,
     _run_xdotool,
     _scale_coordinates,
@@ -1251,3 +1252,69 @@ def test_linux_window_focus_unit():
     assert "windowfocus" in cmd
     # timeout + 2 headroom
     assert call_args[1]["timeout"] == pytest.approx(7.0)
+
+
+# macOS window_focus tests
+# ============================================================
+
+
+def test_macos_window_focus_success():
+    """_macos_window_focus returns when osascript reports 'found'."""
+    with mock.patch("gptme.tools.computer.subprocess.run") as mock_run:
+        mock_run.return_value = mock.MagicMock(
+            returncode=0, stdout="found\n", stderr=""
+        )
+        _macos_window_focus("Terminal", timeout=5.0)
+
+    assert mock_run.called
+    call_args = mock_run.call_args
+    cmd = call_args[0][0]
+    assert cmd[0] == "osascript"
+
+
+def test_macos_window_focus_no_match_raises():
+    """_macos_window_focus raises RuntimeError when no matching process is found within timeout.
+
+    This is the P1 bug: previously the function returned None (false success) when the
+    AppleScript found no matching process, causing subsequent keystrokes to go to the
+    wrong window. Now it raises RuntimeError after the timeout expires.
+    """
+    with (
+        mock.patch("gptme.tools.computer.subprocess.run") as mock_run,
+        mock.patch("gptme.tools.computer.time.monotonic") as mock_time,
+        mock.patch("gptme.tools.computer.time.sleep"),
+        pytest.raises(RuntimeError, match="No window matching.*'MissingApp'"),
+    ):
+        # First call returns not_found, second call has monotonic past deadline
+        mock_run.return_value = mock.MagicMock(
+            returncode=0, stdout="not_found\n", stderr=""
+        )
+        mock_time.side_effect = [0.0, 0.0, 10.1]  # start, after first run, after sleep
+        _macos_window_focus("MissingApp", timeout=10.0)
+
+
+def test_macos_window_focus_retry_then_found():
+    """_macos_window_focus retries until the window appears."""
+    results = [
+        mock.MagicMock(returncode=0, stdout="not_found\n", stderr=""),
+        mock.MagicMock(returncode=0, stdout="not_found\n", stderr=""),
+        mock.MagicMock(returncode=0, stdout="found\n", stderr=""),
+    ]
+    with (
+        mock.patch("gptme.tools.computer.subprocess.run", side_effect=results),
+        mock.patch(
+            "gptme.tools.computer.time.monotonic", side_effect=[0.0, 0.5, 1.0, 1.5]
+        ),
+        mock.patch("gptme.tools.computer.time.sleep"),
+    ):
+        _macos_window_focus("SlowApp", timeout=10.0)
+
+
+def test_macos_window_focus_osascript_failure_raises():
+    """_macos_window_focus raises RuntimeError when osascript exits non-zero."""
+    err = subprocess.CalledProcessError(1, ["osascript"], stderr="permission denied")
+    with (
+        mock.patch("gptme.tools.computer.subprocess.run", side_effect=err),
+        pytest.raises(RuntimeError, match="Failed to focus window matching.*'MyApp'"),
+    ):
+        _macos_window_focus("MyApp", timeout=5.0)


### PR DESCRIPTION
## What

Adds a `window_focus` action to the computer tool. It waits for a window whose title matches a pattern to appear, then focuses it.

## Why this PR vs existing primitives

The current toolkit has `wait_for_change` (detects when the screen changes) and click actions (interact at a coordinate). For the common pattern of opening a new terminal window, neither is fully adequate:

- `wait_for_change` tells you *that* the screen changed, but doesn't focus the window — you still have to click at a guessed coordinate
- `left_click` at a guessed coordinate fails when window position varies (virtual display, different WM, first vs. second window)

`window_focus` uses **xdotool's `--sync` flag** on Linux/X11, which blocks until a window with the matching title exists then focuses it atomically. No screenshot polling, no coordinate guessing:

```python
# Before (brittle):
computer("key", text="ctrl+alt+t")           # open terminal
computer("wait_for_change", text="3")         # hope it appeared
computer("left_click", coordinate=(512, 400)) # guess where to click

# After (reliable):
computer("key", text="ctrl+alt+t")
computer("window_focus", text="Terminal")     # wait + focus atomically
computer("type", text="ls -la")              # type directly
```

This directly addresses the "delays when starting new terminal windows" checklist item in issue #216. The root cause was the lack of a wait-and-focus primitive — agents had to poll screenshots and guess coordinates.

## Changes

- `gptme/tools/computer.py`:
  - `window_focus` added to `Action` type
  - `_linux_window_focus(pattern, display, timeout)` — `xdotool search --sync --limit 1 --name <pattern> windowfocus`
  - `_macos_window_focus(pattern)` — osascript System Events (focuses by process name)
  - Both `computer()` (native path) and `_dispatch_transport()` (transport path) handle the new action
  - Updated module docstring, `instructions` section (with "Opening new windows without guessing their position" guidance), and `examples`

- `gptme/tools/computer_transport.py`:
  - `window_focus(pattern)` added to `ComputerTransport` ABC as a concrete default that raises `NotImplementedError` with a helpful message (not abstract, so `CuaComputerTransport` inherits gracefully)
  - Implemented in `NativeComputerTransport` by delegating to the helpers above

- `tests/test_tools_computer.py`:
  - 5 new unit tests: success path (verifies xdotool args), timeout → RuntimeError, CalledProcessError → RuntimeError, missing text → ValueError, unit test of `_linux_window_focus` directly

## Test plan

- [x] `pytest tests/test_tools_computer.py tests/test_computer_transport.py` — 82+44 tests pass, 3 skipped (display required)
- [x] ruff + mypy clean
- [ ] Manual: `gptme --tools +computer "open a terminal and run ls"` in an Xvfb session

Refs #216
