### PR TITLE
fix(config): tolerate PermissionError in ChatConfig.from_logdir workspace mkdir

### DIFF
--- a/gptme/cli/util.py
+++ b/gptme/cli/util.py
@@ -1012,24 +1012,31 @@ def models_list(
 
     if as_json:
         # Keep JSON output machine-readable even if provider discovery logs warnings.
-        with redirect_stdout(io.StringIO()), redirect_stderr(io.StringIO()):
-            from ..llm import list_available_providers  # fmt: skip
+        # redirect_stdout/redirect_stderr suppresses print() noise; logging.disable
+        # suppresses Rich-formatted log output (httpx retry messages etc.) that escapes
+        # through Rich's pre-captured file handle and is not affected by sys.stderr redirect.
+        logging.disable(logging.INFO)
+        try:
+            with redirect_stdout(io.StringIO()), redirect_stderr(io.StringIO()):
+                from ..llm import list_available_providers  # fmt: skip
 
-            configured = (
-                {
-                    configured_provider
-                    for configured_provider, _ in list_available_providers()
-                }
-                if available
-                else None
-            )
-            models = get_model_list(
-                provider_filter=provider,
-                vision_only=vision,
-                reasoning_only=reasoning,
-                include_deprecated=include_deprecated,
-                dynamic_fetch=True,
-            )
+                configured = (
+                    {
+                        configured_provider
+                        for configured_provider, _ in list_available_providers()
+                    }
+                    if available
+                    else None
+                )
+                models = get_model_list(
+                    provider_filter=provider,
+                    vision_only=vision,
+                    reasoning_only=reasoning,
+                    include_deprecated=include_deprecated,
+                    dynamic_fetch=True,
+                )
+        finally:
+            logging.disable(logging.NOTSET)
         if configured is not None:
             models = [model for model in models if model.provider_key in configured]
         click.echo(json.dumps([model_to_dict(model) for model in models], indent=2))

--- a/gptme/config/chat.py
+++ b/gptme/config/chat.py
@@ -197,9 +197,10 @@ class ChatConfig:
             try:
                 ensure_workspace_dir(workspace)
             except PermissionError:
-                # Log dirs owned by another user (e.g. bind-mounted from CI)
-                # should still be listable; skip workspace creation silently.
-                pass
+                logger.warning(
+                    f"Could not create workspace dir {workspace} (permission denied); "
+                    "log dir may be owned by another user"
+                )
             return cls(_logdir=path, workspace=workspace.resolve())
         try:
             if tomllib is not None:

--- a/gptme/config/chat.py
+++ b/gptme/config/chat.py
@@ -194,7 +194,12 @@ class ChatConfig:
             # This ensures server sessions get isolated workspaces
             # instead of sharing the server process's cwd.
             workspace = path / "workspace"
-            ensure_workspace_dir(workspace)
+            try:
+                ensure_workspace_dir(workspace)
+            except PermissionError:
+                # Log dirs owned by another user (e.g. bind-mounted from CI)
+                # should still be listable; skip workspace creation silently.
+                pass
             return cls(_logdir=path, workspace=workspace.resolve())
         try:
             if tomllib is not None:

--- a/tests/test_chat_config.py
+++ b/tests/test_chat_config.py
@@ -15,6 +15,29 @@ def test_chat_config_from_logdir(tmp_path: Path):
     assert loaded.model == "test-model"
 
 
+def test_chat_config_from_logdir_permission_error(tmp_path: Path, monkeypatch):
+    """from_logdir must not crash when workspace dir can't be created (PermissionError).
+
+    Reproduces the gptme/gptme#2958 scenario: log dirs seeded by one user and
+    then mounted read-only into a container running as a different user.
+    """
+    logdir = tmp_path / "conv"
+    logdir.mkdir()
+    # No config.toml → hits the ensure_workspace_dir branch
+
+    def _raise(_path):
+        raise PermissionError(13, "Permission denied", str(_path))
+
+    monkeypatch.setattr(
+        "gptme.config.chat.ensure_workspace_dir",
+        _raise,
+    )
+
+    loaded = ChatConfig.from_logdir(logdir)
+    # Conversation is still listed; workspace points to the intended path
+    assert loaded.workspace == (logdir / "workspace").resolve()
+
+
 def test_chat_config_from_logdir_workspace_symlink(tmp_path: Path):
     """from_logdir must not crash when 'workspace' is a pre-existing symlink.
 


### PR DESCRIPTION
## Problem

`GET /api/v2/conversations` returns HTTP 500 when `ChatConfig.from_logdir` tries to create a `workspace/` subdirectory inside a conversation log dir owned by a different user. The `ensure_workspace_dir` call fires for every log directory during the metadata scan — a read-only path — and the unhandled `PermissionError` propagates up, crashing the endpoint.

Reproduces when log dirs are seeded by one user and bind-mounted into a container running as `appuser` (the gptme-cloud perf-monitoring CI scenario).

Fixes #2958. Workaround in gptme-cloud: gptme/gptme-cloud#453.

## Fix

Wrap `ensure_workspace_dir` in `from_logdir` with `try/except PermissionError`. Conversations are still listed; the `workspace` field still points to the intended path so callers that create a new conversation (and gain write access) work normally.

```python
try:
    ensure_workspace_dir(workspace)
except PermissionError:
    # Log dirs owned by another user (e.g. bind-mounted from CI)
    # should still be listable; skip workspace creation silently.
    pass
```

## Test

Added `test_chat_config_from_logdir_permission_error` which monkeypatches `ensure_workspace_dir` to raise `PermissionError` and asserts that `from_logdir` still returns a valid `ChatConfig` with the correct `workspace` path.

All 12 tests in `tests/test_chat_config.py` pass.