### PR TITLE
fix(tests): mock thread creation in test_subagent_status_returns_dict

### DIFF
--- a/tests/test_tools_subagent.py
+++ b/tests/test_tools_subagent.py
@@ -387,11 +387,12 @@ def test_subagent_execution_mode_field():
     assert sa2.execution_mode == "subprocess"
 
 
-def test_subagent_status_returns_dict():
+@patch("gptme.tools.subagent.execution._create_subagent_thread")
+def test_subagent_status_returns_dict(mock_create_thread: MagicMock):
     """Test that subagent_status returns a dictionary."""
     from gptme.tools.subagent import subagent, subagent_status
 
-    # First create a subagent
+    # First create a subagent (thread mocked to avoid real API calls in no-extras CI)
     subagent(agent_id="test-status-agent", prompt="Simple test")
 
     # Get status


### PR DESCRIPTION
## Problem

`test_subagent_status_returns_dict` spawned a real subagent thread without any mocking. In the `no-extras` CI environment (no API keys), the thread tried to make LLM API calls and failed with a connection error. Because pytest-xdist runs tests in parallel and `_subagents` is a shared global, the async error log appeared as teardown failures in whichever tests were finishing when `test-status-agent`'s thread gave up:

- `test_subprocess_timeout_passed_to_subagent`
- `test_subagent_with_profile`
- `test_subagent_with_model_override`

This blocked the `Test without API keys or extras` CI job.

## Fix

Add `@patch("gptme.tools.subagent.execution._create_subagent_thread")` to `test_subagent_status_returns_dict`, matching the pattern already used by its neighbors `test_subagent_with_profile` and `test_subagent_with_model_override`. The Subagent object is still registered in `_subagents` and `subagent_status()` still returns a valid dict — only the actual thread is suppressed.

## Test

All three originally-failing tests pass locally after this change. 71 non-slow subagent tests pass (1 unrelated timing-sensitive test intermittently fails under heavy system load — pre-existing, unrelated to this fix).