### PR TITLE
fix(webui): omit default dot-workspace so server applies its @log default

### DIFF
--- a/webui/src/utils/__tests__/api.test.ts
+++ b/webui/src/utils/__tests__/api.test.ts
@@ -3,12 +3,19 @@ jest.mock('@/utils/connectionConfig', () => ({
   getApiBaseUrl: jest.fn(() => 'http://127.0.0.1:5700'),
   CLOUD_BASE_URL: 'https://gptme.ai',
 }));
-jest.mock('@/stores/conversations', () => ({}));
+jest.mock('@/stores/conversations', () => ({
+  initConversation: jest.fn(),
+  setMaxTokens: jest.fn(),
+  setTemperature: jest.fn(),
+  setTopP: jest.fn(),
+}));
 jest.mock('@/stores/servers', () => ({
   serverRegistry$: { get: jest.fn(() => ({ servers: [], activeServerId: null })) },
   getActiveServer: jest.fn(),
   getPrimaryClient: jest.fn(),
 }));
+
+import * as conversationsStore from '@/stores/conversations';
 
 import {
   ApiClient,
@@ -750,5 +757,115 @@ describe('getApiErrorPresentation', () => {
       title: 'Authentication failed',
       description: 'Invalid or expired token.',
     });
+  });
+});
+
+describe('createConversationWithPlaceholder workspace defaults', () => {
+  const originalFetch = global.fetch;
+  const originalCrypto = global.crypto;
+
+  beforeEach(() => {
+    Object.defineProperty(global, 'crypto', {
+      value: { ...originalCrypto, randomUUID: jest.fn(() => 'test-client-id') },
+      configurable: true,
+    });
+    (conversationsStore.initConversation as jest.Mock).mockClear();
+    (conversationsStore.setMaxTokens as jest.Mock).mockClear();
+    (conversationsStore.setTemperature as jest.Mock).mockClear();
+    (conversationsStore.setTopP as jest.Mock).mockClear();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    Object.defineProperty(global, 'crypto', { value: originalCrypto, configurable: true });
+    jest.restoreAllMocks();
+  });
+
+  it('omits workspace from server request when workspace is "." (lets server use @log default)', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ status: 'ok', session_id: 'session-1' }),
+    } as Response);
+
+    const client = new ApiClient('http://127.0.0.1:5700');
+    client.setConnected(true);
+
+    await client.createConversationWithPlaceholder('hello', { workspace: '.' });
+
+    const request = (global.fetch as jest.Mock).mock.calls[0][1] as RequestInit;
+    const body = JSON.parse(request.body as string);
+    // workspace: '.' must NOT be forwarded — server's @log default should apply
+    expect(body.config?.chat?.workspace).toBeUndefined();
+  });
+
+  it('omits workspace from server request when workspace is not provided', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ status: 'ok', session_id: 'session-1' }),
+    } as Response);
+
+    const client = new ApiClient('http://127.0.0.1:5700');
+    client.setConnected(true);
+
+    await client.createConversationWithPlaceholder('hello');
+
+    const request = (global.fetch as jest.Mock).mock.calls[0][1] as RequestInit;
+    const body = JSON.parse(request.body as string);
+    expect(body.config?.chat?.workspace).toBeUndefined();
+  });
+
+  it('uses @log as the placeholder workspace when no explicit workspace is given', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ status: 'ok', session_id: 'session-1' }),
+    } as Response);
+
+    const client = new ApiClient('http://127.0.0.1:5700');
+    client.setConnected(true);
+
+    await client.createConversationWithPlaceholder('hello', { workspace: '.' });
+
+    const [, initData] = (conversationsStore.initConversation as jest.Mock).mock.calls[0];
+    expect(initData.workspace).toBe('@log');
+  });
+
+  it('forwards an explicit custom workspace to the server', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ status: 'ok', session_id: 'session-1' }),
+    } as Response);
+
+    const client = new ApiClient('http://127.0.0.1:5700');
+    client.setConnected(true);
+
+    await client.createConversationWithPlaceholder('hello', {
+      workspace: '/workspace/project',
+    });
+
+    const request = (global.fetch as jest.Mock).mock.calls[0][1] as RequestInit;
+    const body = JSON.parse(request.body as string);
+    expect(body.config?.chat?.workspace).toBe('/workspace/project');
+  });
+
+  it('uses the custom workspace in the placeholder too', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ status: 'ok', session_id: 'session-1' }),
+    } as Response);
+
+    const client = new ApiClient('http://127.0.0.1:5700');
+    client.setConnected(true);
+
+    await client.createConversationWithPlaceholder('hello', {
+      workspace: '/home/user/project',
+    });
+
+    const [, initData] = (conversationsStore.initConversation as jest.Mock).mock.calls[0];
+    expect(initData.workspace).toBe('/home/user/project');
   });
 });

--- a/webui/src/utils/api.ts
+++ b/webui/src/utils/api.ts
@@ -60,6 +60,16 @@ export class ApiClientError extends Error {
   }
 }
 
+// Returns undefined for unset / default '.' workspace so the server can apply
+// its own @log (isolated per-conversation) default. Explicit non-default paths
+// (e.g. '/workspace/project') are passed through unchanged.
+function requestWorkspace(workspace?: string): string | undefined {
+  if (!workspace || workspace === '.') {
+    return undefined;
+  }
+  return workspace;
+}
+
 export function getApiErrorPresentation(
   error: unknown,
   options?: {
@@ -1243,7 +1253,7 @@ export class ApiClient {
         log: [message],
         logfile: conversationId,
         branches: {},
-        workspace: options?.workspace || '.',
+        workspace: requestWorkspace(options?.workspace) ?? '@log',
       },
       { needsInitialStep: true, initialStepStream: options?.stream }
     );
@@ -1266,7 +1276,7 @@ export class ApiClient {
         chat: {
           model: options?.model,
           stream: options?.stream,
-          workspace: options?.workspace || '.',
+          workspace: requestWorkspace(options?.workspace),
         },
       });
       try {
@@ -1285,7 +1295,7 @@ export class ApiClient {
         chat: {
           model: options?.model,
           stream: options?.stream,
-          workspace: options?.workspace || '.',
+          workspace: requestWorkspace(options?.workspace),
         },
       });
     }


### PR DESCRIPTION
## Problem

After PR #3319 the server now defaults to an isolated `@log` per-conversation workspace when none is supplied in the request. But the webui was always forwarding `workspace: '.'` — so the server's default was never reached, and new conversations got the server's current working directory as their workspace instead of an isolated one.

This was the remaining open piece from #3320 (question 4 — webui workspace behavior).

## Changes

**`webui/src/utils/api.ts`**
- Add `requestWorkspace()` helper: returns `undefined` for unset/`'.'`, passes explicit paths through unchanged
- In `createConversationWithPlaceholder`, use `requestWorkspace()` instead of `options?.workspace || '.'`
  - When workspace is `'.'` or absent → key omitted from JSON body → server picks `@log` (isolated per-conversation)
  - When workspace is an explicit path (workspace picker, cloud pod `/workspace`) → forwarded as-is

**Backward-compatibility note**: cloud pods that explicitly pass `workspace: '/workspace'` or another absolute path continue to work unchanged. The only behavior that changes is the default `'.'` case, which now lets the server decide.

## Tests

Five new tests in `api.test.ts` covering:
- `'.'` workspace omitted from server request
- No workspace omitted from server request  
- Placeholder stores `@log` label when no workspace chosen
- Explicit custom workspace forwarded to server
- Explicit workspace reflected in placeholder

All 33 tests in the suite pass. Existing server tests (test_server_config_workspace_containment.py, test_server_host_validation.py) all pass unchanged.

Part of #3320.

<!-- gptme-id:v1:gai_sQgaUwA6eqzjB0RQ7Tfb2GrrbXwK6oOhlnerB5Ad912 -->