### PR TITLE
feat(computer): surface terminal startup delay fix in doctor (#216)

### DIFF
--- a/gptme/cli/cmd_computer.py
+++ b/gptme/cli/cmd_computer.py
@@ -1450,6 +1450,31 @@ def doctor_cmd(display: str | None):
                 warn=True,
                 hint="pip install pyatspi  (optional — needed for accessibility_tree action)",
             )
+
+        # ~/.Xdefaults bitmap-font check (terminal startup delay fix — issue #216).
+        # xterm's default Xft renderer scans all system font dirs on first launch
+        # (fontconfig scan), adding 1–3 s of startup latency.  Setting XTerm*font
+        # to a built-in bitmap font ("fixed") bypasses Xft entirely.
+        _xdefaults = Path.home() / ".Xdefaults"
+        _xres_content = _xdefaults.read_text() if _xdefaults.exists() else ""
+        _has_bitmap_font = bool(
+            __import__("re").search(
+                r"(?m)^XTerm\*(?:bold)?[Ff]ont\s*:\s*(?:fixed|6x13|7x13|8x13|9x15)",
+                _xres_content,
+            )
+        )
+        _check(
+            "~/.Xdefaults uses bitmap font (fast xterm startup)"
+            if _has_bitmap_font
+            else "~/.Xdefaults missing bitmap font (xterm startup may be slow — 1–3 s)",
+            ok=True,
+            warn=not _has_bitmap_font,
+            hint=(
+                "Add  XTerm*font: fixed  to ~/.Xdefaults and run  xrdb -merge ~/.Xdefaults\n"
+                "       This cuts xterm startup from ~2 s to < 100 ms (issue #216).\n"
+                "       See: gptme-util computer latency --terminal"
+            ),
+        )
         click.echo()
 
     # --- macOS native tools ---

--- a/gptme/cli/cmd_computer.py
+++ b/gptme/cli/cmd_computer.py
@@ -1462,7 +1462,9 @@ def doctor_cmd(display: str | None):
         for _fname in (".Xresources", ".Xdefaults"):
             _xp = _xhome / _fname
             if _xp.exists():
-                _xres_content += _xp.read_text() + "\n"
+                _xres_content += (
+                    _xp.read_text(encoding="utf-8", errors="replace") + "\n"
+                )
         _has_bitmap_font = bool(
             re.search(
                 r"(?m)^XTerm\*(?:bold)?[Ff]ont\s*:\s*(?:fixed|6x13|7x13|8x13|9x15)",

--- a/gptme/cli/cmd_computer.py
+++ b/gptme/cli/cmd_computer.py
@@ -1451,22 +1451,28 @@ def doctor_cmd(display: str | None):
                 hint="pip install pyatspi  (optional — needed for accessibility_tree action)",
             )
 
-        # ~/.Xdefaults bitmap-font check (terminal startup delay fix — issue #216).
+        # ~/.Xdefaults / ~/.Xresources bitmap-font check (terminal startup delay fix — #216).
         # xterm's default Xft renderer scans all system font dirs on first launch
         # (fontconfig scan), adding 1–3 s of startup latency.  Setting XTerm*font
         # to a built-in bitmap font ("fixed") bypasses Xft entirely.
-        _xdefaults = Path.home() / ".Xdefaults"
-        _xres_content = _xdefaults.read_text() if _xdefaults.exists() else ""
+        # Many modern distros apply X resources via ~/.Xresources (loaded by the
+        # display manager / xrdb), so we probe both files.
+        _xhome = Path.home()
+        _xres_content = ""
+        for _fname in (".Xresources", ".Xdefaults"):
+            _xp = _xhome / _fname
+            if _xp.exists():
+                _xres_content += _xp.read_text() + "\n"
         _has_bitmap_font = bool(
-            __import__("re").search(
+            re.search(
                 r"(?m)^XTerm\*(?:bold)?[Ff]ont\s*:\s*(?:fixed|6x13|7x13|8x13|9x15)",
                 _xres_content,
             )
         )
         _check(
-            "~/.Xdefaults uses bitmap font (fast xterm startup)"
+            "~/.Xresources / ~/.Xdefaults uses bitmap font (fast xterm startup)"
             if _has_bitmap_font
-            else "~/.Xdefaults missing bitmap font (xterm startup may be slow — 1–3 s)",
+            else "~/.Xresources / ~/.Xdefaults missing bitmap font (xterm startup may be slow — 1–3 s)",
             ok=True,
             warn=not _has_bitmap_font,
             hint=(

--- a/tests/test_computer_doctor_cmd.py
+++ b/tests/test_computer_doctor_cmd.py
@@ -585,7 +585,7 @@ class TestDoctorLatencySection:
 
 
 class TestDoctorXdefaults:
-    """Doctor checks ~/.Xdefaults for the terminal startup delay fix (issue #216)."""
+    """Doctor checks X resource files for the terminal startup delay fix."""
 
     def test_warns_when_xdefaults_missing(self, monkeypatch, tmp_path):
         """When ~/.Xdefaults does not exist, doctor emits a warning about xterm startup."""
@@ -704,6 +704,33 @@ class TestDoctorXdefaults:
         assert result.exit_code == 0, result.output
         assert "fast xterm startup" in result.output
 
+    def test_handles_non_utf8_xresources(self, monkeypatch, tmp_path):
+        """Invalid UTF-8 in X resource files should not crash doctor."""
+        monkeypatch.setenv("DISPLAY", ":1")
+        xresources = tmp_path / ".Xresources"
+        xresources.write_bytes(
+            b"! comment with invalid byte: \xff\nXTerm*font: fixed\n"
+        )
+        runner = CliRunner()
+        with (
+            patch("platform.system", return_value="Linux"),
+            patch("platform.machine", return_value="x86_64"),
+            patch(
+                "gptme.cli.cmd_computer.shutil.which",
+                side_effect=lambda cmd: f"/usr/bin/{cmd}",
+            ),
+            patch(
+                "gptme.tools.computer_transport.get_transport",
+                return_value=_fake_transport(tmp_path),
+            ),
+            patch("gptme.tools.computer_transport.NativeComputerTransport", MagicMock),
+            patch("gptme.cli.cmd_computer.Path.home", staticmethod(lambda: tmp_path)),
+        ):
+            result = runner.invoke(doctor_cmd, [])
+
+        assert result.exit_code == 0, result.output
+        assert "fast xterm startup" in result.output
+
     def test_xdefaults_check_skipped_on_macos(self, tmp_path):
         """The ~/.Xdefaults bitmap-font check is Linux-only; macOS should not show it."""
         # Create a tmp_path home with no .Xdefaults
@@ -722,3 +749,5 @@ class TestDoctorXdefaults:
 
         # ~/.Xdefaults is X11-specific; should not appear in macOS output
         assert "Xdefaults" not in result.output
+        assert "Xresources" not in result.output
+        assert "bitmap" not in result.output

--- a/tests/test_computer_doctor_cmd.py
+++ b/tests/test_computer_doctor_cmd.py
@@ -582,3 +582,167 @@ class TestDoctorLatencySection:
         assert result.exit_code == 1
         assert "could not measure latency: transport boom" in result.output
         assert "check(s) failed" in result.output
+
+
+class TestDoctorXdefaults:
+    """Doctor checks ~/.Xdefaults for the terminal startup delay fix (issue #216)."""
+
+    def _linux_patches(self, tmp_path, xdefaults_content: str | None = None):
+        """Shared Linux patches with optional ~/.Xdefaults content override."""
+        transport = _fake_transport(tmp_path)
+        xdefaults_path = tmp_path / ".Xdefaults"
+        if xdefaults_content is not None:
+            xdefaults_path.write_text(xdefaults_content)
+
+        def _fake_home():
+            return tmp_path
+
+        return [
+            patch("platform.system", return_value="Linux"),
+            patch("platform.machine", return_value="x86_64"),
+            patch(
+                "gptme.cli.cmd_computer.shutil.which",
+                side_effect=lambda cmd: f"/usr/bin/{cmd}",
+            ),
+            patch(
+                "gptme.tools.computer_transport.get_transport", return_value=transport
+            ),
+            patch("gptme.tools.computer_transport.NativeComputerTransport", MagicMock),
+            patch("gptme.cli.cmd_computer.Path.home", staticmethod(_fake_home)),
+        ]
+
+    def test_warns_when_xdefaults_missing(self, monkeypatch, tmp_path):
+        """When ~/.Xdefaults does not exist, doctor emits a warning about xterm startup."""
+        monkeypatch.setenv("DISPLAY", ":1")
+        runner = CliRunner()
+        with (
+            patch("platform.system", return_value="Linux"),
+            patch("platform.machine", return_value="x86_64"),
+            patch(
+                "gptme.cli.cmd_computer.shutil.which",
+                side_effect=lambda cmd: f"/usr/bin/{cmd}",
+            ),
+            patch(
+                "gptme.tools.computer_transport.get_transport",
+                return_value=_fake_transport(tmp_path),
+            ),
+            patch("gptme.tools.computer_transport.NativeComputerTransport", MagicMock),
+            patch("gptme.cli.cmd_computer.Path.home", staticmethod(lambda: tmp_path)),
+        ):
+            result = runner.invoke(doctor_cmd, [])
+
+        # Missing .Xdefaults: warning marker expected, but not a hard failure (exit 0)
+        assert result.exit_code == 0, result.output
+        assert "!" in result.output
+        assert (
+            "Xdefaults" in result.output
+            or "bitmap" in result.output
+            or "xterm" in result.output.lower()
+        )
+
+    def test_warns_when_xdefaults_lacks_bitmap_font(self, monkeypatch, tmp_path):
+        """When ~/.Xdefaults exists but lacks XTerm*font: fixed, doctor warns."""
+        monkeypatch.setenv("DISPLAY", ":1")
+        xdefaults = tmp_path / ".Xdefaults"
+        xdefaults.write_text("! some unrelated X resource\nXTerm*background: #000000\n")
+        runner = CliRunner()
+        with (
+            patch("platform.system", return_value="Linux"),
+            patch("platform.machine", return_value="x86_64"),
+            patch(
+                "gptme.cli.cmd_computer.shutil.which",
+                side_effect=lambda cmd: f"/usr/bin/{cmd}",
+            ),
+            patch(
+                "gptme.tools.computer_transport.get_transport",
+                return_value=_fake_transport(tmp_path),
+            ),
+            patch("gptme.tools.computer_transport.NativeComputerTransport", MagicMock),
+            patch("gptme.cli.cmd_computer.Path.home", staticmethod(lambda: tmp_path)),
+        ):
+            result = runner.invoke(doctor_cmd, [])
+
+        assert result.exit_code == 0, result.output
+        assert "!" in result.output
+        assert "Xdefaults" in result.output or "bitmap" in result.output
+
+    def test_passes_when_xterm_font_fixed(self, monkeypatch, tmp_path):
+        """When ~/.Xdefaults has XTerm*font: fixed, the check passes (no warning)."""
+        monkeypatch.setenv("DISPLAY", ":1")
+        xdefaults = tmp_path / ".Xdefaults"
+        xdefaults.write_text(
+            "XTerm*font:             fixed\nXTerm*background: #1e1e2e\n"
+        )
+        runner = CliRunner()
+        pw_stub = MagicMock()
+        pw_cm = MagicMock()
+        pw_cm.__enter__ = lambda s: MagicMock(
+            chromium=MagicMock(executable_path="/usr/bin/env")
+        )
+        pw_cm.__exit__ = lambda *a: None
+        pw_stub.sync_playwright.return_value = pw_cm
+        with (
+            patch("platform.system", return_value="Linux"),
+            patch("platform.machine", return_value="x86_64"),
+            patch(
+                "gptme.cli.cmd_computer.shutil.which",
+                side_effect=lambda cmd: f"/usr/bin/{cmd}",
+            ),
+            patch(
+                "gptme.tools.computer_transport.get_transport",
+                return_value=_fake_transport(tmp_path),
+            ),
+            patch("gptme.tools.computer_transport.NativeComputerTransport", MagicMock),
+            patch("gptme.cli.cmd_computer.Path.home", staticmethod(lambda: tmp_path)),
+            patch.dict(sys.modules, {"playwright.sync_api": pw_stub, "pyatspi": None}),
+        ):
+            result = runner.invoke(doctor_cmd, [])
+
+        assert result.exit_code == 0, result.output
+        assert "bitmap font" in result.output
+        # Should show a pass (✓), not a warning (!)
+        assert "fast xterm startup" in result.output
+
+    def test_passes_when_xterm_font_alternate_bitmap(self, monkeypatch, tmp_path):
+        """Other standard bitmap fonts (6x13, 8x13) also satisfy the check."""
+        monkeypatch.setenv("DISPLAY", ":1")
+        xdefaults = tmp_path / ".Xdefaults"
+        xdefaults.write_text("XTerm*font: 8x13\n")
+        runner = CliRunner()
+        with (
+            patch("platform.system", return_value="Linux"),
+            patch("platform.machine", return_value="x86_64"),
+            patch(
+                "gptme.cli.cmd_computer.shutil.which",
+                side_effect=lambda cmd: f"/usr/bin/{cmd}",
+            ),
+            patch(
+                "gptme.tools.computer_transport.get_transport",
+                return_value=_fake_transport(tmp_path),
+            ),
+            patch("gptme.tools.computer_transport.NativeComputerTransport", MagicMock),
+            patch("gptme.cli.cmd_computer.Path.home", staticmethod(lambda: tmp_path)),
+        ):
+            result = runner.invoke(doctor_cmd, [])
+
+        assert result.exit_code == 0, result.output
+        assert "fast xterm startup" in result.output
+
+    def test_xdefaults_check_skipped_on_macos(self, tmp_path):
+        """The ~/.Xdefaults bitmap-font check is Linux-only; macOS should not show it."""
+        # Create a tmp_path home with no .Xdefaults
+        runner = CliRunner()
+        with (
+            patch("platform.system", return_value="Darwin"),
+            patch("platform.machine", return_value="arm64"),
+            patch(
+                "gptme.cli.cmd_computer.shutil.which",
+                side_effect=lambda cmd: f"/usr/bin/{cmd}",
+            ),
+            patch("gptme.tools.computer_transport.get_transport", return_value=None),
+            patch("gptme.tools.computer_transport.NativeComputerTransport", MagicMock),
+        ):
+            result = runner.invoke(doctor_cmd, [])
+
+        # ~/.Xdefaults is X11-specific; should not appear in macOS output
+        assert "Xdefaults" not in result.output

--- a/tests/test_computer_doctor_cmd.py
+++ b/tests/test_computer_doctor_cmd.py
@@ -587,30 +587,6 @@ class TestDoctorLatencySection:
 class TestDoctorXdefaults:
     """Doctor checks ~/.Xdefaults for the terminal startup delay fix (issue #216)."""
 
-    def _linux_patches(self, tmp_path, xdefaults_content: str | None = None):
-        """Shared Linux patches with optional ~/.Xdefaults content override."""
-        transport = _fake_transport(tmp_path)
-        xdefaults_path = tmp_path / ".Xdefaults"
-        if xdefaults_content is not None:
-            xdefaults_path.write_text(xdefaults_content)
-
-        def _fake_home():
-            return tmp_path
-
-        return [
-            patch("platform.system", return_value="Linux"),
-            patch("platform.machine", return_value="x86_64"),
-            patch(
-                "gptme.cli.cmd_computer.shutil.which",
-                side_effect=lambda cmd: f"/usr/bin/{cmd}",
-            ),
-            patch(
-                "gptme.tools.computer_transport.get_transport", return_value=transport
-            ),
-            patch("gptme.tools.computer_transport.NativeComputerTransport", MagicMock),
-            patch("gptme.cli.cmd_computer.Path.home", staticmethod(_fake_home)),
-        ]
-
     def test_warns_when_xdefaults_missing(self, monkeypatch, tmp_path):
         """When ~/.Xdefaults does not exist, doctor emits a warning about xterm startup."""
         monkeypatch.setenv("DISPLAY", ":1")


### PR DESCRIPTION
## Summary

- `gptme-util computer doctor` now checks `~/.Xdefaults` for the bitmap-font setting that eliminates the xterm startup delay (1–3 s fontconfig scan)
- If the fix is absent, doctor emits a `!` warning with a one-liner fix and a pointer to `gptme-util computer latency --terminal`
- If the fix is present (`XTerm*font: fixed` or any standard bitmap alias), doctor shows `✓  bitmap font (fast xterm startup)`
- Linux-only; macOS is unaffected; the check is advisory (exit 0), not a hard failure

## Background (issue #216)

The remaining checklist item "figure out what is causing the delays" was traced to xterm's default Xft font renderer scanning all system font directories on first launch.  This was fixed for Docker in #3133 (`.Xdefaults` + `xrdb` in `xvfb_startup.sh`), but non-Docker users had no way to know the fix existed unless they read the howto doc.

This PR surfaces the fix in `gptme-util computer doctor` so it appears automatically when users run the health check.

## Test plan

- [ ] `gptme-util computer doctor` on a system **without** `~/.Xdefaults`: warning shown, exit 0
- [ ] `gptme-util computer doctor` on a system with `XTerm*font: fixed` in `~/.Xdefaults`: passing check shown
- [ ] `gptme-util computer doctor` on macOS: no `~/.Xdefaults` section appears
- [ ] All 26 unit tests in `tests/test_computer_doctor_cmd.py` pass (including 5 new `TestDoctorXdefaults` cases)

Closes part of #216.

<!-- gptme-id:v1:gai_D5y53kuYljMrjhSYQiZofUw8Ex0H4QQTh82Uh63AWQd -->