### PR TITLE
fix(computer): treat playwright missing as warning, not hard failure (#216)

### DIFF
--- a/gptme/cli/cmd_computer.py
+++ b/gptme/cli/cmd_computer.py
@@ -1337,10 +1337,10 @@ def doctor_cmd(display: str | None):
     except ImportError:
         _check(
             "playwright not installed (browser tool disabled)",
-            ok=False,
-            hint="pip install playwright  &&  python -m playwright install chromium",
+            ok=True,
+            warn=True,
+            hint="pip install playwright  &&  python -m playwright install chromium  (optional — needed for browser tool)",
         )
-        errors += 1
     click.echo()
 
     # --- Screenshot latency sample ---

--- a/tests/test_computer_doctor_cmd.py
+++ b/tests/test_computer_doctor_cmd.py
@@ -143,9 +143,7 @@ class TestDoctorLinux:
                 return_value=_fake_transport(tmp_path),
             ),
             patch("gptme.tools.computer_transport.NativeComputerTransport", MagicMock),
-            patch.dict(
-                sys.modules, {"playwright.sync_api": pw_stub, "pyatspi": MagicMock()}
-            ),
+            patch.dict(sys.modules, {"playwright.sync_api": pw_stub, "pyatspi": None}),
         ):
             result = runner.invoke(doctor_cmd, [])
 
@@ -237,9 +235,7 @@ class TestDoctorLinux:
                 "gptme.tools.computer_transport.NativeComputerTransport",
                 return_value=transport,
             ),
-            patch.dict(
-                sys.modules, {"playwright.sync_api": pw_stub, "pyatspi": MagicMock()}
-            ),
+            patch.dict(sys.modules, {"playwright.sync_api": pw_stub, "pyatspi": None}),
         ):
             result = runner.invoke(doctor_cmd, ["--display", ":99"])
 
@@ -426,7 +422,6 @@ class TestDoctorPlaywright:
                 {
                     "playwright": None,
                     "playwright.sync_api": None,
-                    "pyatspi": MagicMock(),
                 },
             ),
         ):
@@ -534,9 +529,7 @@ class TestDoctorLatencySection:
                 side_effect=RuntimeError("transport boom"),
             ),
             patch("gptme.tools.computer_transport.NativeComputerTransport", MagicMock),
-            patch.dict(
-                sys.modules, {"playwright.sync_api": pw_stub, "pyatspi": MagicMock()}
-            ),
+            patch.dict(sys.modules, {"playwright.sync_api": pw_stub, "pyatspi": None}),
         ):
             result = runner.invoke(doctor_cmd, [])
 

--- a/tests/test_computer_doctor_cmd.py
+++ b/tests/test_computer_doctor_cmd.py
@@ -396,10 +396,16 @@ class TestDoctorMacOS:
 class TestDoctorPlaywright:
     """Doctor reports Playwright status correctly."""
 
-    def test_reports_playwright_not_installed(self, monkeypatch):
-        """When playwright cannot be imported, doctor reports it as a failure."""
+    def test_reports_playwright_not_installed(self, monkeypatch, tmp_path):
+        """When playwright cannot be imported, doctor warns but exits 0.
+
+        Native desktop control (xdotool/scrot) works without playwright.
+        Playwright is only needed for the browser tool, so its absence is a
+        warning (like pyatspi), not a hard failure.
+        """
         monkeypatch.setenv("DISPLAY", ":1")
         runner = CliRunner()
+        transport_mock = _fake_transport(tmp_path)
         with (
             patch("platform.system", return_value="Linux"),
             patch("platform.machine", return_value="x86_64"),
@@ -407,12 +413,29 @@ class TestDoctorPlaywright:
                 "gptme.cli.cmd_computer.shutil.which",
                 side_effect=lambda cmd: f"/usr/bin/{cmd}",
             ),
-            patch("gptme.tools.computer_transport.get_transport", return_value=None),
-            patch("gptme.tools.computer_transport.NativeComputerTransport", MagicMock),
-            patch.dict(sys.modules, {"playwright": None, "playwright.sync_api": None}),
+            patch(
+                "gptme.tools.computer_transport.get_transport",
+                return_value=transport_mock,
+            ),
+            patch(
+                "gptme.tools.computer_transport.NativeComputerTransport",
+                return_value=transport_mock,
+            ),
+            patch.dict(
+                sys.modules,
+                {
+                    "playwright": None,
+                    "playwright.sync_api": None,
+                    "pyatspi": MagicMock(),
+                },
+            ),
         ):
             result = runner.invoke(doctor_cmd, [])
         assert "playwright" in result.output.lower()
+        # playwright missing is a warning, not a hard failure — native computer use still works
+        assert result.exit_code == 0, (
+            f"Expected exit 0 (warning), got {result.exit_code}:\n{result.output}"
+        )
 
     def test_reports_chromium_binary_missing(self, monkeypatch, tmp_path):
         """When playwright is installed but chromium binary is missing, doctor reports it."""


### PR DESCRIPTION
## Problem

`gptme-util computer doctor` exited with code 1 (failure) when playwright was not installed, even on systems where native desktop control (screenshots, mouse, keyboard via xdotool/scrot) works correctly. This gave a false signal that computer-use was broken.

The inconsistency: `pyatspi` absent → yellow warning `!`, exit 0 (correct). `playwright` absent → red failure `✗`, exit 1 (incorrect).

Playwright is only needed for the **browser tool** (`snapshot_url`, `open_page`, `fill_element`, etc.). The **computer tool** (`screenshot`, `left_click`, `type`, `key`, `accessibility_tree`) works entirely without it. So "playwright not installed" is an optional-feature warning, not a computer-use failure.

## Fix

- `playwright` absent → `warn=True` (yellow `!`), no `errors += 1`, exit 0 — same pattern as `pyatspi`
- Hint text updated to say `(optional — needed for browser tool)`  
- `playwright` installed but chromium missing → still a hard error (misconfigured install, user intended to set it up)

## Test

Updated `test_reports_playwright_not_installed` to assert `exit_code == 0` and provides a proper mock transport so the latency check also passes — making the test a true end-to-end scenario for "all-native, no playwright" setups.

Closes the playwright/pyatspi inconsistency in the `gptme-util computer doctor` command (#216).

Fixes #216

<!-- gptme-id:v1:gai_IQRHLzRf11NWLTDKdZE1bMbxGIADupQRB5xYjuFf8rO -->