### PR TITLE
fix(computer): adaptive wait_for_change polling + EWMH WM readiness check

### DIFF
--- a/gptme/tools/computer.py
+++ b/gptme/tools/computer.py
@@ -799,7 +799,10 @@ def _dispatch_transport(
 
     if action == "wait_for_change":
         timeout = float(text) if text else 10.0
-        poll_interval = 0.5
+        # Start polling at 50ms, cap at 500ms — catches fast UI updates without
+        # burning CPU on long waits.
+        poll_interval = 0.05
+        max_poll_interval = 0.5
         change_threshold = 0.01
         baseline = transport.screenshot()
         deadline = time.monotonic() + timeout
@@ -810,6 +813,8 @@ def _dispatch_transport(
             if ratio >= change_threshold:
                 print(f"Screen changed ({ratio:.1%} pixels differ)")
                 return _make_screenshot_msg(current)
+            # Back off poll interval up to the cap
+            poll_interval = min(poll_interval * 2, max_poll_interval)
         print(
             f"No screen change detected after {timeout:.0f}s — returning current screenshot"
         )
@@ -1046,7 +1051,10 @@ def computer(
     if action == "wait_for_change":
         # text holds the optional timeout (seconds) as a string; default 10s
         timeout = float(text) if text else 10.0
-        poll_interval = 0.5
+        # Start polling at 50ms, cap at 500ms — catches fast UI updates without
+        # burning CPU on long waits.
+        poll_interval = 0.05
+        max_poll_interval = 0.5
         change_threshold = 0.01  # 1% of pixels must differ
         baseline = screenshot()
         deadline = time.monotonic() + timeout
@@ -1079,6 +1087,8 @@ def computer(
                     ):
                         pass
                 return _make_screenshot_msg(path)
+            # Back off poll interval up to the cap
+            poll_interval = min(poll_interval * 2, max_poll_interval)
         print(
             f"No screen change detected after {timeout:.0f}s — returning current screenshot"
         )

--- a/scripts/computer_home/mutter_startup.sh
+++ b/scripts/computer_home/mutter_startup.sh
@@ -4,19 +4,34 @@ set -e
 echo "Starting mutter..."
 XDG_SESSION_TYPE=x11 mutter --replace --sm-disable 2>/tmp/mutter_stderr.log &
 
-timeout=30
-while [ $timeout -gt 0 ]; do
-    if xdotool search --class "mutter" >/dev/null 2>&1; then
-        break
+# Use EWMH-standard check: _NET_SUPPORTING_WM_CHECK is set on the root window
+# by any EWMH-compliant WM when it takes over management. This works with any
+# WM and is authoritative — unlike searching for a specific window class.
+#
+# Falls back to xdotool class search if xprop is not available (minimal installs).
+timeout_ms=30000
+elapsed_ms=0
+poll_ms=100
+
+while [ $elapsed_ms -lt $timeout_ms ]; do
+    if command -v xprop >/dev/null 2>&1; then
+        if xprop -root _NET_SUPPORTING_WM_CHECK >/dev/null 2>&1; then
+            break
+        fi
+    else
+        if xdotool search --class "mutter" >/dev/null 2>&1; then
+            break
+        fi
     fi
-    sleep 1
-    ((timeout--))
+    sleep "0.${poll_ms}"
+    elapsed_ms=$((elapsed_ms + poll_ms))
 done
 
-if [ $timeout -eq 0 ]; then
-    echo "mutter stderr output:" >&2
+if [ $elapsed_ms -ge $timeout_ms ]; then
+    echo "mutter failed to start within $((timeout_ms / 1000))s" >&2
     cat /tmp/mutter_stderr.log >&2
     exit 1
 fi
 
+echo "mutter ready after ${elapsed_ms}ms"
 rm /tmp/mutter_stderr.log

--- a/scripts/computer_home/mutter_startup.sh
+++ b/scripts/computer_home/mutter_startup.sh
@@ -30,7 +30,7 @@ while [ $elapsed_ms -lt $timeout_ms ]; do
             break
         fi
     fi
-    sleep "$(printf '%.3f' "$(echo "scale=3; ${poll_ms}/1000" | bc)")"
+    sleep 0.1
     elapsed_ms=$((elapsed_ms + poll_ms))
 done
 

--- a/scripts/computer_home/mutter_startup.sh
+++ b/scripts/computer_home/mutter_startup.sh
@@ -13,8 +13,15 @@ timeout_ms=30000
 elapsed_ms=0
 poll_ms=100
 
+# Determine once which readiness probe to use (avoids a subprocess fork per iteration)
+if command -v xprop >/dev/null 2>&1; then
+    _use_xprop=1
+else
+    _use_xprop=0
+fi
+
 while [ $elapsed_ms -lt $timeout_ms ]; do
-    if command -v xprop >/dev/null 2>&1; then
+    if [ "$_use_xprop" -eq 1 ]; then
         if xprop -root _NET_SUPPORTING_WM_CHECK >/dev/null 2>&1; then
             break
         fi
@@ -23,7 +30,7 @@ while [ $elapsed_ms -lt $timeout_ms ]; do
             break
         fi
     fi
-    sleep "0.${poll_ms}"
+    sleep "$(printf '%.3f' "$(echo "scale=3; ${poll_ms}/1000" | bc)")"
     elapsed_ms=$((elapsed_ms + poll_ms))
 done
 

--- a/tests/test_tools_computer.py
+++ b/tests/test_tools_computer.py
@@ -1166,6 +1166,49 @@ def test_wait_for_change_timeout_returns_screenshot(mock_transport, mock_res, tm
     assert result is mock.sentinel.timeout_msg
 
 
+@mock.patch("gptme.tools.computer.IS_MACOS", False)
+@mock.patch(
+    "gptme.tools.computer._get_display_resolution", return_value=_MOCK_LINUX_RES_WFC
+)
+@mock.patch("gptme.tools.computer.get_transport", return_value=None)
+def test_wait_for_change_polls_with_backoff(mock_transport, mock_res, tmp_path):
+    """wait_for_change uses adaptive backoff: starts at 50ms, backs off to 500ms cap."""
+    from PIL import Image
+
+    static = tmp_path / "static.png"
+    Image.new("RGB", (100, 100), (42, 42, 42)).save(static)
+
+    sleep_calls = []
+
+    def _record_sleep(interval):
+        sleep_calls.append(interval)
+
+    # Expire the loop on the 4th poll so we get 3 sleep calls and see the backoff
+    monotonic_values = [0.0, 0.0, 0.0, 0.0, 100.0]
+    monotonic_iter = iter(monotonic_values)
+
+    with (
+        mock.patch("gptme.tools.computer.screenshot", return_value=static),
+        mock.patch("gptme.tools.computer.time.sleep", side_effect=_record_sleep),
+        mock.patch(
+            "gptme.tools.computer.time.monotonic",
+            side_effect=lambda: next(monotonic_iter),
+        ),
+        mock.patch(
+            "gptme.tools.computer._make_screenshot_msg",
+            return_value=mock.sentinel.timeout_msg,
+        ),
+    ):
+        result = computer("wait_for_change", text="1")
+
+    assert result is mock.sentinel.timeout_msg
+    # First call: 50ms; second: 100ms; third: 200ms — doubling backoff
+    assert len(sleep_calls) >= 2
+    assert sleep_calls[0] == pytest.approx(0.05)  # 50ms initial interval
+    assert sleep_calls[1] == pytest.approx(0.10)  # 100ms after first backoff
+    assert sleep_calls[2] == pytest.approx(0.20)  # 200ms after second backoff
+
+
 # ============================================================
 # window_focus action tests
 # ============================================================


### PR DESCRIPTION
## Summary

Two improvements targeting the delay issues flagged in #216:

### 1. Adaptive `wait_for_change` polling (both transport and legacy paths)

- **Before**: fixed 500ms poll interval — fast UI changes (button clicks, window opens) caught late
- **After**: starts at 50ms, doubles each miss up to 500ms cap
- Fast transitions caught in ≤50ms instead of ≤550ms
- CPU cost on long waits is unchanged (caps at same 500ms rate)

### 2. EWMH-standard WM readiness check in `mutter_startup.sh`

- **Before**: `xdotool search --class "mutter"` with 1s polling
  - Class-name fragile (depends on mutter creating a window with class "mutter")
  - Up to 1s unnecessary startup delay even when mutter is ready
- **After**: `xprop -root _NET_SUPPORTING_WM_CHECK` — the EWMH-standard property any compliant WM sets on the root window when it takes over
  - Works with mutter, openbox, fluxbox, or any EWMH WM
  - Poll interval reduced from 1s to 100ms
  - Falls back to xdotool class search if xprop is absent (minimal installs)

## Test plan

- [x] `test_wait_for_change_detects_change` — existing test passes (detection still works)
- [x] `test_wait_for_change_timeout_returns_screenshot` — existing test passes (timeout path still works)
- [x] `test_wait_for_change_polls_with_backoff` — **new test** verifies 50ms→100ms→200ms backoff sequence
- [x] Full computer test suite: 175 passed, 3 skipped

Part of #216.