### PR TITLE
fix(server,webui): external sessions dedup, stable detail IDs, admin nav label

### DIFF
--- a/gptme/server/external_sessions.py
+++ b/gptme/server/external_sessions.py
@@ -11,10 +11,7 @@ import shutil
 import subprocess
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from pathlib import Path
+from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
@@ -68,6 +65,32 @@ class ExternalSessionCatalogItem:
 def _make_external_session_id(path: str) -> str:
     digest = hashlib.sha256(path.encode("utf-8")).hexdigest()
     return digest[:16]
+
+
+def _path_is_under(path: str | None, parent: Path) -> bool:
+    """Whether ``path`` (resolved) is inside ``parent``. False on any error."""
+    if not path:
+        return False
+    try:
+        return Path(path).resolve().is_relative_to(parent)
+    except OSError:
+        return False
+
+
+def _own_logs_dir() -> Path | None:
+    """This server's own conversation logs dir (resolved), or None on error.
+
+    Used to exclude the server's native conversations from external-session
+    discovery — the gptme harness discovery scans the same logs directory the
+    server already serves, so without this filter every local conversation
+    shows up twice in the webui (once native, once "external").
+    """
+    try:
+        from ..dirs import get_logs_dir
+
+        return get_logs_dir().resolve()
+    except Exception:
+        return None
 
 
 class ExternalSessionProvider:
@@ -129,14 +152,21 @@ class ExternalSessionProvider:
         paths: list[Path] = []
         # gptme discovery returns session *directories*; resolve to the
         # conversation.jsonl file inside so IDs are consistent everywhere.
+        # Sessions under this server's own logs dir are excluded: they are
+        # already served as native conversations, and listing them again as
+        # "external" duplicates every conversation in the webui.
+        own_logs_dir = _own_logs_dir()
         for p in self._discover_gptme_sessions(start, end):
             jsonl = p / "conversation.jsonl"
-            if jsonl.exists():
-                paths.append(jsonl.resolve())
-            else:
+            if not jsonl.exists():
                 logger.debug(
                     "gptme session dir has no conversation.jsonl, skipping: %s", p
                 )
+                continue
+            resolved = jsonl.resolve()
+            if own_logs_dir and resolved.is_relative_to(own_logs_dir):
+                continue
+            paths.append(resolved)
         paths.extend(p.resolve() for p in self._discover_cc_sessions(start, end))
         paths.extend(p.resolve() for p in self._discover_codex_sessions(start, end))
         paths.extend(p.resolve() for p in self._discover_copilot_sessions(start, end))
@@ -159,6 +189,12 @@ class ExternalSessionProvider:
         for path in paths[:max_paths]:
             try:
                 transcript = self._read_transcript(path).to_dict()
+                # Canonicalize to the discovered path: get_session() derives the
+                # ID from this exact string, while the transcript may report a
+                # differently-normalized trajectory_path (unresolved symlinks,
+                # session dir vs file). Any mismatch makes listed sessions 404
+                # on detail lookup.
+                transcript["trajectory_path"] = str(path)
                 items.append(
                     ExternalSessionCatalogItem.from_transcript_dict(transcript)
                 )
@@ -205,6 +241,9 @@ class ExternalSessionProvider:
                     exc_info=True,
                 )
                 continue
+            # Keep trajectory_path consistent with the catalog listing (the ID
+            # is derived from this string in both places).
+            transcript["trajectory_path"] = path_str
             return {
                 "id": _make_external_session_id(path_str),
                 "transcript": transcript,
@@ -280,10 +319,36 @@ class CLIExternalSessionProvider:
             return []
         try:
             data = json.loads(output)
-            return data.get("sessions", [])
+            sessions = data.get("sessions", [])
         except (json.JSONDecodeError, KeyError):
             logger.warning("Failed to parse gptme-sessions discover JSON output")
             return []
+        # Exclude sessions under this server's own logs dir — they are already
+        # served as native conversations (see ExternalSessionProvider._discover_paths).
+        own_logs_dir = _own_logs_dir()
+        if own_logs_dir:
+            sessions = [
+                s for s in sessions if not _path_is_under(s.get("path"), own_logs_dir)
+            ]
+        # gptme discovery reports session *directories*, but the `transcript`
+        # subcommand only accepts files — resolve to the conversation.jsonl
+        # inside (mirrors ExternalSessionProvider._discover_paths). Without
+        # this every remaining gptme session logs a CLI usage error and is
+        # skipped.
+        normalized: list[dict] = []
+        for s in sessions:
+            path = s.get("path")
+            if path and Path(path).is_dir():
+                jsonl = Path(path) / "conversation.jsonl"
+                if not jsonl.exists():
+                    logger.debug(
+                        "gptme session dir has no conversation.jsonl, skipping: %s",
+                        path,
+                    )
+                    continue
+                s = {**s, "path": str(jsonl)}
+            normalized.append(s)
+        return normalized
 
     def _read_transcript_cli(self, path: str) -> dict | None:
         """Read a transcript via CLI, returning the full JSON dict."""
@@ -330,6 +395,12 @@ class CLIExternalSessionProvider:
                 transcript = self._read_transcript_cli(path)
                 if transcript is None:
                     continue
+                # Canonicalize to the discovered path: get_session() derives
+                # the ID from this exact string, while the transcript may
+                # report a differently-normalized trajectory_path (e.g.
+                # symlinks resolved: ~/.claude -> ~/dotfiles/home/.claude).
+                # Any mismatch makes every listed session 404 on detail lookup.
+                transcript["trajectory_path"] = str(path)
                 items.append(
                     ExternalSessionCatalogItem.from_transcript_dict(transcript)
                 )
@@ -373,6 +444,9 @@ class CLIExternalSessionProvider:
                     exc_info=True,
                 )
                 continue
+            # Keep trajectory_path consistent with the catalog listing (the ID
+            # is derived from this string in both places).
+            transcript["trajectory_path"] = str(path)
             return {
                 "id": _make_external_session_id(path),
                 "transcript": transcript,

--- a/tests/test_external_sessions.py
+++ b/tests/test_external_sessions.py
@@ -423,3 +423,182 @@ class TestGetProviderNeitherAvailable:
             assert result is None
         finally:
             get_external_session_provider.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# Catalog/detail ID consistency + own-logs filtering (regressions)
+# ---------------------------------------------------------------------------
+
+
+def _cli_responses(discover_json: dict, transcript_json: dict):
+    """Build a _run_cli mock serving discover + transcript subcommands."""
+
+    def run_cli(args, timeout=60):
+        if args[0] == "discover":
+            return json.dumps(discover_json)
+        if args[0] == "transcript":
+            return json.dumps(transcript_json)
+        return None
+
+    return run_cli
+
+
+class TestCLIProviderIdConsistency:
+    """Listed session IDs must be fetchable via get_session.
+
+    Regression: list ids were derived from the transcript's trajectory_path
+    (which may be symlink-resolved, e.g. ~/.claude -> ~/dotfiles/home/.claude)
+    while get_session hashed the discover path — every listed session 404'd
+    on detail lookup.
+    """
+
+    def test_list_id_matches_get_id_when_transcript_path_differs(self, monkeypatch):
+        provider = CLIExternalSessionProvider()
+        discover = {
+            "sessions": [
+                {"path": "/tmp/proj/cc-session.jsonl", "harness": "claude-code"}
+            ]
+        }
+        transcript = {
+            # Reported path differs from the discovered path (symlinks resolved)
+            "trajectory_path": "/private/tmp/proj/cc-session.jsonl",
+            "session_id": "sess-cc",
+            "harness": "claude-code",
+        }
+        monkeypatch.setattr(provider, "_run_cli", _cli_responses(discover, transcript))
+        monkeypatch.setattr(
+            "gptme.server.external_sessions._own_logs_dir", lambda: None
+        )
+
+        items = provider.list_sessions()
+        assert len(items) == 1
+        item = items[0]
+        assert item.id == _make_external_session_id("/tmp/proj/cc-session.jsonl")
+        assert item.trajectory_path == "/tmp/proj/cc-session.jsonl"
+
+        detail = provider.get_session(item.id)
+        assert detail is not None
+        assert detail["id"] == item.id
+        assert detail["transcript"]["trajectory_path"] == item.trajectory_path
+
+
+class TestCLIProviderOwnLogsFilter:
+    """gptme sessions under this server's own logs dir are native conversations
+    and must not be listed again as external (they duplicate every chat)."""
+
+    def test_own_logs_sessions_excluded(self, monkeypatch, tmp_path: Path):
+        own_logs = tmp_path / "logs"
+        native = own_logs / "2026-07-23-native-convo"
+        native.mkdir(parents=True)
+        (native / "conversation.jsonl").write_text("{}\n")
+
+        external_dir = tmp_path / "other-host-logs" / "2026-07-22-remote-convo"
+        external_dir.mkdir(parents=True)
+        (external_dir / "conversation.jsonl").write_text("{}\n")
+
+        provider = CLIExternalSessionProvider()
+        discover = {
+            "sessions": [
+                {"path": str(native), "harness": "gptme"},
+                {"path": str(external_dir), "harness": "gptme"},
+            ]
+        }
+        monkeypatch.setattr(
+            provider, "_run_cli", _cli_responses(discover, {"sessions": []})
+        )
+        monkeypatch.setattr(
+            "gptme.server.external_sessions._own_logs_dir",
+            lambda: own_logs.resolve(),
+        )
+
+        sessions = provider._discover_paths(days=30)
+        paths = [s["path"] for s in sessions]
+        assert str(native) not in paths
+        assert str(native / "conversation.jsonl") not in paths
+        # The non-native gptme session dir is normalized to its jsonl file
+        assert paths == [str(external_dir / "conversation.jsonl")]
+
+
+class TestCLIProviderGptmeDirNormalization:
+    """gptme discovery yields session *dirs*; the transcript subcommand only
+    accepts files. Dirs must be normalized to conversation.jsonl (or dropped),
+    not passed through to fail with a CLI usage error."""
+
+    def test_dir_without_jsonl_dropped(self, monkeypatch, tmp_path: Path):
+        empty_dir = tmp_path / "2026-07-04-jumping-funny-jellyfish"
+        empty_dir.mkdir()
+
+        provider = CLIExternalSessionProvider()
+        discover = {"sessions": [{"path": str(empty_dir), "harness": "gptme"}]}
+        monkeypatch.setattr(
+            provider, "_run_cli", _cli_responses(discover, {"sessions": []})
+        )
+        monkeypatch.setattr(
+            "gptme.server.external_sessions._own_logs_dir", lambda: None
+        )
+
+        assert provider._discover_paths(days=30) == []
+
+
+class TestPythonProviderIdConsistency:
+    """Same list/get ID consistency for the gptme_sessions-backed provider."""
+
+    def _make_provider(self, jsonl: Path, transcript: dict):
+        from gptme.server.external_sessions import ExternalSessionProvider
+
+        class _Transcript:
+            def __init__(self, d: dict):
+                self._d = d
+
+            def to_dict(self) -> dict:
+                return dict(self._d)
+
+        provider = ExternalSessionProvider.__new__(ExternalSessionProvider)
+        provider._discover_gptme_sessions = lambda start, end: []
+        provider._discover_cc_sessions = lambda start, end: [jsonl]
+        provider._discover_codex_sessions = lambda start, end: []
+        provider._discover_copilot_sessions = lambda start, end: []
+        provider._read_transcript = lambda path: _Transcript(transcript)
+        return provider
+
+    def test_list_id_matches_get_id(self, monkeypatch, tmp_path: Path):
+        jsonl = tmp_path / "cc-session.jsonl"
+        jsonl.write_text("{}\n")
+        transcript = {
+            "trajectory_path": "/some/other/normalization.jsonl",
+            "session_id": "sess-py",
+            "harness": "claude-code",
+        }
+        provider = self._make_provider(jsonl, transcript)
+        monkeypatch.setattr(
+            "gptme.server.external_sessions._own_logs_dir", lambda: None
+        )
+
+        items = provider.list_sessions()
+        assert len(items) == 1
+        item = items[0]
+        assert item.id == _make_external_session_id(str(jsonl.resolve()))
+
+        detail = provider.get_session(item.id)
+        assert detail is not None
+        assert detail["id"] == item.id
+
+    def test_own_logs_gptme_sessions_excluded(self, monkeypatch, tmp_path: Path):
+        own_logs = tmp_path / "logs"
+        native = own_logs / "2026-07-23-native-convo"
+        native.mkdir(parents=True)
+        (native / "conversation.jsonl").write_text("{}\n")
+
+        from gptme.server.external_sessions import ExternalSessionProvider
+
+        provider = ExternalSessionProvider.__new__(ExternalSessionProvider)
+        provider._discover_gptme_sessions = lambda start, end: [native]
+        provider._discover_cc_sessions = lambda start, end: []
+        provider._discover_codex_sessions = lambda start, end: []
+        provider._discover_copilot_sessions = lambda start, end: []
+        monkeypatch.setattr(
+            "gptme.server.external_sessions._own_logs_dir",
+            lambda: own_logs.resolve(),
+        )
+
+        assert provider._discover_paths(days=30) == []

--- a/webui/src/components/SidebarIcons.tsx
+++ b/webui/src/components/SidebarIcons.tsx
@@ -30,7 +30,7 @@ interface NavItem {
   id: string;
   icon: React.ComponentType<{ className?: string }>;
   label: string;
-  section: 'chat' | 'tasks' | 'history' | 'agents' | 'workspaces' | 'external-sessions';
+  section: 'chat' | 'tasks' | 'history' | 'agents' | 'workspaces' | 'external-sessions' | 'admin';
 }
 
 interface Props {
@@ -114,6 +114,7 @@ export const SidebarIcons: FC<Props> = ({ tasks }) => {
     { id: 'tasks', icon: Kanban, label: 'Tasks', section: 'tasks' },
     { id: 'history', icon: History, label: 'History', section: 'history' },
     { id: 'external-sessions', icon: Layers, label: 'External', section: 'external-sessions' },
+    { id: 'admin', icon: Shield, label: 'Admin', section: 'admin' },
   ];
 
   return (
@@ -171,22 +172,6 @@ export const SidebarIcons: FC<Props> = ({ tasks }) => {
         })}
 
         {/* Search */}
-        <TooltipProvider>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant={currentSection === 'admin' ? 'secondary' : 'ghost'}
-                size="icon"
-                className="h-8 w-8"
-                onClick={() => handleNavigateToSection('admin')}
-              >
-                <Shield className="h-4 w-4" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent side="right">Admin</TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
-
         <TooltipProvider>
           <Tooltip>
             <TooltipTrigger asChild>


### PR DESCRIPTION
Fixes three issues Erik hit in the webui today:

1. **Every local conversation listed twice** with the Ext toggle on: gptme-harness external discovery scans the same logs dir the server serves natively, so each chat appeared both as native (`2026-07-23-crawling-funny-fish`) and external (`gptme/external-extracted ...`). External discovery now excludes sessions under the server's own logs dir.

2. **Listed external sessions 404 on click** (`GET /api/v2/external-sessions/<id>` → "External session not found"): catalog IDs were derived from the transcript's `trajectory_path` (symlink-resolved, e.g. `~/.claude` → `~/dotfiles/home/.claude`) while the detail lookup hashed the *discover* path (unresolved) — so the IDs never matched. Both sides now derive the ID from the same discovered-path string. Live-reproduced against a running server before the fix.

3. **CLI provider spammed warnings** (`gptme-sessions transcript <dir> --json failed (exit 2)`): gptme discovery returns session *directories* but the `transcript` subcommand only accepts files. Directories are now normalized to their `conversation.jsonl` (or skipped).

Plus: the **Admin** sidebar entry is now rendered through the same `navItems` path as other sections, so it gets a visible label when the sidebar is expanded and an aria-label (was a bare unlabeled icon button).

Tests: 8 new regression tests (ID consistency for both providers, own-logs filtering, dir normalization); all 31 external-session tests pass.