### PR TITLE
fix(chats): discover cursor-chat-history.json when conversations/ dir absent

### DIFF
--- a/gptme/tools/chats.py
+++ b/gptme/tools/chats.py
@@ -164,11 +164,11 @@ def _discover_cursor_sessions(cursor_dir: Path | None = None) -> list[Path]:
     """
     if cursor_dir is None:
         cursor_dir = Path.home() / ".cursor" / "conversations"
-    if not cursor_dir.exists():
-        return []
-    results: list[Path] = sorted(cursor_dir.glob("*/conversation.json"))
     # cursor-chat-history.json lives at the .cursor/ root, not under conversations/
     alt = cursor_dir.parent / "cursor-chat-history.json"
+    if not cursor_dir.exists():
+        return [alt] if alt.exists() else []
+    results: list[Path] = sorted(cursor_dir.glob("*/conversation.json"))
     if alt.exists():
         results.append(alt)
     return results

--- a/tests/test_chats_external_search.py
+++ b/tests/test_chats_external_search.py
@@ -58,6 +58,22 @@ def test_discover_cursor_sessions_alternate_only(tmp_path):
     assert results == [alt_file]
 
 
+def test_discover_cursor_sessions_no_conversations_dir(tmp_path):
+    """Returns cursor-chat-history.json even when conversations/ dir does not exist."""
+    conv_dir = tmp_path / "conversations"  # intentionally NOT created
+    alt_file = tmp_path / "cursor-chat-history.json"
+    alt_file.write_text(json.dumps({"allConversations": []}))
+    results = _discover_cursor_sessions(conv_dir)
+    assert results == [alt_file]
+
+
+def test_discover_cursor_sessions_neither_exists(tmp_path):
+    """Returns empty list when neither conversations/ nor alt file exists."""
+    conv_dir = tmp_path / "conversations"  # intentionally NOT created
+    results = _discover_cursor_sessions(conv_dir)
+    assert results == []
+
+
 def test_discover_cursor_sessions_multiple(tmp_path):
     """Returns all conversation.json files sorted alphabetically."""
     for uid in ("bbb-222", "aaa-111"):


### PR DESCRIPTION
## Summary

- `_discover_cursor_sessions` returned `[]` when `~/.cursor/conversations/` didn't exist, even if `cursor-chat-history.json` was present
- Moves the alt-path check before the early-return guard so the alternate format is always checked
- Adds two regression tests: no-conversations-dir case, and neither-path-exists case
- Fixes the masking issue noted by the reporter: `test_discover_cursor_sessions_alternate_only` was calling `conv_dir.mkdir()`, hiding the real-user scenario

## Root cause

```python
# Before: alt check was AFTER the early return
if not cursor_dir.exists():
    return []  # ← returned here, never reached alt check
alt = cursor_dir.parent / "cursor-chat-history.json"
```

```python
# After: alt is computed first, returned if it exists
alt = cursor_dir.parent / "cursor-chat-history.json"
if not cursor_dir.exists():
    return [alt] if alt.exists() else []
```

## Test plan
- [x] `uv run pytest tests/test_chats_external_search.py -x -q` — 26 tests pass including 2 new regression tests
- [x] Existing `test_discover_cursor_sessions_alternate_only` still passes (empty-dir case still works)

Closes #3075