### PR TITLE
feat(chats): add --all-agents flag to search Cursor and Codex sessions

### DIFF
--- a/gptme/cli/cmd_chats.py
+++ b/gptme/cli/cmd_chats.py
@@ -151,6 +151,12 @@ def chats_search(
     _ensure_tools()
 
     if output_json:
+        if all_agents:
+            click.echo(
+                "Warning: --all-agents is not supported with --json; "
+                "only gptme native sessions will be included.",
+                err=True,
+            )
         from ..logmanager import LogManager, list_conversations  # fmt: skip
         from ..tools.chats import _get_matching_messages  # fmt: skip
 

--- a/gptme/cli/cmd_chats.py
+++ b/gptme/cli/cmd_chats.py
@@ -12,7 +12,12 @@ from ..logmanager import LogManager
 from ..logmanager.conversations import ConversationMeta
 from ..prompt_queue import queue_prompt
 from ..tools import get_tools, init_tools
-from ..tools.chats import find_empty_conversations, list_chats, search_chats
+from ..tools.chats import (
+    find_empty_conversations,
+    list_chats,
+    search_chats,
+    search_external_chats,
+)
 from ..util.conversation_ids import is_valid_conversation_id
 
 
@@ -126,6 +131,11 @@ def chats_list(limit: int, summarize: bool, output_json: bool, metadata: bool):
 @click.option(
     "-m", "--matches", default=1, help="Maximum matches to show per conversation."
 )
+@click.option(
+    "--all-agents",
+    is_flag=True,
+    help="Also search Cursor and Codex CLI sessions (reads ~/.cursor/ and ~/.codex/).",
+)
 def chats_search(
     query: str,
     limit: int,
@@ -133,6 +143,7 @@ def chats_search(
     output_json: bool,
     context: int,
     matches: int,
+    all_agents: bool,
 ):
     """Search conversation logs."""
     if not query.strip():
@@ -177,6 +188,8 @@ def chats_search(
             tool_format="markdown",
         )
     search_chats(query, max_results=limit, context_lines=context, max_matches=matches)
+    if all_agents:
+        search_external_chats(query, max_results=limit)
 
 
 @chats.command("read")

--- a/gptme/tools/chats.py
+++ b/gptme/tools/chats.py
@@ -154,14 +154,24 @@ def search_chats(
 def _discover_cursor_sessions(cursor_dir: Path | None = None) -> list[Path]:
     """Return paths to Cursor conversation files under *cursor_dir*.
 
-    Looks for ``<cursor_dir>/<uuid>/conversation.json`` (the standard Cursor
-    conversation format).  Pass *cursor_dir* explicitly in tests.
+    Looks for:
+
+    - ``<cursor_dir>/<uuid>/conversation.json`` (standard per-session format)
+    - ``<cursor_dir>/../cursor-chat-history.json`` (alternate workspace-storage
+      format with ``allConversations`` array)
+
+    Pass *cursor_dir* explicitly in tests.
     """
     if cursor_dir is None:
         cursor_dir = Path.home() / ".cursor" / "conversations"
     if not cursor_dir.exists():
         return []
-    return sorted(cursor_dir.glob("*/conversation.json"))
+    results: list[Path] = sorted(cursor_dir.glob("*/conversation.json"))
+    # cursor-chat-history.json lives at the .cursor/ root, not under conversations/
+    alt = cursor_dir.parent / "cursor-chat-history.json"
+    if alt.exists():
+        results.append(alt)
+    return results
 
 
 def _search_cursor_session(path: Path, query: str) -> list[dict]:
@@ -304,6 +314,8 @@ def search_external_chats(
 
     if include_cursor:
         for session_path in _discover_cursor_sessions(cursor_dir):
+            if len(all_results) >= max_results:
+                break
             matches = _search_cursor_session(session_path, query)
             if matches:
                 all_results.append(
@@ -312,6 +324,8 @@ def search_external_chats(
 
     if include_codex:
         for session_path in _discover_codex_sessions(codex_dir):
+            if len(all_results) >= max_results:
+                break
             matches = _search_codex_session(session_path, query)
             if matches:
                 all_results.append(

--- a/gptme/tools/chats.py
+++ b/gptme/tools/chats.py
@@ -146,6 +146,197 @@ def search_chats(
             print(f"     {match_str}")
 
 
+# ---------------------------------------------------------------------------
+# External agent session search (Cursor, Codex)
+# ---------------------------------------------------------------------------
+
+
+def _discover_cursor_sessions(cursor_dir: Path | None = None) -> list[Path]:
+    """Return paths to Cursor conversation files under *cursor_dir*.
+
+    Looks for ``<cursor_dir>/<uuid>/conversation.json`` (the standard Cursor
+    conversation format).  Pass *cursor_dir* explicitly in tests.
+    """
+    if cursor_dir is None:
+        cursor_dir = Path.home() / ".cursor" / "conversations"
+    if not cursor_dir.exists():
+        return []
+    return sorted(cursor_dir.glob("*/conversation.json"))
+
+
+def _search_cursor_session(path: Path, query: str) -> list[dict]:
+    """Search a single Cursor ``conversation.json`` for *query*.
+
+    Handles both the standard format (``messages`` list) and the alternate
+    workspace-storage format (``allConversations`` / ``bubbles``).
+    Returns a list of hit dicts with keys ``role``, ``content``,
+    ``session_title``.
+    """
+    try:
+        data = json_mod.loads(path.read_text(encoding="utf-8"))
+    except (json_mod.JSONDecodeError, OSError):
+        return []
+
+    query_lower = query.lower()
+    results: list[dict] = []
+
+    # Standard format: {"title": "...", "messages": [{"role": ..., "content": ...}]}
+    for msg in data.get("messages", []):
+        role = msg.get("role", "unknown")
+        content = msg.get("content", "")
+        if not isinstance(content, str):
+            continue
+        if query_lower in content.lower():
+            results.append(
+                {
+                    "role": role,
+                    "content": content[:500],
+                    "session_title": data.get("title", path.parent.name),
+                }
+            )
+
+    # Alternate format (cursor-chat-history.json):
+    # {"allConversations": [{"composerId": "...", "bubbles": [...]}]}
+    if not results:
+        for conv in data.get("allConversations", []):
+            for bubble in conv.get("bubbles", []):
+                btype = bubble.get("type", "")
+                if btype == "user":
+                    content = bubble.get("text", "")
+                    role = "user"
+                elif btype == "ai":
+                    raw = bubble.get("rawResponse", {})
+                    content = raw.get("text", "") if isinstance(raw, dict) else ""
+                    role = "assistant"
+                else:
+                    continue
+                if not isinstance(content, str):
+                    continue
+                if query_lower in content.lower():
+                    results.append(
+                        {
+                            "role": role,
+                            "content": content[:500],
+                            "session_title": conv.get("composerId", path.parent.name),
+                        }
+                    )
+
+    return results
+
+
+def _discover_codex_sessions(codex_dir: Path | None = None) -> list[Path]:
+    """Return paths to Codex CLI session files under *codex_dir*.
+
+    Looks for ``<codex_dir>/<session-id>.jsonl``.  Pass *codex_dir*
+    explicitly in tests.
+    """
+    if codex_dir is None:
+        codex_dir = Path.home() / ".codex" / "sessions"
+    if not codex_dir.exists():
+        return []
+    return sorted(codex_dir.glob("*.jsonl"))
+
+
+def _search_codex_session(path: Path, query: str) -> list[dict]:
+    """Search a Codex CLI ``.jsonl`` session file for *query*.
+
+    Each line is a JSON record.  Only ``{"type": "message", ...}`` records
+    are searched; tool-call records are skipped.  Returns a list of hit
+    dicts with keys ``role``, ``content``, ``session_title``.
+    """
+    query_lower = query.lower()
+    results: list[dict] = []
+    try:
+        for line in path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                record = json_mod.loads(line)
+            except json_mod.JSONDecodeError:
+                continue
+            if record.get("type") != "message":
+                continue
+            role = record.get("role", "unknown")
+            content = record.get("content", "")
+            if not isinstance(content, str):
+                continue
+            if query_lower in content.lower():
+                results.append(
+                    {
+                        "role": role,
+                        "content": content[:500],
+                        "session_title": path.stem,
+                    }
+                )
+    except OSError:
+        pass
+    return results
+
+
+def search_external_chats(
+    query: str,
+    max_results: int = 5,
+    include_cursor: bool = True,
+    include_codex: bool = True,
+    cursor_dir: Path | None = None,
+    codex_dir: Path | None = None,
+) -> None:
+    """Search external agent sessions (Cursor, Codex) for *query*.
+
+    Prints matching snippets grouped by source agent, with a ``[Cursor]``
+    or ``[Codex]`` label so results are clearly distinguished from gptme
+    native results.
+
+    Args:
+        query: The search query (case-insensitive substring match).
+        max_results: Maximum number of sessions to display.
+        include_cursor: Whether to search Cursor sessions.
+        include_codex: Whether to search Codex sessions.
+        cursor_dir: Override the default Cursor conversations directory.
+        codex_dir: Override the default Codex sessions directory.
+    """
+    if not query.strip():
+        print("Error: search query cannot be empty.", file=sys.stderr)
+        return
+
+    all_results: list[dict] = []
+
+    if include_cursor:
+        for session_path in _discover_cursor_sessions(cursor_dir):
+            matches = _search_cursor_session(session_path, query)
+            if matches:
+                all_results.append(
+                    {"agent": "Cursor", "path": session_path, "matches": matches}
+                )
+
+    if include_codex:
+        for session_path in _discover_codex_sessions(codex_dir):
+            matches = _search_codex_session(session_path, query)
+            if matches:
+                all_results.append(
+                    {"agent": "Codex", "path": session_path, "matches": matches}
+                )
+
+    if not all_results:
+        return
+
+    total_matches = sum(len(r["matches"]) for r in all_results)
+    shown = all_results[:max_results]
+    print(
+        f"\nExternal agent results for '{query}' "
+        f"({len(all_results)} sessions, {total_matches} matches):"
+    )
+    for i, result in enumerate(shown, 1):
+        agent = result["agent"]
+        matches = result["matches"]
+        title = matches[0]["session_title"] if matches else result["path"].stem
+        print(f"\n{i}. [{agent}] {title} ({len(matches)} match(es)):")
+        for match in matches[:1]:
+            snippet = match["content"][:200].replace("\n", " ")
+            print(f"   ({match['role']}): {snippet}…")
+
+
 def _format_message_with_context(
     content: str | object, query: str, context_lines: int = 1, max_matches: int = 1
 ) -> str:

--- a/gptme/tools/chats.py
+++ b/gptme/tools/chats.py
@@ -237,22 +237,27 @@ def _search_cursor_session(path: Path, query: str) -> list[dict]:
 def _discover_codex_sessions(codex_dir: Path | None = None) -> list[Path]:
     """Return paths to Codex CLI session files under *codex_dir*.
 
-    Looks for ``<codex_dir>/<session-id>.jsonl``.  Pass *codex_dir*
-    explicitly in tests.
+    Real Codex CLI sessions are date-partitioned as
+    ``<codex_dir>/YYYY/MM/DD/rollout-*.jsonl``, so this searches recursively.
+    Pass *codex_dir* explicitly in tests.
     """
     if codex_dir is None:
         codex_dir = Path.home() / ".codex" / "sessions"
     if not codex_dir.exists():
         return []
-    return sorted(codex_dir.glob("*.jsonl"))
+    return sorted(codex_dir.rglob("rollout-*.jsonl"))
 
 
 def _search_codex_session(path: Path, query: str) -> list[dict]:
     """Search a Codex CLI ``.jsonl`` session file for *query*.
 
-    Each line is a JSON record.  Only ``{"type": "message", ...}`` records
-    are searched; tool-call records are skipped.  Returns a list of hit
-    dicts with keys ``role``, ``content``, ``session_title``.
+    Each line is a JSON record. Only ``{"type": "response_item", "payload":
+    {"type": "message", ...}}`` records are searched; other record types
+    (``session_meta``, ``event_msg``, ``turn_context``, tool calls, etc.) are
+    skipped. Message content is a list of content-part dicts (``input_text``
+    / ``output_text``) whose ``text`` fields are joined before matching.
+    Returns a list of hit dicts with keys ``role``, ``content``,
+    ``session_title``.
     """
     query_lower = query.lower()
     results: list[dict] = []
@@ -265,12 +270,18 @@ def _search_codex_session(path: Path, query: str) -> list[dict]:
                 record = json_mod.loads(line)
             except json_mod.JSONDecodeError:
                 continue
-            if record.get("type") != "message":
+            if record.get("type") != "response_item":
                 continue
-            role = record.get("role", "unknown")
-            content = record.get("content", "")
-            if not isinstance(content, str):
+            payload = record.get("payload", {})
+            if not isinstance(payload, dict) or payload.get("type") != "message":
                 continue
+            role = payload.get("role", "unknown")
+            parts = payload.get("content", [])
+            if not isinstance(parts, list):
+                continue
+            content = "".join(
+                part.get("text", "") for part in parts if isinstance(part, dict)
+            )
             if query_lower in content.lower():
                 results.append(
                     {

--- a/tests/test_chats_external_search.py
+++ b/tests/test_chats_external_search.py
@@ -1,0 +1,313 @@
+"""Tests for external agent session search (Cursor, Codex)."""
+
+import json
+
+from click.testing import CliRunner
+
+from gptme.cli.cmd_chats import chats
+from gptme.tools.chats import (
+    _discover_codex_sessions,
+    _discover_cursor_sessions,
+    _search_codex_session,
+    _search_cursor_session,
+    search_external_chats,
+)
+
+# ---------------------------------------------------------------------------
+# Cursor — discovery
+# ---------------------------------------------------------------------------
+
+
+def test_discover_cursor_sessions_missing_dir(tmp_path):
+    """Returns empty list when directory does not exist."""
+    assert _discover_cursor_sessions(tmp_path / "nonexistent") == []
+
+
+def test_discover_cursor_sessions(tmp_path):
+    """Discovers conversation.json files in cursor_dir."""
+    session_dir = tmp_path / "abc-123"
+    session_dir.mkdir()
+    conv_file = session_dir / "conversation.json"
+    conv_file.write_text(json.dumps({"id": "abc", "messages": []}))
+    assert _discover_cursor_sessions(tmp_path) == [conv_file]
+
+
+def test_discover_cursor_sessions_multiple(tmp_path):
+    """Returns all conversation.json files sorted alphabetically."""
+    for uid in ("bbb-222", "aaa-111"):
+        d = tmp_path / uid
+        d.mkdir()
+        (d / "conversation.json").write_text("{}")
+    results = _discover_cursor_sessions(tmp_path)
+    assert len(results) == 2
+    assert results[0].parent.name == "aaa-111"
+
+
+# ---------------------------------------------------------------------------
+# Cursor — search (standard format)
+# ---------------------------------------------------------------------------
+
+
+def test_search_cursor_session_match(tmp_path):
+    """Finds matching messages in standard Cursor format."""
+    d = tmp_path / "abc-123"
+    d.mkdir()
+    f = d / "conversation.json"
+    f.write_text(
+        json.dumps(
+            {
+                "id": "abc",
+                "title": "Debug CORS",
+                "messages": [
+                    {"id": "1", "role": "user", "content": "I have a CORS error"},
+                    {
+                        "id": "2",
+                        "role": "assistant",
+                        "content": "Let me fix CORS for you",
+                    },
+                ],
+            }
+        )
+    )
+    results = _search_cursor_session(f, "CORS")
+    assert len(results) == 2
+    assert results[0]["role"] == "user"
+    assert results[1]["role"] == "assistant"
+    assert results[0]["session_title"] == "Debug CORS"
+
+
+def test_search_cursor_session_no_match(tmp_path):
+    """Returns empty list when no messages match."""
+    d = tmp_path / "abc-123"
+    d.mkdir()
+    f = d / "conversation.json"
+    f.write_text(json.dumps({"messages": [{"role": "user", "content": "Hello world"}]}))
+    assert _search_cursor_session(f, "CORS") == []
+
+
+def test_search_cursor_session_case_insensitive(tmp_path):
+    """Query matching is case-insensitive."""
+    d = tmp_path / "abc-123"
+    d.mkdir()
+    f = d / "conversation.json"
+    f.write_text(
+        json.dumps({"messages": [{"role": "user", "content": "cors problem"}]})
+    )
+    assert len(_search_cursor_session(f, "CORS")) == 1
+
+
+def test_search_cursor_session_invalid_json(tmp_path):
+    """Handles invalid JSON gracefully and returns empty list."""
+    d = tmp_path / "abc-123"
+    d.mkdir()
+    f = d / "conversation.json"
+    f.write_text("not valid json")
+    assert _search_cursor_session(f, "anything") == []
+
+
+# ---------------------------------------------------------------------------
+# Cursor — search (alternate workspace-storage format)
+# ---------------------------------------------------------------------------
+
+
+def test_search_cursor_session_alternate_format(tmp_path):
+    """Handles cursor-chat-history.json / allConversations format."""
+    d = tmp_path / "abc-123"
+    d.mkdir()
+    f = d / "cursor-chat-history.json"
+    f.write_text(
+        json.dumps(
+            {
+                "allConversations": [
+                    {
+                        "composerId": "comp-1",
+                        "bubbles": [
+                            {"type": "user", "text": "Fix CORS headers please"},
+                            {
+                                "type": "ai",
+                                "rawResponse": {
+                                    "text": "Add CORS headers to the response"
+                                },
+                            },
+                        ],
+                    }
+                ]
+            }
+        )
+    )
+    results = _search_cursor_session(f, "CORS")
+    assert len(results) == 2
+    assert results[0]["role"] == "user"
+    assert results[1]["role"] == "assistant"
+    assert results[0]["session_title"] == "comp-1"
+
+
+# ---------------------------------------------------------------------------
+# Codex — discovery
+# ---------------------------------------------------------------------------
+
+
+def test_discover_codex_sessions_missing_dir(tmp_path):
+    """Returns empty list when directory does not exist."""
+    assert _discover_codex_sessions(tmp_path / "nonexistent") == []
+
+
+def test_discover_codex_sessions(tmp_path):
+    """Discovers .jsonl files in codex_dir."""
+    f = tmp_path / "abc-def.jsonl"
+    f.write_text('{"type":"message","role":"user","content":"hello"}')
+    assert _discover_codex_sessions(tmp_path) == [f]
+
+
+def test_discover_codex_sessions_multiple(tmp_path):
+    """Returns all .jsonl files sorted alphabetically."""
+    for name in ("session-b.jsonl", "session-a.jsonl"):
+        (tmp_path / name).write_text("{}")
+    results = _discover_codex_sessions(tmp_path)
+    assert len(results) == 2
+    assert results[0].name == "session-a.jsonl"
+
+
+# ---------------------------------------------------------------------------
+# Codex — search
+# ---------------------------------------------------------------------------
+
+
+def test_search_codex_session_match(tmp_path):
+    """Finds matching message records in Codex JSONL format."""
+    f = tmp_path / "sess-1.jsonl"
+    f.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "type": "message",
+                        "role": "user",
+                        "content": "Create a CORS middleware",
+                        "timestamp": "2026-07-01T10:00:00Z",
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "message",
+                        "role": "assistant",
+                        "content": "Here is a CORS middleware example",
+                        "timestamp": "2026-07-01T10:00:05Z",
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "tool_call",
+                        "name": "bash",
+                        "input": {"command": "echo test"},
+                    }
+                ),
+            ]
+        )
+    )
+    results = _search_codex_session(f, "CORS")
+    assert len(results) == 2
+    assert results[0]["role"] == "user"
+    assert results[1]["role"] == "assistant"
+    assert results[0]["session_title"] == "sess-1"
+
+
+def test_search_codex_session_no_match(tmp_path):
+    """Returns empty list when no messages match."""
+    f = tmp_path / "sess-1.jsonl"
+    f.write_text(
+        json.dumps({"type": "message", "role": "user", "content": "Hello world"})
+    )
+    assert _search_codex_session(f, "CORS") == []
+
+
+def test_search_codex_session_invalid_json_line(tmp_path):
+    """Handles malformed JSON lines gracefully and continues."""
+    f = tmp_path / "sess-1.jsonl"
+    f.write_text(
+        "not valid json\n"
+        + json.dumps({"type": "message", "role": "user", "content": "CORS fix needed"})
+    )
+    results = _search_codex_session(f, "CORS")
+    assert len(results) == 1
+
+
+def test_search_codex_session_skips_tool_calls(tmp_path):
+    """Tool-call records are not searched."""
+    f = tmp_path / "sess-1.jsonl"
+    f.write_text(
+        json.dumps({"type": "tool_call", "name": "bash", "input": "CORS something"})
+    )
+    assert _search_codex_session(f, "CORS") == []
+
+
+# ---------------------------------------------------------------------------
+# search_external_chats — integration
+# ---------------------------------------------------------------------------
+
+
+def test_search_external_chats_no_results(tmp_path, capsys):
+    """Prints nothing when no external sessions match."""
+    search_external_chats(
+        "CORS",
+        cursor_dir=tmp_path / "cursor",
+        codex_dir=tmp_path / "codex",
+    )
+    captured = capsys.readouterr()
+    assert captured.out == ""
+
+
+def test_search_external_chats_cursor_match(tmp_path, capsys):
+    """Prints Cursor hits with [Cursor] label."""
+    cursor_dir = tmp_path / "cursor"
+    session_dir = cursor_dir / "abc-123"
+    session_dir.mkdir(parents=True)
+    (session_dir / "conversation.json").write_text(
+        json.dumps(
+            {
+                "title": "My CORS session",
+                "messages": [{"role": "user", "content": "CORS error help"}],
+            }
+        )
+    )
+    search_external_chats(
+        "CORS",
+        cursor_dir=cursor_dir,
+        codex_dir=tmp_path / "codex",
+    )
+    out = capsys.readouterr().out
+    assert "[Cursor]" in out
+    assert "My CORS session" in out
+
+
+def test_search_external_chats_codex_match(tmp_path, capsys):
+    """Prints Codex hits with [Codex] label."""
+    codex_dir = tmp_path / "codex"
+    codex_dir.mkdir(parents=True)
+    (codex_dir / "sess-xyz.jsonl").write_text(
+        json.dumps({"type": "message", "role": "user", "content": "CORS in codex"})
+    )
+    search_external_chats(
+        "CORS",
+        cursor_dir=tmp_path / "cursor",
+        codex_dir=codex_dir,
+    )
+    out = capsys.readouterr().out
+    assert "[Codex]" in out
+    assert "sess-xyz" in out
+
+
+# ---------------------------------------------------------------------------
+# CLI integration — --all-agents flag
+# ---------------------------------------------------------------------------
+
+
+def test_cli_chats_search_all_agents_no_external(tmp_path, monkeypatch, capsys):
+    """--all-agents flag runs without error when no external sessions exist."""
+    # Redirect home so no real ~/.cursor / ~/.codex are read
+    monkeypatch.setenv("HOME", str(tmp_path))
+    runner = CliRunner()
+    result = runner.invoke(chats, ["search", "CORS", "--all-agents"])
+    # The gptme search part may print "No results found" — that's fine.
+    # We only care that the command doesn't crash.
+    assert result.exit_code == 0 or "No results" in (result.output or "")

--- a/tests/test_chats_external_search.py
+++ b/tests/test_chats_external_search.py
@@ -179,19 +179,41 @@ def test_discover_codex_sessions_missing_dir(tmp_path):
 
 
 def test_discover_codex_sessions(tmp_path):
-    """Discovers .jsonl files in codex_dir."""
-    f = tmp_path / "abc-def.jsonl"
-    f.write_text('{"type":"message","role":"user","content":"hello"}')
+    """Discovers rollout-*.jsonl files under date-partitioned subdirs."""
+    session_dir = tmp_path / "2026" / "03" / "27"
+    session_dir.mkdir(parents=True)
+    f = session_dir / "rollout-2026-03-27T13-20-54-abc.jsonl"
+    f.write_text(
+        json.dumps(
+            {
+                "type": "response_item",
+                "payload": {"type": "message", "role": "user", "content": []},
+            }
+        )
+    )
     assert _discover_codex_sessions(tmp_path) == [f]
 
 
 def test_discover_codex_sessions_multiple(tmp_path):
-    """Returns all .jsonl files sorted alphabetically."""
-    for name in ("session-b.jsonl", "session-a.jsonl"):
-        (tmp_path / name).write_text("{}")
+    """Returns all rollout-*.jsonl files sorted, across date subdirs."""
+    for date, name in (
+        ("2026/03/27", "rollout-2026-03-27T00-00-00-b.jsonl"),
+        ("2026/03/26", "rollout-2026-03-26T00-00-00-a.jsonl"),
+    ):
+        d = tmp_path / date
+        d.mkdir(parents=True)
+        (d / name).write_text("{}")
     results = _discover_codex_sessions(tmp_path)
     assert len(results) == 2
-    assert results[0].name == "session-a.jsonl"
+    assert results[0].name == "rollout-2026-03-26T00-00-00-a.jsonl"
+
+
+def test_discover_codex_sessions_ignores_non_rollout_files(tmp_path):
+    """Ignores .jsonl files that don't match the rollout-*.jsonl pattern."""
+    session_dir = tmp_path / "2026" / "03" / "27"
+    session_dir.mkdir(parents=True)
+    (session_dir / "other.jsonl").write_text("{}")
+    assert _discover_codex_sessions(tmp_path) == []
 
 
 # ---------------------------------------------------------------------------
@@ -199,33 +221,35 @@ def test_discover_codex_sessions_multiple(tmp_path):
 # ---------------------------------------------------------------------------
 
 
+def _codex_message(role: str, text: str, part_type: str = "input_text") -> str:
+    """Build a real-shape Codex ``response_item``/``message`` JSONL line."""
+    return json.dumps(
+        {
+            "timestamp": "2026-07-01T10:00:00.000Z",
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": role,
+                "content": [{"type": part_type, "text": text}],
+            },
+        }
+    )
+
+
 def test_search_codex_session_match(tmp_path):
-    """Finds matching message records in Codex JSONL format."""
+    """Finds matching message records in real Codex response_item format."""
     f = tmp_path / "sess-1.jsonl"
     f.write_text(
         "\n".join(
             [
-                json.dumps(
-                    {
-                        "type": "message",
-                        "role": "user",
-                        "content": "Create a CORS middleware",
-                        "timestamp": "2026-07-01T10:00:00Z",
-                    }
+                _codex_message("user", "Create a CORS middleware"),
+                _codex_message(
+                    "assistant", "Here is a CORS middleware example", "output_text"
                 ),
                 json.dumps(
                     {
-                        "type": "message",
-                        "role": "assistant",
-                        "content": "Here is a CORS middleware example",
-                        "timestamp": "2026-07-01T10:00:05Z",
-                    }
-                ),
-                json.dumps(
-                    {
-                        "type": "tool_call",
-                        "name": "bash",
-                        "input": {"command": "echo test"},
+                        "type": "event_msg",
+                        "payload": {"type": "task_started", "turn_id": "abc"},
                     }
                 ),
             ]
@@ -241,28 +265,42 @@ def test_search_codex_session_match(tmp_path):
 def test_search_codex_session_no_match(tmp_path):
     """Returns empty list when no messages match."""
     f = tmp_path / "sess-1.jsonl"
-    f.write_text(
-        json.dumps({"type": "message", "role": "user", "content": "Hello world"})
-    )
+    f.write_text(_codex_message("user", "Hello world"))
     assert _search_codex_session(f, "CORS") == []
 
 
 def test_search_codex_session_invalid_json_line(tmp_path):
     """Handles malformed JSON lines gracefully and continues."""
     f = tmp_path / "sess-1.jsonl"
-    f.write_text(
-        "not valid json\n"
-        + json.dumps({"type": "message", "role": "user", "content": "CORS fix needed"})
-    )
+    f.write_text("not valid json\n" + _codex_message("user", "CORS fix needed"))
     results = _search_codex_session(f, "CORS")
     assert len(results) == 1
 
 
-def test_search_codex_session_skips_tool_calls(tmp_path):
-    """Tool-call records are not searched."""
+def test_search_codex_session_skips_non_message_records(tmp_path):
+    """Non-message record types (session_meta, event_msg, tool calls) are skipped."""
     f = tmp_path / "sess-1.jsonl"
     f.write_text(
-        json.dumps({"type": "tool_call", "name": "bash", "input": "CORS something"})
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "type": "session_meta",
+                        "payload": {"id": "abc", "cwd": "CORS something"},
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "response_item",
+                        "payload": {
+                            "type": "function_call",
+                            "name": "bash",
+                            "arguments": "CORS something",
+                        },
+                    }
+                ),
+            ]
+        )
     )
     assert _search_codex_session(f, "CORS") == []
 
@@ -349,15 +387,15 @@ def test_cli_chats_search_json_all_agents_warning(tmp_path, monkeypatch):
 
 def test_search_external_chats_codex_match(tmp_path, capsys):
     """Prints Codex hits with [Codex] label."""
-    codex_dir = tmp_path / "codex"
+    codex_dir = tmp_path / "codex" / "2026" / "03" / "27"
     codex_dir.mkdir(parents=True)
-    (codex_dir / "sess-xyz.jsonl").write_text(
-        json.dumps({"type": "message", "role": "user", "content": "CORS in codex"})
+    (codex_dir / "rollout-2026-03-27T00-00-00-sess-xyz.jsonl").write_text(
+        _codex_message("user", "CORS in codex")
     )
     search_external_chats(
         "CORS",
         cursor_dir=tmp_path / "cursor",
-        codex_dir=codex_dir,
+        codex_dir=tmp_path / "codex",
     )
     out = capsys.readouterr().out
     assert "[Codex]" in out

--- a/tests/test_chats_external_search.py
+++ b/tests/test_chats_external_search.py
@@ -32,6 +32,32 @@ def test_discover_cursor_sessions(tmp_path):
     assert _discover_cursor_sessions(tmp_path) == [conv_file]
 
 
+def test_discover_cursor_sessions_discovers_alternate_format(tmp_path):
+    """Discovers cursor-chat-history.json at parent level alongside conversation.json."""
+    conv_dir = tmp_path / "conversations"
+    conv_dir.mkdir()
+    session_dir = conv_dir / "abc-123"
+    session_dir.mkdir()
+    conv_file = session_dir / "conversation.json"
+    conv_file.write_text(json.dumps({"messages": []}))
+    alt_file = tmp_path / "cursor-chat-history.json"
+    alt_file.write_text(json.dumps({"allConversations": []}))
+    results = _discover_cursor_sessions(conv_dir)
+    assert conv_file in results
+    assert alt_file in results
+    assert len(results) == 2
+
+
+def test_discover_cursor_sessions_alternate_only(tmp_path):
+    """Returns only cursor-chat-history.json when conversation dir is empty."""
+    conv_dir = tmp_path / "conversations"
+    conv_dir.mkdir()
+    alt_file = tmp_path / "cursor-chat-history.json"
+    alt_file.write_text(json.dumps({"allConversations": []}))
+    results = _discover_cursor_sessions(conv_dir)
+    assert results == [alt_file]
+
+
 def test_discover_cursor_sessions_multiple(tmp_path):
     """Returns all conversation.json files sorted alphabetically."""
     for uid in ("bbb-222", "aaa-111"):
@@ -278,6 +304,47 @@ def test_search_external_chats_cursor_match(tmp_path, capsys):
     out = capsys.readouterr().out
     assert "[Cursor]" in out
     assert "My CORS session" in out
+
+
+def test_search_external_chats_early_exit(tmp_path, capsys):
+    """Stops scanning after max_results sessions are collected."""
+    cursor_dir = tmp_path / "cursor"
+    for i in range(10):
+        session_dir = cursor_dir / f"sess-{i:03d}"
+        session_dir.mkdir(parents=True)
+        (session_dir / "conversation.json").write_text(
+            json.dumps(
+                {
+                    "title": f"Session {i}",
+                    "messages": [{"role": "user", "content": f"CORS issue {i}"}],
+                }
+            )
+        )
+    search_external_chats(
+        "CORS",
+        max_results=3,
+        cursor_dir=cursor_dir,
+        codex_dir=tmp_path / "codex",
+    )
+    out = capsys.readouterr().out
+    session_count = out.count("[Cursor]")
+    assert session_count <= 3, (
+        f"Expected ≤3 Cursor sessions in output, got {session_count}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI integration — --all-agents with --json
+# ---------------------------------------------------------------------------
+
+
+def test_cli_chats_search_json_all_agents_warning(tmp_path, monkeypatch):
+    """--all-agents with --json prints a warning and still succeeds."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    runner = CliRunner()
+    result = runner.invoke(chats, ["search", "CORS", "--json", "--all-agents"])
+    assert result.exit_code == 0
+    assert "Warning: --all-agents is not supported with --json" in result.output
 
 
 def test_search_external_chats_codex_match(tmp_path, capsys):


### PR DESCRIPTION
## Summary

- Adds `--all-agents` flag to `gptme-util chats search` that also searches Cursor and Codex CLI session history alongside gptme native logs
- Supports Cursor (`~/.cursor/conversations/*/conversation.json`, both standard and alternate `allConversations` format) and Codex CLI (`~/.codex/sessions/*.jsonl`)
- Results printed with `[Cursor]` / `[Codex]` labels to distinguish from native gptme results
- 19 offline unit tests covering discovery, parsing, error handling, case-insensitivity, and CLI integration

## Motivation

ctx/cass already cover 8–22 agent history sources as search targets. gptme currently only searches its own sessions. Cursor and Codex CLI are the two most common tools developers use alongside gptme; adding them to `gptme-util chats search` means a developer who switched from Cursor to gptme can find old sessions without installing a separate tool.

## Usage

```bash
# Search only gptme native sessions (existing behaviour, unchanged)
gptme-util chats search "CORS bug"

# Also search Cursor and Codex CLI history
gptme-util chats search "CORS bug" --all-agents
```

## Files changed

- `gptme/tools/chats.py` — five new functions: `_discover_cursor_sessions`, `_search_cursor_session`, `_discover_codex_sessions`, `_search_codex_session`, `search_external_chats`
- `gptme/cli/cmd_chats.py` — `--all-agents` flag wired to `search_external_chats()`
- `tests/test_chats_external_search.py` — 19 new offline tests (no network, no credentials)

## Test plan
- [x] `pytest tests/test_chats_external_search.py --noconftest` — 19/19 pass
- [x] Pre-commit (ruff, mypy) pass
- [ ] Manual smoke test with a real Cursor install (not available in CI)