### PR TITLE
fix(computer): auto-detect native transport in latency diagnostic (#216)

### DIFF
--- a/gptme/cli/cmd_computer.py
+++ b/gptme/cli/cmd_computer.py
@@ -971,9 +971,8 @@ def latency_cmd(shots: int, as_json: bool, display: str | None):
             import platform
 
             _display = os.environ.get("DISPLAY")
-            if platform.system() == "Linux" and _display:
-                transport = NativeComputerTransport()
-            elif platform.system() == "Darwin":
+            _system = platform.system()
+            if (_system == "Linux" and _display) or _system == "Darwin":
                 transport = NativeComputerTransport()
             else:
                 click.echo(

--- a/gptme/cli/cmd_computer.py
+++ b/gptme/cli/cmd_computer.py
@@ -958,17 +958,31 @@ def latency_cmd(shots: int, as_json: bool, display: str | None):
         os.environ["DISPLAY"] = display
 
     try:
-        from ..tools.computer_transport import get_transport  # lazy import
+        from ..tools.computer_transport import (  # lazy import
+            NativeComputerTransport,
+            get_transport,
+        )
 
         transport = get_transport()
         if transport is None:
-            click.echo(
-                "Error: no display available — start an X11 display or set $DISPLAY.\n"
-                "  Xvfb :1 -screen 0 1024x768x24 &\n"
-                "  export DISPLAY=:1",
-                err=True,
-            )
-            sys.exit(1)
+            # No transport explicitly configured — auto-detect native X11/macOS.
+            # This lets `gptme-util computer latency` work without requiring the
+            # user to set GPTME_COMPUTER_TRANSPORT=native first (#216).
+            import platform
+
+            _display = os.environ.get("DISPLAY")
+            if platform.system() == "Linux" and _display:
+                transport = NativeComputerTransport()
+            elif platform.system() == "Darwin":
+                transport = NativeComputerTransport()
+            else:
+                click.echo(
+                    "Error: no display available — start an X11 display or set $DISPLAY.\n"
+                    "  Xvfb :1 -screen 0 1024x768x24 &\n"
+                    "  export DISPLAY=:1",
+                    err=True,
+                )
+                sys.exit(1)
 
         # Warm up: take one shot to initialise any lazy state so the first measured
         # shot isn't artificially slow due to module imports or file descriptor setup.

--- a/tests/test_computer_latency_cmd.py
+++ b/tests/test_computer_latency_cmd.py
@@ -47,7 +47,10 @@ class TestLatencyCmd:
     def test_no_display_exits_1(self, monkeypatch):
         """When no transport is available, exit with code 1."""
         monkeypatch.delenv("DISPLAY", raising=False)
-        with patch("gptme.tools.computer_transport.get_transport", return_value=None):
+        with (
+            patch("gptme.tools.computer_transport.get_transport", return_value=None),
+            patch("platform.system", return_value="Linux"),
+        ):
             runner = CliRunner()
             result = runner.invoke(latency_cmd, [])
         assert result.exit_code == 1

--- a/tests/test_computer_latency_cmd.py
+++ b/tests/test_computer_latency_cmd.py
@@ -236,6 +236,7 @@ class TestLatencyCmd:
 
         with (
             patch("gptme.tools.computer_transport.get_transport", return_value=None),
+            patch("platform.system", return_value="Linux"),
             patch(
                 "gptme.tools.computer_transport.NativeComputerTransport",
                 return_value=native_transport,

--- a/tests/test_computer_latency_cmd.py
+++ b/tests/test_computer_latency_cmd.py
@@ -221,3 +221,38 @@ class TestLatencyCmd:
         assert result.exit_code == 0
         # Either health tag should appear
         assert any(marker in result.output for marker in ("✓", "⚠", "✗"))
+
+    def test_autodetects_native_transport_when_display_set(self, tmp_path, monkeypatch):
+        """When get_transport() returns None but DISPLAY is set, auto-use NativeComputerTransport.
+
+        Fixes #216: previously the latency command failed with "no display available"
+        even when X11 was running, unless GPTME_COMPUTER_TRANSPORT=native was set explicitly.
+        """
+        monkeypatch.setenv("DISPLAY", ":1")
+        native_transport = _make_transport_mock(tmp_path, shot_duration_s=0.001)
+
+        with (
+            patch("gptme.tools.computer_transport.get_transport", return_value=None),
+            patch(
+                "gptme.tools.computer_transport.NativeComputerTransport",
+                return_value=native_transport,
+            ),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(latency_cmd, ["--shots", "1", "--json"])
+
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["successful"] == 1
+
+    def test_no_display_no_transport_exits_1(self, monkeypatch):
+        """No DISPLAY + no transport → exits with an actionable error."""
+        monkeypatch.delenv("DISPLAY", raising=False)
+        with (
+            patch("gptme.tools.computer_transport.get_transport", return_value=None),
+            patch("platform.system", return_value="Linux"),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(latency_cmd, [])
+
+        assert result.exit_code == 1


### PR DESCRIPTION
## Problem

`gptme-util computer latency` exits with a misleading **"no display available"** error even when X11 is running and `xdotool` is installed — because it requires `GPTME_COMPUTER_TRANSPORT=native` to be set explicitly before it creates any transport.

```bash
# Before this fix — fails even with DISPLAY=:1 set
$ DISPLAY=:1 gptme-util computer latency
Error: no display available — start an X11 display or set $DISPLAY.
  Xvfb :1 -screen 0 1024x768x24 &
  export DISPLAY=:1

# After — works out of the box
$ DISPLAY=:1 gptme-util computer latency
  shot  1/3:   59.8 ms
  shot  2/3:   59.6 ms
  shot  3/3:   59.0 ms
Screenshot latency (3/3 successful): min 59.0 ms | median 59.6 ms | max 59.8 ms
✓ Latency is healthy (< 100 ms)
```

This addresses the **"figure out what is causing the delays"** checklist item from issue #216: the diagnostic was supposed to help users debug latency issues, but couldn't even run without knowing about an undocumented env var.

## Fix

When `get_transport()` returns `None` (no explicit transport configured), the latency command now auto-creates a `NativeComputerTransport` if:
- **Linux**: `$DISPLAY` is set
- **macOS**: always (cliclick is the native backend)

Falls back to the original error only when no display is genuinely available.

## Tests

- Added `test_autodetects_native_transport_when_display_set` — verifies `NativeComputerTransport` is created automatically when `get_transport()` returns `None` but `DISPLAY` is set.
- Added `test_no_display_no_transport_exits_1` — verifies the error path still fires when there's truly no display.
- All 14 latency tests pass; 563 other tests unaffected.

Closes #3116 (if created) / part of #216

<!-- gptme-id:v1:gai_2PhOmTYMysFRZdFyROaAnbdfbNi1llFpx7B4Aaw8flF -->