### PR TITLE
fix(models): add gpt-5.6-sol to the openai-subscription registry

### DIFF
--- a/gptme/llm/llm_openai_models.py
+++ b/gptme/llm/llm_openai_models.py
@@ -233,6 +233,22 @@ OPENAI_SUBSCRIPTION_MODELS: dict[str, "_ModelDictMeta"] = {
         "preferred_edit_format": "diff",
         "knowledge_cutoff": datetime(2026, 2, 16, tzinfo=timezone.utc),
     },
+    # GPT-5.6 Sol under its explicit name. ChatGPT-account (Plus/Pro) auth
+    # rejects the bare "gpt-5.6" alias with a 400 ("The 'gpt-5.6' model is not
+    # supported when using Codex with a ChatGPT account"), so subscription
+    # users need the named form — same behavior as the Codex CLI, where only
+    # named variants work on ChatGPT accounts.
+    "gpt-5.6-sol": {
+        "context": 1_000_000,
+        "max_output": 128_000,
+        "price_input": 5,
+        "price_output": 30,
+        "supports_vision": True,
+        "supports_reasoning": True,
+        "supports_parallel_tool_calls": True,
+        "preferred_edit_format": "diff",
+        "knowledge_cutoff": datetime(2026, 2, 16, tzinfo=timezone.utc),
+    },
     # GPT-5.6 Terra — balanced tier; matches GPT-5.5 quality at ~half the price
     "gpt-5.6-terra": {
         "context": 1_000_000,

--- a/gptme/llm/llm_openai_models.py
+++ b/gptme/llm/llm_openai_models.py
@@ -222,22 +222,8 @@ OPENAI_SUBSCRIPTION_MODELS: dict[str, "_ModelDictMeta"] = {
     # GPT-5.6 Sol — flagship tier of the Sol/Terra/Luna family (GA: 2026-07-09)
     # https://openai.com/index/previewing-gpt-5-6-sol/
     # Sol: $5/$30 per 1M; +5.8 pts above GPT-5.5 on Agents' Last Exam (52.7%)
-    "gpt-5.6": {
-        "context": 1_000_000,
-        "max_output": 128_000,
-        "price_input": 5,
-        "price_output": 30,
-        "supports_vision": True,
-        "supports_reasoning": True,
-        "supports_parallel_tool_calls": True,
-        "preferred_edit_format": "diff",
-        "knowledge_cutoff": datetime(2026, 2, 16, tzinfo=timezone.utc),
-    },
-    # GPT-5.6 Sol under its explicit name. ChatGPT-account (Plus/Pro) auth
-    # rejects the bare "gpt-5.6" alias with a 400 ("The 'gpt-5.6' model is not
-    # supported when using Codex with a ChatGPT account"), so subscription
-    # users need the named form — same behavior as the Codex CLI, where only
-    # named variants work on ChatGPT accounts.
+    # ChatGPT-account (Plus/Pro) auth rejects the bare "gpt-5.6" alias with a
+    # 400; the bare name is aliased to this entry via MODEL_ALIASES.
     "gpt-5.6-sol": {
         "context": 1_000_000,
         "max_output": 128_000,

--- a/gptme/llm/models/resolution.py
+++ b/gptme/llm/models/resolution.py
@@ -396,7 +396,7 @@ def get_recommended_model(provider: Provider) -> str:  # pragma: no cover
     if provider == "openai":
         return "gpt-5"
     if provider == "openai-subscription":
-        return "gpt-5.6"
+        return "gpt-5.6-sol"
     if provider == "openrouter":
         return "deepseek/deepseek-v4-pro"
     if provider == "gemini":

--- a/gptme/llm/models/types.py
+++ b/gptme/llm/models/types.py
@@ -32,6 +32,11 @@ MODEL_ALIASES: dict[str, dict[str, str]] = {
         # 2026-07-10); this entry is for metadata lookup, not wire rewriting.
         "gpt-5.6": "gpt-5.6-sol",
     },
+    "openai-subscription": {
+        # ChatGPT-account auth rejects the bare alias with a 400; only the
+        # named form works. Alias so users can still write gpt-5.6 shorthand.
+        "gpt-5.6": "gpt-5.6-sol",
+    },
     "anthropic": {
         "claude-opus-4-1": "claude-opus-4-1-20250805",
         "claude-opus-4-0": "claude-opus-4-20250514",

--- a/tests/test_llm_models.py
+++ b/tests/test_llm_models.py
@@ -244,7 +244,7 @@ def test_get_model_openrouter_subprovider_suffix_not_in_static():
         ("xai", "grok-4"),
         ("deepseek", "deepseek-chat"),
         ("groq", "llama-3.3-70b-versatile"),
-        ("openai-subscription", "gpt-5.6"),
+        ("openai-subscription", "gpt-5.6-sol"),
     ],
 )
 def test_get_recommended_model(provider, expected_model):

--- a/tests/test_llm_models_resolution.py
+++ b/tests/test_llm_models_resolution.py
@@ -206,19 +206,32 @@ class TestAliasResolution:
         assert model.context == 1_000_000
 
     def test_subscription_gpt56_sol_named_form_has_metadata(self):
-        """openai-subscription/gpt-5.6-sol resolves real Sol metadata.
-
-        ChatGPT-account (Plus/Pro) auth rejects the bare gpt-5.6 alias with a
-        400 ("not supported when using Codex with a ChatGPT account" — verified
-        live 2026-07-14), so subscription users must request the named form.
-        It therefore needs a concrete OPENAI_SUBSCRIPTION_MODELS entry rather
-        than falling through to closest-match/128k-fallback metadata.
-        """
+        """openai-subscription/gpt-5.6-sol resolves real Sol metadata."""
         from gptme.llm.llm_openai_models import OPENAI_SUBSCRIPTION_MODELS
 
         assert "gpt-5.6-sol" in OPENAI_SUBSCRIPTION_MODELS
         model = get_model("openai-subscription/gpt-5.6-sol")
         assert model.model == "gpt-5.6-sol"
+        assert model.context == 1_000_000
+        assert model.price_input > 0
+
+    def test_subscription_gpt56_bare_alias_resolves_via_model_aliases(self):
+        """openai-subscription/gpt-5.6 resolves via MODEL_ALIASES to gpt-5.6-sol metadata.
+
+        ChatGPT-account (Plus/Pro) auth rejects the bare gpt-5.6 alias with a
+        400 ("not supported when using Codex with a ChatGPT account" — verified
+        live 2026-07-14). The bare name is NOT in OPENAI_SUBSCRIPTION_MODELS;
+        instead MODEL_ALIASES["openai-subscription"]["gpt-5.6"] -> "gpt-5.6-sol"
+        so metadata lookup still works for users who write the short form.
+        """
+        from gptme.llm.llm_openai_models import OPENAI_SUBSCRIPTION_MODELS
+        from gptme.llm.models.types import MODEL_ALIASES
+
+        assert "gpt-5.6" not in OPENAI_SUBSCRIPTION_MODELS
+        assert (
+            MODEL_ALIASES.get("openai-subscription", {}).get("gpt-5.6") == "gpt-5.6-sol"
+        )
+        model = get_model("openai-subscription/gpt-5.6")
         assert model.context == 1_000_000
         assert model.price_input > 0
 

--- a/tests/test_llm_models_resolution.py
+++ b/tests/test_llm_models_resolution.py
@@ -205,6 +205,23 @@ class TestAliasResolution:
         assert model.model == "gpt-5.6"
         assert model.context == 1_000_000
 
+    def test_subscription_gpt56_sol_named_form_has_metadata(self):
+        """openai-subscription/gpt-5.6-sol resolves real Sol metadata.
+
+        ChatGPT-account (Plus/Pro) auth rejects the bare gpt-5.6 alias with a
+        400 ("not supported when using Codex with a ChatGPT account" — verified
+        live 2026-07-14), so subscription users must request the named form.
+        It therefore needs a concrete OPENAI_SUBSCRIPTION_MODELS entry rather
+        than falling through to closest-match/128k-fallback metadata.
+        """
+        from gptme.llm.llm_openai_models import OPENAI_SUBSCRIPTION_MODELS
+
+        assert "gpt-5.6-sol" in OPENAI_SUBSCRIPTION_MODELS
+        model = get_model("openai-subscription/gpt-5.6-sol")
+        assert model.model == "gpt-5.6-sol"
+        assert model.context == 1_000_000
+        assert model.price_input > 0
+
     def test_all_openai_aliases_resolve_known_metadata(self):
         """Every openai alias should resolve real metadata (not the 128k unknown fallback)."""
         for alias, canonical in MODEL_ALIASES.get("openai", {}).items():


### PR DESCRIPTION
## Problem

The `openai-subscription` registry (#3166) lists the bare `gpt-5.6` alias plus terra/luna, but not `gpt-5.6-sol`. On ChatGPT-account (Plus/Pro) auth the bare alias is rejected server-side with a 400:

```
Codex API error 400: {"detail":"The 'gpt-5.6' model is not supported when using Codex with a ChatGPT account."}
```

(verified live 2026-07-14; same behavior as the Codex CLI, where only named variants work on ChatGPT accounts — the alias appears to be API-key-only.)

So subscription users must request `openai-subscription/gpt-5.6-sol`, which previously fell through to closest-match metadata with an "Unknown model" warning on every call.

## Fix

- Add a concrete `gpt-5.6-sol` entry to `OPENAI_SUBSCRIPTION_MODELS` (same metadata as the bare-alias entry, which OpenAI serves as Sol server-side).
- Keep the bare `gpt-5.6` entry for account types where the alias works.
- Regression test asserting the named form resolves real Sol metadata.

Tested: `tests/test_llm_models_resolution.py` + `tests/test_llm_models.py` — 159 passed. Also verified live end-to-end on a ChatGPT Pro account (`openai-subscription/gpt-5.6-sol` completes a turn).