### PR TITLE
fix(server): reject unknown fields in PUT /api/v2/tasks/{id} to prevent silent no-ops

### DIFF
--- a/gptme/server/tasks_api.py
+++ b/gptme/server/tasks_api.py
@@ -838,6 +838,20 @@ def api_tasks_update(task_id: str):
     if not isinstance(req_json, dict):
         return flask.jsonify({"error": "Request body must be a JSON object"}), 400
 
+    # Reject unknown/unsupported fields to prevent silent no-ops
+    allowed_fields = {"content", "target_type", "target_repo", "metadata"}
+    if "status" in req_json:
+        return flask.jsonify(
+            {
+                "error": "status cannot be set directly; it is derived from conversation and git state. Use the archive endpoint to archive a task."
+            }
+        ), 400
+    unknown_fields = set(req_json) - allowed_fields
+    if unknown_fields:
+        return flask.jsonify(
+            {"error": f"unknown field(s): {', '.join(sorted(unknown_fields))}"}
+        ), 400
+
     # Validate field types before applying
     if "content" in req_json and not isinstance(req_json["content"], str):
         return flask.jsonify({"error": "content must be a string"}), 400

--- a/gptme/server/tasks_api.py
+++ b/gptme/server/tasks_api.py
@@ -840,6 +840,8 @@ def api_tasks_update(task_id: str):
 
     # Reject unknown/unsupported fields to prevent silent no-ops
     allowed_fields = {"content", "target_type", "target_repo", "metadata"}
+    # Check `status` first (before the generic unknown-fields guard) so callers
+    # get an actionable message instead of the generic "unknown field(s): status".
     if "status" in req_json:
         return flask.jsonify(
             {

--- a/tests/test_tasks_api.py
+++ b/tests/test_tasks_api.py
@@ -910,6 +910,25 @@ class TestTasksInputValidation:
             )
             assert resp.status_code == 200, f"target_type '{tt}' should be valid"
 
+    def test_update_status_field_rejected(self, client, sample_task):
+        """status is derived state and cannot be set directly."""
+        resp = client.put(
+            f"/api/v2/tasks/{sample_task.id}",
+            json={"status": "done"},
+        )
+        assert resp.status_code == 400
+        assert "status" in resp.json["error"]
+        assert "archive" in resp.json["error"]
+
+    def test_update_unknown_field_rejected(self, client, sample_task):
+        """Unknown fields must be rejected to prevent silent no-ops."""
+        resp = client.put(
+            f"/api/v2/tasks/{sample_task.id}",
+            json={"bogus_field": 1},
+        )
+        assert resp.status_code == 400
+        assert "bogus_field" in resp.json["error"]
+
 
 # ── Path traversal prevention ─────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- `PUT /api/v2/tasks/{task_id}` silently ignored unknown fields (including `status`) and returned HTTP 200 with unchanged data — callers had no signal the update was a no-op
- Added explicit 400 validation for `status` field (it's derived from conversation/git state, not directly settable) with a clear error message pointing to the archive endpoint
- Added 400 for any other unrecognized fields to prevent future silent ignores

## Root Cause

The PUT handler only applied updates for `content`, `target_type`, `target_repo`, and `metadata`, but had no validation rejecting anything else. Any unknown field (including `status`) was silently accepted and discarded.

## Test Plan

- [x] All 87 existing `tests/test_tasks_api.py` tests pass
- [x] Manual repro: `PUT {"status": "done"}` now returns `{"error": "status cannot be set directly; ..."}` with HTTP 400
- [x] Manual repro: `PUT {"bogus_field": 1}` now returns `{"error": "unknown field(s): bogus_field"}` with HTTP 400  
- [x] Manual repro: `PUT {"content": "new content"}` still works correctly (HTTP 200)

Closes #3031