### PR TITLE
fix(server): allow explicit workspace override when creating conversations

### DIFF
--- a/.github/workflows/webui.yml
+++ b/.github/workflows/webui.yml
@@ -118,7 +118,11 @@ jobs:
         ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY || 'dummy-ci-key' }}
         MODEL: anthropic/claude-3-5-haiku-latest
       run: |
-        gptme-server --cors-origin="http://localhost:5701" &
+        # Playwright serves the webui at http://127.0.0.1:5701 — the CORS origin
+        # must match that exact origin (localhost != 127.0.0.1 for CORS); with a
+        # mismatched origin the webui silently runs offline against demo data
+        # and no e2e test exercises the server at all.
+        gptme-server --cors-origin="http://127.0.0.1:5701,http://localhost:5701" &
         echo $! > /tmp/gptme-server.pid
         sleep 3
 
@@ -128,6 +132,10 @@ jobs:
     - name: Run e2e tests (stable)
       id: e2e-stable
       continue-on-error: true
+      env:
+        # Latest PyPI release still has the workspace-containment create
+        # regression (#2943, fixed by #3319). Remove after the next release.
+        E2E_SKIP_CREATE_CONVERSATION: '1'
       run: npm run test:e2e
 
     - name: Upload stable test results
@@ -145,17 +153,22 @@ jobs:
         kill "$(cat /tmp/gptme-server.pid)" 2>/dev/null || true
         sleep 2
 
-    # ── dev pass (git master) ─────────────────────────────────────────────────
-    - name: Install dev gptme (git master)
+    # ── dev pass (this checkout) ──────────────────────────────────────────────
+    # Install from the PR/branch checkout, NOT git master: the e2e run must
+    # exercise the server code under review, otherwise server-side regressions
+    # (like the #2943 create breakage) can never be caught pre-merge.
+    - name: Install dev gptme (this checkout)
       working-directory: .
-      run: pip install --force-reinstall 'gptme[server] @ git+https://github.com/gptme/gptme.git'
+      run: |
+        pip uninstall -y gptme
+        pip install '.[server]'
 
     - name: Start server (dev)
       env:
         ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY || 'dummy-ci-key' }}
         MODEL: anthropic/claude-3-5-haiku-latest
       run: |
-        gptme-server --cors-origin="http://localhost:5701" &
+        gptme-server --cors-origin="http://127.0.0.1:5701,http://localhost:5701" &
         echo $! > /tmp/gptme-server.pid
         sleep 3
 

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -1655,7 +1655,16 @@ def api_conversation_put(conversation_id: str):
     config_dict["_logdir"] = logdir  # Pass logdir for "@log" workspace resolution
     # Server sessions default to an isolated per-conversation workspace so they
     # don't inherit the server process's cwd.  Clients can override by passing an
-    # explicit workspace in the request config.
+    # explicit workspace in the request config (e.g. the webui workspace picker,
+    # which sends "." or an absolute path for every new conversation).
+    #
+    # No containment check here: an authorized API client can already run
+    # arbitrary shell commands through the agent, so restricting the workspace
+    # at creation adds no security boundary — it only broke webui conversation
+    # creation. Network binds require bearer auth and browsers can't send
+    # cross-origin JSON PUTs without an explicit --cors-origin opt-in.
+    # Workspace changes on *existing* conversations remain contained (see the
+    # config PATCH handler).
     config_dict.setdefault("chat", {})
     if not isinstance(config_dict["chat"], dict):
         return flask.jsonify({"error": "'config.chat' must be an object"}), 400
@@ -1664,12 +1673,6 @@ def api_conversation_put(conversation_id: str):
         request_config = ChatConfig.from_dict(config_dict, create_workspace=False)
     except ValueError as exc:
         return flask.jsonify({"error": str(exc)}), 400
-
-    # Enforce workspace containment: server clients must not direct the agent
-    # outside the conversation's logdir (path traversal / SSRF via workspace).
-    # Resolve logdir to handle symlinks (e.g. macOS /tmp -> /private/tmp).
-    if not request_config.workspace.is_relative_to(logdir.resolve()):
-        return flask.jsonify({"error": "workspace escapes conversation logdir"}), 400
 
     # Create the log directory atomically to avoid TOCTOU race
     try:

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -2703,16 +2703,22 @@ def api_conversation_config_patch(conversation_id: str):
     except ValueError as exc:
         return flask.jsonify({"error": str(exc)}), 400
 
-    # Enforce workspace containment: server clients must not direct the agent
-    # outside the conversation's logdir (path traversal / SSRF via workspace).
+    # Enforce workspace containment: a PATCH must not *redirect* the agent of
+    # an existing conversation outside the conversation's logdir.
     # Only enforce when workspace was explicitly provided — when absent, from_dict
     # infers it from the existing logdir/workspace symlink (which may legitimately
     # point outside logdir for CLI-created conversations).
+    # A round-trip of the already-persisted workspace is also allowed: the webui
+    # settings dialog echoes the full config (including workspace) on every
+    # save, and conversations legitimately have external workspaces (created
+    # via the CLI, or via PUT with an explicit workspace).
     if workspace_in_patch:
-        if not request_config.workspace.is_relative_to(logdir.resolve()):
-            return flask.jsonify(
-                {"error": "workspace escapes conversation logdir"}
-            ), 400
+        existing_workspace = ChatConfig.from_logdir(logdir).workspace
+        if request_config.workspace != existing_workspace:
+            if not request_config.workspace.is_relative_to(logdir.resolve()):
+                return flask.jsonify(
+                    {"error": "workspace escapes conversation logdir"}
+                ), 400
 
     try:
         chat_config = ChatConfig.load_or_create(logdir, request_config).save()

--- a/tests/test_server_config_workspace_containment.py
+++ b/tests/test_server_config_workspace_containment.py
@@ -1,10 +1,12 @@
-"""Tests for workspace path containment in server config endpoints.
+"""Tests for workspace handling in server config endpoints.
 
-Covers the security fix for path traversal via client-supplied workspace in:
-- PUT /api/v2/conversations/<id>  (create conversation with config)
-- PATCH /api/v2/conversations/<id>/config  (update conversation config)
-
-Any workspace that escapes the conversation's logdir must be rejected with 400.
+- PUT /api/v2/conversations/<id> (create) accepts an explicit client-supplied
+  workspace: this is the documented override used by the webui workspace
+  picker (which sends "." or an absolute path for every new conversation).
+  An authorized API client can already run arbitrary shell commands through
+  the agent, so containment at creation adds no security boundary.
+- PATCH /api/v2/conversations/<id>/config (update) remains contained: a
+  workspace that escapes the conversation's logdir is rejected with 400.
 """
 
 import shutil
@@ -26,8 +28,8 @@ def _conv_id() -> str:
     return f"test-ws-containment-{uuid4().hex[:8]}"
 
 
-class TestPutWorkspaceContainment:
-    """PUT /api/v2/conversations/<id> must reject workspaces outside logdir."""
+class TestPutWorkspaceOverride:
+    """PUT /api/v2/conversations/<id> must accept explicit workspace overrides."""
 
     def test_default_atlog_workspace_is_accepted(self, client: FlaskClient):
         """No explicit workspace (defaults to @log) must succeed."""
@@ -45,51 +47,29 @@ class TestPutWorkspaceContainment:
         )
         assert resp.status_code == 200
 
-    def test_absolute_escape_is_rejected(self, client: FlaskClient):
-        """workspace pointing outside logdir (absolute path) must be 400."""
+    def test_explicit_external_workspace_is_accepted(
+        self, client: FlaskClient, tmp_path: Path
+    ):
+        """An explicit absolute workspace outside the logdir must succeed
+        and be reflected in the conversation config (webui workspace picker)."""
+        cid = _conv_id()
         resp = client.put(
-            f"/api/v2/conversations/{_conv_id()}",
-            json={"prompt": "none", "config": {"chat": {"workspace": "/etc"}}},
+            f"/api/v2/conversations/{cid}",
+            json={"prompt": "none", "config": {"chat": {"workspace": str(tmp_path)}}},
         )
-        assert resp.status_code == 400
-        data = resp.get_json()
-        assert "workspace" in data["error"].lower()
+        assert resp.status_code == 200
 
-    def test_absolute_tmp_escape_is_rejected(self, client: FlaskClient):
-        """workspace pointing to /tmp (outside logdir) must be 400."""
-        resp = client.put(
-            f"/api/v2/conversations/{_conv_id()}",
-            json={"prompt": "none", "config": {"chat": {"workspace": "/tmp/evil"}}},
-        )
-        assert resp.status_code == 400
+        config = client.get(f"/api/v2/conversations/{cid}/config").get_json()
+        assert Path(config["chat"]["workspace"]).resolve() == tmp_path.resolve()
 
-    def test_relative_escape_via_cwd_is_rejected(self, client: FlaskClient):
-        """Relative workspace that resolves outside logdir must be 400.
-
-        A bare relative path like '.' resolves to CWD (the server process
-        directory), which is almost certainly outside the logdir.
-        """
+    def test_relative_dot_workspace_is_accepted(self, client: FlaskClient):
+        """workspace='.' (sent by the webui for every new conversation by
+        default) resolves against the server cwd and must succeed."""
         resp = client.put(
             f"/api/v2/conversations/{_conv_id()}",
             json={"prompt": "none", "config": {"chat": {"workspace": "."}}},
         )
-        # The CWD of the test process is not within the logdir, so this should 400.
-        # (If by some coincidence CWD is a subdirectory of logdir, the test would
-        # incorrectly pass, but that cannot happen in practice.)
-        assert resp.status_code == 400
-
-    def test_no_conversation_created_on_escape(self, client: FlaskClient):
-        """Rejected workspace must not create the conversation (no side effects)."""
-        cid = _conv_id()
-        resp = client.put(
-            f"/api/v2/conversations/{cid}",
-            json={"prompt": "none", "config": {"chat": {"workspace": "/etc"}}},
-        )
-        assert resp.status_code == 400
-
-        # The conversation must not exist after the failed PUT
-        check = client.get(f"/api/v2/conversations/{cid}")
-        assert check.status_code == 404
+        assert resp.status_code == 200
 
 
 class TestPatchWorkspaceContainment:

--- a/tests/test_server_config_workspace_containment.py
+++ b/tests/test_server_config_workspace_containment.py
@@ -122,6 +122,51 @@ class TestPatchWorkspaceContainment:
         )
         assert resp.status_code == 400
 
+    def test_roundtrip_of_persisted_external_workspace_is_accepted(
+        self, client: FlaskClient, tmp_path: Path
+    ):
+        """PATCH echoing the already-persisted external workspace must succeed.
+
+        The webui settings dialog sends the full config (including the
+        unchanged workspace) on every save; conversations legitimately have
+        external workspaces (CLI-created, or PUT with explicit workspace).
+        Only *redirecting* the workspace outside logdir is rejected."""
+        cid = _conv_id()
+        resp = client.put(
+            f"/api/v2/conversations/{cid}",
+            json={"prompt": "none", "config": {"chat": {"workspace": str(tmp_path)}}},
+        )
+        assert resp.status_code == 200
+
+        # Settings save round-trips the persisted workspace alongside the change
+        resp = client.patch(
+            f"/api/v2/conversations/{cid}/config",
+            json={"chat": {"workspace": str(tmp_path), "model": "gpt-4"}},
+        )
+        assert resp.status_code == 200, resp.get_json()
+
+        config = client.get(f"/api/v2/conversations/{cid}/config").get_json()
+        assert config["chat"]["model"] == "gpt-4"
+
+    def test_changing_to_different_external_workspace_is_rejected(
+        self, client: FlaskClient, tmp_path: Path
+    ):
+        """PATCH *changing* the workspace to a different external path must be 400."""
+        cid = _conv_id()
+        resp = client.put(
+            f"/api/v2/conversations/{cid}",
+            json={"prompt": "none", "config": {"chat": {"workspace": str(tmp_path)}}},
+        )
+        assert resp.status_code == 200
+
+        other = tmp_path.parent / f"{tmp_path.name}-other"
+        other.mkdir(exist_ok=True)
+        resp = client.patch(
+            f"/api/v2/conversations/{cid}/config",
+            json={"chat": {"workspace": str(other)}},
+        )
+        assert resp.status_code == 400
+
     def test_no_config_change_on_escape_patch(self, client: FlaskClient):
         """A rejected workspace PATCH must not modify the existing config."""
         cid = self._create_conv(client)

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -38,10 +38,9 @@ def create_conversation(client: FlaskClient, config: ChatConfig | None = None):
 
     if config:
         config_dict = config.to_dict()
-        # Strip workspace from the serialized config: the server security check
-        # rejects external workspace paths (path traversal fix). Tests that pass
-        # a config only care about model/tools/system_prompt, not the workspace;
-        # the server will apply the safe @log default.
+        # Strip workspace from the serialized config: tests that pass a config
+        # only care about model/tools/system_prompt, not the workspace; let the
+        # server apply the isolated @log default instead of the test-runner cwd.
         config_dict.get("chat", {}).pop("workspace", None)
         json["config"] = config_dict
 
@@ -1640,12 +1639,12 @@ def test_v2_create_conversation_default_system_prompt(
     )
 
     convname = f"test-server-v2-{random.randint(0, 1000000)}"
-    # Use the default @log workspace (workspace containment requires workspace
-    # to be inside the conversation logdir; external paths like tmp_path are
-    # rejected since the security fix for path traversal via config).
+    # Explicit external workspace: creation accepts client-supplied workspace
+    # overrides (the webui workspace picker relies on this).
     response = client.put(
         f"/api/v2/conversations/{convname}",
         json={
+            "config": {"chat": {"workspace": str(tmp_path)}},
             "messages": [
                 {
                     "role": "user",
@@ -1657,14 +1656,6 @@ def test_v2_create_conversation_default_system_prompt(
     )
     assert response.status_code == 200
     conversation_id = response.get_json()["conversation_id"]
-
-    # Fetch the config to learn the actual resolved workspace path (@log -> logdir/workspace)
-    config_resp = client.get(f"/api/v2/conversations/{conversation_id}/config")
-    assert config_resp.status_code == 200
-    from gptme.config.chat import ChatConfig  # fmt: skip
-
-    conv_config = ChatConfig.from_dict(config_resp.get_json())
-    actual_workspace = conv_config.workspace
 
     response = client.get(f"/api/v2/conversations/{conversation_id}")
     assert response.status_code == 200
@@ -1686,7 +1677,7 @@ def test_v2_create_conversation_default_system_prompt(
         tool_format="markdown",
         model=None,
         prompt="full",
-        workspace=actual_workspace,
+        workspace=tmp_path,
     )
     assert data["log"][0]["content"] == prompt_msgs[0].content
 
@@ -2081,7 +2072,7 @@ def test_v2_chat_config_update_works(client: FlaskClient):
 
     input_config.model = "openai/gpt-4o-mini"
     updated_config_dict = input_config.to_dict()
-    # Strip workspace: server security check rejects external paths (path traversal fix).
+    # Strip workspace: PATCH still enforces workspace containment (unlike create).
     updated_config_dict.get("chat", {}).pop("workspace", None)
     response = client.patch(
         f"/api/v2/conversations/{conversation_id}/config", json=updated_config_dict

--- a/webui/e2e/conversation.spec.ts
+++ b/webui/e2e/conversation.spec.ts
@@ -1,6 +1,18 @@
 import { test, expect } from '@playwright/test';
 
 test.describe('Connecting', () => {
+  test('connects to the API server (hard requirement)', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    // The chat input only becomes enabled once the app has a live server
+    // connection. If this fails, the suite is running offline against demo
+    // data and NO other test is exercising the API server — fix the server
+    // or the --cors-origin (must exactly match the Playwright origin;
+    // localhost != 127.0.0.1) rather than softening this assertion.
+    await expect(page.getByTestId('chat-input')).toBeEnabled({ timeout: 20000 });
+  });
+
   test('should connect and list conversations', async ({ page }) => {
     // Go to the app
     await page.goto('/');
@@ -123,7 +135,7 @@ test.describe('Conversation Creation', () => {
     // matches the Playwright origin exactly; localhost != 127.0.0.1).
     const input = page.getByTestId('chat-input');
     await expect(input).toBeVisible({ timeout: 10000 });
-    await expect(input).toBeEnabled({ timeout: 15000 });
+    await expect(input).toBeEnabled({ timeout: 20000 });
     await input.fill('Hello from the e2e test');
     await input.press('Enter');
 

--- a/webui/e2e/conversation.spec.ts
+++ b/webui/e2e/conversation.spec.ts
@@ -105,6 +105,32 @@ test.describe('Conversation Flow', () => {
   });
 });
 
+test.describe('Conversation Creation', () => {
+  test('should create a new conversation when submitting a message', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    // Type a message in the chat input and submit with Enter
+    const input = page.getByTestId('chat-input');
+    await expect(input).toBeVisible({ timeout: 10000 });
+    await input.fill('Hello from the e2e test');
+    await input.press('Enter');
+
+    // Server-side creation must succeed and navigate to the new conversation.
+    // Regression guard: the server once rejected every webui create with
+    // "workspace escapes conversation logdir" because the webui sends an
+    // explicit workspace ('.') with each create request.
+    await page.waitForURL(/\/chat\/chat-/, { timeout: 15000 });
+
+    // The submitted message should be rendered in the conversation
+    await expect(page.getByText('Hello from the e2e test')).toBeVisible({ timeout: 10000 });
+
+    // No creation-failure toast (generation itself may fail without API keys;
+    // this test only covers conversation creation)
+    await expect(page.getByText(/Failed to (create|start) conversation/)).not.toBeVisible();
+  });
+});
+
 test.describe('Split View', () => {
   test('should render split panes when ?split= param is present', async ({ page }) => {
     // Navigate with the split parameter using two demo conversation IDs

--- a/webui/e2e/conversation.spec.ts
+++ b/webui/e2e/conversation.spec.ts
@@ -106,13 +106,24 @@ test.describe('Conversation Flow', () => {
 });
 
 test.describe('Conversation Creation', () => {
+  // Set E2E_SKIP_CREATE_CONVERSATION=1 to skip when testing against a server
+  // known to reject webui creates (e.g. releases with the #2943 regression).
+  test.skip(
+    process.env.E2E_SKIP_CREATE_CONVERSATION === '1',
+    'server under test has the workspace-containment create regression (fixed by #3319)'
+  );
+
   test('should create a new conversation when submitting a message', async ({ page }) => {
     await page.goto('/');
     await page.waitForLoadState('networkidle');
 
-    // Type a message in the chat input and submit with Enter
+    // Type a message in the chat input and submit with Enter.
+    // The input stays disabled until the app connects to the server — if this
+    // times out, the webui never connected (check the server's --cors-origin
+    // matches the Playwright origin exactly; localhost != 127.0.0.1).
     const input = page.getByTestId('chat-input');
     await expect(input).toBeVisible({ timeout: 10000 });
+    await expect(input).toBeEnabled({ timeout: 15000 });
     await input.fill('Hello from the e2e test');
     await input.press('Enter');
 

--- a/webui/e2e/keyboard.spec.ts
+++ b/webui/e2e/keyboard.spec.ts
@@ -19,8 +19,10 @@ test.describe('Keyboard Navigation', () => {
   });
 
   test('shortcuts dialog: ? opens, Esc closes', async ({ page }) => {
-    // Click body to ensure focus is not in an input before pressing ?
-    await page.locator('body').click();
+    // The chat input autofocuses once the app connects to the server — blur
+    // it so '?' opens the dialog instead of typing into the input. (A bare
+    // body click is not enough to move focus away.)
+    await page.getByTestId('chat-input').blur();
 
     const dialog = page.getByRole('dialog', { name: /keyboard shortcuts/i });
     await expect(dialog).not.toBeVisible();
@@ -50,8 +52,10 @@ test.describe('Keyboard Navigation', () => {
   });
 
   test('focus trap: Tab stays inside an open dialog', async ({ page }) => {
-    // Open the shortcuts dialog (Radix UI Dialog traps focus)
-    await page.locator('body').click();
+    // Open the shortcuts dialog (Radix UI Dialog traps focus).
+    // Blur the (auto-focused, enabled-when-connected) chat input first so
+    // '?' reaches the global shortcut handler.
+    await page.getByTestId('chat-input').blur();
     await page.keyboard.press('?');
 
     const dialog = page.getByRole('dialog', { name: /keyboard shortcuts/i });


### PR DESCRIPTION
## Problem

Creating a conversation from the webui fails with:

```
Failed to create conversation: ApiClientError: workspace escapes conversation logdir
```

PR #2943 added a workspace containment check to the conversation create endpoint (`PUT /api/v2/conversations/<id>`), rejecting any workspace outside the conversation's logdir. But the webui sends an explicit workspace with **every** create request — `'.'` by default (`webui/src/utils/api.ts` `createConversationWithPlaceholder`), or an absolute path when picked via the workspace picker — so every new webui conversation 400s against a post-#2943 server.

gptme-cloud prod/staging are unaffected only because their pinned `gptme-server` image (`ghcr.io/gptme/gptme-server@sha256:ddd4295...`) was built **2026-01-30**, months before #2943 landed.

## Why relaxing create-time containment is OK

The check adds no security boundary at creation time: an authorized API client can already execute arbitrary shell commands through the agent itself, which strictly dominates "read files by pointing workspace somewhere". The actual boundaries are:
- bearer auth, required for non-localhost binds
- CORS preflight: cross-origin JSON PUTs are blocked unless the operator passes `--cors-origin`

The create handler's own comment already documented "Clients can override by passing an explicit workspace in the request config" — the check directly contradicted it. Note #2943's title also scoped it to the "config PUT/PATCH boundary", but the PUT here is *creation*, not mutation.

## Changes

- Remove the containment check from the create endpoint; keep the `@log` isolated default when no workspace is given
- **Keep** containment on `PATCH /api/v2/conversations/<id>/config` (mutating existing conversations)
- Update tests: create-side containment tests become override-accepted tests (external absolute path + `'.'` covered); PATCH containment tests unchanged; restore pre-#2943 explicit-workspace coverage in `test_v2_create_conversation_default_system_prompt`

## Follow-ups (separate discussion)

- DNS-rebinding hardening (Host header validation) for unauthenticated localhost servers would address the residual browser-based vector more directly than workspace containment did
- CI gap: no e2e test creates a conversation through the real webui against a real server, which is why this regression survived ~a month