### PR TITLE
docs(computer): add 'Validate your setup' section to how-to (#216)

### DIFF
--- a/docs/howto/computer-use.md
+++ b/docs/howto/computer-use.md
@@ -56,6 +56,30 @@ export DISPLAY=:1
 fluxbox &   # or any window manager
 ```
 
+## Validate your setup
+
+After installing prerequisites, confirm everything is working:
+
+```bash
+# Check computer-use specific prerequisites (X11 tools, Playwright, ffmpeg, AT-SPI2...)
+gptme-util computer doctor
+
+# Run all three milestone demos (tweet, factorio, doom) against local HTML fixtures
+gptme-util computer demo --all
+```
+
+`gptme-util computer demo --all` drives the real Playwright browser tool against
+local HTML fixtures — the same `open_page`, `fill_element`, and `click_element`
+calls that work against live sites. All three milestones should pass in under
+3 seconds. If they do, browser interaction and selector resolution are working.
+
+For X11/native-desktop diagnostics (requires a running display):
+
+```bash
+gptme-util computer latency            # screenshot capture latency (target: < 200 ms)
+gptme-util computer latency --terminal # terminal startup latency (target: < 500 ms)
+```
+
 ## Start a computer-use session
 
 The `computer-use` profile sets the right tool access and backend selection policy:

--- a/docs/howto/computer-use.md
+++ b/docs/howto/computer-use.md
@@ -68,15 +68,20 @@ gptme-util computer doctor
 gptme-util computer demo --all
 ```
 
+`gptme-util computer doctor` reports Playwright and Chromium availability as
+warnings rather than hard errors. If it warns about a missing browser runtime,
+`gptme-util computer demo --all` will also fail — install the missing dependency
+before proceeding.
+
 `gptme-util computer demo --all` drives the real Playwright browser tool against
 local HTML fixtures — the same `open_page`, `fill_element`, and `click_element`
-calls that work against live sites. All three milestones should pass in under
-3 seconds. If they do, browser interaction and selector resolution are working.
+calls that work against live sites. When all three milestones pass, browser
+interaction and selector resolution are working.
 
 For X11/native-desktop diagnostics (requires a running display):
 
 ```bash
-gptme-util computer latency            # screenshot capture latency (target: < 200 ms)
+gptme-util computer latency            # screenshot capture latency (target: < 100 ms)
 gptme-util computer latency --terminal # terminal startup latency (target: < 500 ms)
 ```
 


### PR DESCRIPTION
## Summary

Adds a dedicated **"Validate your setup"** section to `docs/howto/computer-use.md`,
placed right after Prerequisites and before the first usage example.

**The gap**: the how-to went from install commands straight into usage examples —
no guided path from "installed" to "confirmed working." Users had to figure out
on their own whether their setup was correct.

**What the new section covers:**
- `gptme-util computer doctor` — computer-use specific prerequisites check
  (distinct from the general `gptme-doctor`)
- `gptme-util computer demo --all` — end-to-end browser interaction smoke test
  (all three milestones: tweet, factorio, doom)
- `gptme-util computer latency [--terminal]` — X11 screenshot + terminal
  startup timing diagnostics

Closes part of #216.