### PR TITLE
fix(webui): fix fork_command placeholder in Create Agent dialog

### DIFF
--- a/webui/src/components/CreateAgentDialog.tsx
+++ b/webui/src/components/CreateAgentDialog.tsx
@@ -12,15 +12,7 @@ import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
-import {
-  Bot,
-  GitBranch,
-  FolderOpen,
-  Settings,
-  ChevronDown,
-  ChevronRight,
-  User,
-} from 'lucide-react';
+import { Bot, GitBranch, FolderOpen, Settings, ChevronDown, ChevronRight } from 'lucide-react';
 import { useForm } from 'react-hook-form';
 import {
   Form,
@@ -45,9 +37,6 @@ export interface CreateAgentRequest {
   path?: string; // Now optional - auto-generated if not provided
   fork_command: string;
   project_config?: Record<string, unknown>;
-  // Persona fields (flattened for form use; serialized into project_config on submit)
-  about_agent?: string;
-  response_preference?: string;
 }
 
 export interface CreateAgentResponse {
@@ -76,8 +65,6 @@ const CreateAgentDialog: FC<Props> = ({ open, onOpenChange, onAgentCreated }) =>
       template_repo: 'https://github.com/gptme/gptme-agent-template',
       template_branch: 'master',
       fork_command: '',
-      about_agent: '',
-      response_preference: '',
     },
   });
 
@@ -94,22 +81,6 @@ const CreateAgentDialog: FC<Props> = ({ open, onOpenChange, onAgentCreated }) =>
     if (!processedData.fork_command.trim()) {
       processedData.fork_command = `./scripts/fork.sh {path} {name}`;
     }
-
-    // Serialize persona fields into project_config.prompt
-    if (processedData.about_agent?.trim() || processedData.response_preference?.trim()) {
-      processedData.project_config = {
-        ...processedData.project_config,
-        prompt: {
-          ...(processedData.project_config?.prompt as Record<string, unknown> | undefined),
-          ...(processedData.about_agent?.trim() && { about_user: processedData.about_agent }),
-          ...(processedData.response_preference?.trim() && {
-            response_preference: processedData.response_preference,
-          }),
-        },
-      };
-    }
-    delete processedData.about_agent;
-    delete processedData.response_preference;
 
     setIsLoading(true);
     try {
@@ -191,66 +162,6 @@ const CreateAgentDialog: FC<Props> = ({ open, onOpenChange, onAgentCreated }) =>
                 </FormItem>
               )}
             />
-
-            {/* Persona */}
-            <Card>
-              <CardHeader>
-                <CardTitle className="flex items-center gap-2">
-                  <User className="h-4 w-4" />
-                  Persona (Optional)
-                </CardTitle>
-                <CardDescription>
-                  Describe who this agent is and how it communicates. Leave blank to use the
-                  template defaults or the persona already defined in the workspace repo.
-                </CardDescription>
-              </CardHeader>
-              <CardContent className="space-y-4">
-                <FormField
-                  control={form.control}
-                  name="about_agent"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>About the Agent</FormLabel>
-                      <FormControl>
-                        <Textarea
-                          placeholder="e.g. Alice is a software engineer who specialises in backend systems..."
-                          {...field}
-                          disabled={isLoading}
-                          rows={3}
-                        />
-                      </FormControl>
-                      <FormDescription>
-                        Who is this agent? This is injected into the system prompt as{' '}
-                        <code>about_user</code>.
-                      </FormDescription>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                <FormField
-                  control={form.control}
-                  name="response_preference"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Response Preference</FormLabel>
-                      <FormControl>
-                        <Textarea
-                          placeholder="e.g. Be concise. Prefer code over prose. Use British English."
-                          {...field}
-                          disabled={isLoading}
-                          rows={2}
-                        />
-                      </FormControl>
-                      <FormDescription>
-                        How should the agent communicate? Injected as{' '}
-                        <code>response_preference</code>.
-                      </FormDescription>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-              </CardContent>
-            </Card>
 
             {/* Advanced Options */}
             <Collapsible open={showAdvanced} onOpenChange={setShowAdvanced}>

--- a/webui/src/components/CreateAgentDialog.tsx
+++ b/webui/src/components/CreateAgentDialog.tsx
@@ -12,7 +12,15 @@ import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
-import { Bot, GitBranch, FolderOpen, Settings, ChevronDown, ChevronRight } from 'lucide-react';
+import {
+  Bot,
+  GitBranch,
+  FolderOpen,
+  Settings,
+  ChevronDown,
+  ChevronRight,
+  User,
+} from 'lucide-react';
 import { useForm } from 'react-hook-form';
 import {
   Form,
@@ -37,6 +45,9 @@ export interface CreateAgentRequest {
   path?: string; // Now optional - auto-generated if not provided
   fork_command: string;
   project_config?: Record<string, unknown>;
+  // Persona fields (flattened for form use; serialized into project_config on submit)
+  about_agent?: string;
+  response_preference?: string;
 }
 
 export interface CreateAgentResponse {
@@ -73,11 +84,30 @@ const CreateAgentDialog: FC<Props> = ({ open, onOpenChange, onAgentCreated }) =>
       return;
     }
 
-    // Generate fork_command if not explicitly set
+    // Generate fork_command if not explicitly set.
+    // Use {path} and {name} as server-side format placeholders — the server
+    // substitutes these with the actual (possibly auto-generated) values via
+    // fork_command.format(path=..., name=...) before running the command.
     const processedData = { ...data };
     if (!processedData.fork_command.trim()) {
-      processedData.fork_command = `./scripts/fork.sh ${processedData.path} ${processedData.name}`;
+      processedData.fork_command = `./scripts/fork.sh {path} {name}`;
     }
+
+    // Serialize persona fields into project_config.prompt
+    if (processedData.about_agent?.trim() || processedData.response_preference?.trim()) {
+      processedData.project_config = {
+        ...processedData.project_config,
+        prompt: {
+          ...(processedData.project_config?.prompt as Record<string, unknown> | undefined),
+          ...(processedData.about_agent?.trim() && { about_user: processedData.about_agent }),
+          ...(processedData.response_preference?.trim() && {
+            response_preference: processedData.response_preference,
+          }),
+        },
+      };
+    }
+    delete processedData.about_agent;
+    delete processedData.response_preference;
 
     setIsLoading(true);
     try {
@@ -159,6 +189,66 @@ const CreateAgentDialog: FC<Props> = ({ open, onOpenChange, onAgentCreated }) =>
                 </FormItem>
               )}
             />
+
+            {/* Persona */}
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                  <User className="h-4 w-4" />
+                  Persona (Optional)
+                </CardTitle>
+                <CardDescription>
+                  Describe who this agent is and how it communicates. Leave blank to use the
+                  template defaults or the persona already defined in the workspace repo.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <FormField
+                  control={form.control}
+                  name="about_agent"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>About the Agent</FormLabel>
+                      <FormControl>
+                        <Textarea
+                          placeholder="e.g. Alice is a software engineer who specialises in backend systems..."
+                          {...field}
+                          disabled={isLoading}
+                          rows={3}
+                        />
+                      </FormControl>
+                      <FormDescription>
+                        Who is this agent? This is injected into the system prompt as{' '}
+                        <code>about_user</code>.
+                      </FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="response_preference"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Response Preference</FormLabel>
+                      <FormControl>
+                        <Textarea
+                          placeholder="e.g. Be concise. Prefer code over prose. Use British English."
+                          {...field}
+                          disabled={isLoading}
+                          rows={2}
+                        />
+                      </FormControl>
+                      <FormDescription>
+                        How should the agent communicate? Injected as{' '}
+                        <code>response_preference</code>.
+                      </FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </CardContent>
+            </Card>
 
             {/* Advanced Options */}
             <Collapsible open={showAdvanced} onOpenChange={setShowAdvanced}>

--- a/webui/src/components/CreateAgentDialog.tsx
+++ b/webui/src/components/CreateAgentDialog.tsx
@@ -76,6 +76,8 @@ const CreateAgentDialog: FC<Props> = ({ open, onOpenChange, onAgentCreated }) =>
       template_repo: 'https://github.com/gptme/gptme-agent-template',
       template_branch: 'master',
       fork_command: '',
+      about_agent: '',
+      response_preference: '',
     },
   });
 
@@ -375,7 +377,7 @@ const CreateAgentDialog: FC<Props> = ({ open, onOpenChange, onAgentCreated }) =>
                           <FormLabel>Fork Command</FormLabel>
                           <FormControl>
                             <Textarea
-                              placeholder="./scripts/fork.sh <workspace-path> <agent-name>"
+                              placeholder="./scripts/fork.sh {path} {name}"
                               {...field}
                               disabled={isLoading}
                               rows={3}


### PR DESCRIPTION
## Summary

Fixes a bug where the auto-generated `fork_command` in the Create Agent dialog used JavaScript template literals instead of Python format placeholders. This caused agent creation to fail when no explicit path was specified.

## Root cause

`fork.sh` from `gptme-agent-template` takes `TARGET_DIR` as `$1`. With the old code:
```ts
processedData.fork_command = `./scripts/fork.sh ${processedData.path} ${processedData.name}`;
```
When `path` is empty (auto-generated server-side), this sent `./scripts/fork.sh  Bob` — an empty first argument. The server calls `fork_command.format(path=resolved_path, name=name)` to substitute the actual values, but since the template had no `{path}` tokens, the resolved path never got injected and `fork.sh` received an empty `TARGET_DIR`.

**Fix**: use Python format placeholders instead:
```ts
processedData.fork_command = `./scripts/fork.sh {path} {name}`;
```
The server substitutes these with the actual (possibly auto-generated) values before running the command.

## What this enables

With this fix, the Create Agent flow works correctly in gptme-cloud instances:

1. User navigates to `/agents` in the instance webui
2. Clicks "Create Agent" → enters agent name (e.g. "Bob")
3. The fork_command resolves correctly to `./scripts/fork.sh /workspace/bob bob`
4. `gptme-agent-template` is cloned, `fork.sh` runs, creating the agent workspace
5. `tasks/initial-agent-setup.md` is activated — on first conversation, the agent establishes its identity through the initial setup interview

Agent identity is established through this first conversation (via the task system), not through form fields. This is the correct approach per the architecture discussion in gptme/gptme-cloud#76.

## Test plan

- [x] Create agent with no path specified: fork_command resolves to `./scripts/fork.sh <auto-path> <name>`
- [x] Create agent with explicit path: fork_command resolves to `./scripts/fork.sh <explicit-path> <name>`
- [x] Custom fork_command left as-is (no auto-generation)
- [x] TypeScript: `npx tsc --noEmit` passes
- [x] ESLint: `npx eslint src/components/CreateAgentDialog.tsx` passes

Relates to gptme/gptme-cloud#76 (Run Bob in prod)