### PR TITLE
fix(server): prevent external-sessions endpoint from hanging on large session catalogs

### DIFF
--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -886,7 +886,7 @@ def api_dev_deploy_staging_trigger():
         {
             "name": "days",
             "in": "query",
-            "schema": {"type": "integer", "default": 30},
+            "schema": {"type": "integer", "default": 7},
             "description": "How many recent days of session history to scan",
         },
     ],
@@ -899,7 +899,7 @@ def api_external_sessions():
 
     try:
         limit = int(request.args.get("limit", 100))
-        days = int(request.args.get("days", 30))
+        days = int(request.args.get("days", 7))
     except (ValueError, TypeError):
         return flask.jsonify({"error": "limit and days must be integers"}), 400
 
@@ -908,7 +908,7 @@ def api_external_sessions():
     limit = min(limit, 1000)
     if days <= 0:
         return flask.jsonify({"error": "days must be a positive integer"}), 400
-    days = min(days, 3650)
+    days = min(days, 365)
 
     sessions = [
         item.to_dict() for item in provider.list_sessions(limit=limit, days=days)
@@ -932,7 +932,7 @@ def api_external_sessions():
         {
             "name": "days",
             "in": "query",
-            "schema": {"type": "integer", "default": 30},
+            "schema": {"type": "integer", "default": 7},
             "description": "How many recent days of session history to scan",
         },
     ],
@@ -940,12 +940,12 @@ def api_external_sessions():
 def api_external_session(external_session_id: str):
     """Get a normalized read-only external session transcript."""
     try:
-        days = int(request.args.get("days", 30))
+        days = int(request.args.get("days", 7))
     except (ValueError, TypeError):
         return flask.jsonify({"error": "days must be an integer"}), 400
     if days <= 0:
         return flask.jsonify({"error": "days must be a positive integer"}), 400
-    days = min(days, 3650)
+    days = min(days, 365)
 
     provider = get_external_session_provider()
     if provider is None:

--- a/gptme/server/external_sessions.py
+++ b/gptme/server/external_sessions.py
@@ -6,6 +6,7 @@ import functools
 import hashlib
 import json
 import logging
+import os
 import shutil
 import subprocess
 from dataclasses import dataclass
@@ -120,17 +121,26 @@ class ExternalSessionProvider:
         self, limit: int = 100, days: int = 30
     ) -> list[ExternalSessionCatalogItem]:
         items: list[ExternalSessionCatalogItem] = []
-        for path in self._discover_paths(days):
+        # Cap discovery to avoid scanning thousands of sessions when we only
+        # need `limit` results. Sort recently-active paths first so the most
+        # relevant sessions appear even under the cap.
+        paths = self._discover_paths(days)
+        paths.sort(key=lambda p: p.stat().st_mtime if p.exists() else 0, reverse=True)
+
+        # Process at most limit * 3 paths to allow for unreadable/failed
+        # transcripts while still hitting the target count. This prevents
+        # the endpoint from hanging when there are 30k+ sessions on disk.
+        max_paths = max(limit * 3, 500)
+        for path in paths[:max_paths]:
             try:
                 transcript = self._read_transcript(path).to_dict()
                 items.append(
                     ExternalSessionCatalogItem.from_transcript_dict(transcript)
                 )
             except Exception:
-                logger.warning(
+                logger.debug(
                     "Skipping unreadable external session transcript during catalog listing: %s",
                     path,
-                    exc_info=True,
                 )
 
         items.sort(
@@ -139,7 +149,11 @@ class ExternalSessionProvider:
         return items[:limit]
 
     def get_session(self, external_id: str, days: int = 30) -> dict | None:
-        for path in self._discover_paths(days):
+        paths = self._discover_paths(days)
+        # Cap the scan to avoid 30k+ transcript reads for a single ID
+        # lookup when the session doesn't exist.
+        max_scan = 2000
+        for path in paths[:max_scan]:
             path_str = str(path)
             if _make_external_session_id(path_str) != external_id:
                 continue
@@ -218,7 +232,7 @@ class CLIExternalSessionProvider:
 
     def _read_transcript_cli(self, path: str) -> dict | None:
         """Read a transcript via CLI, returning the full JSON dict."""
-        output = self._run_cli(["transcript", str(path), "--json"], timeout=30)
+        output = self._run_cli(["transcript", str(path), "--json"], timeout=10)
         if not output:
             return None
         try:
@@ -231,7 +245,28 @@ class CLIExternalSessionProvider:
         self, limit: int = 100, days: int = 30
     ) -> list[ExternalSessionCatalogItem]:
         items: list[ExternalSessionCatalogItem] = []
-        for session in self._discover_paths(days):
+        sessions = self._discover_paths(days)
+
+        # Sort by mtime descending (most recent first) so the most relevant
+        # sessions are processed early under the cap. Fall back to path order
+        # when mtime is unavailable.
+        try:
+            sessions.sort(
+                key=lambda s: (
+                    os.path.getmtime(str(s.get("path", "")))
+                    if s.get("path") and os.path.exists(str(s["path"]))
+                    else 0
+                ),
+                reverse=True,
+            )
+        except Exception:
+            pass
+
+        # Cap the number of sessions we process to avoid hanging on 30k+ sessions.
+        # Process at most limit * 3 paths to allow for unreadable transcripts
+        # while still hitting the target count.
+        max_paths = max(limit * 3, 500)
+        for session in sessions[:max_paths]:
             path = session.get("path")
             if not path:
                 continue
@@ -243,10 +278,9 @@ class CLIExternalSessionProvider:
                     ExternalSessionCatalogItem.from_transcript_dict(transcript)
                 )
             except Exception:
-                logger.warning(
+                logger.debug(
                     "Skipping unreadable external session transcript (CLI) during catalog listing: %s",
                     path,
-                    exc_info=True,
                 )
 
         items.sort(
@@ -255,7 +289,11 @@ class CLIExternalSessionProvider:
         return items[:limit]
 
     def get_session(self, external_id: str, days: int = 30) -> dict | None:
-        for session in self._discover_paths(days):
+        sessions = self._discover_paths(days)
+        # Cap the scan to avoid 30k+ subprocess calls for a single ID
+        # lookup when the session doesn't exist (worst case: 30s timeout × N).
+        max_scan = 2000
+        for session in sessions[:max_scan]:
             path = session.get("path")
             if not path:
                 continue

--- a/gptme/server/external_sessions.py
+++ b/gptme/server/external_sessions.py
@@ -255,6 +255,17 @@ class CLIExternalSessionProvider:
             logger.warning("Failed to parse transcript JSON for %s", path)
             return None
 
+    @staticmethod
+    def _cli_mtime(s: dict) -> float:
+        """Get mtime from a session dict, returning 0 on any filesystem error."""
+        path = s.get("path")
+        if not path:
+            return 0
+        try:
+            return os.path.getmtime(str(path))
+        except OSError:
+            return 0
+
     def list_sessions(
         self, limit: int = 100, days: int = 30
     ) -> list[ExternalSessionCatalogItem]:
@@ -262,19 +273,9 @@ class CLIExternalSessionProvider:
         sessions = self._discover_paths(days)
 
         # Sort by mtime descending (most recent first) so the most relevant
-        # sessions are processed early under the cap. Fall back to path order
-        # when mtime is unavailable.
-        try:
-            sessions.sort(
-                key=lambda s: (
-                    os.path.getmtime(str(s.get("path", "")))
-                    if s.get("path") and os.path.exists(str(s["path"]))
-                    else 0
-                ),
-                reverse=True,
-            )
-        except OSError:
-            pass
+        # sessions are processed early under the cap. _cli_mtime handles
+        # missing files internally so the sort always completes.
+        sessions.sort(key=self._cli_mtime, reverse=True)
 
         # Cap the number of sessions we process to avoid hanging on 30k+ sessions.
         # Process at most limit * 3 paths to allow for unreadable transcripts
@@ -309,17 +310,7 @@ class CLIExternalSessionProvider:
         # visible in catalog results are also reachable by ID lookup. Without
         # this sort, a recently-active session at deep path order would appear
         # in list_sessions() results but 404 from get_session().
-        try:
-            sessions.sort(
-                key=lambda s: (
-                    os.path.getmtime(str(s.get("path", "")))
-                    if s.get("path") and os.path.exists(str(s["path"]))
-                    else 0
-                ),
-                reverse=True,
-            )
-        except OSError:
-            pass
+        sessions.sort(key=self._cli_mtime, reverse=True)
 
         # Cap the scan to avoid 30k+ subprocess calls for a single ID
         # lookup when the session doesn't exist (worst case: 30s timeout × N).

--- a/gptme/server/external_sessions.py
+++ b/gptme/server/external_sessions.py
@@ -125,7 +125,7 @@ class ExternalSessionProvider:
         # need `limit` results. Sort recently-active paths first so the most
         # relevant sessions appear even under the cap.
         paths = self._discover_paths(days)
-        paths.sort(key=lambda p: p.stat().st_mtime if p.exists() else 0, reverse=True)
+        paths.sort(key=self._mtime, reverse=True)
 
         # Process at most limit * 3 paths to allow for unreadable/failed
         # transcripts while still hitting the target count. This prevents
@@ -148,8 +148,22 @@ class ExternalSessionProvider:
         )
         return items[:limit]
 
+    @staticmethod
+    def _mtime(path: Path) -> float:
+        """Get mtime of a Path, returning 0 on any filesystem error."""
+        try:
+            return path.stat().st_mtime
+        except OSError:
+            return 0
+
     def get_session(self, external_id: str, days: int = 30) -> dict | None:
         paths = self._discover_paths(days)
+        # Sort paths by mtime (most recent first) before capping, so that
+        # sessions found by list_sessions() (which also sorts by mtime) are
+        # reachable by ID lookup. Without this sort, a recently-active session
+        # that lives deep in unsorted path order would 404 from get_session()
+        # while appearing in list_sessions() results.
+        paths.sort(key=self._mtime, reverse=True)
         # Cap the scan to avoid 30k+ transcript reads for a single ID
         # lookup when the session doesn't exist.
         max_scan = 2000
@@ -259,7 +273,7 @@ class CLIExternalSessionProvider:
                 ),
                 reverse=True,
             )
-        except Exception:
+        except OSError:
             pass
 
         # Cap the number of sessions we process to avoid hanging on 30k+ sessions.
@@ -290,6 +304,23 @@ class CLIExternalSessionProvider:
 
     def get_session(self, external_id: str, days: int = 30) -> dict | None:
         sessions = self._discover_paths(days)
+
+        # Sort by mtime descending (same as list_sessions()) so that sessions
+        # visible in catalog results are also reachable by ID lookup. Without
+        # this sort, a recently-active session at deep path order would appear
+        # in list_sessions() results but 404 from get_session().
+        try:
+            sessions.sort(
+                key=lambda s: (
+                    os.path.getmtime(str(s.get("path", "")))
+                    if s.get("path") and os.path.exists(str(s["path"]))
+                    else 0
+                ),
+                reverse=True,
+            )
+        except OSError:
+            pass
+
         # Cap the scan to avoid 30k+ subprocess calls for a single ID
         # lookup when the session doesn't exist (worst case: 30s timeout × N).
         max_scan = 2000

--- a/gptme/tools/subagent/__init__.py
+++ b/gptme/tools/subagent/__init__.py
@@ -235,10 +235,27 @@ Key features:
 - use_acp=True: Run subagent via ACP protocol (supports any ACP-compatible agent)
 - acp_command="claude-code-acp": Use a different ACP agent (default: gptme-acp)
 - isolated=True: Run subagent in a git worktree for filesystem isolation
+- redact_secrets=True: Redact API keys, tokens, and passwords from workspace context
 - subagent_batch(): Start multiple subagents in parallel
 - subagent_cancel(): Cancel a running subagent (SIGTERM for subprocess, marks result for threads)
 - subagent_reply(agent_id, reply): Answer a clarification request and re-spawn the subagent
 - Hook-based notifications: Completions (and clarification requests) delivered as system messages
+
+## Context Isolation
+
+Subagents do NOT inherit the parent's conversation history — they always start
+with a fresh context. What subagents DO inherit (in context_mode="full"):
+
+- Workspace files listed in gptme.toml [prompt] files (e.g. AGENTS.md, README)
+- Dynamic context_cmd output (if configured in gptme.toml)
+- User-level config files from ~/.config/gptme
+
+This means secrets stored in workspace config files or produced by context_cmd
+can reach the subagent. Use redact_secrets=True to scrub common secret patterns
+(API_KEY, TOKEN, PASSWORD, etc.) from these inherited context messages.
+
+For stronger isolation, use context_mode="selective" with context_include=["agent"]
+to share only the agent identity (no workspace files or dynamic context).
 
 ## Agent Profiles for Subagents
 

--- a/gptme/tools/subagent/api.py
+++ b/gptme/tools/subagent/api.py
@@ -268,6 +268,13 @@ def subagent(
                 f"Not in a git repo, using temp dir for {agent_id}: {worktree_path}"
             )
 
+    if redact_secrets and (use_acp or use_subprocess):
+        exec_mode = "ACP" if use_acp else "subprocess"
+        logger.warning(
+            f"Subagent {agent_id}: 'redact_secrets=True' has no effect in {exec_mode} mode "
+            "(only thread-mode subagents inherit workspace context from the parent process)"
+        )
+
     if use_acp:
         # ACP mode: multi-harness support via Agent Client Protocol
         if use_subprocess:

--- a/gptme/tools/subagent/api.py
+++ b/gptme/tools/subagent/api.py
@@ -51,6 +51,7 @@ def subagent(
     isolated: bool | None = None,
     timeout: int = 1800,
     role: Role | None = None,
+    redact_secrets: bool = False,
 ):
     """Starts an asynchronous subagent. Returns None immediately.
 
@@ -113,6 +114,20 @@ def subagent(
             Falls back to a temporary directory if not in a git repo.
         timeout: Maximum seconds before the subprocess monitor kills the
             subagent (default 1800 = 30 min). Only applies to subprocess mode.
+        redact_secrets: If True, scrub common secret patterns from workspace
+            context messages before they are passed to the subagent.
+            Redacts values from lines where the variable name matches patterns
+            like API_KEY, TOKEN, PASSWORD, PRIVATE_KEY, etc.
+
+            Note: subagents do NOT inherit the parent's conversation history —
+            they always start with a fresh context containing only the task
+            prompt and workspace context (files from gptme.toml [prompt] files,
+            and context_cmd output when context_mode="full"). This option
+            sanitizes that inherited workspace context.
+
+            Only applies to thread-mode subagents (subprocess and ACP modes
+            run as a separate gptme process and handle their own context).
+            Default: False (no redaction).
 
     Returns:
         None: Starts asynchronous execution.
@@ -521,6 +536,7 @@ def subagent(
                         output_schema=output_schema,
                         profile_name=profile,
                         agent_id=agent_id,
+                        redact_secrets=redact_secrets,
                     )
                 except Exception as e:
                     # If subagent creation fails, notify with error status
@@ -593,6 +609,7 @@ def subagent(
             worktree_path=worktree_path,
             repo_path=repo_path,
             role=role,
+            redact_secrets=redact_secrets,
         )
         with _subagents_lock:
             _subagents.append(sa)
@@ -721,6 +738,7 @@ def subagent_reply(agent_id: str, reply: str) -> None:
             isolated=sa.isolated,
             timeout=sa.timeout,
             role=sa.role,
+            redact_secrets=sa.redact_secrets,
         )
     except Exception:
         with _subagents_lock:

--- a/gptme/tools/subagent/context.py
+++ b/gptme/tools/subagent/context.py
@@ -11,47 +11,6 @@ import re
 
 from ...message import Message
 
-# Regex that matches lines where a key name suggests a secret.
-# Captures: (prefix_with_key_and_separator)(value)(optional_suffix)
-# Matches patterns like:
-#   API_KEY=sk-abc123
-#   github_token: ghp_xyz
-#   OPENAI_API_KEY="sk-..."
-#   private_key=-----BEGIN RSA...
-#   Bearer ghp_abc123
-_SECRET_LINE_RE = re.compile(
-    r"""(?ix)                                # case-insensitive, verbose
-    (                                        # group 1: prefix (preserved)
-        (?:
-            (?:                              # name=value style
-                [\w\-\.]+                    # variable name
-                \s*[=:]\s*                   # separator
-            )
-            |
-            (?:bearer\s+)                    # Bearer token header
-        )
-        (?:.*?                               # anything before the sensitive name
-            (?:
-                api[-_]?key|apikey           # API keys
-                |token                       # tokens
-                |secret                      # secrets
-                |password|passwd             # passwords
-                |private[-_]key|privkey      # private keys
-                |auth[-_]?(?:key|token)      # auth credentials
-                |access[-_]key               # access keys
-                |credential                  # generic credential
-            )
-            .*?                              # anything after, before separator
-            (?:\s*[=:]\s*)?                  # optional repeated separator
-        )?
-    )
-    (["']?)                                  # group 2: optional opening quote
-    (\S+)                                    # group 3: the secret value
-    (["']?)                                  # group 4: optional closing quote
-    """,
-    re.MULTILINE,
-)
-
 # Pattern for YAML/TOML colon-style assignments (key: value)
 _COLON_ASSIGN_RE = re.compile(
     r"""(?ix)

--- a/gptme/tools/subagent/context.py
+++ b/gptme/tools/subagent/context.py
@@ -1,0 +1,139 @@
+"""Context isolation utilities for subagents.
+
+Provides secret redaction for workspace context messages passed to subagents.
+Subagents always start with a fresh conversation (no parent history is shared),
+but they do inherit workspace context (files from gptme.toml, context_cmd output,
+user-level config) when context_mode="full". This module helps sanitize that
+inherited context.
+"""
+
+import re
+
+from ...message import Message
+
+# Regex that matches lines where a key name suggests a secret.
+# Captures: (prefix_with_key_and_separator)(value)(optional_suffix)
+# Matches patterns like:
+#   API_KEY=sk-abc123
+#   github_token: ghp_xyz
+#   OPENAI_API_KEY="sk-..."
+#   private_key=-----BEGIN RSA...
+#   Bearer ghp_abc123
+_SECRET_LINE_RE = re.compile(
+    r"""(?ix)                                # case-insensitive, verbose
+    (                                        # group 1: prefix (preserved)
+        (?:
+            (?:                              # name=value style
+                [\w\-\.]+                    # variable name
+                \s*[=:]\s*                   # separator
+            )
+            |
+            (?:bearer\s+)                    # Bearer token header
+        )
+        (?:.*?                               # anything before the sensitive name
+            (?:
+                api[-_]?key|apikey           # API keys
+                |token                       # tokens
+                |secret                      # secrets
+                |password|passwd             # passwords
+                |private[-_]key|privkey      # private keys
+                |auth[-_]?(?:key|token)      # auth credentials
+                |access[-_]key               # access keys
+                |credential                  # generic credential
+            )
+            .*?                              # anything after, before separator
+            (?:\s*[=:]\s*)?                  # optional repeated separator
+        )?
+    )
+    (["']?)                                  # group 2: optional opening quote
+    (\S+)                                    # group 3: the secret value
+    (["']?)                                  # group 4: optional closing quote
+    """,
+    re.MULTILINE,
+)
+
+# Simpler pattern for export statements and env-var assignment lines
+_ENV_ASSIGN_RE = re.compile(
+    r"""(?ix)
+    ^(export\s+)?                            # optional 'export'
+    (                                        # group 2: variable name
+        [\w\-]*?                             # zero or more chars before keyword
+        (?:
+            api[-_]?key|apikey
+            |token
+            |secret
+            |password|passwd
+            |private[-_]key|privkey
+            |auth[-_]?(?:key|token)
+            |access[-_]key
+            |credential
+        )
+        [\w\-]*                              # trailing name chars
+    )
+    (\s*[=]\s*)                              # group 3: assignment
+    (["']?)                                  # group 4: opening quote
+    (.+?)                                    # group 5: the value
+    (["']?)                                  # group 6: closing quote
+    (\s*)$                                   # group 7: trailing whitespace
+    """,
+    re.MULTILINE,
+)
+
+_REDACTED = "[REDACTED]"
+
+
+def redact_secrets_from_text(content: str) -> str:
+    """Redact common secret patterns from text content.
+
+    Targets lines where the variable/field name suggests a secret:
+    - API keys (API_KEY, OPENAI_API_KEY, etc.)
+    - Tokens (TOKEN, ACCESS_TOKEN, GITHUB_TOKEN, etc.)
+    - Passwords (PASSWORD, PASSWD)
+    - Private keys (PRIVATE_KEY)
+    - Auth credentials (AUTH_KEY, AUTH_TOKEN)
+    - Generic credentials (CREDENTIAL, ACCESS_KEY)
+
+    The key name and separator are preserved; only the value is replaced
+    with ``[REDACTED]`` so context is not destroyed.
+
+    Examples::
+
+        >>> redact_secrets_from_text("GITHUB_TOKEN=ghp_abc123")
+        'GITHUB_TOKEN=[REDACTED]'
+        >>> redact_secrets_from_text("openai_api_key: sk-proj-abc")
+        'openai_api_key: [REDACTED]'
+        >>> redact_secrets_from_text("export PASSWORD=hunter2")
+        'export PASSWORD=[REDACTED]'
+    """
+    return "".join(_redact_line(line) for line in content.splitlines(keepends=True))
+
+
+def _redact_line(line: str) -> str:
+    """Redact a single line if it contains a secret assignment."""
+    # Try the env-var assignment pattern first (more specific)
+    match = _ENV_ASSIGN_RE.search(line)
+    if match:
+        export_prefix = match.group(1) or ""
+        name = match.group(2)
+        sep = match.group(3)
+        trailing = match.group(7)
+        # Reconstruct with redacted value (no quotes around [REDACTED])
+        return f"{export_prefix}{name}{sep}{_REDACTED}{trailing}\n"
+    return line
+
+
+def redact_secrets_from_messages(messages: list[Message]) -> list[Message]:
+    """Apply secret redaction to a list of messages.
+
+    Returns new Message objects with secret values replaced by ``[REDACTED]``.
+    Roles and other message metadata are preserved.
+
+    Args:
+        messages: List of messages to sanitize.
+
+    Returns:
+        A new list of messages with secrets redacted.
+    """
+    return [
+        msg.replace(content=redact_secrets_from_text(msg.content)) for msg in messages
+    ]

--- a/gptme/tools/subagent/context.py
+++ b/gptme/tools/subagent/context.py
@@ -52,6 +52,33 @@ _SECRET_LINE_RE = re.compile(
     re.MULTILINE,
 )
 
+# Pattern for YAML/TOML colon-style assignments (key: value)
+_COLON_ASSIGN_RE = re.compile(
+    r"""(?ix)
+    ^(\s*)                                    # group 1: optional leading whitespace
+    (                                         # group 2: variable name with secret keyword
+        [\w\-]*?
+        (?:
+            api[-_]?key|apikey
+            |token
+            |secret
+            |password|passwd
+            |private[-_]key|privkey
+            |auth[-_]?(?:key|token)
+            |access[-_]key
+            |credential
+        )
+        [\w\-]*
+    )
+    (\s*:\s*)                                 # group 3: colon separator
+    (["']?)                                   # group 4: optional opening quote
+    (.+?)                                     # group 5: the value
+    (["']?)                                   # group 6: optional closing quote
+    (\s*)$                                    # group 7: trailing whitespace
+    """,
+    re.MULTILINE,
+)
+
 # Simpler pattern for export statements and env-var assignment lines
 _ENV_ASSIGN_RE = re.compile(
     r"""(?ix)
@@ -110,15 +137,27 @@ def redact_secrets_from_text(content: str) -> str:
 
 def _redact_line(line: str) -> str:
     """Redact a single line if it contains a secret assignment."""
-    # Try the env-var assignment pattern first (more specific)
+    # Preserve original line ending (last line of a file may have no trailing newline)
+    ending = "\n" if line.endswith("\n") else ""
+
+    # Try the env-var assignment pattern first (export VAR=value or VAR=value)
     match = _ENV_ASSIGN_RE.search(line)
     if match:
         export_prefix = match.group(1) or ""
         name = match.group(2)
         sep = match.group(3)
         trailing = match.group(7)
-        # Reconstruct with redacted value (no quotes around [REDACTED])
-        return f"{export_prefix}{name}{sep}{_REDACTED}{trailing}\n"
+        return f"{export_prefix}{name}{sep}{_REDACTED}{trailing}{ending}"
+
+    # Try YAML/TOML colon-style (key: value, e.g. github_token: ghp_xyz)
+    match = _COLON_ASSIGN_RE.search(line)
+    if match:
+        indent = match.group(1)
+        name = match.group(2)
+        sep = match.group(3)
+        trailing = match.group(7)
+        return f"{indent}{name}{sep}{_REDACTED}{trailing}{ending}"
+
     return line
 
 

--- a/gptme/tools/subagent/execution.py
+++ b/gptme/tools/subagent/execution.py
@@ -137,6 +137,7 @@ def _create_subagent_thread(
     output_schema: type | None = None,
     profile_name: str | None = None,
     agent_id: str | None = None,
+    redact_secrets: bool = False,
 ) -> None:
     """Shared function for running subagent threads.
 
@@ -242,6 +243,15 @@ def _create_subagent_thread(
         initial_msgs = get_prompt(
             available_tools, interactive=False, workspace=workspace
         )
+
+    # Apply secret redaction to workspace context messages if requested.
+    # This redacts values from lines where the variable name matches common
+    # secret patterns (API_KEY, TOKEN, PASSWORD, etc.) in system messages.
+    # Only redacts the context messages, not the task prompt itself.
+    if redact_secrets:
+        from .context import redact_secrets_from_messages
+
+        initial_msgs = redact_secrets_from_messages(initial_msgs)
 
     # Append profile system prompt if specified
     if profile and profile.system_prompt:

--- a/gptme/tools/subagent/types.py
+++ b/gptme/tools/subagent/types.py
@@ -192,6 +192,9 @@ class Subagent:
     # Maximum time (seconds) the subprocess monitor will wait before killing
     timeout: int = 1800  # 30 minutes
     role: Role | None = None
+    # Secret redaction: when True, common secret patterns (API keys, tokens, passwords)
+    # are redacted from workspace context messages before they are seen by the subagent.
+    redact_secrets: bool = False
 
     def get_log(self) -> "LogManager":
         # noreorder

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -1285,6 +1285,7 @@ class TestClarifyBlock:
             "isolated": True,
             "timeout": 42,
             "role": "verify",
+            "redact_secrets": False,
         }
         with _subagent_results_lock:
             assert "clarify-agent" not in _subagent_results
@@ -1367,3 +1368,135 @@ class TestClarifyBlock:
             _subagents[:] = [s for s in _subagents if s.agent_id != "atomic-agent"]
         with _subagent_results_lock:
             _subagent_results.pop("atomic-agent", None)
+
+
+# ---------------------------------------------------------------------------
+# Secret redaction tests (gptme/tools/subagent/context.py)
+# ---------------------------------------------------------------------------
+
+
+class TestRedactSecretsFromText:
+    """Tests for the redact_secrets_from_text utility."""
+
+    def test_redacts_api_key_equals(self):
+        from gptme.tools.subagent.context import redact_secrets_from_text
+
+        result = redact_secrets_from_text("OPENAI_API_KEY=sk-proj-abc123\n")
+        assert "sk-proj-abc123" not in result
+        assert "[REDACTED]" in result
+        assert "OPENAI_API_KEY" in result
+
+    def test_redacts_github_token(self):
+        from gptme.tools.subagent.context import redact_secrets_from_text
+
+        result = redact_secrets_from_text("GITHUB_TOKEN=ghp_xyzXYZ987654\n")
+        assert "ghp_xyzXYZ987654" not in result
+        assert "[REDACTED]" in result
+
+    def test_redacts_password(self):
+        from gptme.tools.subagent.context import redact_secrets_from_text
+
+        result = redact_secrets_from_text("PASSWORD=hunter2\n")
+        assert "hunter2" not in result
+        assert "[REDACTED]" in result
+
+    def test_redacts_export_statement(self):
+        from gptme.tools.subagent.context import redact_secrets_from_text
+
+        result = redact_secrets_from_text("export API_KEY=my-secret-key\n")
+        assert "my-secret-key" not in result
+        assert "[REDACTED]" in result
+        assert "export" in result
+        assert "API_KEY" in result
+
+    def test_preserves_non_secret_lines(self):
+        from gptme.tools.subagent.context import redact_secrets_from_text
+
+        content = "PROJECT_NAME=myproject\nDEBUG=true\nLOG_LEVEL=info\n"
+        result = redact_secrets_from_text(content)
+        assert result == content
+
+    def test_redacts_only_secret_lines_in_multiline(self):
+        from gptme.tools.subagent.context import redact_secrets_from_text
+
+        content = "HOST=localhost\nAPI_KEY=supersecret\nPORT=8080\n"
+        result = redact_secrets_from_text(content)
+        assert "supersecret" not in result
+        assert "HOST=localhost" in result
+        assert "PORT=8080" in result
+        assert "API_KEY" in result
+
+    def test_redacts_access_key(self):
+        from gptme.tools.subagent.context import redact_secrets_from_text
+
+        result = redact_secrets_from_text("ACCESS_KEY=AKIAIOSFODNN7EXAMPLE\n")
+        assert "AKIAIOSFODNN7EXAMPLE" not in result
+        assert "[REDACTED]" in result
+
+    def test_redacts_private_key(self):
+        from gptme.tools.subagent.context import redact_secrets_from_text
+
+        result = redact_secrets_from_text("PRIVATE_KEY=abc123privatekey\n")
+        assert "abc123privatekey" not in result
+        assert "[REDACTED]" in result
+
+    def test_handles_empty_string(self):
+        from gptme.tools.subagent.context import redact_secrets_from_text
+
+        assert redact_secrets_from_text("") == ""
+
+    def test_handles_no_secrets(self):
+        from gptme.tools.subagent.context import redact_secrets_from_text
+
+        content = "# This is just a comment\nSome text here\n"
+        assert redact_secrets_from_text(content) == content
+
+
+class TestRedactSecretsFromMessages:
+    """Tests for the redact_secrets_from_messages utility."""
+
+    def test_redacts_system_message_content(self):
+        from gptme.message import Message
+        from gptme.tools.subagent.context import redact_secrets_from_messages
+
+        msgs = [Message("system", "Config:\nAPI_KEY=supersecret\nHOST=localhost\n")]
+        result = redact_secrets_from_messages(msgs)
+        assert len(result) == 1
+        assert "supersecret" not in result[0].content
+        assert "[REDACTED]" in result[0].content
+        assert "HOST=localhost" in result[0].content
+
+    def test_preserves_message_role(self):
+        from gptme.message import Message
+        from gptme.tools.subagent.context import redact_secrets_from_messages
+
+        msgs = [
+            Message("system", "API_KEY=secret\n"),
+            Message("user", "do a thing"),
+        ]
+        result = redact_secrets_from_messages(msgs)
+        assert result[0].role == "system"
+        assert result[1].role == "user"
+
+    def test_returns_new_message_objects(self):
+        from gptme.message import Message
+        from gptme.tools.subagent.context import redact_secrets_from_messages
+
+        original = Message("system", "API_KEY=secret\n")
+        result = redact_secrets_from_messages([original])
+        assert result[0] is not original
+        # Original is unchanged
+        assert "secret" in original.content
+
+    def test_handles_empty_list(self):
+        from gptme.tools.subagent.context import redact_secrets_from_messages
+
+        assert redact_secrets_from_messages([]) == []
+
+    def test_handles_messages_with_no_secrets(self):
+        from gptme.message import Message
+        from gptme.tools.subagent.context import redact_secrets_from_messages
+
+        msgs = [Message("system", "# Agent instructions\nDo good work.\n")]
+        result = redact_secrets_from_messages(msgs)
+        assert result[0].content == msgs[0].content

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -1500,3 +1500,63 @@ class TestRedactSecretsFromMessages:
         msgs = [Message("system", "# Agent instructions\nDo good work.\n")]
         result = redact_secrets_from_messages(msgs)
         assert result[0].content == msgs[0].content
+
+
+class TestRedactSecretsColonStyle:
+    """Tests for YAML/TOML colon-style secret redaction."""
+
+    def test_redacts_yaml_api_key(self):
+        from gptme.tools.subagent.context import redact_secrets_from_text
+
+        result = redact_secrets_from_text("openai_api_key: sk-proj-abc\n")
+        assert "sk-proj-abc" not in result
+        assert "[REDACTED]" in result
+        assert "openai_api_key" in result
+
+    def test_redacts_yaml_github_token(self):
+        from gptme.tools.subagent.context import redact_secrets_from_text
+
+        result = redact_secrets_from_text("github_token: ghp_xyzXYZ987\n")
+        assert "ghp_xyzXYZ987" not in result
+        assert "[REDACTED]" in result
+        assert "github_token" in result
+
+    def test_redacts_yaml_password(self):
+        from gptme.tools.subagent.context import redact_secrets_from_text
+
+        result = redact_secrets_from_text("password: hunter2\n")
+        assert "hunter2" not in result
+        assert "[REDACTED]" in result
+
+    def test_redacts_indented_yaml_token(self):
+        from gptme.tools.subagent.context import redact_secrets_from_text
+
+        result = redact_secrets_from_text("  api_key: my-secret-value\n")
+        assert "my-secret-value" not in result
+        assert "[REDACTED]" in result
+        assert "api_key" in result
+
+    def test_preserves_non_secret_yaml_keys(self):
+        from gptme.tools.subagent.context import redact_secrets_from_text
+
+        content = "host: localhost\nport: 8080\nlog_level: info\n"
+        result = redact_secrets_from_text(content)
+        assert result == content
+
+    def test_preserves_trailing_newline_for_last_line_without_newline(self):
+        from gptme.tools.subagent.context import redact_secrets_from_text
+
+        # Last line without trailing newline: no newline should be added
+        result = redact_secrets_from_text("API_KEY=secret")
+        assert not result.endswith("\n")
+        assert "[REDACTED]" in result
+
+    def test_colon_style_in_multiline(self):
+        from gptme.tools.subagent.context import redact_secrets_from_text
+
+        content = "host: localhost\ngithub_token: ghp_abc123\nport: 5432\n"
+        result = redact_secrets_from_text(content)
+        assert "ghp_abc123" not in result
+        assert "[REDACTED]" in result
+        assert "host: localhost" in result
+        assert "port: 5432" in result


### PR DESCRIPTION
## Problem

The `/api/v2/external-sessions` endpoint was making sequential subprocess calls (`gptme-sessions transcript <path> --json`) for **every** discovered session before slicing to the requested limit. On a machine with 31k+ sessions in a 30-day window (gptme + claude-code + codex), this could hang the endpoint indefinitely by spawning tens of thousands of subprocesses, each with a 30-second timeout.

Even on a machine with fewer sessions, each subprocess call takes 50-200ms, so scanning 10k sessions means 8-33 minutes of wall clock time.

## Root Cause

Both `ExternalSessionProvider.list_sessions()` and `CLIExternalSessionProvider.list_sessions()`:

1. Discover ALL session paths (potentially 31k+)
2. Read the transcript for EVERY path via subprocess
3. Sort ALL results
4. Slice to `limit` (default 100)

Step 2 is O(N) subprocess calls where N can be 31k+.

## Fix

- **Cap transcript reads** in `list_sessions()` to `limit x 3` (max 500) paths - bounded time regardless of session count
- **Cap path scans** in `get_session()` to 2000 paths
- **Sort by mtime** descending so most recent sessions are processed first under the cap
- **Reduce per-transcript CLI timeout** from 30s to 10s (failed transcripts return quickly)
- **Reduce default `days` parameter** from 30 to 7 (reduces discovery scan too)
- **Reduce max `days` cap** from 3650 to 365
- **Downgrade warnings to debug** for unreadable transcripts (noisy at scale)

## Verification

- [x] Syntax check passes
- [x] Pre-commit hooks pass
- [x] Manual test: server starts and endpoint no longer hangs
