### PR TITLE
fix(tauri): bundle matching libgpg-error in AppImage

### DIFF
--- a/.github/workflows/tauri.yml
+++ b/.github/workflows/tauri.yml
@@ -719,6 +719,18 @@ jobs:
           releaseId: ${{ steps.release.outputs.id }}
           args: ${{ matrix.args }} ${{ steps.updater.outputs.extra }}
 
+      - name: Patch AppImage libgpg-error dependency
+        if: matrix.platform == 'ubuntu-24.04'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          bash tauri/scripts/build-appimage.sh --patch-only
+          APPIMAGE=$(find tauri/src-tauri/target/release/bundle/appimage -maxdepth 1 -name '*.AppImage' -print -quit)
+          if [[ -n "$APPIMAGE" ]]; then
+            TAG="${{ inputs.tag || github.ref_name }}"
+            gh release upload "$TAG" "$APPIMAGE" --clobber
+          fi
+
   build-android:
     name: Build Android (APK/AAB)
     # Only aarch64 for PR/push checks; full multi-arch on release tags

--- a/.github/workflows/tauri.yml
+++ b/.github/workflows/tauri.yml
@@ -736,7 +736,7 @@ jobs:
             if [[ -n "$ASSET_ID" ]]; then
               gh api -X DELETE "repos/${{ github.repository }}/releases/assets/$ASSET_ID"
             fi
-            gh release upload "$TAG" "$APPIMAGE"
+            gh release upload --clobber "$TAG" "$APPIMAGE"
           fi
 
   build-android:

--- a/.github/workflows/tauri.yml
+++ b/.github/workflows/tauri.yml
@@ -724,11 +724,19 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          bash tauri/scripts/build-appimage.sh --patch-only
           APPIMAGE=$(find tauri/src-tauri/target/release/bundle/appimage -maxdepth 1 -name '*.AppImage' -print -quit)
           if [[ -n "$APPIMAGE" ]]; then
             TAG="${{ inputs.tag || github.ref_name }}"
-            gh release upload "$TAG" "$APPIMAGE" --clobber
+            # Remove the unpatched asset before patching so the broken version
+            # is never publicly available (even briefly between upload and re-upload)
+            ASSET_NAME=$(basename "$APPIMAGE")
+            ASSET_ID=$(gh api "repos/${{ github.repository }}/releases/tags/$TAG" \
+              --jq ".assets[] | select(.name == \"$ASSET_NAME\") | .id" 2>/dev/null || true)
+            if [[ -n "$ASSET_ID" ]]; then
+              gh api -X DELETE "repos/${{ github.repository }}/releases/assets/$ASSET_ID"
+            fi
+            bash tauri/scripts/build-appimage.sh --patch-only
+            gh release upload "$TAG" "$APPIMAGE"
           fi
 
   build-android:

--- a/.github/workflows/tauri.yml
+++ b/.github/workflows/tauri.yml
@@ -727,15 +727,15 @@ jobs:
           APPIMAGE=$(find tauri/src-tauri/target/release/bundle/appimage -maxdepth 1 -name '*.AppImage' -print -quit)
           if [[ -n "$APPIMAGE" ]]; then
             TAG="${{ inputs.tag || github.ref_name }}"
-            # Remove the unpatched asset before patching so the broken version
-            # is never publicly available (even briefly between upload and re-upload)
             ASSET_NAME=$(basename "$APPIMAGE")
+            # Patch first so a failed patch never leaves the release with no asset
+            bash tauri/scripts/build-appimage.sh --patch-only
+            # Replace the release asset only after patching succeeds
             ASSET_ID=$(gh api "repos/${{ github.repository }}/releases/tags/$TAG" \
               --jq ".assets[] | select(.name == \"$ASSET_NAME\") | .id" 2>/dev/null || true)
             if [[ -n "$ASSET_ID" ]]; then
               gh api -X DELETE "repos/${{ github.repository }}/releases/assets/$ASSET_ID"
             fi
-            bash tauri/scripts/build-appimage.sh --patch-only
             gh release upload "$TAG" "$APPIMAGE"
           fi
 

--- a/Makefile
+++ b/Makefile
@@ -358,7 +358,7 @@ tauri-build: ## Build the gptme-tauri desktop app
 	cd webui && npm install && npm run build
 	cd tauri && npm install && \
 	if [ "$$(uname)" = "Linux" ]; then \
-		NO_STRIP=true npm run tauri build; \
+		./scripts/build-appimage.sh; \
 	else \
 		npm run tauri build; \
 	fi

--- a/tauri/Makefile
+++ b/tauri/Makefile
@@ -1,8 +1,8 @@
 build: prebuild
 	@# Set NO_STRIP=true on Linux to avoid "failed to run linuxdeploy" error
 	@if [ "$$(uname)" = "Linux" ]; then \
-		echo "Building on Linux, setting NO_STRIP=true..."; \
-		NO_STRIP=true npm run tauri build; \
+		echo "Building on Linux with AppImage dependency patch..."; \
+		./scripts/build-appimage.sh; \
 	else \
 		echo "Building on non-Linux platform..."; \
 		npm run tauri build; \

--- a/tauri/scripts/build-appimage.sh
+++ b/tauri/scripts/build-appimage.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Build the Linux AppImage and patch linuxdeploy's incomplete libgcrypt bundle.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TAURI_DIR="$(dirname "$SCRIPT_DIR")"
+APPIMAGE_PLUGIN_URL="https://github.com/linuxdeploy/linuxdeploy-plugin-appimage/releases/download/continuous/linuxdeploy-plugin-appimage-x86_64.AppImage"
+
+cd "$TAURI_DIR"
+
+if [[ "$(uname -s)" != "Linux" ]]; then
+    echo "AppImage builds are Linux-only" >&2
+    exit 1
+fi
+
+NO_STRIP="${NO_STRIP:-true}" npm run tauri -- build "$@"
+
+APPDIR="$TAURI_DIR/src-tauri/target/release/bundle/appimage/gptme-tauri.AppDir"
+APPIMAGE="$(find "$TAURI_DIR/src-tauri/target/release/bundle/appimage" -maxdepth 1 -name '*.AppImage' -print -quit)"
+
+if [[ ! -d "$APPDIR" || -z "$APPIMAGE" ]]; then
+    echo "AppImage build did not produce expected AppDir/AppImage" >&2
+    exit 1
+fi
+
+if [[ -f "$APPDIR/usr/lib/libgcrypt.so.20" && ! -e "$APPDIR/usr/lib/libgpg-error.so.0" ]]; then
+    if command -v ldconfig >/dev/null 2>&1; then
+        libgpg_error="$(ldconfig -p | awk '/libgpg-error.so.0 / { print $NF; exit }')"
+    else
+        libgpg_error="$(find /lib /usr/lib -name 'libgpg-error.so.0' -print -quit 2>/dev/null)"
+    fi
+    if [[ -z "$libgpg_error" || ! -f "$libgpg_error" ]]; then
+        echo "libgcrypt was bundled but matching libgpg-error.so.0 was not found on this system" >&2
+        exit 1
+    fi
+
+    echo "Bundling $(basename "$libgpg_error") to satisfy libgcrypt runtime dependency"
+    cp -L "$libgpg_error" "$APPDIR/usr/lib/$(basename "$(readlink -f "$libgpg_error")")"
+    ln -sf "$(basename "$(readlink -f "$libgpg_error")")" "$APPDIR/usr/lib/libgpg-error.so.0"
+
+    plugin="${XDG_CACHE_HOME:-$HOME/.cache}/tauri/linuxdeploy-plugin-appimage-x86_64.AppImage"
+    if [[ ! -x "$plugin" ]]; then
+        mkdir -p "$(dirname "$plugin")"
+        curl -L --fail -o "$plugin" "$APPIMAGE_PLUGIN_URL"
+        chmod +x "$plugin"
+    fi
+
+    APPIMAGE_EXTRACT_AND_RUN=1 LDAI_OUTPUT="$APPIMAGE" "$plugin" --appdir="$APPDIR"
+fi
+
+echo "AppImage ready: $APPIMAGE"

--- a/tauri/scripts/build-appimage.sh
+++ b/tauri/scripts/build-appimage.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 # Build the Linux AppImage and patch linuxdeploy's incomplete libgcrypt bundle.
+#
+# Usage:
+#   ./build-appimage.sh [tauri build args...]   -- full build + patch
+#   ./build-appimage.sh --patch-only            -- patch an already-built AppImage
 
 set -euo pipefail
 
@@ -15,12 +19,24 @@ if [[ "$(uname -s)" != "Linux" ]]; then
     exit 1
 fi
 
-NO_STRIP="${NO_STRIP:-true}" npm run tauri -- build "$@"
+PATCH_ONLY=false
+if [[ "${1:-}" == "--patch-only" ]]; then
+    PATCH_ONLY=true
+    shift
+fi
+
+if [[ "$PATCH_ONLY" != "true" ]]; then
+    NO_STRIP="${NO_STRIP:-true}" npm run tauri -- build "$@"
+fi
 
 APPDIR="$TAURI_DIR/src-tauri/target/release/bundle/appimage/gptme-tauri.AppDir"
 APPIMAGE="$(find "$TAURI_DIR/src-tauri/target/release/bundle/appimage" -maxdepth 1 -name '*.AppImage' -print -quit)"
 
 if [[ ! -d "$APPDIR" || -z "$APPIMAGE" ]]; then
+    if [[ "$PATCH_ONLY" == "true" ]]; then
+        echo "No AppDir/AppImage found — nothing to patch"
+        exit 0
+    fi
     echo "AppImage build did not produce expected AppDir/AppImage" >&2
     exit 1
 fi

--- a/tauri/scripts/build-appimage.sh
+++ b/tauri/scripts/build-appimage.sh
@@ -5,7 +5,8 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TAURI_DIR="$(dirname "$SCRIPT_DIR")"
-APPIMAGE_PLUGIN_URL="https://github.com/linuxdeploy/linuxdeploy-plugin-appimage/releases/download/continuous/linuxdeploy-plugin-appimage-x86_64.AppImage"
+ARCH="$(uname -m)"
+APPIMAGE_PLUGIN_URL="https://github.com/linuxdeploy/linuxdeploy-plugin-appimage/releases/download/continuous/linuxdeploy-plugin-appimage-${ARCH}.AppImage"
 
 cd "$TAURI_DIR"
 
@@ -39,7 +40,7 @@ if [[ -f "$APPDIR/usr/lib/libgcrypt.so.20" && ! -e "$APPDIR/usr/lib/libgpg-error
     cp -L "$libgpg_error" "$APPDIR/usr/lib/$(basename "$(readlink -f "$libgpg_error")")"
     ln -sf "$(basename "$(readlink -f "$libgpg_error")")" "$APPDIR/usr/lib/libgpg-error.so.0"
 
-    plugin="${XDG_CACHE_HOME:-$HOME/.cache}/tauri/linuxdeploy-plugin-appimage-x86_64.AppImage"
+    plugin="${XDG_CACHE_HOME:-$HOME/.cache}/tauri/linuxdeploy-plugin-appimage-${ARCH}.AppImage"
     if [[ ! -x "$plugin" ]]; then
         mkdir -p "$(dirname "$plugin")"
         curl -L --fail -o "$plugin" "$APPIMAGE_PLUGIN_URL"

--- a/tauri/scripts/build-appimage.sh
+++ b/tauri/scripts/build-appimage.sh
@@ -34,8 +34,11 @@ APPIMAGE="$(find "$TAURI_DIR/src-tauri/target/release/bundle/appimage" -maxdepth
 
 if [[ ! -d "$APPDIR" || -z "$APPIMAGE" ]]; then
     if [[ "$PATCH_ONLY" == "true" ]]; then
-        echo "No AppDir/AppImage found — nothing to patch"
-        exit 0
+        # AppDir left by linuxdeploy must still be present for us to verify and
+        # patch the bundle. Exit non-zero so callers don't re-upload an AppImage
+        # that may be missing libgpg-error.so.0.
+        echo "AppDir not found — cannot verify AppImage is patched" >&2
+        exit 1
     fi
     echo "AppImage build did not produce expected AppDir/AppImage" >&2
     exit 1


### PR DESCRIPTION
## Summary

Fix Linux AppImage runtime failure caused by linuxdeploy bundling `libgcrypt.so.20` without the matching `libgpg-error.so.0`.

The new `tauri/scripts/build-appimage.sh` wrapper:
- runs the normal Tauri build
- detects the incomplete `libgcrypt` bundle in the generated AppDir
- copies the matching system `libgpg-error.so.0` into `AppDir/usr/lib`
- regenerates the AppImage with `linuxdeploy-plugin-appimage`

`tauri/Makefile` now uses this wrapper for Linux builds.

## Verification

In Docker builder derived from `gptme-tauri-build:8861` with `file` installed:

```sh
cd /repo/tauri
PATH=/tmp/ln-wrapper:$PATH ./scripts/build-appimage.sh --bundles appimage
```

Result:
- Tauri AppImage build completed
- script printed `Bundling libgpg-error.so.0 to satisfy libgcrypt runtime dependency`
- regenerated `/repo/tauri/src-tauri/target/release/bundle/appimage/gptme-tauri_0.31.0_amd64.AppImage`

Launch smoke test in Bob's LXC:

```sh
timeout 35 xvfb-run -a env APPIMAGE_EXTRACT_AND_RUN=1 GPTME_DISABLE_AUTO_UPDATE=1 \
  tauri/src-tauri/target/release/bundle/appimage/gptme-tauri_0.31.0_amd64.AppImage
```

Before this fix, launch failed with:

```text
libgcrypt.so.20: undefined symbol: gpgrt_add_post_log_func, version GPG_ERROR_1.0
```

After this fix, the AppImage reaches Tauri startup and WebView logging. The remaining local smoke-test blocker is environmental: Bob's long-lived authenticated `gptme-server` already owns port 5700, and the Tauri app correctly refuses to reuse it without credentials.
