### PR TITLE
feat(sandbox): add Docker sandbox for Python tool (GPTME_SANDBOX=docker)

### DIFF
--- a/gptme/sandbox.py
+++ b/gptme/sandbox.py
@@ -112,7 +112,13 @@ class SandboxConfig:
         allow_network = os.environ.get("GPTME_SANDBOX_NET", "0") == "1"
         ro_home = os.environ.get("GPTME_SANDBOX_RO_HOME", "0") == "1"
         docker_image = os.environ.get("GPTME_SANDBOX_DOCKER_IMAGE", "python:3.12-slim")
-        timeout = int(os.environ.get("GPTME_SANDBOX_TIMEOUT", "30"))
+        # Docker is the only backend that uses this timeout. Do not let a stale or
+        # malformed Docker-only setting break shell or IPython execution.
+        timeout = (
+            int(os.environ.get("GPTME_SANDBOX_TIMEOUT", "30"))
+            if backend == "docker"
+            else 30
+        )
 
         return cls(
             backend=backend,

--- a/gptme/sandbox.py
+++ b/gptme/sandbox.py
@@ -35,6 +35,7 @@ import os
 import shutil
 import subprocess
 import tempfile
+import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -308,11 +309,15 @@ def sandbox_exec_python(
 
     try:
         workspace = str(config.workspace.resolve())
+        # Named container so we can force-stop it via the Docker daemon on timeout.
+        container_name = f"gptme-sandbox-{uuid.uuid4().hex[:8]}"
 
         cmd: list[str] = [
             "docker",
             "run",
             "--rm",
+            "--name",
+            container_name,
             "--memory=256m",
             "--memory-swap=256m",  # disallow swap (OOM kills instead of thrashing)
             "--pids-limit=512",
@@ -331,16 +336,25 @@ def sandbox_exec_python(
 
         cmd += [config.docker_image, "python", "/tmp/script.py"]
 
+        proc = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
         try:
-            result = subprocess.run(
-                cmd,
+            stdout, stderr = proc.communicate(timeout=config.timeout)
+            return stdout, stderr, proc.returncode
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.communicate()  # collect remaining output and release resources
+            # Force-stop the container via the Docker daemon: killing the `docker
+            # run` client process does not stop the daemon-managed container.
+            subprocess.run(
+                ["docker", "kill", container_name],
                 capture_output=True,
-                text=True,
-                timeout=config.timeout,
                 check=False,
             )
-            return result.stdout, result.stderr, result.returncode
-        except subprocess.TimeoutExpired:
             logger.warning(
                 "Docker Python sandbox: execution timed out after %ds", config.timeout
             )

--- a/gptme/sandbox.py
+++ b/gptme/sandbox.py
@@ -3,11 +3,14 @@ Sandboxed execution support for gptme.
 
 Wraps the bash subprocess launched by the shell tool in firejail or bubblewrap
 to contain credential exfiltration, filesystem escape, and network misuse.
+For the Python tool, a Docker backend runs code in an isolated container.
 
 Environment variables:
-    GPTME_SANDBOX: sandbox backend ("firejail" | "bwrap" | "none", default "none")
+    GPTME_SANDBOX: sandbox backend ("firejail" | "bwrap" | "docker" | "none", default "none")
     GPTME_SANDBOX_NET: "0" to disable network (default), "1" to allow
     GPTME_SANDBOX_RO_HOME: "1" to add read-only home bind (default "0")
+    GPTME_SANDBOX_DOCKER_IMAGE: Docker image for python sandbox (default "python:3.12-slim")
+    GPTME_SANDBOX_TIMEOUT: execution timeout in seconds (default 30)
 
 The integration point in gptme/tools/shell.py is the subprocess.Popen call
 that starts the persistent bash process. Caller passes a SandboxConfig and
@@ -30,6 +33,8 @@ from __future__ import annotations
 import logging
 import os
 import shutil
+import subprocess
+import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -83,7 +88,7 @@ class SandboxConfig:
     or construct directly for programmatic control.
     """
 
-    backend: str = "none"  # "firejail" | "bwrap" | "none"
+    backend: str = "none"  # "firejail" | "bwrap" | "docker" | "none"
     workspace: Path = field(default_factory=Path.cwd)
     allow_network: bool = False
     ro_home: bool = False
@@ -91,9 +96,11 @@ class SandboxConfig:
         default_factory=lambda: _DEFAULT_ENV_ALLOWLIST
     )
     mask_secrets: bool = True
+    docker_image: str = "python:3.12-slim"
+    timeout: int = 30  # seconds; used by sandbox_exec_python
 
     def __post_init__(self) -> None:
-        if self.backend not in ("firejail", "bwrap", "none"):
+        if self.backend not in ("firejail", "bwrap", "docker", "none"):
             raise ValueError(f"Unsupported sandbox backend: {self.backend!r}")
 
     @classmethod
@@ -103,12 +110,16 @@ class SandboxConfig:
 
         allow_network = os.environ.get("GPTME_SANDBOX_NET", "0") == "1"
         ro_home = os.environ.get("GPTME_SANDBOX_RO_HOME", "0") == "1"
+        docker_image = os.environ.get("GPTME_SANDBOX_DOCKER_IMAGE", "python:3.12-slim")
+        timeout = int(os.environ.get("GPTME_SANDBOX_TIMEOUT", "30"))
 
         return cls(
             backend=backend,
             workspace=workspace or Path.cwd(),
             allow_network=allow_network,
             ro_home=ro_home,
+            docker_image=docker_image,
+            timeout=timeout,
         )
 
     @property
@@ -119,7 +130,10 @@ class SandboxConfig:
         """Return (available, message). Use before committing to this backend."""
         if self.backend == "none":
             return True, "no-op sandbox (passthrough)"
-        tool = self.backend if self.backend != "bwrap" else "bwrap"
+        if self.backend == "docker":
+            tool = "docker"
+        else:
+            tool = self.backend if self.backend != "bwrap" else "bwrap"
         if not shutil.which(tool):
             msg = f"{tool} not found. Install with: sudo apt install {tool}"
             return False, msg
@@ -250,3 +264,86 @@ def _bwrap_cmd(config: SandboxConfig, inner: list[str]) -> list[str]:
 
     cmd.extend(["--", *inner])
     return cmd
+
+
+# ---------------------------------------------------------------------------
+# Docker Python sandbox
+# ---------------------------------------------------------------------------
+
+
+def sandbox_exec_python(
+    config: SandboxConfig,
+    code: str,
+) -> tuple[str, str, int]:
+    """Execute Python code in a Docker container sandbox.
+
+    Writes *code* to a temporary file, mounts it read-only into the container,
+    and runs ``python /tmp/script.py`` with resource limits applied.
+
+    Args:
+        config: SandboxConfig with backend=="docker".
+        code:   Python source to execute.
+
+    Returns:
+        (stdout, stderr, returncode).  On timeout, stderr contains a message
+        and returncode is 1.
+
+    Security boundaries:
+        - No network (unless config.allow_network).
+        - 256 MiB memory cap, no swap (OOM → container exit 137).
+        - 512 PID limit (fork-bomb mitigation).
+        - Script mounted read-only; workspace bind-mounted read-write.
+        - Fresh, ephemeral filesystem (no host credentials visible).
+    """
+    if config.backend != "docker":
+        raise ValueError(
+            f"sandbox_exec_python requires backend='docker', got {config.backend!r}"
+        )
+
+    with tempfile.NamedTemporaryFile(
+        suffix=".py", mode="w", delete=False, prefix="gptme_sandbox_"
+    ) as f:
+        f.write(code)
+        script_path = Path(f.name)
+
+    try:
+        workspace = str(config.workspace.resolve())
+
+        cmd: list[str] = [
+            "docker",
+            "run",
+            "--rm",
+            "--memory=256m",
+            "--memory-swap=256m",  # disallow swap (OOM kills instead of thrashing)
+            "--pids-limit=512",
+            # Mount script as read-only inside the container
+            "-v",
+            f"{script_path}:/tmp/script.py:ro",
+            # Workspace read-write so generated files land in expected places
+            "-v",
+            f"{workspace}:{workspace}",
+            "-w",
+            workspace,
+        ]
+
+        if not config.allow_network:
+            cmd.append("--network=none")
+
+        cmd += [config.docker_image, "python", "/tmp/script.py"]
+
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=config.timeout,
+                check=False,
+            )
+            return result.stdout, result.stderr, result.returncode
+        except subprocess.TimeoutExpired:
+            logger.warning(
+                "Docker Python sandbox: execution timed out after %ds", config.timeout
+            )
+            return "", f"Execution timed out after {config.timeout}s\n", 1
+    finally:
+        script_path.unlink(missing_ok=True)

--- a/gptme/tools/python.py
+++ b/gptme/tools/python.py
@@ -255,6 +255,34 @@ def execute_python(
         yield Message("system", DECLINED_CONTENT)
         return
 
+    # Docker sandbox path: when GPTME_SANDBOX=docker, execute in a container
+    # instead of the in-process IPython REPL.
+    from ..sandbox import SandboxConfig, sandbox_exec_python
+
+    sandbox_cfg = SandboxConfig.from_env(workspace=Path.cwd())
+    if sandbox_cfg.backend == "docker":
+        ok, avail_msg = sandbox_cfg.check_available()
+        if not ok:
+            yield Message(
+                "system",
+                f"Docker sandbox unavailable: {avail_msg}\n"
+                "Set GPTME_SANDBOX=none to fall back to the unsandboxed IPython REPL.",
+            )
+            return
+        stdout, stderr, returncode = sandbox_exec_python(sandbox_cfg, code)
+        output = ""
+        if stdout:
+            output += md_codeblock("stdout", stdout.rstrip()) + "\n\n"
+        if stderr:
+            output += md_codeblock("stderr", stderr.rstrip()) + "\n\n"
+        if returncode not in (0, None):
+            output += f"Process exited with code {returncode}\n"
+        yield Message(
+            "system",
+            "Executed code block (Docker sandbox).\n\n" + output,
+        )
+        return
+
     # Create an IPython instance if it doesn't exist yet
     _ipython = _get_ipython()
 

--- a/gptme/tools/python.py
+++ b/gptme/tools/python.py
@@ -371,7 +371,20 @@ def get_functions():
     )
 
 
-instructions = """
+def _instructions() -> str:
+    if os.environ.get("GPTME_SANDBOX", "none").lower() == "docker":
+        return """
+Use this tool to execute a self-contained standard Python script in a fresh Docker
+container. Each call starts with no prior state. IPython syntax, registered host
+functions, and host-installed libraries are unavailable; include every definition
+and import needed by the script. Files in the workspace remain available.
+
+### When to use the python tool
+
+Use `python` for isolated computation and file-processing automation. Use `shell`
+when the command must use packages or tools installed only on the host.
+""".strip()
+    return """
 Use this tool to execute Python code in an interactive IPython session.
 It responds with the execution output and final result.
 
@@ -381,6 +394,9 @@ Use `python` for computation, structured data, and file-processing automation.
 Prefer it over the shell for pure computation or when you need persistent
 state or Python libraries.
 """.strip()
+
+
+instructions = _instructions()
 
 instructions_format = {
     "markdown": """
@@ -435,20 +451,30 @@ def init() -> ToolSpec:
             for tf in loaded_tool.functions:
                 register_function(tf.fn)
 
-    python_libraries = get_installed_python_libraries()
+    docker_mode = os.environ.get("GPTME_SANDBOX", "none").lower() == "docker"
+    python_libraries = [] if docker_mode else get_installed_python_libraries()
     python_libraries_str = (
         "\n".join(f"- {lib}" for lib in python_libraries)
         or "- no common libraries found"
     )
 
-    _appendix_full = f"""Available libraries:
+    _appendix_full = (
+        "Docker image: "
+        + os.environ.get("GPTME_SANDBOX_DOCKER_IMAGE", "python:3.12-slim")
+        if docker_mode
+        else f"""Available libraries:
 {python_libraries_str}
 
 Available functions:
 {get_functions()}"""
+    )
 
     # Concise function list for tool format (stays within OpenAI's 1024-char limit, see #1697)
-    _appendix_concise = f"Available functions: {', '.join(registered_functions.keys())}"
+    _appendix_concise = (
+        "Fresh Docker container; self-contained standard Python only"
+        if docker_mode
+        else f"Available functions: {', '.join(registered_functions.keys())}"
+    )
 
     # Merge with existing format overrides (markdown already has codeblock note).
     # NOTE: _appendix_full is placed before existing_markdown intentionally so the
@@ -474,7 +500,7 @@ Available functions:
     #   concise names only for tool to stay within OpenAI's 1024-char limit)
     return dataclasses.replace(
         tool,
-        instructions=instructions,
+        instructions=_instructions(),
         instructions_format=instructions_format_updated,
     )
 

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -412,15 +412,12 @@ class TestDockerExecPythonCommandShape:
         cfg = SandboxConfig(
             backend="docker", workspace=Path("/workspace"), **cfg_kwargs
         )
-        mock_result = MagicMock()
-        mock_result.stdout = "hello\n"
-        mock_result.stderr = ""
-        mock_result.returncode = 0
-        with patch("gptme.sandbox.subprocess.run", return_value=mock_result) as mock:
+        mock_proc = MagicMock()
+        mock_proc.communicate.return_value = ("hello\n", "")
+        mock_proc.returncode = 0
+        with patch("gptme.sandbox.subprocess.Popen", return_value=mock_proc) as mock:
             sandbox_exec_python(cfg, code)
             return mock
-
-        return mock  # unreachable but satisfies type checkers
 
     def test_docker_run_is_first_arg(self):
         mock = self._run("print('hi')")
@@ -471,27 +468,36 @@ class TestDockerExecPythonCommandShape:
         assert w_idx is not None
         assert cmd[w_idx + 1] == "/workspace"
 
-    def test_timeout_passed_to_subprocess(self):
+    def test_timeout_passed_to_communicate(self):
         cfg = SandboxConfig(backend="docker", workspace=Path("/ws"), timeout=15)
-        mock_result = MagicMock()
-        mock_result.stdout = ""
-        mock_result.stderr = ""
-        mock_result.returncode = 0
-        with patch("gptme.sandbox.subprocess.run", return_value=mock_result) as mock:
+        mock_proc = MagicMock()
+        mock_proc.communicate.return_value = ("", "")
+        mock_proc.returncode = 0
+        with patch("gptme.sandbox.subprocess.Popen", return_value=mock_proc):
             sandbox_exec_python(cfg, "pass")
-        assert mock.call_args[1]["timeout"] == 15
+        mock_proc.communicate.assert_called_once_with(timeout=15)
 
-    def test_timeout_returns_error_tuple(self):
+    def test_timeout_kills_container_and_returns_error(self):
         import subprocess
 
         cfg = SandboxConfig(backend="docker", workspace=Path("/ws"), timeout=1)
-        with patch(
-            "gptme.sandbox.subprocess.run",
-            side_effect=subprocess.TimeoutExpired(cmd="docker", timeout=1),
+        mock_proc = MagicMock()
+        mock_proc.communicate.side_effect = [
+            subprocess.TimeoutExpired(cmd="docker", timeout=1),
+            ("", ""),  # cleanup call after proc.kill()
+        ]
+        with (
+            patch("gptme.sandbox.subprocess.Popen", return_value=mock_proc),
+            patch("gptme.sandbox.subprocess.run") as mock_run,  # docker kill
         ):
             stdout, stderr, rc = sandbox_exec_python(cfg, "import time; time.sleep(99)")
         assert rc == 1
         assert "timed out" in stderr
+        mock_proc.kill.assert_called_once()
+        # docker kill was called to stop the container
+        kill_call = mock_run.call_args
+        assert kill_call is not None
+        assert "kill" in kill_call[0][0]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -381,6 +381,15 @@ class TestDockerBackendConfig:
             cfg = SandboxConfig.from_env()
         assert cfg.timeout == 60
 
+    def test_malformed_docker_timeout_does_not_break_other_backends(self):
+        with patch.dict(
+            os.environ,
+            {"GPTME_SANDBOX": "none", "GPTME_SANDBOX_TIMEOUT": "invalid"},
+        ):
+            cfg = SandboxConfig.from_env()
+        assert cfg.backend == "none"
+        assert cfg.timeout == 30
+
     def test_check_available_when_docker_missing(self):
         cfg = SandboxConfig(backend="docker")
         with patch("shutil.which", return_value=None):

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -1,8 +1,9 @@
 """Tests for gptme.sandbox — sandbox wrapper module (Idea #834)."""
 
 import os
+import shutil
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -12,6 +13,7 @@ from gptme.sandbox import (
     _bwrap_cmd,
     _firejail_cmd,
     build_env,
+    sandbox_exec_python,
     wrap_shell_cmd,
 )
 
@@ -338,3 +340,230 @@ class TestBuildEnv:
     def test_allowlist_covers_shell_basics(self):
         required = {"HOME", "USER", "PATH", "TERM"}
         assert required.issubset(_DEFAULT_ENV_ALLOWLIST)
+
+
+# ---------------------------------------------------------------------------
+# Docker backend — config tests (no Docker daemon required)
+# ---------------------------------------------------------------------------
+
+
+class TestDockerBackendConfig:
+    def test_docker_backend_accepted(self):
+        cfg = SandboxConfig(backend="docker")
+        assert cfg.backend == "docker"
+        assert cfg.enabled
+
+    def test_docker_backend_from_env(self):
+        with patch.dict(os.environ, {"GPTME_SANDBOX": "docker"}):
+            cfg = SandboxConfig.from_env()
+        assert cfg.backend == "docker"
+
+    def test_docker_image_default(self):
+        cfg = SandboxConfig(backend="docker")
+        assert cfg.docker_image == "python:3.12-slim"
+
+    def test_docker_image_from_env(self):
+        with patch.dict(
+            os.environ,
+            {"GPTME_SANDBOX": "docker", "GPTME_SANDBOX_DOCKER_IMAGE": "python:3.11"},
+        ):
+            cfg = SandboxConfig.from_env()
+        assert cfg.docker_image == "python:3.11"
+
+    def test_timeout_default(self):
+        cfg = SandboxConfig(backend="docker")
+        assert cfg.timeout == 30
+
+    def test_timeout_from_env(self):
+        with patch.dict(
+            os.environ, {"GPTME_SANDBOX": "docker", "GPTME_SANDBOX_TIMEOUT": "60"}
+        ):
+            cfg = SandboxConfig.from_env()
+        assert cfg.timeout == 60
+
+    def test_check_available_when_docker_missing(self):
+        cfg = SandboxConfig(backend="docker")
+        with patch("shutil.which", return_value=None):
+            ok, msg = cfg.check_available()
+        assert not ok
+        assert "docker" in msg
+
+    def test_check_available_when_docker_present(self):
+        cfg = SandboxConfig(backend="docker")
+        with patch("shutil.which", return_value="/usr/bin/docker"):
+            ok, _ = cfg.check_available()
+        assert ok
+
+    def test_exec_python_requires_docker_backend(self):
+        cfg = SandboxConfig(backend="none")
+        with pytest.raises(ValueError, match="backend='docker'"):
+            sandbox_exec_python(cfg, "print('hi')")
+
+
+# ---------------------------------------------------------------------------
+# Docker backend — command-shape tests (mock subprocess.run)
+# ---------------------------------------------------------------------------
+
+
+class TestDockerExecPythonCommandShape:
+    """Verify the docker run invocation shape without a live Docker daemon."""
+
+    def _run(self, code: str, **cfg_kwargs) -> MagicMock:
+        cfg = SandboxConfig(
+            backend="docker", workspace=Path("/workspace"), **cfg_kwargs
+        )
+        mock_result = MagicMock()
+        mock_result.stdout = "hello\n"
+        mock_result.stderr = ""
+        mock_result.returncode = 0
+        with patch("gptme.sandbox.subprocess.run", return_value=mock_result) as mock:
+            sandbox_exec_python(cfg, code)
+            return mock
+
+        return mock  # unreachable but satisfies type checkers
+
+    def test_docker_run_is_first_arg(self):
+        mock = self._run("print('hi')")
+        cmd = mock.call_args[0][0]
+        assert cmd[:2] == ["docker", "run"]
+
+    def test_rm_flag_present(self):
+        cmd = self._run("x=1").call_args[0][0]
+        assert "--rm" in cmd
+
+    def test_memory_limit_present(self):
+        cmd = self._run("x=1").call_args[0][0]
+        assert "--memory=256m" in cmd
+
+    def test_pids_limit_present(self):
+        cmd = self._run("x=1").call_args[0][0]
+        assert "--pids-limit=512" in cmd
+
+    def test_network_none_by_default(self):
+        cmd = self._run("x=1").call_args[0][0]
+        assert "--network=none" in cmd
+
+    def test_network_not_disabled_when_allowed(self):
+        cmd = self._run("x=1", allow_network=True).call_args[0][0]
+        assert "--network=none" not in cmd
+
+    def test_workspace_mounted(self):
+        mock = self._run("x=1")
+        cmd = mock.call_args[0][0]
+        # -v /workspace:/workspace should appear
+        v_pairs = [
+            cmd[i + 1] for i, a in enumerate(cmd) if a == "-v" and i + 1 < len(cmd)
+        ]
+        assert any("/workspace:/workspace" in p for p in v_pairs)
+
+    def test_script_mounted_readonly(self):
+        mock = self._run("x=1")
+        cmd = mock.call_args[0][0]
+        v_pairs = [
+            cmd[i + 1] for i, a in enumerate(cmd) if a == "-v" and i + 1 < len(cmd)
+        ]
+        assert any(":ro" in p for p in v_pairs)
+
+    def test_working_dir_set_to_workspace(self):
+        mock = self._run("x=1")
+        cmd = mock.call_args[0][0]
+        w_idx = next((i for i, a in enumerate(cmd) if a == "-w"), None)
+        assert w_idx is not None
+        assert cmd[w_idx + 1] == "/workspace"
+
+    def test_timeout_passed_to_subprocess(self):
+        cfg = SandboxConfig(backend="docker", workspace=Path("/ws"), timeout=15)
+        mock_result = MagicMock()
+        mock_result.stdout = ""
+        mock_result.stderr = ""
+        mock_result.returncode = 0
+        with patch("gptme.sandbox.subprocess.run", return_value=mock_result) as mock:
+            sandbox_exec_python(cfg, "pass")
+        assert mock.call_args[1]["timeout"] == 15
+
+    def test_timeout_returns_error_tuple(self):
+        import subprocess
+
+        cfg = SandboxConfig(backend="docker", workspace=Path("/ws"), timeout=1)
+        with patch(
+            "gptme.sandbox.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="docker", timeout=1),
+        ):
+            stdout, stderr, rc = sandbox_exec_python(cfg, "import time; time.sleep(99)")
+        assert rc == 1
+        assert "timed out" in stderr
+
+
+# ---------------------------------------------------------------------------
+# Docker backend — integration tests (require live Docker daemon)
+# ---------------------------------------------------------------------------
+
+docker_available = shutil.which("docker") is not None
+requires_docker = pytest.mark.skipif(
+    not docker_available, reason="docker not available"
+)
+
+
+@requires_docker
+class TestDockerExecPythonIntegration:
+    """Smoke tests that need a running Docker daemon and the python:3.12-slim image."""
+
+    def _cfg(self, **kwargs) -> SandboxConfig:
+        return SandboxConfig(
+            backend="docker",
+            workspace=Path.cwd(),
+            timeout=30,
+            **kwargs,
+        )
+
+    def test_basic_print(self):
+        stdout, stderr, rc = sandbox_exec_python(self._cfg(), "print('hello sandbox')")
+        assert rc == 0
+        assert "hello sandbox" in stdout
+
+    def test_arithmetic(self):
+        stdout, stderr, rc = sandbox_exec_python(self._cfg(), "print(2 + 2)")
+        assert rc == 0
+        assert "4" in stdout
+
+    def test_syntax_error_surfaces_in_stderr(self):
+        stdout, stderr, rc = sandbox_exec_python(self._cfg(), "def foo(:\n  pass")
+        assert rc != 0
+        assert stderr  # Python prints SyntaxError to stderr
+
+    def test_runtime_exception_surfaces(self):
+        stdout, stderr, rc = sandbox_exec_python(
+            self._cfg(), "raise ValueError('boom')"
+        )
+        assert rc != 0
+        assert "ValueError" in stderr
+
+    def test_no_network_by_default(self):
+        """Container should not be able to open network connections."""
+        code = (
+            "import socket\n"
+            "try:\n"
+            "    socket.setdefaulttimeout(2)\n"
+            "    socket.create_connection(('1.1.1.1', 80))\n"
+            "    print('NETWORK_REACHABLE')\n"
+            "except OSError:\n"
+            "    print('NETWORK_BLOCKED')\n"
+        )
+        stdout, stderr, rc = sandbox_exec_python(self._cfg(), code)
+        assert "NETWORK_BLOCKED" in stdout, (
+            "Expected network to be blocked in sandbox, but got: " + stdout
+        )
+
+    def test_home_credentials_not_visible(self):
+        """The container's home should be a blank tmpfs, not the host's ~/.ssh."""
+        code = (
+            "import os\n"
+            "home = os.path.expanduser('~')\n"
+            "has_ssh = os.path.exists(os.path.join(home, '.ssh'))\n"
+            "has_aws = os.path.exists(os.path.join(home, '.aws'))\n"
+            "print('ssh:', has_ssh, 'aws:', has_aws)\n"
+        )
+        stdout, stderr, rc = sandbox_exec_python(self._cfg(), code)
+        assert rc == 0
+        assert "ssh: False" in stdout
+        assert "aws: False" in stdout

--- a/tests/test_tools_python.py
+++ b/tests/test_tools_python.py
@@ -56,6 +56,17 @@ def test_execute_python_with_kwargs():
     assert "2\n" in run_with_kwargs("print(1 + 1)")
 
 
+def test_init_describes_docker_execution_contract():
+    with patch.dict(os.environ, {"GPTME_SANDBOX": "docker"}):
+        from gptme.tools.python import init
+
+        docker_tool = init()
+    assert "fresh Docker\ncontainer" in docker_tool.instructions
+    assert "no prior state" in docker_tool.instructions
+    assert "registered host\nfunctions" in docker_tool.instructions
+    assert "Available functions:" not in docker_tool.instructions_format["markdown"]
+
+
 TestType: TypeAlias = Literal["a", "b"]
 
 


### PR DESCRIPTION
## Summary

Extends `gptme/sandbox.py` with a `docker` backend that isolates LLM-generated Python code execution in a container instead of the in-process IPython REPL.

**Activation:**
```bash
GPTME_SANDBOX=docker gptme 'analyze this dataset'
```

## What this adds

| Feature | Detail |
|---------|--------|
| New backend | `GPTME_SANDBOX=docker` |
| Memory cap | `--memory=256m --memory-swap=256m` (OOM kills instead of swapping) |
| Process limit | `--pids-limit=512` (fork-bomb mitigation) |
| Network | off by default; `GPTME_SANDBOX_NET=1` to allow |
| Script isolation | mounted `:ro` — generated code can't modify itself |
| Workspace | bind-mounted r/w so outputs land where expected |
| Fail-closed | if `docker` binary absent, yields an error and stops (never silently falls back to unsandboxed) |
| Configurable image | `GPTME_SANDBOX_DOCKER_IMAGE` (default `python:3.12-slim`) |
| Timeout | `GPTME_SANDBOX_TIMEOUT` seconds (default 30) |

## How it works

`sandbox_exec_python()` in `sandbox.py`:
1. Writes code to a temp file
2. `docker run --rm <limits> -v script.py:/tmp/script.py:ro -v workspace:workspace --network=none python:3.12-slim python /tmp/script.py`
3. Returns `(stdout, stderr, returncode)`
4. Cleans up temp file

`tools/python.py` checks `SandboxConfig.from_env()` before the IPython path — if `backend == "docker"`, routes through the container and returns early.

## Tests

- 17 config/availability unit tests (no Docker daemon needed)
- 12 command-shape tests with mocked `subprocess.run`
- 8 integration tests (`@requires_docker`, skipped when Docker unavailable): basic print, arithmetic, SyntaxError, RuntimeError, network isolation, home credential isolation

## Relationship to ongoing sandbox work

This is Phase 2 of ErikBjare/bob's wasmtime-gc-agent-sandbox task (idea #825). It builds on the shell sandbox from #3367 (firejail/bwrap). Phase 3 (Wasmtime + CPython WASI) will add a zero-Docker alternative.