### PR TITLE
fix(test): use infinite iterator for monotonic mock to avoid StopIteration

### DIFF
--- a/tests/test_tools_computer.py
+++ b/tests/test_tools_computer.py
@@ -1184,8 +1184,11 @@ def test_wait_for_change_polls_with_backoff(mock_transport, mock_res, tmp_path):
         sleep_calls.append(interval)
 
     # Expire the loop on the 4th poll so we get 3 sleep calls and see the backoff
-    monotonic_values = [0.0, 0.0, 0.0, 0.0, 100.0]
-    monotonic_iter = iter(monotonic_values)
+    # Use an infinite tail (repeat(100.0)) to avoid StopIteration inside a generator
+    # (PEP 479: StopIteration raised in a generator becomes RuntimeError)
+    import itertools
+
+    monotonic_iter = itertools.chain([0.0, 0.0, 0.0, 0.0], itertools.repeat(100.0))
 
     with (
         mock.patch("gptme.tools.computer.screenshot", return_value=static),

--- a/tests/test_tools_computer.py
+++ b/tests/test_tools_computer.py
@@ -1,5 +1,6 @@
 """Tests for the computer tool."""
 
+import itertools
 import shutil
 import subprocess
 from typing import Any, cast
@@ -1186,8 +1187,6 @@ def test_wait_for_change_polls_with_backoff(mock_transport, mock_res, tmp_path):
     # Expire the loop on the 4th poll so we get 3 sleep calls and see the backoff
     # Use an infinite tail (repeat(100.0)) to avoid StopIteration inside a generator
     # (PEP 479: StopIteration raised in a generator becomes RuntimeError)
-    import itertools
-
     monotonic_iter = itertools.chain([0.0, 0.0, 0.0, 0.0], itertools.repeat(100.0))
 
     with (


### PR DESCRIPTION
## Summary

- Fixes `test_wait_for_change_polls_with_backoff` which was failing with `RuntimeError: generator raised StopIteration`
- Root cause: PEP 479 (Python 3.7+) converts `StopIteration` raised inside a generator context into `RuntimeError`. The test used `iter([0.0, 0.0, 0.0, 0.0, 100.0])` which exhausted on the 6th `next()` call — hitting this exactly because `time.monotonic`'s `side_effect=lambda: next(monotonic_iter)` is a generator-adjacent callsite.
- Fix: replace with `itertools.chain([0.0, 0.0, 0.0, 0.0], itertools.repeat(100.0))` — the infinite tail means the iterator never exhausts, so `StopIteration` is never raised.

## Test plan

- [x] `pytest tests/test_tools_computer.py::test_wait_for_change_polls_with_backoff` passes locally