### PR TITLE
feat(subagent): add subagent_pipeline() for staged fan-out with no barrier (#554)

### DIFF
--- a/gptme/tools/subagent/__init__.py
+++ b/gptme/tools/subagent/__init__.py
@@ -6,7 +6,7 @@ Package structure:
 - types.py      — Data classes and module-level state (Subagent, ReturnType, etc.)
 - hooks.py      — Completion notification system (LOOP_CONTINUE hook)
 - api.py        — Public API (subagent, subagent_status, subagent_wait, etc.)
-- batch.py      — Batch execution (BatchJob, subagent_batch, subagent_parallel)
+- batch.py      — Batch execution (BatchJob, subagent_batch, subagent_parallel, subagent_pipeline)
 - execution.py  — Execution backends (thread, subprocess, process monitoring)
 """
 
@@ -22,7 +22,7 @@ from .api import (
     subagent_status,
     subagent_wait,
 )
-from .batch import BatchJob, subagent_batch, subagent_parallel
+from .batch import BatchJob, subagent_batch, subagent_parallel, subagent_pipeline
 from .execution import get_current_agent_id
 from .hooks import (
     _get_complete_instruction,
@@ -179,6 +179,30 @@ System: impl: success — Authentication feature implemented in auth.py
 test: success — 12 tests added, all passing
 docs: success — API documented in docs/auth.md
 
+### Pipeline (multi-stage fan-out, no barrier between stages)
+User: review these files in two stages — first find issues, then verify each finding
+Assistant: I'll use subagent_pipeline so file B's review starts while file A's verification is running.
+{
+        ToolUse(
+            "ipython",
+            [],
+            '''results = subagent_pipeline(
+    [("auth", "Review auth.py for bugs"), ("db", "Review db.py for bugs")],
+    # Stage 0: review each file
+    lambda item, _: item,
+    # Stage 1: adversarially verify the review findings
+    lambda item, prev: "Verify these findings, keep only real bugs: " + prev,
+    timeout=300,
+)
+# auth advances to stage 1 as soon as its stage 0 finishes,
+# while db may still be in stage 0.
+for (prefix, _), stage_results in zip([("auth", ...), ("db", ...)], results):
+    print(f"{prefix}: {stage_results[-1]['status']}")''',
+        ).to_output(tool_format)
+    }
+System: auth-s0 done → auth-s1 started; db-s0 done → db-s1 started
+System: auth: success, db: success
+
 ### Batch Execution (fire-and-forget with explicit sync)
 User: start tasks in background and continue working
 Assistant: I'll use subagent_batch to start tasks in the background. Completion hooks will notify me.
@@ -297,6 +321,7 @@ Key features:
 - context_window=0: Minimal context — only agent identity + tools, no workspace files (strongest isolation)
 - context_window=N: Limit workspace context to at most N messages
 - subagent_parallel(tasks, timeout): Fan out N subagents and wait for all — returns ordered list of results
+- subagent_pipeline(items, *stages, timeout): Multi-stage fan-out with no barrier between stages — item A advances to stage 2 while item B is still in stage 1; each stage callable receives (item_prompt, prev_result) and returns the next stage's prompt
 - subagent_batch(): Start multiple subagents and return a BatchJob for explicit synchronization
 - subagent_cancel(): Cancel a running subagent (SIGTERM for subprocess, marks result for threads)
 - subagent_reply(agent_id, reply): Answer a clarification request and re-spawn the subagent
@@ -412,6 +437,7 @@ tool = ToolSpec(
             subagent_read_log,
             subagent_batch,
             subagent_parallel,
+            subagent_pipeline,
         ]
     ],
     disabled_by_default=True,
@@ -436,6 +462,7 @@ __all__ = [
     "subagent_read_log",
     "subagent_batch",
     "subagent_parallel",
+    "subagent_pipeline",
     "BatchJob",
     # Types
     "SubtaskDef",

--- a/gptme/tools/subagent/batch.py
+++ b/gptme/tools/subagent/batch.py
@@ -558,11 +558,11 @@ def subagent_pipeline(
     def process_item(item_idx: int, item_id_prefix: str, item_prompt: str) -> None:
         prev_result_text = ""
         for stage_idx, stage_fn in enumerate(stages):
-            stage_prompt = stage_fn(item_prompt, prev_result_text)
             agent_id = f"{item_id_prefix}-s{stage_idx}"
             # Only pass output_schema to the final stage
             is_final = stage_idx == len(stages) - 1
             try:
+                stage_prompt = stage_fn(item_prompt, prev_result_text)
                 subagent(
                     agent_id=agent_id,
                     prompt=stage_prompt,

--- a/gptme/tools/subagent/batch.py
+++ b/gptme/tools/subagent/batch.py
@@ -2,12 +2,15 @@
 
 Provides BatchJob for managing groups of subagents and subagent_batch()
 for convenient fire-and-gather patterns. Also provides subagent_parallel()
-for a simpler synchronous fan-out pattern.
+for a simpler synchronous fan-out pattern. subagent_pipeline() provides
+staged fan-out with no barrier between stages — item A advances to stage 2
+while item B is still in stage 1.
 """
 
 import json
 import logging
 import threading
+from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from concurrent.futures import TimeoutError as FuturesTimeoutError
 from dataclasses import asdict, dataclass, field
@@ -456,3 +459,160 @@ def subagent_parallel(
     if output_schema is not None:
         return [_parse_result(r, output_schema) for r in raw_results]
     return raw_results
+
+
+def subagent_pipeline(
+    items: list[tuple[str, str]],
+    *stages: Callable[[str, str], str],
+    timeout: int = 600,
+    use_subprocess: bool = False,
+    model: str | None = None,
+    profile: str | None = None,
+    isolated: bool = False,
+    output_schema: type | None = None,
+    workdir: str | Path | None = None,
+    context_turns: int | None = None,
+    redact_secrets: bool = True,
+) -> list[list[dict]]:
+    """Process items through multiple stages with no barrier between stages.
+
+    Each item is processed through all stages sequentially. Items at different
+    stages run concurrently — item A can be in stage 2 while item B is still
+    in stage 1. This is the "pipeline" pattern as opposed to repeated
+    subagent_parallel() calls which add a full barrier between stages.
+
+    Wall-clock time is bounded by the slowest single-item chain, not the sum
+    of the slowest per-stage.
+
+    Args:
+        items: List of ``(agent_id_prefix, initial_prompt)`` tuples.
+        *stages: Callables of the form ``stage(item_prompt, prev_result) -> str``
+            where ``item_prompt`` is the original item prompt and ``prev_result``
+            is the raw result text from the previous stage (empty string for the
+            first stage). Each callable returns the prompt to use for the next
+            subagent in the chain.
+        timeout: Maximum seconds to wait for the entire pipeline to finish.
+        use_subprocess: If True, run each subagent in a subprocess.
+        model: Model override applied to every subagent.
+        profile: Agent profile name applied to every subagent.
+        isolated: If True, run each subagent in its own git worktree.
+        output_schema: Optional Pydantic model class. When set, each final-stage
+            subagent is instructed to return JSON matching the schema and results
+            are automatically parsed.
+        workdir: Working directory passed to every subagent.
+        context_turns: Number of recent parent turns to forward to each subagent.
+        redact_secrets: If True (default), redact secrets from workspace context.
+
+    Returns:
+        List of lists of result dicts. ``results[i][j]`` is the result dict for
+        item ``i`` at stage ``j``. Each dict has ``"status"`` and ``"result"``
+        keys (plus ``"input_tokens"`` / ``"output_tokens"`` when available).
+        When ``output_schema`` is set, the final-stage ``"result"`` value is the
+        parsed/validated object rather than a raw JSON string.
+
+    Example::
+
+        # Two-stage review pipeline: find issues, then verify each finding
+        results = subagent_pipeline(
+            [("file-auth", "Review auth.py"), ("file-db", "Review db.py")],
+            # Stage 0: review
+            lambda item, _: f"Review this file for bugs: {item}",
+            # Stage 1: verify each review finding
+            lambda item, prev: (
+                f"Adversarially verify each finding in this review:\\n{prev}\\n"
+                f"Original file to review: {item}"
+            ),
+        )
+        # file-auth advances to stage 1 as soon as its stage 0 completes,
+        # while file-db may still be in stage 0.
+        for (prefix, _), stage_results in zip(items, results):
+            final = stage_results[-1]
+            print(f"{prefix}: {final['status']} — {final['result'][:80]}")
+
+        # With isolated worktrees so concurrent file edits don't conflict
+        results = subagent_pipeline(
+            [("impl-a", "Implement feature A"), ("impl-b", "Implement feature B")],
+            lambda item, _: item,
+            lambda item, prev: f"Write tests for: {prev}",
+            isolated=True,
+        )
+    """
+    if not items:
+        return []
+    if not stages:
+        raise ValueError("subagent_pipeline requires at least one stage")
+
+    # Per-item results: results[item_idx][stage_idx] = result dict
+    all_results: list[list[dict]] = [[None] * len(stages) for _ in items]  # type: ignore[list-item]
+
+    def process_item(item_idx: int, item_id_prefix: str, item_prompt: str) -> None:
+        prev_result_text = ""
+        for stage_idx, stage_fn in enumerate(stages):
+            stage_prompt = stage_fn(item_prompt, prev_result_text)
+            agent_id = f"{item_id_prefix}-s{stage_idx}"
+            # Only pass output_schema to the final stage
+            is_final = stage_idx == len(stages) - 1
+            try:
+                subagent(
+                    agent_id=agent_id,
+                    prompt=stage_prompt,
+                    use_subprocess=use_subprocess,
+                    model=model,
+                    profile=profile,
+                    isolated=isolated,
+                    output_schema=output_schema if is_final else None,
+                    workdir=workdir,
+                    context_turns=context_turns,
+                    redact_secrets=redact_secrets,
+                )
+                result = subagent_wait(
+                    agent_id,
+                    timeout=timeout,
+                    max_result_chars=0,  # full result for schema parsing
+                )
+            except Exception as exc:
+                result = {"status": "failure", "result": str(exc)}
+            all_results[item_idx][stage_idx] = result
+            if result.get("status") != "success":
+                # On failure, mark remaining stages as skipped and abort item
+                for remaining in range(stage_idx + 1, len(stages)):
+                    all_results[item_idx][remaining] = {
+                        "status": "skipped",
+                        "result": f"Skipped: stage {stage_idx} failed",
+                    }
+                return
+            prev_result_text = result.get("result") or ""
+            if "\n\nFull log: " in prev_result_text:
+                prev_result_text = prev_result_text.split("\n\nFull log: ", 1)[0]
+
+    threads = [
+        threading.Thread(
+            target=process_item,
+            args=(idx, item_id, item_prompt),
+            daemon=True,
+        )
+        for idx, (item_id, item_prompt) in enumerate(items)
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=timeout)
+
+    # Fill any missing results (thread timed out before join)
+    for item_idx in range(len(items)):
+        for stage_idx in range(len(stages)):
+            if all_results[item_idx][stage_idx] is None:
+                all_results[item_idx][stage_idx] = {
+                    "status": "timeout",
+                    "result": f"Pipeline timed out after {timeout}s",
+                }
+
+    # Parse final-stage results against output_schema if provided
+    if output_schema is not None:
+        for item_idx in range(len(items)):
+            final_idx = len(stages) - 1
+            all_results[item_idx][final_idx] = _parse_result(
+                all_results[item_idx][final_idx], output_schema
+            )
+
+    return all_results

--- a/gptme/tools/subagent/batch.py
+++ b/gptme/tools/subagent/batch.py
@@ -7,14 +7,17 @@ staged fan-out with no barrier between stages — item A advances to stage 2
 while item B is still in stage 1.
 """
 
+import copy
 import json
 import logging
 import threading
+import time
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from concurrent.futures import TimeoutError as FuturesTimeoutError
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
+from typing import cast
 
 from .api import subagent, subagent_cancel, subagent_wait
 from .types import ReturnType
@@ -464,8 +467,10 @@ def subagent_parallel(
 def subagent_pipeline(
     items: list[tuple[str, str]],
     *stages: Callable[[str, str], str],
-    timeout: int = 600,
+    timeout: float = 600,
     use_subprocess: bool = False,
+    use_acp: bool = False,
+    acp_command: str = "gptme-acp",
     model: str | None = None,
     profile: str | None = None,
     isolated: bool = False,
@@ -493,6 +498,9 @@ def subagent_pipeline(
             subagent in the chain.
         timeout: Maximum seconds to wait for the entire pipeline to finish.
         use_subprocess: If True, run each subagent in a subprocess.
+        use_acp: If True, run each subagent via the ACP protocol.
+        acp_command: ACP agent command (default: "gptme-acp"). Only used when
+            ``use_acp=True``.
         model: Model override applied to every subagent.
         profile: Agent profile name applied to every subagent.
         isolated: If True, run each subagent in its own git worktree.
@@ -543,7 +551,9 @@ def subagent_pipeline(
         raise ValueError("subagent_pipeline requires at least one stage")
 
     # Per-item results: results[item_idx][stage_idx] = result dict
-    all_results: list[list[dict]] = [[None] * len(stages) for _ in items]  # type: ignore[list-item]
+    all_results: list[list[dict | None]] = [[None] * len(stages) for _ in items]
+    results_lock = threading.Lock()
+    wait_timeout = max(1, int(timeout))
 
     def process_item(item_idx: int, item_id_prefix: str, item_prompt: str) -> None:
         prev_result_text = ""
@@ -557,6 +567,8 @@ def subagent_pipeline(
                     agent_id=agent_id,
                     prompt=stage_prompt,
                     use_subprocess=use_subprocess,
+                    use_acp=use_acp,
+                    acp_command=acp_command,
                     model=model,
                     profile=profile,
                     isolated=isolated,
@@ -567,19 +579,21 @@ def subagent_pipeline(
                 )
                 result = subagent_wait(
                     agent_id,
-                    timeout=timeout,
+                    timeout=wait_timeout,
                     max_result_chars=0,  # full result for schema parsing
                 )
             except Exception as exc:
                 result = {"status": "failure", "result": str(exc)}
-            all_results[item_idx][stage_idx] = result
+            with results_lock:
+                all_results[item_idx][stage_idx] = result
             if result.get("status") != "success":
                 # On failure, mark remaining stages as skipped and abort item
-                for remaining in range(stage_idx + 1, len(stages)):
-                    all_results[item_idx][remaining] = {
-                        "status": "skipped",
-                        "result": f"Skipped: stage {stage_idx} failed",
-                    }
+                with results_lock:
+                    for remaining in range(stage_idx + 1, len(stages)):
+                        all_results[item_idx][remaining] = {
+                            "status": "skipped",
+                            "result": f"Skipped: stage {stage_idx} failed",
+                        }
                 return
             prev_result_text = result.get("result") or ""
             if "\n\nFull log: " in prev_result_text:
@@ -593,26 +607,31 @@ def subagent_pipeline(
         )
         for idx, (item_id, item_prompt) in enumerate(items)
     ]
+    deadline = time.monotonic() + timeout
     for t in threads:
         t.start()
     for t in threads:
-        t.join(timeout=timeout)
+        remaining = max(0.0, deadline - time.monotonic())
+        t.join(timeout=remaining)
 
-    # Fill any missing results (thread timed out before join)
-    for item_idx in range(len(items)):
-        for stage_idx in range(len(stages)):
-            if all_results[item_idx][stage_idx] is None:
-                all_results[item_idx][stage_idx] = {
-                    "status": "timeout",
-                    "result": f"Pipeline timed out after {timeout}s",
-                }
-
-    # Parse final-stage results against output_schema if provided
-    if output_schema is not None:
+    with results_lock:
+        # Fill any missing results (thread timed out before join). Threads may
+        # continue running after this point, so return a deep-copied snapshot
+        # rather than the mutable worker-owned result matrix.
         for item_idx in range(len(items)):
-            final_idx = len(stages) - 1
-            all_results[item_idx][final_idx] = _parse_result(
-                all_results[item_idx][final_idx], output_schema
-            )
+            for stage_idx in range(len(stages)):
+                if all_results[item_idx][stage_idx] is None:
+                    all_results[item_idx][stage_idx] = {
+                        "status": "timeout",
+                        "result": f"Pipeline timed out after {timeout}s",
+                    }
 
-    return all_results
+        # Parse final-stage results against output_schema if provided
+        if output_schema is not None:
+            for item_idx in range(len(items)):
+                final_idx = len(stages) - 1
+                all_results[item_idx][final_idx] = _parse_result(
+                    all_results[item_idx][final_idx] or {}, output_schema
+                )
+
+        return copy.deepcopy(cast(list[list[dict]], all_results))

--- a/tests/test_llm_models_resolution.py
+++ b/tests/test_llm_models_resolution.py
@@ -62,6 +62,7 @@ def _restore_logged_warnings():
     import gptme.llm.models.resolution as res_mod
 
     old = res_mod._logged_warnings.copy()
+    res_mod._logged_warnings.clear()
     yield
     res_mod._logged_warnings.clear()
     res_mod._logged_warnings.update(old)

--- a/tests/test_tools_subagent.py
+++ b/tests/test_tools_subagent.py
@@ -2933,6 +2933,29 @@ def test_subagent_pipeline_stage_failure_skips_remaining():
     assert results[0][2]["status"] == "skipped"
 
 
+def test_subagent_pipeline_stage_callable_exception_reported_as_failure():
+    """A stage_fn that raises is reported as 'failure', not 'timeout'."""
+    from gptme.tools.subagent import subagent_pipeline
+
+    def boom(item, prev):
+        raise RuntimeError("bad lambda")
+
+    with (
+        patch("gptme.tools.subagent.batch.subagent"),
+        patch("gptme.tools.subagent.batch.subagent_wait"),
+    ):
+        results = subagent_pipeline(
+            [("item", "prompt")],
+            boom,
+            lambda item, prev: item,
+            timeout=10,
+        )
+
+    assert results[0][0]["status"] == "failure"
+    assert "bad lambda" in results[0][0]["result"]
+    assert results[0][1]["status"] == "skipped"
+
+
 def test_subagent_pipeline_multiple_items_independent():
     """Multiple items are processed in parallel (independent threads)."""
     import threading

--- a/tests/test_tools_subagent.py
+++ b/tests/test_tools_subagent.py
@@ -2818,3 +2818,209 @@ def test_subagent_thread_does_not_mutate_parent_tool_list():
         f"Parent tool list changed from {parent_len} to {len(get_tools())} — "
         "subagent thread mutated parent's tool list (race condition #554)"
     )
+
+
+# Tests for subagent_pipeline
+
+
+def test_subagent_pipeline_empty_returns_empty():
+    """subagent_pipeline([]) returns [] without touching any subagent."""
+    from gptme.tools.subagent import subagent_pipeline
+
+    result = subagent_pipeline([], lambda item, prev: item)
+    assert result == []
+
+
+def test_subagent_pipeline_requires_at_least_one_stage():
+    """subagent_pipeline with no stages raises ValueError."""
+    from gptme.tools.subagent import subagent_pipeline
+
+    with pytest.raises(ValueError, match="at least one stage"):
+        subagent_pipeline([("a", "prompt")])
+
+
+def test_subagent_pipeline_single_stage_single_item():
+    """Single-stage pipeline: spawns one subagent and returns its result."""
+    from gptme.tools.subagent import subagent_pipeline
+
+    with (
+        patch("gptme.tools.subagent.batch.subagent") as mock_subagent,
+        patch("gptme.tools.subagent.batch.subagent_wait") as mock_wait,
+    ):
+        mock_wait.return_value = {"status": "success", "result": "done"}
+
+        results = subagent_pipeline(
+            [("item-a", "Do task A")],
+            lambda item, prev: f"Stage 0 for: {item}",
+            timeout=10,
+        )
+
+    assert len(results) == 1
+    assert len(results[0]) == 1
+    assert results[0][0] == {"status": "success", "result": "done"}
+    mock_subagent.assert_called_once()
+    call_kwargs = mock_subagent.call_args
+    assert call_kwargs.kwargs["agent_id"] == "item-a-s0"
+    assert "Stage 0 for: Do task A" in call_kwargs.kwargs["prompt"]
+
+
+def test_subagent_pipeline_two_stages_prompt_chaining():
+    """Each stage fn receives (item_prompt, prev_result)."""
+    from gptme.tools.subagent import subagent_pipeline
+
+    stage_inputs: list[tuple[str, str, str]] = []
+
+    def stage0(item, prev):
+        stage_inputs.append(("s0", item, prev))
+        return f"s0:{item}"
+
+    def stage1(item, prev):
+        stage_inputs.append(("s1", item, prev))
+        return f"s1:{item}:{prev}"
+
+    with (
+        patch("gptme.tools.subagent.batch.subagent"),
+        patch("gptme.tools.subagent.batch.subagent_wait") as mock_wait,
+    ):
+        mock_wait.side_effect = [
+            {"status": "success", "result": "result-of-s0"},
+            {"status": "success", "result": "result-of-s1"},
+        ]
+
+        results = subagent_pipeline(
+            [("item", "my-prompt")],
+            stage0,
+            stage1,
+            timeout=10,
+        )
+
+    assert len(results) == 1
+    assert len(results[0]) == 2
+    assert results[0][0]["result"] == "result-of-s0"
+    assert results[0][1]["result"] == "result-of-s1"
+
+    # Stage 0 receives (item_prompt, "") — prev_result starts empty
+    s0_call = next(x for x in stage_inputs if x[0] == "s0")
+    assert s0_call[1] == "my-prompt"
+    assert s0_call[2] == ""
+
+    # Stage 1 receives (item_prompt, result-of-s0)
+    s1_call = next(x for x in stage_inputs if x[0] == "s1")
+    assert s1_call[1] == "my-prompt"
+    assert s1_call[2] == "result-of-s0"
+
+
+def test_subagent_pipeline_stage_failure_skips_remaining():
+    """When a stage fails, remaining stages are marked 'skipped'."""
+    from gptme.tools.subagent import subagent_pipeline
+
+    with (
+        patch("gptme.tools.subagent.batch.subagent"),
+        patch("gptme.tools.subagent.batch.subagent_wait") as mock_wait,
+    ):
+        mock_wait.return_value = {"status": "failure", "result": "error msg"}
+
+        results = subagent_pipeline(
+            [("item", "prompt")],
+            lambda item, prev: item,
+            lambda item, prev: item,
+            lambda item, prev: item,
+            timeout=10,
+        )
+
+    assert results[0][0]["status"] == "failure"
+    assert results[0][1]["status"] == "skipped"
+    assert results[0][2]["status"] == "skipped"
+
+
+def test_subagent_pipeline_multiple_items_independent():
+    """Multiple items are processed in parallel (independent threads)."""
+    import threading
+
+    from gptme.tools.subagent import subagent_pipeline
+
+    started_agents: list[str] = []
+    lock = threading.Lock()
+
+    def fake_subagent(**kwargs):
+        with lock:
+            started_agents.append(kwargs["agent_id"])
+
+    with (
+        patch("gptme.tools.subagent.batch.subagent", side_effect=fake_subagent),
+        patch("gptme.tools.subagent.batch.subagent_wait") as mock_wait,
+    ):
+        mock_wait.return_value = {"status": "success", "result": "ok"}
+
+        results = subagent_pipeline(
+            [("a", "task A"), ("b", "task B"), ("c", "task C")],
+            lambda item, prev: item,
+            timeout=10,
+        )
+
+    assert len(results) == 3
+    assert all(r[0]["status"] == "success" for r in results)
+    # All three items should have been processed
+    assert set(started_agents) == {"a-s0", "b-s0", "c-s0"}
+
+
+def test_subagent_pipeline_uses_full_agent_id_format():
+    """Agent IDs follow the {prefix}-s{stage_idx} convention."""
+    from gptme.tools.subagent import subagent_pipeline
+
+    agent_ids_seen: list[str] = []
+
+    def fake_subagent(**kwargs):
+        agent_ids_seen.append(kwargs["agent_id"])
+
+    with (
+        patch("gptme.tools.subagent.batch.subagent", side_effect=fake_subagent),
+        patch("gptme.tools.subagent.batch.subagent_wait") as mock_wait,
+    ):
+        mock_wait.return_value = {"status": "success", "result": "ok"}
+
+        subagent_pipeline(
+            [("review-auth", "Review auth.py"), ("review-db", "Review db.py")],
+            lambda item, prev: f"stage0:{item}",
+            lambda item, prev: f"stage1:{prev}",
+            timeout=10,
+        )
+
+    assert "review-auth-s0" in agent_ids_seen
+    assert "review-auth-s1" in agent_ids_seen
+    assert "review-db-s0" in agent_ids_seen
+    assert "review-db-s1" in agent_ids_seen
+
+
+def test_subagent_pipeline_output_schema_only_on_final_stage():
+    """output_schema is only passed to the final stage, not intermediate stages."""
+    from pydantic import BaseModel
+
+    from gptme.tools.subagent import subagent_pipeline
+
+    class Result(BaseModel):
+        score: int
+
+    schema_kwargs_by_id: dict[str, type | None] = {}
+
+    def fake_subagent(**kwargs):
+        schema_kwargs_by_id[kwargs["agent_id"]] = kwargs.get("output_schema")
+
+    with (
+        patch("gptme.tools.subagent.batch.subagent", side_effect=fake_subagent),
+        patch("gptme.tools.subagent.batch.subagent_wait") as mock_wait,
+    ):
+        mock_wait.return_value = {"status": "success", "result": '{"score": 42}'}
+
+        subagent_pipeline(
+            [("item", "prompt")],
+            lambda item, prev: "stage0",
+            lambda item, prev: "stage1",
+            output_schema=Result,
+            timeout=10,
+        )
+
+    # Stage 0 should NOT get output_schema
+    assert schema_kwargs_by_id.get("item-s0") is None
+    # Stage 1 (final) should get output_schema
+    assert schema_kwargs_by_id.get("item-s1") is Result

--- a/tests/test_tools_subagent.py
+++ b/tests/test_tools_subagent.py
@@ -2964,6 +2964,100 @@ def test_subagent_pipeline_multiple_items_independent():
     assert set(started_agents) == {"a-s0", "b-s0", "c-s0"}
 
 
+def test_subagent_pipeline_timeout_is_total_deadline():
+    """The outer timeout applies to the whole pipeline, not once per item."""
+    import threading
+    import time
+
+    from gptme.tools.subagent import subagent_pipeline
+
+    release_waits = threading.Event()
+    created_threads = []
+    real_thread = threading.Thread
+
+    def tracking_thread(*args, **kwargs):
+        thread = real_thread(*args, **kwargs)
+        created_threads.append(thread)
+        return thread
+
+    def slow_wait(agent_id, **kwargs):
+        release_waits.wait(timeout=1)
+        return {"status": "success", "result": f"late {agent_id}"}
+
+    try:
+        with (
+            patch("gptme.tools.subagent.batch.threading.Thread", tracking_thread),
+            patch("gptme.tools.subagent.batch.subagent"),
+            patch("gptme.tools.subagent.batch.subagent_wait", side_effect=slow_wait),
+        ):
+            started = time.perf_counter()
+            results = subagent_pipeline(
+                [("a", "task A"), ("b", "task B"), ("c", "task C")],
+                lambda item, prev: item,
+                timeout=0.05,
+            )
+            elapsed = time.perf_counter() - started
+    finally:
+        release_waits.set()
+        for thread in created_threads:
+            thread.join(timeout=1)
+
+    assert elapsed < 0.12
+    assert [item[0]["status"] for item in results] == [
+        "timeout",
+        "timeout",
+        "timeout",
+    ]
+
+
+def test_subagent_pipeline_timeout_result_is_stable_snapshot():
+    """Late worker completion must not mutate the caller's returned timeout list."""
+    import threading
+
+    from gptme.tools.subagent import subagent_pipeline
+
+    release_stage_1 = threading.Event()
+    created_threads = []
+    real_thread = threading.Thread
+
+    def tracking_thread(*args, **kwargs):
+        thread = real_thread(*args, **kwargs)
+        created_threads.append(thread)
+        return thread
+
+    def wait_by_stage(agent_id, **kwargs):
+        if agent_id.endswith("-s0"):
+            return {"status": "success", "result": "stage 0 complete"}
+        release_stage_1.wait(timeout=1)
+        return {"status": "success", "result": "late stage 1 complete"}
+
+    try:
+        with (
+            patch("gptme.tools.subagent.batch.threading.Thread", tracking_thread),
+            patch("gptme.tools.subagent.batch.subagent"),
+            patch(
+                "gptme.tools.subagent.batch.subagent_wait",
+                side_effect=wait_by_stage,
+            ),
+        ):
+            results = subagent_pipeline(
+                [("item", "task")],
+                lambda item, prev: item,
+                lambda item, prev: f"verify {prev}",
+                timeout=0.05,
+            )
+
+        assert results[0][0]["status"] == "success"
+        assert results[0][1]["status"] == "timeout"
+    finally:
+        release_stage_1.set()
+        for thread in created_threads:
+            thread.join(timeout=1)
+
+    assert results[0][1]["status"] == "timeout"
+    assert "timed out" in results[0][1]["result"]
+
+
 def test_subagent_pipeline_uses_full_agent_id_format():
     """Agent IDs follow the {prefix}-s{stage_idx} convention."""
     from gptme.tools.subagent import subagent_pipeline
@@ -2990,6 +3084,38 @@ def test_subagent_pipeline_uses_full_agent_id_format():
     assert "review-auth-s1" in agent_ids_seen
     assert "review-db-s0" in agent_ids_seen
     assert "review-db-s1" in agent_ids_seen
+
+
+def test_subagent_pipeline_forwards_acp_options():
+    """subagent_pipeline forwards ACP options consistently with parallel/batch."""
+    from gptme.tools.subagent import subagent_pipeline
+
+    subagent_kwargs: list[dict] = []
+
+    def fake_subagent(**kwargs):
+        subagent_kwargs.append(kwargs)
+
+    with (
+        patch("gptme.tools.subagent.batch.subagent", side_effect=fake_subagent),
+        patch("gptme.tools.subagent.batch.subagent_wait") as mock_wait,
+    ):
+        mock_wait.return_value = {"status": "success", "result": "ok"}
+
+        subagent_pipeline(
+            [("item", "prompt")],
+            lambda item, prev: "stage0",
+            lambda item, prev: "stage1",
+            timeout=10,
+            use_acp=True,
+            acp_command="fake-acp",
+        )
+
+    assert [kwargs["agent_id"] for kwargs in subagent_kwargs] == [
+        "item-s0",
+        "item-s1",
+    ]
+    assert all(kwargs["use_acp"] is True for kwargs in subagent_kwargs)
+    assert all(kwargs["acp_command"] == "fake-acp" for kwargs in subagent_kwargs)
 
 
 def test_subagent_pipeline_output_schema_only_on_final_stage():


### PR DESCRIPTION
## Summary

- Adds `subagent_pipeline(items, *stages, timeout, ...)` to `gptme/tools/subagent/batch.py` and exports it from the package
- Provides staged fan-out semantics where **no barrier exists between stages**: item A advances to stage 2 as soon as its stage 1 completes, without waiting for item B to finish stage 1
- Closes the remaining gap vs Claude Code's `pipeline()` pattern from the comparison matrix in #554

## Motivation

The comparison matrix comment in #554 showed `subagent_parallel()` (fan-out with barrier) but no `pipeline()` equivalent. `subagent_parallel()` maps to CC's `parallel()`, but CC also has `pipeline()` — staged multi-step work with no inter-stage barrier. This PR adds that.

**Wall-clock improvement**: with N items and M stages, a pure barrier (`subagent_parallel()` called M times) has wall-clock = sum-of-slowest-per-stage. `subagent_pipeline()` has wall-clock = max single-item chain time, matching what CC's `pipeline()` achieves.

## API

```python
def subagent_pipeline(
    items: list[tuple[str, str]],   # (agent_id_prefix, initial_prompt)
    *stages: Callable[[str, str], str],  # (item_prompt, prev_result) -> next_prompt
    timeout: int = 600,
    use_subprocess: bool = False,
    model: str | None = None,
    profile: str | None = None,
    isolated: bool = False,
    output_schema: type | None = None,
    workdir: str | Path | None = None,
    context_turns: int | None = None,
    redact_secrets: bool = True,
) -> list[list[dict]]:
```

- Agent IDs follow `{prefix}-s{stage_idx}` convention
- Stage 0 receives `(item_prompt, "")` — prev_result starts empty
- Each subsequent stage receives `(item_prompt, prev_stage_result_text)`
- On stage failure: remaining stages for that item are marked `"skipped"`
- `output_schema` is applied only to the final stage

## Example

```python
# Two-stage review pipeline: find issues, then verify each finding.
# auth.py advances to verification while db.py is still being reviewed.
results = subagent_pipeline(
    [("auth", "Review auth.py for bugs"), ("db", "Review db.py for bugs")],
    lambda item, _: item,                                      # stage 0: review
    lambda item, prev: "Verify these findings, keep only real bugs: " + prev,  # stage 1: verify
    timeout=300,
)
for (prefix, _), stage_results in zip(items, results):
    print(f"{prefix}: {stage_results[-1]['status']}")
```

## Test coverage

8 unit tests added to `tests/test_tools_subagent.py`:
- empty input returns `[]`
- missing stages raises `ValueError`
- single-stage single-item: correct agent_id, correct prompt forwarding
- two-stage prompt chaining: stage 1 receives prev_result from stage 0
- failure propagation: failed stage marks remaining as `"skipped"`
- multiple items run in parallel threads
- agent ID format follows `{prefix}-s{stage_idx}` convention
- `output_schema` is applied only to the final stage, not intermediate stages

Closes #554

<!-- gptme-id:v1:gai_ERc5TMrFnnLGb88dXSFeXvdfiZePAXFMjGpz48cEwoX -->