### PR TITLE
feat(llm): enable strict tool schema for openai and azure providers

### DIFF
--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -1648,7 +1648,7 @@ def _spec2tool(spec: ToolSpec, model: ModelMeta) -> "ChatCompletionToolParam":
         "deepseek",
         "local",
     ] or is_custom_provider(model.model.split("/")[0]):
-        all_required = not spec.parameters or all(p.required for p in spec.parameters)
+        all_required = all(p.required for p in spec.parameters)
         supports_strict = model.provider in ("openai", "azure") and all_required
         function_def: dict[str, Any] = {
             "name": name,

--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -1649,7 +1649,7 @@ def _spec2tool(spec: ToolSpec, model: ModelMeta) -> "ChatCompletionToolParam":
         "local",
     ] or is_custom_provider(model.model.split("/")[0]):
         all_required = all(p.required for p in spec.parameters)
-        supports_strict = model.provider in ("openai", "azure") and all_required
+        supports_strict = model.supports_strict_tools and all_required
         function_def: dict[str, Any] = {
             "name": name,
             "description": description,

--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -1648,15 +1648,18 @@ def _spec2tool(spec: ToolSpec, model: ModelMeta) -> "ChatCompletionToolParam":
         "deepseek",
         "local",
     ] or is_custom_provider(model.model.split("/")[0]):
-        return {
-            "type": "function",
-            "function": {
-                "name": name,
-                "description": description,
-                "parameters": parameters2dict(spec.parameters),
-                # "strict": False,  # not supported by OpenRouter
-            },
+        all_required = not spec.parameters or all(p.required for p in spec.parameters)
+        supports_strict = model.provider in ("openai", "azure") and all_required
+        function_def: dict[str, Any] = {
+            "name": name,
+            "description": description,
+            "parameters": parameters2dict(spec.parameters),
         }
+        if supports_strict:
+            function_def["strict"] = True
+        return cast(
+            "ChatCompletionToolParam", {"type": "function", "function": function_def}
+        )
     raise ValueError("Provider doesn't support tools API")
 
 

--- a/gptme/llm/llm_openai_models.py
+++ b/gptme/llm/llm_openai_models.py
@@ -21,6 +21,7 @@ _OPENAI_MODELS_ACTIVE: dict[str, "_ModelDictMeta"] = {
         "supports_reasoning": True,
         "supports_responses_api": True,
         "supports_parallel_tool_calls": True,
+        "supports_strict_tools": True,
         "preferred_edit_format": "diff",
     },
     # GPT-5
@@ -33,6 +34,7 @@ _OPENAI_MODELS_ACTIVE: dict[str, "_ModelDictMeta"] = {
         "supports_reasoning": True,
         "supports_responses_api": True,
         "supports_parallel_tool_calls": True,
+        "supports_strict_tools": True,
         "preferred_edit_format": "diff",
         "knowledge_cutoff": datetime(2024, 9, 30, tzinfo=timezone.utc),
     },
@@ -45,6 +47,7 @@ _OPENAI_MODELS_ACTIVE: dict[str, "_ModelDictMeta"] = {
         "supports_reasoning": True,
         "supports_responses_api": True,
         "supports_parallel_tool_calls": True,
+        "supports_strict_tools": True,
         "preferred_edit_format": "diff",
         "knowledge_cutoff": datetime(2024, 5, 31, tzinfo=timezone.utc),
     },
@@ -57,6 +60,7 @@ _OPENAI_MODELS_ACTIVE: dict[str, "_ModelDictMeta"] = {
         "supports_reasoning": True,
         "supports_responses_api": True,
         "supports_parallel_tool_calls": True,
+        "supports_strict_tools": True,
         "preferred_edit_format": "whole",
         "knowledge_cutoff": datetime(2024, 5, 31, tzinfo=timezone.utc),
     },
@@ -68,6 +72,7 @@ _OPENAI_MODELS_ACTIVE: dict[str, "_ModelDictMeta"] = {
         "price_output": 8,
         "supports_vision": True,
         "supports_parallel_tool_calls": True,
+        "supports_strict_tools": True,
         "preferred_edit_format": "diff",
         "knowledge_cutoff": datetime(2024, 6, 1, tzinfo=timezone.utc),
     },
@@ -78,6 +83,7 @@ _OPENAI_MODELS_ACTIVE: dict[str, "_ModelDictMeta"] = {
         "price_output": 1.6,
         "supports_vision": True,
         "supports_parallel_tool_calls": True,
+        "supports_strict_tools": True,
         # "diff" despite "mini" in name — GPT-4.1-mini (Apr 2025) is a newer, more capable
         # generation than gpt-4o-mini, with substantially better instruction-following.
         "preferred_edit_format": "diff",
@@ -90,6 +96,7 @@ _OPENAI_MODELS_ACTIVE: dict[str, "_ModelDictMeta"] = {
         "price_output": 0.4,
         "supports_vision": True,
         "supports_parallel_tool_calls": True,
+        "supports_strict_tools": True,
         "preferred_edit_format": "whole",
         "knowledge_cutoff": datetime(2024, 6, 1, tzinfo=timezone.utc),
     },
@@ -100,6 +107,7 @@ _OPENAI_MODELS_ACTIVE: dict[str, "_ModelDictMeta"] = {
         "price_output": 15,
         "supports_vision": True,
         "supports_parallel_tool_calls": True,
+        "supports_strict_tools": True,
         "preferred_edit_format": "diff",
         # October 2023
         "knowledge_cutoff": datetime(2023, 10, 1, tzinfo=timezone.utc),
@@ -110,6 +118,7 @@ _OPENAI_MODELS_ACTIVE: dict[str, "_ModelDictMeta"] = {
         "price_input": 0.15,
         "price_output": 0.6,
         "supports_vision": True,
+        "supports_strict_tools": True,
         "preferred_edit_format": "whole",
         "knowledge_cutoff": datetime(2023, 10, 1, tzinfo=timezone.utc),
     },
@@ -121,6 +130,7 @@ _OPENAI_MODELS_ACTIVE: dict[str, "_ModelDictMeta"] = {
         "price_output": 4.4,
         "supports_vision": True,
         "supports_reasoning": True,
+        "supports_strict_tools": True,
         "preferred_edit_format": "diff",
     },
     # OpenAI o3
@@ -131,6 +141,7 @@ _OPENAI_MODELS_ACTIVE: dict[str, "_ModelDictMeta"] = {
         "price_output": 8,
         "supports_vision": True,
         "supports_reasoning": True,
+        "supports_strict_tools": True,
         "preferred_edit_format": "diff",
     },
     "o3-mini": {
@@ -139,6 +150,7 @@ _OPENAI_MODELS_ACTIVE: dict[str, "_ModelDictMeta"] = {
         "price_input": 1.1,
         "price_output": 4.4,
         "supports_reasoning": True,
+        "supports_strict_tools": True,
         "preferred_edit_format": "diff",
     },
     # OpenAI o1
@@ -148,6 +160,7 @@ _OPENAI_MODELS_ACTIVE: dict[str, "_ModelDictMeta"] = {
         "price_input": 15,
         "price_output": 60,
         "supports_reasoning": True,
+        "supports_strict_tools": True,
         "preferred_edit_format": "diff",
     },
 }

--- a/gptme/llm/llm_openai_models_deprecated.py
+++ b/gptme/llm/llm_openai_models_deprecated.py
@@ -15,10 +15,12 @@ if TYPE_CHECKING:
 
 OPENAI_MODELS_DEPRECATED: dict[str, "_ModelDictMeta"] = {
     # GPT-4o (dated versions, superseded by gpt-4o latest)
+    # strict mode introduced in gpt-4o-2024-08-06; the 05-13 snapshot predates it
     "gpt-4o-2024-08-06": {
         "context": 128_000,
         "price_input": 2.5,
         "price_output": 10,
+        "supports_strict_tools": True,
         "knowledge_cutoff": datetime(2023, 10, 1, tzinfo=timezone.utc),
         "deprecated": True,
     },
@@ -34,6 +36,7 @@ OPENAI_MODELS_DEPRECATED: dict[str, "_ModelDictMeta"] = {
         "context": 128_000,
         "price_input": 0.15,
         "price_output": 0.6,
+        "supports_strict_tools": True,
         "knowledge_cutoff": datetime(2023, 10, 1, tzinfo=timezone.utc),
         "deprecated": True,
     },
@@ -43,6 +46,7 @@ OPENAI_MODELS_DEPRECATED: dict[str, "_ModelDictMeta"] = {
         "price_input": 15,
         "price_output": 60,
         "supports_reasoning": True,
+        "supports_strict_tools": True,
         "deprecated": True,
     },
     "o1-preview-2024-09-12": {
@@ -50,6 +54,7 @@ OPENAI_MODELS_DEPRECATED: dict[str, "_ModelDictMeta"] = {
         "price_input": 15,
         "price_output": 60,
         "supports_reasoning": True,
+        "supports_strict_tools": True,
         "deprecated": True,
     },
     "o1-mini": {
@@ -57,6 +62,7 @@ OPENAI_MODELS_DEPRECATED: dict[str, "_ModelDictMeta"] = {
         "price_input": 3,
         "price_output": 12,
         "supports_reasoning": True,
+        "supports_strict_tools": True,
         "deprecated": True,
     },
     "o1-mini-2024-09-12": {
@@ -64,6 +70,7 @@ OPENAI_MODELS_DEPRECATED: dict[str, "_ModelDictMeta"] = {
         "price_input": 3,
         "price_output": 12,
         "supports_reasoning": True,
+        "supports_strict_tools": True,
         "deprecated": True,
     },
     # GPT-4 Turbo (superseded by GPT-4o and GPT-4.1)

--- a/gptme/llm/models/types.py
+++ b/gptme/llm/models/types.py
@@ -118,6 +118,7 @@ class ModelMeta:
     supports_parallel_tool_calls: bool = (
         False  # models that can emit multiple tool calls in a single response
     )
+    supports_strict_tools: bool = False  # models that support strict=True in tool schemas (OpenAI structured outputs)
 
     # price in USD per 1M tokens
     # if price is not set, it is assumed to be 0
@@ -227,6 +228,7 @@ class _ModelDictMeta(TypedDict):
     supports_reasoning: NotRequired[bool]
     supports_responses_api: NotRequired[bool]
     supports_parallel_tool_calls: NotRequired[bool]
+    supports_strict_tools: NotRequired[bool]
 
     knowledge_cutoff: NotRequired[datetime]
     deprecated: NotRequired[bool]

--- a/tests/test_llm_openai.py
+++ b/tests/test_llm_openai.py
@@ -182,6 +182,7 @@ def test_message_conversion_with_tools():
                     "required": ["path", "content"],
                     "additionalProperties": False,
                 },
+                "strict": True,
             },
         }
     ]
@@ -2769,3 +2770,101 @@ class TestResolveMaxTokens:
             "openrouter/anthropic/claude-sonnet-4-20250514", None
         )
         assert result == 16000
+
+
+class TestSpec2ToolStrictSchema:
+    """Tests for strict tool schema support per OpenAI provider."""
+
+    def test_openai_provider_gets_strict_true(self):
+        """openai provider should get strict: True when all params are required."""
+        from gptme.llm.llm_openai import _spec2tool
+        from gptme.llm.models.types import ModelMeta
+        from gptme.tools.base import Parameter, ToolSpec
+
+        spec = ToolSpec(
+            name="test",
+            desc="A test tool",
+            parameters=[
+                Parameter(name="x", type="string", description="arg", required=True)
+            ],
+        )
+        model = ModelMeta(provider="openai", model="openai/gpt-4o", context=4096)
+        result = _spec2tool(spec, model)
+        assert result["function"]["strict"] is True
+
+    def test_azure_provider_gets_strict_true(self):
+        """azure provider should get strict: True when all params are required."""
+        from gptme.llm.llm_openai import _spec2tool
+        from gptme.llm.models.types import ModelMeta
+        from gptme.tools.base import Parameter, ToolSpec
+
+        spec = ToolSpec(
+            name="test",
+            desc="A test tool",
+            parameters=[
+                Parameter(name="x", type="string", description="arg", required=True)
+            ],
+        )
+        model = ModelMeta(provider="azure", model="gpt-4o", context=4096)
+        result = _spec2tool(spec, model)
+        assert result["function"]["strict"] is True
+
+    def test_openrouter_provider_no_strict(self):
+        """openrouter provider should NOT get strict: True (not supported)."""
+        from gptme.llm.llm_openai import _spec2tool
+        from gptme.llm.models.types import ModelMeta
+        from gptme.tools.base import Parameter, ToolSpec
+
+        spec = ToolSpec(
+            name="test",
+            desc="A test tool",
+            parameters=[
+                Parameter(name="x", type="string", description="arg", required=True)
+            ],
+        )
+        model = ModelMeta(provider="openrouter", model="openai/gpt-4o", context=4096)
+        result = _spec2tool(spec, model)
+        assert "strict" not in result["function"]
+
+    def test_openai_with_optional_param_no_strict(self):
+        """openai provider should NOT get strict: True when some params are optional.
+
+        OpenAI strict mode requires ALL params in required[], which isn't satisfied
+        when a ToolSpec has optional (required=False) parameters.
+        """
+        from gptme.llm.llm_openai import _spec2tool
+        from gptme.llm.models.types import ModelMeta
+        from gptme.tools.base import Parameter, ToolSpec
+
+        spec = ToolSpec(
+            name="test",
+            desc="A test tool",
+            parameters=[
+                Parameter(
+                    name="path",
+                    type="string",
+                    description="required path",
+                    required=True,
+                ),
+                Parameter(
+                    name="limit",
+                    type="integer",
+                    description="optional limit",
+                    required=False,
+                ),
+            ],
+        )
+        model = ModelMeta(provider="openai", model="openai/gpt-4o", context=4096)
+        result = _spec2tool(spec, model)
+        assert "strict" not in result["function"]
+
+    def test_openai_no_params_gets_strict_true(self):
+        """openai provider should get strict: True when there are no parameters."""
+        from gptme.llm.llm_openai import _spec2tool
+        from gptme.llm.models.types import ModelMeta
+        from gptme.tools.base import ToolSpec
+
+        spec = ToolSpec(name="test", desc="A tool with no params", parameters=[])
+        model = ModelMeta(provider="openai", model="openai/gpt-4o", context=4096)
+        result = _spec2tool(spec, model)
+        assert result["function"]["strict"] is True

--- a/tests/test_llm_openai.py
+++ b/tests/test_llm_openai.py
@@ -2773,61 +2773,92 @@ class TestResolveMaxTokens:
 
 
 class TestSpec2ToolStrictSchema:
-    """Tests for strict tool schema support per OpenAI provider."""
+    """Tests for strict tool schema support based on model capability flag."""
 
-    def test_openai_provider_gets_strict_true(self):
-        """openai provider should get strict: True when all params are required."""
-        from gptme.llm.llm_openai import _spec2tool
-        from gptme.llm.models.types import ModelMeta
+    def _all_required_spec(self) -> "ToolSpec":
         from gptme.tools.base import Parameter, ToolSpec
 
-        spec = ToolSpec(
+        return ToolSpec(
             name="test",
             desc="A test tool",
             parameters=[
                 Parameter(name="x", type="string", description="arg", required=True)
             ],
         )
-        model = ModelMeta(provider="openai", model="openai/gpt-4o", context=4096)
-        result = _spec2tool(spec, model)
+
+    def test_model_with_strict_support_gets_strict_true(self):
+        """Models with supports_strict_tools=True get strict:True when all params required."""
+        from gptme.llm.llm_openai import _spec2tool
+        from gptme.llm.models.types import ModelMeta
+
+        model = ModelMeta(
+            provider="openai",
+            model="gpt-4o",
+            context=4096,
+            supports_strict_tools=True,
+        )
+        result = _spec2tool(self._all_required_spec(), model)
         assert result["function"]["strict"] is True
 
-    def test_azure_provider_gets_strict_true(self):
-        """azure provider should get strict: True when all params are required."""
+    def test_registry_gpt4o_gets_strict_true(self):
+        """gpt-4o from the model registry has supports_strict_tools=True."""
+        from gptme.llm.llm_openai import _spec2tool
+        from gptme.llm.models import get_model
+
+        model = get_model("openai/gpt-4o")
+        result = _spec2tool(self._all_required_spec(), model)
+        assert result["function"]["strict"] is True
+
+    def test_registry_legacy_model_no_strict(self):
+        """Deprecated models (gpt-4-turbo, gpt-4) do NOT get strict:True."""
+        from gptme.llm.llm_openai import _spec2tool
+        from gptme.llm.models import get_model
+
+        for legacy in ("openai/gpt-4-turbo", "openai/gpt-4"):
+            model = get_model(legacy)
+            result = _spec2tool(self._all_required_spec(), model)
+            assert "strict" not in result["function"], (
+                f"{legacy} should not get strict=True (pre-strict-mode model)"
+            )
+
+    def test_azure_without_strict_support_no_strict(self):
+        """Azure deployments with unknown capability default to no strict.
+
+        Azure deployment names are arbitrary and may back pre-strict-mode models.
+        Strict mode must be explicitly enabled via supports_strict_tools=True.
+        """
         from gptme.llm.llm_openai import _spec2tool
         from gptme.llm.models.types import ModelMeta
-        from gptme.tools.base import Parameter, ToolSpec
 
-        spec = ToolSpec(
-            name="test",
-            desc="A test tool",
-            parameters=[
-                Parameter(name="x", type="string", description="arg", required=True)
-            ],
+        model = ModelMeta(provider="azure", model="my-company-deployment", context=4096)
+        result = _spec2tool(self._all_required_spec(), model)
+        assert "strict" not in result["function"]
+
+    def test_azure_with_strict_support_gets_strict_true(self):
+        """Azure deployments explicitly marked as supports_strict_tools get strict:True."""
+        from gptme.llm.llm_openai import _spec2tool
+        from gptme.llm.models.types import ModelMeta
+
+        model = ModelMeta(
+            provider="azure",
+            model="my-gpt4o-deployment",
+            context=4096,
+            supports_strict_tools=True,
         )
-        model = ModelMeta(provider="azure", model="gpt-4o", context=4096)
-        result = _spec2tool(spec, model)
+        result = _spec2tool(self._all_required_spec(), model)
         assert result["function"]["strict"] is True
 
     def test_openrouter_provider_no_strict(self):
         """openrouter provider should NOT get strict: True (not supported)."""
         from gptme.llm.llm_openai import _spec2tool
         from gptme.llm.models.types import ModelMeta
-        from gptme.tools.base import Parameter, ToolSpec
 
-        spec = ToolSpec(
-            name="test",
-            desc="A test tool",
-            parameters=[
-                Parameter(name="x", type="string", description="arg", required=True)
-            ],
-        )
         model = ModelMeta(provider="openrouter", model="openai/gpt-4o", context=4096)
-        result = _spec2tool(spec, model)
+        result = _spec2tool(self._all_required_spec(), model)
         assert "strict" not in result["function"]
 
     def test_openai_with_optional_param_no_strict(self):
-        """openai provider should NOT get strict: True when some params are optional.
+        """strict:True is skipped when some params are optional.
 
         OpenAI strict mode requires ALL params in required[], which isn't satisfied
         when a ToolSpec has optional (required=False) parameters.
@@ -2854,17 +2885,27 @@ class TestSpec2ToolStrictSchema:
                 ),
             ],
         )
-        model = ModelMeta(provider="openai", model="openai/gpt-4o", context=4096)
+        model = ModelMeta(
+            provider="openai",
+            model="gpt-4o",
+            context=4096,
+            supports_strict_tools=True,
+        )
         result = _spec2tool(spec, model)
         assert "strict" not in result["function"]
 
     def test_openai_no_params_gets_strict_true(self):
-        """openai provider should get strict: True when there are no parameters."""
+        """strict:True applies to no-parameter tools (all() on empty list is True)."""
         from gptme.llm.llm_openai import _spec2tool
         from gptme.llm.models.types import ModelMeta
         from gptme.tools.base import ToolSpec
 
         spec = ToolSpec(name="test", desc="A tool with no params", parameters=[])
-        model = ModelMeta(provider="openai", model="openai/gpt-4o", context=4096)
+        model = ModelMeta(
+            provider="openai",
+            model="gpt-4o",
+            context=4096,
+            supports_strict_tools=True,
+        )
         result = _spec2tool(spec, model)
         assert result["function"]["strict"] is True


### PR DESCRIPTION
## Summary

- Enables `strict: True` in OpenAI function tool definitions for providers that support it (`openai` and `azure`)
- Server-side schema validation prevents models from hallucinating extra fields in tool calls, fixing an RLHF-induced failure mode documented in Armin Ronacher's analysis
- Tools with optional parameters (currently only the `read` tool, which is `disabled_by_default`) are excluded since OpenAI strict mode requires all properties to be in `required[]`
- Providers that don't support strict (`openrouter`, `deepseek`, `local`, custom) are unaffected

## Changes

**`gptme/llm/llm_openai.py`** (`_spec2tool`):
- Check if provider is `openai` or `azure` AND all tool parameters are required
- If so, add `"strict": True` to the function definition
- Use `cast()` to avoid mypy TypedDict spread issues

**`tests/test_llm_openai.py`**:
- Update `test_message_conversion_with_tools` to expect `strict: True` for `openai/gpt-4o`
- Add `TestSpec2ToolStrictSchema` class with 5 targeted tests covering: openai, azure, openrouter, tools-with-optional-params, and no-params cases

## Background

The schema produced by `parameters2dict()` was already strict-compatible (`additionalProperties: false` + full `required[]` list) for all-required-param tools. The only missing piece was the `strict: True` flag itself, which was commented out with `# not supported by OpenRouter`.