### PR TITLE
feat(subagent): mid-turn steer injection via STEP_PRE checkpoint

### DIFF
--- a/gptme/prompt_queue.py
+++ b/gptme/prompt_queue.py
@@ -104,7 +104,8 @@ def drain_prompt_queue(logdir: Path, max_items: int | None = None) -> list[Messa
 
             # Steer-flagged records are reserved for mid-turn draining via the
             # STEP_PRE checkpoint hook (drain_steer_prompts).  Leave them on disk.
-            if record.get("steer"):
+            # Use `is True` to guard against non-boolean truthy values (e.g. "false").
+            if record.get("steer") is True:
                 remaining.append(line)
                 continue
 
@@ -153,7 +154,7 @@ def drain_steer_prompts(logdir: Path) -> list[Message]:
                 remaining.append(line)
                 continue
 
-            if record.get("steer"):
+            if record.get("steer") is True:
                 content = str(record.get("content", "")).strip()
                 if content:
                     steer_msgs.append(Message("user", content, quiet=True))

--- a/gptme/prompt_queue.py
+++ b/gptme/prompt_queue.py
@@ -50,13 +50,22 @@ def _prompt_queue_lock(logdir: Path):
                 fcntl.flock(fd, fcntl.LOCK_UN)
 
 
-def queue_prompt(logdir: Path, content: str) -> None:
-    """Append a prompt to a conversation queue."""
+def queue_prompt(logdir: Path, content: str, *, steer: bool = False) -> None:
+    """Append a prompt to a conversation queue.
+
+    Args:
+        steer: Mark as a steering message for mid-turn injection via the STEP_PRE
+            hook.  Regular (non-steer) prompts are drained between turns; steer
+            prompts are drained at each STEP_PRE checkpoint so the next LLM call
+            in the same turn sees them immediately.
+    """
     queue_path = get_prompt_queue_path(logdir)
-    record = {
+    record: dict = {
         "content": content,
         "queued_at": datetime.now(timezone.utc).isoformat(),
     }
+    if steer:
+        record["steer"] = True
 
     with _prompt_queue_lock(logdir), queue_path.open("a", encoding="utf-8") as f:
         f.write(json.dumps(record) + "\n")
@@ -93,6 +102,12 @@ def drain_prompt_queue(logdir: Path, max_items: int | None = None) -> list[Messa
                 logger.warning("Skipping malformed queued prompt in %s", queue_path)
                 continue
 
+            # Steer-flagged records are reserved for mid-turn draining via the
+            # STEP_PRE checkpoint hook (drain_steer_prompts).  Leave them on disk.
+            if record.get("steer"):
+                remaining.append(line)
+                continue
+
             content = str(record.get("content", "")).strip()
             if not content:
                 logger.warning("Skipping empty queued prompt in %s", queue_path)
@@ -106,3 +121,48 @@ def drain_prompt_queue(logdir: Path, max_items: int | None = None) -> list[Messa
             queue_path.unlink(missing_ok=True)
 
         return drained
+
+
+def drain_steer_prompts(logdir: Path) -> list[Message]:
+    """Drain only steer-flagged prompts from the queue (mid-turn injection).
+
+    Regular (non-steer) prompts remain on disk for between-turn draining by
+    ``drain_prompt_queue``.  Steer prompts written by ``subagent_steer()`` are
+    picked up here at each STEP_PRE checkpoint so the next LLM generation in
+    the same agentic turn sees the orchestrator's guidance immediately.
+    """
+    queue_path = get_prompt_queue_path(logdir)
+    if not queue_path.exists():
+        return []
+
+    with _prompt_queue_lock(logdir):
+        if not queue_path.exists():
+            return []
+
+        lines = queue_path.read_text(encoding="utf-8").splitlines()
+        steer_msgs: list[Message] = []
+        remaining: list[str] = []
+
+        for line in lines:
+            if not line.strip():
+                continue
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                logger.warning("Skipping malformed queued prompt in %s", queue_path)
+                remaining.append(line)
+                continue
+
+            if record.get("steer"):
+                content = str(record.get("content", "")).strip()
+                if content:
+                    steer_msgs.append(Message("user", content, quiet=True))
+            else:
+                remaining.append(line)
+
+        if remaining:
+            queue_path.write_text("\n".join(remaining) + "\n", encoding="utf-8")
+        else:
+            queue_path.unlink(missing_ok=True)
+
+        return steer_msgs

--- a/gptme/tools/subagent/api.py
+++ b/gptme/tools/subagent/api.py
@@ -1141,10 +1141,12 @@ def subagent_cancel(agent_id: str) -> str:
 def subagent_steer(agent_id: str, message: str) -> str:
     """Inject a steering message into a running subagent's conversation.
 
-    The message is queued via the subagent's logdir prompt-queue and picked up
-    on the subagent's next chat loop iteration, allowing the orchestrator to
-    redirect, clarify, or course-correct a subagent mid-run without restarting
-    it. Works for thread-mode and subprocess-mode subagents.
+    The message is queued via the subagent's logdir prompt-queue with a
+    steer flag.  The subagent's STEP_PRE checkpoint hook drains steer-flagged
+    messages at each step boundary so the very next LLM call in the same
+    agentic turn sees the guidance immediately — no need to wait for the
+    current tool chain to finish.  Works for thread-mode and subprocess-mode
+    subagents.
 
     This is distinct from ``subagent_reply()``, which re-spawns a subagent that
     has *already stopped* with a ``clarification_needed`` status. Use this
@@ -1250,7 +1252,7 @@ def subagent_steer(agent_id: str, message: str) -> str:
             "For clarification_needed subagents, use subagent_reply() to re-spawn them."
         )
 
-    queue_prompt(sa.logdir, message)
+    queue_prompt(sa.logdir, message, steer=True)
 
     # Re-check after queuing: catches the race where the subagent exits between
     # the initial check and the queue write.
@@ -1269,7 +1271,8 @@ def subagent_steer(agent_id: str, message: str) -> str:
     logger.info(f"Steering message queued for subagent '{agent_id}': {message[:80]!r}")
     return (
         f"Steering message queued for subagent '{agent_id}'. "
-        "It will be injected into the subagent's conversation on its next loop iteration."
+        "It will be injected at the subagent's next STEP_PRE checkpoint "
+        "(before the next LLM call in the current agentic turn)."
     )
 
 

--- a/gptme/tools/subagent/api.py
+++ b/gptme/tools/subagent/api.py
@@ -812,6 +812,23 @@ def subagent(
                 # even during the narrow window between process exit and result
                 # caching.
                 sa.prompt_queue_closed.set()
+                # Drain any steer messages that arrived after the last STEP_PRE fired
+                # but before the subprocess exited. They were not deliverable mid-turn;
+                # warn so the orchestrator knows the guidance was not seen.
+                try:
+                    from ...prompt_queue import drain_steer_prompts  # fmt: skip
+
+                    stranded = drain_steer_prompts(sa.logdir)
+                    if stranded:
+                        logger.warning(
+                            "Subagent '%s' exited with %d stranded steer message(s) "
+                            "never delivered (arrived after final STEP_PRE checkpoint): %s",
+                            agent_id,
+                            len(stranded),
+                            [m.content[:60] for m in stranded],
+                        )
+                except Exception:
+                    pass
                 _sem.release()
 
         launcher = threading.Thread(target=_launch_subprocess, daemon=True)

--- a/gptme/tools/subagent/execution.py
+++ b/gptme/tools/subagent/execution.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING, Literal
 
 from ...llm.retry_abort import bind_thread_generation, release_thread
 from ...message import Message
+from ...prompt_queue import drain_steer_prompts
 from .. import clear_tools, get_tools, load_tool, set_tools
 from .._allowlist import (
     is_hint_pattern,
@@ -438,6 +439,20 @@ def _create_subagent_thread(
         # sub-microsecond race that requires modifying chat() itself to close.
         if prompt_queue_closed is not None:
             prompt_queue_closed.set()
+        # Drain any steer messages that arrived after the last STEP_PRE fired but
+        # before chat() returned. These were not deliverable mid-turn; warn so
+        # the orchestrator knows the guidance was not seen.
+        try:
+            stranded = drain_steer_prompts(logdir)
+            if stranded:
+                logger.warning(
+                    "Subagent exited with %d stranded steer message(s) never "
+                    "delivered (arrived after final STEP_PRE checkpoint): %s",
+                    len(stranded),
+                    [m.content[:60] for m in stranded],
+                )
+        except Exception:
+            pass
 
 
 def _run_subagent_subprocess(

--- a/gptme/tools/subagent/hooks.py
+++ b/gptme/tools/subagent/hooks.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING
 
 from ...hooks.types import StopPropagation
 from ...message import Message
+from ...prompt_queue import QUEUE_FILENAME, drain_steer_prompts
 from .control import CONTROL_FILENAME, drain_control_ops
 from .types import (
     ReturnType,
@@ -36,21 +37,34 @@ logger = logging.getLogger(__name__)
 
 
 def _subagent_control_hook(manager: "LogManager") -> Generator[Message, None, None]:
-    """Stop a child conversation when its parent writes a cancel operation."""
+    """Apply cancel and steer operations at each STEP_PRE boundary.
+
+    Cancel: reads ``logdir/control.jsonl`` for a ``{"op": "cancel"}`` record
+    written by ``subagent_cancel()``.  On cancel, appends a note, marks the
+    result as *cancelled* (first-writer-wins), and raises
+    ``SessionCompleteException`` so ``chat()`` exits cleanly.
+
+    Steer: drains steer-flagged messages from the prompt queue (written by
+    ``subagent_steer()`` with ``steer=True``) and yields them as user messages
+    so the very next LLM call in the same turn sees the orchestrator's guidance
+    without waiting for the current agentic turn to finish.
+
+    Fast paths (one ``stat()`` per step each) keep overhead negligible for
+    normal conversations that have neither a control file nor a steer queue.
+    """
     # Search by logdir, not logdir.name: thread subagent logdirs have a random suffix
     # (subagent-{agent_id}-{suffix}), so logdir.name != agent_id for thread mode.
     with _subagents_lock:
         sa = next((s for s in _subagents if s.logdir == manager.logdir), None)
     agent_id = sa.agent_id if sa is not None else manager.logdir.name
 
-    # Check in-memory fallback first: set by subagent_cancel() when the control-file
-    # write fails with OSError, so the thread is still stopped at its next checkpoint.
+    # ── Cancel check ─────────────────────────────────────────────────────────
+    # Check in-memory fallback first: set by subagent_cancel() when the
+    # control-file write fails with OSError.
     in_memory_cancel = sa is not None and sa.cancel_event.is_set()
 
-    if not in_memory_cancel:
-        if not (manager.logdir / CONTROL_FILENAME).exists():
-            return
-
+    has_cancel = in_memory_cancel
+    if not in_memory_cancel and (manager.logdir / CONTROL_FILENAME).exists():
         try:
             operations = drain_control_ops(manager.logdir)
         except OSError:
@@ -61,28 +75,41 @@ def _subagent_control_hook(manager: "LogManager") -> Generator[Message, None, No
                 manager.logdir,
             )
             operations = [{"op": "cancel", "agent_id": agent_id}]
-        if not any(operation.get("op") == "cancel" for operation in operations):
-            return
 
-        for operation in operations:
-            candidate_agent_id = operation.get("agent_id")
-            if operation.get("op") == "cancel" and isinstance(candidate_agent_id, str):
-                agent_id = candidate_agent_id
-                break
+        if any(operation.get("op") == "cancel" for operation in operations):
+            has_cancel = True
+            for operation in operations:
+                candidate_agent_id = operation.get("agent_id")
+                if operation.get("op") == "cancel" and isinstance(
+                    candidate_agent_id, str
+                ):
+                    agent_id = candidate_agent_id
+                    break
 
-    manager.append(
-        Message(
-            "system",
-            "Subagent cancellation requested by orchestrator; ending at this step boundary.",
+    if has_cancel:
+        manager.append(
+            Message(
+                "system",
+                "Subagent cancellation requested by orchestrator; ending at this step boundary.",
+            )
         )
-    )
-    set_subagent_result_if_absent(
-        agent_id, ReturnType("cancelled", "Cancelled by orchestrator")
-    )
-    from ..complete import SessionCompleteException
+        set_subagent_result_if_absent(
+            agent_id, ReturnType("cancelled", "Cancelled by orchestrator")
+        )
+        from ..complete import SessionCompleteException
 
-    raise SessionCompleteException("Subagent cancelled by orchestrator")
-    yield from ()
+        raise SessionCompleteException("Subagent cancelled by orchestrator")
+
+    # ── Steer check ───────────────────────────────────────────────────────────
+    # Drain steer-flagged messages mid-turn so the next LLM step sees them
+    # immediately, without waiting for the agentic turn to finish naturally.
+    # Regular (non-steer) queued prompts remain on disk for between-turn draining.
+    if (manager.logdir / QUEUE_FILENAME).exists():
+        for msg in drain_steer_prompts(manager.logdir):
+            logger.debug(
+                "Mid-turn steer injection for %s: %r", agent_id, msg.content[:80]
+            )
+            yield msg
 
 
 # Python built-in types that are valid as values in a {field_name: python_type} mapping.

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -6036,8 +6036,8 @@ class TestSubagentSteer:
             subagent_steer("acp-agent", "steer me")
 
     def test_steer_writes_to_prompt_queue(self, tmp_path):
-        """subagent_steer queues the message via the file-based prompt queue."""
-        from gptme.prompt_queue import drain_prompt_queue
+        """subagent_steer queues the message as a steer-flagged record."""
+        from gptme.prompt_queue import drain_prompt_queue, drain_steer_prompts
 
         logdir = tmp_path / "subagent-steer-test"
         logdir.mkdir()
@@ -6047,14 +6047,18 @@ class TestSubagentSteer:
 
         assert "queued" in result.lower()
 
-        # Verify the message was written to the prompt queue file
-        drained = drain_prompt_queue(logdir)
+        # Steer messages are steer-flagged and NOT visible to drain_prompt_queue
+        # (which drains between-turn prompts).
+        assert drain_prompt_queue(logdir) == []
+
+        # drain_steer_prompts sees them for mid-turn injection.
+        drained = drain_steer_prompts(logdir)
         assert len(drained) == 1
         assert "Focus on async frameworks only" in drained[0].content
 
     def test_steer_multiple_messages_queued_in_order(self, tmp_path):
         """Multiple steer calls append messages in FIFO order."""
-        from gptme.prompt_queue import drain_prompt_queue
+        from gptme.prompt_queue import drain_steer_prompts
 
         logdir = tmp_path / "subagent-steer-fifo"
         logdir.mkdir()
@@ -6064,7 +6068,7 @@ class TestSubagentSteer:
         subagent_steer("running-agent", "Second instruction")
         subagent_steer("running-agent", "Third instruction")
 
-        drained = drain_prompt_queue(logdir)
+        drained = drain_steer_prompts(logdir)
         assert len(drained) == 3
         assert "First instruction" in drained[0].content
         assert "Second instruction" in drained[1].content
@@ -6072,7 +6076,7 @@ class TestSubagentSteer:
 
     def test_steer_subprocess_mode_uses_logdir(self, tmp_path):
         """subagent_steer works for subprocess-mode subagents via the same logdir channel."""
-        from gptme.prompt_queue import drain_prompt_queue
+        from gptme.prompt_queue import drain_steer_prompts
 
         logdir = tmp_path / "subagent-subprocess-steer"
         logdir.mkdir()
@@ -6095,7 +6099,7 @@ class TestSubagentSteer:
         result = subagent_steer("proc-agent", "Change focus to security issues")
 
         assert "queued" in result.lower()
-        drained = drain_prompt_queue(logdir)
+        drained = drain_steer_prompts(logdir)
         assert len(drained) == 1
         assert "Change focus to security issues" in drained[0].content
 
@@ -6378,3 +6382,170 @@ class TestSubagentSteer:
 
         with pytest.raises(ValueError, match="closed its prompt queue"):
             subagent_steer("current-sentinel-agent", "too late")
+
+
+# ---------------------------------------------------------------------------
+# Mid-turn steer injection via _subagent_control_hook (STEP_PRE)
+# ---------------------------------------------------------------------------
+
+
+class TestMidTurnSteerInjection:
+    """Tests for mid-turn steer message injection via _subagent_control_hook."""
+
+    def setup_method(self):
+        with _subagents_lock:
+            _subagents.clear()
+        with _subagent_results_lock:
+            _subagent_results.clear()
+
+    def _make_manager(self, logdir):
+        m = MagicMock()
+        m.logdir = logdir
+        return m
+
+    def test_steer_flag_marks_record(self, tmp_path):
+        """queue_prompt(steer=True) adds steer=true to the JSON record."""
+        import json
+
+        from gptme.prompt_queue import QUEUE_FILENAME, queue_prompt
+
+        logdir = tmp_path / "steer-flag-mark"
+        logdir.mkdir()
+        queue_prompt(logdir, "redirect", steer=True)
+
+        lines = (logdir / QUEUE_FILENAME).read_text().splitlines()
+        record = json.loads(lines[0])
+        assert record["steer"] is True
+        assert record["content"] == "redirect"
+
+    def test_regular_prompt_has_no_steer_flag(self, tmp_path):
+        """queue_prompt() without steer= does not write a steer field."""
+        import json
+
+        from gptme.prompt_queue import QUEUE_FILENAME, queue_prompt
+
+        logdir = tmp_path / "no-steer-flag"
+        logdir.mkdir()
+        queue_prompt(logdir, "regular message")
+
+        lines = (logdir / QUEUE_FILENAME).read_text().splitlines()
+        record = json.loads(lines[0])
+        assert "steer" not in record
+
+    def test_drain_steer_prompts_leaves_regular_messages(self, tmp_path):
+        """drain_steer_prompts leaves non-steer records for drain_prompt_queue."""
+        from gptme.prompt_queue import (
+            drain_prompt_queue,
+            drain_steer_prompts,
+            queue_prompt,
+        )
+
+        logdir = tmp_path / "steer-leaves-regular"
+        logdir.mkdir()
+        queue_prompt(logdir, "regular turn", steer=False)
+        queue_prompt(logdir, "steer guidance", steer=True)
+
+        steer_msgs = drain_steer_prompts(logdir)
+        assert len(steer_msgs) == 1
+        assert "steer guidance" in steer_msgs[0].content
+
+        regular_msgs = drain_prompt_queue(logdir)
+        assert len(regular_msgs) == 1
+        assert "regular turn" in regular_msgs[0].content
+
+    def test_drain_prompt_queue_leaves_steer_messages(self, tmp_path):
+        """drain_prompt_queue leaves steer-flagged records for mid-turn draining."""
+        from gptme.prompt_queue import (
+            drain_prompt_queue,
+            drain_steer_prompts,
+            queue_prompt,
+        )
+
+        logdir = tmp_path / "regular-leaves-steer"
+        logdir.mkdir()
+        queue_prompt(logdir, "steer guidance", steer=True)
+        queue_prompt(logdir, "regular turn", steer=False)
+
+        # drain_prompt_queue must skip steer records
+        regular_msgs = drain_prompt_queue(logdir)
+        assert len(regular_msgs) == 1
+        assert "regular turn" in regular_msgs[0].content
+
+        # steer record is still on disk
+        steer_msgs = drain_steer_prompts(logdir)
+        assert len(steer_msgs) == 1
+        assert "steer guidance" in steer_msgs[0].content
+
+    def test_control_hook_injects_steer_as_user_message(self, tmp_path):
+        """_subagent_control_hook yields steer messages as user messages mid-turn."""
+        from gptme.prompt_queue import queue_prompt
+
+        logdir = tmp_path / "hook-steer-inject"
+        logdir.mkdir()
+        queue_prompt(logdir, "Focus only on async frameworks", steer=True)
+
+        manager = self._make_manager(logdir)
+        msgs = list(_subagent_control_hook(manager))
+
+        assert len(msgs) == 1
+        assert msgs[0].role == "user"
+        assert "Focus only on async frameworks" in msgs[0].content
+
+    def test_control_hook_injects_multiple_steer_messages_in_order(self, tmp_path):
+        """Multiple steer messages are injected in FIFO order."""
+        from gptme.prompt_queue import queue_prompt
+
+        logdir = tmp_path / "hook-steer-fifo"
+        logdir.mkdir()
+        queue_prompt(logdir, "First guidance", steer=True)
+        queue_prompt(logdir, "Second guidance", steer=True)
+
+        manager = self._make_manager(logdir)
+        msgs = list(_subagent_control_hook(manager))
+
+        assert len(msgs) == 2
+        assert "First guidance" in msgs[0].content
+        assert "Second guidance" in msgs[1].content
+
+    def test_control_hook_noop_when_no_steer_and_no_cancel(self, tmp_path):
+        """Hook is inert when there is no control file and no steer queue."""
+        logdir = tmp_path / "hook-noop"
+        logdir.mkdir()
+
+        manager = self._make_manager(logdir)
+        msgs = list(_subagent_control_hook(manager))
+        assert msgs == []
+
+    def test_control_hook_cancel_wins_over_pending_steer(self, tmp_path):
+        """When there is both a cancel op and a steer message, cancel takes priority."""
+        from gptme.prompt_queue import drain_steer_prompts, queue_prompt
+        from gptme.tools.subagent.control import append_control_op
+
+        logdir = tmp_path / "hook-cancel-over-steer"
+        logdir.mkdir()
+        queue_prompt(logdir, "Do this instead", steer=True)
+        append_control_op(logdir, "cancel", agent_id="test-agent")
+
+        manager = self._make_manager(logdir)
+
+        with pytest.raises(SessionCompleteException):
+            list(_subagent_control_hook(manager))
+
+        # Steer message was not consumed — still on disk after cancel
+        # (no point injecting guidance when the agent is stopping)
+        steer_msgs = drain_steer_prompts(logdir)
+        assert len(steer_msgs) == 1
+
+    def test_control_hook_regular_prompt_not_injected_mid_turn(self, tmp_path):
+        """Regular (non-steer) queued prompts are NOT injected mid-turn by the hook."""
+        from gptme.prompt_queue import queue_prompt
+
+        logdir = tmp_path / "hook-no-regular-inject"
+        logdir.mkdir()
+        queue_prompt(logdir, "Between-turn prompt", steer=False)
+
+        manager = self._make_manager(logdir)
+        msgs = list(_subagent_control_hook(manager))
+
+        # Hook must not consume non-steer messages
+        assert msgs == []


### PR DESCRIPTION
## Summary

Implements the missing slice 2 of the orchestrator control plane (issue #3191): `subagent_steer()` now delivers steering messages **mid-turn** via the STEP_PRE checkpoint hook, so the next LLM call in the same agentic turn sees the orchestrator's guidance immediately — no waiting for the current tool chain to finish.

Previously, `subagent_steer()` wrote to the regular prompt queue without a steer flag, so messages were only delivered between turns. For long-running subagents with many tool calls per turn, this could mean significant latency before guidance landed.

## Changes

- **`gptme/prompt_queue.py`**:
  - `queue_prompt(steer=True)`: marks steering records with `"steer": true` to distinguish them from regular queued prompts
  - `drain_steer_prompts()`: new function that atomically drains only steer-flagged records, leaving regular turn-boundary prompts intact for `drain_prompt_queue`
  - `drain_prompt_queue()`: now skips steer-flagged records (reserves them for mid-turn drain), preserving existing TUI/queue semantics

- **`gptme/tools/subagent/api.py`**:
  - `subagent_steer()` now calls `queue_prompt(..., steer=True)`, updated docstring + return message to reflect mid-turn delivery

- **`gptme/tools/subagent/hooks.py`**:
  - `_subagent_control_hook` (STEP_PRE): extended to drain steer-flagged prompts from the prompt queue and yield them as user messages before the next `step()` call; cancel still takes priority over pending steer messages

## Tests

9 new unit tests in `TestMidTurnSteerInjection` covering:
- `steer=True` flag correctly marks records
- `drain_steer_prompts` / `drain_prompt_queue` separation
- Hook injects steer messages as user messages in FIFO order
- Hook no-ops when there's nothing to drain
- Cancel takes priority over pending steer messages
- Regular prompts are not injected mid-turn

All 276 subagent unit tests pass.

Closes #3191 (together with already-merged #3260, #3262, #3263 for slices 1 and 3).

<!-- gptme-id:v1:gai_dTUSoFUTYXUx3KLLgP5ySyFeaVAaqywN1n2kfDRdiLB -->