### PR TITLE
fix(subagent): eliminate cancel status race — set result before writing control file

### DIFF
--- a/gptme/tools/subagent/api.py
+++ b/gptme/tools/subagent/api.py
@@ -1053,22 +1053,20 @@ def subagent_cancel(agent_id: str) -> str:
         return f"Subagent '{agent_id}' is not running (already finished)."
 
     cancelled_result = ReturnType("cancelled", "Cancelled by orchestrator")
-    # Best-effort: write the cancel signal so thread agents stop at their next
-    # checkpoint.  If the logdir is unavailable (removed, read-only, etc.) we
-    # still proceed with subprocess termination / result-marking below.
-    try:
-        append_control_op(sa.logdir, "cancel", agent_id=agent_id)
-    except OSError as e:
-        logger.warning("Failed to write cancel control op for '%s': %s", agent_id, e)
 
     if sa.execution_mode == "subprocess" and sa.process:
+        # Mark result BEFORE writing the control file so the cooperative checkpoint
+        # can never observe the cancel op without a "cancelled" result already in
+        # the cache — preventing a race where the hook's set_subagent_result_if_absent
+        # would win with the wrong status.
         if not set_subagent_result_if_absent(agent_id, cancelled_result):
             return f"Subagent '{agent_id}' already finished before cancellation."
-        # Write cancel op so the subprocess checkpoint can exit cleanly before SIGTERM.
         try:
-            _write_cancel_op(sa.logdir, agent_id)
-        except Exception as e:
-            logger.warning(f"Failed to write cancel op for '{agent_id}': {e}")
+            append_control_op(sa.logdir, "cancel", agent_id=agent_id)
+        except OSError as e:
+            logger.warning(
+                "Failed to write cancel control op for '%s': %s", agent_id, e
+            )
         sa.process.terminate()
         try:
             sa.process.wait(timeout=5)
@@ -1078,14 +1076,16 @@ def subagent_cancel(agent_id: str) -> str:
         logger.info(f"Subagent '{agent_id}' subprocess terminated.")
         return f"Subagent '{agent_id}' cancelled."
     if sa.execution_mode == "thread":
-        # Thread mode: write cancel op so the cooperative STEP_PRE checkpoint stops
-        # the thread cleanly and releases the concurrency slot.
+        # Thread mode: mark result BEFORE writing the control file (same race fix).
+        # The thread stops at its next STEP_PRE checkpoint and releases the slot.
         if not set_subagent_result_if_absent(agent_id, cancelled_result):
             return f"Subagent '{agent_id}' already finished before cancellation."
         try:
-            _write_cancel_op(sa.logdir, agent_id)
-        except Exception as e:
-            logger.warning(f"Failed to write cancel op for '{agent_id}': {e}")
+            append_control_op(sa.logdir, "cancel", agent_id=agent_id)
+        except OSError as e:
+            logger.warning(
+                "Failed to write cancel control op for '%s': %s", agent_id, e
+            )
         logger.info(
             f"Subagent '{agent_id}' marked cancelled (thread will stop at next checkpoint)."
         )

--- a/gptme/tools/subagent/api.py
+++ b/gptme/tools/subagent/api.py
@@ -1084,8 +1084,14 @@ def subagent_cancel(agent_id: str) -> str:
             append_control_op(sa.logdir, "cancel", agent_id=agent_id)
         except OSError as e:
             logger.warning(
-                "Failed to write cancel control op for '%s': %s", agent_id, e
+                "Failed to write cancel control op for '%s': %s — "
+                "falling back to in-memory cancel_event",
+                agent_id,
+                e,
             )
+            # Control file is unavailable; signal the thread in-memory so the
+            # STEP_PRE checkpoint hook can still stop it at its next step.
+            sa.cancel_event.set()
         logger.info(
             f"Subagent '{agent_id}' marked cancelled (thread will stop at next checkpoint)."
         )

--- a/gptme/tools/subagent/hooks.py
+++ b/gptme/tools/subagent/hooks.py
@@ -37,27 +37,36 @@ logger = logging.getLogger(__name__)
 
 def _subagent_control_hook(manager: "LogManager") -> Generator[Message, None, None]:
     """Stop a child conversation when its parent writes a cancel operation."""
-    if not (manager.logdir / CONTROL_FILENAME).exists():
-        return
-
-    try:
-        operations = drain_control_ops(manager.logdir)
-    except OSError:
-        # Control file existed but became unreadable or could not be removed.
-        # Treat as a cancel: a cancel op may have been written and must not be lost.
-        logger.warning(
-            "Could not drain control ops from %s; treating as cancel", manager.logdir
-        )
-        operations = [{"op": "cancel", "agent_id": manager.logdir.name}]
-    if not any(operation.get("op") == "cancel" for operation in operations):
-        return
-
     agent_id = manager.logdir.name
-    for operation in operations:
-        candidate_agent_id = operation.get("agent_id")
-        if operation.get("op") == "cancel" and isinstance(candidate_agent_id, str):
-            agent_id = candidate_agent_id
-            break
+
+    # Check in-memory fallback first: set by subagent_cancel() when the control-file
+    # write fails with OSError, so the thread is still stopped at its next checkpoint.
+    with _subagents_lock:
+        sa = next((s for s in _subagents if s.agent_id == agent_id), None)
+    in_memory_cancel = sa is not None and sa.cancel_event.is_set()
+
+    if not in_memory_cancel:
+        if not (manager.logdir / CONTROL_FILENAME).exists():
+            return
+
+        try:
+            operations = drain_control_ops(manager.logdir)
+        except OSError:
+            # Control file existed but became unreadable or could not be removed.
+            # Treat as a cancel: a cancel op may have been written and must not be lost.
+            logger.warning(
+                "Could not drain control ops from %s; treating as cancel",
+                manager.logdir,
+            )
+            operations = [{"op": "cancel", "agent_id": agent_id}]
+        if not any(operation.get("op") == "cancel" for operation in operations):
+            return
+
+        for operation in operations:
+            candidate_agent_id = operation.get("agent_id")
+            if operation.get("op") == "cancel" and isinstance(candidate_agent_id, str):
+                agent_id = candidate_agent_id
+                break
 
     manager.append(
         Message(

--- a/gptme/tools/subagent/hooks.py
+++ b/gptme/tools/subagent/hooks.py
@@ -66,7 +66,7 @@ def _subagent_control_hook(manager: "LogManager") -> Generator[Message, None, No
         )
     )
     set_subagent_result_if_absent(
-        agent_id, ReturnType("failure", "Cancelled by orchestrator")
+        agent_id, ReturnType("cancelled", "Cancelled by orchestrator")
     )
     from ..complete import SessionCompleteException
 

--- a/gptme/tools/subagent/hooks.py
+++ b/gptme/tools/subagent/hooks.py
@@ -37,12 +37,14 @@ logger = logging.getLogger(__name__)
 
 def _subagent_control_hook(manager: "LogManager") -> Generator[Message, None, None]:
     """Stop a child conversation when its parent writes a cancel operation."""
-    agent_id = manager.logdir.name
+    # Search by logdir, not logdir.name: thread subagent logdirs have a random suffix
+    # (subagent-{agent_id}-{suffix}), so logdir.name != agent_id for thread mode.
+    with _subagents_lock:
+        sa = next((s for s in _subagents if s.logdir == manager.logdir), None)
+    agent_id = sa.agent_id if sa is not None else manager.logdir.name
 
     # Check in-memory fallback first: set by subagent_cancel() when the control-file
     # write fails with OSError, so the thread is still stopped at its next checkpoint.
-    with _subagents_lock:
-        sa = next((s for s in _subagents if s.agent_id == agent_id), None)
     in_memory_cancel = sa is not None and sa.cancel_event.is_set()
 
     if not in_memory_cancel:

--- a/gptme/tools/subagent/types.py
+++ b/gptme/tools/subagent/types.py
@@ -318,6 +318,12 @@ class Subagent:
     # Used by SESSION_END cleanup to scope cancellation to the correct session and
     # prevent cross-conversation interference in multi-session server deployments.
     parent_logdir: Path | None = field(default=None)
+    # In-memory fallback cancellation signal for thread mode.
+    # Set by subagent_cancel() when the control-file write fails (OSError), so the
+    # STEP_PRE checkpoint hook can still stop the thread without the file.
+    cancel_event: threading.Event = field(
+        default_factory=threading.Event, init=False, repr=False
+    )
 
     def _normalize_json_result(self, result: str) -> str:
         """Normalize a complete-block result as canonical JSON.

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -102,6 +102,37 @@ class TestSubagentControlChannel:
 
         assert list(_subagent_control_hook(manager)) == []
 
+    def test_control_hook_cancels_via_in_memory_event(self, tmp_path):
+        """Hook must fire via cancel_event even when no control file exists.
+
+        Regression for the Greptile P1: when append_control_op raises OSError the
+        control file is never written, so without the in-memory fallback the thread
+        keeps running indefinitely.
+        """
+        manager = MagicMock(logdir=tmp_path)
+        sa = Subagent(
+            agent_id=tmp_path.name,
+            prompt="test",
+            thread=None,
+            logdir=tmp_path,
+            model=None,
+        )
+        sa.cancel_event.set()
+        with _subagents_lock:
+            _subagents.append(sa)
+        with _subagent_results_lock:
+            _subagent_results.clear()
+
+        try:
+            with pytest.raises(SessionCompleteException, match="cancelled"):
+                list(_subagent_control_hook(manager))
+        finally:
+            with _subagents_lock:
+                _subagents.remove(sa)
+
+        # No control file should have been needed
+        assert not (tmp_path / CONTROL_FILENAME).exists()
+
     def test_control_hook_stores_cancelled_status(self, tmp_path):
         """Hook must store 'cancelled' (not 'failure') when no prior result exists."""
         append_control_op(tmp_path, "cancel", agent_id="thread-agent")
@@ -910,6 +941,32 @@ class TestSubagentCancel:
         # The result must already be in the cache when the control file is written
         assert control_written_after_result == [True], (
             "Control file was written before result was set — race condition present"
+        )
+        with _subagent_results_lock:
+            assert _subagent_results["thread-agent"].status == "cancelled"
+
+    def test_cancel_thread_sets_cancel_event_on_ioerror(self, tmp_path):
+        """When control-file write fails, cancel_event must be set as fallback signal."""
+        import gptme.tools.subagent.api as _sapi
+
+        mock_thread = MagicMock(spec=threading.Thread)
+        mock_thread.is_alive.return_value = True
+        sa = self._register("thread-agent", thread=mock_thread, logdir=tmp_path)
+
+        original = _sapi.append_control_op
+
+        def failing_append(logdir, op, **kwargs):
+            raise OSError("disk full")
+
+        _sapi.append_control_op = failing_append
+        try:
+            result = subagent_cancel("thread-agent")
+        finally:
+            _sapi.append_control_op = original
+
+        assert "cancelled" in result.lower()
+        assert sa.cancel_event.is_set(), (
+            "cancel_event must be set when control-file write fails"
         )
         with _subagent_results_lock:
             assert _subagent_results["thread-agent"].status == "cancelled"

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -108,10 +108,14 @@ class TestSubagentControlChannel:
         Regression for the Greptile P1: when append_control_op raises OSError the
         control file is never written, so without the in-memory fallback the thread
         keeps running indefinitely.
+
+        Uses a mismatched agent_id/logdir.name to reproduce the real thread-mode
+        shape (logdir = subagent-{agent_id}-{suffix}, agent_id = the bare id).
         """
         manager = MagicMock(logdir=tmp_path)
+        # Deliberately differ from tmp_path.name to catch the old logdir.name lookup.
         sa = Subagent(
-            agent_id=tmp_path.name,
+            agent_id="real-agent-id",
             prompt="test",
             thread=None,
             logdir=tmp_path,

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -102,21 +102,26 @@ class TestSubagentControlChannel:
 
         assert list(_subagent_control_hook(manager)) == []
 
-    def test_control_hook_cancels_and_preserves_completed_result(self, tmp_path):
+    def test_control_hook_stores_cancelled_status(self, tmp_path):
+        """Hook must store 'cancelled' (not 'failure') when no prior result exists."""
         append_control_op(tmp_path, "cancel", agent_id="thread-agent")
         manager = MagicMock(logdir=tmp_path)
+        with _subagent_results_lock:
+            _subagent_results.clear()
 
         with pytest.raises(SessionCompleteException, match="cancelled"):
             list(_subagent_control_hook(manager))
         assert "cancellation requested" in manager.append.call_args.args[0].content
         with _subagent_results_lock:
-            assert _subagent_results["thread-agent"] == ReturnType(
-                "failure", "Cancelled by orchestrator"
-            )
+            assert _subagent_results["thread-agent"].status == "cancelled"
 
-        append_control_op(tmp_path, "cancel", agent_id="thread-agent")
+    def test_control_hook_cancels_and_preserves_completed_result(self, tmp_path):
+        """Hook must not overwrite a success result from natural completion."""
+        manager = MagicMock(logdir=tmp_path)
         with _subagent_results_lock:
             _subagent_results["thread-agent"] = ReturnType("success", "done")
+        append_control_op(tmp_path, "cancel", agent_id="thread-agent")
+
         with pytest.raises(SessionCompleteException, match="cancelled"):
             list(_subagent_control_hook(manager))
         with _subagent_results_lock:
@@ -870,6 +875,44 @@ class TestSubagentCancel:
         subagent_cancel("thread-agent")
 
         assert drain_control_ops(tmp_path)[0]["agent_id"] == "thread-agent"
+
+    def test_cancel_thread_result_set_before_control_file(self, tmp_path):
+        """Result must be 'cancelled' in cache before control file is written.
+
+        Regression test for the race where the STEP_PRE hook could observe the
+        cancel op before set_subagent_result_if_absent and store 'failure'.
+        """
+        control_written_after_result: list[bool] = []
+
+        original_append = __import__(
+            "gptme.tools.subagent.control", fromlist=["append_control_op"]
+        ).append_control_op
+
+        def spy_append(logdir, op, **kwargs):
+            # At the moment the control file is written, check if result is set
+            with _subagent_results_lock:
+                already_set = "thread-agent" in _subagent_results
+            control_written_after_result.append(already_set)
+            original_append(logdir, op, **kwargs)
+
+        import gptme.tools.subagent.api as _sapi
+
+        original = _sapi.append_control_op
+        _sapi.append_control_op = spy_append
+        try:
+            mock_thread = MagicMock(spec=threading.Thread)
+            mock_thread.is_alive.return_value = True
+            self._register("thread-agent", thread=mock_thread, logdir=tmp_path)
+            subagent_cancel("thread-agent")
+        finally:
+            _sapi.append_control_op = original
+
+        # The result must already be in the cache when the control file is written
+        assert control_written_after_result == [True], (
+            "Control file was written before result was set — race condition present"
+        )
+        with _subagent_results_lock:
+            assert _subagent_results["thread-agent"].status == "cancelled"
 
     def test_thread_completion_skips_notify_when_cancel_wins_race(
         self, monkeypatch, tmp_path


### PR DESCRIPTION
## Problem

Two bugs in the cooperative cancel checkpoint (introduced in #3261 + #3262) mean cancellations produce `"failure"` status instead of `"cancelled"`:

**Bug 1 — race condition in `subagent_cancel()`**: `append_control_op()` was called at the _top_ of the function, _before_ `set_subagent_result_if_absent()`. In the window between those two calls, the child thread's STEP_PRE hook could observe the cancel op and call `set_subagent_result_if_absent(agent_id, ReturnType("failure", ...))` — winning the first-writer-wins race and leaving status as `"failure"`.

**Bug 2 — wrong fallback status in `_subagent_control_hook`**: The hook stored `ReturnType("failure", ...)`. Per the issue spec, the status must be `"cancelled"`.

There was also a redundant double-write: `append_control_op` at the top + `_write_cancel_op` inside each mode branch wrote to `control.jsonl` twice.

## Fix

- **`subagent_cancel()`**: Each mode branch now calls `set_subagent_result_if_absent()` _first_, then `append_control_op()`. The result is guaranteed to be `"cancelled"` in the cache before the control file is visible to the child's hook.
- **`_subagent_control_hook`**: Changed fallback `set_subagent_result_if_absent` call to use `ReturnType("cancelled", ...)`.
- **Removed duplicate writes**: The premature top-of-function `append_control_op` and per-mode `_write_cancel_op` calls are removed; each mode branch does exactly one write via `append_control_op`.

## Tests

- Added `test_control_hook_stores_cancelled_status`: verifies the hook stores `"cancelled"` (not `"failure"`) when no prior result exists.
- Fixed `test_control_hook_cancels_and_preserves_completed_result`: was incorrectly asserting `"failure"` status; now correctly asserts the pre-set `"success"` result is preserved.
- Added `test_cancel_thread_result_set_before_control_file`: a spy on `append_control_op` that asserts the result is already `"cancelled"` in the cache _at the moment_ the control file is written, directly catching the race condition.

Closes #3258

<!-- gptme-id:v1:gai_LXIwKMlSH3Hs7w4ExplCd0Pea1XQ8j3UePHBRRXFUqM -->