### PR TITLE
feat(subagent): worktree isolation string API + smart cleanup

### DIFF
--- a/gptme/cli/cmd_hooks.py
+++ b/gptme/cli/cmd_hooks.py
@@ -279,6 +279,11 @@ def run(workspace: Path | None = None) -> None:
     gptme.toml [lessons] dirs. Already-injected lessons are tracked per session
     to avoid duplicates.
     """
+    # Suppress diagnostic output since this command must output only JSON
+    from ..message import set_output_format
+
+    set_output_format("json")
+
     try:
         raw = sys.stdin.read()
         if not raw.strip():

--- a/gptme/tools/subagent/__init__.py
+++ b/gptme/tools/subagent/__init__.py
@@ -316,7 +316,7 @@ Key features:
 - use_subprocess=True: Run subagent in subprocess for output isolation
 - use_acp=True: Run subagent via ACP protocol (supports any ACP-compatible agent)
 - acp_command="claude-code-acp": Use a different ACP agent (default: gptme-acp)
-- isolated=True: Run subagent in a git worktree for filesystem isolation
+- isolation="worktree": Run subagent in a git worktree for filesystem isolation (preferred over isolated=True)
 - workdir="/path/to/dir": Set the working directory for the subagent (defaults to cwd)
 - redact_secrets=True (default): Redact API keys, tokens, and passwords from workspace context
 - context_window=0: Minimal context — only agent identity + tools, no workspace files (strongest isolation)

--- a/gptme/tools/subagent/api.py
+++ b/gptme/tools/subagent/api.py
@@ -30,6 +30,7 @@ from .types import (
     clarification_result_from_content,
     resolve_role_defaults,
     set_subagent_result_if_absent,
+    update_subagent_result_with_branch,
 )
 
 logger = logging.getLogger(__name__)
@@ -849,6 +850,12 @@ def subagent(
                             output_tokens=result.output_tokens,
                         )
                     if not set_subagent_result_if_absent(agent_id, result):
+                        # Timeout/cancel won the cache race. Cleanup already ran above.
+                        # Patch the stored result with branch info so callers can find it.
+                        if preserved_branch:
+                            update_subagent_result_with_branch(
+                                agent_id, preserved_branch
+                            )
                         return
                     try:
                         summary = _exec._summarize_result(result, max_chars=200)

--- a/gptme/tools/subagent/api.py
+++ b/gptme/tools/subagent/api.py
@@ -834,16 +834,27 @@ def subagent(
                     # Use _read_log() instead of status(): the thread is still alive here,
                     # so status() would return "running" and poison the result cache.
                     result = sa._read_log()
+                    # Clean up isolation first so preserved branch name can be
+                    # included in the result returned to callers.
+                    preserved_branch = _exec._cleanup_isolation(sa)
+                    if preserved_branch and isinstance(result.result, str):
+                        from .types import ReturnType as _ReturnType
+
+                        result = _ReturnType(
+                            result.status,
+                            f"{result.result}\n\nChanges preserved on branch "
+                            f"{preserved_branch!r}"
+                            f" — merge with: git merge {preserved_branch}",
+                            input_tokens=result.input_tokens,
+                            output_tokens=result.output_tokens,
+                        )
                     if not set_subagent_result_if_absent(agent_id, result):
-                        _exec._cleanup_isolation(sa)
                         return
                     try:
                         summary = _exec._summarize_result(result, max_chars=200)
                         notify_completion(agent_id, result.status, summary)
                     except Exception as e:
                         logger.warning(f"Failed to notify subagent completion: {e}")
-                    # Clean up worktree isolation
-                    _exec._cleanup_isolation(sa)
             finally:
                 _sem.release()
 

--- a/gptme/tools/subagent/api.py
+++ b/gptme/tools/subagent/api.py
@@ -67,6 +67,7 @@ def subagent(
     profile: str | None = None,
     model: str | None = None,
     isolated: bool | None = None,
+    isolation: Literal["worktree"] | None = None,
     timeout: int = 1800,
     role: Role | None = None,
     redact_secrets: bool = True,
@@ -134,6 +135,20 @@ def subagent(
             can modify files without affecting the parent. The worktree is
             automatically cleaned up after the subagent completes.
             Falls back to a temporary directory if not in a git repo.
+            Prefer ``isolation="worktree"`` for new code — it is the string-based
+            API equivalent and enables smarter cleanup behaviour.
+        isolation: String-based isolation mode. Use ``"worktree"`` to create a
+            temporary git worktree for the subagent, giving it an isolated copy
+            of the repository to work in. On completion:
+
+            - **No local changes**: worktree directory *and* branch are removed
+              automatically (zero cleanup needed).
+            - **Local changes exist**: the branch is preserved and its name is
+              reported in the result so the orchestrator can inspect or merge it.
+              The working-tree directory is still removed.
+
+            Falls back to a temporary directory when not in a git repository.
+            Equivalent to ``isolated=True`` but adds smart cleanup behaviour.
         timeout: Maximum seconds before the subprocess monitor kills the
             subagent (default 1800 = 30 min). Only applies to subprocess mode.
         redact_secrets: If True (default), scrub common secret patterns from
@@ -234,6 +249,15 @@ def subagent(
         raise ValueError(
             f"context_turns must be None or a positive integer, got {context_turns!r}"
         )
+    if isolation is not None and isolation != "worktree":
+        raise ValueError(
+            f"Unknown isolation mode: {isolation!r}. Supported values: 'worktree'."
+        )
+
+    # isolation="worktree" is the string-based API equivalent of isolated=True.
+    # When isolation is set, it overrides isolated (but both can still coexist).
+    if isolation == "worktree":
+        isolated = True
 
     # Fetch parent messages from the active LogManager when context_turns is set.
     # LogManager.get_current_log() reads a ContextVar set by the chat loop, so
@@ -364,6 +388,7 @@ def subagent(
             context_include=context_include,
             profile=profile,
             isolated=isolated,
+            isolation_mode=isolation,
             redact_secrets=redact_secrets,
             context_window=context_window,
             max_time=max_time,
@@ -627,6 +652,7 @@ def subagent(
             acp_command=acp_command,
             workdir=workdir_path,
             isolated=isolated,
+            isolation_mode=isolation,
             worktree_path=worktree_path,
             repo_path=repo_path,
             role=role,
@@ -728,6 +754,7 @@ def subagent(
             execution_mode="subprocess",
             workdir=workdir_path,
             isolated=isolated,
+            isolation_mode=isolation,
             worktree_path=worktree_path,
             repo_path=repo_path,
             timeout=timeout,
@@ -843,6 +870,7 @@ def subagent(
             execution_mode="thread",
             workdir=workdir_path,
             isolated=isolated,
+            isolation_mode=isolation,
             worktree_path=worktree_path,
             repo_path=repo_path,
             role=role,

--- a/gptme/tools/subagent/api.py
+++ b/gptme/tools/subagent/api.py
@@ -637,7 +637,9 @@ def subagent(
                         preserved_branch = _exec._cleanup_isolation(sa_ref)
                         if preserved_branch:
                             update_subagent_result_with_branch(
-                                agent_id, preserved_branch
+                                agent_id,
+                                preserved_branch,
+                                has_output_schema=bool(sa_ref.output_schema),
                             )
             finally:
                 _sem.release()
@@ -845,7 +847,14 @@ def subagent(
                     # Clean up isolation first so preserved branch name can be
                     # included in the result returned to callers.
                     preserved_branch = _exec._cleanup_isolation(sa)
-                    if preserved_branch and isinstance(result.result, str):
+                    # Skip appending human-readable branch text when output_schema
+                    # is set — the result string is JSON that callers parse, and
+                    # appending text after it would break that parse.
+                    if (
+                        preserved_branch
+                        and isinstance(result.result, str)
+                        and not sa.output_schema
+                    ):
                         from .types import ReturnType as _ReturnType
 
                         result = _ReturnType(
@@ -861,7 +870,9 @@ def subagent(
                         # Patch the stored result with branch info so callers can find it.
                         if preserved_branch:
                             update_subagent_result_with_branch(
-                                agent_id, preserved_branch
+                                agent_id,
+                                preserved_branch,
+                                has_output_schema=bool(sa.output_schema),
                             )
                         return
                     try:

--- a/gptme/tools/subagent/api.py
+++ b/gptme/tools/subagent/api.py
@@ -631,7 +631,14 @@ def subagent(
                             (s for s in _subagents if s.agent_id == agent_id), None
                         )
                     if sa_ref:
-                        _exec._cleanup_isolation(sa_ref)
+                        # ACP always caches a result above before reaching this
+                        # cleanup, so patch the already-stored result with any
+                        # preserved branch (mirrors the thread-mode fallback).
+                        preserved_branch = _exec._cleanup_isolation(sa_ref)
+                        if preserved_branch:
+                            update_subagent_result_with_branch(
+                                agent_id, preserved_branch
+                            )
             finally:
                 _sem.release()
 

--- a/gptme/tools/subagent/batch.py
+++ b/gptme/tools/subagent/batch.py
@@ -18,7 +18,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from concurrent.futures import TimeoutError as FuturesTimeoutError
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
-from typing import cast
+from typing import Literal, cast
 
 from .api import subagent, subagent_cancel, subagent_wait
 from .types import ReturnType
@@ -438,6 +438,7 @@ def subagent_parallel(
     model: str | None = None,
     profile: str | None = None,
     isolated: bool = False,
+    isolation: Literal["worktree"] | None = None,
     output_schema: "type | dict | None" = None,
     workdir: str | Path | None = None,
     context_turns: int | None = None,
@@ -471,6 +472,12 @@ def subagent_parallel(
             ``"explorer"``, ``"developer"``, ``"verifier"``).
         isolated: If True, run each subagent in its own git worktree so file
             edits don't conflict between agents or with the parent.
+            Prefer ``isolation="worktree"`` for new code.
+        isolation: String-based isolation mode. Use ``"worktree"`` to give each
+            subagent its own git worktree. On completion, worktrees with no
+            local changes are auto-removed; worktrees with commits ahead of
+            HEAD have their branch preserved (reported in the result) for
+            the caller to inspect or merge.
         output_schema: Optional Pydantic model class. When set, subagents are
             instructed to return valid JSON matching the schema in their
             ``complete`` block. Results are automatically parsed: on success the
@@ -506,10 +513,10 @@ def subagent_parallel(
         for (agent_id, _), result in zip(tasks, results):
             print(f"{agent_id}: {result['status']} — {result['result'][:80]}")
 
-        # With worktree isolation for concurrent file edits
+        # With worktree isolation for concurrent file edits (string API)
         results = subagent_parallel(
             [("fix-a", "Fix bug in module A"), ("fix-b", "Fix bug in module B")],
-            isolated=True,
+            isolation="worktree",
         )
 
         # With structured output (Pydantic model)
@@ -545,6 +552,7 @@ def subagent_parallel(
                 model=model,
                 profile=profile,
                 isolated=isolated,
+                isolation=isolation,
                 output_schema=output_schema,
                 workdir=workdir,
                 context_turns=context_turns,

--- a/gptme/tools/subagent/execution.py
+++ b/gptme/tools/subagent/execution.py
@@ -791,6 +791,15 @@ def _monitor_subprocess(
         status = "failure"
         result = f"Process exited with code {subagent.process.returncode}"
 
+    # Clean up worktree isolation; capture preserved branch so it can be
+    # included in the result that callers receive via subagent_wait() / subagent_parallel().
+    preserved_branch = _cleanup_isolation(subagent)
+    if preserved_branch and isinstance(result, str):
+        result = (
+            f"{result}\n\nChanges preserved on branch {preserved_branch!r}"
+            f" — merge with: git merge {preserved_branch}"
+        )
+
     # Cache the result in module-level dict (Subagent is frozen)
     final_result = ReturnType(
         status,
@@ -799,7 +808,6 @@ def _monitor_subprocess(
         output_tokens=output_tokens,
     )
     if not set_subagent_result_if_absent(subagent.agent_id, final_result):
-        _cleanup_isolation(subagent)
         return
 
     # Notify via hook system (fire-and-forget-then-get-alerted pattern)
@@ -808,9 +816,6 @@ def _monitor_subprocess(
         notify_completion(subagent.agent_id, status, summary)
     except Exception as e:
         logger.warning(f"Failed to notify subagent completion: {e}")
-
-    # Clean up worktree isolation
-    _cleanup_isolation(subagent)
 
 
 def _run_planner(

--- a/gptme/tools/subagent/execution.py
+++ b/gptme/tools/subagent/execution.py
@@ -733,6 +733,7 @@ def _monitor_subprocess(
     from .types import (
         ReturnType,
         set_subagent_result_if_absent,
+        update_subagent_result_with_branch,
     )
 
     if not subagent.process:
@@ -808,6 +809,11 @@ def _monitor_subprocess(
         output_tokens=output_tokens,
     )
     if not set_subagent_result_if_absent(subagent.agent_id, final_result):
+        # Timeout/cancel won the cache race. Patch the stored result with
+        # branch info (mirrors the thread-mode fallback in api.py) so
+        # callers can still find preserved work.
+        if preserved_branch:
+            update_subagent_result_with_branch(subagent.agent_id, preserved_branch)
         return
 
     # Notify via hook system (fire-and-forget-then-get-alerted pattern)

--- a/gptme/tools/subagent/execution.py
+++ b/gptme/tools/subagent/execution.py
@@ -795,7 +795,10 @@ def _monitor_subprocess(
     # Clean up worktree isolation; capture preserved branch so it can be
     # included in the result that callers receive via subagent_wait() / subagent_parallel().
     preserved_branch = _cleanup_isolation(subagent)
-    if preserved_branch and isinstance(result, str):
+    # Skip appending human-readable branch text when output_schema is set —
+    # the result string is JSON that callers parse, and appending text after
+    # it would break that parse.
+    if preserved_branch and isinstance(result, str) and not subagent.output_schema:
         result = (
             f"{result}\n\nChanges preserved on branch {preserved_branch!r}"
             f" — merge with: git merge {preserved_branch}"
@@ -813,7 +816,11 @@ def _monitor_subprocess(
         # branch info (mirrors the thread-mode fallback in api.py) so
         # callers can still find preserved work.
         if preserved_branch:
-            update_subagent_result_with_branch(subagent.agent_id, preserved_branch)
+            update_subagent_result_with_branch(
+                subagent.agent_id,
+                preserved_branch,
+                has_output_schema=bool(subagent.output_schema),
+            )
         return
 
     # Notify via hook system (fire-and-forget-then-get-alerted pattern)

--- a/gptme/tools/subagent/execution.py
+++ b/gptme/tools/subagent/execution.py
@@ -582,17 +582,40 @@ def _summarize_result(result: "ReturnType", max_chars: int = 200) -> str:
     return text[: max_chars - 3] + "..."
 
 
-def _cleanup_isolation(subagent: "Subagent") -> None:
-    """Clean up worktree or temp directory after subagent completes."""
+def _cleanup_isolation(subagent: "Subagent") -> str | None:
+    """Clean up worktree or temp directory after subagent completes.
+
+    For ``isolation_mode="worktree"`` subagents, uses smart cleanup:
+    - No local changes → remove directory AND branch (full cleanup).
+    - Local changes → preserve branch, remove directory only.
+
+    Returns:
+        The preserved branch name when changes exist and smart cleanup is
+        active; ``None`` otherwise.
+    """
     if not subagent.isolated or not subagent.worktree_path:
-        return
+        return None
 
     from ...util.git_worktree import cleanup_worktree
 
     try:
-        cleanup_worktree(subagent.worktree_path, subagent.repo_path)
+        # Smart cleanup: preserve branch when isolation="worktree" was used
+        # and the worktree has local changes so the orchestrator can merge them.
+        keep_if_changed = subagent.isolation_mode == "worktree"
+        preserved_branch = cleanup_worktree(
+            subagent.worktree_path,
+            subagent.repo_path,
+            keep_branch_if_changed=keep_if_changed,
+        )
+        if preserved_branch:
+            logger.info(
+                f"Subagent {subagent.agent_id!r}: changes preserved on branch "
+                f"{preserved_branch!r} — merge with: git merge {preserved_branch}"
+            )
+        return preserved_branch
     except Exception as e:
         logger.warning(f"Failed to cleanup isolation for {subagent.agent_id}: {e}")
+        return None
 
 
 def _drain_progress_file(

--- a/gptme/tools/subagent/types.py
+++ b/gptme/tools/subagent/types.py
@@ -129,13 +129,21 @@ def set_subagent_result_if_absent(agent_id: str, result: "ReturnType") -> bool:
         return True
 
 
-def update_subagent_result_with_branch(agent_id: str, branch: str) -> None:
+def update_subagent_result_with_branch(
+    agent_id: str, branch: str, has_output_schema: bool = False
+) -> None:
     """Amend a cached result to include a preserved branch name.
 
     Called when the normal-completion thread loses the set_subagent_result_if_absent
     race to a timeout/cancel watchdog. Cleanup already ran and found a preserved
     branch; without this patch the caller's stored result would have no branch name.
+
+    When ``has_output_schema`` is True, the cached result string is JSON that
+    callers parse — appending human-readable text would break that parse, so
+    the branch is logged only (via ``_cleanup_isolation``) and not patched in.
     """
+    if has_output_schema:
+        return
     suffix = (
         f"\n\nChanges preserved on branch {branch!r} — merge with: git merge {branch}"
     )

--- a/gptme/tools/subagent/types.py
+++ b/gptme/tools/subagent/types.py
@@ -197,6 +197,9 @@ class Subagent:
     isolated: bool = False
     worktree_path: Path | None = None
     repo_path: Path | None = None
+    # String isolation mode ("worktree" or None). When set, cleanup uses smart
+    # behaviour: auto-remove if unchanged, preserve branch if changes exist.
+    isolation_mode: str | None = None
     # Maximum time (seconds) the subprocess monitor will wait before killing
     timeout: int = 1800  # 30 minutes
     role: Role | None = None

--- a/gptme/tools/subagent/types.py
+++ b/gptme/tools/subagent/types.py
@@ -129,6 +129,34 @@ def set_subagent_result_if_absent(agent_id: str, result: "ReturnType") -> bool:
         return True
 
 
+def update_subagent_result_with_branch(agent_id: str, branch: str) -> None:
+    """Amend a cached result to include a preserved branch name.
+
+    Called when the normal-completion thread loses the set_subagent_result_if_absent
+    race to a timeout/cancel watchdog. Cleanup already ran and found a preserved
+    branch; without this patch the caller's stored result would have no branch name.
+    """
+    suffix = (
+        f"\n\nChanges preserved on branch {branch!r} — merge with: git merge {branch}"
+    )
+    with _subagent_results_lock:
+        existing = _subagent_results.get(agent_id)
+        if existing is None:
+            return
+        if isinstance(existing.result, str):
+            amended: str | None = existing.result + suffix
+        elif existing.result is None:
+            amended = suffix.lstrip("\n")
+        else:
+            return  # structured (dict) result — cannot amend inline
+        _subagent_results[agent_id] = ReturnType(
+            existing.status,
+            amended,
+            input_tokens=existing.input_tokens,
+            output_tokens=existing.output_tokens,
+        )
+
+
 # ---------------------------------------------------------------------------
 # Data classes
 # ---------------------------------------------------------------------------

--- a/gptme/util/git_worktree.py
+++ b/gptme/util/git_worktree.py
@@ -73,7 +73,9 @@ def has_changes(worktree_path: Path) -> bool:
             timeout=10,
         )
         if reflog_r.returncode == 0:
-            shas = [l.strip() for l in reflog_r.stdout.splitlines() if l.strip()]
+            shas = [
+                line.strip() for line in reflog_r.stdout.splitlines() if line.strip()
+            ]
             if shas:
                 creation_sha = shas[-1]  # oldest reflog entry = creation point
                 ahead_r = subprocess.run(

--- a/gptme/util/git_worktree.py
+++ b/gptme/util/git_worktree.py
@@ -16,6 +16,83 @@ logger = logging.getLogger(__name__)
 DEFAULT_WORKTREE_BASE = Path("/tmp/gptme-worktrees")
 
 
+def has_changes(worktree_path: Path) -> bool:
+    """Return True if the worktree has local changes vs the repository HEAD.
+
+    Checks both uncommitted file modifications and commits that were made
+    inside the worktree branch since it was created.
+
+    Args:
+        worktree_path: Path to the worktree to inspect.
+
+    Returns:
+        True if the worktree has any local changes, False if it is identical
+        to the commit it was created from.
+    """
+    try:
+        # 1. Uncommitted changes (staged or unstaged)
+        result = subprocess.run(
+            ["git", "status", "--porcelain"],
+            cwd=worktree_path,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return True
+
+        # 2. Committed changes: find commits in the worktree branch that are
+        # not reachable from the commit the branch was created at (initial
+        # entry in the branch's reflog).
+        #
+        # git reflog show <branch> lists entries newest-first; the last entry
+        # is the creation point. If HEAD != that initial SHA, commits exist.
+        branch_r = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            cwd=worktree_path,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+        if branch_r.returncode != 0:
+            return False
+
+        branch = branch_r.stdout.strip()
+        if branch in ("HEAD", ""):
+            # Detached HEAD — can't use branch reflog
+            return False
+
+        reflog_r = subprocess.run(
+            ["git", "reflog", "show", "--format=%H", branch],
+            cwd=worktree_path,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+        if reflog_r.returncode == 0:
+            shas = [l.strip() for l in reflog_r.stdout.splitlines() if l.strip()]
+            if shas:
+                creation_sha = shas[-1]  # oldest reflog entry = creation point
+                ahead_r = subprocess.run(
+                    ["git", "rev-list", "--count", f"{creation_sha}..HEAD"],
+                    cwd=worktree_path,
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                    timeout=10,
+                )
+                if ahead_r.returncode == 0 and int(ahead_r.stdout.strip() or "0") > 0:
+                    return True
+
+        return False
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        # On error, assume changes exist (safe default: don't lose modified work)
+        return True
+
+
 def get_git_root(path: Path | None = None) -> Path | None:
     """Find the git repository root from the given path.
 
@@ -86,7 +163,8 @@ def create_worktree(
 def cleanup_worktree(
     worktree_path: Path,
     repo_path: Path | None = None,
-) -> None:
+    keep_branch_if_changed: bool = False,
+) -> str | None:
     """Clean up a git worktree and its associated branch.
 
     Attempts git worktree remove first, falls back to directory removal.
@@ -96,10 +174,18 @@ def cleanup_worktree(
     Args:
         worktree_path: Path to the worktree to remove.
         repo_path: Path to the main repository. If None, attempts to find it.
+        keep_branch_if_changed: When True, preserve the branch if the worktree
+            has local changes or commits. The working-tree directory is still
+            removed; only the branch ref is kept so the caller can inspect or
+            merge the changes later.
+
+    Returns:
+        The preserved branch name when ``keep_branch_if_changed=True`` and
+        the worktree had changes; ``None`` otherwise.
     """
     if not worktree_path.exists():
         logger.debug(f"Worktree already removed: {worktree_path}")
-        return
+        return None
 
     # Branch name matches the last path component (as created by create_worktree)
     branch_name = worktree_path.name
@@ -107,6 +193,16 @@ def cleanup_worktree(
     # Try to find repo_path if not given
     if repo_path is None:
         repo_path = get_git_root(worktree_path)
+
+    # Smart cleanup: preserve the branch when the worktree has local changes.
+    # The working-tree directory is always removed; only the branch ref is kept.
+    preserved_branch: str | None = None
+    if keep_branch_if_changed and has_changes(worktree_path):
+        preserved_branch = branch_name
+        logger.info(
+            f"Worktree {worktree_path} has changes — preserving branch {branch_name!r} "
+            "for inspection/merge. Directory will still be removed."
+        )
 
     # Try git worktree remove (clean approach)
     if repo_path:
@@ -128,6 +224,10 @@ def cleanup_worktree(
                 logger.info(f"Removed worktree directory (fallback): {worktree_path}")
             except OSError as e2:
                 logger.warning(f"Failed to remove worktree directory: {e2}")
+
+        if preserved_branch:
+            # Keep the branch — skip deletion so changes remain accessible.
+            return preserved_branch
 
         # Delete the branch that was created for this worktree.
         # git worktree remove only removes the working tree, not the branch.
@@ -168,3 +268,5 @@ def cleanup_worktree(
             logger.info(f"Removed worktree directory (no repo): {worktree_path}")
         except OSError as e:
             logger.warning(f"Failed to remove worktree directory: {e}")
+
+    return None

--- a/tests/test_git_worktree.py
+++ b/tests/test_git_worktree.py
@@ -5,7 +5,12 @@ from pathlib import Path
 
 import pytest
 
-from gptme.util.git_worktree import cleanup_worktree, create_worktree, get_git_root
+from gptme.util.git_worktree import (
+    cleanup_worktree,
+    create_worktree,
+    get_git_root,
+    has_changes,
+)
 
 
 @pytest.fixture
@@ -174,3 +179,138 @@ def test_worktree_isolation(git_repo: Path, tmp_path: Path):
     assert (git_repo / "README.md").read_text() == "# Test\n"
 
     cleanup_worktree(wt, git_repo)
+
+
+# ---------------------------------------------------------------------------
+# Tests for has_changes() and smart cleanup (keep_branch_if_changed)
+# ---------------------------------------------------------------------------
+
+
+def test_has_changes_clean_worktree(git_repo: Path, tmp_path: Path):
+    """has_changes() returns False for a fresh worktree with no modifications."""
+    wt = create_worktree(
+        git_repo,
+        branch_name="clean-wt",
+        worktree_base=tmp_path / "worktrees",
+    )
+    try:
+        assert not has_changes(wt), "Fresh worktree should have no changes"
+    finally:
+        cleanup_worktree(wt, git_repo)
+
+
+def test_has_changes_uncommitted_file(git_repo: Path, tmp_path: Path):
+    """has_changes() returns True when there are uncommitted file modifications."""
+    wt = create_worktree(
+        git_repo,
+        branch_name="dirty-wt",
+        worktree_base=tmp_path / "worktrees",
+    )
+    try:
+        (wt / "new_file.txt").write_text("change\n")
+        assert has_changes(wt), "Worktree with new file should show changes"
+    finally:
+        cleanup_worktree(wt, git_repo)
+
+
+def test_has_changes_committed(git_repo: Path, tmp_path: Path):
+    """has_changes() returns True for a committed change on the worktree branch."""
+    wt = create_worktree(
+        git_repo,
+        branch_name="committed-wt",
+        worktree_base=tmp_path / "worktrees",
+    )
+    try:
+        (wt / "new_file.txt").write_text("change\n")
+        subprocess.run(["git", "add", "."], cwd=wt, capture_output=True, check=True)
+        subprocess.run(
+            ["git", "commit", "--no-verify", "-m", "worktree commit"],
+            cwd=wt,
+            capture_output=True,
+            check=True,
+        )
+        # The worktree has a commit not in the main repo
+        assert has_changes(wt), "Worktree with local commit should show changes"
+    finally:
+        cleanup_worktree(wt, git_repo)
+
+
+def test_cleanup_keeps_branch_when_changed(git_repo: Path, tmp_path: Path):
+    """cleanup_worktree keep_branch_if_changed=True preserves branch when worktree has changes."""
+    branch = "changed-wt"
+    wt = create_worktree(
+        git_repo,
+        branch_name=branch,
+        worktree_base=tmp_path / "worktrees",
+    )
+
+    # Add an uncommitted file to make the worktree dirty
+    (wt / "agent_output.txt").write_text("result\n")
+
+    preserved = cleanup_worktree(wt, git_repo, keep_branch_if_changed=True)
+
+    # Working tree should be gone
+    assert not wt.exists(), "Worktree directory should be removed"
+    # Branch should be preserved and returned
+    assert preserved == branch
+
+    result = subprocess.run(
+        ["git", "branch", "--list", branch],
+        cwd=git_repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert branch in result.stdout, "Branch should be preserved when there are changes"
+
+    # Manual cleanup of the preserved branch
+    subprocess.run(
+        ["git", "branch", "-D", branch],
+        cwd=git_repo,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_cleanup_removes_branch_when_unchanged(git_repo: Path, tmp_path: Path):
+    """cleanup_worktree keep_branch_if_changed=True removes branch when worktree is clean."""
+    branch = "clean-keep"
+    wt = create_worktree(
+        git_repo,
+        branch_name=branch,
+        worktree_base=tmp_path / "worktrees",
+    )
+
+    preserved = cleanup_worktree(wt, git_repo, keep_branch_if_changed=True)
+
+    # No changes → full cleanup
+    assert preserved is None
+    assert not wt.exists()
+
+    result = subprocess.run(
+        ["git", "branch", "--list", branch],
+        cwd=git_repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert branch not in result.stdout, "Branch should be deleted when worktree is clean"
+
+
+def test_two_worktrees_are_isolated(git_repo: Path, tmp_path: Path):
+    """Changes in one worktree do not appear in another worktree."""
+    base = tmp_path / "worktrees"
+    wt_a = create_worktree(git_repo, branch_name="agent-a", worktree_base=base)
+    wt_b = create_worktree(git_repo, branch_name="agent-b", worktree_base=base)
+
+    try:
+        (wt_a / "a_output.txt").write_text("from A\n")
+        (wt_b / "b_output.txt").write_text("from B\n")
+
+        assert not (wt_a / "b_output.txt").exists(), "A should not see B's files"
+        assert not (wt_b / "a_output.txt").exists(), "B should not see A's files"
+        assert not (git_repo / "a_output.txt").exists(), "main repo unaffected by A"
+        assert not (git_repo / "b_output.txt").exists(), "main repo unaffected by B"
+    finally:
+        cleanup_worktree(wt_a, git_repo)
+        cleanup_worktree(wt_b, git_repo)

--- a/tests/test_subagent_worktree_isolation.py
+++ b/tests/test_subagent_worktree_isolation.py
@@ -27,7 +27,6 @@ from gptme.tools.subagent.types import (
     _subagents_lock,
 )
 
-
 # ---------------------------------------------------------------------------
 # Helpers / fixtures
 # ---------------------------------------------------------------------------
@@ -89,7 +88,9 @@ def _patch_subagent_env(monkeypatch, tmp_path):
 
     monkeypatch.setattr(cli_main, "get_logdir", lambda name: tmp_path / name)
     monkeypatch.setattr(llm_models, "get_default_model", lambda: None)
-    monkeypatch.setattr(subagent_execution, "_create_subagent_thread", lambda **kw: None)
+    monkeypatch.setattr(
+        subagent_execution, "_create_subagent_thread", lambda **kw: None
+    )
     monkeypatch.setattr(subagent_api, "notify_completion", lambda *a, **kw: None)
 
 
@@ -111,13 +112,12 @@ def test_isolation_worktree_enables_isolated_flag(monkeypatch, tmp_path, git_rep
     created: list[Path] = []
 
     monkeypatch.setattr(git_worktree, "get_git_root", lambda _: git_repo)
-    monkeypatch.setattr(
-        git_worktree,
-        "create_worktree",
-        lambda repo_path, branch_name=None, worktree_base=None: (
-            created.append(branch_name) or (tmp_path / "wts" / (branch_name or "wt"))
-        ),
-    )
+
+    def _mock_create_worktree(repo_path, branch_name=None, worktree_base=None):
+        created.append(branch_name)
+        return tmp_path / "wts" / (branch_name or "wt")
+
+    monkeypatch.setattr(git_worktree, "create_worktree", _mock_create_worktree)
     monkeypatch.setattr(subagent_execution, "_cleanup_isolation", lambda sa: None)
     _patch_subagent_env(monkeypatch, tmp_path)
 
@@ -144,11 +144,11 @@ def test_isolation_none_does_not_create_worktree(monkeypatch, tmp_path):
     git_worktree = importlib.import_module("gptme.util.git_worktree")
     create_calls: list = []
 
-    monkeypatch.setattr(
-        git_worktree,
-        "create_worktree",
-        lambda *a, **kw: create_calls.append(1) or tmp_path,
-    )
+    def _noop_create_worktree(*a, **kw):
+        create_calls.append(1)
+        return tmp_path
+
+    monkeypatch.setattr(git_worktree, "create_worktree", _noop_create_worktree)
     monkeypatch.setattr(subagent_execution, "_cleanup_isolation", lambda sa: None)
     _patch_subagent_env(monkeypatch, tmp_path)
 
@@ -194,7 +194,9 @@ def test_subagent_parallel_isolation_worktree_creates_per_agent_worktree(
         f"Expected {len(tasks)} worktrees created, got {len(created)}"
     )
     # Branch names should be distinct
-    assert len(set(created)) == len(tasks), "Each agent should get a distinct worktree branch"
+    assert len(set(created)) == len(tasks), (
+        "Each agent should get a distinct worktree branch"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -215,8 +217,6 @@ def test_cleanup_called_after_thread_completes(monkeypatch, tmp_path, git_repo):
             tmp_path / "wts" / (branch_name or "wt")
         ),
     )
-
-    orig_cleanup = subagent_execution._cleanup_isolation
 
     def recording_cleanup(sa):
         cleanup_calls.append(sa.agent_id)
@@ -303,7 +303,9 @@ def test_smart_cleanup_preserves_branch_when_worktree_has_changes(tmp_path):
     from gptme.util.git_worktree import create_worktree
 
     repo = _make_repo(tmp_path, "repo-dirty")
-    wt = create_worktree(repo, branch_name="dirty-agent-wt", worktree_base=tmp_path / "wts")
+    wt = create_worktree(
+        repo, branch_name="dirty-agent-wt", worktree_base=tmp_path / "wts"
+    )
 
     # Dirty the worktree (uncommitted change)
     (wt / "output.txt").write_text("agent result\n")
@@ -323,7 +325,9 @@ def test_smart_cleanup_preserves_branch_when_worktree_has_changes(tmp_path):
     preserved = subagent_execution._cleanup_isolation(sa)
 
     assert not wt.exists(), "Working tree directory should be removed"
-    assert preserved == "dirty-agent-wt", "Branch name should be returned when changes exist"
+    assert preserved == "dirty-agent-wt", (
+        "Branch name should be returned when changes exist"
+    )
 
     result = subprocess.run(
         ["git", "branch", "--list", "dirty-agent-wt"],
@@ -349,7 +353,9 @@ def test_smart_cleanup_removes_branch_when_worktree_is_clean(tmp_path):
     from gptme.util.git_worktree import create_worktree
 
     repo = _make_repo(tmp_path, "repo-clean")
-    wt = create_worktree(repo, branch_name="clean-agent-wt", worktree_base=tmp_path / "wts")
+    wt = create_worktree(
+        repo, branch_name="clean-agent-wt", worktree_base=tmp_path / "wts"
+    )
 
     sa = Subagent(
         agent_id="clean-agent",
@@ -375,7 +381,9 @@ def test_smart_cleanup_removes_branch_when_worktree_is_clean(tmp_path):
         text=True,
         check=False,
     )
-    assert "clean-agent-wt" not in result.stdout, "Branch should be deleted (no changes)"
+    assert "clean-agent-wt" not in result.stdout, (
+        "Branch should be deleted (no changes)"
+    )
 
 
 def test_legacy_isolated_bool_always_does_full_cleanup(tmp_path):

--- a/tests/test_subagent_worktree_isolation.py
+++ b/tests/test_subagent_worktree_isolation.py
@@ -21,6 +21,7 @@ import gptme.tools.subagent.execution as subagent_execution
 from gptme.tools.subagent.api import subagent
 from gptme.tools.subagent.batch import subagent_parallel
 from gptme.tools.subagent.types import (
+    ReturnType,
     _subagent_results,
     _subagent_results_lock,
     _subagents,
@@ -450,3 +451,130 @@ def test_concurrent_worktrees_are_isolated(tmp_path):
     finally:
         cleanup_worktree(wt_a, repo)
         cleanup_worktree(wt_b, repo)
+
+
+# ---------------------------------------------------------------------------
+# Preserved branch must reach the caller even when the normal completion
+# path loses a caching race, or never caches at all before cleanup runs.
+# ---------------------------------------------------------------------------
+
+
+def test_subprocess_monitor_patches_branch_when_result_already_cached(tmp_path):
+    """Subprocess mode: a preserved branch is patched onto a result that a
+    timeout/cancel watchdog already cached before cleanup completed.
+
+    Regression test for a Greptile P1 finding: previously the subprocess
+    monitor discarded ``preserved_branch`` when ``set_subagent_result_if_absent``
+    lost the race, unlike the thread-mode fallback.
+    """
+    from unittest.mock import MagicMock
+
+    from gptme.tools.subagent.types import Subagent
+
+    repo = _make_repo(tmp_path, "repo-subprocess-race")
+    from gptme.util.git_worktree import create_worktree
+
+    wt = create_worktree(
+        repo, branch_name="subprocess-race-wt", worktree_base=tmp_path / "wts"
+    )
+    (wt / "output.txt").write_text("agent result\n")  # dirty the worktree
+
+    mock_proc = MagicMock()
+    mock_proc.wait.return_value = 0
+    mock_proc.returncode = 0
+
+    sa = Subagent(
+        agent_id="subprocess-race",
+        prompt="task",
+        thread=None,
+        logdir=tmp_path / "log",
+        model=None,
+        process=mock_proc,
+        execution_mode="subprocess",
+        isolated=True,
+        isolation_mode="worktree",
+        worktree_path=wt,
+        repo_path=repo,
+    )
+    with _subagents_lock:
+        _subagents.append(sa)
+
+    # Simulate the timeout/cancel watchdog winning the cache race before
+    # _monitor_subprocess reaches its own set_subagent_result_if_absent call.
+    with _subagent_results_lock:
+        _subagent_results["subprocess-race"] = ReturnType(
+            "timeout", "Auto-cancelled after 5s (max_time exceeded)"
+        )
+
+    subagent_execution._monitor_subprocess(sa)
+
+    assert not wt.exists(), "Worktree directory should still be cleaned up"
+    with _subagent_results_lock:
+        result = _subagent_results["subprocess-race"]
+    assert result.status == "timeout", "Cached status should be left untouched"
+    assert result.result is not None
+    assert "Changes preserved on branch" in result.result, (
+        "Preserved branch must be patched onto the already-cached result"
+    )
+    assert "subprocess-race-wt" in result.result
+
+
+def test_acp_cleanup_patches_branch_onto_cached_result(tmp_path, monkeypatch):
+    """ACP mode: a preserved worktree branch is patched onto the cached result.
+
+    Regression test for a Greptile P1 finding: the ACP path runs
+    ``_cleanup_isolation()`` from a ``finally`` block after the result has
+    already been cached, and previously discarded the returned branch name.
+    """
+    import gptme.acp.client as acp_client
+
+    cli_main = importlib.import_module("gptme.cli.main")
+    logdir = tmp_path / "subagent-acp-branch"
+    monkeypatch.setattr(cli_main, "get_logdir", lambda name: logdir)
+
+    repo = _make_repo(tmp_path, "repo-acp-branch")
+
+    class FakeRunResult:
+        stop_reason = "end_turn"
+
+    class FakeAcpClient:
+        def __init__(self, *args, on_update=None, **kwargs):
+            self.on_update = on_update
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        async def run(self, prompt, cwd=None):
+            # Simulate the agent leaving uncommitted work in its worktree.
+            (Path(cwd) / "output.txt").write_text("acp agent result\n")
+            return FakeRunResult()
+
+    monkeypatch.setattr(acp_client, "GptmeAcpClient", FakeAcpClient)
+
+    subagent_api.subagent(
+        "acp-branch",
+        "test prompt",
+        use_acp=True,
+        isolation="worktree",
+        workdir=str(repo),
+    )
+
+    with _subagents_lock:
+        sa = next(s for s in _subagents if s.agent_id == "acp-branch")
+    assert sa.thread is not None
+    sa.thread.join(timeout=5)
+    assert not sa.thread.is_alive()
+
+    with _subagent_results_lock:
+        result = _subagent_results["acp-branch"]
+    assert result.status == "success"
+    assert result.result is not None
+    assert "Changes preserved on branch" in result.result, (
+        "Preserved branch must be patched onto the ACP result after cleanup"
+    )
+    assert "subagent-acp-branch-" in result.result
+    assert sa.worktree_path is not None
+    assert not sa.worktree_path.exists(), "Worktree directory should be cleaned up"

--- a/tests/test_subagent_worktree_isolation.py
+++ b/tests/test_subagent_worktree_isolation.py
@@ -578,3 +578,36 @@ def test_acp_cleanup_patches_branch_onto_cached_result(tmp_path, monkeypatch):
     assert "subagent-acp-branch-" in result.result
     assert sa.worktree_path is not None
     assert not sa.worktree_path.exists(), "Worktree directory should be cleaned up"
+
+
+def test_update_subagent_result_with_branch_skips_structured_results():
+    """update_subagent_result_with_branch() must not corrupt a JSON result string.
+
+    Regression test for a Greptile P1 finding: appending human-readable branch
+    text to a cached ``output_schema`` result (a JSON string) would make it
+    fail to parse for callers.
+    """
+    from gptme.tools.subagent.types import update_subagent_result_with_branch
+
+    with _subagent_results_lock:
+        _subagent_results["schema-agent"] = ReturnType(
+            "success", '{"summary": "done", "score": 5}'
+        )
+
+    update_subagent_result_with_branch(
+        "schema-agent", "subagent-schema-agent-abc123", has_output_schema=True
+    )
+
+    with _subagent_results_lock:
+        result = _subagent_results["schema-agent"]
+    assert result.result == '{"summary": "done", "score": 5}', (
+        "Structured result must be left untouched, not amended with branch text"
+    )
+
+    # Without output_schema, the branch is patched in as before.
+    update_subagent_result_with_branch(
+        "schema-agent", "subagent-schema-agent-abc123", has_output_schema=False
+    )
+    with _subagent_results_lock:
+        result = _subagent_results["schema-agent"]
+    assert "Changes preserved on branch" in (result.result or "")

--- a/tests/test_subagent_worktree_isolation.py
+++ b/tests/test_subagent_worktree_isolation.py
@@ -1,0 +1,444 @@
+"""Tests for subagent worktree isolation contract (issue #3190).
+
+Covers:
+- subagent(..., isolation="worktree") API
+- subagent_parallel([...], isolation="worktree") fan-out
+- Automatic cleanup on success and failure
+- Smart cleanup: branch preserved when changes exist, removed when unchanged
+- Concurrent agents don't clobber each other (isolation guarantee)
+
+Unit-style — mocks the LLM/execution layer; no real API calls needed.
+"""
+
+import importlib
+import subprocess
+from pathlib import Path
+
+import pytest
+
+import gptme.tools.subagent.api as subagent_api
+import gptme.tools.subagent.execution as subagent_execution
+from gptme.tools.subagent.api import subagent
+from gptme.tools.subagent.batch import subagent_parallel
+from gptme.tools.subagent.types import (
+    _subagent_results,
+    _subagent_results_lock,
+    _subagents,
+    _subagents_lock,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def reset_subagent_state():
+    """Clear global subagent state between tests."""
+    with _subagents_lock:
+        _subagents.clear()
+    with _subagent_results_lock:
+        _subagent_results.clear()
+    yield
+    with _subagents_lock:
+        _subagents.clear()
+    with _subagent_results_lock:
+        _subagent_results.clear()
+
+
+@pytest.fixture
+def git_repo(tmp_path: Path) -> Path:
+    """Minimal git repository for testing."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init"], cwd=repo, capture_output=True, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@test.com"],
+        cwd=repo,
+        capture_output=True,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"],
+        cwd=repo,
+        capture_output=True,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "checkout", "-b", "main"],
+        cwd=repo,
+        capture_output=True,
+        check=True,
+    )
+    (repo / "README.md").write_text("# Test\n")
+    subprocess.run(["git", "add", "."], cwd=repo, capture_output=True, check=True)
+    subprocess.run(
+        ["git", "commit", "--no-verify", "-m", "init"],
+        cwd=repo,
+        capture_output=True,
+        check=True,
+    )
+    return repo
+
+
+def _patch_subagent_env(monkeypatch, tmp_path):
+    """Patch the minimal set of imports so subagent() can run without real LLM/CLI."""
+    cli_main = importlib.import_module("gptme.cli.main")
+    llm_models = importlib.import_module("gptme.llm.models")
+
+    monkeypatch.setattr(cli_main, "get_logdir", lambda name: tmp_path / name)
+    monkeypatch.setattr(llm_models, "get_default_model", lambda: None)
+    monkeypatch.setattr(subagent_execution, "_create_subagent_thread", lambda **kw: None)
+    monkeypatch.setattr(subagent_api, "notify_completion", lambda *a, **kw: None)
+
+
+def _wait_for_agent(agent_id: str, timeout: float = 5.0) -> None:
+    with _subagents_lock:
+        sa = next((s for s in _subagents if s.agent_id == agent_id), None)
+    if sa and sa.thread:
+        sa.thread.join(timeout=timeout)
+
+
+# ---------------------------------------------------------------------------
+# isolation="worktree" parameter validation
+# ---------------------------------------------------------------------------
+
+
+def test_isolation_worktree_enables_isolated_flag(monkeypatch, tmp_path, git_repo):
+    """isolation='worktree' sets isolated=True and isolation_mode='worktree'."""
+    git_worktree = importlib.import_module("gptme.util.git_worktree")
+    created: list[Path] = []
+
+    monkeypatch.setattr(git_worktree, "get_git_root", lambda _: git_repo)
+    monkeypatch.setattr(
+        git_worktree,
+        "create_worktree",
+        lambda repo_path, branch_name=None, worktree_base=None: (
+            created.append(branch_name) or (tmp_path / "wts" / (branch_name or "wt"))
+        ),
+    )
+    monkeypatch.setattr(subagent_execution, "_cleanup_isolation", lambda sa: None)
+    _patch_subagent_env(monkeypatch, tmp_path)
+
+    subagent("iso-test", "do something", isolation="worktree", workdir=git_repo)
+    _wait_for_agent("iso-test")
+
+    with _subagents_lock:
+        sa = next((s for s in _subagents if s.agent_id == "iso-test"), None)
+
+    assert sa is not None
+    assert sa.isolated is True, "isolated must be True when isolation='worktree'"
+    assert sa.isolation_mode == "worktree", "isolation_mode must be 'worktree'"
+    assert created, "create_worktree should have been called"
+
+
+def test_isolation_unknown_value_raises():
+    """isolation with an unsupported string raises ValueError immediately."""
+    with pytest.raises(ValueError, match="Unknown isolation mode"):
+        subagent("bad-iso", "task", isolation="container")  # type: ignore[arg-type]
+
+
+def test_isolation_none_does_not_create_worktree(monkeypatch, tmp_path):
+    """Default (no isolation) never calls create_worktree."""
+    git_worktree = importlib.import_module("gptme.util.git_worktree")
+    create_calls: list = []
+
+    monkeypatch.setattr(
+        git_worktree,
+        "create_worktree",
+        lambda *a, **kw: create_calls.append(1) or tmp_path,
+    )
+    monkeypatch.setattr(subagent_execution, "_cleanup_isolation", lambda sa: None)
+    _patch_subagent_env(monkeypatch, tmp_path)
+
+    subagent("no-iso", "do something")
+    _wait_for_agent("no-iso")
+
+    assert not create_calls, "No worktree should be created without isolation parameter"
+
+
+# ---------------------------------------------------------------------------
+# subagent_parallel isolation="worktree" fan-out
+# ---------------------------------------------------------------------------
+
+
+def test_subagent_parallel_isolation_worktree_creates_per_agent_worktree(
+    monkeypatch, tmp_path, git_repo
+):
+    """subagent_parallel(isolation='worktree') gives each agent its own worktree."""
+    git_worktree = importlib.import_module("gptme.util.git_worktree")
+    created: list[str] = []
+
+    def fake_create(repo_path, branch_name=None, worktree_base=None):
+        created.append(branch_name or "unnamed")
+        wt = tmp_path / "wts" / (branch_name or "unnamed")
+        wt.mkdir(parents=True, exist_ok=True)
+        return wt
+
+    monkeypatch.setattr(git_worktree, "get_git_root", lambda _: git_repo)
+    monkeypatch.setattr(git_worktree, "create_worktree", fake_create)
+    monkeypatch.setattr(subagent_execution, "_cleanup_isolation", lambda sa: None)
+    _patch_subagent_env(monkeypatch, tmp_path)
+
+    # Patch subagent_wait so the parallel call doesn't block waiting for real work
+    monkeypatch.setattr(
+        "gptme.tools.subagent.batch.subagent_wait",
+        lambda agent_id, **kw: {"status": "success", "result": "done"},
+    )
+
+    tasks = [("agent-x", "task x"), ("agent-y", "task y")]
+    subagent_parallel(tasks, isolation="worktree", workdir=git_repo)
+
+    assert len(created) == len(tasks), (
+        f"Expected {len(tasks)} worktrees created, got {len(created)}"
+    )
+    # Branch names should be distinct
+    assert len(set(created)) == len(tasks), "Each agent should get a distinct worktree branch"
+
+
+# ---------------------------------------------------------------------------
+# Automatic cleanup contract
+# ---------------------------------------------------------------------------
+
+
+def test_cleanup_called_after_thread_completes(monkeypatch, tmp_path, git_repo):
+    """_cleanup_isolation is called when the thread finishes normally."""
+    git_worktree = importlib.import_module("gptme.util.git_worktree")
+    cleanup_calls: list[str] = []
+
+    monkeypatch.setattr(git_worktree, "get_git_root", lambda _: git_repo)
+    monkeypatch.setattr(
+        git_worktree,
+        "create_worktree",
+        lambda repo, branch_name=None, worktree_base=None: (
+            tmp_path / "wts" / (branch_name or "wt")
+        ),
+    )
+
+    orig_cleanup = subagent_execution._cleanup_isolation
+
+    def recording_cleanup(sa):
+        cleanup_calls.append(sa.agent_id)
+
+    monkeypatch.setattr(subagent_execution, "_cleanup_isolation", recording_cleanup)
+    _patch_subagent_env(monkeypatch, tmp_path)
+
+    subagent("cleanup-agent", "do something", isolation="worktree", workdir=git_repo)
+    _wait_for_agent("cleanup-agent")
+
+    assert "cleanup-agent" in cleanup_calls, (
+        "_cleanup_isolation was not called after subagent thread completed"
+    )
+
+
+def test_cleanup_called_when_thread_raises(monkeypatch, tmp_path, git_repo):
+    """_cleanup_isolation is called even when the subagent thread raises an exception."""
+    git_worktree = importlib.import_module("gptme.util.git_worktree")
+    cleanup_calls: list[str] = []
+
+    monkeypatch.setattr(git_worktree, "get_git_root", lambda _: git_repo)
+    monkeypatch.setattr(
+        git_worktree,
+        "create_worktree",
+        lambda repo, branch_name=None, worktree_base=None: (
+            tmp_path / "wts" / (branch_name or "wt")
+        ),
+    )
+    monkeypatch.setattr(
+        subagent_execution,
+        "_create_subagent_thread",
+        lambda **kw: (_ for _ in ()).throw(RuntimeError("simulated subagent failure")),
+    )
+    monkeypatch.setattr(subagent_api, "notify_completion", lambda *a, **kw: None)
+
+    cli_main = importlib.import_module("gptme.cli.main")
+    llm_models = importlib.import_module("gptme.llm.models")
+    monkeypatch.setattr(cli_main, "get_logdir", lambda name: tmp_path / name)
+    monkeypatch.setattr(llm_models, "get_default_model", lambda: None)
+
+    def recording_cleanup(sa):
+        cleanup_calls.append(sa.agent_id)
+
+    monkeypatch.setattr(subagent_execution, "_cleanup_isolation", recording_cleanup)
+
+    subagent("exc-agent", "will fail", isolation="worktree", workdir=git_repo)
+    _wait_for_agent("exc-agent")
+
+    assert "exc-agent" in cleanup_calls, (
+        "_cleanup_isolation was not called after subagent thread raised"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Smart cleanup — branch preserved vs deleted based on changes
+# ---------------------------------------------------------------------------
+
+
+def _make_repo(tmp_path: Path, name: str) -> Path:
+    """Create a minimal git repo with one commit."""
+    repo = tmp_path / name
+    repo.mkdir()
+    for cmd in [
+        ["git", "init"],
+        ["git", "config", "user.email", "t@t.com"],
+        ["git", "config", "user.name", "T"],
+        ["git", "checkout", "-b", "main"],
+    ]:
+        subprocess.run(cmd, cwd=repo, capture_output=True, check=True)
+    (repo / "README.md").write_text("init\n")
+    subprocess.run(["git", "add", "."], cwd=repo, capture_output=True, check=True)
+    subprocess.run(
+        ["git", "commit", "--no-verify", "-m", "init"],
+        cwd=repo,
+        capture_output=True,
+        check=True,
+    )
+    return repo
+
+
+def test_smart_cleanup_preserves_branch_when_worktree_has_changes(tmp_path):
+    """isolation_mode='worktree': branch kept (and returned) when worktree has changes."""
+    from gptme.tools.subagent.types import Subagent
+    from gptme.util.git_worktree import create_worktree
+
+    repo = _make_repo(tmp_path, "repo-dirty")
+    wt = create_worktree(repo, branch_name="dirty-agent-wt", worktree_base=tmp_path / "wts")
+
+    # Dirty the worktree (uncommitted change)
+    (wt / "output.txt").write_text("agent result\n")
+
+    sa = Subagent(
+        agent_id="dirty-agent",
+        prompt="task",
+        thread=None,
+        logdir=tmp_path / "log",
+        model=None,
+        isolated=True,
+        isolation_mode="worktree",
+        worktree_path=wt,
+        repo_path=repo,
+    )
+
+    preserved = subagent_execution._cleanup_isolation(sa)
+
+    assert not wt.exists(), "Working tree directory should be removed"
+    assert preserved == "dirty-agent-wt", "Branch name should be returned when changes exist"
+
+    result = subprocess.run(
+        ["git", "branch", "--list", "dirty-agent-wt"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert "dirty-agent-wt" in result.stdout, "Branch should still exist in the repo"
+
+    # Cleanup the preserved branch
+    subprocess.run(
+        ["git", "branch", "-D", "dirty-agent-wt"],
+        cwd=repo,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_smart_cleanup_removes_branch_when_worktree_is_clean(tmp_path):
+    """isolation_mode='worktree': branch and directory removed when worktree is unchanged."""
+    from gptme.tools.subagent.types import Subagent
+    from gptme.util.git_worktree import create_worktree
+
+    repo = _make_repo(tmp_path, "repo-clean")
+    wt = create_worktree(repo, branch_name="clean-agent-wt", worktree_base=tmp_path / "wts")
+
+    sa = Subagent(
+        agent_id="clean-agent",
+        prompt="task",
+        thread=None,
+        logdir=tmp_path / "log",
+        model=None,
+        isolated=True,
+        isolation_mode="worktree",
+        worktree_path=wt,
+        repo_path=repo,
+    )
+
+    preserved = subagent_execution._cleanup_isolation(sa)
+
+    assert not wt.exists(), "Working tree directory should be removed"
+    assert preserved is None, "No branch should be preserved when worktree is clean"
+
+    result = subprocess.run(
+        ["git", "branch", "--list", "clean-agent-wt"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert "clean-agent-wt" not in result.stdout, "Branch should be deleted (no changes)"
+
+
+def test_legacy_isolated_bool_always_does_full_cleanup(tmp_path):
+    """isolated=True without isolation_mode always removes both dir and branch."""
+    from gptme.tools.subagent.types import Subagent
+    from gptme.util.git_worktree import create_worktree
+
+    repo = _make_repo(tmp_path, "repo-legacy")
+    wt = create_worktree(repo, branch_name="legacy-wt", worktree_base=tmp_path / "wts")
+
+    # Make the worktree dirty
+    (wt / "file.txt").write_text("changed\n")
+
+    sa = Subagent(
+        agent_id="legacy-agent",
+        prompt="task",
+        thread=None,
+        logdir=tmp_path / "log",
+        model=None,
+        isolated=True,
+        isolation_mode=None,  # legacy: no string mode → full cleanup regardless
+        worktree_path=wt,
+        repo_path=repo,
+    )
+
+    preserved = subagent_execution._cleanup_isolation(sa)
+
+    assert not wt.exists(), "Working tree should be removed"
+    assert preserved is None, "Legacy isolated=True should always do full cleanup"
+
+    result = subprocess.run(
+        ["git", "branch", "--list", "legacy-wt"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert "legacy-wt" not in result.stdout, "Branch should be deleted in legacy mode"
+
+
+# ---------------------------------------------------------------------------
+# Isolation guarantee: concurrent agents don't clobber each other
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_worktrees_are_isolated(tmp_path):
+    """Files written by agent A are not visible in agent B's worktree."""
+    from gptme.util.git_worktree import cleanup_worktree, create_worktree
+
+    repo = _make_repo(tmp_path, "repo-concurrent")
+    base = tmp_path / "wts"
+
+    wt_a = create_worktree(repo, branch_name="agent-a", worktree_base=base)
+    wt_b = create_worktree(repo, branch_name="agent-b", worktree_base=base)
+
+    try:
+        (wt_a / "a_output.txt").write_text("from A\n")
+        (wt_b / "b_output.txt").write_text("from B\n")
+
+        assert not (wt_a / "b_output.txt").exists(), "A should not see B's file"
+        assert not (wt_b / "a_output.txt").exists(), "B should not see A's file"
+        assert not (repo / "a_output.txt").exists(), "Main repo unaffected by A"
+        assert not (repo / "b_output.txt").exists(), "Main repo unaffected by B"
+    finally:
+        cleanup_worktree(wt_a, repo)
+        cleanup_worktree(wt_b, repo)


### PR DESCRIPTION
## Summary

Implements the `isolation="worktree"` string parameter API requested in #3190.

- **`subagent(..., isolation="worktree")`** — string-based API for single subagent worktree isolation
- **`subagent_parallel([...], isolation="worktree")`** — fan-out where each agent gets its own worktree
- **Smart cleanup**: worktrees with no local changes are auto-removed (dir + branch); worktrees with local changes keep their branch so the orchestrator can inspect or merge it
- **No leaked worktrees**: cleanup fires in both success and exception paths
- **Legacy `isolated=True` unchanged**: still supported, still does full cleanup regardless of changes

### API

```python
# Single agent — string API (preferred for new code)
subagent("impl", "Add feature X", isolation="worktree")

# Fan-out — each agent gets its own isolated copy
results = subagent_parallel(
    [("fix-a", "Fix bug in A"), ("fix-b", "Fix bug in B")],
    isolation="worktree",
)

# Smart cleanup: if the agent committed changes, the branch name is logged:
# "Subagent 'impl': changes preserved on branch 'subagent-impl-abc123' — merge with: git merge subagent-impl-abc123"
```

## Changes

- `gptme/util/git_worktree.py`: new `has_changes()` function (checks uncommitted changes + reflog-based committed detection); `cleanup_worktree()` gains `keep_branch_if_changed` param
- `gptme/tools/subagent/types.py`: `isolation_mode: str | None` field on `Subagent`
- `gptme/tools/subagent/execution.py`: `_cleanup_isolation()` uses smart cleanup when `isolation_mode == "worktree"`
- `gptme/tools/subagent/api.py`: `isolation: Literal["worktree"] | None` parameter with validation
- `gptme/tools/subagent/batch.py`: `isolation` forwarded through `subagent_parallel()`
- `gptme/tools/subagent/__init__.py`: tool description updated

## Test plan

- [x] `tests/test_git_worktree.py` — 6 new tests: `has_changes()` (clean/uncommitted/committed), smart cleanup preserve/remove, two-worktree isolation
- [x] `tests/test_subagent_worktree_isolation.py` — 10 new tests covering full isolation contract: API parameter sets flags, unknown value raises, no-isolation skips worktree, parallel fan-out creates one worktree per agent, cleanup called on success, cleanup called on exception, smart cleanup preserves branch when dirty, smart cleanup removes branch when clean, legacy `isolated=True` always does full cleanup, concurrent worktrees don't see each other's files
- [x] `tests/test_subagent_unit.py` — 233 existing tests all pass (no regressions)

Closes #3190