### PR TITLE
perf(server): partial cache update on message POST to avoid O(N) rescan

### DIFF
--- a/gptme/logmanager/__init__.py
+++ b/gptme/logmanager/__init__.py
@@ -9,6 +9,7 @@ from .conversations import (
     ConversationMeta,
     delete_conversation,
     get_conversation_by_id,
+    get_conversation_meta_direct,
     get_conversations,
     get_user_conversations,
     list_conversations,
@@ -49,6 +50,7 @@ __all__ = [
     "get_user_conversations",
     "list_conversations",
     "get_conversation_by_id",
+    "get_conversation_meta_direct",
     "rename_conversation",
     "delete_conversation",
 ]

--- a/gptme/logmanager/conversations.py
+++ b/gptme/logmanager/conversations.py
@@ -292,6 +292,117 @@ def _full_scan(
     )
 
 
+def _meta_from_file(conv_fn: Path, *, detail: bool = True) -> ConversationMeta:
+    """Build ConversationMeta from a single conversation file path.
+
+    Reads only that one file — no glob scan over other conversations.
+    Used by get_conversations() and get_conversation_meta_direct().
+    """
+    conv_id = conv_fn.parent.name
+    log = Log.read_jsonl(conv_fn, limit=1)
+
+    conv_stat = conv_fn.stat()
+    file_size = conv_stat.st_size
+
+    if detail or file_size <= _TAIL_BYTES:
+        # Full scan: exact counts + cost/token aggregation
+        (
+            len_msgs,
+            conv_model,
+            conv_cost,
+            conv_input_tokens,
+            conv_output_tokens,
+            conv_cache_read_tokens,
+            last_msg_line,
+        ) = _full_scan(conv_fn)
+    else:
+        # Fast scan: tail-only for preview + model, fast line count
+        len_msgs, conv_model, last_msg_line = _fast_scan_tail(conv_fn, file_size)
+        conv_cost = 0.0
+        conv_input_tokens = 0
+        conv_output_tokens = 0
+        conv_cache_read_tokens = 0
+
+    last_msg_role, last_msg_preview = (
+        _parse_preview(last_msg_line) if last_msg_line else (None, None)
+    )
+
+    assert len(log) <= 1
+    modified = conv_stat.st_mtime
+    first_timestamp = log[0].timestamp.timestamp() if log else modified
+    # Try to get display name from ChatConfig, fallback to folder name
+    chat_config = ChatConfig.from_logdir(conv_fn.parent)
+    display_name = chat_config.name or conv_id
+
+    agent_path = chat_config.agent
+    agent_project_config = (
+        get_project_config(agent_path, quiet=True) if agent_path else None
+    )
+    agent_name = (
+        agent_project_config.agent.name
+        if agent_project_config and agent_project_config.agent
+        else None
+    )
+    agent_avatar = (
+        agent_project_config.agent.avatar
+        if agent_project_config and agent_project_config.agent
+        else None
+    )
+    agent_urls = (
+        agent_project_config.agent.urls
+        if agent_project_config and agent_project_config.agent
+        else None
+    )
+
+    # Count branches only when doing a full detail scan — the fast-scan
+    # path (used by the list/search endpoint) skips this per-directory
+    # glob since the webui list view doesn't display branch counts.
+    n_branches = 1 + len(list(conv_fn.parent.glob("branches/*.jsonl"))) if detail else 1
+    return ConversationMeta(
+        id=conv_id,
+        name=display_name,
+        path=str(conv_fn),
+        created=first_timestamp,
+        modified=modified,
+        messages=len_msgs,
+        branches=n_branches,
+        workspace=str(chat_config.workspace),
+        agent_name=agent_name,
+        agent_path=str(agent_path) if agent_path else None,
+        agent_avatar=agent_avatar,
+        agent_urls=agent_urls,
+        model=conv_model,
+        total_cost=conv_cost,
+        total_input_tokens=conv_input_tokens,
+        total_output_tokens=conv_output_tokens,
+        total_cache_read_tokens=conv_cache_read_tokens,
+        last_message_role=last_msg_role,
+        last_message_preview=last_msg_preview,
+    )
+
+
+def get_conversation_meta_direct(
+    conv_id: str,
+    *,
+    detail: bool = True,
+    logs_dir: Path | None = None,
+) -> ConversationMeta | None:
+    """Get a single conversation's metadata by direct path lookup.
+
+    Bypasses the full glob+stat scan used by get_conversations().  O(1) file
+    access instead of O(N_conversations) — suitable for partial cache updates
+    where only one conversation changed.
+
+    Returns None when the conversation directory or JSONL file does not exist.
+    """
+    if logs_dir is None:
+        logs_dir = get_logs_dir()
+    conv_fn = logs_dir / conv_id / "conversation.jsonl"
+    if not conv_fn.exists():
+        return None
+    return _meta_from_file(conv_fn, detail=detail)
+
+
 def get_conversations(
     *, detail: bool = True, include_test: bool = True
 ) -> Generator[ConversationMeta, None, None]:
@@ -310,89 +421,7 @@ def get_conversations(
         conv_id = conv_fn.parent.name
         if not include_test and _is_test_conversation_id(conv_id):
             continue
-
-        log = Log.read_jsonl(conv_fn, limit=1)
-
-        conv_stat = conv_fn.stat()
-        file_size = conv_stat.st_size
-
-        if detail or file_size <= _TAIL_BYTES:
-            # Full scan: exact counts + cost/token aggregation
-            (
-                len_msgs,
-                conv_model,
-                conv_cost,
-                conv_input_tokens,
-                conv_output_tokens,
-                conv_cache_read_tokens,
-                last_msg_line,
-            ) = _full_scan(conv_fn)
-        else:
-            # Fast scan: tail-only for preview + model, fast line count
-            len_msgs, conv_model, last_msg_line = _fast_scan_tail(conv_fn, file_size)
-            conv_cost = 0.0
-            conv_input_tokens = 0
-            conv_output_tokens = 0
-            conv_cache_read_tokens = 0
-
-        last_msg_role, last_msg_preview = (
-            _parse_preview(last_msg_line) if last_msg_line else (None, None)
-        )
-
-        assert len(log) <= 1
-        modified = conv_stat.st_mtime
-        first_timestamp = log[0].timestamp.timestamp() if log else modified
-        # Try to get display name from ChatConfig, fallback to folder name
-        chat_config = ChatConfig.from_logdir(conv_fn.parent)
-        display_name = chat_config.name or conv_id
-
-        agent_path = chat_config.agent
-        agent_project_config = (
-            get_project_config(agent_path, quiet=True) if agent_path else None
-        )
-        agent_name = (
-            agent_project_config.agent.name
-            if agent_project_config and agent_project_config.agent
-            else None
-        )
-        agent_avatar = (
-            agent_project_config.agent.avatar
-            if agent_project_config and agent_project_config.agent
-            else None
-        )
-        agent_urls = (
-            agent_project_config.agent.urls
-            if agent_project_config and agent_project_config.agent
-            else None
-        )
-
-        # Count branches only when doing a full detail scan — the fast-scan
-        # path (used by the list/search endpoint) skips this per-directory
-        # glob since the webui list view doesn't display branch counts.
-        n_branches = (
-            1 + len(list(conv_fn.parent.glob("branches/*.jsonl"))) if detail else 1
-        )
-        yield ConversationMeta(
-            id=conv_id,
-            name=display_name,
-            path=str(conv_fn),
-            created=first_timestamp,
-            modified=modified,
-            messages=len_msgs,
-            branches=n_branches,
-            workspace=str(chat_config.workspace),
-            agent_name=agent_name,
-            agent_path=str(agent_path) if agent_path else None,
-            agent_avatar=agent_avatar,
-            agent_urls=agent_urls,
-            model=conv_model,
-            total_cost=conv_cost,
-            total_input_tokens=conv_input_tokens,
-            total_output_tokens=conv_output_tokens,
-            total_cache_read_tokens=conv_cache_read_tokens,
-            last_message_role=last_msg_role,
-            last_message_preview=last_msg_preview,
-        )
+        yield _meta_from_file(conv_fn, detail=detail)
 
 
 def get_user_conversations(
@@ -430,8 +459,10 @@ def list_conversations(
 def get_conversation_by_id(
     conv_id: str, *, detail: bool = True
 ) -> ConversationMeta | None:
-    """
-    Get a conversation by its ID.
+    """Get a conversation by its ID.
+
+    Uses direct path lookup (O(1) file access) rather than scanning all
+    conversations.
 
     Args:
         conv_id: The conversation ID to find
@@ -439,10 +470,7 @@ def get_conversation_by_id(
     Returns:
         ConversationMeta if found, None otherwise
     """
-    for conv in get_conversations(detail=detail):
-        if conv.id == conv_id:
-            return conv
-    return None
+    return get_conversation_meta_direct(conv_id, detail=detail)
 
 
 def rename_conversation(conv_id: str, new_name: str) -> bool:

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -3156,6 +3156,11 @@ def _update_conversation_in_cache(conv_id: str) -> None:
         # stale entry is removed on the next list request.
         _invalidate_conversations_cache()
         return
+    if not any(c.id == conv_id for c in _conversations_cache):
+        # Entry not in cached list (e.g., concurrent external filesystem write).
+        # Fall back to full invalidation so the list gets rebuilt correctly.
+        _invalidate_conversations_cache()
+        return
     _conversations_cache = [
         updated if c.id == conv_id else c for c in _conversations_cache
     ]

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -63,7 +63,13 @@ from ..config.user import (
     get_user_config_runtime_info,
 )
 from ..dirs import get_logs_dir
-from ..logmanager import ConversationMeta, Log, LogManager, get_user_conversations
+from ..logmanager import (
+    ConversationMeta,
+    Log,
+    LogManager,
+    get_conversation_meta_direct,
+    get_user_conversations,
+)
 from ..logmanager import conversations as conversations_module
 from ..message import Message
 from ..tools import get_toolchain, get_tools, init_tools
@@ -1650,7 +1656,9 @@ def api_conversation_post(conversation_id: str):
         },
     )
 
-    _invalidate_conversations_cache()
+    # Partial cache update: only refresh this conversation's entry so the
+    # conversations-list endpoint can keep serving from cache during streaming.
+    _update_conversation_in_cache(conversation_id)
     return flask.jsonify({"status": "ok"})
 
 
@@ -3122,3 +3130,32 @@ def _invalidate_conversations_cache() -> None:
     _conversations_cache = None
     _conversations_cache_logs_dir = None
     _conversations_cache_time = 0.0
+
+
+def _update_conversation_in_cache(conv_id: str) -> None:
+    """Refresh one conversation in the list cache without a full rescan.
+
+    When a message is appended to an existing conversation, we only need to
+    update that conversation's entry (last_message_preview, messages count,
+    modified time). This avoids the O(N_conversations) filesystem scan that a
+    full cache invalidation would trigger on the next conversations-list GET.
+
+    Falls back to full invalidation if:
+    - The cache is already stale (TTL expired) — next GET will rebuild anyway.
+    - The conversation no longer exists on disk (e.g., concurrent deletion).
+    """
+    global _conversations_cache
+    if _conversations_cache is None:
+        return
+    if (time.monotonic() - _conversations_cache_time) >= _CONVERSATIONS_CACHE_TTL:
+        return  # already stale; next GET will trigger a full rebuild
+    logs_dir = _conversations_cache_logs_dir
+    updated = get_conversation_meta_direct(conv_id, detail=False, logs_dir=logs_dir)
+    if updated is None:
+        # Conversation not found — fall back to full invalidation so the
+        # stale entry is removed on the next list request.
+        _invalidate_conversations_cache()
+        return
+    _conversations_cache = [
+        updated if c.id == conv_id else c for c in _conversations_cache
+    ]

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -3145,7 +3145,11 @@ def _update_conversation_in_cache(conv_id: str) -> None:
     - The conversation no longer exists on disk (e.g., concurrent deletion).
     """
     global _conversations_cache
-    if _conversations_cache is None:
+    # Snapshot once to avoid TOCTOU: a concurrent _invalidate_conversations_cache()
+    # can set the global to None between our is-None guard and the any()/comprehension
+    # reads, which would raise TypeError on iteration.
+    cache = _conversations_cache
+    if cache is None:
         return
     if (time.monotonic() - _conversations_cache_time) >= _CONVERSATIONS_CACHE_TTL:
         return  # already stale; next GET will trigger a full rebuild
@@ -3156,11 +3160,9 @@ def _update_conversation_in_cache(conv_id: str) -> None:
         # stale entry is removed on the next list request.
         _invalidate_conversations_cache()
         return
-    if not any(c.id == conv_id for c in _conversations_cache):
+    if not any(c.id == conv_id for c in cache):
         # Entry not in cached list (e.g., concurrent external filesystem write).
         # Fall back to full invalidation so the list gets rebuilt correctly.
         _invalidate_conversations_cache()
         return
-    _conversations_cache = [
-        updated if c.id == conv_id else c for c in _conversations_cache
-    ]
+    _conversations_cache = [updated if c.id == conv_id else c for c in cache]

--- a/tests/test_chats_rename.py
+++ b/tests/test_chats_rename.py
@@ -56,7 +56,7 @@ def _make_conv(
 def test_rename_conversation_not_found():
     """rename_conversation returns False when conversation doesn't exist."""
     with patch(
-        "gptme.logmanager.conversations.get_conversations", return_value=iter([])
+        "gptme.logmanager.conversations.get_conversation_by_id", return_value=None
     ):
         assert rename_conversation("nonexistent", "new name") is False
 
@@ -67,7 +67,7 @@ def test_rename_conversation_updates_config(tmp_path: Path):
     conv = _make_conv("test-conv", path=str(conv_dir / "conversation.jsonl"))
 
     with patch(
-        "gptme.logmanager.conversations.get_conversations", return_value=iter([conv])
+        "gptme.logmanager.conversations.get_conversation_by_id", return_value=conv
     ):
         result = rename_conversation("test-conv", "My Renamed Chat")
 
@@ -93,7 +93,7 @@ def test_rename_conversation_preserves_existing_config(tmp_path: Path):
     conv = _make_conv("test-conv", path=str(conv_dir / "conversation.jsonl"))
 
     with patch(
-        "gptme.logmanager.conversations.get_conversations", return_value=iter([conv])
+        "gptme.logmanager.conversations.get_conversation_by_id", return_value=conv
     ):
         result = rename_conversation("test-conv", "New Name")
 
@@ -113,13 +113,12 @@ def test_rename_conversation_idempotent(tmp_path: Path):
     conv = _make_conv("test-conv", path=str(conv_dir / "conversation.jsonl"))
 
     with patch(
-        "gptme.logmanager.conversations.get_conversations", return_value=iter([conv])
+        "gptme.logmanager.conversations.get_conversation_by_id", return_value=conv
     ):
         assert rename_conversation("test-conv", "Name A") is True
 
-    # Need a fresh iterator each time
     with patch(
-        "gptme.logmanager.conversations.get_conversations", return_value=iter([conv])
+        "gptme.logmanager.conversations.get_conversation_by_id", return_value=conv
     ):
         assert rename_conversation("test-conv", "Name A") is True
 
@@ -131,7 +130,7 @@ def test_rename_conversation_no_workspace_symlink(tmp_path: Path):
     conv = _make_conv("test-conv", path=str(conv_dir / "conversation.jsonl"))
 
     with patch(
-        "gptme.logmanager.conversations.get_conversations", return_value=iter([conv])
+        "gptme.logmanager.conversations.get_conversation_by_id", return_value=conv
     ):
         rename_conversation("test-conv", "NicerName")
 
@@ -150,7 +149,7 @@ def test_cli_rename_success(tmp_path: Path):
 
     runner = CliRunner()
     with patch(
-        "gptme.logmanager.conversations.get_conversations", return_value=iter([conv])
+        "gptme.logmanager.conversations.get_conversation_by_id", return_value=conv
     ):
         result = runner.invoke(chats_rename, ["my-chat", "Better Name"])
 
@@ -163,7 +162,7 @@ def test_cli_rename_not_found():
     """CLI rename command exits with error when chat not found."""
     runner = CliRunner()
     with patch(
-        "gptme.logmanager.conversations.get_conversations", return_value=iter([])
+        "gptme.logmanager.conversations.get_conversation_by_id", return_value=None
     ):
         result = runner.invoke(chats_rename, ["nonexistent", "New Name"])
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -421,6 +421,129 @@ def test_api_conversation_list_cache_tracks_patched_logs_dir(
     assert data[0]["id"] == "cache-target"
 
 
+def test_update_conversation_in_cache_partial_update(tmp_path):
+    """_update_conversation_in_cache must refresh one entry without touching others.
+
+    During LLM streaming (many rapid message additions to one conversation),
+    each POST must not wipe the full cache.  The partial-update helper must:
+    1. Keep _conversations_cache not None.
+    2. Update the modified conversation's message count and preview.
+    3. Leave other conversation entries unchanged.
+    """
+    import time
+
+    import gptme.server.api_v2 as api_v2_module
+    from gptme.logmanager import ConversationMeta
+
+    # Set up two minimal conversation files
+    active_dir = tmp_path / "active-conv"
+    other_dir = tmp_path / "other-conv"
+    active_dir.mkdir()
+    other_dir.mkdir()
+    active_file = active_dir / "conversation.jsonl"
+    other_file = other_dir / "conversation.jsonl"
+    active_file.write_text(
+        '{"role": "system", "content": "sys", "timestamp": "2026-01-01T00:00:00"}\n'
+    )
+    other_file.write_text(
+        '{"role": "system", "content": "other", "timestamp": "2026-01-01T00:00:00"}\n'
+    )
+
+    def _make_meta(conv_id: str, conv_file, n_msgs: int) -> ConversationMeta:
+        return ConversationMeta(
+            id=conv_id,
+            name=conv_id,
+            path=str(conv_file),
+            created=0.0,
+            modified=0.0,
+            messages=n_msgs,
+            branches=1,
+            workspace="",
+            agent_name=None,
+            agent_path=None,
+            agent_avatar=None,
+            agent_urls=None,
+            model=None,
+        )
+
+    # Seed the cache as if a GET just happened
+    api_v2_module._conversations_cache = [
+        _make_meta("active-conv", active_file, 1),
+        _make_meta("other-conv", other_file, 1),
+    ]
+    api_v2_module._conversations_cache_logs_dir = tmp_path
+    api_v2_module._conversations_cache_time = time.monotonic()
+
+    # Append a message to the active conversation on disk
+    with active_file.open("a") as f:
+        f.write(
+            '{"role": "user", "content": "streaming msg", "timestamp": "2026-01-01T00:00:01"}\n'
+        )
+
+    # Partial update
+    api_v2_module._update_conversation_in_cache("active-conv")
+
+    # Cache must remain warm
+    assert api_v2_module._conversations_cache is not None
+
+    # Active conv entry must be updated
+    updated_active = next(
+        c for c in api_v2_module._conversations_cache if c.id == "active-conv"
+    )
+    assert updated_active.messages == 2
+    assert updated_active.last_message_role == "user"
+    assert updated_active.last_message_preview is not None
+    assert "streaming msg" in (updated_active.last_message_preview or "")
+
+    # Other conv entry must be untouched
+    other = next(c for c in api_v2_module._conversations_cache if c.id == "other-conv")
+    assert other.messages == 1
+
+
+def test_update_conversation_in_cache_missing_conv_invalidates(tmp_path):
+    """If the conversation is deleted, partial update must fall back to full invalidation."""
+    import time
+
+    import gptme.server.api_v2 as api_v2_module
+    from gptme.logmanager import ConversationMeta
+
+    gone_dir = tmp_path / "gone-conv"
+    gone_dir.mkdir()
+    gone_file = gone_dir / "conversation.jsonl"
+    gone_file.write_text(
+        '{"role": "system", "content": "sys", "timestamp": "2026-01-01T00:00:00"}\n'
+    )
+
+    api_v2_module._conversations_cache = [
+        ConversationMeta(
+            id="gone-conv",
+            name="gone-conv",
+            path=str(gone_file),
+            created=0.0,
+            modified=0.0,
+            messages=1,
+            branches=1,
+            workspace="",
+            agent_name=None,
+            agent_path=None,
+            agent_avatar=None,
+            agent_urls=None,
+            model=None,
+        )
+    ]
+    api_v2_module._conversations_cache_logs_dir = tmp_path
+    api_v2_module._conversations_cache_time = time.monotonic()
+
+    # Delete the conversation file before partial update
+    gone_file.unlink()
+    gone_dir.rmdir()
+
+    api_v2_module._update_conversation_in_cache("gone-conv")
+
+    # Cache must be invalidated so next GET rebuilds without the deleted conv
+    assert api_v2_module._conversations_cache is None
+
+
 def test_api_conversation_get(conv, client: FlaskClient):
     response = client.get(f"/api/v2/conversations/{conv}")
     assert response.status_code == 200


### PR DESCRIPTION
## Problem

During active LLM streaming, `POST /api/v2/conversations/<id>` fires for every streamed message. Each call called `_invalidate_conversations_cache()`, setting the cache to `None`. This forces the next `GET /api/v2/conversations` (polled by the webui sidebar) to do a full O(N_conversations) filesystem scan: `glob + stat` on every conversation directory, then a tail-read per file.

With 1000 conversations and 10 sidebar polls per second during streaming, this is O(10 × 1000 × file_ops) per second — a hot loop that degraded performance (gptme/gptme-cloud#420).

## Fix

Introduce `_update_conversation_in_cache(conv_id)` as a partial-update path:
- Re-reads only the modified conversation's file (O(1) disk I/O, no glob scan).
- Swaps the old entry in the list with the fresh metadata.
- Falls back to full invalidation only when the conversation is deleted.
- Skips work when the cache is already past its TTL (next GET will rebuild anyway).

Full invalidation is kept for conversation create, fork, and delete — those change the conversation count, so the full list must be rebuilt.

## Changes

- **`logmanager/conversations.py`**: Extract `_meta_from_file()` from `get_conversations()` loop body so single-file lookup and full-list scan share the same metadata logic. Add `get_conversation_meta_direct()` for direct path lookup that bypasses `_conversation_files()` glob+stat. Simplify `get_conversation_by_id()` to use `get_conversation_meta_direct()`.

- **`server/api_v2.py`**: Add `_update_conversation_in_cache()`. Replace `_invalidate_conversations_cache()` with `_update_conversation_in_cache()` at the message POST call site.

- **`tests/test_server.py`**: Two new regression tests:
  1. Partial update keeps cache warm and updates message count + preview.
  2. Missing conversation (concurrent deletion) triggers full invalidation.

## Test

```
86 passed in 13.32s
```

Refs: gptme/gptme-cloud#420