### PR TITLE
fix(openai): embed reasoning content in non-streaming response instead of dropping it

### DIFF
--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -956,7 +956,7 @@ def chat(
             or getattr(choice.message, "reasoning", None)
         ):
             logger.debug("Reasoning content: %s", reasoning_content)
-            result.append(f"<think>\n{reasoning_content}\n</think>")
+            result.append(f"<think>\n{reasoning_content}\n</think>\n")
         if choice.message.content:
             result.append(choice.message.content)
 

--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -292,21 +292,26 @@ def _prepare_messages_for_responses_api(
     return instructions, input_items, responses_tools
 
 
-def _log_responses_reasoning(item: Any) -> None:
+def _extract_responses_reasoning(item: Any) -> str:
+    """Extract reasoning text from a Responses API ``reasoning`` output item.
+
+    Prefers the ``summary`` over the raw ``content``. Returns an empty string
+    when no reasoning text is present. The caller logs it and embeds it in the
+    response as a ``<think>`` block so the non-streaming path is consistent with
+    ``stream()`` and the Anthropic provider, which both preserve reasoning.
+    """
     summary = _obj_get(item, "summary") or []
     summary_text = "\n".join(
         part.text if hasattr(part, "text") else part.get("text", "") for part in summary
     ).strip()
     if summary_text:
-        logger.debug("Reasoning content: %s", summary_text)
-        return
+        return summary_text
 
     content = _obj_get(item, "content") or []
     content_text = "\n".join(
         part.text if hasattr(part, "text") else part.get("text", "") for part in content
     ).strip()
-    if content_text:
-        logger.debug("Reasoning content: %s", content_text)
+    return content_text
 
 
 def _init_openai_client(
@@ -886,7 +891,9 @@ def chat(
         for item in response.output:
             item_type = _obj_get(item, "type")
             if item_type == "reasoning":
-                _log_responses_reasoning(item)
+                if reasoning_text := _extract_responses_reasoning(item):
+                    logger.debug("Reasoning content: %s", reasoning_text)
+                    result.append(f"<think>\n{reasoning_text}\n</think>")
             elif item_type == "function_call":
                 name = _obj_get(item, "name", "").strip()
                 call_id = _obj_get(item, "call_id", "").strip()
@@ -949,6 +956,7 @@ def chat(
             or getattr(choice.message, "reasoning", None)
         ):
             logger.debug("Reasoning content: %s", reasoning_content)
+            result.append(f"<think>\n{reasoning_content}\n</think>")
         if choice.message.content:
             result.append(choice.message.content)
 

--- a/tests/test_llm_openai.py
+++ b/tests/test_llm_openai.py
@@ -771,7 +771,7 @@ def test_chat_completions_embeds_reasoning_content(monkeypatch):
         None,
     )
 
-    assert result == "<think>\nAdding 2 and 2 gives 4.\n</think>\nThe answer is 4."
+    assert result == "<think>\nAdding 2 and 2 gives 4.\n</think>\n\nThe answer is 4."
 
 
 def test_extract_responses_reasoning_prefers_summary_over_content():

--- a/tests/test_llm_openai.py
+++ b/tests/test_llm_openai.py
@@ -689,7 +689,9 @@ def test_chat_uses_responses_api_for_gpt5_by_default(monkeypatch):
         None,
     )
 
-    assert result == "Hello from Responses"
+    # Reasoning summary is embedded as a <think> block, consistent with the
+    # streaming path and the Anthropic provider (instead of being dropped).
+    assert result == "<think>\nNeed no extra tools.\n</think>\nHello from Responses"
     assert metadata is not None
     assert metadata["usage"]["input_tokens"] == 100
     assert metadata["usage"]["output_tokens"] == 30
@@ -733,6 +735,59 @@ def test_chat_responses_api_formats_function_calls(monkeypatch):
     assert metadata is None
     responses_create.assert_called_once()
     mock_client.chat.completions.create.assert_not_called()
+
+
+def test_chat_completions_embeds_reasoning_content(monkeypatch):
+    """Chat Completions reasoning (DeepSeek/OpenRouter) is embedded, not dropped.
+
+    Keeps the non-streaming path consistent with ``stream()`` and Anthropic,
+    which both surface reasoning as a ``<think>`` block instead of discarding it.
+    """
+    completion = SimpleNamespace(
+        usage=None,
+        choices=[
+            SimpleNamespace(
+                finish_reason="stop",
+                message=SimpleNamespace(
+                    content="The answer is 4.",
+                    tool_calls=None,
+                    reasoning_content="Adding 2 and 2 gives 4.",
+                ),
+            )
+        ],
+    )
+    completions_create = Mock(return_value=completion)
+    mock_client = SimpleNamespace(
+        chat=SimpleNamespace(completions=SimpleNamespace(create=completions_create))
+    )
+
+    monkeypatch.setattr(llm_openai, "get_client", lambda provider: mock_client)
+    monkeypatch.setattr(llm_openai, "_is_proxy", lambda client: False)
+    monkeypatch.setattr(llm_openai, "_should_use_responses_api", lambda *args: False)
+
+    result, _ = llm_openai.chat(
+        [Message(role="user", content="What is 2+2?")],
+        "openai/gpt-4o",
+        None,
+    )
+
+    assert result == "<think>\nAdding 2 and 2 gives 4.\n</think>\nThe answer is 4."
+
+
+def test_extract_responses_reasoning_prefers_summary_over_content():
+    item = SimpleNamespace(
+        summary=[SimpleNamespace(text="short summary")],
+        content=[SimpleNamespace(text="full reasoning")],
+    )
+    assert llm_openai._extract_responses_reasoning(item) == "short summary"
+
+
+def test_extract_responses_reasoning_falls_back_to_content():
+    item = SimpleNamespace(
+        summary=[],
+        content=[SimpleNamespace(text="full reasoning")],
+    )
+    assert llm_openai._extract_responses_reasoning(item) == "full reasoning"
 
 
 def test_content_to_responses_input_preserves_images():


### PR DESCRIPTION
## Problem

Follow-up to #2981 (per @ErikBjare's request to fix the structural issue).

While #2981 demoted reasoning-content logging from INFO to DEBUG, it surfaced a deeper inconsistency: **OpenAI's non-streaming `chat()` silently discards reasoning content** while other paths preserve it.

| Provider | Path | Reasoning in response? |
|----------|------|------------------------|
| OpenAI | Responses API (`chat`, non-streaming) | ❌ logged + dropped |
| OpenAI | Chat Completions (`chat`, non-streaming) | ❌ logged + dropped |
| OpenAI | `stream()` | ✅ embedded as `<think>…</think>` |
| Anthropic | both | ✅ embedded as `<think>…</think>` |

The non-streaming OpenAI path was the only one that threw reasoning away — the DEBUG log was the *only* way it surfaced, and it never reached the returned result.

## Fix

Embed reasoning as a `<think>\n…\n</think>` block in both non-streaming OpenAI paths (Responses API and Chat Completions), matching the existing `stream()` behavior and the Anthropic provider. Now the same input produces the same output regardless of whether streaming is used.

- Refactored `_log_responses_reasoning` → `_extract_responses_reasoning` (returns the text; caller logs + embeds).
- Chat Completions path appends a `<think>` block before the content.

## Tests

- Updated `test_chat_uses_responses_api_for_gpt5_by_default` to assert the embedded `<think>` block — note the expected string is now **identical** to the streaming test's (`test_stream_responses_...`) for the same fixture.
- Added `test_chat_completions_embeds_reasoning_content` (DeepSeek/OpenRouter `reasoning_content`).
- Added two unit tests for `_extract_responses_reasoning` (summary-preferred + content-fallback).
- Full `test_llm_openai.py` + `test_llm_openai_sampling.py`: 109 passed.