### PR TITLE
feat(mcp): add 'gptme-util mcp serve' subcommand and docs

### DIFF
--- a/docs/mcp.rst
+++ b/docs/mcp.rst
@@ -3,9 +3,7 @@
 MCP
 ===
 
-gptme acts as a MCP client supporting MCP servers (`Model Context Protocol <https://modelcontextprotocol.io/>`_), allowing integration with external tools and services through a standardized protocol.
-
-We also intend to expose tools in gptme as MCP servers, allowing you to use gptme tools in other MCP clients.
+gptme works as both an MCP **client** (consuming external MCP servers) and an MCP **server** (exposing gptme tools to Claude Desktop, Cursor, and other MCP clients).
 
 Configuration
 -------------
@@ -183,3 +181,45 @@ gptme provides CLI commands to manage and test your MCP servers:
     gptme-util mcp info server-name
 
 These commands help you verify that your MCP servers are properly configured and accessible.
+
+gptme as an MCP Server
+-----------------------
+
+gptme can expose its own tools (shell, Python REPL, file read/save, browser, etc.) as an MCP server so that Claude Desktop, Cursor, and other MCP clients can use them directly.
+
+Quick start for Claude Desktop — add to ``~/.claude/claude_desktop_config.json``:
+
+.. code-block:: json
+
+    {
+      "mcpServers": {
+        "gptme": {
+          "command": "gptme-mcp-server",
+          "args": ["--tools", "shell,ipython,save,read"]
+        }
+      }
+    }
+
+Then restart Claude Desktop. The ``shell``, ``ipython``, ``save``, and ``read`` tools will appear in Claude's tool menu.
+
+Running the server manually:
+
+.. code-block:: bash
+
+    # Standalone entrypoint (recommended for Claude Desktop)
+    gptme-mcp-server --tools shell,ipython,save,read
+
+    # Or via gptme-util (equivalent)
+    gptme-util mcp serve --tools shell,ipython,save,read
+
+Options:
+
+- ``--tools``: Comma-separated tool names to expose. Default: ``shell,ipython,save,append,read``. ``subagent`` and ``mcp`` are always excluded.
+
+- ``--workspace DIR``: Working directory for all tool operations (default: current directory).
+
+- ``--log-level``: Log level sent to stderr (``DEBUG``, ``INFO``, ``WARNING``, ``ERROR``).
+
+The server is **session-backed**: one persistent gptme session per MCP connection, so the bash shell
+retains state, the Python REPL keeps variables, and file operations share a consistent working directory
+across multiple tool calls.

--- a/gptme/cli/cmd_mcp.py
+++ b/gptme/cli/cmd_mcp.py
@@ -159,6 +159,64 @@ def mcp_info(server_name: str):
             sys.exit(1)
 
 
+@mcp.command("serve")
+@click.option(
+    "--tools",
+    default=None,
+    metavar="TOOLS",
+    help="Comma-separated list of tools to expose. "
+    "Default: shell,ipython,save,append,read",
+)
+@click.option(
+    "--workspace",
+    default=None,
+    metavar="DIR",
+    help="Working directory for tool execution. Defaults to current directory.",
+)
+@click.option(
+    "--log-level",
+    default="WARNING",
+    type=click.Choice(["DEBUG", "INFO", "WARNING", "ERROR"], case_sensitive=False),
+    help="Log level for the MCP server process (logs go to stderr).",
+)
+def mcp_serve(tools: str | None, workspace: str | None, log_level: str) -> None:
+    """Expose gptme tools as an MCP server over stdio.
+
+    Connect this server to Claude Desktop, Cursor, or any MCP-compatible client.
+
+    \b
+    Claude Desktop config (~/.claude/claude_desktop_config.json):
+        {
+          "mcpServers": {
+            "gptme": {
+              "command": "gptme-util",
+              "args": ["mcp", "serve", "--tools", "shell,ipython,save,read"]
+            }
+          }
+        }
+
+    Tip: the standalone ``gptme-mcp-server`` command is equivalent and slightly
+    shorter for Claude Desktop configs.
+    """
+    import logging
+
+    from ..mcp.server import DEFAULT_TOOLS, GptmeMCPServer
+
+    logging.basicConfig(level=getattr(logging, log_level.upper()), format="%(message)s")
+
+    tool_names: list[str] | None = None
+    if tools:
+        tool_names = [t.strip() for t in tools.split(",") if t.strip()]
+
+    click.echo(
+        f"Starting gptme MCP server (tools: {','.join(tool_names or DEFAULT_TOOLS)})",
+        err=True,
+    )
+
+    server = GptmeMCPServer(tool_names=tool_names, workspace=workspace)
+    server.serve_stdio()
+
+
 @mcp.command("search")
 @click.argument("query", required=False, default="")
 @click.option(

--- a/tests/test_util_cli_mcp.py
+++ b/tests/test_util_cli_mcp.py
@@ -512,3 +512,55 @@ class TestMCPSearch:
         assert result.exit_code == 1
         assert "Search failed" in result.output
         assert "Network timeout" in result.output
+
+
+class TestMCPServe:
+    """Tests for 'mcp serve' command."""
+
+    def test_serve_help(self):
+        """Test that mcp serve --help shows expected options."""
+        runner = CliRunner()
+        result = runner.invoke(main, ["mcp", "serve", "--help"])
+        assert result.exit_code == 0
+        assert "--tools" in result.output
+        assert "--workspace" in result.output
+        assert "--log-level" in result.output
+
+    def test_serve_launches_server(self, mocker):
+        """Test that mcp serve creates and starts a GptmeMCPServer."""
+        mock_server = Mock()
+        mock_create = mocker.patch(
+            "gptme.mcp.server.GptmeMCPServer", return_value=mock_server
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["mcp", "serve"])
+        assert result.exit_code == 0
+        mock_create.assert_called_once()
+        mock_server.serve_stdio.assert_called_once()
+
+    def test_serve_with_tools(self, mocker):
+        """Test that --tools are parsed and passed to the server."""
+        mock_server = Mock()
+        mock_create = mocker.patch(
+            "gptme.mcp.server.GptmeMCPServer", return_value=mock_server
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["mcp", "serve", "--tools", "shell,ipython"])
+        assert result.exit_code == 0
+        mock_create.assert_called_once_with(
+            tool_names=["shell", "ipython"], workspace=None
+        )
+
+    def test_serve_with_workspace(self, mocker, tmp_path):
+        """Test that --workspace is passed to the server."""
+        mock_server = Mock()
+        mock_create = mocker.patch(
+            "gptme.mcp.server.GptmeMCPServer", return_value=mock_server
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["mcp", "serve", "--workspace", str(tmp_path)])
+        assert result.exit_code == 0
+        mock_create.assert_called_once_with(tool_names=None, workspace=str(tmp_path))


### PR DESCRIPTION
## Summary

Completes the remaining acceptance criteria from #3156 that were not addressed by the merged #3157:

- **`gptme mcp serve --stdio` not available** — #3157 only added the standalone `gptme-mcp-server` entrypoint. The issue also requires `gptme mcp serve` as a subcommand of the `gptme-util mcp` group.
- **Docs still said "We also *intend* to expose tools as MCP servers"** — the feature was shipped but the docs weren't updated.

## Changes

- `gptme/cli/cmd_mcp.py`: new `serve` subcommand with `--tools`, `--workspace`, `--log-level` flags, delegating to `GptmeMCPServer.serve_stdio()`. Mirrors the standalone `gptme-mcp-server` entrypoint.
- `docs/mcp.rst`: replaces the "We also intend to..." stub with a real "gptme as an MCP Server" section — Claude Desktop config quickstart, CLI examples, option docs, and session-backed design note.
- `tests/test_util_cli_mcp.py`: 4 new `TestMCPServe` tests covering `--help`, server construction, `--tools` parsing, and `--workspace` forwarding.

## Test plan

- [x] `gptme-util mcp serve --help` shows expected options
- [x] All 4 new `TestMCPServe` tests pass
- [x] Full `test_util_cli_mcp.py` + `test_mcp_server.py` suite: 57 passed
- [x] Pre-commit hooks (ruff, mypy, RST formatter) pass

Closes #3156