### PR TITLE
feat(reduce): emit visible feedback when log is truncated

### DIFF
--- a/gptme/util/reduce.py
+++ b/gptme/util/reduce.py
@@ -58,13 +58,6 @@ def reduce_log(
     # if we are below the limit, return the log as-is
     tokens = len_tokens(log, model=model.model)
     if tokens <= limit:
-        if _initial_tokens is not None:
-            saved = _initial_tokens - tokens
-            blocks_str = f", truncated {_truncations} block(s)" if _truncations else ""
-            console.log(
-                f"[context] Reduced log by ~{saved // 1000}k tokens"
-                f" ({_initial_tokens // 1000}k → {tokens // 1000}k){blocks_str}"
-            )
         yield from log
         return
 
@@ -124,6 +117,14 @@ def reduce_log(
         # but if prev_len == tokens, we are not making progress, so just return the log as-is
         if prev_len == tokens:
             logger.warning("Not making progress, returning log as-is")
+            if _initial_tokens is not None:
+                blocks_str = (
+                    f", truncated {_truncations} block(s)" if _truncations else ""
+                )
+                console.log(
+                    f"[context] Could not reduce log further ({tokens // 1000}k tokens"
+                    f" still exceeds limit ~{int(limit) // 1000}k{blocks_str})"
+                )
             yield from log
         else:
             yield from reduce_log(

--- a/gptme/util/reduce.py
+++ b/gptme/util/reduce.py
@@ -82,6 +82,13 @@ def reduce_log(
         logger.warning(
             "Cannot reduce log: all messages are pinned or protected tool calls"
         )
+        if _initial_tokens is not None:
+            blocks_str = f", truncated {_truncations} block(s)" if _truncations else ""
+            console.log(
+                "[context] Could not reduce log further: all remaining messages "
+                f"are pinned or protected tool calls ({tokens // 1000}k tokens "
+                f"still exceeds limit ~{int(limit) // 1000}k{blocks_str})"
+            )
         yield from log
         return
 

--- a/gptme/util/reduce.py
+++ b/gptme/util/reduce.py
@@ -12,6 +12,7 @@ from typing import Literal
 from ..codeblock import Codeblock
 from ..llm.models import get_default_model, get_model
 from ..message import Message, len_tokens
+from . import console
 
 logger = logging.getLogger(__name__)
 
@@ -41,6 +42,8 @@ def reduce_log(
     log: list[Message],
     limit=None,
     prev_len=None,
+    _initial_tokens: int | None = None,
+    _truncations: int = 0,
 ) -> Generator[Message, None, None]:
     """Reduces log until it is below `limit` tokens by continually summarizing the longest messages until below the limit."""
     # get the token limit
@@ -55,10 +58,26 @@ def reduce_log(
     # if we are below the limit, return the log as-is
     tokens = len_tokens(log, model=model.model)
     if tokens <= limit:
+        if _initial_tokens is not None:
+            saved = _initial_tokens - tokens
+            blocks_str = f", truncated {_truncations} block(s)" if _truncations else ""
+            console.log(
+                f"[context] Reduced log by ~{saved // 1000}k tokens"
+                f" ({_initial_tokens // 1000}k → {tokens // 1000}k){blocks_str}"
+            )
         yield from log
         return
 
     logger.info(f"Log exceeded limit of {limit}, was {tokens}, reducing")
+
+    if prev_len is None:
+        # First call — notify the user that reduction is starting
+        _initial_tokens = tokens
+        console.log(
+            f"[context] Log too long ({tokens // 1000}k tokens,"
+            f" limit ~{int(limit) // 1000}k), reducing..."
+        )
+
     # Filter out pinned messages and assistant tool-call messages. Tool-call
     # messages must remain parseable so paired tool results keep their anchor.
     non_pinned = [
@@ -84,6 +103,7 @@ def reduce_log(
     # if unchanged after truncate, attempt summarize
     if truncated:
         summary_msg = truncated
+        _truncations += 1
     else:
         summary_msg = longest_msg
 
@@ -91,6 +111,13 @@ def reduce_log(
 
     tokens = len_tokens(log, model.model)
     if tokens <= limit:
+        if _initial_tokens is not None:
+            saved = _initial_tokens - tokens
+            blocks_str = f", truncated {_truncations} block(s)" if _truncations else ""
+            console.log(
+                f"[context] Reduced log by ~{saved // 1000}k tokens"
+                f" ({_initial_tokens // 1000}k → {tokens // 1000}k){blocks_str}"
+            )
         yield from log
     else:
         # recurse until we are below the limit
@@ -99,7 +126,13 @@ def reduce_log(
             logger.warning("Not making progress, returning log as-is")
             yield from log
         else:
-            yield from reduce_log(log, limit, prev_len=tokens)
+            yield from reduce_log(
+                log,
+                limit,
+                prev_len=tokens,
+                _initial_tokens=_initial_tokens,
+                _truncations=_truncations,
+            )
 
 
 def truncate_msg(msg: Message, lines_pre=10, lines_post=10) -> Message | None:

--- a/tests/test_reduce.py
+++ b/tests/test_reduce.py
@@ -5,6 +5,7 @@ import pytest
 from gptme.llm.models.resolution import set_default_model
 from gptme.llm.models.types import ModelMeta
 from gptme.message import Message, len_tokens
+from gptme.util import reduce as reduce_mod
 from gptme.util.reduce import (
     _truncate_details_blocks,
     limit_log,
@@ -150,6 +151,24 @@ def test_reduce_log_all_pinned():
     reduced = list(reduce_log(msgs, limit=100))
     assert len(reduced) == 2
     assert reduced == msgs
+
+
+def test_reduce_log_all_pinned_logs_completion(monkeypatch):
+    """All-pinned reduction should not leave the start message dangling."""
+    console_messages: list[str] = []
+    monkeypatch.setattr(reduce_mod.console, "log", console_messages.append)
+    msgs = [
+        Message("system", content="x " * 5000, pinned=True),
+        Message("system", content="y " * 5000, pinned=True),
+    ]
+
+    reduced = list(reduce_log(msgs, limit=100))
+
+    assert reduced == msgs
+    assert len(console_messages) == 2
+    assert "Log too long" in console_messages[0]
+    assert "Could not reduce log further" in console_messages[1]
+    assert "pinned or protected tool calls" in console_messages[1]
 
 
 def test_truncate_msg_skips_unfindable_codeblock(monkeypatch):


### PR DESCRIPTION
## Summary

Adds user-visible `console.log` messages to `reduce_log()` so users know when and why their conversation history is being compacted.

- **Before truncation starts**: `[context] Log too long (Xk tokens, limit ~Yk), reducing...`
- **After reduction completes**: `[context] Reduced log by ~Zk tokens (Xk → Yk), truncated N block(s)`

Closes/addresses Discussion #138 — user hit the 289k token limit with `ls -R` and had no idea messages were being silently truncated.

## Motivation

`reduce_log()` was silently compacting conversation history. Users would see inexplicable gaps in tool output or watch the same expensive command re-run. Now the reduction is transparent with a single-line status before and after.

## Implementation

- Thread `_initial_tokens` and `_truncations` through the recursive calls so the final summary reflects the full multi-round reduction, not just the last pass
- Use `console.log()` matching the existing pattern in `chat.py`, `cost_display.py`, `interrupt.py`, etc.
- Count each `truncate_msg()` call that returns a modified message as one truncated block
- Existing `logger.info` path preserved for programmatic/debug consumers

## Test plan

- [x] All 15 existing `tests/test_reduce.py` tests pass (verified locally)
- [x] No import cycle: `from . import console` matches the pattern used in `cost.py`, `interrupt.py`, etc.
- [ ] Manually trigger a large-context session and verify the `[context]` lines appear in the terminal