### PR TITLE
feat(cli): add `gptme search` alias for `gptme-util chats search`

### DIFF
--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -560,7 +560,7 @@ def main(
     """Main entrypoint for the CLI."""
 
     # Dispatch: `gptme search QUERY` → chats search (discoverability alias)
-    if prompts and prompts[0] == "search":
+    if prompts and prompts[0] == "search" and not version and not version_json:
         from ..tools.chats import search_chats  # fmt: skip
 
         query = " ".join(prompts[1:]).strip()
@@ -568,7 +568,9 @@ def main(
             raise click.UsageError(
                 "Usage: gptme search <query>\n\nFor all options, use: gptme-util chats search --help"
             )
-        search_chats(query, max_results=20, context_lines=1, max_matches=1)
+        search_chats(
+            query, max_results=20, context_lines=1, max_matches=1
+        )  # show more results than the default 5
         return
 
     # Defense-in-depth: handle empty/whitespace names in case Click bypasses convert()

--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -304,13 +304,17 @@ The interface provides /commands during a conversation:
 {commands_help}
 
 \b
+Built-in shortcuts:
+  gptme search QUERY      Search conversation logs (alias for gptme-util chats search)
+
+\b
 Utilities (gptme-util):
   gptme-util tools list       List all tools and their availability
   gptme-util tools info TOOL  Show detailed tool instructions/examples
   gptme-util skills list      List discoverable skills in the current workspace
   gptme-util skills show NAME Show a skill or lesson by name
   gptme-util chats list       List past conversations
-  gptme-util chats search Q   Search conversations for query
+  gptme-util chats search Q   Search conversations for query (full options)
   gptme-util chats send ID MSG Queue a prompt for a running chat from another terminal
   gptme-util chats rename     Rename a conversation
   gptme-util models list      List available models
@@ -554,6 +558,18 @@ def main(
     output_schema: str | None,
 ):
     """Main entrypoint for the CLI."""
+
+    # Dispatch: `gptme search QUERY` → chats search (discoverability alias)
+    if prompts and prompts[0] == "search":
+        from ..tools.chats import search_chats  # fmt: skip
+
+        query = " ".join(prompts[1:]).strip()
+        if not query:
+            raise click.UsageError(
+                "Usage: gptme search <query>\n\nFor all options, use: gptme-util chats search --help"
+            )
+        search_chats(query, max_results=20, context_lines=1, max_matches=1)
+        return
 
     # Defense-in-depth: handle empty/whitespace names in case Click bypasses convert()
     # (observed to occur in some Click versions when --name "" is passed)

--- a/tests/test_search_alias.py
+++ b/tests/test_search_alias.py
@@ -43,7 +43,10 @@ class TestSearchAlias:
 
         prompts[0] == "search for recipes" (one string), not "search".
         """
-        with patch("gptme.tools.chats.search_chats") as mock_search:
+        with (
+            patch("gptme.tools.chats.search_chats") as mock_search,
+            patch("gptme.cli.main.chat"),
+        ):
             runner.invoke(
                 main,
                 ["--non-interactive", "--no-confirm", "search for recipes"],
@@ -56,3 +59,19 @@ class TestSearchAlias:
         result = runner.invoke(main, ["--help"])
         assert result.exit_code == 0
         assert "search" in result.output.lower()
+
+    def test_search_does_not_swallow_version(self, runner: CliRunner):
+        """gptme --version search QUERY shows version, not search results."""
+        with patch("gptme.tools.chats.search_chats") as mock_search:
+            result = runner.invoke(main, ["--version", "search", "anything"])
+        assert result.exit_code == 0
+        mock_search.assert_not_called()
+        assert "gptme" in result.output.lower() or "version" in result.output.lower()
+
+    def test_search_does_not_swallow_version_json(self, runner: CliRunner):
+        """gptme --version-json search QUERY shows version JSON, not search results."""
+        with patch("gptme.tools.chats.search_chats") as mock_search:
+            result = runner.invoke(main, ["--version-json", "search", "anything"])
+        assert result.exit_code == 0
+        mock_search.assert_not_called()
+        assert "{" in result.output or "version" in result.output.lower()

--- a/tests/test_search_alias.py
+++ b/tests/test_search_alias.py
@@ -1,0 +1,58 @@
+"""Tests for `gptme search` alias → gptme-util chats search."""
+
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from gptme.cli.main import main
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+class TestSearchAlias:
+    def test_search_calls_search_chats(self, runner: CliRunner):
+        """gptme search QUERY delegates to search_chats."""
+        with patch("gptme.tools.chats.search_chats") as mock_search:
+            result = runner.invoke(main, ["search", "flask migration"])
+        assert result.exit_code == 0
+        mock_search.assert_called_once_with(
+            "flask migration", max_results=20, context_lines=1, max_matches=1
+        )
+
+    def test_search_multiword_query_joined(self, runner: CliRunner):
+        """gptme search word1 word2 joins terms into a single query."""
+        with patch("gptme.tools.chats.search_chats") as mock_search:
+            result = runner.invoke(main, ["search", "flask", "migration"])
+        assert result.exit_code == 0
+        mock_search.assert_called_once_with(
+            "flask migration", max_results=20, context_lines=1, max_matches=1
+        )
+
+    def test_search_empty_query_errors(self, runner: CliRunner):
+        """gptme search with no query prints an error."""
+        result = runner.invoke(main, ["search"])
+        assert result.exit_code != 0
+        assert "Usage:" in result.output or "query" in result.output.lower()
+
+    def test_search_does_not_intercept_non_search_prompts(self, runner: CliRunner):
+        """gptme 'search for recipes' is not intercepted by the search alias.
+
+        prompts[0] == "search for recipes" (one string), not "search".
+        """
+        with patch("gptme.tools.chats.search_chats") as mock_search:
+            runner.invoke(
+                main,
+                ["--non-interactive", "--no-confirm", "search for recipes"],
+            )
+        # search_chats must NOT be called — this is a regular chat prompt
+        mock_search.assert_not_called()
+
+    def test_help_mentions_search(self, runner: CliRunner):
+        """gptme --help mentions the search shortcut."""
+        result = runner.invoke(main, ["--help"])
+        assert result.exit_code == 0
+        assert "search" in result.output.lower()


### PR DESCRIPTION
## Problem

`gptme-util chats search <query>` is a useful feature but buried. Users discovering competitors like [ctx](https://github.com/nicholasgasior/ctx) for coding-agent history search don't realize gptme already has this.

Closes #3049

## Change

Adds early dispatch in `main()`: when the first positional argument is the literal word `"search"`, it delegates to `search_chats()` instead of starting a chat session:

```bash
# Before (working but hidden)
gptme-util chats search "flask migration"

# After (discoverable entry point)
gptme search "flask migration"
gptme search flask migration    # multi-word args joined into one query
```

## Implementation

- Minimal: 12 lines of dispatch logic at the start of `main()`, no CLI restructuring
- `gptme "search for recipes"` is **not** intercepted — the full string `"search for recipes"` doesn't match the bare `"search"` literal
- `gptme-util chats search` retains all its flags (`--json`, `--context`, `--matches`, `--summarize`, etc.)
- `--help` updated to mention the shortcut and the full-options path

## Tests

5 new tests covering:
- Delegates to `search_chats()` with correct args
- Multi-word queries joined correctly
- Empty query produces an error
- Single-string prompts starting with "search " are NOT intercepted
- `--help` mentions the search shortcut