### PR TITLE
feat(subagent): subprocess-mode progress notifications via file channel

### DIFF
--- a/gptme/tools/progress.py
+++ b/gptme/tools/progress.py
@@ -8,14 +8,19 @@ then-get-alerted-when-update/done" pattern alongside ``complete`` and ``clarify`
 Unlike ``complete`` (ends session) and ``clarify`` (pauses session), ``progress``
 continues execution after delivering the update.
 
-Only works in thread-mode subagents (same process). Subprocess-mode subagents
-cannot share the in-process progress queue, so updates are not delivered when
-the agent_id cannot be resolved.
+Delivery modes:
+- Thread-mode subagents: uses the in-process ``_progress_queue``; the parent's
+  LOOP_CONTINUE hook picks it up on the next iteration.
+- Subprocess-mode subagents: writes JSON lines to ``GPTME_PROGRESS_FILE`` (set
+  by the parent before spawning); the parent's monitor thread polls that file and
+  delivers updates via the same hook path.
 
 Only enabled in autonomous/subagent sessions (disabled_by_default=True).
 """
 
+import json
 import logging
+import os
 from collections.abc import Generator
 from typing import TYPE_CHECKING
 
@@ -27,6 +32,23 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Env var the parent sets to tell a subprocess-mode subagent where to write
+# progress updates. Value is a path to a JSONL file; each line is a JSON object
+# with "agent_id" and "message" keys.
+_PROGRESS_FILE_ENVVAR = "GPTME_PROGRESS_FILE"
+# Env var conveying the subagent's own identity to subprocess-mode children.
+_AGENT_ID_ENVVAR = "GPTME_SUBAGENT_AGENT_ID"
+
+
+def _write_progress_to_file(agent_id: str, message: str) -> None:
+    """Write a progress update to the file-based channel for subprocess mode."""
+    progress_file = os.environ.get(_PROGRESS_FILE_ENVVAR)
+    if not progress_file:
+        return
+    entry = json.dumps({"agent_id": agent_id, "message": message})
+    with open(progress_file, "a") as f:
+        f.write(entry + "\n")
+
 
 def execute_progress(
     code: str | None,
@@ -35,10 +57,13 @@ def execute_progress(
 ) -> Generator[Message, None, None]:
     """Send an intermediate progress update to the parent orchestrator.
 
-    Reads the current agent_id from thread-local storage (set by
-    _create_subagent_thread) and pushes the update to the shared
-    _progress_queue. The parent's LOOP_CONTINUE hook delivers it as a
-    ⏳ system message on the next loop iteration.
+    In thread mode: reads the current agent_id from thread-local storage (set by
+    _create_subagent_thread) and pushes the update to the shared _progress_queue.
+    The parent's LOOP_CONTINUE hook delivers it as a ⏳ system message.
+
+    In subprocess mode: writes the update to the file pointed to by
+    GPTME_PROGRESS_FILE (set by the parent). The parent's monitor thread polls
+    that file and delivers the update via the same hook path.
     """
     from .subagent.execution import get_current_agent_id
     from .subagent.hooks import notify_progress
@@ -52,16 +77,28 @@ def execute_progress(
 
     agent_id = get_current_agent_id()
     if agent_id is None:
-        # Running outside a thread-mode subagent context (e.g. subprocess or direct call)
-        logger.warning(
-            "progress tool: no agent_id in thread-local — running in subprocess mode? "
-            "Progress update will not be delivered to parent."
-        )
-        yield Message(
-            "system",
-            "Progress update NOT delivered to parent (subprocess mode does not support in-process queue).",
-            quiet=True,
-        )
+        # Not in a thread-mode subagent context — check for subprocess env vars.
+        agent_id = os.environ.get(_AGENT_ID_ENVVAR)
+        if agent_id and os.environ.get(_PROGRESS_FILE_ENVVAR):
+            _write_progress_to_file(agent_id, message)
+            logger.debug(
+                f"Progress update written to file for subagent '{agent_id}': {message[:80]}"
+            )
+            yield Message(
+                "system",
+                "Progress update sent to parent orchestrator (via file channel).",
+                quiet=True,
+            )
+        else:
+            logger.warning(
+                "progress tool: no agent_id in thread-local and GPTME_PROGRESS_FILE "
+                "not set — progress update will not be delivered to parent."
+            )
+            yield Message(
+                "system",
+                "Progress update NOT delivered to parent (not running as a managed subagent).",
+                quiet=True,
+            )
         return
 
     notify_progress(agent_id, message)

--- a/gptme/tools/subagent/execution.py
+++ b/gptme/tools/subagent/execution.py
@@ -457,14 +457,14 @@ def _run_subagent_subprocess(
         profile_obj = get_profile(profile)
         if profile_obj and profile_obj.tools is not None:
             tool_allowlist = list(profile_obj.tools)
-            for tool_name in ("complete", "clarify"):
+            for tool_name in ("complete", "clarify", "progress"):
                 if tool_name not in tool_allowlist:
                     tool_allowlist.append(tool_name)
             cmd.extend(["--tools", ",".join(tool_allowlist)])
         else:
-            cmd.extend(["--tools", "+complete,+clarify"])
+            cmd.extend(["--tools", "+complete,+clarify,+progress"])
     else:
-        cmd.extend(["--tools", "+complete,+clarify"])
+        cmd.extend(["--tools", "+complete,+clarify,+progress"])
 
     # Map context_mode/context_include to the --context CLI flag
     if context_mode == "selective" and context_include:
@@ -504,11 +504,17 @@ def _run_subagent_subprocess(
         )
         prompt = prompt + memory_section
 
-    # Add completion instruction to the prompt for subprocess mode
-    # (In thread mode, this is added as a system message)
+    # Progress file for subprocess-mode progress delivery.
+    # The subprocess writes JSON lines here; _monitor_subprocess polls and
+    # delivers them to the parent via notify_progress().
+    progress_file = logdir / "progress.jsonl"
+
+    # Add completion instruction to the prompt for subprocess mode.
+    # (In thread mode, this is added as a system message.)
+    # Subprocess mode supports progress via the file channel, so enable it.
     complete_section = (
         "\n\n[Completion Instructions]\n"
-        f"{_get_complete_instruction('orchestrator', supports_progress=False)}\n"
+        f"{_get_complete_instruction('orchestrator', supports_progress=True)}\n"
     )
     prompt = prompt + complete_section
 
@@ -521,6 +527,13 @@ def _run_subagent_subprocess(
         tmpf.write(prompt)
         tmpfile_path = Path(tmpf.name)
 
+    # Environment for the subprocess: convey agent identity and progress channel.
+    import os
+
+    env = os.environ.copy()
+    env["GPTME_SUBAGENT_AGENT_ID"] = logdir.name.removeprefix("subagent-")
+    env["GPTME_PROGRESS_FILE"] = str(progress_file)
+
     try:
         with open(tmpfile_path) as stdin_file:
             process = subprocess.Popen(
@@ -529,6 +542,7 @@ def _run_subagent_subprocess(
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
                 cwd=workspace,
+                env=env,
                 text=True,
             )
     finally:
@@ -573,6 +587,64 @@ def _cleanup_isolation(subagent: "Subagent") -> None:
         logger.warning(f"Failed to cleanup isolation for {subagent.agent_id}: {e}")
 
 
+def _poll_subprocess_progress(
+    subagent: "Subagent", stop_event: threading.Event
+) -> None:
+    """Poll the progress file for a subprocess-mode subagent and deliver updates.
+
+    Runs in a background thread alongside _monitor_subprocess. Reads JSON lines
+    from ``logdir/progress.jsonl`` (written by the subprocess via the progress
+    tool's file channel) and calls ``notify_progress`` so the parent receives
+    ⏳ system messages via the LOOP_CONTINUE hook.
+
+    Args:
+        subagent: The subagent being monitored.
+        stop_event: Set by _monitor_subprocess after the process exits. The poll
+            loop runs one final drain pass after the event is set to catch any
+            progress updates written in the last moments before exit.
+    """
+    import json
+    import time
+
+    from .hooks import notify_progress
+
+    progress_file = subagent.logdir / "progress.jsonl"
+    file_pos = 0
+    POLL_INTERVAL = 0.5
+
+    def _drain() -> None:
+        nonlocal file_pos
+        if not progress_file.exists():
+            return
+        try:
+            with open(progress_file) as f:
+                f.seek(file_pos)
+                for raw_line in f:
+                    raw_line = raw_line.strip()
+                    if not raw_line:
+                        continue
+                    try:
+                        entry = json.loads(raw_line)
+                        agent_id = entry.get("agent_id", subagent.agent_id)
+                        message = entry.get("message", "")
+                        if message:
+                            notify_progress(agent_id, message)
+                            logger.debug(
+                                f"Delivered subprocess progress for '{agent_id}': {message[:80]}"
+                            )
+                    except json.JSONDecodeError:
+                        pass  # partial write; will be retried next iteration
+                file_pos = f.tell()
+        except OSError:
+            pass  # file not yet created or already removed
+
+    while not stop_event.is_set():
+        _drain()
+        time.sleep(POLL_INTERVAL)
+    # Final drain after the process exits to catch last-moment writes.
+    _drain()
+
+
 def _monitor_subprocess(
     subagent: "Subagent",
 ) -> None:
@@ -581,6 +653,10 @@ def _monitor_subprocess(
     Runs in a background thread to enable non-blocking operation.
     Subprocess stdout/stderr are sent to DEVNULL since results are read
     from the conversation log, not the process pipes.
+
+    Also starts a progress-polling thread that reads ``logdir/progress.jsonl``
+    written by the subprocess-mode ``progress`` tool and delivers intermediate
+    updates to the parent via ``notify_progress``.
     """
     from .hooks import notify_completion
     from .types import (
@@ -590,6 +666,17 @@ def _monitor_subprocess(
 
     if not subagent.process:
         return
+
+    # Start progress polling in a background thread so the parent receives
+    # ⏳ updates while the subprocess is still running.
+    progress_stop = threading.Event()
+    progress_thread = threading.Thread(
+        target=_poll_subprocess_progress,
+        args=(subagent, progress_stop),
+        daemon=True,
+        name=f"progress-poll-{subagent.agent_id}",
+    )
+    progress_thread.start()
 
     # Track whether the process was killed due to our timeout (vs external SIGKILL)
     _timed_out = False
@@ -604,6 +691,10 @@ def _monitor_subprocess(
         _timed_out = True
         subagent.process.kill()
         subagent.process.wait()  # reap the killed process
+
+    # Stop the progress-poll thread and let it do a final drain.
+    progress_stop.set()
+    progress_thread.join(timeout=2.0)
 
     input_tokens: int | None = None
     output_tokens: int | None = None

--- a/gptme/tools/subagent/execution.py
+++ b/gptme/tools/subagent/execution.py
@@ -8,6 +8,7 @@ subagent() function in api.py.
 """
 
 import logging
+import os
 import random
 import string
 import subprocess
@@ -530,8 +531,6 @@ def _run_subagent_subprocess(
         tmpfile_path = Path(tmpf.name)
 
     # Environment for the subprocess: convey agent identity and progress channel.
-    import os
-
     env = os.environ.copy()
     env["GPTME_SUBAGENT_AGENT_ID"] = logdir.name.removeprefix("subagent-")
     env["GPTME_PROGRESS_FILE"] = str(progress_file)

--- a/gptme/tools/subagent/execution.py
+++ b/gptme/tools/subagent/execution.py
@@ -28,6 +28,8 @@ from .._allowlist import (
 from .concurrency import get_slot_sem
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from .types import ReturnType, Status, Subagent, SubtaskDef
 
 logger = logging.getLogger(__name__)
@@ -587,6 +589,67 @@ def _cleanup_isolation(subagent: "Subagent") -> None:
         logger.warning(f"Failed to cleanup isolation for {subagent.agent_id}: {e}")
 
 
+def _drain_progress_file(
+    progress_file: "Path",
+    file_pos: int,
+    default_agent_id: str,
+    notify_fn: "Callable[[str, str], None]",
+) -> int:
+    """Read new progress entries from progress_file and deliver them via notify_fn.
+
+    Reads from ``file_pos`` forward, advancing only past complete
+    newline-terminated lines. Stops (without advancing) on any incomplete line
+    at EOF so the partial write can be retried on the next poll.
+
+    Args:
+        progress_file: Path to the ``progress.jsonl`` file written by the child.
+        file_pos: Byte offset to start reading from.
+        default_agent_id: Used when an entry omits ``agent_id``.
+        notify_fn: Callable with signature ``(agent_id: str, message: str)``.
+
+    Returns:
+        Updated file_pos (advanced past every complete line that was processed).
+    """
+    import json
+
+    if not progress_file.exists():
+        return file_pos
+    try:
+        with open(progress_file) as f:
+            f.seek(file_pos)
+            while True:
+                raw_line = f.readline()
+                if not raw_line:
+                    break  # EOF — no new content
+                if not raw_line.endswith("\n"):
+                    # Incomplete line at EOF: partial write in progress.
+                    # Don't advance file_pos; retry next poll when the write completes.
+                    break
+                stripped = raw_line.strip()
+                if not stripped:
+                    file_pos = f.tell()
+                    continue
+                try:
+                    entry = json.loads(stripped)
+                    agent_id = entry.get("agent_id", default_agent_id)
+                    message = entry.get("message", "")
+                    if message:
+                        notify_fn(agent_id, message)
+                        logger.debug(
+                            f"Delivered subprocess progress for '{agent_id}': {message[:80]}"
+                        )
+                except json.JSONDecodeError:
+                    logger.debug(
+                        f"Skipping unparseable progress line: {stripped[:80]!r}"
+                    )
+                # Advance past this complete line (parsed or corrupt) so
+                # we don't re-process it on the next poll.
+                file_pos = f.tell()
+    except OSError:
+        pass  # file not yet created or already removed
+    return file_pos
+
+
 def _poll_subprocess_progress(
     subagent: "Subagent", stop_event: threading.Event
 ) -> None:
@@ -603,7 +666,6 @@ def _poll_subprocess_progress(
             loop runs one final drain pass after the event is set to catch any
             progress updates written in the last moments before exit.
     """
-    import json
     import time
 
     from .hooks import notify_progress
@@ -614,29 +676,9 @@ def _poll_subprocess_progress(
 
     def _drain() -> None:
         nonlocal file_pos
-        if not progress_file.exists():
-            return
-        try:
-            with open(progress_file) as f:
-                f.seek(file_pos)
-                for raw_line in f:
-                    raw_line = raw_line.strip()
-                    if not raw_line:
-                        continue
-                    try:
-                        entry = json.loads(raw_line)
-                        agent_id = entry.get("agent_id", subagent.agent_id)
-                        message = entry.get("message", "")
-                        if message:
-                            notify_progress(agent_id, message)
-                            logger.debug(
-                                f"Delivered subprocess progress for '{agent_id}': {message[:80]}"
-                            )
-                    except json.JSONDecodeError:
-                        pass  # partial write; will be retried next iteration
-                file_pos = f.tell()
-        except OSError:
-            pass  # file not yet created or already removed
+        file_pos = _drain_progress_file(
+            progress_file, file_pos, subagent.agent_id, notify_progress
+        )
 
     while not stop_event.is_set():
         _drain()

--- a/gptme/tools/subagent/hooks.py
+++ b/gptme/tools/subagent/hooks.py
@@ -102,8 +102,9 @@ def notify_progress(agent_id: str, message: str) -> None:
     The parent's LOOP_CONTINUE hook delivers it as a system message so the
     orchestrator can react without blocking on subagent_wait().
 
-    Note: Only works for thread-mode subagents (same process). Subprocess-mode
-    subagents cannot share the in-process queue.
+    Note: For thread-mode subagents the progress tool calls this directly (same
+    process). For subprocess-mode subagents, ``_poll_subprocess_progress`` reads
+    from the file channel and calls this function on behalf of the child process.
 
     Args:
         agent_id: The subagent's identifier

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1195,6 +1195,7 @@ def test_fileblock(args: list[str], runner: CliRunner):
     assert content == 'print("hello world")\n'
 
 
+@pytest.mark.timeout(30)
 def test_shell(args: list[str], runner: CliRunner):
     args.append("/shell echo 'yes'")
     result = runner.invoke(cli.main, args)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -532,6 +532,7 @@ def test_get_toolchain_glob_matches_mcp_tools():
 
 def test_get_toolchain_warns_when_plain_allowlist_excludes_mcp_tools(caplog):
     """Plain allowlists should warn when they filter out available MCP tools."""
+    import gptme.tools
     from gptme.tools.base import ToolSpec
 
     clear_tools()
@@ -543,6 +544,7 @@ def test_get_toolchain_warns_when_plain_allowlist_excludes_mcp_tools(caplog):
 
     with (
         patch("gptme.tools.get_available_tools", return_value=fake_tools),
+        patch.object(gptme.tools, "_warned_mcp_allowlists", set()),
         caplog.at_level("WARNING", logger="gptme.tools"),
     ):
         tools = get_toolchain(["save"], strict=True)

--- a/tests/test_tools_subagent.py
+++ b/tests/test_tools_subagent.py
@@ -1031,6 +1031,46 @@ def test_poll_subprocess_progress_delivers_via_notify(tmp_path):
     assert delivered[0] == ("poll-agent", "Step 1 done")
 
 
+def test_drain_progress_file_partial_write_retry(tmp_path):
+    """_drain_progress_file retries partial (no-newline) lines on the next call.
+
+    Regression test: the old code advanced file_pos unconditionally after the
+    loop, silently skipping any line that raised JSONDecodeError — including
+    partial writes that would have been complete on the next poll.
+    """
+    import json
+
+    from gptme.tools.subagent.execution import _drain_progress_file
+
+    progress_file = tmp_path / "progress.jsonl"
+    delivered: list[tuple[str, str]] = []
+
+    def fake_notify(agent_id: str, message: str) -> None:
+        delivered.append((agent_id, message))
+
+    complete = json.dumps({"agent_id": "a", "message": "done"})
+    partial = '{"agent_id": "a", "message": "in-flight'  # missing closing } and \n
+
+    # First poll: one complete line + one partial (no trailing newline)
+    progress_file.write_text(complete + "\n" + partial)
+    pos = _drain_progress_file(progress_file, 0, "a", fake_notify)
+
+    assert len(delivered) == 1, "only the complete line should be delivered"
+    assert delivered[0] == ("a", "done")
+
+    # file_pos must be just after the complete line, not at EOF
+    assert pos == len(complete) + 1, "file_pos should not advance past the partial line"
+
+    # Second poll: the write completes (partial line now has its closing bytes + \n)
+    full_second = json.dumps({"agent_id": "a", "message": "in-flight-complete"})
+    # Overwrite the file with both lines fully written
+    progress_file.write_text(complete + "\n" + full_second + "\n")
+    pos = _drain_progress_file(progress_file, pos, "a", fake_notify)
+
+    assert len(delivered) == 2, "second poll should pick up the now-complete line"
+    assert delivered[1] == ("a", "in-flight-complete")
+
+
 @pytest.mark.slow
 def test_subprocess_working_directory():
     """Test that subprocess runs in the specified working directory."""

--- a/tests/test_tools_subagent.py
+++ b/tests/test_tools_subagent.py
@@ -779,7 +779,7 @@ def test_subprocess_command_includes_required_flags():
     assert "--model" in cmd
     assert "test-model" in cmd
     assert "--tools" in cmd
-    assert cmd[cmd.index("--tools") + 1] == "+complete,+clarify"
+    assert cmd[cmd.index("--tools") + 1] == "+complete,+clarify,+progress"
     assert "Test task" not in cmd  # Prompt passed via stdin, not argv
 
 
@@ -817,7 +817,7 @@ def test_subprocess_profile_preserves_profile_tools_and_adds_clarify():
     assert captured_cmd[captured_cmd.index("--agent-profile") + 1] == "explorer"
     assert "--tools" in captured_cmd
     assert captured_cmd[captured_cmd.index("--tools") + 1] == (
-        "read,chats,complete,clarify"
+        "read,chats,complete,clarify,progress"
     )
 
 
@@ -852,11 +852,14 @@ def test_subprocess_no_profile_includes_complete_and_clarify():
             )
 
     assert "--tools" in captured_cmd
-    assert captured_cmd[captured_cmd.index("--tools") + 1] == "+complete,+clarify"
+    assert (
+        captured_cmd[captured_cmd.index("--tools") + 1]
+        == "+complete,+clarify,+progress"
+    )
 
 
 def test_subprocess_profile_without_toollist_includes_complete_and_clarify():
-    """Profile with no tools list must fall back to +complete,+clarify."""
+    """Profile with no tools list must fall back to +complete,+clarify,+progress."""
     import tempfile
     from pathlib import Path
 
@@ -896,7 +899,136 @@ def test_subprocess_profile_without_toollist_includes_complete_and_clarify():
             )
 
     assert "--tools" in captured_cmd
-    assert captured_cmd[captured_cmd.index("--tools") + 1] == "+complete,+clarify"
+    assert (
+        captured_cmd[captured_cmd.index("--tools") + 1]
+        == "+complete,+clarify,+progress"
+    )
+
+
+def test_subprocess_sets_progress_env_vars():
+    """Subprocess must receive GPTME_SUBAGENT_AGENT_ID and GPTME_PROGRESS_FILE env vars."""
+    import tempfile
+    from pathlib import Path
+
+    from gptme.tools.subagent.execution import _run_subagent_subprocess
+
+    captured_env: dict[str, str] = {}
+
+    def fake_popen(cmd, **kwargs):
+        captured_env.update(kwargs.get("env") or {})
+        mock = MagicMock()
+        mock.poll.return_value = None
+        mock.args = cmd
+        return mock
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        logdir = Path(tmpdir) / "subagent-test-agent"
+        logdir.mkdir()
+
+        with patch("gptme.tools.subagent.execution.subprocess.Popen", fake_popen):
+            _run_subagent_subprocess(
+                prompt="Test progress env",
+                logdir=logdir,
+                model=None,
+                workspace=Path(tmpdir),
+            )
+
+    assert "GPTME_SUBAGENT_AGENT_ID" in captured_env
+    assert captured_env["GPTME_SUBAGENT_AGENT_ID"] == "test-agent"
+    assert "GPTME_PROGRESS_FILE" in captured_env
+    assert captured_env["GPTME_PROGRESS_FILE"].endswith("progress.jsonl")
+
+
+def test_progress_tool_file_delivery(tmp_path):
+    """progress tool writes to file channel when running in subprocess env."""
+    import json
+    import os
+    from unittest.mock import patch
+
+    from gptme.tools.progress import execute_progress
+
+    progress_file = tmp_path / "progress.jsonl"
+    env = {
+        "GPTME_SUBAGENT_AGENT_ID": "sub-1",
+        "GPTME_PROGRESS_FILE": str(progress_file),
+    }
+
+    # Patch at the source so execute_progress's local import resolves to None
+    with (
+        patch.dict(os.environ, env, clear=False),
+        patch("gptme.tools.subagent.execution.get_current_agent_id", return_value=None),
+    ):
+        messages = list(execute_progress("Phase 1 done, starting phase 2", None, None))
+
+    assert len(messages) == 1
+    assert (
+        "parent" in messages[0].content.lower()
+        or "file channel" in messages[0].content.lower()
+    )
+    assert progress_file.exists()
+    lines = [
+        json.loads(line) for line in progress_file.read_text().strip().splitlines()
+    ]
+    assert len(lines) == 1
+    assert lines[0]["agent_id"] == "sub-1"
+    assert "Phase 1 done" in lines[0]["message"]
+
+
+def test_progress_tool_no_env_gives_graceful_message():
+    """progress tool gives clear message when not in a managed subagent context."""
+    import os
+    from unittest.mock import patch
+
+    from gptme.tools.progress import execute_progress
+
+    clean_env = {
+        k: v
+        for k, v in os.environ.items()
+        if k not in ("GPTME_SUBAGENT_AGENT_ID", "GPTME_PROGRESS_FILE")
+    }
+
+    with (
+        patch.dict(os.environ, clean_env, clear=True),
+        patch("gptme.tools.subagent.execution.get_current_agent_id", return_value=None),
+    ):
+        messages = list(execute_progress("some progress", None, None))
+
+    assert len(messages) == 1
+    assert "not" in messages[0].content.lower()
+
+
+def test_poll_subprocess_progress_delivers_via_notify(tmp_path):
+    """_poll_subprocess_progress reads progress.jsonl and calls notify_progress."""
+    import json
+    import threading
+    from unittest.mock import MagicMock, patch
+
+    from gptme.tools.subagent.execution import _poll_subprocess_progress
+
+    progress_file = tmp_path / "progress.jsonl"
+    delivered: list[tuple[str, str]] = []
+
+    def fake_notify(agent_id, message):
+        delivered.append((agent_id, message))
+
+    # Write a progress entry to the file before polling starts
+    entry = json.dumps({"agent_id": "poll-agent", "message": "Step 1 done"})
+    progress_file.write_text(entry + "\n")
+
+    stop_event = threading.Event()
+
+    # Create a minimal fake subagent object with the fields _poll_subprocess_progress needs
+    mock_sa = MagicMock()
+    mock_sa.agent_id = "poll-agent"
+    mock_sa.logdir = tmp_path
+
+    with patch("gptme.tools.subagent.hooks.notify_progress", fake_notify):
+        # Set stop immediately so the loop exits after the final drain
+        stop_event.set()
+        _poll_subprocess_progress(mock_sa, stop_event)
+
+    assert len(delivered) >= 1
+    assert delivered[0] == ("poll-agent", "Step 1 done")
 
 
 @pytest.mark.slow


### PR DESCRIPTION
## Summary

- Subprocess-mode subagents previously could not use the `progress` tool — progress blocks silently failed because they can't reach the parent's in-process `_progress_queue`
- Adds a file-based channel: parent sets `GPTME_SUBAGENT_AGENT_ID` and `GPTME_PROGRESS_FILE` env vars before spawning; subprocess writes JSON lines to that file; parent's monitor thread polls it every 0.5s and delivers updates via `notify_progress()` → same `⏳` system message path as thread-mode
- Enables `supports_progress=True` in subprocess-mode complete instruction and adds `+progress` to the subprocess tool list so the model knows it can use progress blocks
- Closes #554

## Changes

- **`gptme/tools/progress.py`**: file-based delivery path when `get_current_agent_id()` returns `None` but env vars are set; cleaner "not a managed subagent" message otherwise
- **`gptme/tools/subagent/execution.py`**: sets env vars before `Popen`; adds `_poll_subprocess_progress` daemon thread started by `_monitor_subprocess`; adds `progress` to subprocess tool list in both profile and non-profile paths
- **`tests/test_tools_subagent.py`**: updates 4 existing tests to expect `+progress` in tool list; adds 4 new tests covering env var setup, file delivery, graceful no-env message, and poll-and-deliver

## Test plan

- [x] `test_subprocess_command_includes_required_flags` — passes (updated assertion)
- [x] `test_subprocess_profile_preserves_profile_tools_and_adds_clarify` — passes (updated assertion)
- [x] `test_subprocess_no_profile_includes_complete_and_clarify` — passes (updated assertion)
- [x] `test_subprocess_profile_without_toollist_includes_complete_and_clarify` — passes (updated assertion)
- [x] `test_subprocess_sets_progress_env_vars` — new: verifies env vars are set before Popen
- [x] `test_progress_tool_file_delivery` — new: verifies JSON line written to progress file
- [x] `test_progress_tool_no_env_gives_graceful_message` — new: verifies clean error when not in managed subagent
- [x] `test_poll_subprocess_progress_delivers_via_notify` — new: verifies file lines are delivered via notify_progress
- [x] All 110 non-slow tests pass