### PR TITLE
feat(computer): expose audit trail in computer_task() result + --agent-id CLI option (#216)

### DIFF
--- a/gptme/cli/cmd_computer.py
+++ b/gptme/cli/cmd_computer.py
@@ -339,25 +339,46 @@ def audit_log(
     """
     logs_dir = get_logs_dir()
 
+    if agent_id is not None and conversation:
+        click.echo(
+            "Error: --agent-id and CONVERSATION are mutually exclusive.",
+            err=True,
+        )
+        sys.exit(1)
+
     # --agent-id is a shortcut: computer_task() returns agent_id like
-    # "computer-task-abc123", but the conversation is stored as
-    # "subagent-computer-task-abc123". Resolve automatically.
+    # "computer-task-abc123", but thread-mode subagents store conversations as
+    # "subagent-computer-task-abc123-r4nd". Resolve automatically.
     if agent_id is not None:
-        # The subagent conversation is stored with a "subagent-" prefix.
         subagent_conv = f"subagent-{agent_id}"
-        conv_path = logs_dir / subagent_conv / "conversation.jsonl"
-        if not conv_path.exists():
-            # Also try without prefix (backward compat / alternative storage)
-            conv_path_bare = logs_dir / agent_id / "conversation.jsonl"
-            if conv_path_bare.exists():
-                conv_path = conv_path_bare
-            else:
-                click.echo(
-                    f"Error: no conversation found for agent-id '{agent_id}'.\n"
-                    f"Looked for: {logs_dir / subagent_conv} and {logs_dir / agent_id}",
-                    err=True,
-                )
-                sys.exit(1)
+        candidates = [
+            path
+            for path in [
+                logs_dir / subagent_conv / "conversation.jsonl",
+                logs_dir / agent_id / "conversation.jsonl",
+            ]
+            if path.exists()
+        ]
+        candidates.extend(
+            sorted(logs_dir.glob(f"{subagent_conv}-*/conversation.jsonl"))
+        )
+        if not candidates:
+            click.echo(
+                f"Error: no conversation found for agent-id '{agent_id}'.\n"
+                f"Looked for: {logs_dir / subagent_conv}, "
+                f"{logs_dir / (subagent_conv + '-*')}, and {logs_dir / agent_id}",
+                err=True,
+            )
+            sys.exit(1)
+        if len(candidates) > 1:
+            click.echo(
+                f"Error: multiple conversations found for agent-id '{agent_id}'.\n"
+                "Use the exact CONVERSATION name instead:\n"
+                + "\n".join(f"  {path.parent.name}" for path in candidates),
+                err=True,
+            )
+            sys.exit(1)
+        conv_path = candidates[0]
         paths = [conv_path]
     elif conversation:
         # Single named conversation

--- a/gptme/cli/cmd_computer.py
+++ b/gptme/cli/cmd_computer.py
@@ -296,7 +296,23 @@ def computer():
     is_flag=True,
     help="Output newline-delimited JSON (one record per line). Useful for streaming to log aggregators.",
 )
-def audit_log(conversation: str | None, last: int, as_json: bool, as_jsonl: bool):
+@click.option(
+    "--agent-id",
+    "agent_id",
+    default=None,
+    help=(
+        "computer_task() agent ID to audit (e.g. 'computer-task-abc12345'). "
+        "Automatically resolves the subagent conversation name. "
+        "Use the 'agent_id' key from the computer_task() result dict."
+    ),
+)
+def audit_log(
+    conversation: str | None,
+    last: int,
+    as_json: bool,
+    as_jsonl: bool,
+    agent_id: str | None,
+):
     """Extract computer-use actions from session trajectories.
 
     Reads conversation JSONL logs (the authoritative audit trail) and prints a
@@ -308,6 +324,9 @@ def audit_log(conversation: str | None, last: int, as_json: bool, as_jsonl: bool
     CONVERSATION is a conversation name or ID. Omit to scan the most-recent
     session(s) (controlled by --last).
 
+    Use --agent-id to audit a specific computer_task() run by its agent ID.
+    The agent ID comes from the 'agent_id' key in the dict returned by computer_task().
+
     Examples:
 
     \b
@@ -316,10 +335,31 @@ def audit_log(conversation: str | None, last: int, as_json: bool, as_jsonl: bool
         gptme-util computer audit-log my-session-name --json
         gptme-util computer audit-log my-session-name --jsonl
         gptme-util computer audit-log --jsonl | jq 'select(.risk_level == "sensitive")'
+        gptme-util computer audit-log --agent-id computer-task-abc12345
     """
     logs_dir = get_logs_dir()
 
-    if conversation:
+    # --agent-id is a shortcut: computer_task() returns agent_id like
+    # "computer-task-abc123", but the conversation is stored as
+    # "subagent-computer-task-abc123". Resolve automatically.
+    if agent_id is not None:
+        # The subagent conversation is stored with a "subagent-" prefix.
+        subagent_conv = f"subagent-{agent_id}"
+        conv_path = logs_dir / subagent_conv / "conversation.jsonl"
+        if not conv_path.exists():
+            # Also try without prefix (backward compat / alternative storage)
+            conv_path_bare = logs_dir / agent_id / "conversation.jsonl"
+            if conv_path_bare.exists():
+                conv_path = conv_path_bare
+            else:
+                click.echo(
+                    f"Error: no conversation found for agent-id '{agent_id}'.\n"
+                    f"Looked for: {logs_dir / subagent_conv} and {logs_dir / agent_id}",
+                    err=True,
+                )
+                sys.exit(1)
+        paths = [conv_path]
+    elif conversation:
         # Single named conversation
         conv_path = logs_dir / conversation / "conversation.jsonl"
         if not conv_path.exists():

--- a/gptme/tools/computer.py
+++ b/gptme/tools/computer.py
@@ -2310,16 +2310,19 @@ def computer_task(
         model: Optional model override for the subagent.
 
     Returns:
-        Status dict with keys ``status`` (``"success"`` / ``"failure"`` /
-        ``"clarification_needed"`` / ``"timeout"``) and ``result`` (text
-        summary from the subagent).
+        Status dict with keys:
+
+        - ``status``: ``"success"`` / ``"failure"`` / ``"clarification_needed"`` / ``"timeout"``
+        - ``result``: text summary from the subagent
+        - ``agent_id``: subagent identifier — pass to ``subagent_read_log()`` for the full transcript
+        - ``conversation``: conversation name for the audit CLI (``gptme-util computer audit-log CONVERSATION``)
+        - ``logdir``: absolute path to the subagent's conversation directory (str)
+
         ``"clarification_needed"`` is returned if the subagent needs more
         information before it can complete the task.
         ``"timeout"`` is returned when the wall-clock deadline is reached before
         the subagent finishes. The worker thread may still wind down in the
         background, but callers immediately see the terminal timeout result.
-        Call ``subagent_read_log(agent_id)`` for the full step-by-step
-        transcript — the dict also carries the ``agent_id`` key for that.
 
     Example (from IPython in a gptme session)::
 
@@ -2331,15 +2334,18 @@ def computer_task(
         )
         print(result["status"], result["result"])
 
-        # Check if the task produced a file
-        result = computer_task(
-            "Take a screenshot and save it to /tmp/desktop.png"
-        )
-        print(result["status"])
+        # Audit what the subagent actually did (computer-use actions only)
+        import subprocess
+        subprocess.run(["gptme-util", "computer", "audit-log", result["conversation"]])
+
+        # Read the full step-by-step transcript
+        from gptme.tools.subagent import subagent_read_log
+        print(subagent_read_log(result["agent_id"]))
     """
     import uuid as _uuid
 
     from .subagent import subagent, subagent_wait
+    from .subagent.types import _subagents, _subagents_lock
 
     agent_id = f"computer-task-{_uuid.uuid4().hex[:8]}"
     subagent(
@@ -2351,6 +2357,15 @@ def computer_task(
     )
     result = subagent_wait(agent_id, timeout=timeout)
     result["agent_id"] = agent_id
+
+    # Look up the subagent's logdir so callers can find the audit trail without
+    # needing to know that the conversation is stored as "subagent-{agent_id}".
+    with _subagents_lock:
+        sa = next((s for s in _subagents if s.agent_id == agent_id), None)
+    if sa is not None:
+        result["logdir"] = str(sa.logdir)
+        result["conversation"] = sa.logdir.name
+
     return result
 
 

--- a/gptme/tools/computer.py
+++ b/gptme/tools/computer.py
@@ -2310,7 +2310,7 @@ def computer_task(
         model: Optional model override for the subagent.
 
     Returns:
-        Status dict with keys:
+        dict: Status mapping with keys:
 
         - ``status``: ``"success"`` / ``"failure"`` / ``"clarification_needed"`` / ``"timeout"``
         - ``result``: text summary from the subagent

--- a/tests/test_computer_audit.py
+++ b/tests/test_computer_audit.py
@@ -961,10 +961,10 @@ def test_audit_log_cli_jsonl_risk_levels_present(tmp_path, monkeypatch):
 
 
 def test_audit_log_agent_id_resolves_subagent_prefix(tmp_path, monkeypatch):
-    """--agent-id computer-task-abc123 looks up subagent-computer-task-abc123."""
+    """--agent-id computer-task-abc123 looks up suffixed subagent logs."""
     agent_id = "computer-task-abc12345"
-    # The subagent conversation is stored with the "subagent-" prefix
-    conv_dir = tmp_path / f"subagent-{agent_id}"
+    # Thread-mode subagent conversations add a random suffix to the logdir.
+    conv_dir = tmp_path / f"subagent-{agent_id}-r3k9"
     jsonl = conv_dir / "conversation.jsonl"
     msgs = [
         _msg("user", "take a screenshot"),
@@ -981,6 +981,28 @@ def test_audit_log_agent_id_resolves_subagent_prefix(tmp_path, monkeypatch):
     records = json.loads(result.output)
     assert len(records) == 1
     assert records[0]["action"] == "screenshot"
+
+
+def test_audit_log_agent_id_rejects_multiple_matches(tmp_path, monkeypatch):
+    """--agent-id does not silently choose between multiple matching logs."""
+    agent_id = "computer-task-duplicate"
+    msgs = [_msg("assistant", _ipython_block("computer('screenshot')"))]
+    _write_conv_jsonl(
+        tmp_path / f"subagent-{agent_id}-aaaa" / "conversation.jsonl", msgs
+    )
+    _write_conv_jsonl(
+        tmp_path / f"subagent-{agent_id}-bbbb" / "conversation.jsonl", msgs
+    )
+    monkeypatch.setattr("gptme.cli.cmd_computer.get_logs_dir", lambda: tmp_path)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        audit_log, ["--agent-id", agent_id, "--json"], catch_exceptions=False
+    )
+    assert result.exit_code != 0
+    assert "multiple conversations found" in result.output
+    assert f"subagent-{agent_id}-aaaa" in result.output
+    assert f"subagent-{agent_id}-bbbb" in result.output
 
 
 def test_audit_log_agent_id_missing_prints_error(tmp_path, monkeypatch):
@@ -1017,3 +1039,19 @@ def test_audit_log_agent_id_fallback_bare_name(tmp_path, monkeypatch):
     records = json.loads(result.output)
     assert len(records) == 1
     assert records[0]["action"] == "left_click"
+
+
+def test_audit_log_agent_id_and_conversation_are_mutually_exclusive(
+    tmp_path, monkeypatch
+):
+    """Passing both selectors is rejected instead of silently ignoring one."""
+    monkeypatch.setattr("gptme.cli.cmd_computer.get_logs_dir", lambda: tmp_path)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        audit_log,
+        ["some-session", "--agent-id", "computer-task-abc12345"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code != 0
+    assert "--agent-id and CONVERSATION are mutually exclusive" in result.output

--- a/tests/test_computer_audit.py
+++ b/tests/test_computer_audit.py
@@ -953,3 +953,67 @@ def test_audit_log_cli_jsonl_risk_levels_present(tmp_path, monkeypatch):
     assert len(lines) == 3
     risks = [json.loads(line)["risk_level"] for line in lines]
     assert risks == ["read", "write", "sensitive"]
+
+
+# ---------------------------------------------------------------------------
+# --agent-id option: resolve computer_task() agent IDs to subagent conversations
+# ---------------------------------------------------------------------------
+
+
+def test_audit_log_agent_id_resolves_subagent_prefix(tmp_path, monkeypatch):
+    """--agent-id computer-task-abc123 looks up subagent-computer-task-abc123."""
+    agent_id = "computer-task-abc12345"
+    # The subagent conversation is stored with the "subagent-" prefix
+    conv_dir = tmp_path / f"subagent-{agent_id}"
+    jsonl = conv_dir / "conversation.jsonl"
+    msgs = [
+        _msg("user", "take a screenshot"),
+        _msg("assistant", _ipython_block("computer('screenshot')")),
+    ]
+    _write_conv_jsonl(jsonl, msgs)
+    monkeypatch.setattr("gptme.cli.cmd_computer.get_logs_dir", lambda: tmp_path)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        audit_log, ["--agent-id", agent_id, "--json"], catch_exceptions=False
+    )
+    assert result.exit_code == 0, result.output
+    records = json.loads(result.output)
+    assert len(records) == 1
+    assert records[0]["action"] == "screenshot"
+
+
+def test_audit_log_agent_id_missing_prints_error(tmp_path, monkeypatch):
+    """--agent-id for a non-existent subagent prints an actionable error."""
+    monkeypatch.setattr("gptme.cli.cmd_computer.get_logs_dir", lambda: tmp_path)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        audit_log, ["--agent-id", "computer-task-nothere"], catch_exceptions=False
+    )
+    assert result.exit_code != 0
+    assert "computer-task-nothere" in result.output
+
+
+def test_audit_log_agent_id_fallback_bare_name(tmp_path, monkeypatch):
+    """--agent-id falls back to a bare conversation name (no subagent- prefix)."""
+    agent_id = "computer-task-fallback1"
+    # Stored WITHOUT the "subagent-" prefix (e.g. legacy or subprocess mode)
+    conv_dir = tmp_path / agent_id
+    jsonl = conv_dir / "conversation.jsonl"
+    msgs = [
+        _msg(
+            "assistant", _ipython_block("computer('left_click', coordinate=(10, 20))")
+        ),
+    ]
+    _write_conv_jsonl(jsonl, msgs)
+    monkeypatch.setattr("gptme.cli.cmd_computer.get_logs_dir", lambda: tmp_path)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        audit_log, ["--agent-id", agent_id, "--json"], catch_exceptions=False
+    )
+    assert result.exit_code == 0, result.output
+    records = json.loads(result.output)
+    assert len(records) == 1
+    assert records[0]["action"] == "left_click"

--- a/tests/test_computer_task.py
+++ b/tests/test_computer_task.py
@@ -265,3 +265,72 @@ def test_computer_task_registered_in_tool_spec():
     assert "computer_task" in fn_names, (
         f"computer_task not found in tool.functions; found: {fn_names}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Tests for logdir / conversation in result (audit trail discoverability)
+# ---------------------------------------------------------------------------
+
+
+def test_computer_task_result_includes_logdir_and_conversation(monkeypatch, tmp_path):
+    """When the subagent has a logdir, result carries 'logdir' and 'conversation'."""
+    from unittest.mock import MagicMock
+
+    import gptme.tools.subagent as _sa_mod
+    import gptme.tools.subagent.types as _sa_types
+    from gptme.tools.computer import computer_task
+
+    fake_logdir = tmp_path / "subagent-computer-task-deadbeef"
+    fake_logdir.mkdir()
+
+    fake_sa = MagicMock()
+    fake_sa.agent_id = None  # will be set during the call
+    fake_sa.logdir = fake_logdir
+
+    spawned_ids: list[str] = []
+
+    def fake_subagent(agent_id, prompt, profile=None, model=None, **kw):
+        spawned_ids.append(agent_id)
+        fake_sa.agent_id = agent_id
+
+    def fake_wait(agent_id, timeout=300):
+        return _make_status("success", "Done.")
+
+    monkeypatch.setattr(_sa_mod, "subagent", fake_subagent)
+    monkeypatch.setattr(_sa_mod, "subagent_wait", fake_wait)
+
+    monkeypatch.setattr(_sa_types, "_subagents", [fake_sa])
+
+    result = computer_task("take a screenshot")
+
+    assert "logdir" in result, "result should include 'logdir'"
+    assert "conversation" in result, "result should include 'conversation'"
+    assert result["logdir"] == str(fake_logdir)
+    assert result["conversation"] == fake_logdir.name
+
+
+def test_computer_task_result_missing_logdir_does_not_crash(monkeypatch):
+    """If the subagent is not in the registry (shouldn't happen), result is still returned."""
+    import gptme.tools.subagent as _sa_mod
+    import gptme.tools.subagent.types as _sa_types
+    from gptme.tools.computer import computer_task
+
+    def fake_subagent(agent_id, prompt, profile=None, model=None, **kw):
+        pass
+
+    def fake_wait(agent_id, timeout=300):
+        return _make_status("success", "Done.")
+
+    monkeypatch.setattr(_sa_mod, "subagent", fake_subagent)
+    monkeypatch.setattr(_sa_mod, "subagent_wait", fake_wait)
+    # Empty _subagents — subagent lookup fails gracefully
+    monkeypatch.setattr(_sa_types, "_subagents", [])
+
+    result = computer_task("take a screenshot")
+
+    # Status and agent_id are always present
+    assert result["status"] == "success"
+    assert "agent_id" in result
+    # logdir / conversation absent when lookup fails — that's fine
+    assert result.get("logdir") is None
+    assert result.get("conversation") is None


### PR DESCRIPTION
## Problem

`computer_task()` returns an `agent_id` like `computer-task-abc123`, but the subagent conversation is actually stored as `subagent-computer-task-abc123`. Users have no way to connect the result to the audit trail without knowing this internal naming convention.

Previously, to audit a `computer_task()` run you'd need to:
1. Know that conversations are stored with a `subagent-` prefix
2. Manually construct the conversation name
3. Run `gptme-util computer audit-log subagent-computer-task-abc123`

## Fix

Two focused changes:

### 1. `computer_task()` result now includes `conversation` and `logdir`

```python
result = computer_task("Open Firefox, compose a tweet, click Post", timeout=120)
# result now contains:
#   agent_id:     "computer-task-abc12345"
#   conversation: "subagent-computer-task-abc12345"  ← conversation name for audit-log
#   logdir:       "/home/user/.local/share/gptme/logs/subagent-computer-task-abc12345"
#   status:       "success"
#   result:       "Tweet posted successfully."

# Immediately audit what the subagent did:
import subprocess
subprocess.run(["gptme-util", "computer", "audit-log", result["conversation"]])
```

### 2. `audit-log` CLI gains `--agent-id` option

Accepts the `agent_id` from `computer_task()` directly and auto-resolves the `subagent-` prefix:

```bash
# Before: had to know the internal naming convention
gptme-util computer audit-log subagent-computer-task-abc12345

# After: use the agent_id from the result dict directly
gptme-util computer audit-log --agent-id computer-task-abc12345
```

Falls back to the bare name if the `subagent-` prefixed version doesn't exist (backward compat / subprocess mode).

## Tests

- `test_computer_task_result_includes_logdir_and_conversation` — verifies the new keys are present when subagent lookup succeeds
- `test_computer_task_result_missing_logdir_does_not_crash` — verifies graceful degradation when lookup fails
- `test_audit_log_agent_id_resolves_subagent_prefix` — verifies the `--agent-id` option resolves the naming convention
- `test_audit_log_agent_id_missing_prints_error` — verifies actionable error when agent_id not found
- `test_audit_log_agent_id_fallback_bare_name` — verifies fallback to bare name for backward compat

Closes #216 (audit discoverability gap for computer_task runs)

<!-- gptme-id:v1:gai_G57M1IPYhHpEXp6wazXshA0TBfgmqtQu3Bu9PaPpfj3 -->