### PR TITLE
fix(server): prevent workspace path traversal via config PATCH and PUT

### DIFF
--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -75,7 +75,7 @@ from ..message import Message
 from ..tools import get_toolchain, get_tools, init_tools
 from ..util.content import is_message_command
 from ..util.uri import URI, FilePath, is_uri, parse_file_reference
-from .api_v2_agents import agents_api
+from .api_v2_agents import INITIAL_WORKING_DIRECTORY, agents_api
 from .api_v2_common import (
     _abs_to_rel_workspace,
     _validate_branch,
@@ -427,14 +427,13 @@ def _validate_message_file_references(
     return file_paths
 
 
-# Store the initial working directory at module import time (same pattern as api_v2_agents).
-# Used to restrict workspace paths supplied by API clients so they cannot point at
-# arbitrary server-side locations (path traversal via config PATCH / PUT).
-_SERVER_WORKSPACE_ROOT = Path.cwd().resolve()
+# Reuse the constant from api_v2_agents (same capture point, eliminates drift risk).
+# Used to restrict workspace paths supplied by API clients (path traversal via config PATCH / PUT).
+_SERVER_WORKSPACE_ROOT = INITIAL_WORKING_DIRECTORY
 
 
 def _validate_workspace_path(
-    workspace: str | None,
+    workspace: object,
 ) -> tuple[flask.Response, int] | None:
     """Validate a workspace path supplied by an API client.
 

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -427,6 +427,65 @@ def _validate_message_file_references(
     return file_paths
 
 
+# Store the initial working directory at module import time (same pattern as api_v2_agents).
+# Used to restrict workspace paths supplied by API clients so they cannot point at
+# arbitrary server-side locations (path traversal via config PATCH / PUT).
+_SERVER_WORKSPACE_ROOT = Path.cwd().resolve()
+
+
+def _validate_workspace_path(
+    workspace: str | None,
+) -> tuple[flask.Response, int] | None:
+    """Validate a workspace path supplied by an API client.
+
+    Allows:
+    - None / omitted (caller uses a default)
+    - The magic "@log" sentinel (resolved relative to the conversation logdir)
+    - Any absolute or relative path that resolves **within** the server's
+      initial working directory (``_SERVER_WORKSPACE_ROOT``)
+
+    Rejects:
+    - Paths that resolve outside the server working directory, e.g. ``/etc``,
+      ``~/.ssh``, or ``../../sensitive`` — prevents workspace path traversal
+      (CWE-22) via the config PATCH and PUT endpoints.
+
+    Returns None when the path is acceptable, or a (Response, status) tuple
+    with a 400 error when it must be rejected.
+    """
+    if workspace is None or workspace == "@log":
+        return None
+
+    # Non-string values are a type error, not a traversal; let downstream
+    # validation in ChatConfig.from_dict produce the appropriate message.
+    if not isinstance(workspace, str):
+        return None
+
+    resolved = Path(workspace).expanduser().resolve()
+    try:
+        resolved.relative_to(_SERVER_WORKSPACE_ROOT)
+    except ValueError:
+        logger.warning(
+            "Rejected workspace path outside server root",
+            extra={
+                "requested": workspace,
+                "resolved": str(resolved),
+                "server_root": str(_SERVER_WORKSPACE_ROOT),
+            },
+        )
+        return (
+            flask.jsonify(
+                {
+                    "error": (
+                        "workspace path must be within the server working directory; "
+                        "use '@log' for an isolated per-conversation workspace"
+                    )
+                }
+            ),
+            400,
+        )
+    return None
+
+
 def _persist_default_model(model: str) -> bool:
     """Persist the default model to [models].default and try to apply in-process.
 
@@ -1418,6 +1477,12 @@ def api_conversation_put(conversation_id: str):
     if not isinstance(prompt, str):
         return flask.jsonify({"error": "'prompt' must be a string"}), 400
 
+    # Validate workspace path before any side effects (CWE-22: path traversal).
+    chat_raw = config_raw.get("chat", {})
+    if isinstance(chat_raw, dict) and "workspace" in chat_raw:
+        if err := _validate_workspace_path(chat_raw.get("workspace")):
+            return err
+
     # Load or create the chat config, overriding values from request config if provided
     config_dict = dict(config_raw)
     config_dict["_logdir"] = logdir  # Pass logdir for "@log" workspace resolution
@@ -2374,6 +2439,10 @@ def api_conversation_config_patch(conversation_id: str):
                     "error": "model must be a string (e.g. 'gpt-4', 'claude-sonnet-4-5-20250929')"
                 }
             ), 400
+        # Validate workspace path before any side effects (CWE-22: path traversal).
+        if "workspace" in chat_patch:
+            if err := _validate_workspace_path(chat_patch.get("workspace")):
+                return err
 
     logdir = get_logs_dir() / conversation_id
 

--- a/tests/test_server_path_traversal.py
+++ b/tests/test_server_path_traversal.py
@@ -5,8 +5,12 @@ reject path traversal attempts (CWE-22) before any file system operations occur.
 """
 
 import base64
+from typing import TYPE_CHECKING
 
 import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 # Minimal valid 1×1 white-pixel PNG, pre-computed so tests don't need PIL.
 # Verified: `PIL.Image.open(io.BytesIO(_VALID_PNG)).format == "PNG"`
@@ -781,3 +785,159 @@ class TestValidateBranchUnit:
                 assert result is not None, f"Should reject non-string: {value!r}"
                 _response, status_code = result
                 assert status_code == 400
+
+
+# Workspace paths that must be rejected by config PATCH and PUT because they
+# point outside the server's working directory (CWE-22 path traversal).
+WORKSPACE_TRAVERSAL_PAYLOADS = [
+    "/etc",
+    "/etc/passwd",
+    "/tmp/evil",
+    "~/.ssh",
+    "../../etc/passwd",
+    "../../../root",
+    "/home/user/.bashrc",
+]
+
+
+def _make_conv_for_workspace_test(
+    client: "FlaskClient",
+    tmp_path: "Path",
+    monkeypatch,
+):
+    """Create a minimal conversation and wire up get_logs_dir."""
+    from gptme.logmanager import LogManager
+    from gptme.message import Message
+
+    logs_dir = tmp_path / "logs"
+    conv_logdir = logs_dir / "test-ws-conv"
+    LogManager.load(
+        logdir=conv_logdir,
+        initial_msgs=[Message("user", "hi")],
+        create=True,
+    ).write()
+
+    monkeypatch.setattr(
+        "gptme.server.api_v2.get_logs_dir",
+        lambda: logs_dir,
+    )
+    return "test-ws-conv"
+
+
+class TestWorkspacePathValidation:
+    """Config PATCH and conversation PUT must reject workspace paths outside server root.
+
+    CWE-22: Improper Limitation of a Pathname to a Restricted Directory.
+    Without this check a client could set workspace=/etc and cause the server
+    to read project configs, system prompts, and tool outputs from arbitrary
+    filesystem locations.
+    """
+
+    @pytest.mark.parametrize("workspace", WORKSPACE_TRAVERSAL_PAYLOADS)
+    def test_config_patch_rejects_traversal_workspace(
+        self,
+        client: "FlaskClient",
+        tmp_path,
+        monkeypatch,
+        workspace: str,
+    ):
+        """PATCH /conversations/:id/config must reject workspace paths outside server root."""
+        conv_id = _make_conv_for_workspace_test(client, tmp_path, monkeypatch)
+
+        response = client.patch(
+            f"/api/v2/conversations/{conv_id}/config",
+            json={"chat": {"workspace": workspace}},
+        )
+
+        assert response.status_code == 400
+        data = response.get_json()
+        assert data is not None
+        assert "workspace" in data["error"].lower()
+
+    @pytest.mark.parametrize("workspace", WORKSPACE_TRAVERSAL_PAYLOADS)
+    def test_conversation_put_rejects_traversal_workspace(
+        self,
+        client: "FlaskClient",
+        tmp_path,
+        monkeypatch,
+        workspace: str,
+    ):
+        """PUT /conversations/:id must reject workspace paths outside server root."""
+        import random
+
+        logs_dir = tmp_path / "logs"
+        monkeypatch.setattr(
+            "gptme.server.api_v2.get_logs_dir",
+            lambda: logs_dir,
+        )
+
+        conv_id = f"test-put-workspace-{random.randint(0, 1_000_000)}"
+        response = client.put(
+            f"/api/v2/conversations/{conv_id}",
+            json={"config": {"chat": {"workspace": workspace}}},
+        )
+
+        assert response.status_code == 400
+        data = response.get_json()
+        assert data is not None
+        assert "workspace" in data["error"].lower()
+
+    def test_config_patch_accepts_at_log_workspace(
+        self,
+        client: "FlaskClient",
+        tmp_path,
+        monkeypatch,
+    ):
+        """PATCH must accept the '@log' magic sentinel (resolved relative to logdir)."""
+        conv_id = _make_conv_for_workspace_test(client, tmp_path, monkeypatch)
+
+        response = client.patch(
+            f"/api/v2/conversations/{conv_id}/config",
+            json={"chat": {"workspace": "@log"}},
+        )
+
+        # Should not be rejected for traversal (400 with "workspace" error)
+        if response.status_code == 400:
+            data = response.get_json()
+            assert data is None or "workspace" not in data.get("error", "").lower()
+
+    def test_config_patch_accepts_subdir_of_server_root(
+        self,
+        client: "FlaskClient",
+        tmp_path,
+        monkeypatch,
+    ):
+        """PATCH must accept a workspace path that is inside the server's working dir."""
+        from gptme.server.api_v2 import _SERVER_WORKSPACE_ROOT
+
+        # Create a subdirectory of the server root (always valid)
+        safe_workspace = _SERVER_WORKSPACE_ROOT / "safe-subdir"
+        safe_workspace.mkdir(parents=True, exist_ok=True)
+
+        conv_id = _make_conv_for_workspace_test(client, tmp_path, monkeypatch)
+
+        response = client.patch(
+            f"/api/v2/conversations/{conv_id}/config",
+            json={"chat": {"workspace": str(safe_workspace)}},
+        )
+
+        # Should not be rejected for traversal (400 with "workspace" error)
+        if response.status_code == 400:
+            data = response.get_json()
+            assert data is None or "workspace" not in data.get("error", "").lower()
+
+    def test_validate_workspace_path_unit(self):
+        """Unit test: _validate_workspace_path rejects paths outside server root."""
+        from gptme.server.api_v2 import _validate_workspace_path  # fmt: skip
+        from gptme.server.app import create_app
+
+        app = create_app()
+        with app.app_context():
+            # @log sentinel is always allowed
+            assert _validate_workspace_path(None) is None
+            assert _validate_workspace_path("@log") is None
+
+            # Paths outside server root must be rejected
+            assert _validate_workspace_path("/etc") is not None
+            assert _validate_workspace_path("/etc/passwd") is not None
+            assert _validate_workspace_path("../../etc/passwd") is not None

--- a/tests/test_server_path_traversal.py
+++ b/tests/test_server_path_traversal.py
@@ -908,10 +908,14 @@ class TestWorkspacePathValidation:
         monkeypatch,
     ):
         """PATCH must accept a workspace path that is inside the server's working dir."""
-        from gptme.server.api_v2 import _SERVER_WORKSPACE_ROOT
+        import gptme.server.api_v2 as api_v2
 
-        # Create a subdirectory of the server root (always valid)
-        safe_workspace = _SERVER_WORKSPACE_ROOT / "safe-subdir"
+        # Monkeypatch the server root to tmp_path so the safe subdir is created
+        # there, not inside the real project root (which would leave a stray directory).
+        monkeypatch.setattr(api_v2, "_SERVER_WORKSPACE_ROOT", tmp_path.resolve())
+
+        # Create a subdirectory of the (patched) server root — always valid
+        safe_workspace = tmp_path / "safe-subdir"
         safe_workspace.mkdir(parents=True, exist_ok=True)
 
         conv_id = _make_conv_for_workspace_test(client, tmp_path, monkeypatch)

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -1405,6 +1405,11 @@ def test_v2_create_conversation_default_system_prompt(
         "gptme.prompts.workspace.config_path",
         str(tmp_path / "config.toml"),
     )
+    # Expand the server workspace root to include tmp_path so the path
+    # validation guard allows the workspace used in this test.
+    import gptme.server.api_v2 as _api_v2
+
+    monkeypatch.setattr(_api_v2, "_SERVER_WORKSPACE_ROOT", tmp_path.parent.resolve())
 
     convname = f"test-server-v2-{random.randint(0, 1000000)}"
     response = client.put(


### PR DESCRIPTION
## Summary

- Adds `_validate_workspace_path()` to `api_v2.py` that rejects workspace paths supplied by API clients if they resolve outside the server's initial working directory (`_SERVER_WORKSPACE_ROOT`)
- Applies the check early (before any filesystem side-effects) in both `PUT /api/v2/conversations/:id` (create) and `PATCH /api/v2/conversations/:id/config` (update)
- The `@log` magic sentinel is always accepted (resolved relative to the conversation logdir, not user input); non-string values are passed through to the existing type validator

## Security impact

Without this fix, a client could set `chat.workspace` to `/etc`, `~/.ssh`, `../../sensitive`, etc. The server would then read project configs, system prompts, and tool descriptions from those locations (CWE-22: path traversal). The fix follows the same `INITIAL_WORKING_DIRECTORY` boundary pattern already used in `api_v2_agents.py`.

## Test plan

- 14 parametrized endpoint tests covering 7 traversal payloads × 2 endpoints (PATCH config, PUT conversation)
- 1 acceptance test: `@log` sentinel must not be rejected
- 1 acceptance test: path within server root must not be rejected
- 1 unit test for `_validate_workspace_path()` directly
- All 112 existing path traversal tests continue to pass
- All 296 combined `test_server_path_traversal.py` + `test_server_v2.py` tests pass