### PR TITLE
fix(llm): capture usage tokens from subscription response.done events

### DIFF
--- a/gptme/llm/llm_openai_subscription.py
+++ b/gptme/llm/llm_openai_subscription.py
@@ -44,13 +44,13 @@ from collections.abc import Generator
 from dataclasses import dataclass
 from math import isfinite
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 from urllib.parse import parse_qs, urlencode, urlparse
 from uuid import uuid4
 
 import requests
 
-from ..message import Message
+from ..message import Message, MessageMetadata
 from .openai_responses import (
     _extract_usage_token_counts,
     _messages_to_responses_input,
@@ -508,7 +508,7 @@ def stream(
     tools: list[Any] | None = None,
     max_tokens: int | None = None,
     **kwargs: Any,
-) -> Generator[str, None, dict | None]:
+) -> Generator[str, None, MessageMetadata | None]:
     """Stream completion from ChatGPT subscription API.
 
     Returns usage metadata dict via generator return value, captured by
@@ -643,7 +643,7 @@ def stream(
         usage_data["cache_read_tokens"] = counts.cache_read_tokens
     if isinstance(counts.cache_creation_tokens, int):
         usage_data["cache_creation_tokens"] = counts.cache_creation_tokens
-    return {"usage": usage_data} if usage_data else None
+    return cast(MessageMetadata, {"usage": usage_data}) if usage_data else None
 
 
 def chat(

--- a/gptme/llm/llm_openai_subscription.py
+++ b/gptme/llm/llm_openai_subscription.py
@@ -52,6 +52,7 @@ import requests
 
 from ..message import Message
 from .openai_responses import (
+    _extract_usage_token_counts,
     _messages_to_responses_input,
     _stream_responses_events,
     _tool_spec_to_responses_tool,
@@ -507,8 +508,12 @@ def stream(
     tools: list[Any] | None = None,
     max_tokens: int | None = None,
     **kwargs: Any,
-) -> Generator[str, None, None]:
-    """Stream completion from ChatGPT subscription API."""
+) -> Generator[str, None, dict | None]:
+    """Stream completion from ChatGPT subscription API.
+
+    Returns usage metadata dict via generator return value, captured by
+    _StreamWithMetadata in the caller.
+    """
     auth = get_auth()
 
     instructions, api_messages = _messages_to_responses_input(messages)
@@ -617,7 +622,28 @@ def stream(
                 )
                 response = _open_response()
 
-    yield from _stream_responses_events(_sse_events())
+    _usage_holder: list[Any] = []
+
+    def _capture_usage(usage: Any) -> None:
+        _usage_holder.append(usage)
+
+    yield from _stream_responses_events(_sse_events(), usage_callback=_capture_usage)
+
+    # Return usage metadata so _StreamWithMetadata can attach it to the message.
+    # _StreamWithMetadata adds the full provider-prefixed model name automatically.
+    if not _usage_holder:
+        return None
+    counts = _extract_usage_token_counts(_usage_holder[0])
+    usage_data: dict[str, int] = {}
+    if isinstance(counts.input_tokens, int):
+        usage_data["input_tokens"] = counts.input_tokens
+    if isinstance(counts.output_tokens, int):
+        usage_data["output_tokens"] = counts.output_tokens
+    if isinstance(counts.cache_read_tokens, int):
+        usage_data["cache_read_tokens"] = counts.cache_read_tokens
+    if isinstance(counts.cache_creation_tokens, int):
+        usage_data["cache_creation_tokens"] = counts.cache_creation_tokens
+    return {"usage": usage_data} if usage_data else None
 
 
 def chat(

--- a/gptme/llm/openai_responses.py
+++ b/gptme/llm/openai_responses.py
@@ -323,7 +323,7 @@ def _stream_responses_events(
     (chatgpt.com backend) interchangeably.
 
     ``usage_callback`` is called with the usage object from ``response.completed``
-    events; subscription streams (which use ``response.done``) never trigger it.
+    and ``response.done`` events (subscription streams use ``response.done``).
     """
     in_reasoning_block = False
     seen_reasoning_delta = False
@@ -407,7 +407,7 @@ def _stream_responses_events(
                 yield delta
 
         elif event_type in ("response.completed", "response.done"):
-            if usage_callback is not None and event_type == "response.completed":
+            if usage_callback is not None:
                 response_obj = _obj_get(event, "response", None)
                 if response_obj is not None:
                     usage = _obj_get(response_obj, "usage", None)
@@ -424,23 +424,32 @@ def _stream_responses_events(
 
 
 def _extract_usage_token_counts(usage: Any) -> UsageTokenCounts:
-    """Normalize Chat Completions and Responses API usage token fields."""
-    prompt_tokens = getattr(usage, "prompt_tokens", None)
-    output_tokens = getattr(usage, "completion_tokens", None)
-    details = getattr(usage, "prompt_tokens_details", None)
+    """Normalize Chat Completions and Responses API usage token fields.
+
+    Handles both SDK objects (attribute access) and raw dicts (subscription SSE).
+    """
+    prompt_tokens = _obj_get(usage, "prompt_tokens", None)
+    output_tokens = _obj_get(usage, "completion_tokens", None)
+    details = _obj_get(usage, "prompt_tokens_details", None)
     _is_chat_completions = prompt_tokens is not None
     if prompt_tokens is None:
-        prompt_tokens = getattr(usage, "input_tokens", None)
-        details = getattr(usage, "input_tokens_details", None)
+        prompt_tokens = _obj_get(usage, "input_tokens", None)
+        details = _obj_get(usage, "input_tokens_details", None)
     if output_tokens is None:
-        output_tokens = getattr(usage, "output_tokens", None)
-    cache_read_tokens = getattr(details, "cached_tokens", None)
-    cache_creation_tokens = getattr(usage, "cache_creation_input_tokens", None)
+        output_tokens = _obj_get(usage, "output_tokens", None)
+    cache_read_tokens = (
+        _obj_get(details, "cached_tokens", None) if details is not None else None
+    )
+    cache_creation_tokens = _obj_get(usage, "cache_creation_input_tokens", None)
     # OpenRouter nested shape: prompt_tokens_details.cache_write_tokens
     # Only for Chat Completions (not Responses API input_tokens_details.cache_write_tokens)
     if cache_creation_tokens is None and _is_chat_completions:
-        cache_creation_tokens = getattr(details, "cache_write_tokens", None)
-    total_tokens = getattr(usage, "total_tokens", None)
+        cache_creation_tokens = (
+            _obj_get(details, "cache_write_tokens", None)
+            if details is not None
+            else None
+        )
+    total_tokens = _obj_get(usage, "total_tokens", None)
 
     if isinstance(prompt_tokens, int):
         cache_read = cache_read_tokens if isinstance(cache_read_tokens, int) else 0

--- a/tests/test_llm_openai_subscription.py
+++ b/tests/test_llm_openai_subscription.py
@@ -436,3 +436,78 @@ def test_stream_retries_exhausted_reraises(monkeypatch):
         )
 
     assert mock_post.call_count == 3  # initial + 2 retries
+
+
+def _drain_stream(events: list[dict[str, Any]]) -> tuple[str, Any]:
+    """Drain the stream generator, returning (content, return_value)."""
+    auth = _make_auth()
+    response = _FakeSSEStreamResponse(events)
+
+    with (
+        patch("gptme.llm.llm_openai_subscription.get_auth", return_value=auth),
+        patch("gptme.llm.llm_openai_subscription.requests.post", return_value=response),
+    ):
+        gen = llm_openai_subscription.stream(
+            [Message(role="user", content="hello")], "gpt-5.4"
+        )
+        parts = []
+        ret: Any = None
+        try:
+            while True:
+                parts.append(next(gen))
+        except StopIteration as e:
+            ret = e.value
+        return "".join(parts), ret
+
+
+def test_stream_returns_usage_from_response_done():
+    """response.done with usage dict must be returned as metadata by stream()."""
+    content, metadata = _drain_stream(
+        [
+            {"type": "response.output_text.delta", "delta": "Hello."},
+            {
+                "type": "response.done",
+                "response": {
+                    "usage": {
+                        "input_tokens": 100,
+                        "output_tokens": 50,
+                        "total_tokens": 150,
+                    }
+                },
+            },
+        ]
+    )
+
+    assert content == "Hello."
+    assert metadata is not None
+    assert metadata.get("usage", {}).get("input_tokens") == 100
+    assert metadata.get("usage", {}).get("output_tokens") == 50
+
+
+def test_stream_returns_none_when_response_done_has_no_usage():
+    """response.done without usage must return None so the caller falls back."""
+    _, metadata = _drain_stream([{"type": "response.done"}])
+    assert metadata is None
+
+
+def test_stream_captures_usage_without_cache_fields():
+    """Subscription responses don't have cache token fields; must not crash."""
+    _, metadata = _drain_stream(
+        [
+            {
+                "type": "response.done",
+                "response": {
+                    "usage": {
+                        "input_tokens": 200,
+                        "output_tokens": 75,
+                    }
+                },
+            }
+        ]
+    )
+    assert metadata is not None
+    usage = metadata.get("usage", {})
+    assert usage.get("input_tokens") == 200
+    assert usage.get("output_tokens") == 75
+    assert "cache_read_tokens" not in usage
+    assert "cache_creation_tokens" not in usage


### PR DESCRIPTION
## Summary

Three linked bugs prevented `openai-subscription` sessions (e.g. `gpt-5.6-sol`) from recording any token usage, causing ~2% token capture rate instead of ~95%+.

**Bug 1** — `_stream_responses_events()` only called `usage_callback` for `response.completed` events. Subscription streams emit `response.done` instead, so the callback never fired.

**Bug 2** — `_extract_usage_token_counts()` used `getattr()` for all field access. Subscription SSE events are raw dicts (not SDK objects), so every `getattr(usage, "input_tokens")` silently returned `None`.

**Bug 3** — `llm_openai_subscription.stream()` never passed a `usage_callback` and never returned metadata from the generator. `_StreamWithMetadata` fell back to `{"model": self.model}` with no usage.

**Fix:** (a) call `usage_callback` for both `response.completed` and `response.done`; (b) switch `_extract_usage_token_counts` to `_obj_get` (handles both dicts and SDK objects); (c) wire `usage_callback` in `stream()` and return captured counts as the generator's return value so `_StreamWithMetadata` attaches them to the message.

## Test plan

- [x] All 20 existing `test_llm_openai_subscription` tests still pass
- [x] New `test_stream_returns_usage_from_response_done`: verifies `response.done` with usage dict is returned as metadata
- [x] New `test_stream_returns_none_when_response_done_has_no_usage`: verifies no-usage event returns `None` (caller fallback)
- [x] New `test_stream_captures_usage_without_cache_fields`: verifies subscription responses without cache fields don't crash or add spurious fields