### PR TITLE
feat(computer): add per-day audit log for computer-use actions

### DIFF
--- a/docs/howto/computer-use.md
+++ b/docs/howto/computer-use.md
@@ -154,3 +154,14 @@ Then connect a browser to `http://localhost:6080` to watch the agent work.
 - **Combine with `--non-interactive`**: add `-n` for scripted or CI use where you don't want
   prompts (but ensure the task is well-scoped first).
 - **Describe visual outcomes**: "confirm the dialog closed" works better than "click OK and move on".
+
+## Audit log
+
+Every `computer()` call (mouse, keyboard, screenshot, window/accessibility actions) is
+recorded to a per-day JSONL audit log at
+`$XDG_STATE_HOME/gptme/computer-audit/<YYYY-MM-DD>.jsonl` (falls back to the platform
+state dir, e.g. `~/.local/state/gptme` on Linux, when `XDG_STATE_HOME` isn't set). Each record has the action name, coordinate,
+duration, and error (if any) — but never the raw `text` payload, only its length, so
+typed passwords or other sensitive input aren't persisted to disk. Use this log to see
+what a computer-use session actually did and where it failed, independent of what made
+it into the conversation transcript.

--- a/gptme/tools/computer.py
+++ b/gptme/tools/computer.py
@@ -81,7 +81,6 @@ Using a single sequence for complex operations ensures proper timing and recogni
 from __future__ import annotations
 
 import dataclasses
-import functools
 import json
 import logging
 import os
@@ -147,7 +146,7 @@ def _audit_log(
         }
         with path.open("a") as f:
             f.write(json.dumps(entry) + "\n")
-    except OSError as e:
+    except Exception as e:
         # Audit logging must never break the underlying action.
         logger.warning(f"Failed to write computer-use audit log: {e}")
 
@@ -1407,7 +1406,6 @@ def _computer_impl(
     raise ValueError(f"Invalid action: {action}")
 
 
-@functools.wraps(_computer_impl)
 def computer(
     action: Action, text: str | None = None, coordinate: tuple[int, int] | None = None
 ) -> Message | None:

--- a/gptme/tools/computer.py
+++ b/gptme/tools/computer.py
@@ -1423,6 +1423,9 @@ def computer(
         _audit_log(action, text, coordinate, time.perf_counter() - start, error)
 
 
+computer.__doc__ = _computer_impl.__doc__
+
+
 # Common key mappings for both platforms
 # Output is directly compatible with cliclick
 COMMON_KEY_MAP = {

--- a/gptme/tools/computer.py
+++ b/gptme/tools/computer.py
@@ -81,6 +81,8 @@ Using a single sequence for complex operations ensures proper timing and recogni
 from __future__ import annotations
 
 import dataclasses
+import functools
+import json
 import logging
 import os
 import platform
@@ -88,9 +90,11 @@ import shlex
 import shutil
 import subprocess
 import time
+from datetime import datetime, timezone
 from enum import Enum
 from typing import TYPE_CHECKING, Literal, TypedDict
 
+from ..dirs import get_state_dir
 from .base import ToolFunction, ToolSpec, ToolUse
 from .computer_transport import get_transport
 from .screenshot import screenshot
@@ -107,6 +111,45 @@ logger = logging.getLogger(__name__)
 
 # Platform detection
 IS_MACOS = platform.system() == "Darwin"
+
+# Subdirectory of the gptme state dir where computer-use audit records live.
+COMPUTER_AUDIT_SUBDIR = "computer-audit"
+
+
+def _audit_log_path() -> Path:
+    date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    return get_state_dir() / COMPUTER_AUDIT_SUBDIR / f"{date}.jsonl"
+
+
+def _audit_log(
+    action: str,
+    text: str | None,
+    coordinate: tuple[int, int] | None,
+    duration: float,
+    error: str | None,
+) -> None:
+    """Append one record of a computer-use action to the audit log.
+
+    Records action metadata (never raw ``text``, since actions like ``type``
+    can carry passwords or other sensitive input) so failures and the shape of
+    what was done are auditable without leaking typed content into logs.
+    """
+    path = _audit_log_path()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        entry = {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "action": action,
+            "text_len": len(text) if text is not None else None,
+            "coordinate": coordinate,
+            "duration_ms": round(duration * 1000, 1),
+            "error": error,
+        }
+        with path.open("a") as f:
+            f.write(json.dumps(entry) + "\n")
+    except OSError as e:
+        # Audit logging must never break the underlying action.
+        logger.warning(f"Failed to write computer-use audit log: {e}")
 
 
 def _make_screenshot_msg(path: Path, tool: str = "computer") -> Message | None:
@@ -1037,7 +1080,7 @@ def _dispatch_transport(
     raise ValueError(f"Invalid action: {action}")
 
 
-def computer(
+def _computer_impl(
     action: Action, text: str | None = None, coordinate: tuple[int, int] | None = None
 ) -> Message | None:
     """
@@ -1362,6 +1405,24 @@ def computer(
         return None
 
     raise ValueError(f"Invalid action: {action}")
+
+
+@functools.wraps(_computer_impl)
+def computer(
+    action: Action, text: str | None = None, coordinate: tuple[int, int] | None = None
+) -> Message | None:
+    # perf_counter, not monotonic — several tests feed `time.monotonic` a
+    # finite side_effect sequence timed to `_computer_impl`'s internal polling
+    # loop, and an extra consumer here would desync those mocks.
+    start = time.perf_counter()
+    error: str | None = None
+    try:
+        return _computer_impl(action, text, coordinate)
+    except Exception as e:
+        error = str(e)
+        raise
+    finally:
+        _audit_log(action, text, coordinate, time.perf_counter() - start, error)
 
 
 # Common key mappings for both platforms

--- a/tests/test_computer_audit.py
+++ b/tests/test_computer_audit.py
@@ -1,0 +1,96 @@
+"""Tests for the computer-use audit log (gptme/gptme#216).
+
+Verifies that every ``computer()`` call is recorded (action, coordinate,
+outcome) without ever persisting the raw ``text`` payload, and that failures
+are both logged and still propagated to the caller.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+import pytest
+
+import gptme.tools.computer as computer_module
+from gptme.tools.computer import COMPUTER_AUDIT_SUBDIR, computer
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture
+def audit_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setattr(computer_module, "get_state_dir", lambda: tmp_path)
+    return tmp_path / COMPUTER_AUDIT_SUBDIR
+
+
+def _read_entries(audit_dir: Path) -> list[dict]:
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    path = audit_dir / f"{today}.jsonl"
+    assert path.exists(), f"expected audit log at {path}"
+    return [json.loads(line) for line in path.read_text().splitlines() if line]
+
+
+def test_successful_action_is_logged(
+    audit_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        computer_module, "_computer_impl", lambda action, text, coordinate: None
+    )
+    computer("left_click", coordinate=(10, 20))
+
+    entries = _read_entries(audit_dir)
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry["action"] == "left_click"
+    assert entry["coordinate"] == [10, 20]
+    assert entry["error"] is None
+    assert entry["text_len"] is None
+    assert entry["duration_ms"] >= 0
+
+
+def test_typed_text_is_never_logged_raw(
+    audit_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        computer_module, "_computer_impl", lambda action, text, coordinate: None
+    )
+    secret = "hunter2-super-secret"
+    computer("type", text=secret)
+
+    entries = _read_entries(audit_dir)
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry["text_len"] == len(secret)
+    assert secret not in json.dumps(entry)
+
+
+def test_failed_action_is_logged_and_raised(
+    audit_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def _boom(action, text, coordinate):
+        raise ValueError("xdotool not found")
+
+    monkeypatch.setattr(computer_module, "_computer_impl", _boom)
+
+    with pytest.raises(ValueError, match="xdotool not found"):
+        computer("screenshot")
+
+    entries = _read_entries(audit_dir)
+    assert len(entries) == 1
+    assert entries[0]["error"] == "xdotool not found"
+
+
+def test_multiple_actions_append_to_same_day_file(
+    audit_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        computer_module, "_computer_impl", lambda action, text, coordinate: None
+    )
+    computer("screenshot")
+    computer("cursor_position")
+
+    entries = _read_entries(audit_dir)
+    assert [e["action"] for e in entries] == ["screenshot", "cursor_position"]


### PR DESCRIPTION
## Summary

Addresses the audit/permission-boundary gap raised on #216 by @hiSandog: computer-use actions (mouse, keyboard, screenshot, window/accessibility) previously left no independent record of what was done or what failed — only what happened to land in the conversation transcript.

- Wraps `computer()` so every call is appended to a per-day JSONL audit log at `$XDG_STATE_HOME/gptme/computer-audit/<YYYY-MM-DD>.jsonl` (same `get_state_dir()` convention already used by `checkpoint.py`).
- Each record: `timestamp`, `action`, `coordinate`, `duration_ms`, `error`.
- **Typed text is never persisted raw** — only `text_len` — since `type`/`key` actions can carry passwords or other sensitive input.
- Failures are logged with the error message and still propagate to the caller unchanged (no behavior change on the happy/error path, purely additive).
- Documented in `docs/howto/computer-use.md`.

This is a scoped slice of #216 (not a full close — see the issue's remaining-gaps list: Docker/VNC streaming mode, end-to-end "Can it Tweet?" validation). Follows the roadmap I posted on the issue (PR A/B/C) under the "evidence/reporting quality" bucket.

## Test plan
- [x] `poetry run pytest tests/test_tools_computer.py tests/test_computer_actions.py tests/test_computer_transport.py tests/test_computer_artifacts.py tests/test_computer_audit.py -q` — 166 passed, 4 skipped
- [x] `poetry run mypy gptme/tools/computer.py` — clean
- [x] `poetry run ruff check .` / `ruff format --check` — clean
- [x] New tests cover: successful action logged, typed text never appears raw in the log (only length), failed action logs the error and still raises, multiple actions append to the same day's file