### PR TITLE
feat(subagent): cooperative cancel checkpoint — make cancel actually stop thread-mode subagents

### DIFF
--- a/gptme/tools/subagent/__init__.py
+++ b/gptme/tools/subagent/__init__.py
@@ -28,6 +28,7 @@ from .execution import get_current_agent_id
 from .hooks import (
     _get_complete_instruction,
     _session_end_subagent_cleanup,
+    _subagent_cancel_checkpoint,
     _subagent_completion_hook,
     _subagent_control_hook,
     notify_completion,
@@ -574,6 +575,7 @@ __all__ = [
     "notify_progress",
     "_session_end_subagent_cleanup",
     "_subagent_completion_hook",
+    "_subagent_cancel_checkpoint",
     "_get_complete_instruction",
     # Execution context
     "get_current_agent_id",

--- a/gptme/tools/subagent/api.py
+++ b/gptme/tools/subagent/api.py
@@ -37,6 +37,46 @@ from .types import (
 logger = logging.getLogger(__name__)
 
 
+def _write_cancel_op(logdir: Path, agent_id: str) -> None:
+    """Append a cancel op to logdir/control.jsonl for the cooperative checkpoint.
+
+    Uses the same JSONL/flock conventions as prompt_queue.py.
+    The subagent's STEP_PRE checkpoint hook reads this file each step and exits
+    cleanly when it sees a cancel op, releasing its concurrency slot.
+    """
+    import importlib
+    import json
+    from datetime import datetime, timezone
+
+    try:
+        fcntl = importlib.import_module("fcntl")
+    except ImportError:  # Windows / environments without fcntl
+        fcntl = None
+
+    control_file = logdir / "control.jsonl"
+    record = json.dumps(
+        {
+            "op": "cancel",
+            "agent_id": agent_id,
+            "ts": datetime.now(timezone.utc).isoformat(),
+        }
+    )
+
+    lock_file = logdir / ".control.lock"
+    lock_file.parent.mkdir(parents=True, exist_ok=True)
+    lock_file.touch(exist_ok=True)
+
+    with lock_file.open("r+") as lock_fd:
+        if fcntl is not None:
+            fcntl.flock(lock_fd, fcntl.LOCK_EX)
+        try:
+            with control_file.open("a") as f:
+                f.write(record + "\n")
+        finally:
+            if fcntl is not None:
+                fcntl.flock(lock_fd, fcntl.LOCK_UN)
+
+
 def _wait_for_cached_subagent_result(
     agent_id: str, timeout: float = 0.05, poll_interval: float = 0.005
 ) -> ReturnType | None:
@@ -987,10 +1027,15 @@ def _timeout_subagent(agent_id: str, max_time: float) -> None:
 def subagent_cancel(agent_id: str) -> str:
     """Cancel a running subagent.
 
-    For subprocess-mode subagents, sends SIGTERM (then SIGKILL after 5s) to the
-    process. For thread-mode subagents, records a cancellation operation that stops
-    the child at its next step boundary while caching the failure result immediately
-    so callers do not block waiting for it.
+    For subprocess-mode subagents, writes a cancel op to ``logdir/control.jsonl``
+    so the agent's cooperative checkpoint can exit cleanly before SIGTERM arrives,
+    then sends SIGTERM (and SIGKILL after 5s) as escalation.
+
+    For thread-mode subagents, writes the cancel op and marks the result cache so
+    callers don't block.  The thread stops at its next STEP_PRE checkpoint and
+    releases its concurrency slot.
+
+    ACP-mode subagents keep today's cache-mark-only behavior (no control file).
 
     Args:
         agent_id: The subagent to cancel
@@ -1019,6 +1064,11 @@ def subagent_cancel(agent_id: str) -> str:
     if sa.execution_mode == "subprocess" and sa.process:
         if not set_subagent_result_if_absent(agent_id, cancelled_result):
             return f"Subagent '{agent_id}' already finished before cancellation."
+        # Write cancel op so the subprocess checkpoint can exit cleanly before SIGTERM.
+        try:
+            _write_cancel_op(sa.logdir, agent_id)
+        except Exception as e:
+            logger.warning(f"Failed to write cancel op for '{agent_id}': {e}")
         sa.process.terminate()
         try:
             sa.process.wait(timeout=5)
@@ -1027,12 +1077,27 @@ def subagent_cancel(agent_id: str) -> str:
             sa.process.wait()
         logger.info(f"Subagent '{agent_id}' subprocess terminated.")
         return f"Subagent '{agent_id}' cancelled."
-    # Thread/ACP mode: threads cannot be forcefully stopped in Python.
-    # Mark the result so the orchestrator sees it as cancelled immediately.
+    if sa.execution_mode == "thread":
+        # Thread mode: write cancel op so the cooperative STEP_PRE checkpoint stops
+        # the thread cleanly and releases the concurrency slot.
+        if not set_subagent_result_if_absent(agent_id, cancelled_result):
+            return f"Subagent '{agent_id}' already finished before cancellation."
+        try:
+            _write_cancel_op(sa.logdir, agent_id)
+        except Exception as e:
+            logger.warning(f"Failed to write cancel op for '{agent_id}': {e}")
+        logger.info(
+            f"Subagent '{agent_id}' marked cancelled (thread will stop at next checkpoint)."
+        )
+        return (
+            f"Subagent '{agent_id}' marked as cancelled. "
+            "The background thread will stop at its next cooperative checkpoint."
+        )
+    # ACP mode: threads cannot be stopped; keep cache-mark-only behavior.
     if not set_subagent_result_if_absent(agent_id, cancelled_result):
         return f"Subagent '{agent_id}' already finished before cancellation."
     logger.info(
-        f"Subagent '{agent_id}' marked cancelled (thread will stop at next checkpoint)."
+        f"Subagent '{agent_id}' (ACP) marked cancelled (no cooperative checkpoint)."
     )
     return (
         f"Subagent '{agent_id}' marked as cancelled. "

--- a/gptme/tools/subagent/api.py
+++ b/gptme/tools/subagent/api.py
@@ -1052,7 +1052,7 @@ def subagent_cancel(agent_id: str) -> str:
     if not sa.is_running():
         return f"Subagent '{agent_id}' is not running (already finished)."
 
-    cancelled_result = ReturnType("failure", "Cancelled by orchestrator")
+    cancelled_result = ReturnType("cancelled", "Cancelled by orchestrator")
     # Best-effort: write the cancel signal so thread agents stop at their next
     # checkpoint.  If the logdir is unavailable (removed, read-only, etc.) we
     # still proceed with subprocess termination / result-marking below.

--- a/gptme/tools/subagent/batch.py
+++ b/gptme/tools/subagent/batch.py
@@ -422,7 +422,7 @@ class BatchJob:
         done_event = threading.Event()
         first_result: list[tuple[str, ReturnType]] = []
 
-        terminal_statuses = {"success", "failure", "clarification_needed"}
+        terminal_statuses = {"success", "failure", "clarification_needed", "cancelled"}
         deadline = time.monotonic() + timeout
 
         def _wait_one_notify(agent_id: str) -> None:

--- a/gptme/tools/subagent/execution.py
+++ b/gptme/tools/subagent/execution.py
@@ -43,13 +43,14 @@ _thread_local = threading.local()
 
 
 def get_current_agent_id() -> str | None:
-    """Return the agent_id of the currently running subagent thread, or None.
+    """Return the agent_id of the currently running subagent, or None.
 
-    Set by _create_subagent_thread before calling chat(). Used by the progress
-    tool to identify which subagent is sending a progress update.
-    Only populated in thread-mode subagents.
+    Thread-mode subagents: set via _create_subagent_thread (thread-local).
+    Subprocess-mode subagents: set via GPTME_SUBAGENT_AGENT_ID env var.
     """
-    return getattr(_thread_local, "agent_id", None)
+    return getattr(_thread_local, "agent_id", None) or os.environ.get(
+        "GPTME_SUBAGENT_AGENT_ID"
+    )
 
 
 def _ensure_subagent_signal_tools_loaded() -> None:

--- a/gptme/tools/subagent/hooks.py
+++ b/gptme/tools/subagent/hooks.py
@@ -335,3 +335,62 @@ def _subagent_completion_hook(
 
         logger.debug(f"Delivering subagent notification: {msg}")
         yield Message("system", msg)
+
+
+def _subagent_cancel_checkpoint(
+    manager: "LogManager",
+) -> Generator[Message, None, None]:
+    """STEP_PRE cooperative cancel checkpoint for thread-mode subagents.
+
+    Registered at STEP_PRE so it fires before each LLM generation step.
+
+    Fast-path design: two O(1) guards keep overhead minimal for the common case
+    (no cancel, not inside a subagent thread):
+      1. Thread-local check — no-op when called in the parent's loop.
+      2. One stat() per step — no-op when logdir/control.jsonl doesn't exist.
+
+    On cancel op: appends a partial-work note to the conversation, writes
+    ``cancelled`` status to the result cache (first-writer-wins), then raises
+    ``SessionCompleteException`` so ``chat()`` exits cleanly and the thread's
+    semaphore slot is released.
+    """
+    import json
+
+    # Fast path: hook fires in every loop, including the parent's own loop in
+    # thread mode.  Only subagent threads have agent_id set in thread-local.
+    from .execution import get_current_agent_id  # avoid circular at module level
+
+    agent_id = get_current_agent_id()
+    if agent_id is None:
+        return
+
+    # Fast path: one stat() per step — no allocation when no control file.
+    control_file = manager.logdir / "control.jsonl"
+    if not control_file.exists():
+        return
+
+    try:
+        content = control_file.read_text()
+    except OSError:
+        return
+
+    for line in content.splitlines():
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if entry.get("op") == "cancel":
+            # Import here to avoid circular at module level (complete → hooks is safe,
+            # but execution → hooks already creates a cycle if we put it at top).
+            from ..complete import SessionCompleteException
+
+            yield Message(
+                "system",
+                f"Subagent '{agent_id}' received cancel signal — stopping at cooperative checkpoint.",
+            )
+            # First-writer-wins: keeps 'success' if agent already completed naturally.
+            cancelled_result = ReturnType(
+                "cancelled", "Cancelled by orchestrator via checkpoint"
+            )
+            set_subagent_result_if_absent(agent_id, cancelled_result)
+            raise SessionCompleteException("Cancelled at cooperative checkpoint")

--- a/tests/test_subagent_integration.py
+++ b/tests/test_subagent_integration.py
@@ -44,7 +44,7 @@ def clean_subagent_state():
 
 
 class TestCancelLifecycle:
-    """Integration tests: cancel completes within deadline and marks result as failure."""
+    """Integration tests: cancel completes within deadline and marks result as cancelled."""
 
     def _spawn_blocking_subagent(
         self,
@@ -72,8 +72,8 @@ class TestCancelLifecycle:
 
         subagent(agent_id, "do a thing")
 
-    def test_cancel_marks_result_as_failure(self, monkeypatch, tmp_path):
-        """Cancelled subagent result is failure/cancelled within 5 seconds."""
+    def test_cancel_marks_result_as_cancelled(self, monkeypatch, tmp_path):
+        """Cancelled subagent result has status 'cancelled' within 5 seconds."""
         hold = threading.Event()
 
         self._spawn_blocking_subagent("agent-a", hold, monkeypatch, tmp_path)
@@ -90,7 +90,7 @@ class TestCancelLifecycle:
         with _subagent_results_lock:
             result = _subagent_results.get("agent-a")
         assert result is not None
-        assert result.status == "failure"
+        assert result.status == "cancelled"
         assert result.result is not None
         assert isinstance(result.result, str)
         assert "cancelled" in result.result.lower()

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -5735,7 +5735,9 @@ class TestSubagentCancelThreadWritesControlFile:
         assert "cancelled" in result.lower()
         control = tmp_path / "control.jsonl"
         assert control.exists(), "cancel must write control.jsonl for thread mode"
-        entry = json.loads(control.read_text().strip())
+        # Parse first line of JSONL file
+        lines = control.read_text().strip().split("\n")
+        entry = json.loads(lines[0])
         assert entry["op"] == "cancel"
         assert entry["agent_id"] == "thr-agent"
 
@@ -5759,7 +5761,9 @@ class TestSubagentCancelThreadWritesControlFile:
 
         control = tmp_path / "control.jsonl"
         assert control.exists(), "cancel must write control.jsonl for subprocess mode"
-        entry = json.loads(control.read_text().strip())
+        # Parse first line of JSONL file
+        lines = control.read_text().strip().split("\n")
+        entry = json.loads(lines[0])
         assert entry["op"] == "cancel"
 
 

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -707,7 +707,7 @@ class TestSubagentCancel:
         mock_proc.terminate.assert_called_once()
         assert "cancelled" in result.lower()
         with _subagent_results_lock:
-            assert _subagent_results["proc-agent"].status == "failure"
+            assert _subagent_results["proc-agent"].status == "cancelled"
             assert "Cancelled" in (_subagent_results["proc-agent"].result or "")
         assert drain_control_ops(tmp_path)[0]["agent_id"] == "proc-agent"
 
@@ -749,13 +749,13 @@ class TestSubagentCancel:
         )
         with _subagent_results_lock:
             _subagent_results["proc-agent"] = ReturnType(
-                "failure", "Cancelled by orchestrator"
+                "cancelled", "Cancelled by orchestrator"
             )
 
         _monitor_subprocess(sa)
 
         with _subagent_results_lock:
-            assert _subagent_results["proc-agent"].status == "failure"
+            assert _subagent_results["proc-agent"].status == "cancelled"
             assert _subagent_results["proc-agent"].result == "Cancelled by orchestrator"
         assert _completion_queue.empty()
 
@@ -832,7 +832,7 @@ class TestSubagentCancel:
         result = subagent_cancel("thread-agent")
         assert "cancelled" in result.lower()
         with _subagent_results_lock:
-            assert _subagent_results["thread-agent"].status == "failure"
+            assert _subagent_results["thread-agent"].status == "cancelled"
 
     def test_cancel_thread_writes_control_operation(self, tmp_path):
         mock_thread = MagicMock(spec=threading.Thread)
@@ -867,7 +867,7 @@ class TestSubagentCancel:
         ) -> bool:
             with _subagent_results_lock:
                 _subagent_results[agent_id] = ReturnType(
-                    "failure", "Cancelled by orchestrator"
+                    "cancelled", "Cancelled by orchestrator"
                 )
             return False
 
@@ -888,7 +888,7 @@ class TestSubagentCancel:
         assert notify_calls == []
         with _subagent_results_lock:
             assert _subagent_results["thread-agent"] == ReturnType(
-                "failure", "Cancelled by orchestrator"
+                "cancelled", "Cancelled by orchestrator"
             )
 
     def test_thread_exception_cleans_isolation_when_cancel_wins_race(
@@ -916,7 +916,7 @@ class TestSubagentCancel:
         ) -> bool:
             with _subagent_results_lock:
                 _subagent_results[agent_id] = ReturnType(
-                    "failure", "Cancelled by orchestrator"
+                    "cancelled", "Cancelled by orchestrator"
                 )
             return False
 
@@ -937,7 +937,7 @@ class TestSubagentCancel:
         assert cleanup_calls == ["thread-agent"]
         with _subagent_results_lock:
             assert _subagent_results["thread-agent"] == ReturnType(
-                "failure", "Cancelled by orchestrator"
+                "cancelled", "Cancelled by orchestrator"
             )
 
     def test_subprocess_launch_failure_cleans_isolation_when_cancel_wins_race(
@@ -971,7 +971,7 @@ class TestSubagentCancel:
         ) -> bool:
             with _subagent_results_lock:
                 _subagent_results[agent_id] = ReturnType(
-                    "failure", "Cancelled by orchestrator"
+                    "cancelled", "Cancelled by orchestrator"
                 )
             return False
 
@@ -994,7 +994,7 @@ class TestSubagentCancel:
         assert notify_calls == []
         with _subagent_results_lock:
             assert _subagent_results["proc-agent"] == ReturnType(
-                "failure", "Cancelled by orchestrator"
+                "cancelled", "Cancelled by orchestrator"
             )
 
     def test_cancelled_queued_subprocess_does_not_launch_after_slot_frees(
@@ -1041,7 +1041,7 @@ class TestSubagentCancel:
         assert cleanup_calls == ["proc-agent"]
         with _subagent_results_lock:
             assert _subagent_results["proc-agent"] == ReturnType(
-                "failure", "Cancelled by orchestrator"
+                "cancelled", "Cancelled by orchestrator"
             )
 
     def test_cancelled_queued_thread_does_not_launch_after_slot_frees(
@@ -1085,7 +1085,7 @@ class TestSubagentCancel:
         assert cleanup_calls == ["thread-agent"]
         with _subagent_results_lock:
             assert _subagent_results["thread-agent"] == ReturnType(
-                "failure", "Cancelled by orchestrator"
+                "cancelled", "Cancelled by orchestrator"
             )
 
     def test_cancelled_queued_planner_subprocess_does_not_launch_after_slot_frees(
@@ -1137,7 +1137,7 @@ class TestSubagentCancel:
         assert cleanup_calls == ["planner-agent-verify"]
         with _subagent_results_lock:
             assert _subagent_results["planner-agent-verify"] == ReturnType(
-                "failure", "Cancelled by orchestrator"
+                "cancelled", "Cancelled by orchestrator"
             )
 
     def test_cancelled_queued_planner_thread_does_not_launch_after_slot_frees(
@@ -1188,7 +1188,7 @@ class TestSubagentCancel:
         assert cleanup_calls == ["planner-agent-implement"]
         with _subagent_results_lock:
             assert _subagent_results["planner-agent-implement"] == ReturnType(
-                "failure", "Cancelled by orchestrator"
+                "cancelled", "Cancelled by orchestrator"
             )
 
     def test_planner_thread_cleanup_failure_still_releases_semaphore(

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -18,7 +18,7 @@ import gptme.tools.subagent.api as subagent_api
 import gptme.tools.subagent.execution as subagent_execution
 import gptme.tools.subagent.types as subagent_types
 from gptme.tools.complete import SessionCompleteException
-from gptme.tools.subagent.api import subagent, subagent_cancel
+from gptme.tools.subagent.api import _write_cancel_op, subagent, subagent_cancel
 from gptme.tools.subagent.batch import BatchJob
 from gptme.tools.subagent.control import (
     CONTROL_FILENAME,
@@ -28,6 +28,7 @@ from gptme.tools.subagent.control import (
 from gptme.tools.subagent.execution import _monitor_subprocess
 from gptme.tools.subagent.hooks import (
     _get_complete_instruction,
+    _subagent_cancel_checkpoint,
     _subagent_completion_hook,
     _subagent_control_hook,
     notify_completion,
@@ -5645,3 +5646,173 @@ class TestSubagentParallelCancelOnFailure:
         third_idx = 2
         assert results[third_idx]["status"] == "failure"
         assert results[third_idx]["result"] == "third failed"
+
+
+# ---------------------------------------------------------------------------
+# Cooperative cancel checkpoint tests
+# ---------------------------------------------------------------------------
+
+
+class TestWriteCancelOp:
+    """Tests for _write_cancel_op helper."""
+
+    def test_writes_jsonl_to_control_file(self, tmp_path):
+        _write_cancel_op(tmp_path, "agent-1")
+        control = tmp_path / "control.jsonl"
+        assert control.exists()
+        entry = json.loads(control.read_text().strip())
+        assert entry["op"] == "cancel"
+        assert entry["agent_id"] == "agent-1"
+        assert "ts" in entry
+
+    def test_appends_multiple_ops(self, tmp_path):
+        _write_cancel_op(tmp_path, "agent-1")
+        _write_cancel_op(tmp_path, "agent-1")
+        lines = (tmp_path / "control.jsonl").read_text().strip().splitlines()
+        assert len(lines) == 2
+        for line in lines:
+            assert json.loads(line)["op"] == "cancel"
+
+    def test_creates_logdir_if_missing(self, tmp_path):
+        logdir = tmp_path / "nested" / "logdir"
+        _write_cancel_op(logdir, "agent-1")
+        assert (logdir / "control.jsonl").exists()
+
+
+class TestSubagentCancelThreadWritesControlFile:
+    """Verify subagent_cancel() writes to control.jsonl for thread mode."""
+
+    def setup_method(self):
+        with _subagents_lock:
+            _subagents.clear()
+        with _subagent_results_lock:
+            _subagent_results.clear()
+
+    def test_cancel_thread_writes_control_file(self, tmp_path):
+        mock_thread = MagicMock(spec=threading.Thread)
+        mock_thread.is_alive.return_value = True
+        sa = Subagent(
+            agent_id="thr-agent",
+            prompt="test",
+            thread=mock_thread,
+            logdir=tmp_path,
+            model=None,
+            execution_mode="thread",
+        )
+        with _subagents_lock:
+            _subagents.append(sa)
+
+        result = subagent_cancel("thr-agent")
+
+        assert "cancelled" in result.lower()
+        control = tmp_path / "control.jsonl"
+        assert control.exists(), "cancel must write control.jsonl for thread mode"
+        entry = json.loads(control.read_text().strip())
+        assert entry["op"] == "cancel"
+        assert entry["agent_id"] == "thr-agent"
+
+    def test_cancel_subprocess_writes_control_file(self, tmp_path):
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = None
+        mock_proc.wait.return_value = 0
+        sa = Subagent(
+            agent_id="sub-agent",
+            prompt="test",
+            thread=None,
+            logdir=tmp_path,
+            model=None,
+            process=mock_proc,
+            execution_mode="subprocess",
+        )
+        with _subagents_lock:
+            _subagents.append(sa)
+
+        subagent_cancel("sub-agent")
+
+        control = tmp_path / "control.jsonl"
+        assert control.exists(), "cancel must write control.jsonl for subprocess mode"
+        entry = json.loads(control.read_text().strip())
+        assert entry["op"] == "cancel"
+
+
+class TestCancelCheckpointHook:
+    """Unit tests for _subagent_cancel_checkpoint STEP_PRE hook."""
+
+    def setup_method(self):
+        with _subagent_results_lock:
+            _subagent_results.clear()
+        import gptme.tools.subagent.execution as _exe
+
+        _exe._thread_local.__dict__.pop("agent_id", None)
+
+    def _make_manager(self, logdir: Path) -> MagicMock:
+        m = MagicMock()
+        m.logdir = logdir
+        return m
+
+    def _set_agent_id(self, agent_id: str) -> None:
+        import gptme.tools.subagent.execution as _exe
+
+        _exe._thread_local.agent_id = agent_id
+
+    def test_noop_outside_subagent_thread(self, tmp_path):
+        """Hook must be inert when called in the parent's loop (no thread-local agent_id)."""
+        (tmp_path / "control.jsonl").write_text(
+            json.dumps({"op": "cancel", "agent_id": "x"}) + "\n"
+        )
+        msgs = list(_subagent_cancel_checkpoint(self._make_manager(tmp_path)))
+        assert msgs == []
+
+    def test_noop_without_control_file(self, tmp_path):
+        """Hook must be inert when logdir/control.jsonl doesn't exist."""
+        self._set_agent_id("agent-1")
+        msgs = list(_subagent_cancel_checkpoint(self._make_manager(tmp_path)))
+        assert msgs == []
+
+    def test_noop_without_cancel_op(self, tmp_path):
+        """Hook must be inert when control.jsonl has no cancel op."""
+        self._set_agent_id("agent-1")
+        (tmp_path / "control.jsonl").write_text(
+            json.dumps({"op": "steer", "data": "something"}) + "\n"
+        )
+        msgs = list(_subagent_cancel_checkpoint(self._make_manager(tmp_path)))
+        assert msgs == []
+
+    def test_cancels_on_cancel_op(self, tmp_path):
+        """Hook yields a note and raises SessionCompleteException on cancel op."""
+        from gptme.tools.complete import SessionCompleteException
+
+        self._set_agent_id("agent-1")
+        (tmp_path / "control.jsonl").write_text(
+            json.dumps({"op": "cancel", "agent_id": "agent-1"}) + "\n"
+        )
+        gen = _subagent_cancel_checkpoint(self._make_manager(tmp_path))
+        # First iteration yields the partial-work note
+        msg = next(gen)
+        assert "cancel" in msg.content.lower()
+        # Second iteration raises SessionCompleteException
+        with pytest.raises(SessionCompleteException):
+            next(gen)
+        # Result cache must have 'cancelled' status
+        with _subagent_results_lock:
+            assert _subagent_results["agent-1"].status == "cancelled"
+
+    def test_first_writer_wins_on_natural_completion(self, tmp_path):
+        """When agent already completed, cancel doesn't overwrite the success result."""
+        from gptme.tools.complete import SessionCompleteException
+
+        self._set_agent_id("agent-1")
+        # Pre-seed with a success result (agent completed naturally first)
+        with _subagent_results_lock:
+            _subagent_results["agent-1"] = ReturnType("success", "done")
+
+        (tmp_path / "control.jsonl").write_text(
+            json.dumps({"op": "cancel", "agent_id": "agent-1"}) + "\n"
+        )
+        gen = _subagent_cancel_checkpoint(self._make_manager(tmp_path))
+        next(gen)  # yield the note
+        with pytest.raises(SessionCompleteException):
+            next(gen)
+        # Original success result must be preserved
+        with _subagent_results_lock:
+            assert _subagent_results["agent-1"].status == "success"

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -559,6 +559,34 @@ class TestBatchJob:
         )
         assert "b" not in completed  # Only completed agent appears
 
+    def test_wait_any_returns_on_cancelled(self, monkeypatch):
+        """wait_any() must treat 'cancelled' as a terminal status and return immediately."""
+        import threading
+
+        from gptme.tools.subagent import batch as batch_mod
+
+        # Simulate: agent-a is cancelled, agent-b is still running
+        call_counts: dict[str, int] = {}
+        unblock = threading.Event()
+
+        def mock_wait(agent_id, timeout=None, max_result_chars=0):
+            call_counts[agent_id] = call_counts.get(agent_id, 0) + 1
+            if agent_id == "agent-a":
+                return {"status": "cancelled", "result": "Cancelled by orchestrator"}
+            # agent-b blocks until the event — should never be called since agent-a
+            # returns a terminal result first
+            unblock.wait(timeout=timeout)
+            return {"status": "success", "result": "done"}
+
+        monkeypatch.setattr(batch_mod, "subagent_wait", mock_wait)
+
+        job = BatchJob(agent_ids=["agent-a", "agent-b"])
+        result_id, result_dict = job.wait_any(timeout=5)
+
+        assert result_id == "agent-a"
+        assert result_dict["status"] == "cancelled"
+        unblock.set()  # release any background threads
+
     def test_wait_all_does_not_raise_on_as_completed_timeout(self, monkeypatch):
         """wait_all() must not propagate TimeoutError — stalled agents get a result dict."""
         import threading

--- a/tests/test_tools_subagent.py
+++ b/tests/test_tools_subagent.py
@@ -2156,7 +2156,7 @@ def test_cancelled_queued_acp_does_not_launch_after_slot_frees():
         assert cleanup_calls == ["test-acp-cancelled"]
 
     with _subagent_results_lock:
-        assert _subagent_results["test-acp-cancelled"].status == "failure"
+        assert _subagent_results["test-acp-cancelled"].status == "cancelled"
         assert (
             _subagent_results["test-acp-cancelled"].result
             == "Cancelled by orchestrator"


### PR DESCRIPTION
## Problem

`subagent_cancel()` sent a `SIGTERM` / set a cancelled flag, but thread-mode subagents had no mechanism to observe it between LLM steps. The running thread would finish its current generation and potentially several more tool calls before the next natural completion point.

## Solution

Adds a STEP_PRE cooperative checkpoint that fires before every LLM generation step in subagent threads. When a cancel is requested, it writes a `{"op": "cancel"}` record to `logdir/control.jsonl`; the checkpoint reads this file and if found: yields a partial-work note, writes `cancelled` status (first-writer-wins, so a natural completion can still win the race), then raises `SessionCompleteException` to exit `chat()` cleanly and release the semaphore slot.

## Changes

**`gptme/tools/subagent/hooks.py`** — new `_subagent_cancel_checkpoint()`
- Fires at `STEP_PRE` (before each LLM generation)
- Two O(1) fast-path guards keep overhead minimal: thread-local `agent_id is None` check (no-op in parent), and a single `stat()` on `control.jsonl` (no-op when absent)
- On cancel op: appends status message, sets `cancelled` result via `set_subagent_result_if_absent` (first-writer-wins), raises `SessionCompleteException`

**`gptme/tools/subagent/api.py`** — new `_write_cancel_op()` + updated `subagent_cancel()`
- `_write_cancel_op()`: flock-safe JSONL append to `logdir/control.jsonl` (Windows-safe fcntl fallback, same pattern as `prompt_queue.py`)
- `subagent_cancel()` in thread mode: calls `_write_cancel_op` then the existing cache-mark
- `subagent_cancel()` in subprocess mode: calls `_write_cancel_op` before `SIGTERM` (so it works even if the subprocess ignores the signal)
- ACP mode: unchanged (cache-mark-only, as before)

**`gptme/tools/subagent/__init__.py`** — registers `cancel_checkpoint` hook at `STEP_PRE` priority 100

**`tests/test_subagent_unit.py`** — 10 new tests
- `TestWriteCancelOp` (3): JSONL written, appends correctly, creates missing logdir
- `TestSubagentCancelThreadWritesControlFile` (2): thread and subprocess cancel modes write control.jsonl
- `TestCancelCheckpointHook` (5): no-op outside subagent thread, no-op without file, no-op without cancel op, cancels on cancel op, first-writer-wins on natural completion

## Test run

```
241 passed, 1 warning in 8.90s
```

All 241 unit tests pass including 10 new cancel-checkpoint tests.

Closes #3258