### PR TITLE
feat(webui): toggleable external sessions in conversation list

### DIFF
--- a/webui/src/components/ConversationList.tsx
+++ b/webui/src/components/ConversationList.tsx
@@ -119,10 +119,9 @@ export const ConversationList: FC<Props> = ({
 
   const [showExternal, setShowExternal] = useState(readShowExternal);
   const handleToggleExternal = () => {
-    setShowExternal((v) => {
-      writeShowExternal(!v);
-      return !v;
-    });
+    const next = !showExternal;
+    writeShowExternal(next);
+    setShowExternal(next);
   };
 
   // Separately track local star state for optimistic UI updates.
@@ -414,35 +413,42 @@ export const ConversationList: FC<Props> = ({
             )}
           </div>
           {/* Star filter toggle + sort control + external sessions toggle */}
-          {realConversations.length > 0 && (
+          {(realConversations.length > 0 ||
+            (onSelectExternal && externalSessions && externalSessions.length > 0)) && (
             <div className="flex items-center justify-between px-1 pt-1">
-              <button
-                aria-label={showStarredOnly ? 'Show all conversations' : 'Show starred only'}
-                aria-pressed={showStarredOnly}
-                className={`flex items-center gap-1 rounded px-2 py-0.5 text-xs transition-colors ${
-                  showStarredOnly
-                    ? 'bg-yellow-500/20 text-yellow-600 dark:text-yellow-400'
-                    : 'text-muted-foreground hover:text-foreground'
-                }`}
-                onClick={() => setShowStarredOnly((v) => !v)}
-              >
-                <Star className="h-3 w-3" fill={showStarredOnly ? 'currentColor' : 'none'} />
-                {showStarredOnly ? 'Starred' : 'All'}
-              </button>
-              <div className="flex items-center gap-1">
+              {realConversations.length > 0 ? (
                 <button
-                  aria-label={`Sort conversations: ${sortBy === 'recent' ? 'Recent' : sortBy === 'longest' ? 'Longest' : 'A-Z'} (click to cycle)`}
-                  className="flex items-center gap-1 rounded px-2 py-0.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
-                  onClick={() => {
-                    const next: SortBy =
-                      sortBy === 'recent' ? 'longest' : sortBy === 'longest' ? 'alpha' : 'recent';
-                    handleSortChange(next);
-                  }}
-                  title={`Sort: ${sortBy === 'recent' ? 'Recent' : sortBy === 'longest' ? 'Longest' : 'A-Z'} (click to cycle)`}
+                  aria-label={showStarredOnly ? 'Show all conversations' : 'Show starred only'}
+                  aria-pressed={showStarredOnly}
+                  className={`flex items-center gap-1 rounded px-2 py-0.5 text-xs transition-colors ${
+                    showStarredOnly
+                      ? 'bg-yellow-500/20 text-yellow-600 dark:text-yellow-400'
+                      : 'text-muted-foreground hover:text-foreground'
+                  }`}
+                  onClick={() => setShowStarredOnly((v) => !v)}
                 >
-                  <ArrowUpDown className="h-3 w-3" />
-                  {sortBy === 'recent' ? 'Recent' : sortBy === 'longest' ? 'Longest' : 'A-Z'}
+                  <Star className="h-3 w-3" fill={showStarredOnly ? 'currentColor' : 'none'} />
+                  {showStarredOnly ? 'Starred' : 'All'}
                 </button>
+              ) : (
+                <div />
+              )}
+              <div className="flex items-center gap-1">
+                {realConversations.length > 0 && (
+                  <button
+                    aria-label={`Sort conversations: ${sortBy === 'recent' ? 'Recent' : sortBy === 'longest' ? 'Longest' : 'A-Z'} (click to cycle)`}
+                    className="flex items-center gap-1 rounded px-2 py-0.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
+                    onClick={() => {
+                      const next: SortBy =
+                        sortBy === 'recent' ? 'longest' : sortBy === 'longest' ? 'alpha' : 'recent';
+                      handleSortChange(next);
+                    }}
+                    title={`Sort: ${sortBy === 'recent' ? 'Recent' : sortBy === 'longest' ? 'Longest' : 'A-Z'} (click to cycle)`}
+                  >
+                    <ArrowUpDown className="h-3 w-3" />
+                    {sortBy === 'recent' ? 'Recent' : sortBy === 'longest' ? 'Longest' : 'A-Z'}
+                  </button>
+                )}
                 {onSelectExternal && externalSessions && externalSessions.length > 0 && (
                   <button
                     aria-label={showExternal ? 'Hide external sessions' : 'Show external sessions'}

--- a/webui/src/components/ConversationList.tsx
+++ b/webui/src/components/ConversationList.tsx
@@ -52,6 +52,24 @@ function writeSortPreference(value: SortBy): void {
   }
 }
 
+const SHOW_EXTERNAL_KEY = 'gptme:show-external-sessions';
+
+function readShowExternal(): boolean {
+  try {
+    return localStorage.getItem(SHOW_EXTERNAL_KEY) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+function writeShowExternal(value: boolean): void {
+  try {
+    localStorage.setItem(SHOW_EXTERNAL_KEY, value ? 'true' : 'false');
+  } catch {
+    // Silently ignore storage errors
+  }
+}
+
 interface Props {
   conversations: ConversationSummary[];
   onSelect: (id: string, serverId?: string) => void;
@@ -97,6 +115,14 @@ export const ConversationList: FC<Props> = ({
   const handleSortChange = (value: SortBy) => {
     setSortBy(value);
     writeSortPreference(value);
+  };
+
+  const [showExternal, setShowExternal] = useState(readShowExternal);
+  const handleToggleExternal = () => {
+    setShowExternal((v) => {
+      writeShowExternal(!v);
+      return !v;
+    });
   };
 
   // Separately track local star state for optimistic UI updates.
@@ -387,7 +413,7 @@ export const ConversationList: FC<Props> = ({
               </Button>
             )}
           </div>
-          {/* Star filter toggle + sort control */}
+          {/* Star filter toggle + sort control + external sessions toggle */}
           {realConversations.length > 0 && (
             <div className="flex items-center justify-between px-1 pt-1">
               <button
@@ -403,19 +429,37 @@ export const ConversationList: FC<Props> = ({
                 <Star className="h-3 w-3" fill={showStarredOnly ? 'currentColor' : 'none'} />
                 {showStarredOnly ? 'Starred' : 'All'}
               </button>
-              <button
-                aria-label={`Sort conversations: ${sortBy === 'recent' ? 'Recent' : sortBy === 'longest' ? 'Longest' : 'A-Z'} (click to cycle)`}
-                className="flex items-center gap-1 rounded px-2 py-0.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
-                onClick={() => {
-                  const next: SortBy =
-                    sortBy === 'recent' ? 'longest' : sortBy === 'longest' ? 'alpha' : 'recent';
-                  handleSortChange(next);
-                }}
-                title={`Sort: ${sortBy === 'recent' ? 'Recent' : sortBy === 'longest' ? 'Longest' : 'A-Z'} (click to cycle)`}
-              >
-                <ArrowUpDown className="h-3 w-3" />
-                {sortBy === 'recent' ? 'Recent' : sortBy === 'longest' ? 'Longest' : 'A-Z'}
-              </button>
+              <div className="flex items-center gap-1">
+                <button
+                  aria-label={`Sort conversations: ${sortBy === 'recent' ? 'Recent' : sortBy === 'longest' ? 'Longest' : 'A-Z'} (click to cycle)`}
+                  className="flex items-center gap-1 rounded px-2 py-0.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
+                  onClick={() => {
+                    const next: SortBy =
+                      sortBy === 'recent' ? 'longest' : sortBy === 'longest' ? 'alpha' : 'recent';
+                    handleSortChange(next);
+                  }}
+                  title={`Sort: ${sortBy === 'recent' ? 'Recent' : sortBy === 'longest' ? 'Longest' : 'A-Z'} (click to cycle)`}
+                >
+                  <ArrowUpDown className="h-3 w-3" />
+                  {sortBy === 'recent' ? 'Recent' : sortBy === 'longest' ? 'Longest' : 'A-Z'}
+                </button>
+                {onSelectExternal && externalSessions && externalSessions.length > 0 && (
+                  <button
+                    aria-label={showExternal ? 'Hide external sessions' : 'Show external sessions'}
+                    aria-pressed={showExternal}
+                    className={`flex items-center gap-1 rounded px-2 py-0.5 text-xs transition-colors ${
+                      showExternal
+                        ? 'bg-primary/10 text-primary'
+                        : 'text-muted-foreground hover:text-foreground'
+                    }`}
+                    onClick={handleToggleExternal}
+                    title="Toggle external sessions (Claude Code, Codex, etc.)"
+                  >
+                    <Layers className="h-3 w-3" />
+                    Ext
+                  </button>
+                )}
+              </div>
             </div>
           )}
         </div>
@@ -603,8 +647,8 @@ export const ConversationList: FC<Props> = ({
         </div>
       )}
 
-      {/* External sessions section — compact view of cross-harness sessions */}
-      {externalSessions && externalSessions.length > 0 && onSelectExternal && (
+      {/* External sessions section — compact view of cross-harness sessions (toggle-gated, off by default) */}
+      {showExternal && externalSessions && externalSessions.length > 0 && onSelectExternal && (
         <div>
           <div className="flex items-center gap-1 px-2 py-1.5 text-xs font-medium text-muted-foreground">
             <Layers className="h-3 w-3" />

--- a/webui/src/components/__tests__/ConversationList.test.tsx
+++ b/webui/src/components/__tests__/ConversationList.test.tsx
@@ -471,4 +471,134 @@ describe('ConversationList', () => {
       expect(headers[2]).toHaveTextContent('This Week');
     });
   });
+
+  describe('external sessions toggle', () => {
+    const externalSession = {
+      id: 'ext-1',
+      session_id: 'ext-session-1',
+      harness: 'claude-code',
+      session_name: 'My CC Session',
+      project: 'bob',
+      model: 'claude-sonnet-4-6',
+      started_at: '2026-07-19T10:00:00Z',
+      last_activity: '2026-07-19T10:30:00Z',
+      capabilities: [],
+      trajectory_path: '/tmp/traj.jsonl',
+    };
+    const onSelectExternal = jest.fn();
+
+    beforeEach(() => {
+      localStorage.removeItem('gptme:show-external-sessions');
+    });
+
+    it('does not show toggle button when no external sessions are provided', () => {
+      renderWithProviders(
+        <ConversationList {...defaultProps} onSelectExternal={onSelectExternal} />
+      );
+      expect(screen.queryByLabelText('Show external sessions')).not.toBeInTheDocument();
+    });
+
+    it('does not show toggle button when externalSessions is empty', () => {
+      renderWithProviders(
+        <ConversationList
+          {...defaultProps}
+          externalSessions={[]}
+          onSelectExternal={onSelectExternal}
+        />
+      );
+      expect(screen.queryByLabelText('Show external sessions')).not.toBeInTheDocument();
+    });
+
+    it('shows toggle button when external sessions are available', () => {
+      renderWithProviders(
+        <ConversationList
+          {...defaultProps}
+          externalSessions={[externalSession]}
+          onSelectExternal={onSelectExternal}
+        />
+      );
+      expect(screen.getByLabelText('Show external sessions')).toBeInTheDocument();
+    });
+
+    it('hides external sessions by default (toggle off)', () => {
+      renderWithProviders(
+        <ConversationList
+          {...defaultProps}
+          externalSessions={[externalSession]}
+          onSelectExternal={onSelectExternal}
+        />
+      );
+      expect(screen.queryByText('External Sessions')).not.toBeInTheDocument();
+      expect(screen.queryByText('My CC Session')).not.toBeInTheDocument();
+    });
+
+    it('shows external sessions after clicking toggle', () => {
+      renderWithProviders(
+        <ConversationList
+          {...defaultProps}
+          externalSessions={[externalSession]}
+          onSelectExternal={onSelectExternal}
+        />
+      );
+      fireEvent.click(screen.getByLabelText('Show external sessions'));
+      expect(screen.getByText('External Sessions')).toBeInTheDocument();
+      expect(screen.getByText('My CC Session')).toBeInTheDocument();
+    });
+
+    it('hides external sessions again after toggling twice', () => {
+      renderWithProviders(
+        <ConversationList
+          {...defaultProps}
+          externalSessions={[externalSession]}
+          onSelectExternal={onSelectExternal}
+        />
+      );
+      const btn = screen.getByLabelText('Show external sessions');
+      fireEvent.click(btn);
+      expect(screen.getByText('My CC Session')).toBeInTheDocument();
+      fireEvent.click(screen.getByLabelText('Hide external sessions'));
+      expect(screen.queryByText('My CC Session')).not.toBeInTheDocument();
+    });
+
+    it('persists toggle state to localStorage', () => {
+      renderWithProviders(
+        <ConversationList
+          {...defaultProps}
+          externalSessions={[externalSession]}
+          onSelectExternal={onSelectExternal}
+        />
+      );
+      expect(localStorage.getItem('gptme:show-external-sessions')).toBeNull();
+      fireEvent.click(screen.getByLabelText('Show external sessions'));
+      expect(localStorage.getItem('gptme:show-external-sessions')).toBe('true');
+      fireEvent.click(screen.getByLabelText('Hide external sessions'));
+      expect(localStorage.getItem('gptme:show-external-sessions')).toBe('false');
+    });
+
+    it('restores toggle state from localStorage', () => {
+      localStorage.setItem('gptme:show-external-sessions', 'true');
+      renderWithProviders(
+        <ConversationList
+          {...defaultProps}
+          externalSessions={[externalSession]}
+          onSelectExternal={onSelectExternal}
+        />
+      );
+      expect(screen.getByText('My CC Session')).toBeInTheDocument();
+      expect(screen.getByLabelText('Hide external sessions')).toBeInTheDocument();
+    });
+
+    it('calls onSelectExternal when an external session is clicked', () => {
+      localStorage.setItem('gptme:show-external-sessions', 'true');
+      renderWithProviders(
+        <ConversationList
+          {...defaultProps}
+          externalSessions={[externalSession]}
+          onSelectExternal={onSelectExternal}
+        />
+      );
+      fireEvent.click(screen.getByText('My CC Session'));
+      expect(onSelectExternal).toHaveBeenCalledWith('ext-1');
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Implements Phase 1 of #3217: mixed multi-harness sessions in the native chat list.

External sessions (Claude Code, Codex, etc.) can now be toggled inline alongside native gptme conversations in the conversation list sidebar.

**Changes:**

- **Toggle button ("Ext")** appears in the `ConversationList` header controls bar (next to Sort), but **only when external sessions are available** — no button, no noise for users who haven't installed `gptme-sessions`
- **Off by default** — existing users see no change until they enable it
- **localStorage-persisted** (`gptme:show-external-sessions`) — survives refresh
- **Zero backend changes** — uses the existing `externalSessions` prop + `onSelectExternal` callback wired up in `UnifiedSidebar`; clicking a session navigates to the existing `/external-sessions?selected=<id>` detail view
- **9 new tests** covering toggle visibility, default state, click behavior, localStorage persistence, and session click-through

**UX flow:**

1. User has `gptme-sessions` installed → sessions from CC/Codex appear in `externalSessions` → "Ext" button shows in the controls bar
2. User clicks "Ext" → toggle on → sessions appear below the native conversations with harness badges (CC, Codex, etc.)
3. State persists across refresh
4. Without `gptme-sessions`: endpoint returns 503 → `externalSessions` is undefined → "Ext" button never renders

## What's not in this PR

Phase 2 (light steering via `steer_inject` capability) is explicitly deferred — no code path for it is added here.

Closes #3217 (Phase 1)

<!-- gptme-id:v1:gai_ZGraVRlJdrlTrZ8rYxPlgL7lsxSrEGyQRqJ23G5MXFH -->