### PR TITLE
feat(llm): stream idle-timeout retry + env overrides for subscription streaming

### DIFF
--- a/gptme/llm/llm_openai_subscription.py
+++ b/gptme/llm/llm_openai_subscription.py
@@ -42,6 +42,7 @@ import webbrowser
 from base64 import urlsafe_b64decode
 from collections.abc import Generator
 from dataclasses import dataclass
+from math import isfinite
 from pathlib import Path
 from typing import Any
 from urllib.parse import parse_qs, urlencode, urlparse
@@ -537,7 +538,23 @@ def stream(
     # can think for minutes without emitting an event, so the default is
     # deliberately generous. Override via GPTME_SUBSCRIPTION_READ_TIMEOUT
     # for latency-sensitive callers.
-    read_timeout = float(os.environ.get("GPTME_SUBSCRIPTION_READ_TIMEOUT", "600"))
+    _DEFAULT_READ_TIMEOUT = 600.0
+    _env_val = os.environ.get("GPTME_SUBSCRIPTION_READ_TIMEOUT", "")
+    if _env_val:
+        try:
+            _parsed = float(_env_val)
+            if _parsed <= 0 or not isfinite(_parsed):
+                raise ValueError("must be a positive finite number")
+            read_timeout = _parsed
+        except ValueError:
+            logger.warning(
+                "Invalid GPTME_SUBSCRIPTION_READ_TIMEOUT=%r; using default %.0fs",
+                _env_val,
+                _DEFAULT_READ_TIMEOUT,
+            )
+            read_timeout = _DEFAULT_READ_TIMEOUT
+    else:
+        read_timeout = _DEFAULT_READ_TIMEOUT
     response = requests.post(
         CODEX_ENDPOINT,
         json=request_body,

--- a/gptme/llm/llm_openai_subscription.py
+++ b/gptme/llm/llm_openai_subscription.py
@@ -555,28 +555,67 @@ def stream(
             read_timeout = _DEFAULT_READ_TIMEOUT
     else:
         read_timeout = _DEFAULT_READ_TIMEOUT
-    response = requests.post(
-        CODEX_ENDPOINT,
-        json=request_body,
-        headers=headers,
-        stream=True,
-        timeout=(30, read_timeout),
-    )
+    # Stream retries, mirroring codex-rs (DEFAULT_STREAM_IDLE_TIMEOUT_MS=300s
+    # with DEFAULT_STREAM_MAX_RETRIES=5): silence/drop on the wire is a
+    # retryable condition, not fatal. No read timeout is a true upper bound on
+    # a reasoning pause, so a timeout alone always has a failure mode; the
+    # retry closes it. Only retried BEFORE the first event has been yielded —
+    # re-POSTing restarts generation, so retrying after partial output would
+    # duplicate content downstream.
+    try:
+        max_stream_retries = int(
+            os.environ.get("GPTME_SUBSCRIPTION_STREAM_RETRIES", "3")
+        )
+    except ValueError:
+        max_stream_retries = 3
+    max_stream_retries = max(0, min(max_stream_retries, 100))
 
-    if response.status_code != 200:
-        error_text = response.text[:500]
-        raise ValueError(f"Codex API error {response.status_code}: {error_text}")
+    def _open_response() -> requests.Response:
+        resp = requests.post(
+            CODEX_ENDPOINT,
+            json=request_body,
+            headers=headers,
+            stream=True,
+            timeout=(30, read_timeout),
+        )
+        if resp.status_code != 200:
+            error_text = resp.text[:500]
+            raise ValueError(f"Codex API error {resp.status_code}: {error_text}")
+        return resp
 
     def _sse_events():
-        for line in response.iter_lines():
-            if not line:
-                continue
-            data = _parse_sse_response(line)
-            if data is None:
-                continue
-            if data.get("done"):
+        attempts = 0
+        yielded_any = False
+        response = _open_response()
+        while True:
+            try:
+                for line in response.iter_lines():
+                    if not line:
+                        continue
+                    data = _parse_sse_response(line)
+                    if data is None:
+                        continue
+                    if data.get("done"):
+                        return
+                    yielded_any = True
+                    yield data
                 return
-            yield data
+            except (
+                requests.exceptions.Timeout,
+                requests.exceptions.ConnectionError,
+                requests.exceptions.ChunkedEncodingError,
+            ) as e:
+                if yielded_any or attempts >= max_stream_retries:
+                    raise
+                attempts += 1
+                logger.warning(
+                    "Subscription stream idle/dropped before first event (%s); "
+                    "retrying (%d/%d)",
+                    e,
+                    attempts,
+                    max_stream_retries,
+                )
+                response = _open_response()
 
     yield from _stream_responses_events(_sse_events())
 

--- a/gptme/llm/llm_openai_subscription.py
+++ b/gptme/llm/llm_openai_subscription.py
@@ -532,15 +532,18 @@ def stream(
         "session_id": str(uuid4()),
     }
 
+    # Timeout is (connect, read). With stream=True the read timeout applies
+    # BETWEEN stream chunks — reasoning models (gpt-5.5 high, gpt-5.6-sol)
+    # can think for minutes without emitting an event, so the default is
+    # deliberately generous. Override via GPTME_SUBSCRIPTION_READ_TIMEOUT
+    # for latency-sensitive callers.
+    read_timeout = float(os.environ.get("GPTME_SUBSCRIPTION_READ_TIMEOUT", "600"))
     response = requests.post(
         CODEX_ENDPOINT,
         json=request_body,
         headers=headers,
         stream=True,
-        timeout=(
-            30,
-            600,
-        ),  # 30s connect, 10min read — reasoning models can think for minutes
+        timeout=(30, read_timeout),
     )
 
     if response.status_code != 200:

--- a/tests/test_llm_openai_subscription.py
+++ b/tests/test_llm_openai_subscription.py
@@ -3,6 +3,8 @@ from collections.abc import Iterator
 from typing import Any
 from unittest.mock import patch
 
+import pytest
+
 from gptme.llm import llm_openai_subscription
 from gptme.llm.llm_openai_subscription import SubscriptionAuth
 from gptme.message import Message
@@ -259,3 +261,30 @@ def test_stream_read_timeout_env_override(monkeypatch):
         )
 
     assert mock_post.call_args.kwargs["timeout"] == (30, 90.0)
+
+
+@pytest.mark.parametrize("bad_val", ["", "abc", "0", "-1", "inf", "nan"])
+def test_stream_read_timeout_invalid_env_falls_back_to_default(monkeypatch, bad_val):
+    """Invalid or non-positive GPTME_SUBSCRIPTION_READ_TIMEOUT must fall back to 600s
+    rather than raising or passing a bad value to requests."""
+    if bad_val == "":
+        monkeypatch.delenv("GPTME_SUBSCRIPTION_READ_TIMEOUT", raising=False)
+    else:
+        monkeypatch.setenv("GPTME_SUBSCRIPTION_READ_TIMEOUT", bad_val)
+    auth = _make_auth()
+    response = _FakeSSEStreamResponse([{"type": "response.done"}])
+
+    with (
+        patch("gptme.llm.llm_openai_subscription.get_auth", return_value=auth),
+        patch(
+            "gptme.llm.llm_openai_subscription.requests.post",
+            return_value=response,
+        ) as mock_post,
+    ):
+        list(
+            llm_openai_subscription.stream(
+                [Message(role="user", content="hello")], "gpt-5.6-sol"
+            )
+        )
+
+    assert mock_post.call_args.kwargs["timeout"] == (30, 600.0)

--- a/tests/test_llm_openai_subscription.py
+++ b/tests/test_llm_openai_subscription.py
@@ -4,6 +4,7 @@ from typing import Any
 from unittest.mock import patch
 
 import pytest
+import requests
 
 from gptme.llm import llm_openai_subscription
 from gptme.llm.llm_openai_subscription import SubscriptionAuth
@@ -288,3 +289,102 @@ def test_stream_read_timeout_invalid_env_falls_back_to_default(monkeypatch, bad_
         )
 
     assert mock_post.call_args.kwargs["timeout"] == (30, 600.0)
+
+
+class _TimeoutThenEventsResponse:
+    """First iter_lines() call raises ReadTimeout (silent reasoning pause
+    exceeding the read timeout); used to simulate a retryable idle stream."""
+
+    def __init__(self) -> None:
+        self.status_code = 200
+        self.text = ""
+
+    def iter_lines(self) -> Iterator[bytes]:
+        raise requests.exceptions.ReadTimeout("read timeout=600")
+        yield b""  # pragma: no cover — makes this a generator
+
+
+class _EventThenTimeoutResponse:
+    """Emits one event, then times out — retrying here would duplicate output."""
+
+    def __init__(self) -> None:
+        self.status_code = 200
+        self.text = ""
+
+    def iter_lines(self) -> Iterator[bytes]:
+        yield f"data: {json.dumps({'type': 'response.output_text.delta', 'delta': 'partial'})}".encode()
+        raise requests.exceptions.ReadTimeout("read timeout=600")
+
+
+def test_stream_retries_idle_timeout_before_first_event():
+    """A read timeout during the thinking phase (no events yielded yet) retries
+    the request instead of dying — mirrors codex-rs stream_max_retries."""
+    auth = _make_auth()
+    ok = _FakeSSEStreamResponse(
+        [
+            {"type": "response.output_text.delta", "delta": "Done."},
+            {"type": "response.done"},
+        ]
+    )
+
+    with (
+        patch("gptme.llm.llm_openai_subscription.get_auth", return_value=auth),
+        patch(
+            "gptme.llm.llm_openai_subscription.requests.post",
+            side_effect=[_TimeoutThenEventsResponse(), ok],
+        ) as mock_post,
+    ):
+        output = "".join(
+            llm_openai_subscription.stream(
+                [Message(role="user", content="hello")], "gpt-5.6-sol"
+            )
+        )
+
+    assert output == "Done."
+    assert mock_post.call_count == 2
+
+
+def test_stream_does_not_retry_after_first_event():
+    """After partial output a re-POST would duplicate content — re-raise."""
+    auth = _make_auth()
+
+    with (
+        patch("gptme.llm.llm_openai_subscription.get_auth", return_value=auth),
+        patch(
+            "gptme.llm.llm_openai_subscription.requests.post",
+            return_value=_EventThenTimeoutResponse(),
+        ) as mock_post,
+        pytest.raises(requests.exceptions.ReadTimeout),
+    ):
+        list(
+            llm_openai_subscription.stream(
+                [Message(role="user", content="hello")], "gpt-5.6-sol"
+            )
+        )
+
+    assert mock_post.call_count == 1
+
+
+def test_stream_retries_exhausted_reraises(monkeypatch):
+    monkeypatch.setenv("GPTME_SUBSCRIPTION_STREAM_RETRIES", "2")
+    auth = _make_auth()
+
+    with (
+        patch("gptme.llm.llm_openai_subscription.get_auth", return_value=auth),
+        patch(
+            "gptme.llm.llm_openai_subscription.requests.post",
+            side_effect=[
+                _TimeoutThenEventsResponse(),
+                _TimeoutThenEventsResponse(),
+                _TimeoutThenEventsResponse(),
+            ],
+        ) as mock_post,
+        pytest.raises(requests.exceptions.ReadTimeout),
+    ):
+        list(
+            llm_openai_subscription.stream(
+                [Message(role="user", content="hello")], "gpt-5.6-sol"
+            )
+        )
+
+    assert mock_post.call_count == 3  # initial + 2 retries

--- a/tests/test_llm_openai_subscription.py
+++ b/tests/test_llm_openai_subscription.py
@@ -213,3 +213,49 @@ def test_stream_omits_max_output_tokens_when_not_provided():
 
     request_json = mock_post.call_args.kwargs["json"]
     assert "max_output_tokens" not in request_json
+
+
+def test_stream_uses_generous_read_timeout_for_reasoning_models(monkeypatch):
+    """The read timeout applies BETWEEN stream chunks; reasoning-heavy models
+    (gpt-5.5 high, gpt-5.6-sol) can think for minutes without emitting an
+    event, and the old flat timeout=120 killed sessions mid-run after they
+    had already completed real work."""
+    auth = _make_auth()
+    response = _FakeSSEStreamResponse([{"type": "response.done"}])
+
+    with (
+        patch("gptme.llm.llm_openai_subscription.get_auth", return_value=auth),
+        patch(
+            "gptme.llm.llm_openai_subscription.requests.post",
+            return_value=response,
+        ) as mock_post,
+    ):
+        list(
+            llm_openai_subscription.stream(
+                [Message(role="user", content="hello")], "gpt-5.6-sol"
+            )
+        )
+
+    timeout = mock_post.call_args.kwargs["timeout"]
+    assert timeout == (30, 600.0)
+
+
+def test_stream_read_timeout_env_override(monkeypatch):
+    monkeypatch.setenv("GPTME_SUBSCRIPTION_READ_TIMEOUT", "90")
+    auth = _make_auth()
+    response = _FakeSSEStreamResponse([{"type": "response.done"}])
+
+    with (
+        patch("gptme.llm.llm_openai_subscription.get_auth", return_value=auth),
+        patch(
+            "gptme.llm.llm_openai_subscription.requests.post",
+            return_value=response,
+        ) as mock_post,
+    ):
+        list(
+            llm_openai_subscription.stream(
+                [Message(role="user", content="hello")], "gpt-5.6-sol"
+            )
+        )
+
+    assert mock_post.call_args.kwargs["timeout"] == (30, 90.0)


### PR DESCRIPTION
## What

Follow-up to #3247, answering the review question there (*"is 10min really the upper limit?"*):

**No read timeout is a true upper bound on a reasoning pause** — a bigger constant alone always keeps a failure mode. The reference implementation (codex-rs) doesn't rely on the constant either: it pairs a **300s** stream idle timeout with **`DEFAULT_STREAM_MAX_RETRIES = 5`** (`codex-rs/model-provider-info/src/lib.rs`) — wire silence is treated as *retryable*, not fatal.

This PR mirrors that design:

- **Retry on idle timeout / dropped stream, only BEFORE the first SSE event** — re-POSTing restarts generation, so retrying after partial output would duplicate content downstream. Timeouts in practice happen exactly in that pre-first-event thinking phase (all 6 observed gpt-5.6-sol deaths on 2026-07-14).
- `GPTME_SUBSCRIPTION_STREAM_RETRIES` (default 3, capped at 100 like codex-rs).
- `GPTME_SUBSCRIPTION_READ_TIMEOUT` override (validated; falls back to 600s on junk values).
- Regression tests: timeout tuple shape, env overrides + validation, retry-then-succeed, no-retry-after-partial-output, retries-exhausted. 19 pass.

With retries in place the 600s constant stops being load-bearing: worst case before a genuine failure is now ~40min of continuous silence (1+3 attempts × 600s), and callers can tune both knobs.