### PR TITLE
feat(llm): add grok-subscription provider for SuperGrok subscriptions

### DIFF
--- a/gptme/cli/auth.py
+++ b/gptme/cli/auth.py
@@ -7,6 +7,7 @@ Usage:
     gptme-auth logout              # Remove stored gptme credentials
     gptme-auth status              # Show current login status
     gptme-auth openai-subscription # Authenticate for OpenAI subscription
+    gptme-auth grok-subscription   # Check SuperGrok subscription auth status
 """
 
 import json
@@ -309,6 +310,41 @@ def auth_openai_subscription():
         console.print("\n[red bold]✗ Authentication failed[/red bold]")
         console.print(f"  Error: {e}")
         logger.debug("Full error:", exc_info=True)
+        sys.exit(1)
+
+
+@main.command("grok-subscription")
+def auth_grok_subscription():
+    """Check authentication status for your SuperGrok subscription.
+
+    This provider reuses the credentials stored by the grok CLI.
+    Run `grok auth login` first if you haven't authenticated yet.
+    """
+    from pathlib import Path
+
+    grok_auth_path = Path.home() / ".grok" / "auth.json"
+    if not grok_auth_path.exists():
+        console.print("\n[red bold]✗ No grok CLI credentials found[/red bold]")
+        console.print(
+            "  Please install the grok CLI and run: [cyan]grok auth login[/cyan]"
+        )
+        console.print("  Install from: https://x.ai/grok")
+        sys.exit(1)
+
+    try:
+        from ..llm.llm_grok_subscription import get_auth
+
+        auth = get_auth()
+        import time
+
+        remaining_min = (auth.expires_at - time.time()) / 60
+        console.print("\n[green bold]✓ Grok subscription authenticated[/green bold]")
+        console.print(f"  Token expires in: {remaining_min:.0f} minutes")
+        console.print("\nYou can now use: [cyan]grok-subscription/grok-4.5[/cyan]")
+    except Exception as e:
+        console.print("\n[red bold]✗ Authentication check failed[/red bold]")
+        console.print(f"  Error: {e}")
+        console.print("  Try running: [cyan]grok auth login[/cyan]")
         sys.exit(1)
 
 

--- a/gptme/llm/__init__.py
+++ b/gptme/llm/__init__.py
@@ -117,6 +117,7 @@ PROVIDER_API_KEYS: dict[str, str] = {
 
 # Track subscription provider initialization
 _subscription_initialized = False
+_grok_subscription_initialized = False
 
 
 # PEP 562 lazy attribute resolution for provider-specific functions.
@@ -134,6 +135,9 @@ _LAZY_PROVIDER_ATTRS = {
     "chat_subscription": (".llm_openai_subscription", "chat"),
     "stream_subscription": (".llm_openai_subscription", "stream"),
     "init_subscription": (".llm_openai_subscription", "init"),
+    "chat_grok_subscription": (".llm_grok_subscription", "chat"),
+    "stream_grok_subscription": (".llm_grok_subscription", "stream"),
+    "init_grok_subscription": (".llm_grok_subscription", "init"),
 }
 
 
@@ -155,7 +159,7 @@ def init_llm(provider: Provider):
     Args:
         provider: Provider name (built-in or custom)
     """
-    global _subscription_initialized
+    global _subscription_initialized, _grok_subscription_initialized
     config = get_config()
 
     # Provider modules are imported lazily per-branch: each pulls in its SDK
@@ -190,6 +194,10 @@ def init_llm(provider: Provider):
         from .llm_openai_subscription import init as init_subscription
 
         _subscription_initialized = init_subscription(config)
+    elif provider == "grok-subscription" and not _grok_subscription_initialized:
+        from .llm_grok_subscription import init as init_grok_subscription
+
+        _grok_subscription_initialized = init_grok_subscription(config)
     elif (
         plugin := get_provider_plugin(str(provider))
     ) is not None and not has_openai_client(provider):
@@ -481,6 +489,13 @@ def _chat_complete(
             messages, _get_base_model(model), tools, max_tokens=max_tokens
         )
         return content, {"model": model}
+    if provider == "grok-subscription":
+        from .llm_grok_subscription import chat as chat_grok_subscription
+
+        content = chat_grok_subscription(
+            messages, _get_base_model(model), tools, max_tokens=max_tokens
+        )
+        return content, {"model": model}
     if provider == "mock":
         from .llm_mock import chat as chat_mock
 
@@ -620,6 +635,13 @@ def _stream(
         from .llm_openai_subscription import stream as stream_subscription
 
         gen = stream_subscription(
+            messages, _get_base_model(model), tools, max_tokens=max_tokens
+        )
+        return _StreamWithMetadata(gen, model)
+    if provider == "grok-subscription":
+        from .llm_grok_subscription import stream as stream_grok_subscription
+
+        gen = stream_grok_subscription(
             messages, _get_base_model(model), tools, max_tokens=max_tokens
         )
         return _StreamWithMetadata(gen, model)
@@ -1044,6 +1066,12 @@ def list_available_providers() -> list[tuple[Provider, str]]:
     if _token_path.exists() and "openai-subscription" not in seen:
         available.append((cast(Provider, "openai-subscription"), "oauth"))
         seen.add("openai-subscription")
+
+    # grok-subscription: uses tokens from the grok CLI (~/.grok/auth.json)
+    _grok_auth_path = Path.home() / ".grok" / "auth.json"
+    if _grok_auth_path.exists() and "grok-subscription" not in seen:
+        available.append((cast(Provider, "grok-subscription"), "grok-cli"))
+        seen.add("grok-subscription")
 
     # Include plugin providers that have their API key configured
     for plugin_name, env_var in get_plugin_api_keys().items():

--- a/gptme/llm/llm_grok_subscription.py
+++ b/gptme/llm/llm_grok_subscription.py
@@ -1,0 +1,332 @@
+"""Grok Subscription Provider.
+
+Enables use of SuperGrok subscriptions with gptme by reusing the credentials
+stored by the grok CLI (~/.grok/auth.json). No separate auth flow needed if
+the grok CLI is already authenticated.
+
+Uses the standard OpenAI Chat Completions API format served by xAI's CLI proxy:
+- Endpoint: https://cli-chat-proxy.grok.com/v1/chat/completions
+- Auth: Bearer token from grok CLI credential store
+- Token refresh via OIDC at https://auth.x.ai/oauth2/token
+
+NOTICE: For personal development use with your own SuperGrok subscription.
+For production or multi-user applications, use the xAI Platform API with an
+API key instead.
+
+Usage:
+    # Authenticate once via the grok CLI:
+    grok auth login
+    # Then use any grok-4.x model:
+    gptme --model grok-subscription/grok-4.5 "hello"
+"""
+
+import json
+import logging
+import time
+from collections.abc import Generator
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import requests
+
+from ..message import Message
+
+logger = logging.getLogger(__name__)
+
+# xAI CLI proxy — OpenAI-compatible chat completions endpoint
+GROK_SUBSCRIPTION_BASE_URL = "https://cli-chat-proxy.grok.com/v1"
+GROK_SUBSCRIPTION_ENDPOINT = f"{GROK_SUBSCRIPTION_BASE_URL}/chat/completions"
+
+# OIDC config (from grok CLI binary / auth.json)
+GROK_OIDC_CLIENT_ID = "b1a00492-073a-47ea-816f-4c329264a828"
+GROK_TOKEN_ENDPOINT = "https://auth.x.ai/oauth2/token"
+
+# Required version header — the proxy enforces a minimum client version
+GROK_CLIENT_VERSION = "0.2.93"
+
+
+def _get_grok_auth_path() -> Path:
+    """Return path to the grok CLI auth store."""
+    return Path.home() / ".grok" / "auth.json"
+
+
+def _get_grok_version_path() -> Path:
+    """Return path to the grok CLI version file."""
+    return Path.home() / ".grok" / "version.json"
+
+
+def _get_client_version() -> str:
+    """Read the installed grok CLI version (falls back to GROK_CLIENT_VERSION)."""
+    try:
+        data = json.loads(_get_grok_version_path().read_text())
+        return str(data.get("version", GROK_CLIENT_VERSION))
+    except Exception:
+        return GROK_CLIENT_VERSION
+
+
+@dataclass
+class GrokAuth:
+    """Authentication state for grok subscription."""
+
+    access_token: str
+    refresh_token: str | None
+    expires_at: float  # Unix timestamp
+
+
+_auth: GrokAuth | None = None
+
+
+def _load_grok_tokens() -> GrokAuth | None:
+    """Load the auth token stored by the grok CLI."""
+    path = _get_grok_auth_path()
+    if not path.exists():
+        return None
+    try:
+        raw = json.loads(path.read_text())
+        # auth.json maps {issuer::client_id: {...token data...}}
+        entry = next(iter(raw.values())) if raw else None
+        if not entry or "key" not in entry:
+            return None
+        access_token = entry["key"]
+        refresh_token = entry.get("refresh_token")
+        expires_at_str = entry.get("expires_at", "")
+        try:
+            from datetime import datetime
+
+            dt = datetime.fromisoformat(expires_at_str.replace("Z", "+00:00"))
+            expires_at = dt.timestamp()
+        except Exception:
+            expires_at = time.time() + 3600
+        return GrokAuth(
+            access_token=access_token,
+            refresh_token=refresh_token,
+            expires_at=expires_at,
+        )
+    except Exception as e:
+        logger.warning("Failed to load grok auth tokens: %s", e)
+        return None
+
+
+def _refresh_access_token(refresh_token: str) -> GrokAuth:
+    """Refresh the access token using the stored refresh token."""
+    resp = requests.post(
+        GROK_TOKEN_ENDPOINT,
+        data={
+            "grant_type": "refresh_token",
+            "client_id": GROK_OIDC_CLIENT_ID,
+            "refresh_token": refresh_token,
+        },
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        timeout=30,
+    )
+    if resp.status_code != 200:
+        raise ValueError(
+            f"Grok token refresh failed: {resp.status_code} — {resp.text[:200]}"
+        )
+    tokens = resp.json()
+    access_token = tokens.get("access_token")
+    if not access_token:
+        raise ValueError("No access_token in grok token refresh response")
+    new_refresh = tokens.get("refresh_token", refresh_token)
+    # Derive expiry from JWT exp claim if possible
+    try:
+        import base64
+
+        payload = access_token.split(".")[1]
+        padding = 4 - len(payload) % 4
+        if padding != 4:
+            payload += "=" * padding
+        exp = json.loads(base64.urlsafe_b64decode(payload)).get("exp")
+        expires_at = float(exp) if exp else time.time() + 3600
+    except Exception:
+        expires_at = time.time() + 3600
+    auth = GrokAuth(
+        access_token=access_token,
+        refresh_token=new_refresh,
+        expires_at=expires_at,
+    )
+    # Update the grok auth store so the refreshed token persists
+    _write_grok_tokens(auth)
+    logger.info("Grok subscription token refreshed successfully")
+    return auth
+
+
+def _write_grok_tokens(auth: GrokAuth) -> None:
+    """Persist refreshed tokens back to ~/.grok/auth.json."""
+    path = _get_grok_auth_path()
+    try:
+        raw = json.loads(path.read_text()) if path.exists() else {}
+        key = (
+            next(iter(raw)) if raw else f"{GROK_TOKEN_ENDPOINT}::{GROK_OIDC_CLIENT_ID}"
+        )
+        entry = raw.get(key, {})
+        entry["key"] = auth.access_token
+        if auth.refresh_token:
+            entry["refresh_token"] = auth.refresh_token
+        from datetime import datetime, timezone
+
+        entry["expires_at"] = datetime.fromtimestamp(
+            auth.expires_at, tz=timezone.utc
+        ).isoformat()
+        raw[key] = entry
+        path.write_text(json.dumps(raw, indent=2))
+    except Exception as e:
+        logger.warning("Failed to persist refreshed grok tokens: %s", e)
+
+
+def get_auth() -> GrokAuth:
+    """Return a valid GrokAuth, refreshing if needed.
+
+    Raises ValueError if no credentials are available.
+    """
+    global _auth
+
+    # Return in-memory auth if still valid (5-min buffer)
+    if _auth is not None and time.time() < _auth.expires_at - 300:
+        return _auth
+
+    # Try refreshing in-memory auth first
+    if _auth is not None and _auth.refresh_token:
+        try:
+            _auth = _refresh_access_token(_auth.refresh_token)
+            return _auth
+        except Exception as e:
+            logger.warning("In-memory token refresh failed: %s", e)
+
+    # Load from grok CLI auth store
+    stored = _load_grok_tokens()
+    if stored is not None:
+        if time.time() < stored.expires_at - 300:
+            _auth = stored
+            return _auth
+        if stored.refresh_token:
+            try:
+                _auth = _refresh_access_token(stored.refresh_token)
+                return _auth
+            except Exception as e:
+                logger.warning("Stored token refresh failed: %s", e)
+
+    raise ValueError(
+        "Grok subscription not authenticated.\n"
+        "Please run: grok auth login\n"
+        "(Install the grok CLI from https://x.ai/grok)"
+    )
+
+
+def _make_headers() -> dict[str, str]:
+    """Build request headers for the grok subscription API."""
+    auth = get_auth()
+    return {
+        "Authorization": f"Bearer {auth.access_token}",
+        "Content-Type": "application/json",
+        "x-grok-client-version": _get_client_version(),
+    }
+
+
+def _messages_to_openai(messages: list[Message]) -> list[dict[str, Any]]:
+    """Convert gptme messages to OpenAI chat completions format."""
+    result = []
+    for msg in messages:
+        role = msg.role
+        if role == "system":
+            result.append({"role": "system", "content": msg.content})
+        elif role == "user":
+            result.append({"role": "user", "content": msg.content})
+        elif role == "assistant":
+            result.append({"role": "assistant", "content": msg.content})
+    return result
+
+
+def stream(
+    messages: list[Message],
+    model: str,
+    tools: list[Any] | None = None,
+    max_tokens: int | None = None,
+    **kwargs: Any,
+) -> Generator[str, None, None]:
+    """Stream completion from grok subscription API."""
+    api_messages = _messages_to_openai(messages)
+    body: dict[str, Any] = {
+        "model": model,
+        "messages": api_messages,
+        "stream": True,
+    }
+    if max_tokens is not None:
+        body["max_tokens"] = max_tokens
+
+    resp = requests.post(
+        GROK_SUBSCRIPTION_ENDPOINT,
+        json=body,
+        headers=_make_headers(),
+        stream=True,
+        timeout=(30, 300),
+    )
+    if resp.status_code != 200:
+        raise ValueError(
+            f"Grok subscription API error {resp.status_code}: {resp.text[:400]}"
+        )
+
+    for raw_line in resp.iter_lines():
+        if not raw_line:
+            continue
+        line = (
+            raw_line.decode("utf-8") if isinstance(raw_line, bytes) else str(raw_line)
+        )
+        if not line.startswith("data:"):
+            continue
+        data = line[5:].strip()
+        if data == "[DONE]":
+            return
+        try:
+            chunk = json.loads(data)
+        except json.JSONDecodeError:
+            continue
+        choices = chunk.get("choices", [])
+        if not choices:
+            continue
+        delta = choices[0].get("delta", {})
+        content = delta.get("content")
+        if content:
+            yield content
+
+
+def chat(
+    messages: list[Message],
+    model: str,
+    tools: list[Any] | None = None,
+    **kwargs: Any,
+) -> str:
+    """Non-streaming completion from grok subscription API."""
+    return "".join(stream(messages, model, tools, **kwargs))
+
+
+def init(config: Any) -> bool:
+    """Initialize the grok subscription provider."""
+    global _auth
+    stored = _load_grok_tokens()
+    if stored is None:
+        logger.info(
+            "Grok subscription provider available "
+            "(run 'grok auth login' to authenticate)"
+        )
+        return True
+
+    if time.time() < stored.expires_at - 300:
+        _auth = stored
+        logger.info("Grok subscription provider initialized with stored token")
+        return True
+
+    if stored.refresh_token:
+        try:
+            _auth = _refresh_access_token(stored.refresh_token)
+            logger.info("Grok subscription provider initialized with refreshed token")
+            return True
+        except Exception as e:
+            logger.debug("Token refresh during init failed: %s", e)
+
+    logger.info(
+        "Grok subscription provider available but token expired "
+        "(run 'grok auth login' to re-authenticate)"
+    )
+    return True

--- a/gptme/llm/llm_grok_subscription.py
+++ b/gptme/llm/llm_grok_subscription.py
@@ -30,7 +30,7 @@ from typing import Any
 
 import requests
 
-from ..message import Message
+from ..message import Message, msgs2dicts
 
 logger = logging.getLogger(__name__)
 
@@ -75,19 +75,31 @@ class GrokAuth:
 
 
 _auth: GrokAuth | None = None
+# Track which key was loaded from the credential store so we write back to the
+# same entry (not just whichever happens to be first in a multi-entry store).
+_credential_key: str | None = None
 
 
 def _load_grok_tokens() -> GrokAuth | None:
     """Load the auth token stored by the grok CLI."""
+    global _credential_key
     path = _get_grok_auth_path()
     if not path.exists():
         return None
     try:
         raw = json.loads(path.read_text())
+        if not raw:
+            return None
         # auth.json maps {issuer::client_id: {...token data...}}
-        entry = next(iter(raw.values())) if raw else None
+        # Prefer the entry whose key contains our known client ID; fall back to first.
+        preferred_key = next(
+            (k for k in raw if GROK_OIDC_CLIENT_ID in k),
+            next(iter(raw)),
+        )
+        entry = raw[preferred_key]
         if not entry or "key" not in entry:
             return None
+        _credential_key = preferred_key
         access_token = entry["key"]
         refresh_token = entry.get("refresh_token")
         expires_at_str = entry.get("expires_at", "")
@@ -153,13 +165,28 @@ def _refresh_access_token(refresh_token: str) -> GrokAuth:
 
 
 def _write_grok_tokens(auth: GrokAuth) -> None:
-    """Persist refreshed tokens back to ~/.grok/auth.json."""
+    """Persist refreshed tokens back to ~/.grok/auth.json.
+
+    Uses the same key that was identified during the most recent _load_grok_tokens
+    call so that multi-entry stores are updated correctly.
+    """
+    global _credential_key
     path = _get_grok_auth_path()
     try:
         raw = json.loads(path.read_text()) if path.exists() else {}
-        key = (
-            next(iter(raw)) if raw else f"{GROK_TOKEN_ENDPOINT}::{GROK_OIDC_CLIENT_ID}"
-        )
+        # Resolve the target key: prefer the one we previously loaded from,
+        # then the entry containing our client ID, then the first entry, then
+        # the canonical default.
+        default_key = f"{GROK_TOKEN_ENDPOINT}::{GROK_OIDC_CLIENT_ID}"
+        if _credential_key and _credential_key in raw:
+            key = _credential_key
+        elif raw:
+            key = next(
+                (k for k in raw if GROK_OIDC_CLIENT_ID in k),
+                next(iter(raw)),
+            )
+        else:
+            key = default_key
         entry = raw.get(key, {})
         entry["key"] = auth.access_token
         if auth.refresh_token:
@@ -170,7 +197,10 @@ def _write_grok_tokens(auth: GrokAuth) -> None:
             auth.expires_at, tz=timezone.utc
         ).isoformat()
         raw[key] = entry
-        path.write_text(json.dumps(raw, indent=2))
+        # Atomic write: write to a temp file and rename
+        tmp = path.with_suffix(".tmp")
+        tmp.write_text(json.dumps(raw, indent=2))
+        tmp.rename(path)
     except Exception as e:
         logger.warning("Failed to persist refreshed grok tokens: %s", e)
 
@@ -225,17 +255,14 @@ def _make_headers() -> dict[str, str]:
 
 
 def _messages_to_openai(messages: list[Message]) -> list[dict[str, Any]]:
-    """Convert gptme messages to OpenAI chat completions format."""
-    result = []
-    for msg in messages:
-        role = msg.role
-        if role == "system":
-            result.append({"role": "system", "content": msg.content})
-        elif role == "user":
-            result.append({"role": "user", "content": msg.content})
-        elif role == "assistant":
-            result.append({"role": "assistant", "content": msg.content})
-    return result
+    """Convert gptme messages to OpenAI chat completions format.
+
+    Handles tool calls (assistant → tool_calls) and tool results (system+call_id
+    → role:tool) using the same helpers as the main OpenAI provider.
+    """
+    from .llm_openai import _handle_tools
+
+    return list(_handle_tools(msgs2dicts(messages)))
 
 
 def stream(

--- a/gptme/llm/llm_grok_subscription.py
+++ b/gptme/llm/llm_grok_subscription.py
@@ -171,22 +171,24 @@ def _write_grok_tokens(auth: GrokAuth) -> None:
     Uses the same key that was identified during the most recent _load_grok_tokens
     call so that multi-entry stores are updated correctly.
 
-    Uses an exclusive flock + per-pid temp file + os.replace() so concurrent
-    gptme processes and the grok CLI don't interleave their writes.
+    Uses an exclusive flock on a separate .lock file (never replaced) + per-pid
+    temp file + os.replace() so concurrent gptme processes and the grok CLI don't
+    interleave their writes.  Locking auth.json directly is unsafe because
+    os.replace() swaps in a new inode, releasing the lock from under waiters.
     """
     import fcntl
 
     global _credential_key
     path = _get_grok_auth_path()
+    lock_path = path.parent / (path.name + ".lock")
     tmp = path.parent / f"{path.name}.tmp.{os.getpid()}"
     try:
-        # Hold an exclusive lock for the full read-modify-write cycle.
-        # Open with 'a+' so we create the file if absent without truncating.
-        lock_fd = open(path, "a+")
+        # Hold an exclusive lock on a dedicated .lock file that is never replaced.
+        # This keeps the flock valid across the os.replace() call below.
+        lock_fd = open(lock_path, "a")
         try:
             fcntl.flock(lock_fd, fcntl.LOCK_EX)
-            lock_fd.seek(0)
-            raw_text = lock_fd.read()
+            raw_text = path.read_text() if path.exists() else ""
             raw: dict = json.loads(raw_text) if raw_text.strip() else {}
             # Resolve the target key: prefer the one we previously loaded from,
             # then the entry containing our client ID, then the first entry, then
@@ -211,7 +213,9 @@ def _write_grok_tokens(auth: GrokAuth) -> None:
                 auth.expires_at, tz=timezone.utc
             ).isoformat()
             raw[key] = entry
-            # Atomic publish: write to per-pid temp then rename under the lock
+            # Atomic publish under the still-held lock: write to per-pid temp
+            # then rename into place.  The lock_path inode (not auth.json) stays
+            # constant, so the flock remains valid across the replace.
             tmp.write_text(json.dumps(raw, indent=2))
             os.replace(tmp, path)
         finally:
@@ -390,6 +394,13 @@ def stream(
         content = delta.get("content")
         if content:
             yield content
+        # Forward streamed native tool calls in gptme's @name(id): args format
+        for tool_call in delta.get("tool_calls", []):
+            func = tool_call.get("function", {})
+            if func.get("name"):
+                yield f"\n@{func['name']}({tool_call.get('id', '')}): "
+            if func.get("arguments"):
+                yield func["arguments"]
 
 
 def chat(

--- a/gptme/llm/llm_grok_subscription.py
+++ b/gptme/llm/llm_grok_subscription.py
@@ -22,6 +22,7 @@ Usage:
 
 import json
 import logging
+import os
 import time
 from collections.abc import Generator
 from dataclasses import dataclass
@@ -169,40 +170,59 @@ def _write_grok_tokens(auth: GrokAuth) -> None:
 
     Uses the same key that was identified during the most recent _load_grok_tokens
     call so that multi-entry stores are updated correctly.
+
+    Uses an exclusive flock + per-pid temp file + os.replace() so concurrent
+    gptme processes and the grok CLI don't interleave their writes.
     """
+    import fcntl
+
     global _credential_key
     path = _get_grok_auth_path()
+    tmp = path.parent / f"{path.name}.tmp.{os.getpid()}"
     try:
-        raw = json.loads(path.read_text()) if path.exists() else {}
-        # Resolve the target key: prefer the one we previously loaded from,
-        # then the entry containing our client ID, then the first entry, then
-        # the canonical default.
-        default_key = f"{GROK_TOKEN_ENDPOINT}::{GROK_OIDC_CLIENT_ID}"
-        if _credential_key and _credential_key in raw:
-            key = _credential_key
-        elif raw:
-            key = next(
-                (k for k in raw if GROK_OIDC_CLIENT_ID in k),
-                next(iter(raw)),
-            )
-        else:
-            key = default_key
-        entry = raw.get(key, {})
-        entry["key"] = auth.access_token
-        if auth.refresh_token:
-            entry["refresh_token"] = auth.refresh_token
-        from datetime import datetime, timezone
+        # Hold an exclusive lock for the full read-modify-write cycle.
+        # Open with 'a+' so we create the file if absent without truncating.
+        lock_fd = open(path, "a+")
+        try:
+            fcntl.flock(lock_fd, fcntl.LOCK_EX)
+            lock_fd.seek(0)
+            raw_text = lock_fd.read()
+            raw: dict = json.loads(raw_text) if raw_text.strip() else {}
+            # Resolve the target key: prefer the one we previously loaded from,
+            # then the entry containing our client ID, then the first entry, then
+            # the canonical default.
+            default_key = f"{GROK_TOKEN_ENDPOINT}::{GROK_OIDC_CLIENT_ID}"
+            if _credential_key and _credential_key in raw:
+                key = _credential_key
+            elif raw:
+                key = next(
+                    (k for k in raw if GROK_OIDC_CLIENT_ID in k),
+                    next(iter(raw)),
+                )
+            else:
+                key = default_key
+            entry = raw.get(key, {})
+            entry["key"] = auth.access_token
+            if auth.refresh_token:
+                entry["refresh_token"] = auth.refresh_token
+            from datetime import datetime, timezone
 
-        entry["expires_at"] = datetime.fromtimestamp(
-            auth.expires_at, tz=timezone.utc
-        ).isoformat()
-        raw[key] = entry
-        # Atomic write: write to a temp file and rename
-        tmp = path.with_suffix(".tmp")
-        tmp.write_text(json.dumps(raw, indent=2))
-        tmp.rename(path)
+            entry["expires_at"] = datetime.fromtimestamp(
+                auth.expires_at, tz=timezone.utc
+            ).isoformat()
+            raw[key] = entry
+            # Atomic publish: write to per-pid temp then rename under the lock
+            tmp.write_text(json.dumps(raw, indent=2))
+            os.replace(tmp, path)
+        finally:
+            fcntl.flock(lock_fd, fcntl.LOCK_UN)
+            lock_fd.close()
     except Exception as e:
         logger.warning("Failed to persist refreshed grok tokens: %s", e)
+        try:
+            tmp.unlink(missing_ok=True)
+        except Exception:
+            pass
 
 
 def get_auth() -> GrokAuth:
@@ -254,15 +274,66 @@ def _make_headers() -> dict[str, str]:
     }
 
 
-def _messages_to_openai(messages: list[Message]) -> list[dict[str, Any]]:
+def _messages_to_openai(
+    messages: list[Message], tools: list[Any] | None = None
+) -> list[dict[str, Any]]:
     """Convert gptme messages to OpenAI chat completions format.
 
     Handles tool calls (assistant → tool_calls) and tool results (system+call_id
     → role:tool) using the same helpers as the main OpenAI provider.
+    Also expands image file attachments into base64 image_url content parts.
     """
-    from .llm_openai import _handle_tools
+    from .llm_openai import (
+        _handle_tools,
+        _merge_tool_results_with_same_call_id,
+    )
 
-    return list(_handle_tools(msgs2dicts(messages)))
+    raw_dicts = msgs2dicts(messages)
+    if tools:
+        raw_dicts = list(
+            _merge_tool_results_with_same_call_id(_handle_tools(raw_dicts))
+        )
+    else:
+        raw_dicts = list(_handle_tools(raw_dicts))
+
+    result = []
+    for msg in raw_dicts:
+        files = msg.pop("files", None) or []
+        if files:
+            parts: list[dict[str, Any]] = []
+            if msg.get("content"):
+                parts.append({"type": "text", "text": msg["content"]})
+            for f in files:
+                try:
+                    import base64
+                    import mimetypes
+
+                    fpath = Path(f) if isinstance(f, str) else Path(str(f))
+                    mime = mimetypes.guess_type(str(fpath))[0] or "image/png"
+                    if mime.startswith("image/"):
+                        data = base64.b64encode(fpath.read_bytes()).decode()
+                        parts.append(
+                            {
+                                "type": "image_url",
+                                "image_url": {"url": f"data:{mime};base64,{data}"},
+                            }
+                        )
+                except Exception as exc:
+                    logger.warning("Could not attach file %s: %s", f, exc)
+            if parts:
+                msg = dict(msg)
+                msg["content"] = parts
+        result.append(msg)
+    return result
+
+
+def _tools_to_openai(tools: list[Any], model: str) -> list[dict[str, Any]]:
+    """Convert ToolSpec list to OpenAI-compatible tool schema dicts."""
+    from .llm_openai import _spec2tool
+    from .models import get_model
+
+    model_meta = get_model(f"grok-subscription/{model}")
+    return [dict(_spec2tool(t, model_meta)) for t in tools]
 
 
 def stream(
@@ -273,7 +344,7 @@ def stream(
     **kwargs: Any,
 ) -> Generator[str, None, None]:
     """Stream completion from grok subscription API."""
-    api_messages = _messages_to_openai(messages)
+    api_messages = _messages_to_openai(messages, tools)
     body: dict[str, Any] = {
         "model": model,
         "messages": api_messages,
@@ -281,6 +352,9 @@ def stream(
     }
     if max_tokens is not None:
         body["max_tokens"] = max_tokens
+    if tools:
+        body["tools"] = _tools_to_openai(tools, model)
+        body["tool_choice"] = "auto"
 
     resp = requests.post(
         GROK_SUBSCRIPTION_ENDPOINT,

--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -1725,6 +1725,7 @@ def _spec2tool(spec: ToolSpec, model: ModelMeta) -> ChatCompletionToolParam:
         "openrouter",
         "deepseek",
         "local",
+        "grok-subscription",
     ] or is_custom_provider(model.model.split("/")[0]):
         all_required = all(p.required for p in spec.parameters)
         supports_strict = model.supports_strict_tools and all_required

--- a/gptme/llm/models/data.py
+++ b/gptme/llm/models/data.py
@@ -352,6 +352,21 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
             "preferred_edit_format": "whole",
         },
     },
+    # SuperGrok subscription via the grok CLI proxy (cli-chat-proxy.grok.com)
+    # Uses the same token stored by `grok auth login`. Price listed as $0
+    # (subscription-backed; no per-token charge beyond the subscription fee).
+    "grok-subscription": {
+        "grok-4.5": {
+            "context": 500_000,
+            "max_output": 100_000,
+            "price_input": 0,
+            "price_output": 0,
+            "supports_reasoning": True,
+            "supports_vision": True,
+            "preferred_edit_format": "diff",
+            "default_tool_format": "tool",
+        },
+    },
     "openrouter": {
         "qwen/qwen3-max": {
             "context": 256_000,

--- a/gptme/llm/models/types.py
+++ b/gptme/llm/models/types.py
@@ -51,7 +51,6 @@ MODEL_ALIASES: dict[str, dict[str, str]] = {
 BuiltinProvider = Literal[
     "openai",
     "openai-subscription",
-    "grok-subscription",
     "anthropic",
     "azure",
     "openrouter",
@@ -60,6 +59,7 @@ BuiltinProvider = Literal[
     "gemini",
     "groq",
     "xai",
+    "grok-subscription",
     "deepseek",
     "moonshot",
     "nvidia",

--- a/gptme/llm/models/types.py
+++ b/gptme/llm/models/types.py
@@ -51,6 +51,7 @@ MODEL_ALIASES: dict[str, dict[str, str]] = {
 BuiltinProvider = Literal[
     "openai",
     "openai-subscription",
+    "grok-subscription",
     "anthropic",
     "azure",
     "openrouter",

--- a/tests/test_llm_grok_subscription.py
+++ b/tests/test_llm_grok_subscription.py
@@ -1,0 +1,317 @@
+"""Tests for the grok-subscription provider."""
+
+import json
+import time
+from collections.abc import Iterator
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from gptme.llm import llm_grok_subscription
+from gptme.llm.llm_grok_subscription import (
+    GrokAuth,
+    _load_grok_tokens,
+    _write_grok_tokens,
+)
+from gptme.message import Message
+
+
+def _make_auth() -> GrokAuth:
+    return GrokAuth(
+        access_token="test-access-token",
+        refresh_token="test-refresh-token",
+        expires_at=9_999_999_999.0,
+    )
+
+
+def _make_auth_json(
+    key: str = "https://auth.x.ai/oauth2/token::b1a00492-073a-47ea-816f-4c329264a828",
+) -> dict:
+    return {
+        key: {
+            "key": "test-access-token",
+            "refresh_token": "test-refresh-token",
+            "expires_at": "2099-01-01T00:00:00+00:00",
+        }
+    }
+
+
+class _FakeSSEStreamResponse:
+    def __init__(self, events: list[dict[str, Any]]) -> None:
+        self.status_code = 200
+        self.text = ""
+        self._events = events
+
+    def iter_lines(self) -> Iterator[bytes]:
+        for event in self._events:
+            yield f"data: {json.dumps(event)}".encode()
+        yield b"data: [DONE]"
+
+
+def _run_stream(events: list[dict[str, Any]]) -> str:
+    auth = _make_auth()
+    response = _FakeSSEStreamResponse(events)
+    with (
+        patch("gptme.llm.llm_grok_subscription.get_auth", return_value=auth),
+        patch("gptme.llm.llm_grok_subscription.requests.post", return_value=response),
+    ):
+        return "".join(
+            llm_grok_subscription.stream(
+                [Message(role="user", content="hello")], "grok-4.5"
+            )
+        )
+
+
+# ── stream tests ──────────────────────────────────────────────────────────────
+
+
+def test_stream_basic_text():
+    output = _run_stream(
+        [
+            {"choices": [{"delta": {"content": "Hello"}}]},
+            {"choices": [{"delta": {"content": ", world!"}}]},
+        ]
+    )
+    assert output == "Hello, world!"
+
+
+def test_stream_empty_delta_ignored():
+    output = _run_stream(
+        [
+            {"choices": [{"delta": {"content": "Hi"}}]},
+            {"choices": [{"delta": {}}]},
+            {"choices": [{"delta": {"content": "!"}}]},
+        ]
+    )
+    assert output == "Hi!"
+
+
+def test_stream_no_choices_ignored():
+    output = _run_stream(
+        [
+            {"choices": [{"delta": {"content": "A"}}]},
+            {"not_choices": True},
+            {"choices": [{"delta": {"content": "B"}}]},
+        ]
+    )
+    assert output == "AB"
+
+
+def test_stream_builds_correct_request():
+    auth = _make_auth()
+    response = _FakeSSEStreamResponse([{"choices": [{"delta": {"content": "ok"}}]}])
+    with (
+        patch("gptme.llm.llm_grok_subscription.get_auth", return_value=auth),
+        patch(
+            "gptme.llm.llm_grok_subscription.requests.post", return_value=response
+        ) as mock_post,
+    ):
+        list(
+            llm_grok_subscription.stream(
+                [Message(role="user", content="hi")], "grok-4.5"
+            )
+        )
+    call_kwargs = mock_post.call_args.kwargs
+    assert call_kwargs["json"]["model"] == "grok-4.5"
+    assert call_kwargs["json"]["stream"] is True
+    assert call_kwargs["json"]["messages"][0]["role"] == "user"
+    assert call_kwargs["json"]["messages"][0]["content"] == "hi"
+    assert "Authorization" in call_kwargs["headers"]
+
+
+def test_stream_sends_max_tokens_when_provided():
+    auth = _make_auth()
+    response = _FakeSSEStreamResponse([])
+    with (
+        patch("gptme.llm.llm_grok_subscription.get_auth", return_value=auth),
+        patch(
+            "gptme.llm.llm_grok_subscription.requests.post", return_value=response
+        ) as mock_post,
+    ):
+        list(
+            llm_grok_subscription.stream(
+                [Message(role="user", content="hi")], "grok-4.5", max_tokens=512
+            )
+        )
+    assert mock_post.call_args.kwargs["json"]["max_tokens"] == 512
+
+
+def test_stream_omits_max_tokens_when_not_provided():
+    auth = _make_auth()
+    response = _FakeSSEStreamResponse([])
+    with (
+        patch("gptme.llm.llm_grok_subscription.get_auth", return_value=auth),
+        patch(
+            "gptme.llm.llm_grok_subscription.requests.post", return_value=response
+        ) as mock_post,
+    ):
+        list(
+            llm_grok_subscription.stream(
+                [Message(role="user", content="hi")], "grok-4.5"
+            )
+        )
+    assert "max_tokens" not in mock_post.call_args.kwargs["json"]
+
+
+# ── message conversion tests ───────────────────────────────────────────────────
+
+
+def test_messages_to_openai_basic():
+    """Basic role mapping is correct."""
+    msgs = [
+        Message(role="system", content="You are helpful."),
+        Message(role="user", content="Hi!"),
+        Message(role="assistant", content="Hello!"),
+    ]
+    result = llm_grok_subscription._messages_to_openai(msgs)
+    assert result[0]["role"] == "system"
+    assert result[1]["role"] == "user"
+    assert result[2]["role"] == "assistant"
+
+
+def test_messages_to_openai_tool_result_becomes_tool_role():
+    """System messages with call_id should become role:tool for the API."""
+    msgs = [
+        Message(role="user", content="Run save."),
+        Message(
+            role="assistant",
+            content='@save(call_1): {"path": "x.txt", "content": "hi"}',
+        ),
+        Message(role="system", content="Saved x.txt", call_id="call_1"),
+    ]
+    result = llm_grok_subscription._messages_to_openai(msgs)
+    tool_msgs = [m for m in result if m["role"] == "tool"]
+    assert len(tool_msgs) == 1
+    assert tool_msgs[0].get("tool_call_id") == "call_1"
+
+
+# ── credential store tests ─────────────────────────────────────────────────────
+
+
+def test_load_grok_tokens_from_valid_auth_file(tmp_path):
+    auth_file = tmp_path / ".grok" / "auth.json"
+    auth_file.parent.mkdir()
+    auth_file.write_text(json.dumps(_make_auth_json()))
+
+    with patch.object(
+        llm_grok_subscription, "_get_grok_auth_path", return_value=auth_file
+    ):
+        # Reset tracked key
+        llm_grok_subscription._credential_key = None
+        auth = _load_grok_tokens()
+
+    assert auth is not None
+    assert auth.access_token == "test-access-token"
+    assert auth.refresh_token == "test-refresh-token"
+    assert auth.expires_at > time.time()
+
+
+def test_load_grok_tokens_missing_file(tmp_path):
+    missing = tmp_path / ".grok" / "auth.json"
+    with patch.object(
+        llm_grok_subscription, "_get_grok_auth_path", return_value=missing
+    ):
+        assert _load_grok_tokens() is None
+
+
+def test_load_grok_tokens_prefers_known_client_id_entry(tmp_path):
+    """When multiple entries exist, prefer the one matching our client ID."""
+    known_key = "https://auth.x.ai/oauth2/token::b1a00492-073a-47ea-816f-4c329264a828"
+    other_key = "https://other.issuer/token::some-other-client"
+    data = {
+        other_key: {
+            "key": "other-token",
+            "refresh_token": None,
+            "expires_at": "2099-01-01T00:00:00+00:00",
+        },
+        known_key: {
+            "key": "correct-token",
+            "refresh_token": "correct-refresh",
+            "expires_at": "2099-01-01T00:00:00+00:00",
+        },
+    }
+    auth_file = tmp_path / "auth.json"
+    auth_file.write_text(json.dumps(data))
+
+    with patch.object(
+        llm_grok_subscription, "_get_grok_auth_path", return_value=auth_file
+    ):
+        llm_grok_subscription._credential_key = None
+        auth = _load_grok_tokens()
+
+    assert auth is not None
+    assert auth.access_token == "correct-token"
+    assert llm_grok_subscription._credential_key == known_key
+
+
+def test_write_grok_tokens_updates_correct_entry(tmp_path):
+    """_write_grok_tokens must update the same entry that _load_grok_tokens read."""
+    known_key = "https://auth.x.ai/oauth2/token::b1a00492-073a-47ea-816f-4c329264a828"
+    other_key = "https://other.issuer/token::other-client"
+    data = {
+        other_key: {"key": "old-other", "expires_at": "2099-01-01T00:00:00+00:00"},
+        known_key: {
+            "key": "old-correct",
+            "refresh_token": "old-refresh",
+            "expires_at": "2099-01-01T00:00:00+00:00",
+        },
+    }
+    auth_file = tmp_path / "auth.json"
+    auth_file.write_text(json.dumps(data))
+
+    with patch.object(
+        llm_grok_subscription, "_get_grok_auth_path", return_value=auth_file
+    ):
+        # Simulate a prior load that set _credential_key
+        llm_grok_subscription._credential_key = known_key
+
+        new_auth = GrokAuth(
+            access_token="new-token",
+            refresh_token="new-refresh",
+            expires_at=9_999_999_999.0,
+        )
+        _write_grok_tokens(new_auth)
+
+        written = json.loads(auth_file.read_text())
+
+    # The known entry should be updated
+    assert written[known_key]["key"] == "new-token"
+    assert written[known_key]["refresh_token"] == "new-refresh"
+    # The unrelated entry must be untouched
+    assert written[other_key]["key"] == "old-other"
+
+
+def test_write_grok_tokens_does_not_raise_on_error(tmp_path):
+    """_write_grok_tokens logs a warning rather than raising when write fails."""
+    # Point to a non-existent directory — write_text will raise OSError
+    auth_file = tmp_path / "nonexistent_dir" / "auth.json"
+
+    with patch.object(
+        llm_grok_subscription, "_get_grok_auth_path", return_value=auth_file
+    ):
+        # Should NOT raise; logs a warning internally
+        _write_grok_tokens(_make_auth())
+
+
+# ── get_auth tests ─────────────────────────────────────────────────────────────
+
+
+def test_get_auth_returns_cached_if_valid(tmp_path):
+    auth = _make_auth()
+    llm_grok_subscription._auth = auth
+    result = llm_grok_subscription.get_auth()
+    assert result is auth
+    llm_grok_subscription._auth = None  # cleanup
+
+
+def test_get_auth_raises_when_no_credentials(tmp_path):
+    missing = tmp_path / "auth.json"
+    llm_grok_subscription._auth = None
+    with (
+        patch.object(
+            llm_grok_subscription, "_get_grok_auth_path", return_value=missing
+        ),
+        pytest.raises(ValueError, match="not authenticated"),
+    ):
+        llm_grok_subscription.get_auth()


### PR DESCRIPTION
## Summary

- Adds a new `grok-subscription` provider that lets users with a SuperGrok subscription use grok models in gptme without a separate xAI Platform API key
- Reuses credentials stored by the [grok CLI](https://x.ai/grok) at `~/.grok/auth.json` — no new auth flow needed if the CLI is already authenticated
- Supports automatic token refresh via OIDC so sessions stay live without re-login
- Adds `gptme-auth grok-subscription` status command for credential health checks

## How it works

The grok CLI stores OIDC credentials at `~/.grok/auth.json`. The subscription bearer token includes the `api:access` scope, meaning xAI explicitly authorizes its use against their CLI proxy endpoint (`https://cli-chat-proxy.grok.com/v1`), which speaks standard OpenAI Chat Completions format.

```
grok auth login                          # one-time auth via grok CLI
gptme --model grok-subscription/grok-4.5 "hello"
```

## Files changed

- `gptme/llm/llm_grok_subscription.py` (new): provider module with auth loading, token refresh, streaming/non-streaming completion
- `gptme/llm/__init__.py`: wired init/chat/stream + `list_available_providers` detection
- `gptme/llm/models/types.py`: added `"grok-subscription"` to `BuiltinProvider`
- `gptme/llm/models/data.py`: added `grok-4.5` model entry (500k context, $0 marginal, reasoning+vision)
- `gptme/cli/auth.py`: added `gptme-auth grok-subscription` status command

## Test plan

- [x] Live API test: streaming `grok-subscription/grok-4.5` returned "SUBGROK-OK" correctly
- [x] `uv run mypy` passes on changed files (pre-existing errors in `cli/main.py` are unrelated)
- [x] `ruff check` and `ruff format` pass
- [x] All existing tests pass (`uv run pytest` — 215 tests)
- [ ] Verify `gptme-auth grok-subscription` reports correct status with fresh token
- [ ] Verify token refresh path works after token expires (requires waiting ~2h or mocking)

## Notes

- Requires grok CLI to be installed and authenticated (`grok auth login`)
- The `x-grok-client-version` header is mandatory — the proxy rejects requests without it (HTTP 426)
- Version is read dynamically from `~/.grok/version.json`, falling back to the hardcoded `0.2.93`
- For production/multi-user use, the xAI Platform API with a dedicated key is more appropriate; added a NOTICE in the module docstring