### PR TITLE
feat(webui): chat UI polish — role-aligned message footer + Chat-button sidebar toggle

### DIFF
--- a/webui/src/components/ChatMessage.tsx
+++ b/webui/src/components/ChatMessage.tsx
@@ -118,7 +118,7 @@ function MessageMetaLabel({
     <TooltipProvider>
       <Tooltip>
         <TooltipTrigger asChild>
-          <div className="h-0 select-none overflow-visible px-3 text-right text-[10px] leading-4 text-muted-foreground/50 opacity-0 transition-opacity group-hover/message:opacity-100">
+          <div className="flex select-none items-center whitespace-nowrap px-1.5 text-[10px] leading-4 text-muted-foreground/60">
             {shortLabel}
           </div>
         </TooltipTrigger>
@@ -583,9 +583,22 @@ const ChatMessageComponent: FC<Props> = ({
                   userName={api.userInfo$.name?.get()}
                 />
                 <div className={contentOffsetClasses$.get()}>
-                  <div className={`group/message relative ${messageClasses$.get()}`}>
-                    {/* Action buttons (top-right) */}
-                    <div className="absolute right-1 top-1 z-10 flex gap-0.5 opacity-0 transition-opacity hover:!opacity-100 group-hover/message:opacity-50">
+                  <div className={`group/message relative flex flex-col ${messageClasses$.get()}`}>
+                    {/* Per-message actions — rendered under the message (order-last),
+                        aligned left for assistant/system and right for user. */}
+                    <div
+                      className={`order-last flex max-h-0 items-center gap-0.5 overflow-hidden px-1 opacity-0 transition-all duration-150 group-hover/message:max-h-9 group-hover/message:opacity-100 ${
+                        message$.role.get() === 'user' ? 'flex-row-reverse self-end' : 'self-start'
+                      }`}
+                    >
+                      <Memo>
+                        {() => {
+                          const msg = message$.get() as Message;
+                          return (
+                            <MessageMetaLabel timestamp={msg?.timestamp} metadata={msg?.metadata} />
+                          );
+                        }}
+                      </Memo>
                       {onEdit &&
                         messageIndex !== undefined &&
                         message$.role.get() === 'user' &&
@@ -755,14 +768,6 @@ const ChatMessageComponent: FC<Props> = ({
                               </Button>
                             )}
                           </div>
-                        );
-                      }}
-                    </Memo>
-                    <Memo>
-                      {() => {
-                        const msg = message$.get() as Message;
-                        return (
-                          <MessageMetaLabel timestamp={msg?.timestamp} metadata={msg?.metadata} />
                         );
                       }}
                     </Memo>

--- a/webui/src/components/SidebarIcons.tsx
+++ b/webui/src/components/SidebarIcons.tsx
@@ -128,6 +128,7 @@ export const SidebarIcons: FC<Props> = ({ tasks }) => {
         {navItems.map(({ id, icon: Icon, label, section }) => {
           const isActive = currentSection === section;
           const badge = id === 'tasks' && activeTasks.length > 0 ? activeTasks.length : null;
+          const actionLabel = id === 'chat' && isActive ? 'Toggle conversations sidebar' : label;
 
           return (
             <TooltipProvider key={id}>
@@ -137,8 +138,9 @@ export const SidebarIcons: FC<Props> = ({ tasks }) => {
                     variant={isActive ? 'secondary' : 'ghost'}
                     className="relative h-8 w-full min-w-0 justify-start gap-2 px-2"
                     onClick={() => handleNavigateToSection(section)}
-                    aria-label={label}
+                    aria-label={actionLabel}
                     aria-current={isActive ? 'page' : undefined}
+                    data-testid={id === 'chat' ? 'toggle-conversations-sidebar' : undefined}
                   >
                     <Icon className="h-4 w-4 flex-shrink-0" />
                     <span
@@ -161,7 +163,7 @@ export const SidebarIcons: FC<Props> = ({ tasks }) => {
                     )}
                   </Button>
                 </TooltipTrigger>
-                {!isExpanded && <TooltipContent side="right">{label}</TooltipContent>}
+                {!isExpanded && <TooltipContent side="right">{actionLabel}</TooltipContent>}
               </Tooltip>
             </TooltipProvider>
           );

--- a/webui/src/components/SidebarIcons.tsx
+++ b/webui/src/components/SidebarIcons.tsx
@@ -2,8 +2,6 @@ import {
   MessageSquare,
   Kanban,
   History,
-  PanelLeftOpen,
-  PanelLeftClose,
   Settings,
   Bot,
   FolderOpen,
@@ -16,14 +14,13 @@ import {
 import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { useNavigate, useLocation } from 'react-router-dom';
-import { toggleLeftSidebarCollapsed, leftSidebarCollapsed$ } from '@/stores/sidebar';
+import { toggleLeftSidebarCollapsed } from '@/stores/sidebar';
 import { commandPaletteOpen$ } from '@/stores/commandPalette';
 import { SettingsModal } from './SettingsModal';
 import { useProviderHealth } from '@/hooks/useProviderHealth';
 import { allProvidersDown } from '@/stores/providerHealth';
 import type { Task } from '@/types/task';
 import type { FC } from 'react';
-import { use$ } from '@legendapp/state/react';
 import { useState, useEffect } from 'react';
 
 const NAV_SIDEBAR_KEY = 'nav-sidebar-expanded';
@@ -42,7 +39,6 @@ interface Props {
 export const SidebarIcons: FC<Props> = ({ tasks }) => {
   const navigate = useNavigate();
   const location = useLocation();
-  const isConversationPanelCollapsed = use$(leftSidebarCollapsed$);
 
   // User's manual preference for nav sidebar expansion
   const [prefExpanded, setPrefExpanded] = useState<boolean>(() => {
@@ -96,6 +92,12 @@ export const SidebarIcons: FC<Props> = ({ tasks }) => {
   const handleNavigateToSection = (
     section: 'chat' | 'tasks' | 'history' | 'agents' | 'workspaces' | 'external-sessions' | 'admin'
   ) => {
+    // Clicking the already-active Chat button toggles the conversation sidebar
+    // (VS Code activity-bar pattern) instead of being a no-op re-navigation.
+    if (section === 'chat' && currentSection === 'chat') {
+      toggleLeftSidebarCollapsed();
+      return;
+    }
     navigate(`/${section === 'chat' ? 'chat' : section}`);
   };
 
@@ -262,41 +264,6 @@ export const SidebarIcons: FC<Props> = ({ tasks }) => {
               )}
             </TooltipTrigger>
             {!isExpanded && <TooltipContent side="right">Settings</TooltipContent>}
-          </Tooltip>
-        </TooltipProvider>
-      </div>
-
-      {/* Conversation panel toggle */}
-      <div className="flex-shrink-0 p-1">
-        <TooltipProvider>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                className="h-8 w-full min-w-0 justify-start gap-2 px-2"
-                onClick={toggleLeftSidebarCollapsed}
-                data-testid="toggle-conversations-sidebar"
-                aria-label={isConversationPanelCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
-              >
-                {isConversationPanelCollapsed ? (
-                  <PanelLeftOpen className="h-4 w-4 flex-shrink-0" />
-                ) : (
-                  <PanelLeftClose className="h-4 w-4 flex-shrink-0" />
-                )}
-                <span
-                  className={`min-w-0 flex-1 truncate text-left text-sm transition-opacity duration-150 ${
-                    isExpanded ? 'opacity-100' : 'opacity-0'
-                  }`}
-                >
-                  {isConversationPanelCollapsed ? 'Show Chats' : 'Hide Chats'}
-                </span>
-              </Button>
-            </TooltipTrigger>
-            {!isExpanded && (
-              <TooltipContent side="right">
-                {isConversationPanelCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
-              </TooltipContent>
-            )}
           </Tooltip>
         </TooltipProvider>
       </div>

--- a/webui/src/components/__tests__/SidebarIcons.test.tsx
+++ b/webui/src/components/__tests__/SidebarIcons.test.tsx
@@ -74,7 +74,10 @@ describe('SidebarIcons', () => {
 
   it('renders navigation items', () => {
     renderSidebar();
-    expect(screen.getByRole('button', { name: /chat/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /toggle conversations sidebar/i })
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('toggle-conversations-sidebar')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /agents/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /tasks/i })).toBeInTheDocument();
   });
@@ -153,7 +156,9 @@ describe('SidebarIcons', () => {
 
   it('shows labels (non-zero opacity) when expanded', () => {
     renderSidebar();
-    const chatLabel = screen.getByRole('button', { name: /^chat$/i }).querySelector('span.flex-1');
+    const chatLabel = screen
+      .getByTestId('toggle-conversations-sidebar')
+      .querySelector('span.flex-1');
     expect(chatLabel).toHaveClass('opacity-100');
   });
 
@@ -178,7 +183,9 @@ describe('SidebarIcons', () => {
   it('hides labels (zero opacity) when collapsed', () => {
     mockLocalStorage.setItem('nav-sidebar-expanded', 'false');
     renderSidebar();
-    const chatLabel = screen.getByRole('button', { name: /^chat$/i }).querySelector('span.flex-1');
+    const chatLabel = screen
+      .getByTestId('toggle-conversations-sidebar')
+      .querySelector('span.flex-1');
     expect(chatLabel).toHaveClass('opacity-0');
   });
 });


### PR DESCRIPTION
## Summary

Two independent chat-UI/navigation polish changes (both off master):

### 1. Role-aligned message footer
Moves per-message actions and the timestamp/metadata label out of the top-right hover overlay into a single **footer row under each message**:
- **Assistant/system**: aligned left
- **User**: aligned right (mirrored via `flex-row-reverse`)

Reveals on hover via a max-height transition, so it reserves no vertical space when idle.

### 2. Chat-button sidebar toggle
Clicking the already-active **Chat** nav button now toggles the conversation sidebar (VS Code activity-bar pattern), instead of being a no-op re-navigation. Removes the standalone "Hide/Show Chats" button, which showed on every route and was a no-op off the chat view.

## Why

Design feedback: the old action/timestamp overlay didn't read as a coherent footer or align per role; and the "Hide/Show Chats" button was confusing (always visible, no-op off chat).

## Notes

- Branch off master, independent of code-block PR #2945.
- Still open in follow-ups: avatar alignment fine-tuning; demo/showcase rework.

## Test plan

- `npm run typecheck` clean.
- Verified on the running dev instance: hover footers (assistant left / user right); Chat button collapses/expands the conversation panel; standalone toggle removed.