### PR TITLE
fix(test): add @pytest.mark.no_retry to test_multi_tool_per_message

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -352,6 +352,7 @@ markers = [
     "timeout: marks tests with timeout value in seconds",
     "requires_api: marks tests that require API access",
     "flaky: marks tests as flaky (retried automatically)",
+    "no_retry: marks tests that must not be retried (e.g. tmp_path teardown issues with pytest-retry)",
     "integration: marks tests as integration tests requiring external services",
     "x11: marks tests that require a real or headless X11 display (Xvfb, xdotool, scrot)",
     "xdist_group: marks tests that should run in the same xdist group",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -152,6 +152,13 @@ def pytest_collection_modifyitems(config, items):
             if "requires_api" in item.keywords:
                 item.add_marker(skip_api)
 
+    # Wire up no_retry: override pytest-retry's global --retries for these tests.
+    # @pytest.mark.flaky(retries=0) takes precedence over the --retries CLI flag.
+    no_retry_mark = pytest.mark.flaky(retries=0)
+    for item in items:
+        if "no_retry" in item.keywords:
+            item.add_marker(no_retry_mark)
+
 
 def pytest_sessionstart(session):
     global _anthropic_quota_exhausted

--- a/tests/test_server_v2_auto_stepping.py
+++ b/tests/test_server_v2_auto_stepping.py
@@ -241,6 +241,7 @@ def test_append_write_failure_blocks_generation_complete_and_persists_error(
 
 
 @pytest.mark.timeout(60)
+@pytest.mark.no_retry
 def test_multi_tool_per_message(
     init_, setup_conversation, event_listener, mock_generation, wait_for_event, tmp_path
 ):
@@ -250,8 +251,8 @@ def test_multi_tool_per_message(
     - Both tools execute serially (second file writes after first)
     - Auto-step fires only after all tools complete
 
-    Keep this as a single-attempt test: pytest-retry can surface a tmp_path
-    teardown KeyError after the retried attempt passes.
+    Must not be retried: pytest-retry with --retries surfaces a tmp_path
+    teardown KeyError after the retried attempt passes (stash key missing).
     """
     port, conversation_id, session_id = setup_conversation
 


### PR DESCRIPTION
## Summary

- Adds `@pytest.mark.no_retry` to `test_multi_tool_per_message` to prevent the pytest-retry plugin from retrying it
- Registers the `no_retry` marker in `pyproject.toml` to avoid unknown-mark warnings

## Why

When the CI runs with `--retries 2`, `test_multi_tool_per_message` can fail on attempt 1 (timing flakiness), pass on attempt 2, and then crash with:

```
ERROR tests/test_server_v2_auto_stepping.py::test_multi_tool_per_message - KeyError: <_pytest.stash.StashKey object>
```

This is because the test uses `tmp_path`, whose teardown happens after the first attempt passes. When pytest-retry tries to record the retry result in the stash, the key for this test is already gone.

The test's docstring already said "Keep this as a single-attempt test" — this PR enforces that mechanically with the marker.

## Test plan

- [x] Pre-commit hooks pass on the commit
- [ ] CI passes without the KeyError in the test_server_v2_auto_stepping run