### PR TITLE
fix(subagent): apply output_schema parsing in subagent_wait() (#554)

### DIFF
--- a/gptme/tools/subagent/api.py
+++ b/gptme/tools/subagent/api.py
@@ -1138,11 +1138,25 @@ def subagent_wait(
     status = cached_status if cached_status is not None else sa.status()
     result_dict = asdict(status)
 
+    # Apply output_schema parsing before truncation — the parsed object may be
+    # larger or smaller than the raw JSON string, so we measure truncation against
+    # the final result text, not the pre-parse raw.
+    if sa.output_schema is not None and result_dict.get("status") == "success":
+        from .batch import (
+            _parse_result,  # late import avoids circular (batch imports api)
+        )
+
+        result_dict = _parse_result(result_dict, sa.output_schema)
+
     # Compact result: truncate long outputs so they don't flood the parent's context.
     # The complete block is meant to be a brief summary; if it's longer than
     # max_result_chars the parent agent can call subagent_read_log() to get details.
     result_text = result_dict.get("result")
-    if result_text and max_result_chars > 0 and len(result_text) > max_result_chars:
+    if (
+        isinstance(result_text, str)
+        and max_result_chars > 0
+        and len(result_text) > max_result_chars
+    ):
         result_dict["result"] = (
             result_text[:max_result_chars]
             + f"\n... [truncated — call subagent_read_log('{agent_id}') for full output]"

--- a/gptme/tools/subagent/batch.py
+++ b/gptme/tools/subagent/batch.py
@@ -64,6 +64,11 @@ def _parse_result(result_dict: dict, output_schema: type | None) -> dict:
     if result_dict.get("status") != "success" or not result_text:
         return result_dict
 
+    # Already parsed (e.g. subagent_wait() parsed it when output_schema is set on
+    # the individual subagent); return as-is to avoid double-parsing.
+    if not isinstance(result_text, str):
+        return result_dict
+
     out = dict(result_dict)
     try:
         # Strip the log-path suffix that thread-mode _read_log() appends

--- a/gptme/tools/subagent/types.py
+++ b/gptme/tools/subagent/types.py
@@ -137,7 +137,7 @@ def set_subagent_result_if_absent(agent_id: str, result: "ReturnType") -> bool:
 @dataclass(frozen=True)
 class ReturnType:
     status: Status
-    result: str | None = None
+    result: str | dict[str, object] | None = None
     # Token budget tracking: LLM token counts for the subagent's run.
     # None means unavailable (e.g. cached terminal result, pre-budget-tracking log).
     input_tokens: int | None = None

--- a/tests/test_subagent_integration.py
+++ b/tests/test_subagent_integration.py
@@ -92,6 +92,7 @@ class TestCancelLifecycle:
         assert result is not None
         assert result.status == "failure"
         assert result.result is not None
+        assert isinstance(result.result, str)
         assert "cancelled" in result.result.lower()
 
         # Unblock the thread so it can exit cleanly.

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -3637,6 +3637,31 @@ class TestParseResult:
         result = _parse_result(d, Schema)
         assert result["result"] == original
 
+    def test_already_parsed_dict_returned_as_is(self):
+        """_parse_result is idempotent: already-parsed dict results pass through.
+
+        When subagent_wait() parses output_schema automatically (for direct callers),
+        then subagent_parallel() / BatchJob.wait_all() call _parse_result() a second
+        time on the already-parsed dict. This must not raise TypeError or inject a
+        spurious parse_error key.
+        """
+        from gptme.tools.subagent.batch import _parse_result
+
+        class Schema:
+            @classmethod
+            def model_validate(cls, obj):
+                return cls()
+
+            def model_dump(self):
+                return {"key": "value"}
+
+        parsed_dict = {"key": "value"}
+        d = {"status": "success", "result": parsed_dict}
+        result = _parse_result(d, Schema)
+        # Must not add parse_error, must not crash, must return result unchanged
+        assert "parse_error" not in result
+        assert result["result"] is parsed_dict
+
 
 class TestSubagentParallelOutputSchema:
     """Tests for output_schema support in subagent_parallel()."""

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -3478,7 +3478,8 @@ class TestOutputSchema:
         sa = self._make_subagent(tmp_path, content, output_schema=_SampleSchema)
         result = sa._read_log()
         assert result.status == "success"
-        parsed = json.loads((result.result or "").split("\n\nFull log:")[0])
+        assert isinstance(result.result, str)
+        parsed = json.loads(result.result.split("\n\nFull log:")[0])
         assert parsed == {"value": 7, "label": "ok"}
 
     def test_read_log_with_schema_invalid_json_still_succeeds(self, tmp_path, caplog):
@@ -3503,6 +3504,7 @@ class TestOutputSchema:
         assert "hello world" in (result.result or "")
         # Must NOT be interpreted as JSON
         assert result.result is not None
+        assert isinstance(result.result, str)
         assert result.result.startswith("hello world")
 
     def test_read_log_with_schema_empty_complete_tool_no_json_warning(

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -4354,3 +4354,172 @@ class TestTokenBudgetTracking:
         stats = job.total_tokens()
         assert stats["input_tokens"] is None
         assert stats["output_tokens"] is None
+
+
+class TestSubagentWaitOutputSchema:
+    """subagent_wait() applies output_schema parsing automatically (#554).
+
+    subagent_parallel() and subagent_batch().wait_all() already auto-parse
+    results against output_schema via _parse_result(). subagent_wait() should
+    do the same when the subagent was spawned with an output_schema so callers
+    don't need to call model_validate() separately.
+    """
+
+    def _make_subagent_with_schema(
+        self,
+        agent_id: str,
+        output_schema: type | None,
+        result_json: str,
+        tmp_path,
+    ):
+        """Helper: register a completed subagent that returned result_json."""
+        from gptme.tools.subagent.types import (
+            ReturnType,
+            Subagent,
+            _subagent_results,
+            _subagent_results_lock,
+            _subagents,
+            _subagents_lock,
+        )
+
+        logdir = tmp_path / agent_id
+        logdir.mkdir(parents=True)
+
+        sa = Subagent(
+            agent_id=agent_id,
+            prompt="test prompt",
+            thread=None,
+            logdir=logdir,
+            model=None,
+            output_schema=output_schema,
+        )
+        with _subagents_lock:
+            _subagents.append(sa)
+
+        result = ReturnType("success", result_json)
+        with _subagent_results_lock:
+            _subagent_results[agent_id] = result
+
+        return sa
+
+    def test_wait_parses_json_when_output_schema_set(self, tmp_path):
+        """subagent_wait() returns a parsed dict when output_schema is set."""
+        from pydantic import BaseModel
+
+        from gptme.tools.subagent.api import subagent_wait
+        from gptme.tools.subagent.types import (
+            _subagent_results,
+            _subagent_results_lock,
+            _subagents,
+            _subagents_lock,
+        )
+
+        class MySchema(BaseModel):
+            value: int
+            label: str
+
+        agent_id = "wait-schema-test"
+        try:
+            self._make_subagent_with_schema(
+                agent_id, MySchema, '{"value": 42, "label": "hello"}', tmp_path
+            )
+            result = subagent_wait(agent_id, timeout=1)
+            assert result["status"] == "success"
+            # _parse_result calls model_validate(...).model_dump(), so result is a dict
+            parsed = result["result"]
+            assert isinstance(parsed, dict)
+            assert parsed["value"] == 42
+            assert parsed["label"] == "hello"
+        finally:
+            with _subagents_lock:
+                _subagents[:] = [s for s in _subagents if s.agent_id != agent_id]
+            with _subagent_results_lock:
+                _subagent_results.pop(agent_id, None)
+
+    def test_wait_returns_raw_result_when_no_schema(self, tmp_path):
+        """subagent_wait() returns raw result string when no output_schema."""
+        from gptme.tools.subagent.api import subagent_wait
+        from gptme.tools.subagent.types import (
+            _subagent_results,
+            _subagent_results_lock,
+            _subagents,
+            _subagents_lock,
+        )
+
+        raw_json = '{"value": 42, "label": "hello"}'
+        agent_id = "wait-no-schema-test"
+        try:
+            self._make_subagent_with_schema(agent_id, None, raw_json, tmp_path)
+            result = subagent_wait(agent_id, timeout=1)
+            assert result["status"] == "success"
+            # Without schema, result is the raw string
+            assert result["result"] == raw_json
+        finally:
+            with _subagents_lock:
+                _subagents[:] = [s for s in _subagents if s.agent_id != agent_id]
+            with _subagent_results_lock:
+                _subagent_results.pop(agent_id, None)
+
+    def test_wait_adds_parse_error_on_invalid_json(self, tmp_path):
+        """subagent_wait() adds parse_error key if result isn't valid JSON."""
+        from pydantic import BaseModel
+
+        from gptme.tools.subagent.api import subagent_wait
+        from gptme.tools.subagent.types import (
+            _subagent_results,
+            _subagent_results_lock,
+            _subagents,
+            _subagents_lock,
+        )
+
+        class MySchema(BaseModel):
+            value: int
+
+        agent_id = "wait-bad-json-test"
+        try:
+            self._make_subagent_with_schema(
+                agent_id, MySchema, "not valid json at all", tmp_path
+            )
+            result = subagent_wait(agent_id, timeout=1)
+            assert result["status"] == "success"
+            # parse_error is added; result stays as-is
+            assert "parse_error" in result
+            assert result["result"] == "not valid json at all"
+        finally:
+            with _subagents_lock:
+                _subagents[:] = [s for s in _subagents if s.agent_id != agent_id]
+            with _subagent_results_lock:
+                _subagent_results.pop(agent_id, None)
+
+    def test_wait_skips_parsing_on_failure_status(self, tmp_path):
+        """subagent_wait() does not attempt schema parsing when status != success."""
+        from pydantic import BaseModel
+
+        from gptme.tools.subagent.api import subagent_wait
+        from gptme.tools.subagent.types import (
+            ReturnType,
+            _subagent_results,
+            _subagent_results_lock,
+            _subagents,
+            _subagents_lock,
+        )
+
+        class MySchema(BaseModel):
+            value: int
+
+        agent_id = "wait-failure-schema-test"
+        try:
+            self._make_subagent_with_schema(agent_id, MySchema, "irrelevant", tmp_path)
+            # Override the result to be a failure status
+            with _subagent_results_lock:
+                _subagent_results[agent_id] = ReturnType("failure", "error occurred")
+
+            result = subagent_wait(agent_id, timeout=1)
+            assert result["status"] == "failure"
+            # No parse_error should be added for non-success results
+            assert "parse_error" not in result
+        finally:
+            with _subagents_lock:
+                _subagents[:] = [s for s in _subagents if s.agent_id != agent_id]
+            with _subagent_results_lock:
+                _subagent_results.pop(agent_id, None)

--- a/tests/test_tools_subagent.py
+++ b/tests/test_tools_subagent.py
@@ -1005,6 +1005,7 @@ def test_subprocess_monitor_timeout():
     assert result is not None
     assert result.status == "failure"
     assert result.result is not None
+    assert isinstance(result.result, str)
     assert "timeout" in result.result.lower()
 
     # Cleanup


### PR DESCRIPTION
## Summary

- Makes `subagent_wait()` apply `output_schema` parsing automatically when the spawned subagent had `output_schema` set
- Closes the inconsistency where `subagent_parallel()` and `BatchJob.wait_all()` auto-parse results but `subagent_wait()` returned raw JSON strings
- Adds 4 unit tests covering: successful parse, no-schema passthrough, invalid JSON (parse_error key), and failure-status skip

## Motivation

After #554's improvements, users can pass `output_schema` to `subagent()` to get structured output. But the single-agent workflow was inconsistent:

```python
# subagent_parallel() auto-parses — callers get a dict:
results = subagent_parallel([('agent', 'prompt')], output_schema=MySchema, timeout=60)
# results[0]['result'] is a parsed dict

# subagent_wait() did NOT auto-parse — callers got raw JSON string:
subagent('agent', 'prompt', output_schema=MySchema)
result = subagent_wait('agent')
# result['result'] was still '{key: value}' — callers had to manually validate
```

Now both paths behave consistently. The late import of `_parse_result` from `batch.py` (inside the function body) avoids the circular dependency `batch → api → batch`.

## Test coverage

`TestSubagentWaitOutputSchema` (4 tests in `tests/test_subagent_unit.py`):
- `test_wait_parses_json_when_output_schema_set` — success path returns parsed dict
- `test_wait_returns_raw_result_when_no_schema` — no schema → passthrough unchanged
- `test_wait_adds_parse_error_on_invalid_json` — bad JSON → raw result + parse_error key
- `test_wait_skips_parsing_on_failure_status` — failure results skipped (matches batch behavior)

<!-- gptme-id:v1:gai_dpYw3tAx6hGzrTd9b6nzXZVNemhhCm9CB5DZTt5Nwwo -->