### PR TITLE
fix(computer): detect macOS display scale via AppKit/system_profiler (#216)

### DIFF
--- a/gptme/tools/computer.py
+++ b/gptme/tools/computer.py
@@ -280,18 +280,57 @@ def _get_macos_display_scale() -> float:
         output = subprocess.check_output(
             ["system_profiler", "SPDisplaysDataType"], text=True, timeout=10
         )
-        physical_w: int | None = None
+        current_physical_w: int | None = None
+        current_logical_w: int | None = None
+        current_is_main = False
+        fallback_scale: float | None = None
+
+        def record_candidate() -> float | None:
+            nonlocal fallback_scale
+            if (
+                current_physical_w is None
+                or current_logical_w is None
+                or current_logical_w <= 0
+            ):
+                return None
+
+            scale = current_physical_w / current_logical_w
+            if current_is_main:
+                return scale
+            if fallback_scale is None or (fallback_scale == 1.0 and scale != 1.0):
+                fallback_scale = scale
+            return None
+
         for line in output.splitlines():
             stripped = line.strip()
-            if stripped.startswith("Resolution:") and physical_w is None:
+            if (
+                line.startswith("        ")
+                and not line.startswith("          ")
+                and stripped.endswith(":")
+            ):
+                scale = record_candidate()
+                if scale is not None:
+                    return scale
+                current_physical_w = None
+                current_logical_w = None
+                current_is_main = False
+                continue
+
+            if stripped.startswith("Resolution:"):
                 parts = stripped.split(":")[-1].split("x")
-                physical_w = int(parts[0].strip())
-            elif "UI Looks like" in stripped and physical_w is not None:
+                current_physical_w = int(parts[0].strip())
+            elif stripped.startswith("UI Looks like:"):
                 # "UI Looks like: 1280 x 832 @ 60.00Hz"
                 parts = stripped.split(":")[-1].split("x")
-                logical_w = int(parts[0].strip())
-                if logical_w > 0:
-                    return physical_w / logical_w
+                current_logical_w = int(parts[0].strip())
+            elif stripped == "Main Display: Yes":
+                current_is_main = True
+
+        scale = record_candidate()
+        if scale is not None:
+            return scale
+        if fallback_scale is not None:
+            return fallback_scale
     except Exception:
         pass
 

--- a/gptme/tools/computer.py
+++ b/gptme/tools/computer.py
@@ -85,6 +85,7 @@ Using a single sequence for complex operations ensures proper timing and recogni
 from __future__ import annotations
 
 import dataclasses
+import functools
 import logging
 import os
 import platform
@@ -255,24 +256,22 @@ def _get_display_resolution() -> tuple[int, int]:
     raise RuntimeError("Failed to get display resolution")
 
 
+@functools.lru_cache(maxsize=1)
 def _get_macos_display_scale() -> float:
     """Detect the macOS HiDPI/Retina backing scale factor.
 
     Tries in order:
     1. ``AppKit.NSScreen.mainScreen().backingScaleFactor()`` — accurate for any display config
-    2. Ratio of physical "Resolution" to logical "UI Looks like" in ``system_profiler``
+    2. Ratio of physical "Resolution:" to logical "UI Looks like" in ``system_profiler``
     3. Falls back to ``2.0`` (standard Retina)
     """
     # Method 1: AppKit (preferred — works for all display configs including external monitors)
     try:
-        import importlib.util
+        import AppKit  # type: ignore[import-untyped]
 
-        if importlib.util.find_spec("AppKit") is not None:
-            import AppKit  # type: ignore[import]
-
-            screen = AppKit.NSScreen.mainScreen()
-            if screen is not None:
-                return float(screen.backingScaleFactor())
+        screen = AppKit.NSScreen.mainScreen()
+        if screen is not None:
+            return float(screen.backingScaleFactor())
     except Exception:
         pass
 
@@ -284,7 +283,7 @@ def _get_macos_display_scale() -> float:
         physical_w: int | None = None
         for line in output.splitlines():
             stripped = line.strip()
-            if "Resolution" in stripped and physical_w is None:
+            if stripped.startswith("Resolution:") and physical_w is None:
                 parts = stripped.split(":")[-1].split("x")
                 physical_w = int(parts[0].strip())
             elif "UI Looks like" in stripped and physical_w is not None:

--- a/gptme/tools/computer.py
+++ b/gptme/tools/computer.py
@@ -109,6 +109,10 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Patch these aliases in tests instead of mutating the process-wide time module.
+_monotonic = time.monotonic
+_sleep = time.sleep
+
 
 # Platform detection
 IS_MACOS = platform.system() == "Darwin"
@@ -1117,7 +1121,7 @@ def _macos_window_focus(pattern: str, timeout: float = 10.0) -> None:
         "  end tell\n"
         "end run"
     )
-    deadline = time.monotonic() + timeout
+    deadline = _monotonic() + timeout
     while True:
         try:
             result = subprocess.run(
@@ -1136,11 +1140,11 @@ def _macos_window_focus(pattern: str, timeout: float = 10.0) -> None:
 
         if result.stdout.strip() == "found":
             return
-        if time.monotonic() >= deadline:
+        if _monotonic() >= deadline:
             raise RuntimeError(
                 f"No window matching {pattern!r} appeared within {timeout:.0f}s"
             )
-        time.sleep(0.5)
+        _sleep(0.5)
 
 
 def _macos_click(button: int) -> None:
@@ -1294,9 +1298,9 @@ def _dispatch_transport(
         max_poll_interval = 0.5
         change_threshold = 0.01
         baseline = transport.screenshot()
-        deadline = time.monotonic() + timeout
-        while time.monotonic() < deadline:
-            time.sleep(poll_interval)
+        deadline = _monotonic() + timeout
+        while _monotonic() < deadline:
+            _sleep(poll_interval)
             current = transport.screenshot()
             ratio = _compute_change_ratio(baseline, current)
             if ratio >= change_threshold:
@@ -1581,9 +1585,9 @@ def computer(
         max_poll_interval = 0.5
         change_threshold = 0.01  # 1% of pixels must differ
         baseline = screenshot()
-        deadline = time.monotonic() + timeout
-        while time.monotonic() < deadline:
-            time.sleep(poll_interval)
+        deadline = _monotonic() + timeout
+        while _monotonic() < deadline:
+            _sleep(poll_interval)
             current = screenshot()
             ratio = _compute_change_ratio(baseline, current)
             if ratio >= change_threshold:

--- a/gptme/tools/computer.py
+++ b/gptme/tools/computer.py
@@ -255,6 +255,51 @@ def _get_display_resolution() -> tuple[int, int]:
     raise RuntimeError("Failed to get display resolution")
 
 
+def _get_macos_display_scale() -> float:
+    """Detect the macOS HiDPI/Retina backing scale factor.
+
+    Tries in order:
+    1. ``AppKit.NSScreen.mainScreen().backingScaleFactor()`` — accurate for any display config
+    2. Ratio of physical "Resolution" to logical "UI Looks like" in ``system_profiler``
+    3. Falls back to ``2.0`` (standard Retina)
+    """
+    # Method 1: AppKit (preferred — works for all display configs including external monitors)
+    try:
+        import importlib.util
+
+        if importlib.util.find_spec("AppKit") is not None:
+            import AppKit  # type: ignore[import]
+
+            screen = AppKit.NSScreen.mainScreen()
+            if screen is not None:
+                return float(screen.backingScaleFactor())
+    except Exception:
+        pass
+
+    # Method 2: Parse system_profiler output for "UI Looks like: NNN x NNN"
+    try:
+        output = subprocess.check_output(
+            ["system_profiler", "SPDisplaysDataType"], text=True, timeout=10
+        )
+        physical_w: int | None = None
+        for line in output.splitlines():
+            stripped = line.strip()
+            if "Resolution" in stripped and physical_w is None:
+                parts = stripped.split(":")[-1].split("x")
+                physical_w = int(parts[0].strip())
+            elif "UI Looks like" in stripped and physical_w is not None:
+                # "UI Looks like: 1280 x 832 @ 60.00Hz"
+                parts = stripped.split(":")[-1].split("x")
+                logical_w = int(parts[0].strip())
+                if logical_w > 0:
+                    return physical_w / logical_w
+    except Exception:
+        pass
+
+    # Method 3: Assume standard 2× Retina
+    return 2.0
+
+
 def _scale_coordinates(
     source: _ScalingSource, x: int, y: int, api_width: int, api_height: int
 ) -> tuple[int, int]:
@@ -264,11 +309,7 @@ def _scale_coordinates(
 
     # Account for macOS display scaling factor
     if IS_MACOS:
-        # macOS display scaling factor
-        # TODO: retrieve somehow? we could move mouse to the bottom right and then get the position
-        # (but it's hacky and confusing to users)
-        display_scale = 2560 / 1709
-
+        display_scale = _get_macos_display_scale()
         physical_width = int(physical_width / display_scale)
         physical_height = int(physical_height / display_scale)
         logger.info(

--- a/gptme/tools/computer.py
+++ b/gptme/tools/computer.py
@@ -267,7 +267,7 @@ def _get_macos_display_scale() -> float:
     """
     # Method 1: AppKit (preferred — works for all display configs including external monitors)
     try:
-        import AppKit  # type: ignore[import-untyped]
+        import AppKit  # type: ignore[import-not-found,import-untyped]
 
         screen = AppKit.NSScreen.mainScreen()
         if screen is not None:

--- a/tests/test_computer_actions.py
+++ b/tests/test_computer_actions.py
@@ -215,8 +215,8 @@ class TestWaitForChange:
 
         transport = _FixedScreenTransport(tmp_path)
         with (
-            patch("gptme.tools.computer.time.monotonic", side_effect=stepped_clock),
-            patch("gptme.tools.computer.time.sleep"),
+            patch("gptme.tools.computer._monotonic", side_effect=stepped_clock),
+            patch("gptme.tools.computer._sleep"),
         ):
             _dispatch_transport(transport, "wait_for_change", text="0.2")
         assert transport._call_count >= 3
@@ -240,8 +240,8 @@ class TestWaitForChange:
             return start + call_count[0] * 0.001
 
         with (
-            patch("gptme.tools.computer.time.monotonic", side_effect=fast_clock),
-            patch("gptme.tools.computer.time.sleep"),
+            patch("gptme.tools.computer._monotonic", side_effect=fast_clock),
+            patch("gptme.tools.computer._sleep"),
         ):
             result = _dispatch_transport(transport, "wait_for_change")
         assert result is not None

--- a/tests/test_tools_computer.py
+++ b/tests/test_tools_computer.py
@@ -14,6 +14,7 @@ from gptme.tools.computer import (
     MODIFIER_KEYS,
     _chunks,
     _get_display_resolution,
+    _get_macos_display_scale,
     _linux_accessibility_tree,
     _linux_click_accessible_element,
     _linux_scroll,
@@ -301,6 +302,89 @@ Graphics/Displays:
         width, height = _get_display_resolution()
         assert width == 2560
         assert height == 1664
+
+
+# === _get_macos_display_scale() tests ===
+
+
+@mock.patch("gptme.tools.computer.IS_MACOS", True)
+def test_get_macos_display_scale_via_appkit():
+    """Scale factor is read from AppKit.NSScreen.backingScaleFactor() when available."""
+    mock_screen = mock.MagicMock()
+    mock_screen.backingScaleFactor.return_value = 2.0
+    mock_appkit = mock.MagicMock()
+    mock_appkit.NSScreen.mainScreen.return_value = mock_screen
+
+    with mock.patch.dict("sys.modules", {"AppKit": mock_appkit}):
+        scale = _get_macos_display_scale()
+
+    assert scale == 2.0
+
+
+@mock.patch("gptme.tools.computer.IS_MACOS", True)
+def test_get_macos_display_scale_via_system_profiler():
+    """Scale factor is derived from system_profiler when AppKit is unavailable."""
+    profiler_output = """\
+Graphics/Displays:
+    Apple M1:
+      Displays:
+        Color LCD:
+          Resolution: 2560 x 1664 Retina
+          UI Looks like: 1280 x 832 @ 60.00Hz
+"""
+    import importlib
+
+    real_find_spec = importlib.util.find_spec
+
+    def fake_find_spec(name):
+        if name == "AppKit":
+            return None
+        return real_find_spec(name)
+
+    with (
+        mock.patch("importlib.util.find_spec", side_effect=fake_find_spec),
+        mock.patch("subprocess.check_output", return_value=profiler_output),
+    ):
+        scale = _get_macos_display_scale()
+
+    assert scale == pytest.approx(2560 / 1280, rel=1e-3)
+
+
+@mock.patch("gptme.tools.computer.IS_MACOS", True)
+def test_get_macos_display_scale_fallback_to_2x():
+    """Falls back to 2.0 when both AppKit and system_profiler are unavailable."""
+    import importlib
+
+    real_find_spec = importlib.util.find_spec
+
+    def fake_find_spec(name):
+        if name == "AppKit":
+            return None
+        return real_find_spec(name)
+
+    with (
+        mock.patch("importlib.util.find_spec", side_effect=fake_find_spec),
+        mock.patch(
+            "subprocess.check_output",
+            side_effect=subprocess.CalledProcessError(1, "system_profiler"),
+        ),
+    ):
+        scale = _get_macos_display_scale()
+
+    assert scale == 2.0
+
+
+@mock.patch("gptme.tools.computer._get_display_resolution", return_value=(2560, 1664))
+@mock.patch("gptme.tools.computer._get_macos_display_scale", return_value=2.0)
+@mock.patch("gptme.tools.computer.IS_MACOS", True)
+def test_coordinate_scaling_macos_2x(mock_scale, mock_res):
+    """Coordinate scaling on macOS 2× Retina yields logical (non-physical) coords."""
+    # Physical: 2560×1664, logical (after ÷2): 1280×832
+    # Clicking at API (640, 416) with API space 1280×832 → physical (1280, 832)
+    # But gptme works in logical space, so we expect (640, 416)
+    x, y = _scale_coordinates(_ScalingSource.API, 640, 416, 1280, 832)
+    assert x == 640
+    assert y == 416
 
 
 # === _run_xdotool() tests ===
@@ -835,8 +919,9 @@ _MOCK_MACOS_RES = (1920, 1080)
 @mock.patch(
     "gptme.tools.computer._get_display_resolution", return_value=_MOCK_MACOS_RES
 )
+@mock.patch("gptme.tools.computer._get_macos_display_scale", return_value=2.0)
 @mock.patch("subprocess.run")
-def test_computer_cursor_position_macos(mock_run, mock_res):
+def test_computer_cursor_position_macos(mock_run, mock_scale, mock_res):
     """Test cursor_position on macOS parses cliclick output correctly."""
     from gptme.tools.computer import computer
 

--- a/tests/test_tools_computer.py
+++ b/tests/test_tools_computer.py
@@ -310,6 +310,7 @@ Graphics/Displays:
 @mock.patch("gptme.tools.computer.IS_MACOS", True)
 def test_get_macos_display_scale_via_appkit():
     """Scale factor is read from AppKit.NSScreen.backingScaleFactor() when available."""
+    _get_macos_display_scale.cache_clear()
     mock_screen = mock.MagicMock()
     mock_screen.backingScaleFactor.return_value = 2.0
     mock_appkit = mock.MagicMock()
@@ -324,6 +325,7 @@ def test_get_macos_display_scale_via_appkit():
 @mock.patch("gptme.tools.computer.IS_MACOS", True)
 def test_get_macos_display_scale_via_system_profiler():
     """Scale factor is derived from system_profiler when AppKit is unavailable."""
+    _get_macos_display_scale.cache_clear()
     profiler_output = """\
 Graphics/Displays:
     Apple M1:
@@ -332,17 +334,9 @@ Graphics/Displays:
           Resolution: 2560 x 1664 Retina
           UI Looks like: 1280 x 832 @ 60.00Hz
 """
-    import importlib
-
-    real_find_spec = importlib.util.find_spec
-
-    def fake_find_spec(name):
-        if name == "AppKit":
-            return None
-        return real_find_spec(name)
 
     with (
-        mock.patch("importlib.util.find_spec", side_effect=fake_find_spec),
+        mock.patch.dict("sys.modules", {"AppKit": None}),
         mock.patch("subprocess.check_output", return_value=profiler_output),
     ):
         scale = _get_macos_display_scale()
@@ -351,19 +345,40 @@ Graphics/Displays:
 
 
 @mock.patch("gptme.tools.computer.IS_MACOS", True)
-def test_get_macos_display_scale_fallback_to_2x():
-    """Falls back to 2.0 when both AppKit and system_profiler are unavailable."""
-    import importlib
+def test_get_macos_display_scale_via_system_profiler_multi_display():
+    """Scale factor parsed correctly even when system_profiler has 'Maximum Resolution' before 'Resolution:'."""
+    _get_macos_display_scale.cache_clear()
+    profiler_output = """\
+Graphics/Displays:
 
-    real_find_spec = importlib.util.find_spec
-
-    def fake_find_spec(name):
-        if name == "AppKit":
-            return None
-        return real_find_spec(name)
+    Display with External Monitor:
+      Displays:
+        Built-In Retina:
+          Maximum Resolution: 3840 x 2160
+          Resolution: 2560 x 1664 Retina
+          UI Looks like: 1280 x 832 @ 60.00Hz
+        External Monitor:
+          Resolution: 1920 x 1080
+          UI Looks like: 1920 x 1080 @ 60.00Hz
+"""
 
     with (
-        mock.patch("importlib.util.find_spec", side_effect=fake_find_spec),
+        mock.patch.dict("sys.modules", {"AppKit": None}),
+        mock.patch("subprocess.check_output", return_value=profiler_output),
+    ):
+        scale = _get_macos_display_scale()
+
+    # Must NOT match "Maximum Resolution: 3840 x 2160" — should find actual Resolution: 2560
+    # giving 2560 / 1280 = 2.0
+    assert scale == pytest.approx(2.0, rel=1e-3)
+
+
+@mock.patch("gptme.tools.computer.IS_MACOS", True)
+def test_get_macos_display_scale_fallback_to_2x():
+    """Falls back to 2.0 when both AppKit and system_profiler are unavailable."""
+    _get_macos_display_scale.cache_clear()
+    with (
+        mock.patch.dict("sys.modules", {"AppKit": None}),
         mock.patch(
             "subprocess.check_output",
             side_effect=subprocess.CalledProcessError(1, "system_profiler"),

--- a/tests/test_tools_computer.py
+++ b/tests/test_tools_computer.py
@@ -374,6 +374,32 @@ Graphics/Displays:
 
 
 @mock.patch("gptme.tools.computer.IS_MACOS", True)
+def test_get_macos_display_scale_via_system_profiler_prefers_main_display():
+    """Main Display metadata wins when multiple display blocks have valid scale pairs."""
+    _get_macos_display_scale.cache_clear()
+    profiler_output = """\
+Graphics/Displays:
+    Apple M1:
+      Displays:
+        External Monitor:
+          Resolution: 1920 x 1080
+          UI Looks like: 1920 x 1080 @ 60.00Hz
+        Color LCD:
+          Main Display: Yes
+          Resolution: 2560 x 1664 Retina
+          UI Looks like: 1280 x 832 @ 60.00Hz
+"""
+
+    with (
+        mock.patch.dict("sys.modules", {"AppKit": None}),
+        mock.patch("subprocess.check_output", return_value=profiler_output),
+    ):
+        scale = _get_macos_display_scale()
+
+    assert scale == pytest.approx(2.0, rel=1e-3)
+
+
+@mock.patch("gptme.tools.computer.IS_MACOS", True)
 def test_get_macos_display_scale_fallback_to_2x():
     """Falls back to 2.0 when both AppKit and system_profiler are unavailable."""
     _get_macos_display_scale.cache_clear()

--- a/tests/test_tools_computer.py
+++ b/tests/test_tools_computer.py
@@ -1251,7 +1251,7 @@ def test_wait_for_change_detects_change(mock_transport, mock_res, tmp_path):
 
     with (
         mock.patch("gptme.tools.computer.screenshot", side_effect=_fake_screenshot),
-        mock.patch("gptme.tools.computer.time.sleep"),
+        mock.patch("gptme.tools.computer._sleep"),
         mock.patch(
             "gptme.tools.computer._make_screenshot_msg", return_value=mock.sentinel.msg
         ),
@@ -1283,9 +1283,9 @@ def test_wait_for_change_timeout_returns_screenshot(mock_transport, mock_res, tm
 
     with (
         mock.patch("gptme.tools.computer.screenshot", return_value=static),
-        mock.patch("gptme.tools.computer.time.sleep"),
+        mock.patch("gptme.tools.computer._sleep"),
         mock.patch(
-            "gptme.tools.computer.time.monotonic", side_effect=monotonic_side_effect
+            "gptme.tools.computer._monotonic", side_effect=monotonic_side_effect
         ),
         mock.patch(
             "gptme.tools.computer._make_screenshot_msg",
@@ -1321,8 +1321,8 @@ def test_wait_for_change_polls_with_backoff(mock_transport, mock_res, tmp_path):
 
     with (
         mock.patch("gptme.tools.computer.screenshot", return_value=static),
-        mock.patch("gptme.tools.computer.time.sleep", side_effect=_record_sleep),
-        mock.patch("gptme.tools.computer.time.monotonic", side_effect=_fake_monotonic),
+        mock.patch("gptme.tools.computer._sleep", side_effect=_record_sleep),
+        mock.patch("gptme.tools.computer._monotonic", side_effect=_fake_monotonic),
         mock.patch(
             "gptme.tools.computer._make_screenshot_msg",
             return_value=mock.sentinel.timeout_msg,
@@ -1462,8 +1462,8 @@ def test_macos_window_focus_no_match_raises():
     """
     with (
         mock.patch("gptme.tools.computer.subprocess.run") as mock_run,
-        mock.patch("gptme.tools.computer.time.monotonic") as mock_time,
-        mock.patch("gptme.tools.computer.time.sleep"),
+        mock.patch("gptme.tools.computer._monotonic") as mock_time,
+        mock.patch("gptme.tools.computer._sleep"),
         pytest.raises(RuntimeError, match="No window matching.*'MissingApp'"),
     ):
         # First call returns not_found, second call has monotonic past deadline
@@ -1483,10 +1483,8 @@ def test_macos_window_focus_retry_then_found():
     ]
     with (
         mock.patch("gptme.tools.computer.subprocess.run", side_effect=results),
-        mock.patch(
-            "gptme.tools.computer.time.monotonic", side_effect=[0.0, 0.5, 1.0, 1.5]
-        ),
-        mock.patch("gptme.tools.computer.time.sleep"),
+        mock.patch("gptme.tools.computer._monotonic", side_effect=[0.0, 0.5, 1.0, 1.5]),
+        mock.patch("gptme.tools.computer._sleep"),
     ):
         _macos_window_focus("SlowApp", timeout=10.0)
 


### PR DESCRIPTION
## Problem

The macOS display scale factor was hardcoded as `2560 / 1709 ≈ 1.498` — a constant that only happened to work on the author's specific display. On any Mac with different HiDPI scaling (1.5×, 2.0× standard Retina, non-Retina 1.0×, or external monitors), click coordinates would land in the wrong place.

## Fix

Add `_get_macos_display_scale()` with a proper detection chain:
1. **`AppKit.NSScreen.mainScreen().backingScaleFactor()`** — accurate for all display configs
2. **`system_profiler SPDisplaysDataType`** — parse `Resolution:` vs `UI Looks like:` ratio
3. **Fallback to `2.0`** — standard Retina, safe default

## Tests

4 new unit tests:
- `test_get_macos_display_scale_via_appkit` — AppKit path returns backingScaleFactor
- `test_get_macos_display_scale_via_system_profiler` — parses 2560/1280 = 2.0× from system_profiler output
- `test_get_macos_display_scale_fallback_to_2x` — returns 2.0 when both paths fail
- `test_coordinate_scaling_macos_2x` — round-trip coordinate check through 2× Retina path

All 286 computer-use tests pass (3 skipped as expected for platform-specific tests).

Closes part of #216

<!-- gptme-id:v1:gai_39t6oN7eyvc7iEiwA6m6VG8dVbj7LvSwdtVCFyS4Gbu -->