### PR TITLE
feat(server): add /api/v2/version endpoint

### DIFF
--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -91,6 +91,7 @@ from .openapi_docs import (
     CONTRACT_REVISION,
     CONVERSATION_ID_PARAM,
     ApiRootResponse,
+    ApiVersionResponse,
     AudioTranscriptionResponse,
     ConversationCreateRequest,
     ConversationListResponse,
@@ -691,6 +692,21 @@ def api_root():
         "provider_configured": provider_configured,
     }
     response = flask.jsonify(body)
+    response.headers["X-API-Version"] = str(API_VERSION)
+    return response
+
+
+@v2_api.route("/api/v2/version")
+@api_doc_simple(responses={200: ApiVersionResponse}, tags=["meta"])
+def api_version():
+    """Get the current API version.
+
+    Lightweight alternative to the full /api/v2 root for clients that only
+    need to check version compatibility.
+    """
+    response = flask.jsonify(
+        {"api_version": API_VERSION, "contract_revision": CONTRACT_REVISION}
+    )
     response.headers["X-API-Version"] = str(API_VERSION)
     return response
 

--- a/gptme/server/openapi_docs.py
+++ b/gptme/server/openapi_docs.py
@@ -207,6 +207,18 @@ class ApiRootResponse(BaseModel):
     )
 
 
+class ApiVersionResponse(BaseModel):
+    """Response from the /api/v2/version endpoint."""
+
+    api_version: int = Field(
+        ..., description="API contract major version (URL-prefix axis)"
+    )
+    contract_revision: int = Field(
+        ...,
+        description="Additive contract revision; increments for backward-compatible changes",
+    )
+
+
 class UserApiKeySaveRequest(BaseModel):
     """Request to save a provider API key into user config."""
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -39,6 +39,16 @@ def test_api_root(client: FlaskClient):
     assert response.headers.get("X-API-Version") == str(API_VERSION)
 
 
+def test_api_version(client: FlaskClient):
+    response = client.get("/api/v2/version")
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["api_version"] == API_VERSION
+    assert data["contract_revision"] == CONTRACT_REVISION
+    assert response.headers.get("X-API-Version") == str(API_VERSION)
+    assert "message" not in data
+
+
 def test_api_config_no_project(client: FlaskClient, monkeypatch):
     """GET /api/v2/config returns empty agent dict when no gptme.toml is present."""
     import gptme.server.api_v2 as api_v2_module


### PR DESCRIPTION
## Problem

Follow-up to PR #2952 (Slice 1: API version constants + X-API-Version header). Clients that only need to check version compatibility had to parse the full `/api/v2` root response. A lightweight dedicated endpoint avoids this.

## What this does

Adds `GET /api/v2/version` — a minimal endpoint returning `{api_version, contract_revision}` with the `X-API-Version` header. Clients can hit this instead of the heavier root for version negotiation.

## Changes

- `openapi_docs.py`: new `ApiVersionResponse` model
- `api_v2.py`: new `GET /api/v2/version` route
- `tests/test_server.py`: `test_api_version()` — 200, correct fields, header present, no stray fields

## Verification

```
tests/test_server.py::test_api_version PASSED
tests/test_server.py::test_api_root PASSED
```

## Part of the API versioning strategy

- ✅ Slice 1 (PR #2952): `API_VERSION`/`CONTRACT_REVISION` constants, `ApiRootResponse` fields, `X-API-Version` header
- ✅ Slice 2 (this PR): dedicated `/api/v2/version` endpoint
- ⬜ Slice 3: client-side version mismatch detection (separate PR, downstream clients)