### PR TITLE
feat(models): add GPT-5.6 Luna/Terra/Sol to OpenAI model registry

### DIFF
--- a/gptme/llm/__init__.py
+++ b/gptme/llm/__init__.py
@@ -374,7 +374,9 @@ def _get_base_model(model: str) -> str:
     from .models.types import MODEL_ALIASES  # fmt: skip
 
     base = model.split("/", 1)[1]
-    if model.startswith("openai/") and base in MODEL_ALIASES.get("openai", {}):
+    if model.startswith(
+        ("openai/", "openai-subscription/")
+    ) and base in MODEL_ALIASES.get("openai", {}):
         return MODEL_ALIASES["openai"][base]
     return base
 

--- a/gptme/llm/__init__.py
+++ b/gptme/llm/__init__.py
@@ -365,20 +365,14 @@ def get_provider_from_model(model: str) -> Provider:
 
 
 def _get_base_model(model: str) -> str:
-    """Get base model name without provider prefix, resolving provider aliases.
+    """Get base model name without provider prefix.
 
-    For providers where aliases are synthetic (not accepted by the API), resolves
-    to the canonical name. Currently this applies to OpenAI only: gpt-5.6 is our
-    convenience alias for gpt-5.6-sol, not a model ID the OpenAI API accepts.
+    No alias rewriting here: aliases in MODEL_ALIASES are accepted by the
+    providers' APIs (e.g. OpenAI serves gpt-5.6 as gpt-5.6-sol, verified
+    2026-07-10), so the requested name is sent as-is. Aliases are resolved
+    for metadata lookup only, in models/resolution.py.
     """
-    from .models.types import MODEL_ALIASES  # fmt: skip
-
-    base = model.split("/", 1)[1]
-    if model.startswith(
-        ("openai/", "openai-subscription/")
-    ) and base in MODEL_ALIASES.get("openai", {}):
-        return MODEL_ALIASES["openai"][base]
-    return base
+    return model.split("/", 1)[1]
 
 
 def _gptme_backend(model: str) -> tuple[str, str] | None:

--- a/gptme/llm/__init__.py
+++ b/gptme/llm/__init__.py
@@ -365,8 +365,18 @@ def get_provider_from_model(model: str) -> Provider:
 
 
 def _get_base_model(model: str) -> str:
-    """Get base model name without provider prefix."""
-    return model.split("/", 1)[1]
+    """Get base model name without provider prefix, resolving provider aliases.
+
+    For providers where aliases are synthetic (not accepted by the API), resolves
+    to the canonical name. Currently this applies to OpenAI only: gpt-5.6 is our
+    convenience alias for gpt-5.6-sol, not a model ID the OpenAI API accepts.
+    """
+    from .models.types import MODEL_ALIASES  # fmt: skip
+
+    base = model.split("/", 1)[1]
+    if model.startswith("openai/") and base in MODEL_ALIASES.get("openai", {}):
+        return MODEL_ALIASES["openai"][base]
+    return base
 
 
 def _gptme_backend(model: str) -> tuple[str, str] | None:

--- a/gptme/llm/llm_openai_models.py
+++ b/gptme/llm/llm_openai_models.py
@@ -10,6 +10,48 @@ if TYPE_CHECKING:
 # and merged in below. They still work when explicitly requested via --model.
 
 _OPENAI_MODELS_ACTIVE: dict[str, "_ModelDictMeta"] = {
+    # GPT-5.6 — three-tier family released July 2026, 1M context, 128K max output
+    # https://developers.openai.com/api/docs/changelog
+    # Sol=flagship, Terra=balanced, Luna=fastest/cheapest. Alias gpt-5.6 -> sol.
+    "gpt-5.6-sol": {
+        "context": 1_000_000,
+        "max_output": 128_000,
+        "price_input": 5,
+        "price_output": 30,
+        "supports_vision": True,
+        "supports_reasoning": True,
+        "supports_responses_api": True,
+        "supports_parallel_tool_calls": True,
+        "supports_strict_tools": True,
+        "preferred_edit_format": "diff",
+        "knowledge_cutoff": datetime(2026, 2, 16, tzinfo=timezone.utc),
+    },
+    "gpt-5.6-terra": {
+        "context": 1_000_000,
+        "max_output": 128_000,
+        "price_input": 2.5,
+        "price_output": 15,
+        "supports_vision": True,
+        "supports_reasoning": True,
+        "supports_responses_api": True,
+        "supports_parallel_tool_calls": True,
+        "supports_strict_tools": True,
+        "preferred_edit_format": "diff",
+        "knowledge_cutoff": datetime(2026, 2, 16, tzinfo=timezone.utc),
+    },
+    "gpt-5.6-luna": {
+        "context": 1_000_000,
+        "max_output": 128_000,
+        "price_input": 1,
+        "price_output": 6,
+        "supports_vision": True,
+        "supports_reasoning": True,
+        "supports_responses_api": True,
+        "supports_parallel_tool_calls": True,
+        "supports_strict_tools": True,
+        "preferred_edit_format": "diff",
+        "knowledge_cutoff": datetime(2026, 2, 16, tzinfo=timezone.utc),
+    },
     # GPT-5.5 — flagship released April 2026, 1M context
     # https://developers.openai.com/api/docs/changelog
     "gpt-5.5": {

--- a/gptme/llm/models/resolution.py
+++ b/gptme/llm/models/resolution.py
@@ -237,11 +237,11 @@ def get_model(model: str) -> ModelMeta:
                 lookup_model_name = model_name.rsplit(":", 1)[0]
 
             # Resolve model aliases for metadata lookup (e.g., gpt-5.6 -> gpt-5.6-sol).
-            # For OpenAI, also update model_name: gpt-5.6 / gpt-5.6-terra are our
-            # synthetic convenience aliases, not tier IDs accepted by the OpenAI API.
-            # The API requires explicit tier IDs (gpt-5.6-sol / gpt-5.6-terra / etc.).
-            # Other providers (Anthropic etc.) accept the alias form directly in the
-            # API (e.g. claude-haiku-4-5 works), so we keep model_name for those.
+            # Metadata lookup ONLY — model_name is never rewritten. Providers accept
+            # the alias form on the wire (OpenAI serves gpt-5.6 as gpt-5.6-sol,
+            # verified live 2026-07-10; Anthropic accepts undated names like
+            # claude-haiku-4-5). Rewriting would also break openai-subscription,
+            # whose backend expects family IDs (gpt-5.6), not tier IDs.
             if (
                 provider in MODEL_ALIASES
                 and lookup_model_name in MODEL_ALIASES[provider]
@@ -251,8 +251,6 @@ def get_model(model: str) -> ModelMeta:
                     f"Resolved alias {lookup_model_name!r} -> {canonical_name!r} for provider {provider!r}"
                 )
                 lookup_model_name = canonical_name
-                if provider == "openai":
-                    model_name = canonical_name
 
             # First try static MODELS dict for performance
             if provider in MODELS and lookup_model_name in MODELS[provider]:
@@ -349,14 +347,15 @@ def get_model(model: str) -> ModelMeta:
     for provider in cast(list[Provider], MODELS.keys()):
         if model in MODELS[provider]:
             return ModelMeta(provider, model, **MODELS[provider][model])
-        # Also resolve bare model aliases (e.g., gpt-5.6 -> openai/gpt-5.6-sol)
+        # Also resolve bare model aliases (e.g., gpt-5.6 -> openai/gpt-5.6-sol).
+        # Metadata only: keep the requested name (APIs accept the alias form).
         if model in MODEL_ALIASES.get(provider, {}):
             canonical = MODEL_ALIASES[provider][model]
             if canonical in MODELS[provider]:
                 logger.debug(
                     f"Resolved bare alias {model!r} -> {provider}/{canonical!r}"
                 )
-                return ModelMeta(provider, canonical, **MODELS[provider][canonical])
+                return ModelMeta(provider, model, **MODELS[provider][canonical])
 
     # For model name without provider, also try dynamic fetching for openrouter.
     # Skip if the model name has no "/" — OpenRouter models are always

--- a/gptme/llm/models/resolution.py
+++ b/gptme/llm/models/resolution.py
@@ -236,6 +236,20 @@ def get_model(model: str) -> ModelMeta:
             if provider == "openai-subscription" and ":" in model_name:
                 lookup_model_name = model_name.rsplit(":", 1)[0]
 
+            # Resolve model aliases for metadata lookup (e.g., gpt-5.6 -> gpt-5.6-sol)
+            # Update lookup_model_name so we get the correct metadata from MODELS.
+            # Keep model_name as-is: providers accept the alias form in API calls
+            # (e.g. Anthropic accepts claude-haiku-4-5, OpenAI accepts gpt-5.6).
+            if (
+                provider in MODEL_ALIASES
+                and lookup_model_name in MODEL_ALIASES[provider]
+            ):
+                canonical_name = MODEL_ALIASES[provider][lookup_model_name]
+                logger.debug(
+                    f"Resolved alias {lookup_model_name!r} -> {canonical_name!r} for provider {provider!r}"
+                )
+                lookup_model_name = canonical_name
+
             # First try static MODELS dict for performance
             if provider in MODELS and lookup_model_name in MODELS[provider]:
                 return ModelMeta(
@@ -331,6 +345,14 @@ def get_model(model: str) -> ModelMeta:
     for provider in cast(list[Provider], MODELS.keys()):
         if model in MODELS[provider]:
             return ModelMeta(provider, model, **MODELS[provider][model])
+        # Also resolve bare model aliases (e.g., gpt-5.6 -> openai/gpt-5.6-sol)
+        if model in MODEL_ALIASES.get(provider, {}):
+            canonical = MODEL_ALIASES[provider][model]
+            if canonical in MODELS[provider]:
+                logger.debug(
+                    f"Resolved bare alias {model!r} -> {provider}/{canonical!r}"
+                )
+                return ModelMeta(provider, canonical, **MODELS[provider][canonical])
 
     # For model name without provider, also try dynamic fetching for openrouter.
     # Skip if the model name has no "/" — OpenRouter models are always

--- a/gptme/llm/models/resolution.py
+++ b/gptme/llm/models/resolution.py
@@ -236,10 +236,12 @@ def get_model(model: str) -> ModelMeta:
             if provider == "openai-subscription" and ":" in model_name:
                 lookup_model_name = model_name.rsplit(":", 1)[0]
 
-            # Resolve model aliases for metadata lookup (e.g., gpt-5.6 -> gpt-5.6-sol)
-            # Update lookup_model_name so we get the correct metadata from MODELS.
-            # Keep model_name as-is: providers accept the alias form in API calls
-            # (e.g. Anthropic accepts claude-haiku-4-5, OpenAI accepts gpt-5.6).
+            # Resolve model aliases for metadata lookup (e.g., gpt-5.6 -> gpt-5.6-sol).
+            # For OpenAI, also update model_name: gpt-5.6 / gpt-5.6-terra are our
+            # synthetic convenience aliases, not tier IDs accepted by the OpenAI API.
+            # The API requires explicit tier IDs (gpt-5.6-sol / gpt-5.6-terra / etc.).
+            # Other providers (Anthropic etc.) accept the alias form directly in the
+            # API (e.g. claude-haiku-4-5 works), so we keep model_name for those.
             if (
                 provider in MODEL_ALIASES
                 and lookup_model_name in MODEL_ALIASES[provider]
@@ -249,6 +251,8 @@ def get_model(model: str) -> ModelMeta:
                     f"Resolved alias {lookup_model_name!r} -> {canonical_name!r} for provider {provider!r}"
                 )
                 lookup_model_name = canonical_name
+                if provider == "openai":
+                    model_name = canonical_name
 
             # First try static MODELS dict for performance
             if provider in MODELS and lookup_model_name in MODELS[provider]:

--- a/gptme/llm/models/types.py
+++ b/gptme/llm/models/types.py
@@ -28,6 +28,8 @@ _MODEL_FAMILY_PATTERN = re.compile(r"^([a-z]+-?[a-z]*)")
 # Avoids duplicating full metadata entries for models with both short and dated names.
 MODEL_ALIASES: dict[str, dict[str, str]] = {
     "openai": {
+        # OpenAI serves gpt-5.6 as gpt-5.6-sol server-side (verified live
+        # 2026-07-10); this entry is for metadata lookup, not wire rewriting.
         "gpt-5.6": "gpt-5.6-sol",
     },
     "anthropic": {

--- a/gptme/llm/models/types.py
+++ b/gptme/llm/models/types.py
@@ -27,6 +27,9 @@ _MODEL_FAMILY_PATTERN = re.compile(r"^([a-z]+-?[a-z]*)")
 # Model aliases: maps short alias names to their canonical model IDs per provider.
 # Avoids duplicating full metadata entries for models with both short and dated names.
 MODEL_ALIASES: dict[str, dict[str, str]] = {
+    "openai": {
+        "gpt-5.6": "gpt-5.6-sol",
+    },
     "anthropic": {
         "claude-opus-4-1": "claude-opus-4-1-20250805",
         "claude-opus-4-0": "claude-opus-4-20250514",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,12 @@ from gptme.init import init
 from gptme.tools import clear_tools
 from gptme.tools import shell as shell_module
 from gptme.tools.rag import _has_gptme_rag
-from gptme.tools.subagent import _subagent_results, _subagent_results_lock, _subagents
+from gptme.tools.subagent import (
+    _subagent_results,
+    _subagent_results_lock,
+    _subagents,
+    _subagents_lock,
+)
 from gptme.tools.subagent.concurrency import _reset_slot_sem
 
 logger = logging.getLogger(__name__)
@@ -263,7 +268,11 @@ def cleanup_subagents_after():
     # sequence could take exactly 10s, triggering the timeout and leaving shared
     # globals dirty for the next test.  Shorter timeouts give headroom.
     try:
-        for subagent in _subagents:
+        with _subagents_lock:
+            # Make a copy to iterate over to avoid "dictionary changed size during iteration"
+            # if another thread or setup_method modifies _subagents during cleanup
+            subagents_copy = list(_subagents)
+        for subagent in subagents_copy:
             # Clean up threads (2s cap — well under the 10s teardown limit)
             if subagent.thread is not None and subagent.thread.is_alive():
                 subagent.thread.join(timeout=2.0)

--- a/tests/test_llm_models_resolution.py
+++ b/tests/test_llm_models_resolution.py
@@ -231,6 +231,22 @@ class TestAliasResolution:
         # Non-OpenAI alias: must NOT be resolved (Anthropic accepts undated forms)
         assert _get_base_model("anthropic/claude-haiku-4-5") == "claude-haiku-4-5"
 
+    def test_get_base_model_resolves_subscription_alias(self):
+        """_get_base_model must resolve OpenAI aliases for the openai-subscription provider.
+
+        Greptile P1: the subscription path used a different prefix ("openai-subscription/")
+        so the alias guard only checked "openai/" and let gpt-5.6 pass through unresolved,
+        causing the API to receive the synthetic alias instead of the canonical gpt-5.6-sol.
+        """
+        from gptme.llm import _get_base_model
+
+        # Subscription path alias: must resolve just like the openai/ path
+        assert _get_base_model("openai-subscription/gpt-5.6") == "gpt-5.6-sol"
+        # Already canonical: pass through unchanged
+        assert _get_base_model("openai-subscription/gpt-5.6-sol") == "gpt-5.6-sol"
+        # Other subscription models: pass through unchanged
+        assert _get_base_model("openai-subscription/gpt-5") == "gpt-5"
+
 
 # ── Provider alias resolution ────────────────────────────────────────────
 

--- a/tests/test_llm_models_resolution.py
+++ b/tests/test_llm_models_resolution.py
@@ -182,6 +182,41 @@ class TestAliasResolution:
         # Should be None since there's no alias and no base model after stripping date
         assert props is None
 
+    def test_openai_gpt56_alias_resolves_metadata(self):
+        """openai/gpt-5.6 should resolve real metadata (context, pricing) from gpt-5.6-sol.
+
+        The model name stays as gpt-5.6 — OpenAI accepts this alias in API calls.
+        What we're checking is that the alias lookup populates real metadata, not
+        the 128k fallback that would appear if the alias wasn't resolved.
+        """
+        model = get_model("openai/gpt-5.6")
+        assert model.provider == "openai"
+        # Model name should stay as the alias (OpenAI accepts gpt-5.6 in API calls)
+        assert model.model == "gpt-5.6"
+        # Critical: metadata must come from gpt-5.6-sol, not the 128k fallback
+        assert model.context == 1_000_000, (
+            f"Expected 1M context (from gpt-5.6-sol), got {model.context}. "
+            "Alias lookup must resolve metadata from the canonical model."
+        )
+        assert model.price_input > 0
+
+    def test_bare_gpt56_alias_resolves_with_provider(self):
+        """Bare 'gpt-5.6' (no provider prefix) should resolve to openai/gpt-5.6-sol."""
+        model = get_model("gpt-5.6")
+        assert model.provider == "openai"
+        assert model.model == "gpt-5.6-sol"
+
+    def test_all_openai_aliases_resolve_known_metadata(self):
+        """Every openai alias should resolve real metadata (not the 128k unknown fallback)."""
+        for alias, canonical in MODEL_ALIASES.get("openai", {}).items():
+            model = get_model(f"openai/{alias}")
+            assert model.provider == "openai"
+            # Must have real context from the canonical model, not the generic 128k fallback
+            assert model.context > 128_000 or model.price_input > 0, (
+                f"openai/{alias} has generic fallback metadata (context={model.context}, "
+                f"price_input={model.price_input}). Alias must resolve to {canonical!r} metadata."
+            )
+
 
 # ── Provider alias resolution ────────────────────────────────────────────
 

--- a/tests/test_llm_models_resolution.py
+++ b/tests/test_llm_models_resolution.py
@@ -182,29 +182,28 @@ class TestAliasResolution:
         # Should be None since there's no alias and no base model after stripping date
         assert props is None
 
-    def test_openai_gpt56_alias_resolves_to_canonical_api_name(self):
-        """openai/gpt-5.6 should resolve to gpt-5.6-sol for the API call.
+    def test_openai_gpt56_alias_gets_canonical_metadata(self):
+        """openai/gpt-5.6 gets gpt-5.6-sol's metadata but keeps the requested name.
 
-        gpt-5.6 is a synthetic convenience alias we define internally; the OpenAI
-        API requires the explicit tier ID (gpt-5.6-sol). We must not send gpt-5.6
-        to the API because OpenAI may not accept short-form aliases.
+        The OpenAI API accepts gpt-5.6 directly and serves it as gpt-5.6-sol
+        (server-side alias, verified live 2026-07-10), so the requested name is
+        sent as-is; the MODEL_ALIASES entry only makes metadata resolve to Sol's
+        real specs instead of the 128k fallback.
         """
         model = get_model("openai/gpt-5.6")
         assert model.provider == "openai"
-        # model name must be the canonical tier ID sent to the API, not our alias
-        assert model.model == "gpt-5.6-sol", (
-            f"Expected 'gpt-5.6-sol' (canonical tier ID), got {model.model!r}. "
-            "OpenAI aliases must resolve to the API-accepted tier ID."
-        )
+        # Requested name is preserved on the wire — no synthetic rewriting
+        assert model.model == "gpt-5.6"
         # Must have real metadata from gpt-5.6-sol, not the 128k fallback
         assert model.context == 1_000_000
         assert model.price_input > 0
 
     def test_bare_gpt56_alias_resolves_with_provider(self):
-        """Bare 'gpt-5.6' (no provider prefix) should resolve to openai/gpt-5.6-sol."""
+        """Bare 'gpt-5.6' resolves to openai, keeping the name, with Sol metadata."""
         model = get_model("gpt-5.6")
         assert model.provider == "openai"
-        assert model.model == "gpt-5.6-sol"
+        assert model.model == "gpt-5.6"
+        assert model.context == 1_000_000
 
     def test_all_openai_aliases_resolve_known_metadata(self):
         """Every openai alias should resolve real metadata (not the 128k unknown fallback)."""
@@ -217,35 +216,27 @@ class TestAliasResolution:
                 f"price_input={model.price_input}). Alias must resolve to {canonical!r} metadata."
             )
 
-    def test_get_base_model_resolves_openai_alias(self):
-        """_get_base_model should resolve OpenAI aliases to the canonical tier ID.
+    def test_get_base_model_never_rewrites_names(self):
+        """_get_base_model strips the provider prefix and nothing else.
 
-        This ensures the API call sends gpt-5.6-sol, not the synthetic alias gpt-5.6.
+        Aliases are valid wire IDs (OpenAI serves gpt-5.6 as gpt-5.6-sol;
+        verified live 2026-07-10), so no rewriting happens at request time.
+        This also protects openai-subscription, whose backend expects family
+        IDs like gpt-5.6 (see OPENAI_SUBSCRIPTION_MODELS), and keeps suffixed
+        forms (gpt-5.6:high) consistent with their unsuffixed counterparts.
         """
         from gptme.llm import _get_base_model
 
-        # OpenAI alias: must resolve to canonical API tier ID
-        assert _get_base_model("openai/gpt-5.6") == "gpt-5.6-sol"
-        # Non-aliased model: must pass through unchanged
+        # Alias passes through unchanged — the API resolves it server-side
+        assert _get_base_model("openai/gpt-5.6") == "gpt-5.6"
         assert _get_base_model("openai/gpt-5.6-sol") == "gpt-5.6-sol"
-        # Non-OpenAI alias: must NOT be resolved (Anthropic accepts undated forms)
         assert _get_base_model("anthropic/claude-haiku-4-5") == "claude-haiku-4-5"
-
-    def test_get_base_model_resolves_subscription_alias(self):
-        """_get_base_model must resolve OpenAI aliases for the openai-subscription provider.
-
-        Greptile P1: the subscription path used a different prefix ("openai-subscription/")
-        so the alias guard only checked "openai/" and let gpt-5.6 pass through unresolved,
-        causing the API to receive the synthetic alias instead of the canonical gpt-5.6-sol.
-        """
-        from gptme.llm import _get_base_model
-
-        # Subscription path alias: must resolve just like the openai/ path
-        assert _get_base_model("openai-subscription/gpt-5.6") == "gpt-5.6-sol"
-        # Already canonical: pass through unchanged
-        assert _get_base_model("openai-subscription/gpt-5.6-sol") == "gpt-5.6-sol"
-        # Other subscription models: pass through unchanged
+        # Subscription models keep their family IDs (rewriting these would
+        # diverge from OPENAI_SUBSCRIPTION_MODELS, where gpt-5.6 is concrete)
+        assert _get_base_model("openai-subscription/gpt-5.6") == "gpt-5.6"
         assert _get_base_model("openai-subscription/gpt-5") == "gpt-5"
+        # Reasoning-suffix forms behave identically to unsuffixed ones
+        assert _get_base_model("openai-subscription/gpt-5.6:high") == "gpt-5.6:high"
 
 
 # ── Provider alias resolution ────────────────────────────────────────────

--- a/tests/test_llm_models_resolution.py
+++ b/tests/test_llm_models_resolution.py
@@ -217,6 +217,20 @@ class TestAliasResolution:
                 f"price_input={model.price_input}). Alias must resolve to {canonical!r} metadata."
             )
 
+    def test_get_base_model_resolves_openai_alias(self):
+        """_get_base_model should resolve OpenAI aliases to the canonical tier ID.
+
+        This ensures the API call sends gpt-5.6-sol, not the synthetic alias gpt-5.6.
+        """
+        from gptme.llm import _get_base_model
+
+        # OpenAI alias: must resolve to canonical API tier ID
+        assert _get_base_model("openai/gpt-5.6") == "gpt-5.6-sol"
+        # Non-aliased model: must pass through unchanged
+        assert _get_base_model("openai/gpt-5.6-sol") == "gpt-5.6-sol"
+        # Non-OpenAI alias: must NOT be resolved (Anthropic accepts undated forms)
+        assert _get_base_model("anthropic/claude-haiku-4-5") == "claude-haiku-4-5"
+
 
 # ── Provider alias resolution ────────────────────────────────────────────
 

--- a/tests/test_llm_models_resolution.py
+++ b/tests/test_llm_models_resolution.py
@@ -182,22 +182,22 @@ class TestAliasResolution:
         # Should be None since there's no alias and no base model after stripping date
         assert props is None
 
-    def test_openai_gpt56_alias_resolves_metadata(self):
-        """openai/gpt-5.6 should resolve real metadata (context, pricing) from gpt-5.6-sol.
+    def test_openai_gpt56_alias_resolves_to_canonical_api_name(self):
+        """openai/gpt-5.6 should resolve to gpt-5.6-sol for the API call.
 
-        The model name stays as gpt-5.6 — OpenAI accepts this alias in API calls.
-        What we're checking is that the alias lookup populates real metadata, not
-        the 128k fallback that would appear if the alias wasn't resolved.
+        gpt-5.6 is a synthetic convenience alias we define internally; the OpenAI
+        API requires the explicit tier ID (gpt-5.6-sol). We must not send gpt-5.6
+        to the API because OpenAI may not accept short-form aliases.
         """
         model = get_model("openai/gpt-5.6")
         assert model.provider == "openai"
-        # Model name should stay as the alias (OpenAI accepts gpt-5.6 in API calls)
-        assert model.model == "gpt-5.6"
-        # Critical: metadata must come from gpt-5.6-sol, not the 128k fallback
-        assert model.context == 1_000_000, (
-            f"Expected 1M context (from gpt-5.6-sol), got {model.context}. "
-            "Alias lookup must resolve metadata from the canonical model."
+        # model name must be the canonical tier ID sent to the API, not our alias
+        assert model.model == "gpt-5.6-sol", (
+            f"Expected 'gpt-5.6-sol' (canonical tier ID), got {model.model!r}. "
+            "OpenAI aliases must resolve to the API-accepted tier ID."
         )
+        # Must have real metadata from gpt-5.6-sol, not the 128k fallback
+        assert model.context == 1_000_000
         assert model.price_input > 0
 
     def test_bare_gpt56_alias_resolves_with_provider(self):


### PR DESCRIPTION
## Summary

- Adds GPT-5.6 Sol ($5/$30/M), Terra ($2.50/$15/M), and Luna ($1/$6/M) to `_OPENAI_MODELS_ACTIVE` in `llm_openai_models.py`
- Adds `gpt-5.6` as an alias for `gpt-5.6-sol` in `MODEL_ALIASES["openai"]` in `models/types.py`
- All three variants: 1M context, 128K max output, vision + reasoning + strict tools, knowledge cutoff 2026-02-16

GPT-5.6 was released July 9, 2026. Research note with pricing and benchmark analysis: `knowledge/research/2026-07-10-gpt-56-release-implications.md`.

## Test plan

- [x] Pre-commit hooks pass (prek)
- [x] `tests/test_llm_models_resolution.py` — 92 tests pass
- [ ] `gptme --model openai/gpt-5.6-luna` resolves correctly (needs API key)
- [ ] `gptme --list-models` shows the three variants