### PR TITLE
feat(context): proactive context-window summarization before hard limit

### DIFF
--- a/gptme/logmanager/manager.py
+++ b/gptme/logmanager/manager.py
@@ -45,7 +45,7 @@ from ..message import Message, _migrate_metadata, len_tokens, print_msg
 from ..tools import ToolUse
 from ..util.context import enrich_messages_with_context
 from ..util.conversation_ids import conversation_id_error, validate_conversation_id
-from ..util.reduce import limit_log, reduce_log
+from ..util.reduce import limit_log, proactive_summarize_log, reduce_log
 from ..util.uri import URI
 from . import eventlog
 
@@ -783,6 +783,10 @@ def prepare_messages(
 
     # Enrich with enabled context enhancements (RAG, fresh context)
     msgs = enrich_messages_with_context(msgs, workspace)
+
+    # Proactively summarize older turns when approaching the context limit.
+    # No-op unless GPTME_AUTO_SUMMARIZE_THRESHOLD is set (e.g. export GPTME_AUTO_SUMMARIZE_THRESHOLD=0.8).
+    msgs = proactive_summarize_log(msgs)
 
     # Use regular reduction
     msgs_reduced = list(reduce_log(msgs))

--- a/gptme/util/reduce.py
+++ b/gptme/util/reduce.py
@@ -371,24 +371,54 @@ def proactive_summarize_log(
     if not middle:
         return log
 
+    # Guard: push the cut backward until no tool-call/result pair straddles the boundary.
+    # An assistant message with a tool call must stay together with its tool result
+    # (the immediately-following system message).  A system message at the head of
+    # `recent` whose anchor (nearest preceding non-system message) is still in `middle`
+    # would become orphaned — so we absorb it into `recent` until the boundary is safe.
+    while middle and (
+        message_contains_tool_use(middle[-1]) or (recent and recent[0].role == "system")
+    ):
+        recent.insert(0, middle.pop())
+        if not middle:
+            break
+
+    if not middle:
+        return log
+
+    # Separate pinned messages from the middle block — they must never be compressed.
+    # They are placed between the summary and the recent tail so their content survives.
+    pinned_middle = [m for m in middle if m.pinned]
+    summarize_middle = [m for m in middle if not m.pinned]
+    if not summarize_middle:
+        return log
+
     # Lazy import avoids circular dependency at module load time.
     from ..llm import summarize as _llm_summarize  # fmt: skip
 
     logger.info(
         "Proactive summarize triggered: %dk tokens (threshold %d%% of %dk context)"
-        " — summarizing %d middle messages",
+        " — summarizing %d middle messages (%d pinned preserved)",
         tokens // 1000,
         int(threshold * 100),
         model.context // 1000,
-        len(middle),
+        len(summarize_middle),
+        len(pinned_middle),
     )
     console.log(
         f"[context] Approaching context limit ({tokens // 1000}k / {int(limit) // 1000}k),"
-        f" summarizing {len(middle)} older messages..."
+        f" summarizing {len(summarize_middle)} older messages..."
     )
 
-    summary_msg = _llm_summarize(middle)
-    result = initial_system + [summary_msg] + recent
+    try:
+        summary_msg = _llm_summarize(summarize_middle)
+    except Exception:
+        logger.warning(
+            "Proactive summarize failed; falling back to unreduced log", exc_info=True
+        )
+        return log
+
+    result = initial_system + [summary_msg] + pinned_middle + recent
     new_tokens = len_tokens(result, model=model.model)
     saved = tokens - new_tokens
     console.log(

--- a/gptme/util/reduce.py
+++ b/gptme/util/reduce.py
@@ -288,6 +288,116 @@ def _truncate_details_blocks(
     return content
 
 
+def proactive_summarize_log(
+    log: list[Message],
+    threshold: float | None = None,
+    recent_keep: int = 6,
+) -> list[Message]:
+    """
+    Proactively summarize older conversation turns when approaching the context limit.
+
+    Triggered when token usage exceeds ``threshold`` fraction of the active model's
+    context (e.g. 0.8 = 80 %).  Enable via the ``GPTME_AUTO_SUMMARIZE_THRESHOLD``
+    env var, e.g.::
+
+        export GPTME_AUTO_SUMMARIZE_THRESHOLD=0.8
+
+    Or pass ``threshold`` directly for programmatic use.  When ``threshold`` is 0
+    or ``GPTME_AUTO_SUMMARIZE_THRESHOLD`` is unset, this function is a no-op.
+
+    What is preserved (never summarized):
+    - Initial system messages (the prompt header block at the start of the log).
+    - The most recent ``recent_keep`` non-system turns and any system messages
+      interleaved with them.
+    - Pinned messages in the preserved sections.
+
+    What gets summarized:
+    - The "middle" section between the initial system block and the recent tail.
+      A single summary ``system`` message replaces it.
+
+    Returns:
+        A (possibly shorter) list of messages.  Returns the original log unchanged
+        when the threshold is not exceeded or when there is nothing to summarize.
+    """
+    import os
+
+    if threshold is None:
+        env_val = os.environ.get("GPTME_AUTO_SUMMARIZE_THRESHOLD")
+        if not env_val:
+            return log
+        try:
+            threshold = float(env_val)
+        except ValueError:
+            logger.warning(
+                "Invalid GPTME_AUTO_SUMMARIZE_THRESHOLD value: %s (expected float 0–1)",
+                env_val,
+            )
+            return log
+
+    if threshold <= 0:
+        return log
+
+    model = get_default_model() or get_model("gpt-4")
+    limit = threshold * model.context
+    tokens = len_tokens(log, model=model.model)
+
+    if tokens <= limit:
+        return log
+
+    # Collect initial system messages — the always-kept prompt header.
+    initial_system: list[Message] = []
+    for msg in log:
+        if msg.role != "system":
+            break
+        initial_system.append(msg)
+
+    rest = log[len(initial_system) :]
+    if not rest:
+        return log
+
+    # Walk backwards to collect the recent tail: the last `recent_keep`
+    # non-system turns plus any system messages adjacent to them.
+    recent: list[Message] = []
+    non_system_count = 0
+    for msg in reversed(rest):
+        recent.insert(0, msg)
+        if msg.role != "system":
+            non_system_count += 1
+        if non_system_count >= recent_keep:
+            break
+
+    # Middle = everything between the initial system block and the recent tail.
+    middle = rest[: len(rest) - len(recent)]
+    if not middle:
+        return log
+
+    # Lazy import avoids circular dependency at module load time.
+    from ..llm import summarize as _llm_summarize  # fmt: skip
+
+    logger.info(
+        "Proactive summarize triggered: %dk tokens (threshold %d%% of %dk context)"
+        " — summarizing %d middle messages",
+        tokens // 1000,
+        int(threshold * 100),
+        model.context // 1000,
+        len(middle),
+    )
+    console.log(
+        f"[context] Approaching context limit ({tokens // 1000}k / {int(limit) // 1000}k),"
+        f" summarizing {len(middle)} older messages..."
+    )
+
+    summary_msg = _llm_summarize(middle)
+    result = initial_system + [summary_msg] + recent
+    new_tokens = len_tokens(result, model=model.model)
+    saved = tokens - new_tokens
+    console.log(
+        f"[context] Proactive summarize complete:"
+        f" {tokens // 1000}k → {new_tokens // 1000}k tokens (saved ~{saved // 1000}k)"
+    )
+    return result
+
+
 def limit_log(log: list[Message]) -> list[Message]:
     """
     Picks messages until the total number of tokens exceeds limit,

--- a/gptme/util/reduce.py
+++ b/gptme/util/reduce.py
@@ -399,13 +399,12 @@ def proactive_summarize_log(
         m = middle[i]
         if m.pinned:
             pinned_middle.append(m)
-            if (
-                message_contains_tool_use(m)
-                and i + 1 < len(middle)
-                and middle[i + 1].role == "system"
-            ):
-                i += 1
-                pinned_middle.append(middle[i])
+            if message_contains_tool_use(m):
+                # Pull ALL consecutive system messages (tool results) so we don't
+                # orphan any result from a multi-result tool call.
+                while i + 1 < len(middle) and middle[i + 1].role == "system":
+                    i += 1
+                    pinned_middle.append(middle[i])
         else:
             # A non-pinned tool-use whose immediately following message is a pinned
             # tool result must travel to pinned_middle — the pinned result requires

--- a/gptme/util/reduce.py
+++ b/gptme/util/reduce.py
@@ -387,9 +387,28 @@ def proactive_summarize_log(
         return log
 
     # Separate pinned messages from the middle block — they must never be compressed.
-    # They are placed between the summary and the recent tail so their content survives.
-    pinned_middle = [m for m in middle if m.pinned]
-    summarize_middle = [m for m in middle if not m.pinned]
+    # When a pinned assistant message contains a tool use, its immediately following
+    # system message is the tool result and must be preserved with it — otherwise the
+    # result log contains a tool-use without its matching result, which provider APIs
+    # reject.  We therefore walk the middle list and pull the paired result alongside
+    # any pinned tool-use message.
+    pinned_middle: list[Message] = []
+    summarize_middle: list[Message] = []
+    i = 0
+    while i < len(middle):
+        m = middle[i]
+        if m.pinned:
+            pinned_middle.append(m)
+            if (
+                message_contains_tool_use(m)
+                and i + 1 < len(middle)
+                and middle[i + 1].role == "system"
+            ):
+                i += 1
+                pinned_middle.append(middle[i])
+        else:
+            summarize_middle.append(m)
+        i += 1
     if not summarize_middle:
         return log
 

--- a/gptme/util/reduce.py
+++ b/gptme/util/reduce.py
@@ -406,16 +406,22 @@ def proactive_summarize_log(
                     i += 1
                     pinned_middle.append(middle[i])
         else:
-            # A non-pinned tool-use whose immediately following message is a pinned
-            # tool result must travel to pinned_middle — the pinned result requires
-            # its anchor, and the result IS pinned so it will be preserved.
-            if (
-                message_contains_tool_use(m)
-                and i + 1 < len(middle)
-                and middle[i + 1].pinned
-                and middle[i + 1].role == "system"
-            ):
-                pinned_middle.append(m)
+            if message_contains_tool_use(m):
+                # Scan ALL consecutive system messages (tool results) following
+                # this anchor.  If ANY is pinned the entire chain must travel to
+                # pinned_middle — a pinned result requires its anchor and all
+                # sibling results before it; separating them causes provider
+                # validation errors (tool-use with missing or partial results).
+                j = i + 1
+                while j < len(middle) and middle[j].role == "system":
+                    j += 1
+                result_msgs = middle[i + 1 : j]
+                if any(r.pinned for r in result_msgs):
+                    pinned_middle.append(m)
+                    pinned_middle.extend(result_msgs)
+                    i = j - 1  # outer i += 1 will advance past all results
+                else:
+                    summarize_middle.append(m)
             else:
                 summarize_middle.append(m)
         i += 1

--- a/gptme/util/reduce.py
+++ b/gptme/util/reduce.py
@@ -407,7 +407,18 @@ def proactive_summarize_log(
                 i += 1
                 pinned_middle.append(middle[i])
         else:
-            summarize_middle.append(m)
+            # A non-pinned tool-use whose immediately following message is a pinned
+            # tool result must travel to pinned_middle — the pinned result requires
+            # its anchor, and the result IS pinned so it will be preserved.
+            if (
+                message_contains_tool_use(m)
+                and i + 1 < len(middle)
+                and middle[i + 1].pinned
+                and middle[i + 1].role == "system"
+            ):
+                pinned_middle.append(m)
+            else:
+                summarize_middle.append(m)
         i += 1
     if not summarize_middle:
         return log

--- a/tests/test_reduce.py
+++ b/tests/test_reduce.py
@@ -520,3 +520,130 @@ def test_proactive_summarize_env_var(monkeypatch):
         set_default_model(original_model) if original_model else _default_model_var.set(
             None
         )
+
+
+def test_proactive_summarize_pinned_preserved(monkeypatch):
+    """Pinned messages in the middle block are kept verbatim, not summarized."""
+    from gptme.llm.models.resolution import _default_model_var
+    from gptme.util.reduce import proactive_summarize_log
+
+    original_model = _default_model_var.get()
+    try:
+        tiny_model = ModelMeta(provider="unknown", model="gpt-4", context=10)
+        set_default_model(tiny_model)
+
+        fake_summary = Message("system", "Summary of old stuff")
+        monkeypatch.setattr("gptme.llm.summarize", lambda _msgs: fake_summary)
+
+        pinned_msg = Message("system", "IMPORTANT PINNED INSTRUCTION", pinned=True)
+        msgs = [
+            Message("system", "You are helpful."),  # initial system — kept
+            Message("user", "word " * 4),  # old — summarized
+            pinned_msg,  # pinned — must survive verbatim
+            Message("assistant", "word " * 4),  # old — summarized
+            Message("user", "recent q"),  # recent — kept
+            Message("assistant", "recent a"),  # recent — kept
+        ]
+
+        result = proactive_summarize_log(msgs, threshold=0.5, recent_keep=2)
+
+        # Pinned message must appear verbatim in the result.
+        assert any(m is pinned_msg for m in result), (
+            "Pinned message must be preserved verbatim, not compressed into the summary"
+        )
+        # And not be the only survivor — summary + recent must also be present.
+        assert any("Summary" in m.content for m in result)
+        assert any("recent q" in m.content for m in result)
+    finally:
+        set_default_model(original_model) if original_model else _default_model_var.set(
+            None
+        )
+
+
+def test_proactive_summarize_tool_call_boundary(monkeypatch):
+    """Tool-call / tool-result pairs must not be split at the middle/recent boundary."""
+    from gptme.llm.models.resolution import _default_model_var
+    from gptme.util.reduce import proactive_summarize_log
+
+    original_model = _default_model_var.get()
+    try:
+        tiny_model = ModelMeta(provider="unknown", model="gpt-4", context=10)
+        set_default_model(tiny_model)
+
+        summarized: list[list] = []
+
+        def fake_summarize(msgs):
+            summarized.append(msgs)
+            return Message("system", "Summary")
+
+        monkeypatch.setattr("gptme.llm.summarize", fake_summarize)
+
+        tool_use_msg = Message(
+            "assistant",
+            content="I'll run this.\n```shell\necho hi\n```",
+        )
+        tool_result_msg = Message("system", "hi")  # tool result for tool_use_msg
+
+        msgs = [
+            Message("system", "System."),  # initial system
+            Message("user", "word " * 4),  # old — candidate for middle
+            Message("assistant", "word " * 4),  # old — candidate for middle
+            tool_use_msg,  # MUST NOT be in middle alone
+            tool_result_msg,  # MUST stay with tool_use_msg
+            Message("user", "done?"),  # recent
+            Message("assistant", "yes"),  # recent
+        ]
+
+        result = proactive_summarize_log(msgs, threshold=0.5, recent_keep=2)
+
+        # If summarization fired, check that tool_use_msg and tool_result_msg
+        # ended up on the SAME side of the split (both in middle OR both in recent).
+        if summarized:
+            middle_summarized = summarized[0]
+            # tool_use_msg in middle ↔ tool_result_msg also in middle
+            tool_use_in_middle = any(m is tool_use_msg for m in middle_summarized)
+            tool_result_in_middle = any(m is tool_result_msg for m in middle_summarized)
+            assert tool_use_in_middle == tool_result_in_middle, (
+                "tool-call and tool-result must not be split across middle/recent"
+            )
+
+        # Whatever happened, the result must contain the recent messages.
+        assert any("done?" in m.content for m in result)
+        assert any("yes" in m.content for m in result)
+    finally:
+        set_default_model(original_model) if original_model else _default_model_var.set(
+            None
+        )
+
+
+def test_proactive_summarize_error_falls_back(monkeypatch):
+    """If _llm_summarize raises, proactive_summarize_log returns the original log."""
+    from gptme.llm.models.resolution import _default_model_var
+    from gptme.util.reduce import proactive_summarize_log
+
+    original_model = _default_model_var.get()
+    try:
+        tiny_model = ModelMeta(provider="unknown", model="gpt-4", context=10)
+        set_default_model(tiny_model)
+
+        def failing_summarize(_msgs):
+            raise RuntimeError("LLM unavailable")
+
+        monkeypatch.setattr("gptme.llm.summarize", failing_summarize)
+
+        msgs = [
+            Message("system", "System."),
+            Message("user", "word " * 5),
+            Message("assistant", "word " * 5),
+            Message("user", "recent q"),
+            Message("assistant", "recent a"),
+        ]
+
+        result = proactive_summarize_log(msgs, threshold=0.5, recent_keep=2)
+
+        # Must return the original list unchanged (safe fallback).
+        assert result is msgs, "On summarize error, original log must be returned as-is"
+    finally:
+        set_default_model(original_model) if original_model else _default_model_var.set(
+            None
+        )

--- a/tests/test_reduce.py
+++ b/tests/test_reduce.py
@@ -560,6 +560,66 @@ def test_proactive_summarize_pinned_preserved(monkeypatch):
         )
 
 
+def test_proactive_summarize_pinned_tool_use_keeps_result(monkeypatch):
+    """A pinned tool-use message's result must not be summarized away.
+
+    When a pinned assistant message in the middle block contains a tool call,
+    its immediately following system message (the tool result) must be preserved
+    alongside it — even though the result is not itself pinned.  Losing it
+    produces a tool-use message with no matching result, which provider APIs reject.
+    """
+    from gptme.llm.models.resolution import _default_model_var
+    from gptme.util.reduce import proactive_summarize_log
+
+    original_model = _default_model_var.get()
+    try:
+        tiny_model = ModelMeta(provider="unknown", model="gpt-4", context=10)
+        set_default_model(tiny_model)
+
+        summarized: list[list] = []
+
+        def fake_summarize(msgs):
+            summarized.append(msgs)
+            return Message("system", "Summary of old turns")
+
+        monkeypatch.setattr("gptme.llm.summarize", fake_summarize)
+
+        pinned_tool_use = Message(
+            "assistant",
+            content="I'll run this.\n```shell\necho hi\n```",
+            pinned=True,
+        )
+        tool_result = Message("system", "hi")  # NOT pinned — paired result
+
+        msgs = [
+            Message("system", "System."),  # initial system — kept
+            Message("user", "word " * 4),  # old — candidate for middle
+            Message("assistant", "word " * 4),  # old — candidate for middle
+            pinned_tool_use,  # pinned tool-use in middle — must survive with result
+            tool_result,  # paired result (not pinned) — must survive too
+            Message("user", "recent q"),  # recent
+            Message("assistant", "recent a"),  # recent
+        ]
+
+        result = proactive_summarize_log(msgs, threshold=0.5, recent_keep=2)
+
+        assert any(m is pinned_tool_use for m in result), (
+            "Pinned tool-use message must be preserved in result"
+        )
+        assert any(m is tool_result for m in result), (
+            "Tool result of a pinned tool-use must be preserved even if not pinned"
+        )
+        if summarized:
+            assert not any(m is tool_result for m in summarized[0]), (
+                "Tool result of a pinned tool-use must not appear in the summarized portion"
+            )
+        assert any("recent q" in m.content for m in result)
+    finally:
+        set_default_model(original_model) if original_model else _default_model_var.set(
+            None
+        )
+
+
 def test_proactive_summarize_tool_call_boundary(monkeypatch):
     """Tool-call / tool-result pairs must not be split at the middle/recent boundary."""
     from gptme.llm.models.resolution import _default_model_var

--- a/tests/test_reduce.py
+++ b/tests/test_reduce.py
@@ -679,6 +679,72 @@ def test_proactive_summarize_pinned_result_keeps_anchor(monkeypatch):
         )
 
 
+def test_proactive_summarize_pinned_tool_use_keeps_all_results(monkeypatch):
+    """A pinned tool-use message must preserve ALL consecutive tool results, not just one.
+
+    When a pinned assistant message contains a tool call that produces multiple
+    consecutive system messages (tool results), all of them must be preserved
+    in the output.  Losing any result orphans the tool call in the provider API.
+    """
+    from gptme.llm.models.resolution import _default_model_var
+    from gptme.util.reduce import proactive_summarize_log
+
+    original_model = _default_model_var.get()
+    try:
+        tiny_model = ModelMeta(provider="unknown", model="gpt-4", context=10)
+        set_default_model(tiny_model)
+
+        summarized: list[list] = []
+
+        def fake_summarize(msgs):
+            summarized.append(msgs)
+            return Message("system", "Summary of old turns")
+
+        monkeypatch.setattr("gptme.llm.summarize", fake_summarize)
+
+        pinned_tool_use = Message(
+            "assistant",
+            content="I'll run two things.\n```shell\necho a && echo b\n```",
+            pinned=True,
+        )
+        result_1 = Message("system", "a")  # first tool result — not pinned
+        result_2 = Message("system", "b")  # second tool result — not pinned
+
+        msgs = [
+            Message("system", "System."),  # initial system — kept
+            Message("user", "word " * 4),  # old — candidate for middle
+            Message("assistant", "word " * 4),  # old — candidate for middle
+            pinned_tool_use,  # pinned tool-use with multi-result — ALL results must survive
+            result_1,  # first result (not pinned) — must survive
+            result_2,  # second result (not pinned) — must survive too
+            Message("user", "recent q"),  # recent
+            Message("assistant", "recent a"),  # recent
+        ]
+
+        result = proactive_summarize_log(msgs, threshold=0.5, recent_keep=2)
+
+        assert any(m is pinned_tool_use for m in result), (
+            "Pinned tool-use must be preserved"
+        )
+        assert any(m is result_1 for m in result), (
+            "First tool result of a pinned tool-use must be preserved"
+        )
+        assert any(m is result_2 for m in result), (
+            "Second tool result of a pinned tool-use must be preserved (multi-result)"
+        )
+        if summarized:
+            assert not any(m is result_1 for m in summarized[0]), (
+                "First result must not appear in the summarized portion"
+            )
+            assert not any(m is result_2 for m in summarized[0]), (
+                "Second result must not appear in the summarized portion"
+            )
+    finally:
+        set_default_model(original_model) if original_model else _default_model_var.set(
+            None
+        )
+
+
 def test_proactive_summarize_tool_call_boundary(monkeypatch):
     """Tool-call / tool-result pairs must not be split at the middle/recent boundary."""
     from gptme.llm.models.resolution import _default_model_var

--- a/tests/test_reduce.py
+++ b/tests/test_reduce.py
@@ -620,6 +620,65 @@ def test_proactive_summarize_pinned_tool_use_keeps_result(monkeypatch):
         )
 
 
+def test_proactive_summarize_pinned_result_keeps_anchor(monkeypatch):
+    """A pinned tool-result's non-pinned tool-use anchor must not be summarized away.
+
+    When a non-pinned assistant message in the middle block contains a tool call,
+    and its immediately following system message is pinned, the anchor must be
+    preserved alongside the pinned result — otherwise the final log contains a
+    tool result with no preceding tool-use, which provider APIs reject.
+    """
+    from gptme.llm.models.resolution import _default_model_var
+    from gptme.util.reduce import proactive_summarize_log
+
+    original_model = _default_model_var.get()
+    try:
+        tiny_model = ModelMeta(provider="unknown", model="gpt-4", context=10)
+        set_default_model(tiny_model)
+
+        summarized: list[list] = []
+
+        def fake_summarize(msgs):
+            summarized.append(msgs)
+            return Message("system", "Summary of old turns")
+
+        monkeypatch.setattr("gptme.llm.summarize", fake_summarize)
+
+        tool_use = Message(
+            "assistant",
+            content="I'll run this.\n```shell\necho hi\n```",
+        )  # NOT pinned — but its result is pinned
+        pinned_tool_result = Message("system", "hi", pinned=True)
+
+        msgs = [
+            Message("system", "System."),  # initial system — kept
+            Message("user", "word " * 4),  # old — candidate for middle
+            Message("assistant", "word " * 4),  # old — candidate for middle
+            tool_use,  # non-pinned tool-use — anchor must survive with its result
+            pinned_tool_result,  # pinned tool-result — must survive verbatim
+            Message("user", "recent q"),  # recent
+            Message("assistant", "recent a"),  # recent
+        ]
+
+        result = proactive_summarize_log(msgs, threshold=0.5, recent_keep=2)
+
+        assert any(m is pinned_tool_result for m in result), (
+            "Pinned tool-result must be preserved in result"
+        )
+        assert any(m is tool_use for m in result), (
+            "Non-pinned tool-use anchor must be preserved when its result is pinned"
+        )
+        if summarized:
+            assert not any(m is tool_use for m in summarized[0]), (
+                "Tool-use anchor of a pinned result must not appear in the summarized portion"
+            )
+        assert any("recent q" in m.content for m in result)
+    finally:
+        set_default_model(original_model) if original_model else _default_model_var.set(
+            None
+        )
+
+
 def test_proactive_summarize_tool_call_boundary(monkeypatch):
     """Tool-call / tool-result pairs must not be split at the middle/recent boundary."""
     from gptme.llm.models.resolution import _default_model_var

--- a/tests/test_reduce.py
+++ b/tests/test_reduce.py
@@ -745,6 +745,126 @@ def test_proactive_summarize_pinned_tool_use_keeps_all_results(monkeypatch):
         )
 
 
+def test_proactive_summarize_non_pinned_anchor_later_pinned_result(monkeypatch):
+    """A non-pinned tool-use must be preserved when a later (not first) result is pinned.
+
+    If the first result is unpinned but a subsequent result is pinned, the
+    anchor must still travel to pinned_middle alongside both results — the
+    pinned result cannot exist without its anchor.
+    """
+    from gptme.llm.models.resolution import _default_model_var
+    from gptme.util.reduce import proactive_summarize_log
+
+    original_model = _default_model_var.get()
+    try:
+        tiny_model = ModelMeta(provider="unknown", model="gpt-4", context=10)
+        set_default_model(tiny_model)
+
+        summarized: list[list] = []
+
+        def fake_summarize(msgs):
+            summarized.append(msgs)
+            return Message("system", "Summary")
+
+        monkeypatch.setattr("gptme.llm.summarize", fake_summarize)
+
+        tool_use = Message(
+            "assistant",
+            content="I'll run two things.\n```shell\necho a && echo b\n```",
+        )  # NOT pinned
+        result_1 = Message("system", "a")  # NOT pinned — first result
+        result_2 = Message("system", "b", pinned=True)  # pinned — second result
+
+        msgs = [
+            Message("system", "System."),
+            Message("user", "word " * 4),
+            Message("assistant", "word " * 4),
+            tool_use,
+            result_1,
+            result_2,
+            Message("user", "recent q"),
+            Message("assistant", "recent a"),
+        ]
+
+        result = proactive_summarize_log(msgs, threshold=0.5, recent_keep=2)
+
+        assert any(m is tool_use for m in result), (
+            "Non-pinned tool-use anchor must be preserved when a later result is pinned"
+        )
+        assert any(m is result_1 for m in result), (
+            "First (unpinned) result must be preserved alongside its pinned sibling"
+        )
+        assert any(m is result_2 for m in result), "Pinned result_2 must be preserved"
+        if summarized:
+            assert not any(m is tool_use for m in summarized[0])
+            assert not any(m is result_2 for m in summarized[0])
+    finally:
+        set_default_model(original_model) if original_model else _default_model_var.set(
+            None
+        )
+
+
+def test_proactive_summarize_non_pinned_anchor_first_pinned_all_results_kept(
+    monkeypatch,
+):
+    """All results must be preserved when any result in a multi-result chain is pinned.
+
+    When a non-pinned tool-use is followed by a pinned first result and an
+    unpinned second result, both results must travel to pinned_middle — the
+    second result cannot be summarized away leaving the anchor and first
+    result without their sibling.
+    """
+    from gptme.llm.models.resolution import _default_model_var
+    from gptme.util.reduce import proactive_summarize_log
+
+    original_model = _default_model_var.get()
+    try:
+        tiny_model = ModelMeta(provider="unknown", model="gpt-4", context=10)
+        set_default_model(tiny_model)
+
+        summarized: list[list] = []
+
+        def fake_summarize(msgs):
+            summarized.append(msgs)
+            return Message("system", "Summary")
+
+        monkeypatch.setattr("gptme.llm.summarize", fake_summarize)
+
+        tool_use = Message(
+            "assistant",
+            content="I'll run two things.\n```shell\necho a && echo b\n```",
+        )  # NOT pinned
+        result_1 = Message("system", "a", pinned=True)  # pinned — first result
+        result_2 = Message("system", "b")  # NOT pinned — second result
+
+        msgs = [
+            Message("system", "System."),
+            Message("user", "word " * 4),
+            Message("assistant", "word " * 4),
+            tool_use,
+            result_1,
+            result_2,
+            Message("user", "recent q"),
+            Message("assistant", "recent a"),
+        ]
+
+        result = proactive_summarize_log(msgs, threshold=0.5, recent_keep=2)
+
+        assert any(m is tool_use for m in result), "Anchor must be preserved"
+        assert any(m is result_1 for m in result), "Pinned result_1 must be preserved"
+        assert any(m is result_2 for m in result), (
+            "Unpinned result_2 must also be preserved (sibling of pinned result_1)"
+        )
+        if summarized:
+            assert not any(m is result_2 for m in summarized[0]), (
+                "result_2 must not be summarized away"
+            )
+    finally:
+        set_default_model(original_model) if original_model else _default_model_var.set(
+            None
+        )
+
+
 def test_proactive_summarize_tool_call_boundary(monkeypatch):
     """Tool-call / tool-result pairs must not be split at the middle/recent boundary."""
     from gptme.llm.models.resolution import _default_model_var

--- a/tests/test_reduce.py
+++ b/tests/test_reduce.py
@@ -383,3 +383,140 @@ def test_limit_log_cascading_orphans():
         set_default_model(original_model) if original_model else _default_model_var.set(
             None
         )
+
+
+# ---------------------------------------------------------------------------
+# Tests for proactive_summarize_log
+# ---------------------------------------------------------------------------
+
+
+def test_proactive_summarize_noop_below_threshold():
+    """proactive_summarize_log returns the log unchanged when below threshold."""
+    from gptme.llm.models.resolution import _default_model_var
+    from gptme.util.reduce import proactive_summarize_log
+
+    original_model = _default_model_var.get()
+    try:
+        tiny_model = ModelMeta(provider="unknown", model="gpt-4", context=200_000)
+        set_default_model(tiny_model)
+
+        msgs = [
+            Message("system", "You are helpful."),
+            Message("user", "Hello"),
+            Message("assistant", "Hi"),
+        ]
+        result = proactive_summarize_log(msgs, threshold=0.8)
+        assert result is msgs  # identical object — no copy made
+    finally:
+        set_default_model(original_model) if original_model else _default_model_var.set(
+            None
+        )
+
+
+def test_proactive_summarize_triggered(monkeypatch):
+    """proactive_summarize_log summarizes older turns when threshold is exceeded."""
+    from gptme.llm.models.resolution import _default_model_var
+    from gptme.util.reduce import proactive_summarize_log
+
+    original_model = _default_model_var.get()
+    try:
+        # Tiny context so a modest log exceeds the 50 % threshold.
+        tiny_model = ModelMeta(provider="unknown", model="gpt-4", context=10)
+        set_default_model(tiny_model)
+
+        fake_summary = Message(
+            "system",
+            content="Here's a summary of the conversation:\n- User asked about X\n- Assistant explained X",
+        )
+        monkeypatch.setattr("gptme.llm.summarize", lambda _msgs: fake_summary)
+
+        msgs = [
+            Message("system", "You are helpful."),  # initial system — kept
+            Message("user", "word " * 5),  # old — summarized
+            Message("assistant", "word " * 5),  # old — summarized
+            Message("user", "recent question one"),  # recent — kept
+            Message("assistant", "recent answer one"),  # recent — kept
+            Message("user", "recent question two"),  # recent — kept
+            Message("assistant", "recent answer two"),  # recent — kept
+        ]
+
+        result = proactive_summarize_log(msgs, threshold=0.5, recent_keep=4)
+
+        # Initial system message preserved as-is.
+        assert result[0].content == "You are helpful."
+
+        # Summary message present somewhere after the system block.
+        assert any("summary" in m.content.lower() for m in result)
+
+        # Recent messages intact.
+        contents = [m.content for m in result]
+        assert "recent question one" in contents
+        assert "recent answer one" in contents
+        assert "recent question two" in contents
+        assert "recent answer two" in contents
+
+        # Old filler messages NOT present verbatim.
+        assert not any(m.content == "word " * 5 for m in result)
+
+        # Result is strictly shorter than original (summary replaced middle).
+        assert len(result) < len(msgs)
+    finally:
+        set_default_model(original_model) if original_model else _default_model_var.set(
+            None
+        )
+
+
+def test_proactive_summarize_env_disabled_by_default(monkeypatch):
+    """proactive_summarize_log is a no-op when env var is not set."""
+    from gptme.llm.models.resolution import _default_model_var
+    from gptme.util.reduce import proactive_summarize_log
+
+    original_model = _default_model_var.get()
+    try:
+        tiny_model = ModelMeta(provider="unknown", model="gpt-4", context=10)
+        set_default_model(tiny_model)
+
+        monkeypatch.delenv("GPTME_AUTO_SUMMARIZE_THRESHOLD", raising=False)
+
+        msgs = [Message("user", "word " * 20)]
+        result = proactive_summarize_log(msgs)  # no threshold arg, env var absent
+        # Must return original list unchanged.
+        assert result is msgs
+    finally:
+        set_default_model(original_model) if original_model else _default_model_var.set(
+            None
+        )
+
+
+def test_proactive_summarize_env_var(monkeypatch):
+    """GPTME_AUTO_SUMMARIZE_THRESHOLD env var triggers summarization."""
+    from gptme.llm.models.resolution import _default_model_var
+    from gptme.util.reduce import proactive_summarize_log
+
+    original_model = _default_model_var.get()
+    try:
+        tiny_model = ModelMeta(provider="unknown", model="gpt-4", context=10)
+        set_default_model(tiny_model)
+
+        monkeypatch.setenv("GPTME_AUTO_SUMMARIZE_THRESHOLD", "0.5")
+        fake_summary = Message("system", "Summary: all the things")
+        monkeypatch.setattr("gptme.llm.summarize", lambda _msgs: fake_summary)
+
+        msgs = [
+            Message("system", "System prompt."),
+            Message("user", "word " * 5),
+            Message("assistant", "word " * 5),
+            Message("user", "final question"),
+            Message("assistant", "final answer"),
+        ]
+
+        result = proactive_summarize_log(msgs, recent_keep=2)
+
+        assert result[0].content == "System prompt."
+        assert any("Summary" in m.content for m in result)
+        assert any("final question" in m.content for m in result)
+        assert any("final answer" in m.content for m in result)
+    finally:
+        set_default_model(original_model) if original_model else _default_model_var.set(
+            None
+        )


### PR DESCRIPTION
## Summary

- Adds `proactive_summarize_log()` to `gptme/util/reduce.py` — a pre-call hook that fires **before** `reduce_log` when estimated token usage exceeds a configurable fraction of the model's context window.
- Wired into `prepare_messages()` in `logmanager/manager.py` as the first compression step after context enrichment.
- Opt-in via `GPTME_AUTO_SUMMARIZE_THRESHOLD` env var (e.g. `export GPTME_AUTO_SUMMARIZE_THRESHOLD=0.8`); completely transparent no-op when unset.

## Motivation

Closes the gap described in Discussion #138: the old `reduce_log` only reacted _after_ the context was already over-limit. This hook acts proactively at a user-configurable percentage (default suggested: 80 %), summarizing the middle history **before** the hard limit is hit.

## Behaviour

When `tokens > threshold × model.context`:
1. **Keep** the initial system messages (prompt header).
2. **Keep** the most recent `recent_keep` (default 6) non-system turns.
3. **Summarize** the middle section via the existing `llm.summarize()` helper into a single `system` message.
4. Return the shorter log; `reduce_log` and `limit_log` continue as normal afterward.

## Usage

```sh
export GPTME_AUTO_SUMMARIZE_THRESHOLD=0.8   # trigger at 80 % of context
gptme "continue my long session..."
```

## Test plan

- `test_proactive_summarize_noop_below_threshold` — returns original list unchanged when below threshold
- `test_proactive_summarize_triggered` — summarizes middle, preserves system + recent turns
- `test_proactive_summarize_env_disabled_by_default` — no-op when env var absent
- `test_proactive_summarize_env_var` — env-var activation path

```
20 passed, 1 warning in 0.62s   # all existing reduce tests still pass
```