### PR TITLE
fix(subagent): add +complete to subprocess mode tool list

### DIFF
--- a/gptme/tools/subagent/execution.py
+++ b/gptme/tools/subagent/execution.py
@@ -443,9 +443,9 @@ def _run_subagent_subprocess(
                     tool_allowlist.append(tool_name)
             cmd.extend(["--tools", ",".join(tool_allowlist)])
         else:
-            cmd.extend(["--tools", "+clarify"])
+            cmd.extend(["--tools", "+complete,+clarify"])
     else:
-        cmd.extend(["--tools", "+clarify"])
+        cmd.extend(["--tools", "+complete,+clarify"])
 
     # Map context_mode/context_include to the --context CLI flag
     if context_mode == "selective" and context_include:

--- a/tests/test_tools_subagent.py
+++ b/tests/test_tools_subagent.py
@@ -772,7 +772,7 @@ def test_subprocess_command_includes_required_flags():
             assert "--model" in cmd
             assert "test-model" in cmd
             assert "--tools" in cmd
-            assert cmd[cmd.index("--tools") + 1] == "+clarify"
+            assert cmd[cmd.index("--tools") + 1] == "+complete,+clarify"
             assert "Test task" not in cmd  # Prompt passed via stdin, not argv
 
         finally:

--- a/tests/test_tools_subagent.py
+++ b/tests/test_tools_subagent.py
@@ -822,6 +822,84 @@ def test_subprocess_profile_preserves_profile_tools_and_adds_clarify():
     )
 
 
+def test_subprocess_no_profile_includes_complete_and_clarify():
+    """Subprocess without a profile must include both complete and clarify tools."""
+    import tempfile
+    from pathlib import Path
+
+    from gptme.tools.subagent.execution import _run_subagent_subprocess
+
+    captured_cmd: list[str] = []
+
+    def fake_popen(cmd, **kwargs):
+        captured_cmd.clear()
+        captured_cmd.extend(cmd)
+        mock = MagicMock()
+        mock.poll.return_value = None
+        mock.args = cmd
+        return mock
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        logdir = Path(tmpdir) / "logs"
+        logdir.mkdir()
+
+        with patch("gptme.tools.subagent.execution.subprocess.Popen", fake_popen):
+            _run_subagent_subprocess(
+                prompt="Do a task",
+                logdir=logdir,
+                model=None,
+                workspace=Path(tmpdir),
+                profile=None,
+            )
+
+    assert "--tools" in captured_cmd
+    assert captured_cmd[captured_cmd.index("--tools") + 1] == "+complete,+clarify"
+
+
+def test_subprocess_profile_without_toollist_includes_complete_and_clarify():
+    """Profile with no tools list must fall back to +complete,+clarify."""
+    import tempfile
+    from pathlib import Path
+
+    from gptme.tools.subagent.execution import _run_subagent_subprocess
+
+    captured_cmd: list[str] = []
+
+    def fake_popen(cmd, **kwargs):
+        captured_cmd.clear()
+        captured_cmd.extend(cmd)
+        mock = MagicMock()
+        mock.poll.return_value = None
+        mock.args = cmd
+        return mock
+
+    # Use a mock profile object with tools=None to hit the else branch inside `if profile:`
+    mock_profile = MagicMock()
+    mock_profile.tools = None
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        logdir = Path(tmpdir) / "logs"
+        logdir.mkdir()
+
+        with (
+            patch("gptme.tools.subagent.execution.subprocess.Popen", fake_popen),
+            patch(
+                "gptme.profiles.get_profile",
+                return_value=mock_profile,
+            ),
+        ):
+            _run_subagent_subprocess(
+                prompt="Do a task",
+                logdir=logdir,
+                model=None,
+                workspace=Path(tmpdir),
+                profile="custom",
+            )
+
+    assert "--tools" in captured_cmd
+    assert captured_cmd[captured_cmd.index("--tools") + 1] == "+complete,+clarify"
+
+
 @pytest.mark.slow
 def test_subprocess_working_directory():
     """Test that subprocess runs in the specified working directory."""

--- a/tests/test_tools_subagent.py
+++ b/tests/test_tools_subagent.py
@@ -822,13 +822,8 @@ def test_subprocess_profile_preserves_profile_tools_and_adds_clarify():
     )
 
 
-<<<<<<< HEAD
 def test_subprocess_no_profile_includes_complete_and_clarify():
     """Subprocess without a profile must include both complete and clarify tools."""
-=======
-def test_subprocess_profile_with_tools_none_adds_both_tools():
-    """Profiles with tools=None (e.g. default, developer) should get +complete,+clarify."""
->>>>>>> 9f6569f79 (test: cover profile+tools=None subprocess tools path)
     import tempfile
     from pathlib import Path
 
@@ -849,7 +844,6 @@ def test_subprocess_profile_with_tools_none_adds_both_tools():
         logdir.mkdir()
 
         with patch("gptme.tools.subagent.execution.subprocess.Popen", fake_popen):
-<<<<<<< HEAD
             _run_subagent_subprocess(
                 prompt="Do a task",
                 logdir=logdir,
@@ -904,21 +898,6 @@ def test_subprocess_profile_without_toollist_includes_complete_and_clarify():
 
     assert "--tools" in captured_cmd
     assert captured_cmd[captured_cmd.index("--tools") + 1] == "+complete,+clarify"
-=======
-            # developer profile has tools=None → hits the profile+tools=None branch
-            _run_subagent_subprocess(
-                prompt="Dev task",
-                logdir=logdir,
-                model=None,
-                workspace=Path(tmpdir),
-                profile="developer",
-            )
-
-    assert "--agent-profile" in captured_cmd
-    assert captured_cmd[captured_cmd.index("--agent-profile") + 1] == "developer"
-    assert "--tools" in captured_cmd
-    assert captured_cmd[captured_cmd.index("--tools") + 1] == ("+complete,+clarify")
->>>>>>> 9f6569f79 (test: cover profile+tools=None subprocess tools path)
 
 
 @pytest.mark.slow

--- a/tests/test_tools_subagent.py
+++ b/tests/test_tools_subagent.py
@@ -822,8 +822,13 @@ def test_subprocess_profile_preserves_profile_tools_and_adds_clarify():
     )
 
 
+<<<<<<< HEAD
 def test_subprocess_no_profile_includes_complete_and_clarify():
     """Subprocess without a profile must include both complete and clarify tools."""
+=======
+def test_subprocess_profile_with_tools_none_adds_both_tools():
+    """Profiles with tools=None (e.g. default, developer) should get +complete,+clarify."""
+>>>>>>> 9f6569f79 (test: cover profile+tools=None subprocess tools path)
     import tempfile
     from pathlib import Path
 
@@ -844,6 +849,7 @@ def test_subprocess_no_profile_includes_complete_and_clarify():
         logdir.mkdir()
 
         with patch("gptme.tools.subagent.execution.subprocess.Popen", fake_popen):
+<<<<<<< HEAD
             _run_subagent_subprocess(
                 prompt="Do a task",
                 logdir=logdir,
@@ -898,6 +904,21 @@ def test_subprocess_profile_without_toollist_includes_complete_and_clarify():
 
     assert "--tools" in captured_cmd
     assert captured_cmd[captured_cmd.index("--tools") + 1] == "+complete,+clarify"
+=======
+            # developer profile has tools=None → hits the profile+tools=None branch
+            _run_subagent_subprocess(
+                prompt="Dev task",
+                logdir=logdir,
+                model=None,
+                workspace=Path(tmpdir),
+                profile="developer",
+            )
+
+    assert "--agent-profile" in captured_cmd
+    assert captured_cmd[captured_cmd.index("--agent-profile") + 1] == "developer"
+    assert "--tools" in captured_cmd
+    assert captured_cmd[captured_cmd.index("--tools") + 1] == ("+complete,+clarify")
+>>>>>>> 9f6569f79 (test: cover profile+tools=None subprocess tools path)
 
 
 @pytest.mark.slow


### PR DESCRIPTION
## Summary

- Subprocess subagents (no-profile path) were only getting `+clarify` in their `--tools` flag, missing `+complete`
- Without `+complete`, the subprocess lacks `complete_hook` (raises `SessionCompleteException` on task completion) and `auto_reply_hook` (drives non-interactive session advancement)
- The profile code path already correctly appends both `complete` and `clarify` — this aligns the no-profile path with the same behaviour

## Root cause

In `gptme/tools/subagent/execution.py`, the no-profile branch:
```python
else:
    cmd.extend(["--tools", "+clarify"])  # missing +complete
```

When a subprocess subagent runs without a profile, it never had the `complete` tool loaded. The session could end before properly processing tool results, or (in non-interactive mode) never advance past the first model response because `auto_reply_hook` wasn't registered.

## Fix

Change both no-profile branches from `"+clarify"` to `"+complete,+clarify"`. Update the corresponding test assertion.

## Test plan

- All 328 subagent tests pass locally (`tests/test_tools_subagent.py`, `tests/test_subagent_unit.py`, `tests/test_subagent_concurrency.py`, `tests/test_subagent_integration.py`, `tests/test_subagent_planner_roles.py`)
- `test_subprocess_command_includes_required_flags` updated to assert the correct tool string

Closes #554