### PR TITLE
feat(webui): truly mix external sessions inline by recency (#3217)

### DIFF
--- a/webui/src/components/ConversationList.tsx
+++ b/webui/src/components/ConversationList.tsx
@@ -380,22 +380,30 @@ export const ConversationList: FC<Props> = ({
           return getConversationName(a).localeCompare(getConversationName(b));
         });
 
+  // Cap external sessions merged into the timeline to avoid unbounded rendering.
+  const MAX_EXTERNAL_INLINE = 50;
+
   // For 'recent' view: merge external sessions into the native list (true unified timeline).
   // External sessions are adapted to ConversationSummary shape and interleaved by modified time.
+  // Sessions with no parseable timestamp are excluded from the merged view (no meaningful sort key).
   // For non-recency sorts, external sessions appear in a separate section (no message count to sort by).
   const externalAsSummaries: ConversationSummary[] =
     showExternal && externalSessions && onSelectExternal
-      ? externalSessions.map((item) => {
-          const modifiedMs = Date.parse(item.last_activity ?? item.started_at ?? '0');
-          const modified = Number.isFinite(modifiedMs) && modifiedMs > 0 ? modifiedMs / 1000 : 0;
+      ? externalSessions.slice(0, MAX_EXTERNAL_INLINE).flatMap((item) => {
+          const modifiedMs = Date.parse(item.last_activity ?? item.started_at ?? '');
+          // Skip sessions with no parseable timestamp — placing them at epoch (Jan 1970) is misleading.
+          if (!Number.isFinite(modifiedMs) || modifiedMs <= 0) return [];
+          const modified = modifiedMs / 1000;
           const label = HARNESS_LABELS[item.harness] ?? item.harness;
           const name = item.session_name ?? item.session_id.slice(0, 8);
-          return {
-            id: `ext:${item.id}`,
-            name,
-            modified,
-            _externalSession: { id: item.id, harness: item.harness, label },
-          } satisfies ConversationSummary;
+          return [
+            {
+              id: `ext:${item.id}`,
+              name,
+              modified,
+              _externalSession: { id: item.id, harness: item.harness, label },
+            } satisfies ConversationSummary,
+          ];
         })
       : [];
 
@@ -533,8 +541,9 @@ export const ConversationList: FC<Props> = ({
         </div>
       )}
 
-      {/* Render conversations: grouped by date for 'recent' (native + external merged), flat list for other sorts */}
-      {!isLoading &&
+      {/* Render conversations: grouped by date for 'recent' (native + external merged), flat list for other sorts.
+          External sessions render independently of the native loading/error state. */}
+      {(!isLoading || externalAsSummaries.length > 0) &&
         !isError &&
         sortBy === 'recent' &&
         groupByDate<ConversationSummary>(

--- a/webui/src/components/ConversationList.tsx
+++ b/webui/src/components/ConversationList.tsx
@@ -383,34 +383,32 @@ export const ConversationList: FC<Props> = ({
   // Cap external sessions merged into the timeline to avoid unbounded rendering.
   const MAX_EXTERNAL_INLINE = 50;
 
-  // For 'recent' view: merge external sessions into the native list (true unified timeline).
-  // External sessions are adapted to ConversationSummary shape and interleaved by modified time.
-  // Sessions with no parseable timestamp are excluded from the merged view (no meaningful sort key).
-  // For non-recency sorts, external sessions appear in a separate section (no message count to sort by).
+  // External sessions without a usable timestamp cannot be placed honestly in a date group.
+  // Keep them in an undated section instead of manufacturing a January 1970 group.
   const externalAsSummaries: ConversationSummary[] =
     showExternal && externalSessions && onSelectExternal
-      ? externalSessions.slice(0, MAX_EXTERNAL_INLINE).flatMap((item) => {
+      ? externalSessions.slice(0, MAX_EXTERNAL_INLINE).map((item) => {
           const modifiedMs = Date.parse(item.last_activity ?? item.started_at ?? '');
-          // Skip sessions with no parseable timestamp — placing them at epoch (Jan 1970) is misleading.
-          if (!Number.isFinite(modifiedMs) || modifiedMs <= 0) return [];
-          const modified = modifiedMs / 1000;
+          const modified = Number.isFinite(modifiedMs) && modifiedMs > 0 ? modifiedMs / 1000 : 0;
           const label = HARNESS_LABELS[item.harness] ?? item.harness;
           const name = item.session_name ?? item.session_id.slice(0, 8);
-          return [
-            {
-              id: `ext:${item.id}`,
-              name,
-              modified,
-              _externalSession: { id: item.id, harness: item.harness, label },
-            } satisfies ConversationSummary,
-          ];
+          return {
+            id: `ext:${item.id}`,
+            name,
+            modified,
+            _externalSession: { id: item.id, harness: item.harness, label },
+          } satisfies ConversationSummary;
         })
       : [];
+  const datedExternalSummaries = externalAsSummaries.filter((conv) => conv.modified > 0);
+  const undatedExternalSummaries = externalAsSummaries.filter((conv) => conv.modified === 0);
 
-  // For 'recent': merge and re-sort so external sessions appear in the right timeline position.
+  // For 'recent': merge and re-sort so dated external sessions appear in the right timeline position.
   const sortedConversationsWithExternal =
-    sortBy === 'recent' && externalAsSummaries.length > 0
-      ? [...sortedRealConversations, ...externalAsSummaries].sort((a, b) => b.modified - a.modified)
+    sortBy === 'recent' && datedExternalSummaries.length > 0
+      ? [...sortedRealConversations, ...datedExternalSummaries].sort(
+          (a, b) => b.modified - a.modified
+        )
       : sortedRealConversations;
 
   return (
@@ -543,11 +541,9 @@ export const ConversationList: FC<Props> = ({
 
       {/* Render conversations: grouped by date for 'recent' (native + external merged), flat list for other sorts.
           External sessions render independently of the native loading/error state. */}
-      {(!isLoading || externalAsSummaries.length > 0) &&
-        !isError &&
-        sortBy === 'recent' &&
+      {sortBy === 'recent' &&
         groupByDate<ConversationSummary>(
-          sortedConversationsWithExternal,
+          isLoading || isError ? datedExternalSummaries : sortedConversationsWithExternal,
           (c) => c.created ?? c.modified
         ).map(({ group, items }) => (
           <div key={group}>
@@ -716,44 +712,43 @@ export const ConversationList: FC<Props> = ({
         </div>
       )}
 
-      {/* For non-recency sorts: external sessions can't be ranked by message count or alpha among
-          native conversations, so show them in a labeled group at the bottom.
-          For 'recent' sort, external sessions are merged inline above (true unified timeline). */}
-      {!isLoading &&
-        !isError &&
-        sortBy !== 'recent' &&
-        externalAsSummaries.length > 0 &&
+      {/* Non-recency sorts cannot rank external sessions alongside native conversations. Undated
+          sessions also live here in the recent view because they have no honest timeline position. */}
+      {((sortBy !== 'recent' && externalAsSummaries.length > 0) ||
+        (sortBy === 'recent' && undatedExternalSummaries.length > 0)) &&
         onSelectExternal && (
           <div>
             <div className="flex items-center gap-1 px-2 py-1.5 text-xs font-medium text-muted-foreground">
               <Layers className="h-3 w-3" />
-              External Sessions
+              {sortBy === 'recent' ? 'External Sessions — Unknown date' : 'External Sessions'}
             </div>
             <div className="space-y-1 px-2">
-              {externalAsSummaries.map((conv) => {
-                const ext = conv._externalSession!;
-                const isExtSelected = selectedExternalId === ext.id;
-                return (
-                  <button
-                    key={conv.id}
-                    className={`flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors hover:bg-accent/50 ${
-                      isExtSelected ? 'bg-accent ring-1 ring-primary' : ''
-                    }`}
-                    aria-pressed={isExtSelected}
-                    onClick={() => onSelectExternal(ext.id)}
-                  >
-                    <Badge variant="secondary" className="h-4 flex-shrink-0 px-1.5 text-[10px]">
-                      {ext.label}
-                    </Badge>
-                    <span className="min-w-0 flex-1 truncate text-xs">{conv.name}</span>
-                    {conv.modified > 0 && (
-                      <span className="flex-shrink-0 text-[10px] text-muted-foreground">
-                        {getRelativeTimeString(new Date(conv.modified * 1000))}
-                      </span>
-                    )}
-                  </button>
-                );
-              })}
+              {(sortBy === 'recent' ? undatedExternalSummaries : externalAsSummaries).map(
+                (conv) => {
+                  const ext = conv._externalSession!;
+                  const isExtSelected = selectedExternalId === ext.id;
+                  return (
+                    <button
+                      key={conv.id}
+                      className={`flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors hover:bg-accent/50 ${
+                        isExtSelected ? 'bg-accent ring-1 ring-primary' : ''
+                      }`}
+                      aria-pressed={isExtSelected}
+                      onClick={() => onSelectExternal(ext.id)}
+                    >
+                      <Badge variant="secondary" className="h-4 flex-shrink-0 px-1.5 text-[10px]">
+                        {ext.label}
+                      </Badge>
+                      <span className="min-w-0 flex-1 truncate text-xs">{conv.name}</span>
+                      {conv.modified > 0 && (
+                        <span className="flex-shrink-0 text-[10px] text-muted-foreground">
+                          {getRelativeTimeString(new Date(conv.modified * 1000))}
+                        </span>
+                      )}
+                    </button>
+                  );
+                }
+              )}
             </div>
           </div>
         )}

--- a/webui/src/components/ConversationList.tsx
+++ b/webui/src/components/ConversationList.tsx
@@ -380,6 +380,31 @@ export const ConversationList: FC<Props> = ({
           return getConversationName(a).localeCompare(getConversationName(b));
         });
 
+  // For 'recent' view: merge external sessions into the native list (true unified timeline).
+  // External sessions are adapted to ConversationSummary shape and interleaved by modified time.
+  // For non-recency sorts, external sessions appear in a separate section (no message count to sort by).
+  const externalAsSummaries: ConversationSummary[] =
+    showExternal && externalSessions && onSelectExternal
+      ? externalSessions.map((item) => {
+          const modifiedMs = Date.parse(item.last_activity ?? item.started_at ?? '0');
+          const modified = Number.isFinite(modifiedMs) && modifiedMs > 0 ? modifiedMs / 1000 : 0;
+          const label = HARNESS_LABELS[item.harness] ?? item.harness;
+          const name = item.session_name ?? item.session_id.slice(0, 8);
+          return {
+            id: `ext:${item.id}`,
+            name,
+            modified,
+            _externalSession: { id: item.id, harness: item.harness, label },
+          } satisfies ConversationSummary;
+        })
+      : [];
+
+  // For 'recent': merge and re-sort so external sessions appear in the right timeline position.
+  const sortedConversationsWithExternal =
+    sortBy === 'recent' && externalAsSummaries.length > 0
+      ? [...sortedRealConversations, ...externalAsSummaries].sort((a, b) => b.modified - a.modified)
+      : sortedRealConversations;
+
   return (
     <div
       ref={scrollContainerRef}
@@ -508,12 +533,12 @@ export const ConversationList: FC<Props> = ({
         </div>
       )}
 
-      {/* Render real conversations: grouped by date for 'recent', flat list for other sorts */}
+      {/* Render conversations: grouped by date for 'recent' (native + external merged), flat list for other sorts */}
       {!isLoading &&
         !isError &&
         sortBy === 'recent' &&
         groupByDate<ConversationSummary>(
-          sortedRealConversations,
+          sortedConversationsWithExternal,
           (c) => c.created ?? c.modified
         ).map(({ group, items }) => (
           <div key={group}>
@@ -524,30 +549,57 @@ export const ConversationList: FC<Props> = ({
               {group}
             </div>
             <div className="space-y-2 px-2">
-              {items.map((conv) => (
-                <ConversationItem
-                  key={conv.serverId ? `${conv.serverId}:${conv.id}` : conv.id}
-                  conv={conv}
-                  showLabel={showServerLabels}
-                  selectedId$={selectedId$}
-                  onSelect={onSelect}
-                  renamingId={renamingId}
-                  renameValue={renameValue}
-                  setRenameValue={setRenameValue}
-                  onRenameSubmit={handleRenameSubmit}
-                  onRenameCancel={handleRenameCancel}
-                  setDeleteTarget={setDeleteTarget}
-                  getIsStarred={getIsStarred}
-                  toggleStar={toggleStar}
-                  onExportMarkdown={handleExportMarkdown}
-                  onExportJSON={handleExportJSON}
-                  onStartRename={handleStartRename}
-                  demoIds={demoIds}
-                  normalizedFilter={normalizedFilter}
-                  onOpenInSplitView={onOpenInSplitView}
-                  setOptimisticStars={setOptimisticStars}
-                />
-              ))}
+              {items.map((conv) => {
+                const ext = conv._externalSession;
+                if (ext) {
+                  // External session: compact badge row, no context menu
+                  const isExtSelected = selectedExternalId === ext.id;
+                  return (
+                    <button
+                      key={conv.id}
+                      className={`flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors hover:bg-accent/50 ${
+                        isExtSelected ? 'bg-accent ring-1 ring-primary' : ''
+                      }`}
+                      aria-pressed={isExtSelected}
+                      onClick={() => onSelectExternal!(ext.id)}
+                    >
+                      <Badge variant="secondary" className="h-4 flex-shrink-0 px-1.5 text-[10px]">
+                        {ext.label}
+                      </Badge>
+                      <span className="min-w-0 flex-1 truncate text-xs">{conv.name}</span>
+                      {conv.modified > 0 && (
+                        <span className="flex-shrink-0 text-[10px] text-muted-foreground">
+                          {getRelativeTimeString(new Date(conv.modified * 1000))}
+                        </span>
+                      )}
+                    </button>
+                  );
+                }
+                return (
+                  <ConversationItem
+                    key={conv.serverId ? `${conv.serverId}:${conv.id}` : conv.id}
+                    conv={conv}
+                    showLabel={showServerLabels}
+                    selectedId$={selectedId$}
+                    onSelect={onSelect}
+                    renamingId={renamingId}
+                    renameValue={renameValue}
+                    setRenameValue={setRenameValue}
+                    onRenameSubmit={handleRenameSubmit}
+                    onRenameCancel={handleRenameCancel}
+                    setDeleteTarget={setDeleteTarget}
+                    getIsStarred={getIsStarred}
+                    toggleStar={toggleStar}
+                    onExportMarkdown={handleExportMarkdown}
+                    onExportJSON={handleExportJSON}
+                    onStartRename={handleStartRename}
+                    demoIds={demoIds}
+                    normalizedFilter={normalizedFilter}
+                    onOpenInSplitView={onOpenInSplitView}
+                    setOptimisticStars={setOptimisticStars}
+                  />
+                );
+              })}
             </div>
           </div>
         ))}
@@ -655,47 +707,47 @@ export const ConversationList: FC<Props> = ({
         </div>
       )}
 
-      {/* External sessions section — compact view of cross-harness sessions (toggle-gated, off by default) */}
-      {showExternal && externalSessions && externalSessions.length > 0 && onSelectExternal && (
-        <div>
-          <div className="flex items-center gap-1 px-2 py-1.5 text-xs font-medium text-muted-foreground">
-            <Layers className="h-3 w-3" />
-            External Sessions
+      {/* For non-recency sorts: external sessions can't be ranked by message count or alpha among
+          native conversations, so show them in a labeled group at the bottom.
+          For 'recent' sort, external sessions are merged inline above (true unified timeline). */}
+      {!isLoading &&
+        !isError &&
+        sortBy !== 'recent' &&
+        externalAsSummaries.length > 0 &&
+        onSelectExternal && (
+          <div>
+            <div className="flex items-center gap-1 px-2 py-1.5 text-xs font-medium text-muted-foreground">
+              <Layers className="h-3 w-3" />
+              External Sessions
+            </div>
+            <div className="space-y-1 px-2">
+              {externalAsSummaries.map((conv) => {
+                const ext = conv._externalSession!;
+                const isExtSelected = selectedExternalId === ext.id;
+                return (
+                  <button
+                    key={conv.id}
+                    className={`flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors hover:bg-accent/50 ${
+                      isExtSelected ? 'bg-accent ring-1 ring-primary' : ''
+                    }`}
+                    aria-pressed={isExtSelected}
+                    onClick={() => onSelectExternal(ext.id)}
+                  >
+                    <Badge variant="secondary" className="h-4 flex-shrink-0 px-1.5 text-[10px]">
+                      {ext.label}
+                    </Badge>
+                    <span className="min-w-0 flex-1 truncate text-xs">{conv.name}</span>
+                    {conv.modified > 0 && (
+                      <span className="flex-shrink-0 text-[10px] text-muted-foreground">
+                        {getRelativeTimeString(new Date(conv.modified * 1000))}
+                      </span>
+                    )}
+                  </button>
+                );
+              })}
+            </div>
           </div>
-          <div className="space-y-1 px-2">
-            {externalSessions.slice(0, 10).map((session) => {
-              const displayName = session.session_name ?? session.session_id.slice(0, 8);
-              const harnessLabel = HARNESS_LABELS[session.harness] ?? session.harness;
-              const timeStr = session.last_activity
-                ? getRelativeTimeString(new Date(session.last_activity))
-                : session.started_at
-                  ? getRelativeTimeString(new Date(session.started_at))
-                  : null;
-              const isSelected = selectedExternalId === session.id;
-              return (
-                <button
-                  key={session.id}
-                  className={`flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors hover:bg-accent/50 ${
-                    isSelected ? 'bg-accent ring-1 ring-primary' : ''
-                  }`}
-                  aria-pressed={isSelected}
-                  onClick={() => onSelectExternal(session.id)}
-                >
-                  <Badge variant="secondary" className="h-4 flex-shrink-0 px-1.5 text-[10px]">
-                    {harnessLabel}
-                  </Badge>
-                  <span className="min-w-0 flex-1 truncate text-xs">{displayName}</span>
-                  {timeStr && (
-                    <span className="flex-shrink-0 text-[10px] text-muted-foreground">
-                      {timeStr}
-                    </span>
-                  )}
-                </button>
-              );
-            })}
-          </div>
-        </div>
-      )}
+        )}
 
       {/* Delete confirmation dialog */}
       {deleteTarget && (

--- a/webui/src/components/__tests__/ConversationList.test.tsx
+++ b/webui/src/components/__tests__/ConversationList.test.tsx
@@ -631,5 +631,42 @@ describe('ConversationList', () => {
       // Harness badge is present
       expect(screen.getByText('CC')).toBeInTheDocument();
     });
+
+    it('shows undated external sessions without a January 1970 group', () => {
+      localStorage.setItem('gptme:show-external-sessions', 'true');
+      renderWithProviders(
+        <ConversationList
+          {...defaultProps}
+          conversations={[]}
+          externalSessions={[{ ...externalSession, started_at: null, last_activity: null }]}
+          onSelectExternal={onSelectExternal}
+        />
+      );
+
+      expect(screen.getByText('My CC Session')).toBeInTheDocument();
+      expect(screen.getByText('External Sessions — Unknown date')).toBeInTheDocument();
+      expect(screen.queryByText(/January 1970/)).not.toBeInTheDocument();
+    });
+
+    it.each([
+      { state: 'loading', props: { isLoading: true } },
+      {
+        state: 'failed',
+        props: { isError: true, error: new Error('Native request failed') },
+      },
+    ])('keeps external sessions visible while native conversations are $state', ({ props }) => {
+      localStorage.setItem('gptme:show-external-sessions', 'true');
+      renderWithProviders(
+        <ConversationList
+          {...defaultProps}
+          conversations={[]}
+          {...props}
+          externalSessions={[externalSession]}
+          onSelectExternal={onSelectExternal}
+        />
+      );
+
+      expect(screen.getByText('My CC Session')).toBeInTheDocument();
+    });
   });
 });

--- a/webui/src/components/__tests__/ConversationList.test.tsx
+++ b/webui/src/components/__tests__/ConversationList.test.tsx
@@ -541,8 +541,10 @@ describe('ConversationList', () => {
         />
       );
       fireEvent.click(screen.getByLabelText('Show external sessions'));
-      expect(screen.getByText('External Sessions')).toBeInTheDocument();
+      // External sessions are mixed inline with native conversations in the recent view —
+      // no separate "External Sessions" header; items appear with harness badge in date groups.
       expect(screen.getByText('My CC Session')).toBeInTheDocument();
+      expect(screen.getByText('CC')).toBeInTheDocument(); // harness badge
     });
 
     it('hides external sessions again after toggling twice', () => {
@@ -599,6 +601,35 @@ describe('ConversationList', () => {
       );
       fireEvent.click(screen.getByText('My CC Session'));
       expect(onSelectExternal).toHaveBeenCalledWith('ext-1');
+    });
+
+    it('external sessions appear mixed inline with native conversations in the date-grouped view', () => {
+      // Native conversation modified more recently than the external session
+      const recentNative = createConversation({
+        id: 'native-recent',
+        name: 'Recent Native',
+        modified: Date.now() / 1000,
+      });
+      // External session modified 1 hour ago
+      const olderExternal = {
+        ...externalSession,
+        last_activity: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+      };
+      localStorage.setItem('gptme:show-external-sessions', 'true');
+      renderWithProviders(
+        <ConversationList
+          {...defaultProps}
+          conversations={[recentNative]}
+          externalSessions={[olderExternal]}
+          onSelectExternal={onSelectExternal}
+        />
+      );
+      // Both appear — no separate "External Sessions" header in the recent/default view
+      expect(screen.getByText('Recent Native')).toBeInTheDocument();
+      expect(screen.getByText('My CC Session')).toBeInTheDocument();
+      expect(screen.queryByText('External Sessions')).not.toBeInTheDocument();
+      // Harness badge is present
+      expect(screen.getByText('CC')).toBeInTheDocument();
     });
   });
 });

--- a/webui/src/types/conversation.ts
+++ b/webui/src/types/conversation.ts
@@ -66,6 +66,12 @@ export interface ConversationSummary {
   description?: string | null;
   tags?: string[];
   pinned_order?: number | null;
+  // Client-only: set when this entry is an external session merged into the list
+  _externalSession?: {
+    id: string; // original external session id (for API calls and selection)
+    harness: string;
+    label: string;
+  };
 }
 
 export interface GenerateCallbacks {


### PR DESCRIPTION
## Summary

Implements the missing piece of #3217: external sessions now appear **truly mixed** (interleaved by recency) with native gptme conversations in the default view.

### What changed

Prior art (#3281, #3306) added the sidebar toggle and inline transcript view, but external sessions still rendered in a **separate bottom section** ("External Sessions") after all native conversations. The issue title says "mixed" and the design proposal described a unified timeline sorted by recency — that was the gap.

This PR closes it:

- **`ConversationSummary`** gains a client-only `_externalSession` marker (id, harness, label) so adapted external items can safely coexist in the merged sorted list
- **`sortedConversationsWithExternal`** merges native + external, re-sorted by `modified` desc, for the default 'recent' sort view
- **Date-grouped render** detects `_externalSession` items and renders them as compact badge rows (harness label + session name + relative time) **inline within the correct date group** — no separate section
- For **non-recency sorts** (longest/alpha), external sessions still appear in a labeled bottom group because message-count and alpha ordering don't apply to them
- Old `externalSessions.slice(0, 10)` bottom section removed; the 10-item cap is gone
- **Test**: updated expectation (no separate "External Sessions" header in default view; harness badge appears instead) + new test verifying inline mixing

### UX

1. User enables "Ext" toggle → external sessions interleave with native conversations in the "Today" / "Last 7 days" groups by their `last_activity` time
2. Harness badge (CC, Codex, etc.) distinguishes external sessions from native ones
3. Click opens the session inline in the native chat layout (unchanged from #3306)
4. Steering input appears when `steer_inject` is in capabilities (unchanged from #3287)

### Testing

- 568/568 frontend tests pass
- TypeScript: clean
- New test: `external sessions appear mixed inline with native conversations in the date-grouped view`

Closes #3217

<!-- gptme-id:v1:gai_evfzoHYkWoDauKsXj0Xcg4rfxHLi4IkVv5PLmCaIZLv -->