### PR TITLE
feat(ci): run webui e2e tests against both stable and dev gptme

### DIFF
--- a/.github/workflows/webui.yml
+++ b/.github/workflows/webui.yml
@@ -86,6 +86,10 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        gptme-version: [stable, dev]
     steps:
     - uses: actions/checkout@v6
 
@@ -104,9 +108,13 @@ jobs:
     - name: Install dependencies
       run: npm ci
 
-    - name: Install gptme server
-      run: |
-        pip install "gptme[server] @ git+https://github.com/gptme/gptme.git"
+    - name: Install gptme server (stable release)
+      if: matrix.gptme-version == 'stable'
+      run: pip install 'gptme[server]'
+
+    - name: Install gptme server (dev)
+      if: matrix.gptme-version == 'dev'
+      run: pip install 'gptme[server] @ git+https://github.com/gptme/gptme.git'
 
     - name: Start gptme-server in background
       env:
@@ -128,6 +136,6 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v7
       with:
-        name: playwright-report
+        name: playwright-report-${{ matrix.gptme-version }}
         path: webui/playwright-report/
         retention-days: 30

--- a/.github/workflows/webui.yml
+++ b/.github/workflows/webui.yml
@@ -100,6 +100,7 @@ jobs:
       uses: actions/setup-python@v6
       with:
         python-version: '3.11'
+        cache: 'pip'
 
     - name: Install frontend dependencies
       run: npm ci

--- a/.github/workflows/webui.yml
+++ b/.github/workflows/webui.yml
@@ -86,10 +86,6 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     needs: build
-    strategy:
-      fail-fast: false
-      matrix:
-        gptme-version: [stable, dev]
     steps:
     - uses: actions/checkout@v6
 
@@ -105,37 +101,87 @@ jobs:
       with:
         python-version: '3.11'
 
-    - name: Install dependencies
+    - name: Install frontend dependencies
       run: npm ci
-
-    - name: Install gptme server (stable release)
-      if: matrix.gptme-version == 'stable'
-      run: pip install 'gptme[server]'
-
-    - name: Install gptme server (dev)
-      if: matrix.gptme-version == 'dev'
-      run: pip install 'gptme[server] @ git+https://github.com/gptme/gptme.git'
-
-    - name: Start gptme-server in background
-      env:
-        ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-      run: |
-        gptme-server --cors-origin="http://localhost:5701" &
-        sleep 3
 
     - name: Install Playwright browsers
       run: npx playwright install --with-deps chromium
 
-    - name: Check that server is up
+    # ── stable pass (latest PyPI release) ────────────────────────────────────
+    - name: Install stable gptme (PyPI)
+      working-directory: .
+      run: pip install 'gptme[server]'
+
+    - name: Start server (stable)
+      env:
+        ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      run: |
+        gptme-server --cors-origin="http://localhost:5701" &
+        echo $! > /tmp/gptme-server.pid
+        sleep 3
+
+    - name: Health-check server (stable)
       run: curl --retry 2 --retry-delay 5 --retry-connrefused -sSfL http://localhost:5700/api/v2
 
-    - name: Run e2e tests
+    - name: Run e2e tests (stable)
+      id: e2e-stable
+      continue-on-error: true
       run: npm run test:e2e
 
-    - name: Upload test results
+    - name: Upload stable test results
       if: always()
       uses: actions/upload-artifact@v7
       with:
-        name: playwright-report-${{ matrix.gptme-version }}
+        name: playwright-report-stable
         path: webui/playwright-report/
         retention-days: 30
+
+    - name: Stop server (stable)
+      if: always()
+      working-directory: .
+      run: |
+        kill "$(cat /tmp/gptme-server.pid)" 2>/dev/null || true
+        sleep 2
+
+    # ── dev pass (git master) ─────────────────────────────────────────────────
+    - name: Install dev gptme (git master)
+      working-directory: .
+      run: pip install --force-reinstall 'gptme[server] @ git+https://github.com/gptme/gptme.git'
+
+    - name: Start server (dev)
+      env:
+        ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      run: |
+        gptme-server --cors-origin="http://localhost:5701" &
+        echo $! > /tmp/gptme-server.pid
+        sleep 3
+
+    - name: Health-check server (dev)
+      run: curl --retry 2 --retry-delay 5 --retry-connrefused -sSfL http://localhost:5700/api/v2
+
+    - name: Run e2e tests (dev)
+      id: e2e-dev
+      continue-on-error: true
+      run: npm run test:e2e
+
+    - name: Upload dev test results
+      if: always()
+      uses: actions/upload-artifact@v7
+      with:
+        name: playwright-report-dev
+        path: webui/playwright-report/
+        retention-days: 30
+
+    - name: Stop server (dev)
+      if: always()
+      working-directory: .
+      run: kill "$(cat /tmp/gptme-server.pid)" 2>/dev/null || true
+
+    - name: Require both passes to succeed
+      if: always()
+      working-directory: .
+      run: |
+        stable="${{ steps.e2e-stable.outcome }}"
+        dev="${{ steps.e2e-dev.outcome }}"
+        echo "stable: $stable  dev: $dev"
+        [ "$stable" = "success" ] && [ "$dev" = "success" ]


### PR DESCRIPTION
## Summary

Runs the existing Playwright suite against two gptme server installs in a **single job**, sharing checkout, `npm ci`, and Playwright browser installation:

1. **stable**: latest release from PyPI (`pip install 'gptme[server]'`)
2. **dev**: git master (`pip install --force-reinstall 'gptme[server] @ git+...'`)

Both passes run sequentially after the shared frontend setup. Each starts the server, runs the e2e suite, uploads its report, then stops the server. A final step fails the job if either pass failed — so both results are always visible even when stable breaks.

This avoids the original matrix approach (which doubled the runner count and paid for `checkout + npm ci + Playwright install` twice).

Closes #2918