### PR TITLE
fix(server): return 400 not 500 for unknown chat config keys

### DIFF
--- a/gptme/config/chat.py
+++ b/gptme/config/chat.py
@@ -8,7 +8,7 @@ import logging
 import os
 import sys
 import tempfile
-from dataclasses import asdict, dataclass, field, replace
+from dataclasses import asdict, dataclass, field, fields, replace
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -175,6 +175,23 @@ class ChatConfig:
         # Check for unknown keys
         if config_data:
             logger.warning(f"Unknown keys in chat config: {config_data.keys()}")
+
+        # Reject unknown keys remaining in chat_data at this (API) boundary with a
+        # ValueError instead of letting **chat_data raise TypeError in the
+        # constructor. Untrusted callers (e.g. the v2 conversation endpoints) only
+        # catch ValueError, so an unknown key like {"chat": {"foobar": 1}} would
+        # otherwise surface as a 500 instead of a clean 400.
+        _known_chat_fields = {f.name for f in fields(cls)} - {
+            "_logdir",
+            "agent",
+            "env",
+            "mcp",
+        }
+        unknown_chat_keys = set(chat_data) - _known_chat_fields
+        if unknown_chat_keys:
+            raise ValueError(
+                f"Unknown keys in chat config: {sorted(unknown_chat_keys)}"
+            )
 
         return cls(
             _logdir=_logdir,

--- a/tests/test_chat_config.py
+++ b/tests/test_chat_config.py
@@ -216,3 +216,17 @@ def test_chat_config_system_prompt_from_dict_validation(tmp_path: Path):
     data["chat"]["system_prompt"] = {"nested": "dict"}
     with pytest.raises(ValueError, match="chat.system_prompt must be a string"):
         ChatConfig.from_dict(data)
+
+
+def test_chat_config_unknown_chat_key_raises_value_error(tmp_path: Path):
+    """An unknown key under [chat] raises ValueError, not TypeError.
+
+    Untrusted callers (the v2 conversation endpoints) only catch ValueError, so
+    an unknown key must surface as a clean 400 rather than a 500 from the
+    ChatConfig(**chat_data) constructor.
+    """
+    config = ChatConfig(_logdir=tmp_path)
+    data = config.to_dict()
+    data["chat"]["foobar"] = 1
+    with pytest.raises(ValueError, match="Unknown keys in chat config"):
+        ChatConfig.from_dict(data)


### PR DESCRIPTION
## Problem

`ChatConfig.from_dict()` spreads remaining client-provided `[chat]` keys directly into the dataclass constructor via `**chat_data`. An unknown key raises `TypeError`, which the v2 conversation endpoints (`api_conversation_put`) do **not** catch — they only catch `ValueError`. So a request like:

```json
PUT /api/v2/conversations/<id>
{"config": {"chat": {"foobar": 1}}}
```

surfaces as a **500 Internal Server Error** instead of a clean **400 Bad Request**. This is the recurring "client input → 500/traceback instead of 4xx" bug class.

Reproduced against HEAD:
```
UNCAUGHT TypeError (handler -> 500): ChatConfig.__init__() got an unexpected keyword argument 'foobar'
```

## Fix

Validate unknown `chat` keys at the `from_dict` boundary and raise `ValueError`, consistent with how the function already rejects other malformed chat fields (`system_prompt`, `temperature`, `top_p`, `max_tokens`). The endpoint's existing `except ValueError` then returns a clean 400.

## Tests

- Added `test_chat_config_unknown_chat_key_raises_value_error` (confirmed RED before the fix: raised `TypeError`, GREEN after).
- `tests/test_chat_config.py` (13) and `tests/test_server_config_workspace_containment.py` + `tests/test_config.py` (76) all pass.

Found via autonomous server-API dogfooding (ErikBjare/bob#745 work-supply).

Co-Authored-By: Bob <bob@superuserlabs.org>