### PR TITLE
fix(webui): skip hosted loopback probe for first-time users

### DIFF
--- a/webui/src/components/WelcomeView.tsx
+++ b/webui/src/components/WelcomeView.tsx
@@ -194,6 +194,7 @@ export const WelcomeView = () => {
     if (
       demoMode ||
       isConnected ||
+      isFirstVisit ||
       !isDefaultLocalServer ||
       !isHostedOrigin ||
       errorBucket !== 'unknown'
@@ -250,6 +251,7 @@ export const WelcomeView = () => {
     errorBucket,
     isConnected,
     isDefaultLocalServer,
+    isFirstVisit,
     isHostedOrigin,
   ]);
 

--- a/webui/src/components/__tests__/WelcomeView.test.tsx
+++ b/webui/src/components/__tests__/WelcomeView.test.tsx
@@ -226,6 +226,10 @@ describe('WelcomeView', () => {
     expect(screen.queryByRole('button', { name: /use gptme\.ai/i })).not.toBeInTheDocument();
     // Retry connection stays available regardless of onboarding state
     expect(screen.getByRole('button', { name: /retry connection/i })).toBeInTheDocument();
+    expect(
+      screen.queryByText(/appears to be running, but it is not allowing requests from/i)
+    ).not.toBeInTheDocument();
+    expect(mockFetch).not.toHaveBeenCalled();
   });
 
   it('detects a reachable hosted loopback server and shows CORS setup guidance before retry', async () => {

--- a/webui/src/components/__tests__/WelcomeView.test.tsx
+++ b/webui/src/components/__tests__/WelcomeView.test.tsx
@@ -232,6 +232,22 @@ describe('WelcomeView', () => {
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
+  it('does not probe loopback for first-time visitors on a hosted origin (regression guard)', () => {
+    // First-time user (no seedReturningUser) on a hosted origin where the probe
+    // would normally fire — only the `isFirstVisit` guard prevents it.
+    setLocation('https://chat.gptme.org/');
+    isConnected$.set(false);
+
+    render(
+      <SettingsProvider>
+        <WelcomeView />
+      </SettingsProvider>
+    );
+
+    // The probe must not fire — the isFirstVisit guard prevents it.
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
   it('detects a reachable hosted loopback server and shows CORS setup guidance before retry', async () => {
     seedReturningUser();
     setLocation('https://chat.gptme.org/');


### PR DESCRIPTION
## Summary
- stop the hosted loopback reachability probe on first visit, so anonymous users do not hit localhost before choosing a local-server path
- keep the existing probe behavior for returning users who have already completed setup
- lock the behavior down with a WelcomeView regression assertion that no localhost fetch runs on first load

## Testing
- npm test -- --runInBand src/components/__tests__/WelcomeView.test.tsx
- npx eslint src/components/WelcomeView.tsx src/components/__tests__/WelcomeView.test.tsx
- npm run typecheck

Refs gptme/gptme-cloud#414
