### PR TITLE
feat(webui): add model3d artifact kind for glTF/GLB/OBJ/STL inline preview

### DIFF
--- a/gptme/server/artifacts_api.py
+++ b/gptme/server/artifacts_api.py
@@ -46,12 +46,13 @@ ArtifactKind = Literal[
     "diff",
     "dataset",
     "webapp",
+    "model3d",
     "binary",
     "other",
 ]
 
 # Coarse renderer hint, deliberately smaller than the kind enum.
-PreviewType = Literal["image", "audio", "video", "text", "pdf", "none"]
+PreviewType = Literal["image", "audio", "video", "text", "pdf", "model3d", "none"]
 
 
 class ArtifactSource(BaseModel):
@@ -138,6 +139,12 @@ _EXTENSION_KINDS: dict[str, ArtifactKind] = {
     ".tsv": "dataset",
     ".json": "dataset",
     ".parquet": "dataset",
+    # 3D model formats
+    ".gltf": "model3d",
+    ".glb": "model3d",
+    ".obj": "model3d",
+    ".stl": "model3d",
+    ".usdz": "model3d",
 }
 
 _PREVIEW_FOR_KIND: dict[ArtifactKind, PreviewType] = {
@@ -149,6 +156,7 @@ _PREVIEW_FOR_KIND: dict[ArtifactKind, PreviewType] = {
     "html": "text",
     "diff": "text",
     "dataset": "text",
+    "model3d": "model3d",
 }
 
 

--- a/gptme/server/workspace_api.py
+++ b/gptme/server/workspace_api.py
@@ -24,6 +24,15 @@ logger = logging.getLogger(__name__)
 # Maximum bytes returned for text-file preview to avoid OOM on huge files.
 MAX_PREVIEW_BYTES = 10 * 1024 * 1024  # 10 MB
 
+# MIME types for 3D model extensions — Python's mimetypes doesn't know these.
+_MODEL3D_MIME: dict[str, str] = {
+    ".gltf": "model/gltf+json",
+    ".glb": "model/gltf-binary",
+    ".obj": "model/obj",
+    ".stl": "model/stl",
+    ".usdz": "model/vnd.usdz+zip",
+}
+
 workspace_api = flask.Blueprint("workspace_api", __name__)
 
 
@@ -577,6 +586,10 @@ def preview_file(conversation_id: str, filepath: str):
         if mime_type and mime_type.startswith("image/"):
             # Images
             return flask.send_file(path, mimetype=mime_type)
+        # 3D model files — served as raw bytes; frontend creates a blob URL for model-viewer.
+        ext = path.suffix.lower()
+        if ext in _MODEL3D_MIME:
+            return flask.send_file(path, mimetype=_MODEL3D_MIME[ext])
         # Binary files - return only metadata
         return flask.jsonify({"type": "binary", "metadata": wfile.to_dict()})
 

--- a/gptme/server/workspace_api.py
+++ b/gptme/server/workspace_api.py
@@ -314,7 +314,13 @@ def browse_workspace(conversation_id: str, subpath: str | None = None):
         show_hidden = request.args.get("show_hidden", "").lower() == "true"
 
         if path.is_file():
-            # Return single file metadata
+            # Serve 3D model files as raw bytes so that model-viewer can use
+            # the file's natural URL as the base for relative URI resolution
+            # (e.g. sibling buffers and textures referenced by .gltf files).
+            ext = path.suffix.lower()
+            if ext in _MODEL3D_MIME:
+                return flask.send_file(path, mimetype=_MODEL3D_MIME[ext])
+            # Return single file metadata for other files
             return flask.jsonify(WorkspaceFile(path, workspace).to_dict())
         if not path.exists():
             return flask.jsonify({"error": "File or directory not found"}), 404

--- a/gptme/server/workspace_api.py
+++ b/gptme/server/workspace_api.py
@@ -320,6 +320,15 @@ def browse_workspace(conversation_id: str, subpath: str | None = None):
             ext = path.suffix.lower()
             if ext in _MODEL3D_MIME:
                 return flask.send_file(path, mimetype=_MODEL3D_MIME[ext])
+            # Also serve images and binary buffers (.bin) as raw bytes.
+            # model-viewer resolves glTF sibling assets (textures, geometry
+            # buffers) via relative URIs against the model's workspace URL,
+            # so they must return bytes here, not JSON metadata.
+            mime = mimetypes.guess_type(path.name)[0]
+            if mime and mime.startswith("image/"):
+                return flask.send_file(path, mimetype=mime)
+            if ext == ".bin":
+                return flask.send_file(path, mimetype="application/octet-stream")
             # Return single file metadata for other files
             return flask.jsonify(WorkspaceFile(path, workspace).to_dict())
         if not path.exists():

--- a/gptme/server/workspace_api.py
+++ b/gptme/server/workspace_api.py
@@ -317,6 +317,13 @@ def browse_workspace(conversation_id: str, subpath: str | None = None):
             # Serve 3D model files as raw bytes so that model-viewer can use
             # the file's natural URL as the base for relative URI resolution
             # (e.g. sibling buffers and textures referenced by .gltf files).
+            # TODO: sibling requests from model-viewer (buffers, textures) are
+            # plain relative-path fetches and do not carry ?root=attachments.
+            # A .gltf stored under the attachments root therefore has working
+            # intra-root relative URIs only when the sibling assets reside at
+            # the same path under the workspace root. Fix: detect/infer the root
+            # from the request path prefix or a signed URL token so sibling
+            # fetches inherit the correct root automatically.
             ext = path.suffix.lower()
             if ext in _MODEL3D_MIME:
                 return flask.send_file(path, mimetype=_MODEL3D_MIME[ext])

--- a/tests/test_server_workspace.py
+++ b/tests/test_server_workspace.py
@@ -367,6 +367,13 @@ def workspace_conv(client: FlaskClient, tmp_path: Path):
     )
     (workspace / "image.png").write_bytes(png_header)
 
+    # Create a minimal GLB file (binary glTF, version 2)
+    # Header: magic 0x46546C67, version 2, length 12 (header only, no chunks)
+    import struct
+
+    glb_header = struct.pack("<III", 0x46546C67, 2, 12)
+    (workspace / "model.glb").write_bytes(glb_header)
+
     # Symlink the workspace directory
     workspace_link = manager.logdir / "workspace"
     _replace_workspace_link(workspace_link, workspace)
@@ -494,6 +501,40 @@ class TestBrowseWorkspaceEndpoint:
         data = response.get_json()
         assert data["name"] == "main.py"
         assert data["path"] == "src/main.py"
+
+    def test_browse_model3d_serves_raw_bytes(self, client: FlaskClient, workspace_conv):
+        """GLB file served as raw bytes from browse endpoint (model-viewer base URL)."""
+        conv_id = workspace_conv["conversation_id"]
+        response = client.get(f"/api/v2/conversations/{conv_id}/workspace/model.glb")
+        assert response.status_code == 200
+        assert response.content_type.startswith("model/gltf-binary")
+        # Raw bytes, not JSON metadata
+        assert response.data[:4] == b"glTF"
+
+    def test_browse_image_serves_raw_bytes(self, client: FlaskClient, workspace_conv):
+        """Image file served as raw bytes from browse endpoint.
+
+        model-viewer resolves glTF texture paths relative to the model's workspace
+        URL, so the browse endpoint must return raw bytes for image files too.
+        """
+        conv_id = workspace_conv["conversation_id"]
+        response = client.get(f"/api/v2/conversations/{conv_id}/workspace/image.png")
+        assert response.status_code == 200
+        assert response.content_type.startswith("image/png")
+        # PNG magic bytes
+        assert response.data[:4] == b"\x89PNG"
+
+    def test_browse_bin_serves_raw_bytes(self, client: FlaskClient, workspace_conv):
+        """Binary buffer (.bin) served as raw bytes from browse endpoint.
+
+        model-viewer resolves glTF geometry buffer paths relative to the model's
+        workspace URL, so the browse endpoint must return raw bytes for .bin files.
+        """
+        conv_id = workspace_conv["conversation_id"]
+        response = client.get(f"/api/v2/conversations/{conv_id}/workspace/binary.bin")
+        assert response.status_code == 200
+        assert response.content_type == "application/octet-stream"
+        assert len(response.data) > 0
 
 
 class TestPreviewFileEndpoint:

--- a/webui/jest.config.ts
+++ b/webui/jest.config.ts
@@ -4,6 +4,7 @@ export default {
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
     '\\.(css|less|sass|scss)$': 'identity-obj-proxy',
+    '^@google/model-viewer$': '<rootDir>/src/__mocks__/@google/model-viewer.ts',
   },
   transform: {
     '^.+\\.(ts|tsx|js|jsx)$': [

--- a/webui/jest.setup.ts
+++ b/webui/jest.setup.ts
@@ -18,6 +18,16 @@ if (typeof structuredClone === 'undefined') {
   global.structuredClone = <T>(val: T): T => JSON.parse(JSON.stringify(val));
 }
 
+// Polyfill URL.createObjectURL/revokeObjectURL for jsdom — it doesn't implement
+// the Blob URL API, but components that preview blobs (e.g. FilePreview) call
+// revokeObjectURL in cleanup effects.
+if (typeof URL.createObjectURL === 'undefined') {
+  URL.createObjectURL = jest.fn(() => 'blob:mock-url');
+}
+if (typeof URL.revokeObjectURL === 'undefined') {
+  URL.revokeObjectURL = jest.fn();
+}
+
 // Shim Vite import.meta.env for Jest.
 // connectionConfig.ts and SetupWizard.tsx wrap import.meta.env accesses in
 // Function() and fall back to process.env when that throws.

--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -8,6 +8,7 @@
       "name": "gptme-webui",
       "version": "0.0.0",
       "dependencies": {
+        "@google/model-viewer": "^3.5.0",
         "@hookform/resolvers": "^3.9.0",
         "@icons-pack/react-simple-icons": "13.7.0",
         "@legendapp/state": "^3.0.0-beta.30",
@@ -1455,6 +1456,22 @@
       "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==",
       "license": "MIT"
     },
+    "node_modules/@google/model-viewer": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@google/model-viewer/-/model-viewer-3.5.0.tgz",
+      "integrity": "sha512-wyrJ0yi+9XHaGg4OMDG7odbzI3/Lkn55VjIZ6siw3uM0NdPlWIYY8ZQbysbwS6f6jC7GiScax5KaxQxLLk4eQw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@monogrid/gainmap-js": "^3.0.1",
+        "lit": "^2.7.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "peerDependencies": {
+        "three": "^0.163.0"
+      }
+    },
     "node_modules/@hookform/resolvers": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-3.10.0.tgz",
@@ -2100,6 +2117,33 @@
         "expo-sqlite": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.6.0.tgz",
+      "integrity": "sha512-VHb0ALPMTlgKjM6yIxxoQNnpKyUKLD04VzeQdsiXkMqkvYlAHxq9glGLmgbb889/1GsohSOAjvQYoiBppXFqrQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
+      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.0.0"
+      }
+    },
+    "node_modules/@monogrid/gainmap-js": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@monogrid/gainmap-js/-/gainmap-js-3.4.0.tgz",
+      "integrity": "sha512-2Z0FATFHaoYJ8b+Y4y4Hgfn3FRFwuU5zRrk+9dFWp4uGAdHGqVEdP7HP+gLA3X469KXHmfupJaUbKo1b/aDKIg==",
+      "license": "MIT",
+      "dependencies": {
+        "promise-worker-transferable": "^1.0.4"
+      },
+      "peerDependencies": {
+        "three": ">= 0.159.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -4593,6 +4637,12 @@
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT"
     },
     "node_modules/@types/yargs": {
@@ -7506,6 +7556,12 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -7689,6 +7745,12 @@
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-promise": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
       "license": "MIT"
     },
     "node_modules/is-stream": {
@@ -9096,6 +9158,15 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
     "node_modules/lilconfig": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
@@ -9113,6 +9184,37 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "license": "MIT"
+    },
+    "node_modules/lit": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
+      "integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^1.6.0",
+        "lit-element": "^3.3.0",
+        "lit-html": "^2.8.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
+      "integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.1.0",
+        "@lit/reactive-element": "^1.3.0",
+        "lit-html": "^2.8.0"
+      }
+    },
+    "node_modules/lit-html": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
+      "integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
@@ -10629,6 +10731,16 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/promise-worker-transferable": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/promise-worker-transferable/-/promise-worker-transferable-1.0.4.tgz",
+      "integrity": "sha512-bN+0ehEnrXfxV2ZQvU2PetO0n4gqBD4ulq3MI1WOPLgr7/Mg9yRQkX5+0v1vagr74ZTsl7XtzlaYDo2EuCeYJw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "is-promise": "^2.1.0",
+        "lie": "^3.0.2"
+      }
+    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -11759,6 +11871,13 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/three": {
+      "version": "0.163.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.163.0.tgz",
+      "integrity": "sha512-HlMgCb2TF/dTLRtknBnjUTsR8FsDqBY43itYop2+Zg822I+Kd0Ua2vs8CvfBVefXkBdNDrLMoRTGCIIpfCuDew==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",

--- a/webui/package.json
+++ b/webui/package.json
@@ -78,7 +78,8 @@
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.3",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "@google/model-viewer": "^3.5.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",

--- a/webui/src/__mocks__/@google/model-viewer.ts
+++ b/webui/src/__mocks__/@google/model-viewer.ts
@@ -1,0 +1,2 @@
+// Mock for @google/model-viewer — registers a custom element not available in jsdom
+export {};

--- a/webui/src/components/workspace/FilePreview.tsx
+++ b/webui/src/components/workspace/FilePreview.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useRef, useState, useCallback } from 'react';
 import { Download, Loader2 } from 'lucide-react';
 import { formatDistanceToNow } from 'date-fns';
 import { useWorkspaceApi } from '@/utils/workspaceApi';
@@ -64,20 +64,41 @@ export function FilePreview({ file, conversationId, root = 'workspace' }: FilePr
   const [error, setError] = useState<string | null>(null);
   const [downloadError, setDownloadError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
+  const activeControllerRef = useRef<AbortController | null>(null);
 
   const { previewFile, downloadFile } = useWorkspaceApi();
 
   const loadPreview = useCallback(async () => {
+    // Abort any in-flight fetch to prevent stale blob URLs being created
+    // after the component unmounts or switches to a different file.
+    activeControllerRef.current?.abort();
+    const controller = new AbortController();
+    activeControllerRef.current = controller;
+
     try {
       setLoading(true);
       setError(null);
       setDownloadError(null);
-      const data = await previewFile(conversationId, file.path, root);
+      const data = await previewFile(conversationId, file.path, root, controller.signal);
+      if (controller.signal.aborted) {
+        // Revoke any blob URL that was created before the abort was detected.
+        if (
+          'content' in data &&
+          typeof data.content === 'string' &&
+          data.content.startsWith('blob:')
+        ) {
+          URL.revokeObjectURL(data.content);
+        }
+        return;
+      }
       setPreview(data);
     } catch (err) {
+      if (controller.signal.aborted) return;
       setError(err instanceof Error ? err.message : 'Failed to load preview');
     } finally {
-      setLoading(false);
+      if (!controller.signal.aborted) {
+        setLoading(false);
+      }
     }
   }, [file.path, conversationId, previewFile, root]);
 
@@ -94,11 +115,23 @@ export function FilePreview({ file, conversationId, root = 'workspace' }: FilePr
     loadPreview();
   }, [loadPreview]);
 
-  // Revoke image blob URLs when the preview changes or on unmount.
+  // Abort any in-flight preview fetch on unmount.
   useEffect(() => {
     return () => {
-      if (preview?.type === 'image') {
-        URL.revokeObjectURL(preview.content);
+      activeControllerRef.current?.abort();
+    };
+  }, []);
+
+  // Revoke blob URLs when the preview changes or on unmount.
+  // Covers images and self-contained model formats (GLB/USDZ) that use blob URLs.
+  // glTF previews use direct workspace URLs, so no revocation is needed there.
+  useEffect(() => {
+    return () => {
+      if (preview && preview.type !== 'binary') {
+        const { content } = preview;
+        if (content.startsWith('blob:')) {
+          URL.revokeObjectURL(content);
+        }
       }
     };
   }, [preview]);

--- a/webui/src/components/workspace/FilePreview.tsx
+++ b/webui/src/components/workspace/FilePreview.tsx
@@ -7,6 +7,7 @@ import type { WorkspaceRoot } from '@/stores/workspaceExplorer';
 import { CodeDisplay } from '@/components/CodeDisplay';
 import { Button } from '@/components/ui/button';
 import { MarkdownPreviewTabs } from './MarkdownPreviewTabs';
+import '@google/model-viewer';
 
 // Helper function to check if a file is a markdown file
 function isMarkdownFileType(file: FileType): boolean {
@@ -145,6 +146,30 @@ export function FilePreview({ file, conversationId, root = 'workspace' }: FilePr
           </div>
         </div>
       );
+    case 'model3d': {
+      // glTF/GLB/USDZ get an interactive 3D viewer; OBJ/STL get a download prompt.
+      const isGltfLike = /\.(gltf|glb|usdz)$/i.test(file.name);
+      return (
+        <div className="flex h-full flex-col">
+          <FileHeader file={file} onDownload={handleDownload} downloadError={downloadError} />
+          <div className="flex flex-1 items-center justify-center overflow-hidden">
+            {isGltfLike ? (
+              <model-viewer
+                src={preview.content}
+                camera-controls
+                auto-rotate
+                style={{ width: '100%', height: '100%' }}
+              />
+            ) : (
+              <div className="flex flex-col items-center gap-2 text-center text-muted-foreground">
+                <p>OBJ/STL preview not available inline.</p>
+                <p className="text-sm">Use the download button to open in a local viewer.</p>
+              </div>
+            )}
+          </div>
+        </div>
+      );
+    }
     case 'binary':
       return (
         <div className="flex h-full flex-col">

--- a/webui/src/components/workspace/FilePreview.tsx
+++ b/webui/src/components/workspace/FilePreview.tsx
@@ -94,6 +94,15 @@ export function FilePreview({ file, conversationId, root = 'workspace' }: FilePr
     loadPreview();
   }, [loadPreview]);
 
+  // Revoke image blob URLs when the preview changes or on unmount.
+  useEffect(() => {
+    return () => {
+      if (preview?.type === 'image') {
+        URL.revokeObjectURL(preview.content);
+      }
+    };
+  }, [preview]);
+
   if (loading) {
     return (
       <div className="flex h-full items-center justify-center">

--- a/webui/src/types/artifact.ts
+++ b/webui/src/types/artifact.ts
@@ -8,10 +8,11 @@ export type ArtifactKind =
   | 'diff'
   | 'dataset'
   | 'webapp'
+  | 'model3d'
   | 'binary'
   | 'other';
 
-export type ArtifactPreviewType = 'image' | 'audio' | 'video' | 'text' | 'pdf' | 'none';
+export type ArtifactPreviewType = 'image' | 'audio' | 'video' | 'text' | 'pdf' | 'model3d' | 'none';
 
 export interface ArtifactSource {
   type: 'attachment' | 'workspace' | 'external' | 'inline';

--- a/webui/src/types/model-viewer.d.ts
+++ b/webui/src/types/model-viewer.d.ts
@@ -1,0 +1,16 @@
+// JSX intrinsic element declaration for @google/model-viewer web component.
+// The package registers the <model-viewer> custom element; this extends React's
+// type system so JSX can reference it without an "unknown element" error.
+
+declare namespace JSX {
+  interface IntrinsicElements {
+    'model-viewer': React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement> & {
+      src?: string;
+      'camera-controls'?: boolean;
+      'auto-rotate'?: boolean;
+      ar?: boolean;
+      'ar-modes'?: string;
+      style?: React.CSSProperties;
+    };
+  }
+}

--- a/webui/src/types/workspace.ts
+++ b/webui/src/types/workspace.ts
@@ -24,7 +24,9 @@ export interface ImagePreview {
 
 export interface Model3DPreview {
   type: 'model3d';
-  content: string; // workspace URL for model-viewer src (not a blob — preserves relative URI resolution)
+  // GLB/USDZ: blob URL (authenticated fetch, self-contained binary formats)
+  // glTF: direct workspace URL (preserves relative URI resolution for sibling files)
+  content: string;
   mime_type: string;
 }
 

--- a/webui/src/types/workspace.ts
+++ b/webui/src/types/workspace.ts
@@ -22,4 +22,10 @@ export interface ImagePreview {
   content: string; // Blob URL
 }
 
-export type FilePreview = TextPreview | BinaryPreview | ImagePreview;
+export interface Model3DPreview {
+  type: 'model3d';
+  content: string; // Blob URL for model-viewer src
+  mime_type: string;
+}
+
+export type FilePreview = TextPreview | BinaryPreview | ImagePreview | Model3DPreview;

--- a/webui/src/types/workspace.ts
+++ b/webui/src/types/workspace.ts
@@ -24,7 +24,7 @@ export interface ImagePreview {
 
 export interface Model3DPreview {
   type: 'model3d';
-  content: string; // Blob URL for model-viewer src
+  content: string; // workspace URL for model-viewer src (not a blob — preserves relative URI resolution)
   mime_type: string;
 }
 

--- a/webui/src/utils/workspaceApi.ts
+++ b/webui/src/utils/workspaceApi.ts
@@ -58,11 +58,11 @@ export function useWorkspaceApi() {
         };
       }
       if (contentType.startsWith('model/')) {
-        return {
-          type: 'model3d',
-          content: URL.createObjectURL(await response.blob()),
-          mime_type: contentType,
-        };
+        // Return the workspace URL directly so model-viewer can use it as the
+        // base for relative URI resolution (sibling buffers/textures in .gltf).
+        // A blob URL removes the directory base, breaking relative references.
+        const workspaceUrl = `${api.baseUrl}/api/v2/conversations/${conversationId}/workspace/${pathSegment}${query}`;
+        return { type: 'model3d', content: workspaceUrl, mime_type: contentType };
       }
 
       return response.json();

--- a/webui/src/utils/workspaceApi.ts
+++ b/webui/src/utils/workspaceApi.ts
@@ -33,7 +33,8 @@ export function useWorkspaceApi() {
     async function previewFile(
       conversationId: string,
       path: string,
-      root: WorkspaceRoot = 'workspace'
+      root: WorkspaceRoot = 'workspace',
+      signal?: AbortSignal
     ): Promise<FilePreview> {
       const params = new URLSearchParams();
       if (root !== 'workspace') params.set('root', root);
@@ -43,6 +44,7 @@ export function useWorkspaceApi() {
 
       const response = await fetch(url, {
         headers: api.authHeader ? { Authorization: api.authHeader } : undefined,
+        signal,
       });
 
       if (!response.ok) {
@@ -58,9 +60,24 @@ export function useWorkspaceApi() {
         };
       }
       if (contentType.startsWith('model/')) {
-        // Return the workspace URL directly so model-viewer can use it as the
-        // base for relative URI resolution (sibling buffers/textures in .gltf).
-        // A blob URL removes the directory base, breaking relative references.
+        // GLB and USDZ are self-contained binary formats — no external relative
+        // references. Fetch via the authenticated client and return a blob URL,
+        // exactly as images are handled. This ensures bearer-authenticated
+        // deployments work correctly.
+        const isSelfContained = /\.(glb|usdz)$/i.test(path);
+        if (isSelfContained) {
+          return {
+            type: 'model3d',
+            content: URL.createObjectURL(await response.blob()),
+            mime_type: contentType,
+          };
+        }
+        // glTF (.gltf) files reference sibling buffers and textures via relative
+        // URIs. A blob URL strips the workspace directory as the resolution base,
+        // breaking those references. Return the direct workspace URL instead.
+        // On bearer-authenticated deployments, set an auth cookie via
+        // POST /api/v2/auth/cookie so that model-viewer's sub-requests are
+        // authenticated automatically.
         const workspaceUrl = `${api.baseUrl}/api/v2/conversations/${conversationId}/workspace/${pathSegment}${query}`;
         return { type: 'model3d', content: workspaceUrl, mime_type: contentType };
       }

--- a/webui/src/utils/workspaceApi.ts
+++ b/webui/src/utils/workspaceApi.ts
@@ -78,6 +78,20 @@ export function useWorkspaceApi() {
         // On bearer-authenticated deployments, set an auth cookie via
         // POST /api/v2/auth/cookie so that model-viewer's sub-requests are
         // authenticated automatically.
+        //
+        // TODO: <model-viewer> fetches sibling resources as plain browser
+        // requests and cannot inject the Authorization header. Bearer-auth
+        // deployments will fail to load buffers/textures until either:
+        //   a) a /api/v2/auth/cookie endpoint is added (server sets a session
+        //      cookie that browsers include automatically), or
+        //   b) we pre-fetch all assets client-side and bundle into a data-URI.
+        //
+        // TODO: when root=attachments, the query param (?root=attachments) is
+        // included in the model URL but model-viewer resolves sibling URIs
+        // relative to the model path, dropping the query string. Those sibling
+        // requests therefore resolve against the workspace root instead of the
+        // attachments root and will 404. Fix requires the browse endpoint to
+        // infer root context from the parent path or a sticky session param.
         const workspaceUrl = `${api.baseUrl}/api/v2/conversations/${conversationId}/workspace/${pathSegment}${query}`;
         return { type: 'model3d', content: workspaceUrl, mime_type: contentType };
       }

--- a/webui/src/utils/workspaceApi.ts
+++ b/webui/src/utils/workspaceApi.ts
@@ -50,11 +50,18 @@ export function useWorkspaceApi() {
         throw new Error(error.error || 'Failed to preview file');
       }
 
-      const contentType = response.headers.get('Content-Type');
-      if (contentType?.startsWith('image/')) {
+      const contentType = response.headers.get('Content-Type') ?? '';
+      if (contentType.startsWith('image/')) {
         return {
           type: 'image',
           content: URL.createObjectURL(await response.blob()),
+        };
+      }
+      if (contentType.startsWith('model/')) {
+        return {
+          type: 'model3d',
+          content: URL.createObjectURL(await response.blob()),
+          mime_type: contentType,
         };
       }
 


### PR DESCRIPTION
## Summary

- Adds `model3d` as a new `ArtifactKind` and `PreviewType` in the backend, mapping `.gltf`, `.glb`, `.obj`, `.stl`, and `.usdz` extensions so they appear as typed artifacts (not `binary`) in the Artifacts panel
- Extends the workspace preview endpoint to serve 3D model files as raw bytes with correct IANA `model/*` MIME types (Python's `mimetypes` module doesn't know these extensions)
- Adds `@google/model-viewer` to the webui; `FilePreview` renders glTF/GLB/USDZ with a fully interactive inline viewer (camera rotate, auto-rotate); OBJ/STL show a download prompt instead
- Adds `Model3DPreview` type to workspace types and JSX declaration for the `<model-viewer>` custom element

## What changes

**Backend** (`gptme/server/artifacts_api.py`):
```python
# New entries in _EXTENSION_KINDS
".gltf": "model3d",  ".glb": "model3d",
".obj":  "model3d",  ".stl": "model3d",  ".usdz": "model3d"

# New entry in _PREVIEW_FOR_KIND
"model3d": "model3d"
```

**Backend** (`gptme/server/workspace_api.py`): serves 3D files as raw bytes using `flask.send_file()` with IANA MIME types, exactly as images are served today.

**Frontend**: `workspaceApi.ts` detects `model/*` content-type and creates a blob URL (same pattern as images). `FilePreview.tsx` renders:
```tsx
<model-viewer src={preview.content} camera-controls auto-rotate style={{width:'100%', height:'100%'}} />
```
for glTF/GLB/USDZ; OBJ/STL fall back to a download prompt.

## Test plan

- [ ] Verified Python: all 5 model3d extensions classify as `model3d`, `_PREVIEW_FOR_KIND['model3d']` → `'model3d'`
- [ ] TypeScript: `npx tsc --noEmit` passes (exit 0)
- [ ] Pre-commit hooks passed on commit
- [ ] Manual: upload a `.glb` file to a gptme conversation → Artifacts panel shows kind badge `model3d` → clicking shows interactive 3D viewer with mouse rotation