### PR TITLE
fix(llm): increase subscription stream timeout for reasoning models

### DIFF
--- a/gptme/llm/llm_openai_subscription.py
+++ b/gptme/llm/llm_openai_subscription.py
@@ -537,7 +537,10 @@ def stream(
         json=request_body,
         headers=headers,
         stream=True,
-        timeout=120,
+        timeout=(
+            30,
+            600,
+        ),  # 30s connect, 10min read — reasoning models can think for minutes
     )
 
     if response.status_code != 200:


### PR DESCRIPTION
## Problem

The `stream()` function in `llm_openai_subscription.py` uses a hardcoded `timeout=120` (2 minutes) for the POST request to the ChatGPT subscription API.

For frontier reasoning models like `gpt-5.6-sol`, the model can spend several minutes thinking before streaming the first token. This causes a `ReadTimeout` that terminates the session with exit code 1 — even when the session has already done productive work.

**Observed failure pattern** (from autonomous harness data):
- 5 of 7 `gptme:gpt-5.6-sol` sessions recorded as "failed" had deliverables (commits, written files)
- Failure occurred at the *end* of the session, not at the start
- Error: `HTTPSConnectionPool(host='chatgpt.com', port=443): Read timed out. (read timeout=120)`

The sessions were productive but got misclassified as failures, causing the crash-loop detector to block the arm unnecessarily.

## Fix

Change `timeout=120` to `timeout=(30, 600)`:
- **30s connect timeout** — tight guard against hung connections
- **600s read timeout** — allows reasoning models up to 10 minutes to generate a response between SSE events

## Test plan
- [ ] `gptme -m openai-subscription/gpt-5.6-sol` session completes on a reasoning-heavy prompt without timeout
- [ ] Connection hung (no server response) still fails within 30s