### PR TITLE
fix(tauri): add GPTME_DISABLE_AUTO_UPDATE env var to opt out of update check

### DIFF
--- a/tauri/src-tauri/src/lib.rs
+++ b/tauri/src-tauri/src/lib.rs
@@ -429,8 +429,11 @@ fn handle_deep_link_urls(app: &tauri::AppHandle, urls: Vec<url::Url>) {
 
 #[cfg(desktop)]
 async fn check_for_updates(app: tauri::AppHandle) {
-    // Respect user opt-out via environment variable
-    if std::env::var("GPTME_DISABLE_AUTO_UPDATE").is_ok() {
+    // Respect user opt-out via environment variable (truthy values: 1, true, yes, on)
+    if std::env::var("GPTME_DISABLE_AUTO_UPDATE")
+        .map(|v| matches!(v.to_lowercase().as_str(), "1" | "true" | "yes" | "on"))
+        .unwrap_or(false)
+    {
         log::debug!("Update check disabled via GPTME_DISABLE_AUTO_UPDATE");
         return;
     }

--- a/tauri/src-tauri/src/lib.rs
+++ b/tauri/src-tauri/src/lib.rs
@@ -429,6 +429,12 @@ fn handle_deep_link_urls(app: &tauri::AppHandle, urls: Vec<url::Url>) {
 
 #[cfg(desktop)]
 async fn check_for_updates(app: tauri::AppHandle) {
+    // Respect user opt-out via environment variable
+    if std::env::var("GPTME_DISABLE_AUTO_UPDATE").is_ok() {
+        log::debug!("Update check disabled via GPTME_DISABLE_AUTO_UPDATE");
+        return;
+    }
+
     // Skip if pubkey is absent or still a placeholder (key not yet configured)
     let pubkey = app
         .config()


### PR DESCRIPTION
Adds the missing 'setting to disable' from the #3187 checklist.

The merged #3197 implemented the on-startup update check but didn't include the opt-out mechanism the issue specified. This PR adds it via an environment variable:

```bash
GPTME_DISABLE_AUTO_UPDATE=1 gptme-tauri
```

Setting `GPTME_DISABLE_AUTO_UPDATE` to any value (e.g. `1`, `true`, `yes`) skips the startup update check entirely. The existing pubkey-absence guard still applies when the variable is unset.

**Why env var rather than a config file setting?** There's no persistent settings system in the app yet (no `tauri-plugin-store`). An env var is the simplest mechanism that doesn't require new infrastructure and works for CI/scripted use-cases.

Closes #3187 (together with #3197 which implemented the core updater).