### PR TITLE
feat(computer): add `gptme-util computer screenshot` CLI command (#216)

### DIFF
--- a/gptme/cli/cmd_computer.py
+++ b/gptme/cli/cmd_computer.py
@@ -470,4 +470,13 @@ def screenshot_cmd(output: str | None, display: str | None):
             err=True,
         )
         sys.exit(1)
+
+    if size == 0:
+        click.echo(
+            f"Error: screenshot file at {out_path} is empty (0 bytes). "
+            "Possible permission issue.",
+            err=True,
+        )
+        sys.exit(1)
+
     click.echo(f"Screenshot saved to {out_path} ({size:,} bytes)")

--- a/gptme/cli/cmd_computer.py
+++ b/gptme/cli/cmd_computer.py
@@ -450,8 +450,8 @@ def screenshot_cmd(output: str | None, display: str | None):
                 click.echo(
                     f"Error: cannot open display {effective_display!r}.\n"
                     "Start Xvfb first:\n"
-                    "  Xvfb :1 -screen 0 1024x768x24 &\n"
-                    "  export DISPLAY=:1",
+                    f"  Xvfb {effective_display} -screen 0 1024x768x24 &\n"
+                    f"  export DISPLAY={effective_display}",
                     err=True,
                 )
             else:

--- a/gptme/cli/cmd_computer.py
+++ b/gptme/cli/cmd_computer.py
@@ -434,7 +434,14 @@ def screenshot_cmd(output: str | None, display: str | None):
 
         # scrot will not overwrite an existing file — remove the target first so
         # the output path is vacant, then capture directly to it.
-        out_path.unlink(missing_ok=True)
+        try:
+            out_path.unlink(missing_ok=True)
+        except OSError as e:
+            click.echo(
+                f"Error: cannot remove existing screenshot file at {out_path}: {e}",
+                err=True,
+            )
+            sys.exit(1)
         try:
             subprocess.run(
                 ["scrot", str(out_path)],

--- a/gptme/cli/cmd_computer.py
+++ b/gptme/cli/cmd_computer.py
@@ -1,6 +1,7 @@
-"""CLI commands for computer-use tooling (audit-log, etc.)."""
+"""CLI commands for computer-use tooling (audit-log, screenshot, etc.)."""
 
 import json
+import os
 import re
 import sys
 from pathlib import Path
@@ -356,3 +357,107 @@ def audit_log(conversation: str | None, last: int, as_json: bool):
             if "text_len" in r and r["text_len"] is not None:
                 details += f" ({r['text_len']} chars, redacted)"
         click.echo(f"{ts:<30} {conv:<25} {action:<25} {details}")
+
+
+@computer.command("screenshot")
+@click.option(
+    "--output",
+    "-o",
+    default=None,
+    metavar="PATH",
+    help="Save screenshot to PATH (PNG). Defaults to /tmp/gptme-screenshot.png.",
+)
+@click.option(
+    "--display",
+    default=None,
+    metavar="DISPLAY",
+    help="X11 display to capture (e.g. ':1'). Defaults to $DISPLAY or ':1'.",
+)
+def screenshot_cmd(output: str | None, display: str | None):
+    """Take a screenshot of the current display.
+
+    Verifies that the computer tool's screenshot action works in the current
+    environment (X11 display reachable, scrot installed, etc.).  Useful for
+    checking the setup before starting a full computer-use session.
+
+    The screenshot is saved as a PNG file.  When --output is omitted it goes to
+    /tmp/gptme-screenshot.png.
+
+    Examples:
+
+    \b
+        gptme-util computer screenshot
+        gptme-util computer screenshot --output /tmp/my-screen.png
+        gptme-util computer screenshot --display :1
+    """
+    import platform
+    import shutil
+    import subprocess
+
+    out_path = Path(output) if output else Path("/tmp/gptme-screenshot.png")
+
+    system = platform.system()
+
+    if system == "Darwin":
+        # macOS: use screencapture
+        try:
+            subprocess.run(
+                ["screencapture", "-x", str(out_path)],
+                check=True,
+                capture_output=True,
+                timeout=10,
+            )
+        except FileNotFoundError:
+            click.echo("Error: screencapture not found (expected on macOS).", err=True)
+            sys.exit(1)
+        except subprocess.CalledProcessError as e:
+            click.echo(f"Error: screencapture failed: {e.stderr.decode()}", err=True)
+            sys.exit(1)
+    else:
+        # Linux: use scrot via $DISPLAY
+        scrot = shutil.which("scrot")
+        if not scrot:
+            click.echo(
+                "Error: scrot not found. Install it with:\n"
+                "  sudo apt install scrot  # Debian/Ubuntu\n"
+                "  sudo pacman -S scrot    # Arch",
+                err=True,
+            )
+            sys.exit(1)
+
+        effective_display: str = display or os.environ.get("DISPLAY") or ":1"
+        env = os.environ.copy()
+        env["DISPLAY"] = effective_display
+
+        # scrot will not overwrite an existing file — remove the target first so
+        # the output path is vacant, then capture directly to it.
+        out_path.unlink(missing_ok=True)
+        try:
+            subprocess.run(
+                ["scrot", str(out_path)],
+                check=True,
+                capture_output=True,
+                env=env,
+                timeout=10,
+            )
+        except subprocess.CalledProcessError as e:
+            out_path.unlink(missing_ok=True)
+            stderr = e.stderr.decode().strip()
+            if "open" in stderr.lower() and "display" in stderr.lower():
+                click.echo(
+                    f"Error: cannot open display {effective_display!r}.\n"
+                    "Start Xvfb first:\n"
+                    "  Xvfb :1 -screen 0 1024x768x24 &\n"
+                    "  export DISPLAY=:1",
+                    err=True,
+                )
+            else:
+                click.echo(f"Error: scrot failed: {stderr}", err=True)
+            sys.exit(1)
+        except subprocess.TimeoutExpired:
+            out_path.unlink(missing_ok=True)
+            click.echo("Error: scrot timed out.", err=True)
+            sys.exit(1)
+
+    size = out_path.stat().st_size
+    click.echo(f"Screenshot saved to {out_path} ({size:,} bytes)")

--- a/gptme/cli/cmd_computer.py
+++ b/gptme/cli/cmd_computer.py
@@ -462,5 +462,12 @@ def screenshot_cmd(output: str | None, display: str | None):
             click.echo("Error: scrot timed out.", err=True)
             sys.exit(1)
 
-    size = out_path.stat().st_size
+    try:
+        size = out_path.stat().st_size
+    except FileNotFoundError:
+        click.echo(
+            f"Error: screenshot file not created at {out_path} despite successful subprocess run.",
+            err=True,
+        )
+        sys.exit(1)
     click.echo(f"Screenshot saved to {out_path} ({size:,} bytes)")

--- a/gptme/cli/cmd_computer.py
+++ b/gptme/cli/cmd_computer.py
@@ -371,7 +371,7 @@ def audit_log(conversation: str | None, last: int, as_json: bool):
     "--display",
     default=None,
     metavar="DISPLAY",
-    help="X11 display to capture (e.g. ':1'). Defaults to $DISPLAY or ':1'.",
+    help="X11 display to capture (e.g. ':1'). Defaults to $DISPLAY or ':1'. Linux only.",
 )
 def screenshot_cmd(output: str | None, display: str | None):
     """Take a screenshot of the current display.
@@ -412,6 +412,9 @@ def screenshot_cmd(output: str | None, display: str | None):
             sys.exit(1)
         except subprocess.CalledProcessError as e:
             click.echo(f"Error: screencapture failed: {e.stderr.decode()}", err=True)
+            sys.exit(1)
+        except subprocess.TimeoutExpired:
+            click.echo("Error: screencapture timed out.", err=True)
             sys.exit(1)
     else:
         # Linux: use scrot via $DISPLAY

--- a/gptme/cli/cmd_computer.py
+++ b/gptme/cli/cmd_computer.py
@@ -465,16 +465,28 @@ def screenshot_cmd(output: str | None, display: str | None):
     try:
         size = out_path.stat().st_size
     except FileNotFoundError:
+        hint = (
+            "\nOn macOS, check that Screen Recording permission is granted in "
+            "System Settings > Privacy & Security > Screen Recording."
+            if system == "Darwin"
+            else ""
+        )
         click.echo(
-            f"Error: screenshot file not created at {out_path} despite successful subprocess run.",
+            "Error: screenshot file was not created at "
+            f"{out_path} despite successful subprocess run.{hint}",
             err=True,
         )
         sys.exit(1)
 
     if size == 0:
+        hint = (
+            "\nOn macOS, check that Screen Recording permission is granted in "
+            "System Settings > Privacy & Security > Screen Recording."
+            if system == "Darwin"
+            else ""
+        )
         click.echo(
-            f"Error: screenshot file at {out_path} is empty (0 bytes). "
-            "Possible permission issue.",
+            f"Error: screenshot file at {out_path} is empty (0 bytes).{hint}",
             err=True,
         )
         sys.exit(1)

--- a/tests/test_computer_screenshot_cli.py
+++ b/tests/test_computer_screenshot_cli.py
@@ -24,6 +24,7 @@ class TestScreenshotCmd:
         assert result.exit_code == 0
         assert "--output" in result.output
         assert "--display" in result.output
+        assert "Linux only" in result.output
 
     def test_linux_screenshot_saved_to_default_path(self, tmp_path):
         """On Linux, a successful scrot run writes the screenshot and prints the path."""
@@ -130,6 +131,22 @@ class TestScreenshotCmd:
 
         assert result.exit_code != 0
         assert "screencapture" in result.output
+
+    def test_macos_screencapture_timeout_exits_with_error(self, tmp_path):
+        out = tmp_path / "screen.png"
+
+        def fake_run(cmd, **kwargs):
+            raise subprocess.TimeoutExpired(cmd, 10)
+
+        runner = CliRunner()
+        with (
+            patch("platform.system", return_value="Darwin"),
+            patch("subprocess.run", side_effect=fake_run),
+        ):
+            result = runner.invoke(screenshot_cmd, ["--output", str(out)])
+
+        assert result.exit_code != 0
+        assert "timed out" in result.output
 
     def test_custom_display_passed_to_env(self, tmp_path):
         """--display value should be set in the subprocess env."""

--- a/tests/test_computer_screenshot_cli.py
+++ b/tests/test_computer_screenshot_cli.py
@@ -81,6 +81,8 @@ class TestScreenshotCmd:
 
         assert result.exit_code != 0
         assert "Xvfb" in result.output
+        assert "Xvfb :99 -screen 0 1024x768x24 &" in result.output
+        assert "export DISPLAY=:99" in result.output
 
     def test_linux_scrot_timeout_exits_with_error(self, tmp_path):
         out = tmp_path / "screen.png"

--- a/tests/test_computer_screenshot_cli.py
+++ b/tests/test_computer_screenshot_cli.py
@@ -1,0 +1,155 @@
+"""Tests for gptme-util computer screenshot (cmd_computer.py).
+
+Unit-tests the screenshot CLI command without requiring a real X display or
+scrot binary.  All subprocess calls are monkey-patched.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from gptme.cli.cmd_computer import screenshot_cmd
+
+
+class TestScreenshotCmd:
+    """Tests for `gptme-util computer screenshot`."""
+
+    def test_help_text_mentions_output(self):
+        runner = CliRunner()
+        result = runner.invoke(screenshot_cmd, ["--help"])
+        assert result.exit_code == 0
+        assert "--output" in result.output
+        assert "--display" in result.output
+
+    def test_linux_screenshot_saved_to_default_path(self, tmp_path):
+        """On Linux, a successful scrot run writes the screenshot and prints the path."""
+        out = tmp_path / "screen.png"
+
+        def fake_run(cmd, **kwargs):
+            # Simulate scrot writing the file
+            Path(cmd[-1]).write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 100)
+            return subprocess.CompletedProcess(cmd, 0, b"", b"")
+
+        runner = CliRunner()
+        with (
+            patch("platform.system", return_value="Linux"),
+            patch("shutil.which", return_value="/usr/bin/scrot"),
+            patch("subprocess.run", side_effect=fake_run),
+        ):
+            result = runner.invoke(screenshot_cmd, ["--output", str(out)])
+
+        assert result.exit_code == 0, result.output
+        assert str(out) in result.output
+        assert "bytes" in result.output
+
+    def test_linux_missing_scrot_exits_with_error(self):
+        runner = CliRunner()
+        with (
+            patch("platform.system", return_value="Linux"),
+            patch("shutil.which", return_value=None),
+        ):
+            result = runner.invoke(screenshot_cmd, [])
+
+        assert result.exit_code != 0
+        assert "scrot" in result.output
+
+    def test_linux_display_error_gives_actionable_hint(self, tmp_path):
+        out = tmp_path / "screen.png"
+
+        def fake_run(cmd, **kwargs):
+            raise subprocess.CalledProcessError(
+                1,
+                cmd,
+                b"",
+                b"scrot: Can't open X display. It *is* running, yeah? [:99]",
+            )
+
+        runner = CliRunner()
+        with (
+            patch("platform.system", return_value="Linux"),
+            patch("shutil.which", return_value="/usr/bin/scrot"),
+            patch("subprocess.run", side_effect=fake_run),
+        ):
+            result = runner.invoke(
+                screenshot_cmd, ["--output", str(out), "--display", ":99"]
+            )
+
+        assert result.exit_code != 0
+        assert "Xvfb" in result.output
+
+    def test_linux_scrot_timeout_exits_with_error(self, tmp_path):
+        out = tmp_path / "screen.png"
+
+        def fake_run(cmd, **kwargs):
+            raise subprocess.TimeoutExpired(cmd, 10)
+
+        runner = CliRunner()
+        with (
+            patch("platform.system", return_value="Linux"),
+            patch("shutil.which", return_value="/usr/bin/scrot"),
+            patch("subprocess.run", side_effect=fake_run),
+        ):
+            result = runner.invoke(screenshot_cmd, ["--output", str(out)])
+
+        assert result.exit_code != 0
+        assert "timed out" in result.output
+
+    def test_macos_screenshot_saved(self, tmp_path):
+        out = tmp_path / "screen.png"
+
+        def fake_run(cmd, **kwargs):
+            Path(cmd[-1]).write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 100)
+            return subprocess.CompletedProcess(cmd, 0, b"", b"")
+
+        runner = CliRunner()
+        with (
+            patch("platform.system", return_value="Darwin"),
+            patch("subprocess.run", side_effect=fake_run),
+        ):
+            result = runner.invoke(screenshot_cmd, ["--output", str(out)])
+
+        assert result.exit_code == 0, result.output
+        assert str(out) in result.output
+
+    def test_macos_screencapture_missing(self, tmp_path):
+        out = tmp_path / "screen.png"
+
+        def fake_run(cmd, **kwargs):
+            raise FileNotFoundError
+
+        runner = CliRunner()
+        with (
+            patch("platform.system", return_value="Darwin"),
+            patch("subprocess.run", side_effect=fake_run),
+        ):
+            result = runner.invoke(screenshot_cmd, ["--output", str(out)])
+
+        assert result.exit_code != 0
+        assert "screencapture" in result.output
+
+    def test_custom_display_passed_to_env(self, tmp_path):
+        """--display value should be set in the subprocess env."""
+        out = tmp_path / "screen.png"
+        captured_env: dict = {}
+
+        def fake_run(cmd, **kwargs):
+            captured_env.update(kwargs.get("env", {}))
+            Path(cmd[-1]).write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 100)
+            return subprocess.CompletedProcess(cmd, 0, b"", b"")
+
+        runner = CliRunner()
+        with (
+            patch("platform.system", return_value="Linux"),
+            patch("shutil.which", return_value="/usr/bin/scrot"),
+            patch("subprocess.run", side_effect=fake_run),
+        ):
+            result = runner.invoke(
+                screenshot_cmd, ["--output", str(out), "--display", ":42"]
+            )
+
+        assert result.exit_code == 0, result.output
+        assert captured_env.get("DISPLAY") == ":42"

--- a/tests/test_computer_screenshot_cli.py
+++ b/tests/test_computer_screenshot_cli.py
@@ -209,3 +209,23 @@ class TestScreenshotCmd:
 
         assert result.exit_code != 0
         assert "not created" in result.output
+
+    def test_screenshot_file_empty_after_success(self, tmp_path):
+        """Edge case: subprocess succeeds but produces a 0-byte file (e.g., macOS permission denial)."""
+        out = tmp_path / "screen.png"
+
+        def fake_run(cmd, **kwargs):
+            # Simulate subprocess success but writes a 0-byte file
+            out.write_bytes(b"")
+            return subprocess.CompletedProcess(cmd, 0, b"", b"")
+
+        runner = CliRunner()
+        with (
+            patch("platform.system", return_value="Linux"),
+            patch("shutil.which", return_value="/usr/bin/scrot"),
+            patch("subprocess.run", side_effect=fake_run),
+        ):
+            result = runner.invoke(screenshot_cmd, ["--output", str(out)])
+
+        assert result.exit_code != 0
+        assert "empty" in result.output or "0 bytes" in result.output

--- a/tests/test_computer_screenshot_cli.py
+++ b/tests/test_computer_screenshot_cli.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import subprocess
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from click.testing import CliRunner
 
@@ -100,6 +100,23 @@ class TestScreenshotCmd:
 
         assert result.exit_code != 0
         assert "timed out" in result.output
+
+    def test_linux_existing_output_unlink_error_exits_with_error(self, tmp_path):
+        out = tmp_path / "screen.png"
+        run_mock = Mock()
+
+        runner = CliRunner()
+        with (
+            patch("platform.system", return_value="Linux"),
+            patch("shutil.which", return_value="/usr/bin/scrot"),
+            patch.object(Path, "unlink", side_effect=PermissionError("denied")),
+            patch("subprocess.run", run_mock),
+        ):
+            result = runner.invoke(screenshot_cmd, ["--output", str(out)])
+
+        assert result.exit_code != 0
+        assert "cannot remove existing screenshot file" in result.output
+        run_mock.assert_not_called()
 
     def test_macos_screenshot_saved(self, tmp_path):
         out = tmp_path / "screen.png"

--- a/tests/test_computer_screenshot_cli.py
+++ b/tests/test_computer_screenshot_cli.py
@@ -134,6 +134,24 @@ class TestScreenshotCmd:
         assert result.exit_code != 0
         assert "screencapture" in result.output
 
+    def test_macos_screencapture_error_exits_with_error(self, tmp_path):
+        out = tmp_path / "screen.png"
+
+        def fake_run(cmd, **kwargs):
+            raise subprocess.CalledProcessError(
+                1, cmd, b"", b"screencapture: some error"
+            )
+
+        runner = CliRunner()
+        with (
+            patch("platform.system", return_value="Darwin"),
+            patch("subprocess.run", side_effect=fake_run),
+        ):
+            result = runner.invoke(screenshot_cmd, ["--output", str(out)])
+
+        assert result.exit_code != 0
+        assert "screencapture failed" in result.output
+
     def test_macos_screencapture_timeout_exits_with_error(self, tmp_path):
         out = tmp_path / "screen.png"
 
@@ -172,3 +190,22 @@ class TestScreenshotCmd:
 
         assert result.exit_code == 0, result.output
         assert captured_env.get("DISPLAY") == ":42"
+
+    def test_linux_screenshot_file_missing_after_success(self, tmp_path):
+        """Edge case: subprocess succeeds but file doesn't exist (e.g., permission issue)."""
+        out = tmp_path / "screen.png"
+
+        def fake_run(cmd, **kwargs):
+            # Simulate subprocess success but file is never created
+            return subprocess.CompletedProcess(cmd, 0, b"", b"")
+
+        runner = CliRunner()
+        with (
+            patch("platform.system", return_value="Linux"),
+            patch("shutil.which", return_value="/usr/bin/scrot"),
+            patch("subprocess.run", side_effect=fake_run),
+        ):
+            result = runner.invoke(screenshot_cmd, ["--output", str(out)])
+
+        assert result.exit_code != 0
+        assert "not created" in result.output

--- a/tests/test_computer_screenshot_cli.py
+++ b/tests/test_computer_screenshot_cli.py
@@ -191,7 +191,7 @@ class TestScreenshotCmd:
         assert result.exit_code == 0, result.output
         assert captured_env.get("DISPLAY") == ":42"
 
-    def test_linux_screenshot_file_missing_after_success(self, tmp_path):
+    def test_macos_screenshot_file_missing_after_success(self, tmp_path):
         """Edge case: subprocess succeeds but file doesn't exist (e.g., permission issue)."""
         out = tmp_path / "screen.png"
 
@@ -201,16 +201,16 @@ class TestScreenshotCmd:
 
         runner = CliRunner()
         with (
-            patch("platform.system", return_value="Linux"),
-            patch("shutil.which", return_value="/usr/bin/scrot"),
+            patch("platform.system", return_value="Darwin"),
             patch("subprocess.run", side_effect=fake_run),
         ):
             result = runner.invoke(screenshot_cmd, ["--output", str(out)])
 
         assert result.exit_code != 0
         assert "not created" in result.output
+        assert "Screen Recording permission" in result.output
 
-    def test_screenshot_file_empty_after_success(self, tmp_path):
+    def test_macos_screenshot_file_empty_after_success(self, tmp_path):
         """Edge case: subprocess succeeds but produces a 0-byte file (e.g., macOS permission denial)."""
         out = tmp_path / "screen.png"
 
@@ -221,11 +221,11 @@ class TestScreenshotCmd:
 
         runner = CliRunner()
         with (
-            patch("platform.system", return_value="Linux"),
-            patch("shutil.which", return_value="/usr/bin/scrot"),
+            patch("platform.system", return_value="Darwin"),
             patch("subprocess.run", side_effect=fake_run),
         ):
             result = runner.invoke(screenshot_cmd, ["--output", str(out)])
 
         assert result.exit_code != 0
         assert "empty" in result.output or "0 bytes" in result.output
+        assert "Screen Recording permission" in result.output


### PR DESCRIPTION
## Summary

Adds a `screenshot` subcommand to `gptme-util computer` that captures the current display to a PNG file without needing to start a full gptme session. Part of #216.

**Before**: the only way to take a test screenshot was to start a gptme session with `--tools +computer` and ask the agent to screenshot. No quick CLI sanity check existed.

**After**:
```bash
# Verify X11 setup works before starting a session
gptme-util computer screenshot
# Screenshot saved to /tmp/gptme-screenshot.png (197,304 bytes)

# Custom path or display
gptme-util computer screenshot --output /tmp/my-screen.png --display :1
```

Covers both Linux/X11 (scrot) and macOS (screencapture), with actionable error messages:
- Missing scrot → install hint
- Display not reachable → Xvfb start instructions
- Timeout → clear error

## Changes

- `gptme/cli/cmd_computer.py`: adds `screenshot` subcommand (Linux scrot + macOS screencapture)
- `tests/test_computer_screenshot_cli.py`: 8 unit tests covering success path, error cases, and env forwarding (all mock-based, no real display needed in CI)

## Test plan

- [x] `gptme-util computer screenshot --output /tmp/test.png` on a machine with Xvfb running → writes a valid PNG
- [x] `gptme-util computer screenshot --display :99` → actionable error with Xvfb hint
- [x] All 8 unit tests pass (`pytest tests/test_computer_screenshot_cli.py`)
- [x] Existing 183 computer tests still pass
- [x] Pre-commit (ruff + mypy) passes

<!-- gptme-id:v1:gai_CquOWnAHzmAiFMDzscm6mwXq0DLV05s2FK8qfLxpITg -->