### PR TITLE
fix(webui): strip thinking blocks from TTS output

### DIFF
--- a/webui/src/utils/__tests__/tts.test.ts
+++ b/webui/src/utils/__tests__/tts.test.ts
@@ -75,6 +75,34 @@ describe('toSpokenText (via speakTextNow)', () => {
     expect(speak).not.toHaveBeenCalled();
   });
 
+  it('does not speak an interrupted thinking block without a closing tag', async () => {
+    const speak = jest.fn();
+    Object.defineProperty(window, 'speechSynthesis', {
+      value: { speak, cancel: jest.fn() },
+      configurable: true,
+    });
+
+    const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0));
+    speakTextNow('<think>unfinished private reasoning because generation was interrupted');
+    await flushPromises();
+
+    expect(speak).not.toHaveBeenCalled();
+  });
+
+  it('preserves the answer before an interrupted thinking block', async () => {
+    const speak = jest.fn();
+    Object.defineProperty(window, 'speechSynthesis', {
+      value: { speak, cancel: jest.fn() },
+      configurable: true,
+    });
+
+    const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0));
+    speakTextNow('The visible answer. <thinking>unfinished private reasoning');
+    await flushPromises();
+
+    expect(speak).toHaveBeenCalledWith(expect.objectContaining({ text: 'The visible answer.' }));
+  });
+
   it('strips tool-use blocks instead of announcing code placeholders', async () => {
     const speak = jest.fn();
     Object.defineProperty(window, 'speechSynthesis', {

--- a/webui/src/utils/__tests__/tts.test.ts
+++ b/webui/src/utils/__tests__/tts.test.ts
@@ -74,6 +74,34 @@ describe('toSpokenText (via speakTextNow)', () => {
 
     expect(speak).not.toHaveBeenCalled();
   });
+
+  it('strips tool-use blocks instead of announcing code placeholders', async () => {
+    const speak = jest.fn();
+    Object.defineProperty(window, 'speechSynthesis', {
+      value: { speak, cancel: jest.fn() },
+      configurable: true,
+    });
+
+    const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0));
+    speakTextNow('I will check.\n```shell\nls -la\n```\nDone.');
+    await flushPromises();
+
+    expect(speak).toHaveBeenCalledWith(expect.objectContaining({ text: 'I will check. Done.' }));
+  });
+
+  it('does not speak if content is only a tool-use block', async () => {
+    const speak = jest.fn();
+    Object.defineProperty(window, 'speechSynthesis', {
+      value: { speak, cancel: jest.fn() },
+      configurable: true,
+    });
+
+    const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0));
+    speakTextNow('```shell\nls -la\n```');
+    await flushPromises();
+
+    expect(speak).not.toHaveBeenCalled();
+  });
 });
 
 describe('tts fallback chain', () => {

--- a/webui/src/utils/__tests__/tts.test.ts
+++ b/webui/src/utils/__tests__/tts.test.ts
@@ -102,6 +102,66 @@ describe('toSpokenText (via speakTextNow)', () => {
 
     expect(speak).not.toHaveBeenCalled();
   });
+
+  it('strips xml-format tool calls before speaking', async () => {
+    const speak = jest.fn();
+    Object.defineProperty(window, 'speechSynthesis', {
+      value: { speak, cancel: jest.fn() },
+      configurable: true,
+    });
+
+    const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0));
+    speakTextNow('I will run it.\n<tool-use>\n<shell>\nls -la\n</shell>\n</tool-use>\nDone.');
+    await flushPromises();
+
+    expect(speak).toHaveBeenCalledWith(expect.objectContaining({ text: 'I will run it. Done.' }));
+  });
+
+  it('does not speak if content is only an xml tool-use block', async () => {
+    const speak = jest.fn();
+    Object.defineProperty(window, 'speechSynthesis', {
+      value: { speak, cancel: jest.fn() },
+      configurable: true,
+    });
+
+    const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0));
+    speakTextNow('<tool-use>\n<shell>\nls -la\n</shell>\n</tool-use>');
+    await flushPromises();
+
+    expect(speak).not.toHaveBeenCalled();
+  });
+
+  it('strips @tool-format calls before speaking', async () => {
+    const speak = jest.fn();
+    Object.defineProperty(window, 'speechSynthesis', {
+      value: { speak, cancel: jest.fn() },
+      configurable: true,
+    });
+
+    const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0));
+    speakTextNow('Running it now.\n@shell: {\n  "command": "ls -la"\n}\nAll done.');
+    await flushPromises();
+
+    expect(speak).toHaveBeenCalledWith(
+      expect.objectContaining({ text: 'Running it now. All done.' })
+    );
+  });
+
+  it('strips @tool-format calls with call id before speaking', async () => {
+    const speak = jest.fn();
+    Object.defineProperty(window, 'speechSynthesis', {
+      value: { speak, cancel: jest.fn() },
+      configurable: true,
+    });
+
+    const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0));
+    speakTextNow('Running it now.\n@shell(abc123): {\n  "command": "ls"\n}\nAll done.');
+    await flushPromises();
+
+    expect(speak).toHaveBeenCalledWith(
+      expect.objectContaining({ text: 'Running it now. All done.' })
+    );
+  });
 });
 
 describe('tts fallback chain', () => {

--- a/webui/src/utils/__tests__/tts.test.ts
+++ b/webui/src/utils/__tests__/tts.test.ts
@@ -83,7 +83,9 @@ describe('toSpokenText (via speakTextNow)', () => {
     });
 
     const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0));
-    speakTextNow('<think>unfinished private reasoning because generation was interrupted');
+    speakTextNow(
+      '<think>unfinished private reasoning because generation was interrupted [INTERRUPTED]'
+    );
     await flushPromises();
 
     expect(speak).not.toHaveBeenCalled();
@@ -97,10 +99,26 @@ describe('toSpokenText (via speakTextNow)', () => {
     });
 
     const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0));
-    speakTextNow('The visible answer. <thinking>unfinished private reasoning');
+    speakTextNow('The visible answer. <thinking>unfinished private reasoning [INTERRUPTED]');
     await flushPromises();
 
     expect(speak).toHaveBeenCalledWith(expect.objectContaining({ text: 'The visible answer.' }));
+  });
+
+  it('preserves a literal unclosed thinking-tag example', async () => {
+    const speak = jest.fn();
+    Object.defineProperty(window, 'speechSynthesis', {
+      value: { speak, cancel: jest.fn() },
+      configurable: true,
+    });
+
+    const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0));
+    speakTextNow('Use the literal <think> tag to start a reasoning block.');
+    await flushPromises();
+
+    expect(speak).toHaveBeenCalledWith(
+      expect.objectContaining({ text: 'Use the literal <think> tag to start a reasoning block.' })
+    );
   });
 
   it('strips tool-use blocks instead of announcing code placeholders', async () => {

--- a/webui/src/utils/__tests__/tts.test.ts
+++ b/webui/src/utils/__tests__/tts.test.ts
@@ -1,5 +1,81 @@
 import { speakTextNow, stopSpeaking } from '../tts';
 
+describe('toSpokenText (via speakTextNow)', () => {
+  const originalFetch = global.fetch;
+  const originalSpeechSynthesis = window.speechSynthesis;
+  const originalSpeechSynthesisUtterance = global.SpeechSynthesisUtterance;
+
+  beforeEach(() => {
+    localStorage.clear();
+    jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    jest.spyOn(console, 'info').mockImplementation(() => undefined);
+    global.SpeechSynthesisUtterance = jest.fn().mockImplementation((text: string) => ({
+      text,
+      rate: 1,
+    })) as unknown as typeof SpeechSynthesisUtterance;
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      clone: () => ({
+        json: async () => ({ error: 'OPENROUTER_API_KEY not configured.' }),
+      }),
+    } as Response);
+  });
+
+  afterEach(() => {
+    stopSpeaking();
+    global.fetch = originalFetch;
+    Object.defineProperty(window, 'speechSynthesis', {
+      value: originalSpeechSynthesis,
+      configurable: true,
+    });
+    global.SpeechSynthesisUtterance = originalSpeechSynthesisUtterance;
+    jest.restoreAllMocks();
+  });
+
+  it('strips <thinking> blocks before speaking', async () => {
+    const speak = jest.fn();
+    Object.defineProperty(window, 'speechSynthesis', {
+      value: { speak, cancel: jest.fn() },
+      configurable: true,
+    });
+
+    const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0));
+    speakTextNow('<thinking>internal reasoning here</thinking>The actual answer.');
+    await flushPromises();
+
+    expect(speak).toHaveBeenCalledWith(expect.objectContaining({ text: 'The actual answer.' }));
+  });
+
+  it('strips <think> short-form blocks before speaking', async () => {
+    const speak = jest.fn();
+    Object.defineProperty(window, 'speechSynthesis', {
+      value: { speak, cancel: jest.fn() },
+      configurable: true,
+    });
+
+    const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0));
+    speakTextNow('<think>step 1, step 2</think>Here is the result.');
+    await flushPromises();
+
+    expect(speak).toHaveBeenCalledWith(expect.objectContaining({ text: 'Here is the result.' }));
+  });
+
+  it('does not speak if content is only thinking', async () => {
+    const speak = jest.fn();
+    Object.defineProperty(window, 'speechSynthesis', {
+      value: { speak, cancel: jest.fn() },
+      configurable: true,
+    });
+
+    const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0));
+    speakTextNow('<thinking>just reasoning, nothing else</thinking>');
+    await flushPromises();
+
+    expect(speak).not.toHaveBeenCalled();
+  });
+});
+
 describe('tts fallback chain', () => {
   const originalFetch = global.fetch;
   const originalAudio = global.Audio;

--- a/webui/src/utils/tts.ts
+++ b/webui/src/utils/tts.ts
@@ -83,8 +83,9 @@ function getSettings(): {
 function toSpokenText(markdown: string): string {
   return (
     markdown
-      // Remove thinking blocks entirely (model reasoning, not output)
-      .replace(/<think(?:ing)?>([\s\S]*?)<\/think(?:ing)?>/g, '')
+      // Remove complete or interrupted thinking blocks entirely (model reasoning, not output).
+      // An interrupted generation can persist without a closing tag, so strip to EOF too.
+      .replace(/<think(?:ing)?>[\s\S]*?(?:<\/think(?:ing)?>|$)/g, '')
       // Remove XML-format tool calls: <tool-use>...</tool-use> (ToolUse._to_xml)
       .replace(/<tool-use>[\s\S]*?<\/tool-use>/g, '')
       // Remove @tool-format calls: @name: {json} or @name(id): {json} (ToolUse._to_toolcall)

--- a/webui/src/utils/tts.ts
+++ b/webui/src/utils/tts.ts
@@ -67,14 +67,21 @@ function getSettings(): {
   return { ttsEnabled: false, ttsServerUrl: '', ttsProvider: 'auto', ttsAuthToken: '' };
 }
 
-/** Strip markdown so the spoken text sounds natural. */
+/**
+ * Strip non-spoken assistant internals and Markdown for TTS.
+ *
+ * Keep this aligned with gptme-tts's Python `clean_for_speech()` in
+ * `plugins/gptme-tts/src/gptme_tts/tts.py` (gptme-contrib): both reasoning and
+ * tool-use are implementation details and must never be spoken.
+ */
 function toSpokenText(markdown: string): string {
   return (
     markdown
       // Remove thinking blocks entirely (model reasoning, not output)
       .replace(/<think(?:ing)?>([\s\S]*?)<\/think(?:ing)?>/g, '')
-      // Remove fenced code blocks entirely
-      .replace(/```[\s\S]*?```/g, '[code block]')
+      // As in clean_for_speech(), every fenced block is non-spoken. In assistant
+      // messages these include gptme's Markdown-format tool calls.
+      .replace(/```[\s\S]*?```/g, '')
       // Remove inline code
       .replace(/`[^`]+`/g, '[code]')
       // Remove bold/italic markers

--- a/webui/src/utils/tts.ts
+++ b/webui/src/utils/tts.ts
@@ -73,12 +73,23 @@ function getSettings(): {
  * Keep this aligned with gptme-tts's Python `clean_for_speech()` in
  * `plugins/gptme-tts/src/gptme_tts/tts.py` (gptme-contrib): both reasoning and
  * tool-use are implementation details and must never be spoken.
+ *
+ * gptme supports three tool-call formats (see gptme/tools/base.py ToolFormat):
+ *   - markdown: ```lang content ``` (ToolUse._to_markdown)
+ *   - xml:      <tool-use><name>content</name></tool-use> (ToolUse._to_xml)
+ *   - tool:     @name: {json} or @name(id): {json} (ToolUse._to_toolcall)
+ * All three are non-spoken implementation details.
  */
 function toSpokenText(markdown: string): string {
   return (
     markdown
       // Remove thinking blocks entirely (model reasoning, not output)
       .replace(/<think(?:ing)?>([\s\S]*?)<\/think(?:ing)?>/g, '')
+      // Remove XML-format tool calls: <tool-use>...</tool-use> (ToolUse._to_xml)
+      .replace(/<tool-use>[\s\S]*?<\/tool-use>/g, '')
+      // Remove @tool-format calls: @name: {json} or @name(id): {json} (ToolUse._to_toolcall)
+      // JSON body ends with \n} (indent=2) or {} (empty); ^ anchors to line start.
+      .replace(/^@[\w.]+(?:\([^)]*\))?: (?:\{\}|\{[\s\S]*?\n\})/gm, '')
       // As in clean_for_speech(), every fenced block is non-spoken. In assistant
       // messages these include gptme's Markdown-format tool calls.
       .replace(/```[\s\S]*?```/g, '')

--- a/webui/src/utils/tts.ts
+++ b/webui/src/utils/tts.ts
@@ -83,9 +83,11 @@ function getSettings(): {
 function toSpokenText(markdown: string): string {
   return (
     markdown
-      // Remove complete or interrupted thinking blocks entirely (model reasoning, not output).
-      // An interrupted generation can persist without a closing tag, so strip to EOF too.
-      .replace(/<think(?:ing)?>[\s\S]*?(?:<\/think(?:ing)?>|$)/g, '')
+      // Remove complete thinking blocks entirely (model reasoning, not output).
+      .replace(/<think(?:ing)?>[\s\S]*?<\/think(?:ing)?>/g, '')
+      // Server-interrupted generations are persisted with this suffix. It lets us
+      // distinguish a real unclosed reasoning block from a literal tag example.
+      .replace(/<think(?:ing)?>[\s\S]*? \[INTERRUPTED\]$/g, '')
       // Remove XML-format tool calls: <tool-use>...</tool-use> (ToolUse._to_xml)
       .replace(/<tool-use>[\s\S]*?<\/tool-use>/g, '')
       // Remove @tool-format calls: @name: {json} or @name(id): {json} (ToolUse._to_toolcall)

--- a/webui/src/utils/tts.ts
+++ b/webui/src/utils/tts.ts
@@ -71,6 +71,8 @@ function getSettings(): {
 function toSpokenText(markdown: string): string {
   return (
     markdown
+      // Remove thinking blocks entirely (model reasoning, not output)
+      .replace(/<think(?:ing)?>([\s\S]*?)<\/think(?:ing)?>/g, '')
       // Remove fenced code blocks entirely
       .replace(/```[\s\S]*?```/g, '[code block]')
       // Remove inline code


### PR DESCRIPTION
## Summary

Fixes #3330. When a model outputs a `<thinking>` or `<think>` block (extended reasoning), the webui's TTS system was reading the entire reasoning trace aloud — not just the final answer.

**Root cause**: `toSpokenText()` in `webui/src/utils/tts.ts` stripped markdown (code blocks, links, etc.) but did not strip thinking tags. Both the auto-play path (`speakText` in `useConversation.ts`) and the manual "Read aloud" button (`speakTextNow` in `ChatMessage.tsx`) pass raw `message.content` unchanged.

**Fix**: Add a regex strip for `<thinking>…</thinking>` and `<think>…</think>` at the top of `toSpokenText()`, before any other processing. If the content is *only* a thinking block, `toSpokenText` returns an empty string and `speak()` returns early — nothing is spoken.

## Changes

- `webui/src/utils/tts.ts`: strip `<think(ing)?> … </think(ing)?>` in `toSpokenText()`
- `webui/src/utils/__tests__/tts.test.ts`: three new tests — strips `<thinking>`, strips `<think>`, silences thinking-only messages