### PR TITLE
fix(ci): add overwrite: true to tauri release artifact uploads

### DIFF
--- a/.github/workflows/tauri.yml
+++ b/.github/workflows/tauri.yml
@@ -438,6 +438,7 @@ jobs:
         with:
           name: sidecar-${{ matrix.os }}
           path: tauri/bins/gptme-server-*
+          overwrite: true
 
   release:
     name: Release (${{ matrix.platform }})
@@ -814,6 +815,7 @@ jobs:
           path: |
             tauri/src-tauri/gen/android/app/build/outputs/apk/**/*.apk
             tauri/src-tauri/gen/android/app/build/outputs/bundle/**/*.aab
+          overwrite: true
 
   release-android:
     name: Release Android


### PR DESCRIPTION
## Summary

- Adds `overwrite: true` to both `upload-artifact@v7` steps in `tauri.yml`
  (sidecar build and Android build)

## Why

`upload-artifact@v7` (like v4+) rejects re-uploads to an existing artifact name
by default. Without `overwrite: true`, workflow reruns fail mid-job when a
sidecar or Android artifact was already uploaded in a prior run attempt, leaving
the release job without the artifacts it needs.

## Note

This supersedes and replaces #3226, which incorrectly downgraded action versions.