### PR TITLE
fix(cli): validate model provider early, before context_cmd runs

### DIFF
--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -1005,6 +1005,16 @@ def main(
         )
         sys.exit(1)
 
+    # Validate model early to fail fast before the expensive get_prompt() call.
+    # Only check models with a provider/ prefix; bare provider names (e.g. "anthropic")
+    # and model aliases (e.g. "gpt-4o") are left for init_model() to resolve.
+    if config.chat.model and "/" in config.chat.model:
+        try:
+            get_provider_from_model(config.chat.model)
+        except ValueError as e:
+            _cleanup_aborted_new_logdir(logdir, preexisting=logdir_preexisting)
+            raise click.UsageError(f"--model: {e}") from e
+
     if is_existing_conversation:
         logger.debug("Existing conversation found, skipping initial prompt generation")
         initial_msgs = []

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -397,6 +397,43 @@ def test_model_allows_provider_owned_nested_model_path(runner: CliRunner):
     assert "gptme v" in result.output
 
 
+def test_model_allows_nested_path_through_validation_block(
+    monkeypatch, tmp_path: Path, runner: CliRunner
+):
+    """A valid nested-path model should pass the early validation block.
+
+    Unlike test_model_allows_provider_owned_nested_model_path which uses
+    --version and exits before the validation block runs, this test
+    actually exercises the early validation code path.
+    """
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
+
+    # Track that get_prompt was called (means validation passed)
+    called: dict[str, bool] = {"get_prompt": False}
+
+    def _fake_get_prompt(**kwargs):
+        called["get_prompt"] = True
+        return []
+
+    monkeypatch.setattr(cli, "get_prompt", _fake_get_prompt)
+    monkeypatch.setattr(cli, "chat", lambda *args, **kwargs: None)
+    monkeypatch.setattr(cli, "init_telemetry", lambda **kwargs: None)
+
+    result = runner.invoke(
+        cli.main,
+        [
+            "--model",
+            "openrouter/anthropic/claude-sonnet-4-6",
+            "--non-interactive",
+            "hello",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert called["get_prompt"], "execution should reach get_prompt (validation passed)"
+
+
 def test_model_rejects_unknown_provider_before_context_cmd(
     monkeypatch, tmp_path: Path, runner: CliRunner
 ):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -397,6 +397,30 @@ def test_model_allows_provider_owned_nested_model_path(runner: CliRunner):
     assert "gptme v" in result.output
 
 
+def test_model_rejects_unknown_provider_before_context_cmd(
+    monkeypatch, tmp_path: Path, runner: CliRunner
+):
+    """--model with an unknown provider prefix should fail fast before running context_cmd."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
+    monkeypatch.setattr(
+        cli,
+        "get_prompt",
+        lambda **kwargs: pytest.fail("get_prompt was called before model validation"),
+    )
+    monkeypatch.setattr(cli, "chat", lambda *args, **kwargs: pytest.fail("chat ran"))
+    monkeypatch.setattr(cli, "init_telemetry", lambda **kwargs: None)
+
+    result = runner.invoke(
+        cli.main,
+        ["--model", "badprovider/some-model", "--non-interactive", "hello"],
+    )
+
+    assert result.exit_code == 2, result.output
+    assert "Unknown provider: badprovider" in result.output
+    assert "Traceback" not in result.output
+
+
 @pytest.mark.parametrize(
     ("bad_name", "expected_message"),
     [


### PR DESCRIPTION
## Summary

- `gptme --model badprovider/some-model` previously ran the full `context_cmd` (up to 60s timeout) before failing in `init_model()` with an unknown provider error
- Add early validation using the already-imported `get_provider_from_model()` for any `--model` value containing `/`, matching the existing comment and pattern at line 986-1006 of `main.py`
- Bare provider names (`anthropic`) and unqualified aliases (`gpt-4o`) without a `/` are left to `init_model()` as before to avoid false positives
- Clean `UsageError` is raised immediately, no expensive context generation wasted

## Test plan

- [ ] `pytest tests/test_cli.py::test_model_rejects_unknown_provider_before_context_cmd` — asserts `get_prompt` is never called when provider is unknown
- [ ] `pytest tests/test_cli.py::test_model_allows_provider_owned_nested_model_path` — valid provider + nested path still works
- [ ] Manual: `gptme --model badprovider/model --non-interactive hello` exits immediately with `Error: --model: Unknown provider: badprovider` (exit 2, no context_cmd delay)