### PR TITLE
fix(chats): copy files/attachments dirs on fork + validate at-turn range

### DIFF
--- a/gptme/cli/cmd_chats.py
+++ b/gptme/cli/cmd_chats.py
@@ -1,6 +1,7 @@
 """CLI commands for chat/conversation management."""
 
 import json
+import shutil
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -577,6 +578,14 @@ def chats_fork(id: str, at_turn: int, fork_name: str | None):
         raise click.UsageError(f"Session has no conversation: {id!r}")
 
     source_msgs = list(Log.read_jsonl(source_logfile).messages)
+
+    user_turn_count = sum(1 for m in source_msgs if m.role == "user")
+    if at_turn > user_turn_count:
+        raise click.UsageError(
+            f"Turn {at_turn} out of range — session '{id}' has {user_turn_count} user turn(s) "
+            f"(valid range: 0–{user_turn_count})"
+        )
+
     sliced = _slice_at_turn(source_msgs, at_turn)
 
     if fork_name:
@@ -598,6 +607,11 @@ def chats_fork(id: str, at_turn: int, fork_name: str | None):
         ) from None
 
     Log(sliced).write_jsonl(new_logdir / "conversation.jsonl")
+
+    source_files_dir = source_logdir / "files"
+    if source_files_dir.exists():
+        shutil.copytree(source_files_dir, new_logdir / "files")
+
     click.echo(
         f"Forked '{id}' at turn {at_turn} → '{new_name}' ({len(sliced)} messages kept)"
     )

--- a/gptme/cli/cmd_chats.py
+++ b/gptme/cli/cmd_chats.py
@@ -606,12 +606,16 @@ def chats_fork(id: str, at_turn: int, fork_name: str | None):
             f"Session name '{new_name}' already exists. Choose a different name with --name."
         ) from None
 
-    Log(sliced).write_jsonl(new_logdir / "conversation.jsonl")
+    try:
+        Log(sliced).write_jsonl(new_logdir / "conversation.jsonl")
 
-    for subdir in ("files", "attachments"):
-        src = source_logdir / subdir
-        if src.exists():
-            shutil.copytree(src, new_logdir / subdir)
+        for subdir in ("files", "attachments"):
+            src = source_logdir / subdir
+            if src.exists():
+                shutil.copytree(src, new_logdir / subdir)
+    except Exception:
+        shutil.rmtree(new_logdir, ignore_errors=True)
+        raise
 
     click.echo(
         f"Forked '{id}' at turn {at_turn} → '{new_name}' ({len(sliced)} messages kept)"

--- a/gptme/cli/cmd_chats.py
+++ b/gptme/cli/cmd_chats.py
@@ -612,7 +612,7 @@ def chats_fork(id: str, at_turn: int, fork_name: str | None):
         for subdir in ("files", "attachments"):
             src = source_logdir / subdir
             if src.exists():
-                shutil.copytree(src, new_logdir / subdir)
+                shutil.copytree(src, new_logdir / subdir, symlinks=True)
     except Exception:
         shutil.rmtree(new_logdir, ignore_errors=True)
         raise

--- a/gptme/cli/cmd_chats.py
+++ b/gptme/cli/cmd_chats.py
@@ -608,9 +608,10 @@ def chats_fork(id: str, at_turn: int, fork_name: str | None):
 
     Log(sliced).write_jsonl(new_logdir / "conversation.jsonl")
 
-    source_files_dir = source_logdir / "files"
-    if source_files_dir.exists():
-        shutil.copytree(source_files_dir, new_logdir / "files")
+    for subdir in ("files", "attachments"):
+        src = source_logdir / subdir
+        if src.exists():
+            shutil.copytree(src, new_logdir / subdir)
 
     click.echo(
         f"Forked '{id}' at turn {at_turn} → '{new_name}' ({len(sliced)} messages kept)"

--- a/tests/test_cli_from_turn.py
+++ b/tests/test_cli_from_turn.py
@@ -280,7 +280,7 @@ def test_chats_fork_out_of_range_turn_errors(monkeypatch):
 
 
 def test_chats_fork_copies_files_dir(monkeypatch):
-    """Forking copies the source session's files/ directory to the fork."""
+    """Forking copies the source session's files/ and attachments/ directories."""
     from gptme.cli.cmd_chats import chats_fork
 
     runner = CliRunner()
@@ -295,10 +295,13 @@ def test_chats_fork_copies_files_dir(monkeypatch):
                 {"role": "assistant", "content": "A1."},
             ],
         )
-        # Create a files/ subdirectory with a stored attachment
+        # Create files/ (content-addressed store) and attachments/ (paste/upload store)
         files_dir = src_dir / "files"
         files_dir.mkdir()
         (files_dir / "abc123.png").write_bytes(b"\x89PNG\r\n")
+        attachments_dir = src_dir / "attachments"
+        attachments_dir.mkdir()
+        (attachments_dir / "pasted.txt").write_text("pasted content")
 
         monkeypatch.setattr("gptme.cli.cmd_chats.get_logs_dir", lambda: logs_dir)
 
@@ -313,4 +316,7 @@ def test_chats_fork_copies_files_dir(monkeypatch):
         )
         fork_files = logs_dir / "my-fork" / "files"
         assert fork_files.exists(), "files/ dir not copied to fork"
-        assert (fork_files / "abc123.png").exists(), "attachment not copied"
+        assert (fork_files / "abc123.png").exists(), "content-addressed file not copied"
+        fork_attachments = logs_dir / "my-fork" / "attachments"
+        assert fork_attachments.exists(), "attachments/ dir not copied to fork"
+        assert (fork_attachments / "pasted.txt").exists(), "paste attachment not copied"

--- a/tests/test_cli_from_turn.py
+++ b/tests/test_cli_from_turn.py
@@ -247,3 +247,70 @@ def test_chats_fork_name_collision_stale_state(monkeypatch):
 
         assert result.exit_code != 0
         assert "already exists" in result.output
+
+
+def test_chats_fork_out_of_range_turn_errors(monkeypatch):
+    """Forking with --at-turn beyond the session's turn count should error."""
+    from gptme.cli.cmd_chats import chats_fork
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        logs_dir = Path("logs")
+        src_dir = logs_dir / "source-session"
+        _write_conversation(
+            src_dir,
+            [
+                {"role": "system", "content": "You are helpful."},
+                {"role": "user", "content": "Q1."},
+                {"role": "assistant", "content": "A1."},
+                {"role": "user", "content": "Q2."},
+                {"role": "assistant", "content": "A2."},
+            ],
+        )
+        monkeypatch.setattr("gptme.cli.cmd_chats.get_logs_dir", lambda: logs_dir)
+
+        result = runner.invoke(
+            chats_fork,
+            ["source-session", "--at-turn", "99", "--name", "my-fork"],
+            catch_exceptions=False,
+        )
+
+        assert result.exit_code != 0
+        assert "out of range" in result.output
+
+
+def test_chats_fork_copies_files_dir(monkeypatch):
+    """Forking copies the source session's files/ directory to the fork."""
+    from gptme.cli.cmd_chats import chats_fork
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        logs_dir = Path("logs")
+        src_dir = logs_dir / "source-session"
+        _write_conversation(
+            src_dir,
+            [
+                {"role": "system", "content": "You are helpful."},
+                {"role": "user", "content": "Q1."},
+                {"role": "assistant", "content": "A1."},
+            ],
+        )
+        # Create a files/ subdirectory with a stored attachment
+        files_dir = src_dir / "files"
+        files_dir.mkdir()
+        (files_dir / "abc123.png").write_bytes(b"\x89PNG\r\n")
+
+        monkeypatch.setattr("gptme.cli.cmd_chats.get_logs_dir", lambda: logs_dir)
+
+        result = runner.invoke(
+            chats_fork,
+            ["source-session", "--at-turn", "1", "--name", "my-fork"],
+            catch_exceptions=False,
+        )
+
+        assert result.exit_code == 0, (
+            f"Exit {result.exit_code}. Output:\n{result.output}"
+        )
+        fork_files = logs_dir / "my-fork" / "files"
+        assert fork_files.exists(), "files/ dir not copied to fork"
+        assert (fork_files / "abc123.png").exists(), "attachment not copied"


### PR DESCRIPTION
## Summary

Follow-up improvements to `gptme-util chats fork` (introduced in #3209):

- **Validate `--at-turn` range**: raise a clear `UsageError` when the requested turn exceeds the session's user turn count (previously silently forked everything, confusing for typos like `--at-turn 99`)
- **Copy `files/` on fork**: content-addressed attachments in `files/` are now copied to the fork so logdir-relative references stay accessible
- **Copy `attachments/` on fork**: sessions can also store pasted/uploaded files under `attachments/` (via clipboard.py); both dirs are now copied
- **Cleanup partial fork dir on failure**: if `conversation.jsonl` write or the dir copy fails after the fork dir was `mkdir`'d, the partial dir is removed so retrying with `--name my-fork` doesn't hit the name-collision guard on a broken partial state

## Test plan

- [x] `test_chats_fork_out_of_range_turn_errors` — verifies `UsageError` for turn > session length
- [x] `test_chats_fork_copies_files_dir` — verifies `files/` is copied to the fork
- [x] All 16 tests in `tests/test_cli_from_turn.py` pass locally

## Context

Closes #3238 — this PR extracts the incremental improvements from that branch. The core `chats fork` feature landed in #3209; #3238 became conflicting because it still carried the earlier `--from-turn` API commits that predated the refactor.