### PR TITLE
feat(tui): prompt before fetching URLs pasted into TUI

### DIFF
--- a/gptme/tui/app.py
+++ b/gptme/tui/app.py
@@ -59,7 +59,7 @@ from ..tools import ToolFormat, ToolUse
 from ..tools.base import ToolUse as ToolUseType
 from ..tools.complete import SessionCompleteException
 from ..util.content import is_message_command
-from ..util.context import include_paths
+from ..util.context import extract_urls, include_paths
 from ..util.history import append_history, load_history
 from ..util.tokens import len_tokens
 
@@ -518,6 +518,41 @@ class ConfirmScreen(ModalScreen[ConfirmationResult]):
         self.dismiss(ConfirmationResult.confirm())
 
 
+class UrlConfirmScreen(ModalScreen):
+    """Modal asking the user to confirm fetching URLs found in their message."""
+
+    BINDINGS = [
+        Binding("y,enter", "confirm", "Fetch URL(s)"),
+        Binding("n,escape", "skip", "Skip"),
+    ]
+
+    def __init__(self, urls: list[str]) -> None:
+        super().__init__()
+        self.urls = urls
+
+    def compose(self) -> ComposeResult:
+        title = "Fetch URL?" if len(self.urls) == 1 else f"Fetch {len(self.urls)} URLs?"
+        body = (
+            "\n".join(self.urls)
+            if len(self.urls) == 1
+            else "\n".join(f"{i + 1}. {url}" for i, url in enumerate(self.urls))
+        )
+        with Vertical(id="confirm-dialog"):
+            yield Static(Text(title, style="bold"), id="confirm-title")
+            with VerticalScroll(id="confirm-preview"):
+                yield Static(body)
+            yield Static(
+                Text("[y/enter] fetch   [n/esc] skip"),
+                id="confirm-help",
+            )
+
+    def action_confirm(self) -> None:
+        self.dismiss(self.urls)
+
+    def action_skip(self) -> None:
+        self.dismiss([])
+
+
 class GptmeApp(App):
     """gptme TUI: streaming chat with live input, queueing and collapsible output."""
 
@@ -954,7 +989,7 @@ class GptmeApp(App):
         w.update(t)
         w.display = True
 
-    def on_chat_input_submitted(self, event: ChatInput.Submitted) -> None:
+    async def on_chat_input_submitted(self, event: ChatInput.Submitted) -> None:
         text = event.value.strip()
         chat_input = self.query_one("#input", ChatInput)
         chat_input.text = ""
@@ -987,7 +1022,7 @@ class GptmeApp(App):
                 self._mount_in_chat(widget)
             self._update_status()
         else:
-            self._submit(text)
+            await self._submit(text)
 
     def _can_resume(self) -> bool:
         last = next((m for m in reversed(self.manager.log) if not m.hide), None)
@@ -1067,9 +1102,15 @@ class GptmeApp(App):
         chat.remove_children()
         self._render_history()
 
-    def _submit(self, text: str) -> None:
+    async def _submit(self, text: str) -> None:
         msg = Message("user", text, quiet=True)
-        msg = include_paths(msg, self.workspace)
+        # Confirm before fetching any URLs, matching CLI behavior (TUI can't
+        # use prompt_toolkit's sync dialog inside the running event loop).
+        pre_confirmed_urls: list[str] | None = None
+        urls = extract_urls(text)
+        if urls:
+            pre_confirmed_urls = await self.push_screen_wait(UrlConfirmScreen(urls))
+        msg = include_paths(msg, self.workspace, pre_confirmed_urls=pre_confirmed_urls)
         self.manager.append(msg)
         self._show_message(msg)
         self._start_generation()
@@ -1249,7 +1290,7 @@ class GptmeApp(App):
             self._show_tool_placeholder()
         self._update_status()
 
-    def on_worker_state_changed(self, event: Worker.StateChanged) -> None:
+    async def on_worker_state_changed(self, event: Worker.StateChanged) -> None:
         if event.worker.group != "generation":
             return
         if event.state in (
@@ -1257,9 +1298,9 @@ class GptmeApp(App):
             WorkerState.ERROR,
             WorkerState.CANCELLED,
         ):
-            self._generation_done()
+            await self._generation_done()
 
-    def _generation_done(self) -> None:
+    async def _generation_done(self) -> None:
         self.generating = False
         # stream may have ended without a final message (interrupt mid-stream)
         self._clear_stream_view()
@@ -1277,7 +1318,7 @@ class GptmeApp(App):
             if self._queued_widgets:
                 self._queued_widgets.pop(0).remove()
             self._set_state("idle")
-            self._submit(text)
+            await self._submit(text)
             return
         self._set_state("idle")
 

--- a/gptme/util/context.py
+++ b/gptme/util/context.py
@@ -63,6 +63,24 @@ def _is_interactive_mode() -> bool:
         return False
 
 
+def extract_urls(content: str) -> list[str]:
+    """Extract HTTP/HTTPS URLs from message content (outside code blocks).
+
+    Used by callers that want to preview and confirm URLs before passing them
+    back via the ``pre_confirmed_urls`` parameter of :func:`include_paths`.
+    """
+    potential_paths = _find_potential_paths(content)
+    urls = []
+    for word in potential_paths:
+        try:
+            p = urllib.parse.urlparse(word)
+            if p.scheme in ("http", "https") and p.netloc:
+                urls.append(word)
+        except ValueError:
+            pass
+    return urls
+
+
 def _confirm_urls(urls: list[str]) -> list[str]:
     """Prompt user to confirm which URLs to read.
 
@@ -474,7 +492,11 @@ def enrich_messages_with_context(
     return msgs
 
 
-def include_paths(msg: Message, workspace: Path | None = None) -> Message:
+def include_paths(
+    msg: Message,
+    workspace: Path | None = None,
+    pre_confirmed_urls: list[str] | None = None,
+) -> Message:
     """
     Searches the message for any valid paths and:
      - In legacy mode (default):
@@ -496,6 +518,10 @@ def include_paths(msg: Message, workspace: Path | None = None) -> Message:
     Args:
         msg: Message to process
         workspace: If provided, paths will be stored relative to this directory
+        pre_confirmed_urls: URLs already confirmed by the caller (e.g. via a TUI
+            dialog).  When provided, the interactive-mode prompt is bypassed and
+            only these URLs are fetched.  Pass an empty list to skip all URLs
+            without prompting.
     """
     # Check for explicit disable to prevent silent prompt bloat in autonomous mode
     if os.environ.get("GPTME_DISABLE_PATH_INCLUDE", "").lower() in (
@@ -535,9 +561,16 @@ def include_paths(msg: Message, workspace: Path | None = None) -> Message:
         except ValueError:
             file_paths.append(word)
 
-    # In interactive mode, ask for confirmation before reading URLs
+    # Determine which URLs to fetch:
+    # 1. Caller pre-confirmed (e.g. TUI dialog) — use that list directly.
+    # 2. Interactive CLI mode — prompt the user.
+    # 3. Non-interactive / no URLs — read all (or none if urls_found is empty).
     confirmed_urls: list[str] | None = None
-    if urls_found and _is_interactive_mode():
+    if pre_confirmed_urls is not None:
+        confirmed_urls = pre_confirmed_urls
+        if urls_found and not confirmed_urls:
+            logger.info(f"Skipping {len(urls_found)} URL(s) - not confirmed by user")
+    elif urls_found and _is_interactive_mode():
         confirmed_urls = _confirm_urls(urls_found)
         if not confirmed_urls:
             logger.info(f"Skipping {len(urls_found)} URL(s) - not confirmed by user")

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -507,3 +507,74 @@ def test_is_interactive_mode():
     # (This test runs outside the normal CLI context)
     result = _is_interactive_mode()
     assert isinstance(result, bool)
+
+
+def test_extract_urls_basic():
+    """Test that extract_urls finds HTTP/HTTPS URLs in content."""
+    from gptme.util.context import extract_urls
+
+    content = "Check out https://example.com and http://foo.bar/baz for details."
+    urls = extract_urls(content)
+    assert "https://example.com" in urls
+    assert "http://foo.bar/baz" in urls
+
+
+def test_extract_urls_ignores_code_blocks():
+    """URLs inside code blocks should not be extracted."""
+    from gptme.util.context import extract_urls
+
+    content = (
+        "```\nhttps://inside.codeblock.com\n```\nBut https://outside.com is found."
+    )
+    urls = extract_urls(content)
+    assert "https://inside.codeblock.com" not in urls
+    assert "https://outside.com" in urls
+
+
+def test_extract_urls_empty():
+    from gptme.util.context import extract_urls
+
+    assert extract_urls("no urls here") == []
+    assert extract_urls("") == []
+
+
+def test_include_paths_pre_confirmed_urls_allows(tmp_path, monkeypatch):
+    """pre_confirmed_urls lets the caller pre-approve specific URLs."""
+    from unittest.mock import patch
+
+    from gptme.message import Message
+    from gptme.util.context import include_paths
+
+    monkeypatch.delenv("GPTME_DISABLE_PATH_INCLUDE", raising=False)
+    msg = Message("user", "See https://example.com for details")
+    fake_content = "Example page content"
+
+    with (
+        patch("gptme.util.context._resource_to_codeblock", return_value=fake_content),
+        patch("gptme.util.context.use_fresh_context", return_value=False),
+    ):
+        result = include_paths(
+            msg, tmp_path, pre_confirmed_urls=["https://example.com"]
+        )
+
+    # URL was pre-confirmed, so content should be attached
+    assert fake_content in result.content
+
+
+def test_include_paths_pre_confirmed_urls_empty_skips_all(tmp_path, monkeypatch):
+    """pre_confirmed_urls=[] skips all URL fetching without calling _confirm_urls."""
+    from unittest.mock import patch
+
+    from gptme.message import Message
+    from gptme.util.context import include_paths
+
+    monkeypatch.delenv("GPTME_DISABLE_PATH_INCLUDE", raising=False)
+    msg = Message("user", "See https://example.com for details")
+
+    with patch("gptme.util.context._confirm_urls") as mock_confirm:
+        result = include_paths(msg, tmp_path, pre_confirmed_urls=[])
+
+    # _confirm_urls should NOT be called — caller already decided
+    mock_confirm.assert_not_called()
+    # URL should not be fetched — result content is unchanged (just the original text)
+    assert result.content == msg.content


### PR DESCRIPTION
## Problem

The CLI prompts the user when a URL is submitted, but the TUI did not — a user pasting a message containing embedded URLs would have those URLs silently fetched. This inconsistency was identified in #3346/#3349.

## Solution

- **`gptme/util/context.py`**: Add `extract_urls(content)` helper for pre-dialog URL detection. Add `pre_confirmed_urls` parameter to `include_paths()` so callers can supply an already-confirmed URL list, bypassing `_is_interactive_mode()`.

- **`gptme/tui/app.py`**: Add `UrlConfirmScreen` modal (y/enter = fetch, n/esc = skip). Make `_submit()` async so it can `await push_screen_wait(UrlConfirmScreen(...))` before calling `include_paths()`. Propagate async to `on_chat_input_submitted()`, `on_worker_state_changed()`, and `_generation_done()`.

- **`tests/test_context.py`**: Tests for `extract_urls()` and the `pre_confirmed_urls` parameter.

## Test plan

- [x] `uv run pytest tests/test_context.py tests/test_tui.py` — 70 passed
- [ ] Manual: paste a URL in the TUI → dialog appears → y fetches, n skips

Closes #3349

<!-- gptme-id:v1:gai_o5QyDTxqgbf8W6CvclTWJf6SyokKb1hLHbwigUAx9hF -->