### PR TITLE
fix(util): interpolate date in epoch_to_age(incl_date=True)

### DIFF
--- a/gptme/util/__init__.py
+++ b/gptme/util/__init__.py
@@ -32,7 +32,9 @@ def epoch_to_age(epoch, incl_date=False):
     if age < timedelta(days=2):
         return "yesterday"
     return f"{age.days} days ago" + (
-        " ({datetime.fromtimestamp(epoch).strftime('%Y-%m-%d')})" if incl_date else ""
+        f" ({datetime.fromtimestamp(epoch, tz=timezone.utc).strftime('%Y-%m-%d')})"
+        if incl_date
+        else ""
     )
 
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -21,6 +21,16 @@ def test_epoch_to_age():
     assert epoch_to_age(epoch_yesterday) == "yesterday"
 
 
+def test_epoch_to_age_incl_date():
+    # regression: incl_date=True must interpolate the date, not return the
+    # literal f-string template (see gptme/util/__init__.py)
+    epoch = datetime.now(tz=timezone.utc).timestamp() - 3 * 24 * 60 * 60
+    result = epoch_to_age(epoch, incl_date=True)
+    assert "{datetime" not in result
+    expected_date = datetime.fromtimestamp(epoch, tz=timezone.utc).strftime("%Y-%m-%d")
+    assert result == f"3 days ago ({expected_date})"
+
+
 def test_transform_examples_to_chat_directives():
     src = """
 # Example


### PR DESCRIPTION
Fixes #3078

## Root cause

`epoch_to_age(epoch, incl_date=True)` was returning a raw, uninterpolated
f-string template instead of a date. In `gptme/util/__init__.py` the appended
date branch was a plain string literal missing its `f` prefix:

```python
return f"{age.days} days ago" + (
    " ({datetime.fromtimestamp(epoch).strftime('%Y-%m-%d')})" if incl_date else ""
)
```

so `{...}` was treated as literal text. Calling with `incl_date=True` produced:

```
3 days ago ({datetime.fromtimestamp(epoch).strftime('%Y-%m-%d')})
```

This has stayed latent because the only caller (`gptme/cli/main.py`) invokes
`epoch_to_age(conv.modified)` without `incl_date`, and the existing test only
covered the `"just now"` / `"yesterday"` branches — never `incl_date=True` nor
the `"days ago"` branch — so CI stayed green.

## Fix

- Add the missing `f` prefix so the date is interpolated.
- Pass `tz=timezone.utc` to `datetime.fromtimestamp`, matching the timezone-aware
  age calculation a few lines above. This also satisfies ruff's `DTZ006`, which
  couldn't flag the call while it was still string data.

Now:

```
3 days ago (2026-07-01)
```

## Verification

All run in a clean `python:3.10-slim` container built from `scripts/Dockerfile.dev`:

- Added `test_epoch_to_age_incl_date`, which **fails on master** (asserts the
  literal `{datetime` template is absent) and **passes with this fix**.
- `ruff check` / `ruff format --check`: clean.
- `mypy gptme/util/__init__.py`: no new errors (the pre-existing
  `sentence_transformers` stub warning is unrelated and present on master).
- `pytest tests/test_util.py tests/test_codeblock.py tests/test_reduce.py tests/test_message.py`:
  115 passed.

## Notes / scope

Kept intentionally minimal. One adjacent observation, left out of this PR to
avoid scope creep: `incl_date` is only honored in the `"days ago"` branch and
silently ignored for more recent timestamps (minutes/hours/yesterday). Happy to
follow up separately if that behavior is desired.
