### PR TITLE
fix(eval): make subagent eval expect/check_log checks picklable

### DIFF
--- a/gptme/eval/suites/computer.py
+++ b/gptme/eval/suites/computer.py
@@ -69,6 +69,32 @@ def check_did_not_screenshot_for_web(messages: list[Message]) -> bool:
 
 
 # ---------------------------------------------------------------------------
+# Expect-check helpers (named module-level functions required for
+# ProcessPoolExecutor pickling — inline lambdas crash with PicklingError)
+# ---------------------------------------------------------------------------
+
+
+def _expect_summary_written(ctx) -> bool:
+    return "summary.txt" in ctx.files or len(ctx.stdout.strip()) > 5
+
+
+def _expect_title_extracted(ctx) -> bool:
+    return "TITLE=" in ctx.stdout or "Example Domain" in ctx.stdout
+
+
+def _expect_clean_exit(ctx) -> bool:
+    return ctx.exit_code == 0
+
+
+def _expect_links_written(ctx) -> bool:
+    return "links.txt" in ctx.files or len(ctx.stdout.strip()) > 10
+
+
+def _expect_at_least_one_title(ctx) -> bool:
+    return len(ctx.stdout.strip()) > 5
+
+
+# ---------------------------------------------------------------------------
 # Eval specs
 # ---------------------------------------------------------------------------
 
@@ -88,13 +114,9 @@ tests: list["EvalSpec"] = [
         ),
         "tools": ["browser", "computer", "vision", "ipython", "save"],
         "expect": {
-            "summary.txt written": lambda ctx: (
-                "summary.txt" in ctx.files or len(ctx.stdout.strip()) > 5
-            ),
-            "title extracted": lambda ctx: (
-                "TITLE=" in ctx.stdout or "Example Domain" in ctx.stdout
-            ),
-            "clean exit": lambda ctx: ctx.exit_code == 0,
+            "summary.txt written": _expect_summary_written,
+            "title extracted": _expect_title_extracted,
+            "clean exit": _expect_clean_exit,
         },
         "check_log": {
             "used structured snapshot (not screenshot) for web": check_used_snapshot_or_observe_web,
@@ -114,11 +136,9 @@ tests: list["EvalSpec"] = [
         ),
         "tools": ["browser", "computer", "vision", "ipython", "save"],
         "expect": {
-            "links.txt written": lambda ctx: (
-                "links.txt" in ctx.files or len(ctx.stdout.strip()) > 10
-            ),
-            "at least one title extracted": lambda ctx: len(ctx.stdout.strip()) > 5,
-            "clean exit": lambda ctx: ctx.exit_code == 0,
+            "links.txt written": _expect_links_written,
+            "at least one title extracted": _expect_at_least_one_title,
+            "clean exit": _expect_clean_exit,
         },
         "check_log": {
             "used structured snapshot for web content": check_used_snapshot_or_observe_web,

--- a/gptme/eval/suites/subagent.py
+++ b/gptme/eval/suites/subagent.py
@@ -5,7 +5,36 @@ from typing import TYPE_CHECKING
 from gptme.message import Message
 
 if TYPE_CHECKING:
-    from gptme.eval.types import EvalSpec
+    from gptme.eval.types import EvalSpec, ResultContext
+
+
+# `expect`/`check_log` callables are stored in the EvalSpec dict, which gets
+# pickled by ProcessPoolExecutor.submit() even when running with --parallel 1
+# (the executor always routes submissions through a picklable call queue).
+# Lambdas can't be pickled ("attribute lookup <lambda> ... failed"), so every
+# check here must be a named module-level function, not an inline lambda.
+def _expect_words_marker(ctx: "ResultContext") -> bool:
+    return "WORDS=6" in ctx.stdout
+
+
+def _expect_lines_marker(ctx: "ResultContext") -> bool:
+    return "LINES=4" in ctx.stdout
+
+
+def _expect_exists_marker(ctx: "ResultContext") -> bool:
+    return "EXISTS=yes" in ctx.stdout
+
+
+def _expect_clean_exit(ctx: "ResultContext") -> bool:
+    return ctx.exit_code == 0
+
+
+def _expect_sum_marker(ctx: "ResultContext") -> bool:
+    return "SUM=5050" in ctx.stdout
+
+
+def _expect_greeting_marker(ctx: "ResultContext") -> bool:
+    return "GREETING=" in ctx.stdout
 
 
 def _role_contents(messages: list[Message], role: str) -> str:
@@ -165,10 +194,10 @@ tests: list["EvalSpec"] = [
         ),
         "tools": ["read", "save", "shell", "ipython", "subagent"],
         "expect": {
-            "writes WORDS marker": lambda ctx: "WORDS=6" in ctx.stdout,
-            "writes LINES marker": lambda ctx: "LINES=4" in ctx.stdout,
-            "writes EXISTS marker": lambda ctx: "EXISTS=yes" in ctx.stdout,
-            "clean exit": lambda ctx: ctx.exit_code == 0,
+            "writes WORDS marker": _expect_words_marker,
+            "writes LINES marker": _expect_lines_marker,
+            "writes EXISTS marker": _expect_exists_marker,
+            "clean exit": _expect_clean_exit,
         },
         "check_log": {
             "used subagent delegation": check_subagent_parallel_used,
@@ -195,8 +224,8 @@ tests: list["EvalSpec"] = [
         ),
         "tools": ["read", "save", "shell", "ipython", "subagent"],
         "expect": {
-            "writes SUM marker": lambda ctx: "SUM=5050" in ctx.stdout,
-            "clean exit": lambda ctx: ctx.exit_code == 0,
+            "writes SUM marker": _expect_sum_marker,
+            "clean exit": _expect_clean_exit,
         },
         "check_log": {
             "spawned roundtrip subagent": check_subagent_complete_spawned,
@@ -226,8 +255,8 @@ tests: list["EvalSpec"] = [
         ),
         "tools": ["read", "save", "shell", "ipython", "subagent"],
         "expect": {
-            "writes GREETING marker": lambda ctx: "GREETING=" in ctx.stdout,
-            "clean exit": lambda ctx: ctx.exit_code == 0,
+            "writes GREETING marker": _expect_greeting_marker,
+            "clean exit": _expect_clean_exit,
         },
         "check_log": {
             "spawned greeter subagent": check_clarification_spawned,

--- a/tests/test_eval_subagent.py
+++ b/tests/test_eval_subagent.py
@@ -1,3 +1,5 @@
+import pickle
+
 from gptme.eval.suites.subagent import (
     check_clarification_hook_notification,
     check_clarification_reply_called,
@@ -12,7 +14,21 @@ from gptme.eval.suites.subagent import (
     check_subagent_parallel_started_before_wait,
     check_subagent_parallel_used,
 )
+from gptme.eval.suites.subagent import tests as subagent_evals
 from gptme.message import Message
+
+
+def test_subagent_eval_specs_are_picklable():
+    """run_evals() submits each EvalSpec through a ProcessPoolExecutor, which
+    pickles the submitted args even at --parallel 1 (it always routes work
+    through a picklable call queue). A lambda in `expect`/`check_log` crashes
+    every run with a PicklingError before the model is ever invoked — the
+    exact reason the subagent trajectory evals had never completed a live
+    run. Guard against reintroducing inline lambdas here."""
+    for spec in subagent_evals:
+        for checks in (spec.get("expect", {}), spec.get("check_log", {})):
+            for check in checks.values():
+                pickle.dumps(check)
 
 
 def test_parallel_checks_pass_for_planner_style_trajectory():


### PR DESCRIPTION
## Summary

Closes the remaining "E2E eval pass" gap tracked in #554's closeout comment: the subagent trajectory evals (added in #2585/#2593) have never successfully run against a live model, because `run_evals()` submits each `EvalSpec` through a `ProcessPoolExecutor` — which always pickles submitted args to route them through its internal call queue, even at `--parallel 1`.

`gptme/eval/suites/subagent.py`'s `expect` dicts used inline lambdas, which crash immediately with:

```
_pickle.PicklingError: Can't pickle <function <lambda> at 0x...>: attribute lookup <lambda> on gptme.eval.suites.subagent failed
```

This happens *before* the model is ever invoked, for any `subagent-*` eval, regardless of model/API key/parallelism. That's why the closeout comment on #554 reported the E2E pass had "never" happened — it structurally couldn't.

## Changes

- Convert the three `expect` dicts in `gptme/eval/suites/subagent.py` from inline lambdas to named module-level functions (`_expect_words_marker`, `_expect_clean_exit`, etc.), matching the convention already used for `check_log` in the same file.
- Add `test_subagent_eval_specs_are_picklable` regression test that pickles every `expect`/`check_log` callable in the suite, so this class of bug can't silently reappear.

## Verification

- Before the fix: `uv run gptme-eval subagent-complete-roundtrip -m anthropic/claude-sonnet-4-6` crashed with the `PicklingError` above (0 tool calls, error before any model request).
- After the fix: the same command proceeds past that stage and reaches the Anthropic API — confirmed via a live request that got as far as a 401 (invalid test key in my sandbox), i.e. no `PicklingError`. With a valid API key this should now be able to complete an actual E2E run.
- `.venv/bin/python -m pytest tests/test_eval_subagent.py tests/test_subagent_unit.py tests/test_subagent_integration.py tests/test_subagent_concurrency.py tests/test_tools_subagent.py -q` → 248 passed.
- `ruff check` / `ruff format --diff` / `mypy` clean on both changed files.

## Test plan

- [x] Existing subagent unit/integration/concurrency tests pass
- [x] New picklability regression test passes
- [x] ruff + mypy clean
- [ ] Maintainer with a valid `ANTHROPIC_API_KEY` runs `gptme-eval subagent-parallel-delegation subagent-complete-roundtrip subagent-clarification-roundtrip -m <model>` to confirm the full E2E pass now succeeds (I could not complete this in my sandbox — no real Anthropic key available there, only a placeholder)