### PR TITLE
feat(cli): compact log output for user-facing CLIs

### DIFF
--- a/gptme/chat.py
+++ b/gptme/chat.py
@@ -141,8 +141,9 @@ def chat(
 
         # print log (suppressed in JSON output mode and in quiet mode)
         if not is_output_json() and not is_output_quiet():
-            manager.log.print(show_hidden=show_hidden)
-            console.print("--- ^^^ past messages ^^^ ---")
+            # only draw a separator if any past messages were actually shown
+            if manager.log.print(show_hidden=show_hidden):
+                console.rule("[dim]past messages[/]", style="dim")
 
         # Note: todo replay is now handled via SESSION_START hook
         # Note: Confirmation is now handled within ToolUse.execute() using the hook system,

--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -102,14 +102,27 @@ class _DynamicHelpCommand(click.Command):
             return
         self._help_expanded = True
 
+        import textwrap
+
         from ..commands import _gen_help
         from ..llm.models import get_recommended_model
         from ..tools import get_available_tools
+        from ..util import console
 
-        commands_help = "\n".join(_gen_help(incl_langtags=False))
-        tools = get_available_tools(include_mcp=False)
-        available_tools = ", ".join(
-            sorted(tool.name for tool in tools if tool.is_available)
+        # Tool discovery loads plugins, which log status lines (e.g.
+        # "Using plugins ...") — suppress those while rendering help.
+        prev_quiet = console.quiet
+        console.quiet = True
+        try:
+            commands_help = "\n".join(_gen_help(incl_langtags=False))
+            tools = get_available_tools(include_mcp=False)
+        finally:
+            console.quiet = prev_quiet
+        available_tools = textwrap.fill(
+            ", ".join(sorted(tool.name for tool in tools if tool.is_available)),
+            width=76,
+            initial_indent="  ",
+            subsequent_indent="  ",
         )
         model_examples = (
             f"openai/{get_recommended_model('openai')}, "
@@ -117,12 +130,12 @@ class _DynamicHelpCommand(click.Command):
         )
 
         if self.help:
-            self.help = self.help.replace("{commands_help}", commands_help)
+            self.help = self.help.replace("{commands_help}", commands_help).replace(
+                "{available_tools}", available_tools
+            )
         for param in self.params:
             if isinstance(param, click.Option) and param.help:
-                param.help = param.help.replace(
-                    "{available_tools}", available_tools
-                ).replace("{model_examples}", model_examples)
+                param.help = param.help.replace("{model_examples}", model_examples)
 
     def format_help(self, ctx: click.Context, formatter: click.HelpFormatter) -> None:
         self._expand_dynamic_help()
@@ -402,6 +415,10 @@ Examples:
   gptme --context files "do task"             Skip context_cmd, keep project files
 
 \b
+Available tools:
+{{available_tools}}
+
+\b
 The interface provides /commands during a conversation:
 {{commands_help}}
 
@@ -413,19 +430,19 @@ Subcommand shortcuts:
   (installed gptme-* binaries in PATH are listed at the bottom of this help)
 
 \b
-Utilities (gptme-util):
-  gptme-util tools list       List all tools and their availability
-  gptme-util tools info TOOL  Show detailed tool instructions/examples
-  gptme-util skills list      List discoverable skills in the current workspace
-  gptme-util skills show NAME Show a skill or lesson by name
-  gptme-util chats list       List past conversations
-  gptme-util chats search Q   Search conversations for query (full options)
-  gptme-util chats send ID MSG Queue a prompt for a running chat from another terminal
-  gptme-util chats rename     Rename a conversation
-  gptme-util models list      List available models
-  gptme-util snapshot list    List workspace snapshots outside a session
-  gptme-util context index    Index project files for RAG
-  gptme-util llm generate     Direct LLM generation without chat
+Utilities:
+  gptme tools list        List all tools and their availability
+  gptme tools info TOOL   Show detailed tool instructions/examples
+  gptme skills list       List discoverable skills in the current workspace
+  gptme skills show NAME  Show a skill or lesson by name
+  gptme chats list        List past conversations
+  gptme chats search Q    Search conversations for query (full options)
+  gptme chats send ID MSG Queue a prompt for a running chat from another terminal
+  gptme chats rename      Rename a conversation
+  gptme models list       List available models
+  gptme snapshot list     List workspace snapshots outside a session
+  gptme context index     Index project files for RAG
+  gptme llm generate      Direct LLM generation without chat
 
 Run 'gptme-util --help' for all utility commands."""
 
@@ -529,7 +546,7 @@ Run 'gptme-util --help' for all utility commands."""
         lenient_prefixes=["+"],
         metavar="TOOL",
     ),
-    help="Tools to allow. Comma-separated or repeated. Use '+tool' to add to defaults (e.g., '-t +subagent'). Use '-tool' to exclude from defaults (e.g., '-t=-browser'). Use 'none' to disable all tools. Supports .py file paths for custom tools (e.g., '-t path/to/tool.py'). Available: {available_tools}.",
+    help="Tools to allow. Comma-separated or repeated. Use '+tool' to add to defaults (e.g., '-t +subagent'). Use '-tool' to exclude from defaults (e.g., '-t=-browser'). Use 'none' to disable all tools. Supports .py file paths for custom tools (e.g., '-t path/to/tool.py'). See 'Available tools' above for the list.",
 )
 @click.option(
     "--agent-profile",

--- a/gptme/cli/util.py
+++ b/gptme/cli/util.py
@@ -710,42 +710,51 @@ def llm_generate(
     # Capture stderr to suppress console output during initialization
     stderr_capture = io.StringIO()
 
-    with redirect_stderr(stderr_capture):
-        from ..init import init  # fmt: skip
-        from ..llm import (  # fmt: skip
-            _chat_complete,
-            _stream,
-            get_provider_from_model,
-            init_llm,
-        )
-        from ..llm.models import get_default_model  # fmt: skip
-        from ..message import Message  # fmt: skip
-        from ..util import console  # fmt: skip
+    from ..util import console  # fmt: skip
 
-        # Disable console output
-        console.quiet = True
+    # Disable console output during init, and always restore it: the console
+    # is a shared module-level object, so leaving quiet=True would silence all
+    # later console output in this process (notably in-process CLI tests).
+    prev_quiet = console.quiet
+    try:
+        with redirect_stderr(stderr_capture):
+            from ..init import init  # fmt: skip
+            from ..llm import (  # fmt: skip
+                _chat_complete,
+                _stream,
+                get_provider_from_model,
+                init_llm,
+            )
+            from ..llm.models import get_default_model  # fmt: skip
+            from ..message import Message  # fmt: skip
 
-        # Initialize with minimal setup - no tools needed for simple generation
-        try:
-            init(model, interactive=False, tool_allowlist=[], tool_format="markdown")
-        except ValueError as e:
-            raise click.UsageError(str(e)) from e
+            console.quiet = True
 
-        # Get model or use default
-        if not model:
-            default_model = get_default_model()
-            if not default_model:
-                raise click.UsageError(
-                    "No model specified and no default model available."
+            # Initialize with minimal setup - no tools needed for simple generation
+            try:
+                init(
+                    model, interactive=False, tool_allowlist=[], tool_format="markdown"
                 )
-            model = default_model.full
+            except ValueError as e:
+                raise click.UsageError(str(e)) from e
 
-        # Ensure provider is initialized
-        try:
-            provider = get_provider_from_model(model)
-            init_llm(provider)
-        except ValueError as e:
-            raise click.UsageError(str(e)) from e
+            # Get model or use default
+            if not model:
+                default_model = get_default_model()
+                if not default_model:
+                    raise click.UsageError(
+                        "No model specified and no default model available."
+                    )
+                model = default_model.full
+
+            # Ensure provider is initialized
+            try:
+                provider = get_provider_from_model(model)
+                init_llm(provider)
+            except ValueError as e:
+                raise click.UsageError(str(e)) from e
+    finally:
+        console.quiet = prev_quiet
 
     # Anthropic requires the first message to be a system message
     messages = [Message("system", system_prompt), Message("user", prompt)]

--- a/gptme/init.py
+++ b/gptme/init.py
@@ -256,25 +256,64 @@ def _maybe_authenticate_gptme_interactively(
     return True
 
 
-def init_logging(verbose, *, stderr: bool = True):
+class CompactRichHandler(RichHandler):
+    """RichHandler variant for user-facing CLIs.
+
+    Hides the level label for INFO and below (WARNING/ERROR still shown)
+    and dims informational messages, keeping only warnings+ prominent.
+    """
+
+    def render(self, *, record, traceback, message_renderable):
+        from rich.text import Text
+
+        # Per-record toggle is safe: logging serializes emit() per handler.
+        self._log_render.show_level = record.levelno >= logging.WARNING
+        if record.levelno < logging.WARNING and isinstance(message_renderable, Text):
+            message_renderable.style = "dim"
+        return super().render(
+            record=record, traceback=traceback, message_renderable=message_renderable
+        )
+
+
+def init_logging(verbose, *, stderr: bool = True, compact: bool = True):
+    """Set up Rich logging.
+
+    compact tunes output for user-facing CLIs: it hides the INFO level label
+    and the file:line trailer, dims informational messages, and replaces
+    timestamps with a dim "·" marker that distinguishes log/status lines from
+    conversation output (verbose mode disables it to keep full detail).
+    The server passes compact=False to keep conventional log output.
+    """
+    compact = compact and not verbose
+    handler_cls = CompactRichHandler if compact else RichHandler
     if not stderr:
         # Use the shared Rich Console (same instance rprint uses) so log
         # output is serialized with streaming assistant output through a
         # single Console, preventing stderr/stdout interleave mid-stream.
         from rich import get_console as _get_console
 
-        handler = RichHandler(console=_get_console())
+        log_console = _get_console()
     else:
-        handler = RichHandler(
-            console=Console(stderr=True, log_path=False)
-        )  # show_time=False
+        log_console = Console(stderr=True, log_path=False)
+    handler = handler_cls(
+        console=log_console,
+        show_path=not compact,
+        # in compact mode the "time" column is a constant marker, so repeat it
+        omit_repeated_times=not compact,
+    )
     logging.basicConfig(
         level=logging.DEBUG if verbose else logging.INFO,
         format="%(message)s",
-        datefmt="[%X]",
+        # strftime format; "·" has no format codes so renders as a literal marker
+        datefmt="·" if compact else "[%X]",
         handlers=[handler],
         force=True,  # Override any previous logging configuration
     )
+    if compact:
+        # Give console.log() status lines (Using model/logdir/...) the same
+        # "·" marker instead of a timestamp, matching the log lines above.
+        console._log_render.time_format = "·"
+        console._log_render.omit_repeated_times = False
 
     # anthropic spams debug logs for every request
     logging.getLogger("anthropic").setLevel(logging.INFO)

--- a/gptme/init.py
+++ b/gptme/init.py
@@ -311,9 +311,13 @@ def init_logging(verbose, *, stderr: bool = True, compact: bool = True):
     )
     if compact:
         # Give console.log() status lines (Using model/logdir/...) the same
-        # "·" marker instead of a timestamp, matching the log lines above.
+        # treatment as INFO log lines: a dim "·" marker instead of a
+        # timestamp, and dimmed message text.
+        from rich.theme import Theme
+
         console._log_render.time_format = "·"
         console._log_render.omit_repeated_times = False
+        console.push_theme(Theme({"log.message": "dim"}))
 
     # anthropic spams debug logs for every request
     logging.getLogger("anthropic").setLevel(logging.INFO)

--- a/gptme/init.py
+++ b/gptme/init.py
@@ -275,6 +275,28 @@ class CompactRichHandler(RichHandler):
         )
 
 
+# Whether the shared status console is currently in compact mode (dim "·"
+# marker + dimmed messages), so repeated init_logging() calls can toggle it.
+_console_compact = False
+
+
+def _set_console_compact(enabled: bool) -> None:
+    global _console_compact
+    if enabled == _console_compact:
+        return
+    _console_compact = enabled
+    if enabled:
+        from rich.theme import Theme
+
+        console._log_render.time_format = "·"
+        console._log_render.omit_repeated_times = False
+        console.push_theme(Theme({"log.message": "dim"}))
+    else:
+        console._log_render.time_format = "[%X]"
+        console._log_render.omit_repeated_times = True
+        console.pop_theme()
+
+
 def init_logging(verbose, *, stderr: bool = True, compact: bool = True):
     """Set up Rich logging.
 
@@ -309,15 +331,10 @@ def init_logging(verbose, *, stderr: bool = True, compact: bool = True):
         handlers=[handler],
         force=True,  # Override any previous logging configuration
     )
-    if compact:
-        # Give console.log() status lines (Using model/logdir/...) the same
-        # treatment as INFO log lines: a dim "·" marker instead of a
-        # timestamp, and dimmed message text.
-        from rich.theme import Theme
-
-        console._log_render.time_format = "·"
-        console._log_render.omit_repeated_times = False
-        console.push_theme(Theme({"log.message": "dim"}))
+    # Give console.log() status lines (Using model/logdir/...) the same
+    # treatment as INFO log lines in compact mode: a dim "·" marker instead
+    # of a timestamp, and dimmed message text. Restored on non-compact calls.
+    _set_console_compact(compact)
 
     # anthropic spams debug logs for every request
     logging.getLogger("anthropic").setLevel(logging.INFO)

--- a/gptme/logmanager/manager.py
+++ b/gptme/logmanager/manager.py
@@ -104,8 +104,9 @@ class Log:
         with open(path, "w") as file:
             file.writelines(json.dumps(msg.to_dict()) + "\n" for msg in self.messages)
 
-    def print(self, show_hidden: bool = False):
-        print_msg(self.messages, oneline=False, show_hidden=show_hidden)
+    def print(self, show_hidden: bool = False) -> int:
+        """Prints the log to the console. Returns the number of messages shown."""
+        return print_msg(self.messages, oneline=False, show_hidden=show_hidden)
 
 
 # Context-local storage for current LogManager instance

--- a/gptme/message.py
+++ b/gptme/message.py
@@ -627,7 +627,7 @@ def print_msg(
         shown += 1
     if skipped_hidden:
         console.print(
-            f"[dim]{skipped_hidden} hidden system messages skipped (/log --hidden to show)[/]"
+            f"[dim]Skipped {skipped_hidden} hidden system messages (/log --hidden to show)[/]"
         )
     return shown
 

--- a/gptme/message.py
+++ b/gptme/message.py
@@ -567,12 +567,12 @@ def print_msg(
     oneline: bool = False,
     highlight: bool = True,
     show_hidden: bool = False,
-) -> None:
-    """Prints the log to the console."""
+) -> int:
+    """Prints the log to the console. Returns the number of messages shown."""
     # Quiet mode: suppress terminal output (not JSON — JSON is the structured interface).
     # Only skip if we're not in JSON mode.
     if is_output_quiet() and not is_output_json():
-        return
+        return 0
 
     # if not tty, force highlight=False (for tests and such)
     if not sys.stdout.isatty():
@@ -582,9 +582,11 @@ def print_msg(
 
     # JSON output mode: emit line-delimited dicts to stdout
     if is_output_json():
+        shown = 0
         for m in msgs:
             if m.hide and not show_hidden:
                 continue
+            shown += 1
             event: dict = {
                 "type": "message",
                 "role": m.role,
@@ -607,10 +609,11 @@ def print_msg(
                 event["metadata"] = meta_dict
             sys.stdout.write(json.dumps(event, default=str) + "\n")
         sys.stdout.flush()
-        return
+        return shown
 
     msgstrs = format_msgs(msgs, highlight=highlight, oneline=oneline)
     skipped_hidden = 0
+    shown = 0
     for m, s in zip(msgs, msgstrs):
         if m.hide and not show_hidden:
             skipped_hidden += 1
@@ -621,10 +624,12 @@ def print_msg(
             # rich can throw errors, if so then print the raw message
             logger.exception("Error printing message")
             print(s)
+        shown += 1
     if skipped_hidden:
         console.print(
-            f"[grey30]Skipped {skipped_hidden} hidden system messages, use /log --hidden to show[/]"
+            f"[dim]{skipped_hidden} hidden system messages skipped (/log --hidden to show)[/]"
         )
+    return shown
 
 
 def msgs_to_toml(msgs: Iterable[Message]) -> str:

--- a/gptme/plugins/__init__.py
+++ b/gptme/plugins/__init__.py
@@ -319,10 +319,14 @@ def get_plugin_tool_modules(
     Returns:
         List of module names containing tools (e.g., "my_plugin.tools")
     """
+    import importlib
+    import time
+
     plugins = discover_plugins(plugin_paths)
 
     tool_modules: list[str] = []
     newly_loaded: list[str] = []
+    load_times: dict[str, float] = {}
     for plugin in plugins:
         # Apply allowlist if provided
         if enabled_plugins and plugin.name not in enabled_plugins:
@@ -330,18 +334,32 @@ def get_plugin_tool_modules(
             continue
 
         # Track newly loaded plugins
-        # Track newly loaded plugins
         if _mark_plugin_loaded(plugin):
             newly_loaded.append(plugin.name)
+            # Import the plugin's tool modules now so we can attribute import
+            # time per plugin; tool discovery later hits sys.modules for free.
+            start = time.monotonic()
+            for mod in plugin.tool_modules:
+                try:
+                    importlib.import_module(mod)
+                except Exception:
+                    # errors are surfaced by tool discovery, which imports again
+                    logger.debug("Failed to import %s", mod, exc_info=True)
+            load_times[plugin.name] = time.monotonic() - start
 
         # Add plugin's tool modules
         tool_modules.extend(plugin.tool_modules)
 
-    # Log all newly loaded plugins in one line
+    # Log all newly loaded plugins in one line, with init times for slow ones
     if newly_loaded:
-        console.log(
-            f"Using plugins {', '.join(f'[green]{plugin}[/green]' for plugin in newly_loaded)}"
-        )
+
+        def _fmt(name: str) -> str:
+            label = f"[green]{name}[/green]"
+            if (t := load_times.get(name, 0.0)) > 0.2:
+                label += f" [yellow]({t:.1f}s)[/yellow]"
+            return label
+
+        console.log(f"Using plugins {', '.join(_fmt(p) for p in newly_loaded)}")
 
     if tool_modules:
         logger.debug(f"Loaded {len(tool_modules)} tool modules")

--- a/gptme/server/cli.py
+++ b/gptme/server/cli.py
@@ -236,12 +236,8 @@ def serve(
     watch_pid: int | None,
     default_profile: str | None,
 ):  # pragma: no cover
-    """
-    Starts a server and web UI for gptme.
-
-    Note that this is very much a work in progress, and is not yet ready for normal use.
-    """
-    init_logging(verbose)
+    """Starts a server and web UI for gptme."""
+    init_logging(verbose, compact=False)
     set_config_from_workspace(Path.cwd())
 
     if exit_on_parent_death or watch_pid is not None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -82,8 +82,11 @@ def _write_conversation(
 def test_help(runner: CliRunner):
     result = runner.invoke(cli.main, ["--help"])
     assert result.exit_code == 0
-    assert "gptme-util skills list" in result.output
-    assert "gptme-util skills show NAME" in result.output
+    assert "gptme skills list" in result.output
+    assert "gptme skills show NAME" in result.output
+    assert "Available tools:" in result.output
+    # plugin loading during help rendering should not leak status lines
+    assert "Using plugins" not in result.output
 
 
 def test_discover_gptme_plugins_finds_external_binaries(


### PR DESCRIPTION
## Motivation

Interactive CLI output was noisy: every log line carried an `INFO` label, a `file.py:123` trailer, and a timestamp, drowning out actual warnings and blending into conversation output. `gptme --help` also loaded plugins (slow, and leaked a `Using plugins ...` line above the usage text).

## Changes

**Compact log mode** (new `CompactRichHandler` + `compact` param on `init_logging`, default on; the server opts out with `compact=False`, and `--verbose` disables it to keep full detail):
- Hide the level label for INFO and below — WARNING/ERROR labels still shown
- Drop the `file:line` trailer (pure noise outside verbose mode)
- Dim informational log messages and `console.log()` status lines (Using model/plugins/logdir/workspace), keeping color accents
- Replace timestamps with a dim `·` marker on log/status lines — still visually marks diagnostics vs conversation output, without the width/noise
- Compact console state is tracked and restored if `init_logging` is later called non-compact

After:

```
· Using plugins gptme-consortium, gptme-tts (0.8s)
· Using model: openrouter/anthropic/claude-opus-4.8
· WARNING  Parallel agent detected: claude-code PID 86305
· Using logdir: ~/.local/share/gptme/logs/2026-07-11-test
· some info-level log line                    (dimmed)
· ERROR    Telemetry export failed: connection refused
```

**Plugin init times**: plugin tool modules are imported at discovery time so slow plugin imports (>0.2s) are surfaced in the `Using plugins` line, e.g. `gptme-tts (0.8s)`. (The gptme-tts slowness itself is fixed in gptme/gptme-contrib#1279 — eager scipy/requests imports.)

**--help cleanup:**
- Plugin status lines no longer leak into `--help` output
- The long tools list moved from the `-t/--tools` option help into an `Available tools:` section in the main help text
- Utilities section now uses the `gptme <cmd>` shorthand instead of `gptme-util <cmd>`

**Resume output cleanup:**
- `--- ^^^ past messages ^^^ ---` separator is now a dim `console.rule`, only printed when past messages were actually shown
- Restyled the skipped-hidden notice: dim `Skipped 6 hidden system messages (/log --hidden to show)`
- `print_msg`/`Log.print` now return the number of messages shown

**Misc:** removed the stale "very much a work in progress" note from `gptme-server` help.

## Testing

- Verified all modes render correctly (compact, `compact=False`, verbose, and roundtrips between them)
- Verified separator suppression when all past messages are hidden
- `--help` verified clean (no plugin line, tools section renders wrapped)
- `tests/test_message.py`, `tests/test_logmanager.py`, `tests/test_cli.py`, `tests/test_plugins.py` pass; prek hooks green