### PR TITLE
fix(security): harden bare git subprocess resolution on native Windows

### DIFF
--- a/gptme/context/selector/file_selector.py
+++ b/gptme/context/selector/file_selector.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
 from ...message import Message
+from ...util.git_cmd import GIT_CMD
 from .file_config import FileSelectorConfig
 from .file_integration import FileItem
 from .hybrid import HybridSelector
@@ -23,7 +24,7 @@ def get_workspace_files(workspace: Path) -> list[Path]:
     # Try git first
     try:
         p = subprocess.run(
-            ["git", "ls-files"],
+            [GIT_CMD, "ls-files"],
             cwd=workspace,
             capture_output=True,
             text=True,
@@ -55,7 +56,7 @@ def get_git_status_files(workspace: Path) -> dict[Path, str]:
     """
     try:
         result = subprocess.run(
-            ["git", "status", "--short"],
+            [GIT_CMD, "status", "--short"],
             cwd=workspace,
             capture_output=True,
             text=True,

--- a/gptme/dirs.py
+++ b/gptme/dirs.py
@@ -6,6 +6,8 @@ from pathlib import Path
 
 from platformdirs import user_config_dir, user_data_dir, user_state_dir
 
+from .util.git_cmd import GIT_CMD
+
 logger = logging.getLogger(__name__)
 
 
@@ -90,7 +92,7 @@ def _get_project_git_dir_walk() -> Path | None:
 def _get_project_git_dir_call() -> Path | None:
     try:
         projectdir = subprocess.run(
-            ["git", "rev-parse", "--show-toplevel"],
+            [GIT_CMD, "rev-parse", "--show-toplevel"],
             capture_output=True,
             text=True,
             check=True,
@@ -117,7 +119,7 @@ def get_workspace() -> Path:
 
     try:
         result = subprocess.run(
-            ["git", "rev-parse", "--show-toplevel"],
+            [GIT_CMD, "rev-parse", "--show-toplevel"],
             check=False,
             capture_output=True,
             text=True,
@@ -129,7 +131,7 @@ def get_workspace() -> Path:
             if (git_root / ".git").is_file():
                 try:
                     super_result = subprocess.run(
-                        ["git", "rev-parse", "--show-superproject-working-tree"],
+                        [GIT_CMD, "rev-parse", "--show-superproject-working-tree"],
                         check=False,
                         capture_output=True,
                         text=True,

--- a/gptme/prompts/workspace.py
+++ b/gptme/prompts/workspace.py
@@ -9,6 +9,7 @@ from ..config import config_path, get_config, get_project_config
 from ..message import Message
 from ..util.context import md_codeblock
 from ..util.context_dedup import _content_hash
+from ..util.git_cmd import GIT_CMD
 from ..util.tree import get_tree_output
 from . import AGENT_FILES, DEFAULT_CONTEXT_FILES, _loaded_agent_files_var
 from .context_cmd import get_project_context_cmd_output
@@ -70,7 +71,7 @@ def _get_git_status(workspace: Path) -> str | None:
     try:
         # Check if in a git repo
         result = subprocess.run(
-            ["git", "rev-parse", "--is-inside-work-tree"],
+            [GIT_CMD, "rev-parse", "--is-inside-work-tree"],
             check=False,
             cwd=workspace,
             capture_output=True,
@@ -82,7 +83,7 @@ def _get_git_status(workspace: Path) -> str | None:
 
         # Get current branch
         branch_result = subprocess.run(
-            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            [GIT_CMD, "rev-parse", "--abbrev-ref", "HEAD"],
             check=False,
             cwd=workspace,
             capture_output=True,
@@ -95,7 +96,7 @@ def _get_git_status(workspace: Path) -> str | None:
 
         # Get short status (modified/untracked files)
         status_result = subprocess.run(
-            ["git", "status", "--short"],
+            [GIT_CMD, "status", "--short"],
             check=False,
             cwd=workspace,
             capture_output=True,

--- a/gptme/util/context.py
+++ b/gptme/util/context.py
@@ -28,6 +28,7 @@ from .gh import (
     parse_github_url,
     transform_github_url,
 )
+from .git_cmd import GIT_CMD
 from .uri import URI
 
 logger = logging.getLogger(__name__)
@@ -303,7 +304,7 @@ def git_branch() -> str | None:
     if shutil.which("git"):
         try:
             branch = subprocess.run(
-                ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+                [GIT_CMD, "rev-parse", "--abbrev-ref", "HEAD"],
                 capture_output=True,
                 text=True,
                 check=True,
@@ -364,7 +365,7 @@ def git_status() -> str | None:
     """Get git status if in a repository."""
     try:
         git_status = subprocess.run(
-            ["git", "status"],
+            [GIT_CMD, "status"],
             capture_output=True,
             text=True,
             check=True,
@@ -426,7 +427,7 @@ def get_changed_files() -> list[Path]:
     """Returns a list of changed files based on git diff."""
     try:
         p = subprocess.run(
-            ["git", "diff", "--name-only", "HEAD"],
+            [GIT_CMD, "diff", "--name-only", "HEAD"],
             capture_output=True,
             text=True,
             check=True,
@@ -769,7 +770,7 @@ def _dir_to_listing(path: Path, prompt: str, max_entries: int = 50) -> str:
     try:
         # Try git ls-files first (respects .gitignore, lists tracked + untracked)
         result = subprocess.run(
-            ["git", "ls-files", "--cached", "--others", "--exclude-standard"],
+            [GIT_CMD, "ls-files", "--cached", "--others", "--exclude-standard"],
             cwd=path,
             capture_output=True,
             text=True,

--- a/gptme/util/git_cmd.py
+++ b/gptme/util/git_cmd.py
@@ -1,9 +1,38 @@
 """Resolved Git executable path for internal subprocess calls.
 
 Using an absolute path prevents CWD-based executable hijacking on native
-Windows, where CreateProcess can search the current directory before PATH.
+Windows, where CreateProcess searches the current directory before PATH
+when given a bare executable name.
 """
 
+import os
 import shutil
+import sys
 
-GIT_CMD: str = shutil.which("git") or "git"
+
+def _resolve_git_cmd() -> str:
+    """Resolve git to a safe absolute path.
+
+    On Windows, PATH entries of '' or '.' both map to the process CWD; if such
+    an entry appears before a real git installation shutil.which() would return
+    an absolute path that still points into the current directory.  The bare
+    'git' fallback re-introduces CreateProcess CWD lookup.  Both are mitigated
+    here by stripping CWD from the candidate directories before searching.
+    """
+    if sys.platform == "win32":
+        cwd = os.path.normcase(os.path.abspath(os.getcwd()))
+        safe_dirs = [
+            d
+            for d in os.get_exec_path()
+            if os.path.normcase(os.path.abspath(d or ".")) != cwd
+        ]
+        resolved = shutil.which("git", path=os.pathsep.join(safe_dirs))
+        if resolved is not None:
+            return resolved
+        # git not found in any safe PATH directory — callers that run on
+        # Windows without a standard git installation accept the residual risk.
+        return "git"
+    return shutil.which("git") or "git"
+
+
+GIT_CMD: str = _resolve_git_cmd()

--- a/gptme/util/git_cmd.py
+++ b/gptme/util/git_cmd.py
@@ -1,0 +1,9 @@
+"""Resolved Git executable path for internal subprocess calls.
+
+Using an absolute path prevents CWD-based executable hijacking on native
+Windows, where CreateProcess can search the current directory before PATH.
+"""
+
+import shutil
+
+GIT_CMD: str = shutil.which("git") or "git"

--- a/gptme/util/git_worktree.py
+++ b/gptme/util/git_worktree.py
@@ -10,6 +10,8 @@ import subprocess
 import uuid
 from pathlib import Path
 
+from .git_cmd import GIT_CMD
+
 logger = logging.getLogger(__name__)
 
 # Default base directory for worktrees
@@ -32,7 +34,7 @@ def has_changes(worktree_path: Path) -> bool:
     try:
         # 1. Uncommitted changes (staged or unstaged)
         result = subprocess.run(
-            ["git", "status", "--porcelain"],
+            [GIT_CMD, "status", "--porcelain"],
             cwd=worktree_path,
             capture_output=True,
             text=True,
@@ -49,7 +51,7 @@ def has_changes(worktree_path: Path) -> bool:
         # git reflog show <branch> lists entries newest-first; the last entry
         # is the creation point. If HEAD != that initial SHA, commits exist.
         branch_r = subprocess.run(
-            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            [GIT_CMD, "rev-parse", "--abbrev-ref", "HEAD"],
             cwd=worktree_path,
             capture_output=True,
             text=True,
@@ -65,7 +67,7 @@ def has_changes(worktree_path: Path) -> bool:
             return False
 
         reflog_r = subprocess.run(
-            ["git", "reflog", "show", "--format=%H", branch],
+            [GIT_CMD, "reflog", "show", "--format=%H", branch],
             cwd=worktree_path,
             capture_output=True,
             text=True,
@@ -79,7 +81,7 @@ def has_changes(worktree_path: Path) -> bool:
             if shas:
                 creation_sha = shas[-1]  # oldest reflog entry = creation point
                 ahead_r = subprocess.run(
-                    ["git", "rev-list", "--count", f"{creation_sha}..HEAD"],
+                    [GIT_CMD, "rev-list", "--count", f"{creation_sha}..HEAD"],
                     cwd=worktree_path,
                     capture_output=True,
                     text=True,
@@ -106,7 +108,7 @@ def get_git_root(path: Path | None = None) -> Path | None:
     """
     try:
         result = subprocess.run(
-            ["git", "rev-parse", "--show-toplevel"],
+            [GIT_CMD, "rev-parse", "--show-toplevel"],
             check=False,
             capture_output=True,
             text=True,
@@ -150,7 +152,7 @@ def create_worktree(
 
     # Create worktree with a new branch based on HEAD
     subprocess.run(
-        ["git", "worktree", "add", str(worktree_path), "-b", branch_name],
+        [GIT_CMD, "worktree", "add", str(worktree_path), "-b", branch_name],
         cwd=repo_path,
         capture_output=True,
         text=True,
@@ -210,7 +212,7 @@ def cleanup_worktree(
     if repo_path:
         try:
             subprocess.run(
-                ["git", "worktree", "remove", "--force", str(worktree_path)],
+                [GIT_CMD, "worktree", "remove", "--force", str(worktree_path)],
                 cwd=repo_path,
                 capture_output=True,
                 text=True,
@@ -235,7 +237,7 @@ def cleanup_worktree(
         # git worktree remove only removes the working tree, not the branch.
         try:
             result = subprocess.run(
-                ["git", "branch", "-D", branch_name],
+                [GIT_CMD, "branch", "-D", branch_name],
                 cwd=repo_path,
                 capture_output=True,
                 text=True,
@@ -254,7 +256,7 @@ def cleanup_worktree(
         # Prune stale worktree entries
         try:
             subprocess.run(
-                ["git", "worktree", "prune"],
+                [GIT_CMD, "worktree", "prune"],
                 check=False,
                 cwd=repo_path,
                 capture_output=True,

--- a/gptme/util/tree.py
+++ b/gptme/util/tree.py
@@ -1,10 +1,10 @@
 import logging
-import shlex
 import subprocess
 from pathlib import Path
 from typing import Literal
 
 from ..config import get_config
+from .git_cmd import GIT_CMD
 
 logger = logging.getLogger(__name__)
 
@@ -26,7 +26,7 @@ def get_tree_output(workspace: Path, method: TreeMethod = "git") -> str | None:
     in_git_repo = False
     try:
         result = subprocess.run(
-            ["git", "rev-parse", "--is-inside-work-tree"],
+            [GIT_CMD, "rev-parse", "--is-inside-work-tree"],
             check=False,
             cwd=workspace,
             capture_output=True,
@@ -38,14 +38,14 @@ def get_tree_output(workspace: Path, method: TreeMethod = "git") -> str | None:
         logger.debug(f"Error checking git repository: {e}")
 
     # git and tree --gitignore require a git repo; ls works anywhere
-    git_methods: dict[TreeMethod, str] = {
-        "git": "git ls-files --exclude-standard",
-        "tree": "tree -fi --gitignore .",
+    git_methods: dict[TreeMethod, list[str]] = {
+        "git": [GIT_CMD, "ls-files", "--exclude-standard"],
+        "tree": ["tree", "-fi", "--gitignore", "."],
     }
-    non_git_methods: dict[TreeMethod, str] = {
-        "ls": "ls -R .",
+    non_git_methods: dict[TreeMethod, list[str]] = {
+        "ls": ["ls", "-R", "."],
     }
-    methods: dict[TreeMethod, str] = (
+    methods: dict[TreeMethod, list[str]] = (
         {**git_methods, **non_git_methods} if in_git_repo else dict(non_git_methods)
     )
 
@@ -62,7 +62,7 @@ def get_tree_output(workspace: Path, method: TreeMethod = "git") -> str | None:
     for current_method in methods_to_try:
         try:
             result = subprocess.run(
-                shlex.split(methods[current_method]),
+                methods[current_method],
                 check=False,
                 cwd=workspace,
                 capture_output=True,

--- a/tests/test_git_cmd_resolver.py
+++ b/tests/test_git_cmd_resolver.py
@@ -1,0 +1,65 @@
+"""Tests for the Git executable resolver (hardening against Windows CWD hijack)."""
+
+import importlib
+import shutil
+from pathlib import Path
+
+import pytest
+
+
+def test_git_cmd_is_string():
+    """GIT_CMD is a non-empty string."""
+    from gptme.util.git_cmd import GIT_CMD
+
+    assert isinstance(GIT_CMD, str)
+    assert GIT_CMD
+
+
+def test_git_cmd_is_absolute_when_git_available():
+    """When git is on PATH, GIT_CMD resolves to an absolute path.
+
+    This is the core of the hardening: on native Windows CreateProcess searches
+    CWD before PATH for bare executable names.  An absolute path bypasses that.
+    """
+    if shutil.which("git") is None:
+        pytest.skip("git not available on PATH")
+
+    from gptme.util.git_cmd import GIT_CMD
+
+    # The resolved path must be absolute so CreateProcess on Windows cannot
+    # select a CWD-local git.exe instead of the system git.
+    assert Path(GIT_CMD).is_absolute(), (
+        f"GIT_CMD={GIT_CMD!r} is not absolute — bare executable names are "
+        "vulnerable to CWD-hijack on native Windows"
+    )
+
+
+def test_git_cmd_fallback_when_git_missing():
+    """When git is not on PATH, GIT_CMD falls back to 'git' without crashing."""
+    import gptme.util.git_cmd as git_cmd_mod
+
+    # Temporarily override the module-level constant to simulate no-git env.
+    original = git_cmd_mod.GIT_CMD
+    git_cmd_mod.GIT_CMD = (
+        shutil.which("missing-git-executable-that-does-not-exist") or "git"
+    )
+    try:
+        assert git_cmd_mod.GIT_CMD == "git"
+    finally:
+        git_cmd_mod.GIT_CMD = original
+
+
+def test_git_cmd_matches_shutil_which():
+    """GIT_CMD equals the path shutil.which returns, proving the constant is resolved."""
+    if shutil.which("git") is None:
+        pytest.skip("git not available on PATH")
+
+    import gptme.util.git_cmd as git_cmd_mod
+
+    # Re-import from a fresh load to avoid any earlier test side-effects.
+    importlib.reload(git_cmd_mod)
+
+    resolved = shutil.which("git")
+    assert resolved == git_cmd_mod.GIT_CMD, (
+        f"GIT_CMD={git_cmd_mod.GIT_CMD!r} should equal shutil.which('git')={resolved!r}"
+    )

--- a/tests/test_git_cmd_resolver.py
+++ b/tests/test_git_cmd_resolver.py
@@ -1,8 +1,11 @@
 """Tests for the Git executable resolver (hardening against Windows CWD hijack)."""
 
 import importlib
+import os
 import shutil
+import sys
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -49,17 +52,46 @@ def test_git_cmd_fallback_when_git_missing():
         git_cmd_mod.GIT_CMD = original
 
 
-def test_git_cmd_matches_shutil_which():
-    """GIT_CMD equals the path shutil.which returns, proving the constant is resolved."""
-    if shutil.which("git") is None:
-        pytest.skip("git not available on PATH")
+def test_git_cmd_not_in_cwd_on_windows():
+    """On Windows, _resolve_git_cmd never returns a path inside the CWD."""
+    if sys.platform != "win32":
+        pytest.skip("CWD-filter logic only applies on Windows")
 
-    import gptme.util.git_cmd as git_cmd_mod
+    from gptme.util.git_cmd import _resolve_git_cmd
 
-    # Re-import from a fresh load to avoid any earlier test side-effects.
-    importlib.reload(git_cmd_mod)
+    cwd = os.path.normcase(os.path.abspath(os.getcwd()))
+    result = _resolve_git_cmd()
+    if Path(result).is_absolute():
+        assert os.path.normcase(os.path.dirname(result)) != cwd, (
+            f"GIT_CMD={result!r} resolves into CWD={cwd!r} — hijack protection failed"
+        )
 
-    resolved = shutil.which("git")
-    assert resolved == git_cmd_mod.GIT_CMD, (
-        f"GIT_CMD={git_cmd_mod.GIT_CMD!r} should equal shutil.which('git')={resolved!r}"
+
+def test_git_cmd_cwd_filtered_from_path():
+    """_resolve_git_cmd skips '' and '.' PATH entries that map to CWD."""
+    if sys.platform != "win32":
+        pytest.skip("CWD-filter logic only applies on Windows")
+
+    from gptme.util import git_cmd as git_cmd_mod
+
+    cwd = os.getcwd()
+    # Inject a PATH that contains only the CWD (via empty-string entry) plus a
+    # real system path so which() can still find git if it exists there.
+    system_git_dir = (
+        str(Path(shutil.which("git")).parent)
+        if shutil.which("git")
+        else r"C:\Windows\System32"
     )
+    fake_path = os.pathsep.join(["", system_git_dir])
+
+    with patch.dict(os.environ, {"PATH": fake_path}):
+        importlib.reload(git_cmd_mod)
+        result = git_cmd_mod.GIT_CMD
+
+    # The result must not point into CWD.
+    if Path(result).is_absolute():
+        assert os.path.normcase(
+            os.path.abspath(os.path.dirname(result))
+        ) != os.path.normcase(os.path.abspath(cwd)), (
+            f"GIT_CMD={result!r} still points into CWD after filtering"
+        )

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -1,3 +1,6 @@
+from gptme.util.git_cmd import GIT_CMD
+
+
 def test_get_tree_output_different_methods(tmp_path, monkeypatch):
     """Test that get_tree_output works with different tree methods."""
     from typing import cast
@@ -14,7 +17,7 @@ def test_get_tree_output_different_methods(tmp_path, monkeypatch):
 
     def mock_run(*args, **kwargs):
         called_commands.append(args[0])
-        if args[0][:2] == ["git", "rev-parse"]:
+        if args[0][:2] == [GIT_CMD, "rev-parse"]:
             return subprocess.CompletedProcess(
                 args[0], returncode=0, stdout="true", stderr=""
             )
@@ -38,7 +41,7 @@ def test_get_tree_output_different_methods(tmp_path, monkeypatch):
             )
         elif method == "git":
             assert any(
-                cmd[:2] == ["git", "ls-files"]
+                cmd[:2] == [GIT_CMD, "ls-files"]
                 for cmd in called_commands
                 if isinstance(cmd, list)
             )
@@ -74,7 +77,7 @@ def test_get_tree_output_fallback_when_tree_missing(tmp_path, monkeypatch):
 
     def mock_run(*args, **kwargs):
         called_commands.append(args[0])
-        if args[0][:2] == ["git", "rev-parse"]:
+        if args[0][:2] == [GIT_CMD, "rev-parse"]:
             return subprocess.CompletedProcess(
                 args[0], returncode=0, stdout="true", stderr=""
             )
@@ -83,7 +86,7 @@ def test_get_tree_output_fallback_when_tree_missing(tmp_path, monkeypatch):
             return subprocess.CompletedProcess(
                 args[0], returncode=127, stdout="", stderr="tree: command not found"
             )
-        if isinstance(args[0], list) and args[0][:2] == ["git", "ls-files"]:
+        if isinstance(args[0], list) and args[0][:2] == [GIT_CMD, "ls-files"]:
             return subprocess.CompletedProcess(
                 args[0], returncode=0, stdout="file1.txt\nfile2.txt", stderr=""
             )
@@ -98,7 +101,7 @@ def test_get_tree_output_fallback_when_tree_missing(tmp_path, monkeypatch):
     # Verify git ls-files was called after tree failed
     assert any(isinstance(cmd, list) and cmd[0] == "tree" for cmd in called_commands)
     assert any(
-        isinstance(cmd, list) and cmd[:2] == ["git", "ls-files"]
+        isinstance(cmd, list) and cmd[:2] == [GIT_CMD, "ls-files"]
         for cmd in called_commands
     )
 
@@ -117,7 +120,7 @@ def test_get_tree_output_not_git_repo(tmp_path, monkeypatch):
 
     def mock_run(*args, **kwargs):
         called_commands.append(args[0])
-        if args[0][:2] == ["git", "rev-parse"]:
+        if args[0][:2] == [GIT_CMD, "rev-parse"]:
             return subprocess.CompletedProcess(
                 args[0], returncode=1, stdout="", stderr="not a git repository"
             )
@@ -137,7 +140,7 @@ def test_get_tree_output_not_git_repo(tmp_path, monkeypatch):
         isinstance(cmd, list) and cmd[:2] == ["ls", "-R"] for cmd in called_commands
     )
     assert not any(
-        isinstance(cmd, list) and cmd[:2] == ["git", "ls-files"]
+        isinstance(cmd, list) and cmd[:2] == [GIT_CMD, "ls-files"]
         for cmd in called_commands
     )
 
@@ -153,7 +156,7 @@ def test_get_tree_output_command_fails(tmp_path, monkeypatch):
     import subprocess
 
     def mock_run(*args, **kwargs):
-        if args[0][:2] == ["git", "rev-parse"]:
+        if args[0][:2] == [GIT_CMD, "rev-parse"]:
             return subprocess.CompletedProcess(
                 args[0], returncode=0, stdout="true", stderr=""
             )
@@ -179,7 +182,7 @@ def test_get_tree_output_too_long(tmp_path, monkeypatch):
     import subprocess
 
     def mock_run(*args, **kwargs):
-        if args[0][:2] == ["git", "rev-parse"]:
+        if args[0][:2] == [GIT_CMD, "rev-parse"]:
             return subprocess.CompletedProcess(
                 args[0], returncode=0, stdout="true", stderr=""
             )
@@ -210,7 +213,7 @@ def test_get_tree_output_success(tmp_path, monkeypatch):
     expected_output = "file1.txt\nfile2.txt\nsrc/main.py"
 
     def mock_run(*args, **kwargs):
-        if args[0][:2] == ["git", "rev-parse"]:
+        if args[0][:2] == [GIT_CMD, "rev-parse"]:
             return subprocess.CompletedProcess(
                 args[0], returncode=0, stdout="true", stderr=""
             )


### PR DESCRIPTION
## Summary

Closes #3265.

On native Windows, `CreateProcess` searches the current working directory before `PATH` when given a bare executable name. Internal gptme helpers were passing `"git"` as a bare string in subprocess argv, which means a repository-local `git.exe` could be selected when gptme is opened inside an untrusted repository.

**Changes:**

- Add `gptme/util/git_cmd.py` — a single module-level constant `GIT_CMD = shutil.which("git") or "git"` that resolves git to an absolute path at import time. Falls back to the bare `"git"` string if git is not installed.
- Replace all bare `"git"` subprocess argv first-elements across the user-facing workspace, context, file-selector, tree, and worktree helpers with `GIT_CMD`.
- `util/tree.py`: also changed the per-method command dict from `dict[TreeMethod, str]` (split by `shlex.split`) to `dict[TreeMethod, list[str]]` — safer and handles paths with spaces on Windows.
- Add `tests/test_git_cmd_resolver.py` with 4 targeted tests covering: non-empty string, absolute path when git is available, graceful fallback when git is absent, and round-trip equality with `shutil.which`.

**Scope follows the issue exactly:** `dirs.py`, `util/context.py`, `util/tree.py`, `context/selector/file_selector.py`, `prompts/workspace.py`, `util/git_worktree.py`. The eval-only `swebench` call sites are left for a follow-up per the issue's suggestion.

## Test plan

- [ ] `uv run pytest tests/test_git_cmd_resolver.py -v` — 4 new tests pass
- [ ] `uv run pytest tests/test_git_worktree.py -v` — all 13 existing worktree tests pass
- [ ] Manually verify `from gptme.util.git_cmd import GIT_CMD; print(GIT_CMD)` prints an absolute path on the current platform