### PR TITLE
docs: add app.nz as a custom OpenAI-compatible provider example

### DIFF
--- a/docs/custom-providers.md
+++ b/docs/custom-providers.md
@@ -152,6 +152,29 @@ export AZURE_API_KEY="..."
 gptme --model azure-gpt4 "Write a Python function to sort a list"
 ```
 
+### app.nz
+
+[app.nz](https://app.nz/) is an OpenAI-compatible LLM gateway that routes to many
+models through a single API key. Use `app/auto` for the auto-router, one of the
+task-tuned aliases (`app/auto-code`, `app/auto-reasoning`, `app/auto-fast`,
+`app/auto-cheap`, `app/auto-vision`), or an explicit `provider/model`.
+
+```toml
+[[providers]]
+name = "appnz"
+base_url = "https://app.nz/v1"
+api_key_env = "APPNZ_API_KEY"
+default_model = "app/auto"
+```
+
+```bash
+export APPNZ_API_KEY="app_live_..."
+gptme --model appnz "Explain quantum computing"
+gptme --model appnz/app/auto-code "Write a Python function to sort a list"
+```
+
+See https://app.nz/docs for details.
+
 ## Related
 
 - [Issue #673](https://github.com/gptme/gptme/issues/673) - Original feature request

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -182,6 +182,31 @@ falsy values.
 
 Get an API key at https://app.requesty.ai/api-keys. See https://docs.requesty.ai for details.
 
+.. rubric:: app.nz
+
+`app.nz <https://app.nz/>`_ is an OpenAI-compatible (and Anthropic-compatible) LLM gateway that routes to many models through a single API key. Use the auto-router ``app/auto``, a task-tuned alias (``app/auto-code``, ``app/auto-reasoning``, ``app/auto-fast``, ``app/auto-cheap``, ``app/auto-vision``), or an explicit ``provider/model``. It is reached through the standard OpenAI-compatible client path via the :doc:`custom providers <custom-providers>` config.
+
+**Configuration:**
+
+.. code-block:: toml
+
+    # In gptme.toml or ~/.config/gptme/config.toml
+    [[providers]]
+    name = "appnz"
+    base_url = "https://app.nz/v1"
+    api_key_env = "APPNZ_API_KEY"
+    default_model = "app/auto"
+
+**Usage:**
+
+.. code-block:: sh
+
+    export APPNZ_API_KEY="app_live_..."
+    gptme "hello" -m appnz                  # uses default model (app/auto)
+    gptme "hello" -m appnz/app/auto-code
+
+Get an API key and find the model list at https://app.nz/. See https://app.nz/docs for details.
+
 .. rubric:: OpenAI Subscription
 
 You can use your existing ChatGPT Plus/Pro subscription with gptme. This uses the ChatGPT backend API (Codex endpoint) instead of the OpenAI Platform API, allowing you to leverage your subscription for development.


### PR DESCRIPTION
## What

Documents [app.nz](https://app.nz/) — an OpenAI-compatible (and Anthropic-compatible) LLM gateway — as a custom provider in gptme.

- `docs/custom-providers.md`: new app.nz example (TOML `[[providers]]` + CLI usage), mirroring the existing Groq/Azure blocks.
- `docs/providers.rst`: new `app.nz` rubric after Requesty, mirroring that section's Configuration/Usage layout.

Uses `base_url = "https://app.nz/v1"`, `APPNZ_API_KEY`, and `app/auto` (auto-router), noting the variants `app/auto-code|reasoning|fast|cheap|vision`.

## Why

app.nz works with gptme today via the existing custom-providers config — no code change required. This makes it discoverable. Docs-only, low-risk.

## Testing

Docs-only; no code paths changed.
