### PR TITLE
ci(build): add docker/metadata-action for gptme-server image labels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,6 +92,10 @@ jobs:
       uses: docker/metadata-action@v5
       with:
         images: ghcr.io/${{ env.OWNER_LC }}/gptme-server
+        # Use git CLI context so org.opencontainers.image.revision reflects
+        # the checked-out commit SHA, not github.sha (which is the dispatch
+        # event's SHA and diverges when a tag is checked out explicitly).
+        context: git
         tags: |
           type=raw,value=${{ env.DOCKER_EXTRA_TAG }}
           type=raw,value=${{ env.SANITIZED_REF_NAME }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,13 +84,24 @@ jobs:
         context: .
         push: true
 
+    # Derive OCI labels (created/version/revision/source) for the server image so
+    # downstream consumers (e.g. gptme-cloud's image-bump automation) can read
+    # build metadata directly off the image instead of guessing "unknown".
+    - name: Docker meta (server)
+      id: meta-server
+      uses: docker/metadata-action@v5
+      with:
+        images: ghcr.io/${{ env.OWNER_LC }}/gptme-server
+        tags: |
+          type=raw,value=${{ env.DOCKER_EXTRA_TAG }}
+          type=raw,value=${{ env.SANITIZED_REF_NAME }}
+
     # Build and push server image
     - name: Build and push Docker image (server)
       uses: docker/build-push-action@v7
       with:
-        tags: |
-          ghcr.io/${{ env.OWNER_LC }}/gptme-server:${{ env.DOCKER_EXTRA_TAG }}
-          ghcr.io/${{ env.OWNER_LC }}/gptme-server:${{ env.SANITIZED_REF_NAME }}
+        tags: ${{ steps.meta-server.outputs.tags }}
+        labels: ${{ steps.meta-server.outputs.labels }}
         file: ./scripts/Dockerfile.server
         context: .
         build-args: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,14 +72,24 @@ jobs:
         context: .
         push: false
 
+    # Derive OCI labels for the base image (same pattern as server)
+    - name: Docker meta (base)
+      id: meta-base
+      uses: docker/metadata-action@v5
+      with:
+        images: ghcr.io/${{ env.OWNER_LC }}/gptme
+        context: git
+        tags: |
+          type=raw,value=${{ env.DOCKER_EXTRA_TAG }}
+          type=raw,value=${{ env.SANITIZED_REF_NAME }}
+
     # Push base image to registry if on master/tag
     - name: Push Docker image (base)
       uses: docker/build-push-action@v7
       if: env.SHOULD_PUSH == 'true'
       with:
-        tags: |
-          ghcr.io/${{ env.OWNER_LC }}/gptme:${{ env.DOCKER_EXTRA_TAG }}
-          ghcr.io/${{ env.OWNER_LC }}/gptme:${{ env.SANITIZED_REF_NAME }}
+        tags: ${{ steps.meta-base.outputs.tags }}
+        labels: ${{ steps.meta-base.outputs.labels }}
         file: ./scripts/Dockerfile
         context: .
         push: true
@@ -112,13 +122,23 @@ jobs:
           BASE=gptme:latest
         push: ${{ env.SHOULD_PUSH }}
 
+    # Derive OCI labels for the eval image (same pattern as server)
+    - name: Docker meta (eval)
+      id: meta-eval
+      uses: docker/metadata-action@v5
+      with:
+        images: ghcr.io/${{ env.OWNER_LC }}/gptme-eval
+        context: git
+        tags: |
+          type=raw,value=${{ env.DOCKER_EXTRA_TAG }}
+          type=raw,value=${{ env.SANITIZED_REF_NAME }}
+
     # Build and push eval image
     - name: Build and push Docker image (eval)
       uses: docker/build-push-action@v7
       with:
-        tags: |
-          ghcr.io/${{ env.OWNER_LC }}/gptme-eval:${{ env.DOCKER_EXTRA_TAG }}
-          ghcr.io/${{ env.OWNER_LC }}/gptme-eval:${{ env.SANITIZED_REF_NAME }}
+        tags: ${{ steps.meta-eval.outputs.tags }}
+        labels: ${{ steps.meta-eval.outputs.labels }}
         file: ./scripts/Dockerfile.eval
         context: .
         push: ${{ env.SHOULD_PUSH }}


### PR DESCRIPTION
## Summary

The `build.yml` Docker job never set OCI image labels
(`org.opencontainers.image.{created,version,revision,source}`) on the pushed
images. Downstream consumers that read those labels off the manifest (e.g.
gptme-cloud's automated image-bump workflow) got empty values and had to fall
back to `unknown` / running the container to query the version at runtime.

This adds a `docker/metadata-action` step ahead of the `gptme-server` build/push
step and wires its `tags`/`labels` outputs into `docker/build-push-action`. The
action derives `org.opencontainers.image.created` (build timestamp),
`.revision` (git SHA), `.version` (from the git ref), and `.source` (repo URL)
automatically from the workflow's git context — no extra container run needed.

Scoped to the `gptme-server` image only, since that's the one gptme-cloud
consumes and pins. The base (`gptme`) and `gptme-eval` images still use static
tag lists; happy to extend the same pattern to them in a follow-up if useful.

Refs gptme-cloud#773 (comment asking for this), gptme-cloud#775 (the
gptme-cloud-side workaround this makes unnecessary going forward).

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — workflow YAML parses
- [ ] CI on this PR builds the `gptme-server` image (push only happens on
      `master`/tags, so the push step itself won't run on the PR branch — the
      build step still validates the action wiring)
- [ ] After merge, verify the next `gptme-server:dev`/`:latest` push carries the
      new labels: `docker buildx imagetools inspect ghcr.io/gptme/gptme-server:latest --format '{{json .Image.Config.Labels}}'`