### PR TITLE
feat(computer): add --jsonl output format to audit-log (#216)

### DIFF
--- a/gptme/cli/cmd_computer.py
+++ b/gptme/cli/cmd_computer.py
@@ -288,9 +288,15 @@ def computer():
     help="Number of most-recent conversations to scan (ignored when CONVERSATION is given).",
 )
 @click.option(
-    "--json", "as_json", is_flag=True, help="Output raw JSON instead of table."
+    "--json", "as_json", is_flag=True, help="Output raw JSON array instead of table."
 )
-def audit_log(conversation: str | None, last: int, as_json: bool):
+@click.option(
+    "--jsonl",
+    "as_jsonl",
+    is_flag=True,
+    help="Output newline-delimited JSON (one record per line). Useful for streaming to log aggregators.",
+)
+def audit_log(conversation: str | None, last: int, as_json: bool, as_jsonl: bool):
     """Extract computer-use actions from session trajectories.
 
     Reads conversation JSONL logs (the authoritative audit trail) and prints a
@@ -308,6 +314,8 @@ def audit_log(conversation: str | None, last: int, as_json: bool):
         gptme-util computer audit-log
         gptme-util computer audit-log --last 3
         gptme-util computer audit-log my-session-name --json
+        gptme-util computer audit-log my-session-name --jsonl
+        gptme-util computer audit-log --jsonl | jq 'select(.risk_level == "sensitive")'
     """
     logs_dir = get_logs_dir()
 
@@ -352,8 +360,17 @@ def audit_log(conversation: str | None, last: int, as_json: bool):
         click.echo("No computer-use actions found.")
         return
 
+    if as_json and as_jsonl:
+        click.echo("Error: --json and --jsonl are mutually exclusive.", err=True)
+        sys.exit(1)
+
     if as_json:
         click.echo(json.dumps(all_records, indent=2))
+        return
+
+    if as_jsonl:
+        for record in all_records:
+            click.echo(json.dumps(record, separators=(",", ":")))
         return
 
     # Human-readable table

--- a/gptme/cli/cmd_computer.py
+++ b/gptme/cli/cmd_computer.py
@@ -356,13 +356,13 @@ def audit_log(conversation: str | None, last: int, as_json: bool, as_jsonl: bool
             r["conversation"] = path.parent.name
         all_records.extend(records)
 
-    if not all_records:
-        click.echo("No computer-use actions found.")
-        return
-
     if as_json and as_jsonl:
         click.echo("Error: --json and --jsonl are mutually exclusive.", err=True)
         sys.exit(1)
+
+    if not all_records:
+        click.echo("No computer-use actions found.")
+        return
 
     if as_json:
         click.echo(json.dumps(all_records, indent=2))

--- a/tests/test_computer_audit.py
+++ b/tests/test_computer_audit.py
@@ -797,3 +797,141 @@ def test_act_and_observe_table_output(tmp_path):
     assert result.exit_code == 0
     assert "via act_and_observe()" in result.output
     assert "[760, 540]" in result.output
+
+
+# ---------------------------------------------------------------------------
+# --jsonl output format (#216 audit export gap)
+# ---------------------------------------------------------------------------
+
+
+def test_audit_log_cli_jsonl_output(tmp_path, monkeypatch):
+    """--jsonl outputs one JSON object per line (newline-delimited JSON)."""
+    conv_dir = tmp_path / "jsonl-test-conv"
+    jsonl = conv_dir / "conversation.jsonl"
+    msgs = [
+        _msg("assistant", _ipython_block("computer('screenshot')")),
+        _msg(
+            "assistant", _ipython_block("computer('left_click', coordinate=(100, 200))")
+        ),
+    ]
+    _write_conv_jsonl(jsonl, msgs)
+    monkeypatch.setattr("gptme.cli.cmd_computer.get_logs_dir", lambda: tmp_path)
+
+    runner = CliRunner()
+    result = runner.invoke(audit_log, [str(jsonl), "--jsonl"], catch_exceptions=False)
+    assert result.exit_code == 0
+
+    lines = [line for line in result.output.splitlines() if line.strip()]
+    assert len(lines) == 2
+
+    record0 = json.loads(lines[0])
+    assert record0["action"] == "screenshot"
+
+    record1 = json.loads(lines[1])
+    assert record1["action"] == "left_click"
+    assert record1["coordinate"] == [100, 200]
+
+
+def test_audit_log_cli_jsonl_each_line_valid_json(tmp_path, monkeypatch):
+    """Every line in --jsonl output must be valid JSON independently."""
+    conv_dir = tmp_path / "jsonl-validity-conv"
+    jsonl = conv_dir / "conversation.jsonl"
+    msgs = [
+        _msg(
+            "assistant",
+            _ipython_block(
+                "computer('type', text='hello')\ncomputer('key', text='Return')\ncomputer('screenshot')"
+            ),
+        )
+    ]
+    _write_conv_jsonl(jsonl, msgs)
+    monkeypatch.setattr("gptme.cli.cmd_computer.get_logs_dir", lambda: tmp_path)
+
+    runner = CliRunner()
+    result = runner.invoke(audit_log, [str(jsonl), "--jsonl"], catch_exceptions=False)
+    assert result.exit_code == 0
+
+    for line in result.output.splitlines():
+        if not line.strip():
+            continue
+        obj = json.loads(line)  # raises if invalid JSON
+        assert "action" in obj
+        assert "risk_level" in obj
+
+
+def test_audit_log_cli_jsonl_sensitive_text_redacted(tmp_path, monkeypatch):
+    """--jsonl preserves the text_len redaction (text content never logged raw)."""
+    conv_dir = tmp_path / "jsonl-redact-conv"
+    jsonl = conv_dir / "conversation.jsonl"
+    msgs = [_msg("assistant", _ipython_block("computer('type', text='mysecret')"))]
+    _write_conv_jsonl(jsonl, msgs)
+    monkeypatch.setattr("gptme.cli.cmd_computer.get_logs_dir", lambda: tmp_path)
+
+    runner = CliRunner()
+    result = runner.invoke(audit_log, [str(jsonl), "--jsonl"], catch_exceptions=False)
+    assert result.exit_code == 0
+
+    lines = [line for line in result.output.splitlines() if line.strip()]
+    assert len(lines) == 1
+    record = json.loads(lines[0])
+    assert record["action"] == "type"
+    assert "text_len" in record
+    assert "mysecret" not in result.output
+
+
+def test_audit_log_cli_jsonl_compact_no_whitespace(tmp_path, monkeypatch):
+    """--jsonl emits compact JSON (no indentation), one object per line."""
+    conv_dir = tmp_path / "jsonl-compact-conv"
+    jsonl = conv_dir / "conversation.jsonl"
+    msgs = [_msg("assistant", _ipython_block("computer('screenshot')"))]
+    _write_conv_jsonl(jsonl, msgs)
+    monkeypatch.setattr("gptme.cli.cmd_computer.get_logs_dir", lambda: tmp_path)
+
+    runner = CliRunner()
+    result = runner.invoke(audit_log, [str(jsonl), "--jsonl"], catch_exceptions=False)
+    assert result.exit_code == 0
+
+    lines = [line for line in result.output.splitlines() if line.strip()]
+    assert len(lines) == 1
+    # Compact: no newlines within the JSON object itself
+    assert "\n" not in lines[0]
+    # No 2-space indent (which --json uses)
+    assert "  " not in lines[0]
+
+
+def test_audit_log_cli_jsonl_and_json_mutually_exclusive(tmp_path, monkeypatch):
+    """--json and --jsonl together exit with an error."""
+    conv_dir = tmp_path / "jsonl-mutex-conv"
+    jsonl = conv_dir / "conversation.jsonl"
+    msgs = [_msg("assistant", _ipython_block("computer('screenshot')"))]
+    _write_conv_jsonl(jsonl, msgs)
+    monkeypatch.setattr("gptme.cli.cmd_computer.get_logs_dir", lambda: tmp_path)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        audit_log, [str(jsonl), "--json", "--jsonl"], catch_exceptions=False
+    )
+    assert result.exit_code == 1
+
+
+def test_audit_log_cli_jsonl_risk_levels_present(tmp_path, monkeypatch):
+    """--jsonl output includes risk_level for every record."""
+    conv_dir = tmp_path / "jsonl-risk-conv"
+    jsonl = conv_dir / "conversation.jsonl"
+    code = (
+        "computer('screenshot')\n"  # read
+        "computer('left_click', coordinate=(10, 20))\n"  # write
+        "computer('type', text='pw')"  # sensitive
+    )
+    msgs = [_msg("assistant", _ipython_block(code))]
+    _write_conv_jsonl(jsonl, msgs)
+    monkeypatch.setattr("gptme.cli.cmd_computer.get_logs_dir", lambda: tmp_path)
+
+    runner = CliRunner()
+    result = runner.invoke(audit_log, [str(jsonl), "--jsonl"], catch_exceptions=False)
+    assert result.exit_code == 0
+
+    lines = [line for line in result.output.splitlines() if line.strip()]
+    assert len(lines) == 3
+    risks = [json.loads(line)["risk_level"] for line in lines]
+    assert risks == ["read", "write", "sensitive"]

--- a/tests/test_computer_audit.py
+++ b/tests/test_computer_audit.py
@@ -914,6 +914,24 @@ def test_audit_log_cli_jsonl_and_json_mutually_exclusive(tmp_path, monkeypatch):
     assert result.exit_code == 1
 
 
+def test_audit_log_cli_jsonl_and_json_mutually_exclusive_empty_log(
+    tmp_path, monkeypatch
+):
+    """--json and --jsonl conflict is rejected even when no records exist."""
+    conv_dir = tmp_path / "jsonl-empty-mutex-conv"
+    jsonl = conv_dir / "conversation.jsonl"
+    _write_conv_jsonl(jsonl, [_msg("user", "no computer calls here")])
+    monkeypatch.setattr("gptme.cli.cmd_computer.get_logs_dir", lambda: tmp_path)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        audit_log, [str(jsonl), "--json", "--jsonl"], catch_exceptions=False
+    )
+    assert result.exit_code == 1
+    assert "--json and --jsonl are mutually exclusive" in result.output
+    assert "No computer-use actions found" not in result.output
+
+
 def test_audit_log_cli_jsonl_risk_levels_present(tmp_path, monkeypatch):
     """--jsonl output includes risk_level for every record."""
     conv_dir = tmp_path / "jsonl-risk-conv"


### PR DESCRIPTION
## Summary

Adds a `--jsonl` flag to `gptme-util computer audit-log` that outputs newline-delimited JSON (one record per line), closing the last stated audit export gap from #216.

- `--json` already existed (JSON array). `--jsonl` is the streaming-friendly companion: one JSON object per line.
- Useful for piping to log aggregators and `jq` filters:
  ```
  gptme-util computer audit-log --jsonl | jq 'select(.risk_level == "sensitive")'
  ```
- `--json` and `--jsonl` are mutually exclusive (exit 1 if both given)
- Records are compact (no indentation), preserving full privacy redaction: text content never appears, only `text_len`
- `risk_level` (read/write/sensitive) is present on every record

## Tests

6 new tests in `tests/test_computer_audit.py`:
- Basic JSONL output (two records, correct actions)
- Per-line JSON validity (each line independently parseable)
- Sensitive text redaction preserved in JSONL mode
- Compact format (no indentation, no embedded newlines)
- Mutual exclusion with `--json`
- Risk level presence across all three tiers (read/write/sensitive)

All 115 existing computer tests pass.

Closes #216 (final stated audit export gap).

<!-- gptme-id:v1:gai_ILtxsQsf0NoqIlM10J2rD6zN12TQycUnO6MYUoa1Xmw -->