### PR TITLE
docs(subagent): document subagent_pipeline and subagent_wait_any; add wait_any eval (#554)

### DIFF
--- a/docs/tools.rst
+++ b/docs/tools.rst
@@ -236,6 +236,47 @@ Two helpers make it easy to run multiple independent tasks concurrently:
       # ... parent does other work ...
       results = job.wait_all()
 
+``subagent_pipeline(items, *stages, ...)``
+  Staged fan-out **without a barrier** between stages. Each item is processed
+  through all stages in order, but items at different stages run concurrently —
+  item A advances to stage 2 as soon as its stage-1 subagent completes, while
+  item B may still be in stage 1. Wall-clock time is bounded by the slowest
+  single-item chain, not the sum of the slowest per stage.
+
+  This is more efficient than repeated ``subagent_parallel()`` calls (which add
+  a full synchronisation barrier between stages) when items are independent.
+  Each stage is a callable ``stage(item_prompt, prev_result) -> next_prompt``::
+
+      results = subagent_pipeline(
+          [("auth", "Review auth.py"), ("db", "Review db.py")],
+          # Stage 0: review
+          lambda item, _: f"Find bugs in this file: {item}",
+          # Stage 1: verify — runs on auth while db is still in stage 0
+          lambda item, prev: f"Adversarially verify these findings:\n{prev}",
+      )
+      # results[i][j] — result for item i at stage j
+      for (prefix, _), stage_results in zip(items, results):
+          print(f"{prefix}: {stage_results[-1]['result'][:80]}")
+
+  Set ``isolated=True`` so concurrent file-editing subagents each get their own
+  git worktree.
+
+``subagent_wait_any(agent_ids, ...)``
+  Return the first of the given subagents to complete. Useful for
+  **speculative / hedging patterns**: spawn N subagents racing on the same
+  task and take whichever finishes first, then cancel the rest::
+
+      subagent("fast",     "Quick attempt at task X")
+      subagent("thorough", "Thorough attempt at task X")
+      first_id, result = subagent_wait_any(["fast", "thorough"], timeout=120)
+      print(f"{first_id} won: {result['status']}")
+      for aid in ("fast", "thorough"):
+          if aid != first_id:
+              subagent_cancel(aid)
+
+  ``agent_ids`` is the list of IDs to wait on. Raises ``TimeoutError`` if no
+  agent completes within ``timeout`` seconds (default 300).
+
 Structured Output (output_schema)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/tools.rst
+++ b/docs/tools.rst
@@ -247,8 +247,9 @@ Two helpers make it easy to run multiple independent tasks concurrently:
   a full synchronisation barrier between stages) when items are independent.
   Each stage is a callable ``stage(item_prompt, prev_result) -> next_prompt``::
 
+      items = [("auth", "Review auth.py"), ("db", "Review db.py")]
       results = subagent_pipeline(
-          [("auth", "Review auth.py"), ("db", "Review db.py")],
+          items,
           # Stage 0: review
           lambda item, _: f"Find bugs in this file: {item}",
           # Stage 1: verify — runs on auth while db is still in stage 0

--- a/gptme/eval/suites/subagent.py
+++ b/gptme/eval/suites/subagent.py
@@ -240,7 +240,10 @@ def check_pipeline_no_explicit_waits(messages: list[Message]) -> bool:
 
 
 def _expect_race_marker(ctx: "ResultContext") -> bool:
-    return "RACE=done" in ctx.stdout
+    return (
+        "RACE=done" in ctx.stdout
+        and re.search(r"\bWINNER=(fast|thorough)\b", ctx.stdout) is not None
+    )
 
 
 def check_wait_any_used(messages: list[Message]) -> bool:
@@ -250,7 +253,19 @@ def check_wait_any_used(messages: list[Message]) -> bool:
 
 def check_wait_any_loser_cancelled(messages: list[Message]) -> bool:
     """Parent should cancel the agent that did not win the race."""
-    return _any_message_contains(messages, "assistant", "subagent_cancel(")
+    assistant_log = _role_contents(messages, "assistant")
+    if "subagent_cancel(" not in assistant_log:
+        return False
+    if re.search(r"subagent_cancel\(\s*first_id\s*\)", assistant_log):
+        return False
+    return any(
+        re.search(pattern, assistant_log, re.DOTALL) is not None
+        for pattern in (
+            r"if\s+\w+\s*!=\s*first_id\s*:\s*\n\s*subagent_cancel\(\s*\w+\s*\)",
+            r"loser\s*=.*first_id.*subagent_cancel\(\s*loser\s*\)",
+            r"slower\s*=.*first_id.*subagent_cancel\(\s*slower\s*\)",
+        )
+    )
 
 
 def check_wait_any_result_used(messages: list[Message]) -> bool:

--- a/gptme/eval/suites/subagent.py
+++ b/gptme/eval/suites/subagent.py
@@ -256,7 +256,7 @@ def check_wait_any_loser_cancelled(messages: list[Message]) -> bool:
 def check_wait_any_result_used(messages: list[Message]) -> bool:
     """Final assistant message should reference the winning subagent result."""
     final_msg = _last_assistant_content(messages)
-    return "WINNER=" in final_msg or "RACE=" in final_msg
+    return "WINNER=" in final_msg and "RACE=" in final_msg
 
 
 _PARALLEL_A = "alpha beta gamma delta epsilon zeta\n"

--- a/gptme/eval/suites/subagent.py
+++ b/gptme/eval/suites/subagent.py
@@ -239,9 +239,30 @@ def check_pipeline_no_explicit_waits(messages: list[Message]) -> bool:
     return "subagent_wait(" not in assistant_log
 
 
+def _expect_race_marker(ctx: "ResultContext") -> bool:
+    return "RACE=done" in ctx.stdout
+
+
+def check_wait_any_used(messages: list[Message]) -> bool:
+    """Parent should call subagent_wait_any to race two subagents."""
+    return _any_message_contains(messages, "assistant", "subagent_wait_any(")
+
+
+def check_wait_any_loser_cancelled(messages: list[Message]) -> bool:
+    """Parent should cancel the agent that did not win the race."""
+    return _any_message_contains(messages, "assistant", "subagent_cancel(")
+
+
+def check_wait_any_result_used(messages: list[Message]) -> bool:
+    """Final assistant message should reference the winning subagent result."""
+    final_msg = _last_assistant_content(messages)
+    return "WINNER=" in final_msg or "RACE=" in final_msg
+
+
 _PARALLEL_A = "alpha beta gamma delta epsilon zeta\n"
 _PARALLEL_B = "one\ntwo\nthree\nfour\n"
 _NOTES = "Keep this brief. The parent can read this between spawn and wait.\n"
+_RACE_FILE = "The answer is FORTYTWO.\n"
 
 
 tests: list["EvalSpec"] = [
@@ -399,6 +420,35 @@ tests: list["EvalSpec"] = [
             "used subagent_pipeline": check_pipeline_used,
             "integrated pipeline results": check_pipeline_results_integrated,
             "did not call subagent_wait manually": check_pipeline_no_explicit_waits,
+        },
+    },
+    {
+        "name": "subagent-wait-any-race",
+        "files": {
+            "data.txt": _RACE_FILE,
+        },
+        "run": "cat answer.txt",
+        "prompt": (
+            "Demonstrate the race/hedging pattern with subagent_wait_any:\n"
+            "1. Spawn TWO subagents concurrently — agent_id 'fast' and 'thorough' — "
+            "each instructed to read data.txt and return its content via the complete tool.\n"
+            "2. Call subagent_wait_any(['fast', 'thorough']) to wait for whichever "
+            "finishes first.\n"
+            "3. Cancel the slower agent with subagent_cancel().\n"
+            "4. Write answer.txt containing:\n"
+            "WINNER=<the agent_id that won>\n"
+            "RACE=done\n"
+            "Include both WINNER= and RACE= in your final assistant message."
+        ),
+        "tools": ["read", "save", "shell", "ipython", "subagent"],
+        "expect": {
+            "writes RACE marker": _expect_race_marker,
+            "clean exit": _expect_clean_exit,
+        },
+        "check_log": {
+            "called subagent_wait_any": check_wait_any_used,
+            "cancelled the losing agent": check_wait_any_loser_cancelled,
+            "used winner result": check_wait_any_result_used,
         },
     },
 ]

--- a/tests/test_eval_subagent.py
+++ b/tests/test_eval_subagent.py
@@ -1,6 +1,7 @@
 import pickle
 
 from gptme.eval.suites.subagent import (
+    _expect_race_marker,
     check_clarification_hook_notification,
     check_clarification_reply_called,
     check_clarification_reply_with_language,
@@ -24,6 +25,7 @@ from gptme.eval.suites.subagent import (
     check_wait_any_used,
 )
 from gptme.eval.suites.subagent import tests as subagent_evals
+from gptme.eval.types import ResultContext
 from gptme.message import Message
 
 
@@ -456,3 +458,36 @@ def test_wait_any_check_fails_without_cancel():
 
     assert check_wait_any_used(messages)
     assert not check_wait_any_loser_cancelled(messages)
+
+
+def test_wait_any_check_fails_when_winner_cancelled():
+    """Cancelling first_id means the parent killed the winner, not the loser."""
+    messages = [
+        Message(
+            "assistant",
+            "```ipython\n"
+            'subagent("fast", "Read data.txt")\n'
+            'subagent("thorough", "Read data.txt")\n'
+            'first_id, result = subagent_wait_any(["fast", "thorough"])\n'
+            "subagent_cancel(first_id)\n"
+            "```",
+        ),
+        Message("assistant", "WINNER=fast RACE=done"),
+    ]
+
+    assert check_wait_any_used(messages)
+    assert not check_wait_any_loser_cancelled(messages)
+
+
+def test_wait_any_race_marker_requires_winner():
+    assert not _expect_race_marker(
+        ResultContext(files={}, stdout="RACE=done", stderr="", exit_code=0)
+    )
+    assert _expect_race_marker(
+        ResultContext(
+            files={},
+            stdout="WINNER=thorough\nRACE=done\n",
+            stderr="",
+            exit_code=0,
+        )
+    )

--- a/tests/test_eval_subagent.py
+++ b/tests/test_eval_subagent.py
@@ -19,6 +19,9 @@ from gptme.eval.suites.subagent import (
     check_subagent_parallel_integrated_results,
     check_subagent_parallel_started_before_wait,
     check_subagent_parallel_used,
+    check_wait_any_loser_cancelled,
+    check_wait_any_result_used,
+    check_wait_any_used,
 )
 from gptme.eval.suites.subagent import tests as subagent_evals
 from gptme.message import Message
@@ -387,3 +390,69 @@ def test_pipeline_check_fails_when_pipeline_not_used():
     ]
 
     assert not check_pipeline_used(messages)
+
+
+def test_wait_any_checks_pass_for_race_trajectory():
+    """wait_any eval: spawn two racers → subagent_wait_any → cancel loser → report winner."""
+    messages = [
+        Message(
+            "assistant",
+            "```ipython\n"
+            'subagent("fast", "Read data.txt and return its content")\n'
+            'subagent("thorough", "Read data.txt carefully and return its content")\n'
+            "```",
+        ),
+        Message(
+            "assistant",
+            '```ipython\nfirst_id, result = subagent_wait_any(["fast", "thorough"])\n```',
+        ),
+        Message(
+            "assistant",
+            "```ipython\n"
+            'for aid in ("fast", "thorough"):\n'
+            "    if aid != first_id:\n"
+            "        subagent_cancel(aid)\n"
+            "```",
+        ),
+        Message("assistant", "WINNER=fast RACE=done"),
+    ]
+
+    assert check_wait_any_used(messages)
+    assert check_wait_any_loser_cancelled(messages)
+    assert check_wait_any_result_used(messages)
+
+
+def test_wait_any_check_fails_without_wait_any_call():
+    """Using subagent_wait instead of subagent_wait_any should fail the check."""
+    messages = [
+        Message(
+            "assistant",
+            "```ipython\n"
+            'subagent("fast", "Read data.txt")\n'
+            'subagent("thorough", "Read data.txt")\n'
+            'result = subagent_wait("fast")\n'
+            "```",
+        ),
+        Message("assistant", "WINNER=fast RACE=done"),
+    ]
+
+    assert not check_wait_any_used(messages)
+
+
+def test_wait_any_check_fails_without_cancel():
+    """Omitting subagent_cancel on the loser should fail the cancel check."""
+    messages = [
+        Message(
+            "assistant",
+            "```ipython\n"
+            'subagent("fast", "Read data.txt")\n'
+            'subagent("thorough", "Read data.txt")\n'
+            'first_id, result = subagent_wait_any(["fast", "thorough"])\n'
+            "```",
+        ),
+        # Parent does not cancel the loser
+        Message("assistant", "WINNER=fast RACE=done"),
+    ]
+
+    assert check_wait_any_used(messages)
+    assert not check_wait_any_loser_cancelled(messages)


### PR DESCRIPTION
## Summary

Two recently-shipped functions were missing from `docs/tools.rst` and had no trajectory eval coverage:

- `subagent_pipeline()` (PR #3110) — staged fan-out without barriers between stages
- `subagent_wait_any()` (PR #3126) — race/hedging pattern returning the first of N agents to complete

## Changes

**`docs/tools.rst`**
- Added `subagent_pipeline()` entry in the Fan-out section: explains the no-barrier semantics, shows a two-stage review example, notes `isolated=True` for concurrent file-editing
- Added `subagent_wait_any()` entry: explains race/hedging pattern, shows spawn → wait_any → cancel_loser example

**`gptme/eval/suites/subagent.py`**
- New `subagent-wait-any-race` eval spec with three trajectory checks: `called subagent_wait_any`, `cancelled the losing agent`, `used winner result`

**`tests/test_eval_subagent.py`**
- Three unit tests for the new check functions (pass case, fails-without-wait_any, fails-without-cancel)
- All 255 subagent tests pass

Closes part of #554

<!-- gptme-id:v1:gai_TQBOGwqc5QJdoDqnna01hsDZ0CjGUO5vowZHlK2NPMf -->