### PR TITLE
fix(tui): use terminal-native background for active output

### DIFF
--- a/gptme/tui/app.py
+++ b/gptme/tui/app.py
@@ -424,9 +424,11 @@ class GptmeApp(App):
 
     CSS = """
     Screen {
+        background: ansi_default;
+    }
+    Screen:inline {
         height: auto;
         max-height: 40%;
-        background: ansi_default;
     }
     #live {
         height: auto;

--- a/gptme/tui/app.py
+++ b/gptme/tui/app.py
@@ -423,7 +423,7 @@ class GptmeApp(App):
     TITLE = "gptme"
 
     CSS = """
-    Screen:inline {
+    Screen {
         height: auto;
         max-height: 40%;
         background: ansi_default;

--- a/gptme/tui/app.py
+++ b/gptme/tui/app.py
@@ -561,6 +561,10 @@ class GptmeApp(App):
         experimental_jelly_errors: bool = False,
     ):
         super().__init__()
+        # The TUI intentionally follows the terminal's foreground/background.
+        # Textual's default theme resolves ANSI "default" to its own palette,
+        # which produces a different background from finalized Rich output.
+        self.theme = "ansi-dark"
         self.manager = manager
         self.tool_format: ToolFormat = tool_format
         self.workspace = workspace or manager.workspace

--- a/gptme/tui/app.py
+++ b/gptme/tui/app.py
@@ -438,6 +438,7 @@ class GptmeApp(App):
     }
     #chat {
         padding: 0 1;
+        background: ansi_default;
     }
     .message {
         height: auto;
@@ -503,22 +504,26 @@ class GptmeApp(App):
     #bottom {
         dock: bottom;
         height: auto;
+        background: ansi_default;
     }
     #input {
         margin: 1 1 0 1;
         height: auto;
         max-height: 10;
+        background: ansi_default;
     }
     #input-hint {
         height: 1;
         margin: 0 1;
         color: $text-muted;
+        background: ansi_default;
     }
     #status {
         height: 1;
         margin-top: 1;
         padding: 0 1;
         color: $text-muted;
+        background: ansi_default;
     }
     Screen:inline #status {
         margin-top: 0;
@@ -560,9 +565,7 @@ class GptmeApp(App):
         inline: bool = False,
         experimental_jelly_errors: bool = False,
     ):
-        # Preserve the configured Textual theme's colors while allowing explicit
-        # ANSI defaults to pass through as the terminal's native colors.
-        super().__init__(ansi_color=True)
+        super().__init__()
         self.manager = manager
         self.tool_format: ToolFormat = tool_format
         self.workspace = workspace or manager.workspace

--- a/gptme/tui/app.py
+++ b/gptme/tui/app.py
@@ -23,6 +23,7 @@ from textual import events
 from textual.app import App, ComposeResult
 from textual.binding import Binding
 from textual.containers import Vertical, VerticalScroll
+from textual.filter import ANSIToTruecolor
 from textual.message import Message as TextualMessage
 from textual.screen import ModalScreen
 from textual.widget import Widget
@@ -566,6 +567,13 @@ class GptmeApp(App):
         experimental_jelly_errors: bool = False,
     ):
         super().__init__()
+        # Keep Textual's truecolor theme, but preserve ANSI default through the
+        # final output filter so terminal foreground/background remain native.
+        self._filters = [
+            filter_
+            for filter_ in self._filters
+            if not isinstance(filter_, ANSIToTruecolor)
+        ]
         self.manager = manager
         self.tool_format: ToolFormat = tool_format
         self.workspace = workspace or manager.workspace

--- a/gptme/tui/app.py
+++ b/gptme/tui/app.py
@@ -560,11 +560,9 @@ class GptmeApp(App):
         inline: bool = False,
         experimental_jelly_errors: bool = False,
     ):
-        super().__init__()
-        # The TUI intentionally follows the terminal's foreground/background.
-        # Textual's default theme resolves ANSI "default" to its own palette,
-        # which produces a different background from finalized Rich output.
-        self.theme = "ansi-dark"
+        # Preserve the configured Textual theme's colors while allowing explicit
+        # ANSI defaults to pass through as the terminal's native colors.
+        super().__init__(ansi_color=True)
         self.manager = manager
         self.tool_format: ToolFormat = tool_format
         self.workspace = workspace or manager.workspace

--- a/gptme/tui/app.py
+++ b/gptme/tui/app.py
@@ -426,11 +426,13 @@ class GptmeApp(App):
     Screen:inline {
         height: auto;
         max-height: 40%;
+        background: ansi_default;
     }
     #live {
         height: auto;
         max-height: 8;
         margin: 0 1;
+        background: ansi_default;
     }
     #chat {
         padding: 0 1;

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -42,8 +42,9 @@ async def test_inline_screen_uses_ansi_default_background(tmp_path):
     async with app.run_test() as pilot:
         await pilot.pause()
         expected = Color(0, 0, 0, ansi=-1)
-        assert app.theme == "ansi-dark"
+        assert app.theme == "textual-dark"
         assert app.native_ansi_color
+        assert app.get_css_variables()["primary"] == "#0178D4"
         assert app.screen.styles.background == expected
         assert app.query_one("#live", Static).styles.background == expected
 
@@ -70,8 +71,6 @@ async def test_progress_placeholder_uses_message_background(tmp_path):
         assert body.styles.text_style.italic
         first_segment = next(iter(body.render_line(0)))
         assert first_segment.style is not None
-        assert first_segment.style.color is not None
-        assert first_segment.style.color.is_default
         assert first_segment.style.bgcolor is not None
         assert first_segment.style.bgcolor.is_default
 

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -5,6 +5,7 @@ import pytest
 pytest.importorskip("textual")
 
 from textual.color import Color
+from textual.filter import ANSIToTruecolor
 from textual.widgets import Collapsible, Static
 
 from gptme.logmanager import LogManager
@@ -33,6 +34,16 @@ def test_summarize():
     assert _summarize("```stdout\nfoo\n```").startswith("stdout")
     long = "x" * 200
     assert len(_summarize(long)) < 100
+
+
+@pytest.mark.asyncio
+async def test_ansi_default_survives_output_filter(tmp_path):
+    """Terminal-default colors must reach the driver without RGB conversion."""
+    app = GptmeApp(make_manager(tmp_path), workspace=tmp_path)
+
+    assert not any(
+        isinstance(filter_, ANSIToTruecolor) for filter_ in app.get_line_filters()
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -36,14 +36,14 @@ def test_summarize():
 
 
 @pytest.mark.asyncio
-async def test_inline_screen_uses_ansi_default_background(tmp_path):
-    """Both app modes use the terminal background without sharing inline sizing."""
+async def test_active_surfaces_use_ansi_default_background(tmp_path):
+    """Both app modes use the terminal background without changing the palette."""
     app = GptmeApp(make_manager(tmp_path), workspace=tmp_path, inline=True)
     async with app.run_test() as pilot:
         await pilot.pause()
         expected = Color(0, 0, 0, ansi=-1)
         assert app.theme == "textual-dark"
-        assert app.native_ansi_color
+        assert not app.native_ansi_color
         assert app.get_css_variables()["primary"] == "#0178D4"
         assert app.screen.styles.background == expected
         assert app.query_one("#live", Static).styles.background == expected
@@ -54,6 +54,8 @@ async def test_inline_screen_uses_ansi_default_background(tmp_path):
         assert app.screen.styles.background == expected
         assert app.screen.styles.height is None
         assert app.screen.styles.max_height is None
+        for selector in ("#chat", "#bottom", "#input", "#input-hint", "#status"):
+            assert app.query_one(selector).styles.background == expected
 
 
 @pytest.mark.asyncio

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -5,7 +5,7 @@ import pytest
 pytest.importorskip("textual")
 
 from textual.color import Color
-from textual.widgets import Collapsible
+from textual.widgets import Collapsible, Static
 
 from gptme.logmanager import LogManager
 from gptme.message import Message
@@ -33,6 +33,25 @@ def test_summarize():
     assert _summarize("```stdout\nfoo\n```").startswith("stdout")
     long = "x" * 200
     assert len(_summarize(long)) < 100
+
+
+@pytest.mark.asyncio
+async def test_live_widget_uses_ansi_default_background(tmp_path):
+    """#live must use ansi_default background so inline mode matches terminal native bg.
+
+    In inline mode, finalized messages go to the terminal scrollback via _print_above()
+    which has no explicit background (terminal native). The #live streaming area must
+    match; otherwise a gray Textual theme background appears during generation but
+    vanishes when the message finalizes — the bug Erik reported on #3321.
+    """
+    app = GptmeApp(make_manager(tmp_path), workspace=tmp_path, inline=True)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        live = app.query_one("#live", Static)
+        # ansi_default is Color(0, 0, 0, ansi=-1) — not the theme's $background
+        assert live.styles.background == Color(0, 0, 0, ansi=-1), (
+            f"#live has themed background {live.styles.background!r}, expected ansi_default"
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -37,13 +37,20 @@ def test_summarize():
 
 @pytest.mark.asyncio
 async def test_inline_screen_uses_ansi_default_background(tmp_path):
-    """The inline screen and live preview must use the terminal background."""
+    """Both app modes use the terminal background without sharing inline sizing."""
     app = GptmeApp(make_manager(tmp_path), workspace=tmp_path, inline=True)
     async with app.run_test() as pilot:
         await pilot.pause()
         expected = Color(0, 0, 0, ansi=-1)
         assert app.screen.styles.background == expected
         assert app.query_one("#live", Static).styles.background == expected
+
+    app = GptmeApp(make_manager(tmp_path), workspace=tmp_path)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        assert app.screen.styles.background == expected
+        assert app.screen.styles.height is None
+        assert app.screen.styles.max_height is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -42,6 +42,8 @@ async def test_inline_screen_uses_ansi_default_background(tmp_path):
     async with app.run_test() as pilot:
         await pilot.pause()
         expected = Color(0, 0, 0, ansi=-1)
+        assert app.theme == "ansi-dark"
+        assert app.native_ansi_color
         assert app.screen.styles.background == expected
         assert app.query_one("#live", Static).styles.background == expected
 
@@ -65,11 +67,13 @@ async def test_progress_placeholder_uses_message_background(tmp_path):
         assert placeholder is not None
         body = placeholder._body
         assert body.styles.background == Color(0, 0, 0, 0)
-        assert body.styles.color.a == pytest.approx(0.6)
         assert body.styles.text_style.italic
         first_segment = next(iter(body.render_line(0)))
         assert first_segment.style is not None
-        assert first_segment.style.bgcolor == body.background_colors[1].rich_color
+        assert first_segment.style.color is not None
+        assert first_segment.style.color.is_default
+        assert first_segment.style.bgcolor is not None
+        assert first_segment.style.bgcolor.is_default
 
 
 @pytest.mark.asyncio

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -36,22 +36,14 @@ def test_summarize():
 
 
 @pytest.mark.asyncio
-async def test_live_widget_uses_ansi_default_background(tmp_path):
-    """#live must use ansi_default background so inline mode matches terminal native bg.
-
-    In inline mode, finalized messages go to the terminal scrollback via _print_above()
-    which has no explicit background (terminal native). The #live streaming area must
-    match; otherwise a gray Textual theme background appears during generation but
-    vanishes when the message finalizes — the bug Erik reported on #3321.
-    """
+async def test_inline_screen_uses_ansi_default_background(tmp_path):
+    """The inline screen and live preview must use the terminal background."""
     app = GptmeApp(make_manager(tmp_path), workspace=tmp_path, inline=True)
     async with app.run_test() as pilot:
         await pilot.pause()
-        live = app.query_one("#live", Static)
-        # ansi_default is Color(0, 0, 0, ansi=-1) — not the theme's $background
-        assert live.styles.background == Color(0, 0, 0, ansi=-1), (
-            f"#live has themed background {live.styles.background!r}, expected ansi_default"
-        )
+        expected = Color(0, 0, 0, ansi=-1)
+        assert app.screen.styles.background == expected
+        assert app.query_one("#live", Static).styles.background == expected
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

During generation and tool execution, the active TUI surface could use Textual's themed background (gray in the reported terminal) while finalized output used the terminal-native background. The mismatch affected both display paths:

- regular mode: placeholder/chat surface
- `--inline` mode: `#live` preview area

This caused a visible gray background during "Generating…", "Running tool…", and streamed output that disappeared after finalization.

## Root cause

The app-owned `Screen` and `#live` surfaces inherited Textual's themed background. Merely setting their CSS backgrounds to `ansi_default` was insufficient: Textual normally converts ANSI colors through a truecolor terminal-theme palette before emitting the frame. Finalized output is printed through Rich without an explicit background and therefore kept the real terminal background.

## Fix

- Enable Textual's native ANSI output while retaining the existing `textual-dark` theme and its foreground/accent palette.
- Set `background: ansi_default` on the app `Screen` and `#live` surfaces.
- Keep the sizing rules scoped to `Screen:inline`, so regular mode remains full-screen.

This covers both regular and `--inline` active-output paths without replacing the TUI's theme colors.

## Test

The TUI regression tests assert:

- native ANSI output is enabled while the configured theme and primary color remain unchanged;
- `Screen` and `#live` compute to ANSI default background;
- regular mode does not inherit inline sizing;
- the rendered progress placeholder segment has the terminal-default background.

`uv run --extra tui pytest tests/test_tui.py -q` — 23 passed.

Refs #3321 (follow-up for the remaining gray-background report after that PR merged).
