### PR TITLE
fix(webui): avatar alignment + standard-markdown previews

### DIFF
--- a/webui/src/components/ChatMessage.tsx
+++ b/webui/src/components/ChatMessage.tsx
@@ -154,6 +154,8 @@ interface Props {
   onRegenerate?: (index: number) => void;
   onFork?: (index: number) => void;
   messageIndex?: number;
+  /** Suppress the role avatar — used when a CollapsedStepGroup chip immediately precedes this message */
+  hideAvatar?: boolean;
 }
 
 const ChatMessageComponent: FC<Props> = ({
@@ -170,6 +172,7 @@ const ChatMessageComponent: FC<Props> = ({
   onRegenerate,
   onFork,
   messageIndex,
+  hideAvatar,
 }) => {
   const { api, connectionConfig } = useApi();
   const { settings } = useSettings();
@@ -568,20 +571,22 @@ const ChatMessageComponent: FC<Props> = ({
           <div className={`role-${message$.role.get()} ${wrapperClasses$.get()}`}>
             <div className="mx-auto max-w-3xl px-4">
               <div className="relative">
-                <MessageAvatar
-                  role$={message$.role}
-                  isError$={isError$}
-                  isSuccess$={isSuccess$}
-                  chainType$={chainType$}
-                  agentAvatarUrl={agentAvatarUrl}
-                  agentName={agentName}
-                  userAvatarUrl={
-                    api.userInfo$.avatar?.get()
-                      ? `${connectionConfig.baseUrl.replace(/\/+$/, '')}/api/v2/user/avatar`
-                      : undefined
-                  }
-                  userName={api.userInfo$.name?.get()}
-                />
+                {!hideAvatar && (
+                  <MessageAvatar
+                    role$={message$.role}
+                    isError$={isError$}
+                    isSuccess$={isSuccess$}
+                    chainType$={chainType$}
+                    agentAvatarUrl={agentAvatarUrl}
+                    agentName={agentName}
+                    userAvatarUrl={
+                      api.userInfo$.avatar?.get()
+                        ? `${connectionConfig.baseUrl.replace(/\/+$/, '')}/api/v2/user/avatar`
+                        : undefined
+                    }
+                    userName={api.userInfo$.name?.get()}
+                  />
+                )}
                 <div className={contentOffsetClasses$.get()}>
                   <div className={`group/message relative flex flex-col ${messageClasses$.get()}`}>
                     {/* Per-message actions — rendered under the message (order-last),

--- a/webui/src/components/ConversationContent.tsx
+++ b/webui/src/components/ConversationContent.tsx
@@ -729,6 +729,9 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
                   onRegenerate={isReadOnly ? undefined : regenerateMessage}
                   onFork={isReadOnly ? undefined : handleForkMessage}
                   messageIndex={absoluteIndex}
+                  hideAvatar={
+                    stepRole?.type === 'group-start' && expandedGroups$.get().has(stepRole.groupId)
+                  }
                 />
                 {/* Branch indicator at fork points */}
                 <Memo>

--- a/webui/src/components/MessageAvatar.tsx
+++ b/webui/src/components/MessageAvatar.tsx
@@ -53,7 +53,7 @@ export function MessageAvatar({
   const avatarUrl = isUser ? userAvatarUrl : agentAvatarUrl;
   const sideClass = isUser ? 'right-0' : 'left-0';
 
-  const avatarClasses = `absolute flex h-8 w-8 flex-shrink-0 select-none items-center justify-center rounded-full border-2 border-border text-xs font-semibold md:h-10 md:w-10 md:text-sm ${sideClass} ${
+  const avatarClasses = `absolute top-0 flex h-8 w-8 flex-shrink-0 select-none items-center justify-center rounded-full border-2 border-border text-xs font-semibold md:h-10 md:w-10 md:text-sm ${sideClass} ${
     isUser
       ? showCustomAvatar
         ? 'overflow-hidden'

--- a/webui/src/components/TabbedCodeBlock.tsx
+++ b/webui/src/components/TabbedCodeBlock.tsx
@@ -43,8 +43,8 @@ export const TabbedCodeBlock: React.FC<TabbedCodeBlockProps> = ({ language, code
         previewRef.current.innerHTML = '';
         setRenderError(null);
 
-        // Use streaming markdown parser for markdown content
-        const renderer = customRenderer(previewRef.current);
+        // Use streaming markdown parser in standard mode (no chat chrome)
+        const renderer = customRenderer(previewRef.current, false, false, true, true);
         const parser = smd.parser(renderer);
         smd.parser_write(parser, codeText);
         smd.parser_end(parser);

--- a/webui/src/components/workspace/MarkdownPreviewTabs.tsx
+++ b/webui/src/components/workspace/MarkdownPreviewTabs.tsx
@@ -24,8 +24,8 @@ export function MarkdownPreviewTabs({ content, language = 'markdown' }: Markdown
         previewRef.current.innerHTML = '';
         setRenderError(null);
 
-        // Use streaming markdown parser for markdown content
-        const renderer = customRenderer(previewRef.current);
+        // Use streaming markdown parser in standard mode (no chat chrome)
+        const renderer = customRenderer(previewRef.current, false, false, true, true);
         const parser = smd.parser(renderer);
         smd.parser_write(parser, content);
         smd.parser_end(parser);

--- a/webui/src/utils/__tests__/markdownRenderer.test.ts
+++ b/webui/src/utils/__tests__/markdownRenderer.test.ts
@@ -164,3 +164,53 @@ describe('renderMarkdownBlocks', () => {
     expect(div.lastElementChild?.outerHTML).toBe('<p>some other text</p>');
   });
 });
+
+function parseStandard(markdown: string) {
+  const div = document.createElement('div');
+  const renderer = customRenderer(div, false, false, true, true);
+  const parser = smd.parser(renderer);
+  smd.parser_write(parser, markdown);
+  smd.parser_end(parser);
+  return div;
+}
+
+describe('standardMarkdown mode', () => {
+  it('renders plain text without chrome', () => {
+    const div = parseStandard('Hello world');
+    expect(div.innerHTML).toBe('<p>Hello world</p>');
+  });
+
+  it('renders code blocks as plain pre+code without details/summary', () => {
+    const markdown = '```python\nprint("hello")\n```';
+    const div = parseStandard(markdown);
+
+    // No <details> or <summary> wrapper
+    expect(div.querySelector('details')).toBeNull();
+    expect(div.querySelector('summary')).toBeNull();
+
+    // Plain <pre><code> structure
+    const pre = div.querySelector('pre');
+    expect(pre).not.toBeNull();
+    const code = div.querySelector('pre code');
+    expect(code).not.toBeNull();
+    expect(code?.textContent).toContain('print("hello")');
+  });
+
+  it('renders multi-line code blocks without inline-codeblock conversion', () => {
+    // Chat mode converts short blocks (≤2 lines) to inline-codeblock; standard mode should not
+    const markdown = '```sh\necho hello\n```';
+    const div = parseStandard(markdown);
+
+    expect(div.querySelector('.inline-codeblock')).toBeNull();
+    expect(div.querySelector('pre')).not.toBeNull();
+  });
+
+  it('does not collapse tool-use blocks', () => {
+    // In chat mode, 'shell' blocks collapse by default; in standard mode no details exist
+    const markdown = '```shell\nls -la\n```';
+    const div = parseStandard(markdown);
+
+    expect(div.querySelector('details')).toBeNull();
+    expect(div.querySelector('pre')).not.toBeNull();
+  });
+});

--- a/webui/src/utils/markdownRenderer.ts
+++ b/webui/src/utils/markdownRenderer.ts
@@ -89,13 +89,17 @@ export type CustomRenderer = Omit<
  * @param log - Whether to log rendering details (for debugging)
  * @param useReactTabbed - Whether to use React components for code blocks with tabs
  * @param blocksDefaultOpen - Whether code blocks should be open by default
+ * @param standardMarkdown - When true, renders plain code blocks without chat-specific
+ *   chrome (no collapsible details, no tool labels/icons). Use for non-chat contexts
+ *   like workspace file previews and artifact viewers.
  * @returns A CustomRenderer instance
  */
 export function customRenderer(
   root: HTMLElement,
   log: boolean = false,
   useReactTabbed: boolean = false,
-  blocksDefaultOpen: boolean = true
+  blocksDefaultOpen: boolean = true,
+  standardMarkdown: boolean = false
 ): CustomRenderer {
   return {
     add_token: (data: CustomRendererData, type: smd.Token) => {
@@ -108,6 +112,16 @@ export function customRenderer(
       switch (type) {
         case smd.CODE_BLOCK:
         case smd.CODE_FENCE: {
+          if (standardMarkdown) {
+            // Standard mode: plain pre+code, no collapsible details/summary chrome
+            parent = parent.appendChild(document.createElement('pre'));
+            slot = document.createElement('code');
+            data.code = slot;
+            slot.setAttribute('class', 'hljs');
+            data.nodes[++data.index] = parent.appendChild(slot);
+            break;
+          }
+
           parent = parent.appendChild(document.createElement('details'));
           // Default to open (agent code shown to the user). Tool-use/output
           // blocks are collapsed once their langtag is known (see smd.LANG),
@@ -153,40 +167,42 @@ export function customRenderer(
         console.log('end_token');
       }
 
-      if (useReactTabbed && data.placeholder && data.code && data.lang && data.codeText) {
-        const langFromInfo = data.lang ? data.lang.split('.').pop() : undefined;
-        // Only render for markdown and html
-        if (!isMarkdownOrHtml(langFromInfo)) return;
-        try {
-          // Create React root and render the component
-          const reactRoot = createRoot(data.placeholder);
-          reactRoot.render(
-            createElement(TabbedCodeBlock, {
-              language: langFromInfo,
-              codeText: data.codeText,
-              code: data.code!,
-            })
-          );
-        } catch (error) {
-          console.error('Error rendering TabbedCodeBlock:', error);
+      if (!standardMarkdown) {
+        if (useReactTabbed && data.placeholder && data.code && data.lang && data.codeText) {
+          const langFromInfo = data.lang ? data.lang.split('.').pop() : undefined;
+          // Only render for markdown and html
+          if (!isMarkdownOrHtml(langFromInfo)) return;
+          try {
+            // Create React root and render the component
+            const reactRoot = createRoot(data.placeholder);
+            reactRoot.render(
+              createElement(TabbedCodeBlock, {
+                language: langFromInfo,
+                codeText: data.codeText,
+                code: data.code!,
+              })
+            );
+          } catch (error) {
+            console.error('Error rendering TabbedCodeBlock:', error);
+          }
         }
-      }
 
-      // Convert short code blocks (≤2 lines) from <details> to inline display.
-      // Long lines scroll horizontally; the label stays fixed on the left.
-      if (data.code && data.summary) {
-        const codeText = (data.code.textContent || '').replace(/\n$/, '');
-        const lineCount = codeText.split('\n').length;
-        const details = data.summary.parentElement; // the <details> element
+        // Convert short code blocks (≤2 lines) from <details> to inline display.
+        // Long lines scroll horizontally; the label stays fixed on the left.
+        if (data.code && data.summary) {
+          const codeText = (data.code.textContent || '').replace(/\n$/, '');
+          const lineCount = codeText.split('\n').length;
+          const details = data.summary.parentElement; // the <details> element
 
-        if (lineCount <= 2 && codeText.length <= 1000 && details?.tagName === 'DETAILS') {
-          // Replace <details><summary>...<pre><code>... with inline element
-          const inline = document.createElement('div');
-          inline.className = 'inline-codeblock';
-          inline.innerHTML =
-            `<span class="inline-codeblock-label">${data.summary.innerHTML}</span>` +
-            `<code class="${data.code.className}">${data.code.innerHTML}</code>`;
-          details.replaceWith(inline);
+          if (lineCount <= 2 && codeText.length <= 1000 && details?.tagName === 'DETAILS') {
+            // Replace <details><summary>...<pre><code>... with inline element
+            const inline = document.createElement('div');
+            inline.className = 'inline-codeblock';
+            inline.innerHTML =
+              `<span class="inline-codeblock-label">${data.summary.innerHTML}</span>` +
+              `<code class="${data.code.className}">${data.code.innerHTML}</code>`;
+            details.replaceWith(inline);
+          }
         }
       }
 
@@ -232,7 +248,7 @@ export function customRenderer(
       // Set the language in the summary tag
       if (type === smd.LANG) {
         data.lang = value;
-        if (data.summary) {
+        if (!standardMarkdown && data.summary) {
           // Code-block label — CHAT renderer (smd custom renderer, real DOM nodes).
           // This is the path the chat view (/chat/...) actually uses. We build a
           // lucide icon + langtag label as innerHTML (carried over to the inline


### PR DESCRIPTION
Closes #2998.

Two independent fixes from the chat-UI polish follow-up.

## 1. Message avatar alignment

- Add explicit `top-0` to `MessageAvatar` so avatars are top-aligned with the first line of message content (previously implicit, which worked but was ambiguous)
- Add `hideAvatar?: boolean` prop to `ChatMessage` to suppress the avatar when a `CollapsedStepGroup` chip immediately precedes the message — in the expanded n-steps case the chip already acts as a visual separator, and the avatar sitting just below it read as orphaned/misaligned
- `ConversationContent` passes `hideAvatar={true}` for `group-start` messages when their group is expanded

## 2. Standard-markdown mode for non-chat preview bodies

- Add `standardMarkdown: boolean = false` parameter to `customRenderer()` in `markdownRenderer.ts`
- When `true`: code blocks render as plain `<pre><code>` — no collapsible `<details>/<summary>` wrappers, no tool-label icons, no inline-codeblock conversion. Syntax highlighting is preserved.
- Use standard mode in `TabbedCodeBlock` (preview tab for markdown/HTML code blocks in chat) and `workspace/MarkdownPreviewTabs` (workspace `.md` file previews)
- The shared `codeBlockIcons.ts` vocabulary is untouched — icon exports still work in all consumers

## Tests

4 new tests in `markdownRenderer.test.ts` covering the standard-markdown mode:
- plain text still works
- code blocks produce `<pre><code>` without `<details>/<summary>`
- no `inline-codeblock` conversion for short blocks
- tool-use lang tags (e.g. `shell`) don't produce collapsible details

All 501 existing tests continue to pass.