### PR TITLE
feat(computer): add run-task CLI + fix include_paths directory test (#216)

### DIFF
--- a/gptme/cli/cmd_computer.py
+++ b/gptme/cli/cmd_computer.py
@@ -743,3 +743,87 @@ def video_frames_cmd(
     else:
         for f in frames:
             click.echo(str(f))
+
+
+@computer.command("run-task")
+@click.argument("task")
+@click.option(
+    "--timeout",
+    "-t",
+    default=300,
+    show_default=True,
+    help="Maximum seconds to wait for the task to complete.",
+)
+@click.option(
+    "--model",
+    "-m",
+    default=None,
+    metavar="MODEL",
+    help="Model override for the computer-use subagent.",
+)
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    default=False,
+    help="Print the raw result dict as JSON instead of human-readable output.",
+)
+def run_task(task: str, timeout: int, model: str | None, as_json: bool):
+    """Run a computer-use task in an isolated subagent.
+
+    TASK is a natural-language description of what to accomplish.
+
+    The task runs inside a subagent with the 'computer-use' profile so that
+    intermediate screenshots stay inside the subagent's context — only a brief
+    result summary is returned here.  This is the 'context-efficient tool-use
+    loop until goal is achieved' pattern from gptme/gptme#216.
+
+    To review what the subagent actually did after the task completes, use::
+
+        gptme-util computer audit-log SESSION
+
+    where SESSION is the session name printed in the output.
+
+    Examples::
+
+        gptme-util computer run-task "take a screenshot and describe the desktop"
+
+        gptme-util computer run-task \\
+            "open Firefox, go to example.com, and report the page title" \\
+            --timeout 120
+
+        gptme-util computer run-task "screenshot" --json
+    """
+    from ..tools.computer import computer_task  # lazy import (heavy deps)
+
+    result = computer_task(task, timeout=timeout, model=model)
+
+    if as_json:
+        click.echo(json.dumps(result, indent=2))
+        sys.exit(0 if result.get("status") == "success" else 1)
+
+    status = result.get("status", "unknown")
+    summary = result.get("result", "")
+    agent_id = result.get("agent_id", "")
+    logdir = result.get("logdir")
+    conversation = result.get("conversation")
+
+    status_icon = {
+        "success": "✓",
+        "failure": "✗",
+        "timeout": "⏱",
+        "clarification_needed": "?",
+    }.get(status, "?")
+
+    click.echo(f"{status_icon} Status: {status}")
+    if summary:
+        click.echo(f"  Result: {summary}")
+    if agent_id:
+        click.echo(f"  Agent:  {agent_id}")
+    if conversation:
+        click.echo(f"  Session: {conversation}")
+        click.echo(f"  Audit:  gptme-util computer audit-log {conversation}")
+    if logdir:
+        click.echo(f"  Log:    {logdir}")
+
+    sys.exit(0 if status == "success" else 1)

--- a/tests/test_computer_run_task_cli.py
+++ b/tests/test_computer_run_task_cli.py
@@ -1,0 +1,163 @@
+"""Tests for `gptme-util computer run-task` (cmd_computer.py).
+
+Unit-tests the run-task CLI command without spawning a real subagent or
+requiring an API key.  The computer_task() call is monkey-patched to return
+canned results.
+"""
+
+from __future__ import annotations
+
+import json
+
+from click.testing import CliRunner
+
+from gptme.cli.cmd_computer import run_task
+
+
+class TestRunTaskCmd:
+    """Tests for `gptme-util computer run-task`."""
+
+    def test_help_text_present(self):
+        runner = CliRunner()
+        result = runner.invoke(run_task, ["--help"])
+        assert result.exit_code == 0
+        assert "--timeout" in result.output
+        assert "--model" in result.output
+        assert "--json" in result.output
+
+    def test_success_prints_status(self, monkeypatch):
+        """A successful task prints '✓ Status: success' and exits 0."""
+
+        def fake_computer_task(task, timeout=300, model=None):
+            return {
+                "status": "success",
+                "result": "Screenshot saved to /tmp/desktop.png",
+                "agent_id": "computer-task-deadbeef",
+                "conversation": "subagent-computer-task-deadbeef",
+                "logdir": "/tmp/gptme-logs/subagent-computer-task-deadbeef",
+            }
+
+        monkeypatch.setattr("gptme.tools.computer.computer_task", fake_computer_task)
+
+        runner = CliRunner()
+        result = runner.invoke(run_task, ["take a screenshot"])
+        assert result.exit_code == 0
+        assert "success" in result.output
+        assert "Screenshot saved" in result.output
+
+    def test_failure_exits_1(self, monkeypatch):
+        """A failed task exits with code 1."""
+
+        def fake_computer_task(task, timeout=300, model=None):
+            return {
+                "status": "failure",
+                "result": "Could not open Firefox — no display available.",
+                "agent_id": "computer-task-aabbccdd",
+            }
+
+        monkeypatch.setattr("gptme.tools.computer.computer_task", fake_computer_task)
+
+        runner = CliRunner()
+        result = runner.invoke(run_task, ["open firefox"])
+        assert result.exit_code == 1
+        assert "failure" in result.output
+
+    def test_timeout_exits_1(self, monkeypatch):
+        """A timed-out task exits with code 1."""
+
+        def fake_computer_task(task, timeout=300, model=None):
+            return {
+                "status": "timeout",
+                "result": "Auto-cancelled after 42s",
+                "agent_id": "computer-task-11223344",
+            }
+
+        monkeypatch.setattr("gptme.tools.computer.computer_task", fake_computer_task)
+
+        runner = CliRunner()
+        result = runner.invoke(run_task, ["do something", "--timeout", "42"])
+        assert result.exit_code == 1
+        assert "timeout" in result.output
+
+    def test_json_output(self, monkeypatch):
+        """--json flag prints the raw result dict and exits 0 on success."""
+        payload = {
+            "status": "success",
+            "result": "Done.",
+            "agent_id": "computer-task-cafebabe",
+            "conversation": "subagent-computer-task-cafebabe",
+            "logdir": "/tmp/gptme-logs/subagent-computer-task-cafebabe",
+        }
+
+        def fake_computer_task(task, timeout=300, model=None):
+            return payload
+
+        monkeypatch.setattr("gptme.tools.computer.computer_task", fake_computer_task)
+
+        runner = CliRunner()
+        result = runner.invoke(run_task, ["do something", "--json"])
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed["status"] == "success"
+        assert parsed["agent_id"] == "computer-task-cafebabe"
+
+    def test_json_failure_exits_1(self, monkeypatch):
+        """--json flag with a failed task still exits with code 1."""
+
+        def fake_computer_task(task, timeout=300, model=None):
+            return {"status": "failure", "result": "Error", "agent_id": "x"}
+
+        monkeypatch.setattr("gptme.tools.computer.computer_task", fake_computer_task)
+
+        runner = CliRunner()
+        result = runner.invoke(run_task, ["something", "--json"])
+        assert result.exit_code == 1
+
+    def test_model_is_forwarded(self, monkeypatch):
+        """--model flag is forwarded to computer_task()."""
+        captured: list[dict] = []
+
+        def fake_computer_task(task, timeout=300, model=None):
+            captured.append({"task": task, "model": model})
+            return {"status": "success", "result": "ok", "agent_id": "x"}
+
+        monkeypatch.setattr("gptme.tools.computer.computer_task", fake_computer_task)
+
+        runner = CliRunner()
+        runner.invoke(run_task, ["do something", "--model", "claude-opus-4-8"])
+        assert len(captured) == 1
+        assert captured[0]["model"] == "claude-opus-4-8"
+
+    def test_timeout_is_forwarded(self, monkeypatch):
+        """--timeout flag is forwarded to computer_task()."""
+        captured: list[dict] = []
+
+        def fake_computer_task(task, timeout=300, model=None):
+            captured.append({"timeout": timeout})
+            return {"status": "success", "result": "ok", "agent_id": "x"}
+
+        monkeypatch.setattr("gptme.tools.computer.computer_task", fake_computer_task)
+
+        runner = CliRunner()
+        runner.invoke(run_task, ["do something", "--timeout", "60"])
+        assert len(captured) == 1
+        assert captured[0]["timeout"] == 60
+
+    def test_audit_hint_shown_when_conversation_present(self, monkeypatch):
+        """When result includes 'conversation', the output hints at audit-log."""
+
+        def fake_computer_task(task, timeout=300, model=None):
+            return {
+                "status": "success",
+                "result": "Done.",
+                "agent_id": "computer-task-abc123",
+                "conversation": "subagent-computer-task-abc123",
+                "logdir": "/tmp/logs/subagent-computer-task-abc123",
+            }
+
+        monkeypatch.setattr("gptme.tools.computer.computer_task", fake_computer_task)
+
+        runner = CliRunner()
+        result = runner.invoke(run_task, ["do something"])
+        assert "audit-log" in result.output
+        assert "subagent-computer-task-abc123" in result.output

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -482,6 +482,9 @@ def test_include_paths_directory(tmp_path, monkeypatch):
     """Test that include_paths expands directory references."""
     from gptme.util.context import include_paths
 
+    # Ensure path expansion is not suppressed (may be set in autonomous/CI environments)
+    monkeypatch.delenv("GPTME_DISABLE_PATH_INCLUDE", raising=False)
+
     # Create a directory with files
     subdir = tmp_path / "src"
     subdir.mkdir()


### PR DESCRIPTION
## Summary

- Add `gptme-util computer run-task TASK` — a CLI entry point for the context-efficient `computer_task()` subagent pattern from issue #216. Running a computer-use task no longer requires going through an interactive IPython session.
- Fix `test_include_paths_directory` which silently passed in CI but failed in autonomous environments where `GPTME_DISABLE_PATH_INCLUDE=1` is set.

## Changes

**New command: `gptme-util computer run-task`**

```
$ gptme-util computer run-task "open Firefox, go to example.com, and report the page title" --timeout 120
✓ Status: success
  Result: The page title is "Example Domain"
  Agent:  computer-task-a1b2c3d4
  Session: subagent-computer-task-a1b2c3d4
  Audit:  gptme-util computer audit-log subagent-computer-task-a1b2c3d4
```

Options: `--timeout` (default 300s), `--model`, `--json` (machine-readable output).
Exits 0 on success, 1 on failure/timeout.

**Test fix: `test_include_paths_directory`**

The test was missing `monkeypatch.delenv("GPTME_DISABLE_PATH_INCLUDE", raising=False)` — the same guard used by all other `include_paths` tests — causing it to fail in autonomous/CI environments where that env var is set.

## Test plan

- [x] 9 new unit tests for `run-task`: success/failure/timeout exit codes, `--json` output, `--model`/`--timeout` forwarding, audit-log hint
- [x] `test_include_paths_directory` passes in environments with `GPTME_DISABLE_PATH_INCLUDE=1`
- [x] Full test suite passes locally