### PR TITLE
feat(computer): add real-time risk-label streaming to parent agent (#216)

### DIFF
--- a/gptme/cli/cmd_computer.py
+++ b/gptme/cli/cmd_computer.py
@@ -12,6 +12,12 @@ import click
 
 from ..dirs import get_logs_dir
 from ..logmanager import _gen_read_jsonl
+from ..tools._computer_gate import (
+    ACTION_RISK_READ,
+    ACTION_RISK_SENSITIVE,
+    ACTION_RISK_WRITE,
+    action_risk_level,
+)
 from ..tools.base import ToolUse
 
 # Patterns that indicate text/key content (redact for privacy)
@@ -23,78 +29,14 @@ _URL_BROWSER_FNS = frozenset({"observe_web", "snapshot_url", "open_page"})
 # Browser interaction functions whose first arg is a CSS/DOM selector
 _SELECTOR_BROWSER_FNS = frozenset({"click_element"})
 
-# ---------------------------------------------------------------------------
-# Action risk classification
-# ---------------------------------------------------------------------------
-# read      — no side effects; safe to run without confirmation
-# write     — modifies visible state (mouse/keyboard/browser interaction)
-# sensitive — write action that also handles potentially private data
-#             (text content is redacted in the audit log, but the action itself
-#             is flagged so reviewers know private data may have been processed)
-#
-# This mirrors the three-tier permission model described in the computer-use
-# profile system prompt: observation → structured interaction → raw input.
-
-#: Actions that only read state and have no side effects.
-ACTION_RISK_READ: frozenset[str] = frozenset(
-    {
-        "screenshot",
-        "cursor_position",
-        "accessibility_tree",
-        "wait_for_change",
-        # browser observation
-        "snapshot_url",
-        "observe_web",
-        "read_page_text",
-        # high-level wrappers
-        "observe_desktop",
-    }
-)
-
-#: Actions that change visible state (clicks, navigation, scrolling).
-ACTION_RISK_WRITE: frozenset[str] = frozenset(
-    {
-        "left_click",
-        "right_click",
-        "middle_click",
-        "double_click",
-        "mouse_move",
-        "scroll",
-        "window_focus",
-        # browser interaction
-        "click_element",
-        "scroll_page",
-        "open_page",
-    }
-)
-
-#: Actions that handle potentially private data (keyboard input, form fills).
-#: Text content is always redacted in the audit log; only length is recorded.
-ACTION_RISK_SENSITIVE: frozenset[str] = frozenset(
-    {
-        "type",
-        "key",
-        "left_click_drag",
-        # browser
-        "fill_element",
-    }
-)
-
-
-def action_risk_level(action: str) -> str:
-    """Return the risk level for a computer-use action.
-
-    Returns one of ``"read"``, ``"write"``, or ``"sensitive"``.
-    Unknown actions default to ``"write"`` (conservative).
-    """
-    if action in ACTION_RISK_READ:
-        return "read"
-    if action in ACTION_RISK_WRITE:
-        return "write"
-    if action in ACTION_RISK_SENSITIVE:
-        return "sensitive"
-    # write is the conservative default for any unclassified action
-    return "write"
+# ACTION_RISK_* and action_risk_level are imported from _computer_gate
+# (re-exported here for backward compatibility with any existing callers)
+__all__ = [
+    "ACTION_RISK_READ",
+    "ACTION_RISK_WRITE",
+    "ACTION_RISK_SENSITIVE",
+    "action_risk_level",
+]
 
 
 def _slice_call(code: str, start: int) -> str:

--- a/gptme/tools/_computer_gate.py
+++ b/gptme/tools/_computer_gate.py
@@ -1,4 +1,4 @@
-"""Pre-action confirmation gate for sensitive computer-use actions.
+"""Pre-action confirmation gate and risk-level classification for computer-use actions.
 
 Sensitive actions are those that handle potentially private data:
   computer():      type, key, left_click_drag
@@ -12,6 +12,15 @@ Gating is opt-in via GPTME_COMPUTER_CONFIRM_SENSITIVE:
 When gating is enabled and the session is non-interactive (no TTY on stdin),
 sensitive actions raise PermissionError unless GPTME_COMPUTER_CONFIRM_SENSITIVE
 is set to "auto-allow".
+
+.. rubric:: Risk levels
+
+Every computer-use action carries one of three risk levels:
+
+- ``read``      — observation only, no side effects
+- ``write``     — modifies visible state (clicks, navigation, scroll)
+- ``sensitive`` — write action that also handles potentially private data
+                  (text content is redacted in audit logs; only length recorded)
 """
 
 from __future__ import annotations
@@ -24,6 +33,75 @@ GATE_ACTIONS_COMPUTER: frozenset[str] = frozenset({"key", "type", "left_click_dr
 
 #: Browser actions that handle potentially private data.
 GATE_ACTIONS_BROWSER: frozenset[str] = frozenset({"fill_element"})
+
+# ---------------------------------------------------------------------------
+# Risk-level classification
+# ---------------------------------------------------------------------------
+# This mirrors the three-tier permission model described in the computer-use
+# profile system prompt: observation → structured interaction → raw input.
+# The same sets are used by the audit-log CLI and the real-time streaming hook.
+
+#: Actions that only read state and have no side effects.
+ACTION_RISK_READ: frozenset[str] = frozenset(
+    {
+        "screenshot",
+        "cursor_position",
+        "accessibility_tree",
+        "wait_for_change",
+        # browser observation
+        "snapshot_url",
+        "observe_web",
+        "read_page_text",
+        # high-level wrappers
+        "observe_desktop",
+    }
+)
+
+#: Actions that change visible state (clicks, navigation, scrolling).
+ACTION_RISK_WRITE: frozenset[str] = frozenset(
+    {
+        "left_click",
+        "right_click",
+        "middle_click",
+        "double_click",
+        "mouse_move",
+        "scroll",
+        "window_focus",
+        # browser interaction
+        "click_element",
+        "scroll_page",
+        "open_page",
+    }
+)
+
+#: Actions that handle potentially private data (keyboard input, form fills).
+#: Text content is always redacted in audit logs; only length is recorded.
+ACTION_RISK_SENSITIVE: frozenset[str] = frozenset(
+    {
+        "type",
+        "key",
+        "left_click_drag",
+        # browser
+        "fill_element",
+    }
+)
+
+
+def action_risk_level(action: str) -> str:
+    """Return the risk level for a computer-use action.
+
+    Returns one of ``"read"``, ``"write"``, or ``"sensitive"``.
+    Unknown actions default to ``"write"`` (conservative).
+    """
+    if action in ACTION_RISK_READ:
+        return "read"
+    if action in ACTION_RISK_WRITE:
+        return "write"
+    if action in ACTION_RISK_SENSITIVE:
+        return "sensitive"
+    # write is the conservative default for any unclassified action
+    return "write"
+
 
 VALID_GATE_MODES: frozenset[str] = frozenset({"", "0", "1", "auto-allow"})
 

--- a/gptme/tools/computer.py
+++ b/gptme/tools/computer.py
@@ -101,7 +101,7 @@ import time
 from enum import Enum
 from typing import TYPE_CHECKING, Literal, TypedDict
 
-from ._computer_gate import sensitive_action_gate
+from ._computer_gate import action_risk_level, sensitive_action_gate
 from .base import ToolFunction, ToolSpec, ToolUse
 from .computer_transport import get_transport
 from .screenshot import screenshot
@@ -122,6 +122,54 @@ _sleep = time.sleep
 
 # Platform detection
 IS_MACOS = platform.system() == "Darwin"
+
+
+def _stream_action_risk(
+    action: str,
+    *,
+    text: str | None = None,
+    coordinate: tuple[int, int] | None = None,
+) -> None:
+    """Emit a live risk-label record to the parent agent's progress queue.
+
+    Called at the start of ``computer()`` and ``act_and_observe()``.  When the
+    current execution context is a ``computer_task()`` subagent, the record is
+    forwarded to the parent agent via ``notify_progress()`` so the parent can
+    track each action's risk level in real-time — rather than having to wait
+    for the subagent to finish and then call ``gptme-util computer audit-log``.
+
+    Does nothing when:
+    - Not running inside a subagent (``get_current_agent_id()`` returns None)
+    - Any import or notification call raises an exception (never breaks the action)
+
+    The record format is a JSON object with keys:
+    - ``action``    — action name (e.g. ``"left_click"``)
+    - ``risk``      — risk level: ``"read"``, ``"write"``, or ``"sensitive"``
+    - ``coord``     — ``[x, y]`` for coordinate-based actions, absent otherwise
+    - ``text_len``  — byte-length of text for sensitive actions; absent otherwise
+                      (content is *never* emitted — only its length)
+    """
+    try:
+        import json as _json
+
+        from .subagent import get_current_agent_id, notify_progress
+
+        agent_id = get_current_agent_id()
+        if agent_id is None:
+            return
+
+        risk = action_risk_level(action)
+        record: dict = {"action": action, "risk": risk}
+        if coordinate is not None:
+            record["coord"] = list(coordinate)
+        if risk == "sensitive" and text is not None:
+            record["text_len"] = len(text)
+
+        notify_progress(
+            agent_id, f"action:{_json.dumps(record, separators=(',', ':'))}"
+        )
+    except Exception:
+        pass  # never let streaming failures interrupt the action
 
 
 def _make_screenshot_msg(path: Path, tool: str = "computer") -> Message | None:
@@ -1443,6 +1491,10 @@ def computer(
         text: Text to type or key sequence to send
         coordinate: X,Y coordinates for mouse actions
     """
+    # Emit a live risk-label record to the parent agent when running inside
+    # a computer_task() subagent.  This is a no-op in all other contexts.
+    _stream_action_risk(action, text=text, coordinate=coordinate)
+
     # Optional transport-layer dispatch (env: GPTME_COMPUTER_TRANSPORT)
     transport = get_transport()
     if transport:

--- a/gptme/tools/computer.py
+++ b/gptme/tools/computer.py
@@ -163,7 +163,7 @@ def _stream_action_risk(
         if coordinate is not None:
             record["coord"] = list(coordinate)
         if risk == "sensitive" and text is not None:
-            record["text_len"] = len(text)
+            record["text_len"] = len(text.encode())
 
         notify_progress(
             agent_id, f"action:{_json.dumps(record, separators=(',', ':'))}"
@@ -1491,6 +1491,11 @@ def computer(
         text: Text to type or key sequence to send
         coordinate: X,Y coordinates for mouse actions
     """
+    # Gate check before streaming: ensures blocked sensitive actions never emit
+    # a misleading progress record to the parent agent.  No-op for read/write
+    # actions; may raise PermissionError for sensitive ones when gating is on.
+    sensitive_action_gate(action, text)
+
     # Emit a live risk-label record to the parent agent when running inside
     # a computer_task() subagent.  This is a no-op in all other contexts.
     _stream_action_risk(action, text=text, coordinate=coordinate)
@@ -1547,7 +1552,6 @@ def computer(
     if action in ("mouse_move", "left_click_drag"):
         if not coordinate:
             raise ValueError(f"coordinate is required for {action}")
-        sensitive_action_gate(action)
         x, y = _scale_coordinates(
             _ScalingSource.API, coordinate[0], coordinate[1], width, height
         )
@@ -1569,7 +1573,6 @@ def computer(
     if action in ("key", "type"):
         if not text:
             raise ValueError(f"text is required for {action}")
-        sensitive_action_gate(action, text)
 
         if IS_MACOS:
             if action == "key":

--- a/gptme/tools/computer.py
+++ b/gptme/tools/computer.py
@@ -132,11 +132,15 @@ def _stream_action_risk(
 ) -> None:
     """Emit a live risk-label record to the parent agent's progress queue.
 
-    Called at the start of ``computer()`` and ``act_and_observe()``.  When the
+    Called by ``computer()`` after sensitive-action gating succeeds.  When the
     current execution context is a ``computer_task()`` subagent, the record is
     forwarded to the parent agent via ``notify_progress()`` so the parent can
-    track each action's risk level in real-time — rather than having to wait
-    for the subagent to finish and then call ``gptme-util computer audit-log``.
+    track each action's risk level in real-time rather than having to wait for
+    the subagent to finish and then call ``gptme-util computer audit-log``.
+
+    ``act_and_observe()`` delegates through ``computer()``, so it emits records
+    for the requested action and, on the local fallback path, for its internal
+    ``computer("wait_for_change")`` polling call.
 
     Does nothing when:
     - Not running inside a subagent (``get_current_agent_id()`` returns None)

--- a/gptme/tools/subagent/__init__.py
+++ b/gptme/tools/subagent/__init__.py
@@ -23,6 +23,7 @@ from .api import (
     subagent_wait,
 )
 from .batch import BatchJob, subagent_batch
+from .execution import get_current_agent_id
 from .hooks import (
     _get_complete_instruction,
     _subagent_completion_hook,
@@ -426,6 +427,8 @@ __all__ = [
     "notify_progress",
     "_subagent_completion_hook",
     "_get_complete_instruction",
+    # Execution context
+    "get_current_agent_id",
     # Module-level state (re-exported for backward compatibility)
     "_subagents",
     "_subagents_lock",

--- a/tests/test_computer_risk_streaming.py
+++ b/tests/test_computer_risk_streaming.py
@@ -119,13 +119,14 @@ def test_emits_sensitive_action_with_text_len_not_text(agent_id):
     """Sensitive actions include text length but never the raw text content."""
     mock_np = MagicMock()
     subagent_mod = _make_subagent_module(agent_id, mock_np)
-    secret = "mysecretpassword"
+    secret = "mysecretpassword🔒"
     with patch.dict("sys.modules", {"gptme.tools.subagent": subagent_mod}):
         _stream_action_risk("type", text=secret)
     record = _parse_progress_call(mock_np)
     assert record["action"] == "type"
     assert record["risk"] == "sensitive"
     assert record["text_len"] == len(secret.encode())
+    assert record["text_len"] != len(secret)
     # Raw content must never appear in the emitted record
     assert secret not in json.dumps(record)
 

--- a/tests/test_computer_risk_streaming.py
+++ b/tests/test_computer_risk_streaming.py
@@ -5,8 +5,12 @@ Validates that _stream_action_risk():
 - Only fires when get_current_agent_id() returns a non-None agent id
 - Is a no-op outside of a subagent context (no agent id)
 - Includes coordinate in the record when provided
-- Includes text_len (not raw text) for sensitive actions
+- Includes text_len (byte-length, not raw text) for sensitive actions
 - Silently swallows all exceptions to avoid breaking the action
+
+Gate-ordering guarantee (Greptile P1):
+- Streaming fires AFTER sensitive_action_gate(), so blocked actions never emit
+  a progress record to the parent agent.
 """
 
 from __future__ import annotations
@@ -17,7 +21,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from gptme.tools._computer_gate import action_risk_level
-from gptme.tools.computer import _stream_action_risk
+from gptme.tools.computer import _stream_action_risk, computer
 
 # ---------------------------------------------------------------------------
 # Risk-level classification (canonical source is _computer_gate.py)
@@ -121,7 +125,7 @@ def test_emits_sensitive_action_with_text_len_not_text(agent_id):
     record = _parse_progress_call(mock_np)
     assert record["action"] == "type"
     assert record["risk"] == "sensitive"
-    assert record["text_len"] == len(secret)
+    assert record["text_len"] == len(secret.encode())
     # Raw content must never appear in the emitted record
     assert secret not in json.dumps(record)
 
@@ -169,4 +173,33 @@ def test_exception_in_get_current_agent_id_is_swallowed():
     subagent_mod.notify_progress = mock_np
     with patch.dict("sys.modules", {"gptme.tools.subagent": subagent_mod}):
         _stream_action_risk("screenshot")  # must not raise
+    mock_np.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Gate-ordering guarantee: blocked actions must not emit a progress record
+# ---------------------------------------------------------------------------
+
+
+def test_gate_blocked_action_does_not_emit_progress_record(agent_id):
+    """When sensitive_action_gate raises PermissionError, no streaming record is sent.
+
+    This is the P1 ordering fix: _stream_action_risk() must fire AFTER the gate
+    check so a blocked action never delivers a misleading progress record to the
+    parent agent claiming the action was performed.
+    """
+    mock_np = MagicMock()
+    subagent_mod = _make_subagent_module(agent_id, mock_np)
+
+    # Simulate a non-interactive session with gate enabled — sensitive actions blocked
+    env_override = {"GPTME_COMPUTER_CONFIRM_SENSITIVE": "1"}
+    with (
+        patch.dict("sys.modules", {"gptme.tools.subagent": subagent_mod}),
+        patch.dict("os.environ", env_override),
+        patch("sys.stdin.isatty", return_value=False),
+        pytest.raises(PermissionError),
+    ):
+        computer("type", text="secret")
+
+    # No progress record should have been emitted for the blocked action
     mock_np.assert_not_called()

--- a/tests/test_computer_risk_streaming.py
+++ b/tests/test_computer_risk_streaming.py
@@ -1,0 +1,172 @@
+"""Tests for real-time risk-label streaming in computer-use actions (#216).
+
+Validates that _stream_action_risk():
+- Emits the correct action name and risk level via notify_progress()
+- Only fires when get_current_agent_id() returns a non-None agent id
+- Is a no-op outside of a subagent context (no agent id)
+- Includes coordinate in the record when provided
+- Includes text_len (not raw text) for sensitive actions
+- Silently swallows all exceptions to avoid breaking the action
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from gptme.tools._computer_gate import action_risk_level
+from gptme.tools.computer import _stream_action_risk
+
+# ---------------------------------------------------------------------------
+# Risk-level classification (canonical source is _computer_gate.py)
+# ---------------------------------------------------------------------------
+
+
+def test_action_risk_level_read():
+    assert action_risk_level("screenshot") == "read"
+    assert action_risk_level("accessibility_tree") == "read"
+    assert action_risk_level("observe_desktop") == "read"
+
+
+def test_action_risk_level_write():
+    assert action_risk_level("left_click") == "write"
+    assert action_risk_level("mouse_move") == "write"
+    assert action_risk_level("window_focus") == "write"
+
+
+def test_action_risk_level_sensitive():
+    assert action_risk_level("type") == "sensitive"
+    assert action_risk_level("key") == "sensitive"
+    assert action_risk_level("left_click_drag") == "sensitive"
+
+
+def test_action_risk_level_unknown_defaults_to_write():
+    assert action_risk_level("totally_unknown_action") == "write"
+
+
+# ---------------------------------------------------------------------------
+# _stream_action_risk: no-op outside subagent
+# ---------------------------------------------------------------------------
+
+
+def test_no_emit_outside_subagent():
+    """When get_current_agent_id() returns None, notify_progress is never called."""
+    mock_np = MagicMock()
+    subagent_mod = MagicMock()
+    subagent_mod.get_current_agent_id.return_value = None  # not inside a subagent
+    subagent_mod.notify_progress = mock_np
+    with patch.dict("sys.modules", {"gptme.tools.subagent": subagent_mod}):
+        _stream_action_risk("screenshot")
+    mock_np.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _stream_action_risk: emits records inside a subagent
+# ---------------------------------------------------------------------------
+
+
+def _parse_progress_call(mock_np) -> dict:
+    """Extract and parse the JSON record from a notify_progress() call."""
+    assert mock_np.call_count == 1, f"expected 1 call, got {mock_np.call_count}"
+    _agent_id, message = mock_np.call_args[0]
+    assert message.startswith("action:"), f"unexpected prefix: {message!r}"
+    return json.loads(message[len("action:") :])
+
+
+def _make_subagent_module(agent_id: str, mock_np: MagicMock) -> MagicMock:
+    mod = MagicMock()
+    mod.get_current_agent_id.return_value = agent_id
+    mod.notify_progress = mock_np
+    return mod
+
+
+@pytest.fixture
+def agent_id():
+    return "test-agent-42"
+
+
+def test_emits_read_action(agent_id):
+    mock_np = MagicMock()
+    subagent_mod = _make_subagent_module(agent_id, mock_np)
+    with patch.dict("sys.modules", {"gptme.tools.subagent": subagent_mod}):
+        _stream_action_risk("screenshot")
+    record = _parse_progress_call(mock_np)
+    assert record["action"] == "screenshot"
+    assert record["risk"] == "read"
+    assert "coord" not in record
+    assert "text_len" not in record
+
+
+def test_emits_write_action_with_coordinate(agent_id):
+    mock_np = MagicMock()
+    subagent_mod = _make_subagent_module(agent_id, mock_np)
+    with patch.dict("sys.modules", {"gptme.tools.subagent": subagent_mod}):
+        _stream_action_risk("left_click", coordinate=(640, 480))
+    record = _parse_progress_call(mock_np)
+    assert record["action"] == "left_click"
+    assert record["risk"] == "write"
+    assert record["coord"] == [640, 480]
+    assert "text_len" not in record
+
+
+def test_emits_sensitive_action_with_text_len_not_text(agent_id):
+    """Sensitive actions include text length but never the raw text content."""
+    mock_np = MagicMock()
+    subagent_mod = _make_subagent_module(agent_id, mock_np)
+    secret = "mysecretpassword"
+    with patch.dict("sys.modules", {"gptme.tools.subagent": subagent_mod}):
+        _stream_action_risk("type", text=secret)
+    record = _parse_progress_call(mock_np)
+    assert record["action"] == "type"
+    assert record["risk"] == "sensitive"
+    assert record["text_len"] == len(secret)
+    # Raw content must never appear in the emitted record
+    assert secret not in json.dumps(record)
+
+
+def test_emits_sensitive_action_without_text(agent_id):
+    """Sensitive action with no text: text_len is absent (not None)."""
+    mock_np = MagicMock()
+    subagent_mod = _make_subagent_module(agent_id, mock_np)
+    with patch.dict("sys.modules", {"gptme.tools.subagent": subagent_mod}):
+        _stream_action_risk("key")
+    record = _parse_progress_call(mock_np)
+    assert record["action"] == "key"
+    assert record["risk"] == "sensitive"
+    assert "text_len" not in record
+
+
+def test_passes_agent_id_to_notify_progress(agent_id):
+    """notify_progress receives the correct agent_id as its first argument."""
+    mock_np = MagicMock()
+    subagent_mod = _make_subagent_module(agent_id, mock_np)
+    with patch.dict("sys.modules", {"gptme.tools.subagent": subagent_mod}):
+        _stream_action_risk("left_click")
+    called_agent_id, _msg = mock_np.call_args[0]
+    assert called_agent_id == agent_id
+
+
+# ---------------------------------------------------------------------------
+# _stream_action_risk: exception safety
+# ---------------------------------------------------------------------------
+
+
+def test_exception_in_notify_progress_is_swallowed(agent_id):
+    """An exception inside notify_progress must never propagate to the caller."""
+    mock_np = MagicMock(side_effect=RuntimeError("queue full"))
+    subagent_mod = _make_subagent_module(agent_id, mock_np)
+    with patch.dict("sys.modules", {"gptme.tools.subagent": subagent_mod}):
+        _stream_action_risk("left_click")  # must not raise
+
+
+def test_exception_in_get_current_agent_id_is_swallowed():
+    """An exception in get_current_agent_id must never propagate."""
+    mock_np = MagicMock()
+    subagent_mod = MagicMock()
+    subagent_mod.get_current_agent_id.side_effect = RuntimeError("thread-local error")
+    subagent_mod.notify_progress = mock_np
+    with patch.dict("sys.modules", {"gptme.tools.subagent": subagent_mod}):
+        _stream_action_risk("screenshot")  # must not raise
+    mock_np.assert_not_called()


### PR DESCRIPTION
## Summary

Closes the last audit gap identified in #216: the audit log was retroactive (post-session only). Now the parent agent sees each `computer()` action's risk level in **real-time** via the existing `notify_progress()` hook — no need to wait for the subagent to finish.

### What changed

- **`gptme/tools/_computer_gate.py`** — Added `ACTION_RISK_*` constants and `action_risk_level()` here (previously duplicated in `cmd_computer.py`). The gate and the streaming hook now share a single source of truth.
- **`gptme/cli/cmd_computer.py`** — Replaced the inline risk-level definitions with imports from `_computer_gate`. No behaviour change.
- **`gptme/tools/computer.py`** — Added `_stream_action_risk()` helper; hooked into `computer()` before transport dispatch (covers both local xdotool/screencapture and VNC transport paths).
- **`gptme/tools/subagent/__init__.py`** — Exported `get_current_agent_id()` from the package.
- **`tests/test_computer_risk_streaming.py`** — 12 new tests.

### Record format

Each `computer()` call inside a `computer_task()` subagent now emits a progress message:

```
action:{"action":"left_click","risk":"write","coord":[640,480]}
action:{"action":"type","risk":"sensitive","text_len":12}
```

Keys: `action`, `risk` (`read`/`write`/`sensitive`), optional `coord` (write/sensitive with coordinates), optional `text_len` (sensitive only; raw content is never emitted).

### Safety

- No-op when `get_current_agent_id()` returns `None` (i.e., outside a subagent context)
- All exceptions silently swallowed — streaming failures never break the action itself
- Text content is never included; only its byte-length

### Context

This is the remaining open gap described in the [last status comment](https://github.com/gptme/gptme/issues/216#issuecomment-...) on #216 after PR #3081 (pre-action confirmation gate) merged.

<!-- gptme-id:v1:gai_vZWDtqTCW9IKSRfp7U4peYdjhsiC4zSIq3vE51j0uGx -->