### PR TITLE
feat(tui): add input history, fix focus and visual polish

### DIFF
--- a/gptme/tui/app.py
+++ b/gptme/tui/app.py
@@ -236,6 +236,7 @@ class ChatInput(TextArea):
         self._history: list[str] = []
         self._history_idx = -1  # -1 = not browsing; 0 = most recent
         self._history_saved = ""  # text buffered when browsing started
+        self._history_edits: dict[int, str] = {}
 
     def _push_history(self, text: str) -> None:
         """Record a submitted entry; skip duplicates of the last item."""
@@ -243,6 +244,7 @@ class ChatInput(TextArea):
             self._history.append(text)
         self._history_idx = -1
         self._history_saved = ""
+        self._history_edits.clear()
 
     async def _on_key(self, event: events.Key) -> None:
         if event.key == "enter":
@@ -268,10 +270,14 @@ class ChatInput(TextArea):
                 event.prevent_default()
                 if self._history_idx == -1:
                     self._history_saved = self.text
+                else:
+                    self._history_edits[self._history_idx] = self.text
                 new_idx = self._history_idx + 1
                 if new_idx < len(self._history):
                     self._history_idx = new_idx
-                    self._set_text(self._history[-(new_idx + 1)])
+                    self._set_text(
+                        self._history_edits.get(new_idx, self._history[-(new_idx + 1)])
+                    )
                 return
         if event.key == "down":
             lines = self.text.split("\n")
@@ -279,14 +285,16 @@ class ChatInput(TextArea):
             if row == len(lines) - 1 and self._history_idx >= 0:
                 event.stop()
                 event.prevent_default()
+                self._history_edits[self._history_idx] = self.text
                 new_idx = self._history_idx - 1
                 if new_idx < 0:
                     self._history_idx = -1
                     self._set_text(self._history_saved)
-                    self._history_saved = ""
                 else:
                     self._history_idx = new_idx
-                    self._set_text(self._history[-(new_idx + 1)])
+                    self._set_text(
+                        self._history_edits.get(new_idx, self._history[-(new_idx + 1)])
+                    )
                 return
         await super()._on_key(event)
 

--- a/gptme/tui/app.py
+++ b/gptme/tui/app.py
@@ -221,7 +221,7 @@ def complete_input(text: str) -> list[str]:
 
 class ChatInput(TextArea):
     """Multi-line input: Enter submits, Alt+Enter/Ctrl+J inserts a newline,
-    Tab completes slash-commands."""
+    Tab completes slash-commands, Up/Down navigates history."""
 
     class Submitted(TextualMessage):
         def __init__(self, value: str) -> None:
@@ -233,6 +233,16 @@ class ChatInput(TextArea):
         self._tab_candidates: list[str] = []
         self._tab_index = -1
         self._tab_last = ""
+        self._history: list[str] = []
+        self._history_idx = -1  # -1 = not browsing; 0 = most recent
+        self._history_saved = ""  # text buffered when browsing started
+
+    def _push_history(self, text: str) -> None:
+        """Record a submitted entry; skip duplicates of the last item."""
+        if text and (not self._history or self._history[-1] != text):
+            self._history.append(text)
+        self._history_idx = -1
+        self._history_saved = ""
 
     async def _on_key(self, event: events.Key) -> None:
         if event.key == "enter":
@@ -251,6 +261,33 @@ class ChatInput(TextArea):
             event.prevent_default()
             self._cycle_completion()
             return
+        if event.key == "up":
+            row, _ = self.cursor_location
+            if row == 0 and self._history:
+                event.stop()
+                event.prevent_default()
+                if self._history_idx == -1:
+                    self._history_saved = self.text
+                new_idx = self._history_idx + 1
+                if new_idx < len(self._history):
+                    self._history_idx = new_idx
+                    self._set_text(self._history[-(new_idx + 1)])
+                return
+        if event.key == "down":
+            lines = self.text.split("\n")
+            row, _ = self.cursor_location
+            if row == len(lines) - 1 and self._history_idx >= 0:
+                event.stop()
+                event.prevent_default()
+                new_idx = self._history_idx - 1
+                if new_idx < 0:
+                    self._history_idx = -1
+                    self._set_text(self._history_saved)
+                    self._history_saved = ""
+                else:
+                    self._history_idx = new_idx
+                    self._set_text(self._history[-(new_idx + 1)])
+                return
         await super()._on_key(event)
 
     def _set_text(self, text: str) -> None:
@@ -386,6 +423,9 @@ class GptmeApp(App):
         padding: 0;
         background: transparent;
     }
+    .message Static {
+        background: transparent;
+    }
     .message MarkdownFence {
         margin: 0;
     }
@@ -417,8 +457,10 @@ class GptmeApp(App):
         height: 1;
         margin-top: 1;
         padding: 0 1;
-        background: $surface;
         color: $text-muted;
+    }
+    Screen:inline #status {
+        margin-top: 0;
     }
     ConfirmScreen {
         align: center middle;
@@ -545,6 +587,9 @@ class GptmeApp(App):
         if not self.inline:
             # inline mode prints history to the terminal before the app starts
             self._render_history()
+            # prevent the chat scroll area from stealing focus; input is always
+            # the active widget for keyboard input
+            self.query_one("#chat", VerticalScroll).can_focus = False
         self.query_one("#input", ChatInput).focus()
         self._update_status()
         # watchdog: tools can reset the tty at any point during execution
@@ -691,7 +736,10 @@ class GptmeApp(App):
 
     def on_chat_input_submitted(self, event: ChatInput.Submitted) -> None:
         text = event.value.strip()
-        self.query_one("#input", ChatInput).text = ""
+        chat_input = self.query_one("#input", ChatInput)
+        chat_input.text = ""
+        if text:
+            chat_input._push_history(text)
         logger.debug(
             "input submitted: %r (generating=%s, queue=%d)",
             text[:80],

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -194,3 +194,21 @@ async def test_tab_completes_command(tmp_path):
         assert inp.text.startswith("/model")
         # tab must not switch focus away from the input
         assert app.focused is inp
+
+
+@pytest.mark.asyncio
+async def test_history_preserves_edits_while_browsing(tmp_path):
+    app = GptmeApp(make_manager(tmp_path), workspace=tmp_path)
+    async with app.run_test() as pilot:
+        inp = app.query_one("#input", ChatInput)
+        inp._push_history("previous prompt")
+        inp._set_text("draft prompt")
+
+        await pilot.press("up")
+        assert inp.text == "previous prompt"
+        inp._set_text("edited previous prompt")
+
+        await pilot.press("down")
+        assert inp.text == "draft prompt"
+        await pilot.press("up")
+        assert inp.text == "edited previous prompt"


### PR DESCRIPTION
Addresses #3311 (gptme-tui input feedback from Erik).

## Changes

**Input history (Up/Down)**
- `ChatInput` now records every submitted message in a `_history` list
- Pressing Up on the first line steps back through history; Down on the last line steps forward (or restores the in-progress draft)
- Duplicate consecutive entries are deduplicated; the draft text is saved/restored transparently

**Always focused**
- The chat `VerticalScroll` now has `can_focus = False`, so clicking the chat area no longer steals keyboard focus from the input
- In normal TUI mode the input is now always the active typing target (inline mode was already correct)

**Visual fixes**
- Remove `background: $surface` from `#status` to eliminate the gray tint on the status bar
- Add `.message Static { background: transparent }` to fix the gray background behind the "Generating…" italic placeholder in `StreamingMessage`
- Add `Screen:inline #status { margin-top: 0 }` to remove the extra blank line below the status bar in `--inline` mode

## Not in this PR (deferred)
- Alt+Left/Right word navigation (needs manual word-boundary scanning in TextArea)
- Tab completion visual display (needs a popup/overlay widget)
- Alt+Enter terminal reliability (terminal-emulator-specific; Shift+Enter/Ctrl+J are working fallbacks)
- Thinking display toggle