### PR TITLE
feat(setup): add custom OpenAI-compatible provider to interactive setup

### DIFF
--- a/gptme/cli/setup.py
+++ b/gptme/cli/setup.py
@@ -13,7 +13,8 @@ from rich.text import Text
 
 import gptme
 
-from ..config import config_path, get_config, set_config_value
+from ..config import config_path, get_config, save_provider_config, set_config_value
+from ..config.models import ProviderConfig
 from ..llm import get_model_from_api_key, list_available_providers
 from ..llm.models import PROVIDERS, get_default_model
 from ..util import console, path_with_tilde
@@ -740,11 +741,52 @@ def _prompt_api_key() -> tuple[str, str, str]:  # pragma: no cover
     return api_key, provider, env_var
 
 
-def ask_for_api_key():  # pragma: no cover
-    """Interactively ask user for API key."""
+def _setup_custom_provider() -> tuple[str, str]:  # pragma: no cover
+    """Interactively configure a custom OpenAI-compatible provider."""
     console.print(
         Panel.fit(
-            Text("🔑 API Key Setup", style="bold green"),
+            Text("🔧 Custom Provider Setup", style="bold cyan"),
+            style="cyan",
+            padding=(0, 2),
+        )
+    )
+    console.print(
+        "[dim]Configure any OpenAI-compatible provider (self-hosted, relay, proxy, etc.)[/dim]"
+    )
+    console.print()
+
+    name = Prompt.ask("Provider name", default="custom").strip()
+    base_url = Prompt.ask("Base URL", default="https://api.example.com/v1").strip()
+    api_key = Prompt.ask(
+        "API key (leave blank to skip)", password=True, default=""
+    ).strip()
+    default_model = Prompt.ask(
+        "Default model (leave blank to skip)", default=""
+    ).strip()
+
+    provider = ProviderConfig(
+        name=name,
+        base_url=base_url,
+        api_key=api_key or None,
+        default_model=default_model or None,
+    )
+    save_provider_config(provider, local=bool(api_key))
+
+    console.print(
+        Panel.fit(
+            f"[green]✅ Custom provider '{name}' saved![/green]\n"
+            f"[dim]Config written to {config_path}[/dim]",
+            border_style="green",
+        )
+    )
+    return name, api_key
+
+
+def ask_for_api_key():  # pragma: no cover
+    """Interactively ask user for an API key or configure a custom provider."""
+    console.print(
+        Panel.fit(
+            Text("🔑 Provider Setup", style="bold green"),
             style="green",
             padding=(0, 2),
         )
@@ -763,6 +805,11 @@ def ask_for_api_key():  # pragma: no cover
     console.print()
     console.print(providers_table)
     console.print()
+
+    if Confirm.ask(
+        "Set up a custom OpenAI-compatible provider instead?", default=False
+    ):
+        return _setup_custom_provider()
 
     # Save to config
     api_key, provider, env_var = _prompt_api_key()

--- a/gptme/cli/setup.py
+++ b/gptme/cli/setup.py
@@ -15,6 +15,7 @@ import gptme
 
 from ..config import config_path, get_config, save_provider_config, set_config_value
 from ..config.models import ProviderConfig
+from ..config.user import get_user_config_paths
 from ..llm import get_model_from_api_key, list_available_providers
 from ..llm.models import PROVIDERS, get_default_model
 from ..util import console, path_with_tilde
@@ -770,12 +771,15 @@ def _setup_custom_provider() -> tuple[str, str]:  # pragma: no cover
         api_key=api_key or None,
         default_model=default_model or None,
     )
-    save_provider_config(provider, local=bool(api_key))
+    local = bool(api_key)
+    save_provider_config(provider, local=local)
 
+    _, local_path = get_user_config_paths()
+    shown_path = str(local_path) if local else config_path
     console.print(
         Panel.fit(
             f"[green]✅ Custom provider '{name}' saved![/green]\n"
-            f"[dim]Config written to {config_path}[/dim]",
+            f"[dim]Config written to {shown_path}[/dim]",
             border_style="green",
         )
     )

--- a/gptme/config/__init__.py
+++ b/gptme/config/__init__.py
@@ -42,6 +42,7 @@ from .user import (
     config_path,
     default_config,
     load_user_config,
+    save_provider_config,
     set_config_value,
 )
 
@@ -75,6 +76,7 @@ __all__ = [
     "get_project_config",
     "setup_config_from_cli",
     "set_config_value",
+    "save_provider_config",
     # Constants
     "config_path",
     "default_config",

--- a/gptme/config/user.py
+++ b/gptme/config/user.py
@@ -488,6 +488,26 @@ def _merge_config_data(main_config: dict, local_config: dict) -> dict:
                 if mcp_key != "servers":
                     merged["mcp"][mcp_key] = mcp_value
 
+        elif key == "providers" and isinstance(value, list):
+            # Merge providers by name - local provider entries update matching
+            # main providers (e.g. adding api_key to an otherwise-identical entry),
+            # and new providers are appended.
+            if key not in merged:
+                merged[key] = []
+            main_providers = merged[key]
+            main_by_name: dict = {}
+            for p in main_providers:
+                if isinstance(p, dict) and "name" in p:
+                    main_by_name[p["name"]] = p
+            for local_provider in value:
+                if not isinstance(local_provider, dict):
+                    main_providers.append(local_provider)
+                    continue
+                name = local_provider.get("name")
+                if name and name in main_by_name:
+                    main_by_name[name].update(local_provider)
+                else:
+                    main_providers.append(local_provider)
         elif (
             isinstance(value, dict) and key in merged and isinstance(merged[key], dict)
         ):

--- a/gptme/config/user.py
+++ b/gptme/config/user.py
@@ -428,7 +428,14 @@ def save_provider_config(
 
     if "providers" not in doc:
         doc.add("providers", tomlkit.aot())  # type: ignore[attr-defined]
-    doc["providers"].append(provider_table)  # type: ignore[union-attr]
+
+    providers = doc["providers"]
+    for idx, existing_provider in enumerate(providers):  # type: ignore[union-attr]
+        if existing_provider.get("name") == provider.name:
+            providers[idx] = provider_table
+            break
+    else:
+        providers.append(provider_table)
 
     if local:
         os.makedirs(os.path.dirname(write_path), exist_ok=True)

--- a/gptme/config/user.py
+++ b/gptme/config/user.py
@@ -395,6 +395,52 @@ def set_config_value(
         reload_config()
 
 
+def save_provider_config(
+    provider: "ProviderConfig", reload: bool = True, local: bool = False
+) -> None:
+    """Append a [[providers]] entry to the user config file.
+
+    Args:
+        provider: ProviderConfig to save.
+        reload: Whether to reload the in-memory config after writing.
+        local: If True, write to config.local.toml instead of config.toml.
+               Use for entries with inline api_key (secrets).
+    """
+    if local:
+        _, local_path = get_user_config_paths()
+        write_path = str(local_path)
+        doc: TOMLDocument | Container = (
+            _load_config_doc(write_path) if local_path.exists() else tomlkit.document()
+        )
+    else:
+        write_path = config_path
+        doc = _load_config_doc()
+
+    provider_table = tomlkit.table()
+    provider_table.add("name", provider.name)
+    provider_table.add("base_url", provider.base_url)
+    if provider.api_key:
+        provider_table.add("api_key", provider.api_key)
+    if provider.api_key_env:
+        provider_table.add("api_key_env", provider.api_key_env)
+    if provider.default_model:
+        provider_table.add("default_model", provider.default_model)
+
+    if "providers" not in doc:
+        doc.add("providers", tomlkit.aot())  # type: ignore[attr-defined]
+    doc["providers"].append(provider_table)  # type: ignore[union-attr]
+
+    if local:
+        os.makedirs(os.path.dirname(write_path), exist_ok=True)
+    with open(write_path, "w") as config_file:
+        tomlkit.dump(doc, config_file)
+
+    if reload:
+        from .core import reload_config
+
+        reload_config()
+
+
 def _merge_config_data(main_config: dict, local_config: dict) -> dict:
     """
     Merge local configuration into main configuration.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1380,6 +1380,43 @@ def test_set_config_value_creates_intermediate_sections(tmp_path, monkeypatch):
     assert result["user"]["name"] == "Alice"
 
 
+def test_save_provider_config_upserts_existing_provider(tmp_path, monkeypatch):
+    """Repeated setup runs for the same provider should not append duplicates."""
+    import gptme.config.user as user_mod
+    from gptme.config.models import ProviderConfig
+
+    config_file = tmp_path / "config.toml"
+    config_file.write_text("")
+    monkeypatch.setattr(user_mod, "config_path", str(config_file))
+
+    user_mod.save_provider_config(
+        ProviderConfig(
+            name="local",
+            base_url="http://localhost:11434/v1",
+            default_model="llama3",
+        ),
+        reload=False,
+    )
+    user_mod.save_provider_config(
+        ProviderConfig(
+            name="local",
+            base_url="http://127.0.0.1:8000/v1",
+            api_key="sk-local",
+            default_model="qwen3",
+        ),
+        reload=False,
+    )
+
+    result = tomlkit.loads(config_file.read_text()).unwrap()
+    assert len(result["providers"]) == 1
+    assert result["providers"][0] == {
+        "name": "local",
+        "base_url": "http://127.0.0.1:8000/v1",
+        "api_key": "sk-local",
+        "default_model": "qwen3",
+    }
+
+
 def test_chat_config_save_transition_empty_dir_to_symlink(tmp_path):
     """Test that save() replaces an empty from_logdir workspace directory with a symlink."""
     logdir = tmp_path / "conversation-save-transition"


### PR DESCRIPTION
## Problem

The interactive setup (`gptme setup`) only supports 4 built-in providers (OpenAI, Anthropic, OpenRouter, Gemini), auto-detected by API key prefix. Users who want to use OpenAI-compatible services — Ollama, vLLM, relay proxies, etc. — had to manually edit `~/.config/gptme/config.toml` and add a `[[providers]]` section, which isn't discoverable.

Closes #3055

## Solution

Add a "Custom provider" option in `ask_for_api_key()` that prompts the user for:
- **Provider name** (e.g. `"ollama"`)
- **Base URL** (e.g. `"http://localhost:11434/v1"`)
- **API key** (optional — blank is fine for local models)
- **Default model** (optional)

The entry is written as a `[[providers]]` TOML array-of-tables block. When an API key is given, it goes to `config.local.toml` (secrets separation); otherwise to `config.toml`.

## Changes

- `gptme/config/user.py` — new `save_provider_config()` helper that appends a `[[providers]]` entry using `tomlkit.aot()`
- `gptme/config/__init__.py` — export `save_provider_config`
- `gptme/cli/setup.py` — new `_setup_custom_provider()` function; `ask_for_api_key()` now offers the custom option before falling through to the existing key-prefix flow

## Test plan

- [ ] `gptme setup` → "Would you like to set up an API key now?" → Yes → "Set up a custom OpenAI-compatible provider instead?" → Yes → fill in Ollama URL, no API key
- [ ] Verify `~/.config/gptme/config.toml` now has a `[[providers]]` entry with correct name/base_url/default_model
- [ ] Repeat with an API key → verify key appears in `config.local.toml` not `config.toml`
- [ ] `gptme setup` → No to custom provider → existing built-in key flow still works
- [ ] `from gptme.config import save_provider_config` imports cleanly