### PR TITLE
feat(subagent): add output_schema, workdir, context_turns to subagent_parallel() and batch (#554)

### DIFF
--- a/gptme/tools/subagent/batch.py
+++ b/gptme/tools/subagent/batch.py
@@ -168,11 +168,22 @@ class BatchJob:
         return len(self.results) == len(self.agent_ids)
 
     def get_completed(self) -> dict[str, dict]:
-        """Get results of completed subagents so far."""
+        """Get results of completed subagents so far.
+
+        When the ``BatchJob`` was created with an ``output_schema`` (via
+        ``subagent_batch(output_schema=...)``) the results are automatically
+        parsed through ``_parse_result()`` before being returned, matching the
+        behaviour of ``wait_all()``.
+        """
         from dataclasses import asdict
 
         with self._lock:
-            return {aid: asdict(r) for aid, r in self.results.items()}
+            raw = {aid: asdict(r) for aid, r in self.results.items()}
+            if self.output_schema is not None:
+                return {
+                    aid: _parse_result(r, self.output_schema) for aid, r in raw.items()
+                }
+            return raw
 
 
 def subagent_batch(

--- a/gptme/tools/subagent/batch.py
+++ b/gptme/tools/subagent/batch.py
@@ -5,16 +5,53 @@ for convenient fire-and-gather patterns. Also provides subagent_parallel()
 for a simpler synchronous fan-out pattern.
 """
 
+import json
 import logging
 import threading
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from concurrent.futures import TimeoutError as FuturesTimeoutError
 from dataclasses import asdict, dataclass, field
+from pathlib import Path
 
 from .api import subagent, subagent_cancel, subagent_wait
 from .types import ReturnType
 
 logger = logging.getLogger(__name__)
+
+
+def _parse_result(result_dict: dict, output_schema: type | None) -> dict:
+    """Parse a subagent result dict against an output_schema if provided.
+
+    When output_schema is set and the result is a success with a JSON string,
+    attempt to parse it. For Pydantic models, validate with model_validate().
+    On parse failure, keep the raw string and add a "parse_error" key.
+
+    Args:
+        result_dict: Dict from subagent_wait() with "status" and "result" keys.
+        output_schema: Optional Pydantic model class or type to parse against.
+
+    Returns:
+        Updated result dict. On successful parse the "result" value is the
+        parsed object (dict for Pydantic, any JSON value otherwise).
+    """
+    if output_schema is None:
+        return result_dict
+
+    result_text = result_dict.get("result")
+    if result_dict.get("status") != "success" or not result_text:
+        return result_dict
+
+    out = dict(result_dict)
+    try:
+        parsed = json.loads(result_text)
+        if hasattr(output_schema, "model_validate"):
+            out["result"] = output_schema.model_validate(parsed).model_dump()
+        else:
+            out["result"] = parsed
+    except Exception as exc:
+        logger.warning(f"output_schema parse failed: {exc}")
+        out["parse_error"] = str(exc)
+    return out
 
 
 @dataclass
@@ -109,6 +146,10 @@ def subagent_batch(
     use_subprocess: bool = False,
     use_acp: bool = False,
     acp_command: str = "gptme-acp",
+    model: str | None = None,
+    profile: str | None = None,
+    isolated: bool = False,
+    output_schema: type | None = None,
     redact_secrets: bool = True,
 ) -> BatchJob:
     """Start multiple subagents in parallel and return a BatchJob to manage them.
@@ -125,6 +166,14 @@ def subagent_batch(
         use_subprocess: If True, run subagents in subprocesses for output isolation
         use_acp: If True, run subagents via ACP protocol
         acp_command: ACP agent command (default: "gptme-acp")
+        model: Model override applied to every subagent.
+        profile: Agent profile name applied to every subagent.
+        isolated: If True, run each subagent in its own git worktree so file
+            edits don't conflict between agents or with the parent.
+        output_schema: Optional Pydantic model class. When set, subagents are
+            instructed to return JSON matching the schema in their complete block.
+            The schema is used for prompt construction; call ``wait_all()`` and
+            then ``_parse_result()`` to validate results.
         redact_secrets: If True (default), redact secrets from workspace context
             passed to subagents. Pass False only if you need subagents to see
             config values that are incorrectly flagged as secrets.
@@ -159,6 +208,10 @@ def subagent_batch(
             use_subprocess=use_subprocess,
             use_acp=use_acp,
             acp_command=acp_command,
+            model=model,
+            profile=profile,
+            isolated=isolated,
+            output_schema=output_schema,
             redact_secrets=redact_secrets,
         )
 
@@ -175,6 +228,9 @@ def subagent_parallel(
     model: str | None = None,
     profile: str | None = None,
     isolated: bool = False,
+    output_schema: type | None = None,
+    workdir: str | Path | None = None,
+    context_turns: int | None = None,
     redact_secrets: bool = True,
 ) -> list[dict]:
     """Fan out N subagents in parallel, wait for all, return results as an ordered list.
@@ -204,13 +260,25 @@ def subagent_parallel(
             ``"explorer"``, ``"developer"``, ``"verifier"``).
         isolated: If True, run each subagent in its own git worktree so file
             edits don't conflict between agents or with the parent.
+        output_schema: Optional Pydantic model class. When set, subagents are
+            instructed to return valid JSON matching the schema in their
+            ``complete`` block. Results are automatically parsed: on success the
+            ``"result"`` value is the parsed/validated object (a dict for Pydantic
+            models) rather than a raw JSON string. A ``"parse_error"`` key is
+            added to any result that cannot be parsed.
+        workdir: Working directory passed to every subagent. Useful when running
+            subagents against a specific project directory.
+        context_turns: Number of recent parent conversation turns to forward to
+            each subagent as context prefix. Pass ``None`` (default) to use no
+            parent context.
         redact_secrets: If True (default), scrub common secret patterns from
             workspace context before passing it to subagents.
 
     Returns:
         List of result dicts in the same order as ``tasks``. Each dict has
         ``"status"`` (``"success"`` / ``"failure"`` / ``"timeout"``) and
-        ``"result"`` (summary text from the subagent's ``complete`` block).
+        ``"result"`` (parsed object when ``output_schema`` is set, else the
+        summary text from the subagent's ``complete`` block).
 
     Example::
 
@@ -228,6 +296,23 @@ def subagent_parallel(
             [("fix-a", "Fix bug in module A"), ("fix-b", "Fix bug in module B")],
             isolated=True,
         )
+
+        # With structured output (Pydantic model)
+        from pydantic import BaseModel
+
+        class AnalysisResult(BaseModel):
+            summary: str
+            score: int
+            issues: list[str]
+
+        results = subagent_parallel(
+            [("a1", "Analyze module A"), ("a2", "Analyze module B")],
+            output_schema=AnalysisResult,
+        )
+        for r in results:
+            if r["status"] == "success":
+                analysis = r["result"]  # already a validated dict
+                print(f"Score: {analysis['score']}, Issues: {analysis['issues']}")
     """
     if not tasks:
         return []
@@ -245,6 +330,9 @@ def subagent_parallel(
                 model=model,
                 profile=profile,
                 isolated=isolated,
+                output_schema=output_schema,
+                workdir=workdir,
+                context_turns=context_turns,
                 redact_secrets=redact_secrets,
             )
             started_ids.append(agent_id)
@@ -262,8 +350,9 @@ def subagent_parallel(
     job = BatchJob(agent_ids=[t[0] for t in tasks])
     job.wait_all(timeout=timeout)
 
-    # Return results in input order; fall back to failure for missing results
-    return [
+    # Return results in input order; fall back to failure for missing results.
+    # When output_schema is set, parse the JSON result against the schema.
+    raw_results = [
         asdict(
             job.results.get(
                 agent_id, ReturnType("failure", "No result (timeout or missing)")
@@ -271,3 +360,6 @@ def subagent_parallel(
         )
         for agent_id, _ in tasks
     ]
+    if output_schema is not None:
+        return [_parse_result(r, output_schema) for r in raw_results]
+    return raw_results

--- a/gptme/tools/subagent/batch.py
+++ b/gptme/tools/subagent/batch.py
@@ -84,6 +84,7 @@ class BatchJob:
 
     agent_ids: list[str]
     results: dict[str, ReturnType] = field(default_factory=dict)
+    output_schema: type | None = field(default=None)
     _lock: threading.Lock = field(default_factory=threading.Lock)
 
     def wait_all(self, timeout: int = 300) -> dict[str, dict]:
@@ -93,11 +94,18 @@ class BatchJob:
         wall-clock time is bounded by the slowest agent, not the sum of all
         agent times.
 
+        When the ``BatchJob`` was created with an ``output_schema`` (via
+        ``subagent_batch(output_schema=...)``) the results are automatically
+        parsed through ``_parse_result()`` before being returned, matching the
+        auto-parse behaviour of ``subagent_parallel(output_schema=...)``.
+
         Args:
             timeout: Maximum seconds to wait for all subagents
 
         Returns:
-            Dict mapping agent_id to status dict
+            Dict mapping agent_id to status dict. When ``output_schema`` is set,
+            the ``"result"`` value is the parsed/validated object rather than a
+            raw JSON string.
         """
 
         def _wait_one(agent_id: str, deadline: float) -> tuple[str, ReturnType]:
@@ -150,7 +158,10 @@ class BatchJob:
                                 "timeout", f"Timed out after {timeout}s"
                             )
 
-        return {aid: asdict(r) for aid, r in self.results.items()}
+        raw = {aid: asdict(r) for aid, r in self.results.items()}
+        if self.output_schema is not None:
+            return {aid: _parse_result(r, self.output_schema) for aid, r in raw.items()}
+        return raw
 
     def is_complete(self) -> bool:
         """Check if all subagents have completed."""
@@ -197,8 +208,10 @@ def subagent_batch(
             edits don't conflict between agents or with the parent.
         output_schema: Optional Pydantic model class. When set, subagents are
             instructed to return JSON matching the schema in their complete block.
-            The schema is used for prompt construction; call ``wait_all()`` and
-            then ``_parse_result()`` to validate results.
+            Results are automatically parsed when ``wait_all()`` is called — the
+            ``"result"`` value in each returned dict will be the parsed/validated
+            object rather than a raw JSON string, matching the behaviour of
+            ``subagent_parallel(output_schema=...)``.
         workdir: Working directory passed to every subagent. Useful when running
             subagents against a specific project directory.
         context_turns: Number of recent parent conversation turns to forward to
@@ -228,7 +241,7 @@ def subagent_batch(
         # Or explicitly wait for all if needed:
         results = job.wait_all(timeout=300)
     """
-    job = BatchJob(agent_ids=[t[0] for t in tasks])
+    job = BatchJob(agent_ids=[t[0] for t in tasks], output_schema=output_schema)
 
     # Start all subagents (completions delivered via hooks)
     for agent_id, prompt in tasks:

--- a/gptme/tools/subagent/batch.py
+++ b/gptme/tools/subagent/batch.py
@@ -19,12 +19,29 @@ from .types import ReturnType
 logger = logging.getLogger(__name__)
 
 
+def _strip_log_suffix(text: str) -> str:
+    """Strip the ``\\n\\nFull log: ...`` suffix that thread-mode subagents append to results.
+
+    ``Subagent._read_log()`` in ``types.py`` appends ``"\\n\\nFull log: {logdir}"``
+    to every thread-mode result string. This suffix breaks JSON parsing when
+    ``output_schema`` is set. This helper strips it so the caller sees clean content.
+    """
+    log_sep = "\n\nFull log: "
+    if log_sep in text:
+        return text.split(log_sep, 1)[0]
+    return text
+
+
 def _parse_result(result_dict: dict, output_schema: type | None) -> dict:
     """Parse a subagent result dict against an output_schema if provided.
 
     When output_schema is set and the result is a success with a JSON string,
     attempt to parse it. For Pydantic models, validate with model_validate().
     On parse failure, keep the raw string and add a "parse_error" key.
+
+    Automatically strips the ``\\n\\nFull log: ...`` suffix added by
+    ``Subagent._read_log()`` before parsing, so thread-mode subagent results
+    with ``output_schema`` work correctly.
 
     Args:
         result_dict: Dict from subagent_wait() with "status" and "result" keys.
@@ -43,7 +60,9 @@ def _parse_result(result_dict: dict, output_schema: type | None) -> dict:
 
     out = dict(result_dict)
     try:
-        parsed = json.loads(result_text)
+        # Strip the log-path suffix that thread-mode _read_log() appends
+        clean = _strip_log_suffix(result_text)
+        parsed = json.loads(clean)
         if hasattr(output_schema, "model_validate"):
             out["result"] = output_schema.model_validate(parsed).model_dump()
         else:
@@ -86,7 +105,11 @@ class BatchJob:
 
             remaining = max(1, int(deadline - time.monotonic()))
             try:
-                result = subagent_wait(agent_id, timeout=remaining)
+                # Pass max_result_chars=0 so _parse_result() receives the full
+                # raw result without truncation. The default of 2000 would clip
+                # JSON from larger schemas and make structured output silently
+                # fail in _parse_result().
+                result = subagent_wait(agent_id, timeout=remaining, max_result_chars=0)
                 status = result.get("status", "failure")
                 # subagent_wait() returns a non-terminal "running" status (with
                 # result=None) when a thread/ACP agent is still alive after the
@@ -150,6 +173,8 @@ def subagent_batch(
     profile: str | None = None,
     isolated: bool = False,
     output_schema: type | None = None,
+    workdir: str | Path | None = None,
+    context_turns: int | None = None,
     redact_secrets: bool = True,
 ) -> BatchJob:
     """Start multiple subagents in parallel and return a BatchJob to manage them.
@@ -174,6 +199,11 @@ def subagent_batch(
             instructed to return JSON matching the schema in their complete block.
             The schema is used for prompt construction; call ``wait_all()`` and
             then ``_parse_result()`` to validate results.
+        workdir: Working directory passed to every subagent. Useful when running
+            subagents against a specific project directory.
+        context_turns: Number of recent parent conversation turns to forward to
+            each subagent as context prefix. Pass ``None`` (default) to use no
+            parent context.
         redact_secrets: If True (default), redact secrets from workspace context
             passed to subagents. Pass False only if you need subagents to see
             config values that are incorrectly flagged as secrets.
@@ -212,6 +242,8 @@ def subagent_batch(
             profile=profile,
             isolated=isolated,
             output_schema=output_schema,
+            workdir=workdir,
+            context_turns=context_turns,
             redact_secrets=redact_secrets,
         )
 

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -446,6 +446,34 @@ class TestBatchJob:
         job = BatchJob(agent_ids=["x"])
         assert job.get_completed() == {}
 
+    def test_get_completed_auto_parses_output_schema(self):
+        """get_completed() auto-parses results when output_schema is set.
+
+        This is the regression test for the Greptile P1 finding:
+        get_completed() on a BatchJob with output_schema should apply _parse_result()
+        just like wait_all() does, so partial results have consistent parsing.
+        """
+        from gptme.tools.subagent.batch import BatchJob
+        from gptme.tools.subagent.types import ReturnType
+
+        class Schema:
+            pass
+
+        job = BatchJob(agent_ids=["a", "b"], output_schema=Schema)
+        # Simulate a completed result with raw JSON string
+        json_result = '{"x": 42}'
+        job.results["a"] = ReturnType("success", json_result)
+
+        completed = job.get_completed()
+        assert "a" in completed
+        assert completed["a"]["status"] == "success"
+        # Auto-parsed: should be a dict, not the raw JSON string
+        assert completed["a"]["result"] == {"x": 42}, (
+            "get_completed() must auto-parse the result when output_schema is set; "
+            f"got {completed['a']['result']!r} instead of {{'x': 42}}"
+        )
+        assert "b" not in completed  # Only completed agent appears
+
     def test_wait_all_does_not_raise_on_as_completed_timeout(self, monkeypatch):
         """wait_all() must not propagate TimeoutError — stalled agents get a result dict."""
         import threading

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -3802,3 +3802,94 @@ class TestSubagentBatchNewParameters:
         assert len(captured) == 2
         for kw in captured:
             assert kw.get("output_schema") is Schema
+
+    def test_strip_log_suffix_strips_full_log(self):
+        """_strip_log_suffix removes the \\n\\nFull log: ... suffix."""
+        from gptme.tools.subagent.batch import _strip_log_suffix
+
+        text = '{"score": 99}\n\nFull log: /tmp/agent-xyz/logs'
+        assert _strip_log_suffix(text) == '{"score": 99}'
+
+    def test_strip_log_suffix_passthrough_when_no_suffix(self):
+        """_strip_log_suffix returns text unchanged when no log suffix."""
+        from gptme.tools.subagent.batch import _strip_log_suffix
+
+        text = '{"score": 99}'
+        assert _strip_log_suffix(text) == '{"score": 99}'
+
+    def test_strip_log_suffix_passthrough_empty_string(self):
+        """_strip_log_suffix handles empty strings."""
+        from gptme.tools.subagent.batch import _strip_log_suffix
+
+        assert _strip_log_suffix("") == ""
+
+    def test_parse_result_handles_full_log_suffix(self):
+        """_parse_result strips the Full log suffix before parsing JSON."""
+        from gptme.tools.subagent.batch import _parse_result
+
+        class Schema:
+            pass
+
+        d = {
+            "status": "success",
+            "result": '{"score": 99}\n\nFull log: /tmp/agent-xyz/logs',
+        }
+        result = _parse_result(d, Schema)
+        assert result["result"] == {"score": 99}
+        assert "parse_error" not in result
+
+    def test_parse_result_handles_full_log_suffix_with_pydantic(self):
+        """_parse_result strips Full log suffix before Pydantic validation."""
+        from gptme.tools.subagent.batch import _parse_result
+
+        class FakePydantic:
+            @classmethod
+            def model_validate(cls, data):
+                return cls()
+
+            def model_dump(self):
+                return {"validated": True}
+
+        d = {
+            "status": "success",
+            "result": '{"validated": true}\n\nFull log: /tmp/agent-xyz/logs',
+        }
+        result = _parse_result(d, FakePydantic)
+        assert result["result"] == {"validated": True}
+        assert "parse_error" not in result
+
+    def test_workdir_forwarded_to_subagent_batch(self, monkeypatch):
+        """workdir is forwarded to each subagent() call from subagent_batch()."""
+        import gptme.tools.subagent.batch as batch_mod
+        from gptme.tools.subagent.batch import subagent_batch
+
+        captured: list[dict] = []
+
+        def mock_subagent(agent_id, prompt, **kwargs):
+            captured.append(kwargs)
+
+        monkeypatch.setattr(batch_mod, "subagent", mock_subagent)
+
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            subagent_batch([("w1", "p1")], workdir=tmpdir)
+            assert captured[0].get("workdir") == tmpdir
+
+    def test_context_turns_forwarded_to_subagent_batch(self, monkeypatch):
+        """context_turns is forwarded to each subagent() call from subagent_batch()."""
+        import gptme.tools.subagent.batch as batch_mod
+        from gptme.tools.subagent.batch import subagent_batch
+
+        captured: list[dict] = []
+
+        def mock_subagent(agent_id, prompt, **kwargs):
+            captured.append(kwargs)
+
+        monkeypatch.setattr(batch_mod, "subagent", mock_subagent)
+
+        subagent_batch([("c1", "p1"), ("c2", "p2")], context_turns=5)
+
+        assert len(captured) == 2
+        for kw in captured:
+            assert kw.get("context_turns") == 5

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -3823,6 +3823,106 @@ class TestSubagentBatchNewParameters:
 
         assert _strip_log_suffix("") == ""
 
+    def test_wait_all_auto_parses_output_schema(self, monkeypatch):
+        """subagent_batch(output_schema=...) → wait_all() returns parsed dicts.
+
+        This is the end-to-end regression test for the Greptile P1 finding:
+        BatchJob.wait_all() must apply _parse_result() when output_schema is set,
+        matching the auto-parse behaviour of subagent_parallel(output_schema=...).
+        """
+        import threading
+        from pathlib import Path
+        from unittest.mock import MagicMock
+
+        import gptme.tools.subagent.batch as batch_mod
+        from gptme.tools.subagent.batch import subagent_batch
+        from gptme.tools.subagent.types import (
+            ReturnType,
+            Subagent,
+            _subagent_results,
+            _subagent_results_lock,
+            _subagents,
+            _subagents_lock,
+        )
+
+        class Schema:
+            pass
+
+        # Stub out subagent() so no threads are launched
+        monkeypatch.setattr(batch_mod, "subagent", lambda agent_id, prompt, **kw: None)
+
+        # Pre-populate the result registry with a valid JSON string
+        json_result = '{"x": 42}'
+        t = MagicMock(spec=threading.Thread)
+        t.is_alive.return_value = False
+        t.join = MagicMock()
+        sa = Subagent(
+            agent_id="s1",
+            prompt="test",
+            thread=t,
+            logdir=Path("/tmp/fake-log"),
+            model=None,
+        )
+        with _subagents_lock:
+            _subagents.append(sa)
+        with _subagent_results_lock:
+            _subagent_results["s1"] = ReturnType("success", json_result)
+
+        # Call subagent_batch with output_schema and wait_all()
+        job = subagent_batch([("s1", "do something")], output_schema=Schema)
+        assert job.output_schema is Schema, "BatchJob must store output_schema"
+
+        results = job.wait_all(timeout=5)
+
+        assert "s1" in results
+        assert results["s1"]["status"] == "success"
+        # Auto-parsed: should be a dict, not the raw JSON string
+        assert results["s1"]["result"] == {"x": 42}, (
+            "wait_all() must auto-parse the result when output_schema is set; "
+            f"got {results['s1']['result']!r} instead of {{'x': 42}}"
+        )
+
+    def test_wait_all_without_schema_returns_raw_strings(self, monkeypatch):
+        """wait_all() returns raw strings when output_schema is not set (no regression)."""
+        import threading
+        from pathlib import Path
+        from unittest.mock import MagicMock
+
+        import gptme.tools.subagent.batch as batch_mod
+        from gptme.tools.subagent.batch import subagent_batch
+        from gptme.tools.subagent.types import (
+            ReturnType,
+            Subagent,
+            _subagent_results,
+            _subagent_results_lock,
+            _subagents,
+            _subagents_lock,
+        )
+
+        monkeypatch.setattr(batch_mod, "subagent", lambda agent_id, prompt, **kw: None)
+
+        raw = "plain string result"
+        t = MagicMock(spec=threading.Thread)
+        t.is_alive.return_value = False
+        t.join = MagicMock()
+        sa = Subagent(
+            agent_id="ns1",
+            prompt="test",
+            thread=t,
+            logdir=Path("/tmp/fake-log"),
+            model=None,
+        )
+        with _subagents_lock:
+            _subagents.append(sa)
+        with _subagent_results_lock:
+            _subagent_results["ns1"] = ReturnType("success", raw)
+
+        job = subagent_batch([("ns1", "do something")])
+        assert job.output_schema is None
+        results = job.wait_all(timeout=5)
+
+        assert results["ns1"]["result"] == raw
+
     def test_parse_result_handles_full_log_suffix(self):
         """_parse_result strips the Full log suffix before parsing JSON."""
         from gptme.tools.subagent.batch import _parse_result

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -9,6 +9,7 @@ import json
 import queue
 import threading
 from pathlib import Path
+from typing import Literal
 from unittest.mock import MagicMock
 
 import pytest
@@ -3485,3 +3486,319 @@ class TestOutputSchema:
         assert result.status == "success"
         assert "Task completed (no summary provided)" in (result.result or "")
         assert "not valid JSON" not in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# _parse_result() helper + subagent_parallel/subagent_batch new parameters
+# ---------------------------------------------------------------------------
+
+
+class TestParseResult:
+    """Tests for the _parse_result() helper in batch.py."""
+
+    def test_passthrough_when_schema_is_none(self):
+        from gptme.tools.subagent.batch import _parse_result
+
+        d = {"status": "success", "result": "some text"}
+        assert _parse_result(d, None) is d
+
+    def test_passthrough_on_failure_status(self):
+        from gptme.tools.subagent.batch import _parse_result
+
+        d = {"status": "failure", "result": '{"value": 1}'}
+
+        class Schema:
+            @classmethod
+            def model_json_schema(cls):
+                return {}
+
+        result = _parse_result(d, Schema)
+        assert result["result"] == '{"value": 1}'
+
+    def test_passthrough_when_result_is_none(self):
+        from gptme.tools.subagent.batch import _parse_result
+
+        d = {"status": "success", "result": None}
+
+        class Schema:
+            @classmethod
+            def model_json_schema(cls):
+                return {}
+
+        result = _parse_result(d, Schema)
+        assert result["result"] is None
+
+    def test_plain_json_parse_without_pydantic(self):
+        from gptme.tools.subagent.batch import _parse_result
+
+        class PlainSchema:
+            pass
+
+        d = {"status": "success", "result": '{"x": 42, "y": "hello"}'}
+        result = _parse_result(d, PlainSchema)
+        assert result["result"] == {"x": 42, "y": "hello"}
+        assert "parse_error" not in result
+
+    def test_pydantic_model_validate_called(self):
+        from gptme.tools.subagent.batch import _parse_result
+
+        class FakePydantic:
+            @classmethod
+            def model_validate(cls, data):
+                return cls()
+
+            def model_dump(self):
+                return {"validated": True}
+
+        d = {"status": "success", "result": '{"validated": true}'}
+        result = _parse_result(d, FakePydantic)
+        assert result["result"] == {"validated": True}
+        assert "parse_error" not in result
+
+    def test_parse_error_key_on_invalid_json(self):
+        from gptme.tools.subagent.batch import _parse_result
+
+        class Schema:
+            pass
+
+        d = {"status": "success", "result": "not valid json {{"}
+        result = _parse_result(d, Schema)
+        assert "parse_error" in result
+        assert result["result"] == "not valid json {{"
+
+    def test_original_result_preserved_on_parse_error(self):
+        from gptme.tools.subagent.batch import _parse_result
+
+        class Schema:
+            pass
+
+        original = "bad json"
+        d = {"status": "success", "result": original}
+        result = _parse_result(d, Schema)
+        assert result["result"] == original
+
+
+class TestSubagentParallelOutputSchema:
+    """Tests for output_schema support in subagent_parallel()."""
+
+    def setup_method(self):
+        with _subagents_lock:
+            _subagents.clear()
+        with _subagent_results_lock:
+            _subagent_results.clear()
+
+    def _register_fake_agent(
+        self,
+        agent_id: str,
+        result_text: str,
+        status: Literal[
+            "running", "success", "failure", "clarification_needed", "timeout"
+        ] = "success",
+    ):
+        import threading
+
+        t = MagicMock(spec=threading.Thread)
+        t.is_alive.return_value = False
+        t.join = MagicMock()
+        sa = Subagent(
+            agent_id=agent_id,
+            prompt="test prompt",
+            thread=t,
+            logdir=Path("/tmp/fake-log"),
+            model=None,
+        )
+        with _subagents_lock:
+            _subagents.append(sa)
+        with _subagent_results_lock:
+            _subagent_results[agent_id] = ReturnType(status, result_text)
+
+    def test_output_schema_none_returns_raw_strings(self, monkeypatch):
+        """Without output_schema, results have raw string in 'result'."""
+        import gptme.tools.subagent.batch as batch_mod
+        from gptme.tools.subagent.batch import subagent_parallel
+
+        def mock_subagent(agent_id, prompt, **kwargs):
+            self._register_fake_agent(agent_id, '{"value": 1}')
+
+        monkeypatch.setattr(batch_mod, "subagent", mock_subagent)
+
+        results = subagent_parallel([("a", "prompt")], timeout=5)
+        assert results[0]["result"] == '{"value": 1}'
+
+    def test_output_schema_parses_json_results(self, monkeypatch):
+        """With output_schema set, JSON results are automatically parsed."""
+        import gptme.tools.subagent.batch as batch_mod
+        from gptme.tools.subagent.batch import subagent_parallel
+
+        class MySchema:
+            pass
+
+        def mock_subagent(agent_id, prompt, **kwargs):
+            self._register_fake_agent(agent_id, '{"score": 99}')
+
+        monkeypatch.setattr(batch_mod, "subagent", mock_subagent)
+
+        results = subagent_parallel(
+            [("x", "prompt")], output_schema=MySchema, timeout=5
+        )
+        assert results[0]["result"] == {"score": 99}
+        assert "parse_error" not in results[0]
+
+    def test_output_schema_forwarded_to_subagent(self, monkeypatch):
+        """output_schema is forwarded to each subagent() call."""
+        import gptme.tools.subagent.batch as batch_mod
+        from gptme.tools.subagent.batch import subagent_parallel
+
+        class MySchema:
+            pass
+
+        captured: list[dict] = []
+
+        def mock_subagent(agent_id, prompt, **kwargs):
+            captured.append(kwargs)
+            self._register_fake_agent(agent_id, "ok")
+
+        monkeypatch.setattr(batch_mod, "subagent", mock_subagent)
+
+        subagent_parallel(
+            [("s1", "p1"), ("s2", "p2")], output_schema=MySchema, timeout=5
+        )
+
+        assert len(captured) == 2
+        for kw in captured:
+            assert kw.get("output_schema") is MySchema
+
+    def test_output_schema_parse_error_does_not_raise(self, monkeypatch):
+        """Invalid JSON in result adds parse_error but doesn't raise."""
+        import gptme.tools.subagent.batch as batch_mod
+        from gptme.tools.subagent.batch import subagent_parallel
+
+        class MySchema:
+            pass
+
+        def mock_subagent(agent_id, prompt, **kwargs):
+            self._register_fake_agent(agent_id, "not json at all")
+
+        monkeypatch.setattr(batch_mod, "subagent", mock_subagent)
+
+        results = subagent_parallel([("bad", "p")], output_schema=MySchema, timeout=5)
+        assert results[0]["status"] == "success"
+        assert "parse_error" in results[0]
+        assert results[0]["result"] == "not json at all"
+
+    def test_workdir_forwarded_to_subagent(self, monkeypatch, tmp_path):
+        """workdir is forwarded to each subagent() call."""
+        import gptme.tools.subagent.batch as batch_mod
+        from gptme.tools.subagent.batch import subagent_parallel
+
+        captured: list[dict] = []
+
+        def mock_subagent(agent_id, prompt, **kwargs):
+            captured.append(kwargs)
+            self._register_fake_agent(agent_id, "ok")
+
+        monkeypatch.setattr(batch_mod, "subagent", mock_subagent)
+
+        subagent_parallel([("w1", "p1")], workdir=tmp_path, timeout=5)
+
+        assert captured[0].get("workdir") == tmp_path
+
+    def test_context_turns_forwarded_to_subagent(self, monkeypatch):
+        """context_turns is forwarded to each subagent() call."""
+        import gptme.tools.subagent.batch as batch_mod
+        from gptme.tools.subagent.batch import subagent_parallel
+
+        captured: list[dict] = []
+
+        def mock_subagent(agent_id, prompt, **kwargs):
+            captured.append(kwargs)
+            self._register_fake_agent(agent_id, "ok")
+
+        monkeypatch.setattr(batch_mod, "subagent", mock_subagent)
+
+        subagent_parallel([("c1", "p1"), ("c2", "p2")], context_turns=5, timeout=5)
+
+        assert len(captured) == 2
+        for kw in captured:
+            assert kw.get("context_turns") == 5
+
+
+class TestSubagentBatchNewParameters:
+    """Tests for new parameters in subagent_batch()."""
+
+    def setup_method(self):
+        with _subagents_lock:
+            _subagents.clear()
+        with _subagent_results_lock:
+            _subagent_results.clear()
+
+    def test_model_forwarded_to_subagent(self, monkeypatch):
+        """model parameter is forwarded to each subagent() call."""
+        import gptme.tools.subagent.batch as batch_mod
+        from gptme.tools.subagent.batch import subagent_batch
+
+        captured: list[dict] = []
+
+        def mock_subagent(agent_id, prompt, **kwargs):
+            captured.append(kwargs)
+
+        monkeypatch.setattr(batch_mod, "subagent", mock_subagent)
+
+        subagent_batch([("t1", "p1"), ("t2", "p2")], model="openai/gpt-4o")
+
+        assert len(captured) == 2
+        for kw in captured:
+            assert kw.get("model") == "openai/gpt-4o"
+
+    def test_profile_forwarded_to_subagent(self, monkeypatch):
+        """profile parameter is forwarded to each subagent() call."""
+        import gptme.tools.subagent.batch as batch_mod
+        from gptme.tools.subagent.batch import subagent_batch
+
+        captured: list[dict] = []
+
+        def mock_subagent(agent_id, prompt, **kwargs):
+            captured.append(kwargs)
+
+        monkeypatch.setattr(batch_mod, "subagent", mock_subagent)
+
+        subagent_batch([("t1", "p1")], profile="explorer")
+
+        assert captured[0].get("profile") == "explorer"
+
+    def test_isolated_forwarded_to_subagent(self, monkeypatch):
+        """isolated parameter is forwarded to each subagent() call."""
+        import gptme.tools.subagent.batch as batch_mod
+        from gptme.tools.subagent.batch import subagent_batch
+
+        captured: list[dict] = []
+
+        def mock_subagent(agent_id, prompt, **kwargs):
+            captured.append(kwargs)
+
+        monkeypatch.setattr(batch_mod, "subagent", mock_subagent)
+
+        subagent_batch([("t1", "p1")], isolated=True)
+
+        assert captured[0].get("isolated") is True
+
+    def test_output_schema_forwarded_to_subagent(self, monkeypatch):
+        """output_schema is forwarded to each subagent() call."""
+        import gptme.tools.subagent.batch as batch_mod
+        from gptme.tools.subagent.batch import subagent_batch
+
+        class Schema:
+            pass
+
+        captured: list[dict] = []
+
+        def mock_subagent(agent_id, prompt, **kwargs):
+            captured.append(kwargs)
+
+        monkeypatch.setattr(batch_mod, "subagent", mock_subagent)
+
+        subagent_batch([("t1", "p1"), ("t2", "p2")], output_schema=Schema)
+
+        assert len(captured) == 2
+        for kw in captured:
+            assert kw.get("output_schema") is Schema


### PR DESCRIPTION
## Summary

`subagent_parallel()` was missing several parameters from the `subagent()` API surface, making it impossible to use structured output or per-subagent workspace context with the parallel fan-out pattern. This PR closes those gaps.

**Changes to `subagent_parallel()`:**
- `output_schema` — forwarded to each `subagent()` call, and results are automatically parsed: on success the `"result"` value becomes the parsed object (validated dict for Pydantic, plain JSON value otherwise) instead of a raw string. A `"parse_error"` key is added on failure, but never raises.
- `workdir` — forwarded to every subagent, useful when running parallel tasks against a specific project directory.
- `context_turns` — forwards parent conversation context to all parallel subagents.

**Changes to `subagent_batch()`:**
- Add `model`, `profile`, `isolated`, `output_schema` — aligns fire-and-forget BatchJob API with the full `subagent()` parameter surface.

**New `_parse_result()` helper:**
- The JSON schema-parsing logic extracted as a standalone importable function, also usable by callers that use `BatchJob` directly.

## Why this matters

The structured output pattern (`output_schema`) was the highest-value remaining gap between `subagent()` and the parallel fan-out helpers, as noted in the issue's Claude Code comparison matrix. With this change, orchestrators can do:

```python
from pydantic import BaseModel

class AnalysisResult(BaseModel):
    summary: str
    score: int
    issues: list[str]

results = subagent_parallel(
    [("a1", "Analyze module A"), ("a2", "Analyze module B")],
    output_schema=AnalysisResult,
)
for r in results:
    if r["status"] == "success":
        analysis = r["result"]  # already a validated dict
        print(f"Score: {analysis['score']}, Issues: {analysis['issues']}")
```

## Test plan

- [x] 17 new unit tests: `TestParseResult`, `TestSubagentParallelOutputSchema`, `TestSubagentBatchNewParameters`
- [x] All 200 subagent unit tests pass
- [x] ruff + mypy clean

Closes #554

<!-- gptme-id:v1:gai_2Hkv4Nujnw7gd89qwFlfX2cpRFuiET6vfJRlVunp5Pn -->

<!-- gptme-id:v1:gai_vQpD0wq9yPmd2xY6UTJNjuWPKGeFsf7Agu971UCnNJF -->