### PR TITLE
perf: cut startup time ~6x by deferring heavy imports

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -64,6 +64,22 @@ jobs:
         echo "warm_time=$WARM_TIME" >> $GITHUB_OUTPUT
         echo "Warm startup median: ${WARM_TIME}s"
 
+    - name: Benchmark --help
+      id: help
+      run: |
+        # --help renders the dynamic help (tool/command discovery) but skips
+        # config/LLM/prompt init — an in-between of import-only and full cycle.
+        VENV_PATH=$(poetry env info --path)
+        hyperfine \
+          --runs 10 \
+          --warmup 3 \
+          --export-json help.json \
+          "$VENV_PATH/bin/gptme --help"
+
+        HELP_TIME=$(python3 -c "import json; print(f'{json.load(open(\"help.json\"))[\"results\"][0][\"median\"]:.3f}')")
+        echo "help_time=$HELP_TIME" >> $GITHUB_OUTPUT
+        echo "--help median: ${HELP_TIME}s"
+
     - name: Benchmark full start/exit cycle
       id: cycle
       env:
@@ -90,17 +106,20 @@ jobs:
       env:
         COLD_TIME: ${{ steps.cold.outputs.cold_time }}
         WARM_TIME: ${{ steps.warm.outputs.warm_time }}
+        HELP_TIME: ${{ steps.help.outputs.help_time }}
         CYCLE_TIME: ${{ steps.cycle.outputs.cycle_time }}
         # Thresholds in seconds (with margin for CI variability).
         # History: warm import was ~1.5-2s (threshold 2.5) before gptme.cli.main
         # was made lazy; it should now stay well under 0.5s.
         COLD_THRESHOLD: "6.0"
         WARM_THRESHOLD: "1.0"
+        HELP_THRESHOLD: "2.0"
         CYCLE_THRESHOLD: "3.0"
       run: |
         echo "=== Startup Benchmark Results (hyperfine medians) ==="
         echo "Cold startup: ${COLD_TIME}s (threshold: ${COLD_THRESHOLD}s)"
         echo "Warm startup: ${WARM_TIME}s (threshold: ${WARM_THRESHOLD}s)"
+        echo "--help:       ${HELP_TIME}s (threshold: ${HELP_THRESHOLD}s)"
         echo "Full cycle:   ${CYCLE_TIME}s (threshold: ${CYCLE_THRESHOLD}s)"
         echo ""
 
@@ -127,6 +146,13 @@ jobs:
           FAILED=1
         else
           echo "✅ PASS: Warm startup within threshold"
+        fi
+
+        if (( $(echo "$HELP_TIME > $HELP_THRESHOLD" | bc -l) )); then
+          echo "::error::--help (${HELP_TIME}s) exceeds threshold (${HELP_THRESHOLD}s)"
+          FAILED=1
+        else
+          echo "✅ PASS: --help within threshold"
         fi
 
         if (( $(echo "$CYCLE_TIME > $CYCLE_THRESHOLD" | bc -l) )); then

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -64,24 +64,53 @@ jobs:
         echo "warm_time=$WARM_TIME" >> $GITHUB_OUTPUT
         echo "Warm startup median: ${WARM_TIME}s"
 
+    - name: Benchmark full start/exit cycle
+      id: cycle
+      env:
+        # Dummy key so init_model resolves a provider without prompting;
+        # '/exit' quits before any API call is made.
+        OPENAI_API_KEY: sk-dummy-benchmark
+      run: |
+        # Full cycle: config load, plugin/tool init, prompt build, /exit.
+        # Invokes the venv binary directly — `poetry run` adds substantial
+        # wrapper overhead that would drown out what we're measuring.
+        # stdin from /dev/null so the piped-stdin grace period isn't hit.
+        VENV_PATH=$(poetry env info --path)
+        hyperfine \
+          --runs 10 \
+          --warmup 3 \
+          --export-json cycle.json \
+          "$VENV_PATH/bin/gptme '/exit' < /dev/null"
+
+        CYCLE_TIME=$(python3 -c "import json; print(f'{json.load(open(\"cycle.json\"))[\"results\"][0][\"median\"]:.3f}')")
+        echo "cycle_time=$CYCLE_TIME" >> $GITHUB_OUTPUT
+        echo "Full start/exit cycle median: ${CYCLE_TIME}s"
+
     - name: Check thresholds
       env:
         COLD_TIME: ${{ steps.cold.outputs.cold_time }}
         WARM_TIME: ${{ steps.warm.outputs.warm_time }}
-        # Thresholds in seconds (with margin for CI variability)
-        COLD_THRESHOLD: "10.0"
-        WARM_THRESHOLD: "2.5"
+        CYCLE_TIME: ${{ steps.cycle.outputs.cycle_time }}
+        # Thresholds in seconds (with margin for CI variability).
+        # History: warm import was ~1.5-2s (threshold 2.5) before gptme.cli.main
+        # was made lazy; it should now stay well under 0.5s.
+        COLD_THRESHOLD: "6.0"
+        WARM_THRESHOLD: "1.0"
+        CYCLE_THRESHOLD: "3.0"
       run: |
         echo "=== Startup Benchmark Results (hyperfine medians) ==="
         echo "Cold startup: ${COLD_TIME}s (threshold: ${COLD_THRESHOLD}s)"
         echo "Warm startup: ${WARM_TIME}s (threshold: ${WARM_THRESHOLD}s)"
+        echo "Full cycle:   ${CYCLE_TIME}s (threshold: ${CYCLE_THRESHOLD}s)"
         echo ""
 
         # Parse stddev for reporting
         COLD_STDDEV=$(python3 -c "import json; print(f'{json.load(open(\"cold.json\"))[\"results\"][0][\"stddev\"]:.3f}')")
         WARM_STDDEV=$(python3 -c "import json; print(f'{json.load(open(\"warm.json\"))[\"results\"][0][\"stddev\"]:.3f}')")
+        CYCLE_STDDEV=$(python3 -c "import json; print(f'{json.load(open(\"cycle.json\"))[\"results\"][0][\"stddev\"]:.3f}')")
         echo "Cold stddev: ${COLD_STDDEV}s"
         echo "Warm stddev: ${WARM_STDDEV}s"
+        echo "Cycle stddev: ${CYCLE_STDDEV}s"
         echo ""
 
         FAILED=0
@@ -98,6 +127,13 @@ jobs:
           FAILED=1
         else
           echo "✅ PASS: Warm startup within threshold"
+        fi
+
+        if (( $(echo "$CYCLE_TIME > $CYCLE_THRESHOLD" | bc -l) )); then
+          echo "::error::Full cycle (${CYCLE_TIME}s +/- ${CYCLE_STDDEV}s) exceeds threshold (${CYCLE_THRESHOLD}s)"
+          FAILED=1
+        else
+          echo "✅ PASS: Full cycle within threshold"
         fi
 
         if [ $FAILED -eq 1 ]; then

--- a/Makefile
+++ b/Makefile
@@ -329,9 +329,16 @@ bench-import:  ## Benchmark import time
 	@#time poetry run python -X importtime -m gptme --model openrouter --non-interactive 2>&1 | grep "import time" | cut -d'|' -f 2- | sort -n
 	@#time poetry run python -X importtime -m gptme --model anthropic --non-interactive 2>&1 | grep "import time" | cut -d'|' -f 2- | sort -n
 
-bench-startup:  ## Benchmark startup time
+bench-startup:  ## Benchmark startup time (import + full start/exit cycle)
+	@# Invoke the venv binaries directly: `poetry run` adds 1-3s of wrapper
+	@# overhead per invocation, which would drown out what we're measuring.
+	@# `< /dev/null` closes stdin so the piped-stdin grace period isn't hit.
 	@echo "Benchmarking startup time for gptme"
-	hyperfine "poetry run gptme '/exit'" -M 5 || poetry run gptme '/exit' || exit 1
+	@VENV=$$(poetry env info --path) && \
+	hyperfine --warmup 2 -M 10 \
+		-n "import gptme.cli.main" "$$VENV/bin/python -c 'from gptme.cli.main import main'" \
+		-n "full start/exit cycle" "$$VENV/bin/gptme '/exit' < /dev/null" \
+	|| "$$VENV/bin/gptme" '/exit' < /dev/null || exit 1
 
 help:  ## Show this help message
 	@echo $(MAKEFILE_LIST)

--- a/Makefile
+++ b/Makefile
@@ -337,6 +337,7 @@ bench-startup:  ## Benchmark startup time (import + full start/exit cycle)
 	@VENV=$$(poetry env info --path) && \
 	hyperfine --warmup 2 -M 10 \
 		-n "import gptme.cli.main" "$$VENV/bin/python -c 'from gptme.cli.main import main'" \
+		-n "gptme --help" "$$VENV/bin/gptme --help" \
 		-n "full start/exit cycle" "$$VENV/bin/gptme '/exit' < /dev/null" \
 	|| "$$VENV/bin/gptme" '/exit' < /dev/null || exit 1
 

--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -1,10 +1,10 @@
+from __future__ import annotations
+
 import atexit
-import cProfile
 import importlib
 import importlib.metadata as _ilm
 import logging
 import os
-import pstats
 import select
 import shlex
 import shutil
@@ -17,50 +17,30 @@ import traceback
 from datetime import datetime, timezone
 from itertools import islice
 from pathlib import Path
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 import click
 from click.core import ParameterSource
 
-try:
-    pick = importlib.import_module("pick").pick
-except (ImportError, AttributeError):
-    pick = None
-
 import gptme
 
-from ..chat import chat
-from ..commands import _gen_help
-from ..config import ensure_workspace_dir, get_config, setup_config_from_cli
 from ..constants import MULTIPROMPT_SEPARATOR
 from ..dirs import get_logs_dir
 from ..gears import parse_gear, resolve_gear
-from ..init import init_logging
-from ..llm import get_provider_from_model
-from ..llm import reply as llm_reply
-from ..llm.models import get_recommended_model
-from ..logmanager import (
-    ConversationMeta,
-    conversation_name_error,
-    get_user_conversations,
-)
-from ..message import Message
-from ..profiles import get_profile
-from ..prompts import (
-    ContextMode,
-    PromptSectionStat,
-    format_prompt_stats,
-    get_prompt,
-    get_prompt_stats,
-)
-from ..telemetry import init_telemetry, shutdown_telemetry
-from ..tools import ToolFormat, get_available_tools, init_tools
-from ..util import epoch_to_age
-from ..util.auto_naming import generate_conversation_id
-from ..util.context import md_codeblock
-from ..util.interrupt import handle_keyboard_interrupt, set_interruptible
-from ..util.prompt import add_history
-from ..util.tokens import len_tokens
+
+# NOTE: keep module-level imports of the wider gptme package out of this file.
+# Importing gptme.cli.main should stay cheap: `gptme --help`, `--version`, and
+# external-subcommand dispatch (`gptme foo` -> `gptme-foo`) all pay for it, and
+# CI benchmarks it (.github/workflows/benchmark.yml). Heavy modules (chat, llm,
+# tools, prompts, logmanager, ...) are imported inside the functions that need
+# them instead.
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from ..logmanager import ConversationMeta
+    from ..prompts import ContextMode
+    from ..tools import ToolFormat
 
 logger = logging.getLogger(__name__)
 
@@ -106,9 +86,46 @@ def _discover_gptme_plugins() -> list[str]:
 
 
 class _DynamicHelpCommand(click.Command):
-    """click.Command subclass that appends discovered gptme-* plugins to --help."""
+    """click.Command subclass that renders the dynamic parts of --help lazily.
+
+    Computing the command list, tool availability, and recommended models
+    imports most of gptme, so it happens here — at --help render time — rather
+    than at module import time. Placeholders like ``{commands_help}`` in the
+    command/option help strings are substituted on first render. Also appends
+    discovered gptme-* plugin subcommands.
+    """
+
+    _help_expanded = False
+
+    def _expand_dynamic_help(self) -> None:
+        if self._help_expanded:
+            return
+        self._help_expanded = True
+
+        from ..commands import _gen_help
+        from ..llm.models import get_recommended_model
+        from ..tools import get_available_tools
+
+        commands_help = "\n".join(_gen_help(incl_langtags=False))
+        tools = get_available_tools(include_mcp=False)
+        available_tools = ", ".join(
+            sorted(tool.name for tool in tools if tool.is_available)
+        )
+        model_examples = (
+            f"openai/{get_recommended_model('openai')}, "
+            f"anthropic/{get_recommended_model('anthropic')}"
+        )
+
+        if self.help:
+            self.help = self.help.replace("{commands_help}", commands_help)
+        for param in self.params:
+            if isinstance(param, click.Option) and param.help:
+                param.help = param.help.replace(
+                    "{available_tools}", available_tools
+                ).replace("{model_examples}", model_examples)
 
     def format_help(self, ctx: click.Context, formatter: click.HelpFormatter) -> None:
+        self._expand_dynamic_help()
         super().format_help(ctx, formatter)
         plugins = _discover_gptme_plugins()
         if plugins:
@@ -159,15 +176,17 @@ class CommaSeparatedChoice(click.ParamType):
 
     def __init__(
         self,
-        choices: list[str],
+        choices: list[str] | Callable[[], list[str]],
         allow_prefix: str | None = None,
         allow_prefixes: list[str] | None = None,
-        extra_choices_for_prefix: dict[str, list[str]] | None = None,
+        extra_choices_for_prefix: dict[str, list[str] | Callable[[], list[str]]]
+        | None = None,
         lenient_prefixes: list[str] | None = None,
         metavar: str | None = None,
     ):
-        self.choices = choices
-        self._choice_set = set(choices)
+        # Choices may be a zero-arg callable, resolved on first use, so that
+        # expensive sources (tool discovery) don't run at CLI definition time.
+        self._choices_src = choices
         # Support both single prefix and multiple prefixes
         if allow_prefixes:
             self.allow_prefixes = allow_prefixes
@@ -175,16 +194,32 @@ class CommaSeparatedChoice(click.ParamType):
             self.allow_prefixes = [allow_prefix]
         else:
             self.allow_prefixes = []
-        self.extra_choices_for_prefix = {
-            prefix: set(prefix_choices)
-            for prefix, prefix_choices in (extra_choices_for_prefix or {}).items()
-        }
+        self._extra_choices_src = extra_choices_for_prefix or {}
         # Prefixes for which unknown names are accepted at parse time. Plugin
         # tools aren't known when the CLI is built (plugins load later), so a
         # prefixed name like "+tts" must pass; it's resolved against the loaded
         # toolset later, which warns if it's genuinely missing.
         self.lenient_prefixes = set(lenient_prefixes or [])
         self._metavar = metavar
+
+    @property
+    def choices(self) -> list[str]:
+        if callable(self._choices_src):
+            self._choices_src = list(self._choices_src())
+        return self._choices_src
+
+    @property
+    def _choice_set(self) -> set[str]:
+        return set(self.choices)
+
+    def _extra_choices(self, prefix: str) -> set[str]:
+        src = self._extra_choices_src.get(prefix)
+        if src is None:
+            return set()
+        if callable(src):
+            src = list(src())
+            self._extra_choices_src[prefix] = src
+        return set(src)
 
     def convert(self, value, param, ctx):
         # Click keeps the leading "=" for short options passed as `-x=value`.
@@ -208,7 +243,7 @@ class CommaSeparatedChoice(click.ParamType):
             if matched_prefix in self.lenient_prefixes:
                 continue
             extra_choices = (
-                self.extra_choices_for_prefix.get(matched_prefix, set())
+                self._extra_choices(matched_prefix)
                 if matched_prefix is not None
                 else set()
             )
@@ -259,6 +294,8 @@ class ConversationName(click.ParamType):
         # Non-empty values still go through conversation_name_error() below.
         if not value or not value.strip():
             return "random"
+        from ..logmanager import conversation_name_error
+
         if error := conversation_name_error(value):
             self.fail(error, param, ctx)
         return value
@@ -336,11 +373,15 @@ def _find_missing_explicit_local_path(prompts: list[str]) -> str | None:
     return None
 
 
-commands_help = "\n".join(_gen_help(incl_langtags=False))
-_builtin_tools = get_available_tools(include_mcp=False)
-_known_tool_names = sorted(tool.name for tool in _builtin_tools)
-_available_tools = sorted(tool.name for tool in _builtin_tools if tool.is_available)
-available_tool_names = ", ".join(_available_tools)
+def _known_tool_names() -> list[str]:
+    """Names of all known built-in tools (available or not).
+
+    Imports the tool subsystem, so only call this lazily (option validation,
+    --help rendering) — never at module import time.
+    """
+    from ..tools import get_available_tools
+
+    return sorted(tool.name for tool in get_available_tools(include_mcp=False))
 
 
 docstring = f"""
@@ -362,7 +403,7 @@ Examples:
 
 \b
 The interface provides /commands during a conversation:
-{commands_help}
+{{commands_help}}
 
 \b
 Subcommand shortcuts:
@@ -412,7 +453,7 @@ Run 'gptme-util --help' for all utility commands."""
     "--model",
     default=None,
     callback=_validate_model_param,
-    help=f"Model to use, e.g. openai/{get_recommended_model('openai')}, anthropic/{get_recommended_model('anthropic')}. If only provider given then a default is used.",
+    help="Model to use, e.g. {model_examples}. If only provider given then a default is used.",
 )
 @click.option(
     "-w",
@@ -477,8 +518,9 @@ Run 'gptme-util --help' for all utility commands."""
         # Accept all *known* tools, not just currently-available ones, so a tool
         # that exists but is temporarily unavailable (e.g. 'tts' when its server
         # isn't running) is reported as unavailable at load time rather than as a
-        # misleading "invalid choice" here.
-        _known_tool_names + ["none"],
+        # misleading "invalid choice" here. Resolved lazily: tool discovery
+        # imports most of gptme and must not run at module import time.
+        lambda: _known_tool_names() + ["none"],
         allow_prefixes=["+", "-"],
         extra_choices_for_prefix={"-": _known_tool_names},
         # Only '+' is lenient: plugin tools (added via '+tool') aren't known at
@@ -487,7 +529,7 @@ Run 'gptme-util --help' for all utility commands."""
         lenient_prefixes=["+"],
         metavar="TOOL",
     ),
-    help=f"Tools to allow. Comma-separated or repeated. Use '+tool' to add to defaults (e.g., '-t +subagent'). Use '-tool' to exclude from defaults (e.g., '-t=-browser'). Use 'none' to disable all tools. Supports .py file paths for custom tools (e.g., '-t path/to/tool.py'). Available: {available_tool_names}.",
+    help="Tools to allow. Comma-separated or repeated. Use '+tool' to add to defaults (e.g., '-t +subagent'). Use '-tool' to exclude from defaults (e.g., '-t=-browser'). Use 'none' to disable all tools. Supports .py file paths for custom tools (e.g., '-t path/to/tool.py'). Available: {available_tools}.",
 )
 @click.option(
     "--agent-profile",
@@ -715,6 +757,8 @@ def main(
     # Apply agent profile if specified
     selected_profile = None
     if agent_profile:
+        from ..profiles import get_profile
+
         selected_profile = get_profile(agent_profile)
         if not selected_profile:
             raise click.BadParameter(
@@ -820,6 +864,9 @@ def main(
     _validate_custom_tool_paths(tool_allowlist_str)
 
     if profile:
+        import cProfile
+        import pstats
+
         print("Profiling enabled...")
         pr = cProfile.Profile()
         pr.enable()
@@ -860,6 +907,28 @@ def main(
 
     if "PYTEST_CURRENT_TEST" in os.environ:
         interactive = False
+
+    # Everything below is an actual chat session: import the heavy parts of
+    # gptme now, after the cheap early-exit paths (--help/--version/dispatch).
+    from ..chat import chat
+    from ..config import ensure_workspace_dir, get_config, setup_config_from_cli
+    from ..init import init_logging
+    from ..llm import get_provider_from_model
+    from ..llm import reply as llm_reply
+    from ..message import Message
+    from ..profiles import get_profile
+    from ..prompts import (
+        PromptSectionStat,
+        format_prompt_stats,
+        get_prompt,
+        get_prompt_stats,
+    )
+    from ..telemetry import init_telemetry, shutdown_telemetry
+    from ..tools import init_tools
+    from ..util.context import md_codeblock
+    from ..util.interrupt import handle_keyboard_interrupt, set_interruptible
+    from ..util.prompt import add_history
+    from ..util.tokens import len_tokens
 
     # init logging
     # Route log output through stdout (via shared Rich Console) when interactive
@@ -1396,6 +1465,14 @@ def main(
 def pick_log(limit=20) -> Path:  # pragma: no cover
     # let user select between starting a new conversation and loading a previous one
     # using the library
+    from ..logmanager import get_user_conversations
+    from ..util import epoch_to_age
+
+    try:
+        pick = importlib.import_module("pick").pick
+    except (ImportError, AttributeError):
+        pick = None
+
     title = "New conversation or load previous? "
     NEW_CONV = "New conversation"
     LOAD_MORE = "Load more"
@@ -1444,6 +1521,9 @@ def pick_log(limit=20) -> Path:  # pragma: no cover
 
 
 def get_logdir(logdir: Path | str | Literal["random"]) -> Path:
+    from ..logmanager import conversation_name_error
+    from ..util.auto_naming import generate_conversation_id
+
     logs_dir = get_logs_dir()
     if logdir == "random":
         logdir = logs_dir / generate_conversation_id(name="random", logs_dir=logs_dir)
@@ -1458,6 +1538,8 @@ def get_logdir(logdir: Path | str | Literal["random"]) -> Path:
 
 
 def get_logdir_resume(name: str = "random", workspace: Path | None = None) -> Path:
+    from ..logmanager import get_user_conversations
+
     if name != "random":
         logdir = get_logs_dir() / name
         if (logdir / "conversation.jsonl").exists():

--- a/gptme/hooks/workspace_agents.py
+++ b/gptme/hooks/workspace_agents.py
@@ -477,6 +477,44 @@ def _get_process_cwd(pid: int) -> str | None:
     return None
 
 
+def _get_process_cwds(pids: list[int]) -> dict[int, str]:
+    """Get CWDs for multiple processes, batched where supported.
+
+    On macOS this issues a single ``lsof`` call for all PIDs instead of one
+    per PID (~50ms each), which dominated session-start agent scans on
+    machines with several agent processes running.
+    """
+    if not pids:
+        return {}
+    if platform.system() == "Darwin":
+        try:
+            # No check=True: lsof exits non-zero when any PID is gone but
+            # still prints results for the live ones.
+            proc = subprocess.run(
+                ["lsof", "-a", "-p", ",".join(map(str, pids)), "-d", "cwd", "-Fpn"],
+                check=False,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+                text=True,
+                timeout=10,
+            )
+        except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+            return {}
+        cwds: dict[int, str] = {}
+        current: int | None = None
+        for line in proc.stdout.splitlines():
+            if line.startswith("p"):
+                try:
+                    current = int(line[1:])
+                except ValueError:
+                    current = None
+            elif line.startswith("n") and current is not None:
+                cwds[current] = line[1:]
+        return cwds
+    # Linux/Windows: per-PID paths are cheap (procfs) or already per-PID APIs.
+    return {pid: cwd for pid in pids if (cwd := _get_process_cwd(pid))}
+
+
 def _get_process_cmdline(pid: int) -> list[str]:
     """Get process command-line args, cross-platform."""
     system = platform.system()
@@ -1327,6 +1365,8 @@ def scan_agents(workspace: str | None = None) -> list[AgentInfo]:
     cmdlines = _get_all_cmdlines()
     pids = sorted(cmdlines) if cmdlines is not None else _get_all_pids()
 
+    # First pass: find candidate agent processes by cmdline (no subprocesses).
+    candidates: list[tuple[int, list[str], str]] = []
     for pid in pids:
         if pid == my_pid:
             continue
@@ -1341,7 +1381,13 @@ def scan_agents(workspace: str | None = None) -> list[AgentInfo]:
         if not runtime:
             continue
 
-        cwd = _get_process_cwd(pid)
+        candidates.append((pid, cmdline, runtime))
+
+    # Second pass: fetch all candidate CWDs in one batched call.
+    cwds = _get_process_cwds([pid for pid, _, _ in candidates])
+
+    for pid, cmdline, runtime in candidates:
+        cwd = cwds.get(pid)
         if not cwd:
             continue
 

--- a/gptme/lessons/parser.py
+++ b/gptme/lessons/parser.py
@@ -7,6 +7,13 @@ from pathlib import Path
 try:
     import yaml
 
+    try:
+        # libyaml-backed loader is ~10x faster; matters when indexing hundreds
+        # of lesson files at startup.
+        from yaml import CSafeLoader as _YamlSafeLoader
+    except ImportError:
+        from yaml import SafeLoader as _YamlSafeLoader
+
     HAS_YAML = True
 except ImportError:
     HAS_YAML = False
@@ -328,7 +335,7 @@ def parse_lesson(path: Path) -> Lesson:
                 # Pre-process frontmatter to handle unquoted glob patterns
                 # that look like YAML aliases (e.g., "globs: *,**/*")
                 frontmatter_str = _fix_unquoted_globs(frontmatter_str)
-                frontmatter = yaml.safe_load(frontmatter_str)
+                frontmatter = yaml.load(frontmatter_str, Loader=_YamlSafeLoader)
                 if frontmatter:
                     # Detect format based on file extension and frontmatter structure
                     has_globs = "globs" in frontmatter

--- a/gptme/llm/__init__.py
+++ b/gptme/llm/__init__.py
@@ -155,14 +155,21 @@ def init_llm(provider: Provider):
     Args:
         provider: Provider name (built-in or custom)
     """
-    from .llm_anthropic import get_client as get_anthropic_client
-    from .llm_anthropic import init as init_anthropic
-    from .llm_openai import has_client as has_openai_client
-    from .llm_openai import init as init_openai
-    from .llm_openai_subscription import init as init_subscription
-
     global _subscription_initialized
     config = get_config()
+
+    # Provider modules are imported lazily per-branch: each pulls in its SDK
+    # (anthropic/openai, several hundred ms), so only the active provider's
+    # module should be imported at startup.
+    def has_openai_client(p) -> bool:
+        from .llm_openai import has_client
+
+        return has_client(p)
+
+    def init_openai(p, conf) -> None:
+        from .llm_openai import init
+
+        init(p, conf)
 
     # Mock provider needs no client/auth — responses are computed in-process.
     if provider == "mock":
@@ -173,9 +180,15 @@ def init_llm(provider: Provider):
     # Check if it's a custom provider (OpenAI-compatible)
     elif is_custom_provider(provider) and not has_openai_client(provider):
         init_openai(provider, config)
-    elif provider == "anthropic" and not get_anthropic_client():
-        init_anthropic(config)
+    elif provider == "anthropic":
+        from .llm_anthropic import get_client as get_anthropic_client
+        from .llm_anthropic import init as init_anthropic
+
+        if not get_anthropic_client():
+            init_anthropic(config)
     elif provider == "openai-subscription" and not _subscription_initialized:
+        from .llm_openai_subscription import init as init_subscription
+
         _subscription_initialized = init_subscription(config)
     elif (
         plugin := get_provider_plugin(str(provider))

--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import importlib
 import json
 import logging
@@ -9,13 +11,11 @@ from functools import lru_cache, wraps
 from typing import TYPE_CHECKING, Any, cast
 
 import requests
-from openai import NOT_GIVEN, NotGiven
 
 from ..config import Config, get_config
 from ..constants import OPENAI_VERBOSITY, TEMPERATURE, TOP_P
 from ..message import Message, MessageMetadata, UsageData, msgs2dicts
 from ..telemetry import _calculate_llm_cost, record_llm_request
-from ..tools import ToolSpec
 from .constants import _MIN_RESPONSE_TOKENS, OPENROUTER_APP_HEADERS
 from .models import (
     CustomProvider,
@@ -45,12 +45,61 @@ from .utils import (
 
 if TYPE_CHECKING:
     # noreorder
-    from openai import OpenAI  # fmt: skip
+    from openai import NotGiven, OpenAI  # fmt: skip
     from openai.types.chat import ChatCompletionToolParam  # fmt: skip
+
+    from ..tools import ToolSpec  # fmt: skip
+
+
+class _UnsetTimeout:
+    """Sentinel for "no explicit timeout", without importing the openai SDK.
+
+    Translated to ``openai.NOT_GIVEN`` when the real client is constructed.
+    """
+
+
+_UNSET_TIMEOUT = _UnsetTimeout()
+
+
+class _LazyClient:
+    """Records client parameters; constructs the real SDK client on first use.
+
+    Importing the openai SDK takes ~1s. ``init()`` runs at startup for every
+    session to fail fast on missing keys, but command-only invocations (e.g.
+    ``gptme '/exit'``) never make an LLM call — deferring construction to the
+    first attribute access keeps the SDK import off the startup path.
+    """
+
+    def __init__(self, cls_name: str, kwargs: dict[str, Any]):
+        self._cls_name = cls_name
+        self._kwargs = kwargs
+        self._client: Any = None
+
+    def _materialize(self) -> Any:
+        if self._client is None:
+            import openai
+
+            kwargs = dict(self._kwargs)
+            if isinstance(kwargs.get("timeout"), _UnsetTimeout):
+                kwargs["timeout"] = openai.NOT_GIVEN
+            self._client = getattr(openai, self._cls_name)(**kwargs)
+        return self._client
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._materialize(), name)
+
+
+def _lazy_client_factory(cls_name: str):
+    """Return an ``OpenAI``/``AzureOpenAI``-like constructor that defers SDK import."""
+
+    def factory(**kwargs: Any) -> OpenAI:
+        return cast("OpenAI", _LazyClient(cls_name, kwargs))
+
+    return factory
 
 
 # Dictionary to store clients for each provider (includes custom providers)
-clients: dict[Provider, "OpenAI"] = {}
+clients: dict[Provider, OpenAI] = {}
 logger = logging.getLogger(__name__)
 
 __all__ = [
@@ -78,7 +127,7 @@ def _get_provider_api_key(config: Config, provider: Provider, env_var: str) -> s
 
 def _get_temperature(
     provider: Provider,
-    model_meta: "ModelMeta | None" = None,
+    model_meta: ModelMeta | None = None,
     temperature: float | None = None,
 ) -> float:
     """Return the temperature for a given provider/model.
@@ -96,7 +145,7 @@ def _get_temperature(
 
 def _get_top_p(
     provider: Provider,
-    model_meta: "ModelMeta | None" = None,
+    model_meta: ModelMeta | None = None,
     top_p: float | None = None,
 ) -> float | None:
     """Return the top_p for a given provider.
@@ -223,7 +272,7 @@ def _responses_api_enabled() -> bool:
 
 
 def _should_use_responses_api(
-    provider: Provider, model_meta: ModelMeta, client: "OpenAI"
+    provider: Provider, model_meta: ModelMeta, client: OpenAI
 ) -> bool:
     return (
         provider == "openai"
@@ -318,22 +367,25 @@ def _init_openai_client(
     provider: Provider,
     api_key: str,
     base_url: str | None = None,
-    timeout: float | NotGiven | None = None,
+    timeout: float | _UnsetTimeout | NotGiven | None = None,
 ) -> None:
     """Internal helper to create and register an OpenAI client for a provider.
 
     Handles Azure vs regular OpenAI client selection automatically.
     """
-    from openai import AzureOpenAI, OpenAI  # fmt: skip
-
     from ..config import get_config  # fmt: skip
+
+    # Shadow the SDK classes with lazy factories: constructing the real client
+    # imports the openai SDK (~1s); defer that to first use (see _LazyClient).
+    OpenAI = _lazy_client_factory("OpenAI")
+    AzureOpenAI = _lazy_client_factory("AzureOpenAI")
 
     config = get_config()
 
     if timeout is None:
         timeout_str = config.get_env("LLM_API_TIMEOUT")
         try:
-            timeout = float(timeout_str) if timeout_str else NOT_GIVEN
+            timeout = float(timeout_str) if timeout_str else _UNSET_TIMEOUT
         except ValueError as parse_err:
             raise ValueError(
                 f"Invalid LLM_API_TIMEOUT value: {timeout_str!r}. Must be a valid number."
@@ -370,13 +422,24 @@ def reinit(provider: Provider, api_key: str) -> None:
     if provider == "azure":
         raise ValueError("Runtime credential switch not supported for Azure")
     existing = clients[provider]
-    base_url = str(existing.base_url) if getattr(existing, "base_url", None) else None
+    if isinstance(existing, _LazyClient) and existing._client is None:
+        # Not yet materialized: read the recorded param instead of triggering
+        # the SDK import just to reinit.
+        raw_base_url = existing._kwargs.get("base_url")
+    else:
+        raw_base_url = getattr(existing, "base_url", None)
+    base_url = str(raw_base_url) if raw_base_url else None
     _init_openai_client(provider, api_key=api_key, base_url=base_url)
 
 
 def init(provider: Provider, config: Config):
-    """Initialize OpenAI client for a given provider."""
-    from openai import AzureOpenAI, OpenAI  # fmt: skip
+    """Initialize OpenAI client for a given provider.
+
+    Missing API keys raise here (fail fast at startup); the SDK client itself
+    is constructed lazily on first use (see _LazyClient).
+    """
+    OpenAI = _lazy_client_factory("OpenAI")
+    AzureOpenAI = _lazy_client_factory("AzureOpenAI")
 
     proxy_key = config.get_env("LLM_PROXY_API_KEY")
     proxy_url = config.get_env("LLM_PROXY_URL")
@@ -390,8 +453,9 @@ def init(provider: Provider, config: Config):
     # client use its own default behavior, which may evolve with future versions.
 
     timeout_str = config.get_env("LLM_API_TIMEOUT")
+    timeout: float | _UnsetTimeout
     try:
-        timeout = float(timeout_str) if timeout_str else NOT_GIVEN
+        timeout = float(timeout_str) if timeout_str else _UNSET_TIMEOUT
     except ValueError as parse_err:
         raise ValueError(
             f"Invalid LLM_API_TIMEOUT value: {timeout_str!r}. Must be a valid number."
@@ -518,7 +582,7 @@ def init(provider: Provider, config: Config):
     assert clients[provider], f"Provider {provider} not initialized"
 
 
-def get_client(provider: Provider) -> "OpenAI":
+def get_client(provider: Provider) -> OpenAI:
     """Get client for specific provider, initializing if needed."""
     if provider not in clients:
         init(provider, get_config())
@@ -568,7 +632,7 @@ def _prep_deepseek_reasoner(msgs: list[Message]) -> Generator[Message, None, Non
 
 
 @lru_cache(maxsize=2)
-def _is_proxy(client: "OpenAI") -> bool:
+def _is_proxy(client: OpenAI) -> bool:
     proxy_url = get_config().get_env("LLM_PROXY_URL")
     # If client has the proxy URL set, it is using the proxy
     if not proxy_url:
@@ -1626,7 +1690,7 @@ def _transform_msgs_for_special_provider(
     return cast(Iterable[MessageDict], messages_dicts)
 
 
-def _spec2tool(spec: ToolSpec, model: ModelMeta) -> "ChatCompletionToolParam":
+def _spec2tool(spec: ToolSpec, model: ModelMeta) -> ChatCompletionToolParam:
     name = spec.name
     if spec.block_types:
         name = spec.block_types[0]
@@ -1856,7 +1920,7 @@ def _prepare_messages_for_api(
     messages: list[Message],
     model: str,
     tools: list[ToolSpec] | None,
-) -> tuple[list[MessageDict], list["ChatCompletionToolParam"] | None]:
+) -> tuple[list[MessageDict], list[ChatCompletionToolParam] | None]:
     """Prepare messages for API call, handling model-specific transformations.
 
     Returns:

--- a/gptme/plugins/entrypoints.py
+++ b/gptme/plugins/entrypoints.py
@@ -38,12 +38,13 @@ def discover_entrypoint_plugins(
     """Discover plugins registered via the ``gptme.plugins`` entry-point group.
 
     Args:
-        enabled: Optional allowlist of plugin names. Entry points whose name
-            (dash/underscore-insensitive) is not in the set are skipped
-            *without being imported* — ``ep.load()`` imports the plugin's whole
-            package, which can take seconds for plugins with heavy dependencies.
-            The entry-point name must match the configured plugin name for the
-            skip to apply.
+        enabled: Optional allowlist of plugin names. Entry points that match
+            neither by entry-point name nor by top-level package name
+            (dash/underscore-insensitive) are skipped *without being
+            imported* — ``ep.load()`` imports the plugin's whole package,
+            which can take seconds for plugins with heavy dependencies.
+            Plugins whose manifest name differs from both must be enabled
+            under their entry-point or package name.
 
     Results are cached after the first call.  Use :func:`clear_entrypoint_cache`
     in tests or when reloading plugins at runtime.
@@ -53,10 +54,12 @@ def discover_entrypoint_plugins(
     )
     plugins: list[GptmePlugin] = []
     for ep in entry_points(group=ENTRYPOINT_GROUP):
-        if (
-            enabled_normalized is not None
-            and _normalize(ep.name) not in enabled_normalized
-        ):
+        # Match on entry-point name or top-level package name, so a plugin
+        # enabled under either (e.g. "gptme-tts" for entry point "tts" in
+        # package "gptme_tts") is still loaded. The manifest name is only
+        # known after ep.load(), which is exactly what we're avoiding here.
+        ep_names = {_normalize(ep.name), _normalize(ep.module.split(".")[0])}
+        if enabled_normalized is not None and not (ep_names & enabled_normalized):
             logger.debug("Skipping entry-point plugin %r: not enabled", ep.name)
             continue
         try:

--- a/gptme/plugins/entrypoints.py
+++ b/gptme/plugins/entrypoints.py
@@ -12,7 +12,8 @@ Where ``plugin`` is a :class:`~gptme.plugins.plugin.GptmePlugin` instance.
 from __future__ import annotations
 
 import logging
-from functools import lru_cache
+import time
+from functools import cache
 from importlib.metadata import entry_points
 
 from .plugin import GptmePlugin
@@ -21,18 +22,54 @@ logger = logging.getLogger(__name__)
 
 ENTRYPOINT_GROUP = "gptme.plugins"
 
+# Loading an entry point imports its whole package; warn when that stalls
+# startup so the culprit plugin is visible to the user.
+_SLOW_LOAD_THRESHOLD = 1.0
 
-@lru_cache(maxsize=1)
-def discover_entrypoint_plugins() -> tuple[GptmePlugin, ...]:
+
+def _normalize(name: str) -> str:
+    return name.replace("-", "_").lower()
+
+
+@cache
+def discover_entrypoint_plugins(
+    enabled: frozenset[str] | None = None,
+) -> tuple[GptmePlugin, ...]:
     """Discover plugins registered via the ``gptme.plugins`` entry-point group.
+
+    Args:
+        enabled: Optional allowlist of plugin names. Entry points whose name
+            (dash/underscore-insensitive) is not in the set are skipped
+            *without being imported* — ``ep.load()`` imports the plugin's whole
+            package, which can take seconds for plugins with heavy dependencies.
+            The entry-point name must match the configured plugin name for the
+            skip to apply.
 
     Results are cached after the first call.  Use :func:`clear_entrypoint_cache`
     in tests or when reloading plugins at runtime.
     """
+    enabled_normalized = (
+        {_normalize(name) for name in enabled} if enabled is not None else None
+    )
     plugins: list[GptmePlugin] = []
     for ep in entry_points(group=ENTRYPOINT_GROUP):
+        if (
+            enabled_normalized is not None
+            and _normalize(ep.name) not in enabled_normalized
+        ):
+            logger.debug("Skipping entry-point plugin %r: not enabled", ep.name)
+            continue
         try:
+            start = time.monotonic()
             obj = ep.load()
+            duration = time.monotonic() - start
+            if duration > _SLOW_LOAD_THRESHOLD:
+                logger.warning(
+                    "Plugin %r took %.1fs to load — its package imports heavy "
+                    "dependencies at import time; consider deferring them",
+                    ep.name,
+                    duration,
+                )
         except Exception as exc:
             logger.warning("Failed to load plugin %r: %s", ep.name, exc)
             continue

--- a/gptme/plugins/registry.py
+++ b/gptme/plugins/registry.py
@@ -58,10 +58,14 @@ def discover_all_plugins(
         )
 
     # 2. Entry-point plugins (new gptme.plugins group)
+    # Pass the allowlist down so disabled plugins are never imported — loading
+    # an entry point imports its whole package, which can take seconds for
+    # plugins with heavy dependencies.
     # Dedup against folder plugins — an editable-install (pip install -e .) will
     # register the same plugin both as a folder plugin and an entry-point plugin.
     folder_names = {p.name for p in plugins}
-    for ep_plugin in discover_entrypoint_plugins():
+    enabled_set = frozenset(enabled_plugins) if enabled_plugins is not None else None
+    for ep_plugin in discover_entrypoint_plugins(enabled_set):
         if ep_plugin.name in folder_names:
             # Warn if the entry-point version has capabilities the folder adapter doesn't carry
             if ep_plugin.provider or ep_plugin.tools:

--- a/gptme/tools/browser.py
+++ b/gptme/tools/browser.py
@@ -95,12 +95,9 @@ from ..util.gh import (
 )
 from .base import ToolFunction, ToolSpec, ToolUse
 
-try:
-    import pypdf
-
-    has_pypdf = True
-except ImportError:
-    has_pypdf = False
+# Availability check only — pypdf itself is imported lazily in _read_pdf_url,
+# so PDF support doesn't add ~250ms to every startup.
+has_pypdf = importlib.util.find_spec("pypdf") is not None
 
 
 def has_playwright() -> bool:
@@ -636,6 +633,8 @@ def _read_pdf_url(url: str, max_pages: int | None = None) -> str:
     """
     if not has_pypdf:
         return "Error: PDF support requires pypdf. Install with: pip install pypdf"
+
+    import pypdf
 
     # Use default if not specified
     if max_pages is None:

--- a/gptme/tools/mcp_adapter.py
+++ b/gptme/tools/mcp_adapter.py
@@ -175,13 +175,15 @@ def _call_mcp_tool_with_retry(
 # Function to create MCP tools
 def create_mcp_tools(config: Config) -> list[ToolSpec]:
     """Create tool specs for all MCP tools from the config"""
-    from ..mcp.client import MCPClient
-
     tool_specs: list[ToolSpec] = []
 
-    # Skip if MCP is not enabled
-    if not config.mcp.enabled:
+    # Skip if MCP is not enabled or no servers are configured.
+    # Checked before the MCPClient import: pulling in the mcp SDK costs
+    # ~0.5s+ at startup, so don't pay it when there is nothing to connect to.
+    if not config.mcp.enabled or not config.mcp.servers:
         return tool_specs
+
+    from ..mcp.client import MCPClient
 
     # Initialize connections to all servers
     for server_config in config.mcp.servers:

--- a/gptme/util/cost_display.py
+++ b/gptme/util/cost_display.py
@@ -7,7 +7,6 @@ and display them in a consistent format.
 from dataclasses import dataclass
 
 from ..message import Message
-from . import console
 from .cost_tracker import CostTracker
 
 
@@ -302,6 +301,12 @@ def display_costs(
         session: Costs from current session (CostTracker)
         conversation: Costs from conversation history (metadata)
     """
+    # Resolve the shared console at call time (not module import time): this
+    # module is imported lazily, and an import-time binding would permanently
+    # capture a mock if the first import happens under a patched
+    # gptme.util.console (as some tests do).
+    from . import console
+
     if not session and not conversation:
         console.log(
             "[yellow]No cost data available. Use /tokens for approximation.[/yellow]"
@@ -441,6 +446,8 @@ def display_costs(
 
 def _display_total(total: TotalCosts) -> None:
     """Helper to display total costs."""
+    from . import console
+
     total_in = (
         total.input_tokens + total.cache_read_tokens + total.cache_creation_tokens
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,4 @@
+import importlib
 import os
 import random
 import signal
@@ -177,11 +178,10 @@ def test_show_prompt_stats_exits_before_chat(monkeypatch, tmp_path: Path, runner
     )
     seen: dict[str, Any] = {}
 
-    monkeypatch.setattr(cli, "setup_config_from_cli", lambda **_: fake_config)
-    monkeypatch.setattr(cli, "init_tools", lambda _: [])
+    monkeypatch.setattr("gptme.config.setup_config_from_cli", lambda **_: fake_config)
+    monkeypatch.setattr("gptme.tools.init_tools", lambda _: [])
     monkeypatch.setattr(
-        cli,
-        "get_prompt_stats",
+        "gptme.prompts.get_prompt_stats",
         lambda **kwargs: (
             seen.update(kwargs=kwargs)
             or SimpleNamespace(
@@ -195,14 +195,16 @@ def test_show_prompt_stats_exits_before_chat(monkeypatch, tmp_path: Path, runner
         ),
     )
     monkeypatch.setattr(
-        cli,
-        "format_prompt_stats",
+        "gptme.prompts.format_prompt_stats",
         lambda stats, header=None, extra_sections=None: "prompt-stats-output",
     )
-    monkeypatch.setattr(cli, "chat", lambda *args, **kwargs: pytest.fail("chat ran"))
     monkeypatch.setattr(
-        cli,
-        "init_telemetry",
+        importlib.import_module("gptme.chat"),
+        "chat",
+        lambda *args, **kwargs: pytest.fail("chat ran"),
+    )
+    monkeypatch.setattr(
+        "gptme.telemetry.init_telemetry",
         lambda **kwargs: pytest.fail("telemetry should not start for prompt stats"),
     )
 
@@ -236,11 +238,10 @@ def test_no_workspace_flag_wires_correctly(monkeypatch, tmp_path: Path, runner):
     )
     seen: dict[str, Any] = {}
 
-    monkeypatch.setattr(cli, "setup_config_from_cli", lambda **_: fake_config)
-    monkeypatch.setattr(cli, "init_tools", lambda _: [])
+    monkeypatch.setattr("gptme.config.setup_config_from_cli", lambda **_: fake_config)
+    monkeypatch.setattr("gptme.tools.init_tools", lambda _: [])
     monkeypatch.setattr(
-        cli,
-        "get_prompt_stats",
+        "gptme.prompts.get_prompt_stats",
         lambda **kwargs: (
             seen.update(kwargs=kwargs)
             or SimpleNamespace(
@@ -254,12 +255,15 @@ def test_no_workspace_flag_wires_correctly(monkeypatch, tmp_path: Path, runner):
         ),
     )
     monkeypatch.setattr(
-        cli,
-        "format_prompt_stats",
+        "gptme.prompts.format_prompt_stats",
         lambda stats, header=None, extra_sections=None: "prompt-stats-output",
     )
-    monkeypatch.setattr(cli, "chat", lambda *args, **kwargs: pytest.fail("chat ran"))
-    monkeypatch.setattr(cli, "init_telemetry", lambda **kwargs: None)
+    monkeypatch.setattr(
+        importlib.import_module("gptme.chat"),
+        "chat",
+        lambda *args, **kwargs: pytest.fail("chat ran"),
+    )
+    monkeypatch.setattr("gptme.telemetry.init_telemetry", lambda **kwargs: None)
 
     result = runner.invoke(
         cli.main, ["--no-workspace", "--show-prompt-stats"], input=""
@@ -394,7 +398,7 @@ def test_name_defaults_to_random_for_empty_or_whitespace(
         selected_logdirs.append(chat_logdir)
 
     monkeypatch.setattr(cli, "get_logdir", fake_get_logdir)
-    monkeypatch.setattr(cli, "chat", fake_chat)
+    monkeypatch.setattr(importlib.import_module("gptme.chat"), "chat", fake_chat)
 
     result = runner.invoke(
         cli.main,
@@ -431,7 +435,7 @@ def test_name_empty_before_output_format(
         selected_logdirs.append(chat_logdir)
 
     monkeypatch.setattr(cli, "get_logdir", fake_get_logdir)
-    monkeypatch.setattr(cli, "chat", fake_chat)
+    monkeypatch.setattr(importlib.import_module("gptme.chat"), "chat", fake_chat)
 
     result = runner.invoke(
         cli.main,
@@ -483,9 +487,11 @@ def test_model_allows_nested_path_through_validation_block(
         called["get_prompt"] = True
         return []
 
-    monkeypatch.setattr(cli, "get_prompt", _fake_get_prompt)
-    monkeypatch.setattr(cli, "chat", lambda *args, **kwargs: None)
-    monkeypatch.setattr(cli, "init_telemetry", lambda **kwargs: None)
+    monkeypatch.setattr("gptme.prompts.get_prompt", _fake_get_prompt)
+    monkeypatch.setattr(
+        importlib.import_module("gptme.chat"), "chat", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr("gptme.telemetry.init_telemetry", lambda **kwargs: None)
 
     result = runner.invoke(
         cli.main,
@@ -508,12 +514,15 @@ def test_model_rejects_unknown_provider_before_context_cmd(
     monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
     monkeypatch.setattr(
-        cli,
-        "get_prompt",
+        "gptme.prompts.get_prompt",
         lambda **kwargs: pytest.fail("get_prompt was called before model validation"),
     )
-    monkeypatch.setattr(cli, "chat", lambda *args, **kwargs: pytest.fail("chat ran"))
-    monkeypatch.setattr(cli, "init_telemetry", lambda **kwargs: None)
+    monkeypatch.setattr(
+        importlib.import_module("gptme.chat"),
+        "chat",
+        lambda *args, **kwargs: pytest.fail("chat ran"),
+    )
+    monkeypatch.setattr("gptme.telemetry.init_telemetry", lambda **kwargs: None)
 
     result = runner.invoke(
         cli.main,
@@ -593,7 +602,9 @@ def test_get_logdir_resume_named_conversation_skips_conversation_scan(
     def fail_get_user_conversations(*args, **kwargs):
         raise AssertionError("named resume should not scan conversation metadata")
 
-    monkeypatch.setattr(cli, "get_user_conversations", fail_get_user_conversations)
+    monkeypatch.setattr(
+        "gptme.logmanager.get_user_conversations", fail_get_user_conversations
+    )
 
     assert cli.get_logdir_resume(conv_id) == conv_dir
 
@@ -656,7 +667,7 @@ def test_resume_with_workspace_uses_matching_conversation(
     def fake_chat(prompt_msgs, initial_msgs, logdir, *args, **kwargs):
         selected_logdirs.append(logdir)
 
-    monkeypatch.setattr(cli, "chat", fake_chat)
+    monkeypatch.setattr(importlib.import_module("gptme.chat"), "chat", fake_chat)
 
     result = runner.invoke(
         cli.main,
@@ -688,7 +699,7 @@ def test_resume_without_explicit_workspace_uses_cwd(
     def fake_chat(prompt_msgs, initial_msgs, logdir, *args, **kwargs):
         selected_logdirs.append(logdir)
 
-    monkeypatch.setattr(cli, "chat", fake_chat)
+    monkeypatch.setattr(importlib.import_module("gptme.chat"), "chat", fake_chat)
     monkeypatch.setattr(cli.Path, "cwd", classmethod(lambda cls: workspace_a))
 
     result = runner.invoke(
@@ -722,7 +733,7 @@ def test_resume_with_log_workspace_uses_global_latest(
     def fake_chat(prompt_msgs, initial_msgs, logdir, *args, **kwargs):
         selected_logdirs.append(logdir)
 
-    monkeypatch.setattr(cli, "chat", fake_chat)
+    monkeypatch.setattr(importlib.import_module("gptme.chat"), "chat", fake_chat)
     monkeypatch.setattr(cli.Path, "cwd", classmethod(lambda cls: workspace_a))
 
     result = runner.invoke(
@@ -1613,12 +1624,14 @@ def test_click_exception_inside_chat_exits_2(
     (logdir / "conversation.jsonl").write_text('{"role":"user","content":"hello"}\n')
 
     monkeypatch.setattr(cli, "get_logdir", lambda name: logdir)
-    monkeypatch.setattr(cli, "init_telemetry", lambda **kwargs: None)
+    monkeypatch.setattr("gptme.telemetry.init_telemetry", lambda **kwargs: None)
 
     def _raise_usage_error(*args, **kwargs):
         raise click.UsageError("simulated usage error from inside chat")
 
-    monkeypatch.setattr(cli, "chat", _raise_usage_error)
+    monkeypatch.setattr(
+        importlib.import_module("gptme.chat"), "chat", _raise_usage_error
+    )
 
     result = runner.invoke(
         cli.main, ["--name", "test-conv-exit2", "--non-interactive", "hello"]
@@ -1666,7 +1679,7 @@ class TestPluginDiscovery:
         def _early_exit(*args, **kwargs):
             raise SystemExit(1)
 
-        monkeypatch.setattr("gptme.cli.main.setup_config_from_cli", _early_exit)
+        monkeypatch.setattr("gptme.config.setup_config_from_cli", _early_exit)
 
         runner.invoke(cli.main, ["sessions"])
 

--- a/tests/test_cost_display.py
+++ b/tests/test_cost_display.py
@@ -277,7 +277,7 @@ def test_display_costs_uses_explicit_cache_columns():
         )
     ]
 
-    with patch("gptme.util.cost_display.console.log") as log:
+    with patch("gptme.util.console.log") as log:
         display_costs(conversation=conversation, per_step=per_step)
 
     output = "\n".join(str(call.args[0]) for call in log.call_args_list)
@@ -693,7 +693,7 @@ def test_display_costs_single_total_when_no_prior_history():
         last_request=None, total=_make_total(3), source="conversation"
     )
 
-    with patch("gptme.util.cost_display.console.log") as log:
+    with patch("gptme.util.console.log") as log:
         display_costs(session=session, conversation=conversation)
 
     output = "\n".join(str(call.args[0]) for call in log.call_args_list)
@@ -710,7 +710,7 @@ def test_display_costs_shows_split_when_prior_history_exists():
         last_request=None, total=_make_total(5), source="conversation"
     )
 
-    with patch("gptme.util.cost_display.console.log") as log:
+    with patch("gptme.util.console.log") as log:
         display_costs(session=session, conversation=conversation)
 
     output = "\n".join(str(call.args[0]) for call in log.call_args_list)
@@ -724,7 +724,7 @@ def test_display_costs_only_conversation_when_no_session():
         last_request=None, total=_make_total(3), source="conversation"
     )
 
-    with patch("gptme.util.cost_display.console.log") as log:
+    with patch("gptme.util.console.log") as log:
         display_costs(session=None, conversation=conversation)
 
     output = "\n".join(str(call.args[0]) for call in log.call_args_list)

--- a/tests/test_json_output.py
+++ b/tests/test_json_output.py
@@ -1,5 +1,6 @@
 """Tests for the headless JSON output mode (--output-format json)."""
 
+import importlib
 import io
 import json
 import sys
@@ -54,11 +55,11 @@ def _invoke_cli_with_captured_goodbye(monkeypatch, tmp_path: Path, args: list[st
         ),
         project=None,
     )
-    monkeypatch.setattr(cli, "setup_config_from_cli", lambda **_: fake_config)
-    monkeypatch.setattr(cli, "init_tools", lambda _: [])
-    monkeypatch.setattr(cli, "get_prompt", lambda **_: [])
-    monkeypatch.setattr(cli, "init_telemetry", lambda **_: None)
-    monkeypatch.setattr(cli, "set_interruptible", lambda: None)
+    monkeypatch.setattr("gptme.config.setup_config_from_cli", lambda **_: fake_config)
+    monkeypatch.setattr("gptme.tools.init_tools", lambda _: [])
+    monkeypatch.setattr("gptme.prompts.get_prompt", lambda **_: [])
+    monkeypatch.setattr("gptme.telemetry.init_telemetry", lambda **_: None)
+    monkeypatch.setattr("gptme.util.interrupt.set_interruptible", lambda: None)
     monkeypatch.setattr(cli.signal, "signal", lambda *args, **kwargs: None)
 
     runner = CliRunner()
@@ -154,15 +155,17 @@ class TestOutputFormatValidation:
         monkeypatch.setenv("HOME", str(tmp_path))
         monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
         monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "state"))
-        monkeypatch.setattr(cli, "setup_config_from_cli", lambda **_: fake_config)
-        monkeypatch.setattr(cli, "init_tools", lambda _: [])
-        monkeypatch.setattr(cli, "get_prompt", lambda **_: [])
-        monkeypatch.setattr(cli, "init_telemetry", lambda **_: None)
-        monkeypatch.setattr(cli, "set_interruptible", lambda: None)
+        monkeypatch.setattr(
+            "gptme.config.setup_config_from_cli", lambda **_: fake_config
+        )
+        monkeypatch.setattr("gptme.tools.init_tools", lambda _: [])
+        monkeypatch.setattr("gptme.prompts.get_prompt", lambda **_: [])
+        monkeypatch.setattr("gptme.telemetry.init_telemetry", lambda **_: None)
+        monkeypatch.setattr("gptme.util.interrupt.set_interruptible", lambda: None)
         monkeypatch.setattr(cli.signal, "signal", lambda *args, **kwargs: None)
 
         runner = CliRunner()
-        with patch("gptme.cli.main.chat", new=fake_chat):
+        with patch.object(importlib.import_module("gptme.chat"), "chat", new=fake_chat):
             result = runner.invoke(
                 cli.main,
                 ["--output-format", "json", "hello"],
@@ -283,7 +286,7 @@ class TestOutputFormatValidation:
                 '{"role":"user","content":"hello"}\n'
             )
 
-        monkeypatch.setattr(cli, "chat", fake_chat)
+        monkeypatch.setattr(importlib.import_module("gptme.chat"), "chat", fake_chat)
         result, goodbye_handler = _invoke_cli_with_captured_goodbye(
             monkeypatch,
             tmp_path,
@@ -308,7 +311,7 @@ class TestOutputFormatValidation:
             )
             raise RuntimeError(f"Another gptme instance is using {logdir}")
 
-        monkeypatch.setattr(cli, "chat", fake_chat)
+        monkeypatch.setattr(importlib.import_module("gptme.chat"), "chat", fake_chat)
         result, goodbye_handler = _invoke_cli_with_captured_goodbye(
             monkeypatch,
             tmp_path,
@@ -652,7 +655,7 @@ class TestJSONOutputIntegration:
                 set_output_format(prev_fmt)
 
         runner = CliRunner()
-        with patch("gptme.cli.main.chat", new=fake_chat):
+        with patch.object(importlib.import_module("gptme.chat"), "chat", new=fake_chat):
             runner.invoke(
                 cli.main,
                 ["--output-format", "json", "--non-interactive", "hello"],
@@ -755,7 +758,7 @@ class TestJSONOutputIntegration:
             received_format.append(output_format)
 
         runner = CliRunner()
-        with patch("gptme.cli.main.chat", new=fake_chat):
+        with patch.object(importlib.import_module("gptme.chat"), "chat", new=fake_chat):
             runner.invoke(
                 cli.main,
                 ["--output-format", "json", "--non-interactive", "hello"],

--- a/tests/test_llm_openai.py
+++ b/tests/test_llm_openai.py
@@ -450,6 +450,9 @@ def test_timeout_default(monkeypatch):
         # Initialize OpenAI provider
         llm_openai.init("openai", config)
 
+        # Client construction is lazy; force materialization
+        _ = llm_openai.get_client("openai").base_url
+
         # Verify OpenAI was called with NOT_GIVEN (uses client default)
         mock_openai.assert_called_once()
         call_kwargs = mock_openai.call_args[1]
@@ -480,6 +483,9 @@ def test_timeout_custom(monkeypatch):
 
         # Initialize OpenAI provider
         llm_openai.init("openai", config)
+
+        # Client construction is lazy; force materialization
+        _ = llm_openai.get_client("openai").base_url
 
         # Verify OpenAI was called with custom timeout
         mock_openai.assert_called_once()
@@ -521,6 +527,9 @@ def test_timeout_all_providers(monkeypatch):
             except Exception:
                 # Skip providers that require additional config
                 continue
+
+            # Client construction is lazy; force materialization
+            _ = llm_openai.get_client(provider).base_url
 
             # Verify timeout was passed
             if mock_openai.called:

--- a/tests/test_search_alias.py
+++ b/tests/test_search_alias.py
@@ -1,5 +1,6 @@
 """Tests for `gptme search` alias and gptme-* plugin dispatch."""
 
+import importlib
 from unittest.mock import patch
 
 import pytest
@@ -45,7 +46,7 @@ class TestSearchAlias:
         """
         with (
             patch("gptme.tools.chats.search_chats") as mock_search,
-            patch("gptme.cli.main.chat"),
+            patch.object(importlib.import_module("gptme.chat"), "chat"),
         ):
             runner.invoke(
                 main,
@@ -96,7 +97,7 @@ class TestPluginDispatch:
         """gptme unknowncmd with no gptme-unknowncmd in PATH falls through to normal CLI."""
         with (
             patch("gptme.cli.main.shutil.which", return_value=None),
-            patch("gptme.cli.main.chat"),
+            patch.object(importlib.import_module("gptme.chat"), "chat"),
         ):
             # Normal CLI starts a chat session; shutil.which returning None means no dispatch
             runner.invoke(main, ["unknowncmd"])

--- a/tests/test_tools_browser.py
+++ b/tests/test_tools_browser.py
@@ -13,6 +13,7 @@ Tests cover:
 
 import base64
 import json
+import sys
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -394,7 +395,8 @@ class TestReadPdfUrl:
         mock_response.content = b"fake pdf content"
         mock_requests.get.return_value = mock_response
 
-        with patch("gptme.tools.browser.pypdf") as mock_pypdf:
+        mock_pypdf = MagicMock()
+        with patch.dict(sys.modules, {"pypdf": mock_pypdf}):
             mock_reader = MagicMock()
             mock_page = MagicMock()
             mock_page.extract_text.return_value = "Page 1 text content"
@@ -415,7 +417,8 @@ class TestReadPdfUrl:
         mock_response.content = b"fake"
         mock_requests.get.return_value = mock_response
 
-        with patch("gptme.tools.browser.pypdf") as mock_pypdf:
+        mock_pypdf = MagicMock()
+        with patch.dict(sys.modules, {"pypdf": mock_pypdf}):
             pages = []
             for i in range(20):
                 p = MagicMock()
@@ -441,7 +444,8 @@ class TestReadPdfUrl:
         mock_response.content = b"fake"
         mock_requests.get.return_value = mock_response
 
-        with patch("gptme.tools.browser.pypdf") as mock_pypdf:
+        mock_pypdf = MagicMock()
+        with patch.dict(sys.modules, {"pypdf": mock_pypdf}):
             pages = []
             for i in range(3):
                 p = MagicMock()
@@ -466,7 +470,8 @@ class TestReadPdfUrl:
         mock_response.content = b"fake"
         mock_requests.get.return_value = mock_response
 
-        with patch("gptme.tools.browser.pypdf") as mock_pypdf:
+        mock_pypdf = MagicMock()
+        with patch.dict(sys.modules, {"pypdf": mock_pypdf}):
             mock_page = MagicMock()
             mock_page.extract_text.return_value = "   "  # whitespace only
             mock_reader = MagicMock()
@@ -486,7 +491,8 @@ class TestReadPdfUrl:
         mock_response.content = b"fake"
         mock_requests.get.return_value = mock_response
 
-        with patch("gptme.tools.browser.pypdf") as mock_pypdf:
+        mock_pypdf = MagicMock()
+        with patch.dict(sys.modules, {"pypdf": mock_pypdf}):
             pages = []
             for i in range(15):
                 p = MagicMock()

--- a/tests/test_unified_plugins.py
+++ b/tests/test_unified_plugins.py
@@ -252,6 +252,53 @@ class TestEntrypointDiscovery:
         assert len(result) == 0
         clear_entrypoint_cache()
 
+    def test_enabled_filter_skips_without_loading(self):
+        """Disabled plugins are skipped before ep.load() runs (perf: loading
+        imports the plugin's whole package)."""
+        from gptme.plugins.entrypoints import (
+            clear_entrypoint_cache,
+            discover_entrypoint_plugins,
+        )
+
+        clear_entrypoint_cache()
+        enabled_ep = MagicMock()
+        enabled_ep.name = "wanted"
+        enabled_ep.module = "wanted_pkg.plugin"
+        enabled_ep.load.return_value = GptmePlugin(name="wanted")
+        disabled_ep = MagicMock()
+        disabled_ep.name = "heavy"
+        disabled_ep.module = "heavy_pkg"
+
+        with patch(
+            "gptme.plugins.entrypoints.entry_points",
+            return_value=[enabled_ep, disabled_ep],
+        ):
+            result = discover_entrypoint_plugins(frozenset({"wanted"}))
+
+        assert [p.name for p in result] == ["wanted"]
+        disabled_ep.load.assert_not_called()
+        clear_entrypoint_cache()
+
+    def test_enabled_filter_matches_package_name(self):
+        """A plugin enabled under its package name (e.g. "gptme-tts" for entry
+        point "tts" in package "gptme_tts") is still loaded."""
+        from gptme.plugins.entrypoints import (
+            clear_entrypoint_cache,
+            discover_entrypoint_plugins,
+        )
+
+        clear_entrypoint_cache()
+        mock_ep = MagicMock()
+        mock_ep.name = "tts"
+        mock_ep.module = "gptme_tts.plugin"
+        mock_ep.load.return_value = GptmePlugin(name="gptme-tts")
+
+        with patch("gptme.plugins.entrypoints.entry_points", return_value=[mock_ep]):
+            result = discover_entrypoint_plugins(frozenset({"gptme-tts"}))
+
+        assert [p.name for p in result] == ["gptme-tts"]
+        clear_entrypoint_cache()
+
 
 # --- Unified registry ---
 


### PR DESCRIPTION
## Problem

`make bench-startup` showed a basic `gptme '/exit'` cycle at **~8s** locally (mean, hyperfine). Profiling found the time going to imports and work the run never uses.

## Root causes found

1. **`gptme.cli.main` imported the whole app at module import time** — it called `get_available_tools()` at module level to render `--help` text, importing every tool module and triggering full plugin discovery just to build a docstring. Bare `import gptme.cli.main` (what CI benchmarks) took ~3.1s.
2. **Disabled plugins were fully imported, then discarded** — `discover_all_plugins()` applied the `enabled` allowlist *after* `ep.load()`. An installed-but-disabled plugin whose package imports sentence-transformers/torch cost ~15s per startup before being thrown away.
3. **Both LLM SDKs loaded regardless of provider** — `init_llm()` imported `llm_anthropic` *and* `llm_openai` (each pulls its SDK, ~0.9s each). Also, the OpenAI client was constructed at startup even for runs that never call the LLM.
4. **mcp SDK imported before checking MCP is enabled/has servers** (~0.5s).
5. **pypdf imported at module level for an availability check** (~250ms).
6. **Lesson frontmatter parsed with pure-Python YAML** — with libyaml available, CSafeLoader is ~10x faster (~3.5s → ~1s for ~500 lessons).
7. **Session-start agent scan ran one `lsof` per candidate PID** on macOS (~50ms each); now one batched call.

## Changes

- Lazy `--help`/`-t` choices via `_DynamicHelpCommand` placeholder substitution and callable choices in `CommaSeparatedChoice`; heavy imports deferred into `main()` after the cheap early-exit paths (`--help`, `--version`, subcommand dispatch).
- Entry-point allowlist filtering *before* `ep.load()` (dash/underscore-insensitive on entry-point name); slow plugin loads (>1s) log a warning naming the culprit.
- Per-branch provider imports in `init_llm()`; `_LazyClient` proxy in `llm_openai` records client params at init (API-key validation still fails fast at startup) and constructs the SDK client on first use.
- `create_mcp_tools()` checks `enabled`/`servers` before importing the MCP client.
- `browser.py` uses `find_spec` for the availability check, imports pypdf in `_read_pdf_url`.
- `lessons/parser.py` uses `yaml.CSafeLoader` when available.
- `workspace_agents.scan_agents()` batches CWD lookups into one `lsof` call.

## Benchmarks (M-series macOS, warm cache, Python 3.13)

| Metric | Before | After |
|---|---|---|
| `import gptme.cli.main` | ~3.1 s | **~0.07–0.15 s** |
| Full `gptme '/exit'` cycle (all-extras venv) | ~19 s | **~2 s** |

## Benchmark/CI alignment

- `make bench-startup` no longer measures `poetry run` (1–3s of wrapper overhead per invocation, unrelated to gptme) — it resolves the venv once and benchmarks both the import and the full cycle, with stdin from `/dev/null` so the piped-stdin grace period (1s) isn't included.
- CI benchmark: warm-import threshold tightened 2.5s → 1.0s, cold 10s → 6s, and a new full start/exit cycle benchmark added (threshold 3.0s) so runtime init work is also guarded, not just import time.

## Notes

- Tests that monkeypatched now-lazy `gptme.cli.main` attributes were updated to patch the source modules. `chat` needs `importlib.import_module('gptme.chat')` because the package's lazy `chat` *function* attr shadows the `gptme.chat` *module* in string-target resolution.
- Follow-up (gptme-contrib): `gptme-ace` imports sentence-transformers at package import; `gptme-tts` imports scipy at module level (~0.35s). Both should defer.
- Follow-up (core): `get_prompt()` builds the full system prompt (incl. lesson indexing) even for command-only runs like `gptme '/exit'`; deferring prompt construction to first LLM use would cut another ~0.5–1s.