### PR TITLE
feat(tui): render thinking blocks as collapsibles, show Thinking… during generation

### DIFF
--- a/gptme/chat.py
+++ b/gptme/chat.py
@@ -579,6 +579,7 @@ def step(
     model: str | None = None,
     output_schema: type | None = None,
     on_token: Callable[[str], None] | None = None,
+    on_thinking: Callable[[bool], None] | None = None,
     logdir: Path | None = None,
 ) -> Generator[Message, None, None]:
     """Runs a single pass of the chat - generates response and executes tools."""
@@ -613,6 +614,7 @@ def step(
                 workspace,
                 output_schema,
                 on_token=on_token,
+                on_thinking=on_thinking,
             )
             if get_config().get_env_bool("GPTME_COSTS"):
                 log_costs(msgs + [msg_response])

--- a/gptme/llm/__init__.py
+++ b/gptme/llm/__init__.py
@@ -283,6 +283,7 @@ def reply(
     workspace: Path | None = None,
     output_schema: type | None = None,
     on_token: Callable[[str], None] | None = None,
+    on_thinking: Callable[[bool], None] | None = None,
     max_tokens: int | None = None,
     temperature: float | None = None,
     top_p: float | None = None,
@@ -330,6 +331,7 @@ def reply(
             agent_name=agent_name,
             output_schema=output_schema,
             on_token=on_token,
+            on_thinking=on_thinking,
             max_tokens=max_tokens,
             temperature=temperature,
             top_p=top_p,
@@ -692,6 +694,7 @@ def _reply_stream(
     agent_name: str | None = None,
     output_schema: type | None = None,
     on_token: Callable[[str], None] | None = None,
+    on_thinking: Callable[[bool], None] | None = None,
     max_tokens: int | None = None,
     temperature: float | None = None,
     top_p: float | None = None,
@@ -801,6 +804,8 @@ def _reply_stream(
                     if display_enabled:
                         rprint(f"[dim]{last_line}[/dim]", end="")
                     are_thinking = True
+                    if on_thinking is not None:
+                        on_thinking(True)
                 # Check for closing tag
                 elif last_line == "</think>" or last_line == "</thinking>":
                     # Chars were buffered in think_display_buffer, not printed;
@@ -809,6 +814,8 @@ def _reply_stream(
                     if display_enabled:
                         rprint(f"[dim]{last_line}[/dim]", end="")
                     are_thinking = False
+                    if on_thinking is not None:
+                        on_thinking(False)
                     in_think_sig = False
                     just_closed_thinking = True
                 # Suppress Anthropic think-sig comment from display.

--- a/gptme/tui/app.py
+++ b/gptme/tui/app.py
@@ -11,6 +11,7 @@ import contextvars
 import io
 import logging
 import os.path
+import re
 import sys
 import threading
 from pathlib import Path
@@ -64,6 +65,32 @@ def _summarize(content: str, maxlen: int = 80) -> str:
     return f"{first} ({n} line{'s' if n != 1 else ''})"
 
 
+_THINK_RE = re.compile(r"<think(?:ing)?>(.*?)</think(?:ing)?>", re.DOTALL)
+_THINK_SIG_RE = re.compile(r"<!--\s*think-sig:.*?-->\s*", re.DOTALL)
+
+
+def _split_thinking(content: str) -> list[tuple[bool, str]]:
+    """Split message content into (is_thinking, text) segments.
+
+    Detects <think>/<thinking> blocks and separates them from normal content
+    so the TUI can render them in collapsible sections.
+    """
+    segments: list[tuple[bool, str]] = []
+    last_end = 0
+    for m in _THINK_RE.finditer(content):
+        before = content[last_end : m.start()]
+        if before.strip():
+            segments.append((False, before))
+        inner = _THINK_SIG_RE.sub("", m.group(1)).strip()
+        if inner:
+            segments.append((True, inner))
+        last_end = m.end()
+    tail = content[last_end:]
+    if tail.strip():
+        segments.append((False, tail))
+    return segments
+
+
 class UserMessage(Vertical):
     """A user message, rendered with a distinct border."""
 
@@ -86,7 +113,20 @@ class AssistantMessage(Vertical):
 
     def compose(self) -> ComposeResult:
         yield Static(Text("Assistant"), classes="role")
-        yield Markdown(self.content)
+        segments = _split_thinking(self.content)
+        if not any(is_think for is_think, _ in segments):
+            yield Markdown(self.content)
+        else:
+            for is_think, text in segments:
+                if is_think:
+                    yield Collapsible(
+                        Markdown(text),
+                        title="Thinking",
+                        collapsed=True,
+                        classes="thinking-block",
+                    )
+                elif text.strip():
+                    yield Markdown(text)
 
 
 class SystemMessage(Vertical):
@@ -119,6 +159,12 @@ class StreamingMessage(Vertical):
     def append_token(self, token: str) -> None:
         self._buffer += token
         self._body.update(Text(self._buffer))
+
+    def set_thinking(self, is_thinking: bool) -> None:
+        """Update the placeholder when the model transitions in/out of thinking."""
+        if not self._buffer:
+            label = "Thinking…" if is_thinking else "Generating…"
+            self._body.update(Text(label))
 
 
 class ToolPlaceholder(Vertical):
@@ -497,6 +543,19 @@ class GptmeApp(App):
         border: none;
         padding: 0;
         background: transparent;
+    }
+    .thinking-block {
+        border: none;
+        padding: 0;
+        background: transparent;
+        color: $text-muted;
+    }
+    .thinking-block CollapsibleTitle {
+        color: $text-muted;
+        text-style: italic;
+    }
+    .thinking-block Markdown {
+        color: $text-muted;
     }
     /* compact markdown: the widget defaults add blank lines around
        codeblocks (MarkdownFence margin 1 0) and after the last block */
@@ -1017,6 +1076,7 @@ class GptmeApp(App):
                         workspace=self.workspace,
                         logdir=manager.logdir,
                         on_token=self._on_token,
+                        on_thinking=self._on_thinking,
                     ):
                         # each yield may follow a tool execution that reset
                         # the tty (e.g. ipython init) — reassert raw mode
@@ -1071,6 +1131,18 @@ class GptmeApp(App):
         if self._interrupt_event.is_set():
             raise KeyboardInterrupt
         self.call_from_thread(self._on_stream_token, token)
+
+    def _on_thinking(self, is_thinking: bool) -> None:
+        # called from the worker thread when thinking state changes
+        self.call_from_thread(self._set_stream_thinking, is_thinking)
+
+    def _set_stream_thinking(self, is_thinking: bool) -> None:
+        if self._stream_widget is not None:
+            self._stream_widget.set_thinking(is_thinking)
+        if self.inline:
+            label = "Thinking…" if is_thinking else "Generating…"
+            with contextlib.suppress(Exception):
+                self.query_one("#live", Static).update(Text(label, style="italic"))
 
     def _begin_stream(self) -> None:
         # A new model step starts only after the previous tool batch finished.

--- a/gptme/tui/app.py
+++ b/gptme/tui/app.py
@@ -1139,7 +1139,7 @@ class GptmeApp(App):
     def _set_stream_thinking(self, is_thinking: bool) -> None:
         if self._stream_widget is not None:
             self._stream_widget.set_thinking(is_thinking)
-        if self.inline:
+        if self.inline and not self._stream_text:
             label = "Thinking…" if is_thinking else "Generating…"
             with contextlib.suppress(Exception):
                 self.query_one("#live", Static).update(Text(label, style="italic"))

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -15,11 +15,13 @@ from gptme.tui.app import (
     ChatInput,
     GptmeApp,
     InfoMessage,
+    StreamingMessage,
     SystemMessage,
     ToolPlaceholder,
     UserMessage,
     _append_pt_history,
     _load_pt_history,
+    _split_thinking,
     _summarize,
 )
 
@@ -606,3 +608,105 @@ async def test_tab_cycles_and_overlay_updates(tmp_path):
             await pilot.pause()
             assert inp._tab_index != first_idx or inp._tab_index == 0
             assert overlay.display
+
+
+# ─────────────────────────────────────────────────────────
+# Thinking block display
+# ─────────────────────────────────────────────────────────
+
+
+def test_split_thinking_no_blocks():
+    """Content with no thinking tags is returned as a single non-thinking segment."""
+    result = _split_thinking("Hello, world!")
+    assert result == [(False, "Hello, world!")]
+
+
+def test_split_thinking_think_tag():
+    """<think> blocks are extracted as thinking segments."""
+    content = "<think>\nstep 1\n</think>\nAnswer: 42"
+    result = _split_thinking(content)
+    assert any(is_think and "step 1" in text for is_think, text in result)
+    assert any(not is_think and "Answer: 42" in text for is_think, text in result)
+
+
+def test_split_thinking_thinking_tag():
+    """<thinking> blocks (the long-form tag) are also extracted."""
+    content = "<thinking>\nplan here\n</thinking>\nresult"
+    result = _split_thinking(content)
+    assert any(is_think and "plan here" in text for is_think, text in result)
+    assert any(not is_think and "result" in text for is_think, text in result)
+
+
+def test_split_thinking_strips_think_sig():
+    """Anthropic think-sig HTML comments are stripped from thinking content."""
+    content = "<think>\n<!-- think-sig: abc123 -->\nreal thoughts\n</think>\nok"
+    result = _split_thinking(content)
+    thinking_texts = [text for is_think, text in result if is_think]
+    assert thinking_texts
+    assert all("think-sig" not in t for t in thinking_texts)
+    assert any("real thoughts" in t for t in thinking_texts)
+
+
+def test_split_thinking_only_block():
+    """A message that is entirely thinking returns only the thinking segment."""
+    content = "<think>\ninner\n</think>"
+    result = _split_thinking(content)
+    assert len(result) == 1
+    assert result[0][0] is True
+    assert "inner" in result[0][1]
+
+
+@pytest.mark.asyncio
+async def test_assistant_message_renders_thinking_as_collapsible(tmp_path):
+    """AssistantMessage with <think> block renders a Collapsible for the thinking."""
+    content = "<think>\nstep-by-step reasoning\n</think>\nFinal answer."
+    app = GptmeApp(make_manager(tmp_path), workspace=tmp_path)
+    async with app.run_test() as pilot:
+        msg_widget = AssistantMessage(content)
+        await app.mount(msg_widget)
+        await pilot.pause()
+        collapsibles = msg_widget.query(Collapsible)
+        assert len(collapsibles) > 0, "Expected at least one Collapsible for thinking"
+        thinking_collapsible = collapsibles.first()
+        assert thinking_collapsible.collapsed, (
+            "Thinking block should be collapsed by default"
+        )
+
+
+@pytest.mark.asyncio
+async def test_assistant_message_no_collapsible_without_thinking(tmp_path):
+    """AssistantMessage without thinking tags renders no Collapsible."""
+    content = "Plain assistant reply."
+    app = GptmeApp(make_manager(tmp_path), workspace=tmp_path)
+    async with app.run_test() as pilot:
+        msg_widget = AssistantMessage(content)
+        await app.mount(msg_widget)
+        await pilot.pause()
+        collapsibles = msg_widget.query(Collapsible)
+        assert len(collapsibles) == 0, "No Collapsible expected for plain content"
+
+
+def test_streaming_message_set_thinking_updates_placeholder():
+    """set_thinking calls update with 'Thinking…' / 'Generating…' while buffer is empty."""
+    from unittest.mock import patch
+
+    msg = StreamingMessage()
+    with patch.object(msg._body, "update") as mock_update:
+        msg.set_thinking(True)
+        msg.set_thinking(False)
+    assert mock_update.call_count == 2
+    thinking_label = mock_update.call_args_list[0][0][0]
+    generating_label = mock_update.call_args_list[1][0][0]
+    assert "Thinking" in str(thinking_label)
+    assert "Generating" in str(generating_label)
+
+
+def test_streaming_message_set_thinking_ignored_after_tokens():
+    """set_thinking is a no-op once real tokens have arrived."""
+    from unittest.mock import patch
+
+    msg = StreamingMessage()
+    msg._buffer = "partial response"
+    with patch.object(msg._body, "update") as mock_update:
+        msg.set_thinking(True)
+    mock_update.assert_not_called()

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -686,6 +686,24 @@ async def test_assistant_message_no_collapsible_without_thinking(tmp_path):
         assert len(collapsibles) == 0, "No Collapsible expected for plain content"
 
 
+@pytest.mark.asyncio
+async def test_inline_thinking_transition_preserves_streamed_content(tmp_path):
+    """A later thinking transition must not replace inline response text."""
+    app = GptmeApp(make_manager(tmp_path), workspace=tmp_path, inline=True)
+    async with app.run_test() as pilot:
+        app._begin_stream()
+        app._on_stream_token("partial response")
+        await pilot.pause()
+
+        live = app.query_one("#live")
+        assert "partial response" in str(live.render())
+
+        app._set_stream_thinking(True)
+        await pilot.pause()
+        assert "partial response" in str(live.render())
+        assert "Thinking" not in str(live.render())
+
+
 def test_streaming_message_set_thinking_updates_placeholder():
     """set_thinking calls update with 'Thinking…' / 'Generating…' while buffer is empty."""
     from unittest.mock import patch


### PR DESCRIPTION
## Problem

When a reasoning model uses `<think>`/`<thinking>` blocks the TUI gave no signal that reasoning was happening (the stream just appeared frozen at "Generating…"), and finalized messages rendered the raw `<think>...</think>` tags as plain markdown — unreadable and unstructured.

Closes part of #3311 (the thinking display / toggle item).

## Changes

### Finalized assistant messages
- `_split_thinking()` parses `<think>`/`<thinking>` blocks out of message content, stripping Anthropic `think-sig` HTML comments.
- `AssistantMessage.compose()` renders each thinking block as a collapsed `Collapsible` (title: "Thinking") with muted italic styling so it is visually distinct from the main reply. Users can expand/collapse it on demand.
- Messages with no thinking blocks are rendered as before (single `Markdown` widget).

### Streaming indicator
- `StreamingMessage.set_thinking(is_thinking)` updates the progress placeholder between "Thinking…" and "Generating…" while no tokens have arrived yet.
- New `on_thinking: Callable[[bool], None]` parameter added to `_reply_stream()`, `reply()`, and `step()` — fires whenever `are_thinking` transitions.
- `GptmeApp._on_thinking()` routes the callback to both the stream widget (regular mode) and the `#live` area (inline mode).

### CSS
- `.thinking-block` Collapsible: `color: $text-muted`, `CollapsibleTitle` italic — distinguishes reasoning from the main reply without visual noise.

## Tests

9 new tests in `tests/test_tui.py`:
- `_split_thinking` variants: no blocks, `<think>`, `<thinking>`, think-sig strip, block-only content
- `AssistantMessage` renders collapsible for thinking, no collapsible without thinking
- `StreamingMessage.set_thinking` updates placeholder / is a no-op when buffer has content

`uv run pytest tests/test_tui.py -q` — 37 passed.

## What's still deferred
- Alt+Enter reliability (terminal-emulator-specific)

<!-- gptme-id:v1:gai_Y6IeJ0U1t771h2maiIu7GMlfI3JnvikeEoFs2pPJJfd -->