### PR TITLE
fix(computer): lower screen-change threshold 1%→0.2% and fix xvfb teardown (#216)

### DIFF
--- a/gptme/tools/computer.py
+++ b/gptme/tools/computer.py
@@ -1319,7 +1319,12 @@ def _poll_for_change(
     """
     poll_interval = 0.05
     max_poll_interval = 0.5
-    change_threshold = 0.01
+    # 0.2% threshold: detects even small text changes (typing a short command into
+    # a terminal window changes ~0.3–0.5% of a 1024×768 screen; 1% was too high and
+    # caused "No screen change detected" even when the xterm had updated — issue #216).
+    # PNG screenshots are lossless, so consecutive identical frames always read 0.0%,
+    # making false positives effectively impossible in a static Xvfb environment.
+    change_threshold = 0.002
     deadline = _monotonic() + timeout
 
     changed = False  # Have we seen any change from the original baseline?

--- a/tests/test_computer_x11_integration.py
+++ b/tests/test_computer_x11_integration.py
@@ -107,8 +107,17 @@ def xvfb_display() -> Generator[str, None, None]:
 
     wm_proc.terminate()
     proc.terminate()
-    wm_proc.wait(timeout=5)
-    proc.wait(timeout=5)
+    # fluxbox can take longer than 5s to respond to SIGTERM; SIGKILL as fallback
+    try:
+        wm_proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        wm_proc.kill()
+        wm_proc.wait(timeout=2)
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait(timeout=2)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_tools_computer.py
+++ b/tests/test_tools_computer.py
@@ -1219,6 +1219,61 @@ def test_compute_change_ratio_mismatched_sizes():
         p2.unlink(missing_ok=True)
 
 
+def test_compute_change_ratio_small_text_change():
+    """Simulated terminal text change stays above the 0.2% detection threshold.
+
+    Typing a short command into an xterm on a 1024x768 screen changes roughly
+    0.3–0.5% of pixels (22 chars × ~112px each out of 786,432 total).  This
+    test verifies that a 0.3% change is detectable with the new threshold (0.002)
+    and was NOT detectable with the old threshold (0.01) — catching a regression
+    where act_and_observe always reported "No screen change detected" after typing.
+    """
+    from PIL import Image
+
+    # Simulate a 1024×768 terminal screen: mostly black background
+    size = (1024, 768)
+    img1 = Image.new("RGB", size, (0, 0, 0))
+    img2 = img1.copy()
+
+    # Simulate typing "echo act_and_observe_ok" into an xterm at the bottom of the window.
+    # Each character is roughly 7×14 pixels; 22 chars = 22 × 7 × 14 = 2156 pixels.
+    # We paint a 154×14 pixel rectangle (22 chars wide) to represent the text.
+    char_w, char_h = 7, 14
+    num_chars = 22
+    text_x, text_y = 100, 700  # near the bottom of the terminal
+    for x in range(text_x, text_x + num_chars * char_w):
+        for y in range(text_y, text_y + char_h):
+            img2.putpixel((x, y), (200, 200, 200))  # light text on dark background
+
+    changed_pixels = num_chars * char_w * char_h  # 2156
+    expected_ratio = changed_pixels / (size[0] * size[1])  # ~0.0027
+
+    f1 = tempfile.NamedTemporaryFile(suffix=".png", delete=False)
+    f2 = tempfile.NamedTemporaryFile(suffix=".png", delete=False)
+    img1.save(f1.name)
+    img2.save(f2.name)
+    f1.close()
+    f2.close()
+    p1, p2 = Path(f1.name), Path(f2.name)
+    try:
+        ratio = _compute_change_ratio(p1, p2)
+        # Should be approximately the expected ratio
+        assert abs(ratio - expected_ratio) < 0.001, (
+            f"expected ~{expected_ratio:.4f}, got {ratio:.4f}"
+        )
+        # Must be above the new 0.002 threshold so act_and_observe detects it
+        assert ratio >= 0.002, (
+            f"ratio {ratio:.4f} is below new threshold 0.002 — small text changes won't be detected"
+        )
+        # This confirms the old 0.01 threshold was wrong: it was ABOVE the change ratio
+        assert ratio < 0.01, (
+            f"ratio {ratio:.4f} exceeds old 0.01 threshold — old behaviour would have detected this; test premise is wrong"
+        )
+    finally:
+        p1.unlink(missing_ok=True)
+        p2.unlink(missing_ok=True)
+
+
 # ============================================================
 # wait_for_change action tests (unit — mocks screenshot/time)
 # ============================================================


### PR DESCRIPTION
## Problem

`act_and_observe()` was always reporting "No screen change detected" even when the terminal had updated. This left the agent with no feedback after typing commands — a real form of the "delay" symptom tracked in #216.

**Root cause:** `_poll_for_change` used a `change_threshold = 0.01` (1%). A 1024×768 screen has 786,432 total pixels. Typing a short command into an xterm changes roughly:

- 22 chars × 7 px wide × 14 px tall ≈ 2,156 pixels → **0.27% of the screen**

0.27% < 1% → no change detected, timeout reached, agent flies blind.

## Fix

Lower the threshold from `0.01` to `0.002` (0.2%). This detects even short command strings reliably. PNG screenshots are lossless — two frames of identical content always differ by exactly 0.0%, so there are no false positives in a static X11 environment.

**Also fixes:** the `xvfb_display` fixture in `test_computer_x11_integration.py` was raising `subprocess.TimeoutExpired` in teardown because `fluxbox` often ignores SIGTERM and doesn't exit within 5 seconds. Added a SIGKILL fallback.

## Changes

- `gptme/tools/computer.py`: lower `change_threshold` from `0.01` to `0.002`, add explanatory comment
- `tests/test_computer_x11_integration.py`: fix fluxbox teardown (SIGKILL fallback after timeout)
- `tests/test_tools_computer.py`: new regression test that verifies the small-text change ratio (0.27%) is above the new threshold (0.2%) and was NOT above the old threshold (1%)

## Test

```
532 passed, 61 skipped, 1 warning  ✓  (new test + all existing pass)
```

Closes part of #216 — the `act_and_observe` screen-change detection gap.

<!-- gptme-id:v1:gai_Ap6Bjwtcy8ugyJkmJWUQIjrJtsHftQCtm7pOSU19gz1 -->