### PR TITLE
fix(computer): restore Docker build with lockfile-backed install (#216)

### DIFF
--- a/scripts/Dockerfile.computer
+++ b/scripts/Dockerfile.computer
@@ -67,19 +67,16 @@ ENV WIDTH=1024
 ENV HEIGHT=768
 ENV DISPLAY=:${DISPLAY_NUM}
 
-# Install gptme with server and browser extras
-# Two-stage copy for better layer caching: the heavy dep-install layer only
-# re-runs when pyproject.toml or README.md changes, not on every source edit.
+# Install Poetry and dependencies from the committed lockfile.
 WORKDIR /app
-COPY pyproject.toml README.md /app/
-# Minimal stub lets poetry-core (the build backend) resolve and build a wheel
-# so all transitive deps are installed before the full source arrives.
 RUN python3.10 -m pip install --no-cache-dir --upgrade pip && \
-    mkdir -p /app/gptme && touch /app/gptme/__init__.py && \
-    python3.10 -m pip install --no-cache-dir ".[server,browser]"
-# Overwrite stub with real source, then reinstall the package without re-fetching deps.
-COPY . /app
-RUN python3.10 -m pip install --no-cache-dir --no-deps .
+    python3.10 -m pip install --no-cache-dir poetry
+COPY pyproject.toml poetry.lock README.md /app/
+RUN poetry config virtualenvs.create false && \
+    poetry install --no-interaction --no-ansi -E server -E browser --no-root --without=dev
+COPY --chown=$USERNAME:$USERNAME . /app
+RUN python3.10 -m pip install --no-cache-dir build && \
+    poetry install --no-interaction --no-ansi -E server -E browser --without=dev
 
 # Install Playwright system-level deps (needs root)
 RUN python3.10 -m playwright install-deps chromium

--- a/scripts/Dockerfile.computer
+++ b/scripts/Dockerfile.computer
@@ -93,8 +93,6 @@ RUN git config --global user.name "gptme" && \
     git config --global user.email "gptme@superuserlabs.org" && \
     git config --global init.defaultBranch main
 
-# Copy startup scripts
-COPY --chown=$USERNAME:$USERNAME scripts/computer_home/* $HOME/
 RUN chmod +x $HOME/*.sh
 
 # Set working directory

--- a/scripts/Dockerfile.computer
+++ b/scripts/Dockerfile.computer
@@ -67,19 +67,14 @@ ENV WIDTH=1024
 ENV HEIGHT=768
 ENV DISPLAY=:${DISPLAY_NUM}
 
-# Install Poetry and dependencies
-RUN python3.10 -m pip install --no-cache-dir --upgrade pip && \
-    python3.10 -m pip install --no-cache-dir poetry
-
-# Set up project
+# Install gptme with server and browser extras
 WORKDIR /app
-COPY --chown=$USERNAME:$USERNAME pyproject.toml poetry.lock /app/
-RUN poetry config virtualenvs.create false
-RUN poetry install --no-interaction --no-ansi -E server --no-root --without=dev
+COPY . /app
+RUN python3.10 -m pip install --no-cache-dir --upgrade pip && \
+    python3.10 -m pip install --no-cache-dir ".[server,browser]"
 
-COPY --chown=$USERNAME:$USERNAME . /app
-RUN pip install --no-cache-dir build  # this is needed because otherwise poetry removes it
-RUN poetry install --no-interaction --no-ansi -E server --without=dev
+# Install Playwright system-level deps (needs root)
+RUN python3.10 -m playwright install-deps chromium
 
 # Copy desktop environment configs (at the end for faster rebuilds)
 RUN mkdir -p $HOME && chmod 777 $HOME
@@ -89,6 +84,9 @@ RUN chown -R $USERNAME:$USERNAME $HOME
 # Switch to non-root user
 USER $USERNAME
 WORKDIR $HOME
+
+# Install Playwright chromium browser binaries as the runtime user
+RUN python3.10 -m playwright install chromium
 
 # Configure git
 RUN git config --global user.name "gptme" && \

--- a/scripts/Dockerfile.computer
+++ b/scripts/Dockerfile.computer
@@ -68,10 +68,18 @@ ENV HEIGHT=768
 ENV DISPLAY=:${DISPLAY_NUM}
 
 # Install gptme with server and browser extras
+# Two-stage copy for better layer caching: the heavy dep-install layer only
+# re-runs when pyproject.toml or README.md changes, not on every source edit.
 WORKDIR /app
-COPY . /app
+COPY pyproject.toml README.md /app/
+# Minimal stub lets poetry-core (the build backend) resolve and build a wheel
+# so all transitive deps are installed before the full source arrives.
 RUN python3.10 -m pip install --no-cache-dir --upgrade pip && \
+    mkdir -p /app/gptme && touch /app/gptme/__init__.py && \
     python3.10 -m pip install --no-cache-dir ".[server,browser]"
+# Overwrite stub with real source, then reinstall the package without re-fetching deps.
+COPY . /app
+RUN python3.10 -m pip install --no-cache-dir --no-deps .
 
 # Install Playwright system-level deps (needs root)
 RUN python3.10 -m playwright install-deps chromium


### PR DESCRIPTION
## Summary

`make build-docker-computer` was broken around the Docker/VNC computer-use image dependency setup and Playwright install path.

This keeps the image install lockfile-backed with Poetry instead of using an unlocked direct pip install:

- Install dependencies from the committed `poetry.lock` with `poetry install -E server -E browser --without=dev`
- Keep the two-stage install shape: dependency layer from `pyproject.toml`/`poetry.lock`/`README.md`, then install the real source after `COPY . /app`
- `playwright install-deps chromium` runs as root for system apt packages
- `playwright install chromium` runs as the `computeruse` user so browser binaries land in the runtime user's home directory
- Remove the redundant second `scripts/computer_home` copy

This makes the Docker/VNC computer-use mode documented in `docs/howto/computer-use.md` build again while preserving reproducible Python dependency resolution through the lockfile.

## Test plan

- [x] Existing computer tests pass: `pytest tests/test_tools_computer.py tests/test_computer_actions.py tests/test_computer_transport.py tests/test_computer_artifacts.py` (162 passed, 4 skipped)
- [x] `poetry check --lock`
- [x] `make build-docker-computer`
- [ ] `make run-docker-computer` -> noVNC accessible at `http://localhost:6080`

Closes part of #216 (Docker/VNC computer-use mode now buildable again).
