### PR TITLE
feat(subagent): context_window parameter for workspace context isolation

### DIFF
--- a/gptme/tools/subagent/api.py
+++ b/gptme/tools/subagent/api.py
@@ -52,6 +52,7 @@ def subagent(
     timeout: int = 1800,
     role: Role | None = None,
     redact_secrets: bool = True,
+    context_window: int | None = None,
 ):
     """Starts an asynchronous subagent. Returns None immediately.
 
@@ -129,6 +130,22 @@ def subagent(
             run as a separate gptme process and handle their own context).
             Set to False to disable redaction if legitimate config values are
             being incorrectly redacted.
+        context_window: Limit workspace context messages passed to the subagent.
+            Controls how much of the workspace context (files from gptme.toml
+            [prompt] files, context_cmd output) is shared with the subagent.
+
+            - ``None`` (default): no limit — full workspace context is shared.
+            - ``0``: minimal context — only agent identity and tools; no workspace
+              files or context_cmd output. Equivalent to
+              ``context_mode="selective", context_include=["agent", "tools"]``.
+            - ``N > 0``: at most N workspace context messages are passed.
+
+            Use ``context_window=0`` when the subagent does not need the parent
+            workspace configuration (e.g. a verification task that should only
+            see what the orchestrator explicitly tells it).
+
+            Only applies to thread-mode subagents; has no effect in subprocess
+            or ACP modes (which build their own context as a separate process).
 
     Returns:
         None: Starts asynchronous execution.
@@ -212,6 +229,8 @@ def subagent(
             context_include,
             model_name,
             profile_name=profile,
+            redact_secrets=redact_secrets,
+            context_window=context_window,
         )
 
     # Validate context_mode parameters
@@ -545,6 +564,7 @@ def subagent(
                         profile_name=profile,
                         agent_id=agent_id,
                         redact_secrets=redact_secrets,
+                        context_window=context_window,
                     )
                 except Exception as e:
                     # If subagent creation fails, notify with error status
@@ -618,6 +638,7 @@ def subagent(
             repo_path=repo_path,
             role=role,
             redact_secrets=redact_secrets,
+            context_window=context_window,
         )
         with _subagents_lock:
             _subagents.append(sa)
@@ -747,6 +768,7 @@ def subagent_reply(agent_id: str, reply: str) -> None:
             timeout=sa.timeout,
             role=sa.role,
             redact_secrets=sa.redact_secrets,
+            context_window=sa.context_window,
         )
     except Exception:
         with _subagents_lock:

--- a/gptme/tools/subagent/execution.py
+++ b/gptme/tools/subagent/execution.py
@@ -229,13 +229,31 @@ def _create_subagent_thread(
     if context_window == 0:
         # Minimal context: just agent identity and tools, no workspace files.
         # This is the context isolation mode requested by the --isolate flag.
+        # Note: if context_mode="selective" is also set, context_window=0 takes
+        # precedence and the context_include list is ignored — agent+tools only.
         from ...prompts import prompt_gptme, prompt_tools
 
+        if (
+            context_mode == "selective"
+            and context_include
+            and set(context_include)
+            - {
+                "agent",
+                "tools",
+            }
+        ):
+            logger.warning(
+                "context_window=0 overrides context_include=%r; "
+                "only agent identity and tools will be included",
+                context_include,
+            )
         initial_msgs = list(prompt_gptme(False, None, agent_name=None)) + list(
             prompt_tools(tools=available_tools, tool_format="markdown")
         )
     elif context_mode == "selective":
-        # Selective context - build from specified components
+        # Selective context — build from specified components.
+        # context_window > 0 is not applied in selective mode; the caller
+        # controls the context set explicitly via context_include instead.
         from ...prompts import prompt_gptme, prompt_tools
 
         initial_msgs = []
@@ -252,14 +270,19 @@ def _create_subagent_thread(
             )
     else:  # "full" mode (default)
         # Full context (using profile-filtered tools)
+        from ...prompts import prompt_gptme, prompt_tools
+
         initial_msgs = get_prompt(
             available_tools, interactive=False, workspace=workspace
         )
         # Truncate workspace context if a positive window is specified.
-        # Keeps the first two messages (agent identity + tools) and limits
-        # additional workspace context messages to context_window total messages.
+        # The base messages (agent identity + tools) do NOT count against the
+        # window — only the workspace context messages after them do.
         if context_window is not None and context_window > 0:
-            initial_msgs = initial_msgs[:context_window]
+            n_base = len(list(prompt_gptme(False, None, agent_name=None))) + len(
+                list(prompt_tools(tools=available_tools, tool_format="markdown"))
+            )
+            initial_msgs = initial_msgs[: n_base + context_window]
 
     # Apply secret redaction to workspace context messages if requested.
     # This redacts values from lines where the variable name matches common

--- a/gptme/tools/subagent/execution.py
+++ b/gptme/tools/subagent/execution.py
@@ -138,6 +138,7 @@ def _create_subagent_thread(
     profile_name: str | None = None,
     agent_id: str | None = None,
     redact_secrets: bool = True,
+    context_window: int | None = None,
 ) -> None:
     """Shared function for running subagent threads.
 
@@ -151,6 +152,9 @@ def _create_subagent_thread(
         target: Who will review the results ("parent" or "planner")
         profile_name: Optional agent profile to apply (system prompt + hard tool enforcement)
         agent_id: Identifier stored in thread-local so the progress tool can self-identify
+        context_window: Limit workspace context messages. None = no limit; 0 = minimal
+            context (just agent identity + tools, no workspace files); N > 0 = at most
+            N workspace context messages included.
     """
     # Store agent_id in thread-local so the progress tool can identify this subagent
     if agent_id is not None:
@@ -221,8 +225,16 @@ def _create_subagent_thread(
 
     prompt_msgs = [Message("user", prompt)]
 
-    # Build initial messages based on context_mode
-    if context_mode == "selective":
+    # Build initial messages based on context_mode and context_window
+    if context_window == 0:
+        # Minimal context: just agent identity and tools, no workspace files.
+        # This is the context isolation mode requested by the --isolate flag.
+        from ...prompts import prompt_gptme, prompt_tools
+
+        initial_msgs = list(prompt_gptme(False, None, agent_name=None)) + list(
+            prompt_tools(tools=available_tools, tool_format="markdown")
+        )
+    elif context_mode == "selective":
         # Selective context - build from specified components
         from ...prompts import prompt_gptme, prompt_tools
 
@@ -243,6 +255,11 @@ def _create_subagent_thread(
         initial_msgs = get_prompt(
             available_tools, interactive=False, workspace=workspace
         )
+        # Truncate workspace context if a positive window is specified.
+        # Keeps the first two messages (agent identity + tools) and limits
+        # additional workspace context messages to context_window total messages.
+        if context_window is not None and context_window > 0:
+            initial_msgs = initial_msgs[:context_window]
 
     # Apply secret redaction to workspace context messages if requested.
     # This redacts values from lines where the variable name matches common
@@ -538,6 +555,7 @@ def _run_planner(
     model: str | None = None,
     profile_name: str | None = None,
     redact_secrets: bool = True,
+    context_window: int | None = None,
 ) -> None:
     """Run a planner that delegates work to multiple executor subagents.
 
@@ -553,6 +571,8 @@ def _run_planner(
         redact_secrets: If True, scrub secret patterns from workspace context before
             thread-mode executors see it. Has no effect on subprocess-mode executors
             (which manage their own context); a debug message is logged in that case.
+        context_window: Limit workspace context messages passed to executor subagents.
+            None = no limit; 0 = minimal context (no workspace files); N > 0 = at most N.
     """
     from gptme.cli.main import get_logdir
 
@@ -776,6 +796,7 @@ def _run_planner(
                         profile_name=subtask_profile,
                         agent_id=executor_agent_id,
                         redact_secrets=redact_secrets,
+                        context_window=context_window,
                     )
                 finally:
                     try:

--- a/gptme/tools/subagent/types.py
+++ b/gptme/tools/subagent/types.py
@@ -196,6 +196,8 @@ class Subagent:
     # Secret redaction: when True, common secret patterns (API keys, tokens, passwords)
     # are redacted from workspace context messages before they are seen by the subagent.
     redact_secrets: bool = True
+    # Context window: None = no limit; 0 = minimal (no workspace files); N = at most N msgs
+    context_window: int | None = None
     # Timestamp (seconds since epoch) when this subagent was created
     started_at: float = field(default_factory=time.time)
 

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -1915,7 +1915,11 @@ class TestContextWindow:
         )
 
     def test_context_window_positive_truncates_messages(self, monkeypatch, tmp_path):
-        """context_window=N truncates initial_msgs to at most N messages."""
+        """context_window=N limits workspace context to at most N messages.
+
+        Agent-identity and tools messages do NOT count against the window —
+        only the workspace context messages after them do.
+        """
         import importlib
 
         gptme_chat = importlib.import_module("gptme.chat")
@@ -1928,7 +1932,12 @@ class TestContextWindow:
 
         from gptme.message import Message
 
-        many_msgs = [Message("system", f"file {i} content") for i in range(10)]
+        identity_msg = Message("system", "# Agent\nI am gptme.")
+        tools_msg = Message("system", "# Tools\nHere are the tools.")
+        # Realistic get_prompt output: 2 fixed base messages + 10 workspace files
+        base_msgs = [identity_msg, tools_msg]
+        workspace_msgs = [Message("system", f"file {i} content") for i in range(10)]
+        full_prompt_msgs = base_msgs + workspace_msgs
         chat_initial_msgs: list = []
 
         monkeypatch.setattr(
@@ -1940,7 +1949,15 @@ class TestContextWindow:
         monkeypatch.setattr(gptme_llm_models, "set_default_model", lambda *args: None)
         monkeypatch.setattr(gptme_profiles, "get_profile", lambda _: None)
         monkeypatch.setattr(
-            gptme_prompts, "get_prompt", lambda *args, **kwargs: list(many_msgs)
+            gptme_prompts,
+            "get_prompt",
+            lambda *args, **kwargs: list(full_prompt_msgs),
+        )
+        monkeypatch.setattr(
+            gptme_prompts, "prompt_gptme", lambda *args, **kwargs: iter([identity_msg])
+        )
+        monkeypatch.setattr(
+            gptme_prompts, "prompt_tools", lambda *args, **kwargs: iter([tools_msg])
         )
         monkeypatch.setattr(
             hooks_mod, "_get_complete_instruction", lambda *args, **kwargs: "done"
@@ -1961,10 +1978,15 @@ class TestContextWindow:
             context_window=3,
         )
 
-        # Only messages before profile/memory/completion-instruction additions
-        context_msgs = [m for m in chat_initial_msgs if "file" in m.content]
-        assert len(context_msgs) <= 3, (
-            f"context_window=3 should yield at most 3 workspace messages, got {len(context_msgs)}"
+        # Base messages (identity + tools) are always present
+        assert identity_msg in chat_initial_msgs, "identity message must be present"
+        assert tools_msg in chat_initial_msgs, "tools message must be present"
+
+        # Only workspace messages count against the window
+        ws_msgs_in_result = [m for m in chat_initial_msgs if "file" in m.content]
+        assert len(ws_msgs_in_result) <= 3, (
+            f"context_window=3 should yield at most 3 workspace messages, "
+            f"got {len(ws_msgs_in_result)}"
         )
 
 

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -1286,6 +1286,7 @@ class TestClarifyBlock:
             "timeout": 42,
             "role": "verify",
             "redact_secrets": True,
+            "context_window": None,
         }
         with _subagent_results_lock:
             assert "clarify-agent" not in _subagent_results
@@ -1782,3 +1783,278 @@ class TestPlannerRedactSecrets:
                 for s in types_mod._subagents
                 if not s.agent_id.startswith("planner-warn")
             ]
+
+
+class TestContextWindow:
+    """Tests for context_window parameter in _create_subagent_thread."""
+
+    def test_context_window_zero_uses_minimal_context(self, monkeypatch, tmp_path):
+        """context_window=0 skips workspace files and uses only agent identity + tools."""
+        import importlib
+
+        gptme_chat = importlib.import_module("gptme.chat")
+        gptme_executor = importlib.import_module("gptme.executor")
+        gptme_llm_models = importlib.import_module("gptme.llm.models")
+        gptme_profiles = importlib.import_module("gptme.profiles")
+        gptme_prompts = importlib.import_module("gptme.prompts")
+        hooks_mod = importlib.import_module("gptme.tools.subagent.hooks")
+        exec_mod = importlib.import_module("gptme.tools.subagent.execution")
+
+        from gptme.message import Message
+
+        workspace_msgs = [
+            Message("system", "# Agent\nI am gptme."),
+            Message("system", "# Tools\nHere are the tools."),
+            Message("system", "WORKSPACE_SECRET=super_secret_value\nfile content here"),
+        ]
+        minimal_msgs = [
+            Message("system", "# Agent\nI am gptme."),
+            Message("system", "# Tools\nHere are the tools."),
+        ]
+        chat_initial_msgs: list = []
+
+        def mock_chat(prompt_msgs, initial_msgs, **kwargs):
+            chat_initial_msgs.extend(initial_msgs)
+
+        def mock_get_prompt(*args, **kwargs):
+            return list(workspace_msgs)
+
+        def mock_prompt_gptme(*args, **kwargs):
+            return iter([minimal_msgs[0]])
+
+        def mock_prompt_tools(*args, **kwargs):
+            return iter([minimal_msgs[1]])
+
+        monkeypatch.setattr(gptme_chat, "chat", mock_chat)
+        monkeypatch.setattr(
+            gptme_executor, "prepare_execution_environment", lambda **kwargs: None
+        )
+        monkeypatch.setattr(gptme_llm_models, "set_default_model", lambda *args: None)
+        monkeypatch.setattr(gptme_profiles, "get_profile", lambda _: None)
+        monkeypatch.setattr(gptme_prompts, "get_prompt", mock_get_prompt)
+        monkeypatch.setattr(gptme_prompts, "prompt_gptme", mock_prompt_gptme)
+        monkeypatch.setattr(gptme_prompts, "prompt_tools", mock_prompt_tools)
+        monkeypatch.setattr(
+            hooks_mod, "_get_complete_instruction", lambda *args, **kwargs: "done"
+        )
+        monkeypatch.setattr(
+            exec_mod, "_ensure_subagent_signal_tools_loaded", lambda: None
+        )
+        monkeypatch.setattr(exec_mod, "get_tools", lambda: [])
+
+        exec_mod._create_subagent_thread(
+            prompt="do the thing",
+            logdir=tmp_path / "logdir",
+            model=None,
+            context_mode="full",
+            context_include=None,
+            workspace=tmp_path,
+            redact_secrets=False,
+            context_window=0,
+        )
+
+        # Should NOT include the workspace secret file
+        contents = [m.content for m in chat_initial_msgs]
+        assert not any("WORKSPACE_SECRET" in c for c in contents), (
+            "context_window=0 should exclude workspace files"
+        )
+
+    def test_context_window_none_uses_full_context(self, monkeypatch, tmp_path):
+        """context_window=None (default) uses full workspace context."""
+        import importlib
+
+        gptme_chat = importlib.import_module("gptme.chat")
+        gptme_executor = importlib.import_module("gptme.executor")
+        gptme_llm_models = importlib.import_module("gptme.llm.models")
+        gptme_profiles = importlib.import_module("gptme.profiles")
+        gptme_prompts = importlib.import_module("gptme.prompts")
+        hooks_mod = importlib.import_module("gptme.tools.subagent.hooks")
+        exec_mod = importlib.import_module("gptme.tools.subagent.execution")
+
+        from gptme.message import Message
+
+        workspace_msgs = [
+            Message("system", "# Agent\nI am gptme."),
+            Message("system", "WORKSPACE_SECRET=super_secret_value"),
+        ]
+        chat_initial_msgs: list = []
+
+        monkeypatch.setattr(
+            gptme_chat, "chat", lambda pm, im, **kw: chat_initial_msgs.extend(im)
+        )
+        monkeypatch.setattr(
+            gptme_executor, "prepare_execution_environment", lambda **kwargs: None
+        )
+        monkeypatch.setattr(gptme_llm_models, "set_default_model", lambda *args: None)
+        monkeypatch.setattr(gptme_profiles, "get_profile", lambda _: None)
+        monkeypatch.setattr(
+            gptme_prompts, "get_prompt", lambda *args, **kwargs: list(workspace_msgs)
+        )
+        monkeypatch.setattr(
+            hooks_mod, "_get_complete_instruction", lambda *args, **kwargs: "done"
+        )
+        monkeypatch.setattr(
+            exec_mod, "_ensure_subagent_signal_tools_loaded", lambda: None
+        )
+        monkeypatch.setattr(exec_mod, "get_tools", lambda: [])
+
+        exec_mod._create_subagent_thread(
+            prompt="do the thing",
+            logdir=tmp_path / "logdir",
+            model=None,
+            context_mode="full",
+            context_include=None,
+            workspace=tmp_path,
+            redact_secrets=False,
+            context_window=None,
+        )
+
+        contents = [m.content for m in chat_initial_msgs]
+        assert any("WORKSPACE_SECRET" in c for c in contents), (
+            "context_window=None should include all workspace context"
+        )
+
+    def test_context_window_positive_truncates_messages(self, monkeypatch, tmp_path):
+        """context_window=N truncates initial_msgs to at most N messages."""
+        import importlib
+
+        gptme_chat = importlib.import_module("gptme.chat")
+        gptme_executor = importlib.import_module("gptme.executor")
+        gptme_llm_models = importlib.import_module("gptme.llm.models")
+        gptme_profiles = importlib.import_module("gptme.profiles")
+        gptme_prompts = importlib.import_module("gptme.prompts")
+        hooks_mod = importlib.import_module("gptme.tools.subagent.hooks")
+        exec_mod = importlib.import_module("gptme.tools.subagent.execution")
+
+        from gptme.message import Message
+
+        many_msgs = [Message("system", f"file {i} content") for i in range(10)]
+        chat_initial_msgs: list = []
+
+        monkeypatch.setattr(
+            gptme_chat, "chat", lambda pm, im, **kw: chat_initial_msgs.extend(im)
+        )
+        monkeypatch.setattr(
+            gptme_executor, "prepare_execution_environment", lambda **kwargs: None
+        )
+        monkeypatch.setattr(gptme_llm_models, "set_default_model", lambda *args: None)
+        monkeypatch.setattr(gptme_profiles, "get_profile", lambda _: None)
+        monkeypatch.setattr(
+            gptme_prompts, "get_prompt", lambda *args, **kwargs: list(many_msgs)
+        )
+        monkeypatch.setattr(
+            hooks_mod, "_get_complete_instruction", lambda *args, **kwargs: "done"
+        )
+        monkeypatch.setattr(
+            exec_mod, "_ensure_subagent_signal_tools_loaded", lambda: None
+        )
+        monkeypatch.setattr(exec_mod, "get_tools", lambda: [])
+
+        exec_mod._create_subagent_thread(
+            prompt="do the thing",
+            logdir=tmp_path / "logdir",
+            model=None,
+            context_mode="full",
+            context_include=None,
+            workspace=tmp_path,
+            redact_secrets=False,
+            context_window=3,
+        )
+
+        # Only messages before profile/memory/completion-instruction additions
+        context_msgs = [m for m in chat_initial_msgs if "file" in m.content]
+        assert len(context_msgs) <= 3, (
+            f"context_window=3 should yield at most 3 workspace messages, got {len(context_msgs)}"
+        )
+
+
+class TestPlannerForwardsContextWindow:
+    """Tests that _run_planner forwards context_window to thread-mode executors."""
+
+    def test_planner_forwards_context_window_to_thread_executors(
+        self, monkeypatch, tmp_path
+    ):
+        """_run_planner with context_window=0 passes it to _create_subagent_thread."""
+        import importlib
+
+        cli_main = importlib.import_module("gptme.cli.main")
+        exec_mod = importlib.import_module("gptme.tools.subagent.execution")
+        types_mod = importlib.import_module("gptme.tools.subagent.types")
+
+        monkeypatch.setattr(cli_main, "get_logdir", lambda name: tmp_path / name)
+
+        captured_kwargs: list[dict] = []
+        called_event = threading.Event()
+
+        def fake_create_subagent_thread(**kwargs):
+            captured_kwargs.append(kwargs)
+            called_event.set()
+
+        monkeypatch.setattr(
+            exec_mod, "_create_subagent_thread", fake_create_subagent_thread
+        )
+        monkeypatch.setattr(
+            exec_mod, "get_slot_sem", lambda: __import__("threading").Semaphore(10)
+        )
+
+        subtasks = [{"id": "t1", "description": "do something"}]
+        exec_mod._run_planner(
+            agent_id="planner-cw",
+            prompt="context",
+            subtasks=subtasks,
+            execution_mode="sequential",
+            context_window=0,
+        )
+
+        called_event.wait(timeout=5)
+        assert captured_kwargs, "_create_subagent_thread was never called"
+        assert captured_kwargs[0].get("context_window") == 0, (
+            f"Expected context_window=0, got {captured_kwargs[0].get('context_window')}"
+        )
+
+        with types_mod._subagents_lock:
+            types_mod._subagents[:] = [
+                s
+                for s in types_mod._subagents
+                if not s.agent_id.startswith("planner-cw")
+            ]
+
+    def test_subagent_planner_mode_forwards_redact_secrets_false(
+        self, monkeypatch, tmp_path
+    ):
+        """subagent(mode='planner') forwards redact_secrets=False to _run_planner."""
+        import importlib
+
+        cli_main = importlib.import_module("gptme.cli.main")
+        exec_mod = importlib.import_module("gptme.tools.subagent.execution")
+        llm_models = importlib.import_module("gptme.llm.models")
+
+        monkeypatch.setattr(cli_main, "get_logdir", lambda name: tmp_path / name)
+        monkeypatch.setattr(llm_models, "get_default_model", lambda: None)
+
+        captured: dict = {}
+
+        def fake_run_planner(*args, **kwargs):
+            captured.update(kwargs)
+
+        monkeypatch.setattr(exec_mod, "_run_planner", fake_run_planner)
+
+        from gptme.tools.subagent.api import subagent
+        from gptme.tools.subagent.types import SubtaskDef
+
+        subtasks: list[SubtaskDef] = [{"id": "t1", "description": "check output"}]
+        subagent(
+            agent_id="planner-rs-test",
+            prompt="verify something",
+            mode="planner",
+            subtasks=subtasks,
+            redact_secrets=False,
+            context_window=0,
+        )
+
+        assert captured.get("redact_secrets") is False, (
+            "redact_secrets=False should be forwarded to _run_planner"
+        )
+        assert captured.get("context_window") == 0, (
+            "context_window=0 should be forwarded to _run_planner"
+        )


### PR DESCRIPTION
## Summary

Addresses the remaining gaps in #2949 (subagent context isolation) after the `redact_secrets` work in #2950 and #2963.

Two fixes:

- **Bug fix: `redact_secrets` not forwarded in planner mode** — when `mode="planner"`, the caller's `redact_secrets=False` was silently ignored because `api.py` didn't pass it to `_run_planner()`. The function defaults to `True`, so the default still worked, but explicit `redact_secrets=False` had no effect.

- **`context_window` parameter** — the "isolate_context" parameter promised in the #2949 comment. Gives callers a one-line way to limit what workspace context is passed to subagents without needing to know about `context_mode`/`context_include`:
  - `context_window=None` (default): no change, full workspace context
  - `context_window=0`: minimal context — just agent identity + tools, **no workspace files or context_cmd output**; this is the "isolate" mode the issue asked for
  - `context_window=N`: at most N workspace context messages

  Both parameters flow through the planner → executor chain and are preserved across `subagent_reply()` re-spawns.

## Test plan

- [ ] `pytest tests/test_subagent_unit.py` — 104 tests pass (5 new tests for `context_window`, 1 test updated for the new field)
- [ ] `TestContextWindow` verifies `context_window=0` excludes workspace files, `None` includes them, and `N>0` truncates
- [ ] `TestPlannerForwardsContextWindow` verifies planner forwards `context_window` and that `subagent(mode="planner", redact_secrets=False)` actually reaches `_run_planner` with `redact_secrets=False`