### PR TITLE
feat(commands): add /rag slash command for mid-session RAG search

### DIFF
--- a/gptme/commands/__init__.py
+++ b/gptme/commands/__init__.py
@@ -24,6 +24,7 @@ from . import (  # noqa: F401
     export,
     llm,
     meta,
+    rag,
     session,
     snapshot,
 )

--- a/gptme/commands/rag.py
+++ b/gptme/commands/rag.py
@@ -1,0 +1,48 @@
+"""
+RAG search: /rag <query>
+
+Query the indexed document store mid-session and inject the top-N results into
+the conversation as a user message, so the assistant can reference past
+conversations or project docs without restarting gptme.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from ..message import Message
+
+from .base import CommandContext, command
+
+
+@command("rag")
+def cmd_rag(ctx: CommandContext) -> Generator[Message, None, None]:
+    """Search the RAG index and inject results into the conversation."""
+    from ..message import Message
+    from ..tools.rag import _has_gptme_rag, rag_search
+
+    query = ctx.full_args.strip()
+    if not query:
+        print("Usage: /rag <query>")
+        print("Search the RAG index and inject results into the conversation.")
+        return
+
+    if not _has_gptme_rag():
+        print("gptme-rag is not installed. Install it with: pipx install gptme-rag")
+        return
+
+    try:
+        results = rag_search(query, top_k=3)
+    except RuntimeError as e:
+        print(f"RAG search failed: {e}")
+        return
+
+    if not results or results.strip() == "No results found.":
+        print(f"No relevant past conversations or documents found for: {query!r}")
+        return
+
+    snippet = f"Relevant context from past conversations and documents (query: {query!r}):\n\n{results}"
+    yield Message("user", snippet)

--- a/tests/test_commands_rag.py
+++ b/tests/test_commands_rag.py
@@ -1,0 +1,76 @@
+"""Tests for the /rag slash command."""
+
+from unittest.mock import MagicMock, patch
+
+from gptme.commands.base import CommandContext
+from gptme.commands.rag import cmd_rag
+from gptme.message import Message
+
+
+def _make_ctx(query: str) -> CommandContext:
+    args = query.split() if query else []
+    return CommandContext(args=args, full_args=query, manager=MagicMock())
+
+
+def test_rag_cmd_no_query(capsys):
+    """Empty /rag prints usage and yields nothing."""
+    ctx = _make_ctx("")
+    msgs = list(cmd_rag(ctx))
+    out = capsys.readouterr().out
+    assert "Usage:" in out
+    assert msgs == []
+
+
+def test_rag_cmd_no_gptme_rag(capsys):
+    """When gptme-rag is not installed, print a helpful message and yield nothing."""
+    with patch("gptme.tools.rag._has_gptme_rag", return_value=False):
+        ctx = _make_ctx("pytest fixtures")
+        msgs = list(cmd_rag(ctx))
+    out = capsys.readouterr().out
+    assert "gptme-rag is not installed" in out
+    assert msgs == []
+
+
+def test_rag_cmd_injects_results():
+    """When results exist, inject them as a user message."""
+    fake_results = "### past-session-abc\nWe used pytest fixtures like this..."
+    with (
+        patch("gptme.tools.rag._has_gptme_rag", return_value=True),
+        patch("gptme.tools.rag.rag_search", return_value=fake_results),
+    ):
+        ctx = _make_ctx("pytest fixtures")
+        msgs = list(cmd_rag(ctx))
+
+    assert len(msgs) == 1
+    msg = msgs[0]
+    assert isinstance(msg, Message)
+    assert msg.role == "user"
+    assert "pytest fixtures" in msg.content
+    assert fake_results in msg.content
+
+
+def test_rag_cmd_no_results(capsys):
+    """When RAG returns empty results, print a notice and yield nothing."""
+    with (
+        patch("gptme.tools.rag._has_gptme_rag", return_value=True),
+        patch("gptme.tools.rag.rag_search", return_value="No results found."),
+    ):
+        ctx = _make_ctx("something obscure")
+        msgs = list(cmd_rag(ctx))
+    out = capsys.readouterr().out
+    assert "No relevant" in out
+    assert msgs == []
+
+
+def test_rag_cmd_search_error(capsys):
+    """RuntimeError from rag_search is caught and printed gracefully."""
+    with (
+        patch("gptme.tools.rag._has_gptme_rag", return_value=True),
+        patch("gptme.tools.rag.rag_search", side_effect=RuntimeError("index missing")),
+    ):
+        ctx = _make_ctx("anything")
+        msgs = list(cmd_rag(ctx))
+    out = capsys.readouterr().out
+    assert "RAG search failed" in out
+    assert "index missing" in out
+    assert msgs == []


### PR DESCRIPTION
## Summary

- Adds a `/rag <query>` slash command that queries the indexed document store mid-session
- Injects the top-N results as a user message so the assistant can reference past conversations and project docs without restarting gptme
- Graceful no-op when `gptme-rag` is not installed or the index is empty

## Context

After gptme/gptme#2883 (`rag_index_conversations`) merged, past conversations are indexed but only surfaced as pre-session context. There was no way to query mid-session, which required restarting gptme to pick up newly indexed content.

## Changes

- `gptme/commands/rag.py`: new `/rag` command that calls `rag_search(query, top_k=3)` and yields the results as a `user` message  
- `gptme/commands/__init__.py`: adds `rag` to the command module imports
- `tests/test_commands_rag.py`: 5 unit tests covering empty query, missing gptme-rag, result injection, no results, and search error

## Test plan

- [ ] `uv run pytest tests/test_commands_rag.py -v` — all 5 tests pass
- [ ] Install `gptme-rag`, index some content, start gptme and run `/rag <query>` — results injected as user message
- [ ] Run `/rag` with no args — prints usage, no crash
- [ ] Run without `gptme-rag` installed — prints install hint, no crash

Closes #2887