### PR TITLE
feat(hooks): add --manifest-dir for tool-call attribution at JSON-record granularity

### DIFF
--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -673,6 +673,15 @@ Run 'gptme-util --help' for all utility commands."""
     envvar="GPTME_INJECTION_HYGIENE",
     help="Prompt injection hygiene for tool outputs: off (disabled), warn (flag suspicious content), block (redact HIGH-severity patterns). Overrides GPTME_INJECTION_HYGIENE env var.",
 )
+@click.option(
+    "--manifest-dir",
+    "manifest_dir",
+    default=None,
+    type=click.Path(file_okay=False, path_type=Path),
+    envvar="GPTME_MANIFEST_DIR",
+    help="Write a JSON record before and after each tool call to this directory. "
+    "Records can be committed alongside session artifacts for tool-call-level attribution.",
+)
 def main(
     ctx: click.Context,
     prompts: list[str],
@@ -706,6 +715,7 @@ def main(
     no_workspace: bool,
     output_schema: str | None,
     injection_hygiene: str | None,
+    manifest_dir: Path | None,
 ):
     """Main entrypoint for the CLI."""
 
@@ -745,6 +755,12 @@ def main(
         plugin = f"gptme-{prompts[0]}"
         if plugin_path := shutil.which(plugin):
             sys.exit(subprocess.call([plugin_path, *prompts[1:]]))
+
+    # Register manifest hooks early so they are in the registry before any tool call.
+    if manifest_dir is not None:
+        from ..hooks.manifest import register_manifest_hooks  # fmt: skip
+
+        register_manifest_hooks(manifest_dir)
 
     # Defense-in-depth: handle empty/whitespace names in case Click bypasses convert()
     # (observed to occur in some Click versions when --name "" is passed)

--- a/gptme/hooks/manifest.py
+++ b/gptme/hooks/manifest.py
@@ -1,0 +1,109 @@
+"""Tool-call manifest writer.
+
+When activated via --manifest-dir, writes a JSON record before and after each
+tool call. Records can be committed alongside session artifacts for attribution
+at tool-call granularity (complementing ``scripts/analysis/sessions-blame.py``).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+from . import HookType, register_hook
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+    from pathlib import Path
+
+    from ..hooks.types import StopPropagation, ToolExecutePostData, ToolExecutePreData
+    from ..message import Message
+
+logger = logging.getLogger(__name__)
+
+
+def _sha256_hex(data: str) -> str:
+    return "sha256:" + hashlib.sha256(data.encode()).hexdigest()
+
+
+def register_manifest_hooks(manifest_dir: Path) -> None:
+    """Register pre/post tool-call hooks that write JSON manifests to *manifest_dir*.
+
+    Each tool call produces two files::
+
+        <session_id>-<seq:04d>-<tool>-pre.json
+        <session_id>-<seq:04d>-<tool>-post.json
+
+    The pre record captures the tool name, a hash of the args/content, the
+    model, and a timestamp.  The post record adds a hash of the tool result.
+    Together they form a chain that ``sessions-blame.py`` can resolve to
+    tool-call granularity.
+    """
+    manifest_dir.mkdir(parents=True, exist_ok=True)
+    # Mutable counter captured by both closures so pre and post share the same seq.
+    seq: list[int] = [0]
+
+    def _pre(
+        data: ToolExecutePreData,
+    ) -> Generator[Message | StopPropagation, None, None]:
+        if data.tool_use is None:
+            yield from ()
+            return
+        seq[0] += 1
+        session_id = os.environ.get("GPTME_SESSION_ID", "unknown")
+        model = os.environ.get("GPTME_MODEL", os.environ.get("CC_MODEL", "unknown"))
+        args_str = json.dumps(data.tool_use.args, default=str)
+        record: dict = {
+            "session_id": session_id,
+            "model": model,
+            "sequence": seq[0],
+            "tool": data.tool_use.tool,
+            "args_hash": _sha256_hex(args_str),
+            "timestamp": datetime.now(tz=timezone.utc).isoformat(),
+            "phase": "pre",
+        }
+        if data.tool_use.content:
+            record["content_hash"] = _sha256_hex(data.tool_use.content)
+        fname = f"{session_id}-{seq[0]:04d}-{data.tool_use.tool}-pre.json"
+        try:
+            (manifest_dir / fname).write_text(json.dumps(record, indent=2))
+        except OSError as e:
+            logger.warning("manifest pre-write failed: %s", e)
+        yield from ()
+
+    def _post(
+        data: ToolExecutePostData,
+    ) -> Generator[Message | StopPropagation, None, None]:
+        if data.tool_use is None:
+            yield from ()
+            return
+        session_id = os.environ.get("GPTME_SESSION_ID", "unknown")
+        model = os.environ.get("GPTME_MODEL", os.environ.get("CC_MODEL", "unknown"))
+        result_text = "\n".join(
+            m.content
+            for m in (data.result_msgs or ())
+            if hasattr(m, "content") and m.content
+        )
+        record = {
+            "session_id": session_id,
+            "model": model,
+            "sequence": seq[0],
+            "tool": data.tool_use.tool,
+            "result_hash": _sha256_hex(result_text),
+            "timestamp": datetime.now(tz=timezone.utc).isoformat(),
+            "phase": "post",
+        }
+        fname = f"{session_id}-{seq[0]:04d}-{data.tool_use.tool}-post.json"
+        try:
+            (manifest_dir / fname).write_text(json.dumps(record, indent=2))
+        except OSError as e:
+            logger.warning("manifest post-write failed: %s", e)
+        yield from ()
+
+    register_hook("manifest.pre", HookType.TOOL_EXECUTE_PRE, _pre, priority=0)
+    register_hook("manifest.post", HookType.TOOL_EXECUTE_POST, _post, priority=0)
+    logger.debug("Manifest hooks registered, writing to %s", manifest_dir)

--- a/gptme/hooks/manifest.py
+++ b/gptme/hooks/manifest.py
@@ -11,6 +11,7 @@ import hashlib
 import json
 import logging
 import os
+import uuid
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
@@ -44,6 +45,10 @@ def register_manifest_hooks(manifest_dir: Path) -> None:
     tool-call granularity.
     """
     manifest_dir.mkdir(parents=True, exist_ok=True)
+    # Resolve session_id once at registration time so all records in this session share
+    # the same identifier. Fallback generates a unique id per registration to avoid
+    # overwriting files from other anonymous sessions in the same manifest-dir.
+    session_id = os.environ.get("GPTME_SESSION_ID") or f"anon-{uuid.uuid4().hex[:8]}"
     # Mutable counter captured by both closures so pre and post share the same seq.
     seq: list[int] = [0]
 
@@ -54,7 +59,6 @@ def register_manifest_hooks(manifest_dir: Path) -> None:
             yield from ()
             return
         seq[0] += 1
-        session_id = os.environ.get("GPTME_SESSION_ID", "unknown")
         model = os.environ.get("GPTME_MODEL", os.environ.get("CC_MODEL", "unknown"))
         args_str = json.dumps(data.tool_use.args, default=str)
         record: dict = {
@@ -81,7 +85,6 @@ def register_manifest_hooks(manifest_dir: Path) -> None:
         if data.tool_use is None:
             yield from ()
             return
-        session_id = os.environ.get("GPTME_SESSION_ID", "unknown")
         model = os.environ.get("GPTME_MODEL", os.environ.get("CC_MODEL", "unknown"))
         result_text = "\n".join(
             m.content

--- a/gptme/hooks/tests/test_manifest.py
+++ b/gptme/hooks/tests/test_manifest.py
@@ -1,0 +1,101 @@
+"""Tests for the tool-call manifest writer hook."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+from gptme.hooks import HookType
+from gptme.hooks.manifest import register_manifest_hooks
+from gptme.hooks.registry import HookRegistry
+from gptme.hooks.types import ToolExecutePostData, ToolExecutePreData
+from gptme.message import Message
+from gptme.tools.base import ToolUse
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+
+def _run_hook(registry: HookRegistry, hook_type: HookType, data: object) -> list:
+    return list(registry.trigger(hook_type, data))
+
+
+@pytest.fixture()
+def manifest_dir(tmp_path: Path) -> Path:
+    return tmp_path / "manifests"
+
+
+@pytest.fixture()
+def registry(manifest_dir: Path) -> Iterator[HookRegistry]:
+    import gptme.hooks.registry as _mod
+
+    reg = HookRegistry()
+    _mod.set_registry(reg)
+    register_manifest_hooks(manifest_dir)
+    yield reg
+    _mod.set_registry(HookRegistry())
+
+
+class TestManifestHooks:
+    def test_manifest_dir_created(
+        self, manifest_dir: Path, registry: HookRegistry
+    ) -> None:
+        assert manifest_dir.exists()
+
+    def test_pre_hook_writes_file(
+        self, manifest_dir: Path, registry: HookRegistry
+    ) -> None:
+        tool_use = ToolUse(tool="shell", args=["echo hi"], content=None)
+        data = ToolExecutePreData(tool_use=tool_use)
+        _run_hook(registry, HookType.TOOL_EXECUTE_PRE, data)
+
+        files = list(manifest_dir.glob("*-pre.json"))
+        assert len(files) == 1
+        record = json.loads(files[0].read_text())
+        assert record["tool"] == "shell"
+        assert record["phase"] == "pre"
+        assert record["sequence"] == 1
+        assert "args_hash" in record
+        assert record["args_hash"].startswith("sha256:")
+
+    def test_post_hook_writes_file(
+        self, manifest_dir: Path, registry: HookRegistry
+    ) -> None:
+        tool_use = ToolUse(tool="shell", args=["echo hi"], content=None)
+        result_msg = Message("system", "hi\n")
+        pre_data = ToolExecutePreData(tool_use=tool_use)
+        _run_hook(registry, HookType.TOOL_EXECUTE_PRE, pre_data)
+
+        post_data = ToolExecutePostData(tool_use=tool_use, result_msgs=(result_msg,))
+        _run_hook(registry, HookType.TOOL_EXECUTE_POST, post_data)
+
+        files = list(manifest_dir.glob("*-post.json"))
+        assert len(files) == 1
+        record = json.loads(files[0].read_text())
+        assert record["tool"] == "shell"
+        assert record["phase"] == "post"
+        assert "result_hash" in record
+        assert record["result_hash"].startswith("sha256:")
+
+    def test_sequence_increments_per_tool_call(
+        self, manifest_dir: Path, registry: HookRegistry
+    ) -> None:
+        for i in range(3):
+            tool_use = ToolUse(tool="read", args=[f"file{i}.py"], content=None)
+            data = ToolExecutePreData(tool_use=tool_use)
+            _run_hook(registry, HookType.TOOL_EXECUTE_PRE, data)
+
+        pre_files = sorted(manifest_dir.glob("*-pre.json"))
+        assert len(pre_files) == 3
+        seqs = [json.loads(f.read_text())["sequence"] for f in pre_files]
+        assert seqs == [1, 2, 3]
+
+    def test_no_files_when_tool_use_none(
+        self, manifest_dir: Path, registry: HookRegistry
+    ) -> None:
+        data = ToolExecutePreData(tool_use=None)
+        _run_hook(registry, HookType.TOOL_EXECUTE_PRE, data)
+        assert list(manifest_dir.glob("*.json")) == []


### PR DESCRIPTION
## Summary

- Adds `--manifest-dir PATH` CLI option (and `GPTME_MANIFEST_DIR` env var) to gptme that writes a JSON record before and after each tool call
- Records are named `<session_id>-<seq:04d>-<tool>-pre.json` / `<session_id>-<seq:04d>-<tool>-post.json`
- Pre records capture: session_id, model, tool name, sha256 of args (and content if present), timestamp
- Post records add a sha256 of the tool result
- Enables tool-call-level attribution alongside existing session-level attribution via `sessions-blame.py`

## Implementation

New `gptme/hooks/manifest.py` using `TOOL_EXECUTE_PRE` and `TOOL_EXECUTE_POST` hook types, registered via `register_manifest_hooks()`. Wired into `cli/main.py` with a `--manifest-dir` click option that invokes registration early before any tool calls.

## Test plan

- [ ] 5 new tests in `gptme/hooks/tests/test_manifest.py`: dir creation, pre-hook file write, post-hook file write, sequence increment per call, no-op when `tool_use=None`
- [ ] Run `uv run pytest gptme/hooks/tests/test_manifest.py -v` — all 5 pass
- [ ] Manual smoke test: `gptme --manifest-dir /tmp/test-manifest "echo hello"` produces `unknown-0001-shell-pre.json` and `unknown-0001-shell-post.json` with correct structure