### PR TITLE
feat(cli): add GPTME_EXIT_STATS for machine-readable session cost summary

### DIFF
--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -31,7 +31,7 @@ import gptme
 
 from ..chat import chat
 from ..commands import _gen_help
-from ..config import ensure_workspace_dir, setup_config_from_cli
+from ..config import ensure_workspace_dir, get_config, setup_config_from_cli
 from ..constants import MULTIPROMPT_SEPARATOR
 from ..dirs import get_logs_dir
 from ..init import init_logging
@@ -1330,7 +1330,7 @@ def main(
         sys.exit(1)
     finally:
         shutdown_telemetry()
-        if os.getenv("GPTME_EXIT_STATS"):
+        if get_config().get_env_bool("GPTME_EXIT_STATS"):
             from ..util.cost import print_exit_stats
 
             print_exit_stats()

--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -1330,6 +1330,10 @@ def main(
         sys.exit(1)
     finally:
         shutdown_telemetry()
+        if os.getenv("GPTME_EXIT_STATS"):
+            from ..util.cost import print_exit_stats
+
+            print_exit_stats()
 
 
 def pick_log(limit=20) -> Path:  # pragma: no cover

--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -1331,9 +1331,12 @@ def main(
     finally:
         shutdown_telemetry()
         if get_config().get_env_bool("GPTME_EXIT_STATS"):
-            from ..util.cost import print_exit_stats
+            try:
+                from ..util.cost import print_exit_stats
 
-            print_exit_stats()
+                print_exit_stats()
+            except Exception:
+                pass
 
 
 def pick_log(limit=20) -> Path:  # pragma: no cover

--- a/gptme/util/cost.py
+++ b/gptme/util/cost.py
@@ -1,3 +1,6 @@
+import json
+import sys
+
 from ..message import Message, len_tokens
 from . import console
 
@@ -66,3 +69,28 @@ def log_costs(msgs: list[Message]) -> None:
         if turns > 1:
             cost_msg += f" (session: ${sum(costs):.2f})"
         console.log(cost_msg)
+
+
+def print_exit_stats() -> None:
+    """Print a JSON session cost summary to stderr.
+
+    Uses API-reported token counts from CostTracker (more accurate than the
+    message-length estimates in log_costs). Enable with GPTME_EXIT_STATS=1
+    so harnesses that spawn gptme as a subprocess can parse per-session costs
+    without requiring a full OpenTelemetry stack.
+
+    Output format (one JSON line on stderr)::
+
+        {"session_id": "...", "total_cost": 0.05, "total_input_tokens": 12000,
+         "total_output_tokens": 800, "cache_read_tokens": 9000,
+         "cache_creation_tokens": 3000, "cache_hit_rate": 0.75,
+         "request_count": 5}
+
+    No output if no LLM requests were made in the session.
+    """
+    from .cost_tracker import CostTracker
+
+    summary = CostTracker.get_summary()
+    if summary is None or summary.request_count == 0:
+        return
+    print(json.dumps(summary.to_dict()), file=sys.stderr, flush=True)

--- a/tests/test_util_cost.py
+++ b/tests/test_util_cost.py
@@ -1,11 +1,13 @@
 """Tests for gptme.util.cost — token counting and cost calculation."""
 
+import json
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from gptme.message import Message
-from gptme.util.cost import _cost, _tokens_inout
+from gptme.util.cost import _cost, _tokens_inout, print_exit_stats
+from gptme.util.cost_tracker import CostEntry, CostTracker
 
 # ──────────────────────────────────────────────
 # _tokens_inout
@@ -141,3 +143,76 @@ class TestCost:
         with patch.object(Message, "cost", return_value=0.0):
             result = _cost(msgs)
         assert result == 0.0
+
+
+# ──────────────────────────────────────────────
+# print_exit_stats
+# ──────────────────────────────────────────────
+
+
+class TestPrintExitStats:
+    @pytest.fixture(autouse=True)
+    def reset_tracker(self):
+        CostTracker.reset()
+        yield
+        CostTracker.reset()
+
+    def test_emits_json_to_stderr(self, capsys):
+        """print_exit_stats writes a JSON cost summary to stderr."""
+        CostTracker.start_session("test-exit")
+        CostTracker.record(
+            CostEntry(
+                timestamp=1.0,
+                model="anthropic/claude-sonnet-4-5",
+                input_tokens=1000,
+                output_tokens=200,
+                cache_read_tokens=800,
+                cache_creation_tokens=300,
+                cost=0.012,
+            )
+        )
+        print_exit_stats()
+        captured = capsys.readouterr()
+        assert captured.out == ""  # nothing on stdout
+        data = json.loads(captured.err)
+        assert data["total_input_tokens"] == 1000
+        assert data["total_output_tokens"] == 200
+        assert data["cache_read_tokens"] == 800
+        assert data["cache_creation_tokens"] == 300
+        assert data["request_count"] == 1
+        assert abs(data["total_cost"] - 0.012) < 1e-9
+
+    def test_silent_when_no_session(self, capsys):
+        """No output when CostTracker has no active session."""
+        print_exit_stats()
+        captured = capsys.readouterr()
+        assert captured.err == ""
+
+    def test_silent_when_no_requests(self, capsys):
+        """No output when session started but no LLM requests were made."""
+        CostTracker.start_session("empty-session")
+        print_exit_stats()
+        captured = capsys.readouterr()
+        assert captured.err == ""
+
+    def test_aggregates_multiple_requests(self, capsys):
+        """Totals across multiple requests are correctly summed."""
+        CostTracker.start_session("multi-request")
+        for i in range(3):
+            CostTracker.record(
+                CostEntry(
+                    timestamp=float(i),
+                    model="test-model",
+                    input_tokens=100,
+                    output_tokens=50,
+                    cache_read_tokens=0,
+                    cache_creation_tokens=0,
+                    cost=0.001,
+                )
+            )
+        print_exit_stats()
+        data = json.loads(capsys.readouterr().err)
+        assert data["request_count"] == 3
+        assert data["total_input_tokens"] == 300
+        assert data["total_output_tokens"] == 150
+        assert abs(data["total_cost"] - 0.003) < 1e-9


### PR DESCRIPTION
Adds GPTME_EXIT_STATS=1 env var: prints JSON session cost summary to stderr on exit. Uses CostTracker (API-level tokens, more accurate than message-length estimates). Silent when no requests made. Consistent with existing GPTME_COSTS pattern.