### PR TITLE
feat(subagent): compact result summary in subagent_wait (#554)

### DIFF
--- a/gptme/tools/subagent/api.py
+++ b/gptme/tools/subagent/api.py
@@ -928,7 +928,7 @@ def subagent_wait(
     # The complete block is meant to be a brief summary; if it's longer than
     # max_result_chars the parent agent can call subagent_read_log() to get details.
     result_text = result_dict.get("result")
-    if result_text and len(result_text) > max_result_chars:
+    if result_text and max_result_chars > 0 and len(result_text) > max_result_chars:
         result_dict["result"] = (
             result_text[:max_result_chars]
             + f"\n... [truncated — call subagent_read_log('{agent_id}') for full output]"

--- a/gptme/tools/subagent/api.py
+++ b/gptme/tools/subagent/api.py
@@ -874,12 +874,17 @@ def subagent_status(agent_id: str) -> dict:
     return asdict(sa.status())
 
 
-def subagent_wait(agent_id: str, timeout: int = 60) -> dict:
+def subagent_wait(
+    agent_id: str, timeout: int = 60, max_result_chars: int = 2000
+) -> dict:
     """Waits for a subagent to finish.
 
     Args:
         agent_id: The subagent to wait for
         timeout: Maximum seconds to wait (default 60)
+        max_result_chars: Truncate result text to this many characters (default 2000).
+            Long subagent outputs are truncated to keep the parent's context clean.
+            Call subagent_read_log(agent_id) to read the full output.
 
     Returns:
         Status dict with 'status' and 'result' keys
@@ -917,7 +922,19 @@ def subagent_wait(agent_id: str, timeout: int = 60) -> dict:
         sa.thread.join(timeout=timeout)
 
     status = sa.status()
-    return asdict(status)
+    result_dict = asdict(status)
+
+    # Compact result: truncate long outputs so they don't flood the parent's context.
+    # The complete block is meant to be a brief summary; if it's longer than
+    # max_result_chars the parent agent can call subagent_read_log() to get details.
+    result_text = result_dict.get("result")
+    if result_text and len(result_text) > max_result_chars:
+        result_dict["result"] = (
+            result_text[:max_result_chars]
+            + f"\n... [truncated — call subagent_read_log('{agent_id}') for full output]"
+        )
+
+    return result_dict
 
 
 def subagent_read_log(

--- a/tests/test_tools_subagent.py
+++ b/tests/test_tools_subagent.py
@@ -457,6 +457,75 @@ def test_subagent_wait_returns_failure_when_thread_startup_raises(
         _subagent_results.clear()
 
 
+@patch("gptme.tools.subagent.api.notify_completion")
+@patch("gptme.tools.subagent.execution._create_subagent_thread")
+def test_subagent_wait_truncates_long_result(
+    _mock_create_thread: MagicMock, _mock_notify: MagicMock
+):
+    """subagent_wait() should truncate very long results to keep parent context clean."""
+    from gptme.tools.subagent import (
+        ReturnType,
+        _subagent_results,
+        _subagents_lock,
+        subagent,
+        subagent_wait,
+    )
+
+    _subagents.clear()
+    _subagent_results.clear()
+
+    try:
+        subagent(agent_id="test-truncate-wait", prompt="Long output task")
+
+        # Inject a long result into the cache (simulates a completed subagent)
+        long_result = "A" * 5000 + "\n\nFull log: /tmp/test-logdir"
+        with _subagents_lock:
+            _subagent_results["test-truncate-wait"] = ReturnType("success", long_result)
+
+        result = subagent_wait("test-truncate-wait", timeout=1, max_result_chars=2000)
+        assert result["status"] == "success"
+        assert result["result"] is not None
+        assert len(result["result"]) < 3000  # truncated + hint text
+        assert "truncated" in result["result"]
+        assert "subagent_read_log" in result["result"]
+        assert "test-truncate-wait" in result["result"]
+    finally:
+        _subagents.clear()
+        _subagent_results.clear()
+
+
+@patch("gptme.tools.subagent.api.notify_completion")
+@patch("gptme.tools.subagent.execution._create_subagent_thread")
+def test_subagent_wait_short_result_not_truncated(
+    _mock_create_thread: MagicMock, _mock_notify: MagicMock
+):
+    """Short results should pass through unchanged."""
+    from gptme.tools.subagent import (
+        ReturnType,
+        _subagent_results,
+        _subagents_lock,
+        subagent,
+        subagent_wait,
+    )
+
+    _subagents.clear()
+    _subagent_results.clear()
+
+    try:
+        subagent(agent_id="test-short-wait", prompt="Short output task")
+
+        short_result = "Fibonacci 13 = 233\n\nFull log: /tmp/logdir"
+        with _subagents_lock:
+            _subagent_results["test-short-wait"] = ReturnType("success", short_result)
+
+        result = subagent_wait("test-short-wait", timeout=1)
+        assert result["status"] == "success"
+        assert result["result"] == short_result  # unchanged
+    finally:
+        _subagents.clear()
+        _subagent_results.clear()
+
+
 @pytest.mark.slow
 @pytest.mark.eval
 def test_subagent_wait_basic():


### PR DESCRIPTION
## Problem

When a subagent finishes and the orchestrator calls `subagent_wait()`, the returned dict includes the full `result` field — everything the subagent wrote in its `complete` block plus `\n\nFull log: <path>`. For verbose subagents this could be thousands of characters, flooding the parent agent's context window and mixing noise into the conversation.

This is the "parent output UX" gap identified in #554.

## Fix

Add a `max_result_chars=2000` parameter to `subagent_wait()`. Results longer than the threshold are truncated and a hint to call `subagent_read_log(agent_id)` is appended:

```
...result text up to 2000 chars...
... [truncated — call subagent_read_log('agent-id') for full output]
```

Short results (≤ `max_result_chars`) are returned unchanged.

The `complete` block is supposed to be a brief summary by design — this enforces that contract from the parent side. If the subagent writes a long complete block, the parent can use `subagent_read_log()` to get the full text.

## Tests

- `test_subagent_wait_truncates_long_result`: verifies that a 5000-char result is truncated to ≤3000 chars and the hint contains "truncated" + "subagent_read_log" + the agent_id
- `test_subagent_wait_short_result_not_truncated`: verifies that a short result passes through unchanged

All 77 existing non-slow subagent tests continue to pass.

## Related

- Closes part of #554 (parent output UX gap)
- Full log access: `subagent_read_log(agent_id)` — already available