### PR TITLE
fix(tauri): make AppImage GTK links idempotent

### DIFF
--- a/tauri/scripts/appimage-bin/ln
+++ b/tauri/scripts/appimage-bin/ln
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REAL_LN="${REAL_LN:-/usr/bin/ln}"
+
+# linuxdeploy-plugin-gtk creates basename-only links after linuxdeploy has
+# already populated AppDir/usr/lib. Re-running the plugin should replace those
+# links rather than fail with "File exists". Keep normal ln semantics elsewhere.
+for arg in "$@"; do
+    if [[ "$arg" == */target/release/bundle/appimage/*.AppDir/usr/lib ]]; then
+        case "$1" in
+            -s | -sv | -vs)
+                exec "$REAL_LN" -f "$@"
+                ;;
+        esac
+    fi
+done
+
+exec "$REAL_LN" "$@"

--- a/tauri/scripts/build-appimage.sh
+++ b/tauri/scripts/build-appimage.sh
@@ -26,7 +26,10 @@ if [[ "${1:-}" == "--patch-only" ]]; then
 fi
 
 if [[ "$PATCH_ONLY" != "true" ]]; then
-    NO_STRIP="${NO_STRIP:-true}" npm run tauri -- build "$@"
+    # linuxdeploy-plugin-gtk uses plain `ln -s` when creating module links in
+    # AppDir/usr/lib. linuxdeploy can populate the same links first, so make
+    # only that plugin operation idempotent while preserving normal ln behavior.
+    PATH="$SCRIPT_DIR/appimage-bin:$PATH" NO_STRIP="${NO_STRIP:-true}" npm run tauri -- build "$@"
 fi
 
 APPDIR="$TAURI_DIR/src-tauri/target/release/bundle/appimage/gptme-tauri.AppDir"

--- a/tauri/scripts/build-appimage.sh
+++ b/tauri/scripts/build-appimage.sh
@@ -29,7 +29,7 @@ if [[ "$PATCH_ONLY" != "true" ]]; then
     # linuxdeploy-plugin-gtk uses plain `ln -s` when creating module links in
     # AppDir/usr/lib. linuxdeploy can populate the same links first, so make
     # only that plugin operation idempotent while preserving normal ln behavior.
-    PATH="$SCRIPT_DIR/appimage-bin:$PATH" NO_STRIP="${NO_STRIP:-true}" npm run tauri -- build "$@"
+    REAL_LN="$(command -v ln)" PATH="$SCRIPT_DIR/appimage-bin:$PATH" NO_STRIP="${NO_STRIP:-true}" npm run tauri -- build "$@"
 fi
 
 APPDIR="$TAURI_DIR/src-tauri/target/release/bundle/appimage/gptme-tauri.AppDir"

--- a/tauri/scripts/test-appimage-ln-wrapper.sh
+++ b/tauri/scripts/test-appimage-ln-wrapper.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WRAPPER="$SCRIPT_DIR/appimage-bin/ln"
+REAL_LN="$(command -v ln)"
+
+if [[ ! -x "$WRAPPER" ]]; then
+    echo "AppImage ln wrapper is missing or not executable: $WRAPPER" >&2
+    exit 1
+fi
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+appimage_lib="$tmpdir/target/release/bundle/appimage/gptme-tauri.AppDir/usr/lib"
+outside_lib="$tmpdir/outside/usr/lib"
+mkdir -p "$appimage_lib" "$outside_lib" "$tmpdir/first" "$tmpdir/second"
+touch "$tmpdir/first/im-test.so" "$tmpdir/second/im-test.so"
+
+REAL_LN="$REAL_LN" "$WRAPPER" -s "$tmpdir/first/im-test.so" "$appimage_lib"
+REAL_LN="$REAL_LN" "$WRAPPER" -s "$tmpdir/second/im-test.so" "$appimage_lib"
+[[ "$(readlink "$appimage_lib/im-test.so")" == "$tmpdir/second/im-test.so" ]]
+
+REAL_LN="$REAL_LN" "$WRAPPER" -s "$tmpdir/first/im-test.so" "$outside_lib"
+if REAL_LN="$REAL_LN" "$WRAPPER" -s "$tmpdir/second/im-test.so" "$outside_lib" 2>/dev/null; then
+    echo "wrapper unexpectedly forced a symlink outside an AppImage lib directory" >&2
+    exit 1
+fi
+[[ "$(readlink "$outside_lib/im-test.so")" == "$tmpdir/first/im-test.so" ]]
+
+echo "AppImage ln wrapper tests passed"


### PR DESCRIPTION
## Problem

Tauri's vendored `linuxdeploy-plugin-gtk.sh` creates module links with plain `ln -s`. When linuxdeploy has already populated the same AppDir links, local AppImage builds fail with `File exists` (reproduced on `im-ti-et.so`).

## Fix

Prepend a narrowly scoped `ln` wrapper during Linux AppImage builds. It adds `-f` only for symlink operations targeting `target/release/bundle/appimage/*.AppDir/usr/lib`; all other `ln` calls retain normal behavior.

A shell regression test proves both sides of that boundary.

## Verification

- `tauri/scripts/test-appimage-ln-wrapper.sh`
- `shellcheck tauri/scripts/build-appimage.sh tauri/scripts/appimage-bin/ln tauri/scripts/test-appimage-ln-wrapper.sh`
- Full cached Docker `make tauri-build` produced `gptme-tauri_0.31.0_amd64.AppImage` (SHA-256 `acb45617616ec199a246abf479f7da966b1cf96bf2778349ee4e60061b775f30`) without the duplicate-link failure
- Clean-home launch on `DISPLAY=:1`, `APPIMAGE_EXTRACT_AND_RUN=1`, `GPTME_SERVER_PORT=5713`; `/api/v2/server/health` returned green and WebView requests hit port 5713

## Scope

This only fixes reproducible local AppImage builds. The published dev AppImage, signed updater manifest, and real-provider onboarding path were already verified separately.