### PR TITLE
fix(mcp): keep tool stdout off stdio transport

### DIFF
--- a/gptme/acp/__main__.py
+++ b/gptme/acp/__main__.py
@@ -9,7 +9,7 @@ Or via the CLI:
 
     gptme --acp
 
-After ``_capture_stdio_transport()``, fd 1 is redirected to stderr via
+After ``capture_stdio_transport()``, fd 1 is redirected to stderr via
 ``os.dup2(2, 1)``.  The only way to write to the real stdout is through
 the file objects returned by that function.  This is intentional —
 JSON-RPC owns stdout.
@@ -23,6 +23,8 @@ import logging
 import os
 import sys
 from typing import IO, Any
+
+from gptme.util.stdio import capture_stdio_transport
 
 logger = logging.getLogger(__name__)
 
@@ -72,34 +74,6 @@ class _WritePipeProtocol(asyncio.BaseProtocol):
             raise ConnectionResetError("Connection lost")
         if self._paused and self._drain_waiter is not None:
             await self._drain_waiter
-
-
-def _capture_stdio_transport() -> tuple[IO[bytes], IO[bytes]]:
-    """Capture real stdin/stdout fds, then redirect fd 1 to fd 2 at the OS level.
-
-    After this call:
-    - The returned (stdin_file, stdout_file) are the ONLY way to talk to the
-      real stdin/stdout (i.e., the JSON-RPC channel).
-    - fd 1 now points to stderr, so print(), rprint(), Console(),
-      sys.stdout.write(), and even C extensions writing to fd 1 all go to stderr.
-    - No monkey-patching, no import-order sensitivity.
-    """
-    # 1. Duplicate the real fds before we clobber them
-    real_stdin_fd = os.dup(0)
-    real_stdout_fd = os.dup(1)
-
-    # 2. Point fd 1 (stdout) at fd 2 (stderr) — OS level, bulletproof
-    os.dup2(2, 1)
-
-    # 3. Rebuild Python's sys.stdout on the now-redirected fd 1
-    #    so even sys.stdout.write() goes to stderr
-    sys.stdout = open(1, "w", buffering=1, closefd=False)
-
-    # 4. Return raw binary file objects for the JSON-RPC transport
-    real_stdin = os.fdopen(real_stdin_fd, "rb", buffering=0)
-    real_stdout = os.fdopen(real_stdout_fd, "wb", buffering=0)
-
-    return real_stdin, real_stdout
 
 
 def _truncate(value: Any, max_len: int = 200) -> str:
@@ -215,7 +189,7 @@ async def _run_acp(real_stdin: IO[bytes], real_stdout: IO[bytes]) -> None:
 def main() -> int:
     """Run the gptme ACP agent."""
     # === FIRST: capture fds before ANY gptme imports ===
-    real_stdin, real_stdout = _capture_stdio_transport()
+    real_stdin, real_stdout = capture_stdio_transport()
 
     # Logging goes to stderr (fd 2, untouched).
     # Respect GPTME_LOG_LEVEL env var for debugging ACP protocol issues.

--- a/gptme/cli/cmd_mcp_serve.py
+++ b/gptme/cli/cmd_mcp_serve.py
@@ -53,6 +53,10 @@ def main(
     """
     logging.basicConfig(level=getattr(logging, log_level.upper()), format="%(message)s")
 
+    from ..util.stdio import capture_stdio_transport
+
+    real_stdin, real_stdout = capture_stdio_transport()
+
     from ..mcp.server import DEFAULT_TOOLS, GptmeMCPServer
 
     tool_names: list[str] | None = None
@@ -65,4 +69,4 @@ def main(
     )
 
     server = GptmeMCPServer(tool_names=tool_names, workspace=workspace)
-    server.serve_stdio()
+    server.serve_stdio(stdin=real_stdin, stdout=real_stdout)

--- a/gptme/mcp/server.py
+++ b/gptme/mcp/server.py
@@ -218,6 +218,10 @@ class GptmeMCPServer:
         stdout: IO[bytes] | None = None,
     ) -> None:
         """Run the MCP server over stdio (for Claude Desktop and similar clients)."""
+        if stdin is None and stdout is None:
+            from ..util.stdio import capture_stdio_transport
+
+            stdin, stdout = capture_stdio_transport()
         if self._workspace:
             # Change CWD so that all tools (read, save, append, shell) resolve
             # relative paths against the configured workspace directory instead of

--- a/gptme/mcp/server.py
+++ b/gptme/mcp/server.py
@@ -23,12 +23,15 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-from typing import TYPE_CHECKING, Any
+from io import TextIOWrapper
+from typing import IO, TYPE_CHECKING, Any
 
+import anyio
 import mcp.server.stdio
 import mcp.types as types
 from mcp.server.lowlevel import Server
 
+from ..__version__ import __version__
 from ..tools import init_tools
 
 if TYPE_CHECKING:
@@ -114,7 +117,7 @@ class GptmeMCPServer:
             t for t in (tool_names or DEFAULT_TOOLS) if t not in _EXCLUDED_TOOLS
         ]
         self._workspace = workspace
-        self._server = Server("gptme")
+        self._server = Server("gptme", version=__version__)
         self._loaded_tools: list[ToolSpec] = []
         # Persistent shell session shared across all tool calls. Lazily created
         # on first use; injected into each executor thread via _shell_var so that
@@ -209,7 +212,11 @@ class GptmeMCPServer:
             "Loaded tools: %s", [t.name for t in self._loaded_tools if t.execute]
         )
 
-    def serve_stdio(self) -> None:
+    def serve_stdio(
+        self,
+        stdin: IO[bytes] | None = None,
+        stdout: IO[bytes] | None = None,
+    ) -> None:
         """Run the MCP server over stdio (for Claude Desktop and similar clients)."""
         if self._workspace:
             # Change CWD so that all tools (read, save, append, shell) resolve
@@ -219,7 +226,22 @@ class GptmeMCPServer:
         self._init_tools()
 
         async def _run() -> None:
-            async with mcp.server.stdio.stdio_server() as (read_stream, write_stream):
+            stdin_stream = (
+                anyio.wrap_file(
+                    TextIOWrapper(stdin, encoding="utf-8", errors="replace")
+                )
+                if stdin is not None
+                else None
+            )
+            stdout_stream = (
+                anyio.wrap_file(TextIOWrapper(stdout, encoding="utf-8"))
+                if stdout is not None
+                else None
+            )
+            async with mcp.server.stdio.stdio_server(
+                stdin=stdin_stream,
+                stdout=stdout_stream,
+            ) as (read_stream, write_stream):
                 await self._server.run(
                     read_stream,
                     write_stream,

--- a/gptme/util/stdio.py
+++ b/gptme/util/stdio.py
@@ -1,0 +1,29 @@
+"""Utilities for JSON-RPC stdio transports."""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import IO
+
+
+def capture_stdio_transport() -> tuple[IO[bytes], IO[bytes]]:
+    """Capture real stdin/stdout fds, then redirect fd 1 to fd 2.
+
+    After this call:
+    - The returned (stdin_file, stdout_file) are the only way to talk to the
+      real stdin/stdout JSON-RPC channel.
+    - fd 1 points to stderr, so print(), sys.stdout.write(), and C extensions
+      writing to stdout cannot corrupt the protocol stream.
+    - No monkey-patching or import-order sensitivity is required.
+    """
+    real_stdin_fd = os.dup(0)
+    real_stdout_fd = os.dup(1)
+
+    os.dup2(2, 1)
+    sys.stdout = open(1, "w", buffering=1, closefd=False)
+
+    real_stdin = os.fdopen(real_stdin_fd, "rb", buffering=0)
+    real_stdout = os.fdopen(real_stdout_fd, "wb", buffering=0)
+
+    return real_stdin, real_stdout

--- a/tests/test_acp_stdout.py
+++ b/tests/test_acp_stdout.py
@@ -15,15 +15,15 @@ import pytest
 
 
 def test_capture_stdio_transport():
-    """_capture_stdio_transport redirects fd 1 to stderr at OS level."""
-    from gptme.acp.__main__ import _capture_stdio_transport
+    """capture_stdio_transport redirects fd 1 to stderr at OS level."""
+    from gptme.util.stdio import capture_stdio_transport
 
     # Save original state
     original_stdout_fd = os.dup(1)
     original_sys_stdout = sys.stdout
 
     try:
-        real_stdin, real_stdout = _capture_stdio_transport()
+        real_stdin, real_stdout = capture_stdio_transport()
 
         # real_stdout should be a writable binary file object
         assert hasattr(real_stdout, "write")

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -2,6 +2,12 @@
 
 from __future__ import annotations
 
+import json
+import queue
+import subprocess
+import sys
+import threading
+import time
 from typing import TYPE_CHECKING
 
 import pytest
@@ -191,8 +197,8 @@ class TestMCPServerHandlers:
         result = await server_with_mock_tools._server.request_handlers[
             types.ListToolsRequest
         ](req)
-        assert result.root.tools  # type: ignore[union-attr]
-        tool_names = [t.name for t in result.root.tools]  # type: ignore[union-attr]
+        assert result.root.tools
+        tool_names = [t.name for t in result.root.tools]
         assert "shell" in tool_names
 
     @pytest.mark.asyncio
@@ -210,7 +216,7 @@ class TestMCPServerHandlers:
 
         req = types.ListToolsRequest(method="tools/list", params=None)
         result = await server._server.request_handlers[types.ListToolsRequest](req)
-        tool_names = [t.name for t in result.root.tools]  # type: ignore[union-attr]
+        tool_names = [t.name for t in result.root.tools]
         assert "noexec" not in tool_names
 
     @pytest.mark.asyncio
@@ -228,11 +234,9 @@ class TestMCPServerHandlers:
             types.CallToolRequest
         ](req)
         # MCP wraps handler exceptions into an isError=True CallToolResult
-        assert result.root.isError is True  # type: ignore[union-attr]
+        assert result.root.isError is True
         assert any(
-            "nonexistent" in c.text
-            for c in result.root.content  # type: ignore[union-attr]
-            if hasattr(c, "text")
+            "nonexistent" in c.text for c in result.root.content if hasattr(c, "text")
         )
 
     @pytest.mark.asyncio
@@ -268,7 +272,7 @@ class TestMCPServerHandlers:
             types.CallToolRequest
         ](req)
 
-        content = result.root.content  # type: ignore[union-attr]
+        content = result.root.content
         assert any("hello from tool" in c.text for c in content if hasattr(c, "text"))
 
     @pytest.mark.asyncio
@@ -347,6 +351,116 @@ class TestMCPServerCLI:
         runner = CliRunner()
         result = runner.invoke(main, ["--log-level", "INVALID"])
         assert result.exit_code != 0
+
+    def test_stdio_transport_keeps_tool_stdout_out_of_protocol(self, tmp_path) -> None:
+        """Tool prints must not leak as bare lines on the JSON-RPC stdout stream."""
+        from gptme.__version__ import __version__
+
+        marker = "MCP_STDOUT_MARKER"
+        stdout_lines: list[str] = []
+        proc = subprocess.Popen(
+            [
+                sys.executable,
+                "-c",
+                "from gptme.cli.cmd_mcp_serve import main; main()",
+                "--tools",
+                "ipython",
+            ],
+            text=True,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=tmp_path,
+        )
+
+        stdin = proc.stdin
+        stdout = proc.stdout
+        assert stdin is not None
+        assert stdout is not None
+        stdout_queue: queue.Queue[str] = queue.Queue()
+
+        def collect_stdout() -> None:
+            for line in stdout:
+                stdout_queue.put(line.rstrip("\n"))
+
+        stdout_thread = threading.Thread(target=collect_stdout, daemon=True)
+        stdout_thread.start()
+
+        def send(message: dict) -> None:
+            stdin.write(json.dumps(message) + "\n")
+            stdin.flush()
+
+        def read_response(message_id: int, timeout: float = 20) -> dict:
+            deadline = time.monotonic() + timeout
+            while time.monotonic() < deadline:
+                try:
+                    line = stdout_queue.get(timeout=0.1)
+                except queue.Empty:
+                    if proc.poll() is not None:
+                        break
+                    continue
+                if not line:
+                    continue
+                line = line.rstrip("\n")
+                stdout_lines.append(line)
+                assert line != marker
+                message = json.loads(line)
+                if message.get("id") == message_id:
+                    return message
+            if proc.poll() is None:
+                proc.terminate()
+                proc.wait(timeout=5)
+            stderr = proc.stderr.read() if proc.stderr else ""
+            raise AssertionError(
+                f"Timed out waiting for response {message_id}; stdout={stdout_lines!r};"
+                f" stderr={stderr}"
+            )
+
+        send(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-06-18",
+                    "capabilities": {},
+                    "clientInfo": {"name": "pytest", "version": "0"},
+                },
+            }
+        )
+        initialize_response = read_response(1)
+
+        send(
+            {
+                "jsonrpc": "2.0",
+                "method": "notifications/initialized",
+                "params": {},
+            }
+        )
+        send(
+            {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/call",
+                "params": {
+                    "name": "ipython",
+                    "arguments": {"code": f"print({marker!r})"},
+                },
+            }
+        )
+        call_response = read_response(2)
+
+        stdin.close()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.terminate()
+            proc.wait(timeout=5)
+
+        assert initialize_response["result"]["serverInfo"]["version"] == __version__
+
+        content = call_response["result"]["content"]
+        assert any(marker in item.get("text", "") for item in content)
 
 
 class TestWorkspaceHandling:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -356,6 +356,7 @@ class TestMCPServerCLI:
         result = runner.invoke(main, ["--log-level", "INVALID"])
         assert result.exit_code != 0
 
+    @pytest.mark.timeout(60)
     def test_stdio_transport_keeps_tool_stdout_out_of_protocol(self, tmp_path) -> None:
         """Tool prints must not leak as bare lines on the JSON-RPC stdout stream."""
         from gptme.__version__ import __version__
@@ -461,7 +462,10 @@ class TestMCPServerCLI:
             proc.terminate()
             proc.wait(timeout=5)
 
-        assert initialize_response["result"]["serverInfo"]["version"] == __version__
+        # Compare base versions only: the local segment (+hash / +unknown) depends on
+        # install mode and git state, which differ between this process and the child.
+        server_version = initialize_response["result"]["serverInfo"]["version"]
+        assert server_version.split("+")[0] == __version__.split("+")[0]
 
         content = call_response["result"]["content"]
         assert any(marker in item.get("text", "") for item in content)

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -197,6 +197,7 @@ class TestMCPServerHandlers:
         result = await server_with_mock_tools._server.request_handlers[
             types.ListToolsRequest
         ](req)
+        assert isinstance(result.root, types.ListToolsResult)
         assert result.root.tools
         tool_names = [t.name for t in result.root.tools]
         assert "shell" in tool_names
@@ -216,6 +217,7 @@ class TestMCPServerHandlers:
 
         req = types.ListToolsRequest(method="tools/list", params=None)
         result = await server._server.request_handlers[types.ListToolsRequest](req)
+        assert isinstance(result.root, types.ListToolsResult)
         tool_names = [t.name for t in result.root.tools]
         assert "noexec" not in tool_names
 
@@ -233,6 +235,7 @@ class TestMCPServerHandlers:
         result = await server_with_mock_tools._server.request_handlers[
             types.CallToolRequest
         ](req)
+        assert isinstance(result.root, types.CallToolResult)
         # MCP wraps handler exceptions into an isError=True CallToolResult
         assert result.root.isError is True
         assert any(
@@ -271,6 +274,7 @@ class TestMCPServerHandlers:
         result = await server_with_mock_tools._server.request_handlers[
             types.CallToolRequest
         ](req)
+        assert isinstance(result.root, types.CallToolResult)
 
         content = result.root.content
         assert any("hello from tool" in c.text for c in content if hasattr(c, "text"))


### PR DESCRIPTION
## What

Fixes the queued MCP stdio protocol bug from gptme/gptme#3156:

- extract the ACP fd-capture pattern into `gptme.util.stdio.capture_stdio_transport()`
- capture real stdin/stdout in `gptme-mcp-server` before loading the MCP server/tools
- pass the captured streams into `mcp.server.stdio.stdio_server(stdin=..., stdout=...)`
- set the MCP server version to gptme's `__version__` instead of the `mcp` package version

This does not close #3156; that issue still tracks hosted/registry follow-up scope.

## Verification

- `uv --directory /home/bob/bob/projects/gptme-mcp-stdio-b13b run ruff check gptme/util/stdio.py gptme/acp/__main__.py gptme/cli/cmd_mcp_serve.py gptme/mcp/server.py tests/test_mcp_server.py`
- `uv --directory /home/bob/bob/projects/gptme-mcp-stdio-b13b run python3 -m pytest tests/test_mcp_server.py -q`
- `prek run mypy --files gptme/util/stdio.py gptme/acp/__main__.py gptme/cli/cmd_mcp_serve.py gptme/mcp/server.py tests/test_mcp_server.py`
