### PR TITLE
fix(computer): treat missing Playwright chromium binary as warning, not error (#216)

### DIFF
--- a/gptme/cli/cmd_computer.py
+++ b/gptme/cli/cmd_computer.py
@@ -1503,14 +1503,16 @@ def doctor_cmd(display: str | None):
         except Exception:
             ok_chromium = False
 
-        if not _check(
+        # Chromium binary is optional — the computer tool works without it.
+        # Treat a missing binary the same way as a missing playwright package.
+        _check(
             "Playwright chromium available"
             if ok_chromium
-            else "Playwright chromium not found",
+            else "Playwright chromium not installed (browser tool disabled)",
             ok=ok_chromium,
-            hint="python -m playwright install chromium",
-        ):
-            errors += 1
+            warn=not ok_chromium,
+            hint="python -m playwright install chromium  (optional — needed for browser tool)",
+        )
     except ImportError:
         _check(
             "playwright not installed (browser tool disabled)",

--- a/gptme/cli/cmd_computer.py
+++ b/gptme/cli/cmd_computer.py
@@ -1509,7 +1509,7 @@ def doctor_cmd(display: str | None):
             "Playwright chromium available"
             if ok_chromium
             else "Playwright chromium not installed (browser tool disabled)",
-            ok=ok_chromium,
+            ok=True,
             warn=not ok_chromium,
             hint="python -m playwright install chromium  (optional — needed for browser tool)",
         )

--- a/tests/test_computer_doctor_cmd.py
+++ b/tests/test_computer_doctor_cmd.py
@@ -466,6 +466,52 @@ class TestDoctorPlaywright:
             "chromium" in result.output.lower() or "playwright" in result.output.lower()
         )
 
+    def test_chromium_binary_missing_is_warning_not_error(self, monkeypatch, tmp_path):
+        """When playwright package is installed but chromium binary is absent, doctor exits 0.
+
+        A missing chromium binary is optional (only needed for the browser tool) — the
+        computer tool (screenshot, click, keyboard) works without it.  This mirrors
+        the treatment of a missing playwright *package* (PR #3129): both are warnings,
+        not hard failures.
+        """
+        monkeypatch.setenv("DISPLAY", ":1")
+
+        pw_stub = MagicMock()
+        pw_cm = MagicMock()
+        pw_cm.__enter__ = lambda s: MagicMock(
+            chromium=MagicMock(executable_path="/nonexistent/chromium")
+        )
+        pw_cm.__exit__ = lambda *a: None
+        pw_stub.sync_playwright.return_value = pw_cm
+
+        runner = CliRunner()
+        with (
+            patch("platform.system", return_value="Linux"),
+            patch("platform.machine", return_value="x86_64"),
+            patch(
+                "gptme.cli.cmd_computer.shutil.which",
+                side_effect=lambda cmd: f"/usr/bin/{cmd}",
+            ),
+            patch(
+                "gptme.tools.computer_transport.get_transport",
+                return_value=_fake_transport(tmp_path),
+            ),
+            patch("gptme.tools.computer_transport.NativeComputerTransport", MagicMock),
+            patch.dict(sys.modules, {"playwright.sync_api": pw_stub, "pyatspi": None}),
+        ):
+            result = runner.invoke(doctor_cmd, [])
+
+        # Exit 0: missing chromium binary is a warning, not a hard failure
+        assert result.exit_code == 0, (
+            f"Expected exit 0 (warning), got {result.exit_code}:\n{result.output}"
+        )
+        # The warning marker '!' should appear, not the error marker '✗'
+        assert "!" in result.output
+        assert (
+            "optional" in result.output.lower()
+            or "browser tool" in result.output.lower()
+        )
+
 
 class TestDoctorLatencySection:
     """Doctor's latency sample section."""


### PR DESCRIPTION
## Summary

When `playwright` is installed but the Chromium browser binary hasn't been downloaded yet (`playwright install chromium` not yet run), `gptme-util computer doctor` was exiting 1 (failure) even though the computer tool works fine without it.

**Root cause:** The Playwright browser binary is only needed for the browser tool. PR #3129 already made a *missing playwright package* a warning — this applies the same logic consistently to a missing browser *binary*.

**Before:**
```
  ✗  Playwright chromium not found
  ❌  1 check(s) failed.
```

**After:**
```
  !  Playwright chromium not installed (browser tool disabled)
       python -m playwright install chromium  (optional — needed for browser tool)
  ✅  All checks passed — computer-use is ready.
```

## Changes

- `gptme/cli/cmd_computer.py`: changed Playwright chromium binary check from `errors += 1` (hard failure) to `warn=True` (advisory warning), matching the treatment of a missing playwright package
- `tests/test_computer_doctor_cmd.py`: added `test_chromium_binary_missing_is_warning_not_error` regression test

## Tested

- All 21 doctor unit tests pass
- Verified on this machine (X11 display available, playwright installed, chromium binary absent):
  - Before: exit 1 with `❌ 1 check(s) failed`
  - After: exit 0 with `✅ All checks passed — computer-use is ready.`

Closes gptme/gptme#216 (partial: addresses doctor UX gap)

<!-- gptme-id:v1:gai_dyp4k96MWYJKwmEcq2Azj2FgKtRHisc7P1rcWPI88xL -->