### PR TITLE
feat(subagent): add redact_secrets option for context isolation

### DIFF
--- a/gptme/tools/subagent/context.py
+++ b/gptme/tools/subagent/context.py
@@ -38,33 +38,6 @@ _COLON_ASSIGN_RE = re.compile(
     re.MULTILINE,
 )
 
-# Pattern for YAML/TOML colon-style assignments (key: value)
-_COLON_ASSIGN_RE = re.compile(
-    r"""(?ix)
-    ^(\s*)                                    # group 1: optional leading whitespace
-    (                                         # group 2: variable name with secret keyword
-        [\w\-]*?
-        (?:
-            api[-_]?key|apikey
-            |token
-            |secret
-            |password|passwd
-            |private[-_]key|privkey
-            |auth[-_]?(?:key|token)
-            |access[-_]key
-            |credential
-        )
-        [\w\-]*
-    )
-    (\s*:\s*)                                 # group 3: colon separator
-    (["']?)                                   # group 4: optional opening quote
-    (.+?)                                     # group 5: the value
-    (["']?)                                   # group 6: optional closing quote
-    (\s*)$                                    # group 7: trailing whitespace
-    """,
-    re.MULTILINE,
-)
-
 # Simpler pattern for export statements and env-var assignment lines
 _ENV_ASSIGN_RE = re.compile(
     r"""(?ix)

--- a/gptme/tools/subagent/context.py
+++ b/gptme/tools/subagent/context.py
@@ -38,6 +38,33 @@ _COLON_ASSIGN_RE = re.compile(
     re.MULTILINE,
 )
 
+# Pattern for YAML/TOML colon-style assignments (key: value)
+_COLON_ASSIGN_RE = re.compile(
+    r"""(?ix)
+    ^(\s*)                                    # group 1: optional leading whitespace
+    (                                         # group 2: variable name with secret keyword
+        [\w\-]*?
+        (?:
+            api[-_]?key|apikey
+            |token
+            |secret
+            |password|passwd
+            |private[-_]key|privkey
+            |auth[-_]?(?:key|token)
+            |access[-_]key
+            |credential
+        )
+        [\w\-]*
+    )
+    (\s*:\s*)                                 # group 3: colon separator
+    (["']?)                                   # group 4: optional opening quote
+    (.+?)                                     # group 5: the value
+    (["']?)                                   # group 6: optional closing quote
+    (\s*)$                                    # group 7: trailing whitespace
+    """,
+    re.MULTILINE,
+)
+
 # Simpler pattern for export statements and env-var assignment lines
 _ENV_ASSIGN_RE = re.compile(
     r"""(?ix)

--- a/gptme/tools/subagent/execution.py
+++ b/gptme/tools/subagent/execution.py
@@ -537,6 +537,7 @@ def _run_planner(
     context_include: list[str] | None = None,
     model: str | None = None,
     profile_name: str | None = None,
+    redact_secrets: bool = False,
 ) -> None:
     """Run a planner that delegates work to multiple executor subagents.
 
@@ -549,6 +550,9 @@ def _run_planner(
         context_include: For selective mode, list of context components to include
         profile_name: Agent profile to apply to executor subagents (per-subtask role
             always overrides this when set — subtask role is more specific)
+        redact_secrets: If True, scrub secret patterns from workspace context before
+            thread-mode executors see it. Has no effect on subprocess-mode executors
+            (which manage their own context); a warning is logged in that case.
     """
     from gptme.cli.main import get_logdir
 
@@ -642,6 +646,11 @@ def _run_planner(
                 )
 
         if resolved_use_subprocess:
+            if redact_secrets:
+                logger.warning(
+                    f"Planner executor {executor_id}: 'redact_secrets=True' has no effect "
+                    "in subprocess mode (only thread-mode subagents inherit workspace context)"
+                )
             sa = Subagent(
                 executor_id,
                 executor_prompt,
@@ -766,6 +775,7 @@ def _run_planner(
                         target="planner",
                         profile_name=subtask_profile,
                         agent_id=executor_agent_id,
+                        redact_secrets=redact_secrets,
                     )
                 finally:
                     try:

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -1560,3 +1560,112 @@ class TestRedactSecretsColonStyle:
         assert "[REDACTED]" in result
         assert "host: localhost" in result
         assert "port: 5432" in result
+
+
+class TestRedactSecretsNonThreadWarning:
+    """Tests for redact_secrets=True warning when used in non-thread modes."""
+
+    def test_warns_when_redact_secrets_in_subprocess_mode(
+        self, monkeypatch, tmp_path, caplog
+    ):
+        """redact_secrets=True with use_subprocess=True logs a warning."""
+        import importlib
+        import logging
+
+        cli_main = importlib.import_module("gptme.cli.main")
+        llm_models = importlib.import_module("gptme.llm.models")
+        profiles = importlib.import_module("gptme.profiles")
+        git_worktree = importlib.import_module("gptme.util.git_worktree")
+
+        monkeypatch.setattr(cli_main, "get_logdir", lambda name: tmp_path / name)
+        monkeypatch.setattr(llm_models, "get_default_model", lambda: None)
+        monkeypatch.setattr(profiles, "get_profile", lambda _: None)
+        monkeypatch.setattr(git_worktree, "get_git_root", lambda _: None)
+        monkeypatch.setattr(
+            subagent_api._exec,
+            "_run_subagent_subprocess",
+            MagicMock(return_value=MagicMock()),
+        )
+        monkeypatch.setattr(subagent_api._exec, "_monitor_subprocess", lambda sa: None)
+
+        with caplog.at_level(logging.WARNING, logger="gptme.tools.subagent.api"):
+            subagent(
+                "warn-proc-agent",
+                "do the thing",
+                use_subprocess=True,
+                redact_secrets=True,
+            )
+
+        with _subagents_lock:
+            sa = next((s for s in _subagents if s.agent_id == "warn-proc-agent"), None)
+        if sa and sa.thread:
+            sa.thread.join(timeout=2)
+
+        assert any(
+            "redact_secrets=True" in record.message and "subprocess" in record.message
+            for record in caplog.records
+        ), f"Expected warning not found in: {[r.message for r in caplog.records]}"
+
+
+class TestRedactSecretsThreadExecution:
+    """Tests that redact_secrets_from_messages is called in thread-mode execution."""
+
+    def test_redact_secrets_calls_redaction_on_initial_msgs(
+        self, monkeypatch, tmp_path
+    ):
+        """_create_subagent_thread with redact_secrets=True calls redact_secrets_from_messages."""
+        import importlib
+
+        from gptme.message import Message
+
+        gptme_chat = importlib.import_module("gptme.chat")
+        gptme_executor = importlib.import_module("gptme.executor")
+        gptme_llm_models = importlib.import_module("gptme.llm.models")
+        gptme_profiles = importlib.import_module("gptme.profiles")
+        gptme_prompts = importlib.import_module("gptme.prompts")
+        hooks_mod = importlib.import_module("gptme.tools.subagent.hooks")
+        context_mod = importlib.import_module("gptme.tools.subagent.context")
+        exec_mod = importlib.import_module("gptme.tools.subagent.execution")
+
+        test_msgs = [Message("system", "API_KEY=supersecret\nHOST=localhost\n")]
+        redacted_msgs = [Message("system", "API_KEY=[REDACTED]\nHOST=localhost\n")]
+        redact_called_with: list = []
+
+        def mock_redact(msgs):
+            redact_called_with.extend(msgs)
+            return redacted_msgs
+
+        monkeypatch.setattr(gptme_chat, "chat", lambda *args, **kwargs: None)
+        monkeypatch.setattr(
+            gptme_executor,
+            "prepare_execution_environment",
+            lambda **kwargs: None,
+        )
+        monkeypatch.setattr(gptme_llm_models, "set_default_model", lambda *args: None)
+        monkeypatch.setattr(gptme_profiles, "get_profile", lambda _: None)
+        monkeypatch.setattr(
+            gptme_prompts, "get_prompt", lambda *args, **kwargs: list(test_msgs)
+        )
+        monkeypatch.setattr(
+            hooks_mod,
+            "_get_complete_instruction",
+            lambda *args, **kwargs: "done",
+        )
+        monkeypatch.setattr(context_mod, "redact_secrets_from_messages", mock_redact)
+        monkeypatch.setattr(
+            exec_mod, "_ensure_subagent_signal_tools_loaded", lambda: None
+        )
+        monkeypatch.setattr(exec_mod, "get_tools", lambda: [])
+
+        exec_mod._create_subagent_thread(
+            prompt="do the thing",
+            logdir=tmp_path / "logdir",
+            model=None,
+            context_mode="full",
+            context_include=None,
+            workspace=tmp_path,
+            redact_secrets=True,
+        )
+
+        assert redact_called_with, "redact_secrets_from_messages was not called"
+        assert any("supersecret" in msg.content for msg in redact_called_with)

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -1669,3 +1669,100 @@ class TestRedactSecretsThreadExecution:
 
         assert redact_called_with, "redact_secrets_from_messages was not called"
         assert any("supersecret" in msg.content for msg in redact_called_with)
+
+
+class TestPlannerRedactSecrets:
+    """Tests that _run_planner forwards redact_secrets to thread-mode executors."""
+
+    def test_planner_forwards_redact_secrets_to_thread_executors(
+        self, monkeypatch, tmp_path
+    ):
+        """_run_planner with redact_secrets=True passes it to _create_subagent_thread."""
+        import importlib
+
+        cli_main = importlib.import_module("gptme.cli.main")
+        exec_mod = importlib.import_module("gptme.tools.subagent.execution")
+        types_mod = importlib.import_module("gptme.tools.subagent.types")
+
+        monkeypatch.setattr(cli_main, "get_logdir", lambda name: tmp_path / name)
+
+        captured_kwargs: list[dict] = []
+
+        def fake_create_subagent_thread(**kwargs):
+            captured_kwargs.append(kwargs)
+
+        monkeypatch.setattr(
+            exec_mod, "_create_subagent_thread", fake_create_subagent_thread
+        )
+
+        exec_mod._run_planner(
+            agent_id="planner-test",
+            prompt="orchestrate this",
+            subtasks=[{"id": "task1", "description": "do part 1"}],
+            execution_mode="sequential",
+            redact_secrets=True,
+        )
+
+        import time
+
+        time.sleep(0.05)
+
+        assert captured_kwargs, "_create_subagent_thread was never called"
+        assert captured_kwargs[0].get("redact_secrets") is True, (
+            "redact_secrets not forwarded to _create_subagent_thread"
+        )
+
+        with types_mod._subagents_lock:
+            types_mod._subagents[:] = [
+                s
+                for s in types_mod._subagents
+                if not s.agent_id.startswith("planner-test")
+            ]
+
+    def test_planner_warns_redact_secrets_in_subprocess_executor(
+        self, monkeypatch, tmp_path, caplog
+    ):
+        """_run_planner with redact_secrets=True warns when executor uses subprocess."""
+        import importlib
+        import logging
+
+        cli_main = importlib.import_module("gptme.cli.main")
+        exec_mod = importlib.import_module("gptme.tools.subagent.execution")
+        types_mod = importlib.import_module("gptme.tools.subagent.types")
+        git_worktree = importlib.import_module("gptme.util.git_worktree")
+
+        monkeypatch.setattr(cli_main, "get_logdir", lambda name: tmp_path / name)
+        monkeypatch.setattr(git_worktree, "get_git_root", lambda _: None)
+        monkeypatch.setattr(
+            exec_mod,
+            "_run_subagent_subprocess",
+            MagicMock(return_value=MagicMock()),
+        )
+        monkeypatch.setattr(exec_mod, "_monitor_subprocess", lambda sa: None)
+
+        with caplog.at_level(logging.WARNING, logger="gptme.tools.subagent.execution"):
+            exec_mod._run_planner(
+                agent_id="planner-warn",
+                prompt="orchestrate",
+                subtasks=[
+                    {"id": "verify1", "description": "verify it", "role": "verify"}
+                ],
+                execution_mode="sequential",
+                redact_secrets=True,
+            )
+
+        import time
+
+        time.sleep(0.05)
+
+        assert any(
+            "redact_secrets=True" in record.message and "subprocess" in record.message
+            for record in caplog.records
+        ), f"Expected warning not found in: {[r.message for r in caplog.records]}"
+
+        with types_mod._subagents_lock:
+            types_mod._subagents[:] = [
+                s
+                for s in types_mod._subagents
+                if not s.agent_id.startswith("planner-warn")
+            ]


### PR DESCRIPTION
## Summary

Fixes #2949 — subagent context isolation: secrets in workspace context.

Key clarification from code review: **subagents do NOT inherit parent conversation history** — they start fresh. What they *do* inherit (in `context_mode="full"`) is workspace context: files listed in `gptme.toml [prompt] files` and `context_cmd` output. If those contain secrets (API keys, tokens, passwords), they reach the subagent.

### Changes

- **New `redact_secrets=True` parameter** on `subagent()`: scrubs common secret patterns from workspace context messages before the subagent sees them. Patterns: variable names matching `API_KEY`, `TOKEN`, `PASSWORD`, `PRIVATE_KEY`, `AUTH_KEY`, `ACCESS_KEY`, `CREDENTIAL`. The key name and separator are preserved; only the value becomes `[REDACTED]`.
- **New `gptme/tools/subagent/context.py`**: `redact_secrets_from_text()` and `redact_secrets_from_messages()` utilities.
- **Updated `instructions` string**: adds a "Context Isolation" section documenting exactly what subagents do and don't inherit — so users understand the model without reading source code.
- **15 new unit tests** covering redaction of API keys, tokens, passwords, export statements, multi-line content, and `redact_secrets_from_messages()`.

### Usage

```python
# Sanitize workspace context before passing to subagent
subagent("analyzer", "Analyze the codebase", redact_secrets=True)

# For stronger isolation (no workspace files at all):
subagent("analyzer", "...", context_mode="selective", context_include=["agent"])
```

### What is and isn't fixed

| Concern from issue | Status |
|---|---|
| "full history" leaked to subagent | Already not true — subagents start fresh |
| Secrets in workspace config files/context_cmd | Fixed by `redact_secrets=True` |
| Workspace boundary ambiguity | Documented in instructions string |
| Subprocess/ACP context isolation | Subprocess already runs as separate process; no change needed |

## Test plan

- [x] `uv run python -m pytest tests/test_subagent_unit.py` — all 88 tests pass
- [x] New tests: `TestRedactSecretsFromText` (10 cases) + `TestRedactSecretsFromMessages` (5 cases)
- [x] Pre-commit hooks pass (ruff, mypy)