### PR TITLE
fix(webui): tolerate legacy provider health responses

### DIFF
--- a/webui/src/stores/__tests__/providerHealth.test.ts
+++ b/webui/src/stores/__tests__/providerHealth.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from '@jest/globals';
+import { allProvidersDown } from '../providerHealth';
+
+describe('allProvidersDown', () => {
+  it('returns false when provider health data is absent', () => {
+    expect(allProvidersDown(null)).toBe(false);
+  });
+
+  it('returns false for an empty or legacy response shape', () => {
+    expect(allProvidersDown({ providers: {} })).toBe(false);
+    expect(allProvidersDown({} as never)).toBe(false);
+  });
+
+  it('returns true only when every reported provider is down', () => {
+    expect(
+      allProvidersDown({
+        providers: {
+          anthropic: { status: 'error', latency_ms: null, error: 'unavailable' },
+          openai: { status: 'error', latency_ms: null, error: 'unavailable' },
+        },
+      })
+    ).toBe(true);
+
+    expect(
+      allProvidersDown({
+        providers: {
+          anthropic: { status: 'error', latency_ms: null, error: 'unavailable' },
+          openai: { status: 'configured', latency_ms: null, error: null },
+        },
+      })
+    ).toBe(false);
+  });
+});

--- a/webui/src/stores/providerHealth.ts
+++ b/webui/src/stores/providerHealth.ts
@@ -35,8 +35,7 @@ export const providerHealth$ = observable<{
  * trigger a warning. The badge fires only when nothing is left but errors.
  */
 export function allProvidersDown(data: ProviderHealthResponse | null): boolean {
-  if (!data) return false;
-  const providers = Object.values(data.providers);
+  const providers = Object.values(data?.providers ?? {});
   if (providers.length === 0) return false;
   return providers.every((p) => p.status === 'error');
 }


### PR DESCRIPTION
## Summary

- make the provider-health warning selector tolerate legacy `{}` responses
- add focused tests for absent, empty, legacy, all-down, and partially-healthy data

## Why

The managed web UI can receive `{}` from `/api/v2/providers/health`. `allProvidersDown()` called `Object.values(data.providers)` unconditionally, which threw during render and replaced the chat page with the global error boundary.

This is visible in gptme-cloud Live E2E run [29821893176](https://github.com/gptme/gptme-cloud/actions/runs/29821893176): the real staging chat reached a healthy instance, received `200 {}` from provider health, then crashed with `TypeError: Cannot convert undefined or null to object` before a message could be submitted. The unrelated `external-sessions` 503 was graceful; the provider-health response shape caused the render failure.

## Verification

- `npm test -- --runInBand src/stores/__tests__/providerHealth.test.ts`
- `npm run typecheck`
- pre-commit web UI lint/typecheck hooks
