### PR TITLE
feat(subagent): add max_concurrent fleet cap to subagent_parallel()

### DIFF
--- a/gptme/tools/subagent/batch.py
+++ b/gptme/tools/subagent/batch.py
@@ -759,6 +759,15 @@ def subagent_parallel(
     if not tasks:
         return []
 
+    if max_concurrent is not None and max_concurrent < 1:
+        raise ValueError(f"max_concurrent must be >= 1, got {max_concurrent}")
+
+    agent_ids = [aid for aid, _ in tasks]
+    if len(agent_ids) != len(set(agent_ids)):
+        raise ValueError(
+            "Task agent_ids must be unique within a subagent_parallel() call"
+        )
+
     # When max_concurrent is set, use a ThreadPoolExecutor where each worker
     # does spawn+wait — this naturally queues excess tasks and respects the cap.
     if max_concurrent is not None:
@@ -935,6 +944,8 @@ def _subagent_parallel_capped(
                 budget.record(out_tok)
 
         # Trigger cancellation if this agent failed and fail-fast is on.
+        # Note: workers already inside subagent_wait() are not interrupted —
+        # cancellation only takes effect at the next slot-acquire check.
         if cancel_on_failure and result.get("status") in ("failure", "timeout"):
             cancel_event.set()
 

--- a/gptme/tools/subagent/batch.py
+++ b/gptme/tools/subagent/batch.py
@@ -901,6 +901,11 @@ def _subagent_parallel_capped(
     # completed on the boundary (run_one skips record when _timed_out is True,
     # but f.done() futures still have their results returned to the caller).
     budget_recorded_ids: set[str] = set()
+    # Serializes the _timed_out check and budget.record() calls to eliminate the
+    # TOCTOU race where a worker reads _timed_out=False, the main thread then
+    # sets _timed_out=True and returns, and the worker mutates the shared budget
+    # after the function has already handed control back to the caller.
+    budget_lock = threading.Lock()
 
     _budget_exceeded = asdict(
         ReturnType("budget_exceeded", "Budget exhausted before this agent could start")
@@ -995,11 +1000,13 @@ def _subagent_parallel_capped(
         # tokens from timed-out agents are not counted (they never completed usefully).
         # Agents that finish on the boundary (f.done() in the timeout handler) are
         # recorded there instead, using budget_recorded_ids to avoid double-counting.
-        if budget is not None and not _timed_out:
-            out_tok = result.get("output_tokens")
-            if out_tok is not None:
-                budget.record(out_tok)
-                budget_recorded_ids.add(agent_id)
+        if budget is not None:
+            with budget_lock:
+                if not _timed_out:
+                    out_tok = result.get("output_tokens")
+                    if out_tok is not None:
+                        budget.record(out_tok)
+                        budget_recorded_ids.add(agent_id)
 
         # Trigger cancellation if this agent failed and fail-fast is on.
         # Cancel siblings currently blocked in subagent_wait() so they stop
@@ -1027,7 +1034,8 @@ def _subagent_parallel_capped(
                 with results_lock:
                     results_map[aid] = result
         except FuturesTimeoutError:
-            _timed_out = True
+            with budget_lock:
+                _timed_out = True
             # Stop queued workers from starting new agents and cancel in-flight ones.
             cancel_event.set()
             with inflight_lock:

--- a/gptme/tools/subagent/batch.py
+++ b/gptme/tools/subagent/batch.py
@@ -896,6 +896,11 @@ def _subagent_parallel_capped(
     # natural timeout.
     inflight_ids: set[str] = set()
     inflight_lock = threading.Lock()
+    # Tracks which agent_ids have had budget.record() called inside run_one.
+    # The timeout handler needs this to avoid skipping budget for agents that
+    # completed on the boundary (run_one skips record when _timed_out is True,
+    # but f.done() futures still have their results returned to the caller).
+    budget_recorded_ids: set[str] = set()
 
     _budget_exceeded = asdict(
         ReturnType("budget_exceeded", "Budget exhausted before this agent could start")
@@ -988,10 +993,13 @@ def _subagent_parallel_capped(
         # has returned. A post-return budget.record() would corrupt the caller's
         # next-batch spawn decisions. This guard makes the invariant unconditional;
         # tokens from timed-out agents are not counted (they never completed usefully).
+        # Agents that finish on the boundary (f.done() in the timeout handler) are
+        # recorded there instead, using budget_recorded_ids to avoid double-counting.
         if budget is not None and not _timed_out:
             out_tok = result.get("output_tokens")
             if out_tok is not None:
                 budget.record(out_tok)
+                budget_recorded_ids.add(agent_id)
 
         # Trigger cancellation if this agent failed and fail-fast is on.
         # Cancel siblings currently blocked in subagent_wait() so they stop
@@ -1039,11 +1047,20 @@ def _subagent_parallel_capped(
                             ReturnType("cancelled", "Cancelled due to overall timeout")
                         )
                     elif f.done():
-                        # Completed on the timeout boundary but wasn't yielded by as_completed
+                        # Completed on the timeout boundary but wasn't yielded by as_completed.
+                        # f.result() acts as a memory barrier: any writes in run_one (including
+                        # budget_recorded_ids.add) are visible here after this call returns.
                         try:
                             _, result = f.result()
                         except Exception as exc:
                             result = asdict(ReturnType("failure", str(exc)))
+                        # run_one skips budget.record() when _timed_out is True, but this
+                        # result is being returned to the caller, so record the tokens now
+                        # to keep the budget accurate for subsequent batches.
+                        if budget is not None and aid not in budget_recorded_ids:
+                            out_tok = result.get("output_tokens")
+                            if out_tok is not None:
+                                budget.record(out_tok)
                         results_map[aid] = result
                     else:
                         results_map[aid] = asdict(

--- a/gptme/tools/subagent/batch.py
+++ b/gptme/tools/subagent/batch.py
@@ -600,6 +600,7 @@ def subagent_batch(
 def subagent_parallel(
     tasks: list[tuple[str, str]],
     timeout: int = 300,
+    max_concurrent: int | None = None,
     use_subprocess: bool = False,
     use_acp: bool = False,
     acp_command: str = "gptme-acp",
@@ -630,6 +631,12 @@ def subagent_parallel(
             unique within this call.
         timeout: Maximum seconds to wait for all subagents to finish. Agents
             that exceed this deadline are reported with status ``"timeout"``.
+        max_concurrent: Maximum number of subagents to run at the same time.
+            When set, excess tasks are queued and spawned as earlier agents
+            complete — this never raises an error, it only limits concurrency.
+            Pass ``None`` (default) to spawn all tasks simultaneously.
+            Useful for large fan-outs where running too many agents at once
+            would exhaust system resources or API rate limits.
         use_subprocess: If True, run each subagent in a subprocess for output
             isolation. Subprocess mode captures stdout/stderr separately and
             supports hard-kill on timeout.
@@ -740,9 +747,40 @@ def subagent_parallel(
         while not budget.exhausted():
             results = subagent_parallel(next_batch, budget=budget)
             # items skipped after budget exhaustion have status="budget_exceeded"
+
+        # Fleet cap: run at most 4 agents at a time, queueing the rest
+        results = subagent_parallel(
+            [("task-1", "..."), ("task-2", "..."), ("task-3", "..."), ("task-4", "..."),
+             ("task-5", "..."), ("task-6", "...")],
+            max_concurrent=4,
+        )
+        # task-5 and task-6 start only after earlier slots free up
     """
     if not tasks:
         return []
+
+    # When max_concurrent is set, use a ThreadPoolExecutor where each worker
+    # does spawn+wait — this naturally queues excess tasks and respects the cap.
+    if max_concurrent is not None:
+        return _subagent_parallel_capped(
+            tasks=tasks,
+            max_concurrent=max_concurrent,
+            timeout=timeout,
+            use_subprocess=use_subprocess,
+            use_acp=use_acp,
+            acp_command=acp_command,
+            model=model,
+            profile=profile,
+            isolated=isolated,
+            isolation=isolation,
+            output_schema=output_schema,
+            workdir=workdir,
+            context_turns=context_turns,
+            context_window=context_window,
+            redact_secrets=redact_secrets,
+            cancel_on_failure=cancel_on_failure,
+            budget=budget,
+        )
 
     # Track which agent_ids were skipped due to budget exhaustion vs actually started.
     started_ids: list[str] = []
@@ -809,6 +847,122 @@ def subagent_parallel(
             )
         )
         for agent_id, _ in tasks
+    ]
+    if output_schema is not None:
+        return [_parse_result(r, output_schema) for r in raw_results]
+    return raw_results
+
+
+def _subagent_parallel_capped(
+    tasks: list[tuple[str, str]],
+    max_concurrent: int,
+    timeout: int,
+    use_subprocess: bool,
+    use_acp: bool,
+    acp_command: str,
+    model: str | None,
+    profile: str | None,
+    isolated: bool,
+    isolation: "Literal['worktree'] | None",
+    output_schema: "type | dict | None",
+    workdir: "str | Path | None",
+    context_turns: "int | None",
+    context_window: "int | None",
+    redact_secrets: bool,
+    cancel_on_failure: bool,
+    budget: "SubagentBudget | None",
+) -> list[dict]:
+    """Spawn+wait each task with at most max_concurrent running simultaneously.
+
+    Uses a ThreadPoolExecutor so excess tasks are naturally queued.
+    Each worker acquires a slot, checks the budget, spawns, waits, records tokens.
+    """
+    deadline = time.monotonic() + timeout
+    results_map: dict[str, dict] = {}
+    results_lock = threading.Lock()
+    cancel_event = threading.Event()
+
+    _budget_exceeded = asdict(
+        ReturnType("budget_exceeded", "Budget exhausted before this agent could start")
+    )
+
+    def run_one(agent_id: str, prompt: str) -> tuple[str, dict]:
+        # Fast-exit if a sibling failure triggered cancellation.
+        if cancel_event.is_set():
+            return agent_id, asdict(
+                ReturnType("cancelled", "Cancelled due to sibling failure")
+            )
+
+        # Budget check at the moment this slot is acquired.
+        if budget is not None and budget.exhausted():
+            return agent_id, _budget_exceeded
+
+        remaining_secs = max(1, int(deadline - time.monotonic()))
+        if remaining_secs <= 0:
+            return agent_id, asdict(
+                ReturnType("timeout", f"Timed out after {timeout}s")
+            )
+
+        try:
+            subagent(
+                agent_id=agent_id,
+                prompt=prompt,
+                use_subprocess=use_subprocess,
+                use_acp=use_acp,
+                acp_command=acp_command,
+                model=model,
+                profile=profile,
+                isolated=isolated,
+                isolation=isolation,
+                output_schema=output_schema,
+                workdir=workdir,
+                context_turns=context_turns,
+                context_window=context_window,
+                redact_secrets=redact_secrets,
+            )
+        except Exception as exc:
+            return agent_id, asdict(ReturnType("failure", str(exc)))
+
+        try:
+            result = subagent_wait(agent_id, timeout=remaining_secs, max_result_chars=0)
+        except Exception as exc:
+            return agent_id, asdict(ReturnType("failure", str(exc)))
+
+        # Record output tokens in the shared budget.
+        if budget is not None:
+            out_tok = result.get("output_tokens")
+            if out_tok is not None:
+                budget.record(out_tok)
+
+        # Trigger cancellation if this agent failed and fail-fast is on.
+        if cancel_on_failure and result.get("status") in ("failure", "timeout"):
+            cancel_event.set()
+
+        return agent_id, result
+
+    with ThreadPoolExecutor(max_workers=max_concurrent) as pool:
+        futures: dict[Future[tuple[str, dict]], str] = {
+            pool.submit(run_one, aid, prompt): aid for aid, prompt in tasks
+        }
+        try:
+            for future in as_completed(futures, timeout=timeout):
+                aid, result = future.result()
+                with results_lock:
+                    results_map[aid] = result
+        except FuturesTimeoutError:
+            for f, aid in futures.items():
+                if not f.done():
+                    with results_lock:
+                        if aid not in results_map:
+                            results_map[aid] = asdict(
+                                ReturnType("timeout", f"Timed out after {timeout}s")
+                            )
+
+    raw_results = [
+        results_map.get(
+            aid, asdict(ReturnType("failure", "No result (timeout or missing)"))
+        )
+        for aid, _ in tasks
     ]
     if output_schema is not None:
         return [_parse_result(r, output_schema) for r in raw_results]

--- a/gptme/tools/subagent/batch.py
+++ b/gptme/tools/subagent/batch.py
@@ -890,6 +890,11 @@ def _subagent_parallel_capped(
     results_map: dict[str, dict] = {}
     results_lock = threading.Lock()
     cancel_event = threading.Event()
+    # Track agents currently blocked in subagent_wait() so we can cancel them
+    # immediately when cancel_on_failure fires, rather than waiting for their
+    # natural timeout.
+    inflight_ids: set[str] = set()
+    inflight_lock = threading.Lock()
 
     _budget_exceeded = asdict(
         ReturnType("budget_exceeded", "Budget exhausted before this agent could start")
@@ -932,10 +937,15 @@ def _subagent_parallel_capped(
         except Exception as exc:
             return agent_id, asdict(ReturnType("failure", str(exc)))
 
+        with inflight_lock:
+            inflight_ids.add(agent_id)
         try:
             result = subagent_wait(agent_id, timeout=remaining_secs, max_result_chars=0)
         except Exception as exc:
             return agent_id, asdict(ReturnType("failure", str(exc)))
+        finally:
+            with inflight_lock:
+                inflight_ids.discard(agent_id)
 
         # Record output tokens in the shared budget.
         if budget is not None:
@@ -944,10 +954,16 @@ def _subagent_parallel_capped(
                 budget.record(out_tok)
 
         # Trigger cancellation if this agent failed and fail-fast is on.
-        # Note: workers already inside subagent_wait() are not interrupted —
-        # cancellation only takes effect at the next slot-acquire check.
+        # Cancel siblings currently blocked in subagent_wait() so they stop
+        # promptly rather than running until their natural timeout.
         if cancel_on_failure and result.get("status") in ("failure", "timeout"):
             cancel_event.set()
+            with inflight_lock:
+                for sibling_id in list(inflight_ids):
+                    try:
+                        subagent_cancel(sibling_id)
+                    except Exception:
+                        pass
 
         return agent_id, result
 

--- a/gptme/tools/subagent/batch.py
+++ b/gptme/tools/subagent/batch.py
@@ -760,7 +760,8 @@ def subagent_parallel(
         return []
 
     if max_concurrent is not None and max_concurrent < 1:
-        raise ValueError(f"max_concurrent must be >= 1, got {max_concurrent}")
+        # Treat non-positive as uncapped (consistent with docstring: "never raises an error")
+        max_concurrent = None
 
     agent_ids = [aid for aid, _ in tasks]
     if len(agent_ids) != len(set(agent_ids)):
@@ -1029,6 +1030,15 @@ def _subagent_parallel_capped(
         # to stop, but we don't wait for threads blocked in subagent_wait() to return.
         # cancel_futures=True also discards any queued-but-not-yet-started workers.
         pool.shutdown(wait=not _timed_out, cancel_futures=_timed_out)
+        # On timeout: subagent_cancel() was already called for all in-flight agents
+        # above, so their subagent_wait() calls return promptly. Give those threads a
+        # brief window to finish recording budget tokens into the shared budget object
+        # before we return to the caller — otherwise the caller may see a stale
+        # budget.spent() that under-counts tokens from recently-cancelled agents.
+        if budget is not None and _timed_out:
+            _still_running = [f for f in futures if not f.done() and not f.cancelled()]
+            if _still_running:
+                futures_wait(_still_running, timeout=0.5)
 
     raw_results = [
         results_map.get(

--- a/gptme/tools/subagent/batch.py
+++ b/gptme/tools/subagent/batch.py
@@ -967,7 +967,9 @@ def _subagent_parallel_capped(
 
         return agent_id, result
 
-    with ThreadPoolExecutor(max_workers=max_concurrent) as pool:
+    pool = ThreadPoolExecutor(max_workers=max_concurrent)
+    _timed_out = False
+    try:
         futures: dict[Future[tuple[str, dict]], str] = {
             pool.submit(run_one, aid, prompt): aid for aid, prompt in tasks
         }
@@ -977,6 +979,7 @@ def _subagent_parallel_capped(
                 with results_lock:
                     results_map[aid] = result
         except FuturesTimeoutError:
+            _timed_out = True
             # Stop queued workers from starting new agents and cancel in-flight ones.
             cancel_event.set()
             with inflight_lock:
@@ -1006,6 +1009,11 @@ def _subagent_parallel_capped(
                         results_map[aid] = asdict(
                             ReturnType("timeout", f"Timed out after {timeout}s")
                         )
+    finally:
+        # On timeout, don't block on shutdown: subagent_cancel() signals running agents
+        # to stop, but we don't wait for threads blocked in subagent_wait() to return.
+        # cancel_futures=True also discards any queued-but-not-yet-started workers.
+        pool.shutdown(wait=not _timed_out, cancel_futures=_timed_out)
 
     raw_results = [
         results_map.get(

--- a/gptme/tools/subagent/batch.py
+++ b/gptme/tools/subagent/batch.py
@@ -964,7 +964,12 @@ def _subagent_parallel_capped(
                 inflight_ids.discard(agent_id)
 
         # Record output tokens in the shared budget.
-        if budget is not None:
+        # Skip on the overall-timeout path (_timed_out=True): pool.shutdown(wait=False)
+        # means this thread may still be executing after _subagent_parallel_capped()
+        # has returned. A post-return budget.record() would corrupt the caller's
+        # next-batch spawn decisions. This guard makes the invariant unconditional;
+        # tokens from timed-out agents are not counted (they never completed usefully).
+        if budget is not None and not _timed_out:
             out_tok = result.get("output_tokens")
             if out_tok is not None:
                 budget.record(out_tok)
@@ -1029,16 +1034,9 @@ def _subagent_parallel_capped(
         # On timeout, don't block on shutdown: subagent_cancel() signals running agents
         # to stop, but we don't wait for threads blocked in subagent_wait() to return.
         # cancel_futures=True also discards any queued-but-not-yet-started workers.
+        # Budget recording in run_one is guarded by _timed_out so abandoned threads
+        # cannot mutate the shared budget after this function returns.
         pool.shutdown(wait=not _timed_out, cancel_futures=_timed_out)
-        # On timeout: subagent_cancel() was already called for all in-flight agents
-        # above, so their subagent_wait() calls return promptly. Give those threads a
-        # brief window to finish recording budget tokens into the shared budget object
-        # before we return to the caller — otherwise the caller may see a stale
-        # budget.spent() that under-counts tokens from recently-cancelled agents.
-        if budget is not None and _timed_out:
-            _still_running = [f for f in futures if not f.done() and not f.cancelled()]
-            if _still_running:
-                futures_wait(_still_running, timeout=0.5)
 
     raw_results = [
         results_map.get(

--- a/gptme/tools/subagent/batch.py
+++ b/gptme/tools/subagent/batch.py
@@ -977,13 +977,35 @@ def _subagent_parallel_capped(
                 with results_lock:
                     results_map[aid] = result
         except FuturesTimeoutError:
+            # Stop queued workers from starting new agents and cancel in-flight ones.
+            cancel_event.set()
+            with inflight_lock:
+                for sibling_id in list(inflight_ids):
+                    try:
+                        subagent_cancel(sibling_id)
+                    except Exception:
+                        pass
+            for f in futures:
+                f.cancel()
             for f, aid in futures.items():
-                if not f.done():
-                    with results_lock:
-                        if aid not in results_map:
-                            results_map[aid] = asdict(
-                                ReturnType("timeout", f"Timed out after {timeout}s")
-                            )
+                with results_lock:
+                    if aid in results_map:
+                        continue
+                    if f.cancelled():
+                        results_map[aid] = asdict(
+                            ReturnType("cancelled", "Cancelled due to overall timeout")
+                        )
+                    elif f.done():
+                        # Completed on the timeout boundary but wasn't yielded by as_completed
+                        try:
+                            _, result = f.result()
+                        except Exception as exc:
+                            result = asdict(ReturnType("failure", str(exc)))
+                        results_map[aid] = result
+                    else:
+                        results_map[aid] = asdict(
+                            ReturnType("timeout", f"Timed out after {timeout}s")
+                        )
 
     raw_results = [
         results_map.get(

--- a/gptme/tools/subagent/batch.py
+++ b/gptme/tools/subagent/batch.py
@@ -936,6 +936,15 @@ def _subagent_parallel_capped(
                 redact_secrets=redact_secrets,
             )
         except Exception as exc:
+            # cancel_on_failure: sweep siblings even on spawn failure
+            if cancel_on_failure:
+                cancel_event.set()
+                with inflight_lock:
+                    for sibling_id in list(inflight_ids):
+                        try:
+                            subagent_cancel(sibling_id)
+                        except Exception:
+                            pass
             return agent_id, asdict(ReturnType("failure", str(exc)))
 
         with inflight_lock:
@@ -958,6 +967,16 @@ def _subagent_parallel_capped(
         try:
             result = subagent_wait(agent_id, timeout=remaining_secs, max_result_chars=0)
         except Exception as exc:
+            # cancel_on_failure: sweep siblings even when subagent_wait() raises.
+            # Self is removed from inflight_ids by the finally block below.
+            if cancel_on_failure:
+                cancel_event.set()
+                with inflight_lock:
+                    for sibling_id in list(inflight_ids):
+                        try:
+                            subagent_cancel(sibling_id)
+                        except Exception:
+                            pass
             return agent_id, asdict(ReturnType("failure", str(exc)))
         finally:
             with inflight_lock:

--- a/gptme/tools/subagent/batch.py
+++ b/gptme/tools/subagent/batch.py
@@ -939,6 +939,21 @@ def _subagent_parallel_capped(
 
         with inflight_lock:
             inflight_ids.add(agent_id)
+
+        # Race guard: cancel_on_failure can fire between the initial cancel_event
+        # check (above) and this registration. If so, the canceller already walked
+        # inflight_ids without seeing us. Cancel ourselves before entering the wait.
+        if cancel_event.is_set():
+            with inflight_lock:
+                inflight_ids.discard(agent_id)
+            try:
+                subagent_cancel(agent_id)
+            except Exception:
+                pass
+            return agent_id, asdict(
+                ReturnType("cancelled", "Cancelled due to sibling failure")
+            )
+
         try:
             result = subagent_wait(agent_id, timeout=remaining_secs, max_result_chars=0)
         except Exception as exc:

--- a/tests/test_subagent_budget.py
+++ b/tests/test_subagent_budget.py
@@ -867,3 +867,48 @@ class TestSubagentParallelMaxConcurrent:
         # Should return within 2× the overall timeout, not wait for the 5s worker
         assert elapsed < 3.0, f"shutdown blocked for {elapsed:.1f}s (expected <3s)"
         assert results[0]["status"] in {"timeout", "cancelled"}
+
+    def test_cancel_on_failure_race_between_check_and_inflight_registration(self):
+        """cancel_on_failure race: an agent spawns after the initial cancel_event check
+        but before it is added to inflight_ids. The post-registration guard must catch
+        this and cancel the newly spawned agent rather than leaving it running.
+        """
+        fast_failed = threading.Event()  # signalled when the fast agent reports failure
+        cancelled_ids: list[str] = []
+        cancel_lock = threading.Lock()
+
+        def mock_subagent(agent_id, prompt, **kwargs):
+            if agent_id == "slow-spawner":
+                # Block in spawn just long enough for "fast-fail" to finish
+                fast_failed.wait(timeout=5)
+
+        def mock_wait(agent_id, timeout=60, max_result_chars=0):
+            if agent_id == "fast-fail":
+                return {"status": "failure", "result": "boom", "output_tokens": 0}
+            # "slow-spawner" reaches here only if the race guard doesn't fire
+            return {"status": "success", "result": "ok", "output_tokens": 0}
+
+        def mock_cancel(agent_id):
+            with cancel_lock:
+                cancelled_ids.append(agent_id)
+            fast_failed.set()  # unblocks slow-spawner's spawn if still waiting
+
+        with (
+            patch("gptme.tools.subagent.batch.subagent", side_effect=mock_subagent),
+            patch("gptme.tools.subagent.batch.subagent_wait", side_effect=mock_wait),
+            patch(
+                "gptme.tools.subagent.batch.subagent_cancel", side_effect=mock_cancel
+            ),
+        ):
+            results = subagent_parallel(
+                [("fast-fail", "p1"), ("slow-spawner", "p2")],
+                max_concurrent=2,
+                cancel_on_failure=True,
+                timeout=5,
+            )
+
+        statuses_list = [r["status"] for r in results]
+        # "slow-spawner" must be cancelled (or cancelled-due-to-sibling) not "success"
+        assert "success" not in statuses_list, (
+            f"slow-spawner should have been cancelled, got statuses: {statuses_list}"
+        )

--- a/tests/test_subagent_budget.py
+++ b/tests/test_subagent_budget.py
@@ -8,6 +8,8 @@ import threading
 from dataclasses import asdict
 from unittest.mock import patch
 
+import pytest
+
 from gptme.tools.subagent.batch import (
     BatchJob,
     subagent_batch,
@@ -699,3 +701,21 @@ class TestSubagentParallelMaxConcurrent:
         budget_exceeded = [r for r in results if r["status"] == "budget_exceeded"]
         # At most 1 agent ran (serial + tight budget)
         assert len(budget_exceeded) >= 1
+
+    def test_max_concurrent_zero_raises(self):
+        """max_concurrent=0 raises ValueError before spawning any agents."""
+        tasks = [("a", "p1"), ("b", "p2")]
+        with pytest.raises(ValueError, match="max_concurrent must be >= 1"):
+            subagent_parallel(tasks, max_concurrent=0)
+
+    def test_max_concurrent_negative_raises(self):
+        """max_concurrent=-1 raises ValueError before spawning any agents."""
+        tasks = [("a", "p1"), ("b", "p2")]
+        with pytest.raises(ValueError, match="max_concurrent must be >= 1"):
+            subagent_parallel(tasks, max_concurrent=-1)
+
+    def test_duplicate_agent_ids_raises(self):
+        """Duplicate task agent_ids raise ValueError before any work starts."""
+        tasks = [("same-id", "prompt A"), ("same-id", "prompt B")]
+        with pytest.raises(ValueError, match="agent_ids must be unique"):
+            subagent_parallel(tasks)

--- a/tests/test_subagent_budget.py
+++ b/tests/test_subagent_budget.py
@@ -5,6 +5,7 @@ All tests are pure-unit (no LLM calls, no subprocess spawning).
 """
 
 import threading
+import time
 from dataclasses import asdict
 from unittest.mock import patch
 
@@ -822,3 +823,47 @@ class TestSubagentParallelMaxConcurrent:
         assert statuses <= {"timeout", "cancelled", "success"}, (
             f"Unexpected statuses: {statuses}"
         )
+
+    def test_timeout_does_not_block_shutdown(self):
+        """Non-blocking shutdown: subagent_parallel returns shortly after the
+        overall timeout even when a worker's subagent_wait() hasn't returned yet.
+
+        If shutdown(wait=True) were used, the function would block for the full
+        per-agent wait (5s here); with shutdown(wait=False, cancel_futures=True)
+        it returns within ~2× the overall timeout (1s).
+        """
+        slow_done = threading.Event()
+
+        def mock_subagent(agent_id, prompt, **kwargs):
+            pass
+
+        def mock_wait(agent_id, timeout=60, max_result_chars=0):
+            # Blocks for up to 5s regardless of cancel — simulates an agent that
+            # is slow to acknowledge cancellation.
+            slow_done.wait(timeout=5)
+            return {"status": "success", "result": "ok", "output_tokens": 0}
+
+        def mock_cancel(agent_id):
+            pass  # deliberately does NOT release slow_done
+
+        start = time.monotonic()
+        with (
+            patch("gptme.tools.subagent.batch.subagent", side_effect=mock_subagent),
+            patch("gptme.tools.subagent.batch.subagent_wait", side_effect=mock_wait),
+            patch(
+                "gptme.tools.subagent.batch.subagent_cancel", side_effect=mock_cancel
+            ),
+        ):
+            results = subagent_parallel(
+                [("slow", "p1")],
+                max_concurrent=1,
+                timeout=1,  # overall deadline
+            )
+        elapsed = time.monotonic() - start
+
+        # Unblock the still-running background thread so it doesn't linger
+        slow_done.set()
+
+        # Should return within 2× the overall timeout, not wait for the 5s worker
+        assert elapsed < 3.0, f"shutdown blocked for {elapsed:.1f}s (expected <3s)"
+        assert results[0]["status"] in {"timeout", "cancelled"}

--- a/tests/test_subagent_budget.py
+++ b/tests/test_subagent_budget.py
@@ -505,3 +505,197 @@ class TestBatchJobTimeoutRetry:
 
         # "a" must not be double-counted; "b" must now be counted.
         assert budget.spent() == 500  # 200 (a) + 300 (b)
+
+
+# ---------------------------------------------------------------------------
+# subagent_parallel max_concurrent tests
+# ---------------------------------------------------------------------------
+
+
+class TestSubagentParallelMaxConcurrent:
+    """Tests for max_concurrent fleet cap in subagent_parallel()."""
+
+    def _make_mock_wait(self, results_by_id: dict[str, "ReturnType"]):
+        """Return a mock for subagent_wait() that returns pre-set results."""
+
+        def mock_wait(agent_id, timeout=60, max_result_chars=0):
+            r = results_by_id.get(agent_id, ReturnType("success", "done"))
+            return asdict(r)
+
+        return mock_wait
+
+    def test_max_concurrent_none_spawns_all_at_once(self):
+        """With max_concurrent=None, all agents are spawned before any waits."""
+        tasks = [("a", "p"), ("b", "p"), ("c", "p")]
+        all_success = {
+            t[0]: ReturnType("success", "ok", output_tokens=50) for t in tasks
+        }
+
+        with (
+            patch("gptme.tools.subagent.batch.subagent") as mock_sub,
+            patch(
+                "gptme.tools.subagent.batch.subagent_wait",
+                side_effect=self._make_mock_wait(all_success),
+            ),
+        ):
+            results = subagent_parallel(tasks, max_concurrent=None)
+
+        assert mock_sub.call_count == 3
+        assert all(r["status"] == "success" for r in results)
+
+    def test_max_concurrent_limits_simultaneous_agents(self):
+        """At most max_concurrent agents are active at the same time."""
+        n_tasks = 8
+        cap = 3
+        tasks = [(f"t{i}", f"prompt {i}") for i in range(n_tasks)]
+
+        active_count = 0
+        max_active = 0
+        lock = threading.Lock()
+
+        def mock_subagent(agent_id, prompt, **kwargs):
+            pass
+
+        def mock_wait(agent_id, timeout=60, max_result_chars=0):
+            nonlocal active_count, max_active
+            with lock:
+                active_count += 1
+                if active_count > max_active:
+                    max_active = active_count
+            # Small sleep so multiple threads are in this critical section together
+            import time
+
+            time.sleep(0.02)
+            with lock:
+                active_count -= 1
+            return {"status": "success", "result": "done", "output_tokens": 10}
+
+        with (
+            patch("gptme.tools.subagent.batch.subagent", side_effect=mock_subagent),
+            patch("gptme.tools.subagent.batch.subagent_wait", side_effect=mock_wait),
+        ):
+            results = subagent_parallel(tasks, max_concurrent=cap)
+
+        assert max_active <= cap, f"Expected ≤{cap} concurrent, saw {max_active}"
+        assert len(results) == n_tasks
+        assert all(r["status"] == "success" for r in results)
+
+    def test_max_concurrent_all_tasks_complete(self):
+        """With max_concurrent set, all tasks eventually complete (none dropped)."""
+        tasks = [(f"w{i}", f"work {i}") for i in range(10)]
+        all_results = {
+            t[0]: ReturnType("success", f"result {t[0]}", output_tokens=20)
+            for t in tasks
+        }
+
+        with (
+            patch("gptme.tools.subagent.batch.subagent"),
+            patch(
+                "gptme.tools.subagent.batch.subagent_wait",
+                side_effect=self._make_mock_wait(all_results),
+            ),
+        ):
+            results = subagent_parallel(tasks, max_concurrent=3)
+
+        assert len(results) == 10
+        for i, r in enumerate(results):
+            assert r["status"] == "success", f"task {i} failed: {r}"
+
+    def test_max_concurrent_preserves_order(self):
+        """Results are returned in the same order as input tasks."""
+        tasks = [(f"ord-{i}", f"p{i}") for i in range(6)]
+        results_by_id = {
+            f"ord-{i}": ReturnType("success", f"result-{i}", output_tokens=10)
+            for i in range(6)
+        }
+
+        with (
+            patch("gptme.tools.subagent.batch.subagent"),
+            patch(
+                "gptme.tools.subagent.batch.subagent_wait",
+                side_effect=self._make_mock_wait(results_by_id),
+            ),
+        ):
+            results = subagent_parallel(tasks, max_concurrent=2)
+
+        for i, r in enumerate(results):
+            assert r["result"] == f"result-{i}", f"Order wrong at index {i}"
+
+    def test_max_concurrent_with_budget_respects_both_caps(self):
+        """max_concurrent and budget are both enforced simultaneously."""
+        tasks = [(f"b{i}", f"p{i}") for i in range(6)]
+        # Budget only allows 2 agents (50 tokens each, 100 total)
+        budget = SubagentBudget(total=100)
+        results_by_id = {
+            f"b{i}": ReturnType("success", "ok", output_tokens=50) for i in range(6)
+        }
+
+        with (
+            patch("gptme.tools.subagent.batch.subagent"),
+            patch(
+                "gptme.tools.subagent.batch.subagent_wait",
+                side_effect=self._make_mock_wait(results_by_id),
+            ),
+        ):
+            results = subagent_parallel(tasks, max_concurrent=4, budget=budget)
+
+        successes = [r for r in results if r["status"] == "success"]
+        budget_exceeded = [r for r in results if r["status"] == "budget_exceeded"]
+        # At least some agents ran before budget was exhausted
+        assert len(successes) >= 1
+        # Remaining agents got budget_exceeded
+        assert len(budget_exceeded) >= 1
+        assert len(successes) + len(budget_exceeded) == 6
+        # Budget not exceeded significantly — at most a small overrun is allowed
+        # because concurrency makes exact enforcement best-effort
+        assert budget.spent() <= 300  # at most a few extra agents slip through
+
+    def test_max_concurrent_one_limits_to_serial(self):
+        """max_concurrent=1 means agents run one at a time (serial)."""
+        tasks = [(f"s{i}", f"p{i}") for i in range(4)]
+        active_count = 0
+        max_active = 0
+        lock = threading.Lock()
+
+        def mock_wait(agent_id, timeout=60, max_result_chars=0):
+            nonlocal active_count, max_active
+            with lock:
+                active_count += 1
+                max_active = max(max_active, active_count)
+            import time
+
+            time.sleep(0.01)
+            with lock:
+                active_count -= 1
+            return {"status": "success", "result": "ok", "output_tokens": 5}
+
+        with (
+            patch("gptme.tools.subagent.batch.subagent"),
+            patch("gptme.tools.subagent.batch.subagent_wait", side_effect=mock_wait),
+        ):
+            results = subagent_parallel(tasks, max_concurrent=1)
+
+        assert max_active == 1, f"Expected serial execution (max=1), saw {max_active}"
+        assert all(r["status"] == "success" for r in results)
+
+    def test_max_concurrent_budget_exceeded_before_slot(self):
+        """Budget exhausted before a slot is acquired → budget_exceeded status."""
+        tasks = [("first", "p1"), ("second", "p2"), ("third", "p3")]
+        # Budget allows 1 agent; second and third get budget_exceeded
+        budget = SubagentBudget(total=100)
+
+        call_order: list[str] = []
+
+        def mock_wait(agent_id, timeout=60, max_result_chars=0):
+            call_order.append(agent_id)
+            return {"status": "success", "result": "ok", "output_tokens": 100}
+
+        with (
+            patch("gptme.tools.subagent.batch.subagent"),
+            patch("gptme.tools.subagent.batch.subagent_wait", side_effect=mock_wait),
+        ):
+            results = subagent_parallel(tasks, max_concurrent=1, budget=budget)
+
+        budget_exceeded = [r for r in results if r["status"] == "budget_exceeded"]
+        # At most 1 agent ran (serial + tight budget)
+        assert len(budget_exceeded) >= 1

--- a/tests/test_subagent_budget.py
+++ b/tests/test_subagent_budget.py
@@ -703,17 +703,39 @@ class TestSubagentParallelMaxConcurrent:
         # At most 1 agent ran (serial + tight budget)
         assert len(budget_exceeded) >= 1
 
-    def test_max_concurrent_zero_raises(self):
-        """max_concurrent=0 raises ValueError before spawning any agents."""
+    def test_max_concurrent_zero_treated_as_uncapped(self):
+        """max_concurrent=0 is treated as no cap (same as None)."""
         tasks = [("a", "p1"), ("b", "p2")]
-        with pytest.raises(ValueError, match="max_concurrent must be >= 1"):
-            subagent_parallel(tasks, max_concurrent=0)
+        with (
+            patch("gptme.tools.subagent.batch.subagent") as mock_spawn,
+            patch("gptme.tools.subagent.batch.subagent_wait") as mock_wait,
+        ):
+            mock_wait.return_value = {
+                "status": "success",
+                "result": "done",
+                "input_tokens": 10,
+                "output_tokens": 5,
+            }
+            results = subagent_parallel(tasks, max_concurrent=0)
+        assert len(results) == 2
+        assert mock_spawn.call_count == 2
 
-    def test_max_concurrent_negative_raises(self):
-        """max_concurrent=-1 raises ValueError before spawning any agents."""
+    def test_max_concurrent_negative_treated_as_uncapped(self):
+        """max_concurrent=-1 is treated as no cap (same as None)."""
         tasks = [("a", "p1"), ("b", "p2")]
-        with pytest.raises(ValueError, match="max_concurrent must be >= 1"):
-            subagent_parallel(tasks, max_concurrent=-1)
+        with (
+            patch("gptme.tools.subagent.batch.subagent") as mock_spawn,
+            patch("gptme.tools.subagent.batch.subagent_wait") as mock_wait,
+        ):
+            mock_wait.return_value = {
+                "status": "success",
+                "result": "done",
+                "input_tokens": 10,
+                "output_tokens": 5,
+            }
+            results = subagent_parallel(tasks, max_concurrent=-1)
+        assert len(results) == 2
+        assert mock_spawn.call_count == 2
 
     def test_duplicate_agent_ids_raises(self):
         """Duplicate task agent_ids raise ValueError before any work starts."""

--- a/tests/test_subagent_budget.py
+++ b/tests/test_subagent_budget.py
@@ -771,3 +771,54 @@ class TestSubagentParallelMaxConcurrent:
         # fast-fail should have triggered cancellation of "slow"
         assert any(r["status"] == "failure" for r in results)
         assert "slow" in cancelled_ids
+
+    def test_timeout_cancels_inflight_agents(self):
+        """Overall timeout cancels in-flight agents via subagent_cancel() and
+        stops queued workers from starting, rather than letting them run to their
+        natural timeout.
+
+        "blocking" sits inside mock_wait waiting to be released (simulating a
+        long-running agent). After the overall timeout fires, the fix should call
+        subagent_cancel("blocking"), which releases the wait and lets the test
+        complete quickly instead of hanging until the per-agent timeout.
+        """
+        released = threading.Event()
+        cancelled_ids: list[str] = []
+        cancel_lock = threading.Lock()
+
+        def mock_subagent(agent_id, prompt, **kwargs):
+            pass
+
+        def mock_wait(agent_id, timeout=60, max_result_chars=0):
+            if agent_id == "blocking":
+                released.wait(timeout=10)  # released by mock_cancel
+                return {"status": "success", "result": "ok", "output_tokens": 0}
+            return {"status": "success", "result": "ok", "output_tokens": 0}
+
+        def mock_cancel(agent_id):
+            with cancel_lock:
+                cancelled_ids.append(agent_id)
+            if agent_id == "blocking":
+                released.set()
+
+        with (
+            patch("gptme.tools.subagent.batch.subagent", side_effect=mock_subagent),
+            patch("gptme.tools.subagent.batch.subagent_wait", side_effect=mock_wait),
+            patch(
+                "gptme.tools.subagent.batch.subagent_cancel", side_effect=mock_cancel
+            ),
+        ):
+            results = subagent_parallel(
+                [("blocking", "p1"), ("queued", "p2")],
+                max_concurrent=1,
+                timeout=1,  # short timeout triggers the FuturesTimeoutError path
+            )
+
+        # "blocking" should have been cancelled on timeout
+        assert "blocking" in cancelled_ids
+        # All tasks should have a result — no "failure" fallback
+        assert len(results) == 2
+        statuses = {r["status"] for r in results}
+        assert statuses <= {"timeout", "cancelled", "success"}, (
+            f"Unexpected statuses: {statuses}"
+        )

--- a/tests/test_subagent_budget.py
+++ b/tests/test_subagent_budget.py
@@ -719,3 +719,55 @@ class TestSubagentParallelMaxConcurrent:
         tasks = [("same-id", "prompt A"), ("same-id", "prompt B")]
         with pytest.raises(ValueError, match="agent_ids must be unique"):
             subagent_parallel(tasks)
+
+    def test_cancel_on_failure_cancels_inflight_siblings(self):
+        """When cancel_on_failure=True and one agent fails, in-flight siblings
+        are cancelled via subagent_cancel() rather than running to completion.
+
+        Synchronisation: "slow" sets slow_entered once it is inside mock_wait
+        (and already in inflight_ids). "fast-fail" waits for that signal before
+        returning its failure so that inflight_ids is guaranteed to contain "slow"
+        when the cancel sweep runs. mock_cancel("slow") then sets slow_interrupted
+        so the sleeping thread exits promptly and the test completes quickly.
+        """
+        slow_entered = threading.Event()
+        slow_interrupted = threading.Event()
+        cancelled_ids: list[str] = []
+        cancel_lock = threading.Lock()
+
+        def mock_subagent(agent_id, prompt, **kwargs):
+            pass
+
+        def mock_wait(agent_id, timeout=60, max_result_chars=0):
+            if agent_id == "slow":
+                # inflight_ids.add("slow") already ran before this call
+                slow_entered.set()
+                slow_interrupted.wait(timeout=10)  # released by mock_cancel
+                return {"status": "success", "result": "ok", "output_tokens": 10}
+            # fast-fail: wait until slow is registered in inflight_ids
+            slow_entered.wait(timeout=5)
+            return {"status": "failure", "result": "boom", "output_tokens": 0}
+
+        def mock_cancel(agent_id):
+            with cancel_lock:
+                cancelled_ids.append(agent_id)
+            if agent_id == "slow":
+                slow_interrupted.set()
+
+        with (
+            patch("gptme.tools.subagent.batch.subagent", side_effect=mock_subagent),
+            patch("gptme.tools.subagent.batch.subagent_wait", side_effect=mock_wait),
+            patch(
+                "gptme.tools.subagent.batch.subagent_cancel", side_effect=mock_cancel
+            ),
+        ):
+            results = subagent_parallel(
+                [("fast-fail", "p1"), ("slow", "p2")],
+                max_concurrent=2,
+                cancel_on_failure=True,
+                timeout=10,
+            )
+
+        # fast-fail should have triggered cancellation of "slow"
+        assert any(r["status"] == "failure" for r in results)
+        assert "slow" in cancelled_ids


### PR DESCRIPTION
## Summary

Implements the remaining acceptance criterion from #3192: a `max_concurrent` parameter for `subagent_parallel()` that limits how many subagents run simultaneously, with excess tasks queued (never dropped or errored).

- Add `max_concurrent: int | None = None` to `subagent_parallel()` — defaults to `None` (existing behavior, spawn all at once)
- When set, delegates to `_subagent_parallel_capped()`: uses `ThreadPoolExecutor(max_workers=max_concurrent)` where each worker does spawn+wait, naturally limiting concurrency
- Budget checks happen at slot-acquisition time — already-running agents finish; only new spawns are blocked
- `cancel_on_failure` propagated via `threading.Event` across workers
- Results returned in original input order

## Acceptance criteria from #3192

- [x] Single-subagent result includes `token_usage` — done in #3198
- [x] `subagent_parallel()` respects `max_concurrent` — **this PR**
- [x] When token budget is exceeded, pending items return `budget_exceeded` status — done in #3198
- [x] CI covers the budget-exceeded path — done in #3198

## Tests added (7 new)

| Test | What it verifies |
|------|-----------------|
| `test_max_concurrent_none_spawns_all_at_once` | `None` preserves existing behavior |
| `test_max_concurrent_limits_simultaneous_agents` | At most `cap` agents active simultaneously (thread-counter probe) |
| `test_max_concurrent_all_tasks_complete` | All 10 tasks finish — none dropped |
| `test_max_concurrent_preserves_order` | Results in same order as input |
| `test_max_concurrent_with_budget_respects_both_caps` | Budget + concurrency cap both enforced |
| `test_max_concurrent_one_limits_to_serial` | `max_concurrent=1` → serial execution |
| `test_max_concurrent_budget_exceeded_before_slot` | Budget-exhausted check at slot-acquire time |

## Usage

```python
# Run at most 4 agents concurrently; extras queue and start as slots free up
results = subagent_parallel(
    [(f"task-{i}", f"work item {i}") for i in range(20)],
    max_concurrent=4,
)

# Combined with budget cap
budget = SubagentBudget(total=500_000)
results = subagent_parallel(tasks, max_concurrent=8, budget=budget)
```

Closes #3192

<!-- gptme-id:v1:gai_fOckWV9bY2jBRipuRnlajPDDrnK39a4uJhxFKwOXYe2 -->