### PR TITLE
feat(server): add ?status= filter to GET /api/v2/tasks list endpoint

### DIFF
--- a/gptme/server/tasks_api.py
+++ b/gptme/server/tasks_api.py
@@ -686,7 +686,7 @@ def api_tasks_list():
 
     List tasks with their cached status information.
     Archived tasks are excluded by default; include ?archived=true to show them.
-    Filter by status with ?status=pending|active|completed|failed.
+    Filter by cached status with ?status=pending|active|completed|failed.
     """
     try:
         archived_str = flask.request.args.get("archived", "false")

--- a/gptme/server/tasks_api.py
+++ b/gptme/server/tasks_api.py
@@ -678,7 +678,7 @@ def setup_task_workspace(task_id: str, target_repo: str | None = None) -> Path:
 @tasks_api.route("/api/v2/tasks")
 @require_auth
 @api_doc_simple(
-    responses={200: TaskListResponse, 500: ErrorResponse},
+    responses={200: TaskListResponse, 400: ErrorResponse, 500: ErrorResponse},
     tags=["tasks"],
 )
 def api_tasks_list():
@@ -686,11 +686,24 @@ def api_tasks_list():
 
     List tasks with their cached status information.
     Archived tasks are excluded by default; include ?archived=true to show them.
+    Filter by status with ?status=pending|active|completed|failed.
     """
     try:
         archived_str = flask.request.args.get("archived", "false")
         include_archived = archived_str.lower() in ("true", "1")
+
+        status_filter = flask.request.args.get("status")
+        if status_filter is not None:
+            valid_statuses = get_args(TaskStatus)
+            if status_filter not in valid_statuses:
+                return flask.jsonify(
+                    {"error": f"status must be one of: {', '.join(valid_statuses)}"}
+                ), 400
+
         tasks = list_tasks(include_archived=include_archived)
+
+        if status_filter is not None:
+            tasks = [t for t in tasks if t.status == status_filter]
 
         # Return with stored status (no side effects in GET)
         tasks_info = [asdict(task) for task in tasks]

--- a/tests/test_tasks_api.py
+++ b/tests/test_tasks_api.py
@@ -578,6 +578,28 @@ class TestTasksListAPI:
         assert resp.status_code == 200
         assert resp.json == {"tasks": []}
 
+    def test_list_filter_by_status_with_archived(self, client):
+        save_task(
+            Task(
+                id="archived-pending-task",
+                content="Archived pending task",
+                created_at="2026-01-01T00:00:00Z",
+                status="pending",
+                target_type="stdout",
+                archived=True,
+            )
+        )
+
+        resp = client.get("/api/v2/tasks?status=pending")
+        assert resp.status_code == 200
+        assert resp.json == {"tasks": []}
+
+        resp = client.get("/api/v2/tasks?archived=true&status=pending")
+        assert resp.status_code == 200
+        data = resp.json
+        assert len(data["tasks"]) == 1
+        assert data["tasks"][0]["id"] == "archived-pending-task"
+
     def test_list_filter_by_status_invalid(self, client):
         resp = client.get("/api/v2/tasks?status=unknown")
         assert resp.status_code == 400

--- a/tests/test_tasks_api.py
+++ b/tests/test_tasks_api.py
@@ -537,6 +537,53 @@ class TestTasksListAPI:
         assert "tasks" in data
         assert len(data["tasks"]) == 2
 
+    def test_list_filter_by_status(self, client):
+        save_task(
+            Task(
+                id="pending-task",
+                content="Pending task",
+                created_at="2026-01-01T00:00:00Z",
+                status="pending",
+                target_type="stdout",
+            )
+        )
+        save_task(
+            Task(
+                id="active-task",
+                content="Active task",
+                created_at="2026-01-02T00:00:00Z",
+                status="active",
+                target_type="stdout",
+            )
+        )
+
+        resp = client.get("/api/v2/tasks?status=pending")
+        assert resp.status_code == 200
+        data = resp.json
+        assert len(data["tasks"]) == 1
+        assert data["tasks"][0]["id"] == "pending-task"
+
+    def test_list_filter_by_status_no_match(self, client):
+        save_task(
+            Task(
+                id="pending-task-2",
+                content="Pending task",
+                created_at="2026-01-01T00:00:00Z",
+                status="pending",
+                target_type="stdout",
+            )
+        )
+
+        resp = client.get("/api/v2/tasks?status=completed")
+        assert resp.status_code == 200
+        assert resp.json == {"tasks": []}
+
+    def test_list_filter_by_status_invalid(self, client):
+        resp = client.get("/api/v2/tasks?status=unknown")
+        assert resp.status_code == 400
+        assert "error" in resp.json
+        assert "status" in resp.json["error"]
+
 
 class TestTasksGetAPI:
     """Tests for GET /api/v2/tasks/<task_id>."""


### PR DESCRIPTION
## Summary
- Add `?status=` query parameter to `GET /api/v2/tasks`
- Valid values: `pending`, `active`, `completed`, `failed`
- Returns `400` with descriptive error for unknown status values
- Follows the same pattern as the existing `?archived=` filter

## Why
The tasks list endpoint previously returned all non-archived tasks with no way to filter by status. Clients that want to show only pending tasks (e.g. a task queue dashboard) had to load all tasks and filter client-side.

## Test plan
- `test_list_filter_by_status` — verify only matching-status tasks are returned
- `test_list_filter_by_status_no_match` — verify empty list when no tasks match
- `test_list_filter_by_status_invalid` — verify 400 + error message for invalid status

Related to #3031 (also addresses the tasks API; #3032 fixed the PUT endpoint, this improves GET /api/v2/tasks).