### PR TITLE
feat(browser): add session persistence via GPTME_BROWSER_STORAGE_STATE (#216)

### DIFF
--- a/docs/howto/computer-use.md
+++ b/docs/howto/computer-use.md
@@ -72,6 +72,43 @@ gptme --agent-profile computer-use \
   'go to the login form at http://localhost:3000/login, fill username "alice" and password "hunter2", click submit'
 ```
 
+## Authenticated sessions (save and reuse login state)
+
+For sites that require a login — Twitter/X, GitHub, your app — log in once and
+save the session so future runs start already authenticated.
+
+**Step 1: Log in and save the session**
+
+```bash
+gptme --agent-profile computer-use \
+  'open https://x.com/login, fill username and password, click Log in, then call save_browser_state("~/.config/gptme/twitter-session.json")'
+```
+
+Or interactively from IPython inside a gptme session:
+
+```python
+open_page("https://x.com/login")
+fill_element("#username", "yourhandle")
+click_element("text=Next")
+fill_element("[name='password']", "yourpassword")
+click_element("text=Log in")
+save_browser_state("~/.config/gptme/twitter-session.json")
+```
+
+**Step 2: Load the session in future runs**
+
+```bash
+export GPTME_BROWSER_STORAGE_STATE=~/.config/gptme/twitter-session.json
+gptme --agent-profile computer-use 'go to https://x.com/compose/tweet, type "Hello from gptme!", and click Post'
+```
+
+Every `open_page()`, `snapshot_url()`, and `read_url()` call will now start with
+the saved cookies and localStorage, so the site sees you as already logged in.
+
+> **Security note**: The session file contains your browser cookies in plain
+> text. Store it with restricted permissions (`chmod 600`) and keep it out of
+> version control.
+
 ## Desktop / native app control
 
 For native apps or anything not reachable via a URL, the `computer` tool takes over:

--- a/gptme/tools/_browser_playwright.py
+++ b/gptme/tools/_browser_playwright.py
@@ -649,6 +649,7 @@ def _do_save_browser_state(browser: Browser, path: str) -> str:
     resolved = Path(path).expanduser()
     resolved.parent.mkdir(parents=True, exist_ok=True)
     ctx.storage_state(path=str(resolved))
+    os.chmod(resolved, 0o600)
     return f"Browser session state saved to {resolved}"
 
 

--- a/gptme/tools/_browser_playwright.py
+++ b/gptme/tools/_browser_playwright.py
@@ -24,9 +24,9 @@ from playwright.sync_api import (
 
 from ._browser_format import format_snapshot as _format_snapshot
 from ._browser_thread import (
-    DEFAULT_CONTEXT_OPTIONS,
     BrowserThread,
     _is_connection_error,
+    get_context_options,
 )
 
 _browser: BrowserThread | None = None
@@ -161,7 +161,7 @@ def _load_page(browser: Browser, url: str) -> str:
 
     managed = _create_page(
         browser,
-        **DEFAULT_CONTEXT_OPTIONS,
+        **get_context_options(),
         extra_http_headers={
             # Prefer markdown and plaintext over HTML for better LLM consumption
             # Quality values (q) indicate preference order
@@ -362,7 +362,7 @@ def _search_google(browser: Browser, query: str) -> str:
     query = urllib.parse.quote(query)
     url = f"https://www.google.com/search?q={query}&hl=en"
 
-    managed = _create_page(browser, **DEFAULT_CONTEXT_OPTIONS)
+    managed = _create_page(browser, **get_context_options())
     page = managed.page
     try:
         page.goto(url)
@@ -391,7 +391,7 @@ def search_google(query: str) -> str:
 def _search_duckduckgo(browser: Browser, query: str) -> str:
     url = f"https://html.duckduckgo.com/html?q={query}"
 
-    managed = _create_page(browser, **DEFAULT_CONTEXT_OPTIONS)
+    managed = _create_page(browser, **get_context_options())
     page = managed.page
     try:
         page.goto(url)
@@ -604,7 +604,7 @@ def _open_page(browser: Browser, url: str) -> str:
 
     managed = _create_page(
         browser,
-        **DEFAULT_CONTEXT_OPTIONS,
+        **get_context_options(),
         extra_http_headers={
             "Accept": "text/markdown, text/plain, text/html;q=0.9, */*;q=0.8"
         },
@@ -633,6 +633,54 @@ def close_page() -> str:
     if _current_page is None:
         return "No page is currently open."
     return _execute_with_retry(_do_close_page)
+
+
+def _do_save_browser_state(browser: Browser, path: str) -> str:
+    """Save current browser session state (cookies + localStorage) to a JSON file."""
+    ctx: BrowserContext | None = _current_context
+    if ctx is None and _browser is not None and _browser._session_context is not None:
+        # CDP mode — the active context is the shared session context.
+        ctx = _browser._session_context
+    if ctx is None:
+        raise RuntimeError(
+            "No browser context is active. Call open_page(url) first to open a page "
+            "and authenticate, then save the session state."
+        )
+    resolved = Path(path).expanduser()
+    resolved.parent.mkdir(parents=True, exist_ok=True)
+    ctx.storage_state(path=str(resolved))
+    return f"Browser session state saved to {resolved}"
+
+
+def save_browser_state(path: str) -> str:
+    """Save the current browser session state (cookies, localStorage) to a file.
+
+    Captures the full authentication state of the active browser context so it can
+    be restored in a future session via ``GPTME_BROWSER_STORAGE_STATE``.
+
+    Typical workflow::
+
+        # 1. Open the page and log in manually or via fill_element/click_element:
+        open_page("https://x.com/login")
+        fill_element("#username", "you@example.com")
+        fill_element("#password", "hunter2")
+        click_element("text=Log in")
+
+        # 2. Verify you're logged in, then save the session:
+        save_browser_state("~/.config/gptme/twitter-session.json")
+
+        # 3. Future sessions load it automatically:
+        #    export GPTME_BROWSER_STORAGE_STATE=~/.config/gptme/twitter-session.json
+
+    Args:
+        path: File path to write the session JSON. Parent directories are
+              created automatically. ``~`` is expanded.
+
+    Returns:
+        Confirmation string with the absolute path where the state was saved.
+    """
+    logger.info("Saving browser session state to %s", path)
+    return _execute_with_retry(_do_save_browser_state, path)
 
 
 def open_page(url: str) -> str:

--- a/gptme/tools/_browser_thread.py
+++ b/gptme/tools/_browser_thread.py
@@ -185,9 +185,7 @@ class BrowserThread:
                 # gptme instances don't share cookies/tabs. Recreated on every
                 # (re)connect so it never points at a dead browser.
                 if self.cdp_url:
-                    self._session_context = browser.new_context(
-                        **DEFAULT_CONTEXT_OPTIONS
-                    )
+                    self._session_context = browser.new_context(**get_context_options())
                     logger.info("Created isolated session context for CDP connection")
                 return None
             except Exception as e:

--- a/gptme/tools/_browser_thread.py
+++ b/gptme/tools/_browser_thread.py
@@ -3,6 +3,7 @@ import logging
 import time
 from collections.abc import Callable
 from dataclasses import dataclass
+from pathlib import Path
 from queue import Empty, Queue
 from threading import Event, Lock, Thread
 from typing import Any, Literal, TypeVar, cast
@@ -30,6 +31,40 @@ DEFAULT_CONTEXT_OPTIONS: dict[str, Any] = {
     "geolocation": {"latitude": 37.773972, "longitude": 13.39},
     "permissions": ["geolocation"],
 }
+
+
+def get_context_options() -> dict[str, Any]:
+    """Return browser context options, optionally loading a saved session state.
+
+    If ``GPTME_BROWSER_STORAGE_STATE`` points to an existing JSON file (previously
+    created by ``save_browser_state()``), the saved cookies and localStorage are
+    loaded into every new context — enabling authenticated sessions without
+    re-entering credentials on each invocation.
+
+    Typical workflow::
+
+        # 1. Open a browser manually and log in to the target site, then save state:
+        open_page("https://x.com")
+        save_browser_state("~/.config/gptme/twitter-session.json")
+
+        # 2. Next time, load the state automatically:
+        export GPTME_BROWSER_STORAGE_STATE=~/.config/gptme/twitter-session.json
+        gptme --agent-profile computer-use "tweet 'hello from gptme'"
+    """
+    options = dict(DEFAULT_CONTEXT_OPTIONS)
+    storage_path_raw = get_config().get_env("BROWSER_STORAGE_STATE")
+    if storage_path_raw:
+        storage_path = Path(storage_path_raw).expanduser()
+        if storage_path.exists():
+            options["storage_state"] = str(storage_path)
+            logger.info("Loading browser storage state from %s", storage_path)
+        else:
+            logger.warning(
+                "GPTME_BROWSER_STORAGE_STATE=%s does not exist — "
+                "starting with a fresh (unauthenticated) session",
+                storage_path_raw,
+            )
+    return options
 
 
 def _is_connection_error(error: Exception) -> bool:

--- a/gptme/tools/_browser_thread.py
+++ b/gptme/tools/_browser_thread.py
@@ -185,7 +185,9 @@ class BrowserThread:
                 # gptme instances don't share cookies/tabs. Recreated on every
                 # (re)connect so it never points at a dead browser.
                 if self.cdp_url:
-                    self._session_context = browser.new_context(**get_context_options())
+                    self._session_context = browser.new_context(
+                        **get_context_options()
+                    )
                     logger.info("Created isolated session context for CDP connection")
                 return None
             except Exception as e:

--- a/gptme/tools/browser.py
+++ b/gptme/tools/browser.py
@@ -356,6 +356,9 @@ if browser == "playwright":
     from ._browser_playwright import read_logs as read_logs_playwright  # fmt: skip
     from ._browser_playwright import read_page_text as read_page_text_pw  # fmt: skip
     from ._browser_playwright import read_url as read_url_playwright  # fmt: skip
+    from ._browser_playwright import (
+        save_browser_state as save_browser_state_pw,  # fmt: skip
+    )
     from ._browser_playwright import screenshot_url as screenshot_url_pw  # fmt: skip
     from ._browser_playwright import scroll_page as scroll_page_pw  # fmt: skip
     from ._browser_playwright import search_duckduckgo, search_google  # fmt: skip
@@ -958,6 +961,39 @@ def close_page() -> str:
     raise ValueError("Interactive browsing not supported with lynx backend")
 
 
+def save_browser_state(path: str) -> str:
+    """Save the current browser session (cookies, localStorage) to a file.
+
+    Captures the full authentication state of the active browser context so
+    it can be restored in a future session via ``GPTME_BROWSER_STORAGE_STATE``.
+
+    Call this after logging in to a site with open_page() + fill_element() +
+    click_element() so you don't have to re-authenticate next time.
+
+    Typical workflow::
+
+        open_page("https://x.com/login")
+        fill_element("#username", "you@example.com")
+        fill_element("#password", "hunter2")
+        click_element("text=Log in")
+        save_browser_state("~/.config/gptme/twitter-session.json")
+        # Next session: export GPTME_BROWSER_STORAGE_STATE=~/.config/gptme/twitter-session.json
+
+    Args:
+        path: File path to write the session JSON. Directories are created
+              automatically. ``~`` is expanded to the home directory.
+
+    Returns:
+        Confirmation string with the absolute path where the state was saved.
+    """
+    assert browser
+    if browser == "playwright":
+        return save_browser_state_pw(path)
+    raise ValueError(
+        "save_browser_state() is only supported with the playwright backend"
+    )
+
+
 def read_page_text() -> str:
     """Read the full text content of the current interactive page as Markdown.
 
@@ -1051,6 +1087,7 @@ services with APIs, prefer shell or Python over scraping.""",
             snapshot_url,
             open_page,
             close_page,
+            save_browser_state,
             read_page_text,
             click_element,
             fill_element,

--- a/tests/test_browser_session_persistence.py
+++ b/tests/test_browser_session_persistence.py
@@ -13,6 +13,10 @@ import os
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
+
+pytest.importorskip("playwright")
+
 # ---------------------------------------------------------------------------
 # Unit tests for get_context_options()
 # ---------------------------------------------------------------------------

--- a/tests/test_browser_session_persistence.py
+++ b/tests/test_browser_session_persistence.py
@@ -1,0 +1,194 @@
+"""Tests for browser session persistence via GPTME_BROWSER_STORAGE_STATE (#216).
+
+Validates that:
+- get_context_options() includes storage_state when the env var points to an
+  existing file, and omits it when the path doesn't exist.
+- save_browser_state() raises a clear error when no page is open.
+- The public browser.save_browser_state() wrapper delegates correctly.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+# ---------------------------------------------------------------------------
+# Unit tests for get_context_options()
+# ---------------------------------------------------------------------------
+
+
+def test_get_context_options_no_env_var():
+    """Without GPTME_BROWSER_STORAGE_STATE, storage_state key is absent."""
+    from gptme.tools._browser_thread import get_context_options
+
+    with patch.dict(os.environ, {}, clear=False):
+        # Remove the var if it happens to be set in the test environment
+        os.environ.pop("GPTME_BROWSER_STORAGE_STATE", None)
+        opts = get_context_options()
+    assert "storage_state" not in opts
+    # Base options must still be present
+    assert "locale" in opts
+
+
+def test_get_context_options_with_existing_file(tmp_path):
+    """When env var points to an existing file, storage_state is included."""
+    from gptme.tools._browser_thread import get_context_options
+
+    state_file = tmp_path / "session.json"
+    state_file.write_text('{"cookies": [], "origins": []}')
+
+    with patch.dict(os.environ, {"GPTME_BROWSER_STORAGE_STATE": str(state_file)}):
+        opts = get_context_options()
+
+    assert "storage_state" in opts
+    assert opts["storage_state"] == str(state_file)
+
+
+def test_get_context_options_with_missing_file(tmp_path):
+    """When env var points to a missing file, storage_state is NOT included (warn, don't crash)."""
+    from gptme.tools._browser_thread import get_context_options
+
+    missing = str(tmp_path / "nonexistent.json")
+
+    with patch.dict(os.environ, {"GPTME_BROWSER_STORAGE_STATE": missing}):
+        opts = get_context_options()
+
+    assert "storage_state" not in opts
+    # Base options still present
+    assert "locale" in opts
+
+
+def test_get_context_options_with_tilde_path(tmp_path, monkeypatch):
+    """~ in the path is expanded before existence check."""
+    from gptme.tools._browser_thread import get_context_options
+
+    # Point ~ at tmp_path so ~ expansion is testable without touching real home dir
+    monkeypatch.setenv("HOME", str(tmp_path))
+    state_file = tmp_path / "session.json"
+    state_file.write_text('{"cookies": [], "origins": []}')
+
+    with patch.dict(os.environ, {"GPTME_BROWSER_STORAGE_STATE": "~/session.json"}):
+        opts = get_context_options()
+
+    assert "storage_state" in opts
+    assert Path(opts["storage_state"]) == state_file
+
+
+def test_get_context_options_preserves_base_options(tmp_path):
+    """Loading storage_state must not clobber locale/geolocation/permissions."""
+    from gptme.tools._browser_thread import DEFAULT_CONTEXT_OPTIONS, get_context_options
+
+    state_file = tmp_path / "session.json"
+    state_file.write_text('{"cookies": [], "origins": []}')
+
+    with patch.dict(os.environ, {"GPTME_BROWSER_STORAGE_STATE": str(state_file)}):
+        opts = get_context_options()
+
+    for key in DEFAULT_CONTEXT_OPTIONS:
+        assert key in opts, f"Base option {key!r} was dropped from context options"
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for save_browser_state() (no real browser needed)
+# ---------------------------------------------------------------------------
+
+
+def test_save_browser_state_no_open_page_raises():
+    """save_browser_state() raises RuntimeError when no page/context is open."""
+    import gptme.tools._browser_playwright as _pw
+
+    # Ensure no page is open
+    _pw._current_page = None
+    _pw._current_context = None
+    _pw._browser = None
+
+    from gptme.tools._browser_playwright import _do_save_browser_state
+
+    with (
+        patch("gptme.tools._browser_playwright._current_context", None),
+        patch("gptme.tools._browser_playwright._browser", None),
+    ):
+        try:
+            _do_save_browser_state(MagicMock(), "/tmp/state.json")
+            raise AssertionError("Should have raised RuntimeError")
+        except RuntimeError as e:
+            assert "open_page" in str(e).lower() or "No browser context" in str(e)
+
+
+def test_save_browser_state_calls_storage_state(tmp_path):
+    """save_browser_state() calls context.storage_state(path=...) with the right path."""
+    import gptme.tools._browser_playwright as _pw
+
+    mock_context = MagicMock()
+    # Simulate a valid session JSON being written
+    state_path = tmp_path / "session.json"
+
+    def fake_storage_state(path=None):
+        Path(path).write_text('{"cookies":[],"origins":[]}')
+
+    mock_context.storage_state.side_effect = fake_storage_state
+
+    from gptme.tools._browser_playwright import _do_save_browser_state
+
+    with patch.object(_pw, "_current_context", mock_context):
+        result = _do_save_browser_state(MagicMock(), str(state_path))
+
+    mock_context.storage_state.assert_called_once_with(path=str(state_path))
+    assert str(state_path) in result
+
+
+def test_save_browser_state_creates_parent_dirs(tmp_path):
+    """save_browser_state() creates missing parent directories."""
+    import gptme.tools._browser_playwright as _pw
+
+    mock_context = MagicMock()
+    nested_path = tmp_path / "a" / "b" / "c" / "session.json"
+
+    def fake_storage_state(path=None):
+        # The parent must already exist by the time this is called
+        Path(path).write_text('{"cookies":[],"origins":[]}')
+
+    mock_context.storage_state.side_effect = fake_storage_state
+
+    from gptme.tools._browser_playwright import _do_save_browser_state
+
+    with patch.object(_pw, "_current_context", mock_context):
+        _do_save_browser_state(MagicMock(), str(nested_path))
+
+    assert nested_path.parent.exists()
+
+
+# ---------------------------------------------------------------------------
+# Integration: browser.save_browser_state() delegates to playwright backend
+# ---------------------------------------------------------------------------
+
+
+def test_browser_save_browser_state_delegates_to_playwright():
+    """browser.save_browser_state() delegates to the playwright implementation."""
+    from unittest.mock import patch as _patch
+
+    with (
+        _patch("gptme.tools.browser.browser", "playwright"),
+        _patch(
+            "gptme.tools.browser.save_browser_state_pw", return_value="Saved."
+        ) as mock_pw,
+    ):
+        from gptme.tools.browser import save_browser_state
+
+        result = save_browser_state("~/state.json")
+
+    mock_pw.assert_called_once_with("~/state.json")
+    assert result == "Saved."
+
+
+def test_browser_save_browser_state_raises_for_lynx():
+    """save_browser_state() raises ValueError for the lynx backend."""
+    with patch("gptme.tools.browser.browser", "lynx"):
+        from gptme.tools.browser import save_browser_state
+
+        try:
+            save_browser_state("/tmp/state.json")
+            raise AssertionError("Should have raised ValueError")
+        except ValueError as e:
+            assert "playwright" in str(e).lower()


### PR DESCRIPTION
## Summary

Closes the authenticated-session gap that made the "Can it Tweet?" milestone impractical in issue #216.

The computer-use primitives (`open_page`, `fill_element`, `click_element`) already existed, but there was no way to persist login state between gptme invocations. Every new session started unauthenticated, forcing users to re-enter credentials manually each time.

### Changes

**`save_browser_state(path)`** — new browser tool function (callable from IPython inside a gptme session):
- Captures the active context's cookies and localStorage to a JSON file
- Works with both launched browsers and CDP connections
- Creates parent directories automatically; expands `~`
- Registered as a `ToolFunction` in the browser tool spec so the agent can call it

**`get_context_options()`** in `_browser_thread` — replaces bare `DEFAULT_CONTEXT_OPTIONS` dict expansion:
- When `GPTME_BROWSER_STORAGE_STATE` points to an existing file, injects `storage_state` so every new context (`open_page`, `snapshot_url`, `read_url`, search) starts already authenticated
- Falls back to a fresh session with a warning when the file is absent (safe to set before first save)
- All existing `**DEFAULT_CONTEXT_OPTIONS` call-sites updated to `**get_context_options()`

### Usage

```python
# Step 1: log in once and save the session
open_page("https://x.com/login")
fill_element("#username", "yourhandle")
click_element("text=Next")
fill_element("[name='password']", "yourpassword")
click_element("text=Log in")
save_browser_state("~/.config/gptme/twitter-session.json")
```

```bash
# Step 2: future sessions start authenticated
export GPTME_BROWSER_STORAGE_STATE=~/.config/gptme/twitter-session.json
gptme --agent-profile computer-use 'go to https://x.com/compose/tweet, type "Hello from gptme!", and click Post'
```

### Tests

10 new unit tests in `tests/test_browser_session_persistence.py`:
- `get_context_options()`: no env var, existing file, missing file, tilde path, base-options preservation
- `save_browser_state()` / `_do_save_browser_state()`: no-page error, calls `storage_state()` correctly, creates parent dirs
- `browser.save_browser_state()`: delegation to playwright backend, ValueError for lynx backend

All pre-existing tests pass unchanged (325 passed, 3 skipped).

Docs updated in `docs/howto/computer-use.md` with a new "Authenticated sessions" section.

Closes #216 (partially — remaining: native game latency improvements for Factorio/Doom milestones)

<!-- gptme-id:v1:gai_onTgmZ7VEkYfAGr96bfJsaVJQI2pzD5z4SVb9gTojjy -->