### PR TITLE
fix(computer): add browser tool to Docker VNC server for structured-first web interaction (#216)

### DIFF
--- a/scripts/computer_home/entrypoint.sh
+++ b/scripts/computer_home/entrypoint.sh
@@ -4,8 +4,9 @@ set -e
 ./start_all.sh
 ./novnc_startup.sh
 
-# Start gptme server
-python3 -m gptme.server --host 0.0.0.0 --port 8080 --tools ipython,computer,shell,vision --cors-origin '*'
+# Start gptme server with browser tool enabled for structured-first web interaction
+# (browser provides snapshot_url/open_page/fill_element/click_element for the computer-use profile)
+python3 -m gptme.server --host 0.0.0.0 --port 8080 --tools ipython,computer,browser,shell,vision --cors-origin '*'
 
 # Keep the container running
 tail -f /dev/null

--- a/tests/test_computer_docker_config.py
+++ b/tests/test_computer_docker_config.py
@@ -1,0 +1,73 @@
+"""Tests for the computer-use Docker container configuration.
+
+Verifies that the gptme-computer Docker entrypoint starts the server
+with the tools required for computer-use profile functionality.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ENTRYPOINT = (
+    Path(__file__).parent.parent / "scripts" / "computer_home" / "entrypoint.sh"
+)
+
+
+def _parse_server_tools(entrypoint_path: Path) -> list[str]:
+    """Extract the --tools value from the entrypoint server start command."""
+    text = entrypoint_path.read_text()
+    for line in text.splitlines():
+        stripped = line.strip()
+        if "gptme.server" in stripped and "--tools" in stripped:
+            # find --tools VALUE in the line
+            parts = stripped.split()
+            for i, part in enumerate(parts):
+                if part == "--tools" and i + 1 < len(parts):
+                    return parts[i + 1].split(",")
+    return []
+
+
+class TestDockerEntrypointTools:
+    def test_entrypoint_exists(self):
+        assert ENTRYPOINT.exists(), f"Entrypoint not found: {ENTRYPOINT}"
+
+    def test_browser_tool_included(self):
+        """browser tool must be in the server --tools list for structured-first web interaction.
+
+        The computer-use profile relies on snapshot_url/open_page/fill_element/click_element
+        (browser tool functions). Without browser in the tools list, those functions are
+        unavailable and the agent falls back to screenshot-only — breaking the
+        structured-first policy and the 'Can it Tweet?' interactive workflow.
+        """
+        tools = _parse_server_tools(ENTRYPOINT)
+        assert tools, "Could not parse --tools from entrypoint.sh"
+        assert "browser" in tools, (
+            f"browser not in Docker server tools: {tools}. "
+            "The computer-use profile requires browser for snapshot_url/open_page/fill_element/click_element."
+        )
+
+    def test_computer_tool_included(self):
+        """computer tool must be present for native desktop/X11 interaction."""
+        tools = _parse_server_tools(ENTRYPOINT)
+        assert "computer" in tools, f"computer not in Docker server tools: {tools}"
+
+    def test_vision_tool_included(self):
+        """vision tool must be present for screenshot analysis."""
+        tools = _parse_server_tools(ENTRYPOINT)
+        assert "vision" in tools, f"vision not in Docker server tools: {tools}"
+
+    def test_ipython_tool_included(self):
+        """ipython tool must be present for code execution."""
+        tools = _parse_server_tools(ENTRYPOINT)
+        assert "ipython" in tools, f"ipython not in Docker server tools: {tools}"
+
+    def test_all_computer_use_profile_tools_present(self):
+        """All tools required by the computer-use profile must be in the server tools list."""
+        tools = _parse_server_tools(ENTRYPOINT)
+        # These match the tools= list in gptme/profiles.py for the computer-use profile
+        required = {"computer", "browser", "vision", "ipython"}
+        missing = required - set(tools)
+        assert not missing, (
+            f"Docker server missing tools required by computer-use profile: {missing}. "
+            f"Current tools: {tools}"
+        )

--- a/tests/test_computer_docker_config.py
+++ b/tests/test_computer_docker_config.py
@@ -65,7 +65,7 @@ class TestDockerEntrypointTools:
         """All tools required by the computer-use profile must be in the server tools list."""
         tools = _parse_server_tools(ENTRYPOINT)
         # These match the tools= list in gptme/profiles.py for the computer-use profile
-        required = {"computer", "browser", "vision", "ipython"}
+        required = {"computer", "browser", "vision", "ipython", "shell"}
         missing = required - set(tools)
         assert not missing, (
             f"Docker server missing tools required by computer-use profile: {missing}. "


### PR DESCRIPTION
## Summary

Closes one remaining gap in the computer-use Docker/VNC deployment (#216).

The `gptme-computer` Docker container (`Dockerfile.computer`) installs Playwright and the `browser` extra but the server was started without the `browser` tool:

\`\`\`sh
# Before — browser missing
python3 -m gptme.server --tools ipython,computer,shell,vision
\`\`\`

This meant `snapshot_url()`, `open_page()`, `fill_element()`, and `click_element()` were unavailable inside the container, breaking the `computer-use` profile's structured-first web interaction policy and the "Can it Tweet?" interactive workflow. Users connecting via noVNC on `:6080` who started a `computer-use` profile session would silently fall through to screenshot-only mode.

**Fix**: add `browser` to the server `--tools` list so the container matches the tools required by the `computer-use` profile:

\`\`\`sh
# After
python3 -m gptme.server --tools ipython,computer,browser,shell,vision
\`\`\`

Also adds `tests/test_computer_docker_config.py` — a regression guard that parses the entrypoint and asserts all four tools required by the `computer-use` profile (`computer`, `browser`, `vision`, `ipython`) are present.

## Test plan

- [x] `uv run pytest tests/test_computer_docker_config.py` — 6 new tests, all pass
- [x] `uv run pytest tests/test_computer_audit.py tests/test_eval_computer_suite.py tests/test_computer_artifacts.py tests/test_tools_computer.py` — 170 existing tests pass