### PR TITLE
feat(commands): add /rag slash command for mid-session RAG queries

### DIFF
--- a/gptme/commands/__init__.py
+++ b/gptme/commands/__init__.py
@@ -24,6 +24,7 @@ from . import (  # noqa: F401
     export,
     llm,
     meta,
+    rag,
     session,
     snapshot,
 )

--- a/gptme/commands/rag.py
+++ b/gptme/commands/rag.py
@@ -1,0 +1,61 @@
+"""
+/rag command — query the RAG store mid-session and inject results as context.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+from typing import TYPE_CHECKING
+
+from .base import CommandContext, command
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from ..message import Message
+
+logger = logging.getLogger(__name__)
+
+# Imported at module level so tests can patch gptme.commands.rag.rag_search
+try:
+    from ..tools.rag import rag_search
+except ImportError:  # pragma: no cover
+    rag_search = None  # type: ignore[assignment]
+
+
+@command("rag", auto_undo=False)
+def cmd_rag(ctx: CommandContext) -> Generator[Message, None, None]:
+    """Search the RAG index and inject the top results into the conversation.
+
+    Usage: /rag <query>
+
+    Requires gptme-rag to be installed and a populated index.
+    """
+    from ..message import Message  # fmt: skip
+
+    query = ctx.full_args.strip()
+    if not query:
+        print("Usage: /rag <query>")
+        return
+
+    if not shutil.which("gptme-rag"):
+        print("gptme-rag is not installed. Install with: pipx install gptme-rag")
+        return
+
+    if rag_search is None:
+        print("RAG tool unavailable: gptme.tools.rag could not be imported")
+        return
+
+    try:
+        results = rag_search(query, top_k=3)
+    except Exception as e:
+        print(f"RAG search failed: {e}")
+        return
+
+    if not results:
+        print("No relevant results found in the RAG index.")
+        return
+
+    content = f"Relevant context from RAG search for '{query}':\n\n{results}"
+    yield Message("system", content, hide=False)

--- a/tests/test_commands_rag.py
+++ b/tests/test_commands_rag.py
@@ -1,0 +1,106 @@
+"""Tests for the /rag command."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from gptme.commands.base import CommandContext
+from gptme.commands.rag import cmd_rag
+from gptme.message import Message
+
+
+@pytest.fixture()
+def mock_manager():
+    manager = MagicMock()
+    manager.log = MagicMock()
+    manager.log.messages = []
+    manager.logdir = Path("/tmp/test-conversation")
+    manager.logfile = Path("/tmp/test-conversation/conversation.jsonl")
+    manager.name = "test-conversation"
+    manager.workspace = Path("/tmp")
+    return manager
+
+
+def _make_ctx(full_args: str, manager: MagicMock) -> CommandContext:
+    args = full_args.split() if full_args.strip() else []
+    return CommandContext(args=args, full_args=full_args, manager=manager)
+
+
+class TestRagCommand:
+    def test_empty_query_prints_usage(self, mock_manager: MagicMock, capsys) -> None:
+        ctx = _make_ctx("", mock_manager)
+        list(cmd_rag(ctx))
+        captured = capsys.readouterr()
+        assert "Usage" in captured.out
+
+    def test_missing_gptme_rag_prints_install_hint(
+        self, mock_manager: MagicMock, capsys
+    ) -> None:
+        ctx = _make_ctx("pytest fixtures", mock_manager)
+        with patch("shutil.which", return_value=None):
+            list(cmd_rag(ctx))
+        captured = capsys.readouterr()
+        assert "gptme-rag" in captured.out
+        assert "install" in captured.out.lower()
+
+    def test_no_results_prints_message(self, mock_manager: MagicMock, capsys) -> None:
+        ctx = _make_ctx("nonexistent topic XYZ123", mock_manager)
+        with (
+            patch("shutil.which", return_value="/usr/bin/gptme-rag"),
+            patch("gptme.commands.rag.rag_search", return_value=""),
+        ):
+            messages = list(cmd_rag(ctx))
+        captured = capsys.readouterr()
+        assert messages == []
+        assert "No relevant" in captured.out
+
+    def test_results_injected_as_system_message(self, mock_manager: MagicMock) -> None:
+        ctx = _make_ctx("pytest fixtures", mock_manager)
+        fake_results = "Result 1: some snippet\nResult 2: another snippet"
+        with (
+            patch("shutil.which", return_value="/usr/bin/gptme-rag"),
+            patch("gptme.commands.rag.rag_search", return_value=fake_results),
+        ):
+            messages = list(cmd_rag(ctx))
+        assert len(messages) == 1
+        msg = messages[0]
+        assert isinstance(msg, Message)
+        assert msg.role == "system"
+        assert "pytest fixtures" in msg.content
+        assert fake_results in msg.content
+
+    def test_search_exception_prints_error(
+        self, mock_manager: MagicMock, capsys
+    ) -> None:
+        ctx = _make_ctx("pytest fixtures", mock_manager)
+        with (
+            patch("shutil.which", return_value="/usr/bin/gptme-rag"),
+            patch(
+                "gptme.commands.rag.rag_search",
+                side_effect=RuntimeError("index empty"),
+            ),
+        ):
+            messages = list(cmd_rag(ctx))
+        captured = capsys.readouterr()
+        assert messages == []
+        assert "failed" in captured.out.lower()
+        assert "index empty" in captured.out
+
+    def test_rag_command_registered(self) -> None:
+        # Importing commands.rag registers the command
+        import gptme.commands.rag  # noqa: F401
+        from gptme.commands.base import _command_registry
+
+        assert "rag" in _command_registry
+
+    def test_top_k_passed_to_search(self, mock_manager: MagicMock) -> None:
+        ctx = _make_ctx("query text", mock_manager)
+        with (
+            patch("shutil.which", return_value="/usr/bin/gptme-rag"),
+            patch(
+                "gptme.commands.rag.rag_search", return_value="some result"
+            ) as mock_search,
+        ):
+            list(cmd_rag(ctx))
+        mock_search.assert_called_once_with("query text", top_k=3)


### PR DESCRIPTION
## Summary

- Adds `/rag <query>` slash command that searches the gptme-rag index and injects the top-3 results as a `system` message into the active conversation
- Gracefully handles: missing query (prints usage), missing `gptme-rag` CLI (prints install hint), empty results, search errors
- `auto_undo=False` so the `/rag ...` user message stays visible alongside the injected context
- 7 unit tests — all fast (mocked), no gptme-rag required to run the test suite

## Motivation

After `rag_index_conversations` merged in #2883, past conversations can be indexed and searched. But there was no way to query the index **mid-session** — you had to restart gptme for new context to surface. This command fills that gap:

```
/rag pytest fixtures
```

injects the top-3 matches from the RAG store directly into the conversation as a system message, which the assistant sees on the next turn.

## Usage

```
/rag <query>          — search the index and inject top-3 snippets
```

Requires `gptme-rag` to be installed (`pipx install gptme-rag`) and an indexed store (via `rag_index()` or `rag_index_conversations()`).

## Test plan

- [ ] `pytest tests/test_commands_rag.py -v` — 7 tests pass
- [ ] Existing command tests unaffected: `pytest tests/test_commands.py -v`
- [ ] `/rag` appears in `/help` output
- [ ] With a real gptme-rag index: `/rag <topic>` injects relevant snippets