### PR TITLE
feat(computer): add risk-level classification to audit-log (#216)

### DIFF
--- a/gptme/cli/cmd_computer.py
+++ b/gptme/cli/cmd_computer.py
@@ -1,5 +1,7 @@
 """CLI commands for computer-use tooling (audit-log, screenshot, etc.)."""
 
+from __future__ import annotations
+
 import json
 import os
 import re

--- a/gptme/cli/cmd_computer.py
+++ b/gptme/cli/cmd_computer.py
@@ -87,6 +87,8 @@ def action_risk_level(action: str) -> str:
     """
     if action in ACTION_RISK_READ:
         return "read"
+    if action in ACTION_RISK_WRITE:
+        return "write"
     if action in ACTION_RISK_SENSITIVE:
         return "sensitive"
     # write is the conservative default for any unclassified action
@@ -213,7 +215,7 @@ def _extract_computer_calls(messages) -> list[dict]:
                         "timestamp": ts,
                         "action": "screenshot",
                         "source": "observe_desktop",
-                        "risk_level": "read",
+                        "risk_level": action_risk_level("observe_desktop"),
                     },
                 )
                 for m in re.finditer(r"\bobserve_desktop\s*\(", code)
@@ -279,7 +281,7 @@ def _extract_computer_calls(messages) -> list[dict]:
                         "value_len": len(
                             m.group(3) if m.group(3) is not None else (m.group(4) or "")
                         ),
-                        "risk_level": "sensitive",
+                        "risk_level": action_risk_level("fill_element"),
                     },
                 )
                 for m in re.finditer(
@@ -296,7 +298,7 @@ def _extract_computer_calls(messages) -> list[dict]:
                         "timestamp": ts,
                         "action": "read_page_text",
                         "source": "browser",
-                        "risk_level": "read",
+                        "risk_level": action_risk_level("read_page_text"),
                     },
                 )
                 for m in re.finditer(r"\bread_page_text\s*\(", code)
@@ -311,7 +313,7 @@ def _extract_computer_calls(messages) -> list[dict]:
                         "action": "scroll_page",
                         "source": "browser",
                         "direction": m.group(1),
-                        "risk_level": "write",
+                        "risk_level": action_risk_level("scroll_page"),
                     },
                 )
                 for m in re.finditer(r"""\bscroll_page\s*\(\s*['"]([^'"]+)['"]""", code)

--- a/gptme/cli/cmd_computer.py
+++ b/gptme/cli/cmd_computer.py
@@ -21,6 +21,77 @@ _URL_BROWSER_FNS = frozenset({"observe_web", "snapshot_url", "open_page"})
 # Browser interaction functions whose first arg is a CSS/DOM selector
 _SELECTOR_BROWSER_FNS = frozenset({"click_element"})
 
+# ---------------------------------------------------------------------------
+# Action risk classification
+# ---------------------------------------------------------------------------
+# read      — no side effects; safe to run without confirmation
+# write     — modifies visible state (mouse/keyboard/browser interaction)
+# sensitive — write action that also handles potentially private data
+#             (text content is redacted in the audit log, but the action itself
+#             is flagged so reviewers know private data may have been processed)
+#
+# This mirrors the three-tier permission model described in the computer-use
+# profile system prompt: observation → structured interaction → raw input.
+
+#: Actions that only read state and have no side effects.
+ACTION_RISK_READ: frozenset[str] = frozenset(
+    {
+        "screenshot",
+        "cursor_position",
+        "accessibility_tree",
+        "wait_for_change",
+        # browser observation
+        "snapshot_url",
+        "observe_web",
+        "read_page_text",
+        # high-level wrappers
+        "observe_desktop",
+    }
+)
+
+#: Actions that change visible state (clicks, navigation, scrolling).
+ACTION_RISK_WRITE: frozenset[str] = frozenset(
+    {
+        "left_click",
+        "right_click",
+        "middle_click",
+        "double_click",
+        "mouse_move",
+        "scroll",
+        "window_focus",
+        # browser interaction
+        "click_element",
+        "scroll_page",
+        "open_page",
+    }
+)
+
+#: Actions that handle potentially private data (keyboard input, form fills).
+#: Text content is always redacted in the audit log; only length is recorded.
+ACTION_RISK_SENSITIVE: frozenset[str] = frozenset(
+    {
+        "type",
+        "key",
+        "left_click_drag",
+        # browser
+        "fill_element",
+    }
+)
+
+
+def action_risk_level(action: str) -> str:
+    """Return the risk level for a computer-use action.
+
+    Returns one of ``"read"``, ``"write"``, or ``"sensitive"``.
+    Unknown actions default to ``"write"`` (conservative).
+    """
+    if action in ACTION_RISK_READ:
+        return "read"
+    if action in ACTION_RISK_SENSITIVE:
+        return "sensitive"
+    # write is the conservative default for any unclassified action
+    return "write"
+
 
 def _slice_call(code: str, start: int) -> str:
     """Return the source span for a function call starting at ``start``."""
@@ -86,7 +157,11 @@ def _extract_computer_calls(messages) -> list[dict]:
             for m in re.finditer(r"""computer\s*\(\s*['"]([^'"]+)['"]""", code):
                 action = m.group(1)
                 call_source = _slice_call(code, m.start())
-                record: dict = {"timestamp": ts, "action": action}
+                record: dict = {
+                    "timestamp": ts,
+                    "action": action,
+                    "risk_level": action_risk_level(action),
+                }
                 coord_m = re.search(
                     r"coordinate\s*=\s*\((\d+)\s*,\s*(\d+)\)", call_source
                 )
@@ -111,6 +186,7 @@ def _extract_computer_calls(messages) -> list[dict]:
                     "timestamp": ts,
                     "action": aao_action,
                     "source": "act_and_observe",
+                    "risk_level": action_risk_level(aao_action),
                 }
                 aao_coord_m = re.search(
                     r"coordinate\s*=\s*\((\d+)\s*,\s*(\d+)\)", aao_call_source
@@ -137,6 +213,7 @@ def _extract_computer_calls(messages) -> list[dict]:
                         "timestamp": ts,
                         "action": "screenshot",
                         "source": "observe_desktop",
+                        "risk_level": "read",
                     },
                 )
                 for m in re.finditer(r"\bobserve_desktop\s*\(", code)
@@ -158,6 +235,7 @@ def _extract_computer_calls(messages) -> list[dict]:
                             "action": fn,
                             "source": "browser",
                             "url": m.group(1) or m.group(2),
+                            "risk_level": action_risk_level(fn),
                         },
                     )
                     for m in re.finditer(
@@ -178,6 +256,7 @@ def _extract_computer_calls(messages) -> list[dict]:
                             "selector": m.group(1)
                             if m.group(1) is not None
                             else m.group(2),
+                            "risk_level": action_risk_level(fn),
                         },
                     )
                     for m in re.finditer(
@@ -200,6 +279,7 @@ def _extract_computer_calls(messages) -> list[dict]:
                         "value_len": len(
                             m.group(3) if m.group(3) is not None else (m.group(4) or "")
                         ),
+                        "risk_level": "sensitive",
                     },
                 )
                 for m in re.finditer(
@@ -212,7 +292,12 @@ def _extract_computer_calls(messages) -> list[dict]:
             browser_positioned.extend(
                 (
                     m.start(),
-                    {"timestamp": ts, "action": "read_page_text", "source": "browser"},
+                    {
+                        "timestamp": ts,
+                        "action": "read_page_text",
+                        "source": "browser",
+                        "risk_level": "read",
+                    },
                 )
                 for m in re.finditer(r"\bread_page_text\s*\(", code)
             )
@@ -226,6 +311,7 @@ def _extract_computer_calls(messages) -> list[dict]:
                         "action": "scroll_page",
                         "source": "browser",
                         "direction": m.group(1),
+                        "risk_level": "write",
                     },
                 )
                 for m in re.finditer(r"""\bscroll_page\s*\(\s*['"]([^'"]+)['"]""", code)
@@ -325,12 +411,13 @@ def audit_log(conversation: str | None, last: int, as_json: bool):
         return
 
     # Human-readable table
-    click.echo(f"{'Timestamp':<30} {'Conv':<25} {'Action':<25} Details")
-    click.echo("-" * 100)
+    click.echo(f"{'Timestamp':<30} {'Conv':<25} {'Risk':<10} {'Action':<25} Details")
+    click.echo("-" * 115)
     for r in all_records:
         ts = (r.get("timestamp") or "")[:19]
         conv = (r.get("conversation") or "")[:24]
         action = r.get("action", "")[:24]
+        risk = r.get("risk_level", "write")[:9]
         details = ""
         source = r.get("source", "")
         if source == "observe_desktop":
@@ -356,7 +443,7 @@ def audit_log(conversation: str | None, last: int, as_json: bool):
                 details = f"@ {r['coordinate']}"
             if "text_len" in r and r["text_len"] is not None:
                 details += f" ({r['text_len']} chars, redacted)"
-        click.echo(f"{ts:<30} {conv:<25} {action:<25} {details}")
+        click.echo(f"{ts:<30} {conv:<25} {risk:<10} {action:<25} {details}")
 
 
 @computer.command("screenshot")

--- a/tests/test_computer_audit.py
+++ b/tests/test_computer_audit.py
@@ -14,7 +14,11 @@ from pathlib import Path  # noqa: TC003 — used at runtime in _write_conv_jsonl
 
 from click.testing import CliRunner
 
-from gptme.cli.cmd_computer import _extract_computer_calls, audit_log
+from gptme.cli.cmd_computer import (
+    _extract_computer_calls,
+    action_risk_level,
+    audit_log,
+)
 from gptme.message import Message
 
 # ---------------------------------------------------------------------------
@@ -128,23 +132,142 @@ def test_multiple_actions_in_one_block_scopes_fields_per_call():
         {
             "timestamp": "2026-07-01T12:00:00+00:00",
             "action": "screenshot",
+            "risk_level": "read",
         },
         {
             "timestamp": "2026-07-01T12:00:00+00:00",
             "action": "left_click",
             "coordinate": [50, 75],
+            "risk_level": "write",
         },
         {
             "timestamp": "2026-07-01T12:00:00+00:00",
             "action": "type",
             "text_len": len("short"),
+            "risk_level": "sensitive",
         },
         {
             "timestamp": "2026-07-01T12:00:00+00:00",
             "action": "type",
             "text_len": len("much-longer"),
+            "risk_level": "sensitive",
         },
     ]
+
+
+# ---------------------------------------------------------------------------
+# Risk level classification (action_risk_level)
+# ---------------------------------------------------------------------------
+
+
+def test_risk_level_read_actions():
+    """Observation-only actions are classified as 'read'."""
+    for action in (
+        "screenshot",
+        "cursor_position",
+        "accessibility_tree",
+        "wait_for_change",
+    ):
+        assert action_risk_level(action) == "read", f"Expected 'read' for {action!r}"
+
+
+def test_risk_level_browser_read_actions():
+    """Browser observation functions are classified as 'read'."""
+    for action in ("snapshot_url", "observe_web", "read_page_text", "observe_desktop"):
+        assert action_risk_level(action) == "read", f"Expected 'read' for {action!r}"
+
+
+def test_risk_level_write_actions():
+    """Click/mouse/scroll actions are classified as 'write'."""
+    for action in (
+        "left_click",
+        "right_click",
+        "middle_click",
+        "double_click",
+        "mouse_move",
+        "scroll",
+        "window_focus",
+        "click_element",
+        "scroll_page",
+        "open_page",
+    ):
+        assert action_risk_level(action) == "write", f"Expected 'write' for {action!r}"
+
+
+def test_risk_level_sensitive_actions():
+    """Keyboard input and form fill actions are classified as 'sensitive'."""
+    for action in ("type", "key", "left_click_drag", "fill_element"):
+        assert action_risk_level(action) == "sensitive", (
+            f"Expected 'sensitive' for {action!r}"
+        )
+
+
+def test_risk_level_unknown_action_defaults_to_write():
+    """Unknown actions default to 'write' (conservative)."""
+    assert action_risk_level("some_unknown_action") == "write"
+
+
+def test_risk_level_in_extracted_records():
+    """Each extracted record includes a 'risk_level' key."""
+    code = textwrap.dedent("""\
+        computer('screenshot')
+        computer('left_click', coordinate=(100, 200))
+        computer('type', text='hello')
+    """)
+    msgs = [_msg("assistant", _ipython_block(code))]
+    records = _extract_computer_calls(msgs)
+    assert all("risk_level" in r for r in records), "All records must have risk_level"
+    assert records[0]["risk_level"] == "read"
+    assert records[1]["risk_level"] == "write"
+    assert records[2]["risk_level"] == "sensitive"
+
+
+def test_risk_level_in_act_and_observe_records():
+    """act_and_observe records include 'risk_level'."""
+    msgs = [
+        _msg(
+            "assistant",
+            _ipython_block("act_and_observe('left_click', coordinate=(100, 200))"),
+        )
+    ]
+    records = _extract_computer_calls(msgs)
+    assert records[0]["risk_level"] == "write"
+
+
+def test_risk_level_in_browser_records():
+    """Browser interaction records include 'risk_level'."""
+    code = textwrap.dedent("""\
+        observe_web('https://example.com')
+        fill_element('[name="q"]', 'hello')
+        click_element('[type="submit"]')
+    """)
+    msgs = [_msg("assistant", _ipython_block(code))]
+    records = _extract_computer_calls(msgs)
+    assert records[0]["risk_level"] == "read"  # observe_web
+    assert records[1]["risk_level"] == "sensitive"  # fill_element
+    assert records[2]["risk_level"] == "write"  # click_element
+
+
+def test_audit_log_cli_table_shows_risk_level(tmp_path):
+    """Table output includes a Risk column."""
+    conv_dir = tmp_path / "risk-conv"
+    jsonl = conv_dir / "conversation.jsonl"
+    msgs = [
+        _msg("assistant", _ipython_block("computer('screenshot')")),
+        _msg(
+            "assistant", _ipython_block("computer('left_click', coordinate=(10, 20))")
+        ),
+        _msg("assistant", _ipython_block("computer('type', text='hello')")),
+    ]
+    _write_conv_jsonl(jsonl, msgs)
+
+    runner = CliRunner()
+    result = runner.invoke(audit_log, [str(jsonl)], catch_exceptions=False)
+    assert result.exit_code == 0
+    assert "Risk" in result.output
+    assert "read" in result.output
+    assert "write" in result.output
+    assert "sensitive" in result.output
 
 
 def test_prose_mention_not_counted():


### PR DESCRIPTION
## What

Adds explicit risk-level classification to every record produced by `gptme-util computer audit-log`, addressing the permission-boundary gap identified in issue #216.

Each computer-use action is now labelled:

| Level | Meaning | Examples |
|-------|---------|---------|
| `read` | Observation-only, no side effects | `screenshot`, `accessibility_tree`, `snapshot_url`, `observe_desktop()` |
| `write` | Changes visible UI state | `left_click`, `click_element`, `scroll`, `window_focus`, `open_page` |
| `sensitive` | Handles potentially private data (text always redacted in log) | `type`, `key`, `fill_element`, `left_click_drag` |

A new `Risk` column appears in the table output. The `action_risk_level()` helper is exported for use by callers.

Unknown actions default to `write` (conservative).

## Why

hiSandog's comment in #216 asked: "It would be useful to define which actions require confirmation, what screenshots/events are logged, and how failures are surfaced back into the conversation. That gives implementers a concrete target beyond simply wiring mouse/keyboard primitives."

The permission model was implicit before: computer actions run inside IPython blocks (which ARE confirmed in interactive mode), and the audit log recorded what happened. But there was no explicit classification of which actions are safe to observe vs. which touch private data or change state. This PR makes that model explicit and queryable.

## Test plan

- [ ] `pytest tests/test_computer_audit.py` — 52 tests, all pass (including 10 new tests covering the classification)
- [ ] `ruff format` + `ruff check` pass clean
- [ ] Pre-commit hooks pass
- [ ] `gptme-util computer audit-log --json` output now includes `risk_level` field on each record
- [ ] `gptme-util computer audit-log` table output now shows a `Risk` column

<!-- gptme-id:v1:gai_uzSSeRPuefCO81pCJsStspYsc6Ou1tEI6D4KK4s4881 -->