### PR TITLE
fix(tui): update tool format on /model switch, pretty-render tool-format calls

### DIFF
--- a/gptme/commands/llm.py
+++ b/gptme/commands/llm.py
@@ -75,6 +75,13 @@ def cmd_model(ctx: CommandContext) -> None:
         chat_config.model = new_model
         chat_config.save()
         print(f"Set model to {new_model}")
+        # Auto-update tool format when the new model prefers a different one
+        model_meta = get_default_model()
+        if model_meta and model_meta.default_tool_format:
+            from ..tools.base import set_tool_format  # fmt: skip
+
+            set_tool_format(model_meta.default_tool_format)
+            print(f"Switched tool format to '{model_meta.default_tool_format}'")
     else:
         model = get_default_model()
         if not model:

--- a/gptme/commands/llm.py
+++ b/gptme/commands/llm.py
@@ -3,8 +3,17 @@ LLM-related commands: model, tools, context, tokens.
 """
 
 from collections import defaultdict
+from typing import TYPE_CHECKING
+from uuid import uuid4
 
 from .base import CommandContext, command
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from ..config import ChatConfig
+    from ..message import Message
+    from ..tools import ToolFormat
 
 
 def _complete_model(partial: str, _prev_args: list[str]) -> list[tuple[str, str]]:
@@ -58,30 +67,65 @@ def _complete_model(partial: str, _prev_args: list[str]) -> list[tuple[str, str]
     return unique_completions[:30]  # Limit to 30 completions
 
 
+def _replacement_prompt(
+    chat_config: "ChatConfig",
+    *,
+    model: str,
+    tool_format: "ToolFormat",
+) -> list["Message"]:
+    """Generate a replacement startup prompt after runtime configuration changes."""
+    from ..config import get_project_config  # fmt: skip
+    from ..prompts import get_prompt  # fmt: skip
+    from ..tools import get_tools  # fmt: skip
+
+    project_config = get_project_config(chat_config.workspace)
+    prompt = (project_config.system if project_config else None) or "full"
+    if chat_config.system_prompt:
+        prompt = chat_config.system_prompt
+    return get_prompt(
+        get_tools(),
+        prompt=prompt,
+        interactive=chat_config.interactive,
+        tool_format=tool_format,
+        model=model,
+        workspace=chat_config.workspace,
+        agent_path=chat_config.agent,
+        prompt_generation=uuid4().hex,
+    )
+
+
 @command("model", completer=_complete_model)
-def cmd_model(ctx: CommandContext) -> None:
+def cmd_model(ctx: CommandContext) -> "Generator[Message, None, None]":
     """Show or switch the current model."""
     from ..config import ChatConfig  # fmt: skip
     from ..llm.models import (  # fmt: skip
         get_default_model,
         set_default_model,
     )
+    from ..tools.base import get_tool_format, set_tool_format  # fmt: skip
 
     if ctx.args:
         new_model = ctx.args[0]
         set_default_model(new_model)
-        # Persist the model change to config so it survives restart/resume
+        model_meta = get_default_model()
+        assert model_meta is not None
+        new_tool_format = model_meta.default_tool_format or get_tool_format()
+
+        # Persist all dependent runtime state before appending a replacement
+        # generated prompt. Historical prompts remain in the append-only log;
+        # prepare_messages() only sends the newest generation to providers.
         chat_config = ChatConfig.from_logdir(ctx.manager.logdir)
         chat_config.model = new_model
+        chat_config.tool_format = new_tool_format
         chat_config.save()
+        set_tool_format(new_tool_format)
+        yield from _replacement_prompt(
+            chat_config,
+            model=model_meta.full,
+            tool_format=new_tool_format,
+        )
         print(f"Set model to {new_model}")
-        # Auto-update tool format when the new model prefers a different one
-        model_meta = get_default_model()
-        if model_meta and model_meta.default_tool_format:
-            from ..tools.base import set_tool_format  # fmt: skip
-
-            set_tool_format(model_meta.default_tool_format)
-            print(f"Switched tool format to '{model_meta.default_tool_format}'")
+        print(f"Switched tool format to '{new_tool_format}'")
     else:
         model = get_default_model()
         if not model:
@@ -142,7 +186,8 @@ def cmd_tools(ctx: CommandContext):
         /tools --all        Show all available tools including unloaded
         /tools load <name>  Load a tool into the current conversation
     """
-    from ..message import Message  # fmt: skip
+    from ..config import ChatConfig  # fmt: skip
+    from ..llm.models import get_default_model  # fmt: skip
     from ..tools import get_available_tools, get_tool, get_tools, load_tool  # fmt: skip
     from ..tools.base import get_tool_format  # fmt: skip
     from ..util.tool_format import format_tool_info, format_tools_list  # fmt: skip
@@ -170,12 +215,19 @@ def cmd_tools(ctx: CommandContext):
 
         print(f"Tool '{new_tool.name}' loaded successfully.")
 
-        # Build a system message with the tool's instructions
+        # The tool overview is part of the generated startup prompt. Replace the
+        # full generation so the provider sees one authoritative tool set.
         tool_format = get_tool_format()
-        prompt = new_tool.get_tool_prompt(examples=True, tool_format=tool_format)
-        yield Message(
-            "system",
-            f"The following tool has been loaded and is now available:\n{prompt}\n",
+        chat_config = ChatConfig.from_logdir(ctx.manager.logdir)
+        chat_config.tools = [tool.name for tool in get_tools()]
+        chat_config.save()
+        model = get_default_model()
+        if model is None:
+            raise ValueError("No model configured")
+        yield from _replacement_prompt(
+            chat_config,
+            model=model.full,
+            tool_format=tool_format,
         )
         return
 

--- a/gptme/logmanager/manager.py
+++ b/gptme/logmanager/manager.py
@@ -846,6 +846,49 @@ def ephemeral_cache_boundary(
     return first_ephemeral_idx - 1
 
 
+def _active_prompt_generation(msgs: list[Message]) -> list[Message]:
+    """Move the newest generated prompt to the front of provider context.
+
+    Runtime configuration changes append a marked prompt generation. Older
+    generated prompts remain on disk for auditability, while the provider gets
+    only the newest generation followed by intact conversation history. The
+    unmarked contiguous pinned-system prefix is the legacy startup prompt.
+    """
+    latest = next(
+        (
+            msg.metadata["prompt_generation"]
+            for msg in reversed(msgs)
+            if msg.metadata and "prompt_generation" in msg.metadata
+        ),
+        None,
+    )
+    if latest is None:
+        return msgs
+
+    legacy_prompt_ids: set[int] = set()
+    for msg in msgs:
+        if (
+            msg.role != "system"
+            or not msg.pinned
+            or (msg.metadata and "prompt_generation" in msg.metadata)
+        ):
+            break
+        legacy_prompt_ids.add(id(msg))
+
+    active = [
+        msg
+        for msg in msgs
+        if msg.metadata and msg.metadata.get("prompt_generation") == latest
+    ]
+    history = [
+        msg
+        for msg in msgs
+        if id(msg) not in legacy_prompt_ids
+        and not (msg.metadata and "prompt_generation" in msg.metadata)
+    ]
+    return active + history
+
+
 def prepare_messages(
     msgs: list[Message],
     workspace: Path | None = None,
@@ -859,6 +902,10 @@ def prepare_messages(
     """
 
     from gptme.llm.models import get_default_model  # fmt: skip
+
+    # A runtime model/tool change appends a replacement generated prompt. Keep
+    # the historical prompts on disk, but only send the newest generation.
+    msgs = _active_prompt_generation(msgs)
 
     # Enrich with enabled context enhancements (RAG, fresh context)
     msgs = enrich_messages_with_context(msgs, workspace)

--- a/gptme/message.py
+++ b/gptme/message.py
@@ -125,6 +125,9 @@ class MessageMetadata(TypedDict, total=False):
     usage: UsageData
     voice_call: dict[str, Any]  # Voice call metadata (call_sid, source, etc.)
     artifacts: list[ArtifactDescriptor]  # tool/plugin-emitted artifact descriptors
+    # Identifies one generated startup-prompt generation. A newer generation
+    # supersedes older ones in provider context while all remain on disk.
+    prompt_generation: str
 
 
 _TOKEN_KEYS = (

--- a/gptme/prompts/__init__.py
+++ b/gptme/prompts/__init__.py
@@ -480,6 +480,7 @@ def get_prompt(
     include_user_context: bool = True,
     include_examples: bool = True,
     initial_prompt: str | None = None,
+    prompt_generation: str | None = None,
 ) -> list[Message]:
     """
     Get the initial system prompt.
@@ -531,6 +532,9 @@ def get_prompt(
             ``prompt == "full-noexamples"``.
         initial_prompt: First user prompt, exported to context commands as
             ``GPTME_PROMPT_INITIAL``.
+        prompt_generation: Optional unique marker for generated prompt messages.
+            Provider context can omit superseded generations without rewriting
+            the append-only log.
 
     Returns a list of messages: [core_system_prompt, workspace_prompt, ...].
     """
@@ -571,9 +575,18 @@ def get_prompt(
     for _, msgs in dynamic_sections:
         result.extend(msgs)
 
-    # Set hide=True, pinned=True for all messages
+    # Replacement prompts carry a generation marker. Startup prompts created by
+    # older gptme versions remain unmarked, so the first replacement can retire
+    # them using its insertion point (see prepare_messages()).
     for i, msg in enumerate(result):
-        result[i] = msg.replace(hide=True, pinned=True)
+        metadata = dict(msg.metadata) if msg.metadata else {}
+        if prompt_generation is not None:
+            metadata["prompt_generation"] = prompt_generation
+        result[i] = msg.replace(
+            hide=True,
+            pinned=True,
+            metadata=metadata or None,
+        )
 
     return result
 

--- a/gptme/tui/app.py
+++ b/gptme/tui/app.py
@@ -57,6 +57,7 @@ from ..logmanager import LogManager
 from ..message import Message
 from ..tools import ToolFormat, ToolUse
 from ..tools.base import ToolUse as ToolUseType
+from ..tools.base import get_tool_format
 from ..tools.complete import SessionCompleteException
 from ..util.content import is_message_command
 from ..util.context import include_paths
@@ -85,6 +86,9 @@ def _summarize(content: str, maxlen: int = 80) -> str:
 _THINK_RE = re.compile(r"<think(?:ing)?>(.*?)</think(?:ing)?>", re.DOTALL)
 _THINK_SIG_RE = re.compile(r"<!--\s*think-sig:.*?-->\s*", re.DOTALL)
 
+# Matches the `tool` format: @tool_name(call_id): {...json...} on a single line
+_TOOL_CALL_RE = re.compile(r"^(@(\w+)\([^)]*\)):\s*(\{[^\n]+\})", re.MULTILINE)
+
 
 def _split_thinking(content: str) -> list[tuple[bool, str]]:
     """Split message content into (is_thinking, text) segments.
@@ -106,6 +110,49 @@ def _split_thinking(content: str) -> list[tuple[bool, str]]:
     if tail.strip():
         segments.append((False, tail))
     return segments
+
+
+def _split_tool_calls(text: str) -> list[tuple[bool, str]]:
+    """Split a text block into (is_toolcall, segment) pairs.
+
+    Detects ``@tool_name(call_id): {...}`` lines emitted by the ``tool``
+    format so they can be rendered as collapsible blocks instead of raw JSON.
+    """
+    segments: list[tuple[bool, str]] = []
+    last_end = 0
+    for m in _TOOL_CALL_RE.finditer(text):
+        before = text[last_end : m.start()]
+        if before.strip():
+            segments.append((False, before))
+        segments.append((True, m.group(0)))
+        last_end = m.end()
+    tail = text[last_end:]
+    if tail.strip():
+        segments.append((False, tail))
+    return segments or [(False, text)]
+
+
+def _tool_call_renderable(call_text: str) -> tuple[str, str, str]:
+    """Parse a tool-format line into (title, code, lang) for a Collapsible."""
+    import json  # local import — json not used elsewhere in this module
+
+    m = _TOOL_CALL_RE.match(call_text.strip())
+    if not m:
+        return call_text, call_text, "text"
+    tool_name = m.group(2)
+    json_body = m.group(3)
+    try:
+        args = json.loads(json_body)
+        code: str = args.get("code") or args.get("command") or json_body
+    except Exception:
+        code = json_body
+    first_line = code.split("\n")[0].strip()
+    if len(first_line) > 55:
+        first_line = first_line[:54] + "…"
+    suffix = "…" if ("\n" in code or len(code) > 60) else ""
+    title = f"▶ {tool_name}: {first_line}{suffix}" if first_line else f"▶ {tool_name}"
+    lang = "python" if tool_name in ("ipython", "python") else "bash"
+    return title, code, lang
 
 
 class UserMessage(Vertical):
@@ -130,20 +177,35 @@ class AssistantMessage(Vertical):
 
     def compose(self) -> ComposeResult:
         yield Static(Text("Assistant"), classes="role")
-        segments = _split_thinking(self.content)
-        if not any(is_think for is_think, _ in segments):
+        think_segs = _split_thinking(self.content)
+        has_thinking = any(is_think for is_think, _ in think_segs)
+        has_tool_calls = any(
+            not is_think and bool(_TOOL_CALL_RE.search(text))
+            for is_think, text in think_segs
+        )
+        if not has_thinking and not has_tool_calls:
             yield Markdown(self.content)
-        else:
-            for is_think, text in segments:
-                if is_think:
-                    yield Collapsible(
-                        Markdown(text),
-                        title="Thinking",
-                        collapsed=True,
-                        classes="thinking-block",
-                    )
-                elif text.strip():
-                    yield Markdown(text)
+            return
+        for is_think, text in think_segs:
+            if is_think:
+                yield Collapsible(
+                    Markdown(text),
+                    title="Thinking",
+                    collapsed=True,
+                    classes="thinking-block",
+                )
+            else:
+                for is_tool, seg in _split_tool_calls(text):
+                    if is_tool:
+                        title, code, lang = _tool_call_renderable(seg)
+                        yield Collapsible(
+                            Static(Syntax(code, lang, theme="ansi_dark")),
+                            title=title,
+                            collapsed=True,
+                            classes="tool-call-block",
+                        )
+                    elif seg.strip():
+                        yield Markdown(seg)
 
 
 class SystemMessage(Vertical):
@@ -1049,6 +1111,8 @@ class GptmeApp(App):
             sys.stdin = real_stdin
 
         self._model = self._chat_ctx.run(get_default_model)
+        # Sync tool format — /model may have called set_tool_format()
+        self.tool_format = get_tool_format()
         if self.manager.log.messages != before:
             # command changed the log (undo, appended messages, …): re-render
             self._rebuild_chat()

--- a/gptme/tui/app.py
+++ b/gptme/tui/app.py
@@ -86,8 +86,13 @@ def _summarize(content: str, maxlen: int = 80) -> str:
 _THINK_RE = re.compile(r"<think(?:ing)?>(.*?)</think(?:ing)?>", re.DOTALL)
 _THINK_SIG_RE = re.compile(r"<!--\s*think-sig:.*?-->\s*", re.DOTALL)
 
-# Matches the `tool` format: @tool_name(call_id): {...json...} on a single line
-_TOOL_CALL_RE = re.compile(r"^(@(\w+)\([^)]*\)):\s*(\{[^\n]+\})", re.MULTILINE)
+# Matches the `tool` format: @tool_name(call_id): {...json...}. Calls end at
+# the next tool-call header, unindented prose, or the end of the message. JSON
+# string braces are handled by parsing the captured body below.
+_TOOL_CALL_RE = re.compile(
+    r"^(@(\w+)\([^)]*\)):\s*(\{.*?\})(?=\n@\w+\([^)]*\):|\n(?!\s)|\Z)",
+    re.MULTILINE | re.DOTALL,
+)
 
 
 def _split_thinking(content: str) -> list[tuple[bool, str]]:

--- a/gptme/tui/app.py
+++ b/gptme/tui/app.py
@@ -87,10 +87,10 @@ _THINK_RE = re.compile(r"<think(?:ing)?>(.*?)</think(?:ing)?>", re.DOTALL)
 _THINK_SIG_RE = re.compile(r"<!--\s*think-sig:.*?-->\s*", re.DOTALL)
 
 # Matches the `tool` format: @tool_name(call_id): {...json...}. Calls end at
-# the next tool-call header, unindented prose, or the end of the message. JSON
-# string braces are handled by parsing the captured body below.
+# the next tool-call header, any following prose (indented or not), or the end
+# of the message. JSON string braces are handled by parsing the captured body.
 _TOOL_CALL_RE = re.compile(
-    r"^(@(\w+)\([^)]*\)):\s*(\{.*?\})(?=\n@\w+\([^)]*\):|\n(?!\s)|\Z)",
+    r"^(@(\w+)\([^)]*\)):\s*(\{.*?\})(?=\n@\w+\([^)]*\):|\n|\Z)",
     re.MULTILINE | re.DOTALL,
 )
 

--- a/tests/test_commands_llm.py
+++ b/tests/test_commands_llm.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from gptme.commands.base import CommandContext
-from gptme.commands.llm import cmd_context
+from gptme.commands.llm import cmd_context, cmd_model, cmd_tools
 from gptme.message import Message
 from gptme.util.context_savings import record_context_savings
 
@@ -16,6 +16,61 @@ def _make_manager(logdir: Path) -> MagicMock:
     ]
     manager.logdir = logdir
     return manager
+
+
+def test_cmd_model_appends_replacement_prompt_and_persists_generation(tmp_path: Path):
+    manager = _make_manager(tmp_path)
+    ctx = CommandContext(args=["new-model"], full_args="new-model", manager=manager)
+    replacement = Message(
+        "system",
+        "replacement",
+        metadata={"prompt_generation": "replacement-id"},
+    )
+    model_meta = MagicMock(full="provider/new-model", default_tool_format="tool")
+
+    with (
+        patch("gptme.config.ChatConfig.from_logdir") as from_logdir,
+        patch("gptme.llm.models.set_default_model"),
+        patch("gptme.llm.models.get_default_model", return_value=model_meta),
+        patch("gptme.commands.llm._replacement_prompt", return_value=[replacement]),
+        patch("gptme.tools.base.set_tool_format"),
+    ):
+        chat_config = from_logdir.return_value
+        chat_config.interactive = True
+        chat_config.workspace = tmp_path
+        chat_config.agent = None
+
+        yielded = list(cmd_model(ctx))
+
+    assert yielded == [replacement]
+    assert chat_config.model == "new-model"
+    assert chat_config.tool_format == "tool"
+    chat_config.save.assert_called_once_with()
+
+
+def test_cmd_tools_load_appends_replacement_prompt(tmp_path: Path):
+    manager = _make_manager(tmp_path)
+    ctx = CommandContext(
+        args=["load", "python"], full_args="load python", manager=manager
+    )
+    replacement = Message(
+        "system",
+        "replacement",
+        metadata={"prompt_generation": "replacement-id"},
+    )
+    model_meta = MagicMock(full="provider/model")
+
+    with (
+        patch("gptme.config.ChatConfig.from_logdir") as from_logdir,
+        patch("gptme.llm.models.get_default_model", return_value=model_meta),
+        patch("gptme.tools.load_tool"),
+        patch("gptme.commands.llm._replacement_prompt", return_value=[replacement]),
+    ):
+        yielded = list(cmd_tools(ctx))
+
+    assert yielded == [replacement]
+    from_logdir.assert_called_once_with(tmp_path)
+    from_logdir.return_value.save.assert_called_once_with()
 
 
 def test_cmd_context_reports_context_savings(tmp_path: Path):

--- a/tests/test_logmanager.py
+++ b/tests/test_logmanager.py
@@ -9,7 +9,10 @@ from gptme.logmanager import (
     check_for_modifications,
     conversation_name_error,
 )
-from gptme.logmanager.manager import _merge_consecutive_messages
+from gptme.logmanager.manager import (
+    _active_prompt_generation,
+    _merge_consecutive_messages,
+)
 from gptme.message import Message
 from gptme.tools import init_tools
 
@@ -18,6 +21,76 @@ from gptme.tools import init_tools
 def _init_tools():
     """Ensure tools are loaded for check_for_modifications tests."""
     init_tools(allowlist=["save", "patch", "append"])
+
+
+def test_active_prompt_generation_preserves_conversation_history():
+    """A replacement retires generated prompts, never user/assistant history."""
+    old_prompt = Message("system", "old prompt", pinned=True, hide=True)
+    user = Message("user", "question")
+    assistant = Message("assistant", "answer")
+    runtime = Message("system", "tool output")
+    replacement = Message(
+        "system",
+        "new prompt",
+        pinned=True,
+        hide=True,
+        metadata={"prompt_generation": "one"},
+    )
+    user_after = Message("user", "next question")
+
+    result = _active_prompt_generation(
+        [old_prompt, user, assistant, runtime, replacement, user_after]
+    )
+
+    assert result == [replacement, user, assistant, runtime, user_after]
+
+
+def test_active_prompt_generation_preserves_later_pinned_system_messages():
+    runtime_prompt = Message(
+        "system",
+        "runtime instruction",
+        pinned=True,
+        hide=True,
+    )
+    replacement = Message(
+        "system",
+        "complete replacement",
+        pinned=True,
+        hide=True,
+        metadata={"prompt_generation": "replacement"},
+    )
+    user = Message("user", "history")
+
+    result = _active_prompt_generation(
+        [
+            Message("system", "old core", pinned=True),
+            user,
+            runtime_prompt,
+            replacement,
+        ]
+    )
+
+    assert result == [replacement, user, runtime_prompt]
+
+
+def test_active_prompt_generation_keeps_only_newest_replacement():
+    generation_one = Message(
+        "system",
+        "generation one",
+        pinned=True,
+        metadata={"prompt_generation": "z-first"},
+    )
+    generation_two = Message(
+        "system",
+        "generation two",
+        pinned=True,
+        metadata={"prompt_generation": "a-second"},
+    )
+    user = Message("user", "history")
+
+    result = _active_prompt_generation([generation_one, user, generation_two])
+
+    assert result == [generation_two, user]
 
 
 def test_log_repr():

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -795,6 +795,21 @@ def test_split_multiline_tool_calls():
     assert language == "python"
 
 
+def test_split_tool_calls_indented_prose():
+    """Tool calls followed by indented prose are still recognized."""
+    content = (
+        '@ipython(call-1): {\n  "code": "x = 1"\n}\n'
+        "  This prose is indented.\n"
+        "Unindented continuation."
+    )
+
+    segments = _split_tool_calls(content)
+
+    assert segments[0][0] is True, "first segment should be a tool call"
+    assert "x = 1" in segments[0][1]
+    assert not segments[1][0], "second segment should be prose"
+
+
 @pytest.mark.asyncio
 async def test_assistant_message_no_collapsible_without_thinking(tmp_path):
     """AssistantMessage without thinking tags renders no Collapsible."""

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -23,7 +23,9 @@ from gptme.tui.app import (
     _append_pt_history,
     _load_pt_history,
     _split_thinking,
+    _split_tool_calls,
     _summarize,
+    _tool_call_renderable,
 )
 
 
@@ -773,6 +775,24 @@ async def test_assistant_message_renders_thinking_as_collapsible(tmp_path):
         assert thinking_collapsible.collapsed, (
             "Thinking block should be collapsed by default"
         )
+
+
+def test_split_multiline_tool_calls():
+    """Indented JSON calls are split without consuming adjacent prose/calls."""
+    content = (
+        "Before\n"
+        '@ipython(call-1): {\n  "code": "print(1)\\nprint(2)"\n}\n'
+        '@shell(call-2): {"command": "pwd"}\n'
+        "After"
+    )
+
+    segments = _split_tool_calls(content)
+
+    assert [is_tool for is_tool, _ in segments] == [False, True, True, False]
+    title, code, language = _tool_call_renderable(segments[1][1])
+    assert title.startswith("▶ ipython: print(1)")
+    assert code == "print(1)\nprint(2)"
+    assert language == "python"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #3343 (two of the three sub-problems).

## What changed

### Fix 1 — `/model` switch now updates the tool format

`cmd_model` in `gptme/commands/llm.py` now calls `set_tool_format()` with
the new model's `default_tool_format` immediately after `set_default_model()`.
Previously, switching from a markdown-format model to `gpt-5.6-sol` (which
uses `tool` format) left the session in `markdown` mode. The model would emit
`@tool(): {}` calls that gptme couldn't parse, then hallucinate a closing fence
to "complete" the incomplete block — preventing tool execution entirely.

`GptmeApp._handle_command` also syncs `self.tool_format` from the global after
any command, so the generation worker always uses the current format.

### Fix 2 — Pretty-rendering of `tool`-format calls in the TUI

`AssistantMessage.compose` now detects `@tool_name(call_id): {json}` lines
(the `tool` format emitted by GPT-5.x models) and renders them as collapsible
blocks with syntax-highlighted code extracted from the JSON body — exactly like
thinking blocks. Long ipython code dumps that were previously an unreadable flat
JSON blob become a compact collapsed header:

```
▶ ipython: import subprocess, ast…
```

The implementation adds:
- `_TOOL_CALL_RE` regex to detect `@tool_name(call_id): {...}` lines
- `_split_tool_calls(text)` — segments a text block into tool-call and prose pairs
- `_tool_call_renderable(call_text)` — extracts `(title, code, lang)` for display

### Not in this PR

Problem 3 from the issue (consistent format detection across all three formats
in the TUI) — that's a larger refactor and can follow separately.