### PR TITLE
fix(webui): wait for artifact preview in tests

### DIFF
--- a/webui/src/components/__tests__/ArtifactsPanel.test.tsx
+++ b/webui/src/components/__tests__/ArtifactsPanel.test.tsx
@@ -81,7 +81,9 @@ describe('ArtifactsPanel', () => {
     });
 
     expect(mockListArtifacts).toHaveBeenCalledWith('conv-1', expect.any(AbortSignal));
-    expect(screen.getByTestId('file-preview')).toHaveTextContent('hero.png:nested/hero.png');
+    await waitFor(() => {
+      expect(screen.getByTestId('file-preview')).toHaveTextContent('hero.png:nested/hero.png');
+    });
   });
 
   it('routes the selected artifact to the workspace viewer', async () => {
@@ -127,7 +129,9 @@ describe('ArtifactsPanel', () => {
 
     // Toggle to the file preview.
     fireEvent.click(screen.getByRole('button', { name: 'Preview' }));
-    expect(screen.getByTestId('file-preview')).toHaveTextContent('app.py:app.py');
+    await waitFor(() => {
+      expect(screen.getByTestId('file-preview')).toHaveTextContent('app.py:app.py');
+    });
   });
 
   it('shows an error when artifact loading fails', async () => {


### PR DESCRIPTION
## Summary

- harden `ArtifactsPanel` tests to wait for the derived preview state
- keep the component behavior unchanged

## Root cause

The failing master WebUI run hit a React timing race: the test waited for the artifact list item, then immediately queried `file-preview`. `ArtifactsPanel` auto-selects the first artifact in a follow-up effect, so the DOM can briefly still show "Select an artifact to preview".

## Verification

- `npm test -- --runTestsByPath src/components/__tests__/ArtifactsPanel.test.tsx --runInBand`
- `npm test -- --runInBand`
- `npx prettier --check src/components/__tests__/ArtifactsPanel.test.tsx`
- `git diff --check -- webui/src/components/__tests__/ArtifactsPanel.test.tsx`
- `npm run typecheck`
- `npm run lint` (passes with existing warnings)
- `npm run build`
