### PR TITLE
test(server): regression test for generation_complete ordering (refs #3315)

### DIFF
--- a/tests/test_server_v2_sse.py
+++ b/tests/test_server_v2_sse.py
@@ -1,5 +1,9 @@
 """Tests for the Server-Sent Events (SSE) stream functionality in the V2 API."""
 
+import threading
+import time
+import unittest.mock
+
 import pytest
 import requests
 
@@ -76,3 +80,58 @@ def test_event_stream_with_generation(event_listener, wait_for_event):
     assistant_messages = [m for m in messages if m["role"] == "assistant"]
     assert len(assistant_messages) == 1
     assert len(assistant_messages[0]["content"]) > 0
+
+
+@pytest.mark.timeout(10)
+def test_generation_complete_before_auto_naming(
+    setup_conversation, event_listener, mock_generation, wait_for_event
+):
+    """generation_complete must be emitted before _try_auto_name_and_notify runs.
+
+    Regression test for #2081: auto-naming was called synchronously BEFORE
+    generation_complete, blocking SSE delivery for 4+ seconds (LLM naming call).
+
+    This test uses a deadlock to detect the regression:
+    - The auto-naming mock blocks until generation_complete is received by the SSE client.
+    - If auto-naming runs BEFORE generation_complete (the regression): deadlock → timeout → FAIL.
+    - If auto-naming runs AFTER generation_complete (correct order): gate opens → PASS.
+    """
+    port, conversation_id, session_id = setup_conversation
+
+    requests.post(
+        f"http://localhost:{port}/api/v2/conversations/{conversation_id}",
+        json={"role": "user", "content": "Hello"},
+    )
+
+    mock_stream = mock_generation(["Hello!"])
+    generation_complete_gate = threading.Event()
+
+    def gated_auto_name(*args, **kwargs):
+        # If called BEFORE generation_complete: blocks here until gate opens,
+        # preventing generation_complete from being emitted → wait_for_event
+        # times out → assertion fails.
+        # If called AFTER generation_complete (correct): gate already open → immediate return.
+        generation_complete_gate.wait(timeout=6)
+        return
+
+    with (
+        unittest.mock.patch("gptme.server.session_step._stream", mock_stream),
+        unittest.mock.patch(
+            "gptme.server.session_step._try_auto_name_and_notify",
+            side_effect=gated_auto_name,
+        ),
+    ):
+        requests.post(
+            f"http://localhost:{port}/api/v2/conversations/{conversation_id}/step",
+            json={"session_id": session_id, "model": "openai/mock-model"},
+        )
+
+        assert wait_for_event(event_listener, "generation_complete", timeout=5), (
+            "generation_complete not received within 5s — "
+            "_try_auto_name_and_notify may be blocking it (regression of #2081)"
+        )
+        generation_complete_gate.set()
+
+        # Let the gated auto-naming call finish inside the mock context
+        # before the patch is reverted, so the real function is not called.
+        time.sleep(0.3)

--- a/tests/test_server_v2_sse.py
+++ b/tests/test_server_v2_sse.py
@@ -1,7 +1,6 @@
 """Tests for the Server-Sent Events (SSE) stream functionality in the V2 API."""
 
 import threading
-import time
 import unittest.mock
 
 import pytest
@@ -105,21 +104,24 @@ def test_generation_complete_before_auto_naming(
 
     mock_stream = mock_generation(["Hello!"])
     generation_complete_gate = threading.Event()
+    auto_name_finished = threading.Event()
 
     def gated_auto_name(*args, **kwargs):
         # If called BEFORE generation_complete: blocks here until gate opens,
         # preventing generation_complete from being emitted → wait_for_event
         # times out → assertion fails.
         # If called AFTER generation_complete (correct): gate already open → immediate return.
-        generation_complete_gate.wait(timeout=6)
-        return
+        try:
+            generation_complete_gate.wait(timeout=6)
+        finally:
+            auto_name_finished.set()
 
     with (
         unittest.mock.patch("gptme.server.session_step._stream", mock_stream),
         unittest.mock.patch(
             "gptme.server.session_step._try_auto_name_and_notify",
             side_effect=gated_auto_name,
-        ),
+        ) as auto_name_mock,
     ):
         requests.post(
             f"http://localhost:{port}/api/v2/conversations/{conversation_id}/step",
@@ -132,6 +134,7 @@ def test_generation_complete_before_auto_naming(
         )
         generation_complete_gate.set()
 
-        # Let the gated auto-naming call finish inside the mock context
-        # before the patch is reverted, so the real function is not called.
-        time.sleep(0.3)
+        # Keep the patch installed until the background step reaches and exits
+        # auto-naming. This avoids racing patch teardown against a slow worker.
+        assert auto_name_finished.wait(timeout=2), "auto-naming did not finish"
+        auto_name_mock.assert_called_once()


### PR DESCRIPTION
## Summary

Adds a regression test that guards against the bug fixed by #2081: `_try_auto_name_and_notify` being called **before** `generation_complete` was emitted, blocking SSE delivery by 4+ seconds.

## The bug (#2081)

Two causes contributed to the >5s Stop→Submit delay on staging (issue #3315):

1. **SSE event-flag race** (`api_v2_sessions.py`): `generation_complete` could be missed if it arrived between the event-count check and `event_flag.clear()`, causing a 15s wait. Fixed by the clear→re-check pattern.

2. **Auto-naming blocked `generation_complete`** (`session_step.py`): `_try_auto_name_and_notify` was called synchronously **before** `generation_complete` was emitted. The LLM naming call can take 4+ seconds, blocking the SSE event. Fixed by moving auto-naming to after `generation_complete`.

Both fixes are in master. Staging still sees the delay because its pods run the Jan-30 image (predating #2081); the fix reaches staging via a fleet image bump in gptme-cloud once #3319 merges.

## The test

Uses a deadlock to make the regression observable without timing tricks:

- The auto-naming mock blocks on a gate that only opens after `generation_complete` is received by the SSE client.
- **Regression scenario** (auto-naming before `generation_complete`): gate never opens → `wait_for_event` times out → `assert` fails.
- **Correct scenario** (auto-naming after `generation_complete`): gate opens immediately → mock returns → test passes.

No API key needed; uses `mock_generation` fixture.

<!-- gptme-id:v1:gai_1Qo5HuVMd1SARn8aOGaDn1zrisESiVglxcXRpCYmvVr -->