### PR TITLE
fix(test): kill TestMaxTimeWatchdog xdist flake — prevent untracked threads

### DIFF
--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -2750,6 +2750,7 @@ class TestWorkdir:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.xdist_group("max_time_watchdog")
 class TestMaxTimeWatchdog:
     """Tests for max_time auto-cancel watchdog in subagent()."""
 
@@ -3037,13 +3038,20 @@ class TestMaxTimeWatchdog:
 
         subagent("watchdog-test", "do something", max_time=42.0)
 
-        # Wait for the thread to complete
+        # Wait for the thread to complete — join inside the patch window so the mock
+        # is still active when the thread resolves _create_subagent_thread.
+        # Do NOT remove the subagent from _subagents here: cleanup_subagents_after
+        # (conftest autouse) is the authoritative cleanup path.  Removing it early
+        # lets a still-alive thread escape tracking and race the next test's setup
+        # with lazy-import sys.modules mutations ("dictionary changed size" flake).
         with _subagents_lock:
             sa = next((s for s in _subagents if s.agent_id == "watchdog-test"), None)
         if sa and sa.thread:
             sa.thread.join(timeout=5)
-        with _subagents_lock:
-            _subagents[:] = [s for s in _subagents if s.agent_id != "watchdog-test"]
+            assert not sa.thread.is_alive(), (
+                "run_subagent thread must finish inside the mock window; "
+                "if still alive it will leak past teardown and race the next test's setup"
+            )
 
         assert 42.0 in timers_started, f"Expected 42.0s timer; got {timers_started}"
 
@@ -3088,12 +3096,16 @@ class TestMaxTimeWatchdog:
 
         subagent("no-watchdog-test", "do something")  # max_time=None (default)
 
+        # Same as above: join inside the patch window, but let cleanup_subagents_after
+        # own the _subagents removal to prevent untracked-thread leaks.
         with _subagents_lock:
             sa = next((s for s in _subagents if s.agent_id == "no-watchdog-test"), None)
         if sa and sa.thread:
             sa.thread.join(timeout=5)
-        with _subagents_lock:
-            _subagents[:] = [s for s in _subagents if s.agent_id != "no-watchdog-test"]
+            assert not sa.thread.is_alive(), (
+                "run_subagent thread must finish inside the mock window; "
+                "if still alive it will leak past teardown and race the next test's setup"
+            )
 
         assert len(timers_started) == 0, f"No timer expected; got {timers_started}"
 

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -2750,7 +2750,6 @@ class TestWorkdir:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.xdist_group("max_time_watchdog")
 class TestMaxTimeWatchdog:
     """Tests for max_time auto-cancel watchdog in subagent()."""
 


### PR DESCRIPTION
## Problem

`TestMaxTimeWatchdog::test_subagent_wait_returns_cached_timeout_while_thread_is_still_alive` failed intermittently under pytest-xdist with:

```
ERROR at setup of TestMaxTimeWatchdog.test_subagent_wait_returns_cached_timeout_while_thread_is_still_alive
RuntimeError: dictionary changed size during iteration
```

Fixes #3328.

## Root cause

Two tests in `TestMaxTimeWatchdog` — `test_subagent_launches_watchdog_when_max_time_set` and `test_subagent_no_watchdog_when_max_time_none` — call `subagent()`, which starts a real `run_subagent` background thread. After joining the thread (with a 5s timeout), both tests **manually removed the subagent from `_subagents`**:

```python
with _subagents_lock:
    _subagents[:] = [s for s in _subagents if s.agent_id != "watchdog-test"]
```

This bypassed `cleanup_subagents_after` (the autouse fixture from PR #3257 that interrupts and joins any thread registered in `_subagents`). If the `run_subagent` thread was still alive at teardown time — for example, mid-import of `gptme.logmanager` inside `_read_log()` — it became **untracked** and its lazy imports would race any dict-iterating code in the next test's setup phase, producing the `dictionary changed size during iteration` error.

## Fix

Two changes in `tests/test_subagent_unit.py`:

1. **Remove the premature `_subagents[:] = [...]` slices** from both watchdog-launch tests. `cleanup_subagents_after` (PR #3257) is the authoritative teardown path — let it interrupt+join the thread while the `monkeypatch` mocks are still active.

2. **Add `assert not sa.thread.is_alive()` after the join** so that if the thread doesn't die within 5 s, the test fails with a clear `AssertionError` rather than a later obscure flake in a neighbouring test's setup.

All 9 `TestMaxTimeWatchdog` tests pass locally.

<!-- gptme-id:v1:gai_ekAMZcU6RmdswrgaMfFrPtylG9jetPzFeneHQ1jOOOD -->
