### PR TITLE
fix(gh): keep the ref intact when turning a blob URL into a raw URL

### DIFF
--- a/gptme/util/gh.py
+++ b/gptme/util/gh.py
@@ -292,12 +292,17 @@ def transform_github_url(url: str) -> str:
     Transform GitHub blob URLs to raw URLs to get file content without UI.
 
     Transforms:
-    https://github.com/{owner}/{repo}/blob/{branch}/{path}
+    https://github.com/{owner}/{repo}/blob/{ref}/{path}
     to:
-    https://github.com/{owner}/{repo}/raw/refs/heads/{branch}/{path}
+    https://github.com/{owner}/{repo}/raw/{ref}/{path}
+
+    ``ref`` may be a branch, a tag, or a commit SHA. The raw endpoint resolves
+    all three, so the ref is kept as-is; forcing ``refs/heads/`` in front of it
+    only works for branches and 404s on tags and SHAs (GitHub permalinks are
+    SHA-based, so those are common).
     """
     if "/blob/" in url and "github.com" in url:
-        return url.replace("/blob/", "/raw/refs/heads/")
+        return url.replace("/blob/", "/raw/")
     return url
 
 

--- a/tests/test_util_gh.py
+++ b/tests/test_util_gh.py
@@ -23,6 +23,7 @@ from gptme.util.gh import (
     parse_github_url,
     search_github_issues,
     search_github_prs,
+    transform_github_url,
 )
 
 
@@ -54,6 +55,44 @@ def test_parse_github_url_invalid():
     """Test parsing non-GitHub URLs."""
     assert parse_github_url("https://example.com") is None
     assert parse_github_url("https://github.com/owner") is None
+
+
+# --- Tests for transform_github_url ---
+
+
+def test_transform_github_url_branch():
+    assert (
+        transform_github_url("https://github.com/o/r/blob/main/src/app.py")
+        == "https://github.com/o/r/raw/main/src/app.py"
+    )
+
+
+def test_transform_github_url_keeps_tags_and_shas_intact():
+    """A tag or commit SHA must be left as the ref.
+
+    Prefixing ``refs/heads/`` only resolves for branches; on a tag or a SHA
+    the raw endpoint 404s. GitHub permalinks are SHA-based, so this is the
+    common case.
+    """
+    assert (
+        transform_github_url("https://github.com/o/r/blob/v2.31.0/README.md")
+        == "https://github.com/o/r/raw/v2.31.0/README.md"
+    )
+    sha = "a" * 40
+    assert (
+        transform_github_url(f"https://github.com/o/r/blob/{sha}/f.txt")
+        == f"https://github.com/o/r/raw/{sha}/f.txt"
+    )
+
+
+def test_transform_github_url_leaves_other_urls_unchanged():
+    assert (
+        transform_github_url("https://github.com/o/r/pull/42")
+        == "https://github.com/o/r/pull/42"
+    )
+    assert transform_github_url("https://example.com/x/blob/y") == (
+        "https://example.com/x/blob/y"
+    )
 
 
 # --- Tests for parse_github_ref ---


### PR DESCRIPTION
`transform_github_url` turns a `/blob/<ref>/` URL into `/raw/refs/heads/<ref>/`, which only resolves when `<ref>` is a branch.

## Problem

```python
return url.replace("/blob/", "/raw/refs/heads/")
```

`refs/heads/<ref>` names a branch. On a **tag** or a **commit SHA** the raw endpoint 404s, so fetching a file from those URLs returns nothing. GitHub permalinks (the `y` shortcut) are SHA-based, so this is the common case, not an edge one. It is reached by `browser.py` and `context.py` when they fetch GitHub file content.

Verified against github.com (same repo and path, following redirects):

| ref | `/raw/refs/heads/<ref>/` (current) | `/raw/<ref>/` (fix) |
|---|---|---|
| commit SHA | 404 | 200 |
| tag `v2.31.0` | 404 | 200 |
| branch `main` | 200 | 200 |

## Fix

The raw endpoint resolves branches, tags and SHAs directly, so keep the ref as-is: `/blob/` -> `/raw/`. Branches keep working; tags and SHAs start working.

## Tests

`transform_github_url` had no test. Added cases for a branch, a tag, a SHA, and non-blob / non-GitHub URLs. I confirmed the tag and SHA cases fail against the current code and pass with the fix; `ruff` is clean. (One unrelated network test, `test_get_github_pr_content_with_unresolved`, fails on a clean checkout in my environment too.)