### PR TITLE
feat(subagent): add subagent_list() tool for observability

### DIFF
--- a/gptme/tools/subagent/__init__.py
+++ b/gptme/tools/subagent/__init__.py
@@ -16,6 +16,7 @@ from ..base import ToolFunction, ToolSpec, ToolUse
 from .api import (
     subagent,
     subagent_cancel,
+    subagent_list,
     subagent_read_log,
     subagent_reply,
     subagent_status,
@@ -129,6 +130,20 @@ Assistant: I'll use ACP mode to run this via a different agent harness.
         ).to_output(tool_format)
     }
 System: Started subagent "claude-task" in ACP mode.
+
+### List Subagents (observability)
+User: what subagents are currently running?
+Assistant: I'll use subagent_list to check running agents.
+{
+        ToolUse(
+            "ipython",
+            [],
+            "subagent_list()",
+        ).to_output(tool_format)
+    }
+System: Listing 2 subagents::
+  - analyze (running, 42s) -- "Analyze the codebase architecture..."
+  - fib-13 (success, 120s) -- "compute the 13th Fibonacci number"
 
 ### Batch Execution (parallel tasks)
 User: implement, test, and document a feature in parallel
@@ -327,6 +342,7 @@ tool = ToolSpec(
         for f in [
             subagent,
             subagent_cancel,
+            subagent_list,
             subagent_reply,
             subagent_status,
             subagent_wait,
@@ -349,6 +365,7 @@ __all__ = [
     # Public API
     "subagent",
     "subagent_cancel",
+    "subagent_list",
     "subagent_reply",
     "subagent_status",
     "subagent_wait",

--- a/gptme/tools/subagent/api.py
+++ b/gptme/tools/subagent/api.py
@@ -12,7 +12,7 @@ import threading
 import uuid
 from dataclasses import asdict
 from pathlib import Path
-from typing import Literal
+from typing import Any, Literal
 
 from . import execution as _exec
 from .concurrency import get_slot_sem
@@ -764,7 +764,7 @@ def subagent_list() -> list[dict]:
     - status: running/success/failure/clarification_needed
     - model: The model used (or None)
     - execution_mode: thread/subprocess/acp
-    - elapsed_s: Seconds since the subagent started (from logdir mtime)
+    - elapsed_s: Seconds since the subagent started (from started_at timestamp)
     - prompt_preview: First 100 characters of the prompt
 
     Useful for:
@@ -778,7 +778,7 @@ def subagent_list() -> list[dict]:
     with _subagents_lock:
         agents = list(_subagents)  # copy under lock, then iterate outside
 
-    result = []
+    result: list[dict[str, Any]] = []
     for sa in agents:
         status = sa.status().status
 
@@ -800,7 +800,7 @@ def subagent_list() -> list[dict]:
         )
 
     # Sort newest first (smallest elapsed_s = most recently started)
-    result.sort(key=lambda x: x["elapsed_s"])  # type: ignore[arg-type,return-value]
+    result.sort(key=lambda x: x["elapsed_s"])
     return result
 
 

--- a/gptme/tools/subagent/api.py
+++ b/gptme/tools/subagent/api.py
@@ -756,6 +756,57 @@ def subagent_reply(agent_id: str, reply: str) -> None:
         raise
 
 
+def subagent_list() -> list[dict]:
+    """Returns a list of all subagents with their current status.
+
+    Each entry contains:
+    - agent_id: The subagent identifier
+    - status: running/success/failure/clarification_needed
+    - model: The model used (or None)
+    - execution_mode: thread/subprocess/acp
+    - elapsed_s: Seconds since the subagent started (from logdir mtime)
+    - prompt_preview: First 100 characters of the prompt
+
+    Useful for:
+    - Interactive sessions: "what's running right now?"
+    - Orchestrators deciding whether to spawn more agents
+    - Debugging runaway subagent fans
+    """
+    import time
+
+    now = time.time()
+    with _subagents_lock:
+        agents = list(_subagents)  # copy under lock, then iterate outside
+
+    result = []
+    for sa in agents:
+        status = sa.status().status
+
+        # Estimate elapsed time from logdir creation time
+        try:
+            elapsed_s = int(now - sa.logdir.stat().st_mtime)
+        except OSError:
+            elapsed_s = 0
+
+        # Truncate prompt for preview
+        prompt = sa.prompt[:97] + "..." if len(sa.prompt) > 100 else sa.prompt
+
+        result.append(
+            {
+                "agent_id": sa.agent_id,
+                "status": status,
+                "model": sa.model,
+                "execution_mode": sa.execution_mode,
+                "elapsed_s": max(elapsed_s, 0),
+                "prompt_preview": prompt,
+            }
+        )
+
+    # Sort newest first (by elapsed_s descending == most recent first)
+    result.sort(key=lambda x: x["elapsed_s"], reverse=True)  # type: ignore[arg-type,return-value]
+    return result
+
+
 def subagent_status(agent_id: str) -> dict:
     """Returns the status of a subagent."""
     with _subagents_lock:

--- a/gptme/tools/subagent/api.py
+++ b/gptme/tools/subagent/api.py
@@ -782,11 +782,8 @@ def subagent_list() -> list[dict]:
     for sa in agents:
         status = sa.status().status
 
-        # Estimate elapsed time from logdir creation time
-        try:
-            elapsed_s = int(now - sa.logdir.stat().st_mtime)
-        except OSError:
-            elapsed_s = 0
+        # Estimate elapsed time from start time
+        elapsed_s = int(now - sa.started_at)
 
         # Truncate prompt for preview
         prompt = sa.prompt[:97] + "..." if len(sa.prompt) > 100 else sa.prompt
@@ -802,8 +799,8 @@ def subagent_list() -> list[dict]:
             }
         )
 
-    # Sort newest first (by elapsed_s descending == most recent first)
-    result.sort(key=lambda x: x["elapsed_s"], reverse=True)  # type: ignore[arg-type,return-value]
+    # Sort newest first (smallest elapsed_s = most recently started)
+    result.sort(key=lambda x: x["elapsed_s"])  # type: ignore[arg-type,return-value]
     return result
 
 

--- a/gptme/tools/subagent/types.py
+++ b/gptme/tools/subagent/types.py
@@ -13,7 +13,8 @@ import re
 import subprocess
 import sys
 import threading
-from dataclasses import dataclass
+import time
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal, TypedDict
 
@@ -195,6 +196,8 @@ class Subagent:
     # Secret redaction: when True, common secret patterns (API keys, tokens, passwords)
     # are redacted from workspace context messages before they are seen by the subagent.
     redact_secrets: bool = False
+    # Timestamp (seconds since epoch) when this subagent was created
+    started_at: float = field(default_factory=time.time)
 
     def get_log(self) -> "LogManager":
         # noreorder

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -1687,9 +1687,11 @@ class TestPlannerRedactSecrets:
         monkeypatch.setattr(cli_main, "get_logdir", lambda name: tmp_path / name)
 
         captured_kwargs: list[dict] = []
+        called_event = threading.Event()
 
         def fake_create_subagent_thread(**kwargs):
             captured_kwargs.append(kwargs)
+            called_event.set()
 
         monkeypatch.setattr(
             exec_mod, "_create_subagent_thread", fake_create_subagent_thread
@@ -1703,11 +1705,9 @@ class TestPlannerRedactSecrets:
             redact_secrets=True,
         )
 
-        import time
-
-        time.sleep(0.05)
-
-        assert captured_kwargs, "_create_subagent_thread was never called"
+        assert called_event.wait(timeout=2.0), (
+            "_create_subagent_thread was never called"
+        )
         assert captured_kwargs[0].get("redact_secrets") is True, (
             "redact_secrets not forwarded to _create_subagent_thread"
         )
@@ -1733,11 +1733,13 @@ class TestPlannerRedactSecrets:
 
         monkeypatch.setattr(cli_main, "get_logdir", lambda name: tmp_path / name)
         monkeypatch.setattr(git_worktree, "get_git_root", lambda _: None)
-        monkeypatch.setattr(
-            exec_mod,
-            "_run_subagent_subprocess",
-            MagicMock(return_value=MagicMock()),
-        )
+        subprocess_called = threading.Event()
+
+        def subprocess_with_event(*args, **kwargs):
+            subprocess_called.set()
+            return MagicMock()
+
+        monkeypatch.setattr(exec_mod, "_run_subagent_subprocess", subprocess_with_event)
         monkeypatch.setattr(exec_mod, "_monitor_subprocess", lambda sa: None)
 
         with caplog.at_level(logging.WARNING, logger="gptme.tools.subagent.execution"):
@@ -1751,9 +1753,9 @@ class TestPlannerRedactSecrets:
                 redact_secrets=True,
             )
 
-        import time
-
-        time.sleep(0.05)
+        assert subprocess_called.wait(timeout=2.0), (
+            "_run_subagent_subprocess was never called"
+        )
 
         assert any(
             "redact_secrets=True" in record.message and "subprocess" in record.message

--- a/tests/test_tools_subagent.py
+++ b/tests/test_tools_subagent.py
@@ -2553,3 +2553,85 @@ def test_hint_allowlist_filters_subagent_tools(
         assert "hint:read-only" not in str(call), (
             "hint: pattern incorrectly flagged as unknown tool"
         )
+
+
+def test_subagent_list_empty():
+    """Test that subagent_list returns an empty list when no subagents exist."""
+    from gptme.tools.subagent import _subagents, _subagents_lock, subagent_list
+
+    with _subagents_lock:
+        _subagents.clear()
+    result = subagent_list()
+    assert isinstance(result, list)
+    assert result == []
+
+
+def test_subagent_list_structure(mock_create_thread: MagicMock):
+    """Test that subagent_list returns the correct structure."""
+    from gptme.tools.subagent import (
+        _subagents,
+        _subagents_lock,
+        subagent,
+        subagent_list,
+    )
+
+    with _subagents_lock:
+        _subagents.clear()
+
+    subagent(agent_id="test-list-1", prompt="Test agent one")
+    result = subagent_list()
+
+    assert isinstance(result, list)
+    assert len(result) >= 1
+
+    entry = result[0]
+    assert isinstance(entry, dict)
+    assert "agent_id" in entry
+    assert "status" in entry
+    assert "model" in entry
+    assert "execution_mode" in entry
+    assert "elapsed_s" in entry
+    assert "prompt_preview" in entry
+
+    # Verify types
+    assert isinstance(entry["agent_id"], str)
+    assert isinstance(entry["status"], str)
+    assert isinstance(entry["elapsed_s"], int)
+    assert isinstance(entry["prompt_preview"], str)
+
+    # Verify our agent is in the list
+    ids = [e["agent_id"] for e in result]
+    assert "test-list-1" in ids
+
+
+def test_subagent_list_prompt_truncation():
+    """Test that long prompts are truncated in the preview."""
+    import threading
+    from pathlib import Path
+
+    from gptme.tools.subagent import (
+        Subagent,
+        _subagents,
+        _subagents_lock,
+        subagent_list,
+    )
+
+    long_prompt = "x" * 200
+    sa = Subagent(
+        agent_id="test-truncate",
+        prompt=long_prompt,
+        thread=threading.Thread(),
+        logdir=Path("/tmp"),
+        model=None,
+    )
+    with _subagents_lock:
+        _subagents.append(sa)
+
+    try:
+        result = subagent_list()
+        entry = next(e for e in result if e["agent_id"] == "test-truncate")
+        assert len(entry["prompt_preview"]) <= 103  # 100 chars + "..."
+        assert entry["prompt_preview"].endswith("...")
+    finally:
+        with _subagents_lock:
+            _subagents[:] = [s for s in _subagents if s.agent_id != "test-truncate"]

--- a/tests/test_tools_subagent.py
+++ b/tests/test_tools_subagent.py
@@ -2566,6 +2566,7 @@ def test_subagent_list_empty():
     assert result == []
 
 
+@patch("gptme.tools.subagent.execution._create_subagent_thread")
 def test_subagent_list_structure(mock_create_thread: MagicMock):
     """Test that subagent_list returns the correct structure."""
     from gptme.tools.subagent import (

--- a/tests/test_tools_subagent.py
+++ b/tests/test_tools_subagent.py
@@ -2580,29 +2580,34 @@ def test_subagent_list_structure(mock_create_thread: MagicMock):
         _subagents.clear()
 
     subagent(agent_id="test-list-1", prompt="Test agent one")
+    _wait_for_new_subagent_threads(0)
     result = subagent_list()
 
-    assert isinstance(result, list)
-    assert len(result) >= 1
+    try:
+        assert isinstance(result, list)
+        assert len(result) >= 1
 
-    entry = result[0]
-    assert isinstance(entry, dict)
-    assert "agent_id" in entry
-    assert "status" in entry
-    assert "model" in entry
-    assert "execution_mode" in entry
-    assert "elapsed_s" in entry
-    assert "prompt_preview" in entry
+        entry = result[0]
+        assert isinstance(entry, dict)
+        assert "agent_id" in entry
+        assert "status" in entry
+        assert "model" in entry
+        assert "execution_mode" in entry
+        assert "elapsed_s" in entry
+        assert "prompt_preview" in entry
 
-    # Verify types
-    assert isinstance(entry["agent_id"], str)
-    assert isinstance(entry["status"], str)
-    assert isinstance(entry["elapsed_s"], int)
-    assert isinstance(entry["prompt_preview"], str)
+        # Verify types
+        assert isinstance(entry["agent_id"], str)
+        assert isinstance(entry["status"], str)
+        assert isinstance(entry["elapsed_s"], int)
+        assert isinstance(entry["prompt_preview"], str)
 
-    # Verify our agent is in the list
-    ids = [e["agent_id"] for e in result]
-    assert "test-list-1" in ids
+        # Verify our agent is in the list
+        ids = [e["agent_id"] for e in result]
+        assert "test-list-1" in ids
+    finally:
+        with _subagents_lock:
+            _subagents[:] = [s for s in _subagents if s.agent_id != "test-list-1"]
 
 
 def test_subagent_list_prompt_truncation():


### PR DESCRIPTION
Adds `subagent_list()` — returns all registered subagents with their status, execution mode, elapsed time, and a prompt preview.

Useful for:
- **Interactive sessions**: "what subagents are running right now?"
- **Orchestrators** deciding whether to spawn more agents
- **Debugging** runaway subagent fans

```python
subagent_list() -> list[dict]
# [
#   {"agent_id": "analyze", "status": "running", "execution_mode": "thread", "elapsed_s": 42, "prompt_preview": "..."},
#   {"agent_id": "fib-13", "status": "success", "execution_mode": "thread", "elapsed_s": 120, "prompt_preview": "..."},
# ]
```

Newest-first sorting. Prompt preview truncated at 100 chars.