### PR TITLE
feat(computer): add computer_task() for context-efficient subagent delegation (#216)

### DIFF
--- a/gptme/tools/subagent/api.py
+++ b/gptme/tools/subagent/api.py
@@ -9,6 +9,7 @@ import random
 import string
 import subprocess
 import threading
+import time
 import uuid
 from dataclasses import asdict
 from pathlib import Path
@@ -32,6 +33,23 @@ from .types import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _wait_for_cached_subagent_result(
+    agent_id: str, timeout: float = 0.05, poll_interval: float = 0.005
+) -> ReturnType | None:
+    """Briefly wait for a concurrent watchdog/cancel result to hit the cache."""
+    deadline = time.monotonic() + timeout
+    while True:
+        with _subagent_results_lock:
+            cached_result = _subagent_results.get(agent_id)
+        if cached_result is not None:
+            return cached_result
+
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return None
+        time.sleep(min(poll_interval, remaining))
 
 
 def subagent(
@@ -1097,7 +1115,10 @@ def subagent_wait(
         # Thread mode: join thread
         sa.thread.join(timeout=timeout)
 
-    status = sa.status()
+    cached_status = (
+        _wait_for_cached_subagent_result(agent_id) if sa.is_running() else None
+    )
+    status = cached_status if cached_status is not None else sa.status()
     result_dict = asdict(status)
 
     # Compact result: truncate long outputs so they don't flood the parent's context.

--- a/tests/test_computer_task.py
+++ b/tests/test_computer_task.py
@@ -26,7 +26,7 @@ def test_computer_task_returns_status_and_result(monkeypatch):
     import gptme.tools.subagent as _sa_mod
     from gptme.tools.computer import computer_task
 
-    def fake_subagent(agent_id, prompt, profile=None, timeout=300, model=None, **kw):
+    def fake_subagent(agent_id, prompt, profile=None, model=None, **kw):
         pass
 
     def fake_wait(agent_id, timeout=300):
@@ -48,8 +48,14 @@ def test_computer_task_uses_computer_use_profile(monkeypatch):
 
     captured: list[dict] = []
 
-    def fake_subagent(agent_id, prompt, profile=None, timeout=300, model=None, **kw):
-        captured.append({"profile": profile, "max_time": kw.get("max_time")})
+    def fake_subagent(agent_id, prompt, profile=None, model=None, **kw):
+        captured.append(
+            {
+                "profile": profile,
+                "max_time": kw.get("max_time"),
+                "timeout": kw.get("timeout"),
+            }
+        )
 
     def fake_wait(agent_id, timeout=300):
         return _make_status()
@@ -63,6 +69,7 @@ def test_computer_task_uses_computer_use_profile(monkeypatch):
 
     assert len(captured) == 1
     assert captured[0]["profile"] == "computer-use"
+    assert captured[0]["timeout"] is None
 
 
 def test_computer_task_passes_timeout(monkeypatch):
@@ -97,7 +104,7 @@ def test_computer_task_passes_model_override(monkeypatch):
 
     captured_model: list[str | None] = []
 
-    def fake_subagent(agent_id, prompt, profile=None, timeout=300, model=None, **kw):
+    def fake_subagent(agent_id, prompt, profile=None, model=None, **kw):
         captured_model.append(model)
 
     def fake_wait(agent_id, timeout=300):
@@ -119,7 +126,7 @@ def test_computer_task_default_model_is_none(monkeypatch):
 
     captured_model: list[str | None] = []
 
-    def fake_subagent(agent_id, prompt, profile=None, timeout=300, model=None, **kw):
+    def fake_subagent(agent_id, prompt, profile=None, model=None, **kw):
         captured_model.append(model)
 
     def fake_wait(agent_id, timeout=300):
@@ -141,7 +148,7 @@ def test_computer_task_agent_id_is_unique(monkeypatch):
 
     agent_ids: list[str] = []
 
-    def fake_subagent(agent_id, prompt, profile=None, timeout=300, model=None, **kw):
+    def fake_subagent(agent_id, prompt, profile=None, model=None, **kw):
         agent_ids.append(agent_id)
 
     def fake_wait(agent_id, timeout=300):
@@ -168,7 +175,7 @@ def test_computer_task_result_carries_agent_id(monkeypatch):
 
     spawned_ids: list[str] = []
 
-    def fake_subagent(agent_id, prompt, profile=None, timeout=300, model=None, **kw):
+    def fake_subagent(agent_id, prompt, profile=None, model=None, **kw):
         spawned_ids.append(agent_id)
 
     def fake_wait(agent_id, timeout=300):
@@ -188,7 +195,7 @@ def test_computer_task_propagates_failure_status(monkeypatch):
     """If the subagent fails, the status is propagated unchanged."""
     from gptme.tools.computer import computer_task
 
-    def fake_subagent(agent_id, prompt, profile=None, timeout=300, model=None, **kw):
+    def fake_subagent(agent_id, prompt, profile=None, model=None, **kw):
         pass
 
     def fake_wait(agent_id, timeout=300):
@@ -209,7 +216,7 @@ def test_computer_task_propagates_timeout_status(monkeypatch):
     """If the subagent times out, the timeout status is propagated unchanged."""
     from gptme.tools.computer import computer_task
 
-    def fake_subagent(agent_id, prompt, profile=None, timeout=300, model=None, **kw):
+    def fake_subagent(agent_id, prompt, profile=None, model=None, **kw):
         pass
 
     def fake_wait(agent_id, timeout=300):
@@ -230,7 +237,7 @@ def test_computer_task_propagates_clarification_needed_status(monkeypatch):
     """If the subagent asks for clarification, the status is propagated unchanged."""
     from gptme.tools.computer import computer_task
 
-    def fake_subagent(agent_id, prompt, profile=None, timeout=300, model=None, **kw):
+    def fake_subagent(agent_id, prompt, profile=None, model=None, **kw):
         pass
 
     def fake_wait(agent_id, timeout=300):

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -2551,6 +2551,56 @@ class TestMaxTimeWatchdog:
             stop.set()
             t.join(timeout=1)
 
+    def test_subagent_wait_polls_cache_after_join_timeout(self, tmp_path):
+        """subagent_wait() handles join returning just before watchdog writes."""
+        from gptme.tools.subagent.api import subagent_wait
+        from gptme.tools.subagent.types import (
+            _subagent_results,
+            _subagent_results_lock,
+            _subagents,
+            _subagents_lock,
+        )
+
+        writer_threads: list[threading.Thread] = []
+
+        def write_timeout_after_join():
+            import time
+
+            time.sleep(0.01)
+            with _subagent_results_lock:
+                _subagent_results["wait-race-thread"] = ReturnType(
+                    "timeout", "Auto-cancelled after 0.5s (max_time exceeded)"
+                )
+
+        def join_returns_before_watchdog_write(timeout=None):
+            writer = threading.Thread(target=write_timeout_after_join)
+            writer.start()
+            writer_threads.append(writer)
+
+        mock_thread = MagicMock(spec=threading.Thread)
+        mock_thread.join.side_effect = join_returns_before_watchdog_write
+        mock_thread.is_alive.return_value = True
+
+        sa = Subagent(
+            agent_id="wait-race-thread",
+            prompt="test",
+            thread=mock_thread,
+            logdir=tmp_path,
+            model=None,
+            execution_mode="thread",
+        )
+        with _subagents_lock:
+            _subagents.append(sa)
+
+        try:
+            result = subagent_wait("wait-race-thread", timeout=0)
+        finally:
+            for writer in writer_threads:
+                writer.join(timeout=1)
+
+        assert result["status"] == "timeout"
+        assert "max_time exceeded" in (result["result"] or "")
+
     def test_completion_hook_timeout_message(self):
         """_subagent_completion_hook yields a ⏱️ message for timeout status."""
         notify_completion("hook-timeout-agent", "timeout", "Timed out after 10s")


### PR DESCRIPTION
## Summary

- Adds `computer_task(task, timeout=300, model=None)` to `gptme/tools/computer.py` — spawns a `computer-use` profile subagent, blocks until complete or timeout, returns a status dict with `status`, `result`, and `agent_id`
- Fixes status strings and docstring to match actual return values (`success`/`failure`/`clarification_needed`/`timeout`)
- Surfaces watchdog timeout result correctly to callers via `subagent_wait()`
- Adds `test_computer_task.py` with 11 unit tests (all passing, no real subagent needed)
- Cleans up watchdog helper-thread management in `test_subagent_unit.py`

## Motivation

Issue gptme/gptme#216 calls for a "context-efficient tool-use loop until goal is achieved" pattern. Without `computer_task()`, callers issuing long `computer()`+`act_and_observe()` chains accumulate dozens of screenshots in their own context. This wrapper keeps all intermediate steps inside the subagent's context.

## Usage

```python
result = computer_task(
    "Open Firefox, navigate to https://x.com/compose/tweet, "
    "type 'Hello from gptme!', and click Tweet.",
    timeout=120,
)
print(result["status"], result["result"])
# Call subagent_read_log(result["agent_id"]) for the full step-by-step transcript
```

## Test plan

- [x] `uv run pytest tests/test_computer_task.py` — 11/11 pass
- [x] `uv run pytest tests/test_subagent_unit.py::TestMaxTimeWatchdog` — 8/8 pass
- [x] pre-commit hooks clean (prek)
- [ ] CI green