### PR TITLE
feat(webui): warn on server API incompatibility

### DIFF
--- a/webui/src/components/MenuBar.tsx
+++ b/webui/src/components/MenuBar.tsx
@@ -8,9 +8,10 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from './ui/dropdown-menu';
-import { ChevronDown, HelpCircle, Menu, Search, User } from 'lucide-react';
+import { AlertTriangle, ChevronDown, HelpCircle, Menu, Search, User } from 'lucide-react';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { useEmbeddedContext } from '@/contexts/EmbeddedContext';
+import { useApi } from '@/contexts/ApiContext';
 import type { EmbeddedMenuItem } from '@/lib/embeddedContext';
 import { Link } from 'react-router-dom';
 import { appRoute } from '@/utils/routes';
@@ -18,6 +19,7 @@ import { commandPaletteOpen$ } from '@/stores/commandPalette';
 import { shortcutsDialogOpen$ } from '@/stores/shortcutsDialog';
 import { leftSidebarVisible$, toggleLeftSidebar } from '@/stores/sidebar';
 import { use$ } from '@legendapp/state/react';
+import { settingsModal$ } from '@/stores/settingsModal';
 
 import { Fragment, type FC } from 'react';
 
@@ -38,6 +40,8 @@ function groupEmbeddedMenuItems(menuItems: EmbeddedMenuItem[]) {
 
 export const MenuBar: FC = () => {
   const leftSidebarOpen = use$(leftSidebarVisible$);
+  const { api } = useApi();
+  const compatibilityWarning = use$(api.compatibilityWarning$);
   const { menuItems, sendAction, isEmbedded } = useEmbeddedContext();
   const embeddedMenuGroups = groupEmbeddedMenuItems(menuItems);
   const hasEmbeddedMenu = isEmbedded && embeddedMenuGroups.length > 0;
@@ -70,6 +74,31 @@ export const MenuBar: FC = () => {
       </div>
 
       <div className="flex items-center gap-1 sm:gap-4">
+        {compatibilityWarning && (
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-7 w-7 text-amber-700 dark:text-amber-300"
+                  onClick={() => {
+                    settingsModal$.open.set(true);
+                    settingsModal$.category.set('servers');
+                  }}
+                  aria-label="Server compatibility warning"
+                >
+                  <AlertTriangle className="h-4 w-4" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">
+                {compatibilityWarning.kind === 'server_older'
+                  ? 'Server update recommended'
+                  : 'Server API version differs from this web UI'}
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        )}
         <TooltipProvider>
           <Tooltip>
             <TooltipTrigger asChild>

--- a/webui/src/components/WelcomeView.tsx
+++ b/webui/src/components/WelcomeView.tsx
@@ -6,7 +6,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { use$, useObservable } from '@legendapp/state/react';
 import { ChatInput, type ChatOptions } from '@/components/ChatInput';
-import { History, Server, Copy, RotateCcw } from 'lucide-react';
+import { AlertTriangle, History, Server, Copy, RotateCcw } from 'lucide-react';
 import { useSettings } from '@/contexts/SettingsContext';
 import { ExamplesSection } from '@/components/ExamplesSection';
 import { serverRegistry$, getConnectedServers } from '@/stores/servers';
@@ -52,6 +52,7 @@ export const WelcomeView = () => {
   const queryClient = useQueryClient();
   const isConnected = use$(isConnected$);
   const lastConnectionResult = use$(api.lastConnectionResult$);
+  const compatibilityWarning = use$(api.compatibilityWarning$);
   const providerStatusVersion = use$(setupWizard$.providerStatusVersion);
   const registry = use$(serverRegistry$);
   const connectedServers = getConnectedServers();
@@ -309,6 +310,34 @@ export const WelcomeView = () => {
                 </p>
               </div>
             </div>
+
+            {isConnected && compatibilityWarning && (
+              <Alert className="mx-auto w-full max-w-2xl border-amber-500/30 bg-amber-500/10 text-left">
+                <AlertTriangle className="h-4 w-4 text-amber-700 dark:text-amber-300" />
+                <AlertTitle>
+                  {compatibilityWarning.kind === 'server_older'
+                    ? 'Server update recommended'
+                    : 'Server compatibility warning'}
+                </AlertTitle>
+                <AlertDescription className="space-y-3">
+                  <p>
+                    {compatibilityWarning.kind === 'server_older'
+                      ? `This server uses contract revision ${compatibilityWarning.serverContractRevision}, but this web UI needs revision ${compatibilityWarning.minimumContractRevision}. Some features may be unavailable until the server is updated.`
+                      : `This server uses API v${compatibilityWarning.serverApiVersion}, but this web UI expects API v${compatibilityWarning.clientApiVersion}. Some features may not work correctly.`}
+                  </p>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => {
+                      settingsModal$.open.set(true);
+                      settingsModal$.category.set('servers');
+                    }}
+                  >
+                    Update server
+                  </Button>
+                </AlertDescription>
+              </Alert>
+            )}
 
             {!isConnected && (
               <Alert className="mx-auto w-full max-w-2xl border-amber-500/30 bg-amber-500/10 text-left">

--- a/webui/src/components/__tests__/MenuBar.test.tsx
+++ b/webui/src/components/__tests__/MenuBar.test.tsx
@@ -1,0 +1,64 @@
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { observable } from '@legendapp/state';
+import { MenuBar } from '../MenuBar';
+import { settingsModal$ } from '@/stores/settingsModal';
+
+const compatibilityWarning$ = observable<null | {
+  kind: 'server_older' | 'api_major_mismatch';
+  serverApiVersion: number;
+  serverContractRevision: number;
+  clientApiVersion: number;
+  minimumContractRevision: number;
+}>(null);
+
+jest.mock('@/contexts/ApiContext', () => ({
+  useApi: () => ({ api: { compatibilityWarning$ } }),
+}));
+
+jest.mock('@/contexts/EmbeddedContext', () => ({
+  useEmbeddedContext: () => ({ menuItems: [], sendAction: jest.fn(), isEmbedded: false }),
+}));
+
+jest.mock('react-router-dom', () => ({
+  Link: ({ children }: { children: React.ReactNode }) => <a href="/chat">{children}</a>,
+}));
+
+jest.mock('@/utils/routes', () => ({
+  appRoute: (path: string) => path,
+}));
+
+jest.mock('../ServerSelector', () => ({
+  ServerSelector: () => <div data-testid="server-selector" />,
+}));
+
+describe('MenuBar compatibility warning', () => {
+  beforeEach(() => {
+    compatibilityWarning$.set(null);
+    settingsModal$.set({ open: false, category: 'appearance' });
+  });
+
+  it('stays hidden for compatible servers', () => {
+    render(<MenuBar />);
+
+    expect(
+      screen.queryByRole('button', { name: 'Server compatibility warning' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('remains visible across routes and opens server settings', () => {
+    compatibilityWarning$.set({
+      kind: 'server_older',
+      serverApiVersion: 2,
+      serverContractRevision: 0,
+      clientApiVersion: 2,
+      minimumContractRevision: 1,
+    });
+
+    render(<MenuBar />);
+    fireEvent.click(screen.getByRole('button', { name: 'Server compatibility warning' }));
+
+    expect(settingsModal$.open.get()).toBe(true);
+    expect(settingsModal$.category.get()).toBe('servers');
+  });
+});

--- a/webui/src/components/__tests__/WelcomeView.test.tsx
+++ b/webui/src/components/__tests__/WelcomeView.test.tsx
@@ -12,6 +12,13 @@ const mockConnect = jest.fn();
 const mockFetch = jest.fn();
 const mockIsDemoMode = jest.fn(() => false);
 const isConnected$ = observable(true);
+const compatibilityWarning$ = observable<null | {
+  kind: 'server_older' | 'api_major_mismatch';
+  serverApiVersion: number;
+  serverContractRevision: number;
+  clientApiVersion: number;
+  minimumContractRevision: number;
+}>(null);
 const lastConnectionResult$ = observable<null | {
   ok: false;
   url: string;
@@ -59,6 +66,7 @@ jest.mock('@/contexts/ApiContext', () => {
         createConversationWithPlaceholder: jest.fn(),
         authHeader: null,
         lastConnectionResult$,
+        compatibilityWarning$,
       },
       isConnected$,
       connect: mockConnect,
@@ -106,6 +114,7 @@ describe('WelcomeView', () => {
     setLocation('http://localhost/');
     isConnected$.set(true);
     lastConnectionResult$.set(null);
+    compatibilityWarning$.set(null);
     mockBaseUrl = 'http://localhost:5700';
     setupWizard$.step.set('welcome');
     setupWizard$.open.set(false);
@@ -433,6 +442,48 @@ describe('WelcomeView', () => {
     await waitFor(() => {
       expect(screen.queryByText('Provider setup required')).not.toBeInTheDocument();
     });
+  });
+
+  it('warns without disconnecting when the server contract is older', () => {
+    compatibilityWarning$.set({
+      kind: 'server_older',
+      serverApiVersion: 2,
+      serverContractRevision: 0,
+      clientApiVersion: 2,
+      minimumContractRevision: 1,
+    });
+
+    render(
+      <SettingsProvider>
+        <WelcomeView />
+      </SettingsProvider>
+    );
+
+    expect(screen.getByText('Server update recommended')).toBeInTheDocument();
+    expect(
+      screen.getByText(/server uses contract revision 0.*needs revision 1/i)
+    ).toBeInTheDocument();
+    expect(screen.getByText(/some features may be unavailable/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Update server' })).toBeInTheDocument();
+  });
+
+  it('warns without disconnecting when the API major differs', () => {
+    compatibilityWarning$.set({
+      kind: 'api_major_mismatch',
+      serverApiVersion: 3,
+      serverContractRevision: 1,
+      clientApiVersion: 2,
+      minimumContractRevision: 1,
+    });
+
+    render(
+      <SettingsProvider>
+        <WelcomeView />
+      </SettingsProvider>
+    );
+
+    expect(screen.getByText('Server compatibility warning')).toBeInTheDocument();
+    expect(screen.getByText(/server uses API v3.*web UI expects API v2/i)).toBeInTheDocument();
   });
 
   it('shows "server not running" guidance for a network/refused error on the default local server', () => {

--- a/webui/src/utils/__tests__/api.test.ts
+++ b/webui/src/utils/__tests__/api.test.ts
@@ -205,6 +205,31 @@ describe('ApiClient API compatibility', () => {
     expect(client.compatibilityWarning$.get()).toBeNull();
   });
 
+  it('clears a stale compatibility warning when a subsequent probe fails', async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          api_version: CLIENT_API_VERSION + 1,
+          contract_revision: CLIENT_MIN_CONTRACT_REVISION,
+        }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 503,
+        statusText: 'Service Unavailable',
+      } as Response);
+
+    const client = new ApiClient('http://127.0.0.1:5700');
+
+    await client.checkConnection();
+    expect(client.compatibilityWarning$.get()).not.toBeNull();
+    await client.checkConnection();
+    expect(client.compatibilityWarning$.get()).toBeNull();
+    expect(client.isConnected$.get()).toBe(false);
+  });
+
   it('keeps legacy servers without version metadata compatible', async () => {
     global.fetch = jest
       .fn()

--- a/webui/src/utils/__tests__/api.test.ts
+++ b/webui/src/utils/__tests__/api.test.ts
@@ -252,6 +252,57 @@ describe('ApiClient API compatibility', () => {
     await expect(client.checkConnection()).resolves.toBe(true);
     expect(client.compatibilityWarning$.get()).toBeNull();
   });
+
+  it('discards stale probe results when a newer probe finishes first', async () => {
+    // Simulate: probe A (older, incompatible) starts first; probe B (newer, compatible) starts
+    // second and would finish next. Without a generation guard, probe A's catch-path
+    // `compatibilityWarning$.set(null)` or success-path write would overwrite probe B's warning.
+    // With the guard: probe A sees _probeNonce !== nonceA and silently returns false.
+    let resolveOldProbe!: (r: Response) => void;
+    let resolveNewProbe!: (r: Response) => void;
+
+    const oldProbePromise = new Promise<Response>((res) => {
+      resolveOldProbe = res;
+    });
+    const newProbePromise = new Promise<Response>((res) => {
+      resolveNewProbe = res;
+    });
+
+    global.fetch = jest
+      .fn()
+      .mockReturnValueOnce(oldProbePromise)
+      .mockReturnValueOnce(newProbePromise);
+
+    const client = new ApiClient('http://127.0.0.1:5700');
+
+    // Start probe A (nonce=1) — it won't resolve yet.
+    const probeA = client.checkConnection();
+
+    // Start probe B (nonce=2) — probe A is now stale.
+    const probeB = client.checkConnection();
+
+    // Probe B resolves first with an incompatible server.
+    resolveNewProbe({
+      ok: true,
+      json: async () => ({
+        api_version: CLIENT_API_VERSION + 1,
+        contract_revision: CLIENT_MIN_CONTRACT_REVISION,
+      }),
+    } as Response);
+    await probeB;
+    expect(client.compatibilityWarning$.get()).not.toBeNull();
+
+    // Probe A (stale) resolves with a network error — must NOT clear the warning.
+    resolveOldProbe({
+      ok: false,
+      status: 503,
+      statusText: 'Service Unavailable',
+    } as Response);
+    await probeA;
+
+    // Warning from probe B must survive.
+    expect(client.compatibilityWarning$.get()).not.toBeNull();
+  });
 });
 
 describe('ApiClient error parsing', () => {

--- a/webui/src/utils/__tests__/api.test.ts
+++ b/webui/src/utils/__tests__/api.test.ts
@@ -10,7 +10,14 @@ jest.mock('@/stores/servers', () => ({
   getPrimaryClient: jest.fn(),
 }));
 
-import { ApiClient, ApiClientError, getApiErrorPresentation, isLikelyChromeCorsPna } from '../api';
+import {
+  ApiClient,
+  ApiClientError,
+  CLIENT_API_VERSION,
+  CLIENT_MIN_CONTRACT_REVISION,
+  getApiErrorPresentation,
+  isLikelyChromeCorsPna,
+} from '../api';
 
 class MockEventSource {
   static instances: MockEventSource[] = [];
@@ -89,6 +96,136 @@ describe('isLikelyChromeCorsPna', () => {
   it('returns false for invalid URL', () => {
     setHostname('chat.gptme.org');
     expect(isLikelyChromeCorsPna('not-a-url')).toBe(false);
+  });
+});
+
+describe('ApiClient API compatibility', () => {
+  const originalFetch = global.fetch;
+  const originalCrypto = global.crypto;
+
+  beforeEach(() => {
+    Object.defineProperty(global, 'crypto', {
+      value: {
+        ...originalCrypto,
+        randomUUID: jest.fn(() => 'test-client-id'),
+      },
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    Object.defineProperty(global, 'crypto', {
+      value: originalCrypto,
+      configurable: true,
+    });
+    jest.restoreAllMocks();
+  });
+
+  it('records compatible server contract metadata during connection', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        api_version: CLIENT_API_VERSION,
+        contract_revision: CLIENT_MIN_CONTRACT_REVISION,
+      }),
+    } as Response);
+
+    const client = new ApiClient('http://127.0.0.1:5700');
+
+    await expect(client.checkConnection()).resolves.toBe(true);
+    expect(client.compatibilityWarning$.get()).toBeNull();
+  });
+
+  it('warns but remains connected when the server contract is older', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        api_version: CLIENT_API_VERSION,
+        contract_revision: CLIENT_MIN_CONTRACT_REVISION - 1,
+      }),
+    } as Response);
+
+    const client = new ApiClient('http://127.0.0.1:5700');
+
+    await expect(client.checkConnection()).resolves.toBe(true);
+    expect(client.isConnected$.get()).toBe(true);
+    expect(client.compatibilityWarning$.get()).toEqual({
+      kind: 'server_older',
+      serverApiVersion: CLIENT_API_VERSION,
+      serverContractRevision: CLIENT_MIN_CONTRACT_REVISION - 1,
+      clientApiVersion: CLIENT_API_VERSION,
+      minimumContractRevision: CLIENT_MIN_CONTRACT_REVISION,
+    });
+  });
+
+  it('warns but remains connected when the server uses another API major', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        api_version: CLIENT_API_VERSION + 1,
+        contract_revision: 1,
+      }),
+    } as Response);
+
+    const client = new ApiClient('http://127.0.0.1:5700');
+
+    await expect(client.checkConnection()).resolves.toBe(true);
+    expect(client.isConnected$.get()).toBe(true);
+    expect(client.compatibilityWarning$.get()).toMatchObject({
+      kind: 'api_major_mismatch',
+      serverApiVersion: CLIENT_API_VERSION + 1,
+      clientApiVersion: CLIENT_API_VERSION,
+    });
+  });
+
+  it('clears a stale compatibility warning after reconnecting to a compatible server', async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          api_version: CLIENT_API_VERSION,
+          contract_revision: CLIENT_MIN_CONTRACT_REVISION - 1,
+        }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          api_version: CLIENT_API_VERSION,
+          contract_revision: CLIENT_MIN_CONTRACT_REVISION,
+        }),
+      } as Response);
+
+    const client = new ApiClient('http://127.0.0.1:5700');
+
+    await client.checkConnection();
+    expect(client.compatibilityWarning$.get()).not.toBeNull();
+    await client.checkConnection();
+    expect(client.compatibilityWarning$.get()).toBeNull();
+  });
+
+  it('keeps legacy servers without version metadata compatible', async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          api_version: CLIENT_API_VERSION,
+          contract_revision: CLIENT_MIN_CONTRACT_REVISION - 1,
+        }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ version: '0.30.0' }),
+      } as Response);
+
+    const client = new ApiClient('http://127.0.0.1:5700');
+
+    await client.checkConnection();
+    expect(client.compatibilityWarning$.get()).not.toBeNull();
+    await expect(client.checkConnection()).resolves.toBe(true);
+    expect(client.compatibilityWarning$.get()).toBeNull();
   });
 });
 

--- a/webui/src/utils/api.ts
+++ b/webui/src/utils/api.ts
@@ -314,6 +314,7 @@ export class ApiClient {
   private authCookieSet = false;
   private authCookieSetAt: number | null = null;
   private authCookiePromise: Promise<void> | null = null;
+  private _probeNonce = 0;
 
   constructor(baseUrl: string = getApiBaseUrl(), authHeader: string | null = null) {
     this.baseUrl = baseUrl;
@@ -538,9 +539,11 @@ export class ApiClient {
 
   async checkConnection(): Promise<boolean> {
     const url = `${this.baseUrl}/api/v2`;
+    const nonce = ++this._probeNonce;
     console.log('[ApiClient] Checking connection to', this.baseUrl);
     try {
       const response = await this.fetchWithTimeout(url, {}, 3000);
+      if (this._probeNonce !== nonce) return false;
       if (!response.ok) {
         console.error('API endpoint returned non-OK status:', response.status);
         this.isConnected$.set(false);
@@ -560,8 +563,10 @@ export class ApiClient {
       // contract metadata advertised by newer servers.
       try {
         const metadata = (await response.json()) as ApiRootMetadata;
+        if (this._probeNonce !== nonce) return false;
         this.compatibilityWarning$.set(getApiCompatibilityWarning(metadata));
       } catch (parseError) {
+        if (this._probeNonce !== nonce) return false;
         console.error(`[ApiClient] Failed to parse API response from ${url}:`, parseError);
         this.isConnected$.set(false);
         this.compatibilityWarning$.set(null);
@@ -617,6 +622,7 @@ export class ApiClient {
       } else {
         console.error('[ApiClient] Connection check failed:', error);
       }
+      if (this._probeNonce !== nonce) return false;
       this.isConnected$.set(false);
       this.compatibilityWarning$.set(null);
       this.lastConnectionResult$.set({ ok: false, url, reason, message });

--- a/webui/src/utils/api.ts
+++ b/webui/src/utils/api.ts
@@ -544,6 +544,7 @@ export class ApiClient {
       if (!response.ok) {
         console.error('API endpoint returned non-OK status:', response.status);
         this.isConnected$.set(false);
+        this.compatibilityWarning$.set(null);
         this.lastConnectionResult$.set({
           ok: false,
           url,
@@ -563,6 +564,7 @@ export class ApiClient {
       } catch (parseError) {
         console.error(`[ApiClient] Failed to parse API response from ${url}:`, parseError);
         this.isConnected$.set(false);
+        this.compatibilityWarning$.set(null);
         this.lastConnectionResult$.set({
           ok: false,
           url,
@@ -616,6 +618,7 @@ export class ApiClient {
         console.error('[ApiClient] Connection check failed:', error);
       }
       this.isConnected$.set(false);
+      this.compatibilityWarning$.set(null);
       this.lastConnectionResult$.set({ ok: false, url, reason, message });
       return false;
     }

--- a/webui/src/utils/api.ts
+++ b/webui/src/utils/api.ts
@@ -198,6 +198,59 @@ function inferTranscriptionFormat(blobType: string | undefined): string {
   }
 }
 
+// Keep this in sync with gptme.server.openapi_docs. A client may still connect to
+// other revisions; these constants only define when to surface a compatibility warning.
+export const CLIENT_API_VERSION = 2;
+export const CLIENT_MIN_CONTRACT_REVISION = 1;
+
+export type ApiCompatibilityWarning =
+  | {
+      kind: 'api_major_mismatch';
+      serverApiVersion: number;
+      serverContractRevision: number;
+      clientApiVersion: number;
+      minimumContractRevision: number;
+    }
+  | {
+      kind: 'server_older';
+      serverApiVersion: number;
+      serverContractRevision: number;
+      clientApiVersion: number;
+      minimumContractRevision: number;
+    };
+
+interface ApiRootMetadata {
+  api_version?: number;
+  contract_revision?: number;
+}
+
+export function getApiCompatibilityWarning(
+  metadata: ApiRootMetadata
+): ApiCompatibilityWarning | null {
+  const { api_version: serverApiVersion, contract_revision: serverContractRevision } = metadata;
+
+  // Servers released before contract metadata was introduced remain usable. We
+  // cannot make a sound compatibility claim, so preserve the legacy behavior.
+  if (serverApiVersion === undefined || serverContractRevision === undefined) {
+    return null;
+  }
+
+  const common = {
+    serverApiVersion,
+    serverContractRevision,
+    clientApiVersion: CLIENT_API_VERSION,
+    minimumContractRevision: CLIENT_MIN_CONTRACT_REVISION,
+  };
+
+  if (serverApiVersion !== CLIENT_API_VERSION) {
+    return { kind: 'api_major_mismatch', ...common };
+  }
+  if (serverContractRevision < CLIENT_MIN_CONTRACT_REVISION) {
+    return { kind: 'server_older', ...common };
+  }
+  return null;
+}
+
 // Result of a connection probe — captures enough context for a useful user-facing message.
 export type ConnectionProbeResult =
   | { ok: true; url: string }
@@ -248,6 +301,8 @@ export class ApiClient {
   public readonly isConnected$: Observable<boolean> = observable(false);
   public readonly lastConnectionResult$: Observable<ConnectionProbeResult | null> =
     observable<ConnectionProbeResult | null>(null);
+  public readonly compatibilityWarning$: Observable<ApiCompatibilityWarning | null> =
+    observable<ApiCompatibilityWarning | null>(null);
   private identifier: string;
   private controller: AbortController | null = null;
   public sessions$: Observable<Map<string, string>> = observable(new Map()); // Map conversation IDs to session IDs
@@ -500,9 +555,11 @@ export class ApiClient {
         return false;
       }
 
-      // Try to parse the response to ensure it's valid JSON
+      // Parse the root response both to validate JSON and to inspect the API
+      // contract metadata advertised by newer servers.
       try {
-        await response.json();
+        const metadata = (await response.json()) as ApiRootMetadata;
+        this.compatibilityWarning$.set(getApiCompatibilityWarning(metadata));
       } catch (parseError) {
         console.error(`[ApiClient] Failed to parse API response from ${url}:`, parseError);
         this.isConnected$.set(false);
@@ -936,11 +993,19 @@ export class ApiClient {
     return info;
   }
 
-  async getServerInfo(): Promise<{ version?: string }> {
+  async getServerInfo(): Promise<{
+    version?: string;
+    api_version?: number;
+    contract_revision?: number;
+  }> {
     if (!this.isConnected) {
       throw new ApiClientError('Not connected to API');
     }
-    const data = await this.fetchJson<{ version?: string }>(`${this.baseUrl}/api/v2`);
+    const data = await this.fetchJson<{
+      version?: string;
+      api_version?: number;
+      contract_revision?: number;
+    }>(`${this.baseUrl}/api/v2`);
     return data;
   }
 

--- a/webui/src/utils/demoApiClient.ts
+++ b/webui/src/utils/demoApiClient.ts
@@ -13,7 +13,7 @@
  * conversations.
  */
 import { observable } from '@legendapp/state';
-import type { ConnectionProbeResult, IApiClient } from '@/utils/api';
+import type { ApiCompatibilityWarning, ConnectionProbeResult, IApiClient } from '@/utils/api';
 import type {
   UserInfo,
   ConversationResponse,
@@ -168,6 +168,7 @@ export function createDemoApiClient(baseUrl: string = DEMO_BASE_URL): IApiClient
     ok: true,
     url: baseUrl,
   });
+  const compatibilityWarning$ = observable<ApiCompatibilityWarning | null>(null);
   const sessions$ = observable(new Map<string, string>());
   const userInfo$ = observable<UserInfo | null>(DEMO_USER_INFO);
 
@@ -218,6 +219,7 @@ export function createDemoApiClient(baseUrl: string = DEMO_BASE_URL): IApiClient
     authHeader: null,
     isConnected$,
     lastConnectionResult$,
+    compatibilityWarning$,
     sessions$,
     userInfo$,
 


### PR DESCRIPTION
## Summary

- inspect `api_version` and `contract_revision` during the existing connection probe
- keep legacy and incompatible servers connected, but expose a structured compatibility warning
- show actionable warnings on the welcome screen and persist a warning icon in the shared menu bar
- keep offline demo mode compatible with the expanded client interface

## Why

The server has advertised API contract metadata since #2952, but the web UI ignored it. That meant a web UI/server mismatch still failed later and opaquely instead of warning at connection time. This implements the downstream client slice from the API-versioning design while preserving additive compatibility.

## Compatibility policy

- API major differs: warn, do not disconnect
- server contract revision is below the client's minimum: warn, do not disconnect
- metadata absent (legacy server): preserve existing behavior without making an unsupported claim
- compatible reconnect: clear any stale warning

## Verification

- `cd webui && npm run typecheck`
- `cd webui && npm test -- --runInBand` (59 suites, 551 tests)
- targeted ESLint on all changed TypeScript files
- `python3 /home/bob/bob/scripts/pr-quality-gate.py --repo gptme/gptme` (100/100)
