### PR TITLE
feat(sandbox): add sandboxed execution mode for shell tool

### DIFF
--- a/gptme/sandbox.py
+++ b/gptme/sandbox.py
@@ -40,15 +40,13 @@ logger = logging.getLogger(__name__)
 # Secrets NOT in this list are stripped before the subprocess is started.
 _DEFAULT_ENV_ALLOWLIST = frozenset(
     [
-        # LLM providers (gptme needs these to function)
-        "OPENAI_API_KEY",
-        "ANTHROPIC_API_KEY",
-        "OPENROUTER_API_KEY",
-        "GEMINI_API_KEY",
-        "GROQ_API_KEY",
-        "XAI_API_KEY",
-        "MISTRAL_API_KEY",
         # Shell basics
+        # NOTE: Provider API keys are intentionally excluded. LLM calls are
+        # made in the parent Python process, not in the sandboxed bash shell.
+        # Exposing credentials inside the sandbox (especially with
+        # GPTME_SANDBOX_NET=1) would allow agent-generated commands to
+        # exfiltrate them. Add keys to a custom env_allowlist if your workflow
+        # needs agent scripts to call the LLM provider directly.
         "HOME",
         "USER",
         "LOGNAME",
@@ -132,15 +130,11 @@ def wrap_shell_cmd(config: SandboxConfig, cmd: list[str]) -> list[str]:
 
     For backend=="none", returns cmd unchanged.
     For firejail/bwrap, prepends the sandbox invocation.
+    The caller is responsible for checking availability (check_available())
+    before calling this function.
     """
     if not config.enabled:
         return cmd
-
-    available, msg = config.check_available()
-    if not available:
-        logger.warning("Sandbox backend unavailable — running unsandboxed: %s", msg)
-        return cmd
-
     if config.backend == "firejail":
         return _firejail_cmd(config, cmd)
     if config.backend == "bwrap":
@@ -228,14 +222,18 @@ def _bwrap_cmd(config: SandboxConfig, inner: list[str]) -> list[str]:
         if Path(etc_file).exists():
             cmd.extend(["--ro-bind", etc_file, etc_file])
 
-    # Workspace: read-write
-    cmd.extend(["--bind", workspace, workspace])
-
     # Scratch dirs
     cmd.extend(["--proc", "/proc"])
     cmd.extend(["--dev", "/dev"])
     cmd.extend(["--tmpfs", "/tmp"])
-    cmd.extend(["--tmpfs", "/home"])  # blank home — no credentials
+    # Blank home hides credentials (~/.ssh, ~/.aws, etc.).
+    # Must come BEFORE the workspace bind so that when the workspace is under
+    # /home (e.g. /home/user/project) the subsequent --bind overrides the tmpfs
+    # at that specific path, making the workspace accessible.
+    cmd.extend(["--tmpfs", "/home"])
+
+    # Workspace: read-write (after home tmpfs so it wins when under /home)
+    cmd.extend(["--bind", workspace, workspace])
 
     # Optional read-only home overlay (exposes home files read-only)
     if config.ro_home:

--- a/gptme/sandbox.py
+++ b/gptme/sandbox.py
@@ -1,0 +1,251 @@
+"""
+Sandboxed execution support for gptme.
+
+Wraps the bash subprocess launched by the shell tool in firejail or bubblewrap
+to contain credential exfiltration, filesystem escape, and network misuse.
+
+Environment variables:
+    GPTME_SANDBOX: sandbox backend ("firejail" | "bwrap" | "none", default "none")
+    GPTME_SANDBOX_NET: "0" to disable network (default), "1" to allow
+    GPTME_SANDBOX_RO_HOME: "1" to add read-only home bind (default "0")
+
+The integration point in gptme/tools/shell.py is the subprocess.Popen call
+that starts the persistent bash process. Caller passes a SandboxConfig and
+calls wrap_shell_cmd() to get the (possibly sandboxed) command list.
+
+Security scope (what this contains):
+    - Credential exfiltration: env var masking + private tmpfs home
+    - Filesystem escape: workspace-only bind, tmpfs home
+    - Network misuse: --net=none (firejail) / --unshare-net (bwrap)
+    - Resource exhaustion: firejail seccomp caps-drop; bwrap new-session
+
+Out of scope:
+    - Prompt injection → code execution (agent-level problem)
+    - Determined attacker with prompt control (fundamental impossibility)
+    - macOS/Windows (firejail + bwrap are Linux-only)
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+from dataclasses import dataclass, field
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Environment variables that are safe to pass into the sandbox.
+# The API key vars are included so the agent can still call the LLM.
+# Secrets NOT in this list are stripped before the subprocess is started.
+_DEFAULT_ENV_ALLOWLIST = frozenset(
+    [
+        # LLM providers (gptme needs these to function)
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "OPENROUTER_API_KEY",
+        "GEMINI_API_KEY",
+        "GROQ_API_KEY",
+        "XAI_API_KEY",
+        "MISTRAL_API_KEY",
+        # Shell basics
+        "HOME",
+        "USER",
+        "LOGNAME",
+        "PATH",
+        "SHELL",
+        "TERM",
+        "COLORTERM",
+        "LANG",
+        "LC_ALL",
+        "LC_CTYPE",
+        "TMPDIR",
+        "TZ",
+        # Python
+        "PYTHONUNBUFFERED",
+        "PYTHONPATH",
+        # Git (needed for code review tasks)
+        "GIT_AUTHOR_NAME",
+        "GIT_AUTHOR_EMAIL",
+        "GIT_COMMITTER_NAME",
+        "GIT_COMMITTER_EMAIL",
+        # gptme internal
+        "GPTME_SHELL_TIMEOUT",
+        "GPTME_SHELL_TRUNC_PRE_TOKENS",
+        "GPTME_SHELL_TRUNC_POST_TOKENS",
+    ]
+)
+
+
+@dataclass
+class SandboxConfig:
+    """Policy for sandboxed shell execution.
+
+    Instantiate via SandboxConfig.from_env() to read from environment variables,
+    or construct directly for programmatic control.
+    """
+
+    backend: str = "none"  # "firejail" | "bwrap" | "none"
+    workspace: Path = field(default_factory=Path.cwd)
+    allow_network: bool = False
+    ro_home: bool = False
+    env_allowlist: frozenset[str] = field(
+        default_factory=lambda: _DEFAULT_ENV_ALLOWLIST
+    )
+    mask_secrets: bool = True
+
+    @classmethod
+    def from_env(cls, workspace: Path | None = None) -> SandboxConfig:
+        """Build a SandboxConfig from environment variables."""
+        backend = os.environ.get("GPTME_SANDBOX", "none").lower()
+        if backend not in ("firejail", "bwrap", "none"):
+            logger.warning("Unknown GPTME_SANDBOX value %r, using 'none'", backend)
+            backend = "none"
+
+        allow_network = os.environ.get("GPTME_SANDBOX_NET", "0") == "1"
+        ro_home = os.environ.get("GPTME_SANDBOX_RO_HOME", "0") == "1"
+
+        return cls(
+            backend=backend,
+            workspace=workspace or Path.cwd(),
+            allow_network=allow_network,
+            ro_home=ro_home,
+        )
+
+    @property
+    def enabled(self) -> bool:
+        return self.backend != "none"
+
+    def check_available(self) -> tuple[bool, str]:
+        """Return (available, message). Use before committing to this backend."""
+        if self.backend == "none":
+            return True, "no-op sandbox (passthrough)"
+        tool = self.backend if self.backend != "bwrap" else "bwrap"
+        if not shutil.which(tool):
+            msg = f"{tool} not found. Install with: sudo apt install {tool}"
+            return False, msg
+        return True, f"{tool} found at {shutil.which(tool)}"
+
+
+def wrap_shell_cmd(config: SandboxConfig, cmd: list[str]) -> list[str]:
+    """Wrap cmd with the sandbox layer.
+
+    For backend=="none", returns cmd unchanged.
+    For firejail/bwrap, prepends the sandbox invocation.
+    """
+    if not config.enabled:
+        return cmd
+
+    available, msg = config.check_available()
+    if not available:
+        logger.warning("Sandbox backend unavailable — running unsandboxed: %s", msg)
+        return cmd
+
+    if config.backend == "firejail":
+        return _firejail_cmd(config, cmd)
+    if config.backend == "bwrap":
+        return _bwrap_cmd(config, cmd)
+    return cmd
+
+
+def build_env(config: SandboxConfig) -> dict[str, str] | None:
+    """Return sanitized environment dict, or None to inherit current env.
+
+    Strips any env var not in the allowlist so secrets don't leak into the
+    sandboxed process even if the filesystem/network sandbox is bypassed.
+    """
+    if not config.enabled or not config.mask_secrets:
+        return None  # None → subprocess inherits os.environ unchanged
+    return {k: v for k, v in os.environ.items() if k in config.env_allowlist}
+
+
+# ---------------------------------------------------------------------------
+# Backend implementations
+# ---------------------------------------------------------------------------
+
+
+def _firejail_cmd(config: SandboxConfig, inner: list[str]) -> list[str]:
+    """Build firejail command wrapping inner.
+
+    Policy:
+        --private      : fresh tmpfs home (hides ~/.aws, ~/.ssh, ~/.gnupg, etc.)
+        --whitelist=WS : bind the workspace read-write (agent's working dir)
+        --noroot       : deny setuid/setgid binaries
+        --seccomp      : default seccomp filter (blocks rare dangerous syscalls)
+        --caps.drop=all: drop all capabilities
+        --net=none     : no network (unless allow_network=True)
+        --read-only=~  : optional read-only home overlay (ro_home=True)
+    """
+    workspace = str(config.workspace.resolve())
+    cmd: list[str] = [
+        "firejail",
+        "--quiet",
+        "--private",
+        f"--whitelist={workspace}",
+        "--noroot",
+        "--seccomp",
+        "--caps.drop=all",
+    ]
+    if config.ro_home:
+        cmd.append(f"--read-only={Path.home()}")
+    if not config.allow_network:
+        cmd.append("--net=none")
+    cmd.extend(["--", *inner])
+    return cmd
+
+
+def _bwrap_cmd(config: SandboxConfig, inner: list[str]) -> list[str]:
+    """Build bubblewrap command wrapping inner.
+
+    Policy (minimal, user-namespace-based):
+        ro-bind /usr,/lib,...: share read-only OS libraries
+        bind workspace       : read-write workspace
+        tmpfs /home          : blank home (no credentials)
+        tmpfs /tmp           : scratch space
+        --new-session        : new session ID (prevents terminal injection)
+        --die-with-parent    : clean shutdown if gptme exits
+        --unshare-net        : no network (unless allow_network=True)
+    """
+    workspace = str(config.workspace.resolve())
+
+    # Directories to bind read-only from the host OS
+    ro_system_dirs = ["/usr", "/bin", "/sbin", "/lib", "/lib64", "/etc/alternatives"]
+
+    cmd: list[str] = ["bwrap"]
+
+    for d in ro_system_dirs:
+        if Path(d).exists():
+            cmd.extend(["--ro-bind", d, d])
+
+    # /etc: bind selectively to avoid leaking credentials
+    # (resolv.conf needed for DNS; others are optional)
+    for etc_file in [
+        "/etc/resolv.conf",
+        "/etc/passwd",
+        "/etc/group",
+        "/etc/os-release",
+    ]:
+        if Path(etc_file).exists():
+            cmd.extend(["--ro-bind", etc_file, etc_file])
+
+    # Workspace: read-write
+    cmd.extend(["--bind", workspace, workspace])
+
+    # Scratch dirs
+    cmd.extend(["--proc", "/proc"])
+    cmd.extend(["--dev", "/dev"])
+    cmd.extend(["--tmpfs", "/tmp"])
+    cmd.extend(["--tmpfs", "/home"])  # blank home — no credentials
+
+    # Optional read-only home overlay (exposes home files read-only)
+    if config.ro_home:
+        home = str(Path.home())
+        cmd.extend(["--ro-bind", home, home])
+
+    cmd.extend(["--new-session", "--die-with-parent"])
+
+    if not config.allow_network:
+        cmd.append("--unshare-net")
+
+    cmd.extend(["--", *inner])
+    return cmd

--- a/gptme/sandbox.py
+++ b/gptme/sandbox.py
@@ -92,13 +92,14 @@ class SandboxConfig:
     )
     mask_secrets: bool = True
 
+    def __post_init__(self) -> None:
+        if self.backend not in ("firejail", "bwrap", "none"):
+            raise ValueError(f"Unsupported sandbox backend: {self.backend!r}")
+
     @classmethod
     def from_env(cls, workspace: Path | None = None) -> SandboxConfig:
         """Build a SandboxConfig from environment variables."""
         backend = os.environ.get("GPTME_SANDBOX", "none").lower()
-        if backend not in ("firejail", "bwrap", "none"):
-            logger.warning("Unknown GPTME_SANDBOX value %r, using 'none'", backend)
-            backend = "none"
 
         allow_network = os.environ.get("GPTME_SANDBOX_NET", "0") == "1"
         ro_home = os.environ.get("GPTME_SANDBOX_RO_HOME", "0") == "1"
@@ -232,15 +233,17 @@ def _bwrap_cmd(config: SandboxConfig, inner: list[str]) -> list[str]:
     # at that specific path, making the workspace accessible.
     cmd.extend(["--tmpfs", "/home"])
 
-    # Workspace: read-write (after home tmpfs so it wins when under /home)
-    cmd.extend(["--bind", workspace, workspace])
-
-    # Optional read-only home overlay (exposes home files read-only)
+    # Optional read-only home overlay (exposes home files read-only). Apply it
+    # before the workspace bind so a workspace nested under home stays writable.
     if config.ro_home:
         home = str(Path.home())
         cmd.extend(["--ro-bind", home, home])
 
-    cmd.extend(["--new-session", "--die-with-parent"])
+    # Workspace: read-write (after every home mount so it wins when nested there)
+    cmd.extend(["--bind", workspace, workspace])
+
+    # Isolate procfs from the credential-bearing gptme parent process.
+    cmd.extend(["--unshare-pid", "--new-session", "--die-with-parent"])
 
     if not config.allow_network:
         cmd.append("--unshare-net")

--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -285,15 +285,14 @@ class ShellSession:
         )
         if sandbox.enabled:
             available, msg = sandbox.check_available()
-            if available:
-                shell_cmd = wrap_shell_cmd(sandbox, shell_cmd)
-                logger.info("Sandboxed shell: %s", " ".join(shell_cmd))
-            else:
-                logger.warning(
-                    "GPTME_SANDBOX=%s requested but unavailable: %s",
-                    sandbox.backend,
-                    msg,
+            if not available:
+                raise RuntimeError(
+                    f"GPTME_SANDBOX={sandbox.backend!r} was requested but the"
+                    f" backend is not available: {msg}. Either install the"
+                    f" sandbox tool or unset GPTME_SANDBOX."
                 )
+            shell_cmd = wrap_shell_cmd(sandbox, shell_cmd)
+            logger.info("Sandboxed shell: %s", " ".join(shell_cmd))
         sandbox_env = build_env(
             sandbox
         )  # None if sandbox disabled → inherit os.environ

--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -348,6 +348,10 @@ class ShellSession:
             return False  # No /dev/tty on Windows
         if not sys.stdin.isatty():
             return False
+        if SandboxConfig.from_env().enabled:
+            # _run_with_tty launches a separate host process, outside the persistent
+            # sandbox. Keep sandboxed commands on the isolated shell instead.
+            return False
         # Check for sudo without -S (stdin password) or -n (non-interactive)
         try:
             parts = shlex.split(command)

--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -34,6 +34,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from ..message import Message
+from ..sandbox import SandboxConfig, build_env, wrap_shell_cmd
 from ..util import get_installed_programs
 from ..util.ask_execute import execute_with_confirmation
 from ..util.context import md_codeblock
@@ -277,6 +278,26 @@ class ShellSession:
             popen_kwargs = {
                 "start_new_session": True,  # Create new process group for proper signal handling
             }
+
+        # Apply sandbox wrapper if GPTME_SANDBOX is set
+        sandbox = SandboxConfig.from_env(
+            workspace=Path(self._cwd) if self._cwd else None
+        )
+        if sandbox.enabled:
+            available, msg = sandbox.check_available()
+            if available:
+                shell_cmd = wrap_shell_cmd(sandbox, shell_cmd)
+                logger.info("Sandboxed shell: %s", " ".join(shell_cmd))
+            else:
+                logger.warning(
+                    "GPTME_SANDBOX=%s requested but unavailable: %s",
+                    sandbox.backend,
+                    msg,
+                )
+        sandbox_env = build_env(
+            sandbox
+        )  # None if sandbox disabled → inherit os.environ
+
         self.process = subprocess.Popen(
             shell_cmd,
             stdin=subprocess.PIPE,
@@ -285,6 +306,7 @@ class ShellSession:
             bufsize=0,  # Unbuffered
             universal_newlines=True,
             cwd=self._cwd,  # Use explicit workspace dir (thread-safe)
+            env=sandbox_env,  # None → inherit; dict → sanitized env
             **popen_kwargs,
         )
         assert self.process.stdout is not None

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -1,0 +1,278 @@
+"""Tests for gptme.sandbox — sandbox wrapper module (Idea #834)."""
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from gptme.sandbox import (
+    _DEFAULT_ENV_ALLOWLIST,
+    SandboxConfig,
+    _bwrap_cmd,
+    _firejail_cmd,
+    build_env,
+    wrap_shell_cmd,
+)
+
+# ---------------------------------------------------------------------------
+# SandboxConfig
+# ---------------------------------------------------------------------------
+
+
+class TestSandboxConfigFromEnv:
+    def test_default_is_none(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("GPTME_SANDBOX", None)
+            cfg = SandboxConfig.from_env()
+        assert cfg.backend == "none"
+        assert not cfg.enabled
+
+    def test_firejail_backend(self):
+        with patch.dict(os.environ, {"GPTME_SANDBOX": "firejail"}):
+            cfg = SandboxConfig.from_env()
+        assert cfg.backend == "firejail"
+        assert cfg.enabled
+
+    def test_bwrap_backend(self):
+        with patch.dict(os.environ, {"GPTME_SANDBOX": "bwrap"}):
+            cfg = SandboxConfig.from_env()
+        assert cfg.backend == "bwrap"
+        assert cfg.enabled
+
+    def test_unknown_backend_falls_back_to_none(self):
+        with patch.dict(os.environ, {"GPTME_SANDBOX": "nsjail"}):
+            cfg = SandboxConfig.from_env()
+        assert cfg.backend == "none"
+
+    def test_network_disabled_by_default(self):
+        with patch.dict(os.environ, {"GPTME_SANDBOX": "firejail"}):
+            cfg = SandboxConfig.from_env()
+        assert not cfg.allow_network
+
+    def test_network_can_be_enabled(self):
+        with patch.dict(
+            os.environ, {"GPTME_SANDBOX": "firejail", "GPTME_SANDBOX_NET": "1"}
+        ):
+            cfg = SandboxConfig.from_env()
+        assert cfg.allow_network
+
+    def test_ro_home_disabled_by_default(self):
+        with patch.dict(os.environ, {"GPTME_SANDBOX": "bwrap"}):
+            cfg = SandboxConfig.from_env()
+        assert not cfg.ro_home
+
+    def test_ro_home_can_be_enabled(self):
+        with patch.dict(
+            os.environ, {"GPTME_SANDBOX": "bwrap", "GPTME_SANDBOX_RO_HOME": "1"}
+        ):
+            cfg = SandboxConfig.from_env()
+        assert cfg.ro_home
+
+
+class TestSandboxConfigCheckAvailable:
+    def test_none_backend_always_available(self):
+        cfg = SandboxConfig(backend="none")
+        ok, _ = cfg.check_available()
+        assert ok
+
+    def test_missing_backend_not_available(self):
+        cfg = SandboxConfig(backend="firejail")
+        with patch("shutil.which", return_value=None):
+            ok, msg = cfg.check_available()
+        assert not ok
+        assert "firejail" in msg
+
+    def test_present_backend_available(self):
+        cfg = SandboxConfig(backend="firejail")
+        with patch("shutil.which", return_value="/usr/bin/firejail"):
+            ok, _ = cfg.check_available()
+        assert ok
+
+
+# ---------------------------------------------------------------------------
+# wrap_shell_cmd
+# ---------------------------------------------------------------------------
+
+
+class TestWrapShellCmd:
+    def test_none_backend_passthrough(self):
+        cfg = SandboxConfig(backend="none")
+        cmd = ["bash"]
+        assert wrap_shell_cmd(cfg, cmd) == cmd
+
+    def test_firejail_backend_wraps_cmd(self):
+        cfg = SandboxConfig(backend="firejail", workspace=Path("/workspace"))
+        with patch("shutil.which", return_value="/usr/bin/firejail"):
+            wrapped = wrap_shell_cmd(cfg, ["bash"])
+        assert wrapped[0] == "firejail"
+        assert "bash" in wrapped
+        assert "--private" in wrapped
+
+    def test_bwrap_backend_wraps_cmd(self):
+        cfg = SandboxConfig(backend="bwrap", workspace=Path("/workspace"))
+        with patch("shutil.which", return_value="/usr/bin/bwrap"):
+            wrapped = wrap_shell_cmd(cfg, ["bash"])
+        assert wrapped[0] == "bwrap"
+        assert "bash" in wrapped
+
+    def test_unavailable_backend_falls_back_to_passthrough(self):
+        cfg = SandboxConfig(backend="firejail", workspace=Path("/workspace"))
+        cmd = ["bash"]
+        with patch("shutil.which", return_value=None):
+            wrapped = wrap_shell_cmd(cfg, cmd)
+        assert wrapped == cmd  # falls back gracefully
+
+    def test_inner_command_appears_after_separator(self):
+        cfg = SandboxConfig(backend="firejail", workspace=Path("/workspace"))
+        with patch("shutil.which", return_value="/usr/bin/firejail"):
+            wrapped = wrap_shell_cmd(cfg, ["bash", "-c", "echo hi"])
+        sep_idx = wrapped.index("--")
+        assert wrapped[sep_idx + 1 :] == ["bash", "-c", "echo hi"]
+
+
+# ---------------------------------------------------------------------------
+# firejail command builder
+# ---------------------------------------------------------------------------
+
+
+class TestFirejailCmd:
+    def _build(self, **kwargs):
+        workspace = kwargs.pop("workspace", Path("/project"))
+        cfg = SandboxConfig(backend="firejail", workspace=workspace, **kwargs)
+        return _firejail_cmd(cfg, ["bash"])
+
+    def test_starts_with_firejail(self):
+        cmd = self._build()
+        assert cmd[0] == "firejail"
+
+    def test_private_flag_present(self):
+        assert "--private" in self._build()
+
+    def test_noroot_flag_present(self):
+        assert "--noroot" in self._build()
+
+    def test_seccomp_flag_present(self):
+        assert "--seccomp" in self._build()
+
+    def test_net_none_when_network_disabled(self):
+        cmd = self._build(allow_network=False)
+        assert "--net=none" in cmd
+
+    def test_no_net_none_when_network_enabled(self):
+        cmd = self._build(allow_network=True)
+        assert "--net=none" not in cmd
+
+    def test_whitelist_includes_workspace(self):
+        cmd = self._build(workspace=Path("/my/workspace"))
+        assert "--whitelist=/my/workspace" in cmd
+
+    def test_ro_home_flag_absent_by_default(self):
+        cmd = self._build(ro_home=False)
+        ro_flags = [f for f in cmd if f.startswith("--read-only=")]
+        assert not ro_flags
+
+    def test_ro_home_flag_present_when_enabled(self):
+        cmd = self._build(ro_home=True)
+        ro_flags = [f for f in cmd if f.startswith("--read-only=")]
+        assert len(ro_flags) == 1
+
+    def test_separator_before_inner_cmd(self):
+        cmd = self._build()
+        assert "--" in cmd
+        assert cmd[-1] == "bash"
+
+
+# ---------------------------------------------------------------------------
+# bubblewrap command builder
+# ---------------------------------------------------------------------------
+
+
+class TestBwrapCmd:
+    def _build(self, **kwargs):
+        workspace = kwargs.pop("workspace", Path("/project"))
+        cfg = SandboxConfig(backend="bwrap", workspace=workspace, **kwargs)
+        return _bwrap_cmd(cfg, ["bash"])
+
+    def test_starts_with_bwrap(self):
+        assert self._build()[0] == "bwrap"
+
+    def test_workspace_bind_present(self):
+        cmd = self._build(workspace=Path("/project"))
+        # Should have --bind /project /project
+        try:
+            idx = cmd.index("--bind")
+        except ValueError:
+            pytest.fail("--bind not found in bwrap command")
+        assert cmd[idx + 1] == "/project"
+        assert cmd[idx + 2] == "/project"
+
+    def test_tmpfs_home_present(self):
+        cmd = self._build()
+        # --tmpfs /home should be present (blank home = no credentials)
+        tmpfs_targets = []
+        for i, arg in enumerate(cmd):
+            if arg == "--tmpfs" and i + 1 < len(cmd):
+                tmpfs_targets.append(cmd[i + 1])
+        assert "/home" in tmpfs_targets
+
+    def test_unshare_net_when_network_disabled(self):
+        assert "--unshare-net" in self._build(allow_network=False)
+
+    def test_no_unshare_net_when_network_enabled(self):
+        assert "--unshare-net" not in self._build(allow_network=True)
+
+    def test_die_with_parent_present(self):
+        assert "--die-with-parent" in self._build()
+
+    def test_new_session_present(self):
+        assert "--new-session" in self._build()
+
+    def test_separator_before_inner_cmd(self):
+        cmd = self._build()
+        assert "--" in cmd
+        assert cmd[-1] == "bash"
+
+
+# ---------------------------------------------------------------------------
+# Environment filtering
+# ---------------------------------------------------------------------------
+
+
+class TestBuildEnv:
+    def test_none_when_sandbox_disabled(self):
+        cfg = SandboxConfig(backend="none")
+        assert build_env(cfg) is None
+
+    def test_returns_dict_when_sandbox_enabled(self):
+        cfg = SandboxConfig(backend="firejail")
+        with patch.dict(os.environ, {"MY_SECRET": "s3cr3t", "HOME": "/home/user"}):
+            env = build_env(cfg)
+        assert env is not None
+        assert isinstance(env, dict)
+
+    def test_strips_non_allowlisted_vars(self):
+        cfg = SandboxConfig(backend="firejail")
+        with patch.dict(os.environ, {"MY_SECRET": "s3cr3t", "MY_AWS_KEY": "key123"}):
+            env = build_env(cfg)
+        assert "MY_SECRET" not in (env or {})
+        assert "MY_AWS_KEY" not in (env or {})
+
+    def test_passes_allowlisted_vars(self):
+        cfg = SandboxConfig(backend="firejail")
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test123"}):
+            env = build_env(cfg)
+        assert env is not None
+        assert env.get("OPENAI_API_KEY") == "sk-test123"
+
+    def test_mask_secrets_false_returns_none(self):
+        cfg = SandboxConfig(backend="firejail", mask_secrets=False)
+        assert build_env(cfg) is None
+
+    def test_allowlist_covers_common_llm_keys(self):
+        required = {"OPENAI_API_KEY", "ANTHROPIC_API_KEY", "OPENROUTER_API_KEY"}
+        assert required.issubset(_DEFAULT_ENV_ALLOWLIST)
+
+    def test_allowlist_covers_shell_basics(self):
+        required = {"HOME", "USER", "PATH", "TERM"}
+        assert required.issubset(_DEFAULT_ENV_ALLOWLIST)

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -116,13 +116,6 @@ class TestWrapShellCmd:
         assert wrapped[0] == "bwrap"
         assert "bash" in wrapped
 
-    def test_unavailable_backend_falls_back_to_passthrough(self):
-        cfg = SandboxConfig(backend="firejail", workspace=Path("/workspace"))
-        cmd = ["bash"]
-        with patch("shutil.which", return_value=None):
-            wrapped = wrap_shell_cmd(cfg, cmd)
-        assert wrapped == cmd  # falls back gracefully
-
     def test_inner_command_appears_after_separator(self):
         cfg = SandboxConfig(backend="firejail", workspace=Path("/workspace"))
         with patch("shutil.which", return_value="/usr/bin/firejail"):
@@ -233,6 +226,29 @@ class TestBwrapCmd:
         assert "--" in cmd
         assert cmd[-1] == "bash"
 
+    def test_workspace_bind_after_home_tmpfs(self):
+        """Workspace bind must come after --tmpfs /home so it wins when
+        the workspace is under /home (e.g. /home/user/project)."""
+        cmd = self._build(workspace=Path("/home/user/project"))
+        tmpfs_home_idx = next(
+            (i for i, a in enumerate(cmd) if a == "--tmpfs" and cmd[i + 1] == "/home"),
+            None,
+        )
+        workspace_bind_idx = next(
+            (
+                i
+                for i, a in enumerate(cmd)
+                if a == "--bind" and cmd[i + 1] == "/home/user/project"
+            ),
+            None,
+        )
+        assert tmpfs_home_idx is not None, "--tmpfs /home not found in bwrap command"
+        assert workspace_bind_idx is not None, "--bind /home/user/project not found"
+        assert workspace_bind_idx > tmpfs_home_idx, (
+            "workspace --bind must appear after --tmpfs /home so it overrides"
+            " the blank home mount when workspace is under /home"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Environment filtering
@@ -258,20 +274,28 @@ class TestBuildEnv:
         assert "MY_SECRET" not in (env or {})
         assert "MY_AWS_KEY" not in (env or {})
 
-    def test_passes_allowlisted_vars(self):
+    def test_strips_provider_api_keys(self):
+        """Provider API keys must NOT be passed into the sandboxed shell.
+        LLM calls are made by the parent Python process, not by bash commands.
+        Exposing them (especially with GPTME_SANDBOX_NET=1) enables exfiltration."""
         cfg = SandboxConfig(backend="firejail")
-        with patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test123"}):
+        with patch.dict(
+            os.environ,
+            {
+                "OPENAI_API_KEY": "sk-test",
+                "ANTHROPIC_API_KEY": "ant-test",
+                "OPENROUTER_API_KEY": "or-test",
+            },
+        ):
             env = build_env(cfg)
         assert env is not None
-        assert env.get("OPENAI_API_KEY") == "sk-test123"
+        assert "OPENAI_API_KEY" not in env
+        assert "ANTHROPIC_API_KEY" not in env
+        assert "OPENROUTER_API_KEY" not in env
 
     def test_mask_secrets_false_returns_none(self):
         cfg = SandboxConfig(backend="firejail", mask_secrets=False)
         assert build_env(cfg) is None
-
-    def test_allowlist_covers_common_llm_keys(self):
-        required = {"OPENAI_API_KEY", "ANTHROPIC_API_KEY", "OPENROUTER_API_KEY"}
-        assert required.issubset(_DEFAULT_ENV_ALLOWLIST)
 
     def test_allowlist_covers_shell_basics(self):
         required = {"HOME", "USER", "PATH", "TERM"}

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -40,10 +40,16 @@ class TestSandboxConfigFromEnv:
         assert cfg.backend == "bwrap"
         assert cfg.enabled
 
-    def test_unknown_backend_falls_back_to_none(self):
-        with patch.dict(os.environ, {"GPTME_SANDBOX": "nsjail"}):
-            cfg = SandboxConfig.from_env()
-        assert cfg.backend == "none"
+    def test_unknown_backend_fails_closed(self):
+        with (
+            patch.dict(os.environ, {"GPTME_SANDBOX": "nsjail"}),
+            pytest.raises(ValueError, match="Unsupported sandbox backend"),
+        ):
+            SandboxConfig.from_env()
+
+    def test_programmatic_unknown_backend_fails_closed(self):
+        with pytest.raises(ValueError, match="Unsupported sandbox backend"):
+            SandboxConfig(backend="nsjail")
 
     def test_network_disabled_by_default(self):
         with patch.dict(os.environ, {"GPTME_SANDBOX": "firejail"}):
@@ -221,6 +227,10 @@ class TestBwrapCmd:
     def test_new_session_present(self):
         assert "--new-session" in self._build()
 
+    def test_pid_namespace_isolated(self):
+        """The sandbox must not see the credential-bearing parent via /proc."""
+        assert "--unshare-pid" in self._build()
+
     def test_separator_before_inner_cmd(self):
         cmd = self._build()
         assert "--" in cmd
@@ -247,6 +257,34 @@ class TestBwrapCmd:
         assert workspace_bind_idx > tmpfs_home_idx, (
             "workspace --bind must appear after --tmpfs /home so it overrides"
             " the blank home mount when workspace is under /home"
+        )
+
+    def test_workspace_bind_after_read_only_home_overlay(self):
+        """A read-only home overlay must not hide a nested writable workspace."""
+        home = Path.home()
+        workspace = home / "project"
+        cmd = self._build(workspace=workspace, ro_home=True)
+        home_bind_idx = next(
+            (
+                i
+                for i, arg in enumerate(cmd)
+                if arg == "--ro-bind" and cmd[i + 1 : i + 3] == [str(home), str(home)]
+            ),
+            None,
+        )
+        workspace_bind_idx = next(
+            (
+                i
+                for i, arg in enumerate(cmd)
+                if arg == "--bind"
+                and cmd[i + 1 : i + 3] == [str(workspace), str(workspace)]
+            ),
+            None,
+        )
+        assert home_bind_idx is not None, "read-only home bind not found"
+        assert workspace_bind_idx is not None, "workspace bind not found"
+        assert workspace_bind_idx > home_bind_idx, (
+            "workspace --bind must appear after the read-only home overlay"
         )
 
 

--- a/tests/test_tools_shell.py
+++ b/tests/test_tools_shell.py
@@ -1811,6 +1811,11 @@ def test_needs_tty_sudo_detection():
             assert shell._needs_tty(
                 "DEBIAN_FRONTEND=noninteractive sudo apt install vim"
             )
+
+            # A separate TTY subprocess would bypass the configured sandbox.
+            with patch("gptme.tools.shell.SandboxConfig.from_env") as from_env:
+                from_env.return_value.enabled = True
+                assert not shell._needs_tty("sudo apt install vim")
     finally:
         shell.close()
 


### PR DESCRIPTION
## Summary

Adds `gptme/sandbox.py` — an opt-in sandboxed execution mode that wraps the bash subprocess in firejail or bubblewrap to contain credential exfiltration, filesystem escape, and network misuse.

**Off by default. Activated via env var:**
```bash
GPTME_SANDBOX=firejail gptme 'review this code'
GPTME_SANDBOX=bwrap GPTME_SANDBOX_NET=1 gptme 'research async patterns'
```

## What this contains

| Threat | Mitigation |
|--------|------------|
| Credential exfiltration | tmpfs home + env var allowlist (strips non-allowlisted vars) |
| Filesystem escape | workspace-only bind mount; rest excluded or read-only |
| Network misuse | `--net=none` (firejail) / `--unshare-net` (bwrap) by default |
| Resource abuse | firejail seccomp + caps-drop; bwrap new-session + die-with-parent |

## Design

- `SandboxConfig.from_env()` reads `GPTME_SANDBOX` / `GPTME_SANDBOX_NET` / `GPTME_SANDBOX_RO_HOME`
- `wrap_shell_cmd(config, ["bash"])` prepends the sandbox invocation  
- `build_env(config)` returns sanitized env dict (or `None` to inherit)
- Graceful fallback: if backend unavailable, logs a warning and runs unsandboxed
- 41 unit tests covering config, command builders, env filtering

## Backends

- **firejail**: `sudo apt install firejail` — user-friendly, interactive-session-friendly
- **bubblewrap / bwrap**: `sudo apt install bubblewrap` — no SUID, requires user namespaces

## Status: Ready for dogfooding

Integration is ~12 lines in `shell.py:_init()`. Open questions dogfooding will answer:
1. Startup latency overhead (expected <100ms per shell launch)
2. UX friction with workspace access patterns  
3. Whether pre-built profiles are needed

Background: `knowledge/research/2026-07-26-gptme-sandboxed-execution-design.md` (idea #834, sourced from HN Clawk thread).

## Test plan

- [x] 41 unit tests pass (config, firejail/bwrap cmd builders, env filtering)
- [ ] Install firejail: verify workspace accessible, `/etc/shadow` blocked, no network
- [ ] Measure startup overhead with `hyperfine`
- [ ] Verify env masking: `AWS_SECRET_ACCESS_KEY` not visible inside sandboxed bash