### PR TITLE
docs(tools): document subagent isolation contract

### DIFF
--- a/docs/tools.rst
+++ b/docs/tools.rst
@@ -158,9 +158,11 @@ subagent regardless of allowlist — they are how the subagent communicates back
 
 **3. Cancellation and timeout**
 
-- ``max_time`` (seconds) — a watchdog timer that auto-cancels the subagent after
-  the specified duration and delivers a "timeout" status notification. The parent
-  calls ``subagent_cancel()`` to trigger this (thread mode only).
+- ``max_time`` (seconds) — a watchdog timer that marks the subagent result as
+  ``"timeout"`` after the specified duration and delivers a timeout status
+  notification. In subprocess mode the child process is terminated. In thread
+  mode the background thread is not force-stopped; callers see the cached timeout
+  result immediately while the thread continues until it finishes naturally.
 
 - ``timeout`` (default 1800 s) — subprocess monitor kills the child process after
   this many seconds. Only applies in subprocess mode.

--- a/docs/tools.rst
+++ b/docs/tools.rst
@@ -127,6 +127,10 @@ Fine-grained control:
 
 - ``context_mode="selective"`` + ``context_include`` — share only specific components
   (``"agent"``, ``"tools"``, ``"workspace"``) instead of the full workspace.
+  Thread-mode only; ignored in subprocess and ACP. Note:
+  ``context_include=["workspace"]`` produces an empty context in thread mode —
+  the parent's workspace context is already fully assembled and cannot be
+  selectively re-included as a component.
 
 - ``context_window=N`` — limit how many inherited context messages are forwarded
   (``0`` = none, ``None`` = all). Thread mode only; ignored in subprocess and ACP.
@@ -152,6 +156,8 @@ Three ways to restrict tools:
 
 - ``redact_secrets=True`` (default) — scrubs common secret patterns (API keys, tokens,
   passwords) from workspace context messages before they reach the subagent.
+  Thread-mode only; has no effect in subprocess or ACP modes (the child process's
+  own ``gptme.toml`` controls its secret handling).
 
 Signal tools (``complete``, ``clarify``, ``progress``) are always loaded for every
 subagent regardless of allowlist — they are how the subagent communicates back.

--- a/docs/tools.rst
+++ b/docs/tools.rst
@@ -133,8 +133,9 @@ Fine-grained control:
   **Thread**: fully supported — filters the inherited context to the specified components.
 
   **Subprocess**: ``context_mode`` is ignored (the child loads its own workspace from
-  ``gptme.toml``); ``context_include=["workspace"]`` maps to the ``--files`` CLI flag
-  to include workspace files. Other ``context_include`` values are ignored in this mode.
+  ``gptme.toml``); ``context_include=["workspace"]`` maps to the ``--context files``
+  CLI flag to include workspace files. Other ``context_include`` values are ignored in
+  this mode.
 
   **ACP**: both parameters are ignored.
 
@@ -165,8 +166,10 @@ Three ways to restrict tools:
   Thread-mode only; has no effect in subprocess or ACP modes (the child process's
   own ``gptme.toml`` controls its secret handling).
 
-Signal tools (``complete``, ``clarify``, ``progress``) are always loaded for every
-subagent regardless of allowlist — they are how the subagent communicates back.
+Signal tools are loaded regardless of allowlist so the subagent can communicate
+back. Thread-mode subagents get ``complete``, ``clarify``, and ``progress``.
+Subprocess subagents get ``complete`` and ``clarify``; ``progress`` is not loaded
+because it depends on the parent's in-process notification queue.
 
 **3. Cancellation and timeout**
 

--- a/docs/tools.rst
+++ b/docs/tools.rst
@@ -103,6 +103,96 @@ Subagent
     :members:
     :noindex:
 
+Subagent Isolation Contract
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When spawning a subagent you need to know exactly what it inherits from the parent
+and what it starts fresh. There are four dimensions:
+
+**1. Workspace config loading**
+
+*Thread mode* (default, ``use_subprocess=False``):
+  The subagent inherits the parent's *already-assembled* workspace context —
+  the ``[prompt] files`` from ``gptme.toml`` and the ``context_cmd`` output as
+  they were loaded for the parent session. It does **not** re-read from the
+  subagent's working directory, so a subdirectory with its own ``gptme.toml``
+  will not be picked up automatically.
+
+*Subprocess mode* (``use_subprocess=True``):
+  Spawns a fresh ``gptme`` process with ``workdir`` as the CWD, which naturally
+  loads that directory's ``gptme.toml``. Use this when you want subagents to pick
+  up directory-local workspace config.
+
+Fine-grained control:
+
+- ``context_mode="selective"`` + ``context_include`` — share only specific components
+  (``"agent"``, ``"tools"``, ``"workspace"``) instead of the full workspace.
+
+- ``context_window=N`` — limit how many inherited context messages are forwarded
+  (``0`` = none, ``None`` = all).
+
+- ``context_turns=N`` — forward the last N turns of the parent conversation.
+
+**2. Tool and state inheritance**
+
+By default the subagent starts with the same tool list as the parent (both threads
+share the same initial snapshot; contextvars are thread-isolated so the parent's
+tool state cannot be mutated by the subagent).
+
+Three ways to restrict tools:
+
+- ``profile="explorer"`` (or any built-in profile) — applies a tool allowlist at spawn
+  time. Built-in profiles: ``explorer`` (read-only), ``researcher``, ``developer``
+  (full), ``verifier`` (read-only, always subprocess + isolated).
+
+- ``isolated=True`` — runs the subagent in a git worktree so filesystem writes don't
+  affect the parent repo. The worktree is auto-cleaned after completion.
+
+- ``redact_secrets=True`` (default) — scrubs common secret patterns (API keys, tokens,
+  passwords) from workspace context messages before they reach the subagent.
+
+Signal tools (``complete``, ``clarify``, ``progress``) are always loaded for every
+subagent regardless of allowlist — they are how the subagent communicates back.
+
+**3. Cancellation and timeout**
+
+Subagent termination is cooperative, not pre-emptive:
+
+- ``max_time`` (seconds) — triggers a cancel signal to the running subagent thread;
+  the subagent can check this and stop cleanly. No hard kill in thread mode.
+
+- ``timeout`` (default 1800 s) — subprocess monitor kills the child process after
+  this many seconds. Only applies in subprocess mode.
+
+- The parent does not block waiting for subagents. Completion is delivered via the
+  ``LOOP_CONTINUE`` hook, which re-enters the parent's loop with a notification
+  message.
+
+**4. Child transcript and result delivery**
+
+Subagents always start with a **fresh conversation** — they do not inherit the parent's
+message history by default. The result/transcript lifecycle:
+
+- ``context_turns=N`` — the parent's last N turns are prepended to the subagent's
+  conversation as context.
+
+- On completion the subagent calls the ``complete`` signal tool with a summary; this
+  is queued back to the parent via the ``LOOP_CONTINUE`` hook.
+
+- ``subagent_read_log(agent_id)`` — retrieve the full child transcript from the parent
+  after the subagent completes.
+
+- ``subagent_status(agent_id)`` — poll completion/error state without waiting.
+
+.. note::
+
+   The thread-mode transient ``is_runnable`` race (where a tool may briefly appear
+   non-runnable while a concurrent subagent thread is active) is a known open issue
+   tracked in `gptme#554 <https://github.com/gptme/gptme/issues/554>`_. Since
+   `#3072 <https://github.com/gptme/gptme/pull/3072>`_ the crash is non-fatal —
+   non-runnable structured tool calls get a paired error ``tool_result`` — but the
+   root cause is not yet identified.
+
 Read
 ----
 

--- a/docs/tools.rst
+++ b/docs/tools.rst
@@ -127,10 +127,16 @@ Fine-grained control:
 
 - ``context_mode="selective"`` + ``context_include`` — share only specific components
   (``"agent"``, ``"tools"``, ``"workspace"``) instead of the full workspace.
-  Thread-mode only; ignored in subprocess and ACP. Note:
-  ``context_include=["workspace"]`` produces an empty context in thread mode —
-  the parent's workspace context is already fully assembled and cannot be
-  selectively re-included as a component.
+
+  Behavior by mode:
+
+  **Thread**: fully supported — filters the inherited context to the specified components.
+
+  **Subprocess**: ``context_mode`` is ignored (the child loads its own workspace from
+  ``gptme.toml``); ``context_include=["workspace"]`` maps to the ``--files`` CLI flag
+  to include workspace files. Other ``context_include`` values are ignored in this mode.
+
+  **ACP**: both parameters are ignored.
 
 - ``context_window=N`` — limit how many inherited context messages are forwarded
   (``0`` = none, ``None`` = all). Thread mode only; ignored in subprocess and ACP.

--- a/docs/tools.rst
+++ b/docs/tools.rst
@@ -129,9 +129,10 @@ Fine-grained control:
   (``"agent"``, ``"tools"``, ``"workspace"``) instead of the full workspace.
 
 - ``context_window=N`` — limit how many inherited context messages are forwarded
-  (``0`` = none, ``None`` = all).
+  (``0`` = none, ``None`` = all). Thread mode only; ignored in subprocess and ACP.
 
 - ``context_turns=N`` — forward the last N turns of the parent conversation.
+  Thread mode only; ignored in subprocess and ACP.
 
 **2. Tool and state inheritance**
 
@@ -143,7 +144,8 @@ Three ways to restrict tools:
 
 - ``profile="explorer"`` (or any built-in profile) — applies a tool allowlist at spawn
   time. Built-in profiles: ``explorer`` (read-only), ``researcher``, ``developer``
-  (full), ``verifier`` (read-only, always subprocess + isolated).
+  (full), ``verifier`` (read-only). Note: ``role="verify"`` forces
+  ``use_subprocess=True`` and ``isolated=True`` in addition to the verifier profile.
 
 - ``isolated=True`` — runs the subagent in a git worktree so filesystem writes don't
   affect the parent repo. The worktree is auto-cleaned after completion.
@@ -156,10 +158,9 @@ subagent regardless of allowlist — they are how the subagent communicates back
 
 **3. Cancellation and timeout**
 
-Subagent termination is cooperative, not pre-emptive:
-
-- ``max_time`` (seconds) — triggers a cancel signal to the running subagent thread;
-  the subagent can check this and stop cleanly. No hard kill in thread mode.
+- ``max_time`` (seconds) — a watchdog timer that auto-cancels the subagent after
+  the specified duration and delivers a "timeout" status notification. The parent
+  calls ``subagent_cancel()`` to trigger this (thread mode only).
 
 - ``timeout`` (default 1800 s) — subprocess monitor kills the child process after
   this many seconds. Only applies in subprocess mode.

--- a/gptme/tools/subagent/api.py
+++ b/gptme/tools/subagent/api.py
@@ -150,9 +150,12 @@ def subagent(
             Only applies to thread-mode subagents; has no effect in subprocess
             or ACP modes (which build their own context as a separate process).
         max_time: Wall-clock time limit in seconds. When set, a watchdog timer
-            auto-cancels the subagent after ``max_time`` seconds by calling
-            ``subagent_cancel()`` and delivers a "timeout" status notification
-            via the LOOP_CONTINUE hook. Defaults to ``None`` (no limit).
+            marks the subagent result as ``"timeout"`` after ``max_time`` seconds
+            and delivers a timeout status notification via the LOOP_CONTINUE hook.
+            In subprocess mode the child process is terminated. In thread mode
+            the background thread is not force-stopped; callers see the cached
+            timeout result immediately while the thread continues until it
+            finishes naturally. Defaults to ``None`` (no limit).
 
             Use this for defensive orchestration (prevent a stuck subagent from
             blocking the parent) or hard time budgets in autonomous sessions.
@@ -811,8 +814,8 @@ def subagent(
         t.start()
 
     # Launch max_time watchdog after all execution paths have registered the subagent.
-    # The watchdog fires _timeout_subagent() after max_time seconds, which cancels
-    # the subagent and delivers a "timeout" notification via the LOOP_CONTINUE hook.
+    # The watchdog fires _timeout_subagent() after max_time seconds, which marks
+    # a timeout result and delivers a notification via the LOOP_CONTINUE hook.
     if max_time is not None:
         _timer = threading.Timer(max_time, _timeout_subagent, args=(agent_id, max_time))
         _timer.daemon = True


### PR DESCRIPTION
## Summary

Documents the subagent isolation contract — what a subagent inherits from its parent and what it starts fresh — in a new subsection of the Subagent tool docs.

Covers four dimensions that came up in #554 (via a question from @hiSandog):

- **Workspace config loading**: thread mode inherits parent's pre-assembled context; subprocess mode loads the `workdir`'s `gptme.toml` fresh. Documents `context_mode`, `context_window`, and `context_turns`.
- **Tool/state inheritance**: same tool list as parent by default (thread-isolated contextvars); profile allowlist, `isolated` worktree, and `redact_secrets` as restriction mechanisms.
- **Cancellation**: `max_time` cooperative signal vs `timeout` hard-kill; completion via `LOOP_CONTINUE` hook.
- **Child transcript**: fresh conversation by default; `context_turns` to forward parent turns; result delivery via `complete` signal + `subagent_read_log()`.

Also adds a note about the open `is_runnable` transient race (non-fatal since #3072, root cause tracked in #554).

## Test plan

- [ ] RST renders correctly (pre-commit hook passed)
- [ ] Docs build without warnings: `make -C docs html`