### PR TITLE
feat(tui): persist input history to shared prompt-toolkit history file

### DIFF
--- a/gptme/tui/app.py
+++ b/gptme/tui/app.py
@@ -8,8 +8,6 @@ output is rendered in collapsible sections for a compact view.
 
 import contextlib
 import contextvars
-import datetime
-import fcntl
 import io
 import logging
 import os.path
@@ -44,6 +42,7 @@ from ..tools import ToolFormat, ToolUse
 from ..tools.base import ToolUse as ToolUseType
 from ..tools.complete import SessionCompleteException
 from ..util.context import include_paths
+from ..util.history import append_history, load_history
 from ..util.tokens import len_tokens
 
 logger = logging.getLogger(__name__)
@@ -223,40 +222,13 @@ def complete_input(text: str) -> list[str]:
 
 
 def _load_pt_history(path: Path) -> list[str]:
-    """Read a prompt-toolkit FileHistory file; return entries oldest-first."""
-    if not path.exists():
-        return []
-    entries: list[str] = []
-    current: list[str] = []
-    try:
-        with path.open() as f:
-            for raw in f:
-                line = raw.rstrip("\n")
-                if line.startswith("+"):
-                    current.append(line[1:])
-                elif not line.strip():
-                    if current:
-                        entries.append("\n".join(reversed(current)))
-                        current = []
-        if current:
-            entries.append("\n".join(reversed(current)))
-    except OSError:
-        pass
-    return entries
+    """Read a prompt-toolkit history file; return entries oldest-first."""
+    return load_history(path)
 
 
 def _append_pt_history(path: Path, text: str) -> None:
-    """Append one entry to a prompt-toolkit FileHistory file (atomic, concurrency-safe)."""
-    path.parent.mkdir(parents=True, exist_ok=True)
-    entry = f"\n# {datetime.datetime.now(datetime.timezone.utc)}\n"
-    for line in text.split("\n"):
-        entry += f"+{line}\n"
-    with path.open("a") as f:
-        fcntl.flock(f, fcntl.LOCK_EX)
-        try:
-            f.write(entry)
-        finally:
-            fcntl.flock(f, fcntl.LOCK_UN)
+    """Append one entry under the lock shared with the CLI."""
+    append_history(path, text)
 
 
 class ChatInput(TextArea):

--- a/gptme/tui/app.py
+++ b/gptme/tui/app.py
@@ -8,6 +8,7 @@ output is rendered in collapsible sections for a compact view.
 
 import contextlib
 import contextvars
+import datetime
 import io
 import logging
 import os.path
@@ -31,6 +32,7 @@ from textual.worker import Worker, WorkerState
 
 from ..chat import step
 from ..constants import DECLINED_CONTENT, INTERRUPT_CONTENT
+from ..dirs import get_pt_history_file
 from ..hooks import HookType, register_hook, unregister_hook
 from ..hooks.cli_confirm import _get_lang_for_tool
 from ..hooks.confirm import ConfirmationResult
@@ -219,6 +221,38 @@ def complete_input(text: str) -> list[str]:
         return []
 
 
+def _load_pt_history(path: Path) -> list[str]:
+    """Read a prompt-toolkit FileHistory file; return entries oldest-first."""
+    if not path.exists():
+        return []
+    entries: list[str] = []
+    current: list[str] = []
+    try:
+        with path.open() as f:
+            for raw in f:
+                line = raw.rstrip("\n")
+                if line.startswith("+"):
+                    current.append(line[1:])
+                elif not line.strip():
+                    if current:
+                        entries.append("\n".join(reversed(current)))
+                        current = []
+        if current:
+            entries.append("\n".join(reversed(current)))
+    except OSError:
+        pass
+    return entries
+
+
+def _append_pt_history(path: Path, text: str) -> None:
+    """Append one entry to a prompt-toolkit FileHistory file."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a") as f:
+        f.write(f"\n# {datetime.datetime.now(datetime.timezone.utc)}\n")
+        for line in text.split("\n"):
+            f.write(f"+{line}\n")
+
+
 class ChatInput(TextArea):
     """Multi-line input: Enter submits, Alt+Enter/Ctrl+J inserts a newline,
     Tab completes slash-commands, Up/Down navigates history."""
@@ -233,15 +267,17 @@ class ChatInput(TextArea):
         self._tab_candidates: list[str] = []
         self._tab_index = -1
         self._tab_last = ""
-        self._history: list[str] = []
+        self._history_file = get_pt_history_file()
+        self._history: list[str] = _load_pt_history(self._history_file)
         self._history_idx = -1  # -1 = not browsing; 0 = most recent
         self._history_saved = ""  # text buffered when browsing started
         self._history_edits: dict[int, str] = {}
 
     def _push_history(self, text: str) -> None:
-        """Record a submitted entry; skip duplicates of the last item."""
+        """Record a submitted entry and persist it to the shared history file."""
         if text and (not self._history or self._history[-1] != text):
             self._history.append(text)
+            _append_pt_history(self._history_file, text)
         self._history_idx = -1
         self._history_saved = ""
         self._history_edits.clear()

--- a/gptme/tui/app.py
+++ b/gptme/tui/app.py
@@ -9,6 +9,7 @@ output is rendered in collapsible sections for a compact view.
 import contextlib
 import contextvars
 import datetime
+import fcntl
 import io
 import logging
 import os.path
@@ -245,12 +246,17 @@ def _load_pt_history(path: Path) -> list[str]:
 
 
 def _append_pt_history(path: Path, text: str) -> None:
-    """Append one entry to a prompt-toolkit FileHistory file."""
+    """Append one entry to a prompt-toolkit FileHistory file (atomic, concurrency-safe)."""
     path.parent.mkdir(parents=True, exist_ok=True)
+    entry = f"\n# {datetime.datetime.now(datetime.timezone.utc)}\n"
+    for line in text.split("\n"):
+        entry += f"+{line}\n"
     with path.open("a") as f:
-        f.write(f"\n# {datetime.datetime.now(datetime.timezone.utc)}\n")
-        for line in text.split("\n"):
-            f.write(f"+{line}\n")
+        fcntl.flock(f, fcntl.LOCK_EX)
+        try:
+            f.write(entry)
+        finally:
+            fcntl.flock(f, fcntl.LOCK_UN)
 
 
 class ChatInput(TextArea):
@@ -277,7 +283,12 @@ class ChatInput(TextArea):
         """Record a submitted entry and persist it to the shared history file."""
         if text and (not self._history or self._history[-1] != text):
             self._history.append(text)
-            _append_pt_history(self._history_file, text)
+            try:
+                _append_pt_history(self._history_file, text)
+            except OSError as e:
+                logger.warning(
+                    "failed to persist history to %s: %s", self._history_file, e
+                )
         self._history_idx = -1
         self._history_saved = ""
         self._history_edits.clear()

--- a/gptme/util/history.py
+++ b/gptme/util/history.py
@@ -1,0 +1,79 @@
+"""Prompt-toolkit-compatible persistent input history."""
+
+from __future__ import annotations
+
+import importlib
+from contextlib import contextmanager
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Iterator
+
+from prompt_toolkit.history import FileHistory
+
+try:
+    fcntl: Any = importlib.import_module("fcntl")
+except ImportError:  # pragma: no cover - Windows
+    fcntl = None
+
+try:
+    msvcrt: Any = importlib.import_module("msvcrt")
+except ImportError:  # pragma: no cover - POSIX
+    msvcrt = None
+
+
+@contextmanager
+def _history_lock(path: Path) -> Iterator[None]:
+    """Lock the stable sidecar for all gptme history writers."""
+    lock_path = path.with_name(f"{path.name}.lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with lock_path.open("a+b") as lock_file:
+        if fcntl is not None:
+            fcntl.flock(lock_file, fcntl.LOCK_EX)
+        elif msvcrt is not None:  # pragma: no cover - Windows
+            lock_file.seek(0)
+            lock_file.write(b"\0")
+            lock_file.flush()
+            lock_file.seek(0)
+            msvcrt.locking(lock_file.fileno(), msvcrt.LK_LOCK, 1)
+        try:
+            yield
+        finally:
+            if fcntl is not None:
+                fcntl.flock(lock_file, fcntl.LOCK_UN)
+            elif msvcrt is not None:  # pragma: no cover - Windows
+                lock_file.seek(0)
+                msvcrt.locking(lock_file.fileno(), msvcrt.LK_UNLCK, 1)
+
+
+class LockedFileHistory(FileHistory):
+    """A ``FileHistory`` whose reads and writes share a portable lock."""
+
+    def __init__(self, filename: str | Path) -> None:
+        self.path = Path(filename)
+        super().__init__(str(self.path))
+
+    def load_history_strings(self) -> Iterable[str]:
+        with _history_lock(self.path):
+            return list(super().load_history_strings())
+
+    def store_string(self, string: str) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with _history_lock(self.path):
+            super().store_string(string)
+            # FileHistory closes the stream before returning, so its complete
+            # entry is flushed before the lock is released.
+
+
+def load_history(path: Path) -> list[str]:
+    """Read prompt-toolkit history entries oldest-first."""
+    try:
+        return list(reversed(list(LockedFileHistory(path).load_history_strings())))
+    except OSError:
+        return []
+
+
+def append_history(path: Path, text: str) -> None:
+    """Append one prompt-toolkit history entry under the shared writer lock."""
+    LockedFileHistory(path).store_string(text)

--- a/gptme/util/prompt.py
+++ b/gptme/util/prompt.py
@@ -14,7 +14,6 @@ from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
 from prompt_toolkit.completion import Completer, Completion, PathCompleter
 from prompt_toolkit.document import Document
 from prompt_toolkit.formatted_text import ANSI, HTML, to_formatted_text
-from prompt_toolkit.history import FileHistory
 from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.keys import Keys
 from prompt_toolkit.lexers import PygmentsLexer
@@ -26,6 +25,7 @@ from pygments.token import Name, Text
 from rich.console import Console
 
 from ..dirs import get_pt_history_file
+from .history import LockedFileHistory
 
 # Make cache management functions available at module level
 __all__ = ["clear_path_cache", "check_cwd", "is_valid_path", "PathLexer"]
@@ -453,7 +453,7 @@ def get_prompt_session() -> PromptSession:
         history_path = get_pt_history_file()
         if not history_path.parent.exists():
             history_path.parent.mkdir(parents=True, exist_ok=True)
-        history = FileHistory(str(history_path))
+        history = LockedFileHistory(history_path)
         completer = GptmeCompleter()
 
         kb = KeyBindings()

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -281,29 +281,36 @@ def test_pt_history_write_error_is_isolated(tmp_path, monkeypatch):
     assert chat_input._history == ["hello"]
 
 
-def test_pt_history_concurrent_appends(tmp_path):
-    """Concurrent appends from multiple writers must not interleave entries."""
+def test_pt_history_concurrent_tui_and_cli_appends(tmp_path):
+    """TUI and CLI writers share one lock and cannot interleave entries."""
     import threading
 
+    from gptme.util.history import LockedFileHistory
+
     hist_file = tmp_path / "history.pt"
-    entries = [f"entry-{i}" for i in range(20)]
+    entries = [f"entry-{i}\nline-{i}" for i in range(20)]
     errors: list[Exception] = []
 
-    def writer(text: str) -> None:
+    def writer(index: int, text: str) -> None:
         try:
-            _append_pt_history(hist_file, text)
+            if index % 2:
+                _append_pt_history(hist_file, text)
+            else:
+                LockedFileHistory(hist_file).append_string(text)
         except Exception as e:
             errors.append(e)
 
-    threads = [threading.Thread(target=writer, args=(e,)) for e in entries]
-    for t in threads:
-        t.start()
-    for t in threads:
-        t.join()
+    threads = [
+        threading.Thread(target=writer, args=(i, entry))
+        for i, entry in enumerate(entries)
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
 
     assert not errors
     loaded = _load_pt_history(hist_file)
-    # Every entry must appear exactly once, with no corruption (no partial merges)
     assert sorted(loaded) == sorted(entries)
 
 

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -261,6 +261,52 @@ def test_pt_history_missing_file(tmp_path):
     assert _load_pt_history(tmp_path / "no-such-file.pt") == []
 
 
+def test_pt_history_write_error_is_isolated(tmp_path, monkeypatch):
+    """A write failure in _append_pt_history must not propagate out of _push_history."""
+    import gptme.tui.app as tui_app
+
+    hist_file = tmp_path / "history.pt"
+    # Route ChatInput init to the empty tmp file
+    monkeypatch.setattr(tui_app, "get_pt_history_file", lambda: hist_file)
+    # Simulate a read-only filesystem for all subsequent writes
+    monkeypatch.setattr(
+        tui_app,
+        "_append_pt_history",
+        lambda *_: (_ for _ in ()).throw(OSError("disk full")),
+    )
+
+    # _push_history must swallow the error; the in-memory history still grows
+    chat_input = ChatInput()
+    chat_input._push_history("hello")  # must not raise
+    assert chat_input._history == ["hello"]
+
+
+def test_pt_history_concurrent_appends(tmp_path):
+    """Concurrent appends from multiple writers must not interleave entries."""
+    import threading
+
+    hist_file = tmp_path / "history.pt"
+    entries = [f"entry-{i}" for i in range(20)]
+    errors: list[Exception] = []
+
+    def writer(text: str) -> None:
+        try:
+            _append_pt_history(hist_file, text)
+        except Exception as e:
+            errors.append(e)
+
+    threads = [threading.Thread(target=writer, args=(e,)) for e in entries]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors
+    loaded = _load_pt_history(hist_file)
+    # Every entry must appear exactly once, with no corruption (no partial merges)
+    assert sorted(loaded) == sorted(entries)
+
+
 @pytest.mark.asyncio
 async def test_history_persists_across_sessions(tmp_path, monkeypatch):
     """TUI history is written to and read from the shared pt history file."""

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -16,6 +16,8 @@ from gptme.tui.app import (
     InfoMessage,
     SystemMessage,
     UserMessage,
+    _append_pt_history,
+    _load_pt_history,
     _summarize,
 )
 
@@ -243,3 +245,45 @@ async def test_word_navigation(tmp_path):
         await pilot.pause()
         _, col = inp.cursor_location
         assert col == 5, f"expected col 5 (end of 'hello'), got {col}"
+
+
+def test_pt_history_roundtrip(tmp_path):
+    """_append_pt_history / _load_pt_history are inverse operations."""
+    hist_file = tmp_path / "history.pt"
+    _append_pt_history(hist_file, "first entry")
+    _append_pt_history(hist_file, "second entry")
+    entries = _load_pt_history(hist_file)
+    assert entries == ["first entry", "second entry"]
+
+
+def test_pt_history_missing_file(tmp_path):
+    """Loading a non-existent file returns an empty list."""
+    assert _load_pt_history(tmp_path / "no-such-file.pt") == []
+
+
+@pytest.mark.asyncio
+async def test_history_persists_across_sessions(tmp_path, monkeypatch):
+    """TUI history is written to and read from the shared pt history file."""
+    hist_file = tmp_path / "history.pt"
+
+    # Seed the history file with one pre-existing entry (simulates a prior CLI run)
+    _append_pt_history(hist_file, "prior cli entry")
+
+    # Patch get_pt_history_file so both sessions use the same tmp file
+    import gptme.tui.app as tui_app
+
+    monkeypatch.setattr(tui_app, "get_pt_history_file", lambda: hist_file)
+
+    # First TUI session: should load the prior entry and add a new one
+    app1 = GptmeApp(make_manager(tmp_path), workspace=tmp_path)
+    async with app1.run_test():
+        inp1 = app1.query_one("#input", ChatInput)
+        assert inp1._history == ["prior cli entry"]
+        inp1._push_history("tui entry one")
+        assert inp1._history == ["prior cli entry", "tui entry one"]
+
+    # Second TUI session: should see both entries from file
+    app2 = GptmeApp(make_manager(tmp_path), workspace=tmp_path)
+    async with app2.run_test():
+        inp2 = app2.query_one("#input", ChatInput)
+        assert inp2._history == ["prior cli entry", "tui entry one"]


### PR DESCRIPTION
Fixes part of #3311 — addresses the request that TUI history persist across invocations and share the same buffer as the CLI.

## What changed

`ChatInput` now reads from and writes to `~/.local/share/gptme/history.pt` (the same `FileHistory` file the CLI uses via `get_pt_history_file()`), so:

- **History persists** between TUI sessions — reopen the TUI, press ↑, and previous entries are there
- **History is shared with the CLI** — prompts submitted in `gptme` (non-TUI) appear in the TUI history and vice versa

Two module-level helpers handle the prompt-toolkit file format:
- `_load_pt_history(path)` — reads the `+`-prefixed line format, returns entries oldest-first
- `_append_pt_history(path, text)` — appends one entry in the same format `FileHistory.store_string()` uses

`ChatInput.__init__` calls `_load_pt_history` on startup; `_push_history` calls `_append_pt_history` whenever a new (non-duplicate) entry is added.

## Tests

Added three tests:
- `test_pt_history_roundtrip` — write+read roundtrip for multi-entry files
- `test_pt_history_missing_file` — graceful empty list on missing file
- `test_history_persists_across_sessions` — simulates a prior CLI entry, first TUI session loads it and adds its own, second TUI session sees both

All 16 TUI tests pass locally.

## Items still open from #3311

- Tab completion visual candidate list (needs popup/overlay widget)
- Alt+Enter reliability (terminal-emulator-specific; Shift+Enter/Ctrl+J work)
- Thinking display toggle