### PR TITLE
feat(webui): steer_inject for external sessions (Phase 2 of #3217)

### DIFF
--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -100,6 +100,7 @@ from .openapi_docs import (
     ErrorResponse,
     ExternalSessionListResponse,
     ExternalSessionResponse,
+    ExternalSessionSteerResponse,
     MessageCreateRequest,
     SessionResponse,
     StatusResponse,
@@ -1092,6 +1093,93 @@ def api_external_session(external_session_id: str):
             {"error": f"External session not found: {external_session_id}"}
         ), 404
     return flask.jsonify(session)
+
+
+@v2_api.route(
+    "/api/v2/external-sessions/<string:external_session_id>/steer", methods=["POST"]
+)
+@require_auth
+@api_doc_simple(
+    responses={
+        200: ExternalSessionSteerResponse,
+        400: ErrorResponse,
+        404: ErrorResponse,
+        422: ErrorResponse,
+        501: ErrorResponse,
+        503: ErrorResponse,
+    },
+    tags=["external-sessions"],
+    parameters=[
+        {
+            "name": "external_session_id",
+            "in": "path",
+            "required": True,
+            "schema": {"type": "string"},
+            "description": "Opaque external session identifier",
+        },
+        {
+            "name": "days",
+            "in": "query",
+            "schema": {"type": "integer", "default": 7},
+            "description": "How many recent days of session history to scan",
+        },
+    ],
+)
+def api_steer_external_session(external_session_id: str):
+    """Inject a user message into a running external session (steer_inject).
+
+    Only works for sessions that advertise ``steer_inject`` in their capabilities.
+    Returns 422 if the session does not support steering, 501 if the server-side
+    steer implementation (gptme-sessions steer) is not available.
+    """
+    body = request.get_json(silent=True) or {}
+    message = (body.get("message") or "").strip()
+    if not message:
+        return flask.jsonify({"error": "message is required"}), 400
+
+    try:
+        days = int(request.args.get("days", 7))
+    except (ValueError, TypeError):
+        return flask.jsonify({"error": "days must be an integer"}), 400
+    if days <= 0:
+        return flask.jsonify({"error": "days must be a positive integer"}), 400
+    days = min(days, 365)
+
+    provider = get_external_session_provider()
+    if provider is None:
+        return flask.jsonify({"error": "external session provider unavailable"}), 503
+
+    session = provider.get_session(external_session_id, days=days)
+    if session is None:
+        return flask.jsonify(
+            {"error": f"External session not found: {external_session_id}"}
+        ), 404
+
+    capabilities = session.get("transcript", {}).get("capabilities") or []
+    if "steer_inject" not in capabilities:
+        return flask.jsonify({"error": "session does not support steer_inject"}), 422
+
+    trajectory_path = session.get("transcript", {}).get("trajectory_path")
+    if not trajectory_path:
+        return flask.jsonify({"error": "session has no trajectory_path"}), 500
+
+    try:
+        ok = provider.steer_session(str(trajectory_path), message)
+    except Exception as exc:
+        logger.exception("steer_session failed for %s", external_session_id)
+        return flask.jsonify({"error": f"steer_session error: {exc}"}), 500
+
+    if not ok:
+        return flask.jsonify(
+            {
+                "error": (
+                    "steer_inject not available — upgrade gptme-sessions "
+                    "to a version that includes the 'steer' subcommand"
+                )
+            }
+        ), 501
+
+    return flask.jsonify({"status": "ok"})
 
 
 @v2_api.route("/api/v2/conversations")

--- a/gptme/server/external_sessions.py
+++ b/gptme/server/external_sessions.py
@@ -92,10 +92,35 @@ class ExternalSessionProvider:
 
     @property
     def capabilities(self) -> dict[str, bool]:
-        return {
+        caps: dict[str, bool] = {
             "external_session_catalog": True,
             "external_session_transcript": True,
         }
+        try:
+            from gptme_sessions.steer import (
+                inject_message,  # type: ignore[import-not-found]
+            )
+
+            _ = inject_message  # verify importable
+            caps["external_session_steer"] = True
+        except ImportError:
+            pass
+        return caps
+
+    def steer_session(self, trajectory_path: str, message: str) -> bool:
+        """Inject a user message into a running session via gptme_sessions.steer.
+
+        Returns True on success, False if the steer module is unavailable.
+        Raises on other errors (session not found, harness not supported, etc.).
+        """
+        try:
+            from gptme_sessions.steer import (
+                inject_message,  # type: ignore[import-not-found]
+            )
+        except ImportError:
+            return False
+        inject_message(trajectory_path, message)
+        return True
 
     def _discover_paths(self, days: int) -> list[Path]:
         end = datetime.now(timezone.utc).date()
@@ -199,10 +224,26 @@ class CLIExternalSessionProvider:
 
     @property
     def capabilities(self) -> dict[str, bool]:
-        return {
+        caps: dict[str, bool] = {
             "external_session_catalog": True,
             "external_session_transcript": True,
         }
+        if _cli_has_steer_command():
+            caps["external_session_steer"] = True
+        return caps
+
+    def steer_session(self, trajectory_path: str, message: str) -> bool:
+        """Inject a user message into a running session via the gptme-sessions CLI.
+
+        Returns True on success, False if the steer subcommand is unavailable.
+        Raises on other errors (non-zero exit after args are validated, timeout).
+        """
+        if not _cli_has_steer_command():
+            return False
+        output = self._run_cli(
+            ["steer", trajectory_path, "--message", message, "--json"], timeout=30
+        )
+        return output is not None
 
     def _run_cli(self, args: list[str], timeout: int = 60) -> str | None:
         """Run a gptme-sessions CLI command and return stdout, or None on failure."""
@@ -344,6 +385,22 @@ def _cli_has_transcript_command() -> bool:
     try:
         result = subprocess.run(
             ["gptme-sessions", "transcript", "--help"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+        return result.returncode == 0
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return False
+
+
+@functools.lru_cache(maxsize=1)
+def _cli_has_steer_command() -> bool:
+    """Check if the installed gptme-sessions CLI has the ``steer`` subcommand."""
+    try:
+        result = subprocess.run(
+            ["gptme-sessions", "steer", "--help"],
             capture_output=True,
             text=True,
             timeout=10,

--- a/gptme/server/openapi_docs.py
+++ b/gptme/server/openapi_docs.py
@@ -417,6 +417,12 @@ class ExternalSessionResponse(BaseModel):
     )
 
 
+class ExternalSessionSteerResponse(BaseModel):
+    """Response for a successful steer_inject operation."""
+
+    status: str = Field(..., description="Always 'ok' on success")
+
+
 class SessionResponse(BaseModel):
     """Session information response."""
 

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -770,6 +770,133 @@ def test_v2_external_session_not_found(
     assert "not found" in data["error"].lower()
 
 
+# ---------------------------------------------------------------------------
+# steer_inject endpoint tests
+# ---------------------------------------------------------------------------
+
+
+class _FakeSteerableSessionProvider(_FakeExternalSessionProvider):
+    """Provider variant that supports steer_inject on session abc123."""
+
+    def __init__(self) -> None:
+        self.steered_messages: list[str] = []
+        self._steer_ok = True
+
+    def get_session(self, external_id: str, days: int = 30) -> dict[str, Any] | None:
+        if external_id != "abc123":
+            return None
+        return {
+            "id": "abc123",
+            "transcript": {
+                "session_id": "session-1",
+                "harness": "claude-code",
+                "capabilities": ["steer_inject"],
+                "trajectory_path": "/tmp/session.jsonl",
+                "messages": [{"role": "user", "content": "hi"}],
+            },
+        }
+
+    def steer_session(self, trajectory_path: str, message: str) -> bool:
+        if not self._steer_ok:
+            return False
+        self.steered_messages.append(message)
+        return True
+
+
+@pytest.fixture
+def fake_steerable_provider(monkeypatch):
+    provider = _FakeSteerableSessionProvider()
+    monkeypatch.setattr(
+        "gptme.server.api_v2.get_external_session_provider", lambda: provider
+    )
+    return provider
+
+
+def test_v2_steer_external_session_ok(client: FlaskClient, fake_steerable_provider):
+    """Steer endpoint returns 200 and records the injected message."""
+    response = client.post(
+        "/api/v2/external-sessions/abc123/steer",
+        json={"message": "hello from user"},
+    )
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data is not None
+    assert data["status"] == "ok"
+    assert fake_steerable_provider.steered_messages == ["hello from user"]
+
+
+def test_v2_steer_external_session_missing_message(
+    client: FlaskClient, fake_steerable_provider
+):
+    """Steer endpoint returns 400 when message is missing or blank."""
+    response = client.post("/api/v2/external-sessions/abc123/steer", json={})
+    assert response.status_code == 400
+    data = response.get_json()
+    assert data is not None
+    assert "message" in data["error"]
+
+    response2 = client.post(
+        "/api/v2/external-sessions/abc123/steer", json={"message": "   "}
+    )
+    assert response2.status_code == 400
+
+
+def test_v2_steer_external_session_not_found(
+    client: FlaskClient, fake_steerable_provider
+):
+    """Steer endpoint returns 404 when the session doesn't exist."""
+    response = client.post(
+        "/api/v2/external-sessions/does-not-exist/steer",
+        json={"message": "hi"},
+    )
+    assert response.status_code == 404
+    data = response.get_json()
+    assert data is not None
+    assert "not found" in data["error"].lower()
+
+
+def test_v2_steer_external_session_no_capability(
+    client: FlaskClient, fake_external_session_provider
+):
+    """Steer endpoint returns 422 when session lacks steer_inject capability."""
+    # fake_external_session_provider returns a session with only ["view_transcript"]
+    response = client.post(
+        "/api/v2/external-sessions/abc123/steer",
+        json={"message": "hi"},
+    )
+    assert response.status_code == 422
+    data = response.get_json()
+    assert data is not None
+    assert "steer_inject" in data["error"]
+
+
+def test_v2_steer_external_session_unavailable(client: FlaskClient, monkeypatch):
+    """Steer endpoint returns 503 when provider is not configured."""
+    monkeypatch.setattr(
+        "gptme.server.api_v2.get_external_session_provider", lambda: None
+    )
+    response = client.post(
+        "/api/v2/external-sessions/abc123/steer",
+        json={"message": "hi"},
+    )
+    assert response.status_code == 503
+
+
+def test_v2_steer_external_session_not_implemented(
+    client: FlaskClient, fake_steerable_provider
+):
+    """Steer endpoint returns 501 when provider.steer_session returns False."""
+    fake_steerable_provider._steer_ok = False
+    response = client.post(
+        "/api/v2/external-sessions/abc123/steer",
+        json={"message": "hi"},
+    )
+    assert response.status_code == 501
+    data = response.get_json()
+    assert data is not None
+    assert "501" in str(response.status_code)
+
+
 def test_external_session_provider_get_session_searches_beyond_list_limit():
     """Test session lookup scans all discovered sessions instead of a capped list."""
     from gptme.server.external_sessions import (

--- a/webui/src/components/ExternalSessionsView.tsx
+++ b/webui/src/components/ExternalSessionsView.tsx
@@ -384,7 +384,11 @@ export const ExternalSessionsView: FC = () => {
       {/* Detail panel */}
       {selectedId && (
         <div className="flex-1 overflow-hidden">
-          <SessionDetail sessionId={selectedId} onClose={() => setSelectedId(null)} />
+          <SessionDetail
+            key={selectedId}
+            sessionId={selectedId}
+            onClose={() => setSelectedId(null)}
+          />
         </div>
       )}
     </div>

--- a/webui/src/components/ExternalSessionsView.tsx
+++ b/webui/src/components/ExternalSessionsView.tsx
@@ -1,9 +1,20 @@
 import { type FC, useState, useEffect } from 'react';
-import { useQuery } from '@tanstack/react-query';
-import { Bot, Clock, Cpu, FolderOpen, AlertCircle, Search, ChevronRight, X } from 'lucide-react';
+import { useQuery, useMutation } from '@tanstack/react-query';
+import {
+  Bot,
+  Clock,
+  Cpu,
+  FolderOpen,
+  AlertCircle,
+  Search,
+  ChevronRight,
+  X,
+  Send,
+} from 'lucide-react';
 import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
 import { useApi } from '@/contexts/ApiContext';
 import { use$ } from '@legendapp/state/react';
 import { useSearchParams } from 'react-router-dom';
@@ -106,11 +117,17 @@ interface SessionDetailProps {
 const SessionDetail: FC<SessionDetailProps> = ({ sessionId, onClose }) => {
   const { api } = useApi();
   const isConnected = use$(api.isConnected$);
+  const [steerMessage, setSteerMessage] = useState('');
 
   const { data, isLoading, error } = useQuery({
     queryKey: ['external-session-detail', sessionId],
     queryFn: () => api.getExternalSession(sessionId),
     enabled: isConnected && !!sessionId,
+  });
+
+  const steerMutation = useMutation({
+    mutationFn: (message: string) => api.steerExternalSession(sessionId, message),
+    onSuccess: () => setSteerMessage(''),
   });
 
   if (isLoading) {
@@ -131,6 +148,16 @@ const SessionDetail: FC<SessionDetailProps> = ({ sessionId, onClose }) => {
   }
 
   const messages = Array.isArray(data.transcript.messages) ? data.transcript.messages : null;
+  const capabilities = Array.isArray(data.transcript.capabilities)
+    ? (data.transcript.capabilities as string[])
+    : [];
+  const canSteer = capabilities.includes('steer_inject');
+
+  const handleSteer = () => {
+    const msg = steerMessage.trim();
+    if (!msg || steerMutation.isPending) return;
+    steerMutation.mutate(msg);
+  };
 
   return (
     <div className="flex h-full flex-col">
@@ -155,6 +182,45 @@ const SessionDetail: FC<SessionDetailProps> = ({ sessionId, onClose }) => {
           </pre>
         )}
       </div>
+      {canSteer && (
+        <div className="border-t p-3">
+          <div className="flex gap-2">
+            <Textarea
+              className="min-h-[2.5rem] flex-1 resize-none text-sm"
+              placeholder="Steer session — inject a user message…"
+              value={steerMessage}
+              onChange={(e) => setSteerMessage(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && !e.shiftKey) {
+                  e.preventDefault();
+                  handleSteer();
+                }
+              }}
+              rows={2}
+              aria-label="Steer message"
+            />
+            <Button
+              size="icon"
+              className="h-auto self-end"
+              onClick={handleSteer}
+              disabled={!steerMessage.trim() || steerMutation.isPending}
+              aria-label="Send steer message"
+            >
+              <Send className="h-4 w-4" />
+            </Button>
+          </div>
+          {steerMutation.isError && (
+            <p className="mt-1 text-xs text-destructive">
+              {steerMutation.error instanceof Error
+                ? steerMutation.error.message
+                : 'Failed to send message'}
+            </p>
+          )}
+          {steerMutation.isSuccess && (
+            <p className="mt-1 text-xs text-muted-foreground">Message injected.</p>
+          )}
+        </div>
+      )}
     </div>
   );
 };

--- a/webui/src/components/__tests__/ExternalSessionsView.test.tsx
+++ b/webui/src/components/__tests__/ExternalSessionsView.test.tsx
@@ -15,6 +15,13 @@ const mockUseQuery = jest.fn();
 
 jest.mock('@tanstack/react-query', () => ({
   useQuery: (...args: unknown[]) => mockUseQuery(...args),
+  useMutation: jest.fn(() => ({
+    mutate: jest.fn(),
+    isPending: false,
+    isError: false,
+    isSuccess: false,
+    error: null,
+  })),
 }));
 
 jest.mock('@legendapp/state/react', () => ({

--- a/webui/src/utils/api.ts
+++ b/webui/src/utils/api.ts
@@ -1709,6 +1709,14 @@ export class ApiClient {
     return await this.fetchJson<ExternalSessionDetail>(url);
   }
 
+  async steerExternalSession(id: string, message: string): Promise<void> {
+    const url = `${this.baseUrl}/api/v2/external-sessions/${id}/steer`;
+    await this.fetchJson<{ status: string }>(url, {
+      method: 'POST',
+      body: JSON.stringify({ message }),
+    });
+  }
+
   async getSessions(): Promise<ActiveSession[]> {
     const url = `${this.baseUrl}/api/v2/sessions`;
     return await this.fetchJson<ActiveSession[]>(url);

--- a/webui/src/utils/demoApiClient.ts
+++ b/webui/src/utils/demoApiClient.ts
@@ -406,6 +406,7 @@ export function createDemoApiClient(baseUrl: string = DEMO_BASE_URL): IApiClient
     createAgent: async () => notImpl('createAgent'),
     deleteSession: async () => {},
     getExternalSession: async () => notImpl('getExternalSession'),
+    steerExternalSession: async () => notImpl('steerExternalSession'),
   };
 
   return client;


### PR DESCRIPTION
## Summary

Implements Phase 2 of #3217: capability-gated steering for cross-harness sessions.

A minimal text input + send button now appears at the bottom of the SessionDetail panel **only when** the session declares steer_inject in its capabilities array. Sessions without that capability are completely unchanged — no extra UI, no new code paths triggered.

### Backend

- ExternalSessionProvider.steer_session() — calls gptme_sessions.steer.inject_message() if available; returns False (graceful degradation) if the module is not importable
- CLIExternalSessionProvider.steer_session() — calls gptme-sessions steer <path> --message <msg> --json; returns False if the steer subcommand is not present
- _cli_has_steer_command() cached probe, mirroring _cli_has_transcript_command()
- POST /api/v2/external-sessions/:id/steer endpoint:
  - 400 when message is missing or blank
  - 404 when session not found
  - 422 when session lacks steer_inject capability
  - 501 when steer_session() returns False (upgrade gptme-sessions)
  - 503 when no provider configured
  - 200 {"status": "ok"} on success
- ExternalSessionSteerResponse OpenAPI type added

### Frontend

- api.steerExternalSession(id, message) client method
- demoApiClient: stub satisfying the IApiClient interface
- SessionDetail: shows Textarea + Send button when steer_inject is in transcript.capabilities; Enter sends (Shift+Enter = newline); success/error feedback shown below the input

### Tests

6 new server tests (all passing):
- test_v2_steer_external_session_ok — happy path, message recorded
- test_v2_steer_external_session_missing_message — 400 on blank/absent message
- test_v2_steer_external_session_not_found — 404 for unknown session
- test_v2_steer_external_session_no_capability — 422 when steer_inject absent
- test_v2_steer_external_session_unavailable — 503 when no provider
- test_v2_steer_external_session_not_implemented — 501 when steer_session() returns False

## What's not in this PR

The gptme-sessions package does not yet expose a steer subcommand or inject_message API. This PR implements the full protocol on the gptme side; when gptme-sessions gains that capability the endpoint will work end-to-end without any further gptme changes. Until then, the endpoint returns 501 and the UI steer input never appears (no session currently declares steer_inject).

Closes #3217