### PR TITLE
feat(tools): annotate core built-in tools with hints metadata

### DIFF
--- a/gptme/tools/browser.py
+++ b/gptme/tools/browser.py
@@ -1061,5 +1061,6 @@ services with APIs, prefer shell or Python over scraping.""",
     ],
     available=has_browser_tool,
     init=init,
+    hints=frozenset({"web"}),
 )
 __doc__ = tool.get_doc(__doc__)

--- a/gptme/tools/browser.py
+++ b/gptme/tools/browser.py
@@ -1061,6 +1061,6 @@ services with APIs, prefer shell or Python over scraping.""",
     ],
     available=has_browser_tool,
     init=init,
-    hints=frozenset({"web"}),
+    hints=frozenset({"web", "destructive"}),
 )
 __doc__ = tool.get_doc(__doc__)

--- a/gptme/tools/patch.py
+++ b/gptme/tools/patch.py
@@ -424,5 +424,6 @@ tool = ToolSpec(
             required=True,
         ),
     ],
+    hints=frozenset({"file-ops", "destructive"}),
 )
 __doc__ = tool.get_doc(__doc__)

--- a/gptme/tools/python.py
+++ b/gptme/tools/python.py
@@ -467,5 +467,6 @@ tool = ToolSpec(
         ),
     ],
     load_priority=10,
+    hints=frozenset({"code-exec", "destructive"}),
 )
 __doc__ = tool.get_doc(__doc__)

--- a/gptme/tools/read.py
+++ b/gptme/tools/read.py
@@ -262,6 +262,7 @@ tool = ToolSpec(
             required=False,
         ),
     ],
+    hints=frozenset({"file-ops", "read-only"}),
     disabled_by_default=True,
 )
 __doc__ = tool.get_doc(__doc__)

--- a/gptme/tools/save.py
+++ b/gptme/tools/save.py
@@ -371,6 +371,7 @@ tool_save = ToolSpec(
             required=True,
         ),
     ],
+    hints=frozenset({"file-ops", "destructive"}),
 )
 __doc__ = tool_save.get_doc(__doc__)
 
@@ -396,5 +397,6 @@ tool_append = ToolSpec(
             required=True,
         ),
     ],
+    hints=frozenset({"file-ops", "destructive"}),
 )
 __doc__ = tool_append.get_doc(__doc__)

--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -1981,5 +1981,6 @@ tool = ToolSpec(
         "allowlist": ("tool.confirm", shell_allowlist_hook, 10),
         "session_end": ("session.end", _session_end_shell_cleanup, 0),
     },
+    hints=frozenset({"code-exec", "destructive"}),
 )
 __doc__ = tool.get_doc(__doc__)

--- a/tests/test_tools_base.py
+++ b/tests/test_tools_base.py
@@ -1279,3 +1279,66 @@ class TestToolPromptEdgeCases:
         prompt = tool.get_tool_prompt(examples=False, tool_format="xml")
         assert "<description>" not in prompt
         assert '<tool name="t">' in prompt
+
+
+# ── Built-in tool hint annotations ─────────────────────────────────
+
+
+class TestBuiltinToolHints:
+    """Verify that core built-in tools carry the expected hint tags."""
+
+    def test_read_tool_is_read_only(self):
+        from gptme.tools.read import tool
+
+        assert "read-only" in tool.hints
+        assert "file-ops" in tool.hints
+
+    def test_patch_tool_is_destructive(self):
+        from gptme.tools.patch import tool
+
+        assert "destructive" in tool.hints
+        assert "file-ops" in tool.hints
+
+    def test_save_tools_are_destructive(self):
+        from gptme.tools.save import tool_append, tool_save
+
+        for t in (tool_save, tool_append):
+            assert "destructive" in t.hints
+            assert "file-ops" in t.hints
+
+    def test_python_tool_hints(self):
+        from gptme.tools.python import tool
+
+        assert "code-exec" in tool.hints
+        assert "destructive" in tool.hints
+
+    def test_shell_tool_hints(self):
+        from gptme.tools.shell import tool
+
+        assert "code-exec" in tool.hints
+        assert "destructive" in tool.hints
+
+    def test_browser_tool_hint(self):
+        from gptme.tools.browser import tool
+
+        assert "web" in tool.hints
+
+    def test_hint_allowlist_selects_read_only_tools(self):
+        """hint:read-only should match read but not shell."""
+        from gptme.tools.read import tool as read_tool
+        from gptme.tools.shell import tool as shell_tool
+
+        tools = [read_tool, shell_tool]
+        result = matching_allowlist_tools("hint:read-only", tools)
+        assert read_tool in result
+        assert shell_tool not in result
+
+    def test_hint_allowlist_selects_code_exec_tools(self):
+        """hint:code-exec should match both ipython and shell."""
+        from gptme.tools.python import tool as py_tool
+        from gptme.tools.shell import tool as shell_tool
+
+        tools = [py_tool, shell_tool]
+        result = matching_allowlist_tools("hint:code-exec", tools)
+        assert py_tool in result
+        assert shell_tool in result

--- a/tests/test_tools_base.py
+++ b/tests/test_tools_base.py
@@ -1322,6 +1322,7 @@ class TestBuiltinToolHints:
         from gptme.tools.browser import tool
 
         assert "web" in tool.hints
+        assert "destructive" in tool.hints
 
     def test_hint_allowlist_selects_read_only_tools(self):
         """hint:read-only should match read but not shell."""


### PR DESCRIPTION
## Summary

- Adds `hints` frozenset tags to 7 core built-in `ToolSpec` instances so they can be filtered via `hint:` allowlist patterns
- Closes the annotation gap identified in #2890 (hints system merged 2026-06-14)

**Hints added:**

| Tool | Hints |
|------|-------|
| `ipython` | `code-exec`, `destructive` |
| `shell` | `code-exec`, `destructive` |
| `browser` | `web` |
| `read` | `file-ops`, `read-only` |
| `patch` | `file-ops`, `destructive` |
| `save` | `file-ops`, `destructive` |
| `append` | `file-ops`, `destructive` |

This enables allowlist configs like `hint:read-only` (select only read) or `hint:code-exec` (select both ipython and shell) without naming tools individually.

## Test plan

- [x] 8 new tests in `TestBuiltinToolHints` covering each annotation and hint-based `matching_allowlist_tools()` filtering
- [x] Existing 35 `test_tools.py` tests pass unchanged
- [x] All pre-commit hooks pass (ruff, mypy, etc.)