### PR TITLE
fix(webui): latch demo mode so SPA URL rewrites can't split demo state

### DIFF
--- a/webui/src/utils/__tests__/connectionConfig.test.ts
+++ b/webui/src/utils/__tests__/connectionConfig.test.ts
@@ -21,7 +21,9 @@ jest.mock('@/stores/servers', () => ({
 
 import {
   getConnectionConfigFromSources,
+  isDemoMode,
   processConnectionFromHash,
+  resetDemoModeForTests,
   resolveCloudExchangeBaseUrl,
 } from '../connectionConfig';
 
@@ -171,5 +173,35 @@ describe('processConnectionFromHash', () => {
     expect(mockFindOrCreateServerByUrl).not.toHaveBeenCalled();
     expect(mockConnectServer).not.toHaveBeenCalled();
     expect(mockSetActiveServer).not.toHaveBeenCalled();
+  });
+});
+
+describe('isDemoMode', () => {
+  beforeEach(() => {
+    resetDemoModeForTests();
+  });
+
+  afterEach(() => {
+    window.history.replaceState(null, '', '/');
+    resetDemoModeForTests();
+  });
+
+  it('latches true on first call and survives SPA URL rewrites that drop ?demo=1', () => {
+    window.history.replaceState(null, '', '/?demo=1');
+    expect(isDemoMode()).toBe(true);
+
+    // SPA navigation rewrites the URL without the demo param (regression:
+    // guards went false while the demo ApiClient stayed active, firing live
+    // fetches against demo://offline).
+    window.history.replaceState(null, '', '/agents');
+    expect(isDemoMode()).toBe(true);
+  });
+
+  it('latches false on first call; adding ?demo=1 without a reload does not enable demo', () => {
+    window.history.replaceState(null, '', '/');
+    expect(isDemoMode()).toBe(false);
+
+    window.history.replaceState(null, '', '/?demo=1');
+    expect(isDemoMode()).toBe(false);
   });
 });

--- a/webui/src/utils/connectionConfig.ts
+++ b/webui/src/utils/connectionConfig.ts
@@ -24,16 +24,35 @@ function isUnsetViteHtmlPlaceholder(value: string): boolean {
   return /^%VITE_[A-Z0-9_]+%$/.test(value);
 }
 
+let demoModeLatch: boolean | null = null;
+
 /**
  * Whether the app should run in offline demo mode (fixture-backed, no live
  * backend, no auth). Activated by a `?demo=1` URL flag so a demo can be shared
  * as a plain link. Safe to call outside a browser (returns false).
+ *
+ * The result is latched on the first browser call: demo mode can only change
+ * with a full page reload, but SPA navigation may rewrite the URL and drop the
+ * `?demo=1` param. Without the latch, guards that consult this function go
+ * false mid-session while the demo ApiClient (selected once at module init in
+ * `serverClients.ts`) stays active with `baseUrl=demo://offline`, so live
+ * fetches fire against the unfetchable `demo://` scheme
+ * ("Failed to fetch models" console errors on chat.gptme.org after navigating
+ * inside the demo).
  */
 export function isDemoMode(): boolean {
   if (typeof window === 'undefined' || !window.location) {
     return false;
   }
-  return new URLSearchParams(window.location.search).get('demo') === '1';
+  if (demoModeLatch === null) {
+    demoModeLatch = new URLSearchParams(window.location.search).get('demo') === '1';
+  }
+  return demoModeLatch;
+}
+
+/** Test-only: clear the {@link isDemoMode} latch between test cases. */
+export function resetDemoModeForTests(): void {
+  demoModeLatch = null;
 }
 
 // Browser builds can inject runtime env from index.html before this module


### PR DESCRIPTION
## Problem

Live repro on chat.gptme.org: enter the offline demo ("Try the offline demo" on the no-server card), then navigate to Agents. The console fills with:

```
Fetch API cannot load demo://offline/api/v2/providers/health. URL scheme "demo" is not supported.
Fetch API cannot load demo://offline/api/v2/user/settings. URL scheme "demo" is not supported.
Fetch API cannot load demo://offline/api/v2/models. URL scheme "demo" is not supported.
Failed to fetch models: TypeError: Failed to fetch
```

Reproduced at master HEAD with a local vite build (demo load → navigate to `/agents` → `demo://` fetch fires).

## Root cause

The demo-mode signal is split-brained:

- `serverClients.ts` selects the demo `ApiClient` **once at module init** (cached `_isDemoMode`), with `baseUrl=demo://offline`.
- The fetch guards in `useModels` / `useProviderHealth` / `useUserSettings` (added in #2721) call `isDemoMode()` **live**, which re-reads `window.location.search` on every call.

SPA navigation can rewrite the URL and drop `?demo=1` (the bug family #3249 addresses at the router level). When that happens, the live guards flip to "not demo" while the active client still points at `demo://offline` — so real `fetch()` calls fire against the unfetchable `demo://` scheme.

## Fix

Latch `isDemoMode()` on the first browser call. Demo mode only legitimately changes with a full page reload — the demo entry CTA already does `window.location.href = …` — so the latched value is the correct semantic (it's the same one `serverClients.ts` already caches). All guards now agree with the client selection for the whole page lifetime, regardless of URL rewrites.

`resetDemoModeForTests()` is exposed for test isolation.

## Relation to #3249

Complementary, not overlapping: #3249 keeps `?demo=1` on the URL across navigation (fixes shareability/reload semantics); this PR makes the API layer immune to *any* URL rewrite path that drops the param (deep links, redirects, history restore). Either alone masks the console-error symptom in the common path; both together close the class.

## Testing

- 2 new regression tests in `connectionConfig.test.ts` (latch survives `history.replaceState` rewrite; adding the param without reload doesn't enable demo)
- Full webui suite: 57 suites / 538 tests pass; typecheck + lint clean
- E2E: local vite at HEAD reproduces the `demo://` fetch on demo→Agents; with this patch, all three entry/nav paths are clean (playwright, localhost:5700 blocked to simulate a real anonymous visitor)
