### PR TITLE
fix(security): redact secrets in GET /api/v2/user/config-file response

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -83,6 +83,12 @@ The ``prompt`` section contains options included in both interactive and non-int
 
 The ``env`` section contains environment variables that gptme will fall back to if they are not set in the shell environment. This is useful for setting the default model and API keys for :doc:`providers`. It can also be used to set default tool configuration options, see :doc:`custom_tool` for more information.
 
+.. note::
+
+   API keys and other secrets belong in :ref:`config.local.toml <global-config-local>`, not in
+   ``config.toml``. That lets you keep ``config.toml`` in dotfiles or version control without
+   exposing your keys. The webui setup wizard already writes keys to ``config.local.toml``.
+
 The ``settings`` section contains user-level CLI defaults. Currently supported:
 
 - ``gear``: Default autonomy preset for new conversations. Gear ``0`` is read-only

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -490,13 +490,19 @@ _REDACT_SENTINEL = "***"
 # Matches TOML section headers: [section] or [section.subsection]
 _SECTION_HEADER_RE = re.compile(r"^\s*\[([^\]]+)\]")
 
-# Separate patterns for double-quoted and single-quoted TOML string assignments
-# whose key looks like a secret.  Group 1: key + '= <quote>'  Group 2: value  Group 3: closing quote
+# Key sub-patterns: bare (`API_KEY`), double-quoted (`"API_KEY"`), or single-quoted (`'API_KEY'`).
+_SECRET_KEY_BARE = r"\b[\w]*(?:api_key|secret|password|token)\b"
+_SECRET_KEY_DQUOTED = r'"[\w]*(?:api_key|secret|password|token)[\w]*"'
+_SECRET_KEY_SQUOTED = r"'[\w]*(?:api_key|secret|password|token)[\w]*'"
+_SECRET_KEY_ANY = rf"(?:{_SECRET_KEY_BARE}|{_SECRET_KEY_DQUOTED}|{_SECRET_KEY_SQUOTED})"
+
+# Separate patterns for double-quoted and single-quoted TOML string values.
+# Group 1: key + '= <quote>'  Group 2: value  Group 3: closing quote
 _SECRET_KEY_DOUBLE_RE = re.compile(
-    r'(?i)(\b[\w]*(?:api_key|secret|password|token)\b\s*=\s*")([^"]*?)(")',
+    rf'(?i)({_SECRET_KEY_ANY}\s*=\s*")([^"]*?)(")',
 )
 _SECRET_KEY_SINGLE_RE = re.compile(
-    r"(?i)(\b[\w]*(?:api_key|secret|password|token)\b\s*=\s*')([^']*?)(')",
+    rf"(?i)({_SECRET_KEY_ANY}\s*=\s*')([^']*?)(')",
 )
 _SECRET_KEY_PATTERNS = [_SECRET_KEY_DOUBLE_RE, _SECRET_KEY_SINGLE_RE]
 

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -515,29 +515,35 @@ def _restore_redacted_secrets(incoming: str, original: str) -> str:
     any field that still holds the sentinel should preserve the real on-disk
     value rather than writing the placeholder.
 
-    Uses (section, key_name) as the lookup key so duplicate bare key names
-    across different TOML sections are restored to their correct values.
+    Uses (section, occurrence_index, key_name) as the lookup key so that
+    repeated TOML array-of-tables (e.g. [[providers]]) restore each entry
+    to its own correct secret rather than the last-seen value.
     """
     # Build section-scoped map of real secret values from the on-disk file.
-    originals: dict[tuple[str, str], str] = {}
+    # Key: (section_header, occurrence_index, key_name)
+    originals: dict[tuple[str, int, str], str] = {}
+    section_counts: dict[str, int] = {}
     current_section = ""
+    current_section_idx = 0
     for line in original.splitlines():
         sm = _SECTION_HEADER_RE.match(line)
         if sm:
             current_section = sm.group(1)
+            current_section_idx = section_counts.get(current_section, 0)
+            section_counts[current_section] = current_section_idx + 1
             continue
         for pat in _SECRET_KEY_PATTERNS:
             km = pat.search(line)
             if km:
                 key = km.group(1).split("=")[0].strip().lower()
-                originals[(current_section, key)] = km.group(2)
+                originals[(current_section, current_section_idx, key)] = km.group(2)
                 break
 
-    def _make_restore(section: str):
+    def _make_restore(section: str, section_idx: int):
         def _restore(m: re.Match) -> str:
             key = m.group(1).split("=")[0].strip().lower()
             if m.group(2) == _REDACT_SENTINEL:
-                real = originals.get((section, key))
+                real = originals.get((section, section_idx, key))
                 if real is not None:
                     return m.group(1) + real + m.group(3)
             return m.group(0)
@@ -546,14 +552,18 @@ def _restore_redacted_secrets(incoming: str, original: str) -> str:
 
     result_lines: list[str] = []
     current_section = ""
+    current_section_idx = 0
+    section_counts = {}
     for line in incoming.splitlines(keepends=True):
         sm = _SECTION_HEADER_RE.match(line)
         if sm:
             current_section = sm.group(1)
+            current_section_idx = section_counts.get(current_section, 0)
+            section_counts[current_section] = current_section_idx + 1
             result_lines.append(line)
             continue
         for pat in _SECRET_KEY_PATTERNS:
-            line = pat.sub(_make_restore(current_section), line)
+            line = pat.sub(_make_restore(current_section, current_section_idx), line)
         result_lines.append(line)
 
     return "".join(result_lines)

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -9,6 +9,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import shutil
 import threading
 import time
@@ -483,11 +484,52 @@ def _validate_api_key_input(api_key: str) -> str:
     return trimmed
 
 
+# Sentinel substituted for secret values in GET /config-file responses.
+_REDACT_SENTINEL = "***"
+
+# Matches TOML string assignments whose key looks like a secret.
+# Group 1: key + whitespace + '= "'   Group 2: value   Group 3: closing '"'
+_SECRET_KEY_RE = re.compile(
+    r'(?i)(\b[\w]*(?:api_key|secret|password|token)\b\s*=\s*")([^"]*)(")',
+)
+
+
+def _redact_secrets(content: str) -> str:
+    """Replace secret values in TOML config content with the redaction sentinel."""
+    return _SECRET_KEY_RE.sub(rf"\g<1>{_REDACT_SENTINEL}\g<3>", content)
+
+
+def _restore_redacted_secrets(incoming: str, original: str) -> str:
+    """Restore sentinel placeholders with the real values from the on-disk file.
+
+    When the webui reads a redacted config and then submits it back via PUT,
+    any field that still holds the sentinel should preserve the real on-disk
+    value rather than writing the placeholder.
+    """
+    originals: dict[str, str] = {}
+    for m in _SECRET_KEY_RE.finditer(original):
+        key_name = m.group(1).split("=")[0].strip().lower()
+        originals[key_name] = m.group(2)
+
+    def _restore(m: re.Match) -> str:
+        key_name = m.group(1).split("=")[0].strip().lower()
+        if m.group(2) == _REDACT_SENTINEL and key_name in originals:
+            return m.group(1) + originals[key_name] + m.group(3)
+        return m.group(0)
+
+    return _SECRET_KEY_RE.sub(_restore, incoming)
+
+
 def _get_user_config_file_response(content: str) -> dict[str, str | bool]:
-    """Return raw config text with the same path metadata as user settings."""
+    """Return raw config text with the same path metadata as user settings.
+
+    Secret values (API keys etc.) are redacted with ``***`` before being
+    included in the response — even when the auth bypass is active for
+    local-only servers.
+    """
     runtime_info = get_user_config_runtime_info()
     return {
-        "content": content,
+        "content": _redact_secrets(content),
         "path": runtime_info["config_path"],
         "write_target": runtime_info["write_target"],
         "local_config_path": runtime_info["local_config_path"],
@@ -3007,12 +3049,18 @@ def api_user_config_file_put():
 
     config_file, _local_path = get_user_config_paths()
     config_file.parent.mkdir(parents=True, exist_ok=True)
-    config_file.write_text(content)
+
+    # If the submitted content contains redaction sentinels, restore the real
+    # values from the on-disk file so the webui round-trip doesn't wipe secrets.
+    original = config_file.read_text() if config_file.exists() else ""
+    write_content = _restore_redacted_secrets(content, original)
+
+    config_file.write_text(write_content)
     from gptme.config.core import reload_config
 
     reload_config()
 
-    response = _get_user_config_file_response(content)
+    response = _get_user_config_file_response(write_content)
     response["status"] = "ok"
     return flask.jsonify(response)
 

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -487,16 +487,25 @@ def _validate_api_key_input(api_key: str) -> str:
 # Sentinel substituted for secret values in GET /config-file responses.
 _REDACT_SENTINEL = "***"
 
-# Matches TOML string assignments whose key looks like a secret.
-# Group 1: key + whitespace + '= "'   Group 2: value   Group 3: closing '"'
-_SECRET_KEY_RE = re.compile(
-    r'(?i)(\b[\w]*(?:api_key|secret|password|token)\b\s*=\s*")([^"]*)(")',
+# Matches TOML section headers: [section] or [section.subsection]
+_SECTION_HEADER_RE = re.compile(r"^\s*\[([^\]]+)\]")
+
+# Separate patterns for double-quoted and single-quoted TOML string assignments
+# whose key looks like a secret.  Group 1: key + '= <quote>'  Group 2: value  Group 3: closing quote
+_SECRET_KEY_DOUBLE_RE = re.compile(
+    r'(?i)(\b[\w]*(?:api_key|secret|password|token)\b\s*=\s*")([^"]*?)(")',
 )
+_SECRET_KEY_SINGLE_RE = re.compile(
+    r"(?i)(\b[\w]*(?:api_key|secret|password|token)\b\s*=\s*')([^']*?)(')",
+)
+_SECRET_KEY_PATTERNS = [_SECRET_KEY_DOUBLE_RE, _SECRET_KEY_SINGLE_RE]
 
 
 def _redact_secrets(content: str) -> str:
     """Replace secret values in TOML config content with the redaction sentinel."""
-    return _SECRET_KEY_RE.sub(rf"\g<1>{_REDACT_SENTINEL}\g<3>", content)
+    for pat in _SECRET_KEY_PATTERNS:
+        content = pat.sub(rf"\g<1>{_REDACT_SENTINEL}\g<3>", content)
+    return content
 
 
 def _restore_redacted_secrets(incoming: str, original: str) -> str:
@@ -505,19 +514,49 @@ def _restore_redacted_secrets(incoming: str, original: str) -> str:
     When the webui reads a redacted config and then submits it back via PUT,
     any field that still holds the sentinel should preserve the real on-disk
     value rather than writing the placeholder.
+
+    Uses (section, key_name) as the lookup key so duplicate bare key names
+    across different TOML sections are restored to their correct values.
     """
-    originals: dict[str, str] = {}
-    for m in _SECRET_KEY_RE.finditer(original):
-        key_name = m.group(1).split("=")[0].strip().lower()
-        originals[key_name] = m.group(2)
+    # Build section-scoped map of real secret values from the on-disk file.
+    originals: dict[tuple[str, str], str] = {}
+    current_section = ""
+    for line in original.splitlines():
+        sm = _SECTION_HEADER_RE.match(line)
+        if sm:
+            current_section = sm.group(1)
+            continue
+        for pat in _SECRET_KEY_PATTERNS:
+            km = pat.search(line)
+            if km:
+                key = km.group(1).split("=")[0].strip().lower()
+                originals[(current_section, key)] = km.group(2)
+                break
 
-    def _restore(m: re.Match) -> str:
-        key_name = m.group(1).split("=")[0].strip().lower()
-        if m.group(2) == _REDACT_SENTINEL and key_name in originals:
-            return m.group(1) + originals[key_name] + m.group(3)
-        return m.group(0)
+    def _make_restore(section: str):
+        def _restore(m: re.Match) -> str:
+            key = m.group(1).split("=")[0].strip().lower()
+            if m.group(2) == _REDACT_SENTINEL:
+                real = originals.get((section, key))
+                if real is not None:
+                    return m.group(1) + real + m.group(3)
+            return m.group(0)
 
-    return _SECRET_KEY_RE.sub(_restore, incoming)
+        return _restore
+
+    result_lines: list[str] = []
+    current_section = ""
+    for line in incoming.splitlines(keepends=True):
+        sm = _SECTION_HEADER_RE.match(line)
+        if sm:
+            current_section = sm.group(1)
+            result_lines.append(line)
+            continue
+        for pat in _SECRET_KEY_PATTERNS:
+            line = pat.sub(_make_restore(current_section), line)
+        result_lines.append(line)
+
+    return "".join(result_lines)
 
 
 def _get_user_config_file_response(content: str) -> dict[str, str | bool]:

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -621,6 +621,29 @@ def test_restore_redacted_secrets_repeated_array_of_tables():
     assert restored == original
 
 
+def test_redact_secrets_quoted_key_name():
+    """Secrets under quoted TOML key names must also be redacted."""
+    from gptme.server.api_v2 import _redact_secrets, _restore_redacted_secrets
+
+    # Double-quoted key with double-quoted value
+    original_dq = '[env]\n"OPENAI_API_KEY" = "sk-real"\n'
+    redacted_dq = _redact_secrets(original_dq)
+    assert "sk-real" not in redacted_dq, "double-quoted key: value should be redacted"
+    restored_dq = _restore_redacted_secrets(redacted_dq, original_dq)
+    assert restored_dq == original_dq, (
+        "double-quoted key: round-trip should restore value"
+    )
+
+    # Single-quoted key with double-quoted value
+    original_sq = "[env]\n'ANTHROPIC_API_KEY' = \"sk-real2\"\n"
+    redacted_sq = _redact_secrets(original_sq)
+    assert "sk-real2" not in redacted_sq, "single-quoted key: value should be redacted"
+    restored_sq = _restore_redacted_secrets(redacted_sq, original_sq)
+    assert restored_sq == original_sq, (
+        "single-quoted key: round-trip should restore value"
+    )
+
+
 @pytest.mark.parametrize(
     "endpoint", ["/api/v2/user/api-key", "/api/v2/user/default-model"]
 )

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -548,6 +548,59 @@ def test_v2_user_config_file_patch_rejects_invalid_key(client: FlaskClient):
     assert "dotted path" in response.get_json()["error"]
 
 
+# ---------------------------------------------------------------------------
+# Unit tests for _redact_secrets / _restore_redacted_secrets
+# ---------------------------------------------------------------------------
+
+
+def test_redact_secrets_double_quoted():
+    from gptme.server.api_v2 import _redact_secrets
+
+    content = '[openai]\nOPENAI_API_KEY = "sk-abc123"\n'
+    redacted = _redact_secrets(content)
+    assert "sk-abc123" not in redacted
+    assert '***"' in redacted or '"***"' in redacted
+
+
+def test_redact_secrets_single_quoted():
+    """Secrets in single-quoted TOML strings must also be redacted."""
+    from gptme.server.api_v2 import _redact_secrets
+
+    content = "[openai]\nOPENAI_API_KEY = 'sk-abc123'\n"
+    redacted = _redact_secrets(content)
+    assert "sk-abc123" not in redacted
+
+
+def test_redact_secrets_preserves_non_secret_keys():
+    from gptme.server.api_v2 import _redact_secrets
+
+    content = '[env]\nMODEL = "anthropic/claude-3"\n'
+    assert _redact_secrets(content) == content
+
+
+def test_restore_redacted_secrets_section_scoped():
+    """Keys with the same bare name in different sections restore independently."""
+    from gptme.server.api_v2 import _redact_secrets, _restore_redacted_secrets
+
+    original = (
+        '[openai]\napi_key = "key-openai"\n[anthropic]\napi_key = "key-anthropic"\n'
+    )
+    redacted = _redact_secrets(original)
+    restored = _restore_redacted_secrets(redacted, original)
+    assert restored == original
+
+
+def test_restore_redacted_secrets_single_quoted():
+    """Single-quoted secrets survive a redact → restore round-trip."""
+    from gptme.server.api_v2 import _redact_secrets, _restore_redacted_secrets
+
+    original = "[openai]\napi_key = 'sk-real'\n"
+    redacted = _redact_secrets(original)
+    assert "sk-real" not in redacted
+    restored = _restore_redacted_secrets(redacted, original)
+    assert restored == original
+
+
 @pytest.mark.parametrize(
     "endpoint", ["/api/v2/user/api-key", "/api/v2/user/default-model"]
 )

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -601,6 +601,26 @@ def test_restore_redacted_secrets_single_quoted():
     assert restored == original
 
 
+def test_restore_redacted_secrets_repeated_array_of_tables():
+    """Repeated [[section]] tables each restore their own secret, not the last one."""
+    from gptme.server.api_v2 import _redact_secrets, _restore_redacted_secrets
+
+    original = (
+        "[[providers]]\n"
+        'name = "openai"\n'
+        'api_key = "key-openai"\n'
+        "\n"
+        "[[providers]]\n"
+        'name = "anthropic"\n'
+        'api_key = "key-anthropic"\n'
+    )
+    redacted = _redact_secrets(original)
+    assert "key-openai" not in redacted
+    assert "key-anthropic" not in redacted
+    restored = _restore_redacted_secrets(redacted, original)
+    assert restored == original
+
+
 @pytest.mark.parametrize(
     "endpoint", ["/api/v2/user/api-key", "/api/v2/user/default-model"]
 )


### PR DESCRIPTION
## Summary

Addresses the secret-exposure aspect of GHSA-vjp6-7cm5-m8h6 (Missing Authentication on Local gptme-server User Config API).

When the server binds to localhost, \`is_local_host()\` disables auth. The \`GET /api/v2/user/config-file\` endpoint then returned raw \`config.toml\` including any API keys stored in it.

**Changes:**

- \`_redact_secrets()\`: replaces values for keys matching \`api_key\`, \`*_API_KEY\`, \`password\`, \`secret\`, \`token\` with \`***\` in the GET response. Non-secret fields (e.g. \`MODEL\`) pass through unchanged.
- \`_restore_redacted_secrets()\`: on \`PUT\`, before writing, any \`***\` sentinel values are replaced with the on-disk original — so the webui's read→edit→write roundtrip does not wipe real key values.
- \`_get_user_config_file_response()\`: now always applies redaction before returning content.
- **docs**: added a note in \`docs/config.rst\` pointing users to \`config.local.toml\` for API keys, so \`config.toml\` can be safely committed to dotfiles.

**Who is affected:** Users with API keys directly in \`config.toml\`. Users who set keys via the webui wizard (which writes to \`config.local.toml\`) were never exposed — their keys were not in the file being served.

This is defense-in-depth alongside the existing recommendation to use \`config.local.toml\` for secrets.

## Notes

- The \`is_local_host()\` auth bypass itself is not removed — that's a separate design decision. Redaction makes the bypass safe for the config-file endpoint even without auth.
- The PATCH endpoint operates on individual key/value pairs via \`set_config_value()\` and is not affected.

Related to GHSA-vjp6-7cm5-m8h6.