### PR TITLE
fix(cli): re-raise ClickException before catch-all so UsageError exits 2

### DIFF
--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -1183,6 +1183,8 @@ def main(
             output_format,
         )
         show_resume_hint_on_exit = True
+    except click.ClickException:
+        raise  # let Click handle proper exit code (2 for UsageError)
     except (RuntimeError, Exception) as e:
         logger.error("Fatal error occurred")
         if verbose:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1527,3 +1527,34 @@ def test_non_python_custom_tool_path_reports_suffix_before_existence(
     assert "stdin is not a TTY and prompts provided" not in result.output
     assert "Using project configuration" not in result.output
     assert "Using local configuration" not in result.output
+
+
+def test_click_exception_inside_chat_exits_2(
+    tmp_path: Path, monkeypatch, runner: CliRunner
+):
+    """ClickException raised inside chat() must propagate as exit code 2, not 1.
+
+    Regression guard for the except clause ordering fix: before the fix,
+    `except (RuntimeError, Exception)` swallowed ClickException and always
+    exited 1; after the fix `except click.ClickException: raise` runs first.
+    """
+    # Use a pre-existing conversation so get_prompt() is skipped (no LLM call)
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
+    logdir = tmp_path / "test-conv-exit2"
+    logdir.mkdir(parents=True)
+    (logdir / "conversation.jsonl").write_text('{"role":"user","content":"hello"}\n')
+
+    monkeypatch.setattr(cli, "get_logdir", lambda name: logdir)
+    monkeypatch.setattr(cli, "init_telemetry", lambda **kwargs: None)
+
+    def _raise_usage_error(*args, **kwargs):
+        raise click.UsageError("simulated usage error from inside chat")
+
+    monkeypatch.setattr(cli, "chat", _raise_usage_error)
+
+    result = runner.invoke(
+        cli.main, ["--name", "test-conv-exit2", "--non-interactive", "hello"]
+    )
+
+    assert result.exit_code == 2, result.output
+    assert "Fatal error occurred" not in result.output


### PR DESCRIPTION
## Summary

- The chat-loop `except (RuntimeError, Exception)` catch-all swallowed `click.ClickException` (including `UsageError`) raised inside `chat()`, always producing exit code 1 instead of Click's standard exit code 2.
- Add `except click.ClickException: raise` before the catch-all so Click's own error handler takes over and returns the correct exit code.
- Add a regression test that simulates a `UsageError` from inside `chat()` and asserts `exit_code == 2` and no spurious "Fatal error occurred" log noise.

## What changed

- `gptme/cli/main.py`: two-line guard inserted before `except (RuntimeError, Exception)`
- `tests/test_cli.py`: new `test_click_exception_inside_chat_exits_2` test

## Test plan

- [ ] `pytest tests/test_cli.py::test_click_exception_inside_chat_exits_2` passes (confirmed locally)
- [ ] `pytest tests/test_cli.py -k "exit"` — all 3 exit-code tests pass (confirmed locally)
- [ ] CI green