### PR TITLE
fix(lessons): always log dropout record when epsilon>0, even if no lessons withheld

### DIFF
--- a/gptme/lessons/auto_include.py
+++ b/gptme/lessons/auto_include.py
@@ -235,10 +235,6 @@ def auto_include_lessons(
 
         matches = matcher.match(index.lessons, context)
 
-        if not matches:
-            logger.debug("No matching lessons found")
-            return messages
-
         # Limit to top N (matcher may already limit, but ensure it)
         matches = matches[:max_lessons]
 
@@ -246,7 +242,7 @@ def auto_include_lessons(
         # No-op unless LESSON_DROPOUT_EPSILON > 0.
         matches = _apply_lesson_dropout(matches)
         if not matches:
-            logger.debug("All matched lessons withheld by dropout")
+            logger.debug("No matching lessons found (or all withheld by dropout)")
             return messages
 
         for match in matches:

--- a/gptme/lessons/auto_include.py
+++ b/gptme/lessons/auto_include.py
@@ -114,7 +114,9 @@ def _apply_lesson_dropout(matches: list) -> list:
     withhold it. Withheld lessons are logged to
     ``<log dir>/<session-id>.jsonl`` and removed from the returned list so they
     are not injected. When epsilon is 0 (default), the input list is returned
-    unchanged and nothing is logged.
+    unchanged and nothing is logged. When epsilon is > 0, a log record is
+    always written (even if no lessons were withheld), so analysis can
+    distinguish treatment-group sessions from control.
 
     Args:
         matches: Match results (already truncated to the injection cap).
@@ -123,7 +125,7 @@ def _apply_lesson_dropout(matches: list) -> list:
         The matches that survived the dropout roll (to be injected).
     """
     epsilon = _get_dropout_epsilon()
-    if epsilon <= 0.0 or not matches:
+    if epsilon <= 0.0:
         return matches
 
     kept: list = []
@@ -135,8 +137,7 @@ def _apply_lesson_dropout(matches: list) -> list:
         else:
             kept.append(match)
 
-    if withheld:
-        _log_dropout(epsilon, withheld)
+    _log_dropout(epsilon, withheld)
 
     return kept
 

--- a/tests/test_lessons_auto_include.py
+++ b/tests/test_lessons_auto_include.py
@@ -351,3 +351,41 @@ def test_dropout_partial_is_consistent(monkeypatch, tmp_path):
 def test_dropout_log_dir_default(monkeypatch):
     monkeypatch.delenv("LESSON_DROPOUT_LOG_DIR", raising=False)
     assert _get_dropout_log_dir() == Path("state/lesson-dropout")
+
+
+def test_dropout_empty_matches_still_logs_when_epsilon_positive(monkeypatch, tmp_path):
+    """When epsilon>0 and no lessons match, a dropout log record must still be written
+    so the analysis script can identify treatment-group sessions."""
+    log_dir = tmp_path / "drop"
+    monkeypatch.setenv("LESSON_DROPOUT_EPSILON", "0.25")
+    monkeypatch.setenv("LESSON_DROPOUT_LOG_DIR", str(log_dir))
+    monkeypatch.setenv("GPTME_SESSION_ID", "sess-empty")
+    monkeypatch.delenv("CC_SESSION_ID", raising=False)
+
+    # Make the matcher return no matches
+    import gptme.lessons.matcher as matcher_module
+
+    def empty_match(self, index, context):
+        return []
+
+    monkeypatch.setattr(matcher_module.LessonMatcher, "match", empty_match)
+
+    messages = [
+        Message("system", "System prompt"),
+        Message("user", "Something that won't match any lesson"),
+    ]
+    result = auto_include_lessons(messages)
+
+    # No lessons should be injected
+    assert len(result) == 2  # unchanged
+
+    # But a dropout log record MUST exist
+    log_file = log_dir / "sess-empty.jsonl"
+    assert log_file.exists(), (
+        "No dropout log written when epsilon>0 and match list is empty"
+    )
+    records = [json.loads(line) for line in log_file.read_text().splitlines() if line]
+    assert len(records) == 1
+    assert records[0]["session_id"] == "sess-empty"
+    assert records[0]["epsilon"] == 0.25
+    assert records[0]["withheld"] == []  # empty withheld list

--- a/tests/test_lessons_auto_include.py
+++ b/tests/test_lessons_auto_include.py
@@ -362,13 +362,33 @@ def test_dropout_empty_matches_still_logs_when_epsilon_positive(monkeypatch, tmp
     monkeypatch.setenv("GPTME_SESSION_ID", "sess-empty")
     monkeypatch.delenv("CC_SESSION_ID", raising=False)
 
+    # Ensure LessonIndex returns at least one lesson so the early-return guard
+    # at "if not index.lessons" does not fire before _apply_lesson_dropout.
+    import gptme.lessons.index as index_module
+
+    class FakeLesson:
+        path = "test.md"
+        title = "Test Lesson"
+        category = "test"
+        body = "Some content"
+        is_stub = False
+        match_strength = 1
+
+    class FakeIndex:
+        lessons = [FakeLesson()]
+        def materialize_lesson(self, _lesson):
+            return _lesson
+
+    monkeypatch.setattr(index_module, "LessonIndex", lambda: FakeIndex())
+
     # Make the matcher return no matches
     import gptme.lessons.matcher as matcher_module
 
-    def empty_match(self, index, context):
-        return []
-
-    monkeypatch.setattr(matcher_module.LessonMatcher, "match", empty_match)
+    monkeypatch.setattr(
+        matcher_module.LessonMatcher,
+        "match",
+        lambda self, index, context: [],
+    )
 
     messages = [
         Message("system", "System prompt"),

--- a/tests/test_lessons_auto_include.py
+++ b/tests/test_lessons_auto_include.py
@@ -364,7 +364,7 @@ def test_dropout_empty_matches_still_logs_when_epsilon_positive(monkeypatch, tmp
 
     # Ensure LessonIndex returns at least one lesson so the early-return guard
     # at "if not index.lessons" does not fire before _apply_lesson_dropout.
-    import gptme.lessons.index as index_module
+    import gptme.lessons.auto_include as auto_include_module
 
     class FakeLesson:
         path = "test.md"
@@ -376,10 +376,13 @@ def test_dropout_empty_matches_still_logs_when_epsilon_positive(monkeypatch, tmp
 
     class FakeIndex:
         lessons = [FakeLesson()]
+
         def materialize_lesson(self, _lesson):
             return _lesson
 
-    monkeypatch.setattr(index_module, "LessonIndex", lambda: FakeIndex())
+    # Patch at point of use: auto_include does "from .index import LessonIndex"
+    # so we must patch auto_include.LessonIndex, not index.LessonIndex.
+    monkeypatch.setattr(auto_include_module, "LessonIndex", lambda: FakeIndex())
 
     # Make the matcher return no matches
     import gptme.lessons.matcher as matcher_module


### PR DESCRIPTION
## Problem

`_apply_lesson_dropout` called `_log_dropout` only `if withheld:` — meaning epsilon>0 sessions where ALL lessons survived the dropout roll wrote NO log record. This made them indistinguishable from epsilon=0 (control) sessions in `lesson-loo-analysis.py`s `load_randomized_dropout_pairs`, breaking the causal attribution analysis.

## Fix

Two changes, both in `_apply_lesson_dropout`:

1. **Remove `or not matches` from the early-return guard** (line 126) — the function now only short-circuits when `epsilon <= 0.0`. With epsilon>0, even an empty match list should produce a log record so the analysis script can identify the treatment group.
2. **Remove `if withheld:` guard** before `_log_dropout` (line 138) — always call the logger when epsilon>0, writing `withheld: []` when no lessons were randomly dropped.

The `_get_dropout_epsilon()` helper already coerces epsilon ≤ 0 to 0.0, so the `if epsilon <= 0.0` guard handles the noop case correctly.

## Verification

- `pytest tests/test_lessons_auto_include.py` → 16/16 pass
- Pre-commit (ruff, mypy) → clean

## Related

- Original gptme implementation: #2988
- CC hook mirror (already has the always-log fix): gptme/gptme-contrib#1162
- Erik request: https://github.com/gptme/gptme-contrib/pull/1162#issuecomment-4789870564