### PR TITLE
feat(subagent): subagent_steer() — inject steering messages into running subagents

### DIFF
--- a/gptme/chat.py
+++ b/gptme/chat.py
@@ -175,11 +175,12 @@ def chat(
             for msg in session_end_msgs:
                 manager.append(msg)
     finally:
-        # Write a sentinel file so subprocess-mode subagent_steer() can detect
-        # that the chat loop has finished draining the prompt queue. For thread
-        # mode, the Python event (prompt_queue_closed) handles this; subprocess
-        # mode needs a file-based signal because the child and parent don't share
-        # memory. Written before set_output_format to minimise the race window.
+        # Safety-net sentinel write.  The primary writes happen inside
+        # _run_chat_loop at the actual break/raise points so the window between
+        # the final _drain_external_prompt_queue() call and the sentinel being
+        # visible is just a few bytecode instructions.  This finally block
+        # catches any exit path we didn't explicitly handle (exceptions, etc.).
+        # touch() is idempotent so double-writing is harmless.
         if logdir is not None:
             (logdir / "prompt-queue-closed").touch()
         # Restore the caller's format so nested chat() calls (inline subagents)
@@ -231,7 +232,11 @@ def _run_chat_loop(
                 except SessionCompleteException:
                     _drain_external_prompt_queue(manager, prompt_queue)
                     if not prompt_queue:
-                        # No more prompts, properly exit
+                        # No more prompts, properly exit.  Write the sentinel
+                        # before raising so the subprocess-mode race window is
+                        # closed at this boundary too.
+                        if logdir is not None:
+                            (logdir / "prompt-queue-closed").touch()
                         raise
                     # More chained prompts remain — continue processing them
                     logger.debug(
@@ -243,6 +248,12 @@ def _run_chat_loop(
                 # Get user input or exit if non-interactive
                 if not interactive:
                     logger.debug("Non-interactive and exhausted prompts")
+                    # Write the sentinel here, at the actual drain boundary, so
+                    # subprocess-mode subagent_steer() cannot falsely succeed in
+                    # the gap between the final _drain_external_prompt_queue call
+                    # above and the chat() finally block below.
+                    if logdir is not None:
+                        (logdir / "prompt-queue-closed").touch()
                     break
 
                 user_input = _get_user_input(manager.log, manager.workspace)

--- a/gptme/chat.py
+++ b/gptme/chat.py
@@ -175,6 +175,13 @@ def chat(
             for msg in session_end_msgs:
                 manager.append(msg)
     finally:
+        # Write a sentinel file so subprocess-mode subagent_steer() can detect
+        # that the chat loop has finished draining the prompt queue. For thread
+        # mode, the Python event (prompt_queue_closed) handles this; subprocess
+        # mode needs a file-based signal because the child and parent don't share
+        # memory. Written before set_output_format to minimise the race window.
+        if logdir is not None:
+            (logdir / "prompt-queue-closed").touch()
         # Restore the caller's format so nested chat() calls (inline subagents)
         # don't clobber the parent's JSON mode when they exit.
         set_output_format(_prev_output_format)

--- a/gptme/chat.py
+++ b/gptme/chat.py
@@ -149,6 +149,14 @@ def chat(
         # Note: Confirmation is now handled within ToolUse.execute() using the hook system,
         # so we no longer need to create and pass confirm_func.
 
+        # Clear any stale prompt-queue-closed sentinel from a previous run.
+        # Planner-mode subagents reuse the same logdir (same agent_id); the
+        # sentinel from a prior run would otherwise falsely block steering of
+        # the new run even though subagent_steer()'s started_at guard already
+        # handles this — belt-and-suspenders cleanup at the start of each run.
+        if logdir is not None:
+            (logdir / "prompt-queue-closed").unlink(missing_ok=True)
+
         # Convert prompt_msgs to a queue for unified handling
         prompt_queue = list(prompt_msgs)
 

--- a/gptme/chat.py
+++ b/gptme/chat.py
@@ -238,15 +238,22 @@ def _run_chat_loop(
                         manager, stream, tool_format, model, output_schema
                     )
                 except SessionCompleteException:
+                    # Write sentinel BEFORE draining so there is no window
+                    # where the queue file is gone but the sentinel is not yet
+                    # visible.  A concurrent subagent_steer() in that gap would
+                    # see neither the sentinel nor the closed event, write a
+                    # new queue entry, and falsely report success even though
+                    # the chat loop has no remaining drain point.
+                    # If drain finds more chained prompts we unlink the sentinel
+                    # so the loop stays open for steering.
+                    if logdir is not None:
+                        (logdir / "prompt-queue-closed").touch()
                     _drain_external_prompt_queue(manager, prompt_queue)
                     if not prompt_queue:
-                        # No more prompts, properly exit.  Write the sentinel
-                        # before raising so the subprocess-mode race window is
-                        # closed at this boundary too.
-                        if logdir is not None:
-                            (logdir / "prompt-queue-closed").touch()
                         raise
-                    # More chained prompts remain — continue processing them
+                    # More chained prompts remain — clear sentinel, keep loop alive.
+                    if logdir is not None:
+                        (logdir / "prompt-queue-closed").unlink(missing_ok=True)
                     logger.debug(
                         "complete called but %d chained prompts remain, continuing",
                         len(prompt_queue),

--- a/gptme/chat.py
+++ b/gptme/chat.py
@@ -263,12 +263,24 @@ def _run_chat_loop(
                 # Get user input or exit if non-interactive
                 if not interactive:
                     logger.debug("Non-interactive and exhausted prompts")
-                    # Write the sentinel here, at the actual drain boundary, so
-                    # subprocess-mode subagent_steer() cannot falsely succeed in
-                    # the gap between the final _drain_external_prompt_queue call
-                    # above and the chat() finally block below.
+                    # Write sentinel BEFORE the final drain so there is no window
+                    # where a concurrent subagent_steer() can append after the
+                    # top-of-loop drain but before the sentinel is visible. Any
+                    # steer arriving after this touch() sees the sentinel and
+                    # raises ValueError; any steer that arrived before it is
+                    # caught by the drain below.
                     if logdir is not None:
                         (logdir / "prompt-queue-closed").touch()
+                    _drain_external_prompt_queue(manager, prompt_queue)
+                    if prompt_queue:
+                        # A steer arrived in the window — keep the loop alive.
+                        if logdir is not None:
+                            (logdir / "prompt-queue-closed").unlink(missing_ok=True)
+                        logger.debug(
+                            "steer arrived at drain boundary, %d prompt(s) queued, continuing",
+                            len(prompt_queue),
+                        )
+                        continue
                     break
 
                 user_input = _get_user_input(manager.log, manager.workspace)

--- a/gptme/tools/subagent/__init__.py
+++ b/gptme/tools/subagent/__init__.py
@@ -20,6 +20,7 @@ from .api import (
     subagent_read_log,
     subagent_reply,
     subagent_status,
+    subagent_steer,
     subagent_wait,
     subagent_wait_any,
 )
@@ -357,6 +358,20 @@ Assistant: I'll use context_window=0 so the subagent only sees what I explicitly
         ).to_output(tool_format)
     }
 System: Subagent started successfully.
+
+### Steer a Running Subagent (in-flight course correction)
+User: redirect a running subagent without restarting it
+Assistant: I'll use subagent_steer() to inject a new instruction into the running subagent's conversation.
+{
+        ToolUse(
+            "ipython",
+            [],
+            '''subagent("researcher", "Research Python web frameworks and their performance")
+# ... later, after checking progress ...
+subagent_steer("researcher", "Focus only on async frameworks — skip synchronous ones like Flask/Django")''',
+        ).to_output(tool_format)
+    }
+System: Steering message queued for subagent 'researcher'. It will be injected into the subagent's conversation on its next loop iteration.
 """.strip()
 
 
@@ -384,8 +399,9 @@ Key features:
 - subagent_pipeline(items, *stages, timeout): Multi-stage fan-out with no barrier between stages — item A advances to stage 2 while item B is still in stage 1; each stage callable receives (item_prompt, prev_result) and returns the next stage's prompt
 - subagent_batch(): Start multiple subagents and return a BatchJob for explicit synchronization
 - subagent_cancel(): Cancel a running subagent (SIGTERM for subprocess, marks result for threads)
+- subagent_steer(agent_id, message): Inject a steering message into a RUNNING subagent's conversation — redirect, clarify, or course-correct mid-run without restarting. Works for thread-mode and subprocess-mode subagents. Distinct from subagent_reply() which only works on finished clarification_needed subagents.
 - subagent_wait_any(agent_ids, timeout): Wait for the first of N subagents to complete — returns (agent_id, result). Useful for race/hedging patterns.
-- subagent_reply(agent_id, reply): Answer a clarification request and re-spawn the subagent
+- subagent_reply(agent_id, reply): Answer a clarification request and re-spawn the subagent (for subagents that already stopped with clarification_needed status)
 - Hook-based notifications: Completions (and clarification requests) delivered as system messages
 
 ## Token Budget and Concurrency Control
@@ -518,6 +534,7 @@ tool = ToolSpec(
         for f in [
             subagent,
             subagent_cancel,
+            subagent_steer,
             subagent_list,
             subagent_reply,
             subagent_status,
@@ -554,6 +571,7 @@ __all__ = [
     # Public API
     "subagent",
     "subagent_cancel",
+    "subagent_steer",
     "subagent_list",
     "subagent_reply",
     "subagent_status",

--- a/gptme/tools/subagent/api.py
+++ b/gptme/tools/subagent/api.py
@@ -1166,19 +1166,19 @@ def subagent_steer(agent_id: str, message: str) -> str:
             does not expose a logdir channel for steering.
 
     Note:
-        Delivery is **guaranteed for thread-mode** subagents: ``prompt_queue_closed``
-        is set inside the subagent thread immediately when ``chat()`` returns,
-        so any steer attempted after that point raises ``ValueError``.
+        Delivery is **guaranteed for both thread-mode and subprocess-mode**
+        subagents:
 
-        For **subprocess-mode** subagents, delivery is best-effort: there is an
-        inherent window between the child's ``chat()`` loop finishing its last
-        prompt-queue drain and the parent detecting process exit via
-        ``process.poll()``. In practice this window is sub-millisecond (process
-        cleanup only), but it cannot be fully closed without a child-side
-        drain-complete signal (which would require modifying ``chat()`` itself,
-        beyond the scope of this PR). ``prompt_queue_closed`` is set when the
-        subprocess exits, catching the post-exit case; the pre-exit cleanup window
-        is an accepted best-effort limitation.
+        - **Thread mode**: ``prompt_queue_closed`` is a Python event set inside
+          the subagent thread immediately when ``chat()`` returns.
+        - **Subprocess mode**: ``chat()`` writes a ``"prompt-queue-closed"``
+          sentinel file to the logdir in its ``finally`` block — before the
+          process exits — giving a child-side signal that closes the drain
+          boundary precisely.  The parent-side ``prompt_queue_closed`` event
+          (set after ``_monitor_subprocess`` returns) is a second-level catch.
+
+        Any steer attempted after the sentinel/event is set raises
+        ``ValueError``.
 
     Example::
 
@@ -1200,15 +1200,28 @@ def subagent_steer(agent_id: str, message: str) -> str:
             "for ACP subagents — they run in a separate harness with no shared logdir channel."
         )
 
-    # Check prompt_queue_closed first: for thread mode, set inside
-    # _create_subagent_thread right after chat() returns (before any caller
-    # cleanup); for subprocess mode, set in the launcher's finally block after
-    # the process exits. Both paths fire before the disk-reading _read_log()
-    # and result caching, giving an earlier signal than status() alone.
-    # Known limitation: a sub-millisecond window remains between chat()'s last
-    # _drain_external_prompt_queue() call and the event being set; closing that
-    # would require modifying chat() itself.
-    if sa.prompt_queue_closed.is_set():
+    def _queue_is_closed() -> bool:
+        """Return True if the subagent's chat loop has finished draining.
+
+        Thread mode: prompt_queue_closed is a Python event set inside
+        _create_subagent_thread immediately when chat() returns.
+
+        Subprocess mode: chat.py writes a "prompt-queue-closed" sentinel file
+        to the logdir in its finally block — before the process exits — giving
+        a child-side signal that closes the gap between the last queue drain and
+        process exit.  The Python event (set in the launcher's finally block
+        after _monitor_subprocess returns) is a second-level catch.
+        """
+        return sa.prompt_queue_closed.is_set() or (
+            sa.execution_mode == "subprocess"
+            and (sa.logdir / "prompt-queue-closed").exists()
+        )
+
+    # Check prompt_queue_closed / sentinel first: both paths fire as close as
+    # possible to the actual last drain boundary (thread: Python event set inside
+    # the thread; subprocess: sentinel file written by chat.py's finally block
+    # before process exit, so no gap between last drain and parent detection).
+    if _queue_is_closed():
         raise ValueError(
             f"Subagent '{agent_id}' has closed its prompt queue — "
             "its chat loop has finished and will not accept new steering messages."
@@ -1226,9 +1239,7 @@ def subagent_steer(agent_id: str, message: str) -> str:
 
     # Re-check after queuing: catches the race where the subagent exits between
     # the initial check and the queue write.
-    # prompt_queue_closed catches the cleanup window (chat() returned but result
-    # not yet cached); status() catches the post-cache case.
-    if sa.prompt_queue_closed.is_set():
+    if _queue_is_closed():
         raise ValueError(
             f"Subagent '{agent_id}' closed its prompt queue while the steering message "
             "was being queued. The message will not be processed."

--- a/gptme/tools/subagent/api.py
+++ b/gptme/tools/subagent/api.py
@@ -1167,22 +1167,25 @@ def subagent_steer(agent_id: str, message: str) -> str:
             "for ACP subagents — they run in a separate harness with no shared logdir channel."
         )
 
-    if not sa.is_running():
+    pre_status = sa.status().status
+    if pre_status != "running":
         raise ValueError(
-            f"Subagent '{agent_id}' is not running (status: {sa.status().status}). "
+            f"Subagent '{agent_id}' is not running (status: {pre_status}). "
             "Only active subagents can be steered. "
             "For clarification_needed subagents, use subagent_reply() to re-spawn them."
         )
 
     queue_prompt(sa.logdir, message)
 
-    # Re-check is_running() after queuing to detect the race where the subagent
-    # exits between the initial check and the queue write. If it's no longer
-    # running, the queued message will never be drained.
-    if not sa.is_running():
+    # Re-check status() after queuing to detect the race where the subagent exits
+    # between the initial check and the queue write. Using status() (not is_running())
+    # catches the thread-mode "cleanup window": the thread is still alive, but chat()
+    # has returned and the result is already cached — is_running() would falsely pass.
+    post_status = sa.status().status
+    if post_status != "running":
         raise ValueError(
             f"Subagent '{agent_id}' exited after steering message was queued. "
-            "The message may not be processed. Status: {sa.status().status}"
+            f"The message may not be processed. Status: {post_status}"
         )
 
     logger.info(f"Steering message queued for subagent '{agent_id}': {message[:80]!r}")

--- a/gptme/tools/subagent/api.py
+++ b/gptme/tools/subagent/api.py
@@ -1167,25 +1167,22 @@ def subagent_steer(agent_id: str, message: str) -> str:
             "for ACP subagents — they run in a separate harness with no shared logdir channel."
         )
 
-    pre_status = sa.status().status
-    if pre_status != "running":
+    if not sa.is_running():
         raise ValueError(
-            f"Subagent '{agent_id}' is not running (status: {pre_status}). "
+            f"Subagent '{agent_id}' is not running (status: {sa.status().status}). "
             "Only active subagents can be steered. "
             "For clarification_needed subagents, use subagent_reply() to re-spawn them."
         )
 
     queue_prompt(sa.logdir, message)
 
-    # Re-check status() after queuing to detect the race where the subagent exits
-    # between the initial check and the queue write. Using status() (not is_running())
-    # catches the thread-mode "cleanup window": the thread is still alive, but chat()
-    # has returned and the result is already cached — is_running() would falsely pass.
-    post_status = sa.status().status
-    if post_status != "running":
+    # Re-check is_running() after queuing to detect the race where the subagent
+    # exits between the initial check and the queue write. If it's no longer
+    # running, the queued message will never be drained.
+    if not sa.is_running():
         raise ValueError(
             f"Subagent '{agent_id}' exited after steering message was queued. "
-            f"The message may not be processed. Status: {post_status}"
+            f"The message may not be processed. Status: {sa.status().status}"
         )
 
     logger.info(f"Steering message queued for subagent '{agent_id}': {message[:80]!r}")

--- a/gptme/tools/subagent/api.py
+++ b/gptme/tools/subagent/api.py
@@ -1120,6 +1120,68 @@ def subagent_cancel(agent_id: str) -> str:
     )
 
 
+def subagent_steer(agent_id: str, message: str) -> str:
+    """Inject a steering message into a running subagent's conversation.
+
+    The message is queued via the subagent's logdir prompt-queue and picked up
+    on the subagent's next chat loop iteration, allowing the orchestrator to
+    redirect, clarify, or course-correct a subagent mid-run without restarting
+    it. Works for thread-mode and subprocess-mode subagents.
+
+    This is distinct from ``subagent_reply()``, which re-spawns a subagent that
+    has *already stopped* with a ``clarification_needed`` status. Use this
+    function to steer a subagent that is still actively running.
+
+    Args:
+        agent_id: The running subagent to steer.
+        message: The guidance to inject. This will appear as a user turn in the
+            subagent's conversation on its next loop iteration.
+
+    Returns:
+        A human-readable confirmation message.
+
+    Raises:
+        ValueError: If no subagent with ``agent_id`` is found, or if the
+            subagent has already finished (use ``subagent_reply()`` for
+            clarification-needed subagents).
+        NotImplementedError: If the subagent is running in ACP mode, which
+            does not expose a logdir channel for steering.
+
+    Example::
+
+        subagent("researcher", "Research Python async frameworks")
+        # ... the researcher is going off-track ...
+        subagent_steer("researcher", "Focus only on frameworks with >5k GitHub stars")
+    """
+    from ...prompt_queue import queue_prompt  # fmt: skip
+
+    with _subagents_lock:
+        sa = next((s for s in _subagents if s.agent_id == agent_id), None)
+
+    if sa is None:
+        raise ValueError(f"Subagent with ID {agent_id!r} not found.")
+
+    if sa.execution_mode == "acp":
+        raise NotImplementedError(
+            f"Subagent '{agent_id}' is in ACP mode. Steering is not supported "
+            "for ACP subagents — they run in a separate harness with no shared logdir channel."
+        )
+
+    if not sa.is_running():
+        raise ValueError(
+            f"Subagent '{agent_id}' is not running (status: {sa.status().status}). "
+            "Only active subagents can be steered. "
+            "For clarification_needed subagents, use subagent_reply() to re-spawn them."
+        )
+
+    queue_prompt(sa.logdir, message)
+    logger.info(f"Steering message queued for subagent '{agent_id}': {message[:80]!r}")
+    return (
+        f"Steering message queued for subagent '{agent_id}'. "
+        "It will be injected into the subagent's conversation on its next loop iteration."
+    )
+
+
 def subagent_reply(agent_id: str, reply: str) -> None:
     """Re-spawn a subagent that requested clarification.
 

--- a/gptme/tools/subagent/api.py
+++ b/gptme/tools/subagent/api.py
@@ -1175,6 +1175,16 @@ def subagent_steer(agent_id: str, message: str) -> str:
         )
 
     queue_prompt(sa.logdir, message)
+
+    # Re-check is_running() after queuing to detect the race where the subagent
+    # exits between the initial check and the queue write. If it's no longer
+    # running, the queued message will never be drained.
+    if not sa.is_running():
+        raise ValueError(
+            f"Subagent '{agent_id}' exited after steering message was queued. "
+            "The message may not be processed. Status: {sa.status().status}"
+        )
+
     logger.info(f"Steering message queued for subagent '{agent_id}': {message[:80]!r}")
     return (
         f"Steering message queued for subagent '{agent_id}'. "

--- a/gptme/tools/subagent/api.py
+++ b/gptme/tools/subagent/api.py
@@ -906,6 +906,11 @@ def subagent(
                 with _subagents_lock:
                     sa = next((s for s in _subagents if s.agent_id == agent_id), None)
                 if sa:
+                    # Mark the prompt queue as closed: chat() has returned and will no
+                    # longer drain prompt-queue.jsonl. Set this before _read_log() so
+                    # subagent_steer() can detect the cleanup window without waiting
+                    # for the disk read and result caching to complete.
+                    sa.prompt_queue_closed.set()
                     # Use _read_log() instead of status(): the thread is still alive here,
                     # so status() would return "running" and poison the result cache.
                     result = sa._read_log()
@@ -1167,6 +1172,15 @@ def subagent_steer(agent_id: str, message: str) -> str:
             "for ACP subagents — they run in a separate harness with no shared logdir channel."
         )
 
+    # Check prompt_queue_closed first: set by run_subagent() immediately when
+    # chat() returns, before the disk-reading _read_log() and result caching.
+    # This is an earlier and more reliable signal than status() alone.
+    if sa.prompt_queue_closed.is_set():
+        raise ValueError(
+            f"Subagent '{agent_id}' has closed its prompt queue — "
+            "its chat loop has finished and will not accept new steering messages."
+        )
+
     pre_status = sa.status().status
     if pre_status != "running":
         raise ValueError(
@@ -1177,10 +1191,15 @@ def subagent_steer(agent_id: str, message: str) -> str:
 
     queue_prompt(sa.logdir, message)
 
-    # Re-check status() after queuing to detect the race where the subagent exits
-    # between the initial check and the queue write. Using status() (not is_running())
-    # catches the thread-mode "cleanup window": the thread is still alive, but chat()
-    # has returned and the result is already cached — is_running() would falsely pass.
+    # Re-check after queuing: catches the race where the subagent exits between
+    # the initial check and the queue write.
+    # prompt_queue_closed catches the cleanup window (chat() returned but result
+    # not yet cached); status() catches the post-cache case.
+    if sa.prompt_queue_closed.is_set():
+        raise ValueError(
+            f"Subagent '{agent_id}' closed its prompt queue while the steering message "
+            "was being queued. The message will not be processed."
+        )
     post_status = sa.status().status
     if post_status != "running":
         raise ValueError(

--- a/gptme/tools/subagent/api.py
+++ b/gptme/tools/subagent/api.py
@@ -1220,11 +1220,19 @@ def subagent_steer(agent_id: str, message: str) -> str:
         ``chat()``, before the process exits.  ``prompt_queue_closed`` is
         set by the parent launcher after the process exits — a second-level
         catch here too.
+
+        Stale-sentinel guard: planner-mode subagents reuse the same logdir
+        across runs (same ``agent_id`` → same ``subagent-{agent_id}``
+        directory).  A sentinel written by a *previous* run persists on
+        disk.  We ignore it by requiring the file's mtime to be no earlier
+        than ``sa.started_at`` (seconds since epoch, set when the Subagent
+        object is created at spawn time).
         """
-        return (
-            sa.prompt_queue_closed.is_set()
-            or (sa.logdir / "prompt-queue-closed").exists()
+        sentinel = sa.logdir / "prompt-queue-closed"
+        sentinel_is_current = (
+            sentinel.exists() and sentinel.stat().st_mtime >= sa.started_at
         )
+        return sa.prompt_queue_closed.is_set() or sentinel_is_current
 
     # Check closed state first: sentinel file is written at the actual drain
     # boundary for both thread and subprocess modes (see _queue_is_closed).

--- a/gptme/tools/subagent/api.py
+++ b/gptme/tools/subagent/api.py
@@ -805,6 +805,13 @@ def subagent(
                     notify_completion(agent_id, "failure", f"Subprocess failed: {e}")
                 _exec._cleanup_isolation(sa)
             finally:
+                # Mark the prompt queue as closed: the subprocess has exited (or
+                # never started). Any steer attempt after this point would write
+                # to a queue that no process will drain. Set before _sem.release()
+                # so subagent_steer() can detect this via prompt_queue_closed
+                # even during the narrow window between process exit and result
+                # caching.
+                sa.prompt_queue_closed.set()
                 _sem.release()
 
         launcher = threading.Thread(target=_launch_subprocess, daemon=True)

--- a/gptme/tools/subagent/api.py
+++ b/gptme/tools/subagent/api.py
@@ -1203,24 +1203,31 @@ def subagent_steer(agent_id: str, message: str) -> str:
     def _queue_is_closed() -> bool:
         """Return True if the subagent's chat loop has finished draining.
 
-        Thread mode: prompt_queue_closed is a Python event set inside
-        _create_subagent_thread immediately when chat() returns.
+        Both modes: chat.py writes a "prompt-queue-closed" sentinel file to
+        the logdir at the actual drain boundary — right before the ``break``
+        in ``_run_chat_loop`` (non-interactive exit) and right before raising
+        ``SessionCompleteException`` — and again in ``chat()``'s ``finally``
+        block as a safety net.  Checking this file for both thread and
+        subprocess mode closes the race window between ``chat()``'s last
+        drain and ``prompt_queue_closed.set()`` being called.
 
-        Subprocess mode: chat.py writes a "prompt-queue-closed" sentinel file
-        to the logdir in its finally block — before the process exits — giving
-        a child-side signal that closes the gap between the last queue drain and
-        process exit.  The Python event (set in the launcher's finally block
-        after _monitor_subprocess returns) is a second-level catch.
+        Thread mode: the sentinel file is the primary, early signal.
+        ``prompt_queue_closed`` is a Python event set immediately *after*
+        ``chat()`` returns — slightly later than the file, so it is a
+        second-level catch.
+
+        Subprocess mode: the sentinel file is written by the child inside
+        ``chat()``, before the process exits.  ``prompt_queue_closed`` is
+        set by the parent launcher after the process exits — a second-level
+        catch here too.
         """
-        return sa.prompt_queue_closed.is_set() or (
-            sa.execution_mode == "subprocess"
-            and (sa.logdir / "prompt-queue-closed").exists()
+        return (
+            sa.prompt_queue_closed.is_set()
+            or (sa.logdir / "prompt-queue-closed").exists()
         )
 
-    # Check prompt_queue_closed / sentinel first: both paths fire as close as
-    # possible to the actual last drain boundary (thread: Python event set inside
-    # the thread; subprocess: sentinel file written by chat.py's finally block
-    # before process exit, so no gap between last drain and parent detection).
+    # Check closed state first: sentinel file is written at the actual drain
+    # boundary for both thread and subprocess modes (see _queue_is_closed).
     if _queue_is_closed():
         raise ValueError(
             f"Subagent '{agent_id}' has closed its prompt queue — "

--- a/gptme/tools/subagent/api.py
+++ b/gptme/tools/subagent/api.py
@@ -848,6 +848,11 @@ def subagent(
         # Thread mode: original behavior, gated by the concurrency semaphore.
         # The semaphore is acquired before starting LLM work and released in
         # finally so excess agents queue until a slot opens.
+        #
+        # Pre-create the event so run_subagent captures it directly (no lock+lookup
+        # window between _create_subagent_thread returning and finding sa to set it).
+        _pqc = threading.Event()
+
         def run_subagent():
             # Bind retry generation at thread birth so test-teardown interrupts
             # abort backoffs even for LLM calls that start after teardown.
@@ -882,6 +887,7 @@ def subagent(
                         redact_secrets=redact_secrets,
                         context_window=context_window,
                         parent_messages=parent_messages,
+                        prompt_queue_closed=_pqc,
                     )
                 except Exception as e:
                     # If subagent creation fails, notify with error status
@@ -913,11 +919,8 @@ def subagent(
                 with _subagents_lock:
                     sa = next((s for s in _subagents if s.agent_id == agent_id), None)
                 if sa:
-                    # Mark the prompt queue as closed: chat() has returned and will no
-                    # longer drain prompt-queue.jsonl. Set this before _read_log() so
-                    # subagent_steer() can detect the cleanup window without waiting
-                    # for the disk read and result caching to complete.
-                    sa.prompt_queue_closed.set()
+                    # prompt_queue_closed is already set inside _create_subagent_thread
+                    # (right after chat() returns, before this thread gets the lock).
                     # Use _read_log() instead of status(): the thread is still alive here,
                     # so status() would return "running" and poison the result cache.
                     result = sa._read_log()
@@ -970,6 +973,8 @@ def subagent(
         # Register Subagent BEFORE starting thread to avoid race condition:
         # run_subagent closure looks up agent_id in _subagents, which would
         # return None if the thread runs before _subagents.append(sa).
+        # Pass the pre-created _pqc event so sa.prompt_queue_closed and the event
+        # captured by run_subagent are the same object.
         sa = Subagent(
             agent_id=agent_id,
             prompt=prompt,
@@ -993,6 +998,7 @@ def subagent(
             max_time=max_time,
             context_turns=context_turns,
             parent_logdir=parent_logdir,
+            prompt_queue_closed=_pqc,
         )
         with _subagents_lock:
             _subagents.append(sa)
@@ -1179,9 +1185,14 @@ def subagent_steer(agent_id: str, message: str) -> str:
             "for ACP subagents — they run in a separate harness with no shared logdir channel."
         )
 
-    # Check prompt_queue_closed first: set by run_subagent() immediately when
-    # chat() returns, before the disk-reading _read_log() and result caching.
-    # This is an earlier and more reliable signal than status() alone.
+    # Check prompt_queue_closed first: for thread mode, set inside
+    # _create_subagent_thread right after chat() returns (before any caller
+    # cleanup); for subprocess mode, set in the launcher's finally block after
+    # the process exits. Both paths fire before the disk-reading _read_log()
+    # and result caching, giving an earlier signal than status() alone.
+    # Known limitation: a sub-millisecond window remains between chat()'s last
+    # _drain_external_prompt_queue() call and the event being set; closing that
+    # would require modifying chat() itself.
     if sa.prompt_queue_closed.is_set():
         raise ValueError(
             f"Subagent '{agent_id}' has closed its prompt queue — "

--- a/gptme/tools/subagent/api.py
+++ b/gptme/tools/subagent/api.py
@@ -1167,22 +1167,25 @@ def subagent_steer(agent_id: str, message: str) -> str:
             "for ACP subagents — they run in a separate harness with no shared logdir channel."
         )
 
-    if not sa.is_running():
+    pre_status = sa.status().status
+    if pre_status != "running":
         raise ValueError(
-            f"Subagent '{agent_id}' is not running (status: {sa.status().status}). "
+            f"Subagent '{agent_id}' is not running (status: {pre_status}). "
             "Only active subagents can be steered. "
             "For clarification_needed subagents, use subagent_reply() to re-spawn them."
         )
 
     queue_prompt(sa.logdir, message)
 
-    # Re-check is_running() after queuing to detect the race where the subagent
-    # exits between the initial check and the queue write. If it's no longer
-    # running, the queued message will never be drained.
-    if not sa.is_running():
+    # Re-check status() after queuing to detect the race where the subagent exits
+    # between the initial check and the queue write. Using status() (not is_running())
+    # catches the thread-mode "cleanup window": the thread is still alive, but chat()
+    # has returned and the result is already cached — is_running() would falsely pass.
+    post_status = sa.status().status
+    if post_status != "running":
         raise ValueError(
             f"Subagent '{agent_id}' exited after steering message was queued. "
-            f"The message may not be processed. Status: {sa.status().status}"
+            f"The message may not be processed. Status: {post_status}"
         )
 
     logger.info(f"Steering message queued for subagent '{agent_id}': {message[:80]!r}")

--- a/gptme/tools/subagent/api.py
+++ b/gptme/tools/subagent/api.py
@@ -1165,6 +1165,21 @@ def subagent_steer(agent_id: str, message: str) -> str:
         NotImplementedError: If the subagent is running in ACP mode, which
             does not expose a logdir channel for steering.
 
+    Note:
+        Delivery is **guaranteed for thread-mode** subagents: ``prompt_queue_closed``
+        is set inside the subagent thread immediately when ``chat()`` returns,
+        so any steer attempted after that point raises ``ValueError``.
+
+        For **subprocess-mode** subagents, delivery is best-effort: there is an
+        inherent window between the child's ``chat()`` loop finishing its last
+        prompt-queue drain and the parent detecting process exit via
+        ``process.poll()``. In practice this window is sub-millisecond (process
+        cleanup only), but it cannot be fully closed without a child-side
+        drain-complete signal (which would require modifying ``chat()`` itself,
+        beyond the scope of this PR). ``prompt_queue_closed`` is set when the
+        subprocess exits, catching the post-exit case; the pre-exit cleanup window
+        is an accepted best-effort limitation.
+
     Example::
 
         subagent("researcher", "Research Python async frameworks")

--- a/gptme/tools/subagent/execution.py
+++ b/gptme/tools/subagent/execution.py
@@ -165,6 +165,7 @@ def _create_subagent_thread(
     redact_secrets: bool = True,
     context_window: int | None = None,
     parent_messages: list[Message] | None = None,
+    prompt_queue_closed: threading.Event | None = None,
 ) -> None:
     """Shared function for running subagent threads.
 
@@ -184,6 +185,9 @@ def _create_subagent_thread(
         parent_messages: Recent messages from the parent's conversation to inject as context.
             Formatted as a system message so the subagent understands what the parent has
             been doing without confusing the subagent's own conversation flow.
+        prompt_queue_closed: Optional event to set immediately when chat() returns.
+            Passed by run_subagent() so the event fires before the caller acquires
+            _subagents_lock to find sa — closing the lock+lookup window.
     """
     # Store agent_id in thread-local so the progress tool can identify this subagent
     if agent_id is not None:
@@ -412,19 +416,28 @@ def _create_subagent_thread(
     # calling set_output_format() before the call) is required — chat() itself
     # calls set_output_format(output_format) at its start, which would otherwise
     # immediately override quiet mode back to the default "text".
-    chat(
-        prompt_msgs,
-        initial_msgs,
-        logdir=logdir,
-        workspace=workspace,
-        model=model,
-        stream=False,
-        no_confirm=True,
-        interactive=False,
-        show_hidden=False,
-        tool_format="markdown",
-        output_format="quiet",
-    )
+    try:
+        chat(
+            prompt_msgs,
+            initial_msgs,
+            logdir=logdir,
+            workspace=workspace,
+            model=model,
+            stream=False,
+            no_confirm=True,
+            interactive=False,
+            show_hidden=False,
+            tool_format="markdown",
+            output_format="quiet",
+        )
+    finally:
+        # Signal immediately when chat() returns — before any caller cleanup.
+        # This closes the window between "chat() last drain" and the caller
+        # acquiring _subagents_lock to find `sa`. Any concurrent subagent_steer()
+        # that slips between this set and chat()'s actual last drain is a
+        # sub-microsecond race that requires modifying chat() itself to close.
+        if prompt_queue_closed is not None:
+            prompt_queue_closed.set()
 
 
 def _run_subagent_subprocess(

--- a/gptme/tools/subagent/types.py
+++ b/gptme/tools/subagent/types.py
@@ -324,6 +324,12 @@ class Subagent:
     cancel_event: threading.Event = field(
         default_factory=threading.Event, init=False, repr=False
     )
+    # Set when chat() has returned and the prompt queue will no longer be drained.
+    # Provides an earlier, more reliable signal than _subagent_results caching
+    # (which requires a disk read via _read_log() before the result is stored).
+    # subagent_steer() checks this flag to catch the cleanup window where
+    # thread.is_alive() is True but the chat loop has already stopped.
+    prompt_queue_closed: threading.Event = field(default_factory=threading.Event)
 
     def _normalize_json_result(self, result: str) -> str:
         """Normalize a complete-block result as canonical JSON.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -202,12 +202,16 @@ def pytest_collection_modifyitems(config, items):
             if "requires_api" in item.keywords:
                 item.add_marker(skip_api)
 
-    # Wire up no_retry: override pytest-retry's global --retries for these tests.
-    # @pytest.mark.flaky(retries=0) takes precedence over the --retries CLI flag.
-    no_retry_mark = pytest.mark.flaky(retries=0)
+    # Wire up no_retry: prevent pytest-retry from retrying these tests.
+    # flaky(retries=0) is NOT sufficient — the retry loop always runs at least once.
+    # condition=False causes pytest-retry to return early before any retry attempt.
+    # append=False prepends our marker so get_closest_marker() finds it first,
+    # even if pytest-retry already added flaky(retries=N) during its own
+    # pytest_collection_modifyitems pass.
+    no_retry_mark = pytest.mark.flaky(condition=False)
     for item in items:
         if "no_retry" in item.keywords:
-            item.add_marker(no_retry_mark)
+            item.add_marker(no_retry_mark, append=False)
 
 
 def pytest_sessionstart(session):

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -6160,6 +6160,40 @@ class TestSubagentSteer:
         with pytest.raises(ValueError, match="closed its prompt queue"):
             subagent_steer("cleanup-agent", "too late")
 
+    def test_steer_subprocess_cleanup_window_raises(self, tmp_path):
+        """subagent_steer raises for subprocess-mode when prompt_queue_closed is set.
+
+        Subprocess mode: process.poll() can still return None while the OS process
+        is exiting its final teardown. prompt_queue_closed is set by _launch_subprocess()
+        in the finally block immediately when the subprocess exits, before result
+        caching completes. This test verifies that the flag catches the cleanup window
+        for subprocess-mode subagents just as it does for thread-mode.
+        """
+        logdir = tmp_path / "steer-subprocess-cleanup"
+        logdir.mkdir()
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = None  # process appears running per poll()
+        mock_thread = MagicMock(spec=threading.Thread)
+        mock_thread.is_alive.return_value = True  # launcher thread still alive
+        sa = Subagent(
+            agent_id="proc-cleanup-agent",
+            prompt="test",
+            thread=mock_thread,
+            logdir=logdir,
+            model=None,
+            execution_mode="subprocess",
+            process=mock_proc,
+        )
+        with _subagents_lock:
+            _subagents.append(sa)
+        # Simulate _launch_subprocess() finally block: subprocess exited,
+        # prompt_queue_closed set before result is cached.
+        sa.prompt_queue_closed.set()
+        assert "proc-cleanup-agent" not in _subagent_results
+
+        with pytest.raises(ValueError, match="closed its prompt queue"):
+            subagent_steer("proc-cleanup-agent", "too late")
+
     def test_steer_result_cached_still_raises(self, tmp_path):
         """subagent_steer raises when result is cached (covers the post-cache half of cleanup).
 

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -6232,6 +6232,40 @@ class TestSubagentSteer:
         with pytest.raises(ValueError, match="closed its prompt queue"):
             subagent_steer("sentinel-agent", "too late")
 
+    def test_steer_thread_mode_sentinel_file_raises(self, tmp_path):
+        """Thread-mode steer raises when the sentinel file exists but prompt_queue_closed is not set.
+
+        This is the race window Greptile identified: chat() writes the sentinel
+        at the drain boundary (inside _run_chat_loop's non-interactive break),
+        but prompt_queue_closed.set() is called only after chat() returns —
+        a gap where steer could falsely succeed without the file check.
+
+        Verifies that _queue_is_closed() checks the sentinel file for thread mode
+        too, not just subprocess mode.
+        """
+        logdir = tmp_path / "steer-thread-sentinel"
+        logdir.mkdir()
+        mock_thread = MagicMock(spec=threading.Thread)
+        mock_thread.is_alive.return_value = True  # still "alive" — in cleanup
+        sa = Subagent(
+            agent_id="thread-sentinel-agent",
+            prompt="test",
+            thread=mock_thread,
+            logdir=logdir,
+            model=None,
+            execution_mode="thread",
+        )
+        with _subagents_lock:
+            _subagents.append(sa)
+        # Simulate chat.py writing the sentinel at the drain boundary
+        # (prompt_queue_closed NOT yet set — chat() hasn't returned yet).
+        (logdir / "prompt-queue-closed").touch()
+        assert not sa.prompt_queue_closed.is_set()
+        assert sa.execution_mode == "thread"
+
+        with pytest.raises(ValueError, match="closed its prompt queue"):
+            subagent_steer("thread-sentinel-agent", "too late")
+
     def test_steer_result_cached_still_raises(self, tmp_path):
         """subagent_steer raises when result is cached (covers the post-cache half of cleanup).
 

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -6105,7 +6105,11 @@ class TestSubagentSteer:
         logdir = tmp_path / "steer-race-detect"
         logdir.mkdir()
         mock_thread = MagicMock(spec=threading.Thread)
-        # First is_alive() call returns True, subsequent ones return False
+        # Default to False for teardown cleanup calls, but override with side_effect
+        # for the test scenario (True on first check, False on second check after
+        # queuing). This prevents the mock from running out of side_effect values
+        # when teardown calls is_alive() a third time.
+        mock_thread.is_alive.return_value = False
         mock_thread.is_alive.side_effect = [True, False]
         sa = Subagent(
             agent_id="race-agent",

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -6194,6 +6194,42 @@ class TestSubagentSteer:
         with pytest.raises(ValueError, match="closed its prompt queue"):
             subagent_steer("proc-cleanup-agent", "too late")
 
+    def test_steer_subprocess_sentinel_file_raises(self, tmp_path):
+        """subagent_steer raises for subprocess-mode when the sentinel file exists.
+
+        chat.py writes "prompt-queue-closed" to the logdir in its finally block
+        immediately when chat() returns — before the process exits.  This closes
+        the race window between the child's last _drain_external_prompt_queue()
+        call and the parent detecting process exit via process.poll().
+
+        The sentinel is a child-side signal: no shared memory needed.
+        """
+        logdir = tmp_path / "steer-subprocess-sentinel"
+        logdir.mkdir()
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = None  # process appears running per poll()
+        mock_thread = MagicMock(spec=threading.Thread)
+        mock_thread.is_alive.return_value = True
+        sa = Subagent(
+            agent_id="sentinel-agent",
+            prompt="test",
+            thread=mock_thread,
+            logdir=logdir,
+            model=None,
+            execution_mode="subprocess",
+            process=mock_proc,
+        )
+        with _subagents_lock:
+            _subagents.append(sa)
+        # Simulate chat.py writing the sentinel in its finally block
+        # (prompt_queue_closed Python event NOT yet set — that happens later
+        # when the parent's launcher finally block runs after process exit).
+        (logdir / "prompt-queue-closed").touch()
+        assert not sa.prompt_queue_closed.is_set()
+
+        with pytest.raises(ValueError, match="closed its prompt queue"):
+            subagent_steer("sentinel-agent", "too late")
+
     def test_steer_result_cached_still_raises(self, tmp_path):
         """subagent_steer raises when result is cached (covers the post-cache half of cleanup).
 

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -6092,3 +6092,33 @@ class TestSubagentSteer:
         drained = drain_prompt_queue(logdir)
         assert len(drained) == 1
         assert "Change focus to security issues" in drained[0].content
+
+    def test_steer_race_condition_finished_after_check(self, tmp_path):
+        """subagent_steer detects when subagent finishes after the initial running check.
+
+        This tests the race condition where:
+        1. is_running() returns True
+        2. The subagent exits
+        3. queue_prompt() writes to a queue no one will drain
+        4. We re-check is_running() and catch the race
+        """
+        logdir = tmp_path / "steer-race-detect"
+        logdir.mkdir()
+        mock_thread = MagicMock(spec=threading.Thread)
+        # First is_alive() call returns True, subsequent ones return False
+        mock_thread.is_alive.side_effect = [True, False]
+        sa = Subagent(
+            agent_id="race-agent",
+            prompt="test",
+            thread=mock_thread,
+            logdir=logdir,
+            model=None,
+            execution_mode="thread",
+        )
+        with _subagents_lock:
+            _subagents.append(sa)
+
+        with pytest.raises(
+            ValueError, match="exited after steering message was queued"
+        ):
+            subagent_steer("race-agent", "steer me")

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -6197,10 +6197,12 @@ class TestSubagentSteer:
     def test_steer_subprocess_sentinel_file_raises(self, tmp_path):
         """subagent_steer raises for subprocess-mode when the sentinel file exists.
 
-        chat.py writes "prompt-queue-closed" to the logdir in its finally block
-        immediately when chat() returns — before the process exits.  This closes
-        the race window between the child's last _drain_external_prompt_queue()
-        call and the parent detecting process exit via process.poll().
+        chat.py writes "prompt-queue-closed" to the logdir at the actual drain
+        boundary — right before `break` in _run_chat_loop (non-interactive path)
+        and right before raising SessionCompleteException — so the window between
+        the final _drain_external_prompt_queue() call and the sentinel becoming
+        visible is just a few bytecode instructions.  The chat() finally block
+        writes it again as a safety net for unexpected exit paths (idempotent).
 
         The sentinel is a child-side signal: no shared memory needed.
         """

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -6111,12 +6111,19 @@ class TestSubagentSteer:
         logdir = tmp_path / "steer-race-detect"
         logdir.mkdir()
         mock_thread = MagicMock(spec=threading.Thread)
-        # side_effect order: [pre-check, post-check, conftest teardown]
-        # Three calls total: status() pre-check, status() post-check,
-        # and cleanup_subagents_after fixture calling thread.is_alive() directly.
-        # When side_effect list is exhausted it raises StopIteration (overrides
-        # return_value), so the list must cover all calls.
-        mock_thread.is_alive.side_effect = [True, False, False]
+        # side_effect order:
+        #   [pre-check, post-check, interrupt_thread, conftest join, conftest leak-check]
+        # Five calls total:
+        #   1. status() pre-check (inside subagent_steer)
+        #   2. status() post-check (inside subagent_steer, after queue write)
+        #   3. interrupt_thread() — conftest calls interrupt_thread(sa.thread) which
+        #      calls thread.is_alive() internally (retry_abort.py:111)
+        #   4. conftest join loop: thread.is_alive() guard before thread.join()
+        #   5. conftest leak check: thread.is_alive() after join
+        # When side_effect is exhausted it raises StopIteration inside the yield
+        # fixture generator, which Python 3.7+ wraps as RuntimeError — the list
+        # must cover every call.
+        mock_thread.is_alive.side_effect = [True, False, False, False, False]
         sa = Subagent(
             agent_id="race-agent",
             prompt="test",

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -18,7 +18,7 @@ import gptme.tools.subagent.api as subagent_api
 import gptme.tools.subagent.execution as subagent_execution
 import gptme.tools.subagent.types as subagent_types
 from gptme.tools.complete import SessionCompleteException
-from gptme.tools.subagent.api import _write_cancel_op, subagent, subagent_cancel
+from gptme.tools.subagent.api import _write_cancel_op, subagent, subagent_cancel, subagent_steer
 from gptme.tools.subagent.batch import BatchJob
 from gptme.tools.subagent.control import (
     CONTROL_FILENAME,
@@ -5952,3 +5952,143 @@ class TestCancelCheckpointHook:
         # Original success result must be preserved
         with _subagent_results_lock:
             assert _subagent_results["agent-1"].status == "success"
+
+
+# ---------------------------------------------------------------------------
+# subagent_steer tests
+# ---------------------------------------------------------------------------
+
+
+class TestSubagentSteer:
+    """Tests for subagent_steer() — in-flight orchestrator-to-subagent messaging."""
+
+    _logdir = Path("/tmp/test-steer-log")
+
+    def setup_method(self, tmp_path_factory=None):
+        """Clear global subagent registry and steer queue before each test."""
+        with _subagents_lock:
+            _subagents.clear()
+        with _subagent_results_lock:
+            _subagent_results.clear()
+
+    def _register(
+        self,
+        agent_id: str,
+        logdir: Path | None = None,
+        execution_mode: Literal["thread", "subprocess", "acp"] = "thread",
+        **kwargs,
+    ) -> Subagent:
+        mock_thread = MagicMock(spec=threading.Thread)
+        mock_thread.is_alive.return_value = True
+        sa = Subagent(
+            agent_id=agent_id,
+            prompt="test",
+            thread=kwargs.get("thread", mock_thread),
+            logdir=logdir or self._logdir,
+            model=None,
+            execution_mode=execution_mode,
+            process=kwargs.get("process"),
+        )
+        with _subagents_lock:
+            _subagents.append(sa)
+        return sa
+
+    def test_steer_unknown_raises(self):
+        """subagent_steer raises ValueError when agent_id is unknown."""
+
+        with pytest.raises(ValueError, match="not found"):
+            subagent_steer("nonexistent", "change direction")
+
+    def test_steer_finished_subagent_raises(self):
+        """subagent_steer raises ValueError when the subagent has already finished."""
+
+        mock_thread = MagicMock(spec=threading.Thread)
+        mock_thread.is_alive.return_value = False
+        self._register("done-agent", thread=mock_thread)
+
+        with pytest.raises(ValueError, match="not running"):
+            subagent_steer("done-agent", "too late")
+
+    def test_steer_acp_mode_raises_not_implemented(self):
+        """subagent_steer raises NotImplementedError for ACP-mode subagents."""
+
+        mock_thread = MagicMock(spec=threading.Thread)
+        mock_thread.is_alive.return_value = True
+        sa = Subagent(
+            agent_id="acp-agent",
+            prompt="test",
+            thread=mock_thread,
+            logdir=self._logdir,
+            model=None,
+            execution_mode="acp",
+            use_acp=True,
+        )
+        with _subagents_lock:
+            _subagents.append(sa)
+
+        with pytest.raises(NotImplementedError, match="ACP mode"):
+            subagent_steer("acp-agent", "steer me")
+
+    def test_steer_writes_to_prompt_queue(self, tmp_path):
+        """subagent_steer queues the message via the file-based prompt queue."""
+        from gptme.prompt_queue import drain_prompt_queue
+
+        logdir = tmp_path / "subagent-steer-test"
+        logdir.mkdir()
+        self._register("running-agent", logdir=logdir)
+
+        result = subagent_steer("running-agent", "Focus on async frameworks only")
+
+        assert "queued" in result.lower()
+
+        # Verify the message was written to the prompt queue file
+        drained = drain_prompt_queue(logdir)
+        assert len(drained) == 1
+        assert "Focus on async frameworks only" in drained[0].content
+
+    def test_steer_multiple_messages_queued_in_order(self, tmp_path):
+        """Multiple steer calls append messages in FIFO order."""
+        from gptme.prompt_queue import drain_prompt_queue
+
+        logdir = tmp_path / "subagent-steer-fifo"
+        logdir.mkdir()
+        self._register("running-agent", logdir=logdir)
+
+        subagent_steer("running-agent", "First instruction")
+        subagent_steer("running-agent", "Second instruction")
+        subagent_steer("running-agent", "Third instruction")
+
+        drained = drain_prompt_queue(logdir)
+        assert len(drained) == 3
+        assert "First instruction" in drained[0].content
+        assert "Second instruction" in drained[1].content
+        assert "Third instruction" in drained[2].content
+
+    def test_steer_subprocess_mode_uses_logdir(self, tmp_path):
+        """subagent_steer works for subprocess-mode subagents via the same logdir channel."""
+        from gptme.prompt_queue import drain_prompt_queue
+
+        logdir = tmp_path / "subagent-subprocess-steer"
+        logdir.mkdir()
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = None  # still running
+        mock_thread = MagicMock(spec=threading.Thread)
+        mock_thread.is_alive.return_value = True
+        sa = Subagent(
+            agent_id="proc-agent",
+            prompt="test",
+            thread=mock_thread,
+            logdir=logdir,
+            model=None,
+            execution_mode="subprocess",
+            process=mock_proc,
+        )
+        with _subagents_lock:
+            _subagents.append(sa)
+
+        result = subagent_steer("proc-agent", "Change focus to security issues")
+
+        assert "queued" in result.lower()
+        drained = drain_prompt_queue(logdir)
+        assert len(drained) == 1
+        assert "Change focus to security issues" in drained[0].content

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -6130,9 +6130,11 @@ class TestSubagentSteer:
     def test_steer_cleanup_window_raises(self, tmp_path):
         """subagent_steer raises when the subagent is in the cleanup window.
 
-        Thread-mode: the wrapper thread is still alive (is_alive()=True) but
-        chat() has already returned and the result is cached in _subagent_results.
-        is_running() would falsely pass; status() correctly returns the terminal status.
+        Thread-mode: the wrapper thread is still alive (is_alive()=True),
+        the result is NOT yet cached (_subagent_results is empty), but chat()
+        has returned and prompt_queue_closed is set. is_running() and status()
+        alone would both falsely report "running" here; prompt_queue_closed
+        catches this gap directly.
         """
         logdir = tmp_path / "steer-cleanup-window"
         logdir.mkdir()
@@ -6148,10 +6150,38 @@ class TestSubagentSteer:
         )
         with _subagents_lock:
             _subagents.append(sa)
-        # Simulate the result being cached (as set_subagent_result_if_absent does)
-        # while the wrapper thread is still alive doing post-chat cleanup.
+        # Simulate run_subagent() having set prompt_queue_closed immediately
+        # after _create_subagent_thread() returned, before _read_log() and
+        # set_subagent_result_if_absent() are called.
+        sa.prompt_queue_closed.set()
+        # Result is NOT cached yet — the cleanup is mid-flight.
+        assert "cleanup-agent" not in _subagent_results
+
+        with pytest.raises(ValueError, match="closed its prompt queue"):
+            subagent_steer("cleanup-agent", "too late")
+
+    def test_steer_result_cached_still_raises(self, tmp_path):
+        """subagent_steer raises when result is cached (covers the post-cache half of cleanup).
+
+        Thread alive, result already written to _subagent_results but
+        prompt_queue_closed not yet set (extremely narrow gap). status() catches this.
+        """
+        logdir = tmp_path / "steer-cached-not-closed"
+        logdir.mkdir()
+        mock_thread = MagicMock(spec=threading.Thread)
+        mock_thread.is_alive.return_value = True
+        sa = Subagent(
+            agent_id="cached-agent",
+            prompt="test",
+            thread=mock_thread,
+            logdir=logdir,
+            model=None,
+            execution_mode="thread",
+        )
+        with _subagents_lock:
+            _subagents.append(sa)
         with _subagent_results_lock:
-            _subagent_results["cleanup-agent"] = ReturnType("success", "done")
+            _subagent_results["cached-agent"] = ReturnType("success", "done")
 
         with pytest.raises(ValueError, match="not running"):
-            subagent_steer("cleanup-agent", "too late")
+            subagent_steer("cached-agent", "too late")

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -18,7 +18,12 @@ import gptme.tools.subagent.api as subagent_api
 import gptme.tools.subagent.execution as subagent_execution
 import gptme.tools.subagent.types as subagent_types
 from gptme.tools.complete import SessionCompleteException
-from gptme.tools.subagent.api import _write_cancel_op, subagent, subagent_cancel, subagent_steer
+from gptme.tools.subagent.api import (
+    _write_cancel_op,
+    subagent,
+    subagent_cancel,
+    subagent_steer,
+)
 from gptme.tools.subagent.batch import BatchJob
 from gptme.tools.subagent.control import (
     CONTROL_FILENAME,

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -6105,12 +6105,12 @@ class TestSubagentSteer:
         logdir = tmp_path / "steer-race-detect"
         logdir.mkdir()
         mock_thread = MagicMock(spec=threading.Thread)
-        # Default to False for teardown cleanup calls, but override with side_effect
-        # for the test scenario (True on first check, False on second check after
-        # queuing). This prevents the mock from running out of side_effect values
-        # when teardown calls is_alive() a third time.
-        mock_thread.is_alive.return_value = False
-        mock_thread.is_alive.side_effect = [True, False]
+        # side_effect order: [pre-check, post-check, conftest teardown]
+        # Three calls total: status() pre-check, status() post-check,
+        # and cleanup_subagents_after fixture calling thread.is_alive() directly.
+        # When side_effect list is exhausted it raises StopIteration (overrides
+        # return_value), so the list must cover all calls.
+        mock_thread.is_alive.side_effect = [True, False, False]
         sa = Subagent(
             agent_id="race-agent",
             prompt="test",
@@ -6126,3 +6126,32 @@ class TestSubagentSteer:
             ValueError, match="exited after steering message was queued"
         ):
             subagent_steer("race-agent", "steer me")
+
+    def test_steer_cleanup_window_raises(self, tmp_path):
+        """subagent_steer raises when the subagent is in the cleanup window.
+
+        Thread-mode: the wrapper thread is still alive (is_alive()=True) but
+        chat() has already returned and the result is cached in _subagent_results.
+        is_running() would falsely pass; status() correctly returns the terminal status.
+        """
+        logdir = tmp_path / "steer-cleanup-window"
+        logdir.mkdir()
+        mock_thread = MagicMock(spec=threading.Thread)
+        mock_thread.is_alive.return_value = True  # thread alive (cleanup still running)
+        sa = Subagent(
+            agent_id="cleanup-agent",
+            prompt="test",
+            thread=mock_thread,
+            logdir=logdir,
+            model=None,
+            execution_mode="thread",
+        )
+        with _subagents_lock:
+            _subagents.append(sa)
+        # Simulate the result being cached (as set_subagent_result_if_absent does)
+        # while the wrapper thread is still alive doing post-chat cleanup.
+        with _subagent_results_lock:
+            _subagent_results["cleanup-agent"] = ReturnType("success", "done")
+
+        with pytest.raises(ValueError, match="not running"):
+            subagent_steer("cleanup-agent", "too late")

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -8,6 +8,7 @@ import importlib
 import json
 import queue
 import threading
+import time
 from pathlib import Path
 from typing import Literal
 from unittest.mock import MagicMock
@@ -6225,6 +6226,7 @@ class TestSubagentSteer:
             model=None,
             execution_mode="subprocess",
             process=mock_proc,
+            started_at=time.time() - 2.0,  # ensure sentinel written next is "current"
         )
         with _subagents_lock:
             _subagents.append(sa)
@@ -6259,6 +6261,7 @@ class TestSubagentSteer:
             logdir=logdir,
             model=None,
             execution_mode="thread",
+            started_at=time.time() - 2.0,  # ensure sentinel written next is "current"
         )
         with _subagents_lock:
             _subagents.append(sa)
@@ -6296,3 +6299,75 @@ class TestSubagentSteer:
 
         with pytest.raises(ValueError, match="not running"):
             subagent_steer("cached-agent", "too late")
+
+    def test_steer_stale_sentinel_from_previous_run_does_not_block(self, tmp_path):
+        """A prompt-queue-closed sentinel from a *previous* run must not block steering.
+
+        Planner-mode subagents reuse the same logdir (same agent_id, same
+        subagent-{agent_id} directory).  When a run exits it writes
+        prompt-queue-closed.  A subsequent run using the same logdir must not
+        be incorrectly blocked by that stale sentinel — only a sentinel written
+        at or after sa.started_at counts as current.
+        """
+        logdir = tmp_path / "steer-stale-sentinel"
+        logdir.mkdir()
+
+        # Simulate a previous run writing the sentinel (stale).
+        sentinel = logdir / "prompt-queue-closed"
+        sentinel.touch()
+        stale_mtime = sentinel.stat().st_mtime
+
+        mock_thread = MagicMock(spec=threading.Thread)
+        mock_thread.is_alive.return_value = True  # current run is active
+
+        # started_at is clearly after the stale sentinel — this is a new run.
+        sa = Subagent(
+            agent_id="stale-sentinel-agent",
+            prompt="test",
+            thread=mock_thread,
+            logdir=logdir,
+            model=None,
+            execution_mode="thread",
+            started_at=stale_mtime + 1.0,
+        )
+        with _subagents_lock:
+            _subagents.append(sa)
+        assert not sa.prompt_queue_closed.is_set()
+
+        # steer must succeed — the sentinel predates this run.
+        result = subagent_steer("stale-sentinel-agent", "redirect please")
+        assert "stale-sentinel-agent" in result
+
+    def test_steer_current_sentinel_after_reused_logdir_raises(self, tmp_path):
+        """A fresh sentinel written by the *current* run still blocks steering.
+
+        Companion to test_steer_stale_sentinel_from_previous_run_does_not_block:
+        when the sentinel's mtime is >= sa.started_at it belongs to this run
+        and steer must raise.
+        """
+        logdir = tmp_path / "steer-current-sentinel"
+        logdir.mkdir()
+
+        mock_thread = MagicMock(spec=threading.Thread)
+        mock_thread.is_alive.return_value = True
+
+        # Record a "started_at" in the past so the sentinel written next is current.
+        past_start = time.time() - 2.0
+        sa = Subagent(
+            agent_id="current-sentinel-agent",
+            prompt="test",
+            thread=mock_thread,
+            logdir=logdir,
+            model=None,
+            execution_mode="thread",
+            started_at=past_start,
+        )
+        with _subagents_lock:
+            _subagents.append(sa)
+
+        # Sentinel written after started_at — belongs to the current run.
+        (logdir / "prompt-queue-closed").touch()
+        assert not sa.prompt_queue_closed.is_set()
+
+        with pytest.raises(ValueError, match="closed its prompt queue"):
+            subagent_steer("current-sentinel-agent", "too late")


### PR DESCRIPTION
## Summary

Adds `subagent_steer(agent_id, message)` — the missing **parent→subagent** direction of the orchestrator control plane requested in #3191.

**What this enables**: the orchestrator can redirect, clarify, or course-correct a running subagent mid-execution without cancelling and restarting it. The message is queued in the subagent's logdir and injected into its conversation on the next chat loop iteration.

**Implementation**: uses the existing `prompt-queue.jsonl` file channel — the same durable queue the chat loop already polls via `_drain_external_prompt_queue()`. Zero new mechanisms required.

- Works for **thread-mode and subprocess-mode** subagents (both share a logdir the parent can write to)  
- **ACP-mode** subagents raise `NotImplementedError` — they run in a separate harness with no shared logdir channel  
- Distinct from `subagent_reply()`, which re-spawns a *finished* `clarification_needed` subagent; `subagent_steer()` messages an *actively running* one

## What was already in place

Before this PR the control-plane already had:
- `subagent_cancel()` — cancel a running subagent (SIGTERM subprocess / mark-failed thread)  
- `subagent_reply()` — re-spawn after clarification  
- `cancel_on_failure=True` in `subagent_parallel()` / `BatchJob.wait_all()` — fleet-wide cancel on first failure (#3199)  
- Progress blocks (subagent→parent) — periodic status events via `notify_progress()`  
- `subagent_wait_any()` — hedging/race patterns  

The one missing direction was **parent→running subagent** injection, which this PR adds.

## Tests

6 new unit tests in `TestSubagentSteer` (no LLM calls):

| Test | What it verifies |
|---|---|
| `test_steer_unknown_raises` | ValueError for unknown agent_id |
| `test_steer_finished_subagent_raises` | ValueError when agent already finished |
| `test_steer_acp_mode_raises_not_implemented` | NotImplementedError for ACP mode |
| `test_steer_writes_to_prompt_queue` | Message lands in logdir/prompt-queue.jsonl |
| `test_steer_multiple_messages_queued_in_order` | FIFO ordering across multiple steer calls |
| `test_steer_subprocess_mode_uses_logdir` | Works for subprocess-mode subagents |

All 236 tests in `test_subagent_unit.py` pass.

## Usage

```python
subagent("researcher", "Research Python web frameworks and their performance")

# Later, after observing the researcher going off-track:
subagent_steer("researcher", "Focus only on async frameworks — skip synchronous ones like Flask/Django")

# The steering message is injected into the researcher's conversation on its next loop iteration
```

Closes #3191