### PR TITLE
feat(webui): show external sessions in chat sidebar

### DIFF
--- a/webui/src/components/ConversationList.tsx
+++ b/webui/src/components/ConversationList.tsx
@@ -1,8 +1,9 @@
-import { Loader2, Search, BookOpen, X, Star, ArrowUpDown } from 'lucide-react';
+import { Loader2, Search, BookOpen, X, Star, ArrowUpDown, Layers } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { Badge } from '@/components/ui/badge';
 import { useApi } from '@/contexts/ApiContext';
-import { groupByDate } from '@/utils/time';
+import { groupByDate, getRelativeTimeString } from '@/utils/time';
 import { demoConversations } from '@/democonversations';
 import {
   exportConversationAsMarkdown,
@@ -15,12 +16,20 @@ import { ConversationItem, getConversationName } from './ConversationItem';
 
 import { useConversationMetadata } from '@/hooks/useConversationMetadata';
 import type { ConversationSummary } from '@/types/conversation';
+import type { ExternalSessionCatalogItem } from '@/types/api';
 import { type FC, useRef, useEffect, useState, useCallback } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { use$ } from '@legendapp/state/react';
 import { type Observable } from '@legendapp/state';
 import { conversations$ } from '@/stores/conversations';
 import { toast } from 'sonner';
+
+const HARNESS_LABELS: Record<string, string> = {
+  'claude-code': 'CC',
+  gptme: 'gptme',
+  codex: 'Codex',
+  copilot: 'Copilot',
+};
 
 type SortBy = 'recent' | 'longest' | 'alpha';
 const SORT_STORAGE_KEY = 'gptme:conv-sort';
@@ -56,6 +65,8 @@ interface Props {
   selectedId$?: Observable<string | null>;
   showServerLabels?: boolean;
   onOpenInSplitView?: (conversationId: string) => void;
+  externalSessions?: ExternalSessionCatalogItem[];
+  onSelectExternal?: (id: string) => void;
 }
 
 export const ConversationList: FC<Props> = ({
@@ -71,6 +82,8 @@ export const ConversationList: FC<Props> = ({
   selectedId$,
   showServerLabels = false,
   onOpenInSplitView,
+  externalSessions,
+  onSelectExternal,
 }) => {
   const { api, isConnected$ } = useApi();
   const isConnected = use$(isConnected$);
@@ -586,6 +599,44 @@ export const ConversationList: FC<Props> = ({
                 setOptimisticStars={setOptimisticStars}
               />
             ))}
+          </div>
+        </div>
+      )}
+
+      {/* External sessions section — compact view of cross-harness sessions */}
+      {externalSessions && externalSessions.length > 0 && onSelectExternal && (
+        <div>
+          <div className="flex items-center gap-1 px-2 py-1.5 text-xs font-medium text-muted-foreground">
+            <Layers className="h-3 w-3" />
+            External Sessions
+          </div>
+          <div className="space-y-1 px-2">
+            {externalSessions.slice(0, 10).map((session) => {
+              const displayName = session.session_name ?? session.session_id.slice(0, 8);
+              const harnessLabel = HARNESS_LABELS[session.harness] ?? session.harness;
+              const timeStr = session.last_activity
+                ? getRelativeTimeString(new Date(session.last_activity))
+                : session.started_at
+                  ? getRelativeTimeString(new Date(session.started_at))
+                  : null;
+              return (
+                <button
+                  key={session.id}
+                  className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors hover:bg-accent/50"
+                  onClick={() => onSelectExternal(session.id)}
+                >
+                  <Badge variant="secondary" className="h-4 flex-shrink-0 px-1.5 text-[10px]">
+                    {harnessLabel}
+                  </Badge>
+                  <span className="min-w-0 flex-1 truncate text-xs">{displayName}</span>
+                  {timeStr && (
+                    <span className="flex-shrink-0 text-[10px] text-muted-foreground">
+                      {timeStr}
+                    </span>
+                  )}
+                </button>
+              );
+            })}
           </div>
         </div>
       )}

--- a/webui/src/components/ExternalSessionsView.tsx
+++ b/webui/src/components/ExternalSessionsView.tsx
@@ -166,13 +166,11 @@ export const ExternalSessionsView: FC = () => {
   const [searchParams] = useSearchParams();
   const [selectedId, setSelectedId] = useState<string | null>(searchParams.get('selected'));
 
-  // Sync ?selected param on first load only (URL-driven deep link from sidebar)
+  // Sync ?selected param whenever it changes (handles sidebar navigation while component is mounted)
   useEffect(() => {
     const paramId = searchParams.get('selected');
-    if (paramId && !selectedId) {
-      setSelectedId(paramId);
-    }
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+    setSelectedId(paramId);
+  }, [searchParams]);
 
   const {
     data: sessions = [],

--- a/webui/src/components/ExternalSessionsView.tsx
+++ b/webui/src/components/ExternalSessionsView.tsx
@@ -1,4 +1,4 @@
-import { type FC, useState } from 'react';
+import { type FC, useState, useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { Bot, Clock, Cpu, FolderOpen, AlertCircle, Search, ChevronRight, X } from 'lucide-react';
 import { Input } from '@/components/ui/input';
@@ -6,6 +6,7 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { useApi } from '@/contexts/ApiContext';
 import { use$ } from '@legendapp/state/react';
+import { useSearchParams } from 'react-router-dom';
 import { getRelativeTimeString } from '@/utils/time';
 import type { ExternalSessionCatalogItem } from '@/types/api';
 import { ApiClientError } from '@/utils/api';
@@ -162,7 +163,16 @@ export const ExternalSessionsView: FC = () => {
   const { api } = useApi();
   const isConnected = use$(api.isConnected$);
   const [search, setSearch] = useState('');
-  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [searchParams] = useSearchParams();
+  const [selectedId, setSelectedId] = useState<string | null>(searchParams.get('selected'));
+
+  // Sync ?selected param on first load only (URL-driven deep link from sidebar)
+  useEffect(() => {
+    const paramId = searchParams.get('selected');
+    if (paramId && !selectedId) {
+      setSelectedId(paramId);
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   const {
     data: sessions = [],

--- a/webui/src/components/UnifiedSidebar.tsx
+++ b/webui/src/components/UnifiedSidebar.tsx
@@ -139,8 +139,9 @@ export const UnifiedSidebar: FC<Props> = ({
   const currentSection = location.pathname.startsWith('/tasks') ? 'tasks' : 'chat';
 
   // Fetch external sessions for the chat sidebar (capability-gated, best-effort)
+  // Key includes the day window to avoid colliding with ExternalSessionsView's full-range query
   const { data: externalSessions } = useQuery({
-    queryKey: ['external-sessions'],
+    queryKey: ['external-sessions', 7],
     queryFn: () => api.getExternalSessions(7),
     enabled: isConnected && currentSection === 'chat',
     staleTime: 60 * 1000,

--- a/webui/src/components/UnifiedSidebar.tsx
+++ b/webui/src/components/UnifiedSidebar.tsx
@@ -20,7 +20,7 @@ import { Card, CardContent } from '@/components/ui/card';
 import { useApi } from '@/contexts/ApiContext';
 import { initConversation } from '@/stores/conversations';
 import { parseConversationImportJSON } from '@/utils/exportConversation';
-import { useQueryClient } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 
 import type { ChangeEvent, FC } from 'react';
@@ -137,6 +137,22 @@ export const UnifiedSidebar: FC<Props> = ({
 
   // Navigation state - agents/workspaces show chat sidebar content
   const currentSection = location.pathname.startsWith('/tasks') ? 'tasks' : 'chat';
+
+  // Fetch external sessions for the chat sidebar (capability-gated, best-effort)
+  const { data: externalSessions } = useQuery({
+    queryKey: ['external-sessions'],
+    queryFn: () => api.getExternalSessions(7),
+    enabled: isConnected && currentSection === 'chat',
+    staleTime: 60 * 1000,
+    retry: false,
+  });
+
+  const handleSelectExternal = useCallback(
+    (id: string) => {
+      navigate(`/external-sessions?selected=${id}`);
+    },
+    [navigate]
+  );
 
   // Filter state for tasks
   const [selectedTargetTypes, setSelectedTargetTypes] = useState<Set<string>>(new Set(['all']));
@@ -405,6 +421,8 @@ export const UnifiedSidebar: FC<Props> = ({
               hasNextPage={hasNextPage}
               showServerLabels={showServerLabels}
               onOpenInSplitView={onOpenInSplitView}
+              externalSessions={externalSessions}
+              onSelectExternal={handleSelectExternal}
             />
           )}
 

--- a/webui/src/components/__tests__/ExternalSessionsView.test.tsx
+++ b/webui/src/components/__tests__/ExternalSessionsView.test.tsx
@@ -1,7 +1,15 @@
 import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
 import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import { ExternalSessionsView } from '../ExternalSessionsView';
+
+const renderInRouter = (initialEntry = '/external-sessions') =>
+  render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <ExternalSessionsView />
+    </MemoryRouter>
+  );
 
 const mockUseQuery = jest.fn();
 
@@ -58,13 +66,22 @@ describe('ExternalSessionsView', () => {
 
   it('labels the search field and detail close button', async () => {
     const user = userEvent.setup();
-    render(<ExternalSessionsView />);
+    renderInRouter();
 
     expect(screen.getByRole('textbox', { name: 'Search external sessions' })).toBeInTheDocument();
 
     await user.click(screen.getByRole('button', { name: /Imported session/i }));
 
     expect(screen.getByRole('button', { name: 'Close session details' })).toBeInTheDocument();
+  });
+
+  it('pre-selects a session when ?selected param is present in URL', async () => {
+    renderInRouter('/external-sessions?selected=session-1');
+
+    // Detail panel should open immediately without a click
+    expect(
+      await screen.findByRole('button', { name: 'Close session details' })
+    ).toBeInTheDocument();
   });
 
   it('renders normalized transcript messages with a collapsed system prelude', async () => {
@@ -112,7 +129,7 @@ describe('ExternalSessionsView', () => {
     });
 
     const user = userEvent.setup();
-    render(<ExternalSessionsView />);
+    renderInRouter();
     await user.click(screen.getByRole('button', { name: /Imported session/i }));
 
     expect(screen.getByRole('button', { name: /Show 1 system message/i })).toBeInTheDocument();


### PR DESCRIPTION
## Summary

Integrates external/multi-harness sessions (Claude Code, Codex, gptme, Copilot) into the native conversation sidebar, addressing the UX silo identified in #3216.

- **ConversationList**: new optional `externalSessions` prop renders a compact "External Sessions" section below native conversations — harness badge (CC / Codex / gptme) + name + relative timestamp per item
- **UnifiedSidebar**: fetches external sessions via existing `/api/v2/external-sessions` (7-day window, `retry: false`, provider-gated — section is hidden when provider returns 503)
- **ExternalSessionsView**: reads `?selected=<id>` URL param on mount for deep-link pre-selection from the sidebar
- **Tests**: wrap `ExternalSessionsView` renders in `MemoryRouter` (required after `useSearchParams` added); add test for `?selected` deep-link

## Design choices

- **Separate section, not full mixing**: external sessions appear below native conversations with a visual separator, not interleaved in the date-grouped list. This avoids type-system changes to `ConversationSummary` and keeps sorting/filtering logic simple.
- **Read-only, no steering**: clicking navigates to `/external-sessions?selected=<id>` which pre-selects the session in the existing full-page view. No new state contracts.
- **Best-effort fetch**: `retry: false` + `staleTime: 60s`. If the provider is absent (503) the section simply doesn't render.
- **Capped at 10 items**: most recent 10 external sessions shown; link to full page implied by the click-through navigation.

## Test plan

- [ ] TypeScript compiles clean (`npx tsc --noEmit`)
- [ ] Jest tests pass: `npx jest --testPathPattern="ExternalSessionsView|ConversationList"`
- [ ] With `gptme-sessions` installed: external sessions appear in sidebar under "External Sessions" heading
- [ ] Without `gptme-sessions`: section is absent (server returns 503, query returns undefined)
- [ ] Clicking a sidebar item navigates to `/external-sessions?selected=<id>` and pre-selects the session

Closes #3216

<!-- gptme-id:v1:gai_qSL84ihdUuY2y0JuBT8AbIKd4CCk2PSNzVdTWY1j3GR -->