### PR TITLE
fix(ci): harden docs deploy and PyInstaller apt setup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -172,8 +172,8 @@ jobs:
     - name: Install system dependencies (Ubuntu)
       if: runner.os == 'Linux'
       run: |
-        # GitHub's Ubuntu runner image can ship Microsoft apt sources that 403.
-        sudo rm -f /etc/apt/sources.list.d/microsoft*.list
+        # GitHub's Ubuntu runner image can ship Microsoft-hosted apt sources that 403.
+        sudo rm -f /etc/apt/sources.list.d/microsoft*.list /etc/apt/sources.list.d/azure-cli*.list
         sudo apt-get update
         sudo apt-get install -y python3-dev build-essential libffi-dev
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -66,6 +66,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build]
     if: github.ref == 'refs/heads/master'
+    concurrency:
+      group: docs-deploy-gh-pages
+      cancel-in-progress: false
     permissions:
       contents: write
 


### PR DESCRIPTION
## Summary
- serialize the Docs deploy job with a `docs-deploy-gh-pages` concurrency group
- keep docs builds parallel while preventing concurrent pushes to `gh-pages`
- remove both `microsoft*.list` and `azure-cli*.list` apt sources before the Ubuntu PyInstaller `apt-get update`

## Root cause
Run https://github.com/gptme/gptme/actions/runs/28897566163 failed after docs and site builds passed. The deploy job created its `gh-pages` commit, then `git push origin gh-pages` was rejected because another Docs deploy had updated the branch first. Two master Docs runs started one second apart, so this was a deploy race, not a docs build regression.

After opening this PR, the Ubuntu PyInstaller check failed before package install because GitHub's runner had a Microsoft-hosted `azure-cli` apt source returning an invalid clearsigned response. The workflow already removed `microsoft*.list`, but the failing source file is matched by `azure-cli*.list`, so the workaround missed it.

## Verification
- `git diff --check -- .github/workflows/docs.yml .github/workflows/build.yml`
- `uv run prek run --files .github/workflows/docs.yml .github/workflows/build.yml`
- reran the original failed master Docs run; attempt 2 passed
