### PR TITLE
fix(config): cast providers to AoT to fix tomlkit type errors

### DIFF
--- a/gptme/config/user.py
+++ b/gptme/config/user.py
@@ -17,6 +17,7 @@ from tomlkit import TOMLDocument
 
 if TYPE_CHECKING:
     from tomlkit.container import Container
+    from tomlkit.items import AoT
 
 from ..util import path_with_tilde
 from .models import (
@@ -429,8 +430,8 @@ def save_provider_config(
     if "providers" not in doc:
         doc.add("providers", tomlkit.aot())  # type: ignore[attr-defined]
 
-    providers = doc["providers"]
-    for idx, existing_provider in enumerate(providers):  # type: ignore[union-attr]
+    providers: AoT = doc["providers"]  # type: ignore[assignment]
+    for idx, existing_provider in enumerate(providers):
         if existing_provider.get("name") == provider.name:
             providers[idx] = provider_table
             break


### PR DESCRIPTION
## Summary

- `doc["providers"]` returns `Item | Container` but is always `AoT` after the `tomlkit.aot()` init above it
- Annotating `providers` as `AoT` (under `TYPE_CHECKING`) resolves 5 mypy errors on `enumerate`, index-assignment, and `append` without scattering `# type: ignore` on each line
- A single `# type: ignore[assignment]` on the narrowing cast is more localized and self-documenting
- Local variable annotations aren't evaluated at runtime in Python, so having `AoT` under `TYPE_CHECKING` only is safe

Before: 8 mypy errors in 3 files (5 in `gptme/config/user.py`)  
After: 2 mypy errors in 2 files (pre-existing optional-dep `import-not-found` in `hybrid_matcher.py` and `util/__init__.py`)

## Test plan

- [x] `make typecheck` — user.py errors gone
- [x] Pre-commit hooks pass (ruff TC002, mypy, format)