### PR TITLE
fix(rag): stop tools list hook registration warning

### DIFF
--- a/gptme/tools/rag.py
+++ b/gptme/tools/rag.py
@@ -389,7 +389,7 @@ tool = ToolSpec(
     available=_has_gptme_rag,
     init=init,
     hooks={
-        "rag_context": ("generation_pre", _rag_context_hook, 0),
+        "rag_context": ("generation.pre", _rag_context_hook, 0),
     },
 )
 

--- a/tests/test_util_cli.py
+++ b/tests/test_util_cli.py
@@ -5,6 +5,7 @@ import os
 import time
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 from click.testing import CliRunner
@@ -383,7 +384,11 @@ def test_tools_list(mocker):
     """Test the tools list command."""
     import json
 
-    runner = CliRunner()
+    runner_cls: Any = CliRunner
+    try:
+        runner = runner_cls(mix_stderr=False)
+    except TypeError:
+        runner = runner_cls()
 
     mocker.patch("gptme.tools.browser.browser", "playwright")
 
@@ -392,6 +397,7 @@ def test_tools_list(mocker):
     assert "Available tools" in result.output
     assert result.exit_code == 0
     assert "Using browser tool with" not in result.output
+    assert "Failed to register hook" not in getattr(result, "stderr", "")
 
     # Test langtags
     result = runner.invoke(main, ["tools", "list", "--langtags"])


### PR DESCRIPTION
## Summary
- fix the RAG tool hook registration to use the valid dot-notation hook type
- keep `gptme-util tools list` stderr clean with a regression test

## Repro
```bash
uv run --project . gptme-util tools list >/tmp/tools.stdout 2>/tmp/tools.stderr
cat /tmp/tools.stderr
# Failed to register hook 'rag_context' for tool 'rag': 'generation_pre' is not a valid HookType
```

## Verification
- `uv run --project . gptme-util tools list >/tmp/tools.stdout 2>/tmp/tools.stderr && test ! -s /tmp/tools.stderr`
- `.venv/bin/pytest tests/test_util_cli.py -k tools_list -q`
- `uv run --project . ruff check gptme/tools/rag.py tests/test_util_cli.py`
