### PR TITLE
docs(computer): add Background section linking to origin conversation (#216)

### DIFF
--- a/docs/howto/computer-use.md
+++ b/docs/howto/computer-use.md
@@ -421,3 +421,16 @@ mitigations above reduce total session time by shortening the wait, not by fixin
 - **Combine with `--non-interactive`**: add `-n` for scripted or CI use where you don't want
   prompts (but ensure the task is well-scoped first).
 - **Describe visual outcomes**: "confirm the dialog closed" works better than "click OK and move on".
+
+## Background
+
+Computer use support in gptme was bootstrapped in
+[issue #32](https://github.com/gptme/gptme/issues/32), where gptme used its own
+screenshot and keyboard tools to extend its own computer-use capabilities — writing
+much of the initial implementation itself.  That thread is an end-to-end example of
+gptme applying computer use in practice: taking screenshots of its own output, reading
+the results, and editing its own source code in response.
+
+The feature has since grown substantially (see [issue #216](https://github.com/gptme/gptme/issues/216)
+for the full development history), but the original conversation in #32 remains the
+clearest self-contained demonstration of what the tool can do when pointed at a real task.


### PR DESCRIPTION
## Summary

The issue #216 checklist had an unchecked item:
> ☐ share the original conversation where gptme wrote most of it as an example
>   - https://github.com/ErikBjare/gptme/issues/32

The how-to guide (`docs/howto/computer-use.md`) is the living replacement for that thread, but didn't reference where the feature came from. This PR adds a **Background** section at the end of the how-to that links back to both:

- [#32](https://github.com/gptme/gptme/issues/32) — the original self-bootstrapping session where gptme used its own computer tools to write much of the initial implementation
- [#216](https://github.com/gptme/gptme/issues/216) — the full development history

## Context

All other items from issue #216 are already done (see the [full feature inventory](https://github.com/gptme/gptme/issues/216#issuecomment-4884965540)). This is the last unchecked checklist item. Tagging @ErikBjare for the final call on closing #216.

## Test plan
- [x] Docs change only — no logic changes
- [x] All 68 computer-use tests pass (`pytest tests/test_computer_actions.py tests/test_computer_settle.py tests/test_computer_gate.py`)
- [x] Pre-commit hooks pass

<!-- gptme-id:v1:gai_IPyb4oHccQAZmpQuF9lAkfICql5YLI1kdkrEXhCnLpj -->