### PR TITLE
feat(acp): add gptme-acp shim package for ACP agent registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -254,12 +254,6 @@ jobs:
         rm -f dist/*.whl dist/*.tar.gz
         poetry build
 
-    - name: Build gptme-acp shim
-      run: |
-        pip install build
-        cd packages/gptme-acp
-        python -m build
-
     - name: Validate package (dry-run publish)
       run: |
         # Dry-run validates artifact structure and metadata — no upload, no auth check
@@ -270,7 +264,15 @@ jobs:
         POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_TOKEN }}
       run: poetry publish
 
+    - name: Build gptme-acp shim
+      continue-on-error: true
+      run: |
+        pip install build
+        cd packages/gptme-acp
+        python -m build
+
     - name: Publish gptme-acp shim to PyPI
+      continue-on-error: true
       env:
         TWINE_USERNAME: __token__
         TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
@@ -288,7 +290,11 @@ jobs:
           echo "Waiting for release $TAG to become visible... ($i/5)"
           sleep 5
         done
-        gh release upload "$TAG" dist/*.whl dist/*.tar.gz packages/gptme-acp/dist/*.whl packages/gptme-acp/dist/*.tar.gz --clobber
+        gh release upload "$TAG" dist/*.whl dist/*.tar.gz --clobber
+        # Upload shim artifacts if the shim was built successfully
+        if ls packages/gptme-acp/dist/*.whl 2>/dev/null; then
+          gh release upload "$TAG" packages/gptme-acp/dist/*.whl packages/gptme-acp/dist/*.tar.gz --clobber
+        fi
 
     - name: Trigger artifact builds
       env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -254,6 +254,12 @@ jobs:
         rm -f dist/*.whl dist/*.tar.gz
         poetry build
 
+    - name: Build gptme-acp shim
+      run: |
+        pip install build
+        cd packages/gptme-acp
+        python -m build
+
     - name: Validate package (dry-run publish)
       run: |
         # Dry-run validates artifact structure and metadata — no upload, no auth check
@@ -263,6 +269,14 @@ jobs:
       env:
         POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_TOKEN }}
       run: poetry publish
+
+    - name: Publish gptme-acp shim to PyPI
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+      run: |
+        pip install twine
+        twine upload packages/gptme-acp/dist/*
 
     - name: Upload packages to GitHub release
       env:
@@ -274,7 +288,7 @@ jobs:
           echo "Waiting for release $TAG to become visible... ($i/5)"
           sleep 5
         done
-        gh release upload "$TAG" dist/*.whl dist/*.tar.gz --clobber
+        gh release upload "$TAG" dist/*.whl dist/*.tar.gz packages/gptme-acp/dist/*.whl packages/gptme-acp/dist/*.tar.gz --clobber
 
     - name: Trigger artifact builds
       env:

--- a/docs/acp.rst
+++ b/docs/acp.rst
@@ -14,17 +14,27 @@ This enables a seamless integration where your editor can leverage gptme's power
 Installation
 ------------
 
-To use gptme as an ACP agent, install with the ``acp`` extra:
+**Quickest (no install required)**
+
+.. code-block:: bash
+
+    uvx gptme-acp
+
+``gptme-acp`` is a thin shim package that pulls in ``gptme[acp]`` and exposes the ACP server as its default executable.  This is the form used by editor integrations and the `ACP agent registry <https://github.com/agentclientprotocol/registry>`_.
+
+**Persistent install via pipx**
+
+.. code-block:: bash
+
+    pipx install gptme-acp
+    gptme-acp
+
+**Direct install of gptme with the acp extra**
 
 .. code-block:: bash
 
     pipx install 'gptme[acp]'
-
-Or with pip:
-
-.. code-block:: bash
-
-    pip install 'gptme[acp]'
+    gptme-acp
 
 Usage
 -----
@@ -36,10 +46,30 @@ Start the gptme ACP agent:
 
 .. code-block:: bash
 
-    # Via module
+    # Recommended: via the gptme-acp shim (no install needed)
+    uvx gptme-acp
+
+    # Or directly if gptme[acp] is installed
+    gptme-acp
+
+    # Or via module
     python -m gptme.acp
 
 The agent communicates via stdio using the ACP protocol, making it compatible with any ACP client.
+
+ACP Agent Registry
+~~~~~~~~~~~~~~~~~~
+
+gptme can be discovered and launched automatically by ACP-compatible editors via the `ACP agent registry <https://github.com/agentclientprotocol/registry>`_.  The registry entry uses the ``gptme-acp`` package:
+
+.. code-block:: json
+
+    {
+      "package": "gptme-acp",
+      "launch": {"type": "uvx"}
+    }
+
+The separate ``gptme-acp`` package is necessary because the registry only supports launching the default executable of a plain PyPI package name — extras-qualified specs (``gptme[acp]``) and ``--from`` flags are not supported.
 
 Editor Integration
 ~~~~~~~~~~~~~~~~~~

--- a/packages/gptme-acp/README.md
+++ b/packages/gptme-acp/README.md
@@ -1,0 +1,54 @@
+# gptme-acp
+
+ACP (Agent Client Protocol) entry point for [gptme](https://github.com/gptme/gptme).
+
+This is a thin shim package that allows gptme to be listed in the [ACP agent registry](https://github.com/agentclientprotocol/registry) and launched via `uvx`, enabling agent discovery in editors like Zed and JetBrains.
+
+## Usage
+
+### Quick start (no install required)
+
+```bash
+uvx gptme-acp
+```
+
+### Persistent install
+
+```bash
+pipx install gptme-acp
+gptme-acp
+```
+
+## What this package does
+
+`gptme-acp` is a minimal wrapper that:
+
+1. Declares `gptme[acp]` as its dependency (pulls in gptme + the `agent-client-protocol` library)
+2. Exposes `gptme-acp` as its default executable — the ACP server that editors connect to
+
+The agent communicates with editors via JSON-RPC over stdio using the ACP protocol.
+
+## ACP Agent Registry
+
+This package exists so gptme can be listed in the [ACP agent registry](https://github.com/agentclientprotocol/registry):
+
+```json
+{
+  "package": "gptme-acp",
+  "launch": {"type": "uvx"}
+}
+```
+
+The registry powers agent discovery in Zed, JetBrains, and other ACP-compatible editors. Without this package, the registry cannot launch gptme because:
+
+- `uvx gptme` runs the interactive CLI, not the ACP server
+- `uvx --from 'gptme[acp]' gptme-acp` requires `--from`, a shape the registry cannot express
+- Extras-qualified specs like `gptme[acp]` fail the registry's package-existence check
+
+## Configuration
+
+The ACP agent uses gptme's standard configuration (`~/.config/gptme/config.toml`). API keys are read from environment variables (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, etc.).
+
+## Documentation
+
+Full ACP documentation: https://gptme.org/docs/acp.html

--- a/packages/gptme-acp/pyproject.toml
+++ b/packages/gptme-acp/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
 ]
 readme = "README.md"
 license = "MIT"
-requires-python = ">=3.10,<3.15"
+requires-python = ">=3.10"
 dependencies = ["gptme[acp]>=0.31.0"]
 
 [project.urls]

--- a/packages/gptme-acp/pyproject.toml
+++ b/packages/gptme-acp/pyproject.toml
@@ -1,0 +1,29 @@
+[project]
+name = "gptme-acp"
+version = "0.31.0"
+description = "ACP (Agent Client Protocol) entry point for gptme — lets editors like Zed and JetBrains launch gptme via uvx"
+authors = [
+    { name = "Erik Bjäreholt", email = "erik@bjareho.lt" },
+]
+readme = "README.md"
+license = "MIT"
+requires-python = ">=3.10,<3.15"
+dependencies = ["gptme[acp]>=0.31.0"]
+
+[project.urls]
+Homepage = "https://gptme.org/"
+Repository = "https://github.com/gptme/gptme"
+Documentation = "https://gptme.org/docs/acp.html"
+Issues = "https://github.com/gptme/gptme/issues"
+
+[project.scripts]
+gptme-acp = "gptme.acp.__main__:main"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+# No Python source files — the package is purely an entry-point shim.
+# All logic lives in `gptme[acp]` which is a declared dependency.
+packages = []

--- a/scripts/bump_version.sh
+++ b/scripts/bump_version.sh
@@ -91,7 +91,8 @@ if [ -z "$TYPE" ]; then
         echo "The latest tag is ${VERSION_TAG} but the version in pyproject.toml is ${VERSION_PYPROJECT}"
         echo "Updating the version in pyproject.toml to match the latest tag"
         poetry version "${VERSION_TAG}"
-        git add pyproject.toml
+        sed -i "s/^version = \".*\"/version = \"${VERSION_TAG}\"/" packages/gptme-acp/pyproject.toml
+        git add pyproject.toml packages/gptme-acp/pyproject.toml
         git commit -m "chore: bump version to ${VERSION_TAG}" || echo "No version bump needed"
     else
         read -rp "Enter new version number: " VERSION_NEW
@@ -102,7 +103,8 @@ if [ -z "$TYPE" ]; then
         fi
         echo "Bumping version to ${VERSION_NEW}"
         poetry version "${VERSION_NEW}"
-        git add pyproject.toml
+        sed -i "s/^version = \".*\"/version = \"${VERSION_NEW}\"/" packages/gptme-acp/pyproject.toml
+        git add pyproject.toml packages/gptme-acp/pyproject.toml
         git commit -m "chore: bump version to ${VERSION_NEW}"
         git tag -s "v${VERSION_NEW}" -m "v${VERSION_NEW}"
 
@@ -163,8 +165,12 @@ echo "Bumping version: $LAST_STABLE → $TAG (type=$TYPE, pre-release=$PRERELEAS
 poetry version "$NEW_VERSION"
 echo "Updated pyproject.toml: $(grep '^version' pyproject.toml)"
 
+# Also bump gptme-acp shim to keep it in sync with main package
+sed -i "s/^version = \".*\"/version = \"$NEW_VERSION\"/" packages/gptme-acp/pyproject.toml
+echo "Updated packages/gptme-acp/pyproject.toml: $(grep '^version' packages/gptme-acp/pyproject.toml)"
+
 # Commit and tag
-git add pyproject.toml
+git add pyproject.toml packages/gptme-acp/pyproject.toml
 git commit -m "chore: bump version to ${NEW_VERSION}"
 git tag "$TAG"
 echo "Created commit and tag: $TAG"

--- a/scripts/bump_version.sh
+++ b/scripts/bump_version.sh
@@ -29,6 +29,13 @@
 
 set -euo pipefail
 
+# Portable in-place sed: BSD sed (macOS) requires an explicit empty extension;
+# GNU sed uses -i.bak syntax. Using .bak + rm is the only form that works on both.
+_bump_shim_version() {
+    sed -i.bak "s/^version = \".*\"/version = \"$1\"/" packages/gptme-acp/pyproject.toml
+    rm packages/gptme-acp/pyproject.toml.bak
+}
+
 TYPE=""
 DATE=$(date -u +%Y%m%d)
 
@@ -91,7 +98,7 @@ if [ -z "$TYPE" ]; then
         echo "The latest tag is ${VERSION_TAG} but the version in pyproject.toml is ${VERSION_PYPROJECT}"
         echo "Updating the version in pyproject.toml to match the latest tag"
         poetry version "${VERSION_TAG}"
-        sed -i "s/^version = \".*\"/version = \"${VERSION_TAG}\"/" packages/gptme-acp/pyproject.toml
+        _bump_shim_version "${VERSION_TAG}"
         git add pyproject.toml packages/gptme-acp/pyproject.toml
         git commit -m "chore: bump version to ${VERSION_TAG}" || echo "No version bump needed"
     else
@@ -103,7 +110,7 @@ if [ -z "$TYPE" ]; then
         fi
         echo "Bumping version to ${VERSION_NEW}"
         poetry version "${VERSION_NEW}"
-        sed -i "s/^version = \".*\"/version = \"${VERSION_NEW}\"/" packages/gptme-acp/pyproject.toml
+        _bump_shim_version "${VERSION_NEW}"
         git add pyproject.toml packages/gptme-acp/pyproject.toml
         git commit -m "chore: bump version to ${VERSION_NEW}"
         git tag -s "v${VERSION_NEW}" -m "v${VERSION_NEW}"
@@ -166,7 +173,7 @@ poetry version "$NEW_VERSION"
 echo "Updated pyproject.toml: $(grep '^version' pyproject.toml)"
 
 # Also bump gptme-acp shim to keep it in sync with main package
-sed -i "s/^version = \".*\"/version = \"$NEW_VERSION\"/" packages/gptme-acp/pyproject.toml
+_bump_shim_version "$NEW_VERSION"
 echo "Updated packages/gptme-acp/pyproject.toml: $(grep '^version' packages/gptme-acp/pyproject.toml)"
 
 # Commit and tag


### PR DESCRIPTION
## Summary

Adds a thin `packages/gptme-acp/` wrapper package that unblocks gptme from being listed in the [ACP agent registry](https://github.com/agentclientprotocol/registry), enabling agent discovery in Zed, JetBrains, and other ACP-compatible editors.

## Problem

The ACP registry only supports `uvx <package>` where `<package>` is the default executable of a plain PyPI package name. Three blockers prevented gptme from being listed (see #3158):

1. `uvx gptme` runs the interactive CLI, not the ACP server
2. Extras-qualified specs (`gptme[acp]`) fail the registry's package-existence check
3. `--from` flags are not supported by the registry format

## Solution

The `gptme-acp` package is a pure entry-point shim:
- Declares `gptme[acp]>=0.31.0` as its dependency
- Exposes `gptme-acp` as its default executable (pointing to `gptme.acp.__main__:main`)
- No Python source files needed — all logic lives in `gptme[acp]`

This follows the [fast-agent-acp precedent](https://pypi.org/project/fast-agent-acp/) — they hit the same limitation and shipped a thin shim for registry compatibility.

The registry entry becomes:
```json
{"package": "gptme-acp", "launch": {"type": "uvx"}}
```

## Usage

```bash
# No install required
uvx gptme-acp

# Or persistent install
pipx install gptme-acp
gptme-acp
```

## Changes

- `packages/gptme-acp/pyproject.toml` — thin shim package (hatchling build, no Python source files)
- `packages/gptme-acp/README.md` — explains the shim, usage, and why it exists
- `docs/acp.rst` — adds `uvx gptme-acp` as the recommended install path; documents registry entry format

## Test plan

- [ ] All 118 existing ACP tests pass (`python -m pytest tests/test_acp_types.py tests/test_acp_agent.py`)
- [ ] `uv pip install packages/gptme-acp/ --dry-run` resolves `agent-client-protocol` transitively
- [ ] Package needs to be published to PyPI as `gptme-acp` to fully close #3158 (registry entry can then be submitted to agentclientprotocol/registry)

Closes #3158

<!-- gptme-id:v1:gai_giXHfvO3mjvYlwMCz8kgV0wVYOzcaHOIxEfSSLWBmnA -->