### PR TITLE
fix(release): use OIDC Trusted Publisher for gptme-acp PyPI publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -276,7 +276,6 @@ jobs:
         python -m build
 
     - name: Publish gptme-acp shim to PyPI
-      continue-on-error: true
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         packages-dir: packages/gptme-acp/dist/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -220,6 +220,10 @@ jobs:
       !cancelled() &&
       (needs.prepare.result == 'success' || github.event_name == 'release')
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: write
+      id-token: write  # Required for Trusted Publisher (OIDC) PyPI publishing
     env:
       TAG: ${{ needs.prepare.outputs.tag || github.event.release.tag_name || github.ref_name }}
 
@@ -273,12 +277,13 @@ jobs:
 
     - name: Publish gptme-acp shim to PyPI
       continue-on-error: true
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
-      run: |
-        pip install twine
-        twine upload packages/gptme-acp/dist/*
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        packages-dir: packages/gptme-acp/dist/
+        # Uses OIDC Trusted Publisher — no token needed.
+        # Requires a pending trusted publisher configured at:
+        #   https://pypi.org/manage/account/publishing/
+        # with: owner=gptme, repo=gptme, workflow=release.yml
 
     - name: Upload packages to GitHub release
       env:


### PR DESCRIPTION
## Problem

The `Publish gptme-acp shim to PyPI` step in the release workflow fails with `403 Forbidden` because `PYPI_TOKEN` is project-scoped to `gptme` and cannot create the new `gptme-acp` package.

## Fix

Switch to [PyPI Trusted Publishers](https://docs.pypi.org/trusted-publishers/) (OIDC) via `pypa/gh-action-pypi-publish`, which doesn't need a token and can publish new packages.

The job now has `id-token: write` permission, and the publish step uses the standard action instead of twine.

## Required one-time PyPI setup (for a maintainer)

Before this workflow can publish `gptme-acp` for the first time, someone with PyPI account access needs to configure a **pending trusted publisher** at https://pypi.org/manage/account/publishing/:

- **PyPI Project name**: `gptme-acp`
- **Owner**: `gptme`  
- **Repository**: `gptme`
- **Workflow filename**: `release.yml`
- **Environment**: (leave blank)

Once configured, the next release will publish `gptme-acp` to PyPI automatically. This unblocks the ACP agent registry entry (issue #3158).

Closes #3158 (partial — fully resolved once the trusted publisher is configured and first publish succeeds)

<!-- gptme-id:v1:gai_RQbXPta8hhJ6g7Ye3TaGoUndsXoZWkjQmutlTkDb3v4 -->