### PR TITLE
fix(acp): advertise authMethods in initialize response for ACP registry

### DIFF
--- a/gptme/acp/agent.py
+++ b/gptme/acp/agent.py
@@ -89,19 +89,24 @@ def _import_acp() -> bool:
         )
         from acp.interfaces import Client as _Client
         from acp.schema import (
-            AuthMethodAgent as _AuthMethodAgent,
-        )
-        from acp.schema import (
             Implementation as _Implementation,
         )
 
         Agent = _Agent
-        AuthMethodAgent = _AuthMethodAgent
         Implementation = _Implementation
         InitializeResponse = _InitializeResponse
         NewSessionResponse = _NewSessionResponse
         PromptResponse = _PromptResponse
         Client = _Client
+
+        # AuthMethodAgent was added in a later release; degrade gracefully if absent
+        try:
+            from acp.schema import AuthMethodAgent as _AuthMethodAgent
+
+            AuthMethodAgent = _AuthMethodAgent
+        except ImportError:
+            pass
+
         return True
     except ImportError:
         return False
@@ -123,17 +128,20 @@ def _auth_methods() -> list:
     """Build the authMethods for InitializeResponse.
 
     gptme uses API keys (ANTHROPIC_API_KEY, OPENAI_API_KEY, etc.) configured
-    as environment variables or in ~/.config/gptme/config.toml before launch.
+    as environment variables or in ~/.config/gptme/config.local.toml before launch.
+    Returns an empty list on ACP releases that pre-date the AuthMethodAgent schema.
     """
-    _AuthMethodAgent = _check_acp_import(AuthMethodAgent, "AuthMethodAgent")
+    if AuthMethodAgent is None:
+        return []
     return [
-        _AuthMethodAgent(
+        AuthMethodAgent(
             id="api-key",
             name="API Key",
             description=(
                 "Set your LLM provider API key as an environment variable "
                 "(e.g. ANTHROPIC_API_KEY or OPENAI_API_KEY) before running gptme, "
-                "or configure it in ~/.config/gptme/config.toml."
+                "or add it to ~/.config/gptme/config.local.toml (not config.toml, "
+                "which may be version-controlled)."
             ),
         )
     ]

--- a/gptme/acp/agent.py
+++ b/gptme/acp/agent.py
@@ -43,6 +43,7 @@ logger = logging.getLogger(__name__)
 
 # Lazy imports to avoid dependency issues when acp is not installed
 Agent: type | None = None
+AuthMethodAgent: type | None = None
 Implementation: type | None = None
 InitializeResponse: type | None = None
 NewSessionResponse: type | None = None
@@ -67,6 +68,7 @@ def _import_acp() -> bool:
     """Import ACP modules lazily."""
     global \
         Agent, \
+        AuthMethodAgent, \
         Implementation, \
         InitializeResponse, \
         NewSessionResponse, \
@@ -87,10 +89,14 @@ def _import_acp() -> bool:
         )
         from acp.interfaces import Client as _Client
         from acp.schema import (
+            AuthMethodAgent as _AuthMethodAgent,
+        )
+        from acp.schema import (
             Implementation as _Implementation,
         )
 
         Agent = _Agent
+        AuthMethodAgent = _AuthMethodAgent
         Implementation = _Implementation
         InitializeResponse = _InitializeResponse
         NewSessionResponse = _NewSessionResponse
@@ -111,6 +117,26 @@ def _agent_info() -> Any:
     except Exception:
         gptme_version = "unknown"
     return _Impl(name="gptme", title="gptme ACP Agent", version=gptme_version)
+
+
+def _auth_methods() -> list:
+    """Build the authMethods for InitializeResponse.
+
+    gptme uses API keys (ANTHROPIC_API_KEY, OPENAI_API_KEY, etc.) configured
+    as environment variables or in ~/.config/gptme/config.toml before launch.
+    """
+    _AuthMethodAgent = _check_acp_import(AuthMethodAgent, "AuthMethodAgent")
+    return [
+        _AuthMethodAgent(
+            id="api-key",
+            name="API Key",
+            description=(
+                "Set your LLM provider API key as an environment variable "
+                "(e.g. ANTHROPIC_API_KEY or OPENAI_API_KEY) before running gptme, "
+                "or configure it in ~/.config/gptme/config.toml."
+            ),
+        )
+    ]
 
 
 def _cwd_session_id(cwd: str) -> str:
@@ -498,6 +524,7 @@ class GptmeAgent:
                 return _check_acp_import(InitializeResponse, "InitializeResponse")(
                     protocol_version=protocol_version,
                     agent_info=_agent_info(),
+                    auth_methods=_auth_methods(),
                 )
 
             self._initialized = True
@@ -516,6 +543,7 @@ class GptmeAgent:
         return _InitializeResponse(
             protocol_version=protocol_version,
             agent_info=_agent_info(),
+            auth_methods=_auth_methods(),
         )
 
     async def new_session(


### PR DESCRIPTION
## Summary

The ACP agent registry CI validates that agents return at least one auth method (type `agent` or `terminal`) in their `initialize` response. gptme was returning an empty `authMethods: []`, which causes the registry's auth check to fail with "No authMethods in response".

This fix adds an `AuthMethodAgent` entry to the `initialize` response describing gptme's API key setup flow: users configure `ANTHROPIC_API_KEY`/`OPENAI_API_KEY` (or `config.toml`) before running gptme. The ACP library's `client.py` parser defaults missing `type` fields to `"agent"`, which passes registry validation.

## Changes

- Add `AuthMethodAgent` to the lazy ACP imports in `agent.py`
- Add `_auth_methods()` helper building the auth methods list
- Pass `auth_methods=_auth_methods()` in both `InitializeResponse` returns in `initialize()`

## Testing

All 177 ACP tests pass. Verified manually that the response now includes:
```json
{
  "authMethods": [{
    "id": "api-key",
    "name": "API Key",
    "description": "Set your LLM provider API key as an environment variable..."
  }]
}
```

## Context

Closes part of #3158 — this fix is required before gptme can be listed in the [ACP agent registry](https://github.com/agentclientprotocol/registry). The registry PR will follow once a stable release ships with this fix.

<!-- gptme-id:v1:gai_Igwjw8MhXQaosL68yqvJ9tgiifwCZOXCZGsq53StO8P -->