### PR TITLE
fix(test): stop ACP health-monitor thread leaks and SessionManager dict-mutation races

### DIFF
--- a/gptme/server/session_models.py
+++ b/gptme/server/session_models.py
@@ -202,7 +202,7 @@ class SessionManager:
 
         with cls._lock:
             to_remove: list[str] = []
-            for session_id, session in cls._sessions.items():
+            for session_id, session in list(cls._sessions.items()):
                 if session.last_activity < cutoff and not session.generating:
                     to_remove.append(session_id)
                 elif (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -264,19 +264,22 @@ def cleanup_acp_health_monitor():
     """
     yield
     try:
-        from gptme.server.session_step import stop_acp_health_monitor
+        try:
+            from gptme.server.session_step import stop_acp_health_monitor
 
-        stop_acp_health_monitor()
-    except ImportError:
-        pass
-    try:
-        from gptme.server.session_models import SessionManager
+            stop_acp_health_monitor()
+        except ImportError:
+            pass
+        try:
+            from gptme.server.session_models import SessionManager
 
-        with SessionManager._lock:
-            SessionManager._sessions.clear()
-            SessionManager._conversation_sessions.clear()
-    except ImportError:
-        pass
+            with SessionManager._lock:
+                SessionManager._sessions.clear()
+                SessionManager._conversation_sessions.clear()
+        except ImportError:
+            pass
+    except Exception as e:
+        logger.warning(f"Error during ACP health monitor cleanup: {e}")
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -254,6 +254,32 @@ def cleanup_shell_after():
 
 
 @pytest.fixture(autouse=True)
+def cleanup_acp_health_monitor():
+    """Stop the ACP health monitor and clear SessionManager state after each test.
+
+    The health monitor is a module-level singleton thread. Without this fixture
+    the first test that starts it leaks the thread for the rest of the xdist
+    worker's life, racing with any test that writes to SessionManager._sessions
+    directly and causing RuntimeError: dictionary changed size during iteration.
+    """
+    yield
+    try:
+        from gptme.server.session_step import stop_acp_health_monitor
+
+        stop_acp_health_monitor()
+    except ImportError:
+        pass
+    try:
+        from gptme.server.session_models import SessionManager
+
+        with SessionManager._lock:
+            SessionManager._sessions.clear()
+            SessionManager._conversation_sessions.clear()
+    except ImportError:
+        pass
+
+
+@pytest.fixture(autouse=True)
 def cleanup_subagents_after():
     """Clean up subagent threads and subprocesses after each test.
 

--- a/tests/test_acp_session_runtime.py
+++ b/tests/test_acp_session_runtime.py
@@ -205,8 +205,9 @@ def test_acp_step_emits_events(monkeypatch, client: FlaskClient, tmp_path):
     session = ConversationSession(id="sid-evt", conversation_id=conversation_id)
     session.use_acp = True
     session.acp_runtime = AcpSessionRuntime(workspace=tmp_path)
-    SessionManager._sessions["sid-evt"] = session
-    SessionManager._conversation_sessions[conversation_id].add("sid-evt")
+    with SessionManager._lock:
+        SessionManager._sessions["sid-evt"] = session
+        SessionManager._conversation_sessions[conversation_id].add("sid-evt")
 
     try:
         _run(sessions_mod._acp_step(conversation_id, session, tmp_path))
@@ -225,8 +226,9 @@ def test_acp_step_emits_events(monkeypatch, client: FlaskClient, tmp_path):
         assert len(assistant_msgs) == 1
         assert assistant_msgs[0].content == "hello world"
     finally:
-        SessionManager._sessions.pop("sid-evt", None)
-        SessionManager._conversation_sessions[conversation_id].discard("sid-evt")
+        with SessionManager._lock:
+            SessionManager._sessions.pop("sid-evt", None)
+            SessionManager._conversation_sessions[conversation_id].discard("sid-evt")
 
 
 def test_use_acp_step_rejects_non_boolean_flag(client: FlaskClient):
@@ -400,8 +402,9 @@ def test_acp_step_rejects_duplicate_without_new_user_message(
     session = ConversationSession(id="sid-dupe", conversation_id=conversation_id)
     session.use_acp = True
     session.acp_runtime = AcpSessionRuntime(workspace=tmp_path)
-    SessionManager._sessions["sid-dupe"] = session
-    SessionManager._conversation_sessions[conversation_id].add("sid-dupe")
+    with SessionManager._lock:
+        SessionManager._sessions["sid-dupe"] = session
+        SessionManager._conversation_sessions[conversation_id].add("sid-dupe")
 
     try:
         # First run consumes pending user message(s)
@@ -418,8 +421,9 @@ def test_acp_step_rejects_duplicate_without_new_user_message(
         err = session.events[-1]
         assert "No new user message" in str(err)
     finally:
-        SessionManager._sessions.pop("sid-dupe", None)
-        SessionManager._conversation_sessions[conversation_id].discard("sid-dupe")
+        with SessionManager._lock:
+            SessionManager._sessions.pop("sid-dupe", None)
+            SessionManager._conversation_sessions[conversation_id].discard("sid-dupe")
 
 
 def test_acp_step_processes_all_pending_user_messages(
@@ -455,8 +459,9 @@ def test_acp_step_processes_all_pending_user_messages(
     session = ConversationSession(id="sid-pending", conversation_id=conversation_id)
     session.use_acp = True
     session.acp_runtime = AcpSessionRuntime(workspace=tmp_path)
-    SessionManager._sessions["sid-pending"] = session
-    SessionManager._conversation_sessions[conversation_id].add("sid-pending")
+    with SessionManager._lock:
+        SessionManager._sessions["sid-pending"] = session
+        SessionManager._conversation_sessions[conversation_id].add("sid-pending")
 
     try:
         _run(sessions_mod._acp_step(conversation_id, session, tmp_path))
@@ -479,8 +484,11 @@ def test_acp_step_processes_all_pending_user_messages(
         assert session.events[-1]["type"] == "error"
         assert "No new user message" in str(session.events[-1])
     finally:
-        SessionManager._sessions.pop("sid-pending", None)
-        SessionManager._conversation_sessions[conversation_id].discard("sid-pending")
+        with SessionManager._lock:
+            SessionManager._sessions.pop("sid-pending", None)
+            SessionManager._conversation_sessions[conversation_id].discard(
+                "sid-pending"
+            )
 
 
 def test_acp_step_runs_session_start_step_pre_and_turn_post_hooks(
@@ -537,8 +545,9 @@ def test_acp_step_runs_session_start_step_pre_and_turn_post_hooks(
     session = ConversationSession(id="sid-hooks", conversation_id=conversation_id)
     session.use_acp = True
     session.acp_runtime = AcpSessionRuntime(workspace=tmp_path)
-    SessionManager._sessions["sid-hooks"] = session
-    SessionManager._conversation_sessions[conversation_id].add("sid-hooks")
+    with SessionManager._lock:
+        SessionManager._sessions["sid-hooks"] = session
+        SessionManager._conversation_sessions[conversation_id].add("sid-hooks")
 
     try:
         _run(sessions_mod._acp_step(conversation_id, session, tmp_path))
@@ -561,8 +570,9 @@ def test_acp_step_runs_session_start_step_pre_and_turn_post_hooks(
         assert current_conversation_id.get() is None
         assert current_session_id.get() is None
     finally:
-        SessionManager._sessions.pop("sid-hooks", None)
-        SessionManager._conversation_sessions[conversation_id].discard("sid-hooks")
+        with SessionManager._lock:
+            SessionManager._sessions.pop("sid-hooks", None)
+            SessionManager._conversation_sessions[conversation_id].discard("sid-hooks")
 
 
 def test_start_acp_step_thread_propagates_contextvars(monkeypatch, tmp_path):
@@ -648,8 +658,9 @@ def test_acp_step_bridges_generation_progress_events(
     session = ConversationSession(id="sid-stream", conversation_id=conversation_id)
     session.use_acp = True
     session.acp_runtime = AcpSessionRuntime(workspace=tmp_path)
-    SessionManager._sessions["sid-stream"] = session
-    SessionManager._conversation_sessions[conversation_id].add("sid-stream")
+    with SessionManager._lock:
+        SessionManager._sessions["sid-stream"] = session
+        SessionManager._conversation_sessions[conversation_id].add("sid-stream")
 
     try:
         _run(sessions_mod._acp_step(conversation_id, session, tmp_path))
@@ -687,8 +698,9 @@ def test_acp_step_bridges_generation_progress_events(
             final_text = str(final_content)
         assert final_text == "hello world"
     finally:
-        SessionManager._sessions.pop("sid-stream", None)
-        SessionManager._conversation_sessions[conversation_id].discard("sid-stream")
+        with SessionManager._lock:
+            SessionManager._sessions.pop("sid-stream", None)
+            SessionManager._conversation_sessions[conversation_id].discard("sid-stream")
 
 
 @pytest.mark.timeout(15)
@@ -915,8 +927,9 @@ def test_health_check_cleans_dead_subprocess(monkeypatch, tmp_path):
     )()
     session.acp_runtime = runtime
 
-    SessionManager._sessions["dead-session"] = session
-    SessionManager._conversation_sessions["conv-dead"].add("dead-session")
+    with SessionManager._lock:
+        SessionManager._sessions["dead-session"] = session
+        SessionManager._conversation_sessions["conv-dead"].add("dead-session")
 
     try:
         _run_health_check()
@@ -925,8 +938,9 @@ def test_health_check_cleans_dead_subprocess(monkeypatch, tmp_path):
         assert "dead-session" not in SessionManager._sessions
     finally:
         # Cleanup in case test failed
-        SessionManager._sessions.pop("dead-session", None)
-        SessionManager._conversation_sessions.pop("conv-dead", None)
+        with SessionManager._lock:
+            SessionManager._sessions.pop("dead-session", None)
+            SessionManager._conversation_sessions.pop("conv-dead", None)
 
 
 def test_health_check_skips_generating_sessions(monkeypatch, tmp_path):
@@ -951,8 +965,9 @@ def test_health_check_skips_generating_sessions(monkeypatch, tmp_path):
     )()
     session.acp_runtime = runtime
 
-    SessionManager._sessions["gen-session"] = session
-    SessionManager._conversation_sessions["conv-gen"].add("gen-session")
+    with SessionManager._lock:
+        SessionManager._sessions["gen-session"] = session
+        SessionManager._conversation_sessions["conv-gen"].add("gen-session")
 
     try:
         _run_health_check()
@@ -960,8 +975,9 @@ def test_health_check_skips_generating_sessions(monkeypatch, tmp_path):
         # Session should still be present (generating flag protects it)
         assert "gen-session" in SessionManager._sessions
     finally:
-        SessionManager._sessions.pop("gen-session", None)
-        SessionManager._conversation_sessions.pop("conv-gen", None)
+        with SessionManager._lock:
+            SessionManager._sessions.pop("gen-session", None)
+            SessionManager._conversation_sessions.pop("conv-gen", None)
 
 
 def test_health_monitor_start_stop():
@@ -973,9 +989,9 @@ def test_health_monitor_start_stop():
 
     # Start with short interval for testing
     start_acp_health_monitor(interval=1)
-
-    # Starting again should be a no-op
-    start_acp_health_monitor(interval=1)
-
-    # Stop should clean up
-    stop_acp_health_monitor()
+    try:
+        # Starting again should be a no-op
+        start_acp_health_monitor(interval=1)
+    finally:
+        # Stop should clean up; always run so the thread never leaks on failure
+        stop_acp_health_monitor()


### PR DESCRIPTION
## Summary

Fixes the `RuntimeError: dictionary changed size during iteration` teardown-flake class (thread-audit, server-extras instance, closes #3253).

Three interlocking changes:

- **`tests/conftest.py`** — Add `autouse=True` fixture `cleanup_acp_health_monitor` that after every test calls `stop_acp_health_monitor()` and clears `SessionManager._sessions` / `_conversation_sessions` under `SessionManager._lock`. The health monitor is a module-level singleton: the first test to start it leaks the thread for the rest of the xdist worker's life, racing with any direct `_sessions` write in a later test.

- **`tests/test_acp_session_runtime.py`** — Wrap all 14 direct `SessionManager._sessions[...] = ...` / `.pop()` / `.discard()` writes with `with SessionManager._lock:`. The health-monitor thread iterates `_sessions` under this lock; without symmetric locking in the test code, any concurrent write triggers the race. Also wrap `test_health_monitor_start_stop` in `try/finally` so `stop_acp_health_monitor()` is always called even if an assertion fails.

- **`gptme/server/session_models.py`** — Iterate `list(cls._sessions.items())` in `clean_inactive_sessions` as a belt-and-suspenders snapshot so the loop stays safe even if the lock scope is ever narrowed in future refactors.

## Test plan

- [x] `tests/test_acp_session_runtime.py` — all 27 tests pass
- [x] `tests/test_server_session_models.py` — all 76 tests pass

<!-- gptme-id:v1:gai_xPrVcV4FTmp0d9TqbMnS8zr76VTralMq12JhHUFwAt7 -->