### PR TITLE
feat(computer): extend audit-log to track browser interactions (#216)

### DIFF
--- a/gptme/cli/cmd_computer.py
+++ b/gptme/cli/cmd_computer.py
@@ -14,6 +14,12 @@ from ..tools.base import ToolUse
 # Patterns that indicate text/key content (redact for privacy)
 _SENSITIVE_ACTIONS = frozenset({"type", "key"})
 
+# Browser interaction functions whose first arg is a URL
+_URL_BROWSER_FNS = frozenset({"observe_web", "snapshot_url", "open_page"})
+
+# Browser interaction functions whose first arg is a CSS/DOM selector
+_SELECTOR_BROWSER_FNS = frozenset({"click_element"})
+
 
 def _slice_call(code: str, start: int) -> str:
     """Return the source span for a function call starting at ``start``."""
@@ -44,11 +50,21 @@ def _slice_call(code: str, start: int) -> str:
 
 
 def _extract_computer_calls(messages) -> list[dict]:
-    """Extract computer() and observe_desktop() calls from a message list.
+    """Extract computer-use actions from a message list.
 
-    Scans executable tool-use blocks (ipython codeblocks) for calls to the
-    computer() function and the observe_desktop() helper. Typed text is never
-    logged raw — only its length is recorded.
+    Scans executable tool-use blocks (ipython codeblocks) for calls to:
+    - ``computer()`` — desktop/X11 actions (screenshot, click, type, key, …)
+    - ``observe_desktop()`` — explicit desktop observation
+    - ``observe_web(url)`` — structured-first web observation
+    - ``snapshot_url(url)`` — one-shot ARIA snapshot
+    - ``open_page(url)`` — open an interactive browser session
+    - ``click_element(selector)`` — DOM element click
+    - ``fill_element(selector, value)`` — form fill (value length logged, not raw text)
+    - ``read_page_text()`` — read page text content
+    - ``scroll_page(direction)`` — scroll the current page
+
+    Typed/key text and fill_element values are never logged raw — only their
+    length is recorded to avoid leaking passwords or personally identifiable data.
     """
     records: list[dict] = []
     for msg in messages:
@@ -58,15 +74,13 @@ def _extract_computer_calls(messages) -> list[dict]:
             if not tu.is_runnable or not tu.content:
                 continue
             code = tu.content
-            # Match computer("action", ...) and computer('action', ...)
+            ts = msg.timestamp.isoformat() if msg.timestamp else None
+
+            # --- computer("action", ...) ---
             for m in re.finditer(r"""computer\s*\(\s*['"]([^'"]+)['"]""", code):
                 action = m.group(1)
                 call_source = _slice_call(code, m.start())
-                record: dict = {
-                    "timestamp": msg.timestamp.isoformat() if msg.timestamp else None,
-                    "action": action,
-                }
-                # Extract coordinate if present: coordinate=(x, y)
+                record: dict = {"timestamp": ts, "action": action}
                 coord_m = re.search(
                     r"coordinate\s*=\s*\((\d+)\s*,\s*(\d+)\)", call_source
                 )
@@ -75,23 +89,109 @@ def _extract_computer_calls(messages) -> list[dict]:
                         int(coord_m.group(1)),
                         int(coord_m.group(2)),
                     ]
-                # For type/key actions, redact the text value — log only length
                 if action in _SENSITIVE_ACTIONS:
                     text_m = re.search(r"""text\s*=\s*['"]([^'"]*)['"]""", call_source)
-                    if text_m:
-                        record["text_len"] = len(text_m.group(1))
-                    else:
-                        record["text_len"] = None
+                    record["text_len"] = len(text_m.group(1)) if text_m else None
                 records.append(record)
-            # Also capture observe_desktop() calls
+
+            # --- observe_desktop() ---
             records.extend(
-                {
-                    "timestamp": msg.timestamp.isoformat() if msg.timestamp else None,
-                    "action": "screenshot",
-                    "source": "observe_desktop",
-                }
+                {"timestamp": ts, "action": "screenshot", "source": "observe_desktop"}
                 for _ in re.finditer(r"\bobserve_desktop\s*\(", code)
             )
+
+            # --- browser interaction calls ---
+            # Collected with their byte-offset in the code block so they can be
+            # sorted into code order before appending (multiple passes would
+            # otherwise interleave URL-fns, selector-fns, fill-fns, etc.).
+            browser_positioned: list[tuple[int, dict]] = []
+
+            # Functions whose first arg is a URL (no mixed-quote risk)
+            for fn in _URL_BROWSER_FNS:
+                browser_positioned.extend(
+                    (
+                        m.start(),
+                        {
+                            "timestamp": ts,
+                            "action": fn,
+                            "source": "browser",
+                            "url": m.group(1) or m.group(2),
+                        },
+                    )
+                    for m in re.finditer(
+                        rf"""\b{fn}\s*\(\s*(?:'([^']+)'|"([^"]+)")""", code
+                    )
+                )
+
+            # click_element(selector) — selectors may contain the opposite quote
+            # type (e.g. '[name="q"]'), so match each quote style separately.
+            for fn in _SELECTOR_BROWSER_FNS:
+                browser_positioned.extend(
+                    (
+                        m.start(),
+                        {
+                            "timestamp": ts,
+                            "action": fn,
+                            "source": "browser",
+                            "selector": m.group(1)
+                            if m.group(1) is not None
+                            else m.group(2),
+                        },
+                    )
+                    for m in re.finditer(
+                        rf"""\b{fn}\s*\(\s*(?:'([^']*)'|"([^"]*)")""", code
+                    )
+                )
+
+            # fill_element(selector, value) — value is potentially sensitive;
+            # log only its length. Selector may contain opposite-type quotes.
+            browser_positioned.extend(
+                (
+                    m.start(),
+                    {
+                        "timestamp": ts,
+                        "action": "fill_element",
+                        "source": "browser",
+                        "selector": m.group(1)
+                        if m.group(1) is not None
+                        else m.group(2),
+                        "value_len": len(
+                            m.group(3) if m.group(3) is not None else (m.group(4) or "")
+                        ),
+                    },
+                )
+                for m in re.finditer(
+                    r"""\bfill_element\s*\(\s*(?:'([^']*)'|"([^"]*)")\s*,\s*(?:'([^']*)'|"([^"]*)")""",
+                    code,
+                )
+            )
+
+            # read_page_text() — no arguments to extract
+            browser_positioned.extend(
+                (
+                    m.start(),
+                    {"timestamp": ts, "action": "read_page_text", "source": "browser"},
+                )
+                for m in re.finditer(r"\bread_page_text\s*\(", code)
+            )
+
+            # scroll_page(direction)
+            browser_positioned.extend(
+                (
+                    m.start(),
+                    {
+                        "timestamp": ts,
+                        "action": "scroll_page",
+                        "source": "browser",
+                        "direction": m.group(1),
+                    },
+                )
+                for m in re.finditer(r"""\bscroll_page\s*\(\s*['"]([^'"]+)['"]""", code)
+            )
+
+            # Emit browser records in code order (stable, ascending offset)
+            records.extend(r for _, r in sorted(browser_positioned, key=lambda x: x[0]))
+
     return records
 
 
@@ -115,8 +215,9 @@ def audit_log(conversation: str | None, last: int, as_json: bool):
     """Extract computer-use actions from session trajectories.
 
     Reads conversation JSONL logs (the authoritative audit trail) and prints a
-    structured summary of every computer() and observe_desktop() call, with
-    typed/key text redacted to just its length.
+    structured summary of every computer(), observe_desktop(), and browser
+    interaction call (observe_web, open_page, fill_element, click_element, …).
+    Typed/key text and fill_element values are redacted to just their length.
 
     CONVERSATION is a conversation name or ID. Omit to scan the most-recent
     session(s) (controlled by --last).
@@ -183,10 +284,21 @@ def audit_log(conversation: str | None, last: int, as_json: bool):
         conv = (r.get("conversation") or "")[:24]
         action = r.get("action", "")[:24]
         details = ""
-        if "coordinate" in r:
-            details = f"@ {r['coordinate']}"
-        if "text_len" in r and r["text_len"] is not None:
-            details += f" ({r['text_len']} chars, redacted)"
-        if r.get("source") == "observe_desktop":
+        source = r.get("source", "")
+        if source == "observe_desktop":
             details = "via observe_desktop()"
+        elif source == "browser":
+            if "url" in r:
+                details = r["url"][:70]
+            elif "selector" in r and "value_len" in r:
+                details = f"{r['selector']!r} → {r['value_len']} chars"
+            elif "selector" in r:
+                details = repr(r["selector"])
+            elif "direction" in r:
+                details = r["direction"]
+        else:
+            if "coordinate" in r:
+                details = f"@ {r['coordinate']}"
+            if "text_len" in r and r["text_len"] is not None:
+                details += f" ({r['text_len']} chars, redacted)"
         click.echo(f"{ts:<30} {conv:<25} {action:<25} {details}")

--- a/gptme/cli/cmd_computer.py
+++ b/gptme/cli/cmd_computer.py
@@ -76,6 +76,10 @@ def _extract_computer_calls(messages) -> list[dict]:
             code = tu.content
             ts = msg.timestamp.isoformat() if msg.timestamp else None
 
+            # All calls tracked with their byte-offset so desktop and browser
+            # calls within the same block are emitted in source order.
+            all_positioned: list[tuple[int, dict]] = []
+
             # --- computer("action", ...) ---
             for m in re.finditer(r"""computer\s*\(\s*['"]([^'"]+)['"]""", code):
                 action = m.group(1)
@@ -92,12 +96,19 @@ def _extract_computer_calls(messages) -> list[dict]:
                 if action in _SENSITIVE_ACTIONS:
                     text_m = re.search(r"""text\s*=\s*['"]([^'"]*)['"]""", call_source)
                     record["text_len"] = len(text_m.group(1)) if text_m else None
-                records.append(record)
+                all_positioned.append((m.start(), record))
 
             # --- observe_desktop() ---
-            records.extend(
-                {"timestamp": ts, "action": "screenshot", "source": "observe_desktop"}
-                for _ in re.finditer(r"\bobserve_desktop\s*\(", code)
+            all_positioned.extend(
+                (
+                    m.start(),
+                    {
+                        "timestamp": ts,
+                        "action": "screenshot",
+                        "source": "observe_desktop",
+                    },
+                )
+                for m in re.finditer(r"\bobserve_desktop\s*\(", code)
             )
 
             # --- browser interaction calls ---
@@ -189,8 +200,13 @@ def _extract_computer_calls(messages) -> list[dict]:
                 for m in re.finditer(r"""\bscroll_page\s*\(\s*['"]([^'"]+)['"]""", code)
             )
 
-            # Emit browser records in code order (stable, ascending offset)
-            records.extend(r for _, r in sorted(browser_positioned, key=lambda x: x[0]))
+            # Merge desktop and browser records, emit in source order
+            records.extend(
+                r
+                for _, r in sorted(
+                    all_positioned + browser_positioned, key=lambda x: x[0]
+                )
+            )
 
     return records
 

--- a/gptme/cli/cmd_computer.py
+++ b/gptme/cli/cmd_computer.py
@@ -305,7 +305,8 @@ def audit_log(conversation: str | None, last: int, as_json: bool):
             details = "via observe_desktop()"
         elif source == "browser":
             if "url" in r:
-                details = r["url"][:70]
+                url = r["url"]
+                details = url[:70] + ("…" if len(url) > 70 else "")
             elif "selector" in r and "value_len" in r:
                 details = f"{r['selector']!r} → {r['value_len']} chars"
             elif "selector" in r:

--- a/tests/test_computer_audit.py
+++ b/tests/test_computer_audit.py
@@ -1,7 +1,8 @@
 """Tests for gptme-util computer audit-log (cmd_computer.py).
 
-Validates that computer() and observe_desktop() calls are extracted from
-synthetic JSONL trajectories, and that typed text is never logged raw.
+Validates that computer(), observe_desktop(), and browser interaction calls
+are extracted from synthetic JSONL trajectories, and that typed/sensitive
+text is never logged raw.
 """
 
 from __future__ import annotations
@@ -361,3 +362,171 @@ def test_empty_code_block_skipped():
     msgs = [_msg("assistant", "```ipython\n\n```")]
     records = _extract_computer_calls(msgs)
     assert records == []
+
+
+# ---------------------------------------------------------------------------
+# Browser interaction call tracking (observe_web, snapshot_url, open_page,
+# click_element, fill_element, read_page_text, scroll_page)
+# ---------------------------------------------------------------------------
+
+
+def test_observe_web_captured():
+    msgs = [_msg("assistant", _ipython_block("observe_web('https://example.com')"))]
+    records = _extract_computer_calls(msgs)
+    assert len(records) == 1
+    assert records[0]["action"] == "observe_web"
+    assert records[0]["source"] == "browser"
+    assert records[0]["url"] == "https://example.com"
+
+
+def test_observe_web_double_quotes():
+    msgs = [
+        _msg("assistant", _ipython_block('observe_web("https://news.ycombinator.com")'))
+    ]
+    records = _extract_computer_calls(msgs)
+    assert len(records) == 1
+    assert records[0]["url"] == "https://news.ycombinator.com"
+
+
+def test_snapshot_url_captured():
+    msgs = [_msg("assistant", _ipython_block("snapshot_url('https://example.com')"))]
+    records = _extract_computer_calls(msgs)
+    assert len(records) == 1
+    assert records[0]["action"] == "snapshot_url"
+    assert records[0]["source"] == "browser"
+    assert records[0]["url"] == "https://example.com"
+
+
+def test_open_page_captured():
+    msgs = [
+        _msg("assistant", _ipython_block("open_page('https://httpbin.org/forms/post')"))
+    ]
+    records = _extract_computer_calls(msgs)
+    assert len(records) == 1
+    assert records[0]["action"] == "open_page"
+    assert records[0]["source"] == "browser"
+    assert records[0]["url"] == "https://httpbin.org/forms/post"
+
+
+def test_click_element_captured():
+    msgs = [_msg("assistant", _ipython_block("click_element('[type=\"submit\"]')"))]
+    records = _extract_computer_calls(msgs)
+    assert len(records) == 1
+    assert records[0]["action"] == "click_element"
+    assert records[0]["source"] == "browser"
+    assert records[0]["selector"] == '[type="submit"]'
+
+
+def test_fill_element_selector_kept_value_redacted():
+    msgs = [
+        _msg(
+            "assistant", _ipython_block("fill_element('[name=\"custname\"]', 'Alice')")
+        )
+    ]
+    records = _extract_computer_calls(msgs)
+    assert len(records) == 1
+    r = records[0]
+    assert r["action"] == "fill_element"
+    assert r["source"] == "browser"
+    assert r["selector"] == '[name="custname"]'
+    # Raw value must NOT appear
+    assert "value" not in r
+    assert r["value_len"] == len("Alice")
+
+
+def test_fill_element_password_not_logged():
+    code = "fill_element('[name=\"password\"]', 'supersecret')"
+    msgs = [_msg("assistant", _ipython_block(code))]
+    records = _extract_computer_calls(msgs)
+    assert len(records) == 1
+    assert "supersecret" not in str(records)
+    assert records[0]["value_len"] == len("supersecret")
+
+
+def test_read_page_text_captured():
+    msgs = [_msg("assistant", _ipython_block("read_page_text()"))]
+    records = _extract_computer_calls(msgs)
+    assert len(records) == 1
+    assert records[0]["action"] == "read_page_text"
+    assert records[0]["source"] == "browser"
+
+
+def test_scroll_page_captured():
+    msgs = [_msg("assistant", _ipython_block("scroll_page('down')"))]
+    records = _extract_computer_calls(msgs)
+    assert len(records) == 1
+    assert records[0]["action"] == "scroll_page"
+    assert records[0]["source"] == "browser"
+    assert records[0]["direction"] == "down"
+
+
+def test_mixed_computer_and_browser_calls():
+    """Full "Can it Tweet?" style pipeline: open_page + fill + click + read."""
+    code = textwrap.dedent("""\
+        open_page('https://httpbin.org/forms/post')
+        fill_element('[name="custname"]', 'TestUser')
+        fill_element('[name="custemail"]', 'test@example.com')
+        click_element('[type="submit"]')
+        read_page_text()
+    """)
+    msgs = [_msg("assistant", _ipython_block(code))]
+    records = _extract_computer_calls(msgs)
+    actions = [r["action"] for r in records]
+    assert actions == [
+        "open_page",
+        "fill_element",
+        "fill_element",
+        "click_element",
+        "read_page_text",
+    ]
+    # URL captured for open_page
+    assert records[0]["url"] == "https://httpbin.org/forms/post"
+    # Selectors captured for fill/click
+    assert records[1]["selector"] == '[name="custname"]'
+    assert records[2]["selector"] == '[name="custemail"]'
+    assert records[3]["selector"] == '[type="submit"]'
+    # Values redacted
+    assert records[1]["value_len"] == len("TestUser")
+    assert records[2]["value_len"] == len("test@example.com")
+
+
+def test_audit_log_cli_table_shows_browser_url(tmp_path, monkeypatch):
+    """Table output shows URL for observe_web/open_page calls."""
+    conv_dir = tmp_path / "browser-conv"
+    jsonl = conv_dir / "conversation.jsonl"
+    msgs = [
+        _msg("assistant", _ipython_block("observe_web('https://example.com')")),
+        _msg(
+            "assistant", _ipython_block("open_page('https://httpbin.org/forms/post')")
+        ),
+    ]
+    _write_conv_jsonl(jsonl, msgs)
+
+    runner = CliRunner()
+    result = runner.invoke(audit_log, [str(jsonl)], catch_exceptions=False)
+    assert result.exit_code == 0
+    assert "https://example.com" in result.output
+    assert "https://httpbin.org/forms/post" in result.output
+
+
+def test_audit_log_cli_table_shows_selector_and_value_len(tmp_path):
+    """Table output shows selector and value length for fill_element."""
+    conv_dir = tmp_path / "fill-conv"
+    jsonl = conv_dir / "conversation.jsonl"
+    msgs = [
+        _msg(
+            "assistant", _ipython_block("fill_element('[name=\"q\"]', 'hello world')")
+        ),
+        _msg("assistant", _ipython_block("click_element('[type=\"submit\"]')")),
+    ]
+    _write_conv_jsonl(jsonl, msgs)
+
+    runner = CliRunner()
+    result = runner.invoke(audit_log, [str(jsonl)], catch_exceptions=False)
+    assert result.exit_code == 0
+    # Should NOT contain the raw value
+    assert "hello world" not in result.output
+    # Should show the character count
+    assert f"{len('hello world')} chars" in result.output
+    # Selector shown for click_element
+    assert '[type="submit"]' in result.output

--- a/tests/test_computer_audit.py
+++ b/tests/test_computer_audit.py
@@ -490,6 +490,25 @@ def test_mixed_computer_and_browser_calls():
     assert records[2]["value_len"] == len("test@example.com")
 
 
+def test_mixed_desktop_browser_source_order():
+    """Desktop and browser calls interleaved in one block emit in source order."""
+    code = textwrap.dedent("""\
+        observe_web('https://example.com')
+        computer('screenshot')
+        click_element('#btn')
+        computer('click', coordinate=(100, 200))
+    """)
+    msgs = [_msg("assistant", _ipython_block(code))]
+    records = _extract_computer_calls(msgs)
+    actions = [r["action"] for r in records]
+    assert actions == [
+        "observe_web",
+        "screenshot",
+        "click_element",
+        "click",
+    ], f"Expected source order but got: {actions}"
+
+
 def test_audit_log_cli_table_shows_browser_url(tmp_path, monkeypatch):
     """Table output shows URL for observe_web/open_page calls."""
     conv_dir = tmp_path / "browser-conv"

--- a/tests/test_computer_audit.py
+++ b/tests/test_computer_audit.py
@@ -528,6 +528,28 @@ def test_audit_log_cli_table_shows_browser_url(tmp_path, monkeypatch):
     assert "https://httpbin.org/forms/post" in result.output
 
 
+def test_audit_log_cli_table_long_url_truncated(tmp_path):
+    """Table output truncates URLs >70 chars with ellipsis."""
+    long_url = "https://example.com/" + "a" * 60
+    assert len(long_url) > 70
+    conv_dir = tmp_path / "long-url-conv"
+    jsonl = conv_dir / "conversation.jsonl"
+    msgs = [
+        _msg("assistant", _ipython_block(f"observe_web('{long_url}')")),
+    ]
+    _write_conv_jsonl(jsonl, msgs)
+
+    runner = CliRunner()
+    result = runner.invoke(audit_log, [str(jsonl)], catch_exceptions=False)
+    assert result.exit_code == 0
+    # First 70 chars should be present
+    assert long_url[:70] in result.output
+    # Full URL must NOT appear (would mean no truncation happened)
+    assert long_url not in result.output
+    # Ellipsis character should appear at truncation boundary
+    assert "…" in result.output
+
+
 def test_audit_log_cli_table_shows_selector_and_value_len(tmp_path):
     """Table output shows selector and value length for fill_element."""
     conv_dir = tmp_path / "fill-conv"

--- a/tests/test_tools_computer.py
+++ b/tests/test_tools_computer.py
@@ -1,6 +1,5 @@
 """Tests for the computer tool."""
 
-import itertools
 import os
 import shutil
 import subprocess
@@ -1189,18 +1188,15 @@ def test_wait_for_change_polls_with_backoff(mock_transport, mock_res, tmp_path):
     def _record_sleep(interval):
         sleep_calls.append(interval)
 
-    # Expire the loop on the 4th poll so we get 3 sleep calls and see the backoff
-    # Use an infinite tail (repeat(100.0)) to avoid StopIteration inside a generator
-    # (PEP 479: StopIteration raised in a generator becomes RuntimeError)
-    monotonic_iter = itertools.chain([0.0, 0.0, 0.0, 0.0], itertools.repeat(100.0))
+    def _fake_monotonic():
+        # Keep the loop inside the deadline until the third sleep has observed
+        # the backoff sequence, then expire it on the next loop check.
+        return 0.0 if len(sleep_calls) < 3 else 100.0
 
     with (
         mock.patch("gptme.tools.computer.screenshot", return_value=static),
         mock.patch("gptme.tools.computer.time.sleep", side_effect=_record_sleep),
-        mock.patch(
-            "gptme.tools.computer.time.monotonic",
-            side_effect=lambda: next(monotonic_iter),
-        ),
+        mock.patch("gptme.tools.computer.time.monotonic", side_effect=_fake_monotonic),
         mock.patch(
             "gptme.tools.computer._make_screenshot_msg",
             return_value=mock.sentinel.timeout_msg,
@@ -1210,7 +1206,7 @@ def test_wait_for_change_polls_with_backoff(mock_transport, mock_res, tmp_path):
 
     assert result is mock.sentinel.timeout_msg
     # First call: 50ms; second: 100ms; third: 200ms — doubling backoff
-    assert len(sleep_calls) >= 2
+    assert len(sleep_calls) >= 3
     assert sleep_calls[0] == pytest.approx(0.05)  # 50ms initial interval
     assert sleep_calls[1] == pytest.approx(0.10)  # 100ms after first backoff
     assert sleep_calls[2] == pytest.approx(0.20)  # 200ms after second backoff


### PR DESCRIPTION
## Summary

Closes a gap in the computer-use audit trail: `gptme-util computer audit-log` previously only tracked `computer()` and `observe_desktop()` desktop calls, leaving the browser half of computer-use sessions (the structured-first web interaction path) completely invisible.

**New actions tracked:**
- `observe_web(url)` / `snapshot_url(url)` / `open_page(url)` — URL logged
- `click_element(selector)` — selector logged
- `fill_element(selector, value)` — selector logged; **value redacted to length** (same privacy policy as `computer('type', text=...)`)
- `read_page_text()` / `scroll_page(direction)` — direction logged

Records within a code block are sorted to code order (multiple regex passes over the same block would otherwise interleave URL-fns, selector-fns, and fill-fns). The CLI table display shows URLs, selectors, and value lengths for the new action types.

This completes the audit-log so it covers the full "Can it Tweet?" style pipeline that the `computer-use` profile guides agents to use:
```
open_page(url) → fill_element(selector, value) → click_element(selector) → read_page_text()
```

## Test plan

- [x] 13 new unit tests in `test_computer_audit.py` covering all new call types, mixed pipelines, password-redaction invariant, and table output formatting
- [x] All 260 existing computer-use tests still pass
- [x] `ruff check` + `ruff format` clean
- [x] `mypy` clean (pre-commit)

```bash
uv run pytest tests/test_computer_audit.py -v   # 35 passed
uv run pytest tests/test_computer_audit.py tests/test_eval_computer_suite.py tests/test_computer_actions.py tests/test_computer_docker_config.py tests/test_tools_computer.py tests/test_computer_transport.py tests/test_computer_artifacts.py  # 260 passed
```

<!-- gptme-id:v1:gai_j0IAgWr3NwSZMPiAhPIfLUKiPJTpVD9RrkCwBgAfMTz -->