### PR TITLE
fix(logmanager): enforce call_id atomicity in limit_log for Responses API

### DIFF
--- a/gptme/logmanager/manager.py
+++ b/gptme/logmanager/manager.py
@@ -45,7 +45,12 @@ from ..message import Message, _migrate_metadata, len_tokens, print_msg
 from ..tools import ToolUse
 from ..util.context import enrich_messages_with_context
 from ..util.conversation_ids import conversation_id_error, validate_conversation_id
-from ..util.reduce import limit_log, proactive_summarize_log, reduce_log
+from ..util.reduce import (
+    _drop_orphaned_tool_pairs,
+    limit_log,
+    proactive_summarize_log,
+    reduce_log,
+)
 from ..util.uri import URI
 from . import eventlog
 
@@ -736,69 +741,6 @@ def prune_ephemeral_messages(msgs: list[Message]) -> list[Message]:
     pruned = _drop_orphaned_tool_pairs(msgs, pruned)
 
     return _merge_consecutive_messages(pruned)
-
-
-def _drop_orphaned_tool_pairs(
-    original: list[Message],
-    pruned: list[Message],
-) -> list[Message]:
-    """Drop messages that form broken tool call / tool result pairs.
-
-    Two directions are handled, iterating until stable:
-
-    Case 1 — orphaned tool result: a system message with call_id whose
-    nearest non-system predecessor in *original* was dropped by the TTL
-    prune.  Keeping it without the function call causes Responses-API 400.
-
-    Case 2 — orphaned function call: an assistant message immediately
-    followed (in *original*) by one or more system messages with call_id,
-    where at least one of those results is missing from *pruned*.  Keeping
-    the function call without all its outputs also triggers 400.
-    """
-    if not any(m.call_id for m in original):
-        return pruned
-
-    orig_idx = {id(m): i for i, m in enumerate(original)}
-    kept_ids = {id(m) for m in pruned}
-
-    changed = True
-    while changed:
-        changed = False
-        to_remove: set[int] = set()
-
-        for msg in pruned:
-            mid = id(msg)
-            if mid not in kept_ids or mid in to_remove:
-                continue
-            idx = orig_idx.get(mid)
-            if idx is None:
-                continue
-
-            if msg.role == "system" and msg.call_id:
-                # Case 1: walk backward to find nearest non-system anchor.
-                for j in range(idx - 1, -1, -1):
-                    if original[j].role != "system":
-                        if id(original[j]) not in kept_ids:
-                            to_remove.add(mid)
-                            changed = True
-                        break
-
-            elif msg.role == "assistant":
-                # Case 2: walk forward to find immediately following tool
-                # results; if any are missing, drop the function call too.
-                for j in range(idx + 1, len(original)):
-                    nxt = original[j]
-                    if nxt.role == "system" and nxt.call_id:
-                        if id(nxt) not in kept_ids:
-                            to_remove.add(mid)
-                            changed = True
-                            break
-                    elif nxt.role != "system":
-                        break
-
-        kept_ids -= to_remove
-
-    return [m for m in pruned if id(m) in kept_ids]
 
 
 def _merge_consecutive_messages(msgs: list[Message]) -> list[Message]:

--- a/gptme/util/reduce.py
+++ b/gptme/util/reduce.py
@@ -463,6 +463,72 @@ def proactive_summarize_log(
     return result
 
 
+def _drop_orphaned_tool_pairs(
+    original: list[Message],
+    pruned: list[Message],
+) -> list[Message]:
+    """Drop messages that form broken tool call / tool result pairs.
+
+    Two directions are handled, iterating until stable:
+
+    Case 1 — orphaned tool result: a system message with call_id whose
+    nearest non-system predecessor in *original* was dropped.  Keeping
+    it without the function call causes Responses-API 400.
+
+    Case 2 — orphaned function call: an assistant message immediately
+    followed (in *original*) by one or more system messages with call_id,
+    where at least one of those results is missing from *pruned*.  Keeping
+    the function call without all its outputs also triggers 400.
+
+    Used both by ``limit_log`` (context-limit truncation) and
+    ``prune_ephemeral_messages`` (TTL-based pruning) in logmanager.
+    """
+    if not any(m.call_id for m in original):
+        return pruned
+
+    orig_idx = {id(m): i for i, m in enumerate(original)}
+    kept_ids = {id(m) for m in pruned}
+
+    changed = True
+    while changed:
+        changed = False
+        to_remove: set[int] = set()
+
+        for msg in pruned:
+            mid = id(msg)
+            if mid not in kept_ids or mid in to_remove:
+                continue
+            idx = orig_idx.get(mid)
+            if idx is None:
+                continue
+
+            if msg.role == "system" and msg.call_id:
+                # Case 1: walk backward to find nearest non-system anchor.
+                for j in range(idx - 1, -1, -1):
+                    if original[j].role != "system":
+                        if id(original[j]) not in kept_ids:
+                            to_remove.add(mid)
+                            changed = True
+                        break
+
+            elif msg.role == "assistant":
+                # Case 2: walk forward to find immediately following tool
+                # results; if any are missing, drop the function call too.
+                for j in range(idx + 1, len(original)):
+                    nxt = original[j]
+                    if nxt.role == "system" and nxt.call_id:
+                        if id(nxt) not in kept_ids:
+                            to_remove.add(mid)
+                            changed = True
+                            break
+                    elif nxt.role != "system":
+                        break
+
+        kept_ids -= to_remove
+
+    return [m for m in pruned if id(m) in kept_ids]
+
+
 def limit_log(log: list[Message]) -> list[Message]:
     """
     Picks messages until the total number of tokens exceeds limit,
@@ -493,11 +559,10 @@ def limit_log(log: list[Message]) -> list[Message]:
 
     result = initial_system_msgs + list(reversed(msgs))
 
-    # Ensure tool_use/tool_result atomicity: if a non-initial system message's
-    # immediate predecessor in the original log was dropped by the context limit,
-    # drop the system message too. System messages that follow a dropped message
-    # are almost certainly orphaned tool results — keeping them without their
-    # tool-use anchor produces an incoherent log.
+    # Pass 1 — drop non-call_id system messages whose anchor was removed.
+    # These are gptme-native tool results (markdown format, no call_id).
+    # System messages that follow a dropped non-system message are orphaned
+    # tool results; keeping them without their anchor produces an incoherent log.
     result_id_set = {id(m) for m in result}
     log_by_id = {id(m): i for i, m in enumerate(log)}
     initial_id_set = {id(m) for m in initial_system_msgs}
@@ -508,16 +573,19 @@ def limit_log(log: list[Message]) -> list[Message]:
         idx = log_by_id.get(id(msg))
         if idx is None or idx == 0:
             return False
-        # Walk backward through the original log to find the nearest
-        # non-system anchor message. System messages are tool results;
-        # their anchor is the assistant (or user) message that produced
-        # them. If that anchor was dropped by the context limit, this
-        # result is orphaned.
         for j in range(idx - 1, -1, -1):
             if log[j].role != "system":
                 return id(log[j]) not in result_id_set
-        # No non-system predecessor found — shouldn't happen for a
-        # non-initial system message, but treat as not orphaned.
         return False
 
-    return [m for m in result if not _is_orphaned(m)]
+    result = [m for m in result if not _is_orphaned(m)]
+
+    # Pass 2 — enforce Responses-API call_id atomicity.
+    # _is_orphaned above catches orphaned tool *results* (Case 1), but misses
+    # the inverse: an assistant message that kept some call_id results but
+    # lost others.  The API rejects any function_call without all its
+    # matching function_call_outputs.  _drop_orphaned_tool_pairs handles
+    # both directions (and is idempotent with pass 1 for call_id messages).
+    result = _drop_orphaned_tool_pairs(log, result)
+
+    return result

--- a/tests/test_reduce.py
+++ b/tests/test_reduce.py
@@ -385,6 +385,64 @@ def test_limit_log_cascading_orphans():
         )
 
 
+def test_limit_log_partial_call_id_results_dropped():
+    """limit_log must drop assistant when only SOME of its call_id results survive.
+
+    Scenario (Responses-API format):
+    - assistant has 2 function calls: call_id_A and call_id_B
+    - context limit causes the OLDER tool result (call_id_A) to be the
+      message that pushed the budget over, so it gets popped
+    - call_id_B result AND the assistant both survive the initial cut
+    - _is_orphaned misses this: call_id_B's anchor (assistant) is still present
+    - Without the fix: API receives function_call(A)+function_call(B) but only
+      function_call_output(B) → 400 "No tool output found for call_A"
+    - With the fix: _drop_orphaned_tool_pairs detects that assistant has a
+      call_id_A result missing from the result → drops assistant + remaining result
+
+    This reproduces the gptme-gpt-5.5 44% infra-failure-rate root cause
+    (session 96d3, 2026-07-17).
+    """
+    from gptme.llm.models.resolution import _default_model_var
+
+    original_model = _default_model_var.get()
+    try:
+        # Context=11: fits system prompt (2 tok) + call_B result (1 tok)
+        # + assistant (7 tok) = 10 tok; adding call_A result (1 tok) = 11 => over.
+        # So the oldest message in msgs (call_A result, added last in reverse) is popped.
+        tiny_model = ModelMeta(provider="unknown", model="gpt-4", context=11)
+        set_default_model(tiny_model)
+
+        # Assistant message with @tool(call_id): format (Responses API)
+        # Two function calls with distinct call_ids.
+        assistant_content = "@shell(call_A): {}\n@shell(call_B): {}"
+        msgs = [
+            Message("system", "system prompt"),  # 2 tok — initial, always kept
+            Message("assistant", assistant_content),  # ~7 tok — tool use with 2 calls
+            Message("system", "result_A", call_id="call_A"),  # 1 tok — result for A
+            Message("system", "result_B", call_id="call_B"),  # 1 tok — result for B
+        ]
+
+        result = limit_log(msgs)
+
+        result_contents = [m.content for m in result]
+        # Neither partial result should survive without the assistant.
+        # The assistant must also be absent (it has an incomplete pair).
+        assert "result_A" not in result_contents, (
+            "Orphaned call_id_A result should be dropped"
+        )
+        assert "result_B" not in result_contents, (
+            "call_id_B result must be dropped too — its assistant was dropped"
+        )
+        assert assistant_content not in result_contents, (
+            "Assistant with incomplete call_id pair must be dropped"
+        )
+        assert any(m.content == "system prompt" for m in result)
+    finally:
+        set_default_model(original_model) if original_model else _default_model_var.set(
+            None
+        )
+
+
 # ---------------------------------------------------------------------------
 # Tests for proactive_summarize_log
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Moves `_drop_orphaned_tool_pairs` from `logmanager/manager.py` to `util/reduce.py` so it can be shared by both `limit_log` and `prune_ephemeral_messages`
- Applies it as a second pass in `limit_log`: Pass 1 drops non-call_id system messages whose anchor was removed; Pass 2 enforces Responses-API call_id atomicity (drops any `function_call` whose paired `function_call_output` was truncated away)
- Adds a regression test for the integrated `limit_log` atomicity behaviour

## Background

gptme:gpt-5.5 sessions were seeing ~44% infra-failure rate with errors:
```
"No tool output found for function call call_XIZYqQ..." (HTTP 400)
```

The Responses API (Codex / ChatGPT subscription path) requires that every `function_call` item in the conversation has a matching `function_call_output`. When `limit_log` truncates the conversation to fit the context window, it can drop a tool result while leaving the assistant function-call behind — the API rejects this with 400.

Pass 1 (`_is_orphaned`) catches orphaned tool results whose anchor assistant was dropped. Pass 2 (`_drop_orphaned_tool_pairs`) catches the complementary case: an assistant message whose call_id results were truncated. Both passes now share the implementation from `util/reduce.py`.

## Test plan

- [x] `pytest tests/test_reduce.py` — 29 tests pass, including new `test_limit_log_partial_call_id_results_dropped`
- [x] Pre-commit hooks pass (prek)