### PR TITLE
fix(server): flush proxy buffers after generation_complete SSE event

### DIFF
--- a/gptme/server/api_v2_sessions.py
+++ b/gptme/server/api_v2_sessions.py
@@ -232,9 +232,22 @@ def api_conversation_events(conversation_id: str):
                 # Check if there are new events
                 if last_event_index < (new_index := session.events_count):
                     # Send any new events
+                    generation_complete = False
                     for event in session.get_events_since(last_event_index):
                         yield f"data: {flask.json.dumps(event)}\n\n"
+                        if (
+                            isinstance(event, dict)
+                            and event.get("type") == "generation_complete"
+                        ):
+                            generation_complete = True
                     last_event_index = new_index
+                    if generation_complete:
+                        # Reverse proxies (nginx, Traefik) buffer small SSE chunks until the
+                        # buffer fills (~4 KB) or an idle timeout fires (~5s). generation_complete
+                        # + ping together are only ~200 bytes, so without this padding the client
+                        # sees a 5s+ delay before the Stop→Submit state change. A single large SSE
+                        # comment forces an immediate buffer flush.
+                        yield f": {'x' * 4000}\n\n"
 
                 # Wait a bit before checking again
                 yield f"data: {flask.json.dumps({'type': 'ping'})}\n\n"

--- a/tests/test_server_v2_sessions.py
+++ b/tests/test_server_v2_sessions.py
@@ -1147,6 +1147,7 @@ class TestEventsEndpoint:
 
             assert b'"type": "generation_complete"' in next(stream)
             padding = next(stream)
+            assert isinstance(padding, bytes)
             assert padding.startswith(b": ")
             assert padding.endswith(b"\n\n")
             assert len(padding) >= 4000

--- a/tests/test_server_v2_sessions.py
+++ b/tests/test_server_v2_sessions.py
@@ -1123,6 +1123,36 @@ class TestElicitRespondEndpoint:
 class TestEventsEndpoint:
     """Test GET /api/v2/conversations/<id>/events validation."""
 
+    def test_generation_complete_emits_proxy_flush_padding(
+        self, conv, client: FlaskClient
+    ):
+        """A completion event is followed by a wire-level 4 KB SSE comment."""
+        session = SessionManager.get_session(conv["session_id"])
+        assert session is not None
+
+        response = client.get(
+            f"/api/v2/conversations/{conv['conversation_id']}/events"
+            f"?session_id={conv['session_id']}",
+            buffered=False,
+        )
+        stream = iter(response.response)
+        try:
+            next(stream)  # connected
+            next(stream)  # initial ping
+            next(stream)  # loop ping before the generator blocks
+
+            SessionManager.add_event(
+                conv["conversation_id"], {"type": "generation_complete"}
+            )
+
+            assert b'"type": "generation_complete"' in next(stream)
+            padding = next(stream)
+            assert padding.startswith(b": ")
+            assert padding.endswith(b"\n\n")
+            assert len(padding) >= 4000
+        finally:
+            response.close()
+
     def test_invalid_session_id_returns_404(self, conv, client: FlaskClient):
         """Events with nonexistent session_id returns 404."""
         response = client.get(


### PR DESCRIPTION
## Summary

- Reverse proxies (nginx, Traefik) buffer small SSE payloads until the buffer fills (~4 KB) or an idle timeout fires (~5s)
- After generation is complete, the server goes silent for up to 15 seconds — `generation_complete` + `ping` together are only ~200 bytes, not enough to trigger a flush
- This caused a >5s delay before the Stop→Submit state change and turn-complete chime in the staging environment

**Fix**: After yielding a batch that contains `generation_complete`, immediately yield a 4 KB SSE comment to force the proxy buffer to flush. SSE comment lines are discarded by clients — this is transparent to the frontend.

## Root cause chain

```
model finishes → generation_complete event emitted (~200 bytes)
→ proxy buffer holds it (< 4 KB, server goes silent for 15s)
→ client receives event 5+ seconds late
→ Stop→Submit flips late, chime fires late
```

With fix:
```
model finishes → generation_complete + 4 KB padding emitted
→ proxy buffer flushes immediately
→ client receives event in < 100ms
→ Stop→Submit flips, chime fires immediately
```

## Test plan

- [x] All 66 existing server tests pass (`tests/test_server.py`)
- [ ] Verify on staging: after model response completes, the Stop→Submit flip should happen in < 500ms (not 5+ seconds)

Closes #3315