### PR TITLE
feat(eval): add SWE-bench two-stage file retrieval

### DIFF
--- a/gptme/eval/swebench/evaluate.py
+++ b/gptme/eval/swebench/evaluate.py
@@ -9,6 +9,7 @@ from gptme.eval.cost import get_eval_costs, token_fields_from_cost
 from gptme.eval.types import CaseResult, EvalResult
 from gptme.util.cost_tracker import CostTracker
 
+from .retrieval import retrieve_files_for_prompt
 from .utils import (
     KEY_INSTANCE_ID,
     KEY_MODEL,
@@ -31,6 +32,7 @@ def run_swebench_evaluation(
     repo_base_dir: str | None = None,
     output_dir: str | Path | None = None,
     resume: bool = False,
+    retrieval_strategy: str = "none",
 ) -> tuple[list[EvalResult], Path]:
     """Run SWE-bench evaluation, returning results and path to predictions JSONL.
 
@@ -49,6 +51,11 @@ def run_swebench_evaluation(
         repo_base_dir: Base directory to clone repos into.
         output_dir: Directory to write predictions.jsonl; defaults to ./runs/swebench.
         resume: If True, skip instances already present in predictions.jsonl.
+        retrieval_strategy: File retrieval strategy passed to each evaluate_instance call.
+            - "none" (default): plain problem statement, no retrieval.
+            - "grep-embed": two-stage retrieval — keyword-grep to localize files,
+              then embed their contents directly in the prompt. This eliminates the
+              agent's exploration phase by giving it the relevant code upfront.
 
     Returns:
         (results, predictions_path) tuple.
@@ -103,7 +110,9 @@ def run_swebench_evaluation(
         else:
             logger.info(f"[{idx}/{total}] Evaluating {instance_id}")
 
-        result, patch = evaluate_instance(agent, instance, repo_base_dir)
+        result, patch = evaluate_instance(
+            agent, instance, repo_base_dir, retrieval_strategy=retrieval_strategy
+        )
         results.append(result)
 
         # Write incrementally so progress survives interruption
@@ -132,9 +141,23 @@ def run_swebench_evaluation(
 
 
 def evaluate_instance(
-    agent: Agent, instance: dict, repo_base_dir: str | None
+    agent: Agent,
+    instance: dict,
+    repo_base_dir: str | None,
+    retrieval_strategy: str = "none",
 ) -> tuple[EvalResult, str]:
     """Run agent on a single SWE-bench instance and capture the generated patch.
+
+    Args:
+        agent: The agent to evaluate.
+        instance: SWE-bench instance dict (from load_instances).
+        repo_base_dir: Base directory for cloned repos.
+        retrieval_strategy: Controls how the problem statement is augmented:
+            - "none" (default): plain problem statement, no retrieval.
+            - "grep-embed": keyword-grep to localize relevant files, then embed
+              their contents directly in the prompt (two-stage approach). This
+              eliminates the agent's exploration phase — the relevant code is
+              provided upfront so the agent can make a targeted edit immediately.
 
     Returns:
         (EvalResult, patch) where patch is the unified diff produced by the agent.
@@ -145,7 +168,7 @@ def evaluate_instance(
     instance_id = instance["instance_id"]
     problem_statement = instance["problem_statement"]
 
-    logger.info(f"Evaluating instance: {instance_id}")
+    logger.info(f"Evaluating instance: {instance_id} (retrieval: {retrieval_strategy})")
     logger.debug(f"Problem statement: {problem_statement}")
 
     # Reset cost tracker so each task captures only its own tokens, not
@@ -161,7 +184,20 @@ def evaluate_instance(
         # workspace_dir is the agent's working directory; without this copy the agent
         # would only have access to an empty workspace, not the actual repository.
         shutil.copytree(repo_dir, agent.workspace_dir, dirs_exist_ok=True)
-        agent.act(None, problem_statement)
+
+        # Build the prompt based on retrieval strategy.
+        # With "grep-embed": localize relevant files via keyword-grep, then embed
+        # their contents directly so the agent can fix the bug without exploring.
+        if retrieval_strategy == "grep-embed":
+            prompt = retrieve_files_for_prompt(
+                Path(agent.workspace_dir),
+                problem_statement,
+                top_n=3,
+            )
+        else:
+            prompt = problem_statement
+
+        agent.act(None, prompt)
     except Exception as e:
         logger.error(f"Error during agent execution for instance {instance_id}: {e}")
         cost = get_eval_costs()

--- a/gptme/eval/swebench/main.py
+++ b/gptme/eval/swebench/main.py
@@ -97,6 +97,19 @@ logger = logging.getLogger(__name__)
         "in the predictions.jsonl file and appends new results."
     ),
 )
+@click.option(
+    "--retrieval-strategy",
+    default="none",
+    show_default=True,
+    type=click.Choice(["none", "grep-embed"], case_sensitive=False),
+    help=(
+        "File retrieval strategy to use before passing the problem to the agent. "
+        "'none': plain problem statement (baseline). "
+        "'grep-embed': two-stage retrieval — keyword-grep to find relevant files, "
+        "then embed their contents directly in the prompt so the agent can fix the "
+        "bug without any exploration phase."
+    ),
+)
 def main(
     model: list[str],
     dataset: str,
@@ -109,6 +122,7 @@ def main(
     verbose: bool,
     info: bool,
     resume: bool,
+    retrieval_strategy: str,
 ):
     """Run SWE-bench evaluation for gptme.
 
@@ -160,6 +174,7 @@ def main(
             repo_base_dir=repo_base_dir,
             output_dir=Path(output_dir) / m.replace("/", "__"),
             resume=resume,
+            retrieval_strategy=retrieval_strategy,
         )
         swebench_results[ModelConfig.from_spec(m, default_format="markdown")] = results
         all_predictions_paths.append(predictions_path)

--- a/gptme/eval/swebench/retrieval.py
+++ b/gptme/eval/swebench/retrieval.py
@@ -1,0 +1,259 @@
+"""File retrieval utilities for SWE-bench evaluation.
+
+Two-stage retrieval approach:
+  Stage 1 (Localize): Extract keywords from problem statement, grep for relevant files.
+  Stage 2 (Embed): Read top-N file contents and embed them directly in the prompt.
+
+This is fundamentally different from prompt-constraint approaches (sessions 0ff2, 13bf):
+- Constraint approaches tell the agent WHICH files to edit → agent still explores, ignores.
+- Embedded-content approach GIVES the agent the code directly → no exploration needed.
+
+Research context: knowledge/research/2026-07-10-swebench-retrieval-experiment.md
+"""
+
+import logging
+import re
+import subprocess
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Files/paths to exclude from retrieval results — the agent kept "fixing" these
+_EXCLUDE_PATTERNS = (
+    "docs/",
+    "migrations/",
+    ".egg-info/",
+    "dist/",
+    "build/",
+)
+
+
+def extract_keywords(problem_statement: str) -> list[str]:
+    """Extract identifiers from a problem statement for keyword-grep retrieval.
+
+    Extracts CamelCase class names, snake_case function names, and dotted module
+    paths. These are the most discriminating signals for file localization.
+    """
+    camel = re.findall(r"\b[A-Z][a-zA-Z0-9]{4,}\b", problem_statement)
+    snake = re.findall(r"\b[a-z][a-z0-9]*(?:_[a-z0-9]+){2,}\b", problem_statement)
+    dotted = re.findall(
+        r"\b[a-z][a-z0-9]*(?:\.[a-z][a-z0-9]+){2,}\b", problem_statement
+    )
+
+    stopwords = {
+        "This",
+        "The",
+        "When",
+        "That",
+        "There",
+        "What",
+        "From",
+        "With",
+        "Django",
+        "Python",
+        "Error",
+        "True",
+        "False",
+        "None",
+        "Model",
+        "Value",
+        "Field",
+        "Method",
+        "Class",
+        "Object",
+        "String",
+        "Integer",
+        "Using",
+        "Should",
+        "Could",
+        "Would",
+        "Raise",
+        "Return",
+        "Since",
+        "However",
+        "Therefore",
+        "Description",
+        "Given",
+    }
+    filtered_camel = [k for k in camel if k not in stopwords]
+    return list(dict.fromkeys(filtered_camel + snake + dotted))[:12]
+
+
+def grep_candidate_files(workspace_dir: Path, keywords: list[str]) -> dict[str, int]:
+    """Grep for Python files containing any of the keywords.
+
+    Returns a dict of {filepath: hit_count}, where hit_count is the number of
+    distinct keywords found in the file.
+    """
+    file_scores: dict[str, int] = {}
+    for kw in keywords:
+        try:
+            result = subprocess.run(
+                ["grep", "-rln", "--include=*.py", kw, "."],
+                cwd=workspace_dir,
+                capture_output=True,
+                text=True,
+                timeout=15,
+                check=False,
+            )
+            for line in result.stdout.strip().split("\n"):
+                line = line.strip().lstrip("./")
+                if line and not line.startswith("Binary"):
+                    file_scores[line] = file_scores.get(line, 0) + 1
+        except subprocess.TimeoutExpired:
+            logger.warning(f"grep timed out for keyword: {kw!r}")
+
+    return file_scores
+
+
+def rank_source_files(
+    file_scores: dict[str, int],
+    top_n: int = 5,
+    include_tests: bool = False,
+) -> list[tuple[str, int]]:
+    """Rank files by keyword hit count, filtering to source files.
+
+    By default excludes test files and migrations. The agent kept "fixing"
+    docs/_theme/ symlinks in prior sessions — _EXCLUDE_PATTERNS blocks those.
+    Uses substring match (not startswith) so nested paths like
+    django/contrib/auth/migrations/ are caught by the "migrations/" pattern.
+    """
+    filtered = []
+    for path, score in file_scores.items():
+        if any(p in path for p in _EXCLUDE_PATTERNS):
+            continue
+        if not include_tests and ("test_" in path or "/tests/" in path):
+            continue
+        filtered.append((path, score))
+
+    return sorted(filtered, key=lambda x: x[1], reverse=True)[:top_n]
+
+
+def build_embedded_content_prompt(
+    problem_statement: str,
+    candidate_files: list[tuple[str, int]],
+    workspace_dir: Path,
+    max_file_bytes: int = 8000,
+) -> str:
+    """Build a two-stage prompt with embedded file contents.
+
+    Stage 2 of the retrieval pipeline: embed the actual file contents in the
+    prompt so the agent can fix the bug without any exploration phase.
+
+    This is the key insight from the Agentless approach:
+    > "Constrained patch: embed the file contents directly in the prompt, ask for
+    > a targeted edit. By embedding file contents, the agent sees the specific code
+    > immediately, without an exploration phase."
+
+    Args:
+        problem_statement: The original SWE-bench problem statement.
+        candidate_files: Ranked list of (filepath, score) from rank_source_files().
+        workspace_dir: The agent's workspace directory containing the repo.
+        max_file_bytes: Truncate files larger than this to stay within context limits.
+
+    Returns:
+        A prompt string with embedded file contents and a constrained fix instruction.
+        Falls back to the plain problem_statement if no candidate files are found
+        or readable.
+    """
+    if not candidate_files:
+        logger.info("No candidate files — falling back to plain problem statement")
+        return problem_statement
+
+    embedded_files = []
+    for filepath, score in candidate_files:
+        full_path = workspace_dir / filepath
+        if not full_path.exists():
+            logger.warning(f"Candidate file not found in workspace: {filepath}")
+            continue
+        try:
+            content = full_path.read_text(encoding="utf-8", errors="replace")
+        except OSError as e:
+            logger.warning(f"Could not read {filepath}: {e}")
+            continue
+
+        if len(content.encode()) > max_file_bytes:
+            # Truncate large files — first N bytes usually contain the relevant code
+            content = (
+                content[: max_file_bytes // 2] + "\n... [truncated for context] ..."
+            )
+
+        ext = full_path.suffix.lstrip(".")
+        embedded_files.append(
+            f"### `{filepath}` (relevance score: {score})\n```{ext or 'python'}\n{content}\n```"
+        )
+
+    if not embedded_files:
+        logger.info(
+            "No readable candidate files — falling back to plain problem statement"
+        )
+        return problem_statement
+
+    files_section = "\n\n".join(embedded_files)
+    file_list = "\n".join(
+        f"- `{path}`" for path, _ in candidate_files if (workspace_dir / path).exists()
+    )
+
+    return f"""You are fixing a bug in a Python codebase. The relevant source files are provided below.
+
+**INSTRUCTIONS — READ CAREFULLY:**
+1. Study the issue description to understand what bug needs to be fixed.
+2. Read the provided source files below.
+3. Apply the MINIMAL fix to resolve the issue described.
+4. ONLY modify the files listed below. Do NOT explore or modify other files.
+5. Do NOT fix unrelated issues you notice (symlinks, formatting, style, etc.).
+6. After making your changes, run `git diff` to verify only the expected files changed.
+
+**Files you are allowed to modify:**
+{file_list}
+
+---
+
+## Relevant Source Files
+
+{files_section}
+
+---
+
+## Issue to fix
+
+{problem_statement}"""
+
+
+def retrieve_files_for_prompt(
+    workspace_dir: Path,
+    problem_statement: str,
+    top_n: int = 3,
+    include_tests: bool = False,
+    max_file_bytes: int = 8000,
+) -> str:
+    """End-to-end two-stage retrieval: localize → embed → return prompt.
+
+    Stage 1 (Localize): Extract keywords, grep for relevant files, rank by hits.
+    Stage 2 (Embed): Read top-N file contents, embed in constrained prompt.
+
+    Returns the embedded-content prompt, or the plain problem_statement on failure.
+    """
+    keywords = extract_keywords(problem_statement)
+    if not keywords:
+        logger.info("No keywords extracted — using plain problem statement")
+        return problem_statement
+
+    logger.info(f"Extracted keywords: {keywords}")
+
+    file_scores = grep_candidate_files(workspace_dir, keywords)
+    if not file_scores:
+        logger.info("No files found via grep — using plain problem statement")
+        return problem_statement
+
+    ranked = rank_source_files(file_scores, top_n=top_n, include_tests=include_tests)
+    logger.info(f"Ranked candidate files: {ranked}")
+
+    prompt = build_embedded_content_prompt(
+        problem_statement, ranked, workspace_dir, max_file_bytes=max_file_bytes
+    )
+    logger.info(
+        f"Built embedded-content prompt ({len(prompt)} chars) "
+        f"with {len(ranked)} embedded files"
+    )
+    return prompt

--- a/gptme/eval/swebench/retrieval.py
+++ b/gptme/eval/swebench/retrieval.py
@@ -35,9 +35,9 @@ def extract_keywords(problem_statement: str) -> list[str]:
     paths. These are the most discriminating signals for file localization.
     """
     camel = re.findall(r"\b[A-Z][a-zA-Z0-9]{4,}\b", problem_statement)
-    snake = re.findall(r"\b[a-z][a-z0-9]*(?:_[a-z0-9]+){2,}\b", problem_statement)
+    snake = re.findall(r"\b[a-z][a-z0-9]*(?:_[a-z0-9]+){1,}\b", problem_statement)
     dotted = re.findall(
-        r"\b[a-z][a-z0-9]*(?:\.[a-z][a-z0-9]+){2,}\b", problem_statement
+        r"\b[a-z][a-z0-9]*(?:\.[a-z][a-z0-9]+){1,}\b", problem_statement
     )
 
     stopwords = {
@@ -122,7 +122,9 @@ def rank_source_files(
     for path, score in file_scores.items():
         if any(p in path for p in _EXCLUDE_PATTERNS):
             continue
-        if not include_tests and ("test_" in path or "/tests/" in path):
+        if not include_tests and (
+            Path(path).name.startswith("test_") or "/tests/" in path
+        ):
             continue
         filtered.append((path, score))
 
@@ -174,9 +176,7 @@ def build_embedded_content_prompt(
 
         if len(content.encode()) > max_file_bytes:
             # Truncate large files — first N bytes usually contain the relevant code
-            content = (
-                content[: max_file_bytes // 2] + "\n... [truncated for context] ..."
-            )
+            content = content[:max_file_bytes] + "\n... [truncated for context] ..."
 
         ext = full_path.suffix.lstrip(".")
         embedded_files.append(
@@ -200,7 +200,7 @@ def build_embedded_content_prompt(
 1. Study the issue description to understand what bug needs to be fixed.
 2. Read the provided source files below.
 3. Apply the MINIMAL fix to resolve the issue described.
-4. ONLY modify the files listed below. Do NOT explore or modify other files.
+4. Focus on the files listed below. If the fix requires editing another file, you may do so, but keep changes minimal.
 5. Do NOT fix unrelated issues you notice (symlinks, formatting, style, etc.).
 6. After making your changes, run `git diff` to verify only the expected files changed.
 

--- a/gptme/eval/swebench/retrieval.py
+++ b/gptme/eval/swebench/retrieval.py
@@ -122,8 +122,8 @@ def rank_source_files(
     for path, score in file_scores.items():
         if any(p in path for p in _EXCLUDE_PATTERNS):
             continue
-        if not include_tests and (
-            Path(path).name.startswith("test_") or "/tests/" in path
+        if not include_tests and any(
+            part in ("tests", "test") for part in Path(path).parts[:-1]
         ):
             continue
         filtered.append((path, score))

--- a/tests/test_eval_swebench.py
+++ b/tests/test_eval_swebench.py
@@ -119,7 +119,17 @@ def test_evaluate_instance_populates_token_fields(monkeypatch, tmp_path):
         "gptme.eval.swebench.evaluate.shutil.copytree",
         lambda *_args, **_kwargs: None,
     )
-    monkeypatch.setattr(agent, "act", lambda *_args, **_kwargs: {})
+    retrieved_prompt = "retrieved prompt"
+    monkeypatch.setattr(
+        "gptme.eval.swebench.evaluate.retrieve_files_for_prompt",
+        lambda *_args, **_kwargs: retrieved_prompt,
+    )
+    received_prompts = []
+    monkeypatch.setattr(
+        agent,
+        "act",
+        lambda _messages, prompt: received_prompts.append(prompt),
+    )
     monkeypatch.setattr(
         "gptme.eval.swebench.evaluate.subprocess.run",
         lambda *_args, **_kwargs: type(
@@ -140,9 +150,15 @@ def test_evaluate_instance_populates_token_fields(monkeypatch, tmp_path):
         ),
     )
 
-    result, patch = evaluate_instance(agent, instance, repo_base_dir=str(tmp_path))
+    result, patch = evaluate_instance(
+        agent,
+        instance,
+        repo_base_dir=str(tmp_path),
+        retrieval_strategy="grep-embed",
+    )
 
     assert patch.startswith("diff")
+    assert received_prompts == [retrieved_prompt]
     assert result.tokens_input == 1200
     assert result.tokens_output == 300
     assert result.tokens_total == 1500

--- a/tests/test_eval_swebench_retrieval.py
+++ b/tests/test_eval_swebench_retrieval.py
@@ -59,6 +59,21 @@ def test_rank_source_files_allows_test_support_helpers():
     assert not any("test_validators" in p for p in paths)
 
 
+def test_rank_source_files_keeps_production_helpers_named_test():
+    # A production helper named test_*.py that lives outside a test directory
+    # must not be excluded — only files under tests/ or test/ directories are tests.
+    ranked = rank_source_files(
+        {
+            "django/test_utils.py": 5,  # production helper, not under tests/
+            "django/tests/test_validators.py": 4,  # real test, must be excluded
+        }
+    )
+
+    paths = [p for p, _ in ranked]
+    assert "django/test_utils.py" in paths
+    assert "django/tests/test_validators.py" not in paths
+
+
 def test_build_embedded_content_prompt_embeds_only_existing_files(tmp_path: Path):
     source = tmp_path / "django" / "contrib" / "auth" / "validators.py"
     source.parent.mkdir(parents=True)

--- a/tests/test_eval_swebench_retrieval.py
+++ b/tests/test_eval_swebench_retrieval.py
@@ -1,0 +1,69 @@
+"""Tests for the local SWE-bench file-retrieval pipeline."""
+
+from pathlib import Path
+
+from gptme.eval.swebench.retrieval import (
+    build_embedded_content_prompt,
+    extract_keywords,
+    rank_source_files,
+    retrieve_files_for_prompt,
+)
+
+
+def test_extract_keywords_preserves_specific_identifiers():
+    keywords = extract_keywords(
+        "Django's UserValidationError comes from validate_user_name in auth.models."
+    )
+
+    assert "UserValidationError" in keywords
+    assert "validate_user_name" in keywords
+    assert "Django" not in keywords
+
+
+def test_rank_source_files_excludes_non_source_paths():
+    ranked = rank_source_files(
+        {
+            "django/contrib/auth/validators.py": 3,
+            "django/contrib/auth/tests/test_validators.py": 4,
+            "django/contrib/auth/migrations/0001_initial.py": 5,
+            "docs/validators.py": 6,
+        }
+    )
+
+    assert ranked == [("django/contrib/auth/validators.py", 3)]
+
+
+def test_build_embedded_content_prompt_embeds_only_existing_files(tmp_path: Path):
+    source = tmp_path / "django" / "contrib" / "auth" / "validators.py"
+    source.parent.mkdir(parents=True)
+    source.write_text("class UserValidationError(Exception): pass\n")
+
+    prompt = build_embedded_content_prompt(
+        "Fix UserValidationError handling.",
+        [
+            ("django/contrib/auth/validators.py", 2),
+            ("django/contrib/auth/missing.py", 1),
+        ],
+        tmp_path,
+    )
+
+    assert "UserValidationError" in prompt
+    assert "django/contrib/auth/validators.py" in prompt
+    assert "django/contrib/auth/missing.py" not in prompt
+
+
+def test_retrieve_files_for_prompt_filters_tests_and_embeds_source(tmp_path: Path):
+    source = tmp_path / "django" / "contrib" / "auth" / "validators.py"
+    test = tmp_path / "django" / "contrib" / "auth" / "tests" / "test_validators.py"
+    source.parent.mkdir(parents=True)
+    test.parent.mkdir(parents=True)
+    source.write_text("class UserValidationError(Exception): pass\n")
+    test.write_text("from validators import UserValidationError\n")
+
+    prompt = retrieve_files_for_prompt(
+        tmp_path,
+        "Fix the UserValidationError raised by account validation.",
+    )
+
+    assert "django/contrib/auth/validators.py" in prompt
+    assert "django/contrib/auth/tests/test_validators.py" not in prompt

--- a/tests/test_eval_swebench_retrieval.py
+++ b/tests/test_eval_swebench_retrieval.py
@@ -17,7 +17,17 @@ def test_extract_keywords_preserves_specific_identifiers():
 
     assert "UserValidationError" in keywords
     assert "validate_user_name" in keywords
+    assert "auth.models" in keywords  # two-part dotted identifiers must be captured
     assert "Django" not in keywords
+
+
+def test_extract_keywords_captures_two_part_identifiers():
+    keywords = extract_keywords(
+        "The bug is in get_cache when calling auth.models for the cache key."
+    )
+
+    assert "get_cache" in keywords  # two-part snake_case
+    assert "auth.models" in keywords  # two-part dotted
 
 
 def test_rank_source_files_excludes_non_source_paths():
@@ -31,6 +41,22 @@ def test_rank_source_files_excludes_non_source_paths():
     )
 
     assert ranked == [("django/contrib/auth/validators.py", 3)]
+
+
+def test_rank_source_files_allows_test_support_helpers():
+    # A helper module living under test_support/ is source code, not a test module.
+    ranked = rank_source_files(
+        {
+            "django/contrib/auth/validators.py": 3,
+            "test_support/compat.py": 2,  # helper, not a test
+            "django/contrib/auth/tests/test_validators.py": 4,  # real test, excluded
+        }
+    )
+
+    paths = [p for p, _ in ranked]
+    assert "django/contrib/auth/validators.py" in paths
+    assert "test_support/compat.py" in paths
+    assert not any("test_validators" in p for p in paths)
 
 
 def test_build_embedded_content_prompt_embeds_only_existing_files(tmp_path: Path):


### PR DESCRIPTION
## Summary

- localize likely Python source files from issue identifiers with grep
- embed the top-ranked files into the SWE-bench agent prompt via `--retrieval-strategy grep-embed`
- exclude docs, tests, and migrations; preserve the existing plain-prompt default

## Validation

- `PYTHONPATH=. /home/bob/gptme/.venv/bin/pytest tests/test_eval_swebench.py tests/test_eval_swebench_retrieval.py -q` (19 passed)
- `uv run --with mypy mypy gptme/eval/swebench/retrieval.py gptme/eval/swebench/evaluate.py gptme/eval/swebench/main.py`
- `ruff check` on changed source and tests

A real model run remains deliberately separate: it requires a valid provider credential and measures retrieval quality, whereas this PR verifies the deterministic retrieval pipeline and its integration.