### PR TITLE
fix(webui): degrade gracefully when older gptme-server returns 404 for newer api/v2 routes

### DIFF
--- a/webui/src/hooks/__tests__/demoModeHooks.test.tsx
+++ b/webui/src/hooks/__tests__/demoModeHooks.test.tsx
@@ -86,3 +86,55 @@ describe('demo-mode hooks', () => {
     expect(mockFetch).not.toHaveBeenCalled();
   });
 });
+
+describe('older-server 404 graceful degradation', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    mockIsDemoMode.mockReturnValue(false);
+    providerHealth$.set({
+      data: null,
+      isLoading: false,
+      error: null,
+    });
+    Object.defineProperty(window, 'fetch', {
+      writable: true,
+      value: mockFetch,
+    });
+    // Simulate a connected server so the hooks issue the request
+    act(() => {
+      isConnected$.set(true);
+    });
+  });
+
+  afterEach(() => {
+    act(() => {
+      isConnected$.set(false);
+    });
+  });
+
+  it('useProviderHealth treats 404 as empty data without raising an error', async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 404, statusText: 'Not Found' });
+
+    const { result } = renderHook(() => useProviderHealth());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.data).toEqual({ providers: {} });
+    expect(result.current.error).toBeNull();
+  });
+
+  it('useUserSettings treats 404 as null settings without raising an error', async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 404, statusText: 'Not Found' });
+
+    const { result } = renderHook(() => useUserSettings());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.settings).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/webui/src/hooks/useProviderHealth.ts
+++ b/webui/src/hooks/useProviderHealth.ts
@@ -35,6 +35,13 @@ export function useProviderHealth(poll = false) {
         const response = await fetch(`${api.baseUrl}/api/v2/providers/health${suffix}`, {
           headers,
         });
+        if (response.status === 404) {
+          // Older gptme-server versions don't expose /api/v2/providers/health.
+          // Treat as "no provider health data" rather than an error so the UI
+          // degrades gracefully instead of surfacing a background 404.
+          providerHealth$.data.set({ providers: {} });
+          return;
+        }
         if (!response.ok) {
           throw new Error(`Failed to fetch provider health: ${response.statusText}`);
         }

--- a/webui/src/hooks/useProviderHealth.ts
+++ b/webui/src/hooks/useProviderHealth.ts
@@ -40,6 +40,7 @@ export function useProviderHealth(poll = false) {
           // Treat as "no provider health data" rather than an error so the UI
           // degrades gracefully instead of surfacing a background 404.
           providerHealth$.data.set({ providers: {} });
+          providerHealth$.isLoading.set(false);
           return;
         }
         if (!response.ok) {

--- a/webui/src/hooks/useUserSettings.ts
+++ b/webui/src/hooks/useUserSettings.ts
@@ -67,6 +67,14 @@ export function useUserSettings() {
           headers,
           signal: controller.signal,
         });
+        if (response.status === 404) {
+          // Older gptme-server versions don't expose /api/v2/user/settings.
+          // Return null settings without surfacing an error so the UI degrades
+          // gracefully instead of producing a background 404.
+          setSettings(null);
+          setIsLoading(false);
+          return;
+        }
         if (!response.ok) {
           throw new Error(`Failed to fetch user settings: ${response.statusText}`);
         }


### PR DESCRIPTION
## Summary

When the hosted gptme.ai connects to a managed instance whose gptme-server image
lags behind the webui's api/v2 contract, the webui currently surfaces background
404 errors for routes that only exist in newer server versions.

**Affected routes:**
- `GET /api/v2/providers/health` — checked by `useProviderHealth`
- `GET /api/v2/user/settings` — checked by `useUserSettings`

The routes ARE in the current gptme-server codebase, but a running instance using
an older image will return 404. The webui's hooks treated any non-ok response as
an error, including these expected 404s.

## Changes

- **`useProviderHealth.ts`**: treat 404 as "route not supported" — return empty
  `{ providers: {} }` data with no error, instead of surfacing an error state.
- **`useUserSettings.ts`**: treat 404 as "route not supported" — return `null`
  settings with no error, instead of surfacing an error state.
- **Tests**: added two new test cases in `demoModeHooks.test.tsx` that verify
  both hooks handle a 404 response gracefully (no error, expected fallback data).

## Background

This is the client-side resilience fix for gptme/gptme-cloud#689
("dogfood: managed gptme.ai instances miss newer api/v2 routes after connect").
The infrastructure-side fix (bumping the managed-instance image pin to the
current gptme-server) was done in gptme/gptme-cloud#696. This PR adds webui
resilience so that any remaining running instances or future version skew does
not produce 404 noise in the browser.

Direction per Erik's feedback on gptme/gptme-cloud#682: the fix for graceful
degradation belongs in the webui, not in cloud infra.