### PR TITLE
fix(computer): capture pre-action baseline on native xdotool path in act_and_observe

### DIFF
--- a/gptme/tools/computer.py
+++ b/gptme/tools/computer.py
@@ -107,13 +107,12 @@ from typing import IO, TYPE_CHECKING, Literal, TypedDict
 
 from ._computer_gate import action_risk_level, sensitive_action_gate
 from .base import ToolFunction, ToolSpec, ToolUse
-from .computer_transport import get_transport
+from .computer_transport import ComputerTransport, get_transport
 from .screenshot import screenshot
 from .vision import view_image
 
 if TYPE_CHECKING:
     from ..message import ArtifactDescriptor, Message, MessageMetadata
-    from .computer_transport import ComputerTransport
 
 logger = logging.getLogger(__name__)
 
@@ -2546,6 +2545,58 @@ _OBSERVATION_ACTIONS: frozenset[str] = frozenset(
 )
 
 
+class _NativeScreenshotTransport(ComputerTransport):
+    """Minimal ComputerTransport that captures screenshots via the native screenshot() function.
+
+    Used by :func:`act_and_observe` when no ``GPTME_COMPUTER_TRANSPORT`` is configured,
+    so that :func:`_poll_for_change` can be reused for settle_time support and
+    pre-action baseline detection on the native xdotool/cliclick path.
+
+    Only :meth:`screenshot` is implemented; all other methods raise
+    :class:`NotImplementedError` since this transport is used only for
+    observation (polling), never for control actions.
+    """
+
+    def screenshot(self, width: int = 0, height: int = 0) -> Path:
+        return screenshot()
+
+    def close(self) -> None:
+        pass
+
+    def key(self, text: str) -> None:
+        raise NotImplementedError
+
+    def type_text(self, text: str) -> None:
+        raise NotImplementedError
+
+    def mouse_move(self, x: int, y: int) -> None:
+        raise NotImplementedError
+
+    def left_click(self) -> None:
+        raise NotImplementedError
+
+    def right_click(self) -> None:
+        raise NotImplementedError
+
+    def middle_click(self) -> None:
+        raise NotImplementedError
+
+    def double_click(self) -> None:
+        raise NotImplementedError
+
+    def left_click_drag(self, x: int, y: int) -> None:
+        raise NotImplementedError
+
+    def scroll(self, x: int, y: int, direction: str, amount: int = 3) -> None:
+        raise NotImplementedError
+
+    def cursor_position(self) -> tuple[int, int]:
+        raise NotImplementedError
+
+    def window_focus(self, pattern: str) -> None:
+        raise NotImplementedError
+
+
 def act_and_observe(
     action: Action,
     text: str | None = None,
@@ -2615,14 +2666,27 @@ def act_and_observe(
     # always times out, producing the "delay" symptom reported in #216.
     pre_action_baseline = None
     transport = None
+    _poll_transport: ComputerTransport | None = None
     if action not in _OBSERVATION_ACTIONS:
         transport = get_transport()
         if transport is not None:
+            _poll_transport = transport
             try:
                 pre_action_baseline = transport.screenshot()
             except Exception as e:
                 print(
                     f"Warning: pre-action baseline screenshot failed ({e!r}); falling back to post-action polling"
+                )
+        else:
+            # Native path: capture a pre-action baseline using the native screenshot()
+            # function and wrap it in a thin transport so _poll_for_change (and
+            # settle_time) can be reused — same fix as the transport path above.
+            _poll_transport = _NativeScreenshotTransport()
+            try:
+                pre_action_baseline = _poll_transport.screenshot()
+            except Exception as e:
+                print(
+                    f"Warning: native pre-action baseline screenshot failed ({e!r}); falling back to post-action polling"
                 )
 
     result = computer(action, text=text, coordinate=coordinate)
@@ -2635,14 +2699,15 @@ def act_and_observe(
 
     # For any action that modifies desktop state, poll for changes and return
     # one screenshot showing the settled screen.
-    if pre_action_baseline is not None and transport is not None:
+    if pre_action_baseline is not None and _poll_transport is not None:
         # Use the pre-action baseline so changes that happened immediately
         # (e.g. window_focus) are detected rather than missed.
         # settle_time ensures we wait for the screen to stop changing (not just
         # detect the first frame of a multi-phase transition like a terminal
         # appearing frame-by-frame before the shell prompt renders).
+        # This now works on both the transport path AND the native xdotool path.
         settled = _poll_for_change(
-            transport, pre_action_baseline, timeout, settle_time=settle_time
+            _poll_transport, pre_action_baseline, timeout, settle_time=settle_time
         )
     else:
         settled = computer("wait_for_change", text=str(timeout))

--- a/gptme/tools/computer.py
+++ b/gptme/tools/computer.py
@@ -2561,7 +2561,15 @@ class _NativeScreenshotTransport(ComputerTransport):
         path = screenshot()
         if not width or not height:
             width, height = _get_api_resolution()
-        _resize_image(path, width, height)
+        try:
+            _resize_image(path, width, height)
+        except RuntimeError as e:
+            # Tolerate resize failures (e.g. ImageMagick missing) the same way
+            # the old native wait_for_change path did — return the unresized
+            # screenshot rather than aborting the poll/act_and_observe call.
+            print(
+                f"Warning: screenshot resize failed ({e!r}); returning unresized image"
+            )
         return path
 
     def close(self) -> None:

--- a/gptme/tools/computer.py
+++ b/gptme/tools/computer.py
@@ -107,7 +107,7 @@ from typing import IO, TYPE_CHECKING, Literal, TypedDict
 
 from ._computer_gate import action_risk_level, sensitive_action_gate
 from .base import ToolFunction, ToolSpec, ToolUse
-from .computer_transport import ComputerTransport, get_transport
+from .computer_transport import ComputerTransport, _resize_image, get_transport
 from .screenshot import screenshot
 from .vision import view_image
 
@@ -2558,7 +2558,11 @@ class _NativeScreenshotTransport(ComputerTransport):
     """
 
     def screenshot(self, width: int = 0, height: int = 0) -> Path:
-        return screenshot()
+        path = screenshot()
+        if not width or not height:
+            width, height = _get_api_resolution()
+        _resize_image(path, width, height)
+        return path
 
     def close(self) -> None:
         pass

--- a/tests/test_computer_actions.py
+++ b/tests/test_computer_actions.py
@@ -654,6 +654,10 @@ class TestActAndObservePreBaseline:
             patch("gptme.tools.computer.computer", return_value=None),
             patch("gptme.tools.computer.get_transport", return_value=None),
             patch("gptme.tools.computer.screenshot", side_effect=mock_screenshot),
+            patch("gptme.tools.computer._resize_image"),  # no ImageMagick in CI
+            patch(
+                "gptme.tools.computer._get_api_resolution", return_value=(1024, 768)
+            ),  # no display in CI
         ):
             msgs = act_and_observe("left_click", coordinate=(100, 100), timeout=1.0)
 

--- a/tests/test_computer_actions.py
+++ b/tests/test_computer_actions.py
@@ -402,7 +402,14 @@ class TestActAndObserve:
                 return settled_msg
             return action_msg if action == "left_click" else None
 
-        with patch("gptme.tools.computer.computer", side_effect=mock_computer):
+        with (
+            patch("gptme.tools.computer.computer", side_effect=mock_computer),
+            patch("gptme.tools.computer.get_transport", return_value=None),
+            patch(
+                "gptme.tools.computer.screenshot",
+                side_effect=RuntimeError("no display"),
+            ),
+        ):
             msgs = act_and_observe("left_click", coordinate=(100, 200))
 
         assert len(call_args) == 2
@@ -419,7 +426,14 @@ class TestActAndObserve:
             call_args.append((action, text, coordinate))
             return settled_msg if action == "wait_for_change" else None
 
-        with patch("gptme.tools.computer.computer", side_effect=mock_computer):
+        with (
+            patch("gptme.tools.computer.computer", side_effect=mock_computer),
+            patch("gptme.tools.computer.get_transport", return_value=None),
+            patch(
+                "gptme.tools.computer.screenshot",
+                side_effect=RuntimeError("no display"),
+            ),
+        ):
             msgs = act_and_observe("type", text="hello")
 
         assert call_args[0][0] == "type"
@@ -470,6 +484,10 @@ class TestActAndObserve:
         with (
             patch("gptme.tools.computer.get_transport", return_value=None),
             patch("gptme.tools.computer.computer", side_effect=mock_computer),
+            patch(
+                "gptme.tools.computer.screenshot",
+                side_effect=RuntimeError("no display"),
+            ),
         ):
             act_and_observe("left_click", coordinate=(0, 0), timeout=7.5)
 
@@ -488,6 +506,10 @@ class TestActAndObserve:
         with (
             patch("gptme.tools.computer.get_transport", return_value=None),
             patch("gptme.tools.computer.computer", side_effect=mock_computer),
+            patch(
+                "gptme.tools.computer.screenshot",
+                side_effect=RuntimeError("no display"),
+            ),
         ):
             msgs = act_and_observe("scroll", coordinate=(0, 0), text="down")
 
@@ -503,6 +525,10 @@ class TestActAndObserve:
         with (
             patch("gptme.tools.computer.get_transport", return_value=None),
             patch("gptme.tools.computer.computer", side_effect=mock_computer),
+            patch(
+                "gptme.tools.computer.screenshot",
+                side_effect=RuntimeError("no display"),
+            ),
         ):
             msgs = act_and_observe("left_click", coordinate=(100, 100))
 
@@ -519,6 +545,10 @@ class TestActAndObserve:
         with (
             patch("gptme.tools.computer.get_transport", return_value=None),
             patch("gptme.tools.computer.computer", side_effect=mock_computer),
+            patch(
+                "gptme.tools.computer.screenshot",
+                side_effect=RuntimeError("no display"),
+            ),
         ):
             act_and_observe("key", text="Return")
 

--- a/tests/test_computer_actions.py
+++ b/tests/test_computer_actions.py
@@ -593,10 +593,13 @@ class TestActAndObservePreBaseline:
             "act_and_observe should return a screenshot even for window_focus"
         )
 
-    def test_act_and_observe_falls_back_when_no_transport(self) -> None:
-        """When get_transport() returns None, fall back to computer('wait_for_change').
+    def test_act_and_observe_falls_back_when_no_transport_and_screenshot_fails(
+        self,
+    ) -> None:
+        """When get_transport()=None AND native screenshot() fails, fall back to computer('wait_for_change').
 
-        This is the path taken in environments without a display (CI, unit tests).
+        This is the path taken in environments without a display (CI, unit tests)
+        where screenshot() raises because DISPLAY is not set.
         """
         settled_msg = MagicMock()
         calls: list[str] = []
@@ -610,13 +613,58 @@ class TestActAndObservePreBaseline:
         with (
             patch("gptme.tools.computer.computer", side_effect=mock_computer),
             patch("gptme.tools.computer.get_transport", return_value=None),
+            patch(
+                "gptme.tools.computer.screenshot",
+                side_effect=RuntimeError("no display"),
+            ),
         ):
             msgs = act_and_observe("left_click", coordinate=(100, 100))
 
         assert "wait_for_change" in calls, (
-            "fallback path must call computer('wait_for_change') when no transport"
+            "fallback path must call computer('wait_for_change') when screenshot() fails"
         )
         assert settled_msg in msgs
+
+    def test_act_and_observe_native_baseline_uses_poll_for_change(
+        self, tmp_path: Path
+    ) -> None:
+        """When get_transport()=None but screenshot() succeeds, use _poll_for_change.
+
+        This is the native xdotool path (no GPTME_COMPUTER_TRANSPORT set) with a
+        working X11 display.  _poll_for_change should be used with the native
+        baseline so settle_time works and immediate changes (e.g. window_focus)
+        are detected.
+        """
+        # A pre-action baseline (white) and a post-action screenshot (black).
+        baseline_path = tmp_path / "baseline.png"
+        _write_png(baseline_path, (255, 255, 255))
+        post_action_path = tmp_path / "post.png"
+        _write_png(post_action_path, (0, 0, 0))
+
+        screenshot_calls: list[int] = [0]
+
+        def mock_screenshot() -> Path:
+            # First call = pre-action baseline (white); subsequent = changed (black)
+            screenshot_calls[0] += 1
+            if screenshot_calls[0] == 1:
+                return baseline_path
+            return post_action_path
+
+        with (
+            patch("gptme.tools.computer.computer", return_value=None),
+            patch("gptme.tools.computer.get_transport", return_value=None),
+            patch("gptme.tools.computer.screenshot", side_effect=mock_screenshot),
+        ):
+            msgs = act_and_observe("left_click", coordinate=(100, 100), timeout=1.0)
+
+        # The poll must have fired: at least one screenshot after the action
+        assert screenshot_calls[0] >= 2, (
+            "native baseline path must poll for changes after the action"
+        )
+        # A settled screenshot should be returned
+        assert len(msgs) >= 1, (
+            "native baseline path must return at least one message (the settled screenshot)"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_computer_actions.py
+++ b/tests/test_computer_actions.py
@@ -670,6 +670,45 @@ class TestActAndObservePreBaseline:
             "native baseline path must return at least one message (the settled screenshot)"
         )
 
+    def test_act_and_observe_native_tolerates_resize_failure(
+        self, tmp_path: Path
+    ) -> None:
+        """A resize failure (e.g. missing ImageMagick) mid-poll must not abort
+        act_and_observe on the native path — it should return the unresized
+        screenshot instead, matching the old wait_for_change tolerance.
+        """
+        baseline_path = tmp_path / "baseline.png"
+        _write_png(baseline_path, (255, 255, 255))
+        post_action_path = tmp_path / "post.png"
+        _write_png(post_action_path, (0, 0, 0))
+
+        screenshot_calls: list[int] = [0]
+
+        def mock_screenshot() -> Path:
+            screenshot_calls[0] += 1
+            if screenshot_calls[0] == 1:
+                return baseline_path
+            return post_action_path
+
+        with (
+            patch("gptme.tools.computer.computer", return_value=None),
+            patch("gptme.tools.computer.get_transport", return_value=None),
+            patch("gptme.tools.computer.screenshot", side_effect=mock_screenshot),
+            patch(
+                "gptme.tools.computer._resize_image",
+                side_effect=RuntimeError("ImageMagick 'convert' not found."),
+            ),
+            patch("gptme.tools.computer._get_api_resolution", return_value=(1024, 768)),
+        ):
+            msgs = act_and_observe("left_click", coordinate=(100, 100), timeout=1.0)
+
+        assert screenshot_calls[0] >= 2, (
+            "polling must still proceed despite resize failures"
+        )
+        assert len(msgs) >= 1, (
+            "settled screenshot must still be returned when resize fails"
+        )
+
 
 # ---------------------------------------------------------------------------
 # TestTripleClick


### PR DESCRIPTION
## Problem

`act_and_observe` on the native xdotool/cliclick path (no `GPTME_COMPUTER_TRANSPORT` set) took its screen baseline **after** the action by calling `computer('wait_for_change')`. This meant immediate screen changes — e.g. `window_focus` bringing a window to front — were already done before polling started, so the change was missed and polling would time out waiting for a change that had already happened.

The transport path (`GPTME_COMPUTER_TRANSPORT` set) already had this fixed (captures a baseline before the action), but the native path did not.

## Fix

Add `_NativeScreenshotTransport`, a thin `ComputerTransport` wrapper around the native `screenshot()` function, so that `_poll_for_change` (with its `settle_time` and change-detection logic) can be reused on the native path in the same way as the transport path. The pre-action baseline is now captured **before** `computer(action)` fires on both paths.

**Graceful fallback**: if `screenshot()` raises (e.g. no `DISPLAY` in CI), `pre_action_baseline` stays `None` and the code falls back to the old `computer('wait_for_change')` call — no regression in headless environments.

Also lifts `ComputerTransport` from `TYPE_CHECKING`-only to a real import so `_NativeScreenshotTransport` can subclass it at module load time.

## Tests

- Updated `test_act_and_observe_falls_back_when_no_transport` → now explicitly mocks `screenshot()` raising `RuntimeError`, making the fallback path deterministic (renamed to `test_act_and_observe_falls_back_when_no_transport_and_screenshot_fails`).
- Added `test_act_and_observe_native_baseline_uses_poll_for_change`: mocks `screenshot()` returning baseline then a changed image; verifies `_poll_for_change` fires (screenshot called ≥2 times) and a settled screenshot is returned.

All 47 tests pass (`tests/test_computer_actions.py` + `tests/test_computer_task.py`).

Closes #216

<!-- gptme-id:v1:gai_s2lSkov9GoiCdn9IPkjFKW4RD7V6OkXrQfsK2wOJMnf -->