### PR TITLE
feat(subagent): add subagent_wait_any() for race/hedging patterns (#554)

### DIFF
--- a/gptme/tools/subagent/__init__.py
+++ b/gptme/tools/subagent/__init__.py
@@ -21,6 +21,7 @@ from .api import (
     subagent_reply,
     subagent_status,
     subagent_wait,
+    subagent_wait_any,
 )
 from .batch import BatchJob, subagent_batch, subagent_parallel, subagent_pipeline
 from .execution import get_current_agent_id
@@ -324,6 +325,7 @@ Key features:
 - subagent_pipeline(items, *stages, timeout): Multi-stage fan-out with no barrier between stages — item A advances to stage 2 while item B is still in stage 1; each stage callable receives (item_prompt, prev_result) and returns the next stage's prompt
 - subagent_batch(): Start multiple subagents and return a BatchJob for explicit synchronization
 - subagent_cancel(): Cancel a running subagent (SIGTERM for subprocess, marks result for threads)
+- subagent_wait_any(agent_ids, timeout): Wait for the first of N subagents to complete — returns (agent_id, result). Useful for race/hedging patterns.
 - subagent_reply(agent_id, reply): Answer a clarification request and re-spawn the subagent
 - Hook-based notifications: Completions (and clarification requests) delivered as system messages
 
@@ -434,6 +436,7 @@ tool = ToolSpec(
             subagent_reply,
             subagent_status,
             subagent_wait,
+            subagent_wait_any,
             subagent_read_log,
             subagent_batch,
             subagent_parallel,
@@ -459,6 +462,7 @@ __all__ = [
     "subagent_reply",
     "subagent_status",
     "subagent_wait",
+    "subagent_wait_any",
     "subagent_read_log",
     "subagent_batch",
     "subagent_parallel",

--- a/gptme/tools/subagent/api.py
+++ b/gptme/tools/subagent/api.py
@@ -1167,7 +1167,7 @@ def subagent_wait(
 
 def subagent_wait_any(
     agent_ids: list[str],
-    timeout: float = 300,
+    timeout: int = 300,
 ) -> tuple[str, dict]:
     """Wait for the first of the given subagents to complete.
 

--- a/gptme/tools/subagent/api.py
+++ b/gptme/tools/subagent/api.py
@@ -1181,7 +1181,7 @@ def subagent_wait_any(
     Returns:
         Tuple of ``(agent_id, result_dict)`` for the first agent that
         completes. ``result_dict`` has ``"status"`` (``"success"`` /
-        ``"failure"`` / ``"timeout"``) and ``"result"`` keys.
+        ``"failure"`` / ``"clarification_needed"``) and ``"result"`` keys.
 
     Raises:
         ValueError: If ``agent_ids`` is empty.

--- a/gptme/tools/subagent/api.py
+++ b/gptme/tools/subagent/api.py
@@ -1165,6 +1165,49 @@ def subagent_wait(
     return result_dict
 
 
+def subagent_wait_any(
+    agent_ids: list[str],
+    timeout: float = 300,
+) -> tuple[str, dict]:
+    """Wait for the first of the given subagents to complete.
+
+    Useful for speculative/hedging patterns: spawn N subagents and take
+    whichever finishes first, then cancel the rest with ``subagent_cancel()``.
+
+    Args:
+        agent_ids: List of agent IDs to wait on.
+        timeout: Maximum seconds to wait for any agent to complete.
+
+    Returns:
+        Tuple of ``(agent_id, result_dict)`` for the first agent that
+        completes. ``result_dict`` has ``"status"`` (``"success"`` /
+        ``"failure"`` / ``"timeout"``) and ``"result"`` keys.
+
+    Raises:
+        ValueError: If ``agent_ids`` is empty.
+        TimeoutError: If no agent completes within ``timeout`` seconds.
+
+    Example::
+
+        # Race pattern: take whichever approach finishes first
+        subagent("fast", "Quick attempt at task X")
+        subagent("thorough", "Thorough attempt at task X")
+        first_id, result = subagent_wait_any(["fast", "thorough"], timeout=120)
+        print(f"{first_id} won the race: {result['status']}")
+        # Cancel the slower agent
+        for aid in ("fast", "thorough"):
+            if aid != first_id:
+                subagent_cancel(aid)
+    """
+    if not agent_ids:
+        raise ValueError("agent_ids must not be empty")
+
+    from .batch import BatchJob
+
+    job = BatchJob(agent_ids=list(agent_ids))
+    return job.wait_any(timeout=timeout)
+
+
 def subagent_read_log(
     agent_id: str,
     max_messages: int = 50,

--- a/gptme/tools/subagent/batch.py
+++ b/gptme/tools/subagent/batch.py
@@ -233,6 +233,94 @@ class BatchJob:
                 }
             return raw
 
+    def wait_any(self, timeout: float = 300) -> tuple[str, dict]:
+        """Wait for the first subagent to complete and return its result.
+
+        Useful for speculative/hedging patterns: spawn N subagents and take
+        whichever finishes first, then cancel the rest.
+
+        Args:
+            timeout: Maximum seconds to wait for any agent to complete.
+
+        Returns:
+            Tuple of ``(agent_id, result_dict)`` for the first agent that
+            completes. When ``output_schema`` is set on the ``BatchJob`` the
+            result is automatically parsed.
+
+        Raises:
+            TimeoutError: If no agent completes within ``timeout`` seconds.
+
+        Example::
+
+            job = subagent_batch([
+                ("attempt-fast", "Try the quick approach for task X"),
+                ("attempt-thorough", "Try the thorough approach for task X"),
+            ])
+            first_id, result = job.wait_any(timeout=120)
+            print(f"{first_id} finished first: {result['status']}")
+            # Cancel the remaining agent
+            from gptme.tools.subagent import subagent_cancel
+            for aid in job.agent_ids:
+                if aid != first_id:
+                    subagent_cancel(aid)
+        """
+        done_event = threading.Event()
+        first_result: list[tuple[str, ReturnType]] = []
+
+        def _wait_one_notify(agent_id: str) -> None:
+            try:
+                raw = subagent_wait(
+                    agent_id, timeout=int(max(1, timeout)), max_result_chars=0
+                )
+                status = raw.get("status", "failure")
+                if status == "running":
+                    status = "timeout"
+                result = ReturnType(
+                    status,
+                    raw.get("result"),
+                    input_tokens=raw.get("input_tokens"),
+                    output_tokens=raw.get("output_tokens"),
+                )
+            except Exception as exc:
+                result = ReturnType("failure", str(exc))
+
+            with self._lock:
+                if agent_id not in self.results:
+                    self.results[agent_id] = result
+                # Signal if this is the first successful/failed terminal result
+                if not done_event.is_set():
+                    first_result.append((agent_id, result))
+                    done_event.set()
+
+        # If any result is already cached, return it immediately.
+        with self._lock:
+            for aid in self.agent_ids:
+                if aid in self.results:
+                    raw = asdict(self.results[aid])
+                    if self.output_schema is not None:
+                        raw = _parse_result(raw, self.output_schema)
+                    return aid, raw
+            pending = [aid for aid in self.agent_ids if aid not in self.results]
+
+        threads = [
+            threading.Thread(target=_wait_one_notify, args=(aid,), daemon=True)
+            for aid in pending
+        ]
+        for t in threads:
+            t.start()
+
+        signalled = done_event.wait(timeout=timeout)
+        if not signalled or not first_result:
+            raise TimeoutError(
+                f"No subagent completed within {timeout}s (waiting for: {pending})"
+            )
+
+        first_id, first_ret = first_result[0]
+        raw = asdict(first_ret)
+        if self.output_schema is not None:
+            raw = _parse_result(raw, self.output_schema)
+        return first_id, raw
+
 
 def subagent_batch(
     tasks: list[tuple[str, str]],

--- a/gptme/tools/subagent/batch.py
+++ b/gptme/tools/subagent/batch.py
@@ -10,6 +10,7 @@ while item B is still in stage 1.
 import copy
 import json
 import logging
+import math
 import threading
 import time
 from collections.abc import Callable
@@ -233,7 +234,7 @@ class BatchJob:
                 }
             return raw
 
-    def wait_any(self, timeout: float = 300) -> tuple[str, dict]:
+    def wait_any(self, timeout: int = 300) -> tuple[str, dict]:
         """Wait for the first subagent to complete and return its result.
 
         Useful for speculative/hedging patterns: spawn N subagents and take
@@ -267,14 +268,22 @@ class BatchJob:
         done_event = threading.Event()
         first_result: list[tuple[str, ReturnType]] = []
 
+        terminal_statuses = {"success", "failure", "clarification_needed"}
+        deadline = time.monotonic() + timeout
+
         def _wait_one_notify(agent_id: str) -> None:
+            if done_event.is_set():
+                return
+
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+
             try:
                 raw = subagent_wait(
-                    agent_id, timeout=int(max(1, timeout)), max_result_chars=0
+                    agent_id, timeout=max(1, math.ceil(remaining)), max_result_chars=0
                 )
                 status = raw.get("status", "failure")
-                if status == "running":
-                    status = "timeout"
                 result = ReturnType(
                     status,
                     raw.get("result"),
@@ -283,6 +292,9 @@ class BatchJob:
                 )
             except Exception as exc:
                 result = ReturnType("failure", str(exc))
+
+            if result.status not in terminal_statuses:
+                return
 
             with self._lock:
                 if agent_id not in self.results:

--- a/tests/test_tools_subagent.py
+++ b/tests/test_tools_subagent.py
@@ -3290,28 +3290,28 @@ def test_subagent_wait_any_returns_first_completed():
 
 
 def test_subagent_wait_any_timeout_raises():
-    """subagent_wait_any should raise TimeoutError when no agent completes."""
-    import threading
+    """subagent_wait_any should raise TimeoutError when all agents keep running."""
     from unittest.mock import patch
-
-    from gptme.tools.subagent import subagent_wait_any
-
-    barrier = threading.Event()
-
-    def blocking_wait(agent_id, timeout, max_result_chars=0):
-        # Block longer than our timeout
-        barrier.wait(timeout=5)
-        return {"status": "success", "result": "too late"}
 
     import pytest
 
+    from gptme.tools.subagent import subagent_wait_any
+
+    wait_timeouts: list[int] = []
+
+    def still_running_wait(agent_id, timeout, max_result_chars=0):
+        wait_timeouts.append(timeout)
+        return {"status": "running", "result": None}
+
     with (
-        patch("gptme.tools.subagent.batch.subagent_wait", side_effect=blocking_wait),
+        patch(
+            "gptme.tools.subagent.batch.subagent_wait", side_effect=still_running_wait
+        ),
         pytest.raises(TimeoutError),
     ):
-        subagent_wait_any(["a", "b"], timeout=0.05)
+        subagent_wait_any(["a", "b"], timeout=1)
 
-    barrier.set()  # unblock background threads
+    assert wait_timeouts == [1, 1]
 
 
 def test_batch_job_wait_any_returns_first():

--- a/tests/test_tools_subagent.py
+++ b/tests/test_tools_subagent.py
@@ -3252,3 +3252,99 @@ def test_subagent_pipeline_output_schema_only_on_final_stage():
     assert schema_kwargs_by_id.get("item-s0") is None
     # Stage 1 (final) should get output_schema
     assert schema_kwargs_by_id.get("item-s1") is Result
+
+
+# Tests for subagent_wait_any
+
+
+def test_subagent_wait_any_raises_on_empty_list():
+    """subagent_wait_any([]) should raise ValueError."""
+    import pytest
+
+    from gptme.tools.subagent import subagent_wait_any
+
+    with pytest.raises(ValueError, match="agent_ids must not be empty"):
+        subagent_wait_any([])
+
+
+def test_subagent_wait_any_returns_first_completed():
+    """subagent_wait_any should return the first agent that completes."""
+    from unittest.mock import patch
+
+    from gptme.tools.subagent import subagent_wait_any
+
+    call_order: list[str] = []
+
+    def fake_wait(agent_id, timeout, max_result_chars=0):
+        call_order.append(agent_id)
+        if agent_id == "fast":
+            return {"status": "success", "result": "fast result"}
+        # "slow" blocks longer — in practice the thread pool handles it
+        return {"status": "success", "result": "slow result"}
+
+    with patch("gptme.tools.subagent.batch.subagent_wait", side_effect=fake_wait):
+        first_id, result = subagent_wait_any(["fast", "slow"], timeout=10)
+
+    assert first_id in ("fast", "slow")
+    assert result["status"] == "success"
+
+
+def test_subagent_wait_any_timeout_raises():
+    """subagent_wait_any should raise TimeoutError when no agent completes."""
+    import threading
+    from unittest.mock import patch
+
+    from gptme.tools.subagent import subagent_wait_any
+
+    barrier = threading.Event()
+
+    def blocking_wait(agent_id, timeout, max_result_chars=0):
+        # Block longer than our timeout
+        barrier.wait(timeout=5)
+        return {"status": "success", "result": "too late"}
+
+    import pytest
+
+    with (
+        patch("gptme.tools.subagent.batch.subagent_wait", side_effect=blocking_wait),
+        pytest.raises(TimeoutError),
+    ):
+        subagent_wait_any(["a", "b"], timeout=0.05)
+
+    barrier.set()  # unblock background threads
+
+
+def test_batch_job_wait_any_returns_first():
+    """BatchJob.wait_any() should return whichever agent completes first."""
+    from unittest.mock import patch
+
+    from gptme.tools.subagent.batch import BatchJob
+
+    results_seen: list[str] = []
+
+    def fake_wait(agent_id, timeout, max_result_chars=0):
+        results_seen.append(agent_id)
+        return {"status": "success", "result": f"result from {agent_id}"}
+
+    job = BatchJob(agent_ids=["a", "b", "c"])
+    with patch("gptme.tools.subagent.batch.subagent_wait", side_effect=fake_wait):
+        first_id, result = job.wait_any(timeout=10)
+
+    assert first_id in ("a", "b", "c")
+    assert result["status"] == "success"
+    assert f"result from {first_id}" in result["result"]
+
+
+def test_batch_job_wait_any_already_done():
+    """BatchJob.wait_any() should return immediately when a result is already cached."""
+    from gptme.tools.subagent.batch import BatchJob
+    from gptme.tools.subagent.types import ReturnType
+
+    job = BatchJob(agent_ids=["x", "y"])
+    job.results["x"] = ReturnType("success", "cached result")
+
+    # Should not need to call subagent_wait at all
+    first_id, result = job.wait_any(timeout=1)
+    assert first_id == "x"
+    assert result["status"] == "success"
+    assert result["result"] == "cached result"


### PR DESCRIPTION
## Summary

Adds `subagent_wait_any(agent_ids, timeout)` and `BatchJob.wait_any()` — a race/hedging pattern that blocks until the **first** of N subagents completes and returns `(agent_id, result_dict)`.

This fills a gap in the comparison table from #554 where orchestration patterns like "spawn N approaches, take whichever finishes first, cancel the rest" required manual polling. The new function makes this idiomatic:

```python
subagent("fast", "Quick approach for task X")
subagent("thorough", "Thorough approach for task X")
first_id, result = subagent_wait_any(["fast", "thorough"], timeout=120)
print(f"{first_id} won the race: {result['status']}")
for aid in ("fast", "thorough"):
    if aid != first_id:
        subagent_cancel(aid)
```

## Changes

- **`batch.py`**: `BatchJob.wait_any(timeout)` — spawns per-agent waiter threads, signals a `threading.Event` on first completion. Short-circuits immediately if any result is already cached (from a prior hook notification).
- **`api.py`**: `subagent_wait_any(agent_ids, timeout)` — standalone convenience function wrapping `BatchJob.wait_any()`. Raises `ValueError` on empty list, `TimeoutError` on timeout.
- **`__init__.py`**: exports `subagent_wait_any`, registers as `ToolFunction`, adds to `__all__` and instructions.
- **`tests/test_tools_subagent.py`**: 5 new unit tests (empty list validation, first-completer, timeout, cached-result short-circuit, BatchJob.wait_any).

## Test plan

- [x] 5 new unit tests pass
- [x] All 367 existing subagent tests pass
- [x] Pre-commit (ruff, mypy) clean

<!-- gptme-id:v1:gai_oFaCNN8lJ0df8RHh1cgyiE7jcd2qGBU9la64j5rCZ1Y -->