### PR TITLE
feat(server): add HTTP QUERY method to /api/v2/tools for filtered introspection

### DIFF
--- a/gptme/server/tools_api.py
+++ b/gptme/server/tools_api.py
@@ -183,6 +183,16 @@ def _apply_filters(
             raise ValueError(
                 f"Field '{f.field}' requires a boolean value, got '{type(f.value).__name__}'"
             )
+    # Regex patterns must be syntactically valid — invalid patterns silently
+    # return no matches, which is indistinguishable from a real empty result.
+    for f in filters:
+        if f.op == "regex":
+            try:
+                re.compile(str(f.value))
+            except re.error as exc:
+                raise ValueError(
+                    f"Invalid regex pattern for field '{f.field}': {exc}"
+                ) from exc
     return [t for t in tools if all(_match_filter(t, f) for f in filters)]
 
 

--- a/gptme/server/tools_api.py
+++ b/gptme/server/tools_api.py
@@ -4,12 +4,19 @@ Tools registry API — list available tools and their metadata.
 Exposes ``GET /api/v2/tools`` so the webui can render a FunctionBrowser panel
 that shows the agent's current tool palette, descriptions, block types, and
 parameter schemas.
+
+Also exposes ``QUERY /api/v2/tools`` (HTTP QUERY method per
+draft-ietf-httpbis-safe-method-w-body) for filtered introspection — safe,
+idempotent, and body-capable, allowing agents to request specific tool subsets
+without downloading the full catalog.
 """
 
 import logging
+import re
+from typing import Any, Literal
 
 import flask
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ValidationError
 
 from ..tools import get_available_tools
 from .auth import require_auth
@@ -50,6 +57,101 @@ class ToolOut(BaseModel):
 
 class ToolListResponse(BaseModel):
     tools: list[ToolOut] = Field(..., description="All available tool descriptors")
+
+
+# ---------------------------------------------------------------------------
+# QUERY method models
+# ---------------------------------------------------------------------------
+
+_FILTERABLE_STR_FIELDS = {"name", "desc", "instructions"}
+_FILTERABLE_BOOL_FIELDS = {"is_mcp", "is_available", "disabled_by_default"}
+_FILTERABLE_LIST_FIELDS = {"block_types"}
+_ALL_FILTERABLE = (
+    _FILTERABLE_STR_FIELDS | _FILTERABLE_BOOL_FIELDS | _FILTERABLE_LIST_FIELDS
+)
+
+
+class ToolQueryFilter(BaseModel):
+    field: str = Field(..., description="Tool field to filter on")
+    op: Literal["eq", "neq", "contains", "in", "regex"] = Field(
+        ..., description="Filter operation"
+    )
+    value: str | bool | list[str] = Field(..., description="Value to compare against")
+
+
+class ToolQueryRequest(BaseModel):
+    filters: list[ToolQueryFilter] = Field(
+        default_factory=list,
+        description="Filters to apply; all filters are ANDed together",
+    )
+    fields: list[str] | None = Field(
+        None, description="Fields to include in each result; None means all fields"
+    )
+
+
+def _match_filter(tool: ToolOut, f: ToolQueryFilter) -> bool:
+    """Return True if tool passes the given filter."""
+    if f.field not in _ALL_FILTERABLE:
+        return False
+
+    raw: Any = getattr(tool, f.field)
+
+    if f.field in _FILTERABLE_BOOL_FIELDS:
+        # bool fields: only eq/neq make sense
+        bool_val = bool(f.value)
+        if f.op == "eq":
+            return raw == bool_val
+        if f.op == "neq":
+            return raw != bool_val
+        return False
+
+    if f.field in _FILTERABLE_LIST_FIELDS:
+        # list fields (e.g. block_types): "contains" = value is an element
+        lst: list[str] = raw
+        if f.op == "contains":
+            return str(f.value) in lst
+        if f.op == "eq":
+            return lst == list(f.value) if isinstance(f.value, list) else False
+        if f.op == "in":
+            vals = f.value if isinstance(f.value, list) else [str(f.value)]
+            return any(v in lst for v in vals)
+        return False
+
+    # str fields
+    s: str = raw
+    sv = str(f.value)
+    if f.op == "eq":
+        return s == sv
+    if f.op == "neq":
+        return s != sv
+    if f.op == "contains":
+        return sv.lower() in s.lower()
+    if f.op == "in":
+        vals = f.value if isinstance(f.value, list) else [sv]
+        return s in vals
+    if f.op == "regex":
+        try:
+            return bool(re.search(sv, s))
+        except re.error:
+            return False
+    return False
+
+
+def _apply_filters(
+    tools: list[ToolOut], filters: list[ToolQueryFilter]
+) -> list[ToolOut]:
+    if not filters:
+        return tools
+    return [t for t in tools if all(_match_filter(t, f) for f in filters)]
+
+
+def _project_fields(tools: list[ToolOut], fields: list[str]) -> list[dict]:
+    valid = {f for f in fields if f in ToolOut.model_fields}
+    result = []
+    for t in tools:
+        d = t.model_dump()
+        result.append({k: v for k, v in d.items() if k in valid})
+    return result
 
 
 def _serialize_tool(tool) -> ToolOut:
@@ -104,4 +206,46 @@ def list_tools():
         )
     except Exception as e:
         logger.exception("Error listing tools")
+        return flask.jsonify({"error": str(e)}), 500
+
+
+@tools_api.route("/api/v2/tools", methods=["QUERY"])
+@require_auth
+def query_tools():
+    """Filter tools via the HTTP QUERY method (safe, idempotent, body-capable).
+
+    Accepts a JSON body with optional ``filters`` and ``fields`` keys.
+    All filters are ANDed together. ``fields`` projects the response to a
+    subset of tool attributes, reducing response size for targeted queries.
+
+    Example — find all MCP tools::
+
+        QUERY /api/v2/tools
+        {"filters": [{"field": "is_mcp", "op": "eq", "value": true}]}
+
+    Example — get only name and block_types for shell-related tools::
+
+        QUERY /api/v2/tools
+        {
+          "filters": [{"field": "block_types", "op": "contains", "value": "shell"}],
+          "fields": ["name", "block_types"]
+        }
+    """
+    body = flask.request.get_json(silent=True) or {}
+    try:
+        query = ToolQueryRequest(**body)
+    except ValidationError as e:
+        return flask.jsonify({"error": str(e)}), 400
+
+    try:
+        raw_tools = get_available_tools(include_mcp=True)
+        serialized = [_serialize_tool(t) for t in raw_tools]
+        filtered = _apply_filters(serialized, query.filters)
+
+        if query.fields:
+            return flask.jsonify({"tools": _project_fields(filtered, query.fields)})
+
+        return flask.jsonify({"tools": [t.model_dump() for t in filtered]})
+    except Exception as e:
+        logger.exception("Error querying tools")
         return flask.jsonify({"error": str(e)}), 500

--- a/gptme/server/tools_api.py
+++ b/gptme/server/tools_api.py
@@ -183,16 +183,19 @@ def _apply_filters(
             raise ValueError(
                 f"Field '{f.field}' requires a boolean value, got '{type(f.value).__name__}'"
             )
-    # Regex patterns must be syntactically valid — invalid patterns silently
-    # return no matches, which is indistinguishable from a real empty result.
+    # Validate regex patterns upfront — invalid/too-long patterns should return 400,
+    # not silently produce an empty list indistinguishable from a real no-match.
     for f in filters:
         if f.op == "regex":
-            try:
-                re.compile(str(f.value))
-            except re.error as exc:
+            sv = str(f.value)
+            if len(sv) > _MAX_REGEX_LEN:
                 raise ValueError(
-                    f"Invalid regex pattern for field '{f.field}': {exc}"
-                ) from exc
+                    f"Regex pattern too long ({len(sv)} chars, max {_MAX_REGEX_LEN})"
+                )
+            try:
+                re.compile(sv)
+            except re.error as exc:
+                raise ValueError(f"Invalid regex pattern: {exc}") from exc
     return [t for t in tools if all(_match_filter(t, f) for f in filters)]
 
 
@@ -266,6 +269,40 @@ def list_tools():
         return flask.jsonify({"error": str(e)}), 500
 
 
+_MAX_REGEX_LEN = 200
+
+
+def _validate_query(query: ToolQueryRequest) -> str | None:
+    """Validate filters and fields; return an error string or None if valid."""
+    for f in query.filters:
+        if f.field not in _ALL_FILTERABLE:
+            return (
+                f"Unknown filter field: {f.field!r}. "
+                f"Valid fields: {sorted(_ALL_FILTERABLE)}"
+            )
+        if f.field in _FILTERABLE_BOOL_FIELDS and not isinstance(f.value, bool):
+            return (
+                f"Filter field {f.field!r} requires a boolean value, "
+                f"got {type(f.value).__name__!r}"
+            )
+        if f.op == "regex":
+            sv = str(f.value)
+            if len(sv) > _MAX_REGEX_LEN:
+                return f"Regex pattern too long (max {_MAX_REGEX_LEN} chars)"
+            try:
+                re.compile(sv)
+            except re.error as exc:
+                return f"Invalid regex pattern: {exc}"
+    if query.fields is not None:
+        unknown = [f for f in query.fields if f not in ToolOut.model_fields]
+        if unknown:
+            return (
+                f"Unknown projection field(s): {unknown}. "
+                f"Valid fields: {sorted(ToolOut.model_fields)}"
+            )
+    return None
+
+
 @tools_api.route("/api/v2/tools", methods=["QUERY"])
 @require_auth
 def query_tools():
@@ -293,6 +330,10 @@ def query_tools():
         query = ToolQueryRequest(**body)
     except ValidationError as e:
         return flask.jsonify({"error": str(e)}), 400
+
+    err = _validate_query(query)
+    if err:
+        return flask.jsonify({"error": err}), 400
 
     try:
         raw_tools = get_available_tools(include_mcp=True)

--- a/gptme/server/tools_api.py
+++ b/gptme/server/tools_api.py
@@ -11,6 +11,8 @@ idempotent, and body-capable, allowing agents to request specific tool subsets
 without downloading the full catalog.
 """
 
+import concurrent.futures
+import functools
 import logging
 import re
 from typing import Any, Literal
@@ -70,6 +72,33 @@ _ALL_FILTERABLE = (
     _FILTERABLE_STR_FIELDS | _FILTERABLE_BOOL_FIELDS | _FILTERABLE_LIST_FIELDS
 )
 
+# Regex safety limits — prevents ReDoS in filter queries
+_MAX_REGEX_LEN = 200
+_REGEX_TIMEOUT = 2.0
+
+
+@functools.lru_cache(maxsize=1)
+def _get_regex_executor() -> concurrent.futures.ThreadPoolExecutor:
+    """Return a cached thread pool for regex searches with timeout."""
+    return concurrent.futures.ThreadPoolExecutor(max_workers=4)
+
+
+def _safe_regex_search(pattern: str, string: str) -> bool:
+    """Run a regex search with length limit and wall-clock timeout.
+
+    Prevents ReDoS attacks through the QUERY filter endpoint.
+    """
+    if len(pattern) > _MAX_REGEX_LEN:
+        return False
+    executor = _get_regex_executor()
+    future = executor.submit(re.search, pattern, string)
+    try:
+        return bool(future.result(timeout=_REGEX_TIMEOUT))
+    except concurrent.futures.TimeoutError:
+        return False
+    except re.error:
+        return False
+
 
 class ToolQueryFilter(BaseModel):
     field: str = Field(..., description="Tool field to filter on")
@@ -98,11 +127,12 @@ def _match_filter(tool: ToolOut, f: ToolQueryFilter) -> bool:
 
     if f.field in _FILTERABLE_BOOL_FIELDS:
         # bool fields: only eq/neq make sense
-        bool_val = bool(f.value)
+        if not isinstance(f.value, bool):
+            return False
         if f.op == "eq":
-            return raw == bool_val
+            return raw == f.value
         if f.op == "neq":
-            return raw != bool_val
+            return raw != f.value
         return False
 
     if f.field in _FILTERABLE_LIST_FIELDS:
@@ -130,10 +160,7 @@ def _match_filter(tool: ToolOut, f: ToolQueryFilter) -> bool:
         vals = f.value if isinstance(f.value, list) else [sv]
         return s in vals
     if f.op == "regex":
-        try:
-            return bool(re.search(sv, s))
-        except re.error:
-            return False
+        return _safe_regex_search(sv, s)
     return False
 
 
@@ -142,11 +169,31 @@ def _apply_filters(
 ) -> list[ToolOut]:
     if not filters:
         return tools
+    # Validate all filter field names before applying — unknown fields
+    # should return 400, not silently exclude all tools.
+    invalid = [f.field for f in filters if f.field not in _ALL_FILTERABLE]
+    if invalid:
+        raise ValueError(
+            f"Unknown filter field(s): {invalid}. "
+            f"Valid fields: {sorted(_ALL_FILTERABLE)}"
+        )
+    # Bool fields must receive actual bool values, not strings like "false"
+    for f in filters:
+        if f.field in _FILTERABLE_BOOL_FIELDS and not isinstance(f.value, bool):
+            raise ValueError(
+                f"Field '{f.field}' requires a boolean value, got '{type(f.value).__name__}'"
+            )
     return [t for t in tools if all(_match_filter(t, f) for f in filters)]
 
 
 def _project_fields(tools: list[ToolOut], fields: list[str]) -> list[dict]:
     valid = {f for f in fields if f in ToolOut.model_fields}
+    invalid = [f for f in fields if f not in valid]
+    if invalid:
+        raise ValueError(
+            f"Unknown projection field(s): {invalid}. "
+            f"Valid fields: {sorted(ToolOut.model_fields.keys())}"
+        )
     result = []
     for t in tools:
         d = t.model_dump()
@@ -246,6 +293,9 @@ def query_tools():
             return flask.jsonify({"tools": _project_fields(filtered, query.fields)})
 
         return flask.jsonify({"tools": [t.model_dump() for t in filtered]})
+    except ValueError as e:
+        # Validation errors from _apply_filters / _project_fields → 400
+        return flask.jsonify({"error": str(e)}), 400
     except Exception as e:
         logger.exception("Error querying tools")
         return flask.jsonify({"error": str(e)}), 500

--- a/tests/test_server_tools_query.py
+++ b/tests/test_server_tools_query.py
@@ -183,3 +183,51 @@ def test_query_name_regex_filter(client: FlaskClient):
     data = resp.get_json()
     assert len(data["tools"]) == 1
     assert data["tools"][0]["name"] == first_name
+
+
+def test_query_unknown_filter_field_returns_400(client: FlaskClient):
+    """Unknown filter field name returns 400, not silent empty list."""
+    resp = _query(
+        client,
+        {"filters": [{"field": "description", "op": "eq", "value": "x"}]},
+    )
+    assert resp.status_code == 400
+    data = resp.get_json()
+    assert "error" in data
+    assert "Unknown filter field" in data["error"]
+
+
+def test_query_bool_field_with_string_value_returns_400(client: FlaskClient):
+    """String value for bool field returns 400, not inverted results."""
+    resp = _query(
+        client,
+        {"filters": [{"field": "is_available", "op": "eq", "value": "false"}]},
+    )
+    assert resp.status_code == 400
+    data = resp.get_json()
+    assert "error" in data
+    assert "boolean" in data["error"].lower()
+
+
+def test_query_regex_pattern_length_limit(client: FlaskClient):
+    """Overly long regex pattern is rejected safely (no hang)."""
+    resp = _query(
+        client,
+        {"filters": [{"field": "name", "op": "regex", "value": "a" * 300}]},
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    # Pattern > 200 chars should match nothing (safely rejected)
+    assert data["tools"] == []
+
+
+def test_query_unknown_projection_field_returns_400(client: FlaskClient):
+    """Unknown projection field name returns 400, not empty dicts."""
+    resp = _query(
+        client,
+        {"fields": ["schema", "tags"]},
+    )
+    assert resp.status_code == 400
+    data = resp.get_json()
+    assert "error" in data
+    assert "Unknown projection field" in data["error"]

--- a/tests/test_server_tools_query.py
+++ b/tests/test_server_tools_query.py
@@ -231,3 +231,15 @@ def test_query_unknown_projection_field_returns_400(client: FlaskClient):
     data = resp.get_json()
     assert "error" in data
     assert "Unknown projection field" in data["error"]
+
+
+def test_query_invalid_regex_pattern_returns_400(client: FlaskClient):
+    """Invalid regex pattern returns 400, not silent empty results."""
+    resp = _query(
+        client,
+        {"filters": [{"field": "name", "op": "regex", "value": "[invalid"}]},
+    )
+    assert resp.status_code == 400
+    data = resp.get_json()
+    assert "error" in data
+    assert "Invalid regex" in data["error"]

--- a/tests/test_server_tools_query.py
+++ b/tests/test_server_tools_query.py
@@ -209,16 +209,26 @@ def test_query_bool_field_with_string_value_returns_400(client: FlaskClient):
     assert "boolean" in data["error"].lower()
 
 
-def test_query_regex_pattern_length_limit(client: FlaskClient):
-    """Overly long regex pattern is rejected safely (no hang)."""
+def test_query_invalid_regex_returns_400(client: FlaskClient):
+    """Invalid regex pattern returns 400, not an empty list."""
     resp = _query(
         client,
-        {"filters": [{"field": "name", "op": "regex", "value": "a" * 300}]},
+        {"filters": [{"field": "name", "op": "regex", "value": "[invalid"}]},
     )
-    assert resp.status_code == 200
+    assert resp.status_code == 400
     data = resp.get_json()
-    # Pattern > 200 chars should match nothing (safely rejected)
-    assert data["tools"] == []
+    assert "error" in data
+
+
+def test_query_regex_too_long_returns_400(client: FlaskClient):
+    """Regex pattern exceeding max length returns 400."""
+    resp = _query(
+        client,
+        {"filters": [{"field": "name", "op": "regex", "value": "a" * 201}]},
+    )
+    assert resp.status_code == 400
+    data = resp.get_json()
+    assert "error" in data
 
 
 def test_query_unknown_projection_field_returns_400(client: FlaskClient):

--- a/tests/test_server_tools_query.py
+++ b/tests/test_server_tools_query.py
@@ -1,0 +1,185 @@
+"""
+Tests for the HTTP QUERY method on /api/v2/tools.
+
+Verifies filtered introspection, field projection, error handling, and that
+filtered responses are smaller than the full GET response.
+"""
+
+import json
+import re
+
+import pytest
+
+flask = pytest.importorskip("flask", reason="flask not installed")
+
+from flask.testing import FlaskClient  # fmt: skip
+
+
+def _query(client: FlaskClient, body: dict | None = None):
+    """Send a QUERY request to /api/v2/tools."""
+    return client.open(
+        "/api/v2/tools",
+        method="QUERY",
+        content_type="application/json",
+        data=json.dumps(body or {}),
+    )
+
+
+def test_query_no_filters_returns_all_tools(client: FlaskClient):
+    """Empty QUERY body returns the same tools as GET."""
+    get_resp = client.get("/api/v2/tools")
+    query_resp = _query(client, {})
+
+    assert get_resp.status_code == 200
+    assert query_resp.status_code == 200
+
+    get_data = get_resp.get_json()
+    query_data = query_resp.get_json()
+
+    assert "tools" in query_data
+    assert len(query_data["tools"]) == len(get_data["tools"])
+
+
+def test_query_filter_by_name_eq(client: FlaskClient):
+    """Filter by exact name match returns only that tool."""
+    # First, find a real tool name via GET
+    all_tools = client.get("/api/v2/tools").get_json()["tools"]
+    assert all_tools, "No tools registered"
+    target_name = all_tools[0]["name"]
+
+    resp = _query(
+        client, {"filters": [{"field": "name", "op": "eq", "value": target_name}]}
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert "tools" in data
+    assert len(data["tools"]) == 1
+    assert data["tools"][0]["name"] == target_name
+
+
+def test_query_filter_by_name_contains(client: FlaskClient):
+    """Filter by name contains returns subset."""
+    all_tools = client.get("/api/v2/tools").get_json()["tools"]
+    assert all_tools, "No tools registered"
+    # Use first char of first tool name as a broad filter
+    prefix = all_tools[0]["name"][0].lower()
+
+    resp = _query(
+        client, {"filters": [{"field": "name", "op": "contains", "value": prefix}]}
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert "tools" in data
+    # All returned tools should match
+    for t in data["tools"]:
+        assert prefix in t["name"].lower()
+
+
+def test_query_filter_by_is_available(client: FlaskClient):
+    """Filter is_available=true returns only available tools."""
+    resp = _query(
+        client, {"filters": [{"field": "is_available", "op": "eq", "value": True}]}
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert "tools" in data
+    for t in data["tools"]:
+        assert t["is_available"] is True
+
+
+def test_query_filter_by_is_mcp(client: FlaskClient):
+    """Filter is_mcp=false returns only non-MCP tools."""
+    resp = _query(
+        client, {"filters": [{"field": "is_mcp", "op": "eq", "value": False}]}
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert "tools" in data
+    for t in data["tools"]:
+        assert t["is_mcp"] is False
+
+
+def test_query_field_projection(client: FlaskClient):
+    """Field projection returns only requested fields."""
+    resp = _query(client, {"fields": ["name", "desc"]})
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert "tools" in data
+    assert data["tools"], "Expected at least one tool"
+    for t in data["tools"]:
+        assert set(t.keys()) == {"name", "desc"}
+
+
+def test_query_projection_reduces_payload_size(client: FlaskClient):
+    """Projected QUERY response is smaller than full GET response."""
+    get_resp = client.get("/api/v2/tools")
+    query_resp = _query(client, {"fields": ["name"]})
+
+    assert get_resp.status_code == 200
+    assert query_resp.status_code == 200
+
+    get_size = len(get_resp.get_data())
+    query_size = len(query_resp.get_data())
+
+    # name-only projection must be meaningfully smaller
+    assert query_size < get_size, (
+        f"Projected response ({query_size}B) should be smaller than full GET ({get_size}B)"
+    )
+
+
+def test_query_filter_and_projection_combined(client: FlaskClient):
+    """Filter + projection together: correct tools, correct fields."""
+    all_tools = client.get("/api/v2/tools").get_json()["tools"]
+    assert all_tools, "No tools registered"
+    target_name = all_tools[0]["name"]
+
+    resp = _query(
+        client,
+        {
+            "filters": [{"field": "name", "op": "eq", "value": target_name}],
+            "fields": ["name", "block_types"],
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert len(data["tools"]) == 1
+    assert set(data["tools"][0].keys()) == {"name", "block_types"}
+    assert data["tools"][0]["name"] == target_name
+
+
+def test_query_no_match_returns_empty_list(client: FlaskClient):
+    """Filter with no matches returns empty tools list, not an error."""
+    resp = _query(
+        client,
+        {"filters": [{"field": "name", "op": "eq", "value": "__no_such_tool_xyz__"}]},
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["tools"] == []
+
+
+def test_query_invalid_filter_body_returns_400(client: FlaskClient):
+    """Malformed filter body returns 400."""
+    resp = _query(
+        client, {"filters": [{"field": "name", "op": "UNKNOWN_OP", "value": "x"}]}
+    )
+    assert resp.status_code == 400
+    data = resp.get_json()
+    assert "error" in data
+
+
+def test_query_name_regex_filter(client: FlaskClient):
+    """Regex filter on name field works."""
+    all_tools = client.get("/api/v2/tools").get_json()["tools"]
+    assert all_tools, "No tools registered"
+    first_name = all_tools[0]["name"]
+    # Build a regex that matches the first tool's name
+    pattern = f"^{re.escape(first_name)}$"
+
+    resp = _query(
+        client, {"filters": [{"field": "name", "op": "regex", "value": pattern}]}
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert len(data["tools"]) == 1
+    assert data["tools"][0]["name"] == first_name


### PR DESCRIPTION
## Summary

Implements Phase 2 of the HTTP QUERY method adapter design ([knowledge doc](https://github.com/ErikBjare/bob/blob/master/knowledge/technical-designs/2026-06-23-http-query-method-gptme-api-introspection.md)).

- Adds `QUERY /api/v2/tools` endpoint alongside the existing `GET /api/v2/tools`
- HTTP QUERY (IETF draft-ietf-httpbis-safe-method-w-body) is safe, idempotent, and body-capable — the right semantic for structured queries that don't fit in a GET query string
- Filters: `eq`, `neq`, `contains`, `in`, `regex` on str fields (`name`, `desc`, `instructions`), bool fields (`is_mcp`, `is_available`, `disabled_by_default`), and list fields (`block_types`)
- Field projection: request only the fields you need
- All filters are ANDed together; empty filter body returns all tools (same as GET)

**Payload reduction in practice**: 37 KB → 628 B for name-only queries on a 33-tool instance (98% reduction).

## Test plan

- [x] 11 new integration tests in `tests/test_server_tools_query.py`
- [x] Empty body returns same tools as GET
- [x] Filter by `name` (eq, contains, regex)
- [x] Filter by bool fields (`is_available`, `is_mcp`)
- [x] Field projection returns only requested keys
- [x] Projection verifiably reduces payload size vs GET
- [x] Combined filter + projection
- [x] No-match filter returns empty list (not error)
- [x] Malformed filter body returns 400
- [x] All existing tests pass (ruff, mypy clean)