### PR TITLE
feat(cli): add `gptme-util snapshot list` subcommand

### DIFF
--- a/gptme/cli/cmd_snapshot.py
+++ b/gptme/cli/cmd_snapshot.py
@@ -1,0 +1,67 @@
+"""CLI commands for workspace snapshot management (``gptme-util snapshot``)."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import click
+
+
+@click.group()
+def snapshot():
+    """Commands for managing workspace snapshots."""
+
+
+@snapshot.command("list")
+@click.option(
+    "-n",
+    "--limit",
+    default=20,
+    type=click.IntRange(min=1),
+    help="Maximum number of snapshots to show.",
+)
+@click.option(
+    "--json",
+    "output_json",
+    is_flag=True,
+    help="Output as JSON array.",
+)
+@click.option(
+    "--workspace",
+    "-w",
+    default=None,
+    type=click.Path(exists=True, file_okay=False),
+    help="Workspace directory (defaults to current directory).",
+)
+def list_cmd(limit: int, output_json: bool, workspace: str | None) -> None:
+    """List workspace snapshots, newest first.
+
+    Reads snapshots from the shadow git repo for the given workspace.
+    Prints a table with SHA, timestamp, message count, and label.
+    """
+    from ..workspace_snapshot import Shadow, list_snapshots_rich
+
+    ws = Path(workspace) if workspace else Path.cwd()
+    shadow = Shadow.for_workspace(ws)
+    entries = list_snapshots_rich(shadow, limit=limit)
+
+    if output_json:
+        click.echo(json.dumps(entries, indent=2))
+        return
+
+    if not entries:
+        return
+
+    click.echo(f"{'SHA':<9}  {'Date':<16}  {'Msgs':>4}  Label")
+    click.echo("-" * 58)
+    for e in entries:
+        ts = e["timestamp"]
+        dt = (
+            datetime.fromtimestamp(ts, tz=timezone.utc).strftime("%Y-%m-%d %H:%M")
+            if ts
+            else "—" * 16
+        )
+        msgs = str(e["n_msgs"]) if e["n_msgs"] is not None else "—"
+        click.echo(f"{e['sha']:<9}  {dt:<16}  {msgs:>4}  {e['label']}")

--- a/gptme/cli/cmd_snapshot.py
+++ b/gptme/cli/cmd_snapshot.py
@@ -60,7 +60,7 @@ def list_cmd(limit: int, output_json: bool, workspace: str | None) -> None:
         ts = e["timestamp"]
         dt = (
             datetime.fromtimestamp(ts, tz=timezone.utc).strftime("%Y-%m-%d %H:%M")
-            if ts
+            if ts is not None
             else "—" * 16
         )
         msgs = str(e["n_msgs"]) if e["n_msgs"] is not None else "—"

--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -314,6 +314,7 @@ Utilities (gptme-util):
   gptme-util chats send ID MSG Queue a prompt for a running chat from another terminal
   gptme-util chats rename     Rename a conversation
   gptme-util models list      List available models
+  gptme-util snapshot list    List workspace snapshots outside a session
   gptme-util context index    Index project files for RAG
   gptme-util llm generate     Direct LLM generation without chat
 

--- a/gptme/cli/util.py
+++ b/gptme/cli/util.py
@@ -8,6 +8,7 @@ Command groups are split into separate modules for maintainability:
 - cmd_mcp.py: MCP server management (list, test, info, search)
 - cmd_batch.py: Batch runner for stdin prompts as fresh non-interactive sessions
 - cmd_skills.py: Skills and lessons (list, show, search, install, validate, etc.)
+- cmd_snapshot.py: Workspace snapshot management (list snapshots outside a session)
 
 Inline command groups (smaller, live in this file):
 - context: RAG index/retrieve plus workspace/git/journal context generation
@@ -49,6 +50,7 @@ _LAZY_COMMANDS: dict[str, tuple[str, str]] = {
     "hooks": (".cmd_hooks", "hooks"),
     "mcp": (".cmd_mcp", "mcp"),
     "skills": (".cmd_skills", "skills"),
+    "snapshot": (".cmd_snapshot", "snapshot"),
     "status": (".cmd_status", "status"),
 }
 

--- a/gptme/workspace_snapshot.py
+++ b/gptme/workspace_snapshot.py
@@ -225,6 +225,54 @@ def list_snapshots(shadow: Shadow, limit: int = 20) -> list[tuple[str, str]]:
     return out
 
 
+def list_snapshots_rich(shadow: Shadow, limit: int = 20) -> list[dict]:
+    """Return rich snapshot metadata for CLI display.
+
+    Each entry has: ``sha``, ``label``, ``timestamp`` (unix int), ``n_msgs`` (int|None).
+    Entries are ordered newest first.
+    """
+    if not shadow.initialized():
+        return []
+    # Use ASCII unit-separator (0x1f) to delimit fields and record-separator
+    # (0x1e) to delimit entries, so labels with tabs/newlines are safe.
+    # Use %B (full raw body) rather than %s so the first line is the clean
+    # label, unaffected by git joining lines when there's no blank-line separator.
+    result = shadow.run(
+        "log",
+        "--pretty=format:%h\x1f%ct\x1f%B\x1e",
+        "--no-decorate",
+        f"-{limit}",
+        check=False,
+    )
+    if result.returncode != 0 or not result.stdout:
+        return []
+    out: list[dict] = []
+    for record in result.stdout.split("\x1e"):
+        record = record.strip()
+        if not record:
+            continue
+        parts = record.split("\x1f", 2)
+        if len(parts) < 3:
+            continue
+        sha = parts[0].strip()
+        try:
+            ts = int(parts[1].strip())
+        except ValueError:
+            ts = 0
+        lines = parts[2].splitlines()
+        label = lines[0].strip() if lines else ""
+        n_msgs: int | None = None
+        for line in lines[1:]:
+            if line.startswith("n_msgs="):
+                try:
+                    n_msgs = int(line.split("=", 1)[1].strip())
+                except ValueError:
+                    pass
+                break
+        out.append({"sha": sha, "label": label, "timestamp": ts, "n_msgs": n_msgs})
+    return out
+
+
 def _git_date_env(timestamp: int) -> dict[str, str]:
     git_date = f"{timestamp} +0000"
     return {

--- a/gptme/workspace_snapshot.py
+++ b/gptme/workspace_snapshot.py
@@ -239,7 +239,7 @@ def list_snapshots_rich(shadow: Shadow, limit: int = 20) -> list[dict]:
     # label, unaffected by git joining lines when there's no blank-line separator.
     result = shadow.run(
         "log",
-        "--pretty=format:%h\x1f%ct\x1f%B\x1e",
+        "--pretty=format:%h%x1f%ct%x1f%B%x1e",
         "--no-decorate",
         f"-{limit}",
         check=False,
@@ -256,9 +256,9 @@ def list_snapshots_rich(shadow: Shadow, limit: int = 20) -> list[dict]:
             continue
         sha = parts[0].strip()
         try:
-            ts = int(parts[1].strip())
+            ts: int | None = int(parts[1].strip())
         except ValueError:
-            ts = 0
+            ts = None
         lines = parts[2].splitlines()
         label = lines[0].strip() if lines else ""
         n_msgs: int | None = None

--- a/tests/test_snapshot_list.py
+++ b/tests/test_snapshot_list.py
@@ -1,0 +1,181 @@
+"""Tests for list_snapshots_rich and gptme-util snapshot list."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from click.testing import CliRunner
+
+from gptme.cli.util import main
+from gptme.workspace_snapshot import (
+    init_shadow,
+    list_snapshots_rich,
+    snapshot,
+)
+
+
+@pytest.fixture
+def isolated_state_dir(tmp_path, monkeypatch):
+    state = tmp_path / "state"
+    state.mkdir()
+    monkeypatch.setenv("XDG_STATE_HOME", str(state))
+    return state
+
+
+@pytest.fixture
+def workspace(tmp_path, isolated_state_dir):
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    (ws / "README.md").write_text("hello\n")
+    return ws
+
+
+# ── list_snapshots_rich unit tests ───────────────────────────────────────────
+
+
+def test_list_snapshots_rich_empty_on_uninitialised(workspace):
+    from gptme.workspace_snapshot import Shadow
+
+    shadow = Shadow.for_workspace(workspace)
+    assert list_snapshots_rich(shadow) == []
+
+
+def test_list_snapshots_rich_initial(workspace):
+    shadow = init_shadow(workspace)
+    entries = list_snapshots_rich(shadow)
+    assert len(entries) == 1
+    e = entries[0]
+    assert e["sha"]
+    assert e["label"] == "initial"
+    assert e["timestamp"] > 0
+    assert e["n_msgs"] is None
+
+
+def test_list_snapshots_rich_with_n_msgs(workspace):
+    shadow = init_shadow(workspace)
+    (workspace / "a.txt").write_text("v1\n")
+    snapshot(shadow, label="step1", n_msgs=5)
+
+    entries = list_snapshots_rich(shadow)
+    # newest first — step1 is at index 0
+    assert entries[0]["label"] == "step1"
+    assert entries[0]["n_msgs"] == 5
+
+
+def test_list_snapshots_rich_without_n_msgs(workspace):
+    shadow = init_shadow(workspace)
+    (workspace / "a.txt").write_text("v1\n")
+    snapshot(shadow, label="plain-label")
+
+    entries = list_snapshots_rich(shadow)
+    assert entries[0]["label"] == "plain-label"
+    assert entries[0]["n_msgs"] is None
+
+
+def test_list_snapshots_rich_limit(workspace):
+    shadow = init_shadow(workspace)
+    for i in range(5):
+        (workspace / f"f{i}.txt").write_text(f"{i}\n")
+        snapshot(shadow, label=f"snap{i}")
+
+    entries = list_snapshots_rich(shadow, limit=3)
+    assert len(entries) == 3
+    # newest first
+    assert entries[0]["label"] == "snap4"
+
+
+def test_list_snapshots_rich_multiple_newest_first(workspace):
+    shadow = init_shadow(workspace)
+    for i in range(3):
+        (workspace / f"f{i}.txt").write_text(f"{i}\n")
+        snapshot(shadow, label=f"s{i}")
+
+    entries = list_snapshots_rich(shadow, limit=100)
+    labels = [e["label"] for e in entries]
+    assert labels[0] == "s2"
+    assert labels[-1] == "initial"
+
+
+# ── CLI tests (gptme-util snapshot list) ─────────────────────────────────────
+
+
+def test_cli_list_empty_workspace_no_error(workspace, monkeypatch):
+    """No snapshots → empty output, exit 0."""
+    runner = CliRunner()
+    result = runner.invoke(main, ["snapshot", "list", "--workspace", str(workspace)])
+    assert result.exit_code == 0, result.output
+    assert result.output.strip() == ""
+
+
+def test_cli_list_shows_table(workspace):
+    shadow = init_shadow(workspace)
+    (workspace / "a.txt").write_text("x\n")
+    snapshot(shadow, label="my-snap", n_msgs=3)
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["snapshot", "list", "--workspace", str(workspace)])
+    assert result.exit_code == 0, result.output
+    assert "my-snap" in result.output
+    assert "SHA" in result.output
+
+
+def test_cli_list_json_empty_workspace(workspace, monkeypatch):
+    """--json with no snapshots → valid empty JSON array, exit 0."""
+    runner = CliRunner()
+    result = runner.invoke(
+        main, ["snapshot", "list", "--json", "--workspace", str(workspace)]
+    )
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert data == []
+
+
+def test_cli_list_json_with_snapshots(workspace):
+    shadow = init_shadow(workspace)
+    (workspace / "a.txt").write_text("x\n")
+    snapshot(shadow, label="s1", n_msgs=7)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main, ["snapshot", "list", "--json", "--workspace", str(workspace)]
+    )
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert isinstance(data, list)
+    assert any(e["label"] == "s1" for e in data)
+    s1 = next(e for e in data if e["label"] == "s1")
+    assert s1["n_msgs"] == 7
+    assert s1["timestamp"] > 0
+    assert s1["sha"]
+
+
+def test_cli_list_json_no_n_msgs(workspace):
+    shadow = init_shadow(workspace)
+    (workspace / "a.txt").write_text("x\n")
+    snapshot(shadow, label="bare")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main, ["snapshot", "list", "--json", "--workspace", str(workspace)]
+    )
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    bare = next(e for e in data if e["label"] == "bare")
+    assert bare["n_msgs"] is None
+
+
+def test_cli_list_limit(workspace):
+    shadow = init_shadow(workspace)
+    for i in range(4):
+        (workspace / f"f{i}.txt").write_text(f"{i}\n")
+        snapshot(shadow, label=f"snap{i}")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main, ["snapshot", "list", "--json", "-n", "2", "--workspace", str(workspace)]
+    )
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert len(data) == 2
+    assert data[0]["label"] == "snap3"


### PR DESCRIPTION
## Summary

Adds a `gptme-util snapshot list` CLI subcommand so agents (and users) can inspect workspace snapshot history without starting a full `gptme` session.

Before this PR, `/snapshot list` existed only as an in-session slash command. This PR promotes the listing surface to an external CLI tool, following the same pattern as `gptme-util chats`, `gptme-util models`, and `gptme-checkpoint list`.

## Usage

```
gptme-util snapshot list [--limit N] [--json] [--workspace PATH]
```

```
SHA        Date              Msgs  Label
----------------------------------------------------------
a1b2c3d    2026-06-17 02:15     5  auto:before-patch
9f8e7d6    2026-06-17 01:10    —   initial
```

With `--json`:
```json
[{"sha": "a1b2c3d", "label": "auto:before-patch", "timestamp": 1781663720, "n_msgs": 5}]
```

## Changes

- **`gptme/workspace_snapshot.py`**: add `list_snapshots_rich()` returning `{sha, label, timestamp, n_msgs}` dicts. Uses `%B` git log format so labels are clean even without the blank-line separator convention before the `n_msgs=` body trailer.
- **`gptme/cli/cmd_snapshot.py`**: new Click group with `list` subcommand
- **`gptme/cli/util.py`**: register `snapshot` under the lazy-dispatch table
- **`gptme/cli/main.py`**: add `gptme-util snapshot list` to the help text
- **`tests/test_snapshot_list.py`**: 12 tests (unit + CLI with CliRunner) — all pass

## Test plan

- [x] `pytest tests/test_snapshot_list.py -v` — all 12 tests pass
- [x] `make typecheck` — clean
- [x] `gptme-util snapshot list --help` renders correctly
- [x] Empty workspace (no snapshots) exits 0 with no output