### PR TITLE
feat(computer): add ComputerPreview panel using screenshot polling API (#216)

### DIFF
--- a/.github/workflows/tauri.yml
+++ b/.github/workflows/tauri.yml
@@ -44,7 +44,10 @@ jobs:
 
       - name: Install Linux dependencies
         run: |
+          # GitHub's Ubuntu runner image can ship Microsoft-hosted apt sources that 403.
           sudo rm -f /etc/apt/sources.list.d/microsoft*.list /etc/apt/sources.list.d/azure-cli*.list
+          # Also clean from /etc/apt/sources.list when configured directly
+          sudo sed -i '\/packages\.microsoft\.com/d'\ /etc/apt/sources.list 2>/dev/null || true
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev \
             librsvg2-dev libjavascriptcoregtk-4.1-dev libsoup-3.0-dev patchelf
@@ -80,7 +83,10 @@ jobs:
 
       - name: Install Linux dependencies
         run: |
+          # GitHub's Ubuntu runner image can ship Microsoft-hosted apt sources that 403.
           sudo rm -f /etc/apt/sources.list.d/microsoft*.list /etc/apt/sources.list.d/azure-cli*.list
+          # Also clean from /etc/apt/sources.list when configured directly
+          sudo sed -i '\/packages\.microsoft\.com/d'\ /etc/apt/sources.list 2>/dev/null || true
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev \
             librsvg2-dev libjavascriptcoregtk-4.1-dev libsoup-3.0-dev patchelf
@@ -125,7 +131,10 @@ jobs:
 
       - name: Install Linux dependencies
         run: |
+          # GitHub's Ubuntu runner image can ship Microsoft-hosted apt sources that 403.
           sudo rm -f /etc/apt/sources.list.d/microsoft*.list /etc/apt/sources.list.d/azure-cli*.list
+          # Also clean from /etc/apt/sources.list when configured directly
+          sudo sed -i '\/packages\.microsoft\.com/d'\ /etc/apt/sources.list 2>/dev/null || true
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev \
             librsvg2-dev libjavascriptcoregtk-4.1-dev libsoup-3.0-dev patchelf \
@@ -285,7 +294,10 @@ jobs:
       - name: Install Linux dependencies
         if: matrix.platform == 'ubuntu-24.04'
         run: |
+          # GitHub's Ubuntu runner image can ship Microsoft-hosted apt sources that 403.
           sudo rm -f /etc/apt/sources.list.d/microsoft*.list /etc/apt/sources.list.d/azure-cli*.list
+          # Also clean from /etc/apt/sources.list when configured directly
+          sudo sed -i '\/packages\.microsoft\.com/d'\ /etc/apt/sources.list 2>/dev/null || true
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev \
             librsvg2-dev libjavascriptcoregtk-4.1-dev libsoup-3.0-dev patchelf
@@ -384,7 +396,10 @@ jobs:
       - name: Install system dependencies (Linux)
         if: runner.os == 'Linux'
         run: |
+          # GitHub's Ubuntu runner image can ship Microsoft-hosted apt sources that 403.
           sudo rm -f /etc/apt/sources.list.d/microsoft*.list /etc/apt/sources.list.d/azure-cli*.list
+          # Also clean from /etc/apt/sources.list when configured directly
+          sudo sed -i '\/packages\.microsoft\.com/d'\ /etc/apt/sources.list 2>/dev/null || true
           sudo apt-get update
           sudo apt-get install -y python3-dev build-essential libffi-dev
 
@@ -461,7 +476,10 @@ jobs:
       - name: Install Linux dependencies
         if: matrix.platform == 'ubuntu-24.04'
         run: |
+          # GitHub's Ubuntu runner image can ship Microsoft-hosted apt sources that 403.
           sudo rm -f /etc/apt/sources.list.d/microsoft*.list /etc/apt/sources.list.d/azure-cli*.list
+          # Also clean from /etc/apt/sources.list when configured directly
+          sudo sed -i '\/packages\.microsoft\.com/d'\ /etc/apt/sources.list 2>/dev/null || true
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev \
             librsvg2-dev libjavascriptcoregtk-4.1-dev libsoup-3.0-dev patchelf

--- a/.github/workflows/tauri.yml
+++ b/.github/workflows/tauri.yml
@@ -47,7 +47,7 @@ jobs:
           # GitHub's Ubuntu runner image can ship Microsoft-hosted apt sources that 403.
           sudo rm -f /etc/apt/sources.list.d/microsoft*.list /etc/apt/sources.list.d/azure-cli*.list
           # Also clean from /etc/apt/sources.list when configured directly
-          sudo sed -i '\/packages\.microsoft\.com/d'\ /etc/apt/sources.list 2>/dev/null || true
+          sudo sed -i '/packages\.microsoft\.com/d' /etc/apt/sources.list 2>/dev/null || true
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev \
             librsvg2-dev libjavascriptcoregtk-4.1-dev libsoup-3.0-dev patchelf
@@ -86,7 +86,7 @@ jobs:
           # GitHub's Ubuntu runner image can ship Microsoft-hosted apt sources that 403.
           sudo rm -f /etc/apt/sources.list.d/microsoft*.list /etc/apt/sources.list.d/azure-cli*.list
           # Also clean from /etc/apt/sources.list when configured directly
-          sudo sed -i '\/packages\.microsoft\.com/d'\ /etc/apt/sources.list 2>/dev/null || true
+          sudo sed -i '/packages\.microsoft\.com/d' /etc/apt/sources.list 2>/dev/null || true
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev \
             librsvg2-dev libjavascriptcoregtk-4.1-dev libsoup-3.0-dev patchelf
@@ -134,7 +134,7 @@ jobs:
           # GitHub's Ubuntu runner image can ship Microsoft-hosted apt sources that 403.
           sudo rm -f /etc/apt/sources.list.d/microsoft*.list /etc/apt/sources.list.d/azure-cli*.list
           # Also clean from /etc/apt/sources.list when configured directly
-          sudo sed -i '\/packages\.microsoft\.com/d'\ /etc/apt/sources.list 2>/dev/null || true
+          sudo sed -i '/packages\.microsoft\.com/d' /etc/apt/sources.list 2>/dev/null || true
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev \
             librsvg2-dev libjavascriptcoregtk-4.1-dev libsoup-3.0-dev patchelf \
@@ -297,7 +297,7 @@ jobs:
           # GitHub's Ubuntu runner image can ship Microsoft-hosted apt sources that 403.
           sudo rm -f /etc/apt/sources.list.d/microsoft*.list /etc/apt/sources.list.d/azure-cli*.list
           # Also clean from /etc/apt/sources.list when configured directly
-          sudo sed -i '\/packages\.microsoft\.com/d'\ /etc/apt/sources.list 2>/dev/null || true
+          sudo sed -i '/packages\.microsoft\.com/d' /etc/apt/sources.list 2>/dev/null || true
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev \
             librsvg2-dev libjavascriptcoregtk-4.1-dev libsoup-3.0-dev patchelf
@@ -399,7 +399,7 @@ jobs:
           # GitHub's Ubuntu runner image can ship Microsoft-hosted apt sources that 403.
           sudo rm -f /etc/apt/sources.list.d/microsoft*.list /etc/apt/sources.list.d/azure-cli*.list
           # Also clean from /etc/apt/sources.list when configured directly
-          sudo sed -i '\/packages\.microsoft\.com/d'\ /etc/apt/sources.list 2>/dev/null || true
+          sudo sed -i '/packages\.microsoft\.com/d' /etc/apt/sources.list 2>/dev/null || true
           sudo apt-get update
           sudo apt-get install -y python3-dev build-essential libffi-dev
 
@@ -479,7 +479,7 @@ jobs:
           # GitHub's Ubuntu runner image can ship Microsoft-hosted apt sources that 403.
           sudo rm -f /etc/apt/sources.list.d/microsoft*.list /etc/apt/sources.list.d/azure-cli*.list
           # Also clean from /etc/apt/sources.list when configured directly
-          sudo sed -i '\/packages\.microsoft\.com/d'\ /etc/apt/sources.list 2>/dev/null || true
+          sudo sed -i '/packages\.microsoft\.com/d' /etc/apt/sources.list 2>/dev/null || true
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev \
             librsvg2-dev libjavascriptcoregtk-4.1-dev libsoup-3.0-dev patchelf

--- a/.github/workflows/tauri.yml
+++ b/.github/workflows/tauri.yml
@@ -44,6 +44,7 @@ jobs:
 
       - name: Install Linux dependencies
         run: |
+          sudo rm -f /etc/apt/sources.list.d/microsoft*.list /etc/apt/sources.list.d/azure-cli*.list
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev \
             librsvg2-dev libjavascriptcoregtk-4.1-dev libsoup-3.0-dev patchelf
@@ -79,6 +80,7 @@ jobs:
 
       - name: Install Linux dependencies
         run: |
+          sudo rm -f /etc/apt/sources.list.d/microsoft*.list /etc/apt/sources.list.d/azure-cli*.list
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev \
             librsvg2-dev libjavascriptcoregtk-4.1-dev libsoup-3.0-dev patchelf
@@ -123,6 +125,7 @@ jobs:
 
       - name: Install Linux dependencies
         run: |
+          sudo rm -f /etc/apt/sources.list.d/microsoft*.list /etc/apt/sources.list.d/azure-cli*.list
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev \
             librsvg2-dev libjavascriptcoregtk-4.1-dev libsoup-3.0-dev patchelf \
@@ -282,6 +285,7 @@ jobs:
       - name: Install Linux dependencies
         if: matrix.platform == 'ubuntu-24.04'
         run: |
+          sudo rm -f /etc/apt/sources.list.d/microsoft*.list /etc/apt/sources.list.d/azure-cli*.list
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev \
             librsvg2-dev libjavascriptcoregtk-4.1-dev libsoup-3.0-dev patchelf
@@ -380,6 +384,7 @@ jobs:
       - name: Install system dependencies (Linux)
         if: runner.os == 'Linux'
         run: |
+          sudo rm -f /etc/apt/sources.list.d/microsoft*.list /etc/apt/sources.list.d/azure-cli*.list
           sudo apt-get update
           sudo apt-get install -y python3-dev build-essential libffi-dev
 
@@ -456,6 +461,7 @@ jobs:
       - name: Install Linux dependencies
         if: matrix.platform == 'ubuntu-24.04'
         run: |
+          sudo rm -f /etc/apt/sources.list.d/microsoft*.list /etc/apt/sources.list.d/azure-cli*.list
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev \
             librsvg2-dev libjavascriptcoregtk-4.1-dev libsoup-3.0-dev patchelf

--- a/webui/src/components/ComputerPreview.tsx
+++ b/webui/src/components/ComputerPreview.tsx
@@ -1,0 +1,254 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { RefreshCw, Monitor, Wifi, WifiOff, ExternalLink } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { useApi } from '@/contexts/ApiContext';
+import type { FC } from 'react';
+
+const VNC_URL = 'http://localhost:6080/vnc.html';
+const DEFAULT_POLL_INTERVAL_MS = 2000;
+
+interface BackendStatus {
+  screenshot_available: boolean;
+  system: string;
+  display: string | null;
+  backends: Record<string, boolean>;
+}
+
+/**
+ * Live computer desktop preview panel for issue #216.
+ *
+ * Polls /api/v2/computer/screenshot for a live screenshot of the desktop —
+ * a lightweight alternative to VNC that works without Docker/noVNC.
+ * Falls back to a VNC iframe link for Docker-based computer-use deployments.
+ */
+export const ComputerPreview: FC = () => {
+  const { api, connectionConfig } = useApi();
+  const baseUrl = connectionConfig.baseUrl.replace(/\/+$/, '');
+
+  const [screenshotSrc, setScreenshotSrc] = useState<string | null>(null);
+  const [status, setStatus] = useState<BackendStatus | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isPolling, setIsPolling] = useState(true);
+  const [isLoading, setIsLoading] = useState(true);
+  const [showVnc, setShowVnc] = useState(false);
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+  const pollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const prevSrcRef = useRef<string | null>(null);
+
+  const fetchStatus = useCallback(async () => {
+    const headers: Record<string, string> = {};
+    if (api.authHeader) headers.Authorization = api.authHeader;
+    try {
+      const resp = await fetch(`${baseUrl}/api/v2/computer/status`, { headers });
+      if (resp.ok) {
+        const data = await resp.json();
+        setStatus(data);
+      }
+    } catch {
+      // Status fetch failure is non-fatal
+    }
+  }, [baseUrl, api.authHeader]);
+
+  const fetchScreenshot = useCallback(async () => {
+    const headers: Record<string, string> = {};
+    if (api.authHeader) headers.Authorization = api.authHeader;
+    try {
+      const resp = await fetch(`${baseUrl}/api/v2/computer/screenshot?quality=75`, {
+        headers,
+        cache: 'no-store',
+      });
+
+      if (resp.status === 503) {
+        const data = await resp.json();
+        setError(data.error || 'Screenshot backend unavailable');
+        setIsLoading(false);
+        return;
+      }
+
+      if (!resp.ok) {
+        const data = await resp.json().catch(() => ({ error: `HTTP ${resp.status}` }));
+        setError(data.error || `HTTP ${resp.status}`);
+        setIsLoading(false);
+        return;
+      }
+
+      const blob = await resp.blob();
+      const url = URL.createObjectURL(blob);
+
+      // Revoke previous blob URL to prevent memory leak
+      if (prevSrcRef.current) {
+        URL.revokeObjectURL(prevSrcRef.current);
+      }
+      prevSrcRef.current = url;
+
+      setScreenshotSrc(url);
+      setError(null);
+      setIsLoading(false);
+      setLastUpdated(new Date());
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to fetch screenshot');
+      setIsLoading(false);
+    }
+  }, [baseUrl, api.authHeader]);
+
+  const schedulePoll = useCallback(() => {
+    if (pollTimerRef.current) {
+      clearTimeout(pollTimerRef.current);
+    }
+    if (isPolling) {
+      pollTimerRef.current = setTimeout(() => {
+        fetchScreenshot().then(schedulePoll);
+      }, DEFAULT_POLL_INTERVAL_MS);
+    }
+  }, [isPolling, fetchScreenshot]);
+
+  // Fetch status once on mount
+  useEffect(() => {
+    fetchStatus();
+  }, [fetchStatus]);
+
+  // Start polling when component mounts — intentionally run once only
+
+  useEffect(() => {
+    fetchScreenshot().then(schedulePoll);
+    return () => {
+      if (pollTimerRef.current) {
+        clearTimeout(pollTimerRef.current);
+      }
+      if (prevSrcRef.current) {
+        URL.revokeObjectURL(prevSrcRef.current);
+      }
+    };
+  }, []);
+
+  // Restart polling when isPolling changes
+  useEffect(() => {
+    if (isPolling) {
+      schedulePoll();
+    } else if (pollTimerRef.current) {
+      clearTimeout(pollTimerRef.current);
+    }
+  }, [isPolling, schedulePoll]);
+
+  const handleRefresh = () => {
+    setIsLoading(true);
+    fetchScreenshot().then(schedulePoll);
+  };
+
+  const togglePolling = () => setIsPolling((p) => !p);
+
+  if (showVnc) {
+    return (
+      <div className="flex h-full flex-col">
+        <div className="flex items-center gap-2 border-b p-2">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => setShowVnc(false)}
+            title="Back to screenshot view"
+          >
+            <Monitor className="h-4 w-4" />
+            <span className="ml-1 text-xs">Screenshot</span>
+          </Button>
+          <span className="text-xs text-muted-foreground">VNC mode (requires Docker)</span>
+        </div>
+        <iframe
+          src={VNC_URL}
+          className="h-full w-full rounded-md border-0"
+          allow="clipboard-read; clipboard-write"
+          title="VNC Viewer"
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full flex-col">
+      {/* Toolbar */}
+      <div className="flex items-center gap-1 border-b p-2">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={handleRefresh}
+          disabled={isLoading}
+          title="Refresh screenshot"
+        >
+          <RefreshCw className={`h-4 w-4 ${isLoading ? 'animate-spin' : ''}`} />
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={togglePolling}
+          title={isPolling ? 'Pause live view' : 'Resume live view'}
+        >
+          {isPolling ? (
+            <Wifi className="h-4 w-4 text-green-500" />
+          ) : (
+            <WifiOff className="h-4 w-4 text-muted-foreground" />
+          )}
+        </Button>
+        <div className="flex-1" />
+        {lastUpdated && (
+          <span className="text-xs text-muted-foreground">{lastUpdated.toLocaleTimeString()}</span>
+        )}
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => setShowVnc(true)}
+          title="Switch to VNC viewer (requires Docker computer-use service)"
+        >
+          <ExternalLink className="h-4 w-4" />
+          <span className="ml-1 text-xs">VNC</span>
+        </Button>
+      </div>
+
+      {/* Status bar */}
+      {status && (
+        <div className="flex flex-wrap gap-2 bg-muted/30 px-2 py-1 text-xs text-muted-foreground">
+          <span>{status.system}</span>
+          {status.display && <span>DISPLAY={status.display}</span>}
+          {Object.entries(status.backends)
+            .filter(([, available]) => available)
+            .map(([name]) => (
+              <span
+                key={name}
+                className="rounded bg-green-100 px-1 text-green-700 dark:bg-green-900/20 dark:text-green-400"
+              >
+                {name}
+              </span>
+            ))}
+        </div>
+      )}
+
+      {/* Main content */}
+      <div className="relative flex flex-1 items-center justify-center overflow-auto bg-black/5 p-2">
+        {error ? (
+          <div className="text-center text-sm">
+            <WifiOff className="mx-auto mb-2 h-8 w-8 text-muted-foreground" />
+            <p className="mb-2 text-muted-foreground">{error}</p>
+            <p className="mb-3 text-xs text-muted-foreground">
+              Start gptme-server on a machine with a desktop and{' '}
+              <code className="rounded bg-muted px-1">--tools +computer</code>
+            </p>
+            <Button variant="outline" size="sm" onClick={() => setShowVnc(true)}>
+              <ExternalLink className="mr-1 h-3 w-3" />
+              Try VNC viewer
+            </Button>
+          </div>
+        ) : isLoading ? (
+          <div className="text-center text-sm">
+            <Monitor className="mx-auto mb-2 h-8 w-8 animate-pulse text-muted-foreground" />
+            <p className="text-xs text-muted-foreground">Connecting to desktop…</p>
+          </div>
+        ) : screenshotSrc ? (
+          <img
+            src={screenshotSrc}
+            alt="Desktop screenshot"
+            className="max-h-full max-w-full rounded object-contain shadow-sm"
+            style={{ imageRendering: 'pixelated' }}
+          />
+        ) : null}
+      </div>
+    </div>
+  );
+};

--- a/webui/src/components/ComputerPreview.tsx
+++ b/webui/src/components/ComputerPreview.tsx
@@ -34,6 +34,15 @@ export const ComputerPreview: FC = () => {
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
   const pollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const prevSrcRef = useRef<string | null>(null);
+  // Ref so schedulePoll always reads the latest isPolling without stale-closure issues
+  const isPollingRef = useRef(true);
+  // AbortController for the in-flight screenshot fetch — cancelled on unmount
+  const abortControllerRef = useRef<AbortController | null>(null);
+
+  // Keep isPollingRef in sync so timer callbacks see current pause state
+  useEffect(() => {
+    isPollingRef.current = isPolling;
+  }, [isPolling]);
 
   const fetchStatus = useCallback(async () => {
     const headers: Record<string, string> = {};
@@ -50,12 +59,17 @@ export const ComputerPreview: FC = () => {
   }, [baseUrl, api.authHeader]);
 
   const fetchScreenshot = useCallback(async () => {
+    abortControllerRef.current?.abort();
+    const ac = new AbortController();
+    abortControllerRef.current = ac;
+
     const headers: Record<string, string> = {};
     if (api.authHeader) headers.Authorization = api.authHeader;
     try {
       const resp = await fetch(`${baseUrl}/api/v2/computer/screenshot?quality=75`, {
         headers,
         cache: 'no-store',
+        signal: ac.signal,
       });
 
       if (resp.status === 503) {
@@ -86,21 +100,25 @@ export const ComputerPreview: FC = () => {
       setIsLoading(false);
       setLastUpdated(new Date());
     } catch (err) {
+      if (err instanceof Error && err.name === 'AbortError') return;
       setError(err instanceof Error ? err.message : 'Failed to fetch screenshot');
       setIsLoading(false);
     }
   }, [baseUrl, api.authHeader]);
 
+  // Reads isPolling from the ref so recursive .then() chains always see the
+  // current pause state — avoids the stale-closure bug where clicking Pause
+  // while a fetch is in-flight leaves the loop running indefinitely.
   const schedulePoll = useCallback(() => {
     if (pollTimerRef.current) {
       clearTimeout(pollTimerRef.current);
     }
-    if (isPolling) {
+    if (isPollingRef.current) {
       pollTimerRef.current = setTimeout(() => {
         fetchScreenshot().then(schedulePoll);
       }, DEFAULT_POLL_INTERVAL_MS);
     }
-  }, [isPolling, fetchScreenshot]);
+  }, [fetchScreenshot]);
 
   // Fetch status once on mount
   useEffect(() => {
@@ -112,6 +130,7 @@ export const ComputerPreview: FC = () => {
   useEffect(() => {
     fetchScreenshot().then(schedulePoll);
     return () => {
+      abortControllerRef.current?.abort();
       if (pollTimerRef.current) {
         clearTimeout(pollTimerRef.current);
       }

--- a/webui/src/components/ComputerPreview.tsx
+++ b/webui/src/components/ComputerPreview.tsx
@@ -130,6 +130,7 @@ export const ComputerPreview: FC = () => {
   useEffect(() => {
     fetchScreenshot().then(schedulePoll);
     return () => {
+      isPollingRef.current = false;
       abortControllerRef.current?.abort();
       if (pollTimerRef.current) {
         clearTimeout(pollTimerRef.current);

--- a/webui/src/components/ComputerPreview.tsx
+++ b/webui/src/components/ComputerPreview.tsx
@@ -39,11 +39,6 @@ export const ComputerPreview: FC = () => {
   // AbortController for the in-flight screenshot fetch — cancelled on unmount
   const abortControllerRef = useRef<AbortController | null>(null);
 
-  // Keep isPollingRef in sync so timer callbacks see current pause state
-  useEffect(() => {
-    isPollingRef.current = isPolling;
-  }, [isPolling]);
-
   const fetchStatus = useCallback(async () => {
     const headers: Record<string, string> = {};
     if (api.authHeader) headers.Authorization = api.authHeader;
@@ -87,6 +82,10 @@ export const ComputerPreview: FC = () => {
       }
 
       const blob = await resp.blob();
+      // If the component unmounted while the blob was being read, bail out.
+      // The abort signal is set in the cleanup return; without this check the
+      // blob URL is created but never revoked (the cleanup already ran).
+      if (ac.signal.aborted) return;
       const url = URL.createObjectURL(blob);
 
       // Revoke previous blob URL to prevent memory leak
@@ -151,11 +150,30 @@ export const ComputerPreview: FC = () => {
   }, [isPolling, schedulePoll]);
 
   const handleRefresh = () => {
+    // Cancel any pending poll timer so it cannot abort this user-initiated fetch.
+    // Without this, a timer firing mid-refresh calls fetchScreenshot() which
+    // aborts the user's request; the AbortError path skips setIsLoading(false)
+    // so the spinner stays indefinitely until the next scheduled poll completes.
+    if (pollTimerRef.current) {
+      clearTimeout(pollTimerRef.current);
+      pollTimerRef.current = null;
+    }
     setIsLoading(true);
     fetchScreenshot().then(schedulePoll);
   };
 
-  const togglePolling = () => setIsPolling((p) => !p);
+  const togglePolling = () => {
+    // Update the ref immediately (not via a deferred useEffect) so that any
+    // schedulePoll call already in a .then() chain sees the new value before
+    // React flushes the state update and re-runs effects.
+    const next = !isPollingRef.current;
+    isPollingRef.current = next;
+    setIsPolling(next);
+    if (!next && pollTimerRef.current) {
+      clearTimeout(pollTimerRef.current);
+      pollTimerRef.current = null;
+    }
+  };
 
   if (showVnc) {
     return (

--- a/webui/src/components/__tests__/ComputerPreview.test.tsx
+++ b/webui/src/components/__tests__/ComputerPreview.test.tsx
@@ -16,12 +16,12 @@ beforeAll(() => {
   global.URL.revokeObjectURL = jest.fn();
 });
 
-function mockFetch(screenshotStatus: 200 | 503 = 200, backdendAvailable = true) {
+function mockFetch(screenshotStatus: 200 | 503 = 200, backendAvailable = true) {
   const statusPayload = {
-    screenshot_available: backdendAvailable,
+    screenshot_available: backendAvailable,
     system: 'Linux',
     display: ':1',
-    backends: backdendAvailable ? { xdotool: true, scrot: true } : {},
+    backends: backendAvailable ? { xdotool: true, scrot: true } : {},
   };
 
   global.fetch = jest.fn().mockImplementation((url: string) => {

--- a/webui/src/components/__tests__/ComputerPreview.test.tsx
+++ b/webui/src/components/__tests__/ComputerPreview.test.tsx
@@ -1,0 +1,112 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ComputerPreview } from '../ComputerPreview';
+
+// Mock useApi so we don't need the full ApiContext tree
+jest.mock('@/contexts/ApiContext', () => ({
+  useApi: () => ({
+    api: { authHeader: null },
+    connectionConfig: { baseUrl: 'http://127.0.0.1:5700' },
+  }),
+}));
+
+// jsdom doesn't implement URL.createObjectURL — stub it
+beforeAll(() => {
+  global.URL.createObjectURL = jest.fn(() => 'blob:mock-url');
+  global.URL.revokeObjectURL = jest.fn();
+});
+
+function mockFetch(screenshotStatus: 200 | 503 = 200, backdendAvailable = true) {
+  const statusPayload = {
+    screenshot_available: backdendAvailable,
+    system: 'Linux',
+    display: ':1',
+    backends: backdendAvailable ? { xdotool: true, scrot: true } : {},
+  };
+
+  global.fetch = jest.fn().mockImplementation((url: string) => {
+    if (url.includes('/status')) {
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(statusPayload),
+      });
+    }
+    if (screenshotStatus === 503) {
+      return Promise.resolve({
+        ok: false,
+        status: 503,
+        json: () => Promise.resolve({ error: 'Screenshot backend unavailable' }),
+      });
+    }
+    return Promise.resolve({
+      ok: true,
+      status: 200,
+      blob: () => Promise.resolve(new Blob(['png'], { type: 'image/png' })),
+    });
+  });
+}
+
+describe('ComputerPreview', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows loading state on mount', () => {
+    global.fetch = jest.fn().mockReturnValue(new Promise(() => {})); // never resolves
+    render(<ComputerPreview />);
+    expect(screen.getByText(/connecting to desktop/i)).toBeInTheDocument();
+  });
+
+  it('renders a screenshot image when the API returns 200', async () => {
+    mockFetch(200);
+    render(<ComputerPreview />);
+    await waitFor(() => {
+      expect(screen.getByRole('img', { name: /desktop screenshot/i })).toBeInTheDocument();
+    });
+  });
+
+  it('shows error message when API returns 503', async () => {
+    mockFetch(503, false);
+    render(<ComputerPreview />);
+    await waitFor(() => {
+      expect(screen.getByText(/screenshot backend unavailable/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows backend chips when status endpoint returns available backends', async () => {
+    mockFetch(200, true);
+    render(<ComputerPreview />);
+    await waitFor(() => {
+      expect(screen.getByText('xdotool')).toBeInTheDocument();
+      expect(screen.getByText('scrot')).toBeInTheDocument();
+    });
+  });
+
+  it('switches to VNC iframe when VNC button is clicked', async () => {
+    const user = userEvent.setup();
+    mockFetch(200);
+    render(<ComputerPreview />);
+
+    // The VNC button is always present in the toolbar
+    const vncButton = screen.getByTitle(/vnc viewer/i);
+    await user.click(vncButton);
+
+    expect(screen.getByTitle('VNC Viewer')).toBeInTheDocument();
+    expect(screen.getByTitle('VNC Viewer').tagName).toBe('IFRAME');
+  });
+
+  it('returns to screenshot view when back button is clicked in VNC mode', async () => {
+    const user = userEvent.setup();
+    mockFetch(200);
+    render(<ComputerPreview />);
+
+    await user.click(screen.getByTitle(/vnc viewer/i));
+    expect(screen.getByTitle('VNC Viewer').tagName).toBe('IFRAME');
+
+    await user.click(screen.getByTitle('Back to screenshot view'));
+    await waitFor(() => {
+      expect(screen.queryByTitle('VNC Viewer')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/webui/src/components/__tests__/RightSidebarContent.test.tsx
+++ b/webui/src/components/__tests__/RightSidebarContent.test.tsx
@@ -11,6 +11,10 @@ jest.mock('../BrowserPreview', () => ({
   BrowserPreview: () => <div data-testid="browser-panel">browser</div>,
 }));
 
+jest.mock('../ComputerPreview', () => ({
+  ComputerPreview: () => <div data-testid="computer-panel">computer</div>,
+}));
+
 jest.mock('../ArtifactsPanel', () => ({
   ArtifactsPanel: ({ conversationId }: { conversationId: string }) => (
     <div data-testid="artifacts-panel">{conversationId}</div>
@@ -30,9 +34,9 @@ describe('RightSidebarContent', () => {
     expect(screen.getByTestId('artifacts-panel')).toHaveTextContent('conv-art');
   });
 
-  it('renders the computer panel iframe', () => {
-    render(<RightSidebarContent conversationId="conv-vnc" activeTab="computer" />);
+  it('renders the computer panel', () => {
+    render(<RightSidebarContent conversationId="conv-computer" activeTab="computer" />);
 
-    expect(screen.getByTitle('VNC Viewer')).toBeInTheDocument();
+    expect(screen.getByTestId('computer-panel')).toBeInTheDocument();
   });
 });

--- a/webui/src/components/rightSidebarPanels.tsx
+++ b/webui/src/components/rightSidebarPanels.tsx
@@ -12,12 +12,11 @@ import type { LucideIcon } from 'lucide-react';
 import type { RightSidebarPanelId } from '@/types/sidebar';
 import { ArtifactsPanel } from './ArtifactsPanel';
 import { BrowserPreview } from './BrowserPreview';
+import { ComputerPreview } from './ComputerPreview';
 import { ConversationSettings } from './ConversationSettings';
 import { FunctionBrowserPanel } from './FunctionBrowserPanel';
 import { PanelsPanel } from './PanelsPanel';
 import { WorkspaceExplorer } from './workspace/WorkspaceExplorer';
-
-const VNC_URL = 'http://localhost:6080/vnc.html';
 
 interface RightSidebarPanelRenderProps {
   conversationId: string;
@@ -71,14 +70,7 @@ export const rightSidebarPanels: RightSidebarPanelDefinition[] = [
     id: 'computer',
     label: 'Computer',
     icon: Monitor,
-    render: () => (
-      <iframe
-        src={VNC_URL}
-        className="h-full w-full rounded-md border-0"
-        allow="clipboard-read; clipboard-write"
-        title="VNC Viewer"
-      />
-    ),
+    render: () => <ComputerPreview />,
   },
 ];
 


### PR DESCRIPTION
## Summary

The Computer sidebar panel previously hardcoded a VNC iframe pointing to `http://localhost:6080/vnc.html`, which only worked for Docker `computer-use` deployments. This PR replaces it with a `ComputerPreview` component that uses the screenshot polling API added in #3140.

- **Polls `/api/v2/computer/screenshot`** every 2s for a live desktop view — works on any machine running `gptme-server` with a display
- **Shows `/api/v2/computer/status` backend chips** (xdotool, scrot, playwright, etc.) so users know what's available
- **Pause/resume + manual refresh** controls in the toolbar with last-updated timestamp
- **VNC fallback button** switches to the noVNC iframe for Docker `computer-use` users
- **Graceful degradation** — shows an actionable error message with `--tools +computer` hint when no display is available

## Motivation

Issue #216 added the backend screenshot API (#3140) but didn't connect it to the web UI. Non-Docker users who run `gptme-server` locally on a machine with an X11 display could take screenshots via the API but had no way to see them in the chat interface. This closes that loop.

## Test plan

- [x] 6 new unit tests for `ComputerPreview` (loading, success, 503 error, backend chips, VNC toggle, back button)
- [x] Updated `RightSidebarContent` test to mock `ComputerPreview` instead of checking for VNC iframe
- [x] `tsc --noEmit` passes (no TypeScript errors)
- [x] ESLint passes (warnings are pre-existing in the codebase, not introduced here)
- [x] All 416 Python computer tests pass

Closes part of #216

<!-- gptme-id:v1:gai_utMHB4j8YM7aelr3XzjZpnxi72VQun0VHi7IcJFvWRN -->