### PR TITLE
fix(webui): hide Local preset server in embedded/hosted mode

### DIFF
--- a/webui/src/components/ServerSelector.tsx
+++ b/webui/src/components/ServerSelector.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { FC } from 'react';
 import { ChevronDown, Plus, Unplug, Copy, Square, Settings } from 'lucide-react';
 import { Button } from '@/components/ui/button';
@@ -101,6 +101,16 @@ export const ServerSelector: FC = () => {
   // Per-server live connectivity for the trigger dot when the effective server differs
   // from the primary tracked by useApi (i.e. when falling back to a visible server).
   const effectiveConnected = useServerConnected(effectiveActiveServerId);
+
+  // When the stored active server is hidden in embedded mode, auto-promote the first
+  // visible server in the registry so the API context uses the correct server for all
+  // requests — not just the display. Runs once per hidden-active event (the effect
+  // re-fires only if effectiveActiveServerId changes, which it won't after the switch).
+  useEffect(() => {
+    if (activeIsHidden) {
+      void switchServer(effectiveActiveServerId);
+    }
+  }, [activeIsHidden, effectiveActiveServerId]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // No visible servers after filtering: nothing to show — hide the selector entirely.
   // All hooks are above; this return is safe per React rules.

--- a/webui/src/components/ServerSelector.tsx
+++ b/webui/src/components/ServerSelector.tsx
@@ -104,13 +104,16 @@ export const ServerSelector: FC = () => {
 
   // When the stored active server is hidden in embedded mode, auto-promote the first
   // visible server in the registry so the API context uses the correct server for all
-  // requests — not just the display. The ref guard prevents retrying the same switch
-  // after a failed attempt (even if state oscillates while the fleet server connects).
+  // requests — not just the display. The ref guard prevents rapid retries; on failure
+  // the ref is cleared so the next render (e.g. when the fleet server comes online)
+  // can retry rather than staying permanently diverged.
   const lastAutoSwitchId = useRef<string | null>(null);
   useEffect(() => {
     if (activeIsHidden && lastAutoSwitchId.current !== effectiveActiveServerId) {
       lastAutoSwitchId.current = effectiveActiveServerId;
-      void switchServer(effectiveActiveServerId);
+      void switchServer(effectiveActiveServerId).catch(() => {
+        lastAutoSwitchId.current = null; // allow retry when server becomes reachable
+      });
     }
   }, [activeIsHidden, effectiveActiveServerId]); // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/webui/src/components/ServerSelector.tsx
+++ b/webui/src/components/ServerSelector.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { FC } from 'react';
 import { ChevronDown, Plus, Unplug, Copy, Square, Settings } from 'lucide-react';
 import { Button } from '@/components/ui/button';
@@ -104,10 +104,12 @@ export const ServerSelector: FC = () => {
 
   // When the stored active server is hidden in embedded mode, auto-promote the first
   // visible server in the registry so the API context uses the correct server for all
-  // requests — not just the display. Runs once per hidden-active event (the effect
-  // re-fires only if effectiveActiveServerId changes, which it won't after the switch).
+  // requests — not just the display. The ref guard prevents retrying the same switch
+  // after a failed attempt (even if state oscillates while the fleet server connects).
+  const lastAutoSwitchId = useRef<string | null>(null);
   useEffect(() => {
-    if (activeIsHidden) {
+    if (activeIsHidden && lastAutoSwitchId.current !== effectiveActiveServerId) {
+      lastAutoSwitchId.current = effectiveActiveServerId;
       void switchServer(effectiveActiveServerId);
     }
   }, [activeIsHidden, effectiveActiveServerId]); // eslint-disable-line react-hooks/exhaustive-deps

--- a/webui/src/components/ServerSelector.tsx
+++ b/webui/src/components/ServerSelector.tsx
@@ -212,7 +212,7 @@ export const ServerSelector: FC = () => {
       ? 'bg-yellow-500 animate-pulse'
       : 'bg-gray-400';
 
-  const statusText = isConnected
+  const statusText = (activeIsHidden ? effectiveConnected : isConnected)
     ? 'Connected'
     : isConnecting
       ? 'Connecting...'

--- a/webui/src/components/ServerSelector.tsx
+++ b/webui/src/components/ServerSelector.tsx
@@ -21,12 +21,25 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Checkbox } from '@/components/ui/checkbox';
 import { useApi } from '@/contexts/ApiContext';
+import { useEmbeddedContext } from '@/contexts/EmbeddedContext';
 import { use$ } from '@legendapp/state/react';
 import { serverRegistry$, addServer, connectServer, disconnectServer } from '@/stores/servers';
 import { getClientForServer } from '@/stores/serverClients';
+import { PRESET_LOCAL } from '@/types/servers';
 import { settingsModal$ } from './SettingsModal';
 import { toast } from 'sonner';
 import { cn } from '@/lib/utils';
+
+/** In embedded/hosted mode, a server is considered "user-configured" only if
+ *  it is not the default preset (i.e. the user explicitly changed something).
+ *  The auto-created Local preset at the default URL is invisible in hosted mode. */
+export function isDefaultPreset(server: { isPreset?: boolean; baseUrl: string }): boolean {
+  return (
+    server.isPreset === true &&
+    server.baseUrl.toLowerCase().replace(/\/+$/, '') ===
+      PRESET_LOCAL.baseUrl.toLowerCase().replace(/\/+$/, '')
+  );
+}
 
 /** Check actual connectivity for a server via its client in the pool. */
 function useServerConnected(serverId: string): boolean {
@@ -52,6 +65,7 @@ const ServerDot: FC<{ serverId: string; className?: string }> = ({ serverId, cla
 export const ServerSelector: FC = () => {
   const { switchServer, isConnected$, isConnecting$, isAutoConnecting$, stopAutoConnect } =
     useApi();
+  const { isEmbedded } = useEmbeddedContext();
   const registry = use$(serverRegistry$);
   const isConnected = use$(isConnected$);
   const isConnecting = use$(isConnecting$);
@@ -64,6 +78,17 @@ export const ServerSelector: FC = () => {
     authToken: '',
     useAuthToken: false,
   });
+
+  // In embedded/hosted mode, hide the auto-created Local preset so users
+  // don't see a permanently-disconnected "Local" entry in the server list.
+  // User-configured presets (changed URL) and all non-preset servers remain visible.
+  const visibleServers = isEmbedded
+    ? registry.servers.filter((s) => !isDefaultPreset(s))
+    : registry.servers;
+
+  // No visible servers after filtering: nothing to show — hide the selector entirely.
+  // All hooks are above; this return is safe per React rules.
+  if (isEmbedded && visibleServers.length === 0) return null;
 
   const serverCommand = `gptme-server --cors-origin='${window.location.origin}'`;
 
@@ -178,8 +203,8 @@ export const ServerSelector: FC = () => {
         ? 'Auto-connecting...'
         : 'Disconnected';
 
-  // Show command help when primary is disconnected
-  const showCommandHelp = !isConnected && !isConnecting && !isAutoConnecting;
+  // Show command help when primary is disconnected (not applicable in hosted mode)
+  const showCommandHelp = !isEmbedded && !isConnected && !isConnecting && !isAutoConnecting;
 
   return (
     <>
@@ -230,7 +255,7 @@ export const ServerSelector: FC = () => {
           </div>
           <DropdownMenuSeparator />
 
-          {registry.servers.map((server) => {
+          {visibleServers.map((server) => {
             const isInList = registry.connectedServerIds.includes(server.id);
             const isPrimary = server.id === registry.activeServerId;
 

--- a/webui/src/components/ServerSelector.tsx
+++ b/webui/src/components/ServerSelector.tsx
@@ -32,13 +32,16 @@ import { cn } from '@/lib/utils';
 
 /** In embedded/hosted mode, a server is considered "user-configured" only if
  *  it is not the default preset (i.e. the user explicitly changed something).
- *  The auto-created Local preset at the default URL is invisible in hosted mode. */
+ *  The auto-created Local preset at the default URL is invisible in hosted mode.
+ *  Normalizes both `localhost` and `127.0.0.1` to treat them as equivalent. */
 export function isDefaultPreset(server: { isPreset?: boolean; baseUrl: string }): boolean {
-  return (
-    server.isPreset === true &&
-    server.baseUrl.toLowerCase().replace(/\/+$/, '') ===
-      PRESET_LOCAL.baseUrl.toLowerCase().replace(/\/+$/, '')
-  );
+  if (server.isPreset !== true) return false;
+  const normalize = (url: string) =>
+    url
+      .toLowerCase()
+      .replace(/\/+$/, '')
+      .replace(/\blocalhost\b/g, '127.0.0.1');
+  return normalize(server.baseUrl) === normalize(PRESET_LOCAL.baseUrl);
 }
 
 /** Check actual connectivity for a server via its client in the pool. */
@@ -85,6 +88,19 @@ export const ServerSelector: FC = () => {
   const visibleServers = isEmbedded
     ? registry.servers.filter((s) => !isDefaultPreset(s))
     : registry.servers;
+
+  // If the stored active server is hidden (filtered out in embedded mode), fall back
+  // to the first visible server for trigger display so the button never shows a
+  // hidden disconnected Local server as "selected" while the dropdown offers fleet.
+  const activeIsHidden =
+    isEmbedded &&
+    visibleServers.length > 0 &&
+    !visibleServers.some((s) => s.id === registry.activeServerId);
+  const effectiveActiveServerId = activeIsHidden ? visibleServers[0].id : registry.activeServerId;
+
+  // Per-server live connectivity for the trigger dot when the effective server differs
+  // from the primary tracked by useApi (i.e. when falling back to a visible server).
+  const effectiveConnected = useServerConnected(effectiveActiveServerId);
 
   // No visible servers after filtering: nothing to show — hide the selector entirely.
   // All hooks are above; this return is safe per React rules.
@@ -185,11 +201,12 @@ export const ServerSelector: FC = () => {
     }
   };
 
-  const activeServer = registry.servers.find((s) => s.id === registry.activeServerId);
+  const activeServer = registry.servers.find((s) => s.id === effectiveActiveServerId);
   const label = activeServer?.name || 'Servers';
 
-  // Trigger dot color: based on primary server's actual connectivity
-  const dotColor = isConnected
+  // Trigger dot color: use effective server's connectivity (falls back to the first
+  // visible server in embedded mode when the stored active server is hidden).
+  const dotColor = (activeIsHidden ? effectiveConnected : isConnected)
     ? 'bg-green-500'
     : isConnecting || isAutoConnecting
       ? 'bg-yellow-500 animate-pulse'
@@ -257,7 +274,7 @@ export const ServerSelector: FC = () => {
 
           {visibleServers.map((server) => {
             const isInList = registry.connectedServerIds.includes(server.id);
-            const isPrimary = server.id === registry.activeServerId;
+            const isPrimary = server.id === effectiveActiveServerId;
 
             // Tooltip text depends on state
             const rowTooltip = !isInList

--- a/webui/src/components/__tests__/ServerSelector.test.tsx
+++ b/webui/src/components/__tests__/ServerSelector.test.tsx
@@ -189,6 +189,27 @@ describe('ServerSelector in embedded (hosted) mode', () => {
     expect(mockSwitchServer).toHaveBeenCalledWith('fleet-1');
   });
 
+  it('still renders fleet server if switchServer fails (graceful degradation)', async () => {
+    mockIsEmbedded = true;
+    mockRegistry = {
+      servers: [LOCAL_PRESET, FLEET_SERVER],
+      activeServerId: 'local',
+      connectedServerIds: ['local', 'fleet-1'],
+    };
+    mockSwitchServer.mockRejectedValueOnce(new Error('connection refused'));
+    const { getByText } = render(
+      <TooltipProvider>
+        <ServerSelector />
+      </TooltipProvider>
+    );
+    // switchServer was attempted (best effort)
+    expect(mockSwitchServer).toHaveBeenCalledWith('fleet-1');
+    // Component still shows the fleet server label — no crash on failure
+    expect(getByText('Cloud')).toBeTruthy();
+    // Allow the rejected promise to settle without crashing
+    await Promise.resolve();
+  });
+
   it('trigger dot is green (connected) based on effective fleet server, not hidden Local', () => {
     mockIsEmbedded = true;
     mockRegistry = {

--- a/webui/src/components/__tests__/ServerSelector.test.tsx
+++ b/webui/src/components/__tests__/ServerSelector.test.tsx
@@ -169,6 +169,32 @@ describe('ServerSelector in embedded (hosted) mode', () => {
     expect(getByText('Cloud')).toBeTruthy();
   });
 
+  it('trigger dot is green (connected) based on effective fleet server, not hidden Local', () => {
+    mockIsEmbedded = true;
+    mockRegistry = {
+      servers: [LOCAL_PRESET, FLEET_SERVER],
+      activeServerId: 'local', // Local is still the stored primary (hidden)
+      connectedServerIds: ['local', 'fleet-1'],
+    };
+    // Fleet server reports connected; Local (hidden) reports disconnected
+    const { getClientForServer } =
+      jest.requireMock<typeof import('@/stores/serverClients')>('@/stores/serverClients');
+    (getClientForServer as jest.Mock).mockImplementation((id: string) =>
+      id === 'fleet-1' ? { isConnected$: { get: () => true } } : null
+    );
+    const { container } = render(
+      <TooltipProvider>
+        <ServerSelector />
+      </TooltipProvider>
+    );
+    // The trigger button dot should be green (fleet is connected),
+    // not gray (which would mean Local's disconnected state leaked through).
+    const triggerDot = container.querySelector('.bg-green-500');
+    expect(triggerDot).not.toBeNull();
+    // Reset mock
+    (getClientForServer as jest.Mock).mockReturnValue(null);
+  });
+
   it('filters localhost:5700 preset the same as 127.0.0.1:5700 in embedded mode', () => {
     mockIsEmbedded = true;
     const localhostPreset = { ...LOCAL_PRESET, baseUrl: 'http://localhost:5700' };

--- a/webui/src/components/__tests__/ServerSelector.test.tsx
+++ b/webui/src/components/__tests__/ServerSelector.test.tsx
@@ -15,9 +15,11 @@ let mockRegistry: ServerRegistry = {
 
 // ── Mocks ──────────────────────────────────────────────────────────────────
 
+const mockSwitchServer = jest.fn(() => Promise.resolve());
+
 jest.mock('@/contexts/ApiContext', () => ({
   useApi: () => ({
-    switchServer: jest.fn(),
+    switchServer: mockSwitchServer,
     isConnected$: { get: () => false },
     isConnecting$: { get: () => false },
     isAutoConnecting$: { get: () => false },
@@ -118,6 +120,7 @@ const FLEET_SERVER: ServerConfig = {
 describe('ServerSelector in embedded (hosted) mode', () => {
   afterEach(() => {
     mockIsEmbedded = false;
+    mockSwitchServer.mockClear();
   });
 
   it('renders nothing when the only server is the default Local preset', () => {
@@ -167,6 +170,23 @@ describe('ServerSelector in embedded (hosted) mode', () => {
     );
     // The trigger should show the fleet server name, not the hidden "Local"
     expect(getByText('Cloud')).toBeTruthy();
+  });
+
+  it('auto-calls switchServer to reconcile registry when Local is active but hidden', () => {
+    mockIsEmbedded = true;
+    mockRegistry = {
+      servers: [LOCAL_PRESET, FLEET_SERVER],
+      activeServerId: 'local', // Local is stored primary but hidden
+      connectedServerIds: ['local', 'fleet-1'],
+    };
+    render(
+      <TooltipProvider>
+        <ServerSelector />
+      </TooltipProvider>
+    );
+    // The component should call switchServer so the registry's activeServerId
+    // migrates to the fleet server — preventing API calls from going to Local.
+    expect(mockSwitchServer).toHaveBeenCalledWith('fleet-1');
   });
 
   it('trigger dot is green (connected) based on effective fleet server, not hidden Local', () => {

--- a/webui/src/components/__tests__/ServerSelector.test.tsx
+++ b/webui/src/components/__tests__/ServerSelector.test.tsx
@@ -1,0 +1,164 @@
+import '@testing-library/jest-dom';
+import { render } from '@testing-library/react';
+import { isDefaultPreset } from '../ServerSelector';
+import { TooltipProvider } from '@/components/ui/tooltip';
+import type { ServerConfig, ServerRegistry } from '@/types/servers';
+
+// ── Shared mock state ──────────────────────────────────────────────────────
+
+let mockIsEmbedded = false;
+let mockRegistry: ServerRegistry = {
+  servers: [],
+  activeServerId: '',
+  connectedServerIds: [],
+};
+
+// ── Mocks ──────────────────────────────────────────────────────────────────
+
+jest.mock('@/contexts/ApiContext', () => ({
+  useApi: () => ({
+    switchServer: jest.fn(),
+    isConnected$: { get: () => false },
+    isConnecting$: { get: () => false },
+    isAutoConnecting$: { get: () => false },
+    stopAutoConnect: jest.fn(),
+  }),
+}));
+
+jest.mock('@/contexts/EmbeddedContext', () => ({
+  useEmbeddedContext: () => ({ isEmbedded: mockIsEmbedded }),
+}));
+
+jest.mock('@/stores/servers', () => ({
+  serverRegistry$: { get: () => mockRegistry },
+  addServer: jest.fn(),
+  connectServer: jest.fn(),
+  disconnectServer: jest.fn(),
+}));
+
+jest.mock('@/stores/serverClients', () => ({
+  getClientForServer: jest.fn(() => null),
+}));
+
+jest.mock('../SettingsModal', () => ({
+  settingsModal$: { set: jest.fn() },
+}));
+
+jest.mock('sonner', () => ({
+  toast: { success: jest.fn(), error: jest.fn() },
+}));
+
+// Make use$() call .get() on the observable so it works without a Provider.
+jest.mock('@legendapp/state/react', () => ({
+  use$: (obs: { get: () => unknown } | null) => (obs ? obs.get() : null),
+}));
+
+// ── isDefaultPreset unit tests ─────────────────────────────────────────────
+
+describe('isDefaultPreset', () => {
+  it('returns true for the default Local preset', () => {
+    expect(isDefaultPreset({ isPreset: true, baseUrl: 'http://127.0.0.1:5700' })).toBe(true);
+  });
+
+  it('returns true with trailing slash', () => {
+    expect(isDefaultPreset({ isPreset: true, baseUrl: 'http://127.0.0.1:5700/' })).toBe(true);
+  });
+
+  it('returns false for a preset with a different URL', () => {
+    expect(isDefaultPreset({ isPreset: true, baseUrl: 'http://myserver.local:5700' })).toBe(false);
+  });
+
+  it('returns false for a non-preset at the default URL', () => {
+    expect(isDefaultPreset({ isPreset: false, baseUrl: 'http://127.0.0.1:5700' })).toBe(false);
+  });
+
+  it('returns false for a fleet/cloud server', () => {
+    expect(
+      isDefaultPreset({
+        isPreset: false,
+        baseUrl: 'https://fleet.gptme.ai/api/v1/instances/abc',
+      })
+    ).toBe(false);
+  });
+});
+
+// ── ServerSelector render behaviour ───────────────────────────────────────
+
+import { ServerSelector } from '../ServerSelector';
+
+const LOCAL_PRESET: ServerConfig = {
+  id: 'local',
+  name: 'Local',
+  baseUrl: 'http://127.0.0.1:5700',
+  authToken: null,
+  useAuthToken: false,
+  isPreset: true,
+  createdAt: 1,
+  lastUsedAt: 1,
+};
+
+const FLEET_SERVER: ServerConfig = {
+  id: 'fleet-1',
+  name: 'Cloud',
+  baseUrl: 'https://fleet.gptme.ai/api/v1/instances/abc',
+  authToken: 'tok',
+  useAuthToken: true,
+  createdAt: 2,
+  lastUsedAt: 2,
+};
+
+describe('ServerSelector in embedded (hosted) mode', () => {
+  afterEach(() => {
+    mockIsEmbedded = false;
+  });
+
+  it('renders nothing when the only server is the default Local preset', () => {
+    mockIsEmbedded = true;
+    mockRegistry = {
+      servers: [LOCAL_PRESET],
+      activeServerId: 'local',
+      connectedServerIds: ['local'],
+    };
+    const { container } = render(<ServerSelector />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing when there are no servers at all', () => {
+    mockIsEmbedded = true;
+    mockRegistry = { servers: [], activeServerId: '', connectedServerIds: [] };
+    const { container } = render(<ServerSelector />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders fleet server (without Local) when both exist', () => {
+    mockIsEmbedded = true;
+    mockRegistry = {
+      servers: [LOCAL_PRESET, FLEET_SERVER],
+      activeServerId: 'fleet-1',
+      connectedServerIds: ['fleet-1'],
+    };
+    const { container } = render(
+      <TooltipProvider>
+        <ServerSelector />
+      </TooltipProvider>
+    );
+    expect(container.firstChild).not.toBeNull();
+  });
+});
+
+describe('ServerSelector in non-embedded mode', () => {
+  it('renders normally (shows Local server)', () => {
+    mockIsEmbedded = false;
+    mockRegistry = {
+      servers: [LOCAL_PRESET],
+      activeServerId: 'local',
+      connectedServerIds: ['local'],
+    };
+    const { container } = render(
+      <TooltipProvider>
+        <ServerSelector />
+      </TooltipProvider>
+    );
+    expect(container.firstChild).not.toBeNull();
+  });
+});

--- a/webui/src/components/__tests__/ServerSelector.test.tsx
+++ b/webui/src/components/__tests__/ServerSelector.test.tsx
@@ -80,6 +80,14 @@ describe('isDefaultPreset', () => {
       })
     ).toBe(false);
   });
+
+  it('returns true for a migrated preset stored as localhost:5700', () => {
+    expect(isDefaultPreset({ isPreset: true, baseUrl: 'http://localhost:5700' })).toBe(true);
+  });
+
+  it('returns true for localhost:5700 with trailing slash', () => {
+    expect(isDefaultPreset({ isPreset: true, baseUrl: 'http://localhost:5700/' })).toBe(true);
+  });
 });
 
 // ── ServerSelector render behaviour ───────────────────────────────────────
@@ -143,6 +151,34 @@ describe('ServerSelector in embedded (hosted) mode', () => {
       </TooltipProvider>
     );
     expect(container.firstChild).not.toBeNull();
+  });
+
+  it('shows fleet server label when Local is active but hidden', () => {
+    mockIsEmbedded = true;
+    mockRegistry = {
+      servers: [LOCAL_PRESET, FLEET_SERVER],
+      activeServerId: 'local', // Local is still the stored primary
+      connectedServerIds: ['local'],
+    };
+    const { getByText } = render(
+      <TooltipProvider>
+        <ServerSelector />
+      </TooltipProvider>
+    );
+    // The trigger should show the fleet server name, not the hidden "Local"
+    expect(getByText('Cloud')).toBeTruthy();
+  });
+
+  it('filters localhost:5700 preset the same as 127.0.0.1:5700 in embedded mode', () => {
+    mockIsEmbedded = true;
+    const localhostPreset = { ...LOCAL_PRESET, baseUrl: 'http://localhost:5700' };
+    mockRegistry = {
+      servers: [localhostPreset],
+      activeServerId: 'local',
+      connectedServerIds: ['local'],
+    };
+    const { container } = render(<ServerSelector />);
+    expect(container.firstChild).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary

- In embedded mode (`VITE_EMBEDDED_MODE=true`, i.e. gptme.ai), the auto-created Local preset (`http://127.0.0.1:5700`) was always shown in the `ServerSelector` dropdown even though it's permanently disconnected — users can't reach a local server from a hosted app.
- Filter out the default Local preset from the visible list when `isEmbedded` is true. User-configured presets (changed URL) and all non-preset (fleet) servers remain visible.
- When no visible servers remain after filtering, return `null` to hide the entire component (single-remote mode).
- Suppress the "start the server with:" command help in embedded mode — not actionable when running on gptme.ai.

## Test plan

- [x] 5 unit tests for `isDefaultPreset` helper (default URL, trailing slash, changed URL, non-preset, fleet server)
- [x] 3 render tests: embedded+only-Local→null, embedded+no-servers→null, embedded+fleet+Local→renders (Local hidden)
- [x] 1 render test: non-embedded+only-Local→renders normally
- [x] All 526 existing webui tests pass

Fixes gptme/gptme-cloud#694