### PR TITLE
fix(test): use scrollback capture for inline-mode positional assertion

### DIFF
--- a/tests/test_tui_e2e.py
+++ b/tests/test_tui_e2e.py
@@ -467,8 +467,10 @@ class TestTmuxInlineMode:
         pane = tui.capture_scrollback()
         assert_no_escape_garbage(pane)
         # transcript lines are in scrollback (lower index) above the live
-        # input region which contains the prompt (higher index)
-        assert pane.index("Echo: hello inline") < pane.index("Type a message")
+        # input region which contains the prompt (higher index). Use rindex so
+        # we compare against the re-rendered prompt AFTER the echo, not the
+        # initial startup prompt that appears earlier in the scrollback.
+        assert pane.index("Echo: hello inline") < pane.rindex("Type a message")
 
     def test_inline_tool_flow(self, tmux_tui, tmp_path):
         marker = tmp_path / "inline_marker"

--- a/tests/test_tui_e2e.py
+++ b/tests/test_tui_e2e.py
@@ -288,6 +288,16 @@ class TmuxTUI:
         )
         return result.stdout
 
+    def capture_scrollback(self, lines: int = 1000) -> str:
+        """Capture pane content including scrollback history."""
+        result = subprocess.run(
+            ["tmux", "capture-pane", "-t", self.session, "-p", "-S", f"-{lines}"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return result.stdout
+
     def wait_for(self, needle: str, timeout: float = 30.0) -> str:
         deadline = time.monotonic() + timeout
         content = ""
@@ -446,13 +456,18 @@ class TestTmuxInlineMode:
         tui.send("hello inline")
         tui.send_key("Enter")
         tui.wait_for("Echo: hello inline")
-        # Wait for both the echo AND the input prompt to be visible together —
-        # captures taken the moment "Echo:" appears can race before the prompt
-        # re-renders, causing ValueError from str.index().
-        pane = tui.wait_for("Type a message")
+        # Wait for the input prompt to confirm rendering is complete.
+        tui.wait_for("Type a message")
+        # In --inline mode the response is emitted to native scrollback (above
+        # the live input region). tmux capture-pane without -S only shows the
+        # current 30-line visible screen, so "Echo: hello inline" can scroll
+        # above that window by the time the prompt re-appears, causing
+        # ValueError from str.index(). Use a scrollback-aware capture so both
+        # strings are always in the same snapshot.
+        pane = tui.capture_scrollback()
         assert_no_escape_garbage(pane)
-        # transcript lines are plain terminal output (native scrollback), so
-        # they appear above the live region which contains the input
+        # transcript lines are in scrollback (lower index) above the live
+        # input region which contains the prompt (higher index)
         assert pane.index("Echo: hello inline") < pane.index("Type a message")
 
     def test_inline_tool_flow(self, tmux_tui, tmp_path):


### PR DESCRIPTION
## Summary

Eliminates the `test_inline_prints_to_scrollback` flake that was causing sporadic CI failures in the `Test without API keys` job (observed on #3283 and noted in my comment there).

**Root cause**: `tmux capture-pane -p` (used by `TmuxTUI.capture()`) only captures the current 30-line *visible* screen. In `--inline` mode, gptme emits responses to the native terminal scrollback rather than an alternate screen. By the time the input prompt re-renders at the bottom, startup output can push "Echo: hello inline" above the 30-line visible window. So `wait_for("Type a message")` succeeds but the returned pane snapshot no longer contains "Echo: hello inline", causing `ValueError: substring not found` from `str.index()`.

The #3256 workaround (StashKey teardown guard) was intended to suppress the resulting pytest-retry artifact, but the guard is unreliable under xdist — when the retry is dispatched to a different worker process, `item._stash_guard_call_attempts` starts fresh at 0, so the `> 1` condition never fires.

**Fix**: adds `TmuxTUI.capture_scrollback()` which passes `-S -1000` to include scrollback history, and uses it for the positional assertion. Both strings are then guaranteed to be in the same snapshot, eliminating the race. Since the test no longer needs to retry, the StashKey teardown error can't occur either.

## Test plan

- [x] Pre-commit hooks pass
- [ ] `test_inline_prints_to_scrollback` passes in CI without a retry (verify CI run on this PR)

## Related

- Follow-up to #3283 (the dep-bump where the flake was observed)
- #3256 — the teardown guard; its `_stash_guard_call_attempts` tracking is ineffective under xdist, but moot once this fix lands since the retry won't be triggered