### PR TITLE
fix(webui): use dvh units for mobile browser URL bar compatibility

### DIFF
--- a/webui/src/components/ExtensionChat.tsx
+++ b/webui/src/components/ExtensionChat.tsx
@@ -427,7 +427,7 @@ export default function ExtensionChat() {
     : '';
 
   return (
-    <div className="flex h-screen flex-col bg-background text-foreground">
+    <div className="flex h-dvh flex-col bg-background text-foreground">
       {/* Status bar */}
       <div className="flex shrink-0 items-center gap-2 border-b border-border px-3 py-1.5 text-xs">
         <span className={state.online ? 'text-green-500' : 'text-muted-foreground'}>

--- a/webui/src/components/ui/toast.tsx
+++ b/webui/src/components/ui/toast.tsx
@@ -14,7 +14,7 @@ const ToastViewport = React.forwardRef<
   <ToastPrimitives.Viewport
     ref={ref}
     className={cn(
-      'fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]',
+      'fixed top-0 z-[100] flex max-h-dvh w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]',
       className
     )}
     {...props}

--- a/webui/src/pages/Admin.tsx
+++ b/webui/src/pages/Admin.tsx
@@ -10,7 +10,7 @@ const Admin: FC = () => {
   const { data: tasks = [] } = useTasksQuery();
 
   return (
-    <div className="flex h-screen flex-col">
+    <div className="flex h-dvh flex-col">
       <MenuBar />
       <div className="flex min-h-0 flex-1">
         <SidebarIcons tasks={tasks} />

--- a/webui/src/pages/Agents.tsx
+++ b/webui/src/pages/Agents.tsx
@@ -4,7 +4,7 @@ import MainLayout from '@/components/MainLayout';
 
 const Agents: FC = () => {
   return (
-    <div className="flex h-screen flex-col">
+    <div className="flex h-dvh flex-col">
       <MenuBar />
       <MainLayout />
     </div>

--- a/webui/src/pages/ExternalSessions.tsx
+++ b/webui/src/pages/ExternalSessions.tsx
@@ -9,7 +9,7 @@ const ExternalSessions: FC = () => {
   const { data: tasks = [] } = useTasksQuery();
 
   return (
-    <div className="flex h-screen flex-col">
+    <div className="flex h-dvh flex-col">
       <MenuBar />
       <div className="flex min-h-0 flex-1">
         <SidebarIcons tasks={tasks} />

--- a/webui/src/pages/Health.tsx
+++ b/webui/src/pages/Health.tsx
@@ -10,7 +10,7 @@ const Health: FC = () => {
   const { data: tasks = [] } = useTasksQuery();
 
   return (
-    <div className="flex h-screen flex-col">
+    <div className="flex h-dvh flex-col">
       <MenuBar />
       <div className="flex min-h-0 flex-1">
         <SidebarIcons tasks={tasks} />

--- a/webui/src/pages/History.tsx
+++ b/webui/src/pages/History.tsx
@@ -9,7 +9,7 @@ const History: FC = () => {
   const { data: tasks = [] } = useTasksQuery();
 
   return (
-    <div className="flex h-screen flex-col">
+    <div className="flex h-dvh flex-col">
       <MenuBar />
       <div className="flex min-h-0 flex-1">
         <SidebarIcons tasks={tasks} />

--- a/webui/src/pages/Index.tsx
+++ b/webui/src/pages/Index.tsx
@@ -13,7 +13,7 @@ const Index: FC<Props> = () => {
   const conversationId = decodeRouteParam(id);
 
   return (
-    <div className="flex h-screen flex-col">
+    <div className="flex h-dvh flex-col">
       <MenuBar />
       <MainLayout conversationId={conversationId} />
     </div>

--- a/webui/src/pages/NotFound.tsx
+++ b/webui/src/pages/NotFound.tsx
@@ -7,7 +7,7 @@ const NotFound: FC = () => {
   const location = useLocation();
 
   return (
-    <div className="flex h-screen flex-col">
+    <div className="flex h-dvh flex-col">
       <MenuBar />
       <div className="flex flex-1 items-center justify-center">
         <div className="text-center">

--- a/webui/src/pages/SettingsPage.tsx
+++ b/webui/src/pages/SettingsPage.tsx
@@ -57,7 +57,7 @@ const SettingsPage: FC = () => {
   return (
     <div
       ref={containerRef}
-      className="flex h-screen flex-col"
+      className="flex h-dvh flex-col"
       tabIndex={-1}
       onKeyDown={(e) => {
         if (e.key === 'Escape') {

--- a/webui/src/pages/Tasks.tsx
+++ b/webui/src/pages/Tasks.tsx
@@ -11,7 +11,7 @@ const Tasks: FC<Props> = () => {
   const { id } = useParams<{ id?: string }>();
 
   return (
-    <div className="flex h-screen flex-col">
+    <div className="flex h-dvh flex-col">
       <MenuBar />
       <MainLayout taskId={id} />
     </div>

--- a/webui/src/pages/Workspace.tsx
+++ b/webui/src/pages/Workspace.tsx
@@ -10,7 +10,7 @@ const Workspace: FC = () => {
 
   if (!conversationId) {
     return (
-      <div className="flex h-screen flex-col">
+      <div className="flex h-dvh flex-col">
         <MenuBar />
         <div className="flex flex-1 items-center justify-center">
           <div className="text-center">
@@ -29,7 +29,7 @@ const Workspace: FC = () => {
   }
 
   return (
-    <div className="flex h-screen flex-col">
+    <div className="flex h-dvh flex-col">
       <MenuBar />
       <div className="flex-1 overflow-hidden">
         <WorkspaceExplorer conversationId={conversationId} />

--- a/webui/src/pages/Workspaces.tsx
+++ b/webui/src/pages/Workspaces.tsx
@@ -4,7 +4,7 @@ import MainLayout from '@/components/MainLayout';
 
 const Workspaces: FC = () => {
   return (
-    <div className="flex h-screen flex-col">
+    <div className="flex h-dvh flex-col">
       <MenuBar />
       <MainLayout />
     </div>


### PR DESCRIPTION
## Summary

- Replace `h-screen` (`100vh`) with `h-dvh` (`100dvh`) across all webui page components
- Replace `max-h-screen` with `max-h-dvh` in toast viewport

## Problem

On mobile browsers (Firefox, Chrome for Android), the auto-hiding URL bar uses viewport height that isn't reflected in `vh` units. `100vh` equals the viewport height when the URL bar is hidden — so when the bar is visible, it covers bottom UI elements: the bottom menu and the chat input box.

## Fix

`dvh` (dynamic viewport height) updates as the browser chrome appears/disappears, so `100dvh` always equals the actual usable viewport. Tailwind 3.4+ provides `h-dvh` and `max-h-dvh` utilities out of the box.

Files changed: all page components (`Index`, `Workspace`, `Tasks`, `Agents`, `Workspaces`, `History`, `Health`, `Admin`, `ExternalSessions`, `NotFound`, `SettingsPage`) plus `ExtensionChat` and `toast.tsx`.

Fixes: gptme/gptme-cloud#703

## Test plan

- [ ] Open chat on mobile Firefox/Chrome with a URL bar that auto-hides
- [ ] Verify the bottom navigation stays visible (not covered by URL bar)
- [ ] Verify the chat input box is fully accessible