### PR TITLE
perf(webui): skip buildStepRoles recompute on every streaming token

### DIFF
--- a/webui/src/components/ConversationContent.tsx
+++ b/webui/src/components/ConversationContent.tsx
@@ -247,21 +247,41 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
     expandedGroups$.set(next);
   };
 
-  // Recompute step roles when messages or visibility settings change.
-  // All .get() calls inside are auto-tracked, so this re-runs when any of
-  // conversation log, showHiddenMessages, showInitialSystem, firstNonSystemIndex,
-  // or logOffset changes.
+  // Structural key: encodes only message count and logOffset.
+  // The selector re-runs on every log mutation (including streaming tokens), but its
+  // VALUE (e.g. "12:0") only changes when messages are added/removed or the window
+  // shifts. Legend State compares by value, so downstream observers only fire on
+  // actual structural changes — not on per-token content updates.
+  const logStructureKey$ = useObservable(() => {
+    const count = conversation$?.data.log.get()?.length ?? 0;
+    const offset = conversation$?.logOffset?.get() ?? 0;
+    return `${count}:${offset}`;
+  });
+
+  // Recompute step roles when the message structure or visibility settings change.
+  // Subscribes to logStructureKey$ (not the full log) so it does NOT re-run on
+  // every streaming token — only when message count, logOffset, or settings change.
   useObserveEffect(() => {
-    const messages = conversation$?.data.log.get();
-    if (!messages?.length) {
+    const structureKey = logStructureKey$.get();
+    const firstNonSystem = firstNonSystemIndex$.get();
+    const showInitial = showInitialSystem$.get();
+    const showHidden = showHiddenMessages$.get();
+
+    const sep = structureKey.indexOf(':');
+    const messageCount = parseInt(structureKey.slice(0, sep), 10);
+    const logOffset = parseInt(structureKey.slice(sep + 1), 10);
+
+    if (!messageCount) {
       stepRoles$.set(new Map());
       return;
     }
 
-    const logOffset = conversation$?.logOffset?.get() ?? 0;
-    const firstNonSystem = firstNonSystemIndex$.get();
-    const showInitial = showInitialSystem$.get();
-    const showHidden = showHiddenMessages$.get();
+    // Peek (non-reactive read) — structural changes are already tracked via logStructureKey$.
+    const messages = conversation$?.data.log.peek() as Message[] | undefined;
+    if (!messages?.length) {
+      stepRoles$.set(new Map());
+      return;
+    }
 
     // isHidden receives LOCAL indices (array positions in messages[]).
     const isHidden = (idx: number) => {

--- a/webui/src/components/ConversationContent.tsx
+++ b/webui/src/components/ConversationContent.tsx
@@ -247,15 +247,16 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
     expandedGroups$.set(next);
   };
 
-  // Structural key: encodes only message count and logOffset.
+  // Structural key: encodes message count, logOffset, and wholesale-log revision.
   // The selector re-runs on every log mutation (including streaming tokens), but its
-  // VALUE (e.g. "12:0") only changes when messages are added/removed or the window
-  // shifts. Legend State compares by value, so downstream observers only fire on
-  // actual structural changes — not on per-token content updates.
+  // VALUE (e.g. "12:0:3") changes only when messages are added/removed, the window
+  // shifts, or the log is replaced after an edit/branch switch/reload. Legend State
+  // compares by value, so downstream observers skip per-token content updates.
   const logStructureKey$ = useObservable(() => {
     const count = conversation$?.data.log.get()?.length ?? 0;
     const offset = conversation$?.logOffset?.get() ?? 0;
-    return `${count}:${offset}`;
+    const revision = conversation$?.logRevision?.get() ?? 0;
+    return `${count}:${offset}:${revision}`;
   });
 
   // Recompute step roles when the message structure or visibility settings change.
@@ -267,9 +268,9 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
     const showInitial = showInitialSystem$.get();
     const showHidden = showHiddenMessages$.get();
 
-    const sep = structureKey.indexOf(':');
-    const messageCount = parseInt(structureKey.slice(0, sep), 10);
-    const logOffset = parseInt(structureKey.slice(sep + 1), 10);
+    const [messageCountText, logOffsetText] = structureKey.split(':');
+    const messageCount = parseInt(messageCountText, 10);
+    const logOffset = parseInt(logOffsetText, 10);
 
     if (!messageCount) {
       stepRoles$.set(new Map());

--- a/webui/src/components/__tests__/ConversationContent.test.tsx
+++ b/webui/src/components/__tests__/ConversationContent.test.tsx
@@ -66,6 +66,7 @@ function makeConversationState() {
     chatConfig: null,
     needsInitialStep: false,
     currentBranch: 'main',
+    logRevision: 0,
     logOffset: 0,
     isWindowHydrated: true,
     lastMessage: undefined,

--- a/webui/src/components/__tests__/ConversationList.test.tsx
+++ b/webui/src/components/__tests__/ConversationList.test.tsx
@@ -183,6 +183,7 @@ describe('ConversationList', () => {
       chatConfig: null,
       needsInitialStep: false,
       currentBranch: 'main',
+      logRevision: 0,
       logOffset: 0,
       hasMoreBefore: false,
       isWindowHydrated: true,

--- a/webui/src/stores/__tests__/conversations.test.ts
+++ b/webui/src/stores/__tests__/conversations.test.ts
@@ -103,6 +103,17 @@ describe('updateConversationData window metadata', () => {
     updateConversationData(id, makeResponse());
     expect(conversations$.get(id)?.isWindowHydrated.get()).toBe(true);
   });
+
+  it('increments logRevision for same-size full-log replacements', () => {
+    const first = makeResponse({ log: [msg('user', 'first')] });
+    const replacement = makeResponse({ log: [msg('assistant', 'replacement')] });
+
+    updateConversationData(id, first);
+    const revision = conversations$.get(id)?.logRevision.get();
+    updateConversationData(id, replacement);
+
+    expect(conversations$.get(id)?.logRevision.get()).toBe((revision ?? 0) + 1);
+  });
 });
 
 describe('replaceLog window metadata reset', () => {
@@ -116,12 +127,14 @@ describe('replaceLog window metadata reset', () => {
 
   it('resets logOffset and hasMoreBefore to full-log defaults after server mutation', () => {
     const fullLog = [msg('user', 'hi'), msg('assistant', 'hello')];
+    const revision = conversations$.get(id)?.logRevision.get();
     replaceLog(id, fullLog);
 
     const conv = conversations$.get(id);
     expect(conv?.logOffset.get()).toBe(0);
     expect(conv?.hasMoreBefore.get()).toBe(false);
     expect(conv?.isWindowHydrated.get()).toBe(true);
+    expect(conv?.logRevision.get()).toBe((revision ?? 0) + 1);
   });
 });
 
@@ -183,6 +196,7 @@ describe('setCurrentBranch window metadata reset', () => {
   });
 
   it('resets window metadata when switching branches', () => {
+    const revision = conversations$.get(id)?.logRevision.get();
     setCurrentBranch(id, 'alt');
 
     const conv = conversations$.get(id);
@@ -191,6 +205,7 @@ describe('setCurrentBranch window metadata reset', () => {
     expect(conv?.logOffset.get()).toBe(0);
     expect(conv?.hasMoreBefore.get()).toBe(false);
     expect(conv?.isWindowHydrated.get()).toBe(true);
+    expect(conv?.logRevision.get()).toBe((revision ?? 0) + 1);
   });
 
   it('does not switch to a non-existent branch', () => {

--- a/webui/src/stores/conversations.ts
+++ b/webui/src/stores/conversations.ts
@@ -61,6 +61,9 @@ export interface ConversationState {
   initialStepStream?: boolean;
   // Currently displayed branch name
   currentBranch: string;
+  // Incremented whenever the displayed log is replaced wholesale without a
+  // necessarily observable count/offset change (edit, branch switch, reload).
+  logRevision: number;
   // Max tokens setting for model responses, persisted across operations.
   // Set by ChatInput when sending a message; read by all step() call sites.
   maxTokens?: number;
@@ -109,6 +112,7 @@ export function updateConversation(id: string, update: Partial<ConversationState
       needsInitialStep: false,
       initialStepStream: undefined,
       currentBranch: 'main',
+      logRevision: 0,
       logOffset: 0,
       hasMoreBefore: false,
       isWindowHydrated: false,
@@ -282,6 +286,7 @@ export function initConversation(
     needsInitialStep: options?.needsInitialStep ?? false,
     initialStepStream: options?.initialStepStream,
     currentBranch: 'main',
+    logRevision: 0,
     logOffset: 0,
     hasMoreBefore: false,
     // Treat pre-supplied data (e.g. demo conversations) as hydrated;
@@ -334,6 +339,7 @@ export function updateConversationData(id: string, data: ConversationResponse) {
   const logOffset = data.has_more ? (data.before ?? 0) : 0;
   batch(() => {
     conv.data.set(data);
+    conv.logRevision.set((revision) => revision + 1);
     conv.logOffset.set(logOffset);
     conv.hasMoreBefore.set(data.has_more ?? false);
     conv.isWindowHydrated.set(true);
@@ -350,6 +356,7 @@ export function setCurrentBranch(id: string, branch: string) {
   batch(() => {
     conv.currentBranch.set(branch);
     conv.data.log.set(branches[branch]);
+    conv.logRevision.set((revision) => revision + 1);
     conv.logOffset.set(0);
     conv.hasMoreBefore.set(false);
     conv.isWindowHydrated.set(true);
@@ -364,6 +371,7 @@ export function replaceLog(id: string, log: Message[]) {
   if (!conv) return;
   batch(() => {
     conv.data.log.set(log);
+    conv.logRevision.set((revision) => revision + 1);
     conv.logOffset.set(0);
     conv.hasMoreBefore.set(false);
     conv.isWindowHydrated.set(true);


### PR DESCRIPTION
## Problem

`buildStepRoles` was being called on every streaming token during generation. The `useObserveEffect` that recomputes step role groupings subscribed to `conversation$?.data.log.get()`, which in Legend State triggers on **any** change to the log — including individual message content updates (streaming tokens). For a 50-message conversation with 200 streaming tokens that's ~10k O(n) recomputes.

This is the remaining hot path identified in #3362 after #3363/#3364/#3368 fixed the per-token syntax highlighting issues.

## Fix

Introduce a `logStructureKey$` computed observable that encodes only message count and `logOffset` as a string (e.g. `"12:0"`):

```ts
const logStructureKey$ = useObservable(() => {
  const count = conversation$?.data.log.get()?.length ?? 0;
  const offset = conversation$?.logOffset?.get() ?? 0;
  return \`\${count}:\${offset}\`;
});
```

The selector re-runs on every log mutation, but its **value** only changes when messages are added/removed or the window shifts. Legend State compares observables by value, so the downstream `useObserveEffect` only fires when the structure actually changes.

Inside the effect, `conversation$?.data.log.peek()` replaces `.get()` to read messages without creating a subscription — structural tracking is already handled by `logStructureKey$`.

**Result**: per-streaming-token work for step grouping drops from O(n) `buildStepRoles` calls to O(1), with full recomputes only on message boundary events.

Fixes #3362 (remaining hot path after prior perf PRs).

<!-- gptme-id:v1:gai_diKttxcNLl4M1yPcts9LP9IR6OEvhbiApWyErlmFADb -->