### PR TITLE
fix(webui): show --cors-origin command in setup wizard for web users

### DIFF
--- a/webui/src/components/SetupWizard.tsx
+++ b/webui/src/components/SetupWizard.tsx
@@ -375,10 +375,16 @@ export function SetupWizard() {
   };
 
   const serverCommand = `gptme-server --cors-origin='${window.location.origin}'`;
-  const copyServerCommand = () => {
-    void navigator.clipboard.writeText(serverCommand).then(() => {
-      toast.success('Command copied to clipboard');
-    });
+  const pipxRunCommand = `pipx run --spec 'gptme[server]' ${serverCommand}`;
+  const copyServerCommand = (command: string) => {
+    void navigator.clipboard.writeText(command).then(
+      () => {
+        toast.success('Command copied to clipboard');
+      },
+      () => {
+        toast.error('Failed to copy command. Please copy it manually.');
+      }
+    );
   };
 
   const handleLocalSetup = async () => {
@@ -665,11 +671,27 @@ export function SetupWizard() {
                   <p className="text-sm text-muted-foreground">
                     Start the server in your terminal:
                   </p>
+                  <p className="text-xs text-muted-foreground">Already have gptme installed:</p>
                   <div className="flex items-center gap-2 rounded bg-muted px-3 py-2">
                     <code className="flex-1 break-all font-mono text-sm">{serverCommand}</code>
                     <button
-                      onClick={copyServerCommand}
+                      onClick={() => copyServerCommand(serverCommand)}
                       className="shrink-0 rounded p-1 hover:bg-muted-foreground/10"
+                      aria-label="Copy installed server command"
+                      title="Copy command"
+                    >
+                      <Copy className="h-3.5 w-3.5 text-muted-foreground" />
+                    </button>
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    First time? Install and start it with one command:
+                  </p>
+                  <div className="flex items-center gap-2 rounded bg-muted px-3 py-2">
+                    <code className="flex-1 break-all font-mono text-sm">{pipxRunCommand}</code>
+                    <button
+                      onClick={() => copyServerCommand(pipxRunCommand)}
+                      className="shrink-0 rounded p-1 hover:bg-muted-foreground/10"
+                      aria-label="Copy pipx run server command"
                       title="Copy command"
                     >
                       <Copy className="h-3.5 w-3.5 text-muted-foreground" />
@@ -677,10 +699,7 @@ export function SetupWizard() {
                   </div>
                   <p className="text-xs text-muted-foreground">
                     The <code className="rounded bg-muted px-1">--cors-origin</code> flag lets this
-                    page connect to your local server. Or install gptme first:{' '}
-                    <code className="rounded bg-muted px-1">
-                      pipx install &apos;gptme[server]&apos;
-                    </code>
+                    page connect to your local server.
                   </p>
                 </div>
               )}

--- a/webui/src/components/SetupWizard.tsx
+++ b/webui/src/components/SetupWizard.tsx
@@ -27,7 +27,8 @@ import {
   type SetupWizardStep,
 } from '@/stores/setupWizard';
 import { use$ } from '@legendapp/state/react';
-import { Monitor, Cloud, ArrowRight, Check, Terminal, ExternalLink } from 'lucide-react';
+import { Monitor, Cloud, ArrowRight, Check, Terminal, ExternalLink, Copy } from 'lucide-react';
+import { toast } from 'sonner';
 
 type SetupStep = SetupWizardStep;
 type SetupModelInfo = {
@@ -373,6 +374,13 @@ export function SetupWizard() {
     setIsOpen(false);
   };
 
+  const serverCommand = `gptme-server --cors-origin='${window.location.origin}'`;
+  const copyServerCommand = () => {
+    void navigator.clipboard.writeText(serverCommand).then(() => {
+      toast.success('Command copied to clipboard');
+    });
+  };
+
   const handleLocalSetup = async () => {
     if (isConnected) {
       // Already connected — check provider config and advance.
@@ -657,12 +665,22 @@ export function SetupWizard() {
                   <p className="text-sm text-muted-foreground">
                     Start the server in your terminal:
                   </p>
-                  <code className="rounded bg-muted px-3 py-2 font-mono text-sm">
-                    pipx run --spec &apos;gptme[server]&apos; gptme-server
-                  </code>
+                  <div className="flex items-center gap-2 rounded bg-muted px-3 py-2">
+                    <code className="flex-1 break-all font-mono text-sm">{serverCommand}</code>
+                    <button
+                      onClick={copyServerCommand}
+                      className="shrink-0 rounded p-1 hover:bg-muted-foreground/10"
+                      title="Copy command"
+                    >
+                      <Copy className="h-3.5 w-3.5 text-muted-foreground" />
+                    </button>
+                  </div>
                   <p className="text-xs text-muted-foreground">
-                    Or if you have gptme installed:{' '}
-                    <code className="rounded bg-muted px-1">gptme-server</code>
+                    The <code className="rounded bg-muted px-1">--cors-origin</code> flag lets this
+                    page connect to your local server. Or install gptme first:{' '}
+                    <code className="rounded bg-muted px-1">
+                      pipx install &apos;gptme[server]&apos;
+                    </code>
                   </p>
                 </div>
               )}

--- a/webui/src/components/__tests__/SetupWizard.test.tsx
+++ b/webui/src/components/__tests__/SetupWizard.test.tsx
@@ -4,6 +4,7 @@ import { observable } from '@legendapp/state';
 import { SetupWizard } from '../SetupWizard';
 import { SettingsProvider } from '@/contexts/SettingsContext';
 import { setupWizard$ } from '@/stores/setupWizard';
+import { toast } from 'sonner';
 
 const mockConnect = jest.fn();
 const mockOpen = jest.fn();
@@ -184,6 +185,14 @@ describe('SetupWizard', () => {
       writable: true,
       value: mockOpen,
     });
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText: jest.fn().mockResolvedValue(undefined),
+      },
+    });
+    (toast.success as jest.Mock).mockClear();
+    (toast.error as jest.Mock).mockClear();
   });
 
   it('stays closed in demo mode even for first-time users', () => {
@@ -431,6 +440,59 @@ describe('SetupWizard', () => {
     });
     expect(setupWizard$.providerStatusVersion.get()).toBe(1);
     expect(screen.getByRole('heading', { name: /you're all set/i })).toBeInTheDocument();
+  });
+
+  it('shows copyable local server commands for installed and first-time users', async () => {
+    const writeText = jest.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+    const serverCommand = `gptme-server --cors-origin='${window.location.origin}'`;
+    const pipxRunCommand = `pipx run --spec 'gptme[server]' ${serverCommand}`;
+
+    render(
+      <SettingsProvider>
+        <SetupWizard />
+      </SettingsProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /get started/i }));
+    fireEvent.click(screen.getByRole('button', { name: /monitor local/i }));
+
+    expect(screen.getByText(serverCommand)).toBeInTheDocument();
+    expect(screen.getByText(pipxRunCommand)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /copy pipx run server command/i }));
+
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith(pipxRunCommand);
+    });
+    expect(toast.success).toHaveBeenCalledWith('Command copied to clipboard');
+  });
+
+  it('shows an error toast when copying the local server command fails', async () => {
+    const writeText = jest.fn().mockRejectedValue(new Error('clipboard denied'));
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+    const serverCommand = `gptme-server --cors-origin='${window.location.origin}'`;
+
+    render(
+      <SettingsProvider>
+        <SetupWizard />
+      </SettingsProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /get started/i }));
+    fireEvent.click(screen.getByRole('button', { name: /monitor local/i }));
+    fireEvent.click(screen.getByRole('button', { name: /copy installed server command/i }));
+
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith(serverCommand);
+      expect(toast.error).toHaveBeenCalledWith('Failed to copy command. Please copy it manually.');
+    });
   });
 
   it('shows desktop API key entry when the local server lacks a provider', async () => {

--- a/webui/src/components/__tests__/SetupWizard.test.tsx
+++ b/webui/src/components/__tests__/SetupWizard.test.tsx
@@ -140,6 +140,11 @@ jest.mock('lucide-react', () => ({
   Check: () => <span>Check</span>,
   Terminal: () => <span>Terminal</span>,
   ExternalLink: () => <span>ExternalLink</span>,
+  Copy: () => <span>Copy</span>,
+}));
+
+jest.mock('sonner', () => ({
+  toast: { success: jest.fn(), error: jest.fn() },
 }));
 
 describe('SetupWizard', () => {


### PR DESCRIPTION
## Problem

When users visit `chat.gptme.org` (or any HTTPS-hosted gptme webui) and try to connect to their local `gptme-server` at `http://127.0.0.1:5700`, Chrome blocks the request via its [Private Network Access (PNA)](https://developer.chrome.com/blog/private-network-access-update) policy. The server must respond to CORS preflight requests with `Access-Control-Allow-Private-Network: true`.

`gptme-server` already supports this via `--cors-origin=<origin>` — when a named origin is given, the server includes the right PNA header. But the Setup Wizard was showing just `gptme-server` with no flags, leaving users with silent connection failures and no hint of what went wrong.

## Fix

Show `gptme-server --cors-origin='<current-origin>'` in the setup wizard's local mode step. The origin is taken from `window.location.origin` so it's always correct for the host the user is visiting. Added a copy button and a one-liner explaining why the flag is needed.

## Before / After

**Before:**
```
Start the server in your terminal:
pipx run --spec 'gptme[server]' gptme-server
Or if you have gptme installed: gptme-server
```

**After:**
```
Start the server in your terminal:
[gptme-server --cors-origin='https://chat.gptme.org'] [📋]
The --cors-origin flag lets this page connect to your local server.
Or install gptme first: pipx install 'gptme[server]'
```

Found during a live dogfood session of `chat.gptme.org`.