### PR TITLE
fix(tui): prevent crash when pasting GitHub URL

### DIFF
--- a/gptme/util/context.py
+++ b/gptme/util/context.py
@@ -35,11 +35,25 @@ logger = logging.getLogger(__name__)
 
 
 def _is_interactive_mode() -> bool:
-    """Check if we're in interactive CLI mode.
+    """Check if we're in interactive CLI mode where prompt_toolkit prompts are safe.
 
-    Returns True if the cli_confirm hook is registered, indicating
-    interactive mode with confirmation enabled.
+    Returns True if the cli_confirm hook is registered AND we're not inside a
+    running async event loop (e.g. Textual TUI). Calling prompt_toolkit's sync
+    PromptSession.prompt() from inside a running event loop causes
+    ``RuntimeWarning: coroutine 'Application.run_async' was never awaited``
+    and crashes the TUI when the user submits a message containing a URL.
     """
+    import asyncio
+
+    try:
+        asyncio.get_running_loop()
+        # Inside a running event loop (e.g. Textual TUI) — prompt_toolkit's
+        # sync prompt() cannot safely run here; treat as non-interactive so
+        # URLs are included without prompting instead of crashing.
+        return False
+    except RuntimeError:
+        pass  # No running loop — safe to use prompt_toolkit
+
     try:
         from ..hooks import HookType, get_hooks
 

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -143,29 +143,23 @@ def test_include_paths_not_disabled_by_falsy_env_var(tmp_path, monkeypatch, fals
 
 
 def test_is_interactive_mode_false_inside_async_loop():
-    """_is_interactive_mode() must return False inside a running event loop.
-
-    Calling prompt_toolkit's sync PromptSession.prompt() from within an async
-    event loop (e.g. Textual TUI) crashes with:
-        RuntimeWarning: coroutine 'Application.run_async' was never awaited
-    The fix: detect the running loop and return False so URL confirmation is
-    skipped instead of attempting a blocking prompt_toolkit call.
-    """
+    """A running event loop must override the registered interactive CLI hook."""
     import asyncio
 
+    from gptme.hooks import HookType, register_hook, unregister_hook
+    from gptme.hooks.cli_confirm import cli_confirm_hook
     from gptme.util.context import _is_interactive_mode
 
-    result = None
+    register_hook("cli_confirm", HookType.TOOL_CONFIRM, cli_confirm_hook)
+    try:
+        assert _is_interactive_mode() is True
 
-    async def _check():
-        nonlocal result
-        result = _is_interactive_mode()
+        async def _check():
+            assert _is_interactive_mode() is False
 
-    asyncio.run(_check())
-    assert result is False, (
-        "_is_interactive_mode() must return False inside a running event loop "
-        "to prevent prompt_toolkit crashes in the Textual TUI"
-    )
+        asyncio.run(_check())
+    finally:
+        unregister_hook("cli_confirm", HookType.TOOL_CONFIRM)
 
 
 def test_include_paths_skips_system_messages():

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -142,6 +142,32 @@ def test_include_paths_not_disabled_by_falsy_env_var(tmp_path, monkeypatch, fals
     assert "content-should-appear" in result.content
 
 
+def test_is_interactive_mode_false_inside_async_loop():
+    """_is_interactive_mode() must return False inside a running event loop.
+
+    Calling prompt_toolkit's sync PromptSession.prompt() from within an async
+    event loop (e.g. Textual TUI) crashes with:
+        RuntimeWarning: coroutine 'Application.run_async' was never awaited
+    The fix: detect the running loop and return False so URL confirmation is
+    skipped instead of attempting a blocking prompt_toolkit call.
+    """
+    import asyncio
+
+    from gptme.util.context import _is_interactive_mode
+
+    result = None
+
+    async def _check():
+        nonlocal result
+        result = _is_interactive_mode()
+
+    asyncio.run(_check())
+    assert result is False, (
+        "_is_interactive_mode() must return False inside a running event loop "
+        "to prevent prompt_toolkit crashes in the Textual TUI"
+    )
+
+
 def test_include_paths_skips_system_messages():
     """Test that include_paths skips role=system messages (tool output) entirely."""
     from gptme.message import Message


### PR DESCRIPTION
## Problem

Submitting a message containing a GitHub link (e.g. `https://github.com/gptme/gptme/issues/3343`) in `gptme-tui` immediately crashes the app:

```
<sys>:0: RuntimeWarning: coroutine 'Application.run_async' was never awaited
```

## Root Cause

The TUI initializes with `interactive=True`, which registers the `cli_confirm` hook. This makes `_is_interactive_mode()` in `gptme/util/context.py` return `True`, so `include_paths()` calls `_confirm_urls()` → `prompt_alert()` → `prompt_toolkit.PromptSession.prompt()` (the synchronous version).

`PromptSession.prompt()` tries to run an asyncio event loop internally via `run_until_complete()`. Since Textual is already running its own event loop, this raises `RuntimeError: This event loop is already running`, which leaves `prompt_toolkit`'s `Application.run_async()` coroutine un-awaited — triggering the warning and crashing.

## Fix

`_is_interactive_mode()` now calls `asyncio.get_running_loop()` first. If a loop is already running (Textual TUI or any other async context), it returns `False` immediately — skipping the blocking prompt_toolkit call and auto-including URLs instead.

A regression test verifies that `_is_interactive_mode()` returns `False` when called from inside a running event loop.

Fixes #3345