### PR TITLE
feat(computer): add screen recording — start_recording / record_screen / gptme-util computer record (#216)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -144,6 +144,7 @@ nitpick_ignore = [
     ("py:class", "gptme.tools.python.T"),
     ("py:class", "threading.Thread"),
     ("py:class", "gptme.tools.computer.ScalingSource"),
+    ("py:class", "gptme.tools.computer.ScreenRecording"),
     ("py:class", "gptme.config.RagConfig"),
     ("py:class", "ToolFormat"),
     ("py:class", "ConfirmFunc"),

--- a/docs/howto/computer-use.md
+++ b/docs/howto/computer-use.md
@@ -249,6 +249,45 @@ from gptme.tools.subagent import subagent_read_log
 print(subagent_read_log(result["agent_id"]))
 ```
 
+## Record a session (create demo videos)
+
+Use `gptme-util computer record` to capture a screen recording as an MP4, then
+`video-frames` to extract key frames for review or as visual context in gptme:
+
+```bash
+# Record 30 seconds to a file (blocks until done, then prints the path)
+gptme-util computer record /tmp/tweet-demo.mp4 --duration 30
+
+# Record at higher fps for smoother game-like recordings
+gptme-util computer record game.mp4 --fps 24 --duration 10
+
+# Extract frames for LLM review
+gptme-util computer video-frames /tmp/tweet-demo.mp4 --fps 1 --limit 10
+```
+
+From IPython inside a gptme session, use `start_recording()` for async control:
+
+```python
+# Start recording, interact, then stop
+rec = start_recording("demo.mp4")
+computer_task("open Firefox, go to https://example.com, and describe the page")
+path = rec.stop()     # saves the MP4
+print(f"Saved to {path}")
+
+# Or as a context manager:
+with start_recording("demo.mp4") as rec:
+    computer_task("open Firefox, navigate to https://x.com/compose/tweet, "
+                  "type 'Hello from gptme!', and click Tweet.", timeout=120)
+print(rec.output_path)
+
+# Fixed-duration, synchronous:
+path = record_screen("demo.mp4", duration=30)
+```
+
+Recordings use H.264 with fast-start so they play directly in any browser.
+Combine with `video-frames` to extract a small set of key frames for debugging
+or including as visual evidence in GitHub issues.
+
 ## Run inside Docker (isolated headless desktop)
 
 For a fully isolated environment with VNC access:
@@ -259,6 +298,7 @@ make run-docker-computer     # start container (noVNC on :6080, gptme server on 
 ```
 
 Then connect a browser to `http://localhost:6080` to watch the agent work.
+Use `gptme-util computer record` inside the container to capture what the agent does.
 
 ## Backend selection cheat sheet
 
@@ -277,6 +317,7 @@ Then connect a browser to `http://localhost:6080` to watch the agent work.
 | Focus a window by name | `computer('window_focus', text='pattern')` |
 | Scroll in native UI | `computer('scroll', coordinate=(x,y), text='down')` |
 | Multi-step task, keep parent context lean | `computer_task(task, timeout=N)` |
+| Record session for demo / debugging | `start_recording(path)` / `record_screen(path, duration=N)` |
 
 ## Tips
 

--- a/gptme/cli/cmd_computer.py
+++ b/gptme/cli/cmd_computer.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import shutil
 import sys
 from pathlib import Path
 
@@ -827,3 +828,77 @@ def run_task(task: str, timeout: int, model: str | None, as_json: bool):
         click.echo(f"  Log:    {logdir}")
 
     sys.exit(0 if status == "success" else 1)
+
+
+@computer.command("record")
+@click.argument("output", required=False, default=None, metavar="OUTPUT")
+@click.option(
+    "--duration",
+    "-d",
+    default=10.0,
+    show_default=True,
+    type=float,
+    help="Recording duration in seconds.",
+)
+@click.option(
+    "--fps",
+    default=10,
+    show_default=True,
+    type=int,
+    help="Frames per second.  Use 10 for UI demos, 24+ for smooth game recordings.",
+)
+@click.option(
+    "--display",
+    default=None,
+    metavar="DISPLAY",
+    help="X11 display string (Linux only).  Defaults to $DISPLAY env var.",
+)
+def record_cmd(output: str | None, duration: float, fps: int, display: str | None):
+    """Record the screen to an MP4 file.
+
+    Uses ffmpeg x11grab (Linux) or avfoundation (macOS).  Blocks for DURATION
+    seconds, then exits 0 and prints the path to the saved file.
+
+    OUTPUT is the destination file path.  Defaults to a timestamped file
+    in the system temporary directory.
+
+    Use ``gptme-util computer video-frames OUTPUT`` to extract key frames
+    from the recording for review.
+
+    Examples::
+
+        # Record 30 seconds to /tmp/demo.mp4
+        gptme-util computer record /tmp/demo.mp4 --duration 30
+
+        # Record 10s at 24fps (smoother for game recordings)
+        gptme-util computer record game.mp4 --fps 24 --duration 10
+
+        # Pipe into gptme for visual summary
+        gptme-util computer record --duration 15 | xargs -I{} gptme-util computer video-frames {}
+    """
+    if not shutil.which("ffmpeg"):
+        click.echo(
+            "Error: ffmpeg not found. Install it with:\n"
+            "  sudo apt install ffmpeg  # Debian/Ubuntu\n"
+            "  brew install ffmpeg      # macOS",
+            err=True,
+        )
+        sys.exit(1)
+
+    if duration <= 0:
+        click.echo("Error: --duration must be positive.", err=True)
+        sys.exit(1)
+
+    if fps <= 0 or fps > 120:
+        click.echo("Error: --fps must be between 1 and 120.", err=True)
+        sys.exit(1)
+
+    from ..tools.computer import record_screen  # lazy import (heavy deps)
+
+    try:
+        click.echo(f"Recording {duration:.0f}s at {fps} fps...", err=True)
+        path = record_screen(output=output, duration=duration, fps=fps, display=display)
+        click.echo(str(path))
+    except RuntimeError as e:
+        click.echo(f"Error: {e}", err=True)
+        sys.exit(1)

--- a/gptme/tools/computer.py
+++ b/gptme/tools/computer.py
@@ -2193,6 +2193,7 @@ class ScreenRecording:
     def __init__(self, process: subprocess.Popen, output_path: Path) -> None:
         self._process = process
         self.output_path = output_path
+        self._stop_lock = threading.Lock()
         self._stopped = threading.Event()
 
     def stop(self) -> Path:
@@ -2201,7 +2202,12 @@ class ScreenRecording:
         Returns:
             Path to the completed video file.
         """
-        if not self._stopped.is_set():
+        if self._stopped.is_set():
+            return self.output_path
+
+        with self._stop_lock:
+            if self._stopped.is_set():
+                return self.output_path
             self._process.terminate()
             try:
                 self._process.wait(timeout=10)

--- a/gptme/tools/computer.py
+++ b/gptme/tools/computer.py
@@ -2178,7 +2178,7 @@ def observe_desktop() -> Message | None:
 class ScreenRecording:
     """Handle for an in-progress screen recording.
 
-    Returned by :func:`start_recording`.  Call :meth:`stop` to finish the
+    Returned by ``start_recording()``.  Call ``.stop()`` to finish the
     recording and get the output path.  Also usable as a context manager::
 
         with start_recording("session.mp4") as rec:
@@ -2260,7 +2260,7 @@ def start_recording(
     """Start recording the screen to an MP4 file.
 
     Uses ``ffmpeg`` with ``x11grab`` (Linux) or ``avfoundation`` (macOS).
-    Returns a :class:`ScreenRecording` handle — call ``.stop()`` to finish or
+    Returns a ``ScreenRecording`` handle — call ``.stop()`` to finish or
     use it as a context manager.
 
     Args:
@@ -2271,7 +2271,7 @@ def start_recording(
         display: X11 display string (Linux only).  Defaults to ``$DISPLAY``.
 
     Returns:
-        :class:`ScreenRecording` handle.  Call ``.stop()`` when done.
+        ``ScreenRecording`` handle.  Call ``.stop()`` when done.
 
     Raises:
         RuntimeError: If ``ffmpeg`` is not found or recording fails to start.
@@ -2332,7 +2332,7 @@ def record_screen(
 ) -> Path:
     """Record the screen for a fixed duration and return the output path.
 
-    Synchronous wrapper around :func:`start_recording` / :meth:`ScreenRecording.stop`.
+    Synchronous wrapper around ``start_recording()`` / ``ScreenRecording.stop()``.
     Blocks for *duration* seconds.
 
     Args:

--- a/gptme/tools/computer.py
+++ b/gptme/tools/computer.py
@@ -97,11 +97,12 @@ import platform
 import shlex
 import shutil
 import subprocess
+import tempfile
 import threading
 import time
 from enum import Enum
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal, TypedDict
+from typing import IO, TYPE_CHECKING, Literal, TypedDict
 
 from ._computer_gate import action_risk_level, sensitive_action_gate
 from .base import ToolFunction, ToolSpec, ToolUse
@@ -122,6 +123,17 @@ _sleep = time.sleep
 
 # Platform detection
 IS_MACOS = platform.system() == "Darwin"
+
+
+def _read_ffmpeg_stderr(stderr: IO[bytes] | None) -> str:
+    if stderr is None:
+        return ""
+    try:
+        stderr.seek(0)
+        text = stderr.read().decode(errors="replace").strip()
+    except OSError:
+        return ""
+    return text[-4000:]
 
 
 def _stream_action_risk(
@@ -2190,8 +2202,14 @@ class ScreenRecording:
         output_path: Destination file path (set at construction time).
     """
 
-    def __init__(self, process: subprocess.Popen, output_path: Path) -> None:
+    def __init__(
+        self,
+        process: subprocess.Popen,
+        output_path: Path,
+        stderr: IO[bytes] | None = None,
+    ) -> None:
         self._process = process
+        self._stderr = stderr
         self.output_path = output_path
         self._stop_lock = threading.Lock()
         self._stopped = threading.Event()
@@ -2208,12 +2226,29 @@ class ScreenRecording:
         with self._stop_lock:
             if self._stopped.is_set():
                 return self.output_path
+            returncode = self._process.poll()
+            if returncode is not None:
+                diagnostic = _read_ffmpeg_stderr(self._stderr)
+                if self._stderr is not None:
+                    self._stderr.close()
+                if returncode != 0:
+                    message = (
+                        "ffmpeg exited before recording was stopped "
+                        f"(return code {returncode})"
+                    )
+                    if diagnostic:
+                        message += f":\n{diagnostic}"
+                    raise RuntimeError(message)
+                self._stopped.set()
+                return self.output_path
             self._process.terminate()
             try:
                 self._process.wait(timeout=10)
             except subprocess.TimeoutExpired:
                 self._process.kill()
                 self._process.wait()
+            if self._stderr is not None:
+                self._stderr.close()
             self._stopped.set()
         return self.output_path
 
@@ -2314,20 +2349,30 @@ def start_recording(
     width, height = _get_display_resolution()
     cmd = _ffmpeg_record_cmd(output_path, fps, None, disp, width, height)
 
-    proc = subprocess.Popen(
-        cmd,
-        stdin=subprocess.DEVNULL,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-    )
+    stderr_log = tempfile.TemporaryFile()
+    try:
+        proc = subprocess.Popen(
+            cmd,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=stderr_log,
+        )
+    except Exception:
+        stderr_log.close()
+        raise
     # Give ffmpeg a moment to start; if it exits immediately it failed.
     _sleep(0.3)
     if proc.poll() is not None:
-        raise RuntimeError(
+        diagnostic = _read_ffmpeg_stderr(stderr_log)
+        stderr_log.close()
+        message = (
             f"ffmpeg exited immediately (return code {proc.returncode}).  "
             "Check that DISPLAY is set and ffmpeg is installed."
         )
-    return ScreenRecording(proc, output_path)
+        if diagnostic:
+            message += f"\n\nffmpeg stderr:\n{diagnostic}"
+        raise RuntimeError(message)
+    return ScreenRecording(proc, output_path, stderr_log)
 
 
 def record_screen(

--- a/gptme/tools/computer.py
+++ b/gptme/tools/computer.py
@@ -97,8 +97,10 @@ import platform
 import shlex
 import shutil
 import subprocess
+import threading
 import time
 from enum import Enum
+from pathlib import Path
 from typing import TYPE_CHECKING, Literal, TypedDict
 
 from ._computer_gate import action_risk_level, sensitive_action_gate
@@ -108,8 +110,6 @@ from .screenshot import screenshot
 from .vision import view_image
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     from ..message import ArtifactDescriptor, Message, MessageMetadata
     from .computer_transport import ComputerTransport
 
@@ -2175,6 +2175,189 @@ def observe_desktop() -> Message | None:
     return computer("screenshot")
 
 
+class ScreenRecording:
+    """Handle for an in-progress screen recording.
+
+    Returned by :func:`start_recording`.  Call :meth:`stop` to finish the
+    recording and get the output path.  Also usable as a context manager::
+
+        with start_recording("session.mp4") as rec:
+            # ... do things on screen ...
+            pass  # recording stops here
+        print(rec.output_path)  # path to the MP4
+
+    Attributes:
+        output_path: Destination file path (set at construction time).
+    """
+
+    def __init__(self, process: subprocess.Popen, output_path: Path) -> None:
+        self._process = process
+        self.output_path = output_path
+        self._stopped = threading.Event()
+
+    def stop(self) -> Path:
+        """Stop the recording.  Safe to call more than once.
+
+        Returns:
+            Path to the completed video file.
+        """
+        if not self._stopped.is_set():
+            self._process.terminate()
+            try:
+                self._process.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                self._process.kill()
+                self._process.wait()
+            self._stopped.set()
+        return self.output_path
+
+    def __enter__(self) -> ScreenRecording:
+        return self
+
+    def __exit__(self, *_) -> None:
+        self.stop()
+
+
+def _ffmpeg_record_cmd(
+    output: Path,
+    fps: int,
+    duration: float | None,
+    display: str,
+    width: int,
+    height: int,
+) -> list[str]:
+    """Build the ffmpeg command for screen recording (platform-aware)."""
+    cmd: list[str] = ["ffmpeg", "-y"]  # -y: overwrite without prompting
+    if IS_MACOS:
+        # avfoundation: "1" = main display (index 1 = first screen).
+        # Users can run `ffmpeg -f avfoundation -list_devices true -i ""` to find the index.
+        cmd += ["-f", "avfoundation", "-r", str(fps), "-capture_cursor", "1", "-i", "1"]
+    else:
+        # x11grab: grab directly from the X11 display buffer.
+        cmd += [
+            "-f",
+            "x11grab",
+            "-r",
+            str(fps),
+            "-s",
+            f"{width}x{height}",
+            "-i",
+            f"{display}",
+        ]
+    if duration is not None:
+        cmd += ["-t", str(duration)]
+    # H.264 with fast-start for streaming / review in browser.
+    cmd += ["-vcodec", "libx264", "-pix_fmt", "yuv420p", "-movflags", "+faststart"]
+    cmd.append(str(output))
+    return cmd
+
+
+def start_recording(
+    output: str | Path | None = None,
+    fps: int = 10,
+    display: str | None = None,
+) -> ScreenRecording:
+    """Start recording the screen to an MP4 file.
+
+    Uses ``ffmpeg`` with ``x11grab`` (Linux) or ``avfoundation`` (macOS).
+    Returns a :class:`ScreenRecording` handle — call ``.stop()`` to finish or
+    use it as a context manager.
+
+    Args:
+        output: Destination path for the MP4 file.  Defaults to a timestamped
+            file in the system temp directory.
+        fps: Frames per second (default 10 — suitable for UI demos; increase
+            to 24+ for smooth game recordings).
+        display: X11 display string (Linux only).  Defaults to ``$DISPLAY``.
+
+    Returns:
+        :class:`ScreenRecording` handle.  Call ``.stop()`` when done.
+
+    Raises:
+        RuntimeError: If ``ffmpeg`` is not found or recording fails to start.
+
+    Example (from IPython in a computer-use session)::
+
+        rec = start_recording("tweet-demo.mp4")
+        # ... interact with the browser ...
+        rec.stop()  # saves tweet-demo.mp4
+
+        # Or as a context manager:
+        with start_recording("demo.mp4") as rec:
+            computer_task("open Firefox and navigate to https://example.com")
+        print(rec.output_path)
+    """
+    if not shutil.which("ffmpeg"):
+        raise RuntimeError(
+            "ffmpeg not found — install it first:\n"
+            "  sudo apt install ffmpeg   # Debian/Ubuntu\n"
+            "  brew install ffmpeg       # macOS"
+        )
+
+    if output is None:
+        import tempfile as _tempfile
+
+        fd, tmp = _tempfile.mkstemp(suffix=".mp4", prefix="gptme-screen-")
+        os.close(fd)
+        output_path = Path(tmp)
+    else:
+        output_path = Path(output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    disp: str = display if display is not None else os.environ.get("DISPLAY", ":1")
+    width, height = _get_display_resolution()
+    cmd = _ffmpeg_record_cmd(output_path, fps, None, disp, width, height)
+
+    proc = subprocess.Popen(
+        cmd,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    # Give ffmpeg a moment to start; if it exits immediately it failed.
+    _sleep(0.3)
+    if proc.poll() is not None:
+        raise RuntimeError(
+            f"ffmpeg exited immediately (return code {proc.returncode}).  "
+            "Check that DISPLAY is set and ffmpeg is installed."
+        )
+    return ScreenRecording(proc, output_path)
+
+
+def record_screen(
+    output: str | Path | None = None,
+    duration: float = 10.0,
+    fps: int = 10,
+    display: str | None = None,
+) -> Path:
+    """Record the screen for a fixed duration and return the output path.
+
+    Synchronous wrapper around :func:`start_recording` / :meth:`ScreenRecording.stop`.
+    Blocks for *duration* seconds.
+
+    Args:
+        output: Destination path for the MP4 file.  Defaults to a timestamped
+            file in the system temp directory.
+        duration: How many seconds to record (default 10).
+        fps: Frames per second (default 10).
+        display: X11 display string (Linux only).  Defaults to ``$DISPLAY``.
+
+    Returns:
+        :class:`~pathlib.Path` to the finished MP4 file.
+
+    Raises:
+        RuntimeError: If ``ffmpeg`` is not found or recording fails to start.
+
+    Example (from IPython in a computer-use session)::
+
+        path = record_screen("tweet-demo.mp4", duration=30)
+        print(f"Recording saved to {path}")
+    """
+    rec = start_recording(output=output, fps=fps, display=display)
+    _sleep(duration)
+    return rec.stop()
+
+
 # Actions that only read state — no post-action screenshot is useful for these.
 _OBSERVATION_ACTIONS: frozenset[str] = frozenset(
     {"screenshot", "cursor_position", "accessibility_tree", "wait_for_change"}
@@ -2491,6 +2674,8 @@ tool = ToolSpec(
         ToolFunction.from_callable(observe_desktop),
         ToolFunction.from_callable(act_and_observe),
         ToolFunction.from_callable(computer_task),
+        ToolFunction.from_callable(record_screen),
+        ToolFunction.from_callable(start_recording),
     ],
     disabled_by_default=True,
 )

--- a/gptme/tools/computer.py
+++ b/gptme/tools/computer.py
@@ -2212,6 +2212,7 @@ class ScreenRecording:
         self._stderr = stderr
         self.output_path = output_path
         self._stop_lock = threading.Lock()
+        self._stop_error: str | None = None
         self._stopped = threading.Event()
 
     def stop(self) -> Path:
@@ -2221,10 +2222,14 @@ class ScreenRecording:
             Path to the completed video file.
         """
         if self._stopped.is_set():
+            if self._stop_error is not None:
+                raise RuntimeError(self._stop_error)
             return self.output_path
 
         with self._stop_lock:
             if self._stopped.is_set():
+                if self._stop_error is not None:
+                    raise RuntimeError(self._stop_error)
                 return self.output_path
             returncode = self._process.poll()
             if returncode is not None:
@@ -2238,6 +2243,8 @@ class ScreenRecording:
                     )
                     if diagnostic:
                         message += f":\n{diagnostic}"
+                    self._stop_error = message
+                    self._stopped.set()
                     raise RuntimeError(message)
                 self._stopped.set()
                 return self.output_path

--- a/gptme/tools/computer.py
+++ b/gptme/tools/computer.py
@@ -2404,9 +2404,9 @@ def record_screen(
         path = record_screen("tweet-demo.mp4", duration=30)
         print(f"Recording saved to {path}")
     """
-    rec = start_recording(output=output, fps=fps, display=display)
-    _sleep(duration)
-    return rec.stop()
+    with start_recording(output=output, fps=fps, display=display) as rec:
+        _sleep(duration)
+        return rec.output_path
 
 
 # Actions that only read state — no post-action screenshot is useful for these.

--- a/tests/test_computer_record.py
+++ b/tests/test_computer_record.py
@@ -255,14 +255,15 @@ class TestFfmpegRecordCmd:
     def test_linux_uses_x11grab(self, tmp_path):
         from gptme.tools.computer import _ffmpeg_record_cmd
 
-        cmd = _ffmpeg_record_cmd(
-            tmp_path / "out.mp4",
-            fps=10,
-            duration=None,
-            display=":1",
-            width=1024,
-            height=768,
-        )
+        with mock.patch("gptme.tools.computer.IS_MACOS", False):
+            cmd = _ffmpeg_record_cmd(
+                tmp_path / "out.mp4",
+                fps=10,
+                duration=None,
+                display=":1",
+                width=1024,
+                height=768,
+            )
         assert "x11grab" in cmd
         assert "avfoundation" not in cmd
 

--- a/tests/test_computer_record.py
+++ b/tests/test_computer_record.py
@@ -1,0 +1,410 @@
+"""Tests for screen-recording helpers: start_recording / record_screen (#216).
+
+These tests are intentionally offline — they mock ffmpeg so no X11 display or
+real encoder is needed.  A subprocess.Popen mock returns a process that stays
+alive until stop() is called, exactly like a real ffmpeg invocation.
+"""
+
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_alive_proc():
+    """Return a plain MagicMock that acts like a long-running Popen process.
+
+    Deliberately NOT spec'd against subprocess.Popen — when Popen itself is
+    patched via mock.patch, passing spec=subprocess.Popen would resolve to the
+    mock class object (not the real class), causing InvalidSpecError.
+    """
+    proc = mock.MagicMock()
+    proc.returncode = None  # set the attribute so it's accessible
+    _alive = [True]
+
+    def _poll():
+        return None if _alive[0] else 0
+
+    def _terminate():
+        _alive[0] = False
+        proc.returncode = 0
+
+    proc.poll.side_effect = _poll
+    proc.terminate.side_effect = _terminate
+    proc.wait.return_value = 0
+    return proc
+
+
+# ---------------------------------------------------------------------------
+# ScreenRecording
+# ---------------------------------------------------------------------------
+
+
+class TestScreenRecording:
+    def test_stop_returns_output_path(self, tmp_path):
+        from gptme.tools.computer import ScreenRecording
+
+        out = tmp_path / "test.mp4"
+        proc = _make_alive_proc()
+        rec = ScreenRecording(proc, out)
+        result = rec.stop()
+        assert result == out
+        proc.terminate.assert_called_once()
+
+    def test_stop_is_idempotent(self, tmp_path):
+        from gptme.tools.computer import ScreenRecording
+
+        proc = _make_alive_proc()
+        rec = ScreenRecording(proc, tmp_path / "x.mp4")
+        rec.stop()
+        rec.stop()  # should not raise or call terminate a second time
+        assert proc.terminate.call_count == 1
+
+    def test_context_manager_calls_stop(self, tmp_path):
+        from gptme.tools.computer import ScreenRecording
+
+        proc = _make_alive_proc()
+        out = tmp_path / "ctx.mp4"
+        with ScreenRecording(proc, out) as rec:
+            assert rec.output_path == out
+        proc.terminate.assert_called_once()
+
+    def test_output_path_attribute(self, tmp_path):
+        from gptme.tools.computer import ScreenRecording
+
+        out = tmp_path / "attr.mp4"
+        rec = ScreenRecording(_make_alive_proc(), out)
+        assert rec.output_path == out
+
+
+# ---------------------------------------------------------------------------
+# start_recording — mocked ffmpeg
+# ---------------------------------------------------------------------------
+
+
+class TestStartRecording:
+    @pytest.fixture(autouse=True)
+    def _patch_which(self):
+        with mock.patch("shutil.which", return_value="/usr/bin/ffmpeg"):
+            yield
+
+    @pytest.fixture(autouse=True)
+    def _patch_resolution(self):
+        with mock.patch(
+            "gptme.tools.computer._get_display_resolution", return_value=(1024, 768)
+        ):
+            yield
+
+    def test_returns_screen_recording_handle(self, tmp_path):
+        from gptme.tools.computer import ScreenRecording, start_recording
+
+        proc = _make_alive_proc()
+        out = tmp_path / "rec.mp4"
+        with (
+            mock.patch("subprocess.Popen", return_value=proc),
+            mock.patch("gptme.tools.computer._sleep"),
+        ):
+            rec = start_recording(output=out)
+        assert isinstance(rec, ScreenRecording)
+        assert rec.output_path == out
+
+    def test_default_output_in_tmpdir(self, tmp_path):
+        from gptme.tools.computer import start_recording
+
+        proc = _make_alive_proc()
+        with (
+            mock.patch("subprocess.Popen", return_value=proc),
+            mock.patch("gptme.tools.computer._sleep"),
+        ):
+            rec = start_recording()
+        assert rec.output_path.suffix == ".mp4"
+        rec.stop()
+
+    def test_ffmpeg_not_found_raises(self, tmp_path):
+        from gptme.tools.computer import start_recording
+
+        with (
+            mock.patch("shutil.which", return_value=None),
+            pytest.raises(RuntimeError, match="ffmpeg not found"),
+        ):
+            start_recording(output=tmp_path / "x.mp4")
+
+    def test_ffmpeg_exits_immediately_raises(self, tmp_path):
+        from gptme.tools.computer import start_recording
+
+        proc = mock.MagicMock()
+        proc.poll.return_value = 1  # non-None = already exited
+        proc.returncode = 1
+        with (
+            mock.patch("subprocess.Popen", return_value=proc),
+            mock.patch("gptme.tools.computer._sleep"),
+            pytest.raises(RuntimeError, match="ffmpeg exited immediately"),
+        ):
+            start_recording(output=tmp_path / "fail.mp4")
+
+    def test_fps_forwarded_in_cmd(self, tmp_path):
+        from gptme.tools.computer import start_recording
+
+        captured_cmd: list[list[str]] = []
+
+        def _fake_popen(cmd, **kwargs):
+            captured_cmd.append(cmd)
+            return _make_alive_proc()
+
+        with (
+            mock.patch("subprocess.Popen", side_effect=_fake_popen),
+            mock.patch("gptme.tools.computer._sleep"),
+        ):
+            rec = start_recording(output=tmp_path / "fps.mp4", fps=5)
+        rec.stop()
+        cmd = captured_cmd[0]
+        assert "5" in cmd  # fps value appears in the ffmpeg command
+
+    def test_display_used_on_linux(self, tmp_path):
+        import platform
+
+        from gptme.tools.computer import start_recording
+
+        captured_cmd: list[list[str]] = []
+
+        def _fake_popen(cmd, **kwargs):
+            captured_cmd.append(cmd)
+            return _make_alive_proc()
+
+        with (
+            mock.patch("subprocess.Popen", side_effect=_fake_popen),
+            mock.patch("gptme.tools.computer._sleep"),
+            mock.patch.object(platform, "system", return_value="Linux"),
+            mock.patch("gptme.tools.computer.IS_MACOS", False),
+        ):
+            rec = start_recording(output=tmp_path / "disp.mp4", display=":99")
+        rec.stop()
+        cmd = captured_cmd[0]
+        assert ":99" in cmd
+
+
+# ---------------------------------------------------------------------------
+# record_screen — synchronous wrapper
+# ---------------------------------------------------------------------------
+
+
+class TestRecordScreen:
+    @pytest.fixture(autouse=True)
+    def _patch_which(self):
+        with mock.patch("shutil.which", return_value="/usr/bin/ffmpeg"):
+            yield
+
+    @pytest.fixture(autouse=True)
+    def _patch_resolution(self):
+        with mock.patch(
+            "gptme.tools.computer._get_display_resolution", return_value=(1024, 768)
+        ):
+            yield
+
+    def test_returns_path_to_file(self, tmp_path):
+        from gptme.tools.computer import record_screen
+
+        proc = _make_alive_proc()
+        out = tmp_path / "sync.mp4"
+        with (
+            mock.patch("subprocess.Popen", return_value=proc),
+            mock.patch("gptme.tools.computer._sleep"),
+        ):
+            result = record_screen(output=out, duration=1.0)
+        assert result == out
+
+    def test_sleeps_for_duration(self, tmp_path):
+        from gptme.tools.computer import record_screen
+
+        sleep_calls: list[float] = []
+
+        with (
+            mock.patch("subprocess.Popen", return_value=_make_alive_proc()),
+            mock.patch(
+                "gptme.tools.computer._sleep",
+                side_effect=lambda d: sleep_calls.append(d),
+            ),
+        ):
+            record_screen(output=tmp_path / "dur.mp4", duration=7.5)
+
+        # _sleep is called once during Popen startup check (0.3s) and once for duration
+        duration_calls = [d for d in sleep_calls if d == 7.5]
+        assert duration_calls, f"Expected a 7.5s sleep; got {sleep_calls}"
+
+    def test_ffmpeg_not_found_raises(self, tmp_path):
+        from gptme.tools.computer import record_screen
+
+        with (
+            mock.patch("shutil.which", return_value=None),
+            pytest.raises(RuntimeError, match="ffmpeg not found"),
+        ):
+            record_screen(output=tmp_path / "x.mp4")
+
+
+# ---------------------------------------------------------------------------
+# _ffmpeg_record_cmd — unit tests for command construction
+# ---------------------------------------------------------------------------
+
+
+class TestFfmpegRecordCmd:
+    def test_linux_uses_x11grab(self, tmp_path):
+        from gptme.tools.computer import _ffmpeg_record_cmd
+
+        cmd = _ffmpeg_record_cmd(
+            tmp_path / "out.mp4",
+            fps=10,
+            duration=None,
+            display=":1",
+            width=1024,
+            height=768,
+        )
+        assert "x11grab" in cmd
+        assert "avfoundation" not in cmd
+
+    def test_duration_added_when_given(self, tmp_path):
+        from gptme.tools.computer import _ffmpeg_record_cmd
+
+        cmd = _ffmpeg_record_cmd(
+            tmp_path / "out.mp4",
+            fps=10,
+            duration=30.0,
+            display=":1",
+            width=1024,
+            height=768,
+        )
+        assert "-t" in cmd
+        idx = cmd.index("-t")
+        assert cmd[idx + 1] == "30.0"
+
+    def test_no_duration_flag_when_none(self, tmp_path):
+        from gptme.tools.computer import _ffmpeg_record_cmd
+
+        cmd = _ffmpeg_record_cmd(
+            tmp_path / "out.mp4",
+            fps=10,
+            duration=None,
+            display=":1",
+            width=1024,
+            height=768,
+        )
+        assert "-t" not in cmd
+
+    def test_output_path_is_last_arg(self, tmp_path):
+        from gptme.tools.computer import _ffmpeg_record_cmd
+
+        out = tmp_path / "last.mp4"
+        cmd = _ffmpeg_record_cmd(
+            out, fps=10, duration=5.0, display=":1", width=1024, height=768
+        )
+        assert cmd[-1] == str(out)
+
+    def test_faststart_flag_included(self, tmp_path):
+        from gptme.tools.computer import _ffmpeg_record_cmd
+
+        cmd = _ffmpeg_record_cmd(
+            tmp_path / "out.mp4",
+            fps=10,
+            duration=None,
+            display=":1",
+            width=1024,
+            height=768,
+        )
+        assert "+faststart" in " ".join(cmd)
+
+    def test_macos_uses_avfoundation(self, tmp_path):
+        import platform
+
+        from gptme.tools.computer import _ffmpeg_record_cmd
+
+        with (
+            mock.patch.object(platform, "system", return_value="Darwin"),
+            mock.patch("gptme.tools.computer.IS_MACOS", True),
+        ):
+            cmd = _ffmpeg_record_cmd(
+                tmp_path / "out.mp4",
+                fps=10,
+                duration=None,
+                display=":1",
+                width=1024,
+                height=768,
+            )
+        assert "avfoundation" in cmd
+        assert "x11grab" not in cmd
+
+
+# ---------------------------------------------------------------------------
+# CLI — gptme-util computer record
+# ---------------------------------------------------------------------------
+
+
+class TestRecordCLI:
+    """Tests for `gptme-util computer record` command."""
+
+    def test_help_text_present(self):
+        from click.testing import CliRunner
+
+        from gptme.cli.cmd_computer import record_cmd
+
+        runner = CliRunner()
+        result = runner.invoke(record_cmd, ["--help"])
+        assert result.exit_code == 0
+        assert "--duration" in result.output
+        assert "--fps" in result.output
+
+    def test_ffmpeg_not_found_exits_1(self, monkeypatch):
+        from click.testing import CliRunner
+
+        from gptme.cli.cmd_computer import record_cmd
+
+        monkeypatch.setattr("shutil.which", lambda _: None)
+        runner = CliRunner()
+        result = runner.invoke(record_cmd, ["--duration", "1"])
+        assert result.exit_code == 1
+        assert "ffmpeg not found" in result.output
+
+    def test_success_prints_path(self, tmp_path, monkeypatch):
+        from pathlib import Path as _Path
+
+        from click.testing import CliRunner
+
+        from gptme.cli.cmd_computer import record_cmd
+
+        out = tmp_path / "out.mp4"
+        monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/ffmpeg")
+
+        def fake_record_screen(**kwargs):
+            return _Path(kwargs.get("output") or str(out))
+
+        monkeypatch.setattr("gptme.tools.computer.record_screen", fake_record_screen)
+
+        runner = CliRunner()
+        result = runner.invoke(record_cmd, [str(out), "--duration", "2"])
+        assert result.exit_code == 0
+        assert str(out) in result.output
+
+    def test_invalid_duration_exits_1(self, tmp_path, monkeypatch):
+        from click.testing import CliRunner
+
+        from gptme.cli.cmd_computer import record_cmd
+
+        monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/ffmpeg")
+        runner = CliRunner()
+        result = runner.invoke(record_cmd, ["--duration", "-5"])
+        assert result.exit_code == 1
+        assert "duration" in result.output.lower()
+
+    def test_invalid_fps_exits_1(self, tmp_path, monkeypatch):
+        from click.testing import CliRunner
+
+        from gptme.cli.cmd_computer import record_cmd
+
+        monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/ffmpeg")
+        runner = CliRunner()
+        result = runner.invoke(record_cmd, ["--fps", "0", "--duration", "1"])
+        assert result.exit_code == 1
+        assert "fps" in result.output.lower()

--- a/tests/test_computer_record.py
+++ b/tests/test_computer_record.py
@@ -7,6 +7,8 @@ alive until stop() is called, exactly like a real ffmpeg invocation.
 
 from __future__ import annotations
 
+import threading
+import time
 from unittest import mock
 
 import pytest
@@ -63,6 +65,37 @@ class TestScreenRecording:
         rec = ScreenRecording(proc, tmp_path / "x.mp4")
         rec.stop()
         rec.stop()  # should not raise or call terminate a second time
+        assert proc.terminate.call_count == 1
+
+    def test_stop_is_thread_safe(self, tmp_path):
+        from gptme.tools.computer import ScreenRecording
+
+        proc = _make_alive_proc()
+
+        def _slow_terminate():
+            time.sleep(0.05)
+            proc.returncode = 0
+
+        proc.terminate.side_effect = _slow_terminate
+        rec = ScreenRecording(proc, tmp_path / "thread-safe.mp4")
+
+        start = threading.Barrier(3)
+        done = threading.Barrier(3)
+
+        def _call_stop():
+            start.wait()
+            rec.stop()
+            done.wait()
+
+        t1 = threading.Thread(target=_call_stop)
+        t2 = threading.Thread(target=_call_stop)
+        t1.start()
+        t2.start()
+        start.wait()
+        done.wait()
+        t1.join()
+        t2.join()
+
         assert proc.terminate.call_count == 1
 
     def test_context_manager_calls_stop(self, tmp_path):

--- a/tests/test_computer_record.py
+++ b/tests/test_computer_record.py
@@ -304,6 +304,24 @@ class TestRecordScreen:
         duration_calls = [d for d in sleep_calls if d == 7.5]
         assert duration_calls, f"Expected a 7.5s sleep; got {sleep_calls}"
 
+    def test_stops_recording_when_sleep_raises(self, tmp_path):
+        from gptme.tools.computer import record_screen
+
+        proc = _make_alive_proc()
+
+        def _sleep_or_interrupt(delay):
+            if delay == 7.5:
+                raise KeyboardInterrupt
+
+        with (
+            mock.patch("subprocess.Popen", return_value=proc),
+            mock.patch("gptme.tools.computer._sleep", side_effect=_sleep_or_interrupt),
+            pytest.raises(KeyboardInterrupt),
+        ):
+            record_screen(output=tmp_path / "interrupted.mp4", duration=7.5)
+
+        proc.terminate.assert_called_once()
+
     def test_ffmpeg_not_found_raises(self, tmp_path):
         from gptme.tools.computer import record_screen
 

--- a/tests/test_computer_record.py
+++ b/tests/test_computer_record.py
@@ -114,6 +114,22 @@ class TestScreenRecording:
             rec.stop()
         proc.terminate.assert_not_called()
 
+    def test_stop_repeats_cached_early_exit_error(self, tmp_path):
+        from gptme.tools.computer import ScreenRecording
+
+        proc = mock.MagicMock()
+        proc.poll.return_value = 1
+        proc.returncode = 1
+        stderr = tempfile.TemporaryFile()
+        stderr.write(b"Cannot open display :99\n")
+        stderr.flush()
+        rec = ScreenRecording(proc, tmp_path / "failed-twice.mp4", stderr)
+
+        with pytest.raises(RuntimeError, match="Cannot open display"):
+            rec.stop()
+        with pytest.raises(RuntimeError, match="Cannot open display"):
+            rec.stop()
+
     def test_context_manager_calls_stop(self, tmp_path):
         from gptme.tools.computer import ScreenRecording
 

--- a/tests/test_computer_record.py
+++ b/tests/test_computer_record.py
@@ -7,6 +7,7 @@ alive until stop() is called, exactly like a real ffmpeg invocation.
 
 from __future__ import annotations
 
+import tempfile
 import threading
 import time
 from unittest import mock
@@ -98,6 +99,21 @@ class TestScreenRecording:
 
         assert proc.terminate.call_count == 1
 
+    def test_stop_raises_when_ffmpeg_exited_early(self, tmp_path):
+        from gptme.tools.computer import ScreenRecording
+
+        proc = mock.MagicMock()
+        proc.poll.return_value = 1
+        proc.returncode = 1
+        stderr = tempfile.TemporaryFile()
+        stderr.write(b"Cannot open display :99\n")
+        stderr.flush()
+        rec = ScreenRecording(proc, tmp_path / "failed.mp4", stderr)
+
+        with pytest.raises(RuntimeError, match="Cannot open display"):
+            rec.stop()
+        proc.terminate.assert_not_called()
+
     def test_context_manager_calls_stop(self, tmp_path):
         from gptme.tools.computer import ScreenRecording
 
@@ -177,6 +193,25 @@ class TestStartRecording:
             mock.patch("subprocess.Popen", return_value=proc),
             mock.patch("gptme.tools.computer._sleep"),
             pytest.raises(RuntimeError, match="ffmpeg exited immediately"),
+        ):
+            start_recording(output=tmp_path / "fail.mp4")
+
+    def test_ffmpeg_immediate_exit_includes_stderr(self, tmp_path):
+        from gptme.tools.computer import start_recording
+
+        proc = mock.MagicMock()
+        proc.poll.return_value = 1
+        proc.returncode = 1
+
+        def _fake_popen(cmd, **kwargs):
+            kwargs["stderr"].write(b"No such display\n")
+            kwargs["stderr"].flush()
+            return proc
+
+        with (
+            mock.patch("subprocess.Popen", side_effect=_fake_popen),
+            mock.patch("gptme.tools.computer._sleep"),
+            pytest.raises(RuntimeError, match="No such display"),
         ):
             start_recording(output=tmp_path / "fail.mp4")
 


### PR DESCRIPTION
## Summary

Adds ffmpeg-based screen recording to the computer-use stack, closing the last missing piece of the capture pipeline from gptme/gptme#216.

Previously `gptme-util computer video-frames` could extract frames from an *existing* video, but there was no way to *create* a recording in the first place. This PR closes that gap.

## New API (`gptme/tools/computer.py`)

- **`ScreenRecording`**: context-manager handle for an in-progress recording — call `.stop()` to finish, or use as `with start_recording(...) as rec:`
- **`start_recording(output, fps, display)`**: starts recording asynchronously, returns a `ScreenRecording` handle
- **`record_screen(output, duration, fps, display)`**: synchronous, blocks for `duration` seconds then returns the path

Both functions are exported via `ToolSpec.functions` so they are callable from IPython in a computer-use session.

## New CLI (`gptme/cli/cmd_computer.py`)

```
gptme-util computer record [OUTPUT] --duration N --fps N --display DISP
```

Blocks for N seconds, prints the path to stdout, exits 0 on success.

## Platform support

- **Linux**: `ffmpeg -f x11grab` from `$DISPLAY`
- **macOS**: `ffmpeg -f avfoundation -i "1"` (main display)
- H.264 with `-movflags +faststart` — plays directly in browsers

## Demo workflow

```python
# Record the "Can it Tweet?" pipeline
with start_recording("tweet-demo.mp4") as rec:
    computer_task(
        "Open Firefox, navigate to https://x.com/compose/tweet, "
        "type 'Hello from gptme!', and click Tweet.",
        timeout=120,
    )
print(rec.output_path)  # tweet-demo.mp4

# Then extract key frames for review / sharing
# gptme-util computer video-frames tweet-demo.mp4 --fps 1 --limit 10
```

## Test plan

- [x] 24 offline unit tests covering `ScreenRecording` lifecycle, `start_recording` argument forwarding, `record_screen` sleep behaviour, `_ffmpeg_record_cmd` command construction (Linux x11grab + macOS avfoundation), and CLI exit codes
- [x] All 261 existing computer-use tests still pass
- [x] ruff + mypy + pre-commit clean

<!-- gptme-id:v1:gai_7ZLZTkd0N8FS9pDpiD7xV49A2VRmqBYCGew8zIz53uP -->