### PR TITLE
fix(info): fall back to pyproject.toml when editable install omits Provides-Extra (#216)

### DIFF
--- a/gptme/info.py
+++ b/gptme/info.py
@@ -77,12 +77,12 @@ def _parse_extras_from_pyproject(pyproject_path: Path) -> list[ExtraInfo]:
     try:
         with open(pyproject_path, "rb") as f:
             data = tomllib.load(f)  # type: ignore[attr-defined]
-    except (OSError, Exception):
+    except Exception:
         return []
 
-    extras_dict: dict[str, list[str]] = (
-        data.get("tool", {}).get("poetry", {}).get("extras", {})
-    )
+    extras_dict: dict[str, list[str]] = data.get("tool", {}).get("poetry", {}).get(
+        "extras", {}
+    ) or data.get("project", {}).get("optional-dependencies", {})
     if not extras_dict:
         return []
 
@@ -126,9 +126,7 @@ def _parse_extras_from_metadata() -> list[ExtraInfo]:
         try:
             direct_url = dist.read_text("direct_url.json")
             if direct_url:
-                import json as _json
-
-                url_data = _json.loads(direct_url)
+                url_data = json.loads(direct_url)
                 dir_info = url_data.get("dir_info", {})
                 if dir_info.get("editable"):
                     src_url = url_data.get("url", "")

--- a/gptme/info.py
+++ b/gptme/info.py
@@ -12,6 +12,7 @@ import json
 import platform
 import re
 import shutil
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -77,7 +78,7 @@ def _load_toml_data(pyproject_path: Path) -> dict:
     except Exception:
         return {}
 
-    return data if isinstance(data, dict) else {}
+    return dict(data) if isinstance(data, Mapping) else {}
 
 
 def _requirement_package_name(requirement: str) -> str | None:

--- a/gptme/info.py
+++ b/gptme/info.py
@@ -5,6 +5,7 @@ Provides functions to inspect gptme's installation state, configuration,
 and runtime environment. Used by both `--version` and `gptme-doctor`.
 """
 
+import importlib
 import importlib.metadata
 import importlib.util
 import json
@@ -57,27 +58,44 @@ _INTERNAL_EXTRAS = {"all", "eval", "pyinstaller"}
 _EXTRAS_CACHE: list[ExtraInfo] | None = None
 
 
+def _load_toml_data(pyproject_path: Path) -> dict:
+    """Load TOML data using whichever parser is available."""
+    toml_module = None
+    for module_name in ("tomllib", "tomli", "tomlkit"):
+        try:
+            toml_module = importlib.import_module(module_name)
+            break
+        except ImportError:
+            continue
+
+    if toml_module is None:
+        return {}
+
+    try:
+        with pyproject_path.open("rb") as f:
+            data = toml_module.load(f)
+    except Exception:
+        return {}
+
+    return data if isinstance(data, dict) else {}
+
+
+def _requirement_package_name(requirement: str) -> str | None:
+    """Extract the distribution name from a dependency specifier."""
+    match = re.match(r"^\s*([A-Za-z0-9][A-Za-z0-9._-]*)", requirement)
+    if not match:
+        return None
+    return match.group(1)
+
+
 def _parse_extras_from_pyproject(pyproject_path: Path) -> list[ExtraInfo]:
     """Parse extras from pyproject.toml as a fallback for editable installs.
 
     Poetry editable installs don't populate Provides-Extra in package metadata.
     This fallback reads pyproject.toml directly when that happens.
     """
-    try:
-        import tomllib  # Python 3.11+
-    except ImportError:
-        try:
-            import tomli as tomllib  # type: ignore[import-not-found,no-redef]
-        except ImportError:
-            try:
-                import tomlkit as tomllib  # type: ignore[import-not-found,no-redef]
-            except ImportError:
-                return []
-
-    try:
-        with open(pyproject_path, "rb") as f:
-            data = tomllib.load(f)  # type: ignore[attr-defined]
-    except Exception:
+    data = _load_toml_data(pyproject_path)
+    if not data:
         return []
 
     extras_dict: dict[str, list[str]] = data.get("tool", {}).get("poetry", {}).get(
@@ -90,6 +108,13 @@ def _parse_extras_from_pyproject(pyproject_path: Path) -> list[ExtraInfo]:
     for name, packages in sorted(extras_dict.items()):
         if name in _INTERNAL_EXTRAS:
             continue
+        normalized_packages = []
+        for package in packages:
+            if not isinstance(package, str):
+                continue
+            package_name = _requirement_package_name(package)
+            if package_name and package_name not in normalized_packages:
+                normalized_packages.append(package_name)
         result.append(
             ExtraInfo(
                 name=name,
@@ -97,7 +122,7 @@ def _parse_extras_from_pyproject(pyproject_path: Path) -> list[ExtraInfo]:
                 description=_EXTRA_DESCRIPTIONS.get(
                     name, name.replace("_", " ").title()
                 ),
-                packages=[p for p in packages if isinstance(p, str)],
+                packages=normalized_packages,
             )
         )
     return result

--- a/gptme/info.py
+++ b/gptme/info.py
@@ -57,11 +57,59 @@ _INTERNAL_EXTRAS = {"all", "eval", "pyinstaller"}
 _EXTRAS_CACHE: list[ExtraInfo] | None = None
 
 
+def _parse_extras_from_pyproject(pyproject_path: Path) -> list[ExtraInfo]:
+    """Parse extras from pyproject.toml as a fallback for editable installs.
+
+    Poetry editable installs don't populate Provides-Extra in package metadata.
+    This fallback reads pyproject.toml directly when that happens.
+    """
+    try:
+        import tomllib  # Python 3.11+
+    except ImportError:
+        try:
+            import tomli as tomllib  # type: ignore[import-not-found,no-redef]
+        except ImportError:
+            try:
+                import tomlkit as tomllib  # type: ignore[import-not-found,no-redef]
+            except ImportError:
+                return []
+
+    try:
+        with open(pyproject_path, "rb") as f:
+            data = tomllib.load(f)  # type: ignore[attr-defined]
+    except (OSError, Exception):
+        return []
+
+    extras_dict: dict[str, list[str]] = (
+        data.get("tool", {}).get("poetry", {}).get("extras", {})
+    )
+    if not extras_dict:
+        return []
+
+    result = []
+    for name, packages in sorted(extras_dict.items()):
+        if name in _INTERNAL_EXTRAS:
+            continue
+        result.append(
+            ExtraInfo(
+                name=name,
+                installed=False,
+                description=_EXTRA_DESCRIPTIONS.get(
+                    name, name.replace("_", " ").title()
+                ),
+                packages=[p for p in packages if isinstance(p, str)],
+            )
+        )
+    return result
+
+
 def _parse_extras_from_metadata() -> list[ExtraInfo]:
     """Parse extras from package metadata.
 
     Dynamically reads extras and their dependencies from the installed
     gptme package metadata, ensuring the list stays in sync with pyproject.toml.
+    Falls back to reading pyproject.toml directly when the editable install
+    (e.g. Poetry or uv) does not populate Provides-Extra in the metadata.
     """
     try:
         dist = importlib.metadata.distribution("gptme")
@@ -71,6 +119,27 @@ def _parse_extras_from_metadata() -> list[ExtraInfo]:
     # Get list of extras from package metadata
     all_extras = dist.metadata.get_all("Provides-Extra") or []
     extras = [e for e in all_extras if e not in _INTERNAL_EXTRAS]
+
+    # Fallback: Poetry and uv editable installs often omit Provides-Extra.
+    # Read pyproject.toml from the install source directory instead.
+    if not extras:
+        try:
+            direct_url = dist.read_text("direct_url.json")
+            if direct_url:
+                import json as _json
+
+                url_data = _json.loads(direct_url)
+                dir_info = url_data.get("dir_info", {})
+                if dir_info.get("editable"):
+                    src_url = url_data.get("url", "")
+                    if src_url.startswith("file://"):
+                        src_dir = Path(src_url[7:])
+                        pyproject = src_dir / "pyproject.toml"
+                        if pyproject.exists():
+                            return _parse_extras_from_pyproject(pyproject)
+        except Exception:
+            pass
+        return []
 
     # Parse dependencies for each extra from Requires-Dist
     requires = dist.requires or []

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1,6 +1,8 @@
 """Tests for the gptme doctor command."""
 
 import json
+from collections import UserDict
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from click.testing import CliRunner
@@ -389,6 +391,32 @@ class TestCheckPythonDeps:
         assert extras["browser"] == ["playwright"]
         assert extras["telemetry"] == ["opentelemetry-api", "opentelemetry-sdk"]
         assert extras["server"] == ["flask"]
+
+    def test_pyproject_fallback_accepts_tomlkit_mapping(self, tmp_path):
+        """tomlkit returns a mapping, not a plain dict."""
+        from gptme.info import _parse_extras_from_pyproject
+
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text("")
+        tomlkit_like = SimpleNamespace(
+            load=lambda _f: UserDict(
+                {"tool": {"poetry": {"extras": {"browser": ["playwright"]}}}}
+            )
+        )
+
+        def fake_import_module(module_name):
+            if module_name == "tomlkit":
+                return tomlkit_like
+            raise ImportError(module_name)
+
+        with patch(
+            "gptme.info.importlib.import_module", side_effect=fake_import_module
+        ):
+            result = _parse_extras_from_pyproject(pyproject)
+
+        assert [(extra.name, extra.packages) for extra in result] == [
+            ("browser", ["playwright"])
+        ]
 
 
 class TestCheckConfig:

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -370,6 +370,26 @@ class TestCheckPythonDeps:
         finally:
             _info._EXTRAS_CACHE = old_cache
 
+    def test_pyproject_fallback_normalizes_pep621_requirements(self, tmp_path):
+        """PEP 621 optional-dependencies should map to importable package names."""
+        from gptme.info import _parse_extras_from_pyproject
+
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            "[project]\n"
+            "[project.optional-dependencies]\n"
+            'browser = ["playwright>=1.40"]\n'
+            'telemetry = ["opentelemetry-api>=1.20", "opentelemetry-sdk"]\n'
+            'server = ["flask[async]>=3.0"]\n'
+        )
+
+        result = _parse_extras_from_pyproject(pyproject)
+        extras = {extra.name: extra.packages for extra in result}
+
+        assert extras["browser"] == ["playwright"]
+        assert extras["telemetry"] == ["opentelemetry-api", "opentelemetry-sdk"]
+        assert extras["server"] == ["flask"]
+
 
 class TestCheckConfig:
     """Test _check_config function."""

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -313,6 +313,63 @@ class TestCheckPythonDeps:
         assert any("browser" in name for name in dep_names)
         assert any("dspy" in name for name in dep_names)
 
+    def test_pyproject_fallback_used_when_metadata_empty(self, tmp_path):
+        """Test that pyproject.toml is read when Provides-Extra is absent.
+
+        Poetry / uv editable installs often omit Provides-Extra from the
+        package metadata.  The fallback must parse pyproject.toml instead
+        so that gptme-doctor can show optional deps in dev environments.
+        """
+        import json
+
+        from gptme.info import _parse_extras_from_metadata
+
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            "[tool.poetry.extras]\n"
+            'browser = ["playwright"]\n'
+            "computer = []\n"
+            'dspy = ["dspy"]\n'
+        )
+        direct_url = tmp_path / "direct_url.json"
+        direct_url.write_text(
+            json.dumps({"url": f"file://{tmp_path}", "dir_info": {"editable": True}})
+        )
+
+        import gptme.info as _info
+
+        old_cache = _info._EXTRAS_CACHE
+        try:
+            _info._EXTRAS_CACHE = None  # clear cache so fresh parse runs
+
+            def _fake_dist(name):
+                class FakeMeta:
+                    def get_all(self, key):
+                        return [] if key == "Provides-Extra" else None
+
+                class FakeDist:
+                    metadata = FakeMeta()
+                    requires = []
+
+                    def read_text(self, fname):
+                        if fname == "direct_url.json":
+                            return direct_url.read_text()
+                        return None
+
+                return FakeDist()
+
+            import importlib.metadata as _imeta
+
+            with patch.object(_imeta, "distribution", side_effect=_fake_dist):
+                result = _parse_extras_from_metadata()
+
+            names = [e.name for e in result]
+            assert "browser" in names
+            assert "computer" in names
+            assert "dspy" in names
+        finally:
+            _info._EXTRAS_CACHE = old_cache
+
 
 class TestCheckConfig:
     """Test _check_config function."""


### PR DESCRIPTION
## Summary

`gptme doctor` and `gptme-util computer doctor` were silently showing no Python optional-dependency results for dev/editable installs (Poetry, `uv sync`). These tools showed the extras section blank because `get_installed_extras()` returned `[]` — the root cause was that Poetry/uv editable installs don't populate `Provides-Extra` in the package metadata.

This matters for computer-use setup: `gptme-util computer doctor` is how users verify the `browser` and `computer` extras are available, and it was broken in the most common dev-install scenario.

- **`gptme/info.py`**: add `_parse_extras_from_pyproject()` that reads `[tool.poetry.extras]` from the source pyproject.toml via `direct_url.json` when metadata yields empty extras. Falls back gracefully on any error.
- **`tests/test_doctor.py`**: add `test_pyproject_fallback_used_when_metadata_empty` to prevent regression.

## Test plan

- [x] `pytest tests/test_doctor.py::TestCheckPythonDeps` — all 3 tests pass (was 2 failures before)
- [x] `pytest tests/test_doctor.py` — all 75 tests pass
- [x] `gptme-doctor` output shows browser/computer/dspy extras in dev install
- [x] `gptme-util computer doctor` works correctly

<!-- gptme-id:v1:gai_vouKbG3Vo154yRfOl6yATuEu6LmcF7Phe4OU8CVSTMt -->