### PR TITLE
feat(mcp): expose gptme tools as MCP server (gptme-mcp-server)

### DIFF
--- a/gptme/cli/cmd_mcp_serve.py
+++ b/gptme/cli/cmd_mcp_serve.py
@@ -1,0 +1,68 @@
+"""
+CLI entrypoint for gptme-mcp-server.
+
+Expose gptme tools as an MCP server (stdio transport).
+"""
+
+from __future__ import annotations
+
+import logging
+
+import click
+
+
+@click.command("mcp-server")
+@click.option(
+    "--tools",
+    default=None,
+    metavar="TOOLS",
+    help="Comma-separated list of tools to expose. "
+    "Default: shell,ipython,save,append,read",
+)
+@click.option(
+    "--workspace",
+    default=None,
+    metavar="DIR",
+    help="Working directory for tool execution. Defaults to current directory.",
+)
+@click.option(
+    "--log-level",
+    default="WARNING",
+    type=click.Choice(["DEBUG", "INFO", "WARNING", "ERROR"], case_sensitive=False),
+    help="Log level for the MCP server process (logs go to stderr).",
+)
+def main(
+    tools: str | None,
+    workspace: str | None,
+    log_level: str,
+) -> None:
+    """Expose gptme tools as an MCP server over stdio.
+
+    Connect this server to Claude Desktop, Cursor, or any MCP-compatible client.
+
+    \\b
+    Claude Desktop config (~/.claude/claude_desktop_config.json):
+        {
+          "mcpServers": {
+            "gptme": {
+              "command": "gptme-mcp-server",
+              "args": ["--tools", "shell,ipython,save,read"]
+            }
+          }
+        }
+    """
+    logging.basicConfig(level=getattr(logging, log_level.upper()), format="%(message)s")
+
+    from ..mcp.server import DEFAULT_TOOLS, GptmeMCPServer
+
+    tool_names: list[str] | None = None
+    if tools:
+        tool_names = [t.strip() for t in tools.split(",") if t.strip()]
+
+    click.echo(
+        f"Starting gptme MCP server (tools: {','.join(tool_names or DEFAULT_TOOLS)})",
+        err=True,
+    )
+
+    server = GptmeMCPServer(tool_names=tool_names, workspace=workspace)
+    server.serve_stdio()

--- a/gptme/mcp/__init__.py
+++ b/gptme/mcp/__init__.py
@@ -5,6 +5,7 @@ from .registry import (
     format_server_details,
     format_server_list,
 )
+from .server import GptmeMCPServer, create_server
 
 __all__ = [
     "MCPClient",
@@ -12,4 +13,6 @@ __all__ = [
     "MCPServerInfo",
     "format_server_details",
     "format_server_list",
+    "GptmeMCPServer",
+    "create_server",
 ]

--- a/gptme/mcp/__init__.py
+++ b/gptme/mcp/__init__.py
@@ -5,7 +5,6 @@ from .registry import (
     format_server_details,
     format_server_list,
 )
-from .server import GptmeMCPServer, create_server
 
 __all__ = [
     "MCPClient",
@@ -16,3 +15,16 @@ __all__ = [
     "GptmeMCPServer",
     "create_server",
 ]
+
+
+def __getattr__(name: str):
+    # Lazy-import server symbols so that `from gptme.mcp import MCPClient`
+    # does NOT trigger loading gptme.mcp.server (which imports the full tools
+    # package). Only import the server module when explicitly requested.
+    if name in ("GptmeMCPServer", "create_server"):
+        from .server import GptmeMCPServer, create_server
+
+        if name == "GptmeMCPServer":
+            return GptmeMCPServer
+        return create_server
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/gptme/mcp/server.py
+++ b/gptme/mcp/server.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 from typing import TYPE_CHECKING, Any
 
 import mcp.server.stdio
@@ -119,6 +120,9 @@ class GptmeMCPServer:
         # on first use; injected into each executor thread via _shell_var so that
         # stateful tools (shell, ipython) retain state between MCP requests.
         self._shell_session: ShellSession | None = None
+        # Serialize tool calls to prevent concurrent access to stateful tools
+        # (shell subprocess, IPython REPL) from racing on shared session state.
+        self._tool_call_lock = asyncio.Lock()
         self._setup_handlers()
 
     def _get_or_create_shell_session(self) -> ShellSession:
@@ -185,10 +189,13 @@ class GptmeMCPServer:
 
                 return output
 
-            # Run in a thread executor to avoid blocking the event loop during
-            # long-running operations (bash commands, Python REPL, etc.)
-            loop = asyncio.get_event_loop()
-            output = await loop.run_in_executor(None, _run_tool)
+            # Serialize tool calls to prevent concurrent access to stateful tools
+            # (shell subprocess, IPython REPL) which share session state.
+            async with self._tool_call_lock:
+                # Run in a thread executor to avoid blocking the event loop during
+                # long-running operations (bash commands, Python REPL, etc.)
+                loop = asyncio.get_event_loop()
+                output = await loop.run_in_executor(None, _run_tool)
 
             return [types.TextContent(type="text", text=output or "(no output)")]
 
@@ -204,6 +211,11 @@ class GptmeMCPServer:
 
     def serve_stdio(self) -> None:
         """Run the MCP server over stdio (for Claude Desktop and similar clients)."""
+        if self._workspace:
+            # Change CWD so that all tools (read, save, append, shell) resolve
+            # relative paths against the configured workspace directory instead of
+            # the process launch directory.
+            os.chdir(self._workspace)
         self._init_tools()
 
         async def _run() -> None:

--- a/gptme/mcp/server.py
+++ b/gptme/mcp/server.py
@@ -1,0 +1,190 @@
+"""
+MCP server: expose gptme tools as an MCP server.
+
+Allows Claude Desktop, Cursor, and other MCP clients to use gptme's tools
+(bash, Python REPL, file read/save, browser, etc.) directly.
+
+Usage (stdio transport, recommended for Claude Desktop):
+    gptme-mcp-server
+
+Claude Desktop config:
+    {
+      "mcpServers": {
+        "gptme": {
+          "command": "gptme-mcp-server",
+          "args": ["--tools", "shell,ipython,save,append,read"]
+        }
+      }
+    }
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING, Any
+
+import mcp.server.stdio
+import mcp.types as types
+from mcp.server.lowlevel import Server
+
+from ..tools import init_tools
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from ..tools.base import ToolSpec
+
+logger = logging.getLogger(__name__)
+
+# Default tool set: broadly useful, excluding circular (mcp) and risky (subagent).
+DEFAULT_TOOLS = ["shell", "ipython", "save", "append", "read"]
+
+# Tools that should never be exposed via MCP regardless of user request.
+_EXCLUDED_TOOLS = {"subagent", "mcp"}
+
+_PARAM_TYPE_MAP: dict[str, str] = {
+    "string": "string",
+    "str": "string",
+    "integer": "integer",
+    "int": "integer",
+    "number": "number",
+    "float": "number",
+    "boolean": "boolean",
+    "bool": "boolean",
+    "array": "array",
+    "object": "object",
+}
+
+
+def _param_type_to_json(type_str: str) -> str:
+    """Convert a gptme parameter type string to a JSON Schema type."""
+    return _PARAM_TYPE_MAP.get(type_str.lower(), "string")
+
+
+def _toolspec_to_mcp_tool(tool: ToolSpec) -> types.Tool:
+    """Convert a gptme ToolSpec to an MCP Tool with JSON Schema input schema."""
+    properties: dict[str, Any] = {}
+    required: list[str] = []
+
+    for param in tool.parameters:
+        prop: dict[str, Any] = {"type": _param_type_to_json(param.type)}
+        if param.description:
+            prop["description"] = param.description
+        if param.enum:
+            prop["enum"] = param.enum
+        properties[param.name] = prop
+        if param.required:
+            required.append(param.name)
+
+    input_schema: dict[str, Any] = {
+        "type": "object",
+        "properties": properties,
+    }
+    if required:
+        input_schema["required"] = required
+
+    return types.Tool(
+        name=tool.name,
+        description=tool.desc,
+        inputSchema=input_schema,
+    )
+
+
+def _collect_tool_output(gen: Generator[Any, None, None]) -> str:
+    """Collect text output from a tool execute() generator."""
+    return "\n".join(msg.content for msg in gen if msg.content)
+
+
+class GptmeMCPServer:
+    """Session-backed MCP server that exposes gptme tools to MCP clients.
+
+    One server instance = one persistent gptme session, so bash retains shell
+    state, the Python REPL persists variables, etc. across multiple tool calls.
+    """
+
+    def __init__(
+        self,
+        tool_names: list[str] | None = None,
+        workspace: str | None = None,
+    ) -> None:
+        self._tool_names = [
+            t for t in (tool_names or DEFAULT_TOOLS) if t not in _EXCLUDED_TOOLS
+        ]
+        self._workspace = workspace
+        self._server = Server("gptme")
+        self._loaded_tools: list[ToolSpec] = []
+        self._setup_handlers()
+
+    def _setup_handlers(self) -> None:
+        server = self._server
+
+        @server.list_tools()
+        async def handle_list_tools() -> list[types.Tool]:
+            return [
+                _toolspec_to_mcp_tool(t)
+                for t in self._loaded_tools
+                if t.execute is not None
+            ]
+
+        @server.call_tool()
+        async def handle_call_tool(
+            name: str, arguments: dict
+        ) -> list[types.TextContent | types.ImageContent | types.EmbeddedResource]:
+            tool = next((t for t in self._loaded_tools if t.name == name), None)
+            if tool is None:
+                raise ValueError(f"Tool '{name}' not found in loaded tools")
+            if tool.execute is None:
+                raise ValueError(f"Tool '{name}' has no execute function")
+
+            # All arguments arrive as kwargs; each tool's execute() checks kwargs
+            # first (or alongside code/args) so this mapping is universal.
+            kwargs = {k: str(v) for k, v in arguments.items()} if arguments else {}
+
+            # Call tool.execute() directly with kwargs — avoids thread-local registry
+            # lookup in ToolUse.execute(). Auto-confirm is handled by the registered
+            # hook (register_auto_confirm called in _init_tools).
+            def _run_tool() -> str:
+                result = tool.execute(None, None, kwargs)  # type: ignore[misc]
+                if hasattr(result, "__iter__"):
+                    return _collect_tool_output(result)  # type: ignore[arg-type]
+                return str(result.content) if result and result.content else ""
+
+            # Run in a thread executor to avoid blocking the event loop during
+            # long-running operations (bash commands, Python REPL, etc.)
+            loop = asyncio.get_event_loop()
+            output = await loop.run_in_executor(None, _run_tool)
+
+            return [types.TextContent(type="text", text=output or "(no output)")]
+
+    def _init_tools(self) -> None:
+        """Initialize gptme tools and register auto-confirm for non-interactive use."""
+        from ..hooks.auto_confirm import register as register_auto_confirm
+
+        register_auto_confirm()
+        self._loaded_tools = init_tools(self._tool_names)
+        logger.info(
+            "Loaded tools: %s", [t.name for t in self._loaded_tools if t.execute]
+        )
+
+    def serve_stdio(self) -> None:
+        """Run the MCP server over stdio (for Claude Desktop and similar clients)."""
+        self._init_tools()
+
+        async def _run() -> None:
+            async with mcp.server.stdio.stdio_server() as (read_stream, write_stream):
+                await self._server.run(
+                    read_stream,
+                    write_stream,
+                    self._server.create_initialization_options(),
+                )
+
+        asyncio.run(_run())
+
+
+def create_server(
+    tool_names: list[str] | None = None,
+    workspace: str | None = None,
+) -> GptmeMCPServer:
+    """Create and return a GptmeMCPServer instance."""
+    return GptmeMCPServer(tool_names=tool_names, workspace=workspace)

--- a/gptme/mcp/server.py
+++ b/gptme/mcp/server.py
@@ -34,6 +34,7 @@ if TYPE_CHECKING:
     from collections.abc import Generator
 
     from ..tools.base import ToolSpec
+    from ..tools.shell import ShellSession
 
 logger = logging.getLogger(__name__)
 
@@ -114,7 +115,24 @@ class GptmeMCPServer:
         self._workspace = workspace
         self._server = Server("gptme")
         self._loaded_tools: list[ToolSpec] = []
+        # Persistent shell session shared across all tool calls. Lazily created
+        # on first use; injected into each executor thread via _shell_var so that
+        # stateful tools (shell, ipython) retain state between MCP requests.
+        self._shell_session: ShellSession | None = None
         self._setup_handlers()
+
+    def _get_or_create_shell_session(self) -> ShellSession:
+        """Lazily create and return the server's persistent shell session.
+
+        Called from inside executor threads; the returned session is then injected
+        into the thread's ContextVar copy so that subsequent get_shell() calls in
+        that thread return the same subprocess instead of spawning a fresh one.
+        """
+        if self._shell_session is None:
+            from ..tools.shell import ShellSession
+
+            self._shell_session = ShellSession(cwd=self._workspace)
+        return self._shell_session
 
     def _setup_handlers(self) -> None:
         server = self._server
@@ -145,10 +163,27 @@ class GptmeMCPServer:
             # lookup in ToolUse.execute(). Auto-confirm is handled by the registered
             # hook (register_auto_confirm called in _init_tools).
             def _run_tool() -> str:
+                # run_in_executor copies the async context via copy_context(), so
+                # _shell_var resets to None in each new thread — every call would
+                # spawn a fresh subprocess, breaking the advertised shell persistence.
+                # Pre-seed the ContextVar with the server's persistent session so
+                # get_shell() reuses it instead of creating a new one.
+                from ..tools.shell import _shell_var as _shell_ctxvar
+
+                _shell_ctxvar.set(self._get_or_create_shell_session())
+
                 result = tool.execute(None, None, kwargs)  # type: ignore[misc]
                 if hasattr(result, "__iter__"):
-                    return _collect_tool_output(result)  # type: ignore[arg-type]
-                return str(result.content) if result and result.content else ""
+                    output = _collect_tool_output(result)  # type: ignore[arg-type]
+                else:
+                    output = str(result.content) if result and result.content else ""
+
+                # Sync back any session replaced during execution (e.g. by set_shell).
+                updated = _shell_ctxvar.get()
+                if updated is not None:
+                    self._shell_session = updated
+
+                return output
 
             # Run in a thread executor to avoid blocking the event loop during
             # long-running operations (bash commands, Python REPL, etc.)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ gptme-dspy = "gptme.eval.dspy:main"
 gptme-eval-trends = "gptme.eval.trends:main"
 gptme-status = "gptme.cli.cmd_status:status"
 gptme-resume = "gptme.cli.cmd_resume:resume"
+gptme-mcp-server = "gptme.cli.cmd_mcp_serve:main"
 
 [tool.poetry]
 packages = [

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -189,8 +189,8 @@ class TestMCPServerHandlers:
         result = await server_with_mock_tools._server.request_handlers[
             types.ListToolsRequest
         ](req)
-        assert result.root.tools  # type: ignore[attr-defined]
-        tool_names = [t.name for t in result.root.tools]  # type: ignore[attr-defined]
+        assert result.root.tools  # type: ignore[union-attr]
+        tool_names = [t.name for t in result.root.tools]  # type: ignore[union-attr]
         assert "shell" in tool_names
 
     @pytest.mark.asyncio
@@ -208,7 +208,7 @@ class TestMCPServerHandlers:
 
         req = types.ListToolsRequest(method="tools/list", params=None)
         result = await server._server.request_handlers[types.ListToolsRequest](req)
-        tool_names = [t.name for t in result.root.tools]  # type: ignore[attr-defined]
+        tool_names = [t.name for t in result.root.tools]  # type: ignore[union-attr]
         assert "noexec" not in tool_names
 
     @pytest.mark.asyncio
@@ -226,10 +226,10 @@ class TestMCPServerHandlers:
             types.CallToolRequest
         ](req)
         # MCP wraps handler exceptions into an isError=True CallToolResult
-        assert result.root.isError is True  # type: ignore[attr-defined]
+        assert result.root.isError is True  # type: ignore[union-attr]
         assert any(
             "nonexistent" in c.text
-            for c in result.root.content  # type: ignore[attr-defined]
+            for c in result.root.content  # type: ignore[union-attr]
             if hasattr(c, "text")
         )
 
@@ -266,7 +266,7 @@ class TestMCPServerHandlers:
             types.CallToolRequest
         ](req)
 
-        content = result.root.content  # type: ignore[attr-defined]
+        content = result.root.content  # type: ignore[union-attr]
         assert any("hello from tool" in c.text for c in content if hasattr(c, "text"))
 
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -6,6 +6,8 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+pytest.importorskip("mcp", reason="mcp extra not installed")
+
 from gptme.mcp.server import (
     _EXCLUDED_TOOLS,
     DEFAULT_TOOLS,

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -271,6 +271,60 @@ class TestMCPServerHandlers:
         content = result.root.content  # type: ignore[union-attr]
         assert any("hello from tool" in c.text for c in content if hasattr(c, "text"))
 
+    @pytest.mark.asyncio
+    async def test_shell_session_reused_across_calls(
+        self, server_with_mock_tools: GptmeMCPServer
+    ) -> None:
+        """The same ShellSession must be injected into every executor thread.
+
+        run_in_executor copies the async context via copy_context(), so _shell_var
+        resets to None in each thread without explicit injection. This test verifies
+        that the server pre-seeds _shell_var with its persistent session so stateful
+        tools (shell, ipython) see the same subprocess on every call.
+        """
+        from unittest.mock import MagicMock
+
+        import mcp.types as types
+
+        from gptme.message import Message
+        from gptme.tools.shell import _shell_var
+
+        # Use a MagicMock so we avoid spawning a real bash subprocess in tests.
+        mock_session = MagicMock()
+        server_with_mock_tools._shell_session = mock_session  # type: ignore[assignment]
+
+        captured_sessions: list[object] = []
+
+        def session_spy(code, args, kwargs):
+            captured_sessions.append(_shell_var.get())
+            yield Message("system", "ok")
+
+        server_with_mock_tools._loaded_tools[0] = ToolSpec(
+            name="shell",
+            desc="Shell.",
+            execute=session_spy,
+            block_types=["shell"],
+            parameters=[Parameter(name="command", type="string", required=True)],
+        )
+
+        req = types.CallToolRequest(
+            method="tools/call",
+            params=types.CallToolRequestParams(
+                name="shell", arguments={"command": "echo test"}
+            ),
+        )
+        handlers = server_with_mock_tools._server.request_handlers
+        await handlers[types.CallToolRequest](req)
+        await handlers[types.CallToolRequest](req)
+
+        assert len(captured_sessions) == 2, "spy must run twice"
+        assert captured_sessions[0] is mock_session, (
+            "First call must see the persistent session"
+        )
+        assert captured_sessions[1] is mock_session, (
+            "Second call must reuse the same session"
+        )
+
 
 class TestMCPServerCLI:
     """Tests for the gptme-mcp-server CLI command."""

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -347,3 +347,140 @@ class TestMCPServerCLI:
         runner = CliRunner()
         result = runner.invoke(main, ["--log-level", "INVALID"])
         assert result.exit_code != 0
+
+
+class TestWorkspaceHandling:
+    """Tests for --workspace CWD behaviour."""
+
+    def test_serve_stdio_changes_cwd_to_workspace(self, tmp_path) -> None:
+        """serve_stdio must os.chdir to the workspace so file tools use the right dir."""
+        from unittest.mock import patch
+
+        server = GptmeMCPServer(workspace=str(tmp_path))
+
+        chdir_calls: list[str] = []
+
+        # Close the coroutine passed to asyncio.run to avoid "was never awaited" warning.
+        def _drain_coro(coro):
+            coro.close()
+
+        with (
+            patch("gptme.mcp.server.os.chdir", side_effect=chdir_calls.append),
+            patch.object(server, "_init_tools"),
+            patch("asyncio.run", side_effect=_drain_coro),
+        ):
+            server.serve_stdio()
+
+        assert chdir_calls == [str(tmp_path)], (
+            f"Expected os.chdir({tmp_path!s}) but got {chdir_calls}"
+        )
+
+    def test_serve_stdio_no_chdir_without_workspace(self) -> None:
+        """serve_stdio must not call os.chdir when workspace is None."""
+        from unittest.mock import patch
+
+        server = GptmeMCPServer(workspace=None)
+
+        def _drain_coro(coro):
+            coro.close()
+
+        with (
+            patch("gptme.mcp.server.os.chdir") as mock_chdir,
+            patch.object(server, "_init_tools"),
+            patch("asyncio.run", side_effect=_drain_coro),
+        ):
+            server.serve_stdio()
+
+        mock_chdir.assert_not_called()
+
+
+class TestToolCallSerialization:
+    """Tests for per-call asyncio.Lock preventing concurrent stateful access."""
+
+    def test_server_has_tool_call_lock(self) -> None:
+        """GptmeMCPServer must expose a _tool_call_lock for serializing calls."""
+        import asyncio
+
+        server = GptmeMCPServer()
+        assert isinstance(server._tool_call_lock, asyncio.Lock)
+
+    @pytest.mark.asyncio
+    async def test_concurrent_calls_are_serialized(self, simple_tool: ToolSpec) -> None:
+        """Two overlapping MCP tool calls must not interleave inside the lock."""
+        import asyncio
+
+        import mcp.types as types
+
+        from gptme.message import Message
+
+        order: list[str] = []
+
+        def sync_execute(code, args, kwargs):
+            order.append("start")
+            # Yield to the event loop once; a non-serializing server would let
+            # a second call start here before this one appends "end".
+            order.append("end")
+            yield Message("system", "done")
+
+        server = GptmeMCPServer(tool_names=["shell"])
+        server._loaded_tools = [
+            ToolSpec(
+                name="shell",
+                desc="Shell.",
+                execute=sync_execute,
+                block_types=["shell"],
+                parameters=[Parameter(name="command", type="string", required=True)],
+            )
+        ]
+
+        req = types.CallToolRequest(
+            method="tools/call",
+            params=types.CallToolRequestParams(
+                name="shell", arguments={"command": "echo test"}
+            ),
+        )
+        handler = server._server.request_handlers[types.CallToolRequest]
+        await asyncio.gather(handler(req), handler(req))
+
+        # Serialized order must be start,end,start,end — never start,start,...
+        assert order == ["start", "end", "start", "end"], (
+            f"Tool calls interleaved: {order}"
+        )
+
+
+class TestLazyServerImport:
+    """Tests for P2: client imports must not trigger server module loading."""
+
+    def test_mcp_client_import_does_not_load_server_module(self) -> None:
+        """from gptme.mcp import MCPClient must not import gptme.mcp.server."""
+        import sys
+
+        # Remove the server module from the cache (if already loaded by this test run).
+        for key in list(sys.modules):
+            if key == "gptme.mcp.server" or key.startswith("gptme.mcp.server."):
+                del sys.modules[key]
+
+        # Importing MCPClient should NOT cause server.py to be loaded.
+        from gptme.mcp import MCPClient  # noqa: F401
+
+        assert "gptme.mcp.server" not in sys.modules, (
+            "Importing MCPClient triggered gptme.mcp.server import — "
+            "this loads the full tools package as a side-effect."
+        )
+
+    def test_lazy_getattr_loads_server_on_demand(self) -> None:
+        """Accessing GptmeMCPServer via gptme.mcp triggers the lazy import."""
+        import sys
+
+        # Ensure server module is not in cache.
+        for key in list(sys.modules):
+            if key == "gptme.mcp.server" or key.startswith("gptme.mcp.server."):
+                del sys.modules[key]
+
+        import gptme.mcp as mcp_pkg
+
+        _ = mcp_pkg.GptmeMCPServer  # trigger __getattr__
+
+        assert "gptme.mcp.server" in sys.modules, (
+            "Accessing GptmeMCPServer should load gptme.mcp.server lazily."
+        )

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,293 @@
+"""Tests for the gptme MCP server (gptme/mcp/server.py)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from gptme.mcp.server import (
+    _EXCLUDED_TOOLS,
+    DEFAULT_TOOLS,
+    GptmeMCPServer,
+    _toolspec_to_mcp_tool,
+    create_server,
+)
+from gptme.tools.base import Parameter, ToolSpec
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from gptme.message import Message
+
+
+def _noop_execute(
+    code: str | None, args: list[str] | None, kwargs: dict[str, str] | None
+) -> Generator[Message, None, None]:
+    return
+    yield  # make it a generator
+
+
+@pytest.fixture
+def simple_tool() -> ToolSpec:
+    """A minimal ToolSpec for use in schema tests."""
+    return ToolSpec(
+        name="shell",
+        desc="Executes shell commands.",
+        execute=_noop_execute,
+        block_types=["shell"],
+        parameters=[
+            Parameter(
+                name="command",
+                type="string",
+                description="The shell command to execute.",
+                required=True,
+            ),
+        ],
+    )
+
+
+@pytest.fixture
+def multi_param_tool() -> ToolSpec:
+    """A ToolSpec with multiple parameters to test schema mapping."""
+    return ToolSpec(
+        name="read",
+        desc="Read files.",
+        execute=_noop_execute,
+        block_types=["read"],
+        parameters=[
+            Parameter(
+                name="path", type="string", description="File path.", required=True
+            ),
+            Parameter(
+                name="start_line",
+                type="integer",
+                description="Start line.",
+                required=False,
+            ),
+            Parameter(
+                name="end_line", type="integer", description="End line.", required=False
+            ),
+        ],
+    )
+
+
+class TestToolspecToMcpTool:
+    """Tests for _toolspec_to_mcp_tool schema conversion."""
+
+    def test_basic_conversion(self, simple_tool: ToolSpec) -> None:
+        mcp_tool = _toolspec_to_mcp_tool(simple_tool)
+        assert mcp_tool.name == "shell"
+        assert mcp_tool.description == "Executes shell commands."
+
+    def test_required_param_in_schema(self, simple_tool: ToolSpec) -> None:
+        mcp_tool = _toolspec_to_mcp_tool(simple_tool)
+        schema = mcp_tool.inputSchema
+        assert schema["type"] == "object"
+        assert "command" in schema["properties"]
+        assert schema["properties"]["command"]["type"] == "string"
+        assert "command" in schema["required"]
+
+    def test_optional_params_not_in_required(self, multi_param_tool: ToolSpec) -> None:
+        mcp_tool = _toolspec_to_mcp_tool(multi_param_tool)
+        schema = mcp_tool.inputSchema
+        assert "path" in schema["required"]
+        assert "start_line" not in schema["required"]
+        assert "end_line" not in schema["required"]
+
+    def test_integer_type_mapping(self, multi_param_tool: ToolSpec) -> None:
+        mcp_tool = _toolspec_to_mcp_tool(multi_param_tool)
+        schema = mcp_tool.inputSchema
+        assert schema["properties"]["start_line"]["type"] == "integer"
+        assert schema["properties"]["end_line"]["type"] == "integer"
+
+    def test_empty_parameters(self) -> None:
+        tool = ToolSpec(
+            name="noparams",
+            desc="No parameters.",
+            execute=_noop_execute,
+            block_types=["noparams"],
+            parameters=[],
+        )
+        mcp_tool = _toolspec_to_mcp_tool(tool)
+        schema = mcp_tool.inputSchema
+        assert schema["type"] == "object"
+        assert schema["properties"] == {}
+        assert "required" not in schema
+
+    def test_description_in_property(self, simple_tool: ToolSpec) -> None:
+        mcp_tool = _toolspec_to_mcp_tool(simple_tool)
+        prop = mcp_tool.inputSchema["properties"]["command"]
+        assert prop.get("description") == "The shell command to execute."
+
+    def test_enum_param(self) -> None:
+        tool = ToolSpec(
+            name="enumtool",
+            desc="Enum tool.",
+            execute=_noop_execute,
+            block_types=["enumtool"],
+            parameters=[
+                Parameter(
+                    name="mode",
+                    type="string",
+                    description="Mode.",
+                    enum=["fast", "slow"],
+                    required=True,
+                ),
+            ],
+        )
+        mcp_tool = _toolspec_to_mcp_tool(tool)
+        prop = mcp_tool.inputSchema["properties"]["mode"]
+        assert prop["enum"] == ["fast", "slow"]
+
+
+class TestGptmeMCPServer:
+    """Tests for GptmeMCPServer construction and tool filtering."""
+
+    def test_default_tools(self) -> None:
+        server = GptmeMCPServer()
+        assert server._tool_names == DEFAULT_TOOLS
+
+    def test_excluded_tools_filtered_out(self) -> None:
+        tool_names = ["shell", "subagent", "mcp", "ipython"]
+        server = GptmeMCPServer(tool_names=tool_names)
+        for excluded in _EXCLUDED_TOOLS:
+            assert excluded not in server._tool_names
+
+    def test_custom_tools(self) -> None:
+        server = GptmeMCPServer(tool_names=["shell", "read"])
+        assert server._tool_names == ["shell", "read"]
+
+    def test_workspace_stored(self) -> None:
+        server = GptmeMCPServer(workspace="/tmp/test")
+        assert server._workspace == "/tmp/test"
+
+    def test_create_server_factory(self) -> None:
+        server = create_server(tool_names=["shell"])
+        assert isinstance(server, GptmeMCPServer)
+        assert server._tool_names == ["shell"]
+
+
+class TestMCPServerHandlers:
+    """Tests for the MCP request handlers using mock tools."""
+
+    @pytest.fixture
+    def server_with_mock_tools(self, simple_tool: ToolSpec) -> GptmeMCPServer:
+        server = GptmeMCPServer(tool_names=["shell"])
+        server._loaded_tools = [simple_tool]
+        return server
+
+    @pytest.mark.asyncio
+    async def test_list_tools_returns_loaded(
+        self, server_with_mock_tools: GptmeMCPServer
+    ) -> None:
+        """list_tools handler returns tools that have an execute function."""
+        # Access the registered handler directly via server's request_handlers
+        import mcp.types as types
+
+        req = types.ListToolsRequest(method="tools/list", params=None)
+        result = await server_with_mock_tools._server.request_handlers[
+            types.ListToolsRequest
+        ](req)
+        assert result.root.tools  # type: ignore[attr-defined]
+        tool_names = [t.name for t in result.root.tools]  # type: ignore[attr-defined]
+        assert "shell" in tool_names
+
+    @pytest.mark.asyncio
+    async def test_list_tools_excludes_no_execute(self) -> None:
+        """Tools without an execute function are not listed."""
+        import mcp.types as types
+
+        no_execute_tool = ToolSpec(
+            name="noexec",
+            desc="No execute.",
+            parameters=[],
+        )
+        server = GptmeMCPServer(tool_names=["noexec"])
+        server._loaded_tools = [no_execute_tool]
+
+        req = types.ListToolsRequest(method="tools/list", params=None)
+        result = await server._server.request_handlers[types.ListToolsRequest](req)
+        tool_names = [t.name for t in result.root.tools]  # type: ignore[attr-defined]
+        assert "noexec" not in tool_names
+
+    @pytest.mark.asyncio
+    async def test_call_tool_unknown_returns_error(
+        self, server_with_mock_tools: GptmeMCPServer
+    ) -> None:
+        """call_tool for an unknown tool name returns an error result."""
+        import mcp.types as types
+
+        req = types.CallToolRequest(
+            method="tools/call",
+            params=types.CallToolRequestParams(name="nonexistent", arguments={}),
+        )
+        result = await server_with_mock_tools._server.request_handlers[
+            types.CallToolRequest
+        ](req)
+        # MCP wraps handler exceptions into an isError=True CallToolResult
+        assert result.root.isError is True  # type: ignore[attr-defined]
+        assert any(
+            "nonexistent" in c.text
+            for c in result.root.content  # type: ignore[attr-defined]
+            if hasattr(c, "text")
+        )
+
+    @pytest.mark.asyncio
+    async def test_call_tool_collects_output(
+        self, server_with_mock_tools: GptmeMCPServer
+    ) -> None:
+        """call_tool executes the tool and returns text output."""
+        import mcp.types as types
+
+        from gptme.message import Message
+
+        def fake_execute(code, args, kwargs):
+            yield Message("system", "hello from tool")
+
+        server_with_mock_tools._loaded_tools[0] = ToolSpec(
+            name="shell",
+            desc="Shell.",
+            execute=fake_execute,
+            block_types=["shell"],
+            parameters=[
+                Parameter(name="command", type="string", required=True),
+            ],
+        )
+
+        req = types.CallToolRequest(
+            method="tools/call",
+            params=types.CallToolRequestParams(
+                name="shell", arguments={"command": "echo hi"}
+            ),
+        )
+
+        result = await server_with_mock_tools._server.request_handlers[
+            types.CallToolRequest
+        ](req)
+
+        content = result.root.content  # type: ignore[attr-defined]
+        assert any("hello from tool" in c.text for c in content if hasattr(c, "text"))
+
+
+class TestMCPServerCLI:
+    """Tests for the gptme-mcp-server CLI command."""
+
+    def test_cli_help(self) -> None:
+        from click.testing import CliRunner
+
+        from gptme.cli.cmd_mcp_serve import main
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["--help"])
+        assert result.exit_code == 0
+        assert "gptme tools" in result.output or "MCP" in result.output
+
+    def test_cli_invalid_log_level(self) -> None:
+        from click.testing import CliRunner
+
+        from gptme.cli.cmd_mcp_serve import main
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["--log-level", "INVALID"])
+        assert result.exit_code != 0

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -291,7 +291,7 @@ class TestMCPServerHandlers:
 
         # Use a MagicMock so we avoid spawning a real bash subprocess in tests.
         mock_session = MagicMock()
-        server_with_mock_tools._shell_session = mock_session  # type: ignore[assignment]
+        server_with_mock_tools._shell_session = mock_session
 
         captured_sessions: list[object] = []
 


### PR DESCRIPTION
## Summary

Implements gptme as an MCP **server** (inverting the existing client direction). Claude Desktop, Cursor, and any MCP-compatible tool can now use gptme's tools directly.

- `gptme/mcp/server.py` — `GptmeMCPServer` using `mcp.server.lowlevel.Server`. Maps `ToolSpec.parameters` → JSON Schema for `tools/list`; dispatches `tools/call` directly to `tool.execute(None, None, kwargs)`. Auto-confirm is registered so no interactive prompts block execution. Session-backed: bash shell retains state, Python REPL persists variables across calls.
- `gptme/cli/cmd_mcp_serve.py` — `gptme-mcp-server` CLI entrypoint with `--tools`, `--workspace`, `--log-level` flags.
- `tests/test_mcp_server.py` — 18 tests: schema conversion, server construction, handler behavior, CLI.
- `pyproject.toml` — adds `gptme-mcp-server` script entry point.
- `gptme/mcp/__init__.py` — exports `GptmeMCPServer` and `create_server`.

**Default tools**: `shell, ipython, save, append, read`. Excluded: `subagent` (recursive agents via MCP is risky) and `mcp` (circular).

**Claude Desktop config** (3 lines to add):
```json
{
  "mcpServers": {
    "gptme": {
      "command": "gptme-mcp-server",
      "args": ["--tools", "shell,ipython,save,read"]
    }
  }
}
```

## Test plan

- [x] 18 unit tests pass (`tests/test_mcp_server.py`)
- [x] All existing MCP tests still pass (`tests/test_mcp.py`)
- [x] Pre-commit hooks pass (ruff, mypy, format)
- [x] `gptme-mcp-server --help` works after install
- [ ] Manual smoke test: connect Claude Desktop and run `echo hello` via bash tool

Closes #3156