### PR TITLE
test(computer): add missing error-path coverage for _measure_terminal_startup

### DIFF
--- a/tests/test_computer_latency_cmd.py
+++ b/tests/test_computer_latency_cmd.py
@@ -442,6 +442,63 @@ class TestLatencyTerminalFlag:
         assert "error" in result
         assert "xdotool" in result["error"]
 
+    def test_measure_terminal_startup_xdotool_timeout(self):
+        """_measure_terminal_startup returns error dict when xdotool --sync times out."""
+        import subprocess as _subprocess
+
+        from gptme.cli.cmd_computer import _measure_terminal_startup
+
+        fake_proc = MagicMock()
+        fake_proc.pid = 99999
+
+        def _which(cmd: str) -> str | None:
+            return f"/usr/bin/{cmd}" if cmd in ("xterm", "xdotool") else None
+
+        with (
+            patch("shutil.which", side_effect=_which),
+            patch("subprocess.Popen", return_value=fake_proc),
+            patch(
+                "subprocess.run",
+                side_effect=_subprocess.TimeoutExpired(cmd=["xdotool"], timeout=5.0),
+            ),
+        ):
+            result = _measure_terminal_startup(":1", timeout=5.0)
+
+        assert "error" in result
+        assert "xterm" in result.get("terminal", "") or "terminal" in result["error"]
+        assert (
+            "did not appear" in result["error"] or "timeout" in result["error"].lower()
+        )
+
+    def test_measure_terminal_startup_xdotool_called_process_error(self):
+        """_measure_terminal_startup returns error dict when xdotool exits non-zero."""
+        import subprocess as _subprocess
+
+        from gptme.cli.cmd_computer import _measure_terminal_startup
+
+        fake_proc = MagicMock()
+        fake_proc.pid = 99999
+
+        def _which(cmd: str) -> str | None:
+            return f"/usr/bin/{cmd}" if cmd in ("xterm", "xdotool") else None
+
+        with (
+            patch("shutil.which", side_effect=_which),
+            patch("subprocess.Popen", return_value=fake_proc),
+            patch(
+                "subprocess.run",
+                side_effect=_subprocess.CalledProcessError(
+                    returncode=1,
+                    cmd=["xdotool", "search"],
+                    stderr="no windows found",
+                ),
+            ),
+        ):
+            result = _measure_terminal_startup(":1", timeout=5.0)
+
+        assert "error" in result
+        assert "xdotool" in result["error"]
+
     def test_measure_terminal_startup_returns_startup_ms_on_success(self, tmp_path):
         """_measure_terminal_startup returns startup_ms (int) on a successful launch."""
         import subprocess as _subprocess


### PR DESCRIPTION
## Summary

Adds two missing unit tests for error paths in `_measure_terminal_startup()` (the terminal window startup latency measurement introduced for issue #216 delay diagnosis):

- **TimeoutExpired**: when `xdotool --sync` doesn't find the terminal window before the timeout — returns an error dict with a `"did not appear"` message
- **CalledProcessError**: when xdotool exits with a non-zero code (e.g. bad display, permission error) — returns an error dict with `"xdotool failed"`

These complement the three existing tests (no-xterm, no-xdotool, success), giving complete branch coverage of the function.

## Context

`_measure_terminal_startup()` was added to implement `gptme-util computer latency --terminal`, which directly addresses the `"figure out what is causing the delays"` checklist item in #216. The success path and the two `shutil.which()`-failure paths were tested in #3242; these two subprocess-failure paths were not.

## Test plan
- [x] All 24 latency cmd tests pass: `uv run pytest tests/test_computer_latency_cmd.py -q`
- [x] Full computer test suite (526 tests) passes: `uv run pytest tests/test_computer_*.py tests/test_tools_computer.py -q`

<!-- gptme-id:v1:gai_ugTrQqYKRAKoccGYtWU8nbG6padkwkygNeIOzZImQl5 -->