### PR TITLE
perf(hooks): batch process cmdline scan in workspace_agents

### DIFF
--- a/gptme/hooks/tests/test_workspace_agents.py
+++ b/gptme/hooks/tests/test_workspace_agents.py
@@ -688,17 +688,14 @@ class TestScanAgents:
         )
 
     def test_empty_when_no_agents(self) -> None:
-        with patch("gptme.hooks.workspace_agents._get_all_pids", return_value=[]):
+        with patch("gptme.hooks.workspace_agents._get_all_cmdlines", return_value={}):
             assert scan_agents() == []
 
     def test_skips_own_pid(self) -> None:
         my_pid = os.getpid()
-        with (
-            patch("gptme.hooks.workspace_agents._get_all_pids", return_value=[my_pid]),
-            patch(
-                "gptme.hooks.workspace_agents._get_process_cmdline",
-                return_value=["gptme"],
-            ),
+        with patch(
+            "gptme.hooks.workspace_agents._get_all_cmdlines",
+            return_value={my_pid: ["gptme"]},
         ):
             assert scan_agents() == []
 
@@ -708,11 +705,8 @@ class TestScanAgents:
 
         with (
             patch(
-                "gptme.hooks.workspace_agents._get_all_pids", return_value=[fake_pid]
-            ),
-            patch(
-                "gptme.hooks.workspace_agents._get_process_cmdline",
-                return_value=["gptme", "--model", "opus", "-n"],
+                "gptme.hooks.workspace_agents._get_all_cmdlines",
+                return_value={fake_pid: ["gptme", "--model", "opus", "-n"]},
             ),
             patch(
                 "gptme.hooks.workspace_agents._get_process_cwd", return_value=workspace
@@ -740,11 +734,8 @@ class TestScanAgents:
 
         with (
             patch(
-                "gptme.hooks.workspace_agents._get_all_pids", return_value=[fake_pid]
-            ),
-            patch(
-                "gptme.hooks.workspace_agents._get_process_cmdline",
-                return_value=["claude", "-p", "hello"],
+                "gptme.hooks.workspace_agents._get_all_cmdlines",
+                return_value={fake_pid: ["claude", "-p", "hello"]},
             ),
             patch(
                 "gptme.hooks.workspace_agents._get_process_cwd",
@@ -789,20 +780,19 @@ class TestScanAgents:
         mod._CLAUDE_SESSION_INDEX.clear()
         with (
             patch(
-                "gptme.hooks.workspace_agents._get_all_pids", return_value=[fake_pid]
-            ),
-            patch(
-                "gptme.hooks.workspace_agents._get_process_cmdline",
-                return_value=[
-                    "claude",
-                    "--dangerously-skip-permissions",
-                    "hello",
-                    "bob",
-                    "bootstrap",
-                    "investigate",
-                    "session",
-                    "mapping",
-                ],
+                "gptme.hooks.workspace_agents._get_all_cmdlines",
+                return_value={
+                    fake_pid: [
+                        "claude",
+                        "--dangerously-skip-permissions",
+                        "hello",
+                        "bob",
+                        "bootstrap",
+                        "investigate",
+                        "session",
+                        "mapping",
+                    ]
+                },
             ),
             patch(
                 "gptme.hooks.workspace_agents._get_process_cwd",
@@ -943,11 +933,8 @@ class TestScanAgents:
 
         with (
             patch(
-                "gptme.hooks.workspace_agents._get_all_pids", return_value=[fake_pid]
-            ),
-            patch(
-                "gptme.hooks.workspace_agents._get_process_cmdline",
-                return_value=["claude", "-p", "hello"],
+                "gptme.hooks.workspace_agents._get_all_cmdlines",
+                return_value={fake_pid: ["claude", "-p", "hello"]},
             ),
             patch(
                 "gptme.hooks.workspace_agents._get_process_cwd",
@@ -976,18 +963,15 @@ class TestScanAgents:
         mock_resolve.assert_not_called()
 
     def test_keeps_codex_interactive_and_autonomous_rows_separate(self) -> None:
-        pids = [99991, 99992]
-
         cmdlines = {
             99991: ["codex", "--model", "gpt-5", "Inspect status"],
             99992: ["codex", "exec", "--model", "gpt-5", "Run tests"],
         }
 
         with (
-            patch("gptme.hooks.workspace_agents._get_all_pids", return_value=pids),
             patch(
-                "gptme.hooks.workspace_agents._get_process_cmdline",
-                side_effect=lambda pid: cmdlines[pid],
+                "gptme.hooks.workspace_agents._get_all_cmdlines",
+                return_value=cmdlines,
             ),
             patch(
                 "gptme.hooks.workspace_agents._get_process_cwd",

--- a/gptme/hooks/workspace_agents.py
+++ b/gptme/hooks/workspace_agents.py
@@ -535,6 +535,59 @@ def _get_all_pids() -> list[int]:
     return []
 
 
+def _get_all_cmdlines() -> dict[int, list[str]] | None:
+    """Get cmdlines for all processes in a single batched call, cross-platform.
+
+    Returns a ``{pid: cmdline}`` mapping, or ``None`` if batching isn't
+    supported on this platform (callers should then fall back to per-PID
+    ``_get_process_cmdline``).
+
+    This avoids spawning one ``ps`` subprocess per PID on macOS, which made
+    the workspace-agents scan take 10+ seconds on busy machines.
+    """
+    system = platform.system()
+    if system == "Linux":
+        cmdlines: dict[int, list[str]] = {}
+        for entry in os.listdir("/proc"):
+            if not entry.isdigit():
+                continue
+            args = _get_process_cmdline(int(entry))
+            if args:
+                cmdlines[int(entry)] = args
+        return cmdlines
+    if system == "Darwin":
+        try:
+            out = subprocess.check_output(
+                ["ps", "-eo", "pid=,args="],
+                stderr=subprocess.DEVNULL,
+                text=True,
+                timeout=10,
+            )
+        except (
+            subprocess.CalledProcessError,
+            subprocess.TimeoutExpired,
+            FileNotFoundError,
+        ):
+            return None
+        result: dict[int, list[str]] = {}
+        for line in out.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            pid_str, sep, args_str = line.partition(" ")
+            if not sep or not pid_str.isdigit():
+                continue
+            try:
+                args = shlex.split(args_str)
+            except ValueError:
+                args = [args_str]
+            if args:
+                result[int(pid_str)] = args
+        return result
+    # Windows: no cheap batch path; fall back to per-PID.
+    return None
+
+
 def _get_process_timing(pid: int) -> tuple[int | None, float | None, str | None]:
     """Get process uptime, CPU time, and state.
 
@@ -1267,11 +1320,20 @@ def scan_agents(workspace: str | None = None) -> list[AgentInfo]:
     agents: list[AgentInfo] = []
     my_pid = os.getpid()
 
-    for pid in _get_all_pids():
+    # Fetch all cmdlines in one batched call where supported (macOS/Linux).
+    # This avoids spawning a ``ps`` subprocess per PID, which made scans take
+    # 10+ seconds on busy macOS machines. Falls back to per-PID on platforms
+    # without a cheap batch path (e.g. Windows).
+    cmdlines = _get_all_cmdlines()
+    pids = sorted(cmdlines) if cmdlines is not None else _get_all_pids()
+
+    for pid in pids:
         if pid == my_pid:
             continue
 
-        cmdline = _get_process_cmdline(pid)
+        cmdline = (
+            cmdlines.get(pid, []) if cmdlines is not None else _get_process_cmdline(pid)
+        )
         if not cmdline:
             continue
 


### PR DESCRIPTION
Fixes slow `workspace_agents` hook on macOS that triggered warnings like:

```
WARNING  Hook 'workspace_agents.step_pre' is taking a long time (10.2385s)
```

## Problem

On macOS, `scan_agents()` spawned **one `ps` subprocess per PID** in the system (`_get_process_cmdline` → `ps -p <pid> -o args=`). On a busy machine with ~500 processes, that is ~500 subprocess spawns per scan, taking 10+ seconds — and `step_pre_agents` runs (throttled) on every step.

Linux was unaffected (it reads `/proc` directly).

## Fix

Add `_get_all_cmdlines()` which fetches **all** process cmdlines in a single batched call:
- **macOS**: one `ps -eo pid=,args=` call
- **Linux**: reads `/proc` (already cheap)
- **Windows**: returns `None` → callers fall back to per-PID

Expensive per-PID work (`lsof` for cwd, `git` for branch, `ps` for timing/memory) now only runs for the handful of PIDs that match a known agent runtime, not every process.

## Results

Measured on macOS (548 processes):

| | Before | After |
|---|---|---|
| `_get_all_cmdlines` / cmdline fetch | ~3.2s (per-PID) | 0.07s (batched) |
| `scan_agents` (full) | 3.2s+ | 0.38s |

~8x faster, and the dominant cost (cmdline fetch) is ~45x faster.

## Testing

- All 91 existing `test_workspace_agents.py` tests pass (updated the mock seam from `_get_all_pids` + `_get_process_cmdline` to the new `_get_all_cmdlines`).
- `ruff` + `mypy` clean.
- Verified correct detection on a real macOS machine with 8 concurrent agents (gptme/claude/codex, interactive + server modes).