### PR TITLE
fix(server): preserve 'files' field in PUT /api/v2/conversations/:id messages

### DIFF
--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -1492,9 +1492,10 @@ def api_conversation_put(conversation_id: str):
                 files_raw, chat_config.workspace
             )
             if isinstance(validated_files, tuple):
+                shutil.rmtree(logdir, ignore_errors=True)
                 return validated_files
             file_paths = validated_files
-        msgs.append(Message(role, content, timestamp=timestamp, files=file_paths))  # type: ignore[arg-type]
+        msgs.append(Message(role, content, timestamp=timestamp, files=file_paths))  # type: ignore[arg-type]  # list[Path] is valid for list[FilePath]
 
     log = LogManager.load(logdir=logdir, initial_msgs=msgs, create=True)
     log.write()

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -1381,7 +1381,7 @@ def api_conversation_put(conversation_id: str):
         return flask.jsonify({"error": "'messages' must be a list"}), 400
     _RoleType = Literal["system", "user", "assistant"]
     valid_roles = ("system", "user", "assistant")
-    validated_msgs: list[tuple[_RoleType, str, datetime]] = []
+    validated_msgs: list[tuple[_RoleType, str, datetime, list[str]]] = []
     for msg in messages_raw:
         if not isinstance(msg, dict):
             return flask.jsonify({"error": "Each message must be an object"}), 400
@@ -1409,7 +1409,16 @@ def api_conversation_put(conversation_id: str):
                 ), 400
         else:
             ts = datetime.now(tz=timezone.utc)
-        validated_msgs.append((cast(_RoleType, msg["role"]), msg["content"], ts))
+        files_raw = msg.get("files", [])
+        if not isinstance(files_raw, list) or not all(
+            isinstance(f, str) for f in files_raw
+        ):
+            return flask.jsonify(
+                {"error": "Message 'files' must be a list of strings"}
+            ), 400
+        validated_msgs.append(
+            (cast(_RoleType, msg["role"]), msg["content"], ts, files_raw)
+        )
 
     config_raw = req_json.get("config", {})
     if not isinstance(config_raw, dict):
@@ -1476,8 +1485,16 @@ def api_conversation_put(conversation_id: str):
 
     _append_conversation_system_prompt(msgs, chat_config.system_prompt)
 
-    for role, content, timestamp in validated_msgs:
-        msgs.append(Message(role, content, timestamp=timestamp))
+    for role, content, timestamp, files_raw in validated_msgs:
+        file_paths: list[FilePath] = []
+        if files_raw:
+            validated_files = _validate_message_file_references(
+                files_raw, chat_config.workspace
+            )
+            if isinstance(validated_files, tuple):
+                return validated_files
+            file_paths = validated_files
+        msgs.append(Message(role, content, timestamp=timestamp, files=file_paths))  # type: ignore[arg-type]
 
     log = LogManager.load(logdir=logdir, initial_msgs=msgs, create=True)
     log.write()

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -3,6 +3,7 @@ import json
 import random
 import time
 import unittest.mock
+import uuid
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, cast
@@ -2812,8 +2813,6 @@ def test_v2_create_conversation_message_not_object(client: FlaskClient):
 
 def test_v2_create_conversation_preserves_message_files(client: FlaskClient):
     """PUT /conversations/<id> must preserve the 'files' field in initial messages."""
-    import uuid
-
     conv_id = f"test-msg-files-{uuid.uuid4().hex[:8]}"
     uri = "https://example.com/image.png"
     response = client.put(
@@ -2840,8 +2839,6 @@ def test_v2_create_conversation_rejects_invalid_message_files(
     client: FlaskClient, files_payload: object
 ):
     """PUT /conversations/<id> must reject non-list or non-string-list 'files' with 400."""
-    import uuid
-
     conv_id = f"test-msg-bad-files-{uuid.uuid4().hex[:8]}"
     response = client.put(
         f"/api/v2/conversations/{conv_id}",

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -2810,6 +2810,52 @@ def test_v2_create_conversation_message_not_object(client: FlaskClient):
     assert "object" in data["error"].lower()
 
 
+def test_v2_create_conversation_preserves_message_files(client: FlaskClient):
+    """PUT /conversations/<id> must preserve the 'files' field in initial messages."""
+    import uuid
+
+    conv_id = f"test-msg-files-{uuid.uuid4().hex[:8]}"
+    uri = "https://example.com/image.png"
+    response = client.put(
+        f"/api/v2/conversations/{conv_id}",
+        json={
+            "prompt": "none",
+            "messages": [{"role": "user", "content": "hello", "files": [uri]}],
+        },
+    )
+    assert response.status_code == 200
+
+    conversation = client.get(f"/api/v2/conversations/{conv_id}").get_json()
+    assert conversation is not None
+    user_msgs = [m for m in conversation["log"] if m["role"] == "user"]
+    assert len(user_msgs) == 1
+    assert user_msgs[0]["files"] == [uri]
+
+
+@pytest.mark.parametrize(
+    "files_payload",
+    ["not-a-list", 42, {"key": "val"}, [1, 2, 3], [None]],
+)
+def test_v2_create_conversation_rejects_invalid_message_files(
+    client: FlaskClient, files_payload: object
+):
+    """PUT /conversations/<id> must reject non-list or non-string-list 'files' with 400."""
+    import uuid
+
+    conv_id = f"test-msg-bad-files-{uuid.uuid4().hex[:8]}"
+    response = client.put(
+        f"/api/v2/conversations/{conv_id}",
+        json={
+            "prompt": "none",
+            "messages": [{"role": "user", "content": "hello", "files": files_payload}],
+        },
+    )
+    assert response.status_code == 400
+    data = response.get_json()
+    assert data is not None
+    assert "files" in data["error"].lower()
+
+
 @pytest.mark.parametrize("body", [[], [1, 2, 3], "string", 42])
 def test_v2_tasks_put_rejects_non_object_json(client: FlaskClient, body: object):
     """Task PUT should reject non-object JSON bodies with 400."""


### PR DESCRIPTION
## Problem

`PUT /api/v2/conversations/:id` silently drops the `files` field from any message passed in the initial `messages` list. The validation loop only collected `(role, content, timestamp)` tuples; the creation loop passed no `files=` arg to `Message()`.

Fixes #2940.

## Root Cause

In `api_conversation_put()` (`gptme/server/api_v2.py`):

1. `validated_msgs` was typed as `list[tuple[_RoleType, str, datetime]]` — no slot for files.
2. `msg.get("files")` was never read during validation.
3. The message creation loop called `Message(role, content, timestamp=timestamp)` with no `files=`.

## Fix

Follows the same pattern already used by `api_conversation_post()`:

1. Extend `validated_msgs` tuple to include `files_raw: list[str]`.
2. Validate the `files` field (must be `list[str]`) in the pre-creation loop (before any side effects / directory creation).
3. After `chat_config.workspace` is resolved, call `_validate_message_file_references()` per message and pass the result to `Message(files=...)`.

## Tests

- `test_v2_create_conversation_preserves_message_files` — round-trip: PUT with a URI file → GET confirms it appears in the log.
- `test_v2_create_conversation_rejects_invalid_message_files` — parametrized over 5 invalid payloads (non-list, int, dict, list of int, list of None), each returns 400 with a `files`-mentioning error.

Full `test_server_v2.py` suite: **190 passed, 4 skipped**.