### PR TITLE
fix(subagent): report unfinished thread agents as "timeout" in wait_all()

### DIFF
--- a/gptme/tools/subagent/batch.py
+++ b/gptme/tools/subagent/batch.py
@@ -50,10 +50,18 @@ class BatchJob:
             remaining = max(1, int(deadline - time.monotonic()))
             try:
                 result = subagent_wait(agent_id, timeout=remaining)
-                return agent_id, ReturnType(
-                    result.get("status", "failure"),
-                    result.get("result"),
-                )
+                status = result.get("status", "failure")
+                # subagent_wait() returns a non-terminal "running" status (with
+                # result=None) when a thread/ACP agent is still alive after the
+                # wait — these can't be force-killed. Report that as "timeout"
+                # per the documented contract, rather than leaking
+                # status="running"/result=None, which breaks callers that index
+                # into result (e.g. this function's own docstring example).
+                if status == "running":
+                    return agent_id, ReturnType(
+                        "timeout", f"Timed out after {timeout}s"
+                    )
+                return agent_id, ReturnType(status, result.get("result"))
             except Exception as e:
                 logger.warning(f"Error waiting for {agent_id}: {e}")
                 return agent_id, ReturnType("failure", str(e))

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -3126,6 +3126,35 @@ class TestBatchJobWaitAll:
         assert results["agent-b"]["status"] == "timeout"
         assert "30s" in results["agent-a"]["result"]
 
+    def test_wait_all_maps_running_result_to_timeout(self):
+        """An agent still running when subagent_wait() returns is reported as
+        "timeout", not the non-terminal status="running"/result=None.
+
+        Regression: subagent_wait() returns {"status": "running", "result": None}
+        for thread/ACP agents that are still alive after the wait (they can't be
+        force-killed). wait_all() previously leaked that verbatim, violating the
+        documented "timeout" contract and crashing callers that index into result
+        (e.g. the subagent_parallel docstring's own result['result'][:80]).
+        """
+        from unittest.mock import patch
+
+        from gptme.tools.subagent.batch import BatchJob
+
+        def fake_wait(agent_id, timeout=60, max_result_chars=2000):
+            # join(timeout) expires while the thread is still alive → subagent_wait
+            # falls back to status()=="running" with result=None.
+            return {"status": "running", "result": None}
+
+        job = BatchJob(agent_ids=["stuck-worker"])
+        with patch("gptme.tools.subagent.batch.subagent_wait", side_effect=fake_wait):
+            results = job.wait_all(timeout=2)
+
+        r = results["stuck-worker"]
+        assert r["status"] == "timeout"
+        # result must be a usable string, not None — docstring consumers slice it
+        assert r["result"] is not None
+        assert r["result"][:80]  # must not raise TypeError
+
 
 # ---------------------------------------------------------------------------
 # subagent_parallel tests


### PR DESCRIPTION
## What

`BatchJob.wait_all()` — the blocking wait behind `subagent_parallel()` (added in #3085) — reports an agent that's *still running* as `status="running"` with `result=None`, instead of the documented `status="timeout"`.

`subagent_wait()` returns a non-terminal `{"status": "running", "result": None}` for **thread/ACP** agents that are still alive after the wait: they can't be force-killed, so it falls back to `status() == "running"`. Meanwhile `_wait_one()` gives each per-agent wait a deadline ~1s shorter than the outer `as_completed()` timeout (`int()` truncation of the remaining time), so the future completes *normally* carrying `"running"` and the `FuturesTimeoutError` branch that marks stragglers as `"timeout"` never fires.

Two concrete symptoms:

- `wait_all()` violates its own documented contract — *"Agents that exceed this deadline are reported with status `"timeout"`"*.
- The `subagent_parallel()` docstring's **own** consumer example crashes:

  ```python
  print(f"{agent_id}: {result['status']} — {result['result'][:80]}")
  # TypeError: 'NoneType' object is not subscriptable
  ```

## Changes

- **`gptme/tools/subagent/batch.py`** — in `_wait_one()`, map a returned `"running"` status to `"timeout"` (with a message string), consistent with the existing `as_completed` timeout path. `"running"` is the only non-terminal status `subagent_wait()` can return (subprocess-mode stragglers are killed and yield a terminal status), so the mapping is complete.
- **`tests/test_subagent_unit.py`** — add `test_wait_all_maps_running_result_to_timeout`: mocks `subagent_wait()` to return the stuck-thread `{"status": "running", "result": None}` and asserts `wait_all()` reports `"timeout"` with a non-`None`, sliceable result. Fails on the pre-fix code.

## Testing

```
pytest tests/test_subagent_unit.py -q      # 144 passed
uvx ruff check / ruff format --check       # clean
```

Confirmed the new test fails without the fix and passes with it.

Relates to #554.
