### PR TITLE
feat(tui): tool-execution placeholder in chat + fix gray message background

### DIFF
--- a/gptme/tui/app.py
+++ b/gptme/tui/app.py
@@ -110,7 +110,7 @@ class StreamingMessage(Vertical):
     def __init__(self) -> None:
         super().__init__(classes="message assistant streaming")
         self._buffer = ""
-        self._body = Static(Text("Generating…", style="dim italic"))
+        self._body = Static(Text("Generating…"), classes="progress-placeholder")
 
     def compose(self) -> ComposeResult:
         yield Static(Text("Assistant"), classes="role")
@@ -126,14 +126,14 @@ class ToolPlaceholder(Vertical):
 
     def __init__(self) -> None:
         super().__init__(classes="message system tool-placeholder")
-        self._body = Static(Text("Running tool…", style="dim italic"))
+        self._body = Static(Text("Running tool…"), classes="progress-placeholder")
 
     def compose(self) -> ComposeResult:
         yield Static(Text("Tool"), classes="role")
         yield self._body
 
     def set_tool(self, tool_name: str) -> None:
-        self._body.update(Text(f"Running {tool_name}…", style="dim italic"))
+        self._body.update(Text(f"Running {tool_name}…"))
 
 
 class InfoMessage(Static):
@@ -478,6 +478,10 @@ class GptmeApp(App):
     }
     .message Static {
         background: transparent;
+    }
+    .message > .progress-placeholder {
+        color: $text-muted;
+        text-style: italic;
     }
     .message MarkdownFence {
         margin: 0;
@@ -1006,9 +1010,7 @@ class GptmeApp(App):
         self._clear_tool_placeholder()
         self._set_state("generating")
         if self.inline:
-            self.query_one("#live", Static).update(
-                Text("Generating…", style="dim italic")
-            )
+            self.query_one("#live", Static).update(Text("Generating…", style="italic"))
         elif self._stream_widget is None:
             self._stream_widget = StreamingMessage()
             self._mount_in_chat(self._stream_widget)
@@ -1042,7 +1044,7 @@ class GptmeApp(App):
     def _show_tool_placeholder(self) -> None:
         if self.inline:
             self.query_one("#live", Static).update(
-                Text("Running tool…", style="dim italic")
+                Text("Running tool…", style="italic")
             )
             return
         if self._tool_placeholder is not None:

--- a/gptme/tui/app.py
+++ b/gptme/tui/app.py
@@ -574,7 +574,6 @@ class GptmeApp(App):
         self._quitting = False
         self._stream_widget: StreamingMessage | None = None
         self._tool_placeholder: ToolPlaceholder | None = None
-        self._pending_tool_count: int = 0
         self._outputs_expanded = False
         self._stdio_sink: IO[str] | None = None
         self._real_stdout: IO[str] | None = None
@@ -1003,6 +1002,8 @@ class GptmeApp(App):
         self.call_from_thread(self._on_stream_token, token)
 
     def _begin_stream(self) -> None:
+        # A new model step starts only after the previous tool batch finished.
+        self._clear_tool_placeholder()
         self._set_state("generating")
         if self.inline:
             self.query_one("#live", Static).update(
@@ -1062,19 +1063,17 @@ class GptmeApp(App):
             # replace the live stream view with the final rendering
             self._clear_stream_view()
         if msg.role == "system":
-            # one tool finished: decrement counter; clear placeholder only when all done
-            self._pending_tool_count = max(0, self._pending_tool_count - 1)
-            if self._pending_tool_count == 0:
-                self._clear_tool_placeholder()
+            # Keep the indicator at the bottom while results and hook messages
+            # arrive. The next model step or worker completion ends the batch.
+            self._clear_tool_placeholder()
         self._show_message(msg)
-        if msg.role == "assistant":
-            runnable = [
-                t for t in ToolUse.iter_from_content(msg.content) if t.is_runnable
-            ]
-            self._pending_tool_count = len(runnable)
-            if self._pending_tool_count > 0:
-                self._set_state("executing tools")
-                self._show_tool_placeholder()
+        if msg.role == "assistant" and any(
+            tool_use.is_runnable for tool_use in ToolUse.iter_from_content(msg.content)
+        ):
+            self._set_state("executing tools")
+            self._show_tool_placeholder()
+        elif msg.role == "system" and self.state == "executing tools":
+            self._show_tool_placeholder()
         self._update_status()
 
     def on_worker_state_changed(self, event: Worker.StateChanged) -> None:
@@ -1089,7 +1088,6 @@ class GptmeApp(App):
 
     def _generation_done(self) -> None:
         self.generating = False
-        self._pending_tool_count = 0
         # stream may have ended without a final message (interrupt mid-stream)
         self._clear_stream_view()
         self._clear_tool_placeholder()

--- a/gptme/tui/app.py
+++ b/gptme/tui/app.py
@@ -574,6 +574,7 @@ class GptmeApp(App):
         self._quitting = False
         self._stream_widget: StreamingMessage | None = None
         self._tool_placeholder: ToolPlaceholder | None = None
+        self._pending_tool_count: int = 0
         self._outputs_expanded = False
         self._stdio_sink: IO[str] | None = None
         self._real_stdout: IO[str] | None = None
@@ -1061,12 +1062,19 @@ class GptmeApp(App):
             # replace the live stream view with the final rendering
             self._clear_stream_view()
         if msg.role == "system":
-            # tool output arriving: remove the "Running tool…" placeholder
-            self._clear_tool_placeholder()
+            # one tool finished: decrement counter; clear placeholder only when all done
+            self._pending_tool_count = max(0, self._pending_tool_count - 1)
+            if self._pending_tool_count == 0:
+                self._clear_tool_placeholder()
         self._show_message(msg)
         if msg.role == "assistant":
-            self._set_state("executing tools")
-            self._show_tool_placeholder()
+            runnable = [
+                t for t in ToolUse.iter_from_content(msg.content) if t.is_runnable
+            ]
+            self._pending_tool_count = len(runnable)
+            if self._pending_tool_count > 0:
+                self._set_state("executing tools")
+                self._show_tool_placeholder()
         self._update_status()
 
     def on_worker_state_changed(self, event: Worker.StateChanged) -> None:
@@ -1081,6 +1089,7 @@ class GptmeApp(App):
 
     def _generation_done(self) -> None:
         self.generating = False
+        self._pending_tool_count = 0
         # stream may have ended without a final message (interrupt mid-stream)
         self._clear_stream_view()
         self._clear_tool_placeholder()

--- a/gptme/tui/app.py
+++ b/gptme/tui/app.py
@@ -121,6 +121,21 @@ class StreamingMessage(Vertical):
         self._body.update(Text(self._buffer))
 
 
+class ToolPlaceholder(Vertical):
+    """Transient widget shown in the chat while a tool is running."""
+
+    def __init__(self) -> None:
+        super().__init__(classes="message system tool-placeholder")
+        self._body = Static(Text("Running tool…", style="dim italic"))
+
+    def compose(self) -> ComposeResult:
+        yield Static(Text("Tool"), classes="role")
+        yield self._body
+
+    def set_tool(self, tool_name: str) -> None:
+        self._body.update(Text(f"Running {tool_name}…", style="dim italic"))
+
+
 class InfoMessage(Static):
     """Dim informational line (help text, errors, hints)."""
 
@@ -423,6 +438,7 @@ class GptmeApp(App):
     .message {
         height: auto;
         margin: 1 0 0 0;
+        background: transparent;
     }
     .message > .role {
         color: $text-muted;
@@ -557,6 +573,7 @@ class GptmeApp(App):
         self._interrupt_event = threading.Event()
         self._quitting = False
         self._stream_widget: StreamingMessage | None = None
+        self._tool_placeholder: ToolPlaceholder | None = None
         self._outputs_expanded = False
         self._stdio_sink: IO[str] | None = None
         self._real_stdout: IO[str] | None = None
@@ -1020,13 +1037,36 @@ class GptmeApp(App):
             self._stream_widget.remove()
             self._stream_widget = None
 
+    def _show_tool_placeholder(self) -> None:
+        if self.inline:
+            self.query_one("#live", Static).update(
+                Text("Running tool…", style="dim italic")
+            )
+            return
+        if self._tool_placeholder is not None:
+            return
+        self._tool_placeholder = ToolPlaceholder()
+        self._mount_in_chat(self._tool_placeholder)
+
+    def _clear_tool_placeholder(self) -> None:
+        if self.inline:
+            self.query_one("#live", Static).update("")
+            return
+        if self._tool_placeholder is not None:
+            self._tool_placeholder.remove()
+            self._tool_placeholder = None
+
     def _on_step_message(self, msg: Message) -> None:
         if msg.role == "assistant":
             # replace the live stream view with the final rendering
             self._clear_stream_view()
+        if msg.role == "system":
+            # tool output arriving: remove the "Running tool…" placeholder
+            self._clear_tool_placeholder()
         self._show_message(msg)
         if msg.role == "assistant":
             self._set_state("executing tools")
+            self._show_tool_placeholder()
         self._update_status()
 
     def on_worker_state_changed(self, event: Worker.StateChanged) -> None:
@@ -1043,6 +1083,7 @@ class GptmeApp(App):
         self.generating = False
         # stream may have ended without a final message (interrupt mid-stream)
         self._clear_stream_view()
+        self._clear_tool_placeholder()
         if self._interrupt_event.is_set() and self.prompt_queue:
             # user interrupted: hand queued text back instead of auto-submitting
             text = "\n".join(self.prompt_queue)

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -15,6 +15,7 @@ from gptme.tui.app import (
     GptmeApp,
     InfoMessage,
     SystemMessage,
+    ToolPlaceholder,
     UserMessage,
     _append_pt_history,
     _load_pt_history,
@@ -340,3 +341,22 @@ async def test_history_persists_across_sessions(tmp_path, monkeypatch):
     async with app2.run_test():
         inp2 = app2.query_one("#input", ChatInput)
         assert inp2._history == ["prior cli entry", "tui entry one"]
+
+
+@pytest.mark.asyncio
+async def test_tool_placeholder_show_and_clear(tmp_path):
+    """ToolPlaceholder appears after an assistant message and disappears on tool output."""
+    app = GptmeApp(make_manager(tmp_path), workspace=tmp_path)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        assert len(app.query(ToolPlaceholder)) == 0
+
+        # Simulate assistant message arriving (triggers placeholder)
+        app._on_step_message(Message("assistant", "I will run a tool"))
+        await pilot.pause()
+        assert len(app.query(ToolPlaceholder)) == 1
+
+        # Simulate tool output arriving (clears placeholder)
+        app._on_step_message(Message("system", "```stdout\ntool done\n```"))
+        await pilot.pause()
+        assert len(app.query(ToolPlaceholder)) == 0

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -343,20 +343,67 @@ async def test_history_persists_across_sessions(tmp_path, monkeypatch):
         assert inp2._history == ["prior cli entry", "tui entry one"]
 
 
+SHELL_TOOL_MSG = "Running a command\n\n```shell\necho hello\n```"
+TWO_SHELL_TOOLS_MSG = (
+    "Running two commands\n\n```shell\necho first\n```\n\n```shell\necho second\n```"
+)
+
+
 @pytest.mark.asyncio
 async def test_tool_placeholder_show_and_clear(tmp_path):
-    """ToolPlaceholder appears after an assistant message and disappears on tool output."""
+    """ToolPlaceholder appears after an assistant message with tool calls and disappears on tool output."""
+    from gptme.tools import init_tools
+
+    init_tools()
     app = GptmeApp(make_manager(tmp_path), workspace=tmp_path)
     async with app.run_test() as pilot:
         await pilot.pause()
         assert len(app.query(ToolPlaceholder)) == 0
 
-        # Simulate assistant message arriving (triggers placeholder)
-        app._on_step_message(Message("assistant", "I will run a tool"))
+        # Assistant message containing a shell tool call → placeholder shown
+        app._on_step_message(Message("assistant", SHELL_TOOL_MSG))
         await pilot.pause()
         assert len(app.query(ToolPlaceholder)) == 1
 
-        # Simulate tool output arriving (clears placeholder)
-        app._on_step_message(Message("system", "```stdout\ntool done\n```"))
+        # Tool output arriving → placeholder cleared
+        app._on_step_message(Message("system", "```stdout\nhello\n```"))
+        await pilot.pause()
+        assert len(app.query(ToolPlaceholder)) == 0
+
+
+@pytest.mark.asyncio
+async def test_tool_placeholder_not_shown_for_tool_free_response(tmp_path):
+    """ToolPlaceholder must NOT appear for assistant messages without tool calls."""
+    app = GptmeApp(make_manager(tmp_path), workspace=tmp_path)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        # Plain text reply — no tool call content
+        app._on_step_message(Message("assistant", "Just a plain text reply"))
+        await pilot.pause()
+        assert len(app.query(ToolPlaceholder)) == 0
+
+
+@pytest.mark.asyncio
+async def test_tool_placeholder_persists_across_multiple_tools(tmp_path):
+    """ToolPlaceholder must stay visible until ALL tool outputs from one assistant message arrive."""
+    from gptme.tools import init_tools
+
+    init_tools()
+    app = GptmeApp(make_manager(tmp_path), workspace=tmp_path)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+
+        # Assistant message with two shell calls → placeholder appears
+        app._on_step_message(Message("assistant", TWO_SHELL_TOOLS_MSG))
+        await pilot.pause()
+        assert len(app.query(ToolPlaceholder)) == 1
+
+        # First tool output → placeholder must stay (one more tool pending)
+        app._on_step_message(Message("system", "```stdout\nfirst\n```"))
+        await pilot.pause()
+        assert len(app.query(ToolPlaceholder)) == 1, "placeholder cleared too early"
+
+        # Second tool output → now placeholder is cleared
+        app._on_step_message(Message("system", "```stdout\nsecond\n```"))
         await pilot.pause()
         assert len(app.query(ToolPlaceholder)) == 0

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -4,6 +4,7 @@ import pytest
 
 pytest.importorskip("textual")
 
+from textual.color import Color
 from textual.widgets import Collapsible
 
 from gptme.logmanager import LogManager
@@ -32,6 +33,25 @@ def test_summarize():
     assert _summarize("```stdout\nfoo\n```").startswith("stdout")
     long = "x" * 200
     assert len(_summarize(long)) < 100
+
+
+@pytest.mark.asyncio
+async def test_progress_placeholder_uses_message_background(tmp_path):
+    """The placeholder text must not introduce a different background color."""
+    app = GptmeApp(make_manager(tmp_path), workspace=tmp_path)
+    async with app.run_test() as pilot:
+        app._begin_stream()
+        await pilot.pause()
+
+        placeholder = app._stream_widget
+        assert placeholder is not None
+        body = placeholder._body
+        assert body.styles.background == Color(0, 0, 0, 0)
+        assert body.styles.color.a == pytest.approx(0.6)
+        assert body.styles.text_style.italic
+        first_segment = next(iter(body.render_line(0)))
+        assert first_segment.style is not None
+        assert first_segment.style.bgcolor == body.background_colors[1].rich_color
 
 
 @pytest.mark.asyncio

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -365,8 +365,13 @@ async def test_tool_placeholder_show_and_clear(tmp_path):
         await pilot.pause()
         assert len(app.query(ToolPlaceholder)) == 1
 
-        # Tool output arriving → placeholder cleared
+        # Tool output arrives while the batch is still active.
         app._on_step_message(Message("system", "```stdout\nhello\n```"))
+        await pilot.pause()
+        assert len(app.query(ToolPlaceholder)) == 1
+
+        # Starting the next model step marks the tool batch complete.
+        app._begin_stream()
         await pilot.pause()
         assert len(app.query(ToolPlaceholder)) == 0
 
@@ -403,7 +408,18 @@ async def test_tool_placeholder_persists_across_multiple_tools(tmp_path):
         await pilot.pause()
         assert len(app.query(ToolPlaceholder)) == 1, "placeholder cleared too early"
 
-        # Second tool output → now placeholder is cleared
+        # A hook can emit extra system messages for one tool. These must not
+        # consume the later tool's pending state.
+        app._on_step_message(Message("system", "Hook note after first tool"))
+        await pilot.pause()
+        assert len(app.query(ToolPlaceholder)) == 1
+
+        # The indicator remains after the last result until execution leaves
+        # the tool batch and starts the next model step.
         app._on_step_message(Message("system", "```stdout\nsecond\n```"))
+        await pilot.pause()
+        assert len(app.query(ToolPlaceholder)) == 1
+
+        app._begin_stream()
         await pilot.pause()
         assert len(app.query(ToolPlaceholder)) == 0


### PR DESCRIPTION
Closes part of #3311 (follow-up to #3310, #3312, #3313, #3314).

## Changes

### Tool-execution placeholder
When an assistant message arrives that triggers tool execution, a `ToolPlaceholder` widget now appears in the chat area showing **"Running tool…"** — analogous to how `StreamingMessage` shows "Generating…" during LLM generation. It disappears when the tool output arrives.

Before: only the status bar updated to "executing tools"; the conversation area was empty while tools ran.
After: a `System ▏ Running tool…` entry appears in the chat, then is replaced by the real collapsible tool output.

Inline (`--inline`) mode reuses the `#live` area: it shows "Running tool…" there between the assistant message and the tool output scrollback entry.

### Gray background fix
`.message` (the `Vertical` container for all message widgets) was missing `background: transparent`. Only the `Static` *children* were made transparent in #3312, but Textual's surface colour bled through the container itself. Adding `background: transparent` to `.message` fixes the gray background on `StreamingMessage` and all other message widgets.

## Tests
- `test_tool_placeholder_show_and_clear`: verifies the placeholder appears after an assistant message and is removed when tool output arrives.
- All 19 TUI tests pass.

## Still deferred
- Tab completion visual candidate list (popup/overlay widget)
- Alt+Enter reliability (terminal-emulator-specific)
- Thinking display toggle