### PR TITLE
fix(logmanager): don't merge adjacent tool-result system messages

### DIFF
--- a/gptme/logmanager/manager.py
+++ b/gptme/logmanager/manager.py
@@ -738,10 +738,20 @@ def _merge_consecutive_messages(msgs: list[Message]) -> list[Message]:
     Dropping an assistant turn between two user turns creates a sequence strict
     providers reject.  Merge the adjacent messages while preserving attachments
     and message flags via Message.concat().
+
+    Exception: system messages with a call_id are structured tool results.
+    Merging them would discard all but the first call_id, causing providers
+    that use the Responses API (Codex/OpenAI) to return 400 "No tool output
+    found for function call <id>" on the next multi-tool-call turn.
     """
     merged: list[Message] = []
     for msg in msgs:
-        if merged and merged[-1].role == msg.role:
+        if (
+            merged
+            and merged[-1].role == msg.role
+            and not msg.call_id
+            and not merged[-1].call_id
+        ):
             merged[-1] = merged[-1].concat(msg)
         else:
             merged.append(msg)

--- a/tests/test_llm_openai_subscription.py
+++ b/tests/test_llm_openai_subscription.py
@@ -176,6 +176,54 @@ def test_stream_builds_shared_responses_request_shape():
     assert request_json["tools"][0]["name"] == "save"
 
 
+def test_stream_preserves_both_call_ids_for_multi_tool_assistant_turn():
+    """Regression: _merge_consecutive_messages was merging adjacent tool-result
+    system messages, dropping the second call_id.  When an assistant turn
+    contains two tool calls (call_A, call_B), two system messages are produced
+    in sequence.  prune_ephemeral_messages → _merge_consecutive_messages must
+    NOT merge them, so both function_call_output items survive in the Codex
+    Responses API input.  Without the fix the API returns 400:
+    "No tool output found for function call call_B"."""
+    response = _FakeSSEStreamResponse([{"type": "response.done"}])
+    init_tools(allowlist=["save"])
+    save_tool = get_tool("save")
+    assert save_tool is not None
+
+    messages = [
+        Message(role="system", content="You are concise."),
+        Message(role="user", content="Save two files."),
+        Message(
+            role="assistant",
+            content=(
+                '@save(call_A): {"path": "a.txt", "content": "a"}\n'
+                '@save(call_B): {"path": "b.txt", "content": "b"}'
+            ),
+        ),
+        Message(role="system", content="Saved a.txt", call_id="call_A"),
+        Message(role="system", content="Saved b.txt", call_id="call_B"),
+    ]
+
+    with (
+        patch("gptme.llm.llm_openai_subscription.get_auth", return_value=_make_auth()),
+        patch(
+            "gptme.llm.llm_openai_subscription.requests.post", return_value=response
+        ) as mock_post,
+    ):
+        list(llm_openai_subscription.stream(messages, "gpt-5.4", tools=[save_tool]))
+
+    request_json = mock_post.call_args.kwargs["json"]
+    input_items = request_json["input"]
+
+    fc_outputs = [it for it in input_items if it.get("type") == "function_call_output"]
+    assert len(fc_outputs) == 2, (
+        f"Expected 2 function_call_output items, got {len(fc_outputs)}: {fc_outputs}"
+    )
+    output_call_ids = {it["call_id"] for it in fc_outputs}
+    assert output_call_ids == {"call_A", "call_B"}, (
+        f"Expected both call_ids to be present; got {output_call_ids}"
+    )
+
+
 def test_stream_forwards_max_tokens_as_max_output_tokens():
     """max_tokens passed to stream() must appear as max_output_tokens in the POST body."""
     response = _FakeSSEStreamResponse([{"type": "response.done"}])

--- a/tests/test_logmanager.py
+++ b/tests/test_logmanager.py
@@ -9,6 +9,7 @@ from gptme.logmanager import (
     check_for_modifications,
     conversation_name_error,
 )
+from gptme.logmanager.manager import _merge_consecutive_messages
 from gptme.message import Message
 from gptme.tools import init_tools
 
@@ -371,6 +372,44 @@ def test_read_jsonl_malformed(tmp_path):
     assert len(log.messages) == 2
     assert log.messages[0].content == "hello"
     assert log.messages[1].content == "world"
+
+
+def test_merge_consecutive_does_not_merge_tool_result_messages():
+    """Regression: _merge_consecutive_messages must NOT merge adjacent system
+    messages that carry distinct call_ids.
+
+    When an assistant turn contains two tool calls (call_A, call_B), gptme
+    appends two system messages in sequence.  prune_ephemeral_messages() always
+    calls _merge_consecutive_messages() before the next LLM request.  If that
+    merge collapses the two messages into one (keeping only call_A via
+    Message.concat()), the Codex/OpenAI Responses API receives a
+    function_call(A) + function_call(B) but only a single
+    function_call_output(A) and returns 400: "No tool output found for
+    function call call_B".
+    """
+    msgs = [
+        Message(role="system", content="result A", call_id="call_A"),
+        Message(role="system", content="result B", call_id="call_B"),
+    ]
+    result = _merge_consecutive_messages(msgs)
+    assert len(result) == 2, (
+        f"Tool-result messages must NOT be merged; got {len(result)} message(s): {result}"
+    )
+    assert result[0].call_id == "call_A"
+    assert result[1].call_id == "call_B"
+
+
+def test_merge_consecutive_still_merges_plain_same_role_messages():
+    """Non-tool-result adjacent system messages (no call_id) should still be
+    merged as before — the fix must not regress the original pruning purpose."""
+    msgs = [
+        Message(role="system", content="part one"),
+        Message(role="system", content="part two"),
+    ]
+    result = _merge_consecutive_messages(msgs)
+    assert len(result) == 1
+    assert "part one" in result[0].content
+    assert "part two" in result[0].content
 
 
 def test_read_jsonl_unknown_field(tmp_path):


### PR DESCRIPTION
## Summary

- **Root cause**: `_merge_consecutive_messages()` in `logmanager/manager.py` was merging adjacent `system` messages with the same role via `Message.concat()`, which keeps `self.call_id` and drops `other.call_id`. When an assistant turn emits two tool calls (A, B), gptme appends two system messages (`call_id=A`, `call_id=B`). On the next LLM request, `prepare_messages()` → `prune_ephemeral_messages()` → `_merge_consecutive_messages()` collapses them to one message with only `call_id=A`. The Responses API then sees `function_call(A)` + `function_call(B)` but only `function_call_output(A)` → **400 "No tool output found for function call B"**.
- **Fix**: skip merging when either the accumulator or the incoming message has a `call_id` set (i.e. is a structured tool result). Plain adjacent system messages without `call_id` continue to merge as before.
- **Impact**: 9 autonomous Codex sessions (gpt-5.6-sol) failed with this error, each wasting ~15 min of budget.

## Test plan

- `test_merge_consecutive_does_not_merge_tool_result_messages` — directly tests the fixed function; was RED before the fix, GREEN after.
- `test_merge_consecutive_still_merges_plain_same_role_messages` — regression guard for the original merge behavior (no call_id → still merges).
- `test_stream_preserves_both_call_ids_for_multi_tool_assistant_turn` — integration test verifying both `call_id`s appear as `function_call_output` items in the Responses API request body.

```
# Run locally
pytest tests/test_logmanager.py tests/test_llm_openai_subscription.py -v
# 45 passed
```