### PR TITLE
feat(computer): add audit-log CLI + interactive web action evals (#216)

### DIFF
--- a/gptme/cli/cmd_computer.py
+++ b/gptme/cli/cmd_computer.py
@@ -15,6 +15,34 @@ from ..tools.base import ToolUse
 _SENSITIVE_ACTIONS = frozenset({"type", "key"})
 
 
+def _slice_call(code: str, start: int) -> str:
+    """Return the source span for a function call starting at ``start``."""
+    depth = 0
+    quote: str | None = None
+    escaped = False
+
+    for i, ch in enumerate(code[start:], start=start):
+        if quote:
+            if escaped:
+                escaped = False
+            elif ch == "\\":
+                escaped = True
+            elif ch == quote:
+                quote = None
+            continue
+
+        if ch in {"'", '"'}:
+            quote = ch
+        elif ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+            if depth == 0:
+                return code[start : i + 1]
+
+    return code[start:]
+
+
 def _extract_computer_calls(messages) -> list[dict]:
     """Extract computer() and observe_desktop() calls from a message list.
 
@@ -33,12 +61,15 @@ def _extract_computer_calls(messages) -> list[dict]:
             # Match computer("action", ...) and computer('action', ...)
             for m in re.finditer(r"""computer\s*\(\s*['"]([^'"]+)['"]""", code):
                 action = m.group(1)
+                call_source = _slice_call(code, m.start())
                 record: dict = {
                     "timestamp": msg.timestamp.isoformat() if msg.timestamp else None,
                     "action": action,
                 }
                 # Extract coordinate if present: coordinate=(x, y)
-                coord_m = re.search(r"coordinate\s*=\s*\((\d+)\s*,\s*(\d+)\)", code)
+                coord_m = re.search(
+                    r"coordinate\s*=\s*\((\d+)\s*,\s*(\d+)\)", call_source
+                )
                 if coord_m:
                     record["coordinate"] = [
                         int(coord_m.group(1)),
@@ -46,7 +77,7 @@ def _extract_computer_calls(messages) -> list[dict]:
                     ]
                 # For type/key actions, redact the text value — log only length
                 if action in _SENSITIVE_ACTIONS:
-                    text_m = re.search(r"""text\s*=\s*['"]([^'"]*)['"]""", code)
+                    text_m = re.search(r"""text\s*=\s*['"]([^'"]*)['"]""", call_source)
                     if text_m:
                         record["text_len"] = len(text_m.group(1))
                     else:

--- a/gptme/cli/cmd_computer.py
+++ b/gptme/cli/cmd_computer.py
@@ -84,16 +84,14 @@ def _extract_computer_calls(messages) -> list[dict]:
                         record["text_len"] = None
                 records.append(record)
             # Also capture observe_desktop() calls
-            if "observe_desktop(" in code:
-                records.append(
-                    {
-                        "timestamp": msg.timestamp.isoformat()
-                        if msg.timestamp
-                        else None,
-                        "action": "screenshot",
-                        "source": "observe_desktop",
-                    }
-                )
+            records.extend(
+                {
+                    "timestamp": msg.timestamp.isoformat() if msg.timestamp else None,
+                    "action": "screenshot",
+                    "source": "observe_desktop",
+                }
+                for _ in re.finditer(r"\bobserve_desktop\s*\(", code)
+            )
     return records
 
 
@@ -144,6 +142,9 @@ def audit_log(conversation: str | None, last: int, as_json: bool):
         paths = [conv_path]
     else:
         # Most-recent N conversations
+        if not logs_dir.exists():
+            click.echo("No conversations found.", err=True)
+            sys.exit(0)
         conv_dirs = sorted(
             (d for d in logs_dir.iterdir() if (d / "conversation.jsonl").exists()),
             key=lambda d: d.stat().st_mtime,

--- a/gptme/cli/cmd_computer.py
+++ b/gptme/cli/cmd_computer.py
@@ -1,0 +1,160 @@
+"""CLI commands for computer-use tooling (audit-log, etc.)."""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+import click
+
+from ..dirs import get_logs_dir
+from ..logmanager import _gen_read_jsonl
+from ..tools.base import ToolUse
+
+# Patterns that indicate text/key content (redact for privacy)
+_SENSITIVE_ACTIONS = frozenset({"type", "key"})
+
+
+def _extract_computer_calls(messages) -> list[dict]:
+    """Extract computer() and observe_desktop() calls from a message list.
+
+    Scans executable tool-use blocks (ipython codeblocks) for calls to the
+    computer() function and the observe_desktop() helper. Typed text is never
+    logged raw — only its length is recorded.
+    """
+    records: list[dict] = []
+    for msg in messages:
+        if msg.role != "assistant":
+            continue
+        for tu in ToolUse.iter_from_content(msg.content):
+            if not tu.is_runnable or not tu.content:
+                continue
+            code = tu.content
+            # Match computer("action", ...) and computer('action', ...)
+            for m in re.finditer(r"""computer\s*\(\s*['"]([^'"]+)['"]""", code):
+                action = m.group(1)
+                record: dict = {
+                    "timestamp": msg.timestamp.isoformat() if msg.timestamp else None,
+                    "action": action,
+                }
+                # Extract coordinate if present: coordinate=(x, y)
+                coord_m = re.search(r"coordinate\s*=\s*\((\d+)\s*,\s*(\d+)\)", code)
+                if coord_m:
+                    record["coordinate"] = [
+                        int(coord_m.group(1)),
+                        int(coord_m.group(2)),
+                    ]
+                # For type/key actions, redact the text value — log only length
+                if action in _SENSITIVE_ACTIONS:
+                    text_m = re.search(r"""text\s*=\s*['"]([^'"]*)['"]""", code)
+                    if text_m:
+                        record["text_len"] = len(text_m.group(1))
+                    else:
+                        record["text_len"] = None
+                records.append(record)
+            # Also capture observe_desktop() calls
+            if "observe_desktop(" in code:
+                records.append(
+                    {
+                        "timestamp": msg.timestamp.isoformat()
+                        if msg.timestamp
+                        else None,
+                        "action": "screenshot",
+                        "source": "observe_desktop",
+                    }
+                )
+    return records
+
+
+@click.group()
+def computer():
+    """Computer-use tooling: audit, diagnostics."""
+
+
+@computer.command("audit-log")
+@click.argument("conversation", required=False)
+@click.option(
+    "--last",
+    default=1,
+    show_default=True,
+    help="Number of most-recent conversations to scan (ignored when CONVERSATION is given).",
+)
+@click.option(
+    "--json", "as_json", is_flag=True, help="Output raw JSON instead of table."
+)
+def audit_log(conversation: str | None, last: int, as_json: bool):
+    """Extract computer-use actions from session trajectories.
+
+    Reads conversation JSONL logs (the authoritative audit trail) and prints a
+    structured summary of every computer() and observe_desktop() call, with
+    typed/key text redacted to just its length.
+
+    CONVERSATION is a conversation name or ID. Omit to scan the most-recent
+    session(s) (controlled by --last).
+
+    Examples:
+
+    \b
+        gptme-util computer audit-log
+        gptme-util computer audit-log --last 3
+        gptme-util computer audit-log my-session-name --json
+    """
+    logs_dir = get_logs_dir()
+
+    if conversation:
+        # Single named conversation
+        conv_path = logs_dir / conversation / "conversation.jsonl"
+        if not conv_path.exists():
+            # Try treating it as a direct path
+            conv_path = Path(conversation)
+        if not conv_path.exists():
+            click.echo(f"Error: conversation not found: {conversation}", err=True)
+            sys.exit(1)
+        paths = [conv_path]
+    else:
+        # Most-recent N conversations
+        conv_dirs = sorted(
+            (d for d in logs_dir.iterdir() if (d / "conversation.jsonl").exists()),
+            key=lambda d: d.stat().st_mtime,
+            reverse=True,
+        )[:last]
+        paths = [d / "conversation.jsonl" for d in conv_dirs]
+        if not paths:
+            click.echo("No conversations found.", err=True)
+            sys.exit(0)
+
+    all_records: list[dict] = []
+    for path in paths:
+        try:
+            msgs = list(_gen_read_jsonl(path))
+        except Exception as e:
+            click.echo(f"Warning: could not read {path}: {e}", err=True)
+            continue
+        records = _extract_computer_calls(msgs)
+        for r in records:
+            r["conversation"] = path.parent.name
+        all_records.extend(records)
+
+    if not all_records:
+        click.echo("No computer-use actions found.")
+        return
+
+    if as_json:
+        click.echo(json.dumps(all_records, indent=2))
+        return
+
+    # Human-readable table
+    click.echo(f"{'Timestamp':<30} {'Conv':<25} {'Action':<25} Details")
+    click.echo("-" * 100)
+    for r in all_records:
+        ts = (r.get("timestamp") or "")[:19]
+        conv = (r.get("conversation") or "")[:24]
+        action = r.get("action", "")[:24]
+        details = ""
+        if "coordinate" in r:
+            details = f"@ {r['coordinate']}"
+        if "text_len" in r and r["text_len"] is not None:
+            details += f" ({r['text_len']} chars, redacted)"
+        if r.get("source") == "observe_desktop":
+            details = "via observe_desktop()"
+        click.echo(f"{ts:<30} {conv:<25} {action:<25} {details}")

--- a/gptme/cli/util.py
+++ b/gptme/cli/util.py
@@ -4,6 +4,7 @@ CLI for gptme utility commands.
 Command groups are split into separate modules for maintainability:
 - cmd_agents.py: Live agent scanning (scan for gptme/claude/codex/… processes)
 - cmd_chats.py: Chat/conversation management (list, search, export, clean, stats)
+- cmd_computer.py: Computer-use tooling (audit-log extracts actions from trajectories)
 - cmd_hooks.py: Claude Code hook installation and execution
 - cmd_mcp.py: MCP server management (list, test, info, search)
 - cmd_batch.py: Batch runner for stdin prompts as fresh non-interactive sessions
@@ -48,6 +49,7 @@ _LAZY_COMMANDS: dict[str, tuple[str, str]] = {
     "attest": (".cmd_attest", "attest"),
     "batch": (".cmd_batch", "batch_cmd"),
     "chats": (".cmd_chats", "chats"),
+    "computer": (".cmd_computer", "computer"),
     "hooks": (".cmd_hooks", "hooks"),
     "mcp": (".cmd_mcp", "mcp"),
     "resume": (".cmd_resume", "resume"),

--- a/gptme/eval/suites/computer.py
+++ b/gptme/eval/suites/computer.py
@@ -4,6 +4,7 @@ Validates end-to-end computer-use workflows:
 - Structured-first web interaction via ARIA snapshots (no screenshot cost)
 - Backend selection policy: prefers snapshot_url / observe_web for web, not screenshot
 - Web content extraction and summarization
+- Interactive web actions: open_page, fill_element, click_element (the "Can it Tweet?" pipeline)
 
 These tests run without a physical display because they use Playwright's
 headless mode via the browser tool. Desktop/screenshot tests that require
@@ -64,6 +65,21 @@ def check_used_snapshot_or_observe_web(messages: list[Message]) -> bool:
         "snapshot_url(" in code or "observe_web(" in code
         for code in _executed_tool_calls(messages)
     )
+
+
+def check_used_open_page(messages: list[Message]) -> bool:
+    """Agent must use open_page() for interactive navigation (not a one-shot read_url)."""
+    return any("open_page(" in code for code in _executed_tool_calls(messages))
+
+
+def check_used_fill_element(messages: list[Message]) -> bool:
+    """Agent must use fill_element() to fill a form field (not type() or screenshot-click)."""
+    return any("fill_element(" in code for code in _executed_tool_calls(messages))
+
+
+def check_used_click_element(messages: list[Message]) -> bool:
+    """Agent must use click_element() to click a button (not coordinate-based clicking)."""
+    return any("click_element(" in code for code in _executed_tool_calls(messages))
 
 
 def check_did_not_screenshot_for_web(messages: list[Message]) -> bool:
@@ -129,6 +145,24 @@ def _expect_at_least_one_title(ctx) -> bool:
     return len(ctx.stdout.strip()) > 5
 
 
+def _expect_result_written(ctx) -> bool:
+    return "result.txt" in ctx.files or len(ctx.stdout.strip()) > 5
+
+
+def _expect_form_submitted(ctx) -> bool:
+    # httpbin returns the submitted fields in a JSON body or as text
+    return "custname" in ctx.stdout or "result.txt" in ctx.files
+
+
+def _expect_page2_content(ctx) -> bool:
+    return "navigation.txt" in ctx.files or len(ctx.stdout.strip()) > 10
+
+
+def _expect_second_page_reached(ctx) -> bool:
+    # Any content indicating a second page was fetched
+    return len(ctx.stdout.strip()) > 5
+
+
 # ---------------------------------------------------------------------------
 # Eval specs
 # ---------------------------------------------------------------------------
@@ -177,6 +211,60 @@ tests: list["EvalSpec"] = [
         },
         "check_log": {
             "used structured snapshot for web content": check_used_snapshot_or_observe_web,
+        },
+    },
+    # --- Interactive web action tests (the "Can it Tweet?" pipeline) ---
+    # These validate that the agent can use open_page + fill_element + click_element
+    # (structured DOM interaction) rather than screenshot-guessing coordinates.
+    # httpbin.org/forms/post is a stable public form that returns submitted values.
+    {
+        "name": "computer-use-web-form-fill",
+        "files": {},
+        "run": "cat result.txt",
+        "prompt": (
+            "You are in computer-use mode. Use the browser tool to fill and submit a web form:\n"
+            "1. Call open_page('https://httpbin.org/forms/post') to open the pizza order form.\n"
+            "2. Call fill_element('[name=\"custname\"]', 'TestUser') to fill the customer name field.\n"
+            "3. Call fill_element('[name=\"custemail\"]', 'test@example.com') to fill the email field.\n"
+            "4. Call click_element('[type=\"submit\"]') to submit the form.\n"
+            "5. Call read_page_text() to read the response.\n"
+            "6. Write the response (or a summary) to result.txt."
+        ),
+        "tools": ["browser", "computer", "vision", "ipython", "save"],
+        "expect": {
+            "result.txt written": _expect_result_written,
+            "form submission reflected": _expect_form_submitted,
+            "clean exit": _expect_clean_exit,
+        },
+        "check_log": {
+            "used open_page for interactive navigation": check_used_open_page,
+            "used fill_element for form input": check_used_fill_element,
+            "used click_element for form submission": check_used_click_element,
+        },
+    },
+    {
+        "name": "computer-use-web-navigate-multi-step",
+        "files": {},
+        "run": "cat navigation.txt",
+        "prompt": (
+            "You are in computer-use mode. Perform a two-step web navigation:\n"
+            "1. Call open_page('https://en.wikipedia.org/wiki/Python_(programming_language)') "
+            "to open the Python Wikipedia article.\n"
+            "2. Call snapshot_url or read_page_text to read the page. Find the first "
+            "external link or the 'History' section heading.\n"
+            "3. Click or navigate to the 'History of Python' link (or another prominent "
+            "internal link). Use click_element or open_page.\n"
+            "4. Call read_page_text() on the second page.\n"
+            "5. Write the title of the second page to navigation.txt."
+        ),
+        "tools": ["browser", "computer", "vision", "ipython", "save"],
+        "expect": {
+            "navigation.txt written": _expect_page2_content,
+            "second page content reached": _expect_second_page_reached,
+            "clean exit": _expect_clean_exit,
+        },
+        "check_log": {
+            "used open_page or click_element for navigation": check_used_open_page,
         },
     },
 ]

--- a/gptme/eval/suites/computer.py
+++ b/gptme/eval/suites/computer.py
@@ -82,6 +82,14 @@ def check_used_click_element(messages: list[Message]) -> bool:
     return any("click_element(" in code for code in _executed_tool_calls(messages))
 
 
+def check_used_open_page_or_click_element(messages: list[Message]) -> bool:
+    """Agent must navigate interactively with open_page() or click_element()."""
+    return any(
+        "open_page(" in code or "click_element(" in code
+        for code in _executed_tool_calls(messages)
+    )
+
+
 def check_did_not_screenshot_for_web(messages: list[Message]) -> bool:
     """Structured-first policy: screenshots should NOT be the first observation for web."""
     calls = _executed_tool_calls(messages)
@@ -159,8 +167,12 @@ def _expect_page2_content(ctx) -> bool:
 
 
 def _expect_second_page_reached(ctx) -> bool:
-    # Any content indicating a second page was fetched
-    return len(ctx.stdout.strip()) > 5
+    content = ctx.files.get("navigation.txt")
+    if content is None:
+        return False
+    if isinstance(content, bytes):
+        content = content.decode(errors="replace")
+    return len(content.strip()) > 5
 
 
 # ---------------------------------------------------------------------------
@@ -264,7 +276,7 @@ tests: list["EvalSpec"] = [
             "clean exit": _expect_clean_exit,
         },
         "check_log": {
-            "used open_page or click_element for navigation": check_used_open_page,
+            "used open_page or click_element for navigation": check_used_open_page_or_click_element,
         },
     },
 ]

--- a/gptme/eval/suites/computer.py
+++ b/gptme/eval/suites/computer.py
@@ -158,8 +158,8 @@ def _expect_result_written(ctx) -> bool:
 
 
 def _expect_form_submitted(ctx) -> bool:
-    # httpbin returns the submitted fields in a JSON body or as text
-    return "custname" in ctx.stdout or "result.txt" in ctx.files
+    # httpbin returns the submitted fields in a JSON body or as text.
+    return "custname" in ctx.stdout
 
 
 def _expect_page2_content(ctx) -> bool:

--- a/tests/test_computer_audit.py
+++ b/tests/test_computer_audit.py
@@ -80,6 +80,18 @@ def test_observe_desktop_captured():
     assert records[0]["source"] == "observe_desktop"
 
 
+def test_multiple_observe_desktop_calls_counted():
+    code = textwrap.dedent("""\
+        observe_desktop()
+        observe_desktop()
+    """)
+    msgs = [_msg("assistant", _ipython_block(code))]
+    records = _extract_computer_calls(msgs)
+    assert len(records) == 2
+    assert all(r["action"] == "screenshot" for r in records)
+    assert all(r["source"] == "observe_desktop" for r in records)
+
+
 def test_non_assistant_messages_ignored():
     msgs = [
         _msg("user", "please take a screenshot"),
@@ -199,3 +211,14 @@ def test_audit_log_cli_redacts_type(tmp_path):
     assert "mysecretpassword" not in result.output
     assert data[0]["text_len"] == len("mysecretpassword")
     assert "text" not in data[0]
+
+
+def test_audit_log_cli_no_logs_dir(tmp_path, monkeypatch):
+    missing_logs = tmp_path / "missing-logs"
+    monkeypatch.setattr("gptme.cli.cmd_computer.get_logs_dir", lambda: missing_logs)
+
+    runner = CliRunner()
+    result = runner.invoke(audit_log, [], catch_exceptions=False)
+
+    assert result.exit_code == 0
+    assert "No conversations found." in result.output

--- a/tests/test_computer_audit.py
+++ b/tests/test_computer_audit.py
@@ -1,0 +1,165 @@
+"""Tests for gptme-util computer audit-log (cmd_computer.py).
+
+Validates that computer() and observe_desktop() calls are extracted from
+synthetic JSONL trajectories, and that typed text is never logged raw.
+"""
+
+from __future__ import annotations
+
+import json
+import textwrap
+from datetime import datetime, timezone
+from pathlib import Path  # noqa: TC003 — used at runtime in _write_conv_jsonl
+
+from click.testing import CliRunner
+
+from gptme.cli.cmd_computer import _extract_computer_calls, audit_log
+from gptme.message import Message
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _msg(role: str, content: str) -> Message:
+    ts = datetime(2026, 7, 1, 12, 0, 0, tzinfo=timezone.utc)
+    return Message(role=role, content=content, timestamp=ts)  # type: ignore[arg-type,call-arg]
+
+
+def _ipython_block(code: str) -> str:
+    return f"```ipython\n{code}\n```"
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for _extract_computer_calls
+# ---------------------------------------------------------------------------
+
+
+def test_screenshot_action_extracted():
+    msgs = [_msg("assistant", _ipython_block("computer('screenshot')"))]
+    records = _extract_computer_calls(msgs)
+    assert len(records) == 1
+    assert records[0]["action"] == "screenshot"
+    assert "text_len" not in records[0]
+
+
+def test_type_action_text_is_redacted():
+    msgs = [_msg("assistant", _ipython_block("computer('type', text='hunter2')"))]
+    records = _extract_computer_calls(msgs)
+    assert len(records) == 1
+    assert records[0]["action"] == "type"
+    # Raw text must NOT appear in the record
+    assert "text" not in records[0]
+    # Only the length is recorded
+    assert records[0]["text_len"] == len("hunter2")
+
+
+def test_key_action_text_is_redacted():
+    msgs = [_msg("assistant", _ipython_block("computer('key', text='Return')"))]
+    records = _extract_computer_calls(msgs)
+    assert len(records) == 1
+    assert records[0]["action"] == "key"
+    assert "text" not in records[0]
+    assert records[0]["text_len"] == len("Return")
+
+
+def test_click_with_coordinate():
+    code = "computer('left_click', coordinate=(100, 200))"
+    msgs = [_msg("assistant", _ipython_block(code))]
+    records = _extract_computer_calls(msgs)
+    assert len(records) == 1
+    assert records[0]["action"] == "left_click"
+    assert records[0]["coordinate"] == [100, 200]
+
+
+def test_observe_desktop_captured():
+    msgs = [_msg("assistant", _ipython_block("observe_desktop()"))]
+    records = _extract_computer_calls(msgs)
+    assert len(records) == 1
+    assert records[0]["action"] == "screenshot"
+    assert records[0]["source"] == "observe_desktop"
+
+
+def test_non_assistant_messages_ignored():
+    msgs = [
+        _msg("user", "please take a screenshot"),
+        _msg("system", "computer('screenshot')"),  # system message, not assistant
+    ]
+    records = _extract_computer_calls(msgs)
+    assert records == []
+
+
+def test_multiple_actions_in_one_block():
+    code = textwrap.dedent("""\
+        computer('screenshot')
+        computer('left_click', coordinate=(50, 75))
+    """)
+    msgs = [_msg("assistant", _ipython_block(code))]
+    records = _extract_computer_calls(msgs)
+    assert len(records) == 2
+    actions = {r["action"] for r in records}
+    assert actions == {"screenshot", "left_click"}
+
+
+def test_prose_mention_not_counted():
+    # "I will call computer('screenshot')" in plain prose (no code block) should
+    # not be counted — only runnable tool-use blocks count.
+    msgs = [_msg("assistant", "I will call computer('screenshot') to see the screen.")]
+    records = _extract_computer_calls(msgs)
+    # No runnable tool-use block → nothing extracted
+    assert records == []
+
+
+# ---------------------------------------------------------------------------
+# Integration test: audit-log CLI against a synthetic JSONL file
+# ---------------------------------------------------------------------------
+
+
+def _write_conv_jsonl(path: Path, messages: list[Message]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        f.writelines(json.dumps(msg.to_dict()) + "\n" for msg in messages)
+
+
+def test_audit_log_cli_basic(tmp_path):
+    conv_dir = tmp_path / "test-conv-2026-07-01"
+    jsonl = conv_dir / "conversation.jsonl"
+    msgs = [
+        _msg("user", "take a screenshot"),
+        _msg("assistant", _ipython_block("computer('screenshot')")),
+    ]
+    _write_conv_jsonl(jsonl, msgs)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        audit_log, [str(jsonl.parent.name), "--json"], catch_exceptions=False
+    )
+    # The command takes a conversation name and looks in get_logs_dir(); pass
+    # the file directly via a path argument instead.
+    result2 = runner.invoke(
+        audit_log,
+        # Pass the JSONL path directly as the "conversation" arg
+        [str(jsonl)],
+        catch_exceptions=False,
+    )
+    # Either invocation style; just verify the CLI runs without error
+    assert result.exit_code == 0 or result2.exit_code == 0
+
+
+def test_audit_log_cli_redacts_type(tmp_path):
+    conv_dir = tmp_path / "secret-conv"
+    jsonl = conv_dir / "conversation.jsonl"
+    msgs = [
+        _msg("assistant", _ipython_block("computer('type', text='mysecretpassword')")),
+    ]
+    _write_conv_jsonl(jsonl, msgs)
+
+    runner = CliRunner()
+    result = runner.invoke(audit_log, [str(jsonl), "--json"], catch_exceptions=False)
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert len(data) == 1
+    # Raw password must NOT appear anywhere in the output
+    assert "mysecretpassword" not in result.output
+    assert data[0]["text_len"] == len("mysecretpassword")
+    assert "text" not in data[0]

--- a/tests/test_computer_audit.py
+++ b/tests/test_computer_audit.py
@@ -222,3 +222,142 @@ def test_audit_log_cli_no_logs_dir(tmp_path, monkeypatch):
 
     assert result.exit_code == 0
     assert "No conversations found." in result.output
+
+
+# ---------------------------------------------------------------------------
+# _slice_call edge cases (lines 27, 29, 43)
+# ---------------------------------------------------------------------------
+
+from gptme.cli.cmd_computer import _slice_call
+
+
+def test_slice_call_handles_escaped_quote():
+    """Backslash-escaped quote inside string is not treated as end-of-string (lines 27–29)."""
+    code = "computer('type', text='pass\\'word')"
+    result = _slice_call(code, 0)
+    assert result == code
+
+
+def test_slice_call_unclosed_paren_returns_remainder():
+    """When no closing ')' is found the fallback returns the rest of the string (line 43)."""
+    code = "computer('screenshot'"  # no closing paren
+    result = _slice_call(code, 0)
+    assert result == code
+
+
+# ---------------------------------------------------------------------------
+# _extract_computer_calls edge cases (lines 59, 84)
+# ---------------------------------------------------------------------------
+
+
+def test_type_action_without_text_param():
+    """type() called without a text= argument sets text_len to None (line 84)."""
+    msgs = [_msg("assistant", _ipython_block("computer('type')"))]
+    records = _extract_computer_calls(msgs)
+    assert len(records) == 1
+    assert records[0]["action"] == "type"
+    assert records[0]["text_len"] is None
+
+
+# ---------------------------------------------------------------------------
+# CLI: additional paths
+# ---------------------------------------------------------------------------
+
+
+def test_audit_log_cli_no_actions_found(tmp_path):
+    """When conversation has no computer() calls a user-friendly message is printed (lines 171–172)."""
+    conv_dir = tmp_path / "chat-conv"
+    jsonl = conv_dir / "conversation.jsonl"
+    msgs = [_msg("user", "hello"), _msg("assistant", "hi there")]
+    _write_conv_jsonl(jsonl, msgs)
+
+    runner = CliRunner()
+    result = runner.invoke(audit_log, [str(jsonl)], catch_exceptions=False)
+    assert result.exit_code == 0
+    assert "No computer-use actions found." in result.output
+
+
+def test_audit_log_cli_table_output(tmp_path):
+    """Default (non-JSON) table output includes coordinate, redacted text, and observe_desktop details (lines 187, 189, 191)."""
+    conv_dir = tmp_path / "table-conv"
+    jsonl = conv_dir / "conversation.jsonl"
+    msgs = [
+        _msg(
+            "assistant", _ipython_block("computer('left_click', coordinate=(100, 200))")
+        ),
+        _msg("assistant", _ipython_block("computer('type', text='hello')")),
+        _msg("assistant", _ipython_block("observe_desktop()")),
+    ]
+    _write_conv_jsonl(jsonl, msgs)
+
+    runner = CliRunner()
+    result = runner.invoke(audit_log, [str(jsonl)], catch_exceptions=False)
+    assert result.exit_code == 0
+    assert "Timestamp" in result.output  # table header
+    assert "@ [100, 200]" in result.output  # coordinate detail (line 187)
+    assert "chars, redacted" in result.output  # text_len detail (line 189)
+    assert "via observe_desktop()" in result.output  # source detail (line 191)
+
+
+def test_audit_log_cli_named_conv_not_found(tmp_path, monkeypatch):
+    """Named conversation not in logs_dir prints an error and exits 1 (lines 140–141)."""
+    monkeypatch.setattr("gptme.cli.cmd_computer.get_logs_dir", lambda: tmp_path)
+
+    runner = CliRunner()
+    result = runner.invoke(audit_log, ["nonexistent-conv"], catch_exceptions=False)
+    assert result.exit_code == 1
+    assert "not found" in result.output
+
+
+def test_audit_log_cli_scan_recent_conversations(tmp_path, monkeypatch):
+    """--last N scans the N most-recent conversations from logs_dir (lines 148–156)."""
+    monkeypatch.setattr("gptme.cli.cmd_computer.get_logs_dir", lambda: tmp_path)
+
+    for name in ["conv-a", "conv-b"]:
+        msgs = [_msg("assistant", _ipython_block("computer('screenshot')"))]
+        _write_conv_jsonl(tmp_path / name / "conversation.jsonl", msgs)
+
+    runner = CliRunner()
+    result = runner.invoke(audit_log, ["--last", "2", "--json"], catch_exceptions=False)
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert len(data) == 2
+    conv_names = {r["conversation"] for r in data}
+    assert "conv-a" in conv_names
+    assert "conv-b" in conv_names
+
+
+def test_audit_log_cli_empty_logs_dir(tmp_path, monkeypatch):
+    """logs_dir exists but has no conversation subdirectories → 'No conversations found.' (lines 155–156)."""
+    monkeypatch.setattr("gptme.cli.cmd_computer.get_logs_dir", lambda: tmp_path)
+    # tmp_path exists but is empty
+    runner = CliRunner()
+    result = runner.invoke(audit_log, [], catch_exceptions=False)
+    assert result.exit_code == 0
+    assert "No conversations found." in result.output
+
+
+def test_audit_log_cli_corrupted_jsonl_warns(tmp_path, monkeypatch):
+    """When _gen_read_jsonl raises, a warning is printed and processing continues (lines 162–164)."""
+    conv_dir = tmp_path / "corrupt-conv"
+    jsonl = conv_dir / "conversation.jsonl"
+    _write_conv_jsonl(
+        jsonl, [_msg("assistant", _ipython_block("computer('screenshot')"))]
+    )
+
+    def _explode(path):
+        raise OSError("permission denied")
+
+    monkeypatch.setattr("gptme.cli.cmd_computer._gen_read_jsonl", _explode)
+
+    runner = CliRunner()
+    result = runner.invoke(audit_log, [str(jsonl)], catch_exceptions=False)
+    assert result.exit_code == 0
+    assert "Warning: could not read" in result.output
+
+
+def test_empty_code_block_skipped():
+    """An ipython block with empty content hits the continue guard (line 59)."""
+    msgs = [_msg("assistant", "```ipython\n\n```")]
+    records = _extract_computer_calls(msgs)
+    assert records == []

--- a/tests/test_computer_audit.py
+++ b/tests/test_computer_audit.py
@@ -101,6 +101,39 @@ def test_multiple_actions_in_one_block():
     assert actions == {"screenshot", "left_click"}
 
 
+def test_multiple_actions_in_one_block_scopes_fields_per_call():
+    code = textwrap.dedent("""\
+        computer('screenshot')
+        computer('left_click', coordinate=(50, 75))
+        computer('type', text='short')
+        computer('type', text='much-longer')
+    """)
+    msgs = [_msg("assistant", _ipython_block(code))]
+    records = _extract_computer_calls(msgs)
+
+    assert records == [
+        {
+            "timestamp": "2026-07-01T12:00:00+00:00",
+            "action": "screenshot",
+        },
+        {
+            "timestamp": "2026-07-01T12:00:00+00:00",
+            "action": "left_click",
+            "coordinate": [50, 75],
+        },
+        {
+            "timestamp": "2026-07-01T12:00:00+00:00",
+            "action": "type",
+            "text_len": len("short"),
+        },
+        {
+            "timestamp": "2026-07-01T12:00:00+00:00",
+            "action": "type",
+            "text_len": len("much-longer"),
+        },
+    ]
+
+
 def test_prose_mention_not_counted():
     # "I will call computer('screenshot')" in plain prose (no code block) should
     # not be counted — only runnable tool-use blocks count.
@@ -121,7 +154,7 @@ def _write_conv_jsonl(path: Path, messages: list[Message]) -> None:
         f.writelines(json.dumps(msg.to_dict()) + "\n" for msg in messages)
 
 
-def test_audit_log_cli_basic(tmp_path):
+def test_audit_log_cli_basic(tmp_path, monkeypatch):
     conv_dir = tmp_path / "test-conv-2026-07-01"
     jsonl = conv_dir / "conversation.jsonl"
     msgs = [
@@ -129,21 +162,24 @@ def test_audit_log_cli_basic(tmp_path):
         _msg("assistant", _ipython_block("computer('screenshot')")),
     ]
     _write_conv_jsonl(jsonl, msgs)
+    monkeypatch.setattr("gptme.cli.cmd_computer.get_logs_dir", lambda: tmp_path)
 
     runner = CliRunner()
     result = runner.invoke(
         audit_log, [str(jsonl.parent.name), "--json"], catch_exceptions=False
     )
-    # The command takes a conversation name and looks in get_logs_dir(); pass
-    # the file directly via a path argument instead.
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert data[0]["conversation"] == jsonl.parent.name
+    assert data[0]["action"] == "screenshot"
+
     result2 = runner.invoke(
         audit_log,
         # Pass the JSONL path directly as the "conversation" arg
         [str(jsonl)],
         catch_exceptions=False,
     )
-    # Either invocation style; just verify the CLI runs without error
-    assert result.exit_code == 0 or result2.exit_code == 0
+    assert result2.exit_code == 0, result2.output
 
 
 def test_audit_log_cli_redacts_type(tmp_path):

--- a/tests/test_eval_computer_suite.py
+++ b/tests/test_eval_computer_suite.py
@@ -44,3 +44,25 @@ def test_expect_second_page_reached_accepts_navigation_file():
     )
 
     assert computer_suite._expect_second_page_reached(ctx)
+
+
+def test_expect_form_submitted_requires_echoed_field():
+    ctx = ResultContext(
+        files={"result.txt": "Error: form unavailable"},
+        stdout="Error: form unavailable",
+        stderr="",
+        exit_code=0,
+    )
+
+    assert not computer_suite._expect_form_submitted(ctx)
+
+
+def test_expect_form_submitted_accepts_echoed_field():
+    ctx = ResultContext(
+        files={"result.txt": '{"form": {"custname": "TestUser"}}'},
+        stdout='{"form": {"custname": "TestUser"}}',
+        stderr="",
+        exit_code=0,
+    )
+
+    assert computer_suite._expect_form_submitted(ctx)

--- a/tests/test_eval_computer_suite.py
+++ b/tests/test_eval_computer_suite.py
@@ -1,7 +1,23 @@
 """Tests for computer-use eval suite helpers."""
 
+import logging
+from datetime import datetime, timezone
+
 from gptme.eval.suites import computer as computer_suite
 from gptme.eval.types import ResultContext
+from gptme.message import Message
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _ts():
+    return datetime(2026, 7, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _assistant(text: str) -> Message:
+    return Message(role="assistant", content=text, timestamp=_ts())
 
 
 def test_check_used_open_page_or_click_element_accepts_click(monkeypatch):
@@ -66,3 +82,353 @@ def test_expect_form_submitted_accepts_echoed_field():
     )
 
     assert computer_suite._expect_form_submitted(ctx)
+
+
+# ---------------------------------------------------------------------------
+# _executed_tool_calls — direct calls (lines 47-59)
+# ---------------------------------------------------------------------------
+
+
+def test_executed_tool_calls_empty_messages():
+    """Empty message list returns [] without errors (lines 47-53)."""
+    assert computer_suite._executed_tool_calls([]) == []
+
+
+def test_executed_tool_calls_user_message_skipped():
+    """Non-assistant messages are ignored (line 50 filter)."""
+    msgs = [Message(role="user", content="take a screenshot", timestamp=_ts())]
+    assert computer_suite._executed_tool_calls(msgs) == []
+
+
+def test_executed_tool_calls_no_runnable_tools_emits_debug(caplog):
+    """When assistant message exists but no tools are registered, [] is returned and debug is logged (lines 54-58)."""
+    msgs = [_assistant("I will take a screenshot now.")]
+    with caplog.at_level(logging.DEBUG, logger="gptme.eval.suites.computer"):
+        result = computer_suite._executed_tool_calls(msgs)
+    assert result == []
+    assert "verify init_tools" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# check_used_snapshot_or_observe_web (line 64)
+# ---------------------------------------------------------------------------
+
+
+def test_check_used_snapshot_or_observe_web_snapshot(monkeypatch):
+    monkeypatch.setattr(
+        computer_suite,
+        "_executed_tool_calls",
+        lambda messages: ["snapshot_url('https://example.com')"],
+    )
+    assert computer_suite.check_used_snapshot_or_observe_web([])
+
+
+def test_check_used_snapshot_or_observe_web_observe_web(monkeypatch):
+    monkeypatch.setattr(
+        computer_suite,
+        "_executed_tool_calls",
+        lambda messages: ["observe_web('https://example.com')"],
+    )
+    assert computer_suite.check_used_snapshot_or_observe_web([])
+
+
+def test_check_used_snapshot_or_observe_web_rejects_screenshot_only(monkeypatch):
+    monkeypatch.setattr(
+        computer_suite,
+        "_executed_tool_calls",
+        lambda messages: ["computer('screenshot')"],
+    )
+    assert not computer_suite.check_used_snapshot_or_observe_web([])
+
+
+# ---------------------------------------------------------------------------
+# check_used_open_page (line 72)
+# ---------------------------------------------------------------------------
+
+
+def test_check_used_open_page_accepts(monkeypatch):
+    monkeypatch.setattr(
+        computer_suite,
+        "_executed_tool_calls",
+        lambda messages: ["open_page('https://example.com')"],
+    )
+    assert computer_suite.check_used_open_page([])
+
+
+def test_check_used_open_page_rejects_read_url(monkeypatch):
+    monkeypatch.setattr(
+        computer_suite,
+        "_executed_tool_calls",
+        lambda messages: ["read_page_text()"],
+    )
+    assert not computer_suite.check_used_open_page([])
+
+
+# ---------------------------------------------------------------------------
+# check_used_fill_element (line 77)
+# ---------------------------------------------------------------------------
+
+
+def test_check_used_fill_element_accepts(monkeypatch):
+    monkeypatch.setattr(
+        computer_suite,
+        "_executed_tool_calls",
+        lambda messages: ['fill_element(\'[name="custname"]\', "TestUser")'],
+    )
+    assert computer_suite.check_used_fill_element([])
+
+
+def test_check_used_fill_element_rejects_type_action(monkeypatch):
+    monkeypatch.setattr(
+        computer_suite,
+        "_executed_tool_calls",
+        lambda messages: ["computer('type', text='TestUser')"],
+    )
+    assert not computer_suite.check_used_fill_element([])
+
+
+# ---------------------------------------------------------------------------
+# check_used_click_element (line 82)
+# ---------------------------------------------------------------------------
+
+
+def test_check_used_click_element_accepts(monkeypatch):
+    monkeypatch.setattr(
+        computer_suite,
+        "_executed_tool_calls",
+        lambda messages: ["click_element('[type=\"submit\"]')"],
+    )
+    assert computer_suite.check_used_click_element([])
+
+
+def test_check_used_click_element_rejects_coordinate_click(monkeypatch):
+    monkeypatch.setattr(
+        computer_suite,
+        "_executed_tool_calls",
+        lambda messages: ["computer('left_click', coordinate=(100, 200))"],
+    )
+    assert not computer_suite.check_used_click_element([])
+
+
+# ---------------------------------------------------------------------------
+# check_did_not_screenshot_for_web (lines 95-127)
+# ---------------------------------------------------------------------------
+
+
+def test_check_did_not_screenshot_no_structured_call_fails(monkeypatch):
+    """first_snapshot == -1 → structured approach never used → fail (line 121)."""
+    monkeypatch.setattr(
+        computer_suite,
+        "_executed_tool_calls",
+        lambda messages: ["computer('screenshot')"],
+    )
+    assert not computer_suite.check_did_not_screenshot_for_web([])
+
+
+def test_check_did_not_screenshot_structured_only_passes(monkeypatch):
+    """Snapshot used, no screenshot at all → ideal path (line 124)."""
+    monkeypatch.setattr(
+        computer_suite,
+        "_executed_tool_calls",
+        lambda messages: ["snapshot_url('https://example.com')", "read_page_text()"],
+    )
+    assert computer_suite.check_did_not_screenshot_for_web([])
+
+
+def test_check_did_not_screenshot_snapshot_before_screenshot_passes(monkeypatch):
+    """Snapshot precedes screenshot → policy respected (line 127 branch)."""
+    monkeypatch.setattr(
+        computer_suite,
+        "_executed_tool_calls",
+        lambda messages: [
+            "snapshot_url('https://example.com')",
+            "computer('screenshot')",
+        ],
+    )
+    assert computer_suite.check_did_not_screenshot_for_web([])
+
+
+def test_check_did_not_screenshot_screenshot_before_snapshot_fails(monkeypatch):
+    """Screenshot precedes snapshot → policy violated (line 127 branch, False)."""
+    monkeypatch.setattr(
+        computer_suite,
+        "_executed_tool_calls",
+        lambda messages: [
+            "computer('screenshot')",
+            "snapshot_url('https://example.com')",
+        ],
+    )
+    assert not computer_suite.check_did_not_screenshot_for_web([])
+
+
+def test_check_did_not_screenshot_double_quote_screenshot_detected(monkeypatch):
+    """Double-quote variant computer("screenshot") is also detected (lines 110-116)."""
+    monkeypatch.setattr(
+        computer_suite,
+        "_executed_tool_calls",
+        lambda messages: [
+            'computer("screenshot")',
+            "snapshot_url('https://example.com')",
+        ],
+    )
+    assert not computer_suite.check_did_not_screenshot_for_web([])
+
+
+# ---------------------------------------------------------------------------
+# _expect_summary_written (line 137)
+# ---------------------------------------------------------------------------
+
+
+def test_expect_summary_written_file_present():
+    ctx = ResultContext(
+        files={"summary.txt": "TITLE=Hello"}, stdout="", stderr="", exit_code=0
+    )
+    assert computer_suite._expect_summary_written(ctx)
+
+
+def test_expect_summary_written_via_stdout():
+    ctx = ResultContext(files={}, stdout="TITLE=Hello World", stderr="", exit_code=0)
+    assert computer_suite._expect_summary_written(ctx)
+
+
+def test_expect_summary_written_fails_when_empty():
+    ctx = ResultContext(files={}, stdout="", stderr="", exit_code=0)
+    assert not computer_suite._expect_summary_written(ctx)
+
+
+# ---------------------------------------------------------------------------
+# _expect_title_extracted (line 141)
+# ---------------------------------------------------------------------------
+
+
+def test_expect_title_extracted_title_prefix():
+    ctx = ResultContext(files={}, stdout="TITLE=Example Domain", stderr="", exit_code=0)
+    assert computer_suite._expect_title_extracted(ctx)
+
+
+def test_expect_title_extracted_example_domain():
+    ctx = ResultContext(
+        files={}, stdout="Example Domain is the page title.", stderr="", exit_code=0
+    )
+    assert computer_suite._expect_title_extracted(ctx)
+
+
+def test_expect_title_extracted_fails_generic_output():
+    ctx = ResultContext(
+        files={}, stdout="no useful content here", stderr="", exit_code=0
+    )
+    assert not computer_suite._expect_title_extracted(ctx)
+
+
+# ---------------------------------------------------------------------------
+# _expect_clean_exit (line 145)
+# ---------------------------------------------------------------------------
+
+
+def test_expect_clean_exit_zero():
+    ctx = ResultContext(files={}, stdout="", stderr="", exit_code=0)
+    assert computer_suite._expect_clean_exit(ctx)
+
+
+def test_expect_clean_exit_nonzero():
+    ctx = ResultContext(files={}, stdout="", stderr="error", exit_code=1)
+    assert not computer_suite._expect_clean_exit(ctx)
+
+
+# ---------------------------------------------------------------------------
+# _expect_links_written (line 149)
+# ---------------------------------------------------------------------------
+
+
+def test_expect_links_written_file_present():
+    ctx = ResultContext(
+        files={"links.txt": "Python\nJava\nRust"}, stdout="", stderr="", exit_code=0
+    )
+    assert computer_suite._expect_links_written(ctx)
+
+
+def test_expect_links_written_via_stdout():
+    ctx = ResultContext(files={}, stdout="Python\nJava\nRust", stderr="", exit_code=0)
+    assert computer_suite._expect_links_written(ctx)
+
+
+def test_expect_links_written_fails_empty():
+    ctx = ResultContext(files={}, stdout="", stderr="", exit_code=0)
+    assert not computer_suite._expect_links_written(ctx)
+
+
+# ---------------------------------------------------------------------------
+# _expect_at_least_one_title (line 153)
+# ---------------------------------------------------------------------------
+
+
+def test_expect_at_least_one_title_success():
+    ctx = ResultContext(files={}, stdout="Example Domain", stderr="", exit_code=0)
+    assert computer_suite._expect_at_least_one_title(ctx)
+
+
+def test_expect_at_least_one_title_fails_empty():
+    ctx = ResultContext(files={}, stdout="", stderr="", exit_code=0)
+    assert not computer_suite._expect_at_least_one_title(ctx)
+
+
+# ---------------------------------------------------------------------------
+# _expect_result_written (line 157)
+# ---------------------------------------------------------------------------
+
+
+def test_expect_result_written_file_present():
+    ctx = ResultContext(
+        files={"result.txt": "submitted"}, stdout="", stderr="", exit_code=0
+    )
+    assert computer_suite._expect_result_written(ctx)
+
+
+def test_expect_result_written_via_stdout():
+    ctx = ResultContext(files={}, stdout="Form submitted!", stderr="", exit_code=0)
+    assert computer_suite._expect_result_written(ctx)
+
+
+def test_expect_result_written_fails_empty():
+    ctx = ResultContext(files={}, stdout="", stderr="", exit_code=0)
+    assert not computer_suite._expect_result_written(ctx)
+
+
+# ---------------------------------------------------------------------------
+# _expect_page2_content (line 166)
+# ---------------------------------------------------------------------------
+
+
+def test_expect_page2_content_file_present():
+    ctx = ResultContext(
+        files={"navigation.txt": "History of Python"}, stdout="", stderr="", exit_code=0
+    )
+    assert computer_suite._expect_page2_content(ctx)
+
+
+def test_expect_page2_content_via_stdout():
+    ctx = ResultContext(
+        files={}, stdout="History of Python (redirected)", stderr="", exit_code=0
+    )
+    assert computer_suite._expect_page2_content(ctx)
+
+
+def test_expect_page2_content_fails_empty():
+    ctx = ResultContext(files={}, stdout="", stderr="", exit_code=0)
+    assert not computer_suite._expect_page2_content(ctx)
+
+
+# ---------------------------------------------------------------------------
+# _expect_second_page_reached bytes branch (line 174)
+# ---------------------------------------------------------------------------
+
+
+def test_expect_second_page_reached_decodes_bytes():
+    """bytes content is decoded before length check (line 174)."""
+    ctx = ResultContext(
+        files={"navigation.txt": b"History of Python"},
+        stdout="",
+        stderr="",
+        exit_code=0,
+    )
+    assert computer_suite._expect_second_page_reached(ctx)

--- a/tests/test_eval_computer_suite.py
+++ b/tests/test_eval_computer_suite.py
@@ -1,0 +1,46 @@
+"""Tests for computer-use eval suite helpers."""
+
+from gptme.eval.suites import computer as computer_suite
+from gptme.eval.types import ResultContext
+
+
+def test_check_used_open_page_or_click_element_accepts_click(monkeypatch):
+    monkeypatch.setattr(
+        computer_suite,
+        "_executed_tool_calls",
+        lambda messages: ["click_element('a[title=\"History of Python\"]')"],
+    )
+
+    assert computer_suite.check_used_open_page_or_click_element([])
+
+
+def test_check_used_open_page_or_click_element_rejects_read_only(monkeypatch):
+    monkeypatch.setattr(
+        computer_suite,
+        "_executed_tool_calls",
+        lambda messages: ["read_page_text()"],
+    )
+
+    assert not computer_suite.check_used_open_page_or_click_element([])
+
+
+def test_expect_second_page_reached_requires_navigation_file():
+    ctx = ResultContext(
+        files={},
+        stdout="cat: navigation.txt: No such file or directory",
+        stderr="",
+        exit_code=1,
+    )
+
+    assert not computer_suite._expect_second_page_reached(ctx)
+
+
+def test_expect_second_page_reached_accepts_navigation_file():
+    ctx = ResultContext(
+        files={"navigation.txt": "History of Python"},
+        stdout="History of Python",
+        stderr="",
+        exit_code=0,
+    )
+
+    assert computer_suite._expect_second_page_reached(ctx)


### PR DESCRIPTION
## Summary

Two substantive gaps closed for issue #216 (Complete computer-use support):

### 1. `gptme-util computer audit-log`

New CLI subcommand (`gptme/cli/cmd_computer.py`) that reads session trajectory JSONL files and extracts every `computer()` / `observe_desktop()` call in a structured, privacy-safe format.

- Typed/key text is **never logged raw** — only `text_len` is recorded (addresses the audit-boundary concern raised by @hiSandog and the trajectory-based approach agreed on when PR #3024 was closed)
- Coordinates, action names, and timestamps are extracted and displayed
- Supports `--json` for machine-readable output and `--last N` to scan N most-recent sessions
- Registered as `gptme-util computer audit-log` via the `_LAZY_COMMANDS` lazy-loader

```
$ gptme-util computer audit-log
Timestamp                      Conv                      Action                    Details
----------------------------------------------------------------------------------------------------
2026-07-01T12:00:00            my-session                screenshot
2026-07-01T12:00:05            my-session                left_click                @ [100, 200]
2026-07-01T12:00:10            my-session                type                      (8 chars, redacted)

$ gptme-util computer audit-log my-session --json
[{"timestamp": "...", "action": "screenshot", "conversation": "my-session"}, ...]
```

### 2. Interactive web action evals (the "Can it Tweet?" pipeline)

Extended `gptme/eval/suites/computer.py` with two new eval specs that test the **interactive** web path — not just read-only observation:

- **`computer-use-web-form-fill`**: tests `open_page` + `fill_element` + `click_element` + `read_page_text` against `httpbin.org/forms/post`. `check_log` verifies all three DOM-interaction functions were actually called (not screenshot-coordinate guessing).
- **`computer-use-web-navigate-multi-step`**: tests multi-step navigation (open a Wikipedia page, follow a link, read the second page). Validates the stateful browser session model.

New `check_log` helpers added: `check_used_open_page`, `check_used_fill_element`, `check_used_click_element`.

## Test plan

- [x] 10 new unit + integration tests in `tests/test_computer_audit.py` — all pass locally
- [x] All existing computer tool tests pass (162 passed, 4 skipped)
- [x] `ruff check` + `ruff format` clean
- [x] `mypy` clean (via pre-commit)
- [x] New eval specs load correctly (`4 test specs loaded` confirmed)

## What remains before #216 can close

- End-to-end "Can it Tweet?" live validation (needs a Twitter/X session)
- Docker/VNC end-to-end test in a CI pipeline
- macOS accessibility backend (AT-SPI2 is done for Linux; macOS integration still pending)