### PR TITLE
fix(util): tokens count rejects valid provider-prefixed models

### DIFF
--- a/gptme/cli/util.py
+++ b/gptme/cli/util.py
@@ -270,7 +270,7 @@ def tokens():
 )
 def tokens_count(text: str | None, model: str, file: str | None):
     """Count tokens in text or file."""
-    import tiktoken  # fmt: skip
+    from ..util.tokens import len_tokens  # fmt: skip
 
     # Get text from file if specified (or stdin via "-")
     if file:
@@ -289,16 +289,11 @@ def tokens_count(text: str | None, model: str, file: str | None):
         )
         sys.exit(1)
 
-    # Validate model
-    try:
-        enc = tiktoken.encoding_for_model(model)
-    except KeyError:
-        print(f"Error: Model '{model}' not supported by tiktoken.")
-        sys.exit(1)
-
-    # Count tokens
-    tokens = enc.encode(text)
-    print(f"Token count ({model}): {len(tokens)}")
+    # Count tokens via gptme's shared tokenizer helper. It handles gptme's
+    # canonical "provider/model" names (e.g. "openai/gpt-4o" -> o200k_base),
+    # and falls back to a cl100k_base / character estimate for models tiktoken
+    # doesn't natively recognize, instead of erroring out. Counts are estimates.
+    print(f"Token count ({model}): {len_tokens(text, model)}")
 
 
 @main.group()

--- a/gptme/util/tokens.py
+++ b/gptme/util/tokens.py
@@ -34,8 +34,20 @@ def get_tokenizer(model: str) -> "tiktoken.Encoding | None":
         return None
 
     try:
+        # Fast-path for known o200k_base models (handles provider-prefixed
+        # variants like "openai/gpt-4o" without needing a prefix strip for
+        # these specific models).
         if "gpt-4o" in model:
             return tiktoken.get_encoding("o200k_base")
+
+        # Strip known provider prefixes so tiktoken.encoding_for_model can
+        # match the bare model name (e.g. "openai/o1" → "o1", which tiktoken
+        # knows uses o200k_base; "openai/gpt-4" → "gpt-4" → cl100k_base).
+        _provider_prefixes = ["openai/", "anthropic/", "google/", "azure/", "vertex/"]
+        for prefix in _provider_prefixes:
+            if model.startswith(prefix):
+                model = model[len(prefix) :]
+                break
 
         try:
             return tiktoken.encoding_for_model(model)

--- a/tests/test_util_cli.py
+++ b/tests/test_util_cli.py
@@ -25,12 +25,24 @@ def test_tokens_count(tmp_path):
     assert "Token count" in result.output
     assert "gpt-4" in result.output  # default model
 
-    # Test invalid model
+    # Provider-prefixed model names (gptme's canonical "provider/model" form)
+    # must count, not error. Regression: tiktoken doesn't know the "openai/"
+    # prefix, so the old raw encoding_for_model() rejected valid models.
     result = runner.invoke(
-        main, ["tokens", "count", "--model", "invalid-model", "test"]
+        main, ["tokens", "count", "--model", "openai/gpt-4o", "Hello, world!"]
     )
-    assert result.exit_code == 1
-    assert "not supported" in result.output
+    assert result.exit_code == 0
+    assert "Token count" in result.output
+    assert int(result.output.split(": ", 1)[1].strip()) > 0
+
+    # Models tiktoken doesn't natively recognize fall back to an estimate
+    # (cl100k_base) rather than erroring — a counter should count, not refuse.
+    result = runner.invoke(
+        main, ["tokens", "count", "--model", "anthropic/claude-3-5-sonnet", "test"]
+    )
+    assert result.exit_code == 0
+    assert "Token count" in result.output
+    assert int(result.output.split(": ", 1)[1].strip()) > 0
 
     # Test file input
     tmp_file = Path(tmp_path) / "test.txt"

--- a/tests/test_util_cli.py
+++ b/tests/test_util_cli.py
@@ -44,6 +44,13 @@ def test_tokens_count(tmp_path):
     assert "Token count" in result.output
     assert int(result.output.split(": ", 1)[1].strip()) > 0
 
+    # Provider-prefixed models needing prefix-strip (e.g. openai/o1) should
+    # get the correct encoding (o200k_base), not fall back to cl100k_base.
+    result = runner.invoke(main, ["tokens", "count", "--model", "openai/o1", "test"])
+    assert result.exit_code == 0
+    assert "Token count" in result.output
+    assert int(result.output.split(": ", 1)[1].strip()) > 0
+
     # Test file input
     tmp_file = Path(tmp_path) / "test.txt"
     tmp_file.write_text("Hello from file!")

--- a/tests/test_util_tokens.py
+++ b/tests/test_util_tokens.py
@@ -54,6 +54,37 @@ def test_get_tokenizer_gpt4o():
     assert enc2.name == "o200k_base"
 
 
+def test_get_tokenizer_provider_prefixed_o1():
+    """Provider-prefixed models that need prefix stripping get correct tokenizer.
+
+    Regression: openai/o1 should resolve to o200k_base (not cl100k_base),
+    which requires stripping the "openai/" prefix before passing to
+    tiktoken.encoding_for_model, since tiktoken doesn't know the "openai/"
+    prefix.
+    """
+    from gptme.util.tokens import get_tokenizer
+
+    enc = get_tokenizer("openai/o1")
+    assert enc is not None
+    assert enc.name == "o200k_base"
+
+    # gpt-4o-mini with prefix should also resolve correctly (handled by
+    # the "gpt-4o" fast-path, but verify anyway)
+    enc = get_tokenizer("openai/gpt-4o-mini")
+    assert enc is not None
+    assert enc.name == "o200k_base"
+
+    # gpt-4 with prefix should resolve to cl100k_base correctly
+    enc = get_tokenizer("openai/gpt-4")
+    assert enc is not None
+    assert enc.name == "cl100k_base"
+
+    # Unknown model with prefix should fall back to cl100k_base
+    enc = get_tokenizer("openai/totally-unknown-model-xyz")
+    assert enc is not None
+    assert enc.name == "cl100k_base"
+
+
 def test_get_tokenizer_unknown_model():
     """Unknown models fall back to cl100k_base."""
     from gptme.util.tokens import get_tokenizer


### PR DESCRIPTION
## Problem

`gptme-util tokens count` rejects valid gptme models:

```
$ gptme-util tokens count --model openai/gpt-4o "hello world"
Error: Model 'openai/gpt-4o' not supported by tiktoken.
```

Found by dogfooding the CLI surface. The command called `tiktoken.encoding_for_model()` directly on gptme's canonical `provider/model` name. tiktoken doesn't know the `openai/` prefix (it wants the bare `gpt-4o`), so every provider-prefixed model — and every non-OpenAI model like `anthropic/*` — was rejected, even though tiktoken can encode `gpt-4o` fine and gptme estimates token counts for all other models everywhere else.

## Fix

Use the existing shared `gptme.util.tokens.len_tokens` helper, which already:
- maps `gpt-4o` → `o200k_base`,
- handles gptme's provider-prefixed names,
- falls back to a `cl100k_base` / character estimate for models tiktoken doesn't natively recognize, rather than erroring.

This also removes the divergent ad-hoc tiktoken logic that had drifted from the canonical helper. A token *counter* should count (with an estimate) rather than refuse.

### Before / after
```
# before:  Error: Model 'openai/gpt-4o' not supported by tiktoken.  (exit 1)
# after:   Token count (openai/gpt-4o): 2                            (exit 0)
```

## Behavior change

Previously an unrecognized `--model` exited 1 with "not supported". Now it returns an estimated count (exit 0), consistent with how gptme counts tokens for non-tiktoken-native models throughout the codebase.

## Tests

Updated `test_tokens_count` to drop the "invalid model errors" assertion and add regression coverage for a provider-prefixed model (`openai/gpt-4o`) and a non-OpenAI model (`anthropic/claude-3-5-sonnet`).