### PR TITLE
fix(browser): drop unreachable select_option label fallback that doubles timeout

### DIFF
--- a/gptme/tools/_browser_playwright.py
+++ b/gptme/tools/_browser_playwright.py
@@ -828,11 +828,12 @@ def _select_option(browser: Browser, selector: str, value: str) -> str:
     """Select an option from a <select> element on the current page."""
     if _current_page is None:
         raise RuntimeError("No page is open. Call open_page(url) first.")
-    locator = _current_page.locator(selector)
-    try:
-        locator.select_option(value=value, timeout=10000)
-    except PlaywrightTimeoutError:
-        locator.select_option(label=value, timeout=10000)
+    # Playwright's value= matcher already matches by the option's value
+    # attribute *or* its label text, so a single call handles both. A label=
+    # fallback is unreachable: whatever label= would match, value= already
+    # matches, so if value= times out label= times out too — its only effect
+    # is doubling the wait (10s -> 20s) before the error surfaces.
+    _current_page.locator(selector).select_option(value=value, timeout=10000)
     return _page_snapshot()
 
 

--- a/tests/test_tools_browser.py
+++ b/tests/test_tools_browser.py
@@ -1041,3 +1041,45 @@ class TestCreatePage:
         browser.new_context.assert_called_once_with(locale="en-US")
         assert managed.page is page
         assert managed._owned_context is context
+
+
+@pytest.mark.skipif(not has_playwright(), reason="playwright not installed")
+class TestSelectOption:
+    """select_option should not double the timeout via an unreachable fallback."""
+
+    def test_single_attempt_when_value_matches_nothing(self, monkeypatch):
+        # Playwright's value= already matches by value attribute or label text,
+        # so once value= times out, a label= retry can never match — it only
+        # doubles the wait. _select_option must make exactly one attempt.
+        from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
+
+        from gptme.tools import _browser_playwright as bp
+
+        locator = MagicMock()
+        locator.select_option.side_effect = PlaywrightTimeoutError("timeout")
+        page = MagicMock()
+        page.locator.return_value = locator
+
+        monkeypatch.setattr(bp, "_current_page", page)
+        with pytest.raises(PlaywrightTimeoutError):
+            bp._select_option(MagicMock(), "[name='size']", "no-such-option")
+
+        assert locator.select_option.call_count == 1
+        locator.select_option.assert_called_once_with(
+            value="no-such-option", timeout=10000
+        )
+
+    def test_returns_snapshot_on_success(self, monkeypatch):
+        from gptme.tools import _browser_playwright as bp
+
+        locator = MagicMock()
+        page = MagicMock()
+        page.locator.return_value = locator
+
+        monkeypatch.setattr(bp, "_current_page", page)
+        monkeypatch.setattr(bp, "_page_snapshot", lambda: "SNAPSHOT")
+
+        result = bp._select_option(MagicMock(), "[name='size']", "large")
+
+        assert result == "SNAPSHOT"
+        locator.select_option.assert_called_once_with(value="large", timeout=10000)


### PR DESCRIPTION
## Root cause

`_select_option` tried by value, then fell back to label on timeout:

```python
locator.select_option(value=value, timeout=10000)
# on PlaywrightTimeoutError:
locator.select_option(label=value, timeout=10000)
```

Playwright's `value=` matcher already matches an option by its `value` attribute or its visible label text, so the set of options `label=value` can match is a subset of what `value=value` matches. If the first call times out, the second one always times out too. The fallback rescues nothing and only doubles the wait before the error surfaces (10s + 10s = 20s).

Verified on Playwright 1.60.0 (repo pins 1.61.0): `select_option(value="Large")` selects the option whose value attribute is `aaa` and label is `Large`, and a value matching neither takes ~20s to raise.

## Fix

Collapse to a single call:

```python
_current_page.locator(selector).select_option(value=value, timeout=10000)
```

Behavior is identical for every value that currently succeeds, and a genuine miss now surfaces in 10s instead of 20s.

## Verification

- Added `TestSelectOption` with a regression test asserting exactly one `select_option` attempt on a miss. It fails on the old code (2 calls) and passes with the fix. Second test covers the success path.
- `pytest tests/test_tools_browser.py` — 106 passed.
- `ruff check` / `ruff format --check` clean.

Fixes #3100
