### PR TITLE
fix(models): update stale OpenRouter model IDs

### DIFF
--- a/gptme/eval/main.py
+++ b/gptme/eval/main.py
@@ -659,7 +659,7 @@ def main(
         default_models.extend(
             [
                 "openrouter/meta-llama/llama-3.1-70b-instruct@xml",
-                # "openrouter/meta-llama/llama-3.1-405b-instruct",
+                # "openrouter/meta-llama/llama-3.3-70b-instruct",
             ]
         )
     if config.get_env("GEMINI_API_KEY"):

--- a/gptme/llm/__init__.py
+++ b/gptme/llm/__init__.py
@@ -90,7 +90,7 @@ def _drain_toolbreak_stream(stream: "_StreamWithMetadata") -> None:
 PROVIDER_DEFAULT_MODELS: dict[str, str] = {
     "anthropic": "anthropic/claude-haiku-4-5",
     "openai": "openai/gpt-4o-mini",
-    "openrouter": "openrouter/anthropic/claude-haiku-4-5",
+    "openrouter": "openrouter/anthropic/claude-haiku-4.5",
     "requesty": "requesty/openai/gpt-4o-mini",
     "gemini": "gemini/gemini-2.0-flash",
     "groq": "groq/llama-3.3-70b-versatile",


### PR DESCRIPTION
## Summary

Fixes the `Check OpenRouter model IDs` CI job failing on master.

Two stale model IDs detected by `scripts/check_model_freshness.py`:

- `openrouter/anthropic/claude-haiku-4-5` → `openrouter/anthropic/claude-haiku-4.5` (OpenRouter uses dot notation, not dashes)
- Commented-out `meta-llama/llama-3.1-405b-instruct` → `meta-llama/llama-3.3-70b-instruct` (405b no longer available on OpenRouter)

## Test plan

- [ ] CI `Check OpenRouter model IDs` job passes