### PR TITLE
fix(acp): add gptme_acp stub so hatchling can build the shim wheel

### DIFF
--- a/packages/gptme-acp/pyproject.toml
+++ b/packages/gptme-acp/pyproject.toml
@@ -24,6 +24,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
-# No Python source files — the package is purely an entry-point shim.
-# All logic lives in `gptme[acp]` which is a declared dependency.
-packages = []
+# Minimal stub package — all logic lives in `gptme[acp]` (a declared dependency).
+# The gptme_acp/__init__.py is empty; it exists only to satisfy hatchling's
+# requirement that the wheel contain at least one Python package.
+packages = ["gptme_acp"]


### PR DESCRIPTION
## Problem

The `packages/gptme-acp/` shim added in #3160 has never been published to PyPI because its `pyproject.toml` contained `packages = []`, which causes hatchling to error with:

```
ValueError: Unable to determine which files to ship inside the wheel
```

Since the build step had `continue-on-error: true`, this failure was silent — no wheel artifact was uploaded to the GitHub release and nothing was published to PyPI.

## Fix

Add an empty `gptme_acp/__init__.py` stub file and change `packages = []` to `packages = ["gptme_acp"]` so hatchling has a valid package directory to include in the wheel.

The stub is intentionally empty — all logic remains in `gptme[acp]` (a declared dependency). The entry point `gptme-acp = gptme.acp.__main__:main` still delegates to gptme's ACP implementation.

## Verification

```
$ uv run --with build python3 -m build packages/gptme-acp/
Successfully built gptme_acp-0.31.0.tar.gz and gptme_acp-0.31.0-py3-none-any.whl
```

Wheel contents confirm the entry point is correct:

```
[console_scripts]
gptme-acp = gptme.acp.__main__:main
```

Fixes #3158 (once the shim is published to PyPI on the next release).