### PR TITLE
feat(computer): add computer-use service to docker-compose.yml (#216)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,10 @@ services:
   # Runs a full X11 desktop inside Docker with VNC streaming via noVNC so you
   # can watch (and optionally intervene) as gptme controls the virtual desktop.
   #
+  # Note: No persistent volumes are mounted — all conversation data, credentials,
+  # and state are ephemeral and lost on container stop/remove. This is intentional
+  # for the sandboxed/ephemeral use case; use gptme-server for persistent sessions.
+  #
   # Ports:
   #   6080 — noVNC web interface (open in browser to see the live desktop)
   #   8080 — gptme server with computer + browser tools enabled

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,16 @@
-# Self-host gptme-server with one command:
+# Two services are available:
 #
-#   docker compose up --build
+#   gptme-server  — headless API server for use with the web UI:
 #
-# Then open the hosted web UI at https://chat.gptme.org and point it at
-# http://localhost:5700 — or host your own web UI (see docs/server.rst).
+#       docker compose up --build
+#
+#   computer-use  — full sandboxed desktop environment with VNC streaming
+#                   for computer-use tasks (issue #216):
+#
+#       docker compose up --build computer-use
+#
+#   Then open http://localhost:6080 in your browser for the live VNC view
+#   and http://localhost:8080 for the gptme chat interface.
 #
 # Configuration: copy .env.example to .env and fill in at least one provider
 # key. Everything below reads from that .env file (or your shell environment).
@@ -34,6 +41,43 @@ services:
       - gptme-config:/home/gptme/.config/gptme
       - gptme-data:/home/gptme/.local/share/gptme
     restart: unless-stopped
+
+  # Sandboxed desktop environment for computer-use tasks (issue #216).
+  #
+  # Runs a full X11 desktop inside Docker with VNC streaming via noVNC so you
+  # can watch (and optionally intervene) as gptme controls the virtual desktop.
+  #
+  # Ports:
+  #   6080 — noVNC web interface (open in browser to see the live desktop)
+  #   8080 — gptme server with computer + browser tools enabled
+  #
+  # Usage:
+  #   docker compose up --build computer-use
+  #   # Open http://localhost:6080 to watch the desktop
+  #   # Then start a gptme conversation that uses --tools computer,browser
+  computer-use:
+    build:
+      context: .
+      dockerfile: scripts/Dockerfile.computer
+    image: gptme-computer-use
+    ports:
+      # noVNC web interface — watch the live desktop in any browser
+      - "${NOVNC_PORT:-6080}:6080"
+      # gptme server with computer + browser tools
+      - "${COMPUTER_SERVER_PORT:-8080}:8080"
+    environment:
+      # At least one provider key is required to run conversations.
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+      OPENROUTER_API_KEY: ${OPENROUTER_API_KEY:-}
+      # Virtual display resolution (must match Xvfb resolution in Dockerfile)
+      WIDTH: ${COMPUTER_WIDTH:-1024}
+      HEIGHT: ${COMPUTER_HEIGHT:-768}
+      DISPLAY_NUM: ${COMPUTER_DISPLAY_NUM:-1}
+    # Default: don't start automatically with `docker compose up` (only start
+    # when explicitly requested via `docker compose up computer-use`).
+    profiles:
+      - computer-use
 
 volumes:
   gptme-config:

--- a/tests/test_computer_docker_config.py
+++ b/tests/test_computer_docker_config.py
@@ -6,10 +6,15 @@ with the tools required for computer-use profile functionality.
 Also verifies that computer.html does not hardcode VNC hostnames so that
 remote Docker setups (where gptme server and the browser are on different
 machines) work without any configuration changes.
+
+Also verifies that docker-compose.yml includes a computer-use service that
+wires up the Dockerfile.computer image with the correct ports, environment,
+and profiles configuration.
 """
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 ENTRYPOINT = (
@@ -131,3 +136,161 @@ class TestComputerHtmlVncUrl:
             "computer.html does not support a vncHost query parameter override. "
             "Users with split-horizon networking (separate VNC and gptme hosts) need this."
         )
+
+
+DOCKER_COMPOSE = Path(__file__).parent.parent / "docker-compose.yml"
+DOCKERFILE_COMPUTER = Path(__file__).parent.parent / "scripts" / "Dockerfile.computer"
+
+
+def _parse_compose(path: Path) -> dict:
+    """Parse docker-compose.yml without requiring PyYAML — uses a minimal regex approach
+    for the specific checks we need, falling back to yaml if available."""
+    try:
+        import yaml  # type: ignore[import-untyped]
+
+        return yaml.safe_load(path.read_text())
+    except ImportError:
+        pass
+    # Fallback: return raw text in a wrapper so callers can check containment
+    return {"_raw": path.read_text()}
+
+
+class TestDockerComposeComputerUseService:
+    """Verify docker-compose.yml has a working computer-use service (issue #216).
+
+    The computer-use service is the Docker/VNC streaming path described in
+    issue #216 as the sandboxed deployment mode.  It must be present so users
+    can run `docker compose up --build computer-use` to get a full sandboxed
+    desktop environment with live VNC streaming.
+    """
+
+    def test_docker_compose_exists(self):
+        assert DOCKER_COMPOSE.exists(), (
+            f"docker-compose.yml not found: {DOCKER_COMPOSE}"
+        )
+
+    def test_dockerfile_computer_exists(self):
+        assert DOCKERFILE_COMPUTER.exists(), (
+            f"scripts/Dockerfile.computer not found: {DOCKERFILE_COMPUTER}"
+        )
+
+    def test_computer_use_service_present(self):
+        """docker-compose.yml must define a computer-use service."""
+        compose = _parse_compose(DOCKER_COMPOSE)
+        if "_raw" in compose:
+            assert "computer-use:" in compose["_raw"], (
+                "docker-compose.yml has no 'computer-use' service. "
+                "Add a computer-use service using scripts/Dockerfile.computer "
+                "so users can run `docker compose up computer-use` for VNC streaming."
+            )
+        else:
+            services = compose.get("services", {})
+            assert "computer-use" in services, (
+                f"docker-compose.yml services: {list(services)}. "
+                "Missing 'computer-use' service. "
+                "Add a computer-use service using scripts/Dockerfile.computer."
+            )
+
+    def test_computer_use_dockerfile_is_dockerfile_computer(self):
+        """The computer-use service must reference scripts/Dockerfile.computer."""
+        compose = _parse_compose(DOCKER_COMPOSE)
+        if "_raw" in compose:
+            assert "Dockerfile.computer" in compose["_raw"], (
+                "docker-compose.yml does not reference Dockerfile.computer for computer-use. "
+                "The computer-use service needs the Xvfb/VNC/xdotool image."
+            )
+        else:
+            service = compose.get("services", {}).get("computer-use", {})
+            build = service.get("build", {})
+            dockerfile = build.get("dockerfile", "")
+            assert "Dockerfile.computer" in dockerfile, (
+                f"computer-use service uses '{dockerfile}', expected scripts/Dockerfile.computer. "
+                "The Dockerfile.computer image provides Xvfb, VNC, xdotool, noVNC."
+            )
+
+    def test_novnc_port_exposed(self):
+        """The computer-use service must expose port 6080 for the noVNC web interface."""
+        compose = _parse_compose(DOCKER_COMPOSE)
+        if "_raw" in compose:
+            assert "6080" in compose["_raw"], (
+                "docker-compose.yml computer-use service does not expose port 6080 (noVNC). "
+                "Users need port 6080 to view the live desktop via their browser."
+            )
+        else:
+            service = compose.get("services", {}).get("computer-use", {})
+            ports = service.get("ports", [])
+            port_strs = [str(p) for p in ports]
+            assert any("6080" in p for p in port_strs), (
+                f"computer-use ports: {ports}. Port 6080 (noVNC) must be exposed."
+            )
+
+    def test_gptme_server_port_exposed(self):
+        """The computer-use service must expose port 8080 for the gptme server."""
+        compose = _parse_compose(DOCKER_COMPOSE)
+        if "_raw" in compose:
+            assert "8080" in compose["_raw"], (
+                "docker-compose.yml computer-use service does not expose port 8080 (gptme server). "
+                "Port 8080 provides the chat interface and REST API for computer-use."
+            )
+        else:
+            service = compose.get("services", {}).get("computer-use", {})
+            ports = service.get("ports", [])
+            port_strs = [str(p) for p in ports]
+            assert any("8080" in p for p in port_strs), (
+                f"computer-use ports: {ports}. "
+                "Port 8080 (gptme server) must be exposed."
+            )
+
+    def test_computer_use_in_profile_not_default(self):
+        """computer-use must be in a Docker Compose profile so it doesn't start by default.
+
+        Running `docker compose up` should start only the headless gptme-server.
+        The heavy computer-use container (Xvfb + VNC + browser) should only start
+        when explicitly requested via `docker compose up computer-use`.
+        """
+        compose = _parse_compose(DOCKER_COMPOSE)
+        if "_raw" in compose:
+            # The profiles: key must appear somewhere in the computer-use block.
+            # We check by looking for 'profiles' after 'computer-use:' in the raw YAML.
+            raw = compose["_raw"]
+            # Find the computer-use service block and ensure 'profiles' appears in it
+            match = re.search(r"computer-use:.*?(?=\n\S|\Z)", raw, re.DOTALL)
+            service_block = match.group(0) if match else ""
+            assert "profiles" in service_block, (
+                "computer-use service has no 'profiles' key. "
+                "Add `profiles: [computer-use]` to prevent it from starting with plain "
+                "`docker compose up` (which should start only gptme-server)."
+            )
+        else:
+            service = compose.get("services", {}).get("computer-use", {})
+            profiles = service.get("profiles", [])
+            assert profiles, (
+                "computer-use service has no profiles configured. "
+                "Add `profiles: [computer-use]` to keep it out of the default `docker compose up`."
+            )
+
+    def test_api_keys_passed_to_computer_use(self):
+        """computer-use service must forward provider API keys as environment variables."""
+        compose = _parse_compose(DOCKER_COMPOSE)
+        if "_raw" in compose:
+            raw = compose["_raw"]
+            match = re.search(r"computer-use:.*?(?=\n\S|\Z)", raw, re.DOTALL)
+            service_block = match.group(0) if match else raw
+            assert (
+                "ANTHROPIC_API_KEY" in service_block
+                or "OPENAI_API_KEY" in service_block
+            ), (
+                "computer-use service does not forward any provider API keys. "
+                "At least one of ANTHROPIC_API_KEY or OPENAI_API_KEY must be in the environment."
+            )
+        else:
+            service = compose.get("services", {}).get("computer-use", {})
+            env = service.get("environment", {})
+            env_keys = list(env.keys()) if isinstance(env, dict) else env
+            assert any(
+                k in ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "OPENROUTER_API_KEY")
+                for k in env_keys
+            ), (
+                f"computer-use environment: {env_keys}. "
+                "Must forward at least one provider API key."
+            )

--- a/tests/test_computer_docker_config.py
+++ b/tests/test_computer_docker_config.py
@@ -208,11 +208,17 @@ class TestDockerComposeComputerUseService:
                 "The Dockerfile.computer image provides Xvfb, VNC, xdotool, noVNC."
             )
 
+    def _computer_use_service_block(self, raw: str) -> str:
+        """Extract the computer-use service block from raw YAML text."""
+        match = re.search(r"computer-use:.*?(?=\n\S|\Z)", raw, re.DOTALL)
+        return match.group(0) if match else ""
+
     def test_novnc_port_exposed(self):
         """The computer-use service must expose port 6080 for the noVNC web interface."""
         compose = _parse_compose(DOCKER_COMPOSE)
         if "_raw" in compose:
-            assert "6080" in compose["_raw"], (
+            service_block = self._computer_use_service_block(compose["_raw"])
+            assert "6080" in service_block, (
                 "docker-compose.yml computer-use service does not expose port 6080 (noVNC). "
                 "Users need port 6080 to view the live desktop via their browser."
             )
@@ -228,7 +234,8 @@ class TestDockerComposeComputerUseService:
         """The computer-use service must expose port 8080 for the gptme server."""
         compose = _parse_compose(DOCKER_COMPOSE)
         if "_raw" in compose:
-            assert "8080" in compose["_raw"], (
+            service_block = self._computer_use_service_block(compose["_raw"])
+            assert "8080" in service_block, (
                 "docker-compose.yml computer-use service does not expose port 8080 (gptme server). "
                 "Port 8080 provides the chat interface and REST API for computer-use."
             )
@@ -275,7 +282,7 @@ class TestDockerComposeComputerUseService:
         if "_raw" in compose:
             raw = compose["_raw"]
             match = re.search(r"computer-use:.*?(?=\n\S|\Z)", raw, re.DOTALL)
-            service_block = match.group(0) if match else raw
+            service_block = match.group(0) if match else ""
             assert (
                 "ANTHROPIC_API_KEY" in service_block
                 or "OPENAI_API_KEY" in service_block


### PR DESCRIPTION
## Summary

Wires the existing `scripts/Dockerfile.computer` into `docker-compose.yml` as a `computer-use` profile service, addressing the "Docker/VNC streaming mode for sandboxed/remote computer use" gap identified in issue #216.

Users can now launch the full sandboxed desktop environment with one command:

```bash
docker compose up --build computer-use
```

Then open `http://localhost:6080` in any browser to see the live VNC desktop stream, and `http://localhost:8080` for the gptme chat interface.

## What changed

**`docker-compose.yml`**: Added `computer-use` service with:
- `Dockerfile.computer` image (Xvfb + mutter + x11vnc + noVNC + xdotool + Playwright)
- Port 6080 → noVNC web interface (live desktop view in browser)
- Port 8080 → gptme server with `computer,browser,vision,ipython,shell` tools
- `profiles: [computer-use]` — does NOT start with plain `docker compose up` (heavy container, only on request)
- Passes through provider API keys (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `OPENROUTER_API_KEY`)
- Configurable resolution and display number via `COMPUTER_WIDTH`, `COMPUTER_HEIGHT`, `COMPUTER_DISPLAY_NUM`

**`tests/test_computer_docker_config.py`**: Added `TestDockerComposeComputerUseService` (8 new tests) that verify:
- The `computer-use` service exists in docker-compose.yml
- It references `Dockerfile.computer` (not the selfhost image)
- Port 6080 (noVNC) is exposed
- Port 8080 (gptme server) is exposed
- The service is in a profile (not started by default)
- Provider API keys are forwarded

## Test results

```
247 passed, 3 skipped, 1 warning, 4 subtests passed
```

All existing computer-use tests continue to pass.

Closes #216 (partially — addresses the Docker/VNC sandboxed deployment mode gap)

<!-- gptme-id:v1:gai_aaonqT686Rl0CYEt4BK00TulVkibPOQWx6pcMIw1SIL -->