### PR TITLE
fix(eval): harden computer-use eval suite flagged at Greptile 3/5 on #3020

### DIFF
--- a/gptme/eval/suites/computer.py
+++ b/gptme/eval/suites/computer.py
@@ -14,6 +14,7 @@ pipelines.
 from typing import TYPE_CHECKING
 
 from gptme.message import Message
+from gptme.tools.base import ToolUse
 
 if TYPE_CHECKING:
     from gptme.eval.types import EvalSpec
@@ -24,39 +25,56 @@ if TYPE_CHECKING:
 # ---------------------------------------------------------------------------
 
 
-def _role_contents(messages: list[Message], role: str) -> str:
-    return "\n".join(msg.content for msg in messages if msg.role == role)
+def _executed_tool_calls(messages: list[Message]) -> list[str]:
+    """Code of every runnable tool call, across assistant messages, in call order.
+
+    Scans parsed ``ToolUse`` blocks rather than raw message text, so a tool
+    name mentioned in prose (e.g. "I will call observe_web(...)") without an
+    actual executable code block does not count as having been used.
+    """
+    return [
+        tu.content
+        for msg in messages
+        if msg.role == "assistant"
+        for tu in ToolUse.iter_from_content(msg.content)
+        if tu.is_runnable and tu.content is not None
+    ]
 
 
 def check_used_snapshot_or_observe_web(messages: list[Message]) -> bool:
-    """Agent must use snapshot_url or observe_web, not screenshot, for a pure web task."""
-    assistant_log = _role_contents(messages, "assistant")
-    return "snapshot_url(" in assistant_log or "observe_web(" in assistant_log
+    """Agent must actually call snapshot_url or observe_web, not screenshot, for a pure web task."""
+    return any(
+        "snapshot_url(" in code or "observe_web(" in code
+        for code in _executed_tool_calls(messages)
+    )
 
 
 def check_did_not_screenshot_for_web(messages: list[Message]) -> bool:
     """Structured-first policy: screenshots should NOT be the first observation for web."""
-    assistant_log = _role_contents(messages, "assistant")
-    first_snapshot = min(
+    calls = _executed_tool_calls(messages)
+    first_snapshot = next(
         (
-            assistant_log.find(needle)
-            for needle in ("snapshot_url(", "observe_web(")
-            if needle in assistant_log
+            i
+            for i, code in enumerate(calls)
+            if "snapshot_url(" in code or "observe_web(" in code
         ),
-        default=-1,
+        -1,
     )
-    first_screenshot = min(
+    first_screenshot = next(
         (
-            assistant_log.find(needle)
-            for needle in (
-                "computer('screenshot')",
-                'computer("screenshot")',
-                "computer(action='screenshot')",
-                'computer(action="screenshot")',
+            i
+            for i, code in enumerate(calls)
+            if any(
+                needle in code
+                for needle in (
+                    "computer('screenshot')",
+                    'computer("screenshot")',
+                    "computer(action='screenshot')",
+                    'computer(action="screenshot")',
+                )
             )
-            if needle in assistant_log
         ),
-        default=-1,
+        -1,
     )
     if first_snapshot == -1:
         # never used structured approach at all — fail
@@ -106,10 +124,10 @@ tests: list["EvalSpec"] = [
         "files": {},
         "run": "cat links.txt",
         "prompt": (
-            "You are in computer-use mode. Use observe_web('https://news.ycombinator.com') "
-            "or snapshot_url('https://news.ycombinator.com') to get the page structure — "
+            "You are in computer-use mode. Use observe_web('https://en.wikipedia.org/wiki/Main_Page') "
+            "or snapshot_url('https://en.wikipedia.org/wiki/Main_Page') to get the page structure — "
             "prefer the structured approach over taking screenshots. "
-            "Find the top 3 story titles (the text of the first 3 ranked links). "
+            "Find the top 3 linked article titles you see on the page. "
             "Write each title on its own line to links.txt."
         ),
         "tools": ["browser", "computer", "vision", "ipython", "save"],

--- a/gptme/eval/suites/computer.py
+++ b/gptme/eval/suites/computer.py
@@ -11,6 +11,7 @@ an X11 display are not included here — they belong in manual or CI-with-displa
 pipelines.
 """
 
+import logging
 from typing import TYPE_CHECKING
 
 from gptme.message import Message
@@ -18,6 +19,8 @@ from gptme.tools.base import ToolUse
 
 if TYPE_CHECKING:
     from gptme.eval.types import EvalSpec
+
+logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -31,14 +34,28 @@ def _executed_tool_calls(messages: list[Message]) -> list[str]:
     Scans parsed ``ToolUse`` blocks rather than raw message text, so a tool
     name mentioned in prose (e.g. "I will call observe_web(...)") without an
     actual executable code block does not count as having been used.
+
+    Note: ``tu.is_runnable`` and ``ToolUse.iter_from_content`` both resolve
+    against the global tool registry (``get_tool`` / ``get_tool_for_langtag``).
+    If ``init_tools()`` was never called — e.g. in a unit test constructing
+    synthetic ``Message`` objects — the registry is empty and this returns
+    ``[]`` for every message, which makes both trajectory checks below fail
+    silently rather than raising. This matches the existing pattern in
+    ``count_tool_calls`` (``eval/run.py``).
     """
-    return [
+    calls = [
         tu.content
         for msg in messages
         if msg.role == "assistant"
         for tu in ToolUse.iter_from_content(msg.content)
         if tu.is_runnable and tu.content is not None
     ]
+    if not calls and any(msg.role == "assistant" for msg in messages):
+        logger.debug(
+            "_executed_tool_calls found no runnable tool calls; "
+            "if this is unexpected, verify init_tools() has been called"
+        )
+    return calls
 
 
 def check_used_snapshot_or_observe_web(messages: list[Message]) -> bool:


### PR DESCRIPTION
## Summary

Addresses the two concrete concerns Greptile raised on #3020 (merged at a 3/5
confidence score, floor for self-merge eligibility is 5/5):

- **Flaky live fetch**: `computer-use-web-extract-links` hit
  `news.ycombinator.com` directly. HN sits behind Cloudflare bot protection
  that routinely blocks headless browsers, making the eval likely to produce
  false failures in network-restricted or containerized CI. Swapped to
  Wikipedia's Main Page, which doesn't bot-block automated fetches.
- **Fragile trajectory checks**: `check_used_snapshot_or_observe_web` and
  `check_did_not_screenshot_for_web` scanned raw concatenated assistant text
  for substrings like `"observe_web("`. An agent that merely *described*
  calling `observe_web(...)` in prose — without ever executing it — would
  satisfy the check. Both helpers now walk parsed `ToolUse.iter_from_content`
  blocks and only count `is_runnable` tool calls, matching the pattern
  `count_tool_calls` already uses in `eval/run.py`.

## Verification

- `poetry run pytest tests/test_profiles.py -q` — 37 passed
- Manual check with `init_tools()` loaded confirming: a prose-only mention of
  `observe_web(` does NOT satisfy the check, but an actual ipython tool-call
  block does; screenshot-before-snapshot ordering is still correctly flagged
  as a policy violation.
- `ruff check`, `ruff format --check`, `mypy` all clean on the changed file.

## Context

Original PR: #3020 (merged 2026-06-30 at Greptile 3/5). This follow-up closes
the quality gap Greptile identified before the eval suite runs in CI as
intended.