### PR TITLE
feat(subagent): add context_window to subagent_batch, subagent_parallel, subagent_pipeline (#554)

### DIFF
--- a/gptme/tools/subagent/batch.py
+++ b/gptme/tools/subagent/batch.py
@@ -345,6 +345,7 @@ def subagent_batch(
     output_schema: type | None = None,
     workdir: str | Path | None = None,
     context_turns: int | None = None,
+    context_window: int | None = None,
     redact_secrets: bool = True,
 ) -> BatchJob:
     """Start multiple subagents in parallel and return a BatchJob to manage them.
@@ -376,6 +377,10 @@ def subagent_batch(
         context_turns: Number of recent parent conversation turns to forward to
             each subagent as context prefix. Pass ``None`` (default) to use no
             parent context.
+        context_window: Limit workspace context messages passed to each subagent.
+            Pass ``0`` for strongest isolation (subagent sees only agent identity
+            and tools, no workspace files). Pass ``None`` (default) for the full
+            inherited workspace context. Only applies to thread-mode subagents.
         redact_secrets: If True (default), redact secrets from workspace context
             passed to subagents. Pass False only if you need subagents to see
             config values that are incorrectly flagged as secrets.
@@ -416,6 +421,7 @@ def subagent_batch(
             output_schema=output_schema,
             workdir=workdir,
             context_turns=context_turns,
+            context_window=context_window,
             redact_secrets=redact_secrets,
         )
 
@@ -435,6 +441,7 @@ def subagent_parallel(
     output_schema: type | None = None,
     workdir: str | Path | None = None,
     context_turns: int | None = None,
+    context_window: int | None = None,
     redact_secrets: bool = True,
 ) -> list[dict]:
     """Fan out N subagents in parallel, wait for all, return results as an ordered list.
@@ -475,6 +482,10 @@ def subagent_parallel(
         context_turns: Number of recent parent conversation turns to forward to
             each subagent as context prefix. Pass ``None`` (default) to use no
             parent context.
+        context_window: Limit workspace context messages passed to each subagent.
+            Pass ``0`` for strongest isolation (subagent sees only agent identity
+            and tools, no workspace files). Pass ``None`` (default) for the full
+            inherited workspace context. Only applies to thread-mode subagents.
         redact_secrets: If True (default), scrub common secret patterns from
             workspace context before passing it to subagents.
 
@@ -537,6 +548,7 @@ def subagent_parallel(
                 output_schema=output_schema,
                 workdir=workdir,
                 context_turns=context_turns,
+                context_window=context_window,
                 redact_secrets=redact_secrets,
             )
             started_ids.append(agent_id)
@@ -582,6 +594,7 @@ def subagent_pipeline(
     output_schema: type | None = None,
     workdir: str | Path | None = None,
     context_turns: int | None = None,
+    context_window: int | None = None,
     redact_secrets: bool = True,
 ) -> list[list[dict]]:
     """Process items through multiple stages with no barrier between stages.
@@ -614,6 +627,10 @@ def subagent_pipeline(
             are automatically parsed.
         workdir: Working directory passed to every subagent.
         context_turns: Number of recent parent turns to forward to each subagent.
+        context_window: Limit workspace context messages passed to each subagent.
+            Pass ``0`` for strongest isolation (subagent sees only agent identity
+            and tools, no workspace files). Pass ``None`` (default) for the full
+            inherited workspace context. Only applies to thread-mode subagents.
         redact_secrets: If True (default), redact secrets from workspace context.
 
     Returns:
@@ -680,6 +697,7 @@ def subagent_pipeline(
                     output_schema=output_schema if is_final else None,
                     workdir=workdir,
                     context_turns=context_turns,
+                    context_window=context_window,
                     redact_secrets=redact_secrets,
                 )
                 result = subagent_wait(

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -4081,6 +4081,96 @@ class TestSubagentBatchNewParameters:
         for kw in captured:
             assert kw.get("context_turns") == 5
 
+    def test_context_window_forwarded_to_subagent_batch(self, monkeypatch):
+        """context_window is forwarded to each subagent() call from subagent_batch()."""
+        import gptme.tools.subagent.batch as batch_mod
+        from gptme.tools.subagent.batch import subagent_batch
+
+        captured: list[dict] = []
+
+        def mock_subagent(agent_id, prompt, **kwargs):
+            captured.append(kwargs)
+
+        monkeypatch.setattr(batch_mod, "subagent", mock_subagent)
+
+        subagent_batch([("w1", "p1"), ("w2", "p2")], context_window=0)
+
+        assert len(captured) == 2
+        for kw in captured:
+            assert kw.get("context_window") == 0
+
+    def test_context_window_forwarded_to_subagent_parallel(self, monkeypatch):
+        """context_window is forwarded to each subagent() call from subagent_parallel()."""
+        from unittest.mock import MagicMock
+
+        import gptme.tools.subagent.batch as batch_mod
+        from gptme.tools.subagent.batch import BatchJob, ReturnType, subagent_parallel
+
+        captured: list[dict] = []
+
+        def mock_subagent(agent_id, prompt, **kwargs):
+            captured.append(kwargs)
+
+        mock_job = MagicMock(spec=BatchJob)
+        mock_job.agent_ids = ["pw1", "pw2"]
+        mock_job.results = {
+            "pw1": ReturnType("success", "done"),
+            "pw2": ReturnType("success", "done"),
+        }
+        mock_job.wait_all.return_value = None
+
+        monkeypatch.setattr(batch_mod, "subagent", mock_subagent)
+        monkeypatch.setattr(batch_mod, "subagent_cancel", lambda aid: None)
+        monkeypatch.setattr(batch_mod, "BatchJob", lambda agent_ids, **kw: mock_job)
+
+        subagent_parallel([("pw1", "p1"), ("pw2", "p2")], context_window=0)
+
+        assert len(captured) == 2
+        for kw in captured:
+            assert kw.get("context_window") == 0
+
+    def test_context_window_forwarded_to_subagent_pipeline(self, monkeypatch):
+        """context_window is forwarded to each subagent() call from subagent_pipeline()."""
+        import gptme.tools.subagent.batch as batch_mod
+        from gptme.tools.subagent.batch import subagent_pipeline
+
+        captured: list[dict] = []
+
+        def mock_subagent(agent_id, prompt, **kwargs):
+            captured.append(kwargs)
+
+        def mock_wait(agent_id, **kwargs):
+            return {"status": "success", "result": "done"}
+
+        monkeypatch.setattr(batch_mod, "subagent", mock_subagent)
+        monkeypatch.setattr(batch_mod, "subagent_wait", mock_wait)
+
+        subagent_pipeline(
+            [("pp1", "prompt1")],
+            lambda item, _: item,
+            context_window=0,
+        )
+
+        assert len(captured) == 1
+        assert captured[0].get("context_window") == 0
+
+    def test_context_window_none_by_default_in_batch(self, monkeypatch):
+        """context_window defaults to None in subagent_batch() (full workspace context)."""
+        import gptme.tools.subagent.batch as batch_mod
+        from gptme.tools.subagent.batch import subagent_batch
+
+        captured: list[dict] = []
+
+        def mock_subagent(agent_id, prompt, **kwargs):
+            captured.append(kwargs)
+
+        monkeypatch.setattr(batch_mod, "subagent", mock_subagent)
+
+        subagent_batch([("d1", "p1")])
+
+        assert len(captured) == 1
+        assert captured[0].get("context_window") is None
+
 
 # ---------------------------------------------------------------------------
 # Token budget tracking tests

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -4169,7 +4169,8 @@ class TestSubagentBatchNewParameters:
         subagent_batch([("d1", "p1")])
 
         assert len(captured) == 1
-        assert captured[0].get("context_window") is None
+        assert "context_window" in captured[0]
+        assert captured[0]["context_window"] is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

\`context_window\` was available on the low-level \`subagent()\` call but missing from the convenience fan-out helpers. This meant you couldn't do context-isolated parallel fan-outs without manually dispatching N individual \`subagent()\` calls.

This PR adds \`context_window: int | None = None\` to:
- \`subagent_batch()\`
- \`subagent_parallel()\`
- \`subagent_pipeline()\`

The parameter is threaded through to the internal \`subagent()\` dispatch in each function, and all three docstrings are updated. Strongest isolation (\`context_window=0\`) now works cleanly with fan-out patterns:

\`\`\`python
# Context-isolated fan-out: each verifier only sees what you pass in the prompt
results = subagent_parallel([
    ("verifier-1", "Does this output contain SQL injection? Output: ..."),
    ("verifier-2", "Does this output leak secrets? Output: ..."),
], context_window=0)
\`\`\`

## Changes
- \`gptme/tools/subagent/batch.py\`: add \`context_window\` param to all three helpers + pass through to \`subagent()\`
- \`tests/test_subagent_unit.py\`: 4 new unit tests verifying the parameter is forwarded from each helper

## Tests
4 new unit tests added. All 292 subagent tests pass.

Closes (partially) #554