### PR TITLE
feat(computer): add pre-action confirmation gate for sensitive actions (#216)

### DIFF
--- a/gptme/tools/_browser_playwright.py
+++ b/gptme/tools/_browser_playwright.py
@@ -746,9 +746,9 @@ def fill_element(selector: str, value: str) -> str:
         selector: Playwright selector for the input/textarea element.
         value: Text to fill into the field.
     """
-    sensitive_action_gate("fill_element", value, is_browser=True)
     if _current_page is None:
         raise RuntimeError("No page is open. Call open_page(url) first.")
+    sensitive_action_gate("fill_element", value, is_browser=True)
     logger.info(f"Filling element '{selector}' with value")
     return _execute_with_retry(_fill, selector, value)
 

--- a/gptme/tools/_browser_playwright.py
+++ b/gptme/tools/_browser_playwright.py
@@ -28,6 +28,7 @@ from ._browser_thread import (
     _is_connection_error,
     get_context_options,
 )
+from ._computer_gate import sensitive_action_gate
 
 _browser: BrowserThread | None = None
 _last_logs: dict = {"logs": [], "errors": [], "url": None}
@@ -745,6 +746,7 @@ def fill_element(selector: str, value: str) -> str:
         selector: Playwright selector for the input/textarea element.
         value: Text to fill into the field.
     """
+    sensitive_action_gate("fill_element", value, is_browser=True)
     if _current_page is None:
         raise RuntimeError("No page is open. Call open_page(url) first.")
     logger.info(f"Filling element '{selector}' with value")

--- a/gptme/tools/_computer_gate.py
+++ b/gptme/tools/_computer_gate.py
@@ -1,0 +1,97 @@
+"""Pre-action confirmation gate for sensitive computer-use actions.
+
+Sensitive actions are those that handle potentially private data:
+  computer():      type, key, left_click_drag
+  fill_element():  browser form fills
+
+Gating is opt-in via GPTME_COMPUTER_CONFIRM_SENSITIVE:
+  (unset or "0") — gate disabled, actions proceed silently (default, back-compat)
+  "1"            — gate enabled; interactive sessions prompt, non-interactive block
+  "auto-allow"   — gate enabled but auto-approves (useful in tests)
+
+When gating is enabled and the session is non-interactive (no TTY on stdin),
+sensitive actions raise PermissionError unless GPTME_COMPUTER_CONFIRM_SENSITIVE
+is set to "auto-allow".
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+#: Desktop actions that handle potentially private data.
+GATE_ACTIONS_COMPUTER: frozenset[str] = frozenset({"key", "type", "left_click_drag"})
+
+#: Browser actions that handle potentially private data.
+GATE_ACTIONS_BROWSER: frozenset[str] = frozenset({"fill_element"})
+
+
+def _gate_mode() -> str:
+    """Return the current gate mode from the environment.
+
+    Values:
+      ""           — gate disabled
+      "0"          — gate disabled (explicit)
+      "1"          — gate enabled (prompt in TTY, block otherwise)
+      "auto-allow" — gate enabled but auto-approves without prompting
+    """
+    return os.environ.get("GPTME_COMPUTER_CONFIRM_SENSITIVE", "")
+
+
+def sensitive_action_gate(
+    action: str,
+    text: str | None = None,
+    *,
+    is_browser: bool = False,
+) -> None:
+    """Block or prompt before a sensitive computer-use action executes.
+
+    Call this *before* executing any action in GATE_ACTIONS_COMPUTER or
+    GATE_ACTIONS_BROWSER.  Does nothing if the gate is disabled (default).
+
+    Args:
+        action: The action name (e.g. "type", "fill_element").
+        text: The text/value to be entered (used to compute display length only;
+              content is never shown).
+        is_browser: True when called from the browser tool (fill_element).
+
+    Raises:
+        PermissionError: If the gate is enabled and the action is denied,
+            either by the user (interactive) or automatically (non-interactive).
+    """
+    gate_set = GATE_ACTIONS_BROWSER if is_browser else GATE_ACTIONS_COMPUTER
+    if action not in gate_set:
+        return
+
+    mode = _gate_mode()
+    if not mode or mode == "0":
+        return  # gate disabled — default; back-compatible
+
+    if mode == "auto-allow":
+        return  # gate enabled but unconditionally approves
+
+    # Build a short, non-revealing description
+    if text:
+        detail = f"({len(text)} chars, content hidden)"
+    else:
+        detail = ""
+
+    if not sys.stdin.isatty():
+        raise PermissionError(
+            f"computer: sensitive action '{action}' blocked in non-interactive mode "
+            f"{detail}. "
+            "Set GPTME_COMPUTER_CONFIRM_SENSITIVE=auto-allow to permit in scripts."
+        )
+
+    # Interactive: ask the user
+    print(
+        f"\n[computer] Sensitive action: {action}  {detail}",
+        file=sys.stderr,
+    )
+    try:
+        answer = input("Allow? [y/N]: ").strip().lower()
+    except EOFError:
+        answer = ""
+
+    if answer not in ("y", "yes"):
+        raise PermissionError(f"computer: sensitive action '{action}' denied by user.")

--- a/gptme/tools/_computer_gate.py
+++ b/gptme/tools/_computer_gate.py
@@ -25,6 +25,8 @@ GATE_ACTIONS_COMPUTER: frozenset[str] = frozenset({"key", "type", "left_click_dr
 #: Browser actions that handle potentially private data.
 GATE_ACTIONS_BROWSER: frozenset[str] = frozenset({"fill_element"})
 
+VALID_GATE_MODES: frozenset[str] = frozenset({"", "0", "1", "auto-allow"})
+
 
 def _gate_mode() -> str:
     """Return the current gate mode from the environment.
@@ -35,7 +37,14 @@ def _gate_mode() -> str:
       "1"          — gate enabled (prompt in TTY, block otherwise)
       "auto-allow" — gate enabled but auto-approves without prompting
     """
-    return os.environ.get("GPTME_COMPUTER_CONFIRM_SENSITIVE", "")
+    raw_mode = os.environ.get("GPTME_COMPUTER_CONFIRM_SENSITIVE", "")
+    mode = raw_mode.strip().lower()
+    if mode not in VALID_GATE_MODES:
+        raise ValueError(
+            "Invalid GPTME_COMPUTER_CONFIRM_SENSITIVE value "
+            f"{raw_mode!r}; expected one of: unset, '0', '1', 'auto-allow'."
+        )
+    return mode
 
 
 def sensitive_action_gate(

--- a/gptme/tools/computer.py
+++ b/gptme/tools/computer.py
@@ -34,6 +34,11 @@ The tool uses these environment variables:
 - DISPLAY: X11 display to use (default: ":1", Linux only)
 - WIDTH: Screen width (default: 1024)
 - HEIGHT: Screen height (default: 768)
+- GPTME_COMPUTER_CONFIRM_SENSITIVE: Pre-execution gate for sensitive actions
+  (type, key, left_click_drag, fill_element).  Values:
+  - unset / "0": gate disabled (default, back-compatible)
+  - "1": gate enabled; interactive sessions prompt the user, non-interactive sessions block
+  - "auto-allow": gate enabled but approves silently (useful in automated scripts)
 
 .. rubric:: Usage
 
@@ -96,6 +101,7 @@ import time
 from enum import Enum
 from typing import TYPE_CHECKING, Literal, TypedDict
 
+from ._computer_gate import sensitive_action_gate
 from .base import ToolFunction, ToolSpec, ToolUse
 from .computer_transport import get_transport
 from .screenshot import screenshot
@@ -1489,6 +1495,7 @@ def computer(
     if action in ("mouse_move", "left_click_drag"):
         if not coordinate:
             raise ValueError(f"coordinate is required for {action}")
+        sensitive_action_gate(action)
         x, y = _scale_coordinates(
             _ScalingSource.API, coordinate[0], coordinate[1], width, height
         )
@@ -1510,6 +1517,7 @@ def computer(
     if action in ("key", "type"):
         if not text:
             raise ValueError(f"text is required for {action}")
+        sensitive_action_gate(action, text)
 
         if IS_MACOS:
             if action == "key":

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -349,8 +349,9 @@ def test_click_without_open_page():
         click_element("#some-button")
 
 
-def test_fill_without_open_page():
+def test_fill_without_open_page(monkeypatch):
     """Test that fill_element fails gracefully without open_page."""
+    monkeypatch.setenv("GPTME_COMPUTER_CONFIRM_SENSITIVE", "1")
     close_page()  # Ensure no page is open
     with pytest.raises(RuntimeError, match="No page is open"):
         fill_element("#some-input", "value")

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -357,6 +357,16 @@ def test_fill_without_open_page(monkeypatch):
         fill_element("#some-input", "value")
 
 
+def test_fill_with_open_page_checks_sensitive_gate(monkeypatch):
+    """Test that fill_element checks the gate once a page is open."""
+    from gptme.tools import _browser_playwright
+
+    monkeypatch.setenv("GPTME_COMPUTER_CONFIRM_SENSITIVE", "true")
+    monkeypatch.setattr(_browser_playwright, "_current_page", object())
+    with pytest.raises(ValueError, match="GPTME_COMPUTER_CONFIRM_SENSITIVE"):
+        _browser_playwright.fill_element("#some-input", "value")
+
+
 def test_scroll_without_open_page():
     """Test that scroll_page fails gracefully without open_page."""
     close_page()  # Ensure no page is open

--- a/tests/test_computer_gate.py
+++ b/tests/test_computer_gate.py
@@ -1,0 +1,238 @@
+"""Tests for the sensitive-action confirmation gate (_computer_gate.py).
+
+Validates that:
+- The gate is disabled by default (back-compat)
+- GPTME_COMPUTER_CONFIRM_SENSITIVE=1 blocks non-interactive sensitive actions
+- GPTME_COMPUTER_CONFIRM_SENSITIVE=auto-allow permits sensitive actions without prompting
+- Non-sensitive actions always pass through regardless of mode
+- fill_element and left_click_drag are gated; left_click is not
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gptme.tools._computer_gate import (
+    GATE_ACTIONS_BROWSER,
+    GATE_ACTIONS_COMPUTER,
+    sensitive_action_gate,
+)
+
+# ---------------------------------------------------------------------------
+# Default behaviour: gate disabled
+# ---------------------------------------------------------------------------
+
+
+def test_gate_disabled_by_default_type(monkeypatch):
+    """type() proceeds silently when GPTME_COMPUTER_CONFIRM_SENSITIVE is unset."""
+    monkeypatch.delenv("GPTME_COMPUTER_CONFIRM_SENSITIVE", raising=False)
+    sensitive_action_gate("type", "hello")  # must not raise
+
+
+def test_gate_disabled_by_default_key(monkeypatch):
+    monkeypatch.delenv("GPTME_COMPUTER_CONFIRM_SENSITIVE", raising=False)
+    sensitive_action_gate("key", "Return")
+
+
+def test_gate_disabled_by_default_fill_element(monkeypatch):
+    monkeypatch.delenv("GPTME_COMPUTER_CONFIRM_SENSITIVE", raising=False)
+    sensitive_action_gate("fill_element", "secret", is_browser=True)
+
+
+def test_gate_disabled_explicit_zero(monkeypatch):
+    monkeypatch.setenv("GPTME_COMPUTER_CONFIRM_SENSITIVE", "0")
+    sensitive_action_gate("type", "secret")  # must not raise
+
+
+def test_gate_does_not_block_non_sensitive_actions(monkeypatch):
+    """Non-sensitive actions are always allowed regardless of gate mode."""
+    monkeypatch.setenv("GPTME_COMPUTER_CONFIRM_SENSITIVE", "1")
+    for action in (
+        "screenshot",
+        "left_click",
+        "scroll",
+        "open_page",
+        "cursor_position",
+    ):
+        sensitive_action_gate(action)  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# auto-allow mode: gate enabled but approves unconditionally
+# ---------------------------------------------------------------------------
+
+
+def test_gate_auto_allow_permits_type(monkeypatch):
+    monkeypatch.setenv("GPTME_COMPUTER_CONFIRM_SENSITIVE", "auto-allow")
+    sensitive_action_gate("type", "hunter2")  # must not raise
+
+
+def test_gate_auto_allow_permits_key(monkeypatch):
+    monkeypatch.setenv("GPTME_COMPUTER_CONFIRM_SENSITIVE", "auto-allow")
+    sensitive_action_gate("key", "ctrl+c")
+
+
+def test_gate_auto_allow_permits_fill_element(monkeypatch):
+    monkeypatch.setenv("GPTME_COMPUTER_CONFIRM_SENSITIVE", "auto-allow")
+    sensitive_action_gate("fill_element", "password", is_browser=True)
+
+
+def test_gate_auto_allow_permits_left_click_drag(monkeypatch):
+    monkeypatch.setenv("GPTME_COMPUTER_CONFIRM_SENSITIVE", "auto-allow")
+    sensitive_action_gate("left_click_drag")
+
+
+# ---------------------------------------------------------------------------
+# Enabled + non-interactive: sensitive actions are blocked
+# ---------------------------------------------------------------------------
+
+
+def test_gate_blocks_type_in_noninteractive(monkeypatch):
+    """type() raises PermissionError in non-interactive mode when gate=1."""
+    monkeypatch.setenv("GPTME_COMPUTER_CONFIRM_SENSITIVE", "1")
+    monkeypatch.setattr("sys.stdin", _fake_noninteractive_stdin())
+    with pytest.raises(PermissionError, match="type"):
+        sensitive_action_gate("type", "hunter2")
+
+
+def test_gate_blocks_key_in_noninteractive(monkeypatch):
+    monkeypatch.setenv("GPTME_COMPUTER_CONFIRM_SENSITIVE", "1")
+    monkeypatch.setattr("sys.stdin", _fake_noninteractive_stdin())
+    with pytest.raises(PermissionError, match="key"):
+        sensitive_action_gate("key", "Return")
+
+
+def test_gate_blocks_left_click_drag_in_noninteractive(monkeypatch):
+    monkeypatch.setenv("GPTME_COMPUTER_CONFIRM_SENSITIVE", "1")
+    monkeypatch.setattr("sys.stdin", _fake_noninteractive_stdin())
+    with pytest.raises(PermissionError, match="left_click_drag"):
+        sensitive_action_gate("left_click_drag")
+
+
+def test_gate_blocks_fill_element_in_noninteractive(monkeypatch):
+    monkeypatch.setenv("GPTME_COMPUTER_CONFIRM_SENSITIVE", "1")
+    monkeypatch.setattr("sys.stdin", _fake_noninteractive_stdin())
+    with pytest.raises(PermissionError, match="fill_element"):
+        sensitive_action_gate("fill_element", "secret", is_browser=True)
+
+
+def test_gate_error_message_hides_content(monkeypatch):
+    """The PermissionError message must not contain the actual text value."""
+    monkeypatch.setenv("GPTME_COMPUTER_CONFIRM_SENSITIVE", "1")
+    monkeypatch.setattr("sys.stdin", _fake_noninteractive_stdin())
+    with pytest.raises(PermissionError) as exc_info:
+        sensitive_action_gate("type", "mysecret")
+    assert "mysecret" not in str(exc_info.value)
+
+
+def test_gate_error_message_includes_char_count(monkeypatch):
+    """The PermissionError message should include the character count."""
+    monkeypatch.setenv("GPTME_COMPUTER_CONFIRM_SENSITIVE", "1")
+    monkeypatch.setattr("sys.stdin", _fake_noninteractive_stdin())
+    with pytest.raises(PermissionError) as exc_info:
+        sensitive_action_gate("type", "hello")
+    # "5 chars" or "5 chars" should appear
+    assert "5" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# Interactive mode: user approval / denial
+# ---------------------------------------------------------------------------
+
+
+def test_gate_interactive_allows_on_yes(monkeypatch, capsys):
+    """'y' at the prompt allows the action."""
+    monkeypatch.setenv("GPTME_COMPUTER_CONFIRM_SENSITIVE", "1")
+    monkeypatch.setattr("sys.stdin", _fake_interactive_stdin("y"))
+    # Must not raise
+    sensitive_action_gate("type", "hello")
+
+
+def test_gate_interactive_allows_on_yes_full(monkeypatch):
+    monkeypatch.setenv("GPTME_COMPUTER_CONFIRM_SENSITIVE", "1")
+    monkeypatch.setattr("sys.stdin", _fake_interactive_stdin("yes"))
+    sensitive_action_gate("key", "Return")
+
+
+def test_gate_interactive_blocks_on_no(monkeypatch):
+    monkeypatch.setenv("GPTME_COMPUTER_CONFIRM_SENSITIVE", "1")
+    monkeypatch.setattr("sys.stdin", _fake_interactive_stdin("n"))
+    with pytest.raises(PermissionError, match="denied by user"):
+        sensitive_action_gate("type", "hello")
+
+
+def test_gate_interactive_blocks_on_empty(monkeypatch):
+    """Empty reply defaults to N (deny)."""
+    monkeypatch.setenv("GPTME_COMPUTER_CONFIRM_SENSITIVE", "1")
+    monkeypatch.setattr("sys.stdin", _fake_interactive_stdin(""))
+    with pytest.raises(PermissionError, match="denied by user"):
+        sensitive_action_gate("type", "hello")
+
+
+def test_gate_interactive_blocks_on_eof(monkeypatch):
+    """EOFError at prompt (piped empty stdin) defaults to deny."""
+    monkeypatch.setenv("GPTME_COMPUTER_CONFIRM_SENSITIVE", "1")
+    monkeypatch.setattr("sys.stdin", _fake_interactive_stdin_eof())
+    with pytest.raises(PermissionError, match="denied by user"):
+        sensitive_action_gate("type", "hello")
+
+
+# ---------------------------------------------------------------------------
+# Action set membership
+# ---------------------------------------------------------------------------
+
+
+def test_gate_actions_computer_contents():
+    assert "type" in GATE_ACTIONS_COMPUTER
+    assert "key" in GATE_ACTIONS_COMPUTER
+    assert "left_click_drag" in GATE_ACTIONS_COMPUTER
+    assert "left_click" not in GATE_ACTIONS_COMPUTER
+    assert "screenshot" not in GATE_ACTIONS_COMPUTER
+
+
+def test_gate_actions_browser_contents():
+    assert "fill_element" in GATE_ACTIONS_BROWSER
+    assert "click_element" not in GATE_ACTIONS_BROWSER
+    assert "open_page" not in GATE_ACTIONS_BROWSER
+
+
+def test_is_browser_flag_routes_correctly(monkeypatch):
+    """fill_element is only gated when is_browser=True."""
+    monkeypatch.setenv("GPTME_COMPUTER_CONFIRM_SENSITIVE", "auto-allow")
+    # With is_browser=True: gated (passes because auto-allow)
+    sensitive_action_gate("fill_element", "val", is_browser=True)
+    # With is_browser=False: fill_element is not in GATE_ACTIONS_COMPUTER → passes
+    sensitive_action_gate("fill_element", "val", is_browser=False)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _FakeStdin:
+    """Fake stdin whose isatty() and readline() are controllable."""
+
+    def __init__(self, *, is_tty: bool, line: str | None):
+        self._is_tty = is_tty
+        self._line = line  # None triggers EOFError
+
+    def isatty(self) -> bool:
+        return self._is_tty
+
+    def readline(self) -> str:
+        if self._line is None:
+            raise EOFError
+        return self._line + "\n"
+
+
+def _fake_noninteractive_stdin() -> _FakeStdin:
+    return _FakeStdin(is_tty=False, line=None)
+
+
+def _fake_interactive_stdin(answer: str) -> _FakeStdin:
+    return _FakeStdin(is_tty=True, line=answer)
+
+
+def _fake_interactive_stdin_eof() -> _FakeStdin:
+    return _FakeStdin(is_tty=True, line=None)

--- a/tests/test_computer_gate.py
+++ b/tests/test_computer_gate.py
@@ -44,6 +44,17 @@ def test_gate_disabled_explicit_zero(monkeypatch):
     sensitive_action_gate("type", "secret")  # must not raise
 
 
+def test_gate_rejects_unknown_mode(monkeypatch):
+    monkeypatch.setenv("GPTME_COMPUTER_CONFIRM_SENSITIVE", "true")
+    with pytest.raises(ValueError, match="GPTME_COMPUTER_CONFIRM_SENSITIVE"):
+        sensitive_action_gate("type", "secret")
+
+
+def test_gate_normalizes_mode(monkeypatch):
+    monkeypatch.setenv("GPTME_COMPUTER_CONFIRM_SENSITIVE", " AUTO-ALLOW ")
+    sensitive_action_gate("type", "secret")  # must not raise
+
+
 def test_gate_does_not_block_non_sensitive_actions(monkeypatch):
     """Non-sensitive actions are always allowed regardless of gate mode."""
     monkeypatch.setenv("GPTME_COMPUTER_CONFIRM_SENSITIVE", "1")


### PR DESCRIPTION
## Summary

- Adds `GPTME_COMPUTER_CONFIRM_SENSITIVE` env var to gate keyboard input and form-fill actions before they execute
- Addresses the open permission-boundary gap from the #216 thread: "the label now exists at the tool layer; the enforcement hook doesn't yet"
- Fully backward-compatible — gate is opt-in and disabled by default

## What changed

**`gptme/tools/_computer_gate.py`** (new) — standalone gate module:
- `sensitive_action_gate(action, text, *, is_browser)` — call before executing any sensitive action; does nothing when gate is disabled
- `GATE_ACTIONS_COMPUTER = {"key", "type", "left_click_drag"}`
- `GATE_ACTIONS_BROWSER = {"fill_element"}`

**`gptme/tools/computer.py`** — wires the gate before `key`/`type`/`left_click_drag` execution

**`gptme/tools/_browser_playwright.py`** — wires the gate in `fill_element()`

**`tests/test_computer_gate.py`** (new, 23 tests) — covers all modes, all sensitive actions, privacy guarantee (text is never in the error message), and interactive y/N/EOF paths

## Gate modes

| `GPTME_COMPUTER_CONFIRM_SENSITIVE` | Behaviour |
|------------------------------------|-----------|
| unset / `"0"` | Gate disabled — actions proceed silently (default, back-compat) |
| `"1"` | Gate enabled — interactive sessions show `y/N` prompt; non-interactive sessions raise `PermissionError` |
| `"auto-allow"` | Gate enabled but auto-approves (for automated scripts that opt into the gate infrastructure) |

## What remains for #216

- Real-time risk-label streaming to parent agent (audit log is still retroactive)
- Native accessibility backends (AT-SPI/macOS) for non-browser native apps
- Docker/VNC streaming mode

Closes #216 partial — the pre-action gate identified as the next step in the last issue comment thread.