### PR TITLE
fix(test): skip real model loading in semantic unit tests

### DIFF
--- a/tests/test_hybrid_lessons.py
+++ b/tests/test_hybrid_lessons.py
@@ -372,7 +372,9 @@ def test_semantic_score_zero_norm_returns_zero():
     np = pytest.importorskip("numpy")
     from unittest.mock import MagicMock
 
-    config = HybridConfig(enable_semantic=True)
+    # enable_semantic=False skips real model loading; embedder is set below.
+    # _semantic_score only checks self.embedder, not config.enable_semantic.
+    config = HybridConfig(enable_semantic=False)
     matcher = HybridLessonMatcher(config=config)
 
     # Mock the embedder to return a zero vector
@@ -402,7 +404,8 @@ def test_semantic_score_uses_description_field():
     np = pytest.importorskip("numpy")
     from unittest.mock import MagicMock
 
-    config = HybridConfig(enable_semantic=True)
+    # enable_semantic=False skips real model loading; embedder is set below.
+    config = HybridConfig(enable_semantic=False)
     matcher = HybridLessonMatcher(config=config)
 
     mock_embedder = MagicMock()
@@ -471,7 +474,8 @@ def test_semantic_score_caches_lesson_embeddings():
     np = pytest.importorskip("numpy")
     from unittest.mock import MagicMock
 
-    config = HybridConfig(enable_semantic=True)
+    # enable_semantic=False skips real model loading; embedder is set below.
+    config = HybridConfig(enable_semantic=False)
     matcher = HybridLessonMatcher(config=config)
 
     mock_embedder = MagicMock()


### PR DESCRIPTION
## Problem

Three tests (`test_semantic_score_zero_norm_returns_zero`, `test_semantic_score_uses_description_field`, `test_semantic_score_caches_lesson_embeddings`) constructed `HybridLessonMatcher(config=HybridConfig(enable_semantic=True))` and then immediately replaced `matcher.embedder` with a `MagicMock`. The real `SentenceTransformer("all-MiniLM-L6-v2")` load happened between construction and the mock assignment — wasted and slow.

On CI with a cold HuggingFace model cache the download+load exceeded pytest-timeout (60s), causing `test_semantic_score_zero_norm_returns_zero` to fail on attempt 1 and pass on attempt 2 once the model was cached. Flagged in the gptme/gptme#3176 merge comment.

## Fix

Use `enable_semantic=False` in all three tests. `_semantic_score` only checks `if not self.embedder`, not `config.enable_semantic`, so the tests remain fully valid — they inject a mock embedder directly after construction.

## Test plan

- [x] All three tests pass locally in 1.8s total (vs model-download time in CI)
- [x] Pre-commit checks pass