### PR TITLE
fix(server): rewrite model IDs to gptme/ prefix when LLM_PROXY_URL is set

### DIFF
--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -2190,7 +2190,17 @@ def api_models():
 
     # User-curated favorites (only those still available in the model list)
     available_ids = {m["id"] for m in models_data}
-    favorites = [m for m in config.user.models.favorites if m in available_ids]
+    if is_proxy:
+        # Saved favorites may use native IDs (e.g. "anthropic/model") even though
+        # proxy mode rewrites them to "gptme/anthropic/model". Translate on output.
+        native_to_proxy = {mid.removeprefix("gptme/"): mid for mid in available_ids}
+        favorites = [
+            native_to_proxy.get(fav, fav)
+            for fav in config.user.models.favorites
+            if fav in available_ids or fav in native_to_proxy
+        ]
+    else:
+        favorites = [m for m in config.user.models.favorites if m in available_ids]
 
     return flask.jsonify(
         {

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -2157,8 +2157,13 @@ def api_models():
         models = _apply_model_filters(provider_models, include_deprecated=False)
         models_data.extend(
             {
-                "id": model.full,
-                "provider": model.provider,
+                # When routing through LLM proxy, rewrite model IDs to the gptme/
+                # provider prefix so they route correctly. Without this, selecting
+                # e.g. "anthropic/claude-sonnet-4-6" fails with 'LLM not initialized'
+                # because the pod has no ANTHROPIC_API_KEY — only the gptme provider
+                # routes through the proxy.
+                "id": f"gptme/{model.full}" if is_proxy else model.full,
+                "provider": "gptme" if is_proxy else model.provider,
                 "model": model.model,
                 "context": model.context,
                 "max_output": model.max_output,
@@ -2177,7 +2182,7 @@ def api_models():
     for provider in providers_to_check:
         try:
             rec = get_recommended_model(provider)
-            full_id = f"{provider}/{rec}"
+            full_id = f"gptme/{provider}/{rec}" if is_proxy else f"{provider}/{rec}"
             if any(m["id"] == full_id for m in models_data):
                 recommended.append(full_id)
         except ValueError:

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -238,6 +238,63 @@ def test_models_endpoint_proxy_rewrites_ids(client: FlaskClient, monkeypatch):
     )
 
 
+def test_models_endpoint_proxy_translates_native_favorites(
+    client: FlaskClient, monkeypatch
+):
+    """Favorites saved with native IDs should be translated to gptme/ prefix in proxy mode.
+
+    A user may have saved 'anthropic/claude-test' before the proxy was configured.
+    The endpoint must return the gptme/-prefixed equivalent so the UI can mark
+    those models as favorited without requiring the user to re-save.
+    """
+    from gptme.llm.models.types import ModelMeta
+
+    fake_anthropic_model = ModelMeta(
+        provider="anthropic",
+        model="claude-test",
+        context=100_000,
+        max_output=4096,
+    )
+
+    def fake_get_models(provider, dynamic_fetch=True):
+        if provider == "anthropic":
+            return [fake_anthropic_model]
+        return []
+
+    monkeypatch.setattr("gptme.server.api_v2._get_models_for_provider", fake_get_models)
+    monkeypatch.setattr("gptme.server.api_v2.get_default_model", lambda: None)
+
+    # Simulate a user whose favorite was saved using the native (pre-proxy) ID
+    class FakeUserModels:
+        favorites = ["anthropic/claude-test"]
+
+    class FakeUser:
+        models = FakeUserModels()
+
+    class FakeConfig:
+        user = FakeUser()
+
+        def get_env(self, key):
+            if key == "LLM_PROXY_URL":
+                return "https://proxy.example.com"
+            if key == "LLM_PROXY_API_KEY":
+                return "test-key"
+            return None
+
+    monkeypatch.setattr("gptme.server.api_v2.Config", FakeConfig)
+
+    response = client.get("/api/v2/models")
+    assert response.status_code == 200
+    data = response.get_json()
+
+    favorites = data["favorites"]
+    # Native ID must be translated to gptme/ prefix — not silently dropped
+    assert "gptme/anthropic/claude-test" in favorites, (
+        f"Expected favorite to be translated to gptme/ prefix, got: {favorites}"
+    )
+    assert "anthropic/claude-test" not in favorites
+
+
 def test_webui_deploy_status_disabled(client: FlaskClient, monkeypatch):
     """The web UI deploy endpoint reports disabled state by default."""
     monkeypatch.delenv("GPTME_WEBUI_ENABLE_DEV_DEPLOY", raising=False)

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -184,6 +184,60 @@ def test_v2_api_root_provider_configured(client: FlaskClient, monkeypatch):
     assert data["provider_configured"] is True
 
 
+def test_models_endpoint_proxy_rewrites_ids(client: FlaskClient, monkeypatch):
+    """When LLM_PROXY_URL is set, /api/v2/models must only expose gptme/ prefixed IDs.
+
+    Raw provider IDs (anthropic/..., openrouter/...) cannot be used on managed
+    instances because the pod has no provider API keys — only gptme/ routes through
+    the proxy. Selecting a raw ID causes 'LLM not initialized'. See gptme/gptme#3232.
+    """
+    from gptme.llm.models.types import ModelMeta
+
+    fake_anthropic_model = ModelMeta(
+        provider="anthropic",
+        model="claude-test",
+        context=100_000,
+        max_output=4096,
+    )
+
+    def fake_get_models(provider, dynamic_fetch=True):
+        if provider == "anthropic":
+            return [fake_anthropic_model]
+        return []
+
+    monkeypatch.setattr("gptme.server.api_v2._get_models_for_provider", fake_get_models)
+    monkeypatch.setattr("gptme.server.api_v2.get_default_model", lambda: None)
+
+    # Without proxy: model IDs should use native provider prefix
+    monkeypatch.delenv("LLM_PROXY_URL", raising=False)
+    monkeypatch.delenv("LLM_PROXY_API_KEY", raising=False)
+    response = client.get("/api/v2/models")
+    assert response.status_code == 200
+    data = response.get_json()
+    ids_no_proxy = [m["id"] for m in data["models"]]
+    assert any(mid == "anthropic/claude-test" for mid in ids_no_proxy)
+    assert not any(mid.startswith("gptme/") for mid in ids_no_proxy)
+
+    # With proxy: all model IDs must be gptme/ prefixed so they route correctly
+    monkeypatch.setenv("LLM_PROXY_URL", "https://proxy.example.com")
+    monkeypatch.setenv("LLM_PROXY_API_KEY", "test-key")
+    response = client.get("/api/v2/models")
+    assert response.status_code == 200
+    data = response.get_json()
+    ids_proxy = [m["id"] for m in data["models"]]
+    assert all(mid.startswith("gptme/") for mid in ids_proxy), (
+        f"Expected all IDs to start with 'gptme/' when proxy is set, got: {ids_proxy}"
+    )
+    assert any(mid == "gptme/anthropic/claude-test" for mid in ids_proxy)
+    # Raw provider IDs must not appear — they would cause 'LLM not initialized'
+    assert "anthropic/claude-test" not in ids_proxy
+    # Provider field should be 'gptme' for all models
+    providers = [m["provider"] for m in data["models"]]
+    assert all(p == "gptme" for p in providers), (
+        f"Expected all providers to be 'gptme' when proxy is set, got: {providers}"
+    )
+
+
 def test_webui_deploy_status_disabled(client: FlaskClient, monkeypatch):
     """The web UI deploy endpoint reports disabled state by default."""
     monkeypatch.delenv("GPTME_WEBUI_ENABLE_DEV_DEPLOY", raising=False)


### PR DESCRIPTION
## Summary

When `LLM_PROXY_URL` + `LLM_PROXY_API_KEY` are set (managed gptme.ai pods), the `/api/v2/models` endpoint was returning raw provider model IDs like `anthropic/claude-sonnet-4-6`. Selecting these fails with `'LLM not initialized'` because the pod has no `ANTHROPIC_API_KEY` — only the `gptme` provider routes through the proxy.

**Fix**: when `is_proxy=True`, rewrite model IDs from `<provider>/<model>` → `gptme/<provider>/<model>` and set the `provider` field to `"gptme"`. Also rewrites the recommended-models list to use the same prefix so the default picker selection is valid.

**Changes**:
- `gptme/server/api_v2.py`: conditional ID/provider rewrite in the proxy branch
- `tests/test_server_v2.py`: test verifying no-proxy returns native IDs and proxy returns `gptme/`-prefixed IDs only

Fixes #3232.

## Test plan
- [ ] New test `test_models_endpoint_proxy_rewrites_ids` covers both no-proxy and proxy cases
- [ ] All existing `test_server_v2.py` tests (186) still pass

<!-- gptme-id:v1:gai_pKvxW6FoS2QVgqLEjMoicDbUhKPsO60X58e8GAvA34x -->