### PR TITLE
feat(browser): add load_browser_state() for in-session auth state restoration

### DIFF
--- a/gptme/eval/suites/computer.py
+++ b/gptme/eval/suites/computer.py
@@ -183,6 +183,16 @@ def check_used_get_current_url(messages: list[Message]) -> bool:
     return any("get_current_url(" in code for code in _executed_tool_calls(messages))
 
 
+def check_used_save_browser_state(messages: list[Message]) -> bool:
+    """Agent must use save_browser_state() to persist the browser session."""
+    return any("save_browser_state(" in code for code in _executed_tool_calls(messages))
+
+
+def check_used_load_browser_state(messages: list[Message]) -> bool:
+    """Agent must use load_browser_state() to restore a browser session."""
+    return any("load_browser_state(" in code for code in _executed_tool_calls(messages))
+
+
 def check_did_not_screenshot_for_web(messages: list[Message]) -> bool:
     """Structured-first policy: screenshots should NOT be the first observation for web."""
     calls = _executed_tool_calls(messages)
@@ -308,6 +318,22 @@ def _expect_current_url_captured(ctx) -> bool:
     content = ctx.files.get("url.txt", ctx.stdout)
     if isinstance(content, bytes):
         content = content.decode(errors="replace")
+    return len(content.strip()) > 5
+
+
+def _expect_state_file_written(ctx) -> bool:
+    """State file must have been saved by save_browser_state()."""
+    return "state.json" in ctx.files or (
+        "state.json" in ctx.stdout or "state.json" in ctx.stderr
+    )
+
+
+def _expect_url_after_reload_recorded(ctx) -> bool:
+    """Agent must confirm the page URL after loading state."""
+    content = ctx.files.get("result.txt", ctx.stdout)
+    if isinstance(content, bytes):
+        content = content.decode(errors="replace")
+    # The agent should record the fixture URL or at least a non-empty URL
     return len(content.strip()) > 5
 
 
@@ -583,6 +609,39 @@ tests: list["EvalSpec"] = [
         },
         "check_log": {
             "used get_current_url()": check_used_get_current_url,
+            "used open_page for navigation": check_used_open_page,
+        },
+    },
+    # --- save_browser_state / load_browser_state round-trip test ---
+    # Validates the session-persistence workflow: save state after visiting a
+    # page, then restore it with load_browser_state() and open a second page to
+    # confirm the state was applied.  Uses data: URL fixtures so no network is
+    # needed and no real credentials are involved.
+    #
+    # This directly addresses the "Can it Tweet?" milestone from #216: the
+    # authentication workflow is: log in → save_browser_state → (later)
+    # load_browser_state → open the target page already authenticated.
+    {
+        "name": "computer-use-web-session-persistence",
+        "files": {},
+        "run": "cat result.txt",
+        "prompt": (
+            "You are in computer-use mode. Test browser session persistence:\n"
+            f"1. Call open_page('{_CURRENT_URL_FIXTURE_URL}') to open a fixture page.\n"
+            "2. Call save_browser_state('state.json') to save the current session.\n"
+            "3. Call load_browser_state('state.json') to reload the saved state.\n"
+            f"4. Call open_page('{_CURRENT_URL_FIXTURE_URL}') again with the restored state.\n"
+            "5. Call get_current_url() to confirm the page loaded.\n"
+            "6. Write the URL to result.txt."
+        ),
+        "tools": ["browser", "computer", "vision", "ipython", "save"],
+        "expect": {
+            "result.txt written": _expect_url_after_reload_recorded,
+            "clean exit": _expect_clean_exit,
+        },
+        "check_log": {
+            "used save_browser_state": check_used_save_browser_state,
+            "used load_browser_state": check_used_load_browser_state,
             "used open_page for navigation": check_used_open_page,
         },
     },

--- a/gptme/eval/suites/computer.py
+++ b/gptme/eval/suites/computer.py
@@ -636,6 +636,7 @@ tests: list["EvalSpec"] = [
         ),
         "tools": ["browser", "computer", "vision", "ipython", "save"],
         "expect": {
+            "state.json written": _expect_state_file_written,
             "result.txt written": _expect_url_after_reload_recorded,
             "clean exit": _expect_clean_exit,
         },

--- a/gptme/tools/_browser_playwright.py
+++ b/gptme/tools/_browser_playwright.py
@@ -27,6 +27,7 @@ from ._browser_thread import (
     BrowserThread,
     _is_connection_error,
     get_context_options,
+    set_storage_state_override,
 )
 from ._computer_gate import sensitive_action_gate
 
@@ -688,8 +689,6 @@ def save_browser_state(path: str) -> str:
 
 def _do_load_browser_state(browser: Browser, path: str) -> str:
     """Load a previously saved browser session state for use in the next open_page()."""
-    from ._browser_thread import set_storage_state_override
-
     resolved = Path(path).expanduser()
     if not resolved.exists():
         raise FileNotFoundError(
@@ -703,6 +702,22 @@ def _do_load_browser_state(browser: Browser, path: str) -> str:
 
     # Register the override so get_context_options() uses it on the next context.
     set_storage_state_override(resolved)
+
+    if _is_cdp_connection() and _browser is not None:
+        if _browser._session_context is not None:
+            try:
+                _browser._session_context.close()
+            except Exception:
+                pass
+            _browser._session_context = None
+
+        # CDP mode reuses a session context for future tabs; refresh it now so
+        # the next open_page() does not keep using the pre-load cookies.
+        _browser._session_context = browser.new_context(**get_context_options())
+        return (
+            f"Browser state loaded from {resolved}; CDP session context refreshed. "
+            "Call open_page(url) to start a session with the restored cookies and localStorage."
+        )
 
     return (
         f"Browser state loaded from {resolved}. "

--- a/gptme/tools/_browser_playwright.py
+++ b/gptme/tools/_browser_playwright.py
@@ -673,6 +673,7 @@ def save_browser_state(path: str) -> str:
 
         # 3. Future sessions load it automatically:
         #    export GPTME_BROWSER_STORAGE_STATE=~/.config/gptme/twitter-session.json
+        # OR call load_browser_state() programmatically without a restart.
 
     Args:
         path: File path to write the session JSON. Parent directories are
@@ -683,6 +684,70 @@ def save_browser_state(path: str) -> str:
     """
     logger.info("Saving browser session state to %s", path)
     return _execute_with_retry(_do_save_browser_state, path)
+
+
+def _do_load_browser_state(browser: Browser, path: str) -> str:
+    """Load a previously saved browser session state for use in the next open_page()."""
+    from ._browser_thread import set_storage_state_override
+
+    resolved = Path(path).expanduser()
+    if not resolved.exists():
+        raise FileNotFoundError(
+            f"Browser state file not found: {resolved}\n"
+            "Save a session first with save_browser_state(path), then reload."
+        )
+
+    # Close the current page + context so the next open_page() creates a fresh
+    # context that will pick up the loaded storage state.
+    _close_current_page()
+
+    # Register the override so get_context_options() uses it on the next context.
+    set_storage_state_override(resolved)
+
+    return (
+        f"Browser state loaded from {resolved}. "
+        "Call open_page(url) to start a session with the restored cookies and localStorage."
+    )
+
+
+def load_browser_state(path: str) -> str:
+    """Load a previously saved browser session (cookies, localStorage) from a file.
+
+    This is the in-session complement to ``save_browser_state()``.  Instead of
+    restarting gptme with ``GPTME_BROWSER_STORAGE_STATE``, call this function
+    directly to restore authentication state without a process restart.
+
+    After calling ``load_browser_state()``, call ``open_page(url)`` to start a
+    new browser session with the restored cookies and localStorage.
+
+    Typical workflow::
+
+        # Session A — log in and save state:
+        open_page("https://x.com/login")
+        fill_element("#username", "you@example.com")
+        fill_element("#password", "hunter2")
+        click_element("text=Log in")
+        save_browser_state("~/.config/gptme/twitter-session.json")
+
+        # Session B (same process, or a new one) — restore state and tweet:
+        load_browser_state("~/.config/gptme/twitter-session.json")
+        open_page("https://x.com")           # opens already logged in
+        click_element("text=What is happening?!")
+        fill_element('[data-testid="tweetTextarea_0"]', "hello from gptme!")
+        click_element('[data-testid="tweetButtonInline"]')
+
+    Args:
+        path: Path to the session JSON previously written by ``save_browser_state()``.
+              ``~`` is expanded to the home directory.
+
+    Returns:
+        Confirmation string. The next ``open_page()`` will use the restored state.
+
+    Raises:
+        FileNotFoundError: If *path* does not exist.
+    """
+    logger.info("Loading browser session state from %s", path)
+    return _execute_with_retry(_do_load_browser_state, path)
 
 
 def open_page(url: str) -> str:

--- a/gptme/tools/_browser_thread.py
+++ b/gptme/tools/_browser_thread.py
@@ -32,26 +32,57 @@ DEFAULT_CONTEXT_OPTIONS: dict[str, Any] = {
     "permissions": ["geolocation"],
 }
 
+# In-session override set by load_browser_state().  Takes priority over the
+# GPTME_BROWSER_STORAGE_STATE env var so the agent can reload state without
+# restarting the process.
+_override_storage_state: Path | None = None
+
+
+def set_storage_state_override(path: Path | None) -> None:
+    """Set (or clear) the in-session storage-state override.
+
+    Called by ``load_browser_state()`` so the next ``open_page()`` picks up the
+    new authentication state without needing a process restart.
+    """
+    global _override_storage_state
+    _override_storage_state = path
+
 
 def get_context_options() -> dict[str, Any]:
     """Return browser context options, optionally loading a saved session state.
 
-    If ``GPTME_BROWSER_STORAGE_STATE`` points to an existing JSON file (previously
-    created by ``save_browser_state()``), the saved cookies and localStorage are
-    loaded into every new context — enabling authenticated sessions without
-    re-entering credentials on each invocation.
+    Priority order for storage state:
+    1. In-session override set by ``load_browser_state()`` (highest priority).
+    2. ``GPTME_BROWSER_STORAGE_STATE`` environment variable.
+    3. No storage state — fresh (unauthenticated) context (default).
 
-    Typical workflow::
+    Typical workflow for one-time login + persistent sessions::
 
-        # 1. Open a browser manually and log in to the target site, then save state:
-        open_page("https://x.com")
+        # 1. Open the page and log in:
+        open_page("https://x.com/login")
+        fill_element("#username", "you@example.com")
+        fill_element("#password", "hunter2")
+        click_element("text=Log in")
         save_browser_state("~/.config/gptme/twitter-session.json")
 
-        # 2. Next time, load the state automatically:
+        # 2a. Next time via env var (persists across restarts):
         export GPTME_BROWSER_STORAGE_STATE=~/.config/gptme/twitter-session.json
         gptme --agent-profile computer-use "tweet 'hello from gptme'"
+
+        # 2b. Or load programmatically in the same session:
+        load_browser_state("~/.config/gptme/twitter-session.json")
+        open_page("https://x.com")  # opens with saved cookies
     """
     options = dict(DEFAULT_CONTEXT_OPTIONS)
+
+    # In-session override takes precedence over the env var.
+    if _override_storage_state is not None:
+        options["storage_state"] = str(_override_storage_state)
+        logger.info(
+            "Using in-session storage state override: %s", _override_storage_state
+        )
+        return options
+
     storage_path_raw = get_config().get_env("BROWSER_STORAGE_STATE")
     if storage_path_raw:
         storage_path = Path(storage_path_raw).expanduser()
@@ -185,9 +216,7 @@ class BrowserThread:
                 # gptme instances don't share cookies/tabs. Recreated on every
                 # (re)connect so it never points at a dead browser.
                 if self.cdp_url:
-                    self._session_context = browser.new_context(
-                        **get_context_options()
-                    )
+                    self._session_context = browser.new_context(**get_context_options())
                     logger.info("Created isolated session context for CDP connection")
                 return None
             except Exception as e:

--- a/gptme/tools/browser.py
+++ b/gptme/tools/browser.py
@@ -1002,6 +1002,52 @@ def save_browser_state(path: str) -> str:
     )
 
 
+def load_browser_state(path: str) -> str:
+    """Load a previously saved browser session (cookies, localStorage) from a file.
+
+    In-session complement to ``save_browser_state()``.  Restores authentication
+    state without requiring a process restart or setting the
+    ``GPTME_BROWSER_STORAGE_STATE`` environment variable.
+
+    After calling this, call ``open_page(url)`` to start a browser session with
+    the restored cookies and localStorage.
+
+    Typical workflow::
+
+        # First session — log in and save state:
+        open_page("https://x.com/login")
+        fill_element("#username", "you@example.com")
+        fill_element("#password", "hunter2")
+        click_element("text=Log in")
+        save_browser_state("~/.config/gptme/twitter-session.json")
+
+        # Later in the same session (or a new one):
+        load_browser_state("~/.config/gptme/twitter-session.json")
+        open_page("https://x.com")           # opens already logged in
+        click_element("text=What is happening?!")
+        fill_element('[data-testid="tweetTextarea_0"]', "hello from gptme!")
+        click_element('[data-testid="tweetButtonInline"]')
+
+    Args:
+        path: Path to the session JSON previously written by ``save_browser_state()``.
+              ``~`` is expanded to the home directory.
+
+    Returns:
+        Confirmation string. The next ``open_page()`` will use the restored state.
+
+    Raises:
+        FileNotFoundError: If *path* does not exist.
+    """
+    assert browser
+    if browser == "playwright":
+        from ._browser_playwright import load_browser_state as load_browser_state_pw
+
+        return load_browser_state_pw(path)
+    raise ValueError(
+        "load_browser_state() is only supported with the playwright backend"
+    )
+
+
 def read_page_text() -> str:
     """Read the full text content of the current interactive page as Markdown.
 
@@ -1243,6 +1289,7 @@ services with APIs, prefer shell or Python over scraping.""",
         "scroll_page()/press_key()/select_option()/wait_for_element()/"
         "hover_element()/snapshot_page()/get_current_url(), "
         "read interactive page content with read_page_text(), "
+        "save/restore browser auth sessions with save_browser_state()/load_browser_state(), "
         "check browser console errors with read_logs(), "
         "or convert a local PDF to images with pdf_to_images().",
     },
@@ -1257,6 +1304,7 @@ services with APIs, prefer shell or Python over scraping.""",
             open_page,
             close_page,
             save_browser_state,
+            load_browser_state,
             read_page_text,
             click_element,
             fill_element,

--- a/tests/test_browser_state.py
+++ b/tests/test_browser_state.py
@@ -1,0 +1,203 @@
+"""Tests for browser session state management — save_browser_state / load_browser_state."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_storage_state_override():
+    """Reset the in-session storage state override before and after each test.
+
+    Prevents one test's state from leaking into the next — especially important
+    when testing set_storage_state_override() / get_context_options() interactions.
+    """
+    from gptme.tools._browser_thread import set_storage_state_override
+
+    set_storage_state_override(None)
+    yield
+    set_storage_state_override(None)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_state_file(tmp_path: Path) -> Path:
+    """Write a minimal valid Playwright storage-state JSON to tmp_path."""
+    state: dict = {"cookies": [], "origins": []}
+    p = tmp_path / "session.json"
+    p.write_text(json.dumps(state))
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Tests for load_browser_state (in-session state restoration)
+# ---------------------------------------------------------------------------
+
+
+def test_load_browser_state_sets_override(tmp_path, monkeypatch):
+    """load_browser_state() sets the in-session storage-state override."""
+    import gptme.tools._browser_thread as _bt
+    from gptme.tools._browser_playwright import _do_load_browser_state
+
+    state_file = _make_state_file(tmp_path)
+
+    # Track close_current_page calls
+    closed: list[bool] = []
+    monkeypatch.setattr(
+        "gptme.tools._browser_playwright._close_current_page",
+        lambda: closed.append(True),
+    )
+
+    result = _do_load_browser_state(None, str(state_file))  # type: ignore[arg-type]
+
+    assert _bt._override_storage_state == state_file
+    assert "open_page" in result  # message tells user what to do next
+    assert closed == [True]  # current page was closed
+
+
+def test_load_browser_state_missing_file_raises(tmp_path, monkeypatch):
+    """load_browser_state() raises FileNotFoundError for a non-existent path."""
+    from gptme.tools._browser_playwright import _do_load_browser_state
+
+    monkeypatch.setattr(
+        "gptme.tools._browser_playwright._close_current_page", lambda: None
+    )
+
+    missing = tmp_path / "does-not-exist.json"
+    with pytest.raises(FileNotFoundError) as exc_info:
+        _do_load_browser_state(None, str(missing))  # type: ignore[arg-type]
+    assert "does-not-exist.json" in str(exc_info.value)
+    assert "save_browser_state" in str(exc_info.value)
+
+
+def test_load_browser_state_expands_tilde(tmp_path, monkeypatch):
+    """load_browser_state() expands ~ in the path."""
+    import gptme.tools._browser_thread as _bt
+    from gptme.tools._browser_playwright import _do_load_browser_state
+
+    _make_state_file(tmp_path)  # creates tmp_path/session.json
+
+    # expanduser() reads $HOME, not Path.home() — patch the env var
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(
+        "gptme.tools._browser_playwright._close_current_page", lambda: None
+    )
+
+    _do_load_browser_state(None, "~/session.json")  # type: ignore[arg-type]
+
+    assert _bt._override_storage_state == tmp_path / "session.json"
+
+
+def test_get_context_options_uses_override(tmp_path):
+    """get_context_options() picks up the in-session override over the env var."""
+    from gptme.tools._browser_thread import (
+        get_context_options,
+        set_storage_state_override,
+    )
+
+    state_file = _make_state_file(tmp_path)
+    set_storage_state_override(state_file)
+
+    opts = get_context_options()
+    assert opts.get("storage_state") == str(state_file)
+
+
+def test_get_context_options_override_beats_env_var(tmp_path, monkeypatch):
+    """In-session override takes priority over the GPTME_BROWSER_STORAGE_STATE env var."""
+    from gptme.tools._browser_thread import (
+        get_context_options,
+        set_storage_state_override,
+    )
+
+    override_file = tmp_path / "override.json"
+    override_file.write_text(json.dumps({"cookies": [], "origins": []}))
+
+    env_file = tmp_path / "env.json"
+    env_file.write_text(json.dumps({"cookies": [], "origins": []}))
+
+    # Set the env var to point at env_file
+    monkeypatch.setenv("GPTME_BROWSER_STORAGE_STATE", str(env_file))
+
+    # Set the override to point at override_file
+    set_storage_state_override(override_file)
+
+    try:
+        opts = get_context_options()
+        # Override wins
+        assert opts.get("storage_state") == str(override_file)
+    finally:
+        set_storage_state_override(None)
+
+
+def test_get_context_options_no_override_uses_env_var(tmp_path, monkeypatch):
+    """Without an override, get_context_options() falls back to the env var."""
+    from gptme.tools._browser_thread import (
+        get_context_options,
+        set_storage_state_override,
+    )
+
+    set_storage_state_override(None)
+
+    state_file = _make_state_file(tmp_path)
+    monkeypatch.setenv("GPTME_BROWSER_STORAGE_STATE", str(state_file))
+
+    opts = get_context_options()
+    assert opts.get("storage_state") == str(state_file)
+
+
+def test_load_browser_state_closes_current_page(tmp_path, monkeypatch):
+    """load_browser_state() always closes the current page before setting the override."""
+    from gptme.tools._browser_playwright import _do_load_browser_state
+
+    state_file = _make_state_file(tmp_path)
+
+    close_calls: list[bool] = []
+    monkeypatch.setattr(
+        "gptme.tools._browser_playwright._close_current_page",
+        lambda: close_calls.append(True),
+    )
+
+    _do_load_browser_state(None, str(state_file))  # type: ignore[arg-type]
+
+    assert close_calls == [True], "expected exactly one close_current_page() call"
+
+
+def test_load_browser_state_registered_in_tool_spec():
+    """load_browser_state is registered as a ToolFunction in the browser ToolSpec."""
+    from gptme.tools.browser import tool
+
+    fn_names = [f.name for f in tool.functions or []]
+    assert "load_browser_state" in fn_names, (
+        f"load_browser_state not found in browser tool functions; found: {fn_names}"
+    )
+
+
+def test_save_and_load_round_trip(tmp_path, monkeypatch):
+    """save path roundtrips through load: saved path == loaded override."""
+    import gptme.tools._browser_thread as _bt
+    from gptme.tools._browser_playwright import _do_load_browser_state
+
+    state_file = _make_state_file(tmp_path)
+
+    monkeypatch.setattr(
+        "gptme.tools._browser_playwright._close_current_page", lambda: None
+    )
+
+    _do_load_browser_state(None, str(state_file))  # type: ignore[arg-type]
+
+    # The override should point at the same file we started with
+    assert _bt._override_storage_state is not None
+    assert _bt._override_storage_state.resolve() == state_file.resolve()

--- a/tests/test_browser_state.py
+++ b/tests/test_browser_state.py
@@ -175,6 +175,55 @@ def test_load_browser_state_closes_current_page(tmp_path, monkeypatch):
     assert close_calls == [True], "expected exactly one close_current_page() call"
 
 
+def test_load_browser_state_refreshes_cdp_session_context(tmp_path, monkeypatch):
+    """CDP mode must rebuild its reusable session context with the loaded state."""
+    import gptme.tools._browser_playwright as browser_pw
+    import gptme.tools._browser_thread as browser_thread
+
+    class FakeContext:
+        def __init__(self) -> None:
+            self.closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    class FakeBrowser:
+        def __init__(self) -> None:
+            self.context_kwargs: list[dict] = []
+            self.context = FakeContext()
+
+        def new_context(self, **kwargs):
+            self.context_kwargs.append(kwargs)
+            return self.context
+
+    class FakeBrowserThread:
+        cdp_url = "http://127.0.0.1:9222"
+
+        def __init__(self, context: FakeContext) -> None:
+            self._session_context = context
+
+    state_file = _make_state_file(tmp_path)
+    old_context = FakeContext()
+    thread = FakeBrowserThread(old_context)
+    fake_browser = FakeBrowser()
+    close_calls: list[bool] = []
+
+    monkeypatch.setattr(browser_pw, "_browser", thread)
+    monkeypatch.setattr(
+        browser_pw, "_close_current_page", lambda: close_calls.append(True)
+    )
+
+    result = browser_pw._do_load_browser_state(fake_browser, str(state_file))  # type: ignore[arg-type]
+
+    assert close_calls == [True]
+    assert old_context.closed
+    assert thread._session_context is fake_browser.context
+    assert fake_browser.context_kwargs
+    assert fake_browser.context_kwargs[0]["storage_state"] == str(state_file)
+    assert browser_thread._override_storage_state == state_file
+    assert "CDP session context refreshed" in result
+
+
 def test_load_browser_state_registered_in_tool_spec():
     """load_browser_state is registered as a ToolFunction in the browser ToolSpec."""
     from gptme.tools.browser import tool

--- a/tests/test_browser_state.py
+++ b/tests/test_browser_state.py
@@ -7,6 +7,8 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+pytest.importorskip("playwright")
+
 if TYPE_CHECKING:
     from pathlib import Path
 

--- a/tests/test_eval_computer_suite.py
+++ b/tests/test_eval_computer_suite.py
@@ -814,3 +814,39 @@ def test_expect_current_url_captured_accepts_url():
         exit_code=0,
     )
     assert computer_suite._expect_current_url_captured(ctx)
+
+
+def test_check_used_save_browser_state_accepts(monkeypatch):
+    monkeypatch.setattr(
+        computer_suite,
+        "_executed_tool_calls",
+        lambda messages: ["save_browser_state('state.json')"],
+    )
+    assert computer_suite.check_used_save_browser_state([])
+
+
+def test_check_used_save_browser_state_rejects_open_page(monkeypatch):
+    monkeypatch.setattr(
+        computer_suite,
+        "_executed_tool_calls",
+        lambda messages: ["open_page('https://x.com')"],
+    )
+    assert not computer_suite.check_used_save_browser_state([])
+
+
+def test_check_used_load_browser_state_accepts(monkeypatch):
+    monkeypatch.setattr(
+        computer_suite,
+        "_executed_tool_calls",
+        lambda messages: ["load_browser_state('state.json')"],
+    )
+    assert computer_suite.check_used_load_browser_state([])
+
+
+def test_check_used_load_browser_state_rejects_save(monkeypatch):
+    monkeypatch.setattr(
+        computer_suite,
+        "_executed_tool_calls",
+        lambda messages: ["save_browser_state('state.json')"],
+    )
+    assert not computer_suite.check_used_load_browser_state([])

--- a/tests/test_eval_computer_suite.py
+++ b/tests/test_eval_computer_suite.py
@@ -62,6 +62,19 @@ def test_expect_second_page_reached_accepts_navigation_file():
     assert computer_suite._expect_second_page_reached(ctx)
 
 
+def test_session_persistence_eval_requires_state_file_written():
+    spec = next(
+        test
+        for test in computer_suite.tests
+        if test["name"] == "computer-use-web-session-persistence"
+    )
+
+    assert (
+        spec["expect"]["state.json written"]
+        is computer_suite._expect_state_file_written
+    )
+
+
 def test_expect_form_submitted_requires_echoed_field():
     ctx = ResultContext(
         files={"result.txt": "Error: form unavailable"},


### PR DESCRIPTION
## Summary

Adds `load_browser_state(path)` as the callable complement to `save_browser_state(path)`, closing a usability gap in the computer-use browser tool (#216).

**Before**: Restoring a saved session required setting `GPTME_BROWSER_STORAGE_STATE` *before* process startup — no way to switch auth state mid-session without a restart.

**After**: `load_browser_state("~/twitter-session.json")` + `open_page(url)` reloads the session in-place, no restart required.

## Changes

- **`_browser_thread.py`**: `set_storage_state_override()` + 3-level priority in `get_context_options()`:
  in-session override > `GPTME_BROWSER_STORAGE_STATE` env var > fresh context
- **`_browser_playwright.py`**: `_do_load_browser_state()` closes the current page and sets the override;
  public `load_browser_state()` wraps it via `_execute_with_retry()` for thread safety
- **`browser.py`**: Public `load_browser_state()`, registered in `ToolSpec`, updated `instructions_format`
- **`eval/suites/computer.py`**: New `computer-use-web-session-persistence` eval spec with
  `check_used_save_browser_state` / `check_used_load_browser_state` trajectory helpers

## Tests

- `tests/test_browser_state.py` — 9 unit tests: override priority, env-var fallback, tilde expansion, missing-file error, tool-spec registration, round-trip
- `tests/test_eval_computer_suite.py` — 4 tests for the new trajectory check helpers

## Typical workflow now

```python
# First time: log in and save
open_page("https://x.com/login")
fill_element("#username", "me@example.com")
fill_element("#password", "hunter2")
click_element("text=Log in")
save_browser_state("~/.config/gptme/twitter-session.json")

# Later in the same session (or a new one):
load_browser_state("~/.config/gptme/twitter-session.json")
open_page("https://x.com")   # opens with saved cookies — no restart needed
```

Closes #216