### PR TITLE
fix(subscription): close streaming response on all exit paths to prevent SIGSEGV

### DIFF
--- a/gptme/llm/llm_openai_subscription.py
+++ b/gptme/llm/llm_openai_subscription.py
@@ -592,35 +592,46 @@ def stream(
         attempts = 0
         yielded_any = False
         response = _open_response()
-        while True:
-            try:
-                for line in response.iter_lines():
-                    if not line:
-                        continue
-                    data = _parse_sse_response(line)
-                    if data is None:
-                        continue
-                    if data.get("done"):
-                        return
-                    yielded_any = True
-                    yield data
-                return
-            except (
-                requests.exceptions.Timeout,
-                requests.exceptions.ConnectionError,
-                requests.exceptions.ChunkedEncodingError,
-            ) as e:
-                if yielded_any or attempts >= max_stream_retries:
-                    raise
-                attempts += 1
-                logger.warning(
-                    "Subscription stream idle/dropped before first event (%s); "
-                    "retrying (%d/%d)",
-                    e,
-                    attempts,
-                    max_stream_retries,
-                )
-                response = _open_response()
+        try:
+            while True:
+                try:
+                    for line in response.iter_lines():
+                        if not line:
+                            continue
+                        data = _parse_sse_response(line)
+                        if data is None:
+                            continue
+                        if data.get("done"):
+                            return
+                        yielded_any = True
+                        yield data
+                    return
+                except (
+                    requests.exceptions.Timeout,
+                    requests.exceptions.ConnectionError,
+                    requests.exceptions.ChunkedEncodingError,
+                ) as e:
+                    # Close before rebinding so the abandoned SSL socket is
+                    # released immediately rather than at interpreter teardown.
+                    response.close()
+                    if yielded_any or attempts >= max_stream_retries:
+                        raise
+                    attempts += 1
+                    logger.warning(
+                        "Subscription stream idle/dropped before first event (%s); "
+                        "retrying (%d/%d)",
+                        e,
+                        attempts,
+                        max_stream_retries,
+                    )
+                    response = _open_response()
+        finally:
+            # Runs on every exit path: normal return, exception, or GeneratorExit
+            # when _stream_responses_events breaks early on response.done.
+            # Without this the streaming SSL socket lingers until interpreter
+            # teardown and can SIGSEGV when _ssl is finalized out-of-order
+            # (status=139, recurring in PM canary with gpt-5.6-sol).
+            response.close()
 
     _usage_holder: list[Any] = []
 

--- a/tests/test_llm_openai_subscription.py
+++ b/tests/test_llm_openai_subscription.py
@@ -26,10 +26,14 @@ class _FakeSSEStreamResponse:
         self.status_code = 200
         self.text = ""
         self._events = events
+        self.closed = False
 
     def iter_lines(self) -> Iterator[bytes]:
         for event in self._events:
             yield f"data: {json.dumps(event)}".encode()
+
+    def close(self) -> None:
+        self.closed = True
 
 
 def _run_stream(events: list[dict[str, Any]]) -> str:
@@ -346,10 +350,14 @@ class _TimeoutThenEventsResponse:
     def __init__(self) -> None:
         self.status_code = 200
         self.text = ""
+        self.closed = False
 
     def iter_lines(self) -> Iterator[bytes]:
         raise requests.exceptions.ReadTimeout("read timeout=600")
         yield b""  # pragma: no cover — makes this a generator
+
+    def close(self) -> None:
+        self.closed = True
 
 
 class _EventThenTimeoutResponse:
@@ -358,10 +366,14 @@ class _EventThenTimeoutResponse:
     def __init__(self) -> None:
         self.status_code = 200
         self.text = ""
+        self.closed = False
 
     def iter_lines(self) -> Iterator[bytes]:
         yield f"data: {json.dumps({'type': 'response.output_text.delta', 'delta': 'partial'})}".encode()
         raise requests.exceptions.ReadTimeout("read timeout=600")
+
+    def close(self) -> None:
+        self.closed = True
 
 
 def test_stream_retries_idle_timeout_before_first_event():
@@ -511,3 +523,65 @@ def test_stream_captures_usage_without_cache_fields():
     assert usage.get("output_tokens") == 75
     assert "cache_read_tokens" not in usage
     assert "cache_creation_tokens" not in usage
+
+
+def test_stream_closes_response_after_done_event():
+    """response.close() must be called when the done event is received.
+
+    Regression test for SIGSEGV (status=139) on interpreter teardown: a
+    streaming requests.Response keeps its SSL socket open until explicitly
+    closed.  If we return from _sse_events() without calling close(), the
+    socket lingers in urllib3's pool and can SIGSEGV when _ssl is finalized
+    during Python shutdown before the pool is torn down.
+    """
+    auth = _make_auth()
+    response = _FakeSSEStreamResponse(
+        [
+            {"type": "response.output_text.delta", "delta": "Hi."},
+            {"type": "response.done"},
+        ]
+    )
+
+    with (
+        patch("gptme.llm.llm_openai_subscription.get_auth", return_value=auth),
+        patch("gptme.llm.llm_openai_subscription.requests.post", return_value=response),
+    ):
+        list(
+            llm_openai_subscription.stream(
+                [Message(role="user", content="hello")], "gpt-5.4"
+            )
+        )
+
+    assert response.closed, "response.close() must be called after the done event"
+
+
+def test_stream_closes_response_on_retry():
+    """The old response must be closed before opening the retry request.
+
+    Without this, the abandoned SSL socket lingers until interpreter teardown,
+    which can SIGSEGV when _ssl is finalized before urllib3 pools are GC'd.
+    """
+    auth = _make_auth()
+    timed_out = _TimeoutThenEventsResponse()
+    ok = _FakeSSEStreamResponse(
+        [
+            {"type": "response.output_text.delta", "delta": "Done."},
+            {"type": "response.done"},
+        ]
+    )
+
+    with (
+        patch("gptme.llm.llm_openai_subscription.get_auth", return_value=auth),
+        patch(
+            "gptme.llm.llm_openai_subscription.requests.post",
+            side_effect=[timed_out, ok],
+        ),
+    ):
+        list(
+            llm_openai_subscription.stream(
+                [Message(role="user", content="hello")], "gpt-5.6-sol"
+            )
+        )
+
+    assert timed_out.closed, "timed-out response must be closed before retry"
+    assert ok.closed, "final response must be closed after done event"


### PR DESCRIPTION
## Problem

`gptme` was exiting with SIGSEGV (status=139) after successful runs when using the `openai-subscription` provider (`gpt-5.6-sol`). This was reproducible in PM canary sessions.

Root cause: the `_sse_events()` generator in `llm_openai_subscription.py` opens a `requests.post(stream=True)` response that holds an open SSL socket. Two paths left this socket unclosed:

1. **Early generator abandonment**: `_stream_responses_events` breaks out of its `for event in event_iter` loop when it sees a `response.done` event. Python sends `GeneratorExit` to the suspended `_sse_events` generator. Without a `try/finally`, the SSL socket was never closed.

2. **Retry without closing**: On network timeout before any events, the generator rebound `response` to a new connection without closing the old one.

Both unclosed sockets lingered in urllib3's connection pool until Python interpreter teardown, where they SIGSEGV'd when `_ssl` was finalized before the pool was GC'd.

## Fix

Wrap `_sse_events` in a `try/finally` so `response.close()` is always called — on normal return, on exception, and on `GeneratorExit` from early abandonment. In the retry exception handler, explicitly close the old response before rebinding so the socket is released immediately.

## Tests

Added two regression tests that assert `response.closed` is `True` after the stream completes:

- `test_stream_closes_response_after_done_event` — verifies the response is closed when the generator exits via a `response.done` event (the primary SIGSEGV trigger)
- `test_stream_closes_response_on_retry` — verifies both the timed-out response and the successful retry response are closed

All 25 tests pass.

Fixes #3350