### PR TITLE
fix(acp): complete tool-driven prompt turns

### DIFF
--- a/gptme/acp/agent.py
+++ b/gptme/acp/agent.py
@@ -1086,8 +1086,10 @@ class GptmeAgent:
         # the exception handler (including early import/setup failures).
         batch_buffer: list[str] = []
         try:
-            # Import chat step
+            # Import chat step and lifecycle-hook helpers
             from ..chat import step as chat_step
+            from ..hooks.registry import HookType, trigger_hook
+            from ..message import Message as _RuntimeMessage
 
             # Run gptme chat step in executor to not block event loop
             loop = asyncio.get_running_loop()
@@ -1163,8 +1165,13 @@ class GptmeAgent:
                 ) and (now - last_attempt[0]) >= FLUSH_INTERVAL:
                     _flush_batch()
 
-            def run_chat_turn() -> list[Message]:
-                """Run every generation/tool step in one ACP prompt turn."""
+            def run_chat_turn() -> tuple[list[Message], str]:
+                """Run every generation/tool step in one ACP prompt turn.
+
+                Returns (response_msgs, stop_reason) where stop_reason is
+                "end_turn" for normal completion or "max_steps" when the
+                GPTME_MAX_STEPS cap was reached mid-turn.
+                """
                 # The interactive chat loop keeps stepping after a runnable tool
                 # call so the model can inspect its result and finish the turn.
                 # ACP has no outer gptme loop, so reproduce that behavior here.
@@ -1183,6 +1190,14 @@ class GptmeAgent:
 
                 step_count = 0
                 while True:
+                    # Fire STEP_PRE hooks so hook-managed state (working
+                    # directory, injected context) is current before each LLM
+                    # generation.  Matches the behaviour of gptme's interactive
+                    # chat loop in gptme/chat.py.
+                    if pre_msgs := list(trigger_hook(HookType.STEP_PRE, manager=log)):
+                        step_log.extend(pre_msgs)
+                        response_msgs.extend(pre_msgs)
+
                     step_msgs = list(
                         chat_step(
                             log=step_log,
@@ -1203,7 +1218,16 @@ class GptmeAgent:
                             "ACP prompt reached GPTME_MAX_STEPS=%d; ending turn",
                             max_steps,
                         )
-                        break
+                        # Record the cap in the conversation so ACP clients and
+                        # log consumers can distinguish a capped, incomplete turn
+                        # from a normal completion (mirrors gptme/chat.py behaviour).
+                        cap_msg = _RuntimeMessage(
+                            "system",
+                            f"Stopped: reached max steps limit ({max_steps})",
+                        )
+                        step_log.append(cap_msg)
+                        response_msgs.append(cap_msg)
+                        return response_msgs, "max_steps"
 
                     assistant_content = next(
                         (
@@ -1220,12 +1244,14 @@ class GptmeAgent:
                         )
                     ):
                         break
-                return response_msgs
+                return response_msgs, "end_turn"
 
             # Copy context to propagate ContextVars (model, config, tools, etc.)
             # to the executor thread — run_in_executor doesn't do this by default
             ctx = contextvars.copy_context()
-            response_msgs = await loop.run_in_executor(None, ctx.run, run_chat_turn)
+            response_msgs, chat_stop_reason = await loop.run_in_executor(
+                None, ctx.run, run_chat_turn
+            )
 
             # Final flush: send any remaining buffered tokens
             if batch_buffer and self._conn:
@@ -1266,7 +1292,7 @@ class GptmeAgent:
                     log.append(response_msg)
 
             _PromptResponse = _check_acp_import(PromptResponse, "PromptResponse")
-            return _PromptResponse(stop_reason="end_turn")
+            return _PromptResponse(stop_reason=chat_stop_reason)
 
         except Exception as e:
             logger.exception("Error processing prompt: %s", e)

--- a/gptme/acp/agent.py
+++ b/gptme/acp/agent.py
@@ -10,6 +10,7 @@ import asyncio
 import contextvars
 import hashlib
 import logging
+import os
 import time
 from datetime import datetime, timezone
 from pathlib import Path
@@ -22,7 +23,7 @@ from ..llm.models import get_default_model, set_default_model
 from ..logmanager import LogManager, list_conversations
 from ..prompts import get_prompt
 from ..session import SessionRegistry
-from ..tools import get_tools, set_tools
+from ..tools import ToolUse, get_tools, set_tools
 from ..util.auto_naming import generate_conversation_id
 from ..util.context import md_codeblock
 from .adapter import acp_content_to_gptme_message, gptme_message_to_acp_content
@@ -1162,23 +1163,69 @@ class GptmeAgent:
                 ) and (now - last_attempt[0]) >= FLUSH_INTERVAL:
                     _flush_batch()
 
-            def run_chat_step() -> list[Message]:
-                """Run chat step synchronously with per-token streaming."""
-                # Note: confirmation is now handled via the hook system
-                return list(
-                    chat_step(
-                        log=log.log,
-                        stream=True,
-                        tool_format="markdown",
-                        model=effective_model,
-                        on_token=on_token,
+            def run_chat_turn() -> list[Message]:
+                """Run every generation/tool step in one ACP prompt turn."""
+                # The interactive chat loop keeps stepping after a runnable tool
+                # call so the model can inspect its result and finish the turn.
+                # ACP has no outer gptme loop, so reproduce that behavior here.
+                response_msgs: list[Message] = []
+                step_log = list(log.log)
+                max_steps: int | None = None
+                max_steps_str = os.environ.get("GPTME_MAX_STEPS")
+                if max_steps_str:
+                    try:
+                        max_steps = int(max_steps_str)
+                    except ValueError:
+                        logger.warning(
+                            "Invalid GPTME_MAX_STEPS value %r, ignoring",
+                            max_steps_str,
+                        )
+
+                step_count = 0
+                while True:
+                    step_msgs = list(
+                        chat_step(
+                            log=step_log,
+                            stream=True,
+                            tool_format="markdown",
+                            workspace=log.workspace,
+                            model=effective_model,
+                            on_token=on_token,
+                            logdir=log.logdir,
+                        )
                     )
-                )
+                    response_msgs.extend(step_msgs)
+                    step_log.extend(step_msgs)
+                    step_count += 1
+
+                    if max_steps is not None and step_count >= max_steps:
+                        logger.warning(
+                            "ACP prompt reached GPTME_MAX_STEPS=%d; ending turn",
+                            max_steps,
+                        )
+                        break
+
+                    assistant_content = next(
+                        (
+                            item.content
+                            for item in reversed(step_msgs)
+                            if item.role == "assistant"
+                        ),
+                        "",
+                    )
+                    if not any(
+                        tool_use.is_runnable
+                        for tool_use in ToolUse.iter_from_content(
+                            assistant_content, tool_format_override="markdown"
+                        )
+                    ):
+                        break
+                return response_msgs
 
             # Copy context to propagate ContextVars (model, config, tools, etc.)
             # to the executor thread — run_in_executor doesn't do this by default
             ctx = contextvars.copy_context()
-            response_msgs = await loop.run_in_executor(None, ctx.run, run_chat_step)
+            response_msgs = await loop.run_in_executor(None, ctx.run, run_chat_turn)
 
             # Final flush: send any remaining buffered tokens
             if batch_buffer and self._conn:

--- a/tests/test_acp_agent.py
+++ b/tests/test_acp_agent.py
@@ -1411,6 +1411,117 @@ class TestCwdSessionId:
         assert all(c in "0123456789abcdef" for c in hash_part)
 
 
+class TestPromptTurnLoop:
+    """Regression tests for complete ACP prompt-turn execution."""
+
+    def test_prompt_continues_after_tool_result(self, monkeypatch):
+        """A tool call must be followed by another model step in the same turn."""
+        if not _import_acp():
+            pytest.skip("acp not installed")
+
+        from gptme.message import Message
+
+        agent = GptmeAgent()
+        agent._conn = MagicMock()
+        agent._conn.session_update = AsyncMock()
+        agent._session_commands_advertised.add("s1")
+        agent._session_models["s1"] = "openai/gpt-4o-mini"
+
+        log = _make_mock_log()
+        log.log = []
+        log.workspace = None
+        log.logdir = None
+        agent._registry.create("s1", log=log)
+
+        calls: list[list[Message]] = []
+
+        def fake_step(log, **kwargs):
+            calls.append(list(log))
+            if len(calls) == 1:
+                return iter(
+                    [
+                        Message(
+                            "assistant",
+                            "```save scratch.txt\nhello\n```",
+                        ),
+                        Message("system", "Saved to scratch.txt"),
+                    ]
+                )
+            return iter([Message("assistant", "Done")])
+
+        import importlib
+
+        chat_module = importlib.import_module("gptme.chat")
+        monkeypatch.setattr(chat_module, "step", fake_step)
+
+        result = _run(
+            agent.prompt(
+                prompt=[{"type": "text", "text": "create scratch.txt"}],
+                session_id="s1",
+            )
+        )
+
+        assert result.stop_reason == "end_turn"
+        assert len(calls) == 2
+        assert [message.content for message in calls[1][-2:]] == [
+            "```save scratch.txt\nhello\n```",
+            "Saved to scratch.txt",
+        ]
+        assert [call.args[0].content for call in log.append.call_args_list] == [
+            "create scratch.txt",
+            "```save scratch.txt\nhello\n```",
+            "Saved to scratch.txt",
+            "Done",
+        ]
+
+    def test_prompt_respects_max_steps(self, monkeypatch):
+        """ACP prompt loops must honor the same step cap as interactive chat."""
+        if not _import_acp():
+            pytest.skip("acp not installed")
+
+        import importlib
+
+        from gptme.message import Message
+
+        agent = GptmeAgent()
+        agent._conn = MagicMock()
+        agent._conn.session_update = AsyncMock()
+        agent._session_commands_advertised.add("s1")
+        agent._session_models["s1"] = "openai/gpt-4o-mini"
+
+        log = _make_mock_log()
+        log.log = []
+        log.workspace = None
+        log.logdir = None
+        agent._registry.create("s1", log=log)
+
+        calls = 0
+
+        def fake_step(log, **kwargs):
+            nonlocal calls
+            calls += 1
+            return iter(
+                [
+                    Message("assistant", "```save scratch.txt\nhello\n```"),
+                    Message("system", "Saved to scratch.txt"),
+                ]
+            )
+
+        chat_module = importlib.import_module("gptme.chat")
+        monkeypatch.setattr(chat_module, "step", fake_step)
+        monkeypatch.setenv("GPTME_MAX_STEPS", "2")
+
+        result = _run(
+            agent.prompt(
+                prompt=[{"type": "text", "text": "create scratch.txt"}],
+                session_id="s1",
+            )
+        )
+
+        assert result.stop_reason == "end_turn"
+        assert calls == 2
+
+
 class TestPromptErrorHandling:
     """Regression tests for prompt() error-path robustness."""
 

--- a/tests/test_acp_agent.py
+++ b/tests/test_acp_agent.py
@@ -1518,7 +1518,7 @@ class TestPromptTurnLoop:
             )
         )
 
-        assert result.stop_reason == "end_turn"
+        assert result.stop_reason == "max_steps"
         assert calls == 2
 
 


### PR DESCRIPTION
## Problem

When an ACP agent receives a prompt, the current implementation only runs a single `chat_step`. If the model responds with a tool call, that tool call executes but the model never sees the result — the turn ends immediately without the follow-up generation step that gptme's interactive loop provides.

This means tool-using prompts silently produce incomplete results: the tool fires, but the model's synthesis of the result (which is usually the actual answer) is never generated or returned to the ACP caller.

## Fix

Rename `run_chat_step` → `run_chat_turn` and add an inner loop that keeps stepping while the last assistant message contains runnable tool calls. The loop terminates when:

1. The assistant produces a response with no pending tool calls (normal completion), or
2. `GPTME_MAX_STEPS` steps have been reached (safety cap, default: no limit)

This matches what gptme's interactive `main.py` loop does for every user turn.

## Changes

- `gptme/acp/agent.py`: `run_chat_step` → `run_chat_turn` with step loop
- `tests/test_acp_agent.py`: Two new tests
  - `test_prompt_runs_complete_tool_turn` — verifies tool call + follow-up generation happen in a single `run()` call
  - `test_prompt_respects_max_steps` — verifies `GPTME_MAX_STEPS=1` terminates after the tool-call step

## Test plan

- [ ] `pytest tests/test_acp_agent.py -v` passes
- [ ] Existing ACP tests unaffected