### PR TITLE
feat(tui): show 'Generating…' placeholder before first token

### DIFF
--- a/gptme/tui/app.py
+++ b/gptme/tui/app.py
@@ -108,7 +108,7 @@ class StreamingMessage(Vertical):
     def __init__(self) -> None:
         super().__init__(classes="message assistant streaming")
         self._buffer = ""
-        self._body = Static(Text(""))
+        self._body = Static(Text("Generating…", style="dim italic"))
 
     def compose(self) -> ComposeResult:
         yield Static(Text("Assistant"), classes="role")
@@ -901,6 +901,13 @@ class GptmeApp(App):
 
     def _begin_stream(self) -> None:
         self._set_state("generating")
+        if self.inline:
+            self.query_one("#live", Static).update(
+                Text("Generating…", style="dim italic")
+            )
+        elif self._stream_widget is None:
+            self._stream_widget = StreamingMessage()
+            self._mount_in_chat(self._stream_widget)
 
     def _on_stream_token(self, token: str) -> None:
         if self.inline:


### PR DESCRIPTION
## Summary

- Mounts the `StreamingMessage` widget immediately when `_begin_stream()` is called, displaying a dimmed italic "Generating…" placeholder in the chat area
- Previously, users saw no chat-area feedback between sending a message and the first token arriving — only the status bar changed to "generating"
- Also shows "Generating…" in the `#live` inline region for the inline layout mode

The placeholder is replaced automatically by `append_token()` when the first token arrives (since it overwrites `_body` with `Text(self._buffer)`).

Closes #3309