### PR TITLE
feat(lessons): randomized lesson-dropout injection for causal LOO

### DIFF
--- a/gptme/lessons/auto_include.py
+++ b/gptme/lessons/auto_include.py
@@ -1,7 +1,12 @@
 """Automatic lesson inclusion based on context."""
 
+import json
 import logging
 import os
+import random
+import time
+import uuid
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from .index import LessonIndex
@@ -52,6 +57,116 @@ def _estimate_tokens(text: str) -> int:
     enforcement — actual tokenization varies by model.
     """
     return max(1, len(text) // 3)
+
+
+def _get_dropout_epsilon() -> float:
+    """Get the randomized lesson-dropout probability from the environment.
+
+    Controlled by ``LESSON_DROPOUT_EPSILON`` (float in [0, 1]). When > 0, each
+    otherwise-matched lesson is independently withheld with this probability and
+    the withheld set is logged for causal leave-one-out analysis. Default 0.0
+    means no dropout (fully backwards compatible).
+    """
+    raw = os.environ.get("LESSON_DROPOUT_EPSILON")
+    if not raw:
+        return 0.0
+    try:
+        epsilon = float(raw)
+    except (ValueError, TypeError):
+        logger.warning("Invalid LESSON_DROPOUT_EPSILON=%r, ignoring", raw)
+        return 0.0
+    if epsilon <= 0.0:
+        return 0.0
+    if epsilon > 1.0:
+        logger.warning("LESSON_DROPOUT_EPSILON=%s clamped to 1.0", epsilon)
+        return 1.0
+    return epsilon
+
+
+def _get_dropout_session_id() -> str:
+    """Resolve the session id used to correlate dropout logs with outcomes.
+
+    Prefers ``GPTME_SESSION_ID`` / ``CC_SESSION_ID`` (the same id used in lesson
+    trajectory logs) so causal analysis can join withheld lessons to session
+    outcomes. Falls back to a random id when neither is set.
+    """
+    for key in ("GPTME_SESSION_ID", "CC_SESSION_ID"):
+        value = os.environ.get(key)
+        if value:
+            return value
+    return uuid.uuid4().hex
+
+
+def _get_dropout_log_dir() -> Path:
+    """Directory for randomized-dropout logs (``state/lesson-dropout`` default).
+
+    Overridable via ``LESSON_DROPOUT_LOG_DIR``. The default is relative to the
+    current working directory so analysis tooling that reads
+    ``state/lesson-dropout/*.jsonl`` works without extra configuration.
+    """
+    return Path(os.environ.get("LESSON_DROPOUT_LOG_DIR", "state/lesson-dropout"))
+
+
+def _apply_lesson_dropout(matches: list) -> list:
+    """Randomly withhold matched lessons for causal LOO measurement.
+
+    For each match, flips a coin with probability ``LESSON_DROPOUT_EPSILON`` to
+    withhold it. Withheld lessons are logged to
+    ``<log dir>/<session-id>.jsonl`` and removed from the returned list so they
+    are not injected. When epsilon is 0 (default), the input list is returned
+    unchanged and nothing is logged.
+
+    Args:
+        matches: Match results (already truncated to the injection cap).
+
+    Returns:
+        The matches that survived the dropout roll (to be injected).
+    """
+    epsilon = _get_dropout_epsilon()
+    if epsilon <= 0.0 or not matches:
+        return matches
+
+    kept: list = []
+    withheld: list[dict] = []
+    for match in matches:
+        if random.random() < epsilon:
+            lesson = match.lesson
+            withheld.append({"path": str(lesson.path), "title": lesson.title})
+        else:
+            kept.append(match)
+
+    if withheld:
+        _log_dropout(epsilon, withheld)
+
+    return kept
+
+
+def _log_dropout(epsilon: float, withheld: list[dict]) -> None:
+    """Append a randomized-dropout record for causal LOO analysis.
+
+    Failures are logged and swallowed — dropout logging must never break lesson
+    injection.
+    """
+    try:
+        session_id = _get_dropout_session_id()
+        log_dir = _get_dropout_log_dir()
+        log_dir.mkdir(parents=True, exist_ok=True)
+        record = {
+            "ts": time.time(),
+            "session_id": session_id,
+            "epsilon": epsilon,
+            "withheld": withheld,
+        }
+        with open(log_dir / f"{session_id}.jsonl", "a") as f:
+            f.write(json.dumps(record) + "\n")
+        logger.debug(
+            "Lesson dropout: withheld %d lesson(s) at epsilon=%s (session %s)",
+            len(withheld),
+            epsilon,
+            session_id,
+        )
+    except Exception as e:
+        logger.warning("Failed to log lesson dropout: %s", e)
 
 
 def auto_include_lessons(
@@ -125,6 +240,14 @@ def auto_include_lessons(
 
         # Limit to top N (matcher may already limit, but ensure it)
         matches = matches[:max_lessons]
+
+        # Optionally withhold a random subset for causal LOO measurement.
+        # No-op unless LESSON_DROPOUT_EPSILON > 0.
+        matches = _apply_lesson_dropout(matches)
+        if not matches:
+            logger.debug("All matched lessons withheld by dropout")
+            return messages
+
         for match in matches:
             if match.lesson.is_stub:
                 match.lesson = index.materialize_lesson(match.lesson)

--- a/tests/test_lessons_auto_include.py
+++ b/tests/test_lessons_auto_include.py
@@ -248,3 +248,106 @@ Execute Python code interactively.
     lesson_msg = updated[1]
     assert "Python REPL Skill" in lesson_msg.content
     assert "Execute Python code interactively." in lesson_msg.content
+
+
+# --- Randomized lesson dropout (causal LOO measurement) ---
+
+from gptme.lessons.auto_include import (
+    _apply_lesson_dropout,
+    _get_dropout_epsilon,
+    _get_dropout_log_dir,
+    _get_dropout_session_id,
+)
+
+
+def test_dropout_epsilon_unset_is_zero(monkeypatch):
+    monkeypatch.delenv("LESSON_DROPOUT_EPSILON", raising=False)
+    assert _get_dropout_epsilon() == 0.0
+
+
+def test_dropout_epsilon_parses_and_clamps(monkeypatch):
+    monkeypatch.setenv("LESSON_DROPOUT_EPSILON", "0.25")
+    assert _get_dropout_epsilon() == 0.25
+    monkeypatch.setenv("LESSON_DROPOUT_EPSILON", "2.5")
+    assert _get_dropout_epsilon() == 1.0
+    monkeypatch.setenv("LESSON_DROPOUT_EPSILON", "0")
+    assert _get_dropout_epsilon() == 0.0
+    monkeypatch.setenv("LESSON_DROPOUT_EPSILON", "-0.3")
+    assert _get_dropout_epsilon() == 0.0
+    monkeypatch.setenv("LESSON_DROPOUT_EPSILON", "not-a-number")
+    assert _get_dropout_epsilon() == 0.0
+
+
+def test_dropout_session_id_prefers_env(monkeypatch):
+    monkeypatch.setenv("GPTME_SESSION_ID", "sess-123")
+    monkeypatch.delenv("CC_SESSION_ID", raising=False)
+    assert _get_dropout_session_id() == "sess-123"
+    monkeypatch.delenv("GPTME_SESSION_ID", raising=False)
+    monkeypatch.setenv("CC_SESSION_ID", "cc-456")
+    assert _get_dropout_session_id() == "cc-456"
+    monkeypatch.delenv("CC_SESSION_ID", raising=False)
+    # Falls back to a generated id (non-empty)
+    assert _get_dropout_session_id()
+
+
+def test_dropout_disabled_is_noop(monkeypatch, tmp_path):
+    monkeypatch.delenv("LESSON_DROPOUT_EPSILON", raising=False)
+    monkeypatch.setenv("LESSON_DROPOUT_LOG_DIR", str(tmp_path / "drop"))
+    matches = [_MockMatch(_make_lesson("A", "body", "/tmp/a.md"))]
+    result = _apply_lesson_dropout(matches)
+    assert result == matches
+    assert not (tmp_path / "drop").exists()  # nothing written
+
+
+def test_dropout_epsilon_one_withholds_all_and_logs(monkeypatch, tmp_path):
+    log_dir = tmp_path / "drop"
+    monkeypatch.setenv("LESSON_DROPOUT_EPSILON", "1.0")
+    monkeypatch.setenv("LESSON_DROPOUT_LOG_DIR", str(log_dir))
+    monkeypatch.setenv("GPTME_SESSION_ID", "sess-all")
+    monkeypatch.delenv("CC_SESSION_ID", raising=False)
+    matches = [
+        _MockMatch(_make_lesson("A", "abody", "/tmp/a.md")),
+        _MockMatch(_make_lesson("B", "bbody", "/tmp/b.md")),
+    ]
+    result = _apply_lesson_dropout(matches)
+    assert result == []  # all withheld
+
+    log_file = log_dir / "sess-all.jsonl"
+    assert log_file.exists()
+    records = [json.loads(line) for line in log_file.read_text().splitlines() if line]
+    assert len(records) == 1
+    record = records[0]
+    assert record["session_id"] == "sess-all"
+    assert record["epsilon"] == 1.0
+    withheld_paths = {w["path"] for w in record["withheld"]}
+    assert withheld_paths == {"/tmp/a.md", "/tmp/b.md"}
+
+
+def test_dropout_partial_is_consistent(monkeypatch, tmp_path):
+    import random as _random
+
+    log_dir = tmp_path / "drop"
+    monkeypatch.setenv("LESSON_DROPOUT_EPSILON", "0.5")
+    monkeypatch.setenv("LESSON_DROPOUT_LOG_DIR", str(log_dir))
+    monkeypatch.setenv("GPTME_SESSION_ID", "sess-part")
+    monkeypatch.delenv("CC_SESSION_ID", raising=False)
+    matches = [
+        _MockMatch(_make_lesson(f"L{i}", "body", f"/tmp/l{i}.md")) for i in range(20)
+    ]
+    _random.seed(42)
+    kept = _apply_lesson_dropout(matches)
+
+    # The withheld log plus the kept set must reconstruct the original set.
+    log_file = log_dir / "sess-part.jsonl"
+    records = [json.loads(line) for line in log_file.read_text().splitlines() if line]
+    withheld_paths = {w["path"] for r in records for w in r["withheld"]}
+    kept_paths = {str(m.lesson.path) for m in kept}
+    all_paths = {str(m.lesson.path) for m in matches}
+    assert kept_paths.isdisjoint(withheld_paths)
+    assert kept_paths | withheld_paths == all_paths
+    assert 0 < len(withheld_paths) < len(matches)  # genuinely partial
+
+
+def test_dropout_log_dir_default(monkeypatch):
+    monkeypatch.delenv("LESSON_DROPOUT_LOG_DIR", raising=False)
+    assert _get_dropout_log_dir() == Path("state/lesson-dropout")


### PR DESCRIPTION
## Problem
`scripts/lesson-loo-analysis.py` reads randomized-dropout logs from `state/lesson-dropout/*.jsonl` (`load_randomized_dropout_pairs`) to compute **causal** leave-one-out estimates of lesson effectiveness, but nothing ever wrote those logs. The injection-side dropout was never implemented, so causal estimates always came up empty ("Enable LESSON_DROPOUT_EPSILON>0 to collect causal controls").

## What this does
In `auto_include_lessons`, after matched lessons are truncated to the injection cap:

1. Read `LESSON_DROPOUT_EPSILON` (float in [0,1], default `0.0`).
2. For each otherwise-matched lesson, withhold it independently with probability ε.
3. Withheld lessons are **removed from injection** and logged to `<LESSON_DROPOUT_LOG_DIR>/<session-id>.jsonl`.
4. The surviving lessons are injected as before.

Record format (one JSON object per line):
```json
{"ts": 1782299822.0, "session_id": "...", "epsilon": 0.2, "withheld": [{"path": "...", "title": "..."}]}
```

Session id comes from `GPTME_SESSION_ID` / `CC_SESSION_ID` (the same id used in lesson-trajectory outcome logs, so the two join for causal analysis); falls back to a random id. Log dir defaults to `state/lesson-dropout` relative to cwd, overridable via `LESSON_DROPOUT_LOG_DIR`.

## Backwards compatibility
`LESSON_DROPOUT_EPSILON` unset or `0` ⇒ **no behavioral change**, nothing written. Logging failures are caught and swallowed so dropout can never break lesson injection.

## Tests
`tests/test_lessons_auto_include.py` (+6 tests): epsilon parsing/clamping, session-id resolution, ε=0 no-op (no file written), ε=1 withholds all + log format, seeded partial dropout (kept ∪ withheld reconstructs the input, disjoint), default log dir. `23 passed`.

Also verified end-to-end that the generated log is consumed by `load_randomized_dropout_pairs` in `lesson-loo-analysis.py`.

Closes part of ErikBjare/bob#791.