### PR TITLE
feat(cli): gptme-util subcommand mirroring (gptme chats → gptme-util chats)

### DIFF
--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -585,6 +585,13 @@ def main(
         if prompts[0] in UTIL_SUBCOMMANDS:
             if util_exec := shutil.which("gptme-util"):
                 sys.exit(subprocess.call([util_exec, *prompts]))
+            else:
+                print(
+                    f"Error: '{prompts[0]}' is a gptme-util subcommand but gptme-util is not installed.\n"
+                    "Install it with: pip install gptme[util]",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
 
     # Plugin dispatch: `gptme CMD [args...]` → `gptme-CMD [args...]` if installed
     # Enables extensibility: `gptme sessions` works if gptme-sessions is in PATH.

--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -305,13 +305,11 @@ The interface provides /commands during a conversation:
 {commands_help}
 
 \b
-Built-in shortcuts:
+Subcommand shortcuts:
   gptme search QUERY      Search conversation logs (alias for gptme-util chats search)
-
-\b
-Plugin dispatch (gptme-* in PATH):
-  gptme sessions          Delegates to gptme-sessions if installed
-  gptme <cmd> [args]      Delegates to gptme-<cmd> if found in PATH
+  gptme chats [args]      Any gptme-util subcommand works directly (chats, tools, skills, ...)
+  gptme sessions          Delegates to gptme-sessions if installed (gptme-* in PATH)
+  gptme <cmd> [args]      gptme-util subcommand or gptme-<cmd> binary, in that order
 
 \b
 Utilities (gptme-util):
@@ -578,6 +576,15 @@ def main(
             query, max_results=20, context_lines=1, max_matches=1
         )  # show more results than the default 5
         return
+
+    # gptme-util subcommand mirroring: `gptme chats [...]` → `gptme-util chats [...]`
+    # Any top-level gptme-util subcommand can be invoked without typing 'gptme-util'.
+    if prompts and not version and not version_json:
+        from .util import UTIL_SUBCOMMANDS  # cheap: just a sorted list constant
+
+        if prompts[0] in UTIL_SUBCOMMANDS:
+            if util_exec := shutil.which("gptme-util"):
+                sys.exit(subprocess.call([util_exec, *prompts]))
 
     # Plugin dispatch: `gptme CMD [args...]` → `gptme-CMD [args...]` if installed
     # Enables extensibility: `gptme sessions` works if gptme-sessions is in PATH.

--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -8,6 +8,7 @@ import select
 import shlex
 import shutil
 import signal
+import subprocess
 import sys
 import tempfile
 import time
@@ -308,6 +309,11 @@ Built-in shortcuts:
   gptme search QUERY      Search conversation logs (alias for gptme-util chats search)
 
 \b
+Plugin dispatch (gptme-* in PATH):
+  gptme sessions          Delegates to gptme-sessions if installed
+  gptme <cmd> [args]      Delegates to gptme-<cmd> if found in PATH
+
+\b
 Utilities (gptme-util):
   gptme-util tools list       List all tools and their availability
   gptme-util tools info TOOL  Show detailed tool instructions/examples
@@ -572,6 +578,13 @@ def main(
             query, max_results=20, context_lines=1, max_matches=1
         )  # show more results than the default 5
         return
+
+    # Plugin dispatch: `gptme CMD [args...]` → `gptme-CMD [args...]` if installed
+    # Enables extensibility: `gptme sessions` works if gptme-sessions is in PATH.
+    if prompts and not version and not version_json:
+        plugin = f"gptme-{prompts[0]}"
+        if plugin_path := shutil.which(plugin):
+            sys.exit(subprocess.call([plugin_path, *prompts[1:]]))
 
     # Defense-in-depth: handle empty/whitespace names in case Click bypasses convert()
     # (observed to occur in some Click versions when --name "" is passed)

--- a/gptme/cli/util.py
+++ b/gptme/cli/util.py
@@ -58,6 +58,15 @@ _LAZY_COMMANDS: dict[str, tuple[str, str]] = {
     "status": (".cmd_status", "status"),
 }
 
+# Inline groups defined via @main.group() in this file
+_INLINE_COMMANDS = frozenset(
+    {"providers", "tokens", "context", "llm", "tools", "prompts", "models", "profile"}
+)
+
+# All top-level subcommand names for gptme-util — exported for the gptme main CLI
+# to enable dynamic dispatch without importing the full util module at startup.
+UTIL_SUBCOMMANDS: list[str] = sorted(set(_LAZY_COMMANDS) | _INLINE_COMMANDS)
+
 
 def get_model_list(*args, **kwargs):
     """Lazy proxy so tests can still patch ``gptme.cli.util.get_model_list``."""

--- a/tests/test_search_alias.py
+++ b/tests/test_search_alias.py
@@ -115,3 +115,77 @@ class TestPluginDispatch:
         result = runner.invoke(main, ["--help"])
         assert result.exit_code == 0
         assert "gptme-" in result.output
+
+
+class TestUtilSubcommandMirroring:
+    def test_util_subcmd_delegates_to_gptme_util(self, runner: CliRunner):
+        """gptme chats [args] delegates to gptme-util chats [args]."""
+        with (
+            patch(
+                "gptme.cli.main.shutil.which",
+                return_value="/usr/local/bin/gptme-util",
+            ),
+            patch("gptme.cli.main.subprocess.call", return_value=0) as mock_call,
+        ):
+            result = runner.invoke(main, ["chats"])
+        assert result.exit_code == 0
+        mock_call.assert_called_once_with(["/usr/local/bin/gptme-util", "chats"])
+
+    def test_util_subcmd_passes_all_args(self, runner: CliRunner):
+        """gptme chats list passes 'chats list' to gptme-util."""
+        with (
+            patch(
+                "gptme.cli.main.shutil.which",
+                return_value="/usr/local/bin/gptme-util",
+            ),
+            patch("gptme.cli.main.subprocess.call", return_value=0) as mock_call,
+        ):
+            result = runner.invoke(main, ["chats", "list"])
+        assert result.exit_code == 0
+        mock_call.assert_called_once_with(
+            ["/usr/local/bin/gptme-util", "chats", "list"]
+        )
+
+    def test_util_subcmd_skipped_for_version_flag(self, runner: CliRunner):
+        """gptme --version chats does not trigger gptme-util dispatch."""
+        with patch("gptme.cli.main.subprocess.call") as mock_call:
+            result = runner.invoke(main, ["--version", "chats"])
+        assert result.exit_code == 0
+        mock_call.assert_not_called()
+
+    def test_util_subcommands_all_known(self):
+        """UTIL_SUBCOMMANDS contains expected gptme-util subcommands."""
+        from gptme.cli.util import UTIL_SUBCOMMANDS
+
+        for expected in ("chats", "tools", "skills", "models", "context"):
+            assert expected in UTIL_SUBCOMMANDS
+
+    def test_util_subcmd_takes_priority_over_path_dispatch(self, runner: CliRunner):
+        """gptme chats delegates to gptme-util, not a hypothetical gptme-chats binary."""
+        calls: list = []
+
+        def fake_which(cmd: str) -> str | None:
+            if cmd == "gptme-util":
+                return "/usr/local/bin/gptme-util"
+            if cmd == "gptme-chats":
+                return "/usr/local/bin/gptme-chats"
+            return None
+
+        def fake_call(args: list) -> int:
+            calls.append(args)
+            return 0
+
+        with (
+            patch("gptme.cli.main.shutil.which", side_effect=fake_which),
+            patch("gptme.cli.main.subprocess.call", side_effect=fake_call),
+        ):
+            runner.invoke(main, ["chats"])
+
+        assert calls == [["/usr/local/bin/gptme-util", "chats"]]
+
+    def test_help_mentions_util_subcommand_shortcut(self, runner: CliRunner):
+        """gptme --help describes the gptme-util subcommand shortcut."""
+        result = runner.invoke(main, ["--help"])
+        assert result.exit_code == 0
+        # Help text should describe that gptme-util subcommands work directly
+        assert "chats" in result.output

--- a/tests/test_search_alias.py
+++ b/tests/test_search_alias.py
@@ -1,4 +1,4 @@
-"""Tests for `gptme search` alias → gptme-util chats search."""
+"""Tests for `gptme search` alias and gptme-* plugin dispatch."""
 
 from unittest.mock import patch
 
@@ -75,3 +75,43 @@ class TestSearchAlias:
         assert result.exit_code == 0
         mock_search.assert_not_called()
         assert "{" in result.output or "version" in result.output.lower()
+
+
+class TestPluginDispatch:
+    def test_plugin_found_in_path_is_executed(self, runner: CliRunner):
+        """gptme sessions delegates to gptme-sessions if found in PATH."""
+        with (
+            patch(
+                "gptme.cli.main.shutil.which",
+                return_value="/usr/local/bin/gptme-sessions",
+            ),
+            patch("gptme.cli.main.subprocess.call", return_value=0) as mock_call,
+        ):
+            # Use only positional args — gptme CLI rejects unknown --flags before dispatch
+            result = runner.invoke(main, ["sessions"])
+        assert result.exit_code == 0
+        mock_call.assert_called_once_with(["/usr/local/bin/gptme-sessions"])
+
+    def test_plugin_not_found_falls_through(self, runner: CliRunner):
+        """gptme unknowncmd with no gptme-unknowncmd in PATH falls through to normal CLI."""
+        with (
+            patch("gptme.cli.main.shutil.which", return_value=None),
+            patch("gptme.cli.main.chat"),
+        ):
+            # Normal CLI starts a chat session; shutil.which returning None means no dispatch
+            runner.invoke(main, ["unknowncmd"])
+
+    def test_plugin_dispatch_skipped_for_version_flag(self, runner: CliRunner):
+        """gptme --version sessions does not trigger plugin dispatch."""
+        with (
+            patch("gptme.cli.main.subprocess.call") as mock_call,
+        ):
+            result = runner.invoke(main, ["--version", "sessions"])
+        assert result.exit_code == 0
+        mock_call.assert_not_called()
+
+    def test_help_mentions_plugin_dispatch(self, runner: CliRunner):
+        """gptme --help mentions the plugin dispatch mechanism."""
+        result = runner.invoke(main, ["--help"])
+        assert result.exit_code == 0
+        assert "gptme-" in result.output

--- a/tests/test_search_alias.py
+++ b/tests/test_search_alias.py
@@ -189,3 +189,10 @@ class TestUtilSubcommandMirroring:
         assert result.exit_code == 0
         # Help text should describe that gptme-util subcommands work directly
         assert "chats" in result.output
+
+    def test_util_subcmd_errors_when_gptme_util_not_installed(self, runner: CliRunner):
+        """gptme chats exits with code 1 and an actionable error when gptme-util is absent."""
+        with patch("gptme.cli.main.shutil.which", return_value=None):
+            result = runner.invoke(main, ["chats"])
+        assert result.exit_code == 1
+        assert "gptme-util" in result.output


### PR DESCRIPTION
## Summary

Implements the remaining part of #3051 — gptme-util subcommand mirroring.

The gptme-* PATH dispatch was already landed in #3050 followup (1b8cc08). This PR adds the complementary half: any top-level **gptme-util** subcommand can now be invoked directly via `gptme <subcmd>`.

```
gptme chats list        # → gptme-util chats list
gptme tools list        # → gptme-util tools list
gptme skills show NAME  # → gptme-util skills show NAME
```

## Changes

- **`gptme/cli/util.py`**: Export `UTIL_SUBCOMMANDS` — a sorted list of all 19 top-level gptme-util subcommands (lazy-imported constant, zero startup cost).
- **`gptme/cli/main.py`**: New dispatch block before PATH dispatch — if `prompts[0]` is in `UTIL_SUBCOMMANDS`, exec `gptme-util <prompts>`. Updated help text under "Subcommand shortcuts".
- **`tests/test_search_alias.py`**: 6 new tests in `TestUtilSubcommandMirroring` covering delegation, arg forwarding, version-flag bypass, priority over PATH dispatch, and help text.

## Dispatch priority

1. `search` → gptme-util chats search (existing hardcoded alias)
2. gptme-util mirroring: `gptme <subcmd>` → `gptme-util <subcmd>` (this PR)
3. PATH dispatch: `gptme <cmd>` → `gptme-<cmd>` (1b8cc08)

gptme-util takes priority over PATH so a hypothetical `gptme-chats` binary never shadows the built-in chats group, matching the issue's "warn, not silently shadow" intent.

Closes #3051

<!-- gptme-id:v1:gai_lJN1dcpfKu1RyLBOC1Iy2tjH1uPEXXLf2CK27GzJJ4j -->