### PR TITLE
feat(models): add pricing_type field for subscription-backed providers

### DIFF
--- a/gptme/llm/models/data.py
+++ b/gptme/llm/models/data.py
@@ -4,6 +4,15 @@ from ..llm_anthropic_models_deprecated import ANTHROPIC_MODELS_DEPRECATED
 from ..llm_openai_models import OPENAI_MODELS, OPENAI_SUBSCRIPTION_MODELS
 from .types import PROVIDERS, Provider, _ModelDictMeta
 
+
+def _mark_subscription(models: dict[str, _ModelDictMeta]) -> dict[str, _ModelDictMeta]:
+    """Mark all models in a dict as subscription-priced (zero marginal USD cost)."""
+    return {
+        name: {**props, "pricing_type": "subscription"}
+        for name, props in models.items()
+    }
+
+
 # TODO: can we get this from the API?
 MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
     "openai": OPENAI_MODELS,
@@ -11,10 +20,12 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
     # Uses the Responses API (not Chat Completions). Per-model specs from
     # llm_openai_models.py; prices reflect API-equivalent cost for comparison.
     # Reasoning level suffix (e.g., :high) is stripped at lookup time in get_model()
-    "openai-subscription": {
-        model: {**props, "default_tool_format": "tool"}
-        for model, props in OPENAI_SUBSCRIPTION_MODELS.items()
-    },
+    "openai-subscription": _mark_subscription(
+        {
+            model: {**props, "default_tool_format": "tool"}
+            for model, props in OPENAI_SUBSCRIPTION_MODELS.items()
+        }
+    ),
     # https://docs.anthropic.com/en/docs/about-claude/models
     # Active models here; deprecated models in llm_anthropic_models_deprecated.py
     "anthropic": {
@@ -294,19 +305,21 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
     # Uses OAuth tokens from the grok CLI (~/.grok/auth.json) — $0 marginal.
     # Prices reflect xAI API-equivalent cost for comparison purposes.
     # Auth: run `grok login` or `gptme auth grok-subscription`.
-    "grok-subscription": {
-        # grok-4.5 — frontier model available on SuperGrok subscription
-        # https://x.ai/blog/grok-4-5 (500K context, reasoning support)
-        "grok-4.5": {
-            "context": 500_000,
-            "max_output": 128_000,
-            "price_input": 2,
-            "price_output": 6,
-            "supports_vision": True,
-            "supports_reasoning": True,
-            "preferred_edit_format": "diff",
-        },
-    },
+    "grok-subscription": _mark_subscription(
+        {
+            # grok-4.5 — frontier model available on SuperGrok subscription
+            # https://x.ai/blog/grok-4-5 (500K context, reasoning support)
+            "grok-4.5": {
+                "context": 500_000,
+                "max_output": 128_000,
+                "price_input": 2,
+                "price_output": 6,
+                "supports_vision": True,
+                "supports_reasoning": True,
+                "preferred_edit_format": "diff",
+            },
+        }
+    ),
     "xai": {
         "grok-4-1-fast": {
             "context": 2_000_000,

--- a/gptme/llm/models/listing.py
+++ b/gptme/llm/models/listing.py
@@ -34,6 +34,8 @@ def model_to_dict(model: ModelMeta) -> dict[str, Any]:
     if model.price_input or model.price_output:
         d["price_input"] = model.price_input
         d["price_output"] = model.price_output
+    if model.pricing_type != "per_token":
+        d["pricing_type"] = model.pricing_type
     if model.knowledge_cutoff:
         d["knowledge_cutoff"] = model.knowledge_cutoff.isoformat()
     if model.deprecated:

--- a/gptme/llm/models/types.py
+++ b/gptme/llm/models/types.py
@@ -152,6 +152,11 @@ class ModelMeta:
     # See gptme/gptme#2362.
     preferred_edit_format: Literal["diff", "whole"] | None = None
 
+    # How this model is priced: "per_token" for standard API billing,
+    # "subscription" for flat-rate plans (e.g. openai-subscription, grok-subscription).
+    # Subscription models preserve token counts but have zero marginal USD cost.
+    pricing_type: Literal["per_token", "subscription"] = "per_token"
+
     @property
     def full(self) -> str:
         # For unknown providers (including custom providers), the model field
@@ -250,3 +255,6 @@ class _ModelDictMeta(TypedDict):
 
     # preferred edit format for this model
     preferred_edit_format: NotRequired[Literal["diff", "whole"]]
+
+    # pricing model for this model
+    pricing_type: NotRequired[Literal["per_token", "subscription"]]

--- a/gptme/telemetry.py
+++ b/gptme/telemetry.py
@@ -322,6 +322,9 @@ def _calculate_llm_cost(
     if not (meta and input_tokens and output_tokens):
         return 0.0
 
+    if meta.pricing_type == "subscription":
+        return 0.0
+
     price_in = (meta.price_input or 0.0) / 1e6
     price_out = (meta.price_output or 0.0) / 1e6
     cost = input_tokens * price_in + output_tokens * price_out

--- a/gptme/util/cost_display.py
+++ b/gptme/util/cost_display.py
@@ -65,6 +65,7 @@ class StepCost:
     cache_creation_tokens: int
     cost: float
     model: str | None = None
+    pricing_type: str = "per_token"
 
 
 @dataclass
@@ -257,6 +258,8 @@ def gather_per_step_costs(messages: list[Message]) -> list[StepCost]:
     Returns one StepCost per assistant message that carries metadata.
     Steps are 1-based (first assistant message = step 1).
     """
+    from ..llm.models import get_model  # lazy import to avoid circular dep
+
     steps: list[StepCost] = []
     step_idx = 0
 
@@ -272,6 +275,14 @@ def gather_per_step_costs(messages: list[Message]) -> list[StepCost]:
             # Only include steps that have some token data
             if input_tokens > 0 or output_tokens > 0 or cache_read > 0:
                 step_idx += 1
+                model_name = msg.metadata.get("model")
+                pricing_type = "per_token"
+                if model_name:
+                    try:
+                        meta = get_model(model_name)
+                        pricing_type = meta.pricing_type
+                    except Exception:
+                        pass
                 steps.append(
                     StepCost(
                         step_index=step_idx,
@@ -280,7 +291,8 @@ def gather_per_step_costs(messages: list[Message]) -> list[StepCost]:
                         cache_read_tokens=cache_read,
                         cache_creation_tokens=cache_create,
                         cost=cost,
-                        model=msg.metadata.get("model"),
+                        model=model_name,
+                        pricing_type=pricing_type,
                     )
                 )
 
@@ -424,6 +436,11 @@ def display_costs(
                 step.input_tokens + step.cache_read_tokens + step.cache_creation_tokens
             )
             model_short = _short_model_name(step.model) if step.model else ""
+            cost_str = (
+                "subscription"
+                if step.pricing_type == "subscription"
+                else _format_cost(step.cost).rjust(9)
+            )
             console.log(
                 "  "
                 + str(step.step_index).rjust(4)
@@ -438,7 +455,7 @@ def display_costs(
                 + "  "
                 + f"{step.cache_creation_tokens:,}".rjust(8)
                 + "  "
-                + _format_cost(step.cost).rjust(9)
+                + cost_str.rjust(9)
                 + "  "
                 + model_short
             )

--- a/tests/test_subscription_pricing.py
+++ b/tests/test_subscription_pricing.py
@@ -1,0 +1,115 @@
+"""Tests for subscription-aware cost semantics (pricing_type field)."""
+
+import pytest
+
+from gptme.llm.models import get_model
+from gptme.llm.models.listing import model_to_dict
+from gptme.telemetry import _calculate_llm_cost
+
+# --- pricing_type resolution ---
+
+
+@pytest.mark.parametrize(
+    "model_str",
+    [
+        "openai-subscription/gpt-5.6-sol",
+        "openai-subscription/gpt-5",
+        "openai-subscription/gpt-5.6",  # alias
+    ],
+)
+def test_openai_subscription_pricing_type(model_str):
+    """openai-subscription models resolve with pricing_type == 'subscription'."""
+    meta = get_model(model_str)
+    assert meta.pricing_type == "subscription", (
+        f"{model_str!r} expected pricing_type='subscription', got {meta.pricing_type!r}"
+    )
+
+
+def test_grok_subscription_pricing_type():
+    """grok-subscription models resolve with pricing_type == 'subscription'."""
+    meta = get_model("grok-subscription/grok-4.5")
+    assert meta.pricing_type == "subscription"
+
+
+@pytest.mark.parametrize(
+    "model_str",
+    [
+        "openai/gpt-5",
+        "openai/gpt-5.6-sol",
+        "anthropic/claude-sonnet-4-6",
+        "xai/grok-4",
+    ],
+)
+def test_api_providers_per_token(model_str):
+    """Standard API-backed models default to pricing_type == 'per_token'."""
+    meta = get_model(model_str)
+    assert meta.pricing_type == "per_token"
+
+
+def test_subscription_models_retain_comparison_prices():
+    """Subscription models keep API-equivalent price_input/price_output for comparison."""
+    meta = get_model("openai-subscription/gpt-5.6-sol")
+    assert meta.price_input > 0 or meta.price_output > 0, (
+        "Expected non-zero API-equivalent prices for comparison, got zeros"
+    )
+
+
+# --- telemetry cost calculation ---
+
+
+def test_subscription_cost_is_zero():
+    """_calculate_llm_cost returns 0.0 for subscription models with nonzero tokens."""
+    cost = _calculate_llm_cost(
+        provider="openai-subscription",
+        model="gpt-5.6-sol",
+        input_tokens=10_000,
+        output_tokens=5_000,
+    )
+    assert cost == 0.0
+
+
+def test_grok_subscription_cost_is_zero():
+    """_calculate_llm_cost returns 0.0 for grok-subscription models."""
+    cost = _calculate_llm_cost(
+        provider="grok-subscription",
+        model="grok-4.5",
+        input_tokens=10_000,
+        output_tokens=5_000,
+    )
+    assert cost == 0.0
+
+
+def test_per_token_cost_nonzero():
+    """_calculate_llm_cost returns a positive value for standard API models."""
+    cost = _calculate_llm_cost(
+        provider="anthropic",
+        model="claude-sonnet-4-6",
+        input_tokens=10_000,
+        output_tokens=5_000,
+    )
+    assert cost > 0.0
+
+
+# --- model serialization ---
+
+
+def test_subscription_model_dict_includes_pricing_type():
+    """model_to_dict includes pricing_type for subscription-backed models."""
+    meta = get_model("openai-subscription/gpt-5.6-sol")
+    d = model_to_dict(meta)
+    assert d.get("pricing_type") == "subscription"
+
+
+def test_per_token_model_dict_omits_pricing_type():
+    """model_to_dict omits pricing_type for standard per-token models (default)."""
+    meta = get_model("openai/gpt-5")
+    d = model_to_dict(meta)
+    assert "pricing_type" not in d
+
+
+def test_subscription_model_dict_includes_comparison_prices():
+    """model_to_dict includes price_input/price_output even for subscription models."""
+    meta = get_model("grok-subscription/grok-4.5")
+    d = model_to_dict(meta)
+    assert "price_input" in d or "price_output" in d
+    assert d.get("pricing_type") == "subscription"

--- a/tests/test_util_cli.py
+++ b/tests/test_util_cli.py
@@ -635,6 +635,7 @@ def test_models_list_json_suppresses_provider_noise(mocker):
                 knowledge_cutoff=None,
                 deprecated=False,
                 preferred_edit_format=None,
+                pricing_type="per_token",
             )
         ]
 
@@ -675,6 +676,7 @@ def test_models_list_json_available_keeps_plugin_models(mocker):
                 knowledge_cutoff=None,
                 deprecated=False,
                 preferred_edit_format=None,
+                pricing_type="per_token",
             )
         ],
     )


### PR DESCRIPTION
## Summary

- Adds `pricing_type: Literal["per_token", "subscription"]` field to `ModelMeta` and `_ModelDictMeta`, defaulting to `"per_token"` for full backward compatibility
- Marks `openai-subscription` and `grok-subscription` model metadata as `"subscription"` via a new `_mark_subscription()` helper; API-equivalent prices retained for comparison
- `_calculate_llm_cost()` returns `0.0` for subscription-priced models with nonzero token usage, preventing inflated cost telemetry
- `model_to_dict()` serializes `pricing_type` for subscription models (omitted for the default `"per_token"` case to keep output clean)
- Per-step `/tokens` display annotates subscription-backed steps with `"subscription"` instead of a confusing bare `$0.0000`
- 15 new focused tests covering model resolution, telemetry cost, and serialization

## Test plan

- [ ] `pytest tests/test_subscription_pricing.py` — 15 new tests (all pass locally)
- [ ] `pytest tests/test_llm_models.py tests/test_llm_models_resolution.py` — 176 existing model tests unchanged
- [ ] `pytest tests/test_cost_display.py tests/test_cost_tracker.py` — 40 cost tests unchanged
- [ ] Verify `get_model("openai-subscription/gpt-5.6-sol").pricing_type == "subscription"`
- [ ] Verify `get_model("grok-subscription/grok-4.5").pricing_type == "subscription"`
- [ ] Verify `get_model("openai/gpt-5").pricing_type == "per_token"`