### PR TITLE
fix(webui): expose server URL validation inline

### DIFF
--- a/webui/src/components/ServerSelector.tsx
+++ b/webui/src/components/ServerSelector.tsx
@@ -75,6 +75,8 @@ export const ServerSelector: FC = () => {
   const isAutoConnecting = use$(isAutoConnecting$);
 
   const [addDialogOpen, setAddDialogOpen] = useState(false);
+  const [urlError, setUrlError] = useState<string | null>(null);
+  const urlInputRef = useRef<HTMLInputElement>(null);
   const [formState, setFormState] = useState({
     name: '',
     baseUrl: '',
@@ -185,7 +187,10 @@ export const ServerSelector: FC = () => {
 
   const handleAdd = async () => {
     if (!formState.baseUrl.trim()) {
-      toast.error('Server URL is required');
+      const message = 'Server URL is required';
+      setUrlError(message);
+      urlInputRef.current?.focus();
+      toast.error(message);
       return;
     }
 
@@ -263,7 +268,11 @@ export const ServerSelector: FC = () => {
                     variant="ghost"
                     size="icon"
                     className="h-6 w-6"
-                    onClick={() => setAddDialogOpen(true)}
+                    aria-label="Add server"
+                    onClick={() => {
+                      setUrlError(null);
+                      setAddDialogOpen(true);
+                    }}
                   >
                     <Plus className="h-3.5 w-3.5" />
                   </Button>
@@ -415,11 +424,22 @@ export const ServerSelector: FC = () => {
             <div className="space-y-2">
               <Label htmlFor="server-url">Server URL</Label>
               <Input
+                ref={urlInputRef}
                 id="server-url"
                 value={formState.baseUrl}
-                onChange={(e) => setFormState((prev) => ({ ...prev, baseUrl: e.target.value }))}
+                onChange={(e) => {
+                  setFormState((prev) => ({ ...prev, baseUrl: e.target.value }));
+                  if (e.target.value.trim()) setUrlError(null);
+                }}
                 placeholder="http://127.0.0.1:5700"
+                aria-invalid={urlError ? true : undefined}
+                aria-describedby={urlError ? 'server-url-error' : undefined}
               />
+              {urlError && (
+                <p id="server-url-error" className="text-sm text-destructive">
+                  {urlError}
+                </p>
+              )}
             </div>
             <div className="flex items-center space-x-2">
               <Checkbox

--- a/webui/src/components/__tests__/ServerSelector.test.tsx
+++ b/webui/src/components/__tests__/ServerSelector.test.tsx
@@ -1,5 +1,6 @@
 import '@testing-library/jest-dom';
-import { render } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { isDefaultPreset } from '../ServerSelector';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import type { ServerConfig, ServerRegistry } from '@/types/servers';
@@ -250,18 +251,39 @@ describe('ServerSelector in embedded (hosted) mode', () => {
 });
 
 describe('ServerSelector in non-embedded mode', () => {
-  it('renders normally (shows Local server)', () => {
+  beforeEach(() => {
     mockIsEmbedded = false;
     mockRegistry = {
       servers: [LOCAL_PRESET],
       activeServerId: 'local',
       connectedServerIds: ['local'],
     };
+  });
+
+  it('renders normally (shows Local server)', () => {
     const { container } = render(
       <TooltipProvider>
         <ServerSelector />
       </TooltipProvider>
     );
     expect(container.firstChild).not.toBeNull();
+  });
+
+  it('focuses and marks the server URL invalid when submitted empty', async () => {
+    const user = userEvent.setup();
+    render(
+      <TooltipProvider>
+        <ServerSelector />
+      </TooltipProvider>
+    );
+
+    await user.click(screen.getByText('Local'));
+    await user.click(await screen.findByRole('button', { name: 'Add server' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Add & Connect' }));
+
+    const urlInput = screen.getByRole('textbox', { name: 'Server URL' });
+    await waitFor(() => expect(urlInput).toHaveFocus());
+    expect(urlInput).toHaveAttribute('aria-invalid', 'true');
+    expect(urlInput).toHaveAccessibleDescription('Server URL is required');
   });
 });

--- a/webui/src/components/settings/ServerConfiguration.tsx
+++ b/webui/src/components/settings/ServerConfiguration.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import type { FC } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -83,6 +83,8 @@ export const ServerConfiguration: FC = () => {
   const registry = use$(serverRegistry$);
 
   const [editDialogOpen, setEditDialogOpen] = useState(false);
+  const [urlError, setUrlError] = useState<string | null>(null);
+  const urlInputRef = useRef<HTMLInputElement>(null);
   const [editingServerId, setEditingServerId] = useState<string | null>(null);
   const [formState, setFormState] = useState<ServerFormState>(emptyForm);
   const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null);
@@ -147,18 +149,23 @@ export const ServerConfiguration: FC = () => {
   const handleOpenAdd = () => {
     setEditingServerId(null);
     setFormState(emptyForm);
+    setUrlError(null);
     setEditDialogOpen(true);
   };
 
   const handleOpenEdit = (server: ServerConfig) => {
     setEditingServerId(server.id);
     setFormState(serverToForm(server));
+    setUrlError(null);
     setEditDialogOpen(true);
   };
 
   const handleSave = async () => {
     if (!formState.baseUrl.trim()) {
-      toast.error('Server URL is required');
+      const message = 'Server URL is required';
+      setUrlError(message);
+      urlInputRef.current?.focus();
+      toast.error(message);
       return;
     }
 
@@ -484,11 +491,22 @@ export const ServerConfiguration: FC = () => {
             <div className="space-y-2">
               <Label htmlFor="edit-server-url">Server URL</Label>
               <Input
+                ref={urlInputRef}
                 id="edit-server-url"
                 value={formState.baseUrl}
-                onChange={(e) => setFormState((prev) => ({ ...prev, baseUrl: e.target.value }))}
+                onChange={(e) => {
+                  setFormState((prev) => ({ ...prev, baseUrl: e.target.value }));
+                  if (e.target.value.trim()) setUrlError(null);
+                }}
                 placeholder="http://127.0.0.1:5700"
+                aria-invalid={urlError ? true : undefined}
+                aria-describedby={urlError ? 'edit-server-url-error' : undefined}
               />
+              {urlError && (
+                <p id="edit-server-url-error" className="text-sm text-destructive">
+                  {urlError}
+                </p>
+              )}
             </div>
             <div className="flex items-center space-x-2">
               <Checkbox

--- a/webui/src/components/settings/__tests__/ServerConfiguration.test.tsx
+++ b/webui/src/components/settings/__tests__/ServerConfiguration.test.tsx
@@ -1,0 +1,78 @@
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ServerConfiguration } from '../ServerConfiguration';
+import { TooltipProvider } from '@/components/ui/tooltip';
+
+const mockRegistry = {
+  servers: [
+    {
+      id: 'local',
+      name: 'Local',
+      baseUrl: 'http://127.0.0.1:5700',
+      authToken: null,
+      useAuthToken: false,
+      isPreset: true,
+      createdAt: 1,
+      lastUsedAt: 1,
+    },
+  ],
+  activeServerId: 'local',
+  connectedServerIds: ['local'],
+};
+
+jest.mock('@/contexts/ApiContext', () => ({
+  useApi: () => ({
+    connect: jest.fn(),
+    switchServer: jest.fn(() => Promise.resolve()),
+  }),
+}));
+
+jest.mock('@/hooks/useUserSettings', () => ({
+  useUserSettings: () => ({ settings: null }),
+}));
+
+jest.mock('@/stores/servers', () => ({
+  serverRegistry$: { get: () => mockRegistry },
+  addServer: jest.fn(),
+  updateServer: jest.fn(),
+  removeServer: jest.fn(),
+  connectServer: jest.fn(),
+  disconnectServer: jest.fn(),
+}));
+
+jest.mock('@/stores/serverClients', () => ({
+  getClientForServer: jest.fn(() => null),
+}));
+
+jest.mock('@legendapp/state/react', () => ({
+  use$: (obs: { get: () => unknown } | null) => (obs ? obs.get() : null),
+}));
+
+jest.mock('../ConfigFileEditor', () => ({ ConfigFileEditor: () => null }));
+jest.mock('../ServerDefaultModelSettings', () => ({ ServerDefaultModelSettings: () => null }));
+jest.mock('../ServerApiKeySettings', () => ({ ServerApiKeySettings: () => null }));
+jest.mock('../ServerProviderHealthSettings', () => ({ ServerProviderHealthSettings: () => null }));
+
+jest.mock('sonner', () => ({
+  toast: { success: jest.fn(), error: jest.fn() },
+}));
+
+describe('ServerConfiguration', () => {
+  it('focuses and marks the server URL invalid when submitted empty', async () => {
+    const user = userEvent.setup();
+    render(
+      <TooltipProvider>
+        <ServerConfiguration />
+      </TooltipProvider>
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Add Server' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Add & Connect' }));
+
+    const urlInput = screen.getByRole('textbox', { name: 'Server URL' });
+    await waitFor(() => expect(urlInput).toHaveFocus());
+    expect(urlInput).toHaveAttribute('aria-invalid', 'true');
+    expect(urlInput).toHaveAccessibleDescription('Server URL is required');
+  });
+});


### PR DESCRIPTION
## Problem

The live `chat.gptme.org` Add Server flow reports an empty required URL only through a transient toast. The URL field is not focused, marked invalid, or associated with the message, so keyboard and assistive-technology users cannot locate the failing control reliably.

## Changes

- render the required-URL error directly below the URL input in both Add Server entry points
- set `aria-invalid` and `aria-describedby`, then focus the URL input on failed submit
- clear the validation state once a non-empty URL is entered
- give the compact selector's icon-only Add server button an accessible name
- add regression tests for both entry points

## Live reproduction

On `https://chat.gptme.org/?demo=1`:

1. Settings → Servers → Add Server
2. Enter a name but leave Server URL empty
3. Click **Add & Connect**
4. Observed: toast `Server URL is required`; `aria-invalid` and `aria-describedby` absent; focus remains on the submit button

The same gap was observed previously on 2026-06-20, so this is persistent rather than transient.

## Verification

- `ServerSelector.test.tsx`: 17/17 passing
- `ServerConfiguration.test.tsx`: 1/1 passing
- `npm run typecheck`
- `npm run lint` (0 errors; existing warnings only)
- scoped pre-commit hooks passed
