### PR TITLE
feat(webui): fork conversations from any message

### DIFF
--- a/.github/workflows/webui.yml
+++ b/.github/workflows/webui.yml
@@ -115,7 +115,8 @@ jobs:
 
     - name: Start server (stable)
       env:
-        ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY || 'dummy-ci-key' }}
+        MODEL: anthropic/claude-3-5-haiku-latest
       run: |
         gptme-server --cors-origin="http://localhost:5701" &
         echo $! > /tmp/gptme-server.pid
@@ -151,7 +152,8 @@ jobs:
 
     - name: Start server (dev)
       env:
-        ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY || 'dummy-ci-key' }}
+        MODEL: anthropic/claude-3-5-haiku-latest
       run: |
         gptme-server --cors-origin="http://localhost:5701" &
         echo $! > /tmp/gptme-server.pid

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -336,7 +336,7 @@ def _copy_messages_for_fork(
     """Copy a message slice into a new conversation, preserving attachments."""
     source_attachments = source_logdir / "attachments"
     dest_attachments = dest_logdir / "attachments"
-    needs_attachment_copy = False
+    attachment_copies: set[tuple[Path, Path]] = set()
     copied_messages: list[Message] = []
 
     for msg in messages:
@@ -348,8 +348,10 @@ def _copy_messages_for_fork(
             )
             new_files.append(new_ref)
             if copied:
-                needs_attachment_copy = True
+                assert isinstance(new_ref, Path)
                 path_map[str(file_ref)] = str(new_ref)
+                source_path = source_attachments / new_ref.relative_to(dest_attachments)
+                attachment_copies.add((source_path, new_ref))
 
         new_file_hashes = {
             path_map.get(path, path): digest for path, digest in msg.file_hashes.items()
@@ -358,8 +360,14 @@ def _copy_messages_for_fork(
             replace(msg, files=new_files, file_hashes=new_file_hashes)
         )
 
-    if needs_attachment_copy and source_attachments.exists():
-        shutil.copytree(source_attachments, dest_attachments, dirs_exist_ok=True)
+    for source_path, dest_path in attachment_copies:
+        if not source_path.exists():
+            continue
+        if source_path.is_dir():
+            shutil.copytree(source_path, dest_path, dirs_exist_ok=True)
+        else:
+            dest_path.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(source_path, dest_path)
 
     return copied_messages
 
@@ -1948,7 +1956,7 @@ def api_conversation_fork(conversation_id: str):
                     "error": f"Message index {after_message} out of range (0-{len(source_messages) - 1})"
                 }
             ),
-            404,
+            400,
         )
 
     new_conversation_id = _generate_fork_conversation_id()
@@ -1960,7 +1968,6 @@ def api_conversation_fork(conversation_id: str):
     fork_manager = LogManager.load(
         logdir=new_logdir, initial_msgs=forked_messages, create=True, lock=False
     )
-    fork_manager.log = Log(forked_messages)
     fork_manager.write()
 
     source_config = ChatConfig.from_logdir(manager.logdir)

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -304,6 +304,66 @@ def _append_conversation_system_prompt(
         messages.append(Message("system", system_prompt))
 
 
+def _generate_fork_conversation_id() -> str:
+    """Generate a reasonably unique conversation id for forked copies."""
+    timestamp = datetime.now(tz=timezone.utc).isoformat().replace(":", "-")
+    return f"chat-{timestamp}-{time.time_ns() % 1_000_000_000:09d}"
+
+
+def _fork_message_file_reference(
+    file_ref: FilePath, source_attachments: Path, dest_attachments: Path
+) -> tuple[FilePath, bool]:
+    """Re-root attachment file paths into the forked conversation when needed."""
+    if isinstance(file_ref, URI):
+        return file_ref, False
+
+    path = Path(file_ref)
+    try:
+        rel = path.relative_to(source_attachments)
+        return dest_attachments / rel, True
+    except ValueError:
+        pass
+
+    if path.parts[:1] == ("attachments",):
+        return dest_attachments / Path(*path.parts[1:]), True
+
+    return path, False
+
+
+def _copy_messages_for_fork(
+    messages: list[Message], source_logdir: Path, dest_logdir: Path
+) -> list[Message]:
+    """Copy a message slice into a new conversation, preserving attachments."""
+    source_attachments = source_logdir / "attachments"
+    dest_attachments = dest_logdir / "attachments"
+    needs_attachment_copy = False
+    copied_messages: list[Message] = []
+
+    for msg in messages:
+        new_files: list[FilePath] = []
+        path_map: dict[str, str] = {}
+        for file_ref in msg.files:
+            new_ref, copied = _fork_message_file_reference(
+                file_ref, source_attachments, dest_attachments
+            )
+            new_files.append(new_ref)
+            if copied:
+                needs_attachment_copy = True
+                path_map[str(file_ref)] = str(new_ref)
+
+        new_file_hashes = {
+            path_map.get(path, path): digest for path, digest in msg.file_hashes.items()
+        }
+        copied_messages.append(
+            replace(msg, files=new_files, file_hashes=new_file_hashes)
+        )
+
+    if needs_attachment_copy and source_attachments.exists():
+        shutil.copytree(source_attachments, dest_attachments, dirs_exist_ok=True)
+
+    return copied_messages
+
+
 def _get_optional_string_list_field(
     req_json: dict, field: str
 ) -> list[str] | None | tuple[flask.Response, int]:
@@ -1827,6 +1887,95 @@ def api_conversation_delete_message(conversation_id: str, index: int):
 
     _invalidate_conversations_cache()
     return flask.jsonify(log_dict)
+
+
+@v2_api.route("/api/v2/conversations/<string:conversation_id>/fork", methods=["POST"])
+@require_auth
+@api_doc_simple(
+    responses={
+        200: SessionResponse,
+        400: ErrorResponse,
+        404: ErrorResponse,
+        409: ErrorResponse,
+    },
+    tags=["conversations-v2"],
+)
+def api_conversation_fork(conversation_id: str):
+    """Create a forked copy of a conversation from a specific message index."""
+    if error := _validate_conversation_id(conversation_id):
+        return error
+
+    after_message_raw = request.args.get("after_message")
+    if after_message_raw is None:
+        return flask.jsonify(
+            {"error": "after_message query parameter is required"}
+        ), 400
+    try:
+        after_message = int(after_message_raw)
+    except ValueError:
+        return flask.jsonify({"error": "after_message must be an integer"}), 400
+
+    branch = request.args.get("branch", "main")
+    if error := _validate_branch(branch):
+        return error
+
+    sessions = SessionManager.get_sessions_for_conversation(conversation_id)
+    for sess in sessions:
+        if sess.generating:
+            return (
+                flask.jsonify({"error": "Cannot fork while generation is in progress"}),
+                409,
+            )
+
+    try:
+        manager = LogManager.load(conversation_id, branch=branch, lock=False)
+    except FileNotFoundError:
+        if branch == "main":
+            return (
+                flask.jsonify({"error": f"Conversation not found: {conversation_id}"}),
+                404,
+            )
+        return (
+            flask.jsonify({"error": f"Branch not found: {branch}"}),
+            404,
+        )
+
+    source_messages = list(manager.log.messages)
+    if after_message < 0 or after_message >= len(source_messages):
+        return (
+            flask.jsonify(
+                {
+                    "error": f"Message index {after_message} out of range (0-{len(source_messages) - 1})"
+                }
+            ),
+            404,
+        )
+
+    new_conversation_id = _generate_fork_conversation_id()
+    new_logdir = get_logs_dir() / new_conversation_id
+
+    forked_messages = _copy_messages_for_fork(
+        source_messages[: after_message + 1], manager.logdir, new_logdir
+    )
+    fork_manager = LogManager.load(
+        logdir=new_logdir, initial_msgs=forked_messages, create=True, lock=False
+    )
+    fork_manager.log = Log(forked_messages)
+    fork_manager.write()
+
+    source_config = ChatConfig.from_logdir(manager.logdir)
+    fork_name = f"Fork of {manager.name} @ msg {after_message + 1}"
+    replace(source_config, _logdir=new_logdir, name=fork_name).save()
+
+    session = SessionManager.create_session(new_conversation_id)
+    _invalidate_conversations_cache()
+    return flask.jsonify(
+        {
+            "status": "ok",
+            "conversation_id": new_conversation_id,
+            "session_id": session.id,
+        }
+    )
 
 
 @v2_api.route("/api/v2/conversations/<string:conversation_id>", methods=["DELETE"])

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -2361,6 +2361,42 @@ def test_v2_fork_conversation_from_message(client: FlaskClient):
     ]
 
 
+def test_v2_fork_conversation_rejects_out_of_range_index(client: FlaskClient):
+    """Out-of-range fork indexes are bad requests, not missing conversations."""
+    conversation_id = create_conversation(client)["conversation_id"]
+
+    response = client.post(
+        f"/api/v2/conversations/{conversation_id}/fork?after_message=999"
+    )
+
+    assert response.status_code == 400
+    assert "out of range" in response.get_json()["error"]
+
+
+def test_copy_messages_for_fork_copies_only_referenced_attachments(tmp_path: Path):
+    """Forking should not copy attachments excluded from the retained message slice."""
+    from gptme.message import Message  # fmt: skip
+    from gptme.server.api_v2 import _copy_messages_for_fork  # fmt: skip
+
+    source_logdir = tmp_path / "source"
+    dest_logdir = tmp_path / "fork"
+    source_attachments = source_logdir / "attachments"
+    source_attachments.mkdir(parents=True)
+    (source_attachments / "keep.txt").write_text("keep", encoding="utf-8")
+    (source_attachments / "skip.txt").write_text("skip", encoding="utf-8")
+
+    copied = _copy_messages_for_fork(
+        [Message("user", "Keep this file", files=[Path("attachments/keep.txt")])],
+        source_logdir,
+        dest_logdir,
+    )
+
+    assert copied[0].files == [dest_logdir / "attachments" / "keep.txt"]
+    fork_attachments = dest_logdir / "attachments"
+    assert (fork_attachments / "keep.txt").read_text(encoding="utf-8") == "keep"
+    assert not (fork_attachments / "skip.txt").exists()
+
+
 def test_v2_edit_message_rejects_non_string_content(client: FlaskClient):
     """Test that edit rejects non-string content with a 400."""
     conversation_id = create_conversation(client)["conversation_id"]

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -2319,6 +2319,48 @@ def test_v2_message_file_uris_reject_file_scheme(client: FlaskClient, endpoint_b
     assert conversation["log"][user_index].get("files") is None
 
 
+def test_v2_fork_conversation_from_message(client: FlaskClient):
+    """Forking should create a new conversation with messages up to the selected index."""
+    conversation_id = create_conversation(client)["conversation_id"]
+    client.post(
+        f"/api/v2/conversations/{conversation_id}",
+        json={"role": "user", "content": "First question"},
+    )
+    client.post(
+        f"/api/v2/conversations/{conversation_id}",
+        json={"role": "assistant", "content": "First answer"},
+    )
+    client.post(
+        f"/api/v2/conversations/{conversation_id}",
+        json={"role": "user", "content": "Second question"},
+    )
+
+    source = client.get(f"/api/v2/conversations/{conversation_id}").get_json()
+    assert source is not None
+    fork_index = len(source["log"]) - 2
+
+    response = client.post(
+        f"/api/v2/conversations/{conversation_id}/fork?after_message={fork_index}"
+    )
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data is not None
+    assert data["status"] == "ok"
+    assert data["conversation_id"] != conversation_id
+    assert data["session_id"]
+
+    forked = client.get(f"/api/v2/conversations/{data['conversation_id']}").get_json()
+    assert forked is not None
+    assert forked["name"] == f"Fork of {conversation_id} @ msg {fork_index + 1}"
+    assert [msg["content"] for msg in forked["log"]] == [
+        msg["content"] for msg in source["log"][: fork_index + 1]
+    ]
+    assert [msg["role"] for msg in forked["log"]] == [
+        msg["role"] for msg in source["log"][: fork_index + 1]
+    ]
+
+
 def test_v2_edit_message_rejects_non_string_content(client: FlaskClient):
     """Test that edit rejects non-string content with a 400."""
     conversation_id = create_conversation(client)["conversation_id"]

--- a/webui/src/components/ChatMessage.tsx
+++ b/webui/src/components/ChatMessage.tsx
@@ -23,6 +23,7 @@ import {
   AlertCircle,
   RotateCcw,
   Pencil,
+  GitBranch,
   Play,
   RefreshCw,
   Trash2,
@@ -151,6 +152,7 @@ interface Props {
   onDelete?: (index: number) => void;
   onRerun?: (index: number) => void;
   onRegenerate?: (index: number) => void;
+  onFork?: (index: number) => void;
   messageIndex?: number;
 }
 
@@ -166,6 +168,7 @@ const ChatMessageComponent: FC<Props> = ({
   onDelete,
   onRerun,
   onRegenerate,
+  onFork,
   messageIndex,
 }) => {
   const { api, connectionConfig } = useApi();
@@ -628,6 +631,18 @@ const ChatMessageComponent: FC<Props> = ({
                             </Button>
                           )}
                         </>
+                      )}
+                      {onFork && messageIndex !== undefined && !isEditing$.get() && (
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => onFork(messageIndex)}
+                          className="h-7 w-7 p-0"
+                          aria-label="Fork from here"
+                          title="Fork from here"
+                        >
+                          <GitBranch size={14} />
+                        </Button>
                       )}
                       {message$.role.get() === 'assistant' && isSpeechSupported() && (
                         <Button

--- a/webui/src/components/ConversationContent.tsx
+++ b/webui/src/components/ConversationContent.tsx
@@ -1,5 +1,7 @@
 import type { FC } from 'react';
 import { useRef, useEffect, useCallback, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useQueryClient } from '@tanstack/react-query';
 import { ChatMessage } from './ChatMessage';
 import { ChatInput, type ChatOptions } from './ChatInput';
 import { CollapsedStepGroup } from './CollapsedStepGroup';
@@ -18,6 +20,7 @@ import { getObservableIndex } from '@legendapp/state';
 import { useApi } from '@/contexts/ApiContext';
 import { useSettings } from '@/contexts/SettingsContext';
 import { useModels } from '@/hooks/useModels';
+import { chatRoute } from '@/utils/routes';
 import { AlertTriangle, ArrowDown, RefreshCw, WifiOff } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 
@@ -37,10 +40,13 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
     deleteMessage,
     rerunFromMessage,
     regenerateMessage,
+    forkConversation,
     switchBranch,
     confirmTool,
     interruptGeneration,
   } = useConversation(conversationId, serverId);
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const loadError = use$(() => conversation$?.loadError.get() ?? null);
   const messageCount = use$(() => conversation$?.data.log.get()?.length ?? 0);
   const connectionStatus = use$(() => conversation$?.connectionStatus.get() ?? 'disconnected');
@@ -489,6 +495,30 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
     isScrolledUp$.set(false);
   };
 
+  const handleForkMessage = useCallback(
+    async (index: number) => {
+      const forkedConversationId = await forkConversation(index);
+      if (!forkedConversationId) return;
+
+      await queryClient.invalidateQueries({
+        predicate: (query) => {
+          const key = query.queryKey[0];
+          return typeof key === 'string' && key.startsWith('conversation');
+        },
+      });
+
+      const params = new URLSearchParams(window.location.search);
+      params.delete('split');
+      if (serverId) {
+        params.set('server', serverId);
+      } else {
+        params.delete('server');
+      }
+      navigate(chatRoute(forkedConversationId, params.toString()));
+    },
+    [forkConversation, navigate, queryClient, serverId]
+  );
+
   const showConnectionBanner =
     !isReadOnly && (connectionStatus === 'reconnecting' || connectionStatus === 'disconnected');
 
@@ -697,6 +727,7 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
                   onDelete={isReadOnly ? undefined : deleteMessage}
                   onRerun={isReadOnly ? undefined : rerunFromMessage}
                   onRegenerate={isReadOnly ? undefined : regenerateMessage}
+                  onFork={isReadOnly ? undefined : handleForkMessage}
                   messageIndex={absoluteIndex}
                 />
                 {/* Branch indicator at fork points */}

--- a/webui/src/components/__tests__/ChatMessage.test.tsx
+++ b/webui/src/components/__tests__/ChatMessage.test.tsx
@@ -105,6 +105,27 @@ describe('ChatMessage', () => {
     expect(copyButton).toBeInTheDocument();
   });
 
+  it('renders fork button and calls handler with the message index', () => {
+    const onFork = jest.fn();
+    const message$ = observable<Message>({
+      role: 'assistant',
+      content: 'Some response text',
+      timestamp: new Date().toISOString(),
+    });
+
+    renderWithProviders(
+      <ChatMessage
+        message$={message$}
+        conversationId={testConversationId}
+        messageIndex={3}
+        onFork={onFork}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Fork from here' }));
+    expect(onFork).toHaveBeenCalledWith(3);
+  });
+
   it('copies message content to clipboard on copy button click', async () => {
     const writeText = jest.fn().mockResolvedValue(undefined);
     Object.assign(navigator, {

--- a/webui/src/hooks/useConversation.ts
+++ b/webui/src/hooks/useConversation.ts
@@ -784,6 +784,18 @@ export function useConversation(conversationId: string, serverId?: string) {
     }
   };
 
+  const forkConversation = async (index: number) => {
+    try {
+      const branch = conversation$?.currentBranch.get() ?? 'main';
+      return await api.forkConversation(conversationId, index, branch);
+    } catch (error) {
+      console.error('Error forking conversation:', error);
+      const errorMsg = error instanceof Error ? error.message : 'Failed to fork conversation';
+      toast({ variant: 'destructive', title: 'Fork failed', description: errorMsg });
+      return null;
+    }
+  };
+
   const switchBranch = (branchName: string) => {
     setCurrentBranch(conversationId, branchName);
   };
@@ -806,6 +818,7 @@ export function useConversation(conversationId: string, serverId?: string) {
     deleteMessage,
     rerunFromMessage,
     regenerateMessage,
+    forkConversation,
     switchBranch,
     confirmTool,
     interruptGeneration,

--- a/webui/src/utils/__tests__/api.test.ts
+++ b/webui/src/utils/__tests__/api.test.ts
@@ -302,6 +302,54 @@ describe('ApiClient conversation list detail flag', () => {
   });
 });
 
+describe('ApiClient forkConversation', () => {
+  const originalFetch = global.fetch;
+  const originalCrypto = global.crypto;
+
+  beforeEach(() => {
+    Object.defineProperty(global, 'crypto', {
+      value: {
+        ...originalCrypto,
+        randomUUID: jest.fn(() => 'test-client-id'),
+      },
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    Object.defineProperty(global, 'crypto', {
+      value: originalCrypto,
+      configurable: true,
+    });
+    jest.restoreAllMocks();
+  });
+
+  it('forks a conversation at the selected message index', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        status: 'ok',
+        conversation_id: 'forked-conv',
+        session_id: 'fork-session',
+      }),
+    } as Response);
+
+    const client = new ApiClient('http://127.0.0.1:5700');
+    client.setConnected(true);
+
+    const forkedId = await client.forkConversation('conv-1', 7, 'main-edit-0');
+
+    expect(forkedId).toBe('forked-conv');
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://127.0.0.1:5700/api/v2/conversations/conv-1/fork?after_message=7&branch=main-edit-0',
+      expect.objectContaining({ method: 'POST' })
+    );
+    expect(client.sessions$.get('forked-conv').get()).toBe('fork-session');
+  });
+});
+
 describe('ApiClient event stream reconnection', () => {
   const originalEventSource = global.EventSource;
   const originalCrypto = global.crypto;

--- a/webui/src/utils/api.ts
+++ b/webui/src/utils/api.ts
@@ -1041,6 +1041,38 @@ export class ApiClient {
     }
   }
 
+  async forkConversation(
+    logfile: string,
+    afterMessage: number,
+    branch: string = 'main'
+  ): Promise<string> {
+    if (!this.isConnected) {
+      throw new ApiClientError('Not connected to API');
+    }
+    try {
+      const params = new URLSearchParams({
+        after_message: String(afterMessage),
+      });
+      if (branch && branch !== 'main') {
+        params.set('branch', branch);
+      }
+      const response = await this.fetchJson<{
+        status: string;
+        session_id: string;
+        conversation_id: string;
+      }>(`${this.baseUrl}/api/v2/conversations/${logfile}/fork?${params.toString()}`, {
+        method: 'POST',
+      });
+      this.sessions$.set(response.conversation_id, response.session_id);
+      return response.conversation_id;
+    } catch (error) {
+      if (error instanceof DOMException && error.name === 'AbortError') {
+        throw new ApiClientError('Request aborted', 499);
+      }
+      throw error;
+    }
+  }
+
   async createConversation(
     logfile: string,
     messages: Message[],

--- a/webui/src/utils/demoApiClient.ts
+++ b/webui/src/utils/demoApiClient.ts
@@ -281,6 +281,29 @@ export function createDemoApiClient(baseUrl: string = DEMO_BASE_URL): IApiClient
       if (local) return clone(local);
       throw new DemoModeError(`getConversation(${logfile})`);
     },
+    forkConversation: async (logfile, afterMessage, branch = 'main') => {
+      const source =
+        logfile === DEMO_CONV_ID
+          ? clone(DEMO_CONV_RESPONSE)
+          : clone(localConversations.get(logfile));
+      if (!source) {
+        throw new DemoModeError(`forkConversation(${logfile})`);
+      }
+      const branchLog = clone(source.branches[branch] ?? source.log);
+      const forkLog = branchLog.slice(0, afterMessage + 1);
+      const forkId = `demo/conv-${Date.now()}-fork`;
+      const forked: ConversationResponse = {
+        id: forkId,
+        name: `Fork of ${source.name || source.id} @ msg ${afterMessage + 1}`,
+        log: forkLog,
+        logfile: forkId,
+        branches: { main: clone(forkLog) },
+        workspace: source.workspace,
+      };
+      localConversations.set(forkId, forked);
+      sessions$.set(forkId, `demo-session-${forkId}`);
+      return forkId;
+    },
 
     // Config — return a minimal demo config.
     getChatConfig: async () => DEMO_CHAT_CONFIG,


### PR DESCRIPTION
## Summary
- add a server endpoint to fork a conversation into a new conversation seeded with messages 0..N
- add a message-level "Fork from here" action in the webui and navigate to the new conversation
- cover the new API surface and UI action with targeted tests

## Testing
- uv run ruff check gptme/server/api_v2.py tests/test_server_v2.py
- ./.venv/bin/pytest tests/test_server_v2.py -k fork_conversation_from_message
- npm test -- --runTestsByPath src/components/__tests__/ChatMessage.test.tsx src/utils/__tests__/api.test.ts
- npm run typecheck