### PR TITLE
feat(rag): add project-scoped indexes

### DIFF
--- a/gptme/tools/rag.py
+++ b/gptme/tools/rag.py
@@ -66,7 +66,9 @@ def _sanitize_project_name(name: str) -> str:
     sanitized = re.sub(r"[/\\\s]+", "_", name)
     # Remove any remaining non-alphanumeric/underscore/hyphen/dot characters
     sanitized = re.sub(r"[^\w\-.]", "_", sanitized)
-    return sanitized.strip("_") or "default"
+    # Strip leading/trailing underscores and dots; bare dots (".", "..") are
+    # path-traversal hazards that must not survive as the final component.
+    return sanitized.strip("_.") or "default"
 
 
 def _project_persist_dir(project: str | None) -> Path | None:
@@ -238,10 +240,9 @@ def rag_status(project: str | None = None) -> str:
     if persist_dir is not None:
         # gptme-rag status does not support --persist-dir, so we report directory info
         if persist_dir.exists():
-            file_count = sum(1 for f in persist_dir.rglob("*") if f.is_file())
-            size_bytes = sum(
-                f.stat().st_size for f in persist_dir.rglob("*") if f.is_file()
-            )
+            files = [f for f in persist_dir.rglob("*") if f.is_file()]
+            file_count = len(files)
+            size_bytes = sum(f.stat().st_size for f in files)
             size_kb = size_bytes / 1024
             return (
                 f"Project index '{project}' at {persist_dir}\n"

--- a/gptme/tools/rag.py
+++ b/gptme/tools/rag.py
@@ -42,6 +42,7 @@ Configure RAG in your ``gptme.toml``::
 """
 
 import logging
+import re
 import shutil
 import subprocess
 import tempfile
@@ -51,12 +52,29 @@ from functools import lru_cache
 from pathlib import Path
 
 from ..config import RagConfig, get_project_config
-from ..dirs import get_logs_dir, get_project_gptme_dir
+from ..dirs import get_data_dir, get_logs_dir, get_project_gptme_dir
 from ..llm import _chat_complete
 from ..message import Message
 from .base import ToolFunction, ToolSpec, ToolUse
 
 logger = logging.getLogger(__name__)
+
+
+def _sanitize_project_name(name: str) -> str:
+    """Sanitize a project name for use as a filesystem path component."""
+    # Replace path separators and whitespace with underscores
+    sanitized = re.sub(r"[/\\\s]+", "_", name)
+    # Remove any remaining non-alphanumeric/underscore/hyphen/dot characters
+    sanitized = re.sub(r"[^\w\-.]", "_", sanitized)
+    return sanitized.strip("_") or "default"
+
+
+def _project_persist_dir(project: str | None) -> Path | None:
+    """Return the persist directory for a project, or None to use the global index."""
+    if not project:
+        return None
+    return get_data_dir() / "rag" / _sanitize_project_name(project)
+
 
 instructions = """
 ### When to use RAG
@@ -156,33 +174,83 @@ def _run_rag_cmd(cmd: list[str]) -> subprocess.CompletedProcess:
         )
 
 
-def rag_index(*paths: str, glob: str | None = None) -> str:
-    """Index documents in specified paths."""
+def rag_index(*paths: str, glob: str | None = None, project: str | None = None) -> str:
+    """Index documents in specified paths.
+
+    Args:
+        paths: Paths to index (files or directories). Defaults to current directory.
+        glob: Glob pattern to filter files.
+        project: Project name to scope the index to. When set, documents are stored
+            in a project-specific index isolated from all other projects and the
+            global index. When omitted, uses the global index.
+    """
     paths = paths or (".",)
     cmd = ["gptme-rag", "index"]
     cmd.extend(paths)
     if glob:
         cmd.extend(["--glob", glob])
+    persist_dir = _project_persist_dir(project)
+    if persist_dir is not None:
+        cmd.extend(["--persist-dir", str(persist_dir)])
 
     result = _run_rag_cmd(cmd)
     return result.stdout.strip()
 
 
-def rag_search(query: str, return_full: bool = False, top_k: int | None = None) -> str:
-    """Search indexed documents."""
+def rag_search(
+    query: str,
+    return_full: bool = False,
+    top_k: int | None = None,
+    project: str | None = None,
+) -> str:
+    """Search indexed documents.
+
+    Args:
+        query: Search query.
+        return_full: Return full document content instead of excerpts.
+        top_k: Maximum number of results to return.
+        project: Project name to restrict the search to. Must match the project
+            used when indexing. When omitted, searches the global index.
+    """
     cmd = ["gptme-rag", "search", query]
     if return_full:
         # shows full context of the search results
         cmd.extend(["--raw"])
     if top_k is not None:
         cmd.extend(["--top-k", str(top_k)])
+    persist_dir = _project_persist_dir(project)
+    if persist_dir is not None:
+        cmd.extend(["--persist-dir", str(persist_dir)])
 
     result = _run_rag_cmd(cmd)
     return result.stdout.strip()
 
 
-def rag_status() -> str:
-    """Show index status."""
+def rag_status(project: str | None = None) -> str:
+    """Show index status.
+
+    Args:
+        project: Project name to show status for. When set, shows information
+            about the project-specific index directory. When omitted, shows the
+            global index status.
+    """
+    persist_dir = _project_persist_dir(project)
+    if persist_dir is not None:
+        # gptme-rag status does not support --persist-dir, so we report directory info
+        if persist_dir.exists():
+            file_count = sum(1 for f in persist_dir.rglob("*") if f.is_file())
+            size_bytes = sum(
+                f.stat().st_size for f in persist_dir.rglob("*") if f.is_file()
+            )
+            size_kb = size_bytes / 1024
+            return (
+                f"Project index '{project}' at {persist_dir}\n"
+                f"Storage files: {file_count} ({size_kb:.1f} KB)"
+            )
+        return (
+            f"Project index '{project}' not found at {persist_dir}\n"
+            f"Run rag_index(project='{project}') to create it."
+        )
     cmd = ["gptme-rag", "status"]
     result = _run_rag_cmd(cmd)
     return result.stdout.strip()

--- a/tests/test_tools_rag.py
+++ b/tests/test_tools_rag.py
@@ -9,7 +9,16 @@ import pytest
 
 from gptme.config import RagConfig
 from gptme.message import Message
-from gptme.tools.rag import _has_gptme_rag, _rag_context_hook, rag_index_conversations
+from gptme.tools.rag import (
+    _has_gptme_rag,
+    _project_persist_dir,
+    _rag_context_hook,
+    _sanitize_project_name,
+    rag_index,
+    rag_index_conversations,
+    rag_search,
+    rag_status,
+)
 
 
 @pytest.mark.skipif(not _has_gptme_rag(), reason="RAG is not available")
@@ -241,3 +250,164 @@ def test_rag_index_conversations_uses_tmpdir_by_default(tmp_path):
     assert "Indexed 1 conversations" in result
     # The temp dir path should have been passed to gptme-rag index
     assert "gptme-rag-convs-" in captured_cmd[-1]
+
+
+# --- Project-specific index tests ---
+
+
+def test_sanitize_project_name_basic():
+    assert _sanitize_project_name("myproject") == "myproject"
+
+
+def test_sanitize_project_name_slashes():
+    assert _sanitize_project_name("org/repo") == "org_repo"
+
+
+def test_sanitize_project_name_spaces():
+    assert _sanitize_project_name("my project") == "my_project"
+
+
+def test_sanitize_project_name_special_chars():
+    result = _sanitize_project_name("proj!@#$")
+    assert "/" not in result
+    assert " " not in result
+    assert len(result) > 0
+
+
+def test_project_persist_dir_none():
+    assert _project_persist_dir(None) is None
+
+
+def test_project_persist_dir_empty_string():
+    assert _project_persist_dir("") is None
+
+
+def test_project_persist_dir_returns_path(tmp_path):
+    with patch("gptme.tools.rag.get_data_dir", return_value=tmp_path):
+        d = _project_persist_dir("myproject")
+    assert d is not None
+    assert d == tmp_path / "rag" / "myproject"
+
+
+def test_project_persist_dir_sanitizes_name(tmp_path):
+    with patch("gptme.tools.rag.get_data_dir", return_value=tmp_path):
+        d = _project_persist_dir("org/repo")
+    assert d is not None
+    # slash replaced with underscore
+    assert d.name == "org_repo"
+
+
+def test_rag_index_no_project_no_persist_dir():
+    """Without project, no --persist-dir is passed to the CLI."""
+    mock_proc = MagicMock()
+    mock_proc.stdout = "Indexed 1 paths\n"
+    with patch("gptme.tools.rag._run_rag_cmd", return_value=mock_proc) as mock_run:
+        rag_index(".")
+    cmd = mock_run.call_args[0][0]
+    assert "--persist-dir" not in cmd
+
+
+def test_rag_index_with_project_passes_persist_dir(tmp_path):
+    """With project set, --persist-dir is appended pointing to the project dir."""
+    mock_proc = MagicMock()
+    mock_proc.stdout = "Indexed 1 paths\n"
+    with (
+        patch("gptme.tools.rag.get_data_dir", return_value=tmp_path),
+        patch("gptme.tools.rag._run_rag_cmd", return_value=mock_proc) as mock_run,
+    ):
+        rag_index(".", project="myproject")
+    cmd = mock_run.call_args[0][0]
+    assert "--persist-dir" in cmd
+    persist_dir_idx = cmd.index("--persist-dir")
+    assert cmd[persist_dir_idx + 1] == str(tmp_path / "rag" / "myproject")
+
+
+def test_rag_search_no_project_no_persist_dir():
+    """Without project, no --persist-dir is passed."""
+    mock_proc = MagicMock()
+    mock_proc.stdout = "results\n"
+    with patch("gptme.tools.rag._run_rag_cmd", return_value=mock_proc) as mock_run:
+        rag_search("query")
+    cmd = mock_run.call_args[0][0]
+    assert "--persist-dir" not in cmd
+
+
+def test_rag_search_with_project_passes_persist_dir(tmp_path):
+    """With project set, search is scoped to the project-specific persist dir."""
+    mock_proc = MagicMock()
+    mock_proc.stdout = "results\n"
+    with (
+        patch("gptme.tools.rag.get_data_dir", return_value=tmp_path),
+        patch("gptme.tools.rag._run_rag_cmd", return_value=mock_proc) as mock_run,
+    ):
+        rag_search("query", project="myproject")
+    cmd = mock_run.call_args[0][0]
+    assert "--persist-dir" in cmd
+    persist_dir_idx = cmd.index("--persist-dir")
+    assert cmd[persist_dir_idx + 1] == str(tmp_path / "rag" / "myproject")
+
+
+def test_rag_status_no_project_calls_cli():
+    """Without project, delegates to gptme-rag status CLI."""
+    mock_proc = MagicMock()
+    mock_proc.stdout = "Index contains 42 documents\n"
+    with patch("gptme.tools.rag._run_rag_cmd", return_value=mock_proc) as mock_run:
+        result = rag_status()
+    assert "42 documents" in result
+    cmd = mock_run.call_args[0][0]
+    assert cmd == ["gptme-rag", "status"]
+
+
+def test_rag_status_with_project_not_found(tmp_path):
+    """project status reports missing index cleanly when dir doesn't exist."""
+    with patch("gptme.tools.rag.get_data_dir", return_value=tmp_path):
+        result = rag_status(project="myproject")
+    assert "not found" in result
+    assert "myproject" in result
+
+
+def test_rag_status_with_project_found(tmp_path):
+    """project status reports directory info when the index dir exists."""
+    project_dir = tmp_path / "rag" / "myproject"
+    project_dir.mkdir(parents=True)
+    (project_dir / "chroma.sqlite3").write_bytes(b"x" * 1024)
+
+    with patch("gptme.tools.rag.get_data_dir", return_value=tmp_path):
+        result = rag_status(project="myproject")
+
+    assert "myproject" in result
+    assert str(project_dir) in result
+
+
+def test_project_isolation(tmp_path):
+    """Index in project A must not appear when searching project B."""
+    calls = []
+
+    def fake_run_rag_cmd(cmd):
+        calls.append(cmd[:])
+        proc = MagicMock()
+        proc.stdout = "results\n"
+        return proc
+
+    with (
+        patch("gptme.tools.rag.get_data_dir", return_value=tmp_path),
+        patch("gptme.tools.rag._run_rag_cmd", side_effect=fake_run_rag_cmd),
+    ):
+        rag_index(".", project="projectA")
+        rag_search("query", project="projectB")
+
+        index_cmd, search_cmd = calls
+        # Both commands use --persist-dir
+        assert "--persist-dir" in index_cmd
+        assert "--persist-dir" in search_cmd
+
+        # The persist dirs must differ between project A and project B
+        idx_persist = index_cmd[index_cmd.index("--persist-dir") + 1]
+        search_persist = search_cmd[search_cmd.index("--persist-dir") + 1]
+        assert idx_persist != search_persist
+
+        # Global search (no project) must not pass --persist-dir at all
+        calls.clear()
+        rag_search("query")
+        global_cmd = calls[0]
+        assert "--persist-dir" not in global_cmd

--- a/tests/test_tools_rag.py
+++ b/tests/test_tools_rag.py
@@ -274,6 +274,26 @@ def test_sanitize_project_name_special_chars():
     assert len(result) > 0
 
 
+def test_sanitize_project_name_dot_traversal():
+    # "." and ".." must not survive as the sanitized name (path-traversal hazard)
+    assert _sanitize_project_name(".") == "default"
+    assert _sanitize_project_name("..") == "default"
+    # Internal dots in valid names must be preserved
+    assert _sanitize_project_name("v1.2.3") == "v1.2.3"
+    assert _sanitize_project_name("my.project") == "my.project"
+
+
+def test_project_persist_dir_dot_traversal(tmp_path):
+    with patch("gptme.tools.rag.get_data_dir", return_value=tmp_path):
+        d_dot = _project_persist_dir(".")
+        d_dotdot = _project_persist_dir("..")
+    assert d_dot is not None
+    # Must stay under rag/ — not resolve to rag/../ or rag/ root itself
+    assert d_dot.name == "default"
+    assert d_dotdot is not None
+    assert d_dotdot.name == "default"
+
+
 def test_project_persist_dir_none():
     assert _project_persist_dir(None) is None
 


### PR DESCRIPTION
## Summary

- Add a `project` parameter to `rag_index`, `rag_search`, and `rag_status` that isolates each project's RAG index to its own directory under `XDG_DATA_HOME/gptme/rag/{project}/`
- When `project` is set, `--persist-dir` is passed to `gptme-rag` so indexed documents never pollute searches in other projects or the global index
- Fully backward compatible: when `project` is omitted, behaviour is identical to before
- Project names with slashes, spaces, or special characters are sanitized to a filesystem-safe form

## Problem solved

Before this change, `rag_index` and `rag_search` used a single global index. Indexing docs for one project would pollute search results in every other project, making RAG unreliable in multi-repo workflows.

## Implementation notes

- `rag_index` and `rag_search` pass `--persist-dir <path>` to the CLI (supported by gptme-rag)
- `rag_status` uses directory introspection for project-scoped status (the CLI's `status` subcommand doesn't support `--persist-dir`)
- 17 new tests covering sanitization, persist-dir routing, backward compat, and isolation invariant

## Test plan

- [ ] `uv run pytest tests/test_tools_rag.py -q` — all tests pass
- [ ] `mypy gptme/tools/rag.py` — clean
- [ ] Verify `rag_index(project="A")` + `rag_search("query")` does NOT return project A docs (isolation)