### PR TITLE
feat(subagent): add context_turns parameter for parent conversation forwarding

### DIFF
--- a/gptme/tools/subagent/api.py
+++ b/gptme/tools/subagent/api.py
@@ -158,10 +158,12 @@ def subagent(
             blocking the parent) or hard time budgets in autonomous sessions.
             ``max_time=None`` is fully backwards-compatible — no change in behavior.
         context_turns: Number of recent parent conversation turns to forward to
-            the subagent as context. A "turn" is one user+assistant exchange,
-            so ``context_turns=3`` forwards up to 6 messages. The messages are
-            injected as a system message so the subagent understands what the
-            parent has been doing without confusing its own conversation flow.
+            the subagent as context. A "turn" starts at a user message and
+            includes all subsequent assistant and tool-result (system) messages
+            until the next user message, so the total message count per turn
+            varies with the number of tool calls. The messages are injected as
+            a system message so the subagent understands what the parent has
+            been doing without confusing its own conversation flow.
 
             - ``None`` (default): no parent context forwarded (current behavior).
             - ``N > 0``: forward the last N turns from the parent's active log.

--- a/gptme/tools/subagent/api.py
+++ b/gptme/tools/subagent/api.py
@@ -222,8 +222,18 @@ def subagent(
         parent_log = LogManager.get_current_log()
         if parent_log is not None:
             msgs = parent_log.log
-            # Each turn = user + assistant pair; slice the last context_turns*2 messages.
-            parent_messages = list(msgs[-(context_turns * 2) :])
+            # Slice from the N-th-from-last user message so tool-result system
+            # messages within a turn are included and the count is exact.
+            user_indices = [i for i, m in enumerate(msgs) if m.role == "user"]
+            if user_indices:
+                start = (
+                    user_indices[-context_turns]
+                    if len(user_indices) >= context_turns
+                    else 0
+                )
+                parent_messages = list(msgs[start:])
+            else:
+                parent_messages = list(msgs)
         else:
             logger.warning(
                 "context_turns=%d set but no active LogManager found; "
@@ -454,6 +464,12 @@ def subagent(
             logger.warning(
                 f"Subagent {agent_id}: 'context_include' is not supported in ACP mode (ignored)"
             )
+        if context_turns is not None:
+            logger.warning(
+                "context_turns=%d set but ACP mode does not forward parent context; "
+                "parameter is ignored",
+                context_turns,
+            )
 
         def run_acp_subagent():
             _sem = get_slot_sem()
@@ -587,6 +603,12 @@ def subagent(
         # A launcher thread acquires the slot before starting the OS process so that
         # excess agents queue (rather than all starting at once).
         logger.info(f"Starting subagent {agent_id} in subprocess mode")
+        if context_turns is not None:
+            logger.warning(
+                "context_turns=%d set but subprocess mode does not forward parent context; "
+                "parameter is ignored",
+                context_turns,
+            )
         if profile:
             logger.info(f"  with profile: {profile}")
         # Convert output_schema type to JSON string if present

--- a/gptme/tools/subagent/api.py
+++ b/gptme/tools/subagent/api.py
@@ -226,12 +226,15 @@ def subagent(
             msgs = parent_log.log
             # Slice from the N-th-from-last user message so tool-result system
             # messages within a turn are included and the count is exact.
+            # Fallback to user_indices[0] (not 0) so leading system bootstrap
+            # messages (identity, workspace context) are never forwarded when
+            # context_turns exceeds available turns.
             user_indices = [i for i, m in enumerate(msgs) if m.role == "user"]
             if user_indices:
                 start = (
                     user_indices[-context_turns]
                     if len(user_indices) >= context_turns
-                    else 0
+                    else user_indices[0]
                 )
                 parent_messages = list(msgs[start:])
             else:

--- a/gptme/tools/subagent/api.py
+++ b/gptme/tools/subagent/api.py
@@ -54,6 +54,7 @@ def subagent(
     redact_secrets: bool = True,
     context_window: int | None = None,
     max_time: float | None = None,
+    context_turns: int | None = None,
     workdir: str | Path | None = None,
 ):
     """Starts an asynchronous subagent. Returns None immediately.
@@ -156,6 +157,26 @@ def subagent(
             Use this for defensive orchestration (prevent a stuck subagent from
             blocking the parent) or hard time budgets in autonomous sessions.
             ``max_time=None`` is fully backwards-compatible — no change in behavior.
+        context_turns: Number of recent parent conversation turns to forward to
+            the subagent as context. A "turn" is one user+assistant exchange,
+            so ``context_turns=3`` forwards up to 6 messages. The messages are
+            injected as a system message so the subagent understands what the
+            parent has been doing without confusing its own conversation flow.
+
+            - ``None`` (default): no parent context forwarded (current behavior).
+            - ``N > 0``: forward the last N turns from the parent's active log.
+
+            The parent log is fetched automatically from the currently active
+            ``LogManager`` (set by the chat loop via ``ContextVar``). This works
+            when ``subagent()`` is called from within the ``ipython`` tool during
+            a running chat session.
+
+            Use this when the subagent needs awareness of what the parent has
+            already done (e.g. "the parent tried A and B, now try C") or when
+            the task prompt alone doesn't provide enough context.
+
+            Only applies to thread-mode subagents; has no effect in subprocess
+            or ACP modes.
         workdir: Working directory for the subagent. Defaults to the current
             working directory (``Path.cwd()``) when ``None``.
 
@@ -186,6 +207,29 @@ def subagent(
         raise ValueError(
             f"context_window must be None, 0, or a positive integer, got {context_window!r}"
         )
+    if context_turns is not None and context_turns <= 0:
+        raise ValueError(
+            f"context_turns must be None or a positive integer, got {context_turns!r}"
+        )
+
+    # Fetch parent messages from the active LogManager when context_turns is set.
+    # LogManager.get_current_log() reads a ContextVar set by the chat loop, so
+    # this works when subagent() is called from within an ipython tool execution.
+    parent_messages = None
+    if context_turns is not None:
+        from ...logmanager import LogManager  # fmt: skip
+
+        parent_log = LogManager.get_current_log()
+        if parent_log is not None:
+            msgs = parent_log.log
+            # Each turn = user + assistant pair; slice the last context_turns*2 messages.
+            parent_messages = list(msgs[-(context_turns * 2) :])
+        else:
+            logger.warning(
+                "context_turns=%d set but no active LogManager found; "
+                "parent context will not be forwarded",
+                context_turns,
+            )
 
     # noreorder
     from gptme.cli.main import get_logdir  # fmt: skip
@@ -649,6 +693,7 @@ def subagent(
                         agent_id=agent_id,
                         redact_secrets=redact_secrets,
                         context_window=context_window,
+                        parent_messages=parent_messages,
                     )
                 except Exception as e:
                     # If subagent creation fails, notify with error status

--- a/gptme/tools/subagent/api.py
+++ b/gptme/tools/subagent/api.py
@@ -304,6 +304,12 @@ def subagent(
             raise ValueError(f"workdir is not a directory: {workdir_path}")
 
     if mode == "planner":
+        if context_turns is not None:
+            logger.warning(
+                "context_turns=%d set but planner mode does not forward parent context; "
+                "parameter is ignored",
+                context_turns,
+            )
         if not subtasks:
             raise ValueError("Planner mode requires subtasks parameter")
 
@@ -568,6 +574,7 @@ def subagent(
             repo_path=repo_path,
             role=role,
             max_time=max_time,
+            context_turns=context_turns,
         )
         # Append sa before starting the thread so the finally block can find it
         # (avoids race condition where fast completion can't locate sa in _subagents)
@@ -655,6 +662,7 @@ def subagent(
             timeout=timeout,
             role=role,
             max_time=max_time,
+            context_turns=context_turns,
         )
         with _subagents_lock:
             _subagents.append(sa)
@@ -769,6 +777,7 @@ def subagent(
             redact_secrets=redact_secrets,
             context_window=context_window,
             max_time=max_time,
+            context_turns=context_turns,
         )
         with _subagents_lock:
             _subagents.append(sa)
@@ -946,6 +955,7 @@ def subagent_reply(agent_id: str, reply: str) -> None:
             redact_secrets=sa.redact_secrets,
             context_window=sa.context_window,
             max_time=sa.max_time,
+            context_turns=sa.context_turns,
         )
     except Exception:
         with _subagents_lock:

--- a/gptme/tools/subagent/execution.py
+++ b/gptme/tools/subagent/execution.py
@@ -131,7 +131,7 @@ def _build_parent_context_message(parent_messages: list[Message]) -> Message:
     lines = ["# Parent Conversation Context\n"]
     for msg in parent_messages:
         role_label = msg.role.capitalize()
-        lines.append(f"**{role_label}:** {msg.content}\n")
+        lines.append(f"**{role_label}:**\n\n{msg.content}\n")
     lines.append(
         "\n_This context is provided so you can understand what the parent agent has been doing. "
         "Focus on your own task — don't re-execute work the parent has already completed._"
@@ -327,7 +327,13 @@ def _create_subagent_thread(
         initial_msgs.append(memory_msg)
 
     # Inject parent conversation context if provided
+    # Redact secrets from parent messages to prevent leaking API keys/tokens
+    # that may appear in parent conversation output (e.g., shell output, env reads).
     if parent_messages:
+        if redact_secrets:
+            from .context import redact_secrets_from_messages
+
+            parent_messages = redact_secrets_from_messages(parent_messages)
         initial_msgs.append(_build_parent_context_message(parent_messages))
 
     # Add completion instruction as a system message

--- a/gptme/tools/subagent/execution.py
+++ b/gptme/tools/subagent/execution.py
@@ -126,6 +126,19 @@ def _build_memory_system_message(
     return Message("system", "\n\n".join(parts))
 
 
+def _build_parent_context_message(parent_messages: list[Message]) -> Message:
+    """Format parent conversation messages into a system context message for the subagent."""
+    lines = ["# Parent Conversation Context\n"]
+    for msg in parent_messages:
+        role_label = msg.role.capitalize()
+        lines.append(f"**{role_label}:** {msg.content}\n")
+    lines.append(
+        "\n_This context is provided so you can understand what the parent agent has been doing. "
+        "Focus on your own task — don't re-execute work the parent has already completed._"
+    )
+    return Message("system", "\n".join(lines))
+
+
 def _create_subagent_thread(
     prompt: str,
     logdir: Path,
@@ -139,6 +152,7 @@ def _create_subagent_thread(
     agent_id: str | None = None,
     redact_secrets: bool = True,
     context_window: int | None = None,
+    parent_messages: list[Message] | None = None,
 ) -> None:
     """Shared function for running subagent threads.
 
@@ -155,6 +169,9 @@ def _create_subagent_thread(
         context_window: Limit workspace context messages. None = no limit; 0 = minimal
             context (just agent identity + tools, no workspace files); N > 0 = at most
             N workspace context messages included.
+        parent_messages: Recent messages from the parent's conversation to inject as context.
+            Formatted as a system message so the subagent understands what the parent has
+            been doing without confusing the subagent's own conversation flow.
     """
     # Store agent_id in thread-local so the progress tool can identify this subagent
     if agent_id is not None:
@@ -308,6 +325,10 @@ def _create_subagent_thread(
     if memory_dir is not None:
         memory_msg = _build_memory_system_message(memory_content, memory_dir)
         initial_msgs.append(memory_msg)
+
+    # Inject parent conversation context if provided
+    if parent_messages:
+        initial_msgs.append(_build_parent_context_message(parent_messages))
 
     # Add completion instruction as a system message
     complete_instruction = Message(

--- a/gptme/tools/subagent/types.py
+++ b/gptme/tools/subagent/types.py
@@ -198,6 +198,8 @@ class Subagent:
     redact_secrets: bool = True
     # Context window: None = no limit; 0 = minimal (no workspace files); N = at most N msgs
     context_window: int | None = None
+    # Number of parent conversation turns to forward as context (P1: persist for re-spawn)
+    context_turns: int | None = None
     # Timestamp (seconds since epoch) when this subagent was created
     started_at: float = field(default_factory=time.time)
     # Wall-clock limit in seconds; when set, a watchdog auto-cancels after this time

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -2808,3 +2808,58 @@ class TestParentContextForwarding:
         # Cleanup
         with _subagents_lock:
             _subagents[:] = [s for s in _subagents if s.agent_id != "test-none-turns"]
+
+    def test_context_turns_fallback_skips_leading_system_messages(self, monkeypatch):
+        """When context_turns exceeds available turns, fallback starts at first user msg.
+
+        A real gptme log opens with system bootstrap messages (identity, workspace
+        context). When context_turns > available user turns the fallback must start at
+        user_indices[0], not at 0, so those setup messages are never forwarded.
+        """
+        import gptme.tools.subagent.execution as exec_mod
+        from gptme.logmanager import Log, LogManager
+        from gptme.message import Message
+
+        # Log with leading system messages before the first user message
+        msgs = [
+            Message("system", "[agent identity]"),
+            Message("system", "[workspace context]"),
+            Message("user", "first user task"),
+            Message("assistant", "first response"),
+        ]
+        mock_log = MagicMock(spec=LogManager)
+        mock_log.log = Log(msgs)
+
+        monkeypatch.setattr(
+            LogManager, "get_current_log", staticmethod(lambda: mock_log)
+        )
+
+        captured: list = []
+
+        def mock_create_thread(**kw):
+            captured.append(kw.get("parent_messages"))
+
+        monkeypatch.setattr(exec_mod, "_create_subagent_thread", mock_create_thread)
+
+        # context_turns=5 exceeds the 1 available user turn → triggers fallback
+        subagent("test-fallback-skip-system", "do something", context_turns=5)
+
+        import time
+
+        for _ in range(20):
+            if captured:
+                break
+            time.sleep(0.05)
+
+        assert len(captured) == 1
+        assert captured[0] is not None
+        # Must NOT include the leading system bootstrap messages
+        assert captured[0][0].content == "first user task"
+        assert captured[0][0].role == "user"
+        assert len(captured[0]) == 2  # user + assistant only
+
+        # Cleanup
+        with _subagents_lock:
+            _subagents[:] = [
+                s for s in _subagents if s.agent_id != "test-fallback-skip-system"
+            ]

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -2685,13 +2685,20 @@ class TestParentContextForwarding:
             _subagents[:] = [s for s in _subagents if s.agent_id != "test-no-log"]
 
     def test_context_turns_slices_log(self, monkeypatch):
-        """context_turns=2 forwards the last 4 messages from the parent log."""
+        """context_turns=2 forwards the last 2 turns (from 2nd-to-last user msg onward)."""
         import gptme.tools.subagent.execution as exec_mod
         from gptme.logmanager import Log, LogManager
         from gptme.message import Message
 
-        # Build a mock log with 6 messages
-        msgs = [Message("user", f"msg {i}") for i in range(6)]
+        # Build a log with 3 realistic user+assistant turns
+        msgs = [
+            Message("user", "turn 1 user"),
+            Message("assistant", "turn 1 assistant"),
+            Message("user", "turn 2 user"),
+            Message("assistant", "turn 2 assistant"),
+            Message("user", "turn 3 user"),
+            Message("assistant", "turn 3 assistant"),
+        ]
         mock_log = MagicMock(spec=LogManager)
         mock_log.log = Log(msgs)
 
@@ -2716,15 +2723,64 @@ class TestParentContextForwarding:
             time.sleep(0.05)
 
         assert len(captured) == 1
-        # context_turns=2 → last 4 messages (2 turns × 2 msgs/turn)
+        # context_turns=2 → starts from 2nd-to-last user message (index 2)
         assert captured[0] is not None
         assert len(captured[0]) == 4
-        assert captured[0][0].content == "msg 2"
-        assert captured[0][-1].content == "msg 5"
+        assert captured[0][0].content == "turn 2 user"
+        assert captured[0][-1].content == "turn 3 assistant"
 
         # Cleanup
         with _subagents_lock:
             _subagents[:] = [s for s in _subagents if s.agent_id != "test-slice"]
+
+    def test_context_turns_slices_log_with_tool_results(self, monkeypatch):
+        """context_turns correctly includes tool-result system msgs within a turn."""
+        import gptme.tools.subagent.execution as exec_mod
+        from gptme.logmanager import Log, LogManager
+        from gptme.message import Message
+
+        # Log with 2 turns; turn 1 has a tool-result system message in the middle
+        msgs = [
+            Message("user", "turn 1 user"),
+            Message("assistant", "calling tool"),
+            Message("system", "[tool result]"),
+            Message("assistant", "turn 1 final"),
+            Message("user", "turn 2 user"),
+            Message("assistant", "turn 2 assistant"),
+        ]
+        mock_log = MagicMock(spec=LogManager)
+        mock_log.log = Log(msgs)
+
+        monkeypatch.setattr(
+            LogManager, "get_current_log", staticmethod(lambda: mock_log)
+        )
+
+        captured: list = []
+
+        def mock_create_thread(**kw):
+            captured.append(kw.get("parent_messages"))
+
+        monkeypatch.setattr(exec_mod, "_create_subagent_thread", mock_create_thread)
+
+        subagent("test-slice-tool", "do something", context_turns=2)
+
+        import time
+
+        for _ in range(20):
+            if captured:
+                break
+            time.sleep(0.05)
+
+        assert len(captured) == 1
+        # Both turns included; tool-result system message is included within turn 1
+        assert captured[0] is not None
+        assert len(captured[0]) == 6
+        assert captured[0][0].content == "turn 1 user"
+        assert captured[0][-1].content == "turn 2 assistant"
+
+        # Cleanup
+        with _subagents_lock:
+            _subagents[:] = [s for s in _subagents if s.agent_id != "test-slice-tool"]
 
     def test_context_turns_none_passes_none(self, monkeypatch):
         """context_turns=None (default) passes parent_messages=None to thread."""

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -2598,3 +2598,155 @@ class TestMaxTimeWatchdog:
             _subagents[:] = [s for s in _subagents if s.agent_id != "no-watchdog-test"]
 
         assert len(timers_started) == 0, f"No timer expected; got {timers_started}"
+
+
+# ---------------------------------------------------------------------------
+# context_turns + parent context forwarding tests
+# ---------------------------------------------------------------------------
+
+
+class TestParentContextForwarding:
+    """Tests for the context_turns parameter and parent message injection."""
+
+    def test_build_parent_context_message_format(self):
+        """_build_parent_context_message produces a correctly structured system message."""
+        from gptme.message import Message
+        from gptme.tools.subagent.execution import _build_parent_context_message
+
+        msgs = [
+            Message("user", "What is 1+1?"),
+            Message("assistant", "It is 2."),
+        ]
+        result = _build_parent_context_message(msgs)
+        assert result.role == "system"
+        assert "Parent Conversation Context" in result.content
+        assert "What is 1+1?" in result.content
+        assert "It is 2." in result.content
+        assert "User:" in result.content
+        assert "Assistant:" in result.content
+
+    def test_build_parent_context_message_guidance(self):
+        """Parent context message includes guidance not to duplicate parent work."""
+        from gptme.message import Message
+        from gptme.tools.subagent.execution import _build_parent_context_message
+
+        msgs = [Message("user", "hello")]
+        result = _build_parent_context_message(msgs)
+        assert "Focus on your own task" in result.content
+
+    def test_context_turns_validation_zero(self):
+        """context_turns=0 raises ValueError."""
+        with pytest.raises(ValueError, match="context_turns must be None"):
+            subagent("test-turns-zero", "task", context_turns=0)
+
+    def test_context_turns_validation_negative(self):
+        """context_turns=-1 raises ValueError."""
+        with pytest.raises(ValueError, match="context_turns must be None"):
+            subagent("test-turns-neg", "task", context_turns=-1)
+
+    def test_context_turns_no_active_log_warns(self, monkeypatch, caplog):
+        """context_turns with no active LogManager logs a warning and spawns without parent context."""
+        import logging
+
+        import gptme.tools.subagent.execution as exec_mod
+        from gptme.logmanager import LogManager
+
+        # No active log in this context
+        monkeypatch.setattr(LogManager, "get_current_log", staticmethod(lambda: None))
+
+        captured_parent_msgs = []
+
+        def mock_create_thread(**kw):
+            captured_parent_msgs.append(kw.get("parent_messages"))
+
+        monkeypatch.setattr(exec_mod, "_create_subagent_thread", mock_create_thread)
+
+        with caplog.at_level(logging.WARNING, logger="gptme.tools.subagent.api"):
+            subagent("test-no-log", "do something", context_turns=3)
+
+        # Wait briefly for the daemon thread to call mock_create_thread
+        import time
+
+        for _ in range(20):
+            if captured_parent_msgs:
+                break
+            time.sleep(0.05)
+
+        # The spawn should still happen
+        assert len(captured_parent_msgs) == 1
+        # But parent_messages should be None (no log found)
+        assert captured_parent_msgs[0] is None
+        assert any("context_turns" in r.message for r in caplog.records)
+
+        # Cleanup
+        with _subagents_lock:
+            _subagents[:] = [s for s in _subagents if s.agent_id != "test-no-log"]
+
+    def test_context_turns_slices_log(self, monkeypatch):
+        """context_turns=2 forwards the last 4 messages from the parent log."""
+        import gptme.tools.subagent.execution as exec_mod
+        from gptme.logmanager import Log, LogManager
+        from gptme.message import Message
+
+        # Build a mock log with 6 messages
+        msgs = [Message("user", f"msg {i}") for i in range(6)]
+        mock_log = MagicMock(spec=LogManager)
+        mock_log.log = Log(msgs)
+
+        monkeypatch.setattr(
+            LogManager, "get_current_log", staticmethod(lambda: mock_log)
+        )
+
+        captured: list = []
+
+        def mock_create_thread(**kw):
+            captured.append(kw.get("parent_messages"))
+
+        monkeypatch.setattr(exec_mod, "_create_subagent_thread", mock_create_thread)
+
+        subagent("test-slice", "do something", context_turns=2)
+
+        import time
+
+        for _ in range(20):
+            if captured:
+                break
+            time.sleep(0.05)
+
+        assert len(captured) == 1
+        # context_turns=2 → last 4 messages (2 turns × 2 msgs/turn)
+        assert captured[0] is not None
+        assert len(captured[0]) == 4
+        assert captured[0][0].content == "msg 2"
+        assert captured[0][-1].content == "msg 5"
+
+        # Cleanup
+        with _subagents_lock:
+            _subagents[:] = [s for s in _subagents if s.agent_id != "test-slice"]
+
+    def test_context_turns_none_passes_none(self, monkeypatch):
+        """context_turns=None (default) passes parent_messages=None to thread."""
+        import gptme.tools.subagent.execution as exec_mod
+
+        captured: list = []
+
+        def mock_create_thread(**kw):
+            captured.append(kw.get("parent_messages"))
+
+        monkeypatch.setattr(exec_mod, "_create_subagent_thread", mock_create_thread)
+
+        subagent("test-none-turns", "do something")
+
+        import time
+
+        for _ in range(20):
+            if captured:
+                break
+            time.sleep(0.05)
+
+        assert len(captured) == 1
+        assert captured[0] is None
+
+        # Cleanup
+        with _subagents_lock:
+            _subagents[:] = [s for s in _subagents if s.agent_id != "test-none-turns"]

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -1264,6 +1264,7 @@ class TestClarifyBlock:
                         isolated=kwargs["isolated"],
                         timeout=kwargs["timeout"],
                         role=kwargs["role"],
+                        context_turns=kwargs.get("context_turns"),
                     )
                 )
 
@@ -1288,6 +1289,7 @@ class TestClarifyBlock:
             "redact_secrets": True,
             "context_window": None,
             "max_time": None,
+            "context_turns": None,
         }
         with _subagent_results_lock:
             assert "clarify-agent" not in _subagent_results

--- a/tests/test_tools_subagent.py
+++ b/tests/test_tools_subagent.py
@@ -15,6 +15,19 @@ def _wait_for_new_subagent_threads(initial_count: int, timeout: float = 1.0) -> 
             assert not sa.thread.is_alive()
 
 
+def _new_subagents(initial_count: int):
+    """Return subagents registered since the test started."""
+    return _subagents[initial_count:]
+
+
+def _planner_children(initial_count: int, planner_id: str):
+    """Split new planner-mode registrations into planner + executor children."""
+    new_agents = _new_subagents(initial_count)
+    planner = next(sa for sa in new_agents if sa.agent_id == planner_id)
+    executors = [sa for sa in new_agents if sa.agent_id != planner_id]
+    return planner, executors
+
+
 def test_planner_mode_requires_subtasks():
     """Test that planner mode requires subtasks parameter."""
     with pytest.raises(ValueError, match="Planner mode requires subtasks"):
@@ -39,11 +52,12 @@ def test_planner_mode_spawns_executors(mock_create_thread: MagicMock):
     )
     _wait_for_new_subagent_threads(initial_count)
 
-    # Should have spawned 2 executor subagents
-    assert len(_subagents) == initial_count + 2
+    planner, executors = _planner_children(initial_count, "test-planner")
+    assert planner.agent_id == "test-planner"
+    assert len(executors) == 2
 
     # Check executor IDs are correctly formed
-    executor_ids = [s.agent_id for s in _subagents[-2:]]
+    executor_ids = [s.agent_id for s in executors]
     assert "test-planner-task1" in executor_ids
     assert "test-planner-task2" in executor_ids
 
@@ -65,7 +79,9 @@ def test_planner_mode_executor_prompts(mock_create_thread: MagicMock):
     _wait_for_new_subagent_threads(initial_count)
 
     # Check the spawned executor has correct prompt
-    executor = _subagents[-1]
+    _, executors = _planner_children(initial_count, "test-planner")
+    assert len(executors) == 1
+    executor = executors[0]
     assert "This is the overall context" in executor.prompt
     assert "Do something specific" in executor.prompt
 
@@ -107,11 +123,11 @@ def test_planner_parallel_mode(mock_create_thread: MagicMock):
     )
     _wait_for_new_subagent_threads(initial_count)
 
-    # All 3 executors should be spawned
-    assert len(_subagents) == initial_count + 3
+    _, executors = _planner_children(initial_count, "test-parallel")
+    assert len(executors) == 3
 
     # Check all have correct ID prefix
-    executor_ids = [s.agent_id for s in _subagents[-3:]]
+    executor_ids = [s.agent_id for s in executors]
     assert all(eid.startswith("test-parallel-") for eid in executor_ids)
 
 
@@ -136,11 +152,11 @@ def test_planner_sequential_mode():
         )
         _wait_for_new_subagent_threads(initial_count)
 
-    # Should spawn 2 executors
-    assert len(_subagents) == initial_count + 2
+    _, executors = _planner_children(initial_count, "test-sequential")
+    assert len(executors) == 2
 
     # Check IDs are correctly formed
-    executor_ids = [s.agent_id for s in _subagents[-2:]]
+    executor_ids = [s.agent_id for s in executors]
     assert "test-sequential-seq1" in executor_ids
     assert "test-sequential-seq2" in executor_ids
 
@@ -163,8 +179,8 @@ def test_planner_default_is_parallel(mock_create_thread: MagicMock):
     )
     _wait_for_new_subagent_threads(initial_count)
 
-    # Should spawn 1 executor (parallel is default)
-    assert len(_subagents) == initial_count + 1
+    _, executors = _planner_children(initial_count, "test-default")
+    assert len(executors) == 1
 
 
 @patch("gptme.tools.subagent.execution._create_subagent_thread")
@@ -279,8 +295,8 @@ def test_planner_mode_with_context_modes(mock_create_thread: MagicMock):
     )
     _wait_for_new_subagent_threads(initial_count)
 
-    # Should spawn 2 executors
-    assert len(_subagents) == initial_count + 2
+    _, executors = _planner_children(initial_count, "test-planner-context")
+    assert len(executors) == 2
 
 
 # Phase 1 Tests: Subprocess mode, callbacks, batch execution
@@ -1171,7 +1187,8 @@ def test_planner_with_profile(mock_create_thread: MagicMock):
         profile="explorer",
     )
 
-    assert len(_subagents) == initial_count + 2
+    _, executors = _planner_children(initial_count, "test-planner-profile")
+    assert len(executors) == 2
 
     _wait_for_new_subagent_threads(initial_count)
 
@@ -2155,11 +2172,12 @@ def test_planner_subtask_role_passthrough(
 
     time.sleep(0.3)
 
-    # Should have spawned 3 executors
-    assert len(_subagents) == initial_count + 3
-    assert _subagents[-3].agent_id.endswith("-scout")
-    assert _subagents[-2].agent_id.endswith("-build")
-    assert _subagents[-1].agent_id.endswith("-check")
+    _, executors = _planner_children(initial_count, "test-role-planner")
+    assert len(executors) == 3
+    executor_ids = {sa.agent_id for sa in executors}
+    assert "test-role-planner-scout" in executor_ids
+    assert "test-role-planner-build" in executor_ids
+    assert "test-role-planner-check" in executor_ids
 
 
 @patch("gptme.tools.subagent.execution._create_subagent_thread")
@@ -2187,8 +2205,9 @@ def test_planner_subtask_role_does_not_affect_planner_internals(
         subtasks=subtasks,
     )
 
-    assert len(_subagents) == initial_count + 1
-    executor = _subagents[-1]
+    _, executors = _planner_children(initial_count, "test-planner-with-role")
+    assert len(executors) == 1
+    executor = executors[0]
     assert executor.agent_id == "test-planner-with-role-task1"
 
     _wait_for_new_subagent_threads(initial_count, timeout=5.0)
@@ -2226,7 +2245,8 @@ def test_planner_with_role_uses_role_for_self_profile(mock_create_thread: MagicM
         subtasks=subtasks,
     )
 
-    assert len(_subagents) == initial_count + 2
+    _, executors = _planner_children(initial_count, "builder-plan")
+    assert len(executors) == 2
 
     _wait_for_new_subagent_threads(initial_count, timeout=2.0)
 
@@ -2295,9 +2315,9 @@ def test_planner_subtask_role_overrides_planner_profile(
         "Per-subtask role should always override planner-level profile."
     )
 
-    new_agents = _subagents[initial_count:]
-    assert len(new_agents) == 1
-    assert new_agents[0].execution_mode == "subprocess"
+    _, executors = _planner_children(initial_count, "impl-plan")
+    assert len(executors) == 1
+    assert executors[0].execution_mode == "subprocess"
 
 
 # ---------------------------------------------------------------------------
@@ -2342,9 +2362,9 @@ def test_planner_subtask_role_verify_uses_subprocess(
     mock_monitor.assert_called_once()
 
     # The registered Subagent should carry execution_mode="subprocess"
-    new_agents = _subagents[initial_count:]
-    assert len(new_agents) == 1
-    sa = new_agents[0]
+    _, executors = _planner_children(initial_count, "test-verify-sub")
+    assert len(executors) == 1
+    sa = executors[0]
     assert sa.execution_mode == "subprocess"
     assert sa.agent_id == "test-verify-sub-check"
 
@@ -2377,9 +2397,9 @@ def test_planner_subtask_role_verify_sets_isolated(
 
     _wait_for_new_subagent_threads(initial_count, timeout=1.0)
 
-    new_agents = _subagents[initial_count:]
-    assert len(new_agents) == 1
-    sa = new_agents[0]
+    _, executors = _planner_children(initial_count, "test-verify-isolated")
+    assert len(executors) == 1
+    sa = executors[0]
     assert sa.isolated is True
 
 
@@ -2416,9 +2436,9 @@ def test_planner_subtask_role_verify_cleans_isolation_on_launch_failure(
     mock_run_subprocess.assert_called_once()
     mock_monitor.assert_not_called()
     mock_cleanup_isolation.assert_called_once()
-    new_agents = _subagents[initial_count:]
-    assert len(new_agents) == 1
-    assert new_agents[0].execution_mode == "subprocess"
+    _, executors = _planner_children(initial_count, "test-verify-launch-failure")
+    assert len(executors) == 1
+    assert executors[0].execution_mode == "subprocess"
 
 
 @patch("gptme.tools.subagent.execution._create_subagent_thread")
@@ -2441,9 +2461,9 @@ def test_planner_subtask_role_explore_uses_thread_mode(mock_create_thread: Magic
     # Thread backend used, not subprocess
     mock_create_thread.assert_called_once()
 
-    new_agents = _subagents[initial_count:]
-    assert len(new_agents) == 1
-    sa = new_agents[0]
+    _, executors = _planner_children(initial_count, "test-explore-thread")
+    assert len(executors) == 1
+    sa = executors[0]
     assert sa.execution_mode == "thread"
 
 
@@ -2482,9 +2502,9 @@ def test_planner_thread_mode_cleans_isolation_after_completion(
 
     mock_create_thread.assert_called_once()
     mock_cleanup_isolation.assert_called_once()
-    new_agents = _subagents[initial_count:]
-    assert len(new_agents) == 1
-    assert new_agents[0].isolated is True
+    _, executors = _planner_children(initial_count, "test-thread-isolated-cleanup")
+    assert len(executors) == 1
+    assert executors[0].isolated is True
 
 
 @patch("gptme.tools.subagent.execution._create_subagent_thread")
@@ -2506,9 +2526,9 @@ def test_planner_subtask_role_implement_uses_thread_mode(mock_create_thread: Mag
 
     mock_create_thread.assert_called_once()
 
-    new_agents = _subagents[initial_count:]
-    assert len(new_agents) == 1
-    sa = new_agents[0]
+    _, executors = _planner_children(initial_count, "test-impl-thread")
+    assert len(executors) == 1
+    sa = executors[0]
     assert sa.execution_mode == "thread"
 
 
@@ -2548,10 +2568,10 @@ def test_planner_mixed_roles_use_correct_backends(
     mock_run_subprocess.assert_called_once()
     mock_monitor.assert_called_once()
 
-    new_agents = _subagents[initial_count:]
-    assert len(new_agents) == 2
+    _, executors = _planner_children(initial_count, "test-mixed")
+    assert len(executors) == 2
 
-    by_id = {sa.agent_id: sa for sa in new_agents}
+    by_id = {sa.agent_id: sa for sa in executors}
     assert by_id["test-mixed-impl"].execution_mode == "thread"
     assert by_id["test-mixed-verify"].execution_mode == "subprocess"
 


### PR DESCRIPTION
## Summary

Implements gap #3 from the #554 subagent improvement audit: **conversation context forwarding**.

Subagents previously received only their isolated prompt with no awareness of what the parent agent had been doing. This PR adds an opt-in `context_turns=N` parameter to `subagent()` that forwards the last N turns of the parent's conversation as context to the subagent.

## Changes

- **`context_turns: int | None = None`** parameter on `subagent()` — forward the last N turns from the parent's active log. A "turn" starts at a user message and includes all subsequent assistant and tool-result (system) messages until the next user message, so the total message count per turn varies with the number of tool calls.
- Auto-fetches from `LogManager.get_current_log()` (the `ContextVar` set by the chat loop) — works transparently when called from within the `ipython` tool
- `_build_parent_context_message()` in `execution.py` formats parent messages as a system message with role headers and a note not to duplicate already-done work
- Injected into `initial_msgs` just before the completion instruction, after profile/memory messages
- Validates `context_turns > 0`; warns and passes `None` when no active `LogManager` is found
- Only applies to thread-mode subagents (subprocess/ACP run as separate processes)
- Turn slicing anchors to user message boundaries (via `user_indices`), not a fixed N×2 offset, correctly handling turns with multiple tool calls

## Example usage

```python
# Delegate with context: subagent knows what the parent already tried
subagent("impl", "Implement feature X (see parent context for prior attempts)", context_turns=5)
```

## Test plan

- [x] Unit tests in `TestParentContextForwarding`: message format, guidance text, zero/negative validation, missing-log warning, user-boundary slicing (with and without tool-result messages), system-bootstrap skip on fallback, `None` passthrough
- [x] All subagent unit tests pass
- [x] Pre-commit hooks pass (ruff, mypy, formatting)

Closes part of #554