### PR TITLE
feat(cli): add opt-in tool-output pruning

### DIFF
--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -496,6 +496,12 @@ Run 'gptme-util --help' for all utility commands."""
     help="Tool format to use.",
 )
 @click.option(
+    "--prune-tool-output/--no-prune-tool-output",
+    "prune_tool_output",
+    default=None,
+    help="Use a summary model to keep only the relevant lines from large shell/read tool outputs.",
+)
+@click.option(
     "--stream/--no-stream",
     "stream",
     default=True,
@@ -602,6 +608,7 @@ def main(
     tool_allowlist: tuple[str, ...],
     agent_profile: str | None,
     tool_format: ToolFormat | None,
+    prune_tool_output: bool | None,
     stream: bool,
     verbose: bool,
     no_confirm: bool,
@@ -934,6 +941,7 @@ def main(
                     model=model,
                     tool_allowlist=tool_allowlist_str,
                     tool_format=tool_format,
+                    prune_tool_output=prune_tool_output,
                     stream=stream,
                     interactive=interactive,
                     agent_path=Path(agent_path) if agent_path else None,
@@ -1067,6 +1075,7 @@ def main(
             model=model,
             tool_allowlist=tool_allowlist_str,
             tool_format=tool_format,
+            prune_tool_output=prune_tool_output,
             stream=stream,
             interactive=interactive,
             agent_path=Path(agent_path) if agent_path else None,

--- a/gptme/config/cli_setup.py
+++ b/gptme/config/cli_setup.py
@@ -85,6 +85,7 @@ def setup_config_from_cli(
     model: str | None = None,
     tool_allowlist: str | None = None,
     tool_format: "ToolFormat | None" = None,
+    prune_tool_output: bool | None = None,
     stream: bool = True,
     interactive: bool = True,
     agent_path: Path | None = None,
@@ -219,6 +220,12 @@ def setup_config_from_cli(
             agent=resolved_agent_path,
         ),
     )
+
+    if prune_tool_output is not None:
+        config.chat.env = {
+            **config.chat.env,
+            "PRUNE_TOOL_OUTPUT": "1" if prune_tool_output else "0",
+        }
 
     # Set tools if not already set or if CLI override provided
     if config.chat.tools is None or tool_allowlist is not None:

--- a/gptme/tools/pruner.py
+++ b/gptme/tools/pruner.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+import json
+import logging
+import re
+from contextlib import contextmanager
+from dataclasses import dataclass
+
+from ..config import get_config
+from ..message import Message, get_output_format, set_output_format
+from ..util.tokens import len_tokens
+
+logger = logging.getLogger(__name__)
+
+_JSON_OBJECT_RE = re.compile(r"\{.*\}", re.DOTALL)
+_DEFAULT_THRESHOLD_TOKENS = 500
+_FULL_OUTPUT_HINTS = (
+    "full output",
+    "entire output",
+    "whole output",
+    "show everything",
+    "full file",
+    "entire file",
+    "whole file",
+)
+
+
+@dataclass(frozen=True)
+class PrunePlan:
+    ranges: tuple[tuple[int, int], ...]
+    total_lines: int
+    kept_lines: int
+    original_tokens: int
+    kept_tokens: int
+    model: str
+
+    def apply(self, lines: list[str]) -> str:
+        selected: list[str] = []
+        for start, end in self.ranges:
+            selected.extend(lines[start - 1 : end])
+        return "\n".join(selected)
+
+
+def _estimate_tokens(text: str, model: str) -> int:
+    try:
+        return len_tokens(text, model)
+    except Exception:
+        return max(1, len(text) // 4)
+
+
+def _threshold_tokens() -> int:
+    raw = get_config().get_env("PRUNE_TOOL_OUTPUT_THRESHOLD_TOKENS")
+    if not raw:
+        return _DEFAULT_THRESHOLD_TOKENS
+    try:
+        parsed = int(raw)
+    except ValueError:
+        logger.warning(
+            "Invalid PRUNE_TOOL_OUTPUT_THRESHOLD_TOKENS value %r, using %d",
+            raw,
+            _DEFAULT_THRESHOLD_TOKENS,
+        )
+        return _DEFAULT_THRESHOLD_TOKENS
+    return parsed if parsed > 0 else _DEFAULT_THRESHOLD_TOKENS
+
+
+def _resolve_model_name() -> str | None:
+    override = get_config().get_env("PRUNE_TOOL_OUTPUT_MODEL")
+    if override:
+        return override
+
+    from ..llm.models import get_default_model_summary
+
+    if summary_model := get_default_model_summary():
+        return summary_model.full
+
+    config = get_config()
+    return (config.chat and config.chat.model) or config.get_env("MODEL")
+
+
+def _latest_user_query() -> str | None:
+    from ..logmanager import LogManager
+
+    manager = LogManager.get_current_log()
+    if not manager:
+        return None
+    for msg in reversed(manager.log.messages):
+        if msg.role == "user" and msg.content.strip():
+            return msg.content
+    return None
+
+
+def _normalize_ranges(
+    ranges: list[tuple[int, int]], total_lines: int
+) -> list[tuple[int, int]]:
+    merged: list[tuple[int, int]] = []
+    for start, end in sorted(ranges):
+        if start < 1 or end < start or end > total_lines:
+            continue
+        if merged and start <= merged[-1][1] + 1:
+            prev_start, prev_end = merged[-1]
+            merged[-1] = (prev_start, max(prev_end, end))
+        else:
+            merged.append((start, end))
+    return merged
+
+
+def _parse_ranges(response: str, total_lines: int) -> list[tuple[int, int]] | None:
+    match = _JSON_OBJECT_RE.search(response)
+    if not match:
+        return None
+
+    try:
+        payload = json.loads(match.group(0))
+    except json.JSONDecodeError:
+        return None
+
+    raw_ranges = payload.get("ranges")
+    if not isinstance(raw_ranges, list):
+        return None
+
+    ranges = [
+        (item[0], item[1])
+        for item in raw_ranges
+        if (
+            isinstance(item, list | tuple)
+            and len(item) == 2
+            and isinstance(item[0], int)
+            and isinstance(item[1], int)
+        )
+    ]
+    normalized = _normalize_ranges(ranges, total_lines)
+    return normalized or None
+
+
+@contextmanager
+def _quiet_llm_output():
+    previous = get_output_format()
+    set_output_format("quiet")
+    try:
+        yield
+    finally:
+        set_output_format(previous)
+
+
+def _should_skip(query: str) -> bool:
+    lowered = query.lower()
+    return any(hint in lowered for hint in _FULL_OUTPUT_HINTS)
+
+
+def plan_tool_output_prune(
+    tool_name: str,
+    output: str,
+    *,
+    context_label: str | None = None,
+) -> PrunePlan | None:
+    if not get_config().get_env_bool("PRUNE_TOOL_OUTPUT", default=False):
+        return None
+
+    lines = output.splitlines()
+    if len(lines) < 2:
+        return None
+
+    query = _latest_user_query()
+    if not query or _should_skip(query):
+        return None
+
+    model = _resolve_model_name()
+    if not model:
+        return None
+
+    original_tokens = _estimate_tokens(output, model)
+    if original_tokens < _threshold_tokens():
+        return None
+
+    numbered_output = "\n".join(f"{i}\t{line}" for i, line in enumerate(lines, start=1))
+    prompt = (
+        "Select the minimal exact line ranges from this tool output that are needed "
+        "to answer the latest user request. Return strict JSON only in the form "
+        '{"ranges":[[start,end],...]}.\n'
+        "Rules:\n"
+        "- 1-indexed inclusive line ranges.\n"
+        "- Keep exact lines only; no paraphrasing or rewriting.\n"
+        "- If unsure, keep more rather than less.\n"
+        "- If almost everything matters, return the full range.\n\n"
+        f"Latest user request:\n{query}\n\n"
+        f"Tool: {tool_name}\n"
+    )
+    if context_label:
+        prompt += f"Context: {context_label}\n"
+    prompt += f"\nTool output ({len(lines)} lines):\n{numbered_output}"
+
+    messages = [
+        Message(
+            "system",
+            "You are a precise extraction helper for coding-agent tool output.",
+        ),
+        Message("user", prompt),
+    ]
+
+    try:
+        from ..llm import reply as llm_reply
+
+        with _quiet_llm_output():
+            response = llm_reply(messages, model=model, stream=False, tools=None)
+    except Exception as exc:
+        logger.debug("Tool-output pruning skipped after LLM failure: %s", exc)
+        return None
+
+    ranges = _parse_ranges(response.content, total_lines=len(lines))
+    if not ranges:
+        return None
+
+    kept_lines = sum(end - start + 1 for start, end in ranges)
+    if kept_lines >= len(lines):
+        return None
+
+    selected_text = "\n".join(
+        line for start, end in ranges for line in lines[start - 1 : end]
+    )
+    kept_tokens = _estimate_tokens(selected_text, model)
+    if kept_tokens >= original_tokens:
+        return None
+
+    return PrunePlan(
+        ranges=tuple(ranges),
+        total_lines=len(lines),
+        kept_lines=kept_lines,
+        original_tokens=original_tokens,
+        kept_tokens=kept_tokens,
+        model=model,
+    )

--- a/gptme/tools/read.py
+++ b/gptme/tools/read.py
@@ -13,11 +13,15 @@ from pathlib import Path
 
 from ..message import Message
 from ..util.context import md_codeblock
+from ..util.context_savings import record_context_savings
+from ..util.output_storage import save_large_output
+from ..util.tokens import len_tokens
 from .base import (
     Parameter,
     ToolSpec,
     ToolUse,
 )
+from .pruner import plan_tool_output_prune
 
 instructions = """
 Read the content of one or more files, or list the contents of a directory.
@@ -121,6 +125,13 @@ def _list_directory(path: Path) -> Generator[Message, None, None]:
     )
 
 
+def _current_logdir() -> Path | None:
+    from ..logmanager import LogManager
+
+    manager = LogManager.get_current_log()
+    return manager.logdir if manager and manager.logdir else None
+
+
 def _read_one(
     path: Path,
     start_line: int = 1,
@@ -170,11 +181,59 @@ def _read_one(
     start_idx = max(0, start_line - 1)
     end_idx = min(total_lines, end_line) if end_line is not None else total_lines
     selected = lines[start_idx:end_idx]
+    display_pairs = list(enumerate(selected, start=start_idx + 1))
+
+    pruned_message_prefix = ""
+    if display_pairs:
+        display_text = "\n".join(line for _, line in display_pairs)
+        plan = plan_tool_output_prune("read", display_text, context_label=str(path))
+        if plan:
+            display_pairs = [
+                pair
+                for start, end in plan.ranges
+                for pair in display_pairs[start - 1 : end]
+            ]
+            logdir = _current_logdir()
+            saved_path: Path | None = None
+            if logdir:
+                _, saved_path = save_large_output(
+                    content=display_text,
+                    logdir=logdir,
+                    output_type="read",
+                    command_info=str(path),
+                )
+
+            pruned_message_prefix = f"Pruned to {plan.kept_lines} of {plan.total_lines} lines for the current query."
+            if saved_path:
+                pruned_message_prefix += f" Full output saved to {saved_path}; read that file for the complete result."
+            else:
+                pruned_message_prefix += " Full output was not saved because no conversation logdir is active."
+
+            if logdir:
+                final_preview = md_codeblock(
+                    str(path),
+                    "\n".join(f"{line_no}\t{line}" for line_no, line in display_pairs),
+                )
+                try:
+                    kept_tokens = len_tokens(
+                        pruned_message_prefix + "\n\n" + final_preview, plan.model
+                    )
+                except Exception:
+                    kept_tokens = plan.kept_tokens
+                record_context_savings(
+                    logdir=logdir,
+                    source="read",
+                    original_tokens=plan.original_tokens,
+                    kept_tokens=kept_tokens,
+                    command_info=str(path),
+                    saved_path=saved_path,
+                )
 
     # Format with line numbers (cat -n style)
-    width = len(str(end_idx)) if end_idx > 0 else 1
+    last_line_number = display_pairs[-1][0] if display_pairs else end_idx
+    width = len(str(last_line_number)) if last_line_number > 0 else 1
     numbered = "\n".join(
-        f"{i:>{width}}\t{line}" for i, line in enumerate(selected, start=start_idx + 1)
+        f"{line_no:>{width}}\t{line}" for line_no, line in display_pairs
     )
 
     range_info = ""
@@ -182,7 +241,11 @@ def _read_one(
         shown = f"{start_idx + 1}-{end_idx}"
         range_info = f" (lines {shown} of {total_lines})"
 
-    yield Message("system", md_codeblock(f"{path}{range_info}", numbered))
+    body = md_codeblock(f"{path}{range_info}", numbered)
+    if pruned_message_prefix:
+        body = pruned_message_prefix + "\n\n" + body
+
+    yield Message("system", body)
 
 
 def execute_read(

--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -45,6 +45,7 @@ from .base import (
     ToolSpec,
     ToolUse,
 )
+from .pruner import plan_tool_output_prune
 from .shell_background import (
     execute_bg_command,
     execute_jobs_command,
@@ -1252,6 +1253,53 @@ def _format_gh_list_preview(cmd: str, stdout: str, logdir: Path | None) -> str |
     return body
 
 
+def _format_query_pruned_output(
+    cmd: str,
+    stdout: str,
+    logdir: Path | None,
+) -> str | None:
+    plan = plan_tool_output_prune("shell", stdout, context_label=cmd)
+    if not plan:
+        return None
+
+    lines = stdout.splitlines()
+    pruned_stdout = plan.apply(lines)
+    effective_logdir = logdir or get_path_fn()
+
+    saved_path: Path | None = None
+    if effective_logdir:
+        _, saved_path = save_large_output(
+            content=stdout,
+            logdir=effective_logdir,
+            output_type="shell",
+            command_info=cmd,
+        )
+
+    detail = f"Pruned to {plan.kept_lines} of {plan.total_lines} lines for the current query."
+    if saved_path:
+        detail += f" Full output saved to {saved_path}; read that file for the complete result."
+    else:
+        detail += " Full output was not saved because no conversation logdir is active."
+
+    body = detail + "\n\n" + md_codeblock("stdout", pruned_stdout)
+
+    if effective_logdir:
+        try:
+            kept_tokens = len_tokens(body, plan.model)
+        except Exception:
+            kept_tokens = plan.kept_tokens
+        record_context_savings(
+            logdir=effective_logdir,
+            source="shell",
+            original_tokens=plan.original_tokens,
+            kept_tokens=kept_tokens,
+            command_info=f"query-pruned: {cmd}",
+            saved_path=saved_path,
+        )
+
+    return body
+
+
 def _format_shell_output(
     cmd: str,
     stdout: str,
@@ -1294,6 +1342,14 @@ def _format_shell_output(
             compact_stdout = _format_gh_list_preview(cmd, stdout, logdir)
         except OSError as e:
             logger.warning("Failed to format compact shell output: %s", e)
+
+    if compact_stdout is None and (
+        returncode == 0 and stdout and not stderr and not interrupted and not timed_out
+    ):
+        try:
+            compact_stdout = _format_query_pruned_output(cmd, stdout, logdir)
+        except OSError as e:
+            logger.warning("Failed to format query-pruned shell output: %s", e)
 
     if compact_stdout is None:
         # Apply shortening logic with output storage

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1215,7 +1215,39 @@ def test_cli_auto_envvar_prefix():
     params = {p.name: p for p in main.params}
     assert "model" in params, "CLI should have --model option"
     assert "tool_format" in params, "CLI should have --tool-format option"
+    assert "prune_tool_output" in params, "CLI should have --prune-tool-output option"
     assert "workspace" in params, "CLI should have --workspace option"
+
+
+def test_setup_config_from_cli_merges_prune_tool_output_override(tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    logdir = tmp_path / "logs"
+    logdir.mkdir()
+    (logdir / "config.toml").write_text(
+        f"""[chat]
+workspace = "{workspace!s}"
+
+[env]
+EXISTING = "1"
+"""
+    )
+
+    config = setup_config_from_cli(
+        workspace=workspace,
+        logdir=logdir,
+        model=None,
+        tool_allowlist=None,
+        tool_format=None,
+        prune_tool_output=True,
+        stream=True,
+        interactive=True,
+        agent_path=None,
+    )
+
+    assert config.chat is not None
+    assert config.chat.env["EXISTING"] == "1"
+    assert config.chat.env["PRUNE_TOOL_OUTPUT"] == "1"
 
 
 def test_tool_exclusion_config(tmp_path):

--- a/tests/test_tools_pruner.py
+++ b/tests/test_tools_pruner.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+from unittest.mock import patch
+
+from gptme.message import Message
+from gptme.tools.pruner import plan_tool_output_prune
+
+
+def test_plan_tool_output_prune_selects_requested_ranges(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv("GPTME_PRUNE_TOOL_OUTPUT", "1")
+    monkeypatch.setenv("GPTME_PRUNE_TOOL_OUTPUT_THRESHOLD_TOKENS", "1")
+    monkeypatch.setenv("GPTME_PRUNE_TOOL_OUTPUT_MODEL", "mock/echo")
+
+    output = "keep 1\ndrop 2\nkeep 3\ndrop 4\n"
+
+    with (
+        patch("gptme.tools.pruner._latest_user_query", return_value="keep lines"),
+        patch("gptme.tools.pruner._resolve_model_name", return_value="mock/echo"),
+        patch(
+            "gptme.tools.pruner._estimate_tokens",
+            side_effect=lambda text, model: max(1, len(text.splitlines())),
+        ),
+        patch("gptme.tools.pruner._threshold_tokens", return_value=1),
+        patch(
+            "gptme.llm.reply",
+            return_value=Message("assistant", '{"ranges": [[1, 1], [3, 3]]}'),
+        ),
+    ):
+        plan = plan_tool_output_prune("shell", output, context_label="rg keep .")
+
+    assert plan is not None
+    assert plan.ranges == ((1, 1), (3, 3))
+    assert plan.kept_lines == 2
+    assert plan.apply(output.splitlines()) == "keep 1\nkeep 3"
+
+
+def test_plan_tool_output_prune_skips_full_output_requests(monkeypatch):
+    monkeypatch.setenv("GPTME_PRUNE_TOOL_OUTPUT", "1")
+    monkeypatch.setenv("GPTME_PRUNE_TOOL_OUTPUT_THRESHOLD_TOKENS", "1")
+
+    with patch(
+        "gptme.tools.pruner._latest_user_query",
+        return_value="show the full output",
+    ):
+        assert plan_tool_output_prune("shell", "line 1\nline 2\n") is None

--- a/tests/test_tools_read.py
+++ b/tests/test_tools_read.py
@@ -3,9 +3,11 @@
 import os
 import stat
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
+from gptme.tools.pruner import PrunePlan
 from gptme.tools.read import execute_read
 
 
@@ -117,6 +119,32 @@ def test_read_binary_file(tmp_path: Path):
     messages = list(execute_read(None, [str(path)], None))
     assert len(messages) == 1
     assert "Cannot read binary file" in messages[0].content
+
+
+def test_read_file_query_prunes_output(tmp_path: Path):
+    path = tmp_path / "test.txt"
+    path.write_text("keep 1\ndrop 2\nkeep 3\ndrop 4\n")
+    plan = PrunePlan(
+        ranges=((1, 1), (3, 3)),
+        total_lines=4,
+        kept_lines=2,
+        original_tokens=40,
+        kept_tokens=10,
+        model="mock/echo",
+    )
+
+    with (
+        patch("gptme.tools.read.plan_tool_output_prune", return_value=plan),
+        patch("gptme.tools.read._current_logdir", return_value=tmp_path / "logdir"),
+    ):
+        messages = list(execute_read(None, [str(path)], None))
+
+    assert len(messages) == 1
+    content = messages[0].content
+    assert "Pruned to 2 of 4 lines" in content
+    assert "1\tkeep 1" in content
+    assert "3\tkeep 3" in content
+    assert "2\tdrop 2" not in content
 
 
 def test_read_empty_file(tmp_path: Path):

--- a/tests/test_tools_shell.py
+++ b/tests/test_tools_shell.py
@@ -7,10 +7,12 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from gptme.tools.pruner import PrunePlan
 from gptme.tools.shell import (
     ShellSession,
     _format_gh_list_preview,
     _format_git_log_preview,
+    _format_query_pruned_output,
     _format_shell_output,
     _get_truncation_budget,
     _matches_gh_list,
@@ -618,6 +620,32 @@ def test_format_shell_output_lower_threshold_records_savings(monkeypatch, tmp_pa
     assert "output truncated" in output or "lines truncated" in output
     ledger = tmp_path / "context-savings.jsonl"
     assert ledger.exists()
+
+
+def test_format_query_pruned_output_records_savings(tmp_path):
+    stdout = "keep 1\ndrop 2\nkeep 3\ndrop 4\n"
+    plan = PrunePlan(
+        ranges=((1, 1), (3, 3)),
+        total_lines=4,
+        kept_lines=2,
+        original_tokens=400,
+        kept_tokens=10,
+        model="mock/echo",
+    )
+
+    with patch("gptme.tools.shell.plan_tool_output_prune", return_value=plan):
+        output = _format_query_pruned_output("rg keep .", stdout, tmp_path)
+
+    assert output is not None
+    assert "Pruned to 2 of 4 lines" in output
+    assert "keep 1" in output
+    assert "keep 3" in output
+    assert "drop 2" not in output
+
+    ledger = tmp_path / "context-savings.jsonl"
+    rows = [json.loads(line) for line in ledger.read_text().splitlines()]
+    assert len(rows) == 1
+    assert rows[0]["command_info"] == "query-pruned: rg keep ."
     rows = [
         json.loads(line) for line in ledger.read_text().splitlines() if line.strip()
     ]


### PR DESCRIPTION
## Summary
- add an opt-in `--prune-tool-output/--no-prune-tool-output` CLI flag wired through chat env
- add a small query-aware pruner for large `shell` and `read` outputs using the summary model
- save full outputs plus context-savings telemetry when pruning fires, and cover the new paths with focused tests

## Testing
- `uv run python -m pytest /tmp/worktrees/gptme-tool-output-pruning-70a0/tests/test_tools_pruner.py /tmp/worktrees/gptme-tool-output-pruning-70a0/tests/test_tools_shell.py /tmp/worktrees/gptme-tool-output-pruning-70a0/tests/test_tools_read.py /tmp/worktrees/gptme-tool-output-pruning-70a0/tests/test_config.py -q`
- `uv run ruff check /tmp/worktrees/gptme-tool-output-pruning-70a0/gptme/tools/pruner.py /tmp/worktrees/gptme-tool-output-pruning-70a0/gptme/tools/shell.py /tmp/worktrees/gptme-tool-output-pruning-70a0/gptme/tools/read.py /tmp/worktrees/gptme-tool-output-pruning-70a0/gptme/cli/main.py /tmp/worktrees/gptme-tool-output-pruning-70a0/gptme/config/cli_setup.py /tmp/worktrees/gptme-tool-output-pruning-70a0/tests/test_tools_pruner.py /tmp/worktrees/gptme-tool-output-pruning-70a0/tests/test_tools_shell.py /tmp/worktrees/gptme-tool-output-pruning-70a0/tests/test_tools_read.py /tmp/worktrees/gptme-tool-output-pruning-70a0/tests/test_config.py`
