### PR TITLE
fix(cli): make tokens count --file - read from stdin

### DIFF
--- a/gptme/cli/util.py
+++ b/gptme/cli/util.py
@@ -265,17 +265,20 @@ def tokens():
 @click.option(
     "-f",
     "--file",
-    type=click.Path(exists=True, dir_okay=False),
-    help="File to count tokens in.",
+    type=click.Path(exists=True, dir_okay=False, allow_dash=True),
+    help="File to count tokens in. Use '-' to read from stdin.",
 )
 def tokens_count(text: str | None, model: str, file: str | None):
     """Count tokens in text or file."""
     import tiktoken  # fmt: skip
 
-    # Get text from file if specified
+    # Get text from file if specified (or stdin via "-")
     if file:
-        with open(file) as f:
-            text = f.read()
+        if file == "-":
+            text = sys.stdin.read()
+        else:
+            with open(file) as f:
+                text = f.read()
     elif text == "-":
         text = sys.stdin.read()
 

--- a/tests/test_tools_computer.py
+++ b/tests/test_tools_computer.py
@@ -1146,7 +1146,8 @@ def test_wait_for_change_timeout_returns_screenshot(mock_transport, mock_res, tm
         mock.patch("gptme.tools.computer.screenshot", return_value=static),
         mock.patch("gptme.tools.computer.time.sleep"),
         mock.patch(
-            "gptme.tools.computer.time.monotonic", side_effect=[0.0, 0.0, 100.0]
+            "gptme.tools.computer.time.monotonic",
+            side_effect=iter([0.0, 0.0, 100.0] + [100.0] * 20),
         ),
         mock.patch(
             "gptme.tools.computer._make_screenshot_msg",

--- a/tests/test_tools_computer.py
+++ b/tests/test_tools_computer.py
@@ -1142,12 +1142,19 @@ def test_wait_for_change_timeout_returns_screenshot(mock_transport, mock_res, tm
     static = tmp_path / "static.png"
     Image.new("RGB", (100, 100), (42, 42, 42)).save(static)
 
+    call_count = {"count": 0}
+
+    def monotonic_side_effect():
+        call_count["count"] += 1
+        if call_count["count"] <= 2:
+            return 0.0
+        return 100.0
+
     with (
         mock.patch("gptme.tools.computer.screenshot", return_value=static),
         mock.patch("gptme.tools.computer.time.sleep"),
         mock.patch(
-            "gptme.tools.computer.time.monotonic",
-            side_effect=iter([0.0, 0.0, 100.0] + [100.0] * 20),
+            "gptme.tools.computer.time.monotonic", side_effect=monotonic_side_effect
         ),
         mock.patch(
             "gptme.tools.computer._make_screenshot_msg",

--- a/tests/test_util_cli.py
+++ b/tests/test_util_cli.py
@@ -58,6 +58,25 @@ def test_tokens_count(tmp_path):
     assert result.exception is None or isinstance(result.exception, SystemExit)
     assert "is a directory" in result.output.lower()
 
+    # Test `--file -` reads from stdin (Unix convention: '-' as file = stdin).
+    # Regression: prior to allow_dash=True on --file, this failed with
+    # click.Path validation ("File '-' does not exist") even though the
+    # error message advertised '-' for stdin.
+    result = runner.invoke(
+        main, ["tokens", "count", "-f", "-"], input="stdin via file flag"
+    )
+    assert result.exit_code == 0
+    assert "Token count" in result.output
+    count = int(result.output.split(": ", 1)[1].strip())
+    assert count > 1
+
+    # Test `--file -` with empty stdin: should still error with the same
+    # "No text provided" path, not crash with click validation or
+    # FileNotFoundError.
+    result = runner.invoke(main, ["tokens", "count", "-f", "-"], input="")
+    assert result.exit_code == 1
+    assert "No text provided" in result.output
+
 
 def test_chats_list(tmp_path, mocker):
     """Test the chats list command."""


### PR DESCRIPTION
## Problem

`gptme-util tokens count` advertises `'-\'` as a way to read from stdin
in its error message ("Use --file, a text argument, or '-' to read from
stdin."), but `--file -` rejects it because `click.Path(exists=True)`
treats `-` as a non-existent path:

```
$ echo "hello stdin" | gptme-util tokens count --file -
Usage: gptme-util tokens count [OPTIONS] [TEXT]
Try 'gptme-util tokens count --help' for help.

Error: Invalid value for '-f' / '--file': File '-' does not exist.
```

The positional argument form `gptme-util tokens count - <stdin>` happens to
work because `text == "-"` is checked after click parses it, but the
`--file` flag is broken in the exact case the error message steers users
toward.

## Fix

Pass `allow_dash=True` to `click.Path` so click skips the existence check
for `-`, then handle `-` in the function body by reading stdin. Keeping
`exists=True` preserves the standard click validation for nonexistent
paths and directories (exit code 2, usage error).

## Tests

Added two cases to `test_tokens_count`:

1. `--file -` with stdin → reads stdin, counts tokens (exit 0)
2. `--file -` with empty stdin → still errors with "No text provided" (exit 1)

Full `tests/test_util_cli.py` suite (45 tests) passes.

## Why a small change

Surfaced during a dogfood pass on the gptme CLI surface — the top-level CLI
itself was the focus area (flag parsing, --model/--tool/--tools, conversation
path/name handling, resume, non-interactive -n). The `tokens count` error
message was the only inconsistency between doc/UX and behavior found.