### PR TITLE
feat(subagent): stop thread agents at control checkpoints

### DIFF
--- a/gptme/tools/subagent/__init__.py
+++ b/gptme/tools/subagent/__init__.py
@@ -29,6 +29,7 @@ from .hooks import (
     _get_complete_instruction,
     _session_end_subagent_cleanup,
     _subagent_completion_hook,
+    _subagent_control_hook,
     notify_completion,
     notify_progress,
 )
@@ -538,6 +539,11 @@ tool = ToolSpec(
             "session.end",  # HookType.SESSION_END.value
             _session_end_subagent_cleanup,
             0,  # Default priority
+        ),
+        "control": (
+            "step.pre",  # HookType.STEP_PRE.value
+            _subagent_control_hook,
+            0,
         ),
     },
 )

--- a/gptme/tools/subagent/api.py
+++ b/gptme/tools/subagent/api.py
@@ -17,6 +17,7 @@ from typing import Any, Literal
 
 from . import execution as _exec
 from .concurrency import get_slot_sem
+from .control import append_control_op
 from .hooks import notify_completion
 from .types import (
     ReturnType,
@@ -987,9 +988,9 @@ def subagent_cancel(agent_id: str) -> str:
     """Cancel a running subagent.
 
     For subprocess-mode subagents, sends SIGTERM (then SIGKILL after 5s) to the
-    process. For thread-mode subagents, marks the result as cancelled — the thread
-    continues until its next natural checkpoint but the result is already recorded
-    as failure so callers won't block waiting for it.
+    process. For thread-mode subagents, records a cancellation operation that stops
+    the child at its next step boundary while caching the failure result immediately
+    so callers do not block waiting for it.
 
     Args:
         agent_id: The subagent to cancel
@@ -1007,6 +1008,7 @@ def subagent_cancel(agent_id: str) -> str:
         return f"Subagent '{agent_id}' is not running (already finished)."
 
     cancelled_result = ReturnType("failure", "Cancelled by orchestrator")
+    append_control_op(sa.logdir, "cancel", agent_id=agent_id)
 
     if sa.execution_mode == "subprocess" and sa.process:
         if not set_subagent_result_if_absent(agent_id, cancelled_result):
@@ -1028,7 +1030,7 @@ def subagent_cancel(agent_id: str) -> str:
     )
     return (
         f"Subagent '{agent_id}' marked as cancelled. "
-        "The background thread will stop at its next natural checkpoint."
+        "The background thread will stop at its next step boundary."
     )
 
 

--- a/gptme/tools/subagent/api.py
+++ b/gptme/tools/subagent/api.py
@@ -1008,7 +1008,13 @@ def subagent_cancel(agent_id: str) -> str:
         return f"Subagent '{agent_id}' is not running (already finished)."
 
     cancelled_result = ReturnType("failure", "Cancelled by orchestrator")
-    append_control_op(sa.logdir, "cancel", agent_id=agent_id)
+    # Best-effort: write the cancel signal so thread agents stop at their next
+    # checkpoint.  If the logdir is unavailable (removed, read-only, etc.) we
+    # still proceed with subprocess termination / result-marking below.
+    try:
+        append_control_op(sa.logdir, "cancel", agent_id=agent_id)
+    except OSError as e:
+        logger.warning("Failed to write cancel control op for '%s': %s", agent_id, e)
 
     if sa.execution_mode == "subprocess" and sa.process:
         if not set_subagent_result_if_absent(agent_id, cancelled_result):

--- a/gptme/tools/subagent/control.py
+++ b/gptme/tools/subagent/control.py
@@ -71,7 +71,7 @@ def drain_control_ops(logdir: Path) -> list[dict[str, object]]:
             text = control_path.read_text(encoding="utf-8")
         except OSError as e:
             logger.warning("Could not read control file %s: %s", control_path, e)
-            return []  # Leave file in place; hook will retry at next checkpoint
+            raise  # Let the hook treat a read failure as a cancel signal
         for line in text.splitlines():
             if not line.strip():
                 continue

--- a/gptme/tools/subagent/control.py
+++ b/gptme/tools/subagent/control.py
@@ -67,7 +67,12 @@ def drain_control_ops(logdir: Path) -> list[dict[str, object]]:
             return []
 
         operations: list[dict[str, object]] = []
-        for line in control_path.read_text(encoding="utf-8").splitlines():
+        try:
+            text = control_path.read_text(encoding="utf-8")
+        except OSError as e:
+            logger.warning("Could not read control file %s: %s", control_path, e)
+            return []  # Leave file in place; hook will retry at next checkpoint
+        for line in text.splitlines():
             if not line.strip():
                 continue
             try:
@@ -84,5 +89,8 @@ def drain_control_ops(logdir: Path) -> list[dict[str, object]]:
                 continue
             operations.append(record)
 
-        control_path.unlink(missing_ok=True)
+        try:
+            control_path.unlink(missing_ok=True)
+        except OSError as e:
+            logger.warning("Could not remove %s: %s", control_path, e)
         return operations

--- a/gptme/tools/subagent/control.py
+++ b/gptme/tools/subagent/control.py
@@ -1,0 +1,88 @@
+"""Durable control operations for a running subagent conversation."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import logging
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+try:
+    fcntl: Any = importlib.import_module("fcntl")
+except ImportError:  # pragma: no cover
+    fcntl = None
+
+
+CONTROL_FILENAME = "control.jsonl"
+LOCK_FILENAME = ".control.lock"
+
+
+def _control_path(logdir: Path) -> Path:
+    return logdir / CONTROL_FILENAME
+
+
+@contextmanager
+def _control_lock(logdir: Path):
+    lock_path = logdir / LOCK_FILENAME
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path.touch(exist_ok=True)
+
+    with lock_path.open("r+") as fd:
+        if fcntl is not None:
+            fcntl.flock(fd, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            if fcntl is not None:
+                fcntl.flock(fd, fcntl.LOCK_UN)
+
+
+def append_control_op(logdir: Path, op: str, **payload: object) -> None:
+    """Append a control operation for the conversation in *logdir*."""
+    record = {
+        "op": op,
+        "queued_at": datetime.now(timezone.utc).isoformat(),
+        **payload,
+    }
+    control_path = _control_path(logdir)
+    with _control_lock(logdir), control_path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(record) + "\n")
+
+
+def drain_control_ops(logdir: Path) -> list[dict[str, object]]:
+    """Drain valid control operations from *logdir* in FIFO order."""
+    control_path = _control_path(logdir)
+    if not control_path.exists():
+        return []
+
+    with _control_lock(logdir):
+        if not control_path.exists():
+            return []
+
+        operations: list[dict[str, object]] = []
+        for line in control_path.read_text(encoding="utf-8").splitlines():
+            if not line.strip():
+                continue
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                logger.warning(
+                    "Skipping malformed subagent control op in %s", control_path
+                )
+                continue
+            if not isinstance(record, dict):
+                logger.warning(
+                    "Skipping non-object subagent control op in %s", control_path
+                )
+                continue
+            operations.append(record)
+
+        control_path.unlink(missing_ok=True)
+        return operations

--- a/gptme/tools/subagent/execution.py
+++ b/gptme/tools/subagent/execution.py
@@ -216,7 +216,10 @@ def _create_subagent_thread(
 
     from ...profiles import get_profile  # fmt: skip
     from ...prompts import get_prompt  # fmt: skip
-    from .hooks import _get_complete_instruction  # fmt: skip
+    from .hooks import (
+        _get_complete_instruction,  # fmt: skip
+        _subagent_control_hook,  # fmt: skip
+    )
 
     # Resolve profile if specified
     profile = get_profile(profile_name) if profile_name else None
@@ -234,6 +237,14 @@ def _create_subagent_thread(
 
     prepare_execution_environment(workspace=workspace, tools=None)
     _ensure_subagent_signal_tools_loaded()
+
+    # Register the control hook in this child thread's ContextVar context.
+    # Hook registrations use a ContextVar — child threads start with an empty
+    # registry and do not inherit the parent's registrations, so registering
+    # at module level is not sufficient: the child never sees those hooks.
+    from ...hooks import HookType, register_hook  # fmt: skip
+
+    register_hook("subagent-control", HookType.STEP_PRE, _subagent_control_hook, 0)
 
     # Get tools, filtered by profile if applicable
     if tool_allowlist is not None:

--- a/gptme/tools/subagent/hooks.py
+++ b/gptme/tools/subagent/hooks.py
@@ -16,7 +16,9 @@ from typing import TYPE_CHECKING
 
 from ...hooks.types import StopPropagation
 from ...message import Message
+from .control import CONTROL_FILENAME, drain_control_ops
 from .types import (
+    ReturnType,
     Status,
     _completion_queue,
     _progress_queue,
@@ -24,12 +26,44 @@ from .types import (
     _subagent_results_lock,
     _subagents,
     _subagents_lock,
+    set_subagent_result_if_absent,
 )
 
 if TYPE_CHECKING:
     from ...logmanager import LogManager  # fmt: skip
 
 logger = logging.getLogger(__name__)
+
+
+def _subagent_control_hook(manager: "LogManager") -> Generator[Message, None, None]:
+    """Stop a child conversation when its parent writes a cancel operation."""
+    if not (manager.logdir / CONTROL_FILENAME).exists():
+        return
+
+    operations = drain_control_ops(manager.logdir)
+    if not any(operation.get("op") == "cancel" for operation in operations):
+        return
+
+    agent_id = manager.logdir.name
+    for operation in operations:
+        candidate_agent_id = operation.get("agent_id")
+        if operation.get("op") == "cancel" and isinstance(candidate_agent_id, str):
+            agent_id = candidate_agent_id
+            break
+
+    manager.append(
+        Message(
+            "system",
+            "Subagent cancellation requested by orchestrator; ending at this step boundary.",
+        )
+    )
+    set_subagent_result_if_absent(
+        agent_id, ReturnType("failure", "Cancelled by orchestrator")
+    )
+    from ..complete import SessionCompleteException
+
+    raise SessionCompleteException("Subagent cancelled by orchestrator")
+    yield from ()
 
 
 # Python built-in types that are valid as values in a {field_name: python_type} mapping.

--- a/gptme/tools/subagent/hooks.py
+++ b/gptme/tools/subagent/hooks.py
@@ -40,7 +40,15 @@ def _subagent_control_hook(manager: "LogManager") -> Generator[Message, None, No
     if not (manager.logdir / CONTROL_FILENAME).exists():
         return
 
-    operations = drain_control_ops(manager.logdir)
+    try:
+        operations = drain_control_ops(manager.logdir)
+    except OSError:
+        # Control file existed but became unreadable or could not be removed.
+        # Treat as a cancel: a cancel op may have been written and must not be lost.
+        logger.warning(
+            "Could not drain control ops from %s; treating as cancel", manager.logdir
+        )
+        operations = [{"op": "cancel", "agent_id": manager.logdir.name}]
     if not any(operation.get("op") == "cancel" for operation in operations):
         return
 

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -75,6 +75,27 @@ class TestSubagentControlChannel:
 
         assert operations[0]["agent_id"] == "child"
 
+    def test_drain_control_ops_raises_on_read_error(self, tmp_path):
+        control_path = tmp_path / CONTROL_FILENAME
+        control_path.write_text('{"op": "cancel", "agent_id": "child"}\n')
+        control_path.chmod(0o000)
+        try:
+            with pytest.raises(OSError, match="Permission denied"):
+                drain_control_ops(tmp_path)
+        finally:
+            control_path.chmod(0o644)
+
+    def test_control_hook_treats_read_error_as_cancel(self, tmp_path):
+        control_path = tmp_path / CONTROL_FILENAME
+        control_path.write_text('{"op": "cancel", "agent_id": "thread-agent"}\n')
+        control_path.chmod(0o000)
+        manager = MagicMock(logdir=tmp_path)
+        try:
+            with pytest.raises(SessionCompleteException, match="cancelled"):
+                list(_subagent_control_hook(manager))
+        finally:
+            control_path.chmod(0o644)
+
     def test_control_hook_noops_without_control_file(self, tmp_path):
         manager = MagicMock(logdir=tmp_path)
 

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -17,12 +17,19 @@ import pytest
 import gptme.tools.subagent.api as subagent_api
 import gptme.tools.subagent.execution as subagent_execution
 import gptme.tools.subagent.types as subagent_types
+from gptme.tools.complete import SessionCompleteException
 from gptme.tools.subagent.api import subagent, subagent_cancel
 from gptme.tools.subagent.batch import BatchJob
+from gptme.tools.subagent.control import (
+    CONTROL_FILENAME,
+    append_control_op,
+    drain_control_ops,
+)
 from gptme.tools.subagent.execution import _monitor_subprocess
 from gptme.tools.subagent.hooks import (
     _get_complete_instruction,
     _subagent_completion_hook,
+    _subagent_control_hook,
     notify_completion,
     notify_progress,
 )
@@ -37,6 +44,62 @@ from gptme.tools.subagent.types import (
     _subagents_lock,
     resolve_role_defaults,
 )
+
+# ---------------------------------------------------------------------------
+# Subagent control channel tests
+# ---------------------------------------------------------------------------
+
+
+class TestSubagentControlChannel:
+    def setup_method(self):
+        with _subagent_results_lock:
+            _subagent_results.clear()
+
+    def test_control_operations_drain_in_fifo_order(self, tmp_path):
+        append_control_op(tmp_path, "cancel", agent_id="first")
+        append_control_op(tmp_path, "cancel", agent_id="second")
+
+        operations = drain_control_ops(tmp_path)
+
+        assert [(op["op"], op["agent_id"]) for op in operations] == [
+            ("cancel", "first"),
+            ("cancel", "second"),
+        ]
+        assert not (tmp_path / CONTROL_FILENAME).exists()
+
+    def test_control_operations_skip_malformed_lines(self, tmp_path):
+        control_path = tmp_path / CONTROL_FILENAME
+        control_path.write_text('not json\n{"op": "cancel", "agent_id": "child"}\n')
+
+        operations = drain_control_ops(tmp_path)
+
+        assert operations[0]["agent_id"] == "child"
+
+    def test_control_hook_noops_without_control_file(self, tmp_path):
+        manager = MagicMock(logdir=tmp_path)
+
+        assert list(_subagent_control_hook(manager)) == []
+
+    def test_control_hook_cancels_and_preserves_completed_result(self, tmp_path):
+        append_control_op(tmp_path, "cancel", agent_id="thread-agent")
+        manager = MagicMock(logdir=tmp_path)
+
+        with pytest.raises(SessionCompleteException, match="cancelled"):
+            list(_subagent_control_hook(manager))
+        assert "cancellation requested" in manager.append.call_args.args[0].content
+        with _subagent_results_lock:
+            assert _subagent_results["thread-agent"] == ReturnType(
+                "failure", "Cancelled by orchestrator"
+            )
+
+        append_control_op(tmp_path, "cancel", agent_id="thread-agent")
+        with _subagent_results_lock:
+            _subagent_results["thread-agent"] = ReturnType("success", "done")
+        with pytest.raises(SessionCompleteException, match="cancelled"):
+            list(_subagent_control_hook(manager))
+        with _subagent_results_lock:
+            assert _subagent_results["thread-agent"] == ReturnType("success", "done")
+
 
 # ---------------------------------------------------------------------------
 # ReturnType tests
@@ -608,17 +671,23 @@ class TestSubagentCancel:
         result = subagent_cancel("done-agent")
         assert "not running" in result
 
-    def test_cancel_subprocess_terminates_process(self):
+    def test_cancel_subprocess_terminates_process(self, tmp_path):
         mock_proc = MagicMock()
         mock_proc.poll.return_value = None  # still running
         mock_proc.wait.return_value = 0
-        self._register("proc-agent", process=mock_proc, execution_mode="subprocess")
+        self._register(
+            "proc-agent",
+            process=mock_proc,
+            execution_mode="subprocess",
+            logdir=tmp_path,
+        )
         result = subagent_cancel("proc-agent")
         mock_proc.terminate.assert_called_once()
         assert "cancelled" in result.lower()
         with _subagent_results_lock:
             assert _subagent_results["proc-agent"].status == "failure"
             assert "Cancelled" in (_subagent_results["proc-agent"].result or "")
+        assert drain_control_ops(tmp_path)[0]["agent_id"] == "proc-agent"
 
     def test_cancel_subprocess_kills_on_timeout(self):
         import subprocess as _subprocess
@@ -742,6 +811,15 @@ class TestSubagentCancel:
         assert "cancelled" in result.lower()
         with _subagent_results_lock:
             assert _subagent_results["thread-agent"].status == "failure"
+
+    def test_cancel_thread_writes_control_operation(self, tmp_path):
+        mock_thread = MagicMock(spec=threading.Thread)
+        mock_thread.is_alive.return_value = True
+        self._register("thread-agent", thread=mock_thread, logdir=tmp_path)
+
+        subagent_cancel("thread-agent")
+
+        assert drain_control_ops(tmp_path)[0]["agent_id"] == "thread-agent"
 
     def test_thread_completion_skips_notify_when_cancel_wins_race(
         self, monkeypatch, tmp_path


### PR DESCRIPTION
## Summary
- add a flocked per-subagent `control.jsonl` channel
- make cancellation stop thread-mode children at their next `step.pre` boundary
- preserve first-writer-wins cached results and retain subprocess termination behavior

## Verification
- `uv run --with requests --with pytest python -m pytest tests/test_subagent_unit.py tests/test_subagent_roundtrip.py -q` (244 passed)
- `uv run --with requests --with mypy mypy gptme/tools/subagent`
- Ruff on touched files

Closes #3258