### PR TITLE
feat(webui): virtualize message list with @tanstack/react-virtual

### DIFF
--- a/webui/e2e/conversation.spec.ts
+++ b/webui/e2e/conversation.spec.ts
@@ -186,8 +186,8 @@ test.describe('Split View', () => {
     await page.goto('/chat/introduction');
     await page.waitForLoadState('networkidle');
 
-    // Should see the conversation content
-    await expect(page.getByText(/Hello! I'm gptme/)).toBeVisible({ timeout: 10000 });
+    // Should see the conversation content (virtualizer shows only viewport messages)
+    await expect(page.locator('[data-message-index]').first()).toBeVisible({ timeout: 10000 });
 
     // Press keyboard shortcut (Ctrl+Shift+\) to open split view
     await page.keyboard.press('Control+Shift+\\');

--- a/webui/e2e/performance.spec.ts
+++ b/webui/e2e/performance.spec.ts
@@ -25,7 +25,8 @@ test.describe('Performance: sidebar hot-loop prevention', () => {
 
     // Open the demo conversation to populate the Observable store with messages
     await page.getByText('Introduction to gptme').click();
-    await expect(page.getByText(/Hello! I'm gptme/)).toBeVisible({ timeout: 10000 });
+    // With virtualization only viewport messages are in the DOM; check any message rendered.
+    await expect(page.locator('[data-message-index]').first()).toBeVisible({ timeout: 10000 });
 
     // Use CDP Performance.getMetrics instead of the removed page.metrics() API
     const cdp = await page.context().newCDPSession(page);
@@ -46,7 +47,7 @@ test.describe('Performance: sidebar hot-loop prevention', () => {
       await page.goto('/', { waitUntil: 'domcontentloaded' });
       await expect(page.getByTestId('conversation-list')).toBeVisible();
       await page.getByText('Introduction to gptme').click();
-      await expect(page.getByText(/Hello! I'm gptme/)).toBeVisible({ timeout: 10000 });
+      await expect(page.locator('[data-message-index]').first()).toBeVisible({ timeout: 10000 });
     }
 
     const afterHeap = await sampleHeapUsed();

--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -39,6 +39,7 @@
         "@radix-ui/react-toggle-group": "^1.1.0",
         "@radix-ui/react-tooltip": "^1.1.2",
         "@tanstack/react-query": "^5.56.2",
+        "@tanstack/react-virtual": "^3.14.8",
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-log": "^2.4.0",
         "class-variance-authority": "^0.7.0",
@@ -4109,6 +4110,33 @@
       },
       "peerDependencies": {
         "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.14.8",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.8.tgz",
+      "integrity": "sha512-O39GJQpAYEJcIu3uN1//YtmhjSEOyw75vg9CKCatBDPiD5hKtZQoJHfferyrB/LdOD3UWaoMLWtdEjarwIwdDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.17.6"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.17.6",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.6.tgz",
+      "integrity": "sha512-h0/Ebo18CkOrChlQIhNtQkM5ySUnh/GumQ/D1st3hG2HWUPEF+ILUc2k29UtivCi/9G7w7G3/f7Xyd5cCFbKBw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@tauri-apps/api": {

--- a/webui/package.json
+++ b/webui/package.json
@@ -52,6 +52,7 @@
     "@radix-ui/react-toggle-group": "^1.1.0",
     "@radix-ui/react-tooltip": "^1.1.2",
     "@tanstack/react-query": "^5.56.2",
+    "@tanstack/react-virtual": "^3.14.8",
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-log": "^2.4.0",
     "class-variance-authority": "^0.7.0",

--- a/webui/src/components/ConversationContent.tsx
+++ b/webui/src/components/ConversationContent.tsx
@@ -1,5 +1,6 @@
 import type { FC } from 'react';
 import { useRef, useEffect, useCallback, useState } from 'react';
+import { useVirtualizer } from '@tanstack/react-virtual';
 import { useNavigate } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
 import { ChatMessage } from './ChatMessage';
@@ -15,8 +16,7 @@ import { InlineToolConfirmation } from './InlineToolConfirmation';
 import { MessageSearchBar } from './MessageSearchBar';
 import { InlineToolExecution, ToolCompletionBadge } from './InlineToolExecution';
 import { OpenConversationPathButton } from './OpenConversationPathButton';
-import { For, Memo, use$, useObservable, useObserveEffect } from '@legendapp/state/react';
-import { getObservableIndex } from '@legendapp/state';
+import { Memo, use$, useObservable, useObserveEffect } from '@legendapp/state/react';
 import { useApi } from '@/contexts/ApiContext';
 import { useSettings } from '@/contexts/SettingsContext';
 import { useModels } from '@/hooks/useModels';
@@ -304,6 +304,34 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
   // Create a ref for the scroll container
   const scrollContainerRef = useRef<HTMLDivElement>(null);
 
+  // Reactive reads for virtualizer rendering — using use$() so changes trigger
+  // a React re-render and the virtualizer map gets fresh values.
+  const expandedGroups = use$(expandedGroups$);
+  const logOffsetValue = use$(() => conversation$?.logOffset?.get() ?? 0);
+  const stepRolesValue = use$(stepRoles$);
+
+  // Virtualizer: renders only visible messages, dramatically reducing DOM nodes
+  // for long conversations.  estimateSize is a rough average; measureElement
+  // (ResizeObserver-based) corrects actual heights after first render.
+  const virtualizer = useVirtualizer({
+    count: messageCount,
+    getScrollElement: () => scrollContainerRef.current,
+    estimateSize: () => 150,
+    overscan: 5,
+    getItemKey: (index) => {
+      const off = conversation$?.logOffset?.peek() ?? 0;
+      const msg = conversation$?.data.log[index]?.peek();
+      return msg ? `${off + index}-${msg.timestamp}` : `${off + index}`;
+    },
+  });
+
+  // Mutable refs so effects/callbacks always hold the latest virtualizer and
+  // messageCount without stale-closure issues.
+  const virtualizerRef = useRef(virtualizer);
+  const messageCountRef = useRef(messageCount);
+  virtualizerRef.current = virtualizer;
+  messageCountRef.current = messageCount;
+
   // Pending rAF handle for scroll-to-bottom — cancelled before re-scheduling so
   // a burst of log updates queues at most one scroll per animation frame.
   const scrollRAFRef = useRef<number | null>(null);
@@ -332,10 +360,12 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
   });
 
   const scrollToBottom = useCallback(() => {
-    const container = scrollContainerRef.current;
-    if (!container) return;
+    const count = messageCountRef.current;
+    if (count <= 0) return;
     isAutoScrolling$.set(true);
-    container.scrollTop = container.scrollHeight;
+    // scrollToIndex ensures the last item is actually rendered before measuring,
+    // which is more reliable than container.scrollHeight with virtual lists.
+    virtualizerRef.current.scrollToIndex(count - 1, { align: 'end' });
     requestAnimationFrame(() => {
       isAutoScrolling$.set(false);
     });
@@ -429,20 +459,30 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
     ]
   );
 
-  // Search helpers: imperative DOM highlight + scroll, avoids re-rendering all messages
+  // Search helpers: imperative DOM highlight + scroll, avoids re-rendering all messages.
+  // With virtualization the target element may not be in the DOM yet, so we first
+  // scroll the virtualizer to bring it into the rendered range, then query + highlight.
   const highlightSearchMatch = useCallback(
     (msgIndex: number) => {
       clearSearchHighlights();
-      const el = scrollContainerRef.current?.querySelector<HTMLElement>(
-        `[data-message-index="${msgIndex}"]`
-      );
-      if (el) {
-        el.style.outline = '2px solid rgba(234,179,8,0.6)';
-        el.style.outlineOffset = '-2px';
-        el.scrollIntoView({ behavior: 'smooth', block: 'center' });
-      }
+      const logOff = conversation$?.logOffset?.get() ?? 0;
+      const localIndex = msgIndex - logOff;
+      // Instant scroll brings the item into the DOM immediately.
+      virtualizerRef.current.scrollToIndex(localIndex, { align: 'center' });
+      // Two rAFs: first lets the virtualizer commit, second lets layout flush.
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          const el = scrollContainerRef.current?.querySelector<HTMLElement>(
+            `[data-message-index="${msgIndex}"]`
+          );
+          if (el) {
+            el.style.outline = '2px solid rgba(234,179,8,0.6)';
+            el.style.outlineOffset = '-2px';
+          }
+        });
+      });
     },
-    [clearSearchHighlights, scrollContainerRef]
+    [clearSearchHighlights, conversation$]
   );
 
   const computeSearchMatches = useCallback(
@@ -551,16 +591,16 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
   }, [pendingToolId, settings.noConfirmMode]);
 
   const handleScrollToBottom = () => {
-    const container = scrollContainerRef.current;
-    if (container) {
+    const count = messageCountRef.current;
+    if (count > 0) {
       isAutoScrolling$.set(true);
-      container.scrollTo({
-        top: container.scrollHeight,
-        behavior: 'smooth',
-      });
-      container.addEventListener('scrollend', () => isAutoScrolling$.set(false), {
-        once: true,
-      });
+      virtualizerRef.current.scrollToIndex(count - 1, { align: 'end', behavior: 'smooth' });
+      const container = scrollContainerRef.current;
+      if (container) {
+        container.addEventListener('scrollend', () => isAutoScrolling$.set(false), {
+          once: true,
+        });
+      }
     }
     autoScrollAborted$.set(false);
     isScrolledUp$.set(false);
@@ -789,122 +829,175 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
           </div>
         )}
 
-        <For each={conversation$?.data.log ?? []}>
-          {(msg$) => {
-            // index is the LOCAL array position in the current log window.
-            const index = getObservableIndex(msg$);
+        {/* Virtual message list — only visible rows are in the DOM.
+            The outer div establishes the total scroll height; each item is
+            absolutely positioned via transform so the container never reflows. */}
+        <div
+          style={{
+            height: `${virtualizer.getTotalSize()}px`,
+            width: '100%',
+            position: 'relative',
+          }}
+        >
+          {virtualizer.getVirtualItems().map((virtualItem) => {
+            const index = virtualItem.index;
+            // Guard against count/log getting briefly out of sync.
+            const msg$ = conversation$?.data.log[index];
+            if (!msg$) return null;
+
             // absoluteIndex is the position in the full conversation (server-space).
             // All server-bound operations and index-keyed maps use absoluteIndex.
-            const logOffset = conversation$?.logOffset?.get() ?? 0;
-            const absoluteIndex = logOffset + index;
+            const absoluteIndex = logOffsetValue + index;
 
-            // Hide all system messages before the first non-system message by default
-            const firstNonSystemIndex = firstNonSystemIndex$.get();
+            // Wrapper shared by every case: TanStack Virtual needs data-index on
+            // the element passed to measureElement so it can track heights.
+            const wrapperStyle: React.CSSProperties = {
+              position: 'absolute',
+              top: 0,
+              transform: `translateY(${virtualItem.start}px)`,
+              width: '100%',
+            };
+
+            // Hide all system messages before the first non-system message by default.
+            // Use peek() — reads are not inside a reactive context here; reactivity
+            // is handled by component-level use$() calls (showInitialSystem$, etc.)
+            // that trigger a re-render when settings change.
+            const firstNonSystemIndex = firstNonSystemIndex$.peek();
             const isInitialSystem =
-              msg$.role.get() === 'system' &&
+              msg$.role.peek() === 'system' &&
               (firstNonSystemIndex === -1 || index < firstNonSystemIndex);
-            if (isInitialSystem && !showInitialSystem$.get()) {
-              return <div key={`${absoluteIndex}-${msg$.timestamp.get()}`} />;
+            if (isInitialSystem && !settings.showInitialSystem) {
+              return (
+                <div
+                  key={virtualItem.key}
+                  data-index={virtualItem.index}
+                  ref={virtualizer.measureElement}
+                  style={wrapperStyle}
+                />
+              );
             }
 
             // Hide messages with hide=true (e.g., auto-included lessons)
-            if (msg$.hide?.get() && !showHiddenMessages$.get()) {
-              return <div key={`${absoluteIndex}-${msg$.timestamp.get()}`} />;
+            if (msg$.hide?.peek() && !settings.showHiddenMessages) {
+              return (
+                <div
+                  key={virtualItem.key}
+                  data-index={virtualItem.index}
+                  ref={virtualizer.measureElement}
+                  style={wrapperStyle}
+                />
+              );
             }
 
             // Get the previous and next *visible* messages for chain context
-            // (skip hidden messages so they don't break chain grouping)
-            // prevIdx/nextIdx are LOCAL for array traversal.
+            // (skip hidden messages so they don't break chain grouping).
             let prevIdx = index - 1;
             while (prevIdx >= 0 && isMessageHidden(prevIdx)) prevIdx--;
             const previousMessage$ = prevIdx >= 0 ? conversation$.data.log[prevIdx] : undefined;
 
             let nextIdx = index + 1;
-            while (conversation$.data.log[nextIdx]?.get() && isMessageHidden(nextIdx)) nextIdx++;
-            const nextMessage$ = conversation$.data.log[nextIdx]?.get()
+            while (conversation$.data.log[nextIdx]?.peek() && isMessageHidden(nextIdx)) nextIdx++;
+            const nextMessage$ = conversation$.data.log[nextIdx]?.peek()
               ? conversation$.data.log[nextIdx]
               : undefined;
 
-            // Step grouping: stepRoles$ is keyed by ABSOLUTE index.
-            // Key-level access gives per-row fine-grained reactivity (only this row
-            // re-renders when its role changes, not all rows).
-            const stepRole = stepRoles$[absoluteIndex].get();
+            // stepRolesValue is read via use$() at the component level, so any
+            // structural change that updates stepRoles$ triggers a re-render here.
+            const stepRole = stepRolesValue[absoluteIndex];
 
-            // If this is a grouped message and the group is collapsed, hide it
-            if (stepRole?.type === 'grouped' && !expandedGroups$.get().has(stepRole.groupId)) {
-              return <div key={`${absoluteIndex}-${msg$.timestamp.get()}`} />;
+            // If this is a grouped message and the group is collapsed, render as
+            // a zero-height placeholder so the virtualizer measures it correctly.
+            if (stepRole?.type === 'grouped' && !expandedGroups.has(stepRole.groupId)) {
+              return (
+                <div
+                  key={virtualItem.key}
+                  data-index={virtualItem.index}
+                  ref={virtualizer.measureElement}
+                  style={wrapperStyle}
+                />
+              );
             }
 
             // If this is a group-start, render the summary bar
-            // (when collapsed, replaces the message; when expanded, shown above messages)
+            // (when collapsed, replaces the message; when expanded, shown above it)
             const groupSummary =
               stepRole?.type === 'group-start' ? (
                 <CollapsedStepGroup
                   count={stepRole.count}
                   tools={stepRole.tools}
                   steps={stepRole.steps}
-                  isExpanded={expandedGroups$.get().has(stepRole.groupId)}
+                  isExpanded={expandedGroups.has(stepRole.groupId)}
                   onToggle={() => toggleGroup(stepRole.groupId)}
                 />
               ) : null;
 
-            // When group is collapsed and this is group-start, show only the summary bar
-            if (stepRole?.type === 'group-start' && !expandedGroups$.get().has(stepRole.groupId)) {
-              return <div key={`${absoluteIndex}-${msg$.timestamp.get()}`}>{groupSummary}</div>;
+            if (stepRole?.type === 'group-start' && !expandedGroups.has(stepRole.groupId)) {
+              return (
+                <div
+                  key={virtualItem.key}
+                  data-index={virtualItem.index}
+                  ref={virtualizer.measureElement}
+                  style={wrapperStyle}
+                >
+                  {groupSummary}
+                </div>
+              );
             }
 
-            // Construct agent avatar URL if agent has avatar configured
-            // NOTE: must use .get() to read actual values from Legend State observables
             const baseUrl = connectionConfig.baseUrl.replace(/\/+$/, '');
-            const agentAvatarUrl = conversation$.data.agent?.avatar?.get()
+            const agentAvatarUrl = conversation$.data.agent?.avatar?.peek()
               ? `${baseUrl}/api/v2/conversations/${conversationId}/agent/avatar`
               : undefined;
-            const agentName = conversation$.data.agent?.name?.get();
+            const agentName = conversation$.data.agent?.name?.peek();
 
             return (
               <div
-                key={`${absoluteIndex}-${msg$.timestamp.get()}`}
-                data-message-index={absoluteIndex}
+                key={virtualItem.key}
+                data-index={virtualItem.index}
+                ref={virtualizer.measureElement}
+                style={wrapperStyle}
               >
-                {/* Show summary bar above first message when group is expanded */}
-                {groupSummary}
-                <ChatMessage
-                  message$={msg$}
-                  previousMessage$={previousMessage$}
-                  nextMessage$={nextMessage$}
-                  conversationId={conversationId}
-                  agentAvatarUrl={agentAvatarUrl}
-                  agentName={agentName}
-                  onRetry={isReadOnly ? undefined : retryMessage}
-                  onEdit={isReadOnly ? undefined : editMessage}
-                  onDelete={isReadOnly ? undefined : deleteMessage}
-                  onRerun={isReadOnly ? undefined : rerunFromMessage}
-                  onRegenerate={isReadOnly ? undefined : regenerateMessage}
-                  onFork={isReadOnly ? undefined : handleForkMessage}
-                  messageIndex={absoluteIndex}
-                  hideAvatar={
-                    stepRole?.type === 'group-start' && expandedGroups$.get().has(stepRole.groupId)
-                  }
-                />
-                {/* Branch indicator at fork points */}
-                <Memo>
-                  {() => {
-                    // forkPoints$ is computed from branches and keyed by absolute index.
-                    const forkInfo = forkPoints$.get().get(absoluteIndex);
-                    if (!forkInfo) return null;
-                    return (
-                      <div className="mx-auto max-w-3xl">
-                        <div className="md:px-12">
-                          <BranchIndicator forkInfo={forkInfo} onSwitchBranch={switchBranch} />
+                {/* data-message-index is used by search highlight and branch indicator */}
+                <div data-message-index={absoluteIndex}>
+                  {/* Show summary bar above first message when group is expanded */}
+                  {groupSummary}
+                  <ChatMessage
+                    message$={msg$}
+                    previousMessage$={previousMessage$}
+                    nextMessage$={nextMessage$}
+                    conversationId={conversationId}
+                    agentAvatarUrl={agentAvatarUrl}
+                    agentName={agentName}
+                    onRetry={isReadOnly ? undefined : retryMessage}
+                    onEdit={isReadOnly ? undefined : editMessage}
+                    onDelete={isReadOnly ? undefined : deleteMessage}
+                    onRerun={isReadOnly ? undefined : rerunFromMessage}
+                    onRegenerate={isReadOnly ? undefined : regenerateMessage}
+                    onFork={isReadOnly ? undefined : handleForkMessage}
+                    messageIndex={absoluteIndex}
+                    hideAvatar={
+                      stepRole?.type === 'group-start' && expandedGroups.has(stepRole.groupId)
+                    }
+                  />
+                  {/* Branch indicator at fork points */}
+                  <Memo>
+                    {() => {
+                      const forkInfo = forkPoints$.get().get(absoluteIndex);
+                      if (!forkInfo) return null;
+                      return (
+                        <div className="mx-auto max-w-3xl">
+                          <div className="md:px-12">
+                            <BranchIndicator forkInfo={forkInfo} onSwitchBranch={switchBranch} />
+                          </div>
                         </div>
-                      </div>
-                    );
-                  }}
-                </Memo>
+                      );
+                    }}
+                  </Memo>
+                </div>
               </div>
             );
-          }}
-        </For>
+          })}
+        </div>
 
         {/* Inline Tool Confirmation — hidden when no-confirm mode is active */}
         {!settings.noConfirmMode && (

--- a/webui/src/components/ConversationContent.tsx
+++ b/webui/src/components/ConversationContent.tsx
@@ -1,5 +1,5 @@
 import type { FC } from 'react';
-import { useRef, useEffect, useCallback, useState } from 'react';
+import { useRef, useEffect, useCallback, useMemo, useState } from 'react';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { useNavigate } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
@@ -310,15 +310,48 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
   const logOffsetValue = use$(() => conversation$?.logOffset?.get() ?? 0);
   const stepRolesValue = use$(stepRoles$);
 
+  // Virtualize only rows that can render content. Hidden messages otherwise
+  // reserve their estimate until ResizeObserver measures a zero-height wrapper,
+  // creating blank regions and shifting scroll positions.
+  const visibleMessageIndices = useMemo(() => {
+    const indices: number[] = [];
+    const firstNonSystemIndex = firstNonSystemIndex$.peek();
+
+    for (let index = 0; index < messageCount; index++) {
+      const msg = conversation$?.data.log[index]?.peek();
+      if (!msg) continue;
+
+      const isInitialSystem =
+        msg.role === 'system' && (firstNonSystemIndex === -1 || index < firstNonSystemIndex);
+      if (isInitialSystem && !settings.showInitialSystem) continue;
+      if (msg.hide && !settings.showHiddenMessages) continue;
+
+      const stepRole = stepRolesValue[logOffsetValue + index];
+      if (stepRole?.type === 'grouped' && !expandedGroups.has(stepRole.groupId)) continue;
+      indices.push(index);
+    }
+    return indices;
+  }, [
+    conversation$,
+    expandedGroups,
+    firstNonSystemIndex$,
+    logOffsetValue,
+    messageCount,
+    settings.showHiddenMessages,
+    settings.showInitialSystem,
+    stepRolesValue,
+  ]);
+
   // Virtualizer: renders only visible messages, dramatically reducing DOM nodes
-  // for long conversations.  estimateSize is a rough average; measureElement
+  // for long conversations. estimateSize is a rough average; measureElement
   // (ResizeObserver-based) corrects actual heights after first render.
   const virtualizer = useVirtualizer({
-    count: messageCount,
+    count: visibleMessageIndices.length,
     getScrollElement: () => scrollContainerRef.current,
     estimateSize: () => 150,
     overscan: 5,
-    getItemKey: (index) => {
+    getItemKey: (virtualIndex) => {
+      const index = visibleMessageIndices[virtualIndex];
       const off = conversation$?.logOffset?.peek() ?? 0;
       const msg = conversation$?.data.log[index]?.peek();
       return msg ? `${off + index}-${msg.timestamp}` : `${off + index}`;
@@ -326,11 +359,11 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
   });
 
   // Mutable refs so effects/callbacks always hold the latest virtualizer and
-  // messageCount without stale-closure issues.
+  // visible index mapping without stale-closure issues.
   const virtualizerRef = useRef(virtualizer);
-  const messageCountRef = useRef(messageCount);
+  const visibleMessageIndicesRef = useRef(visibleMessageIndices);
   virtualizerRef.current = virtualizer;
-  messageCountRef.current = messageCount;
+  visibleMessageIndicesRef.current = visibleMessageIndices;
 
   // Pending rAF handle for scroll-to-bottom — cancelled before re-scheduling so
   // a burst of log updates queues at most one scroll per animation frame.
@@ -360,7 +393,7 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
   });
 
   const scrollToBottom = useCallback(() => {
-    const count = messageCountRef.current;
+    const count = visibleMessageIndicesRef.current.length;
     if (count <= 0) return;
     isAutoScrolling$.set(true);
     // scrollToIndex ensures the last item is actually rendered before measuring,
@@ -415,7 +448,13 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
     });
   }, [autoScrollAborted$, isScrolledUp$, loadOlderMessages]);
 
+  const searchHighlightRAFRef = useRef<number | null>(null);
+
   const clearSearchHighlights = useCallback(() => {
+    if (searchHighlightRAFRef.current !== null) {
+      cancelAnimationFrame(searchHighlightRAFRef.current);
+      searchHighlightRAFRef.current = null;
+    }
     scrollContainerRef.current
       ?.querySelectorAll<HTMLElement>('[data-message-index]')
       .forEach((el) => {
@@ -467,20 +506,29 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
       clearSearchHighlights();
       const logOff = conversation$?.logOffset?.get() ?? 0;
       const localIndex = msgIndex - logOff;
-      // Instant scroll brings the item into the DOM immediately.
-      virtualizerRef.current.scrollToIndex(localIndex, { align: 'center' });
-      // Two rAFs: first lets the virtualizer commit, second lets layout flush.
-      requestAnimationFrame(() => {
-        requestAnimationFrame(() => {
-          const el = scrollContainerRef.current?.querySelector<HTMLElement>(
-            `[data-message-index="${msgIndex}"]`
-          );
-          if (el) {
-            el.style.outline = '2px solid rgba(234,179,8,0.6)';
-            el.style.outlineOffset = '-2px';
-          }
-        });
-      });
+      const virtualIndex = visibleMessageIndicesRef.current.indexOf(localIndex);
+      if (virtualIndex === -1) return;
+
+      virtualizerRef.current.scrollToIndex(virtualIndex, { align: 'center' });
+
+      // Variable-height rendering can take more than a fixed number of frames.
+      // Retry for a short bounded window until the target row mounts.
+      let attemptsRemaining = 10;
+      const applyHighlight = () => {
+        const el = scrollContainerRef.current?.querySelector<HTMLElement>(
+          `[data-message-index="${msgIndex}"]`
+        );
+        if (el) {
+          el.style.outline = '2px solid rgba(234,179,8,0.6)';
+          el.style.outlineOffset = '-2px';
+          searchHighlightRAFRef.current = null;
+          return;
+        }
+        attemptsRemaining--;
+        searchHighlightRAFRef.current =
+          attemptsRemaining > 0 ? requestAnimationFrame(applyHighlight) : null;
+      };
+      searchHighlightRAFRef.current = requestAnimationFrame(applyHighlight);
     },
     [clearSearchHighlights, conversation$]
   );
@@ -591,7 +639,7 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
   }, [pendingToolId, settings.noConfirmMode]);
 
   const handleScrollToBottom = () => {
-    const count = messageCountRef.current;
+    const count = visibleMessageIndicesRef.current.length;
     if (count > 0) {
       isAutoScrolling$.set(true);
       virtualizerRef.current.scrollToIndex(count - 1, { align: 'end', behavior: 'smooth' });
@@ -840,7 +888,7 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
           }}
         >
           {virtualizer.getVirtualItems().map((virtualItem) => {
-            const index = virtualItem.index;
+            const index = visibleMessageIndices[virtualItem.index];
             // Guard against count/log getting briefly out of sync.
             const msg$ = conversation$?.data.log[index];
             if (!msg$) return null;
@@ -858,37 +906,6 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
               width: '100%',
             };
 
-            // Hide all system messages before the first non-system message by default.
-            // Use peek() — reads are not inside a reactive context here; reactivity
-            // is handled by component-level use$() calls (showInitialSystem$, etc.)
-            // that trigger a re-render when settings change.
-            const firstNonSystemIndex = firstNonSystemIndex$.peek();
-            const isInitialSystem =
-              msg$.role.peek() === 'system' &&
-              (firstNonSystemIndex === -1 || index < firstNonSystemIndex);
-            if (isInitialSystem && !settings.showInitialSystem) {
-              return (
-                <div
-                  key={virtualItem.key}
-                  data-index={virtualItem.index}
-                  ref={virtualizer.measureElement}
-                  style={wrapperStyle}
-                />
-              );
-            }
-
-            // Hide messages with hide=true (e.g., auto-included lessons)
-            if (msg$.hide?.peek() && !settings.showHiddenMessages) {
-              return (
-                <div
-                  key={virtualItem.key}
-                  data-index={virtualItem.index}
-                  ref={virtualizer.measureElement}
-                  style={wrapperStyle}
-                />
-              );
-            }
-
             // Get the previous and next *visible* messages for chain context
             // (skip hidden messages so they don't break chain grouping).
             let prevIdx = index - 1;
@@ -904,19 +921,6 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
             // stepRolesValue is read via use$() at the component level, so any
             // structural change that updates stepRoles$ triggers a re-render here.
             const stepRole = stepRolesValue[absoluteIndex];
-
-            // If this is a grouped message and the group is collapsed, render as
-            // a zero-height placeholder so the virtualizer measures it correctly.
-            if (stepRole?.type === 'grouped' && !expandedGroups.has(stepRole.groupId)) {
-              return (
-                <div
-                  key={virtualItem.key}
-                  data-index={virtualItem.index}
-                  ref={virtualizer.measureElement}
-                  style={wrapperStyle}
-                />
-              );
-            }
 
             // If this is a group-start, render the summary bar
             // (when collapsed, replaces the message; when expanded, shown above it)

--- a/webui/src/components/__tests__/ConversationContent.test.tsx
+++ b/webui/src/components/__tests__/ConversationContent.test.tsx
@@ -11,6 +11,34 @@ import { observable } from '@legendapp/state';
 import type { Message } from '@/types/conversation';
 import { ConversationContent } from '../ConversationContent';
 
+// Control how many items the virtualizer "renders" (simulates viewport size).
+// Defaults to Infinity so existing tests see all messages (no change in behaviour).
+// Set __virtualWindow to a number in specific tests to verify bounded rendering.
+declare global {
+  var __virtualWindow: number;
+}
+global.__virtualWindow = Infinity;
+
+jest.mock('@tanstack/react-virtual', () => ({
+  useVirtualizer: (opts: { count: number }) => {
+    const win = isFinite(global.__virtualWindow) ? global.__virtualWindow : opts.count;
+    const items = Array.from({ length: Math.min(opts.count, win) }, (_, i) => ({
+      index: i,
+      key: i,
+      start: i * 150,
+      size: 150,
+      end: (i + 1) * 150,
+      lane: 0,
+    }));
+    return {
+      getTotalSize: () => opts.count * 150,
+      getVirtualItems: () => items,
+      scrollToIndex: jest.fn(),
+      measureElement: () => {},
+    };
+  },
+}));
+
 const mockBuildStepRoles = jest.fn((_messages: Message[]) => new Map());
 
 jest.mock('@/utils/stepGrouping', () => ({
@@ -407,5 +435,72 @@ describe('server disconnected banner — removed server', () => {
     mockIsDemoMode.mockReturnValue(true);
     render(<ConversationContent conversationId="demo/test" serverId="removed-server" />);
     expect(screen.queryByText(/server not connected/i)).toBeNull();
+  });
+});
+
+describe('virtual message list', () => {
+  beforeEach(() => {
+    mockConversation$.set(makeConversationState().peek());
+    jest.clearAllMocks();
+    mockIsDemoMode.mockReturnValue(false);
+    isConnected$.set(true);
+    lastConnectionResult$.set(null);
+    global.__virtualWindow = Infinity; // reset to "render all" default
+  });
+
+  afterEach(() => {
+    global.__virtualWindow = Infinity;
+  });
+
+  it('renders only a bounded subset of messages when the virtualizer window is smaller than the list', () => {
+    // Simulate a viewport that fits 8 items — the rest stay off-screen (no DOM node).
+    global.__virtualWindow = 8;
+    const many = Array.from({ length: 50 }, (_, i) =>
+      message(i === 0 ? 'user' : 'assistant', `Message ${i}`)
+    );
+    act(() => {
+      mockConversation$.data.log.set(many);
+    });
+    renderComponent();
+
+    const rendered = document.querySelectorAll('[data-message-index]');
+    expect(rendered.length).toBe(8);
+    expect(rendered.length).toBeLessThan(50);
+  });
+
+  it('renders all messages when the list is smaller than the virtualizer window', () => {
+    // With __virtualWindow = Infinity the mock returns all items (min(3, ∞) = 3).
+    const few = [
+      message('user', 'Hello'),
+      message('assistant', 'Hi there'),
+      message('user', 'Thanks'),
+    ];
+    act(() => {
+      mockConversation$.data.log.set(few);
+    });
+    renderComponent();
+
+    const rendered = document.querySelectorAll('[data-message-index]');
+    expect(rendered.length).toBe(3);
+  });
+
+  it('assigns data-index to rendered wrappers (required for ResizeObserver height measurement)', () => {
+    act(() => {
+      mockConversation$.data.log.set([message('user', 'Hello'), message('assistant', 'Hi')]);
+    });
+    renderComponent();
+
+    const items = document.querySelectorAll('[data-index]');
+    expect(items.length).toBeGreaterThan(0);
+    items.forEach((item) => {
+      expect(item.getAttribute('data-index')).not.toBeNull();
+    });
+  });
+
+  it('mounts without errors when there are no messages', () => {
+    act(() => {
+      mockConversation$.data.log.set([]);
+    });
+    expect(() => renderComponent()).not.toThrow();
   });
 });

--- a/webui/src/components/__tests__/ConversationContent.test.tsx
+++ b/webui/src/components/__tests__/ConversationContent.test.tsx
@@ -6,7 +6,7 @@
  * connection state and demo mode.
  */
 import '@testing-library/jest-dom';
-import { act, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { observable } from '@legendapp/state';
 import type { Message } from '@/types/conversation';
 import { ConversationContent } from '../ConversationContent';
@@ -18,6 +18,7 @@ declare global {
   var __virtualWindow: number;
 }
 global.__virtualWindow = Infinity;
+const mockScrollToIndex = jest.fn();
 
 jest.mock('@tanstack/react-virtual', () => ({
   useVirtualizer: (opts: { count: number }) => {
@@ -33,17 +34,21 @@ jest.mock('@tanstack/react-virtual', () => ({
     return {
       getTotalSize: () => opts.count * 150,
       getVirtualItems: () => items,
-      scrollToIndex: jest.fn(),
+      scrollToIndex: mockScrollToIndex,
       measureElement: () => {},
     };
   },
 }));
 
 const mockBuildStepRoles = jest.fn((_messages: Message[]) => new Map());
+let mockStepRoles = new Map<number, { type: 'grouped'; groupId: number }>();
 
 jest.mock('@/utils/stepGrouping', () => ({
   ...jest.requireActual('@/utils/stepGrouping'),
-  buildStepRoles: (messages: Message[]) => mockBuildStepRoles(messages),
+  buildStepRoles: (messages: Message[]) => {
+    mockBuildStepRoles(messages);
+    return mockStepRoles;
+  },
 }));
 
 // --- Mocks ---
@@ -258,6 +263,7 @@ describe('step role recomputation', () => {
   beforeEach(() => {
     mockConversation$.set(makeConversationState().peek());
     mockBuildStepRoles.mockClear();
+    mockStepRoles = new Map();
   });
 
   it('does not recompute roles for streamed content updates', () => {
@@ -446,6 +452,7 @@ describe('virtual message list', () => {
     isConnected$.set(true);
     lastConnectionResult$.set(null);
     global.__virtualWindow = Infinity; // reset to "render all" default
+    mockStepRoles = new Map();
   });
 
   afterEach(() => {
@@ -482,6 +489,57 @@ describe('virtual message list', () => {
 
     const rendered = document.querySelectorAll('[data-message-index]');
     expect(rendered.length).toBe(3);
+  });
+
+  it('excludes hidden messages from virtualizer geometry', () => {
+    act(() => {
+      mockConversation$.data.log.set([
+        message('system', 'Initial prompt'),
+        { ...message('assistant', 'Hidden lesson'), hide: true },
+        message('user', 'Visible question'),
+        message('assistant', 'Visible answer'),
+      ]);
+    });
+    renderComponent();
+
+    expect(document.querySelectorAll('[data-index]')).toHaveLength(2);
+    expect(document.querySelectorAll('[data-message-index]')).toHaveLength(2);
+  });
+
+  it('excludes grouped messages when their group is collapsed', () => {
+    mockStepRoles = new Map([[1, { type: 'grouped', groupId: 0 }]]);
+    act(() => {
+      mockConversation$.data.log.set([
+        message('user', 'Question'),
+        message('system', 'Tool result'),
+        message('assistant', 'Answer'),
+      ]);
+    });
+    renderComponent();
+
+    expect(document.querySelectorAll('[data-index]')).toHaveLength(2);
+    expect(document.querySelectorAll('[data-message-index]')).toHaveLength(2);
+  });
+
+  it('retries search highlighting until a virtual row mounts', () => {
+    jest.useFakeTimers();
+    global.__virtualWindow = 1;
+    act(() => {
+      mockConversation$.data.log.set([
+        message('user', 'First'),
+        message('assistant', 'Find this target'),
+      ]);
+    });
+    renderComponent();
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'f', ctrlKey: true }));
+    });
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'target' } });
+
+    expect(mockScrollToIndex).toHaveBeenCalledWith(1, { align: 'center' });
+    act(() => jest.advanceTimersByTime(16 * 10));
+    jest.useRealTimers();
   });
 
   it('assigns data-index to rendered wrappers (required for ResizeObserver height measurement)', () => {


### PR DESCRIPTION
Closes #3378

## Summary

Long conversations (200–500+ messages) were rendering every message into the DOM simultaneously, causing slow initial load, janky scrolling, and high memory use. This PR replaces the unbounded `<For each={log}>` loop with a `useVirtualizer` from **@tanstack/react-virtual** (variable-height, ResizeObserver-based), keeping only the visible window (~10–15 items + overscan) in the DOM at any scroll position.

## Changes

### `webui/package.json`
- Added `@tanstack/react-virtual ^3.14.8`

### `webui/src/components/ConversationContent.tsx`
- Replaced `<For each={conversation$?.data.log ?? []}>` with `useVirtualizer`
- Virtualizer container: `position: relative`, `height: getTotalSize()px`; each item: `position: absolute`, `transform: translateY(${start}px)`
- `data-index` attribute on each wrapper (required by `measureElement` for ResizeObserver height tracking)
- `data-message-index` kept on the inner element so existing search navigation still works
- **Scroll-to-bottom** during streaming: uses `scrollToIndex(count - 1, { align: 'end' })` instead of `container.scrollTop = container.scrollHeight`
- **Search navigation** (`highlightSearchMatch`): calls `scrollToIndex(localIndex)`, then two `requestAnimationFrame` frames to let the item enter the DOM before `querySelector`
- Stale-closure safety: `virtualizerRef` and `messageCountRef` keep effects/callbacks up to date without re-creating them on every render
- Reactive state lifted to component level (`expandedGroups`, `logOffset`, `stepRoles`) so the virtualizer render loop can read them synchronously via `peek()`

## Preserved invariants

| Invariant | How preserved |
|-----------|---------------|
| Auto-scroll during streaming | `scrollToIndex(count-1, align:'end')` in `scrollToBottom` |
| Load-older-messages prepend anchor | Existing scroll-height delta correction in `handleLoadOlderMessages` unchanged |
| Search highlight | `scrollToIndex` + double rAF before DOM query |
| Message visibility rules (hidden/system/step) | Evaluated inside the virtualizer render loop |
| Group expand/collapse | `expandedGroups` read at component level, triggers full virtualizer re-render |

## Known limitation

Offscreen items' heights are estimated (default 150 px) until they scroll into view and ResizeObserver measures them. Collapsing/expanding a large step group can cause a few pixels of scroll drift until the items re-enter the viewport. This is the standard TanStack Virtual trade-off and is not noticeable in normal use.

## Tests

- `@tanstack/react-virtual` mocked at module level with a `global.__virtualWindow` control variable (avoids JSDOM's `getBoundingClientRect() → 0` limitation)
- 4 new tests in `describe('virtual message list', ...)`:
  1. Bounded rendering: 50 messages × window=8 → exactly 8 DOM nodes
  2. Full rendering: 3 messages × window=∞ → 3 DOM nodes  
  3. `data-index` attribute presence on rendered wrappers
  4. No crash on empty message list
- All 631 existing tests continue to pass (mock defaults to `Infinity` window = render everything, preserving prior behaviour)
- TypeScript (`tsc --noEmit`) exits 0