### PR TITLE
feat(typecheck): add human-readable imprecision summary to typecheck-coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,9 +72,12 @@ eval: ## Run evaluation suite
 typecheck: ## Run mypy type checking
 	poetry run mypy ${SRCDIRS} $(if $(EXCLUDES),$(foreach EXCLUDE,$(EXCLUDES),--exclude $(EXCLUDE)))
 
-typecheck-coverage: ## Run mypy type checking with Cobertura XML coverage report
+typecheck-coverage: ## Run mypy type checking with type coverage report (XML for CI + text imprecision summary)
 	mkdir -p .mypy_coverage_report
-	poetry run mypy ${SRCDIRS} $(if $(EXCLUDES),$(foreach EXCLUDE,$(EXCLUDES),--exclude $(EXCLUDE))) --cobertura-xml-report .mypy_coverage_report
+	poetry run mypy ${SRCDIRS} $(if $(EXCLUDES),$(foreach EXCLUDE,$(EXCLUDES),--exclude $(EXCLUDE))) --cobertura-xml-report .mypy_coverage_report --txt-report .mypy_coverage_report
+	@echo ""
+	@echo "=== Type Coverage Summary ==="
+	@grep "Total" .mypy_coverage_report/index.txt || cat .mypy_coverage_report/index.txt
 
 RUFF_ARGS=${SRCDIRS} $(foreach EXCLUDE,$(EXCLUDES),--exclude $(EXCLUDE))
 

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ typecheck-coverage: ## Run mypy type checking with type coverage report (XML for
 	poetry run mypy ${SRCDIRS} $(if $(EXCLUDES),$(foreach EXCLUDE,$(EXCLUDES),--exclude $(EXCLUDE))) --cobertura-xml-report .mypy_coverage_report --txt-report .mypy_coverage_report
 	@echo ""
 	@echo "=== Type Coverage Summary ==="
-	@grep "Total" .mypy_coverage_report/index.txt || cat .mypy_coverage_report/index.txt
+	@cat .mypy_coverage_report/index.txt
 
 RUFF_ARGS=${SRCDIRS} $(foreach EXCLUDE,$(EXCLUDES),--exclude $(EXCLUDE))
 

--- a/Makefile
+++ b/Makefile
@@ -74,10 +74,12 @@ typecheck: ## Run mypy type checking
 
 typecheck-coverage: ## Run mypy type checking with type coverage report (XML for CI + text imprecision summary)
 	mkdir -p .mypy_coverage_report
-	poetry run mypy ${SRCDIRS} $(if $(EXCLUDES),$(foreach EXCLUDE,$(EXCLUDES),--exclude $(EXCLUDE))) --cobertura-xml-report .mypy_coverage_report --txt-report .mypy_coverage_report
-	@echo ""
-	@echo "=== Type Coverage Summary ==="
-	@cat .mypy_coverage_report/index.txt
+	@status=0; \
+	poetry run mypy ${SRCDIRS} $(if $(EXCLUDES),$(foreach EXCLUDE,$(EXCLUDES),--exclude $(EXCLUDE))) --cobertura-xml-report .mypy_coverage_report --txt-report .mypy_coverage_report || status=$$?; \
+	echo ""; \
+	echo "=== Type Coverage Summary ==="; \
+	cat .mypy_coverage_report/index.txt; \
+	exit $$status
 
 RUFF_ARGS=${SRCDIRS} $(foreach EXCLUDE,$(EXCLUDES),--exclude $(EXCLUDE))
 


### PR DESCRIPTION
## Summary

- `make typecheck-coverage` now generates both the Cobertura XML report (for CI/Codecov) **and** a `--txt-report` with the imprecision % per module
- Prints a `=== Type Coverage Summary ===` block to stdout so developers can see the overall imprecision trend locally, without opening the XML

## Motivation

The brain repo's `make typecheck-coverage` has always printed the human-readable imprecision summary. gptme's existing target only generated XML for CI tooling, giving no local feedback. This brings gptme in line with the brain's pattern.

Running `make typecheck-coverage` after this PR prints something like:

```
=== Type Coverage Summary ===
Module                 Imprecise  Total  Imprecision (%)
...
gptme.tools.browser    12         134    9%
Total                  NNN        XXXX   Y.Y%
```

Both reports land in `.mypy_coverage_report/` (already gitignored) in a single mypy run — no extra overhead.

## Related

- Closes ErikBjare/bob#1056 (step 2: mypy coverage target for gptme)
- Analogous to brain's `make typecheck-coverage` → `--txt-report`