### PR TITLE
revert(prompts): revert brief response mode (#3230)

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -80,7 +80,6 @@ The ``prompt`` section contains options included in both interactive and non-int
 
 - ``files``: A list of additional files to always include in context. Supports absolute paths, ``~`` expansion, and paths relative to the config directory.
 - ``project``: A table of project descriptions, keyed by project name, included when working in the matching Git repository. The default config includes descriptions for ``activitywatch`` and ``gptme`` — when the git root directory name matches one of these keys, the description is automatically injected into the system prompt.
-- ``system``: Selects the project system prompt: ``full`` (default), ``short`` (smaller startup prompt), or ``brief`` (full context with concise response guidance). The CLI ``--system`` option overrides this value.
 
 The ``env`` section contains environment variables that gptme will fall back to if they are not set in the shell environment. This is useful for setting the default model and API keys for :doc:`providers`. It can also be used to set default tool configuration options, see :doc:`custom_tool` for more information.
 

--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -523,7 +523,7 @@ Run 'gptme-util --help' for all utility commands."""
     "--system",
     "prompt_system",
     default=None,
-    help="System prompt [full|short|brief|<custom>]. Defaults to 'full', or the value of `system` in gptme.toml [prompt] if set.",
+    help="System prompt [full|short|<custom>]. Defaults to 'full', or the value of `system` in gptme.toml [prompt] if set.",
 )
 @click.option(
     "-t",

--- a/gptme/config/models.py
+++ b/gptme/config/models.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-VALID_PROJECT_SYSTEM_PROMPTS = {"brief", "full", "short"}
+VALID_PROJECT_SYSTEM_PROMPTS = {"full", "short"}
 
 
 def _pop_object_section(config_data: dict, key: str) -> dict:

--- a/gptme/prompts/__init__.py
+++ b/gptme/prompts/__init__.py
@@ -53,13 +53,7 @@ DEFAULT_CONTEXT_FILES = [
     "docker-compose.y*ml",
 ]
 
-PromptType = Literal["full", "short", "brief"]
-
-BREVITY_PROMPT = """# Response Style: Brief
-
-Respond in the minimum words needed to be correct. Use fragments when clear,
-skip preambles, and do not hedge unless uncertainty changes the answer. Keep
-necessary technical detail, safety guidance, and tool results."""
+PromptType = Literal["full", "short"]
 
 logger = logging.getLogger(__name__)
 
@@ -136,11 +130,9 @@ def _build_core_prompt_sections(
             "prompt_gptme",
             list(prompt_gptme(interactive, model, agent_name, tool_format=tool_format)),
         )
-        if prompt == "brief":
-            add("prompt_brief", [Message("system", BREVITY_PROMPT)])
         return sections
 
-    if prompt in {"full", "brief"}:
+    if prompt == "full":
         add(
             "prompt_gptme",
             list(prompt_gptme(interactive, model, agent_name, tool_format=tool_format)),
@@ -163,8 +155,6 @@ def _build_core_prompt_sections(
                 "prompt_skills_summary",
                 list(prompt_skills_summary(tool_format=tool_format)),
             )
-        if prompt == "brief":
-            add("prompt_brief", [Message("system", BREVITY_PROMPT)])
         return sections
 
     if prompt == "short":

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -291,15 +291,6 @@ files = ["README.md"]
     assert project_config.system is None
 
 
-def test_project_config_system_field_accepts_brief():
-    import tomlkit
-
-    config_data = dict(tomlkit.loads('[prompt]\nsystem = "brief"\n'))
-    project_config = ProjectConfig.from_dict(config_data)
-
-    assert project_config.system == "brief"
-
-
 def test_project_config_system_field_rejects_invalid_value():
     """Test that [prompt] system rejects typos instead of treating them as custom prompts."""
     import tomlkit
@@ -309,9 +300,7 @@ def test_project_config_system_field_rejects_invalid_value():
 system = "typo"
 """
     config_data = dict(tomlkit.loads(toml_str))
-    with pytest.raises(
-        ValueError, match="prompt.system must be one of: brief, full, short"
-    ):
+    with pytest.raises(ValueError, match="prompt.system must be one of: full, short"):
         ProjectConfig.from_dict(config_data)
 
 

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -5,12 +5,7 @@ from types import SimpleNamespace
 import pytest
 
 from gptme.message import len_tokens
-from gptme.prompts import (
-    BREVITY_PROMPT,
-    format_prompt_stats,
-    get_prompt,
-    get_prompt_stats,
-)
+from gptme.prompts import format_prompt_stats, get_prompt, get_prompt_stats
 from gptme.tools import get_tools, init_tools
 
 
@@ -41,19 +36,6 @@ def test_get_prompt_short():
     # TODO: make the short prompt shorter
     # Note: prompt size grows with new tools/features; bump ceiling as needed
     assert 400 < len_tokens(combined_content, "gpt-4") < 4500 + user_config_size
-
-
-def test_get_prompt_brief_keeps_full_context_and_adds_response_constraint():
-    brief_content = "\n\n".join(
-        msg.content for msg in get_prompt(get_tools(), prompt="brief")
-    )
-    full_content = "\n\n".join(
-        msg.content for msg in get_prompt(get_tools(), prompt="full")
-    )
-
-    assert BREVITY_PROMPT in brief_content
-    assert BREVITY_PROMPT not in full_content
-    assert "Current Project" in brief_content
 
 
 def test_get_prompt_custom():
@@ -141,17 +123,6 @@ def test_get_prompt_stats_short_without_tools_keeps_minimal_core():
     )
 
     assert [section.name for section in stats.sections] == ["prompt_gptme"]
-
-
-def test_get_prompt_stats_brief_marks_response_constraint():
-    stats = get_prompt_stats(
-        [], prompt="brief", context_mode="selective", context_include=[]
-    )
-
-    assert [section.name for section in stats.sections] == [
-        "prompt_gptme",
-        "prompt_brief",
-    ]
 
 
 def test_get_prompt_stats_includes_workspace_and_dynamic_context(tmp_path):


### PR DESCRIPTION
Reverts #3230.

Per Erik's feedback: brief response mode is what user `response_preferences` are for — this feature doesn't belong as a system prompt variant.