### PR TITLE
feat(computer): add gptme-util computer demo command (#216)

### DIFF
--- a/gptme/cli/cmd_computer.py
+++ b/gptme/cli/cmd_computer.py
@@ -11,6 +11,13 @@ from pathlib import Path
 
 import click
 
+# Optional Playwright import — present only when the browser extra is installed.
+# Defined at module level so tests can patch `gptme.cli.cmd_computer.sync_playwright`.
+try:
+    from playwright.sync_api import sync_playwright  # type: ignore[import-not-found]
+except ImportError:  # pragma: no cover
+    sync_playwright = None  # type: ignore[assignment]
+
 from ..dirs import get_logs_dir
 from ..logmanager import _gen_read_jsonl
 from ..tools._computer_gate import (
@@ -1626,3 +1633,269 @@ def doctor_cmd(display: str | None):
             + "  Fix the items above and re-run `gptme-util computer doctor`."
         )
         raise SystemExit(1)
+
+
+# ---------------------------------------------------------------------------
+# demo command
+# ---------------------------------------------------------------------------
+
+# Same HTML fixture used by the eval suite's computer-use-web-tweet-compose spec
+# (gptme/eval/suites/computer.py).  Uses Twitter's real data-testid selectors so
+# the same fill_element / click_element calls that pass here work against a real
+# X.com compose page once the user provides authenticated browser state.
+_DEMO_TWEET_HTML = (
+    "<!doctype html><html><body>"
+    "<h1>Compose</h1>"
+    '<div role="group" aria-label="Tweet compose">'
+    '<div data-testid="tweetTextarea_0" role="textbox" contenteditable="true" '
+    'aria-label="Tweet text" style="width:100%;min-height:80px"></div>'
+    '<button data-testid="tweetButtonInline" data-role="tweet-button" '
+    'style="margin-top:8px">Tweet</button>'
+    "</div>"
+    '<div id="status"></div>'
+    "<script>"
+    "document.querySelector('[data-role=\"tweet-button\"]')"
+    ".addEventListener('click', function() {"
+    "var compose = document.querySelector('[data-testid=\"tweetTextarea_0\"]');"
+    "var text = (compose.innerText || compose.textContent || '').trim();"
+    "document.getElementById('status').textContent = 'tweet-posted:' + text;"
+    "});"
+    "</script>"
+    "</body></html>"
+)
+
+
+def _demo_tweet_url() -> str:
+    import base64
+
+    return "data:text/html;base64," + base64.b64encode(
+        _DEMO_TWEET_HTML.encode()
+    ).decode("ascii")
+
+
+@computer.command("demo")
+@click.option(
+    "--text",
+    default="Hello from gptme!",
+    show_default=True,
+    help="Tweet text to type into the compose box.",
+)
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    default=False,
+    help="Output result as JSON.",
+)
+def demo_cmd(text: str, as_json: bool):
+    """Run a self-contained end-to-end demo of the browser automation pipeline.
+
+    Opens a local HTML fixture that mimics the Twitter/X compose UI (same
+    ``data-testid`` selectors as the real page), types a tweet, clicks the
+    submit button, and verifies that the DOM updated — all without an LLM or
+    network access.
+
+    This is the tool-layer equivalent of the "Can it Tweet?" milestone from
+    gptme/gptme#216.  If the demo passes, the full
+    ``open_page → fill_element → click_element → read_page_text`` pipeline is
+    working and ready for a live gptme computer-use session.
+
+    Examples::
+
+        # Run the demo (exit 0 = pass, exit 1 = fail)
+        gptme-util computer demo
+
+        # Custom tweet text
+        gptme-util computer demo --text "Shipped it!"
+
+        # Machine-readable output for scripting
+        gptme-util computer demo --json
+    """
+    import time
+
+    # sync_playwright is imported at module level; None when playwright is absent.
+    if sync_playwright is None:
+        msg = (
+            "playwright is not installed — browser demo unavailable.\n"
+            "Install it with:\n"
+            "  pip install playwright\n"
+            "  python -m playwright install chromium"
+        )
+        if as_json:
+            click.echo(
+                json.dumps(
+                    {
+                        "status": "error",
+                        "error": "playwright not installed",
+                        "steps": [],
+                    }
+                )
+            )
+        else:
+            click.echo(f"✗ {msg}", err=True)
+        raise SystemExit(1)
+
+    steps: list[dict] = []
+    overall_t0 = time.perf_counter()
+
+    def _step(name: str, ok: bool, elapsed_ms: float, detail: str = "") -> None:
+        steps.append(
+            {"step": name, "ok": ok, "elapsed_ms": round(elapsed_ms), "detail": detail}
+        )
+        if not as_json:
+            icon = _PASS if ok else _FAIL
+            detail_str = f"  ({detail})" if detail else ""
+            click.echo(f"  {icon}  {name}{detail_str}  [{elapsed_ms:.0f} ms]")
+
+    if not as_json:
+        click.echo("Computer-use browser demo (tweet-compose fixture)\n")
+
+    fixture_url = _demo_tweet_url()
+
+    with sync_playwright() as pw:
+        t0 = time.perf_counter()
+        try:
+            browser = pw.chromium.launch(headless=True)
+            context = browser.new_context()
+            page = context.new_page()
+            _step("launch browser", True, (time.perf_counter() - t0) * 1000)
+        except Exception as exc:
+            elapsed = (time.perf_counter() - t0) * 1000
+            _step("launch browser", False, elapsed, str(exc))
+            _finish(steps, overall_t0, as_json, failed=True)
+            raise SystemExit(1) from None
+
+        # Step 1: open_page — load the fixture
+        t0 = time.perf_counter()
+        try:
+            page.goto(fixture_url, wait_until="domcontentloaded", timeout=10_000)
+            _step("open_page (load fixture)", True, (time.perf_counter() - t0) * 1000)
+        except Exception as exc:
+            _step(
+                "open_page (load fixture)",
+                False,
+                (time.perf_counter() - t0) * 1000,
+                str(exc),
+            )
+            browser.close()
+            _finish(steps, overall_t0, as_json, failed=True)
+            raise SystemExit(1) from None
+
+        # Step 2: wait_for_element — compose box ready
+        t0 = time.perf_counter()
+        try:
+            page.wait_for_selector('[data-testid="tweetTextarea_0"]', timeout=5_000)
+            _step(
+                'wait_for_element [data-testid="tweetTextarea_0"]',
+                True,
+                (time.perf_counter() - t0) * 1000,
+            )
+        except Exception as exc:
+            _step(
+                'wait_for_element [data-testid="tweetTextarea_0"]',
+                False,
+                (time.perf_counter() - t0) * 1000,
+                str(exc),
+            )
+            browser.close()
+            _finish(steps, overall_t0, as_json, failed=True)
+            raise SystemExit(1) from None
+
+        # Step 3: fill_element — type the tweet text
+        t0 = time.perf_counter()
+        try:
+            el = page.locator('[data-testid="tweetTextarea_0"]')
+            el.click()
+            el.fill(text)
+            actual = el.inner_text()
+            ok_fill = text.strip() in actual or actual.strip() == text.strip()
+            _step(
+                "fill_element (type tweet)",
+                ok_fill,
+                (time.perf_counter() - t0) * 1000,
+                f"typed {len(text)} chars",
+            )
+        except Exception as exc:
+            _step(
+                "fill_element (type tweet)",
+                False,
+                (time.perf_counter() - t0) * 1000,
+                str(exc),
+            )
+            browser.close()
+            _finish(steps, overall_t0, as_json, failed=True)
+            raise SystemExit(1) from None
+
+        # Step 4: click_element — submit the tweet
+        t0 = time.perf_counter()
+        try:
+            page.locator('[data-testid="tweetButtonInline"]').click()
+            _step(
+                'click_element [data-testid="tweetButtonInline"]',
+                True,
+                (time.perf_counter() - t0) * 1000,
+            )
+        except Exception as exc:
+            _step(
+                'click_element [data-testid="tweetButtonInline"]',
+                False,
+                (time.perf_counter() - t0) * 1000,
+                str(exc),
+            )
+            browser.close()
+            _finish(steps, overall_t0, as_json, failed=True)
+            raise SystemExit(1) from None
+
+        # Step 5: read_page_text — verify the DOM updated
+        t0 = time.perf_counter()
+        try:
+            page_text = page.locator("#status").inner_text(timeout=3_000)
+            ok_verify = page_text.startswith("tweet-posted:")
+            _step(
+                "read_page_text (verify submit)",
+                ok_verify,
+                (time.perf_counter() - t0) * 1000,
+                repr(page_text[:60]) if page_text else "(empty)",
+            )
+        except Exception as exc:
+            _step(
+                "read_page_text (verify submit)",
+                False,
+                (time.perf_counter() - t0) * 1000,
+                str(exc),
+            )
+            browser.close()
+            _finish(steps, overall_t0, as_json, failed=True)
+            raise SystemExit(1) from None
+
+        browser.close()
+
+    failed = any(not s["ok"] for s in steps)
+    _finish(steps, overall_t0, as_json, failed=failed)
+    if failed:
+        raise SystemExit(1)
+
+
+def _finish(steps: list[dict], t0: float, as_json: bool, failed: bool) -> None:
+    import time
+
+    total_ms = round((time.perf_counter() - t0) * 1000)
+    status = "fail" if failed else "pass"
+    if as_json:
+        click.echo(
+            json.dumps(
+                {"status": status, "total_ms": total_ms, "steps": steps}, indent=2
+            )
+        )
+    else:
+        click.echo("")
+        if failed:
+            click.echo(
+                click.style("✗  Demo failed.", fg="red")
+                + "  Check the steps above and run `gptme-util computer doctor`."
+            )
+        else:
+            click.echo(
+                click.style(f"✅  Demo passed in {total_ms} ms.", fg="green")
+                + "  The browser automation pipeline is working end-to-end."
+            )

--- a/gptme/cli/cmd_computer.py
+++ b/gptme/cli/cmd_computer.py
@@ -1727,6 +1727,7 @@ def demo_cmd(text: str, as_json: bool):
                     {
                         "status": "error",
                         "error": "playwright not installed",
+                        "total_ms": 0,
                         "steps": [],
                     }
                 )
@@ -1808,13 +1809,17 @@ def demo_cmd(text: str, as_json: bool):
             el.click()
             el.fill(text)
             actual = el.inner_text()
-            ok_fill = text.strip() in actual or actual.strip() == text.strip()
+            ok_fill = text.strip() in actual
             _step(
                 "fill_element (type tweet)",
                 ok_fill,
                 (time.perf_counter() - t0) * 1000,
                 f"typed {len(text)} chars",
             )
+            if not ok_fill:
+                browser.close()
+                _finish(steps, overall_t0, as_json, failed=True)
+                raise SystemExit(1) from None
         except Exception as exc:
             _step(
                 "fill_element (type tweet)",

--- a/tests/test_computer_demo_cmd.py
+++ b/tests/test_computer_demo_cmd.py
@@ -151,6 +151,8 @@ class TestDemoCmd:
         assert result.exit_code == 1
         data = json.loads(result.output)
         assert data["status"] == "error"
+        assert data["total_ms"] == 0
+        assert data["steps"] == []
 
     def test_goto_failure_exits_1(self):
         """If page.goto raises, demo exits 1 and reports the failure."""
@@ -164,6 +166,47 @@ class TestDemoCmd:
         assert data["status"] == "fail"
         failed = [s for s in data["steps"] if not s["ok"]]
         assert any("open_page" in s["step"] for s in failed)
+
+    def test_fill_mismatch_aborts_before_submit(self):
+        """If typed text does not round-trip, demo stops before submit/verify."""
+        page = _make_page_mock()
+
+        compose_el = MagicMock()
+        compose_el.inner_text.return_value = ""
+        compose_el.click.return_value = None
+        compose_el.fill.return_value = None
+
+        btn_el = MagicMock()
+        status_el = MagicMock()
+        status_el.inner_text.return_value = "tweet-posted:"
+
+        def _locator(sel):
+            if "tweetTextarea_0" in sel:
+                return compose_el
+            if "tweetButtonInline" in sel:
+                return btn_el
+            if sel == "#status":
+                return status_el
+            return MagicMock()
+
+        page.locator.side_effect = _locator
+
+        with _make_playwright_patcher(page):
+            runner = CliRunner()
+            result = runner.invoke(demo_cmd, ["--json"])
+
+        assert result.exit_code == 1
+        data = json.loads(result.output)
+        assert data["status"] == "fail"
+        assert [s["step"] for s in data["steps"]] == [
+            "launch browser",
+            "open_page (load fixture)",
+            'wait_for_element [data-testid="tweetTextarea_0"]',
+            "fill_element (type tweet)",
+        ]
+        assert not data["steps"][-1]["ok"]
+        btn_el.click.assert_not_called()
+        status_el.inner_text.assert_not_called()
 
     def test_click_failure_exits_1(self):
         """If click_element raises, demo exits 1."""

--- a/tests/test_computer_demo_cmd.py
+++ b/tests/test_computer_demo_cmd.py
@@ -1,0 +1,232 @@
+"""Tests for `gptme-util computer demo` (cmd_computer.py).
+
+Unit-tests the demo CLI command without requiring a real browser or Playwright
+installation.  The playwright context manager is monkey-patched so the tests
+run in any environment.
+"""
+
+from __future__ import annotations
+
+import json
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from gptme.cli.cmd_computer import demo_cmd
+
+# ---------------------------------------------------------------------------
+# Playwright mock helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_page_mock(status_text: str = "tweet-posted:Hello from gptme!") -> MagicMock:
+    """Return a page mock that simulates a successful tweet-compose interaction."""
+    page = MagicMock()
+    page.goto.return_value = None
+    page.wait_for_selector.return_value = None
+
+    compose_el = MagicMock()
+    compose_el.inner_text.return_value = "Hello from gptme!"
+    compose_el.click.return_value = None
+    compose_el.fill.return_value = None
+    page.locator.side_effect = lambda sel: (
+        compose_el if "tweetTextarea_0" in sel else MagicMock()
+    )
+
+    status_el = MagicMock()
+    status_el.inner_text.return_value = status_text
+
+    # override: #status locator should return status_el
+    def _locator(sel):
+        if "tweetTextarea_0" in sel:
+            return compose_el
+        if sel == "#status":
+            return status_el
+        return MagicMock()
+
+    page.locator.side_effect = _locator
+    return page
+
+
+def _make_playwright_patcher(page: MagicMock):
+    """Return a context-manager patcher that injects the given page mock."""
+    browser = MagicMock()
+    context = MagicMock()
+    context.new_page.return_value = page
+    browser.new_context.return_value = context
+
+    chromium = MagicMock()
+    chromium.launch.return_value = browser
+
+    pw_instance = MagicMock()
+    pw_instance.chromium = chromium
+
+    @contextmanager
+    def fake_sync_playwright():
+        yield pw_instance
+
+    return patch("gptme.cli.cmd_computer.sync_playwright", fake_sync_playwright)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestDemoCmd:
+    """Tests for `gptme-util computer demo`."""
+
+    def test_help_text_present(self):
+        runner = CliRunner()
+        result = runner.invoke(demo_cmd, ["--help"])
+        assert result.exit_code == 0
+        assert "--text" in result.output
+        assert "--json" in result.output
+
+    def test_success_human_readable(self):
+        """Successful run prints all steps as ✓ and exits 0."""
+        page = _make_page_mock()
+        with _make_playwright_patcher(page):
+            runner = CliRunner()
+            result = runner.invoke(demo_cmd, [])
+        assert result.exit_code == 0, result.output
+        assert "Demo passed" in result.output
+        assert "✓" in result.output or "pass" in result.output
+
+    def test_success_json_output(self):
+        """--json output has status=pass and all steps ok=true."""
+        page = _make_page_mock()
+        with _make_playwright_patcher(page):
+            runner = CliRunner()
+            result = runner.invoke(demo_cmd, ["--json"])
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["status"] == "pass"
+        assert all(s["ok"] for s in data["steps"])
+        assert data["total_ms"] >= 0
+
+    def test_custom_text_forwarded(self):
+        """--text value is typed into the compose box and echoed back."""
+        page = _make_page_mock(status_text="tweet-posted:Shipped it!")
+
+        compose_el = MagicMock()
+        compose_el.inner_text.return_value = "Shipped it!"
+        compose_el.click.return_value = None
+        compose_el.fill.return_value = None
+
+        status_el = MagicMock()
+        status_el.inner_text.return_value = "tweet-posted:Shipped it!"
+
+        def _locator(sel):
+            if "tweetTextarea_0" in sel:
+                return compose_el
+            if sel == "#status":
+                return status_el
+            return MagicMock()
+
+        page.locator.side_effect = _locator
+
+        with _make_playwright_patcher(page):
+            runner = CliRunner()
+            result = runner.invoke(demo_cmd, ["--text", "Shipped it!", "--json"])
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["status"] == "pass"
+        fill_step = next(s for s in data["steps"] if "fill_element" in s["step"])
+        assert fill_step["ok"]
+
+    def test_playwright_missing_exits_1(self):
+        """If playwright is not installed (sync_playwright=None), demo exits 1."""
+        with patch("gptme.cli.cmd_computer.sync_playwright", None):
+            runner = CliRunner()
+            result = runner.invoke(demo_cmd, [])
+        assert result.exit_code == 1
+
+    def test_playwright_missing_json_output(self):
+        """Missing playwright with --json outputs error JSON and exits 1."""
+        with patch("gptme.cli.cmd_computer.sync_playwright", None):
+            runner = CliRunner()
+            result = runner.invoke(demo_cmd, ["--json"])
+        assert result.exit_code == 1
+        data = json.loads(result.output)
+        assert data["status"] == "error"
+
+    def test_goto_failure_exits_1(self):
+        """If page.goto raises, demo exits 1 and reports the failure."""
+        page = _make_page_mock()
+        page.goto.side_effect = Exception("net::ERR_ABORTED")
+        with _make_playwright_patcher(page):
+            runner = CliRunner()
+            result = runner.invoke(demo_cmd, ["--json"])
+        assert result.exit_code == 1
+        data = json.loads(result.output)
+        assert data["status"] == "fail"
+        failed = [s for s in data["steps"] if not s["ok"]]
+        assert any("open_page" in s["step"] for s in failed)
+
+    def test_click_failure_exits_1(self):
+        """If click_element raises, demo exits 1."""
+        page = _make_page_mock()
+
+        compose_el = MagicMock()
+        compose_el.inner_text.return_value = "Hello from gptme!"
+        compose_el.click.return_value = None
+        compose_el.fill.return_value = None
+
+        btn_el = MagicMock()
+        btn_el.click.side_effect = Exception("element not found")
+
+        def _locator(sel):
+            if "tweetTextarea_0" in sel:
+                return compose_el
+            if "tweetButtonInline" in sel:
+                return btn_el
+            return MagicMock()
+
+        page.locator.side_effect = _locator
+
+        with _make_playwright_patcher(page):
+            runner = CliRunner()
+            result = runner.invoke(demo_cmd, ["--json"])
+        assert result.exit_code == 1
+        data = json.loads(result.output)
+        assert data["status"] == "fail"
+        assert any("click_element" in s["step"] and not s["ok"] for s in data["steps"])
+
+    def test_verify_step_fails_when_status_missing(self):
+        """If the #status div returns empty text, verify step fails."""
+        page = _make_page_mock(status_text="")
+
+        status_el = MagicMock()
+        status_el.inner_text.return_value = ""
+
+        compose_el = MagicMock()
+        compose_el.inner_text.return_value = "Hello from gptme!"
+        compose_el.click.return_value = None
+        compose_el.fill.return_value = None
+
+        def _locator(sel):
+            if "tweetTextarea_0" in sel:
+                return compose_el
+            if sel == "#status":
+                return status_el
+            return MagicMock()
+
+        page.locator.side_effect = _locator
+
+        with _make_playwright_patcher(page):
+            runner = CliRunner()
+            result = runner.invoke(demo_cmd, ["--json"])
+        assert result.exit_code == 1
+        data = json.loads(result.output)
+        verify_step = next(s for s in data["steps"] if "read_page_text" in s["step"])
+        assert not verify_step["ok"]
+
+    def test_demo_url_uses_correct_selectors(self):
+        """The fixture URL must embed the Twitter data-testid selectors."""
+        from gptme.cli.cmd_computer import _DEMO_TWEET_HTML
+
+        assert 'data-testid="tweetTextarea_0"' in _DEMO_TWEET_HTML
+        assert 'data-testid="tweetButtonInline"' in _DEMO_TWEET_HTML
+        assert "tweet-posted:" in _DEMO_TWEET_HTML


### PR DESCRIPTION
## Summary

- Adds `gptme-util computer demo` — a self-contained, **LLM-free** end-to-end validation of the browser automation pipeline
- Uses the same HTML fixture (Twitter `data-testid` selectors) as the eval suite's `computer-use-web-tweet-compose` spec
- Exercises the full `open_page → wait_for_element → fill_element → click_element → read_page_text` pipeline without API keys or network access
- Supports `--text`, `--json`, exits 0/1 for scripting
- Also promotes `sync_playwright` to module level (with `ImportError` fallback) so it's patchable in tests

## Demo output

```
$ gptme-util computer demo
Computer-use browser demo (tweet-compose fixture)

  ✓  launch browser  [83 ms]
  ✓  open_page (load fixture)  [7 ms]
  ✓  wait_for_element [data-testid="tweetTextarea_0"]  [20 ms]
  ✓  fill_element (type tweet)  (typed 17 chars)  [36 ms]
  ✓  click_element [data-testid="tweetButtonInline"]  [27 ms]
  ✓  read_page_text (verify submit)  ('tweet-posted:Hello from gptme!')  [2 ms]

✅  Demo passed in 371 ms.  The browser automation pipeline is working end-to-end.
```

## Test plan

- [x] `gptme-util computer demo` runs and passes on this machine (Playwright + Chromium installed)
- [x] `gptme-util computer demo --json` outputs valid JSON with `status: "pass"`
- [x] `gptme-util computer demo --text "Shipped it!"` works with custom text
- [x] 10 unit tests in `tests/test_computer_demo_cmd.py` — all pass without a real browser (Playwright mocked)
- [x] All existing `tests/test_computer_*` tests still pass (121 tests)
- [x] `ruff check` and `ruff format` clean
- [x] Pre-commit hooks pass

Closes part of gptme/gptme#216 (tool-layer validation of the "Can it Tweet?" milestone).