### PR TITLE
fix(webui): tolerate legacy non-paginated conversations response (#2916)

### DIFF
--- a/webui/src/components/MainLayout.tsx
+++ b/webui/src/components/MainLayout.tsx
@@ -178,7 +178,7 @@ const MainLayout: FC<Props> = ({ conversationId, taskId }) => {
     const all =
       data?.pages.flatMap(
         (page: { conversations: ConversationSummary[]; nextCursor: string | undefined }) =>
-          page.conversations.map((conv) => ({
+          (page.conversations ?? []).map((conv) => ({
             ...conv,
             serverId: registry.activeServerId,
             serverName: primaryServer?.name,

--- a/webui/src/utils/__tests__/api.test.ts
+++ b/webui/src/utils/__tests__/api.test.ts
@@ -264,6 +264,42 @@ describe('ApiClient conversation list detail flag', () => {
       expect.any(Object)
     );
   });
+
+  it('tolerates a legacy bare-list response from servers older than #2860', async () => {
+    const legacyList = [
+      { id: 'conv-a', name: 'conv-a' },
+      { id: 'conv-b', name: 'conv-b' },
+    ];
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => legacyList,
+    } as Response);
+
+    const client = new ApiClient('http://127.0.0.1:5700');
+    client.setConnected(true);
+
+    const result = await client.getConversationsPaginated(undefined, 50);
+
+    expect(result.conversations).toEqual(legacyList);
+    expect(result.nextCursor).toBeUndefined();
+  });
+
+  it('returns an empty list when the paginated response is missing the conversations field', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ next_cursor: null }),
+    } as Response);
+
+    const client = new ApiClient('http://127.0.0.1:5700');
+    client.setConnected(true);
+
+    const result = await client.getConversationsPaginated(undefined, 50);
+
+    expect(result.conversations).toEqual([]);
+    expect(result.nextCursor).toBeUndefined();
+  });
 });
 
 describe('ApiClient event stream reconnection', () => {

--- a/webui/src/utils/api.ts
+++ b/webui/src/utils/api.ts
@@ -994,14 +994,24 @@ export class ApiClient {
       if (cursor !== undefined) {
         url += `&cursor=${encodeURIComponent(cursor)}`;
       }
-      const response = await this.fetchJson<{
-        conversations: ConversationSummary[];
-        next_cursor: string | null;
-      }>(url);
+      // Tolerate both the paginated shape ({ conversations, next_cursor })
+      // and a legacy bare-list shape ([...]) returned by servers older than #2860.
+      const response = await this.fetchJson<
+        | {
+            conversations: ConversationSummary[];
+            next_cursor: string | null;
+          }
+        | ConversationSummary[]
+      >(url);
 
-      const nextCursor = response.next_cursor ?? undefined;
+      const conversations = Array.isArray(response)
+        ? response
+        : Array.isArray(response?.conversations)
+          ? response.conversations
+          : [];
+      const nextCursor = Array.isArray(response) ? undefined : (response.next_cursor ?? undefined);
 
-      return { conversations: response.conversations, nextCursor };
+      return { conversations, nextCursor };
     } catch (error) {
       if (error instanceof DOMException && error.name === 'AbortError') {
         throw new ApiClientError('Request aborted', 499);


### PR DESCRIPTION
Fixes #2916.

## Root cause
The /chat view crashed with `TypeError: page.conversations is undefined` and fell into the ErrorBoundary ("Something went wrong"). This is a client/server shape skew: a gptme server older than #2860 returns the conversation list as a bare array `[...]`, but the webui's `getConversationsPaginated` assumed the paginated shape `{ conversations, next_cursor }`. It read `response.conversations` unconditionally, so the value was `undefined` and `MainLayout`'s `page.conversations.map(...)` threw.

## What changed
- `webui/src/utils/api.ts` (`getConversationsPaginated`): normalize the response to tolerate both shapes — a bare list `[...]`, the paginated object `{ conversations, next_cursor }`, and a response missing the `conversations` field (falls back to `[]`). The fetch type was widened to the union of both shapes.
- `webui/src/components/MainLayout.tsx`: defensive `(page.conversations ?? [])` in the page mapping (defense-in-depth).
- `webui/src/utils/__tests__/api.test.ts`: added unit tests covering the legacy bare-list response and the missing-`conversations`-field case.

## Verification
- `npm ci` clean
- `npm run build` (tsc + vite) — passes
- `npm run lint` (eslint + tsc) — 0 errors
- `npx jest src/utils/__tests__/api.test.ts` — 18/18 pass (including the 2 new tests)
- prettier formatting applied to changed files