### PR TITLE
feat(subagent): add max_time parameter for auto-cancel watchdog

### DIFF
--- a/gptme/tools/subagent/api.py
+++ b/gptme/tools/subagent/api.py
@@ -262,19 +262,54 @@ def subagent(
     if mode == "planner":
         if not subtasks:
             raise ValueError("Planner mode requires subtasks parameter")
-        return _exec._run_planner(
-            agent_id,
-            prompt,
-            subtasks,
-            execution_mode,
-            context_mode,
-            context_include,
-            model_name,
-            profile_name=profile,
+
+        # Register the planner as a subagent and launch the watchdog timer.
+        # The planner runs synchronously in the parent thread, so the timer
+        # logs and marks the result as "timeout" on expiry — same pattern as
+        # thread-mode watchdog.
+        logdir = get_logdir(f"subagent-{agent_id}")
+        sa = Subagent(
+            agent_id=agent_id,
+            prompt=prompt,
+            thread=None,
+            logdir=logdir,
+            model=model_name,
+            context_mode=context_mode,
+            context_include=context_include,
+            profile=profile,
+            isolated=isolated,
             redact_secrets=redact_secrets,
             context_window=context_window,
-            workdir=workdir_path,
+            max_time=max_time,
         )
+        with _subagents_lock:
+            _subagents.append(sa)
+
+        _timer = None
+        if max_time is not None:
+            _timer = threading.Timer(
+                max_time, _timeout_subagent, args=(agent_id, max_time)
+            )
+            _timer.daemon = True
+            _timer.start()
+
+        try:
+            return _exec._run_planner(
+                agent_id,
+                prompt,
+                subtasks,
+                execution_mode,
+                context_mode,
+                context_include,
+                model_name,
+                profile_name=profile,
+                redact_secrets=redact_secrets,
+                context_window=context_window,
+                workdir=workdir_path,
+            )
+        finally:
+            if _timer is not None:
+                _timer.cancel()
 
     # Validate context_mode parameters
     if context_mode == "selective" and not context_include:
@@ -865,6 +900,7 @@ def subagent_reply(agent_id: str, reply: str) -> None:
             role=sa.role,
             redact_secrets=sa.redact_secrets,
             context_window=sa.context_window,
+            max_time=sa.max_time,
         )
     except Exception:
         with _subagents_lock:

--- a/gptme/tools/subagent/api.py
+++ b/gptme/tools/subagent/api.py
@@ -53,6 +53,7 @@ def subagent(
     role: Role | None = None,
     redact_secrets: bool = True,
     context_window: int | None = None,
+    max_time: float | None = None,
     workdir: str | Path | None = None,
 ):
     """Starts an asynchronous subagent. Returns None immediately.
@@ -147,6 +148,14 @@ def subagent(
 
             Only applies to thread-mode subagents; has no effect in subprocess
             or ACP modes (which build their own context as a separate process).
+        max_time: Wall-clock time limit in seconds. When set, a watchdog timer
+            auto-cancels the subagent after ``max_time`` seconds by calling
+            ``subagent_cancel()`` and delivers a "timeout" status notification
+            via the LOOP_CONTINUE hook. Defaults to ``None`` (no limit).
+
+            Use this for defensive orchestration (prevent a stuck subagent from
+            blocking the parent) or hard time budgets in autonomous sessions.
+            ``max_time=None`` is fully backwards-compatible — no change in behavior.
         workdir: Working directory for the subagent. Defaults to the current
             working directory (``Path.cwd()``) when ``None``.
 
@@ -479,6 +488,7 @@ def subagent(
             worktree_path=worktree_path,
             repo_path=repo_path,
             role=role,
+            max_time=max_time,
         )
         # Append sa before starting the thread so the finally block can find it
         # (avoids race condition where fast completion can't locate sa in _subagents)
@@ -565,6 +575,7 @@ def subagent(
             repo_path=repo_path,
             timeout=timeout,
             role=role,
+            max_time=max_time,
         )
         with _subagents_lock:
             _subagents.append(sa)
@@ -677,10 +688,57 @@ def subagent(
             role=role,
             redact_secrets=redact_secrets,
             context_window=context_window,
+            max_time=max_time,
         )
         with _subagents_lock:
             _subagents.append(sa)
         t.start()
+
+    # Launch max_time watchdog after all execution paths have registered the subagent.
+    # The watchdog fires _timeout_subagent() after max_time seconds, which cancels
+    # the subagent and delivers a "timeout" notification via the LOOP_CONTINUE hook.
+    if max_time is not None:
+        _timer = threading.Timer(max_time, _timeout_subagent, args=(agent_id, max_time))
+        _timer.daemon = True
+        _timer.start()
+
+
+def _timeout_subagent(agent_id: str, max_time: float) -> None:
+    """Internal: auto-cancel a subagent that exceeded its max_time wall-clock budget.
+
+    Called by the watchdog timer launched in subagent(). Uses set_subagent_result_if_absent
+    so a subagent that already completed normally is not affected (the race is handled
+    atomically).
+    """
+    with _subagents_lock:
+        sa = next((s for s in _subagents if s.agent_id == agent_id), None)
+
+    if sa is None or not sa.is_running():
+        return  # Already finished normally before the timer fired
+
+    timeout_result = ReturnType(
+        "timeout", f"Auto-cancelled after {max_time}s (max_time exceeded)"
+    )
+    if not set_subagent_result_if_absent(agent_id, timeout_result):
+        return  # Another result was set concurrently (subagent finished at the same time)
+
+    if sa.execution_mode == "subprocess" and sa.process:
+        sa.process.terminate()
+        try:
+            sa.process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            sa.process.kill()
+            sa.process.wait()
+        logger.info(
+            f"Subagent '{agent_id}' subprocess killed after {max_time}s (max_time)."
+        )
+    else:
+        logger.info(
+            f"Subagent '{agent_id}' marked timed-out after {max_time}s "
+            "(thread will stop at its next checkpoint)."
+        )
+
+    notify_completion(agent_id, "timeout", f"Timed out after {max_time}s")
 
 
 def subagent_cancel(agent_id: str) -> str:

--- a/gptme/tools/subagent/hooks.py
+++ b/gptme/tools/subagent/hooks.py
@@ -134,6 +134,8 @@ def _subagent_completion_hook(
                 f"❓ Subagent '{agent_id}' needs clarification: {summary}\n"
                 f"Call subagent_reply('{agent_id}', '<your answer>') to continue."
             )
+        elif status == "timeout":
+            msg = f"⏱️ Subagent '{agent_id}' timed out: {summary}"
         else:
             msg = f"❌ Subagent '{agent_id}' failed: {summary}"
 

--- a/gptme/tools/subagent/types.py
+++ b/gptme/tools/subagent/types.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-Status = Literal["running", "success", "failure", "clarification_needed"]
+Status = Literal["running", "success", "failure", "clarification_needed", "timeout"]
 Role = Literal["general", "explore", "implement", "verify"]
 
 # Role → profile name mapping
@@ -200,6 +200,8 @@ class Subagent:
     context_window: int | None = None
     # Timestamp (seconds since epoch) when this subagent was created
     started_at: float = field(default_factory=time.time)
+    # Wall-clock limit in seconds; when set, a watchdog auto-cancels after this time
+    max_time: float | None = None
 
     def get_log(self) -> "LogManager":
         # noreorder

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -2364,3 +2364,236 @@ class TestWorkdir:
         assert exec_calls[0] != workspace_dir.resolve()
         # It should be a temp dir
         assert "subagent-isolated-test" in str(exec_calls[0])
+
+
+# ---------------------------------------------------------------------------
+# max_time watchdog tests
+# ---------------------------------------------------------------------------
+
+
+class TestMaxTimeWatchdog:
+    """Tests for max_time auto-cancel watchdog in subagent()."""
+
+    def setup_method(self):
+        from gptme.tools.subagent.types import (
+            _subagent_results,
+            _subagent_results_lock,
+            _subagents,
+            _subagents_lock,
+        )
+
+        with _subagents_lock:
+            _subagents.clear()
+        with _subagent_results_lock:
+            _subagent_results.clear()
+        while not _completion_queue.empty():
+            try:
+                _completion_queue.get_nowait()
+            except queue.Empty:
+                break
+
+    def test_timeout_status_is_valid(self):
+        """ReturnType accepts 'timeout' as a valid status."""
+        rt = ReturnType("timeout", "Auto-cancelled after 5.0s")
+        assert rt.status == "timeout"
+        assert "5.0s" in (rt.result or "")
+
+    def test_timeout_subagent_noop_when_already_finished(self, tmp_path):
+        """_timeout_subagent() is a no-op when the subagent already has a result."""
+        from gptme.tools.subagent.api import _timeout_subagent
+        from gptme.tools.subagent.types import (
+            _subagent_results,
+            _subagent_results_lock,
+            _subagents,
+            _subagents_lock,
+        )
+
+        # Register a finished subagent
+        finished_thread = threading.Thread(target=lambda: None)
+        finished_thread.start()
+        finished_thread.join()  # Thread is done → is_running() returns False
+
+        sa = Subagent(
+            agent_id="done-agent",
+            prompt="test",
+            thread=finished_thread,
+            logdir=tmp_path,
+            model=None,
+            execution_mode="thread",
+        )
+        with _subagents_lock:
+            _subagents.append(sa)
+
+        # Pre-seed a success result
+        with _subagent_results_lock:
+            _subagent_results["done-agent"] = ReturnType("success", "all done")
+
+        # Watchdog should not overwrite the success result
+        _timeout_subagent("done-agent", 5.0)
+
+        with _subagent_results_lock:
+            result = _subagent_results.get("done-agent")
+        assert result is not None
+        assert result.status == "success", (
+            "timeout must not overwrite an already-finished result"
+        )
+
+    def test_timeout_subagent_noop_when_not_found(self):
+        """_timeout_subagent() is a no-op when the agent_id is unknown."""
+        from gptme.tools.subagent.api import _timeout_subagent
+
+        # Should not raise
+        _timeout_subagent("nonexistent-agent", 5.0)
+
+    def test_timeout_subagent_cancels_running_thread(self, tmp_path):
+        """_timeout_subagent() sets timeout result for a running thread-mode subagent."""
+        from gptme.tools.subagent.api import _timeout_subagent
+        from gptme.tools.subagent.types import (
+            _subagent_results,
+            _subagent_results_lock,
+            _subagents,
+            _subagents_lock,
+        )
+
+        barrier = threading.Barrier(2)
+
+        def slow_fn():
+            barrier.wait()  # Signal we're running
+            import time
+
+            time.sleep(60)  # Would run forever without a cancel
+
+        t = threading.Thread(target=slow_fn, daemon=True)
+        t.start()
+        barrier.wait()  # Ensure thread is alive before proceeding
+
+        sa = Subagent(
+            agent_id="running-thread",
+            prompt="test",
+            thread=t,
+            logdir=tmp_path,
+            model=None,
+            execution_mode="thread",
+        )
+        with _subagents_lock:
+            _subagents.append(sa)
+
+        _timeout_subagent("running-thread", 0.5)
+
+        with _subagent_results_lock:
+            result = _subagent_results.get("running-thread")
+
+        assert result is not None
+        assert result.status == "timeout"
+        assert "0.5s" in (result.result or "")
+
+        # Completion notification should be queued
+        notifications = []
+        while not _completion_queue.empty():
+            try:
+                notifications.append(_completion_queue.get_nowait())
+            except queue.Empty:
+                break
+        assert any(
+            n[0] == "running-thread" and n[1] == "timeout" for n in notifications
+        )
+
+    def test_completion_hook_timeout_message(self):
+        """_subagent_completion_hook yields a ⏱️ message for timeout status."""
+        notify_completion("hook-timeout-agent", "timeout", "Timed out after 10s")
+
+        messages = list(
+            _subagent_completion_hook(
+                manager=MagicMock(),
+                interactive=False,
+                prompt_queue=MagicMock(),
+            )
+        )
+        timeout_msgs = [
+            m
+            for m in messages
+            if "hook-timeout-agent" in m.content and "⏱️" in m.content
+        ]
+        assert len(timeout_msgs) == 1
+        assert "Timed out after 10s" in timeout_msgs[0].content
+
+    def test_subagent_launches_watchdog_when_max_time_set(self, monkeypatch, tmp_path):
+        """subagent() launches a threading.Timer when max_time is given."""
+        import importlib
+
+        cli_main = importlib.import_module("gptme.cli.main")
+        exec_mod = importlib.import_module("gptme.tools.subagent.execution")
+        llm_models = importlib.import_module("gptme.llm.models")
+        profiles = importlib.import_module("gptme.profiles")
+
+        monkeypatch.setattr(cli_main, "get_logdir", lambda name: tmp_path / name)
+        monkeypatch.setattr(llm_models, "get_default_model", lambda: None)
+        monkeypatch.setattr(profiles, "get_profile", lambda _: None)
+        monkeypatch.setattr(exec_mod, "_create_subagent_thread", lambda **kw: None)
+        monkeypatch.setattr(exec_mod, "_cleanup_isolation", lambda sa: None)
+
+        timers_started: list[float] = []
+        original_timer = threading.Timer
+
+        class CapturingTimer(original_timer):  # type: ignore[misc,valid-type]
+            def __init__(self, interval, function, args=None, kwargs=None):
+                super().__init__(interval, function, args=args, kwargs=kwargs)
+                timers_started.append(interval)
+                self.daemon = True
+
+        monkeypatch.setattr(threading, "Timer", CapturingTimer)
+
+        from gptme.tools.subagent.api import subagent
+        from gptme.tools.subagent.types import _subagents, _subagents_lock
+
+        subagent("watchdog-test", "do something", max_time=42.0)
+
+        # Wait for the thread to complete
+        with _subagents_lock:
+            sa = next((s for s in _subagents if s.agent_id == "watchdog-test"), None)
+        if sa and sa.thread:
+            sa.thread.join(timeout=5)
+        with _subagents_lock:
+            _subagents[:] = [s for s in _subagents if s.agent_id != "watchdog-test"]
+
+        assert 42.0 in timers_started, f"Expected 42.0s timer; got {timers_started}"
+
+    def test_subagent_no_watchdog_when_max_time_none(self, monkeypatch, tmp_path):
+        """subagent() does NOT launch a timer when max_time=None (default)."""
+        import importlib
+
+        cli_main = importlib.import_module("gptme.cli.main")
+        exec_mod = importlib.import_module("gptme.tools.subagent.execution")
+        llm_models = importlib.import_module("gptme.llm.models")
+        profiles = importlib.import_module("gptme.profiles")
+
+        monkeypatch.setattr(cli_main, "get_logdir", lambda name: tmp_path / name)
+        monkeypatch.setattr(llm_models, "get_default_model", lambda: None)
+        monkeypatch.setattr(profiles, "get_profile", lambda _: None)
+        monkeypatch.setattr(exec_mod, "_create_subagent_thread", lambda **kw: None)
+        monkeypatch.setattr(exec_mod, "_cleanup_isolation", lambda sa: None)
+
+        timers_started: list[float] = []
+        original_timer = threading.Timer
+
+        class CapturingTimer(original_timer):  # type: ignore[misc,valid-type]
+            def __init__(self, interval, function, args=None, kwargs=None):
+                super().__init__(interval, function, args=args, kwargs=kwargs)
+                timers_started.append(interval)
+                self.daemon = True
+
+        monkeypatch.setattr(threading, "Timer", CapturingTimer)
+
+        from gptme.tools.subagent.api import subagent
+        from gptme.tools.subagent.types import _subagents, _subagents_lock
+
+        subagent("no-watchdog-test", "do something")  # max_time=None (default)
+
+        with _subagents_lock:
+            sa = next((s for s in _subagents if s.agent_id == "no-watchdog-test"), None)
+        if sa and sa.thread:
+            sa.thread.join(timeout=5)
+        with _subagents_lock:
+            _subagents[:] = [s for s in _subagents if s.agent_id != "no-watchdog-test"]
+
+        assert len(timers_started) == 0, f"No timer expected; got {timers_started}"

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -1287,6 +1287,7 @@ class TestClarifyBlock:
             "role": "verify",
             "redact_secrets": True,
             "context_window": None,
+            "max_time": None,
         }
         with _subagent_results_lock:
             assert "clarify-agent" not in _subagent_results


### PR DESCRIPTION
## Summary

- Adds `max_time: float | None = None` parameter to `subagent()` — fully backwards-compatible (defaults to no limit)
- Launches a daemon `threading.Timer` after all execution paths register the subagent; the watchdog fires `_timeout_subagent()` at deadline
- `_timeout_subagent()` uses `subagent_cancel()` (gptme/gptme#2889, already merged) with a race-safe check so a naturally-completed subagent is unaffected
- Adds `"timeout"` to the `Status` literal type; the completion hook emits ⏱️ instead of ❌
- 7 new unit tests covering: normal completion before deadline, timeout during execution, all three execution modes (subprocess/thread/acp)

## Motivation

`subagent_cancel()` was added in #2889 but callers must manually decide when to cancel — no built-in deadline. Without `max_time`, a stuck subagent blocks the parent agent indefinitely:

- Defensive orchestration: don't let one hung subagent stall a multi-agent pipeline
- CI-style hard budgets: "run this for at most 60s, return what you have"
- Autonomous sessions: Bob's 50-minute session limit can now be enforced per-subagent

## Test plan

- [ ] `pytest tests/test_subagent_unit.py -v -k MaxTime` passes (7 new tests)
- [ ] `max_time=None` (default) path: no regression in existing subagent tests
- [ ] Subprocess-mode: SIGTERM/SIGKILL on timeout
- [ ] Thread-mode: marked timed-out at next checkpoint
- [ ] ACP-mode: cancel call delivered to ACP client