### PR TITLE
fix(subagent): isolate thread tool list via clear_tools() at entry (#554)

### DIFF
--- a/gptme/tools/__init__.py
+++ b/gptme/tools/__init__.py
@@ -445,11 +445,18 @@ def get_available_tools(include_mcp: bool = True) -> list[ToolSpec]:
 
 
 def clear_tools():
-    """Clear all context-local tool state."""
+    """Clear all context-local tool state.
+
+    Resets the ContextVar-bound tool list so the current context has a
+    fresh empty list, fully decoupled from any other context (parent
+    thread, sibling thread, etc.).
+
+    Does NOT clear module-global state like _warned_mcp_allowlists, which
+    is shared across all contexts for log-deduplication. Only the
+    context-local tool list and its cache are reset.
+    """
     _set_available_tools_cache(None)
     _loaded_tools_var.set([])
-    with _warned_mcp_allowlists_lock:
-        _warned_mcp_allowlists.clear()
 
 
 def get_tools() -> list[ToolSpec]:

--- a/gptme/tools/subagent/execution.py
+++ b/gptme/tools/subagent/execution.py
@@ -19,7 +19,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
 from ...message import Message
-from .. import get_tools, load_tool, set_tools
+from .. import clear_tools, get_tools, load_tool, set_tools
 from .._allowlist import (
     is_hint_pattern,
     matching_allowlist_tools,
@@ -176,6 +176,16 @@ def _create_subagent_thread(
     # Store agent_id in thread-local so the progress tool can identify this subagent
     if agent_id is not None:
         _thread_local.agent_id = agent_id
+
+    # Detach from the parent thread's tool list. Python's threading.Thread copies
+    # the parent's context into the child, so _loaded_tools_var initially points to
+    # the *same list object* as the parent. Any append inside init_tools() or
+    # _ensure_subagent_signal_tools_loaded() would mutate the parent's list, creating
+    # a data race with the parent's concurrent execute_msg() calls. Calling
+    # clear_tools() here replaces the ContextVar binding with a fresh empty list so
+    # all subsequent tool operations operate on an independent list. This is the fix
+    # for the thread-mode "transient non-runnable" race (#554).
+    clear_tools()
 
     # noreorder
     from gptme.chat import chat  # fmt: skip

--- a/tests/test_tools_subagent.py
+++ b/tests/test_tools_subagent.py
@@ -2739,3 +2739,79 @@ def test_subagent_list_prompt_truncation():
     finally:
         with _subagents_lock:
             _subagents[:] = [s for s in _subagents if s.agent_id != "test-truncate"]
+
+
+def test_subagent_thread_does_not_mutate_parent_tool_list():
+    """Thread-mode subagent must NOT mutate the parent's loaded tool list.
+
+    Python's threading.Thread copies the parent's ContextVar context into the
+    child thread, so _loaded_tools_var initially points to the *same list object*
+    as the parent. Before the fix, init_tools() and
+    _ensure_subagent_signal_tools_loaded() would append signal tools to that
+    shared list, creating a data race with the parent's concurrent execute_msg()
+    calls (#554 — "transient non-runnable" crash).
+
+    After the fix, clear_tools() at thread entry replaces the ContextVar binding
+    with a fresh empty list so the subagent's tool operations never touch the
+    parent's list.
+    """
+    import threading
+    from contextvars import copy_context
+
+    from gptme.tools import clear_tools, get_tools, init_tools
+
+    # Set up a baseline tool list in the parent's context.
+    init_tools(["read"])
+    parent_list = get_tools()
+    parent_list_id = id(parent_list)
+    parent_len = len(parent_list)
+
+    # Simulate what happened BEFORE the fix: a child thread that inherits the
+    # parent's context and calls load_tool() without first calling clear_tools().
+    # This would mutate the parent's list (append to it).
+    without_fix_appended: list[bool] = []
+
+    def child_without_fix():
+        # Inherit parent list (same object), then append a new tool.
+        # In the real bug, this was init_tools()/load_tool("complete") etc.
+        inherited = get_tools()  # Returns parent's list
+        without_fix_appended.append(id(inherited) == parent_list_id)
+        # Simulate what load_tool does: appends to the ContextVar list
+        get_tools().append(object())  # type: ignore[arg-type]
+
+    ctx = copy_context()
+    t_bad = threading.Thread(target=lambda: ctx.run(child_without_fix))
+    t_bad.start()
+    t_bad.join(timeout=2.0)
+    assert not t_bad.is_alive()
+    # Confirm the "without fix" thread DID see the parent's list
+    assert without_fix_appended == [True], "setup: child must inherit parent list"
+    # And that it mutated it (this is the pre-fix behavior we're guarding against)
+    assert len(parent_list) == parent_len + 1, "setup: pre-fix mutation confirmed"
+    parent_list.pop()  # undo the mutation for the real test
+
+    # Simulate what happens AFTER the fix: child calls clear_tools() first.
+    child_saw_fresh_list: list[bool] = []
+    child_appended_to_parent: list[bool] = []
+
+    def child_with_fix():
+        clear_tools()  # The fix: detach from parent's list
+        child_saw_fresh_list.append(id(get_tools()) != parent_list_id)
+        # Any subsequent tool operations use the child's own fresh list
+        get_tools().append(object())  # type: ignore[arg-type]
+        child_appended_to_parent.append(id(get_tools()) == parent_list_id)
+
+    ctx2 = copy_context()
+    t_good = threading.Thread(target=lambda: ctx2.run(child_with_fix))
+    t_good.start()
+    t_good.join(timeout=2.0)
+    assert not t_good.is_alive()
+
+    # After the fix: child got a fresh list, parent's list is unchanged.
+    assert child_saw_fresh_list == [True], (
+        "child must get a fresh list after clear_tools()"
+    )
+    assert len(get_tools()) == parent_len, (
+        f"Parent tool list changed from {parent_len} to {len(get_tools())} — "
+        "subagent thread mutated parent's tool list (race condition #554)"
+    )

--- a/tests/test_tools_subagent.py
+++ b/tests/test_tools_subagent.py
@@ -2811,6 +2811,9 @@ def test_subagent_thread_does_not_mutate_parent_tool_list():
     assert child_saw_fresh_list == [True], (
         "child must get a fresh list after clear_tools()"
     )
+    assert child_appended_to_parent == [False], (
+        "child's append went to parent's list, not child's own list"
+    )
     assert len(get_tools()) == parent_len, (
         f"Parent tool list changed from {parent_len} to {len(get_tools())} — "
         "subagent thread mutated parent's tool list (race condition #554)"


### PR DESCRIPTION
## Root cause

Python's `threading.Thread` copies the parent's `ContextVar` context into the child, so `_loaded_tools_var` initially refers to the *same list object* as the parent. Before this fix, `init_tools()` and `_ensure_subagent_signal_tools_loaded()` would append signal tools to that shared list from the subagent thread, creating a data race with the parent's concurrent `execute_msg()` calls.

The race: while the parent's `execute_msg()` was checking `is_runnable` on a tool use, the subagent thread was appending new tools to the same list. The intermittent result was that existing tools (e.g. `read`) transiently appeared non-runnable — `get_tool("read")` returned `None` during the brief mutation window. This caused the parent's next API request to get a hard 400 (`tool_use` without a paired `tool_result`).

PR #3072 made the crash non-fatal (defensive `tool_result` on non-runnable tool use). This commit fixes the root cause.

## Fix

Call `clear_tools()` at the very start of `_create_subagent_thread`, before any tool initialization. This calls `_loaded_tools_var.set([])` in the **child thread's** context, replacing the ContextVar binding with a fresh empty list fully decoupled from the parent's. All subsequent operations (`prepare_execution_environment` → `init_tools`, `_ensure_subagent_signal_tools_loaded`, `set_tools`) work on the child's own list and never touch the parent's.

## Test

The regression test proves both sides:
1. **Pre-fix behavior was real** — a child thread that inherits the parent's context and appends to `get_tools()` does mutate the parent's list.
2. **Fix prevents it** — after `clear_tools()`, the child's list is independent and the parent's list is unchanged.

## Closes

Fixes the "transient non-runnable" root cause from #554. Combined with #3072 (defensive pairing) and #3098 (regression test for the pairing), this should close the thread-mode race track of the issue.

<!-- gptme-id:v1:gai_ZxG7IPCmPj5e93jiTe6e00jfvrQQBpk1RztxaroDEds -->