### PR TITLE
feat(webui): render normalized transcript messages in session replay detail

### DIFF
--- a/webui/src/components/ExternalSessionsView.tsx
+++ b/webui/src/components/ExternalSessionsView.tsx
@@ -9,6 +9,7 @@ import { use$ } from '@legendapp/state/react';
 import { getRelativeTimeString } from '@/utils/time';
 import type { ExternalSessionCatalogItem } from '@/types/api';
 import { ApiClientError } from '@/utils/api';
+import { SessionReplayMessages } from '@/components/SessionReplayMessages';
 
 const HARNESS_LABELS: Record<string, string> = {
   'claude-code': 'Claude Code',
@@ -128,7 +129,7 @@ const SessionDetail: FC<SessionDetailProps> = ({ sessionId, onClose }) => {
     );
   }
 
-  const transcript = data.transcript as Record<string, unknown>;
+  const messages = Array.isArray(data.transcript.messages) ? data.transcript.messages : null;
 
   return (
     <div className="flex h-full flex-col">
@@ -145,9 +146,13 @@ const SessionDetail: FC<SessionDetailProps> = ({ sessionId, onClose }) => {
         </Button>
       </div>
       <div className="flex-1 overflow-y-auto p-4">
-        <pre className="whitespace-pre-wrap rounded-md bg-muted p-3 text-xs">
-          {JSON.stringify(transcript, null, 2)}
-        </pre>
+        {messages ? (
+          <SessionReplayMessages messages={messages} />
+        ) : (
+          <pre className="whitespace-pre-wrap rounded-md bg-muted p-3 text-xs">
+            {JSON.stringify(data.transcript, null, 2)}
+          </pre>
+        )}
       </div>
     </div>
   );

--- a/webui/src/components/SessionReplayMessages.tsx
+++ b/webui/src/components/SessionReplayMessages.tsx
@@ -1,0 +1,148 @@
+import { type FC, useState } from 'react';
+import { AlertTriangle, ChevronDown, ChevronRight, Terminal, User, Bot } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
+import type { NormalizedMessage } from '@/types/api';
+
+const MAX_TOOL_RESULT_CHARS = 500;
+
+function formatBytes(chars: number): string {
+  return chars < 1024 ? `${chars}B` : `${(chars / 1024).toFixed(1)}KB`;
+}
+
+const ToolCallRow: FC<{ message: NormalizedMessage }> = ({ message }) => {
+  const [open, setOpen] = useState(false);
+  const hasInput = !!message.tool_input && Object.keys(message.tool_input).length > 0;
+
+  return (
+    <div className="mt-1 rounded-md border bg-muted/30 px-2 py-1 text-xs">
+      <Collapsible open={open} onOpenChange={setOpen}>
+        <CollapsibleTrigger asChild>
+          <button
+            className="flex w-full items-center gap-1.5 text-left text-muted-foreground hover:text-foreground"
+            disabled={!hasInput}
+          >
+            <Terminal className="h-3 w-3 flex-shrink-0" />
+            <span className="font-mono">{message.tool_name}</span>
+            {hasInput && (
+              <span className="ml-auto">
+                {open ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
+              </span>
+            )}
+          </button>
+        </CollapsibleTrigger>
+        {hasInput && (
+          <CollapsibleContent>
+            <pre className="mt-1 overflow-x-auto whitespace-pre-wrap rounded bg-muted p-2 font-mono text-[11px]">
+              {JSON.stringify(message.tool_input, null, 2)}
+            </pre>
+          </CollapsibleContent>
+        )}
+      </Collapsible>
+    </div>
+  );
+};
+
+const ToolResultRow: FC<{ message: NormalizedMessage }> = ({ message }) => {
+  const text = message.tool_result ?? message.content ?? '';
+  const isLong = text.length > MAX_TOOL_RESULT_CHARS;
+  const [expanded, setExpanded] = useState(false);
+  const shown = expanded || !isLong ? text : `${text.slice(0, MAX_TOOL_RESULT_CHARS)}…`;
+
+  return (
+    <div
+      className={`mt-1 rounded-md border px-2 py-1 text-xs ${
+        message.is_error ? 'border-destructive/50 bg-destructive/5' : 'bg-muted/20'
+      }`}
+    >
+      <div className="mb-1 flex items-center gap-1.5 text-muted-foreground">
+        <span className="font-mono">tool result</span>
+        {message.is_error && (
+          <Badge variant="destructive" className="h-4 gap-0.5 px-1 text-[10px]">
+            <AlertTriangle className="h-2.5 w-2.5" />
+            error
+          </Badge>
+        )}
+      </div>
+      <pre className="overflow-x-auto whitespace-pre-wrap font-mono text-[11px]">{shown}</pre>
+      {isLong && (
+        <button
+          className="mt-1 text-[11px] text-primary hover:underline"
+          onClick={() => setExpanded((e) => !e)}
+        >
+          {expanded ? 'Show less' : `Show more (${formatBytes(text.length)})`}
+        </button>
+      )}
+    </div>
+  );
+};
+
+const MessageRow: FC<{ message: NormalizedMessage }> = ({ message }) => {
+  if (message.role === 'tool_result') {
+    return <ToolResultRow message={message} />;
+  }
+
+  const isUser = message.role === 'user';
+  return (
+    <div
+      className={`rounded-md border-l-2 px-3 py-2 ${
+        isUser ? 'border-l-blue-500 bg-blue-500/5' : 'border-l-muted-foreground/30'
+      }`}
+    >
+      <div className="mb-1 flex items-center gap-1.5 text-xs text-muted-foreground">
+        {isUser ? <User className="h-3 w-3" /> : <Bot className="h-3 w-3" />}
+        <span className="font-medium">{isUser ? 'User' : 'Assistant'}</span>
+        {message.timestamp && (
+          <span className="text-[10px] opacity-70">
+            {new Date(message.timestamp).toLocaleTimeString()}
+          </span>
+        )}
+      </div>
+      {message.content && <p className="whitespace-pre-wrap text-sm">{message.content}</p>}
+      {message.tool_name && <ToolCallRow message={message} />}
+    </div>
+  );
+};
+
+const SystemPrelude: FC<{ messages: NormalizedMessage[] }> = ({ messages }) => {
+  const [open, setOpen] = useState(false);
+  const totalChars = messages.reduce((sum, m) => sum + (m.content?.length ?? 0), 0);
+
+  return (
+    <Collapsible open={open} onOpenChange={setOpen}>
+      <CollapsibleTrigger asChild>
+        <Button variant="outline" size="sm" className="h-7 gap-1.5 text-xs">
+          {open ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
+          {open ? 'Hide' : 'Show'} {messages.length} system message
+          {messages.length !== 1 ? 's' : ''} ({formatBytes(totalChars)})
+        </Button>
+      </CollapsibleTrigger>
+      <CollapsibleContent className="mt-2 space-y-2">
+        {messages.map((m, i) => (
+          <MessageRow key={i} message={m} />
+        ))}
+      </CollapsibleContent>
+    </Collapsible>
+  );
+};
+
+/** Renders a normalized session transcript: leading system messages collapsed
+ * into a toggle, remaining messages rendered with legible tool call/result rows. */
+export const SessionReplayMessages: FC<{ messages: NormalizedMessage[] }> = ({ messages }) => {
+  let prefixEnd = 0;
+  while (prefixEnd < messages.length && messages[prefixEnd].role === 'system') {
+    prefixEnd++;
+  }
+  const prelude = messages.slice(0, prefixEnd);
+  const rest = messages.slice(prefixEnd);
+
+  return (
+    <div className="space-y-2">
+      {prelude.length > 0 && <SystemPrelude messages={prelude} />}
+      {rest.map((m, i) => (
+        <MessageRow key={prefixEnd + i} message={m} />
+      ))}
+    </div>
+  );
+};

--- a/webui/src/components/SessionReplayMessages.tsx
+++ b/webui/src/components/SessionReplayMessages.tsx
@@ -1,14 +1,24 @@
 import { type FC, useState } from 'react';
-import { AlertTriangle, ChevronDown, ChevronRight, Terminal, User, Bot } from 'lucide-react';
+import {
+  AlertTriangle,
+  ChevronDown,
+  ChevronRight,
+  Terminal,
+  User,
+  Bot,
+  Settings,
+} from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 import type { NormalizedMessage } from '@/types/api';
 
 const MAX_TOOL_RESULT_CHARS = 500;
+const textEncoder = new TextEncoder();
 
-function formatBytes(chars: number): string {
-  return chars < 1024 ? `${chars}B` : `${(chars / 1024).toFixed(1)}KB`;
+function formatByteSize(text: string): string {
+  const bytes = textEncoder.encode(text).length;
+  return bytes < 1024 ? `${bytes}B` : `${(bytes / 1024).toFixed(1)}KB`;
 }
 
 const ToolCallRow: FC<{ message: NormalizedMessage }> = ({ message }) => {
@@ -71,7 +81,7 @@ const ToolResultRow: FC<{ message: NormalizedMessage }> = ({ message }) => {
           className="mt-1 text-[11px] text-primary hover:underline"
           onClick={() => setExpanded((e) => !e)}
         >
-          {expanded ? 'Show less' : `Show more (${formatBytes(text.length)})`}
+          {expanded ? 'Show less' : `Show more (${formatByteSize(text)})`}
         </button>
       )}
     </div>
@@ -84,6 +94,8 @@ const MessageRow: FC<{ message: NormalizedMessage }> = ({ message }) => {
   }
 
   const isUser = message.role === 'user';
+  const isSystem = message.role === 'system';
+  const label = isUser ? 'User' : isSystem ? 'System' : 'Assistant';
   return (
     <div
       className={`rounded-md border-l-2 px-3 py-2 ${
@@ -91,8 +103,14 @@ const MessageRow: FC<{ message: NormalizedMessage }> = ({ message }) => {
       }`}
     >
       <div className="mb-1 flex items-center gap-1.5 text-xs text-muted-foreground">
-        {isUser ? <User className="h-3 w-3" /> : <Bot className="h-3 w-3" />}
-        <span className="font-medium">{isUser ? 'User' : 'Assistant'}</span>
+        {isUser ? (
+          <User className="h-3 w-3" />
+        ) : isSystem ? (
+          <Settings className="h-3 w-3" />
+        ) : (
+          <Bot className="h-3 w-3" />
+        )}
+        <span className="font-medium">{label}</span>
         {message.timestamp && (
           <span className="text-[10px] opacity-70">
             {new Date(message.timestamp).toLocaleTimeString()}
@@ -107,7 +125,7 @@ const MessageRow: FC<{ message: NormalizedMessage }> = ({ message }) => {
 
 const SystemPrelude: FC<{ messages: NormalizedMessage[] }> = ({ messages }) => {
   const [open, setOpen] = useState(false);
-  const totalChars = messages.reduce((sum, m) => sum + (m.content?.length ?? 0), 0);
+  const totalText = messages.map((m) => m.content ?? '').join('');
 
   return (
     <Collapsible open={open} onOpenChange={setOpen}>
@@ -115,7 +133,7 @@ const SystemPrelude: FC<{ messages: NormalizedMessage[] }> = ({ messages }) => {
         <Button variant="outline" size="sm" className="h-7 gap-1.5 text-xs">
           {open ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
           {open ? 'Hide' : 'Show'} {messages.length} system message
-          {messages.length !== 1 ? 's' : ''} ({formatBytes(totalChars)})
+          {messages.length !== 1 ? 's' : ''} ({formatByteSize(totalText)})
         </Button>
       </CollapsibleTrigger>
       <CollapsibleContent className="mt-2 space-y-2">

--- a/webui/src/components/__tests__/ExternalSessionsView.test.tsx
+++ b/webui/src/components/__tests__/ExternalSessionsView.test.tsx
@@ -66,4 +66,59 @@ describe('ExternalSessionsView', () => {
 
     expect(screen.getByRole('button', { name: 'Close session details' })).toBeInTheDocument();
   });
+
+  it('renders normalized transcript messages with a collapsed system prelude', async () => {
+    mockUseQuery.mockImplementation(({ queryKey }: { queryKey: unknown[] }) => {
+      if (queryKey[0] === 'external-sessions') {
+        return {
+          data: [
+            {
+              id: 'session-1',
+              session_id: 'session-1',
+              harness: 'codex',
+              session_name: 'Imported session',
+              project: 'bob',
+              model: 'gpt-5.4',
+              started_at: '2026-05-31T12:00:00Z',
+              last_activity: '2026-05-31T12:05:00Z',
+              capabilities: ['shell'],
+              trajectory_path: '/tmp/trajectory.jsonl',
+            },
+          ],
+          isLoading: false,
+          error: null,
+        };
+      }
+
+      return {
+        data: {
+          transcript: {
+            messages: [
+              { role: 'system', content: 'system prompt' },
+              { role: 'user', content: 'do the thing' },
+              {
+                role: 'assistant',
+                content: 'running it',
+                tool_name: 'shell',
+                tool_input: { command: 'ls' },
+              },
+              { role: 'tool_result', content: '', tool_result: 'boom', is_error: true },
+            ],
+          },
+        },
+        isLoading: false,
+        error: null,
+      };
+    });
+
+    const user = userEvent.setup();
+    render(<ExternalSessionsView />);
+    await user.click(screen.getByRole('button', { name: /Imported session/i }));
+
+    expect(screen.getByRole('button', { name: /Show 1 system message/i })).toBeInTheDocument();
+    expect(screen.getByText('do the thing')).toBeInTheDocument();
+    expect(screen.getByText('running it')).toBeInTheDocument();
+    expect(screen.getByText('boom')).toBeInTheDocument();
+    expect(screen.getByText('error')).toBeInTheDocument();
+  });
 });

--- a/webui/src/types/api.ts
+++ b/webui/src/types/api.ts
@@ -44,7 +44,8 @@ export interface ExternalSessionCatalogItem {
 // Normalized transcript message (see gptme_sessions.transcript.NormalizedMessage)
 export interface NormalizedMessage {
   role: 'user' | 'assistant' | 'system' | 'tool_result';
-  content: string;
+  // Server's to_dict() omits falsy fields, so a tool-call-only turn has no content.
+  content?: string;
   timestamp?: string;
   tool_name?: string;
   tool_input?: Record<string, unknown>;

--- a/webui/src/types/api.ts
+++ b/webui/src/types/api.ts
@@ -41,10 +41,21 @@ export interface ExternalSessionCatalogItem {
   trajectory_path: string;
 }
 
+// Normalized transcript message (see gptme_sessions.transcript.NormalizedMessage)
+export interface NormalizedMessage {
+  role: 'user' | 'assistant' | 'system' | 'tool_result';
+  content: string;
+  timestamp?: string;
+  tool_name?: string;
+  tool_input?: Record<string, unknown>;
+  tool_result?: string;
+  is_error?: boolean;
+}
+
 // External session detail (from /api/v2/external-sessions/:id)
 export interface ExternalSessionDetail {
   id: string;
-  transcript: Record<string, unknown>;
+  transcript: Record<string, unknown> & { messages?: NormalizedMessage[] };
 }
 
 export interface ApiErrorDetails {


### PR DESCRIPTION
## Summary
- The `/external-sessions` detail panel (shipped in #2062) just dumped the whole transcript as raw JSON via `<pre>{JSON.stringify(...)}</pre>`.
- This replaces it with a proper message-by-message replay view: user/assistant message rows, collapsible tool-call inputs, truncated tool results with an error badge, and a collapsed system-prelude toggle for leading system messages.
- Completes items 2-4 of the Phase 3 MVP scope in `knowledge/technical-designs/gptme-session-replay-phase3-webui.md` (item 1, the session list, already shipped in #2062). Keyboard nav and file-diff overlay remain explicitly out of scope for MVP per that doc.
- Falls back to the raw JSON dump when a transcript has no `messages` array (defensive, keeps existing behavior for malformed/legacy payloads).

## Test plan
- [x] `npm run typecheck` - clean
- [x] `npx eslint` on changed files - clean
- [x] `npx prettier --check` on changed files - clean
- [x] `npx jest src/components/__tests__/ExternalSessionsView.test.tsx` - both tests pass (existing raw-JSON-fallback test + new test asserting system-prelude collapse toggle, user/assistant content, and tool-result error badge render correctly)