### PR TITLE
fix(server): validate Host header to block DNS-rebinding on unauthenticated local servers

### DIFF
--- a/docs/server.rst
+++ b/docs/server.rst
@@ -65,6 +65,21 @@ To use the server with a locally hosted gptme-webui, configure the CORS origin w
     ``http://localhost:5701``) avoids the prompt entirely, since that is a
     local-to-local request.
 
+.. note::
+
+    **Host-header validation (DNS-rebinding protection).**
+    On loopback binds the server runs without an auth token, so it validates
+    the request ``Host`` header to block DNS-rebinding attacks (a malicious page
+    whose hostname re-resolves to ``127.0.0.1`` would otherwise become
+    same-origin with your local server and gain full unauthenticated API
+    access, including shell execution via the agent). ``localhost``,
+    ``127.0.0.1`` and ``[::1]`` (any port) are always allowed. If you proxy the
+    local server behind a hostname, allow it with
+    ``gptme-server serve --allowed-hosts gptme.local`` (comma-separated, or via
+    ``GPTME_SERVER_ALLOWED_HOSTS``). Validation is skipped when auth is enabled
+    (network binds) or explicitly disabled with ``GPTME_DISABLE_AUTH`` — those
+    operators own their own access control (e.g. an authenticated ingress).
+
 Self-Hosting with Docker Compose
 --------------------------------
 

--- a/gptme/server/app.py
+++ b/gptme/server/app.py
@@ -52,6 +52,7 @@ def create_app(
     host: str = "127.0.0.1",
     webui_dir: str | Path | None = None,
     default_profile: str | None = None,
+    allowed_hosts: list[str] | None = None,
 ) -> flask.Flask:
     """Create the Flask app.
 
@@ -60,6 +61,10 @@ def create_app(
             A comma-separated string allows multiple origins, e.g.
             "tauri://localhost,http://tauri.localhost". Whitespace around
             entries is ignored.
+        allowed_hosts: Extra hostnames to accept in the Host header when Host
+            validation is active (loopback binds without auth). Adds to the
+            built-in localhost/127.0.0.1/[::1] allow-list, for users who proxy
+            the local server behind a hostname. See init_host_validation.
         webui_dir: Optional directory containing a web UI build (e.g. the
             modern React webui's ``dist/``) to serve instead of the bundled
             legacy UI. Falls back to the ``GPTME_WEBUI_DIR`` environment
@@ -169,9 +174,15 @@ def create_app(
             )
 
     # Initialize auth (defaults to local-only, no auth required)
-    from .auth import init_auth  # fmt: skip
+    from .auth import init_auth, init_host_validation, validate_host  # fmt: skip
 
     init_auth(host=host, display=False)
+
+    # Configure and register Host-header validation (DNS-rebinding hardening).
+    # Enforced only for unauthenticated loopback binds; see init_host_validation.
+    # Registered as a before_request hook so it runs ahead of any route/auth.
+    init_host_validation(host=host, allowed_hosts=allowed_hosts)
+    app.before_request(validate_host)
 
     # Register Prometheus metrics middleware and /api/v0/metrics endpoint
     from .metrics import init_metrics  # fmt: skip

--- a/gptme/server/auth.py
+++ b/gptme/server/auth.py
@@ -71,25 +71,29 @@ def _extract_hostname(host_header: str) -> str:
     """Extract the hostname part (without port) from a Host header value.
 
     Handles IPv6 literals in brackets (``[::1]`` / ``[::1]:5700``) as well as
-    plain hostnames and IPv4 addresses with an optional ``:port`` suffix.
+    plain hostnames and IPv4 addresses with an optional ``:port`` suffix. A
+    trailing dot (the absolute-DNS root form, e.g. ``localhost.``) is stripped
+    so that fully-qualified equivalents of an allowed host still match.
 
     Args:
         host_header: The raw Host header value (may include a port).
 
     Returns:
-        The hostname portion, lowercased, with any port and IPv6 brackets
-        stripped.
+        The hostname portion, lowercased, with any port, IPv6 brackets, and a
+        trailing root dot stripped.
     """
     value = host_header.strip()
     if value.startswith("["):
         # IPv6 literal: "[::1]" or "[::1]:5700"
         end = value.find("]")
         if end != -1:
-            return value[1:end].lower()
-        return value.lower()
-    # Plain hostname or IPv4, optionally "host:port"
-    if ":" in value:
+            value = value[1:end]
+        # else: malformed (no closing bracket) — fall through with raw value
+    elif ":" in value:
+        # Plain hostname or IPv4, optionally "host:port"
         value = value.rsplit(":", 1)[0]
+    # Normalize the absolute-DNS trailing dot (e.g. "localhost." -> "localhost").
+    value = value.removesuffix(".")
     return value.lower()
 
 

--- a/gptme/server/auth.py
+++ b/gptme/server/auth.py
@@ -92,9 +92,18 @@ def _extract_hostname(host_header: str) -> str:
     elif ":" in value:
         # Plain hostname or IPv4, optionally "host:port"
         value = value.rsplit(":", 1)[0]
-    # Normalize the absolute-DNS trailing dot (e.g. "localhost." -> "localhost").
-    value = value.removesuffix(".")
-    return value.lower()
+    return _normalize_allowed_host(value)
+
+
+def _normalize_allowed_host(name: str) -> str:
+    """Normalize a hostname for allow-list comparison.
+
+    Lowercases and strips a trailing absolute-DNS root dot so that both parsed
+    Host headers and configured allow-list entries use the same canonical form
+    (e.g. a configured ``gptme.local.`` matches an incoming ``Host: gptme.local``
+    and vice versa).
+    """
+    return name.strip().removesuffix(".").lower()
 
 
 def init_host_validation(
@@ -123,7 +132,7 @@ def init_host_validation(
     """
     global _host_validation_enabled, _allowed_hosts
 
-    extra = {h.strip().lower() for h in (allowed_hosts or []) if h.strip()}
+    extra = {_normalize_allowed_host(h) for h in (allowed_hosts or []) if h.strip()}
 
     # Auth enabled → bearer token gates access, no Host check needed.
     if _auth_enabled:
@@ -147,7 +156,7 @@ def init_host_validation(
     # GPTME_DISABLE_AUTH with an explicit allow-list. Enforce Host validation.
     allowed = set(_DEFAULT_ALLOWED_HOSTS)
     if host and host not in ("0.0.0.0", "::"):
-        allowed.add(host.lower())
+        allowed.add(_normalize_allowed_host(host))
     allowed |= extra
     _allowed_hosts = allowed
     _host_validation_enabled = True

--- a/gptme/server/auth.py
+++ b/gptme/server/auth.py
@@ -26,6 +26,18 @@ _server_token: str | None = None
 # Auth state (disabled for local-only binding)
 _auth_enabled: bool = True
 
+# Host-header validation state (DNS-rebinding hardening).
+# Only enforced when auth is disabled for a loopback bind: a malicious page
+# whose hostname re-resolves to 127.0.0.1 becomes same-origin with the local
+# server and bypasses CORS entirely, gaining full unauthenticated API access
+# (which includes shell execution via the agent). Validating the Host header
+# blocks that vector without affecting legitimate localhost/127.0.0.1 clients.
+_host_validation_enabled: bool = False
+_allowed_hosts: set[str] = set()
+
+# Hostnames always allowed for loopback binds (any port).
+_DEFAULT_ALLOWED_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
+
 # Cookie configuration
 AUTH_COOKIE_NAME = "gptme_auth"
 AUTH_COOKIE_MAX_AGE = 86400  # 24 hours
@@ -53,6 +65,118 @@ def is_local_host(host: str) -> bool:
         True if host is localhost or 127.0.0.1, False otherwise.
     """
     return host in ("127.0.0.1", "localhost", "::1")
+
+
+def _extract_hostname(host_header: str) -> str:
+    """Extract the hostname part (without port) from a Host header value.
+
+    Handles IPv6 literals in brackets (``[::1]`` / ``[::1]:5700``) as well as
+    plain hostnames and IPv4 addresses with an optional ``:port`` suffix.
+
+    Args:
+        host_header: The raw Host header value (may include a port).
+
+    Returns:
+        The hostname portion, lowercased, with any port and IPv6 brackets
+        stripped.
+    """
+    value = host_header.strip()
+    if value.startswith("["):
+        # IPv6 literal: "[::1]" or "[::1]:5700"
+        end = value.find("]")
+        if end != -1:
+            return value[1:end].lower()
+        return value.lower()
+    # Plain hostname or IPv4, optionally "host:port"
+    if ":" in value:
+        value = value.rsplit(":", 1)[0]
+    return value.lower()
+
+
+def init_host_validation(
+    host: str = "127.0.0.1", allowed_hosts: list[str] | None = None
+) -> None:
+    """Configure Host-header validation for DNS-rebinding hardening.
+
+    Must be called after :func:`init_auth` (it reads ``_auth_enabled``).
+
+    Validation is only enabled when auth is disabled for a loopback bind — the
+    one case where a DNS-rebinding page can reach the API without credentials.
+    It is skipped when:
+
+    - Auth is enabled (network bind): the bearer token already gates access.
+    - ``GPTME_DISABLE_AUTH`` is explicitly set and no ``--allowed-hosts`` was
+      given: the operator owns security here (e.g. gptme-cloud pods bind
+      ``0.0.0.0`` behind an authenticated ingress). We must not break those
+      setups. If the operator *does* pass ``--allowed-hosts``, we honor it and
+      enforce the check against the given hosts.
+
+    Args:
+        host: The host the server is binding to. A concrete (non-wildcard)
+            bind host is added to the allow-list so proxied setups work.
+        allowed_hosts: Extra hostnames to allow (from ``--allowed-hosts``), for
+            users who proxy their local server behind a hostname.
+    """
+    global _host_validation_enabled, _allowed_hosts
+
+    extra = {h.strip().lower() for h in (allowed_hosts or []) if h.strip()}
+
+    # Auth enabled → bearer token gates access, no Host check needed.
+    if _auth_enabled:
+        _host_validation_enabled = False
+        _allowed_hosts = set()
+        return
+
+    # Auth explicitly disabled via env (operator owns security). Skip the check
+    # unless they opted into an explicit allow-list.
+    disabled_via_env = os.environ.get("GPTME_DISABLE_AUTH", "").lower() in (
+        "true",
+        "1",
+        "yes",
+    )
+    if disabled_via_env and not extra:
+        _host_validation_enabled = False
+        _allowed_hosts = set()
+        return
+
+    # Auth disabled for a loopback bind (the DNS-rebinding vector), or
+    # GPTME_DISABLE_AUTH with an explicit allow-list. Enforce Host validation.
+    allowed = set(_DEFAULT_ALLOWED_HOSTS)
+    if host and host not in ("0.0.0.0", "::"):
+        allowed.add(host.lower())
+    allowed |= extra
+    _allowed_hosts = allowed
+    _host_validation_enabled = True
+
+
+def validate_host():
+    """Flask ``before_request`` hook enforcing Host-header validation.
+
+    Returns a 403 JSON response for a disallowed Host, or ``None`` to let the
+    request proceed. A no-op when validation is disabled (see
+    :func:`init_host_validation`).
+    """
+    if not _host_validation_enabled:
+        return None
+
+    hostname = _extract_hostname(request.host or "")
+    if hostname in _allowed_hosts:
+        return None
+
+    logger.warning("Rejected request with disallowed Host header: %r", request.host)
+    return (
+        jsonify(
+            {
+                "error": (
+                    f"Host '{request.host}' is not allowed. The local gptme-server "
+                    "validates the Host header to block DNS-rebinding attacks. "
+                    "If this host is legitimate (e.g. a reverse proxy), allow it "
+                    f"with: gptme-server serve --allowed-hosts {hostname}"
+                )
+            }
+        ),
+        403,
+    )
 
 
 def get_server_token() -> str | None:

--- a/gptme/server/cli.py
+++ b/gptme/server/cli.py
@@ -180,6 +180,19 @@ def main():
     ),
 )
 @click.option(
+    "--allowed-hosts",
+    default=None,
+    envvar="GPTME_SERVER_ALLOWED_HOSTS",
+    help=(
+        "Comma-separated hostnames to accept in the Host header, in addition "
+        "to the built-in localhost/127.0.0.1/[::1] allow-list. Only relevant "
+        "for unauthenticated loopback binds, where the server validates the "
+        "Host header to block DNS-rebinding attacks. Set this if you proxy the "
+        "local server behind a hostname (e.g. 'gptme.local'). Can also be set "
+        "via the GPTME_SERVER_ALLOWED_HOSTS environment variable."
+    ),
+)
+@click.option(
     "--webui-dir",
     type=click.Path(exists=True, file_okay=False, dir_okay=True, path_type=Path),
     default=None,
@@ -231,6 +244,7 @@ def serve(
     port: int,
     tools: str | None,
     cors_origin: str | None,
+    allowed_hosts: str | None,
     webui_dir: Path | None,
     exit_on_parent_death: bool,
     watch_pid: int | None,
@@ -301,6 +315,9 @@ def serve(
         host=host,
         webui_dir=webui_dir,
         default_profile=default_profile,
+        allowed_hosts=[h.strip() for h in allowed_hosts.split(",") if h.strip()]
+        if allowed_hosts
+        else None,
     )
 
     # Route SIGTERM through the same clean-shutdown path as Ctrl+C so the

--- a/tests/test_server_host_validation.py
+++ b/tests/test_server_host_validation.py
@@ -1,0 +1,158 @@
+"""Tests for Host-header validation (DNS-rebinding hardening) in gptme-server.
+
+gptme-server disables bearer auth for loopback binds. CORS preflight blocks
+plain cross-origin JSON, but DNS rebinding defeats CORS: a malicious page whose
+hostname re-resolves to 127.0.0.1 becomes same-origin with the local server and
+gains full unauthenticated API access (which includes shell execution via the
+agent). Validating the Host header blocks that vector.
+
+See issue #3320.
+"""
+
+import pytest
+
+pytest.importorskip(
+    "flask", reason="flask not installed, install server extras (-E server)"
+)
+
+from flask.testing import FlaskClient  # fmt: skip
+
+import gptme.server.auth as auth_mod  # fmt: skip
+from gptme.server.app import create_app  # fmt: skip
+
+pytestmark = [pytest.mark.timeout(15)]
+
+# A lightweight endpoint that exists and returns JSON. Host validation runs as a
+# before_request hook, so it fires before auth/routing regardless of endpoint.
+HEALTH = "/api/v2/server/health"
+
+
+def _client(host: str = "127.0.0.1", allowed_hosts: list[str] | None = None):
+    app = create_app(host=host, allowed_hosts=allowed_hosts)
+    app.config["TESTING"] = True
+    return app.test_client()
+
+
+def _get(client: FlaskClient, host_header: str):
+    return client.get(HEALTH, headers={"Host": host_header})
+
+
+class TestLoopbackAllowed:
+    """Loopback binds enforce validation but allow the standard local hosts."""
+
+    def test_localhost_with_port_allowed(self):
+        resp = _get(_client(), "localhost:5700")
+        assert resp.status_code == 200
+
+    def test_localhost_without_port_allowed(self):
+        resp = _get(_client(), "localhost")
+        assert resp.status_code == 200
+
+    def test_ipv4_loopback_with_port_allowed(self):
+        resp = _get(_client(), "127.0.0.1:5700")
+        assert resp.status_code == 200
+
+    def test_ipv4_loopback_without_port_allowed(self):
+        resp = _get(_client(), "127.0.0.1")
+        assert resp.status_code == 200
+
+    def test_ipv6_loopback_allowed(self):
+        resp = _get(_client(), "[::1]:5700")
+        assert resp.status_code == 200
+
+
+class TestRebindingRejected:
+    """A Host that isn't on the allow-list is rejected with a clear 403."""
+
+    def test_evil_host_rejected(self):
+        resp = _get(_client(), "attacker.example.com")
+        assert resp.status_code == 403
+        error = resp.get_json()["error"]
+        # Error must name the offending host and how to allow it.
+        assert "attacker.example.com" in error
+        assert "--allowed-hosts" in error
+
+    def test_evil_host_with_port_rejected(self):
+        resp = _get(_client(), "attacker.example.com:5700")
+        assert resp.status_code == 403
+
+
+class TestAllowedHostsExtension:
+    """--allowed-hosts / allowed_hosts extends the allow-list for proxied setups."""
+
+    def test_configured_host_allowed(self):
+        client = _client(allowed_hosts=["gptme.local"])
+        assert _get(client, "gptme.local").status_code == 200
+        assert _get(client, "gptme.local:8080").status_code == 200
+
+    def test_default_hosts_still_allowed_with_extension(self):
+        client = _client(allowed_hosts=["gptme.local"])
+        assert _get(client, "localhost").status_code == 200
+
+    def test_other_host_still_rejected_with_extension(self):
+        client = _client(allowed_hosts=["gptme.local"])
+        assert _get(client, "attacker.example.com").status_code == 403
+
+
+class TestConfiguredBindHost:
+    """A concrete (non-wildcard) bind host is added to the allow-list."""
+
+    def test_bind_host_allowed(self):
+        # Binding to a concrete host enables auth (non-loopback), so validation
+        # is skipped there; but a loopback bind with a custom host stays enforced.
+        client = _client(host="127.0.0.1", allowed_hosts=["myhost.internal"])
+        assert _get(client, "myhost.internal").status_code == 200
+
+
+class TestDisableAuthBypass:
+    """GPTME_DISABLE_AUTH setups (cloud pods behind authenticated ingress) must
+    not break: Host validation is skipped so the operator owns security."""
+
+    def test_disable_auth_skips_host_validation(self, monkeypatch):
+        monkeypatch.setenv("GPTME_DISABLE_AUTH", "true")
+        # 0.0.0.0 bind with auth disabled via env: any Host must pass through.
+        client = _client(host="0.0.0.0")
+        assert auth_mod._host_validation_enabled is False
+        assert _get(client, "attacker.example.com").status_code == 200
+
+    def test_disable_auth_honors_explicit_allowed_hosts(self, monkeypatch):
+        monkeypatch.setenv("GPTME_DISABLE_AUTH", "true")
+        # If the operator opts into an allow-list, we enforce it even under
+        # GPTME_DISABLE_AUTH.
+        client = _client(host="0.0.0.0", allowed_hosts=["ingress.internal"])
+        assert auth_mod._host_validation_enabled is True
+        assert _get(client, "ingress.internal").status_code == 200
+        assert _get(client, "attacker.example.com").status_code == 403
+
+
+class TestAuthEnabledSkipsValidation:
+    """When auth is enabled (network bind), the bearer token gates access and
+    Host validation is skipped — an evil Host reaches auth (401), not 403."""
+
+    def test_network_bind_skips_host_validation(self, monkeypatch):
+        # Ensure no env override is in play.
+        monkeypatch.delenv("GPTME_DISABLE_AUTH", raising=False)
+        client = _client(host="0.0.0.0")
+        assert auth_mod._host_validation_enabled is False
+        # Host check skipped → request falls through to bearer auth, which
+        # rejects the missing token with 401 (not a 403 host rejection).
+        resp = _get(client, "attacker.example.com")
+        assert resp.status_code == 401
+
+
+class TestHostnameExtraction:
+    """Unit coverage for the Host-header parsing helper."""
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("localhost", "localhost"),
+            ("localhost:5700", "localhost"),
+            ("127.0.0.1:5700", "127.0.0.1"),
+            ("[::1]", "::1"),
+            ("[::1]:5700", "::1"),
+            ("Example.COM:80", "example.com"),
+        ],
+    )
+    def test_extract_hostname(self, raw, expected):
+        assert auth_mod._extract_hostname(raw) == expected

--- a/tests/test_server_host_validation.py
+++ b/tests/test_server_host_validation.py
@@ -99,6 +99,14 @@ class TestAllowedHostsExtension:
         client = _client(allowed_hosts=["gptme.local"])
         assert _get(client, "attacker.example.com").status_code == 403
 
+    def test_configured_fqdn_with_trailing_dot_matches(self):
+        # An operator configuring the absolute-DNS form must match both the bare
+        # and trailing-dot Host header forms (regression: #3324 Greptile P1).
+        client = _client(allowed_hosts=["gptme.local."])
+        assert _get(client, "gptme.local").status_code == 200
+        assert _get(client, "gptme.local.").status_code == 200
+        assert _get(client, "gptme.local.:8080").status_code == 200
+
 
 class TestConfiguredBindHost:
     """A concrete (non-wildcard) bind host is added to the allow-list."""

--- a/tests/test_server_host_validation.py
+++ b/tests/test_server_host_validation.py
@@ -60,6 +60,12 @@ class TestLoopbackAllowed:
         resp = _get(_client(), "[::1]:5700")
         assert resp.status_code == 200
 
+    def test_trailing_dot_localhost_allowed(self):
+        # "localhost." is the valid absolute-DNS root form and resolves to the
+        # loopback host; it must be accepted (regression: #3324 Greptile P1).
+        assert _get(_client(), "localhost.").status_code == 200
+        assert _get(_client(), "localhost.:5700").status_code == 200
+
 
 class TestRebindingRejected:
     """A Host that isn't on the allow-list is rejected with a clear 403."""
@@ -152,6 +158,9 @@ class TestHostnameExtraction:
             ("[::1]", "::1"),
             ("[::1]:5700", "::1"),
             ("Example.COM:80", "example.com"),
+            ("localhost.", "localhost"),
+            ("localhost.:5700", "localhost"),
+            ("127.0.0.1.", "127.0.0.1"),
         ],
     )
     def test_extract_hostname(self, raw, expected):


### PR DESCRIPTION
## Problem

gptme-server disables bearer auth when bound to loopback (`gptme/server/auth.py` — `_auth_enabled` is `False` for `localhost`/`127.0.0.1`/`::1` binds). CORS preflight blocks plain cross-origin JSON, but **DNS rebinding defeats CORS entirely**: a malicious site whose hostname re-resolves to `127.0.0.1` becomes *same-origin* with the local server, so a drive-by page gets full unauthenticated API access — which includes **shell execution via the agent**.

Workspace containment never addressed this (a rebinding attacker has full API access anyway). The direct mitigation is validating the `Host` header. Identified in #3320.

## Changes

- **Host-header validation** as a Flask `before_request` hook (`gptme/server/auth.py`, wired in `create_app`), running ahead of routing/auth.
  - Always allows `localhost`, `127.0.0.1`, `[::1]` (any port — the port is stripped, IPv6 brackets handled).
  - Adds the configured bind host (when not a wildcard) to the allow-list.
- **`--allowed-hosts`** CLI flag (comma-separated) on `gptme-server serve` + `GPTME_SERVER_ALLOWED_HOSTS` env var + `allowed_hosts` param on `create_app`, for users who proxy the local server behind a hostname.
- **Disallowed host → 403** with a JSON error naming the offending `Host` and showing the `--allowed-hosts` remedy.
- **Skips validation** when it would add nothing or could break things:
  - Auth enabled (network bind): the bearer token already gates access.
  - `GPTME_DISABLE_AUTH` explicitly set with no allow-list: the operator owns security (gptme-cloud pods bind `0.0.0.0` behind an authenticated ingress — these must not break). `--allowed-hosts` **is** honored even under `GPTME_DISABLE_AUTH`.
- Docs note in `docs/server.rst`.

The Docker `HEALTHCHECK` (`curl -f http://localhost:5700/`) uses `localhost`, which is allowed, so it keeps passing.

## Threat model summary

| Setup | Auth | Host check | Rebinding page reaching 127.0.0.1 |
|---|---|---|---|
| Loopback bind (default) | off | **on** | **blocked (403)** |
| Network bind | on (token) | off | blocked by bearer auth (401) |
| `GPTME_DISABLE_AUTH` (cloud pod) | off | off | operator's ingress owns access |
| `GPTME_DISABLE_AUTH` + `--allowed-hosts` | off | **on** | enforced against allow-list |

## Test plan

New `tests/test_server_host_validation.py` (20 tests) covering: localhost/127.0.0.1/[::1] allowed with & without port, evil host rejected (403 + error content), `--allowed-hosts` extension, `GPTME_DISABLE_AUTH` bypass + its allow-list override, auth-enabled skip, and hostname-parsing unit cases. All pass. Existing `test_server_auth.py`, `test_llm_auth.py`, `test_server_config_workspace_containment.py`, and the `test_server_v2.py` health tests still pass. `prek` clean on all changed files.

Part of #3320.