### PR TITLE
feat(browser): add press_key, select_option, wait_for_element for computer-use (#216)

### DIFF
--- a/gptme/tools/_browser_playwright.py
+++ b/gptme/tools/_browser_playwright.py
@@ -790,7 +790,10 @@ def _press_key(browser: Browser, key: str) -> str:
     if _current_page is None:
         raise RuntimeError("No page is open. Call open_page(url) first.")
     _current_page.keyboard.press(key)
-    _current_page.wait_for_timeout(200)
+    try:
+        _current_page.wait_for_load_state("domcontentloaded", timeout=5000)
+    except PlaywrightTimeoutError:
+        pass  # Timeout is fine — key press may not navigate
     return _page_snapshot()
 
 
@@ -825,7 +828,11 @@ def _select_option(browser: Browser, selector: str, value: str) -> str:
     """Select an option from a <select> element on the current page."""
     if _current_page is None:
         raise RuntimeError("No page is open. Call open_page(url) first.")
-    _current_page.locator(selector).select_option(value=value, timeout=10000)
+    locator = _current_page.locator(selector)
+    try:
+        locator.select_option(value=value, timeout=10000)
+    except PlaywrightTimeoutError:
+        locator.select_option(label=value, timeout=10000)
     return _page_snapshot()
 
 

--- a/gptme/tools/_browser_playwright.py
+++ b/gptme/tools/_browser_playwright.py
@@ -785,6 +785,120 @@ def scroll_page(direction: str = "down", amount: int = 500) -> str:
     return _execute_with_retry(_scroll, direction, amount)
 
 
+def _press_key(browser: Browser, key: str) -> str:
+    """Press a keyboard key or shortcut in the current page."""
+    if _current_page is None:
+        raise RuntimeError("No page is open. Call open_page(url) first.")
+    _current_page.keyboard.press(key)
+    _current_page.wait_for_timeout(200)
+    return _page_snapshot()
+
+
+def press_key(key: str) -> str:
+    """Press a keyboard key or shortcut in the current browser page.
+
+    Dispatches the key event to the active focused element, or the document if
+    nothing is focused. Useful for submitting forms (``Enter``), navigating
+    autocomplete menus (``ArrowDown``), dismissing modals (``Escape``), and
+    triggering keyboard shortcuts (e.g. ``Control+a`` to select all).
+
+    Args:
+        key: Playwright key name. Examples: ``"Enter"``, ``"Tab"``,
+             ``"Escape"``, ``"ArrowDown"``, ``"Control+a"``, ``"Meta+k"``.
+
+    Returns:
+        Updated ARIA snapshot of the page after the key press.
+
+    Example::
+
+        open_page("https://example.com/search")
+        fill_element("[name='q']", "gptme")
+        press_key("Enter")   # submit the search form
+    """
+    if _current_page is None:
+        raise RuntimeError("No page is open. Call open_page(url) first.")
+    logger.info("Pressing key: '%s'", key)
+    return _execute_with_retry(_press_key, key)
+
+
+def _select_option(browser: Browser, selector: str, value: str) -> str:
+    """Select an option from a <select> element on the current page."""
+    if _current_page is None:
+        raise RuntimeError("No page is open. Call open_page(url) first.")
+    _current_page.locator(selector).select_option(value=value, timeout=10000)
+    return _page_snapshot()
+
+
+def select_option(selector: str, value: str) -> str:
+    """Select an option from a <select> dropdown on the current page.
+
+    Finds the ``<select>`` element and selects the option matching ``value``
+    by its ``value`` attribute or visible text.
+
+    Args:
+        selector: Playwright selector for the ``<select>`` element
+                  (e.g. ``"select#country"``, ``"[name='size']"``).
+        value: The option value (``value`` attribute) or label text to select.
+
+    Returns:
+        Updated ARIA snapshot of the page after the selection.
+
+    Example::
+
+        open_page("https://example.com/order")
+        select_option("[name='size']", "large")
+        click_element("text=Add to cart")
+    """
+    if _current_page is None:
+        raise RuntimeError("No page is open. Call open_page(url) first.")
+    logger.info("Selecting option '%s' from '%s'", value, selector)
+    return _execute_with_retry(_select_option, selector, value)
+
+
+def _wait_for_element(browser: Browser, selector: str, timeout_ms: int) -> str:
+    """Wait for an element to be visible on the current page."""
+    if _current_page is None:
+        raise RuntimeError("No page is open. Call open_page(url) first.")
+    try:
+        _current_page.locator(selector).wait_for(state="visible", timeout=timeout_ms)
+    except PlaywrightTimeoutError as e:
+        raise RuntimeError(
+            f"Element '{selector}' did not appear within {timeout_ms}ms. "
+            "The page may still be loading, or the selector is wrong."
+        ) from e
+    return _page_snapshot()
+
+
+def wait_for_element(selector: str, timeout_ms: int = 5000) -> str:
+    """Wait for a DOM element to become visible on the current page.
+
+    Blocks until the element matching ``selector`` is visible, then returns
+    the updated page snapshot. Useful after clicking something that triggers
+    a dynamic content load, modal, or redirect.
+
+    Args:
+        selector: Playwright selector for the element to wait for.
+        timeout_ms: Maximum wait time in milliseconds (default: 5000).
+                    Raises ``RuntimeError`` if element does not appear.
+
+    Returns:
+        Updated ARIA snapshot of the page once the element is visible.
+
+    Example::
+
+        open_page("https://x.com/compose/tweet")
+        wait_for_element("[data-testid='tweetTextarea_0']", timeout_ms=8000)
+        fill_element("[data-testid='tweetTextarea_0']", "Hello from gptme!")
+        click_element("[data-testid='tweetButtonInline']")
+    """
+    if _current_page is None:
+        raise RuntimeError("No page is open. Call open_page(url) first.")
+    if timeout_ms <= 0:
+        raise ValueError(f"timeout_ms must be positive, got: {timeout_ms!r}")
+    logger.info("Waiting for element '%s' (timeout=%dms)", selector, timeout_ms)
+    return _execute_with_retry(_wait_for_element, selector, timeout_ms)
+
+
 def _take_screenshot(
     browser: Browser, url: str, path: Path | str | None = None
 ) -> Path:

--- a/gptme/tools/browser.py
+++ b/gptme/tools/browser.py
@@ -353,6 +353,7 @@ if browser == "playwright":
     from ._browser_playwright import close_page as close_page_pw  # fmt: skip
     from ._browser_playwright import fill_element as fill_element_pw  # fmt: skip
     from ._browser_playwright import open_page as open_page_pw  # fmt: skip
+    from ._browser_playwright import press_key as press_key_pw  # fmt: skip
     from ._browser_playwright import read_logs as read_logs_playwright  # fmt: skip
     from ._browser_playwright import read_page_text as read_page_text_pw  # fmt: skip
     from ._browser_playwright import read_url as read_url_playwright  # fmt: skip
@@ -362,6 +363,10 @@ if browser == "playwright":
     from ._browser_playwright import screenshot_url as screenshot_url_pw  # fmt: skip
     from ._browser_playwright import scroll_page as scroll_page_pw  # fmt: skip
     from ._browser_playwright import search_duckduckgo, search_google  # fmt: skip
+    from ._browser_playwright import select_option as select_option_pw  # fmt: skip
+    from ._browser_playwright import (
+        wait_for_element as wait_for_element_pw,  # fmt: skip
+    )
 elif browser == "lynx":
     from ._browser_lynx import read_url as read_url_lynx  # fmt: skip
     from ._browser_lynx import search as search_lynx  # fmt: skip
@@ -1058,6 +1063,87 @@ def scroll_page(direction: str = "down", amount: int = 500) -> str:
     raise ValueError("Interactive browsing not supported with lynx backend")
 
 
+def press_key(key: str) -> str:
+    """Press a keyboard key or shortcut in the current browser page.
+
+    Dispatches the key event to the focused element (or document). Use for
+    submitting forms (``Enter``), navigating menus (``ArrowDown``), dismissing
+    dialogs (``Escape``), or triggering shortcuts (e.g. ``Control+a``).
+
+    Requires open_page() to be called first.
+
+    Args:
+        key: Playwright key name. Examples: ``"Enter"``, ``"Tab"``,
+             ``"Escape"``, ``"ArrowDown"``, ``"Control+a"``, ``"Meta+k"``.
+
+    Returns:
+        Updated ARIA snapshot of the page after the key press.
+
+    Example::
+
+        open_page("https://example.com/search")
+        fill_element("[name='q']", "gptme")
+        press_key("Enter")
+    """
+    assert browser
+    if browser == "playwright":
+        return press_key_pw(key)
+    raise ValueError("Interactive browsing not supported with lynx backend")
+
+
+def select_option(selector: str, value: str) -> str:
+    """Select an option from a <select> dropdown on the current page.
+
+    Requires open_page() to be called first.
+
+    Args:
+        selector: Playwright selector for the ``<select>`` element.
+        value: The option value attribute or visible text to select.
+
+    Returns:
+        Updated ARIA snapshot of the page after the selection.
+
+    Example::
+
+        open_page("https://example.com/order")
+        select_option("[name='size']", "large")
+        click_element("text=Add to cart")
+    """
+    assert browser
+    if browser == "playwright":
+        return select_option_pw(selector, value)
+    raise ValueError("Interactive browsing not supported with lynx backend")
+
+
+def wait_for_element(selector: str, timeout_ms: int = 5000) -> str:
+    """Wait for a DOM element to become visible on the current page.
+
+    Blocks until the element matching ``selector`` is visible, then returns
+    the updated ARIA snapshot. Use after actions that trigger dynamic content
+    loading (modals, async renders, redirects).
+
+    Requires open_page() to be called first.
+
+    Args:
+        selector: Playwright selector for the element to wait for.
+        timeout_ms: Maximum wait time in milliseconds (default: 5000).
+
+    Returns:
+        Updated ARIA snapshot once the element is visible.
+
+    Example::
+
+        open_page("https://x.com/compose/tweet")
+        wait_for_element("[data-testid='tweetTextarea_0']", timeout_ms=8000)
+        fill_element("[data-testid='tweetTextarea_0']", "Hello from gptme!")
+        click_element("[data-testid='tweetButtonInline']")
+    """
+    assert browser
+    if browser == "playwright":
+        return wait_for_element_pw(selector, timeout_ms)
+    raise ValueError("Interactive browsing not supported with lynx backend")
+
+
 tool = ToolSpec(
     name="browser",
     desc="Browse, interact with, search, or screenshot the web",
@@ -1072,7 +1158,8 @@ services with APIs, prefer shell or Python over scraping.""",
         "search the web with search() using auto-detected backends and fallback, "
         "capture screenshots with screenshot_url(), "
         "get ARIA accessibility snapshots with snapshot_url(), "
-        "interact with pages using open_page() + click_element()/fill_element()/scroll_page(), "
+        "interact with pages using open_page() + click_element()/fill_element()/"
+        "scroll_page()/press_key()/select_option()/wait_for_element(), "
         "read interactive page content with read_page_text(), "
         "check browser console errors with read_logs(), "
         "or convert a local PDF to images with pdf_to_images().",
@@ -1092,6 +1179,9 @@ services with APIs, prefer shell or Python over scraping.""",
             click_element,
             fill_element,
             scroll_page,
+            press_key,
+            select_option,
+            wait_for_element,
             read_logs,
             pdf_to_images,
         ]

--- a/tests/test_computer_use_integration.py
+++ b/tests/test_computer_use_integration.py
@@ -316,6 +316,19 @@ def test_press_key_returns_snapshot(form_server: str):
 
 
 @pytest.mark.integration
+def test_press_key_waits_for_navigation_after_enter(form_server: str):
+    """press_key("Enter") should return the post-submit page snapshot."""
+    from gptme.tools.browser import fill_element, open_page, press_key
+
+    open_page(f"{form_server}/")
+    fill_element("#message", "enter submit test")
+    result = press_key("Enter")
+
+    assert "Posted!" in result
+    assert _FormHandler.submitted.get("message") == "enter submit test"
+
+
+@pytest.mark.integration
 def test_select_option_picks_dropdown_value(form_server: str):
     """select_option() should pick an option from a <select> element."""
     from gptme.tools.browser import (
@@ -332,6 +345,26 @@ def test_select_option_picks_dropdown_value(form_server: str):
 
     assert _FormHandler.submitted.get("category") == "news", (
         f"Expected category=news, got: {_FormHandler.submitted}"
+    )
+
+
+@pytest.mark.integration
+def test_select_option_picks_dropdown_label_text(form_server: str):
+    """select_option() should fall back to selecting by visible option label."""
+    from gptme.tools.browser import (
+        click_element,
+        fill_element,
+        open_page,
+        select_option,
+    )
+
+    open_page(f"{form_server}/")
+    fill_element("#message", "dropdown label test")
+    select_option("#category", "News")
+    click_element("#submit-btn")
+
+    assert _FormHandler.submitted.get("category") == "news", (
+        f"Expected category=news from visible label, got: {_FormHandler.submitted}"
     )
 
 
@@ -358,7 +391,8 @@ def test_wait_for_element_finds_dynamically_shown_element(form_server: str):
     # The dynamic content is hidden initially; clicking the button shows it
     click_element("#show-dynamic")
     result = wait_for_element("#dynamic-content", timeout_ms=3000)
-    assert "Dynamic content" in result or result is not None
+    assert result is not None
+    assert "Dynamic content" in result
 
 
 @pytest.mark.integration

--- a/tests/test_computer_use_integration.py
+++ b/tests/test_computer_use_integration.py
@@ -91,8 +91,18 @@ _FORM_HTML = """\
   <input id="message" name="message" type="text" />
   <label for="author">Author:</label>
   <input id="author" name="author" type="text" />
+  <label for="category">Category:</label>
+  <select id="category" name="category">
+    <option value="tech">Tech</option>
+    <option value="news">News</option>
+    <option value="other">Other</option>
+  </select>
   <button type="submit" id="submit-btn">Post Tweet</button>
 </form>
+<div id="dynamic-content" style="display:none">Dynamic content loaded!</div>
+<button id="show-dynamic" onclick="document.getElementById('dynamic-content').style.display='block'">
+  Show Dynamic
+</button>
 </body>
 </html>
 """
@@ -291,3 +301,73 @@ def test_observe_web_returns_structured_result(form_server: str):
         m.content if isinstance(m.content, str) else str(m.content) for m in msgs
     )
     assert combined.strip(), "observe_web() returned messages with no content"
+
+
+@pytest.mark.integration
+def test_press_key_returns_snapshot(form_server: str):
+    """press_key() should not raise and should return a page snapshot."""
+    from gptme.tools.browser import open_page, press_key
+
+    open_page(f"{form_server}/")
+    # Tab between form fields — a benign key press that won't navigate away
+    result = press_key("Tab")
+    assert result is not None
+    assert isinstance(result, str)
+
+
+@pytest.mark.integration
+def test_select_option_picks_dropdown_value(form_server: str):
+    """select_option() should pick an option from a <select> element."""
+    from gptme.tools.browser import (
+        click_element,
+        fill_element,
+        open_page,
+        select_option,
+    )
+
+    open_page(f"{form_server}/")
+    fill_element("#message", "dropdown test")
+    select_option("#category", "news")  # select the "news" option
+    click_element("#submit-btn")
+
+    assert _FormHandler.submitted.get("category") == "news", (
+        f"Expected category=news, got: {_FormHandler.submitted}"
+    )
+
+
+@pytest.mark.integration
+def test_wait_for_element_finds_visible_element(form_server: str):
+    """wait_for_element() should resolve immediately for already-visible elements."""
+    from gptme.tools.browser import open_page, wait_for_element
+
+    snapshot = open_page(f"{form_server}/")
+    assert snapshot
+
+    # The submit button is visible immediately — wait_for_element should not timeout
+    result = wait_for_element("#submit-btn", timeout_ms=3000)
+    assert result is not None
+    assert isinstance(result, str)
+
+
+@pytest.mark.integration
+def test_wait_for_element_finds_dynamically_shown_element(form_server: str):
+    """wait_for_element() should find an element revealed by a click."""
+    from gptme.tools.browser import click_element, open_page, wait_for_element
+
+    open_page(f"{form_server}/")
+    # The dynamic content is hidden initially; clicking the button shows it
+    click_element("#show-dynamic")
+    result = wait_for_element("#dynamic-content", timeout_ms=3000)
+    assert "Dynamic content" in result or result is not None
+
+
+@pytest.mark.integration
+def test_wait_for_element_raises_on_missing(form_server: str):
+    """wait_for_element() should raise RuntimeError when the element never appears."""
+    import pytest
+
+    from gptme.tools.browser import open_page, wait_for_element
+
+    open_page(f"{form_server}/")
+    with pytest.raises(RuntimeError, match="did not appear"):
+        wait_for_element("#nonexistent-element-xyz", timeout_ms=500)

--- a/tests/test_util_cli.py
+++ b/tests/test_util_cli.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import re
 import time
 from pathlib import Path
 from types import SimpleNamespace
@@ -33,7 +34,8 @@ def test_tokens_count(tmp_path):
     )
     assert result.exit_code == 0
     assert "Token count" in result.output
-    assert int(result.output.split(": ", 1)[1].strip()) > 0
+    m = re.search(r"Token count [^:]+: (\d+)", result.output)
+    assert m and int(m.group(1)) > 0
 
     # Models tiktoken doesn't natively recognize fall back to an estimate
     # (cl100k_base) rather than erroring — a counter should count, not refuse.
@@ -42,14 +44,16 @@ def test_tokens_count(tmp_path):
     )
     assert result.exit_code == 0
     assert "Token count" in result.output
-    assert int(result.output.split(": ", 1)[1].strip()) > 0
+    m = re.search(r"Token count [^:]+: (\d+)", result.output)
+    assert m and int(m.group(1)) > 0
 
     # Provider-prefixed models needing prefix-strip (e.g. openai/o1) should
     # get the correct encoding (o200k_base), not fall back to cl100k_base.
     result = runner.invoke(main, ["tokens", "count", "--model", "openai/o1", "test"])
     assert result.exit_code == 0
     assert "Token count" in result.output
-    assert int(result.output.split(": ", 1)[1].strip()) > 0
+    m = re.search(r"Token count [^:]+: (\d+)", result.output)
+    assert m and int(m.group(1)) > 0
 
     # Test file input
     tmp_file = Path(tmp_path) / "test.txt"


### PR DESCRIPTION
## What

Adds three missing browser interaction primitives to the `browser` tool, needed for real-world computer-use tasks (the \"Can it Tweet?\" milestone and similar autonomous web workflows):

| Function | Purpose |
|----------|---------|
| `press_key(key)` | Dispatch keyboard events to the focused element — `Enter` to submit forms, `Tab` to navigate between fields, `Escape` to dismiss modals, `Control+a` for shortcuts |
| `select_option(selector, value)` | Select from `<select>` dropdowns by value attribute or visible label text |
| `wait_for_element(selector, timeout_ms=5000)` | Block until a DOM element becomes visible — essential for dynamic pages that load content asynchronously after a click |

## Why these are needed

The existing interactive browser API (`open_page`, `fill_element`, `click_element`, `scroll_page`) covers the basics but hits real walls on modern web apps:

- **`press_key`**: Twitter's tweet composer requires `Ctrl+Enter` to post; search forms often submit on `Enter`; autocomplete menus navigate with arrow keys
- **`select_option`**: Many forms use `<select>` dropdowns (country, category, size) that `fill_element` can't handle (it calls `fill()` which only works on `<input>`/`<textarea>`)
- **`wait_for_element`**: Dynamic SPAs (React/Vue) render elements asynchronously — clicking a button and immediately trying to interact with the result races the DOM

## Implementation

All three follow the same retry/error pattern as the existing functions:

- `_browser_playwright.py`: core implementation using Playwright's `keyboard.press()`, `locator().select_option()`, and `locator().wait_for(state="visible")`
- `browser.py`: thin wrapper that dispatches to the playwright implementation (with the same lynx fallback error for non-playwright backends)
- Registered in `ToolSpec.functions` so they appear in the model's tool list and docstrings

## Tests

Extended `test_computer_use_integration.py` with 5 new integration tests (all gated behind the existing playwright/chromium skip guard):

- `test_press_key_returns_snapshot` — Tab key doesn't crash, returns a snapshot
- `test_select_option_picks_dropdown_value` — selects \"news\" from the category dropdown; verified at the server
- `test_wait_for_element_finds_visible_element` — resolves immediately for an already-visible button
- `test_wait_for_element_finds_dynamically_shown_element` — resolves after a JS click reveals a hidden div
- `test_wait_for_element_raises_on_missing` — raises `RuntimeError` with \"did not appear\" for a nonexistent selector

The test form server gained a `<select id="category">` and a JS-revealed `<div id="dynamic-content">` to give the new tests real targets.

Closes part of #216

<!-- gptme-id:v1:gai_e80rd7dOOe7n0TC0a8RsXG5mpFSZKNkFaIL5uDAv9OJ -->