### PR TITLE
fix(webui): connect server after auth-code exchange + lazy cloud env vars

### DIFF
--- a/webui/src/utils/__tests__/connectionConfig.test.ts
+++ b/webui/src/utils/__tests__/connectionConfig.test.ts
@@ -8,10 +8,12 @@ const mockFindOrCreateServerByUrl = jest.fn((baseUrl: string, config: Record<str
 }));
 const mockGetActiveServer = jest.fn(() => null);
 const mockSetActiveServer = jest.fn();
+const mockConnectServer = jest.fn();
 const mockUpdateServer = jest.fn();
 
 jest.mock('@/stores/servers', () => ({
   findOrCreateServerByUrl: mockFindOrCreateServerByUrl,
+  connectServer: mockConnectServer,
   getActiveServer: mockGetActiveServer,
   setActiveServer: mockSetActiveServer,
   updateServer: mockUpdateServer,
@@ -44,6 +46,7 @@ describe('processConnectionFromHash', () => {
 
   beforeEach(() => {
     mockFindOrCreateServerByUrl.mockClear();
+    mockConnectServer.mockClear();
     mockGetActiveServer.mockClear();
     mockSetActiveServer.mockClear();
     mockUpdateServer.mockClear();
@@ -86,6 +89,7 @@ describe('processConnectionFromHash', () => {
       }
     );
     expect(mockSetActiveServer).toHaveBeenCalledWith('server-1');
+    expect(mockConnectServer).toHaveBeenCalledWith('server-1');
     expect(result).toEqual({
       baseUrl: 'https://instance-123.fleet.gptme.ai',
       authToken: 'token-123',
@@ -106,6 +110,7 @@ describe('processConnectionFromHash', () => {
 
     // Registry should not be mutated on failed exchange
     expect(mockFindOrCreateServerByUrl).not.toHaveBeenCalled();
+    expect(mockConnectServer).not.toHaveBeenCalled();
     expect(mockSetActiveServer).not.toHaveBeenCalled();
   });
 });

--- a/webui/src/utils/__tests__/connectionConfig.test.ts
+++ b/webui/src/utils/__tests__/connectionConfig.test.ts
@@ -19,7 +19,11 @@ jest.mock('@/stores/servers', () => ({
   updateServer: mockUpdateServer,
 }));
 
-import { processConnectionFromHash, resolveCloudExchangeBaseUrl } from '../connectionConfig';
+import {
+  getConnectionConfigFromSources,
+  processConnectionFromHash,
+  resolveCloudExchangeBaseUrl,
+} from '../connectionConfig';
 
 const runtimeEnvWindow = window as typeof window & {
   __GPTME_WEBUI_ENV__?: Record<string, string | undefined>;
@@ -107,7 +111,7 @@ describe('processConnectionFromHash', () => {
       VITE_GPTME_FLEET_BASE_URL: 'http://fleet.gptme.local:8080',
     };
 
-    await processConnectionFromHash('code=local-ci-code');
+    const result = await processConnectionFromHash('code=local-ci-code');
 
     expect(global.fetch).toHaveBeenCalledWith(
       'http://fleet.gptme.local:8080/api/v1/operator/auth/exchange',
@@ -117,6 +121,39 @@ describe('processConnectionFromHash', () => {
         body: JSON.stringify({ code: 'local-ci-code' }),
       })
     );
+    expect(mockFindOrCreateServerByUrl).toHaveBeenCalledWith(
+      'https://instance-123.fleet.gptme.ai',
+      {
+        authToken: 'token-123',
+        useAuthToken: true,
+      }
+    );
+    expect(mockConnectServer).toHaveBeenCalledWith('server-1');
+    expect(mockSetActiveServer).toHaveBeenCalledWith('server-1');
+    expect(result).toEqual({
+      baseUrl: 'https://instance-123.fleet.gptme.ai',
+      authToken: 'token-123',
+      useAuthToken: true,
+    });
+  });
+
+  it('connects the registered server from legacy fragment URL config', () => {
+    const result = getConnectionConfigFromSources(
+      'baseUrl=https://legacy.example.com&userToken=legacy-token'
+    );
+
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(mockFindOrCreateServerByUrl).toHaveBeenCalledWith('https://legacy.example.com', {
+      authToken: 'legacy-token',
+      useAuthToken: true,
+    });
+    expect(mockConnectServer).toHaveBeenCalledWith('server-1');
+    expect(mockSetActiveServer).toHaveBeenCalledWith('server-1');
+    expect(result).toEqual({
+      baseUrl: 'https://legacy.example.com',
+      authToken: 'legacy-token',
+      useAuthToken: true,
+    });
   });
 
   it('rejects with error when exchange fails (non-2xx response)', async () => {

--- a/webui/src/utils/__tests__/connectionConfig.test.ts
+++ b/webui/src/utils/__tests__/connectionConfig.test.ts
@@ -21,6 +21,10 @@ jest.mock('@/stores/servers', () => ({
 
 import { processConnectionFromHash, resolveCloudExchangeBaseUrl } from '../connectionConfig';
 
+const runtimeEnvWindow = window as typeof window & {
+  __GPTME_WEBUI_ENV__?: Record<string, string | undefined>;
+};
+
 describe('resolveCloudExchangeBaseUrl', () => {
   it('routes the managed app default through fleet for auth-code exchange', () => {
     expect(resolveCloudExchangeBaseUrl('https://gptme.ai')).toBe('https://fleet.gptme.ai');
@@ -68,6 +72,7 @@ describe('processConnectionFromHash', () => {
 
   afterEach(() => {
     global.fetch = originalFetch;
+    delete runtimeEnvWindow.__GPTME_WEBUI_ENV__;
   });
 
   it('posts auth-code exchange to fleet.gptme.ai by default', async () => {
@@ -95,6 +100,23 @@ describe('processConnectionFromHash', () => {
       authToken: 'token-123',
       useAuthToken: true,
     });
+  });
+
+  it('posts auth-code exchange to explicit browser runtime fleet URL', async () => {
+    runtimeEnvWindow.__GPTME_WEBUI_ENV__ = {
+      VITE_GPTME_FLEET_BASE_URL: 'http://fleet.gptme.local:8080',
+    };
+
+    await processConnectionFromHash('code=local-ci-code');
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://fleet.gptme.local:8080/api/v1/operator/auth/exchange',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ code: 'local-ci-code' }),
+      })
+    );
   });
 
   it('rejects with error when exchange fails (non-2xx response)', async () => {

--- a/webui/src/utils/connectionConfig.ts
+++ b/webui/src/utils/connectionConfig.ts
@@ -177,6 +177,7 @@ export function getConnectionConfigFromSources(hash?: string): ConnectionConfig 
       authToken: fragmentUserToken || null,
       useAuthToken: Boolean(fragmentUserToken),
     });
+    connectServer(server.id);
     setActiveServer(server.id);
 
     // Clean fragment from URL

--- a/webui/src/utils/connectionConfig.ts
+++ b/webui/src/utils/connectionConfig.ts
@@ -10,8 +10,18 @@ const DEFAULT_API_URL = 'http://127.0.0.1:5700';
 const DEFAULT_CLOUD_APP_BASE_URL = 'https://gptme.ai';
 const DEFAULT_CLOUD_EXCHANGE_BASE_URL = 'https://fleet.gptme.ai';
 
+declare global {
+  interface Window {
+    __GPTME_WEBUI_ENV__?: Record<string, string | undefined>;
+  }
+}
+
 function trimTrailingSlash(url: string): string {
   return url.replace(/\/+$/, '');
+}
+
+function isUnsetViteHtmlPlaceholder(value: string): boolean {
+  return /^%VITE_[A-Z0-9_]+%$/.test(value);
 }
 
 /**
@@ -26,30 +36,40 @@ export function isDemoMode(): boolean {
   return new URLSearchParams(window.location.search).get('demo') === '1';
 }
 
-// Vite statically replaces `import.meta.env.VITE_*` at build time for browser
-// bundles. Jest can't parse import.meta syntax (it's ESM-only), so we wrap it
-// in a Function() body to defer evaluation, then fall back to process.env
-// shimmed by jest.setup.ts. All three env vars (CLOUD_BASE_URL, FLEET_BASE_URL,
-// API_URL) will silently fall through to hardcoded defaults in browsers — a
-// known limitation also present in SetupWizard.tsx.
+// Browser builds can inject runtime env from index.html before this module
+// loads. Keep process.env fallback for Jest/Node tests; the Function() path is
+// retained only for compatibility with any bundler that supports it.
 function getEnvVar(name: string): string | undefined {
+  if (typeof window !== 'undefined') {
+    const value = window.__GPTME_WEBUI_ENV__?.[name];
+    if (value && !isUnsetViteHtmlPlaceholder(value)) {
+      return value;
+    }
+  }
+
   try {
-    return Function(`return import.meta.env.${name}`)() as string | undefined;
+    const value = Function(`return import.meta.env.${name}`)() as string | undefined;
+    if (value && !isUnsetViteHtmlPlaceholder(value)) {
+      return value;
+    }
   } catch {
     // Jest / Node runtime (import.meta not available)
     if (typeof process !== 'undefined' && process.env) {
-      return process.env[name];
+      const value = process.env[name];
+      if (value && !isUnsetViteHtmlPlaceholder(value)) {
+        return value;
+      }
     }
-    return undefined;
   }
+  return undefined;
 }
 
 // The browser auth UI lives on gptme.ai, but the auth-code exchange POST is
 // handled by the fleet operator. For custom single-origin deployments, keep the
 // previous "same origin" behavior unless an explicit fleet base URL is set.
-const CLOUD_APP_BASE_URL = trimTrailingSlash(
-  getEnvVar('VITE_GPTME_CLOUD_BASE_URL') || DEFAULT_CLOUD_APP_BASE_URL
-);
+function getCloudAppBaseUrl(): string {
+  return trimTrailingSlash(getEnvVar('VITE_GPTME_CLOUD_BASE_URL') || DEFAULT_CLOUD_APP_BASE_URL);
+}
 
 export function resolveCloudExchangeBaseUrl(
   cloudAppBaseUrl: string,
@@ -64,10 +84,9 @@ export function resolveCloudExchangeBaseUrl(
   return trimTrailingSlash(cloudAppBaseUrl);
 }
 
-const CLOUD_EXCHANGE_BASE_URL = resolveCloudExchangeBaseUrl(
-  CLOUD_APP_BASE_URL,
-  getEnvVar('VITE_GPTME_FLEET_BASE_URL')
-);
+function getCloudExchangeBaseUrl(): string {
+  return resolveCloudExchangeBaseUrl(getCloudAppBaseUrl(), getEnvVar('VITE_GPTME_FLEET_BASE_URL'));
+}
 
 export interface ConnectionConfig {
   baseUrl: string;
@@ -142,7 +161,7 @@ function getAuthCodeParams(hash?: string): { code: string } | null {
  * the managed-service default or the custom cloud app origin.
  */
 function getExchangeUrl(): string {
-  return `${CLOUD_EXCHANGE_BASE_URL}/api/v1/operator/auth/exchange`;
+  return `${getCloudExchangeBaseUrl()}/api/v1/operator/auth/exchange`;
 }
 
 export function getConnectionConfigFromSources(hash?: string): ConnectionConfig {

--- a/webui/src/utils/connectionConfig.ts
+++ b/webui/src/utils/connectionConfig.ts
@@ -1,5 +1,6 @@
 import {
   findOrCreateServerByUrl,
+  connectServer,
   getActiveServer,
   setActiveServer,
   updateServer,
@@ -223,6 +224,7 @@ export async function processConnectionFromHash(hash?: string): Promise<Connecti
         authToken: result.userToken,
         useAuthToken: true,
       });
+      connectServer(server.id);
       setActiveServer(server.id);
 
       // Clean fragment from URL


### PR DESCRIPTION
## Summary

Two bugs in the cloud gptme.ai chat flow that caused "No gptme server connected" on staging:

1. **`connectServer()` not called after auth-code exchange** (`19f9439`): `processConnectionFromHash()` was calling `findOrCreateServerByUrl` and `setActiveServer(id)` but NOT `connectServer(id)`. The webui registered the server but never initiated the connection — so the chat input stayed disabled.

2. **`CLOUD_EXCHANGE_BASE_URL` evaluated at module init** (`e6d7f1e`): The exchange URL was a module-level constant initialized before `window.__GPTME_WEBUI_ENV__` was populated. Converted to lazy functions (`getCloudAppBaseUrl()`, `getCloudExchangeBaseUrl()`) that read env vars at call time. Also adds `isUnsetViteHtmlPlaceholder()` to filter out literal `%VITE_FOO%` unresolved placeholders.

## Test plan

- [ ] E2E: gptme/gptme-cloud#648 exercises the full browser → fleet → pod → chat flow in minikube CI
- [ ] Unit tests in `webui/src/utils/__tests__/connectionConfig.test.ts` cover the lazy env var path

Closes: part of gptme/gptme-cloud#131