### PR TITLE
feat(computer): add triple_click action and fill_native helper for native field filling

### DIFF
--- a/gptme/cli/cmd_computer.py
+++ b/gptme/cli/cmd_computer.py
@@ -104,6 +104,7 @@ def _extract_computer_calls(messages) -> list[dict]:
     - ``click_element(selector)`` — DOM element click
     - ``hover_element(selector)`` — hover over a DOM element
     - ``fill_element(selector, value)`` — form fill (value length logged, not raw text)
+    - ``fill_native(coordinate, text)`` — native field fill (triple-click + type; text length logged)
     - ``press_key(key)`` — navigation key press (Enter, Tab, Escape, …)
     - ``select_option(selector, value)`` — dropdown/select element change
     - ``wait_for_element(selector)`` — wait for a DOM element to appear
@@ -261,6 +262,29 @@ def _extract_computer_calls(messages) -> list[dict]:
                 )
                 for m in re.finditer(
                     r"""\bfill_element\s*\(\s*(?:'([^']*)'|"([^"]*)")\s*,\s*(?:'([^']*)'|"([^"]*)")""",
+                    code,
+                )
+            )
+
+            # fill_native(coordinate, text) — native field fill; text is sensitive.
+            # The coordinate arg may contain a comma (e.g. (300, 200)), so the
+            # pattern uses (?:\([^)]*\)|[^,])+ to consume a parenthesised tuple
+            # or non-comma chars before matching the text argument.
+            all_positioned.extend(
+                (
+                    m.start(),
+                    {
+                        "timestamp": ts,
+                        "action": "fill_native",
+                        "source": "computer",
+                        "value_len": len(
+                            m.group(1) if m.group(1) is not None else (m.group(2) or "")
+                        ),
+                        "risk_level": action_risk_level("fill_native"),
+                    },
+                )
+                for m in re.finditer(
+                    r"""\bfill_native\s*\((?:\([^)]*\)|[^,])+,\s*(?:'([^']*)'|"([^"]*)")""",
                     code,
                 )
             )

--- a/gptme/cli/cmd_computer.py
+++ b/gptme/cli/cmd_computer.py
@@ -270,6 +270,7 @@ def _extract_computer_calls(messages) -> list[dict]:
             # The coordinate arg may contain a comma (e.g. (300, 200)), so the
             # pattern uses (?:\([^)]*\)|[^,])+ to consume a parenthesised tuple
             # or non-comma chars before matching the text argument.
+            # Also handle keyword-arg form (text=...) and variable args (value_len=None).
             all_positioned.extend(
                 (
                     m.start(),
@@ -278,13 +279,15 @@ def _extract_computer_calls(messages) -> list[dict]:
                         "action": "fill_native",
                         "source": "computer",
                         "value_len": len(
-                            m.group(1) if m.group(1) is not None else (m.group(2) or "")
-                        ),
+                            m.group(1) if m.group(1) is not None else m.group(2)
+                        )
+                        if (m.group(1) is not None or m.group(2) is not None)
+                        else None,
                         "risk_level": action_risk_level("fill_native"),
                     },
                 )
                 for m in re.finditer(
-                    r"""\bfill_native\s*\((?:\([^)]*\)|[^,])+,\s*(?:'([^']*)'|"([^"]*)")""",
+                    r"""\bfill_native\s*\((?:\([^)]*\)|[^,])+,\s*(?:text\s*=\s*)?(?:'([^']*)'|"([^"]*)"|\w+)""",
                     code,
                 )
             )

--- a/gptme/cli/cmd_computer.py
+++ b/gptme/cli/cmd_computer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ast as _ast
 import json
 import os
 import re
@@ -267,30 +268,41 @@ def _extract_computer_calls(messages) -> list[dict]:
             )
 
             # fill_native(coordinate, text) — native field fill; text is sensitive.
-            # The coordinate arg may contain a comma (e.g. (300, 200)), so the
-            # pattern uses (?:\([^)]*\)|[^,])+ to consume a parenthesised tuple
-            # or non-comma chars before matching the text argument.
-            # Also handle keyword-arg form (text=...) and variable args (value_len=None).
-            all_positioned.extend(
-                (
-                    m.start(),
-                    {
-                        "timestamp": ts,
-                        "action": "fill_native",
-                        "source": "computer",
-                        "value_len": len(
-                            m.group(1) if m.group(1) is not None else m.group(2)
-                        )
-                        if (m.group(1) is not None or m.group(2) is not None)
-                        else None,
-                        "risk_level": action_risk_level("fill_native"),
-                    },
+            # Use _slice_call + ast.parse to handle all valid text forms:
+            # triple-quoted strings, escaped quotes, variables, keyword args.
+            for m in re.finditer(r"\bfill_native\s*\(", code):
+                call_src = _slice_call(code, m.start())
+                value_len: int | None = None
+                try:
+                    tree = _ast.parse(call_src, mode="eval")
+                    call_node = tree.body
+                    if isinstance(call_node, _ast.Call):
+                        text_node = None
+                        if len(call_node.args) >= 2:
+                            text_node = call_node.args[1]
+                        else:
+                            for kw in call_node.keywords:
+                                if kw.arg == "text":
+                                    text_node = kw.value
+                                    break
+                        if isinstance(text_node, _ast.Constant) and isinstance(
+                            text_node.value, str
+                        ):
+                            value_len = len(text_node.value)
+                except (SyntaxError, AttributeError, TypeError):
+                    pass
+                all_positioned.append(
+                    (
+                        m.start(),
+                        {
+                            "timestamp": ts,
+                            "action": "fill_native",
+                            "source": "computer",
+                            "value_len": value_len,
+                            "risk_level": action_risk_level("fill_native"),
+                        },
+                    )
                 )
-                for m in re.finditer(
-                    r"""\bfill_native\s*\((?:\([^)]*\)|[^,])+,\s*(?:text\s*=\s*)?(?:'([^']*)'|"([^"]*)"|\w+)""",
-                    code,
-                )
-            )
 
             # No-argument browser observation functions
             # (read_page_text, snapshot_page, get_current_url)

--- a/gptme/profiles.py
+++ b/gptme/profiles.py
@@ -190,6 +190,8 @@ BUILTIN_PROFILES: dict[str, Profile] = {
             "- Fall back to `computer('left_click', coordinate=(x, y))` only when the app lacks accessibility support (games, canvas UIs, electron apps)\n"
             "- Use `act_and_observe('window_focus', text='pattern')` (not bare `computer('window_focus', ...)`) before acting on newly-opened windows — the automatic `wait_for_change` ensures the app has rendered its UI before you type\n"
             "- Use `computer('scroll', coordinate=(x,y), text='down')` when the interface is only exposed through a native viewport\n"
+            "- Use `computer('triple_click', coordinate=(x, y))` to select all text in a native field before replacing it\n"
+            "- Use `fill_native((x, y), text)` as a single-call shortcut to replace text in a native field — equivalent to `fill_element(selector, value)` for DOM targets\n"
             "\n"
             "## Efficiency rules\n"
             "- Use `observe_web(url)` for web — structured ARIA snapshot with no vision tokens\n"

--- a/gptme/tools/_computer_gate.py
+++ b/gptme/tools/_computer_gate.py
@@ -68,6 +68,7 @@ ACTION_RISK_WRITE: frozenset[str] = frozenset(
         "right_click",
         "middle_click",
         "double_click",
+        "triple_click",
         "mouse_move",
         "scroll",
         "window_focus",
@@ -90,6 +91,8 @@ ACTION_RISK_SENSITIVE: frozenset[str] = frozenset(
         "left_click_drag",
         # browser
         "fill_element",
+        # high-level wrappers that handle text input
+        "fill_native",
     }
 )
 

--- a/gptme/tools/computer.py
+++ b/gptme/tools/computer.py
@@ -54,6 +54,7 @@ Mouse:
     - right_click: Click right mouse button
     - middle_click: Click middle mouse button
     - double_click: Double click left mouse button
+    - triple_click: Triple click at position (selects all text in most native inputs; use with coordinate to click a field)
     - left_click_drag: Click and drag to coordinates
 
 Screen:
@@ -244,6 +245,7 @@ Action = Literal[
     "right_click",
     "middle_click",
     "double_click",
+    "triple_click",
     "scroll",
     "screenshot",
     "cursor_position",
@@ -1410,7 +1412,13 @@ def _dispatch_transport(
             print(f"Dragged to {x},{y}")
         return None
 
-    click_actions = {"left_click", "right_click", "middle_click", "double_click"}
+    click_actions = {
+        "left_click",
+        "right_click",
+        "middle_click",
+        "double_click",
+        "triple_click",
+    }
     if action in click_actions:
         if coordinate:
             x, y = coordinate
@@ -1420,6 +1428,7 @@ def _dispatch_transport(
             "right_click": transport.right_click,
             "middle_click": transport.middle_click,
             "double_click": transport.double_click,
+            "triple_click": transport.triple_click,
         }[action]
         click_fn()
         print(f"Performed {action}")
@@ -1637,6 +1646,55 @@ def computer(
         else:
             _run_xdotool("click --repeat 2 --delay 100 1", display)
         print("Performed double_click")
+        return None
+    if action == "triple_click":
+        if coordinate:
+            sx, sy = _scale_coordinates(
+                _ScalingSource.API, coordinate[0], coordinate[1], width, height
+            )
+            if IS_MACOS:
+                try:
+                    subprocess.run(
+                        ["cliclick", f"tc:{sx},{sy}"],
+                        check=True,
+                        capture_output=True,
+                        text=True,
+                        timeout=10,
+                    )
+                except subprocess.TimeoutExpired as e:
+                    raise RuntimeError("cliclick triple-click timed out") from e
+                except subprocess.CalledProcessError as e:
+                    raise RuntimeError(f"Failed to triple-click: {e.stderr}") from e
+            else:
+                _run_xdotool(
+                    f"mousemove --sync {sx} {sy} click --repeat 3 --delay 100 1",
+                    display,
+                )
+        else:
+            if IS_MACOS:
+                try:
+                    result = subprocess.run(
+                        ["cliclick", "p"],
+                        check=True,
+                        capture_output=True,
+                        text=True,
+                        timeout=10,
+                    )
+                    pos = result.stdout.strip()
+                    subprocess.run(
+                        ["cliclick", f"tc:{pos}"],
+                        check=True,
+                        capture_output=True,
+                        text=True,
+                        timeout=10,
+                    )
+                except subprocess.TimeoutExpired as e:
+                    raise RuntimeError("cliclick triple-click timed out") from e
+                except subprocess.CalledProcessError as e:
+                    raise RuntimeError(f"Failed to triple-click: {e.stderr}") from e
+            else:
+                _run_xdotool("click --repeat 3 --delay 100 1", display)
+        print("Performed triple_click")
         return None
     if action in ("left_click", "right_click", "middle_click"):
         click_map = {
@@ -2040,7 +2098,7 @@ Common modifiers (ctrl, alt, cmd/super, shift) work consistently across platform
 
 ### Observation helpers (structured-first policy)
 
-Three higher-level helpers are available that implement the structured-first observation policy:
+Higher-level helpers are available that implement the structured-first observation policy:
 
 - ``observe_web(url, screenshot_too=False)`` — observe a web page using ARIA snapshots first
   (no vision tokens), with automatic fallback to a browser screenshot, then desktop screenshot.
@@ -2052,6 +2110,10 @@ Three higher-level helpers are available that implement the structured-first obs
   ``wait_for_change`` in one call — the complete "act then look" loop without separate
   screenshot calls. Use this for tight interaction loops where you want to see the screen
   after every click, keypress, or scroll.
+- ``fill_native(coordinate, text)`` — replace text in a native (non-browser) text field in one
+  call. Triple-clicks to select all existing text, then types the replacement. The native
+  equivalent of ``fill_element(selector, value)`` for DOM targets. Use when the target is a
+  native app input (terminal, dialog, form) rather than a web page.
 - ``computer_task(task, timeout=300, model=None)`` — run a multi-step computer-use task
   in a **context-isolated subagent** and block until done. All screenshots and intermediate
   steps are kept inside the subagent's own context — the caller's context stays lean. Use
@@ -2190,6 +2252,43 @@ def observe_desktop() -> Message | None:
         # Equivalent to computer("screenshot"), but signals intent clearly.
     """
     return computer("screenshot")
+
+
+def fill_native(coordinate: tuple[int, int], text: str) -> list[Message]:
+    """Fill a native (non-browser) text field by clicking, selecting all, and typing.
+
+    Use this to replace the content of a native text input with new text —
+    equivalent to ``fill_element(selector, value)`` for web targets, but for
+    native desktop/X11/macOS apps.
+
+    The sequence is: triple-click to select all existing text, then type the
+    replacement text.  No separate ctrl+a step is needed.
+
+    Args:
+        coordinate: X,Y coordinates of the text field (in API space).
+        text: Replacement text to type into the field.
+
+    Returns:
+        List of :class:`~gptme.message.Message` objects from the operations.
+
+    Example (from IPython in a computer-use session)::
+
+        # Replace the URL bar text in a browser window
+        msgs = fill_native((400, 50), "https://example.com")
+
+        # Fill a login field in a native app
+        msgs = fill_native((300, 200), "username@example.com")
+    """
+    messages: list[Message] = []
+    # Triple-click selects all text in the field (works in most native text inputs)
+    result = computer("triple_click", coordinate=coordinate)
+    if result is not None:
+        messages.append(result)
+    # Type the replacement text (overwrites the selected content)
+    result = computer("type", text=text)
+    if result is not None:
+        messages.append(result)
+    return messages
 
 
 class ScreenRecording:
@@ -2699,6 +2798,18 @@ User: Open Firefox, go to https://x.com/compose/tweet, type "Hello from gptme!" 
 Assistant: I'll delegate this to computer_task() so all the intermediate screenshots stay in a subagent context rather than here.
 {ToolUse("ipython", [], _COMPUTER_TASK_TWEET_EXAMPLE).to_output(tool_format)}
 System: {{"status": "success", "result": "Tweet submitted successfully. Firefox opened, x.com/compose/tweet loaded, typed the message, clicked Tweet. Confirmed tweet posted.", "agent_id": "computer-task-a1b2c3d4"}}
+
+User: Replace the text in the URL bar of the browser window with "https://example.com"
+Assistant: I'll use fill_native to triple-click the URL bar to select all text, then type the new URL.
+{ToolUse("ipython", [], 'fill_native((760, 45), "https://example.com")').to_output(tool_format)}
+System: Performed triple_click
+Typed text: https://example.com
+
+User: Fill the "Username" field at (300, 200) in this native login dialog
+Assistant: I'll use fill_native to replace whatever is in the field with the username.
+{ToolUse("ipython", [], 'fill_native((300, 200), "alice@example.com")').to_output(tool_format)}
+System: Performed triple_click
+Typed text: alice@example.com
 """
 
     # Platform-specific keyboard shortcut examples
@@ -2736,6 +2847,7 @@ tool = ToolSpec(
         ToolFunction.from_callable(observe_web),
         ToolFunction.from_callable(observe_desktop),
         ToolFunction.from_callable(act_and_observe),
+        ToolFunction.from_callable(fill_native),
         ToolFunction.from_callable(computer_task),
         ToolFunction.from_callable(record_screen),
         ToolFunction.from_callable(start_recording),

--- a/gptme/tools/computer.py
+++ b/gptme/tools/computer.py
@@ -2270,17 +2270,16 @@ def fill_native(coordinate: tuple[int, int], text: str) -> list[Message]:
         Verify the field type before using this helper in those contexts.
 
     .. note::
-        Native transport actions do not return a screenshot, so this function
-        typically returns an empty list.  Call ``observe_desktop()`` afterwards
-        to confirm the fill succeeded.
+        A screenshot is always captured after the fill so callers can observe
+        the field state and detect partial or failed replacements.
 
     Args:
         coordinate: X,Y coordinates of the text field (in API space).
         text: Replacement text to type into the field.
 
     Returns:
-        List of :class:`~gptme.message.Message` objects from the operations
-        (usually empty for native targets; call ``observe_desktop()`` to verify).
+        List of :class:`~gptme.message.Message` objects — usually a single
+        screenshot message showing the field state after the fill.
 
     Example (from IPython in a computer-use session)::
 
@@ -2299,6 +2298,11 @@ def fill_native(coordinate: tuple[int, int], text: str) -> list[Message]:
     result = computer("type", text=text)
     if result is not None:
         messages.append(result)
+    # Capture a post-fill screenshot so callers can observe the field state
+    # and detect partial or failed replacements before continuing.
+    observation = computer("screenshot")
+    if observation is not None:
+        messages.append(observation)
     return messages
 
 

--- a/gptme/tools/computer.py
+++ b/gptme/tools/computer.py
@@ -2264,12 +2264,23 @@ def fill_native(coordinate: tuple[int, int], text: str) -> list[Message]:
     The sequence is: triple-click to select all existing text, then type the
     replacement text.  No separate ctrl+a step is needed.
 
+    .. note::
+        Triple-click selects all text in *most* single-line native inputs, but
+        may select only a word or line in terminals and multi-line text widgets.
+        Verify the field type before using this helper in those contexts.
+
+    .. note::
+        Native transport actions do not return a screenshot, so this function
+        typically returns an empty list.  Call ``observe_desktop()`` afterwards
+        to confirm the fill succeeded.
+
     Args:
         coordinate: X,Y coordinates of the text field (in API space).
         text: Replacement text to type into the field.
 
     Returns:
-        List of :class:`~gptme.message.Message` objects from the operations.
+        List of :class:`~gptme.message.Message` objects from the operations
+        (usually empty for native targets; call ``observe_desktop()`` to verify).
 
     Example (from IPython in a computer-use session)::
 

--- a/gptme/tools/computer_transport.py
+++ b/gptme/tools/computer_transport.py
@@ -77,6 +77,17 @@ class ComputerTransport(abc.ABC):
         """Double-click left mouse button at current position."""
         ...
 
+    def triple_click(self) -> None:
+        """Triple-click left mouse button at current position.
+
+        Selects all text in most native text inputs.
+        Not all transports support triple-click natively; the default falls
+        back to three rapid left_click calls.
+        """
+        self.left_click()
+        self.left_click()
+        self.left_click()
+
     @abc.abstractmethod
     def left_click_drag(self, x: int, y: int) -> None:
         """Click and drag from current position to (x, y)."""

--- a/gptme/tools/computer_transport.py
+++ b/gptme/tools/computer_transport.py
@@ -86,16 +86,18 @@ class ComputerTransport(abc.ABC):
 
         For transports that require an explicit cursor position (e.g. CUA),
         the fallback queries ``cursor_position()`` to anchor the cursor with
-        a ``mouse_move`` before clicking.  If the transport cannot report the
-        current position, the fallback will raise from ``left_click()`` with a
-        clear message.  Pass a ``coordinate`` to the top-level
-        ``computer('triple_click', coordinate=...)`` call to move to a specific
-        position instead.
+        a ``mouse_move`` before clicking.  If the transport raises
+        ``RuntimeError`` (e.g. CUA transport before any ``mouse_move``), that
+        error propagates immediately.  Pass a ``coordinate`` to the top-level
+        ``computer('triple_click', coordinate=...)`` call to avoid this.
+        Transports that do not implement ``cursor_position`` at all
+        (``NotImplementedError`` / ``AttributeError``) proceed directly to the
+        three ``left_click`` calls.
         """
         try:
             x, y = self.cursor_position()
             self.mouse_move(x, y)
-        except (RuntimeError, NotImplementedError, AttributeError):
+        except (NotImplementedError, AttributeError):
             pass
         self.left_click()
         self.left_click()

--- a/gptme/tools/computer_transport.py
+++ b/gptme/tools/computer_transport.py
@@ -83,6 +83,13 @@ class ComputerTransport(abc.ABC):
         Selects all text in most native text inputs.
         Not all transports support triple-click natively; the default falls
         back to three rapid left_click calls.
+
+        .. note::
+            Transports that require an explicit cursor position (e.g. CUA) must
+            have had a prior ``mouse_move`` call; otherwise the fallback
+            ``left_click`` calls will fail.  Pass a ``coordinate`` to the
+            top-level ``computer('triple_click', coordinate=...)`` call to
+            ensure ``mouse_move`` is issued automatically.
         """
         self.left_click()
         self.left_click()

--- a/gptme/tools/computer_transport.py
+++ b/gptme/tools/computer_transport.py
@@ -84,13 +84,19 @@ class ComputerTransport(abc.ABC):
         Not all transports support triple-click natively; the default falls
         back to three rapid left_click calls.
 
-        .. note::
-            Transports that require an explicit cursor position (e.g. CUA) must
-            have had a prior ``mouse_move`` call; otherwise the fallback
-            ``left_click`` calls will fail.  Pass a ``coordinate`` to the
-            top-level ``computer('triple_click', coordinate=...)`` call to
-            ensure ``mouse_move`` is issued automatically.
+        For transports that require an explicit cursor position (e.g. CUA),
+        the fallback queries ``cursor_position()`` to anchor the cursor with
+        a ``mouse_move`` before clicking.  If the transport cannot report the
+        current position, the fallback will raise from ``left_click()`` with a
+        clear message.  Pass a ``coordinate`` to the top-level
+        ``computer('triple_click', coordinate=...)`` call to move to a specific
+        position instead.
         """
+        try:
+            x, y = self.cursor_position()
+            self.mouse_move(x, y)
+        except (RuntimeError, NotImplementedError, AttributeError):
+            pass
         self.left_click()
         self.left_click()
         self.left_click()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -287,7 +287,8 @@ def cleanup_subagents_after():
     finally:
         # Always reset shared state so subsequent tests start clean,
         # even if the join/terminate phase above was interrupted.
-        _subagents.clear()
+        with _subagents_lock:
+            _subagents.clear()
         # Clear cached terminal results too; many tests intentionally reuse agent IDs
         # like "explorer"/"checker", and the queued-cancel guards now treat a stale
         # cached result as "already completed" and skip the new launch.

--- a/tests/test_computer_actions.py
+++ b/tests/test_computer_actions.py
@@ -24,6 +24,7 @@ from gptme.tools.computer import (
     _dispatch_transport,
     _poll_for_change,
     act_and_observe,
+    fill_native,
     observe_desktop,
     observe_web,
 )
@@ -616,3 +617,96 @@ class TestActAndObservePreBaseline:
             "fallback path must call computer('wait_for_change') when no transport"
         )
         assert settled_msg in msgs
+
+
+# ---------------------------------------------------------------------------
+# TestTripleClick
+# ---------------------------------------------------------------------------
+
+
+class TestTripleClick:
+    """Tests for the triple_click action via the mock transport."""
+
+    def test_triple_click_dispatches_to_transport(self):
+        """triple_click must call transport.triple_click()."""
+        transport = MagicMock(spec=ComputerTransport)
+        _dispatch_transport(transport, "triple_click", None, None)
+        transport.triple_click.assert_called_once()
+
+    def test_triple_click_with_coordinate_moves_then_clicks(self):
+        """triple_click with coordinate must move mouse first, then triple_click."""
+        transport = MagicMock(spec=ComputerTransport)
+        _dispatch_transport(transport, "triple_click", None, (100, 200))
+        transport.mouse_move.assert_called_once_with(100, 200)
+        transport.triple_click.assert_called_once()
+
+    def test_triple_click_no_coordinate_skips_mouse_move(self):
+        """triple_click without coordinate must NOT move the mouse first."""
+        transport = MagicMock(spec=ComputerTransport)
+        _dispatch_transport(transport, "triple_click", None, None)
+        transport.mouse_move.assert_not_called()
+        transport.triple_click.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# TestFillNative
+# ---------------------------------------------------------------------------
+
+
+class TestFillNative:
+    """Tests for fill_native() — click, select-all, type sequence."""
+
+    def test_fill_native_calls_triple_click_then_type(self):
+        """fill_native must call triple_click then type in sequence."""
+        calls: list[tuple] = []
+
+        def mock_computer(action, text=None, coordinate=None):
+            calls.append((action, coordinate, text))
+            return
+
+        with patch("gptme.tools.computer.computer", side_effect=mock_computer):
+            fill_native((300, 200), "new text")
+
+        assert len(calls) == 2, f"Expected 2 calls, got {len(calls)}: {calls}"
+        assert calls[0] == ("triple_click", (300, 200), None), (
+            f"First call should be triple_click with coordinate, got {calls[0]}"
+        )
+        assert calls[1][0] == "type", f"Second call should be type, got {calls[1][0]}"
+        assert calls[1][2] == "new text", (
+            f"type call should carry the replacement text, got {calls[1][2]}"
+        )
+
+    def test_fill_native_returns_list(self):
+        """fill_native always returns a list (empty when computer returns None)."""
+        with patch("gptme.tools.computer.computer", return_value=None):
+            result = fill_native((100, 100), "hello")
+        assert isinstance(result, list)
+
+    def test_fill_native_includes_messages_from_computer(self):
+        """fill_native collects non-None messages returned by computer()."""
+        msg = MagicMock()
+
+        def mock_computer(action, text=None, coordinate=None):
+            if action == "type":
+                return msg
+            return None
+
+        with patch("gptme.tools.computer.computer", side_effect=mock_computer):
+            result = fill_native((100, 100), "hello")
+
+        assert msg in result, "type result message must be in fill_native return value"
+
+    def test_fill_native_coordinate_is_passed_to_triple_click(self):
+        """The coordinate argument must be forwarded to triple_click unchanged."""
+        seen: list[tuple] = []
+
+        def mock_computer(action, text=None, coordinate=None):
+            seen.append((action, coordinate))
+            return
+
+        with patch("gptme.tools.computer.computer", side_effect=mock_computer):
+            fill_native((760, 45), "https://example.com")
+
+        assert seen[0] == ("triple_click", (760, 45)), (
+            f"triple_click must receive the exact coordinate, got {seen[0]}"
+        )

--- a/tests/test_computer_actions.py
+++ b/tests/test_computer_actions.py
@@ -667,13 +667,16 @@ class TestFillNative:
         with patch("gptme.tools.computer.computer", side_effect=mock_computer):
             fill_native((300, 200), "new text")
 
-        assert len(calls) == 2, f"Expected 2 calls, got {len(calls)}: {calls}"
+        assert len(calls) == 3, f"Expected 3 calls, got {len(calls)}: {calls}"
         assert calls[0] == ("triple_click", (300, 200), None), (
             f"First call should be triple_click with coordinate, got {calls[0]}"
         )
         assert calls[1][0] == "type", f"Second call should be type, got {calls[1][0]}"
         assert calls[1][2] == "new text", (
             f"type call should carry the replacement text, got {calls[1][2]}"
+        )
+        assert calls[2][0] == "screenshot", (
+            f"Third call should be screenshot for post-fill observation, got {calls[2][0]}"
         )
 
     def test_fill_native_returns_list(self):

--- a/tests/test_computer_audit.py
+++ b/tests/test_computer_audit.py
@@ -611,6 +611,28 @@ def test_fill_native_keyword_arg_is_audited():
     assert r["value_len"] is None
 
 
+def test_fill_native_triple_quoted_string_is_audited():
+    """fill_native with a triple-quoted text arg must log the correct length."""
+    code = 'fill_native((300, 200), """line1\nline2""")'
+    msgs = [_msg("assistant", _ipython_block(code))]
+    records = _extract_computer_calls(msgs)
+    assert len(records) == 1, "triple-quoted fill_native must be audited"
+    r = records[0]
+    assert r["action"] == "fill_native"
+    assert r["value_len"] == len("line1\nline2")
+
+
+def test_fill_native_escaped_quote_is_audited():
+    """fill_native with an escaped quote in text must log the correct length."""
+    code = r"fill_native((300, 200), 'it\'s secret')"
+    msgs = [_msg("assistant", _ipython_block(code))]
+    records = _extract_computer_calls(msgs)
+    assert len(records) == 1, "escaped-quote fill_native must be audited"
+    r = records[0]
+    assert r["action"] == "fill_native"
+    assert r["value_len"] == len("it's secret")
+
+
 def test_read_page_text_captured():
     msgs = [_msg("assistant", _ipython_block("read_page_text()"))]
     records = _extract_computer_calls(msgs)

--- a/tests/test_computer_audit.py
+++ b/tests/test_computer_audit.py
@@ -589,6 +589,28 @@ def test_fill_native_risk_is_sensitive():
     assert records[0]["risk_level"] == "sensitive"
 
 
+def test_fill_native_variable_text_is_audited():
+    """fill_native with a variable text arg must still appear in the audit (value_len=None)."""
+    code = "fill_native((300, 200), password)"
+    msgs = [_msg("assistant", _ipython_block(code))]
+    records = _extract_computer_calls(msgs)
+    assert len(records) == 1, "variable-text fill_native must be audited"
+    r = records[0]
+    assert r["action"] == "fill_native"
+    assert r["value_len"] is None, "value_len must be None when text is a variable"
+
+
+def test_fill_native_keyword_arg_is_audited():
+    """fill_native(coordinate=..., text=variable) must be audited."""
+    code = "fill_native(coordinate=(300, 200), text=user_input)"
+    msgs = [_msg("assistant", _ipython_block(code))]
+    records = _extract_computer_calls(msgs)
+    assert len(records) == 1, "keyword-arg fill_native must be audited"
+    r = records[0]
+    assert r["action"] == "fill_native"
+    assert r["value_len"] is None
+
+
 def test_read_page_text_captured():
     msgs = [_msg("assistant", _ipython_block("read_page_text()"))]
     records = _extract_computer_calls(msgs)

--- a/tests/test_computer_audit.py
+++ b/tests/test_computer_audit.py
@@ -567,6 +567,28 @@ def test_fill_element_password_not_logged():
     assert records[0]["value_len"] == len("supersecret")
 
 
+def test_fill_native_value_redacted():
+    """fill_native must log only value length, never raw text."""
+    code = "fill_native((300, 200), 'secret-password')"
+    msgs = [_msg("assistant", _ipython_block(code))]
+    records = _extract_computer_calls(msgs)
+    assert len(records) == 1
+    r = records[0]
+    assert r["action"] == "fill_native"
+    assert r["source"] == "computer"
+    assert "secret-password" not in str(r), "raw text must not appear in audit record"
+    assert r["value_len"] == len("secret-password")
+
+
+def test_fill_native_risk_is_sensitive():
+    """fill_native carries sensitive risk level (handles private text)."""
+    code = "fill_native((100, 50), 'alice@example.com')"
+    msgs = [_msg("assistant", _ipython_block(code))]
+    records = _extract_computer_calls(msgs)
+    assert len(records) == 1
+    assert records[0]["risk_level"] == "sensitive"
+
+
 def test_read_page_text_captured():
     msgs = [_msg("assistant", _ipython_block("read_page_text()"))]
     records = _extract_computer_calls(msgs)


### PR DESCRIPTION
## Summary

Adds two missing capabilities to complete computer-use support for native desktop interaction:

- **`triple_click` action**: New `Action` value that triple-clicks at the current mouse position (or moves then triple-clicks at a given coordinate). Implements via `xdotool click --repeat 3` on Linux and `cliclick tc:` on macOS. Added to `ComputerTransport` ABC with a safe fallback of three rapid `left_click` calls. Classified as `ACTION_RISK_WRITE`.

- **`fill_native(coordinate, text)` helper**: Single-call shortcut for replacing text in a native (non-browser) form field — equivalent to `fill_element(selector, value)` for DOM targets. Internally does `triple_click` (to select all) then `type`. Registered as a `ToolFunction` for REPL/IPython exposure. Classified as `ACTION_RISK_SENSITIVE` and tracked in the computer audit extractor.

### Files changed
- `gptme/tools/computer.py` — `triple_click` action + `fill_native` helper
- `gptme/tools/computer_transport.py` — `triple_click()` on ABC
- `gptme/tools/_computer_gate.py` — risk classifications
- `gptme/profiles.py` — native field-filling guidance in `computer-use` profile
- `gptme/cli/cmd_computer.py` — audit extraction for `fill_native`
- `tests/test_computer_actions.py` — 7 new tests (TestTripleClick × 3, TestFillNative × 4)
- `tests/test_computer_audit.py` — 2 new audit tests

Closes #216