### PR TITLE
fix(computer): add shell+vision to Docker server, Xvfb liveness check in doctor

### DIFF
--- a/gptme/cli/doctor.py
+++ b/gptme/cli/doctor.py
@@ -639,7 +639,7 @@ def _check_computer(verbose: bool = False) -> list[CheckResult]:
                     env = os.environ.copy()
                     env["DISPLAY"] = display
                     subprocess.run(
-                        ["xdpyinfo"],
+                        [xdpyinfo_path],
                         env=env,
                         capture_output=True,
                         check=True,

--- a/gptme/cli/doctor.py
+++ b/gptme/cli/doctor.py
@@ -11,6 +11,7 @@ import importlib.util
 import logging
 import os
 import shutil
+import subprocess
 import sys
 from dataclasses import dataclass
 from enum import Enum
@@ -631,13 +632,48 @@ def _check_computer(verbose: bool = False) -> list[CheckResult]:
         # Check DISPLAY
         display = os.environ.get("DISPLAY")
         if display:
-            results.append(
-                CheckResult(
-                    name="Computer: DISPLAY",
-                    status=CheckStatus.OK,
-                    message=f"X11 display available ({display})",
+            # Verify the X server at DISPLAY is actually reachable
+            xdpyinfo_path = shutil.which("xdpyinfo")
+            if xdpyinfo_path:
+                try:
+                    env = os.environ.copy()
+                    env["DISPLAY"] = display
+                    subprocess.run(
+                        ["xdpyinfo"],
+                        env=env,
+                        capture_output=True,
+                        check=True,
+                        timeout=3,
+                    )
+                    results.append(
+                        CheckResult(
+                            name="Computer: DISPLAY",
+                            status=CheckStatus.OK,
+                            message=f"X11 display reachable ({display})",
+                        )
+                    )
+                except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
+                    results.append(
+                        CheckResult(
+                            name="Computer: DISPLAY",
+                            status=CheckStatus.WARNING,
+                            message=f"DISPLAY={display} is set but X server is not responding",
+                            fix_hint=(
+                                "Start an X server first:\n"
+                                "  Xvfb :1 -screen 0 1024x768x24 &\n"
+                                "  export DISPLAY=:1\n"
+                                "Or use: xvfb-run gptme ..."
+                            ),
+                        )
+                    )
+            else:
+                results.append(
+                    CheckResult(
+                        name="Computer: DISPLAY",
+                        status=CheckStatus.OK,
+                        message=f"X11 display set ({display}) — install xdpyinfo to verify it's reachable",
+                    )
                 )
-            )
         else:
             results.append(
                 CheckResult(

--- a/scripts/computer_home/entrypoint.sh
+++ b/scripts/computer_home/entrypoint.sh
@@ -5,7 +5,7 @@ set -e
 ./novnc_startup.sh
 
 # Start gptme server
-python3 -m gptme.server --host 0.0.0.0 --port 8080 --tools ipython,computer --cors-origin '*'
+python3 -m gptme.server --host 0.0.0.0 --port 8080 --tools ipython,computer,shell,vision --cors-origin '*'
 
 # Keep the container running
 tail -f /dev/null

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -946,3 +946,41 @@ class TestCheckComputer:
 
         xdotool = next(r for r in results if r.name == "Computer: xdotool")
         assert xdotool.details == "/usr/bin/xdotool"
+
+    @patch("sys.platform", "linux")
+    @patch("subprocess.run")
+    @patch("shutil.which")
+    @patch.dict("os.environ", {"DISPLAY": ":1"})
+    def test_display_live_xdpyinfo_ok(self, mock_which, mock_run):
+        """When xdpyinfo confirms the display is live, DISPLAY check is OK."""
+        mock_which.side_effect = lambda t: (
+            f"/usr/bin/{t}" if t in ("xdotool", "scrot", "xdpyinfo") else None
+        )
+        mock_run.return_value = None  # subprocess.run returns CompletedProcess-like; None is fine since we only check=True
+
+        results = _check_computer()
+
+        names = {r.name: r for r in results}
+        assert names["Computer: DISPLAY"].status == CheckStatus.OK
+        assert "reachable" in names["Computer: DISPLAY"].message
+
+    @patch("sys.platform", "linux")
+    @patch("subprocess.run")
+    @patch("shutil.which")
+    @patch.dict("os.environ", {"DISPLAY": ":1"})
+    def test_display_dead_xdpyinfo_fails(self, mock_which, mock_run):
+        """When xdpyinfo reports the X server is unreachable, DISPLAY check warns."""
+        import subprocess
+
+        mock_which.side_effect = lambda t: (
+            f"/usr/bin/{t}" if t in ("xdotool", "scrot", "xdpyinfo") else None
+        )
+        mock_run.side_effect = subprocess.CalledProcessError(1, "xdpyinfo")
+
+        results = _check_computer()
+
+        names = {r.name: r for r in results}
+        assert names["Computer: DISPLAY"].status == CheckStatus.WARNING
+        assert "not responding" in names["Computer: DISPLAY"].message
+        hint = names["Computer: DISPLAY"].fix_hint or ""
+        assert "Xvfb" in hint or "xvfb-run" in hint


### PR DESCRIPTION
## Summary

Two concrete gaps in the computer-use story, identified while reviewing issue #216:

### 1. Docker server was missing `shell` and `vision` tools

`scripts/computer_home/entrypoint.sh` started `gptme-server` with only `--tools ipython,computer`. This meant users connecting to the Docker container couldn't:
- Run shell commands in the container (`shell` tool)
- Analyze screenshots with vision reasoning (`vision` tool)

Both are listed in the `computer-use` profile's tool set and are essential for practical computer-use workflows. Fixed by adding them to the `--tools` argument.

### 2. `gptme-doctor` DISPLAY check was surface-level

The doctor reported `OK` for `Computer: DISPLAY` whenever `$DISPLAY` was set in the environment — even if no X server was actually listening at that address. A stale `DISPLAY` env var (e.g. from a previous Xvfb session) would pass the check while causing every `computer()` call to fail.

Added an `xdpyinfo` reachability probe:
- When `xdpyinfo` is available: runs it; if it fails, warns with an Xvfb fix hint
- When `xdpyinfo` is absent: falls back to the existing "set but unverified" OK message (preserves behaviour for minimal installs)

## Test plan
- [x] `tests/test_doctor.py::TestCheckComputer` — all 8 tests pass (2 new: `test_display_live_xdpyinfo_ok`, `test_display_dead_xdpyinfo_fails`)
- [x] `tests/test_tools_computer.py` + `tests/test_computer_transport.py` + `tests/test_profiles.py` — 168 passed, 3 skipped

Part of #216.