### PR TITLE
fix(server): accept --tools none to disable all tools

### DIFF
--- a/gptme/server/cli.py
+++ b/gptme/server/cli.py
@@ -163,7 +163,11 @@ def main():
     envvar="GPTME_SERVER_PORT",
     help="Port to run the server on.",
 )
-@click.option("--tools", default=None, help="Tools to enable, comma separated.")
+@click.option(
+    "--tools",
+    default=None,
+    help="Tools to enable (comma separated). Use 'none' to disable all tools.",
+)
 @click.option(
     "--cors-origin",
     default=None,

--- a/gptme/server/cli.py
+++ b/gptme/server/cli.py
@@ -20,6 +20,28 @@ from .constants import _pick_fallback_model
 logger = logging.getLogger(__name__)
 
 
+def _parse_tools_allowlist(tools: str | None) -> list[str] | None:
+    """Parse the --tools value into an allowlist for init().
+
+    Mirrors the main `gptme` CLI semantics:
+    - ``None`` (flag not passed) -> ``None`` ("use default tools").
+    - ``"none"`` -> ``[]`` (disable all tools). Cannot be combined with
+      other tool names.
+    - otherwise -> the comma-separated list of tool names.
+    """
+    if tools is None:
+        return None
+    names = [t.strip() for t in tools.split(",") if t.strip()]
+    if any(t.lower() == "none" for t in names):
+        non_none = [t for t in names if t.lower() != "none"]
+        if non_none:
+            raise click.UsageError(
+                f"Cannot combine 'none' with other tools: {', '.join(non_none)}"
+            )
+        return []
+    return names
+
+
 def _pid_alive(pid: int) -> bool:
     """Check if a PID is still alive on this host.
 
@@ -213,7 +235,7 @@ def serve(
         init(
             model,
             interactive=False,
-            tool_allowlist=None if tools is None else tools.split(","),
+            tool_allowlist=_parse_tools_allowlist(tools),
             tool_format="markdown",
             server=True,
         )
@@ -242,7 +264,7 @@ def serve(
         init(
             fallback_model,
             interactive=False,
-            tool_allowlist=None if tools is None else tools.split(","),
+            tool_allowlist=_parse_tools_allowlist(tools),
             tool_format="markdown",
             server=True,
             require_llm=False,

--- a/tests/test_server_cli_tools.py
+++ b/tests/test_server_cli_tools.py
@@ -1,0 +1,35 @@
+"""Tests for gptme-server --tools parsing (parity with the main CLI's `none`)."""
+
+import pytest
+
+pytest.importorskip(
+    "flask", reason="flask not installed, install server extras (-E server)"
+)
+
+from gptme.server.cli import _parse_tools_allowlist
+
+
+def test_none_flag_returns_none():
+    # Flag not passed -> use default tools.
+    assert _parse_tools_allowlist(None) is None
+
+
+def test_tools_none_disables_all_tools():
+    # `--tools none` must disable all tools, like the main `gptme` CLI,
+    # instead of crashing with "Tool 'none' not found".
+    assert _parse_tools_allowlist("none") == []
+    assert _parse_tools_allowlist("NONE") == []
+    assert _parse_tools_allowlist(" none ") == []
+
+
+def test_regular_tool_list_is_split_and_stripped():
+    assert _parse_tools_allowlist("read,shell") == ["read", "shell"]
+    assert _parse_tools_allowlist(" read , shell ") == ["read", "shell"]
+    assert _parse_tools_allowlist("read,,shell,") == ["read", "shell"]
+
+
+def test_none_cannot_be_combined_with_other_tools():
+    import click
+
+    with pytest.raises(click.UsageError):
+        _parse_tools_allowlist("read,none")


### PR DESCRIPTION
Found while dogfooding the gptme server CLI (durable work-supply sweep, ErikBjare/bob#745).

## Problem

The main `gptme` CLI special-cases `--tools none` to disable all tools, but `gptme-server serve --tools none` did a naive `tools.split(",")` and passed `["none"]` straight to `init()`, crashing on startup:

```
ValueError: Tool 'none' not found. Available tools: append, autocommit, ...
```

So the natural "start a server with no tools enabled" invocation (which works for the main CLI) crashes the server.

## Fix

Add a `_parse_tools_allowlist()` helper in `gptme/server/cli.py` that mirrors the main CLI semantics:

- flag not passed → `None` (use default tools)
- `--tools none` → `[]` (disable all tools)
- `none` combined with other tools → `click.UsageError`
- otherwise → stripped, comma-split list

Used at both `init()` call sites in `serve()` (primary + fallback-model path).

## Verification

- New unit tests in `tests/test_server_cli_tools.py` (none handling, case-insensitivity, whitespace, combine-rejection).
- End-to-end: patched `gptme-server serve --tools none` now starts cleanly (health 200) instead of crashing.