### PR TITLE
feat(tui): collapsible rendering for XML and markdown tool-call formats

### DIFF
--- a/gptme/tui/app.py
+++ b/gptme/tui/app.py
@@ -94,6 +94,12 @@ _TOOL_CALL_RE = re.compile(
     re.MULTILINE | re.DOTALL,
 )
 
+# Matches XML tool-call blocks (<tool-use>...</tool-use> or <function_calls>...</function_calls>).
+_XML_TOOLUSE_RE = re.compile(
+    r"(<tool-use>.*?</tool-use>|<function_calls>.*?</function_calls>)",
+    re.DOTALL | re.IGNORECASE,
+)
+
 
 def _split_thinking(content: str) -> list[tuple[bool, str]]:
     """Split message content into (is_thinking, text) segments.
@@ -160,6 +166,109 @@ def _tool_call_renderable(call_text: str) -> tuple[str, str, str]:
     return title, code, lang
 
 
+def _split_markdown_tool_calls(content: str) -> list[tuple[bool, str]]:
+    """Split content into (is_tool, segment) pairs for markdown-format tool codeblocks.
+
+    Uses Codeblock.iter_from_markdown to find tool codeblocks (identified by their
+    language tag) and splits the raw content at those boundaries so they can be
+    rendered as collapsible sections instead of inline code fences.
+    """
+    from ..codeblock import Codeblock
+    from ..tools.base import ToolUse as _ToolUse
+
+    # Collect (start_line, codeblock) pairs for tool-call codeblocks.
+    tool_blocks: list[tuple[int, Codeblock]] = [
+        (cb.start, cb)
+        for cb in Codeblock.iter_from_markdown(content)
+        if cb.start is not None and _ToolUse._from_codeblock(cb) is not None
+    ]
+
+    if not tool_blocks:
+        return [(False, content)]
+
+    lines = content.split("\n")
+    segments: list[tuple[bool, str]] = []
+    prose_lines: list[str] = []
+    i = 0
+    # Build a dict for O(1) lookup by start line
+    blocks_by_line = dict(tool_blocks)
+
+    while i < len(lines):
+        cb = blocks_by_line.get(i)
+        if cb is not None:
+            if prose_lines:
+                prose = "\n".join(prose_lines).strip()
+                if prose:
+                    segments.append((False, prose))
+                prose_lines = []
+            cb_text = f"{cb.fence}{cb.lang}\n{cb.content}\n{cb.fence}"
+            segments.append((True, cb_text))
+            # Skip: 1 opening-fence line + N content lines + 1 closing-fence line
+            n_content = len(cb.content.splitlines()) if cb.content else 0
+            i += 2 + n_content
+        else:
+            prose_lines.append(lines[i])
+            i += 1
+
+    if prose_lines:
+        prose = "\n".join(prose_lines).strip()
+        if prose:
+            segments.append((False, prose))
+
+    return segments or [(False, content)]
+
+
+def _split_xml_tool_calls(content: str) -> list[tuple[bool, str]]:
+    """Split content into (is_tool, segment) pairs for XML-format tool-call blocks."""
+    segments: list[tuple[bool, str]] = []
+    last_end = 0
+    for m in _XML_TOOLUSE_RE.finditer(content):
+        before = content[last_end : m.start()]
+        if before.strip():
+            segments.append((False, before))
+        segments.append((True, m.group(0)))
+        last_end = m.end()
+    tail = content[last_end:]
+    if tail.strip():
+        segments.append((False, tail))
+    return segments or [(False, content)]
+
+
+def _markdown_tool_renderable(segment: str) -> tuple[str, str, str]:
+    """Parse a markdown tool codeblock into (title, code, lang) for a Collapsible."""
+    from ..codeblock import Codeblock
+
+    cb = Codeblock.from_markdown(segment)
+    code = cb.content.strip()
+    tool_name = cb.lang.split()[0] if cb.lang else "tool"
+    first_line = code.split("\n")[0].strip()
+    if len(first_line) > 55:
+        first_line = first_line[:54] + "…"
+    suffix = "…" if ("\n" in code or len(code) > 60) else ""
+    title = f"▶ {tool_name}: {first_line}{suffix}" if first_line else f"▶ {tool_name}"
+    lang = "python" if tool_name in ("ipython", "python") else "bash"
+    return title, code, lang
+
+
+def _xml_tool_renderable(segment: str) -> tuple[str, str, str]:
+    """Parse an XML tool-call block into (title, code, lang) for a Collapsible."""
+    from ..tools.base import ToolUse as _ToolUse
+
+    tool_uses = list(_ToolUse._iter_from_xml(segment))
+    if not tool_uses:
+        return "▶ tool", segment, "xml"
+    tu = tool_uses[0]
+    tool_name = tu.tool
+    code = (tu.content or "").strip()
+    first_line = code.split("\n")[0].strip()
+    if len(first_line) > 55:
+        first_line = first_line[:54] + "…"
+    suffix = "…" if ("\n" in code or len(code) > 60) else ""
+    title = f"▶ {tool_name}: {first_line}{suffix}" if first_line else f"▶ {tool_name}"
+    lang = "python" if tool_name in ("ipython", "python") else "bash"
+    return title, code, lang
+
+
 class UserMessage(Vertical):
     """A user message, rendered with a distinct border."""
 
@@ -184,13 +293,20 @@ class AssistantMessage(Vertical):
         yield Static(Text("Assistant"), classes="role")
         think_segs = _split_thinking(self.content)
         has_thinking = any(is_think for is_think, _ in think_segs)
+
+        def _has_tool_calls(text: str) -> bool:
+            if _TOOL_CALL_RE.search(text) or _XML_TOOLUSE_RE.search(text):
+                return True
+            return any(is_tool for is_tool, _ in _split_markdown_tool_calls(text))
+
         has_tool_calls = any(
-            not is_think and bool(_TOOL_CALL_RE.search(text))
-            for is_think, text in think_segs
+            not is_think and _has_tool_calls(text) for is_think, text in think_segs
         )
+
         if not has_thinking and not has_tool_calls:
             yield Markdown(self.content)
             return
+
         for is_think, text in think_segs:
             if is_think:
                 yield Collapsible(
@@ -199,10 +315,34 @@ class AssistantMessage(Vertical):
                     collapsed=True,
                     classes="thinking-block",
                 )
-            else:
+            elif _TOOL_CALL_RE.search(text):
                 for is_tool, seg in _split_tool_calls(text):
                     if is_tool:
                         title, code, lang = _tool_call_renderable(seg)
+                        yield Collapsible(
+                            Static(Syntax(code, lang, theme="ansi_dark")),
+                            title=title,
+                            collapsed=True,
+                            classes="tool-call-block",
+                        )
+                    elif seg.strip():
+                        yield Markdown(seg)
+            elif _XML_TOOLUSE_RE.search(text):
+                for is_tool, seg in _split_xml_tool_calls(text):
+                    if is_tool:
+                        title, code, lang = _xml_tool_renderable(seg)
+                        yield Collapsible(
+                            Static(Syntax(code, lang, theme="ansi_dark")),
+                            title=title,
+                            collapsed=True,
+                            classes="tool-call-block",
+                        )
+                    elif seg.strip():
+                        yield Markdown(seg)
+            else:
+                for is_tool, seg in _split_markdown_tool_calls(text):
+                    if is_tool:
+                        title, code, lang = _markdown_tool_renderable(seg)
                         yield Collapsible(
                             Static(Syntax(code, lang, theme="ansi_dark")),
                             title=title,

--- a/gptme/tui/app.py
+++ b/gptme/tui/app.py
@@ -27,6 +27,7 @@ from rich.control import Control
 from rich.markdown import Markdown as RichMarkdown
 from rich.markup import escape as markup_escape
 from rich.padding import Padding
+from rich.panel import Panel
 from rich.syntax import Syntax
 from rich.text import Text
 from textual import events
@@ -250,23 +251,27 @@ def _markdown_tool_renderable(segment: str) -> tuple[str, str, str]:
     return title, code, lang
 
 
-def _xml_tool_renderable(segment: str) -> tuple[str, str, str]:
-    """Parse an XML tool-call block into (title, code, lang) for a Collapsible."""
+def _xml_tool_renderables(segment: str) -> list[tuple[str, str, str]]:
+    """Parse an XML tool-call block into (title, code, lang) tuples, one per invoke."""
     from ..tools.base import ToolUse as _ToolUse
 
     tool_uses = list(_ToolUse._iter_from_xml(segment))
     if not tool_uses:
-        return "▶ tool", segment, "xml"
-    tu = tool_uses[0]
-    tool_name = tu.tool
-    code = (tu.content or "").strip()
-    first_line = code.split("\n")[0].strip()
-    if len(first_line) > 55:
-        first_line = first_line[:54] + "…"
-    suffix = "…" if ("\n" in code or len(code) > 60) else ""
-    title = f"▶ {tool_name}: {first_line}{suffix}" if first_line else f"▶ {tool_name}"
-    lang = "python" if tool_name in ("ipython", "python") else "bash"
-    return title, code, lang
+        return [("▶ tool", segment, "xml")]
+    result = []
+    for tu in tool_uses:
+        tool_name = tu.tool
+        code = (tu.content or "").strip()
+        first_line = code.split("\n")[0].strip()
+        if len(first_line) > 55:
+            first_line = first_line[:54] + "…"
+        suffix = "…" if ("\n" in code or len(code) > 60) else ""
+        title = (
+            f"▶ {tool_name}: {first_line}{suffix}" if first_line else f"▶ {tool_name}"
+        )
+        lang = "python" if tool_name in ("ipython", "python") else "bash"
+        result.append((title, code, lang))
+    return result
 
 
 class UserMessage(Vertical):
@@ -330,13 +335,13 @@ class AssistantMessage(Vertical):
             elif _XML_TOOLUSE_RE.search(text):
                 for is_tool, seg in _split_xml_tool_calls(text):
                     if is_tool:
-                        title, code, lang = _xml_tool_renderable(seg)
-                        yield Collapsible(
-                            Static(Syntax(code, lang, theme="ansi_dark")),
-                            title=title,
-                            collapsed=True,
-                            classes="tool-call-block",
-                        )
+                        for title, code, lang in _xml_tool_renderables(seg):
+                            yield Collapsible(
+                                Static(Syntax(code, lang, theme="ansi_dark")),
+                                title=title,
+                                collapsed=True,
+                                classes="tool-call-block",
+                            )
                     elif seg.strip():
                         yield Markdown(seg)
             else:
@@ -461,11 +466,70 @@ def renderables_for_message(msg: Message, expanded: bool = False) -> list:
             Text(),
         ]
     if msg.role == "assistant":
-        return [
-            Text("Assistant", style="bold blue"),
-            Padding(RichMarkdown(content), (0, 0, 0, 2)),
-            Text(),
-        ]
+        items: list = [Text("Assistant", style="bold blue")]
+        think_segs = _split_thinking(content)
+
+        def _has_tool(t: str) -> bool:
+            return bool(
+                _TOOL_CALL_RE.search(t)
+                or _XML_TOOLUSE_RE.search(t)
+                or any(is_tool for is_tool, _ in _split_markdown_tool_calls(t))
+            )
+
+        has_tool_calls = any(
+            not is_think and _has_tool(t) for is_think, t in think_segs
+        )
+        has_thinking = any(is_think for is_think, _ in think_segs)
+
+        if not has_tool_calls and not has_thinking:
+            items.append(Padding(RichMarkdown(content), (0, 0, 0, 2)))
+        else:
+            for is_think, text in think_segs:
+                if is_think:
+                    items.append(
+                        Panel(RichMarkdown(text), title="Thinking", expand=False)
+                    )
+                elif _TOOL_CALL_RE.search(text):
+                    for is_tool, seg in _split_tool_calls(text):
+                        if is_tool:
+                            title, code, lang = _tool_call_renderable(seg)
+                            items.append(
+                                Panel(
+                                    Syntax(code, lang, theme="ansi_dark"),
+                                    title=title,
+                                    expand=False,
+                                )
+                            )
+                        elif seg.strip():
+                            items.append(Padding(RichMarkdown(seg), (0, 0, 0, 2)))
+                elif _XML_TOOLUSE_RE.search(text):
+                    for is_tool, seg in _split_xml_tool_calls(text):
+                        if is_tool:
+                            for title, code, lang in _xml_tool_renderables(seg):
+                                items.append(
+                                    Panel(
+                                        Syntax(code, lang, theme="ansi_dark"),
+                                        title=title,
+                                        expand=False,
+                                    )
+                                )
+                        elif seg.strip():
+                            items.append(Padding(RichMarkdown(seg), (0, 0, 0, 2)))
+                else:
+                    for is_tool, seg in _split_markdown_tool_calls(text):
+                        if is_tool:
+                            title, code, lang = _markdown_tool_renderable(seg)
+                            items.append(
+                                Panel(
+                                    Syntax(code, lang, theme="ansi_dark"),
+                                    title=title,
+                                    expand=False,
+                                )
+                            )
+                        elif seg.strip():
+                            items.append(Padding(RichMarkdown(seg), (0, 0, 0, 2)))
+        items.append(Text())
+        return items
     # system/tool output: compact summary line, optionally expanded
     renderables: list = [Text(f"▶ {_summarize(content)}", style="dim")]
     if expanded:

--- a/gptme/tui/app.py
+++ b/gptme/tui/app.py
@@ -206,7 +206,18 @@ def _split_markdown_tool_calls(content: str) -> list[tuple[bool, str]]:
             segments.append((True, cb_text))
             # Skip: 1 opening-fence line + N content lines + 1 closing-fence line
             n_content = len(cb.content.splitlines()) if cb.content else 0
-            i += 2 + n_content
+            closing_line_idx = i + 1 + n_content
+            # When the closing fence is also an adjacent opening fence (e.g. ``````lang),
+            # _extract_codeblocks normalizes it in-place and keeps start_line pointing at
+            # that same raw line. Don't advance past it so the next block can be matched.
+            adjacent_opening = (
+                closing_line_idx < len(lines)
+                and lines[closing_line_idx].startswith(cb.fence)
+                and bool(
+                    re.match(r"^`{3,}\S", lines[closing_line_idx][len(cb.fence) :])
+                )
+            )
+            i = closing_line_idx if adjacent_opening else closing_line_idx + 1
         else:
             prose_lines.append(lines[i])
             i += 1

--- a/gptme/tui/app.py
+++ b/gptme/tui/app.py
@@ -274,6 +274,39 @@ def _xml_tool_renderables(segment: str) -> list[tuple[str, str, str]]:
     return result
 
 
+def _split_all_tool_calls(text: str) -> list[tuple[bool, str, str]]:
+    """Split *text* on all three tool-call formats in priority order.
+
+    Returns ``(is_tool, fmt, segment)`` triples where ``fmt`` is ``"tool"``,
+    ``"xml"``, ``"markdown"``, or ``"prose"``.  Non-tool prose from each
+    parser is fed into the next parser, so mixed-format segments are handled
+    correctly: e.g. a segment that contains both ``@tool`` calls and XML
+    ``<function_calls>`` blocks renders all of them as collapsibles.
+    """
+    out: list[tuple[bool, str, str]] = []
+    for is_t, seg1 in _split_tool_calls(text):
+        if is_t:
+            out.append((True, "tool", seg1))
+        else:
+            for is_x, seg2 in _split_xml_tool_calls(seg1):
+                if is_x:
+                    out.append((True, "xml", seg2))
+                else:
+                    for is_m, seg3 in _split_markdown_tool_calls(seg2):
+                        if is_m:
+                            out.append((True, "markdown", seg3))
+                        elif seg3.strip():
+                            out.append((False, "prose", seg3))
+    return out or [(False, "prose", text)]
+
+
+def _has_tool_calls(text: str) -> bool:
+    """Return True if *text* contains any tool call in any supported format."""
+    if _TOOL_CALL_RE.search(text) or _XML_TOOLUSE_RE.search(text):
+        return True
+    return any(is_tool for is_tool, _ in _split_markdown_tool_calls(text))
+
+
 class UserMessage(Vertical):
     """A user message, rendered with a distinct border."""
 
@@ -298,12 +331,6 @@ class AssistantMessage(Vertical):
         yield Static(Text("Assistant"), classes="role")
         think_segs = _split_thinking(self.content)
         has_thinking = any(is_think for is_think, _ in think_segs)
-
-        def _has_tool_calls(text: str) -> bool:
-            if _TOOL_CALL_RE.search(text) or _XML_TOOLUSE_RE.search(text):
-                return True
-            return any(is_tool for is_tool, _ in _split_markdown_tool_calls(text))
-
         has_tool_calls = any(
             not is_think and _has_tool_calls(text) for is_think, text in think_segs
         )
@@ -320,9 +347,11 @@ class AssistantMessage(Vertical):
                     collapsed=True,
                     classes="thinking-block",
                 )
-            elif _TOOL_CALL_RE.search(text):
-                for is_tool, seg in _split_tool_calls(text):
-                    if is_tool:
+            else:
+                for is_tool, fmt, seg in _split_all_tool_calls(text):
+                    if not is_tool:
+                        yield Markdown(seg)
+                    elif fmt == "tool":
                         title, code, lang = _tool_call_renderable(seg)
                         yield Collapsible(
                             Static(Syntax(code, lang, theme="ansi_dark")),
@@ -330,11 +359,7 @@ class AssistantMessage(Vertical):
                             collapsed=True,
                             classes="tool-call-block",
                         )
-                    elif seg.strip():
-                        yield Markdown(seg)
-            elif _XML_TOOLUSE_RE.search(text):
-                for is_tool, seg in _split_xml_tool_calls(text):
-                    if is_tool:
+                    elif fmt == "xml":
                         for title, code, lang in _xml_tool_renderables(seg):
                             yield Collapsible(
                                 Static(Syntax(code, lang, theme="ansi_dark")),
@@ -342,11 +367,7 @@ class AssistantMessage(Vertical):
                                 collapsed=True,
                                 classes="tool-call-block",
                             )
-                    elif seg.strip():
-                        yield Markdown(seg)
-            else:
-                for is_tool, seg in _split_markdown_tool_calls(text):
-                    if is_tool:
+                    else:  # markdown
                         title, code, lang = _markdown_tool_renderable(seg)
                         yield Collapsible(
                             Static(Syntax(code, lang, theme="ansi_dark")),
@@ -354,8 +375,6 @@ class AssistantMessage(Vertical):
                             collapsed=True,
                             classes="tool-call-block",
                         )
-                    elif seg.strip():
-                        yield Markdown(seg)
 
 
 class SystemMessage(Vertical):
@@ -468,16 +487,8 @@ def renderables_for_message(msg: Message, expanded: bool = False) -> list:
     if msg.role == "assistant":
         items: list = [Text("Assistant", style="bold blue")]
         think_segs = _split_thinking(content)
-
-        def _has_tool(t: str) -> bool:
-            return bool(
-                _TOOL_CALL_RE.search(t)
-                or _XML_TOOLUSE_RE.search(t)
-                or any(is_tool for is_tool, _ in _split_markdown_tool_calls(t))
-            )
-
         has_tool_calls = any(
-            not is_think and _has_tool(t) for is_think, t in think_segs
+            not is_think and _has_tool_calls(t) for is_think, t in think_segs
         )
         has_thinking = any(is_think for is_think, _ in think_segs)
 
@@ -489,9 +500,11 @@ def renderables_for_message(msg: Message, expanded: bool = False) -> list:
                     items.append(
                         Panel(RichMarkdown(text), title="Thinking", expand=False)
                     )
-                elif _TOOL_CALL_RE.search(text):
-                    for is_tool, seg in _split_tool_calls(text):
-                        if is_tool:
+                else:
+                    for is_tool, fmt, seg in _split_all_tool_calls(text):
+                        if not is_tool:
+                            items.append(Padding(RichMarkdown(seg), (0, 0, 0, 2)))
+                        elif fmt == "tool":
                             title, code, lang = _tool_call_renderable(seg)
                             items.append(
                                 Panel(
@@ -500,11 +513,7 @@ def renderables_for_message(msg: Message, expanded: bool = False) -> list:
                                     expand=False,
                                 )
                             )
-                        elif seg.strip():
-                            items.append(Padding(RichMarkdown(seg), (0, 0, 0, 2)))
-                elif _XML_TOOLUSE_RE.search(text):
-                    for is_tool, seg in _split_xml_tool_calls(text):
-                        if is_tool:
+                        elif fmt == "xml":
                             for title, code, lang in _xml_tool_renderables(seg):
                                 items.append(
                                     Panel(
@@ -513,11 +522,7 @@ def renderables_for_message(msg: Message, expanded: bool = False) -> list:
                                         expand=False,
                                     )
                                 )
-                        elif seg.strip():
-                            items.append(Padding(RichMarkdown(seg), (0, 0, 0, 2)))
-                else:
-                    for is_tool, seg in _split_markdown_tool_calls(text):
-                        if is_tool:
+                        else:  # markdown
                             title, code, lang = _markdown_tool_renderable(seg)
                             items.append(
                                 Panel(
@@ -526,8 +531,6 @@ def renderables_for_message(msg: Message, expanded: bool = False) -> list:
                                     expand=False,
                                 )
                             )
-                        elif seg.strip():
-                            items.append(Padding(RichMarkdown(seg), (0, 0, 0, 2)))
         items.append(Text())
         return items
     # system/tool output: compact summary line, optionally expanded

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -21,8 +21,10 @@ from gptme.tui.app import (
     ToolPlaceholder,
     UserMessage,
     _append_pt_history,
+    _has_tool_calls,
     _load_pt_history,
     _markdown_tool_renderable,
+    _split_all_tool_calls,
     _split_markdown_tool_calls,
     _split_thinking,
     _split_tool_calls,
@@ -1063,4 +1065,117 @@ def test_renderables_for_message_inline_multiple_xml_invokes():
     panels = [r for r in renderables if isinstance(r, Panel)]
     assert len(panels) == 2, (
         f"expected 2 Panels for 2-invoke XML block, got {len(panels)}"
+    )
+
+
+# --- _split_all_tool_calls / mixed-format tests ---
+
+
+def test_split_all_tool_calls_pure_tool_format():
+    """@tool-only segment returns (True, 'tool', seg) for the tool call."""
+    content = '@shell(abc): {"command": "ls"}'
+    result = _split_all_tool_calls(content)
+    tool_segs = [(fmt, seg) for is_t, fmt, seg in result if is_t]
+    assert len(tool_segs) == 1
+    assert tool_segs[0][0] == "tool"
+
+
+def test_split_all_tool_calls_pure_xml():
+    """XML-only segment returns (True, 'xml', seg)."""
+    content = (
+        '<function_calls>\n<invoke name="shell">\nls\n</invoke>\n</function_calls>'
+    )
+    result = _split_all_tool_calls(content)
+    tool_segs = [(fmt, seg) for is_t, fmt, seg in result if is_t]
+    assert len(tool_segs) == 1
+    assert tool_segs[0][0] == "xml"
+
+
+def test_split_all_tool_calls_pure_markdown():
+    """Markdown codeblock tool call returns (True, 'markdown', seg)."""
+    from gptme.tools import init_tools
+
+    init_tools()
+    content = "```ipython\nprint(1)\n```"
+    result = _split_all_tool_calls(content)
+    tool_segs = [(fmt, seg) for is_t, fmt, seg in result if is_t]
+    assert len(tool_segs) == 1, f"expected 1 tool seg, got: {result}"
+    assert tool_segs[0][0] == "markdown"
+
+
+def test_split_all_tool_calls_mixed_tool_and_xml():
+    """A segment with both @tool and XML tool calls detects both."""
+    content = (
+        '@shell(abc): {"command": "ls"}\n'
+        "Some prose.\n"
+        '<function_calls>\n<invoke name="ipython">\nprint(1)\n</invoke>\n</function_calls>'
+    )
+    result = _split_all_tool_calls(content)
+    formats = [fmt for is_t, fmt, _ in result if is_t]
+    assert "tool" in formats, "expected @tool format to be detected"
+    assert "xml" in formats, "expected XML format to be detected in prose segment"
+
+
+def test_split_all_tool_calls_mixed_xml_and_markdown():
+    """A segment with both XML and markdown tool calls detects both."""
+    from gptme.tools import init_tools
+
+    init_tools()
+    content = (
+        '<function_calls>\n<invoke name="shell">\nls\n</invoke>\n</function_calls>\n'
+        "Some prose.\n"
+        "```ipython\nprint(2)\n```"
+    )
+    result = _split_all_tool_calls(content)
+    formats = [fmt for is_t, fmt, _ in result if is_t]
+    assert "xml" in formats, "expected XML format to be detected"
+    assert "markdown" in formats, "expected markdown format to be detected in prose"
+
+
+def test_has_tool_calls_detects_all_formats():
+    """_has_tool_calls returns True for each of the three formats."""
+    from gptme.tools import init_tools
+
+    init_tools()
+    assert _has_tool_calls('@shell(x): {"command": "ls"}')
+    assert _has_tool_calls(
+        '<function_calls>\n<invoke name="shell">\nls\n</invoke>\n</function_calls>'
+    )
+    assert _has_tool_calls("```ipython\nprint(1)\n```")
+    assert not _has_tool_calls("Just plain prose with no tool calls.")
+
+
+@pytest.mark.asyncio
+async def test_assistant_message_mixed_tool_and_xml(tmp_path):
+    """AssistantMessage renders both @tool and XML tool calls as Collapsibles."""
+    content = (
+        '@shell(abc): {"command": "ls"}\n'
+        "Some text.\n"
+        '<function_calls>\n<invoke name="ipython">\nprint(1)\n</invoke>\n</function_calls>'
+    )
+    app = GptmeApp(make_manager(tmp_path), workspace=tmp_path)
+    async with app.run_test(size=(120, 40)) as pilot:
+        widget = AssistantMessage(content)
+        await app.mount(widget)
+        await pilot.pause()
+        collapsibles = widget.query(Collapsible)
+        assert len(collapsibles) >= 2, (
+            f"expected ≥2 Collapsibles for mixed @tool+XML content, got {len(collapsibles)}"
+        )
+
+
+def test_renderables_for_message_mixed_formats():
+    """renderables_for_message emits Panels for both @tool and XML tool calls."""
+    from rich.panel import Panel
+
+    content = (
+        '@shell(abc): {"command": "ls"}\n'
+        "Some prose.\n"
+        '<function_calls>\n<invoke name="ipython">\nprint(1)\n</invoke>\n</function_calls>'
+    )
+    msg = Message("assistant", content)
+    renderables = renderables_for_message(msg)
+    panels = [r for r in renderables if isinstance(r, Panel)]
+    assert len(panels) >= 2, (
+        f"expected ≥2 Panels for mixed @tool+XML content, got {len(panels)}"
     )

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -29,7 +29,8 @@ from gptme.tui.app import (
     _split_xml_tool_calls,
     _summarize,
     _tool_call_renderable,
-    _xml_tool_renderable,
+    _xml_tool_renderables,
+    renderables_for_message,
 )
 
 
@@ -904,13 +905,30 @@ def test_split_xml_tool_calls_no_xml():
     assert segments == [(False, content)]
 
 
-def test_xml_tool_renderable_extracts_name_and_code():
-    """_xml_tool_renderable extracts the tool name and code for display."""
+def test_xml_tool_renderables_single():
+    """_xml_tool_renderables extracts tool name and code from a single-invoke block."""
     segment = "<tool-use>\n<ipython>\nprint('hello')\n</ipython>\n</tool-use>"
-    title, code, lang = _xml_tool_renderable(segment)
+    renderables = _xml_tool_renderables(segment)
+    assert len(renderables) == 1
+    title, code, lang = renderables[0]
     assert "ipython" in title
     assert "print" in code
     assert lang == "python"
+
+
+def test_xml_tool_renderables_multiple_invokes():
+    """_xml_tool_renderables emits one tuple per <invoke> in a <function_calls> block."""
+    segment = (
+        "<function_calls>\n"
+        '<invoke name="shell">\nls /tmp\n</invoke>\n'
+        '<invoke name="ipython">\nprint(42)\n</invoke>\n'
+        "</function_calls>"
+    )
+    renderables = _xml_tool_renderables(segment)
+    assert len(renderables) == 2, f"expected 2 renderables, got {len(renderables)}"
+    titles = [t for t, _, _ in renderables]
+    assert any("shell" in t for t in titles)
+    assert any("ipython" in t for t in titles)
 
 
 def test_split_markdown_tool_calls_no_tools():
@@ -991,3 +1009,58 @@ async def test_assistant_message_renders_markdown_tool_call_as_collapsible(tmp_p
         assert any("ipython" in (t or "") for t in titles), (
             f"Expected 'ipython' in a collapsible title, got: {titles}"
         )
+
+
+# Inline mode (renderables_for_message) format detection
+# ────────────────────────────────────────────────────────
+
+
+def test_renderables_for_message_inline_xml_tool_call():
+    """renderables_for_message renders XML tool calls as Rich Panels, not raw text."""
+    from rich.panel import Panel
+
+    content = "Let me run it.\n<tool-use>\n<ipython>\nprint(1)\n</ipython>\n</tool-use>"
+    msg = Message("assistant", content)
+    renderables = renderables_for_message(msg)
+    panels = [r for r in renderables if isinstance(r, Panel)]
+    assert panels, "expected at least one Panel for XML tool call in inline mode"
+    titles = [p.title for p in panels]
+    assert any("ipython" in str(t) for t in titles), (
+        f"Expected 'ipython' in a Panel title, got: {titles}"
+    )
+
+
+def test_renderables_for_message_inline_markdown_tool_call():
+    """renderables_for_message renders markdown tool calls as Rich Panels."""
+    from rich.panel import Panel
+
+    from gptme.tools import init_tools
+
+    init_tools()
+    content = "Running:\n\n```ipython\nprint('hello')\n```\n\nDone."
+    msg = Message("assistant", content)
+    renderables = renderables_for_message(msg)
+    panels = [r for r in renderables if isinstance(r, Panel)]
+    assert panels, "expected at least one Panel for markdown tool call in inline mode"
+    titles = [p.title for p in panels]
+    assert any("ipython" in str(t) for t in titles), (
+        f"Expected 'ipython' in a Panel title, got: {titles}"
+    )
+
+
+def test_renderables_for_message_inline_multiple_xml_invokes():
+    """renderables_for_message emits one Panel per invoke in a multi-invoke XML block."""
+    from rich.panel import Panel
+
+    content = (
+        "<function_calls>\n"
+        '<invoke name="shell">\nls\n</invoke>\n'
+        '<invoke name="ipython">\nprint(2)\n</invoke>\n'
+        "</function_calls>"
+    )
+    msg = Message("assistant", content)
+    renderables = renderables_for_message(msg)
+    panels = [r for r in renderables if isinstance(r, Panel)]
+    assert len(panels) == 2, (
+        f"expected 2 Panels for 2-invoke XML block, got {len(panels)}"
+    )

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -22,10 +22,14 @@ from gptme.tui.app import (
     UserMessage,
     _append_pt_history,
     _load_pt_history,
+    _markdown_tool_renderable,
+    _split_markdown_tool_calls,
     _split_thinking,
     _split_tool_calls,
+    _split_xml_tool_calls,
     _summarize,
     _tool_call_renderable,
+    _xml_tool_renderable,
 )
 
 
@@ -865,3 +869,125 @@ def test_streaming_message_set_thinking_ignored_after_tokens():
     with patch.object(msg._body, "update") as mock_update:
         msg.set_thinking(True)
     mock_update.assert_not_called()
+
+
+# ─────────────────────────────────────────────────────────
+# Format detection across all three tool-call formats
+# ─────────────────────────────────────────────────────────
+
+
+def test_split_xml_tool_calls_basic():
+    """<tool-use> blocks are split out as tool segments."""
+    content = (
+        "Before.\n<tool-use>\n<ipython>\nprint('hi')\n</ipython>\n</tool-use>\nAfter."
+    )
+    segments = _split_xml_tool_calls(content)
+    is_tool_flags = [is_tool for is_tool, _ in segments]
+    assert True in is_tool_flags, "expected at least one tool segment"
+    tool_segs = [seg for is_tool, seg in segments if is_tool]
+    assert any("<tool-use>" in s for s in tool_segs)
+
+
+def test_split_xml_function_calls():
+    """<function_calls> blocks (Haiku format) are also split out."""
+    content = 'Run:\n<function_calls>\n<invoke name="shell">\nls\n</invoke>\n</function_calls>\nDone.'
+    segments = _split_xml_tool_calls(content)
+    tool_segs = [seg for is_tool, seg in segments if is_tool]
+    assert tool_segs, "expected function_calls block to be detected as a tool segment"
+    assert any("<function_calls>" in s for s in tool_segs)
+
+
+def test_split_xml_tool_calls_no_xml():
+    """Content with no XML tool-call blocks is returned as a single prose segment."""
+    content = "Just some plain text."
+    segments = _split_xml_tool_calls(content)
+    assert segments == [(False, content)]
+
+
+def test_xml_tool_renderable_extracts_name_and_code():
+    """_xml_tool_renderable extracts the tool name and code for display."""
+    segment = "<tool-use>\n<ipython>\nprint('hello')\n</ipython>\n</tool-use>"
+    title, code, lang = _xml_tool_renderable(segment)
+    assert "ipython" in title
+    assert "print" in code
+    assert lang == "python"
+
+
+def test_split_markdown_tool_calls_no_tools():
+    """Content with no tool-call codeblocks returns a single prose segment."""
+    content = "Just prose.\n\n```txt\nsome text block\n```\n"
+    segments = _split_markdown_tool_calls(content)
+    assert all(not is_tool for is_tool, _ in segments)
+
+
+def test_split_markdown_tool_calls_basic():
+    """A markdown ipython codeblock is detected and split as a tool segment."""
+    from gptme.tools import init_tools
+
+    init_tools()
+    content = "Before.\n\n```ipython\nprint('hello')\n```\n\nAfter."
+    segments = _split_markdown_tool_calls(content)
+    tool_segs = [seg for is_tool, seg in segments if is_tool]
+    assert tool_segs, f"expected tool segment but got: {segments}"
+    assert any("print" in seg for seg in tool_segs)
+
+
+def test_split_markdown_tool_calls_preserves_prose():
+    """Prose before and after tool codeblocks is preserved as non-tool segments."""
+    from gptme.tools import init_tools
+
+    init_tools()
+    content = "Before.\n\n```bash\necho hello\n```\n\nAfter."
+    segments = _split_markdown_tool_calls(content)
+    prose_segs = [seg for is_tool, seg in segments if not is_tool]
+    assert any("Before" in s for s in prose_segs)
+    assert any("After" in s for s in prose_segs)
+
+
+def test_markdown_tool_renderable_extracts_name_and_code():
+    """_markdown_tool_renderable returns a collapsible-ready (title, code, lang) tuple."""
+    from gptme.tools import init_tools
+
+    init_tools()
+    segment = "```ipython\nprint('world')\n```"
+    title, code, lang = _markdown_tool_renderable(segment)
+    assert "ipython" in title
+    assert "print" in code
+    assert lang == "python"
+
+
+@pytest.mark.asyncio
+async def test_assistant_message_renders_xml_tool_call_as_collapsible(tmp_path):
+    """AssistantMessage with an XML tool-use block renders a Collapsible for it."""
+    content = "Let me run that.\n<tool-use>\n<ipython>\nprint('hello')\n</ipython>\n</tool-use>"
+    app = GptmeApp(make_manager(tmp_path), workspace=tmp_path)
+    async with app.run_test() as pilot:
+        msg_widget = AssistantMessage(content)
+        await app.mount(msg_widget)
+        await pilot.pause()
+        collapsibles = msg_widget.query(Collapsible)
+        assert len(collapsibles) > 0, "Expected Collapsible for XML tool call"
+        titles = [c.title for c in collapsibles]
+        assert any("ipython" in (t or "") for t in titles), (
+            f"Expected 'ipython' in a collapsible title, got: {titles}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_assistant_message_renders_markdown_tool_call_as_collapsible(tmp_path):
+    """AssistantMessage with a markdown-format ipython block renders a Collapsible."""
+    from gptme.tools import init_tools
+
+    init_tools()
+    content = "Running code:\n\n```ipython\nprint('hello')\n```\n\nDone."
+    app = GptmeApp(make_manager(tmp_path), workspace=tmp_path)
+    async with app.run_test() as pilot:
+        msg_widget = AssistantMessage(content)
+        await app.mount(msg_widget)
+        await pilot.pause()
+        collapsibles = msg_widget.query(Collapsible)
+        assert len(collapsibles) > 0, "Expected Collapsible for markdown tool call"
+        titles = [c.title for c in collapsibles]
+        assert any("ipython" in (t or "") for t in titles), (
+            f"Expected 'ipython' in a collapsible title, got: {titles}"
+        )

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -964,6 +964,23 @@ def test_split_markdown_tool_calls_preserves_prose():
     assert any("After" in s for s in prose_segs)
 
 
+def test_split_markdown_tool_calls_adjacent_fences():
+    """Adjacent close+open fences (``````lang) yield two separate tool segments."""
+    from gptme.tools import init_tools
+
+    init_tools()
+    # Model emits closing fence immediately followed by opening fence on same line:
+    # ``````shell instead of ```\n```shell
+    content = "```shell\necho hello\n``````shell\necho world\n```"
+    segments = _split_markdown_tool_calls(content)
+    tool_segs = [seg for is_tool, seg in segments if is_tool]
+    assert len(tool_segs) == 2, (
+        f"expected 2 tool segments but got {len(tool_segs)}: {segments}"
+    )
+    assert any("echo hello" in seg for seg in tool_segs)
+    assert any("echo world" in seg for seg in tool_segs)
+
+
 def test_markdown_tool_renderable_extracts_name_and_code():
     """_markdown_tool_renderable returns a collapsible-ready (title, code, lang) tuple."""
     from gptme.tools import init_tools


### PR DESCRIPTION
Closes #3343 (Problem 3 — format detection across all three formats).

Problems 1 and 2 were fixed in #3347. This PR adds format detection and
collapsible rendering for XML and markdown tool-call formats in the TUI.

## What changed

### XML tool-call rendering (`<tool-use>` / `<function_calls>`)

- `_XML_TOOLUSE_RE` — compiled regex matching both `<tool-use>` and
  `<function_calls>` blocks (covers Anthropic XML and Haiku/Bedrock variants)
- `_split_xml_tool_calls(content)` — splits content into `(is_tool, segment)`
  pairs
- `_xml_tool_renderable(segment)` — parses via `ToolUse._iter_from_xml()` and
  returns `(title, code, lang)` for a `Collapsible`; title shows
  `▶ tool_name: first_line…`

### Markdown codeblock tool-call rendering (`` ```ipython ``, `` ```bash ``, etc.)

- `_split_markdown_tool_calls(content)` — uses `Codeblock.iter_from_markdown()`
  + `ToolUse._from_codeblock()` to detect tool codeblocks; non-tool codeblocks
  (`` ```txt ``, `` ```json ``, etc.) pass through as prose
- `_markdown_tool_renderable(segment)` — parses via `Codeblock.from_markdown()`
  and returns `(title, code, lang)` for collapsible rendering

### Integration in `AssistantMessage.compose()`

The `else` branch now tries all three paths per non-thinking segment in priority
order: `@tool` format → XML → markdown codeblocks → plain markdown. All formats
render as `Collapsible` widgets with syntax-highlighted code.

## Tests

10 new tests in `tests/test_tui.py`:
- Unit: `_split_xml_tool_calls`, `_split_markdown_tool_calls`,
  `_xml_tool_renderable`, `_markdown_tool_renderable`
- Async TUI integration: `AssistantMessage` with XML and markdown tool-call
  content mounts `Collapsible` widgets with the correct tool name in the title