### PR TITLE
fix(security): replace last bare 'git' subprocess call in tasks_api with GIT_CMD

### DIFF
--- a/gptme/server/tasks_api.py
+++ b/gptme/server/tasks_api.py
@@ -652,7 +652,7 @@ def setup_task_workspace(task_id: str, target_repo: str | None = None) -> Path:
             try:
                 subprocess.run(
                     [
-                        "git",
+                        GIT_CMD,
                         "clone",
                         f"https://github.com/{target_repo}.git",
                         str(repo_path),


### PR DESCRIPTION
## Summary

PRs #3266 and #3267 introduced `GIT_CMD` (an absolute-path-resolved git executable from `gptme/util/git_cmd.py`) and applied the hardening across all call sites audited at the time. However, one call site was missed:

- `gptme/server/tasks_api.py:655` — the `git clone` inside `setup_task_workspace()` still used bare `"git"` despite the file already importing `GIT_CMD` at line 28.

This single-line fix completes the hardening and fully resolves #3265.

## Change

```diff
-                        "git",
+                        GIT_CMD,
```

No new imports needed — `GIT_CMD` was already imported in the file.

## Testing

- All 3 existing `test_git_cmd_resolver.py` tests pass (2 Windows-only tests correctly skipped on Linux)
- Module imports cleanly

Closes #3265