### PR TITLE
feat(subagent): add SubagentBudget for fleet-wide token budget coordination

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -156,7 +156,9 @@ nitpick_ignore = [
     # Phase 1 async subagent types
     ("py:class", "gptme.tools.subagent.ReturnType"),
     ("py:class", "gptme.tools.subagent.BatchJob"),
+    ("py:class", "gptme.tools.subagent.SubagentBudget"),
     ("py:class", "gptme.tools.subagent.types.SubtaskDef"),
+    ("py:class", "gptme.tools.subagent.types.SubagentBudget"),
     ("py:class", "gptme.tools.subagent.batch.BatchJob"),
     # Hook confirmation system types
     ("py:class", "gptme.hooks.confirm.ToolConfirmHook"),

--- a/gptme/tools/subagent/__init__.py
+++ b/gptme/tools/subagent/__init__.py
@@ -35,6 +35,7 @@ from .types import (
     ReturnType,
     Status,
     Subagent,
+    SubagentBudget,
     SubtaskDef,
     _completion_queue,
     _progress_queue,
@@ -473,6 +474,7 @@ __all__ = [
     "ReturnType",
     "Subagent",
     "Status",
+    "SubagentBudget",
     # Hooks
     "notify_completion",
     "notify_progress",

--- a/gptme/tools/subagent/api.py
+++ b/gptme/tools/subagent/api.py
@@ -339,6 +339,13 @@ def subagent(
         if not workdir_path.is_dir():
             raise ValueError(f"workdir is not a directory: {workdir_path}")
 
+    # Clear any stale cached result for this agent_id before starting a new run.
+    # Without this, a reused deterministic id (e.g. "<item>-s0" in a pipeline) can
+    # return the previous run's terminal result from the shared cache, hiding the
+    # current run entirely.
+    with _subagent_results_lock:
+        _subagent_results.pop(agent_id, None)
+
     if mode == "planner":
         if context_turns is not None:
             logger.warning(

--- a/gptme/tools/subagent/api.py
+++ b/gptme/tools/subagent/api.py
@@ -1111,12 +1111,10 @@ def subagent_wait(
     Returns:
         Status dict with 'status' and 'result' keys
     """
-    sa = None
+    # Use the most recently spawned entry — _subagents is append-only, so
+    # reversed() finds the newest match when the same agent_id is reused.
     with _subagents_lock:
-        for s in _subagents:
-            if s.agent_id == agent_id:
-                sa = s
-                break
+        sa = next((s for s in reversed(_subagents) if s.agent_id == agent_id), None)
 
     if sa is None:
         raise ValueError(f"Subagent with ID {agent_id} not found.")
@@ -1236,12 +1234,10 @@ def subagent_read_log(
     Returns:
         Formatted log output showing the conversation
     """
-    sa = None
+    # Use the most recently spawned entry — _subagents is append-only, so
+    # reversed() finds the newest match when the same agent_id is reused.
     with _subagents_lock:
-        for s in _subagents:
-            if s.agent_id == agent_id:
-                sa = s
-                break
+        sa = next((s for s in reversed(_subagents) if s.agent_id == agent_id), None)
 
     if sa is None:
         raise ValueError(f"Subagent with ID {agent_id} not found.")

--- a/gptme/tools/subagent/batch.py
+++ b/gptme/tools/subagent/batch.py
@@ -14,8 +14,9 @@ import math
 import threading
 import time
 from collections.abc import Callable
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from concurrent.futures import TimeoutError as FuturesTimeoutError
+from concurrent.futures import wait as futures_wait
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import cast
@@ -152,7 +153,7 @@ class BatchJob:
                         if agent_id in self.results:
                             return agent_id, self.results[agent_id]
                     return agent_id, ReturnType(
-                        "failure", "Cancelled due to sibling failure"
+                        "cancelled", "Cancelled due to sibling failure"
                     )
 
                 remaining = deadline - time.monotonic()
@@ -188,6 +189,9 @@ class BatchJob:
         import time
 
         deadline = time.monotonic() + timeout
+        # Safe default: if the try block raises before agent_to_future is built,
+        # the post-cancel sweep below still has a valid (empty) dict to iterate.
+        agent_to_future: dict[str, Future[tuple[str, ReturnType]]] = {}
         # Use explicit lifecycle instead of context manager so we can return
         # immediately after cancellation without blocking on still-running
         # _wait_one threads (ThreadPoolExecutor.__exit__ calls shutdown(wait=True)).
@@ -211,9 +215,10 @@ class BatchJob:
                     agent_id, result = future.result()
                     with self._lock:
                         prev = self.results.get(agent_id)
-                        # Overwrite a prior timeout placeholder with the real result;
-                        # never overwrite a non-timeout (already-final) result.
-                        if prev is None or prev.status == "timeout":
+                        # Overwrite placeholder results (timeout, synthetic cancel)
+                        # with the real result. Never overwrite an already-final
+                        # non-placeholder result.
+                        if prev is None or prev.status in ("timeout", "cancelled"):
                             self.results[agent_id] = result
 
                     # Cancel remaining agents on first failure/timeout
@@ -241,7 +246,7 @@ class BatchJob:
                                         except Exception:
                                             pass
                                     self.results[aid_to_cancel] = real or ReturnType(
-                                        "failure", "Cancelled due to sibling failure"
+                                        "cancelled", "Cancelled due to sibling failure"
                                     )
                         # Signal workers to exit poll loops, then exit the loop.
                         cancel_event.set()
@@ -274,6 +279,42 @@ class BatchJob:
             # collected in self.results. Workers will exit their poll loops within
             # _POLL_SECS seconds once cancel_event is set.
             pool.shutdown(wait=False, cancel_futures=True)
+
+        # Post-cancel sweep: upgrade synthetic "cancelled" placeholders with real
+        # results from futures that completed after the cancel loop wrote the
+        # placeholder.  This handles the race where:
+        #   1. cancel loop checks f.done() → False, writes "cancelled" placeholder
+        #   2. main loop breaks because all agent slots are filled
+        #   3. _wait_one thread finishes shortly after (future becomes done)
+        # Without this sweep the real result (which may carry output_tokens) is
+        # discarded and the budget under-counts.
+        if cancel_on_failure and agent_to_future:
+            # Brief wait for _wait_one threads whose agents were just cancelled via
+            # subagent_cancel().  After cancel, those threads typically finish within
+            # microseconds (the cancel call unblocks their subagent_wait), but
+            # pool.shutdown(wait=False) does not wait for them.  0.5s is generous.
+            with self._lock:
+                pending = [
+                    agent_to_future[aid]
+                    for aid, r in self.results.items()
+                    if r.status == "cancelled" and aid in agent_to_future
+                ]
+            if pending:
+                futures_wait(pending, timeout=0.5)
+            for aid, f in agent_to_future.items():
+                if f.done() and not f.cancelled():
+                    with self._lock:
+                        r = self.results.get(aid)
+                    if r is not None and r.status == "cancelled":
+                        try:
+                            _, real = f.result()
+                            with self._lock:
+                                # Only replace if still the same placeholder (another
+                                # concurrent wait_all() hasn't updated it first).
+                                if self.results.get(aid) is r:
+                                    self.results[aid] = real
+                        except Exception:
+                            pass
 
         raw = {aid: asdict(r) for aid, r in self.results.items()}
 

--- a/gptme/tools/subagent/batch.py
+++ b/gptme/tools/subagent/batch.py
@@ -200,11 +200,13 @@ class BatchJob:
             futures = {
                 pool.submit(_wait_one, aid, deadline): aid
                 for aid in self.agent_ids
-                # Re-wait agents whose previous wait_all() call timed out —
-                # their placeholder result has output_tokens=None, so a naive
-                # "skip if already in results" would leave the budget undercounted
-                # when the agent eventually finishes in a later call.
-                if aid not in self.results or self.results[aid].status == "timeout"
+                # Re-wait agents whose previous wait_all() call timed out, or
+                # whose post-cancel sweep left a synthetic "cancelled" placeholder
+                # after the 0.5s grace window — both have output_tokens=None, so
+                # skipping them would leave the budget undercounted when the agent
+                # eventually finishes in a later call.
+                if aid not in self.results
+                or self.results[aid].status in ("timeout", "cancelled")
             }
             # Reverse lookup so the cancel_on_failure path can collect real
             # results from concurrently-completed futures before writing synthetic

--- a/gptme/tools/subagent/batch.py
+++ b/gptme/tools/subagent/batch.py
@@ -97,7 +97,9 @@ class BatchJob:
     agent_ids: list[str]
     results: dict[str, ReturnType] = field(default_factory=dict)
     output_schema: "type | dict | None" = field(default=None)
+    budget: SubagentBudget | None = field(default=None)
     _lock: threading.Lock = field(default_factory=threading.Lock)
+    _budget_recorded: bool = field(default=False, init=False, repr=False)
 
     def wait_all(
         self, timeout: int = 300, cancel_on_failure: bool = False
@@ -249,6 +251,15 @@ class BatchJob:
             pool.shutdown(wait=False, cancel_futures=True)
 
         raw = {aid: asdict(r) for aid, r in self.results.items()}
+
+        # Record output tokens from completed agents into the shared budget.
+        # Guard with _budget_recorded so multiple wait_all() calls don't double-count.
+        if self.budget is not None and not self._budget_recorded:
+            self._budget_recorded = True
+            for r in self.results.values():
+                if r.output_tokens is not None:
+                    self.budget.record(r.output_tokens)
+
         if self.output_schema is not None:
             return {aid: _parse_result(r, self.output_schema) for aid, r in raw.items()}
         return raw
@@ -479,7 +490,9 @@ def subagent_batch(
         # Or explicitly wait for all if needed:
         results = job.wait_all(timeout=300)
     """
-    job = BatchJob(agent_ids=[t[0] for t in tasks], output_schema=output_schema)
+    job = BatchJob(
+        agent_ids=[t[0] for t in tasks], output_schema=output_schema, budget=budget
+    )
 
     # Start subagents, skipping any after the budget is exhausted
     started: list[str] = []
@@ -832,7 +845,12 @@ def subagent_pipeline(
             # Only pass output_schema to the final stage
             is_final = stage_idx == len(stages) - 1
 
-            # Budget check: skip remaining stages if budget is exhausted
+            # Budget check: skip remaining stages if budget is exhausted.
+            # Note: enforcement near exhaustion is best-effort in concurrent pipelines.
+            # Another thread may record tokens and exhaust the budget between this check
+            # and the subagent() call below. The violation is bounded (at most one extra
+            # agent per concurrent item thread). A hard atomic reserve is not possible
+            # without knowing the token cost upfront.
             if budget is not None and budget.exhausted():
                 logger.debug(
                     "subagent_pipeline: budget exhausted, skipping '%s'", agent_id

--- a/gptme/tools/subagent/batch.py
+++ b/gptme/tools/subagent/batch.py
@@ -202,6 +202,10 @@ class BatchJob:
                 # when the agent eventually finishes in a later call.
                 if aid not in self.results or self.results[aid].status == "timeout"
             }
+            # Reverse lookup so the cancel_on_failure path can collect real
+            # results from concurrently-completed futures before writing synthetic
+            # placeholders (otherwise output_tokens can be silently lost).
+            agent_to_future = {aid: f for f, aid in futures.items()}
             try:
                 for future in as_completed(futures, timeout=timeout):
                     agent_id, result = future.result()
@@ -225,7 +229,18 @@ class BatchJob:
                                 pass  # Agent already finished
                             with self._lock:
                                 if aid_to_cancel not in self.results:
-                                    self.results[aid_to_cancel] = ReturnType(
+                                    # Prefer the real result if the future has already
+                                    # completed concurrently — preserves output_tokens
+                                    # for accurate budget accounting instead of losing
+                                    # them to a synthetic placeholder with None tokens.
+                                    f = agent_to_future.get(aid_to_cancel)
+                                    real: ReturnType | None = None
+                                    if f is not None and f.done() and not f.cancelled():
+                                        try:
+                                            _, real = f.result()
+                                        except Exception:
+                                            pass
+                                    self.results[aid_to_cancel] = real or ReturnType(
                                         "failure", "Cancelled due to sibling failure"
                                     )
                         # Signal workers to exit poll loops, then exit the loop.

--- a/gptme/tools/subagent/batch.py
+++ b/gptme/tools/subagent/batch.py
@@ -21,7 +21,7 @@ from pathlib import Path
 from typing import cast
 
 from .api import subagent, subagent_cancel, subagent_wait
-from .types import ReturnType
+from .types import ReturnType, SubagentBudget
 
 logger = logging.getLogger(__name__)
 
@@ -420,6 +420,7 @@ def subagent_batch(
     context_turns: int | None = None,
     context_window: int | None = None,
     redact_secrets: bool = True,
+    budget: SubagentBudget | None = None,
 ) -> BatchJob:
     """Start multiple subagents in parallel and return a BatchJob to manage them.
 
@@ -480,8 +481,18 @@ def subagent_batch(
     """
     job = BatchJob(agent_ids=[t[0] for t in tasks], output_schema=output_schema)
 
-    # Start all subagents (completions delivered via hooks)
+    # Start subagents, skipping any after the budget is exhausted
+    started: list[str] = []
     for agent_id, prompt in tasks:
+        if budget is not None and budget.exhausted():
+            logger.debug(
+                "subagent_batch: budget exhausted, skipping agent '%s'", agent_id
+            )
+            with job._lock:
+                job.results[agent_id] = ReturnType(
+                    "budget_exceeded", "Budget exhausted before this agent could start"
+                )
+            continue
         subagent(
             agent_id=agent_id,
             prompt=prompt,
@@ -497,8 +508,9 @@ def subagent_batch(
             context_window=context_window,
             redact_secrets=redact_secrets,
         )
+        started.append(agent_id)
 
-    logger.info(f"Started batch of {len(tasks)} subagents: {job.agent_ids}")
+    logger.info(f"Started batch of {len(started)} subagents: {started}")
     return job
 
 
@@ -517,6 +529,7 @@ def subagent_parallel(
     context_window: int | None = None,
     redact_secrets: bool = True,
     cancel_on_failure: bool = False,
+    budget: SubagentBudget | None = None,
 ) -> list[dict]:
     """Fan out N subagents in parallel, wait for all, return results as an ordered list.
 
@@ -574,12 +587,20 @@ def subagent_parallel(
             waste resources. Equivalent to calling ``subagent_cancel()``
             manually after ``subagent_wait_any()`` detects a failure, but
             handled automatically inside the parallel wait.
+        budget: Optional shared token budget. When set, each agent's output
+            tokens are recorded after it completes, and any agent whose spawn
+            is attempted after the budget is exhausted is returned immediately
+            with ``status="budget_exceeded"`` without being started. Agents
+            already running when the budget hits zero are allowed to finish
+            normally. Pass a ``SubagentBudget`` to share a budget across
+            multiple ``subagent_parallel()`` calls (dynamic fan-out loop).
 
     Returns:
         List of result dicts in the same order as ``tasks``. Each dict has
-        ``"status"`` (``"success"`` / ``"failure"`` / ``"timeout"``) and
-        ``"result"`` (parsed object when ``output_schema`` is set, else the
-        summary text from the subagent's ``complete`` block).
+        ``"status"`` (``"success"`` / ``"failure"`` / ``"timeout"`` /
+        ``"budget_exceeded"``) and ``"result"`` (parsed object when
+        ``output_schema`` is set, else the summary text from the subagent's
+        ``complete`` block).
 
     Example::
 
@@ -622,14 +643,29 @@ def subagent_parallel(
             if r["status"] == "success":
                 analysis = r["result"]  # already a validated dict
                 print(f"Score: {analysis['score']}, Issues: {analysis['issues']}")
+
+        # Budget-aware dynamic loop (spawn until budget runs out)
+        from gptme.tools.subagent import SubagentBudget
+        budget = SubagentBudget(total=200_000)
+        while not budget.exhausted():
+            results = subagent_parallel(next_batch, budget=budget)
+            # items skipped after budget exhaustion have status="budget_exceeded"
     """
     if not tasks:
         return []
 
-    # Start all subagents; on failure, cancel any already-started ones to avoid orphans
+    # Track which agent_ids were skipped due to budget exhaustion vs actually started.
     started_ids: list[str] = []
+    budget_exceeded_ids: set[str] = set()
+
     try:
         for agent_id, prompt in tasks:
+            if budget is not None and budget.exhausted():
+                budget_exceeded_ids.add(agent_id)
+                logger.debug(
+                    "subagent_parallel: budget exhausted, skipping agent '%s'", agent_id
+                )
+                continue
             subagent(
                 agent_id=agent_id,
                 prompt=prompt,
@@ -654,17 +690,34 @@ def subagent_parallel(
                 pass
         raise
 
-    logger.info(f"subagent_parallel: started {len(tasks)} subagents")
+    logger.info(
+        "subagent_parallel: started %d subagents%s",
+        len(started_ids),
+        f", skipped {len(budget_exceeded_ids)} (budget exhausted)"
+        if budget_exceeded_ids
+        else "",
+    )
 
-    # Collect results in parallel using BatchJob
-    job = BatchJob(agent_ids=[t[0] for t in tasks])
-    job.wait_all(timeout=timeout, cancel_on_failure=cancel_on_failure)
+    # Collect results from started agents in parallel
+    job = BatchJob(agent_ids=started_ids)
+    if started_ids:
+        job.wait_all(timeout=timeout, cancel_on_failure=cancel_on_failure)
 
-    # Return results in input order; fall back to failure for missing results.
-    # When output_schema is set, parse the JSON result against the schema.
+    # Record output tokens from completed agents into the shared budget
+    if budget is not None:
+        for result in job.results.values():
+            if result.output_tokens is not None:
+                budget.record(result.output_tokens)
+
+    # Build ordered results, substituting budget_exceeded for skipped agents
+    _budget_exceeded_result = ReturnType(
+        "budget_exceeded", "Budget exhausted before this agent could start"
+    )
     raw_results = [
         asdict(
-            job.results.get(
+            _budget_exceeded_result
+            if agent_id in budget_exceeded_ids
+            else job.results.get(
                 agent_id, ReturnType("failure", "No result (timeout or missing)")
             )
         )
@@ -690,6 +743,7 @@ def subagent_pipeline(
     context_turns: int | None = None,
     context_window: int | None = None,
     redact_secrets: bool = True,
+    budget: SubagentBudget | None = None,
 ) -> list[list[dict]]:
     """Process items through multiple stages with no barrier between stages.
 
@@ -777,6 +831,20 @@ def subagent_pipeline(
             agent_id = f"{item_id_prefix}-s{stage_idx}"
             # Only pass output_schema to the final stage
             is_final = stage_idx == len(stages) - 1
+
+            # Budget check: skip remaining stages if budget is exhausted
+            if budget is not None and budget.exhausted():
+                logger.debug(
+                    "subagent_pipeline: budget exhausted, skipping '%s'", agent_id
+                )
+                with results_lock:
+                    for remaining in range(stage_idx, len(stages)):
+                        all_results[item_idx][remaining] = {
+                            "status": "budget_exceeded",
+                            "result": "Budget exhausted before this stage could start",
+                        }
+                return
+
             try:
                 stage_prompt = stage_fn(item_prompt, prev_result_text)
                 subagent(
@@ -801,10 +869,17 @@ def subagent_pipeline(
                 )
             except Exception as exc:
                 result = {"status": "failure", "result": str(exc)}
+
+            # Record output tokens in the shared budget
+            if budget is not None:
+                out_tok = result.get("output_tokens")
+                if out_tok is not None:
+                    budget.record(out_tok)
+
             with results_lock:
                 all_results[item_idx][stage_idx] = result
             if result.get("status") != "success":
-                # On failure, mark remaining stages as skipped and abort item
+                # On failure/budget_exceeded, mark remaining stages as skipped
                 with results_lock:
                     for remaining in range(stage_idx + 1, len(stages)):
                         all_results[item_idx][remaining] = {

--- a/gptme/tools/subagent/batch.py
+++ b/gptme/tools/subagent/batch.py
@@ -723,16 +723,12 @@ def subagent_parallel(
         else "",
     )
 
-    # Collect results from started agents in parallel
-    job = BatchJob(agent_ids=started_ids)
+    # Collect results from started agents in parallel.
+    # Pass budget so wait_all() records tokens once via BatchJob._budget_recorded_ids,
+    # which prevents double-counting on repeated wait_all() calls.
+    job = BatchJob(agent_ids=started_ids, budget=budget)
     if started_ids:
         job.wait_all(timeout=timeout, cancel_on_failure=cancel_on_failure)
-
-    # Record output tokens from completed agents into the shared budget
-    if budget is not None:
-        for result in job.results.values():
-            if result.output_tokens is not None:
-                budget.record(result.output_tokens)
 
     # Build ordered results, substituting budget_exceeded for skipped agents
     _budget_exceeded_result = ReturnType(

--- a/gptme/tools/subagent/batch.py
+++ b/gptme/tools/subagent/batch.py
@@ -196,13 +196,20 @@ class BatchJob:
             futures = {
                 pool.submit(_wait_one, aid, deadline): aid
                 for aid in self.agent_ids
-                if aid not in self.results
+                # Re-wait agents whose previous wait_all() call timed out —
+                # their placeholder result has output_tokens=None, so a naive
+                # "skip if already in results" would leave the budget undercounted
+                # when the agent eventually finishes in a later call.
+                if aid not in self.results or self.results[aid].status == "timeout"
             }
             try:
                 for future in as_completed(futures, timeout=timeout):
                     agent_id, result = future.result()
                     with self._lock:
-                        if agent_id not in self.results:
+                        prev = self.results.get(agent_id)
+                        # Overwrite a prior timeout placeholder with the real result;
+                        # never overwrite a non-timeout (already-final) result.
+                        if prev is None or prev.status == "timeout":
                             self.results[agent_id] = result
 
                     # Cancel remaining agents on first failure/timeout
@@ -233,7 +240,10 @@ class BatchJob:
                 timed_out_ids: list[str] = []
                 for aid in futures.values():
                     with self._lock:
-                        if aid not in self.results:
+                        prev = self.results.get(aid)
+                        # Only set/keep the timeout placeholder if no final result
+                        # is stored yet (don't overwrite a real result that snuck in).
+                        if prev is None or prev.status == "timeout":
                             self.results[aid] = ReturnType(
                                 "timeout", f"Timed out after {timeout}s"
                             )

--- a/gptme/tools/subagent/batch.py
+++ b/gptme/tools/subagent/batch.py
@@ -913,8 +913,17 @@ def subagent_pipeline(
                         from .types import _subagents, _subagents_lock
 
                         with _subagents_lock:
+                            # Use the last match — _subagents is append-only so the
+                            # most recently spawned entry for this agent_id is last.
+                            # next() with a forward iterator would return the oldest
+                            # (stale) entry when the same id is reused across runs.
                             sa = next(
-                                (s for s in _subagents if s.agent_id == agent_id), None
+                                (
+                                    s
+                                    for s in reversed(_subagents)
+                                    if s.agent_id == agent_id
+                                ),
+                                None,
                             )
                         if sa:
                             _, fb_out = sa._read_token_stats()

--- a/gptme/tools/subagent/batch.py
+++ b/gptme/tools/subagent/batch.py
@@ -99,7 +99,7 @@ class BatchJob:
     output_schema: "type | dict | None" = field(default=None)
     budget: SubagentBudget | None = field(default=None)
     _lock: threading.Lock = field(default_factory=threading.Lock)
-    _budget_recorded: bool = field(default=False, init=False, repr=False)
+    _budget_recorded_ids: set = field(default_factory=set, init=False, repr=False)
 
     def wait_all(
         self, timeout: int = 300, cancel_on_failure: bool = False
@@ -253,12 +253,14 @@ class BatchJob:
         raw = {aid: asdict(r) for aid, r in self.results.items()}
 
         # Record output tokens from completed agents into the shared budget.
-        # Guard with _budget_recorded so multiple wait_all() calls don't double-count.
-        if self.budget is not None and not self._budget_recorded:
-            self._budget_recorded = True
-            for r in self.results.values():
-                if r.output_tokens is not None:
+        # Track per-agent IDs so repeated wait_all() calls (e.g. after a timeout
+        # followed by a second wait) record newly-completed agents without
+        # double-counting those already recorded in a prior call.
+        if self.budget is not None:
+            for aid, r in self.results.items():
+                if aid not in self._budget_recorded_ids and r.output_tokens is not None:
                     self.budget.record(r.output_tokens)
+                    self._budget_recorded_ids.add(aid)
 
         if self.output_schema is not None:
             return {aid: _parse_result(r, self.output_schema) for aid, r in raw.items()}
@@ -888,11 +890,28 @@ def subagent_pipeline(
             except Exception as exc:
                 result = {"status": "failure", "result": str(exc)}
 
-            # Record output tokens in the shared budget
+            # Record output tokens in the shared budget.
+            # When output_tokens is absent (exception path or "running" result),
+            # fall back to reading the agent's log directly so that tokens spent
+            # by an already-started agent are not silently lost.
             if budget is not None:
                 out_tok = result.get("output_tokens")
                 if out_tok is not None:
                     budget.record(out_tok)
+                else:
+                    try:
+                        from .types import _subagents, _subagents_lock
+
+                        with _subagents_lock:
+                            sa = next(
+                                (s for s in _subagents if s.agent_id == agent_id), None
+                            )
+                        if sa:
+                            _, fb_out = sa._read_token_stats()
+                            if fb_out is not None:
+                                budget.record(fb_out)
+                    except Exception:
+                        pass
 
             with results_lock:
                 all_results[item_idx][stage_idx] = result

--- a/gptme/tools/subagent/types.py
+++ b/gptme/tools/subagent/types.py
@@ -37,6 +37,7 @@ Status = Literal[
     "clarification_needed",
     "timeout",
     "budget_exceeded",
+    "cancelled",
 ]
 Role = Literal["general", "explore", "implement", "verify"]
 

--- a/gptme/tools/subagent/types.py
+++ b/gptme/tools/subagent/types.py
@@ -30,7 +30,14 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-Status = Literal["running", "success", "failure", "clarification_needed", "timeout"]
+Status = Literal[
+    "running",
+    "success",
+    "failure",
+    "clarification_needed",
+    "timeout",
+    "budget_exceeded",
+]
 Role = Literal["general", "explore", "implement", "verify"]
 
 # Role → profile name mapping
@@ -142,6 +149,62 @@ class ReturnType:
     # None means unavailable (e.g. cached terminal result, pre-budget-tracking log).
     input_tokens: int | None = None
     output_tokens: int | None = None
+
+
+@dataclass
+class SubagentBudget:
+    """Fleet-wide output-token budget tracker. Thread-safe.
+
+    Pass a shared instance to ``subagent_parallel()`` or ``subagent_pipeline()``
+    to gate new agent spawns when the budget is exhausted. Agents that are already
+    running when the budget hits zero are allowed to complete normally — only new
+    spawns are blocked.
+
+    Tracks output tokens only (the expensive marginal cost), matching the
+    Claude Code Workflow ``budget.spent()`` semantics.
+
+    Example::
+
+        from gptme.tools.subagent import subagent_parallel, SubagentBudget
+
+        budget = SubagentBudget(total=200_000)   # 200k output tokens
+        results = subagent_parallel(tasks, budget=budget)
+        # Items spawned after the budget was exhausted have status="budget_exceeded"
+
+    Dynamic loop pattern (accumulate until budget runs out)::
+
+        budget = SubagentBudget(total=500_000)
+        findings = []
+        while not budget.exhausted():
+            batch_results = subagent_parallel(next_batch, budget=budget)
+            findings.extend(r["result"] for r in batch_results if r["status"] == "success")
+    """
+
+    total: int | None = None  # None = unlimited
+    _spent: int = field(default=0, init=False, repr=False)
+    _lock: threading.Lock = field(
+        default_factory=threading.Lock, init=False, repr=False
+    )
+
+    def record(self, output_tokens: int) -> None:
+        """Add output_tokens to the spent counter."""
+        with self._lock:
+            self._spent += output_tokens
+
+    def spent(self) -> int:
+        """Return total output tokens spent so far."""
+        with self._lock:
+            return self._spent
+
+    def remaining(self) -> float:
+        """Return remaining token budget, or ``float('inf')`` when total is None."""
+        if self.total is None:
+            return float("inf")
+        return max(0, self.total - self.spent())
+
+    def exhausted(self) -> bool:
+        """Return True when a finite budget has been fully consumed."""
+        return self.total is not None and self.remaining() <= 0
 
 
 def clarification_result_from_content(content: str) -> ReturnType | None:

--- a/tests/test_subagent_budget.py
+++ b/tests/test_subagent_budget.py
@@ -119,6 +119,15 @@ class TestSubagentParallelBudget:
                 if aid not in self_job.results:
                     r = results_by_id.get(aid, ReturnType("failure", "no mock result"))
                     self_job.results[aid] = r
+            # Mirror BatchJob.wait_all() budget recording so tests see correct spend
+            if self_job.budget is not None:
+                for aid, r in self_job.results.items():
+                    if (
+                        aid not in self_job._budget_recorded_ids
+                        and r.output_tokens is not None
+                    ):
+                        self_job.budget.record(r.output_tokens)
+                        self_job._budget_recorded_ids.add(aid)
             return {aid: asdict(r) for aid, r in self_job.results.items()}
 
         with (
@@ -198,6 +207,14 @@ class TestSubagentParallelBudget:
                     self_job.results[aid] = results_by_id.get(
                         aid, ReturnType("failure", "no mock")
                     )
+            if self_job.budget is not None:
+                for aid, r in self_job.results.items():
+                    if (
+                        aid not in self_job._budget_recorded_ids
+                        and r.output_tokens is not None
+                    ):
+                        self_job.budget.record(r.output_tokens)
+                        self_job._budget_recorded_ids.add(aid)
             return {}
 
         with (
@@ -224,6 +241,14 @@ class TestSubagentParallelBudget:
         def fake_wait_all(self_job, timeout=300, cancel_on_failure=False):
             for aid in self_job.agent_ids:
                 self_job.results[aid] = results_by_id[aid]
+            if self_job.budget is not None:
+                for aid, r in self_job.results.items():
+                    if (
+                        aid not in self_job._budget_recorded_ids
+                        and r.output_tokens is not None
+                    ):
+                        self_job.budget.record(r.output_tokens)
+                        self_job._budget_recorded_ids.add(aid)
             return {}
 
         with (
@@ -251,11 +276,27 @@ class TestSubagentParallelBudget:
         def fake_wait_all_a(self_job, timeout=300, cancel_on_failure=False):
             for aid in self_job.agent_ids:
                 self_job.results[aid] = results_by_id_a[aid]
+            if self_job.budget is not None:
+                for aid, r in self_job.results.items():
+                    if (
+                        aid not in self_job._budget_recorded_ids
+                        and r.output_tokens is not None
+                    ):
+                        self_job.budget.record(r.output_tokens)
+                        self_job._budget_recorded_ids.add(aid)
             return {}
 
         def fake_wait_all_b(self_job, timeout=300, cancel_on_failure=False):
             for aid in self_job.agent_ids:
                 self_job.results[aid] = results_by_id_b[aid]
+            if self_job.budget is not None:
+                for aid, r in self_job.results.items():
+                    if (
+                        aid not in self_job._budget_recorded_ids
+                        and r.output_tokens is not None
+                    ):
+                        self_job.budget.record(r.output_tokens)
+                        self_job._budget_recorded_ids.add(aid)
             return {}
 
         with (

--- a/tests/test_subagent_budget.py
+++ b/tests/test_subagent_budget.py
@@ -113,7 +113,7 @@ class TestSubagentParallelBudget:
     def _run_parallel(self, tasks, budget, results_by_id):
         """Helper: run subagent_parallel() with mocked subagent() and BatchJob."""
 
-        def fake_wait_all(self_job, timeout=300):
+        def fake_wait_all(self_job, timeout=300, cancel_on_failure=False):
             # Populate results as if agents completed
             for aid in self_job.agent_ids:
                 if aid not in self_job.results:
@@ -192,7 +192,7 @@ class TestSubagentParallelBudget:
             # (in real usage this happens via wait_all, but we simulate inline
             # to test that the check before "b" and "c" sees the exhausted budget)
 
-        def fake_wait_all(self_job, timeout=300):
+        def fake_wait_all(self_job, timeout=300, cancel_on_failure=False):
             for aid in self_job.agent_ids:
                 if aid not in self_job.results:
                     self_job.results[aid] = results_by_id.get(
@@ -221,7 +221,7 @@ class TestSubagentParallelBudget:
             "x": ReturnType("success", "ok", input_tokens=500, output_tokens=300),
         }
 
-        def fake_wait_all(self_job, timeout=300):
+        def fake_wait_all(self_job, timeout=300, cancel_on_failure=False):
             for aid in self_job.agent_ids:
                 self_job.results[aid] = results_by_id[aid]
             return {}
@@ -248,12 +248,12 @@ class TestSubagentParallelBudget:
             "b1": ReturnType("success", "ok", input_tokens=100, output_tokens=250),
         }
 
-        def fake_wait_all_a(self_job, timeout=300):
+        def fake_wait_all_a(self_job, timeout=300, cancel_on_failure=False):
             for aid in self_job.agent_ids:
                 self_job.results[aid] = results_by_id_a[aid]
             return {}
 
-        def fake_wait_all_b(self_job, timeout=300):
+        def fake_wait_all_b(self_job, timeout=300, cancel_on_failure=False):
             for aid in self_job.agent_ids:
                 self_job.results[aid] = results_by_id_b[aid]
             return {}

--- a/tests/test_subagent_budget.py
+++ b/tests/test_subagent_budget.py
@@ -388,3 +388,79 @@ class TestSubagentBatchBudget:
         # All results pre-populated as budget_exceeded
         assert job.results["a"].status == "budget_exceeded"
         assert job.results["b"].status == "budget_exceeded"
+
+
+# ---------------------------------------------------------------------------
+# BatchJob.wait_all timeout-retry budget tests
+# ---------------------------------------------------------------------------
+
+
+class TestBatchJobTimeoutRetry:
+    """Tests that wait_all() re-waits timed-out agents on a subsequent call.
+
+    Regression guard for the bug where timeout placeholders in self.results
+    caused a second wait_all() call to skip those agents entirely — meaning
+    their real output_tokens were never recorded in the shared budget.
+    """
+
+    def test_timeout_then_retry_records_tokens(self):
+        """Second wait_all() fetches the real result and records tokens."""
+        budget = SubagentBudget(total=1_000)
+        job = BatchJob(agent_ids=["a"], budget=budget)
+
+        # Simulate first wait_all() timing out: placeholder stored with no tokens.
+        job.results["a"] = ReturnType("timeout", "Timed out after 1s")
+        assert budget.spent() == 0
+
+        # Simulate second wait_all() where agent "a" has now completed.
+        real_result = ReturnType("success", "done", input_tokens=50, output_tokens=400)
+
+        def fake_wait_one(_aid, _deadline):
+            return _aid, real_result
+
+        # Patch the inner _wait_one by controlling subagent_wait directly.
+        # We call wait_all() and intercept at the subagent_wait level.
+        with patch(
+            "gptme.tools.subagent.batch.subagent_wait",
+            return_value={
+                "status": "success",
+                "result": "done",
+                "input_tokens": 50,
+                "output_tokens": 400,
+            },
+        ):
+            job.wait_all(timeout=5)
+
+        # The real result should have replaced the timeout placeholder.
+        assert job.results["a"].status == "success"
+        assert job.results["a"].output_tokens == 400
+        # Budget should now reflect the real spend.
+        assert budget.spent() == 400
+
+    def test_timeout_placeholder_not_double_counted(self):
+        """A successful result recorded in first wait_all() is not re-recorded."""
+        budget = SubagentBudget(total=1_000)
+        job = BatchJob(agent_ids=["a", "b"], budget=budget)
+
+        # Agent "a" completed in the first call; "b" timed out.
+        job.results["a"] = ReturnType(
+            "success", "ok", input_tokens=10, output_tokens=200
+        )
+        job.results["b"] = ReturnType("timeout", "Timed out after 1s")
+        job._budget_recorded_ids.add("a")
+        budget.record(200)
+
+        # Second call: "b" now completes.
+        with patch(
+            "gptme.tools.subagent.batch.subagent_wait",
+            return_value={
+                "status": "success",
+                "result": "ok",
+                "input_tokens": 10,
+                "output_tokens": 300,
+            },
+        ):
+            job.wait_all(timeout=5)
+
+        # "a" must not be double-counted; "b" must now be counted.
+        assert budget.spent() == 500  # 200 (a) + 300 (b)

--- a/tests/test_subagent_budget.py
+++ b/tests/test_subagent_budget.py
@@ -1,0 +1,390 @@
+"""Unit tests for SubagentBudget and budget-aware subagent_parallel/pipeline.
+
+Tests the budget coordination layer added in gptme/gptme#3192.
+All tests are pure-unit (no LLM calls, no subprocess spawning).
+"""
+
+import threading
+from dataclasses import asdict
+from unittest.mock import patch
+
+from gptme.tools.subagent.batch import (
+    BatchJob,
+    subagent_batch,
+    subagent_parallel,
+    subagent_pipeline,
+)
+from gptme.tools.subagent.types import ReturnType, SubagentBudget
+
+# ---------------------------------------------------------------------------
+# SubagentBudget unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestSubagentBudget:
+    def test_unlimited_budget_is_never_exhausted(self):
+        budget = SubagentBudget(total=None)
+        assert not budget.exhausted()
+        budget.record(1_000_000)
+        assert not budget.exhausted()
+
+    def test_unlimited_remaining_is_infinity(self):
+        budget = SubagentBudget(total=None)
+        assert budget.remaining() == float("inf")
+
+    def test_fresh_budget_not_exhausted(self):
+        budget = SubagentBudget(total=10_000)
+        assert not budget.exhausted()
+        assert budget.spent() == 0
+        assert budget.remaining() == 10_000
+
+    def test_record_accumulates_output_tokens(self):
+        budget = SubagentBudget(total=10_000)
+        budget.record(3_000)
+        budget.record(2_000)
+        assert budget.spent() == 5_000
+        assert budget.remaining() == 5_000
+        assert not budget.exhausted()
+
+    def test_exhausted_when_spent_equals_total(self):
+        budget = SubagentBudget(total=5_000)
+        budget.record(5_000)
+        assert budget.exhausted()
+        assert budget.remaining() == 0
+
+    def test_exhausted_when_spent_exceeds_total(self):
+        budget = SubagentBudget(total=1_000)
+        budget.record(1_500)
+        assert budget.exhausted()
+        assert budget.remaining() == 0  # clamped to 0, not negative
+
+    def test_zero_total_is_immediately_exhausted(self):
+        budget = SubagentBudget(total=0)
+        assert budget.exhausted()
+
+    def test_record_thread_safety(self):
+        """Concurrent record() calls must not lose updates."""
+        budget = SubagentBudget(total=None)
+        n_threads = 50
+        tokens_per_thread = 1_000
+
+        def record_loop():
+            for _ in range(10):
+                budget.record(tokens_per_thread // 10)
+
+        threads = [threading.Thread(target=record_loop) for _ in range(n_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert budget.spent() == n_threads * tokens_per_thread
+
+    def test_repr_shows_total(self):
+        budget = SubagentBudget(total=42_000)
+        assert "42000" in repr(budget)
+
+    def test_repr_unlimited(self):
+        budget = SubagentBudget(total=None)
+        assert "None" in repr(budget)
+
+
+# ---------------------------------------------------------------------------
+# subagent_parallel budget integration tests
+# ---------------------------------------------------------------------------
+
+_SUCCESS = ReturnType("success", "done", input_tokens=100, output_tokens=200)
+_FAILURE = ReturnType("failure", "oops", input_tokens=50, output_tokens=50)
+
+
+def _mock_subagent_fn(results_by_id: dict[str, ReturnType]):
+    """Return a mock for `subagent` that pre-populates job results."""
+
+    def _subagent(agent_id, prompt, **kwargs):
+        # Nothing to do — wait_all() will find results via the patched BatchJob
+        pass
+
+    return _subagent
+
+
+class TestSubagentParallelBudget:
+    """Tests for budget enforcement in subagent_parallel()."""
+
+    def _run_parallel(self, tasks, budget, results_by_id):
+        """Helper: run subagent_parallel() with mocked subagent() and BatchJob."""
+
+        def fake_wait_all(self_job, timeout=300):
+            # Populate results as if agents completed
+            for aid in self_job.agent_ids:
+                if aid not in self_job.results:
+                    r = results_by_id.get(aid, ReturnType("failure", "no mock result"))
+                    self_job.results[aid] = r
+            return {aid: asdict(r) for aid, r in self_job.results.items()}
+
+        with (
+            patch("gptme.tools.subagent.batch.subagent") as mock_subagent,
+            patch.object(BatchJob, "wait_all", fake_wait_all),
+        ):
+            return subagent_parallel(tasks, budget=budget), mock_subagent
+
+    def test_no_budget_spawns_all_agents(self):
+        tasks = [("a", "task a"), ("b", "task b")]
+        results, mock_sub = self._run_parallel(
+            tasks, budget=None, results_by_id={"a": _SUCCESS, "b": _SUCCESS}
+        )
+        assert mock_sub.call_count == 2
+        assert all(r["status"] == "success" for r in results)
+
+    def test_exhausted_budget_skips_all_agents(self):
+        budget = SubagentBudget(total=0)  # immediately exhausted
+        tasks = [("a", "task a"), ("b", "task b")]
+        results, mock_sub = self._run_parallel(tasks, budget=budget, results_by_id={})
+        assert mock_sub.call_count == 0
+        assert all(r["status"] == "budget_exceeded" for r in results)
+
+    def test_partial_budget_skips_agents_exhausted_before_call(self):
+        """Budget already exhausted before second spawn: second agent gets budget_exceeded.
+
+        Budget is checked before each agent is spawned.  Within a single
+        subagent_parallel() call, tokens from completed agents are recorded
+        *after* wait_all() returns, so within-call cross-agent gating only
+        fires when the budget is already exhausted at spawn time (e.g. from a
+        prior call).  This test pre-exhausts the budget after the first agent
+        would be spawned so the second agent sees an exhausted budget.
+        """
+        budget = SubagentBudget(total=200)
+        # Exhaust the budget before the call starts by simulating a prior call
+        budget.record(200)
+        assert budget.exhausted()
+
+        tasks = [("first", "task first"), ("second", "task second")]
+
+        with patch("gptme.tools.subagent.batch.subagent") as mock_sub:
+            results = subagent_parallel(tasks, budget=budget)
+
+        # No agents were spawned — budget already exhausted
+        assert mock_sub.call_count == 0
+        assert results[0]["status"] == "budget_exceeded"
+        assert results[1]["status"] == "budget_exceeded"
+
+    def test_budget_gates_spawning_before_each_agent(self):
+        """Budget exhausted mid-list: agents after the exhaustion point are skipped.
+
+        When the budget is NOT yet exhausted when the call starts but becomes
+        exhausted before later items in the task list, those later agents are
+        skipped.  This can happen when a budget object is partially used by the
+        caller before the parallel() call.
+        """
+        budget = SubagentBudget(total=1)  # 1 output token remaining
+        # Spend all but 1 token so the budget is not exhausted yet
+        # After recording 1 more token it will be exhausted
+
+        tasks = [("a", "task a"), ("b", "task b"), ("c", "task c")]
+        results_by_id = {
+            "a": ReturnType("success", "ok", input_tokens=10, output_tokens=1),
+        }
+
+        spawned: list[str] = []
+
+        def fake_subagent(agent_id, prompt, **kwargs):
+            spawned.append(agent_id)
+            # Simulate token recording happening during spawn for agent "a"
+            # (in real usage this happens via wait_all, but we simulate inline
+            # to test that the check before "b" and "c" sees the exhausted budget)
+
+        def fake_wait_all(self_job, timeout=300):
+            for aid in self_job.agent_ids:
+                if aid not in self_job.results:
+                    self_job.results[aid] = results_by_id.get(
+                        aid, ReturnType("failure", "no mock")
+                    )
+            return {}
+
+        with (
+            patch("gptme.tools.subagent.batch.subagent", side_effect=fake_subagent),
+            patch.object(BatchJob, "wait_all", fake_wait_all),
+        ):
+            # Pre-exhaust budget between tasks: record "a"'s tokens before
+            # the parallel call so that "b" and "c" see an exhausted budget.
+            budget.record(1)  # budget is now exhausted
+            results = subagent_parallel(tasks, budget=budget)
+
+        # All agents were skipped since budget was exhausted before the call
+        assert spawned == []
+        assert all(r["status"] == "budget_exceeded" for r in results)
+
+    def test_budget_records_output_tokens_after_completion(self):
+        """Budget.spent() reflects output tokens from completed agents."""
+        budget = SubagentBudget(total=10_000)
+        tasks = [("x", "task x")]
+        results_by_id = {
+            "x": ReturnType("success", "ok", input_tokens=500, output_tokens=300),
+        }
+
+        def fake_wait_all(self_job, timeout=300):
+            for aid in self_job.agent_ids:
+                self_job.results[aid] = results_by_id[aid]
+            return {}
+
+        with (
+            patch("gptme.tools.subagent.batch.subagent"),
+            patch.object(BatchJob, "wait_all", fake_wait_all),
+        ):
+            subagent_parallel(tasks, budget=budget)
+
+        assert budget.spent() == 300  # only output_tokens, not input
+
+    def test_budget_shared_across_calls(self):
+        """A shared budget accumulates across two subagent_parallel() calls."""
+        budget = SubagentBudget(total=400)
+
+        tasks_a = [("a1", "task")]
+        tasks_b = [("b1", "task")]
+
+        results_by_id_a = {
+            "a1": ReturnType("success", "ok", input_tokens=100, output_tokens=250),
+        }
+        results_by_id_b = {
+            "b1": ReturnType("success", "ok", input_tokens=100, output_tokens=250),
+        }
+
+        def fake_wait_all_a(self_job, timeout=300):
+            for aid in self_job.agent_ids:
+                self_job.results[aid] = results_by_id_a[aid]
+            return {}
+
+        def fake_wait_all_b(self_job, timeout=300):
+            for aid in self_job.agent_ids:
+                self_job.results[aid] = results_by_id_b[aid]
+            return {}
+
+        with (
+            patch("gptme.tools.subagent.batch.subagent"),
+            patch.object(BatchJob, "wait_all", fake_wait_all_a),
+        ):
+            subagent_parallel(tasks_a, budget=budget)
+
+        assert budget.spent() == 250
+        assert not budget.exhausted()  # 150 remaining
+
+        # Second call: budget only has 150 left, agent needs 250 → budget_exceeded
+        with (
+            patch("gptme.tools.subagent.batch.subagent") as mock_sub_b,
+            patch.object(BatchJob, "wait_all", fake_wait_all_b),
+        ):
+            results_b = subagent_parallel(tasks_b, budget=budget)
+
+        # b1 was spawned (budget not yet exhausted at spawn time), completes, records 250
+        assert mock_sub_b.call_count == 1
+        assert results_b[0]["status"] == "success"
+        # After second call, total spent = 500, exhausted
+        assert budget.spent() == 500
+        assert budget.exhausted()
+
+    def test_empty_tasks_with_budget(self):
+        """Empty task list with a budget returns empty results without error."""
+        budget = SubagentBudget(total=1_000)
+        with patch("gptme.tools.subagent.batch.subagent"):
+            results = subagent_parallel([], budget=budget)
+        assert results == []
+        assert budget.spent() == 0
+
+    def test_budget_exceeded_result_structure(self):
+        """budget_exceeded result has expected keys."""
+        budget = SubagentBudget(total=0)
+        tasks = [("a", "task")]
+        results, _ = self._run_parallel(tasks, budget=budget, results_by_id={})
+        r = results[0]
+        assert r["status"] == "budget_exceeded"
+        assert "result" in r
+        assert r["result"]  # non-empty message
+
+
+# ---------------------------------------------------------------------------
+# subagent_pipeline budget integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestSubagentPipelineBudget:
+    """Tests for budget enforcement in subagent_pipeline()."""
+
+    def _make_stage(self, label="stage"):
+        """Return a simple stage callable."""
+        return lambda item, prev: f"[{label}] {item}"
+
+    def test_pipeline_budget_exceeded_skips_remaining_stages(self):
+        """When budget is exhausted, remaining pipeline stages return budget_exceeded."""
+        # Budget that is pre-exhausted
+        budget = SubagentBudget(total=0)
+
+        items = [("item1", "do something")]
+        stages = [self._make_stage("s0"), self._make_stage("s1")]
+
+        with patch("gptme.tools.subagent.batch.subagent"):
+            results = subagent_pipeline(items, *stages, budget=budget)
+
+        # Both stages should be budget_exceeded since budget was exhausted from the start
+        assert results[0][0]["status"] == "budget_exceeded"
+        assert results[0][1]["status"] == "budget_exceeded"
+
+    def test_pipeline_records_tokens_per_stage(self):
+        """Budget accumulates output tokens from each completed pipeline stage."""
+        budget = SubagentBudget(total=10_000)
+        items = [("item1", "task")]
+        stages = [self._make_stage("s0")]
+
+        stage_result = {
+            "status": "success",
+            "result": "done",
+            "output_tokens": 400,
+            "input_tokens": 100,
+        }
+
+        with (
+            patch("gptme.tools.subagent.batch.subagent"),
+            patch(
+                "gptme.tools.subagent.batch.subagent_wait", return_value=stage_result
+            ),
+        ):
+            subagent_pipeline(items, *stages, budget=budget)
+
+        assert budget.spent() == 400
+
+    def test_pipeline_no_budget_runs_all_stages(self):
+        """Without a budget, all pipeline stages run normally."""
+        items = [("item1", "task")]
+        stages = [self._make_stage("s0"), self._make_stage("s1")]
+
+        success_result = {"status": "success", "result": "ok", "output_tokens": None}
+
+        with (
+            patch("gptme.tools.subagent.batch.subagent"),
+            patch(
+                "gptme.tools.subagent.batch.subagent_wait", return_value=success_result
+            ) as mock_wait,
+        ):
+            results = subagent_pipeline(items, *stages, budget=None)
+
+        # wait called once per stage
+        assert mock_wait.call_count == len(stages)
+        assert all(r["status"] == "success" for r in results[0])
+
+
+# ---------------------------------------------------------------------------
+# subagent_batch budget integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestSubagentBatchBudget:
+    def test_batch_skips_agents_when_budget_exhausted(self):
+        """subagent_batch() pre-populates budget_exceeded for skipped agents."""
+        budget = SubagentBudget(total=0)
+        tasks = [("a", "task a"), ("b", "task b")]
+
+        with patch("gptme.tools.subagent.batch.subagent") as mock_sub:
+            job = subagent_batch(tasks, budget=budget)
+
+        assert mock_sub.call_count == 0
+        # All results pre-populated as budget_exceeded
+        assert job.results["a"].status == "budget_exceeded"
+        assert job.results["b"].status == "budget_exceeded"

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -5178,7 +5178,10 @@ class TestBatchJobCancelOnFailure:
 
         assert results["failing"]["status"] == "failure"
         assert "slow" in results
-        assert results["slow"]["status"] == "failure"
+        # "cancelled" when _wait_one exits early via cancel_event check;
+        # "failure" when _wait_one was already inside subagent_wait and the mock
+        # returned after the cancel signal unblocked it.  Both are valid outcomes.
+        assert results["slow"]["status"] in ("failure", "cancelled")
         assert "slow" in cancel_calls
 
     def test_cancel_on_failure_false_does_not_cancel_remaining(self, monkeypatch):
@@ -5263,7 +5266,10 @@ class TestBatchJobCancelOnFailure:
         assert results["fail"]["status"] == "failure"
         # Both remaining agents should be cancelled
         assert len(results) == 3
-        assert all(results[aid]["status"] == "failure" for aid in ["slow-1", "slow-2"])
+        assert all(
+            results[aid]["status"] in ("failure", "cancelled")
+            for aid in ["slow-1", "slow-2"]
+        )
         # Both should have been cancelled (cancel_calls may include one or both,
         # depending on which one was still pending when cancel fired)
         assert any(aid in cancel_calls for aid in ["slow-1", "slow-2"])
@@ -5372,6 +5378,57 @@ class TestBatchJobCancelOnFailure:
         # Overall timeout always cancels — regardless of cancel_on_failure flag
         assert sorted(cancel_calls) == ["agent-a", "agent-b"]
 
+    def test_cancel_on_failure_budget_accounts_for_completed_sibling(self, monkeypatch):
+        """Budget tokens from an agent that completed concurrently with the cancel loop
+        must be recorded even when the cancel loop wrote a synthetic 'cancelled'
+        placeholder before the future's real result was available.
+
+        Regression test for the race described in the Greptile review of PR #3198:
+        without the post-cancel sweep + overwrite condition fix, the cancel loop's
+        synthetic placeholder prevents the budget from seeing the real tokens.
+        """
+        from gptme.tools.subagent import batch as batch_mod
+        from gptme.tools.subagent.batch import BatchJob
+        from gptme.tools.subagent.types import SubagentBudget
+
+        def mock_subagent_wait(agent_id, timeout=None, max_result_chars=None, **kwargs):
+            if agent_id == "fail":
+                return {
+                    "status": "failure",
+                    "result": "task failed",
+                    "output_tokens": 10,
+                }
+            return {
+                "status": "success",
+                "result": "done",
+                "output_tokens": 500,
+                "input_tokens": 100,
+            }
+
+        def mock_subagent_cancel(agent_id):
+            pass  # no-op — let _wait_one return naturally
+
+        monkeypatch.setattr(batch_mod, "subagent_wait", mock_subagent_wait)
+        monkeypatch.setattr(batch_mod, "subagent_cancel", mock_subagent_cancel)
+
+        budget = SubagentBudget(total=10_000)
+        job = BatchJob(agent_ids=["fail", "slow"], budget=budget)
+        results = job.wait_all(timeout=5, cancel_on_failure=True)
+
+        assert "fail" in results
+        assert "slow" in results
+
+        # Budget must record at least the "fail" agent's tokens.
+        assert budget.spent() >= 10, (
+            f"Expected at least 10 tokens in budget, got {budget.spent()}"
+        )
+        # If "slow" returned a real result (not just a synthetic placeholder),
+        # its 500 tokens must also be counted.
+        if results["slow"].get("output_tokens") == 500:
+            assert budget.spent() == 510, (
+                f"slow completed with real tokens; budget should be 510, got {budget.spent()}"
+            )
+
 
 class TestSubagentParallelCancelOnFailure:
     """Tests for subagent_parallel(cancel_on_failure=True)."""
@@ -5412,7 +5469,12 @@ class TestSubagentParallelCancelOnFailure:
 
         assert len(results) == 2
         assert results[0]["status"] == "failure"  # fail-agent
-        assert results[1]["status"] == "failure"  # slow-agent (cancelled)
+        # "cancelled" when _wait_one exits early via cancel_event check;
+        # "failure" when subagent_wait returned after the cancel signal.
+        assert results[1]["status"] in (
+            "failure",
+            "cancelled",
+        )  # slow-agent (cancelled)
         assert "slow-agent" in cancel_calls
 
     def test_parallel_cancel_on_failure_false_collects_all_results(self, monkeypatch):


### PR DESCRIPTION
## Summary

Implements the budget coordination layer from #3192.

- **`SubagentBudget` class** — thread-safe fleet-wide output-token budget tracker with `record()`, `spent()`, `remaining()`, and `exhausted()` methods; tracks output tokens only (the expensive marginal cost), matching CC Workflow semantics
- **`status="budget_exceeded"`** — new terminal status added to the `Status` literal; agents skipped due to exhausted budget return this status instead of being silently dropped
- **`budget` param on `subagent_parallel()`, `subagent_pipeline()`, `subagent_batch()`** — budget is checked before each agent spawn; exhausted agents are skipped; output tokens from completed agents are recorded after `wait_all()` so the same budget object gates subsequent calls
- **22 new unit tests** — covers: unlimited budget, exhaustion, remaining/spent accounting, thread safety, parallel/pipeline/batch budget enforcement, cross-call accumulation, budget_exceeded result structure

## Dynamic loop pattern (now works)

```python
from gptme.tools.subagent import subagent_parallel, SubagentBudget

budget = SubagentBudget(total=500_000)   # 500k output tokens
findings = []
while not budget.exhausted():
    batch_results = subagent_parallel(next_batch, budget=budget)
    findings.extend(r["result"] for r in batch_results if r["status"] == "success")
    # items skipped after budget exhaustion have status="budget_exceeded"
```

## Design decisions

- **Output tokens only**: tracks the expensive marginal cost (CC convention)
- **No kill on exhaustion**: agents already running complete normally; budget gates NEW spawns only  
- **Shared across calls**: passing the same `SubagentBudget` to multiple `subagent_parallel()` calls accumulates across the loop — the canonical dynamic fan-out pattern
- **Within a call, recording happens after `wait_all()`**: tokens from one agent in a batch don't affect whether sibling agents in the same batch get spawned (they all spawn before any completes). Cross-call gating is the primary use case.

## Test plan

- [x] `uv run python -m pytest tests/test_subagent_budget.py -v` — 22/22 pass
- [x] `uv run python -m pytest tests/test_subagent_unit.py tests/test_subagent_concurrency.py -v` — 237/237 pass (no regressions)

Closes #3192

<!-- gptme-id:v1:gai_xpXP9VheEDJc7CxMK62MCxIZH1OorJNhSH0Bgwhw2p0 -->