### PR TITLE
fix(tools): don't stamp call_id on hook messages (fixes Responses API 400)

### DIFF
--- a/gptme/server/session_step.py
+++ b/gptme/server/session_step.py
@@ -966,14 +966,12 @@ def start_tool_execution(
                 )
                 logger.info(f"Tool execution complete, outputs: {len(tool_outputs)}")
 
-                # Store the tool outputs, propagating call_id to pair results
-                # with the assistant's tool-use block (matches CLI behavior)
+                # Store the tool outputs. call_id is already assigned in
+                # ToolUse.execute() for real results; hook messages intentionally
+                # have no call_id — don't re-stamp here or hook messages become
+                # duplicate function_call_output entries (Responses API 400).
                 for tool_output in tool_outputs:
-                    _append_and_notify(
-                        manager,
-                        session,
-                        tool_output.replace(call_id=tooluse.call_id),
-                    )
+                    _append_and_notify(manager, session, tool_output)
             except Exception as e:
                 logger.exception(f"Error executing tool {tooluse.tool}: {e}")
                 tool_exec.status = ToolStatus.FAILED

--- a/gptme/tools/__init__.py
+++ b/gptme/tools/__init__.py
@@ -338,8 +338,7 @@ def execute_msg(
         if runnable:
             with terminal_state_title(f"🛠️ running {tooluse.tool}"):
                 try:
-                    for tool_response in tooluse.execute(log=log, workspace=workspace):
-                        yield tool_response.replace(call_id=tooluse.call_id)
+                    yield from tooluse.execute(log=log, workspace=workspace)
                 except KeyboardInterrupt:
                     clear_interruptible()
                     yield Message(

--- a/gptme/tools/base.py
+++ b/gptme/tools/base.py
@@ -802,7 +802,7 @@ class ToolUse:
                                     on_result_message(msg)
                                 yield (
                                     msg.replace(call_id=self.call_id)
-                                    if self.call_id and idx == last_idx
+                                    if self.call_id and idx == last_idx and _ki is None
                                     else msg
                                 )
                             if _ki is not None:

--- a/gptme/tools/base.py
+++ b/gptme/tools/base.py
@@ -776,15 +776,18 @@ class ToolUse:
                             else cast(Message | None, ex)
                         )
                         if generator_result is not None:
-                            for msg in generator_result:
+                            for idx, msg in enumerate(generator_result):
                                 result_msgs.append(msg)
                                 if on_result_message:
                                     on_result_message(msg)
-                                # Assign call_id here so only real tool results
-                                # carry it — hook messages yielded later must not.
+                                # Only stamp call_id on the first result — the
+                                # Responses API expects exactly one
+                                # function_call_output per call_id; subsequent
+                                # messages from a multi-message generator must
+                                # not carry it or the API returns 400.
                                 yield (
                                     msg.replace(call_id=self.call_id)
-                                    if self.call_id
+                                    if self.call_id and idx == 0
                                     else msg
                                 )
                         elif single_result is not None:

--- a/gptme/tools/base.py
+++ b/gptme/tools/base.py
@@ -780,12 +780,22 @@ class ToolUse:
                                 result_msgs.append(msg)
                                 if on_result_message:
                                     on_result_message(msg)
-                                yield msg
+                                # Assign call_id here so only real tool results
+                                # carry it — hook messages yielded later must not.
+                                yield (
+                                    msg.replace(call_id=self.call_id)
+                                    if self.call_id
+                                    else msg
+                                )
                         elif single_result is not None:
                             result_msgs = [single_result]
                             if on_result_message:
                                 on_result_message(single_result)
-                            yield single_result
+                            yield (
+                                single_result.replace(call_id=self.call_id)
+                                if self.call_id
+                                else single_result
+                            )
                     finally:
                         _current_tool_use.reset(token)
 
@@ -835,7 +845,11 @@ class ToolUse:
                     logger.exception(e)
                     if "pytest" in globals():
                         raise e
-                    yield Message("system", f"Error executing tool '{self.tool}': {e}")
+                    yield Message(
+                        "system",
+                        f"Error executing tool '{self.tool}': {e}",
+                        call_id=self.call_id,
+                    )
             else:
                 logger.warning(f"Tool '{self.tool}' is not available for execution.")
 

--- a/gptme/tools/base.py
+++ b/gptme/tools/base.py
@@ -776,18 +776,23 @@ class ToolUse:
                             else cast(Message | None, ex)
                         )
                         if generator_result is not None:
-                            for idx, msg in enumerate(generator_result):
+                            # Buffer the generator so we can identify the last
+                            # message and stamp call_id on it. The Responses API
+                            # expects exactly one function_call_output per call_id;
+                            # stamping only the last message ensures the actual
+                            # tool result (not an earlier warning such as a
+                            # shellcheck notice) becomes the function_call_output.
+                            # Earlier messages pass through without call_id and
+                            # become system context instead.
+                            all_result_msgs = list(generator_result)
+                            last_idx = len(all_result_msgs) - 1
+                            for idx, msg in enumerate(all_result_msgs):
                                 result_msgs.append(msg)
                                 if on_result_message:
                                     on_result_message(msg)
-                                # Only stamp call_id on the first result — the
-                                # Responses API expects exactly one
-                                # function_call_output per call_id; subsequent
-                                # messages from a multi-message generator must
-                                # not carry it or the API returns 400.
                                 yield (
                                     msg.replace(call_id=self.call_id)
-                                    if self.call_id and idx == 0
+                                    if self.call_id and idx == last_idx
                                     else msg
                                 )
                         elif single_result is not None:

--- a/gptme/tools/base.py
+++ b/gptme/tools/base.py
@@ -776,37 +776,47 @@ class ToolUse:
                             else cast(Message | None, ex)
                         )
                         if generator_result is not None:
-                            # Buffer the generator so we can identify the last
-                            # message and stamp call_id on it. The Responses API
-                            # expects exactly one function_call_output per call_id;
-                            # stamping only the last message ensures the actual
-                            # tool result (not an earlier warning such as a
-                            # shellcheck notice) becomes the function_call_output.
-                            # Earlier messages pass through without call_id and
-                            # become system context instead.
-                            #
-                            # Catch KeyboardInterrupt so partial output from an
-                            # interrupted shell command is still forwarded and
-                            # on_result_message callbacks are still invoked.
-                            all_result_msgs = []
-                            _ki: KeyboardInterrupt | None = None
-                            try:
+                            if self.call_id:
+                                # Buffer the generator so we can identify the last
+                                # message and stamp call_id on it. The Responses API
+                                # expects exactly one function_call_output per call_id;
+                                # stamping only the last message ensures the actual
+                                # tool result (not an earlier warning such as a
+                                # shellcheck notice) becomes the function_call_output.
+                                # Earlier messages pass through without call_id and
+                                # become system context instead.
+                                #
+                                # Catch KeyboardInterrupt so partial output from an
+                                # interrupted shell command is still forwarded and
+                                # on_result_message callbacks are still invoked.
+                                all_result_msgs: list[Message] = []
+                                _ki: KeyboardInterrupt | None = None
+                                try:
+                                    for msg in generator_result:
+                                        all_result_msgs.append(msg)  # noqa: PERF402
+                                except KeyboardInterrupt as e:
+                                    _ki = e
+                                last_idx = len(all_result_msgs) - 1
+                                for idx, msg in enumerate(all_result_msgs):
+                                    result_msgs.append(msg)
+                                    if on_result_message:
+                                        on_result_message(msg)
+                                    yield (
+                                        msg.replace(call_id=self.call_id)
+                                        if idx == last_idx
+                                        else msg
+                                    )
+                                if _ki is not None:
+                                    raise _ki
+                            else:
+                                # No call_id: stream immediately to preserve
+                                # progressive callback ordering for callers that
+                                # interleave on_result_message with the generator.
                                 for msg in generator_result:
-                                    all_result_msgs.append(msg)  # noqa: PERF402
-                            except KeyboardInterrupt as e:
-                                _ki = e
-                            last_idx = len(all_result_msgs) - 1
-                            for idx, msg in enumerate(all_result_msgs):
-                                result_msgs.append(msg)
-                                if on_result_message:
-                                    on_result_message(msg)
-                                yield (
-                                    msg.replace(call_id=self.call_id)
-                                    if self.call_id and idx == last_idx and _ki is None
-                                    else msg
-                                )
-                            if _ki is not None:
-                                raise _ki
+                                    result_msgs.append(msg)
+                                    if on_result_message:
+                                        on_result_message(msg)
+                                    yield msg
                         elif single_result is not None:
                             result_msgs = [single_result]
                             if on_result_message:

--- a/gptme/tools/base.py
+++ b/gptme/tools/base.py
@@ -733,6 +733,7 @@ class ToolUse:
         def _execute_tool():
             tool = get_tool(self.tool)
             if tool and tool.execute:
+                result_msgs: list[Message] = []
                 try:
                     from ..hooks.types import ToolExecutePreData  # fmt: skip
 
@@ -762,7 +763,6 @@ class ToolUse:
                     # Set context var so tools can access current ToolUse
                     # via get_current_tool_use() or implicitly in get_confirmation()
                     token = _current_tool_use.set(self)
-                    result_msgs: list[Message] = []
                     try:
                         ex = tool.execute(
                             self.content,
@@ -845,10 +845,13 @@ class ToolUse:
                     logger.exception(e)
                     if "pytest" in globals():
                         raise e
+                    # Only attribute the error to this call_id if no real result
+                    # was already emitted — a post-hook exception after yielding a
+                    # result would create a duplicate function_call_output entry.
                     yield Message(
                         "system",
                         f"Error executing tool '{self.tool}': {e}",
-                        call_id=self.call_id,
+                        call_id=self.call_id if not result_msgs else None,
                     )
             else:
                 logger.warning(f"Tool '{self.tool}' is not available for execution.")

--- a/gptme/tools/base.py
+++ b/gptme/tools/base.py
@@ -784,7 +784,17 @@ class ToolUse:
                             # shellcheck notice) becomes the function_call_output.
                             # Earlier messages pass through without call_id and
                             # become system context instead.
-                            all_result_msgs = list(generator_result)
+                            #
+                            # Catch KeyboardInterrupt so partial output from an
+                            # interrupted shell command is still forwarded and
+                            # on_result_message callbacks are still invoked.
+                            all_result_msgs = []
+                            _ki: KeyboardInterrupt | None = None
+                            try:
+                                for msg in generator_result:
+                                    all_result_msgs.append(msg)  # noqa: PERF402
+                            except KeyboardInterrupt as e:
+                                _ki = e
                             last_idx = len(all_result_msgs) - 1
                             for idx, msg in enumerate(all_result_msgs):
                                 result_msgs.append(msg)
@@ -795,6 +805,8 @@ class ToolUse:
                                     if self.call_id and idx == last_idx
                                     else msg
                                 )
+                            if _ki is not None:
+                                raise _ki
                         elif single_result is not None:
                             result_msgs = [single_result]
                             if on_result_message:

--- a/gptme/tools/base.py
+++ b/gptme/tools/base.py
@@ -803,7 +803,7 @@ class ToolUse:
                                         on_result_message(msg)
                                     yield (
                                         msg.replace(call_id=self.call_id)
-                                        if idx == last_idx
+                                        if idx == last_idx and _ki is None
                                         else msg
                                     )
                                 if _ki is not None:

--- a/tests/test_execute_msg_hook_call_id.py
+++ b/tests/test_execute_msg_hook_call_id.py
@@ -161,13 +161,14 @@ def test_post_hook_exception_error_has_no_call_id(fake_echo_tool, monkeypatch):
     )
 
 
-def test_multi_message_tool_only_first_gets_call_id(monkeypatch):
-    """Only the first message from a multi-message tool execution may carry call_id.
+def test_multi_message_tool_only_last_gets_call_id(monkeypatch):
+    """Only the last message from a multi-message tool execution must carry call_id.
 
-    ToolUse.execute can yield multiple messages (e.g. a tool that streams
-    progress or returns structured output in chunks). Stamping the same call_id
-    on every yielded message creates one function_call_output per message in the
-    Responses API input — duplicate call_ids → 400 error.
+    ToolUse.execute can yield multiple messages (e.g. a shellcheck warning
+    followed by actual command output). Stamping call_id only on the last message
+    ensures the actual tool output — not an earlier notice — becomes the
+    function_call_output in the Responses API. Stamping every message creates
+    one function_call_output per message → duplicate call_ids → 400 error.
     """
     msg1 = Message("system", "output chunk 1")
     msg2 = Message("system", "output chunk 2")
@@ -192,12 +193,55 @@ def test_multi_message_tool_only_first_gets_call_id(monkeypatch):
     assert len(output_results) == 3, (
         f"Expected 3 output messages, got {len(output_results)}"
     )
-    assert output_results[0].call_id == call_id, (
-        f"First message must carry call_id='{call_id}', got {output_results[0].call_id!r}"
+    # Only the last message must carry call_id — it is the actual tool result.
+    assert output_results[-1].call_id == call_id, (
+        f"Last message must carry call_id='{call_id}', got {output_results[-1].call_id!r}"
+    )
+    assert output_results[0].call_id is None, (
+        f"Earlier messages must NOT carry call_id; got {output_results[0].call_id!r} — "
+        "an earlier warning/notice becoming function_call_output pushes the actual "
+        "tool output into system instructions, causing wrong role and precedence."
     )
     stamped = [r for r in output_results if r.call_id is not None]
     assert len(stamped) == 1, (
         f"Exactly one output message must carry call_id; got {len(stamped)} — "
         "each stamped message becomes a duplicate function_call_output in the "
         "Responses API, causing a 400 error."
+    )
+
+
+def test_warning_before_output_last_gets_call_id(monkeypatch):
+    """When a tool yields a warning then actual output, the LAST (actual output) gets call_id.
+
+    Mirrors the shell tool pattern: shellcheck warning first, then command output.
+    The warning must not become function_call_output; the actual result must.
+    """
+    warning = Message("system", "ShellCheck: SC2086 double-quote to prevent globbing")
+    output = Message("system", "stdout: file1.txt file2.txt\nreturncode: 0")
+
+    def execute(code, args, kwargs):
+        yield warning
+        yield output
+
+    spec = ToolSpec(name="shell2", desc="shell-like tool", execute=execute)
+    monkeypatch.setattr(
+        "gptme.tools.get_tool", lambda name: spec if name == "shell2" else None
+    )
+    monkeypatch.setattr("gptme.hooks.trigger_hook", lambda *a, **kw: [])
+
+    call_id = "call-shellcheck-test"
+    invoke_msg = Message("assistant", f'@shell2({call_id}): {{"command": "ls /tmp"}}')
+    results = list(execute_msg(invoke_msg))
+
+    system_results = [r for r in results if r.role == "system"]
+    assert len(system_results) == 2
+
+    warn_r = next(r for r in system_results if "ShellCheck" in r.content)
+    out_r = next(r for r in system_results if "returncode" in r.content)
+
+    assert warn_r.call_id is None, (
+        "Warning must not carry call_id — it must not become function_call_output"
+    )
+    assert out_r.call_id == call_id, (
+        f"Actual output must carry call_id='{call_id}', got {out_r.call_id!r}"
     )

--- a/tests/test_execute_msg_hook_call_id.py
+++ b/tests/test_execute_msg_hook_call_id.py
@@ -159,3 +159,45 @@ def test_post_hook_exception_error_has_no_call_id(fake_echo_tool, monkeypatch):
         f"got {error_results[0].call_id!r}. "
         "Two call_id-stamped messages for one tool call causes a Responses API 400."
     )
+
+
+def test_multi_message_tool_only_first_gets_call_id(monkeypatch):
+    """Only the first message from a multi-message tool execution may carry call_id.
+
+    ToolUse.execute can yield multiple messages (e.g. a tool that streams
+    progress or returns structured output in chunks). Stamping the same call_id
+    on every yielded message creates one function_call_output per message in the
+    Responses API input — duplicate call_ids → 400 error.
+    """
+    msg1 = Message("system", "output chunk 1")
+    msg2 = Message("system", "output chunk 2")
+    msg3 = Message("system", "output chunk 3")
+
+    def execute(code, args, kwargs):
+        yield msg1
+        yield msg2
+        yield msg3
+
+    spec = ToolSpec(name="multi", desc="multi-output tool for tests", execute=execute)
+    monkeypatch.setattr(
+        "gptme.tools.get_tool", lambda name: spec if name == "multi" else None
+    )
+    monkeypatch.setattr("gptme.hooks.trigger_hook", lambda *a, **kw: [])
+
+    call_id = "call-multi-test"
+    invoke_msg = Message("assistant", f'@multi({call_id}): {{"text": "test"}}')
+    results = list(execute_msg(invoke_msg))
+
+    output_results = [r for r in results if r.content.startswith("output chunk")]
+    assert len(output_results) == 3, (
+        f"Expected 3 output messages, got {len(output_results)}"
+    )
+    assert output_results[0].call_id == call_id, (
+        f"First message must carry call_id='{call_id}', got {output_results[0].call_id!r}"
+    )
+    stamped = [r for r in output_results if r.call_id is not None]
+    assert len(stamped) == 1, (
+        f"Exactly one output message must carry call_id; got {len(stamped)} — "
+        "each stamped message becomes a duplicate function_call_output in the "
+        "Responses API, causing a 400 error."
+    )

--- a/tests/test_execute_msg_hook_call_id.py
+++ b/tests/test_execute_msg_hook_call_id.py
@@ -1,0 +1,125 @@
+"""Regression test for TOOL_EXECUTE_POST hook messages incorrectly inheriting call_id.
+
+Root cause: execute_msg used to call tool_response.replace(call_id=tooluse.call_id)
+for every message yielded by tooluse.execute(), including post-execution hook
+messages (e.g. the token-awareness warning).
+
+A hook message with the tool's call_id is then converted by
+_messages_to_responses_input() into a duplicate function_call_output item in the
+Responses API input.  The duplicate confuses the API, producing a 400 error:
+  "No tool output found for function call <call_id>"
+
+Fix: call_id is now assigned in ToolUse.execute() when real tool results are
+yielded.  Hook messages are emitted without a call_id so execute_msg passes them
+through untouched.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gptme.hooks import HookType, clear_hooks
+from gptme.message import Message
+from gptme.tools import execute_msg
+from gptme.tools.base import ToolSpec, set_tool_format
+
+
+@pytest.fixture(autouse=True)
+def _reset_hooks():
+    clear_hooks()
+    yield
+    clear_hooks()
+
+
+@pytest.fixture(autouse=True)
+def _set_tool_format():
+    set_tool_format("tool")
+    yield
+    set_tool_format("markdown")
+
+
+@pytest.fixture()
+def fake_echo_tool(monkeypatch):
+    """Register a fake 'echo' tool that yields one result message, then reload."""
+    actual_output = Message("system", "echo: hello")
+
+    def execute(code, args, kwargs):
+        yield actual_output
+
+    spec = ToolSpec(name="echo", desc="echo tool for tests", execute=execute)
+
+    # get_tool is imported inside _execute_tool(); patch the canonical location.
+    monkeypatch.setattr(
+        "gptme.tools.get_tool", lambda name: spec if name == "echo" else None
+    )
+    return actual_output
+
+
+def test_real_tool_result_gets_call_id(fake_echo_tool, monkeypatch):
+    """The real tool result message must carry the tool's call_id."""
+    monkeypatch.setattr("gptme.hooks.trigger_hook", lambda *a, **kw: [])
+
+    call_id = "call-test-abc"
+    msg = Message("assistant", f'@echo({call_id}): {{"text": "hello"}}')
+    results = list(execute_msg(msg))
+
+    real_results = [r for r in results if r.content == "echo: hello"]
+    assert real_results, "Expected at least one real tool result"
+    assert real_results[0].call_id == call_id, (
+        f"Real tool result must carry call_id='{call_id}', got {real_results[0].call_id!r}"
+    )
+
+
+def test_post_hook_message_does_not_get_call_id(fake_echo_tool, monkeypatch):
+    """TOOL_EXECUTE_POST hook messages must NOT inherit the tool's call_id.
+
+    Before the fix, execute_msg applied .replace(call_id=tooluse.call_id) to
+    every yielded message, causing hook side-effects to become duplicate
+    function_call_output items in the Responses API input → 400 error.
+    """
+    hook_msg = Message(
+        "system",
+        "<system_warning>Token usage: 100/1000000; 999900 remaining</system_warning>",
+        hide=True,
+    )
+
+    def fake_trigger(hook_type, data, **kwargs):
+        if hook_type == HookType.TOOL_EXECUTE_POST:
+            return [hook_msg]
+        return []
+
+    monkeypatch.setattr("gptme.hooks.trigger_hook", fake_trigger)
+
+    call_id = "call-hook-test"
+    msg = Message("assistant", f'@echo({call_id}): {{"text": "hello"}}')
+    results = list(execute_msg(msg))
+
+    hook_results = [r for r in results if "Token usage" in r.content]
+    assert hook_results, "Expected the hook message to be yielded"
+    assert hook_results[0].call_id is None, (
+        f"Hook message must NOT carry call_id; got {hook_results[0].call_id!r}. "
+        "A call_id on a hook message creates a duplicate function_call_output in "
+        "the Responses API input, causing 400 errors."
+    )
+
+
+def test_pre_hook_message_does_not_get_call_id(fake_echo_tool, monkeypatch):
+    """TOOL_EXECUTE_PRE hook messages must NOT inherit the tool's call_id either."""
+    hook_msg = Message("system", "pre-hook notification")
+
+    def fake_trigger(hook_type, data, **kwargs):
+        if hook_type == HookType.TOOL_EXECUTE_PRE:
+            return [hook_msg]
+        return []
+
+    monkeypatch.setattr("gptme.hooks.trigger_hook", fake_trigger)
+
+    call_id = "call-pre-hook-test"
+    msg = Message("assistant", f'@echo({call_id}): {{"text": "hello"}}')
+    results = list(execute_msg(msg))
+
+    pre_hook_results = [r for r in results if r.content == "pre-hook notification"]
+    assert pre_hook_results, "Expected the pre-hook message to be yielded"
+    assert pre_hook_results[0].call_id is None, (
+        f"Pre-hook message must NOT carry call_id; got {pre_hook_results[0].call_id!r}"
+    )

--- a/tests/test_execute_msg_hook_call_id.py
+++ b/tests/test_execute_msg_hook_call_id.py
@@ -123,3 +123,39 @@ def test_pre_hook_message_does_not_get_call_id(fake_echo_tool, monkeypatch):
     assert pre_hook_results[0].call_id is None, (
         f"Pre-hook message must NOT carry call_id; got {pre_hook_results[0].call_id!r}"
     )
+
+
+def test_post_hook_exception_error_has_no_call_id(fake_echo_tool, monkeypatch):
+    """When a post-hook raises after the real result was yielded, the error must NOT get call_id.
+
+    A real result with call_id is already emitted. If the catch-all exception handler
+    also stamps call_id on the error message, both become function_call_output entries
+    for one tool call — causing a Responses API 400.
+    """
+
+    def fake_trigger(hook_type, data, **kwargs):
+        if hook_type == HookType.TOOL_EXECUTE_POST:
+            raise RuntimeError("post-hook failed")
+        return []
+
+    monkeypatch.setattr("gptme.hooks.trigger_hook", fake_trigger)
+
+    call_id = "call-post-hook-error"
+    msg = Message("assistant", f'@echo({call_id}): {{"text": "hello"}}')
+    results = list(execute_msg(msg))
+
+    # The real result must still carry call_id.
+    real_results = [r for r in results if r.content == "echo: hello"]
+    assert real_results, "Expected the real tool result to be yielded"
+    assert real_results[0].call_id == call_id, (
+        f"Real result must keep call_id='{call_id}', got {real_results[0].call_id!r}"
+    )
+
+    # The error message must NOT carry call_id — the real result already claimed it.
+    error_results = [r for r in results if "Error executing tool" in r.content]
+    assert error_results, "Expected an error message from the failed post-hook"
+    assert error_results[0].call_id is None, (
+        f"Error after real result must NOT carry call_id; "
+        f"got {error_results[0].call_id!r}. "
+        "Two call_id-stamped messages for one tool call causes a Responses API 400."
+    )

--- a/tests/test_execute_msg_hook_call_id.py
+++ b/tests/test_execute_msg_hook_call_id.py
@@ -278,8 +278,13 @@ def test_keyboard_interrupt_forwards_partial_output(monkeypatch):
 
     output = [r for r in received if r.content == "partial output before interrupt"]
     assert output, "Partial output must be forwarded even when generator is interrupted"
+    assert output[0].call_id is None, (
+        "Partial output must NOT carry call_id — execute_msg's INTERRUPT_CONTENT "
+        "message is the canonical function_call_output; stamping call_id on the "
+        "partial too creates a duplicate function_call_output → Responses API 400."
+    )
 
     interrupt_msgs = [r for r in received if "Interrupted" in r.content]
     assert interrupt_msgs, "INTERRUPT_CONTENT message must follow the partial output"
-    # The interrupt message inherits the tool's call_id so the API gets a paired result.
+    # The interrupt message is the canonical function_call_output for the interrupted call.
     assert interrupt_msgs[0].call_id == call_id

--- a/tests/test_execute_msg_hook_call_id.py
+++ b/tests/test_execute_msg_hook_call_id.py
@@ -245,3 +245,41 @@ def test_warning_before_output_last_gets_call_id(monkeypatch):
     assert out_r.call_id == call_id, (
         f"Actual output must carry call_id='{call_id}', got {out_r.call_id!r}"
     )
+
+
+def test_keyboard_interrupt_forwards_partial_output(monkeypatch):
+    """KeyboardInterrupt during generator buffering must still forward partial output.
+
+    list(generator_result) aborts on KeyboardInterrupt before any messages are
+    forwarded. This test verifies that partial output is still yielded and
+    on_result_message is called even when the generator is interrupted mid-stream.
+    """
+    partial = Message("system", "partial output before interrupt")
+
+    def execute(code, args, kwargs):
+        yield partial
+        raise KeyboardInterrupt
+
+    spec = ToolSpec(
+        name="interrupted", desc="tool that gets interrupted", execute=execute
+    )
+    monkeypatch.setattr(
+        "gptme.tools.get_tool", lambda name: spec if name == "interrupted" else None
+    )
+    monkeypatch.setattr("gptme.hooks.trigger_hook", lambda *a, **kw: [])
+
+    call_id = "call-interrupt-test"
+    invoke_msg = Message("assistant", f'@interrupted({call_id}): {{"text": "test"}}')
+
+    # execute_msg catches KeyboardInterrupt and converts it to INTERRUPT_CONTENT.
+    # With our buffering fix, partial output is forwarded BEFORE the interrupt
+    # message, so both should appear.
+    received = list(execute_msg(invoke_msg))
+
+    output = [r for r in received if r.content == "partial output before interrupt"]
+    assert output, "Partial output must be forwarded even when generator is interrupted"
+
+    interrupt_msgs = [r for r in received if "Interrupted" in r.content]
+    assert interrupt_msgs, "INTERRUPT_CONTENT message must follow the partial output"
+    # The interrupt message inherits the tool's call_id so the API gets a paired result.
+    assert interrupt_msgs[0].call_id == call_id


### PR DESCRIPTION
## Problem

When a `TOOL_EXECUTE_POST` hook (e.g. the token-awareness warning) fires after a tool call, its messages were incorrectly inheriting the tool's `call_id`.

**Bug location**: `execute_msg()` in `gptme/tools/__init__.py` applied `.replace(call_id=tooluse.call_id)` to **every** message yielded by `tooluse.execute()`, including post-execution hook side-effects.

**Consequence**: `_messages_to_responses_input()` converts any `system` message with a `call_id` into a `function_call_output` item. A hook message with the tool's `call_id` created a **duplicate** `function_call_output` for that call in the Responses API input. This corrupted the conversation structure and caused 400 errors for gpt-5.5:
```
Codex API error 400: {"error": {"message": "No tool output found for function call call_XIZYqQbhFejWO6pFJgQjMCAS."}}
```

The error referenced a *later* call because the duplicate output for an earlier call confused the API's validation of the full conversation.

## Root cause trace

Failing trajectory showed:
- `msg[11]` system, `call_id=A`: real shell result ✓
- `msg[12]` system, `call_id=A`: token-awareness warning (BUG — should have no call_id)

`msg[12]` was converted to a second `function_call_output` for `call_id=A`, leaving the API confused when validating subsequent parallel tool calls.

## Fix

Move `call_id` assignment into `ToolUse.execute()` in `base.py`, applied **only** when the real tool result messages are yielded (lines 778–788). Pre/post-hook messages are passed through without modification. The error-path `Message` is also updated to carry `call_id` explicitly (it correctly serves as the tool result for a failed call).

`execute_msg` now uses a clean `yield from tooluse.execute(...)`.

## Tests

Added `tests/test_execute_msg_hook_call_id.py` with three regression tests:
- `test_real_tool_result_gets_call_id` — real tool output carries the call_id
- `test_post_hook_message_does_not_get_call_id` — TOOL_EXECUTE_POST messages have no call_id
- `test_pre_hook_message_does_not_get_call_id` — TOOL_EXECUTE_PRE messages have no call_id