### PR TITLE
test(tui): guard against italic text-style regression (#3340)

### DIFF
--- a/tests/test_tui_visual.py
+++ b/tests/test_tui_visual.py
@@ -95,6 +95,35 @@ def _check_no_gray_rects(svg: str, label: str) -> None:
     )
 
 
+def _italic_cell_classes(svg: str) -> list[str]:
+    """Return terminal cell CSS class names that apply italic font-style.
+
+    Textual encodes per-cell styling as ``.terminal-HASH-rN { fill: #color }``
+    rules in the SVG ``<style>`` block.  Italic text adds ``font-style: italic``
+    to those rules.  The ``@font-face`` declarations also contain ``font-style``
+    descriptors (``normal`` / ``bold``) but never ``italic``, so a match here
+    always indicates actual italic content styling.
+    """
+    style_match = re.search(r"<style>(.*?)</style>", svg, re.DOTALL)
+    if not style_match:
+        return []
+    return re.findall(
+        r"(\.terminal-[^{]+)\{[^}]*font-style:\s*italic[^}]*\}",
+        style_match.group(1),
+    )
+
+
+def _check_no_italic_text(svg: str, label: str) -> None:
+    """Fail if any terminal cell class applies italic font-style (regression #3340)."""
+    italic_classes = _italic_cell_classes(svg)
+    assert not italic_classes, (
+        f"{label}: italic font-style detected on terminal cell class(es) in SVG: "
+        f"{italic_classes!r}. This may be a regression of the italic "
+        "CollapsibleTitle bug (see gptme#3340). Check that 'text-style: italic' "
+        "is not applied to content-area elements in app.tcss / GptmeApp CSS."
+    )
+
+
 def _snapshot_check(name: str, svg: str, *, update: bool) -> None:
     path = SNAPSHOT_DIR / f"{name}.svg"
     normalized = _normalize_svg(svg)
@@ -142,6 +171,7 @@ async def test_idle_state_no_gray_background(tmp_path):
         await pilot.pause()
         svg = app.export_screenshot()
     _check_no_gray_rects(svg, "idle state")
+    _check_no_italic_text(svg, "idle state")
 
 
 @pytest.mark.asyncio
@@ -154,6 +184,7 @@ async def test_stream_state_no_gray_background(tmp_path):
         await pilot.pause()
         svg = app.export_screenshot()
     _check_no_gray_rects(svg, "streaming state")
+    _check_no_italic_text(svg, "streaming state")
 
 
 @pytest.mark.asyncio
@@ -164,6 +195,7 @@ async def test_inline_mode_no_gray_background(tmp_path):
         await pilot.pause()
         svg = app.export_screenshot()
     _check_no_gray_rects(svg, "inline mode")
+    _check_no_italic_text(svg, "inline mode")
 
 
 @pytest.mark.asyncio

--- a/tests/test_tui_visual.py
+++ b/tests/test_tui_visual.py
@@ -19,6 +19,7 @@ import pytest
 pytest.importorskip("textual")
 
 from gptme.logmanager import LogManager
+from gptme.message import Message
 from gptme.tui.app import GptmeApp
 
 SNAPSHOT_DIR = Path(__file__).parent / "snapshots"
@@ -196,6 +197,27 @@ async def test_inline_mode_no_gray_background(tmp_path):
         svg = app.export_screenshot()
     _check_no_gray_rects(svg, "inline mode")
     _check_no_italic_text(svg, "inline mode")
+
+
+@pytest.mark.asyncio
+async def test_thinking_title_no_italic_text(tmp_path):
+    """Thinking-block title must not render italic text (regression #3340)."""
+    manager = LogManager(
+        [
+            Message(
+                "assistant",
+                "<think>step-by-step reasoning</think>\n\nFinal answer.",
+            )
+        ],
+        logdir=tmp_path / "conv",
+        lock=False,
+    )
+    app = GptmeApp(manager, workspace=tmp_path)
+    async with app.run_test(size=TERM_SIZE) as pilot:
+        await pilot.pause()
+        svg = app.export_screenshot()
+    assert "Thinking" in svg
+    _check_no_italic_text(svg, "thinking-block title")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Adds `_italic_cell_classes()` helper that extracts terminal cell CSS class names from the SVG `<style>` block that carry `font-style: italic`
- Adds `_check_no_italic_text()` that fails if any such class is found
- Applies both checks to the three existing `no_gray_background` tests (idle, stream, inline) — no extra TUI renders needed

## Background

This is the follow-up requested in gptme/gptme#3339's review thread after #3340 landed. The `text-style: italic` on `.thinking-block CollapsibleTitle` was the specific bug fixed by #3340; these guards catch any future re-introduction of italic on content-area elements in the base UI scenarios.

**How detection works**: Textual encodes per-cell text styling as `.terminal-HASH-rN { fill: #color }` rules in the SVG `<style>` block. Italic adds `font-style: italic` to those rules. The `@font-face` declarations also contain `font-style` descriptors (`normal` / `bold`) but never `italic`, so a match is unambiguous.

**Scope**: The three test scenarios (idle, stream, inline) don't exercise the thinking-block `CollapsibleTitle` code path (which would require a message with `<thinking>` content to be rendered). A follow-up test that renders a thinking block would cover that exact path — left for a future PR since it requires more test scaffolding.

## Test plan

- [x] `test_idle_state_no_gray_background` — passes (adds `_check_no_italic_text`)
- [x] `test_stream_state_no_gray_background` — passes
- [x] `test_inline_mode_no_gray_background` — passes
- [x] Pre-commit hooks clean