### PR TITLE
eval(subagent): trajectory evals for output_schema and subagent_pipeline (#554)

### DIFF
--- a/gptme/eval/suites/subagent.py
+++ b/gptme/eval/suites/subagent.py
@@ -1,5 +1,6 @@
 """Trajectory-focused evals for the subagent tool."""
 
+import re
 from typing import TYPE_CHECKING
 
 from gptme.message import Message
@@ -35,6 +36,14 @@ def _expect_sum_marker(ctx: "ResultContext") -> bool:
 
 def _expect_greeting_marker(ctx: "ResultContext") -> bool:
     return "GREETING=" in ctx.stdout
+
+
+def _expect_score_marker(ctx: "ResultContext") -> bool:
+    return "SCORE=" in ctx.stdout
+
+
+def _expect_reviewed_marker(ctx: "ResultContext") -> bool:
+    return "REVIEWED=" in ctx.stdout
 
 
 def _role_contents(messages: list[Message], role: str) -> str:
@@ -174,6 +183,50 @@ def check_clarification_reply_with_language(messages: list[Message]) -> bool:
     )
 
 
+def check_output_schema_used(messages: list[Message]) -> bool:
+    """Parent should pass output_schema= when spawning the subagent."""
+    assistant_log = _role_contents(messages, "assistant")
+    return "output_schema=" in assistant_log
+
+
+def check_output_schema_result_is_structured(messages: list[Message]) -> bool:
+    """The result retrieved via subagent_wait should look like parsed JSON/dict.
+
+    A trajectory-level check: the parent's final assistant message must contain
+    a Python dict literal or JSON object that includes the 'score' key, proving
+    the parent received and used a structured (not free-text) result.
+    """
+    final_msg = _last_assistant_content(messages)
+    return re.search(r"['\"]?score['\"]?\s*[:=]", final_msg) is not None
+
+
+def check_output_schema_wait_called(messages: list[Message]) -> bool:
+    """Parent must call subagent_wait after spawning the output_schema subagent."""
+    return _any_message_contains(messages, "assistant", "subagent_wait(")
+
+
+def check_pipeline_used(messages: list[Message]) -> bool:
+    """Parent should use subagent_pipeline for staged fan-out."""
+    return _any_message_contains(messages, "assistant", "subagent_pipeline(")
+
+
+def check_pipeline_results_integrated(messages: list[Message]) -> bool:
+    """Final assistant message should include results from the pipeline."""
+    final_msg = _last_assistant_content(messages)
+    return "REVIEWED=" in final_msg or "SUMMARY=" in final_msg
+
+
+def check_pipeline_no_explicit_waits(messages: list[Message]) -> bool:
+    """subagent_pipeline manages its own waits; the parent should not call subagent_wait.
+
+    The point of subagent_pipeline is barrier-free fan-out — the helper handles
+    scheduling internally. If the parent still calls subagent_wait() manually it
+    defeats the purpose and suggests the agent misunderstood the API.
+    """
+    assistant_log = _role_contents(messages, "assistant")
+    return "subagent_wait(" not in assistant_log
+
+
 _PARALLEL_A = "alpha beta gamma delta epsilon zeta\n"
 _PARALLEL_B = "one\ntwo\nthree\nfour\n"
 _NOTES = "Keep this brief. The parent can read this between spawn and wait.\n"
@@ -271,6 +324,69 @@ tests: list["EvalSpec"] = [
             "received clarification hook notification": check_clarification_hook_notification,
             "called subagent_reply": check_clarification_reply_called,
             "replied with English": check_clarification_reply_with_language,
+        },
+    },
+    {
+        "name": "subagent-output-schema",
+        "files": {
+            "reviews.txt": (
+                "Product A: excellent build quality, fast shipping\n"
+                "Product B: poor packaging, slow delivery\n"
+            ),
+        },
+        "run": "cat answer.txt",
+        "prompt": (
+            "Spawn a subagent with agent_id 'reviewer' to evaluate reviews.txt. "
+            "Pass output_schema={'score': int, 'summary': str} so the subagent returns "
+            "structured data. In the subagent prompt tell it to:\n"
+            "  - Read reviews.txt\n"
+            "  - Compute an overall quality score from 1-10\n"
+            "  - Write a one-sentence summary\n"
+            "  - Return the result via complete() as JSON: "
+            '{"score": <int>, "summary": "<text>"}\n'
+            "After spawning, wait for the subagent. "
+            "The result from subagent_wait should be a parsed dict, not raw text. "
+            "Write answer.txt containing:\n"
+            "SCORE=<the integer score>\n"
+            "SUMMARY=<the one-sentence summary>\n"
+            "Include SCORE= in your final assistant message."
+        ),
+        "tools": ["read", "save", "shell", "ipython", "subagent"],
+        "expect": {
+            "writes SCORE marker": _expect_score_marker,
+            "clean exit": _expect_clean_exit,
+        },
+        "check_log": {
+            "passed output_schema to subagent": check_output_schema_used,
+            "called subagent_wait for result": check_output_schema_wait_called,
+            "result contains structured score field": check_output_schema_result_is_structured,
+        },
+    },
+    {
+        "name": "subagent-pipeline-staged",
+        "files": {
+            "items.txt": "apple\nbanana\ncherry\n",
+        },
+        "run": "cat answer.txt",
+        "prompt": (
+            "Use subagent_pipeline to process items.txt in two stages without a barrier:\n"
+            "Stage 1: for each fruit name, spawn a subagent that converts it to UPPERCASE.\n"
+            "Stage 2: for each uppercased result, spawn a subagent that wraps it in "
+            "'REVIEWED: <name>'.\n"
+            "subagent_pipeline runs stage 2 on item A while item B is still in stage 1 — "
+            "do NOT call subagent_wait manually; let subagent_pipeline manage scheduling.\n"
+            "When finished, write answer.txt containing the three REVIEWED= lines, one per fruit.\n"
+            "Include 'REVIEWED=' in your final assistant message."
+        ),
+        "tools": ["read", "save", "shell", "ipython", "subagent"],
+        "expect": {
+            "writes REVIEWED marker": _expect_reviewed_marker,
+            "clean exit": _expect_clean_exit,
+        },
+        "check_log": {
+            "used subagent_pipeline": check_pipeline_used,
+            "integrated pipeline results": check_pipeline_results_integrated,
+            "did not call subagent_wait manually": check_pipeline_no_explicit_waits,
         },
     },
 ]

--- a/gptme/eval/suites/subagent.py
+++ b/gptme/eval/suites/subagent.py
@@ -195,12 +195,16 @@ def check_output_schema_result_is_structured(messages: list[Message]) -> bool:
     A trajectory-level check: the parent's final assistant message must contain
     a Python dict literal or JSON object that includes the 'score' key, proving
     the parent received and used a structured (not free-text) result.
+
+    Pattern: matches `'score': <value>` (with dict/list delimiters before the key)
+    where <value> is NOT a type keyword (int, str, etc), but IS a concrete value
+    (number, string literal, object/array, or JSON constant).
     """
     final_msg = _last_assistant_content(messages)
     return (
         re.search(
             r"[\{\[,]\s*['\"]score['\"]\s*:\s*"
-            r"(?!(?:int|str|float|bool|list|dict|tuple|set)\b)"
+            r"(?!(?:int|str|float|bool|list|dict|tuple|set)(?:\b|[,\}\]]))"
             r"(?:-?\d+(?:\.\d+)?|['\"]|\{|\[|true\b|false\b|null\b|None\b)",
             final_msg,
         )

--- a/gptme/eval/suites/subagent.py
+++ b/gptme/eval/suites/subagent.py
@@ -197,7 +197,15 @@ def check_output_schema_result_is_structured(messages: list[Message]) -> bool:
     the parent received and used a structured (not free-text) result.
     """
     final_msg = _last_assistant_content(messages)
-    return re.search(r"['\"]?score['\"]?\s*[:=]", final_msg) is not None
+    return (
+        re.search(
+            r"[\{\[,]\s*['\"]score['\"]\s*:\s*"
+            r"(?!(?:int|str|float|bool|list|dict|tuple|set)\b)"
+            r"(?:-?\d+(?:\.\d+)?|['\"]|\{|\[|true\b|false\b|null\b|None\b)",
+            final_msg,
+        )
+        is not None
+    )
 
 
 def check_output_schema_wait_called(messages: list[Message]) -> bool:

--- a/tests/test_eval_subagent.py
+++ b/tests/test_eval_subagent.py
@@ -307,7 +307,8 @@ def test_output_schema_structured_check_requires_score_field():
     ]
 
     assert check_output_schema_used(messages)
-    # Prose markers do not count as a structured field reference.
+    # Prose markers (uppercase, no delimiters) do not count as a structured field reference.
+    # The check requires a score key inside a dict or list, not just text with "score=".
     assert not check_output_schema_result_is_structured(messages)
 
 

--- a/tests/test_eval_subagent.py
+++ b/tests/test_eval_subagent.py
@@ -270,6 +270,25 @@ def test_output_schema_check_fails_without_schema_param():
     assert not check_output_schema_used(messages)
 
 
+def test_output_schema_wait_check_fails_without_wait_call():
+    """Omitting subagent_wait should fail the wait-call check."""
+    messages = [
+        Message(
+            "assistant",
+            "```ipython\n"
+            "subagent('reviewer', 'Evaluate reviews.txt', output_schema={'score': int, 'summary': str})\n"
+            "```",
+        ),
+        Message(
+            "assistant",
+            "The structured result was {'score': 7, 'summary': 'Positive'}.",
+        ),
+    ]
+
+    assert check_output_schema_used(messages)
+    assert not check_output_schema_wait_called(messages)
+
+
 def test_output_schema_structured_check_requires_score_field():
     """Final message without a score field fails the structured-result check."""
     messages = [
@@ -288,7 +307,28 @@ def test_output_schema_structured_check_requires_score_field():
     ]
 
     assert check_output_schema_used(messages)
-    # "SCORE=7" in text doesn't count as a structured field reference
+    # Prose markers do not count as a structured field reference.
+    assert not check_output_schema_result_is_structured(messages)
+
+
+def test_output_schema_structured_check_rejects_lowercase_prose_score():
+    """A lowercase prose score marker is still not a structured result."""
+    messages = [
+        Message("assistant", "The score=7 based on my analysis."),
+    ]
+
+    assert not check_output_schema_result_is_structured(messages)
+
+
+def test_output_schema_structured_check_rejects_schema_definition_only():
+    """Re-mentioning output_schema={'score': int} is not using the result."""
+    messages = [
+        Message(
+            "assistant",
+            "I used output_schema={'score': int, 'summary': str} and the overall rating was 8.",
+        ),
+    ]
+
     assert not check_output_schema_result_is_structured(messages)
 
 

--- a/tests/test_eval_subagent.py
+++ b/tests/test_eval_subagent.py
@@ -5,6 +5,12 @@ from gptme.eval.suites.subagent import (
     check_clarification_reply_called,
     check_clarification_reply_with_language,
     check_clarification_spawned,
+    check_output_schema_result_is_structured,
+    check_output_schema_used,
+    check_output_schema_wait_called,
+    check_pipeline_no_explicit_waits,
+    check_pipeline_results_integrated,
+    check_pipeline_used,
     check_subagent_complete_hook_notification,
     check_subagent_complete_parent_result,
     check_subagent_complete_roundtrip_marker,
@@ -221,3 +227,122 @@ def test_clarification_checks_fail_without_reply():
     ]
 
     assert not check_clarification_reply_called(messages)
+
+
+def test_output_schema_checks_pass_for_full_trajectory():
+    """output_schema eval: spawn with schema → wait → use structured result."""
+    messages = [
+        Message(
+            "assistant",
+            "```ipython\n"
+            "subagent('reviewer', 'Evaluate reviews.txt', output_schema={'score': int, 'summary': str})\n"
+            "```",
+        ),
+        Message(
+            "assistant",
+            "```ipython\nresult = subagent_wait('reviewer')\n```",
+        ),
+        Message(
+            "assistant",
+            "The structured result was {'score': 7, 'summary': 'Generally positive'}. SCORE=7",
+        ),
+    ]
+
+    assert check_output_schema_used(messages)
+    assert check_output_schema_wait_called(messages)
+    assert check_output_schema_result_is_structured(messages)
+
+
+def test_output_schema_check_fails_without_schema_param():
+    """Spawning without output_schema= should fail the schema check."""
+    messages = [
+        Message(
+            "assistant",
+            "```ipython\nsubagent('reviewer', 'Evaluate reviews.txt')\n```",
+        ),
+        Message(
+            "assistant",
+            "```ipython\nresult = subagent_wait('reviewer')\n```",
+        ),
+        Message("assistant", "SCORE=7"),
+    ]
+
+    assert not check_output_schema_used(messages)
+
+
+def test_output_schema_structured_check_requires_score_field():
+    """Final message without a score field fails the structured-result check."""
+    messages = [
+        Message(
+            "assistant",
+            "```ipython\n"
+            "subagent('reviewer', 'Evaluate', output_schema={'score': int, 'summary': str})\n"
+            "```",
+        ),
+        Message(
+            "assistant",
+            "```ipython\nresult = subagent_wait('reviewer')\n```",
+        ),
+        # Parent uses the result but doesn't show any structured field
+        Message("assistant", "The review looks mostly positive. SCORE=7 (from text)"),
+    ]
+
+    assert check_output_schema_used(messages)
+    # "SCORE=7" in text doesn't count as a structured field reference
+    assert not check_output_schema_result_is_structured(messages)
+
+
+def test_pipeline_checks_pass_for_staged_trajectory():
+    """pipeline eval: subagent_pipeline call → results integrated → no manual waits."""
+    messages = [
+        Message(
+            "assistant",
+            "```ipython\n"
+            "results = subagent_pipeline(\n"
+            "    ['apple', 'banana', 'cherry'],\n"
+            "    lambda item, _: subagent(f'upper-{item}', f'Uppercase {item}'),\n"
+            "    lambda item, prev: subagent(f'review-{item}', f'Wrap {prev} as REVIEWED: {prev}'),\n"
+            ")\n"
+            "```",
+        ),
+        Message("assistant", "Done. REVIEWED=APPLE REVIEWED=BANANA REVIEWED=CHERRY"),
+    ]
+
+    assert check_pipeline_used(messages)
+    assert check_pipeline_results_integrated(messages)
+    assert check_pipeline_no_explicit_waits(messages)
+
+
+def test_pipeline_check_fails_when_subagent_wait_called_manually():
+    """Using subagent_wait manually defeats pipeline's barrier-free contract."""
+    messages = [
+        Message(
+            "assistant",
+            "```ipython\n"
+            "results = subagent_pipeline(['apple'], stage1, stage2)\n"
+            "subagent_wait('apple-stage1')\n"
+            "```",
+        ),
+        Message("assistant", "Done. REVIEWED=APPLE"),
+    ]
+
+    assert check_pipeline_used(messages)
+    assert not check_pipeline_no_explicit_waits(messages)
+
+
+def test_pipeline_check_fails_when_pipeline_not_used():
+    """Manually launching subagents without subagent_pipeline should not pass."""
+    messages = [
+        Message(
+            "assistant",
+            "```ipython\n"
+            "subagent('upper-apple', 'Uppercase apple')\n"
+            "subagent_wait('upper-apple')\n"
+            "subagent('review-apple', 'Wrap APPLE as REVIEWED')\n"
+            "subagent_wait('review-apple')\n"
+            "```",
+        ),
+        Message("assistant", "Done. REVIEWED=APPLE"),
+    ]
+
+    assert not check_pipeline_used(messages)


### PR DESCRIPTION
## Summary

Adds two new trajectory-level eval specs and their supporting `check_log` functions, directly addressing the final request in issue #554:

> "Would be interesting adding an eval/test or two for the subagents (would need to evaluate the trajectory, not the outcome/artifacts) to ensure they are actually better/good now." — @ErikBjare

### New eval specs

- **`subagent-output-schema`**: verifies the parent passes `output_schema=` when spawning a subagent, calls `subagent_wait`, and incorporates the resulting structured dict (keyed on `score`) into its final answer. Covers the output_schema contract from #3090/#3114.

- **`subagent-pipeline-staged`**: verifies the parent uses `subagent_pipeline()` for two-stage fan-out without manually calling `subagent_wait`. Covers the barrier-free scheduling contract from #3110.

### New check functions

Six named module-level functions (not lambdas — lambdas fail `pickle.dumps`):

| Function | What it checks |
|---|---|
| `check_output_schema_used` | `output_schema=` appears in a `subagent()` call |
| `check_output_schema_wait_called` | `subagent_wait()` is called after spawning |
| `check_output_schema_result_is_structured` | final message contains a `score:` or `score=` field |
| `check_pipeline_used` | `subagent_pipeline(` appears in the trajectory |
| `check_pipeline_results_integrated` | final message contains `REVIEWED=` or `SUMMARY=` |
| `check_pipeline_no_explicit_waits` | no `subagent_wait(` calls (pipeline manages its own scheduling) |

### Tests

6 new unit tests for the check functions (pass + fail cases), including:
- `test_output_schema_structured_check_requires_score_field` — verifies the check rejects free-text output that lacks a structured field
- `test_pipeline_check_fails_when_subagent_wait_called_manually` — verifies the no-wait invariant catches misuse

All 232 subagent tests pass (215 unit + 17 eval unit).

Closes the eval coverage gap for #554.

<!-- gptme-id:v1:gai_DhFUkwAAPD3RDjvqwSvfHLZE49QR3dPQTqXvKNTmZ55 -->