### PR TITLE
feat(subagent): cancel_on_failure — cancel the fleet when a sibling fails

### DIFF
--- a/gptme/tools/subagent/batch.py
+++ b/gptme/tools/subagent/batch.py
@@ -123,42 +123,65 @@ class BatchJob:
                 thread-mode agents it marks the result immediately while the
                 background thread continues until its next natural checkpoint.
 
+                Note: regardless of this flag, any agents still running when the
+                overall ``timeout`` expires are always cancelled so subprocess/ACP
+                agents do not keep running after the caller has received timed-out
+                results.
+
         Returns:
             Dict mapping agent_id to status dict. When ``output_schema`` is set,
             the ``"result"`` value is the parsed/validated object rather than a
             raw JSON string.
         """
+        # cancel_event is set when we decide to bail early so that _wait_one
+        # worker threads exit their poll loops promptly instead of blocking for
+        # the full remaining timeout.
+        cancel_event = threading.Event()
+        # Poll subagent_wait() in short chunks so cancellation is responsive.
+        _POLL_SECS = 5
 
         def _wait_one(agent_id: str, deadline: float) -> tuple[str, ReturnType]:
             import time
 
-            remaining = max(1, int(deadline - time.monotonic()))
-            try:
-                # Pass max_result_chars=0 so _parse_result() receives the full
-                # raw result without truncation. The default of 2000 would clip
-                # JSON from larger schemas and make structured output silently
-                # fail in _parse_result().
-                result = subagent_wait(agent_id, timeout=remaining, max_result_chars=0)
-                status = result.get("status", "failure")
-                # subagent_wait() returns a non-terminal "running" status (with
-                # result=None) when a thread/ACP agent is still alive after the
-                # wait — these can't be force-killed. Report that as "timeout"
-                # per the documented contract, rather than leaking
-                # status="running"/result=None, which breaks callers that index
-                # into result (e.g. this function's own docstring example).
-                if status == "running":
+            while True:
+                # Exit quickly when a sibling failure or overall timeout fired.
+                if cancel_event.is_set():
+                    with self._lock:
+                        if agent_id in self.results:
+                            return agent_id, self.results[agent_id]
+                    return agent_id, ReturnType(
+                        "failure", "Cancelled due to sibling failure"
+                    )
+
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
                     return agent_id, ReturnType(
                         "timeout", f"Timed out after {timeout}s"
                     )
+
+                poll_secs = max(1, min(int(remaining), _POLL_SECS))
+                try:
+                    # Pass max_result_chars=0 so _parse_result() receives the full
+                    # raw result without truncation. The default of 2000 would clip
+                    # JSON from larger schemas and make structured output silently
+                    # fail in _parse_result().
+                    result = subagent_wait(
+                        agent_id, timeout=poll_secs, max_result_chars=0
+                    )
+                except Exception as e:
+                    logger.warning(f"Error waiting for {agent_id}: {e}")
+                    return agent_id, ReturnType("failure", str(e))
+
+                status = result.get("status", "failure")
+                if status == "running":
+                    # Agent still alive after this poll — loop and check again.
+                    continue
                 return agent_id, ReturnType(
                     status,
                     result.get("result"),
                     input_tokens=result.get("input_tokens"),
                     output_tokens=result.get("output_tokens"),
                 )
-            except Exception as e:
-                logger.warning(f"Error waiting for {agent_id}: {e}")
-                return agent_id, ReturnType("failure", str(e))
 
         import time
 
@@ -196,13 +219,15 @@ class BatchJob:
                                     self.results[aid_to_cancel] = ReturnType(
                                         "failure", "Cancelled due to sibling failure"
                                     )
-                        # All remaining results are now pre-populated; exit early
+                        # Signal workers to exit poll loops, then exit the loop.
+                        cancel_event.set()
                         with self._lock:
                             if len(self.results) >= len(self.agent_ids):
                                 break
             except FuturesTimeoutError:
                 # as_completed timed out — mark any unfinished agents as timeout
-                # and cancel subprocess/ACP agents so they don't keep running.
+                # and cancel them so subprocess/ACP agents don't keep running
+                # after the caller has already received "timeout" results.
                 timed_out_ids: list[str] = []
                 for aid in futures.values():
                     with self._lock:
@@ -211,16 +236,16 @@ class BatchJob:
                                 "timeout", f"Timed out after {timeout}s"
                             )
                             timed_out_ids.append(aid)
-                if cancel_on_failure:
-                    for aid in timed_out_ids:
-                        try:
-                            subagent_cancel(aid)
-                        except Exception:
-                            pass
+                for aid in timed_out_ids:
+                    try:
+                        subagent_cancel(aid)
+                    except Exception:
+                        pass
+                cancel_event.set()
         finally:
             # Don't block on remaining _wait_one threads — all results are already
-            # collected in self.results. Threads may still be running subagent_wait()
-            # for cancelled agents but their outcomes are no longer relevant.
+            # collected in self.results. Workers will exit their poll loops within
+            # _POLL_SECS seconds once cancel_event is set.
             pool.shutdown(wait=False, cancel_futures=True)
 
         raw = {aid: asdict(r) for aid, r in self.results.items()}

--- a/gptme/tools/subagent/batch.py
+++ b/gptme/tools/subagent/batch.py
@@ -163,7 +163,11 @@ class BatchJob:
         import time
 
         deadline = time.monotonic() + timeout
-        with ThreadPoolExecutor(max_workers=len(self.agent_ids) or 1) as pool:
+        # Use explicit lifecycle instead of context manager so we can return
+        # immediately after cancellation without blocking on still-running
+        # _wait_one threads (ThreadPoolExecutor.__exit__ calls shutdown(wait=True)).
+        pool = ThreadPoolExecutor(max_workers=len(self.agent_ids) or 1)
+        try:
             futures = {
                 pool.submit(_wait_one, aid, deadline): aid
                 for aid in self.agent_ids
@@ -197,13 +201,27 @@ class BatchJob:
                             if len(self.results) >= len(self.agent_ids):
                                 break
             except FuturesTimeoutError:
-                # as_completed timed out — mark any unfinished agents
+                # as_completed timed out — mark any unfinished agents as timeout
+                # and cancel subprocess/ACP agents so they don't keep running.
+                timed_out_ids: list[str] = []
                 for aid in futures.values():
                     with self._lock:
                         if aid not in self.results:
                             self.results[aid] = ReturnType(
                                 "timeout", f"Timed out after {timeout}s"
                             )
+                            timed_out_ids.append(aid)
+                if cancel_on_failure:
+                    for aid in timed_out_ids:
+                        try:
+                            subagent_cancel(aid)
+                        except Exception:
+                            pass
+        finally:
+            # Don't block on remaining _wait_one threads — all results are already
+            # collected in self.results. Threads may still be running subagent_wait()
+            # for cancelled agents but their outcomes are no longer relevant.
+            pool.shutdown(wait=False, cancel_futures=True)
 
         raw = {aid: asdict(r) for aid, r in self.results.items()}
         if self.output_schema is not None:

--- a/gptme/tools/subagent/batch.py
+++ b/gptme/tools/subagent/batch.py
@@ -99,7 +99,9 @@ class BatchJob:
     output_schema: "type | dict | None" = field(default=None)
     _lock: threading.Lock = field(default_factory=threading.Lock)
 
-    def wait_all(self, timeout: int = 300) -> dict[str, dict]:
+    def wait_all(
+        self, timeout: int = 300, cancel_on_failure: bool = False
+    ) -> dict[str, dict]:
         """Wait for all subagents to complete concurrently.
 
         Uses a thread pool to wait for all subagents simultaneously, so the
@@ -113,6 +115,13 @@ class BatchJob:
 
         Args:
             timeout: Maximum seconds to wait for all subagents
+            cancel_on_failure: When True, cancel all remaining running subagents
+                as soon as the first failure or timeout is detected. Cancelled
+                agents are marked with ``status="failure"`` and
+                ``result="Cancelled due to sibling failure"`` in the returned
+                dict. For subprocess-mode agents this sends SIGTERM (fast); for
+                thread-mode agents it marks the result immediately while the
+                background thread continues until its next natural checkpoint.
 
         Returns:
             Dict mapping agent_id to status dict. When ``output_schema`` is set,
@@ -166,6 +175,27 @@ class BatchJob:
                     with self._lock:
                         if agent_id not in self.results:
                             self.results[agent_id] = result
+
+                    # Cancel remaining agents on first failure/timeout
+                    if cancel_on_failure and result.status in ("failure", "timeout"):
+                        with self._lock:
+                            remaining_ids = [
+                                aid for aid in self.agent_ids if aid not in self.results
+                            ]
+                        for aid_to_cancel in remaining_ids:
+                            try:
+                                subagent_cancel(aid_to_cancel)
+                            except ValueError:
+                                pass  # Agent already finished
+                            with self._lock:
+                                if aid_to_cancel not in self.results:
+                                    self.results[aid_to_cancel] = ReturnType(
+                                        "failure", "Cancelled due to sibling failure"
+                                    )
+                        # All remaining results are now pre-populated; exit early
+                        with self._lock:
+                            if len(self.results) >= len(self.agent_ids):
+                                break
             except FuturesTimeoutError:
                 # as_completed timed out — mark any unfinished agents
                 for aid in futures.values():
@@ -443,6 +473,7 @@ def subagent_parallel(
     context_turns: int | None = None,
     context_window: int | None = None,
     redact_secrets: bool = True,
+    cancel_on_failure: bool = False,
 ) -> list[dict]:
     """Fan out N subagents in parallel, wait for all, return results as an ordered list.
 
@@ -488,6 +519,18 @@ def subagent_parallel(
             inherited workspace context. Only applies to thread-mode subagents.
         redact_secrets: If True (default), scrub common secret patterns from
             workspace context before passing it to subagents.
+        cancel_on_failure: When True, cancel all remaining running subagents
+            as soon as the first failure or timeout is detected. Cancelled
+            agents are reported with ``status="failure"`` and
+            ``result="Cancelled due to sibling failure"``. For subprocess-mode
+            agents this sends SIGTERM (fast); for thread-mode agents the result
+            is marked immediately while the background thread finishes naturally.
+
+            Use this for defensive fan-out orchestration where one failing
+            subagent means the overall task has failed and continuing would
+            waste resources. Equivalent to calling ``subagent_cancel()``
+            manually after ``subagent_wait_any()`` detects a failure, but
+            handled automatically inside the parallel wait.
 
     Returns:
         List of result dicts in the same order as ``tasks``. Each dict has
@@ -511,6 +554,14 @@ def subagent_parallel(
             [("fix-a", "Fix bug in module A"), ("fix-b", "Fix bug in module B")],
             isolated=True,
         )
+
+        # Fail-fast: cancel the fleet when the first subagent fails
+        results = subagent_parallel(
+            [("verifier-a", "Verify output A"), ("verifier-b", "Verify output B")],
+            cancel_on_failure=True,
+        )
+        if any(r["status"] == "failure" for r in results):
+            print("Verification failed — remaining agents were cancelled")
 
         # With structured output (Pydantic model)
         from pydantic import BaseModel
@@ -564,7 +615,7 @@ def subagent_parallel(
 
     # Collect results in parallel using BatchJob
     job = BatchJob(agent_ids=[t[0] for t in tasks])
-    job.wait_all(timeout=timeout)
+    job.wait_all(timeout=timeout, cancel_on_failure=cancel_on_failure)
 
     # Return results in input order; fall back to failure for missing results.
     # When output_schema is set, parse the JSON result against the schema.

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -5301,6 +5301,72 @@ class TestBatchJobCancelOnFailure:
         assert "remaining" in results
         assert "remaining" in cancel_calls
 
+    def test_cancel_on_failure_cancels_on_overall_timeout(self, monkeypatch):
+        """When the overall as_completed timeout fires, cancel_on_failure cancels agents."""
+        import threading
+        from concurrent.futures import TimeoutError as FuturesTimeoutError
+
+        from gptme.tools.subagent import batch as batch_mod
+        from gptme.tools.subagent.batch import BatchJob
+
+        cancel_calls: list[str] = []
+        # Block all agents so the overall timeout fires
+        unblocked = threading.Event()
+
+        def mock_subagent_wait(agent_id, timeout=None, max_result_chars=None, **kwargs):
+            unblocked.wait(timeout=2)
+            return {"status": "success", "result": "done"}
+
+        def mock_as_completed(fs, timeout=None):
+            raise FuturesTimeoutError
+
+        def mock_subagent_cancel(agent_id):
+            cancel_calls.append(agent_id)
+
+        monkeypatch.setattr(batch_mod, "subagent_wait", mock_subagent_wait)
+        monkeypatch.setattr(batch_mod, "as_completed", mock_as_completed)
+        monkeypatch.setattr(batch_mod, "subagent_cancel", mock_subagent_cancel)
+
+        job = BatchJob(agent_ids=["agent-a", "agent-b"])
+        results = job.wait_all(timeout=1, cancel_on_failure=True)
+
+        # Both agents should be marked as timed out
+        assert results["agent-a"]["status"] == "timeout"
+        assert results["agent-b"]["status"] == "timeout"
+        # And both should have been cancelled
+        assert sorted(cancel_calls) == ["agent-a", "agent-b"]
+        unblocked.set()  # unblock background threads
+
+    def test_cancel_on_failure_false_no_cancel_on_overall_timeout(self, monkeypatch):
+        """Without cancel_on_failure, overall timeout does NOT call subagent_cancel."""
+        from concurrent.futures import TimeoutError as FuturesTimeoutError
+
+        from gptme.tools.subagent import batch as batch_mod
+        from gptme.tools.subagent.batch import BatchJob
+
+        cancel_calls: list[str] = []
+
+        def mock_subagent_wait(agent_id, timeout=None, max_result_chars=None, **kwargs):
+            return {"status": "success", "result": "done"}
+
+        def mock_as_completed(fs, timeout=None):
+            raise FuturesTimeoutError
+
+        def mock_subagent_cancel(agent_id):
+            cancel_calls.append(agent_id)
+
+        monkeypatch.setattr(batch_mod, "subagent_wait", mock_subagent_wait)
+        monkeypatch.setattr(batch_mod, "as_completed", mock_as_completed)
+        monkeypatch.setattr(batch_mod, "subagent_cancel", mock_subagent_cancel)
+
+        job = BatchJob(agent_ids=["agent-a", "agent-b"])
+        results = job.wait_all(timeout=1, cancel_on_failure=False)
+
+        assert results["agent-a"]["status"] == "timeout"
+        assert results["agent-b"]["status"] == "timeout"
+        # No cancel calls without cancel_on_failure
+        assert cancel_calls == []
+
 
 class TestSubagentParallelCancelOnFailure:
     """Tests for subagent_parallel(cancel_on_failure=True)."""

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -5337,8 +5337,13 @@ class TestBatchJobCancelOnFailure:
         assert sorted(cancel_calls) == ["agent-a", "agent-b"]
         unblocked.set()  # unblock background threads
 
-    def test_cancel_on_failure_false_no_cancel_on_overall_timeout(self, monkeypatch):
-        """Without cancel_on_failure, overall timeout does NOT call subagent_cancel."""
+    def test_overall_timeout_always_cancels_agents(self, monkeypatch):
+        """Overall timeout always cancels agents regardless of cancel_on_failure.
+
+        Subprocess/ACP agents must not keep running after the caller has already
+        received timed-out results — cancel_on_failure only controls early
+        cancellation on sibling failure, not cleanup at the overall deadline.
+        """
         from concurrent.futures import TimeoutError as FuturesTimeoutError
 
         from gptme.tools.subagent import batch as batch_mod
@@ -5364,8 +5369,8 @@ class TestBatchJobCancelOnFailure:
 
         assert results["agent-a"]["status"] == "timeout"
         assert results["agent-b"]["status"] == "timeout"
-        # No cancel calls without cancel_on_failure
-        assert cancel_calls == []
+        # Overall timeout always cancels — regardless of cancel_on_failure flag
+        assert sorted(cancel_calls) == ["agent-a", "agent-b"]
 
 
 class TestSubagentParallelCancelOnFailure:

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -5138,3 +5138,278 @@ class TestSubagentPipeline:
         assert len(results[0]) == 1  # 1 stage each
         assert results[0][0]["result"] == "a-stage0"
         assert results[1][0]["result"] == "b-stage0"
+
+
+# ---------------------------------------------------------------------------
+# cancel_on_failure tests
+# ---------------------------------------------------------------------------
+
+
+class TestBatchJobCancelOnFailure:
+    """Tests for BatchJob.wait_all(cancel_on_failure=True)."""
+
+    def test_cancel_on_failure_cancels_remaining_when_one_fails(self, monkeypatch):
+        """When cancel_on_failure=True, a failing agent causes remaining to be cancelled."""
+        import threading
+
+        from gptme.tools.subagent import batch as batch_mod
+        from gptme.tools.subagent.batch import BatchJob
+
+        slow_agent_unblocked = threading.Event()
+        cancel_calls: list[str] = []
+
+        def mock_subagent_wait(agent_id, timeout=None, max_result_chars=None, **kwargs):
+            if agent_id == "failing":
+                return {"status": "failure", "result": "task failed"}
+            # slow agent blocks until cancelled
+            slow_agent_unblocked.wait(timeout=5)
+            return {"status": "failure", "result": "Cancelled due to sibling failure"}
+
+        def mock_subagent_cancel(agent_id):
+            cancel_calls.append(agent_id)
+            slow_agent_unblocked.set()
+            return f"Subagent '{agent_id}' cancelled."
+
+        monkeypatch.setattr(batch_mod, "subagent_wait", mock_subagent_wait)
+        monkeypatch.setattr(batch_mod, "subagent_cancel", mock_subagent_cancel)
+
+        job = BatchJob(agent_ids=["failing", "slow"])
+        results = job.wait_all(timeout=5, cancel_on_failure=True)
+
+        assert results["failing"]["status"] == "failure"
+        assert "slow" in results
+        assert results["slow"]["status"] == "failure"
+        assert "slow" in cancel_calls
+
+    def test_cancel_on_failure_false_does_not_cancel_remaining(self, monkeypatch):
+        """Without cancel_on_failure=True, a failure does not cancel other agents."""
+
+        from gptme.tools.subagent import batch as batch_mod
+        from gptme.tools.subagent.batch import BatchJob
+
+        cancel_calls: list[str] = []
+
+        def mock_subagent_wait(agent_id, timeout=None, max_result_chars=None, **kwargs):
+            if agent_id == "failing":
+                return {"status": "failure", "result": "task failed"}
+            return {"status": "success", "result": "slow done"}
+
+        def mock_subagent_cancel(agent_id):
+            cancel_calls.append(agent_id)
+            return f"Subagent '{agent_id}' cancelled."
+
+        monkeypatch.setattr(batch_mod, "subagent_wait", mock_subagent_wait)
+        monkeypatch.setattr(batch_mod, "subagent_cancel", mock_subagent_cancel)
+
+        job = BatchJob(agent_ids=["failing", "slow"])
+        results = job.wait_all(timeout=5, cancel_on_failure=False)
+
+        assert results["failing"]["status"] == "failure"
+        assert results["slow"]["status"] == "success"
+        assert cancel_calls == []
+
+    def test_cancel_on_failure_no_cancel_when_all_succeed(self, monkeypatch):
+        """When all agents succeed, no cancellation happens."""
+        from gptme.tools.subagent import batch as batch_mod
+        from gptme.tools.subagent.batch import BatchJob
+
+        cancel_calls: list[str] = []
+
+        def mock_subagent_wait(agent_id, timeout=None, max_result_chars=None, **kwargs):
+            return {"status": "success", "result": f"{agent_id} done"}
+
+        def mock_subagent_cancel(agent_id):
+            cancel_calls.append(agent_id)
+            return f"cancelled {agent_id}"
+
+        monkeypatch.setattr(batch_mod, "subagent_wait", mock_subagent_wait)
+        monkeypatch.setattr(batch_mod, "subagent_cancel", mock_subagent_cancel)
+
+        job = BatchJob(agent_ids=["a", "b", "c"])
+        results = job.wait_all(timeout=5, cancel_on_failure=True)
+
+        assert all(r["status"] == "success" for r in results.values())
+        assert cancel_calls == []
+
+    def test_cancel_on_failure_multiple_remaining_agents_all_cancelled(
+        self, monkeypatch
+    ):
+        """When one agent fails, ALL remaining agents are cancelled."""
+        import threading
+
+        from gptme.tools.subagent import batch as batch_mod
+        from gptme.tools.subagent.batch import BatchJob
+
+        slow_unblocked = threading.Event()
+        cancel_calls: list[str] = []
+
+        def mock_subagent_wait(agent_id, timeout=None, max_result_chars=None, **kwargs):
+            if agent_id == "fail":
+                return {"status": "failure", "result": "fail"}
+            slow_unblocked.wait(timeout=5)
+            return {"status": "failure", "result": "Cancelled due to sibling failure"}
+
+        def mock_subagent_cancel(agent_id):
+            cancel_calls.append(agent_id)
+            slow_unblocked.set()
+            return f"cancelled {agent_id}"
+
+        monkeypatch.setattr(batch_mod, "subagent_wait", mock_subagent_wait)
+        monkeypatch.setattr(batch_mod, "subagent_cancel", mock_subagent_cancel)
+
+        job = BatchJob(agent_ids=["fail", "slow-1", "slow-2"])
+        results = job.wait_all(timeout=5, cancel_on_failure=True)
+
+        assert results["fail"]["status"] == "failure"
+        # Both remaining agents should be cancelled
+        assert len(results) == 3
+        assert all(results[aid]["status"] == "failure" for aid in ["slow-1", "slow-2"])
+        # Both should have been cancelled (cancel_calls may include one or both,
+        # depending on which one was still pending when cancel fired)
+        assert any(aid in cancel_calls for aid in ["slow-1", "slow-2"])
+
+    def test_cancel_on_failure_with_timeout_result_also_triggers_cancel(
+        self, monkeypatch
+    ):
+        """A timeout result (not just failure) also triggers cancel_on_failure."""
+        import threading
+
+        from gptme.tools.subagent import batch as batch_mod
+        from gptme.tools.subagent.batch import BatchJob
+
+        slow_unblocked = threading.Event()
+        cancel_calls: list[str] = []
+
+        def mock_subagent_wait(agent_id, timeout=None, max_result_chars=None, **kwargs):
+            if agent_id == "timed-out":
+                return {"status": "timeout", "result": "timed out"}
+            slow_unblocked.wait(timeout=5)
+            return {"status": "failure", "result": "Cancelled due to sibling failure"}
+
+        def mock_subagent_cancel(agent_id):
+            cancel_calls.append(agent_id)
+            slow_unblocked.set()
+            return f"cancelled {agent_id}"
+
+        monkeypatch.setattr(batch_mod, "subagent_wait", mock_subagent_wait)
+        monkeypatch.setattr(batch_mod, "subagent_cancel", mock_subagent_cancel)
+
+        job = BatchJob(agent_ids=["timed-out", "remaining"])
+        results = job.wait_all(timeout=5, cancel_on_failure=True)
+
+        assert results["timed-out"]["status"] == "timeout"
+        assert "remaining" in results
+        assert "remaining" in cancel_calls
+
+
+class TestSubagentParallelCancelOnFailure:
+    """Tests for subagent_parallel(cancel_on_failure=True)."""
+
+    def test_parallel_cancel_on_failure_cancels_remaining_on_failure(self, monkeypatch):
+        """subagent_parallel with cancel_on_failure=True cancels fleet on first failure."""
+        import threading
+
+        from gptme.tools.subagent import batch as batch_mod
+        from gptme.tools.subagent.batch import subagent_parallel
+
+        slow_unblocked = threading.Event()
+        cancel_calls: list[str] = []
+
+        def mock_subagent(agent_id, prompt, **kwargs):
+            pass  # fire-and-forget
+
+        def mock_subagent_wait(agent_id, timeout=None, max_result_chars=None, **kwargs):
+            if agent_id == "fail-agent":
+                return {"status": "failure", "result": "something went wrong"}
+            slow_unblocked.wait(timeout=5)
+            return {"status": "failure", "result": "Cancelled due to sibling failure"}
+
+        def mock_subagent_cancel(agent_id):
+            cancel_calls.append(agent_id)
+            slow_unblocked.set()
+            return f"cancelled {agent_id}"
+
+        monkeypatch.setattr(batch_mod, "subagent", mock_subagent)
+        monkeypatch.setattr(batch_mod, "subagent_wait", mock_subagent_wait)
+        monkeypatch.setattr(batch_mod, "subagent_cancel", mock_subagent_cancel)
+
+        results = subagent_parallel(
+            [("fail-agent", "do something"), ("slow-agent", "do something slow")],
+            timeout=5,
+            cancel_on_failure=True,
+        )
+
+        assert len(results) == 2
+        assert results[0]["status"] == "failure"  # fail-agent
+        assert results[1]["status"] == "failure"  # slow-agent (cancelled)
+        assert "slow-agent" in cancel_calls
+
+    def test_parallel_cancel_on_failure_false_collects_all_results(self, monkeypatch):
+        """Without cancel_on_failure, subagent_parallel waits for all agents."""
+        from gptme.tools.subagent import batch as batch_mod
+        from gptme.tools.subagent.batch import subagent_parallel
+
+        cancel_calls: list[str] = []
+
+        def mock_subagent(agent_id, prompt, **kwargs):
+            pass
+
+        def mock_subagent_wait(agent_id, timeout=None, max_result_chars=None, **kwargs):
+            if agent_id == "fail-agent":
+                return {"status": "failure", "result": "task failed"}
+            return {"status": "success", "result": f"{agent_id} done"}
+
+        def mock_subagent_cancel(agent_id):
+            cancel_calls.append(agent_id)
+            return f"cancelled {agent_id}"
+
+        monkeypatch.setattr(batch_mod, "subagent", mock_subagent)
+        monkeypatch.setattr(batch_mod, "subagent_wait", mock_subagent_wait)
+        monkeypatch.setattr(batch_mod, "subagent_cancel", mock_subagent_cancel)
+
+        results = subagent_parallel(
+            [("fail-agent", "do x"), ("success-agent", "do y")],
+            timeout=5,
+            cancel_on_failure=False,
+        )
+
+        assert len(results) == 2
+        assert results[0]["status"] == "failure"
+        assert results[1]["status"] == "success"
+        assert cancel_calls == []
+
+    def test_parallel_cancel_on_failure_results_in_input_order(self, monkeypatch):
+        """Results are returned in input task order even when cancel_on_failure fires."""
+        import threading
+
+        from gptme.tools.subagent import batch as batch_mod
+        from gptme.tools.subagent.batch import subagent_parallel
+
+        slow_unblocked = threading.Event()
+
+        def mock_subagent(agent_id, prompt, **kwargs):
+            pass
+
+        def mock_subagent_wait(agent_id, timeout=None, max_result_chars=None, **kwargs):
+            if agent_id == "third":
+                return {"status": "failure", "result": "third failed"}
+            slow_unblocked.wait(timeout=5)
+            return {"status": "failure", "result": "cancelled"}
+
+        def mock_subagent_cancel(agent_id):
+            slow_unblocked.set()
+            return f"cancelled {agent_id}"
+
+        monkeypatch.setattr(batch_mod, "subagent", mock_subagent)
+        monkeypatch.setattr(batch_mod, "subagent_wait", mock_subagent_wait)
+        monkeypatch.setattr(batch_mod, "subagent_cancel", mock_subagent_cancel)
+
+        tasks = [("first", "p1"), ("second", "p2"), ("third", "p3")]
+        results = subagent_parallel(tasks, timeout=5, cancel_on_failure=True)
+
+        # 3 results, in order of input tasks
+        assert len(results) == 3
+        # "third" failed — it should be the failure that triggered cancellation
+        third_idx = 2
+        assert results[third_idx]["status"] == "failure"
+        assert results[third_idx]["result"] == "third failed"


### PR DESCRIPTION
## Summary

Implements the `cancel_on_failure` fleet-cancellation pattern requested in #3191.

- Adds `cancel_on_failure: bool = False` to `BatchJob.wait_all()` and `subagent_parallel()`
- When enabled: the first failing or timed-out subagent sends SIGTERM to all remaining agents via `subagent_cancel()`, then pre-populates their results as `("failure", "Cancelled due to sibling failure")` so the orchestrator unblocks immediately
- Default is `False` — existing behaviour is unchanged

### Usage

```python
# Fail-fast: cancel the fleet when the first subagent fails
results = subagent_parallel(
    [("verifier-a", "Verify output A"), ("verifier-b", "Verify output B")],
    cancel_on_failure=True,
)
if any(r["status"] == "failure" for r in results):
    print("Verification failed — remaining agents were cancelled")
```

## What was already implemented

Before this PR, `subagent_cancel()`, `subagent_reply()` (steer/clarify), progress notifications, and `subagent_wait_any()` (hedging) were all already implemented in `gptme/tools/subagent/api.py`. The only missing piece was wiring `cancel_on_failure` into the batch fan-out layer.

## Tests

Added 8 unit tests (no LLM calls) in two new test classes:

- `TestBatchJobCancelOnFailure` (5 tests): verifies cancel is called on failure/timeout, default is unchanged, multiple remaining agents all get cancelled
- `TestSubagentParallelCancelOnFailure` (3 tests): end-to-end through `subagent_parallel()`, verifies default unchanged, results in input order

All 245 tests in `test_subagent_unit.py` + `test_subagent_concurrency.py` pass.

Closes #3191

<!-- gptme-id:v1:gai_wy9jFFObRplzdj9IolqOI2uLJGkQvR2BuTuJKRY7iYQ -->