### PR TITLE
fix(computer): classify new browser functions in risk/audit system (#216)

### DIFF
--- a/gptme/cli/cmd_computer.py
+++ b/gptme/cli/cmd_computer.py
@@ -28,7 +28,22 @@ _SENSITIVE_ACTIONS = frozenset({"type", "key"})
 _URL_BROWSER_FNS = frozenset({"observe_web", "snapshot_url", "open_page"})
 
 # Browser interaction functions whose first arg is a CSS/DOM selector
-_SELECTOR_BROWSER_FNS = frozenset({"click_element"})
+_SELECTOR_BROWSER_FNS = frozenset(
+    {
+        "click_element",
+        "hover_element",  # added PR #3104
+        "wait_for_element",  # added PR #3095
+    }
+)
+
+# Browser functions with no arguments (observation only)
+_NO_ARG_BROWSER_FNS = frozenset(
+    {
+        "read_page_text",
+        "snapshot_page",  # added PR #3104
+        "get_current_url",  # added PR #3104
+    }
+)
 
 # ACTION_RISK_* and action_risk_level are imported from _computer_gate
 # (re-exported here for backward compatibility with any existing callers)
@@ -79,8 +94,15 @@ def _extract_computer_calls(messages) -> list[dict]:
     - ``snapshot_url(url)`` — one-shot ARIA snapshot
     - ``open_page(url)`` — open an interactive browser session
     - ``click_element(selector)`` — DOM element click
+    - ``hover_element(selector)`` — hover over a DOM element
     - ``fill_element(selector, value)`` — form fill (value length logged, not raw text)
+    - ``press_key(key)`` — navigation key press (Enter, Tab, Escape, …)
+    - ``select_option(selector, value)`` — dropdown/select element change
+    - ``wait_for_element(selector)`` — wait for a DOM element to appear
     - ``read_page_text()`` — read page text content
+    - ``snapshot_page()`` — take current-page ARIA snapshot
+    - ``get_current_url()`` — get the current page URL
+    - ``load_browser_state(path)`` — restore a saved browser session
     - ``scroll_page(direction)`` — scroll the current page
 
     Typed/key text and fill_element values are never logged raw — only their
@@ -235,19 +257,21 @@ def _extract_computer_calls(messages) -> list[dict]:
                 )
             )
 
-            # read_page_text() — no arguments to extract
-            browser_positioned.extend(
-                (
-                    m.start(),
-                    {
-                        "timestamp": ts,
-                        "action": "read_page_text",
-                        "source": "browser",
-                        "risk_level": action_risk_level("read_page_text"),
-                    },
+            # No-argument browser observation functions
+            # (read_page_text, snapshot_page, get_current_url)
+            for fn in _NO_ARG_BROWSER_FNS:
+                browser_positioned.extend(
+                    (
+                        m.start(),
+                        {
+                            "timestamp": ts,
+                            "action": fn,
+                            "source": "browser",
+                            "risk_level": action_risk_level(fn),
+                        },
+                    )
+                    for m in re.finditer(rf"\b{fn}\s*\(", code)
                 )
-                for m in re.finditer(r"\bread_page_text\s*\(", code)
-            )
 
             # scroll_page(direction)
             browser_positioned.extend(
@@ -262,6 +286,60 @@ def _extract_computer_calls(messages) -> list[dict]:
                     },
                 )
                 for m in re.finditer(r"""\bscroll_page\s*\(\s*['"]([^'"]+)['"]""", code)
+            )
+
+            # press_key(key) — navigation key presses (Enter, Tab, Escape, …)
+            browser_positioned.extend(
+                (
+                    m.start(),
+                    {
+                        "timestamp": ts,
+                        "action": "press_key",
+                        "source": "browser",
+                        "key": m.group(1) if m.group(1) is not None else m.group(2),
+                        "risk_level": action_risk_level("press_key"),
+                    },
+                )
+                for m in re.finditer(
+                    r"""\bpress_key\s*\(\s*(?:'([^']*)'|"([^"]*)")""", code
+                )
+            )
+
+            # select_option(selector, value) — dropdown selection; value not sensitive
+            browser_positioned.extend(
+                (
+                    m.start(),
+                    {
+                        "timestamp": ts,
+                        "action": "select_option",
+                        "source": "browser",
+                        "selector": m.group(1)
+                        if m.group(1) is not None
+                        else m.group(2),
+                        "value": m.group(3)
+                        if m.group(3) is not None
+                        else (m.group(4) or ""),
+                        "risk_level": action_risk_level("select_option"),
+                    },
+                )
+                for m in re.finditer(
+                    r"""\bselect_option\s*\(\s*(?:'([^']*)'|"([^"]*)")\s*,\s*(?:'([^']*)'|"([^"]*)")""",
+                    code,
+                )
+            )
+
+            # load_browser_state(path) — restores a saved browser session
+            browser_positioned.extend(
+                (
+                    m.start(),
+                    {
+                        "timestamp": ts,
+                        "action": "load_browser_state",
+                        "source": "browser",
+                        "risk_level": action_risk_level("load_browser_state"),
+                    },
+                )
+                for m in re.finditer(r"\bload_browser_state\s*\(", code)
             )
 
             # Merge desktop and browser records, emit in source order

--- a/gptme/cli/cmd_computer.py
+++ b/gptme/cli/cmd_computer.py
@@ -535,6 +535,12 @@ def audit_log(
             if "url" in r:
                 url = r["url"]
                 details = url[:70] + ("…" if len(url) > 70 else "")
+            elif "key" in r:
+                # press_key(key) — show which key was pressed
+                details = repr(r["key"])
+            elif "selector" in r and "value" in r:
+                # select_option(selector, value) — show both selector and value
+                details = f"{r['selector']!r} → {r['value']!r}"
             elif "selector" in r and "value_len" in r:
                 details = f"{r['selector']!r} → {r['value_len']} chars"
             elif "selector" in r:

--- a/gptme/tools/_computer_gate.py
+++ b/gptme/tools/_computer_gate.py
@@ -52,6 +52,10 @@ ACTION_RISK_READ: frozenset[str] = frozenset(
         "snapshot_url",
         "observe_web",
         "read_page_text",
+        "snapshot_page",
+        "get_current_url",
+        "wait_for_element",
+        "load_browser_state",
         # high-level wrappers
         "observe_desktop",
     }
@@ -71,6 +75,9 @@ ACTION_RISK_WRITE: frozenset[str] = frozenset(
         "click_element",
         "scroll_page",
         "open_page",
+        "hover_element",
+        "press_key",
+        "select_option",
     }
 )
 

--- a/tests/test_computer_audit.py
+++ b/tests/test_computer_audit.py
@@ -697,6 +697,96 @@ def test_audit_log_cli_table_shows_selector_and_value_len(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# New browser functions (PRs #3095/#3104) — audit extraction coverage
+# ---------------------------------------------------------------------------
+
+
+def test_hover_element_captured():
+    """hover_element(selector) appears in the audit log with write risk level."""
+    msgs = [_msg("assistant", _ipython_block("hover_element('nav > .dropdown')"))]
+    records = _extract_computer_calls(msgs)
+    assert len(records) == 1
+    assert records[0]["action"] == "hover_element"
+    assert records[0]["source"] == "browser"
+    assert records[0]["risk_level"] == "write"
+    assert records[0]["selector"] == "nav > .dropdown"
+
+
+def test_press_key_captured():
+    """press_key(key) appears in the audit log with write risk level."""
+    msgs = [_msg("assistant", _ipython_block("press_key('Enter')"))]
+    records = _extract_computer_calls(msgs)
+    assert len(records) == 1
+    assert records[0]["action"] == "press_key"
+    assert records[0]["source"] == "browser"
+    assert records[0]["risk_level"] == "write"
+    assert records[0]["key"] == "Enter"
+
+
+def test_select_option_captured():
+    """select_option(selector, value) appears with write risk, value logged (not sensitive)."""
+    msgs = [
+        _msg("assistant", _ipython_block("select_option('[name=\"size\"]', 'large')"))
+    ]
+    records = _extract_computer_calls(msgs)
+    assert len(records) == 1
+    assert records[0]["action"] == "select_option"
+    assert records[0]["source"] == "browser"
+    assert records[0]["risk_level"] == "write"
+    assert records[0]["value"] == "large"
+
+
+def test_wait_for_element_captured():
+    """wait_for_element(selector) appears in the audit log with read risk level."""
+    msgs = [
+        _msg(
+            "assistant",
+            _ipython_block("wait_for_element('[data-testid=\"result\"]')"),
+        )
+    ]
+    records = _extract_computer_calls(msgs)
+    assert len(records) == 1
+    assert records[0]["action"] == "wait_for_element"
+    assert records[0]["source"] == "browser"
+    assert records[0]["risk_level"] == "read"
+
+
+def test_snapshot_page_captured():
+    """snapshot_page() appears in the audit log with read risk level."""
+    msgs = [_msg("assistant", _ipython_block("snapshot_page()"))]
+    records = _extract_computer_calls(msgs)
+    assert len(records) == 1
+    assert records[0]["action"] == "snapshot_page"
+    assert records[0]["source"] == "browser"
+    assert records[0]["risk_level"] == "read"
+
+
+def test_get_current_url_captured():
+    """get_current_url() appears in the audit log with read risk level."""
+    msgs = [_msg("assistant", _ipython_block("get_current_url()"))]
+    records = _extract_computer_calls(msgs)
+    assert len(records) == 1
+    assert records[0]["action"] == "get_current_url"
+    assert records[0]["source"] == "browser"
+    assert records[0]["risk_level"] == "read"
+
+
+def test_load_browser_state_captured():
+    """load_browser_state(path) appears in the audit log with read risk level."""
+    msgs = [
+        _msg(
+            "assistant",
+            _ipython_block("load_browser_state('~/.config/gptme/twitter.json')"),
+        )
+    ]
+    records = _extract_computer_calls(msgs)
+    assert len(records) == 1
+    assert records[0]["action"] == "load_browser_state"
+    assert records[0]["source"] == "browser"
+    assert records[0]["risk_level"] == "read"
+
+
+# ---------------------------------------------------------------------------
 # act_and_observe() audit tracking
 # The computer-use profile recommends act_and_observe() as the primary
 # "act then look" primitive — it must appear in the audit trail.

--- a/tests/test_computer_audit.py
+++ b/tests/test_computer_audit.py
@@ -701,6 +701,24 @@ def test_audit_log_cli_table_shows_selector_and_value_len(tmp_path):
 # ---------------------------------------------------------------------------
 
 
+def test_audit_log_cli_table_shows_press_key_and_select_option(tmp_path):
+    """Table output shows key for press_key and selector+value for select_option."""
+    conv_dir = tmp_path / "browser-actions"
+    jsonl = conv_dir / "conversation.jsonl"
+    msgs = [
+        _msg("assistant", _ipython_block("press_key('Enter')")),
+        _msg("assistant", _ipython_block("select_option('[name=\"size\"]', 'large')")),
+    ]
+    _write_conv_jsonl(jsonl, msgs)
+
+    runner = CliRunner()
+    result = runner.invoke(audit_log, [str(jsonl)], catch_exceptions=False)
+    assert result.exit_code == 0
+    assert "'Enter'" in result.output
+    assert '[name="size"]' in result.output
+    assert "'large'" in result.output
+
+
 def test_hover_element_captured():
     """hover_element(selector) appears in the audit log with write risk level."""
     msgs = [_msg("assistant", _ipython_block("hover_element('nav > .dropdown')"))]
@@ -733,6 +751,7 @@ def test_select_option_captured():
     assert records[0]["action"] == "select_option"
     assert records[0]["source"] == "browser"
     assert records[0]["risk_level"] == "write"
+    assert records[0]["selector"] == '[name="size"]'
     assert records[0]["value"] == "large"
 
 
@@ -749,6 +768,7 @@ def test_wait_for_element_captured():
     assert records[0]["action"] == "wait_for_element"
     assert records[0]["source"] == "browser"
     assert records[0]["risk_level"] == "read"
+    assert records[0]["selector"] == '[data-testid="result"]'
 
 
 def test_snapshot_page_captured():

--- a/tests/test_computer_risk_streaming.py
+++ b/tests/test_computer_risk_streaming.py
@@ -34,10 +34,25 @@ def test_action_risk_level_read():
     assert action_risk_level("observe_desktop") == "read"
 
 
+def test_action_risk_level_read_new_browser_observation():
+    """New browser observation functions added in PRs #3095/#3104 must be read."""
+    assert action_risk_level("snapshot_page") == "read"
+    assert action_risk_level("get_current_url") == "read"
+    assert action_risk_level("wait_for_element") == "read"
+    assert action_risk_level("load_browser_state") == "read"
+
+
 def test_action_risk_level_write():
     assert action_risk_level("left_click") == "write"
     assert action_risk_level("mouse_move") == "write"
     assert action_risk_level("window_focus") == "write"
+
+
+def test_action_risk_level_write_new_browser_interaction():
+    """New browser interaction functions added in PRs #3095/#3104 must be write."""
+    assert action_risk_level("hover_element") == "write"
+    assert action_risk_level("press_key") == "write"
+    assert action_risk_level("select_option") == "write"
 
 
 def test_action_risk_level_sensitive():


### PR DESCRIPTION
## Problem

PRs #3095 (`press_key`, `select_option`, `wait_for_element`) and #3104 (`hover_element`, `snapshot_page`, `get_current_url`) added new browser tool functions to `browser.py`, but two systems were not updated to include them:

1. **Risk classification** (`_computer_gate.py`) — all new functions defaulted to `"write"` since they weren't in any of the three risk sets. This misclassified `wait_for_element`, `snapshot_page`, and `get_current_url` as write actions when they are observation-only (`"read"`).

2. **Audit log extraction** (`cmd_computer.py / _extract_computer_calls`) — all new functions were silently dropped from audit logs produced by `gptme-util computer audit-log`, so sessions using these functions appeared to have fewer actions than they did.

## Changes

### `gptme/tools/_computer_gate.py`
- `read`: add `snapshot_page`, `get_current_url`, `wait_for_element`, `load_browser_state`
- `write`: add `hover_element`, `press_key`, `select_option`

### `gptme/cli/cmd_computer.py`
- Extend `_SELECTOR_BROWSER_FNS` with `hover_element` and `wait_for_element`
- Introduce `_NO_ARG_BROWSER_FNS` set (`read_page_text`, `snapshot_page`, `get_current_url`) replacing the per-function `read_page_text` extraction with a shared loop
- Add dedicated extraction for `press_key` (logs `key` field), `select_option` (logs `selector` + `value`, not sensitive), and `load_browser_state`

### Tests
- 2 new risk-classification tests in `test_computer_risk_streaming.py`
- 7 new audit-extraction tests in `test_computer_audit.py` (one per new function)

## Test plan

- [x] `uv run pytest tests/test_computer_risk_streaming.py` — 2 new tests added
- [x] `uv run pytest tests/test_computer_audit.py` — 7 new tests added
- [x] Full suite: 320 passed, 3 skipped (display-dependent)

Closes part of #216.

<!-- gptme-id:v1:gai_b9vRrvP1Pup54R6z3QfMY0EBgznzfYdYxnGI9Jh7CjQ -->