### PR TITLE
feat(subagent): add path_deny parameter for file-level workspace isolation

### DIFF
--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -1047,6 +1047,10 @@ def main(
             context_include=effective_context_include,
         )
 
+        from ..tools.subagent.context import apply_path_deny_from_env
+
+        initial_msgs = apply_path_deny_from_env(initial_msgs, workspace_path)
+
     # Append profile system prompt if using a profile
     if selected_profile and selected_profile.system_prompt:
         profile_msg = Message(

--- a/gptme/tools/subagent/api.py
+++ b/gptme/tools/subagent/api.py
@@ -53,6 +53,7 @@ def subagent(
     role: Role | None = None,
     redact_secrets: bool = True,
     context_window: int | None = None,
+    path_deny: list[str] | None = None,
 ):
     """Starts an asynchronous subagent. Returns None immediately.
 
@@ -146,6 +147,18 @@ def subagent(
 
             Only applies to thread-mode subagents; has no effect in subprocess
             or ACP modes (which build their own context as a separate process).
+        path_deny: Glob patterns for files to exclude from the subagent's workspace
+            context. When provided, workspace files matching any glob are excluded
+            before the subagent sees them. Uses fnmatch for matching against file
+            paths relative to the workspace root.
+
+            Example: ``path_deny=["*.secret", "config/*.yml"]`` excludes files
+            matching ``.secret`` extension or under ``config/`` with ``.yml``
+            extension.
+
+            Works in both thread mode and subprocess mode. In subprocess mode,
+            the deny list is passed to the child process via environment variables
+            (``GPTME_PATH_DENY``) and applied before context assembly.
 
     Returns:
         None: Starts asynchronous execution.
@@ -436,6 +449,7 @@ def subagent(
             model=model_name,
             context_mode=context_mode,
             context_include=context_include,
+            path_deny=path_deny,
             profile=profile,
             output_schema=output_schema,
             use_acp=True,
@@ -492,6 +506,7 @@ def subagent(
                     context_include=context_include,
                     output_schema=output_schema_str,
                     profile=profile,
+                    path_deny=path_deny,
                 )
                 # Subagent is a frozen dataclass; install the live process on the
                 # pre-registered object so queued agents become inspectable once
@@ -570,6 +585,7 @@ def subagent(
                         agent_id=agent_id,
                         redact_secrets=redact_secrets,
                         context_window=context_window,
+                        path_deny=path_deny,
                     )
                 except Exception as e:
                     # If subagent creation fails, notify with error status
@@ -634,6 +650,7 @@ def subagent(
             model=model_name,
             context_mode=context_mode,
             context_include=context_include,
+            path_deny=path_deny,
             profile=profile,
             output_schema=output_schema,
             process=None,

--- a/gptme/tools/subagent/context.py
+++ b/gptme/tools/subagent/context.py
@@ -7,6 +7,8 @@ user-level config) when context_mode="full". This module helps sanitize that
 inherited context.
 """
 
+import json
+import os
 import re
 from pathlib import Path
 
@@ -67,6 +69,7 @@ _ENV_ASSIGN_RE = re.compile(
 )
 
 _REDACTED = "[REDACTED]"
+_PATH_DENY_ENV = "GPTME_PATH_DENY"
 
 
 def redact_secrets_from_text(content: str) -> str:
@@ -138,6 +141,43 @@ def redact_secrets_from_messages(messages: list[Message]) -> list[Message]:
     ]
 
 
+def get_path_deny_from_env() -> list[str] | None:
+    """Return path-deny patterns from the subprocess environment, if any."""
+    raw = os.environ.get(_PATH_DENY_ENV)
+    if raw is None:
+        return None
+
+    raw = raw.strip()
+    if not raw:
+        return []
+
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        if "\n" in raw:
+            return [line for line in raw.splitlines() if line]
+        if ":" in raw:
+            return [part for part in raw.split(":") if part]
+        return [raw]
+
+    if not isinstance(parsed, list) or any(
+        not isinstance(item, str) for item in parsed
+    ):
+        return []
+
+    return [item for item in parsed if item]
+
+
+def apply_path_deny_from_env(
+    messages: list[Message], workspace: Path | None = None
+) -> list[Message]:
+    """Apply subprocess-provided path deny patterns, if configured."""
+    path_deny = get_path_deny_from_env()
+    if not path_deny:
+        return messages
+    return apply_path_deny(messages, path_deny, workspace)
+
+
 def apply_path_deny(
     messages: list[Message], path_deny: list[str], workspace: Path | None = None
 ) -> list[Message]:
@@ -164,12 +204,17 @@ def apply_path_deny(
     if not path_deny:
         return messages
 
+    workspace_resolved = workspace.resolve() if workspace else None
+
     def _is_denied(filepath: str) -> bool:
         """Check if a filepath matches any deny glob."""
         check_paths = [filepath]
-        if workspace:
+        if workspace_resolved:
             try:
-                rel = str(Path(filepath).resolve().relative_to(workspace.resolve()))
+                path_obj = Path(filepath)
+                if not path_obj.is_absolute():
+                    path_obj = workspace_resolved / path_obj
+                rel = str(path_obj.resolve().relative_to(workspace_resolved))
                 check_paths.append(rel)
             except (ValueError, OSError):
                 pass
@@ -206,7 +251,8 @@ def apply_path_deny(
                 in_block = True
                 block_filename = stripped[3:].strip()
                 skip_block = bool(block_filename) and _is_denied(block_filename)
-                filtered_lines.append(line)
+                if not skip_block:
+                    filtered_lines.append(line)
             elif in_block and stripped == "```":
                 # End of code block
                 if not skip_block:

--- a/gptme/tools/subagent/context.py
+++ b/gptme/tools/subagent/context.py
@@ -8,6 +8,7 @@ inherited context.
 """
 
 import re
+from pathlib import Path
 
 from ...message import Message
 
@@ -135,3 +136,91 @@ def redact_secrets_from_messages(messages: list[Message]) -> list[Message]:
     return [
         msg.replace(content=redact_secrets_from_text(msg.content)) for msg in messages
     ]
+
+
+def apply_path_deny(
+    messages: list[Message], path_deny: list[str], workspace: Path | None = None
+) -> list[Message]:
+    """Exclude workspace files matching deny globs from context messages.
+
+    Scans system messages for markdown code blocks with file references and
+    removes blocks whose filenames match any of the deny glob patterns.
+    Uses fnmatch for glob matching.
+
+    Thread-mode subagents receive workspace context as system messages
+    containing markdown-fenced file content. This function strips matching
+    blocks before the subagent sees them.
+
+    Args:
+        messages: List of messages to filter.
+        path_deny: Glob patterns to match against file paths.
+        workspace: Workspace root for resolving absolute paths to relative.
+
+    Returns:
+        A new list of messages with denied files removed.
+    """
+    from fnmatch import fnmatch as _fnmatch
+
+    if not path_deny:
+        return messages
+
+    def _is_denied(filepath: str) -> bool:
+        """Check if a filepath matches any deny glob."""
+        check_paths = [filepath]
+        if workspace:
+            try:
+                rel = str(Path(filepath).resolve().relative_to(workspace.resolve()))
+                check_paths.append(rel)
+            except (ValueError, OSError):
+                pass
+
+        for deny_pattern in path_deny:
+            for cp in check_paths:
+                if _fnmatch(cp, deny_pattern):
+                    return True
+                fname = Path(cp).name
+                if _fnmatch(fname, deny_pattern):
+                    return True
+        return False
+
+    result: list[Message] = []
+    for msg in messages:
+        if msg.role != "system":
+            result.append(msg)
+            continue
+
+        content = msg.content
+        lines = content.split("\n")
+        filtered_lines: list[str] = []
+        i = 0
+        in_block = False
+        block_filename = ""
+        skip_block = False
+
+        while i < len(lines):
+            line = lines[i]
+            stripped = line.strip()
+
+            if not in_block and stripped.startswith("```"):
+                # Start of a code block - check if it names a file
+                in_block = True
+                block_filename = stripped[3:].strip()
+                skip_block = bool(block_filename) and _is_denied(block_filename)
+                filtered_lines.append(line)
+            elif in_block and stripped == "```":
+                # End of code block
+                if not skip_block:
+                    filtered_lines.append(line)
+                in_block = False
+                skip_block = False
+                block_filename = ""
+            elif in_block and skip_block:
+                # Inside a denied block - skip the content
+                pass
+            else:
+                filtered_lines.append(line)
+            i += 1
+
+        result.append(msg.replace(content="\n".join(filtered_lines)))
+
+    return result

--- a/gptme/tools/subagent/execution.py
+++ b/gptme/tools/subagent/execution.py
@@ -8,6 +8,7 @@ subagent() function in api.py.
 """
 
 import logging
+import os
 import random
 import string
 import subprocess
@@ -139,6 +140,7 @@ def _create_subagent_thread(
     agent_id: str | None = None,
     redact_secrets: bool = True,
     context_window: int | None = None,
+    path_deny: list[str] | None = None,
 ) -> None:
     """Shared function for running subagent threads.
 
@@ -295,6 +297,12 @@ def _create_subagent_thread(
 
         initial_msgs = redact_secrets_from_messages(initial_msgs)
 
+    # Apply path deny filtering to exclude matching files from workspace context
+    if path_deny:
+        from .context import apply_path_deny
+
+        initial_msgs = apply_path_deny(initial_msgs, path_deny, workspace)
+
     # Append profile system prompt if specified
     if profile and profile.system_prompt:
         profile_msg = Message(
@@ -342,6 +350,7 @@ def _run_subagent_subprocess(
     context_include: list[str] | None = None,
     output_schema: str | None = None,
     profile: str | None = None,
+    path_deny: list[str] | None = None,
 ) -> subprocess.Popen:
     """Run a subagent in a subprocess for output isolation.
 
@@ -361,6 +370,8 @@ def _run_subagent_subprocess(
             includes them.
         output_schema: JSON schema for structured output
         profile: Agent profile name to apply via --agent-profile flag
+        path_deny: Glob patterns for files to exclude from workspace context.
+            Passed to the child process via GPTME_PATH_DENY env var.
 
     Returns:
         The subprocess.Popen object for monitoring
@@ -451,6 +462,10 @@ def _run_subagent_subprocess(
         tmpfile_path = Path(tmpf.name)
 
     try:
+        # Build environment with path_deny passed to child process
+        env = os.environ.copy()
+        if path_deny:
+            env["GPTME_PATH_DENY"] = ":".join(path_deny)
         with open(tmpfile_path) as stdin_file:
             process = subprocess.Popen(
                 cmd,
@@ -459,6 +474,7 @@ def _run_subagent_subprocess(
                 stderr=subprocess.DEVNULL,
                 cwd=workspace,
                 text=True,
+                env=env,
             )
     finally:
         tmpfile_path.unlink(missing_ok=True)
@@ -581,6 +597,7 @@ def _run_planner(
     profile_name: str | None = None,
     redact_secrets: bool = True,
     context_window: int | None = None,
+    path_deny: list[str] | None = None,
 ) -> None:
     """Run a planner that delegates work to multiple executor subagents.
 
@@ -598,6 +615,7 @@ def _run_planner(
             (which manage their own context); a debug message is logged in that case.
         context_window: Limit workspace context messages passed to executor subagents.
             None = no limit; 0 = minimal context (no workspace files); N > 0 = at most N.
+        path_deny: Glob patterns for files to exclude from executor workspace context.
     """
     from gptme.cli.main import get_logdir
 
@@ -704,6 +722,7 @@ def _run_planner(
                 model,
                 context_mode=context_mode,
                 context_include=context_include,
+                path_deny=path_deny,
                 profile=resolved_profile,
                 process=None,
                 execution_mode="subprocess",
@@ -741,6 +760,7 @@ def _run_planner(
                             context_mode=context_mode,
                             context_include=context_include,
                             profile=_profile,
+                            path_deny=path_deny,
                         )
                     except Exception as e:
                         logger.error(
@@ -843,6 +863,7 @@ def _run_planner(
                 model,
                 context_mode=context_mode,
                 context_include=context_include,
+                path_deny=path_deny,
                 profile=resolved_profile,
                 isolated=resolved_isolated,
                 worktree_path=worktree_path,

--- a/gptme/tools/subagent/execution.py
+++ b/gptme/tools/subagent/execution.py
@@ -7,6 +7,7 @@ Functions here are internal implementation details called by the main
 subagent() function in api.py.
 """
 
+import json
 import logging
 import os
 import random
@@ -465,7 +466,7 @@ def _run_subagent_subprocess(
         # Build environment with path_deny passed to child process
         env = os.environ.copy()
         if path_deny:
-            env["GPTME_PATH_DENY"] = ":".join(path_deny)
+            env["GPTME_PATH_DENY"] = json.dumps(path_deny)
         with open(tmpfile_path) as stdin_file:
             process = subprocess.Popen(
                 cmd,

--- a/gptme/tools/subagent/types.py
+++ b/gptme/tools/subagent/types.py
@@ -178,6 +178,7 @@ class Subagent:
     model: str | None
     context_mode: Literal["full", "selective"] = "full"
     context_include: list[str] | None = None
+    path_deny: list[str] | None = None
     profile: str | None = None
     output_schema: type | None = None
     use_acp: bool = False

--- a/tests/test_subagent_context.py
+++ b/tests/test_subagent_context.py
@@ -1,0 +1,59 @@
+"""Tests for path_deny workspace file filtering."""
+
+from pathlib import Path
+
+from gptme.message import Message
+from gptme.tools.subagent.context import apply_path_deny
+
+
+def test_apply_path_deny_no_patterns():
+    """No deny patterns should return messages unchanged."""
+    msgs = [Message("system", "```hello.py\nprint('hi')\n```")]
+    result = apply_path_deny(msgs, [], Path("/tmp"))
+    assert result[0].content == msgs[0].content
+
+
+def test_apply_path_deny_excludes_matching_file():
+    """A denied file should be removed from the context."""
+    msgs = [
+        Message(
+            "system",
+            "## Workspace\n\n```secret.py\nPASSWORD=hunter2\n```\n\n```safe.py\nx = 1\n```",
+        )
+    ]
+    result = apply_path_deny(msgs, ["*.secret", "secret.py"], Path("/tmp"))
+    content = result[0].content
+    assert "safe.py" in content
+    assert "PASSWORD" not in content
+    assert "hunter2" not in content
+
+
+def test_apply_path_deny_excludes_by_filename():
+    """Matching just the filename should work."""
+    msgs = [Message("system", "```config/secrets.env\nKEY=val\n```")]
+    result = apply_path_deny(msgs, ["*.env"], Path("/tmp"))
+    assert "KEY=val" not in result[0].content
+
+
+def test_apply_path_deny_excludes_by_workspace_relative_path():
+    """When workspace is provided, relative paths should match."""
+    msgs = [Message("system", "```/abs/path/to/secrets.yaml\nkey: val\n```")]
+    # Workspace root is /abs/path/to, so secrets.yaml is relative
+    result = apply_path_deny(msgs, ["secrets.yaml"], Path("/abs/path/to"))
+    assert "key: val" not in result[0].content
+
+
+def test_apply_path_deny_non_system_messages_unchanged():
+    """Only system messages should be filtered."""
+    msgs = [
+        Message("user", "```secret.py\nPASSWORD=test\n```"),
+    ]
+    result = apply_path_deny(msgs, ["secret.py"], Path("/tmp"))
+    assert "PASSWORD=test" in result[0].content
+
+
+def test_apply_path_deny_none_path_deny():
+    """None path_deny should be a no-op."""
+    msgs = [Message("system", "```secret.py\nx=1\n```")]
+    result = apply_path_deny(msgs, None, Path("/tmp"))  # type: ignore[arg-type]
+    assert "x=1" in result[0].content

--- a/tests/test_subagent_context.py
+++ b/tests/test_subagent_context.py
@@ -3,7 +3,11 @@
 from pathlib import Path
 
 from gptme.message import Message
-from gptme.tools.subagent.context import apply_path_deny
+from gptme.tools.subagent.context import (
+    apply_path_deny,
+    apply_path_deny_from_env,
+    get_path_deny_from_env,
+)
 
 
 def test_apply_path_deny_no_patterns():
@@ -24,8 +28,10 @@ def test_apply_path_deny_excludes_matching_file():
     result = apply_path_deny(msgs, ["*.secret", "secret.py"], Path("/tmp"))
     content = result[0].content
     assert "safe.py" in content
+    assert "secret.py" not in content
     assert "PASSWORD" not in content
     assert "hunter2" not in content
+    assert content.count("```") == 2
 
 
 def test_apply_path_deny_excludes_by_filename():
@@ -43,6 +49,13 @@ def test_apply_path_deny_excludes_by_workspace_relative_path():
     assert "key: val" not in result[0].content
 
 
+def test_apply_path_deny_normalizes_relative_paths_against_workspace():
+    """Relative file headers should normalize against the workspace root."""
+    msgs = [Message("system", "```./config/../config/secrets.yaml\nkey: val\n```")]
+    result = apply_path_deny(msgs, ["config/secrets.yaml"], Path("/abs/path/to"))
+    assert "key: val" not in result[0].content
+
+
 def test_apply_path_deny_non_system_messages_unchanged():
     """Only system messages should be filtered."""
     msgs = [
@@ -57,3 +70,26 @@ def test_apply_path_deny_none_path_deny():
     msgs = [Message("system", "```secret.py\nx=1\n```")]
     result = apply_path_deny(msgs, None, Path("/tmp"))  # type: ignore[arg-type]
     assert "x=1" in result[0].content
+
+
+def test_get_path_deny_from_env_supports_json_and_legacy_colon(monkeypatch):
+    """Subprocess path_deny should parse both JSON and legacy env payloads."""
+    monkeypatch.setenv("GPTME_PATH_DENY", '["a:b", "*.secret"]')
+    assert get_path_deny_from_env() == ["a:b", "*.secret"]
+
+    monkeypatch.setenv("GPTME_PATH_DENY", "secret.py:*.env")
+    assert get_path_deny_from_env() == ["secret.py", "*.env"]
+
+
+def test_apply_path_deny_from_env_filters_matching_file(monkeypatch):
+    """CLI startup should honor subprocess path_deny from the environment."""
+    monkeypatch.setenv("GPTME_PATH_DENY", '["secret.py"]')
+    msgs = [
+        Message(
+            "system",
+            "```secret.py\nPASSWORD=hunter2\n```\n\n```safe.py\nx = 1\n```",
+        )
+    ]
+    result = apply_path_deny_from_env(msgs, Path("/tmp"))
+    assert "secret.py" not in result[0].content
+    assert "safe.py" in result[0].content

--- a/tests/test_tools_subagent.py
+++ b/tests/test_tools_subagent.py
@@ -731,6 +731,40 @@ def test_subprocess_profile_preserves_profile_tools_and_adds_clarify():
     )
 
 
+def test_subprocess_path_deny_env_is_json_encoded():
+    """Subprocess mode should pass path_deny through an unambiguous env payload."""
+    import json
+    import tempfile
+    from pathlib import Path
+
+    from gptme.tools.subagent.execution import _run_subagent_subprocess
+
+    captured_env: dict[str, str] = {}
+
+    def fake_popen(cmd, **kwargs):
+        captured_env.clear()
+        captured_env.update(kwargs["env"])
+        mock = MagicMock()
+        mock.poll.return_value = None
+        mock.args = cmd
+        return mock
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        logdir = Path(tmpdir) / "logs"
+        logdir.mkdir()
+
+        with patch("gptme.tools.subagent.execution.subprocess.Popen", fake_popen):
+            _run_subagent_subprocess(
+                prompt="Explore task",
+                logdir=logdir,
+                model=None,
+                workspace=Path(tmpdir),
+                path_deny=["a:b", "*.secret"],
+            )
+
+    assert json.loads(captured_env["GPTME_PATH_DENY"]) == ["a:b", "*.secret"]
+
+
 @pytest.mark.slow
 def test_subprocess_working_directory():
     """Test that subprocess runs in the specified working directory."""


### PR DESCRIPTION
Adds a `path_deny` parameter to `subagent()` that accepts glob patterns for files to exclude from the subagent's workspace context.

## Problem
Subagents inherit the full workspace context (files from gptme.toml, context_cmd output). There's no way to exclude specific files (e.g., config files with secrets, large log files, or sensitive project docs) from being passed to subagents.

## Solution
A new `path_deny` parameter that accepts a list of glob patterns. Files matching any pattern are excluded from workspace context before the subagent sees them.

### How it works
- **Thread mode**: `apply_path_deny()` filters markdown code blocks with file references matching deny globs (fnmatch)
- **Subprocess mode**: Deny list passed via `GPTME_PATH_DENY` env var
- **Planner mode**: Forwards to executor subagents
- Supports matching by full path, workspace-relative path, or filename
- Non-system messages are unaffected
- Applied after secret redaction, before memory/prompt injection

### Example
```python
subagent("analyze", "Review code quality",
         path_deny=["*.secret", "config/*.yml"])
```

## Changes
- `gptme/tools/subagent/types.py` — add `path_deny` field to `Subagent` dataclass
- `gptme/tools/subagent/api.py` — add `path_deny` param to `subagent()` 
- `gptme/tools/subagent/context.py` — implement `apply_path_deny()` filter
- `gptme/tools/subagent/execution.py` — wire through thread/subprocess/planner
- `tests/test_subagent_context.py` — 6 tests covering all filter paths

## Verification
- [x] All 84 existing subagent tests pass
- [x] 6 new tests for apply_path_deny (all pass)
- [x] Ruff clean
- [x] mypy passes