### PR TITLE
fix(tokens): graceful tiktoken fallback for local/airgapped endpoints

### DIFF
--- a/gptme/util/tokens.py
+++ b/gptme/util/tokens.py
@@ -18,6 +18,12 @@ _token_cache: dict[tuple[str, str], int] = {}
 # so a future call can retry (e.g. after network recovery or TIKTOKEN_CACHE_DIR is populated).
 _tokenizer_cache: dict[str, "tiktoken.Encoding"] = {}
 
+# Tracks encoding downloads currently in progress: encoding_name -> (thread, result_holder).
+# While a thread is running for an encoding, new callers join it instead of spawning a
+# duplicate — prevents unbounded stuck daemon threads in long-running offline sessions.
+_inflight_loads: dict[str, "tuple[threading.Thread, list]"] = {}
+_inflight_lock = threading.Lock()
+
 _warned_models: set[str] = set()
 
 logger = logging.getLogger(__name__)
@@ -148,21 +154,39 @@ class _GetTokenizer:
             # Use a daemon thread so a timed-out fetch doesn't keep a short-lived
             # process alive — non-daemon threads block process exit until they finish,
             # which can delay CLI exit by the full TCP timeout.
-            result_holder: list[tiktoken.Encoding | Exception | None] = [None]
+            #
+            # At most one thread runs per encoding_name at a time.  If a previous
+            # call already spawned a thread for this encoding and it is still running
+            # (i.e. the download is stuck), we join that same thread instead of
+            # starting another — prevents unbounded stuck threads in long sessions.
+            with _inflight_lock:
+                if encoding_name in _inflight_loads:
+                    t, result_holder = _inflight_loads[encoding_name]
+                else:
+                    result_holder = [None]
+                    _enc = encoding_name  # capture for closure
 
-            def _do_load() -> None:
-                try:
-                    result_holder[0] = _load_encoding(encoding_name)
-                except Exception as exc:
-                    result_holder[0] = exc
+                    def _do_load() -> None:
+                        try:
+                            result_holder[0] = _load_encoding(_enc)
+                        except Exception as exc:
+                            result_holder[0] = exc
+                        finally:
+                            with _inflight_lock:
+                                _inflight_loads.pop(_enc, None)
 
-            t = threading.Thread(target=_do_load, daemon=True, name="tiktoken-fetch")
-            t.start()
+                    t = threading.Thread(
+                        target=_do_load, daemon=True, name="tiktoken-fetch"
+                    )
+                    t.start()
+                    _inflight_loads[encoding_name] = (t, result_holder)
+
             t.join(timeout=_TIKTOKEN_TIMEOUT)
 
             if t.is_alive():
-                # Still fetching after timeout; return None without caching so that
-                # a future call can retry (e.g. after pre-caching the encodings).
+                # Thread still running after timeout.  Leave it in _inflight_loads
+                # so the next call for this encoding joins the same thread rather
+                # than spawning yet another one.
                 logger.warning(
                     f"tiktoken encoding '{encoding_name}' fetch timed out after"
                     f" {_TIKTOKEN_TIMEOUT:.1f}s. Using character-based approximation"
@@ -191,6 +215,8 @@ class _GetTokenizer:
     def cache_clear(self) -> None:
         """Clear the tokenizer cache (for testing or after environment changes)."""
         _tokenizer_cache.clear()
+        with _inflight_lock:
+            _inflight_loads.clear()
 
 
 get_tokenizer = _GetTokenizer()

--- a/gptme/util/tokens.py
+++ b/gptme/util/tokens.py
@@ -1,9 +1,8 @@
-import concurrent.futures
 import hashlib
 import logging
 import os
+import threading
 import typing
-from functools import lru_cache
 
 if typing.TYPE_CHECKING:
     import tiktoken  # fmt: skip
@@ -14,9 +13,27 @@ if typing.TYPE_CHECKING:
 # Global cache mapping hashes to token counts
 _token_cache: dict[tuple[str, str], int] = {}
 
+# Cache for successfully loaded tokenizers (keyed by model name).
+# Unlike @lru_cache, failed loads (timeout / offline) are NOT stored here,
+# so a future call can retry (e.g. after network recovery or TIKTOKEN_CACHE_DIR is populated).
+_tokenizer_cache: dict[str, "tiktoken.Encoding"] = {}
+
 _warned_models: set[str] = set()
 
 logger = logging.getLogger(__name__)
+
+
+def _parse_tiktoken_timeout() -> float:
+    """Parse GPTME_TIKTOKEN_TIMEOUT from the environment, falling back to 5.0."""
+    raw = os.environ.get("GPTME_TIKTOKEN_TIMEOUT", "5.0")
+    try:
+        return float(raw)
+    except ValueError:
+        logger.warning(
+            f"Invalid GPTME_TIKTOKEN_TIMEOUT value {raw!r}; using default 5.0 seconds."
+        )
+        return 5.0
+
 
 # Timeout (seconds) for tiktoken encoding fetches. On first use tiktoken may
 # need to download BPE data from the internet (~1-2 MB per encoding). Users
@@ -26,7 +43,7 @@ logger = logging.getLogger(__name__)
 # Set GPTME_TIKTOKEN_TIMEOUT=0 to skip tiktoken entirely (always use the
 # ~4 chars/token approximation). Set a larger value if the download
 # consistently times out on a slow internet connection.
-_TIKTOKEN_TIMEOUT = float(os.environ.get("GPTME_TIKTOKEN_TIMEOUT", "5.0"))
+_TIKTOKEN_TIMEOUT = _parse_tiktoken_timeout()
 
 
 def _load_encoding(name: str) -> "tiktoken.Encoding":
@@ -36,112 +53,147 @@ def _load_encoding(name: str) -> "tiktoken.Encoding":
     return tiktoken.get_encoding(name)
 
 
-@lru_cache
-def get_tokenizer(model: str) -> "tiktoken.Encoding | None":
-    """Get the tokenizer for a given model, with caching and fallbacks.
+class _GetTokenizer:
+    """Callable that loads tokenizers with timeout, caching only successful results.
 
-    Returns None if tiktoken is unavailable or encodings can't be loaded
-    (e.g. offline/airgapped environments). Callers should fall back to
-    character-based approximation when None is returned.
-
-    The first call for a given encoding may trigger a network download of
-    BPE data from OpenAI's CDN. To avoid blocking indefinitely on local /
-    airgapped setups, the download is wrapped in a timeout controlled by
-    the GPTME_TIKTOKEN_TIMEOUT env var (default 5 s). Set it to 0 to
-    always use the char-based approximation without attempting a download.
-    Pre-cache the encodings by running once with internet access, or set
-    TIKTOKEN_CACHE_DIR to a directory containing the pre-downloaded files.
+    Exposes ``cache_clear()`` for test compatibility with the previous
+    ``@lru_cache``-based implementation.
     """
-    try:
-        import tiktoken  # fmt: skip
-    except ImportError:
-        logger.warning(
-            "tiktoken not installed. Token counts will use character-based approximation."
-        )
-        return None
 
-    # Allow users to skip tiktoken entirely (useful for local-only setups).
-    if _TIKTOKEN_TIMEOUT <= 0:
-        logger.debug(
-            "GPTME_TIKTOKEN_TIMEOUT<=0: skipping tiktoken, using char-based approximation."
-        )
-        return None
+    def __call__(self, model: str) -> "tiktoken.Encoding | None":
+        """Get the tokenizer for a given model, with caching and fallbacks.
 
-    try:
-        # Determine the encoding name without loading BPE data (instant).
-        if "gpt-4o" in model:
-            encoding_name = "o200k_base"
-        else:
-            # Strip known provider prefixes so tiktoken.encoding_for_model can
-            # match the bare model name (e.g. "openai/o1" → "o1").
-            _provider_prefixes = [
-                "openai/",
-                "anthropic/",
-                "google/",
-                "azure/",
-                "vertex/",
-            ]
-            bare_model = model
-            for prefix in _provider_prefixes:
-                if model.startswith(prefix):
-                    bare_model = model[len(prefix) :]
-                    break
+        Returns None if tiktoken is unavailable or encodings can't be loaded
+        (e.g. offline/airgapped environments). Callers should fall back to
+        character-based approximation when None is returned.
 
-            try:
-                # MODEL_TO_ENCODING is a static dict — no network needed.
-                _enc: str | None = tiktoken.model.MODEL_TO_ENCODING.get(bare_model)
-                if _enc is None:
-                    # Check prefix table (e.g. "gpt-3.5-turbo-*")
-                    _enc = next(
-                        (
-                            enc
-                            for prefix, enc in tiktoken.model.MODEL_PREFIX_TO_ENCODING.items()
-                            if bare_model.startswith(prefix)
-                        ),
-                        None,
-                    )
-                if _enc is None:
-                    global _warned_models
-                    if bare_model not in _warned_models:
-                        logger.debug(
-                            f"No tokenizer for '{bare_model}'. Using tiktoken cl100k_base."
-                            " Use results only as estimates."
-                        )
-                        _warned_models |= {bare_model}
-                    encoding_name = "cl100k_base"
-                else:
-                    encoding_name = _enc
-            except AttributeError:
-                # Older tiktoken versions may not expose MODEL_TO_ENCODING.
-                encoding_name = "cl100k_base"
+        Successful loads are cached; failed or timed-out loads are NOT cached,
+        allowing retries after network recovery or TIKTOKEN_CACHE_DIR is populated.
 
-        # Load encoding with a timeout so we don't hang on airgapped systems.
-        # Use shutdown(wait=False) so a timed-out background thread doesn't
-        # block the caller — the thread finishes on its own (TCP timeout etc).
-        executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
-        future = executor.submit(_load_encoding, encoding_name)
+        The first call for a given encoding may trigger a network download of
+        BPE data from OpenAI's CDN. To avoid blocking indefinitely on local /
+        airgapped setups, the download is wrapped in a timeout controlled by
+        the GPTME_TIKTOKEN_TIMEOUT env var (default 5 s). Set it to 0 to
+        always use the char-based approximation without attempting a download.
+        Pre-cache the encodings by running once with internet access, or set
+        TIKTOKEN_CACHE_DIR to a directory containing the pre-downloaded files.
+        """
+        if model in _tokenizer_cache:
+            return _tokenizer_cache[model]
+
         try:
-            result = future.result(timeout=_TIKTOKEN_TIMEOUT)
-            executor.shutdown(wait=False)
-            return result
-        except concurrent.futures.TimeoutError:
-            executor.shutdown(wait=False)
+            import tiktoken  # fmt: skip
+        except ImportError:
             logger.warning(
-                f"tiktoken encoding '{encoding_name}' fetch timed out after"
-                f" {_TIKTOKEN_TIMEOUT:.1f}s. Using character-based approximation"
-                " (~4 chars/token). For offline/local-model use: pre-cache by"
-                " running once with internet access, or set TIKTOKEN_CACHE_DIR"
-                " to a directory with the encoding files. Set"
-                " GPTME_TIKTOKEN_TIMEOUT=0 to always use the approximation."
+                "tiktoken not installed. Token counts will use character-based approximation."
             )
             return None
 
-    except Exception as e:
-        logger.warning(
-            f"Failed to load tiktoken encoding: {e}. "
-            "Token counts will use character-based approximation (~4 chars/token)."
-        )
-        return None
+        # Allow users to skip tiktoken entirely (useful for local-only setups).
+        if _TIKTOKEN_TIMEOUT <= 0:
+            logger.debug(
+                "GPTME_TIKTOKEN_TIMEOUT<=0: skipping tiktoken, using char-based approximation."
+            )
+            return None
+
+        try:
+            # Determine the encoding name without loading BPE data (instant).
+            if "gpt-4o" in model:
+                encoding_name = "o200k_base"
+            else:
+                # Strip known provider prefixes so tiktoken.encoding_for_model can
+                # match the bare model name (e.g. "openai/o1" → "o1").
+                _provider_prefixes = [
+                    "openai/",
+                    "anthropic/",
+                    "google/",
+                    "azure/",
+                    "vertex/",
+                ]
+                bare_model = model
+                for prefix in _provider_prefixes:
+                    if model.startswith(prefix):
+                        bare_model = model[len(prefix) :]
+                        break
+
+                try:
+                    # MODEL_TO_ENCODING is a static dict — no network needed.
+                    _enc: str | None = tiktoken.model.MODEL_TO_ENCODING.get(bare_model)
+                    if _enc is None:
+                        # Check prefix table (e.g. "gpt-3.5-turbo-*")
+                        _enc = next(
+                            (
+                                enc
+                                for prefix, enc in tiktoken.model.MODEL_PREFIX_TO_ENCODING.items()
+                                if bare_model.startswith(prefix)
+                            ),
+                            None,
+                        )
+                    if _enc is None:
+                        global _warned_models
+                        if bare_model not in _warned_models:
+                            logger.debug(
+                                f"No tokenizer for '{bare_model}'. Using tiktoken cl100k_base."
+                                " Use results only as estimates."
+                            )
+                            _warned_models |= {bare_model}
+                        encoding_name = "cl100k_base"
+                    else:
+                        encoding_name = _enc
+                except AttributeError:
+                    # Older tiktoken versions may not expose MODEL_TO_ENCODING.
+                    encoding_name = "cl100k_base"
+
+            # Load encoding with a timeout so we don't hang on airgapped systems.
+            # Use a daemon thread so a timed-out fetch doesn't keep a short-lived
+            # process alive — non-daemon threads block process exit until they finish,
+            # which can delay CLI exit by the full TCP timeout.
+            result_holder: list[tiktoken.Encoding | Exception | None] = [None]
+
+            def _do_load() -> None:
+                try:
+                    result_holder[0] = _load_encoding(encoding_name)
+                except Exception as exc:
+                    result_holder[0] = exc
+
+            t = threading.Thread(target=_do_load, daemon=True, name="tiktoken-fetch")
+            t.start()
+            t.join(timeout=_TIKTOKEN_TIMEOUT)
+
+            if t.is_alive():
+                # Still fetching after timeout; return None without caching so that
+                # a future call can retry (e.g. after pre-caching the encodings).
+                logger.warning(
+                    f"tiktoken encoding '{encoding_name}' fetch timed out after"
+                    f" {_TIKTOKEN_TIMEOUT:.1f}s. Using character-based approximation"
+                    " (~4 chars/token). For offline/local-model use: pre-cache by"
+                    " running once with internet access, or set TIKTOKEN_CACHE_DIR"
+                    " to a directory with the encoding files. Set"
+                    " GPTME_TIKTOKEN_TIMEOUT=0 to always use the approximation."
+                )
+                return None
+
+            enc_or_exc = result_holder[0]
+            if isinstance(enc_or_exc, Exception):
+                raise enc_or_exc
+
+            if enc_or_exc is not None:
+                _tokenizer_cache[model] = enc_or_exc
+            return enc_or_exc
+
+        except Exception as e:
+            logger.warning(
+                f"Failed to load tiktoken encoding: {e}. "
+                "Token counts will use character-based approximation (~4 chars/token)."
+            )
+            return None
+
+    def cache_clear(self) -> None:
+        """Clear the tokenizer cache (for testing or after environment changes)."""
+        _tokenizer_cache.clear()
+
+
+get_tokenizer = _GetTokenizer()
 
 
 def _hash_content(content: str) -> str:

--- a/gptme/util/tokens.py
+++ b/gptme/util/tokens.py
@@ -1,5 +1,7 @@
+import concurrent.futures
 import hashlib
 import logging
+import os
 import typing
 from functools import lru_cache
 
@@ -16,6 +18,23 @@ _warned_models: set[str] = set()
 
 logger = logging.getLogger(__name__)
 
+# Timeout (seconds) for tiktoken encoding fetches. On first use tiktoken may
+# need to download BPE data from the internet (~1-2 MB per encoding). Users
+# on airgapped systems or pointing gptme at a local endpoint (Ollama, vLLM,
+# LiteLLM, …) would otherwise block here indefinitely on a TCP black-hole.
+#
+# Set GPTME_TIKTOKEN_TIMEOUT=0 to skip tiktoken entirely (always use the
+# ~4 chars/token approximation). Set a larger value if the download
+# consistently times out on a slow internet connection.
+_TIKTOKEN_TIMEOUT = float(os.environ.get("GPTME_TIKTOKEN_TIMEOUT", "5.0"))
+
+
+def _load_encoding(name: str) -> "tiktoken.Encoding":
+    """Load a tiktoken encoding (may trigger a network download on first use)."""
+    import tiktoken  # fmt: skip
+
+    return tiktoken.get_encoding(name)
+
 
 @lru_cache
 def get_tokenizer(model: str) -> "tiktoken.Encoding | None":
@@ -24,6 +43,14 @@ def get_tokenizer(model: str) -> "tiktoken.Encoding | None":
     Returns None if tiktoken is unavailable or encodings can't be loaded
     (e.g. offline/airgapped environments). Callers should fall back to
     character-based approximation when None is returned.
+
+    The first call for a given encoding may trigger a network download of
+    BPE data from OpenAI's CDN. To avoid blocking indefinitely on local /
+    airgapped setups, the download is wrapped in a timeout controlled by
+    the GPTME_TIKTOKEN_TIMEOUT env var (default 5 s). Set it to 0 to
+    always use the char-based approximation without attempting a download.
+    Pre-cache the encodings by running once with internet access, or set
+    TIKTOKEN_CACHE_DIR to a directory containing the pre-downloaded files.
     """
     try:
         import tiktoken  # fmt: skip
@@ -33,32 +60,82 @@ def get_tokenizer(model: str) -> "tiktoken.Encoding | None":
         )
         return None
 
+    # Allow users to skip tiktoken entirely (useful for local-only setups).
+    if _TIKTOKEN_TIMEOUT <= 0:
+        logger.debug(
+            "GPTME_TIKTOKEN_TIMEOUT<=0: skipping tiktoken, using char-based approximation."
+        )
+        return None
+
     try:
-        # Fast-path for known o200k_base models (handles provider-prefixed
-        # variants like "openai/gpt-4o" without needing a prefix strip for
-        # these specific models).
+        # Determine the encoding name without loading BPE data (instant).
         if "gpt-4o" in model:
-            return tiktoken.get_encoding("o200k_base")
+            encoding_name = "o200k_base"
+        else:
+            # Strip known provider prefixes so tiktoken.encoding_for_model can
+            # match the bare model name (e.g. "openai/o1" → "o1").
+            _provider_prefixes = [
+                "openai/",
+                "anthropic/",
+                "google/",
+                "azure/",
+                "vertex/",
+            ]
+            bare_model = model
+            for prefix in _provider_prefixes:
+                if model.startswith(prefix):
+                    bare_model = model[len(prefix) :]
+                    break
 
-        # Strip known provider prefixes so tiktoken.encoding_for_model can
-        # match the bare model name (e.g. "openai/o1" → "o1", which tiktoken
-        # knows uses o200k_base; "openai/gpt-4" → "gpt-4" → cl100k_base).
-        _provider_prefixes = ["openai/", "anthropic/", "google/", "azure/", "vertex/"]
-        for prefix in _provider_prefixes:
-            if model.startswith(prefix):
-                model = model[len(prefix) :]
-                break
+            try:
+                # MODEL_TO_ENCODING is a static dict — no network needed.
+                _enc: str | None = tiktoken.model.MODEL_TO_ENCODING.get(bare_model)
+                if _enc is None:
+                    # Check prefix table (e.g. "gpt-3.5-turbo-*")
+                    _enc = next(
+                        (
+                            enc
+                            for prefix, enc in tiktoken.model.MODEL_PREFIX_TO_ENCODING.items()
+                            if bare_model.startswith(prefix)
+                        ),
+                        None,
+                    )
+                if _enc is None:
+                    global _warned_models
+                    if bare_model not in _warned_models:
+                        logger.debug(
+                            f"No tokenizer for '{bare_model}'. Using tiktoken cl100k_base."
+                            " Use results only as estimates."
+                        )
+                        _warned_models |= {bare_model}
+                    encoding_name = "cl100k_base"
+                else:
+                    encoding_name = _enc
+            except AttributeError:
+                # Older tiktoken versions may not expose MODEL_TO_ENCODING.
+                encoding_name = "cl100k_base"
 
+        # Load encoding with a timeout so we don't hang on airgapped systems.
+        # Use shutdown(wait=False) so a timed-out background thread doesn't
+        # block the caller — the thread finishes on its own (TCP timeout etc).
+        executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+        future = executor.submit(_load_encoding, encoding_name)
         try:
-            return tiktoken.encoding_for_model(model)
-        except KeyError:
-            global _warned_models
-            if model not in _warned_models:
-                logger.debug(
-                    f"No tokenizer for '{model}'. Using tiktoken cl100k_base. Use results only as estimates."
-                )
-                _warned_models |= {model}
-            return tiktoken.get_encoding("cl100k_base")
+            result = future.result(timeout=_TIKTOKEN_TIMEOUT)
+            executor.shutdown(wait=False)
+            return result
+        except concurrent.futures.TimeoutError:
+            executor.shutdown(wait=False)
+            logger.warning(
+                f"tiktoken encoding '{encoding_name}' fetch timed out after"
+                f" {_TIKTOKEN_TIMEOUT:.1f}s. Using character-based approximation"
+                " (~4 chars/token). For offline/local-model use: pre-cache by"
+                " running once with internet access, or set TIKTOKEN_CACHE_DIR"
+                " to a directory with the encoding files. Set"
+                " GPTME_TIKTOKEN_TIMEOUT=0 to always use the approximation."
+            )
+            return None
+
     except Exception as e:
         logger.warning(
             f"Failed to load tiktoken encoding: {e}. "

--- a/gptme/util/tokens.py
+++ b/gptme/util/tokens.py
@@ -1,5 +1,6 @@
 import hashlib
 import logging
+import math
 import os
 import threading
 import typing
@@ -33,7 +34,13 @@ def _parse_tiktoken_timeout() -> float:
     """Parse GPTME_TIKTOKEN_TIMEOUT from the environment, falling back to 5.0."""
     raw = os.environ.get("GPTME_TIKTOKEN_TIMEOUT", "5.0")
     try:
-        return float(raw)
+        val = float(raw)
+        if math.isnan(val) or math.isinf(val):
+            logger.warning(
+                f"Invalid GPTME_TIKTOKEN_TIMEOUT value {raw!r} (NaN or infinite); using default 5.0 seconds."
+            )
+            return 5.0
+        return val
     except ValueError:
         logger.warning(
             f"Invalid GPTME_TIKTOKEN_TIMEOUT value {raw!r}; using default 5.0 seconds."

--- a/tests/test_util_tokens.py
+++ b/tests/test_util_tokens.py
@@ -377,6 +377,15 @@ def test_get_tokenizer_timeout_not_cached(monkeypatch):
         assert model not in tokens_mod._tokenizer_cache
         hang_event.set()  # unblock daemon thread
 
+        # Wait for the in-flight thread to finish its cleanup before retrying.
+        # Without this wait the second get_tokenizer call might join the still-running
+        # first thread (which used the _hang loader) instead of starting a fresh one.
+        import time
+
+        deadline = time.monotonic() + 1.0
+        while tokens_mod._inflight_loads and time.monotonic() < deadline:
+            time.sleep(0.001)
+
         # Second call: replace with a fast-returning loader to confirm retry happens
         fake_enc = object()
         load_called: list[str] = []
@@ -422,4 +431,43 @@ def test_get_tokenizer_successful_load_is_cached(monkeypatch):
             "Second call should be served from cache, not reload"
         )
     finally:
+        tokens_mod.get_tokenizer.cache_clear()
+
+
+def test_get_tokenizer_no_duplicate_threads(monkeypatch):
+    """Repeated calls during a timeout reuse the in-flight thread, not spawn new ones.
+
+    Regression test: in an airgapped/local-model session len_tokens() is called
+    repeatedly (once per message). Each call used to start a new daemon thread for
+    the same stuck encoding download, accumulating unbounded blocked threads.
+    """
+    import threading
+
+    import gptme.util.tokens as tokens_mod
+
+    tokens_mod.get_tokenizer.cache_clear()
+    model = "local/model-thread-dedup"
+    hang_event = threading.Event()
+    load_calls: list[str] = []
+
+    def _hang(name: str) -> None:
+        load_calls.append(name)
+        hang_event.wait()
+
+    monkeypatch.setattr(tokens_mod, "_load_encoding", _hang)
+    monkeypatch.setattr(tokens_mod, "_TIKTOKEN_TIMEOUT", 0.05)
+
+    try:
+        # Two sequential calls while the encoding thread is blocked.
+        # Both should time out and return None; only one thread should be created.
+        result1 = tokens_mod.get_tokenizer(model)
+        result2 = tokens_mod.get_tokenizer(model)
+
+        assert result1 is None
+        assert result2 is None
+        assert len(load_calls) == 1, (
+            f"Expected exactly one _load_encoding call (one thread), got {len(load_calls)}: {load_calls}"
+        )
+    finally:
+        hang_event.set()
         tokens_mod.get_tokenizer.cache_clear()

--- a/tests/test_util_tokens.py
+++ b/tests/test_util_tokens.py
@@ -195,29 +195,74 @@ def test_len_tokens_invalid_type():
 
 
 def test_get_tokenizer_returns_none_on_network_failure(monkeypatch):
-    """get_tokenizer returns None when tiktoken fails to load encodings."""
+    """get_tokenizer returns None when tiktoken raises a network-like error."""
     import gptme.util.tokens as tokens_mod
 
-    # Clear lru_cache so our patched version is called
     tokens_mod.get_tokenizer.cache_clear()
-
     try:
-        import tiktoken
-
-        # Patch tiktoken to raise network-like errors
+        # Patch _load_encoding (the function that actually downloads) to raise
         monkeypatch.setattr(
-            tiktoken,
-            "get_encoding",
+            tokens_mod,
+            "_load_encoding",
             lambda name: (_ for _ in ()).throw(Exception("Connection timed out")),
         )
-        monkeypatch.setattr(
-            tiktoken,
-            "encoding_for_model",
-            lambda name: (_ for _ in ()).throw(Exception("Connection timed out")),
-        )
-
         result = tokens_mod.get_tokenizer("some-offline-model")
         assert result is None
+    finally:
+        tokens_mod.get_tokenizer.cache_clear()
+
+
+def test_get_tokenizer_timeout_fallback(monkeypatch):
+    """get_tokenizer returns None and falls back to char-based when tiktoken hangs.
+
+    Regression test for the local-model / airgapped scenario described in
+    gptme Discussion #559: vLLM / Ollama users with a custom base_url would
+    block indefinitely on the cl100k_base BPE data download.
+    """
+    import threading
+
+    import gptme.util.tokens as tokens_mod
+
+    tokens_mod.get_tokenizer.cache_clear()
+    try:
+        # Simulate a hanging network fetch — block until the test gives up
+        hang_event = threading.Event()
+
+        def _hang(name: str):
+            hang_event.wait()  # blocks indefinitely during this test
+            raise RuntimeError("should not reach here")
+
+        monkeypatch.setattr(tokens_mod, "_load_encoding", _hang)
+        # Use a very short timeout so the test doesn't actually wait 5 s
+        monkeypatch.setattr(tokens_mod, "_TIKTOKEN_TIMEOUT", 0.05)
+
+        result = tokens_mod.get_tokenizer("ollama/llama3.2")
+        assert result is None
+
+        # Unblock the background thread so the executor can shut down cleanly
+        hang_event.set()
+    finally:
+        tokens_mod.get_tokenizer.cache_clear()
+
+
+def test_get_tokenizer_disabled_by_timeout_zero(monkeypatch):
+    """GPTME_TIKTOKEN_TIMEOUT=0 skips tiktoken entirely — no network attempt."""
+    import gptme.util.tokens as tokens_mod
+
+    tokens_mod.get_tokenizer.cache_clear()
+    try:
+        called = []
+
+        def _should_not_be_called(name: str):
+            called.append(name)
+            raise RuntimeError("tiktoken should not be called when timeout=0")
+
+        monkeypatch.setattr(tokens_mod, "_load_encoding", _should_not_be_called)
+        monkeypatch.setattr(tokens_mod, "_TIKTOKEN_TIMEOUT", 0.0)
+
+        result = tokens_mod.get_tokenizer("any-local-model")
+        assert result is None
+        assert not called, f"_load_encoding was called unexpectedly: {called}"
     finally:
         tokens_mod.get_tokenizer.cache_clear()
 

--- a/tests/test_util_tokens.py
+++ b/tests/test_util_tokens.py
@@ -324,3 +324,102 @@ def test_len_tokens_approximation_not_cached():
         tokens_mod.get_tokenizer = orig_get_tokenizer
         tokens_mod._token_cache.clear()
         orig_get_tokenizer.cache_clear()
+
+
+def test_tiktoken_timeout_invalid_env():
+    """Invalid GPTME_TIKTOKEN_TIMEOUT value falls back to 5.0 instead of crashing."""
+    # Monkeypatching os.environ is not needed here — we test the parser directly
+    import os
+    import unittest.mock as mock
+
+    from gptme.util.tokens import _parse_tiktoken_timeout
+
+    with mock.patch.dict(os.environ, {"GPTME_TIKTOKEN_TIMEOUT": "not-a-number"}):
+        val = _parse_tiktoken_timeout()
+    assert val == 5.0
+
+
+def test_tiktoken_timeout_valid_env():
+    """Valid GPTME_TIKTOKEN_TIMEOUT values are parsed correctly."""
+    import os
+    import unittest.mock as mock
+
+    from gptme.util.tokens import _parse_tiktoken_timeout
+
+    with mock.patch.dict(os.environ, {"GPTME_TIKTOKEN_TIMEOUT": "0"}):
+        assert _parse_tiktoken_timeout() == 0.0
+
+    with mock.patch.dict(os.environ, {"GPTME_TIKTOKEN_TIMEOUT": "10.5"}):
+        assert _parse_tiktoken_timeout() == 10.5
+
+
+def test_get_tokenizer_timeout_not_cached(monkeypatch):
+    """Timeout results (None) are NOT cached, enabling retries after network recovery."""
+    import threading
+
+    import gptme.util.tokens as tokens_mod
+
+    tokens_mod.get_tokenizer.cache_clear()
+    model = "local/model-retry-test"
+    try:
+        # First call: simulate a hang → timeout → None (not cached)
+        hang_event = threading.Event()
+
+        def _hang(name: str) -> None:
+            hang_event.wait()
+
+        monkeypatch.setattr(tokens_mod, "_load_encoding", _hang)
+        monkeypatch.setattr(tokens_mod, "_TIKTOKEN_TIMEOUT", 0.05)
+
+        result1 = tokens_mod.get_tokenizer(model)
+        assert result1 is None
+        # None must NOT be cached — _tokenizer_cache should still be empty for this model
+        assert model not in tokens_mod._tokenizer_cache
+        hang_event.set()  # unblock daemon thread
+
+        # Second call: replace with a fast-returning loader to confirm retry happens
+        fake_enc = object()
+        load_called: list[str] = []
+
+        def _fast(name: str):
+            load_called.append(name)
+            return fake_enc
+
+        monkeypatch.setattr(tokens_mod, "_load_encoding", _fast)
+        monkeypatch.setattr(tokens_mod, "_TIKTOKEN_TIMEOUT", 5.0)
+
+        result2 = tokens_mod.get_tokenizer(model)
+        assert result2 is fake_enc, "Expected retry to succeed after timeout"
+        assert load_called, (
+            "Expected _load_encoding to be called on retry (not served None from cache)"
+        )
+    finally:
+        tokens_mod.get_tokenizer.cache_clear()
+
+
+def test_get_tokenizer_successful_load_is_cached(monkeypatch):
+    """Successful tokenizer loads ARE cached so repeated calls don't reload."""
+    import gptme.util.tokens as tokens_mod
+
+    tokens_mod.get_tokenizer.cache_clear()
+    model = "gpt-4-cache-test"
+    try:
+        load_count: list[str] = []
+        fake_enc = object()
+
+        def _counting_load(name: str):
+            load_count.append(name)
+            return fake_enc
+
+        monkeypatch.setattr(tokens_mod, "_load_encoding", _counting_load)
+
+        result1 = tokens_mod.get_tokenizer(model)
+        result2 = tokens_mod.get_tokenizer(model)
+
+        assert result1 is fake_enc
+        assert result2 is fake_enc
+        assert len(load_count) == 1, (
+            "Second call should be served from cache, not reload"
+        )
+    finally:
+        tokens_mod.get_tokenizer.cache_clear()


### PR DESCRIPTION
## Summary

- Wraps tiktoken BPE data fetch in a `ThreadPoolExecutor` with a configurable timeout (`GPTME_TIKTOKEN_TIMEOUT`, default 5 s) so `gptme` never blocks indefinitely when encoding files aren't cached and the host can't reach `openaipublic.blob.core.windows.net`
- Fixes the common local-model setup pain: Ollama / vLLM / LiteLLM / airgapped systems hang on startup because tiktoken tries to download `cl100k_base.tiktoken` (~1 MB) on first use
- Strips provider prefixes (`openai/`, `anthropic/`, …) before the `MODEL_TO_ENCODING` static-dict lookup so `openai/o1` → `o200k_base` instead of falling through to `cl100k_base`

## Behaviour

| Scenario | Before | After |
|---|---|---|
| tiktoken cached (normal) | works | works (unchanged) |
| tiktoken not installed | returns `None` | returns `None` (unchanged) |
| BPE fetch hangs (airgapped) | **hangs indefinitely** | logs warning, returns `None`, uses `~4 chars/token` |
| `GPTME_TIKTOKEN_TIMEOUT=0` | N/A | skips tiktoken entirely from the start |
| `openai/o1` model | → `cl100k_base` (wrong) | → `o200k_base` (correct) |

The `len_tokens()` signature is unchanged. Approximated counts are not stored in `_token_cache` so accurate counts are used if the tokenizer later becomes available.

## Configuration

```bash
# Default — 5 second timeout for BPE data download
# Set higher on slow connections:
export GPTME_TIKTOKEN_TIMEOUT=30

# Disable tiktoken entirely (always use char-based approximation):
export GPTME_TIKTOKEN_TIMEOUT=0

# Pre-cache encodings for offline use:
python -c "import tiktoken; tiktoken.get_encoding('cl100k_base'); tiktoken.get_encoding('o200k_base')"
# Or point at a directory with pre-downloaded .tiktoken files:
export TIKTOKEN_CACHE_DIR=/path/to/cache
```

## Test plan

- [x] `test_get_tokenizer_timeout_fallback` — simulates a hanging download, asserts `None` returned
- [x] `test_get_tokenizer_disabled_by_timeout_zero` — asserts `_load_encoding` never called when `TIMEOUT=0`
- [x] `test_len_tokens_fallback_approximation` — asserts `400 chars → 100 tokens` via char fallback
- [x] `test_len_tokens_approximation_not_cached` — asserts approximated results are not stored in cache
- [x] All 21 tests pass: `uv run --with tiktoken pytest tests/test_util_tokens.py`