### PR TITLE
test(computer): native X11 integration tests for issue #216

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -318,6 +318,7 @@ markers = [
     "requires_api: marks tests that require API access",
     "flaky: marks tests as flaky (retried automatically)",
     "integration: marks tests as integration tests requiring external services",
+    "x11: marks tests that require a real or headless X11 display (Xvfb, xdotool, scrot)",
     "xdist_group: marks tests that should run in the same xdist group",
 ]
 asyncio_default_fixture_loop_scope = "function"

--- a/tests/test_computer_x11_integration.py
+++ b/tests/test_computer_x11_integration.py
@@ -1,0 +1,364 @@
+"""Native X11 integration tests for the computer tool (issue #216).
+
+Validates the full 'screenshot → window_focus → type → wait_for_change'
+pipeline using real xdotool/scrot against a headless Xvfb display.
+
+These tests are the counterpart to ``test_computer_use_integration.py``
+(which covers the browser/Playwright path).  Together they prove both legs
+of the computer-use stack work end-to-end.
+
+Run manually (requires xdotool, scrot, Xvfb, xterm, fluxbox):
+    pytest tests/test_computer_x11_integration.py -v -m x11
+
+Marked ``x11`` and automatically skipped when the required tools are absent,
+so they never block CI in environments without X11.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import shutil
+import subprocess
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+
+# ---------------------------------------------------------------------------
+# Availability guards
+# ---------------------------------------------------------------------------
+
+
+def _cmd_ok(*cmds: str) -> bool:
+    """Return True if all commands are on PATH."""
+    return all(shutil.which(c) for c in cmds)
+
+
+def _pil_available() -> bool:
+    return importlib.util.find_spec("PIL") is not None
+
+
+@pytest.fixture(autouse=True, scope="module")
+def _x11_tools_or_skip():
+    """Skip the whole module if required tools are missing."""
+    missing = [
+        c
+        for c in ("Xvfb", "xdotool", "scrot", "xterm", "fluxbox")
+        if not shutil.which(c)
+    ]
+    if missing:
+        pytest.skip(f"x11 tools missing: {', '.join(missing)}")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def xvfb_display() -> Generator[str, None, None]:
+    """Start a private Xvfb display and yield the DISPLAY string.
+
+    Uses display :98 to avoid collisions with production displays (:1, :0).
+    The display is torn down after the module finishes.
+    """
+    display = ":98"
+    proc = subprocess.Popen(
+        ["Xvfb", display, "-screen", "0", "1024x768x24"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    # Give Xvfb a moment to start accepting connections
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline:
+        result = subprocess.run(
+            ["xdotool", "getmouselocation"],
+            env={**os.environ, "DISPLAY": display},
+            capture_output=True,
+            check=False,
+        )
+        if result.returncode == 0:
+            break
+        time.sleep(0.2)
+    else:
+        proc.kill()
+        pytest.skip("Xvfb did not start within 10s")
+
+    # Start a minimal window manager so window_focus works
+    wm_proc = subprocess.Popen(
+        ["fluxbox"],
+        env={**os.environ, "DISPLAY": display},
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    time.sleep(0.5)  # let fluxbox initialise
+
+    yield display
+
+    wm_proc.terminate()
+    proc.terminate()
+    proc.wait(timeout=5)
+
+
+@pytest.fixture(autouse=True)
+def _set_display(xvfb_display, monkeypatch):
+    """Point the computer tool at the private Xvfb display for every test."""
+    monkeypatch.setenv("DISPLAY", xvfb_display)
+    # Clear any transport override so we use the native xdotool path
+    monkeypatch.delenv("GPTME_COMPUTER_TRANSPORT", raising=False)
+
+
+@pytest.fixture()
+def xterm_window(xvfb_display) -> Generator[subprocess.Popen, None, None]:
+    """Launch an xterm on the test display and yield the process.
+
+    The terminal is killed after each test so tests start with a clean
+    display.
+    """
+    env = {**os.environ, "DISPLAY": xvfb_display}
+    # Use bash --norc so the PS1 doesn't override the -T title via escape codes;
+    # this keeps WM_NAME stable and lets _linux_window_focus (--name search) find it.
+    proc = subprocess.Popen(
+        [
+            "xterm",
+            "-T",
+            "GptmeTestXterm",
+            "-geometry",
+            "80x24+100+100",
+            "-e",
+            "bash",
+            "--norc",
+            "--noprofile",
+        ],
+        env=env,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    # Wait for the window to appear — xdotool search --sync blocks until found;
+    # enforce an outer timeout via subprocess.run(timeout=...) since this version
+    # of xdotool does not support a --timeout flag.
+    try:
+        result = subprocess.run(
+            ["xdotool", "search", "--sync", "--limit", "1", "--name", "GptmeTestXterm"],
+            env=env,
+            capture_output=True,
+            timeout=10,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        pytest.skip("xterm window did not appear within 10s")
+    if result.returncode != 0:
+        proc.kill()
+        pytest.skip(
+            f"xdotool search failed (rc={result.returncode}): {result.stderr!r}"
+        )
+    yield proc
+    proc.kill()
+    proc.wait(timeout=3)
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+
+def _pixel_variance(path: Path) -> float:
+    """Return the mean pixel variance of an image (0 = blank/uniform)."""
+    import statistics
+    import struct as _struct
+
+    from PIL import Image
+
+    img = Image.open(path).convert("L")  # grayscale
+    pixels = list(_struct.unpack(f"{img.width * img.height}B", img.tobytes()))
+    if len(pixels) < 2:
+        return 0.0
+    mean = sum(pixels) / len(pixels)
+    return statistics.mean((p - mean) ** 2 for p in pixels) ** 0.5
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.x11
+@pytest.mark.integration
+def test_screenshot_returns_image(tmp_path, monkeypatch):
+    """computer('screenshot') returns a Message containing a real PNG file."""
+    monkeypatch.setenv("WIDTH", "1024")
+    monkeypatch.setenv("HEIGHT", "768")
+
+    from gptme.tools.computer import computer
+
+    msg = computer("screenshot")
+
+    assert msg is not None, "computer('screenshot') returned None"
+    assert msg.files, "screenshot message has no attached files"
+    shot = msg.files[0]
+    assert isinstance(shot, Path), f"expected Path, got {type(shot)}"
+    assert shot.exists(), f"screenshot file does not exist: {shot}"
+    assert shot.suffix.lower() == ".png"
+    assert shot.stat().st_size > 0, "screenshot file is empty"
+
+
+@pytest.mark.x11
+@pytest.mark.integration
+def test_screenshot_is_not_uniform(tmp_path, xterm_window, monkeypatch):
+    """A screenshot with an xterm visible should have non-uniform pixels.
+
+    A completely black or white image would suggest scrot captured nothing.
+    """
+    if not _pil_available():
+        pytest.skip("PIL not installed")
+
+    monkeypatch.setenv("WIDTH", "1024")
+    monkeypatch.setenv("HEIGHT", "768")
+
+    from gptme.tools.computer import computer
+
+    msg = computer("screenshot")
+    assert msg is not None
+    shot = msg.files[0]
+    assert isinstance(shot, Path)
+
+    variance = _pixel_variance(shot)
+    assert variance > 5.0, (
+        f"Screenshot appears uniform (std-dev={variance:.1f}) — "
+        "scrot may not be capturing xterm content"
+    )
+
+
+@pytest.mark.x11
+@pytest.mark.integration
+def test_window_focus_targets_xterm(xterm_window, monkeypatch):
+    """computer('window_focus', text='GptmeTestXterm') does not raise."""
+    from gptme.tools.computer import computer
+
+    # Should not raise RuntimeError("No window matching ...")
+    result = computer("window_focus", text="GptmeTestXterm")
+    # window_focus returns None on success
+    assert result is None
+
+
+@pytest.mark.x11
+@pytest.mark.integration
+def test_type_changes_screen(xterm_window, monkeypatch):
+    """computer('type', text=...) after window_focus updates the terminal display.
+
+    This validates the full 'focus → type → observe' loop that the
+    "Can it Tweet?" milestone relies on for web form interaction.
+    """
+    monkeypatch.setenv("WIDTH", "1024")
+    monkeypatch.setenv("HEIGHT", "768")
+
+    from gptme.tools.computer import computer
+
+    # Focus the xterm so keystrokes land there
+    computer("window_focus", text="GptmeTestXterm")
+    time.sleep(0.3)
+
+    # Baseline screenshot
+    before_msg = computer("screenshot")
+    assert before_msg is not None
+
+    # Type something visible (newline forces shell prompt to redraw)
+    computer("type", text="echo gptme_native_test\n")
+    time.sleep(0.5)
+
+    # Screenshot after typing
+    after_msg = computer("screenshot")
+    assert after_msg is not None
+
+    if not _pil_available():
+        pytest.skip("PIL not installed — cannot compare screenshots")
+
+    before_path = before_msg.files[0]
+    after_path = after_msg.files[0]
+    assert isinstance(before_path, Path) and isinstance(after_path, Path)
+
+    # At least some pixels must have changed
+    from gptme.tools.computer import _compute_change_ratio
+
+    ratio = _compute_change_ratio(before_path, after_path)
+    assert ratio > 0.001, (
+        f"Screen did not change after typing (changed ratio={ratio:.4f}) — "
+        "xdotool type may not be delivering keystrokes to the xterm"
+    )
+
+
+@pytest.mark.x11
+@pytest.mark.integration
+def test_wait_for_change_detects_terminal_output(xterm_window, monkeypatch):
+    """wait_for_change returns as soon as the xterm renders new output.
+
+    This is the context-efficient polling primitive used by act_and_observe().
+    It should return well before its 10-second timeout when xterm renders text.
+    """
+    monkeypatch.setenv("WIDTH", "1024")
+    monkeypatch.setenv("HEIGHT", "768")
+
+    from gptme.tools.computer import computer
+
+    computer("window_focus", text="GptmeTestXterm")
+    time.sleep(0.3)
+
+    # Kick off wait_for_change before we type so it races the terminal render
+    import threading
+
+    result_holder: list = []
+
+    def _wait():
+        msg = computer("wait_for_change", text="8")
+        result_holder.append(msg)
+
+    t = threading.Thread(target=_wait, daemon=True)
+    t.start()
+
+    # Give the polling loop a moment to take its baseline screenshot
+    time.sleep(0.2)
+
+    # Type a command — this should trigger a screen change
+    computer("type", text="echo wait_for_change_test\n")
+
+    t.join(timeout=12)
+    assert not t.is_alive(), "wait_for_change thread did not return within 12s"
+    assert result_holder, "wait_for_change returned no result"
+    msg = result_holder[0]
+    assert msg is not None, "wait_for_change returned None instead of a screenshot"
+
+
+@pytest.mark.x11
+@pytest.mark.integration
+def test_act_and_observe_full_loop(xterm_window, monkeypatch):
+    """act_and_observe() dispatches an action and returns an automatic screenshot.
+
+    This is the top-level primitive the computer-use profile recommends for
+    all interactive steps.  It should return a list with at least one Message
+    containing a screenshot.
+    """
+    monkeypatch.setenv("WIDTH", "1024")
+    monkeypatch.setenv("HEIGHT", "768")
+
+    from gptme.tools.computer import act_and_observe, computer
+
+    computer("window_focus", text="GptmeTestXterm")
+    time.sleep(0.3)
+
+    msgs = act_and_observe("type", text="echo act_and_observe_ok\n", timeout=5.0)
+
+    assert msgs, "act_and_observe() returned empty list"
+    # At least one message should carry a screenshot
+    images = [m for m in msgs if getattr(m, "files", None)]
+    assert images, "act_and_observe() returned no messages with screenshot files"
+    shot = images[0].files[0]
+    assert isinstance(shot, Path), f"expected Path, got {type(shot)}"
+    assert shot.exists(), f"Screenshot file missing: {shot}"
+    assert shot.stat().st_size > 0

--- a/tests/test_computer_x11_integration.py
+++ b/tests/test_computer_x11_integration.py
@@ -103,6 +103,7 @@ def xvfb_display() -> Generator[str, None, None]:
 
     wm_proc.terminate()
     proc.terminate()
+    wm_proc.wait(timeout=5)
     proc.wait(timeout=5)
 
 
@@ -169,8 +170,8 @@ def xterm_window(xvfb_display) -> Generator[subprocess.Popen, None, None]:
 # ---------------------------------------------------------------------------
 
 
-def _pixel_variance(path: Path) -> float:
-    """Return the mean pixel variance of an image (0 = blank/uniform)."""
+def _pixel_stddev(path: Path) -> float:
+    """Return the pixel standard deviation of an image (0 = blank/uniform)."""
     import statistics
     import struct as _struct
 
@@ -229,9 +230,9 @@ def test_screenshot_is_not_uniform(tmp_path, xterm_window, monkeypatch):
     shot = msg.files[0]
     assert isinstance(shot, Path)
 
-    variance = _pixel_variance(shot)
-    assert variance > 5.0, (
-        f"Screenshot appears uniform (std-dev={variance:.1f}) — "
+    stddev = _pixel_stddev(shot)
+    assert stddev > 5.0, (
+        f"Screenshot appears uniform (std-dev={stddev:.1f}) — "
         "scrot may not be capturing xterm content"
     )
 
@@ -319,11 +320,19 @@ def test_wait_for_change_detects_terminal_output(xterm_window, monkeypatch):
         msg = computer("wait_for_change", text="8")
         result_holder.append(msg)
 
+    # Warm up the screenshot pipeline so the first snapshot inside the
+    # wait_for_change thread lands quickly, then start polling.
+    computer("screenshot")
+
     t = threading.Thread(target=_wait, daemon=True)
     t.start()
 
-    # Give the polling loop a moment to take its baseline screenshot
-    time.sleep(0.2)
+    # Allow the thread to start and take its baseline screenshot before we type.
+    # The warm-up screenshot above makes this generous window reliable; a true
+    # synchronization primitive would require modifying the production
+    # wait_for_change handler to accept an Event, which is disproportionate for
+    # a manual-only (-m x11) test.
+    time.sleep(1.0)
 
     # Type a command — this should trigger a screen change
     computer("type", text="echo wait_for_change_test\n")

--- a/tests/test_computer_x11_integration.py
+++ b/tests/test_computer_x11_integration.py
@@ -35,6 +35,15 @@ if TYPE_CHECKING:
 # ---------------------------------------------------------------------------
 
 
+_REQUIRED_X11_TOOLS = ("Xvfb", "xdotool", "scrot", "xterm", "fluxbox")
+_MISSING_X11_TOOLS = [c for c in _REQUIRED_X11_TOOLS if not shutil.which(c)]
+
+pytestmark = pytest.mark.skipif(
+    bool(_MISSING_X11_TOOLS),
+    reason=f"x11 tools missing: {', '.join(_MISSING_X11_TOOLS)}",
+)
+
+
 def _cmd_ok(*cmds: str) -> bool:
     """Return True if all commands are on PATH."""
     return all(shutil.which(c) for c in cmds)
@@ -47,13 +56,8 @@ def _pil_available() -> bool:
 @pytest.fixture(autouse=True, scope="module")
 def _x11_tools_or_skip():
     """Skip the whole module if required tools are missing."""
-    missing = [
-        c
-        for c in ("Xvfb", "xdotool", "scrot", "xterm", "fluxbox")
-        if not shutil.which(c)
-    ]
-    if missing:
-        pytest.skip(f"x11 tools missing: {', '.join(missing)}")
+    if _MISSING_X11_TOOLS:
+        pytest.skip(f"x11 tools missing: {', '.join(_MISSING_X11_TOOLS)}")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

This PR adds end-to-end integration tests for the native xdotool/scrot X11 pipeline — the counterpart to the existing browser/Playwright tests in `test_computer_use_integration.py`.

Prior PRs for #216 added the browser pipeline tests, accessibility backends, orchestration helpers, Docker/VNC streaming, and docs — but none verified that the native X11 path (`screenshot → window_focus → type → wait_for_change`) actually works end-to-end against real processes. That gap is what this PR fills.

**What's tested:**
- `test_screenshot_returns_image` — `computer('screenshot')` returns a valid non-empty PNG via scrot
- `test_screenshot_is_not_uniform` — pixels differ when xterm is visible (scrot really captures content)
- `test_window_focus_targets_xterm` — `_linux_window_focus` finds an xterm window by WM_NAME via xdotool
- `test_type_changes_screen` — xdotool delivers keystrokes; screen pixel ratio changes after typing
- `test_wait_for_change_detects_terminal_output` — polling loop exits promptly when terminal renders output
- `test_act_and_observe_full_loop` — top-level orchestration helper returns a screenshot message

Tests are marked `@pytest.mark.x11` and auto-skip when Xvfb/xdotool/scrot/xterm/fluxbox are absent, so CI is never blocked on systems without X11.  The `x11` marker is registered in `pyproject.toml`.

All 6 tests pass on Bob's LXC (verified against a headless Xvfb display); the 138 existing computer tests are unaffected.

Relates to #216.

## Test plan
- [ ] `pytest tests/test_computer_x11_integration.py -v -m x11 --timeout=60` — all 6 pass on a host with X11 tools
- [ ] `pytest tests/test_computer_use_integration.py -v` — existing browser tests still pass
- [ ] On a host without X11 tools: tests skip cleanly (no failures)