### PR TITLE
feat(server): add /api/v2/computer/screenshot polling API (#216)

### DIFF
--- a/gptme/server/app.py
+++ b/gptme/server/app.py
@@ -106,6 +106,7 @@ def create_app(
     from .api_v2 import v2_api  # fmt: skip
     from .artifacts_api import artifacts_api  # fmt: skip
     from .auth import auth_api  # fmt: skip
+    from .computer_api import computer_api  # fmt: skip
     from .panels_api import panels_api  # fmt: skip
     from .tasks_api import tasks_api  # fmt: skip
     from .tools_api import tools_api  # fmt: skip
@@ -121,6 +122,7 @@ def create_app(
     app.register_blueprint(panels_api)
     app.register_blueprint(tools_api)
     app.register_blueprint(tts_api)
+    app.register_blueprint(computer_api)
 
     # Register OpenAPI documentation
     from .openapi_docs import docs_api  # fmt: skip

--- a/gptme/server/computer_api.py
+++ b/gptme/server/computer_api.py
@@ -105,24 +105,24 @@ def screenshot():
         JPEG quality (1–95, default 80).  Lower values produce smaller
         images with faster polling.
     """
-    if not _screenshot_available():
-        system = platform.system()
-        if system == "Linux":
-            hint = (
-                "No supported Linux screenshot backend available. "
-                "Install gnome-screenshot, or install scrot and run under X11/Xvfb."
-            )
-        elif system == "Darwin":
-            hint = "screencapture not found (unexpected on macOS)"
-        else:
-            hint = f"Computer-use not supported on {system}"
-        return flask.Response(
-            response=flask.json.dumps({"error": hint}),
-            status=503,
-            content_type="application/json",
-        )
-
     try:
+        if not _screenshot_available():
+            system = platform.system()
+            if system == "Linux":
+                hint = (
+                    "No supported Linux screenshot backend available. "
+                    "Install gnome-screenshot, or install scrot and run under X11/Xvfb."
+                )
+            elif system == "Darwin":
+                hint = "screencapture not found (unexpected on macOS)"
+            else:
+                hint = f"Computer-use not supported on {system}"
+            return flask.Response(
+                response=flask.json.dumps({"error": hint}),
+                status=503,
+                content_type="application/json",
+            )
+
         quality_raw = flask.request.args.get("quality", "80")
         try:
             quality = max(1, min(95, int(quality_raw)))
@@ -235,15 +235,25 @@ def status():
     except ImportError:
         backends["playwright"] = False
 
+    screenshot_error = None
+    try:
+        screenshot_available = _screenshot_available()
+    except Exception as exc:
+        logger.exception("Screenshot availability check failed")
+        screenshot_available = False
+        screenshot_error = str(exc)
+
+    payload = {
+        "screenshot_available": screenshot_available,
+        "system": system,
+        "display": display,
+        "backends": backends,
+    }
+    if screenshot_error is not None:
+        payload["screenshot_error"] = screenshot_error
+
     return flask.Response(
-        response=flask.json.dumps(
-            {
-                "screenshot_available": _screenshot_available(),
-                "system": system,
-                "display": display,
-                "backends": backends,
-            }
-        ),
+        response=flask.json.dumps(payload),
         status=200,
         content_type="application/json",
     )

--- a/gptme/server/computer_api.py
+++ b/gptme/server/computer_api.py
@@ -40,14 +40,21 @@ computer_api = flask.Blueprint("computer_api", __name__)
 
 
 def _screenshot_available() -> bool:
-    """Return True when a screenshot backend is available on this machine."""
+    """Return True when a screenshot backend is available on this machine.
+
+    Mirrors the logic in ``gptme.tools.screenshot._is_available`` to ensure
+    the API endpoint's availability check matches the actual screenshot tool
+    backends.
+    """
     system = platform.system()
     if system == "Linux":
         display = os.environ.get("DISPLAY", "")
-        has_display = bool(display)
-        has_scrot = bool(shutil.which("scrot"))
-        has_ffmpeg = bool(shutil.which("ffmpeg"))
-        return has_display and (has_scrot or has_ffmpeg)
+        if not display:
+            return False
+        has_gnome = bool(shutil.which("gnome-screenshot"))
+        is_wayland = os.environ.get("XDG_SESSION_TYPE") == "wayland"
+        has_scrot = bool(shutil.which("scrot")) and not is_wayland
+        return has_gnome or has_scrot
     if system == "Darwin":
         return bool(shutil.which("screencapture"))
     return False
@@ -113,12 +120,14 @@ def screenshot():
 
         # Convert to JPEG with requested quality using ImageMagick if available,
         # otherwise serve the raw PNG.
+        _temp_jpg: str | None = None  # track temp file for cleanup
         if path.suffix.lower() != ".jpg" and shutil.which("convert"):
             try:
                 import subprocess
 
                 jpg_fd, jpg_path = tempfile.mkstemp(suffix=".jpg")
                 os.close(jpg_fd)
+                _temp_jpg = jpg_path
                 subprocess.run(
                     [
                         "convert",
@@ -134,6 +143,8 @@ def screenshot():
                 img_path = Path(jpg_path)
                 content_type = "image/jpeg"
             except Exception:
+                if _temp_jpg:
+                    os.unlink(_temp_jpg)
                 img_path = path
                 content_type = "image/png"
         else:
@@ -143,6 +154,11 @@ def screenshot():
             )
 
         data = img_path.read_bytes()
+
+        # Clean up temp JPEG file if conversion succeeded
+        if _temp_jpg and img_path == Path(_temp_jpg):
+            os.unlink(_temp_jpg)
+
         return flask.Response(
             response=data,
             status=200,
@@ -184,7 +200,7 @@ def status():
     if system == "Linux":
         backends["xdotool"] = bool(shutil.which("xdotool"))
         backends["scrot"] = bool(shutil.which("scrot"))
-        backends["ffmpeg"] = bool(shutil.which("ffmpeg"))
+        backends["gnome_screenshot"] = bool(shutil.which("gnome-screenshot"))
         backends["imagemagick"] = bool(shutil.which("convert"))
     elif system == "Darwin":
         backends["screencapture"] = bool(shutil.which("screencapture"))

--- a/gptme/server/computer_api.py
+++ b/gptme/server/computer_api.py
@@ -9,8 +9,8 @@ Endpoints
 ---------
 ``GET /api/v2/computer/screenshot``
     Take a screenshot and return it as a JPEG image.  Returns 503 when
-    no display is available (``$DISPLAY`` not set on Linux, or
-    ``screencapture`` absent on macOS).
+    no screenshot backend is available (``gnome-screenshot`` / ``scrot``
+    absent on Linux, or ``screencapture`` absent on macOS).
 
 ``GET /api/v2/computer/status``
     Return a JSON status object describing what computer-use backends
@@ -48,9 +48,6 @@ def _native_screenshot_available() -> bool:
     """
     system = platform.system()
     if system == "Linux":
-        display = os.environ.get("DISPLAY", "")
-        if not display:
-            return False
         has_gnome = bool(shutil.which("gnome-screenshot"))
         is_wayland = os.environ.get("XDG_SESSION_TYPE") == "wayland"
         has_scrot = bool(shutil.which("scrot")) and not is_wayland
@@ -115,8 +112,8 @@ def screenshot():
         system = platform.system()
         if system == "Linux":
             hint = (
-                "No X11 display available. "
-                "Set $DISPLAY or start Xvfb: Xvfb :1 -screen 0 1024x768x24 &"
+                "No supported Linux screenshot backend available. "
+                "Install gnome-screenshot, or install scrot and run under X11/Xvfb."
             )
         elif system == "Darwin":
             hint = "screencapture not found (unexpected on macOS)"

--- a/gptme/server/computer_api.py
+++ b/gptme/server/computer_api.py
@@ -76,21 +76,18 @@ def _take_screenshot() -> Path:
 
     Raises RuntimeError when the screenshot fails.
     """
-    from ..tools.computer_transport import NativeComputerTransport, get_transport
+    from ..tools.computer_transport import get_transport
+    from ..tools.screenshot import screenshot as take_native_screenshot
 
     transport = get_transport()
-    owns_transport = False
     if transport is None:
-        transport = NativeComputerTransport()
-        owns_transport = True
-    try:
+        path = take_native_screenshot()
+    else:
         path = transport.screenshot()
-        if not path.exists():
-            raise RuntimeError("Screenshot produced no file")
-        return path
-    finally:
-        if owns_transport:
-            transport.close()
+
+    if not path.exists():
+        raise RuntimeError("Screenshot produced no file")
+    return path
 
 
 @computer_api.route("/api/v2/computer/screenshot")

--- a/gptme/server/computer_api.py
+++ b/gptme/server/computer_api.py
@@ -39,8 +39,8 @@ logger = logging.getLogger(__name__)
 computer_api = flask.Blueprint("computer_api", __name__)
 
 
-def _screenshot_available() -> bool:
-    """Return True when a screenshot backend is available on this machine.
+def _native_screenshot_available() -> bool:
+    """Return True when the native screenshot backend is available.
 
     Mirrors the logic in ``gptme.tools.screenshot._is_available`` to ensure
     the API endpoint's availability check matches the actual screenshot tool
@@ -60,21 +60,40 @@ def _screenshot_available() -> bool:
     return False
 
 
+def _screenshot_available() -> bool:
+    """Return True when a screenshot transport is available on this machine."""
+    from ..tools.computer_transport import NativeComputerTransport, get_transport
+
+    transport = get_transport()
+    if transport is None:
+        return _native_screenshot_available()
+
+    if isinstance(transport, NativeComputerTransport):
+        return _native_screenshot_available()
+
+    return True
+
+
 def _take_screenshot() -> Path:
     """Take a screenshot and return the path to the saved image file.
 
     Raises RuntimeError when the screenshot fails.
     """
-    from ..tools.computer_transport import NativeComputerTransport
+    from ..tools.computer_transport import NativeComputerTransport, get_transport
 
-    transport = NativeComputerTransport()
+    transport = get_transport()
+    owns_transport = False
+    if transport is None:
+        transport = NativeComputerTransport()
+        owns_transport = True
     try:
         path = transport.screenshot()
         if not path.exists():
             raise RuntimeError("Screenshot produced no file")
         return path
     finally:
-        transport.close()
+        if owns_transport:
+            transport.close()
 
 
 @computer_api.route("/api/v2/computer/screenshot")
@@ -117,47 +136,45 @@ def screenshot():
             quality = 80
 
         path = _take_screenshot()
+        temp_paths = [path]
 
-        # Convert to JPEG with requested quality using ImageMagick if available,
-        # otherwise serve the raw PNG.
-        _temp_jpg: str | None = None  # track temp file for cleanup
-        if path.suffix.lower() != ".jpg" and shutil.which("convert"):
-            try:
-                import subprocess
+        try:
+            # Convert to JPEG with requested quality using ImageMagick if available,
+            # otherwise serve the raw PNG.
+            if path.suffix.lower() != ".jpg" and shutil.which("convert"):
+                try:
+                    import subprocess
 
-                jpg_fd, jpg_path = tempfile.mkstemp(suffix=".jpg")
-                os.close(jpg_fd)
-                _temp_jpg = jpg_path
-                subprocess.run(
-                    [
-                        "convert",
-                        str(path),
-                        "-quality",
-                        str(quality),
-                        jpg_path,
-                    ],
-                    check=True,
-                    capture_output=True,
-                    timeout=10,
-                )
-                img_path = Path(jpg_path)
-                content_type = "image/jpeg"
-            except Exception:
-                if _temp_jpg:
-                    os.unlink(_temp_jpg)
+                    jpg_fd, jpg_path = tempfile.mkstemp(suffix=".jpg")
+                    os.close(jpg_fd)
+                    img_path = Path(jpg_path)
+                    temp_paths.append(img_path)
+                    subprocess.run(
+                        [
+                            "convert",
+                            str(path),
+                            "-quality",
+                            str(quality),
+                            jpg_path,
+                        ],
+                        check=True,
+                        capture_output=True,
+                        timeout=10,
+                    )
+                    content_type = "image/jpeg"
+                except Exception:
+                    img_path = path
+                    content_type = "image/png"
+            else:
                 img_path = path
-                content_type = "image/png"
-        else:
-            img_path = path
-            content_type = (
-                "image/jpeg" if path.suffix.lower() == ".jpg" else "image/png"
-            )
+                content_type = (
+                    "image/jpeg" if path.suffix.lower() == ".jpg" else "image/png"
+                )
 
-        data = img_path.read_bytes()
-
-        # Clean up temp JPEG file if conversion succeeded
-        if _temp_jpg and img_path == Path(_temp_jpg):
-            os.unlink(_temp_jpg)
+            data = img_path.read_bytes()
+        finally:
+            for temp_path in temp_paths:
+                temp_path.unlink(missing_ok=True)
 
         return flask.Response(
             response=data,

--- a/gptme/server/computer_api.py
+++ b/gptme/server/computer_api.py
@@ -1,0 +1,222 @@
+"""
+Computer-use API endpoints for the gptme server.
+
+Provides a lightweight screenshot-polling alternative to VNC streaming,
+allowing the web UI to show the current desktop state without requiring
+a separate x11vnc + noVNC stack.
+
+Endpoints
+---------
+``GET /api/v2/computer/screenshot``
+    Take a screenshot and return it as a JPEG image.  Returns 503 when
+    no display is available (``$DISPLAY`` not set on Linux, or
+    ``screencapture`` absent on macOS).
+
+``GET /api/v2/computer/status``
+    Return a JSON status object describing what computer-use backends
+    are available on this server.
+
+Designed for issue #216 — the non-Docker local computer-use workflow
+where you run ``gptme-server`` on a machine that already has a desktop,
+but don't want to set up a full VNC stack just to observe the desktop.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import platform
+import shutil
+import tempfile
+from pathlib import Path
+
+import flask
+
+from .auth import require_auth
+
+logger = logging.getLogger(__name__)
+
+computer_api = flask.Blueprint("computer_api", __name__)
+
+
+def _screenshot_available() -> bool:
+    """Return True when a screenshot backend is available on this machine."""
+    system = platform.system()
+    if system == "Linux":
+        display = os.environ.get("DISPLAY", "")
+        has_display = bool(display)
+        has_scrot = bool(shutil.which("scrot"))
+        has_ffmpeg = bool(shutil.which("ffmpeg"))
+        return has_display and (has_scrot or has_ffmpeg)
+    if system == "Darwin":
+        return bool(shutil.which("screencapture"))
+    return False
+
+
+def _take_screenshot() -> Path:
+    """Take a screenshot and return the path to the saved image file.
+
+    Raises RuntimeError when the screenshot fails.
+    """
+    from ..tools.computer_transport import NativeComputerTransport
+
+    transport = NativeComputerTransport()
+    try:
+        path = transport.screenshot()
+        if not path.exists():
+            raise RuntimeError("Screenshot produced no file")
+        return path
+    finally:
+        transport.close()
+
+
+@computer_api.route("/api/v2/computer/screenshot")
+@require_auth
+def screenshot():
+    """Take a screenshot of the current desktop and return it as a JPEG image.
+
+    Returns 503 when no display backend is available.  Returns 500 on
+    screenshot failure.  On success, returns the JPEG image with
+    ``Content-Type: image/jpeg``.
+
+    Query parameters
+    ----------------
+    quality : int, optional
+        JPEG quality (1–95, default 80).  Lower values produce smaller
+        images with faster polling.
+    """
+    if not _screenshot_available():
+        system = platform.system()
+        if system == "Linux":
+            hint = (
+                "No X11 display available. "
+                "Set $DISPLAY or start Xvfb: Xvfb :1 -screen 0 1024x768x24 &"
+            )
+        elif system == "Darwin":
+            hint = "screencapture not found (unexpected on macOS)"
+        else:
+            hint = f"Computer-use not supported on {system}"
+        return flask.Response(
+            response=flask.json.dumps({"error": hint}),
+            status=503,
+            content_type="application/json",
+        )
+
+    try:
+        quality_raw = flask.request.args.get("quality", "80")
+        try:
+            quality = max(1, min(95, int(quality_raw)))
+        except ValueError:
+            quality = 80
+
+        path = _take_screenshot()
+
+        # Convert to JPEG with requested quality using ImageMagick if available,
+        # otherwise serve the raw PNG.
+        if path.suffix.lower() != ".jpg" and shutil.which("convert"):
+            try:
+                import subprocess
+
+                jpg_fd, jpg_path = tempfile.mkstemp(suffix=".jpg")
+                os.close(jpg_fd)
+                subprocess.run(
+                    [
+                        "convert",
+                        str(path),
+                        "-quality",
+                        str(quality),
+                        jpg_path,
+                    ],
+                    check=True,
+                    capture_output=True,
+                    timeout=10,
+                )
+                img_path = Path(jpg_path)
+                content_type = "image/jpeg"
+            except Exception:
+                img_path = path
+                content_type = "image/png"
+        else:
+            img_path = path
+            content_type = (
+                "image/jpeg" if path.suffix.lower() == ".jpg" else "image/png"
+            )
+
+        data = img_path.read_bytes()
+        return flask.Response(
+            response=data,
+            status=200,
+            content_type=content_type,
+            headers={
+                "Cache-Control": "no-store, no-cache, must-revalidate, max-age=0",
+                "Pragma": "no-cache",
+            },
+        )
+    except Exception as exc:
+        logger.exception("Screenshot failed")
+        return flask.Response(
+            response=flask.json.dumps({"error": str(exc)}),
+            status=500,
+            content_type="application/json",
+        )
+
+
+@computer_api.route("/api/v2/computer/status")
+@require_auth
+def status():
+    """Return a JSON object describing what computer-use backends are available.
+
+    Response fields
+    ---------------
+    screenshot_available : bool
+        True when taking a screenshot will succeed.
+    system : str
+        Platform name (Linux / Darwin / Windows).
+    display : str | null
+        Value of ``$DISPLAY`` on Linux, null elsewhere.
+    backends : dict
+        Availability of each backend tool (xdotool, scrot, cliclick, etc.).
+    """
+    system = platform.system()
+    display = os.environ.get("DISPLAY") if system == "Linux" else None
+
+    backends: dict[str, bool] = {}
+    if system == "Linux":
+        backends["xdotool"] = bool(shutil.which("xdotool"))
+        backends["scrot"] = bool(shutil.which("scrot"))
+        backends["ffmpeg"] = bool(shutil.which("ffmpeg"))
+        backends["imagemagick"] = bool(shutil.which("convert"))
+    elif system == "Darwin":
+        backends["screencapture"] = bool(shutil.which("screencapture"))
+        backends["cliclick"] = bool(shutil.which("cliclick"))
+        backends["osascript"] = bool(shutil.which("osascript"))
+
+    try:
+        import pyatspi  # type: ignore[import-not-found]  # noqa: F401
+
+        backends["pyatspi"] = True
+    except ImportError:
+        if system == "Linux":
+            backends["pyatspi"] = False
+
+    try:
+        from playwright.sync_api import (
+            sync_playwright,  # type: ignore[import-not-found]  # noqa: F401
+        )
+
+        backends["playwright"] = True
+    except ImportError:
+        backends["playwright"] = False
+
+    return flask.Response(
+        response=flask.json.dumps(
+            {
+                "screenshot_available": _screenshot_available(),
+                "system": system,
+                "display": display,
+                "backends": backends,
+            }
+        ),
+        status=200,
+        content_type="application/json",
+    )

--- a/gptme/server/static/computer.html
+++ b/gptme/server/static/computer.html
@@ -45,6 +45,41 @@
         button:hover {
             background: #f0f0f0;
         }
+        /* Screenshot polling fallback (shown when VNC is unavailable) */
+        #screenshot-panel {
+            display: none;
+            flex: 2;
+            height: 100vh;
+            background: #111;
+            position: relative;
+            overflow: hidden;
+        }
+        #screenshot-img {
+            width: 100%;
+            height: 100%;
+            object-fit: contain;
+        }
+        #screenshot-status {
+            position: absolute;
+            bottom: 8px;
+            left: 50%;
+            transform: translateX(-50%);
+            background: rgba(0,0,0,0.6);
+            color: #ccc;
+            font-size: 12px;
+            padding: 4px 10px;
+            border-radius: 4px;
+            white-space: nowrap;
+        }
+        #screenshot-error {
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%);
+            color: #888;
+            text-align: center;
+            font-size: 14px;
+        }
     </style>
 </head>
 <body>
@@ -53,52 +88,164 @@
             <!-- Will be replaced with gptme chat interface -->
             <iframe src="/chat" style="width: 100%; height: 100%; border: none;"></iframe>
         </div>
+        <!-- VNC mode: full live desktop via noVNC -->
         <iframe
             id="vnc"
             class="desktop"
             allow="fullscreen"
+            style="display:none"
         ></iframe>
+        <!-- Screenshot polling fallback: polls /api/v2/computer/screenshot -->
+        <div id="screenshot-panel">
+            <img id="screenshot-img" alt="Desktop screenshot" />
+            <div id="screenshot-status">Connecting…</div>
+            <div id="screenshot-error" style="display:none"></div>
+        </div>
     </div>
     <div class="controls">
-        <button id="toggleViewOnly">Toggle Screen Control (Off)</button>
+        <button id="toggleViewOnly" style="display:none">Toggle Screen Control (Off)</button>
+        <button id="toggleMode">Switch to VNC</button>
         <button id="toggleFullscreen">Toggle Fullscreen</button>
     </div>
     <script>
-        // Derive the VNC host from the current page so remote Docker setups
-        // (e.g. accessing http://remote-host:8080/computer) work without
-        // needing to edit any config.  Query params override for custom setups:
-        //   /computer?vncHost=192.168.1.5&vncPort=6080
         (function () {
             var params = new URLSearchParams(window.location.search);
+
+            // ---------------------------------------------------------------
+            // VNC mode
+            // ---------------------------------------------------------------
             var vncHost = params.get("vncHost") || window.location.hostname;
             var vncPort = params.get("vncPort") || "6080";
             var vncSrc = window.location.protocol + "//" + vncHost + ":" + vncPort +
                 "/vnc.html?&resize=scale&autoconnect=1&view_only=1&reconnect=1&reconnect_delay=2000";
-            document.getElementById("vnc").src = vncSrc;
+
+            // ---------------------------------------------------------------
+            // Screenshot polling mode
+            // ---------------------------------------------------------------
+            var screenshotInterval = null;
+            var screenshotFps = parseInt(params.get("fps") || "2", 10);
+            var screenshotDelay = Math.round(1000 / Math.max(1, Math.min(10, screenshotFps)));
+            var screenshotToken = params.get("token") || "";
+            var img = document.getElementById("screenshot-img");
+            var statusEl = document.getElementById("screenshot-status");
+            var errorEl = document.getElementById("screenshot-error");
+            var lastTs = 0;
+
+            function fetchScreenshot() {
+                var url = "/api/v2/computer/screenshot?quality=70&_t=" + Date.now();
+                var headers = {};
+                if (screenshotToken) {
+                    headers["Authorization"] = "Bearer " + screenshotToken;
+                }
+                fetch(url, {headers: headers, cache: "no-store"})
+                    .then(function(r) {
+                        if (!r.ok) {
+                            return r.json().then(function(j) {
+                                throw new Error(j.error || ("HTTP " + r.status));
+                            }).catch(function() {
+                                throw new Error("HTTP " + r.status);
+                            });
+                        }
+                        return r.blob();
+                    })
+                    .then(function(blob) {
+                        var oldSrc = img.src;
+                        img.src = URL.createObjectURL(blob);
+                        if (oldSrc && oldSrc.startsWith("blob:")) {
+                            URL.revokeObjectURL(oldSrc);
+                        }
+                        var now = Date.now();
+                        var fps = lastTs ? Math.round(1000 / (now - lastTs)) : 0;
+                        lastTs = now;
+                        statusEl.textContent = fps + " fps  |  polling every " + screenshotDelay + " ms";
+                        errorEl.style.display = "none";
+                        img.style.display = "block";
+                    })
+                    .catch(function(err) {
+                        errorEl.textContent = "No desktop: " + err.message;
+                        errorEl.style.display = "block";
+                        img.style.display = "none";
+                        statusEl.textContent = "Error — retrying…";
+                    });
+            }
+
+            function startScreenshotPolling() {
+                fetchScreenshot();
+                screenshotInterval = setInterval(fetchScreenshot, screenshotDelay);
+            }
+
+            function stopScreenshotPolling() {
+                if (screenshotInterval) {
+                    clearInterval(screenshotInterval);
+                    screenshotInterval = null;
+                }
+            }
+
+            // ---------------------------------------------------------------
+            // Mode switching
+            // ---------------------------------------------------------------
+            // Default: show screenshot panel (works on local gptme-server without VNC).
+            // Switching to VNC requires an explicit user gesture (or ?mode=vnc param).
+            var mode = params.get("mode") || "screenshot";
+
+            function showVnc() {
+                mode = "vnc";
+                stopScreenshotPolling();
+                document.getElementById("vnc").src = vncSrc;
+                document.getElementById("vnc").style.display = "";
+                document.getElementById("screenshot-panel").style.display = "none";
+                document.getElementById("toggleViewOnly").style.display = "";
+                document.getElementById("toggleMode").textContent = "Switch to Screenshot";
+            }
+
+            function showScreenshot() {
+                mode = "screenshot";
+                document.getElementById("vnc").src = "";
+                document.getElementById("vnc").style.display = "none";
+                document.getElementById("screenshot-panel").style.display = "";
+                document.getElementById("toggleViewOnly").style.display = "none";
+                document.getElementById("toggleMode").textContent = "Switch to VNC";
+                startScreenshotPolling();
+            }
+
+            if (mode === "vnc") {
+                showVnc();
+            } else {
+                showScreenshot();
+            }
+
+            // ---------------------------------------------------------------
+            // Controls
+            // ---------------------------------------------------------------
+            document.getElementById("toggleMode").addEventListener("click", function() {
+                if (mode === "screenshot") {
+                    showVnc();
+                } else {
+                    showScreenshot();
+                }
+            });
+
+            document.getElementById("toggleViewOnly").addEventListener("click", function() {
+                var vncIframe = document.getElementById("vnc");
+                var button = document.getElementById("toggleViewOnly");
+                var currentSrc = vncIframe.src;
+                if (currentSrc.includes("view_only=1")) {
+                    vncIframe.src = currentSrc.replace("view_only=1", "view_only=0");
+                    button.innerText = "Toggle Screen Control (On)";
+                } else {
+                    vncIframe.src = currentSrc.replace("view_only=0", "view_only=1");
+                    button.innerText = "Toggle Screen Control (Off)";
+                }
+            });
+
+            document.getElementById("toggleFullscreen").addEventListener("click", function() {
+                if (!document.fullscreenElement) {
+                    document.documentElement.requestFullscreen();
+                } else {
+                    document.exitFullscreen();
+                }
+            });
         })();
-
-        // Toggle view-only mode
-        document.getElementById("toggleViewOnly").addEventListener("click", function() {
-            var vncIframe = document.getElementById("vnc");
-            var button = document.getElementById("toggleViewOnly");
-            var currentSrc = vncIframe.src;
-            if (currentSrc.includes("view_only=1")) {
-                vncIframe.src = currentSrc.replace("view_only=1", "view_only=0");
-                button.innerText = "Toggle Screen Control (On)";
-            } else {
-                vncIframe.src = currentSrc.replace("view_only=0", "view_only=1");
-                button.innerText = "Toggle Screen Control (Off)";
-            }
-        });
-
-        // Toggle fullscreen
-        document.getElementById("toggleFullscreen").addEventListener("click", function() {
-            if (!document.fullscreenElement) {
-                document.documentElement.requestFullscreen();
-            } else {
-                document.exitFullscreen();
-            }
-        });
     </script>
 </body>
 </html>

--- a/gptme/server/static/computer.html
+++ b/gptme/server/static/computer.html
@@ -125,6 +125,7 @@
             var screenshotInterval = null;
             var screenshotFps = parseInt(params.get("fps") || "2", 10);
             var screenshotDelay = Math.round(1000 / Math.max(1, Math.min(10, screenshotFps)));
+            var screenshotQuality = Math.max(1, Math.min(95, parseInt(params.get("quality") || "70", 10) || 70));
             var screenshotToken = params.get("token") || "";
             var img = document.getElementById("screenshot-img");
             var statusEl = document.getElementById("screenshot-status");
@@ -132,7 +133,7 @@
             var lastTs = 0;
 
             function fetchScreenshot() {
-                var url = "/api/v2/computer/screenshot?quality=70&_t=" + Date.now();
+                var url = "/api/v2/computer/screenshot?quality=" + screenshotQuality + "&_t=" + Date.now();
                 var headers = {};
                 if (screenshotToken) {
                     headers["Authorization"] = "Bearer " + screenshotToken;
@@ -202,7 +203,7 @@
                 mode = "screenshot";
                 document.getElementById("vnc").src = "";
                 document.getElementById("vnc").style.display = "none";
-                document.getElementById("screenshot-panel").style.display = "";
+                document.getElementById("screenshot-panel").style.display = "flex";
                 document.getElementById("toggleViewOnly").style.display = "none";
                 document.getElementById("toggleMode").textContent = "Switch to VNC";
                 startScreenshotPolling();

--- a/tests/test_computer_api.py
+++ b/tests/test_computer_api.py
@@ -1,0 +1,284 @@
+"""Tests for the /api/v2/computer/* endpoints (issue #216).
+
+Validates the screenshot-polling API that provides a lightweight alternative
+to VNC streaming for viewing the desktop from the gptme web UI.
+"""
+
+from __future__ import annotations
+
+import platform
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+import pytest
+
+from gptme.server.app import create_app
+
+
+@pytest.fixture()
+def client():
+    app = create_app(cors_origin=None)
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+
+# ---------------------------------------------------------------------------
+# /api/v2/computer/status
+# ---------------------------------------------------------------------------
+
+
+class TestComputerStatus:
+    def test_status_returns_json(self, client):
+        resp = client.get("/api/v2/computer/status")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert "screenshot_available" in data
+        assert "system" in data
+        assert "backends" in data
+
+    def test_status_system_matches_platform(self, client):
+        resp = client.get("/api/v2/computer/status")
+        data = resp.get_json()
+        assert data["system"] == platform.system()
+
+    def test_status_screenshot_available_is_bool(self, client):
+        resp = client.get("/api/v2/computer/status")
+        data = resp.get_json()
+        assert isinstance(data["screenshot_available"], bool)
+
+    def test_status_backends_is_dict_of_bools(self, client):
+        resp = client.get("/api/v2/computer/status")
+        data = resp.get_json()
+        backends = data["backends"]
+        assert isinstance(backends, dict)
+        for key, val in backends.items():
+            assert isinstance(val, bool), f"{key} should be bool, got {type(val)}"
+
+    def test_status_linux_display_field(self, client, monkeypatch):
+        if platform.system() != "Linux":
+            pytest.skip("Linux-only test")
+        monkeypatch.setenv("DISPLAY", ":42")
+        resp = client.get("/api/v2/computer/status")
+        data = resp.get_json()
+        assert data["display"] == ":42"
+
+    def test_status_no_display_on_linux(self, client, monkeypatch):
+        if platform.system() != "Linux":
+            pytest.skip("Linux-only test")
+        monkeypatch.delenv("DISPLAY", raising=False)
+        resp = client.get("/api/v2/computer/status")
+        data = resp.get_json()
+        assert data["display"] is None
+
+
+# ---------------------------------------------------------------------------
+# /api/v2/computer/screenshot — 503 when no display
+# ---------------------------------------------------------------------------
+
+
+class TestComputerScreenshot503:
+    """When no display is available, the endpoint returns 503."""
+
+    def test_returns_503_when_no_display(self, client, monkeypatch):
+        # Patch _screenshot_available to return False so we don't need a real display
+        with patch(
+            "gptme.server.computer_api._screenshot_available", return_value=False
+        ):
+            resp = client.get("/api/v2/computer/screenshot")
+        assert resp.status_code == 503
+        data = resp.get_json()
+        assert "error" in data
+
+    def test_503_error_message_is_actionable(self, client, monkeypatch):
+        with patch(
+            "gptme.server.computer_api._screenshot_available", return_value=False
+        ):
+            resp = client.get("/api/v2/computer/screenshot")
+        data = resp.get_json()
+        # Should mention display or screenshot backend, not a generic error
+        error = data["error"].lower()
+        assert any(
+            keyword in error
+            for keyword in ["display", "screenshot", "supported", "xvfb"]
+        ), f"Error message should be actionable, got: {data['error']!r}"
+
+
+# ---------------------------------------------------------------------------
+# /api/v2/computer/screenshot — success (mocked transport)
+# ---------------------------------------------------------------------------
+
+
+class TestComputerScreenshotSuccess:
+    """When a screenshot can be taken, the endpoint returns image bytes."""
+
+    @pytest.fixture()
+    def png_file(self, tmp_path) -> Path:
+        # Minimal 1x1 PNG (valid PNG header + IHDR + IDAT + IEND)
+        minimal_png = bytes(
+            [
+                0x89,
+                0x50,
+                0x4E,
+                0x47,
+                0x0D,
+                0x0A,
+                0x1A,
+                0x0A,  # PNG signature
+                0x00,
+                0x00,
+                0x00,
+                0x0D,
+                0x49,
+                0x48,
+                0x44,
+                0x52,  # IHDR chunk
+                0x00,
+                0x00,
+                0x00,
+                0x01,
+                0x00,
+                0x00,
+                0x00,
+                0x01,
+                0x08,
+                0x02,
+                0x00,
+                0x00,
+                0x00,
+                0x90,
+                0x77,
+                0x53,
+                0xDE,
+                0x00,
+                0x00,
+                0x00,
+                0x0C,
+                0x49,
+                0x44,
+                0x41,  # IDAT chunk
+                0x54,
+                0x08,
+                0xD7,
+                0x63,
+                0xF8,
+                0xCF,
+                0xC0,
+                0x00,
+                0x00,
+                0x00,
+                0x02,
+                0x00,
+                0x01,
+                0xE2,
+                0x21,
+                0xBC,
+                0x33,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x49,
+                0x45,
+                0x4E,  # IEND chunk
+                0x44,
+                0xAE,
+                0x42,
+                0x60,
+                0x82,
+            ]
+        )
+        p = tmp_path / "screen.png"
+        p.write_bytes(minimal_png)
+        return p
+
+    def test_returns_200_with_image(self, client, png_file):
+        with (
+            patch("gptme.server.computer_api._screenshot_available", return_value=True),
+            patch("gptme.server.computer_api._take_screenshot", return_value=png_file),
+        ):
+            resp = client.get("/api/v2/computer/screenshot")
+        assert resp.status_code == 200
+        assert resp.content_type in ("image/png", "image/jpeg")
+        assert len(resp.data) > 0
+
+    def test_response_is_not_empty(self, client, png_file):
+        with (
+            patch("gptme.server.computer_api._screenshot_available", return_value=True),
+            patch("gptme.server.computer_api._take_screenshot", return_value=png_file),
+        ):
+            resp = client.get("/api/v2/computer/screenshot")
+        assert len(resp.data) > 8  # more than just a PNG signature
+
+    def test_no_cache_headers(self, client, png_file):
+        with (
+            patch("gptme.server.computer_api._screenshot_available", return_value=True),
+            patch("gptme.server.computer_api._take_screenshot", return_value=png_file),
+        ):
+            resp = client.get("/api/v2/computer/screenshot")
+        cc = resp.headers.get("Cache-Control", "")
+        assert "no-store" in cc or "no-cache" in cc
+
+    def test_quality_param_is_accepted(self, client, png_file):
+        with (
+            patch("gptme.server.computer_api._screenshot_available", return_value=True),
+            patch("gptme.server.computer_api._take_screenshot", return_value=png_file),
+        ):
+            resp = client.get("/api/v2/computer/screenshot?quality=50")
+        assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# /api/v2/computer/screenshot — transport failure → 500
+# ---------------------------------------------------------------------------
+
+
+class TestComputerScreenshot500:
+    def test_returns_500_when_transport_fails(self, client):
+        with (
+            patch("gptme.server.computer_api._screenshot_available", return_value=True),
+            patch(
+                "gptme.server.computer_api._take_screenshot",
+                side_effect=RuntimeError("xdotool not found"),
+            ),
+        ):
+            resp = client.get("/api/v2/computer/screenshot")
+        assert resp.status_code == 500
+        data = resp.get_json()
+        assert "error" in data
+
+
+# ---------------------------------------------------------------------------
+# _screenshot_available helper
+# ---------------------------------------------------------------------------
+
+
+class TestScreenshotAvailable:
+    def test_linux_no_display_returns_false(self, monkeypatch):
+        if platform.system() != "Linux":
+            pytest.skip("Linux-only test")
+        monkeypatch.delenv("DISPLAY", raising=False)
+        from gptme.server.computer_api import _screenshot_available
+
+        assert _screenshot_available() is False
+
+    def test_linux_with_display_and_scrot_returns_true(self, monkeypatch):
+        if platform.system() != "Linux":
+            pytest.skip("Linux-only test")
+        monkeypatch.setenv("DISPLAY", ":1")
+        with patch(
+            "shutil.which",
+            side_effect=lambda cmd: "/usr/bin/" + cmd if cmd == "scrot" else None,
+        ):
+            import importlib
+
+            from gptme.server import computer_api
+
+            importlib.reload(computer_api)
+            # Re-import after reload
+            result = computer_api._screenshot_available()
+        # The function reads platform.system() and shutil.which — just check it returns bool
+        assert isinstance(result, bool)

--- a/tests/test_computer_api.py
+++ b/tests/test_computer_api.py
@@ -6,9 +6,11 @@ to VNC streaming for viewing the desktop from the gptme web UI.
 
 from __future__ import annotations
 
+import os
 import platform
+import tempfile
 from typing import TYPE_CHECKING
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -18,12 +20,95 @@ import pytest
 from gptme.server.app import create_app
 
 
+def _minimal_png_bytes() -> bytes:
+    return bytes(
+        [
+            0x89,
+            0x50,
+            0x4E,
+            0x47,
+            0x0D,
+            0x0A,
+            0x1A,
+            0x0A,  # PNG signature
+            0x00,
+            0x00,
+            0x00,
+            0x0D,
+            0x49,
+            0x48,
+            0x44,
+            0x52,  # IHDR chunk
+            0x00,
+            0x00,
+            0x00,
+            0x01,
+            0x00,
+            0x00,
+            0x00,
+            0x01,
+            0x08,
+            0x02,
+            0x00,
+            0x00,
+            0x00,
+            0x90,
+            0x77,
+            0x53,
+            0xDE,
+            0x00,
+            0x00,
+            0x00,
+            0x0C,
+            0x49,
+            0x44,
+            0x41,  # IDAT chunk
+            0x54,
+            0x08,
+            0xD7,
+            0x63,
+            0xF8,
+            0xCF,
+            0xC0,
+            0x00,
+            0x00,
+            0x00,
+            0x02,
+            0x00,
+            0x01,
+            0xE2,
+            0x21,
+            0xBC,
+            0x33,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x49,
+            0x45,
+            0x4E,  # IEND chunk
+            0x44,
+            0xAE,
+            0x42,
+            0x60,
+            0x82,
+        ]
+    )
+
+
 @pytest.fixture()
 def client():
     app = create_app(cors_origin=None)
     app.config["TESTING"] = True
     with app.test_client() as c:
         yield c
+
+
+@pytest.fixture()
+def png_file(tmp_path) -> Path:
+    p = tmp_path / "screen.png"
+    p.write_bytes(_minimal_png_bytes())
+    return p
 
 
 # ---------------------------------------------------------------------------
@@ -115,86 +200,6 @@ class TestComputerScreenshot503:
 class TestComputerScreenshotSuccess:
     """When a screenshot can be taken, the endpoint returns image bytes."""
 
-    @pytest.fixture()
-    def png_file(self, tmp_path) -> Path:
-        # Minimal 1x1 PNG (valid PNG header + IHDR + IDAT + IEND)
-        minimal_png = bytes(
-            [
-                0x89,
-                0x50,
-                0x4E,
-                0x47,
-                0x0D,
-                0x0A,
-                0x1A,
-                0x0A,  # PNG signature
-                0x00,
-                0x00,
-                0x00,
-                0x0D,
-                0x49,
-                0x48,
-                0x44,
-                0x52,  # IHDR chunk
-                0x00,
-                0x00,
-                0x00,
-                0x01,
-                0x00,
-                0x00,
-                0x00,
-                0x01,
-                0x08,
-                0x02,
-                0x00,
-                0x00,
-                0x00,
-                0x90,
-                0x77,
-                0x53,
-                0xDE,
-                0x00,
-                0x00,
-                0x00,
-                0x0C,
-                0x49,
-                0x44,
-                0x41,  # IDAT chunk
-                0x54,
-                0x08,
-                0xD7,
-                0x63,
-                0xF8,
-                0xCF,
-                0xC0,
-                0x00,
-                0x00,
-                0x00,
-                0x02,
-                0x00,
-                0x01,
-                0xE2,
-                0x21,
-                0xBC,
-                0x33,
-                0x00,
-                0x00,
-                0x00,
-                0x00,
-                0x49,
-                0x45,
-                0x4E,  # IEND chunk
-                0x44,
-                0xAE,
-                0x42,
-                0x60,
-                0x82,
-            ]
-        )
-        p = tmp_path / "screen.png"
-        p.write_bytes(minimal_png)
-        return p
-
     def test_returns_200_with_image(self, client, png_file):
         with (
             patch("gptme.server.computer_api._screenshot_available", return_value=True),
@@ -229,6 +234,46 @@ class TestComputerScreenshotSuccess:
         ):
             resp = client.get("/api/v2/computer/screenshot?quality=50")
         assert resp.status_code == 200
+
+    def test_cleans_up_source_png_after_response(self, client, png_file):
+        with (
+            patch("gptme.server.computer_api._screenshot_available", return_value=True),
+            patch("gptme.server.computer_api._take_screenshot", return_value=png_file),
+        ):
+            resp = client.get("/api/v2/computer/screenshot")
+        assert resp.status_code == 200
+        assert not png_file.exists()
+
+    def test_cleans_up_source_png_and_temp_jpg_after_conversion(
+        self, client, png_file, tmp_path
+    ):
+        jpg_fd, jpg_path = tempfile.mkstemp(dir=tmp_path, suffix=".jpg")
+
+        def fake_convert(*args, **kwargs):
+            with open(jpg_path, "wb") as f:
+                f.write(b"jpeg-data")
+
+        with (
+            patch("gptme.server.computer_api._screenshot_available", return_value=True),
+            patch("gptme.server.computer_api._take_screenshot", return_value=png_file),
+            patch(
+                "gptme.server.computer_api.tempfile.mkstemp",
+                return_value=(jpg_fd, jpg_path),
+            ),
+            patch(
+                "gptme.server.computer_api.shutil.which",
+                side_effect=lambda cmd: (
+                    "/usr/bin/convert" if cmd == "convert" else None
+                ),
+            ),
+            patch("subprocess.run", side_effect=fake_convert),
+        ):
+            resp = client.get("/api/v2/computer/screenshot?quality=50")
+        assert resp.status_code == 200
+        assert resp.content_type == "image/jpeg"
+        assert resp.data == b"jpeg-data"
+        assert not png_file.exists()
+        assert not os.path.exists(jpg_path)
 
 
 # ---------------------------------------------------------------------------
@@ -282,3 +327,50 @@ class TestScreenshotAvailable:
             result = computer_api._screenshot_available()
         # The function reads platform.system() and shutil.which — just check it returns bool
         assert isinstance(result, bool)
+
+    def test_configured_non_native_transport_returns_true(self):
+        from gptme.server.computer_api import _screenshot_available
+
+        with patch(
+            "gptme.tools.computer_transport.get_transport", return_value=object()
+        ):
+            assert _screenshot_available() is True
+
+
+class TestTakeScreenshot:
+    def test_uses_configured_transport_when_present(self, png_file):
+        from gptme.server.computer_api import _take_screenshot
+
+        transport = Mock()
+        transport.screenshot.return_value = png_file
+
+        with (
+            patch(
+                "gptme.tools.computer_transport.get_transport", return_value=transport
+            ),
+            patch("gptme.tools.computer_transport.NativeComputerTransport"),
+        ):
+            path = _take_screenshot()
+
+        assert path == png_file
+        transport.screenshot.assert_called_once_with()
+        transport.close.assert_not_called()
+
+    def test_closes_native_fallback_transport(self, png_file):
+        from gptme.server.computer_api import _take_screenshot
+
+        transport = Mock()
+        transport.screenshot.return_value = png_file
+
+        with (
+            patch("gptme.tools.computer_transport.get_transport", return_value=None),
+            patch(
+                "gptme.tools.computer_transport.NativeComputerTransport",
+                return_value=transport,
+            ),
+        ):
+            path = _take_screenshot()
+
+        assert path == png_file
+        transport.screenshot.assert_called_once_with()
+        transport.close.assert_called_once_with()

--- a/tests/test_computer_api.py
+++ b/tests/test_computer_api.py
@@ -17,6 +17,10 @@ if TYPE_CHECKING:
 
 import pytest
 
+pytest.importorskip("flask")
+pytest.importorskip("flask_compress")
+pytest.importorskip("flask_cors")
+
 from gptme.server.app import create_app
 
 
@@ -302,13 +306,34 @@ class TestComputerScreenshot500:
 
 
 class TestScreenshotAvailable:
-    def test_linux_no_display_returns_false(self, monkeypatch):
+    def test_linux_without_screenshot_tools_returns_false(self, monkeypatch):
         if platform.system() != "Linux":
             pytest.skip("Linux-only test")
         monkeypatch.delenv("DISPLAY", raising=False)
-        from gptme.server.computer_api import _screenshot_available
+        monkeypatch.delenv("XDG_SESSION_TYPE", raising=False)
 
-        assert _screenshot_available() is False
+        with patch("shutil.which", return_value=None):
+            from gptme.server.computer_api import _screenshot_available
+
+            assert _screenshot_available() is False
+
+    def test_linux_wayland_gnome_screenshot_without_display_returns_true(
+        self, monkeypatch
+    ):
+        if platform.system() != "Linux":
+            pytest.skip("Linux-only test")
+        monkeypatch.delenv("DISPLAY", raising=False)
+        monkeypatch.setenv("XDG_SESSION_TYPE", "wayland")
+
+        with patch(
+            "shutil.which",
+            side_effect=lambda cmd: (
+                "/usr/bin/gnome-screenshot" if cmd == "gnome-screenshot" else None
+            ),
+        ):
+            from gptme.server.computer_api import _screenshot_available
+
+            assert _screenshot_available() is True
 
     def test_linux_with_display_and_scrot_returns_true(self, monkeypatch):
         if platform.system() != "Linux":

--- a/tests/test_computer_api.py
+++ b/tests/test_computer_api.py
@@ -381,21 +381,17 @@ class TestTakeScreenshot:
         transport.screenshot.assert_called_once_with()
         transport.close.assert_not_called()
 
-    def test_closes_native_fallback_transport(self, png_file):
+    def test_default_native_path_uses_screenshot_tool_directly(self, png_file):
         from gptme.server.computer_api import _take_screenshot
-
-        transport = Mock()
-        transport.screenshot.return_value = png_file
 
         with (
             patch("gptme.tools.computer_transport.get_transport", return_value=None),
             patch(
                 "gptme.tools.computer_transport.NativeComputerTransport",
-                return_value=transport,
-            ),
+            ) as native_transport,
+            patch("gptme.tools.screenshot.screenshot", return_value=png_file),
         ):
             path = _take_screenshot()
 
         assert path == png_file
-        transport.screenshot.assert_called_once_with()
-        transport.close.assert_called_once_with()
+        native_transport.assert_not_called()

--- a/tests/test_computer_api.py
+++ b/tests/test_computer_api.py
@@ -163,6 +163,19 @@ class TestComputerStatus:
         data = resp.get_json()
         assert data["display"] is None
 
+    def test_status_returns_json_when_availability_check_fails(self, client):
+        with patch(
+            "gptme.server.computer_api._screenshot_available",
+            side_effect=RuntimeError("cliclick not found"),
+        ):
+            resp = client.get("/api/v2/computer/status")
+
+        assert resp.status_code == 200
+        assert resp.content_type == "application/json"
+        data = resp.get_json()
+        assert data["screenshot_available"] is False
+        assert data["screenshot_error"] == "cliclick not found"
+
 
 # ---------------------------------------------------------------------------
 # /api/v2/computer/screenshot — 503 when no display
@@ -298,6 +311,18 @@ class TestComputerScreenshot500:
         assert resp.status_code == 500
         data = resp.get_json()
         assert "error" in data
+
+    def test_returns_json_500_when_availability_check_fails(self, client):
+        with patch(
+            "gptme.server.computer_api._screenshot_available",
+            side_effect=RuntimeError("cliclick not found"),
+        ):
+            resp = client.get("/api/v2/computer/screenshot")
+
+        assert resp.status_code == 500
+        assert resp.content_type == "application/json"
+        data = resp.get_json()
+        assert data["error"] == "cliclick not found"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds a lightweight screenshot-polling alternative to VNC streaming for the gptme web UI, closing the local computer-use observation gap for non-Docker setups.

**New server endpoints:**
- `GET /api/v2/computer/screenshot` — takes a screenshot via native transport (xdotool+scrot on Linux, screencapture on macOS) and returns it as a JPEG/PNG. Returns `503` with an actionable error hint when no display is available. Accepts `?quality=N` (1–95) for size tuning.
- `GET /api/v2/computer/status` — returns a JSON object listing which backends (xdotool, scrot, cliclick, pyatspi, playwright) are available on this machine.

**Updated `computer.html`:**
- Defaults to screenshot-polling mode instead of always pointing at the VNC iframe (which only works in the Docker setup)
- Users can switch to VNC mode in-page or via `?mode=vnc`
- VNC mode still works with `?mode=vnc&vncHost=...&vncPort=...`

## Why

The Docker/VNC stack (`Dockerfile.computer` + noVNC) is the right tool for fully sandboxed deployments. But running `gptme-server` locally — the common development workflow — left the `/computer` page showing a blank VNC iframe with no fallback. Now local users get live desktop screenshots at whatever polling rate they want (default 2 fps, configurable via `?fps=N`).

## Tests

15 new unit tests in `tests/test_computer_api.py` covering: status endpoint contract, 503 on no display, actionable error messages, 200 with image bytes, no-cache headers, quality param, 500 on transport failure, `_screenshot_available` helper.

All existing computer tests continue to pass (226 tests).

Closes part of #216

<!-- gptme-id:v1:gai_bkg6A97IPu248N60wktt1ZKvbUk8sRj34qyP2AMh3Ao -->