### PR TITLE
feat(computer): add macOS accessibility tree + click via osascript (#216)

### DIFF
--- a/gptme/tools/computer.py
+++ b/gptme/tools/computer.py
@@ -59,9 +59,13 @@ Screen:
 Window management:
     - window_focus: Wait for a window matching a name pattern to appear and focus it
 
-Accessibility (Linux/AT-SPI2 only):
-    - accessibility_tree: Dump the AT-SPI2 accessibility tree for all apps
-    - click_accessible_element: Find and click an element by role and name (text='role:name')
+Accessibility (cross-platform):
+    - accessibility_tree: Dump the native accessibility tree for all visible apps.
+      On Linux uses AT-SPI2 (role names like "push button", "entry").
+      On macOS uses System Events via AppleScript (role names like "AXButton", "AXTextField").
+    - click_accessible_element: Find and click an element by role and name (text='role:name').
+      Linux example: text='push button:Submit'
+      macOS example: text='AXButton:Submit'
 
 The tool automatically handles screen resolution scaling to ensure optimal performance
 with LLM vision capabilities.
@@ -777,6 +781,230 @@ def _linux_click_accessible_element(
     return x, y
 
 
+def _macos_accessibility_tree(max_depth: int = 2) -> str:
+    """Return a text dump of the macOS accessibility tree for visible apps.
+
+    Uses AppleScript via ``osascript`` to query the System Events accessibility
+    API.  On macOS, roles use the AX prefix (``AXButton``, ``AXTextField``, etc.)
+    rather than the AT-SPI2 names used on Linux.
+
+    Args:
+        max_depth: Levels below each window to walk (default 2). Deeper values
+            are slower; most interactive elements appear within 2 levels.
+
+    Returns:
+        Multi-line text representation of the accessibility tree.
+
+    Raises:
+        RuntimeError: If osascript fails or accessibility is not granted.
+    """
+    # Build a depth-limited AppleScript walker using a repeat-based stack approach.
+    # AppleScript cannot recurse into named handlers inside a tell block, so we
+    # unroll two levels explicitly and rely on max_depth to guard.
+    if max_depth < 1:
+        max_depth = 1
+    if max_depth > 4:
+        max_depth = 4  # safety cap — deep trees in complex apps can hang
+
+    # Generate indented lines for each visible app / window / element
+    script = """\
+tell application "System Events"
+    set output to ""
+    set procs to (every process whose background only is false)
+    repeat with proc in procs
+        set procName to name of proc
+        set output to output & "Process: " & procName & linefeed
+        try
+            repeat with win in (every window of proc)
+                set winName to ""
+                try
+                    set winName to name of win
+                end try
+                set output to output & "  Window: " & winName & linefeed
+                try
+                    repeat with elem in (every UI element of win)
+                        set eRole to ""
+                        set eName to ""
+                        try
+                            set eRole to role of elem
+                        end try
+                        try
+                            set eName to title of elem
+                        end try
+                        if eName is "" then
+                            try
+                                set eName to name of elem
+                            end try
+                        end if
+                        set output to output & "    " & eRole & ": " & eName & linefeed
+                        try
+                            repeat with child in (every UI element of elem)
+                                set cRole to ""
+                                set cName to ""
+                                try
+                                    set cRole to role of child
+                                end try
+                                try
+                                    set cName to title of child
+                                end try
+                                if cName is "" then
+                                    try
+                                        set cName to name of child
+                                    end try
+                                end if
+                                set output to output & "      " & cRole & ": " & cName & linefeed
+                            end repeat
+                        end try
+                    end repeat
+                end try
+            end repeat
+        end try
+    end repeat
+    return output
+end tell
+"""
+    try:
+        result = subprocess.run(
+            ["osascript", "-e", script],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=20,
+        )
+        out = result.stdout.strip()
+        return out or "(empty accessibility tree)"
+    except FileNotFoundError:
+        raise RuntimeError(
+            "osascript not found — macOS accessibility tree requires macOS"
+        ) from None
+    except subprocess.TimeoutExpired:
+        raise RuntimeError(
+            "accessibility_tree timed out — try reducing max_depth or targeting fewer apps"
+        ) from None
+    except subprocess.CalledProcessError as e:
+        raise RuntimeError(
+            f"accessibility_tree failed: {e.stderr.strip()}\n"
+            "Ensure the terminal has Accessibility permission in System Preferences → Privacy & Security."
+        ) from e
+
+
+def _macos_click_accessible_element(
+    role_name: str, element_name: str
+) -> tuple[int, int]:
+    """Find a UI element on macOS by AX role and name and return its center coordinates.
+
+    Searches the frontmost application's window hierarchy up to two levels deep.
+    On macOS, role names use the AX prefix, e.g. ``AXButton``, ``AXTextField``,
+    ``AXCheckBox``.  Run ``computer('accessibility_tree')`` first to discover
+    available roles and names.
+
+    Args:
+        role_name: AX role string, e.g. ``"AXButton"``, ``"AXTextField"``.
+        element_name: Element title or name (case-insensitive substring match).
+
+    Returns:
+        ``(x, y)`` center of the first matching element in screen coordinates.
+
+    Raises:
+        RuntimeError: If osascript fails, element is not found, or has no position.
+    """
+    name_lower = element_name.lower()
+
+    # Search first level then second level; return CSV "x,y" or "not_found"
+    script = f"""\
+tell application "System Events"
+    set frontApp to first application process whose frontmost is true
+    set wins to every window of frontApp
+    repeat with win in wins
+        repeat with elem in (every UI element of win)
+            set eRole to ""
+            set eName to ""
+            try
+                set eRole to role of elem
+            end try
+            try
+                set eName to title of elem
+            end try
+            if eName is "" then
+                try
+                    set eName to name of elem
+                end try
+            end if
+            if eRole is "{role_name}" and eName contains "{name_lower}" then
+                set pos to position of elem
+                set sz to size of elem
+                set cx to (item 1 of pos) + (item 1 of sz) / 2
+                set cy to (item 2 of pos) + (item 2 of sz) / 2
+                return (cx as integer) as text & "," & (cy as integer) as text
+            end if
+            -- second level
+            try
+                repeat with child in (every UI element of elem)
+                    set cRole to ""
+                    set cName to ""
+                    try
+                        set cRole to role of child
+                    end try
+                    try
+                        set cName to title of child
+                    end try
+                    if cName is "" then
+                        try
+                            set cName to name of child
+                        end try
+                    end if
+                    if cRole is "{role_name}" and cName contains "{name_lower}" then
+                        set pos to position of child
+                        set sz to size of child
+                        set cx to (item 1 of pos) + (item 1 of sz) / 2
+                        set cy to (item 2 of pos) + (item 2 of sz) / 2
+                        return (cx as integer) as text & "," & (cy as integer) as text
+                    end if
+                end repeat
+            end try
+        end repeat
+    end repeat
+    return "not_found"
+end tell
+"""
+    try:
+        result = subprocess.run(
+            ["osascript", "-e", script],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except FileNotFoundError:
+        raise RuntimeError(
+            "osascript not found — macOS accessibility requires macOS"
+        ) from None
+    except subprocess.TimeoutExpired:
+        raise RuntimeError(
+            f"click_accessible_element timed out searching for {role_name!r}: {element_name!r}"
+        ) from None
+    except subprocess.CalledProcessError as e:
+        raise RuntimeError(
+            f"click_accessible_element failed: {e.stderr.strip()}\n"
+            "Ensure the terminal has Accessibility permission in System Preferences → Privacy & Security."
+        ) from e
+
+    out = result.stdout.strip()
+    if out == "not_found" or not out:
+        raise RuntimeError(
+            f"No accessible element with role={role_name!r} containing name {element_name!r} "
+            "found in the frontmost app. Run computer('accessibility_tree') to see available elements."
+        )
+
+    try:
+        x_str, y_str = out.split(",", 1)
+        return int(x_str.strip()), int(y_str.strip())
+    except ValueError:
+        raise RuntimeError(
+            f"Unexpected position output from accessibility search: {out!r}"
+        ) from None
+
+
 def _macos_window_focus(pattern: str, timeout: float = 10.0) -> None:
     """Focus the frontmost application whose name contains pattern on macOS.
 
@@ -1008,8 +1236,11 @@ def _dispatch_transport(
         return None
 
     if action == "accessibility_tree":
-        display = os.getenv("DISPLAY", ":1")
-        tree = _linux_accessibility_tree(display)
+        if IS_MACOS:
+            tree = _macos_accessibility_tree()
+        else:
+            display = os.getenv("DISPLAY", ":1")
+            tree = _linux_accessibility_tree(display)
         print(tree)
         return None
 
@@ -1020,13 +1251,18 @@ def _dispatch_transport(
             )
         if ":" not in text:
             raise ValueError(
-                "text must be 'role_name:element_name', e.g. 'push button:Submit'"
+                "text must be 'role_name:element_name', e.g. 'AXButton:Submit' (macOS) or 'push button:Submit' (Linux)"
             )
         role_name, _, element_name = text.partition(":")
-        display = os.getenv("DISPLAY", ":1")
-        x, y = _linux_click_accessible_element(
-            role_name.strip(), element_name.strip(), display
-        )
+        if IS_MACOS:
+            x, y = _macos_click_accessible_element(
+                role_name.strip(), element_name.strip()
+            )
+        else:
+            display = os.getenv("DISPLAY", ":1")
+            x, y = _linux_click_accessible_element(
+                role_name.strip(), element_name.strip(), display
+            )
         transport.mouse_move(x, y)
         transport.left_click()
         print(
@@ -1328,34 +1564,35 @@ def computer(
 
     if action == "accessibility_tree":
         if IS_MACOS:
-            raise RuntimeError(
-                "accessibility_tree is only supported on Linux (AT-SPI2). "
-                "On macOS, use the browser tool's snapshot_url() for web content."
-            )
-        tree = _linux_accessibility_tree(display)
+            tree = _macos_accessibility_tree()
+        else:
+            tree = _linux_accessibility_tree(display)
         print(tree)
         return None
 
     if action == "click_accessible_element":
-        if IS_MACOS:
-            raise RuntimeError(
-                "click_accessible_element is only supported on Linux (AT-SPI2). "
-                "On macOS, use the browser tool's click_element() for web content."
-            )
         if not text:
             raise ValueError(
                 "text='role_name:element_name' is required for click_accessible_element"
             )
         if ":" not in text:
             raise ValueError(
-                "text must be 'role_name:element_name', e.g. 'push button:Submit'"
+                "text must be 'role_name:element_name', e.g. 'AXButton:Submit' (macOS) or 'push button:Submit' (Linux)"
             )
         role_name, _, element_name = text.partition(":")
-        x, y = _linux_click_accessible_element(
-            role_name.strip(), element_name.strip(), display
-        )
-        # AT-SPI2 DESKTOP_COORDS are already physical screen pixels — no scaling needed.
-        _run_xdotool(f"mousemove --sync {x} {y} click 1", display)
+        if IS_MACOS:
+            x, y = _macos_click_accessible_element(
+                role_name.strip(), element_name.strip()
+            )
+            # Use cliclick or native mouse move on macOS — no xdotool
+            _macos_mouse_move(x, y)
+            _macos_click(1)
+        else:
+            x, y = _linux_click_accessible_element(
+                role_name.strip(), element_name.strip(), display
+            )
+            # AT-SPI2 DESKTOP_COORDS are already physical screen pixels — no scaling needed.
+            _run_xdotool(f"mousemove --sync {x} {y} click 1", display)
         print(
             f"Clicked accessible element {role_name!r}: {element_name!r} at ({x}, {y})"
         )
@@ -1510,24 +1747,31 @@ Available actions:
 - window_focus: Wait for a window whose title contains text=<pattern> to appear,
   then focus it. On Linux/X11 this uses xdotool --sync so no screenshot polling
   is needed. Use after opening a new application to avoid guessing where to click.
-- accessibility_tree: (Linux/AT-SPI2 only) Dump the accessibility tree for all
-  open applications as structured text. Each node shows role, name, and state.
+- accessibility_tree: Dump the native accessibility tree for all open applications.
+  On Linux (AT-SPI2): role names like 'push button', 'entry', 'check box'.
+    Requires: pip install pyatspi (and AT-SPI2 accessibility stack).
+  On macOS (System Events): role names like 'AXButton', 'AXTextField', 'AXCheckBox'.
+    Requires Accessibility permission for the terminal in System Preferences.
   Use this to discover element names and roles before using click_accessible_element.
-  Requires: pip install pyatspi (and AT-SPI2 accessibility stack).
-- click_accessible_element: (Linux/AT-SPI2 only) Find and click an element by
-  role and name without needing screen coordinates. Use text='role:name' where
-  role is the AT-SPI role name (e.g. 'push button', 'entry', 'check box') and
-  name is a substring of the element's accessible name. Example:
-  computer('click_accessible_element', text='push button:Submit')
+- click_accessible_element: Find and click an element by role and name without
+  needing screen coordinates. Use text='role:name' where role is the platform role
+  name and name is a substring of the element's accessible name. Examples:
+    Linux:  computer('click_accessible_element', text='push button:Submit')
+    macOS:  computer('click_accessible_element', text='AXButton:Submit')
 
-### Accessibility-first for native apps (Linux)
+### Accessibility-first for native apps
 
-Prefer click_accessible_element over coordinate-based clicks for native Linux apps:
+Prefer click_accessible_element over coordinate-based clicks for native apps:
 
   computer("accessibility_tree")                               # inspect available elements
+  # Linux:
   computer("click_accessible_element", text="entry:Username")  # fill username field
   computer("type", text="user@example.com")
   computer("click_accessible_element", text="push button:Log In")
+  # macOS:
+  computer("click_accessible_element", text="AXTextField:Username")
+  computer("type", text="user@example.com")
+  computer("click_accessible_element", text="AXButton:Log In")
 
 This is more robust than coordinate guessing: element names don't shift when
 window size or position changes. Use coordinate-based clicks only when the app

--- a/gptme/tools/computer.py
+++ b/gptme/tools/computer.py
@@ -798,16 +798,44 @@ def _macos_accessibility_tree(max_depth: int = 2) -> str:
     Raises:
         RuntimeError: If osascript fails or accessibility is not granted.
     """
-    # Build a depth-limited AppleScript walker using a repeat-based stack approach.
-    # AppleScript cannot recurse into named handlers inside a tell block, so we
-    # unroll two levels explicitly and rely on max_depth to guard.
     if max_depth < 1:
         max_depth = 1
     if max_depth > 4:
         max_depth = 4  # safety cap — deep trees in complex apps can hang
 
+    def level_script(parent: str, depth: int) -> str:
+        elem = f"elem{depth}"
+        role = f"role{depth}"
+        name = f"name{depth}"
+        indent = "  " * (depth + 1)
+        child_walk = ""
+        if depth < max_depth:
+            child_walk = f"""\
+                        try
+{level_script(elem, depth + 1)}
+                        end try
+"""
+        return f"""\
+                        repeat with {elem} in (every UI element of {parent})
+                            set {role} to ""
+                            set {name} to ""
+                            try
+                                set {role} to role of {elem}
+                            end try
+                            try
+                                set {name} to title of {elem}
+                            end try
+                            if {name} is "" then
+                                try
+                                    set {name} to name of {elem}
+                                end try
+                            end if
+                            set output to output & "{indent}" & {role} & ": " & {name} & linefeed
+{child_walk}                        end repeat
+"""
+
     # Generate indented lines for each visible app / window / element
-    script = """\
+    script = f"""\
 tell application "System Events"
     set output to ""
     set procs to (every process whose background only is false)
@@ -822,40 +850,7 @@ tell application "System Events"
                 end try
                 set output to output & "  Window: " & winName & linefeed
                 try
-                    repeat with elem in (every UI element of win)
-                        set eRole to ""
-                        set eName to ""
-                        try
-                            set eRole to role of elem
-                        end try
-                        try
-                            set eName to title of elem
-                        end try
-                        if eName is "" then
-                            try
-                                set eName to name of elem
-                            end try
-                        end if
-                        set output to output & "    " & eRole & ": " & eName & linefeed
-                        try
-                            repeat with child in (every UI element of elem)
-                                set cRole to ""
-                                set cName to ""
-                                try
-                                    set cRole to role of child
-                                end try
-                                try
-                                    set cName to title of child
-                                end try
-                                if cName is "" then
-                                    try
-                                        set cName to name of child
-                                    end try
-                                end if
-                                set output to output & "      " & cRole & ": " & cName & linefeed
-                            end repeat
-                        end try
-                    end repeat
+{level_script("win", 1)}
                 end try
             end repeat
         end try
@@ -909,10 +904,14 @@ def _macos_click_accessible_element(
         RuntimeError: If osascript fails, element is not found, or has no position.
     """
     name_lower = element_name.lower()
+    delimiter = "\x1f"
 
-    # Search first level then second level; return CSV "x,y" or "not_found"
-    script = f"""\
+    # Search first level then second level and let Python match caller input.
+    # This avoids interpolating LLM/user-controlled text into AppleScript.
+    script = """\
 tell application "System Events"
+    set delimiter to ASCII character 31
+    set output to ""
     set frontApp to first application process whose frontmost is true
     set wins to every window of frontApp
     repeat with win in wins
@@ -930,13 +929,13 @@ tell application "System Events"
                     set eName to name of elem
                 end try
             end if
-            if eRole is "{role_name}" and eName contains "{name_lower}" then
+            try
                 set pos to position of elem
                 set sz to size of elem
                 set cx to (item 1 of pos) + (item 1 of sz) / 2
                 set cy to (item 2 of pos) + (item 2 of sz) / 2
-                return (cx as integer) as text & "," & (cy as integer) as text
-            end if
+                set output to output & eRole & delimiter & eName & delimiter & (cx as integer) as text & delimiter & (cy as integer) as text & linefeed
+            end try
             -- second level
             try
                 repeat with child in (every UI element of elem)
@@ -953,18 +952,18 @@ tell application "System Events"
                             set cName to name of child
                         end try
                     end if
-                    if cRole is "{role_name}" and cName contains "{name_lower}" then
+                    try
                         set pos to position of child
                         set sz to size of child
                         set cx to (item 1 of pos) + (item 1 of sz) / 2
                         set cy to (item 2 of pos) + (item 2 of sz) / 2
-                        return (cx as integer) as text & "," & (cy as integer) as text
-                    end if
+                        set output to output & cRole & delimiter & cName & delimiter & (cx as integer) as text & delimiter & (cy as integer) as text & linefeed
+                    end try
                 end repeat
             end try
         end repeat
     end repeat
-    return "not_found"
+    return output
 end tell
 """
     try:
@@ -989,20 +988,23 @@ end tell
             "Ensure the terminal has Accessibility permission in System Preferences → Privacy & Security."
         ) from e
 
-    out = result.stdout.strip()
-    if out == "not_found" or not out:
-        raise RuntimeError(
-            f"No accessible element with role={role_name!r} containing name {element_name!r} "
-            "found in the frontmost app. Run computer('accessibility_tree') to see available elements."
-        )
+    for line in result.stdout.splitlines():
+        parts = line.split(delimiter)
+        if len(parts) != 4:
+            continue
+        candidate_role, candidate_name, x_str, y_str = parts
+        if candidate_role == role_name and name_lower in candidate_name.lower():
+            try:
+                return int(x_str.strip()), int(y_str.strip())
+            except ValueError:
+                raise RuntimeError(
+                    f"Unexpected position output from accessibility search: {line!r}"
+                ) from None
 
-    try:
-        x_str, y_str = out.split(",", 1)
-        return int(x_str.strip()), int(y_str.strip())
-    except ValueError:
-        raise RuntimeError(
-            f"Unexpected position output from accessibility search: {out!r}"
-        ) from None
+    raise RuntimeError(
+        f"No accessible element with role={role_name!r} containing name {element_name!r} "
+        "found in the frontmost app. Run computer('accessibility_tree') to see available elements."
+    )
 
 
 def _macos_window_focus(pattern: str, timeout: float = 10.0) -> None:

--- a/tests/test_tools_computer.py
+++ b/tests/test_tools_computer.py
@@ -19,6 +19,8 @@ from gptme.tools.computer import (
     _linux_click_accessible_element,
     _linux_scroll,
     _linux_window_focus,
+    _macos_accessibility_tree,
+    _macos_click_accessible_element,
     _macos_window_focus,
     _parse_key_sequence,
     _run_xdotool,
@@ -1551,12 +1553,16 @@ def test_click_accessible_element_not_found_raises():
         _linux_click_accessible_element("push button", "Nonexistent", ":1")
 
 
-def test_computer_accessibility_tree_invalid_on_macos():
-    """On macOS, accessibility_tree raises a helpful error."""
-    if not IS_MACOS:
-        pytest.skip("macOS-only test")
-    with pytest.raises(RuntimeError, match="AT-SPI2"):
+@mock.patch("gptme.tools.computer.IS_MACOS", True)
+@mock.patch("gptme.tools.computer._get_display_resolution", return_value=(1920, 1080))
+def test_computer_accessibility_tree_routes_to_macos(mock_res):
+    """On macOS, accessibility_tree calls _macos_accessibility_tree (not Linux path)."""
+    with mock.patch(
+        "gptme.tools.computer._macos_accessibility_tree",
+        return_value="Process: Safari\n  Window: Test\n    AXButton: Search",
+    ) as mock_tree:
         computer("accessibility_tree")
+    mock_tree.assert_called_once()
 
 
 @mock.patch("gptme.tools.computer.IS_MACOS", False)
@@ -1573,3 +1579,112 @@ def test_computer_click_accessible_element_missing_colon(mock_res):
     """click_accessible_element with text missing ':' raises ValueError."""
     with pytest.raises(ValueError, match="role_name:element_name"):
         computer("click_accessible_element", text="no-colon-here")
+
+
+# === macOS accessibility_tree tests ===
+
+
+def test_macos_accessibility_tree_success():
+    """_macos_accessibility_tree parses osascript output correctly."""
+    fake_output = "Process: Safari\n  Window: Test\n    AXButton: Search\n      AXTextField: query"
+    mock_result = mock.MagicMock()
+    mock_result.stdout = fake_output
+
+    with mock.patch("subprocess.run", return_value=mock_result):
+        result = _macos_accessibility_tree()
+
+    assert "Process: Safari" in result
+    assert "AXButton: Search" in result
+
+
+def test_macos_accessibility_tree_empty_output():
+    """_macos_accessibility_tree returns placeholder for empty output."""
+    mock_result = mock.MagicMock()
+    mock_result.stdout = ""
+
+    with mock.patch("subprocess.run", return_value=mock_result):
+        result = _macos_accessibility_tree()
+
+    assert result == "(empty accessibility tree)"
+
+
+def test_macos_accessibility_tree_osascript_missing():
+    """_macos_accessibility_tree raises RuntimeError if osascript is not found."""
+    with (
+        mock.patch("subprocess.run", side_effect=FileNotFoundError),
+        pytest.raises(RuntimeError, match="osascript not found"),
+    ):
+        _macos_accessibility_tree()
+
+
+def test_macos_accessibility_tree_timeout():
+    """_macos_accessibility_tree raises RuntimeError on timeout."""
+    with (
+        mock.patch(
+            "subprocess.run", side_effect=subprocess.TimeoutExpired("osascript", 20)
+        ),
+        pytest.raises(RuntimeError, match="timed out"),
+    ):
+        _macos_accessibility_tree()
+
+
+def test_macos_accessibility_tree_permission_error():
+    """_macos_accessibility_tree raises RuntimeError with helpful message on failure."""
+    err = subprocess.CalledProcessError(1, "osascript", stderr="Not authorized")
+    with (
+        mock.patch("subprocess.run", side_effect=err),
+        pytest.raises(RuntimeError, match="Accessibility permission"),
+    ):
+        _macos_accessibility_tree()
+
+
+# === macOS click_accessible_element tests ===
+
+
+def test_macos_click_accessible_element_success():
+    """_macos_click_accessible_element returns correct (x, y) from osascript output."""
+    mock_result = mock.MagicMock()
+    mock_result.stdout = "150,300"
+
+    with mock.patch("subprocess.run", return_value=mock_result):
+        x, y = _macos_click_accessible_element("AXButton", "Submit")
+
+    assert x == 150
+    assert y == 300
+
+
+def test_macos_click_accessible_element_not_found():
+    """_macos_click_accessible_element raises RuntimeError when element not found."""
+    mock_result = mock.MagicMock()
+    mock_result.stdout = "not_found"
+
+    with (
+        mock.patch("subprocess.run", return_value=mock_result),
+        pytest.raises(RuntimeError, match="No accessible element"),
+    ):
+        _macos_click_accessible_element("AXButton", "Nonexistent")
+
+
+def test_macos_click_accessible_element_osascript_missing():
+    """_macos_click_accessible_element raises RuntimeError when osascript not found."""
+    with (
+        mock.patch("subprocess.run", side_effect=FileNotFoundError),
+        pytest.raises(RuntimeError, match="osascript not found"),
+    ):
+        _macos_click_accessible_element("AXButton", "Submit")
+
+
+@mock.patch("gptme.tools.computer.IS_MACOS", True)
+@mock.patch("gptme.tools.computer._get_display_resolution", return_value=(1920, 1080))
+def test_computer_click_accessible_element_routes_to_macos(mock_res):
+    """On macOS, click_accessible_element calls _macos_click_accessible_element."""
+    with (
+        mock.patch(
+            "gptme.tools.computer._macos_click_accessible_element",
+            return_value=(100, 200),
+        ) as mock_click,
+        mock.patch("gptme.tools.computer._macos_mouse_move"),
+        mock.patch("gptme.tools.computer._macos_click"),
+    ):
+        computer("click_accessible_element", text="AXButton:OK")
+    mock_click.assert_called_once_with("AXButton", "OK")

--- a/tests/test_tools_computer.py
+++ b/tests/test_tools_computer.py
@@ -1597,6 +1597,23 @@ def test_macos_accessibility_tree_success():
     assert "AXButton: Search" in result
 
 
+def test_macos_accessibility_tree_max_depth_controls_child_walk():
+    """_macos_accessibility_tree wires max_depth into the generated AppleScript."""
+    mock_result = mock.MagicMock()
+    mock_result.stdout = ""
+
+    with mock.patch("subprocess.run", return_value=mock_result) as mock_run:
+        _macos_accessibility_tree(max_depth=1)
+    script_depth_1 = mock_run.call_args.args[0][2]
+
+    with mock.patch("subprocess.run", return_value=mock_result) as mock_run:
+        _macos_accessibility_tree(max_depth=2)
+    script_depth_2 = mock_run.call_args.args[0][2]
+
+    assert "every UI element of elem1" not in script_depth_1
+    assert "every UI element of elem1" in script_depth_2
+
+
 def test_macos_accessibility_tree_empty_output():
     """_macos_accessibility_tree returns placeholder for empty output."""
     mock_result = mock.MagicMock()
@@ -1644,7 +1661,7 @@ def test_macos_accessibility_tree_permission_error():
 def test_macos_click_accessible_element_success():
     """_macos_click_accessible_element returns correct (x, y) from osascript output."""
     mock_result = mock.MagicMock()
-    mock_result.stdout = "150,300"
+    mock_result.stdout = "AXButton\x1fSubmit\x1f150\x1f300\n"
 
     with mock.patch("subprocess.run", return_value=mock_result):
         x, y = _macos_click_accessible_element("AXButton", "Submit")
@@ -1656,7 +1673,7 @@ def test_macos_click_accessible_element_success():
 def test_macos_click_accessible_element_not_found():
     """_macos_click_accessible_element raises RuntimeError when element not found."""
     mock_result = mock.MagicMock()
-    mock_result.stdout = "not_found"
+    mock_result.stdout = ""
 
     with (
         mock.patch("subprocess.run", return_value=mock_result),
@@ -1665,11 +1682,42 @@ def test_macos_click_accessible_element_not_found():
         _macos_click_accessible_element("AXButton", "Nonexistent")
 
 
+def test_macos_click_accessible_element_does_not_inject_inputs():
+    """Caller-controlled role/name values are matched in Python, not AppleScript."""
+    mock_result = mock.MagicMock()
+    mock_result.stdout = ""
+
+    role_name = 'AXButton" then\n    do shell script "touch /tmp/pwned"'
+    element_name = 'Submit" then\n    do shell script "touch /tmp/pwned"'
+
+    with (
+        mock.patch("subprocess.run", return_value=mock_result) as mock_run,
+        pytest.raises(RuntimeError, match="No accessible element"),
+    ):
+        _macos_click_accessible_element(role_name, element_name)
+
+    script = mock_run.call_args.args[0][2]
+    assert role_name not in script
+    assert element_name not in script
+    assert "do shell script" not in script
+
+
 def test_macos_click_accessible_element_osascript_missing():
     """_macos_click_accessible_element raises RuntimeError when osascript not found."""
     with (
         mock.patch("subprocess.run", side_effect=FileNotFoundError),
         pytest.raises(RuntimeError, match="osascript not found"),
+    ):
+        _macos_click_accessible_element("AXButton", "Submit")
+
+
+def test_macos_click_accessible_element_timeout():
+    """_macos_click_accessible_element raises RuntimeError on timeout."""
+    with (
+        mock.patch(
+            "subprocess.run", side_effect=subprocess.TimeoutExpired("osascript", 15)
+        ),
+        pytest.raises(RuntimeError, match="timed out"),
     ):
         _macos_click_accessible_element("AXButton", "Submit")
 


### PR DESCRIPTION
## What

Add `_macos_accessibility_tree()` and `_macos_click_accessible_element()` using AppleScript via `osascript`, making `accessibility_tree` and `click_accessible_element` cross-platform.

## Why

Previously, both actions dispatched unconditionally to `_linux_accessibility_tree` / `_linux_click_accessible_element` — crashing on macOS since AT-SPI2 is Linux-only. The `computer("accessibility_tree")` action would raise a `RuntimeError("AT-SPI2")` error, and `click_accessible_element` would fail similarly.

This was one of the remaining gaps blocking issue #216 — the computer-use stack has mouse, keyboard, screenshots, window focus, and AT-SPI2 on Linux, but macOS native app accessibility was a hard error.

## How

`osascript` (AppleScript via System Events) is built into every macOS system — zero additional dependencies. The pattern is already used by `_macos_window_focus()` in this file.

- `_macos_accessibility_tree()`: walks visible processes → windows → UI elements 2 levels deep (capped to avoid hanging on complex apps). Returns role names in AX-prefix format (`AXButton`, `AXTextField`, `AXCheckBox`, etc.)
- `_macos_click_accessible_element()`: searches frontmost app's window hierarchy for an element by role + name (case-insensitive substring), returns center `(x, y)` coordinates, then dispatches via `_macos_mouse_move` + `_macos_click`
- Both dispatch points in `_dispatch_transport` and `computer()` now check `IS_MACOS` and route to the correct backend
- Updated module docstring and tips section to document cross-platform role name differences

## Tests

10 new unit tests (all mocked, no display required):
- success / empty-output / timeout / CalledProcessError / not-found for both functions
- platform routing test: `IS_MACOS=True` mock verifies `computer("accessibility_tree")` calls `_macos_accessibility_tree` (not Linux path)
- routing test: `click_accessible_element` with `IS_MACOS=True` calls `_macos_click_accessible_element`

All 108 tests pass.

Closes #216 (partial — macOS accessibility backend now complete; the remaining open items are Docker/VNC streaming and the "Can it Tweet?" end-to-end validation)

<!-- gptme-id:v1:gai_JXqWS370euF8LQ5diokbixqvEOQzgLmyWOcGPWwWdH1 -->