### PR TITLE
feat(subagent): progress tool — intermediate parent notifications during long tasks (#554)

### DIFF
--- a/gptme/tools/progress.py
+++ b/gptme/tools/progress.py
@@ -1,0 +1,112 @@
+"""Progress tool — subagents use this to send intermediate updates to the parent.
+
+Registers the ``progress`` block type so subagents can report status mid-task
+without stopping their session. The parent orchestrator receives these updates
+via the LOOP_CONTINUE hook as ⏳ system messages, enabling the "fire-and-forget-
+then-get-alerted-when-update/done" pattern alongside ``complete`` and ``clarify``.
+
+Unlike ``complete`` (ends session) and ``clarify`` (pauses session), ``progress``
+continues execution after delivering the update.
+
+Only works in thread-mode subagents (same process). Subprocess-mode subagents
+cannot share the in-process progress queue — updates will be silently dropped
+with a warning if the agent_id cannot be resolved.
+
+Only enabled in autonomous/subagent sessions (disabled_by_default=True).
+"""
+
+import logging
+from collections.abc import Generator
+from typing import TYPE_CHECKING
+
+from ..message import Message
+from .base import ToolSpec
+
+if TYPE_CHECKING:
+    pass
+
+logger = logging.getLogger(__name__)
+
+
+def execute_progress(
+    code: str | None,
+    args: list[str] | None,
+    kwargs: dict[str, str] | None,
+) -> Generator[Message, None, None]:
+    """Send an intermediate progress update to the parent orchestrator.
+
+    Reads the current agent_id from thread-local storage (set by
+    _create_subagent_thread) and pushes the update to the shared
+    _progress_queue. The parent's LOOP_CONTINUE hook delivers it as a
+    ⏳ system message on the next loop iteration.
+    """
+    from .subagent.execution import get_current_agent_id
+    from .subagent.hooks import notify_progress
+
+    message = (code or "").strip()
+    if not message:
+        yield Message(
+            "system", "Progress block was empty — no update sent.", quiet=True
+        )
+        return
+
+    agent_id = get_current_agent_id()
+    if agent_id is None:
+        # Running outside a thread-mode subagent context (e.g. subprocess or direct call)
+        logger.warning(
+            "progress tool: no agent_id in thread-local — running in subprocess mode? "
+            "Progress update will not be delivered to parent."
+        )
+        yield Message(
+            "system",
+            "Progress update recorded (parent notification unavailable in subprocess mode).",
+            quiet=True,
+        )
+        return
+
+    notify_progress(agent_id, message)
+    logger.debug(f"Progress update queued for subagent '{agent_id}': {message[:80]}")
+    yield Message(
+        "system",
+        "Progress update sent to parent orchestrator.",
+        quiet=True,
+    )
+
+
+tool = ToolSpec(
+    name="progress",
+    desc="Send an intermediate progress update to the parent orchestrator without stopping the session",
+    disabled_by_default=True,
+    instructions="""
+Use this block to send an intermediate status update to the parent orchestrator
+while your task is still in progress. The session continues after the update.
+
+```progress
+Brief status: what you have completed so far and what still remains.
+```
+
+Guidelines:
+- Use for meaningful milestones, not every step (too many updates are noise)
+- Keep it brief — one or two sentences summarizing state and next steps
+- Use ``complete`` when fully done, ``clarify`` when blocked on a question
+
+Example milestones worth reporting:
+- Finished analysis phase, starting implementation
+- Encountered an obstacle, switching approach
+- Completed subtask A, now working on B
+""".strip(),
+    examples="""
+> User: Run a long analysis task using a subagent
+> Assistant: I'll start the analysis subagent.
+```ipython
+subagent("analysis", "Analyze the entire codebase for security issues")
+```
+> System: Started subagent "analysis"
+> System: ⏳ Subagent 'analysis' progress: Finished scanning auth module (47 files). Starting API layer.
+> System: ⏳ Subagent 'analysis' progress: API layer done, 3 issues found. Starting data layer.
+> System: ✅ Subagent 'analysis' completed: Found 5 security issues across 3 modules. See analysis.md.
+""",
+    execute=execute_progress,
+    block_types=["progress"],
+    available=True,
+)

--- a/gptme/tools/progress.py
+++ b/gptme/tools/progress.py
@@ -9,8 +9,8 @@ Unlike ``complete`` (ends session) and ``clarify`` (pauses session), ``progress`
 continues execution after delivering the update.
 
 Only works in thread-mode subagents (same process). Subprocess-mode subagents
-cannot share the in-process progress queue — updates will be silently dropped
-with a warning if the agent_id cannot be resolved.
+cannot share the in-process progress queue, so updates are not delivered when
+the agent_id cannot be resolved.
 
 Only enabled in autonomous/subagent sessions (disabled_by_default=True).
 """
@@ -59,7 +59,7 @@ def execute_progress(
         )
         yield Message(
             "system",
-            "Progress update recorded (parent notification unavailable in subprocess mode).",
+            "Progress update NOT delivered to parent (subprocess mode does not support in-process queue).",
             quiet=True,
         )
         return

--- a/gptme/tools/subagent/__init__.py
+++ b/gptme/tools/subagent/__init__.py
@@ -26,6 +26,7 @@ from .hooks import (
     _get_complete_instruction,
     _subagent_completion_hook,
     notify_completion,
+    notify_progress,
 )
 from .types import (
     ReturnType,
@@ -33,6 +34,7 @@ from .types import (
     Subagent,
     SubtaskDef,
     _completion_queue,
+    _progress_queue,
     _subagent_results,
     _subagent_results_lock,
     _subagents,
@@ -343,6 +345,7 @@ __all__ = [
     "Status",
     # Hooks
     "notify_completion",
+    "notify_progress",
     "_subagent_completion_hook",
     "_get_complete_instruction",
     # Module-level state (re-exported for backward compatibility)
@@ -351,6 +354,7 @@ __all__ = [
     "_subagent_results",
     "_subagent_results_lock",
     "_completion_queue",
+    "_progress_queue",
     # Tool registration
     "tool",
 ]

--- a/gptme/tools/subagent/api.py
+++ b/gptme/tools/subagent/api.py
@@ -520,6 +520,7 @@ def subagent(
                         target="parent",
                         output_schema=output_schema,
                         profile_name=profile,
+                        agent_id=agent_id,
                     )
                 except Exception as e:
                     # If subagent creation fails, notify with error status

--- a/gptme/tools/subagent/execution.py
+++ b/gptme/tools/subagent/execution.py
@@ -32,7 +32,21 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-_SUBAGENT_SIGNAL_TOOLS = ("complete", "clarify")
+_SUBAGENT_SIGNAL_TOOLS = ("complete", "clarify", "progress")
+
+# Thread-local storage for subagent context
+# Used by the progress tool to know which agent_id it's running as
+_thread_local = threading.local()
+
+
+def get_current_agent_id() -> str | None:
+    """Return the agent_id of the currently running subagent thread, or None.
+
+    Set by _create_subagent_thread before calling chat(). Used by the progress
+    tool to identify which subagent is sending a progress update.
+    Only populated in thread-mode subagents.
+    """
+    return getattr(_thread_local, "agent_id", None)
 
 
 def _ensure_subagent_signal_tools_loaded() -> None:
@@ -122,6 +136,7 @@ def _create_subagent_thread(
     target: str = "parent",
     output_schema: type | None = None,
     profile_name: str | None = None,
+    agent_id: str | None = None,
 ) -> None:
     """Shared function for running subagent threads.
 
@@ -134,7 +149,12 @@ def _create_subagent_thread(
         workspace: Workspace directory
         target: Who will review the results ("parent" or "planner")
         profile_name: Optional agent profile to apply (system prompt + hard tool enforcement)
+        agent_id: Identifier stored in thread-local so the progress tool can self-identify
     """
+    # Store agent_id in thread-local so the progress tool can identify this subagent
+    if agent_id is not None:
+        _thread_local.agent_id = agent_id
+
     # noreorder
     from gptme.chat import chat  # fmt: skip
     from gptme.executor import prepare_execution_environment  # fmt: skip
@@ -734,6 +754,7 @@ def _run_planner(
                         workspace=ws,
                         target="planner",
                         profile_name=subtask_profile,
+                        agent_id=executor_agent_id,
                     )
                 finally:
                     try:

--- a/gptme/tools/subagent/execution.py
+++ b/gptme/tools/subagent/execution.py
@@ -334,7 +334,7 @@ def _run_subagent_subprocess(
         profile_obj = get_profile(profile)
         if profile_obj and profile_obj.tools is not None:
             tool_allowlist = list(profile_obj.tools)
-            for tool_name in _SUBAGENT_SIGNAL_TOOLS:
+            for tool_name in ("complete", "clarify"):
                 if tool_name not in tool_allowlist:
                     tool_allowlist.append(tool_name)
             cmd.extend(["--tools", ",".join(tool_allowlist)])
@@ -384,7 +384,8 @@ def _run_subagent_subprocess(
     # Add completion instruction to the prompt for subprocess mode
     # (In thread mode, this is added as a system message)
     complete_section = (
-        f"\n\n[Completion Instructions]\n{_get_complete_instruction('orchestrator')}\n"
+        "\n\n[Completion Instructions]\n"
+        f"{_get_complete_instruction('orchestrator', supports_progress=False)}\n"
     )
     prompt = prompt + complete_section
 

--- a/gptme/tools/subagent/hooks.py
+++ b/gptme/tools/subagent/hooks.py
@@ -19,14 +19,18 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def _get_complete_instruction(target: str = "orchestrator") -> str:
+def _get_complete_instruction(
+    target: str = "orchestrator",
+    *,
+    supports_progress: bool = True,
+) -> str:
     """Get the standard instruction for using the complete tool.
 
     Used by both thread and subprocess modes to ensure consistent behavior.
     The instruction is intentionally minimal - profile system prompts and
     task context should guide what the complete answer should contain.
     """
-    return (
+    instruction = (
         "When finished, use the `complete` tool with your full answer/result.\n"
         f"Include everything the {target} needs - they shouldn't need to read the full log.\n"
         "```complete\n"
@@ -35,12 +39,17 @@ def _get_complete_instruction(target: str = "orchestrator") -> str:
         f"If you cannot proceed without more information from the {target}, use the `clarify` block instead:\n"
         "```clarify\n"
         "Your specific question here.\n"
-        "```\n"
-        f"To send an intermediate progress update to the {target} (without stopping), use the `progress` block:\n"
-        "```progress\n"
-        "Brief status update: what you have done so far and what remains.\n"
         "```"
     )
+    if supports_progress:
+        instruction += (
+            "\n"
+            f"To send an intermediate progress update to the {target} (without stopping), use the `progress` block:\n"
+            "```progress\n"
+            "Brief status update: what you have done so far and what remains.\n"
+            "```"
+        )
+    return instruction
 
 
 def notify_completion(agent_id: str, status: Status, summary: str) -> None:

--- a/gptme/tools/subagent/hooks.py
+++ b/gptme/tools/subagent/hooks.py
@@ -1,7 +1,8 @@
-"""Subagent hook system — completion notifications and instructions.
+"""Subagent hook system — completion and progress notifications.
 
 Handles the "fire-and-forget-then-get-alerted" pattern where subagent
-completions are delivered via the LOOP_CONTINUE hook as system messages.
+completions and intermediate progress updates are delivered via the
+LOOP_CONTINUE hook as system messages.
 """
 
 import logging
@@ -10,7 +11,7 @@ from collections.abc import Generator
 from typing import TYPE_CHECKING
 
 from ...message import Message
-from .types import Status, _completion_queue
+from .types import Status, _completion_queue, _progress_queue
 
 if TYPE_CHECKING:
     from ...logmanager import LogManager  # fmt: skip
@@ -34,6 +35,10 @@ def _get_complete_instruction(target: str = "orchestrator") -> str:
         f"If you cannot proceed without more information from the {target}, use the `clarify` block instead:\n"
         "```clarify\n"
         "Your specific question here.\n"
+        "```\n"
+        f"To send an intermediate progress update to the {target} (without stopping), use the `progress` block:\n"
+        "```progress\n"
+        "Brief status update: what you have done so far and what remains.\n"
         "```"
     )
 
@@ -54,6 +59,24 @@ def notify_completion(agent_id: str, status: Status, summary: str) -> None:
     logger.debug(f"Queued completion notification for subagent '{agent_id}': {status}")
 
 
+def notify_progress(agent_id: str, message: str) -> None:
+    """Add a subagent progress update to the notification queue.
+
+    Called by the progress tool when a subagent sends an intermediate update.
+    The parent's LOOP_CONTINUE hook delivers it as a system message so the
+    orchestrator can react without blocking on subagent_wait().
+
+    Note: Only works for thread-mode subagents (same process). Subprocess-mode
+    subagents cannot share the in-process queue.
+
+    Args:
+        agent_id: The subagent's identifier
+        message: Progress update message
+    """
+    _progress_queue.put((agent_id, message))
+    logger.debug(f"Queued progress notification for subagent '{agent_id}'")
+
+
 def _subagent_completion_hook(
     manager: "LogManager",
     interactive: bool,
@@ -65,11 +88,27 @@ def _subagent_completion_hook(
     This hook is triggered during each chat loop iteration via LOOP_CONTINUE.
     It checks the completion queue and yields system messages for any
     finished subagents, allowing the orchestrator to react naturally.
+
+    Also drains the progress queue and delivers intermediate updates as
+    ⏳ system messages.
     """
 
-    notifications = []
+    # Drain progress notifications first (in-flight updates before completions)
+    progress_updates: list[tuple[str, str]] = []
+    while True:
+        try:
+            agent_id, message = _progress_queue.get_nowait()
+            progress_updates.append((agent_id, message))
+        except queue.Empty:
+            break
 
-    # Drain all available notifications
+    for agent_id, message in progress_updates:
+        msg = f"⏳ Subagent '{agent_id}' progress: {message}"
+        logger.debug(f"Delivering subagent progress notification: {msg}")
+        yield Message("system", msg)
+
+    # Drain completion notifications
+    notifications: list[tuple[str, Status, str]] = []
     while True:
         try:
             agent_id, status, summary = _completion_queue.get_nowait()

--- a/gptme/tools/subagent/types.py
+++ b/gptme/tools/subagent/types.py
@@ -113,6 +113,11 @@ _subagent_results_lock = threading.Lock()
 # Each entry is (agent_id, status, summary)
 _completion_queue: queue.Queue[tuple[str, Status, str]] = queue.Queue()
 
+# Thread-safe queue for intermediate progress notifications from subagents
+# Each entry is (agent_id, message) — delivered as ⏳ system messages via LOOP_CONTINUE
+# Only populated in thread-mode subagents (subprocess mode cannot share in-process queues)
+_progress_queue: queue.Queue[tuple[str, str]] = queue.Queue()
+
 
 def set_subagent_result_if_absent(agent_id: str, result: "ReturnType") -> bool:
     """Cache a subagent result unless another terminal result already exists."""

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -216,6 +216,12 @@ class TestProgressNotifications:
         assert "progress" in instruction
         assert "```progress" in instruction
 
+    def test_progress_omitted_when_not_supported(self):
+        """Subprocess-mode instructions should not advertise progress."""
+        instruction = _get_complete_instruction(supports_progress=False)
+        assert "progress" not in instruction
+        assert "```progress" not in instruction
+
 
 class TestProgressTool:
     """Tests for the progress tool execution path."""
@@ -257,7 +263,7 @@ class TestProgressTool:
 
         assert _progress_queue.empty()  # Nothing queued
         assert len(messages) == 1
-        assert "unavailable" in messages[0].content
+        assert "NOT delivered" in messages[0].content
 
     def test_progress_tool_empty_message(self):
         """Empty progress block yields a warning message."""

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -22,11 +22,13 @@ from gptme.tools.subagent.hooks import (
     _get_complete_instruction,
     _subagent_completion_hook,
     notify_completion,
+    notify_progress,
 )
 from gptme.tools.subagent.types import (
     ReturnType,
     Subagent,
     _completion_queue,
+    _progress_queue,
     _subagent_results,
     _subagent_results_lock,
     _subagents,
@@ -141,6 +143,129 @@ class TestCompletionNotifications:
             _subagent_completion_hook(manager, interactive=False, prompt_queue=None)
         )
         assert len(messages) == 0
+
+
+# ---------------------------------------------------------------------------
+# Progress notification tests
+# ---------------------------------------------------------------------------
+
+
+class TestProgressNotifications:
+    def setup_method(self):
+        """Drain the global queues before each test."""
+        for q in (_completion_queue, _progress_queue):
+            while not q.empty():
+                try:
+                    q.get_nowait()
+                except queue.Empty:
+                    break
+
+    def test_notify_progress_adds_to_queue(self):
+        notify_progress("worker-1", "Halfway done")
+        assert not _progress_queue.empty()
+        agent_id, message = _progress_queue.get_nowait()
+        assert agent_id == "worker-1"
+        assert message == "Halfway done"
+
+    def test_hook_yields_progress_before_completion(self):
+        """Progress messages are delivered before completion messages."""
+        notify_progress("agent-p", "50% done")
+        notify_completion("agent-p", "success", "all done")
+        manager = MagicMock()
+        messages = list(
+            _subagent_completion_hook(manager, interactive=False, prompt_queue=None)
+        )
+        assert len(messages) == 2
+        # Progress comes first
+        assert "⏳" in messages[0].content
+        assert "agent-p" in messages[0].content
+        assert "50% done" in messages[0].content
+        # Completion second
+        assert "✅" in messages[1].content
+        assert "agent-p" in messages[1].content
+
+    def test_hook_yields_progress_message_format(self):
+        notify_progress("my-agent", "Scanning files: 10/50 done")
+        manager = MagicMock()
+        messages = list(
+            _subagent_completion_hook(manager, interactive=False, prompt_queue=None)
+        )
+        assert len(messages) == 1
+        assert messages[0].role == "system"
+        assert "⏳" in messages[0].content
+        assert "my-agent" in messages[0].content
+        assert "Scanning files: 10/50 done" in messages[0].content
+
+    def test_hook_drains_multiple_progress_updates(self):
+        notify_progress("agent-x", "Step 1 done")
+        notify_progress("agent-x", "Step 2 done")
+        notify_progress("agent-y", "Starting")
+        manager = MagicMock()
+        messages = list(
+            _subagent_completion_hook(manager, interactive=False, prompt_queue=None)
+        )
+        assert len(messages) == 3
+        contents = [m.content for m in messages]
+        assert any("Step 1 done" in c for c in contents)
+        assert any("Step 2 done" in c for c in contents)
+        assert any("Starting" in c for c in contents)
+
+    def test_progress_mention_in_complete_instruction(self):
+        """_get_complete_instruction should mention the progress block."""
+        instruction = _get_complete_instruction()
+        assert "progress" in instruction
+        assert "```progress" in instruction
+
+
+class TestProgressTool:
+    """Tests for the progress tool execution path."""
+
+    def setup_method(self):
+        while not _progress_queue.empty():
+            try:
+                _progress_queue.get_nowait()
+            except queue.Empty:
+                break
+
+    def test_progress_tool_with_agent_id(self):
+        """When agent_id is set in thread-local, progress tool queues the update."""
+        import gptme.tools.subagent.execution as exec_mod
+        from gptme.tools.progress import execute_progress
+
+        exec_mod._thread_local.agent_id = "thread-agent"
+        try:
+            messages = list(execute_progress("Phase 1 complete.", None, None))
+        finally:
+            del exec_mod._thread_local.agent_id
+
+        assert not _progress_queue.empty()
+        agent_id, message = _progress_queue.get_nowait()
+        assert agent_id == "thread-agent"
+        assert message == "Phase 1 complete."
+        assert any("sent" in m.content for m in messages)
+
+    def test_progress_tool_without_agent_id(self):
+        """Without a thread-local agent_id (subprocess mode), tool warns but doesn't crash."""
+        import gptme.tools.subagent.execution as exec_mod
+        from gptme.tools.progress import execute_progress
+
+        # Ensure no agent_id is set
+        if hasattr(exec_mod._thread_local, "agent_id"):
+            del exec_mod._thread_local.agent_id
+
+        messages = list(execute_progress("Some update", None, None))
+
+        assert _progress_queue.empty()  # Nothing queued
+        assert len(messages) == 1
+        assert "unavailable" in messages[0].content
+
+    def test_progress_tool_empty_message(self):
+        """Empty progress block yields a warning message."""
+        from gptme.tools.progress import execute_progress
+
+        messages = list(execute_progress("", None, None))
+        assert len(messages) == 1
+        assert "empty" in messages[0].content.lower()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tools_subagent.py
+++ b/tests/test_tools_subagent.py
@@ -726,7 +726,7 @@ def test_subprocess_profile_preserves_profile_tools_and_adds_clarify():
     assert captured_cmd[captured_cmd.index("--agent-profile") + 1] == "explorer"
     assert "--tools" in captured_cmd
     assert captured_cmd[captured_cmd.index("--tools") + 1] == (
-        "read,chats,complete,clarify"
+        "read,chats,complete,clarify,progress"
     )
 
 
@@ -1385,8 +1385,14 @@ def test_create_subagent_thread_loads_signal_tools_for_default_profile(tmp_path)
     assert [call.args[0] for call in mock_load_tool.call_args_list] == [
         "complete",
         "clarify",
+        "progress",
     ]
-    assert {tool.name for tool in loaded_tools} == {"shell", "complete", "clarify"}
+    assert {tool.name for tool in loaded_tools} == {
+        "shell",
+        "complete",
+        "clarify",
+        "progress",
+    }
 
 
 def test_subprocess_mode_with_profile():

--- a/tests/test_tools_subagent.py
+++ b/tests/test_tools_subagent.py
@@ -726,7 +726,7 @@ def test_subprocess_profile_preserves_profile_tools_and_adds_clarify():
     assert captured_cmd[captured_cmd.index("--agent-profile") + 1] == "explorer"
     assert "--tools" in captured_cmd
     assert captured_cmd[captured_cmd.index("--tools") + 1] == (
-        "read,chats,complete,clarify,progress"
+        "read,chats,complete,clarify"
     )
 
 


### PR DESCRIPTION
## Summary

Closes part of #554 (Better subagents).

Adds the missing piece of the "fire-and-forget-then-get-alerted-when-**update**/done" pattern Erik described. Previously subagents could only signal `complete` (done) or `clarify` (paused/needs info). There was no way to send intermediate progress updates while still running.

### New: `progress` block tool

```progress
Finished scanning auth module (47 files). Starting API layer.
```

The parent orchestrator receives this as a `⏳` system message via the existing LOOP_CONTINUE hook — no polling, no blocking:

```
⏳ Subagent 'analysis' progress: Finished scanning auth module (47 files). Starting API layer.
```

### Changes

- **`gptme/tools/progress.py`** — new `progress` block tool (disabled by default, loaded automatically in subagent context via `_SUBAGENT_SIGNAL_TOOLS`)
- **`types.py`** — `_progress_queue: queue.Queue[tuple[str, str]]` (same pattern as `_completion_queue`)
- **`hooks.py`** — `notify_progress()`, LOOP_CONTINUE hook drains progress queue before completion queue; `_get_complete_instruction()` updated to mention `progress` block
- **`execution.py`** — thread-local `_thread_local.agent_id` set before `chat()` so the tool can self-identify; `get_current_agent_id()` exposed; `progress` added to `_SUBAGENT_SIGNAL_TOOLS`
- **8 new unit tests**: 5 notification-path + 3 tool execution-path tests

### Design note

Progress delivery is in-process (thread-local agent_id → shared `_progress_queue`), so it works in **thread-mode** subagents (the default). Subprocess-mode subagents run in a different process and cannot share the queue — the tool warns gracefully and continues rather than crashing. Subprocess progress support (file-based IPC) can be added in a follow-up.

## Test plan

- [ ] `uv run pytest tests/test_subagent_unit.py` — 72/72 pass
- [ ] `ruff check` + `ruff format --check` — clean
- [ ] Verify subagent uses `progress` block → parent receives ⏳ message (manual/eval)