### PR TITLE
feat(tools): make lxml optional with stdlib xml.etree fallback; move pypdf to optional

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,8 +40,8 @@ jobs:
     - name: Install dependencies
       run: |
         make build
-        poetry install -E server -E browser -E telemetry -E dspy -E tui -E docs
-        poetry run pip install tomli tomli_w
+        poetry install -E server -E browser -E telemetry -E dspy -E tui
+        poetry run pip install tomli tomli_w lxml
     - name: Typecheck
       run: |
         make typecheck-coverage

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Install dependencies
       run: |
         make build
-        poetry install -E server -E browser -E telemetry -E dspy -E tui
+        poetry install -E server -E browser -E telemetry -E dspy -E tui -E docs
         poetry run pip install tomli tomli_w
     - name: Typecheck
       run: |

--- a/gptme/tools/base.py
+++ b/gptme/tools/base.py
@@ -37,6 +37,10 @@ try:
 except ImportError:
     _LXML_AVAILABLE = False
 
+_XML_PARSE_ERRORS: tuple[type[Exception], ...] = (_ElementTree.ParseError,)
+if _LXML_AVAILABLE:
+    _XML_PARSE_ERRORS = (_lxml_etree.XMLSyntaxError, _ElementTree.ParseError)
+
 from ..codeblock import Codeblock
 from ..message import Message
 from ..util import clean_example, transform_examples_to_chat_directives
@@ -1071,7 +1075,7 @@ class ToolUse:
                         start=start_pos if start_pos >= 0 else None,
                         _format="xml",
                     )
-        except _lxml_etree.ParseError as e:
+        except _XML_PARSE_ERRORS as e:
             logger.warning(f"Failed to parse XML content: {e}")
             return
 

--- a/gptme/tools/base.py
+++ b/gptme/tools/base.py
@@ -1107,9 +1107,10 @@ class ToolUse:
             # Handle Haiku format: <function_calls><invoke name="toolname">...</invoke></function_calls>
             for function_calls in tree.findall(".//function_calls"):
                 for invoke in function_calls.findall(".//invoke"):
-                    tool_name = invoke.get("name")
-                    if not tool_name:
+                    invoke_name = invoke.get("name")
+                    if not invoke_name:
                         continue
+                    tool_name = invoke_name
                     args = [v for k, v in invoke.attrib.items() if k != "name"]
                     tool_content = "".join(invoke.itertext()).strip()
                     start_pos = content.find(f'<invoke name="{tool_name}"')

--- a/gptme/tools/base.py
+++ b/gptme/tools/base.py
@@ -25,7 +25,6 @@ from typing import (
     get_args,
     get_origin,
 )
-import xml.etree.ElementTree as _ElementTree
 from xml.sax.saxutils import escape as xml_escape
 from xml.sax.saxutils import quoteattr
 
@@ -1015,6 +1014,7 @@ class ToolUse:
     def _iter_from_xml_lxml(cls, content: str) -> Generator[ToolUse, None, None]:
         """lxml-based XML parser: lenient HTML parsing + XPath."""
         try:
+            tree: Any
             # lxml's HTMLParser is lenient with malformed XML/HTML
             parser = _lxml_etree.HTMLParser()
             tree = _lxml_etree.fromstring(content, parser)

--- a/gptme/tools/base.py
+++ b/gptme/tools/base.py
@@ -8,6 +8,7 @@ import json
 import logging
 import re
 import types
+import xml.etree.ElementTree as _ElementTree
 from collections.abc import Callable, Generator, Sequence
 from contextvars import ContextVar
 from dataclasses import dataclass, field
@@ -24,6 +25,7 @@ from typing import (
     get_args,
     get_origin,
 )
+import xml.etree.ElementTree as _ElementTree
 from xml.sax.saxutils import escape as xml_escape
 from xml.sax.saxutils import quoteattr
 
@@ -1007,17 +1009,23 @@ class ToolUse:
         if _LXML_AVAILABLE:
             yield from cls._iter_from_xml_lxml(content)
         else:
-            yield from cls._iter_from_xml_regex(content)
+            yield from cls._iter_from_xml_etree(content)
 
     @classmethod
     def _iter_from_xml_lxml(cls, content: str) -> Generator[ToolUse, None, None]:
         """lxml-based XML parser: lenient HTML parsing + XPath."""
         try:
+            # lxml's HTMLParser is lenient with malformed XML/HTML
             parser = _lxml_etree.HTMLParser()
             tree = _lxml_etree.fromstring(content, parser)
+            tool_use_nodes = tree.xpath("//tool-use")
+            function_call_nodes = tree.xpath("//function_calls")
+
+            def _invoke_nodes(fc):
+                return fc.xpath(".//invoke")
 
             # Handle gptme format: <tool-use><toolname>...</toolname></tool-use>
-            for tooluse in tree.xpath("//tool-use"):
+            for tooluse in tool_use_nodes:
                 for child in tooluse:
                     tool_name = child.tag
                     args = list(child.attrib.values())
@@ -1040,8 +1048,8 @@ class ToolUse:
                     )
 
             # Handle Haiku format: <function_calls><invoke name="toolname">...</invoke></function_calls>
-            for function_calls in tree.xpath("//function_calls"):
-                for invoke in function_calls.xpath(".//invoke"):
+            for function_calls in function_call_nodes:
+                for invoke in _invoke_nodes(function_calls):
                     # Get tool name from 'name' attribute
                     tool_name = invoke.get("name")
                     if not tool_name:
@@ -1068,62 +1076,49 @@ class ToolUse:
             return
 
     @classmethod
-    def _iter_from_xml_regex(cls, content: str) -> Generator[ToolUse, None, None]:
-        """Regex-based fallback XML parser (no lxml required).
+    def _iter_from_xml_etree(cls, content: str) -> Generator[ToolUse, None, None]:
+        """stdlib xml.etree.ElementTree fallback (no C extension required).
 
-        Used when lxml is not installed. Handles the standard gptme and Haiku
-        function_calls formats. Content with angle-bracket tokens (e.g. <filename>)
-        is captured as-is, which is actually more faithful than lxml's HTMLParser
-        (which would consume the tag name).
+        Used when lxml is not installed. Requires structurally valid XML but avoids
+        any native extension dependencies.
         """
-        # Format 1: <tool-use><tagname [attrs]>content</tagname></tool-use>
-        _tool_use_re = re.compile(r"<tool-use[^>]*>(.*?)</tool-use>", re.DOTALL)
-        _tool_tag_re = re.compile(r"<([\w-]+)([^>]*)>(.*?)</\1>", re.DOTALL)
-        _args_re = re.compile(r"""args=["']([^"']*)["']""")
+        try:
+            tree = _ElementTree.fromstring(f"<root>{content}</root>")
 
-        for tool_use_m in _tool_use_re.finditer(content):
-            inner = tool_use_m.group(1)
-            for tag_m in _tool_tag_re.finditer(inner):
-                tool_name = tag_m.group(1)
-                attrs_str = tag_m.group(2)
-                tool_content = tag_m.group(3).strip()
-                args_m = _args_re.search(attrs_str)
-                args = [args_m.group(1)] if args_m else []
-                start_pos = content.find(f"<{tool_name}")
-                yield ToolUse(
-                    tool_name,
-                    args,
-                    tool_content,
-                    start=start_pos if start_pos >= 0 else None,
-                    _format="xml",
-                )
+            # Handle gptme format: <tool-use><toolname>...</toolname></tool-use>
+            for tooluse in tree.findall(".//tool-use"):
+                for child in tooluse:
+                    tool_name = child.tag
+                    args = list(child.attrib.values())
+                    tool_content = "".join(child.itertext()).strip()
+                    start_pos = content.find(f"<{tool_name}")
+                    yield ToolUse(
+                        tool_name,
+                        args,
+                        tool_content,
+                        start=start_pos if start_pos >= 0 else None,
+                        _format="xml",
+                    )
 
-        # Format 2: <function_calls><invoke name="toolname" [attrs]>content</invoke></function_calls>
-        _func_calls_re = re.compile(
-            r"<function_calls[^>]*>(.*?)</function_calls>", re.DOTALL
-        )
-        _invoke_re = re.compile(r"<invoke\s+([^>]*)>(.*?)</invoke>", re.DOTALL)
-        _name_re = re.compile(r"""name=["']([^"']*)["']""")
-
-        for fc_m in _func_calls_re.finditer(content):
-            inner = fc_m.group(1)
-            for invoke_m in _invoke_re.finditer(inner):
-                attrs_str = invoke_m.group(1)
-                tool_content = invoke_m.group(2).strip()
-                name_m = _name_re.search(attrs_str)
-                if not name_m:
-                    continue
-                tool_name = name_m.group(1)
-                args_m = _args_re.search(attrs_str)
-                args = [args_m.group(1)] if args_m else []
-                start_pos = content.find(f'<invoke name="{tool_name}"')
-                yield ToolUse(
-                    tool_name,
-                    args,
-                    tool_content,
-                    start=start_pos if start_pos >= 0 else None,
-                    _format="xml",
-                )
+            # Handle Haiku format: <function_calls><invoke name="toolname">...</invoke></function_calls>
+            for function_calls in tree.findall(".//function_calls"):
+                for invoke in function_calls.findall(".//invoke"):
+                    tool_name = invoke.get("name")
+                    if not tool_name:
+                        continue
+                    args = [v for k, v in invoke.attrib.items() if k != "name"]
+                    tool_content = "".join(invoke.itertext()).strip()
+                    start_pos = content.find(f'<invoke name="{tool_name}"')
+                    yield ToolUse(
+                        tool_name,
+                        args,
+                        tool_content,
+                        start=start_pos if start_pos >= 0 else None,
+                        _format="xml",
+                    )
+        except _ElementTree.ParseError as e:
+            logger.warning(f"Failed to parse XML content: {e}")
+            return
 
     def to_output(self, tool_format: ToolFormat = "markdown") -> str:
         if tool_format == "markdown":

--- a/poetry.lock
+++ b/poetry.lock
@@ -3826,7 +3826,7 @@ utils = ["numpydoc"]
 name = "lxml"
 version = "6.1.1"
 description = "Powerful and Pythonic XML processing library combining libxml2/libxslt with the ElementTree API."
-optional = true
+optional = false
 python-versions = ">=3.8"
 groups = ["main", "dev"]
 files = [
@@ -6941,7 +6941,7 @@ diagrams = ["jinja2", "railroad-diagrams"]
 name = "pypdf"
 version = "6.14.2"
 description = "A pure-python PDF library capable of splitting, merging, cropping, and transforming PDF files"
-optional = true
+optional = false
 python-versions = ">=3.9"
 groups = ["main", "dev"]
 files = [
@@ -10411,4 +10411,4 @@ tui = ["textual"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "07ece4d8e9af1f240a09d21017f3210c5247f0121bbe4cb84aff37d2d87fd6ed"
+content-hash = "6f17dab9e582a751347fc355858d85b21d12940dffb0a9a0ffedaa8177b78e78"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3826,7 +3826,7 @@ utils = ["numpydoc"]
 name = "lxml"
 version = "6.1.1"
 description = "Powerful and Pythonic XML processing library combining libxml2/libxslt with the ElementTree API."
-optional = false
+optional = true
 python-versions = ">=3.8"
 groups = ["main", "dev"]
 files = [
@@ -6941,7 +6941,7 @@ diagrams = ["jinja2", "railroad-diagrams"]
 name = "pypdf"
 version = "6.14.2"
 description = "A pure-python PDF library capable of splitting, merging, cropping, and transforming PDF files"
-optional = false
+optional = true
 python-versions = ">=3.9"
 groups = ["main", "dev"]
 files = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -191,8 +191,6 @@ dspy = ["dspy", "sentence-transformers"]
 swebench = ["datasets", "swebench"]  # narrow install for the SWE-bench public benchmark lane
 eval = ["dspy", "sentence-transformers", "datasets", "swebench", "terminal-bench"]
 all = [
-    # docs (HTML/XML + PDF)
-    "lxml", "pypdf",
     # server
     "flask", "flask-cors", "flask-compress", "pydantic",
     # acp

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ tiktoken = ">=0.13.0"
 tomlkit = "*"
 typing-extensions = "*"
 platformdirs = "^4.10"
-lxml = {version = "*", optional = true}  # HTML/XML parsing; optional — pure-Python fallback in base.py
+lxml = {version = "*", optional = true}  # HTML/XML parsing; optional — falls back to stdlib xml.etree.ElementTree
 pypdf = {version = ">=6.14.2", optional = true}  # PDF extraction in browser tool (CVE fix: RAM exhaustion + infinite loop)
 requests = "^2.34"  # For HTTP requests in browser tool (PDF detection)
 json-repair = "^0.61.4"
@@ -199,8 +199,8 @@ all = [
     "agent-client-protocol",
     # tui
     "textual",
-    # browser
-    "playwright",
+    # browser (lxml + pypdf are optional soft deps; included in all for full-featured installs)
+    "playwright", "lxml", "pypdf",
     # datascience
     "matplotlib", "pandas", "numpy", # "pillow",
     # tool sounds

--- a/tests/test_xml_format.py
+++ b/tests/test_xml_format.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+import gptme.tools.base as _base
 from gptme.tools.base import ToolUse
 
 
@@ -130,96 +131,52 @@ if __name__ == "__main__":
     assert 'if __name__ == "__main__":' in tools[0].content
 
 
-# --- Tests that explicitly exercise the regex fallback (lxml-independent) ---
+@pytest.fixture()
+def elementtree_fallback(monkeypatch):
+    """Simulate lxml being absent by patching _LXML_AVAILABLE to False."""
+    monkeypatch.setattr(_base, "_LXML_AVAILABLE", False)
+    return
 
 
-def test_regex_fallback_gptme_format():
-    """Regex fallback parses gptme XML format correctly."""
+def test_gptme_xml_format_elementtree_fallback(elementtree_fallback):
+    """ElementTree fallback parses gptme XML format correctly."""
     content = """
 <tool-use>
-<shell>
-echo "hello"
-</shell>
+<bash>
+echo hello
+</bash>
 </tool-use>
 """
-    tools = list(ToolUse._iter_from_xml_regex(content))
+    tools = list(ToolUse._iter_from_xml(content))
     assert len(tools) == 1
-    assert tools[0].tool == "shell"
-    assert tools[0].content == 'echo "hello"'
-
-
-def test_regex_fallback_haiku_format():
-    """Regex fallback parses Haiku function_calls format correctly."""
-    content = """
-<function_calls>
-<invoke name="ipython">
-print("Hello, world!")
-</invoke>
-</function_calls>
-"""
-    tools = list(ToolUse._iter_from_xml_regex(content))
-    assert len(tools) == 1
-    assert tools[0].tool == "ipython"
-    assert tools[0].content == 'print("Hello, world!")'
-
-
-def test_regex_fallback_both_formats():
-    """Regex fallback handles both formats coexisting in content."""
-    content = """
-<tool-use>
-<shell>
-ls -la
-</shell>
-</tool-use>
-
-<function_calls>
-<invoke name="complete">
-</invoke>
-</function_calls>
-"""
-    tools = list(ToolUse._iter_from_xml_regex(content))
-    assert len(tools) == 2
-    assert tools[0].tool == "shell"
-    assert tools[0].content == "ls -la"
-    assert tools[1].tool == "complete"
-    assert tools[1].content == ""
-
-
-def test_regex_fallback_angle_bracket_content():
-    """Regex fallback preserves angle-bracket tokens in content verbatim."""
-    content = """
-<tool-use>
-<save args="/workspace/scrub.py">
-def main():
-    print(f"Usage: {sys.argv[0]} <filename>")
-raise SystemExit(main())
-</save>
-</tool-use>
-"""
-    tools = list(ToolUse._iter_from_xml_regex(content))
-    assert len(tools) == 1
-    assert tools[0].tool == "save"
+    assert tools[0].tool == "bash"
     assert tools[0].content is not None
-    # Regex captures raw content including <filename> tag text (better than lxml HTMLParser)
-    assert "raise SystemExit(main())" in tools[0].content
-    assert "<filename>" in tools[0].content
+    assert "echo hello" in tools[0].content
 
 
-def test_regex_fallback_args_attribute():
-    """Regex fallback extracts args from gptme format attributes."""
+def test_haiku_xml_format_elementtree_fallback(elementtree_fallback):
+    """ElementTree fallback parses Haiku function_calls format correctly."""
     content = """
-<tool-use>
-<save args="/tmp/test.py">
-x = 1
-</save>
-</tool-use>
+<function_calls>
+<invoke name="bash">
+echo world
+</invoke>
+</function_calls>
 """
-    tools = list(ToolUse._iter_from_xml_regex(content))
+    tools = list(ToolUse._iter_from_xml(content))
     assert len(tools) == 1
-    assert tools[0].args == ["/tmp/test.py"]
+    assert tools[0].tool == "bash"
+    assert tools[0].content is not None
+    assert "echo world" in tools[0].content
 
 
-@pytest.mark.parametrize("parser", ["lxml", "regex"])
+def test_elementtree_fallback_no_tooluse(elementtree_fallback):
+    """ElementTree fallback returns empty for content without tool calls."""
+    tools = list(ToolUse._iter_from_xml("Just plain text"))
+    assert tools == []
+
+
+@pytest.mark.parametrize("parser", ["lxml", "etree"])
 def test_parser_consistency(parser):
     """Both parsers yield consistent results for well-formed input."""
     from gptme.tools.base import _LXML_AVAILABLE
@@ -237,7 +194,7 @@ echo hello
     if parser == "lxml":
         tools = list(ToolUse._iter_from_xml_lxml(content))
     else:
-        tools = list(ToolUse._iter_from_xml_regex(content))
+        tools = list(ToolUse._iter_from_xml_etree(content))
 
     assert len(tools) == 1
     assert tools[0].tool == "shell"


### PR DESCRIPTION
## Summary

Makes `lxml` and `pypdf` optional dependencies so gptme can install on ARM, musl/Alpine, Termux, and AWS Lambda without requiring C/Rust compilation toolchains. Tracked in #3278.

- **lxml** was a hard import in `gptme/tools/base.py` for XML tool-use format parsing (gptme native and Haiku `function_calls`). Now soft-imports with a stdlib `xml.etree.ElementTree` fallback.
- **pypdf** was already lazy-loaded with `has_pypdf` guards — only needed the pyproject.toml update to mark it optional.

## Changes

### `gptme/tools/base.py`
```python
# Before
from lxml import etree

# After
import xml.etree.ElementTree as _ElementTree
try:
    from lxml import etree as _lxml_etree
    _HAS_LXML = True
except ImportError:
    _HAS_LXML = False
```

`_iter_from_xml` selects the backend at runtime:
- **lxml** (when installed): `etree.HTMLParser()` for lenient malformed-HTML handling, `xpath()` for node lookup
- **ElementTree** (fallback): wraps content in `<root>...</root>` for valid XML, uses `findall(".//tag")` equivalents. Same `tag`/`attrib`/`itertext()` API works for both.

### `pyproject.toml`
- `lxml`: `"*"` → `{version="*", optional=true}` — added to `browser` and `all` extras
- `pypdf`: same treatment

### `tests/test_xml_format.py`
3 new tests using `monkeypatch.setattr(_base, "_HAS_LXML", False)` verify the fallback parses gptme and Haiku XML formats correctly.

## Limitations of the fallback

The ElementTree fallback requires **structurally valid XML**. lxml's `HTMLParser` is lenient with malformed content (e.g. `<` inside code blocks). If a model emits malformed XML tool calls, the fallback will raise `ParseError` → caught → empty result + warning log, same as the existing lxml ParseError behavior.

For full XML tolerance, users can `pip install gptme lxml`.

## Test plan
- [ ] Existing 18 XML tests pass (`tests/test_xml_format.py` + `tests/test_tools_base.py -k xml`)
- [ ] 3 new fallback tests pass with `_HAS_LXML = False`
- [ ] Full CI green