### PR TITLE
feat(subagent): add workdir parameter for explicit workspace control

### DIFF
--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -1462,9 +1462,9 @@ def _check_workspace_config() -> Message | None:
         f"To work within this workspace context (custom tools, files, prompt), "
         f"spawn a subagent here:\n"
         f"```ipython\n"
-        f'subagent("{workspace_name}", "Your task here", use_subprocess=True)\n'
+        f'subagent("{workspace_name}", "Your task here", workdir="{cwd}", use_subprocess=True)\n'
         f"```\n"
-        f"The subagent will inherit the workspace config from `{config_file}`.",
+        f"The subagent will load the workspace config from `{config_file}`.",
     )
 
 

--- a/gptme/tools/subagent/__init__.py
+++ b/gptme/tools/subagent/__init__.py
@@ -119,6 +119,18 @@ Assistant: I'll use subprocess mode for better output isolation.
     }
 System: Subagent started in subprocess mode.
 
+### Workspace-Aware Subagent (explicit workdir)
+User: I just cd'd into /path/to/project which has a gptme.toml — spawn a subagent there
+Assistant: I'll use workdir to make the subagent operate in that workspace and load its config.
+{
+        ToolUse(
+            "ipython",
+            [],
+            'subagent("project", "Add feature X", workdir="/path/to/project", use_subprocess=True)',
+        ).to_output(tool_format)
+    }
+System: Subagent started in subprocess mode (workdir=/path/to/project).
+
 ### ACP Mode (multi-harness support)
 User: delegate this task to a Claude Code agent
 Assistant: I'll use ACP mode to run this via a different agent harness.
@@ -262,6 +274,7 @@ Key features:
 - use_acp=True: Run subagent via ACP protocol (supports any ACP-compatible agent)
 - acp_command="claude-code-acp": Use a different ACP agent (default: gptme-acp)
 - isolated=True: Run subagent in a git worktree for filesystem isolation
+- workdir="/path/to/dir": Set the working directory for the subagent (defaults to cwd)
 - redact_secrets=True (default): Redact API keys, tokens, and passwords from workspace context
 - context_window=0: Minimal context — only agent identity + tools, no workspace files (strongest isolation)
 - context_window=N: Limit workspace context to at most N messages

--- a/gptme/tools/subagent/api.py
+++ b/gptme/tools/subagent/api.py
@@ -240,6 +240,16 @@ def subagent(
         current_model = get_default_model()
         model_name = current_model.full if current_model else None
 
+    # Resolve explicit workdir once, shared by the planner and executor paths.
+    # When workdir is None each path falls back to Path.cwd() at spawn time.
+    workdir_path: Path | None = None
+    if workdir is not None:
+        workdir_path = Path(workdir).resolve()
+        if not workdir_path.exists():
+            raise ValueError(f"workdir does not exist: {workdir_path}")
+        if not workdir_path.is_dir():
+            raise ValueError(f"workdir is not a directory: {workdir_path}")
+
     if mode == "planner":
         if not subtasks:
             raise ValueError("Planner mode requires subtasks parameter")
@@ -254,6 +264,7 @@ def subagent(
             profile_name=profile,
             redact_secrets=redact_secrets,
             context_window=context_window,
+            workdir=workdir_path,
         )
 
     # Validate context_mode parameters
@@ -269,13 +280,9 @@ def subagent(
     name = f"subagent-{agent_id}"
     logdir = get_logdir(name + "-" + random_string(4))
 
-    # Resolve workspace: explicit workdir > current working directory
-    if workdir is not None:
-        workspace = Path(workdir).resolve()
-        if not workspace.exists():
-            raise ValueError(f"workdir does not exist: {workspace}")
-        if not workspace.is_dir():
-            raise ValueError(f"workdir is not a directory: {workspace}")
+    # Resolve workspace: explicit workdir (validated above) > current working dir
+    if workdir_path is not None:
+        workspace = workdir_path
     else:
         # Get workspace, handling case where cwd was deleted (e.g., in tests)
         try:

--- a/gptme/tools/subagent/api.py
+++ b/gptme/tools/subagent/api.py
@@ -53,6 +53,7 @@ def subagent(
     role: Role | None = None,
     redact_secrets: bool = True,
     context_window: int | None = None,
+    workdir: str | Path | None = None,
 ):
     """Starts an asynchronous subagent. Returns None immediately.
 
@@ -146,6 +147,23 @@ def subagent(
 
             Only applies to thread-mode subagents; has no effect in subprocess
             or ACP modes (which build their own context as a separate process).
+        workdir: Working directory for the subagent. Defaults to the current
+            working directory (``Path.cwd()``) when ``None``.
+
+            Use this when you want the subagent to operate in a specific
+            directory — for example, when a ``cd`` into a project with a
+            ``gptme.toml`` triggers workspace detection and you want the
+            subagent to load that workspace's config:
+
+            .. code-block:: python
+
+                subagent("impl", "Add feature X", workdir="/path/to/project",
+                         use_subprocess=True)
+
+            In subprocess mode the subagent process starts with this as its
+            ``cwd``, so it picks up the ``gptme.toml`` from that directory.
+            In thread mode the workspace context (files, ``context_cmd``) is
+            loaded relative to this path.
 
     Returns:
         None: Starts asynchronous execution.
@@ -251,12 +269,18 @@ def subagent(
     name = f"subagent-{agent_id}"
     logdir = get_logdir(name + "-" + random_string(4))
 
-    # Get workspace, handling case where cwd was deleted (e.g., in tests)
-    try:
-        workspace = Path.cwd()
-    except FileNotFoundError:
-        # Fallback to logdir's parent if cwd doesn't exist
-        workspace = logdir.parent
+    # Resolve workspace: explicit workdir > current working directory
+    if workdir is not None:
+        workspace = Path(workdir).resolve()
+        if not workspace.exists():
+            raise ValueError(f"workdir does not exist: {workspace}")
+    else:
+        # Get workspace, handling case where cwd was deleted (e.g., in tests)
+        try:
+            workspace = Path.cwd()
+        except FileNotFoundError:
+            # Fallback to logdir's parent if cwd doesn't exist
+            workspace = logdir.parent
 
     # Set up worktree isolation if requested
     worktree_path: Path | None = None

--- a/gptme/tools/subagent/api.py
+++ b/gptme/tools/subagent/api.py
@@ -274,6 +274,8 @@ def subagent(
         workspace = Path(workdir).resolve()
         if not workspace.exists():
             raise ValueError(f"workdir does not exist: {workspace}")
+        if not workspace.is_dir():
+            raise ValueError(f"workdir is not a directory: {workspace}")
     else:
         # Get workspace, handling case where cwd was deleted (e.g., in tests)
         try:

--- a/gptme/tools/subagent/execution.py
+++ b/gptme/tools/subagent/execution.py
@@ -581,6 +581,7 @@ def _run_planner(
     profile_name: str | None = None,
     redact_secrets: bool = True,
     context_window: int | None = None,
+    workdir: Path | None = None,
 ) -> None:
     """Run a planner that delegates work to multiple executor subagents.
 
@@ -598,6 +599,8 @@ def _run_planner(
             (which manage their own context); a debug message is logged in that case.
         context_window: Limit workspace context messages passed to executor subagents.
             None = no limit; 0 = minimal context (no workspace files); N > 0 = at most N.
+        workdir: Pre-resolved working directory for all executor subagents. When
+            None, each executor falls back to Path.cwd() at spawn time.
     """
     from gptme.cli.main import get_logdir
 
@@ -649,12 +652,15 @@ def _run_planner(
                 f"isolated={resolved_isolated}"
             )
 
-        # Capture workspace before spawning to avoid FileNotFoundError
-        # if cwd is deleted (e.g., tmpdir cleanup in tests)
-        try:
-            workspace = Path.cwd()
-        except FileNotFoundError:
-            workspace = logdir.parent
+        # Explicit workdir > current working directory. Capture before spawning
+        # to avoid FileNotFoundError if cwd is deleted (e.g., tmpdir cleanup in tests)
+        if workdir is not None:
+            workspace = workdir
+        else:
+            try:
+                workspace = Path.cwd()
+            except FileNotFoundError:
+                workspace = logdir.parent
 
         # Set up worktree isolation if the resolved role requires it
         worktree_path: Path | None = None

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -2269,8 +2269,8 @@ class TestWorkdir:
         assert isinstance(exec_calls[0], Path)
         assert exec_calls[0] == workspace_dir.resolve()
 
-    def test_workdir_ignored_in_planner_mode(self, monkeypatch, tmp_path):
-        """workdir is silently ignored when mode='planner' (returns early before workdir resolution)."""
+    def test_workdir_validated_in_planner_mode(self, monkeypatch, tmp_path):
+        """workdir is validated before the planner branch — a bad path raises."""
         import importlib
 
         exec_mod = importlib.import_module("gptme.tools.subagent.execution")
@@ -2281,15 +2281,42 @@ class TestWorkdir:
 
         from gptme.tools.subagent.api import subagent
 
-        # Should NOT raise ValueError even though workdir doesn't exist,
-        # because the planner path returns before workdir is validated
+        with pytest.raises(ValueError, match="workdir does not exist"):
+            subagent(
+                "agent",
+                "do planner thing",
+                mode="planner",
+                subtasks=[{"id": "test-1", "description": "test subtask"}],
+                workdir="/nonexistent",
+            )
+
+    def test_workdir_forwarded_to_planner(self, monkeypatch, tmp_path):
+        """A valid workdir is resolved and forwarded to _run_planner."""
+        import importlib
+
+        exec_mod = importlib.import_module("gptme.tools.subagent.execution")
+        llm_models = importlib.import_module("gptme.llm.models")
+
+        captured: dict = {}
+        monkeypatch.setattr(
+            exec_mod, "_run_planner", lambda *args, **kw: captured.update(kw)
+        )
+        monkeypatch.setattr(llm_models, "get_default_model", lambda: None)
+
+        from gptme.tools.subagent.api import subagent
+
+        workspace_dir = tmp_path / "planner-workspace"
+        workspace_dir.mkdir()
+
         subagent(
             "agent",
             "do planner thing",
             mode="planner",
             subtasks=[{"id": "test-1", "description": "test subtask"}],
-            workdir="/nonexistent",
+            workdir=str(workspace_dir),
         )
+
+        assert captured.get("workdir") == workspace_dir.resolve()
 
     def test_workdir_overridden_when_isolated(self, monkeypatch, tmp_path):
         """When isolated=True, workdir is overridden by the isolated workspace (tempdir or worktree)."""

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -2178,6 +2178,21 @@ class TestWorkdir:
         with pytest.raises(ValueError, match="workdir does not exist"):
             subagent("agent", "do something", workdir="/nonexistent/path/xyz")
 
+    def test_workdir_file_raises(self, monkeypatch, tmp_path):
+        """Passing a file (not a directory) as workdir raises ValueError immediately."""
+        import importlib
+
+        llm_models = importlib.import_module("gptme.llm.models")
+        monkeypatch.setattr(llm_models, "get_default_model", lambda: None)
+
+        from gptme.tools.subagent.api import subagent
+
+        file_path = tmp_path / "not_a_dir.txt"
+        file_path.write_text("i am a file")
+
+        with pytest.raises(ValueError, match="workdir is not a directory"):
+            subagent("agent", "do something", workdir=str(file_path))
+
     def _spawn_and_wait(self, monkeypatch, tmp_path, agent_id, exec_calls, **kwargs):
         """Spawn a subagent, capture workspace kwarg, wait for thread to finish."""
         import importlib

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -2131,3 +2131,125 @@ class TestContextWindowValidation:
         # Clean up registered subagent
         with _subagents_lock:
             _subagents[:] = [s for s in _subagents if s.agent_id != "isolation-test"]
+
+
+class TestWorkdir:
+    """Tests for the workdir parameter of subagent()."""
+
+    def _spawn(self, monkeypatch, tmp_path, **kwargs):
+        """Helper: spawn a subagent with mocked deps and return the Subagent record."""
+        import importlib
+
+        cli_main = importlib.import_module("gptme.cli.main")
+        exec_mod = importlib.import_module("gptme.tools.subagent.execution")
+        llm_models = importlib.import_module("gptme.llm.models")
+        profiles = importlib.import_module("gptme.profiles")
+
+        monkeypatch.setattr(cli_main, "get_logdir", lambda name: tmp_path / name)
+        monkeypatch.setattr(llm_models, "get_default_model", lambda: None)
+        monkeypatch.setattr(profiles, "get_profile", lambda _: None)
+        monkeypatch.setattr(exec_mod, "_create_subagent_thread", lambda **kw: None)
+        monkeypatch.setattr(exec_mod, "_cleanup_isolation", lambda sa: None)
+
+        from gptme.tools.subagent.api import subagent
+        from gptme.tools.subagent.types import _subagents, _subagents_lock
+
+        agent_id = kwargs.pop("agent_id", "workdir-test")
+        subagent(agent_id, "do something", **kwargs)
+
+        with _subagents_lock:
+            sa = next((s for s in _subagents if s.agent_id == agent_id), None)
+
+        # cleanup
+        with _subagents_lock:
+            _subagents[:] = [s for s in _subagents if s.agent_id != agent_id]
+
+        return sa
+
+    def test_workdir_nonexistent_raises(self, monkeypatch, tmp_path):
+        """Passing a non-existent workdir raises ValueError immediately."""
+        import importlib
+
+        llm_models = importlib.import_module("gptme.llm.models")
+        monkeypatch.setattr(llm_models, "get_default_model", lambda: None)
+
+        from gptme.tools.subagent.api import subagent
+
+        with pytest.raises(ValueError, match="workdir does not exist"):
+            subagent("agent", "do something", workdir="/nonexistent/path/xyz")
+
+    def _spawn_and_wait(self, monkeypatch, tmp_path, agent_id, exec_calls, **kwargs):
+        """Spawn a subagent, capture workspace kwarg, wait for thread to finish."""
+        import importlib
+
+        cli_main = importlib.import_module("gptme.cli.main")
+        exec_mod = importlib.import_module("gptme.tools.subagent.execution")
+        llm_models = importlib.import_module("gptme.llm.models")
+        profiles = importlib.import_module("gptme.profiles")
+
+        monkeypatch.setattr(cli_main, "get_logdir", lambda name: tmp_path / name)
+        monkeypatch.setattr(llm_models, "get_default_model", lambda: None)
+        monkeypatch.setattr(profiles, "get_profile", lambda _: None)
+
+        def capture_thread(**kw):
+            exec_calls.append(kw.get("workspace"))
+
+        monkeypatch.setattr(exec_mod, "_create_subagent_thread", capture_thread)
+        monkeypatch.setattr(exec_mod, "_cleanup_isolation", lambda sa: None)
+
+        from gptme.tools.subagent.api import subagent
+        from gptme.tools.subagent.types import _subagents, _subagents_lock
+
+        subagent(agent_id, "do something", **kwargs)
+
+        # Wait for the daemon thread to finish so exec_calls is populated
+        with _subagents_lock:
+            sa = next((s for s in _subagents if s.agent_id == agent_id), None)
+        if sa and sa.thread:
+            sa.thread.join(timeout=5)
+
+        with _subagents_lock:
+            _subagents[:] = [s for s in _subagents if s.agent_id != agent_id]
+
+    def test_workdir_none_uses_cwd(self, monkeypatch, tmp_path):
+        """When workdir=None the subagent is launched in Path.cwd()."""
+        from pathlib import Path
+
+        exec_calls: list[Path] = []
+        self._spawn_and_wait(
+            monkeypatch, tmp_path, "cwd-test", exec_calls, workdir=None
+        )
+
+        assert len(exec_calls) == 1
+        assert exec_calls[0] == Path.cwd()
+
+    def test_workdir_explicit_path_is_used(self, monkeypatch, tmp_path):
+        """workdir=<path> is resolved and passed as the workspace to the thread."""
+        from pathlib import Path
+
+        workspace_dir = tmp_path / "myproject"
+        workspace_dir.mkdir()
+
+        exec_calls: list[Path] = []
+        self._spawn_and_wait(
+            monkeypatch, tmp_path, "workdir-explicit", exec_calls, workdir=workspace_dir
+        )
+
+        assert len(exec_calls) == 1
+        assert exec_calls[0] == workspace_dir.resolve()
+
+    def test_workdir_string_is_resolved_to_path(self, monkeypatch, tmp_path):
+        """A workdir passed as a string is converted to a resolved Path."""
+        from pathlib import Path
+
+        workspace_dir = tmp_path / "strproject"
+        workspace_dir.mkdir()
+
+        exec_calls: list[Path] = []
+        self._spawn_and_wait(
+            monkeypatch, tmp_path, "workdir-str", exec_calls, workdir=str(workspace_dir)
+        )
+
+        assert len(exec_calls) == 1
+        assert isinstance(exec_calls[0], Path)
+        assert exec_calls[0] == workspace_dir.resolve()

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -2230,7 +2230,7 @@ class TestWorkdir:
         """When workdir=None the subagent is launched in Path.cwd()."""
         from pathlib import Path
 
-        exec_calls: list[Path] = []
+        exec_calls: list[Path | None] = []
         self._spawn_and_wait(
             monkeypatch, tmp_path, "cwd-test", exec_calls, workdir=None
         )
@@ -2245,7 +2245,7 @@ class TestWorkdir:
         workspace_dir = tmp_path / "myproject"
         workspace_dir.mkdir()
 
-        exec_calls: list[Path] = []
+        exec_calls: list[Path | None] = []
         self._spawn_and_wait(
             monkeypatch, tmp_path, "workdir-explicit", exec_calls, workdir=workspace_dir
         )
@@ -2260,7 +2260,7 @@ class TestWorkdir:
         workspace_dir = tmp_path / "strproject"
         workspace_dir.mkdir()
 
-        exec_calls: list[Path] = []
+        exec_calls: list[Path | None] = []
         self._spawn_and_wait(
             monkeypatch, tmp_path, "workdir-str", exec_calls, workdir=str(workspace_dir)
         )
@@ -2268,3 +2268,72 @@ class TestWorkdir:
         assert len(exec_calls) == 1
         assert isinstance(exec_calls[0], Path)
         assert exec_calls[0] == workspace_dir.resolve()
+
+    def test_workdir_ignored_in_planner_mode(self, monkeypatch, tmp_path):
+        """workdir is silently ignored when mode='planner' (returns early before workdir resolution)."""
+        import importlib
+
+        exec_mod = importlib.import_module("gptme.tools.subagent.execution")
+        llm_models = importlib.import_module("gptme.llm.models")
+
+        monkeypatch.setattr(exec_mod, "_run_planner", lambda *args, **kw: None)
+        monkeypatch.setattr(llm_models, "get_default_model", lambda: None)
+
+        from gptme.tools.subagent.api import subagent
+
+        # Should NOT raise ValueError even though workdir doesn't exist,
+        # because the planner path returns before workdir is validated
+        subagent(
+            "agent",
+            "do planner thing",
+            mode="planner",
+            subtasks=[{"id": "test-1", "description": "test subtask"}],
+            workdir="/nonexistent",
+        )
+
+    def test_workdir_overridden_when_isolated(self, monkeypatch, tmp_path):
+        """When isolated=True, workdir is overridden by the isolated workspace (tempdir or worktree)."""
+        import importlib
+
+        cli_main = importlib.import_module("gptme.cli.main")
+        exec_mod = importlib.import_module("gptme.tools.subagent.execution")
+        llm_models = importlib.import_module("gptme.llm.models")
+        profiles = importlib.import_module("gptme.profiles")
+        git_worktree = importlib.import_module("gptme.util.git_worktree")
+
+        workspace_dir = tmp_path / "myproject"
+        workspace_dir.mkdir()
+
+        monkeypatch.setattr(cli_main, "get_logdir", lambda name: tmp_path / name)
+        monkeypatch.setattr(llm_models, "get_default_model", lambda: None)
+        monkeypatch.setattr(profiles, "get_profile", lambda _: None)
+
+        # Mock get_git_root to return None → falls back to temp dir
+        monkeypatch.setattr(git_worktree, "get_git_root", lambda _: None)
+
+        exec_calls: list[Path | None] = []
+
+        def capture_thread(**kw):
+            exec_calls.append(kw.get("workspace"))
+
+        monkeypatch.setattr(exec_mod, "_create_subagent_thread", capture_thread)
+        monkeypatch.setattr(exec_mod, "_cleanup_isolation", lambda sa: None)
+
+        from gptme.tools.subagent.api import subagent
+        from gptme.tools.subagent.types import _subagents, _subagents_lock
+
+        subagent("isolated-test", "do something", workdir=workspace_dir, isolated=True)
+
+        with _subagents_lock:
+            sa = next((s for s in _subagents if s.agent_id == "isolated-test"), None)
+        if sa and sa.thread:
+            sa.thread.join(timeout=5)
+
+        with _subagents_lock:
+            _subagents[:] = [s for s in _subagents if s.agent_id != "isolated-test"]
+
+        assert len(exec_calls) == 1
+        # The workspace should NOT be the workdir — it's overridden by isolation
+        assert exec_calls[0] != workspace_dir.resolve()
+        # It should be a temp dir
+        assert "subagent-isolated-test" in str(exec_calls[0])

--- a/tests/test_tools_shell.py
+++ b/tests/test_tools_shell.py
@@ -1884,6 +1884,27 @@ def test_check_workspace_config_hints_only_once_per_workspace(tmp_path):
         _hinted_workspaces.discard(str(tmp_path.resolve()))
 
 
+def test_check_workspace_config_hint_includes_workdir_param(tmp_path):
+    """The workspace hint snippet includes workdir= so the subagent uses the right path."""
+    from gptme.tools.shell import _check_workspace_config, _hinted_workspaces
+
+    (tmp_path / "gptme.toml").write_text("[gptme]\n")
+
+    original_cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        _hinted_workspaces.discard(str(tmp_path.resolve()))
+
+        result = _check_workspace_config()
+        assert result is not None
+        # The hint should include workdir= so the spawned subagent inherits the workspace
+        assert "workdir=" in result.content
+        assert str(tmp_path) in result.content
+    finally:
+        os.chdir(original_cwd)
+        _hinted_workspaces.discard(str(tmp_path.resolve()))
+
+
 def test_shell_bare_cd_updates_working_directory(tmp_path):
     """A bare ``cd`` should update cwd to HOME, not leave stale state behind."""
     original_cwd = os.getcwd()


### PR DESCRIPTION
## Summary

Adds a `workdir` parameter to `subagent()` so callers can explicitly specify
the working directory for a subagent, rather than always inheriting `Path.cwd()`
at spawn time.

This directly addresses the workspace-detection use case from #554: the shell
tool already detects `gptme.toml` after a `cd` and hints at spawning a
subagent, but the hint previously omitted the workspace path. If the parent
agent later `cd`s to a different directory before the thread spawns, the
subagent would run in the wrong workspace.

### Changes

- **`subagent()` API**: new `workdir: str | Path | None = None` parameter.
  Resolved to an absolute path at call time and validated to exist before
  spawning. Applies to both thread-mode and subprocess-mode subagents.
- **`shell._check_workspace_config()`**: workspace hint snippet now includes
  `workdir=<path>` so copy-pasted code is complete and correct.
- **`__init__.py`**: instructions bullet + "Workspace-Aware Subagent" example
  showing the pattern.
- **Tests**: `TestWorkdir` (4 unit tests) covers nonexistent path, `None`→cwd,
  explicit Path, and string→Path resolution. Plus
  `test_check_workspace_config_hint_includes_workdir_param` verifying the
  shell hint contains the path.

### Usage

```python
# After cd'ing into a project with gptme.toml:
subagent("impl", "Add feature X", workdir="/path/to/project", use_subprocess=True)

# String also works:
subagent("impl", "Add feature X", workdir=str(workspace_path))
```

## Test plan

- [x] `TestWorkdir` — 4 unit tests covering: nonexistent workdir raises, `None`
  uses cwd, explicit Path is resolved, string is resolved to Path
- [x] `test_check_workspace_config_hint_includes_workdir_param` — shell hint
  contains `workdir=` and the path string
- [x] All 250 existing subagent + shell tests pass (non-eval)

Closes #554 (partial — this is the workspace ergonomics piece)