### PR TITLE
feat(webui): open external sessions inline in native chat layout

### DIFF
--- a/webui/src/components/ConversationList.tsx
+++ b/webui/src/components/ConversationList.tsx
@@ -85,6 +85,7 @@ interface Props {
   onOpenInSplitView?: (conversationId: string) => void;
   externalSessions?: ExternalSessionCatalogItem[];
   onSelectExternal?: (id: string) => void;
+  selectedExternalId?: string;
 }
 
 export const ConversationList: FC<Props> = ({
@@ -102,6 +103,7 @@ export const ConversationList: FC<Props> = ({
   onOpenInSplitView,
   externalSessions,
   onSelectExternal,
+  selectedExternalId,
 }) => {
   const { api, isConnected$ } = useApi();
   const isConnected = use$(isConnected$);
@@ -669,10 +671,14 @@ export const ConversationList: FC<Props> = ({
                 : session.started_at
                   ? getRelativeTimeString(new Date(session.started_at))
                   : null;
+              const isSelected = selectedExternalId === session.id;
               return (
                 <button
                   key={session.id}
-                  className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors hover:bg-accent/50"
+                  className={`flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors hover:bg-accent/50 ${
+                    isSelected ? 'bg-accent ring-1 ring-primary' : ''
+                  }`}
+                  aria-pressed={isSelected}
                   onClick={() => onSelectExternal(session.id)}
                 >
                   <Badge variant="secondary" className="h-4 flex-shrink-0 px-1.5 text-[10px]">

--- a/webui/src/components/ExternalSessionDetail.tsx
+++ b/webui/src/components/ExternalSessionDetail.tsx
@@ -1,0 +1,122 @@
+/**
+ * Standalone external-session detail panel — renders the transcript for one
+ * external session (Claude Code, Codex, etc.) and exposes an optional
+ * steer_inject input when the session advertises that capability.
+ *
+ * Used in two contexts:
+ *   - The dedicated /external-sessions page (two-panel catalog view)
+ *   - Inline inside the native chat layout when a session is selected from the
+ *     sidebar (the "native chat view" integration introduced in gptme#3217)
+ */
+
+import { type FC, useState } from 'react';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { AlertCircle, Send } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+import { useApi } from '@/contexts/ApiContext';
+import { use$ } from '@legendapp/state/react';
+import { SessionReplayMessages } from '@/components/SessionReplayMessages';
+
+interface Props {
+  sessionId: string;
+}
+
+export const ExternalSessionDetail: FC<Props> = ({ sessionId }) => {
+  const { api } = useApi();
+  const isConnected = use$(api.isConnected$);
+  const [steerMessage, setSteerMessage] = useState('');
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['external-session-detail', sessionId],
+    queryFn: () => api.getExternalSession(sessionId),
+    enabled: isConnected && !!sessionId,
+  });
+
+  const steerMutation = useMutation({
+    mutationFn: (message: string) => api.steerExternalSession(sessionId, message),
+    onSuccess: () => setSteerMessage(''),
+  });
+
+  if (isLoading) {
+    return (
+      <div className="flex h-full items-center justify-center text-muted-foreground">
+        Loading session…
+      </div>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-2 text-muted-foreground">
+        <AlertCircle className="h-8 w-8" />
+        <p className="text-sm">Failed to load session details</p>
+      </div>
+    );
+  }
+
+  const messages = Array.isArray(data.transcript.messages) ? data.transcript.messages : null;
+  const capabilities = Array.isArray(data.transcript.capabilities)
+    ? (data.transcript.capabilities as string[])
+    : [];
+  const canSteer = capabilities.includes('steer_inject');
+
+  const handleSteer = () => {
+    const msg = steerMessage.trim();
+    if (!msg || steerMutation.isPending) return;
+    steerMutation.mutate(msg);
+  };
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex-1 overflow-y-auto p-4">
+        {messages ? (
+          <SessionReplayMessages messages={messages} />
+        ) : (
+          <pre className="whitespace-pre-wrap rounded-md bg-muted p-3 text-xs">
+            {JSON.stringify(data.transcript, null, 2)}
+          </pre>
+        )}
+      </div>
+      {canSteer && (
+        <div className="border-t p-3">
+          <div className="flex gap-2">
+            <Textarea
+              className="min-h-[2.5rem] flex-1 resize-none text-sm"
+              placeholder="Steer session — inject a user message…"
+              value={steerMessage}
+              onChange={(e) => setSteerMessage(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && !e.shiftKey) {
+                  e.preventDefault();
+                  handleSteer();
+                }
+              }}
+              rows={2}
+              aria-label="Steer message"
+            />
+            <Button
+              size="icon"
+              className="h-auto self-end"
+              onClick={handleSteer}
+              disabled={!steerMessage.trim() || steerMutation.isPending}
+              aria-label="Send steer message"
+            >
+              <Send className="h-4 w-4" />
+            </Button>
+          </div>
+          {steerMutation.isError && (
+            <p className="mt-1 text-xs text-destructive">
+              {steerMutation.error instanceof Error
+                ? steerMutation.error.message
+                : 'Failed to send message'}
+            </p>
+          )}
+          {steerMutation.isSuccess && (
+            <p className="mt-1 text-xs text-muted-foreground">Message injected.</p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/webui/src/components/ExternalSessionsView.tsx
+++ b/webui/src/components/ExternalSessionsView.tsx
@@ -1,27 +1,16 @@
 import { type FC, useState, useEffect } from 'react';
-import { useQuery, useMutation } from '@tanstack/react-query';
-import {
-  Bot,
-  Clock,
-  Cpu,
-  FolderOpen,
-  AlertCircle,
-  Search,
-  ChevronRight,
-  X,
-  Send,
-} from 'lucide-react';
+import { useQuery } from '@tanstack/react-query';
+import { Bot, Clock, Cpu, FolderOpen, AlertCircle, Search, ChevronRight, X } from 'lucide-react';
 import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { Textarea } from '@/components/ui/textarea';
 import { useApi } from '@/contexts/ApiContext';
 import { use$ } from '@legendapp/state/react';
 import { useSearchParams } from 'react-router-dom';
 import { getRelativeTimeString } from '@/utils/time';
 import type { ExternalSessionCatalogItem } from '@/types/api';
 import { ApiClientError } from '@/utils/api';
-import { SessionReplayMessages } from '@/components/SessionReplayMessages';
+import { ExternalSessionDetail } from '@/components/ExternalSessionDetail';
 
 const HARNESS_LABELS: Record<string, string> = {
   'claude-code': 'Claude Code',
@@ -115,50 +104,6 @@ interface SessionDetailProps {
 }
 
 const SessionDetail: FC<SessionDetailProps> = ({ sessionId, onClose }) => {
-  const { api } = useApi();
-  const isConnected = use$(api.isConnected$);
-  const [steerMessage, setSteerMessage] = useState('');
-
-  const { data, isLoading, error } = useQuery({
-    queryKey: ['external-session-detail', sessionId],
-    queryFn: () => api.getExternalSession(sessionId),
-    enabled: isConnected && !!sessionId,
-  });
-
-  const steerMutation = useMutation({
-    mutationFn: (message: string) => api.steerExternalSession(sessionId, message),
-    onSuccess: () => setSteerMessage(''),
-  });
-
-  if (isLoading) {
-    return (
-      <div className="flex h-full items-center justify-center text-muted-foreground">
-        Loading session…
-      </div>
-    );
-  }
-
-  if (error || !data) {
-    return (
-      <div className="flex h-full flex-col items-center justify-center gap-2 text-muted-foreground">
-        <AlertCircle className="h-8 w-8" />
-        <p className="text-sm">Failed to load session details</p>
-      </div>
-    );
-  }
-
-  const messages = Array.isArray(data.transcript.messages) ? data.transcript.messages : null;
-  const capabilities = Array.isArray(data.transcript.capabilities)
-    ? (data.transcript.capabilities as string[])
-    : [];
-  const canSteer = capabilities.includes('steer_inject');
-
-  const handleSteer = () => {
-    const msg = steerMessage.trim();
-    if (!msg || steerMutation.isPending) return;
-    steerMutation.mutate(msg);
-  };
-
   return (
     <div className="flex h-full flex-col">
       <div className="flex items-center justify-between border-b px-4 py-2">
@@ -173,54 +118,9 @@ const SessionDetail: FC<SessionDetailProps> = ({ sessionId, onClose }) => {
           <X className="h-4 w-4" />
         </Button>
       </div>
-      <div className="flex-1 overflow-y-auto p-4">
-        {messages ? (
-          <SessionReplayMessages messages={messages} />
-        ) : (
-          <pre className="whitespace-pre-wrap rounded-md bg-muted p-3 text-xs">
-            {JSON.stringify(data.transcript, null, 2)}
-          </pre>
-        )}
+      <div className="min-h-0 flex-1 overflow-hidden">
+        <ExternalSessionDetail sessionId={sessionId} />
       </div>
-      {canSteer && (
-        <div className="border-t p-3">
-          <div className="flex gap-2">
-            <Textarea
-              className="min-h-[2.5rem] flex-1 resize-none text-sm"
-              placeholder="Steer session — inject a user message…"
-              value={steerMessage}
-              onChange={(e) => setSteerMessage(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter' && !e.shiftKey) {
-                  e.preventDefault();
-                  handleSteer();
-                }
-              }}
-              rows={2}
-              aria-label="Steer message"
-            />
-            <Button
-              size="icon"
-              className="h-auto self-end"
-              onClick={handleSteer}
-              disabled={!steerMessage.trim() || steerMutation.isPending}
-              aria-label="Send steer message"
-            >
-              <Send className="h-4 w-4" />
-            </Button>
-          </div>
-          {steerMutation.isError && (
-            <p className="mt-1 text-xs text-destructive">
-              {steerMutation.error instanceof Error
-                ? steerMutation.error.message
-                : 'Failed to send message'}
-            </p>
-          )}
-          {steerMutation.isSuccess && (
-            <p className="mt-1 text-xs text-muted-foreground">Message injected.</p>
-          )}
-        </div>
-      )}
     </div>
   );
 };

--- a/webui/src/components/MainLayout.tsx
+++ b/webui/src/components/MainLayout.tsx
@@ -4,6 +4,7 @@ import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from '@/componen
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet';
 import { WelcomeView } from '@/components/WelcomeView';
 import { ConversationContent } from '@/components/ConversationContent';
+import { ExternalSessionDetail } from '@/components/ExternalSessionDetail';
 import { SplitConversationView } from '@/components/SplitConversationView';
 import { TaskDetails } from '@/components/TaskDetails';
 import { RightSidebar } from '@/components/RightSidebar';
@@ -54,6 +55,7 @@ const MainLayout: FC<Props> = ({ conversationId, taskId }) => {
   const stepParam = searchParams.get('step');
   const serverParam = searchParams.get('server');
   const splitParam = searchParams.get('split');
+  const externalParam = searchParams.get('external');
   const splitIds = useMemo((): [string, string] | null => {
     if (!splitParam) return null;
     const ids = splitParam.split(',').filter(Boolean).slice(0, 2);
@@ -583,6 +585,15 @@ const MainLayout: FC<Props> = ({ conversationId, taskId }) => {
       return null;
     }
 
+    // External session selected from sidebar — show transcript inline in the native chat layout
+    if (externalParam) {
+      return (
+        <div className="h-full overflow-hidden">
+          <ExternalSessionDetail key={externalParam} sessionId={externalParam} />
+        </div>
+      );
+    }
+
     return (
       <div className="flex h-full flex-1 items-center justify-center">
         <WelcomeView />
@@ -608,6 +619,7 @@ const MainLayout: FC<Props> = ({ conversationId, taskId }) => {
               <UnifiedSidebar
                 conversations={allConversations}
                 selectedConversationId$={selectedConversation$}
+                selectedExternalId={externalParam ?? undefined}
                 onSelectConversation={(id, serverId) => {
                   handleSelectConversation(id, serverId);
                   leftSidebarVisible$.set(false);
@@ -728,6 +740,7 @@ const MainLayout: FC<Props> = ({ conversationId, taskId }) => {
             <UnifiedSidebar
               conversations={allConversations}
               selectedConversationId$={selectedConversation$}
+              selectedExternalId={externalParam ?? undefined}
               onSelectConversation={handleSelectConversation}
               conversationsLoading={isLoading}
               conversationsFetching={isFetching}

--- a/webui/src/components/MainLayout.tsx
+++ b/webui/src/components/MainLayout.tsx
@@ -286,6 +286,7 @@ const MainLayout: FC<Props> = ({ conversationId, taskId }) => {
 
       const newParams = new URLSearchParams(searchParams);
       newParams.delete('split');
+      newParams.delete('external');
       if (serverId) {
         newParams.set('server', serverId);
       } else {

--- a/webui/src/components/UnifiedSidebar.tsx
+++ b/webui/src/components/UnifiedSidebar.tsx
@@ -96,6 +96,9 @@ interface Props {
   // Split view
   onOpenInSplitView?: (conversationId: string) => void;
 
+  // External sessions
+  selectedExternalId?: string;
+
   // Task props
   tasks: Task[];
   selectedTaskId?: string;
@@ -126,6 +129,7 @@ export const UnifiedSidebar: FC<Props> = ({
   tasksError = false,
   onTasksRetry,
   onOpenInSplitView,
+  selectedExternalId,
 }) => {
   const selectedWorkspace = use$(selectedWorkspace$);
   const selectedAgent = use$(selectedAgent$);
@@ -151,9 +155,7 @@ export const UnifiedSidebar: FC<Props> = ({
 
   const handleSelectExternal = useCallback(
     (id: string) => {
-      const route = appRoute('/external-sessions');
-      const separator = route.includes('?') ? '&' : '?';
-      navigate(`${route}${separator}selected=${encodeURIComponent(id)}`);
+      navigate(`/chat?external=${encodeURIComponent(id)}`);
     },
     [navigate]
   );
@@ -427,6 +429,7 @@ export const UnifiedSidebar: FC<Props> = ({
               onOpenInSplitView={onOpenInSplitView}
               externalSessions={externalSessions}
               onSelectExternal={handleSelectExternal}
+              selectedExternalId={selectedExternalId}
             />
           )}
 


### PR DESCRIPTION
## Summary

Closes #3217 (final piece — the actual native chat view integration).

The two merged PRs (#3281, #3287) added the sidebar toggle and steer_inject backend, but external sessions still opened in the **separate `/external-sessions` page** rather than the native chat layout. Clicking an external session in the sidebar would navigate away, losing the unified sidebar context.

This PR makes clicking an external session open its transcript inline in the main chat content area — the same unified layout used for native gptme conversations.

### Changes

- **`ExternalSessionDetail.tsx`** (new) — standalone component extracted from `ExternalSessionsView`: renders the transcript with `SessionReplayMessages` + capability-gated `steer_inject` textarea. Reusable in both contexts.
- **`ExternalSessionsView.tsx`** — now delegates to `ExternalSessionDetail` (no behaviour change to the `/external-sessions` catalog view)
- **`MainLayout.tsx`** — reads `?external=<id>` URL param and renders `ExternalSessionDetail` in the main content area (same slot as `ConversationContent`)
- **`UnifiedSidebar.tsx`** — `handleSelectExternal` now navigates to `/chat?external=<id>` instead of `/external-sessions?selected=<id>`, keeping the unified sidebar visible
- **`ConversationList.tsx`** — highlights the selected external session in the sidebar (`bg-accent ring-1 ring-primary`, matching native conversation selection style)

### UX flow

1. User clicks "Ext" toggle → external sessions appear in the sidebar list
2. User clicks an external session → navigates to `/chat?external=<id>`
3. The main content area shows the session transcript (same layout position as a native conversation)
4. Steer input appears at the bottom when `steer_inject` is in capabilities
5. Clicking a native conversation clears the `?external=` param and shows the conversation normally
6. The `/external-sessions` full catalog view is unchanged and still accessible via the sidebar nav icon

### Testing

- 567/567 frontend tests pass
- TypeScript: clean (`tsc --noEmit`)
- ESLint: clean (0 errors, 0 warnings)

<!-- gptme-id:v1:gai_w2ZZOvPB5Cuh13XFgJvoWixhxo5TMJ8A20Ge9mbCAYx -->