### PR TITLE
fix(ci): name Android release assets like desktop bundles

### DIFF
--- a/.github/workflows/tauri.yml
+++ b/.github/workflows/tauri.yml
@@ -807,7 +807,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ inputs.tag || github.ref_name }}
         run: |
+          # Rename gradle's generic output names (app-universal-release-unsigned.apk)
+          # to match the desktop bundle naming (gptme-tauri_X.Y.Z_<arch>.<ext>),
+          # e.g. gptme-tauri_0.32.0_universal-unsigned.apk. The "-release" build-type
+          # marker is dropped; "-unsigned" is kept since the APK isn't signed yet.
+          VERSION="${TAG#v}"
           find android-dist -name "*.apk" -o -name "*.aab" | while read -r f; do
-            echo "Uploading $f"
-            gh release upload "$TAG" "$f" --clobber
+            new="$(basename "$f" | sed -E "s/^app-/gptme-tauri_${VERSION}_/; s/-release//")"
+            mv "$f" "$(dirname "$f")/$new"
+            echo "Uploading $new"
+            gh release upload "$TAG" "$(dirname "$f")/$new" --clobber
           done


### PR DESCRIPTION
APK/AAB release assets were uploaded with gradle's generic output names:

```
app-universal-release-unsigned.apk
app-universal-release.aab
```

Rename on upload to match the desktop Tauri bundle naming convention (`gptme-tauri_X.Y.Z_<arch>.<ext>`):

```
gptme-tauri_0.32.0_universal-unsigned.apk
gptme-tauri_0.32.0_universal.aab
```

The transform is generic (`app-` prefix → `gptme-tauri_VERSION_`, drop `-release`), so per-ABI APKs would also get sensible names if the build ever produces them. `-unsigned` is kept since the APK genuinely isn't signed — worth surfacing to users until APK signing is set up.