### PR TITLE
feat(webui): add BranchMapPanel to right sidebar

### DIFF
--- a/webui/src/components/BranchMapPanel.tsx
+++ b/webui/src/components/BranchMapPanel.tsx
@@ -1,0 +1,94 @@
+import { GitBranch } from 'lucide-react';
+import { useObservable } from '@legendapp/state/react';
+import { use$ } from '@legendapp/state/react';
+import type { FC } from 'react';
+import { conversations$, setCurrentBranch } from '@/stores/conversations';
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
+
+interface BranchMapPanelProps {
+  conversationId: string;
+}
+
+export const BranchMapPanel: FC<BranchMapPanelProps> = ({ conversationId }) => {
+  const conversation$ = conversations$.get(conversationId);
+
+  const data$ = useObservable(() => {
+    const branches = conversation$?.data.branches?.get() ?? {};
+    const currentBranch = conversation$?.currentBranch?.get() ?? 'main';
+    return { branches, currentBranch };
+  });
+
+  const { branches, currentBranch } = use$(data$);
+
+  const branchEntries = Object.entries(branches ?? {});
+
+  if (branchEntries.length <= 1) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-3 p-6 text-center">
+        <GitBranch className="h-8 w-8 text-muted-foreground/50" />
+        <div className="text-sm text-muted-foreground">
+          <p className="font-medium">No branches</p>
+          <p className="mt-1 text-xs">
+            Use the fork tool to create branch points in this conversation.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  const sorted = [...branchEntries].sort(([a], [b]) => {
+    if (a === currentBranch) return -1;
+    if (b === currentBranch) return 1;
+    return a.localeCompare(b);
+  });
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden">
+      <div className="shrink-0 border-b px-3 py-2">
+        <span className="text-xs font-semibold text-muted-foreground">
+          BRANCHES ({branchEntries.length})
+        </span>
+      </div>
+      <div className="flex-1 space-y-0.5 overflow-y-auto p-1.5">
+        {sorted.map(([name, messages]) => {
+          const isActive = name === currentBranch;
+          const lastUserMsg = [...messages].reverse().find((m) => m.role === 'user');
+          const preview = lastUserMsg?.content?.slice(0, 60) ?? '';
+
+          return (
+            <button
+              key={name}
+              onClick={() => setCurrentBranch(conversationId, name)}
+              className={cn(
+                'w-full rounded-md px-2.5 py-2 text-left transition-colors',
+                isActive ? 'bg-accent text-accent-foreground' : 'text-foreground hover:bg-accent/50'
+              )}
+            >
+              <div className="flex items-center gap-2">
+                <GitBranch
+                  className={cn(
+                    'h-3.5 w-3.5 shrink-0',
+                    isActive ? 'text-primary' : 'text-muted-foreground'
+                  )}
+                />
+                <span className="flex-1 truncate text-xs font-medium">{name}</span>
+                <Badge
+                  variant={isActive ? 'default' : 'outline'}
+                  className="h-4 shrink-0 px-1 text-[10px]"
+                >
+                  {messages.length}
+                </Badge>
+              </div>
+              {preview && (
+                <p className="ml-[22px] mt-0.5 truncate text-[10px] text-muted-foreground">
+                  {preview}
+                </p>
+              )}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+};

--- a/webui/src/components/BranchMapPanel.tsx
+++ b/webui/src/components/BranchMapPanel.tsx
@@ -1,5 +1,4 @@
 import { GitBranch } from 'lucide-react';
-import { useObservable } from '@legendapp/state/react';
 import { use$ } from '@legendapp/state/react';
 import type { FC } from 'react';
 import { conversations$, setCurrentBranch } from '@/stores/conversations';
@@ -13,13 +12,8 @@ interface BranchMapPanelProps {
 export const BranchMapPanel: FC<BranchMapPanelProps> = ({ conversationId }) => {
   const conversation$ = conversations$.get(conversationId);
 
-  const data$ = useObservable(() => {
-    const branches = conversation$?.data.branches?.get() ?? {};
-    const currentBranch = conversation$?.currentBranch?.get() ?? 'main';
-    return { branches, currentBranch };
-  });
-
-  const { branches, currentBranch } = use$(data$);
+  const branches = use$(() => conversation$?.data.branches?.get()) ?? {};
+  const currentBranch = use$(() => conversation$?.currentBranch?.get()) ?? 'main';
 
   const branchEntries = Object.entries(branches ?? {});
 

--- a/webui/src/components/rightSidebarPanels.tsx
+++ b/webui/src/components/rightSidebarPanels.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react';
 import {
   Cpu,
+  GitBranch,
   Globe,
   FolderOpen,
   LayoutDashboard,
@@ -11,6 +12,7 @@ import {
 import type { LucideIcon } from 'lucide-react';
 import type { RightSidebarPanelId } from '@/types/sidebar';
 import { ArtifactsPanel } from './ArtifactsPanel';
+import { BranchMapPanel } from './BranchMapPanel';
 import { BrowserPreview } from './BrowserPreview';
 import { ComputerPreview } from './ComputerPreview';
 import { ConversationSettings } from './ConversationSettings';
@@ -47,6 +49,12 @@ export const rightSidebarPanels: RightSidebarPanelDefinition[] = [
     label: 'Artifacts',
     icon: Package,
     render: ({ conversationId }) => <ArtifactsPanel conversationId={conversationId} />,
+  },
+  {
+    id: 'branches',
+    label: 'Branches',
+    icon: GitBranch,
+    render: ({ conversationId }) => <BranchMapPanel conversationId={conversationId} />,
   },
   {
     id: 'panels',

--- a/webui/src/types/sidebar.ts
+++ b/webui/src/types/sidebar.ts
@@ -2,6 +2,7 @@ export type RightSidebarPanelId =
   | 'settings'
   | 'workspace'
   | 'artifacts'
+  | 'branches'
   | 'panels'
   | 'functions'
   | 'browser'


### PR DESCRIPTION
## Summary

- Adds a `BranchMapPanel` component to the right sidebar with a new **Branches** tab (GitBranch icon)
- Shows a global list of all branches in the current conversation: name, message count badge, and last-user-message preview
- Clicking any branch switches to it via `setCurrentBranch` from the conversations store
- Shows an empty state when the conversation has ≤1 branch
- The existing `BranchIndicator` (inline 1/N navigation at fork points) is unchanged — this panel complements it with a global overview

Inspired by Juggler's branching conversation tree UI (gptme peer research note 2026-07-15). The highest-value concrete slice is the global overview panel; a visual tree/graph can come later once people actually use branches.

## Technical notes

- `BranchMapPanel` uses `useObservable` from `@legendapp/state/react` to reactively read `branches` and `currentBranch` from the existing `conversations$` store
- `setCurrentBranch` (already exported from the store) handles branch switching
- `'branches'` added to `RightSidebarPanelId` union type
- TypeScript and ESLint pass clean

## Test plan

- [ ] Open a conversation in gptme-webui that has multiple branches (use the fork tool or send messages on different branches via the gptme API)
- [ ] Click the GitBranch icon in the right sidebar icon bar — the Branches panel opens
- [ ] Verify all branches are listed with their message counts
- [ ] Click a non-active branch — verify the conversation view switches to that branch
- [ ] Open a conversation with no branches — verify the empty state is shown