### PR TITLE
fix(ci): harden Build workflow against broken Ubuntu apt sources

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -172,6 +172,8 @@ jobs:
     - name: Install system dependencies (Ubuntu)
       if: runner.os == 'Linux'
       run: |
+        # GitHub's Ubuntu runner image can ship Microsoft apt sources that 403.
+        sudo rm -f /etc/apt/sources.list.d/azure-cli.list /etc/apt/sources.list.d/microsoft-prod.list
         sudo apt-get update
         sudo apt-get install -y python3-dev build-essential libffi-dev
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -173,7 +173,7 @@ jobs:
       if: runner.os == 'Linux'
       run: |
         # GitHub's Ubuntu runner image can ship Microsoft apt sources that 403.
-        sudo rm -f /etc/apt/sources.list.d/azure-cli.list /etc/apt/sources.list.d/microsoft-prod.list
+        sudo rm -f /etc/apt/sources.list.d/microsoft*.list
         sudo apt-get update
         sudo apt-get install -y python3-dev build-essential libffi-dev
 


### PR DESCRIPTION
## Summary
- remove the preinstalled Microsoft apt source files before `apt-get update` in the Build workflow Ubuntu job
- keep the workaround scoped to the failing workflow instead of changing unrelated jobs

## Why
The `Build` workflow on `master` failed on July 3, 2026 in run `28678449508` before project code executed.

`apt-get update` failed on the GitHub Ubuntu runner because these preinstalled third-party repos returned `403 Forbidden`:
- `https://packages.microsoft.com/repos/azure-cli`
- `https://packages.microsoft.com/ubuntu/24.04/prod`

Those repos are not needed for this job; removing them makes the workflow resilient to that runner-image breakage.
