### PR TITLE
fix(computer): surface observe_web failures as actionable error messages (#216)

### DIFF
--- a/gptme/tools/computer.py
+++ b/gptme/tools/computer.py
@@ -1605,6 +1605,7 @@ def observe_web(url: str, screenshot_too: bool = False) -> list[Message]:
 
     messages: list[Message] = []
     _failure_reasons: list[str] = []
+    _playwright_missing = False
 
     snapshot_text: str | None = None
     try:
@@ -1613,6 +1614,7 @@ def observe_web(url: str, screenshot_too: bool = False) -> list[Message]:
         if has_playwright():
             snapshot_text = snapshot_url(url)
         else:
+            _playwright_missing = True
             _failure_reasons.append(
                 "Playwright not installed — snapshot_url unavailable "
                 "(fix: pip install playwright && playwright install chromium)"
@@ -1646,9 +1648,11 @@ def observe_web(url: str, screenshot_too: bool = False) -> list[Message]:
                 if msg is not None:
                     messages.append(msg)
             else:
-                _failure_reasons.append(
-                    "Playwright not installed — screenshot_url unavailable"
-                )
+                if not _playwright_missing:
+                    _failure_reasons.append(
+                        "Playwright not installed — screenshot_url unavailable"
+                    )
+                    _playwright_missing = True
         except Exception as e:
             _failure_reasons.append(f"screenshot_url raised: {e}")
 

--- a/gptme/tools/computer.py
+++ b/gptme/tools/computer.py
@@ -1590,7 +1590,8 @@ def observe_web(url: str, screenshot_too: bool = False) -> list[Message]:
 
     Returns:
         List of :class:`~gptme.message.Message` objects (snapshot and/or screenshots).
-        Empty only if all observation paths fail.
+        Always returns at least one message; if all observation paths fail, returns a
+        single system message explaining what failed and how to fix it.
 
     Example (from IPython in a computer-use session)::
 
@@ -1600,7 +1601,10 @@ def observe_web(url: str, screenshot_too: bool = False) -> list[Message]:
         msgs = observe_web("https://example.com", screenshot_too=True)
         # Returns snapshot Message + screenshot Message side-by-side.
     """
+    from gptme.message import Message
+
     messages: list[Message] = []
+    _failure_reasons: list[str] = []
 
     snapshot_text: str | None = None
     try:
@@ -1608,12 +1612,15 @@ def observe_web(url: str, screenshot_too: bool = False) -> list[Message]:
 
         if has_playwright():
             snapshot_text = snapshot_url(url)
-    except Exception:
-        pass
+        else:
+            _failure_reasons.append(
+                "Playwright not installed — snapshot_url unavailable "
+                "(fix: pip install playwright && playwright install chromium)"
+            )
+    except Exception as e:
+        _failure_reasons.append(f"snapshot_url raised: {e}")
 
     if snapshot_text is not None:
-        from gptme.message import Message
-
         messages.append(Message("system", snapshot_text))
         if screenshot_too:
             # Playwright is available (snapshot succeeded), use browser screenshot.
@@ -1638,13 +1645,35 @@ def observe_web(url: str, screenshot_too: bool = False) -> list[Message]:
                 msg = _make_screenshot_msg(path, tool="computer")
                 if msg is not None:
                     messages.append(msg)
-        except Exception:
-            pass
+            else:
+                _failure_reasons.append(
+                    "Playwright not installed — screenshot_url unavailable"
+                )
+        except Exception as e:
+            _failure_reasons.append(f"screenshot_url raised: {e}")
 
         if not messages:
             msg = computer("screenshot")
             if msg is not None:
                 messages.append(msg)
+            else:
+                display = os.environ.get("DISPLAY", "unset")
+                _failure_reasons.append(
+                    f"desktop screenshot failed (DISPLAY={display!r} — no X11 display?)"
+                )
+
+    # Surface all failures as an actionable error message so the agent can diagnose.
+    if not messages:
+        detail = "; ".join(_failure_reasons) if _failure_reasons else "unknown reason"
+        messages.append(
+            Message(
+                "system",
+                f"observe_web({url!r}) failed — no observation could be collected.\n"
+                f"Reasons: {detail}\n"
+                "To enable structured web observation: "
+                "pip install playwright && playwright install chromium",
+            )
+        )
 
     return messages
 

--- a/tests/test_computer_actions.py
+++ b/tests/test_computer_actions.py
@@ -269,14 +269,23 @@ class TestObserveWeb:
         assert len(msgs) == 1
         assert fake_snapshot in msgs[0].content
 
-    def test_returns_list(self) -> None:
-        """observe_web() always returns a list (possibly empty on hard failure)."""
+    def test_hard_failure_returns_actionable_error(self) -> None:
+        """observe_web() surfaces a diagnosis when all observation paths fail.
+
+        Previously returned an empty list, leaving the agent with no feedback.
+        Now always returns at least one Message — an error explaining what failed
+        and how to fix it — so the agent can self-diagnose instead of looping.
+        """
         with (
             patch.dict("sys.modules", {"gptme.tools.browser": None}),
             patch("gptme.tools.computer.computer", return_value=None),
         ):
             result = observe_web("https://example.com")
         assert isinstance(result, list)
+        assert len(result) == 1, "hard failure must yield exactly one error message"
+        error_text = result[0].content
+        assert "failed" in error_text.lower(), "error message must say what failed"
+        assert "playwright" in error_text.lower(), "error must mention Playwright"
 
     def test_screenshot_too_appends_second_message(self) -> None:
         """screenshot_too=True should add a browser screenshot alongside the snapshot."""

--- a/tests/test_computer_actions.py
+++ b/tests/test_computer_actions.py
@@ -287,6 +287,26 @@ class TestObserveWeb:
         assert "failed" in error_text.lower(), "error message must say what failed"
         assert "playwright" in error_text.lower(), "error must mention Playwright"
 
+    def test_missing_playwright_branch_returns_single_actionable_error(self) -> None:
+        """observe_web() reports missing Playwright once when browser imports work."""
+        browser_module = MagicMock(
+            has_playwright=lambda: False,
+            snapshot_url=MagicMock(),
+            screenshot_url=MagicMock(),
+        )
+        with (
+            patch.dict("sys.modules", {"gptme.tools.browser": browser_module}),
+            patch("gptme.tools.computer.computer", return_value=None),
+        ):
+            result = observe_web("https://example.com")
+
+        assert len(result) == 1
+        error_text = result[0].content
+        assert error_text.count("Playwright not installed") == 1
+        assert "snapshot_url unavailable" in error_text
+        browser_module.snapshot_url.assert_not_called()
+        browser_module.screenshot_url.assert_not_called()
+
     def test_screenshot_too_appends_second_message(self) -> None:
         """screenshot_too=True should add a browser screenshot alongside the snapshot."""
         fake_snapshot = "# Page snapshot"


### PR DESCRIPTION
## Problem

`observe_web()` returned an empty list (`[]`) when all observation paths failed — no Playwright, no display. An agent calling it from IPython saw `Result: []` with zero diagnostic information. This left the agent unable to self-diagnose whether the issue was a missing install, display config, or network problem.

This is the "failures are surfaced back into the conversation" gap mentioned in [this comment](https://github.com/gptme/gptme/issues/216#issuecomment-2921285068).

## Fix

`observe_web()` now always returns at least one `Message`. On total failure it returns a single system message that:
- names each observation path tried and **why it failed** (ImportError, exception, or missing display)  
- explicitly tracks "Playwright not installed" as a named reason instead of swallowing it silently
- includes `os.environ["DISPLAY"]` in the desktop-screenshot failure reason
- gives the concrete fix command

**Before (no feedback):**
```
Result: []
```

**After (actionable):**
```
observe_web('https://example.com') failed — no observation could be collected.
Reasons: Playwright not installed — snapshot_url unavailable (fix: pip install playwright && playwright install chromium); desktop screenshot failed (DISPLAY='unset' — no X11 display?)
To enable structured web observation: pip install playwright && playwright install chromium
```

## Test

`test_returns_list` → renamed `test_hard_failure_returns_actionable_error`:
- Verifies the result is non-empty on hard failure
- Verifies "failed" and "playwright" appear in the error message

Closes #216 (partial — this addresses the failure-surfacing gap; the broader computer-use milestone work continues)

<!-- gptme-id:v1:gai_e0BC9PPM5bhmH7Igm6HPzzAu8bKeIESwBpfcZLypYRm -->