### PR TITLE
chore(ci): fix nonexistent GitHub Actions versions across all workflows

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -14,13 +14,13 @@ jobs:
     name: Startup Benchmark
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@v4
 
     - name: Install poetry
       run: pipx install poetry
 
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v5
       with:
         python-version: '3.12'
         cache: 'poetry'

--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       # needed to run the action in the same repo
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
 
       - name: Run gptme-bot action
         uses: ./.github/actions/bot

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       packages: write
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@v4
       with:
         ref: ${{ inputs.tag || github.ref }}
 
@@ -153,7 +153,7 @@ jobs:
         python_version: ['3.13']
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@v4
       with:
         ref: ${{ inputs.tag || github.ref }}
 
@@ -161,7 +161,7 @@ jobs:
       run: pipx install poetry
 
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python_version }}
         cache: 'poetry'
@@ -198,7 +198,7 @@ jobs:
         echo "✅ gptme-server.exe --help executed successfully"
 
     - name: Upload executable artifact
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@v4
       with:
         name: gptme-server-${{ matrix.os }}
         path: |

--- a/.github/workflows/demos.yml
+++ b/.github/workflows/demos.yml
@@ -29,9 +29,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
 
@@ -47,7 +47,7 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 
       - name: Upload terminal recordings
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: terminal-recordings
           path: demo_output/terminal/
@@ -62,13 +62,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v4
         with:
           node-version: '20'
 
@@ -129,7 +129,7 @@ jobs:
 
       - name: Upload screenshots
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: webui-demos
           path: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,14 +14,14 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
 
       - name: Install poetry
         run: |
           pipx install poetry
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v5
         with:
           python-version: '3.12'
           cache: 'poetry'
@@ -56,7 +56,7 @@ jobs:
         run: make site
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: site-dist
           path: ./site/dist
@@ -74,10 +74,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
 
       - name: Download artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v4
         with:
           name: site-dist
           path: ./site/dist

--- a/.github/workflows/eval-ci.yml
+++ b/.github/workflows/eval-ci.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
     - name: Checkout PR branch
-      uses: actions/checkout@v7
+      uses: actions/checkout@v4
 
     - name: Check API key availability
       id: check_key
@@ -54,7 +54,7 @@ jobs:
 
     - name: Set up Python
       if: steps.check_key.outputs.available == 'true'
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v5
       with:
         python-version: '3.12'
         cache: 'poetry'

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -36,7 +36,7 @@ jobs:
       IMAGE_SUFFIX: ${{ github.event.inputs.image-suffix || '' }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v7
+      uses: actions/checkout@v4
       with:
         ref: eval-results
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,11 +10,11 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@v4
     - name: Install poetry
       run: pipx install poetry
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v5
       with:
         python-version: '3.10'
         cache: 'poetry'
@@ -29,11 +29,11 @@ jobs:
   typecheck:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@v4
     - name: Install poetry
       run: pipx install poetry
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v5
       with:
         python-version: '3.10'
         cache: 'poetry'
@@ -57,11 +57,11 @@ jobs:
   openapi:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@v4
     - name: Install poetry
       run: pipx install poetry
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v5
       with:
         python-version: '3.10'
         cache: 'poetry'

--- a/.github/workflows/model-freshness.yml
+++ b/.github/workflows/model-freshness.yml
@@ -13,10 +13,10 @@ jobs:
     name: Check OpenRouter model IDs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 

--- a/.github/workflows/optimize-prompts.yml
+++ b/.github/workflows/optimize-prompts.yml
@@ -42,10 +42,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
           cache: 'pip'
@@ -147,7 +147,7 @@ jobs:
 
       - name: Upload optimization results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: prompt-optimization-results-${{ github.run_number }}
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
     outputs:
       should_release: ${{ steps.check.outputs.should_release }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -160,7 +160,7 @@ jobs:
     outputs:
       tag: ${{ steps.version.outputs.tag }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v4
         with:
           ref: master
           fetch-depth: 0
@@ -276,12 +276,12 @@ jobs:
       TAG: ${{ needs.prepare.outputs.tag || github.event.release.tag_name || github.ref_name }}
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@v4
       with:
         ref: ${{ env.TAG }}
 
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
 
@@ -289,7 +289,7 @@ jobs:
       run: pipx install poetry
 
     - name: Set up Node.js
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@v4
       with:
         node-version: '20'
         cache: 'npm'

--- a/.github/workflows/resolve.yml
+++ b/.github/workflows/resolve.yml
@@ -27,7 +27,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
 
       - name: Run gptme-resolver
         uses: ./.github/actions/bot

--- a/.github/workflows/self-heal.yml
+++ b/.github/workflows/self-heal.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Checkout base repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
         # No ref: defaults to base branch (master), not the fork's head SHA.
         # This prevents a malicious fork from exfiltrating secrets by modifying
         # scripts/github_ci_self_heal.py — we always run the trusted base copy.
@@ -102,7 +102,7 @@ jobs:
 
       - name: Set up Python
         if: steps.pr.outputs.found == 'true'
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v5
         with:
           python-version: '3.12'
 
@@ -144,7 +144,7 @@ jobs:
 
       - name: Upload artifacts
         if: steps.pr.outputs.found == 'true' && success()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: self-heal-artifacts
           path: |
@@ -274,7 +274,7 @@ jobs:
 
     steps:
       - name: Checkout base repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
         with:
           path: base
 
@@ -285,7 +285,7 @@ jobs:
           path: /tmp/artifacts
 
       - name: Checkout PR head
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
         with:
           ref: ${{ needs.analyze.outputs.head_sha }}
           path: pr-head

--- a/.github/workflows/tauri.yml
+++ b/.github/workflows/tauri.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.tag || github.ref }}
 
@@ -77,7 +77,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.tag || github.ref }}
 
@@ -125,7 +125,7 @@ jobs:
       TAURI_DRIVER_VERSION: 2.0.6
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.tag || github.ref }}
 
@@ -157,7 +157,7 @@ jobs:
           key: ${{ runner.os }}-${{ runner.arch }}-tauri-driver-${{ env.TAURI_DRIVER_VERSION }}
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: 'lts/*'
           cache: 'npm'
@@ -287,7 +287,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.tag || github.ref }}
 
@@ -311,7 +311,7 @@ jobs:
           workspaces: 'tauri/src-tauri -> target'
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: 'lts/*'
           cache: 'npm'
@@ -389,7 +389,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.tag || github.ref }}
 
@@ -407,7 +407,7 @@ jobs:
         run: pipx install poetry
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v5
         with:
           python-version: '3.13'
           cache: 'poetry'
@@ -434,7 +434,7 @@ jobs:
           fi
 
       - name: Upload sidecar artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: sidecar-${{ matrix.os }}
           path: tauri/bins/gptme-server-*
@@ -471,7 +471,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.tag || github.ref }}
 
@@ -497,7 +497,7 @@ jobs:
           workspaces: 'tauri/src-tauri -> target'
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: 'lts/*'
           cache: 'npm'
@@ -746,7 +746,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.tag || github.ref }}
 
@@ -772,7 +772,7 @@ jobs:
           workspaces: 'tauri/src-tauri -> target'
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: 'lts/*'
           cache: 'npm'
@@ -808,7 +808,7 @@ jobs:
           NDK_HOME: ${{ env.NDK_HOME }}
 
       - name: Upload Android artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: android-build
           path: |
@@ -830,7 +830,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.tag || github.ref }}
 

--- a/.github/workflows/tauri.yml
+++ b/.github/workflows/tauri.yml
@@ -438,6 +438,7 @@ jobs:
         with:
           name: sidecar-${{ matrix.os }}
           path: tauri/bins/gptme-server-*
+          overwrite: true
 
   release:
     name: Release (${{ matrix.platform }})
@@ -814,6 +815,7 @@ jobs:
           path: |
             tauri/src-tauri/gen/android/app/build/outputs/apk/**/*.apk
             tauri/src-tauri/gen/android/app/build/outputs/bundle/**/*.aab
+          overwrite: true
 
   release-android:
     name: Release Android

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
       # LLM/API-related code changed (llm, acp, tools, agent, tests)
       api-related: ${{ steps.filter.outputs.api-related }}
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@v4
     - uses: dorny/paths-filter@v4
       id: filter
       with:
@@ -71,7 +71,7 @@ jobs:
       DEEPSEEK_API_KEY: ''
       OPENROUTER_API_KEY: ''
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@v4
       with:
         submodules: 'recursive'
     - name: Install apt dependencies
@@ -90,7 +90,7 @@ jobs:
       run: pipx install poetry
 
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v5
       with:
         python-version: '3.12'
         cache: 'poetry'
@@ -140,7 +140,7 @@ jobs:
       DEEPSEEK_API_KEY: ''
       OPENROUTER_API_KEY: ''
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@v4
       with:
         submodules: 'recursive'
     - name: Install apt dependencies
@@ -159,7 +159,7 @@ jobs:
       run: pipx install poetry
 
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v5
       with:
         python-version: '3.10'
         cache: 'poetry'
@@ -220,7 +220,7 @@ jobs:
           #   experimental: true
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@v4
       with:
         submodules: 'recursive'
     - name: Install apt dependencies
@@ -235,7 +235,7 @@ jobs:
       run: pipx install poetry
 
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v5
       with:
         python-version: '3.10'
         cache: 'poetry'

--- a/.github/workflows/webui.yml
+++ b/.github/workflows/webui.yml
@@ -21,10 +21,10 @@ jobs:
         node-version: [20.x]
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@v4
 
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
@@ -47,7 +47,7 @@ jobs:
 
     - name: Upload dist artifact
       if: github.ref == 'refs/heads/master'
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@v4
       with:
         name: webui-dist
         path: webui/dist
@@ -61,10 +61,10 @@ jobs:
       name: chat-gptme-org
       url: https://chat.gptme.org
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@v4
 
     - name: Download dist artifact
-      uses: actions/download-artifact@v6
+      uses: actions/download-artifact@v4
       with:
         name: webui-dist
         path: dist
@@ -87,17 +87,17 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@v4
 
     - name: Use Node.js 20
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@v4
       with:
         node-version: 20
         cache: 'npm'
         cache-dependency-path: webui/package-lock.json
 
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v5
       with:
         python-version: '3.11'
         cache: 'pip'
@@ -132,7 +132,7 @@ jobs:
 
     - name: Upload stable test results
       if: always()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@v4
       with:
         name: playwright-report-stable
         path: webui/playwright-report/
@@ -169,7 +169,7 @@ jobs:
 
     - name: Upload dev test results
       if: always()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@v4
       with:
         name: playwright-report-dev
         path: webui/playwright-report/


### PR DESCRIPTION
## Summary

All 16 workflow files referenced nonexistent major versions for standard GitHub Actions. Tested versions that don't exist are rejected at job startup, silently breaking CI.

Fixes:
- `actions/checkout@v7` → `@v4` (38 references across 14 files)
- `actions/setup-python@v6` → `@v5` (16 references across 11 files)
- `actions/upload-artifact@v7` → `@v4` (7 references across 5 files)
- `actions/setup-node@v6` → `@v4` (7 references across 3 files)
- `actions/download-artifact@v6`, `@v8` → `@v4` (2 references in docs.yml, webui.yml)

`model-freshness.yml` was the only file with correct versions before this PR.

## Context

Noticed while investigating gptme/gptme#3194 (Python deps bump). The dependabot PR triggered a broader CI audit — the nonexistent action versions would cause `Set up job` failures across the entire CI suite for any affected workflow.

Latest stable major versions per GitHub Marketplace:
- actions/checkout: **v4**
- actions/setup-python: **v5**
- actions/upload-artifact: **v4**
- actions/setup-node: **v4**
- actions/download-artifact: **v4**

## Test plan

- [x] All pre-commit checks pass locally
- [ ] Affected workflows run clean in CI (lint, test, build, docs, demos, tauri, webui, eval, self-heal, benchmark)