### PR TITLE
feat(cli): show discovered gptme-* plugins in `gptme --help` (Part 3 of #3051)

### DIFF
--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -1,6 +1,7 @@
 import atexit
 import cProfile
 import importlib
+import importlib.metadata as _ilm
 import logging
 import os
 import pstats
@@ -62,31 +63,16 @@ from ..util.tokens import len_tokens
 
 logger = logging.getLogger(__name__)
 
-# Core scripts shipped with gptme itself — excluded from external-plugin discovery.
-# Keep in sync with [project.scripts] in pyproject.toml.
-_CORE_GPTME_SCRIPTS = frozenset(
-    {
-        "gptme",
-        "gptme-acp",
-        "gptme-agent",
-        "gptme-attest",
-        "gptme-auth",
-        "gptme-checkpoint",
-        "gptme-doctor",
-        "gptme-dspy",
-        "gptme-eval",
-        "gptme-eval-swebench",
-        "gptme-eval-tbench",
-        "gptme-eval-trends",
-        "gptme-init",
-        "gptme-onboard",
-        "gptme-resume",
-        "gptme-server",
-        "gptme-status",
-        "gptme-util",
-        "gptme-wut",
-    }
-)
+# Core scripts shipped with gptme itself — dynamically discovered from the
+# installed package's console_scripts entry points so this never drifts from
+# [project.scripts] in pyproject.toml.
+try:
+    _dist = _ilm.distribution("gptme")
+    _CORE_GPTME_SCRIPTS: frozenset[str] = frozenset(
+        ep.name for ep in _dist.entry_points if ep.group == "console_scripts"
+    )
+except _ilm.PackageNotFoundError:
+    _CORE_GPTME_SCRIPTS = frozenset()
 
 
 def _discover_gptme_plugins() -> list[str]:
@@ -112,7 +98,7 @@ def _discover_gptme_plugins() -> list[str]:
                 ):
                     seen.add(name)
                     plugins.append(name)
-        except (OSError, PermissionError):
+        except OSError:
             continue
 
     return sorted(plugins)

--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -62,6 +62,79 @@ from ..util.tokens import len_tokens
 
 logger = logging.getLogger(__name__)
 
+# Core scripts shipped with gptme itself — excluded from external-plugin discovery.
+# Keep in sync with [project.scripts] in pyproject.toml.
+_CORE_GPTME_SCRIPTS = frozenset(
+    {
+        "gptme",
+        "gptme-acp",
+        "gptme-agent",
+        "gptme-attest",
+        "gptme-auth",
+        "gptme-checkpoint",
+        "gptme-doctor",
+        "gptme-dspy",
+        "gptme-eval",
+        "gptme-eval-swebench",
+        "gptme-eval-tbench",
+        "gptme-eval-trends",
+        "gptme-init",
+        "gptme-onboard",
+        "gptme-resume",
+        "gptme-server",
+        "gptme-status",
+        "gptme-util",
+        "gptme-wut",
+    }
+)
+
+
+def _discover_gptme_plugins() -> list[str]:
+    """Find gptme-* executables in PATH that are not part of core gptme.
+
+    Returns a sorted list of binary names, e.g. ['gptme-sessions', 'gptme-tools'].
+    """
+    seen: set[str] = set()
+    plugins: list[str] = []
+
+    for path_dir in os.environ.get("PATH", "").split(os.pathsep):
+        if not path_dir:
+            continue
+        try:
+            for entry in Path(path_dir).iterdir():
+                name = entry.name
+                if (
+                    name.startswith("gptme-")
+                    and name not in _CORE_GPTME_SCRIPTS
+                    and name not in seen
+                    and entry.is_file()
+                    and os.access(entry, os.X_OK)
+                ):
+                    seen.add(name)
+                    plugins.append(name)
+        except (OSError, PermissionError):
+            continue
+
+    return sorted(plugins)
+
+
+class _DynamicHelpCommand(click.Command):
+    """click.Command subclass that appends discovered gptme-* plugins to --help."""
+
+    def format_help(self, ctx: click.Context, formatter: click.HelpFormatter) -> None:
+        super().format_help(ctx, formatter)
+        plugins = _discover_gptme_plugins()
+        if plugins:
+            with formatter.section("Installed external subcommands"):
+                rows = [
+                    (
+                        f"gptme {name.removeprefix('gptme-')}",
+                        f"delegates to {name}",
+                    )
+                    for name in plugins
+                ]
+                formatter.write_dl(rows)
+
 
 def _validate_model_param(
     ctx: click.Context, param: click.Parameter, value: str | None
@@ -308,8 +381,8 @@ The interface provides /commands during a conversation:
 Subcommand shortcuts:
   gptme search QUERY      Search conversation logs (alias for gptme-util chats search)
   gptme chats [args]      Any gptme-util subcommand works directly (chats, tools, skills, ...)
-  gptme sessions          Delegates to gptme-sessions if installed (gptme-* in PATH)
   gptme <cmd> [args]      gptme-util subcommand or gptme-<cmd> binary, in that order
+  (installed gptme-* binaries in PATH are listed at the bottom of this help)
 
 \b
 Utilities (gptme-util):
@@ -329,7 +402,11 @@ Utilities (gptme-util):
 Run 'gptme-util --help' for all utility commands."""
 
 
-@click.command(help=docstring, context_settings={"auto_envvar_prefix": "GPTME"})
+@click.command(
+    help=docstring,
+    context_settings={"auto_envvar_prefix": "GPTME"},
+    cls=_DynamicHelpCommand,
+)
 @click.pass_context
 @click.argument(
     "prompts",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -85,6 +85,71 @@ def test_help(runner: CliRunner):
     assert "gptme-util skills show NAME" in result.output
 
 
+def test_discover_gptme_plugins_finds_external_binaries(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """External gptme-* binaries in PATH appear in the discovery list."""
+    # Create a fake gptme-sessions executable
+    fake_bin = tmp_path / "gptme-sessions"
+    fake_bin.write_text("#!/bin/sh\necho sessions\n")
+    fake_bin.chmod(0o755)
+
+    monkeypatch.setenv("PATH", str(tmp_path))
+
+    from gptme.cli.main import _discover_gptme_plugins
+
+    plugins = _discover_gptme_plugins()
+    assert "gptme-sessions" in plugins
+
+
+def test_discover_gptme_plugins_excludes_core_scripts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Core gptme-* scripts are not included in discovered plugins."""
+    # Create fake versions of core scripts
+    for name in ("gptme-util", "gptme-server", "gptme-eval"):
+        p = tmp_path / name
+        p.write_text("#!/bin/sh\n")
+        p.chmod(0o755)
+
+    monkeypatch.setenv("PATH", str(tmp_path))
+
+    from gptme.cli.main import _discover_gptme_plugins
+
+    plugins = _discover_gptme_plugins()
+    assert "gptme-util" not in plugins
+    assert "gptme-server" not in plugins
+    assert "gptme-eval" not in plugins
+
+
+def test_help_shows_discovered_external_subcommands(
+    runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """gptme --help lists gptme-* binaries discovered in PATH."""
+    fake_bin = tmp_path / "gptme-sessions"
+    fake_bin.write_text("#!/bin/sh\necho sessions\n")
+    fake_bin.chmod(0o755)
+
+    monkeypatch.setenv("PATH", str(tmp_path))
+
+    result = runner.invoke(cli.main, ["--help"])
+    assert result.exit_code == 0
+    assert "Installed external subcommands" in result.output
+    assert "gptme sessions" in result.output
+    assert "gptme-sessions" in result.output
+
+
+def test_help_no_external_subcommands_section_when_none_installed(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+):
+    """gptme --help omits the external-subcommands section when PATH has none."""
+    monkeypatch.setenv("PATH", "")
+
+    result = runner.invoke(cli.main, ["--help"])
+    assert result.exit_code == 0
+    assert "Installed external subcommands" not in result.output
+
+
 def test_version(runner: CliRunner):
     result = runner.invoke(cli.main, ["--version"])
     assert result.exit_code == 0


### PR DESCRIPTION
## Summary

This is Part 3 of #3051: **Help integration** for dynamically discovered `gptme-*` external subcommands.

Parts 1 (PATH dispatch) and 2 (gptme-util mirroring) are already merged. This PR closes the remaining item.

### What changed

- **`_discover_gptme_plugins()`** — scans `PATH` for `gptme-*` executables not in the core package set, returns a sorted list (e.g. `['gptme-sessions', 'gptme-tools']`)
- **`_CORE_GPTME_SCRIPTS`** — frozenset of scripts shipped with gptme itself (from `pyproject.toml`), used to filter the discovery output so core scripts don't appear as "external"
- **`_DynamicHelpCommand(click.Command)`** — overrides `format_help` to append an "Installed external subcommands" section at the bottom of `gptme --help`, but only when external plugins are found (section is hidden when PATH has none)
- Updated the `@click.command` decorator to use `cls=_DynamicHelpCommand`
- Updated the static docstring hint to not hardcode "gptme sessions" (it's dynamic now)

### Example output

When `gptme-sessions` is installed in PATH:

```
...
Installed external subcommands:
  gptme sessions  delegates to gptme-sessions
```

### Tests

4 new tests in `tests/test_cli.py`:
- Discovery finds external binaries in PATH
- Discovery excludes core gptme scripts (`gptme-util`, `gptme-server`, etc.)
- `gptme --help` shows the section when an external plugin is present
- `gptme --help` omits the section when PATH has no `gptme-*` plugins

## References

- Closes item 3 (Help integration) in #3051
- Builds on #3052 (gptme-util mirroring) and #3053 (PATH dispatch)