### PR TITLE
fix(subagent): make redact_secrets=True the default (secure by default)

### DIFF
--- a/gptme/tools/subagent/__init__.py
+++ b/gptme/tools/subagent/__init__.py
@@ -250,7 +250,7 @@ Key features:
 - use_acp=True: Run subagent via ACP protocol (supports any ACP-compatible agent)
 - acp_command="claude-code-acp": Use a different ACP agent (default: gptme-acp)
 - isolated=True: Run subagent in a git worktree for filesystem isolation
-- redact_secrets=True: Redact API keys, tokens, and passwords from workspace context
+- redact_secrets=True (default): Redact API keys, tokens, and passwords from workspace context
 - subagent_batch(): Start multiple subagents in parallel
 - subagent_cancel(): Cancel a running subagent (SIGTERM for subprocess, marks result for threads)
 - subagent_reply(agent_id, reply): Answer a clarification request and re-spawn the subagent
@@ -266,8 +266,9 @@ with a fresh context. What subagents DO inherit (in context_mode="full"):
 - User-level config files from ~/.config/gptme
 
 This means secrets stored in workspace config files or produced by context_cmd
-can reach the subagent. Use redact_secrets=True to scrub common secret patterns
-(API_KEY, TOKEN, PASSWORD, etc.) from these inherited context messages.
+can reach the subagent. Secret patterns (API_KEY, TOKEN, PASSWORD, etc.) are
+redacted by default (redact_secrets=True). Pass redact_secrets=False to disable
+if legitimate config values are incorrectly redacted.
 
 For stronger isolation, use context_mode="selective" with context_include=["agent"]
 to share only the agent identity (no workspace files or dynamic context).

--- a/gptme/tools/subagent/api.py
+++ b/gptme/tools/subagent/api.py
@@ -51,7 +51,7 @@ def subagent(
     isolated: bool | None = None,
     timeout: int = 1800,
     role: Role | None = None,
-    redact_secrets: bool = False,
+    redact_secrets: bool = True,
 ):
     """Starts an asynchronous subagent. Returns None immediately.
 
@@ -114,8 +114,8 @@ def subagent(
             Falls back to a temporary directory if not in a git repo.
         timeout: Maximum seconds before the subprocess monitor kills the
             subagent (default 1800 = 30 min). Only applies to subprocess mode.
-        redact_secrets: If True, scrub common secret patterns from workspace
-            context messages before they are passed to the subagent.
+        redact_secrets: If True (default), scrub common secret patterns from
+            workspace context messages before they are passed to the subagent.
             Redacts values from lines where the variable name matches patterns
             like API_KEY, TOKEN, PASSWORD, PRIVATE_KEY, etc.
 
@@ -127,7 +127,8 @@ def subagent(
 
             Only applies to thread-mode subagents (subprocess and ACP modes
             run as a separate gptme process and handle their own context).
-            Default: False (no redaction).
+            Set to False to disable redaction if legitimate config values are
+            being incorrectly redacted.
 
     Returns:
         None: Starts asynchronous execution.
@@ -270,7 +271,7 @@ def subagent(
 
     if redact_secrets and (use_acp or use_subprocess):
         exec_mode = "ACP" if use_acp else "subprocess"
-        logger.warning(
+        logger.debug(
             f"Subagent {agent_id}: 'redact_secrets=True' has no effect in {exec_mode} mode "
             "(only thread-mode subagents inherit workspace context from the parent process)"
         )

--- a/gptme/tools/subagent/batch.py
+++ b/gptme/tools/subagent/batch.py
@@ -74,6 +74,7 @@ def subagent_batch(
     use_subprocess: bool = False,
     use_acp: bool = False,
     acp_command: str = "gptme-acp",
+    redact_secrets: bool = True,
 ) -> BatchJob:
     """Start multiple subagents in parallel and return a BatchJob to manage them.
 
@@ -89,6 +90,9 @@ def subagent_batch(
         use_subprocess: If True, run subagents in subprocesses for output isolation
         use_acp: If True, run subagents via ACP protocol
         acp_command: ACP agent command (default: "gptme-acp")
+        redact_secrets: If True (default), redact secrets from workspace context
+            passed to subagents. Pass False only if you need subagents to see
+            config values that are incorrectly flagged as secrets.
 
     Returns:
         A BatchJob instance for managing the parallel subagents.
@@ -120,6 +124,7 @@ def subagent_batch(
             use_subprocess=use_subprocess,
             use_acp=use_acp,
             acp_command=acp_command,
+            redact_secrets=redact_secrets,
         )
 
     logger.info(f"Started batch of {len(tasks)} subagents: {job.agent_ids}")

--- a/gptme/tools/subagent/execution.py
+++ b/gptme/tools/subagent/execution.py
@@ -137,7 +137,7 @@ def _create_subagent_thread(
     output_schema: type | None = None,
     profile_name: str | None = None,
     agent_id: str | None = None,
-    redact_secrets: bool = False,
+    redact_secrets: bool = True,
 ) -> None:
     """Shared function for running subagent threads.
 
@@ -537,7 +537,7 @@ def _run_planner(
     context_include: list[str] | None = None,
     model: str | None = None,
     profile_name: str | None = None,
-    redact_secrets: bool = False,
+    redact_secrets: bool = True,
 ) -> None:
     """Run a planner that delegates work to multiple executor subagents.
 
@@ -647,7 +647,7 @@ def _run_planner(
 
         if resolved_use_subprocess:
             if redact_secrets:
-                logger.warning(
+                logger.debug(
                     f"Planner executor {executor_id}: 'redact_secrets=True' has no effect "
                     "in subprocess mode (only thread-mode subagents inherit workspace context)"
                 )

--- a/gptme/tools/subagent/execution.py
+++ b/gptme/tools/subagent/execution.py
@@ -552,7 +552,7 @@ def _run_planner(
             always overrides this when set — subtask role is more specific)
         redact_secrets: If True, scrub secret patterns from workspace context before
             thread-mode executors see it. Has no effect on subprocess-mode executors
-            (which manage their own context); a warning is logged in that case.
+            (which manage their own context); a debug message is logged in that case.
     """
     from gptme.cli.main import get_logdir
 

--- a/gptme/tools/subagent/types.py
+++ b/gptme/tools/subagent/types.py
@@ -195,7 +195,7 @@ class Subagent:
     role: Role | None = None
     # Secret redaction: when True, common secret patterns (API keys, tokens, passwords)
     # are redacted from workspace context messages before they are seen by the subagent.
-    redact_secrets: bool = False
+    redact_secrets: bool = True
     # Timestamp (seconds since epoch) when this subagent was created
     started_at: float = field(default_factory=time.time)
 

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -1285,7 +1285,7 @@ class TestClarifyBlock:
             "isolated": True,
             "timeout": 42,
             "role": "verify",
-            "redact_secrets": False,
+            "redact_secrets": True,
         }
         with _subagent_results_lock:
             assert "clarify-agent" not in _subagent_results
@@ -1563,12 +1563,13 @@ class TestRedactSecretsColonStyle:
 
 
 class TestRedactSecretsNonThreadWarning:
-    """Tests for redact_secrets=True warning when used in non-thread modes."""
+    """Tests for redact_secrets=True debug log when used in non-thread modes."""
 
-    def test_warns_when_redact_secrets_in_subprocess_mode(
+    def test_logs_when_redact_secrets_in_subprocess_mode(
         self, monkeypatch, tmp_path, caplog
     ):
-        """redact_secrets=True with use_subprocess=True logs a warning."""
+        """redact_secrets=True with use_subprocess=True logs a debug message (not a warning,
+        since redact_secrets=True is now the default and should not be noisy)."""
         import importlib
         import logging
 
@@ -1588,7 +1589,7 @@ class TestRedactSecretsNonThreadWarning:
         )
         monkeypatch.setattr(subagent_api._exec, "_monitor_subprocess", lambda sa: None)
 
-        with caplog.at_level(logging.WARNING, logger="gptme.tools.subagent.api"):
+        with caplog.at_level(logging.DEBUG, logger="gptme.tools.subagent.api"):
             subagent(
                 "warn-proc-agent",
                 "do the thing",
@@ -1604,7 +1605,13 @@ class TestRedactSecretsNonThreadWarning:
         assert any(
             "redact_secrets=True" in record.message and "subprocess" in record.message
             for record in caplog.records
-        ), f"Expected warning not found in: {[r.message for r in caplog.records]}"
+        ), f"Expected debug log not found in: {[r.message for r in caplog.records]}"
+        # Must NOT be a warning — the default True should not pollute users' logs
+        assert not any(
+            "redact_secrets=True" in record.message
+            and record.levelno >= logging.WARNING
+            for record in caplog.records
+        ), "redact_secrets no-op message should be DEBUG, not WARNING"
 
 
 class TestRedactSecretsThreadExecution:
@@ -1719,10 +1726,11 @@ class TestPlannerRedactSecrets:
                 if not s.agent_id.startswith("planner-test")
             ]
 
-    def test_planner_warns_redact_secrets_in_subprocess_executor(
+    def test_planner_logs_redact_secrets_in_subprocess_executor(
         self, monkeypatch, tmp_path, caplog
     ):
-        """_run_planner with redact_secrets=True warns when executor uses subprocess."""
+        """_run_planner with redact_secrets=True emits a debug log (not warning)
+        when an executor uses subprocess, since redact_secrets=True is now the default."""
         import importlib
         import logging
 
@@ -1742,7 +1750,7 @@ class TestPlannerRedactSecrets:
         monkeypatch.setattr(exec_mod, "_run_subagent_subprocess", subprocess_with_event)
         monkeypatch.setattr(exec_mod, "_monitor_subprocess", lambda sa: None)
 
-        with caplog.at_level(logging.WARNING, logger="gptme.tools.subagent.execution"):
+        with caplog.at_level(logging.DEBUG, logger="gptme.tools.subagent.execution"):
             exec_mod._run_planner(
                 agent_id="planner-warn",
                 prompt="orchestrate",
@@ -1760,7 +1768,13 @@ class TestPlannerRedactSecrets:
         assert any(
             "redact_secrets=True" in record.message and "subprocess" in record.message
             for record in caplog.records
-        ), f"Expected warning not found in: {[r.message for r in caplog.records]}"
+        ), f"Expected debug log not found in: {[r.message for r in caplog.records]}"
+        # Must NOT be a warning — default True should not pollute users' logs
+        assert not any(
+            "redact_secrets=True" in record.message
+            and record.levelno >= logging.WARNING
+            for record in caplog.records
+        ), "redact_secrets no-op message should be DEBUG, not WARNING"
 
         with types_mod._subagents_lock:
             types_mod._subagents[:] = [


### PR DESCRIPTION
## Summary

Prior PR #2950 added `redact_secrets` as an opt-in parameter (defaulting to `False`), but this left the issue (#2949) unresolved: **secrets still leaked into subagent workspace context by default** unless callers explicitly passed `redact_secrets=True`.

This PR makes secret redaction the default, completing the fix.

## Changes

- **`redact_secrets` default: `False` → `True`** in `Subagent` dataclass, `subagent()`, `_create_subagent_thread()`, and `_run_planner()`
- **Subprocess/ACP log: `WARNING` → `DEBUG`** — with `True` as the default, every subprocess subagent would otherwise emit a spurious warning the user didn't ask for
- **Instructions updated** in `__init__.py` to document the new default
- **Tests updated** to match new default and log level

## Behavior

- Thread-mode subagents: API keys, tokens, passwords in workspace context (gptme.toml `[prompt] files`, `context_cmd` output, `~/.config/gptme`) are now redacted by default
- Pass `redact_secrets=False` to disable if legitimate config values are incorrectly redacted
- Subprocess and ACP modes: unchanged (they run as separate `gptme` processes; use `context_mode="selective"` for stronger isolation there)

## Test plan

- [x] All 200 unit + subagent tests pass (`test_subagent_unit.py`, `test_tools_subagent.py`, `test_subagent_concurrency.py`)
- [x] Tests updated to assert new default (`True`) and verify warning was downgraded to DEBUG

Closes #2949