### PR TITLE
perf(webui): skip hljs.highlightAuto for gptme tool-output tags

### DIFF
--- a/webui/src/utils/__tests__/highlightUtils.test.ts
+++ b/webui/src/utils/__tests__/highlightUtils.test.ts
@@ -32,8 +32,10 @@ describe('highlightCode', () => {
   });
 
   it('maps morph → diff', () => {
-    const patchContent = '<<<<<<< ORIGINAL\nold line\n=======\nnew line\n>>>>>>> UPDATED';
-    const result = highlightCode(patchContent, 'morph');
+    // morph invocations use "// ... existing code ..." markers (morphllm.com format)
+    const morphContent =
+      '// ... existing code ...\ndef updated_fn():\n    return True\n// ... existing code ...';
+    const result = highlightCode(morphContent, 'morph');
     expect(result.language).toBe('diff');
   });
 

--- a/webui/src/utils/__tests__/highlightUtils.test.ts
+++ b/webui/src/utils/__tests__/highlightUtils.test.ts
@@ -1,0 +1,66 @@
+import { highlightCode } from '../highlightUtils';
+
+describe('highlightCode', () => {
+  const code = 'x = 1\ny = 2\n';
+
+  it('handles empty input', () => {
+    expect(highlightCode('')).toEqual({ code: '' });
+  });
+
+  it('highlights known languages correctly', () => {
+    const result = highlightCode(code, 'python');
+    expect(result.language).toBe('python');
+    expect(result.code).toContain('class');
+  });
+
+  // gptme tool invocation tag mappings
+  it('maps ipython → python', () => {
+    const result = highlightCode(code, 'ipython');
+    expect(result.language).toBe('python');
+  });
+
+  it('maps tmux → bash', () => {
+    const result = highlightCode('ls -la', 'tmux');
+    expect(result.language).toBe('bash');
+  });
+
+  it('maps patch → diff', () => {
+    const result = highlightCode('--- a/file\n+++ b/file\n@@ -1 +1 @@\n-old\n+new', 'patch');
+    expect(result.language).toBe('diff');
+  });
+
+  it('maps morph → diff', () => {
+    const result = highlightCode('--- a/file\n+++ b/file\n', 'morph');
+    expect(result.language).toBe('diff');
+  });
+
+  // gptme tool output tags: must return plain escaped text without auto-detection
+  it('returns escaped plain text for stdout without running hljs.highlightAuto', () => {
+    const output = 'Hello, world!\n<not-html>\n';
+    const result = highlightCode(output, 'stdout');
+    expect(result.language).toBe('stdout');
+    // HTML entities escaped
+    expect(result.code).toContain('&lt;not-html&gt;');
+    // No hljs span tags
+    expect(result.code).not.toContain('<span');
+  });
+
+  it('returns escaped plain text for stderr', () => {
+    const output = 'Error: something went wrong\n<traceback>\n';
+    const result = highlightCode(output, 'stderr');
+    expect(result.language).toBe('stderr');
+    expect(result.code).toContain('&lt;traceback&gt;');
+    expect(result.code).not.toContain('<span');
+  });
+
+  it('returns escaped plain text for output', () => {
+    const result = highlightCode('plain output', 'output');
+    expect(result.language).toBe('output');
+    expect(result.code).not.toContain('<span');
+  });
+
+  it('escapes HTML entities in plain text output', () => {
+    const result = highlightCode('<b>bold</b> & "quoted"', 'stdout');
+    expect(result.code).toBe('&lt;b&gt;bold&lt;/b&gt; &amp; "quoted"');
+  });
+});

--- a/webui/src/utils/__tests__/highlightUtils.test.ts
+++ b/webui/src/utils/__tests__/highlightUtils.test.ts
@@ -1,3 +1,4 @@
+import hljs from 'highlight.js';
 import { highlightCode } from '../highlightUtils';
 
 describe('highlightCode', () => {
@@ -25,17 +26,20 @@ describe('highlightCode', () => {
   });
 
   it('maps patch → diff', () => {
-    const result = highlightCode('--- a/file\n+++ b/file\n@@ -1 +1 @@\n-old\n+new', 'patch');
+    const patchContent = '<<<<<<< ORIGINAL\nold line\n=======\nnew line\n>>>>>>> UPDATED';
+    const result = highlightCode(patchContent, 'patch');
     expect(result.language).toBe('diff');
   });
 
   it('maps morph → diff', () => {
-    const result = highlightCode('--- a/file\n+++ b/file\n', 'morph');
+    const patchContent = '<<<<<<< ORIGINAL\nold line\n=======\nnew line\n>>>>>>> UPDATED';
+    const result = highlightCode(patchContent, 'morph');
     expect(result.language).toBe('diff');
   });
 
   // gptme tool output tags: must return plain escaped text without auto-detection
   it('returns escaped plain text for stdout without running hljs.highlightAuto', () => {
+    const highlightAutoSpy = jest.spyOn(hljs, 'highlightAuto');
     const output = 'Hello, world!\n<not-html>\n';
     const result = highlightCode(output, 'stdout');
     expect(result.language).toBe('stdout');
@@ -43,20 +47,29 @@ describe('highlightCode', () => {
     expect(result.code).toContain('&lt;not-html&gt;');
     // No hljs span tags
     expect(result.code).not.toContain('<span');
+    // Performance guarantee: auto-detection must be bypassed entirely
+    expect(highlightAutoSpy).not.toHaveBeenCalled();
+    highlightAutoSpy.mockRestore();
   });
 
   it('returns escaped plain text for stderr', () => {
+    const highlightAutoSpy = jest.spyOn(hljs, 'highlightAuto');
     const output = 'Error: something went wrong\n<traceback>\n';
     const result = highlightCode(output, 'stderr');
     expect(result.language).toBe('stderr');
     expect(result.code).toContain('&lt;traceback&gt;');
     expect(result.code).not.toContain('<span');
+    expect(highlightAutoSpy).not.toHaveBeenCalled();
+    highlightAutoSpy.mockRestore();
   });
 
   it('returns escaped plain text for output', () => {
+    const highlightAutoSpy = jest.spyOn(hljs, 'highlightAuto');
     const result = highlightCode('plain output', 'output');
     expect(result.language).toBe('output');
     expect(result.code).not.toContain('<span');
+    expect(highlightAutoSpy).not.toHaveBeenCalled();
+    highlightAutoSpy.mockRestore();
   });
 
   it('escapes HTML entities in plain text output', () => {

--- a/webui/src/utils/highlightUtils.ts
+++ b/webui/src/utils/highlightUtils.ts
@@ -24,12 +24,29 @@ export function highlightCode(
 ): HighlightResult {
   if (!code) return { code: '' };
 
+  const escapeHtml = (s: string) =>
+    s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+  // gptme tool-output blocks contain plain text (command output, error messages, etc.).
+  // Calling hljs.highlightAuto on these is expensive (runs all grammars) and wrong —
+  // it mis-detects random languages in arbitrary command output. Return escaped text.
+  const GPTME_PLAIN_OUTPUT = new Set(['stdout', 'stderr', 'output']);
+
   try {
     // Normalize language name
     if (language) {
       // Handle common aliases
       if (language === 'shell') language = 'bash';
       if (language === 'result') language = 'markdown';
+      // Map gptme tool invocation tags to their correct hljs equivalents
+      if (language === 'ipython') language = 'python';
+      if (language === 'tmux') language = 'bash';
+      if (language === 'patch' || language === 'morph') language = 'diff';
+
+      // Tool output: plain text, skip expensive auto-detection
+      if (GPTME_PLAIN_OUTPUT.has(language)) {
+        return { code: escapeHtml(code), language };
+      }
 
       // Check if language is supported
       if (hljs.getLanguage(language)) {
@@ -44,11 +61,11 @@ export function highlightCode(
     }
 
     // Return escaped plain text for larger blocks or when auto-detect is disabled
-    return { code: code.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;') };
+    return { code: escapeHtml(code) };
   } catch (error) {
     console.warn('Syntax highlighting error:', error);
     // Return escaped text on error
-    return { code: code.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;') };
+    return { code: escapeHtml(code) };
   }
 }
 


### PR DESCRIPTION
## Summary

- **`stdout`/`stderr`/`output` blocks**: return escaped plain text immediately, skipping `hljs.highlightAuto` entirely. These are plain-text command output / error messages; auto-detection runs all registered grammars and mis-detects random languages in arbitrary terminal output.
- **`ipython` → `python`**, **`tmux` → `bash`**, **`patch`/`morph` → `diff`**: map known gptme tool-invocation tags to correct hljs equivalents, avoiding the fallthrough to `highlightAuto`.

## Why this matters

Every code block whose `lang` tag is not an hljs language falls through to `hljs.highlightAuto(code)`. This runs every registered grammar against the content to pick a winner — expensive by design. In a typical 10-20 tool-step session there are:

- 10-20 `stdout`/`stderr` blocks (shell output, error traces)
- Multiple `ipython` and `tmux` blocks

All of these were previously triggering full grammar sweeps. The fix skips the sweep where the content is definitely plain text, or maps the tag to the correct language directly.

**Complements #3363** (defers the per-token O(n²) syntax highlight during streaming). This PR reduces the per-block cost; #3363 reduces the call count.

## Test plan

- [x] New test file `highlightUtils.test.ts` with 10 cases covering all new mappings
- [x] Existing `markdownRenderer.test.ts` passes unchanged (22/22)
- [x] Pre-commit checks pass

Closes #3362 (along with #3363)