### PR TITLE
fix(tui): prevent crash when GitHub URL is pasted in TUI

### DIFF
--- a/gptme/util/context.py
+++ b/gptme/util/context.py
@@ -38,8 +38,20 @@ def _is_interactive_mode() -> bool:
     """Check if we're in interactive CLI mode.
 
     Returns True if the cli_confirm hook is registered, indicating
-    interactive mode with confirmation enabled.
+    interactive mode with confirmation enabled. Returns False if called
+    from inside a running asyncio event loop (e.g. the Textual TUI),
+    because prompt_toolkit's sync prompts crash in that context.
     """
+    import asyncio
+
+    try:
+        asyncio.get_running_loop()
+        # Inside a running event loop (e.g. Textual TUI); prompt_toolkit
+        # sync Application.run() is not safe here.
+        return False
+    except RuntimeError:
+        pass  # No running loop — safe for interactive prompts
+
     try:
         from ..hooks import HookType, get_hooks
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -507,3 +507,27 @@ def test_is_interactive_mode():
     # (This test runs outside the normal CLI context)
     result = _is_interactive_mode()
     assert isinstance(result, bool)
+
+
+def test_is_interactive_mode_false_inside_event_loop():
+    """_is_interactive_mode() must return False inside a running asyncio loop.
+
+    This is the root cause of the TUI crash: the TUI's Textual event loop is
+    already running when include_paths() is called, so prompt_toolkit's sync
+    Application.run() would crash with
+    'RuntimeWarning: coroutine Application.run_async was never awaited'.
+    Returning False makes include_paths() skip the interactive URL-confirm
+    prompt and fetch URLs automatically instead.
+    """
+    import asyncio
+
+    from gptme.util.context import _is_interactive_mode
+
+    async def _check():
+        return _is_interactive_mode()
+
+    result = asyncio.run(_check())
+    assert result is False, (
+        "_is_interactive_mode() must return False inside a running event loop "
+        "to avoid crashing the Textual TUI"
+    )


### PR DESCRIPTION
## Root cause

When a user pastes a GitHub URL (e.g. `https://github.com/gptme/gptme/issues/3343`) into the TUI and submits it, the app crashed with:

```
<sys>:0: RuntimeWarning: coroutine 'Application.run_async' was never awaited
```

The bug path:
1. CLI starts with `interactive=True` → `cli_confirm` hook is registered
2. TUI mounts, registers `tui_confirm` at priority 100 to override `cli_confirm` for tool confirmations
3. User submits a GitHub URL → `_submit()` → `include_paths()` → `_is_interactive_mode()` checks for `cli_confirm` hook → **still registered**, returns `True`
4. `_confirm_urls()` calls `prompt_alert()` → `PromptSession.prompt()` → tries to run a prompt_toolkit `Application` inside Textual's **already-running** asyncio event loop → crash

## Fix

`_is_interactive_mode()` now checks `asyncio.get_running_loop()` first. If a loop is running (Textual TUI context), it returns `False` immediately — skipping the prompt_toolkit confirmation dialog that would crash. `include_paths()` then falls through to non-interactive mode and fetches the URL automatically (which is the right UX: the user explicitly submitted it).

## Changes

- `gptme/util/context.py`: add asyncio event loop guard at top of `_is_interactive_mode()`
- `tests/test_context.py`: add regression test verifying the function returns `False` inside `asyncio.run()`

Fixes #3345