### PR TITLE
feat(llm): add built-in offline mock provider

### DIFF
--- a/gptme/llm/__init__.py
+++ b/gptme/llm/__init__.py
@@ -1027,6 +1027,12 @@ def list_available_providers() -> list[tuple[Provider, str]]:
             available.append((CustomProvider(plugin_name), env_var))
             seen.add(plugin_name)
 
+    # Note: "mock" is intentionally absent here. It requires no credentials and
+    # is always usable when explicitly requested (e.g. "mock/echo"). Surfacing it
+    # in credential discovery would make it a candidate for auto-selection in
+    # environments with no real API keys, which is not the intended use-case.
+    # Users who want mock must specify it explicitly.
+
     return available
 
 

--- a/gptme/llm/__init__.py
+++ b/gptme/llm/__init__.py
@@ -161,6 +161,9 @@ def init_llm(provider: Provider):
     global _subscription_initialized
     config = get_config()
 
+    # Mock provider needs no client/auth — responses are computed in-process.
+    if provider == "mock":
+        return
     # Check if it's a built-in OpenAI-compatible provider
     if provider in PROVIDERS_OPENAI and not has_openai_client(provider):
         init_openai(provider, config)
@@ -456,6 +459,18 @@ def _chat_complete(
             messages, _get_base_model(model), tools, max_tokens=max_tokens
         )
         return content, {"model": model}
+    if provider == "mock":
+        from .llm_mock import chat as chat_mock
+
+        return chat_mock(
+            messages,
+            model,
+            tools,
+            output_schema=output_schema,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            top_p=top_p,
+        )
 
     # Unsupported provider - OpenAI and Anthropic are handled above
     raise ValueError(f"Unsupported provider: {provider}")
@@ -584,6 +599,19 @@ def _stream(
 
         gen = stream_subscription(
             messages, _get_base_model(model), tools, max_tokens=max_tokens
+        )
+        return _StreamWithMetadata(gen, model)
+    if provider == "mock":
+        from .llm_mock import stream as stream_mock
+
+        gen = stream_mock(
+            messages,
+            model,
+            tools,
+            output_schema=output_schema,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            top_p=top_p,
         )
         return _StreamWithMetadata(gen, model)
     # Note: Validation-only fallback for streaming is complex

--- a/gptme/llm/llm_mock.py
+++ b/gptme/llm/llm_mock.py
@@ -49,8 +49,8 @@ def _generate(messages: list[Message], model: str) -> str:
 def chat(
     messages: list[Message],
     model: str,
-    tools=None,
-    output_schema=None,
+    tools: list | None = None,
+    output_schema: type | None = None,
     max_tokens: int | None = None,
     temperature: float | None = None,
     top_p: float | None = None,
@@ -62,8 +62,8 @@ def chat(
 def stream(
     messages: list[Message],
     model: str,
-    tools=None,
-    output_schema=None,
+    tools: list | None = None,
+    output_schema: type | None = None,
     max_tokens: int | None = None,
     temperature: float | None = None,
     top_p: float | None = None,

--- a/gptme/llm/llm_mock.py
+++ b/gptme/llm/llm_mock.py
@@ -1,0 +1,79 @@
+"""Built-in offline mock provider.
+
+Provides deterministic, no-auth canned responses for tests, demos, and offline
+development. Unlike the ``local`` provider (which still talks to an
+OpenAI-compatible HTTP endpoint), the ``mock`` provider needs no server, no API
+key, and no network — responses are computed in-process.
+
+Scripted models (see ``MODELS["mock"]`` in :mod:`gptme.llm.models.data`):
+
+- ``mock/echo``    — echoes the last user message back, prefixed with ``Echo: ``.
+- ``mock/static``  — returns a fixed canned string.
+
+Use these to exercise the LLM plumbing (reply, streaming, model listing) without
+hitting a real provider.
+"""
+
+from collections.abc import Generator
+
+from ..message import Message, MessageMetadata
+
+# Fixed response for the ``mock/static`` model.
+STATIC_RESPONSE = "This is a static mock response."
+
+
+def _last_user_text(messages: list[Message]) -> str:
+    """Return the content of the most recent user message (empty if none)."""
+    for msg in reversed(messages):
+        if msg.role == "user":
+            return msg.content
+    return ""
+
+
+def _generate(messages: list[Message], model: str) -> str:
+    """Compute the canned response for a mock model.
+
+    ``model`` is the fully-qualified name (e.g. ``"mock/echo"``); the bare model
+    name after the provider prefix selects the scripted behaviour.
+    """
+    base_model = model.split("/", 1)[1] if "/" in model else model
+    if base_model == "echo":
+        return f"Echo: {_last_user_text(messages)}"
+    if base_model == "static":
+        return STATIC_RESPONSE
+    raise ValueError(
+        f"Unknown mock model: {model!r} (available: mock/echo, mock/static)"
+    )
+
+
+def chat(
+    messages: list[Message],
+    model: str,
+    tools=None,
+    output_schema=None,
+    max_tokens: int | None = None,
+    temperature: float | None = None,
+    top_p: float | None = None,
+) -> tuple[str, MessageMetadata | None]:
+    """Return a deterministic canned response and zero-cost metadata."""
+    return _generate(messages, model), {"model": model}
+
+
+def stream(
+    messages: list[Message],
+    model: str,
+    tools=None,
+    output_schema=None,
+    max_tokens: int | None = None,
+    temperature: float | None = None,
+    top_p: float | None = None,
+) -> Generator[str, None, MessageMetadata | None]:
+    """Stream the canned response one whitespace-delimited token at a time."""
+    response = _generate(messages, model)
+    # Yield word-by-word so consumers exercise the incremental-chunk path rather
+    # than receiving the whole string at once. Re-insert the separating spaces so
+    # that "".join(chunks) reconstructs the response exactly (matches chat()).
+    words = response.split(" ")
+    for i, word in enumerate(words):
+        yield word if i == 0 else " " + word
+    return {"model": model}

--- a/gptme/llm/models/data.py
+++ b/gptme/llm/models/data.py
@@ -516,6 +516,24 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
     # Empty dict = models fetched dynamically or specified by user
     "gptme": {},
     "local": {},
+    # Built-in offline mock provider — no auth, deterministic canned responses.
+    # For tests, demos, and offline development. See gptme/llm/llm_mock.py.
+    "mock": {
+        # Echoes the last user message back (round-trip / plumbing tests).
+        "echo": {
+            "context": 128_000,
+            "max_output": 4096,
+            "price_input": 0,
+            "price_output": 0,
+        },
+        # Returns a fixed canned string (deterministic output tests).
+        "static": {
+            "context": 128_000,
+            "max_output": 4096,
+            "price_input": 0,
+            "price_output": 0,
+        },
+    },
 }
 
 # check that all providers have a MODELS entry

--- a/gptme/llm/models/types.py
+++ b/gptme/llm/models/types.py
@@ -52,6 +52,7 @@ BuiltinProvider = Literal[
     "moonshot",
     "nvidia",
     "local",
+    "mock",
 ]
 PROVIDERS: list[BuiltinProvider] = cast(
     list[BuiltinProvider], get_args(BuiltinProvider)

--- a/tests/test_llm_mock.py
+++ b/tests/test_llm_mock.py
@@ -1,0 +1,94 @@
+"""Tests for the built-in offline mock provider."""
+
+import pytest
+
+from gptme.llm import _chat_complete, _stream, init_llm
+from gptme.llm.llm_mock import STATIC_RESPONSE, chat, stream
+from gptme.llm.models import get_model
+from gptme.llm.models.data import MODELS
+from gptme.llm.models.types import PROVIDERS
+from gptme.message import Message
+
+
+def test_mock_provider_registered():
+    """The mock provider is a built-in provider with scripted models."""
+    assert "mock" in PROVIDERS
+    assert set(MODELS["mock"]) == {"echo", "static"}
+
+
+def test_mock_models_resolve():
+    """Mock models resolve to ModelMeta with zero cost and no auth."""
+    for name in ("echo", "static"):
+        meta = get_model(f"mock/{name}")
+        assert meta.provider == "mock"
+        assert meta.model == name
+        assert meta.price_input == 0
+        assert meta.price_output == 0
+
+
+def test_init_llm_mock_requires_no_auth():
+    """init_llm('mock') is a no-op and never raises (no client/key needed)."""
+    init_llm("mock")  # should not raise even with no API keys configured
+
+
+def test_echo_chat():
+    """mock/echo echoes the last user message."""
+    messages = [
+        Message("system", "ignored"),
+        Message("user", "hello world"),
+    ]
+    content, meta = chat(messages, "mock/echo", None)
+    assert content == "Echo: hello world"
+    assert meta == {"model": "mock/echo"}
+
+
+def test_echo_uses_last_user_message():
+    """mock/echo picks the most recent user message, not the first."""
+    messages = [
+        Message("user", "first"),
+        Message("assistant", "reply"),
+        Message("user", "second"),
+    ]
+    content, _ = chat(messages, "mock/echo", None)
+    assert content == "Echo: second"
+
+
+def test_static_chat():
+    """mock/static returns a fixed canned response regardless of input."""
+    content, _ = chat([Message("user", "anything")], "mock/static", None)
+    assert content == STATIC_RESPONSE
+
+
+def test_unknown_mock_model_raises():
+    """An unknown mock model name is an explicit error."""
+    with pytest.raises(ValueError, match="Unknown mock model"):
+        chat([Message("user", "x")], "mock/does-not-exist", None)
+
+
+def test_stream_reconstructs_chat_response():
+    """Concatenated stream chunks reconstruct the chat() response exactly."""
+    messages = [Message("user", "stream me please")]
+    chunks = []
+    gen = stream(messages, "mock/echo", None)
+    try:
+        while True:
+            chunks.append(next(gen))
+    except StopIteration as e:
+        meta = e.value
+    expected, _ = chat(messages, "mock/echo", None)
+    assert "".join(chunks) == expected
+    assert meta == {"model": "mock/echo"}
+    # Streaming should produce more than one chunk for a multi-word response.
+    assert len(chunks) > 1
+
+
+def test_chat_complete_routes_to_mock():
+    """The top-level _chat_complete dispatcher routes mock/* to the mock path."""
+    content, _ = _chat_complete([Message("user", "routed")], "mock/echo", None)
+    assert content == "Echo: routed"
+
+
+def test_stream_dispatcher_routes_to_mock():
+    """The top-level _stream dispatcher routes mock/* to the mock path."""
+    stream_wrapper = _stream([Message("user", "routed")], "mock/echo", None)
+    assert "".join(stream_wrapper) == "Echo: routed"


### PR DESCRIPTION
## Summary

Adds a first-class `mock` provider to gptme that needs **no API key, no network, and no server** — responses are computed in-process. This unblocks tests, demos, and offline development that need a working model without real credentials.

Two scripted models:

| Model | Behavior |
|-------|----------|
| `mock/echo` | Echoes the last user message, prefixed `Echo: ` (round-trip / plumbing tests) |
| `mock/static` | Returns a fixed canned string (deterministic output tests) |

## Usage

```python
from gptme.llm import _chat_complete
from gptme.message import Message

content, _ = _chat_complete([Message("user", "hi")], "mock/echo", None)
# content == "Echo: hi"
```

## Design notes

- Clean first-class provider rather than one overgrown magic mock: `mock` is added to `BuiltinProvider` and gets static model metadata in `data.py`. The scripted behaviors live in a small new `gptme/llm/llm_mock.py`.
- `init_llm('mock')` is a no-op (no client/auth).
- Both `_chat_complete` and `_stream` route `mock/*` to the mock module; streamed chunks reconstruct the `chat()` response exactly.
- Model listing works automatically via the existing static-model path in `listing.py` (mock is intentionally **not** in the dynamic-fetch / OpenAI-compatible sets).

## Tests

New `tests/test_llm_mock.py` (10 tests): provider registration, model resolution, no-auth init, echo/static behavior, unknown-model error, stream/chat consistency, and top-level dispatcher routing. Existing `test_llm_models*` (153 tests) still pass.

Implements the request in ErikBjare/bob#916.