### PR TITLE
fix(llm): preserve OpenAI reasoning in <think> tags on non-streaming path

### DIFF
--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -292,21 +292,29 @@ def _prepare_messages_for_responses_api(
     return instructions, input_items, responses_tools
 
 
-def _log_responses_reasoning(item: Any) -> None:
+def _extract_responses_reasoning(item: Any) -> str:
+    """Extract reasoning text from a Responses API ``reasoning`` output item.
+
+    Prefers the ``summary`` parts, falling back to ``content`` parts. Returns an
+    empty string when no reasoning text is present (e.g. encrypted reasoning).
+    """
     summary = _obj_get(item, "summary") or []
     summary_text = "\n".join(
         part.text if hasattr(part, "text") else part.get("text", "") for part in summary
     ).strip()
     if summary_text:
-        logger.debug("Reasoning content: %s", summary_text)
-        return
+        return summary_text
 
     content = _obj_get(item, "content") or []
-    content_text = "\n".join(
+    return "\n".join(
         part.text if hasattr(part, "text") else part.get("text", "") for part in content
     ).strip()
-    if content_text:
-        logger.debug("Reasoning content: %s", content_text)
+
+
+def _log_responses_reasoning(item: Any) -> None:
+    reasoning_text = _extract_responses_reasoning(item)
+    if reasoning_text:
+        logger.debug("Reasoning content: %s", reasoning_text)
 
 
 def _init_openai_client(
@@ -887,6 +895,10 @@ def chat(
             item_type = _obj_get(item, "type")
             if item_type == "reasoning":
                 _log_responses_reasoning(item)
+                # Preserve reasoning in the output so it survives in history,
+                # consistent with the streaming path and Anthropic.
+                if reasoning_text := _extract_responses_reasoning(item):
+                    result.append(f"<think>\n{reasoning_text}\n</think>")
             elif item_type == "function_call":
                 name = _obj_get(item, "name", "").strip()
                 call_id = _obj_get(item, "call_id", "").strip()
@@ -949,6 +961,9 @@ def chat(
             or getattr(choice.message, "reasoning", None)
         ):
             logger.debug("Reasoning content: %s", reasoning_content)
+            # Preserve reasoning in the output so it survives in history,
+            # consistent with the streaming path and Anthropic.
+            result.append(f"<think>\n{reasoning_content}\n</think>")
         if choice.message.content:
             result.append(choice.message.content)
 

--- a/tests/test_llm_openai.py
+++ b/tests/test_llm_openai.py
@@ -689,7 +689,8 @@ def test_chat_uses_responses_api_for_gpt5_by_default(monkeypatch):
         None,
     )
 
-    assert result == "Hello from Responses"
+    # Reasoning is preserved in <think> tags, consistent with the streaming path
+    assert result == "<think>\nNeed no extra tools.\n</think>\nHello from Responses"
     assert metadata is not None
     assert metadata["usage"]["input_tokens"] == 100
     assert metadata["usage"]["output_tokens"] == 30
@@ -733,6 +734,48 @@ def test_chat_responses_api_formats_function_calls(monkeypatch):
     assert metadata is None
     responses_create.assert_called_once()
     mock_client.chat.completions.create.assert_not_called()
+
+
+def test_chat_completions_preserves_reasoning_in_think_tags(monkeypatch):
+    """Non-streaming Chat Completions preserves reasoning_content in <think> tags.
+
+    Mirrors the streaming path (delta.reasoning_content -> <think>) and Anthropic,
+    so reasoning survives in conversation history instead of being silently dropped.
+    """
+    fake_response = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                finish_reason="stop",
+                message=SimpleNamespace(
+                    content="Hi there!",
+                    reasoning_content="The user greeted me, I should greet back.",
+                    tool_calls=None,
+                ),
+            )
+        ],
+        usage=None,
+    )
+    completions_create = Mock(return_value=fake_response)
+    mock_client = SimpleNamespace(
+        responses=SimpleNamespace(create=Mock()),
+        chat=SimpleNamespace(completions=SimpleNamespace(create=completions_create)),
+    )
+
+    monkeypatch.setattr(llm_openai, "get_client", lambda provider: mock_client)
+    monkeypatch.setattr(llm_openai, "_is_proxy", lambda client: False)
+    monkeypatch.setattr(llm_openai, "_should_use_responses_api", lambda *a, **k: False)
+
+    result, _ = llm_openai.chat(
+        [Message(role="user", content="Hello")],
+        "openai/gpt-4o",
+        None,
+    )
+
+    assert (
+        result
+        == "<think>\nThe user greeted me, I should greet back.\n</think>\nHi there!"
+    )
+    completions_create.assert_called_once()
 
 
 def test_content_to_responses_input_preserves_images():


### PR DESCRIPTION
## Problem

Follow-up to #2981. While answering Erik's question on that PR ("is reasoning content being handled consistently throughout the different LLM APIs?"), I traced reasoning handling across all paths and found a structural inconsistency:

| Path | Reasoning in output? |
|------|---------------------|
| Anthropic (stream + non-stream) | ✅ `<think>` tags |
| OpenAI **streaming** | ✅ `<think>` tags |
| OpenAI **non-streaming** (Chat Completions + Responses API) | ❌ only logged, dropped from output |

The non-streaming `chat()` path fetched reasoning content but only logged it (now at debug, per #2981) — it never made it into the returned message. So reasoning silently vanished from conversation history depending on provider *and* stream mode.

## Solution

Both non-streaming branches now wrap reasoning in `<think>` tags, matching their own streaming equivalents and Anthropic:

- **Responses API** branch: extract reasoning from `reasoning` output items. Refactored the extraction out of `_log_responses_reasoning` into `_extract_responses_reasoning` so logging and output-preservation share one code path.
- **Chat Completions** branch: wrap `message.reasoning_content` / `message.reasoning`.

For the same reasoning input, non-streaming output now equals the streaming output (verified in tests — the existing streaming test and the updated non-streaming test assert identical strings).

## Testing

- Updated `test_chat_uses_responses_api_for_gpt5_by_default` to assert the new (consistent) `<think>`-wrapped output.
- Added `test_chat_completions_preserves_reasoning_in_think_tags` for the Chat Completions branch.
- Full `tests/test_llm_openai.py` suite passes (101 tests).

No signature handling is needed for OpenAI (unlike Anthropic) — OpenAI reasoning content has no round-trip signature requirement, matching the existing streaming path.