### PR TITLE
ci(release): push version bumps via release-environment deploy key

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,11 +144,19 @@ jobs:
   # ── Prepare ───────────────────────────────────────────────────────────
   # Only for schedule/dispatch. Bumps version, generates changelog, creates
   # the GitHub release via publish_release.sh.
+  #
+  # Uses the `release` environment's SSH_PRIVATE_KEY (a read-write deploy
+  # key) for git pushes, so the version-bump commit and tag can bypass the
+  # branch ruleset that blocks direct pushes to master (deploy keys are a
+  # bypass actor on the ruleset; GITHUB_TOKEN is not). Note: unlike
+  # GITHUB_TOKEN pushes, deploy-key pushes trigger `push` workflows, so CI
+  # runs on the version-bump commit.
   prepare:
     name: Create release
     needs: check
     if: needs.check.outputs.should_release == 'true'
     runs-on: ubuntu-latest
+    environment: release
     outputs:
       tag: ${{ steps.version.outputs.tag }}
     steps:
@@ -156,7 +164,9 @@ jobs:
         with:
           ref: master
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Clone over SSH and persist the deploy key so the pushes in
+          # publish_release.sh (branch + tag) authenticate with it.
+          ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
       - name: Configure git
         run: |

--- a/scripts/publish_release.sh
+++ b/scripts/publish_release.sh
@@ -76,7 +76,9 @@ echo "Pushing ${TAG} to origin..."
 if [ "$DRY_RUN" = "false" ]; then
     if [ "$PRERELEASE" = "false" ]; then
         # Stable releases: push version bump commit to master.
-        # Requires the user/bot to have branch protection bypass rights.
+        # Requires branch ruleset bypass rights: in CI this is the deploy
+        # key from the `release` environment (set up via actions/checkout
+        # ssh-key); locally it's the maintainer's own credentials.
         git push origin HEAD:master
     else
         # Pre-releases: skip the branch push entirely.


### PR DESCRIPTION
## Summary

Switches the release workflow's `prepare` job to push over SSH using the read-write deploy key (`SSH_PRIVATE_KEY` secret in the new `release` environment) instead of `GITHUB_TOKEN`.

This is the final piece needed to enable the "Only maintainers can push to master" branch ruleset (which requires PRs / blocks direct pushes): the deploy key is already configured as a bypass actor on that ruleset, so the scheduled/dispatched release workflow can keep pushing the version-bump commit and tag to master while everything else is blocked.

## Changes

- `prepare` job: add `environment: release` (grants access to the environment-scoped `SSH_PRIVATE_KEY` secret)
- `prepare` job checkout: use `ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}` instead of `token: ${{ secrets.GITHUB_TOKEN }}` — actions/checkout clones over SSH and persists the key, so the `git push` calls in `scripts/publish_release.sh` (branch + tag) authenticate as the deploy key
- Update comments in `publish_release.sh` to document the auth model

## Verified preconditions

- Deploy key `github-ci-release-workflow` is registered read-write on the repo and matches the key in the `release` environment secret
- `release` environment exists with `SSH_PRIVATE_KEY`, deployment branch policy = protected branches only (master qualifies — it's covered by an active ruleset, so schedule/dispatch runs on master can use the environment)
- Disabled ruleset "Only maintainers can push to master" has `DeployKey` + maintainer-role bypass actors, so it can be enabled after this merges
- `Releases` tag ruleset only blocks deletion/force-update of `v*` tags — new tag creation by the deploy key is unaffected
- `gh release create` in `publish_release.sh` still uses `GITHUB_TOKEN`, so the `release: created` event won't recursively trigger workflow runs

## Behavior change

Deploy-key pushes trigger `push` workflows (unlike `GITHUB_TOKEN` pushes), so CI will now run on stable-release version-bump commits pushed to master. Dev pre-releases are unaffected (they skip the branch push and only push a tag).