### PR TITLE
feat(cli): offer subscription auth on first run

### DIFF
--- a/gptme/cli/setup.py
+++ b/gptme/cli/setup.py
@@ -791,10 +791,11 @@ def _choose_first_run_auth() -> str:
     console.print(
         "[bold]How would you like to connect?[/bold]\n"
         "  1. ChatGPT Plus/Pro subscription [dim](browser sign-in, no API key)[/dim]\n"
-        "  2. Provider API key [dim](OpenAI, Anthropic, OpenRouter, Gemini)[/dim]\n"
-        "  3. Custom OpenAI-compatible provider"
+        "  2. Grok SuperGrok subscription [dim](browser sign-in, no API key)[/dim]\n"
+        "  3. Provider API key [dim](OpenAI, Anthropic, OpenRouter, Gemini)[/dim]\n"
+        "  4. Custom OpenAI-compatible provider"
     )
-    return Prompt.ask("Connection", choices=["1", "2", "3"], default="1")
+    return Prompt.ask("Connection", choices=["1", "2", "3", "4"], default="1")
 
 
 def _show_api_key_sources() -> None:  # pragma: no cover
@@ -827,6 +828,24 @@ def _setup_openai_subscription() -> tuple[str, str]:
     return provider, "oauth"
 
 
+def _setup_grok_subscription() -> tuple[str, str]:
+    """Authenticate a Grok SuperGrok subscription and persist it as the default."""
+    from ..llm.llm_grok_subscription import oauth_authenticate
+
+    console.print(
+        "\n[bold]Opening your browser for Grok sign-in...[/bold]\n"
+        "[dim]This uses your existing SuperGrok subscription; no API key is needed.[/dim]\n"
+        "[dim]If you already have the grok CLI installed and ran 'grok login', "
+        "tokens are reused automatically.[/dim]"
+    )
+    oauth_authenticate()
+    provider = "grok-subscription"
+    model = f"{provider}/{get_recommended_model('grok-subscription')}"
+    set_config_value("models.default", model)
+    console.print(f"[green]✅ Grok subscription connected ({model})[/green]")
+    return provider, "oauth"
+
+
 def ask_for_api_key():  # pragma: no cover
     """Interactively configure subscription, API-key, or custom provider auth."""
     console.print(
@@ -840,7 +859,9 @@ def ask_for_api_key():  # pragma: no cover
     choice = _choose_first_run_auth()
     if choice == "1":
         return _setup_openai_subscription()
-    if choice == "3":
+    if choice == "2":
+        return _setup_grok_subscription()
+    if choice == "4":
         return _setup_custom_provider()
 
     _show_api_key_sources()

--- a/gptme/cli/setup.py
+++ b/gptme/cli/setup.py
@@ -17,7 +17,7 @@ from ..config import config_path, get_config, save_provider_config, set_config_v
 from ..config.models import ProviderConfig
 from ..config.user import get_user_config_paths
 from ..llm import get_model_from_api_key, list_available_providers
-from ..llm.models import PROVIDERS, get_default_model
+from ..llm.models import PROVIDERS, get_default_model, get_recommended_model
 from ..util import console, path_with_tilde
 
 
@@ -786,8 +786,49 @@ def _setup_custom_provider() -> tuple[str, str]:  # pragma: no cover
     return name, api_key
 
 
+def _choose_first_run_auth() -> str:
+    """Ask which authentication path a first-run user wants."""
+    console.print(
+        "[bold]How would you like to connect?[/bold]\n"
+        "  1. ChatGPT Plus/Pro subscription [dim](browser sign-in, no API key)[/dim]\n"
+        "  2. Provider API key [dim](OpenAI, Anthropic, OpenRouter, Gemini)[/dim]\n"
+        "  3. Custom OpenAI-compatible provider"
+    )
+    return Prompt.ask("Connection", choices=["1", "2", "3"], default="1")
+
+
+def _show_api_key_sources() -> None:  # pragma: no cover
+    """Show links for supported API-key providers."""
+    providers_table = Table(title="🔑 Get API Keys", show_header=True, box=None)
+    providers_table.add_column("Provider", style="cyan")
+    providers_table.add_column("URL", style="blue")
+    providers_table.add_row("OpenAI", "https://platform.openai.com/account/api-keys")
+    providers_table.add_row("Anthropic", "https://console.anthropic.com/settings/keys")
+    providers_table.add_row("OpenRouter", "https://openrouter.ai/settings/keys")
+    providers_table.add_row("Gemini", "https://aistudio.google.com/app/apikey")
+    console.print()
+    console.print(providers_table)
+    console.print()
+
+
+def _setup_openai_subscription() -> tuple[str, str]:
+    """Authenticate a ChatGPT subscription and persist it as the default."""
+    from ..llm.llm_openai_subscription import oauth_authenticate
+
+    console.print(
+        "\n[bold]Opening your browser for ChatGPT sign-in...[/bold]\n"
+        "[dim]This uses your existing Plus/Pro subscription; no API key is needed.[/dim]"
+    )
+    oauth_authenticate()
+    provider = "openai-subscription"
+    model = f"{provider}/{get_recommended_model('openai-subscription')}"
+    set_config_value("models.default", model)
+    console.print(f"[green]✅ ChatGPT subscription connected ({model})[/green]")
+    return provider, "oauth"
+
+
 def ask_for_api_key():  # pragma: no cover
-    """Interactively ask user for an API key or configure a custom provider."""
+    """Interactively configure subscription, API-key, or custom provider auth."""
     console.print(
         Panel.fit(
             Text("🔑 Provider Setup", style="bold green"),
@@ -796,25 +837,13 @@ def ask_for_api_key():  # pragma: no cover
         )
     )
 
-    # Create a nice table with provider links
-    providers_table = Table(title="🔑 Get API Keys", show_header=True, box=None)
-    providers_table.add_column("Provider", style="cyan")
-    providers_table.add_column("URL", style="blue")
-
-    providers_table.add_row("OpenAI", "https://platform.openai.com/account/api-keys")
-    providers_table.add_row("Anthropic", "https://console.anthropic.com/settings/keys")
-    providers_table.add_row("OpenRouter", "https://openrouter.ai/settings/keys")
-    providers_table.add_row("Gemini", "https://aistudio.google.com/app/apikey")
-
-    console.print()
-    console.print(providers_table)
-    console.print()
-
-    if Confirm.ask(
-        "Set up a custom OpenAI-compatible provider instead?", default=False
-    ):
+    choice = _choose_first_run_auth()
+    if choice == "1":
+        return _setup_openai_subscription()
+    if choice == "3":
         return _setup_custom_provider()
 
+    _show_api_key_sources()
     # Save to config
     api_key, provider, env_var = _prompt_api_key()
     set_config_value(f"env.{env_var}", api_key)

--- a/gptme/llm/llm_grok_subscription.py
+++ b/gptme/llm/llm_grok_subscription.py
@@ -267,6 +267,134 @@ def _refresh_access_token(
     return auth
 
 
+def oauth_authenticate() -> SubscriptionAuth:
+    """Authenticate via xAI OAuth PKCE flow and return tokens.
+
+    If valid grok CLI tokens already exist (~/.grok/auth.json), they are
+    returned immediately without opening a browser.  Otherwise, the xAI
+    PKCE flow opens the user's browser and waits for the OAuth callback on
+    localhost:{OAUTH_CALLBACK_PORT}.
+    """
+    import base64
+    import hashlib
+    import http.server
+    import secrets
+    import threading
+    import time
+    import webbrowser
+    from urllib.parse import parse_qs, urlencode, urlparse
+
+    cli_auth = _load_grok_cli_tokens()
+    if cli_auth is not None and time.time() < cli_auth.expires_at - 300:
+        return cli_auth
+
+    code_verifier = secrets.token_urlsafe(32)
+    digest = hashlib.sha256(code_verifier.encode()).digest()
+    code_challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode()
+    state = secrets.token_urlsafe(16)
+    callback_url = f"http://localhost:{OAUTH_CALLBACK_PORT}/auth/callback"
+
+    auth_params = {
+        "client_id": OAUTH_CLIENT_ID,
+        "redirect_uri": callback_url,
+        "response_type": "code",
+        "scope": OAUTH_SCOPES,
+        "state": state,
+        "code_challenge": code_challenge,
+        "code_challenge_method": "S256",
+    }
+    auth_url = f"{OAUTH_AUTH_URL}?{urlencode(auth_params)}"
+
+    result: dict = {}
+
+    class _Handler(http.server.BaseHTTPRequestHandler):
+        def log_message(self, *args):
+            pass
+
+        def do_GET(self):
+            parsed = urlparse(self.path)
+            params = parse_qs(parsed.query)
+            received_state = params.get("state", [None])[0]
+            if received_state != state:
+                result["error"] = "Invalid state (possible CSRF)"
+                self._respond(400, "Security error: invalid state.")
+                return
+            if "code" in params:
+                result["code"] = params["code"][0]
+                self._respond(
+                    200, "Authentication successful. You can close this window."
+                )
+            elif "error" in params:
+                result["error"] = params.get("error_description", params["error"])[0]
+                self._respond(400, f"Error: {result['error']}")
+
+        def _respond(self, status: int, msg: str) -> None:
+            body = f"<html><body><p>{msg}</p></body></html>".encode()
+            self.send_response(status)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.end_headers()
+            self.wfile.write(body)
+
+    try:
+        server = http.server.HTTPServer(("127.0.0.1", OAUTH_CALLBACK_PORT), _Handler)
+        server.timeout = 120
+    except OSError as e:
+        raise RuntimeError(
+            f"Could not start callback server on port {OAUTH_CALLBACK_PORT}: {e}"
+        ) from e
+
+    logger.info("Opening browser for xAI authentication (url: %s)", auth_url)
+
+    def _open() -> None:
+        time.sleep(0.5)
+        webbrowser.open(auth_url)
+
+    threading.Thread(target=_open, daemon=True).start()
+
+    deadline = time.time() + 300
+    try:
+        while "code" not in result and "error" not in result:
+            if time.time() > deadline:
+                raise TimeoutError("xAI authentication timed out after 5 minutes.")
+            server.handle_request()
+    finally:
+        server.server_close()
+
+    if "error" in result:
+        raise RuntimeError(f"xAI authentication failed: {result['error']}")
+
+    token_resp = requests.post(
+        OAUTH_TOKEN_URL,
+        data={
+            "client_id": OAUTH_CLIENT_ID,
+            "grant_type": "authorization_code",
+            "code": result["code"],
+            "redirect_uri": callback_url,
+            "code_verifier": code_verifier,
+        },
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        timeout=30,
+    )
+    if token_resp.status_code != 200:
+        raise RuntimeError(
+            f"Token exchange failed: {token_resp.status_code} {token_resp.text[:200]}"
+        )
+    tokens = token_resp.json()
+    access_token = tokens.get("access_token")
+    if not access_token:
+        raise RuntimeError("No access token in xAI response")
+    refresh_token = tokens.get("refresh_token")
+    expires_in = tokens.get("expires_in", 21600)
+
+    auth = SubscriptionAuth(
+        access_token=access_token,
+        refresh_token=refresh_token,
+        expires_at=time.time() + expires_in,
+    )
+    _save_tokens(auth)
+    return auth
+
+
 def get_auth(timeout: float | tuple[float, float] = 30) -> SubscriptionAuth:
     """Get a valid access token, loading or refreshing as needed.
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1316,7 +1316,7 @@ class TestInitModelInteractive:
     @patch("gptme.init.get_model")
     @patch("gptme.init.init_llm")
     @patch("gptme.init.get_recommended_model", return_value="gpt-5")
-    @patch("gptme.init.ask_for_api_key", return_value=("openai/gpt-5", "sk-key"))
+    @patch("gptme.init.ask_for_api_key", return_value=("openai", "sk-key"))
     @patch("gptme.init.guess_provider_from_config", return_value=None)
     @patch("gptme.init.is_custom_provider", return_value=False)
     @patch("gptme.init.get_config")
@@ -1347,6 +1347,47 @@ class TestInitModelInteractive:
         init_model(model=None, interactive=True)
 
         mock_ask.assert_called_once()
+
+    @patch("gptme.init.set_default_model")
+    @patch("gptme.init.get_model")
+    @patch("gptme.init.init_llm")
+    @patch("gptme.init.get_recommended_model", return_value="gpt-5.6-sol")
+    @patch(
+        "gptme.init.ask_for_api_key",
+        return_value=("openai-subscription", "oauth"),
+    )
+    @patch("gptme.init.guess_provider_from_config", return_value=None)
+    @patch("gptme.init.is_custom_provider", return_value=False)
+    @patch("gptme.init.get_config")
+    @patch("gptme.init.console")
+    def test_interactive_accepts_subscription_auth(
+        self,
+        mock_console,
+        mock_config_fn,
+        mock_custom,
+        mock_guess,
+        mock_ask,
+        mock_recommend,
+        mock_init_llm,
+        mock_get_model,
+        mock_set_default,
+        dummy_model_meta,
+    ):
+        """First-run subscription auth should select its recommended model."""
+        from gptme.init import init_model
+
+        config = MagicMock()
+        config.user.models.default = None
+        config.chat = MagicMock(model=None)
+        config.get_env.return_value = None
+        mock_config_fn.return_value = config
+        mock_get_model.return_value = dummy_model_meta
+
+        init_model(model=None, interactive=True)
+
+        mock_ask.assert_called_once()
+        mock_recommend.assert_called_once_with("openai-subscription")
+        mock_init_llm.assert_called_once_with("openai-subscription")
 
     @patch("gptme.init.set_default_model")
     @patch("gptme.init.get_model")

--- a/tests/test_setup_completions.py
+++ b/tests/test_setup_completions.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock
 from gptme.cli.setup import (
     _choose_first_run_auth,
     _generate_click_completion,
+    _setup_grok_subscription,
     _setup_openai_subscription,
 )
 
@@ -49,6 +50,7 @@ def test_choose_first_run_auth_defaults_to_subscription(monkeypatch):
 
     assert _choose_first_run_auth() == "1"
     assert prompt.call_args.kwargs["default"] == "1"
+    assert "4" in prompt.call_args.kwargs["choices"]
 
 
 def test_setup_openai_subscription_persists_default_model(monkeypatch):
@@ -69,4 +71,23 @@ def test_setup_openai_subscription_persists_default_model(monkeypatch):
         "models.default", "openai-subscription/gpt-5.6-sol"
     )
     assert provider == "openai-subscription"
+    assert credential == "oauth"
+
+
+def test_setup_grok_subscription_persists_default_model(monkeypatch):
+    authenticate = MagicMock()
+    set_value = MagicMock()
+    monkeypatch.setattr(
+        "gptme.llm.llm_grok_subscription.oauth_authenticate", authenticate
+    )
+    monkeypatch.setattr("gptme.cli.setup.set_config_value", set_value)
+    monkeypatch.setattr(
+        "gptme.cli.setup.get_recommended_model", lambda _provider: "grok-4.5"
+    )
+
+    provider, credential = _setup_grok_subscription()
+
+    authenticate.assert_called_once_with()
+    set_value.assert_called_once_with("models.default", "grok-subscription/grok-4.5")
+    assert provider == "grok-subscription"
     assert credential == "oauth"

--- a/tests/test_setup_completions.py
+++ b/tests/test_setup_completions.py
@@ -1,6 +1,12 @@
-"""Tests for bash/zsh shell completion generation in setup."""
+"""Tests for setup helpers."""
 
-from gptme.cli.setup import _generate_click_completion
+from unittest.mock import MagicMock
+
+from gptme.cli.setup import (
+    _choose_first_run_auth,
+    _generate_click_completion,
+    _setup_openai_subscription,
+)
 
 
 def test_generate_bash_completion():
@@ -35,3 +41,32 @@ def test_generate_fish_completion():
     assert script is not None
     assert "_GPTME_COMPLETE" in script
     assert "gptme" in script
+
+
+def test_choose_first_run_auth_defaults_to_subscription(monkeypatch):
+    prompt = MagicMock(return_value="1")
+    monkeypatch.setattr("gptme.cli.setup.Prompt.ask", prompt)
+
+    assert _choose_first_run_auth() == "1"
+    assert prompt.call_args.kwargs["default"] == "1"
+
+
+def test_setup_openai_subscription_persists_default_model(monkeypatch):
+    authenticate = MagicMock()
+    set_value = MagicMock()
+    monkeypatch.setattr(
+        "gptme.llm.llm_openai_subscription.oauth_authenticate", authenticate
+    )
+    monkeypatch.setattr("gptme.cli.setup.set_config_value", set_value)
+    monkeypatch.setattr(
+        "gptme.cli.setup.get_recommended_model", lambda _provider: "gpt-5.6-sol"
+    )
+
+    provider, credential = _setup_openai_subscription()
+
+    authenticate.assert_called_once_with()
+    set_value.assert_called_once_with(
+        "models.default", "openai-subscription/gpt-5.6-sol"
+    )
+    assert provider == "openai-subscription"
+    assert credential == "oauth"


### PR DESCRIPTION
## Problem

A clean-room `pipx install gptme` followed by the documented first `gptme` invocation reaches a provider setup screen that only asks for an API key. ChatGPT Plus/Pro OAuth support already exists, but a new user has to discover `gptme-auth openai-subscription` in provider docs before they can use it.

## What changed

- Make first-run provider setup present three explicit paths: ChatGPT Plus/Pro browser sign-in, provider API key, or a custom OpenAI-compatible provider.
- Default the choice to ChatGPT subscription auth, which requires no separate API key.
- Reuse the existing OpenAI subscription OAuth flow and persist its recommended model in `[models].default` so the first chat continues immediately after login.
- Keep the existing API-key links and validation flow behind the API-key choice.

## Reproduction

In a clean `python:3.12-slim` container with a fresh `HOME` and no provider credentials:

```sh
python -m pip install pipx
python -m pipx install gptme
gptme
```

Before this PR, setup immediately displays an API-key table and asks for a custom provider or pasted key. The existing subscription path is absent.

## Verification

- `python -m pytest tests/test_setup_completions.py tests/test_init.py tests/test_llm_openai_subscription.py -q` — 112 passed
- `ruff check gptme/cli/setup.py tests/test_setup_completions.py tests/test_init.py`
- `mypy gptme/cli/setup.py`
- Stubbed first-run smoke check confirmed choice 1 calls OAuth and persists `openai-subscription/gpt-5.6-sol`.

## Scope

This does not change OAuth internals, API-key validation, non-interactive behavior, or add another onboarding command. It fixes discovery at the existing first-run prompt.
