### PR TITLE
fix(webui): guard provider-health and user-settings hooks on isConnected

### DIFF
--- a/webui/src/components/settings/__tests__/ServerProviderHealthSettings.test.tsx
+++ b/webui/src/components/settings/__tests__/ServerProviderHealthSettings.test.tsx
@@ -1,8 +1,10 @@
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { observable } from '@legendapp/state';
 import { ServerProviderHealthSettings } from '../ServerProviderHealthSettings';
 
 const mockFetch = jest.fn();
+const isConnected$ = observable(true);
 
 jest.mock('@/contexts/ApiContext', () => ({
   useApi: () => ({
@@ -10,6 +12,7 @@ jest.mock('@/contexts/ApiContext', () => ({
       baseUrl: 'http://127.0.0.1:5700',
       authHeader: 'Bearer test-token',
     },
+    isConnected$,
   }),
 }));
 

--- a/webui/src/hooks/__tests__/demoModeHooks.test.tsx
+++ b/webui/src/hooks/__tests__/demoModeHooks.test.tsx
@@ -71,4 +71,18 @@ describe('demo-mode hooks', () => {
     expect(result.current.error).toBeNull();
     expect(mockFetch).not.toHaveBeenCalled();
   });
+
+  it('useUserSettings does not fetch when not in demo mode and not connected', async () => {
+    mockIsDemoMode.mockReturnValue(false);
+
+    const { result } = renderHook(() => useUserSettings());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.settings).toBeNull();
+    expect(result.current.error).toBeNull();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
 });

--- a/webui/src/hooks/__tests__/demoModeHooks.test.tsx
+++ b/webui/src/hooks/__tests__/demoModeHooks.test.tsx
@@ -1,10 +1,14 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
+import { observable } from '@legendapp/state';
 import { useProviderHealth } from '../useProviderHealth';
 import { useUserSettings } from '../useUserSettings';
 import { providerHealth$ } from '@/stores/providerHealth';
 
 const mockFetch = jest.fn();
 const mockIsDemoMode = jest.fn();
+// Created at module scope so it can be referenced inside the jest.mock() factory
+// (jest.mock() is hoisted before imports, but factory closures evaluate lazily).
+const isConnected$ = observable(false);
 
 jest.mock('@/contexts/ApiContext', () => ({
   useApi: () => ({
@@ -12,6 +16,7 @@ jest.mock('@/contexts/ApiContext', () => ({
       baseUrl: 'demo://offline',
       authHeader: null,
     },
+    isConnected$,
   }),
 }));
 

--- a/webui/src/hooks/useProviderHealth.ts
+++ b/webui/src/hooks/useProviderHealth.ts
@@ -13,7 +13,8 @@ export const POLL_INTERVAL_MS = 30_000;
  * while the calling component is mounted.
  */
 export function useProviderHealth(poll = false) {
-  const { api } = useApi();
+  const { api, isConnected$ } = useApi();
+  const isConnected = use$(isConnected$);
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const demoMode = isDemoMode();
 
@@ -51,6 +52,13 @@ export function useProviderHealth(poll = false) {
   );
 
   useEffect(() => {
+    // Don't make requests until connected — avoids LNA/CORS errors on hosted
+    // pages (e.g. chat.gptme.org) that would try http://127.0.0.1:5700 before
+    // any server is confirmed reachable.
+    if (!demoMode && !isConnected) {
+      providerHealth$.isLoading.set(false);
+      return;
+    }
     void fetchHealth();
     if (!demoMode && poll) {
       intervalRef.current = setInterval(() => void fetchHealth(), POLL_INTERVAL_MS);
@@ -61,7 +69,7 @@ export function useProviderHealth(poll = false) {
         intervalRef.current = null;
       }
     };
-  }, [demoMode, fetchHealth, poll]);
+  }, [demoMode, fetchHealth, isConnected, poll]);
 
   const data = use$(providerHealth$.data);
   const isLoading = use$(providerHealth$.isLoading);

--- a/webui/src/hooks/useUserSettings.ts
+++ b/webui/src/hooks/useUserSettings.ts
@@ -55,8 +55,8 @@ export function useUserSettings() {
     }
     const controller = new AbortController();
 
+    setIsLoading(true);
     const fetchSettings = async () => {
-      setIsLoading(true);
       setError(null);
       try {
         const headers: Record<string, string> = {};

--- a/webui/src/hooks/useUserSettings.ts
+++ b/webui/src/hooks/useUserSettings.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
+import { use$ } from '@legendapp/state/react';
 import { useApi } from '@/contexts/ApiContext';
 import { isDemoMode } from '@/utils/connectionConfig';
 
@@ -31,7 +32,8 @@ const DEMO_USER_SETTINGS: UserSettings = {
 };
 
 export function useUserSettings() {
-  const { api } = useApi();
+  const { api, isConnected$ } = useApi();
+  const isConnected = use$(isConnected$);
   const [settings, setSettings] = useState<UserSettings | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -41,6 +43,13 @@ export function useUserSettings() {
     if (isDemoMode()) {
       setSettings(DEMO_USER_SETTINGS);
       setError(null);
+      setIsLoading(false);
+      return;
+    }
+    // Don't fetch until connected — avoids LNA/CORS errors on hosted pages
+    // (e.g. chat.gptme.org) that would otherwise hit http://127.0.0.1:5700
+    // before any server is confirmed reachable.
+    if (!isConnected) {
       setIsLoading(false);
       return;
     }
@@ -74,7 +83,7 @@ export function useUserSettings() {
 
     void fetchSettings();
     return () => controller.abort();
-  }, [api.baseUrl, api.authHeader, refetchKey]);
+  }, [api.baseUrl, api.authHeader, isConnected, refetchKey]);
 
   const refetch = useCallback(() => setRefetchKey((k) => k + 1), []);
 


### PR DESCRIPTION
## Summary

- **Root cause**: `useProviderHealth` and `useUserSettings` fired fetch requests on mount unconditionally — no guard on whether a server connection had been established
- **Symptom**: Visiting `chat.gptme.org` as a new user produced Chrome LNA (Local Network Access / Private Network Access) CORS errors:
  ```
  Access to fetch at 'http://127.0.0.1:5700/api/v2/providers/health' from origin 'https://chat.gptme.org' has been blocked by CORS policy: Permission was denied for this request to access the `loopback` address space.
  ```
- **Fix**: Both hooks now check `isConnected` (from `ApiContext.isConnected$`) before fetching; requests only fire after connection is confirmed

`ApiContext` already had `shouldSkipHostedLoopbackAutoConnect` to prevent *auto-connect* from making loopback requests on hosted pages — but the provider-health and user-settings hooks bypassed that guard entirely since they fetch directly from their own `useEffect`.

## Verification

Dogfooded `chat.gptme.org` with Playwright before and after. Before fix, on every fresh page load:
```
FAILED GET http://127.0.0.1:5700/api/v2/providers/health → net::ERR_FAILED
FAILED GET http://127.0.0.1:5700/api/v2/user/settings → net::ERR_FAILED
```
After fix, no loopback requests fire until a server connection is established.

## Test plan

- [x] `ServerProviderHealthSettings.test.tsx` — existing tests updated with `isConnected$: observable(true)` mock; still verify fetch fires when connected
- [x] `demoModeHooks.test.tsx` — existing demo-mode tests updated with `isConnected$: observable(false)`; still verify no fetch in demo mode
- [x] Full webui test suite: 501/501 passing (`npx jest --runInBand`)