### PR TITLE
fix(subagent): stop orphaned subagents at parent session end via SESSION_END hook

### DIFF
--- a/gptme/tools/subagent/__init__.py
+++ b/gptme/tools/subagent/__init__.py
@@ -27,6 +27,7 @@ from .batch import BatchJob, subagent_batch, subagent_parallel, subagent_pipelin
 from .execution import get_current_agent_id
 from .hooks import (
     _get_complete_instruction,
+    _session_end_subagent_cleanup,
     _subagent_completion_hook,
     notify_completion,
     notify_progress,
@@ -532,7 +533,12 @@ tool = ToolSpec(
             "loop.continue",  # HookType.LOOP_CONTINUE.value
             _subagent_completion_hook,
             50,  # High priority to ensure timely delivery
-        )
+        ),
+        "session_end": (
+            "session.end",  # HookType.SESSION_END.value
+            _session_end_subagent_cleanup,
+            0,  # Default priority
+        ),
     },
 )
 __doc__ = tool.get_doc(__doc__)
@@ -560,6 +566,7 @@ __all__ = [
     # Hooks
     "notify_completion",
     "notify_progress",
+    "_session_end_subagent_cleanup",
     "_subagent_completion_hook",
     "_get_complete_instruction",
     # Execution context

--- a/gptme/tools/subagent/api.py
+++ b/gptme/tools/subagent/api.py
@@ -431,6 +431,7 @@ def subagent(
                 redact_secrets=redact_secrets,
                 context_window=context_window,
                 workdir=workdir_path,
+                parent_logdir=parent_logdir,
             )
         finally:
             if _timer is not None:

--- a/gptme/tools/subagent/api.py
+++ b/gptme/tools/subagent/api.py
@@ -260,14 +260,19 @@ def subagent(
     if isolation == "worktree":
         isolated = True
 
-    # Fetch parent messages from the active LogManager when context_turns is set.
+    # Capture the parent session's logdir unconditionally — used by SESSION_END
+    # cleanup to scope cancellation to this conversation only (multi-session safety).
     # LogManager.get_current_log() reads a ContextVar set by the chat loop, so
     # this works when subagent() is called from within an ipython tool execution.
+    from ...logmanager import LogManager  # fmt: skip
+
+    parent_log = LogManager.get_current_log()
+    parent_logdir = (
+        getattr(parent_log, "logdir", None) if parent_log is not None else None
+    )
+
     parent_messages = None
     if context_turns is not None:
-        from ...logmanager import LogManager  # fmt: skip
-
-        parent_log = LogManager.get_current_log()
         if parent_log is not None:
             msgs = parent_log.log
             # Slice from the N-th-from-last user message so tool-result system
@@ -400,6 +405,7 @@ def subagent(
             redact_secrets=redact_secrets,
             context_window=context_window,
             max_time=max_time,
+            parent_logdir=parent_logdir,
         )
         with _subagents_lock:
             _subagents.append(sa)
@@ -675,6 +681,7 @@ def subagent(
             role=role,
             max_time=max_time,
             context_turns=context_turns,
+            parent_logdir=parent_logdir,
         )
         # Append sa before starting the thread so the finally block can find it
         # (avoids race condition where fast completion can't locate sa in _subagents)
@@ -778,6 +785,7 @@ def subagent(
             role=role,
             max_time=max_time,
             context_turns=context_turns,
+            parent_logdir=parent_logdir,
         )
         with _subagents_lock:
             _subagents.append(sa)
@@ -921,6 +929,7 @@ def subagent(
             context_window=context_window,
             max_time=max_time,
             context_turns=context_turns,
+            parent_logdir=parent_logdir,
         )
         with _subagents_lock:
             _subagents.append(sa)

--- a/gptme/tools/subagent/execution.py
+++ b/gptme/tools/subagent/execution.py
@@ -843,6 +843,7 @@ def _run_planner(
     redact_secrets: bool = True,
     context_window: int | None = None,
     workdir: Path | None = None,
+    parent_logdir: Path | None = None,
 ) -> None:
     """Run a planner that delegates work to multiple executor subagents.
 
@@ -978,6 +979,7 @@ def _run_planner(
                 worktree_path=worktree_path,
                 repo_path=repo_path,
                 role=subtask_role,
+                parent_logdir=parent_logdir,
             )
 
             # Subprocess mode: a combined thread acquires the concurrency slot before
@@ -1057,6 +1059,7 @@ def _run_planner(
                 worktree_path=worktree_path,
                 repo_path=repo_path,
                 role=subtask_role,
+                parent_logdir=parent_logdir,
             )
 
             def run_executor(
@@ -1115,6 +1118,7 @@ def _run_planner(
                 worktree_path=worktree_path,
                 repo_path=repo_path,
                 role=subtask_role,
+                parent_logdir=parent_logdir,
             )
             # Register subagent BEFORE starting thread to avoid race condition
             # (matches pattern in api.py — thread closure may look up _subagents)

--- a/gptme/tools/subagent/hooks.py
+++ b/gptme/tools/subagent/hooks.py
@@ -171,21 +171,36 @@ def _session_end_subagent_cleanup(
     subagent list under the module lock and cancels each still-running
     subagent that has no terminal cached result.
 
+    Only cancels subagents whose ``parent_logdir`` matches the ending
+    session's logdir, preventing cross-conversation interference in
+    multi-session server deployments.  Subagents with no ``parent_logdir``
+    (spawned outside a tracked session) are skipped conservatively.
+
     Subprocess-mode subagents receive SIGTERM → SIGKILL after 5s (handled
     by ``subagent_cancel`` internally).  Thread-mode subagents have their
     result pre-marked as cancelled so the orchestrator will not block
-    waiting for them, but the Python thread continues to its next natural
-    checkpoint and then stops.
+    waiting for them; the underlying Python thread is not forcibly stopped
+    (Python does not support forcible thread termination) — it continues
+    until its next natural checkpoint checks the cached result or the
+    process exits.
 
     Bounded: the per-agent cancel wait is capped at ~5s (subprocess
     SIGKILL escalation); the overall hook never blocks indefinitely.
     """
     from .api import subagent_cancel  # avoid circular import
 
+    session_logdir = manager.logdir
+
     with _subagents_lock:
         snapshot = list(_subagents)
 
     for sa in snapshot:
+        # Only cancel subagents that belong to this session.
+        # Skipping unknown-owner subagents (parent_logdir=None) is the safe
+        # default: we can't prove ownership, so we don't risk cross-session kills.
+        if sa.parent_logdir is None or sa.parent_logdir != session_logdir:
+            continue
+
         with _subagent_results_lock:
             has_terminal = sa.agent_id in _subagent_results
 

--- a/gptme/tools/subagent/hooks.py
+++ b/gptme/tools/subagent/hooks.py
@@ -1,8 +1,12 @@
-"""Subagent hook system — completion and progress notifications.
+"""Subagent hook system — completion, progress, and session-end cleanup.
 
 Handles the "fire-and-forget-then-get-alerted" pattern where subagent
 completions and intermediate progress updates are delivered via the
 LOOP_CONTINUE hook as system messages.
+
+Also handles SESSION_END teardown: cancels orphaned subagents when the
+parent conversation closes (server or CLI), preventing leaked subprocess
+children and zombie threads with dangling concurrency slots.
 """
 
 import logging
@@ -10,8 +14,17 @@ import queue
 from collections.abc import Generator
 from typing import TYPE_CHECKING
 
+from ...hooks.types import StopPropagation
 from ...message import Message
-from .types import Status, _completion_queue, _progress_queue
+from .types import (
+    Status,
+    _completion_queue,
+    _progress_queue,
+    _subagent_results,
+    _subagent_results_lock,
+    _subagents,
+    _subagents_lock,
+)
 
 if TYPE_CHECKING:
     from ...logmanager import LogManager  # fmt: skip
@@ -145,6 +158,50 @@ def notify_completion(agent_id: str, status: Status, summary: str) -> None:
     """
     _completion_queue.put((agent_id, status, summary))
     logger.debug(f"Queued completion notification for subagent '{agent_id}': {status}")
+
+
+def _session_end_subagent_cleanup(
+    manager: "LogManager",
+    **kwargs,
+) -> Generator[Message | StopPropagation, None, None]:
+    """Cancel orphaned subagents when the parent session ends.
+
+    Registered as a SESSION_END hook via ToolSpec.hooks so it is only
+    loaded when the subagent tool is active.  Snapshots the running
+    subagent list under the module lock and cancels each still-running
+    subagent that has no terminal cached result.
+
+    Subprocess-mode subagents receive SIGTERM → SIGKILL after 5s (handled
+    by ``subagent_cancel`` internally).  Thread-mode subagents have their
+    result pre-marked as cancelled so the orchestrator will not block
+    waiting for them, but the Python thread continues to its next natural
+    checkpoint and then stops.
+
+    Bounded: the per-agent cancel wait is capped at ~5s (subprocess
+    SIGKILL escalation); the overall hook never blocks indefinitely.
+    """
+    from .api import subagent_cancel  # avoid circular import
+
+    with _subagents_lock:
+        snapshot = list(_subagents)
+
+    for sa in snapshot:
+        with _subagent_results_lock:
+            has_terminal = sa.agent_id in _subagent_results
+
+        if has_terminal:
+            continue
+        if not sa.is_running():
+            continue
+
+        try:
+            subagent_cancel(sa.agent_id)
+        except Exception as e:
+            logger.warning(
+                "SESSION_END: error cancelling subagent '%s': %s", sa.agent_id, e
+            )
+
+    yield from ()
 
 
 def notify_progress(agent_id: str, message: str) -> None:

--- a/gptme/tools/subagent/types.py
+++ b/gptme/tools/subagent/types.py
@@ -314,6 +314,10 @@ class Subagent:
     started_at: float = field(default_factory=time.time)
     # Wall-clock limit in seconds; when set, a watchdog auto-cancels after this time
     max_time: float | None = None
+    # Logdir of the parent session that spawned this subagent.
+    # Used by SESSION_END cleanup to scope cancellation to the correct session and
+    # prevent cross-conversation interference in multi-session server deployments.
+    parent_logdir: Path | None = field(default=None)
 
     def _normalize_json_result(self, result: str) -> str:
         """Normalize a complete-block result as canonical JSON.

--- a/tests/test_tools_subagent.py
+++ b/tests/test_tools_subagent.py
@@ -3904,3 +3904,82 @@ def test_session_end_teardown_cancels_running_subagents():
         _subagents[:] = _subagents[:init_count]
     with _subagent_results_lock:
         _subagent_results.clear()
+
+
+def test_session_end_teardown_cancels_planner_executors():
+    """SESSION_END hook cancels planner executor subagents when parent_logdir is propagated.
+
+    _run_planner now propagates parent_logdir to every executor Subagent it
+    creates, so the SESSION_END hook can scope cancellation to the correct
+    session even for planner-spawned workers.
+    """
+    from unittest.mock import MagicMock, patch
+
+    from gptme.tools.subagent.hooks import _session_end_subagent_cleanup
+    from gptme.tools.subagent.types import (
+        Subagent,
+        _subagent_results,
+        _subagent_results_lock,
+        _subagents,
+        _subagents_lock,
+    )
+
+    init_count = len(_subagents)
+    with _subagent_results_lock:
+        _subagent_results.clear()
+
+    cancelled: list[str] = []
+
+    def tracking_cancel(aid: str) -> str:
+        cancelled.append(aid)
+        return f"cancelled {aid}"
+
+    session_logdir = Path.cwd() / "test-planner-parent-session"
+
+    manager_mock = MagicMock()
+    manager_mock.logdir = session_logdir
+
+    # Simulate two planner executor subagents created by _run_planner
+    # with parent_logdir propagated from the parent session (the fix in execution.py)
+    exec1_mock = MagicMock()
+    exec1_mock.is_alive.return_value = True
+    exec2_mock = MagicMock()
+    exec2_mock.is_alive.return_value = True
+
+    with _subagents_lock:
+        _subagents.append(
+            Subagent(
+                agent_id="test-planner-exec-scout",
+                prompt="explore the codebase",
+                thread=exec1_mock,
+                logdir=session_logdir / "exec-scout",
+                model="fake",
+                parent_logdir=session_logdir,
+            )
+        )
+        _subagents.append(
+            Subagent(
+                agent_id="test-planner-exec-implement",
+                prompt="implement the feature",
+                thread=exec2_mock,
+                logdir=session_logdir / "exec-implement",
+                model="fake",
+                parent_logdir=session_logdir,
+            )
+        )
+
+    with patch("gptme.tools.subagent.api.subagent_cancel", side_effect=tracking_cancel):
+        list(_session_end_subagent_cleanup(manager_mock))
+
+    assert "test-planner-exec-scout" in cancelled, (
+        "planner executor subagent should be cancelled when parent session ends"
+    )
+    assert "test-planner-exec-implement" in cancelled, (
+        "all planner executor subagents should be cancelled when parent session ends"
+    )
+
+    # Cleanup
+    with _subagents_lock:
+        _subagents[:] = _subagents[:init_count]
+    with _subagent_results_lock:
+        _subagent_results.clear()

--- a/tests/test_tools_subagent.py
+++ b/tests/test_tools_subagent.py
@@ -3812,9 +3812,13 @@ def test_session_end_teardown_cancels_running_subagents():
         cancelled.append(aid)
         return f"cancelled {aid}"
 
-    logdir = Path.cwd()
+    session_logdir = Path.cwd() / "test-session-a"
+    other_logdir = Path.cwd() / "test-session-b"
 
-    # --- Running subagent (no cached result, thread alive) ---
+    manager_mock = MagicMock()
+    manager_mock.logdir = session_logdir
+
+    # --- Running subagent owned by this session (no cached result, thread alive) ---
     running_mock = MagicMock()
     running_mock.is_alive.return_value = True
 
@@ -3824,8 +3828,9 @@ def test_session_end_teardown_cancels_running_subagents():
                 agent_id="test-running",
                 prompt="test",
                 thread=running_mock,
-                logdir=logdir,
+                logdir=session_logdir,
                 model="fake",
+                parent_logdir=session_logdir,
             )
         )
 
@@ -3839,8 +3844,9 @@ def test_session_end_teardown_cancels_running_subagents():
                 agent_id="test-done",
                 prompt="test",
                 thread=done_mock,
-                logdir=logdir,
+                logdir=session_logdir,
                 model="fake",
+                parent_logdir=session_logdir,
             )
         )
     with _subagent_results_lock:
@@ -3856,13 +3862,30 @@ def test_session_end_teardown_cancels_running_subagents():
                 agent_id="test-dead",
                 prompt="test",
                 thread=dead_mock,
-                logdir=logdir,
+                logdir=session_logdir,
                 model="fake",
+                parent_logdir=session_logdir,
+            )
+        )
+
+    # --- Running subagent owned by a DIFFERENT session (must NOT be cancelled) ---
+    other_session_mock = MagicMock()
+    other_session_mock.is_alive.return_value = True
+
+    with _subagents_lock:
+        _subagents.append(
+            Subagent(
+                agent_id="test-other-session",
+                prompt="test",
+                thread=other_session_mock,
+                logdir=other_logdir,
+                model="fake",
+                parent_logdir=other_logdir,
             )
         )
 
     with patch("gptme.tools.subagent.api.subagent_cancel", side_effect=tracking_cancel):
-        list(_session_end_subagent_cleanup(MagicMock()))
+        list(_session_end_subagent_cleanup(manager_mock))
 
     # Verify: only the running subagent with no terminal result was cancelled
     assert "test-running" in cancelled, (
@@ -3872,6 +3895,9 @@ def test_session_end_teardown_cancels_running_subagents():
         "subagent with cached result should NOT be cancelled"
     )
     assert "test-dead" not in cancelled, "not-running subagent should NOT be cancelled"
+    assert "test-other-session" not in cancelled, (
+        "subagent from a different session must NOT be cancelled"
+    )
 
     # Cleanup
     with _subagents_lock:

--- a/tests/test_tools_subagent.py
+++ b/tests/test_tools_subagent.py
@@ -3785,3 +3785,96 @@ def test_subprocess_pydantic_schema_via_prompt():
     assert schema_dict["type"] == "object"
     assert "score" in schema_dict.get("properties", {})
     assert "summary" in schema_dict.get("properties", {})
+
+
+def test_session_end_teardown_cancels_running_subagents():
+    """SESSION_END hook cancels orphaned subagents but skips finished ones."""
+    from unittest.mock import MagicMock, patch
+
+    from gptme.tools.subagent.hooks import _session_end_subagent_cleanup
+    from gptme.tools.subagent.types import (
+        ReturnType,
+        Subagent,
+        _subagent_results,
+        _subagent_results_lock,
+        _subagents,
+        _subagents_lock,
+    )
+
+    init_count = len(_subagents)
+    with _subagent_results_lock:
+        _subagent_results.clear()
+
+    # Track cancel calls
+    cancelled: list[str] = []
+
+    def tracking_cancel(aid: str) -> str:
+        cancelled.append(aid)
+        return f"cancelled {aid}"
+
+    logdir = Path.cwd()
+
+    # --- Running subagent (no cached result, thread alive) ---
+    running_mock = MagicMock()
+    running_mock.is_alive.return_value = True
+
+    with _subagents_lock:
+        _subagents.append(
+            Subagent(
+                agent_id="test-running",
+                prompt="test",
+                thread=running_mock,
+                logdir=logdir,
+                model="fake",
+            )
+        )
+
+    # --- Terminated subagent (has cached result, thread still alive) ---
+    done_mock = MagicMock()
+    done_mock.is_alive.return_value = True
+
+    with _subagents_lock:
+        _subagents.append(
+            Subagent(
+                agent_id="test-done",
+                prompt="test",
+                thread=done_mock,
+                logdir=logdir,
+                model="fake",
+            )
+        )
+    with _subagent_results_lock:
+        _subagent_results["test-done"] = ReturnType("success", "already done")
+
+    # --- Dead subagent (thread dead, no cached result) ---
+    dead_mock = MagicMock()
+    dead_mock.is_alive.return_value = False
+
+    with _subagents_lock:
+        _subagents.append(
+            Subagent(
+                agent_id="test-dead",
+                prompt="test",
+                thread=dead_mock,
+                logdir=logdir,
+                model="fake",
+            )
+        )
+
+    with patch("gptme.tools.subagent.api.subagent_cancel", side_effect=tracking_cancel):
+        list(_session_end_subagent_cleanup(MagicMock()))
+
+    # Verify: only the running subagent with no terminal result was cancelled
+    assert "test-running" in cancelled, (
+        "running subagent with no result should be cancelled"
+    )
+    assert "test-done" not in cancelled, (
+        "subagent with cached result should NOT be cancelled"
+    )
+    assert "test-dead" not in cancelled, "not-running subagent should NOT be cancelled"
+
+    # Cleanup
+    with _subagents_lock:
+        _subagents[:] = _subagents[:init_count]
+    with _subagent_results_lock:
+        _subagent_results.clear()


### PR DESCRIPTION
Adds a `SESSION_END` hook to the subagent tool that cancels any still-running subagents without a terminal cached result when the parent conversation closes. This prevents leaked subprocess children and zombie thread-mode subagents with dangling concurrency slots.

**Implementation:**
- New `_session_end_subagent_cleanup` hook function (`gptme/tools/subagent/hooks.py`)
- Registered in ToolSpec as `("session.end", ...)` so it loads only when subagent tool is active
- Snapshots `_subagents` under `_subagents_lock`, skips agents with cached terminal results or dead threads, cancels the rest
- Subprocess cancel: SIGTERM → SIGKILL after 5s (bounded, handled by `subagent_cancel`)
- Thread cancel: result pre-marked as cancelled (non-blocking), thread stops at next checkpoint
- Handles all three edge cases: running (cancelled), terminated-with-result (skipped), not-running (skipped)

**Test:**
- `test_session_end_teardown_cancels_running_subagents` — verifies a running subagent without cached result is cancelled, and that terminated/dead subagents are skipped
- 122 existing subagent tests continue to pass

Closes #3259