### PR TITLE
fix(computer): register observe_web/observe_desktop as ToolFunctions + handle list[Message] in ipython

### DIFF
--- a/gptme/tools/computer.py
+++ b/gptme/tools/computer.py
@@ -1292,6 +1292,19 @@ varies across sessions or virtual displays.
 
 Note: Key names are automatically mapped between platforms.
 Common modifiers (ctrl, alt, cmd/super, shift) work consistently across platforms.
+
+### Observation helpers (structured-first policy)
+
+Two higher-level helpers are available that implement the structured-first observation policy:
+
+- ``observe_web(url, screenshot_too=False)`` — observe a web page using ARIA snapshots first
+  (no vision tokens), with automatic fallback to a browser screenshot, then desktop screenshot.
+  Pass ``screenshot_too=True`` to get both an ARIA snapshot AND a screenshot side by side.
+- ``observe_desktop()`` — thin wrapper around ``computer('screenshot')`` that signals intent
+  clearly for native apps and non-browser surfaces.
+
+These helpers are preferred over calling ``computer("screenshot")`` directly when observing
+web pages, because ARIA snapshots avoid costly vision tokens and give a DOM-addressable tree.
 """
 
 
@@ -1446,6 +1459,21 @@ System: Focused window matching: 'Terminal'
 System: Typed text: ls -la
 {ToolUse("ipython", [], 'computer("key", text="return")').to_output(tool_format)}
 System: Sent key sequence: return
+
+User: Read the content of https://news.ycombinator.com
+Assistant: I'll use observe_web to get a structured ARIA snapshot of the page — faster and cheaper than a screenshot.
+{ToolUse("ipython", [], 'observe_web("https://news.ycombinator.com")').to_output(tool_format)}
+System: [ARIA snapshot of Hacker News front page...]
+
+User: Check what's on my desktop right now
+Assistant: I'll capture a screenshot of the desktop.
+{ToolUse("ipython", [], "observe_desktop()").to_output(tool_format)}
+System: Viewing image...
+
+User: Navigate to https://example.com and verify both the text content and visual layout
+Assistant: I'll use observe_web with screenshot_too=True to get both the ARIA snapshot and a screenshot.
+{ToolUse("ipython", [], 'observe_web("https://example.com", screenshot_too=True)').to_output(tool_format)}
+System: [ARIA snapshot + screenshot of example.com]
 """
 
     # Platform-specific keyboard shortcut examples
@@ -1478,7 +1506,11 @@ tool = ToolSpec(
     desc="Control the computer through X11 (keyboard, mouse, screen)",
     instructions=instructions,
     examples=examples,
-    functions=[ToolFunction.from_callable(computer)],
+    functions=[
+        ToolFunction.from_callable(computer),
+        ToolFunction.from_callable(observe_web),
+        ToolFunction.from_callable(observe_desktop),
+    ],
     disabled_by_default=True,
 )
 

--- a/gptme/tools/python.py
+++ b/gptme/tools/python.py
@@ -283,6 +283,10 @@ def execute_python(
     ):
         yield from result.result
         return
+    # Empty list — return a clear message instead of confusing repr output
+    if isinstance(result.result, list) and not result.result:
+        yield Message("system", "No results returned.")
+        return
 
     if result.result is not None:
         # show stdout before result if both exist

--- a/gptme/tools/python.py
+++ b/gptme/tools/python.py
@@ -279,11 +279,7 @@ def execute_python(
         yield result.result
         return
     if isinstance(result.result, list):
-        if not result.result:
-            # Empty list — return a clear message instead of confusing repr output
-            yield Message("system", "No results returned.")
-            return
-        if all(isinstance(m, Message) for m in result.result):
+        if result.result and all(isinstance(m, Message) for m in result.result):
             yield from result.result
             return
 

--- a/gptme/tools/python.py
+++ b/gptme/tools/python.py
@@ -282,6 +282,7 @@ def execute_python(
         if result.result and all(isinstance(m, Message) for m in result.result):
             yield from result.result
             return
+        # empty list or non-Message list falls through to repr output below
 
     if result.result is not None:
         # show stdout before result if both exist

--- a/gptme/tools/python.py
+++ b/gptme/tools/python.py
@@ -274,9 +274,16 @@ def execute_python(
 
     output = ""
     # TODO: should we include captured stdout with messages like these?
-    # used by vision tool
+    # used by vision tool and observe helpers
     if isinstance(result.result, Message):
         yield result.result
+        return
+    if (
+        isinstance(result.result, list)
+        and result.result
+        and isinstance(result.result[0], Message)
+    ):
+        yield from result.result
         return
 
     if result.result is not None:

--- a/gptme/tools/python.py
+++ b/gptme/tools/python.py
@@ -278,15 +278,14 @@ def execute_python(
     if isinstance(result.result, Message):
         yield result.result
         return
-    if isinstance(result.result, list) and all(
-        isinstance(m, Message) for m in result.result
-    ):
-        yield from result.result
-        return
-    # Empty list — return a clear message instead of confusing repr output
-    if isinstance(result.result, list) and not result.result:
-        yield Message("system", "No results returned.")
-        return
+    if isinstance(result.result, list):
+        if not result.result:
+            # Empty list — return a clear message instead of confusing repr output
+            yield Message("system", "No results returned.")
+            return
+        if all(isinstance(m, Message) for m in result.result):
+            yield from result.result
+            return
 
     if result.result is not None:
         # show stdout before result if both exist

--- a/gptme/tools/python.py
+++ b/gptme/tools/python.py
@@ -278,10 +278,8 @@ def execute_python(
     if isinstance(result.result, Message):
         yield result.result
         return
-    if (
-        isinstance(result.result, list)
-        and result.result
-        and isinstance(result.result[0], Message)
+    if isinstance(result.result, list) and all(
+        isinstance(m, Message) for m in result.result
     ):
         yield from result.result
         return

--- a/tests/test_server_metrics.py
+++ b/tests/test_server_metrics.py
@@ -8,12 +8,8 @@ flask = pytest.importorskip(
 
 
 @pytest.fixture()
-def metrics_client(tmp_path):
+def metrics_client():
     """Flask test client with metrics enabled."""
-    import sys
-
-    sys.path.insert(0, str(tmp_path))  # ensure worktree takes precedence
-
     from gptme.server.app import create_app
 
     app = create_app()

--- a/tests/test_tools_python.py
+++ b/tests/test_tools_python.py
@@ -331,9 +331,13 @@ from gptme.message import Message
 def test_execute_python_returns_empty_list_falls_through_to_repr():
     """Empty list should fall through to the normal repr path, showing 'Result: []'.
 
-    An empty list is NOT treated as list[Message] — it falls through to the
-    existing repr branch so the LLM sees 'Result: []', preserving a meaningful
-    empty-result signal for general IPython cells like '[x for x in items if x>0]'.
+    An empty list from any computation — whether from observe_web returning no
+    results or a regular list comprehension filtering to nothing — should show
+    the LLM a clear 'Result: []' rather than silent no-output (which hides
+    information) or a potentially misleading 'No results returned.' message.
+
+    The list[Message] fast-path only activates for non-empty lists where every
+    item is a Message; empty lists fall through to the normal repr output.
     """
     code = """\
 from gptme.message import Message
@@ -342,7 +346,7 @@ from gptme.message import Message
     msgs = list(execute_python(code, [], None))
     assert len(msgs) == 1, f"Expected 1 repr message for empty list, got: {msgs}"
     assert "[]" in msgs[0].content, (
-        f"Expected '[]' in repr output, got: {msgs[0].content}"
+        f"Expected '[]' in repr output, got: {msgs[0].content!r}"
     )
 
 

--- a/tests/test_tools_python.py
+++ b/tests/test_tools_python.py
@@ -328,20 +328,21 @@ from gptme.message import Message
     assert msgs[1].content == "msg2"
 
 
-def test_execute_python_returns_empty_list_of_messages():
-    """Empty list[Message] (e.g. observe_web failure) should produce no output.
+def test_execute_python_returns_empty_list_falls_through_to_repr():
+    """Empty list should fall through to the normal repr path, showing 'Result: []'.
 
-    Without this, the LLM sees confusing 'Result:\n```\n[]\n```' output instead
-    of clean silence. We verify no output is yielded and crucially that the output
-    does NOT contain a repr of [].
+    An empty list is NOT treated as list[Message] — it falls through to the
+    existing repr branch so the LLM sees 'Result: []', preserving a meaningful
+    empty-result signal for general IPython cells like '[x for x in items if x>0]'.
     """
     code = """\
 from gptme.message import Message
 [m for m in [] if isinstance(m, Message)]  # evaluates to []
 """
     msgs = list(execute_python(code, [], None))
-    assert len(msgs) == 0 or (len(msgs) == 1 and "[]" not in msgs[0].content), (
-        f"Expected no confusing [] repr, got: {msgs}"
+    assert len(msgs) == 1, f"Expected 1 repr message for empty list, got: {msgs}"
+    assert "[]" in msgs[0].content, (
+        f"Expected '[]' in repr output, got: {msgs[0].content}"
     )
 
 

--- a/tests/test_tools_python.py
+++ b/tests/test_tools_python.py
@@ -306,3 +306,23 @@ def test_execute_python_no_plot_no_artifact(tmp_path):
 
     artifacts = (msg.metadata or {}).get("artifacts", [])
     assert artifacts == []
+
+
+def test_execute_python_returns_list_of_messages():
+    """execute_python yields each Message when a list[Message] is returned.
+
+    This is the key integration needed for observe_web() which returns
+    list[Message] (ARIA snapshot + optional screenshot). Without this fix,
+    observe_web() results would be shown as repr(list) instead of each
+    message being delivered to the conversation.
+    """
+
+    code = """\
+from gptme.message import Message
+[Message("system", "msg1"), Message("system", "msg2")]
+"""
+    msgs = list(execute_python(code, [], None))
+    # Both messages should be yielded, not collapsed into a repr string
+    assert len(msgs) == 2, f"Expected 2 messages, got {len(msgs)}: {msgs}"
+    assert msgs[0].content == "msg1"
+    assert msgs[1].content == "msg2"

--- a/tests/test_tools_python.py
+++ b/tests/test_tools_python.py
@@ -326,3 +326,36 @@ from gptme.message import Message
     assert len(msgs) == 2, f"Expected 2 messages, got {len(msgs)}: {msgs}"
     assert msgs[0].content == "msg1"
     assert msgs[1].content == "msg2"
+
+
+def test_execute_python_returns_empty_list_of_messages():
+    """Empty list[Message] (e.g. observe_web failure) should produce no output.
+
+    Without this, the LLM sees confusing 'Result:\n```\n[]\n```' output instead
+    of clean silence. We verify no output is yielded and crucially that the output
+    does NOT contain a repr of [].
+    """
+    code = """\
+from gptme.message import Message
+[m for m in [] if isinstance(m, Message)]  # evaluates to []
+"""
+    msgs = list(execute_python(code, [], None))
+    assert len(msgs) == 0 or (len(msgs) == 1 and "[]" not in msgs[0].content), (
+        f"Expected no confusing [] repr, got: {msgs}"
+    )
+
+
+def test_execute_python_returns_mixed_list_falls_through():
+    """A mixed list (Message + non-Message) should NOT yield from; show as repr.
+
+    A type guard checking only result[0] would incorrectly yield the non-Message
+    items, violating the generator's return type. The all() check prevents this.
+    """
+    code = """\
+from gptme.message import Message
+[Message("system", "real"), "not-a-message"]
+"""
+    msgs = list(execute_python(code, [], None))
+    # Should fall through to repr output, not yield 2 items of mixed type
+    assert len(msgs) == 1, f"Expected 1 repr output message, got {len(msgs)}: {msgs}"
+    assert "not-a-message" in msgs[0].content


### PR DESCRIPTION
## Problem

`observe_web()` and `observe_desktop()` were added to `computer.py` (merged PR #3011) but had two critical gaps that made them unreachable in practice:

1. **Not registered in ToolSpec.functions** — they weren't auto-imported into the IPython namespace when `--tools +computer` is active. The LLM had no way to discover or call them without an explicit `from gptme.tools.computer import observe_web` import, which the model wouldn't know to write.

2. **`execute_python` only yielded single `Message`, not `list[Message]`** — `observe_web()` returns `list[Message]` (ARIA snapshot + optional screenshot), but the IPython execution path only handled `isinstance(result.result, Message)`. A `list[Message]` return showed up as `repr(list)` in the conversation output instead of each message being delivered.

Together: the LLM couldn't call `observe_web()`, and even if it did, the results wouldn't show up properly.

## Fix

**`gptme/tools/computer.py`**:
- Add `observe_web` and `observe_desktop` to `ToolSpec.functions`. They now appear in the `Available functions:` hint shown to the LLM and are auto-imported into the IPython namespace — the model can call `observe_web(url)` directly, no imports needed.
- Add examples showing `observe_web` and `observe_desktop` usage in the `examples()` function.
- Extend `instructions` to mention these helpers and the structured-first policy they implement.

**`gptme/tools/python.py`**:
- Handle `list[Message]` returns in `execute_python`: when the IPython cell returns a list whose first element is a `Message`, `yield from` each item. This is the fix that makes `observe_web()` actually deliver the ARIA snapshot (and optional screenshot) to the LLM conversation.

**`tests/test_tools_python.py`**:
- Add `test_execute_python_returns_list_of_messages` regression test that verifies both messages are yielded when a function returns `list[Message]`.

## Verification

```
uv run pytest tests/test_computer_actions.py tests/test_tools_python.py -v
# 39 passed
```

Closes part of #216.