### PR TITLE
feat(subagent): enforce output_schema at the complete-block layer

### DIFF
--- a/gptme/tools/subagent/execution.py
+++ b/gptme/tools/subagent/execution.py
@@ -336,10 +336,17 @@ def _create_subagent_thread(
             parent_messages = redact_secrets_from_messages(parent_messages)
         initial_msgs.append(_build_parent_context_message(parent_messages))
 
-    # Add completion instruction as a system message
+    # Add completion instruction as a system message.
+    # When output_schema is set, the instruction is extended with the expected
+    # JSON schema so the subagent knows the format to use in its complete block.
+    # output_schema is intentionally NOT passed to chat() here — the LLM-level
+    # response_format (structured JSON output) conflicts with markdown tool_format
+    # because the model can't write markdown code blocks while also being forced to
+    # output raw JSON. Schema contract is enforced at the complete-block layer in
+    # Subagent._read_log() instead.
     complete_instruction = Message(
         "system",
-        _get_complete_instruction(target),
+        _get_complete_instruction(target, output_schema=output_schema),
     )
     initial_msgs.append(complete_instruction)
 
@@ -356,7 +363,6 @@ def _create_subagent_thread(
         interactive=False,
         show_hidden=False,
         tool_format="markdown",
-        output_schema=output_schema,
     )
 
 

--- a/gptme/tools/subagent/hooks.py
+++ b/gptme/tools/subagent/hooks.py
@@ -23,24 +23,51 @@ def _get_complete_instruction(
     target: str = "orchestrator",
     *,
     supports_progress: bool = True,
+    output_schema: type | None = None,
 ) -> str:
     """Get the standard instruction for using the complete tool.
 
     Used by both thread and subprocess modes to ensure consistent behavior.
     The instruction is intentionally minimal - profile system prompts and
     task context should guide what the complete answer should contain.
+
+    Args:
+        target: Who will review the result ("orchestrator", "parent", "planner")
+        supports_progress: Whether to include the progress block instructions
+        output_schema: Optional Pydantic model class. When set, the complete
+            block must contain valid JSON matching the model's schema. The
+            instruction is extended with the expected schema.
     """
+    if output_schema is not None:
+        import json
+
+        schema_str = json.dumps(
+            output_schema.model_json_schema()
+            if hasattr(output_schema, "model_json_schema")
+            else {"type": "object"},
+            indent=2,
+        )
+        complete_block_hint = f"Valid JSON matching this schema:\n{schema_str}"
+    else:
+        complete_block_hint = "Your complete answer here."
+
     instruction = (
         "When finished, use the `complete` tool with your full answer/result.\n"
         f"Include everything the {target} needs - they shouldn't need to read the full log.\n"
         "```complete\n"
-        "Your complete answer here.\n"
+        f"{complete_block_hint}\n"
         "```\n"
         f"If you cannot proceed without more information from the {target}, use the `clarify` block instead:\n"
         "```clarify\n"
         "Your specific question here.\n"
         "```"
     )
+    if output_schema is not None:
+        instruction += (
+            "\n"
+            "IMPORTANT: Your `complete` block MUST contain valid JSON matching the schema above. "
+            "Do not include any text outside the JSON object."
+        )
     if supports_progress:
         instruction += (
             "\n"

--- a/gptme/tools/subagent/types.py
+++ b/gptme/tools/subagent/types.py
@@ -205,6 +205,39 @@ class Subagent:
     # Wall-clock limit in seconds; when set, a watchdog auto-cancels after this time
     max_time: float | None = None
 
+    def _validate_schema_result(self, result: str) -> str:
+        """Validate and normalize a complete-block result against output_schema.
+
+        When output_schema is set, the complete block content must be valid JSON.
+        If it parses as valid JSON, the result is returned as a canonical JSON string
+        (re-serialized for consistency). If it fails to parse, the original string
+        is returned unchanged so the caller still gets a result (schema violation is
+        logged as a warning, not treated as a hard failure).
+
+        Args:
+            result: The raw text from the complete block.
+
+        Returns:
+            Canonical JSON string when output_schema is set and the result is valid
+            JSON; otherwise the original result string unchanged.
+        """
+        if self.output_schema is None:
+            return result
+        import json
+
+        try:
+            parsed = json.loads(result)
+            return json.dumps(parsed)
+        except json.JSONDecodeError as e:
+            logger.warning(
+                "Subagent '%s' output_schema set but complete block is not valid JSON: %s. "
+                "Returning raw result. Snippet: %.200r",
+                self.agent_id,
+                e,
+                result,
+            )
+            return result
+
     def get_log(self) -> "LogManager":
         # noreorder
         from ...logmanager import LogManager  # fmt: skip
@@ -273,6 +306,7 @@ class Subagent:
                 result = complete_tool.content.strip()
             else:
                 result = "Task completed (no summary provided)"
+            result = self._validate_schema_result(result)
             return ReturnType(
                 "success",
                 result + f"\n\nFull log: {self.logdir}",
@@ -290,6 +324,7 @@ class Subagent:
                     result = content
                 else:
                     result = "Task completed (no summary provided)"
+                result = self._validate_schema_result(result)
                 return ReturnType(
                     "success",
                     result + f"\n\nFull log: {self.logdir}",

--- a/gptme/tools/subagent/types.py
+++ b/gptme/tools/subagent/types.py
@@ -205,14 +205,18 @@ class Subagent:
     # Wall-clock limit in seconds; when set, a watchdog auto-cancels after this time
     max_time: float | None = None
 
-    def _validate_schema_result(self, result: str) -> str:
-        """Validate and normalize a complete-block result against output_schema.
+    def _normalize_json_result(self, result: str) -> str:
+        """Normalize a complete-block result as canonical JSON.
 
         When output_schema is set, the complete block content must be valid JSON.
         If it parses as valid JSON, the result is returned as a canonical JSON string
         (re-serialized for consistency). If it fails to parse, the original string
-        is returned unchanged so the caller still gets a result (schema violation is
+        is returned unchanged so the caller still gets a result (parsing failure is
         logged as a warning, not treated as a hard failure).
+
+        Note: this validates JSON *syntax*, not Pydantic schema conformance —
+        callers that need full schema validation should call
+        ``output_schema.model_validate(parsed)`` separately.
 
         Args:
             result: The raw text from the complete block.
@@ -304,9 +308,9 @@ class Subagent:
             # Don't silently fall back - make it clear when no summary was provided
             if complete_tool.content and complete_tool.content.strip():
                 result = complete_tool.content.strip()
+                result = self._normalize_json_result(result)
             else:
                 result = "Task completed (no summary provided)"
-            result = self._validate_schema_result(result)
             return ReturnType(
                 "success",
                 result + f"\n\nFull log: {self.logdir}",
@@ -322,9 +326,9 @@ class Subagent:
                 content = match.group(1).strip()
                 if content:
                     result = content
+                    result = self._normalize_json_result(result)
                 else:
                     result = "Task completed (no summary provided)"
-                result = self._validate_schema_result(result)
                 return ReturnType(
                     "success",
                     result + f"\n\nFull log: {self.logdir}",

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -15,6 +15,7 @@ import pytest
 
 import gptme.tools.subagent.api as subagent_api
 import gptme.tools.subagent.execution as subagent_execution
+import gptme.tools.subagent.types as subagent_types
 from gptme.tools.subagent.api import subagent, subagent_cancel
 from gptme.tools.subagent.batch import BatchJob
 from gptme.tools.subagent.execution import _monitor_subprocess
@@ -3413,3 +3414,45 @@ class TestOutputSchema:
         # Must NOT be interpreted as JSON
         assert result.result is not None
         assert result.result.startswith("hello world")
+
+    def test_read_log_with_schema_empty_complete_tool_no_json_warning(
+        self, tmp_path, caplog, monkeypatch
+    ):
+        import logging
+
+        monkeypatch.setattr(
+            subagent_types.ToolUse,
+            "iter_from_content",
+            staticmethod(
+                lambda content: iter([subagent_types.ToolUse("complete", [], "")])
+            ),
+        )
+        sa = self._make_subagent(
+            tmp_path,
+            "ignored when complete tool is parsed",
+            output_schema=_SampleSchema,
+        )
+        with caplog.at_level(logging.WARNING, logger="gptme.tools.subagent.types"):
+            result = sa._read_log()
+        assert result.status == "success"
+        assert "Task completed (no summary provided)" in (result.result or "")
+        assert "not valid JSON" not in caplog.text
+
+    def test_read_log_with_schema_empty_complete_block_fallback_no_json_warning(
+        self, tmp_path, caplog, monkeypatch
+    ):
+        import logging
+
+        monkeypatch.setattr(
+            subagent_types.ToolUse,
+            "iter_from_content",
+            staticmethod(lambda content: iter(())),
+        )
+        sa = self._make_subagent(
+            tmp_path, "```complete\n\n```", output_schema=_SampleSchema
+        )
+        with caplog.at_level(logging.WARNING, logger="gptme.tools.subagent.types"):
+            result = sa._read_log()
+        assert result.status == "success"
+        assert "Task completed (no summary provided)" in (result.result or "")
+        assert "not valid JSON" not in caplog.text

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -3279,3 +3279,137 @@ class TestSubagentParallel:
         assert "s-a" in cancelled
         # Second agent failed to start, so nothing to cancel there
         assert "s-b" not in cancelled
+
+
+# ---------------------------------------------------------------------------
+# output_schema tests
+# ---------------------------------------------------------------------------
+
+
+class _SampleSchema:
+    """Minimal Pydantic-like schema stub for testing schema hints."""
+
+    @classmethod
+    def model_json_schema(cls):
+        return {
+            "type": "object",
+            "properties": {"value": {"type": "integer"}, "label": {"type": "string"}},
+            "required": ["value", "label"],
+        }
+
+
+class TestOutputSchema:
+    """Tests for output_schema handling in complete-block parsing and instructions."""
+
+    def _make_subagent(
+        self,
+        tmp_path: Path,
+        content: str,
+        output_schema=None,
+        agent_id: str = "schema-test",
+    ) -> Subagent:
+        logdir = tmp_path / "subagent-log"
+        logdir.mkdir(exist_ok=True)
+        (logdir / "conversation.jsonl").write_text(
+            json.dumps(
+                {
+                    "role": "assistant",
+                    "content": content,
+                    "timestamp": "2025-01-01T00:00:00+00:00",
+                }
+            )
+            + "\n"
+        )
+        return Subagent(
+            agent_id=agent_id,
+            prompt="task",
+            thread=None,
+            logdir=logdir,
+            model=None,
+            output_schema=output_schema,
+        )
+
+    # -- _get_complete_instruction with output_schema --
+
+    def test_instruction_without_schema_has_no_json_hint(self):
+        instruction = _get_complete_instruction()
+        assert "JSON" not in instruction
+        assert "schema" not in instruction.lower()
+
+    def test_instruction_with_schema_includes_schema_hint(self):
+        instruction = _get_complete_instruction(output_schema=_SampleSchema)
+        assert "JSON" in instruction
+        assert '"type"' in instruction  # schema JSON is embedded
+        assert "value" in instruction  # property from schema
+
+    def test_instruction_with_schema_includes_important_warning(self):
+        instruction = _get_complete_instruction(output_schema=_SampleSchema)
+        assert "IMPORTANT" in instruction
+
+    def test_instruction_without_schema_has_generic_placeholder(self):
+        instruction = _get_complete_instruction()
+        assert "Your complete answer here." in instruction
+
+    def test_instruction_with_schema_replaces_generic_placeholder(self):
+        instruction = _get_complete_instruction(output_schema=_SampleSchema)
+        assert "Your complete answer here." not in instruction
+
+    # -- _validate_schema_result --
+
+    def test_validate_schema_result_no_schema_passthrough(self, tmp_path):
+        sa = self._make_subagent(tmp_path, "anything", output_schema=None)
+        assert sa._validate_schema_result("some text") == "some text"
+
+    def test_validate_schema_result_valid_json_canonicalized(self, tmp_path):
+        sa = self._make_subagent(tmp_path, "{}", output_schema=_SampleSchema)
+        raw = '{"value":  42,  "label": "hello"}'
+        result = sa._validate_schema_result(raw)
+        # Must be valid JSON (parseable)
+        parsed = json.loads(result)
+        assert parsed["value"] == 42
+        assert parsed["label"] == "hello"
+
+    def test_validate_schema_result_invalid_json_passthrough_with_warning(
+        self, tmp_path, caplog
+    ):
+        import logging
+
+        sa = self._make_subagent(tmp_path, "{}", output_schema=_SampleSchema)
+        with caplog.at_level(logging.WARNING, logger="gptme.tools.subagent.types"):
+            result = sa._validate_schema_result("not valid json {{")
+        assert result == "not valid json {{"
+        assert "not valid JSON" in caplog.text
+
+    # -- _read_log() with output_schema --
+
+    def test_read_log_with_schema_valid_json_complete_block(self, tmp_path):
+        content = '```complete\n{"value": 7, "label": "ok"}\n```'
+        sa = self._make_subagent(tmp_path, content, output_schema=_SampleSchema)
+        result = sa._read_log()
+        assert result.status == "success"
+        parsed = json.loads((result.result or "").split("\n\nFull log:")[0])
+        assert parsed == {"value": 7, "label": "ok"}
+
+    def test_read_log_with_schema_invalid_json_still_succeeds(self, tmp_path, caplog):
+        """Schema mismatch degrades gracefully — result is returned as raw text."""
+        import logging
+
+        content = "```complete\nnot json at all\n```"
+        sa = self._make_subagent(
+            tmp_path, content, output_schema=_SampleSchema, agent_id="bad-json"
+        )
+        with caplog.at_level(logging.WARNING, logger="gptme.tools.subagent.types"):
+            result = sa._read_log()
+        assert result.status == "success"
+        assert "not json at all" in (result.result or "")
+        assert "not valid JSON" in caplog.text
+
+    def test_read_log_without_schema_plain_text_unchanged(self, tmp_path):
+        content = "```complete\nhello world\n```"
+        sa = self._make_subagent(tmp_path, content, output_schema=None)
+        result = sa._read_log()
+        assert result.status == "success"
+        assert "hello world" in (result.result or "")
+        # Must NOT be interpreted as JSON
+        assert result.result is not None
+        assert result.result.startswith("hello world")

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -3354,29 +3354,29 @@ class TestOutputSchema:
         instruction = _get_complete_instruction(output_schema=_SampleSchema)
         assert "Your complete answer here." not in instruction
 
-    # -- _validate_schema_result --
+    # -- _normalize_json_result --
 
-    def test_validate_schema_result_no_schema_passthrough(self, tmp_path):
+    def test_normalize_json_result_no_schema_passthrough(self, tmp_path):
         sa = self._make_subagent(tmp_path, "anything", output_schema=None)
-        assert sa._validate_schema_result("some text") == "some text"
+        assert sa._normalize_json_result("some text") == "some text"
 
-    def test_validate_schema_result_valid_json_canonicalized(self, tmp_path):
+    def test_normalize_json_result_valid_json_canonicalized(self, tmp_path):
         sa = self._make_subagent(tmp_path, "{}", output_schema=_SampleSchema)
         raw = '{"value":  42,  "label": "hello"}'
-        result = sa._validate_schema_result(raw)
+        result = sa._normalize_json_result(raw)
         # Must be valid JSON (parseable)
         parsed = json.loads(result)
         assert parsed["value"] == 42
         assert parsed["label"] == "hello"
 
-    def test_validate_schema_result_invalid_json_passthrough_with_warning(
+    def test_normalize_json_result_invalid_json_passthrough_with_warning(
         self, tmp_path, caplog
     ):
         import logging
 
         sa = self._make_subagent(tmp_path, "{}", output_schema=_SampleSchema)
         with caplog.at_level(logging.WARNING, logger="gptme.tools.subagent.types"):
-            result = sa._validate_schema_result("not valid json {{")
+            result = sa._normalize_json_result("not valid json {{")
         assert result == "not valid json {{"
         assert "not valid JSON" in caplog.text
 


### PR DESCRIPTION
## Summary

- Thread-mode subagents were passing `output_schema` to `chat()` which forces OpenAI's `response_format=json` — this conflicts with `tool_format="markdown"` because the model can't write markdown code blocks while simultaneously being forced to output raw JSON. The net effect was that `output_schema` silently did the wrong thing.
- Fix: don't pass `output_schema` to `chat()` in thread mode; enforce the JSON output contract at the complete-block layer instead.

## Changes

**`gptme/tools/subagent/hooks.py`** — `_get_complete_instruction()` gains an optional `output_schema` parameter. When set, the JSON schema is embedded in the instruction and an IMPORTANT warning is appended so the subagent knows it must output valid JSON in the complete block.

**`gptme/tools/subagent/types.py`** — New `Subagent._normalize_json_result()` method normalizes valid JSON syntax (canonical re-serialization) and logs a warning for invalid JSON without hard-failing. It intentionally does not perform Pydantic schema validation. `_read_log()` calls it only for non-empty complete-block results, avoiding misleading invalid-JSON warnings for empty completion fallbacks.

**`gptme/tools/subagent/execution.py`** — Removed `output_schema=output_schema` from the `chat()` call in `_create_subagent_thread()`; passes it to `_get_complete_instruction()` instead. Comment explains the design decision.

**`tests/test_subagent_unit.py`** — Adds coverage for schema instruction content, placeholder replacement, JSON normalization pass/fail/no-schema paths, `_read_log()` integration with valid/invalid JSON, and empty complete-block fallback behavior without spurious JSON warnings.

## Test plan

- [x] `uv run --with pytest python -m pytest tests/test_subagent_unit.py -q` — 156 passed
- [x] `uv run --with pytest --with pytest-cov --with greenlet python -m pytest tests/test_subagent_unit.py -q --cov=gptme.tools.subagent.types --cov-report=term-missing` — 156 passed
- [x] `uv run ruff format tests/test_subagent_unit.py && uv run ruff check tests/test_subagent_unit.py`
- [x] Pre-commit hooks — passed during `git commit`

Closes part of #554 (the `output_schema` contract enforcement slice).
