### PR TITLE
fix(computer): align wait_for_change threshold with _poll_for_change (0.2% not 1%)

### DIFF
--- a/gptme/tools/computer.py
+++ b/gptme/tools/computer.py
@@ -1793,7 +1793,12 @@ def computer(
         # burning CPU on long waits.
         poll_interval = 0.05
         max_poll_interval = 0.5
-        change_threshold = 0.01  # 1% of pixels must differ
+        # 0.2% threshold — must match _poll_for_change (transport path).
+        # The old 1% threshold caused "No screen change detected" even when the
+        # xterm had updated: typing a short command changes only ~0.3–0.5% of a
+        # 1024×768 screen (issue #216). PNG is lossless so identical frames are
+        # always exactly 0.0%, making false positives impossible in Xvfb.
+        change_threshold = 0.002
         baseline = screenshot()
         deadline = _monotonic() + timeout
         while _monotonic() < deadline:

--- a/tests/test_tools_computer.py
+++ b/tests/test_tools_computer.py
@@ -1393,6 +1393,58 @@ def test_wait_for_change_polls_with_backoff(mock_transport, mock_res, tmp_path):
     assert sleep_calls[2] == pytest.approx(0.20)  # 200ms after second backoff
 
 
+@mock.patch("gptme.tools.computer.IS_MACOS", False)
+@mock.patch(
+    "gptme.tools.computer._get_display_resolution", return_value=_MOCK_LINUX_RES_WFC
+)
+@mock.patch("gptme.tools.computer.get_transport", return_value=None)
+def test_wait_for_change_detects_small_change(mock_transport, mock_res, tmp_path):
+    """wait_for_change must detect small pixel changes (~0.3%) typical of terminal output.
+
+    Regression test for issue #216: typing a short command in a terminal changes
+    only ~0.3-0.5% of a 1024x768 screen.  The old 1% threshold missed these small
+    changes and produced spurious "No screen change detected" messages.  The correct
+    0.2% threshold catches them.
+
+    This test uses a 100x100 image where 30 pixels (0.3%) change colour: above the
+    0.2% threshold but below the old 1% threshold.
+    """
+    from PIL import Image
+
+    # 100x100 image; 30 pixels differ = 0.3% change.
+    # 0.3% >= 0.2% (new threshold) → must be detected.
+    # 0.3% <  1.0% (old threshold) → would NOT have been detected.
+    baseline_img = Image.new("RGB", (100, 100), (0, 0, 0))
+    changed_img = baseline_img.copy()
+    for x in range(30):
+        changed_img.putpixel((x, 0), (255, 255, 255))
+
+    baseline = tmp_path / "baseline.png"
+    changed = tmp_path / "changed.png"
+    baseline_img.save(baseline)
+    changed_img.save(changed)
+
+    call_count = {"n": 0}
+
+    def _fake_screenshot():
+        call_count["n"] += 1
+        return baseline if call_count["n"] == 1 else changed
+
+    with (
+        mock.patch("gptme.tools.computer.screenshot", side_effect=_fake_screenshot),
+        mock.patch("gptme.tools.computer._sleep"),
+        mock.patch(
+            "gptme.tools.computer._make_screenshot_msg", return_value=mock.sentinel.msg
+        ),
+    ):
+        result = computer("wait_for_change", text="5")
+
+    assert result is mock.sentinel.msg, (
+        "wait_for_change did not detect a 0.3% pixel change — "
+        "threshold may be set too high (old 1% threshold caused issue #216 terminal delays)"
+    )
+
+
 # ============================================================
 # window_focus action tests
 # ============================================================


### PR DESCRIPTION
## Problem

Issue #216 reported that the computer tool failed to detect screen changes when a terminal received keyboard input.

The root cause is a threshold mismatch between the two change-detection code paths in `computer.py`:

- **Transport path** (`_poll_for_change`): already uses `change_threshold = 0.002` (0.2%)
- **Non-transport path** (`computer('wait_for_change')`): used `change_threshold = 0.01` (**1%**)

Typing a short command in an xterm changes roughly **0.3–0.5%** of a 1024×768 screen (one line of text out of ~780 total lines). The 1% threshold silently skipped these changes and returned `"No screen change detected"`, causing the tool to act before the screen had settled.

PNG screenshots are lossless, so identical frames are always exactly 0.0%. A false positive from lowering the threshold is impossible in a static Xvfb environment.

## Fix

Lower `change_threshold` in the non-transport `wait_for_change` block from `0.01` to `0.002`, matching `_poll_for_change`.

## Test

Adds a regression test `test_wait_for_change_detects_small_change` that:
- Creates a 100×100 image where 30 pixels (0.3%) change colour
- Verifies `wait_for_change` detects it with the new threshold
- Would have **failed** with the old 1% threshold (0.3% < 1%)
- **Passes** with the new 0.2% threshold (0.3% > 0.2%)

The existing tests use 100% pixel-change images (black→white), so they don't catch threshold regressions — this new test does.

Closes #216 (partial — addresses the remaining threshold inconsistency in the non-transport code path)