### PR TITLE
fix(server): flush proxy response buffer after terminal SSE events

### DIFF
--- a/gptme/server/api_v2_sessions.py
+++ b/gptme/server/api_v2_sessions.py
@@ -62,6 +62,18 @@ from .session_step import (  # noqa: F401
 
 logger = logging.getLogger(__name__)
 
+# After terminal SSE events, pad the response to exceed typical proxy response
+# buffers (~4 KB for Traefik). X-Accel-Buffering:no is nginx-specific and not
+# recognised by Traefik or other ingresses, so small payloads can sit in the
+# proxy buffer for 5+ seconds until an idle flush timer fires — causing the
+# visible delay between the last rendered token and the Stop→Submit transition.
+# SSE comment lines (starting with ":") are ignored by browsers.
+_PROXY_FLUSH_PAD = ": " + " " * 4094 + "\n\n"
+
+# Event types that signal the end of a generation turn and require immediate
+# delivery to the browser (Stop→Submit transition, error display, etc.).
+_TERMINAL_EVENT_TYPES = frozenset({"generation_complete", "error", "interrupted"})
+
 
 def _get_request_json_object() -> dict | tuple[flask.Response, int]:
     """Return request JSON as an object or a 400 error response.
@@ -232,9 +244,21 @@ def api_conversation_events(conversation_id: str):
                 # Check if there are new events
                 if last_event_index < (new_index := session.events_count):
                     # Send any new events
+                    has_terminal = False
                     for event in session.get_events_since(last_event_index):
                         yield f"data: {flask.json.dumps(event)}\n\n"
+                        if (
+                            isinstance(event, dict)
+                            and event.get("type") in _TERMINAL_EVENT_TYPES
+                        ):
+                            has_terminal = True
                     last_event_index = new_index
+                    # Pad to flush proxy response buffers after terminal events.
+                    # Without this, Traefik (and other non-nginx proxies) may
+                    # hold the small payload in their internal buffer for several
+                    # seconds before forwarding to the browser.
+                    if has_terminal:
+                        yield _PROXY_FLUSH_PAD
 
                 # Wait a bit before checking again
                 yield f"data: {flask.json.dumps({'type': 'ping'})}\n\n"
@@ -268,6 +292,8 @@ def api_conversation_events(conversation_id: str):
         headers={
             "Cache-Control": "no-cache",
             "X-Accel-Buffering": "no",  # Disable buffering in nginx
+            # Traefik does not recognise X-Accel-Buffering; the padding below
+            # is the server-side complement that flushes proxy response buffers.
         },
     )
 

--- a/tests/test_server_v2_sse.py
+++ b/tests/test_server_v2_sse.py
@@ -1,7 +1,14 @@
 """Tests for the Server-Sent Events (SSE) stream functionality in the V2 API."""
 
+import threading
+import time
+from typing import TYPE_CHECKING, cast
+
 import pytest
 import requests
+
+if TYPE_CHECKING:
+    from gptme.server.api_v2_common import GenerationCompleteEvent
 
 # Skip if flask not installed
 pytest.importorskip(
@@ -36,6 +43,105 @@ def test_event_stream(event_listener, wait_for_event):
     user_messages = [m for m in messages if m["role"] == "user"]
     assert len(user_messages) == 1
     assert user_messages[0]["content"] == "Test message"
+
+
+def test_proxy_flush_pad_constants():
+    """_PROXY_FLUSH_PAD must be a valid SSE comment of sufficient size to flush proxy buffers."""
+    from gptme.server.api_v2_sessions import (
+        _PROXY_FLUSH_PAD,
+        _TERMINAL_EVENT_TYPES,
+    )
+
+    # Must be a valid SSE comment (starts with ":", browsers ignore it)
+    assert _PROXY_FLUSH_PAD.startswith(": "), "Pad must be an SSE comment line"
+    assert _PROXY_FLUSH_PAD.endswith("\n\n"), "Pad must end with SSE event separator"
+    # Must be large enough to exceed typical proxy response buffers (~4KB for Traefik)
+    assert len(_PROXY_FLUSH_PAD) >= 4096, (
+        f"Pad is {len(_PROXY_FLUSH_PAD)} bytes; must be ≥4096 to flush proxy buffers"
+    )
+
+    # Terminal event types that need the flush
+    assert "generation_complete" in _TERMINAL_EVENT_TYPES
+    assert "error" in _TERMINAL_EVENT_TYPES
+    assert "interrupted" in _TERMINAL_EVENT_TYPES
+
+
+@pytest.mark.timeout(10)
+def test_flush_pad_emitted_after_generation_complete(setup_conversation):
+    """SSE stream must include proxy flush padding immediately after generation_complete.
+
+    Regression test for the >5s Stop→Submit delay on Traefik-fronted staging:
+    X-Accel-Buffering:no is nginx-only; small payloads sit in Traefik's ~4KB
+    response buffer until an idle timeout fires.  The padding here ensures the
+    payload exceeds the buffer and is forwarded immediately.
+    """
+    from gptme.server.api_v2_sessions import _PROXY_FLUSH_PAD
+    from gptme.server.session_models import SessionManager
+
+    port, conversation_id, session_id = setup_conversation
+
+    raw_data = bytearray()
+    flush_seen = threading.Event()
+
+    def collect_stream():
+        resp = requests.get(
+            f"http://localhost:{port}/api/v2/conversations/{conversation_id}"
+            f"/events?session_id={session_id}",
+            headers={"Authorization": "Bearer test-token-for-server-thread"},
+            stream=True,
+            timeout=8,
+        )
+        try:
+            for chunk in resp.iter_content(chunk_size=None):
+                raw_data.extend(chunk)
+                # The flush pad is 4KB+; stop collecting once we've seen
+                # the generation_complete event AND enough data for the pad.
+                if b"generation_complete" in bytes(raw_data) and len(raw_data) > 4096:
+                    flush_seen.set()
+                    break
+        except Exception:
+            pass
+        finally:
+            try:
+                resp.close()
+            except Exception:
+                pass
+            flush_seen.set()  # unblock wait() on error
+
+    stream_thread = threading.Thread(target=collect_stream, daemon=True)
+    stream_thread.start()
+
+    # Let the SSE connection establish
+    time.sleep(0.3)
+
+    # Inject a terminal event directly — no LLM call needed.
+    # cast() is required because mypy cannot disambiguate anonymous dict literals
+    # from the union of TypedDicts accepted by add_event.
+    terminal_event = cast(
+        "GenerationCompleteEvent",
+        {
+            "type": "generation_complete",
+            "message": {
+                "role": "assistant",
+                "content": "Hello",
+                "timestamp": "2026-01-01T00:00:00+00:00",
+            },
+        },
+    )
+    SessionManager.add_event(conversation_id, terminal_event)
+
+    flush_seen.wait(timeout=5)
+
+    data = bytes(raw_data)
+    assert b"generation_complete" in data, "generation_complete event not in stream"
+
+    gen_pos = data.find(b"generation_complete")
+    pad_prefix = _PROXY_FLUSH_PAD[:20].encode()
+    pad_pos = data.find(pad_prefix, gen_pos)
+    assert pad_pos > gen_pos, (
+        "Proxy flush padding not found after generation_complete event — "
+        "Traefik and other reverse proxies will delay the Stop→Submit transition"
+    )
 
 
 @pytest.mark.xfail(reason="Flaky test")


### PR DESCRIPTION
## Summary

Fixes the >5s delay between the last rendered token and the Stop→Submit button transition + completion chime on Traefik-fronted staging (gptme.ai).

**Root cause**: `X-Accel-Buffering: no` is nginx-specific. Traefik does not recognise it, so small SSE payloads (~300–500 bytes) sit in Traefik's ~4KB response buffer until an idle flush timer fires — causing the visible delay.

**Fix**: After yielding `generation_complete`, `error`, or `interrupted` events, the SSE generator now emits a 4KB SSE comment line (ignored by browsers). This pushes the payload over Traefik's buffer threshold, forcing immediate delivery to the browser.

```
: <4094 spaces>
```

SSE comment lines starting with `:` are part of the SSE spec and are silently discarded by `EventSource`.

## Changes

- `gptme/server/api_v2_sessions.py`: add `_PROXY_FLUSH_PAD` and `_TERMINAL_EVENT_TYPES` constants; yield pad after terminal events in the SSE loop
- `tests/test_server_v2_sse.py`: two new tests — constant validation + integration test that verifies the pad appears in the raw stream after `generation_complete`

## Test plan

- [x] `test_proxy_flush_pad_constants` — validates pad is a valid SSE comment ≥4096 bytes and terminal event types are correct
- [x] `test_flush_pad_emitted_after_generation_complete` — injects a terminal event into a live server and asserts the flush pad appears in the raw SSE stream after the event
- [x] All existing SSE and session model tests pass (219 tests)

Closes #3315

<!-- gptme-id:v1:gai_Ra01nbs1nVDJFky89ZaVFogP8217oX0G8SUKWMPRnFu -->