### PR TITLE
fix(util): epoch_to_age incl_date=True returns literal f-string (missing f prefix)

### DIFF
--- a/gptme/util/__init__.py
+++ b/gptme/util/__init__.py
@@ -32,7 +32,9 @@ def epoch_to_age(epoch, incl_date=False):
     if age < timedelta(days=2):
         return "yesterday"
     return f"{age.days} days ago" + (
-        " ({datetime.fromtimestamp(epoch).strftime('%Y-%m-%d')})" if incl_date else ""
+        f" ({datetime.fromtimestamp(epoch, tz=timezone.utc).strftime('%Y-%m-%d')})"
+        if incl_date
+        else ""
     )
 
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -19,6 +19,13 @@ def test_epoch_to_age():
     assert epoch_to_age(epoch_today) == "just now"
     epoch_yesterday = epoch_today - 24 * 60 * 60
     assert epoch_to_age(epoch_yesterday) == "yesterday"
+    epoch_3_days_ago = epoch_today - 3 * 24 * 60 * 60
+    assert epoch_to_age(epoch_3_days_ago) == "3 days ago"
+    result = epoch_to_age(epoch_3_days_ago, incl_date=True)
+    expected_date = datetime.fromtimestamp(epoch_3_days_ago, tz=timezone.utc).strftime(
+        "%Y-%m-%d"
+    )
+    assert result == f"3 days ago ({expected_date})"
 
 
 def test_transform_examples_to_chat_directives():


### PR DESCRIPTION
## Summary

Fixes #3078.

`epoch_to_age(epoch, incl_date=True)` was returning the literal string
`{datetime.fromtimestamp(epoch).strftime('%Y-%m-%d')}` instead of the
formatted date, because the second string operand was missing its `f` prefix.

The fix is a one-character change: add `f` to the string literal.

As a bonus, `datetime.fromtimestamp()` is now passed `tz=timezone.utc` to
avoid the naive-datetime footgun (DTZ006 — which ruff caught once the code
became live Python after adding the `f` prefix).

## Changes

- `gptme/util/__init__.py`: add `f` prefix and `tz=timezone.utc` to `fromtimestamp()`
- `tests/test_util.py`: extend `test_epoch_to_age` to cover the `"days ago"` branch and `incl_date=True` path as a regression test

## Test plan

- [x] `uv run pytest tests/test_util.py::test_epoch_to_age -v` passes
- [x] Pre-commit hooks (ruff, mypy) pass

<!-- gptme-id:v1:gai_kFbRjp1OQimwewNPtr63Vv8NnOdqA1lwjvDpe7XlQo7 -->