### PR TITLE
fix(server): enforce workspace containment at config PUT/PATCH boundary

### DIFF
--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -1433,6 +1433,11 @@ def api_conversation_put(conversation_id: str):
     except ValueError as exc:
         return flask.jsonify({"error": str(exc)}), 400
 
+    # Enforce workspace containment: server clients must not direct the agent
+    # outside the conversation's logdir (path traversal / SSRF via workspace).
+    if not request_config.workspace.is_relative_to(logdir):
+        return flask.jsonify({"error": "workspace escapes conversation logdir"}), 400
+
     # Create the log directory atomically to avoid TOCTOU race
     try:
         logdir.mkdir(parents=True)
@@ -2423,6 +2428,15 @@ def api_conversation_config_patch(conversation_id: str):
     req_json["_logdir"] = logdir  # Pass logdir for "@log" workspace resolution
     try:
         request_config = ChatConfig.from_dict(req_json)
+    except ValueError as exc:
+        return flask.jsonify({"error": str(exc)}), 400
+
+    # Enforce workspace containment: server clients must not direct the agent
+    # outside the conversation's logdir (path traversal / SSRF via workspace).
+    if not request_config.workspace.is_relative_to(logdir):
+        return flask.jsonify({"error": "workspace escapes conversation logdir"}), 400
+
+    try:
         chat_config = ChatConfig.load_or_create(logdir, request_config).save()
     except ValueError as exc:
         return flask.jsonify({"error": str(exc)}), 400

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -1435,7 +1435,8 @@ def api_conversation_put(conversation_id: str):
 
     # Enforce workspace containment: server clients must not direct the agent
     # outside the conversation's logdir (path traversal / SSRF via workspace).
-    if not request_config.workspace.is_relative_to(logdir):
+    # Resolve logdir to handle symlinks (e.g. macOS /tmp -> /private/tmp).
+    if not request_config.workspace.is_relative_to(logdir.resolve()):
         return flask.jsonify({"error": "workspace escapes conversation logdir"}), 400
 
     # Create the log directory atomically to avoid TOCTOU race
@@ -2424,6 +2425,13 @@ def api_conversation_config_patch(conversation_id: str):
         except Exception as exc:
             return flask.jsonify({"error": f"Failed to load tool: {exc}"}), 400
 
+    # Determine if workspace was explicitly provided in the request body.
+    # This check must happen BEFORE ChatConfig.from_dict, which mutates the
+    # chat_patch dict by inferring workspace from the existing logdir/workspace
+    # path when workspace is absent (adding it as a side effect via the
+    # `elif _logdir and (_logdir / "workspace").exists()` branch).
+    workspace_in_patch = isinstance(chat_patch, dict) and "workspace" in chat_patch
+
     # Create and set config
     req_json["_logdir"] = logdir  # Pass logdir for "@log" workspace resolution
     try:
@@ -2433,8 +2441,14 @@ def api_conversation_config_patch(conversation_id: str):
 
     # Enforce workspace containment: server clients must not direct the agent
     # outside the conversation's logdir (path traversal / SSRF via workspace).
-    if not request_config.workspace.is_relative_to(logdir):
-        return flask.jsonify({"error": "workspace escapes conversation logdir"}), 400
+    # Only enforce when workspace was explicitly provided — when absent, from_dict
+    # infers it from the existing logdir/workspace symlink (which may legitimately
+    # point outside logdir for CLI-created conversations).
+    if workspace_in_patch:
+        if not request_config.workspace.is_relative_to(logdir.resolve()):
+            return flask.jsonify(
+                {"error": "workspace escapes conversation logdir"}
+            ), 400
 
     try:
         chat_config = ChatConfig.load_or_create(logdir, request_config).save()

--- a/tests/test_server_config_workspace_containment.py
+++ b/tests/test_server_config_workspace_containment.py
@@ -1,0 +1,160 @@
+"""Tests for workspace path containment in server config endpoints.
+
+Covers the security fix for path traversal via client-supplied workspace in:
+- PUT /api/v2/conversations/<id>  (create conversation with config)
+- PATCH /api/v2/conversations/<id>/config  (update conversation config)
+
+Any workspace that escapes the conversation's logdir must be rejected with 400.
+"""
+
+from uuid import uuid4
+
+import pytest
+
+pytest.importorskip(
+    "flask", reason="flask not installed, install server extras (-E server)"
+)
+
+from flask.testing import FlaskClient  # fmt: skip
+
+pytestmark = [pytest.mark.timeout(15)]
+
+
+def _conv_id() -> str:
+    return f"test-ws-containment-{uuid4().hex[:8]}"
+
+
+class TestPutWorkspaceContainment:
+    """PUT /api/v2/conversations/<id> must reject workspaces outside logdir."""
+
+    def test_default_atlog_workspace_is_accepted(self, client: FlaskClient):
+        """No explicit workspace (defaults to @log) must succeed."""
+        resp = client.put(
+            f"/api/v2/conversations/{_conv_id()}",
+            json={"prompt": "none"},
+        )
+        assert resp.status_code == 200
+
+    def test_explicit_atlog_workspace_is_accepted(self, client: FlaskClient):
+        """Explicit @log workspace must succeed."""
+        resp = client.put(
+            f"/api/v2/conversations/{_conv_id()}",
+            json={"prompt": "none", "config": {"chat": {"workspace": "@log"}}},
+        )
+        assert resp.status_code == 200
+
+    def test_absolute_escape_is_rejected(self, client: FlaskClient):
+        """workspace pointing outside logdir (absolute path) must be 400."""
+        resp = client.put(
+            f"/api/v2/conversations/{_conv_id()}",
+            json={"prompt": "none", "config": {"chat": {"workspace": "/etc"}}},
+        )
+        assert resp.status_code == 400
+        data = resp.get_json()
+        assert "workspace" in data["error"].lower()
+
+    def test_absolute_tmp_escape_is_rejected(self, client: FlaskClient):
+        """workspace pointing to /tmp (outside logdir) must be 400."""
+        resp = client.put(
+            f"/api/v2/conversations/{_conv_id()}",
+            json={"prompt": "none", "config": {"chat": {"workspace": "/tmp/evil"}}},
+        )
+        assert resp.status_code == 400
+
+    def test_relative_escape_via_cwd_is_rejected(self, client: FlaskClient):
+        """Relative workspace that resolves outside logdir must be 400.
+
+        A bare relative path like '.' resolves to CWD (the server process
+        directory), which is almost certainly outside the logdir.
+        """
+        resp = client.put(
+            f"/api/v2/conversations/{_conv_id()}",
+            json={"prompt": "none", "config": {"chat": {"workspace": "."}}},
+        )
+        # The CWD of the test process is not within the logdir, so this should 400.
+        # (If by some coincidence CWD is a subdirectory of logdir, the test would
+        # incorrectly pass, but that cannot happen in practice.)
+        assert resp.status_code == 400
+
+    def test_no_conversation_created_on_escape(self, client: FlaskClient):
+        """Rejected workspace must not create the conversation (no side effects)."""
+        cid = _conv_id()
+        resp = client.put(
+            f"/api/v2/conversations/{cid}",
+            json={"prompt": "none", "config": {"chat": {"workspace": "/etc"}}},
+        )
+        assert resp.status_code == 400
+
+        # The conversation must not exist after the failed PUT
+        check = client.get(f"/api/v2/conversations/{cid}")
+        assert check.status_code == 404
+
+
+class TestPatchWorkspaceContainment:
+    """PATCH /api/v2/conversations/<id>/config must reject workspaces outside logdir."""
+
+    def _create_conv(self, client: FlaskClient) -> str:
+        cid = _conv_id()
+        resp = client.put(
+            f"/api/v2/conversations/{cid}",
+            json={"prompt": "none"},
+        )
+        assert resp.status_code == 200
+        return cid
+
+    def test_atlog_workspace_patch_is_accepted(self, client: FlaskClient):
+        """PATCH with @log workspace must succeed."""
+        cid = self._create_conv(client)
+        resp = client.patch(
+            f"/api/v2/conversations/{cid}/config",
+            json={"chat": {"workspace": "@log"}},
+        )
+        assert resp.status_code == 200
+
+    def test_absolute_escape_patch_is_rejected(self, client: FlaskClient):
+        """PATCH with workspace=/etc must be 400."""
+        cid = self._create_conv(client)
+        resp = client.patch(
+            f"/api/v2/conversations/{cid}/config",
+            json={"chat": {"workspace": "/etc"}},
+        )
+        assert resp.status_code == 400
+        data = resp.get_json()
+        assert "workspace" in data["error"].lower()
+
+    def test_absolute_tmp_escape_patch_is_rejected(self, client: FlaskClient):
+        """PATCH with workspace=/tmp/evil must be 400."""
+        cid = self._create_conv(client)
+        resp = client.patch(
+            f"/api/v2/conversations/{cid}/config",
+            json={"chat": {"workspace": "/tmp/evil"}},
+        )
+        assert resp.status_code == 400
+
+    def test_relative_escape_patch_is_rejected(self, client: FlaskClient):
+        """PATCH with relative workspace that resolves outside logdir must be 400."""
+        cid = self._create_conv(client)
+        resp = client.patch(
+            f"/api/v2/conversations/{cid}/config",
+            json={"chat": {"workspace": "."}},
+        )
+        assert resp.status_code == 400
+
+    def test_no_config_change_on_escape_patch(self, client: FlaskClient):
+        """A rejected workspace PATCH must not modify the existing config."""
+        cid = self._create_conv(client)
+
+        # Read the original workspace
+        orig = client.get(f"/api/v2/conversations/{cid}/config").get_json()
+        orig_workspace = orig.get("chat", {}).get("workspace")
+
+        # Attempt to escape
+        resp = client.patch(
+            f"/api/v2/conversations/{cid}/config",
+            json={"chat": {"workspace": "/etc"}},
+        )
+        assert resp.status_code == 400
+
+        # Config must be unchanged
+        after = client.get(f"/api/v2/conversations/{cid}/config").get_json()
+        assert after.get("chat", {}).get("workspace") == orig_workspace

--- a/tests/test_server_config_workspace_containment.py
+++ b/tests/test_server_config_workspace_containment.py
@@ -7,6 +7,8 @@ Covers the security fix for path traversal via client-supplied workspace in:
 Any workspace that escapes the conversation's logdir must be rejected with 400.
 """
 
+import shutil
+from pathlib import Path
 from uuid import uuid4
 
 import pytest
@@ -158,3 +160,57 @@ class TestPatchWorkspaceContainment:
         # Config must be unchanged
         after = client.get(f"/api/v2/conversations/{cid}/config").get_json()
         assert after.get("chat", {}).get("workspace") == orig_workspace
+
+
+class TestPatchWithoutWorkspaceKey:
+    """Regression: PATCH without 'workspace' key on conversation with
+    externally-set workspace should succeed (not block config updates).
+
+    When workspace is absent from the PATCH body, from_dict infers it from the
+    existing logdir/workspace path (which may legitimately point outside logdir
+    for CLI-created conversations). The containment check must only fire when
+    workspace was explicitly in the request body.
+    """
+
+    def _create_conv(self, client: FlaskClient) -> str:
+        cid = _conv_id()
+        resp = client.put(
+            f"/api/v2/conversations/{cid}",
+            json={"prompt": "none"},
+        )
+        assert resp.status_code == 200
+        return cid
+
+    def test_patch_without_workspace_succeeds_on_external_workspace(
+        self, client: FlaskClient
+    ):
+        """PATCH without workspace must succeed even when logdir/workspace
+        points outside logdir (simulating a CLI-created conversation)."""
+        cid = self._create_conv(client)
+
+        # Get the logdir path from the API response
+        conv = client.get(f"/api/v2/conversations/{cid}").get_json()
+        assert conv is not None
+        logdir = conv["logdir"]
+
+        # Create an external workspace directory
+        external_ws = Path("/tmp/test-external-ws-regression")
+        external_ws.mkdir(parents=True, exist_ok=True)
+
+        # Replace logdir/workspace with symlink pointing outside logdir
+        ws_path = Path(logdir) / "workspace"
+        if ws_path.is_dir():
+            shutil.rmtree(ws_path)
+        ws_path.symlink_to(str(external_ws))
+
+        # PATCH without workspace key → must succeed (200), not 400
+        resp = client.patch(
+            f"/api/v2/conversations/{cid}/config",
+            json={"chat": {"model": "gpt-4"}},
+        )
+        assert resp.status_code == 200, (
+            f"PATCH without workspace returned {resp.status_code}: {resp.get_json()}"
+        )
+
+        # Cleanup
+        shutil.rmtree(external_ws, ignore_errors=True)

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -36,7 +36,13 @@ def create_conversation(client: FlaskClient, config: ChatConfig | None = None):
     }
 
     if config:
-        json["config"] = config.to_dict()
+        config_dict = config.to_dict()
+        # Strip workspace from the serialized config: the server security check
+        # rejects external workspace paths (path traversal fix). Tests that pass
+        # a config only care about model/tools/system_prompt, not the workspace;
+        # the server will apply the safe @log default.
+        config_dict.get("chat", {}).pop("workspace", None)
+        json["config"] = config_dict
 
     response = client.put(
         f"/api/v2/conversations/{convname}",
@@ -1407,10 +1413,12 @@ def test_v2_create_conversation_default_system_prompt(
     )
 
     convname = f"test-server-v2-{random.randint(0, 1000000)}"
+    # Use the default @log workspace (workspace containment requires workspace
+    # to be inside the conversation logdir; external paths like tmp_path are
+    # rejected since the security fix for path traversal via config).
     response = client.put(
         f"/api/v2/conversations/{convname}",
         json={
-            "config": {"chat": {"workspace": str(tmp_path)}},
             "messages": [
                 {
                     "role": "user",
@@ -1422,6 +1430,14 @@ def test_v2_create_conversation_default_system_prompt(
     )
     assert response.status_code == 200
     conversation_id = response.get_json()["conversation_id"]
+
+    # Fetch the config to learn the actual resolved workspace path (@log -> logdir/workspace)
+    config_resp = client.get(f"/api/v2/conversations/{conversation_id}/config")
+    assert config_resp.status_code == 200
+    from gptme.config.chat import ChatConfig  # fmt: skip
+
+    conv_config = ChatConfig.from_dict(config_resp.get_json())
+    actual_workspace = conv_config.workspace
 
     response = client.get(f"/api/v2/conversations/{conversation_id}")
     assert response.status_code == 200
@@ -1443,7 +1459,7 @@ def test_v2_create_conversation_default_system_prompt(
         tool_format="markdown",
         model=None,
         prompt="full",
-        workspace=tmp_path,
+        workspace=actual_workspace,
     )
     assert data["log"][0]["content"] == prompt_msgs[0].content
 
@@ -1837,8 +1853,11 @@ def test_v2_chat_config_update_works(client: FlaskClient):
     ) == _normalize_config_for_comparison(input_config.to_dict())
 
     input_config.model = "openai/gpt-4o-mini"
+    updated_config_dict = input_config.to_dict()
+    # Strip workspace: server security check rejects external paths (path traversal fix).
+    updated_config_dict.get("chat", {}).pop("workspace", None)
     response = client.patch(
-        f"/api/v2/conversations/{conversation_id}/config", json=input_config.to_dict()
+        f"/api/v2/conversations/{conversation_id}/config", json=updated_config_dict
     )
     assert response.status_code == 200
 


### PR DESCRIPTION
## Summary

Closes #2938 — workspace path traversal via server config PATCH and PUT.

After resolving `chat.workspace` in both handlers, checks that the path is relative to the conversation's `logdir` before any side effects; returns 400 if it escapes. The default `@log` workspace (`logdir/workspace`) always passes; explicitly-supplied external absolute paths are blocked.

## What was the vulnerability

A client could PUT or PATCH a conversation config with `chat.workspace: "/etc/"` (or any absolute path), directing the server's LLM agent to operate in an arbitrary directory on the server filesystem.

## Fix surface

Containment enforced at the **server boundary only** (`api_v2.py`), not in `_coerce_config_path` (shared with CLI where external workspaces are legitimate).

Two insertion points:
- `api_conversation_put`: check after `ChatConfig.from_dict()`, before `logdir.mkdir()`
- `api_conversation_config_patch`: check after `ChatConfig.from_dict()`, before `load_or_create().save()`

Pattern reuses the existing containment idiom already present in the file at line 422-424.

## Tests

11 new regression tests in `tests/test_server_config_workspace_containment.py` covering:
- PUT/PATCH with `/etc` or `/tmp/evil` → 400
- PUT/PATCH with relative path resolving outside logdir → 400
- PUT/PATCH with `@log` (default) → 200
- No side effects on rejection (no conversation created, no config change)

Also updated existing tests that inadvertently sent the test-runner's CWD as workspace (correctly stripped before sending to server).