### PR TITLE
feat(cli): add context search-conversations subcommand for RAG conversation search

### DIFF
--- a/gptme/cli/util.py
+++ b/gptme/cli/util.py
@@ -375,7 +375,7 @@ def context_search_conversations(query: str, top_k: int):
     init()
 
     # Search for the query
-    results = rag_search(query, return_full=True)
+    results = rag_search(query, return_full=True, top_k=top_k)
 
     if not results.strip():
         print(

--- a/gptme/cli/util.py
+++ b/gptme/cli/util.py
@@ -347,6 +347,48 @@ def context_retrieve(query: str, full: bool):
     print(results)
 
 
+@context.command("search-conversations")
+@click.argument("query")
+@click.option(
+    "--top-k",
+    default=3,
+    show_default=True,
+    type=int,
+    help="Number of results to return",
+)
+def context_search_conversations(query: str, top_k: int):
+    """Search indexed conversations for relevant context.
+
+    Returns the most relevant past conversation snippets for the given query.
+    Requires conversations to be indexed first with `rag_index_conversations`
+    (use `rag_index_conversations()` via the ipython tool, or `gptme context index` on a directory).
+    """
+    from ..tools.rag import _has_gptme_rag, init, rag_search  # fmt: skip
+
+    if not _has_gptme_rag():
+        print(
+            "Error: gptme-rag is not installed. Please install it to use this feature."
+        )
+        sys.exit(1)
+
+    # Initialize RAG
+    init()
+
+    # Search for the query
+    results = rag_search(query, return_full=True)
+
+    if not results.strip():
+        print(
+            "No relevant conversations found. "
+            "Try indexing conversations first with `rag_index_conversations()` "
+            "via the ipython tool."
+        )
+        return
+
+    print(f"Top {top_k} relevant conversations:\n")
+    print(results)
+
+
 def _git_run(cmd: list[str], check: bool = True, timeout: int = 10) -> tuple[str, bool]:
     """Run a git command and return (stdout, success)."""
     try:

--- a/gptme/tools/rag.py
+++ b/gptme/tools/rag.py
@@ -168,12 +168,14 @@ def rag_index(*paths: str, glob: str | None = None) -> str:
     return result.stdout.strip()
 
 
-def rag_search(query: str, return_full: bool = False) -> str:
+def rag_search(query: str, return_full: bool = False, top_k: int | None = None) -> str:
     """Search indexed documents."""
     cmd = ["gptme-rag", "search", query]
     if return_full:
         # shows full context of the search results
         cmd.extend(["--raw"])
+    if top_k is not None:
+        cmd.extend(["--top-k", str(top_k)])
 
     result = _run_rag_cmd(cmd)
     return result.stdout.strip()

--- a/tests/test_util_cli.py
+++ b/tests/test_util_cli.py
@@ -12,7 +12,6 @@ from click.testing import CliRunner
 from gptme.cli.util import main
 from gptme.logmanager import ConversationMeta
 from gptme.profiles import Profile
-from gptme.tools.rag import _has_gptme_rag
 
 
 def test_tokens_count(tmp_path):
@@ -1144,21 +1143,30 @@ def test_context_journal_rejects_file_path(tmp_path):
     assert "Directory" in result.output
 
 
-@pytest.mark.skipif(not _has_gptme_rag(), reason="RAG is not available")
 def test_context_search_conversations(tmp_path):
-    """context search-conversations is registered and runs without error."""
+    """context search-conversations is registered and returns results."""
+    from unittest.mock import patch
+
     runner = CliRunner()
-    result = runner.invoke(main, ["context", "search-conversations", "pytest"])
+    with patch(
+        "gptme.tools.rag.rag_search", return_value="snippet from a past conversation"
+    ):
+        result = runner.invoke(main, ["context", "search-conversations", "pytest"])
     assert result.exit_code == 0, result.output
     assert "Top 3 relevant conversations" in result.output
 
 
-@pytest.mark.skipif(not _has_gptme_rag(), reason="RAG is not available")
 def test_context_search_conversations_top_k(tmp_path):
-    """context search-conversations --top-k option works."""
+    """context search-conversations --top-k option is forwarded correctly."""
+    from unittest.mock import patch
+
     runner = CliRunner()
-    result = runner.invoke(
-        main, ["context", "search-conversations", "--top-k", "5", "pytest"]
-    )
+    with patch(
+        "gptme.tools.rag.rag_search", return_value="snippet from a past conversation"
+    ) as mock_search:
+        result = runner.invoke(
+            main, ["context", "search-conversations", "--top-k", "5", "pytest"]
+        )
     assert result.exit_code == 0, result.output
     assert "Top 5 relevant conversations" in result.output
+    mock_search.assert_called_once_with("pytest", return_full=True, top_k=5)

--- a/tests/test_util_cli.py
+++ b/tests/test_util_cli.py
@@ -1148,8 +1148,12 @@ def test_context_search_conversations(tmp_path):
     from unittest.mock import patch
 
     runner = CliRunner()
-    with patch(
-        "gptme.tools.rag.rag_search", return_value="snippet from a past conversation"
+    with (
+        patch("gptme.tools.rag._has_gptme_rag", return_value=True),
+        patch(
+            "gptme.tools.rag.rag_search",
+            return_value="snippet from a past conversation",
+        ),
     ):
         result = runner.invoke(main, ["context", "search-conversations", "pytest"])
     assert result.exit_code == 0, result.output
@@ -1161,9 +1165,13 @@ def test_context_search_conversations_top_k(tmp_path):
     from unittest.mock import patch
 
     runner = CliRunner()
-    with patch(
-        "gptme.tools.rag.rag_search", return_value="snippet from a past conversation"
-    ) as mock_search:
+    with (
+        patch("gptme.tools.rag._has_gptme_rag", return_value=True),
+        patch(
+            "gptme.tools.rag.rag_search",
+            return_value="snippet from a past conversation",
+        ) as mock_search,
+    ):
         result = runner.invoke(
             main, ["context", "search-conversations", "--top-k", "5", "pytest"]
         )

--- a/tests/test_util_cli.py
+++ b/tests/test_util_cli.py
@@ -12,6 +12,7 @@ from click.testing import CliRunner
 from gptme.cli.util import main
 from gptme.logmanager import ConversationMeta
 from gptme.profiles import Profile
+from gptme.tools.rag import _has_gptme_rag
 
 
 def test_tokens_count(tmp_path):
@@ -1143,6 +1144,7 @@ def test_context_journal_rejects_file_path(tmp_path):
     assert "Directory" in result.output
 
 
+@pytest.mark.skipif(not _has_gptme_rag(), reason="RAG is not available")
 def test_context_search_conversations(tmp_path):
     """context search-conversations is registered and runs without error."""
     runner = CliRunner()
@@ -1151,6 +1153,7 @@ def test_context_search_conversations(tmp_path):
     assert "Top 3 relevant conversations" in result.output
 
 
+@pytest.mark.skipif(not _has_gptme_rag(), reason="RAG is not available")
 def test_context_search_conversations_top_k(tmp_path):
     """context search-conversations --top-k option works."""
     runner = CliRunner()

--- a/tests/test_util_cli.py
+++ b/tests/test_util_cli.py
@@ -1141,3 +1141,21 @@ def test_context_journal_rejects_file_path(tmp_path):
     result = runner.invoke(main, ["context", "journal", "--path", str(journal_file)])
     assert result.exit_code != 0
     assert "Directory" in result.output
+
+
+def test_context_search_conversations(tmp_path):
+    """context search-conversations is registered and runs without error."""
+    runner = CliRunner()
+    result = runner.invoke(main, ["context", "search-conversations", "pytest"])
+    assert result.exit_code == 0, result.output
+    assert "Top 3 relevant conversations" in result.output
+
+
+def test_context_search_conversations_top_k(tmp_path):
+    """context search-conversations --top-k option works."""
+    runner = CliRunner()
+    result = runner.invoke(
+        main, ["context", "search-conversations", "--top-k", "5", "pytest"]
+    )
+    assert result.exit_code == 0, result.output
+    assert "Top 5 relevant conversations" in result.output


### PR DESCRIPTION
## Summary

Adds `gptme context search-conversations <query>` — a dedicated CLI subcommand for searching indexed conversations using the existing RAG infrastructure.

## Changes
- New `context search-conversations <query>` subcommand in `gptme/cli/util.py`
- `--top-k N` option to control result count (default 3)
- Follows the existing `context index` / `context retrieve` pattern
- Tests: verify registration and output format

## Usage
```
gptme context search-conversations "pytest fixtures"
```
Requires: gptme-rag installed + conversations indexed via rag_index_conversations()

## Acceptance
- [x] `gptme context search-conversations "pytest"` returns top-3 results with snippet
- [x] `--top-k 5` controls result count
- [x] Error message when gptme-rag not installed
- [x] Graceful message when no conversations indexed
