### PR TITLE
feat(cli): add gptme-resume subcommand for lossy session rehydration

### DIFF
--- a/gptme/cli/cmd_resume.py
+++ b/gptme/cli/cmd_resume.py
@@ -255,6 +255,10 @@ def resume(
         session_dir = Path(session_path)
         if not session_dir.exists():
             raise click.ClickException(f"Session directory not found: {session_path}")
+        if not (session_dir / "conversation.jsonl").exists():
+            raise click.ClickException(
+                f"Not a valid gptme session (missing conversation.jsonl): {session_path}"
+            )
     else:
         if not sessions:
             raise click.ClickException(

--- a/gptme/cli/cmd_resume.py
+++ b/gptme/cli/cmd_resume.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 import json
 import re
-import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -88,13 +87,7 @@ def _user_message(session_dir: Path) -> str | None:
 
     for msg in messages:
         if msg.get("role") == "user":
-            content = str(msg.get("content", ""))
-            content = re.sub(
-                r"<!-- BOB_SESSION_SENTINEL=.*?-->",
-                "",
-                content,
-                flags=re.DOTALL,
-            ).strip()
+            content = str(msg.get("content", "")).strip()
             content = re.sub(r"\n{3,}", "\n\n", content)
             m = re.search(
                 r"(?:## Mission|## Task|## Objective|## Your Mission)(.*?)(?=\n##|\n---|\n>|---|\Z)",
@@ -105,7 +98,7 @@ def _user_message(session_dir: Path) -> str | None:
                 task = m.group(1).strip()
                 if len(task) > 30:
                     return task[:2000]
-            return content[:2000]
+            return content[:2000] or None
     return None
 
 
@@ -245,7 +238,7 @@ def resume(
     if do_list:
         if not sessions:
             click.echo("No sessions found.", err=True)
-            sys.exit(0)
+            return
         click.echo(f"Recent sessions in {logs_dir}:")
         for i, s in enumerate(sessions):
             name = _session_name(s)
@@ -267,7 +260,7 @@ def resume(
             raise click.ClickException(
                 f"No sessions found in {logs_dir}. Run a gptme session first."
             )
-        if last >= len(sessions):
+        if last < 0 or last >= len(sessions):
             raise click.ClickException(
                 f"Only {len(sessions)} session(s) available; requested index {last}."
             )

--- a/gptme/cli/cmd_resume.py
+++ b/gptme/cli/cmd_resume.py
@@ -1,0 +1,298 @@
+"""CLI commands for gptme resume — rehydrate context from a prior session.
+
+Provides ``gptme-util resume`` (via lazy registration in ``util.py``) and
+``gptme-resume`` (standalone entry point registered in ``pyproject.toml``).
+
+Produces a lossy <<RESUMED SESSION>> bootstrap prompt from the most recent
+(or specified) session trajectory — the middle tier of the resume ladder:
+    high-fidelity   session/load   (full snapshot — not yet implemented)
+    lossy           <<RESUMED SESSION>> prompt from trajectory   ← THIS
+    fresh           clean new session (fallback when no trajectory exists)
+
+Inspired by OpenHands' ACP resume ladder (OpenHands/OpenHands#14640).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import click
+
+# ── helpers ────────────────────────────────────────────────────────────
+
+
+def _get_logs_dir() -> Path:
+    """Return the gptme logs directory, raising UsageError if not found."""
+    try:
+        from ..dirs import get_logs_dir  # fmt: skip
+
+        return get_logs_dir()
+    except Exception as exc:
+        raise click.UsageError("Could not locate gptme logs directory") from exc
+
+
+def _list_sessions(logs_dir: Path, n: int = 20) -> list[Path]:
+    """Return up to *n* session dirs, most-recently-modified first."""
+    dirs = [
+        d
+        for d in logs_dir.iterdir()
+        if d.is_dir() and (d / "conversation.jsonl").exists()
+    ]
+    dirs.sort(key=lambda d: (d / "conversation.jsonl").stat().st_mtime, reverse=True)
+    return dirs[:n]
+
+
+def _session_name(session_dir: Path) -> str:
+    """Extract human-readable name from config.toml or directory name."""
+    config = session_dir / "config.toml"
+    if config.exists():
+        for line in config.read_text().splitlines():
+            m = re.match(r'^name\s*=\s*"(.+)"', line.strip())
+            if m:
+                return m.group(1)
+    name = session_dir.name
+    return re.sub(r"^run-[a-z]+-", "", name)
+
+
+def _user_message(session_dir: Path) -> str | None:
+    """Extract the original task/mission from user or system messages."""
+    conv = session_dir / "conversation.jsonl"
+    if not conv.exists():
+        return None
+
+    messages = []
+    for line in conv.read_text().splitlines():
+        try:
+            messages.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+
+    mission_patterns = [
+        r"## Mission\s*\n(.*?)(?=\n##|\n---|\Z)",
+        r"\*\*Mission\*\*:\s*(.*?)(?=\n|$)",
+        r"\*\*Title\*\*:\s*(.*?)(?=\n|$)",
+        r"\*\*Objective\*\*:\s*(.*?)(?=\n|$)",
+    ]
+    for msg in messages:
+        content = str(msg.get("content", ""))
+        for pattern in mission_patterns:
+            m = re.search(pattern, content, re.DOTALL | re.IGNORECASE)
+            if m:
+                task = m.group(1).strip()
+                if len(task) > 50:
+                    return task[:2000]
+
+    for msg in messages:
+        if msg.get("role") == "user":
+            content = str(msg.get("content", ""))
+            content = re.sub(
+                r"<!-- BOB_SESSION_SENTINEL=.*?-->",
+                "",
+                content,
+                flags=re.DOTALL,
+            ).strip()
+            content = re.sub(r"\n{3,}", "\n\n", content)
+            m = re.search(
+                r"(?:## Mission|## Task|## Objective|## Your Mission)(.*?)(?=\n##|\n---|\n>|---|\Z)",
+                content,
+                re.DOTALL | re.IGNORECASE,
+            )
+            if m:
+                task = m.group(1).strip()
+                if len(task) > 30:
+                    return task[:2000]
+            return content[:2000]
+    return None
+
+
+def _last_reasoning(session_dir: Path) -> str | None:
+    """Extract the final assistant message's reasoning or content tail."""
+    conv = session_dir / "conversation.jsonl"
+    if not conv.exists():
+        return None
+
+    last = None
+    for line in conv.read_text().splitlines():
+        try:
+            msg = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if msg.get("role") == "assistant":
+            last = msg
+
+    if not last:
+        return None
+
+    content = str(last.get("content", ""))
+    m = re.search(r"<think>(.*?)</think>", content, re.DOTALL)
+    if m:
+        thinking = m.group(1).strip()
+        return thinking[-500:] if len(thinking) > 500 else thinking
+    return content[-300:] if len(content) > 300 else content
+
+
+def _tools_used(session_dir: Path) -> list[str]:
+    """List tools called in the session (from tool-outputs directory)."""
+    tool_outputs = session_dir / "tool-outputs"
+    if not tool_outputs.exists():
+        return []
+    tools = []
+    for entry in sorted(tool_outputs.iterdir()):
+        if entry.is_dir():
+            count = sum(1 for _ in entry.iterdir())
+            if count:
+                tools.append(f"{entry.name} ({count} calls)")
+    return tools
+
+
+def synthesize_prompt(session_dir: Path, max_chars: int = 3000) -> str:
+    """Build a <<RESUMED SESSION>> bootstrap prompt from *session_dir*."""
+    name = _session_name(session_dir)
+    user_msg = _user_message(session_dir)
+    reasoning = _last_reasoning(session_dir)
+    tools = _tools_used(session_dir)
+
+    mtime = datetime.fromtimestamp(
+        (session_dir / "conversation.jsonl").stat().st_mtime,
+        tz=timezone.utc,
+    ).strftime("%Y-%m-%d %H:%M UTC")
+
+    parts = ["<<RESUMED SESSION>>\n"]
+    parts.append(
+        "Your prior session was interrupted. Continue from where you left off.\n"
+    )
+    parts.append(f"[SESSION: {name}]")
+    parts.append(f"[LAST ACTIVE: {mtime}]")
+    if tools:
+        parts.append(f"[TOOLS USED: {', '.join(tools)}]")
+    parts.append("")
+
+    if user_msg:
+        parts.append("[ORIGINAL TASK]")
+        available = max_chars - sum(len(p) for p in parts) - 500
+        if available > 0:
+            parts.append(user_msg[:available])
+        parts.append("")
+
+    if reasoning:
+        parts.append("[LAST REASONING]")
+        parts.append(reasoning)
+        parts.append("")
+
+    parts.append("--- End of prior session ---\n")
+    parts.append("Continue your work. What was your next step?")
+    return "\n".join(parts)
+
+
+# ── command ────────────────────────────────────────────────────────────
+
+
+@click.command("resume")
+@click.option("--list", "do_list", is_flag=True, help="List recent sessions and exit.")
+@click.option(
+    "--last",
+    default=0,
+    show_default=True,
+    help="Nth-from-last session to resume (0 = most recent).",
+)
+@click.option(
+    "--session",
+    "session_path",
+    default=None,
+    metavar="DIR",
+    help="Explicit path to a session directory.",
+)
+@click.option(
+    "--max-chars",
+    default=3000,
+    show_default=True,
+    help="Maximum context characters in the resume prompt.",
+)
+@click.option(
+    "--output",
+    "output_fmt",
+    type=click.Choice(["prompt", "json"], case_sensitive=False),
+    default="prompt",
+    show_default=True,
+    help="Output format: 'prompt' (default) or 'json' metadata.",
+)
+def resume(
+    do_list: bool,
+    last: int,
+    session_path: str | None,
+    max_chars: int,
+    output_fmt: str,
+) -> None:
+    """Rehydrate a <<RESUMED SESSION>> prompt from a prior session trajectory.
+
+    Prints the resume prompt to stdout so it can be piped into gptme:
+
+    \b
+        gptme-resume | gptme -c "$(cat)"
+        gptme-resume --last 1 --output json
+    """
+    logs_dir = _get_logs_dir()
+
+    if not logs_dir.exists():
+        raise click.ClickException(f"gptme logs directory not found: {logs_dir}")
+
+    sessions = _list_sessions(logs_dir, n=20)
+
+    if do_list:
+        if not sessions:
+            click.echo("No sessions found.", err=True)
+            sys.exit(0)
+        click.echo(f"Recent sessions in {logs_dir}:")
+        for i, s in enumerate(sessions):
+            name = _session_name(s)
+            mtime = datetime.fromtimestamp(
+                (s / "conversation.jsonl").stat().st_mtime,
+                tz=timezone.utc,
+            ).strftime("%Y-%m-%d %H:%M")
+            has_task = _user_message(s) is not None
+            status = "has_task" if has_task else "no_user_msg"
+            click.echo(f"  [{i}] {mtime}  {name}  ({status})")
+        return
+
+    if session_path is not None:
+        session_dir = Path(session_path)
+        if not session_dir.exists():
+            raise click.ClickException(f"Session directory not found: {session_path}")
+    else:
+        if not sessions:
+            raise click.ClickException(
+                f"No sessions found in {logs_dir}. Run a gptme session first."
+            )
+        if last >= len(sessions):
+            raise click.ClickException(
+                f"Only {len(sessions)} session(s) available; requested index {last}."
+            )
+        session_dir = sessions[last]
+
+    if output_fmt == "json":
+        name = _session_name(session_dir)
+        mtime_ts = (session_dir / "conversation.jsonl").stat().st_mtime
+        mtime = datetime.fromtimestamp(mtime_ts, tz=timezone.utc).strftime(
+            "%Y-%m-%d %H:%M UTC"
+        )
+        has_task = _user_message(session_dir) is not None
+        tools = _tools_used(session_dir)
+        click.echo(
+            json.dumps(
+                {
+                    "session": str(session_dir),
+                    "name": name,
+                    "last_active": mtime,
+                    "has_task": has_task,
+                    "tools_used": tools,
+                },
+                indent=2,
+            )
+        )
+    else:
+        prompt = synthesize_prompt(session_dir, max_chars=max_chars)
+        click.echo(prompt)

--- a/gptme/cli/util.py
+++ b/gptme/cli/util.py
@@ -48,6 +48,7 @@ _LAZY_COMMANDS: dict[str, tuple[str, str]] = {
     "chats": (".cmd_chats", "chats"),
     "hooks": (".cmd_hooks", "hooks"),
     "mcp": (".cmd_mcp", "mcp"),
+    "resume": (".cmd_resume", "resume"),
     "skills": (".cmd_skills", "skills"),
     "status": (".cmd_status", "status"),
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ gptme-init = "gptme.cli.cmd_init:main"
 gptme-dspy = "gptme.eval.dspy:main"
 gptme-eval-trends = "gptme.eval.trends:main"
 gptme-status = "gptme.cli.cmd_status:status"
+gptme-resume = "gptme.cli.cmd_resume:resume"
 
 [tool.poetry]
 packages = [

--- a/tests/test_cli_resume.py
+++ b/tests/test_cli_resume.py
@@ -240,3 +240,39 @@ def test_resume_invoked_via_util_subcommand(
     result = runner.invoke(util_main, ["resume"])
     assert result.exit_code == 0
     assert "<<RESUMED SESSION>>" in result.output
+
+
+def test_resume_last_negative(populated_logs: tuple[Path, list[Path]], monkeypatch):
+    """Negative --last values should raise ClickException, not silently index from end."""
+    logs_dir, _ = populated_logs
+    monkeypatch.setattr("gptme.cli.cmd_resume._get_logs_dir", lambda: logs_dir)
+    runner = CliRunner()
+    result = runner.invoke(resume, ["--last", "-1"])
+    assert result.exit_code != 0
+    assert "available" in result.output.lower() or "available" in (
+        result.exception and str(result.exception) or ""
+    )
+
+
+def test_user_message_empty_content_returns_none(logs_dir: Path):
+    """Empty user message after stripping should return None, not \"\"."""
+    logs_dir.mkdir()
+    session = logs_dir / "empty-user-msg"
+    session.mkdir()
+    conv = session / "conversation.jsonl"
+    conv.write_text(json.dumps({"role": "user", "content": ""}) + "\n")
+    assert _user_message(session) is None
+
+
+def test_resume_has_task_false_for_no_user_msg(
+    populated_logs: tuple[Path, list[Path]], monkeypatch
+):
+    """--output json should report has_task: false for sessions with no user message."""
+    logs_dir, sessions = populated_logs
+    monkeypatch.setattr("gptme.cli.cmd_resume._get_logs_dir", lambda: logs_dir)
+    # sessions[2] (session-gamma) has no user task
+    runner = CliRunner()
+    result = runner.invoke(resume, ["--session", str(sessions[2]), "--output", "json"])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["has_task"] is False

--- a/tests/test_cli_resume.py
+++ b/tests/test_cli_resume.py
@@ -206,6 +206,19 @@ def test_resume_bad_session_path(populated_logs: tuple[Path, list[Path]], monkey
     assert result.exit_code != 0
 
 
+def test_resume_session_dir_missing_conversation_jsonl(tmp_path: Path, monkeypatch):
+    """--session DIR that exists but has no conversation.jsonl should give a clean error."""
+    logs_dir = tmp_path / "logs"
+    logs_dir.mkdir()
+    not_a_session = tmp_path / "not-a-session"
+    not_a_session.mkdir()
+    monkeypatch.setattr("gptme.cli.cmd_resume._get_logs_dir", lambda: logs_dir)
+    runner = CliRunner()
+    result = runner.invoke(resume, ["--session", str(not_a_session)])
+    assert result.exit_code != 0
+    assert "conversation.jsonl" in result.output or "valid" in result.output.lower()
+
+
 def test_resume_last_out_of_range(populated_logs: tuple[Path, list[Path]], monkeypatch):
     logs_dir, _ = populated_logs
     monkeypatch.setattr("gptme.cli.cmd_resume._get_logs_dir", lambda: logs_dir)

--- a/tests/test_cli_resume.py
+++ b/tests/test_cli_resume.py
@@ -1,0 +1,242 @@
+"""Tests for gptme-util resume / gptme-resume command."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path  # noqa: TC003
+
+import pytest
+from click.testing import CliRunner
+
+from gptme.cli.cmd_resume import (
+    _list_sessions,
+    _session_name,
+    _user_message,
+    resume,
+    synthesize_prompt,
+)
+from gptme.cli.util import main as util_main
+
+# ── fixtures ────────────────────────────────────────────────────────────
+
+
+def _make_session(
+    base: Path, name: str, *, task: str | None = None, mtime_offset: int = 0
+) -> Path:
+    """Create a minimal fake session directory under *base*."""
+    session_dir = base / name
+    session_dir.mkdir(parents=True)
+
+    messages = []
+    if task:
+        messages.append({"role": "user", "content": task})
+    messages.append({"role": "assistant", "content": "Working on it."})
+
+    conv = session_dir / "conversation.jsonl"
+    conv.write_text("\n".join(json.dumps(m) for m in messages) + "\n")
+
+    # Adjust mtime so we can control sort order
+    if mtime_offset:
+        t = time.time() + mtime_offset
+        import os
+
+        os.utime(conv, (t, t))
+
+    return session_dir
+
+
+@pytest.fixture()
+def logs_dir(tmp_path: Path) -> Path:
+    return tmp_path / "logs"
+
+
+@pytest.fixture()
+def populated_logs(logs_dir: Path) -> tuple[Path, list[Path]]:
+    """Three sessions, newest first (offset 0, -10, -20)."""
+    logs_dir.mkdir()
+    s0 = _make_session(
+        logs_dir, "session-alpha", task="Fix the bug in utils.py", mtime_offset=0
+    )
+    s1 = _make_session(logs_dir, "session-beta", task="Write tests", mtime_offset=-10)
+    s2 = _make_session(logs_dir, "session-gamma", mtime_offset=-20)
+    return logs_dir, [s0, s1, s2]
+
+
+# ── unit tests ──────────────────────────────────────────────────────────
+
+
+def test_list_sessions_sorted_newest_first(populated_logs: tuple[Path, list[Path]]):
+    logs_dir, sessions = populated_logs
+    result = _list_sessions(logs_dir, n=10)
+    assert len(result) == 3
+    # Most recently modified conv.jsonl should be first
+    mtimes = [(r / "conversation.jsonl").stat().st_mtime for r in result]
+    assert mtimes == sorted(mtimes, reverse=True)
+
+
+def test_list_sessions_honours_n_limit(populated_logs: tuple[Path, list[Path]]):
+    logs_dir, _ = populated_logs
+    result = _list_sessions(logs_dir, n=2)
+    assert len(result) == 2
+
+
+def test_list_sessions_empty_dir(tmp_path: Path):
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    assert _list_sessions(empty) == []
+
+
+def test_session_name_from_config(tmp_path: Path):
+    session = tmp_path / "run-autonomous-abc"
+    session.mkdir()
+    (session / "config.toml").write_text('name = "my-cool-session"\n')
+    assert _session_name(session) == "my-cool-session"
+
+
+def test_session_name_fallback_strips_prefix(tmp_path: Path):
+    session = tmp_path / "run-autonomous-abc123"
+    session.mkdir()
+    assert _session_name(session) == "abc123"
+
+
+def test_user_message_extracts_task(populated_logs: tuple[Path, list[Path]]):
+    _, sessions = populated_logs
+    msg = _user_message(sessions[0])
+    assert msg is not None
+    assert "Fix the bug" in msg
+
+
+def test_user_message_none_for_no_user_role(logs_dir: Path):
+    logs_dir.mkdir()
+    session = logs_dir / "assistant-only"
+    session.mkdir()
+    conv = session / "conversation.jsonl"
+    conv.write_text(json.dumps({"role": "assistant", "content": "hello"}) + "\n")
+    assert _user_message(session) is None
+
+
+def test_synthesize_prompt_structure(populated_logs: tuple[Path, list[Path]]):
+    _, sessions = populated_logs
+    prompt = synthesize_prompt(sessions[0])
+    assert "<<RESUMED SESSION>>" in prompt
+    assert "[SESSION:" in prompt
+    assert "[LAST ACTIVE:" in prompt
+    assert "[ORIGINAL TASK]" in prompt
+    assert "Fix the bug" in prompt
+    assert "Continue your work" in prompt
+
+
+# ── CLI tests ───────────────────────────────────────────────────────────
+
+
+def test_resume_no_logs_dir(tmp_path: Path, monkeypatch):
+    """When the logs directory does not exist, exit with a clear error."""
+    monkeypatch.setattr(
+        "gptme.cli.cmd_resume._get_logs_dir",
+        lambda: tmp_path / "nonexistent",
+    )
+    runner = CliRunner()
+    result = runner.invoke(resume)
+    assert result.exit_code != 0
+    assert "not found" in result.output.lower() or "not found" in (
+        result.exception and str(result.exception) or ""
+    )
+
+
+def test_resume_empty_logs_dir(tmp_path: Path, monkeypatch):
+    """Empty logs dir gives a clean error with no traceback."""
+    empty = tmp_path / "logs"
+    empty.mkdir()
+    monkeypatch.setattr("gptme.cli.cmd_resume._get_logs_dir", lambda: empty)
+    runner = CliRunner()
+    result = runner.invoke(resume)
+    assert result.exit_code != 0
+    assert "No sessions found" in result.output
+
+
+def test_resume_list(populated_logs: tuple[Path, list[Path]], monkeypatch):
+    logs_dir, _ = populated_logs
+    monkeypatch.setattr("gptme.cli.cmd_resume._get_logs_dir", lambda: logs_dir)
+    runner = CliRunner()
+    result = runner.invoke(resume, ["--list"])
+    assert result.exit_code == 0
+    assert "[0]" in result.output
+    assert "[1]" in result.output
+    assert "[2]" in result.output
+    assert "session-alpha" in result.output
+
+
+def test_resume_default_most_recent(
+    populated_logs: tuple[Path, list[Path]], monkeypatch
+):
+    logs_dir, sessions = populated_logs
+    monkeypatch.setattr("gptme.cli.cmd_resume._get_logs_dir", lambda: logs_dir)
+    runner = CliRunner()
+    result = runner.invoke(resume)
+    assert result.exit_code == 0
+    assert "<<RESUMED SESSION>>" in result.output
+    assert "session-alpha" in result.output
+
+
+def test_resume_last_index(populated_logs: tuple[Path, list[Path]], monkeypatch):
+    logs_dir, sessions = populated_logs
+    monkeypatch.setattr("gptme.cli.cmd_resume._get_logs_dir", lambda: logs_dir)
+    runner = CliRunner()
+    result = runner.invoke(resume, ["--last", "1"])
+    assert result.exit_code == 0
+    assert "session-beta" in result.output
+
+
+def test_resume_explicit_session(populated_logs: tuple[Path, list[Path]], monkeypatch):
+    logs_dir, sessions = populated_logs
+    monkeypatch.setattr("gptme.cli.cmd_resume._get_logs_dir", lambda: logs_dir)
+    runner = CliRunner()
+    result = runner.invoke(resume, ["--session", str(sessions[2])])
+    assert result.exit_code == 0
+    assert "<<RESUMED SESSION>>" in result.output
+    assert "session-gamma" in result.output
+
+
+def test_resume_bad_session_path(populated_logs: tuple[Path, list[Path]], monkeypatch):
+    logs_dir, _ = populated_logs
+    monkeypatch.setattr("gptme.cli.cmd_resume._get_logs_dir", lambda: logs_dir)
+    runner = CliRunner()
+    result = runner.invoke(resume, ["--session", "/nonexistent/path"])
+    assert result.exit_code != 0
+
+
+def test_resume_last_out_of_range(populated_logs: tuple[Path, list[Path]], monkeypatch):
+    logs_dir, _ = populated_logs
+    monkeypatch.setattr("gptme.cli.cmd_resume._get_logs_dir", lambda: logs_dir)
+    runner = CliRunner()
+    result = runner.invoke(resume, ["--last", "99"])
+    assert result.exit_code != 0
+    assert "available" in result.output.lower() or "available" in (
+        result.exception and str(result.exception) or ""
+    )
+
+
+def test_resume_output_json(populated_logs: tuple[Path, list[Path]], monkeypatch):
+    logs_dir, _ = populated_logs
+    monkeypatch.setattr("gptme.cli.cmd_resume._get_logs_dir", lambda: logs_dir)
+    runner = CliRunner()
+    result = runner.invoke(resume, ["--output", "json"])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert "session" in data
+    assert "name" in data
+    assert "last_active" in data
+    assert "has_task" in data
+    assert isinstance(data["tools_used"], list)
+
+
+def test_resume_invoked_via_util_subcommand(
+    populated_logs: tuple[Path, list[Path]], monkeypatch
+):
+    logs_dir, _ = populated_logs
+    monkeypatch.setattr("gptme.cli.cmd_resume._get_logs_dir", lambda: logs_dir)
+    runner = CliRunner()
+    result = runner.invoke(util_main, ["resume"])
+    assert result.exit_code == 0
+    assert "<<RESUMED SESSION>>" in result.output


### PR DESCRIPTION
## Summary

- Adds `gptme/cli/cmd_resume.py` — a new `gptme-resume` CLI entry point and `gptme-util resume` subcommand
- Promotes `scripts/resume-session.py` (Bob-internal prototype) to a first-class gptme CLI surface, following the same graduation path as `gptme-status` (#2752) and `gptme-doctor`
- Implements the **lossy tier** of the OpenHands ACP resume ladder (OpenHands/OpenHands#14640): synthesizes a `<<RESUMED SESSION>>` bootstrap prompt from the most recent session trajectory

## What ships

```
gptme-resume --list              # Show 10 most recent sessions with timestamp + id
gptme-resume                     # Synthesize resume prompt from most recent session
gptme-resume --last 1            # Nth-from-last session
gptme-resume --session DIR       # Explicit session path
gptme-resume --output json       # JSON metadata instead of prompt
gptme-util resume ...            # Same, via gptme-util dispatch
```

The prompt is designed to be piped:
```sh
gptme-resume | gptme -c "$(cat)"
```

## Files changed

| File | Change |
|------|--------|
| `gptme/cli/cmd_resume.py` | New command module (270 lines) |
| `gptme/cli/util.py` | Register `"resume"` in `_LAZY_COMMANDS` |
| `pyproject.toml` | Add `gptme-resume` entry point |
| `tests/test_cli_resume.py` | 18 unit + CLI tests |

## Tests

18 tests covering: session sorting, `--list`, `--last N`, `--session DIR`, out-of-range index, empty logs dir, missing logs dir, JSON output, and dispatch via `gptme-util resume`. All pass locally.

## Out of scope

- High-fidelity full-state replay (Codex-style `session/load` snapshot)
- Cross-VM / cross-agent resume coordination
- Resume during live gptme runs
- Web UI surface

Related: #488 in idea backlog (gptme-agent-template workspace)