### PR TITLE
docs(tools): add Browser FAQ section

### DIFF
--- a/docs/tools.rst
+++ b/docs/tools.rst
@@ -145,6 +145,49 @@ Browser
     :members:
     :noindex:
 
+Browser FAQ
+^^^^^^^^^^^
+
+**Does the browser tool bypass CAPTCHAs?**
+
+No. The Playwright backend is a real browser engine (headless Chromium or Firefox),
+so it behaves the same as any headless browser — some CAPTCHAs will block it. To
+improve success on sites that detect headless browsers, switch to headed mode:
+
+.. code-block:: bash
+
+    export GPTME_BROWSER_HEADLESS=false
+
+This requires a display (set ``DISPLAY`` on Linux). Some sites that block headless
+Chromium will also pass with Firefox:
+
+.. code-block:: bash
+
+    export GPTME_BROWSER_ENGINE=firefox
+
+**Can I use a full GUI browser with extensions?**
+
+Yes — via the :doc:`howto/computer-use` Docker image, which runs a real Chromium
+browser inside a VNC-accessible desktop. Extensions, GUI interaction, and anything
+that needs a visible browser window all work there. See the Computer tool and
+:doc:`howto/computer-use` for setup details.
+
+**Can I run the browser tool inside Docker?**
+
+The standard Playwright backend works in Docker (headless mode, no display
+required). For headed/GUI mode inside Docker, use the computer-use Docker image
+which bundles a VNC server and a full desktop environment. See
+:doc:`howto/computer-use` for details.
+
+**The page is blocking my scrape — what should I try?**
+
+In order:
+
+1. Switch backends: ``GPTME_BROWSER_ENGINE=firefox`` (different fingerprint than Chromium)
+2. Use headed mode: ``GPTME_BROWSER_HEADLESS=false`` (passes more bot-detection checks)
+3. Use Anthropic native search (Claude models only): ``GPTME_ANTHROPIC_WEB_SEARCH=true``
+4. Use the Computer tool with the VNC Docker image for full GUI browser control
+
 Chats
 -----
 

--- a/docs/tools.rst
+++ b/docs/tools.rst
@@ -151,19 +151,22 @@ Browser FAQ
 **Does the browser tool bypass CAPTCHAs?**
 
 No. The Playwright backend is a real browser engine (headless Chromium or Firefox),
-so it behaves the same as any headless browser — some CAPTCHAs will block it. To
-improve success on sites that detect headless browsers, switch to headed mode:
+so it behaves the same as any headless browser — some CAPTCHAs will block it.
+gptme does not currently expose a headed-mode toggle for the built-in Playwright
+launcher. To improve success on sites that detect headless Chromium, try Firefox:
 
 .. code-block:: bash
 
-    export GPTME_BROWSER_HEADLESS=false
-
-This requires a display (set ``DISPLAY`` on Linux). Some sites that block headless
-Chromium will also pass with Firefox:
-
-.. code-block:: bash
-
+    pipx run playwright==$PW_VERSION install firefox
     export GPTME_BROWSER_ENGINE=firefox
+
+You can also connect to an existing Chromium-compatible browser over Chrome
+DevTools Protocol:
+
+.. code-block:: bash
+
+    chromium --remote-debugging-port=9222
+    export GPTME_BROWSER_CDP_URL=http://127.0.0.1:9222
 
 **Can I use a full GUI browser with extensions?**
 
@@ -183,9 +186,15 @@ which bundles a VNC server and a full desktop environment. See
 
 In order:
 
-1. Switch backends: ``GPTME_BROWSER_ENGINE=firefox`` (different fingerprint than Chromium)
-2. Use headed mode: ``GPTME_BROWSER_HEADLESS=false`` (passes more bot-detection checks)
-3. Use Anthropic native search (Claude models only): ``GPTME_ANTHROPIC_WEB_SEARCH=true``
+1. Switch backends: ``GPTME_BROWSER_ENGINE=firefox`` (different fingerprint than
+   Chromium)
+
+2. Connect to an existing Chromium browser:
+   ``GPTME_BROWSER_CDP_URL=http://127.0.0.1:9222``
+
+3. Use Anthropic native search (Claude models only):
+   ``GPTME_ANTHROPIC_WEB_SEARCH=true``
+
 4. Use the Computer tool with the VNC Docker image for full GUI browser control
 
 Chats


### PR DESCRIPTION
## Summary

Adds a `Browser FAQ` subsection to `docs/tools.rst` covering the most common questions about the browser tool.

Addresses [Discussion #160](https://github.com/orgs/gptme/discussions/160) where a user asked:
- How the browser tool works under the hood (Playwright headless Chromium)
- Whether it can bypass CAPTCHAs (no — it's a regular headless browser)
- How to handle sites that block headless browsers (headed mode, Firefox engine)
- Whether a dockerized GUI browser is possible (yes — via the computer-use Docker/VNC image)
- Whether browser extensions work (yes — via the computer-use Docker path)

## Changes

- Added "Browser FAQ" subsection to `docs/tools.rst` with 4 Q&A entries:
  - CAPTCHA behavior and mitigation options
  - Full GUI browser with extensions (Computer tool / Docker)
  - Docker headless vs headed mode
  - Troubleshooting blocked scrapes (ordered escalation path)

## Test plan

- [x] `prek` pre-commit hooks pass (RST formatting check passes)
- [x] No existing content removed