### PR TITLE
feat(tui): add experimental jelly error feedback

### DIFF
--- a/gptme/tui/app.py
+++ b/gptme/tui/app.py
@@ -125,6 +125,43 @@ class InfoMessage(Static):
         super().__init__(Text(content), classes="info" + (" error" if error else ""))
 
 
+class BouncingError(Static):
+    """An opt-in error line that briefly draws attention to recovery hints."""
+
+    DEFAULT_CSS = """
+    BouncingError {
+        border-left: tall $error;
+        color: $error;
+        padding: 0 1;
+    }
+    """
+
+    def __init__(self, content: str):
+        super().__init__(Text(content), classes="info error")
+        self.content = content
+
+    def on_mount(self) -> None:
+        self.styles.animate("background", "#ff6600", duration=0.1)
+        self.set_timer(
+            0.1,
+            lambda: self.styles.animate("background", "transparent", duration=0.2),
+        )
+        self.styles.animate("opacity", 0.7, duration=0.06)
+        self.set_timer(
+            0.06,
+            lambda: self.styles.animate("opacity", 1.0, duration=0.18),
+        )
+        self.set_timer(0.3, self._show_recovery)
+
+    def _show_recovery(self) -> None:
+        self.update(
+            Text.from_markup(
+                f"{self.content}\\n[dim]Recovery:[/dim] edit the command and resubmit, "
+                "or retry the action."
+            )
+        )
+
+
 def renderables_for_message(msg: Message, expanded: bool = False) -> list:
     """Rich renderables for a message, for native-scrollback (inline) mode."""
     from rich.markdown import Markdown as RichMarkdown
@@ -417,6 +454,7 @@ class GptmeApp(App):
         workspace: Path | None = None,
         auto_confirm: bool = False,
         inline: bool = False,
+        experimental_jelly_errors: bool = False,
     ):
         super().__init__()
         self.manager = manager
@@ -424,6 +462,7 @@ class GptmeApp(App):
         self.workspace = workspace or manager.workspace
         self.auto_confirm = auto_confirm
         self.inline = inline
+        self.experimental_jelly_errors = experimental_jelly_errors
         self._stream_text = ""
         # Snapshot the caller's context (default model, output format, …) so
         # worker threads see it — gptme stores this state in ContextVars,
@@ -596,7 +635,12 @@ class GptmeApp(App):
         if self.inline:
             self._print_above(Text(text, style="red" if error else "bright_black"))
             return
-        self._mount_in_chat(InfoMessage(text, error=error))
+        widget: Widget
+        if error and self.experimental_jelly_errors:
+            widget = BouncingError(text)
+        else:
+            widget = InfoMessage(text, error=error)
+        self._mount_in_chat(widget)
 
     def _mount_in_chat(self, widget: Widget) -> None:
         chat = self.query_one("#chat", VerticalScroll)

--- a/gptme/tui/app.py
+++ b/gptme/tui/app.py
@@ -16,6 +16,7 @@ import threading
 from pathlib import Path
 from typing import IO, cast
 
+from rich.markup import escape as markup_escape
 from rich.syntax import Syntax
 from rich.text import Text
 from textual import events
@@ -138,7 +139,7 @@ class BouncingError(Static):
 
     def __init__(self, content: str):
         super().__init__(Text(content), classes="info error")
-        self.content = content
+        self.error_text = content
 
     def on_mount(self) -> None:
         self.styles.animate("background", "#ff6600", duration=0.1)
@@ -156,7 +157,7 @@ class BouncingError(Static):
     def _show_recovery(self) -> None:
         self.update(
             Text.from_markup(
-                f"{self.content}\\n[dim]Recovery:[/dim] edit the command and resubmit, "
+                f"{markup_escape(self.error_text)}\\n[dim]Recovery:[/dim] edit the command and resubmit, "
                 "or retry the action."
             )
         )

--- a/gptme/tui/main.py
+++ b/gptme/tui/main.py
@@ -95,6 +95,11 @@ def _print_history(manager: LogManager, limit: int = 50) -> None:
     "messages into the terminal's native scrollback (tmux/terminal scrolling "
     "works normally, like Claude Code).",
 )
+@click.option(
+    "--experimental-jelly-errors",
+    is_flag=True,
+    help="Animate TUI error messages and show recovery hints.",
+)
 @click.option("-v", "--verbose", is_flag=True, help="Enable verbose logging.")
 def main(
     name: str,
@@ -105,6 +110,7 @@ def main(
     tool_format: str | None,
     no_confirm: bool,
     inline: bool,
+    experimental_jelly_errors: bool,
     verbose: bool,
 ) -> None:
     """gptme TUI — interactive terminal UI for gptme.
@@ -180,6 +186,7 @@ def main(
         workspace=workspace_path,
         auto_confirm=no_confirm,
         inline=inline,
+        experimental_jelly_errors=experimental_jelly_errors,
     )
     if inline:
         _print_history(manager)

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -111,8 +111,15 @@ async def test_experimental_jelly_errors_show_recovery_hints(tmp_path):
     app = GptmeApp(make_manager(tmp_path), experimental_jelly_errors=True)
     async with app.run_test() as pilot:
         app._show_info("Command failed", error=True)
-        await pilot.pause(0.35)
-        error = app.query_one(BouncingError)
+        # Poll until the recovery hint appears (callback fires after ~0.3s).
+        # A fixed wait races on busy runners; polling converges faster and reliably.
+        for _ in range(40):
+            await pilot.pause(0.025)
+            error = app.query_one(BouncingError)
+            if "Recovery:" in str(error.render()):
+                break
+        else:
+            pytest.fail("Recovery hint did not appear within 1s")
         rendered = error.render()
         assert "Recovery:" in str(rendered)
         assert "retry" in str(rendered)

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -10,6 +10,7 @@ from gptme.logmanager import LogManager
 from gptme.message import Message
 from gptme.tui.app import (
     AssistantMessage,
+    BouncingError,
     ChatInput,
     GptmeApp,
     InfoMessage,
@@ -103,6 +104,28 @@ async def test_slash_command_help(tmp_path):
         await pilot.pause()
         infos = list(app.query(InfoMessage))
         assert infos, "expected /help output to be shown"
+
+
+@pytest.mark.asyncio
+async def test_experimental_jelly_errors_show_recovery_hints(tmp_path):
+    app = GptmeApp(make_manager(tmp_path), experimental_jelly_errors=True)
+    async with app.run_test() as pilot:
+        app._show_info("Command failed", error=True)
+        await pilot.pause(0.35)
+        error = app.query_one(BouncingError)
+        rendered = error.render()
+        assert "Recovery:" in str(rendered)
+        assert "retry" in str(rendered)
+
+
+@pytest.mark.asyncio
+async def test_jelly_errors_are_disabled_by_default(tmp_path):
+    app = GptmeApp(make_manager(tmp_path))
+    async with app.run_test() as pilot:
+        app._show_info("Command failed", error=True)
+        await pilot.pause()
+        assert not app.query(BouncingError)
+        assert app.query_one(InfoMessage).has_class("error")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- add opt-in `--experimental-jelly-errors` for the Textual TUI
- pulse tool-error messages, then surface honest recovery hints
- cover enabled and default-disabled behaviour in TUI tests

## Verification

- `uv run --extra tui --with pytest --with pytest-asyncio --with requests pytest tests/test_tui.py -q`
- `uv run --extra tui ruff check gptme/tui/app.py gptme/tui/main.py tests/test_tui.py`
- pre-commit hooks