### PR TITLE
feat(subagent): token budget tracking — input/output tokens in ReturnType and BatchJob (#554)

### DIFF
--- a/gptme/tools/subagent/api.py
+++ b/gptme/tools/subagent/api.py
@@ -570,7 +570,21 @@ def subagent(
                 try:
                     status, summary = asyncio.run(_acp_run())
 
-                    result = ReturnType(status, summary)
+                    with _subagents_lock:
+                        sa_ref = next(
+                            (s for s in _subagents if s.agent_id == agent_id), None
+                        )
+                    in_tok, out_tok = (
+                        sa_ref._read_token_stats()
+                        if sa_ref is not None
+                        else (None, None)
+                    )
+                    result = ReturnType(
+                        status,
+                        summary,
+                        input_tokens=in_tok,
+                        output_tokens=out_tok,
+                    )
                     if not set_subagent_result_if_absent(agent_id, result):
                         return
                     notify_completion(

--- a/gptme/tools/subagent/batch.py
+++ b/gptme/tools/subagent/batch.py
@@ -167,6 +167,38 @@ class BatchJob:
         """Check if all subagents have completed."""
         return len(self.results) == len(self.agent_ids)
 
+    def total_tokens(self) -> dict[str, int | None]:
+        """Return aggregated token counts across all completed subagents.
+
+        Sums ``input_tokens`` and ``output_tokens`` from each completed result.
+        Any subagent whose log has no usage metadata contributes ``None`` to its
+        part — the aggregate is ``None`` when *no* completed subagent has token
+        data, otherwise it is the sum of available counts.
+
+        Returns:
+            Dict with keys ``"input_tokens"`` and ``"output_tokens"``.
+            Values are integers (sum of available counts) or ``None`` when no
+            usage metadata was found in any completed subagent's log.
+
+        Example::
+
+            job = subagent_batch([("a", "task A"), ("b", "task B")])
+            results = job.wait_all()
+            stats = job.total_tokens()
+            print(f"Tokens used: {stats['input_tokens']} in / {stats['output_tokens']} out")
+        """
+        with self._lock:
+            completed = list(self.results.values())
+
+        total_in: int | None = None
+        total_out: int | None = None
+        for r in completed:
+            if r.input_tokens is not None:
+                total_in = (total_in or 0) + r.input_tokens
+            if r.output_tokens is not None:
+                total_out = (total_out or 0) + r.output_tokens
+        return {"input_tokens": total_in, "output_tokens": total_out}
+
     def get_completed(self) -> dict[str, dict]:
         """Get results of completed subagents so far.
 

--- a/gptme/tools/subagent/batch.py
+++ b/gptme/tools/subagent/batch.py
@@ -129,7 +129,12 @@ class BatchJob:
                     return agent_id, ReturnType(
                         "timeout", f"Timed out after {timeout}s"
                     )
-                return agent_id, ReturnType(status, result.get("result"))
+                return agent_id, ReturnType(
+                    status,
+                    result.get("result"),
+                    input_tokens=result.get("input_tokens"),
+                    output_tokens=result.get("output_tokens"),
+                )
             except Exception as e:
                 logger.warning(f"Error waiting for {agent_id}: {e}")
                 return agent_id, ReturnType("failure", str(e))

--- a/gptme/tools/subagent/execution.py
+++ b/gptme/tools/subagent/execution.py
@@ -576,6 +576,9 @@ def _monitor_subprocess(
         subagent.process.kill()
         subagent.process.wait()  # reap the killed process
 
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+
     # Determine status based on return code
     if subagent.process.returncode == 0:
         status: Status = "success"
@@ -585,6 +588,8 @@ def _monitor_subprocess(
             if log_status.status == "clarification_needed":
                 status = "clarification_needed"
             result = log_status.result
+            input_tokens = log_status.input_tokens
+            output_tokens = log_status.output_tokens
         except Exception:
             result = "Task completed (check log for details)"
     elif _timed_out:
@@ -596,7 +601,12 @@ def _monitor_subprocess(
         result = f"Process exited with code {subagent.process.returncode}"
 
     # Cache the result in module-level dict (Subagent is frozen)
-    final_result = ReturnType(status, result)
+    final_result = ReturnType(
+        status,
+        result,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+    )
     if not set_subagent_result_if_absent(subagent.agent_id, final_result):
         _cleanup_isolation(subagent)
         return

--- a/gptme/tools/subagent/types.py
+++ b/gptme/tools/subagent/types.py
@@ -138,6 +138,10 @@ def set_subagent_result_if_absent(agent_id: str, result: "ReturnType") -> bool:
 class ReturnType:
     status: Status
     result: str | None = None
+    # Token budget tracking: LLM token counts for the subagent's run.
+    # None means unavailable (e.g. cached terminal result, pre-budget-tracking log).
+    input_tokens: int | None = None
+    output_tokens: int | None = None
 
 
 def clarification_result_from_content(content: str) -> ReturnType | None:
@@ -248,6 +252,55 @@ class Subagent:
 
         return LogManager.load(self.logdir)
 
+    def _read_token_stats(self) -> tuple[int | None, int | None]:
+        """Return (input_tokens, output_tokens) from the subagent's conversation log.
+
+        Reads the JSONL log file directly to sum up usage metadata across all
+        assistant turns — same approach as logmanager/conversations.py _full_scan().
+        Returns (None, None) on any error so missing stats never block the caller.
+        """
+        import json
+
+        try:
+            conv_fn = self.logdir / "conversation.jsonl"
+            if not conv_fn.exists():
+                # Some log layouts use the directory name as the file
+                candidates = list(self.logdir.glob("*.jsonl"))
+                if not candidates:
+                    return None, None
+                conv_fn = candidates[0]
+
+            input_tokens = 0
+            output_tokens = 0
+            with open(conv_fn, "rb") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line or b'"metadata"' not in line:
+                        continue
+                    try:
+                        msg = json.loads(line)
+                        meta = msg.get("metadata")
+                        if not meta:
+                            continue
+                        usage = meta.get("usage", {})
+                        src = usage or meta
+                        cache_read = src.get("cache_read_tokens", 0) or 0
+                        input_tokens += (
+                            (src.get("input_tokens", 0) or 0)
+                            + cache_read
+                            + (src.get("cache_creation_tokens", 0) or 0)
+                        )
+                        output_tokens += src.get("output_tokens", 0) or 0
+                    except (json.JSONDecodeError, TypeError):
+                        continue
+            # Only return non-zero counts (0,0 means no usage metadata was present)
+            if input_tokens == 0 and output_tokens == 0:
+                return None, None
+            return input_tokens, output_tokens
+        except Exception as e:
+            logger.debug("Could not read token stats for %s: %s", self.agent_id, e)
+            return None, None
+
     def is_running(self) -> bool:
         """Check if the subagent is still running."""
         if self.execution_mode == "subprocess" and self.process:
@@ -279,6 +332,9 @@ class Subagent:
             if self.agent_id in _subagent_results:
                 return _subagent_results[self.agent_id]
 
+        # Read token stats once; attach to every terminal ReturnType we return.
+        in_tok, out_tok = self._read_token_stats()
+
         # Check if executor used the complete tool
         try:
             log = self.get_log().log
@@ -286,9 +342,16 @@ class Subagent:
             return ReturnType(
                 "failure",
                 f"Subagent exited before creating a conversation log: {self.logdir}",
+                input_tokens=in_tok,
+                output_tokens=out_tok,
             )
         if not log:
-            return ReturnType("failure", "No messages in log")
+            return ReturnType(
+                "failure",
+                "No messages in log",
+                input_tokens=in_tok,
+                output_tokens=out_tok,
+            )
 
         last_msg = log[-1]
 
@@ -296,7 +359,13 @@ class Subagent:
         # Must be checked before the complete block so a "clarify" isn't misread as failure.
         clarification_result = clarification_result_from_content(last_msg.content)
         if clarification_result:
-            return clarification_result
+            # Attach token stats to clarification result too
+            return ReturnType(
+                clarification_result.status,
+                clarification_result.result,
+                input_tokens=in_tok,
+                output_tokens=out_tok,
+            )
 
         # Check for complete tool call in last message
         # Try parsing as ToolUse first
@@ -314,6 +383,8 @@ class Subagent:
             return ReturnType(
                 "success",
                 result + f"\n\nFull log: {self.logdir}",
+                input_tokens=in_tok,
+                output_tokens=out_tok,
             )
 
         # Fallback: Check for complete code block directly
@@ -332,6 +403,8 @@ class Subagent:
                 return ReturnType(
                     "success",
                     result + f"\n\nFull log: {self.logdir}",
+                    input_tokens=in_tok,
+                    output_tokens=out_tok,
                 )
 
         # Check if session ended with system completion message
@@ -339,10 +412,14 @@ class Subagent:
             return ReturnType(
                 "success",
                 f"Task completed successfully. Full log: {self.logdir}",
+                input_tokens=in_tok,
+                output_tokens=out_tok,
             )
 
         # Task didn't complete properly
         return ReturnType(
             "failure",
             f"Task did not complete properly. Check log: {self.logdir}",
+            input_tokens=in_tok,
+            output_tokens=out_tok,
         )

--- a/gptme/tools/subagent/types.py
+++ b/gptme/tools/subagent/types.py
@@ -272,6 +272,7 @@ class Subagent:
 
             input_tokens = 0
             output_tokens = 0
+            saw_usage = False
             with open(conv_fn, "rb") as f:
                 for line in f:
                     line = line.strip()
@@ -282,8 +283,17 @@ class Subagent:
                         meta = msg.get("metadata")
                         if not meta:
                             continue
-                        usage = meta.get("usage", {})
-                        src = usage or meta
+                        usage = meta.get("usage")
+                        src = usage if isinstance(usage, dict) else meta
+                        token_keys = (
+                            "input_tokens",
+                            "output_tokens",
+                            "cache_read_tokens",
+                            "cache_creation_tokens",
+                        )
+                        if not any(k in src for k in token_keys):
+                            continue
+                        saw_usage = True
                         cache_read = src.get("cache_read_tokens", 0) or 0
                         input_tokens += (
                             (src.get("input_tokens", 0) or 0)
@@ -293,8 +303,7 @@ class Subagent:
                         output_tokens += src.get("output_tokens", 0) or 0
                     except (json.JSONDecodeError, TypeError):
                         continue
-            # Only return non-zero counts (0,0 means no usage metadata was present)
-            if input_tokens == 0 and output_tokens == 0:
+            if not saw_usage:
                 return None, None
             return input_tokens, output_tokens
         except Exception as e:

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -4141,6 +4141,35 @@ class TestTokenBudgetTracking:
         assert in_tok is None
         assert out_tok is None
 
+    def test_read_token_stats_preserves_zero_token_metadata(self, tmp_path):
+        """_read_token_stats() returns zeroes when usage metadata is present but zero."""
+        import json
+
+        logdir = tmp_path / "test-agent-zero-usage"
+        logdir.mkdir()
+        conv_file = logdir / "conversation.jsonl"
+
+        messages = [
+            {
+                "role": "assistant",
+                "content": "Zero usage response.",
+                "metadata": {"usage": {"input_tokens": 0, "output_tokens": 0}},
+            },
+        ]
+        with open(conv_file, "w") as f:
+            f.writelines(json.dumps(msg) + "\n" for msg in messages)
+
+        sa = Subagent(
+            agent_id="test-zero-usage",
+            prompt="test",
+            thread=None,
+            logdir=logdir,
+            model=None,
+        )
+        in_tok, out_tok = sa._read_token_stats()
+        assert in_tok == 0
+        assert out_tok == 0
+
     def test_read_token_stats_returns_none_when_logdir_missing(self, tmp_path):
         """_read_token_stats() returns (None, None) gracefully when logdir doesn't exist."""
         sa = Subagent(
@@ -4192,6 +4221,27 @@ class TestTokenBudgetTracking:
         stats = job.total_tokens()
         assert stats["input_tokens"] == 1000  # Only from 'a'
         assert stats["output_tokens"] == 100
+
+    def test_batch_job_wait_all_preserves_token_counts(self):
+        """BatchJob.wait_all() stores token fields returned by subagent_wait()."""
+        from unittest.mock import patch
+
+        def fake_wait(agent_id, timeout=60, max_result_chars=2000):
+            tokens = {
+                "a": {"input_tokens": 1000, "output_tokens": 100},
+                "b": {"input_tokens": 2000, "output_tokens": 200},
+            }[agent_id]
+            return {"status": "success", "result": f"{agent_id} done", **tokens}
+
+        job = BatchJob(agent_ids=["a", "b"])
+        with patch("gptme.tools.subagent.batch.subagent_wait", side_effect=fake_wait):
+            results = job.wait_all(timeout=5)
+
+        assert results["a"]["input_tokens"] == 1000
+        assert results["a"]["output_tokens"] == 100
+        stats = job.total_tokens()
+        assert stats["input_tokens"] == 3000
+        assert stats["output_tokens"] == 300
 
     def test_batch_job_total_tokens_empty_results(self):
         """BatchJob.total_tokens() returns None when no results are present yet."""

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -702,6 +702,38 @@ class TestSubagentCancel:
         assert status == "clarification_needed"
         assert "Which format" in summary
 
+    def test_subprocess_monitor_preserves_token_counts(self, tmp_path):
+        logdir = tmp_path / "proc-token-log"
+        logdir.mkdir()
+        (logdir / "conversation.jsonl").write_text(
+            json.dumps(
+                {
+                    "role": "assistant",
+                    "content": "```complete\nDone.\n```",
+                    "timestamp": "2025-01-01T00:00:00+00:00",
+                    "metadata": {"usage": {"input_tokens": 123, "output_tokens": 45}},
+                }
+            )
+            + "\n"
+        )
+        mock_proc = MagicMock()
+        mock_proc.wait.return_value = 0
+        mock_proc.returncode = 0
+        sa = self._register(
+            "proc-token",
+            process=mock_proc,
+            execution_mode="subprocess",
+            logdir=logdir,
+        )
+
+        _monitor_subprocess(sa)
+
+        with _subagent_results_lock:
+            result = _subagent_results["proc-token"]
+        assert result.status == "success"
+        assert result.input_tokens == 123
+        assert result.output_tokens == 45
+
     def test_cancel_thread_marks_result(self):
         mock_thread = MagicMock(spec=threading.Thread)
         mock_thread.is_alive.return_value = True
@@ -4182,6 +4214,79 @@ class TestTokenBudgetTracking:
         in_tok, out_tok = sa._read_token_stats()
         assert in_tok is None
         assert out_tok is None
+
+    def test_acp_completion_preserves_token_counts(self, tmp_path, monkeypatch):
+        """ACP mode caches token fields read from the subagent conversation log."""
+        import gptme.acp.client as acp_client
+
+        cli_main = importlib.import_module("gptme.cli.main")
+        logdir = tmp_path / "subagent-acp-token"
+        monkeypatch.setattr(cli_main, "get_logdir", lambda name: logdir)
+
+        with _subagents_lock:
+            _subagents.clear()
+        with _subagent_results_lock:
+            _subagent_results.clear()
+        while not _completion_queue.empty():
+            try:
+                _completion_queue.get_nowait()
+            except queue.Empty:
+                break
+
+        class FakeUpdate:
+            type = "agent_message_chunk"
+            chunk = {"text": "ACP completed."}
+
+        class FakeRunResult:
+            stop_reason = "end_turn"
+
+        class FakeAcpClient:
+            def __init__(self, *args, on_update=None, **kwargs):
+                self.on_update = on_update
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return None
+
+            async def run(self, prompt, cwd=None):
+                logdir.mkdir(parents=True, exist_ok=True)
+                (logdir / "conversation.jsonl").write_text(
+                    json.dumps(
+                        {
+                            "role": "assistant",
+                            "content": "ACP completed.",
+                            "metadata": {
+                                "usage": {
+                                    "input_tokens": 321,
+                                    "output_tokens": 54,
+                                }
+                            },
+                        }
+                    )
+                    + "\n"
+                )
+                if self.on_update:
+                    self.on_update("session-1", FakeUpdate())
+                return FakeRunResult()
+
+        monkeypatch.setattr(acp_client, "GptmeAcpClient", FakeAcpClient)
+
+        subagent_api.subagent("acp-token", "test prompt", use_acp=True)
+
+        with _subagents_lock:
+            sa = next(s for s in _subagents if s.agent_id == "acp-token")
+        assert sa.thread is not None
+        sa.thread.join(timeout=5)
+        assert not sa.thread.is_alive()
+
+        with _subagent_results_lock:
+            result = _subagent_results["acp-token"]
+        assert result.status == "success"
+        assert result.result == "ACP completed."
+        assert result.input_tokens == 321
+        assert result.output_tokens == 54
 
     def test_batch_job_total_tokens_sums_all_results(self):
         """BatchJob.total_tokens() sums input/output tokens from all completed results."""

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -4021,3 +4021,181 @@ class TestSubagentBatchNewParameters:
         assert len(captured) == 2
         for kw in captured:
             assert kw.get("context_turns") == 5
+
+
+# ---------------------------------------------------------------------------
+# Token budget tracking tests
+# ---------------------------------------------------------------------------
+
+
+class TestTokenBudgetTracking:
+    """Tests for token budget tracking in ReturnType, Subagent._read_token_stats(), and BatchJob."""
+
+    def test_return_type_default_token_fields_are_none(self):
+        """ReturnType defaults to None for both token fields."""
+        rt = ReturnType("success", "done")
+        assert rt.input_tokens is None
+        assert rt.output_tokens is None
+
+    def test_return_type_stores_token_counts(self):
+        """ReturnType stores input_tokens and output_tokens when provided."""
+        rt = ReturnType("success", "done", input_tokens=1000, output_tokens=200)
+        assert rt.input_tokens == 1000
+        assert rt.output_tokens == 200
+
+    def test_read_token_stats_with_usage_metadata(self, tmp_path):
+        """_read_token_stats() reads input/output tokens from conversation.jsonl."""
+        import json
+
+        logdir = tmp_path / "test-agent"
+        logdir.mkdir()
+        conv_file = logdir / "conversation.jsonl"
+
+        # Write a log with two assistant messages that have usage metadata
+        messages = [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {
+                "role": "assistant",
+                "content": "Hello!",
+                "metadata": {"usage": {"input_tokens": 100, "output_tokens": 50}},
+            },
+            {
+                "role": "assistant",
+                "content": "Done.",
+                "metadata": {"usage": {"input_tokens": 150, "output_tokens": 80}},
+            },
+        ]
+        with open(conv_file, "w") as f:
+            f.writelines(json.dumps(msg) + "\n" for msg in messages)
+
+        sa = Subagent(
+            agent_id="test-token-read",
+            prompt="test",
+            thread=None,
+            logdir=logdir,
+            model=None,
+        )
+        in_tok, out_tok = sa._read_token_stats()
+        assert in_tok == 250  # 100 + 150
+        assert out_tok == 130  # 50 + 80
+
+    def test_read_token_stats_with_cache_tokens(self, tmp_path):
+        """_read_token_stats() sums cache_read and cache_creation tokens into input."""
+        import json
+
+        logdir = tmp_path / "test-agent-cache"
+        logdir.mkdir()
+        conv_file = logdir / "conversation.jsonl"
+
+        messages = [
+            {
+                "role": "assistant",
+                "content": "Cached response.",
+                "metadata": {
+                    "usage": {
+                        "input_tokens": 100,
+                        "cache_read_tokens": 200,
+                        "cache_creation_tokens": 50,
+                        "output_tokens": 30,
+                    }
+                },
+            },
+        ]
+        with open(conv_file, "w") as f:
+            f.writelines(json.dumps(msg) + "\n" for msg in messages)
+
+        sa = Subagent(
+            agent_id="test-token-cache",
+            prompt="test",
+            thread=None,
+            logdir=logdir,
+            model=None,
+        )
+        in_tok, out_tok = sa._read_token_stats()
+        assert in_tok == 350  # 100 + 200 (cache_read) + 50 (cache_creation)
+        assert out_tok == 30
+
+    def test_read_token_stats_returns_none_when_no_metadata(self, tmp_path):
+        """_read_token_stats() returns (None, None) when no usage metadata is present."""
+        import json
+
+        logdir = tmp_path / "test-agent-no-meta"
+        logdir.mkdir()
+        conv_file = logdir / "conversation.jsonl"
+
+        messages = [
+            {"role": "system", "content": "System prompt."},
+            {"role": "assistant", "content": "Response without metadata."},
+        ]
+        with open(conv_file, "w") as f:
+            f.writelines(json.dumps(msg) + "\n" for msg in messages)
+
+        sa = Subagent(
+            agent_id="test-no-meta",
+            prompt="test",
+            thread=None,
+            logdir=logdir,
+            model=None,
+        )
+        in_tok, out_tok = sa._read_token_stats()
+        assert in_tok is None
+        assert out_tok is None
+
+    def test_read_token_stats_returns_none_when_logdir_missing(self, tmp_path):
+        """_read_token_stats() returns (None, None) gracefully when logdir doesn't exist."""
+        sa = Subagent(
+            agent_id="test-no-log",
+            prompt="test",
+            thread=None,
+            logdir=tmp_path / "nonexistent-agent",
+            model=None,
+        )
+        in_tok, out_tok = sa._read_token_stats()
+        assert in_tok is None
+        assert out_tok is None
+
+    def test_batch_job_total_tokens_sums_all_results(self):
+        """BatchJob.total_tokens() sums input/output tokens from all completed results."""
+        job = BatchJob(agent_ids=["a", "b", "c"])
+        job.results["a"] = ReturnType(
+            "success", "done", input_tokens=1000, output_tokens=100
+        )
+        job.results["b"] = ReturnType(
+            "success", "done", input_tokens=2000, output_tokens=200
+        )
+        job.results["c"] = ReturnType(
+            "failure", "error", input_tokens=500, output_tokens=50
+        )
+
+        stats = job.total_tokens()
+        assert stats["input_tokens"] == 3500
+        assert stats["output_tokens"] == 350
+
+    def test_batch_job_total_tokens_returns_none_when_no_data(self):
+        """BatchJob.total_tokens() returns None values when no subagent has token data."""
+        job = BatchJob(agent_ids=["a", "b"])
+        job.results["a"] = ReturnType("success", "done")
+        job.results["b"] = ReturnType("failure", "error")
+
+        stats = job.total_tokens()
+        assert stats["input_tokens"] is None
+        assert stats["output_tokens"] is None
+
+    def test_batch_job_total_tokens_partial_data(self):
+        """BatchJob.total_tokens() sums only available data when some subagents lack token info."""
+        job = BatchJob(agent_ids=["a", "b"])
+        job.results["a"] = ReturnType(
+            "success", "done", input_tokens=1000, output_tokens=100
+        )
+        job.results["b"] = ReturnType("failure", "error")  # No token data
+
+        stats = job.total_tokens()
+        assert stats["input_tokens"] == 1000  # Only from 'a'
+        assert stats["output_tokens"] == 100
+
+    def test_batch_job_total_tokens_empty_results(self):
+        """BatchJob.total_tokens() returns None when no results are present yet."""
+        job = BatchJob(agent_ids=["a", "b"])
+        stats = job.total_tokens()
+        assert stats["input_tokens"] is None
+        assert stats["output_tokens"] is None


### PR DESCRIPTION
## Summary

Closes one of the remaining gaps from the Claude Code comparison table in #554: token budget tracking.

Parent agents can now see how many LLM tokens each subagent consumed, enabling cost-aware orchestration patterns.

### Changes

**`gptme/tools/subagent/types.py`**
- `ReturnType`: add `input_tokens: int | None` and `output_tokens: int | None` fields (default `None` for backward compatibility)
- `Subagent._read_token_stats()`: reads usage metadata from `conversation.jsonl`, summing `input_tokens + cache_read_tokens + cache_creation_tokens` across all assistant turns (same approach as `logmanager/conversations.py _full_scan()`)
- `Subagent._read_log()`: attaches token stats to every terminal `ReturnType` — so `subagent_wait()` naturally includes them

**`gptme/tools/subagent/batch.py`**
- `BatchJob.total_tokens()`: sums `input_tokens` and `output_tokens` across all completed subagents; returns `None` when no subagent has usage metadata

### Usage

`subagent_wait()` now returns token counts:
```python
result = subagent_wait("my-agent")
# {"status": "success", "result": "...", "input_tokens": 1234, "output_tokens": 56}
```

`BatchJob` aggregation:
```python
job = subagent_batch([("a", "task A"), ("b", "task B")])
results = job.wait_all()
stats = job.total_tokens()
print(f"Total: {stats['input_tokens']} in / {stats['output_tokens']} out")
```

### Backward compatibility

- `input_tokens` / `output_tokens` default to `None` — existing call sites are unaffected
- Logs from before this PR have no usage metadata, so `_read_token_stats()` returns `(None, None)` gracefully
- `BatchJob.total_tokens()` returns `None` values when no subagent has token data

## Test plan

- [x] `pytest tests/test_subagent_unit.py::TestTokenBudgetTracking` — 10/10 new tests pass
- [x] `pytest tests/test_tools_subagent.py tests/test_subagent_unit.py tests/test_subagent_concurrency.py tests/test_subagent_integration.py tests/test_eval_subagent.py tests/test_subagent_planner_roles.py` — 317/317 pass (no regressions)

<!-- gptme-id:v1:gai_CwVUHnYCQxNV2nG6DDf2sP7xh5Y9lrHMQt3EQnyFnHU -->