### PR TITLE
feat(chats): add `gptme-util chats fork` for point-in-time session forking

### DIFF
--- a/gptme/cli/cmd_chats.py
+++ b/gptme/cli/cmd_chats.py
@@ -1,6 +1,7 @@
 """CLI commands for chat/conversation management."""
 
 import json
+import shutil
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -577,6 +578,14 @@ def chats_fork(id: str, at_turn: int, fork_name: str | None):
         raise click.UsageError(f"Session has no conversation: {id!r}")
 
     source_msgs = list(Log.read_jsonl(source_logfile).messages)
+
+    user_turn_count = sum(1 for m in source_msgs if m.role == "user")
+    if at_turn > user_turn_count:
+        raise click.UsageError(
+            f"Turn {at_turn} out of range — session '{id}' has {user_turn_count} user turn(s) "
+            f"(valid range: 0–{user_turn_count})"
+        )
+
     sliced = _slice_at_turn(source_msgs, at_turn)
 
     if fork_name:
@@ -598,6 +607,11 @@ def chats_fork(id: str, at_turn: int, fork_name: str | None):
         ) from None
 
     Log(sliced).write_jsonl(new_logdir / "conversation.jsonl")
+
+    source_files_dir = source_logdir / "files"
+    if source_files_dir.exists():
+        shutil.copytree(source_files_dir, new_logdir / "files")
+
     click.echo(
         f"Forked '{id}' at turn {at_turn} → '{new_name}' ({len(sliced)} messages kept)"
     )

--- a/gptme/cli/cmd_chats.py
+++ b/gptme/cli/cmd_chats.py
@@ -486,6 +486,123 @@ def chats_clean(max_messages: int, include_test: bool, delete: bool, json_output
         click.echo("\nDry run. Use --delete to remove these conversations.")
 
 
+def _slice_at_turn(messages: list, turn: int) -> list:
+    """Return messages up to the end of the Nth user turn (1-indexed).
+
+    Turn 0: system/pre-user messages only (no user input included).
+    Turn N: through the Nth complete user+assistant exchange.
+
+    If N exceeds the number of turns in the conversation, all messages
+    are returned (no truncation).
+    """
+    if turn < 0:
+        raise ValueError(f"Turn must be non-negative, got {turn}")
+
+    if turn == 0:
+        result = []
+        for msg in messages:
+            if msg.role == "user":
+                break
+            result.append(msg)
+        return result
+
+    user_count = 0
+    for i, msg in enumerate(messages):
+        if msg.role == "user":
+            user_count += 1
+            if user_count == turn:
+                # Include all messages through the rest of this exchange
+                # (up to but not including the next user message)
+                for j in range(i + 1, len(messages)):
+                    if messages[j].role == "user":
+                        return list(messages[:j])
+                # This was the last user turn — include all remaining
+                return list(messages)
+
+    # Requested turn exceeds available turns — include all messages
+    return list(messages)
+
+
+@chats.command("fork")
+@click.argument("id")
+@click.option(
+    "--at-turn",
+    "at_turn",
+    required=True,
+    type=click.IntRange(min=0),
+    metavar="N",
+    help="Fork at turn N. Turn 0 = system context only; turn N = through Nth user+assistant exchange.",
+)
+@click.option(
+    "--name",
+    "fork_name",
+    default=None,
+    metavar="NAME",
+    help="Name for the forked session. Defaults to '<source>-fork-<timestamp>'.",
+)
+def chats_fork(id: str, at_turn: int, fork_name: str | None):
+    """Fork a session at a specific turn into a new session.
+
+    Creates a new session containing only the first N user turns from the
+    source session. The source session is never modified.
+
+    Turn 0 keeps only pre-user messages (e.g. system prompt).
+    Turn N includes through the Nth complete user+assistant exchange.
+
+    Examples:
+
+    \b
+        # Fork at turn 2
+        gptme-util chats fork my-session --at-turn 2
+
+    \b
+        # Fork at turn 5 with a custom name
+        gptme-util chats fork my-session --at-turn 5 --name retry-v2
+    """
+    from datetime import datetime, timezone  # fmt: skip
+
+    from ..logmanager import conversation_name_error  # fmt: skip
+    from ..logmanager.manager import Log  # fmt: skip
+
+    if not _is_valid_id(id):
+        raise click.UsageError(f"Invalid conversation ID: {id!r}")
+
+    logs_dir = get_logs_dir()
+    source_logdir = logs_dir / id
+    source_logfile = source_logdir / "conversation.jsonl"
+
+    if not source_logdir.exists():
+        raise click.UsageError(f"Session not found: {id!r}")
+    if not source_logfile.exists():
+        raise click.UsageError(f"Session has no conversation: {id!r}")
+
+    source_msgs = list(Log.read_jsonl(source_logfile).messages)
+    sliced = _slice_at_turn(source_msgs, at_turn)
+
+    if fork_name:
+        new_name = fork_name
+    else:
+        ts = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+        new_name = f"{id}-fork-{ts}"
+
+    name_err = conversation_name_error(new_name)
+    if name_err:
+        raise click.UsageError(name_err)
+
+    new_logdir = logs_dir / new_name
+    try:
+        new_logdir.mkdir(parents=True, exist_ok=False)
+    except FileExistsError:
+        raise click.UsageError(
+            f"Session name '{new_name}' already exists. Choose a different name with --name."
+        ) from None
+
+    Log(sliced).write_jsonl(new_logdir / "conversation.jsonl")
+    click.echo(
+        f"Forked '{id}' at turn {at_turn} → '{new_name}' ({len(sliced)} messages kept)"
+    )
+
+
 @chats.command("stats")
 @click.argument("id", required=False)
 @click.option(

--- a/gptme/cli/cmd_chats.py
+++ b/gptme/cli/cmd_chats.py
@@ -606,12 +606,16 @@ def chats_fork(id: str, at_turn: int, fork_name: str | None):
             f"Session name '{new_name}' already exists. Choose a different name with --name."
         ) from None
 
-    Log(sliced).write_jsonl(new_logdir / "conversation.jsonl")
+    try:
+        Log(sliced).write_jsonl(new_logdir / "conversation.jsonl")
 
-    for subdir in ("files", "attachments"):
-        src = source_logdir / subdir
-        if src.exists():
-            shutil.copytree(src, new_logdir / subdir)
+        for subdir in ("files", "attachments"):
+            src = source_logdir / subdir
+            if src.exists():
+                shutil.copytree(src, new_logdir / subdir)
+    except Exception:
+        shutil.rmtree(new_logdir, ignore_errors=True)
+        raise
 
     click.echo(
         f"Forked '{id}' at turn {at_turn} → '{new_name}' ({len(sliced)} messages kept)"

--- a/gptme/cli/cmd_chats.py
+++ b/gptme/cli/cmd_chats.py
@@ -608,9 +608,10 @@ def chats_fork(id: str, at_turn: int, fork_name: str | None):
 
     Log(sliced).write_jsonl(new_logdir / "conversation.jsonl")
 
-    source_files_dir = source_logdir / "files"
-    if source_files_dir.exists():
-        shutil.copytree(source_files_dir, new_logdir / "files")
+    for subdir in ("files", "attachments"):
+        src = source_logdir / subdir
+        if src.exists():
+            shutil.copytree(src, new_logdir / subdir)
 
     click.echo(
         f"Forked '{id}' at turn {at_turn} → '{new_name}' ({len(sliced)} messages kept)"

--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -17,7 +17,7 @@ import traceback
 from datetime import datetime, timezone
 from itertools import islice
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 import click
 from click.core import ParameterSource
@@ -447,6 +447,43 @@ Utilities:
 Run 'gptme-util --help' for all utility commands."""
 
 
+def _slice_at_turn(messages: list[Any], turn: int) -> list[Any]:
+    """Return messages up to the end of the Nth user turn (1-indexed).
+
+    Turn 0: system/pre-user messages only (no user input included).
+    Turn N: through the Nth complete user+assistant exchange.
+
+    If N exceeds the number of turns in the conversation, all messages
+    are returned (no truncation).
+    """
+    if turn < 0:
+        raise ValueError(f"Turn must be non-negative, got {turn}")
+
+    if turn == 0:
+        result = []
+        for msg in messages:
+            if msg.role == "user":
+                break
+            result.append(msg)
+        return result
+
+    user_count = 0
+    for i, msg in enumerate(messages):
+        if msg.role == "user":
+            user_count += 1
+            if user_count == turn:
+                # Include all messages through the rest of this exchange
+                # (up to but not including the next user message)
+                for j in range(i + 1, len(messages)):
+                    if messages[j].role == "user":
+                        return list(messages[:j])
+                # This was the last user turn — include all remaining
+                return list(messages)
+
+    # Requested turn exceeds available turns — include all messages
+    return list(messages)
+
+
 @click.command(
     help=docstring,
     context_settings={"auto_envvar_prefix": "GPTME"},
@@ -492,6 +529,21 @@ Run 'gptme-util --help' for all utility commands."""
     "--resume",
     is_flag=True,
     help="Load most recent conversation.",
+)
+@click.option(
+    "--from-turn",
+    "from_turn",
+    default=None,
+    type=int,
+    metavar="N",
+    help="Fork at turn N: create a new session with the first N user turns from the source (requires --resume or --name). Turn 0 = system context only; turn N = through Nth user+assistant exchange.",
+)
+@click.option(
+    "--branch",
+    "branch_name",
+    default=None,
+    metavar="NAME",
+    help="Name for the branched session (used with --from-turn). Defaults to '<source>-branch-<timestamp>'.",
 )
 @click.option(
     "-y",
@@ -686,6 +738,8 @@ def main(
     version: bool,
     version_json: bool,
     resume: bool,
+    from_turn: int | None,
+    branch_name: str | None,
     workspace: str | None,
     agent_path: str | None,
     profile: bool,
@@ -1163,6 +1217,43 @@ def main(
         logdir_preexisting = name != "random" and (get_logs_dir() / name).exists()
         logdir = get_logdir(name)
         prompt_msgs = inject_stdin(prompt_msgs, piped_input)
+
+    # --from-turn: fork the source session at turn N into a new session
+    if from_turn is not None:
+        if not resume and name == "random":
+            raise click.UsageError(
+                "--from-turn requires --resume or --name to identify the source session"
+            )
+        from ..logmanager.manager import Log  # heavy import, deferred
+
+        source_logfile = logdir / "conversation.jsonl"
+        if not source_logfile.exists():
+            raise click.UsageError(f"Source session has no conversation: {logdir}")
+
+        source_msgs = list(Log.read_jsonl(source_logfile).messages)
+        sliced = _slice_at_turn(source_msgs, from_turn)
+
+        if branch_name:
+            new_name = branch_name
+        else:
+            ts = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+            new_name = f"{logdir.name}-branch-{ts}"
+
+        new_logdir = get_logdir(new_name)
+        if (new_logdir / "conversation.jsonl").exists():
+            raise click.UsageError(
+                f"Branch name '{new_name}' already exists with a conversation. "
+                f"Choose a different branch name with --branch."
+            )
+        Log(sliced).write_jsonl(new_logdir / "conversation.jsonl")
+
+        click.echo(
+            f"Branching '{logdir.name}' at turn {from_turn} → '{new_name}' ({len(sliced)} messages kept)",
+            err=True,
+        )
+        logdir = new_logdir
+        logdir_preexisting = True
+        resume = False  # treat as existing conversation, not resume
 
     show_resume_hint_on_exit = False
 

--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -1239,12 +1239,14 @@ def main(
             ts = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
             new_name = f"{logdir.name}-branch-{ts}"
 
-        new_logdir = get_logdir(new_name)
-        if new_logdir.exists() and any(new_logdir.iterdir()):
+        # Check for collision BEFORE get_logdir(), which creates the dir
+        _candidate = get_logs_dir() / new_name
+        if _candidate.exists() and any(_candidate.iterdir()):
             raise click.UsageError(
                 f"Branch name '{new_name}' already exists with session state. "
                 f"Choose a different branch name with --branch."
             )
+        new_logdir = get_logdir(new_name)
         Log(sliced).write_jsonl(new_logdir / "conversation.jsonl")
 
         click.echo(

--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -1239,14 +1239,21 @@ def main(
             ts = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
             new_name = f"{logdir.name}-branch-{ts}"
 
-        # Check for collision BEFORE get_logdir(), which creates the dir
-        _candidate = get_logs_dir() / new_name
-        if _candidate.exists() and any(_candidate.iterdir()):
+        # Atomically claim the branch directory to prevent concurrent branches
+        # from overwriting each other (check-then-mkdir races on exist_ok=True).
+        from ..logmanager import conversation_name_error
+
+        name_err = conversation_name_error(new_name)
+        if name_err:
+            raise click.UsageError(name_err)
+        new_logdir = get_logs_dir() / new_name
+        try:
+            new_logdir.mkdir(parents=True, exist_ok=False)
+        except FileExistsError:
             raise click.UsageError(
-                f"Branch name '{new_name}' already exists with session state. "
+                f"Branch name '{new_name}' already exists. "
                 f"Choose a different branch name with --branch."
-            )
-        new_logdir = get_logdir(new_name)
+            ) from None
         Log(sliced).write_jsonl(new_logdir / "conversation.jsonl")
 
         click.echo(

--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -17,7 +17,7 @@ import traceback
 from datetime import datetime, timezone
 from itertools import islice
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Literal
 
 import click
 from click.core import ParameterSource
@@ -447,43 +447,6 @@ Utilities:
 Run 'gptme-util --help' for all utility commands."""
 
 
-def _slice_at_turn(messages: list[Any], turn: int) -> list[Any]:
-    """Return messages up to the end of the Nth user turn (1-indexed).
-
-    Turn 0: system/pre-user messages only (no user input included).
-    Turn N: through the Nth complete user+assistant exchange.
-
-    If N exceeds the number of turns in the conversation, all messages
-    are returned (no truncation).
-    """
-    if turn < 0:
-        raise ValueError(f"Turn must be non-negative, got {turn}")
-
-    if turn == 0:
-        result = []
-        for msg in messages:
-            if msg.role == "user":
-                break
-            result.append(msg)
-        return result
-
-    user_count = 0
-    for i, msg in enumerate(messages):
-        if msg.role == "user":
-            user_count += 1
-            if user_count == turn:
-                # Include all messages through the rest of this exchange
-                # (up to but not including the next user message)
-                for j in range(i + 1, len(messages)):
-                    if messages[j].role == "user":
-                        return list(messages[:j])
-                # This was the last user turn — include all remaining
-                return list(messages)
-
-    # Requested turn exceeds available turns — include all messages
-    return list(messages)
-
-
 @click.command(
     help=docstring,
     context_settings={"auto_envvar_prefix": "GPTME"},
@@ -529,21 +492,6 @@ def _slice_at_turn(messages: list[Any], turn: int) -> list[Any]:
     "--resume",
     is_flag=True,
     help="Load most recent conversation.",
-)
-@click.option(
-    "--from-turn",
-    "from_turn",
-    default=None,
-    type=click.IntRange(min=0),
-    metavar="N",
-    help="Fork at turn N: create a new session with the first N user turns from the source (requires --resume or --name). Turn 0 = system context only; turn N = through Nth user+assistant exchange.",
-)
-@click.option(
-    "--branch",
-    "branch_name",
-    default=None,
-    metavar="NAME",
-    help="Name for the branched session (used with --from-turn). Defaults to '<source>-branch-<timestamp>'.",
 )
 @click.option(
     "-y",
@@ -738,8 +686,6 @@ def main(
     version: bool,
     version_json: bool,
     resume: bool,
-    from_turn: int | None,
-    branch_name: str | None,
     workspace: str | None,
     agent_path: str | None,
     profile: bool,
@@ -1217,52 +1163,6 @@ def main(
         logdir_preexisting = name != "random" and (get_logs_dir() / name).exists()
         logdir = get_logdir(name)
         prompt_msgs = inject_stdin(prompt_msgs, piped_input)
-
-    # --from-turn: fork the source session at turn N into a new session
-    if from_turn is not None:
-        if not resume and name == "random":
-            raise click.UsageError(
-                "--from-turn requires --resume or --name to identify the source session"
-            )
-        from ..logmanager.manager import Log  # heavy import, deferred
-
-        source_logfile = logdir / "conversation.jsonl"
-        if not source_logfile.exists():
-            raise click.UsageError(f"Source session has no conversation: {logdir}")
-
-        source_msgs = list(Log.read_jsonl(source_logfile).messages)
-        sliced = _slice_at_turn(source_msgs, from_turn)
-
-        if branch_name:
-            new_name = branch_name
-        else:
-            ts = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
-            new_name = f"{logdir.name}-branch-{ts}"
-
-        # Atomically claim the branch directory to prevent concurrent branches
-        # from overwriting each other (check-then-mkdir races on exist_ok=True).
-        from ..logmanager import conversation_name_error
-
-        name_err = conversation_name_error(new_name)
-        if name_err:
-            raise click.UsageError(name_err)
-        new_logdir = get_logs_dir() / new_name
-        try:
-            new_logdir.mkdir(parents=True, exist_ok=False)
-        except FileExistsError:
-            raise click.UsageError(
-                f"Branch name '{new_name}' already exists. "
-                f"Choose a different branch name with --branch."
-            ) from None
-        Log(sliced).write_jsonl(new_logdir / "conversation.jsonl")
-
-        click.echo(
-            f"Branching '{logdir.name}' at turn {from_turn} → '{new_name}' ({len(sliced)} messages kept)",
-            err=True,
-        )
-        logdir = new_logdir
-        logdir_preexisting = True
-        resume = False  # treat as existing conversation, not resume
 
     show_resume_hint_on_exit = False
 

--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -534,7 +534,7 @@ def _slice_at_turn(messages: list[Any], turn: int) -> list[Any]:
     "--from-turn",
     "from_turn",
     default=None,
-    type=int,
+    type=click.IntRange(min=0),
     metavar="N",
     help="Fork at turn N: create a new session with the first N user turns from the source (requires --resume or --name). Turn 0 = system context only; turn N = through Nth user+assistant exchange.",
 )
@@ -1240,9 +1240,9 @@ def main(
             new_name = f"{logdir.name}-branch-{ts}"
 
         new_logdir = get_logdir(new_name)
-        if (new_logdir / "conversation.jsonl").exists():
+        if new_logdir.exists() and any(new_logdir.iterdir()):
             raise click.UsageError(
-                f"Branch name '{new_name}' already exists with a conversation. "
+                f"Branch name '{new_name}' already exists with session state. "
                 f"Choose a different branch name with --branch."
             )
         Log(sliced).write_jsonl(new_logdir / "conversation.jsonl")

--- a/tests/test_cli_from_turn.py
+++ b/tests/test_cli_from_turn.py
@@ -197,7 +197,7 @@ def test_from_turn_creates_branched_session(
     assert roles == ["system", "user", "assistant", "user", "assistant"]
 
 
-def test_from_turn_branch_name_collision():
+def test_from_turn_branch_name_collision(monkeypatch):
     """--branch with an existing session name should error."""
     from gptme.cli.main import main
 
@@ -225,6 +225,11 @@ def test_from_turn_branch_name_collision():
                 {"role": "assistant", "content": "A2."},
             ],
         )
+
+        # Redirect get_logs_dir to use the isolated filesystem
+        logs_dir = Path("logs")
+        monkeypatch.setattr("gptme.cli.main.get_logs_dir", lambda: logs_dir)
+        monkeypatch.setattr("gptme.dirs.get_logs_dir", lambda: logs_dir)
 
         # Try to branch into the existing session name
         result = runner.invoke(

--- a/tests/test_cli_from_turn.py
+++ b/tests/test_cli_from_turn.py
@@ -280,7 +280,7 @@ def test_chats_fork_out_of_range_turn_errors(monkeypatch):
 
 
 def test_chats_fork_copies_files_dir(monkeypatch):
-    """Forking copies the source session's files/ directory to the fork."""
+    """Forking copies the source session's files/ and attachments/ directories."""
     from gptme.cli.cmd_chats import chats_fork
 
     runner = CliRunner()
@@ -295,10 +295,13 @@ def test_chats_fork_copies_files_dir(monkeypatch):
                 {"role": "assistant", "content": "A1."},
             ],
         )
-        # Create a files/ subdirectory with a stored attachment
+        # Create files/ (content-addressed store) and attachments/ (paste/upload store)
         files_dir = src_dir / "files"
         files_dir.mkdir()
         (files_dir / "abc123.png").write_bytes(b"\x89PNG\r\n")
+        attachments_dir = src_dir / "attachments"
+        attachments_dir.mkdir()
+        (attachments_dir / "pasted.txt").write_text("pasted content")
 
         monkeypatch.setattr("gptme.cli.cmd_chats.get_logs_dir", lambda: logs_dir)
 
@@ -313,4 +316,7 @@ def test_chats_fork_copies_files_dir(monkeypatch):
         )
         fork_files = logs_dir / "my-fork" / "files"
         assert fork_files.exists(), "files/ dir not copied to fork"
-        assert (fork_files / "abc123.png").exists(), "attachment not copied"
+        assert (fork_files / "abc123.png").exists(), "content-addressed file not copied"
+        fork_attachments = logs_dir / "my-fork" / "attachments"
+        assert fork_attachments.exists(), "attachments/ dir not copied to fork"
+        assert (fork_attachments / "pasted.txt").exists(), "paste attachment not copied"

--- a/tests/test_cli_from_turn.py
+++ b/tests/test_cli_from_turn.py
@@ -251,3 +251,50 @@ def test_from_turn_branch_name_collision(monkeypatch):
         assert (
             "already exists" in result.output or "choose a different" in result.output
         )
+
+
+def test_from_turn_branch_name_collision_stale_state(monkeypatch):
+    """--branch into a dir with stale state (no conversation.jsonl) should also error."""
+    from gptme.cli.main import main
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        # Simulate an interrupted run: directory exists with config.toml but no conversation.jsonl
+        stale_dir = Path("logs/stale-branch")
+        stale_dir.mkdir(parents=True)
+        (stale_dir / "config.toml").write_text("[session]\n")
+
+        # Create a source session
+        src_dir = Path("logs/source-session")
+        _write_conversation(
+            src_dir,
+            [
+                {"role": "system", "content": "You are helpful."},
+                {"role": "user", "content": "Q1."},
+                {"role": "assistant", "content": "A1."},
+            ],
+        )
+
+        logs_dir = Path("logs")
+        monkeypatch.setattr("gptme.cli.main.get_logs_dir", lambda: logs_dir)
+        monkeypatch.setattr("gptme.dirs.get_logs_dir", lambda: logs_dir)
+
+        result = runner.invoke(
+            main,
+            [
+                "--name",
+                "source-session",
+                "--from-turn",
+                "1",
+                "--branch",
+                "stale-branch",
+                "--non-interactive",
+            ],
+            catch_exceptions=False,
+        )
+
+        # Stale state should be rejected the same as an existing conversation
+        assert result.exit_code != 0
+        assert (
+            "already exists" in result.output or "choose a different" in result.output
+        )

--- a/tests/test_cli_from_turn.py
+++ b/tests/test_cli_from_turn.py
@@ -1,0 +1,248 @@
+"""Tests for gptme --from-turn session branching."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Literal
+
+import pytest
+from click.testing import CliRunner
+
+from gptme.cli.main import _slice_at_turn
+from gptme.message import Message
+
+# ── _slice_at_turn unit tests ─────────────────────────────────────────
+
+_Role = Literal["system", "user", "assistant"]
+
+
+def _msgs(*roles: _Role) -> list[Message]:
+    """Build a minimal message list from a role sequence."""
+    role_content = {
+        "system": "You are helpful.",
+        "user": "A question.",
+        "assistant": "An answer.",
+    }
+    return [Message(r, role_content[r]) for r in roles]
+
+
+def test_slice_turn_0_keeps_only_system():
+    msgs = _msgs("system", "user", "assistant", "user", "assistant")
+    result = _slice_at_turn(msgs, 0)
+    assert [m.role for m in result] == ["system"]
+
+
+def test_slice_turn_0_no_system():
+    """Turn 0 with no leading system messages returns empty list."""
+    msgs = _msgs("user", "assistant", "user", "assistant")
+    result = _slice_at_turn(msgs, 0)
+    assert result == []
+
+
+def test_slice_turn_1_through_first_exchange():
+    msgs = _msgs("system", "user", "assistant", "user", "assistant")
+    result = _slice_at_turn(msgs, 1)
+    assert [m.role for m in result] == ["system", "user", "assistant"]
+
+
+def test_slice_turn_2_through_second_exchange():
+    msgs = _msgs(
+        "system", "user", "assistant", "user", "assistant", "user", "assistant"
+    )
+    result = _slice_at_turn(msgs, 2)
+    assert [m.role for m in result] == [
+        "system",
+        "user",
+        "assistant",
+        "user",
+        "assistant",
+    ]
+
+
+def test_slice_turn_equals_total_returns_all():
+    msgs = _msgs("system", "user", "assistant", "user", "assistant")
+    result = _slice_at_turn(msgs, 2)
+    assert result == msgs
+
+
+def test_slice_turn_exceeds_total_returns_all():
+    msgs = _msgs("system", "user", "assistant")
+    result = _slice_at_turn(msgs, 99)
+    assert result == msgs
+
+
+def test_slice_turn_1_last_turn_includes_all():
+    """When there's only one user turn, from-turn 1 returns everything."""
+    msgs = _msgs("system", "user", "assistant")
+    result = _slice_at_turn(msgs, 1)
+    assert result == msgs
+
+
+def test_slice_negative_turn_raises_error():
+    """Negative turn values should raise ValueError."""
+    msgs = _msgs("system", "user", "assistant")
+    with pytest.raises(ValueError, match="Turn must be non-negative"):
+        _slice_at_turn(msgs, -1)
+
+
+def test_slice_negative_turn_large_raises_error():
+    """Large negative turn values should also raise ValueError."""
+    msgs = _msgs("system", "user", "assistant")
+    with pytest.raises(ValueError, match="Turn must be non-negative"):
+        _slice_at_turn(msgs, -100)
+
+
+def test_slice_preserves_content():
+    msgs = [
+        Message("system", "System prompt"),
+        Message("user", "Hello"),
+        Message("assistant", "Hi there"),
+        Message("user", "Goodbye"),
+        Message("assistant", "Bye"),
+    ]
+    result = _slice_at_turn(msgs, 1)
+    assert result[1].content == "Hello"
+    assert result[2].content == "Hi there"
+
+
+def test_slice_multi_assistant_same_turn():
+    """Multiple assistant messages in one turn (tool calls) all get included."""
+    msgs = [
+        Message("system", "You are helpful."),
+        Message("user", "Do a thing."),
+        Message("assistant", "Let me run this."),
+        Message("assistant", "Tool result received."),
+        Message("user", "Thanks."),
+        Message("assistant", "Done."),
+    ]
+    result = _slice_at_turn(msgs, 1)
+    # Should include everything up to (not including) the second user message
+    assert len(result) == 4
+    assert result[-1].content == "Tool result received."
+
+
+# ── --from-turn CLI integration tests ────────────────────────────────
+
+
+def _write_conversation(logdir: Path, messages: list[dict]) -> None:
+    logdir.mkdir(parents=True, exist_ok=True)
+    conv = logdir / "conversation.jsonl"
+    conv.write_text("\n".join(json.dumps(m) for m in messages) + "\n")
+
+
+@pytest.fixture()
+def source_session(tmp_path: Path) -> Path:
+    """A source session with 3 user turns in a temp logs dir."""
+    logs_dir = tmp_path / "logs"
+    src_dir = logs_dir / "my-session"
+    _write_conversation(
+        src_dir,
+        [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "Turn 1 question."},
+            {"role": "assistant", "content": "Turn 1 answer."},
+            {"role": "user", "content": "Turn 2 question."},
+            {"role": "assistant", "content": "Turn 2 answer."},
+            {"role": "user", "content": "Turn 3 question."},
+            {"role": "assistant", "content": "Turn 3 answer."},
+        ],
+    )
+    return logs_dir
+
+
+def test_slice_at_turn_requires_name_or_resume():
+    """--from-turn without --resume or --name should error."""
+    from gptme.cli.main import main
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["--from-turn", "2"])
+    assert result.exit_code != 0
+    assert "--resume" in result.output or "--name" in result.output
+
+
+def test_from_turn_creates_branched_session(
+    source_session: Path, monkeypatch, tmp_path
+):
+    """--name src --from-turn 2 creates a new session with 2 turns."""
+    from gptme.cli.main import main
+
+    logs_dir = source_session
+    monkeypatch.setattr("gptme.cli.main.get_logs_dir", lambda: logs_dir)
+    monkeypatch.setattr("gptme.dirs.get_logs_dir", lambda: logs_dir)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "--name",
+            "my-session",
+            "--from-turn",
+            "2",
+            "--branch",
+            "my-branch",
+            "--non-interactive",
+        ],
+        catch_exceptions=False,
+    )
+
+    # Session was branched: new dir should exist with sliced messages
+    branch_dir = logs_dir / "my-branch"
+    assert branch_dir.exists(), f"Branch dir not created. Output:\n{result.output}"
+    conv = branch_dir / "conversation.jsonl"
+    assert conv.exists()
+    messages = [json.loads(line) for line in conv.read_text().splitlines() if line]
+    roles = [m["role"] for m in messages]
+    # Should have system + 2 user+assistant pairs = 5 messages
+    assert roles == ["system", "user", "assistant", "user", "assistant"]
+
+
+def test_from_turn_branch_name_collision():
+    """--branch with an existing session name should error."""
+    from gptme.cli.main import main
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        # Create an existing session
+        existing_dir = Path("logs/existing-session")
+        _write_conversation(
+            existing_dir,
+            [
+                {"role": "system", "content": "You are helpful."},
+                {"role": "user", "content": "Question."},
+                {"role": "assistant", "content": "Answer."},
+            ],
+        )
+        # Create a source session
+        src_dir = Path("logs/source-session")
+        _write_conversation(
+            src_dir,
+            [
+                {"role": "system", "content": "You are helpful."},
+                {"role": "user", "content": "Q1."},
+                {"role": "assistant", "content": "A1."},
+                {"role": "user", "content": "Q2."},
+                {"role": "assistant", "content": "A2."},
+            ],
+        )
+
+        # Try to branch into the existing session name
+        result = runner.invoke(
+            main,
+            [
+                "--name",
+                "source-session",
+                "--from-turn",
+                "1",
+                "--branch",
+                "existing-session",
+                "--non-interactive",
+            ],
+            catch_exceptions=False,
+        )
+
+        # Should error on branch-name collision
+        assert result.exit_code != 0
+        assert (
+            "already exists" in result.output or "choose a different" in result.output
+        )

--- a/tests/test_cli_from_turn.py
+++ b/tests/test_cli_from_turn.py
@@ -1,4 +1,4 @@
-"""Tests for gptme --from-turn session branching."""
+"""Tests for `gptme-util chats fork` session forking."""
 
 from __future__ import annotations
 
@@ -9,7 +9,7 @@ from typing import Literal
 import pytest
 from click.testing import CliRunner
 
-from gptme.cli.main import _slice_at_turn
+from gptme.cli.cmd_chats import _slice_at_turn
 from gptme.message import Message
 
 # ── _slice_at_turn unit tests ─────────────────────────────────────────
@@ -122,7 +122,7 @@ def test_slice_multi_assistant_same_turn():
     assert result[-1].content == "Tool result received."
 
 
-# ── --from-turn CLI integration tests ────────────────────────────────
+# ── gptme-util chats fork CLI integration tests ───────────────────────
 
 
 def _write_conversation(logdir: Path, messages: list[dict]) -> None:
@@ -151,60 +151,39 @@ def source_session(tmp_path: Path) -> Path:
     return logs_dir
 
 
-def test_slice_at_turn_requires_name_or_resume():
-    """--from-turn without --resume or --name should error."""
-    from gptme.cli.main import main
-
-    runner = CliRunner()
-    result = runner.invoke(main, ["--from-turn", "2"])
-    assert result.exit_code != 0
-    assert "--resume" in result.output or "--name" in result.output
-
-
-def test_from_turn_creates_branched_session(
-    source_session: Path, monkeypatch, tmp_path
-):
-    """--name src --from-turn 2 creates a new session with 2 turns."""
-    from gptme.cli.main import main
+def test_chats_fork_creates_forked_session(source_session: Path, monkeypatch):
+    """chats fork my-session --at-turn 2 --name my-fork creates a new session."""
+    from gptme.cli.cmd_chats import chats_fork
 
     logs_dir = source_session
-    monkeypatch.setattr("gptme.cli.main.get_logs_dir", lambda: logs_dir)
-    monkeypatch.setattr("gptme.dirs.get_logs_dir", lambda: logs_dir)
+    monkeypatch.setattr("gptme.cli.cmd_chats.get_logs_dir", lambda: logs_dir)
 
     runner = CliRunner()
     result = runner.invoke(
-        main,
-        [
-            "--name",
-            "my-session",
-            "--from-turn",
-            "2",
-            "--branch",
-            "my-branch",
-            "--non-interactive",
-        ],
+        chats_fork,
+        ["my-session", "--at-turn", "2", "--name", "my-fork"],
         catch_exceptions=False,
     )
 
-    # Session was branched: new dir should exist with sliced messages
-    branch_dir = logs_dir / "my-branch"
-    assert branch_dir.exists(), f"Branch dir not created. Output:\n{result.output}"
-    conv = branch_dir / "conversation.jsonl"
+    assert result.exit_code == 0, f"Exit {result.exit_code}. Output:\n{result.output}"
+    fork_dir = logs_dir / "my-fork"
+    assert fork_dir.exists(), "Fork dir not created"
+    conv = fork_dir / "conversation.jsonl"
     assert conv.exists()
     messages = [json.loads(line) for line in conv.read_text().splitlines() if line]
     roles = [m["role"] for m in messages]
-    # Should have system + 2 user+assistant pairs = 5 messages
+    # system + 2 user+assistant pairs = 5 messages
     assert roles == ["system", "user", "assistant", "user", "assistant"]
 
 
-def test_from_turn_branch_name_collision(monkeypatch):
-    """--branch with an existing session name should error."""
-    from gptme.cli.main import main
+def test_chats_fork_name_collision(monkeypatch):
+    """Forking into an existing session name should error."""
+    from gptme.cli.cmd_chats import chats_fork
 
     runner = CliRunner()
     with runner.isolated_filesystem():
-        # Create an existing session
-        existing_dir = Path("logs/existing-session")
+        logs_dir = Path("logs")
+        existing_dir = logs_dir / "existing-session"
         _write_conversation(
             existing_dir,
             [
@@ -213,8 +192,7 @@ def test_from_turn_branch_name_collision(monkeypatch):
                 {"role": "assistant", "content": "Answer."},
             ],
         )
-        # Create a source session
-        src_dir = Path("logs/source-session")
+        src_dir = logs_dir / "source-session"
         _write_conversation(
             src_dir,
             [
@@ -226,46 +204,30 @@ def test_from_turn_branch_name_collision(monkeypatch):
             ],
         )
 
-        # Redirect get_logs_dir to use the isolated filesystem
-        logs_dir = Path("logs")
-        monkeypatch.setattr("gptme.cli.main.get_logs_dir", lambda: logs_dir)
-        monkeypatch.setattr("gptme.dirs.get_logs_dir", lambda: logs_dir)
+        monkeypatch.setattr("gptme.cli.cmd_chats.get_logs_dir", lambda: logs_dir)
 
-        # Try to branch into the existing session name
         result = runner.invoke(
-            main,
-            [
-                "--name",
-                "source-session",
-                "--from-turn",
-                "1",
-                "--branch",
-                "existing-session",
-                "--non-interactive",
-            ],
+            chats_fork,
+            ["source-session", "--at-turn", "1", "--name", "existing-session"],
             catch_exceptions=False,
         )
 
-        # Should error on branch-name collision
         assert result.exit_code != 0
-        assert (
-            "already exists" in result.output or "choose a different" in result.output
-        )
+        assert "already exists" in result.output
 
 
-def test_from_turn_branch_name_collision_stale_state(monkeypatch):
-    """--branch into a dir with stale state (no conversation.jsonl) should also error."""
-    from gptme.cli.main import main
+def test_chats_fork_name_collision_stale_state(monkeypatch):
+    """Forking into a dir with stale state (no conversation.jsonl) should also error."""
+    from gptme.cli.cmd_chats import chats_fork
 
     runner = CliRunner()
     with runner.isolated_filesystem():
-        # Simulate an interrupted run: directory exists with config.toml but no conversation.jsonl
-        stale_dir = Path("logs/stale-branch")
+        logs_dir = Path("logs")
+        stale_dir = logs_dir / "stale-fork"
         stale_dir.mkdir(parents=True)
         (stale_dir / "config.toml").write_text("[session]\n")
 
-        # Create a source session
-        src_dir = Path("logs/source-session")
+        src_dir = logs_dir / "source-session"
         _write_conversation(
             src_dir,
             [
@@ -275,26 +237,13 @@ def test_from_turn_branch_name_collision_stale_state(monkeypatch):
             ],
         )
 
-        logs_dir = Path("logs")
-        monkeypatch.setattr("gptme.cli.main.get_logs_dir", lambda: logs_dir)
-        monkeypatch.setattr("gptme.dirs.get_logs_dir", lambda: logs_dir)
+        monkeypatch.setattr("gptme.cli.cmd_chats.get_logs_dir", lambda: logs_dir)
 
         result = runner.invoke(
-            main,
-            [
-                "--name",
-                "source-session",
-                "--from-turn",
-                "1",
-                "--branch",
-                "stale-branch",
-                "--non-interactive",
-            ],
+            chats_fork,
+            ["source-session", "--at-turn", "1", "--name", "stale-fork"],
             catch_exceptions=False,
         )
 
-        # Stale state should be rejected the same as an existing conversation
         assert result.exit_code != 0
-        assert (
-            "already exists" in result.output or "choose a different" in result.output
-        )
+        assert "already exists" in result.output

--- a/tests/test_cli_from_turn.py
+++ b/tests/test_cli_from_turn.py
@@ -247,3 +247,70 @@ def test_chats_fork_name_collision_stale_state(monkeypatch):
 
         assert result.exit_code != 0
         assert "already exists" in result.output
+
+
+def test_chats_fork_out_of_range_turn_errors(monkeypatch):
+    """Forking with --at-turn beyond the session's turn count should error."""
+    from gptme.cli.cmd_chats import chats_fork
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        logs_dir = Path("logs")
+        src_dir = logs_dir / "source-session"
+        _write_conversation(
+            src_dir,
+            [
+                {"role": "system", "content": "You are helpful."},
+                {"role": "user", "content": "Q1."},
+                {"role": "assistant", "content": "A1."},
+                {"role": "user", "content": "Q2."},
+                {"role": "assistant", "content": "A2."},
+            ],
+        )
+        monkeypatch.setattr("gptme.cli.cmd_chats.get_logs_dir", lambda: logs_dir)
+
+        result = runner.invoke(
+            chats_fork,
+            ["source-session", "--at-turn", "99", "--name", "my-fork"],
+            catch_exceptions=False,
+        )
+
+        assert result.exit_code != 0
+        assert "out of range" in result.output
+
+
+def test_chats_fork_copies_files_dir(monkeypatch):
+    """Forking copies the source session's files/ directory to the fork."""
+    from gptme.cli.cmd_chats import chats_fork
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        logs_dir = Path("logs")
+        src_dir = logs_dir / "source-session"
+        _write_conversation(
+            src_dir,
+            [
+                {"role": "system", "content": "You are helpful."},
+                {"role": "user", "content": "Q1."},
+                {"role": "assistant", "content": "A1."},
+            ],
+        )
+        # Create a files/ subdirectory with a stored attachment
+        files_dir = src_dir / "files"
+        files_dir.mkdir()
+        (files_dir / "abc123.png").write_bytes(b"\x89PNG\r\n")
+
+        monkeypatch.setattr("gptme.cli.cmd_chats.get_logs_dir", lambda: logs_dir)
+
+        result = runner.invoke(
+            chats_fork,
+            ["source-session", "--at-turn", "1", "--name", "my-fork"],
+            catch_exceptions=False,
+        )
+
+        assert result.exit_code == 0, (
+            f"Exit {result.exit_code}. Output:\n{result.output}"
+        )
+        fork_files = logs_dir / "my-fork" / "files"
+        assert fork_files.exists(), "files/ dir not copied to fork"
+        assert (fork_files / "abc123.png").exists(), "attachment not copied"


### PR DESCRIPTION
## Summary

Adds `gptme-util chats fork <session> --at-turn N [--name NAME]` to let users fork any session at a specific conversation turn and re-run from that point with a different approach.

- **No destructive changes**: the source session is never modified
- **Turn semantics**: turn 0 = system/pre-user messages only; turn N = through the Nth complete user+assistant exchange
- **Atomic fork directory creation** guards against name collision races
- **Auto-naming** defaults to `<source>-fork-<timestamp>` when `--name` is omitted
- Placed under `gptme-util chats` (not main `gptme` CLI) to keep the primary surface clean

```
# Fork at turn 2 and continue with a different approach
gptme-util chats fork my-session --at-turn 2

# Fork at turn 5 with a custom name
gptme-util chats fork my-session --at-turn 5 --name retry-v2

# Then resume the forked session
gptme --name retry-v2
```

**Use case**: "This approach failed at turn 12, backtrack and try a different strategy" — without re-running expensive earlier steps.

Inspired by arXiv:2605.21997 "The Log Is the Agent".

## Test plan

- [x] `gptme-util chats fork` slices at the correct turn boundary
- [x] Auto-names as `<source>-fork-<timestamp>` when `--name` omitted
- [x] Validates session exists and `--at-turn` is in range
- [x] Atomic `mkdir` raises `UsageError` on name collision
- [x] Pre-commit hooks pass