### PR TITLE
feat(auth): add OpenRouter OAuth and gptme.ai device-connect to first-run setup

### DIFF
--- a/gptme/cli/auth.py
+++ b/gptme/cli/auth.py
@@ -494,5 +494,49 @@ def auth_grok_subscription():
     )
 
 
+@main.command("openrouter")
+def auth_openrouter():
+    """Authenticate with OpenRouter via PKCE OAuth and store a permanent API key.
+
+    Opens a browser so you can sign in to openrouter.ai.  After successful
+    sign-in, a permanent API key (``sk-or-v1-…``) is exchanged and saved to
+    the gptme config as ``env.OPENROUTER_API_KEY``.
+
+    You can then use any model on OpenRouter::
+
+        gptme --model openrouter/anthropic/claude-sonnet-4-6 "Hello"
+    """
+    try:
+        from ..llm.llm_openrouter_subscription import oauth_get_api_key
+    except ImportError as exc:
+        console.print(f"[red]✗ Could not import OpenRouter OAuth module: {exc}[/red]")
+        sys.exit(1)
+
+    console.print("\n[bold]OpenRouter Authentication[/bold]\n")
+    console.print("This will open your browser to sign in to openrouter.ai.")
+    console.print(
+        "After sign-in, a permanent API key will be created and saved to your"
+        " gptme config.\n"
+    )
+
+    try:
+        api_key = oauth_get_api_key()
+    except RuntimeError as exc:
+        console.print(f"\n[red bold]✗ Authentication failed: {exc}[/red bold]")
+        sys.exit(1)
+
+    # Persist to config
+    from ..config import set_config_value
+
+    set_config_value("env.OPENROUTER_API_KEY", api_key)
+
+    console.print("\n[green bold]✓ Authentication successful![/green bold]")
+    console.print(f"  API key saved to config (key: {api_key[:16]}…)")
+    console.print(
+        "\nYou can now use any OpenRouter model, for example:\n"
+        "  [cyan]gptme --model openrouter/anthropic/claude-sonnet-4-6 'Hello'[/cyan]"
+    )
+
+
 if __name__ == "__main__":
     main()

--- a/gptme/cli/auth.py
+++ b/gptme/cli/auth.py
@@ -528,7 +528,7 @@ def auth_openrouter():
     # Persist to config
     from ..config import set_config_value
 
-    set_config_value("env.OPENROUTER_API_KEY", api_key)
+    set_config_value("env.OPENROUTER_API_KEY", api_key, local=True)
 
     console.print("\n[green bold]✓ Authentication successful![/green bold]")
     console.print(f"  API key saved to config (key: {api_key[:16]}…)")

--- a/gptme/cli/setup.py
+++ b/gptme/cli/setup.py
@@ -863,7 +863,7 @@ def _setup_openrouter_oauth() -> tuple[str, str]:  # pragma: no cover
         console.print(f"[red]❌ OpenRouter OAuth failed: {exc}[/red]")
         raise
 
-    set_config_value("env.OPENROUTER_API_KEY", api_key)
+    set_config_value("env.OPENROUTER_API_KEY", api_key, local=True)
     provider = "openrouter"
     model = f"{provider}/{get_recommended_model('openrouter')}"
     set_config_value("models.default", model)

--- a/gptme/cli/setup.py
+++ b/gptme/cli/setup.py
@@ -792,10 +792,12 @@ def _choose_first_run_auth() -> str:
         "[bold]How would you like to connect?[/bold]\n"
         "  1. ChatGPT Plus/Pro subscription [dim](browser sign-in, no API key)[/dim]\n"
         "  2. Grok SuperGrok subscription [dim](browser sign-in, no API key)[/dim]\n"
-        "  3. Provider API key [dim](OpenAI, Anthropic, OpenRouter, Gemini)[/dim]\n"
-        "  4. Custom OpenAI-compatible provider"
+        "  3. OpenRouter [dim](browser sign-in, access 300+ models, no API key required)[/dim]\n"
+        "  4. gptme.ai [dim](device sign-in, hosted service)[/dim]\n"
+        "  5. Provider API key [dim](OpenAI, Anthropic, OpenRouter, Gemini)[/dim]\n"
+        "  6. Custom OpenAI-compatible provider"
     )
-    return Prompt.ask("Connection", choices=["1", "2", "3", "4"], default="1")
+    return Prompt.ask("Connection", choices=["1", "2", "3", "4", "5", "6"], default="1")
 
 
 def _show_api_key_sources() -> None:  # pragma: no cover
@@ -846,6 +848,46 @@ def _setup_grok_subscription() -> tuple[str, str]:
     return provider, "oauth"
 
 
+def _setup_openrouter_oauth() -> tuple[str, str]:  # pragma: no cover
+    """Authenticate via OpenRouter OAuth and persist the API key as the default."""
+    from ..llm.llm_openrouter_subscription import oauth_get_api_key
+
+    console.print(
+        "\n[bold]Opening your browser for OpenRouter sign-in...[/bold]\n"
+        "[dim]OpenRouter gives access to 300+ models (GPT, Claude, Gemini, …).[/dim]\n"
+        "[dim]The sign-in returns a permanent API key — no subscription required.[/dim]"
+    )
+    try:
+        api_key = oauth_get_api_key()
+    except RuntimeError as exc:
+        console.print(f"[red]❌ OpenRouter OAuth failed: {exc}[/red]")
+        raise
+
+    set_config_value("env.OPENROUTER_API_KEY", api_key)
+    provider = "openrouter"
+    model = f"{provider}/{get_recommended_model('openrouter')}"
+    set_config_value("models.default", model)
+    console.print(f"[green]✅ OpenRouter connected ({model})[/green]")
+    return provider, api_key
+
+
+def _setup_gptme_ai() -> tuple[str, str]:  # pragma: no cover
+    """Authenticate via gptme.ai device flow and persist the token as default."""
+    from ..llm.llm_gptme import DEFAULT_SERVICE_URL, device_flow_authenticate
+
+    console.print(
+        "\n[bold]Starting gptme.ai device sign-in...[/bold]\n"
+        "[dim]You'll be given a short code to enter on gptme.ai in your browser.[/dim]\n"
+        "[dim]Works in SSH/headless environments — no browser redirect needed.[/dim]"
+    )
+    device_flow_authenticate(server_url=DEFAULT_SERVICE_URL)
+    provider = "gptme"
+    model = f"{provider}/{get_recommended_model('gptme')}"
+    set_config_value("models.default", model)
+    console.print(f"[green]✅ gptme.ai connected ({model})[/green]")
+    return provider, "device-flow"
+
+
 def ask_for_api_key():  # pragma: no cover
     """Interactively configure subscription, API-key, or custom provider auth."""
     console.print(
@@ -861,7 +903,11 @@ def ask_for_api_key():  # pragma: no cover
         return _setup_openai_subscription()
     if choice == "2":
         return _setup_grok_subscription()
+    if choice == "3":
+        return _setup_openrouter_oauth()
     if choice == "4":
+        return _setup_gptme_ai()
+    if choice == "6":
         return _setup_custom_provider()
 
     _show_api_key_sources()

--- a/gptme/llm/llm_openrouter_subscription.py
+++ b/gptme/llm/llm_openrouter_subscription.py
@@ -123,17 +123,19 @@ def oauth_get_api_key() -> str:
             f"Could not start OAuth callback server on port {OAUTH_CALLBACK_PORT}: {exc}"
         ) from exc
 
-    server_thread = threading.Thread(target=server.handle_request, daemon=True)
+    server_thread = threading.Thread(target=server.serve_forever, daemon=True)
     server_thread.start()
 
     webbrowser.open(auth_url)
 
     # Wait up to 5 minutes for the user to complete the browser flow
     if not _done.wait(timeout=300):
+        server.shutdown()
         server.server_close()
         raise RuntimeError(
             "OpenRouter OAuth timed out (no browser callback after 5 minutes)."
         )
+    server.shutdown()
     server.server_close()
 
     if "error" in _result:

--- a/gptme/llm/llm_openrouter_subscription.py
+++ b/gptme/llm/llm_openrouter_subscription.py
@@ -1,0 +1,169 @@
+"""OpenRouter OAuth helper.
+
+Authenticates via OpenRouter's PKCE OAuth flow and returns a persistent API key
+that is stored in the gptme config.  Unlike the ChatGPT / Grok subscription
+providers, OpenRouter OAuth produces a **permanent API key** (not an expiring
+access token), so no refresh machinery is needed.
+
+Flow
+----
+1. Generate a PKCE code-verifier/challenge pair.
+2. Open ``https://openrouter.ai/auth?callback_url=…&code_challenge=…`` in the
+   browser.
+3. Start a local HTTP server on ``OAUTH_CALLBACK_PORT`` to receive the redirect.
+4. Exchange the returned ``code`` for the API key via a POST to the OpenRouter
+   key-exchange endpoint.
+5. Return the ``sk-or-v1-…`` key string; callers persist it to the config.
+
+Usage
+-----
+From setup.py ``_setup_openrouter_oauth()`` or directly::
+
+    from gptme.llm.llm_openrouter_subscription import oauth_get_api_key
+    api_key = oauth_get_api_key()
+
+Or via the auth CLI::
+
+    gptme auth openrouter
+"""
+
+import base64
+import hashlib
+import http.server
+import logging
+import secrets
+import socket
+import threading
+from urllib.parse import parse_qs, urlencode, urlparse
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+# OpenRouter OAuth endpoints
+OAUTH_AUTH_URL = "https://openrouter.ai/auth"
+OAUTH_KEY_EXCHANGE_URL = "https://openrouter.ai/api/v1/auth/keys"
+OAUTH_CALLBACK_PORT = 1458  # 1455=openai-sub, 1456=grok-sub, 1457=reserved
+OAUTH_CALLBACK_PATH = "/auth/callback"
+
+
+def _generate_pkce() -> tuple[str, str]:
+    """Return (code_verifier, code_challenge) for PKCE-S256."""
+    verifier = secrets.token_urlsafe(32)
+    digest = hashlib.sha256(verifier.encode()).digest()
+    challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode()
+    return verifier, challenge
+
+
+def oauth_get_api_key() -> str:
+    """Run the OpenRouter PKCE OAuth flow and return the API key.
+
+    Opens the user's browser, waits for the local OAuth callback, then
+    exchanges the authorization code for a permanent ``sk-or-v1-…`` key.
+
+    Raises
+    ------
+    RuntimeError
+        If the browser callback does not arrive within the timeout, the code
+        exchange fails, or the server cannot bind the callback port.
+    """
+    import webbrowser
+
+    code_verifier, code_challenge = _generate_pkce()
+    callback_url = f"http://localhost:{OAUTH_CALLBACK_PORT}{OAUTH_CALLBACK_PATH}"
+
+    params = {
+        "callback_url": callback_url,
+        "code_challenge": code_challenge,
+        "code_challenge_method": "S256",
+    }
+    auth_url = f"{OAUTH_AUTH_URL}?{urlencode(params)}"
+
+    # Shared state between the HTTP handler and this function
+    _result: dict[str, object] = {}
+    _done = threading.Event()
+
+    class _Handler(http.server.BaseHTTPRequestHandler):
+        def log_message(self, *_args):
+            pass  # silence access log
+
+        def do_GET(self):
+            parsed = urlparse(self.path)
+            if parsed.path != OAUTH_CALLBACK_PATH:
+                self._respond(404, "Not found")
+                return
+
+            qs = parse_qs(parsed.query)
+            code_list = qs.get("code", [])
+            if not code_list:
+                _result["error"] = Exception("No 'code' in OAuth callback URL")
+            else:
+                _result["code"] = code_list[0]
+
+            self._respond(
+                200,
+                "<html><body><h2>Authentication complete — you can close this tab."
+                "</h2></body></html>",
+                content_type="text/html",
+            )
+            _done.set()
+
+        def _respond(self, status: int, body: str, content_type: str = "text/plain"):
+            encoded = body.encode()
+            self.send_response(status)
+            self.send_header("Content-Type", content_type)
+            self.send_header("Content-Length", str(len(encoded)))
+            self.end_headers()
+            self.wfile.write(encoded)
+
+    try:
+        server = http.server.HTTPServer(("127.0.0.1", OAUTH_CALLBACK_PORT), _Handler)
+    except OSError as exc:
+        raise RuntimeError(
+            f"Could not start OAuth callback server on port {OAUTH_CALLBACK_PORT}: {exc}"
+        ) from exc
+
+    server_thread = threading.Thread(target=server.handle_request, daemon=True)
+    server_thread.start()
+
+    webbrowser.open(auth_url)
+
+    # Wait up to 5 minutes for the user to complete the browser flow
+    if not _done.wait(timeout=300):
+        server.server_close()
+        raise RuntimeError(
+            "OpenRouter OAuth timed out (no browser callback after 5 minutes)."
+        )
+    server.server_close()
+
+    if "error" in _result:
+        raise RuntimeError(f"OpenRouter OAuth error: {_result['error']}")
+
+    auth_code = _result.get("code")
+    if not isinstance(auth_code, str):
+        raise RuntimeError("OpenRouter OAuth callback did not return a code.")
+
+    # Exchange the authorization code for a permanent API key
+    try:
+        resp = requests.post(
+            OAUTH_KEY_EXCHANGE_URL,
+            json={"code": auth_code, "code_verifier": code_verifier},
+            timeout=30,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+    except requests.RequestException as exc:
+        raise RuntimeError(f"OpenRouter key exchange failed: {exc}") from exc
+
+    api_key: str = data.get("key", "")
+    if not api_key:
+        raise RuntimeError(f"OpenRouter key exchange returned no 'key' field: {data!r}")
+
+    return api_key
+
+
+def _check_port_available(port: int) -> bool:
+    """Return True if the given TCP port is free."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.settimeout(0.5)
+        return s.connect_ex(("127.0.0.1", port)) != 0


### PR DESCRIPTION
## Summary

Extends the first-run provider setup introduced in #3295 with two new authentication paths requested by Erik immediately after that PR merged.

### OpenRouter OAuth (new `llm_openrouter_subscription.py`)
- Full PKCE-S256 OAuth flow against `https://openrouter.ai/auth`
- A local HTTP server on port 1458 captures the authorization callback
- The auth code is exchanged for a **permanent** `sk-or-v1-…` API key via `POST /api/v1/auth/keys`
- Key is stored as `env.OPENROUTER_API_KEY` in the gptme config and default model set to `openrouter/<recommended>`
- Also exposed as `gptme auth openrouter` for re-authentication

### gptme.ai device-connect
- Wraps the existing `device_flow_authenticate()` from `gptme/cli/auth.py` (RFC 8628)
- User receives a short code to enter at the gptme.ai verification URL — no browser redirect, works in SSH/headless
- Sets default model to `gptme/<recommended>`

### First-run menu (was 4 choices → now 6)

```
1. ChatGPT Plus/Pro subscription   (unchanged)
2. Grok SuperGrok subscription     (unchanged)
3. OpenRouter                      ← new (browser sign-in, 300+ models)
4. gptme.ai                        ← new (device sign-in, hosted service)
5. Provider API key                (was 3)
6. Custom OpenAI-compatible        (was 4)
```

## Test plan
- [ ] `gptme auth openrouter` opens browser, completes flow, saves key to config
- [ ] `gptme auth login` (gptme.ai device flow) unchanged and still works
- [ ] `gptme setup` → choice 3 runs OpenRouter OAuth → config has `OPENROUTER_API_KEY`
- [ ] `gptme setup` → choice 4 runs gptme.ai device flow → config has `gptme` default model
- [ ] `gptme setup` → choice 5 (API key) still works as before
- [ ] `gptme setup` → choice 6 (custom) still works as before
- [ ] Existing tests in `tests/test_setup_completions.py` pass (7/7)