### PR TITLE
fix(tauri): sync webui to managed server port

### DIFF
--- a/webui/src/contexts/ApiContext.tsx
+++ b/webui/src/contexts/ApiContext.tsx
@@ -117,7 +117,11 @@ export function ApiProvider({
 }) {
   const [isExchangingAuthCode, setIsExchangingAuthCode] = useState(needsAuthCodeExchange);
   const isTauri = isTauriEnvironment();
-  const { isLoading: isLoadingTauriStatus, managesLocalServer } = useTauriServerStatus();
+  const {
+    isLoading: isLoadingTauriStatus,
+    managesLocalServer,
+    serverStatus: tauriServerStatus,
+  } = useTauriServerStatus();
 
   // Get client for any server from the shared pool
   const getClient = useCallback((serverId?: string): IApiClient => {
@@ -373,6 +377,22 @@ export function ApiProvider({
       }
     : { baseUrl: DEFAULT_LOCAL_SERVER_URL, authToken: null, useAuthToken: false };
 
+  const tauriServerBaseUrl = tauriServerStatus
+    ? `http://127.0.0.1:${tauriServerStatus.port}`
+    : null;
+  const needsTauriServerUrlSync = Boolean(
+    isTauri &&
+      tauriServerBaseUrl &&
+      activeServer &&
+      isDefaultLoopbackTarget(connectionConfig.baseUrl) &&
+      connectionConfig.baseUrl.replace(/\/+$/, '') !== tauriServerBaseUrl
+  );
+
+  useEffect(() => {
+    if (!needsTauriServerUrlSync || !activeServer || !tauriServerBaseUrl) return;
+    updateServer(activeServer.id, { baseUrl: tauriServerBaseUrl });
+  }, [activeServer, needsTauriServerUrlSync, tauriServerBaseUrl]);
+
   const shouldSkipInitialMobileAutoConnect =
     isTauri && managesLocalServer === false && isDefaultLoopbackTarget(connectionConfig.baseUrl);
   const shouldSkipHostedLoopbackAutoConnectOnFirstLoad = shouldSkipHostedLoopbackAutoConnect(
@@ -389,6 +409,7 @@ export function ApiProvider({
     const currentHash = window.location.hash.substring(1);
     if (hasAuthCodeInHash(currentHash)) return;
     if (isTauri && isLoadingTauriStatus) return;
+    if (needsTauriServerUrlSync) return;
     if (shouldSkipInitialMobileAutoConnect) return;
     if (shouldSkipHostedLoopbackAutoConnectOnFirstLoad) return;
 
@@ -401,6 +422,7 @@ export function ApiProvider({
     connectionConfig.baseUrl,
     isLoadingTauriStatus,
     isTauri,
+    needsTauriServerUrlSync,
     shouldSkipHostedLoopbackAutoConnectOnFirstLoad,
     shouldSkipInitialMobileAutoConnect,
   ]);

--- a/webui/src/contexts/__tests__/ApiContext.test.tsx
+++ b/webui/src/contexts/__tests__/ApiContext.test.tsx
@@ -185,6 +185,28 @@ describe('ApiProvider mobile auto-connect', () => {
     expect(mockCheckConnection).not.toHaveBeenCalled();
   });
 
+  it('syncs the default local URL to the Tauri-managed server port before auto-connect', async () => {
+    mockUseTauriServerStatus.mockReturnValue({
+      isLoading: false,
+      managesLocalServer: true,
+      serverStatus: {
+        running: true,
+        port: 5712,
+        port_available: false,
+        manages_local_server: true,
+      },
+    });
+
+    renderProvider();
+
+    await waitFor(() => {
+      expect(mockUpdateServer).toHaveBeenCalledWith('server-1', {
+        baseUrl: 'http://127.0.0.1:5712',
+      });
+    });
+    expect(mockCheckConnection).not.toHaveBeenCalled();
+  });
+
   it('stops retrying after a CORS failure (permanent, not transient)', async () => {
     setActiveServerBaseUrl('https://bob.example.com');
 

--- a/webui/src/contexts/__tests__/ApiContext.test.tsx
+++ b/webui/src/contexts/__tests__/ApiContext.test.tsx
@@ -142,11 +142,15 @@ describe('ApiProvider mobile auto-connect', () => {
 
       return serverRegistry$.get().servers[0] ?? null;
     });
-    mockGetConnectionConfigFromSources.mockImplementation(() => ({
-      baseUrl: getActiveServerBaseUrl(),
-      authToken: null,
-      useAuthToken: false,
-    }));
+    // Dynamic mock that reads from current registry state
+    mockGetConnectionConfigFromSources.mockImplementation(() => {
+      const currentUrl = getActiveServerBaseUrl();
+      return {
+        baseUrl: currentUrl,
+        authToken: null,
+        useAuthToken: false,
+      };
+    });
     mockProcessConnectionFromHash.mockResolvedValue({
       baseUrl: getActiveServerBaseUrl(),
       authToken: null,
@@ -199,12 +203,19 @@ describe('ApiProvider mobile auto-connect', () => {
 
     renderProvider();
 
+    // Verify: the sync effect triggers updateServer with the Tauri-managed port
     await waitFor(() => {
       expect(mockUpdateServer).toHaveBeenCalledWith('server-1', {
         baseUrl: 'http://127.0.0.1:5712',
       });
     });
+
+    // Verify: auto-connect is skipped during the sync (needsTauriServerUrlSync is true)
     expect(mockCheckConnection).not.toHaveBeenCalled();
+
+    // After the sync completes (registry updates), the next render should proceed
+    // with auto-connect. This is tested in integration/e2e scenarios where the
+    // full reactive chain (update → registry change → component re-render) works.
   });
 
   it('stops retrying after a CORS failure (permanent, not transient)', async () => {


### PR DESCRIPTION
## Summary
- sync the active local web UI server URL to the port reported by Tauri `get_server_status`
- skip the stale default-port auto-connect while that sync is pending
- add regression coverage for `GPTME_SERVER_PORT=5712` with the default 5700 local URL

## Verification
- Built current-master Linux AppImage in `gptme-tauri-build:ac3b`: `/tmp/worktrees/gptme-tauri-verify-2b01/tauri/src-tauri/target/release/bundle/appimage/gptme-tauri_0.31.0_amd64.AppImage`
- Launched AppImage with clean HOME/config/data/cache and `GPTME_SERVER_PORT=5712` while Bob's shared 5700 server remained running
- Confirmed sidecar started from the AppImage with `--port 5712` and `/api/v2/server/health` returned green
- Confirmed clean settings initially had no configured providers, then `/api/v2/user/api-key` saved OpenRouter via the same endpoint used by the setup wizard
- Real OpenRouter generation reached provider call but failed with key daily-limit 403, so paid-provider reply remains unverified with Bob's current key
- Control chat loop with built-in `mock/echo` completed: assistant reply `Echo: Tauri onboarding OK`
- `cd webui && npm test -- ApiContext.test.tsx --runInBand`
- `cd webui && npm run build`

## Root Cause
`gptme/gptme#3220` made the sidecar honor `GPTME_SERVER_PORT`, but the bundled web UI still seeded its active server registry from hardcoded `http://127.0.0.1:5700`. In the AppImage test, the sidecar was healthy on 5712 while the WebView repeatedly failed connection checks against 5700.

## Notes
This PR fixes the WebView wiring needed for the port-collision onboarding path. It does not claim a full real-provider shippability verdict because the available OpenRouter key is currently quota-exhausted.