### PR TITLE
fix(llm): embed OpenAI reasoning content in non-streaming output

### DIFF
--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -292,14 +292,22 @@ def _prepare_messages_for_responses_api(
     return instructions, input_items, responses_tools
 
 
-def _log_responses_reasoning(item: Any) -> None:
+def _extract_responses_reasoning(item: Any) -> str:
+    """Extract reasoning summary/content text from a Responses API reasoning item.
+
+    Returns the reasoning text (preferring ``summary`` over ``content``), logging
+    it at DEBUG. Returns an empty string when no reasoning text is present. The
+    caller is responsible for wrapping the text in ``<think>`` tags so that the
+    non-streaming path stays consistent with the streaming path, which already
+    embeds reasoning content into the output stream.
+    """
     summary = _obj_get(item, "summary") or []
     summary_text = "\n".join(
         part.text if hasattr(part, "text") else part.get("text", "") for part in summary
     ).strip()
     if summary_text:
         logger.debug("Reasoning content: %s", summary_text)
-        return
+        return summary_text
 
     content = _obj_get(item, "content") or []
     content_text = "\n".join(
@@ -307,6 +315,7 @@ def _log_responses_reasoning(item: Any) -> None:
     ).strip()
     if content_text:
         logger.debug("Reasoning content: %s", content_text)
+    return content_text
 
 
 def _init_openai_client(
@@ -886,7 +895,8 @@ def chat(
         for item in response.output:
             item_type = _obj_get(item, "type")
             if item_type == "reasoning":
-                _log_responses_reasoning(item)
+                if reasoning_text := _extract_responses_reasoning(item):
+                    result.append(f"<think>\n{reasoning_text}\n</think>\n")
             elif item_type == "function_call":
                 name = _obj_get(item, "name", "").strip()
                 call_id = _obj_get(item, "call_id", "").strip()
@@ -949,6 +959,10 @@ def chat(
             or getattr(choice.message, "reasoning", None)
         ):
             logger.debug("Reasoning content: %s", reasoning_content)
+            # Embed reasoning as a <think> block so the non-streaming path stays
+            # consistent with the streaming path (which already wraps reasoning
+            # content in <think> tags) instead of silently dropping it.
+            result.append(f"<think>\n{reasoning_content}\n</think>\n")
         if choice.message.content:
             result.append(choice.message.content)
 

--- a/tests/test_llm_openai.py
+++ b/tests/test_llm_openai.py
@@ -689,7 +689,9 @@ def test_chat_uses_responses_api_for_gpt5_by_default(monkeypatch):
         None,
     )
 
-    assert result == "Hello from Responses"
+    # Reasoning summary is embedded as a <think> block (consistent with the
+    # streaming path) rather than silently dropped.
+    assert result == "<think>\nNeed no extra tools.\n</think>\n\nHello from Responses"
     assert metadata is not None
     assert metadata["usage"]["input_tokens"] == 100
     assert metadata["usage"]["output_tokens"] == 30
@@ -700,6 +702,45 @@ def test_chat_uses_responses_api_for_gpt5_by_default(monkeypatch):
     assert kwargs["input"] == [{"role": "user", "content": "Say hello."}]
     assert kwargs["store"] is False
     mock_client.chat.completions.create.assert_not_called()
+
+
+def test_chat_completions_embeds_reasoning_content(monkeypatch):
+    """Non-streaming Chat Completions wraps reasoning_content in a <think> block.
+
+    Keeps the non-streaming path consistent with the streaming path (which
+    already embeds reasoning into the output) instead of silently dropping it.
+    """
+    fake_message = SimpleNamespace(
+        content="The answer is 42.",
+        reasoning_content="Let me think about this carefully.",
+        tool_calls=None,
+    )
+    fake_response = SimpleNamespace(
+        choices=[SimpleNamespace(finish_reason="stop", message=fake_message)],
+        usage=None,
+    )
+    completions_create = Mock(return_value=fake_response)
+    mock_client = SimpleNamespace(
+        responses=SimpleNamespace(create=Mock()),
+        chat=SimpleNamespace(completions=SimpleNamespace(create=completions_create)),
+    )
+
+    monkeypatch.setattr(llm_openai, "get_client", lambda provider: mock_client)
+    monkeypatch.setattr(llm_openai, "_is_proxy", lambda client: False)
+
+    # gpt-4o does not use the Responses API → Chat Completions path
+    result, metadata = llm_openai.chat(
+        [Message(role="user", content="What is the answer?")],
+        "openai/gpt-4o",
+        None,
+    )
+
+    assert result == (
+        "<think>\nLet me think about this carefully.\n</think>\n\nThe answer is 42."
+    )
+    assert metadata is None
+    completions_create.assert_called_once()
+    mock_client.responses.create.assert_not_called()
 
 
 def test_chat_responses_api_formats_function_calls(monkeypatch):


### PR DESCRIPTION
## What

Makes OpenAI reasoning-content handling consistent across all code paths.

The non-streaming OpenAI paths (Responses API and Chat Completions) logged reasoning content at DEBUG and then **dropped it** from the returned response. Meanwhile, the **streaming** path already wraps reasoning in `<think>` tags and includes it in the output. So:

| Provider | Path | Reasoning in output? |
|----------|------|----------------------|
| Anthropic | both | ✅ embedded as `<think>` tags |
| OpenAI | streaming | ✅ embedded as `<think>` tags |
| OpenAI | non-streaming (Responses API) | ❌ logged & dropped |
| OpenAI | non-streaming (Chat Completions) | ❌ logged & dropped |

This PR makes the two non-streaming paths embed reasoning in `<think>` blocks, matching the streaming path and Anthropic. Reasoning is now preserved in the response (and thus conversation history) regardless of which path serves the request.

## Why

Follow-up to #2981, which demoted the reasoning logging from INFO to DEBUG. As discussed in ErikBjare/bob#984, the deeper structural inconsistency was that OpenAI non-streaming silently discarded reasoning content while every other path preserves it. Erik asked for this to be fixed in a separate PR.

## Changes

- `_log_responses_reasoning` → `_extract_responses_reasoning`: now returns the extracted reasoning text (still logs at DEBUG); caller wraps it in `<think>` tags and appends to the result.
- Chat Completions non-streaming path: wrap `reasoning_content` / `reasoning` in a `<think>` block before the content.
- Downstream parsing in `codeblock.py` already handles `<think>` tags, so no parsing changes are needed.

## Tests

- New `test_chat_completions_embeds_reasoning_content` for the Chat Completions path.
- Updated `test_chat_uses_responses_api_for_gpt5_by_default` to assert the reasoning is embedded.
- All 101 tests in `test_llm_openai.py` pass; mypy + ruff clean.