### PR TITLE
fix(chats): discover cursor-chat-history.json when conversations/ dir absent

### DIFF
--- a/gptme/tools/chats.py
+++ b/gptme/tools/chats.py
@@ -164,11 +164,12 @@ def _discover_cursor_sessions(cursor_dir: Path | None = None) -> list[Path]:
     """
     if cursor_dir is None:
         cursor_dir = Path.home() / ".cursor" / "conversations"
-    if not cursor_dir.exists():
-        return []
-    results: list[Path] = sorted(cursor_dir.glob("*/conversation.json"))
     # cursor-chat-history.json lives at the .cursor/ root, not under conversations/
+    # Check it first so it's found even when conversations/ dir doesn't exist.
     alt = cursor_dir.parent / "cursor-chat-history.json"
+    if not cursor_dir.exists():
+        return [alt] if alt.exists() else []
+    results: list[Path] = sorted(cursor_dir.glob("*/conversation.json"))
     if alt.exists():
         results.append(alt)
     return results

--- a/tests/test_chats_external_search.py
+++ b/tests/test_chats_external_search.py
@@ -58,6 +58,15 @@ def test_discover_cursor_sessions_alternate_only(tmp_path):
     assert results == [alt_file]
 
 
+def test_discover_cursor_sessions_alt_without_conversations_dir(tmp_path):
+    """Returns cursor-chat-history.json when conversations/ dir is absent (issue #3075)."""
+    conv_dir = tmp_path / "conversations"  # NOT created — mirrors real Cursor installs
+    alt_file = tmp_path / "cursor-chat-history.json"
+    alt_file.write_text(json.dumps({"allConversations": []}))
+    results = _discover_cursor_sessions(conv_dir)
+    assert results == [alt_file]
+
+
 def test_discover_cursor_sessions_multiple(tmp_path):
     """Returns all conversation.json files sorted alphabetically."""
     for uid in ("bbb-222", "aaa-111"):


### PR DESCRIPTION
## Problem

`_discover_cursor_sessions` returned `[]` when `~/.cursor/conversations/` didn't exist, even if `~/.cursor/cursor-chat-history.json` was present. Real Cursor installs using only the workspace-storage alt format (no `conversations/` subdir) were silently skipped.

Root cause: the alt-file check came *after* the `if not cursor_dir.exists(): return []` early return.

The existing test `test_discover_cursor_sessions_alternate_only` masked this by calling `conv_dir.mkdir()` first.

## Fix

Move the alt-file path computation before the early return so it's checked regardless of whether `conversations/` exists.

## Changes

- `gptme/tools/chats.py`: reorder alt-file check before early return
- `tests/test_chats_external_search.py`: add `test_discover_cursor_sessions_alt_without_conversations_dir` that reproduces the exact failure (no `conversations/` mkdir)

## Testing

All 25 tests pass including the new regression test.

Closes #3075

<!-- gptme-id:v1:gai_Kq0bljdWgIrt3LH47vVFHPoyJ7QHKMDovvhxpc5ayx7 -->