### PR TITLE
fix(subagent): delete worktree branch on cleanup (#554)

### DIFF
--- a/gptme/util/git_worktree.py
+++ b/gptme/util/git_worktree.py
@@ -146,7 +146,7 @@ def cleanup_worktree(
                 logger.debug(
                     f"Could not delete branch {branch_name!r}: {result.stderr.strip()}"
                 )
-        except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+        except (subprocess.TimeoutExpired, OSError) as e:
             logger.debug(f"Branch deletion skipped for {branch_name!r}: {e}")
 
         # Prune stale worktree entries

--- a/gptme/util/git_worktree.py
+++ b/gptme/util/git_worktree.py
@@ -87,9 +87,11 @@ def cleanup_worktree(
     worktree_path: Path,
     repo_path: Path | None = None,
 ) -> None:
-    """Clean up a git worktree.
+    """Clean up a git worktree and its associated branch.
 
     Attempts git worktree remove first, falls back to directory removal.
+    Always attempts to delete the branch named after the worktree directory,
+    since ``git worktree remove`` only removes the working tree, not the branch.
 
     Args:
         worktree_path: Path to the worktree to remove.
@@ -98,6 +100,9 @@ def cleanup_worktree(
     if not worktree_path.exists():
         logger.debug(f"Worktree already removed: {worktree_path}")
         return
+
+    # Branch name matches the last path component (as created by create_worktree)
+    branch_name = worktree_path.name
 
     # Try to find repo_path if not given
     if repo_path is None:
@@ -115,19 +120,36 @@ def cleanup_worktree(
                 timeout=30,
             )
             logger.info(f"Removed git worktree: {worktree_path}")
-            return
         except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
             logger.warning(f"git worktree remove failed: {e}")
+            # Fallback: remove directory manually
+            try:
+                shutil.rmtree(worktree_path)
+                logger.info(f"Removed worktree directory (fallback): {worktree_path}")
+            except OSError as e2:
+                logger.warning(f"Failed to remove worktree directory: {e2}")
 
-    # Fallback: remove directory manually
-    try:
-        shutil.rmtree(worktree_path)
-        logger.info(f"Removed worktree directory (fallback): {worktree_path}")
-    except OSError as e:
-        logger.warning(f"Failed to remove worktree directory: {e}")
+        # Delete the branch that was created for this worktree.
+        # git worktree remove only removes the working tree, not the branch.
+        try:
+            result = subprocess.run(
+                ["git", "branch", "-D", branch_name],
+                cwd=repo_path,
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=10,
+            )
+            if result.returncode == 0:
+                logger.info(f"Deleted worktree branch: {branch_name}")
+            else:
+                logger.debug(
+                    f"Could not delete branch {branch_name!r}: {result.stderr.strip()}"
+                )
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+            logger.debug(f"Branch deletion skipped for {branch_name!r}: {e}")
 
-    # Also try to prune stale worktree entries
-    if repo_path:
+        # Prune stale worktree entries
         try:
             subprocess.run(
                 ["git", "worktree", "prune"],
@@ -139,3 +161,10 @@ def cleanup_worktree(
             )
         except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
             pass
+    else:
+        # No repo_path — just remove the directory
+        try:
+            shutil.rmtree(worktree_path)
+            logger.info(f"Removed worktree directory (no repo): {worktree_path}")
+        except OSError as e:
+            logger.warning(f"Failed to remove worktree directory: {e}")

--- a/tests/test_git_worktree.py
+++ b/tests/test_git_worktree.py
@@ -107,12 +107,22 @@ def test_create_worktree_auto_branch(git_repo: Path, tmp_path: Path):
 
 
 def test_cleanup_worktree(git_repo: Path, tmp_path: Path):
-    """Test cleaning up a git worktree."""
+    """Test cleaning up a git worktree removes the directory and the branch."""
     worktree_base = tmp_path / "worktrees"
     wt = create_worktree(
         git_repo, branch_name="cleanup-test", worktree_base=worktree_base
     )
     assert wt.exists()
+
+    # Verify branch exists before cleanup
+    result = subprocess.run(
+        ["git", "branch", "--list", "cleanup-test"],
+        check=False,
+        cwd=git_repo,
+        capture_output=True,
+        text=True,
+    )
+    assert "cleanup-test" in result.stdout, "Branch should exist before cleanup"
 
     cleanup_worktree(wt, git_repo)
     assert not wt.exists()
@@ -126,6 +136,20 @@ def test_cleanup_worktree(git_repo: Path, tmp_path: Path):
         text=True,
     )
     assert "cleanup-test" not in result.stdout
+
+    # Verify the branch was deleted (the key fix — git worktree remove alone
+    # removes the working tree but leaves the branch behind, causing branch pollution)
+    result = subprocess.run(
+        ["git", "branch", "--list", "cleanup-test"],
+        check=False,
+        cwd=git_repo,
+        capture_output=True,
+        text=True,
+    )
+    assert "cleanup-test" not in result.stdout, (
+        "Branch should be deleted after cleanup_worktree() — "
+        "git worktree remove only removes the directory, not the branch"
+    )
 
 
 def test_cleanup_nonexistent_worktree(tmp_path: Path):


### PR DESCRIPTION
## Problem

`cleanup_worktree()` called `git worktree remove` to clean up isolated subagent workspaces, but `git worktree remove` only removes the **working tree directory** — it leaves the associated branch behind. Every `isolated=True` subagent run was permanently polluting the repo with dangling branches like `subagent-checker-2ce95b0b`, `subagent-thread-agent-15a1d462`, etc. (confirmed visible in the repo right now).

## Fix

After a successful worktree remove, also run `git branch -D <branch-name>`. The branch name is inferred from `worktree_path.name`, which matches the naming convention in `create_worktree()` (`worktree_path = worktree_base / branch_name`).

Branch deletion is best-effort: failure is logged at DEBUG level and does not block cleanup. This handles edge cases like manually-deleted branches or branches checked out elsewhere.

Also restructured the fallback path (directory-only removal when `git worktree remove` fails) so directory removal and branch deletion are independent, and `git worktree prune` always runs.

## Test

Extended `test_cleanup_worktree` to assert that the branch is gone after `cleanup_worktree()` — the previous test only checked the directory and worktree list, not branch deletion.

Closes #554 (partial — fixes branch pollution from worktree isolation)

<!-- gptme-id:v1:gai_IyUeXvyMwOFkMPP417yPTsYo3l1NSXJ4LZD9uAJuoOd -->