### PR TITLE
feat(logmanager): append-only event log for session durability (Phase 1)

### DIFF
--- a/gptme/logmanager/eventlog.py
+++ b/gptme/logmanager/eventlog.py
@@ -143,8 +143,10 @@ def recover_messages(
     1. Finding the latest checkpoint (if any) and loading its message list.
     2. Replaying events after the checkpoint to reconstruct current state.
 
-    Returns *None* if no event log exists, otherwise a list of message dicts
-    (in the same format as JSONL lines, with ``"timestamp"`` as ISO strings).
+    Returns *None* if no event log exists.  Returns an empty list if the event
+    log exists but all messages have been undone (distinguishable from missing
+    log).  Otherwise returns a list of message dicts (in the same format as
+    JSONL lines, with ``"timestamp"`` as ISO strings).
     """
     from ..message import _migrate_metadata
 
@@ -182,9 +184,11 @@ def recover_messages(
             messages.append(msg_dict)  # type: ignore[arg-type]
             replay_count += 1
         elif event_type == EVENT_UNDO:
-            if messages:
-                messages.pop()
-                replay_count += 1
+            n = int(event.get("payload", {}).get("n", 1))
+            for _ in range(n):
+                if messages:
+                    messages.pop()
+            replay_count += 1
         elif event_type == EVENT_MESSAGE_EDIT:
             # Edit events store the full message list at time of edit
             messages[:] = [
@@ -196,7 +200,7 @@ def recover_messages(
     if replay_count:
         logger.info("Recovery: replayed %d event(s) post-checkpoint", replay_count)
 
-    return messages or None
+    return messages
 
 
 # ── convenience: event builders ──────────────────────────────────────
@@ -222,9 +226,9 @@ def build_message_edit_event(
     )
 
 
-def build_undo_event(seq: int) -> dict[str, Any]:
-    """Build an ``undo`` event."""
-    return _make_event(seq, EVENT_UNDO, {})
+def build_undo_event(seq: int, n: int = 1) -> dict[str, Any]:
+    """Build an ``undo`` event storing the count of messages removed."""
+    return _make_event(seq, EVENT_UNDO, {"n": n})
 
 
 def build_checkpoint_event(

--- a/gptme/logmanager/eventlog.py
+++ b/gptme/logmanager/eventlog.py
@@ -1,0 +1,225 @@
+"""Append-only event log for session durability.
+
+Provides an append-only JSONL event log alongside the primary
+``conversation.jsonl``.  Periodic checkpoint cells (every
+:py:data:`CHECKPOINT_INTERVAL` events) allow efficient recovery of the
+message list from the event log alone — skipping replay from event 1.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from ..message import Message
+
+logger = logging.getLogger(__name__)
+
+# ── file name and checkpoint interval ────────────────────────────────
+EVENT_LOG_NAME = "events.jsonl"
+CHECKPOINT_INTERVAL = 50
+
+# ── event type constants ─────────────────────────────────────────────
+EVENT_MESSAGE_APPEND = "message_append"
+EVENT_CHECKPOINT = "checkpoint"
+EVENT_UNDO = "undo"
+EVENT_MESSAGE_EDIT = "message_edit"
+
+
+# ── helpers ──────────────────────────────────────────────────────────
+
+
+def _event_log_path(logdir: Path) -> Path:
+    return logdir / EVENT_LOG_NAME
+
+
+def _make_event(seq: int, type: str, payload: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "seq": seq,
+        "ts": datetime.now(timezone.utc).isoformat(),
+        "type": type,
+        "payload": payload,
+    }
+
+
+# ── public API ───────────────────────────────────────────────────────
+
+
+def append_event(logdir: Path, event: dict[str, Any]) -> None:
+    """Append a single event record to the event log."""
+    path = _event_log_path(logdir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "a", encoding="utf-8") as f:
+        f.write(json.dumps(event, default=str) + "\n")
+
+
+def read_events(logdir: Path) -> list[dict[str, Any]]:
+    """Read all events from the event log, oldest first.
+
+    Returns an empty list if no event log exists.
+    """
+    path = _event_log_path(logdir)
+    if not path.exists():
+        return []
+    events: list[dict[str, Any]] = []
+    with open(path, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                events.append(json.loads(line))
+            except json.JSONDecodeError:
+                logger.warning("Skipping malformed event line in %s", path)
+    return events
+
+
+def sequence_number(logdir: Path) -> int:
+    """Return the next sequence number for a new event."""
+    events = read_events(logdir)
+    if not events:
+        return 1  # start at 1 (0 is reserved for initial state)
+    return events[-1]["seq"] + 1
+
+
+def write_checkpoint(
+    logdir: Path,
+    seq: int,
+    messages: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Write a checkpoint event that snapshots the full message state.
+
+    Returns the written checkpoint event.
+    """
+    event = _make_event(seq, EVENT_CHECKPOINT, {"messages": messages})
+    append_event(logdir, event)
+    return event
+
+
+def should_checkpoint(logdir: Path, current_seq: int) -> bool:
+    """Return True when a checkpoint should be written.
+
+    A checkpoint is due every :py:data:`CHECKPOINT_INTERVAL` events.
+    """
+    if current_seq == 0:
+        return False
+    return current_seq % CHECKPOINT_INTERVAL == 0
+
+
+def find_latest_checkpoint(
+    events: list[dict[str, Any]],
+) -> dict[str, Any] | None:
+    """Return the most recent checkpoint event, or *None*."""
+    checkpoint: dict[str, Any] | None = None
+    for event in events:
+        if event.get("type") == EVENT_CHECKPOINT:
+            checkpoint = event
+    return checkpoint
+
+
+def _message_from_dict(data: dict[str, Any]) -> dict[str, Any]:
+    """Convert a stored message dict to the format expected by Message.
+
+    The stored format uses ``"timestamp"`` as an ISO string.  ``Message.__init__``
+    expects a ``datetime``, so we keep the raw dict and let the caller handle it.
+    """
+    # The caller (LogManager integration) will parse this through _gen_read_jsonl
+    # or Message.__init__ directly.
+    return data
+
+
+def recover_messages(
+    logdir: Path,
+) -> list[dict[str, Any]] | None:
+    """Reconstruct message dicts from the event log.
+
+    Works by:
+    1. Finding the latest checkpoint (if any) and loading its message list.
+    2. Replaying events after the checkpoint to reconstruct current state.
+
+    Returns *None* if no event log exists, otherwise a list of message dicts
+    (in the same format as JSONL lines, with ``"timestamp"`` as ISO strings).
+    """
+    from ..message import _migrate_metadata
+
+    events = read_events(logdir)
+    if not events:
+        return None
+
+    checkpoint = find_latest_checkpoint(events)
+
+    messages: list[dict[str, Any]] = []
+    start_seq = 0
+
+    if checkpoint:
+        # Start from the checkpoint snapshot
+        messages.extend(
+            _migrate_metadata(dict(msg_dict))  # type: ignore[misc]
+            for msg_dict in checkpoint["payload"]["messages"]
+        )
+        start_seq = checkpoint["seq"]
+        logger.info(
+            "Recovery: starting from checkpoint at seq %d (%d messages)",
+            start_seq,
+            len(messages),
+        )
+
+    # Replay events after the checkpoint (or from the start)
+    replay_count = 0
+    for event in events:
+        if event["seq"] <= start_seq:
+            continue
+
+        event_type = event.get("type")
+        if event_type == EVENT_MESSAGE_APPEND:
+            msg_dict = _migrate_metadata(dict(event["payload"]["message"]))
+            messages.append(msg_dict)  # type: ignore[arg-type]
+            replay_count += 1
+        elif event_type == EVENT_UNDO:
+            if messages:
+                messages.pop()
+                replay_count += 1
+        elif event_type == EVENT_MESSAGE_EDIT:
+            index = event["payload"].get("index")
+            new_msg = _migrate_metadata(dict(event["payload"]["message"]))
+            if index is not None and 0 <= index < len(messages):
+                messages[index] = new_msg  # type: ignore[assignment]
+                replay_count += 1
+
+    if replay_count:
+        logger.info("Recovery: replayed %d event(s) post-checkpoint", replay_count)
+
+    return messages or None
+
+
+# ── convenience: event builder ───────────────────────────────────────
+
+
+def build_message_append_event(
+    seq: int,
+    message: Message,
+) -> dict[str, Any]:
+    """Build a ``message_append`` event from a Message object."""
+    return _make_event(seq, EVENT_MESSAGE_APPEND, {"message": message.to_dict()})
+
+
+def build_undo_event(seq: int) -> dict[str, Any]:
+    """Build an ``undo`` event."""
+    return _make_event(seq, EVENT_UNDO, {})
+
+
+def build_checkpoint_event(
+    seq: int,
+    messages: list[Message],
+) -> dict[str, Any]:
+    """Build a checkpoint event from a list of Message objects."""
+    return _make_event(
+        seq,
+        EVENT_CHECKPOINT,
+        {"messages": [m.to_dict() for m in messages]},
+    )

--- a/gptme/logmanager/eventlog.py
+++ b/gptme/logmanager/eventlog.py
@@ -229,15 +229,3 @@ def build_message_edit_event(
 def build_undo_event(seq: int, n: int = 1) -> dict[str, Any]:
     """Build an ``undo`` event storing the count of messages removed."""
     return _make_event(seq, EVENT_UNDO, {"n": n})
-
-
-def build_checkpoint_event(
-    seq: int,
-    messages: list[Message],
-) -> dict[str, Any]:
-    """Build a checkpoint event from a list of Message objects."""
-    return _make_event(
-        seq,
-        EVENT_CHECKPOINT,
-        {"messages": [m.to_dict() for m in messages]},
-    )

--- a/gptme/logmanager/eventlog.py
+++ b/gptme/logmanager/eventlog.py
@@ -81,10 +81,22 @@ def read_events(logdir: Path) -> list[dict[str, Any]]:
 
 def sequence_number(logdir: Path) -> int:
     """Return the next sequence number for a new event."""
-    events = read_events(logdir)
-    if not events:
-        return 1  # start at 1 (0 is reserved for initial state)
-    return events[-1]["seq"] + 1
+    path = _event_log_path(logdir)
+    if not path.exists():
+        return 1
+    # Read only the last non-empty line to avoid O(n) full-file parse
+    last_line = ""
+    with open(path, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                last_line = line
+    if not last_line:
+        return 1
+    try:
+        return json.loads(last_line)["seq"] + 1
+    except (json.JSONDecodeError, KeyError):
+        return len(read_events(logdir)) + 1
 
 
 def write_checkpoint(
@@ -101,7 +113,7 @@ def write_checkpoint(
     return event
 
 
-def should_checkpoint(logdir: Path, current_seq: int) -> bool:
+def should_checkpoint(current_seq: int) -> bool:
     """Return True when a checkpoint should be written.
 
     A checkpoint is due every :py:data:`CHECKPOINT_INTERVAL` events.
@@ -120,17 +132,6 @@ def find_latest_checkpoint(
         if event.get("type") == EVENT_CHECKPOINT:
             checkpoint = event
     return checkpoint
-
-
-def _message_from_dict(data: dict[str, Any]) -> dict[str, Any]:
-    """Convert a stored message dict to the format expected by Message.
-
-    The stored format uses ``"timestamp"`` as an ISO string.  ``Message.__init__``
-    expects a ``datetime``, so we keep the raw dict and let the caller handle it.
-    """
-    # The caller (LogManager integration) will parse this through _gen_read_jsonl
-    # or Message.__init__ directly.
-    return data
 
 
 def recover_messages(
@@ -185,11 +186,12 @@ def recover_messages(
                 messages.pop()
                 replay_count += 1
         elif event_type == EVENT_MESSAGE_EDIT:
-            index = event["payload"].get("index")
-            new_msg = _migrate_metadata(dict(event["payload"]["message"]))
-            if index is not None and 0 <= index < len(messages):
-                messages[index] = new_msg  # type: ignore[assignment]
-                replay_count += 1
+            # Edit events store the full message list at time of edit
+            messages[:] = [
+                _migrate_metadata(dict(m))  # type: ignore[misc]
+                for m in event["payload"]["messages"]
+            ]
+            replay_count += 1
 
     if replay_count:
         logger.info("Recovery: replayed %d event(s) post-checkpoint", replay_count)
@@ -197,7 +199,7 @@ def recover_messages(
     return messages or None
 
 
-# ── convenience: event builder ───────────────────────────────────────
+# ── convenience: event builders ──────────────────────────────────────
 
 
 def build_message_append_event(
@@ -206,6 +208,18 @@ def build_message_append_event(
 ) -> dict[str, Any]:
     """Build a ``message_append`` event from a Message object."""
     return _make_event(seq, EVENT_MESSAGE_APPEND, {"message": message.to_dict()})
+
+
+def build_message_edit_event(
+    seq: int,
+    messages: list[Message],
+) -> dict[str, Any]:
+    """Build a ``message_edit`` event from the current full message list."""
+    return _make_event(
+        seq,
+        EVENT_MESSAGE_EDIT,
+        {"messages": [m.to_dict() for m in messages]},
+    )
 
 
 def build_undo_event(seq: int) -> dict[str, Any]:

--- a/gptme/logmanager/manager.py
+++ b/gptme/logmanager/manager.py
@@ -47,6 +47,7 @@ from ..util.context import enrich_messages_with_context
 from ..util.conversation_ids import conversation_id_error, validate_conversation_id
 from ..util.reduce import limit_log, reduce_log
 from ..util.uri import URI
+from . import eventlog
 
 PathLike: TypeAlias = str | Path
 
@@ -358,6 +359,51 @@ class LogManager:
         chat_config = ChatConfig.from_logdir(self.logdir)
         return chat_config.name or self.chat_id
 
+    def _write_event_log(self, event_type: str, **extra: object) -> None:
+        """Write an event to the event log and optionally a checkpoint.
+
+        Writes a ``message_append``, ``message_edit``, or ``undo`` event
+        followed by a checkpoint if one is due.  Writes alongside the main
+        conversation JSONL (``get_logs_dir() / chat_id / events.jsonl``).
+        Silent-noop when the log directory is not set up yet.
+        """
+        event_dir = self.logfile.parent
+        event_dir.mkdir(parents=True, exist_ok=True)
+        seq = eventlog.sequence_number(event_dir)
+        if event_type == eventlog.EVENT_MESSAGE_APPEND:
+            # Build from the last message in the current log
+            if self.log.messages:
+                last = self.log.messages[-1]
+                event = eventlog._make_event(
+                    seq, event_type, {"message": last.to_dict()}
+                )
+            else:
+                return
+        elif event_type == eventlog.EVENT_MESSAGE_EDIT:
+            # Build from the full current log state
+            event = eventlog._make_event(
+                seq,
+                event_type,
+                {
+                    "messages": [m.to_dict() for m in self.log.messages],
+                    **extra,
+                },
+            )
+        elif event_type == eventlog.EVENT_UNDO:
+            event = eventlog._make_event(seq, event_type, {})
+        else:
+            return  # unknown type, skip
+
+        eventlog.append_event(event_dir, event)
+
+        # Checkpoint if due
+        if eventlog.should_checkpoint(event_dir, seq):
+            eventlog.write_checkpoint(
+                event_dir,
+                seq + 1,  # next seq for the checkpoint
+                [m.to_dict() for m in self.log.messages],
+            )
+
     def append(self, msg: Message) -> None:
         """Appends a message to the log, writes the log, prints the message.
 
@@ -381,6 +427,7 @@ class LogManager:
             self.log = self.log.append(msg)
 
         self.write()
+        self._write_event_log(eventlog.EVENT_MESSAGE_APPEND)
         if not msg.quiet:
             print_msg(msg, oneline=False)
 
@@ -467,6 +514,7 @@ class LogManager:
         self._save_backup_branch(type="edit")
         self.log = new_log
         self.write()
+        self._write_event_log(eventlog.EVENT_MESSAGE_EDIT)
 
     def undo(self, n: int = 1, quiet=False) -> None:
         """Removes the last message from the log."""
@@ -497,6 +545,7 @@ class LogManager:
                 )
             peek = self.log[-1] if self.log else None
         self.write()
+        self._write_event_log(eventlog.EVENT_UNDO)
 
     @classmethod
     def load(

--- a/gptme/logmanager/manager.py
+++ b/gptme/logmanager/manager.py
@@ -371,33 +371,21 @@ class LogManager:
         event_dir.mkdir(parents=True, exist_ok=True)
         seq = eventlog.sequence_number(event_dir)
         if event_type == eventlog.EVENT_MESSAGE_APPEND:
-            # Build from the last message in the current log
             if self.log.messages:
-                last = self.log.messages[-1]
-                event = eventlog._make_event(
-                    seq, event_type, {"message": last.to_dict()}
-                )
+                event = eventlog.build_message_append_event(seq, self.log.messages[-1])
             else:
                 return
         elif event_type == eventlog.EVENT_MESSAGE_EDIT:
-            # Build from the full current log state
-            event = eventlog._make_event(
-                seq,
-                event_type,
-                {
-                    "messages": [m.to_dict() for m in self.log.messages],
-                    **extra,
-                },
-            )
+            event = eventlog.build_message_edit_event(seq, list(self.log.messages))
         elif event_type == eventlog.EVENT_UNDO:
-            event = eventlog._make_event(seq, event_type, {})
+            event = eventlog.build_undo_event(seq)
         else:
             return  # unknown type, skip
 
         eventlog.append_event(event_dir, event)
 
         # Checkpoint if due
-        if eventlog.should_checkpoint(event_dir, seq):
+        if eventlog.should_checkpoint(seq):
             eventlog.write_checkpoint(
                 event_dir,
                 seq + 1,  # next seq for the checkpoint

--- a/gptme/logmanager/manager.py
+++ b/gptme/logmanager/manager.py
@@ -378,7 +378,9 @@ class LogManager:
         elif event_type == eventlog.EVENT_MESSAGE_EDIT:
             event = eventlog.build_message_edit_event(seq, list(self.log.messages))
         elif event_type == eventlog.EVENT_UNDO:
-            event = eventlog.build_undo_event(seq)
+            n_raw = extra.get("n", 1)
+            n = n_raw if isinstance(n_raw, int) else 1
+            event = eventlog.build_undo_event(seq, n=n)
         else:
             return  # unknown type, skip
 
@@ -533,7 +535,7 @@ class LogManager:
                 )
             peek = self.log[-1] if self.log else None
         self.write()
-        self._write_event_log(eventlog.EVENT_UNDO)
+        self._write_event_log(eventlog.EVENT_UNDO, n=n)
 
     @classmethod
     def load(

--- a/tests/test_eventlog.py
+++ b/tests/test_eventlog.py
@@ -1,0 +1,297 @@
+"""Tests for gptme/logmanager/eventlog.py"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+import pytest
+
+from gptme.logmanager import Log, LogManager
+from gptme.logmanager.eventlog import (
+    CHECKPOINT_INTERVAL,
+    EVENT_CHECKPOINT,
+    EVENT_MESSAGE_APPEND,
+    EVENT_MESSAGE_EDIT,
+    EVENT_UNDO,
+    _event_log_path,
+    append_event,
+    find_latest_checkpoint,
+    read_events,
+    recover_messages,
+    sequence_number,
+    should_checkpoint,
+    write_checkpoint,
+)
+from gptme.message import Message
+from gptme.tools import init_tools
+
+
+@pytest.fixture(autouse=True)
+def _init_tools():
+    init_tools(allowlist=["save", "patch", "append"])
+
+
+@pytest.fixture
+def logdir(tmp_path: Path):
+    """Create a logdir and set GPTME_LOGS_HOME so events/JSONL go there."""
+    d = tmp_path / "logs" / "test-conv"
+    d.mkdir(parents=True, exist_ok=True)
+    monkey = pytest.MonkeyPatch()
+    monkey.setenv("GPTME_LOGS_HOME", str(tmp_path / "logs"))
+    yield d
+    monkey.undo()
+
+
+def test_event_log_path(logdir: Path):
+    """Event log path is derived correctly."""
+    assert _event_log_path(logdir) == logdir / "events.jsonl"
+
+
+def test_append_and_read_events(logdir: Path):
+    """Appending events and reading them back works."""
+    event1 = {"seq": 1, "ts": "2026-01-01T00:00:00Z", "type": "test", "payload": {}}
+    event2 = {"seq": 2, "ts": "2026-01-01T00:00:01Z", "type": "test", "payload": {}}
+
+    append_event(logdir, event1)
+    append_event(logdir, event2)
+
+    events = read_events(logdir)
+    assert len(events) == 2
+    assert events[0]["seq"] == 1
+    assert events[1]["seq"] == 2
+
+
+def test_read_events_empty_logdir(logdir: Path):
+    """Reading events from a non-existent log returns empty list."""
+    assert read_events(logdir) == []
+
+
+def test_sequence_number_begins_at_one(logdir: Path):
+    """Sequence number starts at 1 for a fresh log directory."""
+    assert sequence_number(logdir) == 1
+
+
+def test_sequence_number_increments(logdir: Path):
+    """Sequence number increments after appending events."""
+    append_event(logdir, {"seq": 1, "ts": "", "type": "test", "payload": {}})
+    assert sequence_number(logdir) == 2
+
+    append_event(logdir, {"seq": 2, "ts": "", "type": "test", "payload": {}})
+    assert sequence_number(logdir) == 3
+
+
+def test_should_checkpoint(logdir: Path):
+    """Checkpoint is due every CHECKPOINT_INTERVAL events."""
+    assert should_checkpoint(logdir, 0) is False
+    assert should_checkpoint(logdir, 1) is False
+    assert should_checkpoint(logdir, CHECKPOINT_INTERVAL - 1) is False
+    assert should_checkpoint(logdir, CHECKPOINT_INTERVAL) is True
+    assert should_checkpoint(logdir, CHECKPOINT_INTERVAL * 2) is True
+    assert should_checkpoint(logdir, CHECKPOINT_INTERVAL * 2 + 1) is False
+
+
+def test_write_and_find_checkpoint(logdir: Path):
+    """Writing a checkpoint and finding it works."""
+    messages = [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "hi"},
+    ]
+    write_checkpoint(logdir, 50, messages)
+
+    # Read events, find checkpoint
+    events = read_events(logdir)
+    assert len(events) == 1
+    assert events[0]["type"] == EVENT_CHECKPOINT
+    assert events[0]["seq"] == 50
+    assert len(events[0]["payload"]["messages"]) == 2
+
+    # find_latest_checkpoint
+    cp = find_latest_checkpoint(events)
+    assert cp is not None
+    assert cp["seq"] == 50
+
+
+def test_find_latest_among_multiple(logdir: Path):
+    """find_latest_checkpoint returns the most recent checkpoint."""
+    write_checkpoint(logdir, 50, [])
+    write_checkpoint(logdir, 100, [{"role": "user", "content": "last"}])
+
+    cp = find_latest_checkpoint(read_events(logdir))
+    assert cp is not None
+    assert cp["seq"] == 100
+    assert cp["payload"]["messages"][0]["content"] == "last"
+
+
+def test_recover_messages_no_event_log(logdir: Path):
+    """recover_messages returns None when no event log exists."""
+    assert recover_messages(logdir) is None
+
+
+def test_recover_messages_from_append_events(logdir: Path):
+    """Recovery reconstructs messages from append events."""
+    append_event(
+        logdir,
+        {
+            "seq": 1,
+            "ts": "2026-01-01T00:00:00Z",
+            "type": EVENT_MESSAGE_APPEND,
+            "payload": {"message": {"role": "user", "content": "hello"}},
+        },
+    )
+    append_event(
+        logdir,
+        {
+            "seq": 2,
+            "ts": "2026-01-01T00:00:01Z",
+            "type": EVENT_MESSAGE_APPEND,
+            "payload": {"message": {"role": "assistant", "content": "world"}},
+        },
+    )
+
+    result = recover_messages(logdir)
+    assert result is not None
+    assert len(result) == 2
+    assert result[0]["role"] == "user"
+    assert result[0]["content"] == "hello"
+    assert result[1]["role"] == "assistant"
+    assert result[1]["content"] == "world"
+
+
+def test_recover_messages_with_checkpoint_and_replay(logdir: Path):
+    """Recovery starts from latest checkpoint, then replays appends."""
+    # Write a checkpoint with 2 messages
+    write_checkpoint(
+        logdir,
+        10,
+        [
+            {"role": "user", "content": "msg1"},
+            {"role": "assistant", "content": "msg2"},
+        ],
+    )
+
+    # Append events after the checkpoint
+    append_event(
+        logdir,
+        {
+            "seq": 11,
+            "ts": "2026-01-01T00:00:00Z",
+            "type": EVENT_MESSAGE_APPEND,
+            "payload": {"message": {"role": "user", "content": "msg3"}},
+        },
+    )
+
+    result = recover_messages(logdir)
+    assert result is not None
+    assert len(result) == 3
+    assert result[0]["content"] == "msg1"
+    assert result[1]["content"] == "msg2"
+    assert result[2]["content"] == "msg3"
+
+
+def test_recover_messages_with_undo_events(logdir: Path):
+    """Recovery handles undo events by removing the last message."""
+    append_event(
+        logdir,
+        {
+            "seq": 1,
+            "ts": "2026-01-01T00:00:00Z",
+            "type": EVENT_MESSAGE_APPEND,
+            "payload": {"message": {"role": "user", "content": "hello"}},
+        },
+    )
+    append_event(
+        logdir,
+        {
+            "seq": 2,
+            "ts": "2026-01-01T00:00:01Z",
+            "type": EVENT_MESSAGE_APPEND,
+            "payload": {"message": {"role": "assistant", "content": "world"}},
+        },
+    )
+    append_event(
+        logdir,
+        {
+            "seq": 3,
+            "ts": "2026-01-01T00:00:02Z",
+            "type": EVENT_UNDO,
+            "payload": {},
+        },
+    )
+
+    result = recover_messages(logdir)
+    assert result is not None
+    assert len(result) == 1
+    assert result[0]["content"] == "hello"
+
+
+# ── Integration with LogManager ──────────────────────────────────────
+
+
+def test_logmanager_append_writes_event_log(logdir: Path):
+    """LogManager.append writes a message_append event."""
+    with LogManager(logdir=logdir) as lm:
+        lm.append(Message("user", "hello from event log test"))
+
+    events = read_events(logdir)
+    assert len(events) >= 1
+    assert events[0]["type"] == EVENT_MESSAGE_APPEND
+    assert events[0]["payload"]["message"]["content"] == "hello from event log test"
+
+
+def test_logmanager_undo_writes_undo_event(logdir: Path):
+    """LogManager.undo writes an undo event."""
+    with LogManager(logdir=logdir) as lm:
+        lm.append(Message("user", "hello"))
+        lm.append(Message("assistant", "world"))
+        lm.undo()
+
+    events = read_events(logdir)
+    types = [e["type"] for e in events]
+    assert EVENT_UNDO in types
+
+
+def test_logmanager_edit_writes_edit_event(logdir: Path):
+    """LogManager.edit writes a message_edit event."""
+    with LogManager(logdir=logdir) as lm:
+        lm.append(Message("user", "hello"))
+        new_log = Log([Message("user", "edited")])
+        lm.edit(new_log)
+
+    events = read_events(logdir)
+    types = [e["type"] for e in events]
+    assert EVENT_MESSAGE_EDIT in types
+
+
+def test_integration_recovery(logdir: Path):
+    """Can recover from event log after LogManager operations."""
+    with LogManager(logdir=logdir) as lm:
+        lm.append(Message("user", "hello"))
+        lm.append(Message("assistant", "world"))
+
+    # Delete the primary JSONL to simulate corruption
+    jsonl_path = logdir / "conversation.jsonl"
+    assert jsonl_path.exists()
+    jsonl_path.unlink()
+
+    # Recover from event log
+    recovered = recover_messages(logdir)
+    assert recovered is not None
+    assert len(recovered) == 2
+    assert recovered[0]["content"] == "hello"
+    assert recovered[1]["content"] == "world"
+
+
+def test_integration_checkpoint_logmanager(logdir: Path):
+    """LogManager with many appends produces checkpoints."""
+    with LogManager(logdir=logdir) as lm:
+        for i in range(CHECKPOINT_INTERVAL + 5):
+            lm.append(Message("user", f"msg{i}"))
+
+    events = read_events(logdir)
+    checkpoints = [e for e in events if e["type"] == EVENT_CHECKPOINT]
+    assert len(checkpoints) >= 1, (
+        f"Expected at least 1 checkpoint, got {len(checkpoints)}"
+    )

--- a/tests/test_eventlog.py
+++ b/tests/test_eventlog.py
@@ -249,6 +249,7 @@ def test_recover_messages_with_undo_events(logdir: Path):
             "payload": {"message": {"role": "assistant", "content": "world"}},
         },
     )
+    # Legacy payload without "n" (backward compat: should pop 1 message)
     append_event(
         logdir,
         {
@@ -263,6 +264,63 @@ def test_recover_messages_with_undo_events(logdir: Path):
     assert result is not None
     assert len(result) == 1
     assert result[0]["content"] == "hello"
+
+
+def test_recover_messages_multi_undo(logdir: Path):
+    """Recovery handles undo(n>1) by popping the correct number of messages."""
+    for i, (role, content) in enumerate(
+        [("user", "a"), ("assistant", "b"), ("user", "c"), ("assistant", "d")], start=1
+    ):
+        append_event(
+            logdir,
+            {
+                "seq": i,
+                "ts": "2026-01-01T00:00:00Z",
+                "type": EVENT_MESSAGE_APPEND,
+                "payload": {"message": {"role": role, "content": content}},
+            },
+        )
+    # undo(n=3): removes last 3 messages, leaving only "a"
+    append_event(
+        logdir,
+        {
+            "seq": 5,
+            "ts": "2026-01-01T00:00:01Z",
+            "type": EVENT_UNDO,
+            "payload": {"n": 3},
+        },
+    )
+
+    result = recover_messages(logdir)
+    assert result is not None
+    assert len(result) == 1
+    assert result[0]["content"] == "a"
+
+
+def test_recover_messages_fully_undone(logdir: Path):
+    """fully-undone session returns [] not None (distinguishable from missing log)."""
+    append_event(
+        logdir,
+        {
+            "seq": 1,
+            "ts": "2026-01-01T00:00:00Z",
+            "type": EVENT_MESSAGE_APPEND,
+            "payload": {"message": {"role": "user", "content": "hello"}},
+        },
+    )
+    append_event(
+        logdir,
+        {
+            "seq": 2,
+            "ts": "2026-01-01T00:00:01Z",
+            "type": EVENT_UNDO,
+            "payload": {"n": 1},
+        },
+    )
+
+    result = recover_messages(logdir)
+    # Must be [] (event log exists, no messages), not None (missing log)
+    assert result == []
 
 
 # ── Integration with LogManager ──────────────────────────────────────

--- a/tests/test_eventlog.py
+++ b/tests/test_eventlog.py
@@ -85,12 +85,12 @@ def test_sequence_number_increments(logdir: Path):
 
 def test_should_checkpoint(logdir: Path):
     """Checkpoint is due every CHECKPOINT_INTERVAL events."""
-    assert should_checkpoint(logdir, 0) is False
-    assert should_checkpoint(logdir, 1) is False
-    assert should_checkpoint(logdir, CHECKPOINT_INTERVAL - 1) is False
-    assert should_checkpoint(logdir, CHECKPOINT_INTERVAL) is True
-    assert should_checkpoint(logdir, CHECKPOINT_INTERVAL * 2) is True
-    assert should_checkpoint(logdir, CHECKPOINT_INTERVAL * 2 + 1) is False
+    assert should_checkpoint(0) is False
+    assert should_checkpoint(1) is False
+    assert should_checkpoint(CHECKPOINT_INTERVAL - 1) is False
+    assert should_checkpoint(CHECKPOINT_INTERVAL) is True
+    assert should_checkpoint(CHECKPOINT_INTERVAL * 2) is True
+    assert should_checkpoint(CHECKPOINT_INTERVAL * 2 + 1) is False
 
 
 def test_write_and_find_checkpoint(logdir: Path):
@@ -189,6 +189,44 @@ def test_recover_messages_with_checkpoint_and_replay(logdir: Path):
     assert result[0]["content"] == "msg1"
     assert result[1]["content"] == "msg2"
     assert result[2]["content"] == "msg3"
+
+
+def test_recover_messages_with_edit_events(logdir: Path):
+    """Recovery handles message_edit events by replacing the full message list."""
+    # Append two messages
+    append_event(
+        logdir,
+        {
+            "seq": 1,
+            "ts": "2026-01-01T00:00:00Z",
+            "type": EVENT_MESSAGE_APPEND,
+            "payload": {"message": {"role": "user", "content": "hello"}},
+        },
+    )
+    append_event(
+        logdir,
+        {
+            "seq": 2,
+            "ts": "2026-01-01T00:00:01Z",
+            "type": EVENT_MESSAGE_APPEND,
+            "payload": {"message": {"role": "assistant", "content": "world"}},
+        },
+    )
+    # Edit replaces the full message list (as written by _write_event_log)
+    append_event(
+        logdir,
+        {
+            "seq": 3,
+            "ts": "2026-01-01T00:00:02Z",
+            "type": EVENT_MESSAGE_EDIT,
+            "payload": {"messages": [{"role": "user", "content": "edited hello"}]},
+        },
+    )
+
+    result = recover_messages(logdir)
+    assert result is not None
+    assert len(result) == 1
+    assert result[0]["content"] == "edited hello"
 
 
 def test_recover_messages_with_undo_events(logdir: Path):


### PR DESCRIPTION
## Summary

Add an append-only JSONL event log alongside the primary `conversation.jsonl` for improved session durability and crash recovery. This is Phase 1 of the Session State Replication feature (part of #526).

## Changes

- **New `gptme/logmanager/eventlog.py`**: Event schema, writer, reader, checkpoint logic, and `recover_messages()` function
- **LogManager hook**: Events are written on every `append()`, `edit()`, and `undo()` call
- **Checkpoint cells**: Every 50 events, a compacted checkpoint is written with the full message state for efficient recovery
- **Recovery**: `recover_messages()` can reconstruct the full message list from the event log alone (useful if `conversation.jsonl` is corrupt)

## Design

- Append-only: events are written with `O_APPEND` semantics via JSONL append
- Sequence numbers: monotonic per-conversation, starting at 1
- Checkpoints: every `CHECKPOINT_INTERVAL` (50) events, a compacted snapshot is written
- Recovery: finds latest checkpoint, replays events after it
- Non-disruptive: the primary `conversation.jsonl` continues to work as before

## Testing

17 new tests covering:
- Event append/read and sequence numbering
- Checkpoint write and find-latest semantics
- Recovery from events without a checkpoint
- Recovery with checkpoint + tail replay
- Recovery with undo events
- LogManager integration (append/undo/edit write events)
- Integration recovery (delete JSONL, recover from events)

## Related

- Part of gptme/gptme#526 — Session State Replication
- Research doc: `knowledge/research/2026-06-19-cell-based-session-state-replication.md`