### PR TITLE
feat(eval): add 'Can it play Doom?' local milestone validation (#216)

### DIFF
--- a/gptme/eval/suites/computer.py
+++ b/gptme/eval/suites/computer.py
@@ -11,6 +11,7 @@ Validates end-to-end computer-use workflows:
 - Hover interaction: hover_element() for revealing hover-only menus/tooltips
 - Page state inspection: snapshot_page() after interactions, get_current_url() after navigation
 - "Can it Tweet?" end-to-end: full compose→post pipeline using a Twitter-like local fixture
+- "Can it play Doom?" end-to-end: keyboard-driven game-loop using a Doom-like local fixture
 
 These tests run without a physical display because they use Playwright's
 headless mode via the browser tool. Desktop/screenshot tests that require
@@ -122,6 +123,69 @@ _TWEET_COMPOSE_FIXTURE_HTML = (
 )
 _TWEET_COMPOSE_FIXTURE_URL = "data:text/html;base64," + base64.b64encode(
     _TWEET_COMPOSE_FIXTURE_HTML.encode()
+).decode("ascii")
+
+# "Can it play Doom?" fixture (issue #216 milestone).
+#
+# A self-contained keyboard-driven game that validates the full
+# "read state → press key → verify result" loop without requiring an X11
+# display or a real game binary.
+#
+# Game mechanics (readable via read_page_text / ARIA):
+#   - 7-cell 1-D battlefield rendered as text: . . . @ . . E
+#   - ArrowLeft / ArrowRight move the player (@) one cell
+#   - Space fires a bullet that travels toward the enemy (E)
+#   - When the bullet reaches the enemy the status div shows:
+#       doom-milestone:enemy-defeated score:100
+#
+# The "doom-milestone:enemy-defeated" marker is written only when the JS shoot
+# handler actually reaches the enemy cell, so read_page_text() cannot return
+# it from the initial page state.  Pressing Space once with the player
+# adjacent to the enemy (or with directional auto-aim) is enough to win.
+#
+# The same press_key() calls work against a real game running in the browser;
+# this fixture validates the tool-call pipeline without any external dep.
+_DOOM_MILESTONE_FIXTURE_HTML = (
+    "<!doctype html><html><head><title>gptme Doom Milestone Fixture</title>"
+    "<style>body{font-family:monospace;padding:20px;}"
+    "#game{font-size:24px;letter-spacing:8px;padding:10px;border:1px solid #333;display:inline-block;}"
+    "#status{margin-top:12px;font-size:14px;color:#444;}"
+    "#instructions{margin-top:8px;font-size:12px;color:#888;}</style></head><body>"
+    "<h2>Doom Milestone Fixture</h2>"
+    '<div id="game"></div>'
+    '<div id="status">doom-milestone:waiting score:0 player-at:3 enemy-at:6 enemy-alive:true</div>'
+    '<div id="instructions">ArrowLeft/ArrowRight: move player | Space: shoot</div>'
+    "<script>"
+    "var playerX=3,COLS=7,enemyX=6,enemyAlive=true,score=0,milestone='waiting';"
+    "function render(){"
+    "var row=[];"
+    "for(var i=0;i<COLS;i++) row.push('.');"
+    "if(enemyAlive) row[enemyX]='E';"
+    "row[playerX]='@';"
+    "document.getElementById('game').textContent=row.join(' ');"
+    "document.getElementById('status').textContent="
+    "'doom-milestone:'+milestone+' score:'+score+' player-at:'+playerX+' enemy-at:'+enemyX+' enemy-alive:'+enemyAlive;"
+    "}"
+    "function shoot(){"
+    "if(!enemyAlive) return;"
+    "var dir=enemyX>playerX?1:-1;"
+    "var pos=playerX+dir;"
+    "while(pos>=0&&pos<COLS){"
+    "if(pos===enemyX){enemyAlive=false;score=100;milestone='enemy-defeated';break;}"
+    "pos+=dir;}"
+    "}"
+    "document.addEventListener('keydown',function(e){"
+    "if(e.key==='ArrowLeft'){playerX=Math.max(0,playerX-1);e.preventDefault();}"
+    "else if(e.key==='ArrowRight'){playerX=Math.min(COLS-1,playerX+1);e.preventDefault();}"
+    "else if(e.key===' '){shoot();e.preventDefault();}"
+    "render();"
+    "});"
+    "render();"
+    "</script>"
+    "</body></html>"
+)
+_DOOM_MILESTONE_FIXTURE_URL = "data:text/html;base64," + base64.b64encode(
+    _DOOM_MILESTONE_FIXTURE_HTML.encode()
 ).decode("ascii")
 
 
@@ -399,6 +463,44 @@ def _expect_tweet_text_echoed(ctx) -> bool:
 def check_used_tweet_textarea(messages: list[Message]) -> bool:
     """Agent must address the tweet textarea by its Twitter data-testid selector."""
     return any("tweetTextarea_0" in code for code in _executed_tool_calls(messages))
+
+
+def _expect_doom_milestone_achieved(ctx) -> bool:
+    """The "Can it play Doom?" milestone check.
+
+    The fixture's JS shoot handler writes "doom-milestone:enemy-defeated" into
+    #status only after the player's bullet reaches the enemy cell.  It is not
+    present in the initial page text, so this cannot pass on narration or
+    unfired tool calls.
+    """
+    content = ctx.files.get("game.txt", ctx.stdout)
+    if isinstance(content, bytes):
+        content = content.decode(errors="replace")
+    return "doom-milestone:enemy-defeated" in content
+
+
+def _expect_doom_score_nonzero(ctx) -> bool:
+    """The score must be > 0, proving the enemy was actually hit."""
+    content = ctx.files.get("game.txt", ctx.stdout)
+    if isinstance(content, bytes):
+        content = content.decode(errors="replace")
+    return "score:100" in content
+
+
+def check_used_game_control_keys(messages: list[Message]) -> bool:
+    """Agent must press at least one game-control key (arrows or Space).
+
+    The "Can it play Doom?" flow requires the agent to actually drive the game
+    via press_key() rather than just reading the initial page state.  We
+    accept any of the four control keys: ArrowLeft, ArrowRight, ArrowUp,
+    ArrowDown, or Space (the shoot key).
+    """
+    _GAME_KEYS = {"ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown", "Space", " "}
+    for code in _executed_tool_calls(messages):
+        if "press_key" in code:
+            if any(k in code for k in _GAME_KEYS):
+                return True
+    return False
 
 
 # ---------------------------------------------------------------------------
@@ -749,6 +851,56 @@ tests: list["EvalSpec"] = [
             "used fill_element for tweet text": check_used_fill_element,
             "used click_element for Tweet button": check_used_click_element,
             "addressed compose box by Twitter data-testid": check_used_tweet_textarea,
+        },
+    },
+    # --- "Can it play Doom?" milestone (issue #216) ---
+    #
+    # End-to-end validation of the keyboard-driven game-loop using a
+    # self-contained Doom-like fixture: a 7-cell 1-D battlefield where the
+    # player (@) must shoot the enemy (E) using arrow keys + Space.
+    #
+    # The milestone marker "doom-milestone:enemy-defeated" only appears in the
+    # DOM after a real press_key(' ') fires the shoot handler and the bullet
+    # reaches the enemy cell.  It is absent from the initial page state, so
+    # read_page_text() cannot return it without the agent actually playing.
+    #
+    # This tests the core game-playing loop:
+    #   1. open_page → observe game state via read_page_text()
+    #   2. press_key(ArrowLeft/Right) → move player into position
+    #   3. press_key(' ') → fire
+    #   4. read_page_text() → confirm "doom-milestone:enemy-defeated"
+    #
+    # The same press_key() calls work against a real game in the browser once
+    # that game is open in the interactive browser session.
+    {
+        "name": "computer-use-web-doom-milestone",
+        "files": {},
+        "run": "cat game.txt",
+        "prompt": (
+            "You are in computer-use mode. Play a simple Doom-like game to hit the 'Can it play Doom?' milestone:\n"
+            f"1. Call open_page('{_DOOM_MILESTONE_FIXTURE_URL}') to open the game.\n"
+            "2. Call read_page_text() to read the current game state.\n"
+            "   The status line shows: 'doom-milestone:waiting score:0 player-at:3 enemy-at:6 enemy-alive:true'\n"
+            "   The game board shows: '. . . @ . . E'  (@ = player, E = enemy)\n"
+            "3. Move the player toward the enemy using press_key('ArrowRight') one or more times.\n"
+            "4. When the player is in position, call press_key(' ') (Space) to fire.\n"
+            "   You can also fire from any position — the bullet auto-aims toward the enemy.\n"
+            "5. Call read_page_text() to verify the result.\n"
+            "6. Write the full page text to game.txt."
+        ),
+        "tools": ["browser", "computer", "vision", "ipython", "save"],
+        "expect": {
+            "game.txt written": lambda ctx: (
+                "game.txt" in ctx.files or len(ctx.stdout.strip()) > 5
+            ),
+            "doom-milestone:enemy-defeated marker present": _expect_doom_milestone_achieved,
+            "score is 100 (enemy hit)": _expect_doom_score_nonzero,
+            "clean exit": _expect_clean_exit,
+        },
+        "check_log": {
+            "used open_page for navigation": check_used_open_page,
+            "used press_key for game control": check_used_game_control_keys,
+            "used press_key overall": check_used_press_key,
         },
     },
 ]

--- a/gptme/eval/suites/computer.py
+++ b/gptme/eval/suites/computer.py
@@ -19,6 +19,7 @@ an X11 display are not included here — they belong in manual or CI-with-displa
 pipelines.
 """
 
+import ast
 import base64
 import logging
 import re
@@ -141,8 +142,8 @@ _TWEET_COMPOSE_FIXTURE_URL = "data:text/html;base64," + base64.b64encode(
 #
 # The "doom-milestone:enemy-defeated" marker is written only when the JS shoot
 # handler actually reaches the enemy cell, so read_page_text() cannot return
-# it from the initial page state.  Pressing Space once with the player
-# adjacent to the enemy (or with directional auto-aim) is enough to win.
+# it from the initial page state.  Pressing Space once is enough to win because
+# the bullet auto-aims toward the enemy.
 #
 # The same press_key() calls work against a real game running in the browser;
 # this fixture validates the tool-call pipeline without any external dep.
@@ -178,7 +179,7 @@ _DOOM_MILESTONE_FIXTURE_HTML = (
     "document.addEventListener('keydown',function(e){"
     "if(e.key==='ArrowLeft'){playerX=Math.max(0,playerX-1);e.preventDefault();}"
     "else if(e.key==='ArrowRight'){playerX=Math.min(COLS-1,playerX+1);e.preventDefault();}"
-    "else if(e.key===' '){shoot();e.preventDefault();}"
+    "else if(e.key===' '||e.key==='Space'){shoot();e.preventDefault();}"
     "render();"
     "});"
     "render();"
@@ -488,19 +489,51 @@ def _expect_doom_score_nonzero(ctx) -> bool:
     return bool(re.search(r"score:([1-9]\d*)", content))
 
 
+def _press_key_values(code: str) -> list[str]:
+    try:
+        tree = ast.parse(code)
+    except SyntaxError:
+        return []
+
+    values: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        is_press_key = (
+            isinstance(func, ast.Name)
+            and func.id == "press_key"
+            or isinstance(func, ast.Attribute)
+            and func.attr == "press_key"
+        )
+        if not is_press_key:
+            continue
+
+        if node.args and isinstance(node.args[0], ast.Constant):
+            value = node.args[0].value
+            if isinstance(value, str):
+                values.append(value)
+        for keyword in node.keywords:
+            if keyword.arg == "key" and isinstance(keyword.value, ast.Constant):
+                value = keyword.value.value
+                if isinstance(value, str):
+                    values.append(value)
+    return values
+
+
 def check_used_game_control_keys(messages: list[Message]) -> bool:
     """Agent must press at least one game-control key (arrows or Space).
 
     The "Can it play Doom?" flow requires the agent to actually drive the game
     via press_key() rather than just reading the initial page state.  We
     accept any of the four control keys: ArrowLeft, ArrowRight, ArrowUp,
-    ArrowDown, or Space (the shoot key).
+    ArrowDown, or Space (the shoot key).  Both "Space" and the browser event
+    key value " " are accepted, but only as exact press_key() arguments.
     """
-    _GAME_KEYS = {"ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown", "Space"}
+    game_keys = {"ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown", "Space", " "}
     for code in _executed_tool_calls(messages):
-        if "press_key" in code:
-            if any(k in code for k in _GAME_KEYS):
-                return True
+        if any(key in game_keys for key in _press_key_values(code)):
+            return True
     return False
 
 
@@ -861,14 +894,14 @@ tests: list["EvalSpec"] = [
     # player (@) must shoot the enemy (E) using arrow keys + Space.
     #
     # The milestone marker "doom-milestone:enemy-defeated" only appears in the
-    # DOM after a real press_key(' ') fires the shoot handler and the bullet
-    # reaches the enemy cell.  It is absent from the initial page state, so
-    # read_page_text() cannot return it without the agent actually playing.
+    # DOM after a real press_key("Space") fires the shoot handler and the
+    # bullet reaches the enemy cell.  It is absent from the initial page state,
+    # so read_page_text() cannot return it without the agent actually playing.
     #
     # This tests the core game-playing loop:
     #   1. open_page → observe game state via read_page_text()
     #   2. press_key(ArrowLeft/Right) → move player into position
-    #   3. press_key(' ') → fire
+    #   3. press_key("Space") → fire
     #   4. read_page_text() → confirm "doom-milestone:enemy-defeated"
     #
     # The same press_key() calls work against a real game in the browser once
@@ -884,7 +917,7 @@ tests: list["EvalSpec"] = [
             "   The status line shows: 'doom-milestone:waiting score:0 player-at:3 enemy-at:6 enemy-alive:true'\n"
             "   The game board shows: '. . . @ . . E'  (@ = player, E = enemy)\n"
             "3. Move the player toward the enemy using press_key('ArrowRight') one or more times.\n"
-            "4. When the player is in position, call press_key(' ') (Space) to fire.\n"
+            "4. When the player is in position, call press_key('Space') to fire.\n"
             "   You can also fire from any position — the bullet auto-aims toward the enemy.\n"
             "5. Call read_page_text() to verify the result.\n"
             "6. Write the full page text to game.txt."

--- a/gptme/eval/suites/computer.py
+++ b/gptme/eval/suites/computer.py
@@ -170,6 +170,7 @@ _DOOM_MILESTONE_FIXTURE_HTML = (
     "}"
     "function shoot(){"
     "if(!enemyAlive) return;"
+    "if(playerX===enemyX){enemyAlive=false;score=100;milestone='enemy-defeated';return;}"
     "var dir=enemyX>playerX?1:-1;"
     "var pos=playerX+dir;"
     "while(pos>=0&&pos<COLS){"

--- a/gptme/eval/suites/computer.py
+++ b/gptme/eval/suites/computer.py
@@ -21,6 +21,7 @@ pipelines.
 
 import base64
 import logging
+import re
 import urllib.parse
 from typing import TYPE_CHECKING
 
@@ -484,7 +485,7 @@ def _expect_doom_score_nonzero(ctx) -> bool:
     content = ctx.files.get("game.txt", ctx.stdout)
     if isinstance(content, bytes):
         content = content.decode(errors="replace")
-    return "score:100" in content
+    return bool(re.search(r"score:([1-9]\d*)", content))
 
 
 def check_used_game_control_keys(messages: list[Message]) -> bool:
@@ -495,7 +496,7 @@ def check_used_game_control_keys(messages: list[Message]) -> bool:
     accept any of the four control keys: ArrowLeft, ArrowRight, ArrowUp,
     ArrowDown, or Space (the shoot key).
     """
-    _GAME_KEYS = {"ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown", "Space", " "}
+    _GAME_KEYS = {"ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown", "Space"}
     for code in _executed_tool_calls(messages):
         if "press_key" in code:
             if any(k in code for k in _GAME_KEYS):
@@ -900,7 +901,6 @@ tests: list["EvalSpec"] = [
         "check_log": {
             "used open_page for navigation": check_used_open_page,
             "used press_key for game control": check_used_game_control_keys,
-            "used press_key overall": check_used_press_key,
         },
     },
 ]

--- a/tests/test_eval_computer_suite.py
+++ b/tests/test_eval_computer_suite.py
@@ -1100,12 +1100,32 @@ def test_check_used_game_control_keys_space_explicit(monkeypatch):
     assert computer_suite.check_used_game_control_keys([])
 
 
+def test_check_used_game_control_keys_keyword_arg(monkeypatch):
+    """Keyword form still counts when the key value is a game control key."""
+    monkeypatch.setattr(
+        computer_suite,
+        "_executed_tool_calls",
+        lambda messages: ["press_key(key='Space')"],
+    )
+    assert computer_suite.check_used_game_control_keys([])
+
+
 def test_check_used_game_control_keys_rejects_enter(monkeypatch):
     """Enter is not a game control key for this fixture."""
     monkeypatch.setattr(
         computer_suite,
         "_executed_tool_calls",
         lambda messages: ["press_key('Enter')"],
+    )
+    assert not computer_suite.check_used_game_control_keys([])
+
+
+def test_check_used_game_control_keys_rejects_enter_with_whitespace(monkeypatch):
+    """Whitespace in a non-game press_key call is not itself a Space key."""
+    monkeypatch.setattr(
+        computer_suite,
+        "_executed_tool_calls",
+        lambda messages: ["result = press_key('Enter')  # submit form"],
     )
     assert not computer_suite.check_used_game_control_keys([])
 

--- a/tests/test_eval_computer_suite.py
+++ b/tests/test_eval_computer_suite.py
@@ -1000,3 +1000,156 @@ def test_tweet_compose_eval_spec_present():
     assert "computer-use-web-tweet-compose" in names, (
         f"'computer-use-web-tweet-compose' not in eval specs: {names}"
     )
+
+
+# ---------------------------------------------------------------------------
+# "Can it play Doom?" milestone tests
+# ---------------------------------------------------------------------------
+
+
+def test_expect_doom_milestone_achieved_from_file():
+    """Milestone check passes when game.txt contains the marker."""
+    ctx = ResultContext(
+        files={
+            "game.txt": "doom-milestone:enemy-defeated score:100 player-at:5 enemy-at:6 enemy-alive:false"
+        },
+        stdout="",
+        stderr="",
+        exit_code=0,
+    )
+    assert computer_suite._expect_doom_milestone_achieved(ctx)
+
+
+def test_expect_doom_milestone_achieved_from_stdout():
+    """Milestone check passes when stdout contains the marker (no file written)."""
+    ctx = ResultContext(
+        files={},
+        stdout="doom-milestone:enemy-defeated score:100 player-at:5 enemy-at:6 enemy-alive:false",
+        stderr="",
+        exit_code=0,
+    )
+    assert computer_suite._expect_doom_milestone_achieved(ctx)
+
+
+def test_expect_doom_milestone_achieved_fails_waiting():
+    """Milestone check fails when status is still 'waiting' (no shot taken)."""
+    ctx = ResultContext(
+        files={
+            "game.txt": "doom-milestone:waiting score:0 player-at:3 enemy-at:6 enemy-alive:true"
+        },
+        stdout="",
+        stderr="",
+        exit_code=0,
+    )
+    assert not computer_suite._expect_doom_milestone_achieved(ctx)
+
+
+def test_expect_doom_milestone_achieved_fails_empty():
+    ctx = ResultContext(files={}, stdout="", stderr="", exit_code=0)
+    assert not computer_suite._expect_doom_milestone_achieved(ctx)
+
+
+def test_expect_doom_score_nonzero_from_file():
+    """Score check passes when score:100 appears in output."""
+    ctx = ResultContext(
+        files={"game.txt": "doom-milestone:enemy-defeated score:100"},
+        stdout="",
+        stderr="",
+        exit_code=0,
+    )
+    assert computer_suite._expect_doom_score_nonzero(ctx)
+
+
+def test_expect_doom_score_nonzero_fails_zero():
+    ctx = ResultContext(
+        files={"game.txt": "doom-milestone:waiting score:0"},
+        stdout="",
+        stderr="",
+        exit_code=0,
+    )
+    assert not computer_suite._expect_doom_score_nonzero(ctx)
+
+
+def test_check_used_game_control_keys_arrow_right(monkeypatch):
+    """ArrowRight press counts as a game control key."""
+    monkeypatch.setattr(
+        computer_suite,
+        "_executed_tool_calls",
+        lambda messages: ["press_key('ArrowRight')"],
+    )
+    assert computer_suite.check_used_game_control_keys([])
+
+
+def test_check_used_game_control_keys_space(monkeypatch):
+    """Space (shoot key) counts as a game control key."""
+    monkeypatch.setattr(
+        computer_suite,
+        "_executed_tool_calls",
+        lambda messages: ["press_key(' ')"],
+    )
+    assert computer_suite.check_used_game_control_keys([])
+
+
+def test_check_used_game_control_keys_space_explicit(monkeypatch):
+    """'Space' string (Playwright key name) counts as a game control key."""
+    monkeypatch.setattr(
+        computer_suite,
+        "_executed_tool_calls",
+        lambda messages: ["press_key('Space')"],
+    )
+    assert computer_suite.check_used_game_control_keys([])
+
+
+def test_check_used_game_control_keys_rejects_enter(monkeypatch):
+    """Enter is not a game control key for this fixture."""
+    monkeypatch.setattr(
+        computer_suite,
+        "_executed_tool_calls",
+        lambda messages: ["press_key('Enter')"],
+    )
+    assert not computer_suite.check_used_game_control_keys([])
+
+
+def test_check_used_game_control_keys_rejects_no_press_key(monkeypatch):
+    """fill_element calls are not game control keys."""
+    monkeypatch.setattr(
+        computer_suite,
+        "_executed_tool_calls",
+        lambda messages: ["fill_element('#msg', 'hello')"],
+    )
+    assert not computer_suite.check_used_game_control_keys([])
+
+
+def test_doom_milestone_fixture_has_initial_waiting_state():
+    """The fixture must start in 'waiting' state (marker absent from static HTML)."""
+    html = computer_suite._DOOM_MILESTONE_FIXTURE_HTML
+    # The status div starts as 'waiting', not 'enemy-defeated'
+    assert "doom-milestone:waiting" in html
+    # enemy-defeated must NOT appear in the initial static HTML
+    assert "doom-milestone:enemy-defeated" not in html
+
+
+def test_doom_milestone_fixture_has_keyboard_listener():
+    """The fixture must attach a keydown listener for game control."""
+    html = computer_suite._DOOM_MILESTONE_FIXTURE_HTML
+    assert "keydown" in html
+    assert "ArrowLeft" in html
+    assert "ArrowRight" in html
+
+
+def test_doom_milestone_prompt_does_not_leak_marker():
+    """The agent must read the page to discover the marker, not copy it from the prompt."""
+    spec = next(
+        test
+        for test in computer_suite.tests
+        if test["name"] == "computer-use-web-doom-milestone"
+    )
+    assert "doom-milestone:enemy-defeated" not in spec["prompt"]
+
+
+def test_doom_milestone_eval_spec_present():
+    """The 'Can it play Doom?' eval spec must be registered in the tests list."""
+    names = [t["name"] for t in computer_suite.tests]
+    assert "computer-use-web-doom-milestone" in names, (
+        f"'computer-use-web-doom-milestone' not in eval specs: {names}"
+    )

--- a/tests/test_eval_computer_suite.py
+++ b/tests/test_eval_computer_suite.py
@@ -1157,6 +1157,13 @@ def test_doom_milestone_fixture_has_keyboard_listener():
     assert "ArrowRight" in html
 
 
+def test_doom_milestone_fixture_shoots_when_player_reaches_enemy_cell():
+    """Auto-aim must still hit if the player moves onto the enemy cell."""
+    html = computer_suite._DOOM_MILESTONE_FIXTURE_HTML
+    assert "if(playerX===enemyX)" in html
+    assert "milestone='enemy-defeated';return;" in html
+
+
 def test_doom_milestone_prompt_does_not_leak_marker():
     """The agent must read the page to discover the marker, not copy it from the prompt."""
     spec = next(


### PR DESCRIPTION
## Summary

Adds a self-contained eval test `computer-use-web-doom-milestone` that directly validates the issue #216 **"Can it play Doom?"** milestone using a local HTML fixture — no real game binary, display, or X11 environment needed.

### What this PR does

**Game fixture** (`_DOOM_MILESTONE_FIXTURE_HTML`):
- A 7-cell 1-D Doom-like battlefield rendered as text: `. . . @ . . E` (@ = player, E = enemy)
- ArrowLeft / ArrowRight move the player; Space fires a bullet that auto-aims toward the enemy
- When the bullet reaches the enemy the status div shows: `doom-milestone:enemy-defeated score:100`
- The marker is absent from the initial HTML — it only appears after a real `press_key(' ')` fires the JS shoot handler and the bullet traverses to the enemy cell

**New eval test** (`computer-use-web-doom-milestone` in `gptme/eval/suites/computer.py`):
- Opens the fixture via `open_page()`
- Agent reads game state with `read_page_text()`: status shows `doom-milestone:waiting score:0 player-at:3 enemy-at:6`
- Agent uses `press_key('ArrowRight')` to position the player and `press_key(' ')` to fire
- Verifies `doom-milestone:enemy-defeated score:100` appears after the shot
- `check_used_game_control_keys` enforces that arrows or Space were actually pressed (agent can't narrate its way past this)

**New check functions:**
- `_expect_doom_milestone_achieved` — marker-based confirmation, same pattern as `_expect_tweet_posted`
- `_expect_doom_score_nonzero` — `score:100` proves the enemy was actually hit
- `check_used_game_control_keys` — enforces agent pressed a game-control key (ArrowLeft/Right/Up/Down or Space)

**17 new unit tests** in `tests/test_eval_computer_suite.py`:
- All new check functions tested for both passing and failing cases
- Fixture structural invariants: `doom-milestone:enemy-defeated` absent from initial HTML, `keydown` listener present, prompt doesn't leak the success marker
- `test_doom_milestone_eval_spec_present` — spec is registered in the tests list

### Why this matters

The "Can it play Doom?" milestone has been on the issue's unchecked list since the issue was opened. All the underlying tools work (`press_key`, `open_page`, `read_page_text`), but there was no eval test validating them in the game-control loop. This PR closes that gap with a verifiable, network-free test following the same pattern as the "Can it Tweet?" eval (#3112).

The same `press_key()` calls work against a real game running in the browser once that game is open in the interactive browser session.

## Test plan

- [x] `uv run pytest tests/test_eval_computer_suite.py -q` → 113 passed (17 new)
- [x] `uv run pytest tests/test_computer_audit.py tests/test_profiles.py -q` → all pass
- [ ] Full live eval run: `gptme-eval --suite computer-use-web-doom-milestone` (requires Playwright)

Closes part of #216

<!-- gptme-id:v1:gai_OPlewhO3vA67sxUwDzbsPI4cMTxqqU2C7E31CHTaaiQ -->