### PR TITLE
fix(logmanager): preserve tool call/result atomicity in prune_ephemeral_messages

### DIFF
--- a/gptme/logmanager/manager.py
+++ b/gptme/logmanager/manager.py
@@ -729,7 +729,76 @@ def prune_ephemeral_messages(msgs: list[Message]) -> list[Message]:
             assistant_turns_after += 1
 
     pruned = list(reversed(kept_reversed))
+
+    # Enforce tool call / tool result atomicity: dropping an assistant message
+    # that contains tool calls must also drop its companion tool results, and
+    # vice versa — otherwise the Responses API returns 400.
+    pruned = _drop_orphaned_tool_pairs(msgs, pruned)
+
     return _merge_consecutive_messages(pruned)
+
+
+def _drop_orphaned_tool_pairs(
+    original: list[Message],
+    pruned: list[Message],
+) -> list[Message]:
+    """Drop messages that form broken tool call / tool result pairs.
+
+    Two directions are handled, iterating until stable:
+
+    Case 1 — orphaned tool result: a system message with call_id whose
+    nearest non-system predecessor in *original* was dropped by the TTL
+    prune.  Keeping it without the function call causes Responses-API 400.
+
+    Case 2 — orphaned function call: an assistant message immediately
+    followed (in *original*) by one or more system messages with call_id,
+    where at least one of those results is missing from *pruned*.  Keeping
+    the function call without all its outputs also triggers 400.
+    """
+    if not any(m.call_id for m in original):
+        return pruned
+
+    orig_idx = {id(m): i for i, m in enumerate(original)}
+    kept_ids = {id(m) for m in pruned}
+
+    changed = True
+    while changed:
+        changed = False
+        to_remove: set[int] = set()
+
+        for msg in pruned:
+            mid = id(msg)
+            if mid not in kept_ids or mid in to_remove:
+                continue
+            idx = orig_idx.get(mid)
+            if idx is None:
+                continue
+
+            if msg.role == "system" and msg.call_id:
+                # Case 1: walk backward to find nearest non-system anchor.
+                for j in range(idx - 1, -1, -1):
+                    if original[j].role != "system":
+                        if id(original[j]) not in kept_ids:
+                            to_remove.add(mid)
+                            changed = True
+                        break
+
+            elif msg.role == "assistant":
+                # Case 2: walk forward to find immediately following tool
+                # results; if any are missing, drop the function call too.
+                for j in range(idx + 1, len(original)):
+                    nxt = original[j]
+                    if nxt.role == "system" and nxt.call_id:
+                        if id(nxt) not in kept_ids:
+                            to_remove.add(mid)
+                            changed = True
+                            break
+                    elif nxt.role != "system":
+                        break
+
+        kept_ids -= to_remove
+
+    return [m for m in pruned if id(m) in kept_ids]
 
 
 def _merge_consecutive_messages(msgs: list[Message]) -> list[Message]:

--- a/tests/test_ephemeral.py
+++ b/tests/test_ephemeral.py
@@ -11,12 +11,27 @@ from gptme.message import Message
 
 Role = Literal["system", "user", "assistant"]
 
+_TS = datetime(2025, 1, 1, tzinfo=timezone.utc)
+
 
 def _msg(role: Role, content: str = "hello", ttl: int | None = None) -> Message:
     return Message(
         role,
         content,
-        timestamp=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        timestamp=_TS,
+        ephemeral_ttl=ttl,
+    )
+
+
+def _tool_result(
+    call_id: str, content: str = "tool output", ttl: int | None = None
+) -> Message:
+    """Create a system message representing a tool call result."""
+    return Message(
+        "system",
+        content,
+        timestamp=_TS,
+        call_id=call_id,
         ephemeral_ttl=ttl,
     )
 
@@ -247,6 +262,110 @@ def test_ephemeral_cache_boundary_returns_index_before_first_ephemeral():
 def test_ephemeral_cache_boundary_none_when_first_msg_is_ephemeral():
     msgs = [_msg("user", ttl=1), _msg("assistant")]
     assert ephemeral_cache_boundary(msgs) is None
+
+
+# ---------------------------------------------------------------------------
+# Tool call / tool result atomicity (orphan guard)
+# Issue: prune_ephemeral_messages could drop one half of a pair, causing
+# Responses API 400 "No tool output found for function call call_XXX".
+# ---------------------------------------------------------------------------
+
+
+def test_expired_assistant_drops_companion_tool_results():
+    """Case 1: expired assistant message also drops its tool results.
+
+    The assistant message has ephemeral_ttl (e.g. from a thinking block) AND
+    is a function call turn.  When the TTL expires, the tool results must be
+    dropped too — keeping them without their anchor causes 400.
+    """
+    msgs = [
+        _msg("system", "System"),
+        _msg("user", "Q0"),
+        _msg(
+            "assistant", "<think>reasoning</think>", ttl=0
+        ),  # expires after 1 assistant turn
+        _tool_result("call_001", "result data"),
+        _msg("user", "Q1"),
+        _msg("assistant", "A1"),  # 1 turn after → assistant0 expires (TTL=0)
+    ]
+    result = prune_ephemeral_messages(msgs)
+    # Neither the expired assistant nor its tool result should survive
+    assert all(m.call_id is None for m in result), (
+        "tool result should be dropped along with its expired assistant anchor"
+    )
+    assert all("<think>" not in m.content for m in result)
+    _assert_no_consecutive_same_role(result)
+
+
+def test_expired_assistant_drops_multiple_companion_tool_results():
+    """Case 1 with multiple tool results from a single assistant turn."""
+    msgs = [
+        _msg("system", "System"),
+        _msg("user", "Q0"),
+        _msg("assistant", "<think>multi-tool</think>", ttl=0),
+        _tool_result("call_001", "result 1"),
+        _tool_result("call_002", "result 2"),
+        _msg("user", "Q1"),
+        _msg("assistant", "A1"),
+    ]
+    result = prune_ephemeral_messages(msgs)
+    assert all(m.call_id is None for m in result), (
+        "all tool results should be dropped with their expired anchor"
+    )
+    _assert_no_consecutive_same_role(result)
+
+
+def test_dropped_tool_result_drops_companion_function_call():
+    """Case 2: dropped tool result forces its function call to be dropped too.
+
+    If a tool result (system+call_id) has ephemeral_ttl and expires, the
+    companion assistant message (function call) must also be dropped.
+    Keeping a function call without its output causes 400.
+    """
+    msgs = [
+        _msg("system", "System"),
+        _msg("user", "Q0"),
+        _msg("assistant", "function call turn"),  # no TTL on the call itself
+        _tool_result("call_001", "result data", ttl=0),  # result expires
+        _msg("user", "Q1"),
+        _msg("assistant", "A1"),  # 1 turn after → tool result expires (TTL=0)
+    ]
+    result = prune_ephemeral_messages(msgs)
+    assert all(m.call_id is None for m in result), "tool result must be dropped"
+    contents = [m.content for m in result]
+    assert "function call turn" not in contents, (
+        "function call must be dropped when its tool result was dropped"
+    )
+    _assert_no_consecutive_same_role(result)
+
+
+def test_non_tool_call_assistant_not_dropped_by_orphan_guard():
+    """Orphan guard must not affect assistant messages that have no tool calls."""
+    msgs = [
+        _msg("system", "System"),
+        _msg("user", "Q0"),
+        _msg("assistant", "plain response"),
+        _msg("user", "Q1"),
+        _msg("assistant", "A1"),
+    ]
+    result = prune_ephemeral_messages(msgs)
+    assert result == msgs
+
+
+def test_tool_result_without_call_id_not_dropped():
+    """System messages without call_id are not treated as tool results."""
+    msgs = [
+        _msg("system", "System prompt"),
+        _msg("user", "Q0"),
+        _msg("assistant", "A0", ttl=0),
+        _msg("system", "tool output without call_id"),  # no call_id
+        _msg("user", "Q1"),
+        _msg("assistant", "A1"),
+    ]
+    result = prune_ephemeral_messages(msgs)
+    # The system message without call_id should survive (it's not a tool result)
+    contents = [m.content for m in result]
+    assert "tool output without call_id" in contents
 
 
 def test_unmarked_thinking_message_not_pruned_by_default():


### PR DESCRIPTION
## Problem

`prune_ephemeral_messages` dropped expired messages individually without checking tool call/result pair integrity. When an assistant message with `ephemeral_ttl` (e.g. a thinking block) also made tool calls, dropping it left the companion system messages (`call_id` set) without their anchor. The OpenAI Responses API (and similar strict providers) then return:

```
Codex API error 400: {"message": "No tool output found for function call call_XXX."}
```

Fixes #3293.

## Solution

Add `_drop_orphaned_tool_pairs` post-processing step called after the TTL prune pass. It enforces atomicity in both directions:

- **Case 1** — orphaned tool result: a system message with `call_id` whose nearest non-system predecessor was dropped → also drop the tool result
- **Case 2** — orphaned function call: an assistant message whose immediately following tool results (system+call_id) were dropped → also drop the assistant

The function iterates until stable to handle cascades, and has a fast-path when no `call_id` messages exist (the common case — zero overhead).

## Tests

Added 5 new test cases to `tests/test_ephemeral.py`:
- `test_expired_assistant_drops_companion_tool_results` — Case 1 (single result)
- `test_expired_assistant_drops_multiple_companion_tool_results` — Case 1 (multiple results)
- `test_dropped_tool_result_drops_companion_function_call` — Case 2
- `test_non_tool_call_assistant_not_dropped_by_orphan_guard` — guard doesn't affect non-tool messages
- `test_tool_result_without_call_id_not_dropped` — system messages without call_id are unaffected

All 25 tests in the file pass.

<!-- gptme-id:v1:gai_aM5l1Neno2kaoqUYLfeSn20djUJDWnEYzuSYoSupwz5 -->