### PR TITLE
feat(tui): add Alt+Left/Right word navigation to ChatInput

### DIFF
--- a/gptme/tui/app.py
+++ b/gptme/tui/app.py
@@ -296,6 +296,16 @@ class ChatInput(TextArea):
                         self._history_edits.get(new_idx, self._history[-(new_idx + 1)])
                     )
                 return
+        if event.key == "alt+left":
+            event.stop()
+            event.prevent_default()
+            self.action_cursor_word_left()
+            return
+        if event.key == "alt+right":
+            event.stop()
+            event.prevent_default()
+            self.action_cursor_word_right()
+            return
         await super()._on_key(event)
 
     def _set_text(self, text: str) -> None:

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -212,3 +212,34 @@ async def test_history_preserves_edits_while_browsing(tmp_path):
         assert inp.text == "draft prompt"
         await pilot.press("up")
         assert inp.text == "edited previous prompt"
+
+
+@pytest.mark.asyncio
+async def test_word_navigation(tmp_path):
+    """Alt+Left/Right navigate by word boundary in the input."""
+    # "hello world foo": h=0 e=1 l=2 l=3 o=4 ' '=5 w=6 ... d=10 ' '=11 f=12 o=13 o=14
+    app = GptmeApp(make_manager(tmp_path), workspace=tmp_path)
+    async with app.run_test() as pilot:
+        inp = app.query_one("#input", ChatInput)
+        inp.focus()
+        inp.text = "hello world foo"
+        inp.move_cursor(inp.document.end)  # column 15
+        await pilot.pause()
+
+        await pilot.press("alt+left")
+        await pilot.pause()
+        _, col = inp.cursor_location
+        assert col == 12, f"expected col 12 (start of 'foo'), got {col}"
+
+        await pilot.press("alt+left")
+        await pilot.pause()
+        _, col = inp.cursor_location
+        assert col == 6, f"expected col 6 (start of 'world'), got {col}"
+
+        # from col 0, word-right jumps to end of 'hello' (col 5)
+        inp.move_cursor((0, 0))
+        await pilot.pause()
+        await pilot.press("alt+right")
+        await pilot.pause()
+        _, col = inp.cursor_location
+        assert col == 5, f"expected col 5 (end of 'hello'), got {col}"


### PR DESCRIPTION
Fixes part of #3311 — adds the **Alt+Left / Alt+Right word navigation** item.

## What changed

`ChatInput._on_key` now intercepts `alt+left` and `alt+right` and delegates to TextArea's existing `action_cursor_word_left` / `action_cursor_word_right` actions (which were already bound to Ctrl+Left/Ctrl+Right but not to Alt+Left/Alt+Right).

The change is a two-liner in `_on_key`, consistent with how the existing Up/Down history navigation and Tab completion interception work in the same method.

## Context

`TextArea` ships word-navigation actions and a `_word_pattern` that finds word/non-word transitions.  The actions are bound to `ctrl+left` / `ctrl+right` but not to `alt+left` / `alt+right`, which is what many users expect from readline/fish muscle memory.  Aliasing `alt+left`/`alt+right` to the same actions gives both keybinding families without duplicating any logic.

## Tests

Added `test_word_navigation` — verifies that:
- `alt+left` from end of "hello world foo" jumps to start of "foo" (col 12), then start of "world" (col 6)
- `alt+right` from col 0 jumps to the end of "hello" (col 5)

All 13 TUI tests pass locally.

## Items still deferred from #3311

- Tab completion visual candidate list (needs popup/overlay widget)
- Alt+Enter reliability (terminal-emulator-specific; Shift+Enter/Ctrl+J work)
- Thinking display toggle (separate PR scope)

<!-- gptme-id:v1:gai_Asb9Q5ndtTE34EK66rMTBXVybzzzn8GUM3NaN1MSAIH -->