### PR TITLE
fix(test): replace slow_stream timing hack with deterministic gate in TUI queue test

### DIFF
--- a/tests/test_tui_e2e.py
+++ b/tests/test_tui_e2e.py
@@ -153,33 +153,49 @@ async def test_e2e_tool_skip(mock_app, tmp_path):
 @pytest.mark.asyncio
 async def test_e2e_queue_dispatches_after_turn(mock_app, monkeypatch):
     """Prompts queued while generating are submitted when the turn ends."""
+    import threading
+
     import gptme.llm.llm_mock as llm_mock
 
     app = mock_app
     orig_stream = llm_mock.stream
 
-    def slow_stream(*args, **kwargs):
+    # Gate that holds the first stream open until after we verify the queue.
+    # time.sleep()-based delays are unreliable: the Textual event loop can
+    # process the worker-done message during await pilot.pause(), clearing the
+    # queue before our assertion runs. A threading.Event is deterministic.
+    first_turn_gate = threading.Event()
+    call_count = 0
+
+    def gated_stream(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        is_first = call_count == 1
+
         def gen():
-            for chunk in orig_stream(*args, **kwargs):
-                time.sleep(0.25)
-                yield chunk
+            if is_first:
+                first_turn_gate.wait(timeout=10)  # block until test releases
+            yield from orig_stream(*args, **kwargs)
 
         return gen()
 
-    monkeypatch.setattr(llm_mock, "stream", slow_stream)
+    monkeypatch.setattr(llm_mock, "stream", gated_stream)
 
     async with app.run_test(size=(100, 40)) as pilot:
         await pilot.pause()
         inp = app.query_one("#input", ChatInput)
         inp.text = "first message please"
         await pilot.press("enter")
-        # generating is set synchronously on submit; the slowed stream keeps
-        # the turn busy while we queue the next prompt
+        # generating is set synchronously on submit; the gate holds the first
+        # stream open so we can safely queue the next prompt and assert
         assert app.generating
         inp.text = "second message please"
         await pilot.press("enter")
         await pilot.pause()
         assert app.prompt_queue == ["second message please"]
+        # Release the gate: first stream completes, generation ends, queued
+        # prompt is dispatched
+        first_turn_gate.set()
         await wait_for(
             pilot,
             lambda: (

--- a/tests/test_tui_e2e.py
+++ b/tests/test_tui_e2e.py
@@ -174,7 +174,7 @@ async def test_e2e_queue_dispatches_after_turn(mock_app, monkeypatch):
 
         def gen():
             if is_first:
-                first_turn_gate.wait(timeout=10)  # block until test releases
+                first_turn_gate.wait()  # block until test releases
             yield from orig_stream(*args, **kwargs)
 
         return gen()


### PR DESCRIPTION
## Summary

- **Root cause**: `test_e2e_queue_dispatches_after_turn` was using `time.sleep(0.25)` per stream chunk to keep generation busy while asserting the prompt queue. The mock model emits 4 words for "Echo: first message please", so total hold time is ~1 s. Textual's `await pilot.pause()` (plus the worker thread's `call_from_thread` notifications) can process the generation-done event during that window, clearing the queue before the assertion runs — yielding `AssertionError: assert [] == ['second message please']` on attempt-1 (the `KeyError: StashKey` on attempt-2 is a pytest-retry×pytest-9 machinery artefact, not the real failure).
- **Fix**: Replace `slow_stream` with a `threading.Event` gate (`first_turn_gate`). The first stream blocks on `gate.wait(timeout=10)` until the test explicitly calls `gate.set()` *after* checking the queue. Generation is guaranteed to still be in progress during the queue assertion, making it race-free.

## Test plan

- [x] `test_e2e_queue_dispatches_after_turn` passes deterministically (was: 1/3 runs failing)
- [x] All 4 non-tmux TUI tests pass: `test_e2e_generation_streams_and_renders`, `test_e2e_tool_confirm_execute`, `test_e2e_tool_skip`, `test_e2e_queue_dispatches_after_turn`
- [x] Pre-commit hooks pass (ruff, mypy, shellcheck)

Fixes ErikBjare/bob#1084 (gptme CI: test_e2e_queue_dispatches_after_turn failing with KeyError StashKey).