### PR TITLE
docs(mcp): add Chrome DevTools MCP server example

### DIFF
--- a/docs/mcp.rst
+++ b/docs/mcp.rst
@@ -134,7 +134,21 @@ The server provides tools across several categories:
 - **Performance**: ``performance_analyze_insight``, ``lighthouse_audit``
 - **Automation**: ``click``, ``type_text``, ``fill_form``, ``hover``, ``drag``
 
-Useful flags: ``--headless`` for server environments, ``--isolated`` for clean browser state per session, ``--slim`` for navigation and screenshots only.
+Useful flags:
+
+- ``--headless`` — run without a visible window (server environments)
+- ``--isolated`` — clean browser state per session
+- ``--slim`` — navigation and screenshots only (lightweight)
+
+For example, to run headless with an isolated browser profile:
+
+.. code-block:: toml
+
+    [[mcp.servers]]
+    name = "chrome-devtools"
+    enabled = true
+    command = "npx"
+    args = ["-y", "chrome-devtools-mcp@latest", "--headless", "--isolated"]
 
 Running MCP Servers
 -------------------

--- a/docs/mcp.rst
+++ b/docs/mcp.rst
@@ -110,6 +110,32 @@ Resources:
 
 The server also includes a demonstration prompt ``mcp-demo`` that guides users through database operations and analysis.
 
+Chrome DevTools Server
+~~~~~~~~~~~~~~~~~~~~~~
+
+The `Chrome DevTools MCP server <https://github.com/ChromeDevTools/chrome-devtools-mcp>`_ exposes Chrome DevTools Protocol capabilities — DOM inspection, network traffic analysis, JavaScript console, performance profiling, and Lighthouse audits — directly as MCP tools.
+
+Requires Node.js and ``npx``.
+
+.. code-block:: toml
+
+    [[mcp.servers]]
+    name = "chrome-devtools"
+    enabled = true
+    command = "npx"
+    args = ["-y", "chrome-devtools-mcp@latest"]
+
+The server provides tools across several categories:
+
+- **Navigation**: ``navigate_page``, ``new_page``, ``close_page``, ``select_page``
+- **Inspection**: ``take_snapshot``, ``take_screenshot``, ``evaluate_script``
+- **Network**: ``list_network_requests``, ``get_network_request``
+- **Console**: ``list_console_messages``, ``get_console_message``
+- **Performance**: ``performance_analyze_insight``, ``lighthouse_audit``
+- **Automation**: ``click``, ``type_text``, ``fill_form``, ``hover``, ``drag``
+
+Useful flags: ``--headless`` for server environments, ``--isolated`` for clean browser state per session, ``--slim`` for navigation and screenshots only.
+
 Running MCP Servers
 -------------------
 


### PR DESCRIPTION
## Summary

- Adds a **Chrome DevTools Server** example to the MCP server examples section in `docs/mcp.rst`
- Covers the config snippet, available tool categories (navigation, inspection, network, console, performance, automation), and useful flags (`--headless`, `--isolated`, `--slim`)
- Links to the upstream repo at https://github.com/ChromeDevTools/chrome-devtools-mcp

The Chrome DevTools MCP server was released by the Chrome DevTools team and provides full DevTools Protocol access as MCP tools — DOM inspection, Lighthouse audits, network traffic analysis, and more. Adding it to the docs gives gptme users a copy-paste config to try it.

## Test plan

- [ ] Docs build without RST errors (`make -C docs html` or `sphinx-build docs docs/_build`)
- [ ] New section renders correctly under "MCP Server Examples"
- [ ] Config snippet follows the same `[[mcp.servers]]` format as the SQLite example