### PR TITLE
feat(server): Host-header validation to prevent DNS-rebinding attacks

### DIFF
--- a/gptme/server/app.py
+++ b/gptme/server/app.py
@@ -169,9 +169,22 @@ def create_app(
             )
 
     # Initialize auth (defaults to local-only, no auth required)
-    from .auth import init_auth  # fmt: skip
+    from .auth import init_auth, init_host_validation, validate_host_header  # fmt: skip
 
     init_auth(host=host, display=False)
+
+    # DNS-rebinding protection: validate Host header on all /api/ requests.
+    # CORS preflights block cross-origin requests from normal websites, but
+    # DNS rebinding bypasses CORS: the attacker page rebinds its domain to
+    # 127.0.0.1 and becomes same-origin with the local server, skipping
+    # preflight entirely.  Checking the Host header stops this because the
+    # rebinding page still sends its original domain name as Host.
+    init_host_validation(bind_host=host)
+
+    @app.before_request
+    def _check_host():
+        if flask.request.path.startswith("/api/"):
+            return validate_host_header()
 
     # Register Prometheus metrics middleware and /api/v0/metrics endpoint
     from .metrics import init_metrics  # fmt: skip

--- a/gptme/server/app.py
+++ b/gptme/server/app.py
@@ -169,12 +169,7 @@ def create_app(
             )
 
     # Initialize auth (defaults to local-only, no auth required)
-    from .auth import (  # fmt: skip
-        init_auth,
-        init_host_validation,
-        is_auth_enabled,
-        validate_host_header,
-    )
+    from .auth import init_auth, init_host_validation, validate_host_header  # fmt: skip
 
     init_auth(host=host, display=False)
 
@@ -184,9 +179,7 @@ def create_app(
     # 127.0.0.1 and becomes same-origin with the local server, skipping
     # preflight entirely.  Checking the Host header stops this because the
     # rebinding page still sends its original domain name as Host.
-    # Pass auth_enabled so validation is still active when auth is explicitly
-    # disabled on a specific network IP (GPTME_DISABLE_AUTH + non-wildcard host).
-    init_host_validation(bind_host=host, auth_enabled=is_auth_enabled())
+    init_host_validation(bind_host=host)
 
     @app.before_request
     def _check_host():

--- a/gptme/server/app.py
+++ b/gptme/server/app.py
@@ -169,7 +169,12 @@ def create_app(
             )
 
     # Initialize auth (defaults to local-only, no auth required)
-    from .auth import init_auth, init_host_validation, validate_host_header  # fmt: skip
+    from .auth import (  # fmt: skip
+        init_auth,
+        init_host_validation,
+        is_auth_enabled,
+        validate_host_header,
+    )
 
     init_auth(host=host, display=False)
 
@@ -179,7 +184,9 @@ def create_app(
     # 127.0.0.1 and becomes same-origin with the local server, skipping
     # preflight entirely.  Checking the Host header stops this because the
     # rebinding page still sends its original domain name as Host.
-    init_host_validation(bind_host=host)
+    # Pass auth_enabled so validation is still active when auth is explicitly
+    # disabled on a specific network IP (GPTME_DISABLE_AUTH + non-wildcard host).
+    init_host_validation(bind_host=host, auth_enabled=is_auth_enabled())
 
     @app.before_request
     def _check_host():

--- a/gptme/server/auth.py
+++ b/gptme/server/auth.py
@@ -97,27 +97,30 @@ def init_host_validation(
     bind_host: str,
     extra_allowed_hosts: list[str] | None = None,
 ) -> None:
-    """Activate Host-header validation for DNS-rebinding protection.
+    """Configure Host-header validation for DNS-rebinding protection.
 
-    Should be called once at server startup, after ``init_auth``.  When
-    ``bind_host`` is a loopback address (auth disabled), this guard prevents
-    a DNS-rebound page from accessing the API by rejecting requests whose
-    Host header is not in the allow-list.
-
-    When auth is enabled (non-loopback bind) the bearer-token check already
-    authenticates the caller; Host validation is still applied for defence in
-    depth but is less critical.
+    Host validation is needed when authentication is disabled for a loopback
+    bind.  Network binds require bearer authentication instead, and may be
+    reached through arbitrary LAN addresses, container hostnames, or proxies
+    that cannot be inferred from the wildcard bind address.
 
     Args:
         bind_host: The address the server listens on (e.g. "127.0.0.1").
-        extra_allowed_hosts: Additional hostnames to accept (e.g. a custom
-            domain that proxies to the local server).
+        extra_allowed_hosts: Additional hostnames to accept for a loopback
+            bind (e.g. a custom local proxy hostname).
     """
     global _host_validation_enabled, _allowed_hosts
 
+    if not is_local_host(bind_host):
+        _allowed_hosts = frozenset()
+        _host_validation_enabled = False
+        logger.debug(
+            "Host validation disabled for authenticated network bind %s", bind_host
+        )
+        return
+
     allowed = set(_LOOPBACK_HOST_NAMES)
-    if bind_host:
-        allowed.add(bind_host)
+    allowed.add(bind_host)
     if extra_allowed_hosts:
         allowed.update(extra_allowed_hosts)
 
@@ -126,7 +129,7 @@ def init_host_validation(
     logger.debug("Host validation enabled; allowed hosts: %s", _allowed_hosts)
 
 
-def validate_host_header() -> "flask.Response | None":
+def validate_host_header() -> "tuple[flask.Response, int] | None":
     """Check the Host header of the current request.
 
     Returns a 403 response if the header is absent or its hostname is not in

--- a/gptme/server/auth.py
+++ b/gptme/server/auth.py
@@ -54,6 +54,11 @@ AUTH_COOKIE_MAX_AGE = 86400  # 24 hours
 auth_api = flask.Blueprint("auth_api", __name__)
 
 
+def is_auth_enabled() -> bool:
+    """Return True if bearer-token authentication is currently active."""
+    return _auth_enabled
+
+
 def generate_token() -> str:
     """Generate a cryptographically secure random token.
 
@@ -78,6 +83,10 @@ def is_local_host(host: str) -> bool:
 # Loopback hostnames that are always safe as Host header values.
 _LOOPBACK_HOST_NAMES = frozenset({"localhost", "127.0.0.1", "[::1]", "::1"})
 
+# Wildcard bind addresses that listen on all interfaces.
+# For these, valid client hostnames cannot be enumerated at startup.
+_WILDCARD_BINDS = frozenset({"0.0.0.0", "::", "*"})
+
 
 def _parse_host_header(host_header: str) -> str:
     """Return the hostname portion of a Host header, stripping the port.
@@ -96,27 +105,61 @@ def _parse_host_header(host_header: str) -> str:
 def init_host_validation(
     bind_host: str,
     extra_allowed_hosts: list[str] | None = None,
+    auth_enabled: bool = True,
 ) -> None:
     """Configure Host-header validation for DNS-rebinding protection.
 
-    Host validation is needed when authentication is disabled for a loopback
-    bind.  Network binds require bearer authentication instead, and may be
-    reached through arbitrary LAN addresses, container hostnames, or proxies
-    that cannot be inferred from the wildcard bind address.
+    Host validation is needed when authentication is disabled.  Authenticated
+    network binds are protected by bearer tokens and may be reached via
+    arbitrary LAN addresses or container hostnames that cannot be inferred at
+    startup, so validation is skipped for those.
+
+    When auth is explicitly disabled on a specific network IP (not a wildcard
+    like 0.0.0.0), Host validation is the only DNS-rebinding defence and is
+    enabled for that IP.
 
     Args:
         bind_host: The address the server listens on (e.g. "127.0.0.1").
-        extra_allowed_hosts: Additional hostnames to accept for a loopback
-            bind (e.g. a custom local proxy hostname).
+        extra_allowed_hosts: Additional hostnames to accept.
+        auth_enabled: Whether bearer-token auth is active.  Pass the result
+            of ``is_auth_enabled()`` after calling ``init_auth()``.
     """
     global _host_validation_enabled, _allowed_hosts
 
     if not is_local_host(bind_host):
-        _allowed_hosts = frozenset()
-        _host_validation_enabled = False
-        logger.debug(
-            "Host validation disabled for authenticated network bind %s", bind_host
-        )
+        if auth_enabled:
+            # Auth protects network binds; host validation not needed.
+            _allowed_hosts = frozenset()
+            _host_validation_enabled = False
+            logger.debug(
+                "Host validation disabled for authenticated network bind %s", bind_host
+            )
+        elif bind_host in _WILDCARD_BINDS:
+            # Wildcard bind with auth disabled: cannot enumerate the set of
+            # valid client hostnames, so host validation is not possible.
+            # Rely on external auth (e.g. k8s ingress) in this configuration.
+            _allowed_hosts = frozenset()
+            _host_validation_enabled = False
+            logger.warning(
+                "⚠️  GPTME_DISABLE_AUTH on a wildcard bind (%s) provides no "
+                "DNS-rebinding protection.  Only use this behind external auth "
+                "(e.g. a k8s ingress controller).",
+                bind_host,
+            )
+        else:
+            # Specific network IP with auth disabled: enable Host validation
+            # against the bind address.  This blocks DNS-rebinding pages that
+            # send their own domain as the Host header.
+            allowed: set[str] = {bind_host}
+            if extra_allowed_hosts:
+                allowed.update(extra_allowed_hosts)
+            _allowed_hosts = frozenset(allowed)
+            _host_validation_enabled = True
+            logger.debug(
+                "Host validation enabled for auth-disabled bind %s; allowed: %s",
+                bind_host,
+                _allowed_hosts,
+            )
         return
 
     allowed = set(_LOOPBACK_HOST_NAMES)

--- a/gptme/server/auth.py
+++ b/gptme/server/auth.py
@@ -54,11 +54,6 @@ AUTH_COOKIE_MAX_AGE = 86400  # 24 hours
 auth_api = flask.Blueprint("auth_api", __name__)
 
 
-def is_auth_enabled() -> bool:
-    """Return True if bearer-token authentication is currently active."""
-    return _auth_enabled
-
-
 def generate_token() -> str:
     """Generate a cryptographically secure random token.
 
@@ -83,10 +78,6 @@ def is_local_host(host: str) -> bool:
 # Loopback hostnames that are always safe as Host header values.
 _LOOPBACK_HOST_NAMES = frozenset({"localhost", "127.0.0.1", "[::1]", "::1"})
 
-# Wildcard bind addresses that listen on all interfaces.
-# For these, valid client hostnames cannot be enumerated at startup.
-_WILDCARD_BINDS = frozenset({"0.0.0.0", "::", "*"})
-
 
 def _parse_host_header(host_header: str) -> str:
     """Return the hostname portion of a Host header, stripping the port.
@@ -105,61 +96,27 @@ def _parse_host_header(host_header: str) -> str:
 def init_host_validation(
     bind_host: str,
     extra_allowed_hosts: list[str] | None = None,
-    auth_enabled: bool = True,
 ) -> None:
     """Configure Host-header validation for DNS-rebinding protection.
 
-    Host validation is needed when authentication is disabled.  Authenticated
-    network binds are protected by bearer tokens and may be reached via
-    arbitrary LAN addresses or container hostnames that cannot be inferred at
-    startup, so validation is skipped for those.
-
-    When auth is explicitly disabled on a specific network IP (not a wildcard
-    like 0.0.0.0), Host validation is the only DNS-rebinding defence and is
-    enabled for that IP.
+    Host validation is needed when authentication is disabled for a loopback
+    bind.  Network binds require bearer authentication instead, and may be
+    reached through arbitrary LAN addresses, container hostnames, or proxies
+    that cannot be inferred from the wildcard bind address.
 
     Args:
         bind_host: The address the server listens on (e.g. "127.0.0.1").
-        extra_allowed_hosts: Additional hostnames to accept.
-        auth_enabled: Whether bearer-token auth is active.  Pass the result
-            of ``is_auth_enabled()`` after calling ``init_auth()``.
+        extra_allowed_hosts: Additional hostnames to accept for a loopback
+            bind (e.g. a custom local proxy hostname).
     """
     global _host_validation_enabled, _allowed_hosts
 
     if not is_local_host(bind_host):
-        if auth_enabled:
-            # Auth protects network binds; host validation not needed.
-            _allowed_hosts = frozenset()
-            _host_validation_enabled = False
-            logger.debug(
-                "Host validation disabled for authenticated network bind %s", bind_host
-            )
-        elif bind_host in _WILDCARD_BINDS:
-            # Wildcard bind with auth disabled: cannot enumerate the set of
-            # valid client hostnames, so host validation is not possible.
-            # Rely on external auth (e.g. k8s ingress) in this configuration.
-            _allowed_hosts = frozenset()
-            _host_validation_enabled = False
-            logger.warning(
-                "⚠️  GPTME_DISABLE_AUTH on a wildcard bind (%s) provides no "
-                "DNS-rebinding protection.  Only use this behind external auth "
-                "(e.g. a k8s ingress controller).",
-                bind_host,
-            )
-        else:
-            # Specific network IP with auth disabled: enable Host validation
-            # against the bind address.  This blocks DNS-rebinding pages that
-            # send their own domain as the Host header.
-            allowed: set[str] = {bind_host}
-            if extra_allowed_hosts:
-                allowed.update(extra_allowed_hosts)
-            _allowed_hosts = frozenset(allowed)
-            _host_validation_enabled = True
-            logger.debug(
-                "Host validation enabled for auth-disabled bind %s; allowed: %s",
-                bind_host,
-                _allowed_hosts,
-            )
+        _allowed_hosts = frozenset()
+        _host_validation_enabled = False
+        logger.debug(
+            "Host validation disabled for authenticated network bind %s", bind_host
+        )
         return
 
     allowed = set(_LOOPBACK_HOST_NAMES)

--- a/gptme/server/auth.py
+++ b/gptme/server/auth.py
@@ -8,6 +8,22 @@ Supports three authentication methods (checked in order):
 1. Authorization header (preferred for normal API calls)
 2. HttpOnly cookie (preferred for SSE/EventSource connections)
 3. Query parameter (deprecated, kept for backward compatibility)
+
+DNS-rebinding protection
+------------------------
+When the server binds to loopback (auth disabled), CORS preflights block
+cross-origin requests from regular websites — but DNS rebinding bypasses
+CORS entirely: a malicious page rebinds its domain to 127.0.0.1, becoming
+same-origin with the local server without a preflight.
+
+The direct fix is Host-header validation: every request must carry a Host
+header whose hostname is a known-safe loopback name or the configured bind
+host.  A rebinding attacker retains the original DNS name as its Host header
+(e.g. ``evil.com``), so this rejects it before any endpoint logic runs.
+
+Call ``init_host_validation(host, allowed_hosts)`` at startup to activate.
+The check applies to the ``/api/`` prefix only, so the static webui continues
+to load even if validation is misconfigured.
 """
 
 import logging
@@ -25,6 +41,10 @@ _server_token: str | None = None
 
 # Auth state (disabled for local-only binding)
 _auth_enabled: bool = True
+
+# Host validation state
+_host_validation_enabled: bool = False
+_allowed_hosts: frozenset[str] = frozenset()
 
 # Cookie configuration
 AUTH_COOKIE_NAME = "gptme_auth"
@@ -53,6 +73,85 @@ def is_local_host(host: str) -> bool:
         True if host is localhost or 127.0.0.1, False otherwise.
     """
     return host in ("127.0.0.1", "localhost", "::1")
+
+
+# Loopback hostnames that are always safe as Host header values.
+_LOOPBACK_HOST_NAMES = frozenset({"localhost", "127.0.0.1", "[::1]", "::1"})
+
+
+def _parse_host_header(host_header: str) -> str:
+    """Return the hostname portion of a Host header, stripping the port.
+
+    RFC 7230 §5.4: Host = uri-host [ ":" port ]
+    IPv6 literals are bracketed: [::1]:5700 → [::1].
+    """
+    if host_header.startswith("["):
+        # IPv6 literal — find the closing bracket
+        bracket = host_header.find("]")
+        return host_header[: bracket + 1] if bracket != -1 else host_header
+    # Strip optional port from plain hostname or IPv4
+    return host_header.rsplit(":", 1)[0]
+
+
+def init_host_validation(
+    bind_host: str,
+    extra_allowed_hosts: list[str] | None = None,
+) -> None:
+    """Activate Host-header validation for DNS-rebinding protection.
+
+    Should be called once at server startup, after ``init_auth``.  When
+    ``bind_host`` is a loopback address (auth disabled), this guard prevents
+    a DNS-rebound page from accessing the API by rejecting requests whose
+    Host header is not in the allow-list.
+
+    When auth is enabled (non-loopback bind) the bearer-token check already
+    authenticates the caller; Host validation is still applied for defence in
+    depth but is less critical.
+
+    Args:
+        bind_host: The address the server listens on (e.g. "127.0.0.1").
+        extra_allowed_hosts: Additional hostnames to accept (e.g. a custom
+            domain that proxies to the local server).
+    """
+    global _host_validation_enabled, _allowed_hosts
+
+    allowed = set(_LOOPBACK_HOST_NAMES)
+    if bind_host:
+        allowed.add(bind_host)
+    if extra_allowed_hosts:
+        allowed.update(extra_allowed_hosts)
+
+    _allowed_hosts = frozenset(allowed)
+    _host_validation_enabled = True
+    logger.debug("Host validation enabled; allowed hosts: %s", _allowed_hosts)
+
+
+def validate_host_header() -> "flask.Response | None":
+    """Check the Host header of the current request.
+
+    Returns a 403 response if the header is absent or its hostname is not in
+    the allow-list, else ``None`` (request is allowed to proceed).
+
+    Call from a ``before_request`` hook scoped to API routes.
+    """
+    if not _host_validation_enabled:
+        return None
+
+    host_header = request.headers.get("Host", "")
+    if not host_header:
+        logger.warning("Rejected request: missing Host header")
+        return jsonify({"error": "Missing Host header"}), 403
+
+    hostname = _parse_host_header(host_header)
+    if hostname not in _allowed_hosts:
+        logger.warning(
+            "Rejected request: Host %r not in allowed list %s",
+            hostname,
+            _allowed_hosts,
+        )
+        return jsonify({"error": "Host header rejected"}), 403
+
+    return None
 
 
 def get_server_token() -> str | None:

--- a/tests/test_server_dns_rebinding.py
+++ b/tests/test_server_dns_rebinding.py
@@ -173,18 +173,3 @@ class TestHostValidation:
         app = _make_app(host="127.0.0.1")
         resp = _api_get(app, "localhost.evil.com")
         assert resp.status_code == 403
-
-    def test_specific_ip_auth_disabled_rejects_rebind_host(self, monkeypatch):
-        """Specific network IP + GPTME_DISABLE_AUTH: Host validation is the only
-        DNS-rebinding defence, so it must still be active."""
-        monkeypatch.setenv("GPTME_DISABLE_AUTH", "true")
-        app = _make_app(host="192.168.1.100")
-        resp = _api_get(app, "evil.example.com")
-        assert resp.status_code == 403
-
-    def test_specific_ip_auth_disabled_allows_bind_host(self, monkeypatch):
-        """The bind IP itself is a valid Host header value when auth is off."""
-        monkeypatch.setenv("GPTME_DISABLE_AUTH", "true")
-        app = _make_app(host="192.168.1.100")
-        resp = _api_get(app, "192.168.1.100")
-        assert resp.status_code != 403

--- a/tests/test_server_dns_rebinding.py
+++ b/tests/test_server_dns_rebinding.py
@@ -173,3 +173,18 @@ class TestHostValidation:
         app = _make_app(host="127.0.0.1")
         resp = _api_get(app, "localhost.evil.com")
         assert resp.status_code == 403
+
+    def test_specific_ip_auth_disabled_rejects_rebind_host(self, monkeypatch):
+        """Specific network IP + GPTME_DISABLE_AUTH: Host validation is the only
+        DNS-rebinding defence, so it must still be active."""
+        monkeypatch.setenv("GPTME_DISABLE_AUTH", "true")
+        app = _make_app(host="192.168.1.100")
+        resp = _api_get(app, "evil.example.com")
+        assert resp.status_code == 403
+
+    def test_specific_ip_auth_disabled_allows_bind_host(self, monkeypatch):
+        """The bind IP itself is a valid Host header value when auth is off."""
+        monkeypatch.setenv("GPTME_DISABLE_AUTH", "true")
+        app = _make_app(host="192.168.1.100")
+        resp = _api_get(app, "192.168.1.100")
+        assert resp.status_code != 403

--- a/tests/test_server_dns_rebinding.py
+++ b/tests/test_server_dns_rebinding.py
@@ -161,10 +161,11 @@ class TestHostValidation:
         # Static routes return 200 for index.html regardless of Host
         assert resp.status_code == 200
 
-    def test_custom_bind_host_allowed(self):
-        """When the server binds to a custom address, that address is allowed."""
+    @pytest.mark.parametrize("host_header", ["192.168.1.42", "gptme.local"])
+    def test_network_bind_allows_real_destination_hosts(self, host_header):
+        """Authenticated wildcard binds may be reached through many hostnames."""
         app = _make_app(host="0.0.0.0")
-        resp = _api_get(app, "0.0.0.0")
+        resp = _api_get(app, host_header)
         assert resp.status_code != 403
 
     def test_subdomain_of_loopback_not_allowed(self):

--- a/tests/test_server_dns_rebinding.py
+++ b/tests/test_server_dns_rebinding.py
@@ -1,0 +1,174 @@
+"""Tests for DNS-rebinding protection via Host-header validation.
+
+DNS rebinding lets a malicious page bypass CORS by resolving its domain to
+127.0.0.1.  The browser then treats the page as same-origin with the local
+server, skipping preflight checks.  Host-header validation blocks this because
+the rebinding page still sends its own domain name as the Host header.
+
+References: gptme/gptme#3320
+"""
+
+import pytest
+
+flask = pytest.importorskip(
+    "flask", reason="flask not installed, install server extras (-E server)"
+)
+
+
+def _make_app(host: str = "127.0.0.1"):
+    from gptme.server.app import create_app
+
+    return create_app(host=host)
+
+
+def _api_get(app, host_header: str | None, path: str = "/api/v2/conversations"):
+    with app.test_client() as client:
+        if host_header is None:
+            # Werkzeug test client always injects localhost; override via environ_base
+            return client.get(path, environ_base={"HTTP_HOST": ""})
+        return client.get(path, headers={"Host": host_header})
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for the helper functions
+# ---------------------------------------------------------------------------
+
+
+class TestParseHostHeader:
+    def test_plain_hostname(self):
+        from gptme.server.auth import _parse_host_header
+
+        assert _parse_host_header("localhost") == "localhost"
+
+    def test_hostname_with_port(self):
+        from gptme.server.auth import _parse_host_header
+
+        assert _parse_host_header("localhost:5700") == "localhost"
+
+    def test_ipv4_with_port(self):
+        from gptme.server.auth import _parse_host_header
+
+        assert _parse_host_header("127.0.0.1:5700") == "127.0.0.1"
+
+    def test_ipv4_without_port(self):
+        from gptme.server.auth import _parse_host_header
+
+        assert _parse_host_header("127.0.0.1") == "127.0.0.1"
+
+    def test_ipv6_literal_with_port(self):
+        from gptme.server.auth import _parse_host_header
+
+        assert _parse_host_header("[::1]:5700") == "[::1]"
+
+    def test_ipv6_literal_without_port(self):
+        from gptme.server.auth import _parse_host_header
+
+        assert _parse_host_header("[::1]") == "[::1]"
+
+    def test_external_domain(self):
+        from gptme.server.auth import _parse_host_header
+
+        assert _parse_host_header("evil.example.com") == "evil.example.com"
+
+    def test_external_domain_with_port(self):
+        from gptme.server.auth import _parse_host_header
+
+        assert _parse_host_header("evil.example.com:80") == "evil.example.com"
+
+
+# ---------------------------------------------------------------------------
+# Integration tests via Flask test client
+# ---------------------------------------------------------------------------
+
+
+class TestHostValidation:
+    """API requests must carry an allowed Host header."""
+
+    def test_localhost_host_allowed(self):
+        app = _make_app(host="127.0.0.1")
+        resp = _api_get(app, "localhost")
+        assert resp.status_code != 403
+
+    def test_127_0_0_1_host_allowed(self):
+        app = _make_app(host="127.0.0.1")
+        resp = _api_get(app, "127.0.0.1")
+        assert resp.status_code != 403
+
+    def test_127_0_0_1_with_port_allowed(self):
+        app = _make_app(host="127.0.0.1")
+        resp = _api_get(app, "127.0.0.1:5700")
+        assert resp.status_code != 403
+
+    def test_localhost_with_port_allowed(self):
+        app = _make_app(host="127.0.0.1")
+        resp = _api_get(app, "localhost:5700")
+        assert resp.status_code != 403
+
+    def test_ipv6_loopback_allowed(self):
+        app = _make_app(host="127.0.0.1")
+        resp = _api_get(app, "[::1]:5700")
+        assert resp.status_code != 403
+
+    def test_dns_rebinding_domain_rejected(self):
+        """A DNS-rebound page sends its original domain as Host — must be rejected."""
+        app = _make_app(host="127.0.0.1")
+        resp = _api_get(app, "evil.example.com")
+        assert resp.status_code == 403
+        data = resp.get_json()
+        assert data is not None
+        assert "error" in data
+
+    def test_dns_rebinding_with_port_rejected(self):
+        app = _make_app(host="127.0.0.1")
+        resp = _api_get(app, "evil.example.com:5700")
+        assert resp.status_code == 403
+
+    def test_missing_host_header_rejected(self):
+        """HTTP/1.1 requires a Host header; absent means a raw client that
+        bypassed the normal stack.  validate_host_header rejects it.
+
+        Note: Flask's Werkzeug test client always normalises a missing HTTP_HOST
+        to 'localhost', so we test this via a direct call to validate_host_header
+        with a mocked request object instead of an integration request.
+        """
+        from unittest.mock import MagicMock, patch
+
+        from gptme.server.auth import init_host_validation, validate_host_header
+
+        init_host_validation(bind_host="127.0.0.1")
+
+        mock_request = MagicMock()
+        mock_request.headers = {}  # no Host header
+        mock_request.path = "/api/v2/conversations"
+
+        app = _make_app(host="127.0.0.1")
+        with app.test_request_context("/api/v2/conversations"):
+            with patch("gptme.server.auth.request", mock_request):
+                result = validate_host_header()
+            assert result is not None, "Expected a 403 response for missing Host"
+            response, status = result
+            assert status == 403
+
+    def test_non_api_path_not_blocked(self):
+        """Static assets (webui) must not be blocked by Host validation.
+
+        The before_request hook only applies to /api/ paths so the webui
+        continues to load even if the Host header is unexpected.
+        """
+        app = _make_app(host="127.0.0.1")
+        with app.test_client() as client:
+            resp = client.get("/", headers={"Host": "evil.example.com"})
+        # Static routes return 200 for index.html regardless of Host
+        assert resp.status_code == 200
+
+    def test_custom_bind_host_allowed(self):
+        """When the server binds to a custom address, that address is allowed."""
+        app = _make_app(host="0.0.0.0")
+        resp = _api_get(app, "0.0.0.0")
+        assert resp.status_code != 403
+
+    def test_subdomain_of_loopback_not_allowed(self):
+        """'localhost.evil.com' looks like localhost but is not — reject it."""
+        app = _make_app(host="127.0.0.1")
+        resp = _api_get(app, "localhost.evil.com")
+        assert resp.status_code == 403


### PR DESCRIPTION
## Problem

When `gptme-server` binds to loopback (the default), authentication is disabled for convenience. CORS preflights protect against ordinary cross-origin requests, but DNS rebinding can make an attacker's origin resolve to the loopback server and bypass CORS.

This was identified in #3320 as the residual browser-based attack vector that workspace containment did not address.

## Fix

Add Host-header validation as a `before_request` hook on `/api/` paths when the server is loopback-bound. Static routes remain outside the check so the bundled web UI still loads. Network binds retain existing Host flexibility because they are authenticated by default and may legitimately be reached through LAN addresses, container names, or reverse-proxy hostnames that cannot be inferred from the bind address.

**`gptme/server/auth.py`**
- `_LOOPBACK_HOST_NAMES` — safe set: `localhost`, `127.0.0.1`, `[::1]`, `::1`
- `_parse_host_header(h)` — strips ports and handles bracketed IPv6 literals
- `init_host_validation(bind_host, extra_allowed_hosts)` — enables a loopback allow-list at startup and disables this check for network binds
- `validate_host_header()` — returns 403 when an API request's Host is absent or outside the active allow-list

**`gptme/server/app.py`**
- Initializes Host validation after auth setup
- Applies it only to `/api/` requests

A DNS-rebound page keeps the attacker's domain in its Host header, so loopback API requests are rejected before endpoint logic runs.

## Scope boundary

`GPTME_DISABLE_AUTH=true` on a network bind is the explicit external-auth deployment mode introduced by #811. A safe defense-in-depth extension for wildcard binds requires an explicit trusted-proxy/allowed-host contract; `0.0.0.0` cannot identify the public Host values a deployment legitimately serves. That separate design is not claimed by this PR.

## Tests

`tests/test_server_dns_rebinding.py` covers:
- Host parsing for plain names, IPv4, IPv6, and ports
- Loopback names accepted
- DNS-rebound and loopback-subdomain hosts rejected
- Missing Host rejected
- Static routes unaffected
- Network-bound deployments retain real destination-host flexibility

Focused DNS-rebinding and CORS suites pass (29 tests), along with Ruff, mypy, and CI lint/typecheck.

## Relationship to #3320

This implements the DNS-rebinding hardening slice only. It does **not** settle #3320's remaining PATCH-containment or web UI workspace-field design questions, so the issue should remain open after this PR merges.

Refs #3320

<!-- gptme-id:v1:gai_fJySPA7pfOgk6q9Bnarx4gct6C23XYvIerdOV1h8BrZ -->
