### PR TITLE
feat(computer): add `gptme-util computer doctor` health-check command (#216)

### DIFF
--- a/gptme/cli/cmd_computer.py
+++ b/gptme/cli/cmd_computer.py
@@ -1069,3 +1069,246 @@ def latency_cmd(shots: int, as_json: bool, display: str | None):
                 os.environ.pop("DISPLAY", None)
             else:
                 os.environ["DISPLAY"] = original_display
+
+
+# ---------------------------------------------------------------------------
+# doctor command
+# ---------------------------------------------------------------------------
+
+_PASS = click.style("✓", fg="green")
+_WARN = click.style("!", fg="yellow")
+_FAIL = click.style("✗", fg="red")
+
+
+def _check(label: str, ok: bool, warn: bool = False, hint: str = "") -> bool:
+    """Print one doctor check line and return True if it passed."""
+    if ok:
+        click.echo(f"  {_PASS}  {label}")
+    elif warn:
+        click.echo(f"  {_WARN}  {label}" + (f"\n       {hint}" if hint else ""))
+    else:
+        click.echo(f"  {_FAIL}  {label}" + (f"\n       {hint}" if hint else ""))
+    return ok
+
+
+@computer.command("doctor")
+@click.option(
+    "--display",
+    default=None,
+    metavar="DISPLAY",
+    help="X11 display string (Linux only). Defaults to $DISPLAY.",
+)
+def doctor_cmd(display: str | None):
+    """Check computer-use prerequisites and report what is (not) working.
+
+    Verifies that all required system tools, Python packages, and display
+    infrastructure are available for the ``computer`` and ``browser`` tools.
+
+    This command directly addresses the "figure out what is causing the delays"
+    checklist item in gptme/gptme#216 by surfacing missing dependencies and
+    reporting a screenshot latency sample.
+
+    Examples::
+
+        # Check current setup
+        gptme-util computer doctor
+
+        # Check a specific X11 display
+        gptme-util computer doctor --display :1
+    """
+    import platform
+    import statistics
+    import time
+
+    system = platform.system()
+    errors = 0
+
+    click.echo("Computer-use doctor\n")
+
+    # --- Platform ---
+    click.echo(f"Platform: {system} ({platform.machine()})\n")
+
+    # --- Display / X11 (Linux) ---
+    if system == "Linux":
+        click.echo("Display:")
+        effective_display = display or os.environ.get("DISPLAY", "")
+        ok_display = bool(effective_display)
+        if not _check(
+            f"$DISPLAY={effective_display!r}" if ok_display else "$DISPLAY not set",
+            ok=ok_display,
+            hint="Start Xvfb:  Xvfb :1 -screen 0 1024x768x24 &  && export DISPLAY=:1",
+        ):
+            errors += 1
+
+        ok_xdotool = bool(shutil.which("xdotool"))
+        if not _check(
+            "xdotool installed" if ok_xdotool else "xdotool not found (mouse/keyboard)",
+            ok=ok_xdotool,
+            hint="sudo apt install xdotool",
+        ):
+            errors += 1
+
+        ok_scrot = bool(shutil.which("scrot"))
+        ok_ffmpeg_scap = bool(shutil.which("ffmpeg"))
+        # scrot is preferred; ffmpeg fallback works too
+        if ok_scrot:
+            _check("scrot installed (screenshot backend)", ok=True)
+        elif ok_ffmpeg_scap:
+            _check("scrot not found, ffmpeg available (fallback)", ok=True, warn=True)
+        else:
+            _check(
+                "scrot not found (screenshots will fail)",
+                ok=False,
+                hint="sudo apt install scrot",
+            )
+            errors += 1
+
+        # AT-SPI (optional — needed for accessibility_tree action)
+        try:
+            import pyatspi  # type: ignore[import-not-found]  # noqa: F401
+
+            _check("pyatspi installed (AT-SPI accessibility tree)", ok=True)
+        except ImportError:
+            _check(
+                "pyatspi not installed (accessibility_tree action disabled)",
+                ok=True,
+                warn=True,
+                hint="pip install pyatspi  (optional — needed for accessibility_tree action)",
+            )
+        click.echo()
+
+    # --- macOS native tools ---
+    if system == "Darwin":
+        click.echo("macOS tools:")
+        # screencapture is a built-in macOS utility — always present
+        ok_sc = bool(shutil.which("screencapture"))
+        if not _check(
+            "screencapture available"
+            if ok_sc
+            else "screencapture missing (unexpected)",
+            ok=ok_sc,
+        ):
+            errors += 1
+
+        ok_cliclick = bool(shutil.which("cliclick"))
+        if not _check(
+            "cliclick installed (mouse/keyboard)"
+            if ok_cliclick
+            else "cliclick not found (mouse/keyboard disabled)",
+            ok=ok_cliclick,
+            hint="brew install cliclick",
+        ):
+            errors += 1
+
+        # osascript: built-in, needed for accessibility tree on macOS
+        ok_osa = bool(shutil.which("osascript"))
+        _check(
+            "osascript available (macOS accessibility tree)"
+            if ok_osa
+            else "osascript missing (unexpected)",
+            ok=ok_osa,
+        )
+        click.echo()
+
+    # --- Browser / Playwright ---
+    click.echo("Browser (Playwright):")
+    try:
+        from playwright.sync_api import (
+            sync_playwright,  # type: ignore[import-not-found]
+        )
+
+        _check("playwright package installed", ok=True)
+
+        # Check that at least one browser binary is present
+        try:
+            with sync_playwright() as pw:
+                chromium_path = pw.chromium.executable_path
+                ok_chromium = bool(chromium_path) and Path(chromium_path).exists()
+        except Exception:
+            ok_chromium = False
+
+        if not _check(
+            "Playwright chromium available"
+            if ok_chromium
+            else "Playwright chromium not found",
+            ok=ok_chromium,
+            hint="python -m playwright install chromium",
+        ):
+            errors += 1
+    except ImportError:
+        _check(
+            "playwright not installed (browser tool disabled)",
+            ok=False,
+            hint="pip install playwright  &&  python -m playwright install chromium",
+        )
+        errors += 1
+    click.echo()
+
+    # --- Screenshot latency sample ---
+    click.echo("Screenshot latency:")
+    try:
+        from ..tools.computer_transport import NativeComputerTransport, get_transport
+
+        transport = get_transport()
+        if transport is None:
+            if (system == "Linux" and os.environ.get("DISPLAY")) or system == "Darwin":
+                transport = NativeComputerTransport()
+
+        if transport is None:
+            _check(
+                "no display available — skipping latency sample",
+                ok=False,
+                hint="Set $DISPLAY first",
+            )
+            errors += 1
+        else:
+            # Warm-up shot (not measured)
+            try:
+                transport.screenshot()
+            except Exception as exc:
+                _check(f"warm-up screenshot failed: {exc}", ok=False)
+                errors += 1
+                transport = None  # skip the timed loop
+
+            if transport is not None:
+                durations_ms: list[float] = []
+                for _ in range(3):
+                    t0 = time.perf_counter()
+                    try:
+                        transport.screenshot()
+                        durations_ms.append((time.perf_counter() - t0) * 1000)
+                    except Exception:
+                        pass
+
+                if durations_ms:
+                    median_ms = statistics.median(durations_ms)
+                    p = _PASS if median_ms < 300 else _WARN
+                    click.echo(
+                        f"  {p}  median={median_ms:.0f} ms  "
+                        f"min={min(durations_ms):.0f} ms  max={max(durations_ms):.0f} ms"
+                        " (3 shots)"
+                    )
+                    if median_ms >= 300:
+                        click.echo(
+                            "       High latency — possible causes: remote X11, high load, "
+                            "missing scrot.\n"
+                            "       Run `gptme-util computer latency --shots 10` for a "
+                            "detailed breakdown."
+                        )
+                else:
+                    _check("all screenshot attempts failed", ok=False)
+                    errors += 1
+    except Exception as exc:
+        _check(f"could not measure latency: {exc}", ok=False)
+    click.echo()
+
+    # --- Summary ---
+    if errors == 0:
+        click.echo(
+            click.style("✅  All checks passed — computer-use is ready.", fg="green")
+        )
+    else:
+        click.echo(
+            click.style(f"❌  {errors} check(s) failed.", fg="red")
+            + "  Fix the items above and re-run `gptme-util computer doctor`."
+        )

--- a/gptme/cli/cmd_computer.py
+++ b/gptme/cli/cmd_computer.py
@@ -1082,10 +1082,10 @@ _FAIL = click.style("✗", fg="red")
 
 def _check(label: str, ok: bool, warn: bool = False, hint: str = "") -> bool:
     """Print one doctor check line and return True if it passed."""
-    if ok:
-        click.echo(f"  {_PASS}  {label}")
-    elif warn:
+    if warn:
         click.echo(f"  {_WARN}  {label}" + (f"\n       {hint}" if hint else ""))
+    elif ok:
+        click.echo(f"  {_PASS}  {label}")
     else:
         click.echo(f"  {_FAIL}  {label}" + (f"\n       {hint}" if hint else ""))
     return ok
@@ -1119,9 +1119,24 @@ def doctor_cmd(display: str | None):
     import platform
     import statistics
     import time
+    from contextlib import contextmanager
 
     system = platform.system()
     errors = 0
+    effective_display = display or os.environ.get("DISPLAY") or ""
+
+    @contextmanager
+    def _temporary_display(display_value: str):
+        old_display = os.environ.get("DISPLAY")
+        if display_value:
+            os.environ["DISPLAY"] = display_value
+        try:
+            yield
+        finally:
+            if old_display is None:
+                os.environ.pop("DISPLAY", None)
+            else:
+                os.environ["DISPLAY"] = old_display
 
     click.echo("Computer-use doctor\n")
 
@@ -1131,7 +1146,6 @@ def doctor_cmd(display: str | None):
     # --- Display / X11 (Linux) ---
     if system == "Linux":
         click.echo("Display:")
-        effective_display = display or os.environ.get("DISPLAY", "")
         ok_display = bool(effective_display)
         if not _check(
             f"$DISPLAY={effective_display!r}" if ok_display else "$DISPLAY not set",
@@ -1249,55 +1263,56 @@ def doctor_cmd(display: str | None):
     try:
         from ..tools.computer_transport import NativeComputerTransport, get_transport
 
-        transport = get_transport()
-        if transport is None:
-            if (system == "Linux" and os.environ.get("DISPLAY")) or system == "Darwin":
-                transport = NativeComputerTransport()
+        with _temporary_display(effective_display if system == "Linux" else ""):
+            transport = get_transport()
+            if transport is None:
+                if (system == "Linux" and effective_display) or system == "Darwin":
+                    transport = NativeComputerTransport()
 
-        if transport is None:
-            _check(
-                "no display available — skipping latency sample",
-                ok=False,
-                hint="Set $DISPLAY first",
-            )
-            errors += 1
-        else:
-            # Warm-up shot (not measured)
-            try:
-                transport.screenshot()
-            except Exception as exc:
-                _check(f"warm-up screenshot failed: {exc}", ok=False)
+            if transport is None:
+                _check(
+                    "no display available — skipping latency sample",
+                    ok=False,
+                    hint="Set $DISPLAY first",
+                )
                 errors += 1
-                transport = None  # skip the timed loop
-
-            if transport is not None:
-                durations_ms: list[float] = []
-                for _ in range(3):
-                    t0 = time.perf_counter()
-                    try:
-                        transport.screenshot()
-                        durations_ms.append((time.perf_counter() - t0) * 1000)
-                    except Exception:
-                        pass
-
-                if durations_ms:
-                    median_ms = statistics.median(durations_ms)
-                    p = _PASS if median_ms < 300 else _WARN
-                    click.echo(
-                        f"  {p}  median={median_ms:.0f} ms  "
-                        f"min={min(durations_ms):.0f} ms  max={max(durations_ms):.0f} ms"
-                        " (3 shots)"
-                    )
-                    if median_ms >= 300:
-                        click.echo(
-                            "       High latency — possible causes: remote X11, high load, "
-                            "missing scrot.\n"
-                            "       Run `gptme-util computer latency --shots 10` for a "
-                            "detailed breakdown."
-                        )
-                else:
-                    _check("all screenshot attempts failed", ok=False)
+            else:
+                # Warm-up shot (not measured)
+                try:
+                    transport.screenshot()
+                except Exception as exc:
+                    _check(f"warm-up screenshot failed: {exc}", ok=False)
                     errors += 1
+                    transport = None  # skip the timed loop
+
+                if transport is not None:
+                    durations_ms: list[float] = []
+                    for _ in range(3):
+                        t0 = time.perf_counter()
+                        try:
+                            transport.screenshot()
+                            durations_ms.append((time.perf_counter() - t0) * 1000)
+                        except Exception:
+                            pass
+
+                    if durations_ms:
+                        median_ms = statistics.median(durations_ms)
+                        p = _PASS if median_ms < 300 else _WARN
+                        click.echo(
+                            f"  {p}  median={median_ms:.0f} ms  "
+                            f"min={min(durations_ms):.0f} ms  max={max(durations_ms):.0f} ms"
+                            " (3 shots)"
+                        )
+                        if median_ms >= 300:
+                            click.echo(
+                                "       High latency — possible causes: remote X11, high load, "
+                                "missing scrot.\n"
+                                "       Run `gptme-util computer latency --shots 10` for a "
+                                "detailed breakdown."
+                            )
+                    else:
+                        _check("all screenshot attempts failed", ok=False)
+                        errors += 1
     except Exception as exc:
         _check(f"could not measure latency: {exc}", ok=False)
     click.echo()
@@ -1312,3 +1327,4 @@ def doctor_cmd(display: str | None):
             click.style(f"❌  {errors} check(s) failed.", fg="red")
             + "  Fix the items above and re-run `gptme-util computer doctor`."
         )
+        raise SystemExit(1)

--- a/gptme/cli/cmd_computer.py
+++ b/gptme/cli/cmd_computer.py
@@ -1216,12 +1216,13 @@ def doctor_cmd(display: str | None):
 
         # osascript: built-in, needed for accessibility tree on macOS
         ok_osa = bool(shutil.which("osascript"))
-        _check(
+        if not _check(
             "osascript available (macOS accessibility tree)"
             if ok_osa
             else "osascript missing (unexpected)",
             ok=ok_osa,
-        )
+        ):
+            errors += 1
         click.echo()
 
     # --- Browser / Playwright ---
@@ -1315,6 +1316,7 @@ def doctor_cmd(display: str | None):
                         errors += 1
     except Exception as exc:
         _check(f"could not measure latency: {exc}", ok=False)
+        errors += 1
     click.echo()
 
     # --- Summary ---

--- a/tests/test_computer_doctor_cmd.py
+++ b/tests/test_computer_doctor_cmd.py
@@ -342,6 +342,39 @@ class TestDoctorMacOS:
             result = runner.invoke(doctor_cmd, [])
         assert "cliclick" in result.output
 
+    def test_missing_osascript_exits_nonzero(self, tmp_path):
+        """Missing osascript is a failed macOS doctor check."""
+        runner = CliRunner()
+        pw_stub = MagicMock()
+        pw_cm = MagicMock()
+        pw_cm.__enter__ = lambda s: MagicMock(
+            chromium=MagicMock(executable_path="/usr/bin/env")
+        )
+        pw_cm.__exit__ = lambda *a: None
+        pw_stub.sync_playwright.return_value = pw_cm
+
+        def fake_which(cmd):
+            if cmd == "osascript":
+                return None
+            return f"/usr/bin/{cmd}"
+
+        with (
+            patch("platform.system", return_value="Darwin"),
+            patch("platform.machine", return_value="arm64"),
+            patch("gptme.cli.cmd_computer.shutil.which", side_effect=fake_which),
+            patch(
+                "gptme.tools.computer_transport.get_transport",
+                return_value=_fake_transport(tmp_path),
+            ),
+            patch("gptme.tools.computer_transport.NativeComputerTransport", MagicMock),
+            patch.dict(sys.modules, {"playwright.sync_api": pw_stub}),
+        ):
+            result = runner.invoke(doctor_cmd, [])
+
+        assert result.exit_code == 1
+        assert "osascript missing" in result.output
+        assert "check(s) failed" in result.output
+
     def test_no_display_section_on_macos(self):
         """macOS doctor output should not show X11/DISPLAY section."""
         runner = CliRunner()
@@ -453,3 +486,37 @@ class TestDoctorLatencySection:
             result = runner.invoke(doctor_cmd, [])
         # Either "no display" or "display" must appear in the output
         assert "display" in result.output.lower() or "DISPLAY" in result.output
+
+    def test_latency_exception_exits_nonzero(self, monkeypatch):
+        """Unexpected latency-section failures are failed doctor checks."""
+        monkeypatch.setenv("DISPLAY", ":1")
+        runner = CliRunner()
+        pw_stub = MagicMock()
+        pw_cm = MagicMock()
+        pw_cm.__enter__ = lambda s: MagicMock(
+            chromium=MagicMock(executable_path="/usr/bin/env")
+        )
+        pw_cm.__exit__ = lambda *a: None
+        pw_stub.sync_playwright.return_value = pw_cm
+
+        with (
+            patch("platform.system", return_value="Linux"),
+            patch("platform.machine", return_value="x86_64"),
+            patch(
+                "gptme.cli.cmd_computer.shutil.which",
+                side_effect=lambda cmd: f"/usr/bin/{cmd}",
+            ),
+            patch(
+                "gptme.tools.computer_transport.get_transport",
+                side_effect=RuntimeError("transport boom"),
+            ),
+            patch("gptme.tools.computer_transport.NativeComputerTransport", MagicMock),
+            patch.dict(
+                sys.modules, {"playwright.sync_api": pw_stub, "pyatspi": MagicMock()}
+            ),
+        ):
+            result = runner.invoke(doctor_cmd, [])
+
+        assert result.exit_code == 1
+        assert "could not measure latency: transport boom" in result.output
+        assert "check(s) failed" in result.output

--- a/tests/test_computer_doctor_cmd.py
+++ b/tests/test_computer_doctor_cmd.py
@@ -1,0 +1,361 @@
+"""Tests for `gptme-util computer doctor` (cmd_computer.py).
+
+Unit-tests the doctor CLI command without requiring a real display, X11 tools,
+or Playwright browser binary.  All external dependencies are monkey-patched.
+"""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from gptme.cli.cmd_computer import doctor_cmd
+
+
+def _fake_transport(tmp_path):
+    """Return a mock transport that writes a stub PNG on every screenshot call."""
+    transport = MagicMock()
+
+    def _fake_shot(**_kw):
+        p = tmp_path / "shot.png"
+        p.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 50)
+        return p
+
+    transport.screenshot.side_effect = _fake_shot
+    return transport
+
+
+class TestDoctorHelp:
+    def test_help_text(self):
+        runner = CliRunner()
+        result = runner.invoke(doctor_cmd, ["--help"])
+        assert result.exit_code == 0
+        assert "--display" in result.output
+
+
+class TestDoctorOutputFormat:
+    """Doctor output format invariants that hold regardless of platform state."""
+
+    def test_output_contains_platform_line(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("DISPLAY", ":1")
+        runner = CliRunner()
+        with (
+            patch("platform.system", return_value="Linux"),
+            patch("platform.machine", return_value="x86_64"),
+            patch("gptme.cli.cmd_computer.shutil.which", return_value=None),
+            patch("gptme.tools.computer_transport.get_transport", return_value=None),
+            patch("gptme.tools.computer_transport.NativeComputerTransport", MagicMock),
+        ):
+            result = runner.invoke(doctor_cmd, [])
+        assert "Platform:" in result.output
+        assert "Linux" in result.output
+
+    def test_output_contains_browser_section(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("DISPLAY", ":1")
+        runner = CliRunner()
+        with (
+            patch("platform.system", return_value="Linux"),
+            patch("platform.machine", return_value="x86_64"),
+            patch("gptme.cli.cmd_computer.shutil.which", return_value=None),
+            patch("gptme.tools.computer_transport.get_transport", return_value=None),
+            patch("gptme.tools.computer_transport.NativeComputerTransport", MagicMock),
+        ):
+            result = runner.invoke(doctor_cmd, [])
+        assert "Browser" in result.output or "playwright" in result.output.lower()
+
+    def test_summary_line_always_present(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("DISPLAY", raising=False)
+        runner = CliRunner()
+        with (
+            patch("platform.system", return_value="Linux"),
+            patch("platform.machine", return_value="x86_64"),
+            patch("gptme.cli.cmd_computer.shutil.which", return_value=None),
+            patch("gptme.tools.computer_transport.get_transport", return_value=None),
+            patch("gptme.tools.computer_transport.NativeComputerTransport", MagicMock),
+        ):
+            result = runner.invoke(doctor_cmd, [])
+        assert "passed" in result.output or "failed" in result.output
+
+
+class TestDoctorLinux:
+    """Doctor behaviour on Linux."""
+
+    def _base_patches(self, tmp_path, which_fn=None, transport=None):
+        """Return a list of context managers for a basic Linux-healthy setup."""
+
+        def _default_which(cmd):
+            return f"/usr/bin/{cmd}"
+
+        if which_fn is None:
+            which_fn = _default_which
+        if transport is None:
+            transport = _fake_transport(tmp_path)
+        return [
+            patch("platform.system", return_value="Linux"),
+            patch("platform.machine", return_value="x86_64"),
+            patch("gptme.cli.cmd_computer.shutil.which", side_effect=which_fn),
+            patch(
+                "gptme.tools.computer_transport.get_transport", return_value=transport
+            ),
+            patch("gptme.tools.computer_transport.NativeComputerTransport", MagicMock),
+        ]
+
+    def test_exit_0_on_healthy_linux(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("DISPLAY", ":1")
+        runner = CliRunner()
+
+        # Use /usr/bin/env as the "chromium" path — it always exists on Linux
+        _chromium_path = "/usr/bin/env"
+        pw_stub = MagicMock()
+        pw_cm = MagicMock()
+        pw_cm.__enter__ = lambda s: MagicMock(
+            chromium=MagicMock(executable_path=_chromium_path)
+        )
+        pw_cm.__exit__ = lambda *a: None
+        pw_stub.sync_playwright.return_value = pw_cm
+
+        with (
+            patch("platform.system", return_value="Linux"),
+            patch("platform.machine", return_value="x86_64"),
+            patch(
+                "gptme.cli.cmd_computer.shutil.which",
+                side_effect=lambda cmd: f"/usr/bin/{cmd}",
+            ),
+            patch(
+                "gptme.tools.computer_transport.get_transport",
+                return_value=_fake_transport(tmp_path),
+            ),
+            patch("gptme.tools.computer_transport.NativeComputerTransport", MagicMock),
+            patch.dict(
+                sys.modules, {"playwright.sync_api": pw_stub, "pyatspi": MagicMock()}
+            ),
+        ):
+            result = runner.invoke(doctor_cmd, [])
+
+        assert result.exit_code == 0, result.output
+        assert "All checks passed" in result.output or "✅" in result.output
+
+    def test_reports_display_missing(self, monkeypatch, tmp_path):
+        """When $DISPLAY is not set, doctor reports it."""
+        monkeypatch.delenv("DISPLAY", raising=False)
+        runner = CliRunner()
+        with (
+            patch("platform.system", return_value="Linux"),
+            patch("platform.machine", return_value="x86_64"),
+            patch(
+                "gptme.cli.cmd_computer.shutil.which",
+                side_effect=lambda cmd: f"/usr/bin/{cmd}",
+            ),
+            patch("gptme.tools.computer_transport.get_transport", return_value=None),
+            patch("gptme.tools.computer_transport.NativeComputerTransport", MagicMock),
+        ):
+            result = runner.invoke(doctor_cmd, [])
+        # Display check section should report the missing display
+        assert "$DISPLAY" in result.output or "not set" in result.output
+
+    def test_reports_xdotool_missing(self, monkeypatch, tmp_path):
+        """When xdotool is absent, the doctor reports it."""
+        monkeypatch.setenv("DISPLAY", ":1")
+
+        def fake_which(cmd):
+            if cmd == "xdotool":
+                return None
+            return f"/usr/bin/{cmd}"
+
+        runner = CliRunner()
+        with (
+            patch("platform.system", return_value="Linux"),
+            patch("platform.machine", return_value="x86_64"),
+            patch("gptme.cli.cmd_computer.shutil.which", side_effect=fake_which),
+            patch("gptme.tools.computer_transport.get_transport", return_value=None),
+            patch("gptme.tools.computer_transport.NativeComputerTransport", MagicMock),
+        ):
+            result = runner.invoke(doctor_cmd, [])
+        assert "xdotool" in result.output
+
+    def test_display_flag_appears_in_output(self, monkeypatch, tmp_path):
+        """When --display is passed, its value appears in the output."""
+        monkeypatch.delenv("DISPLAY", raising=False)
+        runner = CliRunner()
+        with (
+            patch("platform.system", return_value="Linux"),
+            patch("platform.machine", return_value="x86_64"),
+            patch(
+                "gptme.cli.cmd_computer.shutil.which",
+                side_effect=lambda cmd: f"/usr/bin/{cmd}",
+            ),
+            patch(
+                "gptme.tools.computer_transport.get_transport",
+                return_value=_fake_transport(tmp_path),
+            ),
+            patch("gptme.tools.computer_transport.NativeComputerTransport", MagicMock),
+        ):
+            result = runner.invoke(doctor_cmd, ["--display", ":99"])
+        assert ":99" in result.output
+
+
+class TestDoctorMacOS:
+    """Doctor behaviour on macOS."""
+
+    def test_exit_0_on_healthy_macos(self, tmp_path):
+        runner = CliRunner()
+        # Use /usr/bin/env as the "chromium" path — it always exists
+        _chromium_path = "/usr/bin/env"
+        pw_stub = MagicMock()
+        pw_cm = MagicMock()
+        pw_cm.__enter__ = lambda s: MagicMock(
+            chromium=MagicMock(executable_path=_chromium_path)
+        )
+        pw_cm.__exit__ = lambda *a: None
+        pw_stub.sync_playwright.return_value = pw_cm
+
+        with (
+            patch("platform.system", return_value="Darwin"),
+            patch("platform.machine", return_value="arm64"),
+            patch(
+                "gptme.cli.cmd_computer.shutil.which",
+                side_effect=lambda cmd: f"/usr/bin/{cmd}",
+            ),
+            patch(
+                "gptme.tools.computer_transport.get_transport",
+                return_value=_fake_transport(tmp_path),
+            ),
+            patch("gptme.tools.computer_transport.NativeComputerTransport", MagicMock),
+            patch.dict(sys.modules, {"playwright.sync_api": pw_stub}),
+        ):
+            result = runner.invoke(doctor_cmd, [])
+
+        assert result.exit_code == 0, result.output
+        assert "All checks passed" in result.output or "✅" in result.output
+
+    def test_reports_cliclick_missing(self):
+        """When cliclick is absent, the doctor mentions it."""
+        runner = CliRunner()
+        with (
+            patch("platform.system", return_value="Darwin"),
+            patch("platform.machine", return_value="arm64"),
+            patch(
+                "gptme.cli.cmd_computer.shutil.which",
+                side_effect=lambda cmd: (
+                    None if cmd == "cliclick" else f"/usr/bin/{cmd}"
+                ),
+            ),
+            patch("gptme.tools.computer_transport.get_transport", return_value=None),
+            patch("gptme.tools.computer_transport.NativeComputerTransport", MagicMock),
+        ):
+            result = runner.invoke(doctor_cmd, [])
+        assert "cliclick" in result.output
+
+    def test_no_display_section_on_macos(self):
+        """macOS doctor output should not show X11/DISPLAY section."""
+        runner = CliRunner()
+        with (
+            patch("platform.system", return_value="Darwin"),
+            patch("platform.machine", return_value="arm64"),
+            patch(
+                "gptme.cli.cmd_computer.shutil.which",
+                side_effect=lambda cmd: f"/usr/bin/{cmd}",
+            ),
+            patch("gptme.tools.computer_transport.get_transport", return_value=None),
+            patch("gptme.tools.computer_transport.NativeComputerTransport", MagicMock),
+        ):
+            result = runner.invoke(doctor_cmd, [])
+        # $DISPLAY check is Linux-only
+        assert "$DISPLAY" not in result.output
+
+
+class TestDoctorPlaywright:
+    """Doctor reports Playwright status correctly."""
+
+    def test_reports_playwright_not_installed(self, monkeypatch):
+        """When playwright cannot be imported, doctor reports it as a failure."""
+        monkeypatch.setenv("DISPLAY", ":1")
+        runner = CliRunner()
+        with (
+            patch("platform.system", return_value="Linux"),
+            patch("platform.machine", return_value="x86_64"),
+            patch(
+                "gptme.cli.cmd_computer.shutil.which",
+                side_effect=lambda cmd: f"/usr/bin/{cmd}",
+            ),
+            patch("gptme.tools.computer_transport.get_transport", return_value=None),
+            patch("gptme.tools.computer_transport.NativeComputerTransport", MagicMock),
+            patch.dict(sys.modules, {"playwright": None, "playwright.sync_api": None}),
+        ):
+            result = runner.invoke(doctor_cmd, [])
+        assert "playwright" in result.output.lower()
+
+    def test_reports_chromium_binary_missing(self, monkeypatch, tmp_path):
+        """When playwright is installed but chromium binary is missing, doctor reports it."""
+        monkeypatch.setenv("DISPLAY", ":1")
+
+        pw_stub = MagicMock()
+        pw_cm = MagicMock()
+        # chromium executable path returns a non-existent path
+        pw_cm.__enter__ = lambda s: MagicMock(
+            chromium=MagicMock(executable_path="/nonexistent/chromium")
+        )
+        pw_cm.__exit__ = lambda *a: None
+        pw_stub.sync_playwright.return_value = pw_cm
+
+        runner = CliRunner()
+        with (
+            patch("platform.system", return_value="Linux"),
+            patch("platform.machine", return_value="x86_64"),
+            patch(
+                "gptme.cli.cmd_computer.shutil.which",
+                side_effect=lambda cmd: f"/usr/bin/{cmd}",
+            ),
+            patch(
+                "gptme.tools.computer_transport.get_transport",
+                return_value=_fake_transport(tmp_path),
+            ),
+            patch("gptme.tools.computer_transport.NativeComputerTransport", MagicMock),
+            patch.dict(sys.modules, {"playwright.sync_api": pw_stub}),
+        ):
+            result = runner.invoke(doctor_cmd, [])
+        # chromium check must mention playwright or chromium
+        assert (
+            "chromium" in result.output.lower() or "playwright" in result.output.lower()
+        )
+
+
+class TestDoctorLatencySection:
+    """Doctor's latency sample section."""
+
+    def test_latency_sample_shown_when_transport_available(self, monkeypatch, tmp_path):
+        """When a transport is available, a latency sample line is emitted."""
+        monkeypatch.setenv("DISPLAY", ":1")
+        runner = CliRunner()
+        with (
+            patch("platform.system", return_value="Linux"),
+            patch("platform.machine", return_value="x86_64"),
+            patch(
+                "gptme.cli.cmd_computer.shutil.which",
+                side_effect=lambda cmd: f"/usr/bin/{cmd}",
+            ),
+            patch(
+                "gptme.tools.computer_transport.get_transport",
+                return_value=_fake_transport(tmp_path),
+            ),
+            patch("gptme.tools.computer_transport.NativeComputerTransport", MagicMock),
+        ):
+            result = runner.invoke(doctor_cmd, [])
+        assert "median=" in result.output or "ms" in result.output
+
+    def test_latency_section_skipped_when_no_transport(self, monkeypatch):
+        """When no display is available, the latency section reports the error."""
+        monkeypatch.delenv("DISPLAY", raising=False)
+        runner = CliRunner()
+        with (
+            patch("platform.system", return_value="Linux"),
+            patch("platform.machine", return_value="x86_64"),
+            patch("gptme.cli.cmd_computer.shutil.which", return_value=None),
+            patch("gptme.tools.computer_transport.get_transport", return_value=None),
+            patch("gptme.tools.computer_transport.NativeComputerTransport", MagicMock),
+        ):
+            result = runner.invoke(doctor_cmd, [])
+        # Either "no display" or "display" must appear in the output
+        assert "display" in result.output.lower() or "DISPLAY" in result.output

--- a/tests/test_computer_doctor_cmd.py
+++ b/tests/test_computer_doctor_cmd.py
@@ -215,6 +215,16 @@ class TestDoctorLinux:
         monkeypatch.delenv("DISPLAY", raising=False)
         runner = CliRunner()
         transport = _display_asserting_transport(tmp_path, ":99")
+
+        # Mock playwright to avoid ImportError when it's not installed
+        pw_stub = MagicMock()
+        pw_cm = MagicMock()
+        pw_cm.__enter__ = lambda s: MagicMock(
+            chromium=MagicMock(executable_path="/usr/bin/env")
+        )
+        pw_cm.__exit__ = lambda *a: None
+        pw_stub.sync_playwright.return_value = pw_cm
+
         with (
             patch("platform.system", return_value="Linux"),
             patch("platform.machine", return_value="x86_64"),
@@ -226,6 +236,9 @@ class TestDoctorLinux:
             patch(
                 "gptme.tools.computer_transport.NativeComputerTransport",
                 return_value=transport,
+            ),
+            patch.dict(
+                sys.modules, {"playwright.sync_api": pw_stub, "pyatspi": MagicMock()}
             ),
         ):
             result = runner.invoke(doctor_cmd, ["--display", ":99"])

--- a/tests/test_computer_doctor_cmd.py
+++ b/tests/test_computer_doctor_cmd.py
@@ -6,6 +6,7 @@ or Playwright browser binary.  All external dependencies are monkey-patched.
 
 from __future__ import annotations
 
+import os
 import sys
 from unittest.mock import MagicMock, patch
 
@@ -19,6 +20,20 @@ def _fake_transport(tmp_path):
     transport = MagicMock()
 
     def _fake_shot(**_kw):
+        p = tmp_path / "shot.png"
+        p.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 50)
+        return p
+
+    transport.screenshot.side_effect = _fake_shot
+    return transport
+
+
+def _display_asserting_transport(tmp_path, expected_display: str):
+    """Return a mock transport that verifies DISPLAY is set during screenshots."""
+    transport = MagicMock()
+
+    def _fake_shot(**_kw):
+        assert expected_display == os.environ.get("DISPLAY")
         p = tmp_path / "shot.png"
         p.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 50)
         return p
@@ -194,6 +209,72 @@ class TestDoctorLinux:
         ):
             result = runner.invoke(doctor_cmd, ["--display", ":99"])
         assert ":99" in result.output
+
+    def test_display_flag_drives_latency_transport(self, monkeypatch, tmp_path):
+        """The latency sample honors --display even when $DISPLAY is unset."""
+        monkeypatch.delenv("DISPLAY", raising=False)
+        runner = CliRunner()
+        transport = _display_asserting_transport(tmp_path, ":99")
+        with (
+            patch("platform.system", return_value="Linux"),
+            patch("platform.machine", return_value="x86_64"),
+            patch(
+                "gptme.cli.cmd_computer.shutil.which",
+                side_effect=lambda cmd: f"/usr/bin/{cmd}",
+            ),
+            patch("gptme.tools.computer_transport.get_transport", return_value=None),
+            patch(
+                "gptme.tools.computer_transport.NativeComputerTransport",
+                return_value=transport,
+            ),
+        ):
+            result = runner.invoke(doctor_cmd, ["--display", ":99"])
+
+        assert result.exit_code == 0, result.output
+        assert "no display available" not in result.output
+        assert "median=" in result.output or "ms" in result.output
+
+    def test_optional_checks_render_as_warnings(self, monkeypatch):
+        """Advisory checks should show warning output instead of green success."""
+        monkeypatch.setenv("DISPLAY", ":1")
+
+        def fake_which(cmd):
+            if cmd == "scrot":
+                return None
+            return f"/usr/bin/{cmd}"
+
+        runner = CliRunner()
+        with (
+            patch("platform.system", return_value="Linux"),
+            patch("platform.machine", return_value="x86_64"),
+            patch("gptme.cli.cmd_computer.shutil.which", side_effect=fake_which),
+            patch("gptme.tools.computer_transport.get_transport", return_value=None),
+            patch("gptme.tools.computer_transport.NativeComputerTransport", MagicMock),
+        ):
+            result = runner.invoke(doctor_cmd, [])
+
+        assert "!  scrot not found, ffmpeg available (fallback)" in result.output
+        assert (
+            "!  pyatspi not installed (accessibility_tree action disabled)"
+            in result.output
+        )
+        assert "pip install pyatspi" in result.output
+
+    def test_failures_exit_nonzero(self, monkeypatch):
+        """Failing checks should produce a non-zero exit code."""
+        monkeypatch.delenv("DISPLAY", raising=False)
+        runner = CliRunner()
+        with (
+            patch("platform.system", return_value="Linux"),
+            patch("platform.machine", return_value="x86_64"),
+            patch("gptme.cli.cmd_computer.shutil.which", return_value=None),
+            patch("gptme.tools.computer_transport.get_transport", return_value=None),
+            patch("gptme.tools.computer_transport.NativeComputerTransport", MagicMock),
+        ):
+            result = runner.invoke(doctor_cmd, [])
+
+        assert result.exit_code == 1
+        assert "check(s) failed" in result.output
 
 
 class TestDoctorMacOS:


### PR DESCRIPTION
## Summary

Adds `gptme-util computer doctor` — a single command that checks all computer-use prerequisites and reports what's missing, directly addressing the "figure out what is causing the delays" checklist item from #216.

**What it checks:**
- **Linux**: `$DISPLAY` set, `xdotool` installed, `scrot`/ffmpeg available, `pyatspi` optional (for AT-SPI accessibility tree)
- **macOS**: `screencapture` available, `cliclick` installed, `osascript` available
- **Both**: Playwright installed + chromium binary present, screenshot latency (3-shot sample)

**Example output on a healthy Linux system:**
```
Computer-use doctor

Platform: Linux (x86_64)

Display:
  ✓  $DISPLAY=':1'
  ✓  xdotool installed
  ✓  scrot installed (screenshot backend)
  ✓  pyatspi not installed (accessibility_tree action disabled)

Browser (Playwright):
  ✓  playwright package installed
  ✓  Playwright chromium available

Screenshot latency:
  ✓  median=57 ms  min=57 ms  max=58 ms (3 shots)

✅  All checks passed — computer-use is ready.
```

**On a broken setup** (missing xdotool, no display):
```
  ✗  $DISPLAY not set
       Start Xvfb:  Xvfb :1 -screen 0 1024x768x24 &  && export DISPLAY=:1
  ✗  xdotool not found (mouse/keyboard)
       sudo apt install xdotool
...
❌  2 check(s) failed.  Fix the items above and re-run `gptme-util computer doctor`.
```

## Test plan
- [ ] `gptme-util computer doctor` exits 0 and prints "All checks passed" on a healthy system
- [ ] `gptme-util computer doctor --display :99` uses the specified display
- [ ] 15 new unit tests pass (mock-based, no real X11 or browsers required): `pytest tests/test_computer_doctor_cmd.py`
- [ ] All existing computer tests still pass: `pytest tests/ -k computer --ignore=tests/test_computer_x11_integration.py --ignore=tests/test_computer_use_integration.py`

Closes part of #216

<!-- gptme-id:v1:gai_UtgHjMXv30SIOFnmYlkzQ4niqtihgmVlHfBKgybIkjz -->