### PR TITLE
fix(webui): keep offline demo active across navigation

### DIFF
--- a/webui/src/components/AgentsView.tsx
+++ b/webui/src/components/AgentsView.tsx
@@ -6,6 +6,8 @@ import { formatDistanceToNow } from 'date-fns';
 import type { ConversationSummary } from '@/types/conversation';
 import { useApi } from '@/contexts/ApiContext';
 import { useNavigate } from 'react-router-dom';
+import { isDemoMode } from '@/utils/connectionConfig';
+import { appRoute } from '@/utils/routes';
 import { selectedAgent$ } from '@/stores/sidebar';
 import CreateAgentDialog, { type CreateAgentRequest } from './CreateAgentDialog';
 import type { FC } from 'react';
@@ -19,13 +21,14 @@ export const AgentsView: FC<AgentsViewProps> = ({ conversations }) => {
   const baseUrl = connectionConfig.baseUrl.replace(/\/+$/, '');
   const navigate = useNavigate();
   const agents = extractAgentsFromConversations(conversations);
+  const demoMode = isDemoMode();
   const [showCreateDialog, setShowCreateDialog] = useState(false);
 
   const handleAgentClick = (agentName: string) => {
     const agent = agents.find((a) => a.name === agentName);
     if (agent) {
       selectedAgent$.set(agent);
-      navigate('/chat');
+      navigate(appRoute('/chat'));
     }
   };
 
@@ -49,10 +52,12 @@ export const AgentsView: FC<AgentsViewProps> = ({ conversations }) => {
               conversations
             </p>
           </div>
-          <Button onClick={() => setShowCreateDialog(true)}>
-            <Plus className="mr-2 h-4 w-4" />
-            Create Agent
-          </Button>
+          {!demoMode && (
+            <Button onClick={() => setShowCreateDialog(true)}>
+              <Plus className="mr-2 h-4 w-4" />
+              Create Agent
+            </Button>
+          )}
         </div>
 
         {agents.length === 0 ? (
@@ -60,13 +65,16 @@ export const AgentsView: FC<AgentsViewProps> = ({ conversations }) => {
             <Bot className="mb-4 h-16 w-16 text-muted-foreground opacity-40" />
             <h2 className="mb-2 text-lg font-medium">No agents yet</h2>
             <p className="mb-6 max-w-md text-sm text-muted-foreground">
-              Agents are discovered from your conversation history. Create one to get started, or
-              start a conversation in an agent workspace.
+              {demoMode
+                ? 'Agent creation requires a live gptme server.'
+                : 'Agents are discovered from your conversation history. Create one to get started, or start a conversation in an agent workspace.'}
             </p>
-            <Button onClick={() => setShowCreateDialog(true)}>
-              <Plus className="mr-2 h-4 w-4" />
-              Create Agent
-            </Button>
+            {!demoMode && (
+              <Button onClick={() => setShowCreateDialog(true)}>
+                <Plus className="mr-2 h-4 w-4" />
+                Create Agent
+              </Button>
+            )}
           </div>
         ) : (
           <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
@@ -123,11 +131,13 @@ export const AgentsView: FC<AgentsViewProps> = ({ conversations }) => {
         )}
       </div>
 
-      <CreateAgentDialog
-        open={showCreateDialog}
-        onOpenChange={setShowCreateDialog}
-        onAgentCreated={handleAgentCreated}
-      />
+      {!demoMode && (
+        <CreateAgentDialog
+          open={showCreateDialog}
+          onOpenChange={setShowCreateDialog}
+          onAgentCreated={handleAgentCreated}
+        />
+      )}
     </div>
   );
 };

--- a/webui/src/components/CommandPalette.tsx
+++ b/webui/src/components/CommandPalette.tsx
@@ -28,7 +28,7 @@ import {
   exportConversationAsJSON,
   getExportableMessages,
 } from '@/utils/exportConversation';
-import { chatRoute } from '@/utils/routes';
+import { appRoute, chatRoute } from '@/utils/routes';
 import { toast } from 'sonner';
 
 interface CommandAction {
@@ -96,7 +96,7 @@ export function CommandPalette() {
         return;
       }
       e.preventDefault();
-      navigate('/');
+      navigate(appRoute('/'));
       setOpen(false);
     };
     document.addEventListener('keydown', down);
@@ -162,7 +162,7 @@ export function CommandPalette() {
         icon: <Plus className="mr-2 h-4 w-4" />,
         keywords: ['new', 'chat', 'conversation', 'create'],
         action: () => {
-          navigate('/');
+          navigate(appRoute('/'));
           setOpen(false);
         },
         group: 'Actions',
@@ -174,7 +174,7 @@ export function CommandPalette() {
         icon: <Sparkles className="mr-2 h-4 w-4" />,
         keywords: ['agent', 'create', 'new', 'ai'],
         action: () => {
-          navigate('/agents');
+          navigate(appRoute('/agents'));
           setOpen(false);
         },
         group: 'Actions',
@@ -187,7 +187,7 @@ export function CommandPalette() {
         keywords: ['settings', 'preferences', 'config'],
         action: () => {
           setOpen(false);
-          navigate('/settings');
+          navigate(appRoute('/settings'));
         },
         group: 'Navigation',
       },
@@ -198,7 +198,7 @@ export function CommandPalette() {
         icon: <Home className="mr-2 h-4 w-4" />,
         keywords: ['home', 'main'],
         action: () => {
-          navigate('/');
+          navigate(appRoute('/'));
           setOpen(false);
         },
         group: 'Navigation',
@@ -210,7 +210,7 @@ export function CommandPalette() {
         icon: <FileText className="mr-2 h-4 w-4" />,
         keywords: ['workspace', 'folder', 'project'],
         action: () => {
-          navigate('/workspaces');
+          navigate(appRoute('/workspaces'));
           setOpen(false);
         },
         group: 'Navigation',
@@ -222,7 +222,7 @@ export function CommandPalette() {
         icon: <Users className="mr-2 h-4 w-4" />,
         keywords: ['agents', 'list', 'view'],
         action: () => {
-          navigate('/agents');
+          navigate(appRoute('/agents'));
           setOpen(false);
         },
         group: 'Navigation',

--- a/webui/src/components/HistoryView.tsx
+++ b/webui/src/components/HistoryView.tsx
@@ -16,6 +16,7 @@ import {
   ChevronRight,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { appRoute } from '@/utils/routes';
 import { Input } from '@/components/ui/input';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { useApi } from '@/contexts/ApiContext';
@@ -328,7 +329,7 @@ export const HistoryView: FC = () => {
           <Button
             variant="ghost"
             size="icon"
-            onClick={() => navigate('/chat')}
+            onClick={() => navigate(appRoute('/chat'))}
             className="h-8 w-8"
             aria-label="Back to chat"
           >

--- a/webui/src/components/MenuBar.tsx
+++ b/webui/src/components/MenuBar.tsx
@@ -13,6 +13,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/comp
 import { useEmbeddedContext } from '@/contexts/EmbeddedContext';
 import type { EmbeddedMenuItem } from '@/lib/embeddedContext';
 import { Link } from 'react-router-dom';
+import { appRoute } from '@/utils/routes';
 import { commandPaletteOpen$ } from '@/stores/commandPalette';
 import { shortcutsDialogOpen$ } from '@/stores/shortcutsDialog';
 import { leftSidebarVisible$, toggleLeftSidebar } from '@/stores/sidebar';
@@ -60,7 +61,7 @@ export const MenuBar: FC = () => {
           <Menu className="h-4 w-4" />
         </Button>
         <Link
-          to="/chat"
+          to={appRoute('/chat')}
           className="flex items-center space-x-1 transition-opacity hover:opacity-80 sm:space-x-2"
         >
           <img src="/logo.png" alt="gptme logo" className="w-4" />

--- a/webui/src/components/MobileBottomNav.tsx
+++ b/webui/src/components/MobileBottomNav.tsx
@@ -1,6 +1,7 @@
 import { MessageSquare, History, Kanban, Bot, FolderOpen, Search, BadgeCheck } from 'lucide-react';
 import { NavLink, useLocation } from 'react-router-dom';
 import { cn } from '@/lib/utils';
+import { appRoute } from '@/utils/routes';
 import { commandPaletteOpen$ } from '@/stores/commandPalette';
 import type { FC } from 'react';
 
@@ -56,7 +57,7 @@ export const MobileBottomNav: FC = () => {
         return (
           <NavLink
             key={item.id}
-            to={item.path}
+            to={appRoute(item.path)}
             className={cn(
               'flex flex-1 flex-col items-center justify-center gap-0.5 py-1 text-muted-foreground transition-colors',
               isActive && 'text-foreground'

--- a/webui/src/components/SidebarIcons.tsx
+++ b/webui/src/components/SidebarIcons.tsx
@@ -14,6 +14,7 @@ import {
 import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { useNavigate, useLocation } from 'react-router-dom';
+import { appRoute } from '@/utils/routes';
 import { toggleLeftSidebarCollapsed } from '@/stores/sidebar';
 import { commandPaletteOpen$ } from '@/stores/commandPalette';
 import { SettingsModal } from './SettingsModal';
@@ -98,7 +99,7 @@ export const SidebarIcons: FC<Props> = ({ tasks }) => {
       toggleLeftSidebarCollapsed();
       return;
     }
-    navigate(`/${section === 'chat' ? 'chat' : section}`);
+    navigate(appRoute(`/${section === 'chat' ? 'chat' : section}`));
   };
 
   const activeTasks = tasks.filter((t) => t.status === 'active' && !t.archived);
@@ -225,7 +226,7 @@ export const SidebarIcons: FC<Props> = ({ tasks }) => {
                   className="relative h-8 w-full min-w-0 justify-start gap-2 px-2"
                   aria-label="Settings"
                   aria-current="page"
-                  onClick={() => navigate('/settings')}
+                  onClick={() => navigate(appRoute('/settings'))}
                 >
                   <span className="relative flex-shrink-0">
                     <Settings className="h-4 w-4" />

--- a/webui/src/components/UnifiedSidebar.tsx
+++ b/webui/src/components/UnifiedSidebar.tsx
@@ -20,6 +20,7 @@ import { Card, CardContent } from '@/components/ui/card';
 import { useApi } from '@/contexts/ApiContext';
 import { initConversation } from '@/stores/conversations';
 import { parseConversationImportJSON } from '@/utils/exportConversation';
+import { appRoute } from '@/utils/routes';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 
@@ -150,7 +151,9 @@ export const UnifiedSidebar: FC<Props> = ({
 
   const handleSelectExternal = useCallback(
     (id: string) => {
-      navigate(`/external-sessions?selected=${id}`);
+      const route = appRoute('/external-sessions');
+      const separator = route.includes('?') ? '&' : '?';
+      navigate(`${route}${separator}selected=${encodeURIComponent(id)}`);
     },
     [navigate]
   );
@@ -190,7 +193,7 @@ export const UnifiedSidebar: FC<Props> = ({
   }, [tasks, selectedTargetTypes]);
 
   const handleNewConversation = () => {
-    navigate('/chat');
+    navigate(appRoute('/chat'));
   };
 
   const handleImportConversation = useCallback(

--- a/webui/src/components/WelcomeView.tsx
+++ b/webui/src/components/WelcomeView.tsx
@@ -24,7 +24,7 @@ import {
 import { withLocalAddressSpace } from '@/utils/addressSpace';
 import { isLikelyChromeCorsPna } from '@/utils/api';
 import { isDemoMode } from '@/utils/connectionConfig';
-import { chatRoute } from '@/utils/routes';
+import { appRoute, chatRoute } from '@/utils/routes';
 
 const DEFAULT_LOCAL_SERVER_URLS = new Set(['http://127.0.0.1:5700', 'http://localhost:5700']);
 
@@ -566,7 +566,7 @@ export const WelcomeView = () => {
                 type="button"
                 variant="ghost"
                 size="sm"
-                onClick={() => navigate('/history')}
+                onClick={() => navigate(appRoute('/history'))}
                 className="rounded-full border border-transparent text-muted-foreground hover:border-border/70 hover:bg-background/70"
               >
                 <History className="mr-2 h-4 w-4" />

--- a/webui/src/components/WorkspacesView.tsx
+++ b/webui/src/components/WorkspacesView.tsx
@@ -3,6 +3,7 @@ import { extractWorkspacesFromConversations, formatPath } from '@/utils/workspac
 import { formatDistanceToNow } from 'date-fns';
 import type { ConversationSummary } from '@/types/conversation';
 import { useNavigate } from 'react-router-dom';
+import { appRoute } from '@/utils/routes';
 import { selectedWorkspace$ } from '@/stores/sidebar';
 import type { FC } from 'react';
 
@@ -16,7 +17,7 @@ export const WorkspacesView: FC<WorkspacesViewProps> = ({ conversations }) => {
 
   const handleWorkspaceClick = (path: string) => {
     selectedWorkspace$.set(path);
-    navigate('/chat');
+    navigate(appRoute('/chat'));
   };
 
   return (

--- a/webui/src/components/__tests__/AgentsView.test.tsx
+++ b/webui/src/components/__tests__/AgentsView.test.tsx
@@ -1,0 +1,49 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import { AgentsView } from '../AgentsView';
+
+const mockIsDemoMode = jest.fn(() => false);
+
+jest.mock('@/utils/connectionConfig', () => ({
+  isDemoMode: () => mockIsDemoMode(),
+}));
+
+jest.mock('@/contexts/ApiContext', () => ({
+  useApi: () => ({
+    api: { createAgent: jest.fn() },
+    connectionConfig: { baseUrl: 'demo://offline' },
+  }),
+}));
+
+jest.mock('../CreateAgentDialog', () => ({
+  __esModule: true,
+  default: () => <div data-testid="create-agent-dialog" />,
+}));
+
+const renderAgentsView = () =>
+  render(
+    <BrowserRouter>
+      <AgentsView conversations={[]} />
+    </BrowserRouter>
+  );
+
+describe('AgentsView', () => {
+  beforeEach(() => {
+    mockIsDemoMode.mockReturnValue(false);
+  });
+
+  it('offers agent creation with a live server', () => {
+    renderAgentsView();
+
+    expect(screen.getAllByRole('button', { name: 'Create Agent' })).toHaveLength(2);
+  });
+
+  it('does not offer an unsupported create action in offline demo mode', () => {
+    mockIsDemoMode.mockReturnValue(true);
+    renderAgentsView();
+
+    expect(screen.queryByRole('button', { name: 'Create Agent' })).not.toBeInTheDocument();
+    expect(screen.getByText('Agent creation requires a live gptme server.')).toBeInTheDocument();
+  });
+});

--- a/webui/src/components/__tests__/SidebarIcons.test.tsx
+++ b/webui/src/components/__tests__/SidebarIcons.test.tsx
@@ -68,6 +68,7 @@ const renderSidebar = () =>
 describe('SidebarIcons', () => {
   beforeEach(() => {
     mockLocalStorage.clear();
+    window.history.replaceState(null, '', '/chat');
     // Default to lg screen
     Object.defineProperty(window, 'innerWidth', { value: 1280, configurable: true });
   });
@@ -80,6 +81,16 @@ describe('SidebarIcons', () => {
     expect(screen.getByTestId('toggle-conversations-sidebar')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /agents/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /tasks/i })).toBeInTheDocument();
+  });
+
+  it('preserves demo mode when navigating between top-level sections', () => {
+    window.history.replaceState(null, '', '/chat?demo=1');
+    renderSidebar();
+
+    fireEvent.click(screen.getByRole('button', { name: /agents/i }));
+
+    expect(window.location.pathname).toBe('/agents');
+    expect(window.location.search).toBe('?demo=1');
   });
 
   it('starts expanded on lg+ screens when no preference stored', () => {

--- a/webui/src/pages/NotFound.tsx
+++ b/webui/src/pages/NotFound.tsx
@@ -2,6 +2,7 @@ import type { FC } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { MenuBar } from '@/components/MenuBar';
 import { Button } from '@/components/ui/button';
+import { appRoute } from '@/utils/routes';
 
 const NotFound: FC = () => {
   const location = useLocation();
@@ -19,7 +20,7 @@ const NotFound: FC = () => {
             The link may be broken, or the page may have moved.
           </p>
           <Button asChild>
-            <Link to="/">Go to chat</Link>
+            <Link to={appRoute('/')}>Go to chat</Link>
           </Button>
         </div>
       </div>

--- a/webui/src/pages/SettingsPage.tsx
+++ b/webui/src/pages/SettingsPage.tsx
@@ -9,6 +9,7 @@ import { SettingsContent } from '@/components/SettingsContent';
 import { SETTINGS_CATEGORIES, type SettingsCategory } from '@/stores/settingsModal';
 import { use$ } from '@legendapp/state/react';
 import { settingsModal$ } from '@/stores/settingsModal';
+import { appRoute } from '@/utils/routes';
 
 function toCategoryOrDefault(raw: string | undefined): SettingsCategory {
   return (SETTINGS_CATEGORIES as ReadonlyArray<string>).includes(raw ?? '')
@@ -73,7 +74,7 @@ const SettingsPage: FC = () => {
           if (window.history.length > 2) {
             navigate(-1);
           } else {
-            navigate('/chat');
+            navigate(appRoute('/chat'));
           }
         }
       }}

--- a/webui/src/utils/__tests__/routes.test.ts
+++ b/webui/src/utils/__tests__/routes.test.ts
@@ -1,4 +1,4 @@
-import { chatRoute, decodeRouteParam } from '../routes';
+import { appRoute, chatRoute, decodeRouteParam } from '../routes';
 
 describe('chatRoute', () => {
   beforeEach(() => {
@@ -30,6 +30,17 @@ describe('chatRoute', () => {
   it('forwards demo but strips step when both are present', () => {
     window.history.replaceState(null, '', '/?demo=1&step=true');
     expect(chatRoute('demo/conv-123')).toBe('/chat/demo%2Fconv-123?demo=1');
+  });
+});
+
+describe('appRoute', () => {
+  beforeEach(() => {
+    window.history.replaceState(null, '', '/');
+  });
+
+  it('preserves durable mode params across top-level navigation', () => {
+    window.history.replaceState(null, '', '/chat/demo?demo=1&step=true');
+    expect(appRoute('/agents')).toBe('/agents?demo=1');
   });
 });
 

--- a/webui/src/utils/routes.ts
+++ b/webui/src/utils/routes.ts
@@ -1,3 +1,8 @@
+export function appRoute(path: string): string {
+  const search = currentSearchParams();
+  return `${path}${search ? `?${search}` : ''}`;
+}
+
 export function chatRoute(conversationId: string, queryString?: string): string {
   const encodedId = encodeURIComponent(conversationId);
   const search = queryString ?? currentSearchParams();


### PR DESCRIPTION
## Summary
- preserve the durable `?demo=1` flag when navigating between WebUI sections
- hide the unsupported agent-creation action in offline demo mode and explain that it requires a live server
- cover route preservation and demo-mode agent UI with regression tests

## Live reproduction
On `https://chat.gptme.org/?demo=1`, clicking **Agents** changed the URL to `/agents` (dropping `?demo=1`). The UI then exposed **Create Agent**, which failed with:

```txt
Failed to create agent: Demo mode: createAgent() is not available without a live backend
```

The same query-param loss affected other top-level navigation paths.

## Verification
- `npm test -- --runInBand` — 58 suites, 540 tests passed
- `npm run lint` — clean except 16 existing warnings
- `npm run typecheck` — passed
- manual local browser flow: `/?demo=1` → Agents → Workspaces → History retained `?demo=1`; Agents no longer showed Create Agent
