### PR TITLE
feat(doctor): add computer use prerequisite checks + run-docker-computer target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-api docs build build-docker check-rst install-completions help tauri-dev tauri-build tauri-lint tauri-build-sidecar bundle-webui
+.PHONY: test test-api docs build build-docker build-docker-computer run-docker-computer check-rst install-completions help tauri-dev tauri-build tauri-lint tauri-build-sidecar bundle-webui
 
 # set default shell
 SHELL := $(shell which bash)
@@ -25,6 +25,15 @@ build-docker: ## Build Docker images
 
 build-docker-computer: ## Build Docker image for gptme-computer
 	docker build . -t gptme-computer:latest -f scripts/Dockerfile.computer
+
+run-docker-computer: ## Run gptme-computer container (noVNC on :6080, gptme server on :8080)
+	docker run --rm -it \
+		-p 6080:6080 \
+		-p 8080:8080 \
+		-e ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY}" \
+		-e OPENAI_API_KEY="${OPENAI_API_KEY}" \
+		-e OPENROUTER_API_KEY="${OPENROUTER_API_KEY}" \
+		gptme-computer:latest
 
 build-docker-dev: ## Build Docker image for development
 	docker build . -t gptme-dev:latest -f scripts/Dockerfile.dev

--- a/Makefile
+++ b/Makefile
@@ -30,9 +30,9 @@ run-docker-computer: ## Run gptme-computer container (noVNC on :6080, gptme serv
 	docker run --rm -it \
 		-p 6080:6080 \
 		-p 8080:8080 \
-		-e ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY}" \
-		-e OPENAI_API_KEY="${OPENAI_API_KEY}" \
-		-e OPENROUTER_API_KEY="${OPENROUTER_API_KEY}" \
+		-e ANTHROPIC_API_KEY \
+		-e OPENAI_API_KEY \
+		-e OPENROUTER_API_KEY \
 		gptme-computer:latest
 
 build-docker-dev: ## Build Docker image for development

--- a/gptme/cli/doctor.py
+++ b/gptme/cli/doctor.py
@@ -542,6 +542,101 @@ def _check_version(verbose: bool = False) -> list[CheckResult]:
     return results
 
 
+def _check_computer(verbose: bool = False) -> list[CheckResult]:
+    """Check computer tool prerequisites (xdotool on Linux, cliclick on macOS)."""
+    results: list[CheckResult] = []
+
+    if sys.platform == "darwin":
+        # screencapture is always present on macOS — just confirm
+        results.append(
+            CheckResult(
+                name="Computer: screencapture",
+                status=CheckStatus.OK,
+                message="macOS screenshot tool (built-in)",
+            )
+        )
+        # cliclick is required for mouse/keyboard control on macOS
+        if shutil.which("cliclick"):
+            results.append(
+                CheckResult(
+                    name="Computer: cliclick",
+                    status=CheckStatus.OK,
+                    message="macOS mouse/keyboard control",
+                    details=shutil.which("cliclick") if verbose else None,
+                )
+            )
+        else:
+            results.append(
+                CheckResult(
+                    name="Computer: cliclick",
+                    status=CheckStatus.WARNING,
+                    message="Not found — required for mouse/keyboard control on macOS",
+                    fix_hint="brew install cliclick",
+                )
+            )
+    else:
+        # Linux: X11 tools
+        if shutil.which("xdotool"):
+            results.append(
+                CheckResult(
+                    name="Computer: xdotool",
+                    status=CheckStatus.OK,
+                    message="X11 mouse/keyboard automation",
+                    details=shutil.which("xdotool") if verbose else None,
+                )
+            )
+        else:
+            results.append(
+                CheckResult(
+                    name="Computer: xdotool",
+                    status=CheckStatus.WARNING,
+                    message="Not found — required for computer tool on Linux/X11",
+                    fix_hint="sudo apt install xdotool  or  sudo pacman -S xdotool",
+                )
+            )
+
+        if shutil.which("scrot"):
+            results.append(
+                CheckResult(
+                    name="Computer: scrot",
+                    status=CheckStatus.OK,
+                    message="X11 screenshot tool",
+                    details=shutil.which("scrot") if verbose else None,
+                )
+            )
+        else:
+            results.append(
+                CheckResult(
+                    name="Computer: scrot",
+                    status=CheckStatus.WARNING,
+                    message="Not found — screenshot fallback (gnome-screenshot also works)",
+                    fix_hint="sudo apt install scrot  or  sudo pacman -S scrot",
+                )
+            )
+
+        # Check DISPLAY
+        display = os.environ.get("DISPLAY")
+        if display:
+            results.append(
+                CheckResult(
+                    name="Computer: DISPLAY",
+                    status=CheckStatus.OK,
+                    message=f"X11 display available ({display})",
+                )
+            )
+        else:
+            results.append(
+                CheckResult(
+                    name="Computer: DISPLAY",
+                    status=CheckStatus.WARNING,
+                    message="DISPLAY not set — computer tool requires an X11 display",
+                    fix_hint="export DISPLAY=:1  or run inside Xvfb: xvfb-run gptme ...",
+                )
+            )
+
+    return results
+
+
 def _check_browser(verbose: bool = False) -> list[CheckResult]:
     """Check Playwright browser installation if browser extra is installed."""
     results: list[CheckResult] = []
@@ -749,6 +844,7 @@ def run_diagnostics(verbose: bool = False) -> tuple[list[CheckResult], dict]:
     all_results.extend(_check_api_keys(verbose))
     all_results.extend(_check_tools(verbose))
     all_results.extend(_check_python_deps(verbose))
+    all_results.extend(_check_computer(verbose))
     all_results.extend(_check_browser(verbose))
     all_results.extend(_check_mcp(verbose))
     all_results.extend(_check_permissions(verbose))

--- a/gptme/cli/doctor.py
+++ b/gptme/cli/doctor.py
@@ -586,7 +586,7 @@ def _check_computer(verbose: bool = False) -> list[CheckResult]:
                     fix_hint="brew install cliclick",
                 )
             )
-    else:
+    elif sys.platform.startswith("linux"):
         # Linux: X11 tools
         xdotool_path = shutil.which("xdotool")
         if xdotool_path:
@@ -647,6 +647,15 @@ def _check_computer(verbose: bool = False) -> list[CheckResult]:
                     fix_hint="export DISPLAY=:1  or run inside Xvfb: xvfb-run gptme ...",
                 )
             )
+    else:
+        # Unsupported platform (Windows, FreeBSD, etc.) — no checks available
+        results.append(
+            CheckResult(
+                name="Computer: platform",
+                status=CheckStatus.WARNING,
+                message=f"Computer tool is only supported on Linux and macOS (current: {sys.platform})",
+            )
+        )
 
     return results
 

--- a/gptme/cli/doctor.py
+++ b/gptme/cli/doctor.py
@@ -547,22 +547,34 @@ def _check_computer(verbose: bool = False) -> list[CheckResult]:
     results: list[CheckResult] = []
 
     if sys.platform == "darwin":
-        # screencapture is always present on macOS — just confirm
-        results.append(
-            CheckResult(
-                name="Computer: screencapture",
-                status=CheckStatus.OK,
-                message="macOS screenshot tool (built-in)",
+        # screencapture should always be present on macOS — verify for consistency
+        screencapture_path = shutil.which("screencapture")
+        if screencapture_path:
+            results.append(
+                CheckResult(
+                    name="Computer: screencapture",
+                    status=CheckStatus.OK,
+                    message="macOS screenshot tool (built-in)",
+                    details=screencapture_path if verbose else None,
+                )
             )
-        )
+        else:
+            results.append(
+                CheckResult(
+                    name="Computer: screencapture",
+                    status=CheckStatus.WARNING,
+                    message="Not found — screencapture should be built-in on macOS",
+                )
+            )
         # cliclick is required for mouse/keyboard control on macOS
-        if shutil.which("cliclick"):
+        cliclick_path = shutil.which("cliclick")
+        if cliclick_path:
             results.append(
                 CheckResult(
                     name="Computer: cliclick",
                     status=CheckStatus.OK,
                     message="macOS mouse/keyboard control",
-                    details=shutil.which("cliclick") if verbose else None,
+                    details=cliclick_path if verbose else None,
                 )
             )
         else:
@@ -576,13 +588,14 @@ def _check_computer(verbose: bool = False) -> list[CheckResult]:
             )
     else:
         # Linux: X11 tools
-        if shutil.which("xdotool"):
+        xdotool_path = shutil.which("xdotool")
+        if xdotool_path:
             results.append(
                 CheckResult(
                     name="Computer: xdotool",
                     status=CheckStatus.OK,
                     message="X11 mouse/keyboard automation",
-                    details=shutil.which("xdotool") if verbose else None,
+                    details=xdotool_path if verbose else None,
                 )
             )
         else:
@@ -595,13 +608,14 @@ def _check_computer(verbose: bool = False) -> list[CheckResult]:
                 )
             )
 
-        if shutil.which("scrot"):
+        scrot_path = shutil.which("scrot")
+        if scrot_path:
             results.append(
                 CheckResult(
                     name="Computer: scrot",
                     status=CheckStatus.OK,
                     message="X11 screenshot tool",
-                    details=shutil.which("scrot") if verbose else None,
+                    details=scrot_path if verbose else None,
                 )
             )
         else:

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -923,6 +923,16 @@ class TestCheckComputer:
         assert names["Computer: cliclick"].status == CheckStatus.WARNING
         assert "brew install cliclick" in (names["Computer: cliclick"].fix_hint or "")
 
+    @patch("sys.platform", "win32")
+    def test_unsupported_platform(self):
+        """Unsupported platforms (Windows, etc.) should get a single WARNING."""
+        results = _check_computer()
+
+        assert len(results) == 1
+        assert results[0].name == "Computer: platform"
+        assert results[0].status == CheckStatus.WARNING
+        assert "win32" in results[0].message
+
     @patch("sys.platform", "linux")
     @patch("shutil.which")
     @patch.dict("os.environ", {"DISPLAY": ":1"})

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -895,7 +895,11 @@ class TestCheckComputer:
     def test_macos_cliclick_present(self, mock_which):
         """macOS with cliclick should report OK for cliclick and screencapture."""
         mock_which.side_effect = lambda t: (
-            "/usr/local/bin/cliclick" if t == "cliclick" else None
+            "/usr/bin/screencapture"
+            if t == "screencapture"
+            else "/usr/local/bin/cliclick"
+            if t == "cliclick"
+            else None
         )
 
         results = _check_computer()
@@ -905,9 +909,13 @@ class TestCheckComputer:
         assert names["Computer: cliclick"].status == CheckStatus.OK
 
     @patch("sys.platform", "darwin")
-    @patch("shutil.which", return_value=None)
+    @patch("shutil.which")
     def test_macos_cliclick_missing(self, mock_which):
-        """macOS without cliclick should warn with brew install hint."""
+        """macOS without cliclick should warn with brew install hint, screencapture OK."""
+        mock_which.side_effect = lambda t: (
+            "/usr/bin/screencapture" if t == "screencapture" else None
+        )
+
         results = _check_computer()
 
         names = {r.name: r for r in results}

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -11,6 +11,7 @@ from gptme.cli.doctor import (
     CheckStatus,
     _check_api_keys,
     _check_browser,
+    _check_computer,
     _check_config,
     _check_mcp,
     _check_permissions,
@@ -855,3 +856,75 @@ class TestCheckMCP:
         assert server_result.details is not None
         assert "npx" in server_result.details
         assert "-y" in server_result.details
+
+
+class TestCheckComputer:
+    """Test _check_computer function."""
+
+    @patch("sys.platform", "linux")
+    @patch("shutil.which")
+    @patch.dict("os.environ", {"DISPLAY": ":1"})
+    def test_linux_all_tools_present(self, mock_which):
+        """Linux with xdotool + scrot + DISPLAY should be all OK."""
+        mock_which.side_effect = lambda t: (
+            f"/usr/bin/{t}" if t in ("xdotool", "scrot") else None
+        )
+
+        results = _check_computer()
+
+        names = {r.name: r for r in results}
+        assert names["Computer: xdotool"].status == CheckStatus.OK
+        assert names["Computer: scrot"].status == CheckStatus.OK
+        assert names["Computer: DISPLAY"].status == CheckStatus.OK
+
+    @patch("sys.platform", "linux")
+    @patch("shutil.which", return_value=None)
+    @patch.dict("os.environ", {}, clear=True)
+    def test_linux_nothing_installed(self, mock_which):
+        """Linux without xdotool/scrot/DISPLAY should warn on all three."""
+        results = _check_computer()
+
+        names = {r.name: r for r in results}
+        assert names["Computer: xdotool"].status == CheckStatus.WARNING
+        assert names["Computer: scrot"].status == CheckStatus.WARNING
+        assert names["Computer: DISPLAY"].status == CheckStatus.WARNING
+        assert "xdotool" in (names["Computer: xdotool"].fix_hint or "")
+
+    @patch("sys.platform", "darwin")
+    @patch("shutil.which")
+    def test_macos_cliclick_present(self, mock_which):
+        """macOS with cliclick should report OK for cliclick and screencapture."""
+        mock_which.side_effect = lambda t: (
+            "/usr/local/bin/cliclick" if t == "cliclick" else None
+        )
+
+        results = _check_computer()
+
+        names = {r.name: r for r in results}
+        assert names["Computer: screencapture"].status == CheckStatus.OK
+        assert names["Computer: cliclick"].status == CheckStatus.OK
+
+    @patch("sys.platform", "darwin")
+    @patch("shutil.which", return_value=None)
+    def test_macos_cliclick_missing(self, mock_which):
+        """macOS without cliclick should warn with brew install hint."""
+        results = _check_computer()
+
+        names = {r.name: r for r in results}
+        assert names["Computer: screencapture"].status == CheckStatus.OK
+        assert names["Computer: cliclick"].status == CheckStatus.WARNING
+        assert "brew install cliclick" in (names["Computer: cliclick"].fix_hint or "")
+
+    @patch("sys.platform", "linux")
+    @patch("shutil.which")
+    @patch.dict("os.environ", {"DISPLAY": ":1"})
+    def test_verbose_shows_path(self, mock_which):
+        """Verbose mode should include tool path in details."""
+        mock_which.side_effect = lambda t: (
+            f"/usr/bin/{t}" if t in ("xdotool", "scrot") else None
+        )
+
+        results = _check_computer(verbose=True)
+
+        xdotool = next(r for r in results if r.name == "Computer: xdotool")
+        assert xdotool.details == "/usr/bin/xdotool"


### PR DESCRIPTION
## What

Adds `_check_computer()` to `gptme-doctor` so users get actionable feedback when the computer tool's OS-level dependencies are missing, and adds a `run-docker-computer` Makefile target to make the Docker computer-use workflow accessible.

## Why this matters for #216

The computer use infrastructure is complete (xdotool/cliclick actions, CUA transport, noVNC Docker container, structured-first profile), but the gap between "feature exists" and "user can use it" is: there's no feedback when prerequisites are missing. Without `xdotool` on Linux or `cliclick` on macOS, `computer()` calls fail with cryptic errors or segfaults. `gptme-doctor` now catches this before the user even tries.

## Doctor check details

**Linux/X11** — warns when:
- `xdotool` missing (required for all mouse/keyboard actions)
- `scrot` missing (screenshot fallback; gnome-screenshot also works)
- `DISPLAY` not set (headless environment; suggests `xvfb-run gptme ...`)

**macOS** — warns when:
- `cliclick` missing (`brew install cliclick` hint); `screencapture` is always OK (built-in)

## Makefile target

```bash
make build-docker-computer   # already existed — builds the image
make run-docker-computer      # new — launches it with noVNC (:6080) + gptme server (:8080)
```

The run target passes through `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, and `OPENROUTER_API_KEY` from the host environment.

## Tests

5 new unit tests in `TestCheckComputer`:
- Linux with all tools present → all OK
- Linux with nothing installed → all WARNING with fix hints
- macOS with cliclick → screencapture OK + cliclick OK
- macOS without cliclick → screencapture OK + cliclick WARNING with brew hint
- Verbose mode shows tool path in `details`

Part of #216 (Complete "computer use" support).