### PR TITLE
fix(sandbox): drop all Linux capabilities in Docker Python sandbox

### DIFF
--- a/gptme/sandbox.py
+++ b/gptme/sandbox.py
@@ -299,6 +299,8 @@ def sandbox_exec_python(
         - No network (unless config.allow_network).
         - 256 MiB memory cap, no swap (OOM → container exit 137).
         - 512 PID limit (fork-bomb mitigation).
+        - All Linux capabilities dropped (--cap-drop=ALL).
+        - No privilege escalation (--security-opt=no-new-privileges).
         - Script mounted read-only; workspace bind-mounted read-write.
         - Fresh, ephemeral filesystem (no host credentials visible).
     """
@@ -327,6 +329,8 @@ def sandbox_exec_python(
             "--memory=256m",
             "--memory-swap=256m",  # disallow swap (OOM kills instead of thrashing)
             "--pids-limit=512",
+            "--cap-drop=ALL",  # drop all Linux capabilities (no CAP_NET_RAW etc.)
+            "--security-opt=no-new-privileges",  # prevent privilege escalation
             # Mount script as read-only inside the container
             "-v",
             f"{script_path}:/tmp/script.py:ro",

--- a/gptme/sandbox.py
+++ b/gptme/sandbox.py
@@ -314,6 +314,11 @@ def sandbox_exec_python(
     ) as f:
         f.write(code)
         script_path = Path(f.name)
+    # NamedTemporaryFile creates mode 0600. Once all container capabilities are
+    # dropped, container root cannot bypass that host ownership check on a bind
+    # mount. The script contains only the caller-provided code and is mounted
+    # read-only, so make it world-readable before starting the container.
+    script_path.chmod(0o644)
 
     try:
         workspace = str(config.workspace.resolve())

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -445,6 +445,16 @@ class TestDockerExecPythonCommandShape:
         cmd = self._run("x=1").call_args[0][0]
         assert "--pids-limit=512" in cmd
 
+    def test_cap_drop_all_present(self):
+        """All Linux capabilities must be dropped to prevent raw sockets etc."""
+        cmd = self._run("x=1").call_args[0][0]
+        assert "--cap-drop=ALL" in cmd
+
+    def test_no_new_privileges_present(self):
+        """Privilege escalation must be blocked."""
+        cmd = self._run("x=1").call_args[0][0]
+        assert "--security-opt=no-new-privileges" in cmd
+
     def test_network_none_by_default(self):
         cmd = self._run("x=1").call_args[0][0]
         assert "--network=none" in cmd

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -480,6 +480,29 @@ class TestDockerExecPythonCommandShape:
         ]
         assert any(":ro" in p for p in v_pairs)
 
+    def test_script_is_readable_without_dac_override(self):
+        """Capability-free container root must be able to read the bind mount."""
+        observed_mode = None
+
+        def inspect_mode(cmd, **kwargs):
+            nonlocal observed_mode
+            script_mount = next(
+                cmd[i + 1]
+                for i, arg in enumerate(cmd)
+                if arg == "-v" and cmd[i + 1].endswith(":/tmp/script.py:ro")
+            )
+            observed_mode = Path(script_mount.split(":", 1)[0]).stat().st_mode & 0o777
+            mock_proc = MagicMock()
+            mock_proc.communicate.return_value = ("", "")
+            mock_proc.returncode = 0
+            return mock_proc
+
+        cfg = SandboxConfig(backend="docker", workspace=Path("/workspace"))
+        with patch("gptme.sandbox.subprocess.Popen", side_effect=inspect_mode):
+            sandbox_exec_python(cfg, "x=1")
+
+        assert observed_mode == 0o644
+
     def test_working_dir_set_to_workspace(self):
         mock = self._run("x=1")
         cmd = mock.call_args[0][0]


### PR DESCRIPTION
## Summary

- Add `--cap-drop=ALL` to the `docker run` command in `sandbox_exec_python()`, dropping all Linux capabilities including `CAP_NET_RAW` and `CAP_NET_BIND_SERVICE`
- Add `--security-opt=no-new-privileges` to prevent privilege escalation via setuid/setgid binaries

## Motivation

The compliance test suite for the sandbox identified that the Docker sandbox was failing two capability tests (CAP-01, CAP-02): the container runs as root (uid=0) and retained `CAP_NET_RAW` and `CAP_NET_BIND_SERVICE` despite `--network=none`.

While `--network=none` prevents actual network exploitation, the retained capabilities are a defense-in-depth gap: a compromised container can still create raw sockets and bind privileged ports internally. Dropping all capabilities closes this gap.

bwrap already passes all capability checks because it runs in a user namespace as non-root, naturally dropping capabilities.

## Test plan

- `TestDockerExecPythonCommandShape.test_cap_drop_all_present` — asserts `--cap-drop=ALL` is in the docker run command
- `TestDockerExecPythonCommandShape.test_no_new_privileges_present` — asserts `--security-opt=no-new-privileges` is in the docker run command
- Both new tests pass; all 13 tests in the class pass locally