### PR TITLE
docs: add contributor-facing PR lifecycle guide

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -6,6 +6,10 @@ We welcome contributions to the project. Here is some information to get you sta
 .. note::
     This document is a work in progress. PRs are welcome.
 
+If you already have a change ready, read :doc:`pr-lifecycle` for the current
+pull-request flow: what automation runs, what maintainers look for, and the
+recent response/merge timings contributors can expect.
+
 Looking to **add a new LLM provider**? See :doc:`provider-integration` for the
 dedicated guide covering plugin packages, custom provider configs, and built-in
 provider PRs.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -60,6 +60,7 @@ See the `README <https://github.com/gptme/gptme/blob/master/README.md>`_ file fo
    :caption: Developer Guide
 
    contributing
+   pr-lifecycle
    building
    custom_tool
    hooks

--- a/docs/pr-lifecycle.rst
+++ b/docs/pr-lifecycle.rst
@@ -19,7 +19,7 @@ Quick expectations
   merged PRs, the median time from open to merge was **2.29 hours**.
 
 - Human maintainer follow-up is less uniform than bot feedback. Only 11 of those
-  50 merged PRs needed an on-thread maintainer reply or review, but when that
+  50 merged PRs had on-thread maintainer follow-up, but when that
   happened the median first maintainer response was **1.32 hours**.
 
 - ``master`` currently has **no GitHub branch-protection rule**. Merge decisions

--- a/docs/pr-lifecycle.rst
+++ b/docs/pr-lifecycle.rst
@@ -1,0 +1,103 @@
+PR lifecycle
+============
+
+This page describes what usually happens after you open a pull request against
+``gptme``.
+
+It is intentionally written as a snapshot of **observed repo behavior**, not a
+promise. Numbers below were measured from the last 50 merged PRs as of
+2026-07-25, and repo policy details were checked on 2026-07-26.
+
+Quick expectations
+------------------
+
+- Automated feedback usually lands first. Across the last 50 merged PRs, the
+  median first non-author response was **0.04 hours** (about **2.4 minutes**),
+  mostly from bots and CI.
+
+- Merges are currently fast when a PR is small and green. Across the same 50
+  merged PRs, the median time from open to merge was **2.29 hours**.
+
+- Human maintainer follow-up is less uniform than bot feedback. Only 11 of those
+  50 merged PRs needed an on-thread maintainer reply or review, but when that
+  happened the median first maintainer response was **1.32 hours**.
+
+- ``master`` currently has **no GitHub branch-protection rule**. Merge decisions
+  are made by maintainer judgment, not by a rigid GitHub gate.
+
+What happens after you open a PR
+--------------------------------
+
+1. GitHub Actions runs the project checks. Expect CI signal quickly.
+
+2. Automated reviewers may comment early. In practice this often includes
+   Greptile and Codecov before a human replies.
+
+3. Maintainers look for a narrow scope, clear rationale, and whether the change
+   is actually ready to merge rather than still in the "design in the PR
+   thread" phase.
+
+4. If the change is small, tested, and easy to verify, it may merge without a
+   long discussion.
+
+What maintainers look for
+-------------------------
+
+These are the current merge criteria in practice:
+
+- **Green CI**. There is no hard GitHub branch rule right now, but merged PRs
+  are typically clean.
+
+- **Clear scope**. Small, surgical PRs move faster than mixed refactor +
+  feature bundles.
+
+- **Enough verification**. Add or update tests when the change affects behavior.
+
+- **Context**. Link the issue when there is one, and explain the user-facing or
+  architectural reason for the change in the PR body.
+
+- **Resolvable review feedback**. If Greptile, Codecov, or a maintainer flags a
+  real issue, address it or explain why it is a false positive.
+
+How to make your PR easy to merge
+---------------------------------
+
+- Keep the diff focused on one problem.
+
+- Run the relevant tests locally before you push.
+
+- Include screenshots or terminal output when the change affects UX.
+
+- Say what you verified, not just what you changed.
+
+- If the work is non-trivial, open or link an issue first so the PR is not the
+  first place design context appears.
+
+What slows review down
+----------------------
+
+- Red CI or missing verification
+
+- A PR that mixes unrelated fixes
+
+- No explanation of why the change exists
+
+- Large diffs that require reconstructing design intent from code alone
+
+- Repeated force-pushes that invalidate earlier review context
+
+Current contributor reality
+---------------------------
+
+The repo is moving quickly right now. That is good for throughput, but it means
+the safest assumption is:
+
+- automation will respond first,
+
+- maintainers will optimize for clear, mergeable slices,
+
+- and the fastest path is a small PR with obvious verification.
+
+If you want a concrete starting point before coding, use the issue labels in
+:doc:`contributing` and comment on the issue so other contributors know you are
+on it.


### PR DESCRIPTION
## Summary
- add a contributor-facing `docs/pr-lifecycle.rst` page describing what happens after a PR is opened
- link it from `docs/contributing.rst` and the Developer Guide toctree
- anchor the page in recent observed repo behavior instead of generic contribution boilerplate

## Why
Recent contributor guidance said how to install and test gptme, but not what contributors should expect after opening a PR. This adds a concrete answer backed by current repo data.

## Evidence included
- last 50 merged PRs through 2026-07-25: median open→merge time `2.29h`
- last 50 merged PRs through 2026-07-25: median first non-author response `0.04h` (~2.4 min), mostly bots/CI
- 11/50 merged PRs had on-thread maintainer follow-up; among those, median first maintainer response `1.32h`
- checked 2026-07-26: `master` currently has no GitHub branch-protection rule, so merge criteria are maintainer judgment plus repo norms rather than hard branch gates

## Verification
- `prek` / pre-commit hooks passed on the changed files during commit
- ad-hoc Sphinx dummy build loaded the new page and doc tree successfully; full repo docs build still has unrelated baseline warnings/import failures (`flask` missing for autodoc, existing `server.rst` label warning)
