### PR TITLE
fix(cli): re-raise ClickException before catch-all to preserve exit codes

### DIFF
--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -1183,6 +1183,8 @@ def main(
             output_format,
         )
         show_resume_hint_on_exit = True
+    except click.ClickException:
+        raise
     except (RuntimeError, Exception) as e:
         logger.error("Fatal error occurred")
         if verbose:


### PR DESCRIPTION
## Problem

The catch-all handler at `gptme/cli/main.py:1186` catches `(RuntimeError, Exception)`. If any code path inside `chat()` raises `click.UsageError` (or any `click.ClickException`), it exits with code 1 instead of Click's expected code 2 for `UsageError`.

## Fix

Add a guard clause before the catch-all to re-raise `click.ClickException`, letting Click's own exception handler set the proper exit code:

```python
except click.ClickException:
    raise  # Let Click handle with proper exit code (2 for UsageError)
except (RuntimeError, Exception) as e:
    ...
```

## Testing

The fix is a two-line guard clause that follows the standard Click exception handling pattern. Full integration testing would require mocking `chat()` to raise `UsageError`, which is complex for a rare edge case — the fix's correctness is evident from Click's documented behavior (`UsageError.show()` + `sys.exit(2)`).