### PR TITLE
fix(webui): persistent disconnected banner in conversation view

### DIFF
--- a/webui/src/components/ConversationContent.tsx
+++ b/webui/src/components/ConversationContent.tsx
@@ -25,6 +25,7 @@ import { AlertTriangle, ArrowDown, ChevronUp, RefreshCw, WifiOff } from 'lucide-
 import { Button } from '@/components/ui/button';
 import { isDemoMode } from '@/utils/connectionConfig';
 import { isLikelyChromeCorsPna } from '@/utils/api';
+import { getClientForServer } from '@/stores/serverClients';
 
 interface Props {
   conversationId: string;
@@ -66,6 +67,10 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
   const paneRef = useRef<HTMLElement>(null);
 
   const { api, connectionConfig, connect, getClient } = useApi();
+  // When a conversation's server is removed from the registry, getClient(serverId) silently
+  // falls back to the primary client. Detect this so the banner can report "server not found"
+  // instead of showing the wrong server's connection status.
+  const serverNotFound = !!serverId && !getClientForServer(serverId);
   // Use the conversation's server client when serverId is provided, not the primary.
   const serverClient = serverId ? getClient(serverId) : api;
   const isConnected = use$(serverClient.isConnected$);
@@ -554,7 +559,7 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
   // Top-of-view banner when the API server itself is unreachable (not in intentional demo mode).
   // This is distinct from the SSE-level reconnect banner above which fires after a successful
   // connection drops mid-session. This fires on load when the server was never reachable.
-  const showServerDisconnectedBanner = !isConnected && !isDemoMode();
+  const showServerDisconnectedBanner = (serverNotFound || !isConnected) && !isDemoMode();
 
   // Classify failure reason to give actionable guidance (mirrors WelcomeView logic).
   const disconnectedDesc = (() => {
@@ -668,9 +673,11 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
           <WifiOff className="h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
           <span className="min-w-0 flex-1 text-amber-800 dark:text-amber-200">
             <span className="font-medium">Server not connected</span>
-            {disconnectedDesc
-              ? ` — ${disconnectedDesc}`
-              : ' — browsing demo data. Connect a server to start a real conversation.'}
+            {serverNotFound
+              ? ' — the server for this conversation is no longer registered. Add it again in settings to reconnect.'
+              : disconnectedDesc
+                ? ` — ${disconnectedDesc}`
+                : ' — browsing demo data. Connect a server to start a real conversation.'}
           </span>
           <Button
             type="button"

--- a/webui/src/components/ConversationContent.tsx
+++ b/webui/src/components/ConversationContent.tsx
@@ -65,9 +65,11 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
   const prevConversationIdRef = useRef<string | null>(null);
   const paneRef = useRef<HTMLElement>(null);
 
-  const { api, connectionConfig, isConnected$, connect } = useApi();
-  const isConnected = use$(isConnected$);
-  const lastConnectionResult = use$(api.lastConnectionResult$);
+  const { api, connectionConfig, connect, getClient } = useApi();
+  // Use the conversation's server client when serverId is provided, not the primary.
+  const serverClient = serverId ? getClient(serverId) : api;
+  const isConnected = use$(serverClient.isConnected$);
+  const lastConnectionResult = use$(serverClient.lastConnectionResult$);
   const [isRetryingConnection, setIsRetryingConnection] = useState(false);
   const hasSession$ = useObservable<boolean>(false);
   const { defaultModel } = useModels();
@@ -573,9 +575,14 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
   const handleRetryConnection = async () => {
     setIsRetryingConnection(true);
     try {
-      await connect();
+      if (serverId) {
+        // Retry the conversation's specific server, not the primary.
+        await serverClient.checkConnection();
+      } else {
+        await connect();
+      }
     } catch {
-      // connect() shows toast on failure; swallow to avoid double-toast
+      // connect()/checkConnection() shows toast on failure; swallow to avoid double-toast
     } finally {
       setIsRetryingConnection(false);
     }

--- a/webui/src/components/ConversationContent.tsx
+++ b/webui/src/components/ConversationContent.tsx
@@ -23,6 +23,8 @@ import { useModels } from '@/hooks/useModels';
 import { chatRoute } from '@/utils/routes';
 import { AlertTriangle, ArrowDown, ChevronUp, RefreshCw, WifiOff } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { isDemoMode } from '@/utils/connectionConfig';
+import { isLikelyChromeCorsPna } from '@/utils/api';
 
 interface Props {
   conversationId: string;
@@ -63,7 +65,10 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
   const prevConversationIdRef = useRef<string | null>(null);
   const paneRef = useRef<HTMLElement>(null);
 
-  const { api, connectionConfig } = useApi();
+  const { api, connectionConfig, isConnected$, connect } = useApi();
+  const isConnected = use$(isConnected$);
+  const lastConnectionResult = use$(api.lastConnectionResult$);
+  const [isRetryingConnection, setIsRetryingConnection] = useState(false);
   const hasSession$ = useObservable<boolean>(false);
   const { defaultModel } = useModels();
 
@@ -544,6 +549,38 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
   const showConnectionBanner =
     !isReadOnly && (connectionStatus === 'reconnecting' || connectionStatus === 'disconnected');
 
+  // Top-of-view banner when the API server itself is unreachable (not in intentional demo mode).
+  // This is distinct from the SSE-level reconnect banner above which fires after a successful
+  // connection drops mid-session. This fires on load when the server was never reachable.
+  const showServerDisconnectedBanner = !isConnected && !isDemoMode();
+
+  // Classify failure reason to give actionable guidance (mirrors WelcomeView logic).
+  const disconnectedDesc = (() => {
+    if (!lastConnectionResult || lastConnectionResult.ok) return null;
+    const { reason, url } = lastConnectionResult;
+    if (reason === 'cors') {
+      return isLikelyChromeCorsPna(url)
+        ? 'Chrome blocked this connection (Local Network Access). Allow the permission prompt, then retry.'
+        : `The server rejected cross-origin requests from this page. Restart it with --cors-origin='${window.location.origin}' to allow this page.`;
+    }
+    if (reason === 'network')
+      return 'Cannot reach the server — check that it is running and the URL is correct.';
+    if (reason === 'timeout')
+      return 'Connection timed out. The server may be starting up — retry in a moment.';
+    return null;
+  })();
+
+  const handleRetryConnection = async () => {
+    setIsRetryingConnection(true);
+    try {
+      await connect();
+    } catch {
+      // connect() shows toast on failure; swallow to avoid double-toast
+    } finally {
+      setIsRetryingConnection(false);
+    }
+  };
+
   // Live countdown timer — decrements every second while reconnecting
   const [reconnectRetrySeconds, setReconnectRetrySeconds] = useState<number | null>(null);
   useEffect(() => {
@@ -618,6 +655,30 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
           ) : null
         }
       </Memo>
+
+      {showServerDisconnectedBanner && (
+        <div className="flex shrink-0 items-center gap-3 border-b border-amber-500/30 bg-amber-500/10 px-4 py-2 text-sm">
+          <WifiOff className="h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
+          <span className="min-w-0 flex-1 text-amber-800 dark:text-amber-200">
+            <span className="font-medium">Server not connected</span>
+            {disconnectedDesc
+              ? ` — ${disconnectedDesc}`
+              : ' — browsing demo data. Connect a server to start a real conversation.'}
+          </span>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-7 shrink-0 gap-1.5 text-xs text-amber-700 hover:bg-amber-500/20 hover:text-amber-900 dark:text-amber-300 dark:hover:text-amber-100"
+            onClick={() => void handleRetryConnection()}
+            disabled={isRetryingConnection}
+          >
+            <RefreshCw className={`h-3.5 w-3.5 ${isRetryingConnection ? 'animate-spin' : ''}`} />
+            {isRetryingConnection ? 'Retrying…' : 'Retry'}
+          </Button>
+        </div>
+      )}
+
       <div
         className="flex-1 overflow-y-auto"
         ref={scrollContainerRef}

--- a/webui/src/components/ConversationContent.tsx
+++ b/webui/src/components/ConversationContent.tsx
@@ -679,17 +679,19 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
                 ? ` — ${disconnectedDesc}`
                 : ' — browsing demo data. Connect a server to start a real conversation.'}
           </span>
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            className="h-7 shrink-0 gap-1.5 text-xs text-amber-700 hover:bg-amber-500/20 hover:text-amber-900 dark:text-amber-300 dark:hover:text-amber-100"
-            onClick={() => void handleRetryConnection()}
-            disabled={isRetryingConnection}
-          >
-            <RefreshCw className={`h-3.5 w-3.5 ${isRetryingConnection ? 'animate-spin' : ''}`} />
-            {isRetryingConnection ? 'Retrying…' : 'Retry'}
-          </Button>
+          {!serverNotFound && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-7 shrink-0 gap-1.5 text-xs text-amber-700 hover:bg-amber-500/20 hover:text-amber-900 dark:text-amber-300 dark:hover:text-amber-100"
+              onClick={() => void handleRetryConnection()}
+              disabled={isRetryingConnection}
+            >
+              <RefreshCw className={`h-3.5 w-3.5 ${isRetryingConnection ? 'animate-spin' : ''}`} />
+              {isRetryingConnection ? 'Retrying…' : 'Retry'}
+            </Button>
+          )}
         </div>
       )}
 

--- a/webui/src/components/__tests__/ConversationContent.test.tsx
+++ b/webui/src/components/__tests__/ConversationContent.test.tsx
@@ -340,6 +340,11 @@ describe('server disconnected banner — removed server', () => {
     expect(screen.getByText(/no longer registered/i)).toBeInTheDocument();
   });
 
+  it('hides Retry button when server is no longer in registry', () => {
+    render(<ConversationContent conversationId="demo/test" serverId="removed-server" />);
+    expect(screen.queryByRole('button', { name: /retry/i })).toBeNull();
+  });
+
   it('does not show removed-server banner in intentional demo mode', () => {
     mockIsDemoMode.mockReturnValue(true);
     render(<ConversationContent conversationId="demo/test" serverId="removed-server" />);

--- a/webui/src/components/__tests__/ConversationContent.test.tsx
+++ b/webui/src/components/__tests__/ConversationContent.test.tsx
@@ -1,0 +1,238 @@
+/**
+ * Focused tests for the server-disconnected banner in ConversationContent.
+ *
+ * The full component has many complex dependencies; we mock them heavily so
+ * we can focus on verifying that the banner appears/disappears based on
+ * connection state and demo mode.
+ */
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { observable } from '@legendapp/state';
+import { ConversationContent } from '../ConversationContent';
+
+// --- Mocks ---
+
+const mockNavigate = jest.fn();
+const mockConnect = jest.fn();
+const mockIsDemoMode = jest.fn(() => false);
+const mockIsLikelyChromeCorsPna = jest.fn((_url: string) => false);
+
+const isConnected$ = observable(true);
+const lastConnectionResult$ = observable<null | {
+  ok: false;
+  url: string;
+  reason: 'network' | 'http_error' | 'parse_error' | 'timeout' | 'cors';
+  message: string;
+}>(null);
+const sessions$ = observable(new Map<string, string>());
+
+// Minimal ConversationState observable for the component to reach the banner
+function makeConversationState() {
+  return observable({
+    loadError: null,
+    data: {
+      log: [],
+      logdir: 'demo/test',
+      name: 'Test',
+      id: 'demo/test',
+      logfile: 'demo/test',
+      branches: {},
+      workspace: '/demo',
+    },
+    connectionStatus: 'connected',
+    reconnectAttempt: null,
+    reconnectMaxAttempts: null,
+    reconnectRetryInMs: null,
+    reconnectRetryStartedAt: null,
+    connectionError: null,
+    hasMoreBefore: false,
+    isConnected: true,
+    isGenerating: false,
+    pendingTool: null,
+    executingTool: null,
+    lastCompletedTool: null,
+    showInitialSystem: false,
+    chatConfig: null,
+    needsInitialStep: false,
+    currentBranch: 'main',
+    logOffset: 0,
+    isWindowHydrated: true,
+    lastMessage: undefined,
+    maxTokens: undefined,
+    temperature: undefined,
+    topP: undefined,
+  });
+}
+
+const mockConversation$ = makeConversationState();
+
+jest.mock('@/utils/api', () => ({
+  isLikelyChromeCorsPna: (url: string) => mockIsLikelyChromeCorsPna(url),
+}));
+
+jest.mock('@/utils/connectionConfig', () => ({
+  isDemoMode: () => mockIsDemoMode(),
+}));
+
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+    useSearchParams: () => [new URLSearchParams(), jest.fn()],
+  };
+});
+
+jest.mock('@/contexts/ApiContext', () => ({
+  useApi: () => ({
+    api: {
+      isConnected$,
+      lastConnectionResult$,
+      sessions$,
+      authHeader: null,
+      getUserInfo: jest.fn().mockResolvedValue({}),
+      step: jest.fn(),
+      sendMessage: jest.fn(),
+      subscribeToEvents: jest.fn(),
+      cancelPendingRequests: jest.fn(),
+      getConversation: jest.fn(),
+      getConversations: jest.fn(),
+    },
+    isConnected$,
+    connect: mockConnect,
+    connectionConfig: {
+      baseUrl: 'http://localhost:5700',
+      authToken: null,
+      useAuthToken: false,
+    },
+  }),
+}));
+
+jest.mock('@/contexts/SettingsContext', () => ({
+  useSettings: () => ({
+    settings: {
+      showHiddenMessages: false,
+      showInitialSystem: false,
+      blocksDefaultOpen: true,
+    },
+    updateSettings: jest.fn(),
+  }),
+}));
+
+jest.mock('@/hooks/useModels', () => ({
+  useModels: () => ({ defaultModel: undefined }),
+}));
+
+jest.mock('@/hooks/useConversation', () => ({
+  useConversation: () => ({
+    conversation$: mockConversation$,
+    retryLoad: jest.fn(),
+    sendMessage: jest.fn(),
+    retryMessage: jest.fn(),
+    editMessage: jest.fn(),
+    deleteMessage: jest.fn(),
+    rerunFromMessage: jest.fn(),
+    regenerateMessage: jest.fn(),
+    forkConversation: jest.fn(),
+    switchBranch: jest.fn(),
+    confirmTool: jest.fn(),
+    interruptGeneration: jest.fn(),
+    isLoadingOlderMessages: false,
+    loadOlderMessages: jest.fn(),
+  }),
+}));
+
+// Heavy component deps that aren't under test — stub to avoid rendering complexity
+jest.mock('../ChatInput', () => ({
+  ChatInput: () => <div data-testid="chat-input" />,
+}));
+
+jest.mock('../OpenConversationPathButton', () => ({
+  OpenConversationPathButton: () => null,
+}));
+
+jest.mock('../BranchIndicator', () => ({
+  BranchIndicator: () => null,
+}));
+
+jest.mock('@tanstack/react-query', () => ({
+  useQueryClient: () => ({ cancelQueries: jest.fn(), invalidateQueries: jest.fn() }),
+}));
+
+// --- Tests ---
+
+function renderComponent() {
+  return render(<ConversationContent conversationId="demo/test" />);
+}
+
+describe('server disconnected banner', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsDemoMode.mockReturnValue(false);
+    isConnected$.set(true);
+    lastConnectionResult$.set(null);
+  });
+
+  it('is hidden when connected', () => {
+    isConnected$.set(true);
+    renderComponent();
+    expect(screen.queryByText(/server not connected/i)).toBeNull();
+  });
+
+  it('shows when disconnected and not in demo mode', () => {
+    isConnected$.set(false);
+    renderComponent();
+    expect(screen.getByText(/server not connected/i)).toBeInTheDocument();
+  });
+
+  it('is hidden when disconnected but in intentional demo mode', () => {
+    isConnected$.set(false);
+    mockIsDemoMode.mockReturnValue(true);
+    renderComponent();
+    expect(screen.queryByText(/server not connected/i)).toBeNull();
+  });
+
+  it('shows CORS guidance when the failure reason is cors', () => {
+    isConnected$.set(false);
+    lastConnectionResult$.set({
+      ok: false,
+      url: 'http://localhost:5700',
+      reason: 'cors',
+      message: 'CORS error',
+    });
+    renderComponent();
+    expect(screen.getByText(/--cors-origin/i)).toBeInTheDocument();
+  });
+
+  it('shows network guidance when the failure reason is network', () => {
+    isConnected$.set(false);
+    lastConnectionResult$.set({
+      ok: false,
+      url: 'http://localhost:5700',
+      reason: 'network',
+      message: 'Network error',
+    });
+    renderComponent();
+    expect(screen.getByText(/check that it is running/i)).toBeInTheDocument();
+  });
+
+  it('shows timeout guidance when the failure reason is timeout', () => {
+    isConnected$.set(false);
+    lastConnectionResult$.set({
+      ok: false,
+      url: 'http://localhost:5700',
+      reason: 'timeout',
+      message: 'Timeout',
+    });
+    renderComponent();
+    expect(screen.getByText(/timed out/i)).toBeInTheDocument();
+  });
+
+  it('shows a Retry button that calls connect()', async () => {
+    isConnected$.set(false);
+    renderComponent();
+    const btn = screen.getByRole('button', { name: /retry/i });
+    btn.click();
+    expect(mockConnect).toHaveBeenCalled();
+  });
+});

--- a/webui/src/components/__tests__/ConversationContent.test.tsx
+++ b/webui/src/components/__tests__/ConversationContent.test.tsx
@@ -77,6 +77,22 @@ function makeConversationState() {
 
 const mockConversation$ = makeConversationState();
 
+// Allow tests to control which server IDs are "registered" in the server registry.
+const mockGetClientForServer = jest.fn((serverId?: string) => {
+  if (serverId === 'secondary-server') {
+    return {
+      isConnected$: secondaryIsConnected$,
+      lastConnectionResult$: secondaryLastConnectionResult$,
+      checkConnection: secondaryCheckConnection,
+    };
+  }
+  return null; // unregistered / removed server
+});
+
+jest.mock('@/stores/serverClients', () => ({
+  getClientForServer: (serverId?: string) => mockGetClientForServer(serverId),
+}));
+
 jest.mock('@/utils/api', () => ({
   isLikelyChromeCorsPna: (url: string) => mockIsLikelyChromeCorsPna(url),
 }));
@@ -295,5 +311,38 @@ describe('server disconnected banner — serverId (secondary server)', () => {
     btn.click();
     expect(secondaryCheckConnection).toHaveBeenCalled();
     expect(mockConnect).not.toHaveBeenCalled();
+  });
+});
+
+describe('server disconnected banner — removed server', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsDemoMode.mockReturnValue(false);
+    // Primary is connected
+    isConnected$.set(true);
+    lastConnectionResult$.set(null);
+    // Simulate a removed server: getClientForServer returns null for 'removed-server'
+    mockGetClientForServer.mockImplementation((serverId?: string) => {
+      if (serverId === 'secondary-server') {
+        return {
+          isConnected$: secondaryIsConnected$,
+          lastConnectionResult$: secondaryLastConnectionResult$,
+          checkConnection: secondaryCheckConnection,
+        };
+      }
+      return null;
+    });
+  });
+
+  it('shows banner when serverId refers to a server no longer in the registry', () => {
+    render(<ConversationContent conversationId="demo/test" serverId="removed-server" />);
+    expect(screen.getByText(/server not connected/i)).toBeInTheDocument();
+    expect(screen.getByText(/no longer registered/i)).toBeInTheDocument();
+  });
+
+  it('does not show removed-server banner in intentional demo mode', () => {
+    mockIsDemoMode.mockReturnValue(true);
+    render(<ConversationContent conversationId="demo/test" serverId="removed-server" />);
+    expect(screen.queryByText(/server not connected/i)).toBeNull();
   });
 });

--- a/webui/src/components/__tests__/ConversationContent.test.tsx
+++ b/webui/src/components/__tests__/ConversationContent.test.tsx
@@ -14,6 +14,7 @@ import { ConversationContent } from '../ConversationContent';
 
 const mockNavigate = jest.fn();
 const mockConnect = jest.fn();
+const mockCheckConnection = jest.fn().mockResolvedValue(true);
 const mockIsDemoMode = jest.fn(() => false);
 const mockIsLikelyChromeCorsPna = jest.fn((_url: string) => false);
 
@@ -25,6 +26,16 @@ const lastConnectionResult$ = observable<null | {
   message: string;
 }>(null);
 const sessions$ = observable(new Map<string, string>());
+
+// Secondary server observables for serverId tests
+const secondaryIsConnected$ = observable(true);
+const secondaryLastConnectionResult$ = observable<null | {
+  ok: false;
+  url: string;
+  reason: 'network' | 'http_error' | 'parse_error' | 'timeout' | 'cors';
+  message: string;
+}>(null);
+const secondaryCheckConnection = jest.fn().mockResolvedValue(true);
 
 // Minimal ConversationState observable for the component to reach the banner
 function makeConversationState() {
@@ -97,9 +108,25 @@ jest.mock('@/contexts/ApiContext', () => ({
       cancelPendingRequests: jest.fn(),
       getConversation: jest.fn(),
       getConversations: jest.fn(),
+      checkConnection: mockCheckConnection,
     },
     isConnected$,
     connect: mockConnect,
+    getClient: (serverId?: string) => {
+      if (serverId === 'secondary-server') {
+        return {
+          isConnected$: secondaryIsConnected$,
+          lastConnectionResult$: secondaryLastConnectionResult$,
+          checkConnection: secondaryCheckConnection,
+        };
+      }
+      // Unknown server ID falls back to primary (matches ApiContext behavior)
+      return {
+        isConnected$,
+        lastConnectionResult$,
+        checkConnection: mockCheckConnection,
+      };
+    },
     connectionConfig: {
       baseUrl: 'http://localhost:5700',
       authToken: null,
@@ -234,5 +261,39 @@ describe('server disconnected banner', () => {
     const btn = screen.getByRole('button', { name: /retry/i });
     btn.click();
     expect(mockConnect).toHaveBeenCalled();
+  });
+});
+
+describe('server disconnected banner — serverId (secondary server)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsDemoMode.mockReturnValue(false);
+    // Primary is always connected in these tests
+    isConnected$.set(true);
+    lastConnectionResult$.set(null);
+    // Secondary starts connected
+    secondaryIsConnected$.set(true);
+    secondaryLastConnectionResult$.set(null);
+  });
+
+  it('is hidden when the secondary server is connected (primary irrelevant)', () => {
+    secondaryIsConnected$.set(true);
+    render(<ConversationContent conversationId="demo/test" serverId="secondary-server" />);
+    expect(screen.queryByText(/server not connected/i)).toBeNull();
+  });
+
+  it('shows when the secondary server is disconnected, even if primary is connected', () => {
+    secondaryIsConnected$.set(false);
+    render(<ConversationContent conversationId="demo/test" serverId="secondary-server" />);
+    expect(screen.getByText(/server not connected/i)).toBeInTheDocument();
+  });
+
+  it('Retry calls checkConnection() on the secondary server, not connect()', async () => {
+    secondaryIsConnected$.set(false);
+    render(<ConversationContent conversationId="demo/test" serverId="secondary-server" />);
+    const btn = screen.getByRole('button', { name: /retry/i });
+    btn.click();
+    expect(secondaryCheckConnection).toHaveBeenCalled();
+    expect(mockConnect).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Closes #3326

## Problem

When the gptme server is unreachable, the webui silently falls back to demo conversations in the sidebar. The app looks functional — conversations are listed, content renders — but the only indication of the disconnect is a disabled chat input with a small "Connect to gptme to send messages" placeholder. This was easy to miss and caused real confusion: Erik hit it, CI hit it, and the #2943 conversation-create regression went undetected for a month because e2e tests ran entirely on demo data.

`WelcomeView` already shows a clear disconnection alert, but that screen disappears the moment a user clicks any demo conversation. Once inside a conversation, there was nothing showing the user they were offline.

## Fix

Add a **persistent amber banner** at the top of `ConversationContent` (above the message list) that fires whenever:
- The API server is not connected (`api.isConnected$` is false), AND
- The user is **not** intentionally in `?demo=1` mode

The banner:
- Takes up layout space (not floating/overlay) so it's always visible
- Classifies the failure reason — CORS, Chrome Local Network Access, network refusal, timeout — using the same heuristics as `WelcomeView` (via `isLikelyChromeCorsPna`)
- Falls back to "browsing demo data. Connect a server to start a real conversation." for unclassified failures
- Has a **Retry** button that calls `connect()` and shows a spinner while retrying
- Disappears immediately when the connection is established

Intentional `?demo=1` mode is explicitly excluded — the banner only fires for silent fallback-to-demo situations.

## Tests

7 new unit tests in `ConversationContent.test.tsx` covering:
- Hidden when connected
- Visible when disconnected (not demo mode)
- Hidden when disconnected but in intentional demo mode
- CORS failure reason shown with `--cors-origin` guidance
- Network failure reason shown
- Timeout failure reason shown
- Retry button triggers `connect()`

<!-- gptme-id:v1:gai_NlYoPv6cvMWgIaDCvwnzPE2W1wKowJRmAqLuupwGU4l -->