### PR TITLE
fix(test): wait for input prompt before asserting scrollback order in inline test

### DIFF
--- a/tests/test_tui_e2e.py
+++ b/tests/test_tui_e2e.py
@@ -445,7 +445,11 @@ class TestTmuxInlineMode:
         tui.wait_ready()
         tui.send("hello inline")
         tui.send_key("Enter")
-        pane = tui.wait_for("Echo: hello inline")
+        tui.wait_for("Echo: hello inline")
+        # Wait for both the echo AND the input prompt to be visible together —
+        # captures taken the moment "Echo:" appears can race before the prompt
+        # re-renders, causing ValueError from str.index().
+        pane = tui.wait_for("Type a message")
         assert_no_escape_garbage(pane)
         # transcript lines are plain terminal output (native scrollback), so
         # they appear above the live region which contains the input


### PR DESCRIPTION
## Summary

- `test_inline_prints_to_scrollback` captured the tmux pane the moment `"Echo: hello inline"` appeared, before `"Type a message"` (the input prompt) had re-rendered in `--inline` mode
- This caused `pane.index("Type a message")` to raise `ValueError: substring not found` on attempt 1
- On retry attempt 2 the timing worked out; but the retry triggered the known pytest-retry × tmp_path StashKey teardown issue (#3256), keeping CI red

## Fix

Added a second `wait_for("Type a message")` call after the echo check, so the snapshot is taken only once both strings are present in the pane — eliminating the timing race.

## Context

Identified while investigating the CI failure on #3283 (dependabot bump) where Erik asked whether #3256 should have fixed the red CI. #3256's teardown guard should have suppressed the artifact, but the underlying test flakiness was still driving the retry that triggered it. This PR addresses the root cause.