### PR TITLE
fix(security): extend GIT_CMD hardening to all remaining bare git subprocess call sites

### DIFF
--- a/gptme/__version__.py
+++ b/gptme/__version__.py
@@ -2,6 +2,8 @@ import importlib.metadata
 import os.path
 import subprocess
 
+from .util.git_cmd import GIT_CMD
+
 _cached_version: str | None = None
 
 
@@ -16,7 +18,7 @@ def get_git_version(package_dir):
 
         if (
             subprocess.call(
-                ["git", "rev-parse", "--is-inside-work-tree"],
+                [GIT_CMD, "rev-parse", "--is-inside-work-tree"],
                 cwd=package_dir,
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
@@ -24,12 +26,12 @@ def get_git_version(package_dir):
             )
             == 0
         ):
-            tags = git_cmd(["git", "tag", "--list", "v*", "--sort=-v:refname"])
+            tags = git_cmd([GIT_CMD, "tag", "--list", "v*", "--sort=-v:refname"])
             if tags:
                 latest_tag = tags.split("\n")[0]
                 version = latest_tag.lstrip("v")
-                commit_hash = git_cmd(["git", "rev-parse", "--short", "HEAD"])
-                is_dirty = bool(git_cmd(["git", "status", "--porcelain"]))
+                commit_hash = git_cmd([GIT_CMD, "rev-parse", "--short", "HEAD"])
+                is_dirty = bool(git_cmd([GIT_CMD, "status", "--porcelain"]))
                 version += f"+{commit_hash}"
                 if is_dirty:
                     version += ".dirty"

--- a/gptme/agent/doctor.py
+++ b/gptme/agent/doctor.py
@@ -12,6 +12,8 @@ from pathlib import Path
 
 import tomlkit
 
+from ..util.git_cmd import GIT_CMD
+
 try:
     import yaml
 
@@ -188,7 +190,7 @@ def check_git(workspace: Path, report: DoctorReport) -> None:
     # Check for remote
     try:
         result = subprocess.run(
-            ["git", "remote", "get-url", "origin"],
+            [GIT_CMD, "remote", "get-url", "origin"],
             cwd=workspace,
             capture_output=True,
             text=True,
@@ -275,7 +277,7 @@ def check_submodules(workspace: Path, report: DoctorReport, fix: bool = False) -
 
     try:
         result = subprocess.run(
-            ["git", "submodule", "status"],
+            [GIT_CMD, "submodule", "status"],
             cwd=workspace,
             capture_output=True,
             text=True,
@@ -301,7 +303,7 @@ def check_submodules(workspace: Path, report: DoctorReport, fix: bool = False) -
             )
             if fix:
                 subprocess.run(
-                    ["git", "submodule", "update", "--init", "--recursive"],
+                    [GIT_CMD, "submodule", "update", "--init", "--recursive"],
                     cwd=workspace,
                     capture_output=True,
                     timeout=60,

--- a/gptme/agent/workspace.py
+++ b/gptme/agent/workspace.py
@@ -36,6 +36,7 @@ from gptme.prompts import get_prompt
 from ..dirs import get_logs_dir
 from ..logmanager import LogManager
 from ..tools import get_toolchain
+from ..util.git_cmd import GIT_CMD
 
 logger = logging.getLogger(__name__)
 
@@ -91,7 +92,7 @@ def create_workspace_from_template(
     _success = False
     try:
         # Clone template repository
-        clone_cmd = ["git", "clone"]
+        clone_cmd = [GIT_CMD, "clone"]
         if template_branch:
             clone_cmd.extend(["--branch", template_branch])
         clone_cmd.extend([template_repo, str(temp_dir)])
@@ -106,7 +107,7 @@ def create_workspace_from_template(
         # Update submodules
         logger.info("Updating submodules")
         result = subprocess.run(
-            ["git", "submodule", "update", "--init", "--recursive"],
+            [GIT_CMD, "submodule", "update", "--init", "--recursive"],
             capture_output=True,
             check=False,
             cwd=temp_dir,
@@ -375,7 +376,7 @@ def _replace_template_strings(path: Path, agent_name: str) -> None:
     files: list[Path] = []
     try:
         result = subprocess.run(
-            ["git", "ls-files", "--cached", "--others", "--exclude-standard", "-z"],
+            [GIT_CMD, "ls-files", "--cached", "--others", "--exclude-standard", "-z"],
             cwd=path,
             capture_output=True,
             check=True,
@@ -439,7 +440,7 @@ def _reset_git_history(path: Path, agent_name: str) -> None:
     # Use -c flags to bypass global git hooks and set identity for CI environments
     # where user.email/user.name may not be configured globally
     git_no_hooks = [
-        "git",
+        GIT_CMD,
         "-c",
         "core.hooksPath=/dev/null",
         "-c",

--- a/gptme/attestation.py
+++ b/gptme/attestation.py
@@ -14,6 +14,7 @@ from typing import Any
 
 from .__version__ import __version__
 from .llm.models.resolution import get_default_model
+from .util.git_cmd import GIT_CMD
 from .util.git_worktree import get_git_root
 
 _SESSION_ENV_VARS = (
@@ -62,7 +63,7 @@ def _base62_encode(data: bytes, *, min_length: int = 1) -> str:
 def _run_git(repo_root: Path, args: list[str]) -> str:
     try:
         result = subprocess.run(
-            ["git", *args],
+            [GIT_CMD, *args],
             cwd=repo_root,
             check=False,
             capture_output=True,

--- a/gptme/checkpoint.py
+++ b/gptme/checkpoint.py
@@ -30,6 +30,7 @@ from pathlib import Path
 from typing import Literal
 
 from .dirs import get_state_dir
+from .util.git_cmd import GIT_CMD
 
 BackendKind = Literal["clean_git", "dirty_git", "non_git", "multi_root"]
 
@@ -78,7 +79,7 @@ def _git(repo: Path, *args: str) -> str:
     """Run ``git`` in ``repo``; return stripped stdout, or ``''`` on non-zero."""
     try:
         proc = subprocess.run(
-            ["git", *args],
+            [GIT_CMD, *args],
             cwd=str(repo),
             capture_output=True,
             text=True,
@@ -392,7 +393,7 @@ def restore_checkpoint(
         return f"Already at checkpoint {record.head_sha[:12]} — nothing to restore."
 
     result = subprocess.run(
-        ["git", "reset", "--hard", record.head_sha],
+        [GIT_CMD, "reset", "--hard", record.head_sha],
         check=False,
         cwd=decision.repo_root,
         capture_output=True,
@@ -407,7 +408,7 @@ def restore_checkpoint(
         # git reset --hard does not remove untracked files; clean them up so the
         # workspace is truly restored to the checkpointed state.
         clean = subprocess.run(
-            ["git", "clean", "-fd"],
+            [GIT_CMD, "clean", "-fd"],
             check=False,
             cwd=decision.repo_root,
             capture_output=True,
@@ -435,7 +436,7 @@ def diff_checkpoint(workspace: str | Path, identifier: str) -> str:
     record = _resolve_checkpoint(decision.repo_root, identifier)
 
     result = subprocess.run(
-        ["git", "diff", record.head_sha],
+        [GIT_CMD, "diff", record.head_sha],
         check=False,
         cwd=decision.repo_root,
         capture_output=True,

--- a/gptme/cli/cmd_init.py
+++ b/gptme/cli/cmd_init.py
@@ -19,6 +19,8 @@ from pathlib import Path
 
 import click
 
+from ..util.git_cmd import GIT_CMD
+
 logger = logging.getLogger(__name__)
 
 GPTME_TOML_TEMPLATE = """\
@@ -337,7 +339,7 @@ def _scaffold_from_template(
     else:
         click.echo(f"  Cloning template from {template_url}...")
         result = subprocess.run(
-            ["git", "clone", template_url, str(target)],
+            [GIT_CMD, "clone", template_url, str(target)],
             capture_output=True,
             text=True,
             check=False,

--- a/gptme/cli/cmd_status.py
+++ b/gptme/cli/cmd_status.py
@@ -20,6 +20,8 @@ from pathlib import Path
 
 import click
 
+from ..util.git_cmd import GIT_CMD
+
 logger = logging.getLogger(__name__)
 
 
@@ -36,7 +38,7 @@ def _run(cmd: list[str], *, timeout: int = 10) -> str:
 
 
 def _git_root() -> Path | None:
-    raw = _run(["git", "rev-parse", "--show-toplevel"])
+    raw = _run([GIT_CMD, "rev-parse", "--show-toplevel"])
     return Path(raw) if raw else None
 
 
@@ -74,7 +76,7 @@ def _active_tasks(lines: int = 3) -> list[dict]:
 
 
 def _recent_commits(n: int = 3) -> list[str]:
-    raw = _run(["git", "log", "--oneline", f"-{n}", "--no-merges"])
+    raw = _run([GIT_CMD, "log", "--oneline", f"-{n}", "--no-merges"])
     return raw.splitlines() if raw else []
 
 

--- a/gptme/cli/util.py
+++ b/gptme/cli/util.py
@@ -41,6 +41,8 @@ from typing import TYPE_CHECKING
 
 import click
 
+from ..util.git_cmd import GIT_CMD
+
 if TYPE_CHECKING:
     from rich.tree import Tree as RichTree
 
@@ -403,7 +405,7 @@ def _git_run(cmd: list[str], check: bool = True, timeout: int = 10) -> tuple[str
         env = os.environ.copy()
         env.update({"PAGER": "cat", "GIT_PAGER": "cat", "GIT_TERMINAL_PROMPT": "0"})
         result = subprocess.run(
-            ["git"] + cmd,
+            [GIT_CMD] + cmd,
             capture_output=True,
             text=True,
             check=check,

--- a/gptme/eval/main.py
+++ b/gptme/eval/main.py
@@ -26,6 +26,7 @@ from tabulate import tabulate
 from ..config import get_config
 from ..message import len_tokens
 from ..tools import ToolFormat
+from ..util.git_cmd import GIT_CMD
 from .run import run_evals
 from .suites import suites, tests_default, tests_default_ids, tests_map
 from .types import CaseResult, EvalResult, EvalSpec, ModelConfig
@@ -69,7 +70,7 @@ def docker_reexec(argv: list[str]) -> None:
     # Get git root
     try:
         git_root = subprocess.check_output(
-            ["git", "rev-parse", "--show-toplevel"],
+            [GIT_CMD, "rev-parse", "--show-toplevel"],
             text=True,
             cwd=Path(__file__).parent,
             timeout=10,
@@ -1004,7 +1005,7 @@ def _get_commit_hash() -> str:
     """Get current commit hash and dirty status, like: a8b2ef0-dirty."""
     try:
         git_result = subprocess.run(
-            ["git", "describe", "--always", "--dirty", "--exclude", "'*'"],
+            [GIT_CMD, "describe", "--always", "--dirty", "--exclude", "'*'"],
             check=False,
             text=True,
             capture_output=True,

--- a/gptme/eval/swebench/evaluate.py
+++ b/gptme/eval/swebench/evaluate.py
@@ -8,6 +8,7 @@ from gptme.eval.agents import Agent
 from gptme.eval.cost import get_eval_costs, token_fields_from_cost
 from gptme.eval.types import CaseResult, EvalResult
 from gptme.util.cost_tracker import CostTracker
+from gptme.util.git_cmd import GIT_CMD
 
 from .retrieval import retrieve_files_for_prompt
 from .utils import (
@@ -227,7 +228,7 @@ def evaluate_instance(
     # Capture diff from agent workspace (repo copy)
     try:
         diff_result = subprocess.run(
-            ["git", "diff"],
+            [GIT_CMD, "diff"],
             cwd=agent.workspace_dir,
             capture_output=True,
             text=True,

--- a/gptme/eval/swebench/utils.py
+++ b/gptme/eval/swebench/utils.py
@@ -4,6 +4,8 @@ import os
 import subprocess
 from pathlib import Path
 
+from ...util.git_cmd import GIT_CMD
+
 logger = logging.getLogger(__name__)
 
 # SWE-bench prediction format keys
@@ -133,7 +135,7 @@ def setup_github_repo(repo: str, base_commit: str, base_dir: str | None = None) 
             logger.info(f"Cloning repository {repo} to {repo_dir}")
             os.makedirs(repo_dir, exist_ok=True)
             subprocess.run(
-                ["git", "clone", f"https://github.com/{repo}.git", repo_dir],
+                [GIT_CMD, "clone", f"https://github.com/{repo}.git", repo_dir],
                 check=True,
                 capture_output=True,
                 text=True,
@@ -142,7 +144,7 @@ def setup_github_repo(repo: str, base_commit: str, base_dir: str | None = None) 
 
         logger.info(f"Checking out commit {base_commit} in {repo_dir}")
         subprocess.run(
-            ["git", "fetch", "origin"],
+            [GIT_CMD, "fetch", "origin"],
             check=True,
             capture_output=True,
             text=True,
@@ -150,7 +152,7 @@ def setup_github_repo(repo: str, base_commit: str, base_dir: str | None = None) 
             timeout=120,
         )
         subprocess.run(
-            ["git", "checkout", base_commit],
+            [GIT_CMD, "checkout", base_commit],
             check=True,
             capture_output=True,
             text=True,

--- a/gptme/hooks/workspace_agents.py
+++ b/gptme/hooks/workspace_agents.py
@@ -31,6 +31,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 from ..hooks import HookType, StopPropagation, register_hook
 from ..message import Message
+from ..util.git_cmd import GIT_CMD
 
 if TYPE_CHECKING:
     from collections.abc import Generator
@@ -785,7 +786,7 @@ def _get_git_branch(cwd: str) -> str | None:
     try:
         return (
             subprocess.check_output(
-                ["git", "-C", cwd, "rev-parse", "--abbrev-ref", "HEAD"],
+                [GIT_CMD, "-C", cwd, "rev-parse", "--abbrev-ref", "HEAD"],
                 stderr=subprocess.DEVNULL,
                 text=True,
                 timeout=10,

--- a/gptme/lessons/installer.py
+++ b/gptme/lessons/installer.py
@@ -17,6 +17,7 @@ from pathlib import Path
 import yaml
 
 from ..dirs import get_config_dir
+from ..util.git_cmd import GIT_CMD
 
 logger = logging.getLogger(__name__)
 
@@ -175,7 +176,7 @@ def _clone_skill_from_git(url: str, skill_path: str | None, dest: Path) -> Path 
         try:
             subprocess.run(
                 [
-                    "git",
+                    GIT_CMD,
                     "clone",
                     "--depth",
                     "1",
@@ -203,7 +204,7 @@ def _clone_skill_from_git(url: str, skill_path: str | None, dest: Path) -> Path 
         if skill_path:
             try:
                 subprocess.run(
-                    ["git", "sparse-checkout", "set", skill_path],
+                    [GIT_CMD, "sparse-checkout", "set", skill_path],
                     cwd=tmp,
                     check=True,
                     capture_output=True,

--- a/gptme/server/tasks_api.py
+++ b/gptme/server/tasks_api.py
@@ -25,6 +25,7 @@ from ..logmanager import LogManager
 from ..message import Message
 from ..prompts import get_prompt
 from ..tools import get_toolchain
+from ..util.git_cmd import GIT_CMD
 from .auth import require_auth
 from .openapi_docs import ErrorResponse, StatusResponse, api_doc_simple
 
@@ -389,7 +390,7 @@ def get_git_status(workspace_path: Path) -> dict[str, Any]:
 
         # Check if it's a git repository
         result = subprocess.run(
-            ["git", "rev-parse", "--git-dir"],
+            [GIT_CMD, "rev-parse", "--git-dir"],
             cwd=workspace_path,
             capture_output=True,
             text=True,
@@ -403,7 +404,7 @@ def get_git_status(workspace_path: Path) -> dict[str, Any]:
 
         # Get current branch
         branch_result = subprocess.run(
-            ["git", "branch", "--show-current"],
+            [GIT_CMD, "branch", "--show-current"],
             cwd=workspace_path,
             capture_output=True,
             text=True,
@@ -418,7 +419,7 @@ def get_git_status(workspace_path: Path) -> dict[str, Any]:
 
         # Get status
         status_result = subprocess.run(
-            ["git", "status", "--porcelain"],
+            [GIT_CMD, "status", "--porcelain"],
             cwd=workspace_path,
             capture_output=True,
             text=True,
@@ -434,7 +435,7 @@ def get_git_status(workspace_path: Path) -> dict[str, Any]:
         upstream_branch = None
         for candidate in ["origin/main", "origin/master", "origin/develop"]:
             check_result = subprocess.run(
-                ["git", "rev-parse", "--verify", candidate],
+                [GIT_CMD, "rev-parse", "--verify", candidate],
                 cwd=workspace_path,
                 capture_output=True,
                 text=True,
@@ -449,7 +450,7 @@ def get_git_status(workspace_path: Path) -> dict[str, Any]:
         diff_stats = {"files_changed": 0, "lines_added": 0, "lines_removed": 0}
         if upstream_branch:
             diff_stat_result = subprocess.run(
-                ["git", "diff", "--stat", upstream_branch, "HEAD"],
+                [GIT_CMD, "diff", "--stat", upstream_branch, "HEAD"],
                 cwd=workspace_path,
                 capture_output=True,
                 text=True,
@@ -486,7 +487,7 @@ def get_git_status(workspace_path: Path) -> dict[str, Any]:
         commits = []
         if upstream_branch:
             log_result = subprocess.run(
-                ["git", "log", "--oneline", f"{upstream_branch}..HEAD"],
+                [GIT_CMD, "log", "--oneline", f"{upstream_branch}..HEAD"],
                 cwd=workspace_path,
                 capture_output=True,
                 text=True,
@@ -499,7 +500,7 @@ def get_git_status(workspace_path: Path) -> dict[str, Any]:
         else:
             # Fallback: show recent commits if no upstream found
             log_result = subprocess.run(
-                ["git", "log", "--oneline", "-5"],
+                [GIT_CMD, "log", "--oneline", "-5"],
                 cwd=workspace_path,
                 capture_output=True,
                 text=True,
@@ -512,7 +513,7 @@ def get_git_status(workspace_path: Path) -> dict[str, Any]:
 
         # Try to get remote info for PR detection
         remote_result = subprocess.run(
-            ["git", "config", "--get", "remote.origin.url"],
+            [GIT_CMD, "config", "--get", "remote.origin.url"],
             cwd=workspace_path,
             capture_output=True,
             text=True,

--- a/gptme/tools/autocommit.py
+++ b/gptme/tools/autocommit.py
@@ -24,6 +24,7 @@ from ..config import get_config
 from ..hooks import HookType, StopPropagation
 from ..logmanager import check_for_modifications
 from ..message import Message
+from ..util.git_cmd import GIT_CMD
 from .base import ToolSpec
 
 if TYPE_CHECKING:
@@ -42,7 +43,7 @@ def autocommit() -> Message:
         # See if there are any changes to commit by checking for
         # changes, excluding untracked files.
         status_result_porcelain = subprocess.run(
-            ["git", "status", "--porcelain", "--untracked-files=no"],
+            [GIT_CMD, "status", "--porcelain", "--untracked-files=no"],
             capture_output=True,
             text=True,
             check=True,
@@ -54,12 +55,12 @@ def autocommit() -> Message:
 
         # Get current git status
         status_result = subprocess.run(
-            ["git", "status"], capture_output=True, text=True, check=True, timeout=30
+            [GIT_CMD, "status"], capture_output=True, text=True, check=True, timeout=30
         )
 
         # Get git diff to show what changed
         diff_result = subprocess.run(
-            ["git", "diff", "HEAD"],
+            [GIT_CMD, "diff", "HEAD"],
             capture_output=True,
             text=True,
             check=True,

--- a/gptme/tools/precommit.py
+++ b/gptme/tools/precommit.py
@@ -40,6 +40,7 @@ from ..hooks import HookType, StopPropagation
 from ..logmanager import check_for_modifications
 from ..message import Message
 from ..util.context import md_codeblock
+from ..util.git_cmd import GIT_CMD
 from .base import ToolSpec
 
 if TYPE_CHECKING:
@@ -110,7 +111,7 @@ def _get_modified_files() -> list[str]:
     try:
         # Modified (unstaged) + staged files
         result = subprocess.run(
-            ["git", "diff", "--name-only", "HEAD"],
+            [GIT_CMD, "diff", "--name-only", "HEAD"],
             capture_output=True,
             text=True,
             check=False,
@@ -121,7 +122,7 @@ def _get_modified_files() -> list[str]:
 
         # Untracked files (new files not yet added to git)
         result = subprocess.run(
-            ["git", "ls-files", "--others", "--exclude-standard"],
+            [GIT_CMD, "ls-files", "--others", "--exclude-standard"],
             capture_output=True,
             text=True,
             check=False,

--- a/gptme/util/gh.py
+++ b/gptme/util/gh.py
@@ -12,6 +12,8 @@ import subprocess
 import urllib.parse
 from pathlib import Path
 
+from .git_cmd import GIT_CMD
+
 logger = logging.getLogger(__name__)
 
 # Default threshold for truncating long comment bodies
@@ -172,7 +174,7 @@ def _get_repo_from_git_remote(
     """
     try:
         result = subprocess.run(
-            ["git", "remote", "get-url", "origin"],
+            [GIT_CMD, "remote", "get-url", "origin"],
             capture_output=True,
             text=True,
             check=True,

--- a/gptme/workspace_snapshot.py
+++ b/gptme/workspace_snapshot.py
@@ -25,6 +25,7 @@ from pathlib import Path
 
 from .checkpoint import repo_fingerprint
 from .dirs import get_state_dir
+from .util.git_cmd import GIT_CMD
 
 logger = logging.getLogger(__name__)
 
@@ -64,7 +65,7 @@ class Shadow:
         if env:
             run_env.update(env)
         return subprocess.run(
-            ["git", *args],
+            [GIT_CMD, *args],
             env=run_env,
             cwd=self.workspace,
             check=check,
@@ -104,16 +105,16 @@ def init_shadow(workspace: Path) -> Shadow:
 
     shadow.git_dir.mkdir(parents=True, exist_ok=True)
     subprocess.run(
-        ["git", "init", "--quiet", "--bare", str(shadow.git_dir)], check=True
+        [GIT_CMD, "init", "--quiet", "--bare", str(shadow.git_dir)], check=True
     )
     # Operate via env vars, not via the bare-repo working-tree machinery.
     subprocess.run(
-        ["git", "--git-dir", str(shadow.git_dir), "config", "core.bare", "false"],
+        [GIT_CMD, "--git-dir", str(shadow.git_dir), "config", "core.bare", "false"],
         check=True,
     )
     subprocess.run(
         [
-            "git",
+            GIT_CMD,
             "--git-dir",
             str(shadow.git_dir),
             "config",
@@ -124,7 +125,7 @@ def init_shadow(workspace: Path) -> Shadow:
     )
     subprocess.run(
         [
-            "git",
+            GIT_CMD,
             "--git-dir",
             str(shadow.git_dir),
             "config",
@@ -137,7 +138,7 @@ def init_shadow(workspace: Path) -> Shadow:
     # cannot fire on our internal snapshots.
     subprocess.run(
         [
-            "git",
+            GIT_CMD,
             "--git-dir",
             str(shadow.git_dir),
             "symbolic-ref",

--- a/tests/test_tools_autocommit.py
+++ b/tests/test_tools_autocommit.py
@@ -20,7 +20,6 @@ from gptme.tools.autocommit import (
     handle_commit_command,
     tool,
 )
-from gptme.util.git_cmd import GIT_CMD
 
 # ── autocommit() ────────────────────────────────────────────────────────
 
@@ -178,6 +177,8 @@ class TestAutocommit:
     @patch("gptme.tools.autocommit.subprocess.run")
     def test_three_git_commands_called(self, mock_run: MagicMock):
         """When changes exist, exactly 3 git commands are run: porcelain, status, diff."""
+        from gptme.util.git_cmd import GIT_CMD
+
         mock_run.side_effect = [
             MagicMock(stdout=" M a.py\n", returncode=0),
             MagicMock(stdout="status output", returncode=0),
@@ -188,7 +189,7 @@ class TestAutocommit:
 
         assert mock_run.call_count == 3
         cmds = [call[0][0] for call in mock_run.call_args_list]
-        assert GIT_CMD in cmds[0]
+        assert cmds[0][0] == GIT_CMD
         assert "--porcelain" in cmds[0]
         assert cmds[1] == [GIT_CMD, "status"]
         assert cmds[2] == [GIT_CMD, "diff", "HEAD"]

--- a/tests/test_tools_autocommit.py
+++ b/tests/test_tools_autocommit.py
@@ -20,6 +20,7 @@ from gptme.tools.autocommit import (
     handle_commit_command,
     tool,
 )
+from gptme.util.git_cmd import GIT_CMD
 
 # ── autocommit() ────────────────────────────────────────────────────────
 
@@ -187,10 +188,10 @@ class TestAutocommit:
 
         assert mock_run.call_count == 3
         cmds = [call[0][0] for call in mock_run.call_args_list]
-        assert "git" in cmds[0]
+        assert GIT_CMD in cmds[0]
         assert "--porcelain" in cmds[0]
-        assert cmds[1] == ["git", "status"]
-        assert cmds[2] == ["git", "diff", "HEAD"]
+        assert cmds[1] == [GIT_CMD, "status"]
+        assert cmds[2] == [GIT_CMD, "diff", "HEAD"]
 
 
 # ── handle_commit_command() ──────────────────────────────────────────────

--- a/tests/test_util_gh.py
+++ b/tests/test_util_gh.py
@@ -96,8 +96,10 @@ def _mock_git_remote(url: str):
     """Helper to mock subprocess.run for git remote get-url."""
     import subprocess
 
+    from gptme.util.git_cmd import GIT_CMD
+
     def fake_run(cmd, **kwargs):
-        if cmd == ["git", "remote", "get-url", "origin"]:
+        if cmd == [GIT_CMD, "remote", "get-url", "origin"]:
             return subprocess.CompletedProcess(cmd, 0, stdout=url + "\n", stderr="")
         raise subprocess.CalledProcessError(1, cmd)
 


### PR DESCRIPTION
## Summary

PR #3266 introduced `GIT_CMD` (an absolute, Windows-CWD-filtered git path from `gptme/util/git_cmd.py`) and applied it to the workspace/context/selector/tree/worktree/dirs surface. This PR extends the same hardening to the **18 remaining files** that were not covered by the initial audit.

### Files changed

| File | What was using bare `"git"` |
|------|-----------------------------|
| `gptme/tools/autocommit.py` | `status`, `diff HEAD` — runs on every turn in autocommit mode |
| `gptme/tools/precommit.py` | `diff --name-only`, `ls-files` — runs on every file save |
| `gptme/server/tasks_api.py` | `rev-parse`, `branch`, `status`, `rev-parse --verify`, `diff --stat`, `log`, `config` |
| `gptme/cli/cmd_status.py` | `rev-parse --show-toplevel`, `log --oneline` |
| `gptme/cli/util.py` | `_git_run()` helper |
| `gptme/util/gh.py` | `remote get-url origin` — GitHub repo detection |
| `gptme/hooks/workspace_agents.py` | `rev-parse --abbrev-ref HEAD` |
| `gptme/checkpoint.py` | `_git()` helper + `reset --hard`, `clean -fd`, `diff` |
| `gptme/attestation.py` | `_run_git()` helper |
| `gptme/workspace_snapshot.py` | Shadow-repo `init`, `config`, `symbolic-ref` + `Shadow._run()` |
| `gptme/__version__.py` | Editable-install version detection (`rev-parse`, `tag`, `status`) |
| `gptme/agent/workspace.py` | `clone`, `submodule update`, `ls-files`, `git_no_hooks` base list |
| `gptme/agent/doctor.py` | `remote get-url origin`, `submodule status/update` |
| `gptme/lessons/installer.py` | Skill `clone --sparse` + `sparse-checkout set` |
| `gptme/cli/cmd_init.py` | Template `clone` |
| `gptme/eval/main.py` | `rev-parse --show-toplevel`, `describe` |
| `gptme/eval/swebench/evaluate.py` | `diff` capture |
| `gptme/eval/swebench/utils.py` | Repo `clone`, `fetch origin`, `checkout` |

## Testing

- All 11 existing `test_git_cmd_resolver.py` and `test_tree.py` tests pass (2 Windows-only tests correctly skipped on Linux).
- All modified modules import cleanly.
- Pre-commit (ruff, mypy) passes.

Closes #3265