### PR TITLE
feat(computer): add `gptme-util computer video-frames` CLI command

### DIFF
--- a/gptme/cli/cmd_computer.py
+++ b/gptme/cli/cmd_computer.py
@@ -589,6 +589,10 @@ def video_frames_cmd(
     if output_dir:
         out_dir = Path(output_dir)
         out_dir.mkdir(parents=True, exist_ok=True)
+        # Remove stale frames so a reused --output-dir never leaks old files into
+        # the glob result (temp dirs from the else branch are always fresh).
+        for _stale in out_dir.glob("frame_*.png"):
+            _stale.unlink()
     else:
         out_dir = Path(tempfile.mkdtemp(prefix="gptme-video-frames-"))
         click.echo(

--- a/gptme/cli/cmd_computer.py
+++ b/gptme/cli/cmd_computer.py
@@ -499,3 +499,120 @@ def screenshot_cmd(output: str | None, display: str | None):
         sys.exit(1)
 
     click.echo(f"Screenshot saved to {out_path} ({size:,} bytes)")
+
+
+@computer.command("video-frames")
+@click.argument("input", metavar="INPUT")
+@click.option(
+    "--fps",
+    default=1.0,
+    show_default=True,
+    type=float,
+    help="Frames per second to extract.",
+)
+@click.option(
+    "--limit",
+    default=None,
+    type=int,
+    metavar="N",
+    help="Maximum number of frames to extract.",
+)
+@click.option(
+    "--output-dir",
+    "-o",
+    default=None,
+    metavar="DIR",
+    help="Directory for output frames. Defaults to a system temporary directory.",
+)
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    help="Output JSON with frame paths and metadata instead of one path per line.",
+)
+def video_frames_cmd(
+    input: str,
+    fps: float,
+    limit: int | None,
+    output_dir: str | None,
+    as_json: bool,
+):
+    """Extract key frames from a video for use as gptme context.
+
+    Uses ffmpeg to extract frames at the specified rate and prints the resulting
+    PNG file paths.  Useful for reviewing screen recordings of CI failures, UI
+    bugs, or multi-step workflows without manually scrubbing the video.
+
+    INPUT is the path to the video file (MP4, MKV, WebM, etc.).
+
+    Examples:
+
+    \b
+        gptme-util computer video-frames recording.mp4
+        gptme-util computer video-frames recording.mp4 --fps 0.5 --limit 5
+        gptme-util computer video-frames recording.mp4 --output-dir /tmp/frames --json
+    """
+    import shutil
+    import subprocess
+    import tempfile
+
+    if not shutil.which("ffmpeg"):
+        click.echo(
+            "Error: ffmpeg not found. Install it with:\n"
+            "  sudo apt install ffmpeg  # Debian/Ubuntu\n"
+            "  brew install ffmpeg      # macOS",
+            err=True,
+        )
+        sys.exit(1)
+
+    in_path = Path(input)
+    if not in_path.exists():
+        click.echo(f"Error: input file not found: {in_path}", err=True)
+        sys.exit(1)
+
+    if fps <= 0:
+        click.echo("Error: --fps must be a positive number.", err=True)
+        sys.exit(1)
+
+    if limit is not None and limit <= 0:
+        click.echo("Error: --limit must be a positive integer.", err=True)
+        sys.exit(1)
+
+    if output_dir:
+        out_dir = Path(output_dir)
+        out_dir.mkdir(parents=True, exist_ok=True)
+    else:
+        out_dir = Path(tempfile.mkdtemp(prefix="gptme-video-frames-"))
+
+    out_pattern = str(out_dir / "frame_%04d.png")
+    cmd = ["ffmpeg", "-i", str(in_path), "-vf", f"fps={fps}"]
+    if limit is not None:
+        cmd += ["-frames:v", str(limit)]
+    cmd += ["-y", out_pattern]
+
+    try:
+        subprocess.run(cmd, check=True, capture_output=True, timeout=120)
+    except subprocess.CalledProcessError as e:
+        click.echo(f"Error: ffmpeg failed:\n{e.stderr.decode()}", err=True)
+        sys.exit(1)
+    except subprocess.TimeoutExpired:
+        click.echo("Error: ffmpeg timed out.", err=True)
+        sys.exit(1)
+
+    frames = sorted(out_dir.glob("frame_*.png"))
+    if not frames:
+        click.echo(
+            f"Error: no frames were extracted from {in_path}.",
+            err=True,
+        )
+        sys.exit(1)
+
+    if as_json:
+        click.echo(
+            json.dumps(
+                {"frames": [str(f) for f in frames], "count": len(frames), "fps": fps}
+            )
+        )
+    else:
+        for f in frames:
+            click.echo(str(f))

--- a/gptme/cli/cmd_computer.py
+++ b/gptme/cli/cmd_computer.py
@@ -574,6 +574,14 @@ def video_frames_cmd(
         click.echo("Error: --fps must be a positive number.", err=True)
         sys.exit(1)
 
+    if fps > 60:
+        click.echo(
+            "Error: --fps must be at most 60. "
+            "Higher rates risk extracting thousands of frames and filling disk.",
+            err=True,
+        )
+        sys.exit(1)
+
     if limit is not None and limit <= 0:
         click.echo("Error: --limit must be a positive integer.", err=True)
         sys.exit(1)
@@ -583,6 +591,10 @@ def video_frames_cmd(
         out_dir.mkdir(parents=True, exist_ok=True)
     else:
         out_dir = Path(tempfile.mkdtemp(prefix="gptme-video-frames-"))
+        click.echo(
+            f"Output directory: {out_dir} (temp directory, not auto-cleaned)",
+            err=True,
+        )
 
     out_pattern = str(out_dir / "frame_%04d.png")
     cmd = ["ffmpeg", "-i", str(in_path), "-vf", f"fps={fps}"]

--- a/tests/test_computer_video_frames_cli.py
+++ b/tests/test_computer_video_frames_cli.py
@@ -1,0 +1,306 @@
+"""Tests for gptme-util computer video-frames (cmd_computer.py).
+
+Unit-tests the video-frames CLI command without requiring ffmpeg or a real
+video file.  All subprocess calls and filesystem checks are monkey-patched.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from gptme.cli.cmd_computer import video_frames_cmd
+
+
+def _make_fake_ffmpeg(out_dir: Path, n_frames: int = 3):
+    """Return a fake ffmpeg run() that creates N PNG files in the output dir."""
+
+    def fake_run(cmd, **kwargs):
+        # Determine output dir from the pattern argument (last arg)
+        pattern = cmd[-1]  # e.g. /tmp/gptme-video-frames-xxx/frame_%04d.png
+        out = Path(pattern).parent
+        for i in range(1, n_frames + 1):
+            (out / f"frame_{i:04d}.png").write_bytes(
+                b"\x89PNG\r\n\x1a\n" + b"\x00" * 50
+            )
+        return subprocess.CompletedProcess(cmd, 0, b"", b"")
+
+    return fake_run
+
+
+class TestVideoFramesCmd:
+    """Tests for `gptme-util computer video-frames`."""
+
+    def test_help_text(self):
+        runner = CliRunner()
+        result = runner.invoke(video_frames_cmd, ["--help"])
+        assert result.exit_code == 0
+        assert "--fps" in result.output
+        assert "--limit" in result.output
+        assert "--output-dir" in result.output
+        assert "--json" in result.output
+
+    def test_basic_extraction_prints_frame_paths(self, tmp_path):
+        video = tmp_path / "rec.mp4"
+        video.write_bytes(b"fake-mp4")
+        out_dir = tmp_path / "frames"
+
+        runner = CliRunner()
+        with (
+            patch("shutil.which", return_value="/usr/bin/ffmpeg"),
+            patch("subprocess.run", side_effect=_make_fake_ffmpeg(out_dir, n_frames=3)),
+        ):
+            result = runner.invoke(
+                video_frames_cmd,
+                ["--output-dir", str(out_dir), str(video)],
+            )
+
+        assert result.exit_code == 0, result.output
+        lines = [ln for ln in result.output.splitlines() if ln]
+        assert len(lines) == 3
+        assert all("frame_" in ln for ln in lines)
+
+    def test_json_output_structure(self, tmp_path):
+        video = tmp_path / "rec.mp4"
+        video.write_bytes(b"fake-mp4")
+        out_dir = tmp_path / "frames"
+
+        runner = CliRunner()
+        with (
+            patch("shutil.which", return_value="/usr/bin/ffmpeg"),
+            patch("subprocess.run", side_effect=_make_fake_ffmpeg(out_dir, n_frames=2)),
+        ):
+            result = runner.invoke(
+                video_frames_cmd,
+                ["--output-dir", str(out_dir), "--json", str(video)],
+            )
+
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["count"] == 2
+        assert data["fps"] == 1.0
+        assert len(data["frames"]) == 2
+
+    def test_fps_passed_to_ffmpeg(self, tmp_path):
+        video = tmp_path / "rec.mp4"
+        video.write_bytes(b"fake-mp4")
+        out_dir = tmp_path / "frames"
+        captured_cmd: list[list[str]] = []
+
+        def fake_run(cmd, **kwargs):
+            captured_cmd.append(cmd)
+            out = Path(cmd[-1]).parent
+            (out / "frame_0001.png").write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 50)
+            return subprocess.CompletedProcess(cmd, 0, b"", b"")
+
+        runner = CliRunner()
+        with (
+            patch("shutil.which", return_value="/usr/bin/ffmpeg"),
+            patch("subprocess.run", side_effect=fake_run),
+        ):
+            result = runner.invoke(
+                video_frames_cmd,
+                ["--output-dir", str(out_dir), "--fps", "0.5", str(video)],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert any("fps=0.5" in arg for arg in captured_cmd[0])
+
+    def test_limit_passed_to_ffmpeg(self, tmp_path):
+        video = tmp_path / "rec.mp4"
+        video.write_bytes(b"fake-mp4")
+        out_dir = tmp_path / "frames"
+        captured_cmd: list[list[str]] = []
+
+        def fake_run(cmd, **kwargs):
+            captured_cmd.append(cmd)
+            out = Path(cmd[-1]).parent
+            (out / "frame_0001.png").write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 50)
+            return subprocess.CompletedProcess(cmd, 0, b"", b"")
+
+        runner = CliRunner()
+        with (
+            patch("shutil.which", return_value="/usr/bin/ffmpeg"),
+            patch("subprocess.run", side_effect=fake_run),
+        ):
+            result = runner.invoke(
+                video_frames_cmd,
+                ["--output-dir", str(out_dir), "--limit", "7", str(video)],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert "-frames:v" in captured_cmd[0]
+        assert "7" in captured_cmd[0]
+
+    def test_missing_ffmpeg_exits_with_error(self, tmp_path):
+        video = tmp_path / "rec.mp4"
+        video.write_bytes(b"fake-mp4")
+
+        runner = CliRunner()
+        with patch("shutil.which", return_value=None):
+            result = runner.invoke(video_frames_cmd, [str(video)])
+
+        assert result.exit_code != 0
+        assert "ffmpeg" in result.output
+        assert "apt install" in result.output
+
+    def test_missing_input_file_exits_with_error(self, tmp_path):
+        runner = CliRunner()
+        with patch("shutil.which", return_value="/usr/bin/ffmpeg"):
+            result = runner.invoke(
+                video_frames_cmd, [str(tmp_path / "nonexistent.mp4")]
+            )
+
+        assert result.exit_code != 0
+        assert "not found" in result.output
+
+    def test_ffmpeg_failure_exits_with_error(self, tmp_path):
+        video = tmp_path / "rec.mp4"
+        video.write_bytes(b"fake-mp4")
+
+        def fake_run(cmd, **kwargs):
+            raise subprocess.CalledProcessError(1, cmd, b"", b"Invalid data found")
+
+        runner = CliRunner()
+        with (
+            patch("shutil.which", return_value="/usr/bin/ffmpeg"),
+            patch("subprocess.run", side_effect=fake_run),
+        ):
+            result = runner.invoke(video_frames_cmd, [str(video)])
+
+        assert result.exit_code != 0
+        assert "ffmpeg failed" in result.output
+
+    def test_ffmpeg_timeout_exits_with_error(self, tmp_path):
+        video = tmp_path / "rec.mp4"
+        video.write_bytes(b"fake-mp4")
+
+        def fake_run(cmd, **kwargs):
+            raise subprocess.TimeoutExpired(cmd, 120)
+
+        runner = CliRunner()
+        with (
+            patch("shutil.which", return_value="/usr/bin/ffmpeg"),
+            patch("subprocess.run", side_effect=fake_run),
+        ):
+            result = runner.invoke(video_frames_cmd, [str(video)])
+
+        assert result.exit_code != 0
+        assert "timed out" in result.output
+
+    def test_no_frames_extracted_exits_with_error(self, tmp_path):
+        video = tmp_path / "rec.mp4"
+        video.write_bytes(b"fake-mp4")
+        out_dir = tmp_path / "frames"
+
+        def fake_run(cmd, **kwargs):
+            # ffmpeg "succeeds" but produces no PNG files
+            Path(cmd[-1]).parent.mkdir(parents=True, exist_ok=True)
+            return subprocess.CompletedProcess(cmd, 0, b"", b"")
+
+        runner = CliRunner()
+        with (
+            patch("shutil.which", return_value="/usr/bin/ffmpeg"),
+            patch("subprocess.run", side_effect=fake_run),
+        ):
+            result = runner.invoke(
+                video_frames_cmd, ["--output-dir", str(out_dir), str(video)]
+            )
+
+        assert result.exit_code != 0
+        assert "no frames" in result.output
+
+    def test_invalid_fps_exits_with_error(self, tmp_path):
+        video = tmp_path / "rec.mp4"
+        video.write_bytes(b"fake-mp4")
+
+        runner = CliRunner()
+        with patch("shutil.which", return_value="/usr/bin/ffmpeg"):
+            result = runner.invoke(video_frames_cmd, ["--fps", "-1", str(video)])
+
+        assert result.exit_code != 0
+        assert "fps" in result.output.lower()
+
+    def test_invalid_limit_exits_with_error(self, tmp_path):
+        video = tmp_path / "rec.mp4"
+        video.write_bytes(b"fake-mp4")
+
+        runner = CliRunner()
+        with patch("shutil.which", return_value="/usr/bin/ffmpeg"):
+            result = runner.invoke(video_frames_cmd, ["--limit", "0", str(video)])
+
+        assert result.exit_code != 0
+        assert "limit" in result.output.lower()
+
+    def test_output_dir_created_if_missing(self, tmp_path):
+        video = tmp_path / "rec.mp4"
+        video.write_bytes(b"fake-mp4")
+        out_dir = tmp_path / "nested" / "frames"
+
+        runner = CliRunner()
+        with (
+            patch("shutil.which", return_value="/usr/bin/ffmpeg"),
+            patch("subprocess.run", side_effect=_make_fake_ffmpeg(out_dir, n_frames=1)),
+        ):
+            result = runner.invoke(
+                video_frames_cmd, ["--output-dir", str(out_dir), str(video)]
+            )
+
+        assert result.exit_code == 0, result.output
+        assert out_dir.exists()
+
+    def test_default_tempdir_used_when_no_output_dir(self, tmp_path):
+        video = tmp_path / "rec.mp4"
+        video.write_bytes(b"fake-mp4")
+
+        created_dirs: list[Path] = []
+
+        def fake_mkdtemp(prefix=""):
+            d = tmp_path / "tmp-frames"
+            d.mkdir()
+            created_dirs.append(d)
+            return str(d)
+
+        def fake_run(cmd, **kwargs):
+            out = Path(cmd[-1]).parent
+            (out / "frame_0001.png").write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 50)
+            return subprocess.CompletedProcess(cmd, 0, b"", b"")
+
+        runner = CliRunner()
+        with (
+            patch("shutil.which", return_value="/usr/bin/ffmpeg"),
+            patch("subprocess.run", side_effect=fake_run),
+            patch("tempfile.mkdtemp", side_effect=fake_mkdtemp),
+        ):
+            result = runner.invoke(video_frames_cmd, [str(video)])
+
+        assert result.exit_code == 0, result.output
+        assert len(created_dirs) == 1
+
+    @pytest.mark.parametrize("n_frames", [1, 5, 10])
+    def test_json_count_matches_extracted_frames(self, tmp_path, n_frames):
+        video = tmp_path / "rec.mp4"
+        video.write_bytes(b"fake-mp4")
+        out_dir = tmp_path / "frames"
+
+        runner = CliRunner()
+        with (
+            patch("shutil.which", return_value="/usr/bin/ffmpeg"),
+            patch(
+                "subprocess.run",
+                side_effect=_make_fake_ffmpeg(out_dir, n_frames=n_frames),
+            ),
+        ):
+            result = runner.invoke(
+                video_frames_cmd,
+                ["--output-dir", str(out_dir), "--json", str(video)],
+            )
+
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["count"] == n_frames

--- a/tests/test_computer_video_frames_cli.py
+++ b/tests/test_computer_video_frames_cli.py
@@ -24,6 +24,7 @@ def _make_fake_ffmpeg(out_dir: Path, n_frames: int = 3):
         # Determine output dir from the pattern argument (last arg)
         pattern = cmd[-1]  # e.g. /tmp/gptme-video-frames-xxx/frame_%04d.png
         out = Path(pattern).parent
+        assert out == out_dir, f"ffmpeg writing to {out}, expected {out_dir}"
         for i in range(1, n_frames + 1):
             (out / f"frame_{i:04d}.png").write_bytes(
                 b"\x89PNG\r\n\x1a\n" + b"\x00" * 50

--- a/tests/test_computer_video_frames_cli.py
+++ b/tests/test_computer_video_frames_cli.py
@@ -226,6 +226,18 @@ class TestVideoFramesCmd:
         assert result.exit_code != 0
         assert "fps" in result.output.lower()
 
+    def test_fps_ceiling_exits_with_error(self, tmp_path):
+        """FPS above 60 should be rejected to prevent disk exhaustion."""
+        video = tmp_path / "rec.mp4"
+        video.write_bytes(b"fake-mp4")
+
+        runner = CliRunner()
+        with patch("shutil.which", return_value="/usr/bin/ffmpeg"):
+            result = runner.invoke(video_frames_cmd, ["--fps", "120", str(video)])
+
+        assert result.exit_code != 0
+        assert "at most 60" in result.output.lower()
+
     def test_invalid_limit_exits_with_error(self, tmp_path):
         video = tmp_path / "rec.mp4"
         video.write_bytes(b"fake-mp4")

--- a/tests/test_computer_video_frames_cli.py
+++ b/tests/test_computer_video_frames_cli.py
@@ -317,3 +317,37 @@ class TestVideoFramesCmd:
         assert result.exit_code == 0, result.output
         data = json.loads(result.output)
         assert data["count"] == n_frames
+
+    def test_stale_frames_cleared_when_output_dir_reused(self, tmp_path):
+        """Second run with fewer frames must not include stale files from the first run."""
+        video = tmp_path / "rec.mp4"
+        video.write_bytes(b"fake-mp4")
+        out_dir = tmp_path / "frames"
+        runner = CliRunner()
+
+        # First run: 5 frames
+        with (
+            patch("shutil.which", return_value="/usr/bin/ffmpeg"),
+            patch("subprocess.run", side_effect=_make_fake_ffmpeg(out_dir, n_frames=5)),
+        ):
+            result = runner.invoke(
+                video_frames_cmd,
+                ["--output-dir", str(out_dir), "--json", str(video)],
+            )
+        assert result.exit_code == 0, result.output
+        assert json.loads(result.output)["count"] == 5
+
+        # Second run: only 2 frames — stale files from first run must not appear.
+        with (
+            patch("shutil.which", return_value="/usr/bin/ffmpeg"),
+            patch("subprocess.run", side_effect=_make_fake_ffmpeg(out_dir, n_frames=2)),
+        ):
+            result = runner.invoke(
+                video_frames_cmd,
+                ["--output-dir", str(out_dir), "--json", str(video)],
+            )
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["count"] == 2, (
+            f"expected 2 frames, got {data['count']} (stale files leaked)"
+        )


### PR DESCRIPTION
## Summary

- Adds `gptme-util computer video-frames <INPUT>` subcommand to the `gptme-util computer` group
- Uses ffmpeg (already used by gptme for audio) to extract PNG frames from any video file at a configurable rate
- Follows the same patterns as the recently merged `computer screenshot` command (#3060)

## Use cases

- Review CI failure screen recordings: extract frames → ask gptme "what went wrong in step 3?"
- Attach a screen recording of a UI bug as before/after frame pairs in a bug report
- Replay multi-step UI regressions without manual video scrubbing

## CLI interface

\`\`\`
gptme-util computer video-frames recording.mp4
gptme-util computer video-frames recording.mp4 --fps 0.5 --limit 5
gptme-util computer video-frames recording.mp4 --output-dir /tmp/frames --json
\`\`\`

Options:
- `--fps` — Frames per second to extract (default: 1.0)
- `--limit N` — Maximum number of frames to extract
- `--output-dir / -o` — Directory for output PNGs (default: auto temp dir)
- `--json` — Output JSON `{"frames": [...], "count": N, "fps": F}` instead of one path per line

## Tests

13 unit tests (no ffmpeg required, all subprocess calls mocked) covering:
basic extraction, JSON output, fps/limit passed correctly to ffmpeg, missing ffmpeg, missing input file, ffmpeg error and timeout, no frames produced, invalid options, output dir creation, and parametrized frame-count validation.