### PR TITLE
fix(server): only reject message-delete that creates a NEW role adjacency

### DIFF
--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -1916,18 +1916,24 @@ def api_conversation_delete_message(conversation_id: str, index: int):
 
     new_msgs = msgs[:index] + msgs[index + 1 :]
 
-    # Validate role sequence: consecutive same-role messages break LLM APIs
-    non_system = [m for m in new_msgs if m.role != "system"]
-    for i in range(1, len(non_system)):
-        if non_system[i].role == non_system[i - 1].role:
-            return (
-                flask.jsonify(
-                    {
-                        "error": f"Deleting this message would create consecutive {non_system[i].role!r} messages, which is not supported by LLM APIs"
-                    }
-                ),
-                400,
-            )
+    # Validate role sequence: consecutive same-role messages break LLM APIs.
+    # Deleting a (non-system) message can only introduce a NEW adjacency at the
+    # seam — between its nearest non-system neighbours on either side. Check only
+    # that seam; scanning the whole conversation would reject valid deletions
+    # whenever an unrelated pre-existing adjacency exists elsewhere in the log.
+    prev_role = next(
+        (m.role for m in reversed(msgs[:index]) if m.role != "system"), None
+    )
+    next_role = next((m.role for m in msgs[index + 1 :] if m.role != "system"), None)
+    if prev_role is not None and prev_role == next_role:
+        return (
+            flask.jsonify(
+                {
+                    "error": f"Deleting this message would create consecutive {next_role!r} messages, which is not supported by LLM APIs"
+                }
+            ),
+            400,
+        )
 
     manager.edit(Log(new_msgs))
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1509,3 +1509,65 @@ def test_api_v2_delete_message_success(conv_with_messages, client: FlaskClient):
     assert not any(
         m["role"] == "user" and m["content"] == "hello world" for m in final_log
     )
+
+
+def test_api_v2_delete_message_preexisting_adjacency(client: FlaskClient):
+    """Deleting a message must not fail just because the conversation already
+    contains a consecutive same-role pair elsewhere.
+
+    Regression: the role-sequence guard used to scan the whole conversation, so
+    any pre-existing adjacency made *every* delete return 400 with a misleading
+    "Deleting this message would create consecutive..." error. The guard should
+    only reject deletions that create a NEW adjacency at the deletion seam.
+    """
+    convname = f"test-delete-adj-{random.randint(0, 1000000)}"
+    response = client.put(
+        f"/api/v2/conversations/{convname}",
+        json={
+            "messages": [
+                {"role": "system", "content": "you are a test assistant"},
+                {"role": "user", "content": "first"},
+                {"role": "assistant", "content": "reply A"},
+                {"role": "assistant", "content": "reply B"},  # pre-existing pair
+                {"role": "user", "content": "second"},
+            ]
+        },
+    )
+    assert response.status_code == 200
+
+    # Deleting the trailing user message does not create a new adjacency (its
+    # only non-system neighbour is an assistant), so it must succeed despite the
+    # unrelated assistant/assistant pair earlier in the log.
+    r = client.get(f"/api/v2/conversations/{convname}")
+    log = r.get_json().get("log", [])
+    idx = next(
+        i for i, m in enumerate(log) if m["role"] == "user" and m["content"] == "second"
+    )
+    response = client.delete(f"/api/v2/conversations/{convname}/messages/{idx}")
+    assert response.status_code == 200, response.get_json()
+
+
+def test_api_v2_delete_message_creates_adjacency_rejected(client: FlaskClient):
+    """Deletions that DO create a new consecutive same-role pair are still rejected."""
+    convname = f"test-delete-adj2-{random.randint(0, 1000000)}"
+    response = client.put(
+        f"/api/v2/conversations/{convname}",
+        json={
+            "messages": [
+                {"role": "system", "content": "you are a test assistant"},
+                {"role": "user", "content": "first"},
+                {"role": "assistant", "content": "reply"},
+                {"role": "user", "content": "second"},
+            ]
+        },
+    )
+    assert response.status_code == 200
+
+    # Deleting the assistant message would join the two user messages -> 400.
+    r = client.get(f"/api/v2/conversations/{convname}")
+    log = r.get_json().get("log", [])
+    idx = next(i for i, m in enumerate(log) if m["role"] == "assistant")
+    response = client.delete(f"/api/v2/conversations/{convname}/messages/{idx}")
+    assert response.status_code == 400
+    data = response.get_json()
+    assert data is not None and "consecutive" in data["error"]

--- a/tests/test_tools_subagent.py
+++ b/tests/test_tools_subagent.py
@@ -1938,6 +1938,7 @@ def test_role_explore_does_not_set_use_subprocess(mock_create_thread: MagicMock)
     )
 
     assert len(_subagents) == initial_count + 1
+    _wait_for_new_subagent_threads(initial_count)
     sa = _subagents[-1]
     assert sa.execution_mode == "thread"
     assert sa.isolated is False
@@ -1955,6 +1956,7 @@ def test_role_implement_does_not_set_use_subprocess(mock_create_thread: MagicMoc
     )
 
     assert len(_subagents) == initial_count + 1
+    _wait_for_new_subagent_threads(initial_count)
     sa = _subagents[-1]
     assert sa.execution_mode == "thread"
     assert sa.isolated is False
@@ -1973,6 +1975,7 @@ def test_role_verify_subprocess_has_verifier_profile(
         role="verify",
     )
 
+    _wait_for_new_subagent_threads(0)
     sa = _subagents[-1]
 
     # The Subagent should capture isolate=True


### PR DESCRIPTION
## Problem

`DELETE /api/v2/conversations/<id>/messages/<index>` guards against creating consecutive same-role messages (which break LLM APIs). But it validated by scanning the **entire** resulting conversation:

```python
non_system = [m for m in new_msgs if m.role != "system"]
for i in range(1, len(non_system)):
    if non_system[i].role == non_system[i - 1].role:
        return 400 ...
```

So a conversation that **already** contained a consecutive non-system pair (two assistant messages from a branch/import/edited history) made *every* delete return 400 with a misleading `Deleting this message would create consecutive ...` error — even when the deletion introduced no new adjacency. Wrong-but-200-class behavioral bug surfaced via API dogfooding.

## Fix

Deleting a (non-system) message can only introduce a new adjacency at the **seam** between its nearest non-system neighbours on either side. Check only that seam instead of the whole log.

## Tests

- `test_api_v2_delete_message_preexisting_adjacency` — delete unrelated message in a log with a pre-existing assistant/assistant pair now returns 200 (was 400).
- `test_api_v2_delete_message_creates_adjacency_rejected` — deleting a message that genuinely joins two same-role messages is still rejected (400).

Verified RED→GREEN against the existing test suite (`tests/test_server.py -k delete_message`, 6 passed; `-k 'message or fork or edit'`, 11 passed).