### PR TITLE
fix(test): suppress pytest-retry StashKey teardown errors

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -120,10 +120,16 @@ def pytest_configure(config):
 @pytest.hookimpl(wrapper=True)
 def pytest_runtest_makereport(item, call):
     """Convert API quota/rate-limit failures to skips for requires_api tests.
+    Also suppresses pytest-retry × pytest≥9.1 StashKey teardown errors.
 
     The session-start quota check may pass with a tiny haiku call, but the
     actual test can hit quota limits with heavier models or longer generations.
     This hook catches those mid-run failures and converts them to skips.
+
+    For the StashKey case: when pytest-retry retries a test that uses tmp_path,
+    pytest≥9.1's stash-based tmp_path tracking loses its key during teardown of
+    the retried attempt. The test body itself passed; treat the teardown as
+    passed to prevent a spurious CI ERROR from masking the real result.
     """
     report = yield
 
@@ -137,6 +143,25 @@ def pytest_runtest_makereport(item, call):
         if any(pattern in error_str for pattern in _QUOTA_ERROR_PATTERNS):
             report.outcome = "skipped"
             report.longrepr = f"API quota exhausted or invalid credentials during test: {call.excinfo.value}"
+
+    # pytest-retry × pytest≥9.1 compat: tmp_path (and caplog) stash keys are
+    # populated by pytest's fixture machinery during the first (failed) attempt.
+    # When pytest-retry re-runs the test body without a full fixture re-setup,
+    # the stash entry is absent during teardown of the retried (passing) attempt,
+    # producing KeyError: <_pytest.stash.StashKey object at 0x...>.
+    # The test itself passed; converting teardown to "passed" avoids surfacing
+    # this infrastructure artifact as a CI ERROR.
+    if report.when == "teardown" and report.failed:
+        longrepr_str = str(report.longrepr)
+        if "StashKey" in longrepr_str and "KeyError" in longrepr_str:
+            logger.warning(
+                "Suppressed pytest-retry × pytest≥9.1 StashKey teardown error "
+                "for %s — the test body passed; this is a known infrastructure "
+                "artifact (see ErikBjare/bob#1084)",
+                item.nodeid,
+            )
+            report.outcome = "passed"
+            report.longrepr = None
 
     return report
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -120,16 +120,17 @@ def pytest_configure(config):
 @pytest.hookimpl(wrapper=True)
 def pytest_runtest_makereport(item, call):
     """Convert API quota/rate-limit failures to skips for requires_api tests.
-    Also suppresses pytest-retry × pytest≥9.1 StashKey teardown errors.
+    Also suppresses pytest-retry StashKey teardown errors.
 
     The session-start quota check may pass with a tiny haiku call, but the
     actual test can hit quota limits with heavier models or longer generations.
     This hook catches those mid-run failures and converts them to skips.
 
     For the StashKey case: when pytest-retry retries a test that uses tmp_path,
-    pytest≥9.1's stash-based tmp_path tracking loses its key during teardown of
-    the retried attempt. The test body itself passed; treat the teardown as
-    passed to prevent a spurious CI ERROR from masking the real result.
+    pytest's stash-based fixture tracking loses its key during teardown of the
+    retried attempt (an architectural issue in pytest-retry, not version-specific).
+    The test body itself passed; treat the teardown as passed to prevent a
+    spurious CI ERROR from masking the real result.
     """
     report = yield
 
@@ -153,7 +154,7 @@ def pytest_runtest_makereport(item, call):
         )
         item._stash_guard_call_passed = report.passed
 
-    # pytest-retry × pytest≥9.1 compat: tmp_path (and caplog) stash keys are
+    # pytest-retry compat: tmp_path (and caplog) stash keys are
     # populated by pytest's fixture machinery during the first (failed) attempt.
     # When pytest-retry re-runs the test body without a full fixture re-setup,
     # the stash entry is absent during teardown of the retried (passing) attempt,
@@ -171,7 +172,8 @@ def pytest_runtest_makereport(item, call):
         longrepr_str = str(report.longrepr)
         if "_pytest.stash.StashKey" in longrepr_str and "KeyError" in longrepr_str:
             logger.warning(
-                "Suppressed pytest-retry × pytest≥9.1 StashKey teardown error "
+                "Suppressed pytest-retry StashKey teardown error (known "
+                "infrastructure artifact, not version-specific) "
                 "for %s — the test body passed; this is a known infrastructure "
                 "artifact (see ErikBjare/bob#1084)",
                 item.nodeid,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -144,16 +144,26 @@ def pytest_runtest_makereport(item, call):
             report.outcome = "skipped"
             report.longrepr = f"API quota exhausted or invalid credentials during test: {call.excinfo.value}"
 
+    # Track call-phase outcome so the teardown guard below can verify the test
+    # body actually passed before suppressing any teardown error.
+    if report.when == "call":
+        item._stash_guard_call_passed = report.passed
+
     # pytest-retry × pytest≥9.1 compat: tmp_path (and caplog) stash keys are
     # populated by pytest's fixture machinery during the first (failed) attempt.
     # When pytest-retry re-runs the test body without a full fixture re-setup,
     # the stash entry is absent during teardown of the retried (passing) attempt,
     # producing KeyError: <_pytest.stash.StashKey object at 0x...>.
-    # The test itself passed; converting teardown to "passed" avoids surfacing
-    # this infrastructure artifact as a CI ERROR.
-    if report.when == "teardown" and report.failed:
+    # Guard: only suppress when (a) the test body passed and (b) the error is
+    # specifically from _pytest.stash internals — avoids masking genuine fixture
+    # teardown bugs that happen to involve a KeyError (Greptile P1).
+    if (
+        report.when == "teardown"
+        and report.failed
+        and getattr(item, "_stash_guard_call_passed", False)
+    ):
         longrepr_str = str(report.longrepr)
-        if "StashKey" in longrepr_str and "KeyError" in longrepr_str:
+        if "_pytest.stash.StashKey" in longrepr_str and "KeyError" in longrepr_str:
             logger.warning(
                 "Suppressed pytest-retry × pytest≥9.1 StashKey teardown error "
                 "for %s — the test body passed; this is a known infrastructure "

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -144,9 +144,13 @@ def pytest_runtest_makereport(item, call):
             report.outcome = "skipped"
             report.longrepr = f"API quota exhausted or invalid credentials during test: {call.excinfo.value}"
 
-    # Track call-phase outcome so the teardown guard below can verify the test
-    # body actually passed before suppressing any teardown error.
+    # Count call-phase attempts so the teardown guard below can verify the test
+    # was actually retried (not just that a single passing call existed). Track
+    # whether the last call passed so we know the retry succeeded.
     if report.when == "call":
+        item._stash_guard_call_attempts = (
+            getattr(item, "_stash_guard_call_attempts", 0) + 1
+        )
         item._stash_guard_call_passed = report.passed
 
     # pytest-retry × pytest≥9.1 compat: tmp_path (and caplog) stash keys are
@@ -154,12 +158,14 @@ def pytest_runtest_makereport(item, call):
     # When pytest-retry re-runs the test body without a full fixture re-setup,
     # the stash entry is absent during teardown of the retried (passing) attempt,
     # producing KeyError: <_pytest.stash.StashKey object at 0x...>.
-    # Guard: only suppress when (a) the test body passed and (b) the error is
-    # specifically from _pytest.stash internals — avoids masking genuine fixture
-    # teardown bugs that happen to involve a KeyError (Greptile P1).
+    # Three-way guard to avoid masking genuine teardown failures (Greptile P1):
+    #   (a) test was actually retried (>1 call attempts seen by this hook)
+    #   (b) the last call attempt passed (retry succeeded)
+    #   (c) the error is specifically from _pytest.stash internals
     if (
         report.when == "teardown"
         and report.failed
+        and getattr(item, "_stash_guard_call_attempts", 0) > 1
         and getattr(item, "_stash_guard_call_passed", False)
     ):
         longrepr_str = str(report.longrepr)


### PR DESCRIPTION
## Summary

- Adds a guard in `pytest_runtest_makereport` that catches `KeyError: <_pytest.stash.StashKey object>` during teardown of retried tests
- Converts these infrastructure artifacts to `passed` reports (with a warning log) rather than surfacing them as CI ERRORs
- Generalizes protection beyond `test_e2e_queue_dispatches_after_turn` to cover any `tmp_path`-using test that retries

## Background

When pytest-retry retries a test that uses `tmp_path` (or `caplog`), pytest's stash-based fixture tracking loses its key during teardown of the retried (passing) attempt. This is an architectural issue in pytest-retry — it does not do a full fixture re-setup between retry attempts — and is not version-specific (see str0zzapreti/pytest-retry#46).

The test body itself passed — the teardown `KeyError` is a known pytest-retry compatibility issue.

This was responsible for ErikBjare/bob#1084 (CI blinking red with `KeyError: <_pytest.stash.StashKey...>` after the underlying test flakiness was fixed in #3255 and #3254).

## Three-way guard

The guard only fires when all three conditions hold, to avoid masking genuine teardown failures:
- (a) call attempts counter > 1 (test was actually retried)
- (b) last call passed (retry succeeded)
- (c) error string matches `_pytest.stash.StashKey` + `KeyError`

## What is NOT changed

The underlying test flakiness was already fixed separately:
- **#3255**: Replaced `slow_stream` timing hack with deterministic `threading.Event` gate
- **#3254**: Stopped ACP health-monitor thread leaks and SessionManager dict-mutation races

This PR adds the infrastructure-level guard so the symptom can't recur for any `tmp_path`-using test that becomes flaky under retry.

## Test plan

- [x] All `tests/test_tui_e2e.py` tests pass locally (4 passed in 5.02s)
- [x] Pre-commit hooks pass
- [x] CI passes