### PR TITLE
fix(acp): use max_turn_requests stop_reason when GPTME_MAX_STEPS reached

### DIFF
--- a/gptme/acp/agent.py
+++ b/gptme/acp/agent.py
@@ -1169,7 +1169,7 @@ class GptmeAgent:
                 """Run every generation/tool step in one ACP prompt turn.
 
                 Returns (response_msgs, stop_reason) where stop_reason is
-                "end_turn" for normal completion or "max_steps" when the
+                "end_turn" for normal completion or "max_turn_requests" when the
                 GPTME_MAX_STEPS cap was reached mid-turn.
                 """
                 # The interactive chat loop keeps stepping after a runnable tool
@@ -1227,7 +1227,12 @@ class GptmeAgent:
                         )
                         step_log.append(cap_msg)
                         response_msgs.append(cap_msg)
-                        return response_msgs, "max_steps"
+                        # Use "max_turn_requests" — the ACP protocol's stop reason
+                        # for a turn cut short by a per-turn request/step cap.
+                        # "max_steps" is not a valid ACP PromptResponse stop_reason;
+                        # passing it triggers a Pydantic ValidationError caught by the
+                        # exception handler, which then returns stop_reason="cancelled".
+                        return response_msgs, "max_turn_requests"
 
                     assistant_content = next(
                         (

--- a/tests/test_acp_agent.py
+++ b/tests/test_acp_agent.py
@@ -1518,7 +1518,7 @@ class TestPromptTurnLoop:
             )
         )
 
-        assert result.stop_reason == "max_steps"
+        assert result.stop_reason == "max_turn_requests"
         assert calls == 2
 
 


### PR DESCRIPTION
## Summary

- `run_chat_turn` was returning `"max_steps"` as the stop reason when `GPTME_MAX_STEPS` was hit
- `"max_steps"` is not a valid ACP `PromptResponse` stop_reason — only `end_turn`, `max_tokens`, `max_turn_requests`, `refusal`, `cancelled` are accepted
- Pydantic raised a `ValidationError`, which the `except Exception` handler caught, returning `stop_reason="cancelled"` instead
- Fix: use `"max_turn_requests"` (the correct ACP stop reason for a turn cut short by a per-turn step cap) and update the test assertion to match

Fixes regression in `test_prompt_respects_max_steps` introduced by #3300, which has been red on master since `a3b12126`.

## Test plan

- `tests/test_acp_agent.py::TestPromptTurnLoop::test_prompt_respects_max_steps` should now pass consistently (no longer returns `"cancelled"` due to Pydantic error)
- All other `TestPromptTurnLoop` tests unaffected