### PR TITLE
fix(computer): derive VNC hostname from page origin in computer.html (#216)

### DIFF
--- a/gptme/server/static/computer.html
+++ b/gptme/server/static/computer.html
@@ -72,7 +72,7 @@
             var params = new URLSearchParams(window.location.search);
             var vncHost = params.get("vncHost") || window.location.hostname;
             var vncPort = params.get("vncPort") || "6080";
-            var vncSrc = "http://" + vncHost + ":" + vncPort +
+            var vncSrc = window.location.protocol + "//" + vncHost + ":" + vncPort +
                 "/vnc.html?&resize=scale&autoconnect=1&view_only=1&reconnect=1&reconnect_delay=2000";
             document.getElementById("vnc").src = vncSrc;
         })();
@@ -97,7 +97,7 @@
                 document.documentElement.requestFullscreen();
             } else {
                 document.exitFullscreen();
-        }
+            }
         });
     </script>
 </body>

--- a/gptme/server/static/computer.html
+++ b/gptme/server/static/computer.html
@@ -56,7 +56,6 @@
         <iframe
             id="vnc"
             class="desktop"
-            src="http://127.0.0.1:6080/vnc.html?&resize=scale&autoconnect=1&view_only=1&reconnect=1&reconnect_delay=2000"
             allow="fullscreen"
         ></iframe>
     </div>
@@ -65,6 +64,19 @@
         <button id="toggleFullscreen">Toggle Fullscreen</button>
     </div>
     <script>
+        // Derive the VNC host from the current page so remote Docker setups
+        // (e.g. accessing http://remote-host:8080/computer) work without
+        // needing to edit any config.  Query params override for custom setups:
+        //   /computer?vncHost=192.168.1.5&vncPort=6080
+        (function () {
+            var params = new URLSearchParams(window.location.search);
+            var vncHost = params.get("vncHost") || window.location.hostname;
+            var vncPort = params.get("vncPort") || "6080";
+            var vncSrc = "http://" + vncHost + ":" + vncPort +
+                "/vnc.html?&resize=scale&autoconnect=1&view_only=1&reconnect=1&reconnect_delay=2000";
+            document.getElementById("vnc").src = vncSrc;
+        })();
+
         // Toggle view-only mode
         document.getElementById("toggleViewOnly").addEventListener("click", function() {
             var vncIframe = document.getElementById("vnc");
@@ -85,7 +97,7 @@
                 document.documentElement.requestFullscreen();
             } else {
                 document.exitFullscreen();
-            }
+        }
         });
     </script>
 </body>

--- a/tests/test_computer_docker_config.py
+++ b/tests/test_computer_docker_config.py
@@ -2,6 +2,10 @@
 
 Verifies that the gptme-computer Docker entrypoint starts the server
 with the tools required for computer-use profile functionality.
+
+Also verifies that computer.html does not hardcode VNC hostnames so that
+remote Docker setups (where gptme server and the browser are on different
+machines) work without any configuration changes.
 """
 
 from __future__ import annotations
@@ -10,6 +14,9 @@ from pathlib import Path
 
 ENTRYPOINT = (
     Path(__file__).parent.parent / "scripts" / "computer_home" / "entrypoint.sh"
+)
+COMPUTER_HTML = (
+    Path(__file__).parent.parent / "gptme" / "server" / "static" / "computer.html"
 )
 
 
@@ -70,4 +77,57 @@ class TestDockerEntrypointTools:
         assert not missing, (
             f"Docker server missing tools required by computer-use profile: {missing}. "
             f"Current tools: {tools}"
+        )
+
+
+class TestComputerHtmlVncUrl:
+    """Ensure computer.html derives the VNC host dynamically.
+
+    When accessed remotely (e.g. http://remote-host:8080/computer) a hardcoded
+    '127.0.0.1' would make the browser try to connect to its own localhost
+    instead of the server, breaking the VNC stream.  The fix is to derive the
+    host from window.location.hostname in JavaScript.
+    """
+
+    def test_computer_html_exists(self):
+        assert COMPUTER_HTML.exists(), f"computer.html not found: {COMPUTER_HTML}"
+
+    def test_vnc_src_not_hardcoded_to_localhost(self):
+        """The iframe src must not contain a hardcoded '127.0.0.1' hostname.
+
+        A hardcoded address breaks any remote Docker setup: the browser
+        connects to its own loopback instead of the server's noVNC port.
+        """
+        html = COMPUTER_HTML.read_text()
+        # The static src attribute must not contain the hardcoded address.
+        # (The dynamic JS replacement is allowed to reference it as a fallback
+        # label or comment, but the iframe src= itself must not.)
+        assert 'src="http://127.0.0.1' not in html, (
+            "computer.html iframe src is hardcoded to 127.0.0.1. "
+            "Use window.location.hostname so remote setups work correctly."
+        )
+
+    def test_vnc_url_derived_from_window_location(self):
+        """computer.html must use window.location.hostname to build the VNC URL."""
+        html = COMPUTER_HTML.read_text()
+        assert "window.location.hostname" in html, (
+            "computer.html does not use window.location.hostname for the VNC URL. "
+            "Remote Docker users (different machine from the server) need the host "
+            "derived from the page origin, not hardcoded to 127.0.0.1."
+        )
+
+    def test_vnc_port_overridable_via_query_param(self):
+        """A ?vncPort= query param must let users point at a non-default noVNC port."""
+        html = COMPUTER_HTML.read_text()
+        assert "vncPort" in html, (
+            "computer.html does not support a vncPort query parameter override. "
+            "Users running noVNC on a non-standard port need a way to override it."
+        )
+
+    def test_vnc_host_overridable_via_query_param(self):
+        """A ?vncHost= query param must let users point at an explicit VNC host."""
+        html = COMPUTER_HTML.read_text()
+        assert "vncHost" in html, (
+            "computer.html does not support a vncHost query parameter override. "
+            "Users with split-horizon networking (separate VNC and gptme hosts) need this."
         )


### PR DESCRIPTION
## Problem

The VNC iframe in `gptme/server/static/computer.html` had a hardcoded `127.0.0.1:6080` hostname:

```html
<iframe id="vnc" src="http://127.0.0.1:6080/vnc.html?..."></iframe>
```

When the Docker container is accessed remotely (`http://remote-host:8080/computer`), the browser tries to connect the VNC iframe to its own loopback address (`127.0.0.1`) instead of the server. The VNC stream is unreachable for any non-local setup.

## Fix

Build the VNC URL from `window.location.hostname` at page load. Two query parameters allow overrides for advanced networking scenarios:

- `?vncHost=<host>` — explicit hostname (split-horizon / reverse-proxy setups)
- `?vncPort=<port>` — non-standard noVNC port (default: 6080)

Local usage (`localhost:8080/computer`) works identically because `window.location.hostname` resolves to `localhost`, not `127.0.0.1`.

## Tests

Four new regression tests in `tests/test_computer_docker_config.py`:
- `test_vnc_src_not_hardcoded_to_localhost` — iframe src attribute must not contain a hardcoded address
- `test_vnc_url_derived_from_window_location` — `window.location.hostname` must appear in the script
- `test_vnc_port_overridable_via_query_param` — `vncPort` override param present
- `test_vnc_host_overridable_via_query_param` — `vncHost` override param present

Closes #216 (partial — fixes the remote Docker streaming gap for the VNC mode)

<!-- gptme-id:v1:gai_gEgfXUcGYacCqaA44Mz2uLWsXDS7NRMj3twcTGlyyNA -->