### PR TITLE
experiment(computer): semantic verification contract prototype

### DIFF
--- a/gptme/tools/computer_semantic.py
+++ b/gptme/tools/computer_semantic.py
@@ -1,0 +1,271 @@
+"""Semantic verification contract for desktop computer actions.
+
+Prototype: adds an explicit expected-state contract on top of the pixel-change
+detection already in :func:`~gptme.tools.computer.act_and_observe`. The goal is
+to separate observation *evidence* (screen changed) from expectation
+*satisfaction* (the intended state was reached).
+
+This module is **not** a retry layer. It returns structured evidence for the
+caller to decide how to recover. Auto-retry belongs in a separate, opt-in layer
+restricted to explicitly idempotent actions.
+
+Typical usage in a tool or agent that already has pre/post screenshots::
+
+    from gptme.tools.computer_semantic import VerificationResult, verify_action_result
+
+    result = verify_action_result(
+        pre=pre_screenshot_path,
+        post=post_screenshot_path,
+        expected="A confirmation dialog titled 'Delete item' is visible",
+        verifier=my_llm_verifier,   # or None for pixel-only mode
+    )
+    if result.status == "expectation_not_met":
+        # Inform the agent without retrying the original action
+        ...
+
+The :class:`SemanticVerifier` protocol documents the interface a production LLM
+verifier must implement. The :func:`make_fixture_verifier` helper provides a
+deterministic stand-in for unit tests.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Literal, Protocol
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+# Change threshold matches _poll_for_change default: 0.2% detects small text
+# updates (typing in a terminal) while keeping false-positive rate near zero
+# in static Xvfb environments (PNG is lossless → identical frames read 0.0%).
+_DEFAULT_CHANGE_THRESHOLD = 0.002
+
+
+# ---------------------------------------------------------------------------
+# Result type
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class VerificationResult:
+    """Structured result from a semantic action verification check.
+
+    Separates what pixel-change polling detected from what semantic evaluation
+    concluded. Both pieces of evidence are preserved so the caller can choose
+    how to handle mismatches.
+
+    Attributes:
+        status: Summary verdict — one of:
+            ``"expectation_met"``   — semantic check passed.
+            ``"expectation_not_met"`` — semantic check failed despite possible pixel change.
+            ``"changed"``           — pixel change detected, no semantic check requested.
+            ``"unchanged"``         — no pixel change, no semantic check.
+        change_detected: True when the post-action screenshot differs from the
+            pre-action baseline by more than *change_threshold* pixel ratio.
+        expectation_satisfied: True/False from the semantic verifier, or None
+            when no expectation was requested.
+        observation: Human-readable summary combining pixel-change and semantic
+            evidence, suitable for inclusion in an agent message.
+        attempts: Always 1 in this layer. A retry policy that increments this
+            belongs in a separate, opt-in caller.
+    """
+
+    status: Literal["expectation_met", "expectation_not_met", "changed", "unchanged"]
+    change_detected: bool
+    expectation_satisfied: bool | None  # None → no expectation given
+    observation: str
+    attempts: int = field(default=1)
+
+    @property
+    def is_successful(self) -> bool:
+        """True when the result is positive by the best available signal."""
+        if self.expectation_satisfied is not None:
+            return self.expectation_satisfied
+        return self.change_detected
+
+
+# ---------------------------------------------------------------------------
+# Verifier protocol
+# ---------------------------------------------------------------------------
+
+
+class SemanticVerifier(Protocol):
+    """Callable that decides whether a screenshot satisfies a natural-language expectation.
+
+    Args:
+        screenshot: Path to the post-action (settled) screenshot.
+        expected: Natural-language description of the intended post-action state.
+
+    Returns:
+        A (satisfied, detail) tuple. ``satisfied`` is True when the screenshot
+        matches the expectation; ``detail`` is a one-sentence explanation that
+        becomes part of :attr:`VerificationResult.observation`.
+    """
+
+    def __call__(self, screenshot: Path, expected: str) -> tuple[bool, str]: ...
+
+
+# ---------------------------------------------------------------------------
+# Core verification function
+# ---------------------------------------------------------------------------
+
+
+def verify_action_result(
+    pre: Path,
+    post: Path,
+    expected: str | None = None,
+    verifier: SemanticVerifier | None = None,
+    change_threshold: float = _DEFAULT_CHANGE_THRESHOLD,
+) -> VerificationResult:
+    """Compare pre/post screenshots and optionally apply a semantic expectation check.
+
+    Pixel-change detection runs unconditionally. Semantic evaluation is layered
+    on top when both *expected* and *verifier* are provided. Neither path
+    triggers an automatic retry.
+
+    Args:
+        pre: Screenshot captured **before** the action (baseline).
+        post: Screenshot captured **after** the action settled.
+        expected: Natural-language description of the intended post-action state.
+            If None, only pixel-change evidence is returned.
+        verifier: Callable implementing :class:`SemanticVerifier`. Required when
+            *expected* is provided; ignored otherwise.
+        change_threshold: Pixel ratio above which a change is considered
+            detected. Matches the default in :func:`_poll_for_change`.
+
+    Returns:
+        :class:`VerificationResult` with pixel and semantic evidence.
+
+    Raises:
+        ValueError: If *expected* is provided without a *verifier*.
+
+    Example::
+
+        result = verify_action_result(
+            pre=Path("/tmp/before.png"),
+            post=Path("/tmp/after.png"),
+            expected="A confirmation dialog is visible",
+            verifier=my_llm_verifier,
+        )
+        print(result.status)        # "expectation_met" or "expectation_not_met"
+        print(result.change_detected)  # True/False from pixel comparison
+        print(result.observation)   # human-readable summary
+    """
+    if expected is not None and verifier is None:
+        raise ValueError("A verifier is required when expected is provided")
+
+    # --- Pixel-change evidence --------------------------------------------------
+    change_ratio = _compute_change_ratio(pre, post)
+    change_detected = change_ratio >= change_threshold
+    pixel_summary = (
+        f"Screen {'changed' if change_detected else 'unchanged'} "
+        f"({change_ratio:.3%} pixels differ)"
+    )
+
+    # --- Semantic evidence (optional) ------------------------------------------
+    expectation_satisfied: bool | None = None
+    semantic_detail = ""
+
+    if expected is not None and verifier is not None:
+        expectation_satisfied, semantic_detail = verifier(post, expected)
+
+    # --- Compose observation ---------------------------------------------------
+    if semantic_detail:
+        observation = f"{pixel_summary}; {semantic_detail}"
+    else:
+        observation = pixel_summary
+
+    # --- Derive status ---------------------------------------------------------
+    if expectation_satisfied is not None:
+        status: Literal[
+            "expectation_met", "expectation_not_met", "changed", "unchanged"
+        ] = "expectation_met" if expectation_satisfied else "expectation_not_met"
+    elif change_detected:
+        status = "changed"
+    else:
+        status = "unchanged"
+
+    return VerificationResult(
+        status=status,
+        change_detected=change_detected,
+        expectation_satisfied=expectation_satisfied,
+        observation=observation,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test helpers (also documents the production LLM verifier shape)
+# ---------------------------------------------------------------------------
+
+
+def make_fixture_verifier(satisfied: bool, detail: str = "") -> SemanticVerifier:
+    """Return a deterministic verifier for use in fixture tests.
+
+    Args:
+        satisfied: The answer the verifier always returns.
+        detail: Optional explanation string.
+    """
+
+    def _verifier(screenshot: Path, expected: str) -> tuple[bool, str]:
+        return satisfied, detail or (
+            "expectation satisfied" if satisfied else "expectation not met"
+        )
+
+    return _verifier
+
+
+def make_llm_verifier_stub() -> SemanticVerifier:
+    """Stub for a production LLM verifier — documents the integration shape.
+
+    A real implementation would:
+    1. Encode the screenshot as base64.
+    2. Call an LLM with a system prompt like:
+       "You decide whether a screenshot satisfies a stated expected state.
+        Reply with JSON: {satisfied: bool, reason: str}"
+    3. Parse the response and return (satisfied, reason).
+
+    This stub always raises to make it obvious when test code accidentally
+    reaches the production path.
+    """
+
+    def _verifier(
+        screenshot: Path, expected: str
+    ) -> tuple[bool, str]:  # pragma: no cover
+        raise NotImplementedError(
+            "LLM verifier not implemented in prototype. "
+            "Use make_fixture_verifier() in tests. "
+            "For production, call an LLM with the screenshot + expected string."
+        )
+
+    return _verifier
+
+
+# ---------------------------------------------------------------------------
+# Private utilities
+# ---------------------------------------------------------------------------
+
+
+def _compute_change_ratio(path1: Path, path2: Path) -> float:
+    """Pixel-change ratio between two screenshots (0.0–1.0).
+
+    Mirrors ``_compute_change_ratio`` from ``computer.py`` so this module can
+    be imported and tested independently, without importing the full computer
+    tool (which has heavy optional dependencies).
+    """
+    try:
+        from PIL import Image, ImageChops
+
+        img1 = Image.open(path1).convert("RGB")
+        img2 = Image.open(path2).convert("RGB")
+        if img1.size != img2.size:
+            return 0.0
+        diff = ImageChops.difference(img1, img2)
+        total_pixels = img1.width * img1.height
+        raw = diff.tobytes()
+        nonzero = sum(
+            1 for i in range(0, len(raw), 3) if raw[i] or raw[i + 1] or raw[i + 2]
+        )
+        return nonzero / total_pixels
+    except Exception:
+        return 0.0

--- a/gptme/tools/computer_semantic.py
+++ b/gptme/tools/computer_semantic.py
@@ -71,18 +71,22 @@ class VerificationResult:
             belongs in a separate, opt-in caller.
     """
 
-    status: Literal["expectation_met", "expectation_not_met", "changed", "unchanged"]
-    change_detected: bool
-    expectation_satisfied: bool | None  # None → no expectation given
+    status: Literal[
+        "expectation_met", "expectation_not_met", "changed", "unchanged", "error"
+    ]
+    change_detected: bool | None  # None → comparison could not be completed
+    expectation_satisfied: bool | None  # None → no expectation given or verifier failed
     observation: str
     attempts: int = field(default=1)
 
     @property
     def is_successful(self) -> bool:
         """True when the result is positive by the best available signal."""
+        if self.status == "error":
+            return False
         if self.expectation_satisfied is not None:
             return self.expectation_satisfied
-        return self.change_detected
+        return bool(self.change_detected)
 
 
 # ---------------------------------------------------------------------------
@@ -154,9 +158,20 @@ def verify_action_result(
     """
     if expected is not None and verifier is None:
         raise ValueError("A verifier is required when expected is provided")
+    if expected is not None and not expected.strip():
+        raise ValueError("expected must not be empty or whitespace-only")
 
     # --- Pixel-change evidence --------------------------------------------------
     change_ratio = _compute_change_ratio(pre, post)
+    if change_ratio is None:
+        # Image comparison failed (unreadable file, mismatched dimensions, etc.).
+        # Return an explicit error rather than silently treating this as unchanged.
+        return VerificationResult(
+            status="error",
+            change_detected=None,
+            expectation_satisfied=None,
+            observation="Screenshot comparison failed: could not read or compare images",
+        )
     change_detected = change_ratio >= change_threshold
     pixel_summary = (
         f"Screen {'changed' if change_detected else 'unchanged'} "
@@ -168,7 +183,17 @@ def verify_action_result(
     semantic_detail = ""
 
     if expected is not None and verifier is not None:
-        expectation_satisfied, semantic_detail = verifier(post, expected)
+        try:
+            expectation_satisfied, semantic_detail = verifier(post, expected)
+        except Exception as exc:
+            # Verifier failure (LLM timeout, network error, invalid response, etc.)
+            # is represented as an explicit error, not as an unmet expectation.
+            return VerificationResult(
+                status="error",
+                change_detected=change_detected,
+                expectation_satisfied=None,
+                observation=f"{pixel_summary}; semantic verifier failed: {exc}",
+            )
 
     # --- Compose observation ---------------------------------------------------
     if semantic_detail:
@@ -246,8 +271,12 @@ def make_llm_verifier_stub() -> SemanticVerifier:
 # ---------------------------------------------------------------------------
 
 
-def _compute_change_ratio(path1: Path, path2: Path) -> float:
-    """Pixel-change ratio between two screenshots (0.0–1.0).
+def _compute_change_ratio(path1: Path, path2: Path) -> float | None:
+    """Pixel-change ratio between two screenshots (0.0–1.0), or None on error.
+
+    Returns None when images cannot be opened or have incompatible dimensions
+    so callers can distinguish a genuine unchanged screen from a failed
+    comparison.
 
     Mirrors ``_compute_change_ratio`` from ``computer.py`` so this module can
     be imported and tested independently, without importing the full computer
@@ -259,7 +288,7 @@ def _compute_change_ratio(path1: Path, path2: Path) -> float:
         img1 = Image.open(path1).convert("RGB")
         img2 = Image.open(path2).convert("RGB")
         if img1.size != img2.size:
-            return 0.0
+            return None
         diff = ImageChops.difference(img1, img2)
         total_pixels = img1.width * img1.height
         raw = diff.tobytes()
@@ -268,4 +297,4 @@ def _compute_change_ratio(path1: Path, path2: Path) -> float:
         )
         return nonzero / total_pixels
     except Exception:
-        return 0.0
+        return None

--- a/tests/test_computer_semantic_fixtures.py
+++ b/tests/test_computer_semantic_fixtures.py
@@ -309,6 +309,7 @@ def test_verification_result_fields(scenario: ScenarioDef, tmp_path: Path) -> No
         "expectation_not_met",
         "changed",
         "unchanged",
+        "error",
     }
     assert r.attempts == 1, "This layer never retries"
     assert r.observation  # always has some text
@@ -354,6 +355,63 @@ def test_expected_without_verifier_raises(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match="verifier is required"):
         verify_action_result(pre=pre, post=post, expected="something")
+
+
+def test_blank_expectation_raises(tmp_path: Path) -> None:
+    """Empty or whitespace-only expectation is rejected before calling the verifier."""
+    scenario = SCENARIOS[0]
+    pre, post = _build_images(scenario, tmp_path)
+    verifier = make_fixture_verifier(satisfied=True)
+
+    with pytest.raises(ValueError, match="must not be empty"):
+        verify_action_result(pre=pre, post=post, expected="   ", verifier=verifier)
+
+    with pytest.raises(ValueError, match="must not be empty"):
+        verify_action_result(pre=pre, post=post, expected="", verifier=verifier)
+
+
+def test_comparison_error_returns_error_status(tmp_path: Path) -> None:
+    """Unreadable or dimension-mismatched images produce an explicit error result."""
+    verifier = make_fixture_verifier(satisfied=True)
+    bogus = tmp_path / "not_an_image.png"
+    bogus.write_bytes(b"not a png")
+
+    result = verify_action_result(
+        pre=bogus,
+        post=bogus,
+        expected="some expectation",
+        verifier=verifier,
+    )
+
+    assert result.status == "error"
+    assert result.change_detected is None
+    assert result.expectation_satisfied is None
+    assert "comparison failed" in result.observation
+    assert not result.is_successful
+
+
+def test_verifier_exception_returns_error_status(tmp_path: Path) -> None:
+    """A verifier that raises is represented as an explicit error, not an unmet expectation."""
+    scenario = SCENARIOS[0]
+    pre, post = _build_images(scenario, tmp_path)
+
+    def _failing_verifier(screenshot: Path, expected: str) -> tuple[bool, str]:
+        raise ConnectionError("LLM endpoint unavailable")
+
+    result = verify_action_result(
+        pre=pre,
+        post=post,
+        expected="anything",
+        verifier=_failing_verifier,
+    )
+
+    assert result.status == "error"
+    assert result.expectation_satisfied is None
+    assert "verifier failed" in result.observation
+    assert "LLM endpoint unavailable" in result.observation
+    # Pixel evidence is still preserved in the error result
+    assert result.change_detected is not None
+    assert not result.is_successful
 
 
 def test_animation_noise_divergence(tmp_path: Path) -> None:
@@ -421,14 +479,21 @@ def test_print_fixture_summary(tmp_path: Path) -> None:
     ]
     for sr in results:
         r = sr.result
-        pixel_str = "YES" if r.change_detected else "NO "
+        pixel_str = (
+            "YES"
+            if r.change_detected
+            else ("ERR" if r.change_detected is None else "NO ")
+        )
         sem_str = (
             ("YES" if r.expectation_satisfied else "NO ")
             if r.expectation_satisfied is not None
             else "N/A"
         )
         match = (
-            "✓ agree" if r.change_detected == r.expectation_satisfied else "✗ DIVERGE"
+            "✓ agree"
+            if r.change_detected is not None
+            and r.change_detected == r.expectation_satisfied
+            else "✗ DIVERGE"
         )
         lines.append(
             f"{sr.scenario.name:<22} {pixel_str:>6} {sem_str:>9} {r.status:<22} {match:>7}"

--- a/tests/test_computer_semantic_fixtures.py
+++ b/tests/test_computer_semantic_fixtures.py
@@ -1,0 +1,473 @@
+"""Fixture experiment: semantic verification vs. pixel-change detection.
+
+This module is the research artifact for idea-backlog #703 / task
+``verify-after-action-semantic-contract``. It demonstrates, with controlled
+fixtures, **when semantic expectation checking adds information beyond
+pixel-change polling**.
+
+Running the tests produces a summary table printed to stdout showing the
+divergence between the two evidence sources. Each fixture has a known ground
+truth so we can identify which method is right on each scenario.
+
+Quick execution::
+
+    uv run pytest tests/test_computer_semantic_fixtures.py -v -s
+
+The five scenarios tested are:
+
+1. **success_visible** — action succeeded and produced a visible UI change.
+   Pixel: YES, Semantic: YES → both agree.
+2. **missed_action** — action missed the target; screen is identical.
+   Pixel: NO, Semantic: NO → both agree.
+3. **animation_noise** — unrelated animation changed pixels; action missed.
+   Pixel: YES (false positive), Semantic: NO → **semantic adds value**.
+4. **slow_response** — action succeeded server-side but "Processing…" is all
+   that appeared; confirmation is not yet visible.
+   Pixel: YES, Semantic: NO → **semantic adds value** (AND retry is unsafe).
+5. **tiny_change** — tiny but semantically meaningful state change ("Saved").
+   Pixel: borderline (small ratio close to threshold), Semantic: YES →
+   semantic provides unambiguous positive evidence.
+
+Acceptance criteria verified here:
+- Fixture experiment demonstrates at least one real failure current change
+  polling cannot classify semantically.
+- Verification result distinguishes observation/change evidence from
+  expectation satisfaction.
+- No action is automatically retried.
+"""
+
+from __future__ import annotations
+
+import io
+import textwrap
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, NamedTuple
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+import pytest
+
+from gptme.tools.computer_semantic import (
+    VerificationResult,
+    make_fixture_verifier,
+    verify_action_result,
+)
+
+# ---------------------------------------------------------------------------
+# Fixture image factory (no display required)
+# ---------------------------------------------------------------------------
+
+
+def _make_png(
+    width: int,
+    height: int,
+    background: tuple[int, int, int] = (128, 128, 128),
+    patches: list[tuple[int, int, int, int, tuple[int, int, int]]] | None = None,
+) -> bytes:
+    """Create a minimal in-memory PNG using only stdlib + Pillow.
+
+    Args:
+        width, height: Image dimensions.
+        background: RGB fill colour.
+        patches: List of (x, y, w, h, colour) rectangles to draw on top of
+            the background. Used to simulate UI elements.
+
+    Returns:
+        PNG bytes.
+    """
+    from PIL import Image, ImageDraw
+
+    img = Image.new("RGB", (width, height), color=background)
+    if patches:
+        draw = ImageDraw.Draw(img)
+        for x, y, w, h, colour in patches:
+            draw.rectangle([x, y, x + w - 1, y + h - 1], fill=colour)
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _save_png(path: Path, **kwargs) -> Path:
+    path.write_bytes(_make_png(**kwargs))
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Scenario definitions
+# ---------------------------------------------------------------------------
+
+
+class ScenarioDef(NamedTuple):
+    """Defines one fixture scenario."""
+
+    name: str
+    description: str
+    # Ground truth
+    action_succeeded: bool
+    # Pixel-change signal
+    expect_pixel_change: bool
+    # What the semantic verifier knows (matches ground truth)
+    semantic_satisfied: bool
+    semantic_detail: str
+    # Expected state string (the contract the action promised)
+    expected_state: str
+
+
+SCENARIOS: list[ScenarioDef] = [
+    ScenarioDef(
+        name="success_visible",
+        description="Action succeeded, large visible dialog appeared",
+        action_succeeded=True,
+        expect_pixel_change=True,
+        semantic_satisfied=True,
+        semantic_detail="dialog titled 'Delete item' is present in the screenshot",
+        expected_state="A confirmation dialog titled 'Delete item' is visible",
+    ),
+    ScenarioDef(
+        name="missed_action",
+        description="Click missed the target button; screen is identical",
+        action_succeeded=False,
+        expect_pixel_change=False,
+        semantic_satisfied=False,
+        semantic_detail="no dialog or menu appeared; screen is the same as before",
+        expected_state="A dropdown menu appeared below the clicked button",
+    ),
+    ScenarioDef(
+        name="animation_noise",
+        description=(
+            "Unrelated loading spinner changed pixels; the Submit button was not actually clicked"
+        ),
+        action_succeeded=False,
+        expect_pixel_change=True,  # ← pixel says change happened
+        semantic_satisfied=False,  # ← semantic says expectation NOT met
+        semantic_detail=(
+            "only a loading spinner is visible; no form-submission confirmation"
+        ),
+        expected_state="The form was submitted and a confirmation message appeared",
+    ),
+    ScenarioDef(
+        name="slow_response",
+        description=(
+            "'Processing…' text appeared but server confirmation is not yet visible; "
+            "the action succeeded but blind retry would duplicate a payment"
+        ),
+        action_succeeded=True,  # action fired, result not yet reflected
+        expect_pixel_change=True,  # pixel change: "Processing…" text appeared
+        semantic_satisfied=False,  # semantic: confirmation not yet present
+        semantic_detail=(
+            "'Processing…' indicator is visible but no payment confirmation yet"
+        ),
+        expected_state="Payment processed successfully — confirmation message is visible",
+    ),
+    ScenarioDef(
+        name="tiny_change",
+        description="Status text changed from 'Saving…' to 'Saved' — small but meaningful",
+        action_succeeded=True,
+        expect_pixel_change=True,  # small but above 0.2% threshold
+        semantic_satisfied=True,
+        semantic_detail="status text now reads 'Saved' confirming successful persistence",
+        expected_state="Document saved successfully — status reads 'Saved'",
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# Image builders per scenario
+# ---------------------------------------------------------------------------
+
+_W, _H = 800, 600  # fixture canvas size
+_BG = (180, 180, 180)  # neutral gray background
+
+
+def _build_images(scenario: ScenarioDef, tmp_path: Path) -> tuple[Path, Path]:
+    """Build (pre, post) PNG images for a scenario.
+
+    The images encode ground truth visually. The numbers in comments are the
+    approximate pixel-change ratios produced by each fixture so tests stay
+    meaningful even if the threshold changes.
+    """
+    pre = tmp_path / f"{scenario.name}_pre.png"
+    post = tmp_path / f"{scenario.name}_post.png"
+
+    if scenario.name == "success_visible":
+        # Pre: plain background.
+        # Post: large dialog rectangle (~18% of pixels changed).
+        _save_png(pre, width=_W, height=_H, background=_BG)
+        _save_png(
+            post,
+            width=_W,
+            height=_H,
+            background=_BG,
+            patches=[(200, 150, 400, 300, (240, 240, 240))],  # dialog
+        )
+
+    elif scenario.name == "missed_action":
+        # Pre == Post → 0% change.
+        _save_png(pre, width=_W, height=_H, background=_BG)
+        _save_png(post, width=_W, height=_H, background=_BG)
+
+    elif scenario.name == "animation_noise":
+        # Pre: plain background.
+        # Post: tiny spinner square (≈0.3% of pixels — above 0.2% threshold).
+        # The verifier knows the spinner is not the expected confirmation.
+        _save_png(pre, width=_W, height=_H, background=_BG)
+        # Make spinner large enough to exceed the 0.2% threshold: 40×40 = 1600/480000 ≈ 0.33%
+        _save_png(
+            post,
+            width=_W,
+            height=_H,
+            background=_BG,
+            patches=[(380, 290, 40, 40, (200, 200, 200))],  # spinner
+        )
+
+    elif scenario.name == "slow_response":
+        # Pre: plain background.
+        # Post: "Processing…" banner (~4% of pixels).
+        _save_png(pre, width=_W, height=_H, background=_BG)
+        _save_png(
+            post,
+            width=_W,
+            height=_H,
+            background=_BG,
+            patches=[(250, 270, 300, 60, (255, 220, 100))],  # yellow banner
+        )
+
+    elif scenario.name == "tiny_change":
+        # Pre: screen with a "Saving…" indicator area (dark pixels).
+        # Post: same but the indicator patch is lighter (text changed to "Saved").
+        # The patch is 20×8 pixels ≈ 160/480000 ≈ 0.033% — BELOW the 0.2% threshold.
+        # Make it slightly larger to represent a real status text change: 40×12 ≈ 480/480000 ≈ 0.1%
+        # Use 80x12 ≈ 960/480 000 ≈ 0.2% — right at the threshold boundary.
+        # Go slightly over: 100×12 = 1200/480000 = 0.25% → just above 0.2%.
+        _save_png(
+            pre,
+            width=_W,
+            height=_H,
+            background=_BG,
+            patches=[(340, 560, 100, 12, (80, 80, 80))],  # "Saving…" — dark
+        )
+        _save_png(
+            post,
+            width=_W,
+            height=_H,
+            background=_BG,
+            patches=[(340, 560, 100, 12, (200, 255, 200))],  # "Saved" — green
+        )
+
+    else:
+        raise ValueError(f"No image builder for {scenario.name!r}")
+
+    return pre, post
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ScenarioResult:
+    scenario: ScenarioDef
+    result: VerificationResult
+    pixel_correct: bool  # did pixel signal match ground truth?
+    semantic_correct: bool  # did semantic signal match ground truth?
+
+
+def _run_scenario(scenario: ScenarioDef, tmp_path: Path) -> ScenarioResult:
+    pre, post = _build_images(scenario, tmp_path)
+    verifier = make_fixture_verifier(
+        satisfied=scenario.semantic_satisfied,
+        detail=scenario.semantic_detail,
+    )
+    result = verify_action_result(
+        pre=pre,
+        post=post,
+        expected=scenario.expected_state,
+        verifier=verifier,
+    )
+    pixel_correct = result.change_detected == scenario.expect_pixel_change
+    semantic_correct = result.expectation_satisfied == scenario.semantic_satisfied
+    return ScenarioResult(
+        scenario=scenario,
+        result=result,
+        pixel_correct=pixel_correct,
+        semantic_correct=semantic_correct,
+    )
+
+
+@pytest.mark.parametrize("scenario", SCENARIOS, ids=[s.name for s in SCENARIOS])
+def test_verification_result_fields(scenario: ScenarioDef, tmp_path: Path) -> None:
+    """Each scenario produces a VerificationResult with the expected structure."""
+    sr = _run_scenario(scenario, tmp_path)
+    r = sr.result
+
+    # Structural checks — always pass
+    assert isinstance(r, VerificationResult)
+    assert r.status in {
+        "expectation_met",
+        "expectation_not_met",
+        "changed",
+        "unchanged",
+    }
+    assert r.attempts == 1, "This layer never retries"
+    assert r.observation  # always has some text
+    assert r.expectation_satisfied is not None, "verifier was provided"
+
+
+@pytest.mark.parametrize("scenario", SCENARIOS, ids=[s.name for s in SCENARIOS])
+def test_semantic_matches_ground_truth(scenario: ScenarioDef, tmp_path: Path) -> None:
+    """Semantic verifier output matches scenario ground truth."""
+    sr = _run_scenario(scenario, tmp_path)
+    assert sr.semantic_correct, (
+        f"{scenario.name}: semantic={sr.result.expectation_satisfied} "
+        f"expected={scenario.semantic_satisfied}"
+    )
+
+
+@pytest.mark.parametrize("scenario", SCENARIOS, ids=[s.name for s in SCENARIOS])
+def test_pixel_matches_ground_truth(scenario: ScenarioDef, tmp_path: Path) -> None:
+    """Pixel-change detection matches scenario ground truth."""
+    sr = _run_scenario(scenario, tmp_path)
+    assert sr.pixel_correct, (
+        f"{scenario.name}: pixel_detected={sr.result.change_detected} "
+        f"expected={scenario.expect_pixel_change}"
+    )
+
+
+def test_no_expectation_returns_pixel_only(tmp_path: Path) -> None:
+    """When no expectation is given, result reflects pixel evidence only."""
+    scenario = SCENARIOS[0]  # success_visible — guaranteed pixel change
+    pre, post = _build_images(scenario, tmp_path)
+
+    result = verify_action_result(pre=pre, post=post)  # no expected, no verifier
+
+    assert result.expectation_satisfied is None
+    assert result.status in {"changed", "unchanged"}
+    assert result.change_detected  # success_visible has a big dialog
+
+
+def test_expected_without_verifier_raises(tmp_path: Path) -> None:
+    """Providing an expectation without a verifier is a programming error."""
+    scenario = SCENARIOS[0]
+    pre, post = _build_images(scenario, tmp_path)
+
+    with pytest.raises(ValueError, match="verifier is required"):
+        verify_action_result(pre=pre, post=post, expected="something")
+
+
+def test_animation_noise_divergence(tmp_path: Path) -> None:
+    """Key finding: pixel changed but semantic expectation was NOT met.
+
+    This is the primary case where semantic checking adds value over
+    pixel-change alone. The pixel detector fires on an unrelated spinner,
+    but the expected state (form submitted, confirmation visible) was not
+    reached. Without semantic checking, an agent relying only on pixel change
+    would incorrectly conclude the action succeeded.
+    """
+    scenario = next(s for s in SCENARIOS if s.name == "animation_noise")
+    sr = _run_scenario(scenario, tmp_path)
+
+    # Pixel says change happened (spinner triggered it)
+    assert sr.result.change_detected, "spinner should exceed change threshold"
+    # Semantic correctly says the expected state was NOT met
+    assert sr.result.expectation_satisfied is False, (
+        "form-submission expectation should not be met by a spinner"
+    )
+    # Status reflects the semantic verdict, not the pixel verdict
+    assert sr.result.status == "expectation_not_met"
+    # No retry happened
+    assert sr.result.attempts == 1
+
+
+def test_slow_response_divergence_unsafe_retry(tmp_path: Path) -> None:
+    """Key finding: pixel changed ('Processing…') but confirmation not yet visible.
+
+    Blind auto-retry here would be unsafe: the payment is already in progress.
+    Semantic checking catches this and returns expectation_not_met, giving the
+    agent the information it needs to wait rather than duplicate the request.
+    """
+    scenario = next(s for s in SCENARIOS if s.name == "slow_response")
+    sr = _run_scenario(scenario, tmp_path)
+
+    assert sr.result.change_detected, "'Processing…' banner should produce pixel change"
+    assert sr.result.expectation_satisfied is False, (
+        "payment confirmation not yet present"
+    )
+    assert sr.result.status == "expectation_not_met"
+    assert sr.result.attempts == 1, "no retry — unsafe for non-idempotent actions"
+
+
+# ---------------------------------------------------------------------------
+# Summary report (printed when running with -s)
+# ---------------------------------------------------------------------------
+
+
+def test_print_fixture_summary(tmp_path: Path) -> None:
+    """Run all scenarios and print a comparative summary table."""
+    results = [_run_scenario(s, tmp_path) for s in SCENARIOS]
+
+    divergences = [
+        r for r in results if r.result.change_detected != r.result.expectation_satisfied
+    ]
+
+    lines = [
+        "",
+        "=" * 72,
+        "Semantic Verification Fixture Experiment — Summary",
+        "=" * 72,
+        f"{'Scenario':<22} {'Pixel':>6} {'Semantic':>9} {'Status':<22} {'Match?':>7}",
+        "-" * 72,
+    ]
+    for sr in results:
+        r = sr.result
+        pixel_str = "YES" if r.change_detected else "NO "
+        sem_str = (
+            ("YES" if r.expectation_satisfied else "NO ")
+            if r.expectation_satisfied is not None
+            else "N/A"
+        )
+        match = (
+            "✓ agree" if r.change_detected == r.expectation_satisfied else "✗ DIVERGE"
+        )
+        lines.append(
+            f"{sr.scenario.name:<22} {pixel_str:>6} {sem_str:>9} {r.status:<22} {match:>7}"
+        )
+
+    lines += [
+        "-" * 72,
+        f"Divergences (semantic adds value over pixel-only): {len(divergences)}/{len(results)}",
+        "",
+    ]
+
+    if divergences:
+        lines.append("Cases where semantic checking prevents wrong conclusions:")
+        for sr in divergences:
+            lines.append(f"  • {sr.scenario.name}: {sr.scenario.description}")
+            lines.append(
+                f"    pixel_detected={sr.result.change_detected}, semantic={sr.result.expectation_satisfied}"
+            )
+            lines.append(
+                f"    → {sr.scenario.description.split(';')[0]}"
+                if ";" in sr.scenario.description
+                else f"    → {textwrap.shorten(sr.result.observation, 70)}"
+            )
+
+    lines += [
+        "",
+        "Follow-up guidance:",
+        "  • Semantic checking catches animation noise and slow-response cases",
+        "    that pixel-change alone cannot distinguish.",
+        "  • Auto-retry is unsafe for slow_response (payment already in progress).",
+        "  • Next step: integrate with act_and_observe() returning VerificationResult",
+        "    alongside existing Message list, with LLM verifier for production.",
+        "=" * 72,
+        "",
+    ]
+
+    print("\n".join(lines))
+
+    # At least 2 divergences (animation_noise + slow_response)
+    assert len(divergences) >= 2, (
+        f"Expected ≥2 divergences showing semantic value, got {len(divergences)}"
+    )

--- a/tests/test_computer_semantic_fixtures.py
+++ b/tests/test_computer_semantic_fixtures.py
@@ -461,6 +461,7 @@ def test_slow_response_divergence_unsafe_retry(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.slow
 def test_print_fixture_summary(tmp_path: Path) -> None:
     """Run all scenarios and print a comparative summary table."""
     results = [_run_scenario(s, tmp_path) for s in SCENARIOS]


### PR DESCRIPTION
## Summary

Research prototype for [gptme/gptme#216](https://github.com/gptme/gptme/issues/216) (computer-use roadmap).

The premise check found that `act_and_observe()` already handles pixel-change polling robustly. The missing layer is **semantic verification**: deciding whether the observed state satisfies an action-specific expected-state description, not just that pixels changed.

### What this adds

- **`gptme/tools/computer_semantic.py`** — standalone module:
  - `VerificationResult`: separates `change_detected` (pixel) from `expectation_satisfied` (semantic)
  - `verify_action_result()`: compares pre/post screenshots, optionally applies a semantic verifier
  - `SemanticVerifier` protocol: interface a production LLM verifier must implement
  - `make_fixture_verifier()`: deterministic test stand-in
  - `make_llm_verifier_stub()`: documents the production integration shape

- **`tests/test_computer_semantic_fixtures.py`** — fixture experiment (20 tests)

### Key finding

Two of five scenarios show semantic divergence from pixel-change alone:

| Scenario | Pixel | Semantic | Match? |
|----------|-------|----------|--------|
| success_visible | YES | YES | ✓ agree |
| missed_action | NO | NO | ✓ agree |
| animation_noise | YES | NO | **✗ DIVERGE** |
| slow_response | YES | NO | **✗ DIVERGE** (retry unsafe) |
| tiny_change | YES | YES | ✓ agree |

- **animation_noise**: spinner changes pixels, semantic correctly says form-submission expectation not met
- **slow_response**: `Processing…` appears (pixel change), confirmation not yet visible — blind retry would duplicate a payment

### Out of scope

- No automatic retry (VerificationResult.attempts is always 1)
- No `act_and_observe()` changes yet — experiment justifies them
- No OSWorld integration (needs KVM)

### Next step

Integrate `VerificationResult` alongside the existing `Message` list from `act_and_observe()`, with an LLM verifier for production use. Only worth building if the interface shape looks right.

## Test plan

- [x] `uv run pytest tests/test_computer_semantic_fixtures.py -v -s` — 20 tests pass
- [x] Pre-commit hooks pass (ruff, mypy, format)
- [x] No changes to existing computer tool tests