### PR TITLE
fix(webui): stabilize WelcomeView autoFocus$ to prevent focus-steal on re-render

### DIFF
--- a/webui/src/components/WelcomeView.tsx
+++ b/webui/src/components/WelcomeView.tsx
@@ -4,8 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import { useApi } from '@/contexts/ApiContext';
 import { useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
-import { use$ } from '@legendapp/state/react';
-import { observable } from '@legendapp/state';
+import { use$, useObservable } from '@legendapp/state/react';
 import { ChatInput, type ChatOptions } from '@/components/ChatInput';
 import { History, Server, Copy, RotateCcw } from 'lucide-react';
 import { useSettings } from '@/contexts/SettingsContext';
@@ -78,8 +77,8 @@ export const WelcomeView = () => {
     activeServerBaseUrl
   );
 
-  // Create observables that ChatInput expects
-  const autoFocus$ = observable(true);
+  // Stable observable for ChatInput autoFocus — must not be recreated on re-renders
+  const autoFocus$ = useObservable(true);
 
   const handleServerSwitch = async (serverId: string) => {
     try {

--- a/webui/src/components/__tests__/ChatInput.test.tsx
+++ b/webui/src/components/__tests__/ChatInput.test.tsx
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { observable } from '@legendapp/state';
 import { ChatInput } from '../ChatInput';
 
@@ -199,6 +199,37 @@ describe('ChatInput', () => {
     const stopButton = screen.getByRole('button', { name: 'Stop generation' });
     expect(stopButton).toBeEnabled();
     expect(stopButton).toHaveTextContent('Stop');
+  });
+
+  it('focuses the textarea on mount when autoFocus$ is true and resets the observable', async () => {
+    // autoFocus$ must be reset to false after focusing so a stable observable
+    // (useObservable in WelcomeView) doesn't re-trigger focus on subsequent renders.
+    const autoFocus$ = observable(true);
+    render(<ChatInput conversationId="conv-a" onSend={jest.fn()} autoFocus$={autoFocus$} />);
+
+    const textarea = screen.getByRole('textbox', { name: 'Chat message' });
+    await waitFor(() => expect(document.activeElement).toBe(textarea));
+    expect(autoFocus$.get()).toBe(false);
+  });
+
+  it('does not steal focus on re-render when autoFocus$ is false', () => {
+    // Regression guard for the WelcomeView focus-steal bug:
+    // before the fix, WelcomeView created a new observable(true) on every render,
+    // so each state change stole focus from open popups and settings inputs.
+    // With the fix (useObservable), the observable is stable and stays false after
+    // the initial focus, so subsequent re-renders must not move focus.
+    const autoFocus$ = observable(false);
+    const onSend = jest.fn();
+    const { rerender } = render(
+      <ChatInput conversationId="conv-a" onSend={onSend} autoFocus$={autoFocus$} />
+    );
+
+    const textarea = screen.getByRole('textbox', { name: 'Chat message' });
+    act(() => textarea.blur());
+    expect(document.activeElement).not.toBe(textarea);
+
+    rerender(<ChatInput conversationId="conv-a" onSend={onSend} autoFocus$={autoFocus$} />);
+    expect(document.activeElement).not.toBe(textarea);
   });
 
   it('preserves existing attachments in edit mode', async () => {


### PR DESCRIPTION
## Problem

Two UX regressions on gptme.ai (reported by Erik 2026-07-08):

1. **Popup/menu focus-steal**: opening the model selector or Options popover caused it to immediately close and re-focus the chat textarea.
2. **Single-character input**: settings inputs (max tokens, temperature, top P) only registered the last character typed — each keystroke appeared to replace the value.

Both share one root cause.

## Root cause

`WelcomeView.tsx` created `autoFocus$` as a plain variable:

```tsx
const autoFocus$ = observable(true);  // ← new object on every render
```

Since this runs on every render of `WelcomeView`, any state change (opening a popover, typing, etc.) produced a fresh `observable(true)` and passed it to `ChatInput`. `ChatInput`'s `useEffect` subscribes via `use$()` and calls `textarea.focus()` whenever the value is `true` — which it always was on the new object. This stole focus from open popovers (closing them) and from settings inputs (replacing each character).

## Fix

Replace `observable()` with `useObservable()` from `@legendapp/state/react`, which creates the observable once on mount and returns the same reference across renders — the pattern already used in `ConversationContent.tsx`.

```tsx
// Before — new observable on every render
const autoFocus$ = observable(true);

// After — stable reference, created once on mount
const autoFocus$ = useObservable(true);
```

## Tests

Added two regression tests to `ChatInput.test.tsx`:
- Verifies focus IS captured on mount when `autoFocus$=true` and the observable is reset to `false` afterward (the ChatInput side of the contract)
- Verifies no focus-steal occurs on re-render when `autoFocus$` stays `false` (guards against the WelcomeView regression)