### PR TITLE
docs: add a narrated walkthrough to the documentation landing page

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,6 +21,14 @@ See the `README <https://github.com/gptme/gptme/blob/master/README.md>`_ file fo
 .. note::
     This documentation site is still under construction.
 
+.. raw:: html
+
+   <div style="position:relative;padding-bottom:56.25%;height:0;overflow:hidden;max-width:100%;margin:1.5rem 0;border-radius:10px;border:1px solid rgba(128,128,128,0.2);box-shadow:0 4px 20px rgba(0,0,0,0.15);">
+     <iframe src="https://bisque.cloud/p/github/gptme-gptme" title="gptme — narrated walkthrough" loading="lazy"
+       style="position:absolute;top:0;left:0;width:100%;height:100%;border:0;"
+       allow="autoplay; fullscreen; encrypted-media" allowfullscreen></iframe>
+   </div>
+
 .. toctree::
    :maxdepth: 2
    :caption: User Guide


### PR DESCRIPTION
## What this adds

A short (~2 min) narrated walkthrough embedded near the top of the docs landing page — a quick "what is gptme + the agent loop" tour: how a task flows User → Assistant (a codeblock) → System (the output) and repeats until it's done, plus running it interactively and one-shot. A fast orientation for first-time visitors before the guide.

It's a single responsive, lazy-loaded `<iframe>` (via a `.. raw:: html` directive) embedding a Bisque-hosted presentation — no scripts, no dependencies, no `conf.py` or theme changes. One file changed (`docs/index.rst`), eight lines added.

## Notes

- Everything shown was re-checked against the current docs and README — install via pipx/uv/the installer, interactive and one-shot use, the self-correcting `make test | gptme ...` loop, and the built-in tools.
- Docs-only change.

Happy to adjust the placement or wording, or close it if it's not a fit. If useful I can do short per-topic walkthroughs (tools, custom tools, agents) too.

Preview of the embedded presentation: https://bisque.cloud/p/github/gptme-gptme
