### PR TITLE
fix(shell): only show workspace-detected hint once per workspace

### DIFF
--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -1427,12 +1427,18 @@ def execute_shell_impl(
                 yield workspace_hint
 
 
+# Workspace paths already hinted this session, so we don't spam the
+# "Workspace detected" message on every cd into the same workspace.
+_hinted_workspaces: set[str] = set()
+
+
 def _check_workspace_config() -> Message | None:
     """Return a hint message if the current directory has a gptme.toml config.
 
     Called after a successful ``cd`` to let the agent know it can spawn a
     workspace-aware subagent instead of running in a generic context.
-    Returns None if no gptme.toml is found (or CWD lookup fails).
+    Returns None if no gptme.toml is found (or CWD lookup fails), or if this
+    workspace has already been hinted this session.
     """
     try:
         cwd = Path.cwd()
@@ -1442,6 +1448,12 @@ def _check_workspace_config() -> Message | None:
     config_file = cwd / "gptme.toml"
     if not config_file.exists():
         return None
+
+    # Only hint once per workspace per session.
+    workspace_key = str(cwd.resolve())
+    if workspace_key in _hinted_workspaces:
+        return None
+    _hinted_workspaces.add(workspace_key)
 
     workspace_name = cwd.name
     return Message(

--- a/tests/test_tools_shell.py
+++ b/tests/test_tools_shell.py
@@ -1843,7 +1843,7 @@ def test_check_workspace_config_with_gptme_toml(tmp_path):
 
 def test_check_workspace_config_hint_includes_workspace_name(tmp_path):
     """The suggestion uses the workspace directory name as the agent_id."""
-    from gptme.tools.shell import _check_workspace_config
+    from gptme.tools.shell import _check_workspace_config, _hinted_workspaces
 
     workspace = tmp_path / "my-project"
     workspace.mkdir()
@@ -1852,11 +1852,33 @@ def test_check_workspace_config_hint_includes_workspace_name(tmp_path):
     original_cwd = os.getcwd()
     try:
         os.chdir(workspace)
+        _hinted_workspaces.discard(str(workspace.resolve()))
         result = _check_workspace_config()
         assert result is not None
         assert "my-project" in result.content
     finally:
         os.chdir(original_cwd)
+
+
+def test_check_workspace_config_hints_only_once_per_workspace(tmp_path):
+    """The hint fires once per workspace per session, not on every cd."""
+    from gptme.tools.shell import _check_workspace_config, _hinted_workspaces
+
+    (tmp_path / "gptme.toml").write_text("[gptme]\n")
+
+    original_cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        _hinted_workspaces.discard(str(tmp_path.resolve()))
+
+        first = _check_workspace_config()
+        assert first is not None  # first cd into workspace → hint
+
+        second = _check_workspace_config()
+        assert second is None  # subsequent cd into same workspace → no hint
+    finally:
+        os.chdir(original_cwd)
+        _hinted_workspaces.discard(str(tmp_path.resolve()))
 
 
 def test_shell_bare_cd_updates_working_directory(tmp_path):

--- a/tests/test_tools_shell.py
+++ b/tests/test_tools_shell.py
@@ -1824,7 +1824,10 @@ def test_check_workspace_config_no_gptme_toml(tmp_path):
 
 def test_check_workspace_config_with_gptme_toml(tmp_path):
     """Returns a hint Message when gptme.toml exists in the current directory."""
-    from gptme.tools.shell import _check_workspace_config
+    from gptme.tools.shell import _check_workspace_config, _hinted_workspaces
+
+    # Ensure clean state for isolation
+    _hinted_workspaces.discard(str(tmp_path.resolve()))
 
     (tmp_path / "gptme.toml").write_text("[gptme]\n")
 


### PR DESCRIPTION
## Problem

The `📂 Workspace detected: ... has a gptme.toml config` hint fires on **every** `cd` into a directory containing a `gptme.toml`. When navigating around a workspace — or bouncing between a couple of them (e.g. main repo + worktrees) — this spams the same hint repeatedly into the context, wasting tokens and adding noise to every shell result.

## Fix

Track hinted workspace paths in a module-level `_hinted_workspaces` set. Each resolved workspace path is hinted at most **once per session** — subsequent `cd`s into the same workspace return no hint.

This keeps the genuinely-useful first-time hint (suggesting a workspace-aware subagent) while eliminating the repetition.

## Testing

- Added `test_check_workspace_config_hints_only_once_per_workspace` — verifies first call hints, second call into the same workspace does not.
- Existing `_check_workspace_config` tests updated to clear session state for isolation.
- `ruff` + `mypy` clean.