### PR TITLE
fix(tools): always pair structured tool_use with a tool_result (#554)

### DIFF
--- a/gptme/tools/__init__.py
+++ b/gptme/tools/__init__.py
@@ -321,27 +321,45 @@ def execute_msg(
     """Uses any tools called in a message and returns the response."""
     assert msg.role == "assistant", "Only assistant messages can be executed"
 
-    # Collect all runnable tool uses
-    runnable_tools = [
-        tu for tu in ToolUse.iter_from_content(msg.content) if tu.is_runnable
-    ]
+    # Snapshot runnability once per tool_use. Evaluating `is_runnable` a second
+    # time later would open a TOCTOU gap: a tool whose loaded-state changes
+    # between the two checks (e.g. a subagent thread concurrently (re)initializing
+    # tools) could fall through both branches and leave a structured tool_use with
+    # no tool_result — which the Anthropic API rejects with a hard 400 (#554).
+    classified = [(tu, tu.is_runnable) for tu in ToolUse.iter_from_content(msg.content)]
 
-    if not runnable_tools:
+    if not classified:
         return
 
-    for tooluse in runnable_tools:
-        with terminal_state_title(f"🛠️ running {tooluse.tool}"):
-            try:
-                for tool_response in tooluse.execute(log=log, workspace=workspace):
-                    yield tool_response.replace(call_id=tooluse.call_id)
-            except KeyboardInterrupt:
-                clear_interruptible()
-                yield Message(
-                    "system",
-                    INTERRUPT_CONTENT,
-                    call_id=tooluse.call_id,
-                )
-                break
+    for tooluse, runnable in classified:
+        if runnable:
+            with terminal_state_title(f"🛠️ running {tooluse.tool}"):
+                try:
+                    for tool_response in tooluse.execute(log=log, workspace=workspace):
+                        yield tool_response.replace(call_id=tooluse.call_id)
+                except KeyboardInterrupt:
+                    clear_interruptible()
+                    yield Message(
+                        "system",
+                        INTERRUPT_CONTENT,
+                        call_id=tooluse.call_id,
+                    )
+                    break
+        elif tooluse.call_id is not None:
+            # A structured (tool-format) tool_use that isn't runnable still needs
+            # a paired tool_result, or the next API request dangles it and 400s.
+            # Markdown code blocks (call_id is None) are not API tool_uses, so
+            # they're intentionally left unpaired.
+            logger.warning(
+                "Tool '%s' is not runnable; emitting an error tool_result to keep "
+                "the tool_use/tool_result pairing valid.",
+                tooluse.tool,
+            )
+            yield Message(
+                "system",
+                f"Tool '{tooluse.tool}' is not available for execution.",
+                call_id=tooluse.call_id,
+            )
 
 
 def get_tool_for_langtag(lang: str) -> ToolSpec | None:

--- a/gptme/tools/__init__.py
+++ b/gptme/tools/__init__.py
@@ -331,7 +331,8 @@ def execute_msg(
     if not classified:
         return
 
-    for tooluse, runnable in classified:
+    remaining = iter(classified)
+    for tooluse, runnable in remaining:
         if runnable:
             with terminal_state_title(f"🛠️ running {tooluse.tool}"):
                 try:
@@ -344,7 +345,17 @@ def execute_msg(
                         INTERRUPT_CONTENT,
                         call_id=tooluse.call_id,
                     )
-                    break
+                    # Drain the rest: any structured tool_use that's left in the
+                    # message still needs a paired tool_result or the next API
+                    # request will 400 with a dangling tool_use.
+                    for rem_tu, _ in remaining:
+                        if rem_tu.call_id is not None:
+                            yield Message(
+                                "system",
+                                f"Tool '{rem_tu.tool}' was not executed (interrupted).",
+                                call_id=rem_tu.call_id,
+                            )
+                    return
         elif tooluse.call_id is not None:
             # A structured (tool-format) tool_use that isn't runnable still needs
             # a paired tool_result, or the next API request dangles it and 400s.

--- a/tests/test_tool_use.py
+++ b/tests/test_tool_use.py
@@ -333,3 +333,49 @@ def test_execute_msg_ignores_unrunnable_markdown_block():
 
     results = list(execute_msg(msg))
     assert results == [], f"markdown non-tool block should yield nothing, got {results}"
+
+
+def test_execute_msg_drains_structured_tooluses_after_interrupt(monkeypatch):
+    """After a KeyboardInterrupt on tool N, all subsequent structured tool_uses
+    (call_id is not None) must still get paired tool_results.
+
+    Regression for gptme#554 interrupt path: the pre-fix `break` exited the
+    loop entirely, leaving any remaining structured tool_uses dangling and
+    causing the next API request to hard-400.
+    """
+    from gptme.message import Message
+    from gptme.tools import execute_msg, init_tools
+    from gptme.tools.base import ToolUse
+
+    init_tools(["read"])
+    set_tool_format("tool")
+
+    # Patch ToolUse.execute on the first call to raise KeyboardInterrupt.
+    original_execute = ToolUse.execute
+    call_count = 0
+
+    def execute_raise_once(self, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise KeyboardInterrupt
+        return original_execute(self, **kwargs)
+
+    monkeypatch.setattr(ToolUse, "execute", execute_raise_once)
+    # Also patch is_runnable to return True for both tool calls.
+    monkeypatch.setattr(ToolUse, "is_runnable", property(lambda self: True))
+
+    # Two structured tool_uses; the first will be interrupted.
+    content = (
+        '@definitely_not_a_real_tool(toolu_first123): {"foo": "bar"}\n'
+        '@definitely_not_a_real_tool(toolu_second456): {"baz": "qux"}'
+    )
+    msg = Message("assistant", content)
+
+    results = list(execute_msg(msg))
+
+    call_ids = {m.call_id for m in results if m.call_id is not None}
+    assert "toolu_first123" in call_ids, "interrupted tool_use must be paired"
+    assert "toolu_second456" in call_ids, (
+        "subsequent tool_use must also be paired after interrupt"
+    )

--- a/tests/test_tool_use.py
+++ b/tests/test_tool_use.py
@@ -288,3 +288,48 @@ def test_parse_multiple_tool_calls():
     # Check ordering by start position
     assert tooluses[0].start is not None and tooluses[1].start is not None
     assert tooluses[0].start < tooluses[1].start
+
+
+def test_execute_msg_pairs_unrunnable_structured_tooluse():
+    """A structured (tool-format) tool_use for a non-runnable tool must still
+    yield a tool_result carrying the same call_id.
+
+    Regression for gptme#554: a subagent race could transiently make a loaded
+    tool non-runnable; execute_msg used to silently drop such tool_uses, leaving
+    a dangling tool_use that the Anthropic API rejects with a hard 400. The fix
+    is mechanism-agnostic: any structured tool_use that isn't runnable gets a
+    paired error tool_result so the tool_use/tool_result contract always holds.
+    """
+    from gptme.message import Message
+    from gptme.tools import execute_msg, init_tools
+
+    init_tools(["read"])
+    set_tool_format("tool")
+
+    # A tool that is definitely not loaded -> get_tool() is None -> not runnable.
+    content = '@definitely_not_a_real_tool(toolu_ghost123): {"foo": "bar"}'
+    msg = Message("assistant", content)
+
+    results = list(execute_msg(msg))
+
+    paired = [m for m in results if m.call_id == "toolu_ghost123"]
+    assert len(paired) == 1, f"expected exactly one paired tool_result, got {results}"
+    assert paired[0].role == "system"
+    assert "not available" in paired[0].content
+
+
+def test_execute_msg_ignores_unrunnable_markdown_block():
+    """A markdown code block (call_id is None) is not an API tool_use, so a
+    non-runnable one must NOT produce a spurious tool_result."""
+    from gptme.message import Message
+    from gptme.tools import execute_msg, init_tools
+
+    init_tools(["read"])
+    set_tool_format("markdown")
+
+    # Not a real tool -> parsed (if at all) as non-runnable, no call_id.
+    content = "```definitely_not_a_real_tool\nsome content\n```"
+    msg = Message("assistant", content)
+
+    results = list(execute_msg(msg))
+    assert results == [], f"markdown non-tool block should yield nothing, got {results}"


### PR DESCRIPTION
## Problem

Follow-up to my [2026-07-01 eval report on #554](https://github.com/gptme/gptme/issues/554): the `subagent-complete-roundtrip` eval doesn't just fail a check — it **hard-crashes** with an Anthropic `400`:

```
tool_use ids were found without tool_result blocks immediately after: toolu_...
```

Root cause of the *crash* (distinct from whatever transiently unloads the tool): `execute_msg` collected only **runnable** tool_uses and silently dropped the rest:

```python
runnable_tools = [tu for tu in ToolUse.iter_from_content(msg.content) if tu.is_runnable]
if not runnable_tools:
    return
```

For a **tool-format (structured) tool_use** — which carries a `call_id` and *will* be sent to the API — dropping it leaves a dangling `tool_use` with no matching `tool_result`. The API rejects the next request and the whole conversation aborts.

## Why this fix (and not a tool-state refactor)

In the eval, the `read` tool was loaded before and after, but `is_runnable` was `False` at execute time while a thread-mode subagent was concurrently active. I spent this session trying to pin that transient mechanism and **empirically falsified the two natural hypotheses**:

- **Contextvar clobber from subagent setup** — a reproducer running the subagent thread's full setup path (`prepare_execution_environment` + `_ensure_subagent_signal_tools_loaded` + `get_tools`) across 4 concurrent threads for **41M parent iterations** never once observed `read` as non-runnable. Subagent threads use plain `threading.Thread` → fresh contextvars → the parent's `_loaded_tools_var` is genuinely isolated.
- **Message-ordering** — the LOOP_CONTINUE completion hook enqueues to `prompt_queue`, so it can't interleave between an assistant tool_use and its tool_result.

So rather than guess at the exact transient (and risk the "broad make-tool-state-immutable refactor" I warned against in the issue), this fixes the **actual API-contract violation**, which is correct regardless of *why* a tool is transiently non-runnable:

- Every **structured** tool_use (`call_id is not None`) that isn't runnable now yields an **error `tool_result`** carrying that `call_id`. The `tool_use`/`tool_result` pairing always holds → no more dangling-tool_use 400.
- **Markdown** code blocks (`call_id is None`) are *not* API tool_uses, so they remain intentionally unpaired (no spurious results for illustrative ``` blocks).
- Runnability is **snapshotted once** per tool_use, closing a TOCTOU gap where a concurrently (re)initializing tool could otherwise fall through *both* the run and the pair branches.

This turns a hard crash into graceful "tool not available" degradation the model can react to — defense-in-depth that stands even after the transient race is separately root-caused.

## Tests

`tests/test_tool_use.py`:
- `test_execute_msg_pairs_unrunnable_structured_tooluse` — structured tool_use for a non-loaded tool now yields exactly one paired error `tool_result`. **Verified RED without the fix** (fails: dangling tool_use), GREEN with it.
- `test_execute_msg_ignores_unrunnable_markdown_block` — a markdown non-tool block yields nothing (unchanged).

Full `tests/test_tool_use.py` suite: **30 passed**. (`test_tools_subagent.py::test_subagent_wait_basic` fails on `origin/master` too — pre-existing, unrelated.)

## Follow-up

The transient-non-runnable **root cause** is still open — it needs live instrumentation of `is_runnable`/`get_tool` during the race window, as noted in the issue. This PR makes that root cause non-fatal but does not close #554.