### PR TITLE
fix(subagent): fix eval checks and subagent_wait_basic test (#554)

### DIFF
--- a/gptme/eval/suites/subagent.py
+++ b/gptme/eval/suites/subagent.py
@@ -85,8 +85,8 @@ def check_subagent_complete_spawned(messages: list[Message]) -> bool:
     return (
         'subagent("sum-roundtrip"' in assistant_log
         or "subagent('sum-roundtrip'" in assistant_log
-        or 'agent_id="sum-roundtrip"' in assistant_log
-        or "agent_id='sum-roundtrip'" in assistant_log
+        or 'subagent(agent_id="sum-roundtrip"' in assistant_log
+        or "subagent(agent_id='sum-roundtrip'" in assistant_log
     )
 
 
@@ -147,8 +147,8 @@ def check_clarification_spawned(messages: list[Message]) -> bool:
     return (
         'subagent("greeter"' in assistant_log
         or "subagent('greeter'" in assistant_log
-        or 'agent_id="greeter"' in assistant_log
-        or "agent_id='greeter'" in assistant_log
+        or 'subagent(agent_id="greeter"' in assistant_log
+        or "subagent(agent_id='greeter'" in assistant_log
     )
 
 

--- a/gptme/eval/suites/subagent.py
+++ b/gptme/eval/suites/subagent.py
@@ -81,9 +81,12 @@ def check_subagent_parallel_integrated_results(messages: list[Message]) -> bool:
 def check_subagent_complete_spawned(messages: list[Message]) -> bool:
     """Parent log should show the roundtrip subagent being started."""
     assistant_log = _role_contents(messages, "assistant")
+    # Accept both positional and keyword argument syntax
     return (
         'subagent("sum-roundtrip"' in assistant_log
         or "subagent('sum-roundtrip'" in assistant_log
+        or 'agent_id="sum-roundtrip"' in assistant_log
+        or "agent_id='sum-roundtrip'" in assistant_log
     )
 
 
@@ -139,9 +142,14 @@ def check_subagent_complete_waited_before_result(messages: list[Message]) -> boo
 
 def check_clarification_spawned(messages: list[Message]) -> bool:
     """Parent log should show the clarification subagent being started."""
-    return _any_message_contains(
-        messages, "assistant", 'subagent("greeter"'
-    ) or _any_message_contains(messages, "assistant", "subagent('greeter'")
+    # Accept both positional and keyword argument syntax
+    assistant_log = _role_contents(messages, "assistant")
+    return (
+        'subagent("greeter"' in assistant_log
+        or "subagent('greeter'" in assistant_log
+        or 'agent_id="greeter"' in assistant_log
+        or "agent_id='greeter'" in assistant_log
+    )
 
 
 def check_clarification_hook_notification(messages: list[Message]) -> bool:

--- a/tests/test_tools_subagent.py
+++ b/tests/test_tools_subagent.py
@@ -555,8 +555,14 @@ def test_subagent_wait_basic():
     # Note: This test may take up to timeout seconds
     result = subagent_wait("test-wait-agent", timeout=30)
     assert isinstance(result, dict)
-    # Status should be either success, failure, or running (if it takes too long)
-    assert result.get("status") in ["success", "failure", "running", "timeout"]
+    # Status should be a valid subagent status (including clarification_needed)
+    assert result.get("status") in [
+        "success",
+        "failure",
+        "running",
+        "timeout",
+        "clarification_needed",
+    ]
 
 
 @pytest.mark.slow


### PR DESCRIPTION
Two correctness fixes for the subagent system (#554):

## Changes

### 1. `tests/test_tools_subagent.py` — `test_subagent_wait_basic`

Add `"clarification_needed"` to the set of valid expected statuses.

`clarification_needed` is a documented, valid `Status` value (defined in `types.py` as `Literal["running", "success", "failure", "clarification_needed", "timeout"]`) but was missing from the assertion. When a subagent responds to an ambiguous prompt with a `clarify` block (which is correct behavior), the test incorrectly failed.

### 2. `gptme/eval/suites/subagent.py` — eval spawn checks

`check_subagent_complete_spawned` and `check_clarification_spawned` only matched positional argument syntax (`subagent("greeter", ...)`). LLMs sometimes use keyword argument syntax (`subagent(agent_id="greeter", ...)`), which is equally valid but was not matched. This caused spurious eval failures even when the subagent was correctly spawned. Both checks now accept both forms.

## Test

```
poetry run pytest tests/test_tools_subagent.py tests/test_tool_use.py -m "not slow and not eval" -q
# 108 passed
```

Fixes part of #554.

<!-- gptme-id:v1:gai_tDUgoVYOIDTNvyFvjLWoggKGbAx8wWjLVv74pKf9E9E -->