### PR TITLE
feat(webui): windowed open (limit=50) + 'Load older' button

### DIFF
--- a/webui/src/components/ConversationContent.tsx
+++ b/webui/src/components/ConversationContent.tsx
@@ -44,6 +44,7 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
     switchBranch,
     confirmTool,
     interruptGeneration,
+    isLoadingOlderMessages,
     loadOlderMessages,
   } = useConversation(conversationId, serverId);
   const navigate = useNavigate();
@@ -649,10 +650,13 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
                   variant="outline"
                   size="sm"
                   onClick={() => void loadOlderMessages()}
+                  disabled={isLoadingOlderMessages}
                   className="gap-1 text-xs text-muted-foreground"
                 >
-                  <ChevronUp className="h-3 w-3" />
-                  Load older messages
+                  <ChevronUp
+                    className={`h-3 w-3 ${isLoadingOlderMessages ? 'animate-pulse' : ''}`}
+                  />
+                  {isLoadingOlderMessages ? 'Loading older messages' : 'Load older messages'}
                 </Button>
               </div>
             );

--- a/webui/src/components/ConversationContent.tsx
+++ b/webui/src/components/ConversationContent.tsx
@@ -21,7 +21,7 @@ import { useApi } from '@/contexts/ApiContext';
 import { useSettings } from '@/contexts/SettingsContext';
 import { useModels } from '@/hooks/useModels';
 import { chatRoute } from '@/utils/routes';
-import { AlertTriangle, ArrowDown, RefreshCw, WifiOff } from 'lucide-react';
+import { AlertTriangle, ArrowDown, ChevronUp, RefreshCw, WifiOff } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 
 interface Props {
@@ -44,6 +44,7 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
     switchBranch,
     confirmTool,
     interruptGeneration,
+    loadOlderMessages,
   } = useConversation(conversationId, serverId);
   const navigate = useNavigate();
   const queryClient = useQueryClient();
@@ -634,6 +635,26 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
                 baseUrl={connectionConfig.baseUrl}
                 activeModel={activeModel}
               />
+            );
+          }}
+        </Memo>
+
+        <Memo>
+          {() => {
+            const hasMoreBefore = conversation$?.hasMoreBefore?.get() ?? false;
+            if (!hasMoreBefore) return null;
+            return (
+              <div className="flex justify-center py-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => void loadOlderMessages()}
+                  className="gap-1 text-xs text-muted-foreground"
+                >
+                  <ChevronUp className="h-3 w-3" />
+                  Load older messages
+                </Button>
+              </div>
             );
           }}
         </Memo>

--- a/webui/src/components/ConversationContent.tsx
+++ b/webui/src/components/ConversationContent.tsx
@@ -317,6 +317,25 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
     sendMessage({ message, options });
   };
 
+  const handleLoadOlderMessages = useCallback(async () => {
+    const container = scrollContainerRef.current;
+    if (!container) {
+      await loadOlderMessages();
+      return;
+    }
+
+    const previousScrollHeight = container.scrollHeight;
+    const previousScrollTop = container.scrollTop;
+    autoScrollAborted$.set(true);
+    isScrolledUp$.set(true);
+
+    await loadOlderMessages();
+
+    requestAnimationFrame(() => {
+      container.scrollTop = previousScrollTop + (container.scrollHeight - previousScrollHeight);
+    });
+  }, [autoScrollAborted$, isScrolledUp$, loadOlderMessages]);
+
   const clearSearchHighlights = useCallback(() => {
     scrollContainerRef.current
       ?.querySelectorAll<HTMLElement>('[data-message-index]')
@@ -646,7 +665,7 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
             <Button
               variant="outline"
               size="sm"
-              onClick={() => void loadOlderMessages()}
+              onClick={() => void handleLoadOlderMessages()}
               disabled={isLoadingOlderMessages}
               className="gap-1 text-xs text-muted-foreground"
             >

--- a/webui/src/components/ConversationContent.tsx
+++ b/webui/src/components/ConversationContent.tsx
@@ -56,6 +56,7 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
   const reconnectMaxAttempts = use$(() => conversation$?.reconnectMaxAttempts.get() ?? null);
   const reconnectRetryInMs = use$(() => conversation$?.reconnectRetryInMs.get() ?? null);
   const connectionError = use$(() => conversation$?.connectionError.get() ?? null);
+  const hasMoreBefore = use$(() => conversation$?.hasMoreBefore.get() ?? false);
   // State to track when to auto-focus the input
   const shouldFocus$ = useObservable(false);
   // Store the previous conversation ID to detect changes
@@ -640,28 +641,20 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
           }}
         </Memo>
 
-        <Memo>
-          {() => {
-            const hasMoreBefore = conversation$?.hasMoreBefore?.get() ?? false;
-            if (!hasMoreBefore) return null;
-            return (
-              <div className="flex justify-center py-2">
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => void loadOlderMessages()}
-                  disabled={isLoadingOlderMessages}
-                  className="gap-1 text-xs text-muted-foreground"
-                >
-                  <ChevronUp
-                    className={`h-3 w-3 ${isLoadingOlderMessages ? 'animate-pulse' : ''}`}
-                  />
-                  {isLoadingOlderMessages ? 'Loading older messages' : 'Load older messages'}
-                </Button>
-              </div>
-            );
-          }}
-        </Memo>
+        {hasMoreBefore && (
+          <div className="flex justify-center py-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => void loadOlderMessages()}
+              disabled={isLoadingOlderMessages}
+              className="gap-1 text-xs text-muted-foreground"
+            >
+              <ChevronUp className={`h-3 w-3 ${isLoadingOlderMessages ? 'animate-pulse' : ''}`} />
+              {isLoadingOlderMessages ? 'Loading older messages' : 'Load older messages'}
+            </Button>
+          </div>
+        )}
 
         <For each={conversation$?.data.log ?? []}>
           {(msg$) => {

--- a/webui/src/hooks/useConversation.ts
+++ b/webui/src/hooks/useConversation.ts
@@ -5,7 +5,7 @@ import type { Message, StreamingMessage } from '@/types/conversation';
 import type { ChatOptions } from '@/components/ChatInput';
 import { demoConversations, getDemoMessages } from '@/democonversations';
 import { isDemoMode } from '@/utils/connectionConfig';
-import { use$ } from '@legendapp/state/react';
+import { use$, useObservable } from '@legendapp/state/react';
 import {
   conversations$,
   updateConversation,
@@ -54,7 +54,8 @@ export function useConversation(conversationId: string, serverId?: string) {
 
   const messageJustCompleted = useRef(false);
   const loadingOlderMessagesRef = useRef(false);
-  const [isLoadingOlderMessages, setIsLoadingOlderMessages] = useState(false);
+  const isLoadingOlderMessages$ = useObservable(false);
+  const isLoadingOlderMessages = use$(isLoadingOlderMessages$);
   // Bumped by retryLoad() to re-run the load+connect effect after a failure.
   const [retryNonce, setRetryNonce] = useState(0);
 
@@ -819,7 +820,7 @@ export function useConversation(conversationId: string, serverId?: string) {
     if (logOffset <= 0) return;
     if (loadingOlderMessagesRef.current) return;
     loadingOlderMessagesRef.current = true;
-    setIsLoadingOlderMessages(true);
+    isLoadingOlderMessages$.set(true);
     try {
       const data = await api.getConversation(conversationId, {
         limit: 50,
@@ -844,7 +845,7 @@ export function useConversation(conversationId: string, serverId?: string) {
       });
     } finally {
       loadingOlderMessagesRef.current = false;
-      setIsLoadingOlderMessages(false);
+      isLoadingOlderMessages$.set(false);
     }
   };
 

--- a/webui/src/hooks/useConversation.ts
+++ b/webui/src/hooks/useConversation.ts
@@ -53,6 +53,8 @@ export function useConversation(conversationId: string, serverId?: string) {
   const topP = use$(() => conversation$?.topP.get());
 
   const messageJustCompleted = useRef(false);
+  const loadingOlderMessagesRef = useRef(false);
+  const [isLoadingOlderMessages, setIsLoadingOlderMessages] = useState(false);
   // Bumped by retryLoad() to re-run the load+connect effect after a failure.
   const [retryNonce, setRetryNonce] = useState(0);
 
@@ -810,11 +812,14 @@ export function useConversation(conversationId: string, serverId?: string) {
     setRetryNonce((n) => n + 1);
   }, [conversationId]);
 
-  const loadOlderMessages = useCallback(async () => {
+  const loadOlderMessages = async () => {
     const conv$ = conversations$.get(conversationId);
     if (!conv$) return;
     const logOffset = conv$.logOffset.peek();
     if (logOffset <= 0) return;
+    if (loadingOlderMessagesRef.current) return;
+    loadingOlderMessagesRef.current = true;
+    setIsLoadingOlderMessages(true);
     try {
       const data = await api.getConversation(conversationId, {
         limit: 50,
@@ -828,8 +833,11 @@ export function useConversation(conversationId: string, serverId?: string) {
       );
     } catch (error) {
       console.warn('[useConversation] Failed to load older messages:', error);
+    } finally {
+      loadingOlderMessagesRef.current = false;
+      setIsLoadingOlderMessages(false);
     }
-  }, [conversationId, api]);
+  };
 
   return {
     conversation$,
@@ -844,6 +852,7 @@ export function useConversation(conversationId: string, serverId?: string) {
     switchBranch,
     confirmTool,
     interruptGeneration,
+    isLoadingOlderMessages,
     loadOlderMessages,
   };
 }

--- a/webui/src/hooks/useConversation.ts
+++ b/webui/src/hooks/useConversation.ts
@@ -833,6 +833,15 @@ export function useConversation(conversationId: string, serverId?: string) {
       );
     } catch (error) {
       console.warn('[useConversation] Failed to load older messages:', error);
+      const { title, description } = getApiErrorPresentation(error, {
+        fallbackTitle: 'Failed to load older messages',
+        fallbackDescription: 'Failed to load older messages',
+      });
+      toast({
+        variant: 'destructive',
+        title,
+        description,
+      });
     } finally {
       loadingOlderMessagesRef.current = false;
       setIsLoadingOlderMessages(false);

--- a/webui/src/hooks/useConversation.ts
+++ b/webui/src/hooks/useConversation.ts
@@ -30,6 +30,7 @@ import {
   setMaxTokens,
   setTemperature,
   setTopP,
+  prependLogPage,
 } from '@/stores/conversations';
 import { playChime } from '@/utils/audio';
 import { speakText } from '@/utils/tts';
@@ -132,7 +133,7 @@ export function useConversation(conversationId: string, serverId?: string) {
         if (!isWindowHydrated) {
           // Only load from API if we don't already have conversation data
           try {
-            const data = await api.getConversation(conversationId);
+            const data = await api.getConversation(conversationId, { limit: 50 });
 
             // Also load the chat config
             try {
@@ -809,6 +810,27 @@ export function useConversation(conversationId: string, serverId?: string) {
     setRetryNonce((n) => n + 1);
   }, [conversationId]);
 
+  const loadOlderMessages = useCallback(async () => {
+    const conv$ = conversations$.get(conversationId);
+    if (!conv$) return;
+    const logOffset = conv$.logOffset.peek();
+    if (logOffset <= 0) return;
+    try {
+      const data = await api.getConversation(conversationId, {
+        limit: 50,
+        before: logOffset,
+      });
+      prependLogPage(
+        conversationId,
+        data.log,
+        data.has_more ? (data.before ?? 0) : 0,
+        data.has_more ?? false
+      );
+    } catch (error) {
+      console.warn('[useConversation] Failed to load older messages:', error);
+    }
+  }, [conversationId, api]);
+
   return {
     conversation$,
     retryLoad,
@@ -822,5 +844,6 @@ export function useConversation(conversationId: string, serverId?: string) {
     switchBranch,
     confirmTool,
     interruptGeneration,
+    loadOlderMessages,
   };
 }

--- a/webui/src/utils/api.ts
+++ b/webui/src/utils/api.ts
@@ -1020,17 +1020,24 @@ export class ApiClient {
     }
   }
 
-  async getConversation(logfile: string): Promise<ConversationResponse> {
+  async getConversation(
+    logfile: string,
+    params?: { limit?: number; before?: number }
+  ): Promise<ConversationResponse> {
     if (!this.isConnected) {
       throw new ApiClientError('Not connected to API');
     }
     try {
-      const response = await this.fetchJson<ConversationResponse>(
-        `${this.baseUrl}/api/v2/conversations/${logfile}`,
-        {
-          signal: this.controller?.signal,
-        }
-      );
+      let url = `${this.baseUrl}/api/v2/conversations/${logfile}`;
+      if (params?.limit !== undefined || params?.before !== undefined) {
+        const qs = new URLSearchParams();
+        if (params.limit !== undefined) qs.set('limit', String(params.limit));
+        if (params.before !== undefined) qs.set('before', String(params.before));
+        url = `${url}?${qs.toString()}`;
+      }
+      const response = await this.fetchJson<ConversationResponse>(url, {
+        signal: this.controller?.signal,
+      });
       return response;
     } catch (error) {
       if (error instanceof DOMException && error.name === 'AbortError') {


### PR DESCRIPTION
## Summary

Implements Slice 2 of the message pagination work (server-side Slice 1 landed in #2872):

- **Windowed open**: conversations now fetch only the last 50 messages on open instead of the full log, so long sessions (200+ messages) open immediately
- **'Load older messages' button**: appears above the message list when older messages exist, and pages back via `?before=<logOffset>&limit=50`
- **No regression for short conversations**: `has_more=false` means `hasMoreBefore` stays false and the button never renders; all existing behavior is unchanged

## Changes

- `api.ts`: `getConversation()` accepts optional `{limit, before}` params and builds the query string — `getConversation(id)` with no params is unchanged
- `hooks/useConversation.ts`: initial load passes `limit: 50`; adds `loadOlderMessages()` callback that fetches the previous page and prepends it via `prependLogPage()`
- `components/ConversationContent.tsx`: renders a "Load older messages" button (ChevronUp icon) inside a `<Memo>` that only mounts when `hasMoreBefore` is true

## Architecture

The `logOffset`/`hasMoreBefore`/`prependLogPage` infrastructure from #2872 handles all the absolute-index translation, so edit/delete/rerun/fork still target the correct message after windowing. This slice adds the UI end only.

## Test plan

- [ ] TypeScript: `tsc --noEmit` clean (verified locally)
- [ ] Conversations with ≤ 50 messages: loads normally, no "Load older" button appears
- [ ] Conversations with > 50 messages: loads last 50, "Load older" button visible, clicking it prepends the previous 50 messages
- [ ] After loading older messages: subsequent edit/delete/rerun on any message still targets the correct absolute index
- [ ] CI green

Closes the Slice 2 follow-on from #2861.