### PR TITLE
chore(deps): group dependabot minor/patch bumps into single PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,24 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    # Collapse routine minor/patch bumps into a single PR per run to keep the
+    # review queue small. Major bumps still open individual PRs so breaking
+    # changes get scrutiny.
+    groups:
+      python-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Problem

Routine dependency bumps each open their own PR. As of 2026-06-15 there were **5 open dependabot PRs simultaneously** in this repo (anthropic, pytest-timeout, sphinxcontrib-mermaid, pytest-retry, pypdf), all low-risk minor/patch bumps. They can't self-merge (bot-authored) so they accumulate in the review queue and require manual merges.

## Change

Add `groups:` to `.github/dependabot.yml` so each weekly run collapses **minor/patch** updates into a single grouped PR per ecosystem (pip, github-actions). **Major** bumps still open individual PRs so breaking changes keep individual scrutiny.

This is the same pattern aw-webui-style repos use to keep dependency noise down. It only affects *future* dependabot runs (the 5 currently-open PRs are unchanged).

## Verification

- `dependabot.yml` validated as well-formed YAML (`version: 2`, both ecosystems retain their schedule, groups parse correctly).
- Grouping with `update-types: [minor, patch]` is standard dependabot config — majors fall outside the group and continue opening individual PRs.

## Follow-up (not in this PR)

A dependabot **auto-merge** workflow (`dependabot/fetch-metadata` + `gh pr merge --auto`) would fully close the loop, but that needs "Allow auto-merge" enabled in repo settings. Grouping is the safe, self-contained first step.