### PR TITLE
fix(tests): replace external duckduckgo.com URL in test_fill_element with local fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 """Test configuration and shared fixtures."""
 
+import http.server
 import json
 import logging
 import os
@@ -532,6 +533,51 @@ def mock_generation():
         return mock_stream
 
     return create
+
+
+_LOCAL_FORM_HTML = """\
+<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"><title>Test Form</title></head>
+<body>
+<form>
+  <input name="q" type="text" placeholder="Search" />
+  <button type="submit">Go</button>
+</form>
+</body>
+</html>
+"""
+
+
+class _LocalFormHandler(http.server.BaseHTTPRequestHandler):
+    """Minimal HTTP handler that serves a simple form page."""
+
+    def log_message(self, *args):  # suppress request logs in test output
+        pass
+
+    def do_GET(self):
+        encoded = _LOCAL_FORM_HTML.encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(len(encoded)))
+        self.end_headers()
+        self.wfile.write(encoded)
+
+
+@pytest.fixture()
+def local_form_page():
+    """Serve a minimal HTML form page locally and yield its URL.
+
+    Replaces external URLs (e.g. duckduckgo.com) in browser tests so the
+    suite stays hermetic and free of network flakiness.
+    """
+    server = http.server.HTTPServer(("127.0.0.1", 0), _LocalFormHandler)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    yield f"http://127.0.0.1:{port}/"
+    server.shutdown()
+    thread.join(timeout=2)
 
 
 @pytest.fixture

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -331,12 +331,11 @@ def test_scroll_page():
 
 
 @pytest.mark.slow
-def test_fill_element():
+def test_fill_element(local_form_page):
     """Test filling a form field on an open page."""
-    # Use DuckDuckGo which has a simple search input
-    open_page("https://duckduckgo.com")
+    open_page(local_form_page)
 
-    # Fill the search box
+    # Fill the search input (name="q" matches the local fixture's HTML)
     snapshot = fill_element("input[name='q']", "gptme test")
     assert snapshot, "Fill should return a valid snapshot"
     assert "gptme test" in snapshot, "Snapshot should reflect filled value"


### PR DESCRIPTION
## Problem

`test_fill_element` in `tests/test_browser.py` opened `https://duckduckgo.com`
via Playwright, causing intermittent `TimeoutError` (20 s) in CI environments
where external HTTP is unreliable or rate-limited.

Closes #3212.

## Fix

Added a `local_form_page` fixture to `tests/conftest.py` that starts a minimal
`http.server.HTTPServer` on a random port and serves a page containing
`<input name="q" />`. Updated `test_fill_element` to accept the fixture and
open the local URL instead of the external one.

The implementation reuses the same in-process server pattern already established
in `test_computer_use_integration.py` — no new dependencies required.

## Test

```
tests/test_browser.py::test_fill_element PASSED (1.18s)
```

All 27 tests in `test_browser.py` pass (1 skipped as before).

<!-- gptme-id:v1:gai_HBDD49prcEI2zC83mnhu9u9ylTm94um4amTP7RmiMNv -->